### PR TITLE
feat(freehand): F5b theming — CSS tokens and semantic part addresses (rf2-drpa3.39)

### DIFF
--- a/implementation/freehand/test/re_frame/freehand/pilot_theming.cljc
+++ b/implementation/freehand/test/re_frame/freehand/pilot_theming.cljc
@@ -1,0 +1,136 @@
+(ns re-frame.freehand.pilot-theming
+  "THE THEMING PILOT — a component-library leaf built the two-plane way
+  D018 rules, and the fixture the F5b acceptance is proved against.
+
+  Everything here is CONSUMER code. It declares one view with `v/defview`,
+  emits ordinary host values, and adds NO substrate machinery: there is no
+  theme registry, no theme context protocol, no per-leaf token
+  subscription, and — the point of the slice — no late tree transform. A
+  theme is CSS, and a part is an address. Both ride the platform the host
+  already runs.
+
+  ## The two planes, and what carries each
+
+  D018 splits theming into a portable STYLING plane and the existing
+  structural composition plane. F5b lands the styling plane, and it is two
+  mechanisms and no more:
+
+  - **CSS TOKENS.** Visual values travel by the CSS cascade. An ancestor
+    scope selects a named token bundle (`data-theme`) and inheritance
+    reaches every descendant, so a theme switch re-renders nothing — no
+    token subscription per leaf, no remount. The one value a stylesheet
+    cannot know — a genuinely dynamic colour the caller supplies at the
+    call site — rides as an inline namespaced custom property (`:accent`
+    -> `--acme-chip-accent`). That is the whole token contract.
+
+  - **SEMANTIC PART ADDRESSES.** A component declares a finite roster of
+    public parts ([[part-ids]]) and emits each as a literal `data-part`
+    value under a `data-component` scope, so a caller's stylesheet reaches
+    a named region without a class contract and without colliding with
+    another library's `label` or `control`. A part id is API: renaming or
+    removing one is a breaking component-contract change even when the DOM
+    stays visually identical. A private implementation node carries NO
+    part id — the roster is a deliberate PUBLIC subset, not \"every node
+    is addressable\".
+
+  A component VARIANT — `:tone` here — is neither of those. It is an
+  ordinary value prop rendered as a class, because it is a fixed choice
+  the component anticipated, not an open address. Variants carry variants;
+  they never carry part identity ([[variant-class]]).
+
+  ## What this pilot is deliberately NOT
+
+  It is not a theme service. Freehand invents no universal late `parts`
+  transform and exports no re-theming verb; a library opts into this
+  convention through its own props schema and part roster, exactly as this
+  namespace does. Structural replacement — swap the dot for an icon, wrap
+  the label in a popover — is the composition plane's job (children,
+  compound children, `v/render-fn`/slot, a declared child), not a theme
+  operation, and stays outside this fixture on purpose."
+  (:require [re-frame.freehand :as v]))
+
+;; ---------------------------------------------------------------------------
+;; The library's public catalogue — the component id and its part roster
+;; ---------------------------------------------------------------------------
+
+(def component-id
+  "The `data-component` marker that scopes this component's part names.
+  A library decision: `acme.*` is this library's vocabulary, and the
+  substrate reserves nothing for it."
+  "acme/chip")
+
+(def part-ids
+  "The PUBLIC part roster, in emission order — the part schema a
+  stylesheet, a structural test, a doc generator or an AI reads to learn
+  every region it may address.
+
+  It is a CLOSED set: a caller styles `root`, `dot` and `label`, and
+  nothing else this component renders is addressable. Growing it is an
+  additive API change; renaming or dropping one is a breaking change to
+  every stylesheet that reached it."
+  [:root :dot :label])
+
+(def ^:private part-set (set part-ids))
+
+(defn valid-part?
+  "Is `id` a declared public part of this component?"
+  [id]
+  (contains? part-set id))
+
+(defn part
+  "The semantic part ADDRESS for `id` — the attribute fragment a component
+  region merges to become reachable: `{:data-part \"label\"}`.
+
+  The roster is the single source of truth, so an undeclared id is REFUSED
+  here rather than silently emitting an address no stylesheet was told
+  about and no test can enumerate. That refusal is the part contract with
+  teeth: a typo in the component body fails at build/render, and a caller
+  asking to address a part the component does not declare is told so with
+  the roster in hand."
+  [id]
+  (when-not (valid-part? id)
+    (throw (ex-info (str "re-frame.freehand.pilot-theming/part — " (pr-str component-id)
+                         " declares no part " (pr-str id)
+                         "; the public roster is " (pr-str part-ids))
+                    {:component component-id :part id :roster part-ids})))
+  {:data-part (name id)})
+
+(defn variant-class
+  "A component VARIANT lowered to a class. `:tone` is a value prop the
+  component anticipated, so it rides a class — never a `data-part`, which
+  would confuse a fixed choice with an open address."
+  [tone]
+  (str "acme-chip acme-chip--" (name (or tone :neutral))))
+
+;; ---------------------------------------------------------------------------
+;; The component — props only, two planes, one private node
+;; ---------------------------------------------------------------------------
+
+(v/defview chip
+  "A small labelled status chip, styled entirely through the two planes.
+
+  The root carries the `data-component` scope, the `root` part address,
+  the variant class, and — only when the caller supplies the one value the
+  cascade cannot know — an inline `--acme-chip-accent` custom property. The
+  `dot` and `label` regions carry their part addresses and nothing that
+  names a colour: their visual values are a stylesheet's to decide, live,
+  through the token cascade an ancestor scopes.
+
+  `:accent` is optional BECAUSE it is the dynamic-residue escape, not the
+  default path; a chip that needs no per-instance accent emits no inline
+  style at all and takes every value from the cascade."
+  {:props [:map
+           [:label :string]
+           [:tone {:optional true} :keyword]
+           [:accent {:optional true} [:maybe :string]]]}
+  [{:keys [label tone accent]}]
+  [:span (merge {:data-component component-id}
+                (part :root)
+                {:class (variant-class tone)
+                 :style (when accent {:--acme-chip-accent accent})})
+   [:span (part :dot)]
+   [:span (part :label) label]
+   ;; A PRIVATE implementation node: a decorative glow the caller neither
+   ;; names nor styles. It carries a class for the library's own stylesheet
+   ;; and NO part id, which is what makes the roster a public subset.
+   [:span {:class "acme-chip__glow" :aria-hidden "true"}]])

--- a/implementation/freehand/test/re_frame/freehand/pilot_theming_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/pilot_theming_cljs_test.cljc
@@ -1,0 +1,185 @@
+(ns re-frame.freehand.pilot-theming-cljs-test
+  "THE THEMING PILOT, judged structurally — the F5b acceptance whose
+  evidence a tree can hold, on BOTH hosts from one `.cljc` body.
+
+  Two of the three F5b proofs live here because they are host-common:
+
+  - **Part addresses appear in the structural tree** (acceptance 2). The
+    `data-component` scope and each declared `data-part` are ordinary host
+    values in the versioned tree, readable on the JVM and in ClojureScript
+    alike. A private node carries none, and the emitted address set is
+    EXACTLY the declared roster — no undeclared part leaks, no declared
+    part goes missing.
+  - **No transform seam is exported** (acceptance 3). The public-API
+    manifest — the enumerated public surface — carries no re-theming or
+    tree-transform verb on the Freehand namespaces. F5b adds tokens and
+    addresses, both ordinary host values, and NO substrate verb.
+
+  The third proof — a caller targets a part and the computed style changes
+  — is a live-browser fact and is OWED to `pilot-theming-dom-cljs-test`; a
+  structural stand-in for a cascade proves nothing.
+
+  `chip` is props-only, so `t/render` renders it directly: there is no
+  `v/sub` in its body and thus no render candidate to supply."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test :refer-macros [deftest is testing]])
+            [clojure.string :as str]
+            #?(:clj [clojure.edn :as edn] :cljs [cljs.reader :as edn])
+            [re-frame.freehand.pilot-theming :as chip-lib]
+            [re-frame.freehand.test :as t]))
+
+;; ===========================================================================
+;; Harness
+;; ===========================================================================
+
+(def ^:private a-chip
+  "One rendered chip carrying every plane: a variant class, an inline
+  accent (the dynamic residue), and a label a caller reads."
+  (t/render [chip-lib/chip {:label "Ready" :tone :ok :accent "rgb(1, 2, 3)"}]))
+
+(defn- root-of [tree]
+  (t/find tree #(= chip-lib/component-id (:data-component (:attrs %)))))
+
+(defn- by-part [tree p]
+  (t/find tree #(= p (:data-part (:attrs %)))))
+
+(defn- emitted-parts [tree]
+  (into #{}
+        (keep #(:data-part (:attrs %)))
+        (t/find-all tree (constantly true))))
+
+(defn- custom-property
+  "The value of style custom property named `css-name` on `node`, or nil —
+  reading by the key's NAME so a keyword or string spelling both resolve."
+  [node css-name]
+  (some (fn [[k v]] (when (= css-name (name k)) v))
+        (:style (t/attrs node))))
+
+;; ===========================================================================
+;; Acceptance 2 — part addresses appear in the structural tree
+;; ===========================================================================
+
+(deftest the-component-scope-and-part-addresses-appear-in-the-tree
+  (testing "The root carries the `data-component` scope and the `root` part;
+            `dot` and `label` carry their addresses; the label's text is
+            reachable through its address."
+    (let [root (root-of a-chip)]
+      (is (some? root) "the component scope marker is in the tree")
+      (is (= "root" (:data-part (:attrs root))) "the root part addresses the scope node")
+      (is (some? (by-part a-chip "dot")) "the dot part is addressable")
+      (is (= "Ready" (t/text (by-part a-chip "label")))
+          "the label part is addressable and carries its text"))))
+
+(deftest the-emitted-addresses-are-exactly-the-declared-roster
+  (testing "Every declared part is emitted and nothing undeclared leaks — the
+            roster is the closed public surface a stylesheet enumerates."
+    (is (= (set (map name chip-lib/part-ids))
+           (emitted-parts a-chip))
+        "emitted data-part set == declared roster")))
+
+(deftest a-private-node-carries-no-part-address
+  (testing "The decorative glow is an implementation node the caller cannot
+            address — part ids are a deliberate PUBLIC subset, not every node."
+    (let [glow (t/find a-chip #(= "acme-chip__glow" (:class (:attrs %))))]
+      (is (some? glow) "the private node is present")
+      (is (nil? (:data-part (:attrs glow))) "and it carries no part address"))))
+
+(deftest a-variant-rides-a-class-never-a-part-address
+  (testing "`:tone` is a value prop lowered to a class; it never becomes a
+            `data-part`, which would confuse a fixed choice with an open
+            address."
+    (let [root (root-of a-chip)]
+      (is (str/includes? (:class (:attrs root)) "acme-chip--ok")
+          "the variant is on the class")
+      (is (not (contains? (emitted-parts a-chip) "ok"))
+          "and the variant name is not a part address"))))
+
+;; ===========================================================================
+;; The CSS-token plane — the inline dynamic residue, and its absence by default
+;; ===========================================================================
+
+(deftest the-dynamic-accent-rides-an-inline-namespaced-custom-property
+  (testing "The one value the cascade cannot know rides as an inline
+            `--acme-chip-accent` custom property — a token, in the tree, as an
+            ordinary host value."
+    (is (= "rgb(1, 2, 3)" (custom-property (root-of a-chip) "--acme-chip-accent"))
+        "the accent is an inline custom property")))
+
+(deftest a-chip-with-no-accent-emits-no-inline-style
+  (testing "The inline custom property is the dynamic-residue ESCAPE, not the
+            default path: with no accent, the chip carries no inline style and
+            takes every value from the cascade."
+    (let [plain (t/render [chip-lib/chip {:label "Idle"}])]
+      (is (nil? (:style (t/attrs (root-of plain))))
+          "no accent -> no inline style"))))
+
+;; ===========================================================================
+;; The part contract has teeth — an undeclared address is refused
+;; ===========================================================================
+
+(deftest an-undeclared-part-address-is-refused
+  (testing "The roster is the single source of truth: asking to address a part
+            the component does not declare is refused with the roster in hand,
+            rather than emitting an address no stylesheet was told about."
+    (is (true?  (chip-lib/valid-part? :label)) "a declared part is valid")
+    (is (false? (chip-lib/valid-part? :bogus)) "an undeclared part is not")
+    (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo)
+          (chip-lib/part :bogus))
+        "and emitting an undeclared address throws")))
+
+;; ===========================================================================
+;; Acceptance 3 — no transform seam is exported
+;; ===========================================================================
+
+(defn- manifest-path
+  "The repo's spec/api-manifest.edn, found by walking up from the process
+  working directory — node under `npm run test:freehand` (cwd
+  implementation/) and the JVM under `clojure -M:test` (cwd
+  implementation/freehand/) both reach the same file."
+  []
+  #?(:clj
+     (loop [dir (.getCanonicalFile (clojure.java.io/file (System/getProperty "user.dir")))]
+       (when dir
+         (let [f (clojure.java.io/file dir "spec" "api-manifest.edn")]
+           (if (.exists f) (.getPath f) (recur (.getParentFile dir))))))
+     :cljs
+     (let [fs   (js/require "fs")
+           path (js/require "path")]
+       (loop [dir (js/process.cwd)]
+         (let [f (.join path dir "spec" "api-manifest.edn")]
+           (cond
+             (.existsSync fs f) f
+             :else (let [parent (.dirname path dir)]
+                     (when-not (= parent dir) (recur parent)))))))))
+
+(defn- manifest-vars []
+  (let [p (manifest-path)]
+    (when p
+      (let [content #?(:clj  (slurp p)
+                       :cljs (.readFileSync (js/require "fs") p "utf8"))
+            ;; skip the generated leading `;;` banner — read from the map.
+            body    (subs content (str/index-of content "{"))]
+        (:vars (edn/read-string body))))))
+
+(defn- transform-seam?
+  [{:keys [var]}]
+  (let [n (str/lower-case var)]
+    (or (str/includes? n "transform")
+        (str/includes? n "rewrite")
+        (str/includes? n "retheme")
+        (str/includes? n "restyle")
+        (contains? #{"theme" "themes" "parts" "with-theme" "reparent" "rehome"} n))))
+
+(deftest no-transform-seam-is-exported-on-the-freehand-surface
+  (testing "The public-API manifest carries no re-theming or tree-transform verb
+            on the Freehand namespaces — F5b is tokens and addresses, both
+            ordinary host values, and no substrate verb (D018: transforms remain
+            interpreted/test-only)."
+    (let [vars      (manifest-vars)
+          freehand  (filter #(str/starts-with? (:namespace %) "re-frame.freehand") vars)
+          offenders (filter transform-seam? freehand)]
+      (is (seq freehand)
+          "the Freehand public surface is present in the manifest (path resolved)")
+      (is (empty? offenders)
+          (str "a theme/tree-transform seam leaked onto the public Freehand surface: "
+               (mapv (juxt :namespace :var) offenders))))))

--- a/implementation/freehand/test/re_frame/freehand/pilot_theming_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/pilot_theming_dom_cljs_test.cljs
@@ -1,0 +1,154 @@
+(ns re-frame.freehand.pilot-theming-dom-cljs-test
+  "THE THEMING PILOT in a real browser — the F5b proof a tree cannot hold:
+  that a caller targeting a named part changes the COMPUTED style, and that
+  a theme switch recolours through the CSS cascade while the substrate
+  renders nothing.
+
+  `pilot-theming-cljs-test` fills in the structural half — the addresses
+  are in the tree, the roster is closed, no transform seam is exported.
+  This file fills in the half only a live DOM has: `getComputedStyle`.
+
+  Three claims, each a real `react-dom/client` mount of the pilot's own
+  `chip`, every value read back off the browser's own style resolution:
+
+  - **A part address is a style handle.** A caller's stylesheet selects
+    `[data-part=\"label\"]` under the `data-component` scope and the label's
+    computed colour is what the rule said — the whole point of a semantic
+    part address (acceptance 1).
+  - **An inline token reaches a part.** The dynamic-residue accent, carried
+    as an inline `--acme-chip-accent` custom property, resolves through a
+    `var()` on the dot's computed background.
+  - **A theme switch re-renders nothing.** With the token bundle selected
+    by an ancestor `data-theme`, flipping that one attribute — never
+    re-rendering the chip — recolours the chip through inheritance, and the
+    chip's DOM node is the SAME object across the switch. No token
+    subscription per leaf, no remount.
+
+  This suite rides the browser lane through its `-dom-cljs-test` suffix; it
+  also matches the node suites' broader regex, where there is no DOM to
+  mount and it says so rather than passing quietly."
+  (:require ["react-dom/client" :as rdc]
+            ["react" :as react]
+            [cljs.test :refer-macros [async deftest is testing]]
+            [clojure.string :as str]
+            [re-frame.freehand.pilot-theming :as chip-lib]
+            [re-frame.freehand.react :as fr]))
+
+(defn- browser? []
+  (and (exists? js/document) (some? (.-createElement js/document))))
+
+(defn- act
+  [thunk]
+  (try
+    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+    (js/Promise.resolve (react/act (fn [] (js/Promise.resolve (thunk)))))
+    (catch :default e
+      (js/Promise.reject e))))
+
+(defn- inject-style! [css]
+  (let [el (js/document.createElement "style")]
+    (set! (.-textContent el) css)
+    (.appendChild js/document.head el)
+    el))
+
+(defn- container!
+  [theme]
+  (let [c (js/document.createElement "div")]
+    (when theme (.setAttribute c "data-theme" theme))
+    (.appendChild js/document.body c)
+    c))
+
+(defn- computed [node prop]
+  (-> (js/getComputedStyle node) (.getPropertyValue prop)))
+
+(defn- norm
+  "Colours read back from `getComputedStyle` differ only in spacing across
+  engines; compare on the spaces-stripped form."
+  [s]
+  (str/replace (or s "") " " ""))
+
+;; ---------------------------------------------------------------------------
+;; Acceptance 1 — a caller targets a named part, and the style applies
+;; ---------------------------------------------------------------------------
+
+(deftest a-part-address-is-a-style-handle
+  (testing "A stylesheet selecting the `label` part under the `acme/chip`
+            scope sets the label's computed colour."
+    (if-not (browser?)
+      (is true "a real browser is required for a computed-style assertion")
+      (async done
+        (let [style     (inject-style!
+                          (str "[data-component=\"acme/chip\"] [data-part=\"label\"]"
+                               " { color: rgb(9, 105, 218); }"))
+              container  (container! nil)
+              root       (rdc/createRoot container)
+              cleanup    (fn [] (.remove style) (.remove container) (done))]
+          (-> (act #(.render root (fr/element [chip-lib/chip {:label "Ready"}])))
+              (.then (fn [_]
+                       (let [label (.querySelector container "[data-part=\"label\"]")]
+                         (is (some? label) "the label part mounted")
+                         (is (= (norm "rgb(9, 105, 218)") (norm (computed label "color")))
+                             "the part-targeted rule reaches the label's computed style"))
+                       (act #(.unmount root))))
+              (.then (fn [_] (cleanup)))
+              (.catch (fn [e] (is false (str "mount rejected: " e)) (cleanup)))))))))
+
+;; ---------------------------------------------------------------------------
+;; The token plane — an inline custom property resolves through var()
+;; ---------------------------------------------------------------------------
+
+(deftest an-inline-token-reaches-a-parts-computed-style
+  (testing "The dynamic-residue accent, carried inline as `--acme-chip-accent`,
+            resolves through a `var()` on the dot's computed background."
+    (if-not (browser?)
+      (is true "a real browser is required for a computed-style assertion")
+      (async done
+        (let [style     (inject-style!
+                          "[data-part=\"dot\"] { background-color: var(--acme-chip-accent); }")
+              container  (container! nil)
+              root       (rdc/createRoot container)
+              cleanup    (fn [] (.remove style) (.remove container) (done))]
+          (-> (act #(.render root (fr/element [chip-lib/chip {:label "Ready"
+                                                              :accent "rgb(1, 2, 3)"}])))
+              (.then (fn [_]
+                       (let [dot (.querySelector container "[data-part=\"dot\"]")]
+                         (is (some? dot) "the dot part mounted")
+                         (is (= (norm "rgb(1, 2, 3)") (norm (computed dot "background-color")))
+                             "the inline token resolves on the dot's computed style"))
+                       (act #(.unmount root))))
+              (.then (fn [_] (cleanup)))
+              (.catch (fn [e] (is false (str "mount rejected: " e)) (cleanup)))))))))
+
+;; ---------------------------------------------------------------------------
+;; The cascade — a theme switch recolours without a re-render
+;; ---------------------------------------------------------------------------
+
+(deftest a-theme-switch-recolours-through-the-cascade-without-remounting
+  (testing "With the token bundle selected by an ancestor `data-theme`, flipping
+            that one attribute — never re-rendering the chip — recolours the chip
+            through inheritance, and the chip's DOM node is unchanged."
+    (if-not (browser?)
+      (is true "a real browser is required for a computed-style assertion")
+      (async done
+        (let [style     (inject-style!
+                          (str ".acme-chip { background-color: var(--acme-chip-bg); }"
+                               " [data-theme=\"light\"] { --acme-chip-bg: rgb(240, 240, 240); }"
+                               " [data-theme=\"dark\"]  { --acme-chip-bg: rgb(20, 20, 20); }"))
+              container  (container! "light")
+              root       (rdc/createRoot container)
+              cleanup    (fn [] (.remove style) (.remove container) (done))]
+          (-> (act #(.render root (fr/element [chip-lib/chip {:label "Ready"}])))
+              (.then (fn [_]
+                       (let [before (.querySelector container "[data-component=\"acme/chip\"]")]
+                         (is (= (norm "rgb(240, 240, 240)") (norm (computed before "background-color")))
+                             "the light token colours the chip")
+                         ;; Flip the ancestor scope ONLY — no re-render.
+                         (.setAttribute container "data-theme" "dark")
+                         (let [after (.querySelector container "[data-component=\"acme/chip\"]")]
+                           (is (= (norm "rgb(20, 20, 20)") (norm (computed after "background-color")))
+                               "the dark token recolours the chip through the cascade")
+                           (is (identical? before after)
+                               "the same DOM node — the switch re-rendered nothing")))
+                       (act #(.unmount root))))
+              (.then (fn [_] (cleanup)))
+              (.catch (fn [e] (is false (str "mount rejected: " e)) (cleanup)))))))))


### PR DESCRIPTION
Implements **rf2-drpa3.39** — F5b theming: CSS tokens and semantic part addresses (EP-0036 slice F5, decision **D018**).

## Outcome

Theming is **CSS tokens** plus **semantic part addresses** — a component exposes named parts a caller can target, and tokens carry the visual values. There is **no portable tree-transform theming seam**.

Per D018 the styling plane adds **no substrate machinery**: a theme is CSS and a part is an address, both ordinary host values a component library opts into through its own props schema and part roster. So F5b lands as a component-library pilot plus the acceptance proofs, in **test-tier namespaces only** — no new public var, no facade change, no api-manifest change.

## What landed (all under `implementation/freehand/test/`)

- **`pilot_theming.cljc`** — a themeable `chip` leaf built the two-plane way: a `data-component` scope, a closed public `part` roster emitted as literal `data-part` addresses, a variant (`:tone`) lowered to a class (never a part id), and the one value the cascade cannot know carried inline as a `--acme-chip-accent` custom property. The roster is the single source of truth; an undeclared address is refused.
- **`pilot_theming_cljs_test.cljc`** — host-common (JVM + CLJS) structural + negative + manifest proofs.
- **`pilot_theming_dom_cljs_test.cljs`** — real-browser computed-style proofs (dual-lane: real under `test:browser`, trivially green under node).

## Acceptance

1. **A caller targets a named part and the style applies** — *real-browser assertion on computed style.* `pilot_theming_dom_cljs_test.cljs`: a stylesheet selecting `[data-part="label"]` under the `acme/chip` scope sets the label's computed colour; an inline token resolves through `var()`; a `data-theme` switch recolours the chip through the cascade while its DOM node stays the same object (no remount).
2. **Part addresses appear in the structural tree** — *JVM structural assertion.* `pilot_theming_cljs_test.cljc`: the `data-component` scope and each `data-part` are in the versioned tree; the emitted address set is **exactly** the declared roster; a private node carries none; a variant is a class, not a part.
3. **No transform seam is exported** — *api-manifest drift-check.* `pilot_theming_cljs_test.cljc` reads `spec/api-manifest.edn` and asserts the Freehand public surface carries no re-theming / tree-transform verb.

Negative case (≥1): an undeclared part address is **refused** (`valid-part?` false, `part` throws).

## Quality gates

| Gate | Result | Exit |
|---|---|---|
| `npm run test:freehand` (node / CLJS) | Ran 649 tests, 4132 assertions. 0 failures, 0 errors. | 0 |
| `clojure -M:test -n …pilot-theming-cljs-test` (JVM host) | Ran 8 tests, 16 assertions. 0 failures, 0 errors. | 0 |
| `npm run test:browser` (real Chromium) | Ran 600 tests, 3519 assertions. 0 failures, 0 errors. | 0 |

`mkdocs build --strict` not run — no `spec/` or `docs/` files were touched (see note).

## Note on the spec section

The theming section's canonical home is `spec/004-Views.md` (a declared vacancy), which is under the worker file-ownership fence for this dispatch (a live/pending worker holds it, and it is a hot-zone file). I did **not** edit it. The bead's acceptance is fully code/test/manifest-provable and is proven above; the `004-Views.md` §"Theming and semantic parts" prose should land through its owning worker's lane.

## Cross-reference

- Bead: `rf2-drpa3.39` (parent `rf2-drpa3` / EP-0036; depends on `rf2-drpa3.38` F5a; blocks `rf2-drpa3.53` F6a).
- Decision: `docs/design/freehand/decisions/D018-theming-and-parts.md`.
