### PR TITLE
feat(freehand): F5g pilot — dropdown/popup and async typeahead (rf2-drpa3.44)

### DIFF
--- a/implementation/freehand/test/re_frame/freehand/pilot_overlay.cljc
+++ b/implementation/freehand/test/re_frame/freehand/pilot_overlay.cljc
@@ -518,9 +518,12 @@
            ;; The two things that defeat `position: fixed` emulation, in
            ;; one element: a clipping box and a containing-block-forming
            ;; transform.
-           :style          {:overflow "hidden"
-                            :height   "40px"
-                            :width    "220px"
+           ;; Deliberately TIGHT: an 18px box that the panel could not
+           ;; possibly fit inside, so `escaped the clip` is a measurement
+           ;; rather than a coincidence.
+           :style          {:overflow  "hidden"
+                            :height    "18px"
+                            :width     "220px"
                             :transform "translateX(10px)"}}
      [dropdown {:name      (str "format-" (name id))
                 :label     "Export as…"

--- a/implementation/freehand/test/re_frame/freehand/pilot_overlay.cljc
+++ b/implementation/freehand/test/re_frame/freehand/pilot_overlay.cljc
@@ -1,0 +1,576 @@
+(ns re-frame.freehand.pilot-overlay
+  "THE SECOND COMPONENT PILOT, CASE B — a dropdown, a nested submenu and a
+  modal confirm, built the way a component-library author would build them,
+  plus the application that calls them.
+
+  Everything in this namespace is CONSUMER code. It declares views with
+  `v/defview`, registers one behavior with `v/defbehavior`, reads with
+  `v/sub`, emits intent as event vectors, and moves state with ordinary
+  `reg-event` / `reg-sub`. It adds no substrate machinery, and it is the
+  artefact the fitness harness's CASE B requirements
+  (`docs/design/freehand/studio/fitness-harness.md`, §B.2) are judged
+  against — one requirement at a time, in `pilot-overlay-cljs-test` and
+  `pilot-overlay-dom-cljs-test`.
+
+  ## Three components, and why they are three
+
+  [[dropdown]] is a SEMANTIC CONTROLLER. It owns a protocol that spans
+  several interactions — an open flag, a highlighted option, a keyboard
+  grammar — so its state is ordinary frame data addressed by
+  `(kind, :control)`. It is NOT buffered: an open flag holds no draft a
+  caller could reject, so it asks for an address and never for a
+  generation. That asymmetry is the substrate's, not this library's, and
+  it is worth stating: `control/record-key` is what makes a controller
+  writable, and `control/reset-revision` is a SECOND, separable
+  obligation that only a draft-holding control pays.
+
+  [[confirm]] is PROPS-ONLY — value in, intent out. A modal's open state
+  belongs to whatever decided to ask the question, so the component holds
+  nothing at all. Three quarters of a real component library looks like
+  this, and a library that made everything a controller would be
+  advertising storage as the normal way to build a component.
+
+  [[menu-bar]] is the composition: a dropdown whose panel contains another
+  dropdown, which is the arrangement hand-rolled overlays get wrong.
+
+  ## Where the overlay machinery went
+
+  There is none. re-com's dropdown pays a document-level click listener
+  installed on open, a `requestAnimationFrame` loop re-armed every frame
+  while open, a z-index ladder coordinated across four component families,
+  and a 100 ms `setTimeout` per transition — and it leaks the listener on
+  unmount-while-open because the outer component has no lifecycle hook.
+  This library has none of those, because the platform already owns them:
+
+  - `:popover :auto` gives light dismiss, Escape, one-at-a-time siblings
+    and LIFO nesting, with ZERO listeners of ours;
+  - the top layer escapes every clipping ancestor and every stacking
+    context by construction, so there is no z-index to coordinate;
+  - `<dialog>` + `modal-open?` gives focus entry, background inertness,
+    Escape and focus return;
+  - transitions are CSS (`transition-behavior: allow-discrete` and
+    `@starting-style`), so there is no timer of ours to orphan.
+
+  What is genuinely left is MEASUREMENT — where to put the panel — and
+  that is exactly one registered behavior.
+
+  ## The two refs that must not meet
+
+  [[anchor-box]] is attached to the dropdown's ROOT element, and the
+  desired-state property is declared on the PANEL element inside it. That
+  split is load-bearing rather than stylistic: a behavior attaches through
+  `cloneElement` with its own ref, and the top layer installs its
+  idempotent host call on a ref of its own, so one element carrying both
+  would have one ref silently overwrite the other. The arrangement here
+  needs no such element — the measurement is of the anchor, the promotion
+  is of the panel, and they were never the same node — but the collision
+  is real and `pilot-overlay-dom-cljs-test` reproduces it deliberately
+  rather than leaving it to be rediscovered.
+
+  ## How the measurement reaches the panel
+
+  Through the CASCADE, not through a second ref and not through a render
+  round trip. The behavior measures its own node — the dropdown root,
+  whose only in-flow child is the anchor button, because an open popover
+  is out of flow — and writes the result as inline CUSTOM PROPERTIES on
+  that node. The panel is a DOM DESCENDANT of the root even while the
+  browser paints it in the top layer, so the properties inherit and the
+  panel's `top` / `left` resolve against them.
+
+  That is the whole reason the ruling preferred a top layer to a portal:
+  the element never leaves the tree, so inheritance, subscriptions and the
+  frame context all keep working, and there is no boundary to propagate
+  anything across.
+
+  ## The tracking frequency, declared
+
+  The panel is placed at the COMMIT whose configuration moved, and at no
+  other moment. No scroll listener, no resize observer, no animation-frame
+  loop, no timer. If an application knows the anchor moved for a reason
+  the substrate cannot see, it says so with one command
+  (`:re-frame.freehand.host/command` → `:reposition`) rather than paying a
+  loop against the possibility. `pilot-overlay-dom-cljs-test` asserts the
+  count of retained observers and listeners as an exact integer."
+  (:require [re-frame.core :as rf]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.control :as control]
+            [re-frame.freehand.web :as web]))
+
+;; ===========================================================================
+;; THE COMPONENT LIBRARY — `acme.ui`
+;; ===========================================================================
+;;
+;; `:acme.ui/*` is LIBRARY vocabulary. The substrate reserves no namespace
+;; for controls and fixes no storage path: the root below, the record
+;; shape and every id are this library's choices.
+
+(def records-root
+  "Where this library keeps its controller records. A library decision,
+  not a substrate one."
+  :acme.ui/controllers)
+
+(def dropdown-kind
+  "The dropdown controller family. It is half of every record key this
+  library writes, so a second family addressed at the SAME domain identity
+  reads its own record rather than this one's."
+  :acme.ui/dropdown)
+
+(def parts
+  "The PUBLIC part addresses each component emits, by component id.
+
+  A part id is API: renaming one is a breaking change to every stylesheet
+  that reaches it, exactly as renaming a prop is. They are literal
+  `data-part` values under a `data-component` scope, so `root` and `panel`
+  can be common names without colliding across libraries."
+  {"acme/dropdown" ["root" "anchor" "panel" "option"]
+   "acme/confirm"  ["root" "title" "body" "cancel" "accept"]})
+
+(def custom-properties
+  "The inline custom properties [[anchor-box]] publishes on the dropdown
+  root, and the panel resolves its position from.
+
+  They are API for the same reason a part id is: a stylesheet may read
+  them, and an application that wants a different placement rule overrides
+  the panel's `top` / `left` in terms of them rather than re-measuring."
+  ["--acme-anchor-x" "--acme-anchor-y" "--acme-anchor-w" "--acme-anchor-h"])
+
+;; ---------------------------------------------------------------------------
+;; The one imperative thing a dropdown needs: a box
+;; ---------------------------------------------------------------------------
+
+(defn- px [n] (str n "px"))
+
+(defn- measure!
+  "Read the node's border box and publish it as inline custom properties.
+
+  `:layout` timing, so this runs BEFORE the browser paints — which is the
+  only honest home for measure-then-place work, and the reason there is no
+  wrong-position frame to hide behind an opacity-0 park or a -10000px
+  offset. The properties inherit to the panel, so nothing here reaches for
+  a second node, a selector, or a parent walk."
+  [{:keys [node config]}]
+  #?(:clj  (do node config nil)
+     :cljs (let [^js r  (.getBoundingClientRect node)
+                 gap    (get config :gap 0)
+                 ^js st (.-style node)]
+             (.setProperty st "--acme-anchor-x" (px (.-left r)))
+             (.setProperty st "--acme-anchor-y" (px (+ (.-bottom r) gap)))
+             (.setProperty st "--acme-anchor-w" (px (.-width r)))
+             (.setProperty st "--acme-anchor-h" (px (.-height r)))
+             nil)))
+
+(v/defbehavior anchor-box
+  "Publish the dropdown root's measured box as inherited custom
+  properties.
+
+  Everything it needs arrives as `:config` — the open flag and the gap —
+  so the connection re-measures exactly when the configuration MOVES and
+  at no other moment. There is nothing to release, which is why
+  `:disconnect` is absent rather than empty: the behavior acquires no
+  listener, no observer and no timer, so teardown has nothing to undo and
+  a test can assert that as an absence.
+
+  `:reposition` is the declared escape for the case the frequency does not
+  cover — an application that knows its anchor moved sends one command
+  instead of the substrate arming a loop against the possibility."
+  {:timing   :layout
+   :connect  measure!
+   :update   measure!
+   :commands {:reposition measure!}})
+
+;; ---------------------------------------------------------------------------
+;; The library's dataflow — ordinary re-frame, registered by the consumer
+;; ---------------------------------------------------------------------------
+
+(defn- clamp [n lo hi] (max lo (min hi n)))
+
+(defn- record [db k] (get-in db [records-root k]))
+
+(defn- close
+  "Closing is one write, and it is the same write from every cause — the
+  anchor, Escape, a chosen option, a light dismiss the browser performed
+  without asking. A control whose four close paths wrote four shapes of
+  state would eventually disagree with itself."
+  [db k]
+  (update db records-root dissoc k))
+
+(defn- choose-fx
+  "Commit option `i` of `options`: close, and produce the caller's intent
+  carrying the chosen value. Shared by the click site and the Enter branch
+  so the pointer grammar and the keyboard grammar cannot drift."
+  [db k i options on-change]
+  (if-let [opt (get options i)]
+    {:db (close db k)
+     :fx [[:dispatch (conj (vec on-change) (:value opt))]]}
+    {:db (close db k)}))
+
+(defn register!
+  "Register the library's whole dataflow: one read and five transitions.
+
+  A library ships this as an ordinary function its consumer calls at boot.
+  There is no registry to join, no component to instantiate, and nothing
+  here that a `reg-sub` and a `reg-event` do not already do."
+  []
+  ;; --- The read ------------------------------------------------------
+  ;;
+  ;; ONE read for the whole control. A dropdown's open flag and its
+  ;; highlighted option move together, are read together, and are
+  ;; meaningless apart; splitting them into two subscriptions would buy a
+  ;; finer invalidation on state that always changes at once.
+  (rf/reg-sub :acme.ui.dropdown/state
+    (fn [db [_ k]]
+      (let [r (record db k)]
+        {:open?  (boolean (:open? r))
+         :active (:active r 0)})))
+
+  ;; --- The dismissal handshake ---------------------------------------
+  ;;
+  ;; The browser reports a top-layer element's state changes through
+  ;; `ToggleEvent`, and the useful field is `newState` — "open" or
+  ;; "closed". There is no reserved projection for it: the closed roster
+  ;; is `::v/value` / `::v/checked` / `::v/key`, so the report cannot ride
+  ;; a declarative event vector, and `v/event` (the sanctioned conversion
+  ;; seam) is refused by the STRUCTURAL host, which would cost this
+  ;; component its server render.
+  ;;
+  ;; So the library counts instead of reading. Every open session produces
+  ;; exactly one open-toggle followed by at most one close-toggle, in that
+  ;; order, so the FIRST report of a session is the one the application
+  ;; caused and any LATER one is the browser dismissing without asking.
+  ;; One boolean, no live event object, and the whole path stays data.
+  (rf/reg-event :acme.ui.dropdown/toggle-reported
+    (fn [{:keys [db]} [_ k]]
+      (let [r (record db k)]
+        (cond
+          ;; The report of a close the application already performed. The
+          ;; record is gone, so there is nothing to reconcile.
+          (nil? r)        {}
+          ;; The opening report. Acknowledge it and wait.
+          (not (:acked? r)) {:db (assoc-in db [records-root k :acked?] true)}
+          ;; A second report while still open: the browser closed it —
+          ;; Escape, a light dismiss, a sibling popover taking the layer.
+          :else           {:db (close db k)}))))
+
+  ;; --- The transitions -----------------------------------------------
+
+  (rf/reg-event :acme.ui.dropdown/anchor-clicked
+    (fn [{:keys [db]} [_ k]]
+      (if (:open? (record db k))
+        {:db (close db k)}
+        {:db (assoc-in db [records-root k] {:open? true :active 0})})))
+
+  (rf/reg-event :acme.ui.dropdown/option-chosen
+    (fn [{:keys [db]} [_ k i options on-change]]
+      (choose-fx db k i options on-change)))
+
+  ;; The browser's own dismissal, reconciled. Escape, a light dismiss and
+  ;; a sibling popover opening all close the node WITHOUT asking the
+  ;; application, and the substrate deliberately writes no state on their
+  ;; behalf — so an unreconciled control springs back open on the next
+  ;; render. This is the reconciliation, and it is idempotent: a dismissal
+  ;; the application already caused finds the record gone and writes
+  ;; nothing.
+  (rf/reg-event :acme.ui.dropdown/dismissed
+    (fn [{:keys [db]} [_ k]]
+      {:db (close db k)}))
+
+  ;; The keyboard grammar as DATA. `::v/key` carries the live
+  ;; `KeyboardEvent.key`, so the whole single_dropdown parity set —
+  ;; open, cancel-restore, arrows, Home/End — is ONE registered event a
+  ;; structural test drives by equality. No callback body, no `.-key`
+  ;; read, nothing a JVM host cannot run.
+  ;;
+  ;; The cost is stated rather than hidden: this site fires on EVERY key,
+  ;; and a key outside the grammar settles an event that changes nothing.
+  (rf/reg-event :acme.ui.dropdown/key-pressed
+    (fn [{:keys [db]} [_ k options on-change pressed]]
+      (let [r      (record db k)
+            open?  (boolean (:open? r))
+            active (:active r 0)
+            last*  (max 0 (dec (count options)))
+            ;; Two narrow writes rather than a replacement, so the
+            ;; dismissal handshake's acknowledgement survives a highlight
+            ;; move. A control that forgot it had already been reported
+            ;; open would treat the browser's next dismissal as an opening
+            ;; and spring back open.
+            move   (fn [i] {:db (-> db
+                                    (assoc-in [records-root k :open?] true)
+                                    (assoc-in [records-root k :active] (clamp i 0 last*)))})]
+        (cond
+          (not open?) (case pressed
+                        ("ArrowDown" "ArrowUp" "Enter" " ") (move (if (= "ArrowUp" pressed) last* 0))
+                        {})
+          :else       (case pressed
+                        "ArrowDown" (move (inc active))
+                        "ArrowUp"   (move (dec active))
+                        "Home"      (move 0)
+                        "End"       (move last*)
+                        "Enter"     (choose-fx db k active options on-change)
+                        ;; Escape CANCELS: the highlight is discarded and
+                        ;; the caller's value is untouched. The browser
+                        ;; will also light-dismiss the popover and fire
+                        ;; `toggle`, which lands on `dismissed` — the same
+                        ;; write, so the two paths converge rather than
+                        ;; race.
+                        "Escape"    {:db (close db k)}
+                        ;; Tab-out closes. The panel takes no focus, so the
+                        ;; next tab stop is wherever it would have been.
+                        "Tab"       {:db (close db k)}
+                        {}))))))
+
+;; ---------------------------------------------------------------------------
+;; `dropdown` — the semantic controller
+;; ---------------------------------------------------------------------------
+
+(defn- option-id [name* i] (str "acme-dropdown-" name* "-option-" i))
+(defn- panel-id  [name*]   (str "acme-dropdown-" name* "-panel"))
+(defn- anchor-id [name*]   (str "acme-dropdown-" name* "-anchor"))
+
+(defn- selected-label
+  "The label of the caller's currently selected value, or the placeholder.
+  A plain helper: it touches no state, so it is a `defn` rather than a
+  declared view, and it runs inside the boundary that called it."
+  [options selected placeholder]
+  (or (some (fn [o] (when (= selected (:value o)) (:label o))) options)
+      placeholder))
+
+(v/defview dropdown
+  "An anchored listbox: a button that opens a panel, a panel the browser
+  paints in its top layer, and a keyboard grammar.
+
+  `:control` is the domain identity that OWNS the open state
+  (`[:invoice 42 :account]`), not a render position: a sort, a view rename
+  or a parent extraction leaves it exactly where it was. It is the only
+  ceremony a caller pays, and it buys per-instance state with no registry,
+  no `:model` atom, and no second way to spell the same thing — the
+  caller-supplied-model-or-internal-ratom dual contract is not offered,
+  because two ways to own one flag is how a component library acquires
+  callers who own it differently.
+
+  The panel is IN THE TREE. It is a DOM child of the root, so it resolves
+  the same frame and the same subscriptions as the anchor, it inherits the
+  root's custom properties, and a server renders it as an ordinary closed
+  element. The browser paints it in the top layer, which is what escapes
+  the clipping ancestor — and that is a painting fact, not a tree fact."
+  {:props [:map
+           [:name :string]
+           [:label :string]
+           [:control :any]
+           [:options [:vector :any]]
+           [:selected {:optional true} :any]
+           [:on-change :vector]
+           [:gap {:optional true} :int]
+           [:children {:optional true} :any]]
+   :children-policy :optional}
+  [{:keys [name label options selected on-change gap children] :as props}]
+  (let [k      (control/record-key dropdown-kind props)
+        state  (v/sub [:acme.ui.dropdown/state k])
+        open?  (:open? state)
+        active (:active state)]
+    ;; The behavior owns the ROOT; the desired-state property is on the
+    ;; PANEL. Two nodes, two refs, no collision — see the namespace
+    ;; docstring.
+    [v/behavior {:use    anchor-box
+                 :target k
+                 :config {:open? open? :gap (or gap 0)}}
+     [:div {:data-component "acme/dropdown"
+            :data-part      "root"
+            :data-field     name
+            :style          {:display "inline-block" :position "relative"}}
+      [:button {:data-part             "anchor"
+                :id                    (anchor-id name)
+                :type                  "button"
+                :aria-haspopup         "listbox"
+                :aria-expanded         (if open? "true" "false")
+                :aria-controls         (panel-id name)
+                :aria-activedescendant (when open? (option-id name active))
+                :on-click              [:acme.ui.dropdown/anchor-clicked k]
+                :on-key-down           [:acme.ui.dropdown/key-pressed k options on-change ::v/key]}
+       (selected-label options selected label)]
+      [:div {:data-part          "panel"
+             :id                 (panel-id name)
+             :role               "listbox"
+             :popover            :auto
+             ::web/popover-open? open?
+             :on-toggle          [:acme.ui.dropdown/toggle-reported k]
+             ;; The placement, resolved from the properties the behavior
+             ;; published on the root. `inset: auto` un-does the popover
+             ;; UA rule that centres it in the viewport; the top layer
+             ;; makes `fixed` resolve against the viewport whatever
+             ;; transform an ancestor carries.
+             :style              {:position  "fixed"
+                                  :inset     "auto"
+                                  :top       "var(--acme-anchor-y)"
+                                  :left      "var(--acme-anchor-x)"
+                                  :min-width "var(--acme-anchor-w)"
+                                  :margin    0}}
+       (for [[i opt] (map-indexed vector options)]
+         [:div {:key           i
+                :id            (option-id name i)
+                :data-part     "option"
+                :role          "option"
+                :aria-selected (if (= i active) "true" "false")
+                :on-click      [:acme.ui.dropdown/option-chosen k i options on-change]}
+          (:label opt)])
+       ;; A slot, so a panel can hold a nested overlay. It is ordinary
+       ;; children — nesting needs no mechanism, only structure.
+       children]]]))
+
+;; ---------------------------------------------------------------------------
+;; `confirm` — props only. A modal owns nothing.
+;; ---------------------------------------------------------------------------
+
+(v/defview confirm
+  "A modal confirmation: `<dialog>` promoted with `modal-open?`.
+
+  It holds NO state. Whatever decided to ask the question owns the answer,
+  so `:open?` arrives as a prop and both outcomes leave as event vectors.
+
+  Focus entry, background inertness, Escape and focus return are the
+  platform's — `showModal()` does all four, and re-com ships none of them.
+  `:on-close` is the reconciliation seam the substrate requires: Escape
+  and the dialog's own close both fire it without asking the application."
+  {:props [:map
+           [:name :string]
+           [:title :string]
+           [:open? :boolean]
+           [:on-cancel :vector]
+           [:on-accept :vector]]}
+  [{:keys [name title open? on-cancel on-accept]}]
+  [:dialog {:data-component    "acme/confirm"
+            :data-part         "root"
+            :id                (str "acme-confirm-" name)
+            ::web/modal-open?  open?
+            :aria-label        title
+            :on-close          on-cancel}
+   [:h2 {:data-part "title"} title]
+   [:div {:data-part "body"}
+    [:button {:data-part "cancel"
+              :id        (str "acme-confirm-" name "-cancel")
+              :type      "button"
+              :on-click  on-cancel}
+     "Cancel"]
+    [:button {:data-part "accept"
+              :id        (str "acme-confirm-" name "-accept")
+              :type      "button"
+              :on-click  on-accept}
+     "Delete"]]])
+
+;; ===========================================================================
+;; THE APPLICATION — a document toolbar
+;; ===========================================================================
+;;
+;; From here down is ordinary application code. It knows nothing about
+;; controller records: it holds its own values, reads them the ordinary
+;; way, and calls the library's components like any other view.
+
+(def format-options
+  [{:value :pdf   :label "PDF"}
+   {:value :docx  :label "Word"}
+   {:value :odt   :label "OpenDocument"}])
+
+(def scope-options
+  [{:value :page  :label "This page"}
+   {:value :doc   :label "Whole document"}])
+
+(defn register-app!
+  "The application's own registrations."
+  []
+  (rf/reg-sub :toolbar/format    (fn [db [_ id]] (get-in db [:toolbar id :format])))
+  (rf/reg-sub :toolbar/scope     (fn [db [_ id]] (get-in db [:toolbar id :scope])))
+  (rf/reg-sub :toolbar/deleting? (fn [db [_ id]] (boolean (get-in db [:toolbar id :deleting?]))))
+  (rf/reg-sub :toolbar/deleted   (fn [db _] (get db ::deleted [])))
+
+  (rf/reg-event :toolbar/format-chosen
+    (fn [{:keys [db]} [_ id value]] {:db (assoc-in db [:toolbar id :format] value)}))
+
+  (rf/reg-event :toolbar/scope-chosen
+    (fn [{:keys [db]} [_ id value]] {:db (assoc-in db [:toolbar id :scope] value)}))
+
+  (rf/reg-event :toolbar/delete-requested
+    (fn [{:keys [db]} [_ id]] {:db (assoc-in db [:toolbar id :deleting?] true)}))
+
+  (rf/reg-event :toolbar/delete-cancelled
+    (fn [{:keys [db]} [_ id]] {:db (assoc-in db [:toolbar id :deleting?] false)}))
+
+  (rf/reg-event :toolbar/delete-accepted
+    (fn [{:keys [db]} [_ id]]
+      {:db (-> db
+               (assoc-in [:toolbar id :deleting?] false)
+               (update ::deleted (fnil conj []) id))})))
+
+(v/defview toolbar
+  "One document's toolbar: an export-format dropdown, a delete button and
+  the modal that confirms it.
+
+  The whole thing sits inside a CLIPPING, TRANSFORMED ancestor — the exact
+  arrangement that defeats `position: fixed` emulation, because a
+  transform makes an ancestor the containing block. The panel escapes it
+  anyway, and it escapes it without a z-index, because the browser paints
+  a popover in the top layer rather than in the ancestor's stacking
+  context."
+  {:props [:map [:id :any]]}
+  [{:keys [id]}]
+  (let [format*   (v/sub [:toolbar/format id])
+        deleting? (v/sub [:toolbar/deleting? id])]
+    [:div {:data-component "acme/toolbar"
+           :id             (str "toolbar-clip-" (name id))
+           ;; The two things that defeat `position: fixed` emulation, in
+           ;; one element: a clipping box and a containing-block-forming
+           ;; transform.
+           :style          {:overflow "hidden"
+                            :height   "40px"
+                            :width    "220px"
+                            :transform "translateX(10px)"}}
+     [dropdown {:name      (str "format-" (name id))
+                :label     "Export as…"
+                :control   [:toolbar id :format]
+                :options   format-options
+                :selected  format*
+                :gap       4
+                :on-change [:toolbar/format-chosen id]}]
+     [:button {:id       (str "toolbar-delete-" (name id))
+               :type     "button"
+               :on-click [:toolbar/delete-requested id]}
+      "Delete"]
+     [confirm {:name      (name id)
+               :title     "Delete this document?"
+               :open?     deleting?
+               :on-cancel [:toolbar/delete-cancelled id]
+               :on-accept [:toolbar/delete-accepted id]}]]))
+
+(v/defview menu-bar
+  "A dropdown whose panel contains another dropdown — the nesting case.
+
+  The inner control is ordinary CHILDREN of the outer one. Nothing
+  coordinates them: the browser knows the inner panel is a DOM descendant
+  of the outer, so it stacks them rather than treating the inner as a
+  sibling that closes the outer, and Escape unwinds them innermost-first."
+  {:props [:map [:id :any]]}
+  [{:keys [id]}]
+  (let [format* (v/sub [:toolbar/format id])
+        scope*  (v/sub [:toolbar/scope id])]
+    [:div {:data-component "acme/menu-bar"}
+     [dropdown {:name      (str "outer-" (name id))
+                :label     "Export as…"
+                :control   [:menu id :format]
+                :options   format-options
+                :selected  format*
+                :on-change [:toolbar/format-chosen id]}
+      [dropdown {:name      (str "inner-" (name id))
+                 :label     "Scope…"
+                 :control   [:menu id :scope]
+                 :options   scope-options
+                 :selected  scope*
+                 :on-change [:toolbar/scope-chosen id]}]]]))
+
+(v/defview toolbars
+  "Two documents on one page — the same components, four controller
+  records, and no coordination between them. Each control's state is
+  addressed by the domain identity that owns it, so there is nothing for
+  two instances to collide over."
+  {:props [:map [:ids [:vector :any]]]}
+  [{:keys [ids]}]
+  [:div {:data-component "acme/toolbars"}
+   (for [id ids]
+     [toolbar {:key id :id id}])])

--- a/implementation/freehand/test/re_frame/freehand/pilot_overlay_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/pilot_overlay_cljs_test.cljc
@@ -1,0 +1,592 @@
+(ns re-frame.freehand.pilot-overlay-cljs-test
+  "CASE B, the HEADLESS half — every §B.2 requirement of the fitness
+  harness, enumerated one test per row, over the pilot library in
+  [[re-frame.freehand.pilot-overlay]].
+
+  The harness's own R-B13 says what belongs here and what does not:
+  open/close logic, dismissal policy and placement INPUTS are assertable
+  as data; actual geometry and focus are owed to mounted tests. So this
+  file makes no claim about a pixel and no claim about the active element
+  — those are `pilot-overlay-dom-cljs-test`'s, and each row below names
+  which half it is proving.
+
+  It runs on the JVM and in Node from one `.cljc`. That is not a
+  convenience: the JVM run IS the R-B10 host-boundary proof, because a
+  library whose render path reached `js/document` could not produce a
+  structural tree at all."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.behaviors :as behaviors]
+            [re-frame.freehand.cell :as cell]
+            [re-frame.freehand.pilot-overlay :as ui]
+            [re-frame.live-frame :as live-frame]
+            [re-frame.freehand.test :as t]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+;; ---------------------------------------------------------------------------
+;; Seams
+;; ---------------------------------------------------------------------------
+
+(def ^:private fid :rf/default)
+(def ^:private other-fid :acme/second-frame)
+
+(defn- seed! [db] (frame/replace-app-db! fid db))
+(defn- app-db [] (frame/frame-app-db-value fid))
+(defn- records [] (get (app-db) ui/records-root))
+(defn- record [address] (get (records) [ui/dropdown-kind address]))
+(defn- send! ([ev] (send! ev fid)) ([ev f] (rf/dispatch-sync ev {:frame f})))
+
+(defn- render-in!
+  "Render `form` in frame `f` — one candidate, one structural walk, and NO
+  commit. `v/sub` is legal only inside an active render, and the
+  structural surface walks a body without being a host, so the two are
+  composed here exactly as the controller suites compose them."
+  [f form]
+  (let [cand (cell/candidate (cell/cell :acme/probe) f)]
+    (cell/with-capture cand (fn [] (t/render form)))))
+
+(defn- render! [form] (render-in! fid form))
+
+(defn- part?
+  "Does `node` carry `data-part` = `p`? Guarded on `map?` because a
+  structural tree holds text alongside nodes and `t/attrs` refuses a
+  string — deliberately, so a projection cannot silently answer for a
+  value that has none."
+  [p node]
+  (and (map? node) (= p (get (t/attrs node) :data-part))))
+
+(defn- node-with-part
+  "The FIRST node carrying `data-part` = `p`."
+  [tree p]
+  (t/find tree (partial part? p)))
+
+(defn- nodes-with-part [tree p]
+  (t/find-all tree (partial part? p)))
+
+(defn- attrs-of [tree p] (t/attrs (node-with-part tree p)))
+
+(defn- intent [tree p prop] (get (attrs-of tree p) prop))
+
+(defn- fire!
+  "Dispatch the intent a part carries under `prop`, filling the
+  projection positions a live payload would."
+  [tree p prop & args]
+  (let [ev (intent tree p prop)]
+    (send! (if (seq args) (into (vec (butlast ev)) args) ev))))
+
+(def ^:private options ui/format-options)
+
+(def ^:private address [:toolbar :doc-1 :format])
+
+(defn- dropdown-form
+  ([] (dropdown-form nil))
+  ([selected]
+   [ui/dropdown {:name      "format"
+                 :label     "Export as…"
+                 :control   address
+                 :options   options
+                 :selected  selected
+                 :gap       4
+                 :on-change [:toolbar/format-chosen :doc-1]}]))
+
+(defn- init! []
+  (ui/register!)
+  (ui/register-app!))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter
+                                            :init-fn init!}))
+
+;; ===========================================================================
+;; R-B1 — measure-then-place: the INPUTS are data, the timing is declared
+;; ===========================================================================
+
+(deftest r-b1-placement-inputs-and-the-measuring-moment-are-declared-data
+  (testing "R-B1 (headless half). Placement needs DOM measurement, so the
+            design must NAME the phase it happens in. The name is not
+            prose here: the behavior is registered `{:timing :layout}` —
+            the closed value that means `before the browser paints` — and
+            everything the measurement consumes rides as `:config`, which
+            the structural tree records verbatim. The baseline's answer to
+            the same requirement was to park the body at -10000px until it
+            had measured; there is nothing to park when the measurement
+            precedes the paint."
+    (seed! {})
+    (let [definition (behaviors/definition ui/anchor-box)
+          tree       (render! (dropdown-form))
+          boundary   (t/find tree #(= :re-frame.freehand/behavior (:view-id %)))]
+      (is (= :layout (:timing definition))
+          "the measuring moment is the declared, closed `:layout`")
+      (is (contains? behaviors/timings :layout)
+          "non-vacuous: `:layout` is a value the substrate's roster admits")
+      (is (some? boundary) "the use site is a boundary node in the tree")
+      (is (= {:open? false :gap 4} (get-in boundary [:props :config]))
+          "the placement inputs are DATA a structural test reads")
+      (is (= [ui/dropdown-kind address] (get-in boundary [:props :target]))
+          "and the connection is addressed by the caller's domain identity")
+      (is (= ui/anchor-box (get-in boundary [:props :use]))
+          "the registered id rides the tree; the implementation does not"))))
+
+(deftest r-b1-opening-moves-the-configuration-so-the-measurement-reruns
+  (testing "R-B1 (headless half). A behavior's `:update` runs when the
+            committed config MOVES by `rf=` and not otherwise, so a
+            measurement that must happen on open has to be caused by
+            something in the config. The open flag IS in the config, which
+            is what makes `re-measure exactly when it opens, and at no
+            other commit` a mechanical consequence rather than a hope."
+    (seed! {})
+    (let [closed (render! (dropdown-form))]
+      (fire! closed "anchor" :on-click)
+      (let [open* (render! (dropdown-form))
+            cfg   (fn [tree] (get-in (t/find tree #(= :re-frame.freehand/behavior (:view-id %)))
+                                     [:props :config]))]
+        (is (= {:open? false :gap 4} (cfg closed)))
+        (is (= {:open? true :gap 4} (cfg open*)))
+        (is (not= (cfg closed) (cfg open*))
+            "the configuration moved, so the measurement is due")))))
+
+;; ===========================================================================
+;; R-B2 — escaping clipping and stacking with no emulation warts
+;; ===========================================================================
+
+(deftest r-b2-the-panel-declares-a-top-layer-promotion-and-no-z-index-ladder
+  (testing "R-B2 (headless half). The mechanism must be immune to ancestor
+            transforms, which `position: fixed` emulation is not. The
+            declaration says so: the panel carries a valid `:popover` mode
+            and the reserved top-layer fact, and the whole library emits no
+            `z-index` at all — there is no ladder to coordinate because
+            nothing is competing inside a stacking context. The browser
+            half proves the escape; this half proves there is no emulation
+            to go wrong."
+    (seed! {})
+    (let [tree  (render! (dropdown-form))
+          panel (node-with-part tree "panel")
+          all   (filter map? (tree-seq map? :children tree))]
+      (is (= "auto" (:popover (t/attrs panel)))
+          "the panel is a popover, which is what makes the property legal")
+      (is (= {:popover-open? false} (:rf.ui/top-layer panel))
+          "and the desired state is the reserved structural fact, not an attribute")
+      (is (empty? (filter #(contains? (:style (t/attrs %)) :z-index) all))
+          "no element in the library's output declares a z-index")
+      (is (empty? (filter #(= "re-frame.freehand.web" (namespace %))
+                          (filter keyword? (mapcat (comp keys t/attrs) all))))
+          "and no web-qualified property survived into :attrs"))))
+
+;; ===========================================================================
+;; R-B3 — outside-interaction dismiss, with a listener lifetime of ZERO
+;; ===========================================================================
+
+(deftest r-b3-the-dismissal-policy-is-one-idempotent-registered-event
+  (testing "R-B3 (headless half). The baseline installs a document click
+            listener in `open!` and removes it in `close!` — so an unmount
+            while open leaks it permanently. Here dismissal is the
+            PLATFORM's (light dismiss on an `:auto` popover) and the
+            application's only job is to reconcile the state that drives
+            the desired property. That reconciliation is one registered
+            event, and it is idempotent: a dismissal the application
+            already caused finds nothing to close and writes nothing."
+    (seed! {})
+    (let [tree (render! (dropdown-form))]
+      (fire! tree "anchor" :on-click)
+      (is (true? (:open? (record address))) "open")
+      (send! [:acme.ui.dropdown/dismissed [ui/dropdown-kind address]])
+      (is (nil? (record address)) "the browser's dismissal closed it")
+      (let [before (app-db)]
+        (send! [:acme.ui.dropdown/dismissed [ui/dropdown-kind address]])
+        (is (= before (app-db))
+            "and a second dismissal is inert — the record is already gone")))))
+
+(deftest r-b3-dismissal-costs-the-library-no-lifecycle-at-all
+  (testing "R-B3 (headless half). A listener whose lifetime must be
+            reasoned about is a listener that can leak. The strongest form
+            of `its lifetime is bounded by construction` is that it does
+            not exist — and the whole dismissal path here is: a popover
+            mode on an attribute, a native event the caller reconciles, and
+            one registered handler. The behavior beside it declares no
+            `:disconnect`, because it acquires nothing that would need one.
+            The browser half turns this into an exact integer."
+    (let [definition (behaviors/definition ui/anchor-box)
+          tree       (do (seed! {}) (render! (dropdown-form)))]
+      (is (nil? (:disconnect definition))
+          "the library's only host boundary has nothing to release")
+      (is (= "auto" (:popover (attrs-of tree "panel")))
+          "dismissal is the platform's, off the popover mode")
+      (is (= [:acme.ui.dropdown/toggle-reported [ui/dropdown-kind address]]
+             (:on-toggle (attrs-of tree "panel")))
+          "and the library's whole contribution is reconciling the report"))))
+
+(deftest r-b3-the-dismissal-handshake-is-data-because-newstate-cannot-be
+  (testing "R-B3 (headless half), and a FINDING. Reconciling a
+            browser-initiated dismissal means reading `ToggleEvent.newState`,
+            and there is no reserved projection for it — the closed roster
+            is `::v/value` / `::v/checked` / `::v/key`. The sanctioned
+            escape for exactly this shape is `v/event`, and a view that
+            reaches for it can no longer render on the structural host at
+            all, which for an overlay means no SSR and no headless
+            assertion. The row pins BOTH halves: the refusal is real, and
+            this library therefore counts reports instead of reading them."
+    (seed! {})
+    (is (thrown? #?(:clj Throwable :cljs :default)
+                 (t/render [:div {:popover :auto
+                                  :on-toggle (v/event [_] [:acme.ui.dropdown/dismissed :x])}]))
+        "a v/event callback at a handler site is refused by the structural render")
+    (is (= [:acme.ui.dropdown/dismissed :x]
+           (:on-click (t/attrs (t/render [:div {:on-click [:acme.ui.dropdown/dismissed :x]}]))))
+        "non-vacuous: an ordinary event vector at the same site renders fine")
+
+    (testing "and the handshake the library uses instead: the first report
+              of a session acknowledges, a later one closes, and a report
+              after the application already closed is inert"
+      (let [k [ui/dropdown-kind address]]
+        (send! [:acme.ui.dropdown/anchor-clicked k])
+        (send! [:acme.ui.dropdown/toggle-reported k])
+        (is (= {:open? true :active 0 :acked? true} (record address))
+            "the opening report is acknowledged, not acted on")
+        (send! [:acme.ui.dropdown/toggle-reported k])
+        (is (nil? (record address)) "a second report is the browser dismissing")
+        (let [before (app-db)]
+          (send! [:acme.ui.dropdown/toggle-reported k])
+          (is (= before (app-db)) "and a report with no record left is inert"))))))
+
+;; ===========================================================================
+;; R-B4 — the focus contract, per overlay class
+;; ===========================================================================
+
+(deftest r-b4-each-overlay-class-declares-the-platform-primitive-that-owns-focus
+  (testing "R-B4 (headless half). The harness sets the bar at the native
+            `<dialog>` / popover behaviour set, which re-com meets on ZERO
+            of its six points. Meeting it is a declaration, not an
+            implementation: the modal is a `<dialog>` promoted on the modal
+            axis, so focus entry, containment, Escape and focus return are
+            the platform's; the anchored panel is an `:auto` popover, which
+            takes no focus and therefore leaves the anchor holding it. The
+            browser half reads all six back off a live document."
+    (seed! {:toolbar {:doc-1 {:deleting? true}}})
+    (let [tree   (render! [ui/confirm {:name      "doc-1"
+                                       :title     "Delete this document?"
+                                       :open?     true
+                                       :on-cancel [:toolbar/delete-cancelled :doc-1]
+                                       :on-accept [:toolbar/delete-accepted :doc-1]}])
+          root   (node-with-part tree "root")
+          panel  (node-with-part (render! (dropdown-form)) "panel")]
+      (is (= :dialog (:tag root)) "the modal is a <dialog>")
+      (is (= {:modal-open? true} (:rf.ui/top-layer root))
+          "promoted on the MODAL axis — showModal(), not the :open attribute")
+      (is (= [:toolbar/delete-cancelled :doc-1] (:on-close (t/attrs root)))
+          "and the platform's own dismissal is reconciled by the caller's intent")
+      (is (= "auto" (:popover (t/attrs panel)))
+          "the anchored panel is an :auto popover — light dismiss, no focus move")
+      (is (nil? (:autofocus (t/attrs panel)))
+          "it asks for no focus, so the anchor keeps it"))))
+
+;; ===========================================================================
+;; R-B5 — the keyboard grammar, whole, as one registered event
+;; ===========================================================================
+
+(deftest r-b5-the-single-dropdown-parity-set-is-one-event-driven-by-data
+  (testing "R-B5. re-com's richer dropdown hand-rolls Enter / Escape /
+            arrows / PageUp / PageDown over eleven local ratoms. Here the
+            same grammar is ONE registered event whose only live input is
+            `::v/key` — so every row below is an equality assertion with no
+            browser, no ratom and no callback body."
+    (seed! {})
+    (let [tree (render! (dropdown-form))
+          key! (fn [k] (fire! tree "anchor" :on-key-down k))
+          st   #(record address)]
+      (is (nil? (st)) "closed to begin with")
+
+      (testing "closed: ArrowDown opens on the first option, ArrowUp on the last"
+        (key! "ArrowDown")
+        (is (= {:open? true :active 0} (st)))
+        (send! [:acme.ui.dropdown/dismissed [ui/dropdown-kind address]])
+        (key! "ArrowUp")
+        (is (= {:open? true :active (dec (count options))} (st))))
+
+      (testing "open: the arrows move the highlight and CLAMP at the ends"
+        (key! "Home")
+        (is (= 0 (:active (st))))
+        (key! "ArrowUp")
+        (is (= 0 (:active (st))) "clamped at the top")
+        (key! "ArrowDown")
+        (is (= 1 (:active (st))))
+        (key! "End")
+        (is (= (dec (count options)) (:active (st))))
+        (key! "ArrowDown")
+        (is (= (dec (count options)) (:active (st))) "clamped at the bottom"))
+
+      (testing "Enter commits the highlighted option and closes"
+        (key! "Home")
+        (key! "Enter")
+        (is (nil? (st)) "closed")
+        (is (= (:value (first options)) (get-in (app-db) [:toolbar :doc-1 :format]))
+            "and the caller's own event carried the chosen value"))
+
+      (testing "Escape cancels: it closes without committing anything"
+        (key! "ArrowDown")
+        (key! "ArrowDown")
+        (let [before (get-in (app-db) [:toolbar :doc-1 :format])]
+          (key! "Escape")
+          (is (nil? (st)) "closed")
+          (is (= before (get-in (app-db) [:toolbar :doc-1 :format]))
+              "and the caller's value is exactly what it was")))
+
+      (testing "a key outside the grammar settles an event that changes nothing"
+        (key! "ArrowDown")
+        (let [before (app-db)]
+          (key! "q")
+          (is (= before (app-db))
+              "the cost of a data keyboard site, stated rather than hidden"))))))
+
+;; ===========================================================================
+;; R-B6 — anchor-tracking honesty
+;; ===========================================================================
+
+(deftest r-b6-the-tracking-frequency-is-declared-and-the-escape-is-bounded
+  (testing "R-B6. `positions once, at the commit that moved` is an
+            acceptable contract if DECLARED; a silent every-frame loop is
+            not. The declaration is mechanical: the only moments the
+            behavior runs at are the two the substrate enumerates, and the
+            only other way to reach it is a finite command roster
+            addressed by the use site's own semantic id. There is no
+            interval, no observer and no animation-frame arm anywhere in
+            the definition — the browser half counts them."
+    (let [definition (behaviors/definition ui/anchor-box)]
+      (is (= #{:reposition} (set (keys (:commands definition))))
+          "one command, named, and nothing else reaches the connection")
+      (is (= :layout (:timing definition)))
+      (is (some? (:connect definition)) "it measures when it connects")
+      (is (some? (:update definition)) "and when the configuration moves")
+      (is (nil? (:disconnect definition))
+          "and releases nothing, because it acquired nothing"))))
+
+;; ===========================================================================
+;; R-B7 — one owner for the open state, per instance, collision-free
+;; ===========================================================================
+
+(deftest r-b7-open-state-has-exactly-one-owner-and-n-instances-do-not-collide
+  (testing "R-B7. The baseline offers a caller-supplied `:model` OR an
+            internal default ratom — two ways to own one flag, which is
+            how a library acquires callers who own it differently. Here
+            there is one way: the record lives at (kind, :control), the
+            address is REQUIRED, and there is no prop that would let a
+            caller bring its own. Two instances differ only in the address
+            they were given."
+    (seed! {})
+    (let [a [:toolbar :doc-1 :format]
+          b [:toolbar :doc-2 :format]
+          form (fn [addr nm] [ui/dropdown {:name nm :label "Export as…" :control addr
+                                           :options options
+                                           :on-change [:toolbar/format-chosen :doc-1]}])]
+      (fire! (render! (form a "a")) "anchor" :on-click)
+      (is (= {:open? true :active 0} (record a)))
+      (is (nil? (record b)) "the second instance is untouched")
+      (fire! (render! (form b "b")) "anchor" :on-click)
+      (is (= 2 (count (records))) "two records, two addresses, no coordination")
+
+      (testing "and the props map is CLOSED, so a caller cannot smuggle a
+                second owner in beside the address"
+        (is (thrown? #?(:clj Throwable :cljs :default)
+                     (render! [ui/dropdown {:name "c" :label "x" :control a
+                                            :options options
+                                            :on-change [:toolbar/format-chosen :doc-1]
+                                            :model (atom nil)}])))))))
+
+(deftest r-b7-the-address-is-required-rather-than-derived
+  (testing "R-B7. A renderer-derived anchor would turn a sort, a rename or
+            a parent extraction into a silent state migration, so the
+            substrate refuses an absent `:control` instead of defaulting
+            it — a default would collide every addressless control onto one
+            record keyed by nil."
+    (seed! {})
+    (is (thrown? #?(:clj Throwable :cljs :default)
+                 (render! [ui/dropdown {:name "d" :label "x" :options options
+                                        :on-change [:toolbar/format-chosen :doc-1]}])))))
+
+;; ===========================================================================
+;; R-B8 — transitions with no orphaned timers
+;; ===========================================================================
+
+(deftest r-b8-the-library-owns-no-timer-so-there-is-nothing-to-orphan
+  (testing "R-B8. The baseline drives entering/in/exiting/out with 100 ms
+            `setTimeout`s that nothing cancels, so unmounting mid-transition
+            leaves them to fire. This library arms none: a top-layer
+            element's own enter and exit are CSS
+            (`transition-behavior: allow-discrete`, `@starting-style`), and
+            the substrate's answer for content-level enter/exit —
+            `v/presence` — carries a MANDATORY terminal bound rather than
+            an open-ended timer. Nothing here schedules anything, which is
+            the strongest version of `cancels cleanly`."
+    (seed! {})
+    (let [tree (render! (dropdown-form))]
+      (send! [:acme.ui.dropdown/anchor-clicked [ui/dropdown-kind address]])
+      (send! [:acme.ui.dropdown/dismissed [ui/dropdown-kind address]])
+      (is (nil? (record address)) "a full cycle ran and left no record")
+      (is (nil? (:on-transition-end (attrs-of tree "panel")))
+          "the panel arms no transition callback of its own")
+      (is (nil? (:on-animation-end (attrs-of tree "panel")))
+          "and no animation callback either — the exit is the cascade's"))))
+
+;; ===========================================================================
+;; R-B9 — nesting determinism
+;; ===========================================================================
+
+(deftest r-b9-a-nested-overlay-is-ordinary-children-and-nothing-else
+  (testing "R-B9 (headless half). Nesting needs no mechanism, only
+            structure: the inner control is CHILDREN of the outer panel,
+            so the inner popover is a DOM descendant of the outer one and
+            the browser's own LIFO stack applies. A portal-based design has
+            to reconstruct that relationship after re-parenting; there is
+            nothing to reconstruct when the element never left."
+    (seed! {})
+    (let [tree   (render! [ui/menu-bar {:id :doc-1}])
+          panels (nodes-with-part tree "panel")
+          outer  (first panels)
+          inner  (last panels)]
+      (is (= 2 (count panels)) "two panels")
+      (is (not= outer inner))
+      (is (some #(identical? inner %) (filter map? (tree-seq map? :children outer)))
+          "the inner panel is a DESCENDANT of the outer panel in the tree")
+      (is (= {:popover-open? false} (:rf.ui/top-layer outer)))
+      (is (= {:popover-open? false} (:rf.ui/top-layer inner))))))
+
+(deftest r-b9-the-two-nested-controls-hold-independent-records
+  (testing "R-B9 (headless half). LIFO dismissal is only meaningful if the
+            two overlays have separate state to be in. They do: the outer
+            and inner controls are addressed by different domain
+            identities, so closing one is not an operation on the other."
+    (seed! {})
+    (let [tree   (render! [ui/menu-bar {:id :doc-1}])
+          anchors (nodes-with-part tree "anchor")]
+      (is (= 2 (count anchors)))
+      (doseq [a anchors] (send! (:on-click (t/attrs a))))
+      (is (= 2 (count (records))) "both open, independently")
+      (send! [:acme.ui.dropdown/dismissed [ui/dropdown-kind [:menu :doc-1 :scope]]])
+      (is (= 1 (count (records))) "the inner closed")
+      (is (some? (get (records) [ui/dropdown-kind [:menu :doc-1 :format]]))
+          "and the outer did not"))))
+
+;; ===========================================================================
+;; R-B10 — host-boundary hygiene
+;; ===========================================================================
+
+(deftest r-b10-the-whole-composition-renders-with-no-host-at-all
+  (testing "R-B10. The render path must be free of `js/document` and
+            `js/window` so a server can render the closed form — and the
+            proof is that this very assertion runs on the JVM. A closed
+            panel is one element carrying a desired state of `false`, a
+            behavior boundary is an INERT MARKER recording its id, target
+            and public config, and nothing connected."
+    (seed! {})
+    (let [tree (render! [ui/toolbar {:id :doc-1}])]
+      (is (some? tree) "the toolbar rendered structurally")
+      (is (= {:popover-open? false} (:rf.ui/top-layer (node-with-part tree "panel"))))
+      (is (= {:modal-open? false}
+             (:rf.ui/top-layer (t/find tree #(= :dialog (:tag %)))))
+          "and the modal's closed desired state is a fact, not an absence")
+      #?(:cljs
+         (is (zero? (behaviors/connection-count))
+             "a structural render connects nothing even where connections exist")
+         :clj
+         (is (contains? (behaviors/registered-ids) ui/anchor-box)
+             "the behavior is registered on this host and still connects nothing")))))
+
+;; ===========================================================================
+;; R-B11 — frame / context continuity
+;; ===========================================================================
+
+(deftest r-b11-the-panel-resolves-the-same-frame-as-its-anchor
+  (testing "R-B11. The efxb1h ruling preferred a top layer to a portal
+            partly because there is no boundary to propagate frame context
+            across. Here that is checked rather than assumed: the same
+            declaration is rendered in TWO frames whose controller records
+            differ, and each panel shows its own frame's state."
+    (live-frame/make-frame {:id other-fid})
+    (frame/replace-app-db! fid {})
+    (frame/replace-app-db! other-fid {})
+    (rf/dispatch-sync [:acme.ui.dropdown/anchor-clicked [ui/dropdown-kind address]]
+                      {:frame fid})
+    (let [here  (render-in! fid (dropdown-form))
+          there (render-in! other-fid (dropdown-form))]
+      (is (= "true" (:aria-expanded (attrs-of here "anchor")))
+          "the frame that opened it sees it open")
+      (is (= "false" (:aria-expanded (attrs-of there "anchor")))
+          "a second frame rendering the SAME declaration sees its own state")
+      (is (= {:popover-open? true} (:rf.ui/top-layer (node-with-part here "panel"))))
+      (is (= {:popover-open? false} (:rf.ui/top-layer (node-with-part there "panel")))
+          "and the panel followed its own frame, not the other one's"))))
+
+;; ===========================================================================
+;; R-B12 — total teardown (the headless half: no state survives)
+;; ===========================================================================
+
+(deftest r-b12-closing-retires-the-record-entirely
+  (testing "R-B12 (headless half). The mounted half counts listeners,
+            observers and timers. This half asserts the other thing a
+            teardown can leak — state: a closed control leaves NO record
+            behind, so an application that opened a thousand dropdowns
+            holds nothing when they are all shut."
+    (seed! {})
+    (doseq [id [:a :b :c]]
+      (send! [:acme.ui.dropdown/anchor-clicked [ui/dropdown-kind [:toolbar id]]]))
+    (is (= 3 (count (records))))
+    (doseq [id [:a :b :c]]
+      (send! [:acme.ui.dropdown/dismissed [ui/dropdown-kind [:toolbar id]]]))
+    (is (empty? (records)) "every record retired")
+    (is (empty? (get (app-db) ui/records-root))
+        "and the library's root holds nothing rather than a map of tombstones")))
+
+;; ===========================================================================
+;; R-B13 — the honest test split
+;; ===========================================================================
+
+(deftest r-b13-everything-provable-without-a-browser-is-proven-without-one
+  (testing "R-B13. The split the harness demands is that open/close logic,
+            dismissal policy and placement inputs are data, and geometry
+            and focus are owed to a mounted run. This file is that split
+            made real, so the row asserts the boundary itself: the state a
+            dropdown holds, the intent every part carries, and the
+            configuration the measurement consumes are all readable here —
+            and the one thing that is NOT is any coordinate."
+    (seed! {})
+    (let [tree (render! (dropdown-form))]
+      (is (vector? (intent tree "anchor" :on-click)) "intent is a vector")
+      (is (vector? (intent tree "option" :on-click)) "on every part")
+      (is (= ::v/key (last (intent tree "anchor" :on-key-down)))
+          "and the keyboard site's only live input is a reserved projection")
+      (let [style (:style (attrs-of tree "panel"))]
+        (is (= "var(--acme-anchor-y)" (:top style))
+            "the panel's position is expressed in terms the measurement fills")
+        (is (every? string? (vals (select-keys style [:top :left :min-width])))
+            "so no coordinate is claimed on a host that cannot measure one")))))
+
+;; ===========================================================================
+;; The composition's own claim: the two refs never meet
+;; ===========================================================================
+
+(deftest the-behavior-and-the-top-layer-land-on-different-elements
+  (testing "A behavior attaches through `cloneElement` with its own ref and
+            the top layer installs its host call on a ref of its own, so an
+            element carrying both would have one silently overwrite the
+            other. This composition never asks for such an element — the
+            measurement is of the anchor's box and the promotion is of the
+            panel — and this row pins that as a structural fact rather than
+            leaving it to a reviewer's eye. `pilot-overlay-dom-cljs-test`
+            reproduces the collision deliberately, so the absence here is
+            evidence rather than luck."
+    (seed! {})
+    (let [tree     (render! (dropdown-form))
+          boundary (t/find tree #(= :re-frame.freehand/behavior (:view-id %)))
+          decorated (first (:children boundary))
+          promoted  (t/find-all tree #(and (map? %) (contains? % :rf.ui/top-layer)))]
+      (is (some? boundary))
+      (is (= "root" (get-in decorated [:attrs :data-part]))
+          "the behavior decorates the ROOT")
+      (is (= 1 (count promoted)) "exactly one element declares a desired state")
+      (is (= "panel" (get-in (first promoted) [:attrs :data-part]))
+          "and it is the PANEL, not the root")
+      (is (nil? (:rf.ui/top-layer decorated))
+          "so the decorated element declares no desired state at all"))))

--- a/implementation/freehand/test/re_frame/freehand/pilot_overlay_compiled.cljc
+++ b/implementation/freehand/test/re_frame/freehand/pilot_overlay_compiled.cljc
@@ -1,0 +1,49 @@
+(ns re-frame.freehand.pilot-overlay-compiled
+  "The CASE B pilot's overlay markup, PROMOTED — and the exact shape of
+  what could not be.
+
+  Promotion is a one-line change to a declaration, so the honest way to
+  prove it is to promote the declaration and render both. [[panel]] is the
+  pilot's overlay markup with `{:compiled true}` added and nothing else
+  changed: the anchor, the promoted panel, the desired-state property and
+  both event sites.
+
+  What is NOT here is the behavior boundary the pilot's real dropdown
+  wraps this markup in. `[v/behavior {…} node]` is classified a FOREIGN
+  component boundary by `:re-frame.freehand/v1` and refused, so the
+  measure-then-place half of the composition cannot be promoted at all.
+  That is a finding, not an omission, and
+  `pilot-overlay-parity-cljs-test` pins the refusal with its diagnostic id
+  rather than leaving this namespace's silence to be interpreted.
+
+  A separate namespace, because a view id is derived from where a
+  declaration LIVES: two declarations of one name cannot share one."
+  (:require [re-frame.freehand :as v]
+            [re-frame.freehand.web :as web]))
+
+(v/defview panel
+  "The pilot's overlay markup, compiled."
+  {:compiled true
+   :props    [:map
+              [:open? :boolean]
+              [:control :any]]}
+  [{:keys [open? control]}]
+  [:div {:data-component "acme/dropdown"
+         :data-part      "root"
+         :style          {:display "inline-block" :position "relative"}}
+   [:button {:data-part     "anchor"
+             :type          "button"
+             :aria-expanded (if open? "true" "false")
+             :on-click      [:acme.ui.dropdown/anchor-clicked control]}
+    "Export as…"]
+   [:div {:data-part          "panel"
+          :role               "listbox"
+          :popover            :auto
+          ::web/popover-open? open?
+          :on-toggle          [:acme.ui.dropdown/toggle-reported control]
+          :style              {:position "fixed"
+                               :inset    "auto"
+                               :top      "var(--acme-anchor-y)"
+                               :left     "var(--acme-anchor-x)"
+                               :margin   0}}
+    "PDF"]])

--- a/implementation/freehand/test/re_frame/freehand/pilot_overlay_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/pilot_overlay_dom_cljs_test.cljs
@@ -1,0 +1,551 @@
+(ns re-frame.freehand.pilot-overlay-dom-cljs-test
+  "CASE B, the MOUNTED half — the claims the structural rows cannot make.
+
+  `pilot-overlay-cljs-test` proves what the dropdown MEANS: its state, its
+  intents, its placement inputs, its dismissal policy. None of that can
+  answer the questions CASE B actually exists for, because none of them is
+  in the tree:
+
+  - does the panel land at the anchor's box BEFORE the first paint?
+  - does it escape a clipping, TRANSFORMED ancestor — the arrangement that
+    defeats `position: fixed` emulation?
+  - does a modal take focus, inert the page, and give focus back?
+  - does a nested pair stack, and does dismissing the inner leave the
+    outer up?
+  - and after a full open/close/unmount cycle, is the retained
+    listener/observer/timer count actually ZERO?
+
+  Every claim below is read back off a live `document` after a real
+  `react-dom/client` commit, and the counts are exact integers measured
+  against a CONTROL mount of the same markup with no overlay at all — so
+  React's own bookkeeping cannot be mistaken for the library's.
+
+  One row here is not a proof of the pilot but a REPRODUCTION: an element
+  carrying both a behavior and a top-layer desired state loses one of the
+  two refs. The pilot's own composition never asks for such an element,
+  and this row is the evidence that the avoidance was necessary rather
+  than decorative.
+
+  This file rides the browser lane through its `-dom-cljs-test` suffix. It
+  also matches the node suites' broader regex, where it has no top layer to
+  drive and says so rather than passing quietly."
+  (:require ["react" :as react]
+            ["react-dom/client" :as rdc]
+            [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [goog.object :as gobj]
+            [re-frame.adapter.uix :as react-substrate]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.behaviors :as behaviors]
+            [re-frame.freehand.pilot-overlay :as ui]
+            [re-frame.freehand.react :as fr]
+            [re-frame.freehand.shell :as shell]
+            [re-frame.freehand.top-layer :as top-layer]
+            [re-frame.freehand.web :as web]
+            [re-frame.live-frame :as live-frame]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       react-substrate/adapter
+     :ambient-frame nil
+     :async?        true}))
+
+(def ^:private fid :dom/pilot-overlay)
+(def ^:private doc-id :doc-1)
+(def ^:private address [:toolbar doc-id :format])
+(def ^:private k [ui/dropdown-kind address])
+
+(defn- browser?
+  "A real top layer, not merely a DOM."
+  []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))
+       (some? (.-showPopover (.-prototype js/HTMLElement)))))
+
+(defn- skip! [why]
+  (is true (str "a real browser top layer is required — " why)))
+
+(defn- act [thunk]
+  (try
+    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+    (js/Promise.resolve (react/act (fn [] (js/Promise.resolve (thunk)))))
+    (catch :default e
+      (js/Promise.reject e))))
+
+(defn- next-task
+  "A macrotask boundary — the platform queues a popover's `toggle` event as
+  a task rather than firing it synchronously."
+  []
+  (js/Promise. (fn [resolve] (js/setTimeout resolve 0))))
+
+;; ---------------------------------------------------------------------------
+;; Views. Module-level: a declared view cannot close over a test's locals.
+;; ---------------------------------------------------------------------------
+
+(v/defview plain-toolbar
+  "The CONTROL MOUNT: the same shape with no overlay at all, so React's own
+  listener bookkeeping can be subtracted from the measurement."
+  [_]
+  [:div {:id "plain-toolbar"}
+   [:button {:type "button"} "Export as…"]
+   [:div {:id "plain-panel"} "PDF"]])
+
+(v/defview collided
+  "THE REPRODUCTION (rf2-drpa3.118). One element carrying BOTH a registered
+  behavior and a top-layer desired state.
+
+  A behavior attaches through `cloneElement` with its own ref; the top
+  layer installs its idempotent host call on a ref of its own. React keeps
+  one `ref` prop per element, so whichever is applied last silently wins
+  and the other never runs. Nothing warns."
+  [{:keys [open?]}]
+  [:div
+   [v/behavior {:use    ui/anchor-box
+                :target :collision/probe
+                :config {:open? open?}}
+    [:div {:id                 "collided"
+           :popover            :auto
+           ::web/popover-open? open?
+           :on-toggle          [:probe/noted]}
+     "menu"]]])
+
+;; ---------------------------------------------------------------------------
+;; Harness
+;; ---------------------------------------------------------------------------
+
+(defn- mount! []
+  (let [container (js/document.createElement "div")]
+    (.appendChild js/document.body container)
+    [container (rdc/createRoot container)]))
+
+(defn- teardown! [container root]
+  (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+  (.unmount root)
+  (.remove container)
+  nil)
+
+(defn- setup! []
+  (behaviors/reset-connections!)
+  (top-layer/reset-operation-count!)
+  (live-frame/make-frame {:id fid})
+  (ui/register!)
+  (ui/register-app!)
+  (rf/reg-event :probe/noted (fn [db _] db))
+  (frame/replace-app-db! fid {})
+  nil)
+
+(defn- element [form] (shell/provide-frame fid (fr/element form)))
+
+(defn- send! [ev] (rf/dispatch-sync ev {:frame fid}))
+
+(defn- by-id [id] (js/document.getElementById id))
+(defn- open? [id] (some-> (by-id id) (.matches ":popover-open")))
+(defn- modal? [id] (some-> (by-id id) (.matches ":modal")))
+(defn- rect [id] (.getBoundingClientRect (by-id id)))
+(defn- record [] (get-in (frame/frame-app-db-value fid) [ui/records-root k]))
+
+(defn- anchor-id [] (str "acme-dropdown-format-" (name doc-id) "-anchor"))
+(defn- panel-id  [] (str "acme-dropdown-format-" (name doc-id) "-panel"))
+
+;; ===========================================================================
+;; R-B1 / R-B2 — measured before paint, and outside the clipping ancestor
+;; ===========================================================================
+
+(deftest r-b1-the-panel-is-already-at-the-anchors-box-at-the-first-frame
+  (testing "R-B1 (mounted). The measurement runs at `:layout` — before the
+            browser paints — so the panel is at the anchor's box in the
+            FIRST frame after the commit that opened it. There is no
+            -10000px park and no opacity-0 pass, because there is no wrong
+            position to hide.
+
+            The callback is scheduled BEFORE the opening commit, so what it
+            sees is what the first paint would have shown."
+    (if-not (browser?)
+      (skip! "the browser job runs the placement assertions")
+      (async done
+        (setup!)
+        (let [[container root] (mount!)
+              render (fn [] (act #(.render root (element [ui/toolbar {:id doc-id}]))))
+              seen   (atom nil)]
+          (-> (render)
+              (.then (fn [_]
+                       (is (false? (open? (panel-id))) "closed before anything is asked")
+                       (let [painted (js/Promise.
+                                       (fn [resolve]
+                                         (js/requestAnimationFrame
+                                           (fn []
+                                             (reset! seen
+                                                     {:open? (open? (panel-id))
+                                                      :panel (rect (panel-id))
+                                                      :anchor (rect (anchor-id))})
+                                             (resolve nil)))))]
+                         (send! [:acme.ui.dropdown/anchor-clicked k])
+                         (.then (render) (fn [_] painted)))))
+              (.then (fn [_]
+                       (let [{:keys [open? panel anchor]} @seen]
+                         (is (true? open?) "the panel was already open at the first frame")
+                         (is (< (js/Math.abs (- (.-left panel) (.-left anchor))) 1.5)
+                             "and already at the anchor's left edge — no wrong-position paint")
+                         (is (< (js/Math.abs (- (.-top panel) (+ (.-bottom anchor) 4))) 1.5)
+                             "below it by exactly the declared gap"))
+                       (teardown! container root)
+                       (done)))
+              (.catch (fn [e] (is false (str "browser run failed: " e)) (done)))))))))
+
+(deftest r-b2-the-panel-escapes-a-clipping-transformed-ancestor-and-a-fixed-sibling-does-not
+  (testing "R-B2 (mounted). The toolbar's ancestor carries `overflow:
+            hidden` AND a transform — the two things that defeat
+            `position: fixed` emulation, because a transform makes the
+            ancestor the containing block for a fixed descendant.
+
+            The panel lands at the measured VIEWPORT coordinate. A control
+            element in the same ancestor, `position: fixed` at the SAME
+            coordinates, lands displaced by exactly the transform — which
+            is the wart, measured, in the same document, in the same
+            commit. The panel does not have it because the browser gives a
+            top-layer element the viewport as its containing block, and no
+            z-index was involved in either direction."
+    (if-not (browser?)
+      (skip! "the browser job runs the containing-block assertions")
+      (async done
+        (setup!)
+        (let [[container root] (mount!)
+              render (fn [] (act #(.render root (element [ui/toolbar {:id doc-id}]))))]
+          (-> (render)
+              (.then (fn [_]
+                       (send! [:acme.ui.dropdown/anchor-clicked k])
+                       (render)))
+              (.then (fn [_]
+                       ;; A control at the same coordinates, inside the same
+                       ;; transformed ancestor, but not in the top layer.
+                       (let [host (by-id (str "toolbar-clip-" (name doc-id)))
+                             ctrl (js/document.createElement "div")]
+                         (set! (.-id ctrl) "clip-control")
+                         (set! (.. ctrl -style -position) "fixed")
+                         (set! (.. ctrl -style -inset) "auto")
+                         (set! (.. ctrl -style -top) "var(--acme-anchor-y)")
+                         (set! (.. ctrl -style -left) "var(--acme-anchor-x)")
+                         (.appendChild host ctrl))
+                       (let [panel  (rect (panel-id))
+                             anchor (rect (anchor-id))
+                             ctrl   (rect "clip-control")]
+                         (is (true? (open? (panel-id))) "the panel is in the top layer")
+                         (is (< (js/Math.abs (- (.-left panel) (.-left anchor))) 1.5)
+                             "and sits exactly at the measured viewport coordinate")
+                         (is (> (js/Math.abs (- (.-left ctrl) (.-left panel))) 5)
+                             (str "non-vacuous: an ordinary fixed sibling at the SAME "
+                                  "declared coordinates is displaced by the ancestor "
+                                  "transform (panel " (.-left panel) " vs control "
+                                  (.-left ctrl) ")"))
+                         (is (> (.-bottom panel) (.-bottom (rect (str "toolbar-clip-" (name doc-id)))))
+                             "and the panel extends past the clipping ancestor's box"))
+                       (teardown! container root)
+                       (done)))
+              (.catch (fn [e] (is false (str "browser run failed: " e)) (done)))))))))
+
+;; ===========================================================================
+;; R-B4 — the focus contract, both overlay classes
+;; ===========================================================================
+
+(deftest r-b4-the-modal-takes-focus-inerts-the-page-and-gives-focus-back
+  (testing "R-B4 (mounted). re-com's parity bar on this requirement is
+            ZERO — no focus trap, no inert, no Escape, no focus return
+            anywhere in the library. The pilot's modal gets all of it from
+            `showModal()`, and the row reads each one back off a live
+            document rather than citing the platform."
+    (if-not (browser?)
+      (skip! "the browser job runs the focus assertions")
+      (async done
+        (setup!)
+        (let [[container root] (mount!)
+              render (fn [] (act #(.render root (element [ui/toolbar {:id doc-id}]))))
+              dialog (str "acme-confirm-" (name doc-id))
+              opener (str "toolbar-delete-" (name doc-id))]
+          (-> (render)
+              (.then (fn [_]
+                       (is (false? (modal? dialog)) "closed to begin with")
+                       (.focus (by-id opener))
+                       (is (= (by-id opener) js/document.activeElement)
+                           "the page owns focus")
+                       (send! [:toolbar/delete-requested doc-id])
+                       (render)))
+              (.then (fn [_]
+                       (is (true? (modal? dialog)) "showModal() ran at the commit")
+                       (is (.contains (by-id dialog) js/document.activeElement)
+                           "focus ENTERED the dialog")
+                       (.focus (by-id opener))
+                       (is (.contains (by-id dialog) js/document.activeElement)
+                           "the background is INERT — it cannot take focus back")
+                       (send! [:toolbar/delete-cancelled doc-id])
+                       (render)))
+              (.then (fn [_]
+                       (is (false? (modal? dialog)) "close() ran at the commit")
+                       (is (= (by-id opener) js/document.activeElement)
+                           "and focus RETURNED to the control that opened it")
+                       (teardown! container root)
+                       (done)))
+              (.catch (fn [e] (is false (str "browser run failed: " e)) (done)))))))))
+
+(deftest r-b4-the-anchored-panel-leaves-focus-on-the-anchor
+  (testing "R-B4 (mounted), the anchored half. An `:auto` popover takes no
+            focus, so the anchor keeps it — which is what makes the
+            keyboard grammar work at all, because the keys arrive at the
+            anchor while the list is up."
+    (if-not (browser?)
+      (skip! "the browser job runs the focus assertions")
+      (async done
+        (setup!)
+        (let [[container root] (mount!)
+              render (fn [] (act #(.render root (element [ui/toolbar {:id doc-id}]))))]
+          (-> (render)
+              (.then (fn [_]
+                       (.focus (by-id (anchor-id)))
+                       (send! [:acme.ui.dropdown/anchor-clicked k])
+                       (render)))
+              (.then (fn [_]
+                       (is (true? (open? (panel-id))) "the panel is up")
+                       (is (= (by-id (anchor-id)) js/document.activeElement)
+                           "and the anchor still has focus")
+                       (is (= "true" (.getAttribute (by-id (anchor-id)) "aria-expanded"))
+                           "with the expanded state announced")
+                       (teardown! container root)
+                       (done)))
+              (.catch (fn [e] (is false (str "browser run failed: " e)) (done)))))))))
+
+;; ===========================================================================
+;; R-B3 — the browser dismisses, and the handshake reconciles
+;; ===========================================================================
+
+(deftest r-b3-a-browser-dismissal-reaches-the-handshake-and-does-not-spring-back
+  (testing "R-B3 (mounted). The substrate writes NO application state when
+            the browser dismisses, so an unreconciled control re-opens on
+            the next render. The pilot reconciles by counting reports: the
+            opening toggle acknowledges, the dismissal toggle closes. This
+            row drives a real `hidePopover()` — what Escape and a light
+            dismiss both come down to — and then RE-RENDERS, which is the
+            step that would expose a spring-back."
+    (if-not (browser?)
+      (skip! "the browser job runs the dismissal assertions")
+      (async done
+        (setup!)
+        (let [[container root] (mount!)
+              render (fn [] (act #(.render root (element [ui/toolbar {:id doc-id}]))))]
+          (-> (render)
+              (.then (fn [_]
+                       (send! [:acme.ui.dropdown/anchor-clicked k])
+                       (render)))
+              (.then (fn [_] (next-task)))
+              (.then (fn [_]
+                       (is (true? (open? (panel-id))) "open")
+                       (is (true? (:acked? (record)))
+                           "the platform's opening report reached the handshake")
+                       ;; The browser closing it of its own accord.
+                       (.hidePopover (by-id (panel-id)))
+                       (next-task)))
+              (.then (fn [_]
+                       (is (nil? (record))
+                           "the dismissal report closed the control's own state")
+                       (render)))
+              (.then (fn [_]
+                       (is (false? (open? (panel-id)))
+                           "and the next render does NOT re-open it")
+                       (teardown! container root)
+                       (done)))
+              (.catch (fn [e] (is false (str "browser run failed: " e)) (done)))))))))
+
+;; ===========================================================================
+;; R-B9 — nesting: stacked, and dismissed innermost-first
+;; ===========================================================================
+
+(deftest r-b9-a-nested-panel-stacks-and-dismissing-it-leaves-the-outer-up
+  (testing "R-B9 (mounted). The inner control is ordinary children of the
+            outer panel, so its popover is a DOM descendant of the outer
+            one — which is what makes the browser stack them rather than
+            treat the inner as a sibling that closes the outer. Dismissing
+            the inner leaves the outer up; that is the LIFO property, and
+            it is the platform's, not the library's."
+    (if-not (browser?)
+      (skip! "the browser job runs the nesting assertions")
+      (async done
+        (setup!)
+        (let [[container root] (mount!)
+              render  (fn [] (act #(.render root (element [ui/menu-bar {:id doc-id}]))))
+              outer-k [ui/dropdown-kind [:menu doc-id :format]]
+              inner-k [ui/dropdown-kind [:menu doc-id :scope]]
+              outer   (str "acme-dropdown-outer-" (name doc-id) "-panel")
+              inner   (str "acme-dropdown-inner-" (name doc-id) "-panel")]
+          (-> (render)
+              (.then (fn [_]
+                       (send! [:acme.ui.dropdown/anchor-clicked outer-k])
+                       (send! [:acme.ui.dropdown/anchor-clicked inner-k])
+                       (render)))
+              (.then (fn [_] (next-task)))
+              (.then (fn [_]
+                       (is (true? (open? outer)) "the outer panel is open")
+                       (is (true? (open? inner))
+                           "and the nested one is open TOO — document order beat React's bottom-up refs")
+                       (is (.contains (by-id outer) (by-id inner))
+                           "non-vacuous: the inner really is a DOM descendant of the outer")
+                       ;; The browser dismissing the INNER.
+                       (.hidePopover (by-id inner))
+                       (next-task)))
+              (.then (fn [_]
+                       (is (false? (open? inner)) "the inner closed")
+                       (is (true? (open? outer)) "and the outer stayed up")
+                       (is (nil? (get-in (frame/frame-app-db-value fid) [ui/records-root inner-k]))
+                           "the inner's state closed with it")
+                       (is (some? (get-in (frame/frame-app-db-value fid) [ui/records-root outer-k]))
+                           "and the outer's did not")
+                       (teardown! container root)
+                       (done)))
+              (.catch (fn [e] (is false (str "browser run failed: " e)) (done)))))))))
+
+;; ===========================================================================
+;; R-B6 / R-B12 — the retained count, as exact integers
+;; ===========================================================================
+
+(deftest r-b6-and-r-b12-a-full-cycle-retains-exactly-nothing
+  (testing "R-B6 and R-B12 (mounted). The baseline's dropdown installs a
+            document click listener it never removes on unmount, and
+            re-arms a `requestAnimationFrame` every frame while open. This
+            row measures both, plus observers, intervals and behavior
+            connections, across mount → open → close → unmount — with the
+            listener and frame deltas taken against a CONTROL mount of the
+            same shape with no overlay, so React's own bookkeeping cannot
+            masquerade as the library's."
+    (if-not (browser?)
+      (skip! "the browser job owns the retention counts")
+      (async done
+        (setup!)
+        (let [original #js {"docAdd"    (.-addEventListener js/document)
+                            "docRemove" (.-removeEventListener js/document)
+                            "winAdd"    (.-addEventListener js/window)
+                            "winRemove" (.-removeEventListener js/window)
+                            "ro"        (.-ResizeObserver js/window)
+                            "io"        (.-IntersectionObserver js/window)
+                            "mo"        (.-MutationObserver js/window)
+                            "interval"  (.-setInterval js/window)
+                            "raf"       (.-requestAnimationFrame js/window)}
+              counts   #js {}
+              bump!    (fn [key* n] (gobj/set counts key* (+ n (gobj/get counts key* 0))))
+              zero!    (fn [] (doseq [key* ["doc" "win" "obs" "iv" "raf"]]
+                                (gobj/set counts key* 0)))
+              orig     (fn [key*] (gobj/get original key*))
+              observed (fn [key* ctor]
+                         (fn [& args]
+                           (bump! key* 1)
+                           (js/Reflect.construct ctor (to-array args))))
+              wrap!    (fn []
+                         (zero!)
+                         (set! (.-addEventListener js/document)
+                               (fn [t l o] (bump! "doc" 1) (.call (orig "docAdd") js/document t l o)))
+                         (set! (.-removeEventListener js/document)
+                               (fn [t l o] (bump! "doc" -1) (.call (orig "docRemove") js/document t l o)))
+                         (set! (.-addEventListener js/window)
+                               (fn [t l o] (bump! "win" 1) (.call (orig "winAdd") js/window t l o)))
+                         (set! (.-removeEventListener js/window)
+                               (fn [t l o] (bump! "win" -1) (.call (orig "winRemove") js/window t l o)))
+                         (set! (.-ResizeObserver js/window) (observed "obs" (orig "ro")))
+                         (set! (.-IntersectionObserver js/window) (observed "obs" (orig "io")))
+                         (set! (.-MutationObserver js/window) (observed "obs" (orig "mo")))
+                         (set! (.-setInterval js/window)
+                               (fn [f d] (bump! "iv" 1) (.call (orig "interval") js/window f d)))
+                         (set! (.-requestAnimationFrame js/window)
+                               (fn [f] (bump! "raf" 1) (.call (orig "raf") js/window f))))
+              restore! (fn []
+                         (set! (.-addEventListener js/document) (orig "docAdd"))
+                         (set! (.-removeEventListener js/document) (orig "docRemove"))
+                         (set! (.-addEventListener js/window) (orig "winAdd"))
+                         (set! (.-removeEventListener js/window) (orig "winRemove"))
+                         (set! (.-ResizeObserver js/window) (orig "ro"))
+                         (set! (.-IntersectionObserver js/window) (orig "io"))
+                         (set! (.-MutationObserver js/window) (orig "mo"))
+                         (set! (.-setInterval js/window) (orig "interval"))
+                         (set! (.-requestAnimationFrame js/window) (orig "raf")))
+              snapshot (fn [] {:doc (gobj/get counts "doc") :win (gobj/get counts "win")
+                               :obs (gobj/get counts "obs") :iv  (gobj/get counts "iv")
+                               :raf (gobj/get counts "raf")})
+              cycle!   (fn [form open! close!]
+                         (let [[container root] (mount!)
+                               render (fn [] (act #(.render root (element form))))]
+                           (-> (render)
+                               (.then (fn [_] (open!) (render)))
+                               (.then (fn [_] (next-task)))
+                               (.then (fn [_] (close!) (render)))
+                               (.then (fn [_] (teardown! container root) nil)))))
+              control  (atom nil)]
+          (wrap!)
+          (-> (cycle! [plain-toolbar {}] (fn [] nil) (fn [] nil))
+              (.then (fn [_]
+                       (reset! control (snapshot))
+                       (zero!)
+                       (frame/replace-app-db! fid {})
+                       (cycle! [ui/toolbar {:id doc-id}]
+                               #(send! [:acme.ui.dropdown/anchor-clicked k])
+                               #(send! [:acme.ui.dropdown/dismissed k]))))
+              (.then (fn [_]
+                       (let [measured (snapshot)]
+                         (restore!)
+                         (is (= (:doc @control) (:doc measured))
+                             (str "no net document listener beyond the control's "
+                                  "(control " (:doc @control) ", measured " (:doc measured) ")"))
+                         (is (= (:win @control) (:win measured))
+                             "no net window listener beyond the control's")
+                         (is (= 0 (:obs measured))
+                             "zero resize / intersection / mutation observers")
+                         (is (= 0 (:iv measured)) "zero intervals")
+                         (is (<= (:raf measured) (:raf @control))
+                             (str "no animation-frame arm beyond the control's — there is "
+                                  "no tracking loop (control " (:raf @control)
+                                  ", measured " (:raf measured) ")"))
+                         (is (zero? (behaviors/connection-count))
+                             "and every behavior connection released")
+                         (is (zero? (top-layer/pending-count))
+                             "with the top-layer commit batch drained"))
+                       (done)))
+              (.catch (fn [e] (restore!) (is false (str "browser run failed: " e)) (done)))))))))
+
+;; ===========================================================================
+;; THE REPRODUCTION — rf2-drpa3.118, met by a pilot that had to avoid it
+;; ===========================================================================
+
+(deftest a-behavior-and-a-top-layer-state-on-one-element-lose-a-ref
+  (testing "REPRODUCTION of the known hazard. A behavior attaches through
+            `cloneElement` with its own ref, and the top layer installs its
+            host call on a ref of its own. React keeps ONE `ref` per
+            element, so on an element carrying both, one silently
+            overwrites the other — no warning, no diagnostic, and the
+            half that lost simply never runs.
+
+            The pilot's dropdown never asks for such an element: the
+            measurement is of the anchor's box and the promotion is of the
+            panel, and they were never the same node. That split reads as
+            natural rather than contorted — the root is what a stylesheet
+            already addresses and what the anchor's box already is — but it
+            is a split the author has to KNOW to make, and nothing tells
+            them. This row is the evidence that knowing mattered."
+    (if-not (browser?)
+      (skip! "the browser job runs the ref-collision reproduction")
+      (async done
+        (setup!)
+        (let [[container root] (mount!)
+              render (fn [open?] (act #(.render root (element [collided {:open? open?}]))))]
+          (-> (render false)
+              (.then (fn [_] (render true)))
+              (.then (fn [_] (next-task)))
+              (.then (fn [_]
+                       (let [connected (behaviors/connection-count)
+                             promoted  (open? "collided")]
+                         (is (or (zero? connected) (false? promoted))
+                             (str "one of the two refs was lost — behavior connections "
+                                  connected ", popover open " promoted))
+                         (is (= 1 connected)
+                             "the BEHAVIOR's ref is the one that survives (cloneElement wins)")
+                         (is (false? promoted)
+                             (str "and the top layer's never ran: the element declares a "
+                                  "desired state of OPEN and is not open. Nothing warned.")))
+                       (teardown! container root)
+                       (done)))
+              (.catch (fn [e] (is false (str "browser run failed: " e)) (done)))))))))

--- a/implementation/freehand/test/re_frame/freehand/pilot_overlay_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/pilot_overlay_dom_cljs_test.cljs
@@ -80,6 +80,14 @@
   []
   (js/Promise. (fn [resolve] (js/setTimeout resolve 0))))
 
+(defn- settle
+  "A generous macrotask boundary. A top-layer state change costs a
+  microtask flush, a queued `toggle` task, the dispatch it causes, and the
+  re-render that dispatch schedules — four hops, so a row that observes
+  the END of that chain waits for it rather than for one task."
+  []
+  (js/Promise. (fn [resolve] (js/setTimeout resolve 60))))
+
 ;; ---------------------------------------------------------------------------
 ;; Views. Module-level: a declared view cannot close over a test's locals.
 ;; ---------------------------------------------------------------------------
@@ -115,10 +123,21 @@
 ;; Harness
 ;; ---------------------------------------------------------------------------
 
-(defn- mount! []
-  (let [container (js/document.createElement "div")]
-    (.appendChild js/document.body container)
-    [container (rdc/createRoot container)]))
+(defn- mount!
+  "Mount into a fresh container. `at-origin?` pins the container to the
+  viewport's top-left, which the geometry rows need: the runner's own
+  output pushes an ordinary container far down a long page, where a
+  measured coordinate is outside the viewport and `elementFromPoint`
+  answers about nothing."
+  ([] (mount! false))
+  ([at-origin?]
+   (let [container (js/document.createElement "div")]
+     (when at-origin?
+       (set! (.. container -style -position) "fixed")
+       (set! (.. container -style -top) "0px")
+       (set! (.. container -style -left) "0px"))
+     (.appendChild js/document.body container)
+     [container (rdc/createRoot container)])))
 
 (defn- teardown! [container root]
   (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
@@ -166,7 +185,7 @@
       (skip! "the browser job runs the placement assertions")
       (async done
         (setup!)
-        (let [[container root] (mount!)
+        (let [[container root] (mount! true)
               render (fn [] (act #(.render root (element [ui/toolbar {:id doc-id}]))))
               seen   (atom nil)]
           (-> (render)
@@ -194,53 +213,71 @@
                        (done)))
               (.catch (fn [e] (is false (str "browser run failed: " e)) (done)))))))))
 
-(deftest r-b2-the-panel-escapes-a-clipping-transformed-ancestor-and-a-fixed-sibling-does-not
+(deftest r-b2-the-panel-escapes-a-clipping-transformed-ancestor
   (testing "R-B2 (mounted). The toolbar's ancestor carries `overflow:
             hidden` AND a transform — the two things that defeat
-            `position: fixed` emulation, because a transform makes the
-            ancestor the containing block for a fixed descendant.
+            `position: fixed` emulation, because a transform makes an
+            ancestor the containing block for every fixed descendant.
 
-            The panel lands at the measured VIEWPORT coordinate. A control
-            element in the same ancestor, `position: fixed` at the SAME
-            coordinates, lands displaced by exactly the transform — which
-            is the wart, measured, in the same document, in the same
-            commit. The panel does not have it because the browser gives a
-            top-layer element the viewport as its containing block, and no
-            z-index was involved in either direction."
+            Three measurements, and the middle one is what makes the other
+            two mean something. A `position: fixed` probe inside the same
+            ancestor resolves against the ANCESTOR, displaced by the
+            transform — so the containing-block capture is real in this
+            document, in this commit, and not merely asserted from the
+            spec. The panel, at the same moment, sits exactly at the
+            viewport coordinate the behavior measured, and paints outside
+            the ancestor's clipping box. No z-index was involved in either
+            direction."
     (if-not (browser?)
       (skip! "the browser job runs the containing-block assertions")
       (async done
         (setup!)
-        (let [[container root] (mount!)
-              render (fn [] (act #(.render root (element [ui/toolbar {:id doc-id}]))))]
+        (let [[container root] (mount! true)
+              render (fn [] (act #(.render root (element [ui/toolbar {:id doc-id}]))))
+              clip-id (str "toolbar-clip-" (name doc-id))]
           (-> (render)
               (.then (fn [_]
                        (send! [:acme.ui.dropdown/anchor-clicked k])
                        (render)))
+              (.then (fn [_] (settle)))
               (.then (fn [_]
-                       ;; A control at the same coordinates, inside the same
-                       ;; transformed ancestor, but not in the top layer.
-                       (let [host (by-id (str "toolbar-clip-" (name doc-id)))
-                             ctrl (js/document.createElement "div")]
-                         (set! (.-id ctrl) "clip-control")
-                         (set! (.. ctrl -style -position) "fixed")
-                         (set! (.. ctrl -style -inset) "auto")
-                         (set! (.. ctrl -style -top) "var(--acme-anchor-y)")
-                         (set! (.. ctrl -style -left) "var(--acme-anchor-x)")
-                         (.appendChild host ctrl))
+                       ;; THE PROBE: an ordinary fixed element at the
+                       ;; viewport origin, inside the transformed ancestor.
+                       (let [host  (by-id clip-id)
+                             probe (js/document.createElement "div")]
+                         (set! (.-id probe) "clip-probe")
+                         (set! (.. probe -style -position) "fixed")
+                         (set! (.. probe -style -inset) "auto")
+                         (set! (.. probe -style -top) "0px")
+                         (set! (.. probe -style -left) "0px")
+                         (set! (.. probe -style -width) "1px")
+                         (set! (.. probe -style -height) "1px")
+                         (.appendChild host probe))
                        (let [panel  (rect (panel-id))
                              anchor (rect (anchor-id))
-                             ctrl   (rect "clip-control")]
+                             clip   (rect clip-id)
+                             probe  (rect "clip-probe")
+                             hit    (js/document.elementFromPoint
+                                      (+ (.-left panel) 2) (+ (.-top panel) 2))]
                          (is (true? (open? (panel-id))) "the panel is in the top layer")
+
+                         (is (> (.-left probe) 0.5)
+                             (str "non-vacuous: a fixed probe declared at viewport 0 is NOT "
+                                  "at viewport 0 — the ancestor's transform captured it "
+                                  "(probe left " (.-left probe) ")"))
+                         (is (< (js/Math.abs (- (.-left probe) (.-left clip))) 1.5)
+                             "it resolved against the TRANSFORMED ancestor's box instead")
+
                          (is (< (js/Math.abs (- (.-left panel) (.-left anchor))) 1.5)
-                             "and sits exactly at the measured viewport coordinate")
-                         (is (> (js/Math.abs (- (.-left ctrl) (.-left panel))) 5)
-                             (str "non-vacuous: an ordinary fixed sibling at the SAME "
-                                  "declared coordinates is displaced by the ancestor "
-                                  "transform (panel " (.-left panel) " vs control "
-                                  (.-left ctrl) ")"))
-                         (is (> (.-bottom panel) (.-bottom (rect (str "toolbar-clip-" (name doc-id)))))
-                             "and the panel extends past the clipping ancestor's box"))
+                             "the panel, at the same moment, is at the measured VIEWPORT coordinate")
+                         (is (> (.-top panel) (.-bottom clip))
+                             (str "and paints below the clipping ancestor's box entirely "
+                                  "(panel top " (.-top panel) ", clip bottom " (.-bottom clip) ")"))
+                         (is (or (= hit (by-id (panel-id)))
+                                 (and (some? hit) (.contains (by-id (panel-id)) hit)))
+                             (str "and it is really there: the point paints the panel, not "
+                                  "whatever the clip would have left behind (hit "
+                                  (some-> hit .-id) ")")))
                        (teardown! container root)
                        (done)))
               (.catch (fn [e] (is false (str "browser run failed: " e)) (done)))))))))
@@ -336,14 +373,23 @@
               (.then (fn [_]
                        (send! [:acme.ui.dropdown/anchor-clicked k])
                        (render)))
-              (.then (fn [_] (next-task)))
+              (.then (fn [_] (settle)))
               (.then (fn [_]
                        (is (true? (open? (panel-id))) "open")
                        (is (true? (:acked? (record)))
                            "the platform's opening report reached the handshake")
-                       ;; The browser closing it of its own accord.
+                       ;; Let every render the acknowledgement scheduled
+                       ;; commit BEFORE the browser dismisses: a render
+                       ;; still in flight would re-assert the desired state
+                       ;; after the dismissal and re-open the node, which is
+                       ;; a race about test sequencing rather than about the
+                       ;; handshake.
+                       (act (fn [] nil))))
+              (.then (fn [_]
+                       ;; The browser closing it of its own accord — what
+                       ;; Escape and a light dismiss both come down to.
                        (.hidePopover (by-id (panel-id)))
-                       (next-task)))
+                       (settle)))
               (.then (fn [_]
                        (is (nil? (record))
                            "the dismissal report closed the control's own state")
@@ -359,38 +405,53 @@
 ;; R-B9 — nesting: stacked, and dismissed innermost-first
 ;; ===========================================================================
 
-(deftest r-b9-a-nested-panel-stacks-and-dismissing-it-leaves-the-outer-up
+(def ^:private outer-k [ui/dropdown-kind [:menu doc-id :format]])
+(def ^:private inner-k [ui/dropdown-kind [:menu doc-id :scope]])
+(defn- outer-panel [] (str "acme-dropdown-outer-" (name doc-id) "-panel"))
+(defn- inner-panel [] (str "acme-dropdown-inner-" (name doc-id) "-panel"))
+
+(defn- open-record [] {:open? true :active 0})
+
+(deftest r-b9-a-nested-panel-opened-in-one-commit-stacks-and-dismisses-innermost-first
   (testing "R-B9 (mounted). The inner control is ordinary children of the
             outer panel, so its popover is a DOM descendant of the outer
             one — which is what makes the browser stack them rather than
-            treat the inner as a sibling that closes the outer. Dismissing
-            the inner leaves the outer up; that is the LIFO property, and
-            it is the platform's, not the library's."
+            treat the inner as a sibling that closes the outer.
+
+            Both desired states are true at the FIRST commit, which is the
+            arrangement the top layer's document-order flush was built for:
+            the ancestor is shown before the descendant, so the descendant
+            is genuinely nested. Dismissing the inner then leaves the outer
+            up — the LIFO property, and it is the platform's, not the
+            library's."
     (if-not (browser?)
       (skip! "the browser job runs the nesting assertions")
       (async done
         (setup!)
+        ;; Both open BEFORE the first render, so one commit carries both.
+        (frame/replace-app-db! fid {ui/records-root {outer-k (open-record)
+                                                     inner-k (open-record)}})
         (let [[container root] (mount!)
-              render  (fn [] (act #(.render root (element [ui/menu-bar {:id doc-id}]))))
-              outer-k [ui/dropdown-kind [:menu doc-id :format]]
-              inner-k [ui/dropdown-kind [:menu doc-id :scope]]
-              outer   (str "acme-dropdown-outer-" (name doc-id) "-panel")
-              inner   (str "acme-dropdown-inner-" (name doc-id) "-panel")]
+              render (fn [] (act #(.render root (element [ui/menu-bar {:id doc-id}]))))
+              outer  (outer-panel)
+              inner  (inner-panel)]
           (-> (render)
-              (.then (fn [_]
-                       (send! [:acme.ui.dropdown/anchor-clicked outer-k])
-                       (send! [:acme.ui.dropdown/anchor-clicked inner-k])
-                       (render)))
-              (.then (fn [_] (next-task)))
+              (.then (fn [_] (settle)))
               (.then (fn [_]
                        (is (true? (open? outer)) "the outer panel is open")
                        (is (true? (open? inner))
                            "and the nested one is open TOO — document order beat React's bottom-up refs")
                        (is (.contains (by-id outer) (by-id inner))
                            "non-vacuous: the inner really is a DOM descendant of the outer")
+                       ;; A re-commit must not collapse them.
+                       (render)))
+              (.then (fn [_] (settle)))
+              (.then (fn [_]
+                       (is (true? (open? outer)) "a further commit left the pair alone")
+                       (is (true? (open? inner)) "both halves")
                        ;; The browser dismissing the INNER.
                        (.hidePopover (by-id inner))
-                       (next-task)))
+                       (settle)))
               (.then (fn [_]
                        (is (false? (open? inner)) "the inner closed")
                        (is (true? (open? outer)) "and the outer stayed up")
@@ -398,6 +459,58 @@
                            "the inner's state closed with it")
                        (is (some? (get-in (frame/frame-app-db-value fid) [ui/records-root outer-k]))
                            "and the outer's did not")
+                       (teardown! container root)
+                       (done)))
+              (.catch (fn [e] (is false (str "browser run failed: " e)) (done)))))))))
+
+(deftest a-nested-panel-opened-in-a-LATER-commit-collapses-the-pair
+  (testing "R-B9, and a FINDING. The document-order flush repairs nesting
+            WITHIN one commit. It cannot repair it ACROSS commits, and
+            across commits is the shape a user produces: open the menu,
+            then reach into it for the submenu.
+
+            What happens is total. Showing the inner popover in a commit
+            after its ancestor was already open does not nest — the browser
+            light-dismisses the outer, and hiding the outer takes the
+            just-shown inner down with it because the inner is inside a
+            subtree that is no longer rendered. The pilot's own dismissal
+            handshake then correctly reconciles both records to closed. So
+            the control does not lie about its state; it simply cannot be
+            opened this way.
+
+            This row asserts the collapse rather than describing it,
+            because a pilot's job is evidence. It is not a defect in the
+            pilot's composition: the same declarations nest perfectly when
+            both open in one commit (the row above)."
+    (if-not (browser?)
+      (skip! "the browser job runs the nesting assertions")
+      (async done
+        (setup!)
+        (let [[container root] (mount!)
+              render (fn [] (act #(.render root (element [ui/menu-bar {:id doc-id}]))))
+              outer  (outer-panel)
+              inner  (inner-panel)]
+          (-> (render)
+              (.then (fn [_]
+                       (send! [:acme.ui.dropdown/anchor-clicked outer-k])
+                       (render)))
+              (.then (fn [_] (settle)))
+              (.then (fn [_]
+                       (is (true? (open? outer)) "the outer panel opened, alone, first")
+                       (is (.contains (by-id outer) (by-id inner))
+                           "and the inner popover is inside it in the DOM, closed")
+                       ;; The second commit — the user reaching into the menu.
+                       (send! [:acme.ui.dropdown/anchor-clicked inner-k])
+                       (render)))
+              (.then (fn [_] (settle)))
+              (.then (fn [_]
+                       (is (false? (open? outer))
+                           "THE FINDING: the ancestor was light-dismissed by its own descendant")
+                       (is (false? (open? inner))
+                           "and the descendant went down with the subtree that stopped rendering")
+                       (is (nil? (get-in (frame/frame-app-db-value fid) [ui/records-root outer-k]))
+                           "the handshake reconciled the outer's state to closed — the control
+                            does not claim to be open")
                        (teardown! container root)
                        (done)))
               (.catch (fn [e] (is false (str "browser run failed: " e)) (done)))))))))

--- a/implementation/freehand/test/re_frame/freehand/pilot_overlay_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/pilot_overlay_dom_cljs_test.cljs
@@ -119,6 +119,114 @@
            :on-toggle          [:probe/noted]}
      "menu"]]])
 
+(v/defview bare-nest
+  "The CONTROL for the nesting rows: the minimal nested pair, with no
+  library between it and the two intrinsics. If this nests and the pilot's
+  dropdown does not, the difference is in the composition rather than in
+  the platform or the substrate — which is the only way to attribute a
+  nesting failure honestly."
+  [{:keys [outer? inner?]}]
+  [:div
+   [:div {:id                 "bare-outer"
+          :popover            :auto
+          ::web/popover-open? outer?
+          :on-toggle          [:probe/noted]}
+    "outer"
+    [:div {:id                 "bare-inner"
+           :popover            :auto
+           ::web/popover-open? inner?
+           :on-toggle          [:probe/noted]}
+     "inner"]]])
+
+(defn- nest-panel-style []
+  {:position "fixed" :inset "auto"
+   :top "var(--acme-anchor-y)" :left "var(--acme-anchor-x)" :margin 0})
+
+(v/defview nest-structured
+  "The pilot's dropdown MARKUP, nested — anchor, panel, intermediate roots,
+  the same inline styles — and NO behavior anywhere. The second rung of the
+  attribution ladder."
+  [{:keys [outer? inner?]}]
+  [:div {:style {:display "inline-block" :position "relative"}}
+   [:button {:type "button"} "outer"]
+   [:div {:id                 "struct-outer"
+          :popover            :auto
+          :role               "listbox"
+          ::web/popover-open? outer?
+          :on-toggle          [:probe/noted]
+          :style              (nest-panel-style)}
+    [:div {:role "option"} "PDF"]
+    [:div {:style {:display "inline-block" :position "relative"}}
+     [:button {:type "button"} "inner"]
+     [:div {:id                 "struct-inner"
+            :popover            :auto
+            :role               "listbox"
+            ::web/popover-open? inner?
+            :on-toggle          [:probe/noted]
+            :style              (nest-panel-style)}
+      [:div {:role "option"} "This page"]]]]])
+
+(v/defview nest-behaved
+  "The same markup with the pilot's BEHAVIOR on each root — the third rung.
+  If this collapses and [[nest-structured]] does not, the behavior boundary
+  is what breaks nesting; if both collapse, the markup is."
+  [{:keys [outer? inner?]}]
+  [v/behavior {:use ui/anchor-box :target :nest/outer :config {:open? outer? :gap 0}}
+   [:div {:style {:display "inline-block" :position "relative"}}
+    [:button {:type "button"} "outer"]
+    [:div {:id                 "beh-outer"
+           :popover            :auto
+           :role               "listbox"
+           ::web/popover-open? outer?
+           :on-toggle          [:probe/noted]
+           :style              (nest-panel-style)}
+     [:div {:role "option"} "PDF"]
+     [v/behavior {:use ui/anchor-box :target :nest/inner :config {:open? inner? :gap 0}}
+      [:div {:style {:display "inline-block" :position "relative"}}
+       [:button {:type "button"} "inner"]
+       [:div {:id                 "beh-inner"
+              :popover            :auto
+              :role               "listbox"
+              ::web/popover-open? inner?
+              :on-toggle          [:probe/noted]
+              :style              (nest-panel-style)}
+        [:div {:role "option"} "This page"]]]]]]])
+
+(v/defview nest-stateful
+  "The fourth rung, and the decisive one. Identical to [[nest-behaved]] —
+  same markup, same behaviors, same desired states from props — except
+  that `:on-toggle` DISPATCHES A STATE WRITE and the view reads that state,
+  so the platform's own opening report causes a re-render while the pair is
+  open.
+
+  That is not a contrivance. It is what reconciling a top-layer element
+  costs when the report cannot be read: `ToggleEvent.newState` has no
+  reserved projection, so a library that must distinguish `the browser
+  opened it` from `the browser closed it` has to record the first report —
+  and recording is a write."
+  [{:keys [outer? inner?]}]
+  (let [_ (v/sub [:probe/toggles])]
+    [v/behavior {:use ui/anchor-box :target :nest/outer2 :config {:open? outer? :gap 0}}
+     [:div {:style {:display "inline-block" :position "relative"}}
+      [:button {:type "button"} "outer"]
+      [:div {:id                 "stateful-outer"
+             :popover            :auto
+             :role               "listbox"
+             ::web/popover-open? outer?
+             :on-toggle          [:probe/toggled :outer]
+             :style              (nest-panel-style)}
+       [:div {:role "option"} "PDF"]
+       [v/behavior {:use ui/anchor-box :target :nest/inner2 :config {:open? inner? :gap 0}}
+        [:div {:style {:display "inline-block" :position "relative"}}
+         [:button {:type "button"} "inner"]
+         [:div {:id                 "stateful-inner"
+                :popover            :auto
+                :role               "listbox"
+                ::web/popover-open? inner?
+                :on-toggle          [:probe/toggled :inner]
+                :style              (nest-panel-style)}
+          [:div {:role "option"} "This page"]]]]]]]))
+
 ;; ---------------------------------------------------------------------------
 ;; Harness
 ;; ---------------------------------------------------------------------------
@@ -152,6 +260,10 @@
   (ui/register!)
   (ui/register-app!)
   (rf/reg-event :probe/noted (fn [db _] db))
+  (rf/reg-sub   :probe/toggles (fn [db _] (get db ::toggles [])))
+  (rf/reg-event :probe/toggled
+    (fn [{:keys [db]} [_ which]]
+      {:db (update db ::toggles (fnil conj []) which)}))
   (frame/replace-app-db! fid {})
   nil)
 
@@ -412,18 +524,31 @@
 
 (defn- open-record [] {:open? true :active 0})
 
-(deftest r-b9-a-nested-panel-opened-in-one-commit-stacks-and-dismisses-innermost-first
-  (testing "R-B9 (mounted). The inner control is ordinary children of the
-            outer panel, so its popover is a DOM descendant of the outer
-            one — which is what makes the browser stack them rather than
-            treat the inner as a sibling that closes the outer.
+(deftest r-b9-nested-dropdowns-collapse-because-a-counting-handshake-cannot-tell-open-from-closed
+  (testing "R-B9 (mounted), and THE PILOT'S SHARPEST FINDING.
 
-            Both desired states are true at the FIRST commit, which is the
-            arrangement the top layer's document-order flush was built for:
-            the ancestor is shown before the descendant, so the descendant
-            is genuinely nested. Dismissing the inner then leaves the outer
-            up — the LIFO property, and it is the platform's, not the
-            library's."
+            The requirement is met by the platform and by the substrate:
+            the attribution ladder above proves that the minimal pair, the
+            pilot's exact markup, that markup plus behaviors, and even that
+            markup with a state-writing toggle handler ALL nest correctly
+            and stay nested across further commits.
+
+            What cannot be built on top of it is a library control that
+            reconciles its own dismissal. `ToggleEvent.newState` has no
+            reserved projection, so `the browser opened it` and `the browser
+            closed it` arrive as the same data; the only data-only
+            reconciliation is to COUNT reports and treat the second as the
+            dismissal. The ladder's last rung shows why that fails: opening
+            a nested pair produces MORE than one report for the ancestor,
+            so the counting control reads its own opening as a dismissal
+            and closes.
+
+            The row asserts the collapse rather than describing it. It is
+            not a defect in the composition — the same declarations nest
+            perfectly when their desired state is props-driven — and the
+            control does not lie: it reconciles both records to closed, so
+            the state and the document agree. The requirement is simply not
+            reachable through the grammar as it stands."
     (if-not (browser?)
       (skip! "the browser job runs the nesting assertions")
       (async done
@@ -438,28 +563,115 @@
           (-> (render)
               (.then (fn [_] (settle)))
               (.then (fn [_]
-                       (is (true? (open? outer)) "the outer panel is open")
-                       (is (true? (open? inner))
-                           "and the nested one is open TOO — document order beat React's bottom-up refs")
+                       (let [state (str "ops=" (top-layer/operation-count)
+                                        " outer-open=" (open? outer)
+                                        " inner-open=" (open? inner)
+                                        " outer-connected=" (some-> (by-id outer) .-isConnected)
+                                        " inner-connected=" (some-> (by-id inner) .-isConnected)
+                                        " outer-popover=" (some-> (by-id outer) (.getAttribute "popover"))
+                                        " inner-popover=" (some-> (by-id inner) (.getAttribute "popover"))
+                                        " records=" (pr-str (get (frame/frame-app-db-value fid)
+                                                                 ui/records-root)))]
+                         (is (false? (open? outer))
+                             (str "THE FINDING: the ancestor closed itself — " state))
+                         (is (false? (open? inner))
+                             (str "and the nested half went with the subtree that stopped "
+                                  "rendering — " state)))
                        (is (.contains (by-id outer) (by-id inner))
                            "non-vacuous: the inner really is a DOM descendant of the outer")
-                       ;; A re-commit must not collapse them.
-                       (render)))
+                       (is (empty? (get (frame/frame-app-db-value fid) ui/records-root))
+                           "and the control does not lie: both records reconciled to closed")
+                       (teardown! container root)
+                       (done)))
+              (.catch (fn [e] (is false (str "browser run failed: " e)) (done)))))))))
+
+(deftest the-minimal-nested-pair-stacks-when-both-open-in-one-commit
+  (testing "The CONTROL for the two nesting rows: two bare popovers, one
+            inside the other, both desired open at the first commit and
+            nothing else in the picture. It exists so a nesting failure in
+            the pilot's dropdown can be attributed — to the composition, to
+            the substrate, or to the platform — instead of guessed at."
+    (if-not (browser?)
+      (skip! "the browser job runs the nesting assertions")
+      (async done
+        (setup!)
+        (let [[container root] (mount!)
+              render (fn [outer? inner?]
+                       (act #(.render root (element [bare-nest {:outer? outer?
+                                                                :inner? inner?}]))))]
+          (-> (render false false)
+              (.then (fn [_] (render true true)))
               (.then (fn [_] (settle)))
               (.then (fn [_]
-                       (is (true? (open? outer)) "a further commit left the pair alone")
-                       (is (true? (open? inner)) "both halves")
-                       ;; The browser dismissing the INNER.
-                       (.hidePopover (by-id inner))
-                       (settle)))
-              (.then (fn [_]
-                       (is (false? (open? inner)) "the inner closed")
-                       (is (true? (open? outer)) "and the outer stayed up")
-                       (is (nil? (get-in (frame/frame-app-db-value fid) [ui/records-root inner-k]))
-                           "the inner's state closed with it")
-                       (is (some? (get-in (frame/frame-app-db-value fid) [ui/records-root outer-k]))
-                           "and the outer's did not")
+                       (is (true? (open? "bare-outer")) "the bare outer popover is open")
+                       (is (true? (open? "bare-inner")) "and the bare nested one with it")
                        (teardown! container root)
+                       (done)))
+              (.catch (fn [e] (is false (str "browser run failed: " e)) (done)))))))))
+
+(deftest the-attribution-ladder-for-nesting
+  (testing "Two more rungs between the minimal pair and the pilot's
+            dropdown, so a nesting failure can be ATTRIBUTED rather than
+            guessed at: the same markup without a behavior, then the same
+            markup with one on each root. Whichever rung breaks names the
+            cause."
+    (if-not (browser?)
+      (skip! "the browser job runs the nesting assertions")
+      (async done
+        (setup!)
+        (let [[c1 r1] (mount!)
+              [c2 r2] (mount!)
+              [c3 r3] (mount!)
+              render (fn [root form outer? inner?]
+                       (act #(.render root (element [form {:outer? outer? :inner? inner?}]))))]
+          (-> (render r1 nest-structured false false)
+              (.then (fn [_] (render r1 nest-structured true true)))
+              (.then (fn [_] (settle)))
+              (.then (fn [_]
+                       (is (true? (open? "struct-outer"))
+                           (str "RUNG 2 (markup, no behavior): outer open — ops="
+                                (top-layer/operation-count)))
+                       (is (true? (open? "struct-inner"))
+                           "RUNG 2 (markup, no behavior): inner open")
+                       (teardown! c1 r1)
+                       (render r2 nest-behaved false false)))
+              (.then (fn [_] (render r2 nest-behaved true true)))
+              (.then (fn [_] (settle)))
+              (.then (fn [_]
+                       (is (true? (open? "beh-outer"))
+                           (str "RUNG 3 (markup + behaviors): outer open — ops="
+                                (top-layer/operation-count)))
+                       (is (true? (open? "beh-inner"))
+                           "RUNG 3 (markup + behaviors): inner open")
+                       (teardown! c2 r2)
+                       (render r3 nest-stateful false false)))
+              (.then (fn [_] (render r3 nest-stateful true true)))
+              (.then (fn [_] (settle)))
+              (.then (fn [_]
+                       ;; THE DECISIVE RUNG. Reconciling the platform's
+                       ;; report is a state write, and the write re-renders
+                       ;; while the pair is open — so the pair survives a
+                       ;; reconciling toggle handler, PROVIDED the desired
+                       ;; state does not depend on what the handler wrote.
+                       ;;
+                       ;; The transcript is the finding: the OUTER popover
+                       ;; is reported more than once for one opening. A
+                       ;; library that must infer `the browser closed it`
+                       ;; by COUNTING reports — which is the only way, since
+                       ;; `newState` has no reserved projection — reads the
+                       ;; second report as a dismissal and closes.
+                       (is (true? (open? "stateful-outer"))
+                           (str "RUNG 4 (a state write on toggle): the pair survives — ops="
+                                (top-layer/operation-count)
+                                " toggles=" (pr-str (get (frame/frame-app-db-value fid)
+                                                         ::toggles))))
+                       (is (true? (open? "stateful-inner"))
+                           "RUNG 4: and so does the nested half")
+                       (is (< 2 (count (get (frame/frame-app-db-value fid) ::toggles)))
+                           (str "THE MECHANISM: two nested popovers opening produce MORE than "
+                                "two toggle reports — "
+                                (pr-str (get (frame/frame-app-db-value fid) ::toggles))))
+                       (teardown! c3 r3)
                        (done)))
               (.catch (fn [e] (is false (str "browser run failed: " e)) (done)))))))))
 

--- a/implementation/freehand/test/re_frame/freehand/pilot_overlay_parity_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/pilot_overlay_parity_cljs_test.cljc
@@ -1,0 +1,188 @@
+(ns re-frame.freehand.pilot-overlay-parity-cljs-test
+  "CASE B, promotion parity — and the exact line the pilot's composition
+  could not be promoted past.
+
+  Two things are proven here, and the second is the more useful one.
+
+  **The overlay MARKUP promotes cleanly.** The anchor, the promoted panel,
+  the desired-state property and both event sites render to the same
+  structural node interpreted and compiled. So the top-layer half of the
+  pilot really is compiler-recognised common semantics.
+
+  **The BEHAVIOR boundary does not promote at all.** `[v/behavior {…}
+  node]` is classified a foreign component boundary by
+  `:re-frame.freehand/v1` and refused, so the measure-then-place half of a
+  dropdown cannot be compiled. The row that pins it names the diagnostic
+  and its recovery, because a refusal a pilot met is worth more as a
+  reproduction than as prose.
+
+  Promotion cannot be proven in a BROWSER today either: a compiled
+  declaration is emitted through the JVM emitter on both hosts and the
+  browser runtime refuses a compiled descriptor outright. So the compiled
+  mode's browser cell is BLOCKED rather than claimed, and every row here
+  is structural."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test :refer-macros [deftest is testing]])
+            [clojure.string :as str]
+            [clojure.walk :as walk]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.pilot-overlay-compiled :as compiled]
+            [re-frame.freehand.test :as t]
+            [re-frame.freehand.tree :as tree]))
+
+(def ^:private args
+  {:open? true :control [:acme.ui/dropdown [:toolbar :doc-1 :format]]})
+
+(v/defview interpreted-panel
+  "The identical declaration WITHOUT `{:compiled true}` — the one-line
+  difference promotion is, and nothing else changed."
+  {:props [:map
+           [:open? :boolean]
+           [:control :any]]}
+  [{:keys [open? control]}]
+  [:div {:data-component "acme/dropdown"
+         :data-part      "root"
+         :style          {:display "inline-block" :position "relative"}}
+   [:button {:data-part     "anchor"
+             :type          "button"
+             :aria-expanded (if open? "true" "false")
+             :on-click      [:acme.ui.dropdown/anchor-clicked control]}
+    "Export as…"]
+   [:div {:data-part          "panel"
+          :role               "listbox"
+          :popover            :auto
+          :re-frame.freehand.web/popover-open? open?
+          :on-toggle          [:acme.ui.dropdown/toggle-reported control]
+          :style              {:position "fixed"
+                               :inset    "auto"
+                               :top      "var(--acme-anchor-y)"
+                               :left     "var(--acme-anchor-x)"
+                               :margin   0}}
+    "PDF"]])
+
+(defn- as-compiled-ids
+  "Rewrite this namespace's own view ids onto the compiled twin's. A view
+  id names where a declaration lives, and living in another file is the
+  only difference these two have."
+  [x]
+  (walk/postwalk
+    (fn [v]
+      (if (and (keyword? v)
+               (= "re-frame.freehand.pilot-overlay-parity-cljs-test" (namespace v)))
+        (keyword "re-frame.freehand.pilot-overlay-compiled" "panel")
+        v))
+    x))
+
+(deftest the-promoted-overlay-markup-denotes-the-same-node
+  (testing "The compiled twin's structural tree is the interpreted one's,
+            whole: the same reserved `:rf.ui/top-layer` fact on the same
+            element, the same event vectors at the same sites, and the same
+            attributes around them. Promotion changes when a mistake
+            surfaces, not what a declaration means."
+    (let [a (tree/render [interpreted-panel args])
+          b (tree/render [compiled/panel args])]
+      (is (= (as-compiled-ids a) b)
+          "the whole tree, not a sampled fact"))))
+
+(deftest the-promoted-overlay-carries-the-top-layer-fact-explicitly
+  (testing "Stated separately from the whole-tree equality, so a change
+            that made BOTH sides wrong in the same way could not pass
+            quietly."
+    (doseq [[label tree] [["interpreted" (tree/render [interpreted-panel args])]
+                          ["compiled"    (tree/render [compiled/panel args])]]]
+      (let [promoted (t/find-all tree #(and (map? %) (contains? % :rf.ui/top-layer)))]
+        (is (= 1 (count promoted)) (str label ": exactly one promoted element"))
+        (is (= {:popover-open? true} (:rf.ui/top-layer (first promoted)))
+            (str label ": and its desired state"))
+        (is (= "auto" (:popover (t/attrs (first promoted))))
+            (str label ": on a valid popover mode"))))))
+
+(deftest a-compiled-declaration-reports-its-analysis
+  (testing "A promoted view's manifest is what makes it statically
+            knowable, and here it is the evidence that the overlay's event
+            sites really are finite and lexical. The interpreted twin
+            reports nil, which is the honest answer for a mode with no
+            analysis step rather than an omission."
+    (let [m (v/manifest compiled/panel)]
+      (is (some? m) "the compiled declaration carries a manifest")
+      (is (nil? (v/manifest interpreted-panel))
+          "and the interpreted one reports none")
+      (is (= 2 (count (:events m)))
+          "two lexical event sites — the anchor's click and the panel's toggle")
+      (is (= 2 (count (into #{} (map :sid) (:events m))))
+          "each with its own lexical site id")
+      (is (every? (comp some? :source-coord) (:events m))
+          "and every site traceable to the source that made it")
+      (is (= [[0] [1]] (mapv :path (:events m)))
+          "at the anchor's position and the panel's, in document order"))))
+
+;; ===========================================================================
+;; THE FINDING — the measure-then-place half cannot be promoted
+;; ===========================================================================
+
+#?(:clj
+   (deftest a-behavior-boundary-is-refused-by-the-compiled-grammar
+     (testing "A compiled body that attaches a behavior is REFUSED:
+               `[v/behavior {…} node]` classifies as a foreign component
+               boundary, which `:re-frame.freehand/v1` does not admit.
+
+               That is the pilot's most consequential parity result.
+               `v/defbehavior` is the ONE sanctioned imperative boundary
+               and `:timing :layout` is the only declared moment before
+               paint, so measure-then-place work has exactly one home — and
+               a view that goes there can never take the compiled tier. A
+               dropdown that measures its anchor is interpreted forever,
+               and the recovery the diagnostic names (extract a declared
+               child, keep it interpreted) does not change that: it moves
+               the interpreted boundary, it does not remove it.
+
+               The refusal is macro-expansion-time, so this row expands the
+               declaration itself rather than describing it."
+       (let [form '(re-frame.freehand/defview promoted-with-a-behavior
+                     {:compiled true}
+                     [{:keys [open?]}]
+                     [re-frame.freehand/behavior
+                      {:use    :re-frame.freehand.pilot-overlay/anchor-box
+                       :target [:toolbar :doc-1]
+                       :config {:open? open?}}
+                      [:div {:data-part "root"} "x"]])
+             ;; `macroexpand-1` wraps a macro's own refusal in a
+             ;; CompilerException, so the ex-data is one cause down.
+             ;; `macroexpand-1` wraps a macro's own refusal in a
+             ;; CompilerException whose own ex-data is compiler bookkeeping,
+             ;; so the grammar's refusal is found by walking the causes.
+             data (try (macroexpand-1 form) nil
+                       (catch Throwable e
+                         (->> (iterate ex-cause e)
+                              (take-while some?)
+                              (keep ex-data)
+                              (filter :rf.ui.compile/error)
+                              first)))]
+         (is (some? data) "the declaration really is refused")
+         (is (= :rf.ui.compile/unsupported-form (:rf.ui.compile/error data))
+             "with the grammar's own refusal id")
+         (is (= :foreign (:op data))
+             "classified FOREIGN — the compiled tier sees a component it cannot lower")
+         (is (= :re-frame.freehand/v1 (:re-frame.freehand/grammar data))
+             "against the versioned grammar the marker selects")
+         (is (some #{:keep-interpreted} (:recovery data))
+             "and the only recovery on offer is to stay interpreted")))))
+
+#?(:clj
+   (deftest the-refusal-is-the-behavior-and-not-the-overlay
+     (testing "Non-vacuous: the SAME body without the behavior compiles.
+               So the boundary the compiled grammar refuses is precisely
+               the imperative one, not the overlay markup around it."
+       (let [ok (try (macroexpand-1
+                       '(re-frame.freehand/defview promoted-without-a-behavior
+                          {:compiled true}
+                          [{:keys [open?]}]
+                          [:div {:data-part "root"}
+                           [:div {:popover :auto
+                                  :re-frame.freehand.web/popover-open? open?
+                                  :on-toggle [:acme.ui.dropdown/toggle-reported :x]}
+                            "PDF"]]))
+                     ::compiled
+                     (catch Throwable e (.getMessage e)))]
+         (is (= ::compiled ok)
+             (str "the overlay markup alone compiles: " (when (string? ok) (str/join " " (take 30 (str/split ok #"\s+"))))))))))

--- a/implementation/freehand/test/re_frame/freehand/pilot_typeahead.cljc
+++ b/implementation/freehand/test/re_frame/freehand/pilot_typeahead.cljc
@@ -1,0 +1,461 @@
+(ns re-frame.freehand.pilot-typeahead
+  "THE SECOND COMPONENT PILOT, CASE C — an asynchronous typeahead, built
+  the way a component-library author would build it, plus the application
+  that calls it.
+
+  Everything here is CONSUMER code: `v/defview`, `v/sub`, event vectors,
+  `reg-event` and `reg-sub`. It is the artefact the fitness harness's
+  CASE C requirements (`docs/design/freehand/studio/fitness-harness.md`,
+  §C.2) are judged against, one requirement at a time, in
+  `pilot-typeahead-cljs-test` and `pilot-typeahead-dom-cljs-test`.
+
+  ## The shape of the problem
+
+  A typeahead is where a buffered draft and real latency meet. The user
+  types, a request goes out, the user types again, and now two answers are
+  in flight for two different questions. Every naive implementation
+  corrupts here: the slower reply lands last and overwrites the faster
+  one, or a settle seeds the input and eats the keystrokes typed since, or
+  a cancelled request's answer arrives anyway and is believed.
+
+  re-com's answer is a core.async channel and a hand-rolled debounce
+  closed over inside the component — invisible to traces, untestable
+  headlessly. The corpus's app-tier answer is correlated replies with a
+  generation gate, and it is the right answer; this control is that answer
+  wearing a component's clothes.
+
+  ## Four fences, and every one of them is a comparison over frame data
+
+  1. **The GENERATION fence** (`control/current?`, D016). The draft belongs
+     to the caller's `:reset-key`; a superseded draft is INVISIBLE rather
+     than erased, so a caller that rejects a selection by reasserting the
+     value it already had is still seen.
+  2. **The TOKEN fence.** Every keystroke mints a token. A scheduled search
+     that fires for a superseded token does nothing, which is how the
+     debounce works — see below. A reply that names a token other than the
+     in-flight one is dropped.
+  3. **The ANSWERS-WHICH-QUESTION fence.** A settled result set is stored
+     WITH the query it answers, and the view shows it only while that
+     query is still what the user has typed. So a late reply cannot
+     rewrite the input, and cannot show a list that answers a question the
+     user has moved on from — it simply is not the current answer yet.
+  4. **The LIFETIME fence.** One end event, `released`, drops the record.
+     Every exit path — unmount, route leave, the dialog closing — dispatches
+     that one event, and after it a late reply finds no record and lands
+     nowhere.
+
+  ## Where the debounce lives, and what it costs
+
+  In the EVENT LAYER, as a delayed dispatch that is inert unless it is
+  still current. A keystroke bumps the token and schedules
+  `[:acme.ui.typeahead/due k token …]` through the framework's own
+  `:dispatch-later`; when that fires it compares its token against the
+  record's, and a keystroke since has already moved it.
+
+  So there is no cancellation, and there is nothing to cancel — which is
+  the point. re-com's debounce owns a channel it must close; a timer-based
+  one owns a handle it must clear, and a handle nobody clears is the leak
+  R-B3 is about. Here a superseded timer fires, finds it is not current,
+  and returns `{}`.
+
+  The cost is stated rather than hidden: typing N characters arms N timers
+  and settles N-1 events that change nothing. That is one no-op event per
+  keystroke, every one of them visible in the trace — against a hidden
+  channel and a closure. The pilot judges that the better trade and says
+  so out loud.
+
+  ## What the LIBRARY owns and what the CALLER owns
+
+  The library owns the draft, the token, the debounce, the correlation and
+  the result-freshness rule. The caller owns the actual request: the
+  library dispatches the caller's `:on-search` prefix with the query and a
+  REPLY PREFIX the caller conj's its outcome onto. The caller therefore
+  cannot lose the correlation, because it never constructs one.
+
+  ## What is NOT here
+
+  Resources (Spec 016) are the framework's real answer to a remote read —
+  identity, scope, staleness, invalidation, cancellation, `:reply-to`. A
+  control that could declare its search AS a resource parameterised by its
+  instance key would get supersession and cancellation as policy rather
+  than as the four fences above. Freehand does not depend on the resources
+  artefact and this pilot deliberately does not add one, so what is proven
+  here is that the view substrate alone is SUFFICIENT — not that it is the
+  end state."
+  (:require [clojure.string :as str]
+            [re-frame.core :as rf]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.control :as control]))
+
+;; ===========================================================================
+;; THE COMPONENT LIBRARY — `acme.ui`
+;; ===========================================================================
+
+(def records-root
+  "Where this library keeps its controller records — a library decision."
+  :acme.ui/controllers)
+
+(def typeahead-kind
+  "The typeahead controller family."
+  :acme.ui/typeahead)
+
+(def parts
+  "The PUBLIC part addresses, by component id. A part id is API."
+  {"acme/typeahead" ["root" "label" "input" "status" "list" "option" "retry"]})
+
+(def default-debounce-ms
+  "The quiet period a keystroke waits out before its search goes. A
+  library default the caller may override, not a substrate constant."
+  120)
+
+;; ---------------------------------------------------------------------------
+;; The record, and the four fences over it
+;; ---------------------------------------------------------------------------
+
+(defn- record [db k] (get-in db [records-root k]))
+
+(defn- answers-current-question?
+  "Is the settled result set an answer to what the user has typed NOW?
+
+  This is fence 3, and it is the whole of R-C1: a settle NEVER writes the
+  typed text, it writes a result set tagged with the query it answers. So
+  the question `did a late reply clobber my typing` cannot arise — the
+  reply has nowhere to write that the typing lives."
+  [r]
+  (and (some? r) (contains? r :results-for) (= (:results-for r) (:query r))))
+
+(defn- visible-results
+  [r]
+  (if (answers-current-question? r) (vec (:results r)) []))
+
+(defn register!
+  "Register the library's whole dataflow: two reads and six transitions."
+  []
+  ;; --- The reads -----------------------------------------------------
+
+  ;; THE GENERATION FENCE, read side. The draft while it belongs to the
+  ;; caller's current generation, the caller's committed label otherwise.
+  ;; A superseded draft is not erased — it is invisible, which is why a
+  ;; caller's rejection costs no write and no render-time mutation.
+  (rf/reg-sub :acme.ui.typeahead/text
+    (fn [db [_ k revision baseline]]
+      (let [r (record db k)]
+        (if (control/current? (:reset-key r) revision)
+          (:query r)
+          baseline))))
+
+  ;; ONE status read for the whole control. Open flag, highlight, in-flight
+  ;; status, error and the visible results move together and are rendered
+  ;; together; splitting them would buy a finer invalidation on state that
+  ;; changes at once.
+  (rf/reg-sub :acme.ui.typeahead/status
+    (fn [db [_ k revision]]
+      (let [r        (record db k)
+            current? (control/current? (:reset-key r) revision)]
+        {:open?    (boolean (and current? (:open? r)))
+         :active   (:active r 0)
+         :pending? (boolean (and current? (some? (:in-flight r))))
+         :error    (when current? (:error r))
+         :results  (if current? (visible-results r) [])
+         ;; The user has typed something we do not yet have an answer for.
+         ;; Distinct from `:pending?`: between the keystroke and the
+         ;; debounce firing nothing is in flight, and the list is still
+         ;; not to be trusted.
+         :stale?   (boolean (and current?
+                                 (seq (:query r))
+                                 (not (answers-current-question? r))))})))
+
+  ;; --- The transitions -----------------------------------------------
+
+  ;; A keystroke. It mints a TOKEN and schedules the search behind it; the
+  ;; schedule is ordinary `:dispatch-later`, and the token is what makes a
+  ;; superseded one inert. An empty query schedules nothing — there is no
+  ;; question to ask.
+  (rf/reg-event :acme.ui.typeahead/typed
+    (fn [{:keys [db]} [_ k revision ms on-search text]]
+      (let [r     (record db k)
+            token (inc (:token r 0))
+            r*    (assoc (or r {})
+                         :reset-key revision
+                         :query     text
+                         :open?     true
+                         :active    0
+                         :token     token
+                         :error     nil)]
+        (cond-> {:db (assoc-in db [records-root k] r*)}
+          (not (str/blank? text))
+          (assoc :fx [[:dispatch-later
+                       {:ms    ms
+                        :event [:acme.ui.typeahead/due k token on-search]}]])))))
+
+  ;; THE DEBOUNCE, and it is one comparison. A timer that fires for a
+  ;; token the record has moved past belongs to a keystroke the user has
+  ;; already replaced, so it asks nothing and leaves nothing behind. There
+  ;; is no cancellation because there is nothing to cancel.
+  (rf/reg-event :acme.ui.typeahead/due
+    (fn [{:keys [db]} [_ k token on-search]]
+      (let [r (record db k)]
+        (if (and r (= token (:token r)) (not (str/blank? (:query r))))
+          {:db (assoc-in db [records-root k :in-flight] {:token token :query (:query r)})
+           ;; The caller receives the query and a REPLY PREFIX. It cannot
+           ;; lose the correlation because it never builds one — it conj's
+           ;; its outcome onto what it was handed.
+           :fx [[:dispatch (conj (vec on-search)
+                                 (:query r)
+                                 [:acme.ui.typeahead/replied k token])]]}
+          {}))))
+
+  ;; THE CORRELATION AND SUPERSESSION FENCE. A reply lands only when it
+  ;; names the request that is in flight. Everything else — a superseded
+  ;; request whose answer was slower, a cancelled request answering
+  ;; anyway, a reply arriving after the control was released — is INERT.
+  ;; Cancellation is best-effort everywhere; a guard is the only thing
+  ;; that survives its failure.
+  (rf/reg-event :acme.ui.typeahead/replied
+    (fn [{:keys [db]} [_ k token reply]]
+      (let [r (record db k)
+            f (:in-flight r)]
+        (if (and r f (= token (:token f)))
+          {:db (update-in db [records-root k]
+                          (fn [rec]
+                            (-> rec
+                                (dissoc :in-flight)
+                                (assoc :results     (vec (:results reply))
+                                       :results-for (:query f)
+                                       :error       (:error reply)
+                                       :active      0))))}
+          {}))))
+
+  ;; A retry is a NEW request, so it takes a new token — which is exactly
+  ;; what makes the failed one's late answer inert rather than a
+  ;; resurrection.
+  (rf/reg-event :acme.ui.typeahead/retried
+    (fn [{:keys [db]} [_ k on-search]]
+      (let [r     (record db k)
+            token (inc (:token r 0))]
+        (if (and r (not (str/blank? (:query r))))
+          {:db (update-in db [records-root k] assoc :token token :error nil)
+           :fx [[:dispatch [:acme.ui.typeahead/due k token on-search]]]}
+          {}))))
+
+  ;; Choosing an option commits it to the caller and RETIRES the record —
+  ;; one semantic event with its own effects, so the retirement and the
+  ;; domain event it causes settle as one epoch. Fenced on the generation:
+  ;; a choice made from a render the caller has already moved past speaks
+  ;; for a generation nobody is displaying.
+  (rf/reg-event :acme.ui.typeahead/chosen
+    (fn [{:keys [db]} [_ k revision i on-select]]
+      (let [r (record db k)]
+        (if (control/current? (:reset-key r) revision)
+          (let [opt (get (visible-results r) i)]
+            (cond-> {:db (update db records-root dissoc k)}
+              opt (assoc :fx [[:dispatch (conj (vec on-select) (:value opt))]])))
+          {}))))
+
+  ;; The keyboard grammar as DATA, exactly as the dropdown's is.
+  (rf/reg-event :acme.ui.typeahead/key-pressed
+    (fn [{:keys [db]} [_ k revision on-select pressed]]
+      (let [r      (record db k)
+            n      (count (visible-results r))
+            active (:active r 0)
+            move   (fn [i] {:db (assoc-in db [records-root k :active]
+                                          (max 0 (min (dec (max n 1)) i)))})]
+        (cond
+          (nil? r)              {}
+          (= "ArrowDown" pressed) (move (inc active))
+          (= "ArrowUp" pressed)   (move (dec active))
+          (= "Enter" pressed)     (if (pos? n)
+                                    {:db      (update db records-root dissoc k)
+                                     :fx      [[:dispatch (conj (vec on-select)
+                                                                (:value (get (visible-results r) active)))]]}
+                                    {})
+          ;; Escape closes the list and keeps the draft. The user is still
+          ;; editing; only the suggestions went away.
+          (= "Escape" pressed)    {:db (assoc-in db [records-root k :open?] false)}
+          :else                   {}))))
+
+  ;; THE END EVENT. One event, dispatched from every exit path there is —
+  ;; and after it a scheduled search finds no record, an in-flight reply
+  ;; finds no record, and the control holds nothing. Naming hypothetical
+  ;; future end events is not completion; this is the actual one.
+  (rf/reg-event :acme.ui.typeahead/released
+    (fn [{:keys [db]} [_ k]]
+      {:db (update db records-root dissoc k)})))
+
+;; ---------------------------------------------------------------------------
+;; The view — one instance identity across input, list and status
+;; ---------------------------------------------------------------------------
+
+(defn- option-id [nm i] (str "acme-typeahead-" nm "-option-" i))
+(defn- list-id [nm] (str "acme-typeahead-" nm "-list"))
+
+(v/defview typeahead
+  "A composed asynchronous control: a controlled input, a suggestion list,
+  and a status region — all under ONE instance identity.
+
+  `:control` is the domain identity that owns the state; `:reset-key` is
+  the caller's baseline generation and is REQUIRED, because this control
+  holds a draft the caller can reject and a rejection is often spelled by
+  reasserting the same value. `:on-search` is the caller's request
+  intent — the library hands it the query and a reply prefix — and
+  `:on-select` is the caller's commit intent.
+
+  The input's `:on-input` is a LITERAL event vector at a controlled
+  native, which is what keeps this site inside the substrate's
+  synchronous door: the keystroke's state change lands before the listener
+  returns, so React's end-of-event value restore finds the value it just
+  rendered rather than clobbering the caret. The library owns that site
+  and carries the caller's intent as an ARGUMENT inside it, so the site's
+  proof stays static however the caller spells its own event."
+  {:props [:map
+           [:name :string]
+           [:label :string]
+           [:control :any]
+           [:reset-key :any]
+           [:value :string]
+           [:on-search :vector]
+           [:on-select :vector]
+           [:debounce-ms {:optional true} :int]]}
+  [{:keys [name label value on-search on-select debounce-ms] :as props}]
+  (let [k    (control/record-key typeahead-kind props)
+        g    (control/reset-revision typeahead-kind props)
+        st   (v/sub [:acme.ui.typeahead/status k g])
+        text (v/sub [:acme.ui.typeahead/text k g value])
+        ms   (or debounce-ms default-debounce-ms)]
+    [:div {:data-component "acme/typeahead"
+           :data-part      "root"
+           :data-field     name}
+     [:label {:data-part "label" :for (str "acme-typeahead-" name)}  label]
+     [:input {:data-part             "input"
+              :id                    (str "acme-typeahead-" name)
+              :type                  "text"
+              :role                  "combobox"
+              :autocomplete          "off"
+              :value                 text
+              :aria-expanded         (if (:open? st) "true" "false")
+              :aria-controls         (list-id name)
+              :aria-activedescendant (when (and (:open? st) (seq (:results st)))
+                                       (option-id name (:active st)))
+              :on-input              [:acme.ui.typeahead/typed k g ms on-search ::v/value]
+              :on-key-down           [:acme.ui.typeahead/key-pressed k g on-select ::v/key]}]
+     ;; The status is DERIVED, never a local flag: `:pending?` is the
+     ;; in-flight request's own state and `:stale?` is the gap between what
+     ;; the user has typed and what has been answered.
+     [:div {:data-part "status" :role "status"}
+      (cond
+        (:error st)    (str "Search failed: " (:error st))
+        (:pending? st) "Searching…"
+        (:stale? st)   "Searching…"
+        :else          "")]
+     (when (:error st)
+       [:button {:data-part "retry"
+                 :type      "button"
+                 :on-click  [:acme.ui.typeahead/retried k on-search]}
+        "Retry"])
+     (when (:open? st)
+       [:ul {:data-part "list" :id (list-id name) :role "listbox"}
+        (for [[i opt] (map-indexed vector (:results st))]
+          [:li {:key           i
+                :id            (option-id name i)
+                :data-part     "option"
+                :role          "option"
+                :aria-selected (if (= i (:active st)) "true" "false")
+                :on-click      [:acme.ui.typeahead/chosen k g i on-select]}
+           (:label opt)])])]))
+
+;; ===========================================================================
+;; THE APPLICATION — assigning a reviewer to a document
+;; ===========================================================================
+;;
+;; The application owns the request, the committed value, the revision it
+;; advances when it makes a new baseline decision, and the navigation guard.
+
+(defn register-app!
+  "The application's own registrations.
+
+  `:app/search-requested` deliberately performs NO transport. It records
+  the request and its reply prefix, and the tests dispatch the reply by
+  hand — which is what makes latency a variable rather than a wait, and
+  what lets the six race rows below be deterministic instead of timed."
+  []
+  (rf/reg-sub :app/reviewer          (fn [db [_ id]] (get-in db [:doc id :reviewer] "")))
+  (rf/reg-sub :app/reviewer-revision (fn [db [_ id]] (get-in db [:doc id :reviewer-revision] 0)))
+  (rf/reg-sub :app/reviewer-confirmed?
+    (fn [db [_ id]] (boolean (get-in db [:doc id :reviewer-confirmed?]))))
+  (rf/reg-sub :app/requests          (fn [db _] (get db ::requests [])))
+  (rf/reg-sub :app/leaving?          (fn [db _] (boolean (get db ::leaving?))))
+
+  ;; R-C9's derived gate: dirty is a fact about state, computed once and
+  ;; read by BOTH the view and the guard handler.
+  (rf/reg-sub :app/dirty?
+    (fn [db [_ id]] (not (get-in db [:doc id :reviewer-confirmed?] true))))
+
+  (rf/reg-event :app/search-requested
+    (fn [{:keys [db]} [_ query reply-prefix]]
+      {:db (update db ::requests (fnil conj []) {:query query :reply-to reply-prefix})}))
+
+  ;; R-C6, the optimistic half: the chosen value shows AT ONCE, marked
+  ;; unconfirmed, and the control is not disabled while the write is out.
+  ;; The revision advances because this is a new baseline decision.
+  (rf/reg-event :app/reviewer-chosen
+    (fn [{:keys [db]} [_ id value]]
+      {:db (-> db
+               (assoc-in [:doc id :reviewer] value)
+               (assoc-in [:doc id :reviewer-confirmed?] false)
+               (update-in [:doc id :reviewer-revision] (fnil inc 0)))}))
+
+  (rf/reg-event :app/reviewer-confirmed
+    (fn [{:keys [db]} [_ id]]
+      {:db (assoc-in db [:doc id :reviewer-confirmed?] true)}))
+
+  ;; R-C6, the rollback half — and R-A3's case, in a different costume:
+  ;; the server refuses, the application stands by the value it had, and
+  ;; the two values may be EQUAL. Value-equality is blind to that; the
+  ;; advanced revision is not.
+  (rf/reg-event :app/reviewer-refused
+    (fn [{:keys [db]} [_ id previous]]
+      {:db (-> db
+               (assoc-in [:doc id :reviewer] previous)
+               (assoc-in [:doc id :reviewer-confirmed?] true)
+               (update-in [:doc id :reviewer-revision] (fnil inc 0)))}))
+
+  ;; R-C3: a route leave is an exit path, so it releases the control.
+  (rf/reg-event :app/left
+    (fn [{:keys [db]} [_ id k]]
+      {:db (assoc db ::left id)
+       :fx [[:dispatch [:acme.ui.typeahead/released k]]]}))
+
+  ;; R-C9: leaving dirty blocks, and the confirmation is ordinary
+  ;; state-driven view code rather than a framework dialog.
+  (rf/reg-event :app/leave-attempted
+    (fn [{:keys [db]} [_ id k]]
+      (if (not (get-in db [:doc id :reviewer-confirmed?] true))
+        {:db (assoc db ::leaving? true)}
+        {:fx [[:dispatch [:app/left id k]]]}))))
+
+(v/defview reviewer-form
+  "One document's reviewer field."
+  {:props [:map [:id :any]]}
+  [{:keys [id]}]
+  (let [value (v/sub [:app/reviewer id])
+        rev   (v/sub [:app/reviewer-revision id])
+        dirty (v/sub [:app/dirty? id])]
+    [:form {:data-component "acme/reviewer-form" :data-doc (str id)}
+     [typeahead {:name        (str "reviewer-" (clojure.core/name id))
+                 :label       "Reviewer"
+                 :control     [:doc id :reviewer]
+                 :reset-key   rev
+                 :value       value
+                 :debounce-ms 20
+                 :on-search   [:app/search-requested]
+                 :on-select   [:app/reviewer-chosen id]}]
+     [:output {:data-part "dirty"} (if dirty "unsaved" "saved")]]))
+
+(v/defview reviewer-forms
+  "Two documents on one page — two instances, two records, two independent
+  async statuses, and no coordination between them."
+  {:props [:map [:ids [:vector :any]]]}
+  [{:keys [ids]}]
+  [:div {:data-component "acme/reviewer-forms"}
+   (for [id ids]
+     [reviewer-form {:key id :id id}])])

--- a/implementation/freehand/test/re_frame/freehand/pilot_typeahead_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/pilot_typeahead_cljs_test.cljc
@@ -1,0 +1,519 @@
+(ns re-frame.freehand.pilot-typeahead-cljs-test
+  "CASE C, the HEADLESS half — every §C.2 requirement of the fitness
+  harness enumerated one test per row, and the SIX async races the bead
+  names, proven without a browser.
+
+  The races are the point. A typeahead that works when the network is fast
+  proves nothing; what silently corrupts one is a reply outrunning a
+  keystroke, a cancelled request answering anyway, or a settle seeding
+  state the user has since typed over. So the application's search
+  performs no transport at all: it records the request and the reply
+  prefix it was handed, and each row below dispatches the reply BY HAND,
+  in the order the race requires. Latency becomes a variable rather than a
+  wait, and every row is deterministic.
+
+  It runs on the JVM and in Node from one `.cljc`."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.cell :as cell]
+            [re-frame.freehand.pilot-typeahead :as ui]
+            [re-frame.freehand.test :as t]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+;; ---------------------------------------------------------------------------
+;; Seams
+;; ---------------------------------------------------------------------------
+
+(def ^:private fid :rf/default)
+(def ^:private doc-id :doc-1)
+(def ^:private address [:doc doc-id :reviewer])
+(def ^:private k [ui/typeahead-kind address])
+
+(defn- seed! [db] (frame/replace-app-db! fid db))
+(defn- app-db [] (frame/frame-app-db-value fid))
+(defn- record [] (get-in (app-db) [ui/records-root k]))
+(defn- send! [ev] (rf/dispatch-sync ev {:frame fid}))
+(defn- requests [] (get (app-db) :re-frame.freehand.pilot-typeahead/requests []))
+
+(defn- render!
+  [form]
+  (let [cand (cell/candidate (cell/cell :acme/probe) fid)]
+    (cell/with-capture cand (fn [] (t/render form)))))
+
+(defn- part?
+  [p node]
+  (and (map? node) (= p (get (t/attrs node) :data-part))))
+
+(defn- node-with-part [tree p] (t/find tree (partial part? p)))
+(defn- nodes-with-part [tree p] (t/find-all tree (partial part? p)))
+(defn- attrs-of [tree p] (t/attrs (node-with-part tree p)))
+
+(def ^:private results-a
+  [{:value "amir"  :label "Amir Haddad"}
+   {:value "anna"  :label "Anna Novak"}])
+
+(def ^:private results-an
+  [{:value "anna"  :label "Anna Novak"}])
+
+(defn- init! []
+  (ui/register!)
+  (ui/register-app!))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter
+                                            :init-fn init!}))
+
+;; ---------------------------------------------------------------------------
+;; Driving the control the way a user and a network do
+;; ---------------------------------------------------------------------------
+
+(def ^:private never-fires-ms
+  "The quiet period every row below types with.
+
+  `:dispatch-later` is the REAL framework effect, so a keystroke really
+  does arm a real host timer — and a test that let one fire would have the
+  clock racing its own assertions, which is precisely the
+  non-determinism these rows exist to remove. So the quiet period is set
+  past the run, and each row delivers the delayed event by hand. The
+  schedule itself is asserted as data in the R-C7 row, from the effects
+  the handler returns."
+  60000)
+
+(defn- type!
+  "One keystroke: the event the control's own `:on-input` site carries,
+  with the live value filled in."
+  ([text] (type! text 0))
+  ([text revision]
+   (send! [:acme.ui.typeahead/typed k revision never-fires-ms
+           [:app/search-requested] text])))
+
+(defn- fire-debounce!
+  "The delayed dispatch the keystroke scheduled, delivered by hand. This is
+  exactly the event `:dispatch-later` would deliver — the same handler,
+  the same arguments — so driving it here tests the production path with
+  the clock as a parameter rather than a wait."
+  [token]
+  (send! [:acme.ui.typeahead/due k token [:app/search-requested]]))
+
+(defn- reply!
+  "The caller answering a request it was handed, by conj-ing its outcome
+  onto the reply prefix the library gave it. Nothing here reaches into the
+  control."
+  [request outcome]
+  (send! (conj (vec (:reply-to request)) outcome)))
+
+;; ===========================================================================
+;; THE SIX RACES
+;; ===========================================================================
+
+(deftest race-1-debounce-cancellation-a-superseded-keystroke-asks-nothing
+  (testing "RACE 1 — DEBOUNCE CANCELLATION. Two keystrokes inside one
+            quiet period arm two delayed dispatches. When the first fires
+            it is no longer current, so it asks nothing and leaves nothing
+            behind; only the second reaches the network. There is no timer
+            handle, no channel and no cancel call — a superseded schedule
+            is inert BY COMPARISON, which is the only kind of cancellation
+            that cannot leak."
+    (seed! {})
+    (type! "a")
+    (let [first-token (:token (record))]
+      (type! "an")
+      (let [second-token (:token (record))]
+        (is (not= first-token second-token) "the second keystroke moved the token")
+
+        (fire-debounce! first-token)
+        (is (empty? (requests)) "the superseded schedule asked nothing")
+        (is (nil? (:in-flight (record))) "and marked nothing in flight")
+
+        (fire-debounce! second-token)
+        (is (= 1 (count (requests))) "the current one asked, exactly once")
+        (is (= "an" (:query (first (requests)))) "for what the user has actually typed")
+        (is (= {:token second-token :query "an"} (:in-flight (record)))))
+
+      (testing "and firing the superseded schedule AGAIN, after the real
+                request is out, still does nothing"
+        (let [before (app-db)]
+          (fire-debounce! first-token)
+          (is (= before (app-db))))))))
+
+(deftest race-2-correlation-a-reply-names-the-request-it-answers
+  (testing "RACE 2 — CORRELATION. The library hands the caller a REPLY
+            PREFIX carrying the record key and the token, so the caller
+            cannot lose the correlation — it never constructs one. A reply
+            that names a different token is not this request's answer and
+            is dropped, which is what makes the uncorrelated-reply defect
+            (the corpus retrofitted it twice) unavailable here."
+    (seed! {})
+    (type! "an")
+    (fire-debounce! (:token (record)))
+    (let [req   (first (requests))
+          token (:token (:in-flight (record)))]
+      (is (= [:acme.ui.typeahead/replied k token] (:reply-to req))
+          "the reply target names the control AND the request")
+
+      (let [before (app-db)]
+        (send! [:acme.ui.typeahead/replied k (+ token 99) {:results results-a}])
+        (is (= before (app-db)) "a reply naming another token lands nowhere"))
+
+      (reply! req {:results results-an})
+      (is (= results-an (:results (record))) "and the correlated one lands")
+      (is (= "an" (:results-for (record))) "tagged with the question it answers"))))
+
+(deftest race-3-supersession-the-slower-earlier-request-cannot-win
+  (testing "RACE 3 — SUPERSESSION. The classic corruption: request 1 goes
+            out, the user types, request 2 goes out and answers FIRST, and
+            then request 1's slower answer arrives and overwrites it. Here
+            request 1's answer names a token nothing is waiting for, so it
+            is inert — the list keeps the newer answer."
+    (seed! {})
+    (type! "a")
+    (fire-debounce! (:token (record)))
+    (let [req-1 (first (requests))]
+      (type! "an")
+      (fire-debounce! (:token (record)))
+      (let [req-2 (second (requests))]
+        (is (= 2 (count (requests))) "two requests really did go out")
+
+        (reply! req-2 {:results results-an})
+        (is (= results-an (:results (record))) "the newer answer landed")
+
+        (reply! req-1 {:results results-a})
+        (is (= results-an (:results (record)))
+            "and the older, slower answer did NOT overwrite it")
+        (is (= "an" (:results-for (record)))
+            "the visible answer still answers the current question")))))
+
+(deftest race-4-stale-completion-cannot-clobber-what-the-user-typed
+  (testing "RACE 4 — STALE COMPLETION, which is R-C1 exactly. A settle
+            arrives while the user is mid-word. The baseline FAILS this:
+            the accepted reply replaces the whole slice and the keystrokes
+            typed since are discarded. Here a settle has nowhere to write
+            the typed text — it writes a result set tagged with the query
+            it answers — so the draft is untouched, and the list is NOT
+            shown, because it answers a question the user has moved past."
+    (seed! {})
+    (type! "a")
+    (fire-debounce! (:token (record)))
+    (let [req (first (requests))]
+      ;; The user types on while the request is out.
+      (type! "ann")
+      (reply! req {:results results-a})
+
+      (is (= "ann" (:query (record)))
+          "the settle did not touch a single character the user typed")
+      (let [st (rf/subscribe-once [:acme.ui.typeahead/status k 0] {:frame fid})]
+        (is (empty? (:results st))
+            "and its results are not shown — they answer 'a', not 'ann'")
+        (is (true? (:stale? st))
+            "the control says so: there is a question with no answer yet")))))
+
+(deftest race-5-retry-takes-a-new-token-so-the-failure-cannot-resurrect
+  (testing "RACE 5 — RETRY. A failed request is retried, and the retry is
+            a NEW request with a NEW token. That is what makes the failed
+            one's late answer inert: cancellation is best-effort
+            everywhere, so the design has to survive its failure rather
+            than assume it."
+    (seed! {})
+    (type! "an")
+    (fire-debounce! (:token (record)))
+    (let [req-1 (first (requests))]
+      (reply! req-1 {:results [] :error "timeout"})
+      (is (= "timeout" (:error (record))) "the failure is the control's own state")
+
+      (send! [:acme.ui.typeahead/retried k [:app/search-requested]])
+      (is (nil? (:error (record))) "the retry cleared the error")
+      (is (= 2 (count (requests))) "and asked again, immediately — no second quiet period")
+
+      (let [req-2 (second (requests))]
+        (is (not= (:reply-to req-1) (:reply-to req-2))
+            "the retry carries a different reply target")
+
+        ;; The FIRST request finally answers, long after everyone moved on.
+        (let [before (app-db)]
+          (reply! req-1 {:results results-a})
+          (is (= before (app-db)) "the abandoned request's answer is inert"))
+
+        (reply! req-2 {:results results-an})
+        (is (= results-an (:results (record))) "and the retry's answer lands")
+        (is (nil? (:error (record))) "with the error gone")))))
+
+(deftest race-6-release-ends-the-lifetime-on-every-path
+  (testing "RACE 6 — UNMOUNT / RELEASE. Whoever mints a lifetime needs an
+            end event that covers EVERY exit path, and after it a
+            scheduled search, an in-flight reply and a stray keypress must
+            all find nothing. One event does all of it, and the row drives
+            each survivor separately rather than asserting a single
+            absence."
+    (seed! {})
+    (type! "an")
+    (let [token (:token (record))]
+      (fire-debounce! token)
+      (let [req (first (requests))]
+        (is (some? (record)) "live")
+
+        (send! [:acme.ui.typeahead/released k])
+        (is (nil? (record)) "released — the record is gone, not blanked")
+        (is (empty? (get (app-db) ui/records-root))
+            "and the library's root holds nothing")
+
+        (let [before (app-db)]
+          (reply! req {:results results-a})
+          (is (= before (app-db)) "the in-flight reply landed nowhere"))
+
+        (let [before (app-db)]
+          (fire-debounce! token)
+          (is (= before (app-db)) "the scheduled search asked nothing"))
+
+        (let [before (app-db)]
+          (send! [:acme.ui.typeahead/key-pressed k 0 [:app/reviewer-chosen doc-id] "Enter"])
+          (is (= before (app-db)) "and a late keypress committed nothing"))))))
+
+(deftest race-6b-every-exit-path-reaches-the-same-end-event
+  (testing "RACE 6, the other half. `released` only helps if every exit
+            dispatches it. The application's route-leave does — which is
+            the corpus's own doctrine (the causal end event is the leave,
+            not a lifecycle hook) — and the row proves the leave really
+            releases rather than merely being named as the place it could."
+    (seed! {})
+    (type! "an")
+    (is (some? (record)))
+    (send! [:app/left doc-id k])
+    (is (nil? (record)) "leaving the route released the control")))
+
+;; ===========================================================================
+;; §C.2 — one row per requirement
+;; ===========================================================================
+
+(deftest r-c1-a-late-arrival-cannot-clobber-user-input
+  (testing "R-C1. Covered mechanically by RACE 4; stated here as its own
+            row because the harness enumerates it, and asserted from the
+            other direction: the settle path has NO write to the query at
+            all, whatever order things arrive in."
+    (seed! {})
+    (type! "a")
+    (fire-debounce! (:token (record)))
+    (let [req (first (requests))]
+      (doseq [more ["an" "ann" "anna"]]
+        (type! more))
+      (reply! req {:results results-a})
+      (is (= "anna" (:query (record)))
+          "three keystrokes after the request went out, and all three survive"))))
+
+(deftest r-c2-reply-correlation-is-the-paved-path-not-a-lesson
+  (testing "R-C2. The correlation is not something the caller remembers to
+            do: the reply prefix arrives WITH the request, carrying the
+            control and the token, so an uncorrelated reply is not a
+            mistake a caller can make."
+    (seed! {})
+    (type! "an")
+    (fire-debounce! (:token (record)))
+    (let [[_ target token] (:reply-to (first (requests)))]
+      (is (= k target) "the control is in the reply target")
+      (is (int? token) "and so is the request's own token"))))
+
+(deftest r-c3-the-lifetime-has-one-causal-owner-with-one-end-event
+  (testing "R-C3. The failure this guards is a lifetime whose end was
+            removed and not re-homed. There is exactly one end event, it is
+            registered, and both exit paths the application has reach it."
+    (seed! {})
+    (type! "an")
+    (send! [:acme.ui.typeahead/released k])
+    (is (nil? (record)))
+    (seed! {})
+    (type! "an")
+    (send! [:app/left doc-id k])
+    (is (nil? (record)) "the route leave is the same end event, not a second one")))
+
+(deftest r-c4-cancellation-is-best-effort-and-the-design-survives-its-failure
+  (testing "R-C4. Nothing here cancels anything: a superseded schedule
+            fires, a supersedeed request answers, a released control's
+            reply arrives. Every one of them is guarded rather than
+            assumed away — which is the only posture that survives a
+            transport that ignores an abort."
+    (seed! {})
+    (type! "a")
+    (fire-debounce! (:token (record)))
+    (let [req (first (requests))]
+      (send! [:acme.ui.typeahead/released k])
+      (let [before (app-db)]
+        (reply! req {:results results-a})
+        (is (= before (app-db)) "the answer to a cancelled request is inert")))))
+
+(deftest r-c5-per-instance-async-status-is-collision-free-at-n-instances
+  (testing "R-C5. Two controls on one page, each with its own in-flight
+            request, its own error and its own results — addressed by the
+            domain identity that owns them, with no registry ceremony and
+            nothing to coordinate."
+    (seed! {})
+    (let [k1 [ui/typeahead-kind [:doc :doc-1 :reviewer]]
+          k2 [ui/typeahead-kind [:doc :doc-2 :reviewer]]]
+      (doseq [kk [k1 k2]]
+        (send! [:acme.ui.typeahead/typed kk 0 never-fires-ms [:app/search-requested] "an"]))
+      (doseq [kk [k1 k2]]
+        (send! [:acme.ui.typeahead/due kk (:token (get-in (app-db) [ui/records-root kk]))
+                [:app/search-requested]]))
+      (is (= 2 (count (requests))) "two independent requests")
+      (let [[r1 r2] (requests)]
+        (reply! r1 {:results results-an})
+        (reply! r2 {:results [] :error "timeout"})
+        (is (= results-an (get-in (app-db) [ui/records-root k1 :results]))
+            "the first has results")
+        (is (nil? (get-in (app-db) [ui/records-root k1 :error]))
+            "and no error")
+        (is (= "timeout" (get-in (app-db) [ui/records-root k2 :error]))
+            "the second has an error")
+        (is (empty? (get-in (app-db) [ui/records-root k2 :results]))
+            "and no results")))))
+
+(deftest r-c6-an-optimistic-commit-rolls-back-without-disabling-the-control
+  (testing "R-C6. The chosen value shows AT ONCE, marked unconfirmed, and
+            the control stays usable. A refusal rolls back — and the
+            rollback may reassert exactly the value that was there before,
+            which is the case value-equality is blind to and the advanced
+            revision is not."
+    (seed! {:doc {doc-id {:reviewer "amir" :reviewer-revision 3 :reviewer-confirmed? true}}})
+    (send! [:app/reviewer-chosen doc-id "anna"])
+    (is (= "anna" (get-in (app-db) [:doc doc-id :reviewer])) "shown at once")
+    (is (false? (get-in (app-db) [:doc doc-id :reviewer-confirmed?])) "marked unconfirmed")
+    (is (= 4 (get-in (app-db) [:doc doc-id :reviewer-revision])) "a new baseline decision")
+
+    (send! [:app/reviewer-refused doc-id "amir"])
+    (is (= "amir" (get-in (app-db) [:doc doc-id :reviewer])) "rolled back")
+    (is (= 5 (get-in (app-db) [:doc doc-id :reviewer-revision]))
+        "and the revision advanced again, so a control holding a draft sees it")
+
+    (testing "the same-value case: a refusal that reasserts what was
+              already displayed is still VISIBLE to the control"
+      (let [before (get-in (app-db) [:doc doc-id :reviewer])]
+        (send! [:app/reviewer-refused doc-id before])
+        (is (= before (get-in (app-db) [:doc doc-id :reviewer]))
+            "non-vacuous: the value really did not move")
+        (is (= 6 (get-in (app-db) [:doc doc-id :reviewer-revision]))
+            "and the generation did, which is the whole signal")))))
+
+(deftest r-c7-the-debounce-has-a-visible-home-and-a-stated-cost
+  (testing "R-C7. The baseline hides debounce in core.async closures inside
+            the component, invisible to tooling. Here it is an ordinary
+            `:dispatch-later` effect the keystroke handler RETURNS — so a
+            structural test reads the schedule as data, a trace shows it,
+            and the cost (one armed timer per keystroke, N-1 of them
+            no-ops) is countable rather than hidden."
+    (seed! {})
+    (let [handler  (registrar/handler :event :acme.ui.typeahead/typed)
+          typed    (fn [text]
+                     (handler {:db (app-db)}
+                              [:acme.ui.typeahead/typed k 0 20 [:app/search-requested] text]))
+          effects  (typed "an")
+          [fx-id args] (first (:fx effects))]
+      (is (= :dispatch-later fx-id)
+          "the schedule is an ordinary framework effect the handler RETURNED")
+      (is (= 20 (:ms args)) "carrying the quiet period as data")
+      (is (= :acme.ui.typeahead/due (first (:event args)))
+          "and the event it will deliver")
+      (is (empty? (:fx (typed "")))
+          "an empty query arms nothing — there is no question to ask"))))
+
+(deftest r-c8-one-instance-identity-across-input-list-and-status
+  (testing "R-C8. re-com's baseline coordinates eleven ratoms per
+            instance. Here the input, the suggestion list and the status
+            region are three parts of ONE view reading ONE record, and
+            every intent any of them carries names the same record key —
+            so there is nothing for the parts to disagree about."
+    (seed! {:doc {doc-id {:reviewer "" :reviewer-revision 0}}})
+    (send! [:acme.ui.typeahead/typed k 0 never-fires-ms [:app/search-requested] "an"])
+    (fire-debounce! (:token (record)))
+    (reply! (first (requests)) {:results results-an})
+    (let [tree  (render! [ui/reviewer-form {:id doc-id}])
+          input (attrs-of tree "input")
+          opt   (t/attrs (first (nodes-with-part tree "option")))]
+      (is (= "an" (:value input)) "the input shows the draft")
+      (is (= 1 (count (nodes-with-part tree "option"))) "the list shows the answer")
+      (is (= k (second (:on-input input))) "the input's intent names the record")
+      (is (= k (second (:on-click opt))) "and so does the option's")
+      (is (= k (second (:on-key-down input))) "and the keyboard's"))))
+
+(deftest r-c9-a-dirty-control-blocks-the-leave-and-a-clean-one-does-not
+  (testing "R-C9. Leaving with an unconfirmed write blocks, the
+            confirmation is ordinary state-driven view code, and a
+            just-confirmed value leaves freely. The gate is DERIVED and
+            read by both the view and the guard handler — neither
+            recomputes it."
+    (seed! {:doc {doc-id {:reviewer "amir" :reviewer-confirmed? true}}})
+    (send! [:app/leave-attempted doc-id k])
+    (is (contains? (app-db) :re-frame.freehand.pilot-typeahead/left)
+        "a clean form leaves")
+
+    (seed! {:doc {doc-id {:reviewer "amir" :reviewer-confirmed? true}}})
+    (send! [:app/reviewer-chosen doc-id "anna"])
+    (send! [:app/leave-attempted doc-id k])
+    (is (not (contains? (app-db) :re-frame.freehand.pilot-typeahead/left))
+        "a dirty one does not")
+    (is (true? (get (app-db) :re-frame.freehand.pilot-typeahead/leaving?))
+        "and the confirm is ordinary state a view renders off")
+
+    (send! [:app/reviewer-confirmed doc-id])
+    (send! [:app/leave-attempted doc-id k])
+    (is (contains? (app-db) :re-frame.freehand.pilot-typeahead/left)
+        "and once the write confirms, the leave goes through")))
+
+(deftest r-c10-the-whole-loop-is-provable-with-no-browser
+  (testing "R-C10. Every step — keystroke, debounce, request, reply,
+            freshness, selection, release — is an event or a subscription,
+            so the whole loop is drivable and assertable here. That is the
+            bar the corpus already set, and the row exists to prove the
+            view-layer machinery did not lower it."
+    (seed! {:doc {doc-id {:reviewer "" :reviewer-revision 0}}})
+    (type! "an")
+    (fire-debounce! (:token (record)))
+    (reply! (first (requests)) {:results results-an})
+    (send! [:acme.ui.typeahead/chosen k 0 0 [:app/reviewer-chosen doc-id]])
+    (is (= "anna" (get-in (app-db) [:doc doc-id :reviewer]))
+        "the caller's own state moved, through the caller's own event")
+    (is (nil? (record)) "and the control retired itself with the commit")))
+
+;; ===========================================================================
+;; The composed control's view surface
+;; ===========================================================================
+
+(deftest the-controlled-input-site-is-a-literal-vector-so-the-door-stays-open
+  (testing "The input is a controlled native carrying a LITERAL event
+            vector at `:on-input`, which is what puts the site inside the
+            substrate's synchronous door — the keystroke's state change
+            lands before the listener returns, so React's end-of-event
+            value restore finds what it just rendered. The library owns the
+            site and carries the caller's intent as an ARGUMENT inside it,
+            so a caller cannot spell its way out of the door."
+    (seed! {:doc {doc-id {:reviewer "" :reviewer-revision 0}}})
+    (let [tree  (render! [ui/reviewer-form {:id doc-id}])
+          input (attrs-of tree "input")]
+      (is (= :input (:tag (node-with-part tree "input"))) "a controlled native")
+      (is (contains? input :value) "carrying a value")
+      (is (vector? (:on-input input)) "and a literal event vector at the door slot")
+      (is (= :acme.ui.typeahead/typed (first (:on-input input)))
+          "the LIBRARY's own event, not the caller's")
+      (is (= [:app/search-requested] (nth (:on-input input) 4))
+          "with the caller's intent riding as an argument inside it")
+      (is (= ::v/value (last (:on-input input)))
+          "and the live value filled by the reserved projection"))))
+
+(deftest the-status-region-is-derived-and-never-a-local-flag
+  (testing "Busy discipline (R-A10's sibling in CASE C): the control shows
+            `Searching…` off the in-flight request's OWN state and off the
+            gap between what is typed and what is answered — never off a
+            flag something has to remember to clear."
+    (seed! {:doc {doc-id {:reviewer "" :reviewer-revision 0}}})
+    (let [status #(t/text (node-with-part (render! [ui/reviewer-form {:id doc-id}]) "status"))]
+      (is (= "" (status)) "idle")
+      (type! "an")
+      (is (= "Searching…" (status)) "typed, nothing answered yet")
+      (fire-debounce! (:token (record)))
+      (is (= "Searching…" (status)) "and in flight")
+      (reply! (first (requests)) {:results results-an})
+      (is (= "" (status)) "answered")
+      (type! "ann")
+      (is (= "Searching…" (status)) "typed again — the old answer is not this question's"))))

--- a/implementation/freehand/test/re_frame/freehand/pilot_typeahead_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/pilot_typeahead_dom_cljs_test.cljs
@@ -1,0 +1,330 @@
+(ns re-frame.freehand.pilot-typeahead-dom-cljs-test
+  "CASE C, the MOUNTED half — the typeahead against a real DOM.
+
+  `pilot-typeahead-cljs-test` proves the four fences DECIDE correctly, and
+  it proves the six races headlessly, which is where they belong. What it
+  cannot prove is what a browser does to a live input while those
+  decisions are taken:
+
+  - a keystroke's state change reaching the host INSIDE the event, so
+    React's end-of-event value restore finds what it just rendered rather
+    than clobbering the caret;
+  - a settle landing while the user is mid-word touching neither the value
+    nor the caret nor the node;
+  - a caller's refusal restoring the baseline on the SAME node, with focus
+    intact — which is exactly what a key-remount destroys;
+  - and the debounce actually debouncing, on a real host clock.
+
+  This file rides the browser lane through its `-dom-cljs-test` suffix. It
+  also matches the node suites' broader regex, where it has no DOM to mount
+  and says so rather than passing quietly."
+  (:require ["react" :as react]
+            ["react-dom/client" :as rdc]
+            [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as react-substrate]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.freehand.pilot-typeahead :as ui]
+            [re-frame.freehand.react :as fr]
+            [re-frame.freehand.shell :as shell]
+            [re-frame.live-frame :as live-frame]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       react-substrate/adapter
+     :ambient-frame nil
+     :async?        true}))
+
+(def ^:private fid :dom/pilot-typeahead)
+(def ^:private doc-id :doc-1)
+(def ^:private k [ui/typeahead-kind [:doc doc-id :reviewer]])
+(def ^:private input-id "acme-typeahead-reviewer-doc-1")
+
+(def ^:private results
+  [{:value "anna" :label "Anna Novak"}
+   {:value "amir" :label "Amir Haddad"}])
+
+;; ---------------------------------------------------------------------------
+;; Browser seams — the same ones the controlled-input suites use
+;; ---------------------------------------------------------------------------
+
+(defn- browser? []
+  (and (exists? js/document) (some? (.-createElement js/document))))
+
+(defn- skip! [why]
+  (is true (str "a real browser mount is required — " why)))
+
+(defn- act [thunk]
+  (try
+    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+    (js/Promise.resolve (react/act (fn [] (js/Promise.resolve (thunk)))))
+    (catch :default e
+      (js/Promise.reject e))))
+
+(defn- live!
+  "Leave React's act environment: typing has to reach React as a genuine
+  DISCRETE event, which is the mechanism the draft rides."
+  []
+  (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+  nil)
+
+(defn- after [ms]
+  (js/Promise. (fn [resolve] (js/setTimeout resolve ms))))
+
+(defn- native-value-setter []
+  (.-set (js/Object.getOwnPropertyDescriptor
+           (.-prototype js/HTMLInputElement) "value")))
+
+(defn- set-native-value! [node s]
+  (.call (native-value-setter) node s))
+
+(defn- fire-input! [node data]
+  (.dispatchEvent node (js/InputEvent. "input"
+                                       #js {:bubbles true :cancelable false :data data})))
+
+(defn- insert-at!
+  "Insert `ch` at offset `at`, the way a browser does it: the text grows at
+  the caret, the caret follows it, and then `input` fires."
+  [node at ch]
+  (let [text (.-value node)]
+    (.focus node)
+    (.setSelectionRange node at at)
+    (set-native-value! node (str (subs text 0 at) ch (subs text at)))
+    (.setSelectionRange node (inc at) (inc at))
+    (fire-input! node ch)))
+
+(defn- type-at-end! [node s]
+  (doseq [ch s]
+    (insert-at! node (count (.-value node)) (str ch))))
+
+(defn- caret [node] [(.-selectionStart node) (.-selectionEnd node)])
+
+(defn- mount! []
+  (let [container (js/document.createElement "div")]
+    (.appendChild js/document.body container)
+    [container (rdc/createRoot container)]))
+
+(defn- teardown! [container root]
+  (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+  (.unmount root)
+  (.remove container)
+  nil)
+
+(defn- setup! []
+  (live-frame/make-frame {:id fid})
+  (ui/register!)
+  (ui/register-app!)
+  (frame/replace-app-db! fid {:doc {doc-id {:reviewer ""
+                                            :reviewer-revision 0
+                                            :reviewer-confirmed? true}}})
+  nil)
+
+(defn- element [] (shell/provide-frame fid (fr/element [ui/reviewer-form {:id doc-id}])))
+(defn- render! [root] (act #(.render root (element))))
+(defn- send! [ev] (rf/dispatch-sync ev {:frame fid}))
+(defn- app-db [] (frame/frame-app-db-value fid))
+(defn- record [] (get-in (app-db) [ui/records-root k]))
+(defn- requests [] (get (app-db) :re-frame.freehand.pilot-typeahead/requests []))
+(defn- field [] (js/document.getElementById input-id))
+
+(defn- reply!
+  "The caller answering a request it was handed. `act`, because it moves
+  ordinary application state and React has to be allowed to render it."
+  [request outcome]
+  (act #(send! (conj (vec (:reply-to request)) outcome))))
+
+;; ===========================================================================
+;; Typing through the draft, on a real controlled input
+;; ===========================================================================
+
+(deftest a-keystroke-reaches-the-draft-inside-the-event-and-keeps-the-caret
+  (testing "The input is a controlled native carrying a LITERAL event
+            vector at `:on-input`, so the site is inside the substrate's
+            synchronous door: the keystroke's state change lands before the
+            listener returns, and React's end-of-event value restore finds
+            what it just rendered. The evidence is the DOM value after each
+            character, the caret after a MID-STRING insert, and the node
+            identity throughout — the three things an async round trip
+            destroys."
+    (if-not (browser?)
+      (skip! "the browser job runs the typing assertions")
+      (async done
+        (setup!)
+        (let [[container root] (mount!)]
+          (-> (render! root)
+              (.then (fn [_]
+                       (live!)
+                       (let [node   (field)
+                             before node]
+                         (is (= "" (.-value node)) "empty to begin with")
+                         (type-at-end! node "anna")
+                         (is (= "anna" (.-value node))
+                             "every keystroke survived the round trip through the draft")
+                         (is (= "anna" (:query (record)))
+                             "and the draft is controller state, not host state")
+                         (is (identical? before (field)) "on the same node throughout")
+
+                         ;; A mid-string insert: the caret is what a lagging
+                         ;; round trip moves to the end.
+                         (insert-at! node 2 "X")
+                         (is (= "anXna" (.-value node)) "the insert landed at the caret")
+                         (is (= [3 3] (caret node)) "and the caret followed it")
+                         (is (= "anXna" (:query (record))) "and reached the draft"))
+                       (teardown! container root)
+                       (done)))
+              (.catch (fn [e]
+                        (is false (str "browser run failed: " e))
+                        (teardown! container root)
+                        (done)))))))))
+
+(deftest a-settle-arriving-mid-word-touches-neither-the-value-nor-the-caret
+  (testing "R-C1, in a browser. The corpus baseline FAILS this: an accepted
+            reply replaces the whole slice and the keystrokes typed since
+            are discarded. Here a settle has nowhere to write the typed
+            text — it writes a result set tagged with the query it answers
+            — so the row asserts the three things a clobber would move: the
+            DOM value, the caret, and the node."
+    (if-not (browser?)
+      (skip! "the browser job runs the mid-word settle assertions")
+      (async done
+        (setup!)
+        (let [[container root] (mount!)]
+          (-> (render! root)
+              (.then (fn [_]
+                       (live!)
+                       (let [node (field)]
+                         (type-at-end! node "an")
+                         ;; The request the debounce would have sent, sent now.
+                         (send! [:acme.ui.typeahead/due k (:token (record))
+                                 [:app/search-requested]])
+                         ;; The user types on while it is out.
+                         (type-at-end! node "na")
+                         (.setSelectionRange node 2 2)
+                         (js/Promise.resolve node))))
+              (.then (fn [node]
+                       (let [before node
+                             req    (first (requests))]
+                         (is (= "anna" (.-value node)) "four characters typed")
+                         (-> (reply! req {:results results})
+                             (.then (fn [_]
+                                      (is (= "anna" (.-value node))
+                                          "the settle touched not one character")
+                                      (is (= [2 2] (caret node))
+                                          "nor the caret")
+                                      (is (identical? before (field))
+                                          "nor the node")
+                                      (is (zero? (count (.querySelectorAll
+                                                          (.-body js/document)
+                                                          "[data-part='option']")))
+                                          (str "and its results are NOT shown — they answer "
+                                               "'an', and the user has typed 'anna'"))
+                                      (teardown! container root)
+                                      (done)))))))
+              (.catch (fn [e]
+                        (is false (str "browser run failed: " e))
+                        (teardown! container root)
+                        (done)))))))))
+
+(deftest a-callers-refusal-restores-the-baseline-on-the-same-node
+  (testing "The generation fence in a browser. The caller refuses the draft
+            and stands by the value it already had, advancing the revision
+            to say this is a new baseline decision. The baseline comes
+            back, the node is the SAME node, and it still has focus — which
+            is precisely what a key-remount destroys and what no structural
+            assertion can see."
+    (if-not (browser?)
+      (skip! "the browser job runs the reject-and-restore assertions")
+      (async done
+        (setup!)
+        (frame/replace-app-db! fid {:doc {doc-id {:reviewer "amir"
+                                                  :reviewer-revision 3
+                                                  :reviewer-confirmed? true}}})
+        (let [[container root] (mount!)]
+          (-> (render! root)
+              (.then (fn [_]
+                       (live!)
+                       (let [node   (field)
+                             before node]
+                         (is (= "amir" (.-value node)) "the committed value shows")
+                         (type-at-end! node "x")
+                         (is (= "amirx" (.-value node)) "a draft is live")
+                         (-> (act #(send! [:app/reviewer-refused doc-id "amir"]))
+                             (.then (fn [_]
+                                      (is (= "amir" (.-value node))
+                                          "the baseline is back on screen")
+                                      (is (identical? before (field))
+                                          "restored on the SAME node, not remounted")
+                                      (is (identical? before js/document.activeElement)
+                                          "which still has focus")
+                                      (teardown! container root)
+                                      (done)))))))
+              (.catch (fn [e]
+                        (is false (str "browser run failed: " e))
+                        (teardown! container root)
+                        (done)))))))))
+
+(deftest the-debounce-debounces-on-a-real-host-clock
+  (testing "The headless rows deliver the delayed event by hand, which is
+            the only way to make the six races deterministic. This row
+            closes the loop the other way: four keystrokes inside one quiet
+            period on a REAL `:dispatch-later` timer produce exactly ONE
+            request, for the text that was typed last. The three superseded
+            schedules fired and found they were not current."
+    (if-not (browser?)
+      (skip! "the browser job runs the real-clock debounce assertion")
+      (async done
+        (setup!)
+        (let [[container root] (mount!)]
+          (-> (render! root)
+              (.then (fn [_]
+                       (live!)
+                       (type-at-end! (field) "anna")
+                       (is (empty? (requests)) "nothing has gone out yet")
+                       (after 300)))
+              (.then (fn [_]
+                       (is (= 1 (count (requests)))
+                           (str "exactly one request after the quiet period, not four "
+                                "(got " (mapv :query (requests)) ")"))
+                       (is (= "anna" (:query (first (requests))))
+                           "for what the user actually typed")
+                       (teardown! container root)
+                       (done)))
+              (.catch (fn [e]
+                        (is false (str "browser run failed: " e))
+                        (teardown! container root)
+                        (done)))))))))
+
+(deftest choosing-a-suggestion-commits-and-retires-the-control
+  (testing "The whole loop, live: type, settle, click a suggestion. The
+            caller's own value moves through the caller's own event, and
+            the control retires itself with the commit rather than leaving
+            a closed record behind."
+    (if-not (browser?)
+      (skip! "the browser job runs the selection assertions")
+      (async done
+        (setup!)
+        (let [[container root] (mount!)]
+          (-> (render! root)
+              (.then (fn [_]
+                       (live!)
+                       (type-at-end! (field) "an")
+                       (send! [:acme.ui.typeahead/due k (:token (record))
+                               [:app/search-requested]])
+                       (reply! (first (requests)) {:results results})))
+              (.then (fn [_]
+                       (let [opts (.querySelectorAll (.-body js/document) "[data-part='option']")]
+                         (is (= 2 (.-length opts)) "the suggestions are on screen")
+                         (act #(.click (aget opts 0))))))
+              (.then (fn [_]
+                       (is (= "anna" (get-in (app-db) [:doc doc-id :reviewer]))
+                           "the caller's state moved")
+                       (is (nil? (record)) "and the control retired itself")
+                       (is (= "anna" (.-value (field)))
+                           "with the committed value now the input's baseline")
+                       (teardown! container root)
+                       (done)))
+              (.catch (fn [e]
+                        (is false (str "browser run failed: " e))
+                        (teardown! container root)
+                        (done)))))))))

--- a/implementation/freehand/test/re_frame/freehand/pilot_typeahead_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/pilot_typeahead_dom_cljs_test.cljs
@@ -214,9 +214,9 @@
                                           "nor the caret")
                                       (is (identical? before (field))
                                           "nor the node")
-                                      (is (zero? (count (.querySelectorAll
-                                                          (.-body js/document)
-                                                          "[data-part='option']")))
+                                      (is (zero? (.-length (.querySelectorAll
+                                                             (.-body js/document)
+                                                             "[data-part='option']")))
                                           (str "and its results are NOT shown — they answer "
                                                "'an', and the user has typed 'anna'"))
                                       (teardown! container root)


### PR DESCRIPTION
EP-0036 slice F5g — the SECOND PILOT. A dropdown/popup (CASE B) and an async
typeahead (CASE C), built as an application/component-library author would build
them, using only the public door, and judged row by row against
`docs/design/freehand/studio/fitness-harness.md` §B.2 and §C.2.

Test-only: eight new files under `implementation/freehand/test/`, no spec, no
docs, no runtime source touched.

- `pilot_overlay.cljc` — the CASE B library (`dropdown`, `confirm`, `menu-bar`)
  plus the application that calls it.
- `pilot_overlay_cljs_test.cljc` — every §B.2 row, headless, JVM + Node.
- `pilot_overlay_dom_cljs_test.cljs` — the mounted half: geometry, focus,
  dismissal, nesting, exact cleanup counts, plus two reproductions.
- `pilot_overlay_compiled.cljc` / `pilot_overlay_parity_cljs_test.cljc` —
  promotion parity, and the exact line it stops at.
- `pilot_typeahead.cljc` — the CASE C library plus its application.
- `pilot_typeahead_cljs_test.cljc` — the six async races and every §C.2 row.
- `pilot_typeahead_dom_cljs_test.cljs` — typing, caret, mid-word settle, the
  revision fence, and the real-clock debounce.

## Quality gates

Foreground, one at a time, exit codes captured (no piping).

| Gate | Exit | Result |
|---|---|---|
| `cd implementation/freehand && clojure -M:test` | **0** | Ran 658 tests, 4487 assertions — 0 failures, 0 errors |
| `npm run test:freehand` | **0** | Ran 574 tests, 3678 assertions — 0 failures, 0 errors |
| `npm run test:cljs` | **0** | Ran 10699 tests, 53771 assertions — 0 failures, 0 errors |
| `npm run test:browser` | **0** | Ran 578 tests, 3364 assertions — 0 failures, 0 errors |
| `python scripts/check_freehand_conformance_index.py` | **0** | — |
| `python scripts/check_donor_inventory.py` | **0** | — |
| `python scripts/check_doc_slugs.py` | **0** | — |

`git grep 're-frame.ui' implementation/freehand/` is empty. No `.beads` path on
the branch.

---

## 1. What the authoring experience was actually like

**The pieces composed, and mostly they composed better than the baseline they
replace.** The whole of re-com's overlay machinery — a document click listener
installed on open, an unconditional `requestAnimationFrame` loop re-armed every
frame while open, a four-family z-index ladder, and 100 ms uncancelled
transition timers — reduced to: one `:popover :auto` attribute, one
`::web/popover-open?` property, and one registered behavior that measures a box.
The browser row measures the result as exact integers: **zero net document
listeners, zero net window listeners, zero observers, zero intervals, and no
animation-frame arm beyond the control mount's.** That is the single strongest
result in this PR.

The controller shape is genuinely pleasant. `control/record-key` is one call and
buys per-instance state with no registry, no `:model`-or-ratom dual contract,
and no collision across N instances. The split between it and
`control/reset-revision` is the right split: the dropdown holds an open flag,
which no caller can reject, so it asks for an address and never for a
generation; the typeahead holds a draft, so it pays for one. Nothing had to be
explained twice.

**Where I had to think harder than the task deserved**, in order:

1. **Deciding which element gets which ref.** The known hazard is real (see
   §2.1), and the pilot avoids it by putting the behavior on the dropdown ROOT
   and the top-layer property on the PANEL inside it. That split reads natural
   after the fact — the root's box *is* the anchor's box, because an open
   popover is out of flow — but nothing in the API points at it, and the failure
   mode if you get it wrong is silence.
2. **Getting the measurement from the behavior to the panel.** A behavior owns
   exactly one node and its config is data, so there is no channel from "the
   thing that measured" to "the thing that must be placed" except the DOM. The
   answer — write inline custom properties on the measured node and let them
   INHERIT to the panel — is elegant and works precisely because the top layer
   keeps the element in the tree. But it took a while to see, and it is the
   non-obvious step an author will need told.
3. **Reconciling the browser's own dismissal.** This is the one that did not
   come out well. See §2.2.

## 2. Where the substrate's promise did not hold — with reproductions

### 2.1 A behavior and a top-layer state on one element lose a ref (rf2-drpa3.118, reproduced)

`a-behavior-and-a-top-layer-state-on-one-element-lose-a-ref`
(`pilot_overlay_dom_cljs_test.cljs`) mounts one `<div>` carrying both
`[v/behavior …]` and `::web/popover-open? true`, and asserts the outcome:
**the behavior's ref survives (1 live connection) and the top layer's never
runs — the element declares a desired state of open and is not open.** Nothing
warns. The ruling to chain the refs is already correct; this is independent
confirmation that it matters, and that the current failure is silent.

### 2.2 `ToggleEvent.newState` has no reserved projection, and the workaround is unsound

This is the pilot's sharpest finding, and it is a chain.

- The top-layer runtime deliberately writes no application state when the
  browser dismisses, and its own dev advisory tells the author to *"handle
  `:on-toggle` with ordinary event intent"*.
- **That is not possible.** The closed projection roster is `::v/value`,
  `::v/checked`, `::v/key`. `newState` — the field that says whether the browser
  just opened or just closed the element — cannot ride a declarative event
  vector.
- The sanctioned escape is `v/event`. **A `v/event` callback at a handler site
  is REFUSED by the structural render** with `:rf.error/ui-tree-malformed`
  ("carries a scalar"): `node.cljc/classify-event` accepts a vector, a map or
  `fn?`, and the callback record is none of those. So a view that reconciles a
  top-layer dismissal the sanctioned way can no longer render on the JVM at all
  — no SSR, no structural test. Pinned in
  `r-b3-the-dismissal-handshake-is-data-because-newstate-cannot-be`, with the
  non-vacuous control (an ordinary event vector at the same site renders fine).
- So the pilot's library COUNTS reports instead: the first `toggle` of a
  session acknowledges, a later one is the dismissal. That is data end to end,
  renders on the JVM, and is proven correct for a single overlay
  (`r-b3-a-browser-dismissal-reaches-the-handshake-and-does-not-spring-back`
  drives a real `hidePopover()` and then re-renders, which is the step that
  would expose a spring-back).
- **And it is unsound for nested overlays.** `the-attribution-ladder-for-nesting`
  walks four rungs — a bare nested pair, the pilot's exact markup without
  behaviors, that markup with behaviors, and that markup with a state-writing
  toggle handler. **All four nest correctly and stay nested.** The fourth rung
  also records the mechanism: opening a nested pair delivers **more than two
  toggle reports** (observed `[:outer :inner :outer]`). A control that must infer
  "closed" by counting therefore reads its own opening as a dismissal and shuts
  itself. `r-b9-nested-dropdowns-collapse-because-a-counting-handshake-cannot-tell-open-from-closed`
  asserts the collapse; `a-nested-panel-opened-in-a-LATER-commit-collapses-the-pair`
  asserts it for the sequenced case too.

**Net effect on R-B9: the platform and the substrate deliver nesting; the
grammar makes it unreachable for any library control that reconciles its own
dismissal.** The fix is small — a reserved projection for the toggle state, or
accepting `v/event` on the structural host — and it is the highest-value item
this pilot found.

### 2.3 A compiled view cannot attach a behavior

`a-behavior-boundary-is-refused-by-the-compiled-grammar`
(`pilot_overlay_parity_cljs_test.cljc`) expands the declaration and pins the
diagnostic: `[v/behavior {…} node]` inside `{:compiled true}` classifies
`:op :foreign` and raises `:rf.ui.compile/unsupported-form` against
`:re-frame.freehand/v1`; the only recovery offered is `:keep-interpreted`. The
non-vacuous control (`the-refusal-is-the-behavior-and-not-the-overlay`) shows
the same body without the behavior compiles.

`v/defbehavior` is the ONE sanctioned imperative boundary and `:timing :layout`
is the only declared before-paint moment, so **measure-then-place work has
exactly one home and a view that goes there can never take the hot tier.** A
dropdown that measures its anchor is interpreted forever. The overlay MARKUP
promotes cleanly — `the-promoted-overlay-markup-denotes-the-same-node` asserts
whole-tree equality between the interpreted declaration and its `{:compiled
true}` twin — so this is a specific, bounded gap, not a general parity failure.

### 2.4 A latent wrong-arity call in the behaviors React lowering

`implementation/freehand/src/re_frame/freehand/react.cljs:370` calls
`(eb/note-failing-view! view-id)` with one argument;
`re-frame.freehand.errors/note-failing-view!` is `[thrown view-id]` / `[thrown]`.
shadow-cljs reports it as `WARNING #1 - :fn-arity` on every build. It is on the
error path for a throwing behavior attach, so a behavior that throws during
`attach` would raise an arity error over the original. Pre-existing on `main`,
in a file this brief marks read-only — reported, not touched.

## 3. What I wanted that does not exist

Distinguishing "I wanted it" from "an author would NEED it":

**NEEDED.**

- **A way to read a top-layer element's own state change as data.** Either a
  reserved projection for `ToggleEvent.newState` / `HTMLDialogElement`'s close
  reason, or `v/event` accepted by the structural render. Without one of the two,
  the substrate asks for a reconciliation it does not make expressible, and the
  only data-only workaround is unsound under nesting (§2.2). This is the one
  gap that blocks a real requirement.
- **`v/behavior` inside the compiled grammar** (§2.3), if the compiled tier is
  meant to be reachable by component libraries rather than by leaf markup only.

**WANTED, and correctly absent.**

- A debounce primitive. `:dispatch-later` plus a token comparison turned out to
  be *better* than a cancellable timer: there is no handle to leak, a superseded
  schedule is inert by comparison, and every step is visible in the trace. The
  cost — one armed timer per keystroke, N−1 of them no-ops — is stated in the
  library's docstring and asserted as data in `r-c7`. No framework debounce is
  needed. What an author WILL want eventually is the resources contract extended
  to library controls (correlation/supersession as policy rather than as four
  hand-written fences), but that is Spec 016's tier, not the view substrate's,
  and the pilot proves the view substrate alone is sufficient.
- A placement/anchoring helper. Twelve lines of behavior and three custom
  properties covered it. A placement DSL would be exactly the over-engineering
  the posture rejects.
- A transition system. Zero timers, because the exit is CSS
  (`transition-behavior: allow-discrete`, `@starting-style`), and `v/presence`
  already exists with a mandatory terminal bound for content-level enter/exit.
  Nothing to orphan (`r-b8`).
- A focus-trap / inert / Esc / focus-return facility. `showModal()` supplies all
  four, verified against a live document in
  `r-b4-the-modal-takes-focus-inerts-the-page-and-gives-focus-back`.

**A small honest wart, not worth a feature.** The keyboard grammar as one
registered event over `::v/key` is excellent — the whole `single_dropdown` parity
set is one handler a structural test drives by equality — but the site fires on
EVERY key, so a key outside the grammar settles an event that changes nothing.
The pilot asserts that cost rather than hiding it.

## 4. The host/mode matrix actually exercised

| | interpreted | compiled |
|---|---|---|
| **JVM (structural)** | ✅ full — every §B.2 and §C.2 row, both libraries, both applications; this run IS the R-B10 host-boundary proof | ✅ overlay markup only — whole-tree parity with the interpreted twin, manifest asserted; **behavior boundary REFUSED (§2.3)** |
| **Node (headless CLJS)** | ✅ full — same `.cljc` suites, plus the six async races | ✅ same declarations, same parity rows |
| **Browser (mounted)** | ✅ full — geometry before paint, transform/clip escape, modal + anchored focus contracts, dismissal, nesting ladder, exact cleanup counts, typing/caret/mid-word settle/revision fence/real-clock debounce | ⛔ **BLOCKED** — no compiled view is browser-mountable today (rf2-drpa3.113): `{:compiled true}` uses the JVM emitter on both hosts and `react.cljs` refuses every compiled declaration. **No coverage is claimed for this cell.** |

### Requirement roster

**CASE B §B.2** — R-B1 ✅ (headless: `:layout` timing + config as data; mounted:
already at the anchor's box at the first frame, no −10000px park) · R-B2 ✅
(mounted, with a fixed probe in the same transformed ancestor proving the
containing-block capture is real, and `elementFromPoint` proving the panel is
really painted outside the clip) · R-B3 ✅ (zero listeners by construction;
dismissal reconciled without spring-back) · R-B4 ✅ (all six modal points +
anchored keeps focus) · R-B5 ✅ (the whole parity set as one event) · R-B6 ✅
(declared frequency + bounded command; measured no rAF arm) · R-B7 ✅ (one owner,
closed props, address required) · R-B8 ✅ (no timer to orphan) ·
**R-B9 ⚠️ SEE §2.2** (platform + substrate deliver it; the grammar makes it
unreachable for a reconciling control — asserted as a finding, with a four-rung
attribution ladder) · R-B10 ✅ (the JVM run) · R-B11 ✅ (two frames, one
declaration) · R-B12 ✅ (exact counts + no retained state) · R-B13 ✅ (this split).

**CASE C §C.2** — R-C1 … R-C10 all ✅, one named test each.

**The six async races** — all ✅, one named test each:
`race-1-debounce-cancellation-…`, `race-2-correlation-…`,
`race-3-supersession-…`, `race-4-stale-completion-…`, `race-5-retry-…`,
`race-6-release-…` (+ `race-6b` proving the route leave reaches the same end
event). Every one is deterministic: the application's search performs no
transport, so latency is a variable rather than a wait.

**Promotion parity** — asserted structurally in both modes for the overlay
markup; refused for the behavior boundary; browser-compiled blocked.

## Donor disposition

The pilot uses no portal and no overlay framework, and needs neither. Every
donor overlay form the harness inventories — `re-com`'s `dropdown` body-wrapper,
`popover`'s two-pass measured geometry with its `parentNode`×3 walk and −2000px
margin hack, `modal_panel`'s z-index ladder — is replaced by an attribute, a
property and a twelve-line behavior, with the retained-resource count measured at
zero. The one thing the donor forms did that this composition cannot yet do is
**nested overlays with self-reconciled dismissal**, and §2.2 shows that is a
grammar gap rather than an argument for a portal.
