### PR TITLE
test(freehand): F5i pilot — React-library integration across the host shapes (rf2-drpa3.46)

### DIFF
--- a/implementation/freehand/test/re_frame/freehand/pilot_react_interop.cljc
+++ b/implementation/freehand/test/re_frame/freehand/pilot_react_interop.cljc
@@ -1,0 +1,428 @@
+(ns re-frame.freehand.pilot-react-interop
+  "The F5i pilot's APPLICATION — a React-library integration written the way
+  an adopter would write one, using only the public door.
+
+  The question this pilot exists to answer is the first question any real
+  adopter asks: *can I use a third-party React component?* Freehand's answer
+  is deliberately not \"yes, anywhere\" — it is a small set of named host
+  shapes, each with a different bargain. What follows is one worked
+  integration per shape that EXISTS, and a named refusal per shape that does
+  not, so the day a shape lands the refusal fails and this file has to be
+  rewritten rather than quietly staying green.
+
+  ## The shapes, and what an adopter meets today
+
+  | Shape                        | What it is for                          |
+  |------------------------------|-----------------------------------------|
+  | qualified host leaf          | a foreign component with value props    |
+  | explicit React wrapper       | a React-owned protocol (hooks, context) |
+  | registered behavior          | opaque, mutable host state over a node  |
+  | the outward bridge           | a library that wants a COMPONENT value  |
+
+  Exactly one of those four — the registered behavior — is reachable from
+  the door in this tree. The other three are named by the substrate's own
+  diagnostics as landing later, and this pilot asserts those diagnostics
+  verbatim rather than routing around them.
+
+  ## What that leaves an adopter with
+
+  One shape, and it is a good one: `v/defbehavior` + `[v/behavior …]` is a
+  genuinely complete imperative boundary — commit-only connection, a closed
+  timing set, a bounded command roster addressed by a semantic id the caller
+  authored, and a teardown a test can assert as an exact zero. The
+  spreadsheet-class integration below is built entirely on it, and nothing
+  about it feels like a workaround.
+
+  What it is NOT is a React boundary. A behavior receives a DOM node, not a
+  React parent, so the only way to put a third-party REACT component on the
+  page from Freehand today is to open a SECOND React root inside the node
+  the behavior owns. That works — `pilot-react-interop-dom-cljs-test` mounts
+  a real `@xyflow/react` graph that way — and it is a workaround, with costs
+  this pilot measures rather than asserts away.
+
+  ## The four integrations in this file
+
+    1. `acme.sheet`     a SpreadJS-class editable grid: opaque host state,
+                        a reconciled config, a bounded command roster, an
+                        outward intent, and a total release. THE behavior
+                        shape, used for exactly what it was designed for.
+    2. `acme.chart`     a React-Vega-class chart component. The shape that
+                        SHOULD be a qualified leaf; reached instead through
+                        a nested React root inside an opaque behavior. The
+                        CLJS half lives in `pilot-react-interop-react`,
+                        because a `.cljc` cannot `:require` an npm module.
+    3. `acme.table`     a TanStack-Table-class HEADLESS core. The finding
+                        here is that it needs no host shape at all — the
+                        React adapter's whole job (hold state, re-render on
+                        change) is what re-frame already is.
+    4. `acme.dialog`    a Radix-class compound component. Not reachable, and
+                        not reachable for a second reason beyond the missing
+                        leaf: `asChild` needs to clone a Freehand child and
+                        inject a ref into it, and a Freehand element is not
+                        a React element an application can hold.
+
+  Everything here is host-neutral. The imperative widget touches the DOM
+  only under a `:cljs` reader conditional and only when it really has a
+  node, so the SAME declarations render structurally on the JVM — where the
+  behavior is an inert marker, which is itself one of the claims."
+  (:require [clojure.string :as str]
+            [re-frame.core :as rf]
+            [re-frame.freehand :as v]))
+
+;; ===========================================================================
+;; INTEGRATION 1 — `acme.sheet`, a SpreadJS-class editable grid
+;; ===========================================================================
+;;
+;; The library. A faithful stand-in for the SpreadJS / Handsontable / Monaco
+;; class of widget: constructed over a node it then owns, mutated in place,
+;; emitting host events through a listener the caller registers, and released
+;; by an explicit `destroy`. It is deliberately NOT React — that is the whole
+;; point of the class, and it is why the behavior shape exists.
+;;
+;; Every allocation it makes is counted, because acceptance for this pilot is
+;; an EXACT retained count after unmount and not a plausible one.
+
+(def ^:private ledger
+  "What the library is holding right now. `:instances` and `:listeners` are
+  the numbers a cleanup assertion reads; `:constructed` and `:destroyed` are
+  cumulative, so a replayed connect/disconnect pair is visible as movement
+  in the totals while the live counts stay at zero."
+  (atom {:instances 0 :listeners 0 :constructed 0 :destroyed 0}))
+
+(defn ledger-snapshot [] @ledger)
+
+(defn reset-ledger!
+  []
+  (reset! ledger {:instances 0 :listeners 0 :constructed 0 :destroyed 0})
+  nil)
+
+(defn live-instances [] (:instances @ledger))
+(defn live-listeners [] (:listeners @ledger))
+
+#?(:cljs
+   (defn- render-grid!
+     "Paint the instance's rows into the node it owns. The widget owns every
+      descendant of that node — which is exactly what `{:opaque true}`
+      declares on the Freehand side."
+     [inst]
+     (let [node  (:node inst)
+           state @(:state inst)]
+       (set! (.-innerHTML node) "")
+       (let [table (js/document.createElement "table")]
+         (.setAttribute table "class" "acme-sheet")
+         (doseq [[i row] (map-indexed vector (:rows state))]
+           (let [tr (js/document.createElement "tr")]
+             (.setAttribute tr "data-row" (str i))
+             (doseq [[j cell] (map-indexed vector row)]
+               (let [td (js/document.createElement "td")]
+                 (.setAttribute td "data-col" (str j))
+                 (when (= [i j] (:cursor state))
+                   (.setAttribute td "data-cursor" "true"))
+                 (set! (.-textContent td) (str cell))
+                 (.appendChild tr td)))
+             (.appendChild table tr)))
+         (.appendChild node table))
+       nil)))
+
+#?(:cljs
+   (defn create-sheet!
+     "`new acme.Sheet(node, options)` — the library's constructor. Takes the
+      node, paints itself into it, installs ONE host listener, and answers an
+      opaque instance handle."
+     [node {:keys [rows read-only?]}]
+     (let [state    (atom {:rows (or rows []) :cursor [0 0] :read-only? read-only?})
+           inst     {:node node :state state :sink (atom nil)}
+           listener (fn [e]
+                      (let [td (.-target e)]
+                        (when (and (some? td) (= "TD" (.-tagName td)))
+                          (let [r (js/parseInt (.getAttribute (.-parentNode td) "data-row") 10)
+                                c (js/parseInt (.getAttribute td "data-col") 10)]
+                            (swap! state assoc :cursor [r c])
+                            (render-grid! inst)
+                            (when-let [sink @(:sink inst)]
+                              (sink {:row r :col c :value (.-textContent td)}))))))
+           inst     (assoc inst :listener listener)]
+       (.addEventListener node "click" listener)
+       (swap! ledger (fn [l] (-> l
+                                 (update :instances inc)
+                                 (update :listeners inc)
+                                 (update :constructed inc))))
+       (render-grid! inst)
+       inst)))
+
+#?(:cljs
+   (defn set-rows!
+     [inst rows]
+     (swap! (:state inst) assoc :rows rows)
+     (render-grid! inst)
+     nil))
+
+#?(:cljs
+   (defn on-cell-activated!
+     "Register the ONE outward callback the library offers."
+     [inst f]
+     (reset! (:sink inst) f)
+     nil))
+
+#?(:cljs
+   (defn sheet-export
+     "A one-shot imperative operation with a result — the exact case the
+      bounded command channel exists for."
+     [inst {:keys [separator]}]
+     (->> (:rows @(:state inst))
+          (map (fn [row] (str/join (or separator ",") (map str row))))
+          (str/join "\n"))))
+
+#?(:cljs
+   (defn focus-cell!
+     [inst [r c]]
+     (swap! (:state inst) assoc :cursor [r c])
+     (render-grid! inst)
+     nil))
+
+#?(:cljs
+   (defn destroy-sheet!
+     "`instance.destroy()` — release everything the constructor took."
+     [inst]
+     (.removeEventListener (:node inst) "click" (:listener inst))
+     (reset! (:sink inst) nil)
+     (set! (.-innerHTML (:node inst)) "")
+     (swap! ledger (fn [l] (-> l
+                               (update :instances dec)
+                               (update :listeners dec)
+                               (update :destroyed inc))))
+     nil))
+
+;; ---------------------------------------------------------------------------
+;; The Freehand side — ONE registered behavior
+;; ---------------------------------------------------------------------------
+;;
+;; `:timing :layout`, because a grid measures its own column widths and a
+;; measurement that lands after paint is visibly wrong for one frame.
+;;
+;; `{:opaque true}`, because the widget owns every descendant of its node.
+;; Declaring that is what turns "children here would be silently overwritten"
+;; into a loud refusal at the use site.
+;;
+;; NOTE what is NOT in `:config`: the constructor, the instance, the
+;; listener, the outward callback. `:config` is data through and through, so
+;; the behavior's job is exactly "read data, drive the host" — which is the
+;; boundary a chart or grid library wants anyway.
+
+(v/defbehavior sheet
+  "A SpreadJS-class editable grid over one node."
+  {:timing  :layout
+   :opaque  true
+   :connect (fn [{:keys [node config dispatch]}]
+              #?(:cljs
+                 (let [inst (create-sheet! node config)]
+                   ;; The host's outward event leaves as an ordinary event
+                   ;; INTENT. The behavior does not decide anything — it
+                   ;; conveys, and the re-frame handler that receives it sees
+                   ;; the committed frame.
+                   (on-cell-activated! inst
+                     (fn [{:keys [row col value]}]
+                       (dispatch [:invoice/cell-activated row col value])))
+                   inst)
+                 :clj (do node config dispatch nil)))
+   :update  (fn [{:keys [config memory]}]
+              #?(:cljs (when memory (set-rows! memory (:rows config))))
+              memory)
+   :disconnect (fn [{:keys [memory]}]
+                 #?(:cljs (when memory (destroy-sheet! memory)))
+                 nil)
+   :commands {:export     (fn [{:keys [memory args dispatch]}]
+                            #?(:cljs
+                               (when memory
+                                 (dispatch [:invoice/exported (sheet-export memory args)])))
+                            memory)
+              :focus-cell (fn [{:keys [memory args]}]
+                            #?(:cljs (when memory (focus-cell! memory (:at args))))
+                            memory)}})
+
+;; ---------------------------------------------------------------------------
+;; The application that uses it
+;; ---------------------------------------------------------------------------
+
+(def rows-path [:invoice :rows])
+
+(rf/reg-sub :invoice/rows (fn [db _] (get-in db rows-path)))
+(rf/reg-sub :invoice/last-export (fn [db _] (get-in db [:invoice :last-export])))
+(rf/reg-sub :invoice/last-activation (fn [db _] (get-in db [:invoice :last-activation])))
+
+(rf/reg-event :invoice/seeded
+  (fn [{:keys [db]} [_ rows]]
+    {:db (assoc-in db rows-path rows)}))
+
+(rf/reg-event :invoice/cell-activated
+  (fn [{:keys [db]} [_ row col value]]
+    {:db (assoc-in db [:invoice :last-activation] {:row row :col col :value value})}))
+
+(rf/reg-event :invoice/exported
+  (fn [{:keys [db]} [_ csv]]
+    {:db (assoc-in db [:invoice :last-export] csv)}))
+
+;; The command is DATA an ordinary handler returns. Nothing in the view
+;; reaches a host, nothing holds an instance, and the address is the semantic
+;; id the use site authored — not a ref, not a query, not a position.
+(rf/reg-event :invoice/export-requested
+  (fn [_ [_ separator]]
+    {:fx [[:re-frame.freehand.host/command
+           {:target :invoice/sheet
+            :op     :export
+            :args   {:separator separator}}]]}))
+
+(rf/reg-event :invoice/cell-focus-requested
+  (fn [_ [_ at]]
+    {:fx [[:re-frame.freehand.host/command
+           {:target :invoice/sheet :op :focus-cell :args {:at at}}]]}))
+
+(v/defview invoice-sheet
+  "The use site. Everything visible here is data: an id, a semantic target,
+  and a config the substrate records verbatim in the structural tree."
+  [{:keys [read-only?]}]
+  [:section.invoice
+   [v/behavior {:use    sheet
+                :target :invoice/sheet
+                :config {:rows       (v/sub [:invoice/rows])
+                         :read-only? (boolean read-only?)}}
+    [:div.sheet-host]]])
+
+(v/defview invoice-page
+  "The sheet with an ordinary Freehand toolbar above it — the shape that
+  proves the boundary is only around the node the widget owns, not around
+  the region."
+  [_]
+  [:main.invoice-page
+   [:button.export {:on-click [:invoice/export-requested ","]} "Export"]
+   [invoice-sheet {}]])
+
+(v/defview two-sheets
+  "Two live instances under DISTINCT semantic ids — the ordinary
+  multi-instance case, and the decoy arm of the command law."
+  [_]
+  [:section.pair
+   [v/behavior {:use sheet :target :invoice/sheet :config {:rows [["a"]]}}
+    [:div.sheet-host {:data-id "primary"}]]
+   [v/behavior {:use sheet :target :invoice/draft :config {:rows [["z"]]}}
+    [:div.sheet-host {:data-id "decoy"}]]])
+
+(v/defview control-page
+  "The CONTROL: the same markup with no behavior at all, so a zero after
+  teardown means a release rather than a counter that was never written."
+  [_]
+  [:section.invoice
+   [:div.sheet-host]])
+
+;; ===========================================================================
+;; INTEGRATION 3 — `acme.table`, a TanStack-Table-class HEADLESS core
+;; ===========================================================================
+;;
+;; This one is the finding that is NOT a gap.
+;;
+;; A headless table library is a pure function: options and state in, a row
+;; model out. Its React adapter exists to supply the two things React itself
+;; cannot: somewhere to keep the state, and a way to re-run the computation
+;; when that state moves. re-frame already IS both of those, so there is
+;; nothing for a host shape to do — the core belongs in a subscription, and
+;; the rows it answers are ordinary Freehand markup.
+;;
+;; `@tanstack/table-core` is not in this repo's dependency tree and adding an
+;; npm dependency for a pilot is a decision, not an implementation detail. So
+;; the core below is a LOCAL stand-in with the same ABI — `(core-row-model
+;; options state) -> {:rows … :header …}`, pure, framework-free — and the
+;; claim it supports is about the SHAPE of the integration, which is what the
+;; pilot is judging.
+
+(defn core-row-model
+  "The headless core: options + state in, a row model out. No framework, no
+  host, no identity — the same call answers the same value on both hosts."
+  [{:keys [columns data]} {:keys [sort-by-key desc?]}]
+  (let [sorted (if sort-by-key
+                 (let [s (sort-by #(get % sort-by-key) data)]
+                   (vec (if desc? (reverse s) s)))
+                 (vec data))]
+    {:header (mapv (fn [{:keys [key label]}] {:key key :label label}) columns)
+     :rows   (mapv (fn [row]
+                     {:id    (:id row)
+                      :cells (mapv (fn [{:keys [key]}] {:key key :value (get row key)})
+                                   columns)})
+                   sorted)}))
+
+(def ^:private table-columns
+  [{:key :name  :label "Name"}
+   {:key :owed  :label "Owed"}])
+
+(rf/reg-sub :ledger/table
+  (fn [db _]
+    (core-row-model {:columns table-columns
+                     :data    (get-in db [:ledger :rows] [])}
+                    (get-in db [:ledger :sort] {}))))
+
+(rf/reg-event :ledger/seeded
+  (fn [{:keys [db]} [_ rows]] {:db (assoc-in db [:ledger :rows] rows)}))
+
+(rf/reg-event :ledger/sorted
+  (fn [{:keys [db]} [_ k]]
+    {:db (update-in db [:ledger :sort]
+                    (fn [{:keys [sort-by-key desc?]}]
+                      {:sort-by-key k :desc? (and (= k sort-by-key) (not desc?))}))}))
+
+(v/defview headless-table
+  "A headless table core rendered as ORDINARY Freehand markup. No behavior,
+  no leaf, no bridge, no wrapper — the integration needed no host shape at
+  all, which is the honest answer for this whole class of library."
+  [_]
+  (let [{:keys [header rows]} (v/sub [:ledger/table])]
+    [:table.ledger
+     [:thead
+      [:tr (for [{:keys [key label]} header]
+             ^{:key key} [:th {:on-click [:ledger/sorted key]} label])]]
+     [:tbody
+      (for [{:keys [id cells]} rows]
+        ^{:key id}
+        [:tr {:data-row-id (str id)}
+         (for [{:keys [key value]} cells]
+           ^{:key key} [:td {:data-col (name key)} (str value)])])]]))
+
+;; ===========================================================================
+;; Refusal probes — the shapes that are NOT reachable
+;; ===========================================================================
+;;
+;; Each of these is a use site an adopter would write on their first day.
+;; They are declared here rather than inline in the suite so the refusal is
+;; measured against a real declaration, and so the day a shape lands the
+;; declaration is already written and the assertion around it fails loudly.
+
+(def foreign-leaf
+  "A hand-built value shaped like the third legal vector head.
+
+  There is no public verb that mints one — `re-frame.freehand.descriptor`
+  reserves the `:re-frame.freehand/host` marker and says the authoring
+  surface `lands with its own slice`. This map is the pilot reaching PAST the
+  door on purpose, so the refusal it meets is the substrate's own and not a
+  spelling mistake."
+  {:re-frame.freehand/host true
+   :component              "AcmeChart"})
+
+(v/defview chart-as-a-leaf
+  "The obvious spelling for a React chart component with value props, and
+  the one an adopter reaches for first."
+  [_]
+  [:figure.chart
+   [foreign-leaf {:spec "bar" :data [1 2 3]}]])
+
+(v/defview opaque-host-with-children
+  "The refusal that keeps an opaque behavior honest: children under a node
+  the host owns would be rendered and then overwritten."
+  [_]
+  [v/behavior {:use sheet :target :invoice/sheet}
+   [:div.sheet-host [:span "the widget would erase this"]]])
+
+(v/defview behavior-over-a-view
+  "A behavior's child is ONE element. A declared view denotes a group, so
+  there is nothing to attach to — the arm an adopter meets when they try to
+  wrap a component in a behavior instead of a node."
+  [_]
+  [v/behavior {:use sheet :target :invoice/sheet}
+   [control-page {}]])

--- a/implementation/freehand/test/re_frame/freehand/pilot_react_interop.cljc
+++ b/implementation/freehand/test/re_frame/freehand/pilot_react_interop.cljc
@@ -377,7 +377,7 @@
     [:table.ledger
      [:thead
       [:tr (for [{:keys [key label]} header]
-             ^{:key key} [:th {:on-click [:ledger/sorted key]} label])]]
+             ^{:key key} [:th [:button.sort {:on-click [:ledger/sorted key]} label]])]]
      [:tbody
       (for [{:keys [id cells]} rows]
         ^{:key id}

--- a/implementation/freehand/test/re_frame/freehand/pilot_react_interop.cljc
+++ b/implementation/freehand/test/re_frame/freehand/pilot_react_interop.cljc
@@ -130,7 +130,7 @@
       node, paints itself into it, installs ONE host listener, and answers an
       opaque instance handle."
      [node {:keys [rows read-only?]}]
-     (let [state    (atom {:rows (or rows []) :cursor [0 0] :read-only? read-only?})
+     (let [state    (atom {:rows (or rows []) :cursor nil :read-only? read-only?})
            inst     {:node node :state state :sink (atom nil)}
            listener (fn [e]
                       (let [td (.-target e)]

--- a/implementation/freehand/test/re_frame/freehand/pilot_react_interop_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/pilot_react_interop_cljs_test.cljc
@@ -215,14 +215,21 @@
             the use site authored. On the structural host there is no live
             connection, so the command performs no host work.
 
-            TWO things an adopter has to discover the hard way, and both are
-            reported as findings:
+            THREE things an adopter has to discover the hard way, and all
+            three are reported as findings:
 
             1. An fx refusal does NOT propagate out of `dispatch-sync` —
                re-frame catches it and routes it to the always-on error axis.
                The public seam for observing one is
                `rf/register-listener! :errors`.
-            2. On the JVM there is no refusal to observe AT ALL. The command
+            2. The record that arrives there is NOT typed as a command
+               refusal. `:re-frame.freehand.host/command` is a registrar fx,
+               so its typed diagnostic is flattened to the generic
+               `:rf.error/fx-handler-exception` and the real id has to be
+               dug out of the record's `:exception`. An operator surface
+               that wanted to show `your command was refused, and why` has to
+               know to unwrap.
+            3. On the JVM there is no refusal to observe AT ALL. The command
                fx is registered `{:platforms #{:client}}`, so the structural
                host SKIPS it (a `:rf.fx/skipped-on-platform` trace) and the
                JVM refusal `command!` carries is never reached through the
@@ -239,14 +246,20 @@
         (is (= {:instances 0 :listeners 0 :constructed 0 :destroyed 0}
                (pilot/ledger-snapshot))
             "a command with no live connection performs NO host work")
-        (let [ids (mapv :error @seen)]
+        (let [ids   (mapv :error @seen)
+              inner (mapv #(:rf.error/id (ex-data (:exception %))) @seen)]
           #?(:cljs
-             (is (some #{:rf.error/behavior-command-refused} ids)
-                 (str "the refusal is a typed, visible record; got " (pr-str ids)))
+             (do
+               (is (= [:rf.error/fx-handler-exception] ids)
+                   (str "the error axis sees the GENERIC fx wrapper, not the "
+                        "command's own id — finding (2) above; got " (pr-str ids)))
+               (is (= [:rf.error/behavior-command-refused] inner)
+                   (str "and the typed refusal is one unwrap deeper, inside the "
+                        "record's :exception; got " (pr-str inner))))
              :clj
              (is (empty? ids)
                  (str "on the STRUCTURAL host the client-only fx is skipped, so "
-                      "there is no refusal record to observe — finding (2) above; "
+                      "there is no refusal record to observe — finding (3) above; "
                       "got " (pr-str ids)))))
         (finally
           (rf/unregister-listener! :errors ::commands))))))

--- a/implementation/freehand/test/re_frame/freehand/pilot_react_interop_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/pilot_react_interop_cljs_test.cljc
@@ -1,0 +1,357 @@
+(ns re-frame.freehand.pilot-react-interop-cljs-test
+  "F5i, the HEADLESS half — which host shapes a React-library adopter can
+  actually reach, and what the substrate says when they cannot.
+
+  The pilot's subject is the first question every adopter asks: *can I use a
+  third-party React component?* Freehand answers with a small set of named
+  host shapes rather than a general escape hatch, and the honest finding of
+  this pilot is that only ONE of them is reachable in this tree. So the
+  suite below is deliberately two-sided:
+
+    * the shape that EXISTS is exercised as an application author would —
+      declared, mounted, commanded, and read back off the structural tree;
+    * every shape that does NOT exist is asserted at its REFUSAL, verbatim,
+      so the day the slice lands these tests fail and this pilot has to be
+      rewritten instead of quietly continuing to pass.
+
+  The mounted half is `pilot-react-interop-dom-cljs-test`: a real
+  `react-dom/client` commit, a real `@xyflow/react` graph, and exact
+  retained-instance counts after teardown."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [clojure.string :as str]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.cell :as cell]
+            [re-frame.freehand.descriptor :as descriptor]
+            [re-frame.freehand.pilot-react-interop :as pilot]
+            [re-frame.freehand.test :as t]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+;; ===========================================================================
+;; Harness
+;; ===========================================================================
+
+(def ^:private fid :rf/default)
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn (fn [] (pilot/reset-ledger!))}))
+
+(defn- seed! [db] (frame/replace-app-db! fid db))
+(defn- send! [ev] (rf/dispatch-sync ev {:frame fid}))
+
+(defn- render!
+  "Render `form` structurally under a render candidate.
+
+  The `cell/candidate` + `cell/with-capture` pair is INTERNAL, and reaching
+  for it is a finding this pilot inherits rather than discovers: `t/render`
+  is the blessed public structural verb and it opens no candidate, so it
+  cannot render any view that calls `v/sub` — which is every view in this
+  file that reads state. Recorded as such in the PR body, reproduced
+  verbatim by [[t-render-alone-still-cannot-render-a-state-reading-view]],
+  and already filed."
+  [form]
+  (cell/with-capture (cell/candidate (cell/cell :acme/probe) fid)
+    (fn [] (t/render form))))
+
+(defn- caught
+  "The `ex-data` of the diagnostic `thunk` raised, or nil when it returned
+  normally. The whole ex-data, because the interesting half of a refusal here
+  is what it NAMES."
+  [thunk]
+  (try (thunk) nil (catch #?(:clj Throwable :cljs :default) e (ex-data e))))
+
+(defn- message
+  "The human sentence of the diagnostic `thunk` raised, or nil."
+  [thunk]
+  (try (thunk) nil (catch #?(:clj Throwable :cljs :default) e (ex-message e))))
+
+(defn- has? [s sub] (and (string? s) (str/includes? s sub)))
+
+(defn- behavior-nodes
+  [tree]
+  (t/find-all tree #(and (map? %) (= :re-frame.freehand/behavior (:view-id %)))))
+
+;; ===========================================================================
+;; SHAPE 1 and 2 — the qualified host leaf, and the explicit React wrapper
+;; ===========================================================================
+;;
+;; These are the same finding twice, and it is the pilot's headline. A React
+;; component with value props (React-Vega, AG Grid, a Radix primitive) is a
+;; qualified LEAF; a React-owned protocol (hooks, context, `asChild` cloning)
+;; is an explicit WRAPPER. Both are foreign components, so both enter a
+;; Freehand tree at the third legal vector head — the declared host
+;; descriptor. There is no fourth door.
+;;
+;; The classifier already KNOWS about that head. What is missing is
+;; everything behind it: no public verb mints a host descriptor, and both
+;; emitters refuse to cross one. So an adopter's very first integration
+;; attempt does not fail with "you spelled it wrong" — it fails with "this
+;; lands later", which is the right diagnostic and a hard stop.
+
+(deftest the-foreign-component-head-classifies-but-cannot-be-crossed
+  (testing "the third legal vector head is REAL — `classify-head` answers
+            `:host` for a host descriptor, so a foreign component is a
+            first-class citizen of the grammar and not an unclassified
+            value. Everything that would make it USEFUL is what is absent."
+    (is (= :host (descriptor/classify-head pilot/foreign-leaf))
+        "a host descriptor classifies, totally, today")
+    (is (true? (descriptor/host-descriptor? pilot/foreign-leaf)))))
+
+(deftest a-react-component-cannot-enter-a-freehand-tree-today
+  (testing "The obvious first integration — a chart component with value
+            props at a vector head — is REFUSED on the structural host, and
+            the refusal names the slice that will lift it rather than
+            pretending the spelling was wrong. This is the pilot's headline
+            finding: two of the four host shapes are unreachable, and they
+            are the two an adopter reaches for first."
+    (let [d (caught #(t/render [pilot/chart-as-a-leaf {}]))
+          m (message #(t/render [pilot/chart-as-a-leaf {}]))]
+      (is (= :rf.error/ui-tree-malformed (:rf.error/id d))
+          "the structural emitter refuses a host descriptor")
+      (is (has? m "host descriptor")
+          "and says what it refused")
+      (is (has? m "host-lifecycle slice")
+          "and names the slice that lands it — a hard stop, not a typo"))))
+
+(deftest no-public-verb-mints-a-foreign-component-boundary
+  (testing "There is no way to build the value the classifier recognises.
+            `pilot/foreign-leaf` is a hand-written map carrying the reserved
+            `:re-frame.freehand/host` marker — the pilot reaching PAST the
+            door on purpose. The door itself publishes nothing that mints
+            one, so an adopter cannot even construct the thing that would
+            then be refused."
+    #?(:clj
+       (let [publics (set (map name (keys (ns-publics (find-ns 're-frame.freehand)))))]
+         (is (not (contains? publics "host"))
+             "no v/host")
+         (is (not (contains? publics "react"))
+             "no v/react")
+         (is (empty? (filter #(has? % "host") publics))
+             (str "nothing on the door mints or names a host boundary; got "
+                  (pr-str (sort publics)))))
+       :cljs
+       (is true "the door's public roster is enumerated on the JVM arm"))))
+
+;; ===========================================================================
+;; SHAPE 4 — the outward bridge `v/->react`
+;; ===========================================================================
+;;
+;; The AG-Grid-class case: a library that wants a COMPONENT VALUE, not an
+;; element (`{:cellRenderer …}`). D014 rules the spelling `v/->react`; F5c is
+;; the slice. Neither has landed, so this integration cannot be attempted at
+;; all — and unlike the leaf there is not even a refusal to meet, because
+;; there is no call to make.
+
+(deftest the-outward-bridge-does-not-exist-yet
+  (testing "`v/->react` is D014's ruled spelling for handing a declared view
+            to a React library that takes a component value. It is not on the
+            door. An adopter integrating AG Grid's `cellRenderer` today
+            writes a hand-rolled UIx/Helix wrapper — which is exactly the
+            repetition D014 exists to remove. This assertion FAILS the day
+            F5c lands, which is the point of writing it."
+    #?(:clj
+       (let [publics (set (map name (keys (ns-publics (find-ns 're-frame.freehand)))))]
+         (is (not (contains? publics "->react"))
+             "v/->react is absent — F5c has not landed"))
+       :cljs
+       (is true "the door's public roster is enumerated on the JVM arm"))))
+
+;; ===========================================================================
+;; SHAPE 3 — the registered behavior, which DOES exist
+;; ===========================================================================
+;;
+;; The one shape an adopter can use today, and — for the class of library it
+;; was designed for — a genuinely good one. A SpreadJS-class grid is opaque,
+;; mutable, listener-owning host state over one node, which is the behavior's
+;; exact description.
+
+(deftest the-behavior-use-site-is-inert-data-on-the-structural-host
+  (testing "Everything the integration declares is DATA in the tree: the
+            registered id, the caller-authored semantic target, and the
+            config verbatim. A tool, a catalogue and a structural test read
+            the integration without holding one line of its implementation —
+            and on this host nothing connects, so the library's own ledger
+            has to still be at zero."
+    (seed! {:invoice {:rows [["Widget" 10] ["Gasket" 4]]}})
+    (let [tree (render! [pilot/invoice-sheet {}])
+          [b]  (behavior-nodes tree)]
+      (is (some? b) "the use site renders as a behavior boundary")
+      (is (= :re-frame.freehand.pilot-react-interop/sheet (:use (t/attrs b)))
+          "carrying the REGISTERED id, not the implementation")
+      (is (= :invoice/sheet (:target (t/attrs b)))
+          "and the semantic id a command will address it by")
+      (is (= {:rows [["Widget" 10] ["Gasket" 4]] :read-only? false}
+             (:config (t/attrs b)))
+          "and the config verbatim — the sub's value, recorded as data")
+      (is (= :div (:tag (first (:children b))))
+          "over exactly one element — the node the widget will own")
+      (is (= {:instances 0 :listeners 0 :constructed 0 :destroyed 0}
+             (pilot/ledger-snapshot))
+          "and NOTHING connected: a structural render performs no host work"))))
+
+(deftest a-behavior-lives-inside-an-ordinary-freehand-page
+  (testing "The boundary is around the NODE, not around the region. The
+            toolbar above the grid is ordinary Freehand markup with ordinary
+            event intent, and it sits in the same tree as the opaque host —
+            which is what makes the behavior shape composable rather than an
+            island."
+    (seed! {:invoice {:rows [["a" 1]]}})
+    (let [tree   (render! [pilot/invoice-page {}])
+          button (t/find tree #(= :button (:tag %)))]
+      (is (= [:invoice/export-requested ","] (:on-click (t/attrs button)))
+          "ordinary event intent, as data, beside an opaque host")
+      (is (= 1 (count (behavior-nodes tree)))
+          "and exactly one host boundary in the page"))))
+
+(deftest a-command-is-data-an-ordinary-handler-returns
+  (testing "The imperative operation an application performs on the widget —
+            export — never appears in a view. It is one reserved effect a
+            plain `reg-event` handler returns, addressed by the semantic id
+            the use site authored. On the structural host there is no live
+            connection, so the command performs no host work.
+
+            TWO things an adopter has to discover the hard way, and both are
+            reported as findings:
+
+            1. An fx refusal does NOT propagate out of `dispatch-sync` —
+               re-frame catches it and routes it to the always-on error axis.
+               The public seam for observing one is
+               `rf/register-listener! :errors`.
+            2. On the JVM there is no refusal to observe AT ALL. The command
+               fx is registered `{:platforms #{:client}}`, so the structural
+               host SKIPS it (a `:rf.fx/skipped-on-platform` trace) and the
+               JVM refusal `command!` carries is never reached through the
+               documented `{:fx [[…]]}` path. Spec 004 §The structural marker
+               says a command there `is refused with the same channel
+               diagnostic`; through the data path it is silently skipped."
+    (is (some? (rf/handler-meta :fx :re-frame.freehand.host/command))
+        "the command channel is an ordinary registered effect")
+    (let [seen (atom [])]
+      (rf/register-listener! :errors ::commands
+                             (fn [rec] (swap! seen conj rec)))
+      (try
+        (send! [:invoice/export-requested ","])
+        (is (= {:instances 0 :listeners 0 :constructed 0 :destroyed 0}
+               (pilot/ledger-snapshot))
+            "a command with no live connection performs NO host work")
+        (let [ids (mapv :error @seen)]
+          #?(:cljs
+             (is (some #{:rf.error/behavior-command-refused} ids)
+                 (str "the refusal is a typed, visible record; got " (pr-str ids)))
+             :clj
+             (is (empty? ids)
+                 (str "on the STRUCTURAL host the client-only fx is skipped, so "
+                      "there is no refusal record to observe — finding (2) above; "
+                      "got " (pr-str ids)))))
+        (finally
+          (rf/unregister-listener! :errors ::commands))))))
+
+(deftest the-config-rule-forbids-passing-a-component-through-the-use-site
+  (testing "This is the constraint that shapes every React integration built
+            on a behavior, and it is worth stating plainly because it is not
+            obvious until you hit it: `:config` is data all the way down, so
+            a React component — a function — cannot travel through it. There
+            is therefore NO generic `[v/behavior {:use react-host :config
+            {:component SomeComponent}}]`; every foreign component needs its
+            own `v/defbehavior` registration that names it.
+
+            That reads as a limitation and is mostly not one — a component's
+            props ARE data, and one named place to map data to props is
+            where you want it. But it is a real design consequence and an
+            adopter meets it on day one."
+    (let [m (message
+              #(t/render [v/behavior
+                          {:use pilot/sheet :config {:component (fn [] nil)}}
+                          [:div.sheet-host]]))]
+      (is (has? m "DATA through and through")
+          (str "a component value in :config is refused; got " (pr-str m)))
+      (is (has? m "preconstructed host instance")
+          "and the diagnostic names exactly this mistake"))))
+
+(deftest an-opaque-host-refuses-freehand-children
+  (testing "A chart or grid owns every descendant of its node. Declaring
+            `{:opaque true}` turns 'children here are silently overwritten'
+            into a refusal at the use site — which is the correct trade, and
+            it is also the mechanism that makes the nested-React-root
+            workaround one-way: no Freehand content can be interleaved into
+            a foreign component's subtree."
+    (let [m (message #(t/render [pilot/opaque-host-with-children {}]))]
+      (is (has? m "opaque") (str "got " (pr-str m)))
+      (is (has? m "no Freehand children")))))
+
+(deftest a-behavior-cannot-wrap-a-declared-view
+  (testing "A behavior's child is ONE element. An adopter who reads
+            'behaviors are how you integrate a component' and tries to wrap a
+            declared view in one meets a refusal naming the rule, not a
+            silent no-op."
+    (let [m (message #(t/render [pilot/behavior-over-a-view {}]))]
+      (is (has? m "ONE element") (str "got " (pr-str m))))))
+
+;; ===========================================================================
+;; The integration that needed NO host shape at all
+;; ===========================================================================
+;;
+;; A headless table core (TanStack Table's class) is a pure function: options
+;; and state in, a row model out. Its React adapter exists only to hold the
+;; state and re-run the computation when it moves — which is what re-frame
+;; already is. So the integration is a `reg-sub` and ordinary markup, and the
+;; correct amount of new substrate surface for it is zero.
+;;
+;; Reporting a non-gap is as much the pilot's job as reporting a gap: a
+;; substrate that grew a `v/use-headless-library` for this would be worse.
+
+(deftest a-headless-library-needs-no-host-shape
+  (testing "The row model is computed by a framework-free core inside an
+            ordinary subscription, and the rows it answers are ordinary
+            Freehand markup. There is no behavior, no leaf, no wrapper and no
+            bridge in the resulting tree — and there is nothing missing."
+    (seed! {:ledger {:rows [{:id 1 :name "Zoe" :owed 5}
+                            {:id 2 :name "Ada" :owed 9}]
+                     :sort {:sort-by-key :name}}})
+    (let [tree (render! [pilot/headless-table {}])
+          rows (t/find-all tree #(= :tr (:tag %)))]
+      (is (empty? (behavior-nodes tree))
+          "no host boundary — the integration needed none")
+      (is (= 3 (count rows)) "a header row and two data rows")
+      (is (= ["Ada" "9"] (mapv t/text (:children (nth rows 1))))
+          "sorted by the core, rendered by Freehand")
+      (is (= [:ledger/sorted :name]
+             (:on-click (t/attrs (t/find tree #(= :th (:tag %))))))
+          "and the sort control is ordinary event intent"))))
+
+(deftest the-headless-core-is-the-same-value-on-both-hosts
+  (testing "Nothing about the core is host-bound, which is why it needs no
+            shape: the same call answers the same value on the JVM and in
+            ClojureScript, so a structural test of a table is a real test."
+    (let [model (pilot/core-row-model
+                  {:columns [{:key :name :label "Name"}]
+                   :data    [{:id 1 :name "b"} {:id 2 :name "a"}]}
+                  {:sort-by-key :name})]
+      (is (= [{:key :name :label "Name"}] (:header model)))
+      (is (= [2 1] (mapv :id (:rows model)))
+          "sorted rows, in the order the core decided")
+      (is (= "a" (-> model :rows first :cells first :value))))))
+
+;; ===========================================================================
+;; The inherited finding, reproduced
+;; ===========================================================================
+
+(deftest t-render-alone-still-cannot-render-a-state-reading-view
+  (testing "Third pilot, same wall. `t/render` is the PUBLIC structural
+            surface and it opens no render candidate, so it cannot render any
+            view that calls `v/sub` — and a React-library integration reads
+            state like any other view. Every structural assertion in this
+            file goes through the internal `cell/candidate` +
+            `cell/with-capture` composition instead."
+    (seed! {:invoice {:rows [["a" 1]]}})
+    (let [d (caught #(t/render [pilot/invoice-sheet {}]))]
+      (is (= :rf.error/view-read-outside-render (:rf.error/id d))
+          (str "the blessed public verb refuses a state-reading view; got "
+               (pr-str d))))
+    (is (some? (render! [pilot/invoice-sheet {}]))
+        "and the internal composition is what makes the same render work")))

--- a/implementation/freehand/test/re_frame/freehand/pilot_react_interop_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/pilot_react_interop_cljs_test.cljc
@@ -26,6 +26,8 @@
             [re-frame.freehand.cell :as cell]
             [re-frame.freehand.descriptor :as descriptor]
             [re-frame.freehand.pilot-react-interop :as pilot]
+            [re-frame.freehand.pilot-react-interop-compiled :as compiled]
+            #?(:clj [re-frame.freehand.compiler :as compiler])
             [re-frame.freehand.test :as t]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]))
@@ -334,7 +336,7 @@
       (is (= ["Ada" "9"] (mapv t/text (:children (nth rows 1))))
           "sorted by the core, rendered by Freehand")
       (is (= [:ledger/sorted :name]
-             (:on-click (t/attrs (t/find tree #(= :th (:tag %))))))
+             (:on-click (t/attrs (t/find tree #(= :button (:tag %))))))
           "and the sort control is ordinary event intent"))))
 
 (deftest the-headless-core-is-the-same-value-on-both-hosts
@@ -349,6 +351,125 @@
       (is (= [2 1] (mapv :id (:rows model)))
           "sorted rows, in the order the core decided")
       (is (= "a" (-> model :rows first :cells first :value))))))
+
+;; ===========================================================================
+;; The COMPILED arm — newly answerable, and the answer is two-sided
+;; ===========================================================================
+;;
+;; Compiled views became browser-mountable, so `can a compiled page host a
+;; React library?` stopped being academic. It has two halves and the pilot
+;; reports both.
+
+#?(:clj
+   (defn- compile-body
+     "Run the compiled front end over `body`, as the macro does, and answer
+     the diagnostic it is refused with — or `::accepted`."
+     [body]
+     (try
+       (compiler/compile-structural-view
+         {:form            (list 'v/defview 'subject '[props] body)
+          :menv            nil
+          :ns-sym          're-frame.freehand.pilot-react-interop-cljs-test
+          :vname           'subject
+          :view-id         ::subject
+          :params          '[props]
+          :body            [body]
+          :children-policy :optional})
+       ::accepted
+       (catch clojure.lang.ExceptionInfo ex
+         (assoc (select-keys (ex-data ex) [:rf.ui.compile/error :op :recovery])
+                :message (ex-message ex))))))
+
+#?(:clj
+   (deftest a-compiled-body-cannot-attach-the-one-reachable-host-shape
+     (testing "The compiled tier refuses `[v/behavior …]` at BUILD time. So
+               the ONLY host shape Freehand offers today is unavailable in
+               the compiled mode, and any view that owns a chart, a grid or
+               an editor is interpreted-forever — no promotion, ever, for
+               precisely the views whose neighbours most want it.
+
+               The refusal also MISNAMES what it refused. `v/behavior` is a
+               FRAMEWORK-supplied boundary declared on the public door, and
+               the analyzer classifies it `:op :foreign` — `a foreign
+               component boundary`. An author reading that goes looking for
+               the third-party component they did not write. Two sibling
+               framework boundaries declared the ordinary way, `v/route-link`
+               and `v/markup`, compile without comment, which is what makes
+               the misclassification legible as one."
+       (let [d (compile-body '[v/behavior {:use :x/y :target :t} [:div]])]
+         (is (= :rf.ui.compile/unsupported-form (:rf.ui.compile/error d))
+             (str "the compiled grammar refuses the attachment; got " (pr-str d)))
+         (is (= :foreign (:op d))
+             "classified as a FOREIGN component — the misnaming")
+         (is (str/includes? (:message d) "foreign component boundary")
+             "and the sentence says so to the author")
+         (is (= :extract-declared-child (first (:recovery d)))
+             "naming the recovery this pilot then takes"))
+       (is (= ::accepted (compile-body '[v/route-link {:to :x} "t"]))
+           "a sibling FRAMEWORK boundary compiles without comment")
+       (is (= ::accepted (compile-body '[v/markup {:value nil}]))
+           "and so does the other one"))))
+
+(deftest a-compiled-parent-can-contain-the-interpreted-integration
+  (testing "The refusal's own recovery works, and this is the half worth
+            saying as plainly as the gap: a COMPILED page mounts the
+            interpreted view that owns the React library as an ordinary
+            declared child. The hot markup is lowered, the integration is
+            not, and the boundary between them is one line of source.
+
+            The manifest MARKS the crossing rather than quietly claiming the
+            subtree — so `where does the compiled tier stop` is a fact a tool
+            can read, not something an author has to remember."
+    (seed! {:invoice {:rows [["Widget" 10]]}})
+    (let [m (v/manifest compiled/hot-list)]
+      (is (some? m) "the page really is compiled")
+      (is (= :re-frame.freehand/v1 (:grammar m)))
+      (is (= [{:view-id :re-frame.freehand.pilot-react-interop/invoice-sheet
+               :lowering :interpreted}]
+             (mapv #(select-keys % [:view-id :lowering]) (:crossings m)))
+          (str "one crossing, MARKED interpreted — the integration; got "
+               (pr-str (:crossings m)))))
+    (let [tree (render! [compiled/hot-list {:title "Invoices"}])
+          [b]  (behavior-nodes tree)]
+      (is (= "Invoices" (t/text (t/find tree #(= :h1 (:tag %)))))
+          "the compiled parent's own markup rendered")
+      (is (some? b) "and the interpreted child's host boundary is in the tree")
+      (is (= :invoice/sheet (:target (t/attrs b)))
+          "carrying the same semantic target it has interpreted"))))
+
+(deftest the-headless-integration-promotes-but-not-in-one-line
+  (testing "The library that needed no host shape in the interpreted mode
+            needs none in the compiled mode either — the LIBRARY cost
+            nothing to promote. What cost something was the view around it:
+            the compiled grammar refused `[:th {:on-click [:ledger/sorted
+            key]}]` because the event vector captures a `for` binding, and
+            refused `^{:key k}` metadata because a compiled list row carries
+            a literal `:key` PROP. Both refusals are right and both messages
+            are excellent. Neither is a one-line change.
+
+            The trees are therefore text-equal rather than shape-equal: the
+            recovery introduced child boundaries the interpreted twin does
+            not have. That is the honest result of taking the compiler's
+            advice, and it is what an adopter's diff looks like.
+
+            One more thing promotion surfaced: the compiled tier's a11y
+            analyzer refused `:on-click` on a bare `<th>`
+            (`:rf.ui.compile/a11y-click-non-interactive`). The interpreted
+            twin carried the identical mistake in silence. Promotion does not
+            only move WHEN a mistake surfaces — for a11y it decides WHETHER."
+    (seed! {:ledger {:rows [{:id 1 :name "Zoe" :owed 5}
+                            {:id 2 :name "Ada" :owed 9}]
+                     :sort {:sort-by-key :name}}})
+    (let [interpreted (render! [pilot/headless-table {}])
+          promoted    (render! [compiled/compiled-headless-table {}])
+          rows        (fn [tree] (mapv #(mapv t/text (:children %))
+                                       (t/find-all tree #(= :tr (:tag %)))))]
+      (is (some? (v/manifest compiled/compiled-headless-table))
+          "the promoted twin really is compiled")
+      (is (empty? (behavior-nodes promoted))
+          "and still needs no host shape")
+      (is (= (rows interpreted) (rows promoted))
+          "the two modes render the same table from the same core"))))
 
 ;; ===========================================================================
 ;; The inherited finding, reproduced

--- a/implementation/freehand/test/re_frame/freehand/pilot_react_interop_compiled.cljc
+++ b/implementation/freehand/test/re_frame/freehand/pilot_react_interop_compiled.cljc
@@ -1,0 +1,108 @@
+(ns re-frame.freehand.pilot-react-interop-compiled
+  "The F5i pilot's COMPILED arm — what a `{:compiled true}` page can and
+  cannot do with a React-library integration.
+
+  This arm exists because compiled views became browser-mountable. Before
+  that, asking whether a compiled page could host a React library was
+  academic; now it is the question an adopter with a hot list view and a
+  chart in the same page actually has.
+
+  The answer has two halves, and both are load-bearing:
+
+  1. **A compiled body CANNOT attach the integration.** `[v/behavior …]`
+     inside a compiled body is refused at BUILD time — the only host shape
+     Freehand offers today is unreachable from the compiled tier. So a view
+     that owns a chart, a grid or an editor is interpreted-forever.
+
+  2. **A compiled body CAN CONTAIN one.** The refusal's own recovery —
+     extract the awkward part into its own declared child — works, and it
+     works well: the compiled parent mounts the interpreted integration as
+     an ordinary declared child, its manifest MARKS the crossing
+     `:interpreted`, and the page is one React tree. That is the substrate
+     keeping its promise, and it is worth stating as plainly as the gap.
+
+  The refused spelling lives in the suite (it cannot live here — a build
+  failure in this namespace would fail the whole compile). What lives here
+  is the recovery, promoted: `hot-list` is `{:compiled true}` and mounts
+  the interpreted `invoice-sheet` as a child."
+  (:require [re-frame.freehand :as v]
+            [re-frame.freehand.pilot-react-interop :as pilot]))
+
+(v/defview hot-list
+  "The recovery, and the shape an adopter ends up with: a COMPILED page
+  whose hot markup is lowered, mounting the ONE interpreted child that owns
+  the React library. The crossing is visible in the source and counted in
+  the manifest."
+  {:compiled true}
+  [{:keys [title]}]
+  [:main.hot-page
+   [:h1.title title]
+   [:button.export {:on-click [:invoice/export-requested ","]} "Export"]
+   [pilot/invoice-sheet {}]])
+
+;; ---------------------------------------------------------------------------
+;; The headless integration, PROMOTED — and what promotion actually cost
+;; ---------------------------------------------------------------------------
+;;
+;; The interpreted `pilot/headless-table` is one declaration. Promoting it is
+;; advertised as a one-line change, and for this view it was NOT: the
+;; compiled grammar refused the body twice, and the recovery was to extract
+;; TWO child views.
+;;
+;;   [:th {:on-click [:ledger/sorted key]} label]
+;;   ;; => event vector [:ledger/sorted key] at :on-click captures loop
+;;   ;;    binding key — per-row committed slots need per-row instances.
+;;   ;;    Extract a keyed child view and pass key as a prop
+;;
+;; That refusal is CORRECT and its message is excellent — it names the
+;; mechanism, the reason, and the exact recovery. It is also the ordinary
+;; case rather than an exotic one: a table whose header cells dispatch a
+;; sort is about as plain as a data grid gets, and every such view meets it.
+;;
+;; So the honest report is: promotion is a one-line change for a body that
+;; already happens to be inside the grammar, and a small refactor for one
+;; that is not. Both are fine; only the first is what the docstring says.
+
+(v/defview column-header
+  "The extraction the compiled grammar's refusal named: one child per
+  header cell, with the loop binding arriving as a PROP.
+
+  The sort control is a real `<button>` because the compiled tier's a11y
+  analyzer said so — `:on-click` on a bare `<th>` raised
+  `:rf.ui.compile/a11y-click-non-interactive`, naming both the reason (a
+  generic element is not focusable and has no role) and both recoveries.
+  The advice is right and the markup is better for it.
+
+  It is also a MODE ASYMMETRY worth naming: the interpreted twin carries
+  the identical mistake and says nothing, because a11y analysis is part of
+  what compilation buys. So promotion does not only change when a mistake
+  surfaces — for this class of mistake it changes WHETHER it surfaces."
+  {:compiled true}
+  [{:keys [col label]}]
+  [:th [:button.sort {:on-click [:ledger/sorted col]} label]])
+
+(v/defview data-cell
+  {:compiled true}
+  [{:keys [col value]}]
+  [:td {:data-col col} value])
+
+(v/defview data-row
+  {:compiled true}
+  [{:keys [cells]}]
+  [:tr (for [{:keys [key value]} cells]
+         [data-cell {:key key :col (name key) :value (str value)}])])
+
+(v/defview compiled-headless-table
+  "The headless-library integration, PROMOTED. It needed no host shape in
+  the interpreted mode and needs none here — the promotion cost was the
+  grammar's per-row-slot rule, not the library."
+  {:compiled true}
+  [_]
+  (let [{:keys [header rows]} (v/sub [:ledger/table])]
+    [:table.ledger
+     [:thead
+      [:tr (for [{:keys [key label]} header]
+             [column-header {:key key :col key :label label}])]]
+     [:tbody
+      (for [{:keys [id cells]} rows]
+        [data-row {:key id :cells cells}])]]))

--- a/implementation/freehand/test/re_frame/freehand/pilot_react_interop_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/pilot_react_interop_dom_cljs_test.cljs
@@ -1,0 +1,416 @@
+(ns re-frame.freehand.pilot-react-interop-dom-cljs-test
+  "F5i, the MOUNTED half — a React library really on a real page, and the
+  exact count of what is left behind when it goes.
+
+  The headless sibling proves which host shapes an adopter can REACH. This
+  file proves what the one reachable shape actually does, against a real
+  `react-dom/client` commit:
+
+    * a SpreadJS-class imperative widget, connected once from a committed
+      render, reconciled from config, commanded through the bounded channel
+      by the semantic id its use site authored, and released totally;
+    * a REAL third-party React component (`@xyflow/react`, already a
+      dependency of this repo) on the page, reached the only way it can be
+      reached today — a nested React root inside the node an `{:opaque
+      true}` behavior owns;
+    * the ABI that nested root can carry: props, children, a forwarded ref,
+      an imperative handle reached through a command, and a `window`
+      listener that must come back off;
+    * the emitter's refusal for a foreign component at a vector head, which
+      is the OTHER half of why the nested root is necessary.
+
+  Every cleanup claim is an exact integer measured against a CONTROL mount
+  of the same markup with no behavior at all, so a zero cannot be a counter
+  that was never written.
+
+  Mounting goes through the PUBLIC door — `v/mount` / `v/unmount!` — because
+  the pilot's question is what an adopter's own code looks like.
+
+  This file rides the browser lane through its `-dom-cljs-test` suffix. It
+  also matches the node suites' broader regex, where it has no DOM to mount
+  and says so rather than passing quietly."
+  (:require ["react" :as react]
+            [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.behaviors :as behaviors]
+            [re-frame.freehand.pilot-react-interop :as pilot]
+            [re-frame.freehand.pilot-react-interop-react :as rpilot]
+            [re-frame.freehand.react :as fr]
+            [re-frame.freehand.root :as root]
+            [re-frame.live-frame :as live-frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       plain-atom/adapter
+     :ambient-frame nil
+     :async?        true
+     :init-fn       (fn []
+                      (pilot/reset-ledger!)
+                      (rpilot/reset-ledger!)
+                      (behaviors/reset-connections!)
+                      (root/reset-registry!)
+                      (fr/reset-boundaries!))}))
+
+(def ^:private fid :dom/pilot-react-interop)
+
+(defn- browser? []
+  (and (exists? js/document) (some? (.-createElement js/document))))
+
+(defn- skip! [why]
+  (is true (str "a real React mount needs a DOM host — " why)))
+
+(defn- act
+  "A React 19 `act` boundary as a promise, so assertions run after the commit
+  AND its flushed effects rather than racing them."
+  [thunk]
+  (try
+    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+    (js/Promise.resolve (react/act (fn [] (js/Promise.resolve (thunk)))))
+    (catch :default e
+      (js/Promise.reject e))))
+
+(defn- host-node! []
+  (let [container (js/document.createElement "div")]
+    (.appendChild js/document.body container)
+    container))
+
+(defn- setup!
+  "The frame the pilot's page runs in. Created here rather than owned by the
+  root so a test can seed app-db BEFORE the first render, and so two mounts
+  in one test share one application."
+  ([] (setup! nil))
+  ([db]
+   (live-frame/make-frame {:id fid})
+   (when db (frame/replace-app-db! fid db))
+   nil))
+
+(defn- seed! [db] (frame/replace-app-db! fid db))
+(defn- send! [ev] (rf/dispatch-sync ev {:frame fid}))
+(defn- read* [query] (rf/subscribe-once query {:frame fid}))
+
+(defn- mount!
+  "Mount `form` into `container` through the PUBLIC door, scoping the frame
+  the pilot already made."
+  [container form]
+  (v/mount form container {:frame fid}))
+
+(defn- teardown! [container mounted]
+  (v/unmount! mounted)
+  (.remove container)
+  nil)
+
+(defn- q [container selector] (.querySelector container selector))
+
+;; ===========================================================================
+;; 1 — the SpreadJS-class widget: THE behavior shape, used as designed
+;; ===========================================================================
+
+(deftest a-spreadjs-class-widget-connects-once-from-a-committed-render
+  (testing "The integration an adopter would actually write: an opaque,
+            mutable, listener-owning host widget over one node. `:connect`
+            runs once from the commit with the live node in hand, the widget
+            paints itself, and the config it was given came out of an
+            ordinary subscription. Nothing in the view holds an instance and
+            nothing in app-db does either."
+    (if-not (browser?)
+      (skip! "the browser job runs the mounted widget assertions")
+      (async done
+        (setup! {:invoice {:rows [["Widget" 10] ["Gasket" 4]]}})
+        (let [container (host-node!)]
+          (-> (act #(mount! container [pilot/invoice-page {}]))
+              (.then (fn [mounted]
+                       (is (= 1 (pilot/live-instances))
+                           "exactly one widget instance is live")
+                       (is (= 1 (pilot/live-listeners))
+                           "holding exactly one host listener")
+                       (is (= 1 (behaviors/connection-count)))
+                       (is (= #{:invoice/sheet} (behaviors/target-ids))
+                           "claiming the semantic id the use site authored")
+                       (is (some? (q container "table.acme-sheet"))
+                           "and the widget really painted into the node it owns")
+                       (is (some? (q container "button.export"))
+                           "beside ordinary Freehand markup in the same tree")
+                       (act #(teardown! container mounted))))
+              (.then (fn [_]
+                       (is (= 0 (pilot/live-instances)))
+                       (is (= 0 (behaviors/connection-count)))
+                       (done)))
+              (.catch (fn [e]
+                        (is false (str "mount rejected: " e))
+                        (done)))))))))
+
+(deftest the-widget-reconciles-from-config-and-nothing-else
+  (testing "Desired state reaches the host through `:config` and `:update`,
+            and `rf=`-equal config is not movement. An adopter integrating a
+            grid gets edge detection for free — no sticky props, no manual
+            diffing, no `componentDidUpdate` comparison."
+    (if-not (browser?)
+      (skip! "the browser job runs the reconcile assertions")
+      (async done
+        (setup! {:invoice {:rows [["a" 1]]}})
+        (let [container (host-node!)]
+          (-> (act #(mount! container [pilot/invoice-sheet {}]))
+              (.then (fn [mounted]
+                       (is (= 1 (.-length (.querySelectorAll container "table.acme-sheet tr")))
+                           "one row painted")
+                       (act (fn [] (send! [:invoice/seeded [["a" 1] ["b" 2]]]) mounted))))
+              (.then (fn [_]
+                       (is (= 2 (.-length (.querySelectorAll container "table.acme-sheet tr")))
+                           "a moved config reconciles the host in place")
+                       (is (= 1 (pilot/live-instances))
+                           "WITHOUT reconstructing the widget — one instance throughout")
+                       (is (= 1 (:constructed (pilot/ledger-snapshot)))
+                           "constructed exactly once")
+                       (done)))
+              (.catch (fn [e]
+                        (is false (str "mount rejected: " e))
+                        (done)))))))))
+
+(deftest a-command-reaches-the-widget-and-its-result-comes-back-as-an-event
+  (testing "The one-shot imperative operation — export — travels the whole
+            real path: a view's `:on-click` intent, an ordinary `reg-event`
+            handler returning the reserved command effect as DATA, the
+            channel resolving the caller-authored semantic id against the
+            LIVE connection, the widget's registered operation running
+            synchronously, and its RESULT returning as an ordinary event
+            through the behavior's generation-fenced dispatch.
+
+            Nothing in that chain is a handle. No application value ever
+            carries the widget."
+    (if-not (browser?)
+      (skip! "the browser job runs the command assertions")
+      (async done
+        (setup! {:invoice {:rows [["Widget" 10] ["Gasket" 4]]}})
+        (let [container (host-node!)]
+          (-> (act #(mount! container [pilot/invoice-sheet {}]))
+              (.then (fn [mounted]
+                       (act (fn [] (send! [:invoice/export-requested "|"]) mounted))))
+              (.then (fn [mounted]
+                       (is (= "Widget|10\nGasket|4" (read* [:invoice/last-export]))
+                           "the command ran on the live widget and its result came
+                            back as ordinary application state")
+                       (act (fn [] (send! [:invoice/cell-focus-requested [1 0]]) mounted))))
+              (.then (fn [mounted]
+                       (is (some? (q container "td[data-cursor]"))
+                           "a second operation on the same roster reached the host")
+                       (act #(teardown! container mounted))))
+              (.then (fn [_] (done)))
+              (.catch (fn [e]
+                        (is false (str "mount rejected: " e))
+                        (done)))))))))
+
+(deftest a-command-addresses-one-live-widget-and-not-its-neighbour
+  (testing "Two live instances of the SAME registered behavior under DISTINCT
+            semantic ids. If addressing were derived from render position or
+            from the behavior id, the decoy would be reachable — so the
+            assertion is symmetric."
+    (if-not (browser?)
+      (skip! "the browser job runs the addressing assertions")
+      (async done
+        (setup!)
+        (let [container (host-node!)]
+          (-> (act #(mount! container [pilot/two-sheets {}]))
+              (.then (fn [mounted]
+                       (is (= 2 (pilot/live-instances)))
+                       (is (= #{:invoice/sheet :invoice/draft} (behaviors/target-ids)))
+                       (act (fn [] (send! [:invoice/cell-focus-requested [0 0]]) mounted))))
+              (.then (fn [mounted]
+                       (is (some? (q container "[data-id='primary'] td[data-cursor]"))
+                           "the named target performed the host work")
+                       (is (nil? (q container "[data-id='decoy'] td[data-cursor]"))
+                           "and the live DECOY was untouched")
+                       (act #(teardown! container mounted))))
+              (.then (fn [_]
+                       (is (= 0 (pilot/live-instances)))
+                       (done)))
+              (.catch (fn [e]
+                        (is false (str "mount rejected: " e))
+                        (done)))))))))
+
+(deftest widget-teardown-is-total-measured-against-a-control
+  (testing "Acceptance for this pilot is an EXACT retained count after
+            unmount, and a zero only means something measured against a
+            mount that never allocated. The control renders the same markup
+            with no behavior; then the real page mounts, allocates, and is
+            torn down through `v/unmount!`."
+    (if-not (browser?)
+      (skip! "the browser job runs the teardown assertions")
+      (async done
+        (setup!)
+        (let [control (host-node!)
+              live    (host-node!)]
+          (-> (act #(mount! control [pilot/control-page {}]))
+              (.then (fn [mounted]
+                       (is (= {:instances 0 :listeners 0 :constructed 0 :destroyed 0}
+                              (pilot/ledger-snapshot))
+                           "the CONTROL allocates nothing")
+                       (is (some? (q control "div.sheet-host"))
+                           "and really did mount the same node")
+                       (act #(teardown! control mounted))))
+              (.then (fn [_] (act #(mount! live [pilot/invoice-sheet {}]))))
+              (.then (fn [mounted]
+                       (is (= 1 (pilot/live-instances)))
+                       (is (= 1 (pilot/live-listeners)))
+                       (act #(teardown! live mounted))))
+              (.then (fn [_]
+                       (is (= {:instances 0 :listeners 0 :constructed 1 :destroyed 1}
+                              (pilot/ledger-snapshot))
+                           "after teardown: no instance, no listener, and the
+                            cumulative totals prove the release RAN rather than
+                            the counters never having been written")
+                       (is (= 0 (behaviors/connection-count)))
+                       (is (= #{} (behaviors/target-ids)))
+                       (done)))
+              (.catch (fn [e]
+                        (is false (str "mount rejected: " e))
+                        (done)))))))))
+
+;; ===========================================================================
+;; 2 — a foreign component at a vector head, in the BROWSER
+;; ===========================================================================
+
+(deftest the-react-emitter-refuses-a-foreign-component-head
+  (testing "The headless suite proved the structural emitter refuses a host
+            descriptor. The React emitter refuses it too, and names the same
+            missing slice — so an adopter meets exactly one answer on both
+            hosts, and the nested-root workaround below is not a preference."
+    (let [d (try (fr/element [pilot/foreign-leaf {:spec "bar"}]) nil
+                 (catch :default e (ex-data e)))]
+      (is (= :rf.error/ui-tree-malformed (:rf.error/id d)))
+      (is (re-find #"host boundary and its three host shapes"
+                   (or (:reason d) ""))
+          (str "the React emitter names the three host shapes as landing "
+               "later; got " (pr-str (:reason d)))))))
+
+;; ===========================================================================
+;; 3 — a real React component through the nested-root workaround
+;; ===========================================================================
+
+(deftest a-nested-react-root-carries-the-whole-react-abi
+  (testing "The workaround, exercised against a component built the way a
+            real library builds one: value props, React children, a
+            forwarded ref, an imperative handle, and a mount effect that
+            installs a real `window` listener.
+
+            All of it works. What it costs is that the component's subtree is
+            a SEPARATE React tree — no shared context, no shared event path,
+            no Suspense participation, no SSR — and the boundary is one-way:
+            the `{:opaque true}` rule that makes the nested root safe is the
+            same rule that forbids interleaving Freehand content into the
+            foreign component's children."
+    (if-not (browser?)
+      (skip! "the browser job runs the nested-root assertions")
+      (async done
+        (setup!)
+        (let [container (host-node!)]
+          (-> (act #(mount! container [rpilot/widget-page {:label "alpha" :tick 1}]))
+              (.then (fn [mounted]
+                       (is (= 1 (rpilot/live-roots))
+                           "one nested React root, inside the node the behavior owns")
+                       (is (= 1 (rpilot/live-probe-mounts))
+                           "the foreign component's mount effect ran")
+                       (is (= 1 (rpilot/live-probe-listeners))
+                           "and it installed its window listener")
+                       (is (= "alpha" (.getAttribute (q container ".acme-widget")
+                                                     "data-label"))
+                           "value props crossed")
+                       (is (= "react children" (.-textContent (q container ".acme-widget em")))
+                           "and so did React's own children")
+                       ;; The imperative handle a React library expects a
+                       ;; caller to hold is reached through the BOUNDED
+                       ;; command channel. It never leaves the behavior's
+                       ;; private memory.
+                       (act (fn [] (send! [:acme/ping-requested]) mounted))))
+              (.then (fn [mounted]
+                       (is (= "ping:alpha" (read* [:acme/last-ping]))
+                           "the imperative handle answered, and its result came
+                            back as an ordinary event")
+                       (act #(teardown! container mounted))))
+              (.then (fn [_]
+                       (is (= 0 (rpilot/live-roots))
+                           "the nested root closed with the behavior")
+                       (is (= 0 (rpilot/live-probe-mounts))
+                           "the foreign component's cleanup ran")
+                       (is (= 0 (rpilot/live-probe-listeners))
+                           "and its window listener came back off — total release
+                            through a boundary the substrate never sees inside")
+                       (done)))
+              (.catch (fn [e]
+                        (is false (str "mount rejected: " e))
+                        (done)))))))))
+
+(deftest a-real-third-party-react-component-renders-and-releases
+  (testing "`@xyflow/react` — a genuine third-party React component library,
+            already a dependency of this repo and adapted in no way for this
+            pilot — mounted from Freehand through the nested root, rendering
+            its own DOM, and released completely on unmount.
+
+            This is the pilot's answer to `can I use a third-party React
+            component?`: yes, today, through one workaround that costs a
+            second React tree. It is NOT the qualified leaf the design calls
+            for, and this test will need rewriting the day that lands."
+    (if-not (browser?)
+      (skip! "the browser job runs the React Flow mount")
+      (async done
+        (setup!)
+        (let [container (host-node!)
+              nodes     [{:id "a" :position {:x 0 :y 0} :data {:label "A"}}
+                         {:id "b" :position {:x 120 :y 60} :data {:label "B"}}]
+              edges     [{:id "a-b" :source "a" :target "b"}]]
+          (-> (act #(mount! container [rpilot/flow-page {:nodes nodes :edges edges}]))
+              (.then (fn [mounted]
+                       (is (= 1 (rpilot/live-roots)))
+                       (is (some? (q container ".react-flow"))
+                           "React Flow really rendered its own DOM")
+                       (is (= 2 (.-length (.querySelectorAll container ".react-flow__node")))
+                           "with the two nodes the config named")
+                       (act #(teardown! container mounted))))
+              (.then (fn [_]
+                       (is (= 0 (rpilot/live-roots))
+                           "and the nested root closed on unmount")
+                       (is (nil? (q container ".react-flow"))
+                           "leaving no React Flow DOM behind")
+                       (done)))
+              (.catch (fn [e]
+                        (is false (str "mount rejected: " e))
+                        (done)))))))))
+
+(deftest the-nested-root-is-not-free-and-the-cost-is-named
+  (testing "The honest cost accounting, asserted rather than asserted away.
+            The nested root is opened by the behavior at COMMIT — so a
+            candidate React abandons opens none — and closed at disconnect.
+            The `roots-opened` / `roots-closed` totals after a mount/unmount
+            cycle are the proof that the second tree's lifetime is exactly
+            the behavior's, which is the one guarantee that makes the
+            workaround tolerable."
+    (if-not (browser?)
+      (skip! "the browser job runs the nested-root lifetime assertions")
+      (async done
+        (setup!)
+        (let [container (host-node!)]
+          (-> (act #(mount! container [rpilot/control-widget-page {}]))
+              (.then (fn [mounted]
+                       (is (= {:roots 0 :probe-mounts 0 :probe-listeners 0
+                               :roots-opened 0 :roots-closed 0}
+                              (rpilot/ledger-snapshot))
+                           "the CONTROL opens no nested root at all")
+                       (act #(teardown! container mounted))))
+              (.then (fn [_] (act #(mount! (host-node!) [rpilot/widget-page {}]))))
+              (.then (fn [mounted]
+                       (is (= 1 (:roots-opened (rpilot/ledger-snapshot))))
+                       (act #(v/unmount! mounted))))
+              (.then (fn [_]
+                       (let [l (rpilot/ledger-snapshot)]
+                         (is (= 1 (:roots-opened l)))
+                         (is (= 1 (:roots-closed l))
+                             "opened once, closed once — the second React tree's
+                              lifetime is exactly the behavior's connection")
+                         (is (= 0 (:roots l))))
+                       (done)))
+              (.catch (fn [e]
+                        (is false (str "mount rejected: " e))
+                        (done)))))))))

--- a/implementation/freehand/test/re_frame/freehand/pilot_react_interop_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/pilot_react_interop_dom_cljs_test.cljs
@@ -36,6 +36,7 @@
             [re-frame.freehand :as v]
             [re-frame.freehand.behaviors :as behaviors]
             [re-frame.freehand.pilot-react-interop :as pilot]
+            [re-frame.freehand.pilot-react-interop-compiled :as compiled]
             [re-frame.freehand.pilot-react-interop-react :as rpilot]
             [re-frame.freehand.react :as fr]
             [re-frame.freehand.root :as root]
@@ -374,6 +375,56 @@
                            "and the nested root closed on unmount")
                        (is (nil? (q container ".react-flow"))
                            "leaving no React Flow DOM behind")
+                       (done)))
+              (.catch (fn [e]
+                        (is false (str "mount rejected: " e))
+                        (done)))))))))
+
+;; ===========================================================================
+;; 4 — a COMPILED page containing the integration, on a real page
+;; ===========================================================================
+;;
+;; Newly answerable: compiled views became browser-mountable. The headless
+;; sibling proves the compiled tier REFUSES to attach the integration and
+;; that its recovery type-checks; this proves the recovery actually runs.
+
+(deftest a-compiled-page-hosts-the-interpreted-integration-in-one-react-tree
+  (testing "The shape an adopter ends up with once they meet the compiled
+            tier's refusal: a `{:compiled true}` page whose hot markup is
+            lowered, mounting the interpreted view that owns the widget as
+            an ordinary declared child.
+
+            It is ONE React tree — the compiled parent's lowered elements
+            and the interpreted child's boundary render into the same root,
+            the widget connects from the same commit, and a command
+            addressed to the child's semantic target reaches it from an
+            event dispatched by the COMPILED parent's own button. Nothing
+            about the crossing is visible at runtime, which is the promise."
+    (if-not (browser?)
+      (skip! "the browser job runs the compiled-crossing mount")
+      (async done
+        (setup! {:invoice {:rows [["Widget" 10] ["Gasket" 4]]}})
+        (let [container (host-node!)]
+          (-> (act #(mount! container [compiled/hot-list {:title "Invoices"}]))
+              (.then (fn [mounted]
+                       (is (= "Invoices" (.-textContent (q container "h1.title")))
+                           "the COMPILED parent's own markup is on the page")
+                       (is (some? (q container "table.acme-sheet"))
+                           "and the interpreted child's widget really connected")
+                       (is (= 1 (pilot/live-instances)))
+                       (is (= #{:invoice/sheet} (behaviors/target-ids)))
+                       ;; the compiled parent's button, the interpreted
+                       ;; child's widget, one command between them
+                       (act (fn [] (send! [:invoice/export-requested ","]) mounted))))
+              (.then (fn [mounted]
+                       (is (= "Widget,10\nGasket,4" (read* [:invoice/last-export]))
+                           "a command dispatched from the compiled parent reached
+                            the widget the interpreted child owns")
+                       (act #(teardown! container mounted))))
+              (.then (fn [_]
+                       (is (= 0 (pilot/live-instances))
+                           "and teardown across the crossing is still total")
+                       (is (= 0 (behaviors/connection-count)))
                        (done)))
               (.catch (fn [e]
                         (is false (str "mount rejected: " e))

--- a/implementation/freehand/test/re_frame/freehand/pilot_react_interop_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/pilot_react_interop_dom_cljs_test.cljs
@@ -41,12 +41,17 @@
             [re-frame.freehand.react :as fr]
             [re-frame.freehand.root :as root]
             [re-frame.live-frame :as live-frame]
-            [re-frame.substrate.plain-atom :as plain-atom]
+            ;; The REACT substrate adapter, not `plain-atom`. A subscription
+            ;; that moves has to repaint a mounted occurrence, and only the
+            ;; React adapter schedules that — a pilot on the atom adapter
+            ;; would assert reconciliation against a tree that never
+            ;; re-rendered.
+            [re-frame.adapter.uix :as react-substrate]
             [re-frame.test-support :as test-support]))
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture
-    {:adapter       plain-atom/adapter
+    {:adapter       react-substrate/adapter
      :ambient-frame nil
      :async?        true
      :init-fn       (fn []
@@ -105,6 +110,14 @@
   nil)
 
 (defn- q [container selector] (.querySelector container selector))
+
+(defn- tick
+  "One microtask turn. Needed ONLY around the nested-React-root workaround,
+  whose teardown React forces to be asynchronous — see
+  `pilot-react-interop-react/close-root!`. Every release the SUBSTRATE
+  performs is synchronous and is asserted without this."
+  []
+  (js/Promise. (fn [resolve] (js/queueMicrotask #(resolve nil)))))
 
 ;; ===========================================================================
 ;; 1 — the SpreadJS-class widget: THE behavior shape, used as designed
@@ -302,7 +315,14 @@
             no Suspense participation, no SSR — and the boundary is one-way:
             the `{:opaque true}` rule that makes the nested root safe is the
             same rule that forbids interleaving Freehand content into the
-            foreign component's children."
+            foreign component's children.
+
+            And it costs one more thing, asserted below rather than described:
+            the nested root's TEARDOWN cannot be synchronous. React refuses to
+            unmount a root from inside a render, and a behavior's
+            `:disconnect` runs inside the outer tree's unmount, so the second
+            React tree is still open at the instant the substrate's own
+            release has finished."
     (if-not (browser?)
       (skip! "the browser job runs the nested-root assertions")
       (async done
@@ -332,8 +352,21 @@
                             back as an ordinary event")
                        (act #(teardown! container mounted))))
               (.then (fn [_]
+                       (is (= 0 (behaviors/connection-count))
+                           "the substrate's own release is synchronous")
+                       ;; The nested root's is NOT: React refuses a
+                       ;; synchronous unmount from inside a render, so
+                       ;; `close-root!` defers it a microtask. `act` drains
+                       ;; microtasks, so the intermediate open state is not
+                       ;; observable from here — the deferral is evidenced
+                       ;; instead by the ABSENCE of React's
+                       ;; `Attempted to synchronously unmount a root while
+                       ;; React was already rendering` error, which the
+                       ;; browser runner fails the whole lane on.
+                       (tick)))
+              (.then (fn [_]
                        (is (= 0 (rpilot/live-roots))
-                           "the nested root closed with the behavior")
+                           "and the nested root has closed")
                        (is (= 0 (rpilot/live-probe-mounts))
                            "the foreign component's cleanup ran")
                        (is (= 0 (rpilot/live-probe-listeners))
@@ -370,9 +403,11 @@
                        (is (= 2 (.-length (.querySelectorAll container ".react-flow__node")))
                            "with the two nodes the config named")
                        (act #(teardown! container mounted))))
+              (.then (fn [_] (tick)))
               (.then (fn [_]
                        (is (= 0 (rpilot/live-roots))
-                           "and the nested root closed on unmount")
+                           "and the nested root closed on unmount (one microtask
+                            later — see the ABI case above)")
                        (is (nil? (q container ".react-flow"))
                            "leaving no React Flow DOM behind")
                        (done)))
@@ -454,6 +489,7 @@
               (.then (fn [mounted]
                        (is (= 1 (:roots-opened (rpilot/ledger-snapshot))))
                        (act #(v/unmount! mounted))))
+              (.then (fn [_] (tick)))
               (.then (fn [_]
                        (let [l (rpilot/ledger-snapshot)]
                          (is (= 1 (:roots-opened l)))

--- a/implementation/freehand/test/re_frame/freehand/pilot_react_interop_react.cljs
+++ b/implementation/freehand/test/re_frame/freehand/pilot_react_interop_react.cljs
@@ -1,0 +1,254 @@
+(ns re-frame.freehand.pilot-react-interop-react
+  "The F5i pilot's REACT half — the only way a third-party React component
+  reaches the page from Freehand in this tree, and what it costs.
+
+  `pilot-react-interop` explains why: the qualified host leaf and the
+  explicit React wrapper are both refused by the emitters today, and
+  `v/->react` does not exist. The one shape that IS reachable — a registered
+  behavior — hands its implementation a DOM NODE, not a React parent. So an
+  adopter who needs `<ReactFlow>`, `<VegaLite>`, `<AgGridReact>` on the page
+  right now has exactly one move available:
+
+      open a SECOND React root inside the node an `{:opaque true}` behavior
+      owns, and render the foreign component into it.
+
+  That works. This namespace does it twice — once against a purpose-built
+  component that exercises the whole React ABI (props, children, a forwarded
+  ref, an imperative handle, mount/unmount effects, a listener it must
+  release), and once against `@xyflow/react`, a real third-party React
+  component already in this repo's dependency tree.
+
+  ## The costs, stated up front
+
+  The nested root is a SEPARATE React tree. It does not inherit React context
+  from the Freehand tree above it, its events do not bubble through the
+  Freehand tree's React handlers, it does not participate in the outer tree's
+  Suspense boundaries or transitions, and it has no server rendering at all.
+  It is also ONE-WAY: the foreign component's children are React's, so
+  Freehand content cannot be interleaved into them. `Radix`-shaped compound
+  components and `flexRender`-shaped cell APIs need exactly that
+  interleaving, which is why they are reported blocked rather than
+  worked-around.
+
+  Everything here is counted. `live-roots`, `live-probe-mounts` and
+  `live-probe-listeners` are read by the mounted suite AFTER teardown, and
+  the claim is an exact zero measured against a control mount."
+  (:require ["@xyflow/react" :as xyflow]
+            ["react" :as react]
+            ["react-dom/client" :as rdc]
+            [re-frame.core :as rf]
+            [re-frame.freehand :as v]))
+
+;; ===========================================================================
+;; The ledger — what the React half is holding right now
+;; ===========================================================================
+
+(def ^:private ledger
+  (atom {:roots 0 :probe-mounts 0 :probe-listeners 0
+         :roots-opened 0 :roots-closed 0}))
+
+(defn ledger-snapshot [] @ledger)
+(defn reset-ledger!
+  []
+  (reset! ledger {:roots 0 :probe-mounts 0 :probe-listeners 0
+                  :roots-opened 0 :roots-closed 0})
+  nil)
+
+(defn live-roots [] (:roots @ledger))
+(defn live-probe-mounts [] (:probe-mounts @ledger))
+(defn live-probe-listeners [] (:probe-listeners @ledger))
+
+;; ===========================================================================
+;; `acme-widget` — a third-party React component, ABI-complete
+;; ===========================================================================
+;;
+;; Written the way a real React library writes one, because the pilot's
+;; question is whether the boundary can carry a real ABI and not whether it
+;; can carry a `<div>`:
+;;
+;;   * value props in, including a callback prop the host invokes;
+;;   * children React owns;
+;;   * `forwardRef` + `useImperativeHandle` — the imperative handle a caller
+;;     is expected to hold and call methods on;
+;;   * a mount effect that installs a real `window` listener, and a cleanup
+;;     that must release it.
+
+(def acme-widget
+  (react/forwardRef
+    (fn [^js props ref]
+      (let [label   (.-label props)
+            tick    (.-tick props)
+            on-ping (.-onPing props)]
+        (react/useImperativeHandle
+          ref
+          (fn []
+            #js {:ping (fn [] (when on-ping (on-ping (str "ping:" label))) true)})
+          #js [label on-ping])
+        (react/useEffect
+          (fn []
+            (let [listener (fn [_] nil)]
+              (.addEventListener js/window "resize" listener)
+              (swap! ledger (fn [l] (-> l
+                                        (update :probe-mounts inc)
+                                        (update :probe-listeners inc))))
+              (fn []
+                (.removeEventListener js/window "resize" listener)
+                (swap! ledger (fn [l] (-> l
+                                          (update :probe-mounts dec)
+                                          (update :probe-listeners dec))))
+                nil)))
+          #js [])
+        (react/createElement
+          "div"
+          #js {:className "acme-widget" :data-label label :data-tick (str tick)}
+          (react/createElement "span" #js {:className "acme-widget-label"} label)
+          (.-children props))))))
+
+;; ===========================================================================
+;; The nested-root plumbing — the SAME two functions both behaviors use
+;; ===========================================================================
+;;
+;; Two functions, and that is genuinely the whole workaround. It is small,
+;; which is the honest half of the report: what it is not is FREE, and the
+;; costs live in the namespace docstring rather than in the code.
+
+(defn- open-root!
+  [node element]
+  (let [root (rdc/createRoot node)]
+    (swap! ledger (fn [l] (-> l (update :roots inc) (update :roots-opened inc))))
+    (.render root element)
+    root))
+
+(defn- close-root!
+  [root]
+  (.unmount root)
+  (swap! ledger (fn [l] (-> l (update :roots dec) (update :roots-closed inc))))
+  nil)
+
+;; ===========================================================================
+;; INTEGRATION 2a — the ABI-complete component through a nested root
+;; ===========================================================================
+;;
+;; `:config` is DATA, so the behavior — not the use site — decides which
+;; component is rendered and how the data becomes props. That constraint
+;; reads as a limitation and is not one: a chart's props ARE data, and
+;; forcing the mapping into one named place is where you want it. What it
+;; DOES forbid is a generic `[v/behavior {:use react-host :config {:component
+;; SomeComponent}}]`, so every foreign component needs its own registration.
+
+(defn- widget-element
+  [config handle on-ping]
+  (react/createElement
+    acme-widget
+    #js {:label  (str (:label config))
+         :tick   (:tick config)
+         :ref    handle
+         :onPing on-ping}
+    (react/createElement "em" nil "react children")))
+
+(v/defbehavior acme-widget-host
+  "Mount `acme-widget` into a nested React root inside the node this
+  behavior owns."
+  {:opaque true
+   :timing :passive
+   :connect
+   (fn [{:keys [node config dispatch]}]
+     (let [handle  (react/createRef)
+           on-ping (fn [s] (dispatch [:acme/pinged s]))]
+       {:root    (open-root! node (widget-element config handle on-ping))
+        :handle  handle
+        :on-ping on-ping}))
+   :update
+   (fn [{:keys [config memory]}]
+     (when memory
+       (.render (:root memory)
+                (widget-element config (:handle memory) (:on-ping memory))))
+     memory)
+   :disconnect
+   (fn [{:keys [memory]}]
+     (when memory (close-root! (:root memory)))
+     nil)
+   :commands
+   {;; The imperative handle a React library expects a caller to hold is
+    ;; reached through the bounded command channel — which is the RIGHT
+    ;; place for it. The handle never leaves the behavior's private memory,
+    ;; so no application value carries a live host object.
+    :ping (fn [{:keys [memory]}]
+            (when-let [h (some-> memory :handle .-current)]
+              (.ping h))
+            memory)}})
+
+;; ===========================================================================
+;; INTEGRATION 2b — `@xyflow/react`, a REAL third-party component
+;; ===========================================================================
+;;
+;; React Flow is a genuine third-party React component library, already a
+;; devDependency of `implementation/package.json` (the Xray machine chart
+;; consumes it). Nothing about it was adapted for this pilot: the behavior
+;; hands it the props its own documentation names, in a container with real
+;; dimensions, and reads the DOM back.
+
+(def ^:private ReactFlow (.-ReactFlow xyflow))
+
+(defn- flow-element
+  [{:keys [nodes edges]}]
+  (react/createElement
+    "div"
+    #js {:style #js {:width "320px" :height "200px"}}
+    (react/createElement
+      ReactFlow
+      #js {:nodes (clj->js (or nodes []))
+           :edges (clj->js (or edges []))
+           :fitView true
+           ;; Deliberately inert: the pilot is measuring the boundary, not
+           ;; React Flow's interaction model, and a pan/zoom listener would
+           ;; add noise to the retained-listener count.
+           :nodesDraggable false
+           :panOnDrag      false
+           :zoomOnScroll   false
+           :proOptions     #js {:hideAttribution true}})))
+
+(v/defbehavior react-flow-host
+  "A React-Vega-class chart component — a real `@xyflow/react` graph —
+  reached through a nested React root."
+  {:opaque true
+   :timing :passive
+   :connect    (fn [{:keys [node config]}]
+                 {:root (open-root! node (flow-element config))})
+   :update     (fn [{:keys [config memory]}]
+                 (when memory (.render (:root memory) (flow-element config)))
+                 memory)
+   :disconnect (fn [{:keys [memory]}]
+                 (when memory (close-root! (:root memory)))
+                 nil)})
+
+;; ===========================================================================
+;; The use sites
+;; ===========================================================================
+
+(rf/reg-event :acme/pinged
+  (fn [{:keys [db]} [_ s]] {:db (assoc-in db [:acme :last-ping] s)}))
+
+(rf/reg-sub :acme/last-ping (fn [db _] (get-in db [:acme :last-ping])))
+
+(v/defview widget-page
+  [{:keys [label tick]}]
+  [:section.widget-page
+   [v/behavior {:use    acme-widget-host
+                :target :acme/widget
+                :config {:label (or label "alpha") :tick (or tick 0)}}
+    [:div.widget-host]]])
+
+(v/defview flow-page
+  [{:keys [nodes edges]}]
+  [:section.flow-page
+   [v/behavior {:use    react-flow-host
+                :target :acme/flow
+                :config {:nodes nodes :edges edges}}
+    [:div.flow-host]]])
+
+(v/defview control-widget-page
+  "The CONTROL: identical markup, no behavior, no nested root."
+  [_]
+  [:section.widget-page
+   [:div.widget-host]])

--- a/implementation/freehand/test/re_frame/freehand/pilot_react_interop_react.cljs
+++ b/implementation/freehand/test/re_frame/freehand/pilot_react_interop_react.cljs
@@ -119,10 +119,37 @@
     (.render root element)
     root))
 
+;; ---------------------------------------------------------------------------
+;; Closing the nested root — the workaround's sharpest edge
+;; ---------------------------------------------------------------------------
+;;
+;; A behavior's `:disconnect` runs from the OUTER tree's own unmount. Calling
+;; `root.unmount()` there synchronously is calling into React while React is
+;; already rendering, and React 19 says so:
+;;
+;;   Attempted to synchronously unmount a root while React was already
+;;   rendering. React cannot finish unmounting the root until the current
+;;   render has completed, which may lead to a race condition.
+;;
+;; React's own documented remedy is to defer the unmount out of the current
+;; render — a microtask is enough. That is what this does, and it is a REAL
+;; cost of the nested-root shape rather than a detail: it means the second
+;; React tree's teardown is ASYNCHRONOUS while every other release the
+;; substrate performs is synchronous and assertable at the instant of
+;; unmount. A test (or an application counting instances, or a leak check in
+;; CI) has to know to wait a tick.
+;;
+;; Nothing an application author writes can avoid this while the nested root
+;; IS the integration path — which is the argument for the qualified host
+;; leaf, made in the currency of a warning in the console.
+
 (defn- close-root!
   [root]
-  (.unmount root)
-  (swap! ledger (fn [l] (-> l (update :roots dec) (update :roots-closed inc))))
+  (js/queueMicrotask
+    (fn []
+      (.unmount root)
+      (swap! ledger (fn [l] (-> l (update :roots dec) (update :roots-closed inc))))
+      nil))
   nil)
 
 ;; ===========================================================================

--- a/implementation/freehand/test/re_frame/freehand/pilot_react_interop_react.cljs
+++ b/implementation/freehand/test/re_frame/freehand/pilot_react_interop_react.cljs
@@ -231,6 +231,16 @@
 
 (rf/reg-sub :acme/last-ping (fn [db _] (get-in db [:acme :last-ping])))
 
+;; Reaching the foreign component's IMPERATIVE HANDLE is an ordinary bounded
+;; command, addressed by the semantic id the use site authored. The handle
+;; itself never leaves the behavior's private memory — which is the rule that
+;; keeps `no public value carries a live host object` true even when the
+;; foreign component's whole API is a handle.
+(rf/reg-event :acme/ping-requested
+  (fn [_ _]
+    {:fx [[:re-frame.freehand.host/command
+           {:target :acme/widget :op :ping}]]}))
+
 (v/defview widget-page
   [{:keys [label tick]}]
   [:section.widget-page


### PR DESCRIPTION
The F5i pilot: a React-library integration written the way an adopter would write
one, across the host shapes the substrate offers — and an honest report of which
of them actually exist.

Test-only. No production source touched, no public verb added, no npm dependency
added.

## Quality gates

| Gate | Exit | Result |
|---|---|---|
| `cd implementation/freehand && clojure -M:test` | **0** | 754 tests, 5397 assertions, 0 failures, 0 errors |
| `npm run test:freehand` | **0** | 717 tests, 4414 assertions, 0 failures, 0 errors |
| `npm run test:cljs` | **0** | 10842 tests, 54537 assertions, 0 failures, 0 errors |
| `npm run test:browser` | **0** | 633 tests, 3756 assertions, 0 failures, 0 errors |
| `python scripts/check_freehand_conformance_index.py` | **0** | clean |
| `python scripts/check_donor_inventory.py` | **0** | clean |
| `python scripts/check_doc_slugs.py` | **0** | clean |

All numbers re-taken after rebasing onto `fdad3ad983`. In the browser lane the
exit code is the verdict, not the summary — the runner fails on any uncaught
`pageerror`, and it does not fire.

## The headline

**"Can I use a third-party React component?" is the first question any adopter
asks. The answer today is "yes, through a workaround that costs a second React
tree — and not at all if the component wants your content in its children."**

Spec 004 offers four host shapes for foreign UI. Exactly one is reachable:

| Shape | For | Status |
|---|---|---|
| qualified host leaf | a component with value props | **refused by both emitters** |
| explicit React wrapper | a React-owned protocol | **refused by both emitters** |
| registered behavior | opaque, mutable host state | **works, and works well** |
| outward bridge `v/->react` | a library wanting a *component* | **absent from the door** |

The classifier already knows the foreign-component head — `classify-head` answers
`:host`, totally, today. What is missing is everything behind it: no public verb
mints a host descriptor, and both emitters refuse to cross one, each naming the
host-lifecycle slice that will lift it.

A behavior receives a **DOM node**, not a React parent. So the only route onto the
page for a real React component is to open a **second React root** inside the node
an `{:opaque true}` behavior owns. The pilot does exactly that against
`@xyflow/react` — a genuine third-party library already in this repo's dependency
tree, adapted in no way — and it works. Costs, all measured rather than asserted:

1. **A separate React tree.** No shared context, no shared event path, no
   Suspense participation, no transitions, no SSR.
2. **One-way.** The `{:opaque true}` rule that makes the nested root safe is the
   same rule that forbids interleaving Freehand content into the foreign
   component's children. Radix-shaped compound components and `flexRender`-shaped
   cell APIs need exactly that, and are unreachable — reported, not worked around.
3. **Teardown cannot be synchronous.** React refuses `root.unmount()` from inside
   a render, and `:disconnect` runs inside the outer tree's unmount. The first
   browser run emitted React's race-condition error three times. Deferring one
   microtask fixes it — but every other release the substrate performs is
   synchronous and assertable at the instant of unmount, and this one is not.
4. **`:config` is data**, so a component value cannot travel through a use site.
   Every foreign component needs its own `v/defbehavior` registration.

## Where the substrate was genuinely good

Worth saying as plainly as the gaps, because the pilot's job is both.

- **The behavior shape is excellent for what it is for.** A SpreadJS-class grid —
  opaque, mutable, listener-owning, `destroy()`-releasing — is exactly its
  description, and nothing about the integration felt like a workaround.
  Commit-only connection, `rf=` edge detection for free, a bounded command roster
  addressed by a semantic id the *caller* authored, an outward intent that is an
  ordinary event, and cleanup that is an exact zero against a control mount.
- **`:config` being data is right, not restrictive.** It reads as a limitation on
  day one and mostly is not: a chart's props *are* data, and one named place to
  map data to props is where you want it.
- **The imperative handle has a correct home.** `useImperativeHandle` is the part
  of the React ABI with no declarative analogue, and the bounded command channel
  turns out to be exactly the right place for it — the handle never leaves the
  behavior's private memory, so "no public value carries a live host object"
  survives a component whose whole API *is* a handle.
- **The compiled crossing works.** A compiled page mounts the interpreted
  integration as an ordinary declared child, the manifest marks the crossing
  `:interpreted`, and it is one React tree on a real page.

## An integration that needed no framework surface at all

A **TanStack-Table-class headless core** needed no host shape whatsoever. Its
React adapter exists to hold state and re-run a computation when state moves —
which is what re-frame already is. The integration is a `reg-sub` and ordinary
markup, and the correct amount of new substrate surface for it is zero. A
`v/use-headless-library` would have been strictly worse.

Reporting a non-gap is as much the pilot's job as reporting a gap.

## Host / mode matrix — only cells actually exercised

| Integration | Shape used | JVM structural | Interpreted browser | Compiled |
|---|---|---|---|---|
| SpreadJS-class grid (`acme.sheet`) | registered behavior | PASS — inert marker, config verbatim, ledger at 0 | PASS — connect / reconcile / command / exact-zero teardown | BLOCKED — refused at build; recovery (interpreted child) PASS |
| React-Vega-class chart (`@xyflow/react`) | nested root in an opaque behavior | n/a — React component | PASS — renders, 2 nodes, releases | BLOCKED — same refusal, same recovery |
| React ABI probe (`acme-widget`) | nested root in an opaque behavior | n/a | PASS — props / children / forwardRef / imperative handle / listener release | BLOCKED — same |
| TanStack-class headless table | **none needed** | PASS | PASS | PASS — promoted (cost: 3 extracted child views) |
| Radix-class compound component | — | **NOT ATTEMPTED** | **NOT ATTEMPTED** | **NOT ATTEMPTED** |
| AG-Grid-class cell via `v/->react` | — | **NOT ATTEMPTED** | **NOT ATTEMPTED** | **NOT ATTEMPTED** |

**Never claimed, and why.** Radix needs `asChild` — cloning a Freehand child and
injecting a ref into it — and a Freehand element is not a React element an
application can hold; it is also blocked by the missing leaf, so there is nothing
to attempt. The AG-Grid cell needs `v/->react`, which is not on the door, so there
is no call to make. **SSR is not claimed for any cell.** No compiled cell is
claimed for any behavior-bearing integration.

Every refusal above is **asserted**, not merely described, so each fails loudly the
day its slice lands.

## Reaching past the public door — stated, not smoothed

Two internal namespaces, both deliberate:

- **`cell/candidate` + `cell/with-capture`.** `t/render` is the blessed public
  structural verb and it opens no render candidate, so it cannot render any view
  that calls `v/sub`. A React integration reads state like any other view, so
  *every* structural assertion here goes through the internal composition. Third
  pilot to hit this; reproduced verbatim by
  `t-render-alone-still-cannot-render-a-state-reading-view`.
- **`behaviors/connection-count` / `target-ids`** for the exact retained counts
  acceptance requires, and **`fr/element`** for the browser-side head refusal.

`pilot/foreign-leaf` is a hand-written map carrying the reserved
`:re-frame.freehand/host` marker — the pilot reaching past the door on purpose, so
the refusal it meets is the substrate's own and not a spelling mistake.

## What an author would NEED that does not exist

Distinguishing need from want, since the posture rejects gold-plating:

- **NEEDED: the qualified host leaf.** Not a convenience. Without it there is no
  way to render a React component inside the Freehand tree at all, and the
  workaround forfeits context, events, Suspense, SSR and any interleaving of
  content. This is the single highest-value missing piece.
- **NEEDED: a compiled form for `v/behavior`** (or a documented statement that
  integration views are interpreted-forever). Today the one reachable shape is
  unavailable in the compiled tier, so precisely the views whose neighbours most
  want promotion can never have it.
- **NOT needed: a neutral hook / ref / effect / portal.** Nothing in this pilot
  wanted one. The nested-root workaround needs no new primitive — it is two
  functions an author writes once. EP-0036's non-goal held.
- **NOT needed: a generic React-host behavior.** The `:config`-is-data rule
  forbids it and that is the right call.
- **NOT needed: a `v/use-headless-library`.** See above.

## Findings filed

| Bead | |
|---|---|
| `rf2-drpa3.151` (P1) | Only one host shape is reachable; every React component needs a nested root |
| `rf2-drpa3.152` (P2) | A nested React root cannot be unmounted synchronously from `:disconnect` |
| `rf2-drpa3.153` (P2) | The compiled tier misnames `v/behavior` as a *foreign component boundary* |
| `rf2-drpa3.154` (P2) | A refused command reaches the error axis untyped, and on the JVM not at all |
| `rf2-drpa3.155` (P3) | Promotion is not the advertised one-line change |

Evidence added to existing `rf2-drpa3.121` (`t/render`) and `rf2-drpa3.127`
(compiled behaviors).

`rf2-drpa3.154` is the one that contradicts a written contract: Spec 004 §The
structural marker says a JVM command "is refused with the same channel
diagnostic"; because the fx is `{:platforms #{:client}}` it is silently skipped
instead, and the good diagnostic is unreachable through the documented data path.

## Acceptance

1. Each integration renders and functions in a real browser — one named mounted
   test each.
2. The SpreadJS-class pilot exercises commands with an explicit semantic-id
   target, proving delivery, a live decoy left untouched, commit and cleanup.
3. Exact retained counts after unmount — instances, listeners, connections,
   target claims, nested roots — each against a control mount.
4. No neutral hook, ref, portal or lifecycle callback added. Every integration
   states which shape it used and why.
5. Integrations that could not be done within the shapes are reported with the
   blocking mechanism named, not worked around.

## Files

All test-only, all new:

- `pilot_react_interop.cljc` — host-neutral: the widget stand-in, the behavior,
  the app, the headless core, the refusal probes
- `pilot_react_interop_react.cljs` — the React half: ABI-complete component,
  `@xyflow/react`, the nested-root plumbing
- `pilot_react_interop_compiled.cljc` — the compiled arm and the extraction the
  grammar's refusal named
- `pilot_react_interop_cljs_test.cljc` — headless: which shapes are reachable
- `pilot_react_interop_dom_cljs_test.cljs` — mounted: what the reachable one does
