### PR TITLE
fix(freehand): honest root remount — error-callback + immutable-prefix drift precedence (rf2-drpa3.139, .140)

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/root.cljs
+++ b/implementation/freehand/src/re_frame/freehand/root.cljs
@@ -56,6 +56,20 @@
   refused is DRIFT, not the re-mount: the same effective prefix, authored
   or derived, is the ordinary reload.
 
+  The SAME `createRoot`-fixes-the-options fact governs the three host error
+  callbacks — `:on-uncaught-error`, `:on-caught-error`,
+  `:on-recoverable-error` — but their honest answer is the opposite one.
+  Identity must stay put, so a prefix that would move is refused; a callback
+  is meant to move — a hot reload's fresh closure is the ordinary case, and
+  refusing it would make HMR needlessly brittle. So rather than pass the
+  opts' callbacks straight to React (where the first mount's would be fixed
+  and every later one silently ignored), the root installs one STABLE
+  delegate per key that reads the live callback off a mutable cell, and an
+  accepted re-mount advances that cell. React holds the delegate; the
+  delegate's target is what the remount moves. A key a mount omits falls
+  back to React's own default reporting for that error kind, so a stale
+  closure is never retained and a newly supplied one is never dropped.
+
   ## HMR identity — occurrence identity is the qualified view id
 
   A root's occurrence identity is its `:root-id`, and a derived
@@ -222,8 +236,17 @@
 ;; with a descriptor or a props map. It carries the static Root Descriptor
 ;; (the identity the registry keys on), the claims the registry holds on
 ;; its behalf, and the host handles a re-render and a teardown need.
+;;
+;; `callbacks` is a mutable cell (a `volatile!`) holding the root's CURRENT
+;; host-error callbacks — the `{:on-uncaught-error … :on-caught-error …
+;; :on-recoverable-error …}` subset of the last accepted mount's opts. React
+;; fixes a root's options at `createRoot`, so the running root cannot adopt a
+;; fresh callback object; the framework installs a stable delegate per key
+;; that READS this cell, and an accepted re-mount advances the cell rather
+;; than silently keeping the first mount's closures. A remount reuses the
+;; incumbent's cell, so the delegates React already fixed see the new target.
 
-(deftype Root [descriptor container react-root identifier-prefix frame-id hydrated])
+(deftype Root [descriptor container react-root identifier-prefix frame-id hydrated callbacks])
 
 (defn root?
   "True when `x` is a live [[mount]] / [[hydrate-root]] handle."
@@ -726,15 +749,40 @@
 ;; React root options
 ;; ---------------------------------------------------------------------------
 
-(defn- report-recoverable-default!
-  "React's own default `onRecoverableError` reporting, preserved when the
-  app authored no callback but the framework installed a wrapper: once a
-  wrapper is set React no longer runs its default, so it is replicated
-  here rather than swallowed."
+(defn- report-error!
+  "React's own default reporting for an UNCAUGHT or a RECOVERABLE error:
+  hand it to the host `reportError` so a window error handler still sees it,
+  or `console.error` on a runtime without one. Replicated here because the
+  framework always installs a stable delegate for these keys (so a remount
+  can advance the callback), and once a delegate is set React no longer runs
+  its own default — a delegate that swallowed the no-callback case would be
+  a silent regression rather than the honest passthrough this is."
   [error*]
   (if (fn? (.-reportError js/globalThis))
     (js/reportError error*)
     (when (exists? js/console) (.error js/console error*))))
+
+(defn- report-caught!
+  "React's own default for an error an Error Boundary CAUGHT: the boundary
+  handled it, so the default is an informational `console.error`, not a
+  re-throw to the window the way an uncaught or recoverable error earns."
+  [error*]
+  (when (exists? js/console) (.error js/console error*)))
+
+(defn- host-callback-delegate
+  "A stable React error-option callback that dispatches to the CURRENT
+  authored callback under `k` in the root's `callbacks` cell, falling back
+  to `default!` — React's own reporting for that error kind — when the cell
+  holds no fn there.
+
+  This is the whole of the remount-honesty mechanism: React fixes a root's
+  options at creation, so the delegate object never changes, but the cell it
+  reads is advanced by an accepted re-mount. A callback supplied on the
+  reload therefore takes effect and the first mount's is not silently kept."
+  [callbacks k default!]
+  (fn [error* error-info]
+    (let [f (get @callbacks k)]
+      (if (fn? f) (f error* error-info) (default! error*)))))
 
 (defn- emit-hydration-mismatch!
   [root-id error*]
@@ -749,20 +797,23 @@
   "The composed `onRecoverableError` for a HYDRATING root.
 
   `adoption` is the root-local `#js {:adopting true}` window flag;
-  `authored` is the host's own `:on-recoverable-error` or nil. The
-  framework diagnostic fires only while the window is open, and the
-  authored callback is ALWAYS delegated to — compose, never clobber —
-  inside the window and outside it.
+  `callbacks` is the root's live host-callback cell (see [[Root]]). The
+  framework diagnostic fires only while the window is open, and the CURRENT
+  authored `:on-recoverable-error` — the one the last accepted mount
+  supplied — is ALWAYS delegated to (compose, never clobber), inside the
+  window and outside it, falling back to React's default when none is set.
+  Reading the callback off the cell rather than capturing it is what lets a
+  re-mount advance it: React fixes this delegate at `hydrateRoot`, but the
+  cell it reads is not fixed.
 
   Public so a mounted browser proof can drive the REAL callback across the
   window boundary rather than a stand-in shaped like it."
-  [^js adoption root-id authored]
-  (fn on-recoverable [error* error-info]
-    (when (.-adopting adoption)
-      (emit-hydration-mismatch! root-id error*))
-    (if (fn? authored)
-      (authored error* error-info)
-      (report-recoverable-default! error*))))
+  [^js adoption root-id callbacks]
+  (let [delegate (host-callback-delegate callbacks :on-recoverable-error report-error!)]
+    (fn on-recoverable [error* error-info]
+      (when (.-adopting adoption)
+        (emit-hydration-mismatch! root-id error*))
+      (delegate error* error-info))))
 
 (defn ^:no-doc adoption-window-closer
   "A React component that CLOSES a hydrating root's adoption window on its
@@ -781,13 +832,21 @@
   nil)
 
 (defn- root-options
-  [prefix {:keys [on-uncaught-error on-caught-error on-recoverable-error]} on-recoverable]
+  "The React root options object: `identifierPrefix` and the three stable
+  host-error delegates. Each delegate reads the CURRENT authored callback
+  off `callbacks` (the root's live cell, advanced by an accepted remount)
+  and defaults to React's own reporting when none is set — so installing
+  them is honest for a root that supplied no callback and STAYS honest
+  across a remount that supplies or changes one. `recoverable` overrides the
+  recoverable delegate for a hydrating root: the adoption reporter, which
+  composes the mismatch signal over the same cell."
+  [prefix callbacks recoverable]
   (let [o (js-obj)]
     (when prefix (aset o "identifierPrefix" prefix))
-    (when (fn? on-uncaught-error) (aset o "onUncaughtError" on-uncaught-error))
-    (when (fn? on-caught-error) (aset o "onCaughtError" on-caught-error))
-    (let [recoverable (or on-recoverable on-recoverable-error)]
-      (when (fn? recoverable) (aset o "onRecoverableError" recoverable)))
+    (aset o "onUncaughtError" (host-callback-delegate callbacks :on-uncaught-error report-error!))
+    (aset o "onCaughtError"   (host-callback-delegate callbacks :on-caught-error report-caught!))
+    (aset o "onRecoverableError"
+          (or recoverable (host-callback-delegate callbacks :on-recoverable-error report-error!)))
     o))
 
 (defn- root-element
@@ -843,9 +902,11 @@
   fallback. Both are ordinary client renders, and both hand the host root
   they allocate to `keep!` so a render that throws gives it back."
   [desc dom-node prefix opts frame-id element keep!]
-  (let [react-root (keep! (rdc/createRoot dom-node (root-options prefix opts nil)))]
+  (let [callbacks  (volatile! (select-keys opts host-opt-keys))
+        react-root (keep! (rdc/createRoot dom-node (root-options prefix callbacks nil)))]
     (.render react-root element)
-    (register! (:root-id desc) (->Root desc dom-node react-root prefix frame-id false))))
+    (register! (:root-id desc)
+               (->Root desc dom-node react-root prefix frame-id false callbacks))))
 
 (defn mount
   "Mount the declared view at `root-form`'s head into `dom-node`, and
@@ -867,7 +928,17 @@
   `opts` is a CLOSED map: `:root-id` / `:disambiguator` /
   `:identifier-prefix` (identity), `:frame` (the preflight plan), and
   React's `:on-uncaught-error` / `:on-caught-error` /
-  `:on-recoverable-error`."
+  `:on-recoverable-error`.
+
+  The three host error callbacks are LATE-BOUND across the reload. React
+  fixes a root's options when it creates it, so the framework installs a
+  stable delegate per key and an accepted re-mount ADVANCES the callback the
+  delegate runs: the effective callback for each key is the one from the
+  MOST RECENT accepted mount. A re-mount that changes a callback drops the
+  stale one; a re-mount that omits a callback it earlier supplied restores
+  React's own default reporting for that kind. What never happens is the
+  first mount's closure quietly outliving a reload that replaced it — unlike
+  the immutable `:identifier-prefix`, a callback is meant to move."
   ([root-form dom-node] (mount root-form dom-node {}))
   ([root-form dom-node opts]
    (check-opt-keys! 'v/mount opts mount-opt-keys)
@@ -905,8 +976,16 @@
            ;; root belongs to the INCUMBENT, so it is not handed to `keep!`:
            ;; a re-render that fails leaves the incumbent rendering.
            (let [react-root (.-react-root existing)
+                 callbacks  (.-callbacks existing)
                  root       (->Root desc dom-node react-root prefix frame-id
-                                    (.-hydrated existing))]
+                                    (.-hydrated existing) callbacks)]
+             ;; Advance the live host-callback cell to THIS mount's callbacks
+             ;; before re-rendering. React fixed the error delegates at
+             ;; createRoot, so a reload's fresh :on-*-error closures reach
+             ;; React only through the cell those delegates read; keeping the
+             ;; incumbent's cell object is what makes the already-fixed
+             ;; delegates see the new target instead of the stale one.
+             (vreset! callbacks (select-keys opts host-opt-keys))
              (.render react-root element)
              (register! root-id root))
            (client-render! desc dom-node prefix opts frame-id element keep!)))))))
@@ -1017,8 +1096,9 @@
     ;; The adoption window, its reporter and the element they ride on are
     ;; all built BEFORE preflight, for the same reason the element is: they
     ;; are construction, they can fail, and preflight is what writes.
-    (let [adoption  #js {:adopting true}
-          reporter  (hydration-reporter adoption root-id (:on-recoverable-error opts))
+    (let [callbacks (volatile! (select-keys opts host-opt-keys))
+          adoption  #js {:adopting true}
+          reporter  (hydration-reporter adoption root-id callbacks)
           closer    (react/createElement adoption-window-closer
                                          #js {:key "rf-adoption" :rfAdoption adoption})
           element   (root-element root-form frame-id [closer])
@@ -1029,9 +1109,9 @@
         (fn [keep!]
           (recheck-claim! 'v/hydrate-root dom-node root-id prefix existing)
           (let [react-root (keep! (rdc/hydrateRoot dom-node element
-                                                   (root-options prefix opts reporter)))]
+                                                   (root-options prefix callbacks reporter)))]
             (register! root-id (->Root (descriptor-for ident) dom-node react-root
-                                       prefix frame-id true))))))))
+                                       prefix frame-id true callbacks))))))))
 
 (defn hydrate-root
   "Adopt the server-rendered markup already in `dom-node` for the declared

--- a/implementation/freehand/src/re_frame/freehand/root.cljs
+++ b/implementation/freehand/src/re_frame/freehand/root.cljs
@@ -500,8 +500,50 @@
                    (some? root-id) (assoc :root-id root-id))}))
   dom-node)
 
+(defn- require-stable-identifier-prefix!
+  "The fourth admission claim, and the one only a RE-MOUNT can fail: the
+  effective `identifierPrefix` a live root was created with is the prefix
+  it keeps.
+
+  The reload path re-renders the EXISTING host root, and a React root's
+  options are fixed at `createRoot` — the running root has no way to adopt
+  a new prefix. Accepting the drift would put the registry and React out
+  of step in the one place it costs the most: the entry would claim a
+  prefix `use-id` never emits, and would leave the OLD prefix looking free
+  to the uniqueness check, so the next root to author it is admitted
+  against a live root still rendering under it. That is the cross-root
+  `use-id` collision the prefix claim exists to prevent, manufactured by
+  the check itself.
+
+  So drift fails loud, alongside the other three claims and for the same
+  reason: raised before preflight and before any React work, the live root
+  keeps its prefix, its claim, its frame and its committed DOM. It runs
+  inside [[claim!]] with PRECEDENCE over the cross-root prefix-uniqueness
+  check: once the same-root/same-container incumbent is known, a requested
+  prefix that differs from ITS own is drift the reload cannot carry — and
+  its recovery, unmount-first, is the real one. Reporting it as a duplicate
+  of whichever OTHER root happens to own the requested value would send the
+  author chasing a distinct prefix, when EVERY prefix but the incumbent's is
+  equally forbidden for that reused root."
+  [where root-id requested ^Root existing]
+  (when (and (some? existing) (not= requested (.-identifier-prefix existing)))
+    (error/throw-error!
+      :rf.error/root-identifier-prefix-immutable where
+      (str "re-mounting root " (pr-str root-id) " asks for identifierPrefix "
+           (pr-str requested) ", but the live root in that container was created "
+           "with " (pr-str (.-identifier-prefix existing)) " — a root's "
+           "identifierPrefix is fixed when React creates it, so a re-mount "
+           "re-renders that root under the OLD prefix and use-id keeps emitting "
+           "it. Unmount this root and mount again to render under the new "
+           "prefix, or drop the change.")
+      {:recovery :unmount-before-changing-identifier-prefix
+       :extra    {:root-id   root-id
+                  :requested requested
+                  :existing  (.-identifier-prefix existing)}}))
+  nil)
+
 (defn- claim!
-  "Assert the three admission claims and answer the live root this mount
+  "Assert the admission claims and answer the live root this mount
   RE-RENDERS, or nil when it is a fresh root.
 
   Every arm here throws before any React work and before any registry or
@@ -535,6 +577,12 @@
                "first, or mount into a fresh node.")
           {:recovery :unmount-the-owning-root-first
            :extra    {:root-id root-id :owner-root-id owner}})))
+    ;; The fourth admission claim, given PRECEDENCE over cross-root prefix
+    ;; ownership below: once the same-root/same-container incumbent is known,
+    ;; a requested prefix that differs from ITS own is immutable-prefix drift,
+    ;; not a duplicate of whatever other root owns the requested value. A
+    ;; fresh root (no incumbent) skips this and meets the duplicate check.
+    (require-stable-identifier-prefix! where root-id prefix existing)
     (when-let [owner (owner-of-prefix prefix root-id)]
       (error/throw-error!
         :rf.error/duplicate-identifier-prefix where
@@ -546,41 +594,6 @@
         {:recovery :make-identifier-prefixes-unique
          :extra    {:root-id root-id :identifier-prefix prefix :owner-root-id owner}}))
     existing))
-
-(defn- require-stable-identifier-prefix!
-  "The fourth admission claim, and the one only a RE-MOUNT can fail: the
-  effective `identifierPrefix` a live root was created with is the prefix
-  it keeps.
-
-  The reload path re-renders the EXISTING host root, and a React root's
-  options are fixed at `createRoot` — the running root has no way to adopt
-  a new prefix. Accepting the drift would put the registry and React out
-  of step in the one place it costs the most: the entry would claim a
-  prefix `use-id` never emits, and would leave the OLD prefix looking free
-  to the uniqueness check above, so the next root to author it is admitted
-  against a live root still rendering under it. That is the cross-root
-  `use-id` collision the prefix claim exists to prevent, manufactured by
-  the check itself.
-
-  So drift fails loud, here, alongside the other three claims and for the
-  same reason: raised before preflight and before any React work, the live
-  root keeps its prefix, its claim, its frame and its committed DOM."
-  [where root-id requested ^Root existing]
-  (when (and (some? existing) (not= requested (.-identifier-prefix existing)))
-    (error/throw-error!
-      :rf.error/root-identifier-prefix-immutable where
-      (str "re-mounting root " (pr-str root-id) " asks for identifierPrefix "
-           (pr-str requested) ", but the live root in that container was created "
-           "with " (pr-str (.-identifier-prefix existing)) " — a root's "
-           "identifierPrefix is fixed when React creates it, so a re-mount "
-           "re-renders that root under the OLD prefix and use-id keeps emitting "
-           "it. Unmount this root and mount again to render under the new "
-           "prefix, or drop the change.")
-      {:recovery :unmount-before-changing-identifier-prefix
-       :extra    {:root-id   root-id
-                  :requested requested
-                  :existing  (.-identifier-prefix existing)}}))
-  nil)
 
 (defn- recheck-claim!
   "Re-assert the admission claims AFTER preflight, and require the same
@@ -959,10 +972,10 @@
          ;; not read one.
          element        (root-element root-form frame-id nil)
          acquired?      (and (some? frame-id) (not (frame-ref-held? frame-id root-id)))]
-     ;; The fourth admission claim, before preflight because a refused root
-     ;; must not have run one: the effective identifierPrefix a live root was
-     ;; created with is immutable across a re-mount.
-     (require-stable-identifier-prefix! 'v/mount root-id prefix existing)
+     ;; The fourth admission claim — the immutable identifierPrefix — is
+     ;; asserted inside `claim!` above, before preflight and with precedence
+     ;; over cross-root prefix ownership, so a refused re-mount has run no
+     ;; plan and given nothing away.
      (preflight! 'v/mount plan root-id)
      (attempt!
        frame-id root-id acquired?

--- a/implementation/freehand/test/re_frame/freehand/root_error_callbacks_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/root_error_callbacks_dom_cljs_test.cljs
@@ -1,0 +1,290 @@
+(ns re-frame.freehand.root-error-callbacks-dom-cljs-test
+  "FH-ROOT-002, the fourth arm — a root's host ERROR CALLBACKS are honest
+  across an idempotent remount.
+
+  React fixes a root's options at `createRoot`, so a reload that re-renders
+  the live host root cannot hand React a fresh callback object. A root that
+  passed the opts' callbacks straight to React would therefore install the
+  FIRST mount's closures and silently ignore every later one — especially
+  surprising on the HMR path, where a fresh closure per reload is ordinary.
+
+  The fix is a stable delegate per key that reads the CURRENT callback off a
+  mutable per-root cell, advanced by an accepted remount. This file is the
+  adversarial proof of that, on the REAL React root path — real
+  `createRoot`/`hydrateRoot` options, real React error kinds, the callback
+  read back off what actually ran:
+
+    - `:on-caught-error`      — a child throws under a real error boundary on
+                                the reload; React catches and calls the root's
+                                onCaughtError. The NEW callback runs, the
+                                stale one does not.
+    - `:on-uncaught-error`    — the same throw with NO boundary; React reports
+                                it uncaught. Advanced across a remount, AND
+                                honored when the first mount omitted the key
+                                entirely (the delegate is installed regardless
+                                of first-mount opts — a fix that only wired
+                                keys present at createRoot would silently drop
+                                a callback a reload adds).
+    - `:on-recoverable-error` — a hydration mismatch, the canonical trigger,
+                                proving the recoverable delegate reads the
+                                authored callback off the same cell on the
+                                real `hydrateRoot` path.
+
+  An uncaught error with NO callback re-throws at the window and the browser
+  runner fails the whole suite on it (the same reason the hydration suite
+  always supplies `:on-recoverable-error`); every throw here is triggered
+  only under a callback that swallows it.
+
+  This file rides the browser lane through its `-dom-cljs-test` namespace
+  suffix. It also matches the node suites' broader regex, where it has no DOM
+  to mount and says so rather than passing quietly."
+  (:require ["react" :as react]
+            [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.react :as fr]
+            [re-frame.freehand.root :as root]
+            [re-frame.freehand.root-views :as views]
+            ;; The SSR artefact's manifest namespace publishes the discovery
+            ;; hook the recoverable arm's hydrate needs, and owns the wire form
+            ;; the arm plants. A test-tree require of the seam being exercised.
+            [re-frame.ssr.manifest :as ssr-manifest]))
+
+;; ---------------------------------------------------------------------------
+;; The declarations. Module-level, because a declared view cannot close over a
+;; test's locals. `poison?` toggles whether the shared child throws on its
+;; NEXT render, so one view-id can be mounted clean and then re-mounted
+;; throwing — which is exactly the reload shape under test.
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private poison? (atom false))
+
+(v/defview cb-child
+  "The child that throws on render when the module toggle is set. The poison
+  a boundary above catches, or — mounted bare — React reports uncaught."
+  [_]
+  (if @poison?
+    (throw (ex-info "cb-child poison" {}))
+    [:span#ok "ok"]))
+
+(v/defview cb-guarded
+  "`cb-child` under a REAL React error boundary, so a throw from the child is
+  CAUGHT and surfaces at the root's onCaughtError. No `:on-error` — the
+  boundary then dispatches nothing, so this needs no frame in scope."
+  [_]
+  [v/error-boundary {:fallback [:p#fb "caught"] :reset-key 1}
+   [cb-child {}]])
+
+(v/defview cb-bare
+  "`cb-child` with NO boundary, so a throw surfaces at the root's
+  onUncaughtError."
+  [_]
+  [cb-child {}])
+
+(use-fixtures :each
+  {:before (fn [] (reset! poison? false) (root/reset-registry!) (fr/reset-boundaries!))
+   :after  (fn [] (reset! poison? false) (root/reset-registry!) (fr/reset-boundaries!))})
+
+(defn- browser? []
+  (and (exists? js/document) (some? (.-createElement js/document))))
+
+(defn- act
+  [thunk]
+  (try
+    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+    (js/Promise.resolve (react/act (fn [] (js/Promise.resolve (thunk)))))
+    (catch :default e
+      (js/Promise.reject e))))
+
+(defn- host-node! []
+  (let [container (js/document.createElement "div")]
+    (.appendChild js/document.body container)
+    container))
+
+(defn- text [container selector]
+  (some-> (.querySelector container selector) .-textContent))
+
+(defn- skip! [why]
+  (is true (str "a real React mount needs a DOM host — " why)))
+
+(defn- server-node!
+  "A container carrying `html` plus its Root Manifest as the container's
+  immediately following element sibling — the shape a hydrating page
+  presents. Answers the container."
+  [html manifest]
+  (let [host (js/document.createElement "div")]
+    (set! (.-innerHTML host)
+          (str "<div>" html "</div>" (ssr-manifest/script-html manifest)))
+    (.appendChild js/document.body host)
+    (.-firstElementChild host)))
+
+(defn- remove-node! [container]
+  (some-> container .-parentElement .remove))
+
+(defn- poll-until
+  "Poll `pred` every 5ms up to ~2s, then call `k`. Bounded, so an outcome
+  that never arrives lets the assertions fail honestly rather than hang."
+  [pred k]
+  (let [tries (atom 0)]
+    (letfn [(step []
+              (if (or (pred) (>= @tries 400))
+                (k)
+                (do (swap! tries inc) (js/setTimeout step 5))))]
+      (step))))
+
+(defn- settle
+  "Give a clean commit a moment to land, then call `k`."
+  [k]
+  (js/setTimeout k 60))
+
+(defn- cbs
+  "The three host error callbacks, each recording `[tag kind]` into `calls`
+  when React runs it — so an assertion can read back WHICH mount's callback
+  actually fired for a given error kind."
+  [tag calls]
+  {:on-uncaught-error    (fn [_ _] (swap! calls conj [tag :uncaught]))
+   :on-caught-error      (fn [_ _] (swap! calls conj [tag :caught]))
+   :on-recoverable-error (fn [_ _] (swap! calls conj [tag :recoverable]))})
+
+(defn- fired? [calls tag kind]
+  (boolean (some #{[tag kind]} @calls)))
+
+;; ===========================================================================
+;; :on-caught-error — a reload advances the caught callback (act, deterministic)
+;; ===========================================================================
+
+(deftest an-accepted-remount-advances-the-caught-error-callback
+  (testing "Per FH-ROOT-002 (browser): a re-mount re-renders the live host
+            root, whose options React fixed at createRoot. The first mount's
+            :on-caught-error must NOT be the one React invokes after a reload
+            changes it. A child throws under a real error boundary on the
+            reload; React catches it and calls the root's onCaughtError. The
+            NEW callback runs and the stale one does not — the stable delegate
+            read the cell the remount advanced, not a closure React fixed."
+    (if-not (browser?)
+      (skip! "the browser job runs the caught-callback assertions")
+      (async done
+        (let [c     (host-node!)
+              calls (atom [])]
+          (reset! poison? false)
+          (-> (act #(v/mount [cb-guarded {}] c (cbs :A calls)))
+              (.then (fn [mounted]
+                       (is (= "ok" (text c "#ok"))
+                           "the clean first mount rendered its child")
+                       (reset! poison? true)
+                       (-> (act #(v/mount [cb-guarded {}] c (cbs :B calls)))
+                           (.then (fn [_] mounted)))))
+              (.then (fn [mounted]
+                       (is (= "caught" (text c "#fb"))
+                           "the boundary caught the reload's throw")
+                       (is (fired? calls :B :caught)
+                           (str "the remount's caught callback ran. Saw: " (pr-str @calls)))
+                       (is (not (fired? calls :A :caught))
+                           "the first mount's stale caught callback did NOT run")
+                       (act #(v/unmount! mounted))))
+              (.then (fn [_] (.remove c) (done))
+                     (fn [e]
+                       (is false (str "caught suite rejected: " e))
+                       (.remove c)
+                       (done)))))))))
+
+;; ===========================================================================
+;; :on-uncaught-error — a reload advances the uncaught callback (poll)
+;; ===========================================================================
+
+(deftest an-accepted-remount-advances-the-uncaught-error-callback
+  (testing "Per FH-ROOT-002 (browser): the same claim for onUncaughtError, the
+            key with no boundary above it. React reports the reload's throw
+            uncaught, on its own schedule, so the assertion polls; the mount's
+            own :on-uncaught-error swallows it, so the window sees no error and
+            the runner is not tripped. The remount's callback runs; the first
+            mount's does not."
+    (if-not (browser?)
+      (skip! "the browser job runs the uncaught-callback assertions")
+      (async done
+        (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+        (reset! poison? false)
+        (let [c       (host-node!)
+              calls   (atom [])
+              mounted (v/mount [cb-bare {}] c (cbs :A calls))]
+          (settle
+            (fn []
+              (reset! poison? true)
+              (v/mount [cb-bare {}] c (cbs :B calls))
+              (poll-until
+                #(fired? calls :B :uncaught)
+                (fn []
+                  (is (fired? calls :B :uncaught)
+                      (str "the remount's uncaught callback ran. Saw: " (pr-str @calls)))
+                  (is (not (fired? calls :A :uncaught))
+                      "the first mount's stale uncaught callback did NOT run")
+                  (v/unmount! mounted)
+                  (.remove c)
+                  (done))))))))))
+
+(deftest a-remount-installs-an-uncaught-callback-the-first-mount-omitted
+  (testing "Per FH-ROOT-002 (browser): the delegate is installed for every key
+            regardless of the first mount's opts — so a callback a reload ADDS
+            is honored. The first mount supplies NO callbacks; the reload adds
+            :on-uncaught-error and throws. A fix that only wired the keys
+            present at createRoot would install no delegate here, and React's
+            default would re-throw the reload's error at the window instead —
+            failing the runner rather than recording the callback."
+    (if-not (browser?)
+      (skip! "the browser job runs the added-callback assertions")
+      (async done
+        (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+        (reset! poison? false)
+        (let [c       (host-node!)
+              calls   (atom [])
+              mounted (v/mount [cb-bare {}] c {})]
+          (settle
+            (fn []
+              (reset! poison? true)
+              (v/mount [cb-bare {}] c (cbs :B calls))
+              (poll-until
+                #(fired? calls :B :uncaught)
+                (fn []
+                  (is (fired? calls :B :uncaught)
+                      (str "a callback the first mount omitted took effect on the reload. "
+                           "Saw: " (pr-str @calls)))
+                  (v/unmount! mounted)
+                  (.remove c)
+                  (done))))))))))
+
+;; ===========================================================================
+;; :on-recoverable-error — the third key, on the real hydrateRoot path
+;; ===========================================================================
+
+(deftest a-hydrating-root-runs-the-recoverable-callback-through-the-cell
+  (testing "Per FH-ROOT-002/006 (browser): the recoverable delegate reads the
+            authored :on-recoverable-error off the SAME live cell the other
+            two keys use — proven on the real hydrateRoot path by a hydration
+            mismatch, React's canonical onRecoverableError trigger. The
+            server's #who text disagrees with the client's, React recovers,
+            and the host callback runs (composed under the framework's own
+            mismatch signal)."
+    (if-not (browser?)
+      (skip! "the browser job runs the recoverable-callback assertions")
+      (async done
+        (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+        (let [manifest {:rf.root/schema-version 1
+                        :root-id                :fh.root/cb-hydrate
+                        :identifier-prefix      "cb6-"}
+              node     (server-node!
+                         (str "<section id=\"greeting\"><h1 id=\"title\">Hello</h1>"
+                              "<p id=\"who\">SERVER</p></section>")
+                         manifest)
+              calls    (atom [])
+              mounted  (v/hydrate-root node [views/greeting {:name "client"}]
+                                       (cbs :A calls))]
+          (is (root/hydrated? mounted)
+              "a container carrying server markup and a manifest hydrated")
+          (poll-until
+            #(fired? calls :A :recoverable)
+            (fn []
+              (is (fired? calls :A :recoverable)
+                  (str "the recoverable callback fired through the cell. "
+                       "Saw: " (pr-str @calls)))
+              (v/unmount! mounted)
+              (remove-node! node)
+              (done))))))))

--- a/implementation/freehand/test/re_frame/freehand/root_mount_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/root_mount_dom_cljs_test.cljs
@@ -386,3 +386,81 @@
                        (is false (str "identifierPrefix suite rejected: " e))
                        (.remove container) (.remove spare) (.remove fresh)
                        (done)))))))))
+
+;; ===========================================================================
+;; FH-ROOT-002 — immutable-prefix drift OUTRANKS the cross-root duplicate
+;; ===========================================================================
+
+(def ^:private drift (:drift-precedence prefix-arm))
+
+(deftest fh-root-002-immutable-prefix-drift-outranks-cross-root-duplicate
+  (testing "Per FH-ROOT-002 (browser): a re-mount that drifts its prefix
+            toward a value ANOTHER live root already owns reports
+            :rf.error/root-identifier-prefix-immutable, not
+            :rf.error/duplicate-identifier-prefix. Once the same-root
+            incumbent is known its drift is what matters: the recovery is
+            unmount-first, and every prefix but the incumbent's own is equally
+            forbidden for that reused root, so a 'choose a distinct prefix'
+            diagnostic would only surface the immutable failure on the next
+            attempt. Both live roots are untouched, read back off the
+            document. A FRESH root aliasing the owned prefix — no incumbent —
+            still earns the duplicate diagnostic: the precedence is about an
+            incumbent, not about the requested value."
+    (if-not (browser?)
+      (skip! "the browser job runs the drift-precedence assertions")
+      (async done
+        (let [ca    (host-node!)
+              cb    (host-node!)
+              spare (host-node!)
+              ra    (:root-a drift)
+              rb    (:root-b drift)
+              pa    (:prefix-a drift)
+              pb    (:prefix-b drift)]
+          (-> (act #(vector (v/mount [probe {}] ca {:root-id ra :identifier-prefix pa})
+                            (v/mount [probe {}] cb {:root-id rb :identifier-prefix pb})))
+              (.then
+                (fn [[a b]]
+                  (is (= pa (root/root-identifier-prefix a)))
+                  (is (= pb (root/root-identifier-prefix b)))
+                  (let [uid-a (text ca ".uid")
+                        uid-b (text cb ".uid")]
+
+                    ;; 1 — the drift: re-mount A toward B's OWNED prefix.
+                    (let [data (caught #(v/mount [probe {}] ca
+                                                 {:root-id ra :identifier-prefix pb}))]
+                      (is (= (:immutable drift) (:rf.error/id data))
+                          "immutable-prefix drift, NOT the cross-root duplicate — the
+                           incumbent's own diagnostic outranks the owned value's")
+                      (is (= (:recovery drift) (:recovery data))
+                          "with the recovery that actually works — unmount, then mount")
+                      (is (= ra (:root-id data)))
+                      (is (= pb (:requested data)) "the diagnostic names what was asked for")
+                      (is (= pa (:existing data)) "and the incumbent's own prefix, not B's"))
+
+                    ;; 2 — A and B are both untouched, read off the document.
+                    (is (= #{ra rb} (root/live-root-ids)))
+                    (is (= pa (root/root-identifier-prefix a)))
+                    (is (= pb (root/root-identifier-prefix b)))
+                    (is (= uid-a (text ca ".uid"))
+                        "A is still emitting use-id under its own prefix")
+                    (is (= uid-b (text cb ".uid"))
+                        "and B under its — neither claim was touched"))
+
+                  ;; 3 — a FRESH root aliasing B's prefix keeps the DUPLICATE.
+                  (let [data (caught #(v/mount [probe {}] spare
+                                               {:root-id           (:fresh-root drift)
+                                                :identifier-prefix pb}))]
+                    (is (= (:duplicate drift) (:rf.error/id data))
+                        "a fresh root aliasing an owned prefix — no incumbent to make it
+                         drift — still reports the cross-root duplicate"))
+                  (is (zero? (.-childElementCount spare))
+                      "and it put nothing on the page")
+
+                  (act #(do (v/unmount! a) (v/unmount! b)))))
+              (.then (fn [_]
+                       (.remove ca) (.remove cb) (.remove spare)
+                       (done))
+                     (fn [e]
+                       (is false (str "drift-precedence suite rejected: " e))
+                       (.remove ca) (.remove cb) (.remove spare)
+                       (done)))))))))

--- a/spec/004C-Roots-and-Mount.md
+++ b/spec/004C-Roots-and-Mount.md
@@ -706,6 +706,27 @@ to prevent. What is refused is **drift**, never the re-mount: a re-mount
 offering the same effective prefix — authored verbatim, or derived because
 neither site authored one — is the ordinary idempotent reload.
 
+**The host error callbacks move the opposite way, and honestly.** The same
+`createRoot`-fixes-the-options fact governs `:on-uncaught-error`,
+`:on-caught-error` and `:on-recoverable-error`, but their correct lifetime is
+the inverse of the prefix's. Identity must not move, so a drifting prefix is
+refused; a callback is *meant* to move — a hot reload's fresh closure is the
+ordinary case, and refusing it would make HMR needlessly brittle. So the
+callbacks are **late-bound**: rather than pass the opts' closures straight to
+React — where the first mount's would be fixed and every later one silently
+ignored — the root installs one **stable delegate per key** that reads the
+live callback off a per-root cell, and an accepted re-mount **advances** that
+cell. React holds the delegate for the root's lifetime; the delegate's target
+is what the reload moves. The effective callback for each key is the one from
+the **most recent accepted mount**; a re-mount that omits a key it earlier
+supplied restores React's own default reporting for that error kind (an
+uncaught or recoverable error to `reportError`, a boundary-caught one to
+`console.error`), so a stale closure is never silently retained and a newly
+supplied one is never dropped. The delegate is installed for all three keys
+regardless of the first mount's opts, so a callback a reload *adds* takes
+effect too. A rejected re-mount — a prefix drift, a superseded incumbent —
+advances nothing: the cell moves only on the accepted reload's own re-render.
+
 ### Compatible shell versus clean remount
 
 A redefinition is **compatible** when it does not move the boundary's *hook

--- a/spec/004C-Roots-and-Mount.md
+++ b/spec/004C-Roots-and-Mount.md
@@ -441,8 +441,8 @@ prefix-uniqueness backstop share the roster:
 | `:rf.error/duplicate-root-id` | equal root-id at any layer above; client `:existing` includes `:tearing-down? true` while settlement is fenced |
 | `:rf.error/root-container-missing` | hydration locator resolves to no element (§4) |
 | `:rf.error/root-container-in-use` | `create-root`/`mount` on a node already owned by a different live or tearing-down root |
-| `:rf.error/duplicate-identifier-prefix` | `create-root`/`mount`/`hydrate-root` whose effective `identifierPrefix` is already claimed by a different live root — backstops authored `:identifier-prefix` aliasing, and hydrating roots that share React's effective empty prefix `""` when the manifest omits `:identifier-prefix` (the derived mount default is injective over root-id, §1) |
-| `:rf.error/root-identifier-prefix-immutable` | a same-root/same-container re-mount — the idempotent reload path, which RE-RENDERS the live host root — whose effective `identifierPrefix` differs from the one that root was created under. Host root options are fixed at creation, so the running root cannot adopt the new value; the drift is refused before preflight and before any render, and the live root keeps its prefix claim |
+| `:rf.error/duplicate-identifier-prefix` | a **fresh** `create-root`/`mount`/`hydrate-root` whose effective `identifierPrefix` is already claimed by a different live root — backstops authored `:identifier-prefix` aliasing, and hydrating roots that share React's effective empty prefix `""` when the manifest omits `:identifier-prefix` (the derived mount default is injective over root-id, §1). For a **same-root/same-container** incumbent, the immutable-prefix row below takes precedence over this one |
+| `:rf.error/root-identifier-prefix-immutable` | a same-root/same-container re-mount — the idempotent reload path, which RE-RENDERS the live host root — whose effective `identifierPrefix` differs from the one that root was created under. Host root options are fixed at creation, so the running root cannot adopt the new value; the drift is refused before preflight and before any render, and the live root keeps its prefix claim. **Takes precedence over `:rf.error/duplicate-identifier-prefix`** once the incumbent is known: drift toward a value another root owns is still immutable-prefix drift (recovery: unmount first), because every prefix but the incumbent's is equally forbidden for that reused root |
 | `:rf.error/root-not-live` | `render!` on a `Root` whose id is no longer live — `unmount!`ed, tearing-down, or superseded by a newer root claiming the same id (guarded like `unmount!`, but fails loud rather than no-op, before any side effect) |
 | `:rf.error/root-manifest-invalid` | manifest missing/unreadable at hydrate, schema-version incompatible, identity opts passed client-side, unserialisable props at emit, prefix conflict |
 | `:rf.error/frame-payload-conflict` | below |
@@ -705,6 +705,20 @@ manufacturing the very cross-root `use-id` collision the prefix claim exists
 to prevent. What is refused is **drift**, never the re-mount: a re-mount
 offering the same effective prefix — authored verbatim, or derived because
 neither site authored one — is the ordinary idempotent reload.
+
+**This drift check takes precedence over the cross-root prefix-uniqueness
+check.** Once the same-root/same-container incumbent is known, a requested
+prefix that differs from *its own* is reported as
+`:rf.error/root-identifier-prefix-immutable` — even when that requested value
+is a prefix some OTHER live root already owns. The alternative, reporting
+`:rf.error/duplicate-identifier-prefix` because the requested value collides,
+sends the author chasing a *distinct* prefix; but every prefix other than the
+incumbent's is equally forbidden for that reused root, so the honest recovery
+is `:unmount-before-changing-identifier-prefix`, not a different value. A
+**fresh** root (no same-root incumbent) requesting a prefix another root owns
+still reports `:rf.error/duplicate-identifier-prefix` — the drift check is a
+no-op with no incumbent, and the uniqueness backstop is exactly right there.
+Both checks are read-only and run before preflight and any render.
 
 **The host error callbacks move the opposite way, and honestly.** The same
 `createRoot`-fixes-the-options fact governs `:on-uncaught-error`,

--- a/spec/conformance/freehand/fixtures/fh-root-002.edn
+++ b/spec/conformance/freehand/fixtures/fh-root-002.edn
@@ -124,4 +124,23 @@
   ;; and a true `v/unmount!` DOES free it: a successor claiming the same
   ;; identity re-claims the prefix and mounts, after which the dead handle is
   ;; a guarded no-op that cannot release the successor's claim
-  :successor-reclaims-prefix true}}
+  :successor-reclaims-prefix true
+
+  ;; DRIFT PRECEDENCE (rf2-drpa3.140): a re-mount whose prefix drifts toward a
+  ;; value ANOTHER live root already owns is still same-root drift. The
+  ;; immutable-prefix diagnostic OUTRANKS the cross-root duplicate one, because
+  ;; its recovery — unmount first — is the real one: every prefix but the
+  ;; incumbent's own is equally forbidden for that reused root, so a "choose a
+  ;; distinct prefix" recovery would only surface the immutable failure on the
+  ;; next attempt. A FRESH root aliasing the owned prefix has no incumbent, so
+  ;; it keeps the duplicate diagnostic — the precedence is about an incumbent,
+  ;; not about the requested value.
+  :drift-precedence
+  {:root-a     :fh.root/drift-a
+   :prefix-a   "rf2-drift-a-"
+   :root-b     :fh.root/drift-b
+   :prefix-b   "rf2-drift-b-"
+   :fresh-root :fh.root/drift-fresh
+   :immutable  :rf.error/root-identifier-prefix-immutable
+   :recovery   :unmount-before-changing-identifier-prefix
+   :duplicate  :rf.error/duplicate-identifier-prefix}}}


### PR DESCRIPTION
Two same-surface root/remount fixes on `re_frame/freehand/root.cljs`, delivered as one PR. Both come out of the three-lens audit of merged PR #6746 and build on the root-preflight boundary (#6757).

## rf2-drpa3.139 — honest host error callbacks across an idempotent remount

React fixes a root's options at `createRoot`, so the same-root/same-container remount path (which re-renders the live host root) cannot hand React a fresh `:on-uncaught-error` / `:on-caught-error` / `:on-recoverable-error` object. The code passed the opts' closures straight to `createRoot`/`hydrateRoot`, so the **first** mount's callbacks were installed and every later one silently ignored — surprising on the HMR path, where a fresh closure per reload is ordinary.

- One **stable delegate per key** reads the current callback off a mutable per-root cell (carried on the `Root` value); an accepted remount **advances** the cell. React holds the delegate; its target is what the reload moves.
- A key a mount omits falls back to React's own default reporting (`reportError` for uncaught/recoverable, `console.error` for a boundary-caught one), so a stale closure is never retained and a newly supplied one is never dropped. The delegate is installed for all three keys regardless of the first mount's opts, so a callback a reload *adds* takes effect too.
- The hydration reporter now reads `:on-recoverable-error` off the same cell, so a hydrated root's recoverable callback advances on remount as well.
- Public `v/mount` documentation and Spec 004C state the callback lifetime.

## rf2-drpa3.140 — immutable-prefix drift outranks the cross-root duplicate

`claim!` checked cross-root `identifierPrefix` ownership before the same-root immutable-prefix comparison. With live root A on `"a-"` and live root B on `"b-"`, remounting A into its own container with `"b-"` threw `:rf.error/duplicate-identifier-prefix`, whose "choose a distinct prefix" recovery is a dead end — every prefix but A's own is equally forbidden for that reused React root.

- The fourth admission claim (`require-stable-identifier-prefix!`) now runs **inside `claim!`**, after the id/container checks and **before** the cross-root prefix-uniqueness check. Once the same-root/same-container incumbent is known, a requested prefix that differs from *its own* reports `:rf.error/root-identifier-prefix-immutable` with `:unmount-before-changing-identifier-prefix`.
- A **fresh** root (no incumbent) requesting a prefix another root owns still reports `:rf.error/duplicate-identifier-prefix` — the drift check is a no-op with no incumbent. Both checks stay read-only, before preflight and any React work; A, B and their claims are untouched.

## Files

- `implementation/freehand/src/re_frame/freehand/root.cljs` — both fixes.
- `implementation/freehand/test/re_frame/freehand/root_error_callbacks_dom_cljs_test.cljs` — new adversarial proof (.139): all three keys on the real React root path.
- `implementation/freehand/test/re_frame/freehand/root_mount_dom_cljs_test.cljs` — drift-precedence proof (.140).
- `spec/conformance/freehand/fixtures/fh-root-002.edn` — `:drift-precedence` arm (.140).
- `spec/004C-Roots-and-Mount.md` — callback lifetime (.139) and drift precedence (.140).

## Quality gates

Run from `implementation/` (spec build from repo root), all exit `0`:

| Gate | Result |
|---|---|
| `npm run test:freehand` | exit 0 — Ran 652 tests, 4127 assertions, 0 failures, 0 errors |
| `npm run test:browser` | exit 0 — Ran 611 tests, 3622 assertions, 0 failures, 0 errors |
| `python -m mkdocs build --strict` | exit 0 — Documentation built |

Beads: rf2-drpa3.139, rf2-drpa3.140.
