### PR TITLE
test(freehand): prove the controlled-input console watch reds; retire the stale pilot ref heading

### DIFF
--- a/implementation/freehand/test/re_frame/freehand/controlled_input_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/controlled_input_dom_cljs_test.cljs
@@ -262,7 +262,34 @@
   "Collect what React says on `console.error` while a transition runs, and
   answer the restore thunk. The controlled↔uncontrolled complaint is a
   console diagnostic and nothing else — no exception, no visible failure —
-  so a suite that does not listen for it cannot see it."
+  so a suite that does not listen for it cannot see it.
+
+  ## What listening for a HOST library's warning actually buys
+
+  An assertion of the form \"the host said nothing\" inherits that host's
+  WARNING POLICY, including every case where it declines to warn. React
+  19's policy is not uniform across the three diagnostics this file reads,
+  and the differences decide which shape each row has to take:
+
+  - the controlled↔uncontrolled complaint is raised from React's UPDATE
+    path only. It compares the props last committed against the props now
+    committing, so no mount can raise it and a row watching for it MUST
+    be shaped as a transition. It is also latched behind a page-global
+    one-shot flag: React says it ONCE per page, ever;
+  - the `value should not be null` complaint is raised on mount, update
+    and hydration alike, and is latched behind its own page-global
+    one-shot flag;
+  - the `<select>` value-SHAPE complaint is raised on mount and hydration
+    only — never on update — and is not latched at all. A row watching
+    for it must therefore MOUNT the shape it is judging.
+
+  A one-shot flag is the part that bites silently: this file's browser
+  suite is one page, so the first test anywhere in it that legitimately
+  trips a latched diagnostic disarms every later row watching for the
+  same one, and those rows go green while proving nothing. The last
+  deftest in this namespace is the control for that — it drives a field
+  genuinely uncontrolled and REQUIRES React to complain, which can only
+  succeed if the latch was still closed everywhere above it."
   [sink]
   (let [original (.-error js/console)]
     (set! (.-error js/console)
@@ -283,7 +310,12 @@
   `value` is the WRONG SHAPE — a scalar on a multiple select, or an array
   on a single one. Like the controlled/uncontrolled complaint it is a
   console diagnostic and nothing else, so a suite that does not listen for
-  it renders a visibly-correct page over a contract it is breaking."
+  it renders a visibly-correct page over a contract it is breaking.
+
+  React runs this check when the element is CREATED and when it is
+  hydrated, and at no other time: an update never re-reads the shape. So
+  a row asking this question judges the shape of the value the node was
+  MOUNTED with, whatever else has happened to the node since."
   [lines]
   (filterv #(re-find #"(?i)must be an array|must be a scalar" %) lines))
 
@@ -505,7 +537,23 @@
             it keeps the value it last rendered. The symptom is the old
             text still on screen while application state says empty, on a
             site the door has already put on the synchronous lane, so
-            nothing throws and nothing else says so."
+            nothing throws and nothing else says so.
+
+            The console row is shaped as a TRANSITION on purpose, and the
+            shape is load-bearing rather than incidental. React raises the
+            controlled↔uncontrolled complaint by comparing the props it
+            last committed against the props it is committing now, which
+            it can only do on an update — mounting an already-uncontrolled
+            node raises nothing at all. Rewriting this row to mount the
+            bad state, the way a value-SHAPE row has to be written, would
+            silence it permanently.
+
+            It has been shown to fail: drop the nil `:value` slot instead
+            of writing the controlled empty value and React answers with
+            `A component is changing a controlled input to be
+            uncontrolled`, and the row reds. Dropping the nil `:checked`
+            slot reds it the same way — the diagnostic reads whichever
+            slot the element's `type` makes its controlling one."
     (if-not (browser?)
       (skip! "the browser job runs the clearing assertions")
       (async done
@@ -608,7 +656,18 @@
             visible to a structural assertion, and a wrong shape does not
             throw: React writes a console diagnostic and renders a page
             that can look entirely correct, which is why the console is
-            watched here as closely as the DOM is."
+            watched here as closely as the DOM is.
+
+            What the console CANNOT see here is the clearing transition
+            itself. React re-reads a select's value shape at no point
+            after creation, and it has no controlled↔uncontrolled
+            complaint for `<select>` at all — an emitter that stopped
+            writing the slot leaves the old options selected in total
+            silence. So the clearing claim rests on the DOM row that
+            reads `selectedOptions` back, and the console rows after it
+            are the mount's verdict restated plus the one complaint a
+            select does still make on update: that its `value` arrived as
+            a literal null."
     (if-not (browser?)
       (skip! "the browser job runs the multiple-select assertions")
       (async done
@@ -646,13 +705,102 @@
                                         (str "an explicit nil cleared every selected option "
                                              "— the node holds " (pr-str (picked sel))))
                                     (is (= [] (control-complaints @errors))
-                                        (str "React raised no controlled/uncontrolled "
-                                             "diagnostic across the whole sequence: "
-                                             (pr-str @errors)))
+                                        (str "the empty selection reached React as the "
+                                             "empty ARRAY and never as a literal null — "
+                                             "the one control complaint a `<select>` "
+                                             "still makes on update: " (pr-str @errors)))
                                     (is (= [] (value-shape-complaints @errors))
-                                        (str "and none about the value's shape: "
+                                        (str "and the mount's shape verdict still stands, "
+                                             "unchanged by anything since: "
                                              (pr-str @errors)))
                                     (finish))))))))))
+              (.catch (fn [e]
+                        (is false (str "mount rejected: " e))
+                        (finish)))))))))
+
+;; ===========================================================================
+;; THE CONTROL FOR THE CONSOLE ITSELF — declared LAST, and that is the point
+;; ===========================================================================
+
+(v/defview slot-dropping-field
+  "The ONE deliberately wrong view in this file: when state goes nil it
+  OMITS `:value` rather than writing the controlled empty value, which is
+  exactly the emitter defect the clearing row asserts React does not
+  report. Nothing reads it but the control below."
+  [_]
+  (let [text (cell/observe! query)]
+    (if (nil? text)
+      [:input {:id        "slot-dropped"
+               :on-change [evt :re-frame.freehand/value]}]
+      [:input {:id        "slot-dropped"
+               :value     text
+               :on-change [evt :re-frame.freehand/value]}])))
+
+(v/defview slot-dropping-page
+  [_]
+  [:div [slot-dropping-field {}]])
+
+(defn- render-slot-dropping-page!
+  [root db]
+  (act #(do (frame/replace-app-db! fid db)
+            (.render root (shell/provide-frame fid (fr/element [slot-dropping-page {}]))))))
+
+(deftest fh-input-003-the-controlled-to-uncontrolled-channel-was-still-live
+  (testing "The CONTROL for every `React said nothing` row above, and the
+            reason they are claims rather than silence about silence. A
+            row that watches a host library for a warning inherits that
+            library's warning POLICY, and React's policy for the
+            controlled↔uncontrolled complaint is to raise it ONCE per
+            page and never again. This suite is one page. So the first
+            test anywhere in it that legitimately drives a field
+            uncontrolled spends the diagnostic, and every later row
+            watching for it goes green having proved nothing — with
+            nothing on screen to say so.
+
+            This row drives a field genuinely uncontrolled and REQUIRES
+            the complaint. It can only arrive if the latch was still
+            closed, which it can only have been if no row above it
+            consumed it. Declared LAST for that reason: it spends the
+            diagnostic itself, so anything wanting it must come first.
+
+            The DOM row underneath it is this control's own control —
+            React does not clear an uncontrolled node, so the field must
+            still be holding the text it was seeded with. A field that
+            cleared anyway never went uncontrolled, and a complaint about
+            it would be about something else."
+    (if-not (browser?)
+      (skip! "the browser job runs the console control")
+      (async done
+        (reg!)
+        (let [{:keys [seed]} (:clearing input-003)
+              _ (make-frame! {:text seed})
+              [container root] (mount!)
+              errors  (atom [])
+              restore (spy-console-errors! errors)
+              finish  (fn [] (restore) (teardown! container root) (done))]
+          (-> (render-slot-dropping-page! root {:text seed})
+              (.then
+                (fn [_]
+                  (let [field (node container "slot-dropped")]
+                    (is (= seed (.-value field)) "the control field starts controlled")
+                    (-> (render-slot-dropping-page! root {:text nil})
+                        (.then
+                          (fn [_]
+                            (is (identical? field (node container "slot-dropped"))
+                                (str "the SAME host node — an update, which is the only "
+                                     "path that can raise the diagnostic at all"))
+                            (is (= seed (.-value field))
+                                (str "the node really did go uncontrolled — React kept the "
+                                     "text it last rendered instead of clearing it; it "
+                                     "holds " (pr-str (.-value field))))
+                            (is (seq (control-complaints @errors))
+                                (str "React did NOT report a field that genuinely went "
+                                     "uncontrolled. It raises that diagnostic once per "
+                                     "PAGE, so something above this row already spent it "
+                                     "— which means every `React said nothing` row in "
+                                     "this namespace was unable to fail. Captured: "
+                                     (pr-str @errors)))
+                            (finish)))))))
               (.catch (fn [e]
                         (is false (str "mount rejected: " e))
                         (finish)))))))))

--- a/implementation/freehand/test/re_frame/freehand/pilot_overlay.cljc
+++ b/implementation/freehand/test/re_frame/freehand/pilot_overlay.cljc
@@ -54,7 +54,7 @@
   What is genuinely left is MEASUREMENT — where to put the panel — and
   that is exactly one registered behavior.
 
-  ## The two refs that must not meet
+  ## The two refs, and why they still sit apart
 
   [[anchor-box]] is attached to the dropdown's ROOT element, and the
   desired-state property is declared on the PANEL element inside it. That


### PR DESCRIPTION
Two beads, one class: a test or its prose had drifted from what the code
actually does.

## rf2-kynqa — the console watch is armed, and now stays armed

**The suspicion was that `fh-input-003-an-explicit-nil-clears-the-live-node`
could not fail.** It can. Fed known-bad input — the nil `:value` slot
dropped rather than written as the controlled empty value, which is
exactly the emitter defect the row names — it reds:

```
FAIL in (fh-input-003-an-explicit-nil-clears-the-live-node)
React raised no controlled/uncontrolled diagnostic: ["A component is changing a
controlled input to be uncontrolled. This is likely caused by the value changing
from a defined to undefined, which should not happen. ..."]
expected: (= [] (control-complaints (clojure.core/deref errors)))
  actual: (not (= [] ["A component is changing a controlled input to be uncontrolled. ..."]))
```

Dropping the nil `:checked` slot instead reds it the same way (`(not (= false true))`
on the DOM row, and the same console line). So both controlling slots arm it.

**And the row's transition shape is required, not merely tolerable.** React
19.2 raises the controlled/uncontrolled complaint from `updateProperties`
alone, by comparing the props last committed against the props committing
now:

```js
tag  = "checkbox" === lastProps.type || "radio" === lastProps.type
     ? null != lastProps.checked : null != lastProps.value;
nextProps = /* same, for nextProps */;
!tag || nextProps || didWarnControlledToUncontrolled ||
  (console.error("A component is changing a controlled input to be uncontrolled. ..."),
   (didWarnControlledToUncontrolled = !0));
```

No mount can raise it. Restructuring the row to mount the invalid state —
the shape a value-SHAPE row must take — would have silenced it permanently.
That is the opposite of what the bead suspected, and it is why "restructure
every console watch that spans an update" is the wrong general rule.

**What the row really carried was an unstated dependency.** That
`didWarnControlledToUncontrolled` is a page-global one-shot. The browser
suite is one page of 657 tests, so the first test anywhere in it that
legitimately drives a field uncontrolled spends the diagnostic, and every
later row watching for it goes green having proved nothing — with nothing
on screen to say so. A control declared LAST in the namespace now drives a
field genuinely uncontrolled and REQUIRES the complaint; it can only arrive
if no row above it consumed the latch. Injecting a latch consumer ahead of
the clearing row demonstrates the mechanism: the clearing row goes silently
green and the control reds —

```
FAIL in (fh-input-003-the-controlled-to-uncontrolled-channel-was-still-live)
React did NOT report a field that genuinely went uncontrolled. It raises that
diagnostic once per PAGE, so something above this row already spent it — which
means every `React said nothing` row in this namespace was unable to fail.
Captured: []
expected: (seq (control-complaints (clojure.core/deref errors)))
  actual: (not (seq []))
```

**The sibling sweep did find a real one, in the same file.** The
multiple-select row's two trailing console assertions are correct in their
conclusions and wrong in their stated reasons. React re-reads a select's
value shape at no point after creation (`validateSelectProps` is called from
`setInitialProperties` and from hydration, never from `updateProperties`),
and its `case "select":` update branch carries no controlled/uncontrolled
complaint at all. A probe that dropped the select's `:value` on the clearing
render captured **an empty console** — `captured=[] control=[] shape=[]` —
while the DOM row alone went red on `(not (= [] ["a" "c"]))`. So the
messages claiming a verdict "across the whole sequence" and "none about the
value's shape" describe coverage React does not provide. Their reasons are
rewritten and their conclusions kept: the clearing claim rests on the
`selectedOptions` read, and the console rows restate the mount's verdict plus
the one complaint a select still makes on update — that its `value` arrived
as a literal null.

**The general rule this instance teaches**, recorded next to the spy: an
assertion that depends on a HOST LIBRARY emitting a warning inherits that
library's warning POLICY — including when it declines to warn, and including
when it warns only once. A console-watching test that has never been shown to
fail has not been tested.

### Other console-watching rows in the browser lane, for the record

| Row | Watch | Verdict |
| --- | --- | --- |
| `re-frame.ui` `frame-scope-resolve` / `reactive-reincarnation` act-discipline counters | update | already carry positive AND negative paths plus a "not mistaken for an act warning" row — armed by construction. Fenced surface; untouched. |
| `fh-struct-009-canonical-props-mount-without-react-complaining` | mount | carries its own control mount that requires React to complain — armed by construction. |
| `harness-captures-a-known-bad-hydration` (SSR streaming) | hydrate | is itself the control for the rows below it — armed by construction. |
| `mounting-seq-of-keyed-regviews-emits-no-collision-warning` (Reagent) | mount | React's duplicate-key warning is per-list, not latched; no positive control, and never shown to fail. Left alone — no evidence it is vacuous, and it is outside these two beads. |
| `live-stories-live-handoff-no-listener-or-root-leak` (testbed-support) | mount | createRoot-reuse warning is a mount-time check; no positive control, never shown to fail. Its DOM/handle rows carry the weight. Left alone, same reason. |
| Reagent SSR hydration-adoption / keyword-child rows | hydrate | mount-path watches; not exposed to the update blindness. |

The last two are the only places the same "never shown to fail" objection
still applies. Neither is in these beads' scope and neither has evidence
against it, so this PR reports rather than rewrites them.

## rf2-src6y — it was only the heading

`pilot_overlay.cljc` still headed its ref section "The two refs that must
not meet" while the paragraph beneath it said the opposite, and had done
since ref composition shipped. The live assertion under it was already
flipped to the positive shared-node reading by #6754
(`a-behavior-and-a-top-layer-state-on-one-element-both-receive-the-node`,
which asserts `(= 1 connected)`, `(true? promoted)` and a shared measured
box, with two explicit non-vacuity rows). Nothing pinned the old behaviour.
Heading renamed to "The two refs, and why they still sit apart"; the phrase
now appears nowhere in the tree.

## Quality gates

| Gate | Result | Exit |
| --- | --- | --- |
| `cd implementation/freehand && clojure -M:test` | 820 tests, 5804 assertions, 0 failures, 0 errors (re-run post-rebase; 817/5794 pre-rebase) | 0 |
| `npm run test:freehand` | 780 tests, 4740 assertions, 0 failures, 0 errors | 0 |
| `npm run test:cljs` | 10905 tests, 54865 assertions, 0 failures, 0 errors | 0 |
| `npm run test:browser` | 657 tests, 3996 assertions, 0 failures, 0 errors (was 656/3992 — the new control) | 0 |

Baseline before any change: 656 tests / 3992 assertions, 0 failures, 0
errors. Nothing skipped. Every gate run in the foreground, captured to a
worktree-local file, with the shadow-cljs `config:` banner naming this
worktree.
