### PR TITLE
fix(freehand): emit-react reads v/spread and v/spread-safe, and the coverage table gains the props axis

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/compiled_react.cljs
+++ b/implementation/freehand/src/re_frame/freehand/compiled_react.cljs
@@ -29,8 +29,11 @@
   (:require ["react" :as react]
             [goog.object :as gobj]
             [re-frame.error :as error]
+            [re-frame.freehand.controlled :as controlled]
             [re-frame.freehand.conversion :as conv]
-            [re-frame.freehand.react :as fr]))
+            [re-frame.freehand.react :as fr]
+            [re-frame.freehand.reactive :as reactive]
+            [re-frame.freehand.top-layer :as top-layer]))
 
 ;; ---------------------------------------------------------------------------
 ;; Elements
@@ -106,6 +109,78 @@
   [o slot proxy]
   (when (some? proxy) (gobj/set o slot proxy))
   o)
+
+;; ---------------------------------------------------------------------------
+;; Props forwarding — the attribute map only the render knows
+;; ---------------------------------------------------------------------------
+;;
+;; Spec 004 §Props forwarding. A forwarded map is exactly the value the
+;; compiler cannot see, so the compiled tier settles what it can — the tag, the
+;; `.class` sugar, the element's own literal props, the site ids — and hands the
+;; map itself to the SAME rules the interpreted walk applies entry by entry. The
+;; merge, the deny law and the canonicalization already ran in
+;; `re-frame.freehand.node`, which both front ends call; what is left here is
+;; the write, and the write is `re-frame.freehand.react`'s.
+
+(defn- forward-entry!
+  "Write ONE entry of a forwarded author-space attribute map.
+  `sugar` composes with a forwarded `:class` — `put-attr!`'s own `:class`
+  arm composes with nothing, which is right for a per-attribute write and
+  wrong here, where the element's `.class` sugar has to survive the map."
+  [o tag sugar site-id controlled? k raw]
+  (let [k (conv/attr-key k)]
+    (cond
+      (conv/handler-key? k)
+      ;; A forwarded handler is a committed SITE like any other, keyed by the
+      ;; spread's own lexical id plus the slot it lands in — so the map's
+      ;; `:on-click` owns one stable proxy across re-renders, and two forwarded
+      ;; handlers on one element never share a key.
+      (let [slot (conv/react-event-name k)]
+        (when-some [proxy (reactive/event-site (str site-id "/" slot) raw
+                                               {:tag         tag
+                                                :controlled? controlled?
+                                                :slot        slot})]
+          (gobj/set o slot proxy)))
+
+      (= :class k) (fr/put-class! o tag sugar raw)
+      :else        (fr/put-attr! o tag k raw)))
+  o)
+
+(defn ^:no-doc spread!
+  "Fold `(v/spread base overrides)`'s merged map onto a compiled element's
+  props object.
+
+  A `v/spread` IS the element's whole attribute map — the analyzer records
+  no literal attrs beside it — so every rule applies to the forwarded
+  values and nothing is overwritten: the `.class` sugar composes with a
+  forwarded `:class`, a forwarded `:on-*` becomes a committed site, and
+  whether the element is CONTROLLED is decided from the keys that actually
+  arrived, exactly as the interpreted walk decides it."
+  [o tag sugar site-id m]
+  (let [attrs       (top-layer/without m)
+        controlled? (controlled/controlled-props? (keys attrs))]
+    (reduce-kv (fn [_ k raw] (forward-entry! o tag sugar site-id controlled? k raw) nil)
+               nil attrs)
+    ;; The DOM top layer's desired-state pair is Freehand vocabulary, not an
+    ;; attribute, so a forwarded one becomes the commit-time host call here
+    ;; rather than a garbage prop — the interpreted walk's own arm, over the
+    ;; map it was handed.
+    (top-layer/install! o tag m)))
+
+(defn ^:no-doc caller-spread!
+  "Fold a GUARDED `(v/spread-safe owned caller)` caller map UNDER the owned
+  props already written onto `o` — [[re-frame.freehand.react/put-caller!]],
+  the ONE browser fold, with the compiled tier's own site keying.
+
+  Only the handler keying differs, and it differs the way every compiled
+  site does: the key is the spread's proven lexical id plus the slot,
+  rather than this render's ordinal."
+  [o tag site-id controlled? m]
+  (fr/put-caller! o tag
+                  (fn [slot raw]
+                    (reactive/event-site (str site-id "/" slot) raw
+                                         {:tag tag :controlled? controlled? :slot slot}))
+                  m))
 
 ;; ---------------------------------------------------------------------------
 ;; Children

--- a/implementation/freehand/src/re_frame/freehand/compiler/analyze.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/analyze.cljc
@@ -2553,6 +2553,20 @@
               :slot (prop-slot-name k)
               :marker kind          ; :ui-event | :handler
               :callback-fn form*
+              ;; The lowered VALUE, under the slot every other entry carries
+              ;; its value in. A `v/event` / `v/handler` prop is analysed
+              ;; content, so the entry used to carry the body under
+              ;; `:callback-fn` and NOTHING under `:value` — and both v1
+              ;; emitters read `:value`. The crossing therefore handed the
+              ;; boundary `{:on-pick nil}`: every declaration compiled, every
+              ;; mount resolved, and the callback the author wrote was simply
+              ;; not there. It is the roster constructor for the same reason a
+              ;; DOM-site one is — the interpreted macro expands to exactly
+              ;; this, so the boundary records one marker whichever mode wrote
+              ;; the prop.
+              :value (roster-callback (if (= kind :ui-event) :event :handler)
+                                      form*
+                                      (count bindings))
               :classification kind
               :literal? false}))))
 

--- a/implementation/freehand/src/re_frame/freehand/compiler/emit_react.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/emit_react.cljc
@@ -364,31 +364,35 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- prop-value-form
-  "One call-site prop value. `v/raw-fn` and `v/event` / `v/handler` props
-  are OUTSIDE `:re-frame.freehand/v1`'s reachable surface today (the
-  markers exist because the analyzer is shared with the wider grammar),
-  so the ordinary arm is the whole of what a v1 crossing carries: the
-  walked value, handed to the boundary verbatim, exactly as the
-  interpreted walk hands it.
+  "One call-site prop value — one arm per
+  [[re-frame.freehand.compiler.grammar/crossing-prop-markers]] member.
 
-  A `:render-fn` entry is the exception, and it is not optional: the
-  analyzer records a lexically-visible slot body as an ANALYSED template
-  rather than a form, so such an entry carries no `:value` at all. Left
-  to the ordinary arm it emits `nil` — a prop-carried slot that reaches
-  the seam ABSENT, gating cleanly and rendering nothing, which is the
-  quietest possible failure. The arm below mirrors
-  [[re-frame.freehand.compiler.emit-jvm/prop-value-form]]'s call for
-  call: the same [[re-frame.freehand.events/callback]] carrier the
-  interpreted `v/render-fn` macro expands to, so the boundary records one
-  marker whichever mode wrote the slot; only the BODY differs, and it
-  differs the way every other arm does — it is emitted through this
-  emitter, so the deferred body builds React elements."
+  The ordinary arm (marker `nil`) is the walked value handed to the
+  boundary verbatim, exactly as the interpreted walk hands it, and
+  `:foreign` — a `(v/raw …)` host element — is that same value: React
+  takes the element it was given.
+
+  The other three carry ANALYSED CONTENT rather than a plain value, and
+  each is the shape that reaches an emitter reading only `:value` as
+  `nil`: a prop the boundary receives ABSENT, gating cleanly and
+  rendering nothing, which is the quietest possible failure. Each is
+  rebuilt into the very value the interpreted spelling expands to — the
+  same [[re-frame.freehand.events/callback]] roster carrier — so the
+  boundary records one marker whichever mode wrote the prop. Only a
+  `:render-fn`'s BODY differs, and it differs the way every other arm
+  does: it is emitted through this emitter, so the deferred body builds
+  React elements."
   [e st {:keys [value marker render-fn]}]
   (case marker
     :render-fn `(events/callback
                  :render-fn
                  (fn [~@(:params render-fn)] ~(emit-node e st (:body render-fn)))
                  ~(count (:params render-fn)))
+    ;; `v/raw-fn`'s whole promise is that the identity a foreign API receives
+    ;; is the identity it was given, and the roster carrier is how the
+    ;; boundary knows not to stabilize it. The analyzer strips the wrapper to
+    ;; walk the fn, so the wrapper is restored here.
+    :v/raw-fn `(events/raw-fn ~value)
     value))
 
 (defn- emit-view

--- a/implementation/freehand/src/re_frame/freehand/compiler/emit_react.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/emit_react.cljc
@@ -219,6 +219,33 @@
    :controlled? controlled?
    :slot        (conv/react-event-name (:k handler))})
 
+(defn- spread-write
+  "The runtime fold of `(v/spread base overrides)` onto the props object.
+
+  The merged, refusal-checked, canonical author-space map is built by
+  [[re-frame.freehand.node/spread-attrs]] — the ONE seam an interpreted
+  body reaches through the public `v/spread` — so later-arg-wins, the
+  `:key` refusal and the slot canonicalization are one implementation
+  across both modes, and only the WRITE is this tier's."
+  [o tag cls spread]
+  `(re-frame.freehand.compiled-react/spread!
+    ~o ~tag ~(vec (:sugar cls)) ~(:sid spread)
+    (re-frame.freehand.node/spread-attrs ~(:base spread) ~(:overrides spread))))
+
+(defn- safe-spread-write
+  "The runtime fold of `(v/spread-safe owned caller)`'s guarded caller map,
+  UNDER the owned props this element already wrote.
+
+  The deny law is [[re-frame.freehand.node/safe-caller-attrs]]'s — the
+  every-build owned-key refusal plus the forwarding refusals `v/spread`
+  applies — which is the same call the structural emitter makes, so a
+  component library's bound means one thing in both modes."
+  [o tag controlled? safe]
+  `(re-frame.freehand.compiled-react/caller-spread!
+    ~o ~tag ~(:sid safe) ~controlled?
+    (re-frame.freehand.node/safe-caller-attrs
+     ~(:base safe) ~(:owned-handler-keys safe))))
+
 (defn- handler-writes
   [o tag controlled? events]
   (mapv (fn [{:keys [k sid form] :as handler}]
@@ -297,6 +324,16 @@
                                           ~o ~tag ~k ~value ~multi?))
                                       dynamics))
                       true (into (handler-writes o tag controlled? (:events props)))
+                      ;; Both forwards write LAST, and for the same reason: a
+                      ;; forwarded map is folded against props that are already
+                      ;; final. `v/spread` is the element's whole attribute map,
+                      ;; so it composes with the sugar and nothing else; a
+                      ;; `v/spread-safe` caller folds UNDER what the component
+                      ;; owns, which it can only do once the owned writes are on
+                      ;; the object.
+                      (:spread props)      (conj (spread-write o tag cls (:spread props)))
+                      (:safe-spread props) (conj (safe-spread-write
+                                                  o tag controlled? (:safe-spread props)))
                       (seq top) (conj `(re-frame.freehand.top-layer/install!
                                         ~o ~tag ~top))
                       (:present? key-info)

--- a/implementation/freehand/src/re_frame/freehand/compiler/grammar.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/grammar.cljc
@@ -3,14 +3,23 @@
   opts into with `{:compiled true}`, and the recovery ladder every
   rejection outside it names.
 
-  Two facts live here, and nowhere else:
+  Three facts live here, and nowhere else:
 
   1. **What v1 admits.** [[admitted-ops]] is the closed roster of analyzed
      node kinds a compiled body may lower to. A grammar that is finite is
      a grammar you can *name*: the version keyword is not decoration, it
      is the promise that this roster does not quietly grow under a
      running codebase. It grows by ruling, in a new version.
-  2. **What a rejection tells you to do.** [[recovery]] is total over
+  2. **What a node's PROPS may carry.** [[element-props-carriers]] and
+     [[crossing-prop-markers]] are the grammar's second axis, and the one
+     [[check!]] structurally cannot police: it walks `:op`, and a carrier
+     lives INSIDE a node's `:props`. An emitter that never reads one drops
+     the author's content with nothing raised — which is exactly how
+     `v/spread`, `v/spread-safe` and a call-site `v/render-fn` each
+     reached the DOM as an element that simply did not carry what was
+     written. The rosters exist so the emitter coverage suites can prove
+     one row per carrier the way they already prove one row per node kind.
+  3. **What a rejection tells you to do.** [[recovery]] is total over
      diagnostic ids, and its last rung is always `:keep-interpreted`.
      That rung is always available and always correct, because the
      interpreted mode has NO finite grammar — every body the compiler
@@ -41,6 +50,34 @@
   than defensive."
   #{:text :nothing :expr :element :fragment :view :for :if :let :letfn :case
     :presence :slot})
+
+(def element-props-carriers
+  "The CLOSED roster of an ELEMENT's `:props` slots that carry AUTHORED
+  CONTENT every emitter must read.
+
+  Not the whole props map: `:static?` is a verdict, `:property-props` a
+  classification, and neither is content an author wrote. These seven are,
+  and an emitter that skips one produces a well-formed element missing
+  exactly what the author put in that slot.
+
+  `:ref` is deliberately ABSENT and refused by [[check!]] rather than
+  listed. It is analysed — the wider grammar reads it — but no v1 emitter
+  lowers it, and the interpreted walk refuses it outright while the host
+  lifecycle slice is outstanding. Admitting it here would be a row no
+  emitter can satisfy; leaving it silently unread was the same defect
+  class one more time."
+  #{:attrs :class :style :events :key :spread :safe-spread})
+
+(def crossing-prop-markers
+  "The CLOSED roster of MARKERS one boundary-crossing prop entry may carry
+  — the analyzer's classification of the value at a call-site prop.
+
+  `nil` is the ordinary case: a walked value, handed over verbatim. Every
+  other marker means the entry carries ANALYSED CONTENT under its own key
+  rather than a plain `:value`, which is precisely the shape an emitter
+  reading only `:value` turns into `nil` — a prop that reaches the
+  boundary ABSENT, gating cleanly and rendering nothing."
+  #{nil :render-fn :ui-event :handler :foreign :v/raw-fn})
 
 (def ^:private op-rejections
   "Analyzed node kinds outside v1, each with the sentence that names what
@@ -129,7 +166,12 @@
   Returns `ast` unchanged when the whole body is inside the roster — so
   an emitter downstream can be written against the closed set with no
   unknown-node arm, which is the property that makes 'no hidden
-  interpreted fallback' a structural fact rather than an assertion."
+  interpreted fallback' a structural fact rather than an assertion.
+
+  A `:ref` is refused HERE for the same reason and by the same walk: it
+  is a props carrier no v1 emitter lowers, so a compiled declaration
+  carrying one used to render an element with the ref silently gone,
+  while its interpreted twin refused the same declaration outright."
   [e view-id ast]
   (letfn [(walk [n]
             (cond
@@ -149,7 +191,21 @@
                                     :op       op
                                     :view     view-id
                                     :recovery (conj (or (:recovery row) [])
-                                                    :keep-interpreted)}))))
+                                                    :keep-interpreted)})))
+                    (when (some? (get-in n [:props :ref]))
+                      (env/fail! e :rf.ui.compile/unsupported-form
+                                 (str "a :ref is outside " version " — the finite grammar "
+                                      "{:compiled true} selects. " view-id " cannot be "
+                                      "compiled while its body asks for one. A ref is a "
+                                      "commit-phase host hook and lands with the "
+                                      "host-lifecycle slice; the interpreted walk refuses "
+                                      "it today for the same reason, so a compiled "
+                                      "declaration says so rather than rendering an "
+                                      "element with the ref quietly missing.")
+                                 {:re-frame.freehand/grammar version
+                                  :op       (:op n)
+                                  :view     view-id
+                                  :recovery [:keep-interpreted]})))
                   (run! (fn [[_ v]] (walk v)) n))
 
               (vector? n) (run! walk n)))]

--- a/implementation/freehand/src/re_frame/freehand/react.cljs
+++ b/implementation/freehand/src/re_frame/freehand/react.cljs
@@ -62,6 +62,7 @@
             [re-frame.freehand.error-react :as error-react]
             [re-frame.freehand.errors :as eb]
             [re-frame.freehand.events :as events]
+            [re-frame.freehand.node :as node]
             [re-frame.freehand.presence-runtime :as presence-runtime]
             [re-frame.freehand.shell :as shell]
             [re-frame.freehand.top-layer :as top-layer]
@@ -182,6 +183,60 @@
        :else        (put-plain-attr! o tag k raw))
      o)))
 
+(defn- handler-proxy
+  "What this walk attaches at a handler slot: the site's STABLE PROXY when
+  a candidate owns it, and — with no declared boundary above the element,
+  so no commit that could own a site — the caller's own plain function
+  unchanged, because declarative intent there has nothing to belong to."
+  [cand tag controlled? slot raw]
+  (if (some? cand)
+    (events/site (cell/candidate-events cand)
+                 (cell/next-site-key! cand)
+                 raw
+                 events/default-payload
+                 {:tag tag :controlled? controlled? :slot slot})
+    (when (fn? raw) raw)))
+
+(defn ^:no-doc put-caller!
+  "Fold a GUARDED `(v/spread-safe owned caller)` caller map UNDER a props
+  object whose OWNED props are already final.
+
+  The ONE browser fold, reached from both front ends — the interpreted
+  walk below and the compiled tier's `compiled-react/caller-spread!` — and
+  the counterpart of [[re-frame.freehand.node/fold-caller]] on the
+  structural host. Owned wins every collision (the deny law ran at
+  `node/safe-caller-attrs`, so what can still collide is an ordinary
+  attribute), with `:class` the one exception: the two class values
+  COMPOSE, owned first, because a caller passing `.mt-4` is adding a class
+  and not replacing the component's own. That composition runs through the
+  same class rule by handing the owned `className` in as the leading part,
+  so there is no second ordering to keep in step.
+
+  `site!` records one handler entry and answers its proxy (or nil) — the
+  one thing the two front ends genuinely do differently, because a
+  compiled site is keyed by its proven lexical id and an interpreted one
+  by this walk's ordinal."
+  [o tag site! m]
+  (when (some? m)
+    (reduce-kv
+      (fn [_ k raw]
+        (let [k    (conv/attr-key k)
+              slot (controlled/prop-slot k)]
+          (cond
+            (= :class k)
+            (put-class! o tag (when-some [owned (gobj/get o "className")] [owned]) raw)
+
+            ;; owned wins
+            (and (some? slot) (gobj/containsKey o slot)) nil
+
+            (conv/handler-key? k)
+            (when-some [proxy (site! slot raw)] (gobj/set o slot proxy))
+
+            :else (put-attr! o tag k raw)))
+        nil)
+      nil m))
+  o)
+
 (defn- react-props
   "The React props object for one element: the author attribute map in
   React's CANONICAL prop spelling, with the `.class#id` sugar merged in and
@@ -259,20 +314,9 @@
           (gobj/set o (key empty-slot) (react-control-value (val empty-slot))))
 
         (conv/handler-key? k)
-        (if (some? cand)
-          (when-some [proxy (events/site (cell/candidate-events cand)
-                                         (cell/next-site-key! cand)
-                                         raw
-                                         events/default-payload
-                                         {:tag         tag
-                                          :controlled? controlled?
-                                          :slot        (conv/react-event-name k)})]
-            (gobj/set o (conv/react-event-name k) proxy))
-          ;; No boundary above this element, so no commit can own the
-          ;; site. A plain function is still the caller's own callback and
-          ;; is attached; declarative intent has nothing to belong to.
-          (when (fn? raw)
-            (gobj/set o (conv/react-event-name k) raw)))
+        (let [slot (conv/react-event-name k)]
+          (when-some [proxy (handler-proxy cand tag controlled? slot raw)]
+            (gobj/set o slot proxy)))
 
         (= :class k)
         (put-class! o tag sugar-classes raw)
@@ -621,7 +665,16 @@
                 {:value (shape tag-kw)}))
   (let [{:keys [tag classes id]} (conv/parse-tag tag-kw)
         attrs?    (map? (first args))
-        attrs     (if attrs? (first args) {})
+        authored  (if attrs? (first args) {})
+        ;; `(v/spread-safe owned caller)` answers the OWNED map with the guarded
+        ;; caller riding under the reserved carrier key, because the fold — caller
+        ;; under owned, `:class` composing owned-first — belongs to one place and
+        ;; not to either front end. Left in the attribute map it is not an
+        ;; attribute at all: it reached the plain-attribute path and refused the
+        ;; whole element, so `v/spread-safe` did not render in an interpreted
+        ;; browser view. Split here, exactly as `tree/element-attrs` splits it.
+        caller    (get authored node/caller-attrs-key)
+        attrs     (dissoc authored node/caller-attrs-key)
         kid-forms (if attrs? (rest args) args)
         ;; The DOM top layer's desired-state pair never reaches React as a
         ;; prop — an emitter drops the namespace that is the whole of its
@@ -629,6 +682,10 @@
         ;; commit-time host call instead.
         props     (top-layer/install! (react-props cand tag classes id (top-layer/without attrs))
                                       tag attrs)
+        props     (put-caller! props tag
+                               (let [controlled? (controlled/controlled-props? (keys attrs))]
+                                 (fn [slot raw] (handler-proxy cand tag controlled? slot raw)))
+                               caller)
         kids      (children cand kid-forms)]
     (when (and (seq kids) (contains? conv/children-rejected-tags tag))
       (malformed! (str "The element " tag " cannot have children — it is a void element, and "

--- a/implementation/freehand/test/re_frame/freehand/compiled_mount_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/compiled_mount_dom_cljs_test.cljs
@@ -133,6 +133,14 @@
 (defn- attr [container selector n]
   (some-> (.querySelector container selector) (.getAttribute n)))
 
+(defn- attrs-of
+  "EVERY attribute the matched element carries, as a plain map. Read off
+  `document` rather than named one by one, so an attribute that should
+  not be there fails the comparison too."
+  [container selector]
+  (when-some [el (.querySelector container selector)]
+    (into {} (map (fn [a] [(.-name a) (.-value a)])) (array-seq (.-attributes el)))))
+
 ;; ---------------------------------------------------------------------------
 ;; The shell witness
 ;; ---------------------------------------------------------------------------
@@ -221,6 +229,60 @@
   [_]
   [:input#field {:type :text :value (str (v/sub [:compiled/text]))
                  :on-input [:compiled/typed :re-frame.freehand/value]}])
+
+;; ---------------------------------------------------------------------------
+;; Props forwarding — the SAME body, twice, with nothing but the marker
+;; between them (rf2-51d4q)
+;; ---------------------------------------------------------------------------
+;;
+;; The React emitter read `:attrs`, `:class`, `:style`, `:key` and `:events` off
+;; an element's props and never read `:spread` or `:safe-spread` — so a
+;; `{:compiled true}` declaration forwarding an attribute map mounted an element
+;; with the WHOLE forwarded map missing, and the literal override beside it gone
+;; too. Nothing threw and nothing warned: only the DOM knew.
+;;
+;; So these are pairs. Each claim is asserted on the compiled mount and on its
+;; interpreted twin, read back off `document` the same way, and the two are
+;; compared to each other — which is a stronger row than either alone, because
+;; an emitter that dropped the same attribute in both modes would still fail it.
+
+(def ^:private forwarded
+  "The runtime attribute map both twins forward. A class (which COMPOSES
+  with the tag sugar rather than replacing it), an ordinary attribute, a
+  `data-*`, and a handler that has to become a committed site."
+  {:class "from-caller" :title "forwarded" :data-x "1" :on-click [:compiled/pressed]})
+
+(v/defview spread-probe
+  "`(v/spread base overrides)` — the visible-cost forward. The literal
+  override map is the second argument and wins collisions; the tag's
+  `.card.wide` sugar composes ahead of whatever `:class` arrives."
+  {:compiled true}
+  [{:keys [attrs]}]
+  [:div.card.wide (v/spread attrs {:data-override "literal"})])
+
+(v/defview spread-probe-interpreted
+  "The interpreted twin of `spread-probe` — the same body, without the
+  marker."
+  [{:keys [attrs]}]
+  [:div.card.wide (v/spread attrs {:data-override "literal"})])
+
+(v/defview safe-probe
+  "`(v/spread-safe owned caller)` — the bounded forward a component
+  library uses. The owned props win every collision, `:class` composes
+  owned-first, and the deny law refuses a caller key that would clobber
+  what the component promised."
+  {:compiled true}
+  [{:keys [attrs]}]
+  [:input.field (v/spread-safe {:value "owned" :class "owned-class"
+                                :on-input [:compiled/typed :re-frame.freehand/value]}
+                               attrs)])
+
+(v/defview safe-probe-interpreted
+  "The interpreted twin of `safe-probe`."
+  [{:keys [attrs]}]
+  [:input.field (v/spread-safe {:value "owned" :class "owned-class"
+                                :on-input [:compiled/typed :re-frame.freehand/value]}
+                               attrs)])
 
 (v/defview interpreted-shell
   "An INTERPRETED child, mounted BY a compiled parent below, with children
@@ -519,6 +581,112 @@
                         (.remove container)
                         (done)))))))))
 
+;; ===========================================================================
+;; Props forwarding — the forwarded map really reaches the mounted element
+;; ===========================================================================
+
+(deftest a-compiled-v-spread-carries-the-forwarded-map-onto-the-element
+  (testing "Every attribute the forwarded map and the literal override map
+            carry is ON the mounted element, and the compiled element is
+            attribute-for-attribute the element its interpreted twin
+            mounts. Read off `document`: the defect compiled cleanly,
+            mounted cleanly, and rendered `<div class=\"card wide\">` with
+            everything else silently absent."
+    (if-not (browser?)
+      (skip! "the browser job runs the forwarding assertions")
+      (async done
+        (register!)
+        (seed! {:presses 0})
+        (let [c-compiled    (host-node!)
+              c-interpreted (host-node!)
+              mounts        (atom [])]
+          (-> (act #(reset! mounts
+                            [(v/mount [spread-probe {:attrs forwarded}] c-compiled {:frame fid})
+                             (v/mount [spread-probe-interpreted {:attrs forwarded}]
+                                      c-interpreted {:frame fid})]))
+              (.then (fn [_]
+                       (is (= {"class"         "card wide from-caller"
+                               "title"         "forwarded"
+                               "data-x"        "1"
+                               "data-override" "literal"}
+                              (attrs-of c-compiled "div"))
+                           "the forwarded map, the literal override, and the sugar
+                            composed ahead of the forwarded class")
+                       (is (= (attrs-of c-interpreted "div") (attrs-of c-compiled "div"))
+                           "and the compiled element IS the interpreted twin's element")
+                       (is (= 0 (:presses (db))) "nothing dispatched before the click")
+                       (act #(.click (.querySelector c-compiled "div")))))
+              (.then (fn [_]
+                       (is (= 1 (:presses (db)))
+                           "a FORWARDED handler became a committed site and dispatched")
+                       (act #(.click (.querySelector c-interpreted "div")))))
+              (.then (fn [_]
+                       (is (= 2 (:presses (db)))
+                           "and the interpreted twin's forwarded handler dispatched too")
+                       (doseq [[c m] (map vector [c-compiled c-interpreted] @mounts)]
+                         (unmount! c m))
+                       (done)))
+              (.catch (fn [e]
+                        (is false (str "spread arm rejected: " e))
+                        (.remove c-compiled)
+                        (.remove c-interpreted)
+                        (done)))))))))
+
+(deftest a-compiled-v-spread-safe-folds-the-guarded-caller-under-the-owned-props
+  (testing "The guarded caller map reaches the element; the OWNED props win
+            every collision; `:class` is the one exception and COMPOSES,
+            owned first. Asserted against the interpreted twin, which
+            reaches the same fold through the same function."
+    (if-not (browser?)
+      (skip! "the browser job runs the forwarding assertions")
+      (async done
+        (register!)
+        (seed! {:text ""})
+        (let [caller        {:title "from-caller" :class "caller-class" :aria-label "L"}
+              c-compiled    (host-node!)
+              c-interpreted (host-node!)
+              mounts        (atom [])]
+          (-> (act #(reset! mounts
+                            [(v/mount [safe-probe {:attrs caller}] c-compiled {:frame fid})
+                             (v/mount [safe-probe-interpreted {:attrs caller}]
+                                      c-interpreted {:frame fid})]))
+              (.then (fn [_]
+                       (is (= {"class"      "field owned-class caller-class"
+                               "title"      "from-caller"
+                               "aria-label" "L"
+                               "value"      "owned"}
+                              (attrs-of c-compiled "input"))
+                           "the caller's attributes landed, and the classes composed
+                            owned-first")
+                       (is (= (attrs-of c-interpreted "input") (attrs-of c-compiled "input"))
+                           "and the compiled element IS the interpreted twin's element")
+                       (is (= "owned" (.-value (.querySelector c-compiled "input")))
+                           "the owned controlled value is what React is holding")
+                       (doseq [[c m] (map vector [c-compiled c-interpreted] @mounts)]
+                         (unmount! c m))
+                       (done)))
+              (.catch (fn [e]
+                        (is false (str "spread-safe arm rejected: " e))
+                        (.remove c-compiled)
+                        (.remove c-interpreted)
+                        (done)))))))))
+
+(deftest the-spread-safe-deny-law-still-fires-through-the-compiled-fold
+  (testing "The bound is the whole point of the form, so it is not
+            dev-gated and it does not lapse because the element was
+            compiled: a caller map carrying an OWNED or structural key is
+            refused, in both modes, from the one guard both folds call."
+    (doseq [[what caller] {"an owned controlled prop" {:value "clobbered"}
+                           "an owned handler family"  {:on-input [:caller/typed]}
+                           "the reconciliation key"   {:key "k"}}]
+      (is (= :rf.error/ui-tree-malformed
+             (conf/caught-id #(v/spread-safe {:value "owned"
+                                              :on-input [:compiled/typed]}
+                                             caller)))
+          (str what " is denied to the caller")))
+    (is (map? (v/spread-safe {:value "owned"} {:title "fine"}))
+        "non-vacuous: an ordinary caller key passes the same guard")))
+
 (deftest a-compiled-controlled-input-round-trips-through-app-db
   (testing "A compiled `:input` carrying `value` is CONTROLLED, and its
             handler's lane is decided from those element facts by the one
@@ -600,11 +768,15 @@
             assertion above green for the wrong reason."
     (doseq [[nm view] {:page compiled/page :inert inert-probe :sub sub-probe
                        :event event-probe :ui-event ui-event-probe :field field-probe
+                       :spread spread-probe :safe safe-probe
                        :crossing crossing-probe}]
       (is (= :compiled (:lowering (v/describe view))) (str nm " is a compiled declaration"))
       (is (some? (v/manifest view)) (str nm " carries a compiled manifest")))
-    (is (= :interpreted (:lowering (v/describe interpreted-shell)))
-        "and the crossing target is genuinely interpreted")
+    (doseq [[nm view] {:crossing-target interpreted-shell
+                       :spread-twin     spread-probe-interpreted
+                       :safe-twin       safe-probe-interpreted}]
+      (is (= :interpreted (:lowering (v/describe view)))
+          (str nm " is genuinely interpreted — the forwarding twins are the control")))
     (is (<= 8 (count (:dom struct-007))) "the fixture's DOM table is fully loaded")
     (is (not= (:view-cell (v/manifest inert-probe))
               (:view-cell (v/manifest sub-probe)))

--- a/implementation/freehand/test/re_frame/freehand/compiled_mount_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/compiled_mount_dom_cljs_test.cljs
@@ -284,6 +284,23 @@
                                 :on-input [:compiled/typed :re-frame.freehand/value]}
                                attrs)])
 
+(v/defview callback-sink
+  "A child that ATTACHES the callback its parent handed it. The prop is an
+  ordinary value to this view; what it has to BE is a roster callback, or
+  the site it lands on has nothing to dispatch."
+  [{:keys [on-pick]}]
+  [:button#sink {:on-click on-pick} "pick"])
+
+(v/defview callback-parent
+  "A compiled parent passing `(v/event …)` ACROSS a boundary. The analyzer
+  records such a prop as analysed content under its own key, so both v1
+  emitters — reading `:value` — put `nil` on the props map: every
+  declaration compiled, every mount resolved, and the callback the author
+  wrote was simply not there."
+  {:compiled true}
+  [_]
+  [:div [callback-sink {:on-pick (v/event [e] [:compiled/converted (.-detail e)])}]])
+
 (v/defview interpreted-shell
   "An INTERPRETED child, mounted BY a compiled parent below, with children
   the compiled parent already lowered into React elements."
@@ -671,6 +688,39 @@
                         (.remove c-interpreted)
                         (done)))))))))
 
+(deftest a-compiled-v-event-prop-arrives-at-the-boundary-and-dispatches
+  (testing "The same defect one boundary further out. A `(v/event …)` at a
+            CALL SITE is analysed content, and an emitter reading only
+            `:value` hands the crossing `{:on-pick nil}` — a callback that
+            reaches the child ABSENT, so the button it lands on does
+            nothing. What is asserted is the vector app-db received after a
+            real click on the CHILD's element."
+    (if-not (browser?)
+      (skip! "the browser job runs the crossing assertions")
+      (async done
+        (register!)
+        (seed! {})
+        (let [container (host-node!)
+              mounted   (atom nil)]
+          (-> (act #(v/mount [callback-parent {}] container {:frame fid}))
+              (.then (fn [m]
+                       (reset! mounted m)
+                       (is (some? (.querySelector container "#sink"))
+                           "the child mounted")
+                       (act #(.dispatchEvent (.querySelector container "#sink")
+                                             (js/CustomEvent. "click"
+                                                              #js {:bubbles true :detail 5})))))
+              (.then (fn [_]
+                       (is (= [[:compiled/converted 5]] (:converted (db)))
+                           "the callback crossed the boundary intact and dispatched
+                            the vector its body answered")
+                       (unmount! container @mounted)
+                       (done)))
+              (.catch (fn [e]
+                        (is false (str "crossing callback arm rejected: " e))
+                        (.remove container)
+                        (done)))))))))
+
 (deftest the-spread-safe-deny-law-still-fires-through-the-compiled-fold
   (testing "The bound is the whole point of the form, so it is not
             dev-gated and it does not lapse because the element was
@@ -769,6 +819,7 @@
     (doseq [[nm view] {:page compiled/page :inert inert-probe :sub sub-probe
                        :event event-probe :ui-event ui-event-probe :field field-probe
                        :spread spread-probe :safe safe-probe
+                       :callback-parent callback-parent
                        :crossing crossing-probe}]
       (is (= :compiled (:lowering (v/describe view))) (str nm " is a compiled declaration"))
       (is (some? (v/manifest view)) (str nm " carries a compiled manifest")))

--- a/implementation/freehand/test/re_frame/freehand/react_lowering_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/react_lowering_jvm_test.clj
@@ -109,6 +109,131 @@
     (is (= grammar/admitted-ops (into #{} (map :op) rows))
         "one row per admitted node kind, and no row outside the roster")))
 
+;; ---------------------------------------------------------------------------
+;; The OTHER axis — one row per props CARRIER
+;; ---------------------------------------------------------------------------
+;;
+;; The table above is per node KIND, and a per-kind table has a structural
+;; blind spot: `grammar/check!` walks `:op`, and so does the coverage
+;; assertion, but the content an author writes mostly lives INSIDE a node's
+;; `:props`. `:element` is admitted, so an emitter that never read
+;; `(:spread props)` produced a perfectly well-formed `:element` with the
+;; whole forwarded attribute map missing, and every row above stayed green.
+;;
+;; Three defects of exactly that shape landed in a row — a call-site
+;; `v/render-fn` emitting `nil`, `v/spread` / `v/spread-safe` dropped
+;; entirely, a call-site `v/event` emitting `nil` — so the table gained the
+;; second axis. Each row names a carrier, proves the analyzed AST really
+;; FILLS it, and asserts the emitted form REACHES the lowering that carrier
+;; requires. The coverage assertions hold the tables to
+;; `grammar/element-props-carriers` and `grammar/crossing-prop-markers`,
+;; exactly as the kind table is held to `grammar/admitted-ops`.
+
+(defn- emitted
+  "The React lowering of one body, as text to look for calls in."
+  [body]
+  (let [[e ast] (analyzed body)]
+    (pr-str (emit-react/emit-react-body e '[props] ast))))
+
+(def element-rows
+  "One source body per ELEMENT props carrier. `:reaches` is the call that
+  proves the emitter read it — a per-carrier claim, because `some?` on the
+  whole emission proves nothing: a dropped carrier still emits an element."
+  [{:carrier :attrs       :body '[:div {:title (:t props)}]
+    :reaches "compiled-react/attr!"}
+   {:carrier :class       :body '[:div {:class (:c props)}]
+    :reaches "compiled-react/class!"}
+   {:carrier :style       :body '[:div {:style (:s props)}]
+    :reaches "compiled-react/style!"}
+   {:carrier :events      :body '[:div {:on-click [:app/go]}]
+    :reaches "re-frame.freehand.reactive/event-site"}
+   {:carrier :key         :body '[:div {:key (:k props)}]
+    :reaches "cljs.core/unchecked-set"}
+   {:carrier :spread      :body '[:div.sugar (v/spread (:attrs props) {:class "c"})]
+    :reaches "re-frame.freehand.node/spread-attrs"}
+   {:carrier :safe-spread :body '[:input (v/spread-safe {:value "v"} (:attrs props))]
+    :reaches "re-frame.freehand.node/safe-caller-attrs"}])
+
+(def crossing-rows
+  "One source body per CROSSING prop marker. `:reaches` is what the emitted
+  props map must carry for the prop to arrive at all."
+  [{:marker nil          :body '[:div [leaf {:label (:l props)}]]
+    :reaches ":label (:l props)"}
+   {:marker :render-fn   :body '[:div [leaf {:row (v/render-fn [r] [:span r])}]]
+    :reaches ":render-fn"}
+   {:marker :ui-event    :body '[:div [leaf {:on-pick (v/event [x] [:app/picked x])}]]
+    :reaches ":event"}
+   {:marker :handler     :body '[:div [leaf {:on-done (v/handler [x] (prn x))}]]
+    :reaches ":handler"}
+   {:marker :foreign     :body '[:div [leaf {:node (v/raw (host-element))}]]
+    :reaches "(host-element)"}
+   {:marker :v/raw-fn    :body '[:div [leaf {:cb (v/raw-fn (:f props))}]]
+    :reaches "re-frame.freehand.events/raw-fn"}])
+
+(defn- carriers-of
+  "Every ELEMENT props carrier the analyzed AST actually filled."
+  [ast]
+  (let [found (volatile! #{})]
+    (walk/postwalk (fn [x]
+                     (when (= :element (:op x))
+                       (doseq [[k v] (:props x)
+                               :when (and (contains? grammar/element-props-carriers k)
+                                          (if (= :key k) (:present? v) (seq v)))]
+                         (vswap! found conj k)))
+                     x)
+                   ast)
+    @found))
+
+(deftest the-react-emitter-reads-every-element-props-carrier
+  (testing "A carrier the emitter never reads is not a crash and not a
+            diagnostic — it is a well-formed element missing exactly what
+            the author put in that slot. So each row proves its carrier is
+            really in the analyzed props, then proves the emission reaches
+            the lowering that carrier requires."
+    (doseq [{:keys [carrier body reaches]} element-rows]
+      (let [[_ ast] (analyzed body)]
+        (is (contains? (carriers-of ast) carrier)
+            (str carrier " — the row really fills the carrier it names")))
+      (is (.contains ^String (emitted body) ^String reaches)
+          (str carrier " — the emitted body reaches " reaches)))))
+
+(deftest the-react-emitter-lowers-every-crossing-prop-marker
+  (testing "A marked crossing prop carries ANALYSED CONTENT under its own
+            key rather than a plain `:value`, which is exactly the shape an
+            emitter reading only `:value` turns into `nil` — a prop that
+            reaches the boundary ABSENT and renders nothing. Each row
+            asserts what the emitted props map must carry, and that it
+            carries no nil under the prop's own key."
+    (doseq [{:keys [marker body reaches]} crossing-rows]
+      (let [text (emitted body)]
+        (is (.contains ^String text ^String reaches)
+            (str marker " — the emitted props map reaches " reaches))
+        (is (not (re-find #":(label|row|on-pick|on-done|node|cb) nil" text))
+            (str marker " — and the boundary is not handed an absent prop"))))))
+
+(deftest the-props-tables-cover-the-whole-admitted-rosters
+  (testing "A per-carrier table is only as good as its coverage, so the
+            coverage is the assertion — the same claim the node-kind table
+            above makes, on the axis that table cannot see."
+    (is (= grammar/element-props-carriers (into #{} (map :carrier) element-rows))
+        "one row per element props carrier, and no row outside the roster")
+    (is (= grammar/crossing-prop-markers (into #{} (map :marker) crossing-rows))
+        "one row per crossing prop marker, and no row outside the roster")))
+
+(deftest a-ref-is-refused-rather-than-silently-unread
+  (testing "`:ref` is a props carrier no v1 emitter lowers, so the grammar
+            refuses it. Silently leaving it unread rendered an element with
+            the ref gone, while the same declaration INTERPRETED refuses
+            outright — one declaration, two answers, neither of them said."
+    (is (= :rf.ui.compile/unsupported-form
+           (try (analyzed '[:div {:ref (v/raw-fn (:f props))}])
+                nil
+                (catch clojure.lang.ExceptionInfo ex
+                  (:rf.ui.compile/error (ex-data ex)))))
+        "a compiled :ref names the grammar that refused it")
+    (is (some? (analyzed '[:div {:title "t"}]))
+        "non-vacuous: the same element without a ref compiles")))
+
 (deftest a-compiled-slot-lowers-to-the-shared-carrier-contract
   (testing "The browser lowering reaches the SAME three runtime calls the
             structural one does — the gate, the host-independent arity


### PR DESCRIPTION
Closes the `emit-react` props-forwarding silent drop, and the structural hole that hid it.

**Now standalone.** This was stacked on #6780 (`rf2-berc2`); that PR has merged, so this branch is rebased onto current `main` and the berc2 commit dropped out as already-upstream. What remains is this bead's two commits and nothing else:

- `be6db500ae` — the React emitter reads `v/spread` and `v/spread-safe`.
- `c98b960bfc` — the emitter coverage table gains the props axis.

## The defect

`emit-element*` read `:attrs`, `:class`, `:style`, `:key` and `:events` off an element's analyzed props — and never `:spread` or `:safe-spread`. So a `{:compiled true}` declaration forwarding an attribute map compiled cleanly, mounted cleanly, and rendered an element with the whole forwarded map missing, and the literal override beside it gone too:

```clojure
[:div.sugar (v/spread attrs {:class "c"})]
;; emitted
(compiled-react/el "div" (js-obj "className" "sugar") nil)
```

Not a crash, not a diagnostic, not a warning — only the DOM knew.

## The fix

The React emitter gains the two arms its structural sibling has, folded through the SAME `node/spread-attrs` / `node/safe-caller-attrs` seams both modes already call — so the merge, the deny law, the `:key` refusal and the slot canonicalization stay one implementation. What is added is the WRITE, and the write is `re-frame.freehand.react`'s: every forwarded entry goes through `put-attr!` / `put-class!`, a forwarded `:on-*` becomes a committed site keyed by the spread's own lexical id plus its slot, and whether the element is CONTROLLED is decided from the keys that actually arrived, exactly as the interpreted walk decides it.

Fixing it exposed the same defect on the other side, and the bead's premise with it. `v/spread-safe` answers the owned map with the guarded caller riding under the reserved carrier key — and the interpreted BROWSER walk never split that key out. It reached the plain-attribute path, which refuses a map value, so **`v/spread-safe` did not render at all in an interpreted browser view**:

```
The :rf.ui/caller attribute on :input carries a map, which has no attribute spelling.
```

The walk now splits it exactly as `tree/element-attrs` does structurally, and both front ends fold through ONE function — `react/put-caller!`, the browser counterpart of `node/fold-caller`. Owned wins every collision; `:class` composes owned-first, through the same class rule, by handing the owned `className` in as the leading part.

## The structural hole — the part worth more than the point fixes

Three silent drops landed in a row and every one slipped past the same gate for the same reason. `grammar/check!` walks `:op`, and so did the React emitter's coverage table — but the content an author writes mostly lives INSIDE a node's `:props`. `:element` is admitted, so an emitter that never read `(:spread props)` produced a perfectly well-formed `:element` and every row of the table stayed green.

So the grammar now states its second axis where it already states the first — `element-props-carriers` and `crossing-prop-markers`, beside `admitted-ops` — and the React lowering suite gains one table per roster. Each row proves the analyzed AST really FILLS the carrier it names, then proves the emission REACHES the lowering that carrier requires; a coverage assertion holds each table to its roster.

It is not a table written to fit. Reverting the two fixes above reds precisely the rows that name them: `:spread` and `:safe-spread` fail their `:reaches`, and the crossing rows report `":on-pick nil"` — the defect's own signature. The `:render-fn` row catches the third instance (PR #6771) by the same mechanism.

Writing the tables turned up **two more instances of the class**, both fixed here:

- **A `(v/event …)` / `(v/handler …)` at a CALL SITE emitted `nil` in BOTH v1 emitters.** The analyzer recorded the lowered body under `:callback-fn` with nothing under `:value`, and both emitters read `:value`. A compiled parent handed the crossing `{:on-pick nil}` — every declaration compiled, every mount resolved, and the callback the author wrote was not there. It now carries the roster constructor under the slot every other entry uses, so both emitters get it from the arm they already had, and a compiled parent's structural tree is identical to its interpreted twin's. `v/raw-fn` at a crossing prop had the sibling shape (the analyzer strips the wrapper to walk the fn and never restored it), so the child received a bare function where the roster carrier is the whole promise.
- **`:ref` is a props carrier NO v1 emitter lowers.** A compiled declaration carrying one rendered an element with the ref quietly gone, while the same declaration interpreted refuses outright. `check!` now refuses it, naming the grammar and the ladder — a clear fail-fast where there was a silent drop, and the roster is honest rather than quietly short one row.

## Tests assert the attributed result

These defects raise nothing and produce well-formed output with the wrong content, so *"nothing complained"* is not an assertion. The browser rows are **pairs**: the SAME body declared twice with nothing but `{:compiled true}` between them, mounted side by side, and compared attribute-for-attribute off `document`.

- the forwarded map, the literal override and the sugar composed ahead of the forwarded class: `{"class" "card wide from-caller", "title" "forwarded", "data-x" "1", "data-override" "literal"}` — and the compiled element's attribute MAP equals the interpreted twin's, so an attribute that should not be there fails too;
- a FORWARDED `:on-click` becomes a committed site and dispatches, in both modes;
- `v/spread-safe`: `{"class" "field owned-class caller-class", "title" "from-caller", "aria-label" "L", "value" "owned"}` — caller attrs land, owned wins, classes compose owned-first — again equal across modes;
- the deny law still fires through the compiled fold, with a non-vacuous control that an ordinary caller key passes the same guard;
- a `(v/event …)` passed ACROSS a boundary reaches the child intact and dispatches `[[:compiled/converted 5]]` on a real click of the CHILD's element.

Non-vacuity: one assertion inverted per new test; the full gate reds naming that test; restored byte-identical. Each inverted browser row reported the real forwarded values as `actual`.

## Quality gates

Re-taken in full on the rebased tree (tip `c98b960bfc`, onto `533f8012ba`). Main has moved twice under this branch, so no earlier number is carried forward. Each gate ran in the foreground to completion, captured to a worktree-local log with a branch-specific name, exit code read from the runner rather than through a pipe.

| Gate | Result | Exit |
|---|---|---|
| `cd implementation/freehand && clojure -M:test` | 827 tests, 5867 assertions, 0 failures, 0 errors | `0` |
| `npm run test:freehand` (from `implementation/`) | 792 tests, 4789 assertions, 0 failures, 0 errors | `0` |
| `npm run test:cljs` | 10917 tests, 54914 assertions, 0 failures, 0 errors | `0` |
| `npm run test:browser` | 666 tests, 4103 assertions, 0 failures, 0 errors | `0` |
| `python scripts/check_freehand_conformance_index.py` | clean, no output | `0` |

Nothing skipped. Every shadow-cljs run printed a `config:` banner naming this worker's worktree.

The earlier red on the JVM core job was `jvm-provenance-entry-is-weak-and-expunged-when-its-throwable-dies` — a `System/gc` retry loop waiting on a `WeakReference`, non-deterministic by construction. This diff touches no core namespace and no shared spec file, so it cannot reach that path; the re-run went green.
