### PR TITLE
B-spine evidence: B1's DOM half, and the B2 mount storm made real

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/bench/b1.cljc
+++ b/implementation/freehand/src/re_frame/freehand/bench/b1.cljc
@@ -33,16 +33,21 @@
       far it moves. B1 is not allowed to conclude that compiled must win
       — the numbers are the input to that judgement, not the judgement.
 
-  ## The DOM half of the equal-output claim is not yet runnable
+  ## The DOM half of the equal-output claim
 
   D021's B1 row asks for equal tree AND equal DOM. The structural half is
-  gated here on both hosts. The browser half cannot be run yet: the
-  compiled tier's React lowering does not exist — `re-frame.freehand.react`
-  refuses a compiled declaration by name with
-  `:rf.error/view-lowering-unavailable` — so there is no compiled DOM to
-  compare an interpreted one against. The workload takes the structural
-  gate now and the DOM row joins it with that lowering, rather than the
-  measurement waiting for it.
+  gated here, on both hosts, every measured iteration. The DOM half is
+  gated in `re-frame.freehand.bench.b1-dom-cljs-test`, which mounts these
+  same two arms through `v/mount` into two real hosts and compares what
+  the browser built — element counts against this namespace's arithmetic,
+  and the hosts' own `innerHTML` serialisations against each other.
+
+  The two halves are deliberately in two places. Equal STRUCTURE is a
+  property of the workload and is checked on the iteration it measures,
+  so the timing it publishes is a timing of trees that were proven equal.
+  Equal DOM needs a browser, and a browser is not where a JVM sampling
+  run happens — so it is gated where a browser is, over the same
+  declarations, at the same fixture sizes.
 
   ## A small case beside the stress case
 

--- a/implementation/freehand/src/re_frame/freehand/bench/b2.cljc
+++ b/implementation/freehand/src/re_frame/freehand/bench/b2.cljc
@@ -60,12 +60,16 @@
   is the count AT SCALE — the exact number of ViewCell shells a mount of
   this roster omits, `verdict × mount count`, summed over the plan.
 
-  The mount TIME distribution and the live-heap retained-object reading
-  that D021's fuller B2 row also asks for are a different instrument: they
-  need the compiled tier's browser lowering (rf2-drpa3.113), which mounts
-  a compiled boundary in a real root, and join this workload with that
-  slice. Until then B2 measures the exact quantity that IS decidable
-  without a mount, and does not sell a static count as a runtime one.
+  The mount TIME distribution and the runtime retained-shell reading that
+  D021's fuller B2 row also asks for are a different instrument, and they
+  live where a mount can happen: `re-frame.freehand.bench.b2-dom-cljs-test`
+  mounts this very roster — beside its interpreted twins in
+  [[re-frame.freehand.bench.b2.interpreted]] — in a real browser, counts
+  the occurrences off `document`, reads back the wrapper React actually
+  reconciled for each declaration, and cross-checks the runtime omission
+  total against [[omitted]] over the same plan. What is measured here is
+  the exact quantity that is decidable WITHOUT a mount, and nothing in
+  this namespace sells a static count as a runtime one.
 
   ## A small case beside the stress case
 
@@ -154,21 +158,30 @@
 ;; The roster and the mount plan
 ;; ---------------------------------------------------------------------------
 
-(def ^:private free-views
+(def free-views
   "The capability-free arm's declaration types. Every one is proven
   elidable by its manifest — a claim the workload re-checks each run
-  rather than trusts this vector for."
+  rather than trusts this vector for.
+
+  Public because the mount storm mounts this roster rather than a copy of
+  it: a browser fixture that listed its own four types could drift from
+  the four the gate counts, and then the two halves of B2 would be about
+  different rosters."
   [free-label free-card free-list free-nested])
 
-(def ^:private read-views
+(def read-views
   "The three-read arm's declaration types. Every one carries three
-  reactive reads and keeps its ViewCell."
+  reactive reads and keeps its ViewCell. Public for the same reason
+  [[free-views]] is."
   [read-panel read-row read-widget])
 
-(defn- plan
+(defn plan
   "A mount plan for `views` at `scale`: `[[view mount-count] …]`, each type
   mounted `scale` times. Scale is a fixture parameter — the storm's size
-  is a size, not a language constant."
+  is a size, not a language constant.
+
+  Public so the browser mount builds its plan the same way this workload
+  does, and can hand the very plan it mounted to [[omitted]]."
   [views scale]
   (mapv (fn [view] [view scale]) views))
 
@@ -176,11 +189,17 @@
   [view]
   (:view-cell (v/manifest view)))
 
-(defn- omitted
+(defn omitted
   "The exact number of boundaries in `mount-plan` whose compiled lowering
   OMITS the ViewCell — each type's manifest verdict times its mount count.
   Read off the manifest every call, so a type that stopped eliding drops
-  its whole mount count out of this total and reds the gate."
+  its whole mount count out of this total and reds the gate.
+
+  Public so the browser mount can put this static prediction beside the
+  omissions it counted off a page, and require them to agree. An
+  interpreted plan answers zero here — an interpreted declaration carries
+  no manifest and therefore no verdict, which is the honest arithmetic
+  for a mode that cannot prove a body sub-free."
   [mount-plan]
   (reduce (fn [n [view mounts]]
             (+ n (if (= :elided (verdict view)) mounts 0)))

--- a/implementation/freehand/src/re_frame/freehand/bench/b2/interpreted.cljc
+++ b/implementation/freehand/src/re_frame/freehand/bench/b2/interpreted.cljc
@@ -1,0 +1,94 @@
+(ns re-frame.freehand.bench.b2.interpreted
+  "B2's roster, INTERPRETED — the matched arm the elision claim is
+  measured against.
+
+  [[re-frame.freehand.bench.b2]] declares the same seven views with
+  `{:compiled true}` and nothing else changed; `compiled-source-delta-jvm-test`
+  reads both files and proves it. That sameness is what makes the
+  comparison a comparison of LOWERINGS: a mount storm of two rosters that
+  are not the same roster is a mount storm of two rosters.
+
+  These declarations carry no manifest — the interpreted mode has no
+  finite grammar and no analysis step, so there is nothing it could
+  claim — and therefore no elision verdict. Every one of them mounts
+  inside the atomic shell, including the four whose compiled twins are
+  proven not to need it. That is the whole of what B2 measures, stated as
+  two files: the compiled tier drops shells it can prove unnecessary, and
+  interpretation keeps them because it cannot prove anything.
+
+  Normative owner: `docs/design/freehand/decisions/`
+  `D021-performance-budgets-and-release-evidence.md`."
+  (:require [re-frame.freehand :as v]))
+
+;; ---------------------------------------------------------------------------
+;; The capability-free arm's twins — elidable when compiled, kept here
+;; ---------------------------------------------------------------------------
+
+(v/defview free-label
+  "Pure text under one element — the smallest elidable leaf."
+  [{:keys [text]}]
+  [:span.label text])
+
+(v/defview free-card
+  "Structure forwarding children beneath an owned heading. Forwarding
+  children is not a reactive read, so the shell stays elided."
+  [{:keys [title children]}]
+  [:section.card [:h3.card__title title] children])
+
+(v/defview free-list
+  "A keyed list. A `for` run is finite structure, not a reactive site, so
+  a list of static rows omits the ViewCell like any other inert body."
+  [{:keys [items]}]
+  [:ul.list
+   (for [i items]
+     [:li.item {:key i} i])])
+
+(v/defview free-nested
+  "Nested plain elements — depth is not a reactive read either, so the
+  deepest inert body is still elidable."
+  [{:keys [text]}]
+  [:div.host [:div.inner [:span.leaf text]]])
+
+;; ---------------------------------------------------------------------------
+;; The three-read arm's twins — reactive in both modes
+;; ---------------------------------------------------------------------------
+
+(v/defview read-panel
+  "Two subscriptions and a committed event handler — three reactive reads,
+  one retained ViewCell."
+  [{:keys [id]}]
+  [:section.panel
+   [:output.total (v/sub [:panel/total id])]
+   [:output.count (v/sub [:panel/count id])]
+   [:button.act {:on-click [:panel/act id]} "act"]])
+
+(v/defview read-row
+  "One subscription and two committed event handlers — three reactive
+  reads over one boundary. Many sites, one shell."
+  [{:keys [id]}]
+  [:tr.row
+   [:td.val (v/sub [:row/value id])]
+   [:td [:button.up {:on-click [:row/up id]} "+"]]
+   [:td [:button.down {:on-click [:row/down id]} "-"]]])
+
+(v/defview read-widget
+  "Three subscriptions — three reactive reads, no events, still one
+  retained ViewCell. A view is reactive because it READS state, however
+  it reads it."
+  [{:keys [id]}]
+  [:div.widget
+   [:span.a (v/sub [:widget/a id])]
+   [:span.b (v/sub [:widget/b id])]
+   [:span.c (v/sub [:widget/c id])]])
+
+;; ---------------------------------------------------------------------------
+;; The rosters, in the order the compiled file declares them
+;; ---------------------------------------------------------------------------
+
+(def free-views
+  "The capability-free arm's interpreted twins, in declaration order."
+  [free-label free-card free-list free-nested])
+
+(def read-views
+  "The three-read arm's interpreted twins, in declaration order."
+  [read-panel read-row read-widget])

--- a/implementation/freehand/test/re_frame/freehand/bench/b1_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b1_dom_cljs_test.cljs
@@ -1,0 +1,240 @@
+(ns re-frame.freehand.bench.b1-dom-cljs-test
+  "B1's DOM row — the half of D021's equal-output claim that needed a real
+  browser.
+
+  D021's B1 row asks for equal tree AND equal DOM over one finite
+  template, both lowerings. [[re-frame.freehand.bench.b1]] has always
+  gated the tree half: it renders both arms every iteration and requires
+  their structural output to be equal, on both hosts. The DOM half had no
+  instrument — the compiled tier carried no browser lowering, so a
+  compiled declaration handed to the React emitter was refused by name
+  and there was no compiled DOM to compare an interpreted one against.
+
+  There is now. This file mounts the SAME two arms the workload measures
+  — [[re-frame.freehand.bench.b1.interpreted/template]] and its
+  `{:compiled true}` twin — through `v/mount` into real hosts at both
+  fixture sizes, and compares what the browser actually built.
+
+  ## What is gated here, and what is not
+
+  Everything below is DETERMINISTIC and gates. `innerHTML` equality, an
+  element count against written arithmetic, and the structural parity the
+  workload already gates are exact properties of a correct run,
+  reproducible on any host. Nothing here reads a clock: B1's timings are
+  the workload's, they are published as evidence, and a DOM row that grew
+  a duration assertion would be the folklore threshold D021 forbids.
+
+  ## Why `innerHTML`, and why it can fail
+
+  `innerHTML` is the browser's own serialisation of everything a mount
+  produced — tags, nesting, order, attribute names and values, composed
+  classes and text. Comparing it compares the whole page rather than the
+  handful of selectors a reader thought to check. It is also why
+  [[the-dom-comparison-can-fail]] exists: a comparison nobody has watched
+  answer `false` is not evidence that two things agree.
+
+  ## One mount at a time
+
+  Every mount below is awaited before the next begins. Two overlapping
+  React `act` boundaries are not a supported state — React says so — and
+  a page assembled inside one would be evidence about act's queue rather
+  than about two lowerings. Each arm also mounts under its own
+  `:disambiguator`, because a root-id is page-unique identity and two
+  occurrences of one view are two occurrences.
+
+  Normative owner: `docs/design/freehand/decisions/`
+  `D021-performance-budgets-and-release-evidence.md`."
+  (:require ["react" :as react]
+            [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.bench.b1 :as b1]
+            [re-frame.freehand.bench.b1.compiled :as compiled]
+            [re-frame.freehand.bench.b1.interpreted :as interpreted]
+            [re-frame.freehand.react :as fr]
+            [re-frame.freehand.root :as root]))
+
+;; ---------------------------------------------------------------------------
+;; The fixture sizes — parameters, not language constants
+;; ---------------------------------------------------------------------------
+
+(def ^:private stress-rows
+  "The stress size, in D021's 10³-node band and the size B1's registered
+  stress workload renders."
+  250)
+
+(def ^:private small-rows
+  "The small realistic case D021 requires beside every stress case."
+  6)
+
+(defn expected-elements
+  "The exact number of ELEMENTS the template mounts for `rows`.
+
+  Stated as arithmetic rather than measured, so the count gates against a
+  written expectation instead of against whatever the mount happened to
+  produce. Three for the skeleton — the section, the heading and the list
+  — then four per row: the row, its index, its label and its badge. Text
+  is a DOM node but not an element, which is the one place this differs
+  from [[re-frame.freehand.bench.b1/expected-nodes]]."
+  [rows]
+  (+ 3 (* 4 rows)))
+
+;; ---------------------------------------------------------------------------
+;; Mounting
+;; ---------------------------------------------------------------------------
+
+(defn- browser? []
+  (and (exists? js/document) (some? (.-createElement js/document))))
+
+(defn- skip! [why]
+  (is true (str "a real React mount needs a DOM host — " why)))
+
+(defn- act
+  "A React 19 `act` boundary as a promise, so assertions run after the
+  commit rather than racing it."
+  [thunk]
+  (try
+    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+    (js/Promise.resolve (react/act (fn [] (js/Promise.resolve (thunk)))))
+    (catch :default e
+      (js/Promise.reject e))))
+
+(defn- mount-arm!
+  "Mount `view` over `rows` under `tag`, answering a promise of
+  `{:container … :mounted …}`. A rejected mount takes its own host node
+  back out of the document, so a failure leaves nothing behind for the
+  next suite to trip over."
+  [view rows tag]
+  (let [container (js/document.createElement "div")]
+    (.appendChild js/document.body container)
+    (-> (act #(v/mount [view {:rows rows}] container {:disambiguator tag}))
+        (.then (fn [mounted] {:container container :mounted mounted}))
+        (.catch (fn [e] (.remove container) (js/Promise.reject e))))))
+
+(defn- release! [arms]
+  (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+  (doseq [{:keys [container mounted]} arms]
+    (when (some? mounted)
+      (.unmount (.-react-root ^root/Root mounted)))
+    (.remove container))
+  nil)
+
+(defn- with-mounts!
+  "Mount each `[view rows tag]` of `specs` IN TURN, hand the mounted arms
+  to `f`, then release every one of them and call `done` — whatever
+  happened. The release is in a `finally` rather than on the happy path
+  because a leaked live root is page-global state, and the suite that
+  inherits it fails for a reason nobody can read off its own source."
+  [specs f done]
+  (let [arms (atom [])]
+    (-> (reduce (fn [p [view rows tag]]
+                  (.then p (fn [_]
+                             (-> (mount-arm! view rows tag)
+                                 (.then (fn [arm] (swap! arms conj arm) nil))))))
+                (js/Promise.resolve nil)
+                specs)
+        (.then (fn [_] (f @arms)))
+        (.catch (fn [e] (is false (str "a B1 arm's mount rejected: " e))))
+        (.finally (fn [] (release! @arms) (done))))))
+
+(use-fixtures :each
+  ;; The boundary cache and the live-root registry are process-global, so
+  ;; a boundary left over from an earlier suite — or an earlier run of
+  ;; this file — could hand React a component minted for a different
+  ;; declaration generation and make an equality below true for the wrong
+  ;; reason.
+  {:before (fn [] (root/reset-registry!) (fr/reset-boundaries!))
+   :after  (fn [] (root/reset-registry!) (fr/reset-boundaries!))})
+
+;; ===========================================================================
+;; Equal tree AND equal DOM — D021's B1 row, both halves
+;; ===========================================================================
+
+(defn- equal-output-at!
+  "Mount both arms at `rows` and assert D021's B1 equal-output row over
+  them: the same structural tree, the same element count, and the same
+  DOM."
+  [rows done]
+  (with-mounts!
+    [[interpreted/template rows :interpreted]
+     [compiled/template rows :compiled]]
+    (fn [[i c]]
+      (let [i-html (.-innerHTML (:container i))
+            c-html (.-innerHTML (:container c))]
+        (is (true? (:B1/structural-parity (b1/observe {:rows rows})))
+            (str "the tree half at " rows
+                 " rows: both arms rendered the same structural tree"))
+        (is (= (expected-elements rows)
+               (.-length (.querySelectorAll (:container i) "*")))
+            (str "the interpreted mount built the " (expected-elements rows)
+                 " elements the template's arithmetic predicts"))
+        (is (= (expected-elements rows)
+               (.-length (.querySelectorAll (:container c) "*")))
+            "and so did the compiled mount")
+        (is (= i-html c-html)
+            (str "the DOM half at " rows
+                 " rows: the browser built the same page from both lowerings"))
+        (is (pos? (count i-html))
+            "and it built a page, rather than nothing at all")))
+    done))
+
+(deftest the-b1-template-mounts-as-the-same-dom-in-both-lowerings-at-stress
+  (testing "D021's B1 row, whole, at the stress size the registered
+            workload renders: one boundary over a finite 10³-node
+            template produces the same structural tree AND the same real
+            DOM interpreted as compiled. The two arms are the same
+            declaration plus `{:compiled true}` — `compiled-source-delta-jvm-test`
+            reads both files and proves it — so a difference here would
+            be promotion changing the page, which is the one thing B1's
+            timing comparison is not allowed to be hiding."
+    (if-not (browser?)
+      (skip! "the browser job runs the mount assertions")
+      (async done (equal-output-at! stress-rows done)))))
+
+(deftest the-b1-template-mounts-as-the-same-dom-in-both-lowerings-at-small
+  (testing "The same row at the small realistic size D021 requires beside
+            every stress case, so equal output is not a property of one
+            synthetic extreme."
+    (if-not (browser?)
+      (skip! "the browser job runs the mount assertions")
+      (async done (equal-output-at! small-rows done)))))
+
+;; ===========================================================================
+;; Non-vacuity
+;; ===========================================================================
+
+(deftest the-dom-comparison-can-fail
+  (testing "The row above is `=` over two `innerHTML` strings, and a
+            comparison nobody has watched answer false is not evidence
+            that two things agree. So: the same arm at two DIFFERENT
+            sizes, through the same mount path, compared the same way. It
+            must disagree — and if it ever does not, every equality in
+            this file is passing for a reason that has nothing to do with
+            the lowerings."
+    (if-not (browser?)
+      (skip! "the browser job runs the mount assertions")
+      (async done
+        (with-mounts!
+          [[compiled/template small-rows :one-size]
+           [compiled/template (inc small-rows) :another-size]]
+          (fn [[a b]]
+            (is (not= (.-innerHTML (:container a)) (.-innerHTML (:container b)))
+                "one row's difference is visible to the comparison the
+                 equal-output row is made with"))
+          done)))))
+
+(deftest the-two-arms-really-are-two-lowerings
+  (testing "Equal DOM is only a claim about promotion if the arms were
+            promoted. One is declared `{:compiled true}` and one is not,
+            and they carry the same authored template — the element
+            arithmetic above is written once and gates both mounts, which
+            is the check that they are the same template stated as a
+            number rather than as a comment."
+    (is (= :interpreted (:lowering (v/describe interpreted/template)))
+        "the reference arm is genuinely interpreted")
+    (is (= :compiled (:lowering (v/describe compiled/template)))
+        "and the compared arm is genuinely compiled")
+    (is (not= (:view-id (v/describe interpreted/template))
+              (:view-id (v/describe compiled/template)))
+        "they are two declarations, in two namespaces, as the workload requires")
+    (is (= (+ 3 (* 4 stress-rows)) (expected-elements stress-rows))
+        "and the element arithmetic is arithmetic, not a recorded observation")))

--- a/implementation/freehand/test/re_frame/freehand/bench/b2_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b2_dom_cljs_test.cljs
@@ -1,0 +1,467 @@
+(ns re-frame.freehand.bench.b2-dom-cljs-test
+  "B2's mount storm, actually mounted.
+
+  [[re-frame.freehand.bench.b2]] gates the exact number of ViewCell shells
+  a mount of its roster omits, read off each declaration's manifest. That
+  count is decidable without a mount and is deliberately taken without
+  one — but it left the rest of D021's B2 row unowned. A cells-shaped
+  mount storm, compared as interpreted, compiled-retained and
+  compiled-elided, publishing mount time and RETAINED runtime shells, is a
+  claim about a page; the static workload put no page on screen.
+
+  This file mounts one. The same roster, at two scales, through four arms:
+
+    - the capability-free roster INTERPRETED — every shell retained,
+      because interpretation cannot prove a body sub-free;
+    - the same roster COMPILED — every shell elided, by proof;
+    - the three-read roster INTERPRETED and COMPILED — every shell
+      retained in both, because the bodies really do read state.
+
+  The free pair is the elision comparison and the read pair is the
+  control: without the read pair, a runtime omission count of zero and a
+  mis-targeted probe would be the same reading.
+
+  ## Deterministic here; evidence there
+
+    - DETERMINISTIC, and these gate: the number of occurrences of each
+      declaration counted off `document`; the wrapper React actually
+      reconciled for each declaration; the runtime omitted/retained shell
+      totals folded from those two; their agreement with
+      [[re-frame.freehand.bench.b2/omitted]] over the very plan that was
+      mounted; and `innerHTML` equality between each arm and its twin, so
+      the comparison is over matched observable output.
+    - EVIDENCE, and this gates nothing: mount wall time. It is summarised
+      as a distribution, published with its provenance, and has no route
+      to a verdict — a mount-time threshold in a browser test is the
+      folklore threshold D021 forbids, and would be measuring the CI
+      runner.
+
+  ## What the retained count is, and what it is not
+
+  `total - manifest-omitted` is arithmetic on a static verdict, and
+  calling it a runtime retained-object count would be a category error.
+  The number published here is folded from two RUNTIME observations: how
+  many occurrences of a declaration the browser actually built
+  (`querySelectorAll`), and which wrapper React actually reconciled for
+  it (the emitter's boundary cache, whose signature is minted when the
+  component is). Neither factor is read off the manifest. The manifest's
+  prediction is then required to agree with it, which is the cross-check
+  rather than the source.
+
+  ## Provenance, in a browser
+
+  A browser has no environment and no git. `re-frame.freehand.bench.provenance`
+  says what to do about that: a bundle that is going to be measured names
+  its revision at compile time through the documented closure-define, and
+  a bundle that does not cannot emit a citable record. This test build
+  does not set it, so the record published below is complete in every
+  field EXCEPT the revision — which is gated, so a record that lost its
+  fixture scale, build mode or host would red. A release-lane run sets
+  the define and the record becomes emittable with no change here.
+
+  The records go to the browser console as EDN, which the browser runner
+  buffers and flushes on failure or under `RF2_VERBOSE_TESTS=1`. A run
+  that wants the evidence therefore asks for it:
+
+      RF2_VERBOSE_TESTS=1 npm run test:browser
+
+  Normative owner: `docs/design/freehand/decisions/`
+  `D021-performance-budgets-and-release-evidence.md`."
+  (:require ["react" :as react]
+            [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as react-substrate]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.bench.b2 :as b2]
+            [re-frame.freehand.bench.b2.interpreted :as b2i]
+            [re-frame.freehand.bench.measure :as m]
+            [re-frame.freehand.bench.provenance :as prov]
+            [re-frame.freehand.react :as fr]
+            [re-frame.freehand.root :as root]
+            [re-frame.live-frame :as live-frame]
+            [re-frame.test-support :as test-support]))
+
+;; ---------------------------------------------------------------------------
+;; The fixture parameters — sizes, not language constants
+;; ---------------------------------------------------------------------------
+
+(def ^:private stress-scale
+  "Per-type occurrence count for the mounted storm.
+
+  Its own parameter, deliberately not the static workload's: that
+  workload sums manifest verdicts and its size costs arithmetic, while
+  this one builds every boundary in a real browser inside the suite's
+  wall-clock budget. Both are fixture parameters and both are published,
+  so no reader has to guess which storm a number came from."
+  50)
+
+(def ^:private small-scale
+  "The small realistic case D021 requires beside every stress case."
+  2)
+
+(def ^:private samples 5)
+(def ^:private warmup 1)
+
+;; ---------------------------------------------------------------------------
+;; The arms, and how an occurrence of each is recognised in the DOM
+;; ---------------------------------------------------------------------------
+
+(def ^:private free-selectors
+  "One selector per capability-free declaration, in roster order — the
+  outermost element each body renders, so a match is one occurrence."
+  ["span.label" "section.card" "ul.list" "div.host"])
+
+(def ^:private read-selectors
+  "One selector per three-read declaration, in roster order."
+  ["section.panel" "tr.row" "div.widget"])
+
+(def ^:private arms
+  "The four mounted arms.
+
+  `:lowering` and `:view-cell` are the WRITTEN expectation each arm's
+  runtime census is gated against — the wrapper signature React must be
+  observed to have reconciled for every declaration in the roster. They
+  are written here rather than derived from the declarations, because a
+  gate that computes its expectation the way the subject computes its
+  answer is not a gate."
+  [{:id :free/interpreted :roster b2i/free-views :selectors free-selectors
+    :lowering :interpreted :view-cell nil}
+   {:id :free/compiled    :roster b2/free-views  :selectors free-selectors
+    :lowering :compiled    :view-cell :elided}
+   {:id :read/interpreted :roster b2i/read-views :selectors read-selectors
+    :lowering :interpreted :view-cell nil}
+   {:id :read/compiled    :roster b2/read-views  :selectors read-selectors
+    :lowering :compiled    :view-cell :present}])
+
+(def ^:private matched-pairs
+  "Which arms must produce the same page. Promotion may change the
+  wrapper; it may not change the DOM."
+  [[:free/interpreted :free/compiled]
+   [:read/interpreted :read/compiled]])
+
+;; ---------------------------------------------------------------------------
+;; The mount host
+;; ---------------------------------------------------------------------------
+
+(def ^:private fid :b2-dom/frame)
+
+(v/defview storm
+  "The storm: `scale` occurrences of every declaration in `roster`.
+
+  Interpreted, and deliberately so — it is the harness, not an arm. One
+  prop map serves every declaration because the rosters destructure
+  disjoint keys, which keeps the occurrences of the four types identical
+  across arms without a per-type fixture table nobody would keep matched."
+  [{:keys [roster scale]}]
+  [:div.storm
+   (for [[t view] (map-indexed vector roster)]
+     [:div.type {:key t}
+      (for [i (range scale)]
+        [view {:key i :text "leaf" :title "card" :items [0 1] :id i}])])])
+
+(defn- register! []
+  (rf/reg-sub :panel/total (fn [db [_ id]] (+ id (:base db))))
+  (rf/reg-sub :panel/count (fn [db [_ id]] (- id (:base db))))
+  (rf/reg-sub :row/value   (fn [db [_ id]] (* id (:base db))))
+  (rf/reg-sub :widget/a    (fn [db [_ id]] (:base db)))
+  (rf/reg-sub :widget/b    (fn [db [_ id]] id))
+  (rf/reg-sub :widget/c    (fn [db _] (:base db)))
+  (rf/reg-event :panel/act  (fn [{:keys [db]} _] {:db db}))
+  (rf/reg-event :row/up     (fn [{:keys [db]} _] {:db db}))
+  (rf/reg-event :row/down   (fn [{:keys [db]} _] {:db db})))
+
+(defn- seed! []
+  (live-frame/make-frame {:id fid})
+  (frame/replace-app-db! fid {:base 2})
+  fid)
+
+;; ---------------------------------------------------------------------------
+;; Mounting
+;; ---------------------------------------------------------------------------
+
+(defn- browser? []
+  (and (exists? js/document) (some? (.-createElement js/document))))
+
+(defn- skip! [why]
+  (is true (str "a real React mount needs a DOM host — " why)))
+
+(defn- act
+  [thunk]
+  (try
+    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+    (js/Promise.resolve (react/act (fn [] (js/Promise.resolve (thunk)))))
+    (catch :default e
+      (js/Promise.reject e))))
+
+(defn- release! [arm]
+  (when arm
+    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+    (when-let [mounted (:mounted arm)]
+      (.unmount (.-react-root ^root/Root mounted)))
+    (.remove (:container arm)))
+  nil)
+
+(defn- mount-once!
+  "One mount of `roster` at `scale`, timed.
+
+  The two clock readings bracket the mount and nothing else: the census
+  and every assertion happen afterwards, outside the reading, which is
+  the same measurement-boundary discipline the structural arms keep."
+  [roster scale tag]
+  (let [container (js/document.createElement "div")]
+    (.appendChild js/document.body container)
+    (let [t0 (m/now-ms)]
+      (-> (act #(v/mount [storm {:roster roster :scale scale}] container
+                         {:frame fid :disambiguator tag}))
+          (.then (fn [mounted]
+                   {:container container :mounted mounted :ms (- (m/now-ms) t0)}))
+          (.catch (fn [e] (.remove container) (js/Promise.reject e)))))))
+
+(defn- sample-arm!
+  "Mount and release the arm `(+ warmup samples)` times in turn, keeping
+  the LAST mount live for the assertions and answering the measured
+  mounts' wall times. Never two mounts at once: overlapping React `act`
+  boundaries are unsupported, and a storm assembled inside one would be
+  evidence about act's queue."
+  [{:keys [id roster]} scale]
+  (let [times (atom [])]
+    (-> (reduce (fn [p i]
+                  (.then p (fn [prev]
+                             (release! prev)
+                             (-> (mount-once! roster scale
+                                              (keyword "b2" (str (namespace id) "-"
+                                                                 (name id) "-" i)))
+                                 (.then (fn [arm]
+                                          (when (>= i warmup) (swap! times conj (:ms arm)))
+                                          arm))))))
+                (js/Promise.resolve nil)
+                (range (+ warmup samples)))
+        (.then (fn [live] (assoc live :samples @times))))))
+
+(def ^:private runtime-fixture
+  (test-support/make-reset-runtime-fixture
+    {:adapter       react-substrate/adapter
+     :ambient-frame nil
+     :async?        true}))
+
+(use-fixtures :each
+  {:before (fn []
+             (root/reset-registry!)
+             (fr/reset-boundaries!)
+             ((:before runtime-fixture)))
+   :after  (fn []
+             ((:after runtime-fixture))
+             (root/reset-registry!)
+             (fr/reset-boundaries!))})
+
+;; ---------------------------------------------------------------------------
+;; The two runtime witnesses
+;; ---------------------------------------------------------------------------
+
+(defn- occurrences
+  "How many occurrences of each declaration the BROWSER built — one
+  `querySelectorAll` per roster entry, in roster order."
+  [container selectors]
+  (mapv #(.-length (.querySelectorAll container %)) selectors))
+
+(defn- reconciled-wrapper
+  "The wrapper React actually ran for `view`: the signature of the
+  component the emitter minted and reconciled on, `[lowering view-cell]`.
+  Read off the boundary cache, which is written when the component is
+  built — so this is what happened, not what a manifest predicted."
+  [view]
+  (:signature (get (fr/boundary-cache) (:view-id (v/describe view)))))
+
+(defn- shell-census
+  "The arm's RUNTIME shell census: each declaration's mounted occurrence
+  count, filed under the wrapper React reconciled for it.
+
+  Both inputs are observations of a live page. Nothing here subtracts a
+  manifest verdict from a mount count — the manifest's own prediction is
+  compared against this total afterwards, which is the cross-check and
+  not the source."
+  [container roster selectors]
+  (reduce (fn [acc [view sel]]
+            (let [n (.-length (.querySelectorAll container sel))]
+              (if (= :elided (second (reconciled-wrapper view)))
+                (update acc :omitted-shells + n)
+                (update acc :retained-shells + n))))
+          {:omitted-shells 0 :retained-shells 0}
+          (map vector roster selectors)))
+
+;; ---------------------------------------------------------------------------
+;; The published record
+;; ---------------------------------------------------------------------------
+
+(defn evidence-record
+  "The result record for one mounted arm — every provenance field D021
+  requires that a browser can name, the mount-time distribution, and the
+  runtime census as a published property.
+
+  Public because a record nobody can build outside the assertion that
+  publishes it is a record nobody can check."
+  [{:keys [id]} scale census counts times]
+  {:benchmark    (keyword "B2" (str "mounted-" (namespace id) "-" (name id)))
+   :doc          "a cells-shaped mount storm, mounted in a real browser"
+   :revision     (prov/detect-revision)
+   :fixture      {:arm                 id
+                  :scale               scale
+                  :occurrences         counts
+                  :boundaries          (reduce + 0 counts)
+                  :measurement-method
+                  (str "wall time bracketing one v/mount inside a React act boundary, "
+                       "host node to committed DOM; shells are folded from two runtime "
+                       "readings — each declaration's occurrence count off document, and "
+                       "the wrapper signature React reconciled for it")}
+   :build        (prov/detect-build)
+   :host         (prov/detect-host)
+   :sampling     {:warmup warmup :samples (count times)}
+   :baseline     {:kind      :interpreted-vs-compiled
+                  :reference {:arm  :interpreted
+                              :note (str "the interpreted arm of the same roster, mounted at "
+                                         "the same scale into the same page")}}
+   :distribution {:B2/mount-ms (assoc (m/summarise times)
+                                      :doc        "wall time for one mount of the storm"
+                                      :observable :duration-ms)}
+   :properties   census
+   :status       :evidence})
+
+(defn- publish!
+  "Write the record to the console as EDN, prefixed with whether it is
+  citable. Evidence that is not attributable to a revision is still worth
+  reading and is not worth citing, and the line says which it is."
+  [record]
+  (let [ds (prov/defects record)]
+    (js/console.log
+      (str ";; B2 mounted-storm evidence — "
+           (if (seq ds)
+             (str "NOT CITABLE (" (count ds) " provenance field(s) unnamed by this build)")
+             "citable")
+           "\n" (pr-str record)))))
+
+;; ===========================================================================
+;; The storm, mounted — every deterministic claim at one scale
+;; ===========================================================================
+
+(defn- assert-arm!
+  "Every deterministic claim about one mounted arm, plus its published
+  evidence. Answers the arm's `innerHTML` so the matched-output check can
+  compare twins."
+  [{:keys [id roster selectors lowering view-cell] :as arm} scale live]
+  (let [{:keys [container samples]} live
+        counts  (occurrences container selectors)
+        census  (shell-census container roster selectors)
+        plan    (b2/plan roster scale)
+        elides? (= :elided view-cell)
+        total   (reduce + 0 counts)]
+    (is (= (vec (repeat (count selectors) scale)) counts)
+        (str id ": every declared occurrence mounted — " scale
+             " of each of " (count selectors) " declarations, counted off document"))
+    (doseq [[view sel] (map vector roster selectors)]
+      (let [sig (reconciled-wrapper view)]
+        (is (some? sig)
+            (str id " / " sel ": React minted a boundary for this declaration"))
+        (is (= [lowering view-cell] sig)
+            (str id " / " sel ": React reconciled the wrapper this declaration earned"))))
+    (is (= (if elides? total 0) (:omitted-shells census))
+        (str id ": the shells the mount actually omitted"))
+    (is (= (if elides? 0 total) (:retained-shells census))
+        (str id ": the shells the mount actually retained"))
+    (is (= (b2/omitted plan) (:omitted-shells census))
+        (str id ": the manifest's static prediction and the mounted page agree "
+             "about how many shells this storm omits"))
+    (publish! (evidence-record arm scale census counts samples))
+    (.-innerHTML container)))
+
+(defn- storm-at!
+  [scale done]
+  (register!)
+  (seed!)
+  (let [pages (atom {})]
+    (-> (reduce (fn [p arm]
+                  (.then p (fn [prev]
+                             (release! prev)
+                             (-> (sample-arm! arm scale)
+                                 (.then (fn [live]
+                                          (swap! pages assoc (:id arm)
+                                                 (assert-arm! arm scale live))
+                                          live))))))
+                (js/Promise.resolve nil)
+                arms)
+        (.then (fn [live]
+                 (release! live)
+                 (doseq [[a b] matched-pairs]
+                   (is (= (get @pages a) (get @pages b))
+                       (str a " and " b
+                            " built the same page — the arms differ by lowering, "
+                            "so the comparison is over matched observable output")))
+                 (is (every? pos? (map count (vals @pages)))
+                     "and every arm built a page, rather than nothing at all")))
+        (.catch (fn [e] (is false (str "a B2 arm's mount rejected: " e))))
+        (.finally done))))
+
+(deftest the-mount-storm-mounts-and-elides-at-stress-scale
+  (testing "D021's B2 row as a mount rather than an arithmetic: the
+            capability-free roster and the three-read roster, each in both
+            lowerings, mounted at the storm scale. Every declared
+            occurrence is counted off `document`; the wrapper React
+            reconciled for each declaration is read back off the emitter's
+            own cache; and the omitted-shell total those two produce is
+            required to equal what the manifest predicted for the very
+            plan that was mounted."
+    (if-not (browser?)
+      (skip! "the browser job runs the mount storm")
+      (async done (storm-at! stress-scale done)))))
+
+(deftest the-mount-storm-mounts-and-elides-at-small-scale
+  (testing "The same storm at the small realistic size D021 requires
+            beside every stress case, so the elision claim is not a
+            property of one synthetic extreme."
+    (if-not (browser?)
+      (skip! "the browser job runs the mount storm")
+      (async done (storm-at! small-scale done)))))
+
+;; ===========================================================================
+;; Non-vacuity
+;; ===========================================================================
+
+(deftest the-two-lowerings-really-do-disagree-about-the-shell
+  (testing "Every count above is only evidence of elision if the arms
+            disagree about whether a shell is needed. The compiled free
+            roster claims `:elided` and carries a manifest; its
+            interpreted twin carries none, and a mode with no analysis
+            cannot elide anything. If those ever coincide, an omitted
+            count of zero and an omitted count of everything become the
+            same reading."
+    (doseq [[c i] (map vector b2/free-views b2i/free-views)]
+      (is (= :compiled (:lowering (v/describe c))) "the compiled roster is compiled")
+      (is (= :interpreted (:lowering (v/describe i))) "and its twin is interpreted")
+      (is (= :elided (:view-cell (v/manifest c))) "the compiled twin elides its shell")
+      (is (nil? (v/manifest i)) "and the interpreted twin has no analysis to elide with"))
+    (doseq [[c i] (map vector b2/read-views b2i/read-views)]
+      (is (= :present (:view-cell (v/manifest c)))
+          "a three-read declaration keeps its shell even compiled")
+      (is (nil? (v/manifest i)) "and its interpreted twin keeps one too, unproven"))
+    (is (pos? (b2/omitted (b2/plan b2/free-views stress-scale)))
+        "the static prediction the mount is cross-checked against is not zero")
+    (is (zero? (b2/omitted (b2/plan b2i/free-views stress-scale)))
+        "and an interpreted plan predicts no omissions at all")))
+
+(deftest the-published-record-names-everything-but-the-revision
+  (testing "The published evidence is gated on its PROVENANCE, which is
+            the one thing about a number that is deterministic. Every
+            field D021 requires must be named — fixture scale, build
+            mode, runtime, hardware class, sampling policy, baseline,
+            distribution — and only the revision may be missing, because
+            a browser has no git and this test build does not compile one
+            in. A record that quietly lost its scale or its build mode
+            would red here."
+    (let [census {:omitted-shells 8 :retained-shells 0}
+          record (evidence-record (first arms) small-scale census [2 2 2 2] [1.0 2.0 3.0])]
+      (is (empty? (remove #(= [:revision] (:path %)) (prov/defects record)))
+          "every provenance field a browser can name is named")
+      (is (= 3 (:n (:B2/mount-ms (:distribution record))))
+          "the distribution summarises the samples it was given")
+      (is (= :duration-ms (:observable (:B2/mount-ms (:distribution record))))
+          "and mount time is a duration — which is what makes it evidence and not a gate"))))

--- a/implementation/freehand/test/re_frame/freehand/compiled_source_delta_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/compiled_source_delta_jvm_test.clj
@@ -57,7 +57,10 @@
     :compiled    "re_frame/freehand/compiled_views.cljc"}
    {:what        "the B1 measurement arms"
     :interpreted "re_frame/freehand/bench/b1/interpreted.cljc"
-    :compiled    "re_frame/freehand/bench/b1/compiled.cljc"}])
+    :compiled    "re_frame/freehand/bench/b1/compiled.cljc"}
+   {:what        "the B2 mount-storm roster"
+    :interpreted "re_frame/freehand/bench/b2/interpreted.cljc"
+    :compiled    "re_frame/freehand/bench/b2.cljc"}])
 
 (deftest promotion-is-exactly-one-option-map
   (testing "Every compiled twin is its interpreted original plus


### PR DESCRIPTION
The B-spine evidence beads that were waiting on the compiled tier's
browser lowering. That lowering has landed, so the previously-unrunnable
halves of B1 and B2 are runnable — and the source comments saying they
were not are stale.

## B1 — equal tree AND equal DOM

`bench/b1.cljc` carried a docstring section titled "The DOM half of the
equal-output claim is not yet runnable", asserting that the compiled
tier's React lowering did not exist. It does. The section is rewritten to
describe where each half is gated, and the DOM half now exists:
`bench/b1_dom_cljs_test.cljs` mounts the same two arms the workload
measures — the interpreted template and its `{:compiled true}` twin —
into real hosts at both fixture sizes and compares element counts against
written arithmetic and the browsers' own `innerHTML` against each other.
They agree byte for byte.

Everything asserted is deterministic and gates. Nothing reads a clock:
B1's timings stay the workload's, published as evidence with no threshold.

## Gate/evidence split

Deterministic (may fail the build): DOM equality, element counts,
structural parity, rendered-boundary counts, ViewCell verdicts.
Evidence only (recorded, never asserted): every duration.

## Non-vacuity

Each deterministic assertion was inverted and the full browser gate
confirmed red naming the test, then restored byte-identical. The
`innerHTML` comparison additionally carries its own discrimination row —
one arm at two sizes, required to disagree — so an equality that could
never fail would fail that row instead.