### PR TITLE
fix(freehand): compiled parity for the key-condition event map

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/compiler/analyze.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/analyze.cljc
@@ -17,6 +17,7 @@
             [re-frame.freehand.compiler.build :as build]
             [re-frame.freehand.compiler.env :as env]
             [re-frame.freehand.controlled :as controlled]
+            [re-frame.freehand.events :as events]
             [re-frame.freehand.fingerprint :as fingerprint]
             [re-frame.freehand.props-schema :as props-schema]
             [re-frame.freehand.rules :as rules]
@@ -1443,9 +1444,137 @@
           (rest form))
     (meta form)))
 
+(defn- analyze-ui-event-fn
+  "The `(v/event [e] body…)` seq form, lowered to the `(fn [e] body…)` the
+  runtime callback carries. One reader for the two positions a `v/event` is
+  legal in — the whole handler, and one branch of a key-condition map — so the
+  arity refusal, the walk and the loop-capture check cannot differ between
+  them."
+  [e k form]
+  (let [[_ bindings & body] form]
+    (when-not (and (vector? bindings) (= 1 (count bindings)))
+      (env/fail! e :rf.ui.compile/bad-ui-event
+                 (str "(v/event [e] body…) at " k " binds exactly the "
+                      "native event and returns an event vector (or nil to "
+                      "dispatch nothing); got " (pr-str bindings)
+                      ". For imperative work with no dispatch, S3 adds "
+                      "v/handler")
+                 {:prop k :form form}))
+    ;; A v/event handler is a SITE, like a literal vector: capturing a loop
+    ;; binding needs per-row committed slots (its own bindings shadow, so they
+    ;; are excluded from the capture check). Its body is a deferred callback,
+    ;; so render-time sub/frame inside it are rejected by the fn walk.
+    (let [binders (set (env/binding-syms bindings))
+          form*   (walk-expr e [:handler k :ui-event]
+                             (with-meta (apply list 'fn bindings body)
+                               (meta form)))]
+      (check-loop-capture! (update e :loop-syms #(reduce disj % binders))
+                           (str "v/event handler at " k) form)
+      form*)))
+
+;; ---------------------------------------------------------------------------
+;; The compiled key-condition event map
+;; ---------------------------------------------------------------------------
+;;
+;; Spec 004 §Key-condition event maps, ruled by D007. The compiled tier reads
+;; the SAME closed form the runtime normalizer reads — string keys, one level,
+;; legal only on a key listener, each branch an existing dispatching value —
+;; because a declaration that means one thing interpreted and another with
+;; `{:compiled true}` is exactly the promotion break the compiled tier exists to
+;; make impossible. The two rosters this rests on are ASKED rather than
+;; restated: `events/key-slots` names the legal slots and `events/branch-options`
+;; the legal branch keys, so there is one grammar with two front ends.
+
+(defn- key-condition-map?
+  "Is this literal map at an event position the exact-key CONDITION form rather
+  than the listener OPTIONS map? Decided by the presence of a string key, the
+  way `events/map-plan` decides it at render."
+  [form]
+  (boolean (some string? (keys form))))
+
+(defn- analyze-key-branch
+  "One branch of a compiled key-condition map, lowered to the value the
+  emitters write into the map.
+
+  A branch names exactly ONE intent, so the roster is the dispatching one: an
+  event vector, an options map carrying `:event` and at most the two
+  pre-dispatch mechanics, a `v/event`, or `nil`. A literal branch lowers to
+  data; a `v/event` branch lowers to the roster callback its interpreted
+  spelling expands to, so the runtime classifies one branch grammar whichever
+  front end wrote it."
+  [e k key-str form]
+  (cond
+    (nil? form) nil
+
+    (vector? form) (analyze-event-vector! e k form)
+
+    (and (map? form) (or (empty? form) (key-condition-map? form)))
+    (env/fail! e :rf.ui.compile/bad-handler-options
+               (str "the " (pr-str key-str) " branch at " k " is "
+                    (if (empty? form) "an empty map" "another key-condition map")
+                    " — the exact-key form is ONE level deep and every branch names "
+                    "one intent. Nesting selects nothing: a keystroke carries a single "
+                    "key. Write {\"Enter\" [:accept] \"Escape\" [:close]}, and let "
+                    "(v/event [e] …) answer anything richer")
+               {:prop k :key key-str :form form})
+
+    (map? form)
+    (let [unknown (remove events/branch-options (keys form))]
+      (when (seq unknown)
+        (env/fail! e :rf.ui.compile/bad-handler-options
+                   (str "the " (pr-str key-str) " branch at " k " carries "
+                        (str/join ", " (map pr-str (sort unknown)))
+                        " — a branch is SELECTED after the keystroke arrives, so "
+                        (pr-str (vec (sort events/branch-options)))
+                        " is all it can still honour. :capture and :passive are decided "
+                        "when the listener is attached to the node and :once retires the "
+                        "whole site, every one of them before a key has been read. Drop "
+                        "the option rather than have it silently do nothing")
+                   {:prop k :key key-str :form form}))
+      (when-not (vector? (:event form))
+        (env/fail! e :rf.ui.compile/bad-handler-options
+                   (str "the " (pr-str key-str) " branch at " k " is an options map and "
+                        "needs a literal :event vector — {\"Enter\" {:event "
+                        "[:domain/event args...] :prevent-default true}}")
+                   {:prop k :key key-str :form form}))
+      (assoc form :event (analyze-event-vector! e k (:event form))))
+
+    (ui-event-form? e form)
+    ;; The interpreted `v/event` macro expands to this exact constructor, so the
+    ;; branch the runtime classifies is the same roster value in both modes.
+    (list 're-frame.freehand.events/callback :event (analyze-ui-event-fn e k form) 1)
+
+    :else
+    (env/fail! e :rf.ui.compile/bad-handler-options
+               (str "the " (pr-str key-str) " branch at " k " is not an intent — a key "
+                    "branch is an event vector, an options map carrying :event, a "
+                    "(v/event [e] …), or nil (dispatch nothing). A callback that is not "
+                    "itself an intent, and anything the compiler cannot see, are outside "
+                    "the one-level exact-key form")
+               {:prop k :key key-str :form form})))
+
+(defn- analyze-key-map
+  "The whole compiled key-condition map: its slot legality, then every branch.
+
+  Legality is the runtime rule — a map that selects by `KeyboardEvent.key` is
+  legal only where a key IS carried — raised HERE, at build, rather than at the
+  first keystroke of a site that could never have fired."
+  [e k form]
+  (when-not (contains? events/key-slots (rules/caller-key-slot k))
+    (env/fail! e :rf.ui.compile/bad-handler-options
+               (str "a key-condition map at " k " — the exact-key form selects an intent "
+                    "by KeyboardEvent.key, so it is legal only on :on-key-down and "
+                    ":on-key-up. Put an ordinary click or input intent in an event vector "
+                    "or an options map")
+               {:prop k :form form}))
+  (reduce-kv (fn [m key-str branch]
+               (assoc m key-str (analyze-key-branch e k key-str branch)))
+             {}
+             form))
+
 (defn analyze-handler
   "Classify one :on-* entry. -> {:k kw :name str :classification
-  :vector|:options|:fn|:dynamic :form form :capture? bool
+  :vector|:options|:key-map|:fn|:dynamic :form form :capture? bool
   :hoistable? bool :serializable? bool}"
   [e k form]
   (when (:in-render-fn? e)

--- a/implementation/freehand/src/re_frame/freehand/compiler/analyze.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/analyze.cljc
@@ -1553,6 +1553,15 @@
                     "the one-level exact-key form")
                {:prop k :key key-str :form form})))
 
+(defn- key-branch-data?
+  "Is this LOWERED branch still DATA — an event vector, an options map, or
+  `nil` — rather than the `v/event` constructor call only evaluation turns into
+  a callback? The site's `:serializable?` fact is the conjunction over the
+  branches, so one `v/event` branch makes the whole site opaque to the manifest
+  exactly as a whole-handler `v/event` does."
+  [branch]
+  (not (seq? branch)))
+
 (defn- analyze-key-map
   "The whole compiled key-condition map: its slot legality, then every branch.
 
@@ -1601,68 +1610,96 @@
                 :serializable? true}))
 
       (map? form)
-      (let [unknown (remove rules/handler-option-keys (keys form))]
-        (when (seq unknown)
-          (env/fail! e :rf.ui.compile/bad-handler-options
-                     (str "unknown handler option" (when (next unknown) "s") " "
-                          (str/join ", " (map pr-str unknown)) " at " k
-                          " — the closed listener vocabulary is "
-                          "{:event :prevent-default :stop-propagation :capture "
-                          ":passive :once}")
-                     {:prop k :form form}))
-        (when (and (:passive form) (:prevent-default form))
-          (env/fail! e :rf.ui.compile/contradictory-handler-options
-                     (str ":passive true with :prevent-default true at " k
-                          " — a passive listener promises the browser it will "
-                          "NEVER call preventDefault, so the combination is a "
-                          "contradiction (in any stage). Drop one of them")
-                     {:prop k :form form}))
-        (when-not (vector? (:event form))
-          (env/fail! e :rf.ui.compile/bad-handler-options
-                     (str "handler options map at " k " needs a literal "
-                          ":event vector — {:event [:domain/event args...] "
-                          ":prevent-default true ...}")
-                     {:prop k :form form}))
-        (let [event* (analyze-event-vector! e k (:event form))
-              form*  (assoc form :event event*)]
+      ;; A MAP is the one shape two closed forms share, and it is split HERE
+      ;; exactly as `events/map-plan` splits it at render: options first, then
+      ;; the string-keyed exact-key form, with the empty map and the mixed map
+      ;; named as the authoring errors they are. Same order, same three
+      ;; outcomes, so `{:compiled true}` cannot change which form a map IS.
+      (cond
+        (empty? form)
+        (env/fail! e :rf.ui.compile/bad-handler-options
+                   (str "an empty map at " k " is neither an options map — which "
+                        "states its intent under :event — nor a key-condition map, "
+                        "which names at least one exact KeyboardEvent.key branch. "
+                        "Write {:event [:domain/event args...]} or "
+                        "{\"Enter\" [:accept] \"Escape\" [:close]}")
+                   {:prop k :form form})
+
+        (not (key-condition-map? form))
+        (let [unknown (remove rules/handler-option-keys (keys form))]
+          (when (seq unknown)
+            (env/fail! e :rf.ui.compile/bad-handler-options
+                       (str "unknown handler option" (when (next unknown) "s") " "
+                            (str/join ", " (map pr-str unknown)) " at " k
+                            " — the closed listener vocabulary is "
+                            "{:event :prevent-default :stop-propagation :capture "
+                            ":passive :once}")
+                       {:prop k :form form}))
+          (when (and (:passive form) (:prevent-default form))
+            (env/fail! e :rf.ui.compile/contradictory-handler-options
+                       (str ":passive true with :prevent-default true at " k
+                            " — a passive listener promises the browser it will "
+                            "NEVER call preventDefault, so the combination is a "
+                            "contradiction (in any stage). Drop one of them")
+                       {:prop k :form form}))
+          (when-not (vector? (:event form))
+            (env/fail! e :rf.ui.compile/bad-handler-options
+                       (str "handler options map at " k " needs a literal "
+                            ":event vector — {:event [:domain/event args...] "
+                            ":prevent-default true ...}")
+                       {:prop k :form form}))
+          (let [event* (analyze-event-vector! e k (:event form))
+                form*  (assoc form :event event*)]
+            (add-event-site! e identity
+                             {:prop k :handler form*
+                              :classification :options :serializable? true})
+            (merge identity
+                   {:k k :name nm :classification :options :form form*
+                    :capture? (boolean (:capture form))
+                    :passive? (boolean (:passive form))
+                    :hoistable? (every? #(or (literal-scalar? %)
+                                             (contains? rules/placeholders %))
+                                        event*)
+                    :serializable? true})))
+
+        (every? string? (keys form))
+        (let [form* (analyze-key-map e k form)
+              data? (every? key-branch-data? (vals form*))]
+          ;; A key-condition map carries no whole-listener option — the roster
+          ;; that would name one is refused per branch — so the attachment lane
+          ;; is the ordinary one and there is nothing for the door to weigh. It
+          ;; is never hoisted: one committed site owns the whole selection, and
+          ;; a hoisted constant would be a second one.
           (add-event-site! e identity
-                           {:prop k :handler form*
-                            :classification :options :serializable? true})
+                           {:prop k :handler (if data? form* :opaque)
+                            :classification :key-map :serializable? data?})
           (merge identity
-                 {:k k :name nm :classification :options :form form*
-                  :capture? (boolean (:capture form))
-                  :passive? (boolean (:passive form))
-                  :hoistable? (every? #(or (literal-scalar? %)
-                                           (contains? rules/placeholders %))
-                                      event*)
-                  :serializable? true})))
+                 {:k k :name nm :classification :key-map :form form*
+                  :capture? false :passive? false :hoistable? false
+                  :serializable? data?}))
+
+        :else
+        (env/fail! e :rf.ui.compile/bad-handler-options
+                   (str "the map at " k " carries exact-key branch"
+                        (when (next (filter string? (keys form))) "es") " "
+                        (str/join ", " (map pr-str (sort (filter string? (keys form)))))
+                        " beside the listener option"
+                        (when (next (remove string? (keys form))) "s") " "
+                        (str/join ", " (map pr-str (sort (remove string? (keys form)))))
+                        " — the exact-key form and the options map are SEPARATE "
+                        "closed forms. State per-key intents as {\"Enter\" [:accept] …} "
+                        "and whole-listener options in an options map, never both in "
+                        "one map")
+                   {:prop k :form form}))
 
       (ui-event-form? e form)
-      (let [[_ bindings & body] form]
-        (when-not (and (vector? bindings) (= 1 (count bindings)))
-          (env/fail! e :rf.ui.compile/bad-ui-event
-                     (str "(v/event [e] body…) at " k " binds exactly the "
-                          "native event and returns an event vector (or nil to "
-                          "dispatch nothing); got " (pr-str bindings)
-                          ". For imperative work with no dispatch, S3 adds "
-                          "v/handler")
-                     {:prop k :form form}))
-        ;; A v/event handler is a SITE, like a literal vector: capturing a loop
-        ;; binding needs per-row committed slots (its own bindings shadow, so they
-        ;; are excluded from the capture check). Its body is a deferred callback,
-        ;; so render-time sub/frame inside it are rejected by the fn walk.
-        (let [binders (set (env/binding-syms bindings))
-              form*   (walk-expr e [:handler k :ui-event]
-                                 (with-meta (apply list 'fn bindings body)
-                                   (meta form)))]
-          (check-loop-capture! (update e :loop-syms #(reduce disj % binders))
-                               (str "v/event handler at " k) form)
-          (add-event-site! e identity
-                           {:prop k :handler :opaque
-                            :classification :ui-event :serializable? false})
-          (merge identity
-                 {:k k :name nm :classification :ui-event :form form*
-                  :capture? false :hoistable? false :serializable? false})))
+      (let [form* (analyze-ui-event-fn e k form)]
+        (add-event-site! e identity
+                         {:prop k :handler :opaque
+                          :classification :ui-event :serializable? false})
+        (merge identity
+               {:k k :name nm :classification :ui-event :form form*
+                :capture? false :hoistable? false :serializable? false}))
 
       (ui-handler-form? e form)
       ;; The explicit imperative committed callback (`v/handler`) at a DOM

--- a/implementation/freehand/src/re_frame/freehand/controlled.cljc
+++ b/implementation/freehand/src/re_frame/freehand/controlled.cljc
@@ -120,7 +120,10 @@
   cannot dispatch, but because what they dispatch (and whether they
   dispatch at all, or later, from a promise) is unknowable at the moment
   the door would have to open. `:render-fn` and `:raw-fn` never reach an
-  event position's dispatch path at all."
+  event position's dispatch path at all. `:key-map` is absent for a
+  different reason again: it is legal only on a key listener, and no key
+  listener is a [[door-slots]] slot, so admitting it here would decide
+  nothing."
   #{:event-vector :event-options :event})
 
 ;; ---------------------------------------------------------------------------
@@ -210,6 +213,7 @@
 (def ^:private compiled-roles
   {:vector   :event-vector
    :options  :event-options
+   :key-map  :key-map
    :ui-event :event
    :handler  :handler
    :fn       :bare-fn})

--- a/implementation/freehand/src/re_frame/freehand/events.cljc
+++ b/implementation/freehand/src/re_frame/freehand/events.cljc
@@ -485,7 +485,10 @@
 ;; SEPARATE closed form from the options map, legal only on `:on-key-down` /
 ;; `:on-key-up`. Its keys are exact `KeyboardEvent.key` strings and each value
 ;; is an existing DISPATCHING event form — a vector, an options map carrying
-;; `:event`, `v/event`, or `nil`. Selection is one level and by exact equality:
+;; `:event` and at most the two PRE-DISPATCH mechanics, `v/event`, or `nil`.
+;; The three whole-listener facts (`:once`, `:capture`, `:passive`) are refused
+;; inside a branch, because a branch is chosen after the keystroke and all three
+;; are settled before it. Selection is one level and by exact equality:
 ;; a missing key is a no-op, an in-flight IME composition or a chord modifier
 ;; matches nothing, and each selected branch runs its OWN pre-dispatch mechanics
 ;; before its intent dispatches. Everything richer — modifier chords, ordering,
@@ -501,17 +504,67 @@
   emitter writes for `:on-key-down` and `:on-key-up`."
   #{"onKeyDown" "onKeyUp"})
 
+(def branch-options
+  "The CLOSED option roster a SELECTED key branch may carry — its `:event`
+  vector plus the two PRE-DISPATCH browser mechanics.
+
+  It is [[event-options]] minus the three WHOLE-LISTENER facts, and the
+  subtraction states WHEN each option is read rather than a taste in
+  vocabulary. `:capture` and `:passive` are native attachment facts, settled
+  when the listener goes on the node; `:once` retires the SITE, which is a
+  property of the site and not of one key. All three are decided before any
+  keystroke has been looked at, so a branch — chosen only once the key has
+  arrived — cannot honour one. Accepting them here and then dropping them is
+  the exact failure the closed listener roster exists to refuse, so the branch
+  roster refuses them too.
+
+  ONE roster, asked by both front ends: the compiled analyzer validates a
+  literal branch against this set rather than restating it, so the interpreted
+  and compiled tiers cannot accept different branch grammars."
+  #{:event :prevent-default :stop-propagation})
+
 (defn- branch-plan
   "Classify one key branch's value into its dispatching site plan, or `nil`. A
   branch names exactly ONE intent, so only the dispatching roster — an event
   vector, an options map carrying `:event`, or `v/event` — and `nil` are legal;
   a `v/handler`, a bare function, a render/raw callback, and a NESTED key map
-  are refused, which is precisely what keeps the form one level deep."
+  are refused, which is precisely what keeps the form one level deep.
+
+  An options-map branch is additionally held to [[branch-options]]: the three
+  whole-listener facts are refused HERE rather than normalized into a plan that
+  nothing downstream can read, because a branch that accepts `:once` and fires
+  every time is worse than one that says it cannot."
   [k v]
   (let [plan (event-plan v)]
-    (if (or (nil? plan)
-            (contains? #{:event-vector :event-options :event} (:role plan)))
+    (cond
+      (or (nil? plan)
+          (contains? #{:event-vector :event} (:role plan)))
       plan
+
+      (= :event-options (:role plan))
+      (let [whole-listener (remove branch-options (keys v))]
+        (when (seq whole-listener)
+          (bad-event!
+            'v/event-site
+            (str "The key-condition branch " (pr-str k) " carries the whole-listener "
+                 "option" (when (next whole-listener) "s") " "
+                 (pr-str (vec (sort whole-listener)))
+                 ". A branch is selected AFTER the keystroke arrives, and "
+                 (pr-str (vec (sort branch-options))) " is all that can still be honoured "
+                 "then: :capture and :passive are decided when the listener is attached to "
+                 "the node, and :once retires the whole SITE — every one of them is settled "
+                 "before a key has been read. Freehand refuses them here rather than "
+                 "accepting them and doing nothing. Drop the option: one-shot acceptance is "
+                 "state the receiving re-frame handler owns better than a listener does, and "
+                 "an attachment lane belongs to the whole listener — write that listener as "
+                 "one options map, or as a (v/event [e] …) that reads the key itself.")
+            :keep-whole-listener-options-off-key-branches
+            {:key k
+             :whole-listener-keys (vec (sort whole-listener))
+             :legal-keys          (vec (sort branch-options))}))
+        plan)
+
+      :else
       (bad-event!
         'v/event-site
         (str "The key-condition branch " (pr-str k) " is a " (name (:role plan))

--- a/implementation/freehand/test/re_frame/freehand/events_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/events_cljs_test.cljc
@@ -565,6 +565,55 @@
         (is (= error-id (conf/caught-id #(events/event-plan (get forms form))))
             (str "rejects " form))))))
 
+(deftest fh-event-005-a-branch-may-not-carry-a-whole-listener-option
+  (testing "Per FH-EVENT-005: a key branch carries its intent plus the two
+            PRE-DISPATCH mechanics, and nothing else. `:once`, `:capture` and
+            `:passive` are whole-listener facts — the first retires the site,
+            the other two decide native attachment — and all three are settled
+            before a keystroke is read, so a branch naming one is a typed
+            reject rather than a branch that accepts the option and then
+            discards it."
+    (is (seq (:branch-options event-005)) "the fixture's branch-option table loaded")
+    (doseq [{:keys [option accepted error-id]} (:branch-options event-005)]
+      (let [value {"Enter" {:event [:picker/accept] option true}}
+            run   #(events/event-plan value)]
+        (if accepted
+          (is (= {:role :event-options :event [:picker/accept] option true}
+                 (get (:branches (run)) "Enter"))
+              (str option " is a pre-dispatch mechanic a branch may carry"))
+          (is (= error-id (conf/caught-id run))
+              (str option " is a whole-listener fact a branch may not carry")))))))
+
+(defn- keystroke
+  "One keystroke argument for `k`, in the shape THIS host's `key-facts` seam
+  reads — a real event object in the browser, the structural payload map on the
+  JVM. The seam is named rather than hidden, exactly as `default-payload` is,
+  so one body of test code proves the law on both hosts."
+  [k]
+  #?(:cljs #js {:key k}
+     :clj  {:re-frame.freehand/key k}))
+
+(deftest fh-event-005-a-key-map-site-fires-once-per-keystroke
+  (testing "Per FH-EVENT-005: the counterexample the branch roster exists to
+            make unwritable. A committed key-map site invoked twice with the
+            same key dispatches its intent BOTH times — one firing per
+            keystroke — so a branch that could carry `:once` would be reading
+            back a promise the site never keeps."
+    (let [{:keys [branch key invocations dispatched]} (:repeated-key event-005)
+          {:keys [dispatch seen]} (recorder)
+          owner (events/owner :app/picker)
+          cand  (events/candidate owner)
+          proxy (events/site cand :on-key-down {key branch} events/default-payload
+                             {:tag :div :slot "onKeyDown"})]
+      (events/commit! cand dispatch)
+      (dotimes [_ invocations]
+        (proxy (keystroke key)))
+      (is (= dispatched @seen)
+          "every keystroke fires — the site retires nothing per branch")
+      (is (= :rf.error/view-bad-event
+             (conf/caught-id #(events/event-plan {key (assoc branch :once true)})))
+          "and asking for :once on that branch is refused rather than ignored"))))
+
 (deftest fh-event-005-a-key-map-is-legal-only-on-a-key-listener
   (testing "Per FH-EVENT-005: a key-condition map selects an intent by
             KeyboardEvent.key, so it is legal only on `:on-key-down` /

--- a/implementation/freehand/test/re_frame/freehand/key_condition_compiled_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/key_condition_compiled_cljs_test.cljc
@@ -1,0 +1,112 @@
+(ns re-frame.freehand.key-condition-compiled-cljs-test
+  "FH-EVENT-005 through the COMPILED front end.
+
+  The interpreted suite (`events-cljs-test`) proves the key-condition form
+  against `events/event-plan` and a committed proxy. This one proves the
+  other front end reads the same closed form — string keys, one level, legal
+  only on a key listener, every branch an existing dispatching value — at
+  BUILD time, and lowers a data branch to the very value the normalizer
+  classifies. A declaration that meant one thing interpreted and another
+  under `{:compiled true}` is the promotion break the compiled tier exists to
+  make impossible, so both front ends are held to one fixture.
+
+  Runs on both hosts: the analyzer is pure and its resolution is injected, so
+  the suite is identical under `clojure -M:test` and `npm run test:freehand`."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.freehand.analyze-accept-cljs-test :refer [mk-env]]
+            [re-frame.freehand.compiler.analyze :as ana]
+            [re-frame.freehand.conformance :as conf]
+            [re-frame.freehand.controlled :as controlled]
+            [re-frame.freehand.events :as events]))
+
+(def event-005 (conf/fixture :FH-EVENT-005))
+
+(defn- analyzed
+  "Analyze `template` and answer its ONE event site from both directions —
+  `:handler` as the AST carries it (what the emitters lower) and `:site` as
+  the manifest records it (what a tool reads)."
+  [template]
+  (let [e   (mk-env)
+        ast (ana/analyze e template)]
+    {:handler (first (get-in ast [:props :events]))
+     :site    (first (:events @(:sites e)))}))
+
+(def ^:private accepted
+  "What [[compile-error-id]] answers for a template the analyzer accepted."
+  ::accepted)
+
+(defn- compile-error-id
+  "The `:rf.ui.compile/error` id `template` is refused with, or [[accepted]].
+  The compiled tier's diagnostics carry their own id key, so this is the
+  build-time counterpart of `conf/caught-id`."
+  [template]
+  (try
+    (ana/analyze (mk-env) template)
+    accepted
+    (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) ex
+      (:rf.ui.compile/error (ex-data ex)))))
+
+(deftest fh-event-005-a-compiled-key-map-lowers-to-the-interpreted-plan
+  (testing "Per FH-EVENT-005 (compiled front end): a literal exact-key map at
+            an `:on-key-down` / `:on-key-up` position classifies as the
+            key-condition form rather than the listener-options form, and a
+            branch that is DATA lowers to itself — so handing the compiled
+            lowering to the runtime normalizer yields the very plan the
+            interpreted front end classifies from the authored value. That
+            equality is the whole claim: one event shape across both modes."
+    (is (seq (:compiled-accepted event-005))
+        "the fixture's compiled-accept table loaded")
+    (doseq [{:keys [note prop template callback-branches] ser :serializable?}
+            (:compiled-accepted event-005)]
+      (let [authored (get-in template [1 prop])
+            {:keys [handler site]} (analyzed template)]
+        (is (= :key-map (:classification handler))
+            (str note " — the exact-key form, not listener options"))
+        (is (false? (:sync? handler))
+            (str note " — a key listener is not a controlled-input door slot"))
+        (is (= ser (:serializable? handler)) (str note " — serializable?"))
+        (if (seq callback-branches)
+          (do
+            (is (= :opaque (:handler site))
+                (str note " — a callback-bearing site is opaque to the manifest"))
+            (doseq [key-str callback-branches]
+              (let [branch (get (:form handler) key-str)]
+                (is (= 're-frame.freehand.events/callback (first branch))
+                    (str note " — the " (pr-str key-str) " branch lowers to the "
+                         "roster callback the interpreted v/event macro expands to"))
+                (is (= :event (second branch))
+                    (str note " — in the dispatching role")))))
+          (do
+            (is (= authored (:form handler))
+                (str note " — a data branch lowers to itself"))
+            (is (= authored (:handler site))
+                (str note " — and the manifest records that data verbatim"))
+            (is (= (events/event-plan authored)
+                   (events/event-plan (:form handler)))
+                (str note " — the compiled lowering IS the interpreted site plan"))))))))
+
+(deftest fh-event-005-the-compiled-tier-refuses-the-same-forms
+  (testing "Per FH-EVENT-005 (compiled front end): every boundary the
+            one-level exact-key form must not blur is refused at BUILD time,
+            before a keystroke exists — an empty map, a map mixing exact keys
+            with listener options, a nested key map, a branch that is not
+            itself one intent, a branch naming a whole-listener option, and a
+            key map on a listener that carries no key. Each is a typed
+            authoring error about the map's SHAPE, never a report of an
+            unknown listener option, which is what a map read as the wrong
+            closed form produces."
+    (is (seq (:compiled-rejected event-005))
+        "the fixture's compiled-reject table loaded")
+    (doseq [{:keys [note template error-id]} (:compiled-rejected event-005)]
+      (is (= error-id (compile-error-id template)) note))))
+
+(deftest fh-event-005-the-door-is-asked-in-the-rosters-vocabulary
+  (testing "Per FH-EVENT-005: the compiled classification names the key-map
+            form in the ROSTER's vocabulary, so the controlled-input door
+            weighs the value a key site actually carries rather than falling
+            through the bridge's total `:dynamic` answer. It settles the same
+            way either route, and that is the point — the parity is a
+            structural fact, not a coincidence of two lists."
+    (is (= :key-map (controlled/compiled-role :key-map)))
+    (is (not (contains? controlled/synchronous-outcomes :key-map))
+        "the door never opens on a key listener, so the roster admits nothing")))

--- a/spec/conformance/freehand/fixtures/fh-event-005.edn
+++ b/spec/conformance/freehand/fixtures/fh-event-005.edn
@@ -3,16 +3,18 @@
 ;; A SEPARATE closed form from the options map, legal only on
 ;; `:on-key-down` / `:on-key-up`. Its keys are exact `KeyboardEvent.key`
 ;; strings and each value is an existing DISPATCHING event form — a
-;; vector, an options map carrying `:event`, `v/event`, or `nil`.
+;; vector, an options map carrying `:event` and at most the two
+;; pre-dispatch mechanics, `v/event`, or `nil`.
 ;; Selection is one level and by exact equality: a missing key is a
 ;; no-op, a chord modifier (Ctrl/Alt/Meta) or an in-flight IME
 ;; composition matches nothing, and each selected branch runs its OWN
 ;; pre-dispatch mechanics before its intent dispatches. A mixed or empty
-;; map, and a non-dispatching branch, are typed authoring errors. The
-;; form ships SUBJECT TO its delete-before-release pilot gate.
+;; map, a non-dispatching branch, and a branch naming a whole-listener
+;; option are typed authoring errors. The form ships SUBJECT TO its
+;; delete-before-release pilot gate.
 {:fh/id "FH-EVENT-005"
  :fh/law
- "A key-condition map on a key listener selects one intent by exact KeyboardEvent.key — a missing key, a chord modifier, or an in-flight composition dispatches nothing — while a mixed or empty map, a non-dispatching branch, and a key map on a non-key listener are rejected."
+ "A key-condition map on a key listener selects one intent by exact KeyboardEvent.key — a missing key, a chord modifier, or an in-flight composition dispatches nothing — while a mixed or empty map, a non-dispatching branch, a branch naming a whole-listener option, and a key map on a non-key listener are rejected."
 
  ;; Classification: a key-condition map normalizes to a `:key-map` plan
  ;; whose branches are each a classified dispatching plan. `:form` names a
@@ -41,6 +43,33 @@
   {:form :handler-branch :error-id :rf.error/view-bad-event}
   {:form :bare-fn-branch :error-id :rf.error/view-bad-event}
   {:form :nested-key-map :error-id :rf.error/view-bad-event}]
+
+ ;; The CLOSED branch option roster. `:prevent-default` and
+ ;; `:stop-propagation` are pre-dispatch mechanics the SELECTED branch
+ ;; runs, so a branch may name them. `:once`, `:capture` and `:passive`
+ ;; are whole-listener facts — the first retires the site, the other two
+ ;; decide native attachment — and every one of them is settled before a
+ ;; keystroke has been read, so a branch cannot honour them. Each is
+ ;; therefore REJECTED inside a branch rather than accepted and silently
+ ;; discarded. One row per option, so no option can quietly change side.
+ :branch-options
+ [{:option :prevent-default  :accepted true}
+  {:option :stop-propagation :accepted true}
+  {:option :once             :error-id :rf.error/view-bad-event}
+  {:option :capture          :error-id :rf.error/view-bad-event}
+  {:option :passive          :error-id :rf.error/view-bad-event}]
+
+ ;; The repeated-Enter counterexample the branch roster exists to make
+ ;; impossible to write: a committed key-map site invoked TWICE with the
+ ;; same key dispatches its intent twice, once per keystroke. A branch
+ ;; that could carry `:once` would read as a promise the site never keeps,
+ ;; so the grammar refuses the option and this row pins what the site
+ ;; actually does.
+ :repeated-key
+ {:branch      {:event [:picker/accept]}
+  :key         "Enter"
+  :invocations 2
+  :dispatched  [[:picker/accept] [:picker/accept]]}
 
  ;; Site legality: a key-condition map is legal only on a key listener
  ;; slot. `:slot` is the React event slot the emitter writes.

--- a/spec/conformance/freehand/fixtures/fh-event-005.edn
+++ b/spec/conformance/freehand/fixtures/fh-event-005.edn
@@ -71,6 +71,80 @@
   :invocations 2
   :dispatched  [[:picker/accept] [:picker/accept]]}
 
+ ;; ---------------------------------------------------------------------
+ ;; ONE grammar, two front ends
+ ;; ---------------------------------------------------------------------
+ ;;
+ ;; The compiled tier reads the SAME closed form at BUILD time that the
+ ;; normalizer reads at render — a declaration that meant one thing
+ ;; interpreted and another under `{:compiled true}` is the promotion break
+ ;; the compiled tier exists to make impossible. `:template` is the
+ ;; declaration body the analyzer lowers and `:prop` names the event
+ ;; position inside it, so one row states the authored value once: the
+ ;; suite reads it back out of the template and holds the compiled lowering
+ ;; to the plan the interpreted front end classifies from it.
+ ;;
+ ;; A branch that is DATA lowers to itself, which is what makes the two
+ ;; tiers comparable at all; a `v/event` branch lowers to the roster
+ ;; callback constructor the interpreted macro expands to, so the site is
+ ;; opaque to the manifest exactly as a whole-handler `v/event` is.
+ :compiled-accepted
+ [{:note "one exact key on :on-key-down"
+   :prop :on-key-down
+   :template [:input {:on-key-down {"Enter" [:picker/accept]}}]
+   :serializable? true}
+  {:note "several branches — an options map, a bare vector, and an explicit nil — on :on-key-up"
+   :prop :on-key-up
+   :template [:input {:on-key-up {"Enter"  {:event [:picker/accept] :prevent-default true}
+                                  "Escape" [:picker/close]
+                                  "Tab"    nil}}]
+   :serializable? true}
+  {:note "a v/event branch is a legal intent, and it makes the site opaque"
+   :prop :on-key-down
+   :template [:input {:on-key-down {"Enter" (event [ev] [:picker/typed ev])}}]
+   :serializable? false
+   :callback-branches ["Enter"]}]
+
+ ;; The compiled tier raises the SAME boundaries before a keystroke exists,
+ ;; under its own build-time id rather than the render one. Each row is a
+ ;; boundary the one-level exact-key form must not blur — and, crucially,
+ ;; none of them may be reported as an unknown LISTENER OPTION, which is
+ ;; what a map read as the wrong closed form produces.
+ :compiled-rejected
+ [{:note "an empty map is neither form"
+   :template [:input {:on-key-down {}}]
+   :error-id :rf.ui.compile/bad-handler-options}
+  {:note "exact keys mixed with a listener option"
+   :template [:input {:on-key-down {"Enter" [:picker/accept] :prevent-default true}}]
+   :error-id :rf.ui.compile/bad-handler-options}
+  {:note "a nested key map — the form is ONE level deep"
+   :template [:input {:on-key-down {"Enter" {"Escape" [:picker/close]}}}]
+   :error-id :rf.ui.compile/bad-handler-options}
+  {:note "an empty branch names no intent"
+   :template [:input {:on-key-down {"Enter" {}}}]
+   :error-id :rf.ui.compile/bad-handler-options}
+  {:note "a branch options map with no :event vector"
+   :template [:input {:on-key-down {"Enter" {:prevent-default true}}}]
+   :error-id :rf.ui.compile/bad-handler-options}
+  {:note "a v/handler branch is imperative work, not an intent"
+   :template [:input {:on-key-down {"Enter" (handler [ev] ev)}}]
+   :error-id :rf.ui.compile/bad-handler-options}
+  {:note "a bare fn branch is not an intent either"
+   :template [:input {:on-key-down {"Enter" (fn [ev] ev)}}]
+   :error-id :rf.ui.compile/bad-handler-options}
+  {:note "a branch may not carry :once — it retires the whole SITE"
+   :template [:input {:on-key-down {"Enter" {:event [:picker/accept] :once true}}}]
+   :error-id :rf.ui.compile/bad-handler-options}
+  {:note "a branch may not carry :capture — an attachment lane"
+   :template [:input {:on-key-down {"Enter" {:event [:picker/accept] :capture true}}}]
+   :error-id :rf.ui.compile/bad-handler-options}
+  {:note "a branch may not carry :passive — an attachment lane"
+   :template [:input {:on-key-down {"Enter" {:event [:picker/accept] :passive true}}}]
+   :error-id :rf.ui.compile/bad-handler-options}
+  {:note "a key-condition map on a listener that carries no key"
+   :template [:button {:on-click {"Enter" [:picker/accept]}}]
+   :error-id :rf.ui.compile/bad-handler-options}]
+
  ;; Site legality: a key-condition map is legal only on a key listener
  ;; slot. `:slot` is the React event slot the emitter writes.
  :site-legality

--- a/spec/conformance/freehand/fixtures/fh-input-001.edn
+++ b/spec/conformance/freehand/fixtures/fh-input-001.edn
@@ -135,6 +135,8 @@
  :compiled-role-rows
  [{:classification :vector   :role :event-vector}
   {:classification :options  :role :event-options}
+  {:note "the exact-key form is asked in the roster's own vocabulary, so the door weighs the value it actually names"
+   :classification :key-map  :role :key-map}
   {:classification :ui-event :role :event}
   {:classification :handler  :role :handler}
   {:classification :fn       :role :bare-fn}


### PR DESCRIPTION
## The defect

`[:input {:on-key-down {"Enter" [:picker/accept]}}]` was refused by the compiled
analyzer with `:rf.ui.compile/bad-handler-options` — *unknown handler option
`"Enter"`* — while the interpreted normalizer accepted the same value as a
`:key-map`. One declaration meant two different things across `{:compiled true}`,
which is exactly the promotion break the compiled tier exists to make impossible.
The key-condition form landed in the common normalizer without ever reaching the
analyzer, whose `(map? form)` arm read every literal map as the listener-options
form.

## The correction

`analyze-handler`'s single unconditional map arm is split the way
`events/map-plan` splits it at render — same order, same three outcomes:

| the map | is |
|---|---|
| empty | neither form (a typed authoring error) |
| keyword-keyed | the listener **options** map |
| string-keyed | the exact-key **condition** form |
| mixed | the error that says the two forms are separate |

The key-map arm **asks** the runtime's own rosters rather than restating them —
`events/key-slots` decides slot legality and `events/branch-options` decides what
a selected branch may carry — so there is one grammar with two front ends rather
than two lists someone has to keep in step. Slot legality is raised at build,
rather than at the first keystroke of a site that could never have fired.

A branch that is DATA lowers to itself, which is what makes the two tiers
comparable at all: hand the compiled lowering to `events/event-plan` and you get
the very plan the interpreted front end classifies from the authored value. A
`v/event` branch lowers to the roster callback constructor the interpreted macro
expands to, and makes the site opaque to the manifest exactly as a whole-handler
`v/event` does.

`:key-map` joins the compiled-role bridge, so the controlled-input door is asked
in the roster's own vocabulary rather than falling through the bridge's total
`:dynamic` answer. It settles the same way either route — no key listener is a
door slot — and that is the point: the parity is structural, not a coincidence.

The `v/event` reader is extracted to one function shared by the whole-handler
position and the branch position, so the arity refusal, the walk and the
loop-capture check cannot differ between them.

## Coverage

FH-EVENT-005 gains `:compiled-accepted` / `:compiled-rejected` tables and a new
cross-host suite runs them, so the fixture's `common` applicability is earned
rather than claimed. Eleven reject rows pin every boundary the one-level
exact-key form must not blur — and pin that none of them is reported as an
unknown *listener option*, which is what a map read as the wrong closed form
produces. FH-INPUT-001's compiled-role table gains the `:key-map` row.

Each new test was inverted and confirmed to red the full JVM gate by name, then
restored byte-identical.

## Gates

All foreground, all re-taken after rebase onto current `main`.

| gate | exit | result |
|---|---|---|
| `implementation/freehand` `clojure -M:test` | 0 | 775 tests / 5508 assertions |
| `npm run test:freehand` | 0 | 730 tests / 4498 assertions |
| `npm run test:cljs` | 0 | 10855 tests / 54621 assertions |
| `npm run test:browser` | 0 | 637 tests / 3790 assertions |
| `python scripts/check_freehand_conformance_index.py` | 0 | index valid |
