### PR TITLE
fix(freehand): rollback-safe root preflight ownership boundary (rf2-drpa3.109)

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/root.cljs
+++ b/implementation/freehand/src/re_frame/freehand/root.cljs
@@ -98,6 +98,34 @@
   already using it are untouched: a bad plan affects exactly the roots
   carrying it.
 
+  ## Preflight is also the ownership boundary
+
+  Running the plan before React makes preflight the first thing a mount
+  WRITES, and that splits every mount in two.
+
+  AHEAD of it goes everything that can still fail on the SHAPE of the
+  call — the opts, the identity, the three claims, and building the root's
+  element. None of those has written anything, so a rejection there is
+  free: no frame, no ledger record, no claim, nothing to give back. That
+  is the same property the three admission claims have, and it is strictly
+  better than any rollback, so the ordering is arranged to extend it as
+  far as it will go.
+
+  AFTER it, the document is not necessarily the one this mount was
+  admitted against. `:initial-events` are application code running before
+  React, and application code can mount a root, unmount one, or take the
+  container. So the claim is re-asserted ([[recheck-claim!]]) and a mount
+  whose ground moved refuses — `:rf.error/root-container-in-use` when its
+  own plan took the container, `:rf.error/root-not-live` when the
+  incumbent it was going to re-render is gone — rather than allocating a
+  host root over whatever moved onto it.
+
+  What is left outstanding past that point is small and enumerable: a host
+  root React handed over, and the frame reference preflight took. A
+  failure gives back exactly those two and nothing else — never an
+  incumbent's reference and never a sibling's — and re-raises the original
+  error unchanged ([[attempt!]]).
+
   ## Hydration — identity from the wire, then adopt the server's DOM
 
   A hydrating root does not derive its identity; it READS it. The server
@@ -456,7 +484,11 @@
   Every arm here throws before any React work and before any registry or
   ledger mutation, so a rejected root leaves the document exactly as it
   found it — the existing roots keep rendering, and nothing has to be
-  rolled back because nothing was written."
+  rolled back because nothing was written.
+
+  Read-only and cheap, which is why it is also what [[recheck-claim!]]
+  runs a second time once the frame plan has had its chance to move the
+  document underneath the mount."
   [where dom-node root-id prefix]
   (require-container! where root-id dom-node)
   (let [^Root existing (get @live-roots root-id)]
@@ -527,6 +559,48 @@
                   :existing  (.-identifier-prefix existing)}}))
   nil)
 
+(defn- recheck-claim!
+  "Re-assert the admission claims AFTER preflight, and require the same
+  answer they gave before it.
+
+  A plan's `:initial-events` are application code, and they run BEFORE
+  React — so by the time preflight returns, the document is not
+  necessarily the one this mount was admitted against. A handler that
+  mounts a root has taken the container; a handler that unmounts one has
+  taken the incumbent away. Re-asserting is three reads over a handful of
+  roots, and it is the whole difference between refusing and clobbering.
+
+  [[claim!]] itself raises the ordinary admission diagnostics for every way
+  the document can move under a DIFFERENT id. What is left for here is the
+  two ways it can move and still answer: an id and container that were free
+  and are now taken, and an incumbent that is no longer the one captured."
+  [where dom-node root-id prefix ^Root admitted]
+  (let [^Root now (claim! where dom-node root-id prefix)]
+    (when-not (identical? now admitted)
+      (if (some? admitted)
+        (error/throw-error!
+          :rf.error/root-not-live where
+          (str "the live root under " (pr-str root-id) " is no longer the one this "
+               "mount was admitted to re-render — the frame plan unmounted it, or a "
+               "newer root claimed the id while the plan ran. Rendering through the "
+               "handle captured before the plan would render into a host root React "
+               "has already discarded, and registering it would overwrite whatever "
+               "holds the id now.")
+          {:recovery :recreate-the-root
+           :extra    {:root-id root-id}})
+        (error/throw-error!
+          :rf.error/root-container-in-use where
+          (str "that container was free when this mount was admitted and is now owned "
+               "by the live root " (pr-str (:root-id (.-descriptor now))) " — this "
+               "mount's own frame plan took it. A plan's :initial-events run BEFORE "
+               "React, so a handler that mounts a root wins the container; a second "
+               "host root on that node would tear the first one's tree down and "
+               "re-seed it.")
+          {:recovery :unmount-the-owning-root-first
+           :extra    {:root-id       root-id
+                      :owner-root-id (:root-id (.-descriptor now))}})))
+    now))
+
 ;; ---------------------------------------------------------------------------
 ;; Preflight — the frame plan, before React
 ;; ---------------------------------------------------------------------------
@@ -559,9 +633,11 @@
                {:value (error/diag-value-summary frame-opt)})))
 
 (defn- preflight!
-  "Run `plan` to completion and answer the frame-id the root binds. Called
+  "Run `plan` to completion, and answer the frame-id it bound. Called
   BEFORE `createRoot`, so a body that reads a subscription on its first
-  render finds a seeded frame rather than an empty one.
+  render finds a seeded frame rather than an empty one — and called after
+  every step that can fail on the shape of the call, so a rejected mount
+  never reaches it.
 
   The ledger is what makes several roots over one frame honest. An equal
   fingerprint is the ratified idempotent no-op — the frame is NOT re-seeded,
@@ -616,6 +692,17 @@
                 :installed-by       (if owned? (or (:installed-by r) root-id) (:installed-by r))
                 :refs               (conj (or (:refs r) #{}) root-id)}))
       frame-id)))
+
+(defn- frame-ref-held?
+  "True when `root-id` ALREADY references `frame-id` in the ledger.
+
+  Read BEFORE preflight, so an attempt that fails after it can tell the
+  reference IT took from one the incumbent — or a sibling root — was
+  already holding. Giving back a reference this attempt never took is how
+  a rollback turns one failure into two."
+  [frame-id root-id]
+  (boolean (and (some? frame-id)
+                (contains? (:refs (get @frame-ledger frame-id)) root-id))))
 
 (defn- release-frame!
   "Drop `root-id`'s reference to its frame, and destroy the frame when a
@@ -725,28 +812,40 @@
   (swap! live-roots assoc root-id root)
   root)
 
-(defn- abort!
-  "Undo an attempt that allocated a host root and then threw. The claim was
-  never written, so what has to come back is exactly what was: the React
-  root React just handed us, and this root's reference to its frame."
-  [react-root frame-id root-id thrown]
-  (try (.unmount react-root) (catch :default _ nil))
-  (release-frame! frame-id root-id)
-  (throw thrown))
+(defn- attempt!
+  "Run the post-preflight half of a mount, giving back exactly what this
+  attempt took if it throws.
+
+  Preflight is the first thing a mount WRITES, and everything ahead of it
+  is ordered so a rejection there has nothing to undo. What can be
+  outstanding after it is therefore small and enumerable: the host root
+  React hands over, and — when `acquired?` — the frame reference preflight
+  took for this root. `body` reports the host root through the `keep!` it
+  is handed, the moment React returns one; an INCUMBENT's host root is
+  never reported, because a failed re-render must leave the incumbent
+  rendering exactly as it was.
+
+  The original failure stays primary: the give-back is best-effort, and
+  the throw is re-raised unchanged."
+  [frame-id root-id acquired? body]
+  (let [host (volatile! nil)]
+    (try
+      (body (fn keep! [react-root] (vreset! host react-root) react-root))
+      (catch :default e
+        (when-some [react-root @host]
+          (try (.unmount react-root) (catch :default _ nil)))
+        (when acquired? (release-frame! frame-id root-id))
+        (throw e)))))
 
 (defn- client-render!
   "Allocate a host root, render `element` into it, and register the result
   — the shared tail of a fresh [[mount]] and of [[hydrate-root]]'s
-  fallback. Both are ordinary client renders, and both must give back the
-  host root they just allocated if the render throws."
-  [desc dom-node prefix opts frame-id element]
-  (let [root-id    (:root-id desc)
-        react-root (rdc/createRoot dom-node (root-options prefix opts nil))]
-    (try
-      (.render react-root element)
-      (register! root-id (->Root desc dom-node react-root prefix frame-id false))
-      (catch :default e
-        (abort! react-root frame-id root-id e)))))
+  fallback. Both are ordinary client renders, and both hand the host root
+  they allocate to `keep!` so a render that throws gives it back."
+  [desc dom-node prefix opts frame-id element keep!]
+  (let [react-root (keep! (rdc/createRoot dom-node (root-options prefix opts nil)))]
+    (.render react-root element)
+    (register! (:root-id desc) (->Root desc dom-node react-root prefix frame-id false))))
 
 (defn mount
   "Mount the declared view at `root-form`'s head into `dom-node`, and
@@ -778,24 +877,39 @@
          prefix         (or (:identifier-prefix opts)
                             (root-id/default-identifier-prefix root-id))
          plan           (plan-for 'v/mount (:frame opts))
-         ^Root existing (claim! 'v/mount dom-node root-id prefix)]
-     ;; Before preflight, because a refused root must not have run one — and
-     ;; only a mount reaches here with a root it intends to REUSE.
+         frame-id       (:frame-id plan)
+         ^Root existing (claim! 'v/mount dom-node root-id prefix)
+         ;; The element BEFORE preflight. Building it is the last step that
+         ;; can fail on the SHAPE of the call, and preflight is the FIRST
+         ;; step that writes anything — so a malformed root form is refused
+         ;; with no frame created, no ledger record and no claim to give
+         ;; back. It needs the frame's id and nothing else, which the plan
+         ;; already carries: the provider wrapper names a frame, it does
+         ;; not read one.
+         element        (root-element root-form frame-id nil)
+         acquired?      (and (some? frame-id) (not (frame-ref-held? frame-id root-id)))]
+     ;; The fourth admission claim, before preflight because a refused root
+     ;; must not have run one: the effective identifierPrefix a live root was
+     ;; created with is immutable across a re-mount.
      (require-stable-identifier-prefix! 'v/mount root-id prefix existing)
-     (let [frame-id (preflight! 'v/mount plan root-id)
-           element  (root-element root-form frame-id nil)]
-       (if (some? existing)
-         ;; The reload path: the same host root, re-rendered. No createRoot,
-         ;; so nothing downstream is reseeded; the descriptor snapshot is
-         ;; refreshed because the mounted view object may be a fresh
-         ;; generation, but the identity it keys on is unchanged — and its
-         ;; prefix is the one the claim above just proved unmoved.
-         (let [react-root (.-react-root existing)
-               root       (->Root desc dom-node react-root prefix frame-id
-                                  (.-hydrated existing))]
-           (.render react-root element)
-           (register! root-id root))
-         (client-render! desc dom-node prefix opts frame-id element))))))
+     (preflight! 'v/mount plan root-id)
+     (attempt!
+       frame-id root-id acquired?
+       (fn [keep!]
+         (recheck-claim! 'v/mount dom-node root-id prefix existing)
+         (if (some? existing)
+           ;; The reload path: the same host root, re-rendered. No createRoot,
+           ;; so nothing downstream is reseeded; the descriptor snapshot is
+           ;; refreshed because the mounted view object may be a fresh
+           ;; generation, but the identity it keys on is unchanged. That host
+           ;; root belongs to the INCUMBENT, so it is not handed to `keep!`:
+           ;; a re-render that fails leaves the incumbent rendering.
+           (let [react-root (.-react-root existing)
+                 root       (->Root desc dom-node react-root prefix frame-id
+                                    (.-hydrated existing))]
+             (.render react-root element)
+             (register! root-id root))
+           (client-render! desc dom-node prefix opts frame-id element keep!)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; hydrate-root
@@ -866,12 +980,19 @@
         root-id  (:root-id ident)
         prefix   (root-id/default-identifier-prefix root-id)
         plan     (plan-for 'v/hydrate-root (:frame opts))
+        frame-id (:frame-id plan)
         existing (claim! 'v/hydrate-root dom-node root-id prefix)]
     ;; Before preflight, because a rejected root must not have run one.
     (require-fresh-root! existing root-id)
-    (let [frame-id (preflight! 'v/hydrate-root plan root-id)]
-      (client-render! (descriptor-for ident) dom-node prefix opts frame-id
-                      (root-element root-form frame-id nil)))))
+    (let [element   (root-element root-form frame-id nil)
+          acquired? (and (some? frame-id) (not (frame-ref-held? frame-id root-id)))]
+      (preflight! 'v/hydrate-root plan root-id)
+      (attempt!
+        frame-id root-id acquired?
+        (fn [keep!]
+          (recheck-claim! 'v/hydrate-root dom-node root-id prefix existing)
+          (client-render! (descriptor-for ident) dom-node prefix opts frame-id
+                          element keep!))))))
 
 (defn- adopt!
   "The ADOPTION path: `manifest` is the server's own account of what it
@@ -890,18 +1011,27 @@
                    (assoc :view-id (:view-id (descriptor/describe (head-view root-form)))))
         prefix   (:identifier-prefix manifest)
         plan     (plan-for 'v/hydrate-root (:frame opts))
+        frame-id (:frame-id plan)
         existing (claim! 'v/hydrate-root dom-node root-id prefix)]
     (require-fresh-root! existing root-id)
-    (let [frame-id   (preflight! 'v/hydrate-root plan root-id)
-          adoption   #js {:adopting true}
-          reporter   (hydration-reporter adoption root-id (:on-recoverable-error opts))
-          closer     (react/createElement adoption-window-closer
-                                          #js {:key "rf-adoption" :rfAdoption adoption})
-          element    (root-element root-form frame-id [closer])
-          react-root (rdc/hydrateRoot dom-node element
-                                      (root-options prefix opts reporter))]
-      (register! root-id (->Root (descriptor-for ident) dom-node react-root
-                                 prefix frame-id true)))))
+    ;; The adoption window, its reporter and the element they ride on are
+    ;; all built BEFORE preflight, for the same reason the element is: they
+    ;; are construction, they can fail, and preflight is what writes.
+    (let [adoption  #js {:adopting true}
+          reporter  (hydration-reporter adoption root-id (:on-recoverable-error opts))
+          closer    (react/createElement adoption-window-closer
+                                         #js {:key "rf-adoption" :rfAdoption adoption})
+          element   (root-element root-form frame-id [closer])
+          acquired? (and (some? frame-id) (not (frame-ref-held? frame-id root-id)))]
+      (preflight! 'v/hydrate-root plan root-id)
+      (attempt!
+        frame-id root-id acquired?
+        (fn [keep!]
+          (recheck-claim! 'v/hydrate-root dom-node root-id prefix existing)
+          (let [react-root (keep! (rdc/hydrateRoot dom-node element
+                                                   (root-options prefix opts reporter)))]
+            (register! root-id (->Root (descriptor-for ident) dom-node react-root
+                                       prefix frame-id true))))))))
 
 (defn hydrate-root
   "Adopt the server-rendered markup already in `dom-node` for the declared

--- a/implementation/freehand/test/re_frame/freehand/root_preflight_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/root_preflight_dom_cljs_test.cljs
@@ -16,6 +16,24 @@
   before React, and the incumbent — the frame, its value, and the sibling
   root already rendering against it — is untouched.
 
+  ## The boundary the ordering creates
+
+  Running the plan before React makes preflight the first thing a mount
+  WRITES, and that splits the mount in two. What comes before it can fail
+  with nothing to undo, so the last step that can fail on the shape of the
+  call — building the root's element — is put there. What comes after it
+  is looking at a document the plan itself was free to change:
+  `:initial-events` are application code running before React, and
+  application code can mount a root, unmount one, or take the container.
+  So the claim is re-asserted after the plan, and a mount whose ground
+  moved refuses rather than allocating a host root over whatever moved
+  onto it.
+
+  The four tests at the foot of this file are that boundary from both
+  sides, and the fourth is the one that keeps the other three honest: an
+  ordinary re-mount still goes through. A fence strict enough to refuse a
+  hot reload would be a worse defect than the one it closed.
+
   This file rides the browser lane through its `-dom-cljs-test` namespace
   suffix. It also matches the node suites' broader regex, where it has no
   DOM to mount and says so rather than passing quietly."
@@ -204,4 +222,195 @@
                      (fn [e]
                        (is false (str "conflict suite rejected: " e))
                        (.remove node) (.remove rejected)
+                       (done)))))))))
+
+;; ===========================================================================
+;; FH-ROOT-004 — the preflight boundary, from both sides
+;; ===========================================================================
+
+(def ^:private boundary (:boundary root-004))
+
+(deftest fh-root-004-a-call-shape-failure-precedes-every-write
+  (testing "Per FH-ROOT-004 (browser): preflight is the first thing a mount
+            WRITES, so everything that can still fail on the shape of the
+            call happens before it. Building the root's element is the last
+            such step, and a bad props slot at the head is the cheapest way
+            to make it fail: the view is declared, so identity and the three
+            claims all resolve, and the rejection lands after them. What the
+            counts prove is that there was nothing to roll back — no frame,
+            no ledger record, no registry claim, no DOM — and the immediate
+            corrected retry proves the refusal left no residue behind it
+            either."
+    (if-not (browser?)
+      (skip! "the browser job runs the boundary assertions")
+      (async done
+        (reg!)
+        (let [node (host-node!)
+              bad  (:bad-props boundary)
+              fid  (:frame-id bad)
+              plan {:frame {:id fid :initial-events [[:root/seed (:seeded bad)]]}}]
+          (is (= (:error bad)
+                 (error-id #(v/mount [views/counter nil] node plan)))
+              "a non-map props slot fails the element build")
+          (is (= (:frame-live bad) (some? (frame/frame fid)))
+              "the plan never ran — no frame was created")
+          (is (= (:ledger-entries bad) (count (root/frame-ledger-snapshot)))
+              "and no ledger record was written")
+          (is (= (:live-roots bad) (count (root/live-root-ids)))
+              "nothing was registered")
+          (is (= (:container-children bad) (.-childElementCount node))
+              "and nothing reached the container")
+          (-> (act #(v/mount [views/counter {}] node plan))
+              (.then (fn [mounted]
+                       (is (= (:retry-text bad) (text node ".count"))
+                           "the corrected call is an ordinary successful mount —
+                            the refusal left no residue for it to trip over")
+                       (act #(v/unmount! mounted))))
+              (.then (fn [_] (.remove node) (done))
+                     (fn [e]
+                       (is false (str "bad-props boundary suite rejected: " e))
+                       (.remove node)
+                       (done)))))))))
+
+(deftest fh-root-004-a-re-entrant-plan-keeps-the-container-it-took
+  (testing "Per FH-ROOT-004 (browser): `:initial-events` run before React and
+            are ordinary application code, so a handler is free to mount a
+            root — including into the very container this mount was admitted
+            for. The claim taken before the plan is stale by the time the
+            plan returns, so it is taken again: the inner root owns the
+            container, and the outer attempt refuses rather than allocating
+            a second host root over it, which would tear the inner root's
+            tree down and re-seed it. The refusal gives back exactly what the
+            attempt took — the frame reference its own preflight acquired,
+            and nothing else."
+    (if-not (browser?)
+      (skip! "the browser job runs the re-entrancy assertions")
+      (async done
+        (reg!)
+        (let [node  (host-node!)
+              re-in (:re-entrant boundary)
+              fid   (:frame-id re-in)
+              inner (atom nil)]
+          (rf/reg-event :root/mount-inner (fn [_ _] {:fx [[:root/mount-inner true]]}))
+          (rf/reg-fx :root/mount-inner
+                     (fn [_ _]
+                       (reset! inner
+                               (v/mount [views/app {:label "inner"}] node
+                                        {:root-id (:inner-root-id re-in)}))))
+          (-> (act (fn []
+                     (is (= (:error re-in)
+                            (error-id
+                              (fn []
+                                (v/mount [views/counter {}] node
+                                         {:frame {:id             fid
+                                                  :initial-events [[:root/mount-inner]]}}))))
+                         "the outer mount refuses the container its own plan gave away")))
+              (.then
+                (fn [_]
+                  (is (= (:live-root-ids re-in) (root/live-root-ids))
+                      "the re-entrant root is the only live root — it kept the
+                       container, and the outer attempt registered nothing")
+                  (is (= (:ledger-entries re-in) (count (root/frame-ledger-snapshot)))
+                      "the outer attempt gave back the frame reference it took")
+                  (is (= (:frame-live re-in) (some? (frame/frame fid)))
+                      "and with no reference left, the frame it installed is gone")
+                  (act #(v/unmount! @inner))))
+              (.then (fn [_] (.remove node) (done))
+                     (fn [e]
+                       (is false (str "re-entrancy suite rejected: " e))
+                       (.remove node)
+                       (done)))))))))
+
+(deftest fh-root-004-a-superseded-incumbent-is-never-rendered-through
+  (testing "Per FH-ROOT-004 (browser): a re-mount captures the live root it is
+            going to re-render BEFORE running the plan, and the plan can
+            unmount it. Rendering through the captured handle afterwards
+            would render into a host root React has already discarded, and
+            registering it would overwrite whatever legitimately holds the id
+            now. So the incumbent is re-read after the plan and a supersession
+            fails loud — :rf.error/root-not-live, the same diagnostic a stale
+            handle earns anywhere else."
+    (if-not (browser?)
+      (skip! "the browser job runs the supersession assertions")
+      (async done
+        (reg!)
+        (let [node  (host-node!)
+              sup   (:superseded boundary)
+              fid   (:frame-id sup)
+              first-root (atom nil)]
+          (rf/reg-event :root/unmount-first (fn [_ _] {:fx [[:root/unmount-first true]]}))
+          (rf/reg-fx :root/unmount-first (fn [_ _] (v/unmount! @first-root)))
+          (-> (act #(v/mount [views/app {:label "first"}] node))
+              (.then
+                (fn [mounted]
+                  (reset! first-root mounted)
+                  (act (fn []
+                         (is (= (:error sup)
+                                (error-id
+                                  (fn []
+                                    (v/mount [views/app {:label "second"}] node
+                                             {:frame {:id             fid
+                                                      :initial-events [[:root/unmount-first]]}}))))
+                             "the re-mount refuses a handle its own plan unmounted")))))
+              (.then
+                (fn [_]
+                  (is (= (:live-roots sup) (count (root/live-root-ids)))
+                      "the plan's unmount stands; the refused re-mount registered
+                       nothing over it")
+                  (is (= (:ledger-entries sup) (count (root/frame-ledger-snapshot)))
+                      "and gave back the frame reference its preflight took")
+                  (is (= (:frame-live sup) (some? (frame/frame fid)))
+                      "so the frame it installed is gone too")
+                  (.remove node)
+                  (done))
+                (fn [e]
+                  (is false (str "supersession suite rejected: " e))
+                  (.remove node)
+                  (done)))))))))
+
+(deftest fh-root-004-an-ordinary-re-mount-is-still-admitted
+  (testing "Per FH-ROOT-004 (browser): the other direction, and the one that
+            keeps the three refusals above honest. A re-mount under the same
+            id, into the same container, under the same plan is the RELOAD
+            path: it must be admitted, it must re-render, and it must not
+            re-seed. A fence strict enough to refuse it would be a worse
+            defect than the one it closed, and a fence that let the plan
+            re-run would silently reset the frame. The setup COUNT is what
+            separates those two — the rendered text cannot, because a
+            replayed seed writes the same value back."
+    (if-not (browser?)
+      (skip! "the browser job runs the idempotent-re-mount assertions")
+      (async done
+        (reg!)
+        (let [node  (host-node!)
+              idem  (:idempotent boundary)
+              fid   (:frame-id idem)
+              setup (atom 0)
+              plan  {:frame {:id             fid
+                             :initial-events [[:root/seed (:seeded idem)]
+                                              [:root/count-setup]]}}]
+          (rf/reg-event :root/count-setup (fn [_ _] {:fx [[:root/count-setup true]]}))
+          (rf/reg-fx :root/count-setup (fn [_ _] (swap! setup inc)))
+          (-> (act #(v/mount [views/counter {}] node plan))
+              (.then (fn [_]
+                       (is (= (:text idem) (text node ".count")))
+                       (act #(v/mount [views/counter {}] node plan))))
+              (.then
+                (fn [remounted]
+                  (is (= (:text idem) (text node ".count"))
+                      "the re-mount re-rendered")
+                  (is (= (:setup-runs idem) @setup)
+                      "and did NOT re-seed — the plan met its own frame under its
+                       own fingerprint, which is the ratified no-op")
+                  (is (= (:live-roots idem) (count (root/live-root-ids)))
+                      "one live root, not two")
+                  (is (= (:ledger-entries idem) (count (root/frame-ledger-snapshot)))
+                      "one ledger record")
+                  (is (= (:frame-live idem) (some? (frame/frame fid)))
+                      "and the frame the root still references is still live")
+                  (act #(v/unmount! remounted))))
+              (.then (fn [_] (.remove node) (done))
+                     (fn [e]
+                       (is false (str "idempotent re-mount suite rejected: " e))
+                       (.remove node)
                        (done)))))))))

--- a/spec/conformance/freehand/fixtures/fh-root-004.edn
+++ b/spec/conformance/freehand/fixtures/fh-root-004.edn
@@ -54,4 +54,72 @@
  ;; The rejected root left nothing: no host root on its container, no
  ;; registry entry, no second ledger record.
  :rejected-container-children 0
- :ledger-entries-after 1}
+ :ledger-entries-after 1
+
+ ;; ---------------------------------------------------------------------
+ ;; The preflight is also an OWNERSHIP BOUNDARY, and it has two sides.
+ ;;
+ ;; BEFORE it, nothing has been written — so everything that can still
+ ;; fail on the shape of the call belongs there, and a rejection has
+ ;; nothing to undo. Building the root's element is the last such step,
+ ;; and a bad props slot is the cheapest way to make it fail.
+ ;;
+ ;; AFTER it, the document is no longer the one the mount was admitted
+ ;; against: `:initial-events` are arbitrary application code, and code
+ ;; that runs before React can mount a root, unmount one, or take the
+ ;; container. So the claim is re-asserted, and a mount whose ground
+ ;; moved refuses instead of clobbering what moved onto it.
+ ;;
+ ;; Both refusals are LOUD and both give back exactly what the attempt
+ ;; took — never a sibling's frame reference, and never the incumbent's.
+ ;; ---------------------------------------------------------------------
+ :boundary
+ {;; Before: the root form's head is a declared view, so identity and
+  ;; the claims resolve; `nil` in the props slot then fails when the
+  ;; element is built. Preflight never ran, so there is no frame, no
+  ;; ledger record, no claim and no DOM — and the corrected call
+  ;; immediately after is an ordinary successful mount.
+  :bad-props {:frame-id           :fh.root/boundary-bad-props
+              :seeded             7
+              :error              :rf.error/view-bad-props
+              :frame-live         false
+              :ledger-entries     0
+              :live-roots         0
+              :container-children 0
+              :retry-text         "7"}
+
+  ;; After, fresh root: the plan mounts a root into THIS mount's own
+  ;; container. The inner root is live and registered; the outer attempt
+  ;; refuses rather than allocate a second host root over it.
+  :re-entrant {:frame-id       :fh.root/boundary-re-entrant
+               :inner-root-id  :fh.root/boundary-inner
+               :error          :rf.error/root-container-in-use
+               :live-root-ids  #{:fh.root/boundary-inner}
+               :ledger-entries 0
+               :frame-live     false}
+
+  ;; After, live root: the plan unmounts the very root this re-mount was
+  ;; admitted to re-render. The captured handle names a host root React
+  ;; has already discarded.
+  :superseded {:frame-id       :fh.root/boundary-superseded
+               :error          :rf.error/root-not-live
+               :live-roots     0
+               :ledger-entries 0
+               :frame-live     false}
+
+  ;; And the other direction, which matters at least as much: an
+  ;; ORDINARY re-mount — same id, same container, same plan — is still
+  ;; admitted, still re-renders, and still does not re-seed. A fence
+  ;; strict enough to refuse this would be worse than the defect.
+  ;;
+  ;; "Did not re-seed" is counted rather than inferred: one setup step
+  ;; increments a counter, and the count after the re-mount is still one.
+  ;; The rendered text cannot tell the two apart — a replayed seed writes
+  ;; the same value back.
+  :idempotent {:frame-id       :fh.root/boundary-idempotent
+               :seeded         7
+               :text           "7"
+               :setup-runs     1
+               :live-roots     1
+               :ledger-entries 1
+               :frame-live     true}}}


### PR DESCRIPTION
Makes each Freehand `v/mount` / `v/hydrate-root` attempt one small ownership transaction.

- **Before preflight** goes the last step that can fail on the *shape* of the call — building the root element — so a malformed root form is refused with no frame created, no ledger record and no claim to give back. It needs only the frame id the plan already carries.
- **After preflight** (whose `:initial-events` are application code running before React), the exact root/container claim is re-asserted via `recheck-claim!`: `:rf.error/root-container-in-use` when the plan took the container, `:rf.error/root-not-live` when the captured incumbent is gone — instead of allocating a second host root over a live tree or rendering through a handle React already discarded.
- **On a synchronous post-preflight failure**, `attempt!` gives back exactly the host root React handed over plus the frame reference *this* attempt acquired, and re-raises the original error unchanged. An incumbent's reference is never released (the ledger is read before preflight to tell the two apart) and an incumbent's host root is never unmounted by a failed re-render. `v/hydrate-root` gets the same boundary on its fallback and adoption paths.

Both diagnostics are existing Spec 009 catalogue rows — no new coordinator, async framework, public API, or diagnostic id.

Resolves `rf2-drpa3.109`.

## What changed
- `implementation/freehand/src/re_frame/freehand/root.cljs` — element construction moved ahead of preflight; new `recheck-claim!` (post-preflight re-assertion) and `attempt!` (rollback of only the acquired frame reference).
- `implementation/freehand/test/re_frame/freehand/root_preflight_dom_cljs_test.cljs` — FH-ROOT-004 browser suite exercising the real rollback-on-failure path: the bad-props boundary, a re-entrant plan keeping the container it took, a superseded incumbent never rendered through, and an ordinary re-mount still admitted.
- `spec/conformance/freehand/fixtures/fh-root-004.edn` — exact-count fixture rows.

Rebased onto `origin/main`. The one conflict was in `root.cljs`, where main had independently landed the `require-stable-identifier-prefix!` admission claim (commit `377039bb1a`); the resolution keeps that claim and grafts it into the reordered mount body ahead of preflight, alongside the other admission claims.

## Quality gates
Run from `implementation/` (docs build from repo root), all non-vacuous:

| Gate | Command | Result | Exit |
|------|---------|--------|------|
| Freehand (node) | `npm run test:freehand` | Ran 642 tests containing 4117 assertions. 0 failures, 0 errors. | 0 |
| Browser | `npm run test:browser` | Ran 601 tests containing 3532 assertions. 0 failures, 0 errors. | 0 |
| Docs (strict) | `python -m mkdocs build --strict` | Documentation built in 23.41 seconds (no warnings under `--strict`). | 0 |
