### PR TITLE
feat(freehand): support controlled native multiple-select values

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/compiled_react.cljs
+++ b/implementation/freehand/src/re_frame/freehand/compiled_react.cljs
@@ -85,14 +85,18 @@
   o)
 
 (defn ^:no-doc attr!
-  "Write one runtime-valued attribute under the rules the interpreted
-  walk applies to the same value — including the one that cannot be
-  settled at build time: a nil value is an ABSENT attribute, except on a
-  controlled input's own slots, where absence is React's signal for
-  UNCONTROLLED."
-  [o tag k v]
-  (fr/put-attr! o tag k v)
-  o)
+  "Write one attribute the compiler did not fold, under the rules the
+  interpreted walk applies to the same value — including the two it could
+  not settle at build time: a nil value is an ABSENT attribute, except on
+  a controlled input's own slots where absence is React's signal for
+  UNCONTROLLED; and a `<select multiple>`'s EMPTY value is the empty
+  ARRAY, not the empty string.
+
+  `multiple?` is the element's multiple-select verdict, resolved at build
+  time from the declaration's own `multiple` and passed as the constant it
+  is."
+  ([o tag k v] (fr/put-attr! o tag k v false) o)
+  ([o tag k v multiple?] (fr/put-attr! o tag k v multiple?) o))
 
 (defn ^:no-doc handler!
   "Attach a committed handler site's stable proxy, when the site carries

--- a/implementation/freehand/src/re_frame/freehand/compiler/emit_react.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/emit_react.cljc
@@ -167,6 +167,19 @@
                      (:entries sty)))]
     `(re-frame.freehand.compiled-react/style! ~o ~tag ~form)))
 
+(defn- build-time-attr?
+  "Can this attribute be settled at BUILD time?
+
+  A literal value can — that is the point of the tier. A literal `nil`
+  cannot: whether a nil entry is DROPPED or written as a controlled
+  input's empty value is one rule, it depends on facts about the whole
+  element, and it belongs to the runtime rule the interpreted walk already
+  applies rather than to a second statement of it here. So a literal nil
+  rides the dynamic path beside the values only the render knows, and the
+  compiled props object is the interpreted one by construction."
+  [{:keys [literal? value]}]
+  (and literal? (some? value)))
+
 (defn- literal-attr-pair
   "One literal attribute as its `[react-prop-name value]` pair, resolved
   at BUILD time — the projection the interpreted walk pays per attribute
@@ -176,18 +189,17 @@
   than surviving to the first render that reaches it, with the diagnostic
   the JVM emitter raises for the same value."
   [e tag {:keys [k value react-name kind]}]
-  (when (some? value)
-    (if (= :property kind)
-      [react-name value]
-      (let [semantic (conv/attr-value value)]
-        (when (= ::conv/reject semantic)
-          (env/fail! e :rf.ui.compile/collection-attr-value
-                     (str "the " k " attribute on " tag " carries " (pr-str value)
-                          ", which has no attribute spelling — an attribute value is "
-                          "a string, keyword, symbol, number or boolean; :class and "
-                          ":style have their own grammars")
-                     {:attr k}))
-        [(conv/react-prop-name (conv/attr-key k)) semantic]))))
+  (if (= :property kind)
+    [react-name value]
+    (let [semantic (conv/attr-value value)]
+      (when (= ::conv/reject semantic)
+        (env/fail! e :rf.ui.compile/collection-attr-value
+                   (str "the " k " attribute on " tag " carries " (pr-str value)
+                        ", which has no attribute spelling — an attribute value is "
+                        "a string, keyword, symbol, number or boolean; :class and "
+                        ":style have their own grammars")
+                   {:attr k}))
+      [(conv/react-prop-name (conv/attr-key k)) semantic])))
 
 (defn- element-facts
   "The CONTROLLED-INPUT door's element half for one handler site, as a
@@ -251,24 +263,38 @@
                           all-attrs)
         attrs       (remove (fn [{:keys [k]}] (contains? top-layer-keys k)) all-attrs)
         controlled? (controlled/controlled-props? (map :k attrs))
+        ;; The multiple-select verdict, from the LITERAL `multiple` — the
+        ;; only spelling a build-time constant can be read from. It decides
+        ;; one thing: what an EMPTY `<select>` value is. Acceptance of a
+        ;; collection value deliberately does NOT turn on it (see
+        ;; `controlled/select-value-slot?`), so a `multiple` this tier
+        ;; cannot see can cost React's own shape warning on an explicitly
+        ;; nil value and can never refuse a declaration the interpreted
+        ;; walk renders.
+        multi?      (controlled/multiple-select?
+                      tag
+                      (keep (fn [{:keys [k value] :as attr}]
+                              (when (build-time-attr? attr) [k value]))
+                            attrs)
+                      nil)
         cls         (:class props)
         sty         (:style props)
         key-info    (:key props)
-        literals    (into [] (comp (filter :literal?)
-                                   (keep #(literal-attr-pair e tag %)))
+        literals    (into [] (comp (filter build-time-attr?)
+                                   (map #(literal-attr-pair e tag %)))
                           attrs)
         literals    (cond-> literals
                       (static-class-string cls) (conj ["className" (static-class-string cls)])
                       (and sty (:static? sty) (static-style-obj sty))
                       (conj ["style" (static-style-obj sty)]))
-        dynamics    (remove :literal? attrs)
+        dynamics    (remove build-time-attr? attrs)
         o           (gensym "rf-fh-props")
         writes      (cond-> []
                       (and cls (not (:static? cls))) (conj (dynamic-class-form o tag cls))
                       (and sty (not (:static? sty))) (conj (style-write o tag sty))
                       true (into (map (fn [{:keys [k value]}]
                                         `(re-frame.freehand.compiled-react/attr!
-                                          ~o ~tag ~k ~value))
+                                          ~o ~tag ~k ~value ~multi?))
                                       dynamics))
                       true (into (handler-writes o tag controlled? (:events props)))
                       (seq top) (conj `(re-frame.freehand.top-layer/install!

--- a/implementation/freehand/src/re_frame/freehand/controlled.cljc
+++ b/implementation/freehand/src/re_frame/freehand/controlled.cljc
@@ -155,6 +155,65 @@
   [slot]
   (contains? door-slots slot))
 
+;; ---------------------------------------------------------------------------
+;; The one control whose value is COLLECTION-shaped
+;; ---------------------------------------------------------------------------
+;;
+;; A native `<select multiple>` is the single element in the DOM whose `value`
+;; is not a scalar: what is selected is a LIST of option values, and React's own
+;; contract says so — it reads the prop as an array and reports a shape error
+;; for anything else. That is a fact about ONE host element, not a general
+;; collection-valued attribute grammar, and it is stated here for the same
+;; reason the rest of this namespace is: the emitters must not each decide it.
+;;
+;; Both slot names are DERIVED from the same projection an authored key takes,
+;; not spelled as literals, so a guard reading them cannot drift from what the
+;; emitters write and every representation of the name reduces to them.
+
+(def ^:private value-slot
+  "The FINAL-NORMALIZED slot a `value` is written into."
+  (prop-slot :value))
+
+(def ^:private multiple-slot
+  "The FINAL-NORMALIZED slot whose truth turns a native `<select>`'s
+  `value` from a scalar into a collection."
+  (prop-slot :multiple))
+
+(defn select-value-slot?
+  "Is `k` the `value` slot of a native `<select>` — the ONE attribute in
+  the grammar whose authored value may be COLLECTION-shaped?
+
+  Asked of the TAG and the emitted slot, and NOT of `multiple`. What a
+  `<select>` accepts must be decidable from facts both execution modes
+  hold with equal certainty: the tag and the attribute key are lexical in
+  every declaration, while `multiple` may be a runtime value the compiler
+  cannot see. Keying acceptance on it would let a compiled declaration
+  REFUSE at render what its interpreted twin renders, which is a worse
+  failure than the mismatched-shape warning React already raises for a
+  collection on a single select."
+  [tag k]
+  (and (= :select tag) (= value-slot (prop-slot k))))
+
+(defn multiple-select?
+  "Does this element declare a native `<select multiple>` — the control
+  whose EMPTY `value` is the empty COLLECTION rather than the empty
+  string?
+
+  Two attribute sources, because a compiled element's attributes arrive in
+  two: what the compiler settled and what only the render knows. Either
+  may carry the flag, and either may be `nil`. The flag is read through
+  the same slot projection every other rule here reads, so `:x/multiple`
+  counts exactly as `:multiple` does; each source is a map, or any seqable
+  of `[key value]` pairs.
+
+  Only the EMPTY value turns on this — see [[select-value-slot?]] for why
+  acceptance does not."
+  [tag attrs more-attrs]
+  (letfn [(flagged? [entries]
+            (some (fn [[k v]] (and v (= multiple-slot (prop-slot k)))) entries))]
+    (and (= :select tag)
+         (boolean (or (flagged? attrs) (flagged? more-attrs))))))
+
 (defn controlled-props?
   "Does this element's authored attribute key sequence make it controlled
   — do any of the keys normalize onto a [[controlled-slots]] slot?
@@ -183,28 +242,46 @@
   {"value"   ""
    "checked" false})
 
+(def multiple-select-empty-values
+  "The same table, with the ONE row a native `<select multiple>` reads
+  differently: no options selected is the empty COLLECTION, because that
+  control's value is the list of selected option values rather than a
+  scalar. React reads the empty string there as a shape error and says so.
+
+  A Clojure vector, not a host array — this is semantic space, the values
+  the structural tree records. Turning it into the array React's contract
+  requires is the React emitter's own last step, exactly as every other
+  final-shape conversion is."
+  (assoc controlled-empty-values value-slot []))
+
 (defn empty-control-slot
   "The React prop slot an explicitly nil attribute `k` on `tag` must still
   be WRITTEN into, paired with the controlled-empty value it takes — or
   `nil` when this is not a controlled slot on a supported native control,
   where an emitter's ordinary nil-attribute omission stands.
 
-      (empty-control-slot :input :x/value) ;=> [\"value\" \"\"]
-      (empty-control-slot :input :checked) ;=> [\"checked\" false]
-      (empty-control-slot :input :title)   ;=> nil
-      (empty-control-slot :div   :value)   ;=> nil
+      (empty-control-slot :input  :x/value)    ;=> [\"value\" \"\"]
+      (empty-control-slot :input  :checked)    ;=> [\"checked\" false]
+      (empty-control-slot :input  :title)      ;=> nil
+      (empty-control-slot :div    :value)      ;=> nil
+      (empty-control-slot :select :value true) ;=> [\"value\" []]
 
   Scoped to exactly the door's first two facts, and read through the same
   [[prop-slot]] projection, so a spelling that makes a node CONTROLLED is
-  the spelling that clears it.
+  the spelling that clears it. `multiple?` is the element's
+  [[multiple-select?]] verdict — the one fact that changes what EMPTY
+  means — and defaults to false, which every control but a multiple
+  select is.
 
   An ENTRY rather than the value alone, because the empty `checked` value
   IS `false`: a caller asking `(when-let [v …])` would silently drop the
   unchecked case — the same presence-versus-truth collapse this rule
   exists to undo."
-  [tag k]
-  (when (contains? controlled-tags tag)
-    (find controlled-empty-values (prop-slot k))))
+  ([tag k] (empty-control-slot tag k false))
+  ([tag k multiple?]
+   (when (contains? controlled-tags tag)
+     (find (if multiple? multiple-select-empty-values controlled-empty-values)
+           (prop-slot k)))))
 
 ;; ---------------------------------------------------------------------------
 ;; The compiled tier's vocabulary, mapped onto the roster's

--- a/implementation/freehand/src/re_frame/freehand/conversion.cljc
+++ b/implementation/freehand/src/re_frame/freehand/conversion.cljc
@@ -268,6 +268,32 @@
     (boolean? v) v
     :else        ::reject))
 
+(defn select-value
+  "One authored `<select>` `value` in semantic space, or `::reject` when it
+  is outside the grammar — the ONE attribute whose value may be
+  COLLECTION-shaped.
+
+  A native `<select multiple>`'s value is not a scalar: what is selected
+  is the LIST of chosen option values, and the host contract says so. So
+  a SEQUENTIAL value converts member by member through [[attr-value]] —
+  `[:a \"b\" 3]` is `[\"a\" \"b\" \"3\"]`, one grammar, no second value
+  table — and anything else takes [[attr-value]] whole, which is what
+  keeps an ordinary single select exactly as it was.
+
+  SEQUENTIAL and not merely collection-shaped. A set is the tempting
+  spelling for a selection and it is refused, because the tree is ONE
+  value on two hosts: a set has no order, so the vector read out of one
+  can differ between the JVM and ClojureScript, and a declaration would
+  answer two trees. A map is refused for having no members to convert."
+  [v]
+  (if (sequential? v)
+    (reduce (fn [acc x]
+              (let [s (attr-value x)]
+                (if (= ::reject s) (reduced ::reject) (conj acc s))))
+            []
+            v)
+    (attr-value v)))
+
 (defn handler-key?
   "Is `k` a handler-position key? The grammar is the `on-` prefix followed
   by a hyphen, so `:on-click` is a handler site and `:online` is an

--- a/implementation/freehand/src/re_frame/freehand/node.cljc
+++ b/implementation/freehand/src/re_frame/freehand/node.cljc
@@ -359,19 +359,32 @@
   emitter writes ([[re-frame.freehand.controlled/empty-control-slot]]) —
   one projection, so the two hosts describe one declaration the same way.
   Read as an ENTRY and not as a value, because the empty `checked` IS
-  `false`: a truth test here would drop exactly the unchecked case."
-  [tag k v]
+  `false`: a truth test here would drop exactly the unchecked case.
+
+  `multi?` is the element's
+  [[re-frame.freehand.controlled/multiple-select?]] verdict, settled once
+  for the whole element by [[element]] because it is a property of the
+  element and not of the attribute being folded. It changes exactly one
+  thing: what EMPTY means on a `<select multiple>`'s `value`, whose
+  selection is a list of option values rather than a scalar."
+  [tag multi? k v]
   (if (nil? v)
-    (when-some [empty-slot (controlled/empty-control-slot tag k)]
+    (when-some [empty-slot (controlled/empty-control-slot tag k multi?)]
       [k (val empty-slot)])
-    (let [semantic (conv/attr-value v)]
+    (let [select-value? (controlled/select-value-slot? tag k)
+          semantic      (if select-value? (conv/select-value v) (conv/attr-value v))]
       (when (= :re-frame.freehand.conversion/reject semantic)
         (malformed!
           're-frame.freehand/render
           (str "The " k " attribute on " tag " carries a " (type-name v)
                ", which has no attribute spelling. An attribute value is a string, a "
                "keyword, a symbol, a number or a boolean; :class and :style have their "
-               "own richer grammars.")
+               "own richer grammars."
+               (when select-value?
+                 (str " A <select>'s :value additionally takes a SEQUENTIAL collection "
+                      "of them, which is what a multiple select's selection is; a set "
+                      "is not one, because its order is not a value the two hosts "
+                      "agree on.")))
           {:attr k :value (shape v)}))
       [k semantic])))
 
@@ -473,7 +486,7 @@
 
   An ordinary key passes through untouched, namespace and all: the
   structural tree carries authored names."
-  [tag [attrs events class style] k v]
+  [tag multi? [attrs events class style] k v]
   (let [k (conv/attr-key k)]
     (cond
       (= :key k)            [attrs events class style]
@@ -483,7 +496,7 @@
                                      (assoc events k c)
                                      events)
                              class style]
-      :else                 [(if-let [e (attr-entry tag k v)]
+      :else                 [(if-let [e (attr-entry tag multi? k v)]
                                (conj attrs e)
                                attrs)
                              events class style])))
@@ -658,9 +671,9 @@
   attribute — with `:class` the ONE exception: the two class values COMPOSE,
   owned classes first, because a caller passing `.mt-4` is adding a class and
   not replacing the component's own."
-  [tag attrs es caller]
+  [tag multi? attrs es caller]
   (let [[c-attrs c-es c-class c-style]
-        (reduce-kv #(dyn-attr-entry tag %1 %2 %3) [{} {} nil nil] caller)
+        (reduce-kv #(dyn-attr-entry tag multi? %1 %2 %3) [{} {} nil nil] caller)
         c-attrs (if-let [c (class-string tag nil c-class)]
                   (assoc c-attrs :class c)
                   c-attrs)
@@ -697,12 +710,18 @@
   representation."
   [{:keys [tag attrs dyn class sugar style events key? key-val children caller]}]
   (let [ctx        (conv/enter-ns *ns-context* tag)
+        ;; The COLLECTION-shaped `value` verdict is a property of the whole
+        ;; element, exactly as the controlled-input door's element half is,
+        ;; so it is settled once — over both attribute sources, because a
+        ;; compiled element's `multiple` may be a literal the compiler
+        ;; folded or a value only this render knows.
+        multi?     (controlled/multiple-select? tag attrs dyn)
         ;; `:class` and `:style` ride the accumulator because an ALIASED
         ;; spelling of either arrives through `:dyn` — the front end
         ;; discriminates on the exact keyword — and has to reach the one
         ;; place each is composed rather than land beside it.
         [attrs es class style]
-        (reduce-kv #(dyn-attr-entry tag %1 %2 %3) [(or attrs {}) {} class style] dyn)
+        (reduce-kv #(dyn-attr-entry tag multi? %1 %2 %3) [(or attrs {}) {} class style] dyn)
         attrs      (if-let [c (class-string tag sugar class)]
                      (assoc attrs :class c)
                      attrs)
@@ -718,7 +737,7 @@
         ;; component owns, which is why it happens once the owned class and
         ;; style have already resolved. The deny law ran at the call, so what
         ;; arrives here cannot carry a structural or owned key.
-        [attrs es] (if (some? caller) (fold-caller tag attrs es caller) [attrs es])
+        [attrs es] (if (some? caller) (fold-caller tag multi? attrs es caller) [attrs es])
         ;; The DOM top layer's desired-state pair is Freehand vocabulary, not
         ;; attributes: it leaves `:attrs` here and becomes the reserved
         ;; structural fact below. Extracting it at the ONE canonicaliser both

--- a/implementation/freehand/src/re_frame/freehand/react.cljs
+++ b/implementation/freehand/src/re_frame/freehand/react.cljs
@@ -97,16 +97,31 @@
                    o)))
              #js {} v))
 
+(defn- react-control-value
+  "One semantic control value in the shape React takes it. Every scalar is
+  itself; the COLLECTION a native `<select multiple>`'s `value` carries
+  becomes the JavaScript array React's contract requires — the one place
+  an emitted control value's SHAPE differs from the semantic value the
+  structural tree records, and the last step rather than a second grammar."
+  [v]
+  (if (vector? v) (into-array v) v))
+
 (defn- put-plain-attr!
   [o tag k raw]
-  (let [semantic (conv/attr-value raw)]
+  (let [select-value? (controlled/select-value-slot? tag k)
+        semantic      (if select-value? (conv/select-value raw) (conv/attr-value raw))]
     (when (= ::conv/reject semantic)
       (malformed! (str "The " k " attribute on " tag " carries a " (type-name raw)
                        ", which has no attribute spelling. An attribute value is a string, a "
                        "keyword, a symbol, a number or a boolean; :class and :style have their "
-                       "own richer grammars.")
+                       "own richer grammars."
+                       (when select-value?
+                         (str " A <select>'s :value additionally takes a SEQUENTIAL collection "
+                              "of them, which is what a multiple select's selection is; a set "
+                              "is not one, because its order is not a value the two hosts "
+                              "agree on.")))
                   {:attr k :value (shape raw)}))
-    (gobj/set o (conv/react-prop-name k) semantic)))
+    (gobj/set o (conv/react-prop-name k) (react-control-value semantic))))
 
 (defn ^:no-doc put-class!
   "Compose `sugar` (the tag's `.class` shorthand names) with the AUTHORED
@@ -145,20 +160,27 @@
   The compiled tier resolves an element's literal attributes at build
   time and calls this for the rest, so the values a compiler cannot see
   are converted by the one function that converts them when nobody
-  compiled anything."
-  [o tag k raw]
-  (let [k (conv/attr-key k)]
-    (when-some [refusal (conv/attr-key-refusal k)]
-      (malformed! (str "The element " tag " carries " k ". " refusal)
-                  {:attr k}))
-    (cond
-      (= :key k)   nil
-      (nil? raw)   (when-some [empty-slot (controlled/empty-control-slot tag k)]
-                     (gobj/set o (key empty-slot) (val empty-slot)))
-      (= :class k) (put-class! o tag nil raw)
-      (= :style k) (put-style! o tag raw)
-      :else        (put-plain-attr! o tag k raw))
-    o))
+  compiled anything.
+
+  `multiple?` is the element's
+  [[re-frame.freehand.controlled/multiple-select?]] verdict, which the
+  caller settled once for the whole element — it changes only what an
+  EMPTY `<select>` value is. It defaults to false, which every control but
+  a multiple select is."
+  ([o tag k raw] (put-attr! o tag k raw false))
+  ([o tag k raw multiple?]
+   (let [k (conv/attr-key k)]
+     (when-some [refusal (conv/attr-key-refusal k)]
+       (malformed! (str "The element " tag " carries " k ". " refusal)
+                   {:attr k}))
+     (cond
+       (= :key k)   nil
+       (nil? raw)   (when-some [empty-slot (controlled/empty-control-slot tag k multiple?)]
+                      (gobj/set o (key empty-slot) (react-control-value (val empty-slot))))
+       (= :class k) (put-class! o tag nil raw)
+       (= :style k) (put-style! o tag raw)
+       :else        (put-plain-attr! o tag k raw))
+     o)))
 
 (defn- react-props
   "The React props object for one element: the author attribute map in
@@ -178,7 +200,14 @@
         ;; values are irrelevant (an explicit nil is still controlled), and
         ;; the slot is what an alias resolves to, so `:x/value` counts
         ;; exactly as `:value` does.
-        controlled? (controlled/controlled-props? (keys attrs))]
+        controlled? (controlled/controlled-props? (keys attrs))
+        ;; The COLLECTION-shaped `value` verdict is a property of the
+        ;; WHOLE element too, and settled here beside the door's for the
+        ;; same reason: a native `<select multiple>`'s selection is a list
+        ;; of option values, so its EMPTY value is the empty collection
+        ;; rather than the empty string, and React reports the wrong shape
+        ;; loudly.
+        multi?      (controlled/multiple-select? tag attrs nil)]
     (when-let [c (conv/class-string sugar-classes)]
       (gobj/set o "className" c))
     (when sugar-id
@@ -226,8 +255,8 @@
         ;; screen. The exception is scoped exactly as the door is, and
         ;; read through the same slot projection (rf2-drpa3.120).
         (nil? raw)
-        (when-some [empty-slot (controlled/empty-control-slot tag k)]
-          (gobj/set o (key empty-slot) (val empty-slot)))
+        (when-some [empty-slot (controlled/empty-control-slot tag k multi?)]
+          (gobj/set o (key empty-slot) (react-control-value (val empty-slot))))
 
         (conv/handler-key? k)
         (if (some? cand)

--- a/implementation/freehand/test/re_frame/freehand/controlled_input_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/controlled_input_dom_cljs_test.cljs
@@ -102,6 +102,7 @@
   (rf/reg-sub (first query) (fn [db _] (:text db)))
   (rf/reg-sub :fh-input/len (fn [db _] (count (:text db))))
   (rf/reg-sub :fh-input/flag (fn [db _] (:flag db)))
+  (rf/reg-sub :fh-input/picked (fn [db _] (:picked db)))
   (rf/reg-event evt (fn [{:keys [db]} [_ text]] {:db (assoc db :text text)})))
 
 (defn- app-text [] (:text (frame/frame-app-db-value fid)))
@@ -172,6 +173,24 @@
   [_]
   [:div [clearable-field {}] [clearable-box {}]])
 
+(v/defview multi-select-field
+  "A native `<select multiple>` — the ONE control whose value is not a
+  scalar. Its `value` is PRESENT on every render, so the node is
+  controlled on every render; what changes is whether that value is a list
+  of chosen option values or the empty selection."
+  [_]
+  [:select {:id        "multi"
+            :multiple  true
+            :value     (cell/observe! [:fh-input/picked])
+            :on-change [evt :re-frame.freehand/value]}
+   [:option {:value "a"} "Alpha"]
+   [:option {:value "b"} "Bravo"]
+   [:option {:value "c"} "Charlie"]])
+
+(v/defview multi-select-page
+  [_]
+  [:div [multi-select-field {}]])
+
 ;; ---------------------------------------------------------------------------
 ;; Typing, as the browser delivers it
 ;; ---------------------------------------------------------------------------
@@ -233,6 +252,12 @@
   (act #(do (frame/replace-app-db! fid db)
             (.render root (shell/provide-frame fid (fr/element [clearing-page {}]))))))
 
+(defn- render-multi-select-page!
+  "Write `db` and render the multiple-select page from it, inside one act."
+  [root db]
+  (act #(do (frame/replace-app-db! fid db)
+            (.render root (shell/provide-frame fid (fr/element [multi-select-page {}]))))))
+
 (defn- spy-console-errors!
   "Collect what React says on `console.error` while a transition runs, and
   answer the restore thunk. The controlled↔uncontrolled complaint is a
@@ -252,6 +277,15 @@
   `value`/`checked` prop raises."
   [lines]
   (filterv #(re-find #"(?i)uncontrolled|should not be null" %) lines))
+
+(defn- value-shape-complaints
+  "The captured console lines that are React telling us a `<select>`'s
+  `value` is the WRONG SHAPE — a scalar on a multiple select, or an array
+  on a single one. Like the controlled/uncontrolled complaint it is a
+  console diagnostic and nothing else, so a suite that does not listen for
+  it renders a visibly-correct page over a contract it is breaking."
+  [lines]
+  (filterv #(re-find #"(?i)must be an array|must be a scalar" %) lines))
 
 ;; ===========================================================================
 ;; FH-INPUT-003 — rapid typing, and the control that proves it is a claim
@@ -552,3 +586,73 @@
                         (is false (str "mount rejected: " e))
                         (teardown! container root)
                         (done)))))))))
+
+;; ===========================================================================
+;; A CONTROLLED native `<select multiple>`, in a real browser
+;; ===========================================================================
+
+(deftest a-controlled-multiple-select-selects-exactly-the-authored-values
+  (testing "A native `<select multiple>` is the single element in the DOM
+            whose value is not a scalar: what is selected is the LIST of
+            chosen option values, and React's own contract reads the prop
+            as an array. An author writes ordinary Clojure data and the
+            emitter converts at the boundary — so a vector selects exactly
+            those options, and an explicit nil clears every one of them
+            while the node stays controlled.
+
+            The EMPTY selection is mounted first, deliberately. React
+            validates a select's value SHAPE when the element is created,
+            and an explicit nil is exactly where a scalar-only empty-value
+            table would hand it the empty string — the wrong shape, on
+            the transition an author uses to clear a field. Neither half is
+            visible to a structural assertion, and a wrong shape does not
+            throw: React writes a console diagnostic and renders a page
+            that can look entirely correct, which is why the console is
+            watched here as closely as the DOM is."
+    (if-not (browser?)
+      (skip! "the browser job runs the multiple-select assertions")
+      (async done
+        (reg!)
+        (make-frame! {:picked nil})
+        (let [[container root] (mount!)
+              errors  (atom [])
+              restore (spy-console-errors! errors)
+              picked  (fn [n] (mapv #(.-value %) (array-seq (.-selectedOptions n))))
+              finish  (fn [] (restore) (teardown! container root) (done))]
+          (-> (render-multi-select-page! root {:picked nil})
+              (.then
+                (fn [_]
+                  (let [sel (node container "multi")]
+                    (is (true? (.-multiple sel)) "the node really is a multiple select")
+                    (is (= [] (picked sel))
+                        "an explicitly nil value mounts with nothing selected")
+                    (is (= [] (value-shape-complaints @errors))
+                        (str "and React accepted the value's SHAPE at mount — the empty "
+                             "selection reached it as an array, not as the empty string a "
+                             "scalar control clears with: " (pr-str @errors)))
+                    (-> (render-multi-select-page! root {:picked ["a" "c"]})
+                        (.then
+                          (fn [_]
+                            (is (identical? sel (node container "multi"))
+                                "the SAME host node — a value transition, not a remount")
+                            (is (= ["a" "c"] (picked sel))
+                                (str "exactly the authored options are selected — the node "
+                                     "holds " (pr-str (picked sel))))
+                            (-> (render-multi-select-page! root {:picked nil})
+                                (.then
+                                  (fn [_]
+                                    (is (identical? sel (node container "multi")))
+                                    (is (= [] (picked sel))
+                                        (str "an explicit nil cleared every selected option "
+                                             "— the node holds " (pr-str (picked sel))))
+                                    (is (= [] (control-complaints @errors))
+                                        (str "React raised no controlled/uncontrolled "
+                                             "diagnostic across the whole sequence: "
+                                             (pr-str @errors)))
+                                    (is (= [] (value-shape-complaints @errors))
+                                        (str "and none about the value's shape: "
+                                             (pr-str @errors)))
+                                    (finish))))))))))
+              (.catch (fn [e]
+                        (is false (str "mount rejected: " e))
+                        (finish)))))))))

--- a/implementation/freehand/test/re_frame/freehand/controlled_nil_value_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/controlled_nil_value_cljs_test.cljs
@@ -96,6 +96,75 @@
         "present-false was already distinguishable from absent")))
 
 ;; ---------------------------------------------------------------------------
+;; The one control whose value is COLLECTION-shaped
+;; ---------------------------------------------------------------------------
+
+(defn- js-value
+  "A `value` prop read back as ordinary Clojure data, so a row can say what
+  it means. A JavaScript array becomes a vector — and the fact that it WAS
+  an array is asserted separately, because that is React's own contract for
+  a multiple select and the thing an emitter gets wrong."
+  [form]
+  (let [v (slot form "value")]
+    (if (array? v) (vec v) v)))
+
+(deftest a-multiple-selects-value-reaches-react-as-an-array
+  (testing "A native `<select multiple>` is the single element whose value
+            React reads as a COLLECTION: its selection is the list of
+            chosen option values, and React reports any other shape. The
+            author writes ordinary Clojure data and the emitter converts at
+            the boundary — the last step, not a second grammar."
+    (let [form [:select {:multiple true :value ["a" "b"] :on-change [:e]}]]
+      (is (array? (slot form "value")) "the value prop IS a JavaScript array")
+      (is (= ["a" "b"] (js-value form)) "carrying the authored option values, in order"))
+    (is (= ["a" "1"] (js-value [:select {:multiple true :value [:a 1] :on-change [:e]}]))
+        "whose members took the ordinary attribute-value conversion")))
+
+(deftest an-explicit-nil-on-a-multiple-select-is-the-empty-array
+  (testing "The controlled EMPTY value of a collection-shaped slot is the
+            empty collection. The empty string clears a scalar field and is
+            a shape error here — React says so, loudly — while an omitted
+            prop is the uncontrolled claim the door already contradicted."
+    (doseq [form [[:select {:multiple true :value nil :on-change [:e]}]
+                  [:select {:multiple true :x/value nil :on-change [:e]}]
+                  [:select {:x/multiple true :value nil :on-change [:e]}]]]
+      (is (present? form "value") (str (pr-str form) " keeps its value prop"))
+      (is (array? (slot form "value"))
+          (str (pr-str form) " — as an array, which is what React requires here"))
+      (is (= [] (js-value form)) (str (pr-str form) " — and it selects nothing")))))
+
+(deftest a-single-select-is-untouched-by-the-collection-rule
+  (testing "The control that makes the rule mean something. Without
+            `multiple` a select's value is a scalar, and its controlled
+            empty value is the empty STRING exactly as it was — React
+            reports an array there as the wrong shape."
+    (is (= "" (slot [:select {:value nil :on-change [:e]}] "value"))
+        "an explicit nil still clears a single select with the empty string")
+    (is (= "" (slot [:select {:multiple false :value nil :on-change [:e]}] "value"))
+        "and an explicitly FALSE multiple is a single select")
+    (is (= "a" (slot [:select {:value "a" :on-change [:e]}] "value"))
+        "a scalar value is untouched")
+    (is (not (present? [:div {:multiple true :value nil}] "value"))
+        "and nothing is excepted for an element that is not a native control")))
+
+(deftest an-ordinary-collection-attribute-value-is-still-refused
+  (testing "Widening ONE slot on ONE tag is not a general collection
+            attribute grammar. Everywhere else a collection still has no
+            attribute spelling, and inside the exception the members take
+            the same closed scalar grammar — a set among them, because its
+            read order is not a value the two hosts agree on."
+    (doseq [form [[:div {:value ["a"]}]
+                  [:input {:value ["a"]}]
+                  [:select {:multiple true :title ["a"]}]
+                  [:select {:multiple true :value #{"a"}}]
+                  [:select {:multiple true :value {:a 1}}]]]
+      (let [ex (try (fr/element form) nil (catch :default e e))]
+        (is (some? ex) (str (pr-str form) " is refused"))
+        (when ex
+          (is (= :rf.error/ui-tree-malformed (:rf.error/id (ex-data ex)))
+              (str (pr-str form) " — the walk's existing diagnostic, not a new one")))))))
+
+;; ---------------------------------------------------------------------------
 ;; The verdict and the emission are ONE decision
 ;; ---------------------------------------------------------------------------
 

--- a/implementation/freehand/test/re_frame/freehand/controlled_structural_value_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/controlled_structural_value_cljs_test.cljc
@@ -41,21 +41,29 @@
   (dissoc (tree/render body) :rf.ui/tree-version))
 
 #?(:clj
+   (def ^:private params
+     "The bindings the dynamic rows read, so a computed attribute value is a
+     real runtime value in the compiled mode rather than a literal in
+     disguise."
+     '[{:keys [vs flag]}]))
+
+#?(:clj
    (defn- compiled-tree
      "The structural tree a COMPILED declaration answers — the emitted
      lowering, evaluated and called, rather than a claim about the form it
      emitted."
-     [body]
-     (let [lowering (compiler/compile-structural-view
-                      {:form            (list 'v/defview 'subject '[_] body)
-                       :menv            nil
-                       :ns-sym          're-frame.freehand.controlled-structural-value-cljs-test
-                       :vname           'subject
-                       :view-id         ::subject
-                       :params          '[_]
-                       :body            [body]
-                       :children-policy :optional})]
-       ((eval (:body lowering)) {}))))
+     ([body] (compiled-tree body {}))
+     ([body props]
+      (let [lowering (compiler/compile-structural-view
+                       {:form            (list 'v/defview 'subject params body)
+                        :menv            nil
+                        :ns-sym          're-frame.freehand.controlled-structural-value-cljs-test
+                        :vname           'subject
+                        :view-id         ::subject
+                        :params          params
+                        :body            [body]
+                        :children-policy :optional})]
+        ((eval (:body lowering)) props)))))
 
 ;; ---------------------------------------------------------------------------
 ;; The controlled slots, on the supported native controls
@@ -158,3 +166,123 @@
                show here."
        (doseq [{:keys [note body tree]} dropped-rows]
          (is (= tree (compiled-tree body)) (str note " — compiled"))))))
+
+;; ---------------------------------------------------------------------------
+;; The one control whose value is COLLECTION-shaped
+;; ---------------------------------------------------------------------------
+
+(def multiple-select-rows
+  "A native `<select multiple>` is the single element in the DOM whose
+  `value` is not a scalar: what is selected is a LIST of option values.
+  The tree records ORDINARY DATA for it — a Clojure vector whose members
+  took the same conversion every scalar attribute value takes — and
+  turning it into the array React's contract requires is the React
+  emitter's own last step."
+  [{:note "an authored vector of option values is retained, in order"
+    :body '[:select {:multiple true :value ["a" "b"]}]
+    :tree {:tag :select :attrs {:multiple true :value ["a" "b"]}}
+    :literal-collection? true}
+
+   {:note "and its members take the ordinary attribute-value conversion"
+    :body '[:select {:multiple true :value [:a 1]}]
+    :tree {:tag :select :attrs {:multiple true :value ["a" "1"]}}
+    :literal-collection? true}
+
+   {:note "an EMPTY selection is an empty vector, not the empty string"
+    :body '[:select {:multiple true :value nil}]
+    :tree {:tag :select :attrs {:multiple true :value []}}}
+
+   {:note "the aliased value slot takes the same answer, keeping its authored name"
+    :body '[:select {:multiple true :x/value nil}]
+    :tree {:tag :select :attrs {:multiple true :x/value []}}}
+
+   {:note "and the flag is read through the same slot projection, so an alias flags it"
+    :body '[:select {:x/multiple true :value nil}]
+    :tree {:tag :select :attrs {:x/multiple true :value []}}}
+
+   {:note "an explicitly FALSE multiple is a single select — present-false, and the scalar empty"
+    :body '[:select {:multiple false :value nil}]
+    :tree {:tag :select :attrs {:multiple false :value ""}}}
+
+   {:note "an empty authored vector is already the empty selection"
+    :body '[:select {:multiple true :value []}]
+    :tree {:tag :select :attrs {:multiple true :value []}}
+    :literal-collection? true}])
+
+(deftest a-multiple-selects-value-is-collection-shaped-in-the-tree
+  (testing "The empty value is the fact `multiple` decides, and it is
+            decided once for the whole element — from either attribute
+            source, because a compiled element's flag may be a literal the
+            compiler folded or a value only the render knows."
+    (doseq [{:keys [note body tree]} multiple-select-rows]
+      (is (= tree (interpreted-tree body)) (str note " — interpreted")))))
+
+#?(:clj
+   (deftest the-compiled-tree-agrees-about-the-collection-shape
+     (testing "One canonicaliser, so a compiled declaration answers the tree
+               its interpreted twin answers. The rows carrying a LITERAL
+               collection are absent on purpose — the compiled analyzer
+               refuses a literal collection attribute value before either
+               emitter sees it, which is a rule of its own and not this
+               canonicaliser's — so what is proved here is every shape a
+               compiled declaration can actually reach."
+       (doseq [{:keys [note body tree]} (remove (fn [{:keys [literal-collection?]}]
+                                                  literal-collection?)
+                                                multiple-select-rows)]
+         (is (= tree (compiled-tree body)) (str note " — compiled"))))))
+
+#?(:clj
+   (deftest the-compiled-tree-settles-the-collection-shape-at-render
+     (testing "The two facts a compiler cannot always see — the selection
+               itself, and whether the select is MULTIPLE — are both
+               ordinary runtime values, and the canonicaliser reads them from
+               the same slot whichever mode put them there."
+       (is (= {:tag :select :attrs {:multiple true :value ["a" "b"]}}
+              (compiled-tree '[:select {:multiple true :value vs}] {:vs ["a" "b"]}))
+           "a computed selection reaches the tree as ordinary data")
+       (is (= {:tag :select :attrs {:multiple true :value []}}
+              (compiled-tree '[:select {:multiple flag :value nil}] {:flag true}))
+           "and a computed `multiple` still decides what EMPTY means")
+       (is (= {:tag :select :attrs {:multiple false :value ""}}
+              (compiled-tree '[:select {:multiple flag :value nil}] {:flag false}))
+           "including when it decides the element is a single select"))))
+
+(def refused-collection-rows
+  "The collection values that stay REFUSED. Widening one host element's
+  `value` slot is not a general collection-attribute grammar, and a set is
+  refused even there: the tree is ONE value on two hosts, and a set's read
+  order is not something the JVM and ClojureScript agree on."
+  ['[:div {:value ["a"]}]
+   '[:input {:value ["a"]}]
+   '[:select {:multiple true :value #{"a"}}]
+   '[:select {:multiple true :value {:a 1}}]
+   '[:select {:multiple true :title ["a"]}]
+   '[:select {:multiple true :value ["a" ["b"]]}]])
+
+(deftest an-ordinary-collection-attribute-value-is-still-refused
+  (testing "The exception is ONE slot on ONE tag. Everywhere else a
+            collection has no attribute spelling, and inside the exception
+            the members take the same closed scalar grammar."
+    (doseq [body refused-collection-rows]
+      (let [ex (try (interpreted-tree body)
+                    nil
+                    (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) e e))]
+        (is (some? ex) (str (pr-str body) " is refused"))
+        (when ex
+          (is (= :rf.error/ui-tree-malformed (:rf.error/id (ex-data ex)))
+              (str (pr-str body) " — the walk's existing diagnostic, not a new one")))))))
+
+(deftest a-single-selects-scalar-value-is-untouched
+  (testing "The control that makes the widening mean something. A `<select>`
+            with no `multiple` keeps exactly the scalar behaviour it had —
+            the empty string for an explicit nil, and an ordinary
+            conversion for a value."
+    (is (= {:tag :select :attrs {:value ""}}
+           (interpreted-tree '[:select {:value nil}])))
+    (is (= {:tag :select :attrs {:value "a"}}
+           (interpreted-tree '[:select {:value "a"}])))
+    (is (= {:tag :select :attrs {:multiple true :value "a"}}
+           (interpreted-tree '[:select {:multiple true :value "a"}]))
+        "a scalar on a multiple select is still an ordinary scalar here — the
+         shape mismatch is React's own diagnostic, at the boundary that has
+         the contract")))

--- a/implementation/ssr/src/re_frame/ssr/ui_tree.cljc
+++ b/implementation/ssr/src/re_frame/ssr/ui_tree.cljc
@@ -710,7 +710,7 @@
     (str reason " (at tree path " (pr-str path) ")")
     {:extra (assoc extra :path path)}))
 
-(declare emit-node mark-selected)
+(declare emit-node mark-selected selected-values)
 
 (defn- emit-children
   "Emit a children vector, threading each child's root-relative path so a
@@ -900,7 +900,7 @@
                             (escape-html cv) "</" tag-name ">"))
       :else
       (let [children (if (some? sel-val)
-                       (mark-selected (:children el) (coerce-val sel-val))
+                       (mark-selected (:children el) (selected-values sel-val))
                        (:children el))]
         ;; rf2-z05di — <pre>/<listing>/<textarea> with a single string child
         ;; beginning with LF get the one compensating LF react-dom/server emits.
@@ -915,23 +915,36 @@
   [node]
   (apply str (map #(if (string? %) % (node-text %)) (:children node))))
 
+(defn- selected-values
+  "The SET of option values a `<select>`'s tree `:value` selects.
+
+  A scalar selects one option. A native `<select multiple>` carries a
+  COLLECTION — its selection is the list of chosen option values, which is
+  the one attribute value in the tree that is not a scalar — and selects
+  every option named in it. Both answer a set, so the marking below is one
+  membership test rather than two shapes of comparison."
+  [sel-val]
+  (if (vector? sel-val)
+    (into #{} (map coerce-val) sel-val)
+    #{(coerce-val sel-val)}))
+
 (defn- mark-selected
   "The `:value`-on-`:select` row: inject `:selected true` into the option
-  child(ren) whose value (their `:value` attr, else their text content)
-  matches `sel-val`. Recurses into non-option element children (e.g.
+  child(ren) whose value (their `:value` attr, else their text content) is
+  in `selected`. Recurses into non-option element children (e.g.
   `:optgroup`). Mirrors `re-frame.ui.semantic/mark-selected-options`, at the
   raw-tree (author-space) level."
-  [children sel-val]
+  [children selected]
   (mapv (fn [c]
           (cond
             (and (map? c) (= :option (:tag c)))
             (let [ov (coerce-val (or (get-in c [:attrs :value]) (node-text c)))]
-              (if (= ov sel-val)
+              (if (contains? selected ov)
                 (assoc-in c [:attrs :selected] true)
                 c))
 
             (and (map? c) (:tag c) (:children c))
-            (assoc c :children (mark-selected (:children c) sel-val))
+            (assoc c :children (mark-selected (:children c) selected))
 
             :else c))
         children))

--- a/implementation/ssr/test/re_frame/ssr/emit_ui_tree_cljs_test.cljc
+++ b/implementation/ssr/test/re_frame/ssr/emit_ui_tree_cljs_test.cljc
@@ -440,6 +440,32 @@
              (v1 {:tag :select
                   :attrs {:value "b"}
                   :children [{:tag :option :attrs {:value "a"} :children ["A"]}
+                             {:tag :option :attrs {:value "b"} :children ["B"]}]})))))
+  (testing "a MULTIPLE select's :value is a COLLECTION, and selects every option it names"
+    ;; The one tree attribute value that is not a scalar: a `<select multiple>`'s
+    ;; selection is the list of chosen option values. Comparing the collection
+    ;; itself against each option marked NOTHING, so a server render dropped the
+    ;; whole selection and its hydrating client immediately disagreed with it.
+    (is (= (str "<select multiple=\"\">"
+                "<option selected=\"\" value=\"a\">A</option>"
+                "<option value=\"b\">B</option>"
+                "<option selected=\"\" value=\"c\">C</option>"
+                "</select>")
+           (ui-tree/emit-ui-tree
+             (v1 {:tag :select
+                  :attrs {:multiple true :value ["a" "c"]}
+                  :children [{:tag :option :attrs {:value "a"} :children ["A"]}
+                             {:tag :option :attrs {:value "b"} :children ["B"]}
+                             {:tag :option :attrs {:value "c"} :children ["C"]}]})))))
+  (testing "and the EMPTY selection selects none of them"
+    (is (= (str "<select multiple=\"\">"
+                "<option value=\"a\">A</option>"
+                "<option value=\"b\">B</option>"
+                "</select>")
+           (ui-tree/emit-ui-tree
+             (v1 {:tag :select
+                  :attrs {:multiple true :value []}
+                  :children [{:tag :option :attrs {:value "a"} :children ["A"]}
                              {:tag :option :attrs {:value "b"} :children ["B"]}]}))))))
 
 ;; ---------------------------------------------------------------------------

--- a/spec/004B-UI-Tree-and-Conversion.md
+++ b/spec/004B-UI-Tree-and-Conversion.md
@@ -239,10 +239,28 @@ read surface. Text is therefore not a *queryable node*: selectors never match it
   `checked`. One projection, so the structural tree and the React props describe one
   declaration the same way, and a server render and its client hydration agree rather
   than differing by exactly this attribute. Scoped as the door is, and read through the
-  same normalized slot, so `:x/value` clears the field precisely as `:value` does.
+  same normalized slot, so `:x/value` clears the field precisely as `:value` does. A
+  native `<select multiple>` is the one control whose empty value is not a scalar: its
+  selection is a list, so its controlled empty is the empty **collection** `[]`, and the
+  empty string is a shape error the client reports. Whether the element is a multiple
+  select is a property of the *whole element*, settled once from its attributes exactly
+  as the controlled-input door's element half is.
 - collection values outside `:class`/`:style` (e.g. `:data-foo {:a 1}`) → rejected,
   didactic (React would render `"[object Object]"` garbage) — at the declaration in
-  compiled mode, at the walk in interpreted mode.
+  compiled mode, at the walk in interpreted mode. **One host element is excepted**:
+  a native `<select>`'s `value`, because a `<select multiple>`'s value is not a scalar
+  — what is selected is the *list* of chosen option values, and the client contract
+  reads the prop as an array. A **sequential** value there converts member by member
+  through the rows above (`[:a "b" 3]` → `["a" "b" "3"]`) and the tree records ordinary
+  data; a set is refused with every other collection, because a set has no order and the
+  vector read out of one is not a value the two hosts agree on. Turning the recorded
+  collection into the host array is the client emitter's own final step, exactly as
+  every other final-shape conversion is. The exception is the `value` slot on the
+  `select` tag and nothing else: acceptance deliberately does **not** consult
+  `multiple`, whose value a compiled declaration may not be able to see, so a
+  declaration cannot compile in one mode and be refused in the other. The **empty**
+  value does consult it — see the `nil` row above, where a multiple select's controlled
+  empty is `[]` rather than `""`.
 - everything else — a function in an attribute slot, a host object — is likewise
   rejected: the value grammar above is closed, and a value outside it has no
   cross-host spelling to carry.


### PR DESCRIPTION
A native `<select multiple>` is the single element in the DOM whose value is not a scalar: what is selected is the LIST of chosen option values, and React reads the prop as an array and reports any other shape. Both useful states were unreachable through the paved API — the authored vector was rejected before the boundary by the general attribute grammar, and an explicit nil normalized to the single-value empty string, which React calls a shape error on exactly the transition an author uses to clear a field.

Follows the two fixes merged in #6768, and shares their seam: a control's identity and its emptiness are properties of the **element**, settled once and read by every emitter, rather than re-decided per attribute per walk.

### The design, and why it splits in two

- **Acceptance** is keyed on the TAG and the emitted SLOT alone. A native `<select>`'s `value` takes a SEQUENTIAL collection, whose members fold through the same closed scalar grammar every attribute value folds through. Tag and key are lexical in every declaration, while `multiple` may be a runtime value the compiler cannot see — keying acceptance on it would let a compiled declaration refuse at render what its interpreted twin renders, which is a worse failure than the mismatched-shape warning React already raises. A **set** is refused with every other collection: it has no order, so the vector read out of one is not a value the two hosts agree on, and the tree is one value on two hosts.
- The **empty value** does consult `multiple`, because that is the only fact that decides what empty MEANS. It is settled once for the whole element, from either attribute source, exactly as the controlled-input door's element half already is.

Author space and the structural tree carry ordinary Clojure data; turning it into the JavaScript array React requires is the React emitter's final step, beside every other final-shape conversion. No general collection attribute grammar, no form model, no wrapper component, no public verb, no new diagnostic.

The compiled React tier reaches the same rules: a literal nil now rides the dynamic path so the runtime rule owns it (the same repair the JVM emitter took in #6768), and the element's verdict travels as the build-time constant it is.

### The serialiser

The JVM serialiser matched a select's whole `:value` against each option, so a collection marked NOTHING selected — a server render that dropped the selection its hydrating client would immediately disagree with. It now marks every option the selection names, through one membership test that a scalar and a collection both reduce to.

### Two findings worth reading

**React 19.2 validates a `<select>`'s value shape at MOUNT, not on update.** The browser assertion was written first as a controlled→cleared transition and stayed green against a deliberately wrong empty value, because `validateSelectProps` does not fire on that path in this version. The test now mounts the EMPTY selection first, where React does validate — and with that ordering the gate reds with React's own `must be an array if multiple is true` diagnostic captured off the console. Every other assertion in the suite that watches `console.error` for a controlled-input complaint is worth reading with the same question in mind.

**One residue, deliberately left.** A *literal* collection value is refused by the compiled analyzer (`analyze.cljc`) before either emitter sees it, so `[:select {:multiple true :value ["a" "b"]}]` still fails to compile in a `{:compiled true}` view while its interpreted twin renders. That file is owned by another change in flight and is untouched here, so the residue is called out rather than papered over — the one-line widening it needs is the analyzer's literal-collection guard admitting the `<select>` `value` slot. The compiled tier is fully proved for every shape it *can* reach: a computed selection, and a computed `multiple` deciding what empty means.

### Proof

Structural rows run interpreted on both hosts and compiled on the JVM; the React walk proves the rules for itself, because it is a separate walk; the serialiser has its own rows; and the DOM claims are read back off real `selectedOptions` in a real browser with React's console watched as closely as the DOM. Every new suite was shown to RED against the previous behaviour before the fix was restored.