### PR TITLE
fix(freehand): instance-unique error IDs for repeated pilot fields (rf2-drpa3.134)

### DIFF
--- a/implementation/freehand/test/re_frame/freehand/pilot_field.cljc
+++ b/implementation/freehand/test/re_frame/freehand/pilot_field.cljc
@@ -195,6 +195,38 @@
         :else                {}))))
 
 ;; ---------------------------------------------------------------------------
+;; Instance-unique ids for a control's error region
+;; ---------------------------------------------------------------------------
+
+(defn- id-token
+  "A DOM-safe token for one part of a control's identity, or nil when the
+  part is absent. `[:invoice 2 :reference]` becomes `invoice-2-reference`
+  and `\"description\"` stays `description`. Pure and stable, so the same
+  identity yields the same token on every render and after a list
+  reorder."
+  [part]
+  (when (some? part)
+    (let [t (-> (str part)
+                (str/replace #"[^A-Za-z0-9]+" "-")
+                (str/replace #"(^-+)|(-+$)" ""))]
+      (when-not (str/blank? t) t))))
+
+(defn error-region-id
+  "The id of a field's error region, and the target its control points
+  `aria-describedby` at, built from a `prefix` and the identity `parts`
+  the caller supplies to name ONE instance. Absent parts drop out, so a
+  single-instance field keeps the short `acme-field-<name>-error` while a
+  field the caller renders more than once earns
+  `acme-field-<instance>-<name>-error` and two same-named instances no
+  longer collide.
+
+  The library trusts the caller's identity to be distinct — exactly as
+  the buffered controller trusts its `:control` address (D004) — and
+  allocates, counts and polices nothing."
+  [prefix & parts]
+  (str/join "-" (concat [prefix] (keep id-token parts) ["error"])))
+
+;; ---------------------------------------------------------------------------
 ;; `field` — the controlled field. Props only: value in, intent out.
 ;; ---------------------------------------------------------------------------
 
@@ -210,7 +242,13 @@
 
   `:columns` is the one value the cascade cannot know, so it is the one
   value that rides as an inline custom property; everything else is a
-  `data-part` a stylesheet reaches."
+  `data-part` a stylesheet reaches.
+
+  `:instance` is the caller's instance identity — the domain thing this
+  particular field belongs to, such as an invoice line id. It is optional
+  because a single-instance call needs none, and it is what a caller
+  renders the same field name more than once supplies so the two error
+  regions get distinct ids rather than colliding."
   {:props [:map
            [:name :string]
            [:label :string]
@@ -219,9 +257,10 @@
            [:on-blur {:optional true} [:maybe :vector]]
            [:error {:optional true} [:maybe :string]]
            [:busy? {:optional true} :boolean]
-           [:columns {:optional true} :int]]}
-  [{:keys [name label value on-input on-blur error busy? columns]}]
-  (let [error-id (str "acme-field-" name "-error")]
+           [:columns {:optional true} :int]
+           [:instance {:optional true} :any]]}
+  [{:keys [name label value on-input on-blur error busy? columns instance]}]
+  (let [error-id (error-region-id "acme-field" instance name)]
     [:label {:data-component "acme/field"
              :data-part      "root"
              :data-field     name
@@ -273,7 +312,10 @@
   [{:keys [name label value on-commit error busy?] :as props}]
   (let [k        (control/record-key buffered-kind props)
         g        (control/reset-revision buffered-kind props)
-        error-id (str "acme-buffered-" name "-error")]
+        ;; The `:control` address already names this instance uniquely
+        ;; across the whole app (D004), so the error region borrows it and
+        ;; two lines' reference fields never share an id.
+        error-id (error-region-id "acme-buffered" (:control props))]
     [:label {:data-component "acme/buffered-field"
              :data-part      "root"
              :data-field     name
@@ -489,6 +531,7 @@
                              :prevent-default true}}
      [field {:name     "description"
              :label    "Description"
+             :instance id
              :value    (or (:description line) "")
              :columns  40
              :error    (v/sub [:acme.invoice/field-error id :description])
@@ -496,18 +539,21 @@
              :on-blur  [:acme.invoice/field-blurred id :description]}]
      [field {:name     "quantity"
              :label    "Quantity"
+             :instance id
              :value    (or (:quantity line) "")
              :error    (v/sub [:acme.invoice/field-error id :quantity])
              :on-input [:acme.invoice/field-edited id :quantity]
              :on-blur  [:acme.invoice/field-blurred id :quantity]}]
      [field {:name     "unit-price"
              :label    "Unit price"
+             :instance id
              :value    (or (:unit-price line) "")
              :error    (v/sub [:acme.invoice/field-error id :unit-price])
              :on-input [:acme.invoice/field-edited id :unit-price]
              :on-blur  [:acme.invoice/field-blurred id :unit-price]}]
      [field {:name     "account"
              :label    "Account"
+             :instance id
              :value    (or (:account line) "")
              :error    (v/sub [:acme.invoice/field-error id :account])
              :on-input [:acme.invoice/field-edited id :account]

--- a/implementation/freehand/test/re_frame/freehand/pilot_field_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/pilot_field_cljs_test.cljc
@@ -610,6 +610,94 @@
             (is (= "REF-1" (:value (t/attrs (control-of (buffered-node (first (roots)) "reference"))))))
             (is (= "REF-2" (:value (t/attrs (control-of (buffered-node (second (roots)) "reference"))))))))))))
 
+(deftest repeated-fields-emit-instance-unique-error-ids
+  (testing "rf2-drpa3.134. `invoice-lines` renders two lines at once, so
+            two controlled fields named \"description\" and two buffered
+            fields named \"reference\" sit on one page. Each field derives
+            its error-region id from the caller's instance identity — the
+            controlled field from its `:instance` line id, the buffered
+            field from its `:control` address — so the same field name
+            twice no longer collides, and every control's `aria-describedby`
+            resolves to its OWN region."
+    (each-mode
+      (fn [mode]
+        (seed-lines! [1 2])
+        ;; Every field invalid, and every gate open, so every error region
+        ;; renders: blank the descriptions, attempt submit on both lines,
+        ;; and give each reference a rejection reason to display.
+        (frame/replace-app-db! fid (-> (app-db)
+                                       (assoc-in [:invoice 1 :description] "")
+                                       (assoc-in [:invoice 2 :description] "")
+                                       (assoc-in [:invoice 1 :reference-error] "Not on file.")
+                                       (assoc-in [:invoice 2 :reference-error] "Not on file.")))
+        (send! [:acme.invoice/submit-attempted 1])
+        (send! [:acme.invoice/submit-attempted 2])
+        (let [tree     (render! (lines-form mode [1 2]))
+              roots    (nodes tree #(= "acme/invoice-line" (:data-component (:attrs %))))
+              [l1 l2]  roots
+              resolves? (fn [field-node]
+                          (let [ctl   (control-of field-node)
+                                err   (error-of field-node)
+                                by    (:aria-describedby (t/attrs ctl))]
+                            {:by by :id (:id (t/attrs err))}))]
+          (is (= 2 (count roots)) "non-vacuous: two lines rendered")
+
+          (testing "two same-named CONTROLLED fields do not collide"
+            (let [a (resolves? (field-node l1 "description"))
+                  b (resolves? (field-node l2 "description"))]
+              (is (not= (:id a) (:id b))
+                  "distinct error-region ids for the two \"description\" fields")
+              (is (= (:id a) (:by a)) "line 1's control points at line 1's region")
+              (is (= (:id b) (:by b)) "line 2's control points at line 2's region")))
+
+          (testing "and the two BUFFERED fields do not collide either"
+            (let [a (resolves? (buffered-node l1 "reference"))
+                  b (resolves? (buffered-node l2 "reference"))]
+              (is (not= (:id a) (:id b))
+                  "distinct error-region ids for the two \"reference\" fields")
+              (is (= (:id a) (:by a)))
+              (is (= (:id b) (:by b))))))))))
+
+(deftest an-error-id-is-stable-across-a-list-reorder
+  (testing "rf2-drpa3.134, acceptance 3. The id is a pure function of the
+            caller's instance identity, not of render position, so line 1's
+            description carries the SAME id whether it is rendered first or
+            second — an ordinary reorder migrates no ids."
+    (each-mode
+      (fn [mode]
+        (seed-lines! [1 2])
+        (frame/replace-app-db! fid (-> (app-db)
+                                       (assoc-in [:invoice 1 :description] "")
+                                       (assoc-in [:invoice 2 :description] "")))
+        (send! [:acme.invoice/submit-attempted 1])
+        (send! [:acme.invoice/submit-attempted 2])
+        (let [id-of (fn [ids position]
+                      (let [roots (nodes (render! (lines-form mode ids))
+                                         #(= "acme/invoice-line" (:data-component (:attrs %))))]
+                        (:id (t/attrs (error-of (field-node (nth roots position) "description"))))))]
+          (is (= (id-of [1 2] 0) (id-of [2 1] 1))
+              "line 1's description keeps its id when it moves to second position")
+          (is (= (id-of [1 2] 1) (id-of [2 1] 0))
+              "and line 2's likewise, when it moves to first"))))))
+
+(deftest a-single-instance-field-keeps-the-short-id
+  (testing "rf2-drpa3.134, acceptance 4. A field the caller renders once
+            supplies no instance, so its error id stays the short
+            `acme-field-<name>-error` — the single-instance call is
+            unchanged and no id allocator, registry or policing appears."
+    (each-mode
+      (fn [mode]
+        (seed-line! 1 {:description ""})
+        (send! [:acme.invoice/submit-attempted 1])
+        (let [solo (render! (form mode :field {:name     "description"
+                                               :label    "Description"
+                                               :value    ""
+                                               :error    "A description is required."
+                                               :on-input [:noop]}))]
+          (is (= "acme-field-description-error"
+                 (:id (t/attrs (error-of (field-node solo "description")))))
+              "no :instance, so no instance segment"))))))
+
 ;; ===========================================================================
 ;; R-A9 — asynchronous transform race safety
 ;; ===========================================================================
@@ -923,7 +1011,7 @@
       (fn [mode]
         (let [declared (:props-schema (v/describe (get-in modes [mode :field])))]
           (is (= :map (first declared)) "the schema is a literal map schema")
-          (is (= [:name :label :value :on-input :on-blur :error :busy? :columns]
+          (is (= [:name :label :value :on-input :on-blur :error :busy? :columns :instance]
                  (mapv first (rest declared)))
               "and names every prop the component takes, in order"))))))
 

--- a/implementation/freehand/test/re_frame/freehand/pilot_field_compiled.cljc
+++ b/implementation/freehand/test/re_frame/freehand/pilot_field_compiled.cljc
@@ -21,7 +21,7 @@
   promotion parity means."
   (:require [re-frame.freehand :as v]
             [re-frame.freehand.control :as control]
-            [re-frame.freehand.pilot-field :refer [buffered-kind]]))
+            [re-frame.freehand.pilot-field :refer [buffered-kind error-region-id]]))
 
 (v/defview field
   {:compiled true
@@ -33,9 +33,10 @@
               [:on-blur {:optional true} [:maybe :vector]]
               [:error {:optional true} [:maybe :string]]
               [:busy? {:optional true} :boolean]
-              [:columns {:optional true} :int]]}
-  [{:keys [name label value on-input on-blur error busy? columns]}]
-  (let [error-id (str "acme-field-" name "-error")]
+              [:columns {:optional true} :int]
+              [:instance {:optional true} :any]]}
+  [{:keys [name label value on-input on-blur error busy? columns instance]}]
+  (let [error-id (error-region-id "acme-field" instance name)]
     [:label {:data-component "acme/field"
              :data-part      "root"
              :data-field     name
@@ -67,7 +68,7 @@
   [{:keys [name label value on-commit error busy?] :as props}]
   (let [k        (control/record-key buffered-kind props)
         g        (control/reset-revision buffered-kind props)
-        error-id (str "acme-buffered-" name "-error")]
+        error-id (error-region-id "acme-buffered" (:control props))]
     [:label {:data-component "acme/buffered-field"
              :data-part      "root"
              :data-field     name
@@ -100,6 +101,7 @@
                              :prevent-default true}}
      [field {:name     "description"
              :label    "Description"
+             :instance id
              :value    (or (:description line) "")
              :columns  40
              :error    (v/sub [:acme.invoice/field-error id :description])
@@ -107,18 +109,21 @@
              :on-blur  [:acme.invoice/field-blurred id :description]}]
      [field {:name     "quantity"
              :label    "Quantity"
+             :instance id
              :value    (or (:quantity line) "")
              :error    (v/sub [:acme.invoice/field-error id :quantity])
              :on-input [:acme.invoice/field-edited id :quantity]
              :on-blur  [:acme.invoice/field-blurred id :quantity]}]
      [field {:name     "unit-price"
              :label    "Unit price"
+             :instance id
              :value    (or (:unit-price line) "")
              :error    (v/sub [:acme.invoice/field-error id :unit-price])
              :on-input [:acme.invoice/field-edited id :unit-price]
              :on-blur  [:acme.invoice/field-blurred id :unit-price]}]
      [field {:name     "account"
              :label    "Account"
+             :instance id
              :value    (or (:account line) "")
              :error    (v/sub [:acme.invoice/field-error id :account])
              :on-input [:acme.invoice/field-edited id :account]

--- a/implementation/freehand/test/re_frame/freehand/pilot_field_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/pilot_field_dom_cljs_test.cljs
@@ -176,6 +176,23 @@
 (defn- render-line! [root]
   (act #(.render root (shell/provide-frame fid (fr/element [pilot/invoice-line {:id line-id}])))))
 
+(defn- seed-lines!
+  "Seed TWO invoice lines, both with a blank description and submit already
+  attempted, so both lines' \"description\" error regions render on mount."
+  []
+  (live-frame/make-frame {:id fid})
+  (frame/replace-app-db! fid
+    {:invoice {1 (assoc seed-line :description "")
+               2 (assoc seed-line :description "")}
+     :ui      {1 {:submit-attempted? true}
+               2 {:submit-attempted? true}}})
+  (pilot/register!)
+  (pilot/register-app!)
+  fid)
+
+(defn- render-lines! [root]
+  (act #(.render root (shell/provide-frame fid (fr/element [pilot/invoice-lines {:ids [1 2]}])))))
+
 (defn- app [] (frame/frame-app-db-value fid))
 (defn- line [] (get-in (app) [:invoice line-id]))
 
@@ -511,6 +528,48 @@
                            (is (= "REF-2" (.-value node))
                                "and the normalised value is displayed"))))))
           done)))))
+
+;; ===========================================================================
+;; Instance-unique error ids — the mounted a11y check
+;; ===========================================================================
+
+(deftest pilot-repeated-fields-resolve-aria-describedby-to-their-own-region
+  (testing "rf2-drpa3.134, acceptance 2 (mounted). Two invoice lines
+            mounted together put two controlled fields named
+            \"description\" on one page. Each control's `aria-describedby`
+            resolves — by document id, the way assistive technology
+            resolves it — to its OWN error region, and the two ids differ.
+            Before the fix both controls pointed at one ambiguous
+            `acme-field-description-error`."
+    (if-not (browser?)
+      (skip! "the browser job runs the duplicate-id assertion")
+      (async done
+        (seed-lines!)
+        (let [[container root] (mount!)]
+          (-> (render-lines! root)
+              (.then
+                (fn [_]
+                  (let [controls (.querySelectorAll
+                                   container "[data-field='description'] [data-part='control']")
+                        c1  (.item controls 0)
+                        c2  (.item controls 1)
+                        id1 (.getAttribute c1 "aria-describedby")
+                        id2 (.getAttribute c2 "aria-describedby")]
+                    (is (= 2 (.-length controls)) "non-vacuous: two description fields mounted")
+                    (is (some? id1) "line 1's control names a region")
+                    (is (some? id2) "line 2's control names a region")
+                    (is (not= id1 id2) "the two controls name DISTINCT regions")
+                    (is (.contains (.closest c1 "[data-component='acme/field']")
+                                   (.getElementById js/document id1))
+                        "line 1's aria-describedby resolves inside line 1's own field")
+                    (is (.contains (.closest c2 "[data-component='acme/field']")
+                                   (.getElementById js/document id2))
+                        "line 2's aria-describedby resolves inside line 2's own field"))))
+              (.then (fn [_] (teardown! container root) (done)))
+              (.catch (fn [e]
+                        (is false (str "the mounted pilot rejected: " e))
+                        (teardown! container root)
+                        (done)))))))))
 
 ;; ===========================================================================
 ;; The blocked cell, stated rather than skipped quietly


### PR DESCRIPTION
Closes rf2-drpa3.134 (gh-6747 family). Fixes the pilot's repeated-field
error-id collision surfaced by PR #6747's reusable field / buffered field.

## The defect

`field` and `buffered-field` derived their error-region DOM id from the
field NAME alone (`acme-field-description-error`). `invoice-lines`
deliberately renders more than one `invoice-line` at once, so two
touched/invalid `description` fields emitted the same global id and both
controls pointed `aria-describedby` at one ambiguous target. The
component surface offered no instance identity with which a caller could
disambiguate them.

## The fix (local to the pilot component API)

- `field` gains an optional `:instance` prop — the caller's instance
  identity (e.g. an invoice line id). Its error id is derived from
  `instance` + `name` through a new `error-region-id` helper. Two
  same-named fields on one page now get distinct ids; an absent
  `:instance` keeps the short single-instance `acme-field-<name>-error`.
- `buffered-field` derives its error id from the `:control` address it
  already carries (D004) — which already names the instance uniquely
  across the app — so it needs **no new prop**.
- `invoice-line` passes its line id as `:instance` on each controlled
  field.

No global id counter, uniqueness registry, render-time duplicate-id
policing, or substrate-wide accessibility API. The library trusts the
caller's identity to be distinct, exactly as the buffered controller
already trusts its `:control` address. The interpreted twin and its
`{:compiled true}` promotion twin get identical edits, so promotion
parity holds.

## Acceptance (rf2-drpa3.134)

1. Two same-named field instances emit distinct error-region ids — proven
   for both controlled and buffered fields.
2. Each control's `aria-describedby` resolves to its own error region — in
   interpreted and compiled structural evidence, and in one mounted-browser
   check that resolves each id by `document.getElementById`.
3. Identity is stable across an ordinary list reorder (the id is a pure
   function of the caller's instance identity, not render position).
4. The single-instance call is unchanged and small; no allocator/registry/
   policing/new substrate API.

## Tests added

- `pilot-field-cljs-test` (structural, both modes):
  `repeated-fields-emit-instance-unique-error-ids`,
  `an-error-id-is-stable-across-a-list-reorder`,
  `a-single-instance-field-keeps-the-short-id`.
  Adversarial case included: two identical `description` fields → two
  distinct ids, each `aria-describedby` resolving to its own region.
- `pilot-field-dom-cljs-test` (mounted browser):
  `pilot-repeated-fields-resolve-aria-describedby-to-their-own-region` —
  mounts two lines and resolves each control's `aria-describedby` into its
  own field by document id.
- `the-props-schema-closes-the-props-map` updated for the new `:instance`
  prop in the closed schema.

## Quality gates

Run from `implementation/` off this branch (base `b54e3fe25d`):

| Gate | Command | Result | Exit |
| --- | --- | --- | --- |
| Freehand JVM/node suite | `npm run test:freehand` | Ran 647 tests, 4139 assertions. 0 failures, 0 errors. | 0 |
| Browser suite (DOM repro) | `npm run test:browser` | Ran 603 tests, 3585 assertions. 0 failures, 0 errors. | 0 |

(The `:redef` warning from `browser-test` is pre-existing in
`freehand/src/re_frame/freehand/fingerprint.cljc` and unrelated to this
change.)

Do not merge — held for review.
