### PR TITLE
test(freehand): pin attribution when a behavior child throws (rf2-drpa3.128)

### DIFF
--- a/implementation/freehand/test/re_frame/freehand/behavior_throw_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/behavior_throw_cljs_test.cljc
@@ -1,0 +1,195 @@
+(ns re-frame.freehand.behavior-throw-cljs-test
+  "The STRUCTURAL half of the same scenario: a `v/behavior` whose decorated
+  element's children throw, contained on the host that has no lifecycle.
+
+  The browser file beside this one (`behavior-throw-dom-cljs-test`) pins the
+  behavior's OWN occurrence seam, because in React the decorated element is
+  walked inside the behavior component's render. The structural host reaches
+  the identical declaration by a different route, and the difference is worth
+  stating rather than assuming: a boundary's trailing children are lowered
+  BEFORE the boundary is mounted, so the decorated element's walk belongs to
+  the ENCLOSING declared occurrence and the behavior — an inert marker here,
+  with nothing to connect — never sees the throw at all.
+
+  So the cell this file covers is not the behavior seam. It is the claim that
+  a behavior in the path changes NOTHING about containment or attribution on
+  the structural host: the failure is still contained, still attributed to a
+  real declared view rather than to `unknown-view` or to the catcher, and the
+  safe summary is still the closed public envelope. A marker that disturbed
+  any of those would be a marker that made a page behave differently in a
+  server render than in a browser."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test :refer-macros [deftest is testing]])
+            [clojure.set :as set]
+            [clojure.string :as string]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.behaviors :as behaviors]
+            [re-frame.freehand.conformance :as conf]
+            [re-frame.freehand.descriptor :as descriptor]
+            [re-frame.freehand.errors :as eb]
+            [re-frame.freehand.tree :as tree]))
+
+(def ^:private error-001 (conf/fixture :FH-ERROR-001))
+(def ^:private error-003 (conf/fixture :FH-ERROR-003))
+
+;; ---------------------------------------------------------------------------
+;; The declarations
+;; ---------------------------------------------------------------------------
+
+(def ^:private connects
+  "How many times the behavior's `:connect` ran. On the structural host
+  nothing may ever run it — that is the inert-marker claim — so this stays at
+  zero whether the render succeeds or fails."
+  (atom 0))
+
+(v/defbehavior marker
+  "The smallest registered behavior that can legally be attached. Its
+  `:connect` only counts, so a structural render that ran it would be visible
+  rather than merely suspected."
+  {:timing  :passive
+   :connect (fn [_] (swap! connects inc) nil)})
+
+(def ^:private decorated-child-failure
+  "The ONE exception the decorated element's children throw, carrying a
+  marked secret in its `ex-data`: a summary that leaked host detail would
+  carry it too."
+  (ex-info "the decorated element's children threw" {:secret "must-not-leak"}))
+
+(defn- throwing-run
+  "A child run that throws WHEN THE WALK REALISES IT, and not while the view
+  body is still building the form."
+  []
+  (map (fn [_] (throw decorated-child-failure)) [:row]))
+
+(v/defview decorated-child-throws
+  "A behavior over an ordinary element whose children throw as they are
+  walked."
+  [_]
+  [v/behavior {:use marker :target :probe/decorated :config {:label "panel"}}
+   [:div.node (throwing-run)]])
+
+(v/defview decorated-child-renders
+  "The same declaration with a child that does not throw — the control that
+  makes the behavior's presence in the path a fact rather than an assumption."
+  [_]
+  [v/behavior {:use marker :target :probe/decorated :config {:label "panel"}}
+   [:div.node "content"]])
+
+(defn- id-of [view] (:view-id (descriptor/describe view)))
+
+(defn- behavior-node
+  "The behavior boundary node anywhere in `tree`, or nil."
+  [tree]
+  (first (filter #(= behaviors/behavior-view-id (:view-id %))
+                 (tree-seq map? :children tree))))
+
+(defn- contained-summary
+  "The safe summary of the failure `form`'s walk produces under a fresh
+  boundary — the structural host's realisation of what a mounted boundary
+  reports."
+  [form]
+  (let [b (eb/boundary eb/boundary-view-id :rk)]
+    (:summary (eb/contain b #(tree/render form) {:phase :render :frame-id nil}))))
+
+(defn- deep-keys
+  "Every map key anywhere in `x`, so a forbidden slot cannot hide nested."
+  [x]
+  (cond
+    (map? x)  (into (set (keys x)) (mapcat deep-keys (vals x)))
+    (coll? x) (into #{} (mapcat deep-keys x))
+    :else     #{}))
+
+;; ===========================================================================
+;; The control — the behavior really is in the path, and really inert
+;; ===========================================================================
+
+(deftest the-behavior-is-in-the-path-and-connects-nothing
+  (testing "The control mount: the same declaration with a child that does
+            not throw records the behavior boundary in the tree with the
+            decorated element as its child, and nothing connects. Without it,
+            a contained failure below could be a failure of a declaration the
+            behavior was never part of."
+    (reset! connects 0)
+    (let [node (behavior-node (tree/render [decorated-child-renders {}]))]
+      (is (some? node)
+          "the boundary node is recorded")
+      (is (= :div (:tag (first (:children node))))
+          "with the author's own element as its child")
+      (is (zero? @connects)
+          "and no lifecycle ran — the structural host owns no node to connect to"))))
+
+;; ===========================================================================
+;; Containment and attribution with a behavior in the path
+;; ===========================================================================
+
+(deftest a-throw-under-a-behavior-is-contained-and-attributed-to-a-real-view
+  (testing "The decorated element's children throw. On the structural host
+            the boundary's children are lowered before the boundary is
+            mounted, so the throw unwinds through the ENCLOSING declared
+            view's occurrence seam — and that is the view the report names.
+            What it must not be is `unknown-view`, which would say the throw
+            was never observed, or the catcher's own id, which reads like an
+            identification and sends a reader to the wrong file."
+    (reset! connects 0)
+    (let [summary (contained-summary [decorated-child-throws {}])]
+      (is (= (id-of decorated-child-throws) (:view-id summary))
+          "the declared occurrence the walk was inside when it threw")
+      (is (not= eb/unknown-view-id (:view-id summary))
+          "not the truthful-ignorance marker — an occurrence did observe it")
+      (is (not= behaviors/behavior-view-id (:view-id summary))
+          "and not the inert marker, which never entered the walk")
+      (is (= eb/boundary-view-id (:boundary-view-id summary))
+          "the catcher keeps its own separate field")
+      (is (true? (:complete? (:evidence summary)))
+          "the evidence is complete")
+      (is (zero? @connects)
+          "and a failed structural render still connects nothing"))))
+
+(deftest the-contained-failure-still-reports-the-closed-public-envelope
+  (testing "A behavior in the path changes nothing about the report's shape:
+            the safe summary carries exactly the closed public field set and
+            nothing host-shaped — no exception, no `ex-data`, no props, no
+            app-db and no event history — so what an application may put in
+            app-db or dispatch is bounded whichever declaration failed."
+    (let [summary (contained-summary [decorated-child-throws {}])]
+      (is (= (:safe-summary-keys error-003) (set (keys summary)))
+          "exactly the closed public field set")
+      (is (= (:diagnostic-id error-003) (:diagnostic-id summary)))
+      (is (= (:phase error-003) (:phase summary)))
+      (is (= (:basis error-003) (:basis (:evidence summary))))
+      (is (empty? (set/intersection (:forbidden-keys error-003) (deep-keys summary)))
+          "no exception, ex-data, props, app-db or event history")
+      (is (not (string/includes? (pr-str summary) "must-not-leak"))
+          "and the thrown value's ex-data never reaches the public envelope"))))
+
+(deftest a-sibling-of-the-guarded-behavior-keeps-rendering
+  (testing "Per FH-ERROR-001, containment is local: the boundary shows its
+            fallback and the sibling subtree beside it is untouched. Proving
+            it with a behavior under the boundary is what says the marker
+            does not widen the blast radius of a failure below it."
+    (let [tree (tree/render
+                 [:div
+                  [v/error-boundary {:fallback (:fallback error-001)}
+                   [decorated-child-throws {}]]
+                  (:sibling error-001)])
+          {:keys [fallback-tag sibling-tag sibling-text]} (:contained error-001)]
+      (is (= fallback-tag (:tag (first (:children (first (:children tree))))))
+          "the boundary holds the fallback subtree")
+      (is (= sibling-tag (:tag (second (:children tree))))
+          "and the sibling kept rendering")
+      (is (= [sibling-text] (:children (second (:children tree))))))))
+
+;; ===========================================================================
+;; Non-vacuity — the run really throws
+;; ===========================================================================
+
+(deftest non-vacuity-the-run-throws-when-it-is-realised
+  (testing "Non-vacuity: the decorated element's child run really throws when
+            realised, and the enclosing view body really does return without
+            throwing — so the failures above are the WALK's, contained where
+            the tests say they are, and not a body that failed before the
+            behavior was ever reached."
+    (is (thrown? #?(:clj Throwable :cljs :default) (doall (throwing-run)))
+        "realising the run throws")
+    (is (vector? ((descriptor/render-body decorated-child-throws) {}))
+        "while the view body itself returns markup")))

--- a/implementation/freehand/test/re_frame/freehand/behavior_throw_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/behavior_throw_dom_cljs_test.cljs
@@ -46,6 +46,31 @@
   view. Without it, `:view-id` naming the behavior boundary would be
   indistinguishable from the boundary claiming every failure beneath it.
 
+  ## Which assertions carry the discrimination
+
+  Worth saying plainly, because it is the whole reason this file exists.
+  \"SOMETHING THREW\" PASSES AGAINST THE DEFECT. The seam's failure mode is
+  not a suppressed throw — the throw still arrives, the boundary still
+  catches it, the fallback still commits. What is destroyed is WHO it is
+  attributed to. So every assertion here that merely counts a contained
+  failure — the fallback text, the one-record and one-intent counts, the
+  identity of the promoted exception — is a PASSENGER against a broken note:
+  true, worth stating, and green either way.
+
+  The assertions that discriminate are the ones that name the failing view:
+  `:view-id`, its two negative twins (`unknown-view` and the catcher), the
+  evidence completeness that follows from a note being found, and the
+  fingerprint derived from the id. A revert of the one-arg call reds exactly
+  those and nothing else — which is what proves the file covers the defect
+  class rather than merely visiting it.
+
+  The identity assertion is a passenger HERE and a guard ELSEWHERE: in
+  ClojureScript a wrong-arity call to a single-arity `defn` does not raise,
+  so the seam stays quiet by accident rather than by design. It guards
+  against a seam that raises anything of its own inside that catch — which is
+  what the same mistake does on a host that checks arity, and what any future
+  work inside that catch could do on any host.
+
   This file rides the browser lane through its `-dom-cljs-test` namespace
   suffix. It also matches the node suites' broader regex, where there is no
   DOM to mount and no React to render a component through, and it says so

--- a/implementation/freehand/test/re_frame/freehand/behavior_throw_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/behavior_throw_dom_cljs_test.cljs
@@ -1,0 +1,401 @@
+(ns re-frame.freehand.behavior-throw-dom-cljs-test
+  "The ERROR PATH of the `v/behavior` attachment boundary — a real browser
+  mount in which the decorated element's own walk throws.
+
+  `v/behavior` is the one declared boundary whose child is walked INSIDE the
+  boundary's own React render: the component reads its options, installs the
+  timing arms, then builds the decorated element and hands it the node's ref.
+  So a throw while that element is being built unwinds through the behavior's
+  OCCURRENCE SEAM — the one place in this substrate that can say which
+  declared occurrence a throw belongs to, because a throwable carries no view
+  identity and the boundary that catches it several fibers above has no other
+  source for one.
+
+  Every other error-boundary property in this programme is pinned by a test
+  that fails when the property breaks. This seam was not: nothing anywhere in
+  the suite threw from inside a `v/behavior` child, so the seam's error path
+  was reachable only by reading it. A defect on it therefore surfaced as a
+  compiler warning rather than as a red test — which is what this file
+  closes.
+
+  The three claims, and why each is a separate assertion:
+
+    ATTRIBUTION   the report names the occurrence that THREW. Here that is
+                  the behavior attachment boundary itself, because the
+                  decorated element's walk is that boundary's own render —
+                  and NOT `unknown-view`, which is what a seam that failed to
+                  note the throw would produce, and not the error boundary
+                  that caught it, which keeps its own separate field.
+
+    QUIET SEAM    the seam does not itself throw while a render throw is
+                  already unwinding. The assertion is IDENTITY: the exception
+                  that reaches the private egress is the very object the
+                  child threw. A seam that raised anything of its own inside
+                  that catch would replace it, and the report would describe
+                  the substrate's failure instead of the application's.
+
+    CLOSED EGRESS the boundary above receives a well-formed report — the safe
+                  summary's exact field set, the opaque exception and a
+                  capped host stack on the private record, and no app-db,
+                  event history or `ex-data` anywhere the application can
+                  read.
+
+  A fourth case is the discriminator that gives the first its meaning: a
+  DECLARED VIEW mounted under the decorated node renders in its own fiber, so
+  its throw never passes the behavior's seam and must be attributed to that
+  view. Without it, `:view-id` naming the behavior boundary would be
+  indistinguishable from the boundary claiming every failure beneath it.
+
+  This file rides the browser lane through its `-dom-cljs-test` namespace
+  suffix. It also matches the node suites' broader regex, where there is no
+  DOM to mount and no React to render a component through, and it says so
+  rather than passing quietly."
+  (:require ["react" :as react]
+            ["react-dom/client" :as rdc]
+            [clojure.set :as set]
+            [clojure.string :as string]
+            [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.error-emit :as error-emit]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.behaviors :as behaviors]
+            [re-frame.freehand.conformance :as conf]
+            [re-frame.freehand.descriptor :as descriptor]
+            [re-frame.freehand.errors :as eb]
+            [re-frame.freehand.react :as fr]
+            [re-frame.router :as router]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+(def ^:private error-002 (conf/fixture :FH-ERROR-002))
+(def ^:private error-003 (conf/fixture :FH-ERROR-003))
+
+;; ---------------------------------------------------------------------------
+;; The declarations. Module-level, because a declared view cannot close over a
+;; test's locals and a registered behavior is registered when its namespace
+;; loads.
+;; ---------------------------------------------------------------------------
+
+(def ^:private connects
+  "How many times the behavior's `:connect` ran. A render that threw was
+  never committed, so this must stay at zero — host work is commit-only, and
+  a failed render is the strongest case of a candidate the host abandons."
+  (atom 0))
+
+(v/defbehavior watcher
+  "The smallest registered behavior that can legally be attached: one
+  `:connect` arm that touches no host and only counts."
+  {:timing  :passive
+   :connect (fn [_] (swap! connects inc) nil)})
+
+(def ^:private decorated-child-failure
+  "The ONE exception the decorated element's children throw — a stable
+  object, so the egress record's `:exception` can be compared by IDENTITY
+  rather than by shape. Its `ex-data` carries a marked secret: a summary that
+  ever leaked host detail would carry it too."
+  (ex-info "the decorated element's children threw" {:secret "must-not-leak"}))
+
+(defn- throwing-run
+  "A child run that throws WHEN THE WALK REALISES IT, and not before.
+
+  That distinction is the whole scenario. The enclosing view body builds this
+  value and returns; realisation happens inside the emitter's child walk,
+  which for a behavior's decorated element runs inside the behavior
+  component's own render — so the throw unwinds through the behavior's
+  occurrence seam. A value that threw while the body was still running would
+  be the enclosing view's failure instead, which is a different (and already
+  covered) seam."
+  []
+  (map (fn [_] (throw decorated-child-failure)) [:row]))
+
+(v/defview decorated-child-throws
+  "The scenario: a behavior over an ordinary element whose children throw as
+  the behavior's own render walks them."
+  [_]
+  [v/behavior {:use watcher :target :probe/decorated :config {:label "panel"}}
+   [:div.node (throwing-run)]])
+
+(v/defview descendant-view
+  "A declared view mounted UNDER the decorated node. React renders it in its
+  own component, so its throw never reaches the behavior's seam."
+  [_]
+  (throw (ex-info "a declared descendant of the decorated node threw" {})))
+
+(v/defview decorated-descendant-throws
+  "The discriminator: the same behavior over the same node, failing one
+  fiber lower down."
+  [_]
+  [v/behavior {:use watcher :target :probe/decorated}
+   [:div.node [descendant-view {}]]])
+
+(defn- id-of [view] (:view-id (descriptor/describe view)))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       plain-atom/adapter
+     :ambient-frame nil
+     :async?        true
+     :init-fn       (fn []
+                      (fr/reset-boundaries!)
+                      (behaviors/reset-connections!)
+                      (error-emit/clear-error-listeners!)
+                      (reset! connects 0))}))
+
+;; ---------------------------------------------------------------------------
+;; The harness — a real root, a real class boundary, both channels recorded at
+;; the seams they actually travel.
+;; ---------------------------------------------------------------------------
+
+(defn- browser? []
+  (and (exists? js/document) (some? (.-createElement js/document))))
+
+(defn- skip! [why]
+  (is true (str "a real React mount needs a DOM host — " why)))
+
+(defn- act
+  "A React 19 `act` boundary as a promise, so assertions run after the commit
+  and its flushed effects rather than racing them."
+  [thunk]
+  (try
+    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+    (js/Promise.resolve (react/act (fn [] (js/Promise.resolve (thunk)))))
+    (catch :default e
+      (js/Promise.reject e))))
+
+(defn- open-channels!
+  "Record the safe `:on-error` intent and the private egress record at their
+  real seams, and answer the teardown that removes both. The intent rides a
+  `router/dispatch!` redefinition because the assertion is an EXACT COUNT:
+  an event that had to be processed before it could be counted would be
+  counted on a later microtask than the commit that produced it."
+  []
+  (let [intents (atom [])
+        egress  (atom [])
+        orig    router/dispatch!]
+    (error-emit/register-error-listener! ::recorder (fn [r] (swap! egress conj r)))
+    (set! router/dispatch!
+          (fn ([e] (swap! intents conj e))
+            ([e _opts] (swap! intents conj e))))
+    {:intents intents
+     :egress  egress
+     :close!  (fn []
+                (set! router/dispatch! orig)
+                (error-emit/unregister-error-listener! ::recorder))}))
+
+(defn- guarded
+  "One error boundary over `child`, reporting through the fixture's
+  `:on-error` prefix."
+  [child]
+  (fr/element
+    [v/error-boundary {:fallback  [:p {:id "fallback"} "contained"]
+                       :reset-key (:reset-key-1 error-002)
+                       :on-error  (:on-error error-002)}
+     child]))
+
+(defn- mount-one-failure!
+  "Mount a guarded `child`, let the failure commit, and answer a promise of
+  `{:fallback :intents :egress}` — what was on screen, and what each channel
+  received."
+  [child]
+  (let [container (js/document.createElement "div")
+        _         (.appendChild js/document.body container)
+        root      (rdc/createRoot container)
+        {:keys [intents egress close!]} (open-channels!)
+        finish!   (fn []
+                    (let [seen {:fallback (some-> (.querySelector container "#fallback")
+                                                  .-textContent)
+                                :intents  @intents
+                                :egress   @egress}]
+                      (.unmount root)
+                      (.remove container)
+                      (close!)
+                      seen))]
+    (-> (act #(.render root (guarded child)))
+        (.then (fn [_] (finish!))
+               (fn [e] (finish!) (js/Promise.reject e))))))
+
+(defn- deep-keys
+  "Every map key anywhere in `x`, so a forbidden slot cannot hide nested."
+  [x]
+  (cond
+    (map? x)  (into (set (keys x)) (mapcat deep-keys (vals x)))
+    (coll? x) (into #{} (mapcat deep-keys x))
+    :else     #{}))
+
+;; ===========================================================================
+;; The seam: a throw from inside a behavior's decorated child
+;; ===========================================================================
+
+(deftest a-throw-inside-a-behaviors-decorated-child-is-attributed-to-it
+  (testing "A behavior's decorated element is walked inside the behavior's
+            OWN React render, so a throw from that walk passes the behavior's
+            occurrence seam on its way to the error boundary. The report must
+            name that occurrence. `unknown-view` is what a seam that failed to
+            note the throw produces — truthful ignorance for a failure that
+            was, in fact, plainly observed — and it is also what a seam whose
+            note never reached the thrown value produces, which is the exact
+            defect this case exists to catch."
+    (if-not (browser?)
+      (skip! "the browser job runs the behavior-seam attribution assertions")
+      (async done
+        (-> (mount-one-failure! [decorated-child-throws {}])
+            (.then (fn [{:keys [fallback egress]}]
+                     (let [summary (:summary (first egress))]
+                       (is (= "contained" fallback)
+                           "the throw was contained — the fallback is on screen")
+                       (is (= 1 (count egress))
+                           "and exactly one failure was reported")
+                       (is (= behaviors/behavior-view-id (:view-id summary))
+                           "attributed to the behavior boundary whose render threw")
+                       (is (not= eb/unknown-view-id (:view-id summary))
+                           "not the truthful-ignorance marker — the throw WAS observed")
+                       (is (= eb/boundary-view-id (:boundary-view-id summary))
+                           "the catcher keeps its own separate field")
+                       (is (not= eb/boundary-view-id (:view-id summary))
+                           "and is never named as the thrower")
+                       (is (true? (:complete? (:evidence summary)))
+                           "the evidence is complete — nothing about this failure was lost")
+                       (is (nil? (:loss (:evidence summary)))
+                           "so there is no loss to name")
+                       (is (= (eb/fingerprint behaviors/behavior-view-id :render)
+                              (:fingerprint summary))
+                           "and the correlation token follows the attribution"))
+                     (done))
+                  (fn [e]
+                    (is false (str "mount rejected: " e))
+                    (done))))))))
+
+(deftest the-seam-does-not-throw-while-a-render-throw-is-unwinding
+  (testing "The seam's note runs INSIDE the catch, one statement before the
+            re-throw. Anything it raised there would replace the exception on
+            its way out, and the boundary would report the substrate's
+            failure in place of the application's — destroying the very
+            attribution the seam exists to record. The assertion is identity:
+            the object the private egress carries is the object the decorated
+            child threw."
+    (if-not (browser?)
+      (skip! "the browser job runs the quiet-seam assertions")
+      (async done
+        (-> (mount-one-failure! [decorated-child-throws {}])
+            (.then (fn [{:keys [intents egress]}]
+                     (let [record (first egress)]
+                       (is (= 1 (count egress))
+                           "exactly one private egress record")
+                       (is (= (:intents-per-generation error-002) (count intents))
+                           "and exactly one safe intent")
+                       (is (identical? decorated-child-failure (:exception record))
+                           "the exception promoted is the one the child threw, unreplaced")
+                       (is (= (ex-message decorated-child-failure)
+                              (ex-message (:exception record)))
+                           "it is the application's failure that was reported, not the substrate's")
+                       (is (= behaviors/behavior-view-id (:view-id (:summary record)))
+                           "and the attribution the seam recorded survived the unwind")
+                       (is (zero? @connects)
+                           "the abandoned render connected nothing"))
+                     (done))
+                  (fn [e]
+                    (is false (str "mount rejected: " e))
+                    (done))))))))
+
+(deftest the-boundary-above-receives-a-well-formed-report
+  (testing "The report the boundary promotes for a behavior-seam failure is
+            the same closed pair every other contained failure produces: the
+            safe public summary by exact field set, and the private egress
+            record adding the opaque exception and a capped host stack.
+            Neither carries app-db, event history, `ex-data` or props — the
+            automatic capture this substrate deliberately refuses."
+    (if-not (browser?)
+      (skip! "the browser job runs the closed-egress assertions")
+      (async done
+        (-> (mount-one-failure! [decorated-child-throws {}])
+            (.then (fn [{:keys [intents egress]}]
+                     (let [record  (first egress)
+                           summary (:summary record)]
+                       (is (= (:egress-record-keys error-003) (set (keys record)))
+                           "the private record's field set is exactly the closed egress set")
+                       (is (= (:egress-category error-003) (:error record))
+                           "riding the always-on view-render-failed category")
+                       (is (= (:recovery error-003) (:recovery record))
+                           "and stating that the boundary contained it")
+                       (is (some? (:exception record))
+                           "the opaque host exception the private channel keeps")
+                       (is (string? (:component-stack record))
+                           "and the capped host stack an off-box shipper needs")
+                       (is (= (:safe-summary-keys error-003) (set (keys summary)))
+                           "the safe summary's field set is exactly the closed public set")
+                       (is (= (:diagnostic-id error-003) (:diagnostic-id summary)))
+                       (is (= (:phase error-003) (:phase summary))
+                           "a Freehand body threw, so the phase is :render")
+                       (is (= (:basis error-003) (:basis (:evidence summary))))
+                       (is (empty? (set/intersection (:forbidden-keys error-003)
+                                                     (deep-keys summary)))
+                           "no exception, ex-data, props, app-db or event history in the summary")
+                       (is (not (string/includes? (pr-str summary) "must-not-leak"))
+                           "and the thrown value's ex-data never reaches the public envelope")
+                       (is (= (conj (vec (:on-error error-002)) summary)
+                              (first intents))
+                           "the app's intent is its own prefix with that summary appended"))
+                     (done))
+                  (fn [e]
+                    (is false (str "mount rejected: " e))
+                    (done))))))))
+
+;; ===========================================================================
+;; The discriminator — a behavior boundary claims only what it threw
+;; ===========================================================================
+
+(deftest a-declared-descendant-of-the-decorated-node-keeps-its-own-identity
+  (testing "React renders a declared view in its own component, so a view
+            mounted under the decorated node fails one fiber below the
+            behavior and its throw never passes the behavior's seam. The
+            report must name that view. Without this case, a `:view-id` of
+            the behavior boundary above would be indistinguishable from a
+            boundary claiming every failure beneath it — and because the
+            fingerprint derives from the view id, every bug under every
+            behavior in an application would share one correlation token."
+    (if-not (browser?)
+      (skip! "the browser job runs the descendant-attribution assertions")
+      (async done
+        (-> (mount-one-failure! [decorated-descendant-throws {}])
+            (.then (fn [{:keys [fallback egress]}]
+                     (let [summary (:summary (first egress))]
+                       (is (= "contained" fallback)
+                           "the deeper failure is contained too")
+                       (is (= (id-of descendant-view) (:view-id summary))
+                           "the declared view that threw, not the behavior above it")
+                       (is (not= behaviors/behavior-view-id (:view-id summary))
+                           "the behavior boundary does not claim a descendant's failure")
+                       (is (not= eb/unknown-view-id (:view-id summary))
+                           "and the descendant's own seam observed it"))
+                     (done))
+                  (fn [e]
+                    (is false (str "mount rejected: " e))
+                    (done))))))))
+
+;; ===========================================================================
+;; Non-vacuity — the child really throws, and the recorders are really wired
+;; ===========================================================================
+
+(deftest non-vacuity-the-run-throws-and-the-channels-are-live
+  (testing "Non-vacuity: the decorated element's child run really throws when
+            it is realised — the same stable object the assertions compare by
+            identity — and the two recorders sit on the seams a promotion
+            actually travels. Neither a run that quietly produced nothing nor
+            a silent channel could produce the counts above."
+    (is (thrown? :default (doall (throwing-run)))
+        "realising the run throws")
+    (is (identical? decorated-child-failure
+                    (try (doall (throwing-run))
+                         (catch :default e e)))
+        "and throws the very object the egress assertions compare against")
+    (let [{:keys [intents egress close!]} (open-channels!)
+          b (eb/boundary eb/boundary-view-id (:reset-key-1 error-002))]
+      (eb/capture! b {:exception (ex-info "boom" {})
+                      :phase     (:phase error-002)
+                      :view-id   (:view-id error-002)
+                      :frame-id  nil})
+      (eb/promote! b {:on-error (:on-error error-002) :frame-id nil :time 0})
+      (is (= (:intents-per-generation error-002) (count @intents))
+          "the intent recorder is on the router seam the boundary dispatches through")
+      (is (= (:egress-records-per-generation error-002) (count @egress))
+          "and the egress recorder is on the always-on error axis")
+      (close!))))

--- a/implementation/freehand/test/re_frame/freehand/errors_tree_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/errors_tree_cljs_test.cljc
@@ -249,6 +249,61 @@
                             [ok-child {}] [ok-child {}] [ok-child {}]])))
         "and so is a third")))
 
+(deftest the-rest-of-the-error-boundary-grammar-is-refused-arm-by-arm
+  (testing "The other arms of the same closed grammar, each driven so the
+            refusal that owns it actually RUNS.
+
+            The compiled analyzer's counterpart table is asserted arm by arm
+            (`analyze-reject-cljs-test` `error-boundary-grammar`); the
+            interpreted tier's was asserted for the child count alone. So
+            three of `read-opts`' four refusals, and the closed-roster
+            refusal the props schema owns, were code that no test in the
+            corpus executed — the same shape of hole as an occurrence seam
+            whose catch nothing ever entered. Two modes that must agree about
+            one declaration cannot be checked for agreement on arms only one
+            of them ever runs, and a refusal nothing runs is a refusal that
+            can be broken silently.
+
+            The ids differ by arm because the ROSTER is the schema's to close
+            and the SHAPE rules are the boundary's own, and each is pinned as
+            it actually fires rather than as a reader might assume."
+    ;; The option roster is CLOSED — a one-character typo must not produce a
+    ;; boundary that quietly means something other than it says.
+    (is (= :rf.error/view-bad-props
+           (conf/caught-id
+             #(tree/render [v/error-boundary {:fallback (:fallback error-001)
+                                              :catch    true}
+                            [ok-child {}]])))
+        "an option outside the roster is refused, not ignored")
+    ;; A boundary with no fallback would show NOTHING on failure — the one
+    ;; outcome worse than the failure itself.
+    (is (= :rf.error/error-boundary-bad-args
+           (conf/caught-id #(tree/render [v/error-boundary {} [ok-child {}]])))
+        "a boundary with no :fallback is refused")
+    ;; `:on-error` is ONE event prefix. The safe summary is appended to it and
+    ;; dispatched, so a value that is not an event vector has nowhere to go.
+    (is (= :rf.error/error-boundary-bad-args
+           (conf/caught-id
+             #(tree/render [v/error-boundary {:fallback (:fallback error-001)
+                                              :on-error "telemetry/failed"}
+                            [ok-child {}]])))
+        "an :on-error that is not a vector is refused")
+    (is (= :rf.error/error-boundary-bad-args
+           (conf/caught-id
+             #(tree/render [v/error-boundary {:fallback (:fallback error-001)
+                                              :on-error ["telemetry/failed"]}
+                            [ok-child {}]])))
+        "and so is a vector whose head is not the event id keyword")
+    ;; The accepted shape, so the four refusals above are refusals of
+    ;; something and not of everything.
+    (is (= conf/no-throw
+           (conf/caught-id
+             #(tree/render [v/error-boundary {:fallback  (:fallback error-001)
+                                              :reset-key :r1
+                                              :on-error  [:telemetry/failed]}
+                            [ok-child {}]])))
+        "the whole roster, correctly spelled, is accepted")))
+
 ;; ===========================================================================
 ;; Non-vacuity probe — the containment is doing REAL work.
 ;; ===========================================================================


### PR DESCRIPTION
Closes the test gap that let a one-token arity defect on the behavior boundary's occurrence seam ship green and then be discovered three times, independently, as a compiler warning.

The repair itself is already on main (PR #6748). What was not on main is any reason to believe the next defect on that seam would be caught: **nothing anywhere in the suite threw from inside a `v/behavior` child**, so the error path of the behavior attachment boundary was reachable only by reading it.

## Why the behavior boundary is the special case

`v/behavior` is the one declared boundary whose child is walked **inside the boundary's own React render** — the component reads its options, installs the timing arms, then builds the decorated element and hands it the node's ref. So a throw while that element is being built unwinds through the behavior's occurrence seam, which is the only place that can say which declared occurrence a throw belongs to (a throwable carries no view identity, and the boundary that catches it several fibers above has no other source for one).

The scenario is an ordinary application bug: the decorated element's children are a lazy run (`(map row-item items)`) that throws when the walk realises it — inside the behavior's render, not while the enclosing body was still building the form.

## What is asserted

`implementation/freehand/test/re_frame/freehand/behavior_throw_dom_cljs_test.cljs` — a real `react-dom/client` mount, a real class boundary, both channels counted at their real seams:

1. **Attribution** — the report names the occurrence that threw (`:re-frame.freehand/behavior`, whose own render walked the failing element), and not `:re-frame.freehand/unknown-view`, which is exactly what a seam whose note never reached the thrown value produces. `:boundary-view-id` keeps the catcher in its own separate field, evidence is complete, no `:loss`, and the fingerprint follows the attribution.
2. **The seam is quiet under an unwinding throw** — asserted by IDENTITY: the exception the private egress carries is the very object the child threw. Anything the seam raised inside that catch would replace it, and the report would describe the substrate's failure in place of the application's. Plus exactly one intent and one egress record, the fallback on screen, and zero behavior connections (a failed render commits nothing).
3. **Closed egress** — the safe summary's exact field set and the private record's exact field set per the `FH-ERROR-003` fixture, the opaque exception and a capped `:component-stack` on the private record, no `:app-db` / `:event-history` / `:ex-data` / `:props` key anywhere in the summary (deep), and the thrown value's marked `ex-data` secret absent from `(pr-str summary)`.

A fourth case is the **discriminator** that gives the first its meaning: a declared view mounted under the decorated node renders in its own fiber, so its throw never passes the behavior's seam and must be attributed to that view. Without it, `:view-id` naming the behavior boundary would be indistinguishable from the boundary claiming every failure beneath it — and because the fingerprint derives from the view id, every bug under every behavior would share one correlation token.

## Cells covered, per host

| host | cell | covered by |
| --- | --- | --- |
| browser (`react-dom/client`) | the behavior's OWN occurrence seam catches a throw from the decorated element's walk | `behavior_throw_dom_cljs_test.cljs` — the cell the defect lived in, and the cell that reds below |
| browser | a declared descendant of the decorated node keeps its own identity | same file (the discriminator) |
| JVM + node structural walk | a behavior in the path changes nothing about containment, attribution or the public envelope | `behavior_throw_cljs_test.cljc` |

**Not claimed:** the structural host does not exercise the behavior's own seam for a child throw, and the test says so rather than pretending otherwise. On that host a boundary's trailing children are lowered *before* the boundary is mounted, so the decorated element's walk belongs to the **enclosing** declared occurrence and the behavior — an inert marker there, with nothing to connect — never sees the throw. The `.cljc` file asserts that honest answer (attributed to the enclosing view, never `unknown-view`, never the catcher) together with a control mount proving the marker really is in the path and really connects nothing.

No production source changed. No public verb, no new diagnostic id, no api-manifest surface.

## Quality gates

Rebased onto green `main@44216bb8ab` (2026-07-24) — clean rebase, no conflicts, diff still test-only. The two CLJS/browser gates below were re-run on the rebased head `95efaaac3c` and are green (the counts rise because main grew since this PR opened). The remaining rows are from the pre-rebase run and were unaffected — no production source changed.

| gate | exit | result |
| --- | --- | --- |
| `cd implementation/freehand && clojure -M:test` | `0` | Ran 622 tests containing 4354 assertions. 0 failures, 0 errors. |
| `npm run test:freehand` (re-run post-rebase) | `0` | Build completed (323 files, 74 compiled, **0 warnings**). Ran 635 tests containing 4068 assertions. 0 failures, 0 errors. |
| `npm run test:cljs` | `0` | Ran 10659 tests containing 53669 assertions. 0 failures, 0 errors. |
| `npm run test:browser` (re-run post-rebase) | `0` | Ran 597 tests containing 3512 assertions. 0 failures, 0 errors. No uncaught `pageerror` — the deliberate throw is contained by the boundary under test. |
| `python scripts/check_freehand_conformance_index.py` | `0` | clean |
| `python scripts/check_doc_slugs.py` | `0` | clean |
| `git grep 're-frame.ui' implementation/freehand/` | `1` (no match) | empty, as required |

## Red against the reverted arity

The one-arg call was temporarily restored in `implementation/freehand/src/re_frame/freehand/react.cljs` (`(eb/note-failing-view! view-id)`) and the browser gate re-run.

**Compiler, with the arity reverted** — the warning that was the defect's only historical signal reappears:

```
------ WARNING #2 - :fn-arity --------------------------------------------------
 File: .../implementation/freehand/src/re_frame/freehand/react.cljs:384:27
--------------------------------------------------------------------------------
 381 |                       (try
 382 |                         (behaviors/attach (emit cand (:child opts)) set-node)
 383 |                         (catch :default e
 384 |                           (eb/note-failing-view! view-id)
---------------------------------^----------------------------------------------
 Wrong number of args (1) passed to re-frame.freehand.errors/note-failing-view!
```

**Browser gate, with the arity reverted — `EXIT=1`, `6 failures`, named:**

```
Testing re-frame.freehand.behavior-throw-dom-cljs-test

FAIL in (a-throw-inside-a-behaviors-decorated-child-is-attributed-to-it) (behavior_throw_dom_cljs_test.cljs:247:28)
attributed to the behavior boundary whose render threw
expected: (= behaviors/behavior-view-id (:view-id summary))
  actual: (not (= :re-frame.freehand/behavior :re-frame.freehand/unknown-view))

FAIL in (a-throw-inside-a-behaviors-decorated-child-is-attributed-to-it) (behavior_throw_dom_cljs_test.cljs:249:28)
not the truthful-ignorance marker — the throw WAS observed
expected: (not= eb/unknown-view-id (:view-id summary))
  actual: (not (not= :re-frame.freehand/unknown-view :re-frame.freehand/unknown-view))

FAIL in (a-throw-inside-a-behaviors-decorated-child-is-attributed-to-it) (behavior_throw_dom_cljs_test.cljs:255:28)
the evidence is complete — nothing about this failure was lost
expected: (true? (:complete? (:evidence summary)))
  actual: (not (true? false))

FAIL in (a-throw-inside-a-behaviors-decorated-child-is-attributed-to-it) (behavior_throw_dom_cljs_test.cljs:257:28)
so there is no loss to name
expected: (nil? (:loss (:evidence summary)))
  actual: (not (nil? {:reason :failing-view-unobserved}))

FAIL in (a-throw-inside-a-behaviors-decorated-child-is-attributed-to-it) (behavior_throw_dom_cljs_test.cljs:259:28)
and the correlation token follows the attribution
expected: (= (eb/fingerprint behaviors/behavior-view-id :render) (:fingerprint summary))
  actual: (not (= "fh-render-failed::re-frame.freehand/behavior|render"
                  "fh-render-failed::re-frame.freehand/unknown-view|render"))

FAIL in (the-seam-does-not-throw-while-a-render-throw-is-unwinding) (behavior_throw_dom_cljs_test.cljs:290:28)
and the attribution the seam recorded survived the unwind
expected: (= behaviors/behavior-view-id (:view-id (:summary record)))
  actual: (not (= :re-frame.freehand/behavior :re-frame.freehand/unknown-view))

Ran 568 tests containing 3330 assertions.
6 failures, 0 errors.
```

The observable consequence of the reverted arity in ClojureScript is exactly what the seam exists to prevent: the note is keyed on the **view id keyword** instead of on the thrown value, so the real exception carries no note and the report goes out as `unknown-view` with `:loss {:reason :failing-view-unobserved}` — a confident statement that nobody saw the thrower, for a failure that was plainly observed.

**Restored byte-identical** — `sha256(react.cljs)` is `9f998a524cd095edc946063d890e257283709fb37024a6b863f93fe0ccba70dc` before and after, `git status` clean, and the browser gate is green again:

```
$ npm run test:browser
EXIT=0
Browser tests: Ran 568 tests containing 3330 assertions. 0 failures, 0 errors.
```

