### PR TITLE
fix(freehand): the compiled tier's two missing slot arms, and v/spread's two parity splits

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/compiler/analyze.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/analyze.cljc
@@ -2032,8 +2032,17 @@
                  {:form props-form}))
     (cond
       spread?
-      (let [[_ base overrides & extra] props-form]
-        (when (or (nil? base) (seq extra))
+      ;; The shape is judged by ARITY, exactly as `analyze-foreign-spread`
+      ;; judges its own. Testing `(nil? base)` instead read a present
+      ;; literal nil as an ABSENT first argument, so `(v/spread nil)` —
+      ;; which the public function answers `{}` and which §Props
+      ;; forwarding defines as an element with no attributes — failed to
+      ;; compile, while a binding whose runtime value is nil compiled and
+      ;; rendered. Adding an otherwise unnecessary local changed whether
+      ;; the same value was accepted.
+      (let [args             (rest props-form)
+            [base overrides] args]
+        (when-not (<= 1 (count args) 2)
           (env/fail! e :rf.ui.compile/bad-spread
                      "(v/spread base) or (v/spread base overrides)"
                      {:form props-form}))

--- a/implementation/freehand/src/re_frame/freehand/compiler/emit_react.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/emit_react.cljc
@@ -68,6 +68,7 @@
             [re-frame.freehand.compiler.env :as env]
             [re-frame.freehand.controlled :as controlled]
             [re-frame.freehand.conversion :as conv]
+            [re-frame.freehand.events :as events]
             [re-frame.freehand.top-layer :as top-layer]))
 
 (declare emit-node)
@@ -356,6 +357,39 @@
            (.push ~a ~(emit-node e st body*))))
        ~a)))
 
+;; ---------------------------------------------------------------------------
+;; Render slots
+;; ---------------------------------------------------------------------------
+
+(defn- emit-slot
+  "A `v/slot` invocation — the BROWSER half of the lowering
+  [[re-frame.freehand.compiler.emit-jvm/emit-slot]] states structurally,
+  and the same three runtime calls in the same order: the carrier is
+  gated (nil renders nothing), its declared arity is checked against the
+  argument count, and its body is invoked with the runtime arguments.
+
+  Only the render-fn's BODY differs, and it differs the way every other
+  arm does: it is emitted through this emitter, so an inline slot builds
+  React elements while its structural twin builds nodes. The carrier
+  itself is [[re-frame.freehand.events/callback]]'s — the very value the
+  interpreted `v/render-fn` macro expands to — so the arity contract, the
+  slot gate and the boundary's opaque prop record are one implementation
+  across both modes and both hosts (rf2-ckviw).
+
+  The arguments are inlined at the CALL rather than collected into a
+  sequence, so a slot that does not render evaluates none of them."
+  [e st node]
+  (let [rf      (gensym "rf-fh-slot")
+        slotval (if-let [{:keys [params body]} (:render-fn node)]
+                  `(events/callback :render-fn
+                                    (fn [~@params] ~(emit-node e st body))
+                                    ~(count params))
+                  (:slot-value node))]
+    `(let [~rf ~slotval]
+       (when (events/slot-ready? ~rf)
+         (events/check-slot-arity! ~rf ~(count (:args node)))
+         ((events/callback-fn ~rf) ~@(:args node))))))
+
 (defn- emit-presence
   [e st node]
   `(re-frame.freehand.presence-runtime/presence-boundary
@@ -384,6 +418,7 @@
     :fragment (emit-fragment e st node)
     :view     (emit-view e st node)
     :for      (emit-for e st node)
+    :slot     (emit-slot e st node)
     :presence (emit-presence e st node)
     :if       `(if ~(:test node)
                  ~(emit-node e st (:then node))

--- a/implementation/freehand/src/re_frame/freehand/compiler/emit_react.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/emit_react.cljc
@@ -306,9 +306,27 @@
   markers exist because the analyzer is shared with the wider grammar),
   so the ordinary arm is the whole of what a v1 crossing carries: the
   walked value, handed to the boundary verbatim, exactly as the
-  interpreted walk hands it."
-  [{:keys [value]}]
-  value)
+  interpreted walk hands it.
+
+  A `:render-fn` entry is the exception, and it is not optional: the
+  analyzer records a lexically-visible slot body as an ANALYSED template
+  rather than a form, so such an entry carries no `:value` at all. Left
+  to the ordinary arm it emits `nil` — a prop-carried slot that reaches
+  the seam ABSENT, gating cleanly and rendering nothing, which is the
+  quietest possible failure. The arm below mirrors
+  [[re-frame.freehand.compiler.emit-jvm/prop-value-form]]'s call for
+  call: the same [[re-frame.freehand.events/callback]] carrier the
+  interpreted `v/render-fn` macro expands to, so the boundary records one
+  marker whichever mode wrote the slot; only the BODY differs, and it
+  differs the way every other arm does — it is emitted through this
+  emitter, so the deferred body builds React elements."
+  [e st {:keys [value marker render-fn]}]
+  (case marker
+    :render-fn `(events/callback
+                 :render-fn
+                 (fn [~@(:params render-fn)] ~(emit-node e st (:body render-fn)))
+                 ~(count (:params render-fn)))
+    value))
 
 (defn- emit-view
   "An internal boundary crossing — ONE call, whatever mode the child was
@@ -327,7 +345,7 @@
   [e st node]
   (let [entries   (get-in node [:props :entries])
         key-info  (get-in node [:props :key])
-        props-map (cond-> (into {} (map (fn [{:keys [k] :as en}] [k (prop-value-form en)])) entries)
+        props-map (cond-> (into {} (map (fn [{:keys [k] :as en}] [k (prop-value-form e st en)])) entries)
                     (:present? key-info) (assoc :key (:expr key-info)))]
     `(re-frame.freehand.compiled-react/mount
       ~(:sym node) ~props-map

--- a/implementation/freehand/src/re_frame/freehand/node.cljc
+++ b/implementation/freehand/src/re_frame/freehand/node.cljc
@@ -527,6 +527,26 @@
     m)
   m)
 
+(defn- canonical-slot-keys
+  "`m` with every key in the CANONICAL author spelling
+  [[re-frame.freehand.conversion/attr-key]] projects it onto.
+
+  Identity for all but the two SLOT-OWNING keys: `:class`, which composes
+  with the `.class` sugar, and `:style`, which carries the CSS grammar.
+  Those two own a place in the element rather than a place in the
+  attribute map, so `:x/class`, `\"class\"` and `'class` are one key
+  spelled four ways. Everything else — `:x/title`, `:on-click`, a
+  `data-*` — is left in author space, because the structural tree carries
+  authored names and rewriting one would edit the tree for no gain.
+
+  Remembered per key, so this is a map rebuild and not a re-derivation."
+  [m]
+  (if (seq m)
+    (persistent! (reduce-kv (fn [acc k v] (assoc! acc (conv/attr-key k) v))
+                            (transient {})
+                            m))
+    {}))
+
 (defn spread-attrs
   "`(v/spread base overrides)` — the author-space attribute map the element
   receives. `overrides` wins every collision (later-arg-wins), both maps are
@@ -535,7 +555,19 @@
 
   The one seam both modes reach: an interpreted body calls it through the
   public `v/spread`, a compiled body's emitted lowering calls it directly, so
-  the forwarded map cannot mean one thing before promotion and another after."
+  the forwarded map cannot mean one thing before promotion and another after.
+
+  A collision is judged on the CANONICAL slot, not on the authored
+  spelling, which is why both maps are projected before the merge rather
+  than after. `:class` and `:style` own a slot in the element, so
+  `{:x/class \"base\"}` and `{:class \"override\"}` are the same key twice —
+  but a raw `merge` sees two distinct map keys, keeps both, and leaves
+  the winner to whatever the downstream fold happens to visit last. The
+  two front ends fold in different orders, so that is exactly a
+  spelling-dependent split: the interpreted walk answered the BASE and
+  the compiled one the override, for one declaration whose only stated
+  rule is later-arg-wins. Projecting first makes the collision visible to
+  the merge, which is the one place the rule is written down."
   [base overrides]
   (assert-forwardable-attrs! 're-frame.freehand/spread base)
   (assert-forwardable-attrs! 're-frame.freehand/spread overrides)
@@ -543,7 +575,7 @@
   ;; both modes rather than an attribute map in one and an absent child in
   ;; the other — the two happen to render the same tree, and agreement by
   ;; coincidence is the thing this whole slice is written against.
-  (merge (or base {}) overrides))
+  (merge (canonical-slot-keys base) (canonical-slot-keys overrides)))
 
 (defn- owned-handler-keys
   "The `on-*` keys of a `v/spread-safe` OWNED props map — the handler families

--- a/implementation/freehand/test/re_frame/freehand/compiled_slot_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/compiled_slot_dom_cljs_test.cljs
@@ -1,0 +1,197 @@
+(ns re-frame.freehand.compiled-slot-dom-cljs-test
+  "A compiled `v/slot` in a real browser — the BROWSER half of the render
+  slot's cross-mode claim.
+
+  The slots slice shipped `v/slot` as common grammar and proved it on the
+  structural host, mode against mode. The browser emitter had no `:slot`
+  arm at all, so the declarations below did not render wrongly — they
+  could not be COMPILED. `case` with no default arm answers a node kind it
+  does not know with `IllegalArgumentException: No matching clause`,
+  thrown inside macro expansion, naming neither the view nor the form.
+
+  Two lanes prove the repair, and the file rides both:
+
+  - in the NODE suites, which have no DOM, the declarations still load —
+    and loading them is the macro expansion that used to fail, so a
+    missing arm reds the whole build here first;
+  - in the BROWSER job, the same declarations mount and every claim is
+    read back off `document`: an inline render-fn's content, a
+    prop-carried render-fn invoked once per keyed row with that row's
+    own value, and an absent slot whose siblings close over the gap.
+
+  Normative owner:
+  [`spec/004-Views.md`](../../../../../spec/004-Views.md) §Render slots;
+  the compiled tier is
+  [`spec/004D-Freehand-Compiled-Grammar.md`](../../../../../spec/004D-Freehand-Compiled-Grammar.md)."
+  (:require ["react" :as react]
+            [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.react :as fr]
+            [re-frame.freehand.root :as root]
+            [re-frame.adapter.uix :as react-substrate]
+            [re-frame.test-support :as test-support]))
+
+(def ^:private runtime-fixture
+  (test-support/make-reset-runtime-fixture
+    {:adapter       react-substrate/adapter
+     :ambient-frame nil
+     :async?        true}))
+
+(use-fixtures :each
+  {:before (fn []
+             (root/reset-registry!)
+             (fr/reset-boundaries!)
+             ((:before runtime-fixture)))
+   :after  (fn []
+             ((:after runtime-fixture))
+             (root/reset-registry!)
+             (fr/reset-boundaries!))})
+
+;; ---------------------------------------------------------------------------
+;; The declarations. Module-level, and COMPILED — expanding them is the
+;; half of this claim that runs everywhere.
+;; ---------------------------------------------------------------------------
+
+(v/defview cell
+  "An ordinary declared child, mounted from INSIDE a render-fn body — so
+  the browser lane proves a slot renders a boundary and not merely markup."
+  {:compiled true}
+  [{:keys [label]}]
+  [:td.cell label])
+
+(v/defview inline-slot
+  "The slot the compiler can see whole: the render-fn is lexically visible
+  at the invocation, so its body is lowered by the React emitter."
+  {:compiled true}
+  [{:keys [label]}]
+  [:table [:tbody [:tr#inline (v/slot (v/render-fn [r] [:td.inline r]) label)]]])
+
+(v/defview seam
+  "The library seam: content arrives as a PROP and is invoked per row."
+  {:compiled true}
+  [{:keys [rows row]}]
+  [:tbody (for [r rows] [:tr {:key r} (v/slot row r)])])
+
+(v/defview seam-table
+  "The caller, supplying the seam's content. Caller and seam are declared
+  in the same MODE, which is what the crossing law requires."
+  {:compiled true}
+  [{:keys [rows]}]
+  [:table#seam [seam {:rows rows :row (v/render-fn [r] [cell {:label r}])}]])
+
+(v/defview absent-slot
+  "An ABSENT slot renders nothing, and the siblings close over the gap — a
+  component may offer content it does not require."
+  {:compiled true}
+  [{:keys [row]}]
+  [:div#absent [:span.before "before"] (v/slot row "a") [:span.after "after"]])
+
+;; ---------------------------------------------------------------------------
+;; The host-neutral lane
+;; ---------------------------------------------------------------------------
+
+(deftest a-compiled-slot-declaration-expands
+  (testing "The defect was a macro-expansion crash, so the loaded
+            declaration IS the assertion: reaching this test at all means
+            the browser emitter lowered every `v/slot` above. The lowering
+            each declaration reports is asserted too, so a declaration that
+            quietly fell back to the interpreted walk could not pass."
+    (doseq [[note view] [["an inline render-fn" inline-slot]
+                         ["a prop-carried render-fn" seam]
+                         ["a slot's caller" seam-table]
+                         ["an absent slot" absent-slot]]]
+      (is (= :compiled (:lowering (v/describe view)))
+          (str note " — declared compiled"))
+      (is (some? (v/manifest view))
+          (str note " — and carries its analysed manifest")))))
+
+;; ---------------------------------------------------------------------------
+;; The browser lane
+;; ---------------------------------------------------------------------------
+
+(defn- browser? []
+  (and (exists? js/document) (some? (.-createElement js/document))))
+
+(defn- skip! [why]
+  (is true (str "a real React mount needs a DOM host — " why)))
+
+(defn- act [thunk]
+  (try
+    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+    (js/Promise.resolve (react/act (fn [] (js/Promise.resolve (thunk)))))
+    (catch :default e
+      (js/Promise.reject e))))
+
+(defn- host-node! []
+  (let [container (js/document.createElement "div")]
+    (.appendChild js/document.body container)
+    container))
+
+(defn- unmount! [container mounted]
+  (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+  (when (some? mounted)
+    (.unmount (.-react-root ^root/Root mounted)))
+  (.remove container)
+  nil)
+
+(defn- mounted!
+  "Mount `form` into a fresh host node, run `check` against the container,
+  and tear the root down whatever happens."
+  [form check done]
+  (let [container (host-node!)]
+    (-> (act #(v/mount form container))
+        (.then (fn [m]
+                 (check container)
+                 (unmount! container m)
+                 (done)))
+        (.catch (fn [e]
+                  (is false (str "compiled slot mount rejected: " e))
+                  (.remove container)
+                  (done))))))
+
+(deftest an-inline-render-fn-renders-its-content-in-the-dom
+  (testing "The render-fn's body is lowered by the SAME emitter that
+            lowered the view around it, so its content is ordinary
+            compiled markup sitting among its siblings."
+    (if-not (browser?)
+      (skip! "the browser job runs the mount assertions")
+      (async done
+        (mounted! [inline-slot {:label "a"}]
+                  (fn [c]
+                    (is (some? (.querySelector c "tr#inline > td.inline"))
+                        "the slot's content is a real child of the element that declared it")
+                    (is (= "a" (.-textContent (.querySelector c "td.inline")))
+                        "and the slot's argument reached the render-fn"))
+                  done)))))
+
+(deftest a-prop-carried-render-fn-renders-once-per-row
+  (testing "The library seam invokes content its CALLER supplied, once per
+            keyed row, with that row's own value — the shape a component
+            library is built out of."
+    (if-not (browser?)
+      (skip! "the browser job runs the mount assertions")
+      (async done
+        (mounted! [seam-table {:rows ["r1" "r2" "r3"]}]
+                  (fn [c]
+                    (let [cells (array-seq (.querySelectorAll c "table#seam td.cell"))]
+                      (is (= 3 (count cells))
+                          "one declared child boundary per row")
+                      (is (= ["r1" "r2" "r3"] (mapv #(.-textContent %) cells))
+                          "each row's own value reached its render-fn")))
+                  done)))))
+
+(deftest an-absent-slot-renders-nothing-and-the-siblings-close-up
+  (testing "A nil carrier renders nothing at all — not an empty wrapper —
+            so the slot costs nothing in the DOM when the caller supplied
+            no content."
+    (if-not (browser?)
+      (skip! "the browser job runs the mount assertions")
+      (async done
+        (mounted! [absent-slot {:row nil}]
+                  (fn [c]
+                    (let [host (.querySelector c "div#absent")]
+                      (is (= 2 (.-length (.-children host)))
+                          "the absent slot contributed no node")
+                      (is (= "beforeafter" (.-textContent host))
+                          "and the siblings sit next to each other")))
+                  done)))))

--- a/implementation/freehand/test/re_frame/freehand/react_lowering_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/react_lowering_jvm_test.clj
@@ -85,8 +85,9 @@
    {:op :case     :body '[:div (case (:kind props) :a [:i "a"] [:b "z"])]}
    {:op :presence :body '(v/presence {:timeout-ms 120} [:div {:key "a"} "x"])}
    ;; The row this file was written for: an inline render-fn, whose body is
-   ;; lowered by THIS emitter, and a prop-carried one, whose carrier is a
-   ;; runtime value.
+   ;; lowered by THIS emitter. The prop-carried half — the render-fn authored
+   ;; at a CALL SITE, which the analyzer records as an analysed template
+   ;; rather than a value — has its own claim below.
    {:op :slot     :body '[:div (v/slot (v/render-fn [r] [:span r]) (:label props))]}])
 
 (deftest the-react-emitter-lowers-every-admitted-node-kind
@@ -123,3 +124,21 @@
             (str "the emitted body calls " call)))
       (is (.contains emitted "re-frame.freehand.compiled-react/el")
           "and the render-fn's own body was lowered through the React emitter"))))
+
+(deftest a-call-site-render-fn-prop-carries-the-slot-across-the-boundary
+  (testing "The library seam — content authored at the CALL SITE and
+            invoked by the callee through `v/slot`. The analyzer records
+            such a prop as an analysed TEMPLATE, so the entry carries no
+            plain value at all: an emitter that reads only `:value` puts
+            `nil` on the props map, the seam's slot gates as absent, and
+            the crossing renders nothing while every declaration compiles
+            and every mount resolves. Assert the carrier and its lowered
+            body are really on the emitted props map."
+    (let [[e ast] (analyzed '[:div [leaf {:row (v/render-fn [r] [:span r])}]])
+          emitted (pr-str (emit-react/emit-react-body e '[props] ast))]
+      (is (.contains emitted "re-frame.freehand.events/callback")
+          "the prop carries the same roster callback an interpreted v/render-fn expands to")
+      (is (.contains emitted "re-frame.freehand.compiled-react/el")
+          "and the slot body was lowered through the React emitter")
+      (is (not (.contains emitted ":row nil"))
+          "so the boundary is not handed an absent slot"))))

--- a/implementation/freehand/test/re_frame/freehand/react_lowering_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/react_lowering_jvm_test.clj
@@ -1,0 +1,125 @@
+(ns re-frame.freehand.react-lowering-jvm-test
+  "The React emitter lowers EVERY node kind `:re-frame.freehand/v1` admits.
+
+  `re-frame.freehand.compiler.emit-react` walks the normalized AST with a
+  `case` that carries no default arm, and that is deliberate: the grammar
+  check refuses every node kind outside v1 before emission, so a missing
+  arm is not a fallback, it is a crash. `case` states it as
+  `IllegalArgumentException: No matching clause`, thrown during MACRO
+  EXPANSION of the ClojureScript compile — so a declaration using the
+  unlowered form does not render wrongly, it fails to compile, with a
+  diagnostic that names neither the view nor the form.
+
+  A `v/slot` in a `{:compiled true}` body was exactly that: the structural
+  emitter had lowered it since the slots slice shipped, and the browser
+  emitter had no `:slot` arm at all.
+
+  So this suite drives one source body per admitted op through the analyzer
+  and the React emitter, and asserts the table COVERS
+  [[re-frame.freehand.compiler.grammar/admitted-ops]] exactly. Widening the
+  grammar without widening the emitter fails here, at the emitter, rather
+  than in a consumer's ClojureScript build.
+
+  It runs on the JVM against the `:clj` resolver because the two emitters
+  consume the SAME normalized AST — the analysis under test is the analysis
+  a ClojureScript expansion performs, and only the resolver that reads the
+  namespace's aliases differs. The mounted browser half of the claim is
+  `re-frame.freehand.compiled-slot-dom-cljs-test`.
+
+  Normative owner:
+  [`spec/004D-Freehand-Compiled-Grammar.md`](../../../../../spec/004D-Freehand-Compiled-Grammar.md)."
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.walk :as walk]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.compiler.analyze :as ana]
+            [re-frame.freehand.compiler.emit-react :as emit-react]
+            [re-frame.freehand.compiler.env :as env]
+            [re-frame.freehand.compiler.grammar :as grammar]))
+
+(v/defview leaf
+  "A declared child, so a `:view` crossing has something to cross to."
+  [{:keys [label]}]
+  [:i label])
+
+(defn- analyzed
+  "The normalized AST for one view body, analysed exactly as a compiled
+  declaration in THIS namespace would be."
+  [body]
+  (let [e (-> (env/make-env {:host            :clj
+                             :cljs-env        nil
+                             :ns-sym          're-frame.freehand.react-lowering-jvm-test
+                             :self            'subject
+                             :self-id         ::subject
+                             :template-anchor "react-lowering"})
+              (assoc :self-children? true :hooks-region? true)
+              (env/with-locals '#{props}))
+        ast (ana/analyze-view-body e [body])]
+    (grammar/check! e ::subject ast)
+    [e ast]))
+
+(defn- ops
+  "Every `:op` the analyzed AST carries."
+  [ast]
+  (let [found (volatile! #{})]
+    (walk/postwalk (fn [x]
+                     (when (and (map? x) (keyword? (:op x)))
+                       (vswap! found conj (:op x)))
+                     x)
+                   ast)
+    @found))
+
+(def rows
+  "One source body per admitted node kind. `:op` is the kind the row
+  exists to reach — asserted to really be in the analysed AST, so a row
+  that stopped producing its own node kind cannot keep passing."
+  [{:op :text     :body '[:div "text"]}
+   {:op :nothing  :body '[:div nil]}
+   {:op :expr     :body '[:div (:label props)]}
+   {:op :element  :body '[:div.card {:id "x"} "a"]}
+   {:op :fragment :body '[:<> [:i "a"] [:b "b"]]}
+   {:op :view     :body '[:div [leaf {:label "a"}]]}
+   {:op :for      :body '[:ul (for [i (:items props)] [:li {:key i} i])]}
+   {:op :if       :body '[:div (if (:flag props) [:i "y"] [:b "n"])]}
+   {:op :let      :body '[:div (let [x (:label props)] [:i x])]}
+   {:op :letfn    :body '[:div (letfn [(f [] "x")] [:i (f)])]}
+   {:op :case     :body '[:div (case (:kind props) :a [:i "a"] [:b "z"])]}
+   {:op :presence :body '(v/presence {:timeout-ms 120} [:div {:key "a"} "x"])}
+   ;; The row this file was written for: an inline render-fn, whose body is
+   ;; lowered by THIS emitter, and a prop-carried one, whose carrier is a
+   ;; runtime value.
+   {:op :slot     :body '[:div (v/slot (v/render-fn [r] [:span r]) (:label props))]}])
+
+(deftest the-react-emitter-lowers-every-admitted-node-kind
+  (testing "The emitter's `case` has no default arm, so an unlowered kind
+            is a macro-expansion crash rather than a diagnostic. Every kind
+            the grammar admits is emitted here, and the failure below names
+            the kind."
+    (doseq [{:keys [op body]} rows]
+      (let [[e ast] (analyzed body)]
+        (is (contains? (ops ast) op)
+            (str op " — the row really produces the node kind it names"))
+        (is (some? (emit-react/emit-react-body e '[props] ast))
+            (str op " — the React emitter has an arm for it"))))))
+
+(deftest the-table-covers-the-whole-admitted-roster
+  (testing "A per-kind table is only as good as its coverage, so the
+            coverage is the assertion: widening `admitted-ops` without
+            widening this table — and the emitter it drives — fails here."
+    (is (= grammar/admitted-ops (into #{} (map :op) rows))
+        "one row per admitted node kind, and no row outside the roster")))
+
+(deftest a-compiled-slot-lowers-to-the-shared-carrier-contract
+  (testing "The browser lowering reaches the SAME three runtime calls the
+            structural one does — the gate, the host-independent arity
+            check, and the carrier's own fn — so a slot cannot mean one
+            thing in a structural render and another in the DOM."
+    (let [[e ast] (analyzed '[:div (v/slot (v/render-fn [r] [:span r]) (:label props))])
+          emitted (pr-str (emit-react/emit-react-body e '[props] ast))]
+      (doseq [call ["re-frame.freehand.events/callback"
+                    "re-frame.freehand.events/slot-ready?"
+                    "re-frame.freehand.events/check-slot-arity!"
+                    "re-frame.freehand.events/callback-fn"]]
+        (is (.contains emitted call)
+            (str "the emitted body calls " call)))
+      (is (.contains emitted "re-frame.freehand.compiled-react/el")
+          "and the render-fn's own body was lowered through the React emitter"))))

--- a/implementation/freehand/test/re_frame/freehand/spread_literal_nil_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/spread_literal_nil_jvm_test.clj
@@ -1,0 +1,140 @@
+(ns re-frame.freehand.spread-literal-nil-jvm-test
+  "`(v/spread nil)` — a PRESENT first argument that happens to be nil.
+
+  `v/spread` is common interpreted/compiled grammar and nil is defined as
+  an empty runtime attribute map: the public function answers `{}`, and
+  §Props forwarding pins a nil runtime map as an element with no
+  attributes. The compiled analyzer judged the form's SHAPE by asking
+  whether the first argument was nil, which reads a present literal nil
+  as an ABSENT argument — so the declaration did not render differently,
+  it refused to compile with `:rf.ui.compile/bad-spread`.
+
+  The cost is not the rejection, it is what the rejection is CONDITIONAL
+  on. A runtime expression whose value is nil compiled and rendered
+  perfectly, so introducing or removing an otherwise unnecessary local
+  changed whether the same value was accepted — and the empty-forward
+  parity row already in the corpus uses exactly that indirection, which
+  is why it never saw this.
+
+  The shape is now judged by ARITY, the way the sibling foreign-component
+  spread has always judged its own. Zero arguments and more than two are
+  still the same didactic failure at the same phase, and a non-map
+  runtime value is still refused where it always was — at the forward
+  itself, where the value exists.
+
+  Normative owner:
+  [`spec/004-Views.md`](../../../../../spec/004-Views.md) §Props forwarding."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.compiler :as compiler]
+            [re-frame.freehand.tree :as tree]))
+
+(def ^:private params
+  "The binding the runtime-nil rows read, so a nil that arrives at RENDER
+  is a real runtime value and not a literal in disguise."
+  '[{:keys [attrs]}])
+
+(defn- compiled-tree
+  "The structural tree the COMPILED front end answers for `body` — the
+  emitted lowering, evaluated and called."
+  ([body] (compiled-tree body {}))
+  ([body props]
+   (let [lowering (compiler/compile-structural-view
+                    {:form            (list 'v/defview 'subject params body)
+                     :menv            nil
+                     :ns-sym          're-frame.freehand.spread-literal-nil-jvm-test
+                     :vname           'subject
+                     :view-id         ::subject
+                     :params          params
+                     :body            [body]
+                     :children-policy :optional})]
+     ((eval (:body lowering)) props))))
+
+(defn- interpreted-tree
+  [form]
+  (dissoc (tree/render form) :rf.ui/tree-version))
+
+(defn- compile-error
+  "The `:rf.ui.compile/…` id `body` is refused with, or nil if it compiles."
+  [body]
+  (try (compiled-tree body) nil
+       (catch Exception e
+         (:rf.ui.compile/error (ex-data (or (ex-cause e) e))))))
+
+;; ---------------------------------------------------------------------------
+;; The accepted forms
+;; ---------------------------------------------------------------------------
+
+(def accepted-rows
+  "Every way an author can forward nothing, and the ONE tree both modes
+  answer. The literal and the runtime rows sit side by side deliberately:
+  the defect was that they disagreed, and only a table carrying both
+  could have said so."
+  [{:note  "a literal nil base is an element with no attributes"
+    :body  '[:div (v/spread nil)]
+    :form  [:div (v/spread nil)]
+    :tree  {:tag :div}}
+
+   {:note  "a runtime value that IS nil — the form that always compiled"
+    :body  '[:div (v/spread attrs)]
+    :form  [:div (v/spread nil)]
+    :props {:attrs nil}
+    :tree  {:tag :div}}
+
+   {:note  "literal nil in BOTH positions"
+    :body  '[:div (v/spread nil nil)]
+    :form  [:div (v/spread nil nil)]
+    :tree  {:tag :div}}
+
+   {:note  "a nil base with real overrides — the overrides still land"
+    :body  '[:div (v/spread nil {:class "c"})]
+    :form  [:div (v/spread nil {:class "c"})]
+    :tree  {:tag :div :attrs {:class "c"}}}
+
+   {:note  "and the tag shorthand is untouched by an empty forward"
+    :body  '[:div.sugar (v/spread nil)]
+    :form  [:div.sugar (v/spread nil)]
+    :tree  {:tag :div :attrs {:class "sugar"}}}])
+
+(deftest a-literal-nil-forwards-an-empty-map-in-both-modes
+  (testing "nil is a defined value for a forwarded attribute map — the
+            public function answers `{}` for it — so the compiled tier
+            must accept the literal spelling of that value. Judging the
+            form's shape by whether its first argument was nil made
+            acceptance depend on whether the author had written the value
+            directly or through a local, which is not a distinction the
+            grammar makes anywhere else."
+    (doseq [{:keys [note form props tree body]} accepted-rows]
+      (is (= tree (interpreted-tree form)) (str note " — interpreted"))
+      (is (= tree (compiled-tree body (or props {}))) (str note " — compiled")))))
+
+;; ---------------------------------------------------------------------------
+;; The failures that must survive
+;; ---------------------------------------------------------------------------
+
+(deftest the-genuinely-malformed-arities-still-fail-at-compile-time
+  (testing "The control that makes the acceptance above mean something.
+            Accepting a present nil is not accepting an ABSENT argument:
+            zero arguments and more than two are still the same
+            diagnostic at the same phase, so a repair that simply deleted
+            the check would show up here."
+    (is (= :rf.ui.compile/bad-spread (compile-error '[:div (v/spread)]))
+        "zero arguments — there is no map to forward")
+    (is (= :rf.ui.compile/bad-spread
+           (compile-error '[:div (v/spread {:a 1} {:b 2} {:c 3})]))
+        "three arguments — v/spread layers exactly two")))
+
+(deftest a-non-map-runtime-value-is-still-refused-where-the-value-exists
+  (testing "The arity check is about the FORM. What the forwarded
+            expression evaluates to is judged at the forward itself,
+            which is the only phase at which a runtime value exists —
+            and that refusal is unchanged, because a compiled body and an
+            interpreted one reach it through the same seam."
+    (doseq [[mode thunk] [["interpreted" #(interpreted-tree [:div (v/spread "nope")])]
+                          ["compiled"    #(compiled-tree '[:div (v/spread attrs)]
+                                                         {:attrs "nope"})]]]
+      (let [ex (try (thunk) nil (catch clojure.lang.ExceptionInfo e e))]
+        (is (some? ex) (str mode " — a string is not an attribute map"))
+        (when ex
+          (is (= :rf.error/ui-tree-malformed (:rf.error/id (ex-data ex)))
+              (str mode " — the walk's existing diagnostic, not a compile-phase one")))))))

--- a/implementation/freehand/test/re_frame/freehand/spread_precedence_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/spread_precedence_jvm_test.clj
@@ -1,0 +1,210 @@
+(ns re-frame.freehand.spread-precedence-jvm-test
+  "`(v/spread base overrides)` — `overrides` wins EVERY collision, in both
+  modes, however the colliding key is spelled.
+
+  The rule is one sentence and the substrate states it as later-arg-wins,
+  but a collision is only a collision if something SEES it. Two attribute
+  keys own a slot in the element rather than a place in the attribute map
+  — `:class`, which composes with the `.class` sugar, and `:style`, which
+  carries the CSS grammar — and every spelling of those names reaches the
+  same slot. So `{:x/class \"base\"}` and `{:class \"override\"}` are the
+  same key twice; a raw `merge` sees two distinct map keys, keeps both,
+  and leaves the winner to whatever the downstream fold visits last.
+
+  The two front ends fold in different orders. The interpreted walk
+  splits the exact spelling into its dedicated field and applies the
+  aliased one after it; the compiled emitter reduces the merged map in
+  insertion order. One declaration, two answers — interpreted `\"base\"`,
+  compiled `\"override\"` — and the divergence is invisible in an ordinary
+  same-spelling row, which is why the promotion parity suites did not
+  catch it. Reversing the two spellings happens to agree, so half the
+  table would have passed too.
+
+  The repair is that the projection happens BEFORE the merge, inside the
+  one seam both modes call: `overrides` wins on the canonical slot, which
+  is the only place the rule is written down.
+
+  Every row is asserted in BOTH modes from one declaration — interpreted
+  through [[re-frame.freehand.tree/render]], compiled through the emitted
+  lowering itself, evaluated and called. The companion suite for aliased
+  keys on the DIRECT attribute path is
+  `re-frame.freehand.structural-slot-alias-jvm-test`.
+
+  Normative owner:
+  [`spec/004-Views.md`](../../../../../spec/004-Views.md) §Props forwarding."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.compiler :as compiler]
+            [re-frame.freehand.tree :as tree]))
+
+(def ^:private params
+  "The bindings a compiled row reads its two maps through, so `base` and
+  `overrides` are real RUNTIME values in both modes rather than literals
+  the compiler could have settled."
+  '[{:keys [base overrides]}])
+
+(defn- compiled-tree
+  "The structural tree the COMPILED front end answers for `body` — the
+  emitted lowering, evaluated and called on `props`, rather than a claim
+  about the form it emitted."
+  [body props]
+  (let [lowering (compiler/compile-structural-view
+                   {:form            (list 'v/defview 'subject params body)
+                    :menv            nil
+                    :ns-sym          're-frame.freehand.spread-precedence-jvm-test
+                    :vname           'subject
+                    :view-id         ::subject
+                    :params          params
+                    :body            [body]
+                    :children-policy :optional})]
+    ((eval (:body lowering)) props)))
+
+(defn- interpreted-tree
+  "The structural tree the INTERPRETED walk answers for the same element,
+  with the root's version stripped so the two modes' values compare."
+  [form]
+  (dissoc (tree/render form) :rf.ui/tree-version))
+
+;; ---------------------------------------------------------------------------
+;; Precedence across spellings
+;; ---------------------------------------------------------------------------
+
+(def ^:private one-arg-body
+  '[:div (v/spread base)])
+
+(def ^:private two-arg-body
+  '[:div (v/spread base overrides)])
+
+(def ^:private sugared-two-arg-body
+  '[:div.sugar (v/spread base overrides)])
+
+(def collision-rows
+  "One collision per row, spelled every way the grammar accepts, and the
+  ONE tree both modes must answer.
+
+  The first two rows are the reported defect. The rest are the controls
+  that make it mean something: the reverse spelling direction and the
+  same-spelling case already agreed before the repair, so a fix that
+  merely reversed the winner would show up here rather than pass."
+  [{:note      "an aliased base loses to an exact override — the reported divergence"
+    :body      two-arg-body
+    :props     {:base {:x/class "base"} :overrides {:class "override"}}
+    :tree      {:tag :div :attrs {:class "override"}}}
+
+   {:note      "and the same for :style, whose slot carries the CSS grammar"
+    :body      two-arg-body
+    :props     {:base {:x/style {:color "red"}} :overrides {:style {:color "blue"}}}
+    :tree      {:tag :div :attrs {:style {:color "blue"}}}}
+
+   {:note      "the reverse direction — an exact base loses to an aliased override"
+    :body      two-arg-body
+    :props     {:base {:class "base"} :overrides {:x/class "override"}}
+    :tree      {:tag :div :attrs {:class "override"}}}
+
+   {:note      "a string spelling is the same key too"
+    :body      two-arg-body
+    :props     {:base {"class" "base"} :overrides {:class "override"}}
+    :tree      {:tag :div :attrs {:class "override"}}}
+
+   {:note      "as is a symbol spelling"
+    :body      two-arg-body
+    :props     {:base {'class "base"} :overrides {:class "override"}}
+    :tree      {:tag :div :attrs {:class "override"}}}
+
+   {:note      "the same-spelling collision was always correct and stays correct"
+    :body      two-arg-body
+    :props     {:base {:class "base"} :overrides {:class "override"}}
+    :tree      {:tag :div :attrs {:class "override"}}}
+
+   {:note      "an override that collides with NOTHING still lands beside the base"
+    :body      two-arg-body
+    :props     {:base {:x/class "base"} :overrides {:x/title "t"}}
+    :tree      {:tag :div :attrs {:class "base" :x/title "t"}}}
+
+   {:note      "an ORDINARY namespaced key is not a slot, so it keeps its authored name"
+    :body      two-arg-body
+    :props     {:base {:x/title "base"} :overrides {:x/title "override"}}
+    :tree      {:tag :div :attrs {:x/title "override"}}}])
+
+(deftest overrides-win-a-collision-on-the-canonical-slot-in-both-modes
+  (testing "A collision is judged on the SLOT the key projects onto, not
+            on the spelling the author used, because that is the thing the
+            element has one of. Judging it on the raw map key leaves the
+            winner to the downstream fold, and the two front ends fold in
+            different orders — so the same declaration answered the base
+            in one mode and the override in the other."
+    (is (<= 6 (count collision-rows)) "the table is not vacuously small")
+    (doseq [{:keys [note body props tree]} collision-rows]
+      (let [interpreted (interpreted-tree
+                          (if (= body one-arg-body)
+                            [:div (v/spread (:base props))]
+                            [:div (v/spread (:base props) (:overrides props))]))]
+        (is (= tree interpreted) (str note " — interpreted"))
+        (is (= tree (compiled-tree body props)) (str note " — compiled"))))))
+
+(deftest a-winning-class-still-composes-with-the-tag-shorthand
+  (testing "The obligation the canonical projection carries. `:class`
+            owns its slot BECAUSE it composes with `.class` sugar, so a
+            projection that assigned into the slot instead would silently
+            drop `:div.sugar`'s classes — a worse defect than the one
+            being fixed, and an invisible one, because the element still
+            renders."
+    (let [props {:base {:x/class "base"} :overrides {:class "override"}}]
+      (doseq [[mode tree] [["interpreted" (interpreted-tree
+                                            [:div.sugar (v/spread (:base props)
+                                                                  (:overrides props))])]
+                           ["compiled"    (compiled-tree sugared-two-arg-body props)]]]
+        (is (= {:tag :div :attrs {:class "sugar override"}} tree)
+            (str mode " — the shorthand survives and the override won"))))))
+
+(deftest an-explicit-nil-override-clears-the-slot-however-it-is-spelled
+  (testing "`overrides` winning every collision includes winning with
+            nil: the same-spelling case already dropped the attribute,
+            so an aliased base that SURVIVED an explicit nil override
+            would be the divergence back again, one value along."
+    (doseq [[note base overrides tree]
+            [["same spelling"      {:class "base"}   {:class nil} {:tag :div}]
+             ["aliased base"       {:x/class "base"} {:class nil} {:tag :div}]
+             ["aliased override"   {:class "base"}   {:x/class nil} {:tag :div}]
+             ["a nil BASE loses to a real override"
+              {:x/class nil} {:class "override"} {:tag :div :attrs {:class "override"}}]]]
+      (is (= tree (interpreted-tree [:div (v/spread base overrides)]))
+          (str note " — interpreted"))
+      (is (= tree (compiled-tree two-arg-body {:base base :overrides overrides}))
+          (str note " — compiled")))))
+
+(deftest the-one-argument-form-is-unchanged
+  (testing "There is no collision to judge with one map, so the single-
+            argument form must answer exactly what it always did — the
+            base folded onto the element through the ordinary rule table,
+            aliases routed to their slots by that fold."
+    (let [props {:base {:x/class "base" :x/title "t"}}
+          tree  {:tag :div :attrs {:class "base" :x/title "t"}}]
+      (is (= tree (interpreted-tree [:div (v/spread (:base props))])) "interpreted")
+      (is (= tree (compiled-tree one-arg-body props)) "compiled"))
+    (let [tree {:tag :div}]
+      (is (= tree (interpreted-tree [:div (v/spread nil)])) "a nil base is an empty map, interpreted"))))
+
+;; ---------------------------------------------------------------------------
+;; Evaluation order and count
+;; ---------------------------------------------------------------------------
+
+(deftest each-map-expression-is-evaluated-once-in-authored-order
+  (testing "The projection rebuilds two maps, so the obvious way to get
+            it wrong is to evaluate an argument twice — a forwarded map
+            built by a function call would then run its effects twice,
+            and an author cannot see that from the call site. Base then
+            overrides, once each, in both modes."
+    (doseq [[mode run] [["interpreted"
+                         (fn [b o] (interpreted-tree [:div (v/spread (b) (o))]))]
+                        ["compiled"
+                         (fn [b o] (compiled-tree '[:div (v/spread (base) (overrides))]
+                                                  {:base b :overrides o}))]]]
+      (let [log (atom [])
+            b   (fn [] (swap! log conj :base) {:x/class "base"})
+            o   (fn [] (swap! log conj :overrides) {:class "override"})
+            t   (run b o)]
+        (is (= [:base :overrides] @log)
+            (str mode " — each expression ran once, base first"))
+        (is (= {:tag :div :attrs {:class "override"}} t)
+            (str mode " — and the override still won"))))))


### PR DESCRIPTION
Four defects on one surface — the compiled Freehand tier's render slots and `v/spread` — each one a case where a declaration meant something different depending on which front end read it.

## The React emitter's two missing arms

**The `:slot` arm.** `emit-react` walks the normalized AST with a `case` carrying no default arm, and had no `:slot` arm at all. A `{:compiled true}` declaration using `v/slot` therefore did not render wrongly — it could not be compiled: macro expansion answered `IllegalArgumentException: No matching clause: :slot`, naming neither the view nor the form. The structural emitter had lowered the same node since the slots slice shipped. The new arm mirrors `emit-jvm/emit-slot` call for call, on the same `events/callback` carrier the interpreted `v/render-fn` macro expands to.

**The prop-carried render-fn.** The `:slot` arm alone left the library seam broken, and the browser suite written for it said so. A render-fn authored at a CALL SITE — `[seam {:row (v/render-fn [r] [cell {:label r}])}]` — is recorded by the analyzer as an analysed TEMPLATE, so that props entry carries a `:render-fn` AST and no `:value` key at all. `emit-react`'s `prop-value-form` read only `:value` and put `nil` on the props map, so the seam's `v/slot` gated as ABSENT.

That is the quietest failure shape in the tier: nothing throws, nothing warns, every declaration compiles and every mount resolves — the rows appear, empty, and the content the caller supplied is simply gone. Confirmed in a real browser: `<table id="seam"><tbody><tr></tr><tr></tr><tr></tr></tbody></table>`.

## `v/spread`'s two parity splits

**Override precedence.** `(v/spread base overrides)` states one rule — overrides wins every collision — and a collision is only a collision if something SEES it. `:class` and `:style` own a SLOT in the element rather than a place in the attribute map, so `{:x/class "base"}` and `{:class "override"}` are the same key twice. A raw `merge` saw two distinct map keys, kept both, and left the winner to whatever the downstream fold visited last. The two front ends fold in different orders, so one declaration answered `{:class "base"}` interpreted and `{:class "override"}` compiled — and `:x/style` against `:style` diverged the same way, red before promotion and blue after.

The projection now happens BEFORE the merge, inside `node/spread-attrs` — the one seam both modes call, so neither front end gains a branch. Keys go through `conv/attr-key`, identity for everything but the two slot-owning names.

**Literal nil.** `nil` is a defined value for a forwarded attribute map: the public function answers `{}`, and Spec 004 §Props forwarding pins a nil runtime map as an element with no attributes. The compiled analyzer judged the form's SHAPE by asking whether the first argument was nil — reading a present literal nil as an ABSENT argument — so `[:div (v/spread nil)]` refused to compile. A runtime expression whose value is nil compiled and rendered perfectly, so adding or removing an otherwise unnecessary local changed whether the same value was accepted. The shape is now judged by ARITY, the way the sibling foreign-component spread in the same namespace always has.

## Regressions

- A JVM suite drives one source body per admitted node kind through the analyzer and the React emitter and asserts the table covers `grammar/admitted-ops` exactly, so widening the grammar without widening the emitter reds at the emitter rather than in a consumer's build. It gains the call-site render-fn claim its own comment said was covered and was not.
- A browser suite mounts compiled inline, prop-carried and absent slots and reads the DOM back. Loading that file at all is the macro expansion that used to fail.
- A JVM suite drives `v/spread` precedence through BOTH front ends from one declaration across every accepted spelling — keyword, namespaced, string, symbol — holds down the composition obligation the routing carries (a `.sugar` shorthand must survive a winning override), proves an explicit nil override clears the slot however it is spelled, and asserts each map expression is evaluated once, base first.
- A JVM suite drives the literal and runtime-nil spreads side by side through both front ends — the pair whose disagreement was the defect — plus the arity and non-map failures that must survive.

Every new or changed test was probed for non-vacuity: each inverted assertion redded the full gate naming its own test, and each file was restored byte-identical.

## Gates

| gate | exit | result |
| --- | --- | --- |
| `implementation/freehand` `clojure -M:test` | 0 | 782 tests / 5551 assertions |
| `npm run test:freehand` | 0 | 729 tests / 4467 assertions |
| `npm run test:cljs` | 0 | 10854 tests / 54590 assertions |
| `npm run test:browser` | 0 | 641 tests / 3804 assertions |
