### PR TITLE
docs(spec): Freehand's body-authority fence and the real cost of promotion (rf2-drpa3.84, rf2-drpa3.155)

### DIFF
--- a/spec/004D-Freehand-Compiled-Grammar.md
+++ b/spec/004D-Freehand-Compiled-Grammar.md
@@ -101,8 +101,8 @@ compiled tier reuses them rather than restating them.
 
 ### The promotion law
 
-**Promotion is a one-line change to the declaration. It changes no call site,
-no test, and no structural output.**
+**Promotion reaches the declaration and stops there. No call site changes,
+ever.**
 
 Mounting is `[todo-row {…}]` before and after. A caller cannot tell which mode a
 view it mounts was declared in, and must not be able to: a compiled view mounts
@@ -112,12 +112,31 @@ and not transitive**. Demotion is the same change in reverse — deleting the
 marker is always available, and is the last rung of every rejection's recovery
 ladder.
 
-That the structural output is unchanged is a property of construction rather
-than of agreement. The two modes do not each own a canonical form and agree
-about it; they **share** one. The interpreted walk decides what a FORM denotes
-and hands the resulting values to the canonical builders; a compiled body
-resolves its structure at build time and hands its values to the same builders.
-Only the front end differs, so there is no second normalization to drift.
+**What promotion costs.** For a body already inside the grammar the marker is
+the whole change: one line, and the structural output and the view's own tests
+are untouched along with the callers. For a body that is not, the build refuses
+and names the recovery, and taking that recovery is a mechanical refactor of the
+declaration. Two refusals are ordinary rather than exotic — a handler that
+closes over a `for` binding needs the loop body extracted into a keyed child view
+with the binding arriving as a prop, and a `^{:key k}` metadata row needs
+respelling as the literal `:key` prop a compiled list requires. A plain sortable
+table meets both. The extraction adds view-boundary nodes the interpreted twin
+did not have, so the structural tree and any test written against it move with
+the declaration. Nothing above the declaration does.
+
+Promotion also decides **whether** some mistakes surface, not merely when. The
+compile-tier a11y diagnostics ([§Compile-tier warnings](#compile-tier-warnings))
+read a compiled body and have nothing to read in an interpreted one, so an
+`:on-click` on a bare `<th>` is reported the day the marker is added and is
+silent forever without it.
+
+That an unchanged body's structural output is unchanged is a property of
+construction rather than of agreement. The two modes do not each own a canonical
+form and agree about it; they **share** one. The interpreted walk decides what a
+FORM denotes and hands the resulting values to the canonical builders; a compiled
+body resolves its structure at build time and hands its values to the same
+builders. Only the front end differs, so there is no second normalization to
+drift.
 
 What promotion DOES change is the language the body is written in. Compilation
 is **explicit** (EP-0036 governing law 6): the compiler never silently declines
@@ -544,8 +563,8 @@ so the analyzer reports them then, with `:rf.ui.compile/undeclared-prop` and the
 source coordinates of the offending call. A props map delivered at an
 interpreted boundary is knowable at render, so the boundary reports it then,
 with `:rf.error/view-bad-props`. Static knowledge moves the moment a violation
-surfaces and never the set of props that are legal — which is what makes
-`{:compiled true}` a one-line change rather than a contract renegotiation.
+surfaces and never the set of props that are legal — which is what keeps
+`{:compiled true}` a change of lowering rather than a contract renegotiation.
 
 **Closed by default, open by declaration.** The alternative to closure is silent
 tolerance, so a view that really does forward arbitrary props says so once, in
@@ -1827,8 +1846,9 @@ rather than fabricating them (`tools/xray/spec/021` §3.4.1).
 
 ## The read-only checker
 
-`{:compiled true}` is a one-line change, which makes it a tempting thing to try
-and see. Trying and seeing is a poor way to learn a finite language. The build
+`{:compiled true}` looks like a one-line change, which makes it a tempting thing
+to try and see. Trying and seeing is a poor way to learn a finite language, and
+it is worst where the answer is a refusal that wants the body refactored. The build
 stops at the first form outside the grammar, so an author who reached that
 failure by editing has already changed the declaration in order to find out
 whether the change was available — and if the answer is no, the edit and its

--- a/spec/004D-Freehand-Compiled-Grammar.md
+++ b/spec/004D-Freehand-Compiled-Grammar.md
@@ -2046,11 +2046,12 @@ HMR is a designed contract with fixtures, not a hope; the REPL path *is* the HMR
 - **The Pair's hot-swap is this same mechanism** invoked over nREPL.
 
 Cell/ownership reconciliation under reload is owned by
-[006](006-ReactiveSubstrate.md) — including the guard that a re-registration landing in a
-cell's render→commit gap never paints the old body: commit checks body authority (the
-cell-local generation *and* the registered view revision) at **both** the render→commit
-boundary and again immediately before publication, releasing any newly-staged handles and
-re-rendering rather than committing a stale capture ([006 §Body authority under hot
+[006](006-ReactiveSubstrate.md) — including the guard that a cell never publishes
+ownership on behalf of a body it did not execute: the shell raises the cell to the
+boundary's current body revision before a candidate opens, and commit re-checks that
+authority at **both** the render→commit boundary and again immediately before publication,
+returning `:abandoned` — releasing any newly-staged handles and leaving the prior committed
+set installed — rather than publishing a superseded capture ([006 §Body authority under hot
 reload](006-ReactiveSubstrate.md#body-authority-under-hot-reload--the-two-point-commit-fence)).
 Compile budgets (expansion p95, watch-loop rebuild) are gated per
 [008](008-Testing.md) G-14.

--- a/spec/006-ReactiveSubstrate.md
+++ b/spec/006-ReactiveSubstrate.md
@@ -1412,18 +1412,20 @@ named Stage-2 obligation.
 
 Distinct from the value-movement guards (invariant 5, above), a commit also verifies the
 cell's **body authority** — that the body generation the capture was rendered against is
-still current — so an HMR re-registration landing in the render→commit gap can never
-publish a stale body. Authority is **dual** ⟨rf2-vxgfnd.214⟩:
+still the cell's — so a candidate can never publish ownership on behalf of a body it did
+not execute.
 
-- the cell-local **generation** — bumped on an explicit sync/remount; and
-- the **registered-view-revision** — the authoritative body revision the view registry
-  holds for the view-id, which closes the harder `render(old) → re-registration(new) →
-  layout(old)` window even when the cell has not rendered again. A direct/headless caller
-  with no registered slot falls back to the cell-local half alone (the registry half
-  no-ops).
+Authority is **one number**: the cell-local **generation**. Each stable boundary holds the
+body revision its emitter currently publishes, advanced only at the reload seam — a
+genuinely new body, never an ordinary re-walk of an unchanged tree — and the shell raises
+the cell to that revision **before the candidate opens**. A candidate therefore carries the
+revision its own render ran against, and the commit consults nothing but its own cell. The
+raise is monotone, so an occurrence minted after a reload catches up on its first render
+rather than walking a live cell backwards, and a direct or headless caller with no shell
+above it advances the generation itself.
 
-The capture is rejected as **`:stale`** when either half has advanced past the captured
-generation, checked at **two points**:
+The capture is rejected as **`:abandoned`** when the generation has advanced past the
+captured one, checked at **two points**:
 
 1. **Render→commit (step 1).** Commit entry samples the authority once and rejects a
    stale capture before touching any ownership — the host simply re-renders.
@@ -1436,12 +1438,20 @@ generation, checked at **two points**:
    to publish a stale capture: it releases **only the newly-staged handles** (reverse
    acquisition order),
    leaves the prior committed set, published values, and lifecycle untouched, and returns
-   `:stale`. No revision advances, because the re-registration already notified the shell
-   and a fresh render at the new body is inbound.
+   `:abandoned`. No revision advances, because a reload publishes its new body through a
+   render already in flight — a fresh candidate at that body is inbound without the cell
+   asking for one.
 
-The whole fence is **dev/HMR-only**: production mints every cell at body revision 0 and
-never advances it, so both points constant-fold away under `goog.DEBUG=false` — no
-registry lookup on the commit hot path (I-12 production erasure).
+Body authority is one half of the commit's currency check; the other is the frame
+incarnation the render resolved ([§Frame binding and
+retarget](#frame-binding-and-retarget)). A candidate that fails either half is abandoned
+at whichever of the two points sees it first.
+
+The body half is a development concern in effect rather than by compilation: a production
+boundary is minted at revision 0 and nothing ever advances it, so the comparison always
+holds and costs one integer compare. It is not gated out, because it shares a predicate
+with the frame half, which is load-bearing in every build. Neither point consults a view
+registry, in any build.
 
 ### Callback and reentrancy rules
 
@@ -1867,13 +1877,13 @@ dependencies came from two different renders — is not a state the shell can re
 
 ### Body authority across a live cell
 
-A candidate rendered against a body revision the cell has since replaced is **stale** and
-publishes nothing. Authority is checked at the two points
+A candidate rendered against a body revision the cell has since replaced is **`:abandoned`**
+and publishes nothing. Authority is checked at the two points
 [§Body authority under hot reload](#body-authority-under-hot-reload--the-two-point-commit-fence)
 fixes: once at commit entry, before any ownership is touched, and once again at the
 narrowest publication boundary — after the callback-capable staging work, with nothing
-callback-capable between the check and the publish. A candidate that goes stale at the
-second point releases **only** what its own staging acquired.
+callback-capable between the check and the publish. A candidate abandoned at the second
+point releases **only** what its own staging acquired.
 
 Reload that replaces a whole declaration is the ordinary case and needs no fence: a
 declared view is a descriptor VALUE, so a redeclared view is a different boundary, the


### PR DESCRIPTION
Two of a three-bead spec-truth cluster. The third is stopped and reported below — it needs an operator ruling, not a worker fix.

## rf2-drpa3.84 — Spec 006 body-authority fence: THE DOCUMENT WAS WRONG

Spec 006's `§Body authority under hot reload — the two-point commit fence` was written on 2026-07-14 (`f82b70b2ac`) from the donor ViewCell in `implementation/ui/src/re_frame/ui/reactive.cljc`. Freehand's atomic shell then took ownership of the commit law (PR #6701) and the passage was never re-derived. Three separate donor facts were sitting in a Freehand-normative section:

**1. The rejection literal.** `cell/commit!` returns `:abandoned` at both fences (`cell.cljc`), its docstring says `:abandoned`, `FH-SUB-003` pins `:abandoned` at the entry fence *and* the publication fence, and the re-entrancy regression added by PR #6718 asserts `:abandoned`. The spec said `:stale` — which is what `ui/reactive.cljc`'s `publish-commit!` returns, and which Freehand never answers.

**2. The mechanism — a true conclusion resting on a dead reason.** The spec said authority is *dual*: cell generation **plus** a `registered-view-revision` looked up in the view registry at commit. That is the donor's design (`reactive.cljc` really does call `registered-view-revision` inside `publish-commit!`). Freehand performs no registry lookup at commit at all. The boundary slot holds the body revision the emitter publishes (`react.cljs` `publish-body!`, advanced only when the body closure identity changes), and `shell/render` raises the cell to it monotonically **before** the candidate opens — so a candidate always carries the revision its own render ran against and the commit consults nothing but its own cell. The conclusion ("a superseded body publishes nothing, checked twice") was right; the stated reason was another runtime's. Reason rewritten, conclusion kept.

**3. The production claim.** "Both points constant-fold away under `goog.DEBUG=false` — no registry lookup on the commit hot path" was the donor's debug-gated registry read. `cell.cljc` contains no `debug-enabled?` or `goog.DEBUG` gate whatsoever; the currency predicate runs in every build, because it also carries the frame-incarnation half, which is load-bearing in production. The body half is a development concern *in effect*, not by compilation — a production boundary never leaves revision 0, so it is one integer compare that always holds. Restated truthfully; the `I-12` production-erasure citation is dropped because nothing here is erased.

Also names the frame-incarnation half explicitly (the fence abandons on either axis), and repairs the same donor mechanism where 004D restates it. No runtime change, no new status value; `cell.cljc` and the FH-SUB-003 fixture are untouched.

## rf2-drpa3.155 — promotion cost: THE DOCUMENT WAS WRONG

004D's promotion law claimed promotion "is a one-line change to the declaration. It changes no call site, no test, and no structural output." The F5i pilot promoted a plain sortable data table and the grammar refused it twice before it built — a handler closing over a `for` binding, and a `^{:key k}` metadata row where a compiled list wants a literal `:key` prop. Both refusals are correct and both messages are excellent; the grammar is not touched. Recovery was extracting three child views, and a declared child is a **view-boundary node** in the structural tree (004B §node kinds), so the tree and any test written against it move with the declaration.

The law now leads with the part that genuinely always holds — the caller never changes — and states the one-line case as the case it actually is: a body already inside the grammar. Two loose restatements of the retired phrasing went with it (the props-contract paragraph, the read-only checker's opening).

It also now advertises what promotion buys beyond speed, which was unstated: the compile-tier a11y diagnostics read a compiled body and have nothing to read in an interpreted one, so promotion decides **whether** an `:on-click` on a bare `<th>` surfaces, not merely when. The pilot's interpreted twin carried the identical mistake in silence.

**Left undone, fenced:** the same overstatement lives in the `v/defview` docstring (`implementation/freehand/src/re_frame/freehand.cljc`: "Callers do not change, structural output does not change, and the view's own tests do not change") and in its generated row at `docs/api/re-frame.freehand.md:63`. Both are fenced for this dispatch (freehand src; api-manifest serial lane). `docs/EP/EP-0036…:24` carries it too — left alone deliberately, as an EP is a dated decision record. `spec/004-Views.md` was checked and is already truthful ("Promotion changes one declaration and no call site").

## rf2-hl7hr — STOPPED, needs a ruling

Not a documentation defect and not a code defect. The bead's own "Question to settle" section names three candidate rules, and choosing one is the work.

- **The 004B row describes Freehand, not a donor.** 004B's header states it is "the public ABI for Freehand's structural render tree and the DOM conversion table every emitter consumes". The nearby trap does not apply here.
- **Doc and code agree.** `rules.cljc` `react-prop-name` (client emitter) and `dom-attr-name` (serialiser) both pass `data-*` verbatim, casing untouched. The row is an accurate description of what ships.
- **React 19.2 really does warn, and the warning has a nasty property.** Read out of the shipped `react-dom@19.2.0` development bundle rather than reasoned about: `validateProperty` exempts `aria-*` (`rARIA`/`rARIACamel`) and has **no `data-*` exemption**, so `data-fooBar` falls through to the "React does not recognize the ... prop on a DOM element ... spell it as lowercase ... instead" branch. The gate is `isCustomElement(type) || typeof props.is === 'string' || warnUnknownProperties(...)` — namespace-blind, so SVG and MathML take the same path. **It is `console.error` in the development bundle only, and it sets `warnedProperties[name] = true` — once per distinct prop name per session.** Any mounted pin on this warning passes vacuously if anything mounted the same name earlier in the run. That is exactly the "prove the pin reds on known-bad input" hazard, in its worst form.
- **The corpus already routed around the question.** `FH-STRUCT-009` asserts `:react-console-silent true` via `(is (= [] @(:log @subject)))`, and the mounted `props-page` carries only lowercase `:data-priority`. The camelCase `:data-fooBar` appears only in the structural/projection rows, and the fixture note says so in as many words: React's mount-time warning "is a question about that row rather than about this projection".

Two of the three candidate rules (lower-case at the React emitter; refuse mixed-case at the walk) land in `to_react.cljs` / `react.cljs` / `compiler/emit_react.cljc` / `compiler/analyze.cljc` — all fenced for this dispatch. The third (keep verbatim, document the warning) **is** the ruling, so a worker taking it would be ruling by edit. ACs 2 and 3 additionally require a real-browser probe of HTML and SVG/MathML and a mounted FH-STRUCT row, neither of which is in this dispatch's gate set.

Incidental finding for whoever takes it: `tree_views.cljc`'s `props-page` docstring says it mounts "a `data-*` name whose casing must survive", and the page carries only `:data-priority`. That docstring becomes true or moot depending on which way the ruling goes, so it is left for the same change.

## Quality gates

Run from the worktree, foreground, each captured to a file with its exit code echoed. All re-run **after** the rebase onto `origin/main` (`f4a7070166`), because the rebase pulled in `compiler/analyze.cljc` changes.

| Gate | Exit | Result |
|---|---|---|
| `python scripts/check_doc_slugs.py` | 0 | clean |
| `python scripts/check_freehand_conformance_index.py` | 0 | clean |
| `python -m mkdocs build --strict` | 0 | 0 WARNING/ERROR lines (INFO-only) |
| `cd implementation/freehand && clojure -M:test` | 0 | Ran 823 tests, 5837 assertions, 0 failures, 0 errors |
| `cd implementation && npm run test:cljs` | 0 | Ran 10913 tests, 54899 assertions, 0 failures, 0 errors |

Not run: `npm run test:browser` and the Xray/bundle gates — the diff is two spec markdown files with no emitter, bundle or DOM surface. Note `mkdocs --strict` does not fail on a broken anchor; `check_doc_slugs.py` is the link gate and both were run.
