### PR TITLE
fix(freehand): refuse non-list #?@ splice branches in the compile checker (rf2-7xgq4)

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/compiler/check.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/check.cljc
@@ -89,10 +89,11 @@
 
   Where selection leaves source the TARGET's own reader would refuse — a map
   entry with one side elided, two entries selecting the same key, two set
-  members selecting the same value — the checker refuses too (see
-  [[resolve-entries]] and [[resolve-members]]). A branch that does not READ
-  cannot be eligible, and normalising it into something readable would be a
-  green about a literal nobody wrote.
+  members selecting the same value, a `#?@` whose selected branch is a set or
+  map rather than a list or vector — the checker refuses too (see
+  [[resolve-entries]], [[resolve-members]] and [[resolve-children]]). A branch
+  that does not READ cannot be eligible, and normalising it into something
+  readable would be a green about a literal nobody wrote.
 
   A PURE `.cljs` source is the case that has no answer, and it is refused
   rather than approximated (see [[refuse-cljs-source!]]). Resolution needs
@@ -493,6 +494,33 @@
                        "are written as themselves. The set, as preserved: " (pr-str s))
                   {::unreadable true :target (first features) :set s :member member})))
 
+(defn- refuse-unspliceable-branch!
+  "Refuse a `#?@` whose selected `branch` is not a list or vector.
+
+  A `#?@` splices its selected branch by copying that branch's members into the
+  surrounding form — a thing only a list or vector can be. The target reader
+  requires the branch to implement `java.util.List` and refuses anything else
+  (\"Spliced form list in read-cond-splicing must implement java.util.List.\"),
+  so a `#?@` that selects a SET or a MAP does not read. [[resolve-children]]
+  once called `(seq branch)` on the selection regardless, sequencing a set into
+  its members and a map into its entries and reporting the view ELIGIBLE — a
+  green about a splice the compiler cannot read. So the selection is refused at
+  the boundary the reader draws.
+
+  Thrown WITHOUT the file, for the reason [[refuse-unreadable-set!]] is, and
+  marked the same way so [[read-declarations]] prefixes the path."
+  [branch features]
+  (throw (ex-info (str "a #?@ splice whose conditional selects a "
+                       (cond (set? branch) "SET" (map? branch) "MAP" :else "non-list")
+                       ", " (pr-str branch) ", cannot be read for the " (first features)
+                       " target, so the checker will not answer for a declaration "
+                       "containing it. A #?@ copies its branch's members into the "
+                       "surrounding form, so only a list or vector may be spliced — a "
+                       "set or map does not implement java.util.List. Write the "
+                       "conditional around the WHOLE collection — #?(:clj […] :cljs #{…}) "
+                       "— or make the spliced branch a list or vector.")
+                  {::unreadable true :target (first features) :branch branch})))
+
 (defn- resolve-entries
   "Resolve conditionals across a map's entries, at the refusal boundary the
   TARGET's reader draws.
@@ -547,7 +575,14 @@
 (defn- resolve-children
   "Resolve conditionals across a sequence of sibling forms, SPLICING a
   matched `#?@` and dropping an elided conditional — the two things a
-  conditional does that a plain form cannot. Returns a vector."
+  conditional does that a plain form cannot. Returns a vector.
+
+  A `#?@` splices only a list or vector: the target reader copies the selected
+  branch's members into the surrounding form and requires that branch to
+  implement `java.util.List`, refusing a SET or MAP branch outright. So a
+  selected non-list branch is refused at that boundary
+  ([[refuse-unspliceable-branch!]]) rather than sequenced — sequencing it would
+  green a splice the compiler cannot read."
   [xs features]
   (into []
         (mapcat
@@ -556,7 +591,9 @@
              (let [branch (select-branch x features)]
                (cond
                  (= ::elide branch) []
-                 (:splicing? x)     (resolve-children (seq branch) features)
+                 (:splicing? x)     (if (sequential? branch)
+                                      (resolve-children (seq branch) features)
+                                      (refuse-unspliceable-branch! branch features))
                  :else              [(resolve-conditionals branch features)]))
              [(resolve-conditionals x features)])))
         xs))

--- a/implementation/freehand/test/re_frame/freehand/check_splice_branch_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/check_splice_branch_jvm_test.clj
@@ -1,0 +1,261 @@
+(ns re-frame.freehand.check-splice-branch-jvm-test
+  "A green from the checker must mean the target can READ the branch — a `#?@`
+  splice included.
+
+  The checker reads with conditionals preserved and selects each target's
+  branch itself, then splices a matched `#?@` by sequencing its branch. But a
+  real reader splices ONLY a list or vector: it copies the branch's members
+  into the surrounding form and requires the branch to implement
+  `java.util.List`, refusing a set or map with \"Spliced form list in
+  read-cond-splicing must implement java.util.List.\" The shared splice arm
+  called `(seq branch)` regardless — sequencing a set into its members and a
+  map into its entries — so a declaration whose `:cljs` `#?@` selects a set or
+  map was resolved, analyzed, and reported `:compile-eligible? true` even though
+  the browser build's reader cannot read the file.
+
+  Getting this right means pinning BOTH directions, because a rule that only
+  reproduces the refusals is a rule nothing has contradicted: a `#?@` whose
+  selected branch is a list or vector must stay spliced, and one whose OTHER
+  branch is a set or map — the one this target does not select — reads perfectly
+  well. So the load-bearing assertion here is an EQUIVALENCE against an
+  independent reader (`clojure.tools.reader`, which honours `:features` exactly,
+  splices before it validates, and has no unconditional platform feature): over
+  a table of shapes, checker and reader must agree on WHETHER each target can
+  read the splice and, when it can, on WHAT it reads — and the table must
+  contain a substantial number of each verdict.
+
+  Five things are asserted:
+
+    1. checker selection and a real target reader agree in both directions,
+       over a table that is refused eight times and accepted sixteen;
+    2. `check-file` — the public surface — refuses the SET-valued and the
+       MAP-valued selected splice from the bead rather than reporting eligible,
+       naming the file, the branch, the target and the recovery, and an
+       independent reader proves the same verdict;
+    3. valid list/vector splices stay eligible;
+    4. the refusal is target-symmetric, and an invalid branch the target does
+       NOT select reads, because that is what the real reader does with it;
+    5. the checker is still read-only, including after a REFUSED run.
+
+  The refused fixtures are written to a temp file by this suite rather than
+  committed: their `:cljs` branch is source the browser build's reader refuses,
+  so a committed fixture carrying one could not be compiled for CLJS."
+  (:require [clojure.java.io :as io]
+            [clojure.test :refer [deftest is testing]]
+            [clojure.tools.reader :as rdr]
+            [clojure.tools.reader.reader-types :as rt]
+            [re-frame.freehand.check-splice-branch-views]
+            [re-frame.freehand.compiler.check :as check]))
+
+(def ^:private uniform-path
+  (.getPath (io/file (io/resource "re_frame/freehand/check_splice_branch_views.cljc"))))
+
+(def ^:private resolve-conditionals
+  "The checker's branch selection, reached directly — the splice arm answers per
+  target, and a refusal raised here carries no file yet (`check-file` adds it),
+  so the bare sentence is what these assertions see."
+  #'check/resolve-conditionals)
+
+(defn- thrown-by [f]
+  (try (f) nil (catch Throwable t t)))
+
+;; ---------------------------------------------------------------------------
+;; 1 — the boundary is the target reader's own, in both directions
+;; ---------------------------------------------------------------------------
+
+(def ^:private shapes
+  "Splice literals spanning what conditional selection can do to a `#?@`: select
+  a SET or a MAP the reader cannot splice, select an invalid branch on the JVM
+  instead of the browser, select an invalid branch nested inside an attribute
+  set, hit an invalid branch through `:default` — and, just as load-bearing, the
+  shapes that read on every target: a divergent vector, a divergent list, a
+  vector spliced into a set, a one-armed splice that simply elides for the other
+  target, and a collection with no splice in it at all."
+  ["#{#?@(:clj [:a] :cljs #{:b :c})}"
+   "[:x #?@(:clj [:a] :cljs {:b 1})]"
+   "[#?@(:clj #{:a} :cljs [:b])]"
+   "[#?@(:clj {:a 1} :cljs [:b])]"
+   "[:div {:class #{#?@(:clj [:a] :cljs #{:b})}}]"
+   "[#?@(:clj [:a :b] :cljs [:c])]"
+   "[#?@(:clj (:a :b) :cljs (:c))]"
+   "[#?@(:clj [:a] :cljs #{:b})]"
+   "#{#?@(:clj [:a] :cljs [:b :c])}"
+   "[#?@(:default #{:a})]"
+   "[#?@(:clj [:a])]"
+   "[:plain :members]"])
+
+(defn- read-for
+  "What a REAL reader told to read for `features` makes of `src` — `{:read …}`
+  or `{:refused message}`. `clojure.tools.reader` honours `:features` exactly,
+  splices before it validates the branch, and has no unconditional platform
+  feature, so this is the independent statement of what each target sees."
+  [src features]
+  (try {:read (rdr/read-string {:read-cond :allow :features features} src)}
+       (catch Throwable t {:refused (ex-message t)})))
+
+(defn- select-for
+  "The same, through the checker: read with conditionals PRESERVED, then select
+  `features`'s branch the way the checker does."
+  [src features]
+  (try {:read (resolve-conditionals (read-string {:read-cond :preserve} src) features)}
+       (catch Throwable t {:refused (ex-message t)})))
+
+(def ^:private verdicts
+  (for [src shapes, features [#{:clj} #{:cljs}]]
+    {:src src :features features :reader (read-for src features) :checker (select-for src features)}))
+
+(deftest selection-agrees-with-a-real-reader-in-both-directions
+  (testing "every shape, for every target: the checker refuses exactly what the
+            target's own reader refuses, and reads exactly what it reads"
+    (doseq [{:keys [src features reader checker]} verdicts]
+      (is (= (contains? reader :read) (contains? checker :read))
+          (str src " for " features ": reader says "
+               (if (contains? reader :read) "READABLE" (str "REFUSED — " (:refused reader)))
+               ", checker says "
+               (if (contains? checker :read) "READABLE" (str "REFUSED — " (:refused checker)))))
+      (when (and (contains? reader :read) (contains? checker :read))
+        (is (= (:read reader) (:read checker))
+            (str src " for " features ": the same verdict, a different form")))))
+
+  (testing "and the table is not one-sided — a rule that only reproduced the
+            refusals would pass a table with no acceptances in it, and a rule
+            that spliced everything would pass a table with no refusals"
+    (is (= 8  (count (filter (comp :refused :reader) verdicts))))
+    (is (= 16 (count (filter (comp #(contains? % :read) :reader) verdicts))))))
+
+;; ---------------------------------------------------------------------------
+;; 2 — check-file refuses instead of sequencing
+;; ---------------------------------------------------------------------------
+
+(def ^:private refused
+  "The two ways a `#?@` selects a branch the reader cannot splice, as the bead
+  reproduced them. Both `:clj` branches read — the vector `[:a]` splices — which
+  is why the namespace loads; the refusal is about the `:cljs` branch alone."
+  {"set-branch" "[:div {:title (str #{#?@(:clj [:a] :cljs #{:b :c})})} \"x\"]"
+   "map-branch" "[:div {:title (str [#?@(:clj [:a] :cljs {:b 1})])} \"x\"]"})
+
+(defn- write-temp-view
+  "Write a one-view `.cljc` namespace whose body is `refused`'s `nm`, LOAD it so
+  heads resolve, and answer its path."
+  [nm]
+  (let [dir (.toFile (java.nio.file.Files/createTempDirectory
+                      "check-splice-branch"
+                      (make-array java.nio.file.attribute.FileAttribute 0)))
+        f   (io/file dir (str nm ".cljc"))]
+    (.deleteOnExit dir)
+    (.deleteOnExit f)
+    (spit f (str "(ns re-frame.freehand." nm "-temp-splice-views\n"
+                 "  (:require [re-frame.freehand :as v]))\n"
+                 "\n"
+                 "(v/defview subject\n"
+                 "  [_]\n"
+                 "  " (get refused nm) ")\n"))
+    (load-file (.getPath f))
+    (.getPath f)))
+
+(def ^:private temp-view
+  "Each shape is written and loaded ONCE, however many assertions point at it."
+  (memoize write-temp-view))
+
+(defn- read-file-for
+  "Read every form of the file at `path` with a real reader told to read for
+  `features`, and answer nil or the exception it threw."
+  [path features]
+  (let [r (rt/indexing-push-back-reader (slurp path))]
+    (thrown-by
+     #(loop []
+        (when-not (= ::eof (rdr/read {:eof ::eof :read-cond :allow :features features} r))
+          (recur))))))
+
+(deftest check-file-refuses-a-splice-the-target-cannot-read
+  (testing "a #?@ whose :cljs conditional selects a SET cannot be spliced — the
+            reader wants java.util.List — and the checker refuses rather than
+            sequencing the set's members. This reported :compile-eligible? true,
+            no findings"
+    (let [path (temp-view "set-branch")]
+      (is (nil? (read-file-for path #{:clj})) "the JVM branch reads: the vector splices")
+      (is (re-find #"must implement java.util.List" (str (read-file-for path #{:cljs})))
+          "and an independent reader refuses the :cljs branch for the same reason")
+
+      (let [ex (thrown-by #(check/check-file path))]
+        (is (instance? clojure.lang.ExceptionInfo ex) "a refusal, not a report")
+        (let [msg (ex-message ex)]
+          (is (re-find #"^re-frame\.freehand check: " msg))
+          (is (.contains msg path) "the refusal names the file")
+          (is (.contains msg "selects a SET") "and which kind of branch stopped it")
+          (is (.contains msg ":cljs target") "and for which target")
+          (is (.contains msg "list or vector") "the recovery is the payload")
+          (is (.contains msg "around the WHOLE collection") "and the other recovery too"))
+        (is (= :cljs (:target (ex-data ex))))
+        (is (= path (:file (ex-data ex))))
+        (is (set? (:branch (ex-data ex)))
+            "the offending branch rides in the data as authored, so a tool can
+             render it without re-reading"))))
+
+  (testing "and a MAP-valued selected splice is refused the same way — a map is
+            no more a java.util.List than a set is"
+    (let [path (temp-view "map-branch")]
+      (is (nil? (read-file-for path #{:clj})) "the JVM branch reads: the vector splices")
+      (is (re-find #"must implement java.util.List" (str (read-file-for path #{:cljs}))))
+
+      (let [ex (thrown-by #(check/check-file path))]
+        (is (instance? clojure.lang.ExceptionInfo ex))
+        (is (.contains (ex-message ex) "selects a MAP"))
+        (is (.contains (ex-message ex) ":cljs target"))
+        (is (= :cljs (:target (ex-data ex))))
+        (is (map? (:branch (ex-data ex)))))))
+
+  (testing "a duplicate is not what stopped it — the branch is refused for its
+            KIND, before any member is ever looked at"
+    (is (re-find #"selects a SET" (:refused (select-for "[#?@(:clj #{:a :b})]" #{:clj}))))))
+
+;; ---------------------------------------------------------------------------
+;; 3 — the valid splice is untouched
+;; ---------------------------------------------------------------------------
+
+(deftest a-list-or-vector-splice-stays-eligible
+  (testing "splices whose selected branch is a list or vector on every target
+            keep splicing and the view stays eligible — refusing the unspliceable
+            must not cost the spliceable"
+    (is (= [{:view-id           :re-frame.freehand.check-splice-branch-views/splice-branch-uniform
+             :compile-eligible? true
+             :findings          []}]
+           (mapv #(select-keys % [:view-id :compile-eligible? :findings])
+                 (check/check-file uniform-path)))))
+
+  (testing "and resolution still splices a vector and a list, member for member"
+    (is (= [:a :b] (resolve-conditionals (read-string {:read-cond :preserve} "[#?@(:clj [:a :b])]") #{:clj})))
+    (is (= [:a :b] (resolve-conditionals (read-string {:read-cond :preserve} "[#?@(:clj (:a :b))]") #{:clj})))))
+
+;; ---------------------------------------------------------------------------
+;; 4 — symmetry, and the branch that is not selected
+;; ---------------------------------------------------------------------------
+
+(deftest the-refusal-follows-the-target
+  (testing "nothing here is :cljs-specific — the JVM target is refused by the
+            same rule when the branch it selects is the set"
+    (let [src "[#?@(:clj #{:a} :cljs [:b])]"]
+      (is (= [:b] (:read (select-for src #{:cljs}))) "the :cljs vector splices")
+      (is (re-find #"selects a SET" (:refused (select-for src #{:clj})))
+          "and the :clj set is refused for :clj")))
+
+  (testing "and an invalid branch the target does NOT select is not the target's
+            problem — the checker reads it, exactly as the real reader does,
+            because that set is elided for this target and never spliced"
+    (let [src "[#?@(:clj #{:a} :cljs [:b])]"]
+      (is (= [:b] (:read (select-for src #{:cljs}))))
+      (is (= [:b] (:read (read-for   src #{:cljs}))) "independently, per clojure.tools.reader"))))
+
+;; ---------------------------------------------------------------------------
+;; 5 — read-only
+;; ---------------------------------------------------------------------------
+
+(deftest the-checker-never-writes
+  (testing "refusing a splice is still read-only — the source pointed at is
+            byte-identical afterwards, refused run included"
+    (doseq [path [uniform-path (temp-view "set-branch") (temp-view "map-branch")]]
+      (let [before (java.nio.file.Files/readAllBytes (.toPath (io/file path)))
+            _      (thrown-by #(check/check-file path))
+            after  (java.nio.file.Files/readAllBytes (.toPath (io/file path)))]
+        (is (pos? (alength before)) (str path " is not empty"))
+        (is (java.util.Arrays/equals ^bytes before ^bytes after))))))

--- a/implementation/freehand/test/re_frame/freehand/check_splice_branch_views.cljc
+++ b/implementation/freehand/test/re_frame/freehand/check_splice_branch_views.cljc
@@ -1,0 +1,30 @@
+(ns re-frame.freehand.check-splice-branch-views
+  "The control for `check-splice-branch-jvm-test`: `#?@` splices whose selected
+  branch is a LIST or VECTOR on every target — the shapes a real reader splices.
+
+  Refusing the splices a target's reader refuses is only worth anything if the
+  splices it accepts stay accepted. A `#?@` copies its branch's members into the
+  surrounding form and the target reader requires that branch to implement
+  `java.util.List`, so a list or a vector splices and a set or map does not. All
+  three splices below select a list or vector on both targets — a divergent
+  vector, a divergent list, and a vector spliced into a SET — so every target
+  gets a well-formed collection and this view is inside the grammar wherever it
+  is compiled. The checker must say so.
+
+  Nothing invalid lives in this file, and nothing invalid can: a `#?@` whose
+  `:cljs` selection is a set or map does not READ, and would break the browser
+  build of this test tree. The refused shapes are written to a temp file by the
+  suite itself, loaded, checked, and thrown away.
+
+  Loaded on the JVM (required by
+  `re-frame.freehand.check-splice-branch-jvm-test`)."
+  (:require [re-frame.freehand :as v]))
+
+(v/defview splice-branch-uniform
+  "Splices whose selected branch is a list or vector on every target - eligible
+  wherever it is compiled."
+  [_]
+  [:div {:data-vec  (str [#?@(:clj [:a :b] :cljs [:c])])
+         :data-list (str [#?@(:clj (:a :b) :cljs (:c))])
+         :data-set  (str #{#?@(:clj [:a] :cljs [:b :c])})}
+   "splices whose branches are all lists or vectors"])


### PR DESCRIPTION
## Problem

The shared `resolve-children` splice arm called `(seq branch)` for **any** selected `#?@` branch. A real Clojure/CLJS reader only splices a branch implementing `java.util.List` (ordinary lists and vectors); a selected **set** or **map** is refused with *"Spliced form list in read-cond-splicing must implement java.util.List."* With conditionals preserved and each target's branch selected by the checker itself, a declaration whose selected `#?@` branch was a set or map was sequenced anyway (a set into its members, a map into its entries), analyzed, and reported `:compile-eligible? true` — a green about a splice the target reader cannot read.

Repro (from the bead): a JVM-loadable `.cljc` view whose `:cljs` `#?@` supplies a set to a splice —

```clojure
(v/defview subject [_]
  [:div {:title (str #{#?@(:clj [:a] :cljs #{:b :c})})} "x"])
```

`clojure.tools.reader` with `:features #{:cljs}` refuses it; `check/check-file` previously returned `:compile-eligible? true`.

## Fix

Guard the splice arm in `resolve-children` with `sequential?`: a selected list or vector splices exactly as before; a selected set or map is refused at the same boundary the target reader draws, via a new private `refuse-unspliceable-branch!`. The refusal reuses the existing `::unreadable` recovery path — `read-declarations` prefixes the file and target — so there is **no new diagnostic id, no custom reader, no general collection validator, and no public API change**. The message names the target and gives both existing recoveries (whole-conditional and list-or-vector). Valid vector/list splices and unselected branches are unchanged; source bytes are never touched.

Files changed:
- `implementation/freehand/src/re_frame/freehand/compiler/check.cljc` — the guard + `refuse-unspliceable-branch!` + docstrings.
- `implementation/freehand/test/re_frame/freehand/check_splice_branch_jvm_test.clj` — new adversarial/negative suite.
- `implementation/freehand/test/re_frame/freehand/check_splice_branch_views.cljc` — new id-neutral control fixture (valid list/vector splices only, so it compiles for CLJS).

### Tests

- **Equivalence, both directions** against an independent reader (`clojure.tools.reader`, no unconditional platform feature): a 24-row table (8 refused / 16 read) where checker selection and the real reader agree on every row.
- **Public `check-file` regressions** for the bead's **set-** and **map-**valued selected splice, written to a temp file (their `:cljs` branch does not read for a CLJS build, so they cannot be committed), asserting a refusal — not `:compile-eligible? true` — that names the file, the branch kind, the target, and the recovery, with the independent reader proving the same verdict.
- **Valid list/vector controls** stay eligible; **target symmetry** (a set selected on `:clj` is refused for `:clj`, and an invalid branch the target does *not* select reads); **read-only** after a refused run.

## Quality gates

| Gate | Command | Exit | Result |
|------|---------|------|--------|
| Freehand JVM suite | `clojure -M:test` (in `implementation/freehand`) | 0 | Ran 700 tests, 5067 assertions, 0 failures, 0 errors |
| Freehand CLJS node | `npm run test:freehand` (in `implementation`) | 0 | Ran 624 tests, 4035 assertions, 0 failures, 0 errors (build: 321 files, 0 warnings) |
| New suite (focused) | `clojure -M:test -n re-frame.freehand.check-splice-branch-jvm-test` | 0 | Ran 5 tests, 75 assertions, 0 failures, 0 errors |

Cross-ref: bead rf2-7xgq4 (gh-6739). Merge of PR #6739 introduced the two-way oracle framing; this closes the splice arm that still sequenced non-List branches.