### PR TITLE
test(freehand): B-spine evidence — B1 DOM bench, B2 elision count, B5 shipped cost (rf2-drpa3.131, .49, .52)

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/bench/b2.cljc
+++ b/implementation/freehand/src/re_frame/freehand/bench/b2.cljc
@@ -1,0 +1,296 @@
+(ns re-frame.freehand.bench.b2
+  "B2 — capability elision, counted exactly on a mass mount.
+
+  D021's second required workload: a *cells-shaped mount storm* of many
+  boundaries, compared under the `:interpreted-vs-compiled` baseline, to
+  measure the one thing compilation buys that interpretation cannot — a
+  view PROVEN to carry no reactive site OMITS the reactive ViewCell shell,
+  and a mount of a thousand such leaves omits a thousand shells. The
+  omitted-cell count is the value, and it is GATED on an exact integer.
+
+  ## Two arms, one storm
+
+  The interpreted shell ALWAYS observes frame context: it has no finite
+  grammar and cannot prove a body sub-free, so it keeps every ViewCell.
+  The compiled tier earns its elision by proof, and B2 is that proof
+  counted at scale — so it needs both an arm that elides and an arm that
+  does not, or a count of zero omissions and a count of all of them would
+  be indistinguishable from a broken oracle.
+
+    - the **capability-free arm** is inert leaves — no `sub`, no committed
+      event handler, no `(frame)` read, no `dispatch-fn`, and no host
+      capability. Every boundary omits its ViewCell, so the arm's omitted
+      count is its whole boundary count.
+    - the **three-read arm** is reactive boundaries carrying three
+      reactive reads each — subscriptions and a committed event handler.
+      Every boundary observes context and RETAINS its ViewCell, so the
+      arm omits none.
+
+  A gate over the free arm alone could pass by eliding nothing and
+  counting nothing; the read arm is the discrimination that a zero is a
+  real absence and not a mis-targeted probe. It is D021's
+  `sub/event/presence`-free-versus-loaded contrast, made countable.
+
+  ## What gates and what does not
+
+  The split is [[re-frame.freehand.bench.measure]]'s, and B2 sits exactly
+  on the line D021 draws for it: *elision counts are DETERMINISTIC gates,
+  not timing evidence.*
+
+    - `:B2/free-arm-omitted-cells` and `:B2/read-arm-omitted-cells`
+      observe a `:count`. They are deterministic properties — a static
+      function of each declaration's analyzed sites, reproducible on any
+      host — they gate, and a violation exits non-zero. The free arm's
+      count is an EXACT integer, never a range; the read arm's is exactly
+      zero.
+    - the mount DECOMPOSITION and the RETAINED-object counts ride the
+      `:fixture`, published verbatim with the record's full provenance.
+      They are the per-declaration static facts behind the two totals —
+      each type's ViewCell verdict, its capability roster and its reactive
+      site cardinalities — so a reader sees not only THAT the free arm
+      omitted 2600 shells but WHICH declarations earned the verdict.
+
+  ## Static, and honest about it
+
+  The count is read off `re-frame.freehand/manifest` — the analyzer's
+  verdict, produced at compile time and carried on the descriptor as data.
+  Mounting nothing is deliberate: the verdict a mount would act on is
+  already decided before the mount, and reading it as data is how F3d's
+  elision proof is stated in the first place (`FH-DIAG-002`). What B2 adds
+  is the count AT SCALE — the exact number of ViewCell shells a mount of
+  this roster omits, `verdict × mount count`, summed over the plan.
+
+  The mount TIME distribution and the live-heap retained-object reading
+  that D021's fuller B2 row also asks for are a different instrument: they
+  need the compiled tier's browser lowering (rf2-drpa3.113), which mounts
+  a compiled boundary in a real root, and join this workload with that
+  slice. Until then B2 measures the exact quantity that IS decidable
+  without a mount, and does not sell a static count as a runtime one.
+
+  ## A small case beside the stress case
+
+  D021: *\"Include at least one small realistic case beside each stress
+  case so optimization is not tuned only to synthetic extremes.\"* Hence
+  two registered workloads over one roster and one `:run`, differing only
+  in the `:scale` fixture parameter — mount counts are fixture parameters,
+  not language constants.
+
+  Normative owner: `docs/design/freehand/decisions/`
+  `D021-performance-budgets-and-release-evidence.md`."
+  (:require [re-frame.freehand :as v]
+            [re-frame.freehand.bench :as bench]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+;; ---------------------------------------------------------------------------
+;; The capability-free arm — inert leaves, so every ViewCell is omitted
+;; ---------------------------------------------------------------------------
+
+(v/defview free-label
+  "Pure text under one element — the smallest elidable leaf."
+  {:compiled true}
+  [{:keys [text]}]
+  [:span.label text])
+
+(v/defview free-card
+  "Structure forwarding children beneath an owned heading. Forwarding
+  children is not a reactive read, so the shell stays elided."
+  {:compiled true}
+  [{:keys [title children]}]
+  [:section.card [:h3.card__title title] children])
+
+(v/defview free-list
+  "A keyed list. A `for` run is finite structure, not a reactive site, so
+  a list of static rows omits the ViewCell like any other inert body."
+  {:compiled true}
+  [{:keys [items]}]
+  [:ul.list
+   (for [i items]
+     [:li.item {:key i} i])])
+
+(v/defview free-nested
+  "Nested plain elements — depth is not a reactive read either, so the
+  deepest inert body is still elidable."
+  {:compiled true}
+  [{:keys [text]}]
+  [:div.host [:div.inner [:span.leaf text]]])
+
+;; ---------------------------------------------------------------------------
+;; The three-read arm — three reactive reads each, so every ViewCell is kept
+;; ---------------------------------------------------------------------------
+
+(v/defview read-panel
+  "Two subscriptions and a committed event handler — three reactive reads,
+  one retained ViewCell."
+  {:compiled true}
+  [{:keys [id]}]
+  [:section.panel
+   [:output.total (v/sub [:panel/total id])]
+   [:output.count (v/sub [:panel/count id])]
+   [:button.act {:on-click [:panel/act id]} "act"]])
+
+(v/defview read-row
+  "One subscription and two committed event handlers — three reactive
+  reads over one boundary. Many sites, one shell."
+  {:compiled true}
+  [{:keys [id]}]
+  [:tr.row
+   [:td.val (v/sub [:row/value id])]
+   [:td [:button.up {:on-click [:row/up id]} "+"]]
+   [:td [:button.down {:on-click [:row/down id]} "-"]]])
+
+(v/defview read-widget
+  "Three subscriptions — three reactive reads, no events, still one
+  retained ViewCell. A view is reactive because it READS state, however
+  it reads it."
+  {:compiled true}
+  [{:keys [id]}]
+  [:div.widget
+   [:span.a (v/sub [:widget/a id])]
+   [:span.b (v/sub [:widget/b id])]
+   [:span.c (v/sub [:widget/c id])]])
+
+;; ---------------------------------------------------------------------------
+;; The roster and the mount plan
+;; ---------------------------------------------------------------------------
+
+(def ^:private free-views
+  "The capability-free arm's declaration types. Every one is proven
+  elidable by its manifest — a claim the workload re-checks each run
+  rather than trusts this vector for."
+  [free-label free-card free-list free-nested])
+
+(def ^:private read-views
+  "The three-read arm's declaration types. Every one carries three
+  reactive reads and keeps its ViewCell."
+  [read-panel read-row read-widget])
+
+(defn- plan
+  "A mount plan for `views` at `scale`: `[[view mount-count] …]`, each type
+  mounted `scale` times. Scale is a fixture parameter — the storm's size
+  is a size, not a language constant."
+  [views scale]
+  (mapv (fn [view] [view scale]) views))
+
+(defn- verdict
+  [view]
+  (:view-cell (v/manifest view)))
+
+(defn- omitted
+  "The exact number of boundaries in `mount-plan` whose compiled lowering
+  OMITS the ViewCell — each type's manifest verdict times its mount count.
+  Read off the manifest every call, so a type that stopped eliding drops
+  its whole mount count out of this total and reds the gate."
+  [mount-plan]
+  (reduce (fn [n [view mounts]]
+            (+ n (if (= :elided (verdict view)) mounts 0)))
+          0
+          mount-plan))
+
+(defn expected-omitted
+  "The omitted-cell count the free arm's roster predicts for `scale`,
+  stated as arithmetic: every one of its types is elidable, so a mount of
+  `scale` each omits `(count free-views) × scale` shells. A gate against a
+  WRITTEN expectation, not against whatever the walk happened to produce."
+  [scale]
+  (* (count free-views) scale))
+
+;; ---------------------------------------------------------------------------
+;; The mount decomposition — the static facts behind the two totals
+;; ---------------------------------------------------------------------------
+
+(defn- boundary
+  "One declaration's line in the decomposition: the verdict it earned, the
+  capabilities that earned it, its reactive site cardinalities, and how
+  many times the plan mounts it."
+  [[view mounts]]
+  (let [m (v/manifest view)]
+    {:view-id       (:view-id m)
+     :view-cell     (:view-cell m)
+     :capabilities  (:capabilities m)
+     :subscriptions (count (:subscriptions m))
+     :events        (count (:events m))
+     :mounts        mounts}))
+
+(defn- arm-decomposition
+  "An arm's published decomposition: its per-declaration lines, its total
+  boundary count, the ViewCell shells the mount OMITS, and the ones it
+  RETAINS — the retained-object count, as the static count of reactive
+  shells a mount of this arm keeps alive."
+  [mount-plan]
+  (let [lines     (mapv boundary mount-plan)
+        total     (reduce + 0 (map :mounts lines))
+        omitted-n (omitted mount-plan)]
+    {:boundaries          total
+     :omitted-view-cells  omitted-n
+     :retained-view-cells (- total omitted-n)
+     :decomposition       lines}))
+
+;; ---------------------------------------------------------------------------
+;; One iteration
+;; ---------------------------------------------------------------------------
+
+(defn observe
+  "Run one B2 iteration over `fixture` and answer its observations: the
+  exact omitted-ViewCell count of each arm, read off the manifests the
+  plan's declarations carry."
+  [{:keys [free-plan read-plan]}]
+  {:B2/free-arm-omitted-cells (omitted free-plan)
+   :B2/read-arm-omitted-cells (omitted read-plan)})
+
+;; ---------------------------------------------------------------------------
+;; The workloads
+;; ---------------------------------------------------------------------------
+
+(defn workload
+  "Build the B2 workload for `scale`, under `id` and `sampling`.
+
+  The fixture carries the mount plans the `:run` reads and, published
+  beside them, the mount decomposition and the retained-object counts D021
+  asks B2 to publish — every one a per-declaration static fact, so the two
+  gated totals trace back to the declarations that produced them."
+  [{:keys [id doc scale sampling]}]
+  (let [free-plan (plan free-views scale)
+        read-plan (plan read-views scale)]
+    {:id       id
+     :doc      doc
+     :fixture  {:scale     scale
+                :free-plan free-plan
+                :read-plan read-plan
+                :free-arm  (arm-decomposition free-plan)
+                :read-arm  (arm-decomposition read-plan)}
+     :baseline {:kind      :interpreted-vs-compiled
+                :reference {:arm  :interpreted
+                            :note (str "the interpreted lowering retains every ViewCell; the "
+                                       "omitted count is the shells the compiled tier proves "
+                                       "safe to drop that interpretation cannot")}}
+     :sampling sampling
+     :measurements
+     [{:id         :B2/free-arm-omitted-cells
+       :doc        "the exact ViewCell shells a mount of the capability-free arm omits"
+       :observable :count
+       :expect     (expected-omitted scale)}
+      {:id         :B2/read-arm-omitted-cells
+       :doc        "the ViewCell shells the three-read arm omits — exactly zero, it is all reactive"
+       :observable :count
+       :expect     0}]
+     :run observe}))
+
+(def workloads
+  "B2's registered workloads: the mount storm D021 names, and the small
+  realistic case it requires beside it. `:scale` is per-type mount count,
+  so the free arm's stress case omits `4 × 650 = 2600` ViewCell shells —
+  in the cells-shaped band D021's B2 row names."
+  [(workload {:id       :B2/mass-mount
+              :doc      "a cells-shaped mount storm: a capability-free arm and a three-read arm"
+              :scale    650
+              :sampling {:warmup 5 :samples 40}})
+   (workload {:id       :B2/small-mount
+              :doc      "the same roster at a realistic small size — the control on the storm"
+              :scale    2
+              :sampling {:warmup 5 :samples 40}})])
+
+(def registered
+  "Registering at load: requiring this namespace puts B2 in the standing
+  evidence suite `clojure -M:bench` runs."
+  (mapv bench/register! workloads))

--- a/implementation/freehand/src/re_frame/freehand/bench/runner.cljc
+++ b/implementation/freehand/src/re_frame/freehand/bench/runner.cljc
@@ -29,6 +29,7 @@
             ;; workload namespaces required here — one line per B-slice as
             ;; it lands, and nothing discovered by scanning.
             [re-frame.freehand.bench.b1]
+            [re-frame.freehand.bench.b2]
             [re-frame.freehand.bench.falsifiability :as falsifiability]
             #?(:clj [clojure.pprint :as pp] :cljs [cljs.pprint :as pp])))
 

--- a/implementation/freehand/test/re_frame/freehand/bench/b2_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/bench/b2_cljs_test.cljc
@@ -1,0 +1,181 @@
+(ns re-frame.freehand.bench.b2-cljs-test
+  "B2's DETERMINISTIC half, run on both hosts.
+
+  B2's whole correctness claim is a pair of exact counts: the
+  capability-free arm omits every ViewCell it mounts, and the three-read
+  arm omits none. Those are properties — a static function of each
+  declaration's analyzed sites — they reproduce on any host, and a
+  violation reds. This suite proves the counts are the written arithmetic,
+  that the oracle behind them DISCRIMINATES (a reactive view is not
+  counted as omitted), and that the workloads run green and publish the
+  decomposition D021 asks B2 to publish.
+
+  The half this suite does NOT touch: how big any timing is. The only
+  distribution B2 publishes is the harness's own iteration clock, and this
+  file asserts it was published, never that it was fast — that is the
+  half D021 forbids gating on, mechanised in the harness itself
+  ([[re-frame.freehand.bench.measure]]) rather than restated here."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.bench :as bench]
+            [re-frame.freehand.bench.b2 :as b2]
+            [re-frame.freehand.bench.measure :as m]))
+
+(def ^:private provenance
+  "The revision a TEST supplies. A ClojureScript test process is not a
+  build pipeline: no environment variable, no git, and nothing it could
+  truthfully detect. The published run detects its own."
+  {:revision "test-fixture-revision"})
+
+;; ---------------------------------------------------------------------------
+;; Each arm earns its verdict
+;; ---------------------------------------------------------------------------
+
+(deftest b2-the-free-arm-omits-every-view-cell
+  (testing "Every capability-free declaration is proven elidable by its
+            manifest — no reactive site, so the ViewCell shell is omitted.
+            The count is a fact about these declarations before it is a
+            total over a mount."
+    (doseq [view @#'b2/free-views]
+      (let [mm (v/manifest view)]
+        (is (= :elided (:view-cell mm))
+            (str (:view-id mm) " omits the ViewCell shell"))
+        (is (false? (:reactive? mm))
+            (str (:view-id mm) " carries no reactive site"))))))
+
+(deftest b2-the-three-read-arm-retains-every-view-cell
+  (testing "Every three-read declaration observes context and keeps its
+            ViewCell — three reactive reads each, so the arm is the
+            discrimination that a zero omitted count is a real absence and
+            not a broken oracle."
+    (doseq [view @#'b2/read-views]
+      (let [mm (v/manifest view)]
+        (is (= :present (:view-cell mm))
+            (str (:view-id mm) " retains the ViewCell shell"))
+        (is (true? (:reactive? mm))
+            (str (:view-id mm) " carries a reactive site"))
+        (is (= 3 (+ (count (:subscriptions mm)) (count (:events mm))))
+            (str (:view-id mm) " carries three reactive reads"))))))
+
+;; ---------------------------------------------------------------------------
+;; The count is the written arithmetic, and it discriminates
+;; ---------------------------------------------------------------------------
+
+(deftest b2-the-omitted-count-is-the-written-arithmetic
+  (testing "The free arm's omitted count is the one its roster PREDICTS at
+            every scale — `(count free-views) × scale` — not whatever the
+            walk happened to produce, and the read arm's is exactly zero."
+    (doseq [scale [0 1 2 650]]
+      (let [{:keys [B2/free-arm-omitted-cells B2/read-arm-omitted-cells]}
+            (b2/observe (:fixture (b2/workload {:id       :B2/probe
+                                                :doc      "arithmetic probe"
+                                                :scale    scale
+                                                :sampling {:warmup 0 :samples 1}})))]
+        (is (= (b2/expected-omitted scale) free-arm-omitted-cells)
+            (str "scale " scale ": the free arm omits the predicted count"))
+        (is (= 0 read-arm-omitted-cells)
+            (str "scale " scale ": the three-read arm omits none"))))))
+
+(deftest b2-the-count-would-notice-a-view-that-stopped-eliding
+  (testing "A count that could only ever read its whole arm is vacuous.
+            The oracle reads each type's manifest, so a plan mixing an
+            elided and a retained view counts only the elided one's mounts
+            — which is exactly what would happen if a free-arm type
+            regressed into keeping its shell."
+    (let [omitted #'b2/omitted
+          elided  (first @#'b2/free-views)
+          present (first @#'b2/read-views)]
+      (is (= :elided (:view-cell (v/manifest elided))))
+      (is (= :present (:view-cell (v/manifest present))))
+      (is (= 100 (omitted [[elided 100] [present 100]]))
+          "only the elided view's mounts are counted — the present one drops out")
+      (is (= 0 (omitted [[present 100]]))
+          "an all-reactive plan omits nothing")
+      (is (= 200 (omitted [[elided 100] [elided 100]]))
+          "and an all-inert plan omits every mount"))))
+
+;; ---------------------------------------------------------------------------
+;; The registered workloads
+;; ---------------------------------------------------------------------------
+
+(deftest b2-registers-the-mass-mount-and-the-small-case
+  (testing "D021 requires a small realistic case beside the stress case.
+            Both are registered into the standing evidence suite, both run
+            one roster, and the storm omits a cells-shaped number of
+            shells under the baseline D021 names for B2."
+    (let [registered (bench/registered)]
+      (doseq [id [:B2/mass-mount :B2/small-mount]]
+        (is (contains? registered id) (str id " is in the standing evidence suite"))))
+    (let [stress (first (filter #(= :B2/mass-mount (:id %)) b2/workloads))
+          small  (first (filter #(= :B2/small-mount (:id %)) b2/workloads))]
+      (is (<= 1000 (get-in stress [:fixture :free-arm :omitted-view-cells]))
+          "the storm omits a cells-shaped number of ViewCell shells")
+      (is (< (get-in small [:fixture :free-arm :omitted-view-cells]) 100)
+          "and the small case is genuinely small")
+      (is (= :interpreted-vs-compiled (:kind (:baseline stress)))
+          "under the baseline D021 names for B2"))))
+
+(deftest b2-runs-green-and-publishes-its-decomposition
+  (testing "Each registered workload runs, its two deterministic counts
+            hold, and the mount decomposition and retained-object counts
+            ride the record's fixture with full provenance — every one a
+            per-declaration static fact behind the gated totals."
+    (doseq [w b2/workloads]
+      (let [record (bench/run-workload w provenance)
+            label  (str (:id w) ": ")
+            free   (get-in record [:fixture :free-arm])
+            read   (get-in record [:fixture :read-arm])]
+        (is (empty? (:gate-failures record)) (str label "no deterministic property was violated"))
+        (is (= (:omitted-view-cells free)
+               (get-in record [:properties :B2/free-arm-omitted-cells :observed]))
+            (str label "the gated free-arm count matches the published decomposition"))
+        (is (= 0 (get-in record [:properties :B2/read-arm-omitted-cells :observed]))
+            (str label "the three-read arm omits none"))
+        (testing "the decomposition names every declaration and its retained shells"
+          (is (= 0 (:retained-view-cells free))
+              (str label "the free arm retains no ViewCell"))
+          (is (= (:boundaries read) (:retained-view-cells read))
+              (str label "the three-read arm retains every ViewCell it mounts"))
+          (doseq [line (concat (:decomposition free) (:decomposition read))]
+            (is (contains? #{:elided :present} (:view-cell line))
+                (str label (:view-id line) " carries a decided verdict"))
+            (is (set? (:capabilities line))
+                (str label (:view-id line) " publishes its capability roster"))))
+        (testing "and the harness's own reading is published as evidence, with no verdict"
+          (let [d (get-in record [:distribution :bench/iteration-ms])]
+            (is (some? d) (str label "iteration-ms was published"))
+            (is (= (:samples (:sampling w)) (:n d))
+                (str label "it summarises every measured iteration"))
+            (is (not (contains? d :pass?))
+                (str label "it carries no verdict — it is evidence"))))))))
+
+(deftest b2-carries-the-provenance-a-published-result-needs
+  (testing "A count without its environment is not release evidence. The
+            record names its revision, fixture parameters, build mode,
+            runtime and hardware class — the last DETECTED, never a literal
+            naming one machine."
+    (let [record (bench/run-workload (first b2/workloads) provenance)]
+      (is (= "test-fixture-revision" (:revision record)))
+      (is (= (:scale (:fixture (first b2/workloads))) (:scale (:fixture record)))
+          "the scale parameter rides the record — mount counts are parameters, not constants")
+      (is (keyword? (get-in record [:build :optimizations])))
+      (is (boolean? (get-in record [:build :instrumentation?])))
+      (is (seq (get-in record [:host :runtime])))
+      (is (keyword? (get-in record [:host :hardware-class])))
+      (is (= :evidence (:status record))))))
+
+;; ---------------------------------------------------------------------------
+;; The counts gate; the timing cannot
+;; ---------------------------------------------------------------------------
+
+(deftest b2-omitted-counts-gate-and-nothing-else-can
+  (testing "The asymmetry, read off B2's own declarations: both omitted
+            counts class as gates, and the only distribution it publishes
+            — the harness clock — classes as evidence. A future edit that
+            reached for a budget on that timing would be refused when the
+            workload is CONSTRUCTED, not here."
+    (let [by-id (into {} (map (juxt :id identity))
+                      (:measurements (bench/workload (first b2/workloads))))]
+      (doseq [mid [:B2/free-arm-omitted-cells :B2/read-arm-omitted-cells]]
+        (is (m/gate? (get by-id mid)) (str mid " gates")))
+      (is (m/evidence? (get by-id :bench/iteration-ms)) ":bench/iteration-ms is evidence"))))


### PR DESCRIPTION
B-spine EVIDENCE/BENCH cluster (D021). One bead landed; two deferred on a
main-blocker, with the reason recorded on each bead. No fabricated evidence.

## What landed

**rf2-drpa3.49 — B2 evidence: capability elision, exact omitted-ViewCell count on a mass mount** ✅

A B-spine bench workload family (`bench/b2.cljc`) registered into the
standing `clojure -M:bench` suite beside B1. A cells-shaped mount storm of
compiled declarations, two arms under the `:interpreted-vs-compiled`
baseline:

- **capability-free arm** — inert leaves (`free-label` / `free-card` /
  `free-list` / `free-nested`); every one is proven elidable by its
  manifest and omits its reactive ViewCell shell.
- **three-read arm** — reactive boundaries carrying three reactive reads
  each (subscriptions + committed event handlers); every one retains its
  ViewCell.

- **GATES** (deterministic `:count`, exact integer never a range):
  `:B2/free-arm-omitted-cells` = `(count free-views) × scale` — **2600**
  at the storm scale (acceptance #1); `:B2/read-arm-omitted-cells` = **0**
  (acceptance #2). The count is read off `re-frame.freehand/manifest`
  every run, so a type that stopped eliding drops its whole mount count
  and reds the gate.
- **EVIDENCE** (acceptance #3): the per-declaration mount decomposition
  and the retained-object counts ride the record's `:fixture` with full
  provenance — each type's ViewCell verdict, capability roster and
  reactive-site cardinalities behind the two totals.

The count is static and the workload says so: D021's fuller B2 row also
asks for mount TIME and a live-heap retained-object reading, which need
the compiled tier's browser lowering (**rf2-drpa3.113**) and join this
workload with that slice.

## Deferred (recorded on the beads, blocker-linked to rf2-drpa3.113)

**rf2-drpa3.131 — B1 DOM bench** ⛔ The bead's premise is not yet true on
main: rf2-drpa3.113 (compiled-tier browser lowering) is still
IN_PROGRESS, `re-frame.freehand.react` still refuses compiled
declarations with `:rf.error/view-lowering-unavailable`, and no
`compiled-mount-dom-cljs-test` exists. So b1's `## The DOM half … is not
yet runnable` docstring stays accurate, and there is no compiled DOM to
compare against. The fix would also require editing `react.cljs` (another
worker's file-ownership fence). Redispatch when .113 merges.

**rf2-drpa3.52 — B5 shipped cost** ⛔ Needs interpreted + compiled + MIXED
production bundles measured for gzip / parse-eval / **initial mount** /
per-promotion delta across all three shapes. Initial-mount time for the
compiled and mixed shapes cannot be honestly produced while compiled
views are not browser-mountable (rf2-drpa3.113), and no three-shape
production-build + timing harness exists yet. The reachability gate
substantially overlaps what F3d/rf2-drpa3.28 already shipped. Redispatch
when .113 merges and a three-shape bundle-build path exists.

## Quality gates

Ran from `implementation/`:

| Gate | Result |
| --- | --- |
| `npm run test:freehand` | **exit 0** — 646 tests / 4202 assertions, 0 failures, 0 errors |
| `clojure -M:bench` (from `freehand/`) | **exit 0** — 4 workloads (B1×2, B2×2), all deterministic properties held |
| `clojure -M:bench --prove` (from `freehand/`) | **exit 0** — falsifiability PROVEN both ways |

Beads landed: rf2-drpa3.49. Deferred (blocker-linked to rf2-drpa3.113):
rf2-drpa3.131, rf2-drpa3.52.