### PR TITLE
fix(freehand): a compiled top-level v/event at a DOM site dispatches again

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/compiler/analyze.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/analyze.cljc
@@ -1444,6 +1444,23 @@
           (rest form))
     (meta form)))
 
+(defn- roster-callback
+  "The lowered value for one of the body-taking roster forms — the EXACT
+  constructor call the interpreted `v/event` / `v/handler` macro expands
+  to.
+
+  A compiled body must lower a roster form to the ROSTER VALUE and not to
+  the bare function it carries, because the runtime classifies the value
+  PRESENT: [[re-frame.freehand.events/event-plan]] reads a bare fn as
+  `:bare-fn`, whose firing arm applies the function and DISCARDS what it
+  answered. A `v/event` lowered bare therefore dispatched nothing at all
+  while the compiled site's own door verdict said `:event` — a silent
+  no-op the build could not see and no diagnostic named (rf2-berc2). The
+  constructor makes the two halves agree by construction: one value, one
+  classification, one firing arm, whichever front end wrote it."
+  [role f arity]
+  (list 're-frame.freehand.events/callback role f arity))
+
 (defn- analyze-ui-event-fn
   "The `(v/event [e] body…)` seq form, lowered to the `(fn [e] body…)` the
   runtime callback carries. One reader for the two positions a `v/event` is
@@ -1542,7 +1559,7 @@
     (ui-event-form? e form)
     ;; The interpreted `v/event` macro expands to this exact constructor, so the
     ;; branch the runtime classifies is the same roster value in both modes.
-    (list 're-frame.freehand.events/callback :event (analyze-ui-event-fn e k form) 1)
+    (roster-callback :event (analyze-ui-event-fn e k form) 1)
 
     :else
     (env/fail! e :rf.ui.compile/bad-handler-options
@@ -1693,7 +1710,13 @@
                    {:prop k :form form}))
 
       (ui-event-form? e form)
-      (let [form* (analyze-ui-event-fn e k form)]
+      ;; The WHOLE-handler `v/event`, lowered to the same roster constructor a
+      ;; key-condition BRANCH lowers to, and to the same one the interpreted
+      ;; `v/event` macro expands to. Nothing between here and the DOM wraps it,
+      ;; so the value the analyzer writes IS the value `events/event-plan`
+      ;; classifies — and a bare fn there is the `:bare-fn` arm, which applies
+      ;; the body and throws its event vector away (rf2-berc2).
+      (let [form* (roster-callback :event (analyze-ui-event-fn e k form) 1)]
         (add-event-site! e identity
                          {:prop k :handler :opaque
                           :classification :ui-event :serializable? false})
@@ -1716,9 +1739,18 @@
                           ". To DISPATCH a vector, use v/event")
                      {:prop k :form form}))
         (let [binders (set (env/binding-syms bindings))
-              form*   (walk-expr e [:handler k :ui-handler]
-                                 (with-meta (apply list 'fn bindings body)
-                                   (meta form)))]
+              ;; The roster constructor, for the reason the `v/event` arm above
+              ;; gives. `v/handler` and a bare fn happen to FIRE alike, so the
+              ;; drop here is not a lost dispatch — it is the recorded fact: a
+              ;; bare fn records `{:rf.ui/opaque :fn}` on the structural tree
+              ;; where the interpreted twin records `{:rf.ui/opaque :v/handler}`.
+              ;; One spelling, one roster value, one recorded marker.
+              form*   (roster-callback
+                       :handler
+                       (walk-expr e [:handler k :ui-handler]
+                                  (with-meta (apply list 'fn bindings body)
+                                    (meta form)))
+                       1)]
           (check-loop-capture! (update e :loop-syms #(reduce disj % binders))
                                (str "v/handler at " k) form)
           (add-event-site! e identity

--- a/implementation/freehand/test/re_frame/freehand/analyze_accept_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/analyze_accept_cljs_test.cljc
@@ -282,8 +282,12 @@
         "a v/event handler is its own compiler-known committed-callback class")
     (is (false? (:serializable? h)))
     (is (false? (:hoistable? h)))
-    (is (= 'fn (first (:form h)))
-        "the v/event body lowers to a fn the runtime calls with the native event"))
+    (is (= '(re-frame.freehand.events/callback
+             :event (fn [e] [:form/typed (.. e -target -value)]) 1)
+           (:form h))
+        (str "the v/event body lowers to the ROSTER CONSTRUCTOR the interpreted "
+             "v/event macro expands to — not the bare fn it carries, which "
+             "event-plan classifies :bare-fn and fires without dispatching")))
   (let [el (ana* '[:button {:on-click (if a [:x/a] [:x/b])} "x"])]
     (is (= :dynamic (:classification (first (get-in el [:props :events]))))))
   (let [{:keys [ast sites]}
@@ -303,8 +307,11 @@
     (is (= :handler (:classification h))
         "v/handler — the explicit imperative committed callback (bare-fn shorthand)")
     (is (false? (:serializable? h)))
-    (is (= 'fn (first (:form h)))
-        "the body lowers to a fn the runtime calls with the native event"))
+    (is (= '(re-frame.freehand.events/callback
+             :handler (fn [e] (.preventDefault e)) 1)
+           (:form h))
+        (str "the body lowers to the roster constructor v/handler expands to — one "
+             "lowering for the form, at the whole-handler position as everywhere else")))
   ;; v/handler is NOT a controlled-input sync-door class (imperative, not a vector)
   (let [el (ana* '[:input {:value v :on-input (handler [e] (do-something e))}])
         h  (first (get-in el [:props :events]))]
@@ -445,7 +452,9 @@
                              (event [e] (conj on-value (.. e -target -value)))}])
           h  (first (get-in el [:props :events]))]
       (is (= :ui-event (:classification h)))
-      (is (= '(conj on-value (.. e -target -value)) (last (:form h)))
+      ;; `(events/callback :event (fn [e] …) 1)` — the carried fn is the third
+      ;; element, and its body the last form of that fn.
+      (is (= '(conj on-value (.. e -target -value)) (last (nth (:form h) 2)))
           "the interop macro survives into the compiled fn body")))
   (testing "a bare fn handler body keeps its interop macro verbatim"
     (let [el (ana* '[:button {:on-click (fn [e] (.. e -target -value))} "x"])]

--- a/implementation/freehand/test/re_frame/freehand/compiled_event_lowering_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/compiled_event_lowering_cljs_test.cljc
@@ -1,0 +1,154 @@
+(ns re-frame.freehand.compiled-event-lowering-cljs-test
+  "A compiled `(v/event …)` at a DOM handler site DISPATCHES — the two
+  halves of one site, held to the same answer.
+
+  A handler site has two readers and they read different things. The
+  DOOR reads the compiled CLASSIFICATION (`:ui-event`) through
+  `controlled/compiled-role` and decides the lane; the RUNTIME reads the
+  VALUE the lowering produced through `events/event-plan` and decides
+  what firing does. They agree only if the lowering produces the value
+  whose plan role is the role the classification named.
+
+  It did not. `analyze-handler` lowered a whole-handler `v/event` to the
+  BARE `(fn [e] …)` the roster callback carries, so `event-plan`
+  classified it `:bare-fn` — whose firing arm applies the function and
+  THROWS AWAY the event vector it answered. Nothing raised, the build
+  succeeded, the door reported `:event`, and the click did nothing at
+  all (rf2-berc2). A key-condition BRANCH was already correct, because
+  that arm lowers to the roster constructor; the whole-handler position
+  now lowers to the same one.
+
+  The rows below are deliberately about the ATTRIBUTED RESULT — the
+  event vector a fired site really dispatched — because the defect
+  raised nothing and rendered fine. A row asserting `no error` passes
+  against it. The bare-fn control at the bottom fires the value the
+  defect produced and pins that it dispatches NOTHING, so the rows above
+  cannot be green for the wrong reason.
+
+  Runs on both hosts: the analyzer is pure and its resolution injected,
+  and the site/commit/fire machinery is common. The mounted half — a
+  real click on a real button — is
+  `re-frame.freehand.compiled-mount-dom-cljs-test`."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.analyze-accept-cljs-test :refer [mk-env]]
+            [re-frame.freehand.compiler.analyze :as ana]
+            [re-frame.freehand.controlled :as controlled]
+            [re-frame.freehand.events :as events]))
+
+(defn- handler-of
+  "The ONE analyzed handler site of `template`."
+  [template]
+  (first (get-in (ana/analyze (mk-env) template) [:props :events])))
+
+(defn- fired
+  "Everything a committed site carrying `value` dispatches when its proxy
+  is fired once with `payload`. The REAL path — one candidate, one
+  commit, the site's own proxy — not a direct call to the body."
+  ([value] (fired value {}))
+  ([value payload]
+   (let [seen  (atom [])
+         owner (events/owner :app/probe)
+         cand  (events/candidate owner)
+         proxy (events/site cand :on-click value events/payload-map)]
+     (events/commit! cand #(swap! seen conj %))
+     (proxy payload)
+     @seen)))
+
+;; ---------------------------------------------------------------------------
+;; The lowering
+;; ---------------------------------------------------------------------------
+
+(deftest a-whole-handler-v-event-lowers-to-the-roster-constructor
+  (testing "The compiled lowering of `(v/event [e] …)` is the EXACT
+            constructor call the interpreted `v/event` macro expands to,
+            wherever the form appears — so both front ends hand the
+            runtime one value with one classification. Asserted as the
+            emitted form, because that form is what the emitters write
+            and nothing downstream wraps it."
+    (let [h (handler-of '[:button {:on-click (event [e] [:app/clicked])} "x"])]
+      (is (= :ui-event (:classification h)))
+      (is (= '(re-frame.freehand.events/callback :event (fn [e] [:app/clicked]) 1)
+             (:form h))
+          "the roster constructor, in the dispatching role, with the declared arity"))
+    (let [h (handler-of '[:input {:on-key-down {"Enter" (event [e] [:app/entered])}}])]
+      (is (= :key-map (:classification h)))
+      (is (= '(re-frame.freehand.events/callback :event (fn [e] [:app/entered]) 1)
+             (get (:form h) "Enter"))
+          "and a key-condition BRANCH lowers to the same constructor it always did")))
+
+  (testing "`v/handler` lowers to its own role through the same
+            constructor, so the value a compiled site carries is the value
+            its interpreted twin carries — one spelling, one roster member.
+            Its firing behaviour never differed from a bare fn's (both arms
+            apply and drop the return), and the structural tree records both
+            under the mode-neutral `{:rf.ui/opaque :fn}` member, so nothing
+            about the recorded tree moves either. What moves is that there
+            is now ONE lowering for the form rather than a bare fn at the
+            whole-handler position and the constructor everywhere else."
+    (let [h (handler-of '[:button {:on-click (handler [e] (.preventDefault e))} "x"])]
+      (is (= :handler (:classification h)))
+      (is (= '(re-frame.freehand.events/callback :handler (fn [e] (.preventDefault e)) 1)
+             (:form h))))))
+
+;; ---------------------------------------------------------------------------
+;; The two halves agree
+;; ---------------------------------------------------------------------------
+
+(deftest the-door-role-and-the-runtime-plan-role-are-the-same-role
+  (testing "The door is told `:event` by `compiled-role`; the runtime
+            reads the lowered VALUE. Both must name the same role, or the
+            compiled site takes a lane its own handler cannot honour —
+            which is exactly what a bare-fn lowering did, with
+            `compiled-role` saying `:event` and `event-plan` saying
+            `:bare-fn`."
+    (let [lowered (events/callback :event (fn [_] [:app/clicked]) 1)]
+      (is (= :event (controlled/compiled-role :ui-event))
+          "the door's half, read from the compiled classification")
+      (is (= :event (:role (events/event-plan lowered)))
+          "the runtime's half, read from the value the lowering produces")
+      (is (contains? controlled/synchronous-outcomes (:role (events/event-plan lowered)))
+          "so a controlled v/event site really is a synchronous-lane outcome"))
+    (is (= :bare-fn (:role (events/event-plan (fn [_] [:app/clicked]))))
+        "non-vacuous: the value the defect produced classifies as something else"))
+
+  (testing "The same agreement, read off a real analyzed site rather
+            than a hand-built value: the analyzed classification and the
+            emitted form's roster role are the same word."
+    (let [h (handler-of '[:input {:value v :on-input (event [e] [:form/typed])}])]
+      (is (true? (:sync? h)) "a controlled v/event site is inside the door")
+      (is (= (controlled/compiled-role (:classification h))
+             (second (:form h)))
+          "the role the door was told IS the role the emitted constructor carries"))))
+
+;; ---------------------------------------------------------------------------
+;; What a fired site actually dispatches
+;; ---------------------------------------------------------------------------
+
+(deftest a-lowered-v-event-site-dispatches-the-vector-its-body-answered
+  (testing "The attributed result. A committed site carrying the LOWERED
+            value dispatches the exact vector the body answered, with the
+            closed projection trio materialized from the payload — and
+            `nil` dispatches nothing, which is how a v/event declines."
+    (is (= [[:app/clicked]]
+           (fired (events/callback :event (fn [_] [:app/clicked]) 1)))
+        "the body's vector reaches dispatch")
+    (is (= [[:form/typed "mike"]]
+           (fired (events/callback :event (fn [_] [:form/typed :re-frame.freehand/value]) 1)
+                  {:re-frame.freehand/value "mike"}))
+        "and its projections materialize from the site's payload")
+    (is (= []
+           (fired (events/callback :event (fn [_] nil) 1)))
+        "a nil answer dispatches nothing, rather than a malformed event"))
+
+  (testing "NON-VACUITY, and the defect itself. The bare `(fn [e] …)` the
+            analyzer used to emit is a legal value at the same site — it
+            fires, raises nothing, and dispatches NOTHING, because
+            `:bare-fn` applies the function for its side effects and
+            discards what it answered. Every row above would be green
+            against that value if it asserted `no error` instead of the
+            vector."
+    (is (= [] (fired (fn [_] [:app/clicked])))
+        "the shape of the bug: fired, silent, and nothing dispatched")
+    (is (= [] (fired (v/handler [_] [:app/clicked])))
+        "and v/handler is the SPELLING for that outcome — its return is dropped")))

--- a/implementation/freehand/test/re_frame/freehand/compiled_mount_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/compiled_mount_dom_cljs_test.cljs
@@ -198,6 +198,19 @@
                         :on-click   [:compiled/pressed]}
    caption])
 
+(v/defview ui-event-probe
+  "A committed site whose intent is a `(v/event …)` CONVERSION rather than
+  a literal vector — the one spelling for an intent the closed projection
+  trio cannot express. The compiled lowering used to hand the runtime the
+  bare fn the callback carries, which `event-plan` classifies `:bare-fn`:
+  the click ran the body and DISCARDED the vector it answered, with no
+  error and nothing on screen to see (rf2-berc2)."
+  {:compiled true}
+  [{:keys [caption]}]
+  [:button#converted.probe {:data-shell (shell-witness)
+                            :on-click   (v/event [e] [:compiled/converted (.-detail e)])}
+   caption])
+
 (v/defview field-probe
   "A CONTROLLED input: a `value` prop makes the element controlled, and
   the door verdict for its handler is decided from those element facts.
@@ -233,6 +246,8 @@
                 (fn [{:keys [db]} _] {:db (update db :presses inc)}))
   (rf/reg-event :compiled/typed
                 (fn [{:keys [db]} [_ v]] {:db (assoc db :text v)}))
+  (rf/reg-event :compiled/converted
+                (fn [{:keys [db]} ev] {:db (update db :converted (fnil conj []) ev)}))
   (rf/reg-event :compiled/total-set
                 (fn [{:keys [db]} [_ n]] {:db (assoc db :total n)})))
 
@@ -462,6 +477,48 @@
                         (.remove container)
                         (done)))))))))
 
+(deftest a-compiled-v-event-site-dispatches-the-vector-its-body-answered
+  (testing "The arm above fires a LITERAL intent. This one fires a
+            `(v/event …)` — a body that CONVERTS the native event into an
+            intent — which is the whole reason the form exists. What is
+            asserted is the vector app-db received, not that the click
+            raised nothing: the defect this row exists for raised nothing
+            at all. It ran the body, discarded the vector, and left an
+            application whose button did exactly nothing with no
+            diagnostic to search for."
+    (if-not (browser?)
+      (skip! "the browser job runs the dispatch assertions")
+      (async done
+        (register!)
+        (seed! {})
+        (let [container (host-node!)
+              mounted   (atom nil)]
+          (-> (act #(v/mount [ui-event-probe {:caption "convert"}] container {:frame fid}))
+              (.then (fn [m]
+                       (reset! mounted m)
+                       (is (= "shell" (attr container "#converted" "data-shell"))
+                           "a v/event site is a reactive site, so the shell is retained")
+                       (is (nil? (:converted (db))) "nothing has been dispatched yet")
+                       (act #(.dispatchEvent (.querySelector container "#converted")
+                                             (js/CustomEvent. "click"
+                                                              #js {:bubbles true :detail 7})))))
+              (.then (fn [_]
+                       (is (= [[:compiled/converted 7]] (:converted (db)))
+                           "the EXACT vector the v/event body answered reached app-db,
+                            carrying the value it read off the native event")
+                       (act #(.dispatchEvent (.querySelector container "#converted")
+                                             (js/CustomEvent. "click"
+                                                              #js {:bubbles true :detail 8})))))
+              (.then (fn [_]
+                       (is (= [[:compiled/converted 7] [:compiled/converted 8]] (:converted (db)))
+                           "and the site's proxy converted the second click too")
+                       (unmount! container @mounted)
+                       (done)))
+              (.catch (fn [e]
+                        (is false (str "v/event arm rejected: " e))
+                        (.remove container)
+                        (done)))))))))
+
 (deftest a-compiled-controlled-input-round-trips-through-app-db
   (testing "A compiled `:input` carrying `value` is CONTROLLED, and its
             handler's lane is decided from those element facts by the one
@@ -542,7 +599,7 @@
             — or a fixture that loaded empty — would leave every
             assertion above green for the wrong reason."
     (doseq [[nm view] {:page compiled/page :inert inert-probe :sub sub-probe
-                       :event event-probe :field field-probe
+                       :event event-probe :ui-event ui-event-probe :field field-probe
                        :crossing crossing-probe}]
       (is (= :compiled (:lowering (v/describe view))) (str nm " is a compiled declaration"))
       (is (some? (v/manifest view)) (str nm " carries a compiled manifest")))

--- a/implementation/freehand/test/re_frame/freehand/emit_cljs_lowering_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/emit_cljs_lowering_cljs_test.cljc
@@ -144,8 +144,10 @@
                                   (forms-of uncontrolled)))]
     (is (some? ev-call)
         "a v/event handler lowers to the compiler-known event-handler seam")
-    (is (= 'fn (first (nth ev-call 2)))
-        "the compiled fn body is passed for invocation with the native event")
+    (is (= 're-frame.freehand.events/callback (first (nth ev-call 2)))
+        (str "the analyzer's ONE lowering of (v/event …) — the roster constructor "
+             "the interpreted macro expands to — is passed for invocation with "
+             "the native event"))
     (is (odd? (nth ev-call 3))
         "bit 0 rides the controlled-input synchronous door, as a literal vector does")
     (is (some? un-call))


### PR DESCRIPTION
Closes the compiled top-level `v/event` silent no-op.

**Sequenced pair.** This PR is the first of two off one worker surface. Its commit is also the first commit of the `v/spread` PR (#6781), which is stacked on it — merge this one first and that one reduces to its own two commits.

## The defect

A whole-handler `(v/event [e] …)` in a `{:compiled true}` body did nothing at all. The build succeeded, the declaration analyzed, the manifest reported the site, the controlled-input door was told the handler's role was `:event` — and the click dispatched nothing, with no diagnostic to search for.

Measured, not read:

```
classification    = :ui-event
lowered form      = (fn [ev] [:app/clicked])
door is told role = :event      ; controlled/compiled-role
runtime plan role = :bare-fn    ; events/event-plan of that lowered value
dispatched        = []          ; fire!'s :bare-fn arm ignores the return
```

`analyze-handler` lowered the form to the BARE `(fn [e] …)` the roster callback *carries* rather than to the callback itself, so `events/event-plan` classified the value `:bare-fn` — whose firing arm applies the function for its side effects and DISCARDS the event vector it answered. The site's two readers disagreed: `controlled/compiled-role` read the compiled CLASSIFICATION and said `:event`; `event-plan` read the VALUE and said `:bare-fn`.

## The fix

The whole-handler position lowers to `(events/callback :event (fn …) 1)` — the exact constructor the interpreted `v/event` macro expands to, and the one a key-condition BRANCH has always lowered to (PR #6769). One value, one classification, one firing arm, whichever front end wrote it.

`v/handler` lowers through the same constructor for the same reason: one lowering for the form, at the whole-handler position as everywhere else.

### On the structural half, and the rebase

The other half of this repair — teaching `node/classify-event` that a roster callback is a fn-carried SITE rather than a malformed value — **landed independently on main while this branch was in flight**, under its own ruling: the site records the mode-neutral `{:rf.ui/opaque :fn}` member 004B §Element fields names, not a per-role marker. This branch originally carried a competing per-role version of the same repair. The rebase keeps **main's ruling** and drops the competing one; nothing else of this branch touched those files, so nothing was lost. The overlay pilot's R-B3 witness — an assertion that passed only while the defect existed — was flipped by main's commit, and main's flip is the one that stands here.

What remains in this PR is the lowering, which main did not have.

## Tests assert the attributed result

This defect raises nothing and renders fine, so a row asserting *no error* passes against it. Every row here asserts the **event vector that was actually dispatched**:

- `compiled-event-lowering-cljs-test` (both hosts) — the lowered value fired through a real candidate/commit/proxy, and the vector it dispatched. It carries the bare-fn control that fires, raises nothing, and dispatches `[]` — the defect itself — so the rows above cannot be green for the wrong reason. It also pins that the door role and the runtime plan role are the same word.
- `compiled-mount-dom-cljs-test` — a real browser click on a real compiled button, asserting `[[:compiled/converted 7]]` reached app-db, carrying the value the body read off the native event.

Non-vacuity: one assertion inverted per new test; the full gate reds naming that test; restored byte-identical. The browser inversion reported `actual: [[:compiled/converted 7]]`, which is the dispatch itself.

## Quality gates

Re-taken in full on the REBASED tree (`30d73300ba` + the stacked commits; main moved a long way, so no pre-rebase number is carried forward). Each gate ran in the foreground to completion, captured to a worktree-local log, exit code read from the runner rather than through a pipe.

| Gate | Result | Exit |
|---|---|---|
| `cd implementation/freehand && clojure -M:test` | 827 tests, 5851 assertions, 0 failures, 0 errors | `0` |
| `npm run test:freehand` (from `implementation/`) | 787 tests, 4774 assertions, 0 failures, 0 errors | `0` |
| `npm run test:cljs` | 10912 tests, 54899 assertions, 0 failures, 0 errors | `0` |
| `npm run test:browser` | 661 tests, 4020 assertions, 0 failures, 0 errors | `0` |
| `python scripts/check_freehand_conformance_index.py` | clean, no output | `0` |

Nothing skipped. The numbers above were measured on the tip of the stacked pair (this commit plus #6781's two), which is a superset of this diff — running each gate once across the pair rather than twice per branch. Every shadow-cljs run printed a `config:` banner naming this worker's worktree.
