### PR TITLE
fix(freehand): pilot ref-normalization exclusivity + D007 CASE-A suppression evidence (rf2-drpa3.135, .124)

### DIFF
--- a/implementation/freehand/test/re_frame/freehand/pilot_field.cljc
+++ b/implementation/freehand/test/re_frame/freehand/pilot_field.cljc
@@ -472,7 +472,9 @@
 
   ;; R-A9. An asynchronous normalisation of the committed text. The
   ;; request carries a token; only the settle that names the CURRENT token
-  ;; may land, so a superseded reply is inert rather than racing.
+  ;; may land, so a superseded reply is inert rather than racing. The token
+  ;; IS the outstanding request's identity: a terminal outcome retires it,
+  ;; and a settle that does not name the current token does nothing.
   (rf/reg-event :acme.invoice/reference-submitted
     (fn [{:keys [db]} [_ id text token]]
       {:db (-> db
@@ -480,24 +482,36 @@
                (assoc-in [:invoice id :normalise-token] token)
                (assoc-in [:invoice id :submitted-reference] text))}))
 
+  ;; A SUCCESS settles the request it names. It retires the token — so a
+  ;; late or duplicate reply for the same request finds no match and is
+  ;; inert — and clears any prior reference-error, because a current
+  ;; success is the new baseline decision that supersedes an earlier
+  ;; refusal.
   (rf/reg-event :acme.invoice/reference-normalised
     (fn [{:keys [db]} [_ id token normalised]]
       (if (= token (get-in db [:invoice id :normalise-token]))
         {:db (-> db
                  (assoc-in [:invoice id :normalising?] false)
+                 (assoc-in [:invoice id :normalise-token] nil)
                  (assoc-in [:invoice id :reference] normalised)
+                 (assoc-in [:invoice id :reference-error] nil)
                  (update-in [:invoice id :reference-revision] inc)
                  (update ::normalised (fnil conj []) normalised))}
         {})))
 
-  ;; THE REJECTION. The caller refuses the committed draft and stands by
-  ;; the value it already had — advancing the revision is what says "this
-  ;; is a NEW baseline decision" in the one case value-equality cannot
-  ;; see.
+  ;; THE REJECTION, and the other terminal outcome. The caller refuses the
+  ;; committed draft and stands by the value it already had — advancing the
+  ;; revision is what says "this is a NEW baseline decision" in the one case
+  ;; value-equality cannot see. It also retires any outstanding token, so a
+  ;; success still in flight for the refused request cannot land afterwards
+  ;; and overwrite the refusal. With no request outstanding (the direct
+  ;; same-value rejection R-A3 exercises) the token is already nil and this
+  ;; is a no-op.
   (rf/reg-event :acme.invoice/reference-refused
     (fn [{:keys [db]} [_ id reason]]
       {:db (-> db
                (assoc-in [:invoice id :normalising?] false)
+               (assoc-in [:invoice id :normalise-token] nil)
                (assoc-in [:invoice id :reference-error] reason)
                (update-in [:invoice id :reference-revision] inc)
                (update ::refused (fnil inc 0)))}))

--- a/implementation/freehand/test/re_frame/freehand/pilot_field_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/pilot_field_cljs_test.cljc
@@ -763,6 +763,57 @@
           (is (= "REF-DRAFT" (first results))
               "non-vacuous: what they agreed on is the live draft"))))))
 
+(deftest r-a9-terminal-outcomes-are-mutually-exclusive
+  (testing "rf2-drpa3.135. A submitted request settles exactly once. The
+            token IS the request's identity, so whichever terminal outcome —
+            success or refusal — lands FIRST retires it, and any later or
+            duplicate settle for that request is inert. A success also
+            clears a prior refusal's message, because it is the newer
+            baseline decision. These are the terminal-order seams a token
+            protocol that only GUARDS the winner, without RETIRING the
+            request, leaves open."
+    (each-mode
+      (fn [mode]
+        (testing "a refusal retires the request: a success still in flight
+                  for it cannot land afterwards and overwrite the refusal"
+          (seed-line! 1)
+          (send! [:acme.invoice/reference-submitted 1 "ref-x" :req-1])
+          (send! [:acme.invoice/reference-refused 1 "That reference is not on file."])
+          (send! [:acme.invoice/reference-normalised 1 :req-1 "REF-LATE"])
+          (is (= "REF-1" (get-in (app-db) [:invoice 1 :reference]))
+              "the late success did not move the refused baseline")
+          (is (nil? (::pilot/normalised (app-db)))
+              "and settled nothing at all")
+          (is (= "That reference is not on file."
+                 (get-in (app-db) [:invoice 1 :reference-error]))
+              "the refusal's message still stands"))
+
+        (testing "a current success clears a prior refusal's error as it
+                  stores the normalised value"
+          (seed-line! 1)
+          (send! [:acme.invoice/reference-refused 1 "That reference is not on file."])
+          (is (= "That reference is not on file."
+                 (get-in (app-db) [:invoice 1 :reference-error]))
+              "the refusal set an error")
+          (send! [:acme.invoice/reference-submitted 1 "ref-y" :req-2])
+          (send! [:acme.invoice/reference-normalised 1 :req-2 "REF-Y"])
+          (is (= "REF-Y" (get-in (app-db) [:invoice 1 :reference]))
+              "the fresh request's success lands")
+          (is (nil? (get-in (app-db) [:invoice 1 :reference-error]))
+              "and the stale rejection message is gone, not retained"))
+
+        (testing "a duplicate success for an already-settled request is
+                  inert — the first outcome retired it"
+          (seed-line! 1)
+          (send! [:acme.invoice/reference-submitted 1 "ref-z" :req-3])
+          (send! [:acme.invoice/reference-normalised 1 :req-3 "REF-Z"])
+          (let [after-first (app-db)]
+            (send! [:acme.invoice/reference-normalised 1 :req-3 "REF-Z"])
+            (is (= after-first (app-db))
+                "the duplicate settle moved no state at all")
+            (is (= ["REF-Z"] (::pilot/normalised (app-db)))
+                "non-vacuous: the success was recorded exactly once")))))))
+
 ;; ===========================================================================
 ;; R-A10 — busy from the in-flight write's own state
 ;; ===========================================================================

--- a/implementation/freehand/test/re_frame/freehand/pilot_field_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/pilot_field_cljs_test.cljc
@@ -969,6 +969,74 @@
                   "while three of the four fields render byte-identical output"))))))))
 
 ;; ===========================================================================
+;; D007 — CASE A's datum: one data event, and the cost it pays
+;; ===========================================================================
+
+(deftest d007-case-a-wants-suppression-not-prevent-default
+  (testing "rf2-drpa3.124, evidence for D007. The gate asks whether the
+            closed key-condition map earns its place. CASE A's datum is
+            that it did NOT use one, and the reason is the useful part.
+
+            (1) Its two key intents — Enter commits, Escape reverts — ride
+            ONE registered event that branches on the live key string, so
+            the key map buys CASE A nothing on the per-key preventDefault
+            grounds D007 argues from. (2) The one preventDefault CASE A
+            wants is form-level submission, and the options map already
+            carries it — no keyboard site asks for one. (3) The cost a key
+            map WOULD pay for is dispatch SUPPRESSION: the data site fires
+            on every key, so an unmatched key still settles a no-op that a
+            closed map would elide. That argument applies to every
+            keyboard-bearing control, not only the ones that preventDefault,
+            and it is the one to weigh on its own. The MEASURED per-keystroke
+            cost lives in `r-a12-the-per-keystroke-cost-of-a-four-field-form`;
+            this row records the datum as a decision input."
+    (each-mode
+      (fn [mode]
+        (seed-line! 1)
+        (let [tree      (render! (line-form mode 1))
+              form-node (component-node tree "acme/invoice-line")
+              c         (control-of (buffered-node tree "reference"))
+              down      (:on-key-down (t/attrs c))]
+
+          (testing "the keys are ONE data event, not a closed key map"
+            (is (= :acme.ui.buffered/key-pressed (first down))
+                "every key routes through one registered event")
+            (is (= ::v/key (last down))
+                "carrying the live key as data — a JVM test drives it by equality")
+            (is (empty? (filter #{"Enter" "Escape" "Tab" "ArrowUp"} down))
+                "no key literal sits at the site: the branch is in the handler,
+                 so there is no closed key MAP here for D007 to weigh"))
+
+          (testing "the one preventDefault CASE A wants is form submission,
+                    and it rides the options map"
+            (let [submit (:on-submit (t/attrs form-node))]
+              (is (map? submit) "submission is declared as an options map")
+              (is (true? (:prevent-default submit))
+                  "which is where the single preventDefault lives")
+              (is (vector? (:event submit)) "carrying the caller's own intent"))
+            (is (not (contains? (t/attrs c) :prevent-default))
+                "the keyboard site itself asks for no preventDefault — what
+                 CASE A wants there is suppression, not browser mechanics"))
+
+          (testing "the ONE event decides Enter, Escape and everything else —
+                    and an unmatched key still DISPATCHES, which is the no-op
+                    a key map would suppress"
+            (fire! c :on-input "REF-DRAFT")
+            (is (some? (record [:invoice 1 :reference])) "a live draft exists to settle")
+            (let [seen (atom [])]
+              (rf/register-listener! :events ::key-probe #(swap! seen conj (:event-id %)))
+              (let [before (app-db)]
+                (send! (v/materialize-event down {::v/key "a"}))
+                (is (= before (app-db))
+                    "an unmatched key moves NO state — 'a missing key is a no-op'")
+                (is (= [:acme.ui.buffered/key-pressed] @seen)
+                    "yet it DID dispatch: exactly the traffic a key map would elide"))
+              (rf/unregister-listener! :events ::key-probe))
+            (send! (v/materialize-event down {::v/key "Escape"}))
+            (is (nil? (record [:invoice 1 :reference]))
+                "and Escape reverts through that same one event")))))))
+
+;; ===========================================================================
 ;; Promotion parity — the same suite, and the same trees
 ;; ===========================================================================
 


### PR DESCRIPTION
Two pilot-surface beads on the F5f pilot (`pilot_field*`), one PR. Both are test-tier: the fixes live in the pilot's own test/fixture files, with no fenced production code touched.

## rf2-drpa3.135 (P2 bug) — terminal reference-normalisation outcomes made mutually exclusive

The pilot's async reference-normalisation tracked an outstanding `normalise-token` but never finished the ownership protocol at its terminal transitions, so one request could settle twice and a stale rejection could survive a later success (gh-6747).

- `:acme.invoice/reference-normalised` now **retires the token it settles** (a late or duplicate reply for the same request finds no match and is inert) and **clears any prior `reference-error`** — a current success is the newer baseline decision that supersedes an earlier refusal.
- `:acme.invoice/reference-refused` now **retires any outstanding token**, so a success still in flight for the refused request cannot land afterwards and overwrite the refusal. With no request outstanding — the direct same-value rejection R-A3 exercises — the token is already nil and this is a no-op, so R-A3 is preserved.

New `r-a9-terminal-outcomes-are-mutually-exclusive` covers the three terminal-order seams in **both interpreted and compiled** modes:
1. refuse-then-late-success is inert (acceptance 1);
2. a current success clears a prior refusal's error (acceptance 2);
3. a duplicate success for an already-settled request moves nothing (acceptance 1).

R-A9's superseded-reply evidence (acceptance 3) and R-A3's direct rejection (acceptance 4) are unchanged and still green. No async resource/transport framework or new substrate API added (acceptance 5). The bug and fix are pilot/application state-machine bookkeeping in the fixture's own `reg-event` handlers — core reference-normalisation (react.cljs/compiler) was not touched.

## rf2-drpa3.124 (P3, evidence) — D007 CASE-A datum: keys are one data event, the cost is suppression

Records the first pilot's datum for decision **D007** (the delete-before-release gate on the closed key-condition map) as a structural test. `d007-case-a-wants-suppression-not-prevent-default` proves, in both modes:

- CASE A's two key intents (Enter commits, Escape reverts) ride **ONE** registered event branching on the live `::v/key` string — no key literal at the site — so the key map buys nothing on the per-key `preventDefault` grounds D007 argues from.
- The one `preventDefault` CASE A wants is **form-level submission**, carried by the `:on-submit` options map; no keyboard site asks for one.
- The cost a key map WOULD pay for is **dispatch suppression**: an unmatched key still dispatches `key-pressed` (a settled no-op) — the traffic a closed map would elide on every keyboard-bearing control.

The measured per-keystroke cost stays in R-A12; this row cross-references it and frames the datum for the D007 gate. No production/fixture change.

## Quality gates

Run from `implementation/` (exit codes captured, all 0):

- `npm run test:freehand` — **exit 0** — `Ran 653 tests containing 4181 assertions. 0 failures, 0 errors.`
- `npm run test:browser` — **exit 0** — `Browser tests: Ran 607 tests containing 3605 assertions. 0 failures, 0 errors.`

## Cross-refs

- Beads: rf2-drpa3.135 (external gh-6747), rf2-drpa3.124. Parent epic: rf2-drpa3 (EP-0036). Discovered from the F5f pilot rf2-drpa3.43.
- Owning decision for the .124 evidence: **D007**. Gate: dropdown/typeahead pilot rf2-drpa3.44.
- `.beads/` tracker export deliberately excluded from this branch (mayor-owned).
