### PR TITLE
fix(freehand): one verdict for controlled values and #id identity across every mode

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/compiler/emit_jvm.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/emit_jvm.cljc
@@ -53,6 +53,20 @@
 ;; Element parts
 ;; ---------------------------------------------------------------------------
 
+(defn- build-time-attr?
+  "Can this attribute be settled at BUILD time?
+
+  A literal value can — that is the emitter's real work, and the reason a
+  wholly-literal element's `:attrs` map is a constant. A literal `nil`
+  cannot, and deliberately so: whether a nil entry is DROPPED or kept as a
+  controlled input's empty value is one rule, and it belongs to the one
+  canonicaliser both structural modes reach ([[node/element]]) rather than
+  to an emitter that would have to re-state it. So a literal nil rides the
+  `:dyn` slot beside the values only the render knows, and the compiled
+  tree answers what the interpreted tree answers by construction."
+  [{:keys [literal? value]}]
+  (and literal? (some? value)))
+
 (defn- static-attr-entries
   "Compile-time semantic normalization of literal attr values — the
   emitter's real work, and the reason a wholly-literal element costs
@@ -64,8 +78,8 @@
   rather than surviving to the first render that reaches it."
   [e attrs]
   (into {}
-        (keep (fn [{:keys [k value literal?]}]
-                (when (and literal? (some? value))
+        (keep (fn [{:keys [k value] :as attr}]
+                (when (build-time-attr? attr)
                   (let [v (conv/attr-value value)]
                     (when (= ::conv/reject v)
                       (env/fail! e :rf.ui.compile/collection-attr-value
@@ -78,13 +92,15 @@
         attrs))
 
 (defn- dyn-attr-entries
-  "Per-prop attribute values only known at render, in author space. They
+  "Attribute values `node/element` settles at RENDER, in author space —
+  everything [[build-time-attr?]] leaves: the per-prop values only known
+  then, and the literal nils whose verdict is the canonicaliser's. They
   fold through `node/element`'s `:dyn` slot, which applies exactly the
   normalization `static-attr-entries` applied at build time."
   [attrs]
   (into {}
-        (keep (fn [{:keys [k value literal?]}]
-                (when-not literal? [k value])))
+        (keep (fn [{:keys [k value] :as attr}]
+                (when-not (build-time-attr? attr) [k value])))
         attrs))
 
 (defn- class-slots

--- a/implementation/freehand/src/re_frame/freehand/conversion.cljc
+++ b/implementation/freehand/src/re_frame/freehand/conversion.cljc
@@ -575,8 +575,11 @@
 
   The question both walks ask when — and only when — an element carries
   `#id` sugar, because two spellings of one id on one element is an
-  ambiguity the grammar removes rather than ranks (Spec 004B). It is asked
-  of the emitted SLOT, through
+  ambiguity the grammar removes rather than ranks (Spec 004B). It is a
+  question about the KEY alone, so it is asked of PRESENCE and never of
+  the value: the compiled analyzer scans `(keys m)` and has no value to
+  consult, and an authored id spelled `nil` is still the element's second
+  id spelling. It is asked of the emitted SLOT, through
   [[re-frame.freehand.rules/caller-key-slot]], for the reason
   [[attr-key-refusal]] asks about the same projection: a key is classified
   by the name it is about to be written under, so `:x/id`, `\"id\"` and

--- a/implementation/freehand/src/re_frame/freehand/node.cljc
+++ b/implementation/freehand/src/re_frame/freehand/node.cljc
@@ -29,6 +29,7 @@
   (the compiled tier that emits calls to these builders)."
   (:require [clojure.string :as str]
             [re-frame.error :as error]
+            [re-frame.freehand.controlled :as controlled]
             [re-frame.freehand.conversion :as conv]
             [re-frame.freehand.events :as events]
             [re-frame.freehand.rules :as rules]
@@ -340,9 +341,29 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- attr-entry
-  "One author-space `:attrs` entry, or nil when the entry is dropped."
+  "One author-space `:attrs` entry, or nil when the entry is dropped.
+
+  A nil value is an ABSENT attribute — the law an author relies on to
+  write a conditional value — with the ONE exception the controlled-input
+  contract already states. On a supported native control, absence of a
+  `value` / `checked` slot is the HOST's own signal that the node is
+  UNCONTROLLED, so an explicitly present nil there is not nothing: it is a
+  controlled field with nothing in it, and the door has already put the
+  element's event sites on the synchronous lane for it. Dropping the entry
+  would leave the structural tree saying the opposite of what the React
+  emitter says about the same declaration, and would put a server render
+  that omits the attribute against a client render that sets it — a
+  hydration seam, from one authored word.
+
+  So the entry is KEPT, carrying the same controlled-empty value the React
+  emitter writes ([[re-frame.freehand.controlled/empty-control-slot]]) —
+  one projection, so the two hosts describe one declaration the same way.
+  Read as an ENTRY and not as a value, because the empty `checked` IS
+  `false`: a truth test here would drop exactly the unchecked case."
   [tag k v]
-  (when (some? v)
+  (if (nil? v)
+    (when-some [empty-slot (controlled/empty-control-slot tag k)]
+      [k (val empty-slot)])
     (let [semantic (conv/attr-value v)]
       (when (= :re-frame.freehand.conversion/reject semantic)
         (malformed!

--- a/implementation/freehand/src/re_frame/freehand/react.cljs
+++ b/implementation/freehand/src/re_frame/freehand/react.cljs
@@ -197,8 +197,12 @@
       ;; raw key — and this walk is where the raw comparison SHOWED: React
       ;; writes `:id` and `:x/id` into one JavaScript property, so the
       ;; aliased pair silently replaced the sugar while the structural tree
-      ;; reported both. Asked only when there IS sugar to conflict with.
-      (when (and sugar-id (some? raw) (conv/id-slot-key? k))
+      ;; reported both. Asked only when there IS sugar to conflict with,
+      ;; and by PRESENCE: the authored key is the second spelling, and the
+      ;; compiled analyzer that reads `(keys m)` has no value to consult,
+      ;; so a truth test here would accept a declaration `{:compiled true}`
+      ;; refuses.
+      (when (and sugar-id (conv/id-slot-key? k))
         (malformed! (str "The element " tag " spells its id twice — once as #" sugar-id
                          " sugar and once as " k ". Two id spellings on one element is an "
                          "ambiguity; keep one."

--- a/implementation/freehand/src/re_frame/freehand/tree.cljc
+++ b/implementation/freehand/src/re_frame/freehand/tree.cljc
@@ -164,7 +164,15 @@
   attribute and the grammar removes that ambiguity rather than ranking it.
   Asked only when there IS sugar: with no sugar there is no second
   spelling, and `:x/id` is an ordinary qualified attribute that keeps its
-  authored name."
+  authored name.
+
+  PRESENCE decides it, never truth. The authored key IS the second
+  spelling — the generic nil-attribute law says what an id VALUE of nil
+  emits, and it cannot say whether the element was given an id twice. The
+  compiled analyzer reads `(keys m)` and has no value to consult, so a
+  truth test here would accept `[:div#sugar {:id nil}]` that
+  `{:compiled true}` refuses, and adding one word to a declaration would
+  turn a rendering element into a compile error."
   [m tag sugar-id attrs]
   (reduce-kv
     (fn [m k raw]
@@ -172,7 +180,7 @@
         (malformed!
           (str "The element " tag " carries " k ". " refusal)
           {:attr k}))
-      (when (and sugar-id (some? raw) (conv/id-slot-key? k))
+      (when (and sugar-id (conv/id-slot-key? k))
         (malformed!
           (str "The element " tag " spells its id twice — once as #" sugar-id
                " sugar and once as " k ". Two id spellings on one element is an "

--- a/implementation/freehand/test/re_frame/freehand/controlled_structural_value_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/controlled_structural_value_cljs_test.cljc
@@ -1,0 +1,160 @@
+(ns re-frame.freehand.controlled-structural-value-cljs-test
+  "An explicitly present `value` / `checked` holding `nil` is a CONTROLLED
+  slot with nothing in it, and the STRUCTURAL tree has to say so.
+
+  The generic nil-attribute law is right and stays: an author who writes
+  nothing means absent. The controlled slots are the exception the
+  controlled-input contract already states, because on a supported native
+  control absence is the HOST's own signal that the node is uncontrolled —
+  the opposite claim from the one the author made and the door already
+  acted on.
+
+  The React emitter was repaired first, and the structural walk went on
+  dropping the entry. That left the two hosts describing one declaration
+  two ways, and it put a server render that omits the attribute against a
+  client render that sets it — a hydration seam from one authored word.
+  The repair is at the ONE canonicaliser both structural modes reach, so
+  the interpreted walk and a compiled view's emitted body answer the same
+  tree by construction rather than by agreement.
+
+  Runs on BOTH hosts: the structural walk is one implementation and the
+  tree is one value, so a claim proved on the JVM alone would be a claim
+  about the JVM. The compiled rows are JVM-only for the ordinary reason —
+  the lowering is produced by a macro expansion and called.
+
+  The browser half of the claim is
+  `re-frame.freehand.controlled-nil-value-cljs-test` (the React props) and
+  `re-frame.freehand.controlled-input-dom-cljs-test` (a live node).
+
+  Normative owner:
+  [`spec/004B-UI-Tree-and-Conversion.md`](../../../../../spec/004B-UI-Tree-and-Conversion.md)
+  §Attr value normalization."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test :refer-macros [deftest is testing]])
+            [re-frame.freehand.tree :as tree]
+            #?(:clj [re-frame.freehand.compiler :as compiler])))
+
+(defn- interpreted-tree
+  "The structural tree the INTERPRETED walk answers, with the root's
+  version stripped so a row reads as the node it is about."
+  [body]
+  (dissoc (tree/render body) :rf.ui/tree-version))
+
+#?(:clj
+   (defn- compiled-tree
+     "The structural tree a COMPILED declaration answers — the emitted
+     lowering, evaluated and called, rather than a claim about the form it
+     emitted."
+     [body]
+     (let [lowering (compiler/compile-structural-view
+                      {:form            (list 'v/defview 'subject '[_] body)
+                       :menv            nil
+                       :ns-sym          're-frame.freehand.controlled-structural-value-cljs-test
+                       :vname           'subject
+                       :view-id         ::subject
+                       :params          '[_]
+                       :body            [body]
+                       :children-policy :optional})]
+       ((eval (:body lowering)) {}))))
+
+;; ---------------------------------------------------------------------------
+;; The controlled slots, on the supported native controls
+;; ---------------------------------------------------------------------------
+
+(def cleared-rows
+  "Every spelling of a controlled slot an explicit `nil` must leave PRESENT
+  and empty in the tree. The alternate spellings are here because the rule
+  is about the emitted SLOT: `:x/value` is written into the host's own
+  `value`, so it is the same prop and takes the same answer — while the
+  KEY stays in author space, as every other qualified attribute's does."
+  [{:note "the paved path"
+    :body '[:input {:value nil}]
+    :tree {:tag :input :attrs {:value ""}}}
+
+   {:note "an aliased :value is that prop, and keeps its authored name"
+    :body '[:input {:x/value nil}]
+    :tree {:tag :input :attrs {:x/value ""}}}
+
+   {:note "checked is the second slot, and its empty value is FALSE"
+    :body '[:input {:type "checkbox" :checked nil}]
+    :tree {:tag :input :attrs {:type "checkbox" :checked false}}}
+
+   {:note "and its aliased spelling"
+    :body '[:input {:type "checkbox" :x/checked nil}]
+    :tree {:tag :input :attrs {:type "checkbox" :x/checked false}}}
+
+   {:note "a textarea is a supported control"
+    :body '[:textarea {:value nil}]
+    :tree {:tag :textarea :attrs {:value ""}}}
+
+   {:note "and so is a select"
+    :body '[:select {:value nil}]
+    :tree {:tag :select :attrs {:value ""}}}
+
+   {:note "the whole declaration, handler and all — the shape the door acts on"
+    :body '[:input {:value nil :on-change [:field/edited]}]
+    :tree {:tag :input :attrs {:value ""} :events {:on-change [:field/edited]}}}])
+
+(deftest an-explicit-nil-control-value-is-present-and-empty-in-the-tree
+  (testing "Presence is the whole question. An author who wrote `:value
+            nil` declared a controlled field with nothing in it; a tree
+            reporting an element with no value attribute reports the
+            opposite, and hands a hydrating client a prop its server render
+            never wrote."
+    (doseq [{:keys [note body tree]} cleared-rows]
+      (is (= tree (interpreted-tree body)) (str note " — interpreted")))))
+
+#?(:clj
+   (deftest the-compiled-tree-answers-the-same-nodes
+     (testing "A literal nil cannot be settled at build time — whether it
+               is dropped or kept is the canonicaliser's rule — so it rides
+               the same slot the values only the render knows ride, and the
+               compiled tree is the interpreted tree by construction."
+       (doseq [{:keys [note body tree]} cleared-rows]
+         (is (= tree (compiled-tree body)) (str note " — compiled"))))))
+
+;; ---------------------------------------------------------------------------
+;; The generic law is untouched
+;; ---------------------------------------------------------------------------
+
+(def dropped-rows
+  "The declarations the exception must NOT have reached. A nil attribute is
+  an absent attribute, because absent is what an author means by writing
+  nothing — a conditional value is the ordinary way to write one."
+  [{:note "an ordinary nil attribute on a control is still omitted"
+    :body '[:input {:title nil :value "x"}]
+    :tree {:tag :input :attrs {:value "x"}}}
+
+   {:note ":default-value seeds an UNCONTROLLED input and is not a controlled slot"
+    :body '[:input {:default-value nil}]
+    :tree {:tag :input}}
+
+   {:note "a :div has no value the host restores, so nothing is excepted for it"
+    :body '[:div {:value nil}]
+    :tree {:tag :div}}
+
+   {:note "and a custom element's value is its own adapter's protocol"
+    :body '[:my-field {:value nil}]
+    :tree {:tag :my-field}}
+
+   {:note "an ABSENT key is still absent — the exception is about presence"
+    :body '[:input {:type "text"}]
+    :tree {:tag :input :attrs {:type "text"}}}
+
+   {:note "a non-nil control value takes the ordinary conversion, unchanged"
+    :body '[:input {:type "checkbox" :checked false}]
+    :tree {:tag :input :attrs {:type "checkbox" :checked false}}}])
+
+(deftest the-generic-nil-attribute-law-is-untouched
+  (testing "Only the controlled slots on a supported native control are
+            excepted, and the exception is scoped exactly as the door is."
+    (doseq [{:keys [note body tree]} dropped-rows]
+      (is (= tree (interpreted-tree body)) (str note " — interpreted")))))
+
+#?(:clj
+   (deftest the-generic-law-is-untouched-in-the-compiled-tree-too
+     (testing "The build-time fold and the render-time fold are one rule,
+               so an emitter that stopped dropping nils generally would
+               show here."
+       (doseq [{:keys [note body tree]} dropped-rows]
+         (is (= tree (compiled-tree body)) (str note " — compiled"))))))

--- a/implementation/freehand/test/re_frame/freehand/id_sugar_presence_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/id_sugar_presence_cljs_test.cljs
@@ -1,0 +1,75 @@
+(ns re-frame.freehand.id-sugar-presence-cljs-test
+  "The `#id` shorthand conflict is decided by PRESENCE of an authored key
+  that projects onto the emitted `id` slot — never by what that key holds.
+
+  The compiled analyzer scans a literal props map's KEYS, so it has no
+  value to consult and always refused `[:div#sugar {:id nil}]`. The
+  structural and React walks guarded on `(some? raw)` and accepted the
+  same declaration. That is the sharpest shape a mode split can take:
+  adding `{:compiled true}` to a working view turns a rendering element
+  into a compile error while nothing in the declaration changed.
+
+  The structural half of this claim — interpreted and compiled, on the
+  JVM — is `re-frame.freehand.structural-slot-alias-jvm-test`. This is the
+  React walk's half, which is a SEPARATE walk and therefore proves the
+  rule for itself.
+
+  Normative owner:
+  [`spec/004B-UI-Tree-and-Conversion.md`](../../../../../spec/004B-UI-Tree-and-Conversion.md)
+  §`.class#id` sugar vs explicit `:class`/`:id`."
+  (:require [cljs.test :refer [deftest is testing]]
+            [clojure.string :as str]
+            [goog.object :as gobj]
+            [re-frame.freehand.react :as fr]))
+
+(defn- refusal
+  "The `ExceptionInfo` the React walk raised for `form`, or nil when it
+  built an element."
+  [form]
+  (try (fr/element form) nil (catch :default e e)))
+
+(def ^:private nil-rows
+  "One id spelled twice, the second time with a nil value. The qualified
+  row is here because the guard reads the emitted SLOT: React writes `:id`
+  and `:x/id` into one JavaScript property."
+  [{:note "the exact spelling"      :form [:div#sugar {:id nil}]}
+   {:note "and its aliased twin"    :form [:div#sugar {:x/id nil}]}])
+
+(deftest a-nil-authored-id-beside-sugar-is-refused-by-the-react-walk
+  (testing "The authored key IS the second spelling. What it holds is the
+            ordinary attribute question — it decides what the id EMITS, and
+            it cannot decide whether the element was given an id twice."
+    (doseq [{:keys [note form]} nil-rows]
+      (let [ex (refusal form)]
+        (is (some? ex) (str note " — " (pr-str form) " is refused"))
+        (when ex
+          (is (= :rf.error/ui-tree-malformed (:rf.error/id (ex-data ex)))
+              (str note " — the walk's existing diagnostic, not a new one"))
+          (is (str/includes? (ex-message ex) "twice")
+              (str note " — the message says the id is spelled twice")))))))
+
+(deftest a-runtime-nil-id-is-refused-on-the-same-footing
+  (testing "The interpreted walk sees a VALUE, not a form, so a nil that
+            arrived from application state is the same declaration as a
+            literal nil and takes the same verdict. A rule that held only
+            for the literal would be a rule about source text."
+    (let [missing (:absent {})
+          ex      (refusal [:div#sugar {:id missing}])]
+      (is (some? ex) "a runtime nil id beside sugar is refused")
+      (when ex
+        (is (= :rf.error/ui-tree-malformed (:rf.error/id (ex-data ex))))))))
+
+(deftest the-refusal-is-scoped-to-the-shorthand-ambiguity
+  (testing "With no `#id` sugar there is no second spelling, so a nil id is
+            the ordinary nil attribute the generic law drops. A guard that
+            refused every nil id would be a worse defect than the bypass it
+            closed — a conditional id is an ordinary thing to write."
+    (doseq [form [[:div {:id nil}] [:div {:x/id nil}]]]
+      (let [el (fr/element form)]
+        (is (some? el) (str (pr-str form) " still renders"))
+        (is (not (gobj/containsKey (.-props el) "id"))
+            (str (pr-str form) " — and carries no id prop"))))
+    (is (= "sugar" (gobj/get (.-props (fr/element [:div#sugar])) "id"))
+        "the shorthand alone is untouched")
+    (is (= "plain" (gobj/get (.-props (fr/element [:div {:id "plain"}])) "id"))
+        "and so is an authored id with no shorthand to collide with")))

--- a/implementation/freehand/test/re_frame/freehand/structural_slot_alias_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/structural_slot_alias_jvm_test.clj
@@ -297,6 +297,47 @@
                  (:rf.ui.compile/error (ex-data (or (ex-cause ex) ex))))
               (str (pr-str body) " — reusing the existing compile diagnostic")))))))
 
+(def id-nil-rows
+  "The same ambiguity, spelled with a `nil` VALUE. The authored key is what
+  makes the id a second time; what the key holds is the ordinary attribute
+  question and cannot answer the identity one."
+  ['[:div#sugar {:id nil}]
+   '[:div#sugar {:x/id nil}]])
+
+(deftest a-nil-authored-id-beside-id-sugar-is-the-same-ambiguity-in-both-modes
+  (testing "PRESENCE decides the conflict, never truth. The compiled
+            analyzer scans the props map's KEYS and has no value to
+            consult, so it always refused these two; the structural and
+            React walks guarded on `(some? raw)` and accepted them. That
+            split is the sharpest shape the defect can take — adding
+            `{:compiled true}` to a working view turns a rendering element
+            into a compile error, and nothing in the declaration changed."
+    (doseq [body id-nil-rows]
+      (let [ex (try (interpreted-tree body) nil (catch clojure.lang.ExceptionInfo e e))]
+        (is (some? ex) (str (pr-str body) " is refused by the interpreted walk"))
+        (when ex
+          (is (= :rf.error/ui-tree-malformed (:rf.error/id (ex-data ex)))
+              (str (pr-str body) " — the walk's existing diagnostic id, not a new one"))
+          (is (str/includes? (ex-message ex) "twice")
+              (str (pr-str body) " — the message says the id is spelled twice"))))
+      (let [ex (try (compiled-tree body) nil (catch Exception e e))]
+        (is (some? ex) (str (pr-str body) " is refused at compile time"))
+        (when ex
+          (is (= :rf.ui.compile/id-sugar-conflict
+                 (:rf.ui.compile/error (ex-data (or (ex-cause ex) ex))))
+              (str (pr-str body) " — reusing the existing compile diagnostic")))))))
+
+(deftest a-nil-id-with-no-sugar-is-still-an-ordinary-dropped-attribute
+  (testing "The presence rule belongs to the SHORTHAND's ambiguity and
+            nowhere else. With no `#id` sugar there is no second spelling,
+            so a nil id is the ordinary nil attribute the generic law
+            drops — a guard that refused every nil id would be a worse
+            defect than the bypass it closed, because a conditional id is
+            an ordinary thing to write."
+    (doseq [body '[[:div {:id nil}] [:div {:x/id nil}]]]
+      (is (= {:tag :div} (interpreted-tree body)) (str (pr-str body) " — interpreted"))
+      (is (= {:tag :div} (compiled-tree body)) (str (pr-str body) " — compiled")))))
+
 (def id-control-rows
   "The control that makes the refusals above mean something. A guard that
   turned every id away — or every qualified attribute — would look

--- a/spec/004B-UI-Tree-and-Conversion.md
+++ b/spec/004B-UI-Tree-and-Conversion.md
@@ -161,8 +161,9 @@ read surface. Text is therefore not a *queryable node*: selectors never match it
   `:class`/`:id`. Values are normalized to **semantic form** (§Attr value normalization
   below). Final DOM *name* conversion (`tabindex`, `for`, `viewBox`, `className`) is the
   serialiser's/React emitter's half of the table and is **not** stored in the tree —
-  tests and selectors match what the author wrote. Nil-valued entries never appear;
-  the map is absent when empty.
+  tests and selectors match what the author wrote. Nil-valued entries never appear —
+  except the one controlled-slot row below, which records the *controlled empty* value
+  rather than the author's nil; the map is absent when empty.
 - **`:events`** — handler-position keys (`:on-*`, spelled as authored; **no
   `-capture` name suffixes** — capture is a listener *option* per the handler grammar)
   mapped to exactly one of:
@@ -227,7 +228,18 @@ read surface. Text is therefore not a *queryable node*: selectors never match it
 - booleans stay **booleans** in the tree — the boolean/booleanish/overloaded emission
   decision is the serialisation row's job, and tests get the semantic truth
   (`{:disabled false}` is present-false, distinguishable from absent).
-- `nil` → the entry is dropped (canonical trees carry no present-nil attrs).
+- `nil` → the entry is dropped (canonical trees carry no present-nil attrs) — absent is
+  what an author means by writing nothing. **One exception**: a `value` or `checked`
+  slot on a supported native control (`input`, `textarea`, `select`) is a **controlled**
+  slot, and there *absence is the host's own signal for uncontrolled*. An explicitly
+  present nil is a controlled field with nothing in it — the door has already put the
+  element's sites on the synchronous lane for it ([004 §Controlled
+  inputs](004-Views.md#controlled-inputs), fact 2) — so the entry is **kept**, carrying
+  the **controlled empty** value the host emitters write: `""` for `value`, `false` for
+  `checked`. One projection, so the structural tree and the React props describe one
+  declaration the same way, and a server render and its client hydration agree rather
+  than differing by exactly this attribute. Scoped as the door is, and read through the
+  same normalized slot, so `:x/value` clears the field precisely as `:value` does.
 - collection values outside `:class`/`:style` (e.g. `:data-foo {:a 1}`) → rejected,
   didactic (React would render `"[object Object]"` garbage) — at the declaration in
   compiled mode, at the walk in interpreted mode.

--- a/spec/004B-UI-Tree-and-Conversion.md
+++ b/spec/004B-UI-Tree-and-Conversion.md
@@ -517,7 +517,7 @@ unexercised — Stage 1 confirms.
 | Row | Rule |
 |---|---|
 | `.class` + `:class` | **merge**, sugar-first (above) |
-| `#id` + `:id` | **compile error**, didactic — two id spellings on one element is an ambiguity, and this grammar removes ambiguities rather than ranking them |
+| `#id` + `:id` | **compile error**, didactic — two id spellings on one element is an ambiguity, and this grammar removes ambiguities rather than ranking them. Judged on the **emitted `id` slot**, so every spelling that reaches it (`:x/id`, `"id"`, `'id`) is the same second spelling; and judged on **presence, not truth** — the authored key *is* the second spelling, so `{:id nil}` beside `#id` sugar is the same ambiguity. Truth cannot be the test: the compiled analyzer reads the props map's keys, so a value-sensitive guard would accept in one mode what the other refuses, and adding `{:compiled true}` to a view would turn a rendering element into a compile error |
 
 ### Children, text, and escaping
 


### PR DESCRIPTION
Three defects on one seam — a control VALUE or IDENTITY handled inconsistently between the compiled, structural and React walks. All three land here; the shared repair is that a control's identity and its emptiness are properties of the **element**, settled once and read by every emitter, rather than re-decided per attribute per walk.

### 1. The `#id` shorthand conflict is decided on presence, not truth

The compiled analyzer scans a literal props map's KEYS, so it has no value to consult and always refused `[:div#sugar {:id nil}]`. The structural and React walks guarded on `(some? raw)` and accepted the same declaration. Adding `{:compiled true}` to a working view therefore turned a rendering element into a compile error while nothing in the declaration changed.

The authored key IS the element's second id spelling. What that key HOLDS is the ordinary attribute question — it decides what the id emits, and it cannot decide whether the element was given an id twice. Both walks now ask presence, through the emitted-slot projection they already read.

Scoped to the shorthand's ambiguity and nowhere else: with no `#id` sugar there is no second spelling, so a nil id stays the ordinary nil attribute the generic law drops.

### 2. An explicit nil control value survives on the structural host

The React emitter was repaired first; the structural walk went on dropping the entry, so `(tree/render [:input {:value nil :on-change [:e]}])` carried no `:attrs` at all — the two hosts describing one declaration two ways, and a server render that omits the attribute against a client render that sets it.

The tree now records the same controlled-empty projection the React emitter writes (`""` / `false`), at `node/attr-entry` — the one canonicaliser both structural modes reach. Read as an ENTRY rather than a value, because the empty `checked` IS `false` and a truth test would drop exactly the unchecked case.

The compiled JVM emitter folded a literal nil away at build time and never reached that canonicaliser, so it could not have agreed whatever the canonicaliser said. A literal nil now rides the `:dyn` slot beside the values only the render knows: whether it is dropped or kept is one rule, and it belongs to the canonicaliser rather than to an emitter that would have to re-state it.

### 3. A controlled native `<select multiple>`

A native `<select multiple>` is the single element in the DOM whose value is not a scalar: what is selected is the LIST of chosen option values, and React reads the prop as an array and reports any other shape. Both useful states were unreachable — the authored vector was rejected before the boundary by the general attribute grammar, and an explicit nil normalized to the single-value empty string, which React calls a shape error on exactly the transition an author uses to clear a field.

One narrow host-element exception, and it splits in two on purpose:

- **Acceptance** is keyed on the TAG and the emitted SLOT alone. A native `<select>`'s `value` takes a SEQUENTIAL collection, whose members fold through the same closed scalar grammar every attribute value folds through. Tag and key are lexical in every declaration, while `multiple` may be a runtime value the compiler cannot see — keying acceptance on it would let a compiled declaration refuse at render what its interpreted twin renders. A **set** is refused with every other collection: it has no order, so the vector read out of one is not a value the two hosts agree on, and the tree is one value on two hosts.
- The **empty value** does consult `multiple`, because that is the only fact that decides what empty MEANS. It is settled once for the whole element, from either attribute source, exactly as the controlled-input door's element half is.

Author space and the structural tree carry ordinary Clojure data; turning it into the JavaScript array React requires is the React emitter's final step, beside every other final-shape conversion. No general collection attribute grammar, no form model, no wrapper component, no public verb, no new diagnostic.

The JVM serialiser matched a select's whole `:value` against each option, so a collection marked NOTHING selected — a server render that dropped the selection its hydrating client would immediately disagree with. It now marks every option the selection names.

### Two findings worth reading

**React 19.2 validates a `<select>`'s value shape at MOUNT, not on update.** The browser assertion was written first as a controlled→cleared transition and stayed green against a deliberately wrong empty value, because `validateSelectProps` does not fire on that path in this version. The test now mounts the EMPTY selection first, where React does validate — and with that ordering the gate reds with React's own `must be an array if multiple is true` diagnostic captured off the console. Every other assertion in the suite that watches `console.error` for a controlled-input complaint is worth reading with the same question in mind.

**One residue, fenced off.** A *literal* collection value is refused by the compiled analyzer (`analyze.cljc`) before either emitter sees it, so `[:select {:multiple true :value ["a" "b"]}]` still fails to compile in a `{:compiled true}` view while its interpreted twin renders. `analyze.cljc` is owned by another change in flight, so it is untouched here and the residue is called out rather than papered over. The compiled tier is fully proved for every shape it *can* reach — a computed selection, and a computed `multiple` deciding what empty means.

### Proof

Interpreted and compiled structural rows run on both hosts; the React walk proves the rules for itself, because it is a separate walk; the DOM claims are read back off real `selectedOptions` in a real browser, with React's console watched as closely as the DOM. Every new suite was shown to RED against the previous behaviour before the fix was restored — six probes, each restored byte-identical.