### PR TITLE
docs(core): tighten guide voice; Troubleshooting / Advanced headings

### DIFF
--- a/docs/core/25-from-re-frame-v1.md
+++ b/docs/core/25-from-re-frame-v1.md
@@ -1,72 +1,66 @@
 # From re-frame v1
 
-You have a re-frame v1 app and a migration to plan, and the real question on your mind is probably "how big a deal is this?" The reassuring answer: most of your code is already v2 code. This chapter is the map. It shows you the one tool that does the work, then walks the handful of things that genuinely changed — so that when you read a migration diff you can slot every line into a category instead of squinting at it.
+You have a re-frame v1 app and a migration to plan. Most of the code already matches v2's architecture. This page maps what changed: the migration skill that drives the sweep, the mechanical renames, and the few places where behaviour or contracts actually differ.
 
-We'll build up in three moves. First, the good news and the tool that drives the sweep. Then the bounded set of mechanical renames. Then the two or three places where v2 tells a genuinely different story than v1 did — and those turn out to be improvements you'll be glad to adopt.
+## What stayed the same
 
-## The good news first
+v1's signature shape — the [**event pipeline**](glossary.md#event-pipeline), the one-way run a dispatched [event](glossary.md#event) takes through the six stages (dispatch → event handler → effects → derivations → view → DOM) — is the same shape in v2:
 
-The bones are identical. v1's signature shape — the [**event pipeline**](glossary.md#event-pipeline), the one-way run a dispatched [event](glossary.md#event) traverses as it falls through the *six dominoes* (dispatch → event handler → effects → derivations → view → DOM) — is the same shape in v2. Walk it piece by piece and nothing has moved:
-
-- [Events](glossary.md#event) — the data describing what happened — are still data.
+- [Events](glossary.md#event) are still data.
 - [Event handlers](glossary.md#event-handler) are still pure functions of state.
-- [Subscriptions](glossary.md#subscription) are still derivations off a single [app-db](glossary.md#app-db) (your app's whole state, held in one map).
+- [Subscriptions](glossary.md#subscription) are still derivations off a single [app-db](glossary.md#app-db).
 
-The opinionated stance hasn't moved either: one source of truth, data over APIs over syntax, immutable values and stable contracts. v2 is v1's architecture with new capabilities grown on top.
-
-That's why your v1 code reads as v2 code on the first pass. A `reg-sub` is a `reg-sub`. A [hiccup](glossary.md#hiccup) view — Clojure's vectors-as-HTML notation, `[:div ...]` — is still a hiccup view. The migration is not a rewrite — it's a *sweep*: a bounded set of mechanical renames, a smaller set of judgment calls, and a few new shapes you choose to adopt. The framework counts "40-plus rules," and that number sounds alarming, but the vast majority are find-and-replace, and a tool does them for you.
+Same stance: one source of truth, data over APIs over syntax, immutable values and stable contracts. A `reg-sub` is still a `reg-sub`. A [hiccup](glossary.md#hiccup) view is still hiccup. The migration is a *sweep* — mechanical renames, a smaller set of judgment calls, and a few new shapes you opt into. The skill lists many rules; most are find-and-replace and the tool applies them.
 
 ??? info "Coming from a React 17→18 upgrade?"
 
-    Think of this less like that — where concurrent rendering shifted runtime behaviour under you — and more like flipping on TypeScript's `strict` flag. The semantics you relied on are almost all intact; v2 mostly stops *silently swallowing* the things v1 let slide (an ambient frame, an unrecorded clock read) and asks you to say them out loud. Strictness, not rearchitecture — with one genuine runtime-behaviour exception, the run-to-completion dispatch change flagged below.
+    Closer to flipping TypeScript's `strict` flag than concurrent-rendering churn. Semantics you relied on are almost all intact; v2 mostly stops *silently swallowing* what v1 let slide (an ambient frame, an unrecorded clock read) and asks you to declare them. Strictness, not rearchitecture — with one genuine runtime-behaviour exception: the run-to-completion dispatch change below.
 
-## The one tool: don't do this by hand
+## The migration skill
 
-The migration is automated, and you should keep it that way — do not hand-migrate anything larger than a toy. A Claude Code skill ships in this repo, [`skills/re-frame-migration/`](../../skills/re-frame-migration), and its whole job is to drive the sweep. It walks six phases — orient, bump, sweep, verify, optional modernisations, report — applying the mechanical rewrites unprompted and *stopping* at every judgment call to ask you first. The skill calls the mechanical rewrites **Type A** and the judgment calls **Type B**. You'll see those two words throughout this chapter.
+Do not hand-migrate anything larger than a toy. The Claude Code skill in [`skills/re-frame-migration/`](../../skills/re-frame-migration) drives the sweep. Six phases: orient, bump, sweep, verify, optional modernisations, report. It applies mechanical rewrites (**Type A**) unprompted and *stops* at every judgment call (**Type B**) to ask first. Those two labels appear throughout this page.
 
-The workflow is four steps:
+Workflow:
 
 1. Open a fresh Claude Code session at the root of your v1 project.
-2. Paste the kickoff prompt from [`skills/re-frame-migration/references/kickoff-prompt.md`](https://github.com/day8/re-frame2/blob/main/skills/re-frame-migration/references/kickoff-prompt.md). The session loads the skill and walks the phases autonomously.
-3. Answer questions at the Type B checkpoints — the agent explains the risk and waits for your call before rewriting.
-4. Run your test suite. The agent re-verifies and produces a migration report.
+2. Paste the kickoff prompt from [`skills/re-frame-migration/references/kickoff-prompt.md`](https://github.com/day8/re-frame2/blob/main/skills/re-frame-migration/references/kickoff-prompt.md). The session loads the skill and walks the phases.
+3. Answer Type B checkpoints — the agent explains risk and waits before rewriting.
+4. Run your test suite. The agent re-verifies and writes a migration report.
 
-The rest of this chapter is orientation. It gives you the mental model of what the skill is doing, so that when you read a diff at step 3 and ask "what kind of thing am I looking at?", you'll have a category to slot it into. The exhaustive rule list lives in the skill; this is the *why* behind it.
+The rest of this page is orientation so a diff at step 3 has a category. The exhaustive rule list lives in the skill.
 
-!!! note "The one rule that keeps it honest: don't invent migration rules"
+!!! note "Don't invent migration rules"
 
-    The skill's cardinal rule is exactly that — if a failure doesn't match a known shape, it surfaces it for human review instead of guessing. That's the load-bearing safety property of the whole sweep: it does the things it's *sure* of, and asks about the rest. You'll see this rule invoked again and again below.
+    If a failure doesn't match a known shape, the skill surfaces it for human review instead of guessing. It rewrites only what it's sure of and asks about the rest.
 
-## Step one of the sweep: the deps
+## Deps
 
-re-frame2 is **pay-as-you-go**: capabilities ship as separate artefacts, so unused ones never bundle. That one fact shapes the whole deps migration:
+re-frame2 is **pay-as-you-go**: capabilities ship as separate artefacts, so unused ones never bundle.
 
 1. **Swap the core coord.** Remove `re-frame/re-frame`. Add `day8/re-frame2`.
-2. **Add a substrate adapter** for your view library — `day8/re-frame2-reagent` if you're on Reagent (and bump Reagent to v2, which the reference targets), or the UIx adapter if you've already moved off Reagent. ([Chapter 22 — Adapters](how-to/use-uix-or-slim.md) is the [substrate](glossary.md#substrate) story in full.)
-3. **Add per-feature artefacts only for features you actually use.** Don't add them all "to be safe" — the skill tells you which ones the codebase trips. The split is `day8/re-frame2-{machines, flows, routing, http, resources, ssr, schemas, epoch}`, and an app that doesn't use flows doesn't carry flow code.
-4. **Don't bump anything else in the same change.** Keep React, shadow-cljs, and the rest on their current versions until the migration settles. A migration that is also a dependency upgrade is two bugs wearing one diff — separate failure modes are far easier to debug separately.
+2. **Add a substrate adapter** for your view library — `day8/re-frame2-reagent` if you're on Reagent (and bump Reagent to v2, which the reference targets), or the UIx adapter if you've already moved off Reagent. ([Adapters](how-to/use-uix-or-slim.md) covers the [substrate](glossary.md#substrate).)
+3. **Add per-feature artefacts only for features you use.** Don't add them all "to be safe" — the skill reports which ones the codebase trips. Split: `day8/re-frame2-{machines, flows, routing, http, resources, ssr, schemas, epoch}`.
+4. **Don't bump anything else in the same change.** Keep React, shadow-cljs, and the rest on current versions until the migration settles. A migration that is also a dependency upgrade is two failure modes in one diff.
 
-The skill handles every part of this. The list is here so you know what's coming.
+The skill handles this; the list is so you know what's coming.
 
 !!! warning "Gotcha"
 
-    The "settle the migration before upgrading anything else" advice has two carve-outs that aren't optional. **First, a React-19 / Reagent-2 floor.** re-frame2's adapters target React 19 and the Reagent bridge runs on Reagent 2.x, so a React-17/18 project bumps as part of the same change — and if a component library you depend on has no React-19 build, that's a genuine go/no-go blocker the skill surfaces up front (wait for a release, replace it, vendor a patch, or verify it empirically under forced React 19), not a surprise inside a failed compile. **Second, certain v1 add-ons stop compiling the instant re-frame2 is on the classpath.** `http-fx`, `async-flow-fx`, `undo`, and `forward-events-fx` all reference `re-frame.core/console`, which v2 removed with no shim — so the build fails with an unresolved `re-frame.core/console` until each is removed or converted (`http-fx` onto managed HTTP, covered below; `async-flow-fx`'s orchestration sequences onto state machines via `reg-machine`; `undo` re-implemented on app-db snapshots or epoch time-travel). "Drop in re-frame2 and modernise the add-ons later" is therefore not available: you must act on them at the compile gate, even if converting fully comes later.
+    Two carve-outs are not optional. **First, a React-19 / Reagent-2 floor.** re-frame2 adapters target React 19; the Reagent bridge is Reagent 2.x. A React-17/18 project bumps as part of the same change. If a component library has no React-19 build, that's a go/no-go the skill surfaces up front (wait for a release, replace it, vendor a patch, or verify under forced React 19) — not a surprise inside a failed compile. **Second, certain v1 add-ons stop compiling the instant re-frame2 is on the classpath.** `http-fx`, `async-flow-fx`, `undo`, and `forward-events-fx` all reference `re-frame.core/console`, which v2 removed with no shim — the build fails with unresolved `re-frame.core/console` until each is removed or converted (`http-fx` → managed HTTP, below; `async-flow-fx` orchestration → `reg-machine`; `undo` → app-db snapshots or epoch time-travel). "Drop in re-frame2 and modernise add-ons later" is not available: act at the compile gate even if full conversion comes later.
 
 ??? info "Coming from npm's all-or-nothing bundles?"
 
-    The closest mental model is tree-shaking made explicit. Instead of pulling one fat `re-frame` package and trusting the bundler to drop what you don't import, you pull only the artefacts whose features you use. The payoff is that bundle isolation is a contract, not a hope: code you didn't add can't sneak into production.
+    Tree-shaking made explicit: pull only the artefacts whose features you use. Bundle isolation is a contract — code you didn't add can't enter production.
 
-## The mechanical renames
+## Mechanical renames
 
-These are the broad shapes of breakage — the high-volume, deterministic rewrites the skill applies while you watch. We'll take them roughly in order of how often they fire, simplest first.
+High-volume, deterministic rewrites the skill applies. Roughly by how often they fire.
 
 ### One event registration form
 
-This is the highest-volume rewrite, because `reg-event-db` is the most common registration in nearly every v1 app — and v2 doesn't have it. v1 gave you three ways to register an [event handler](glossary.md#event-handler): `reg-event-db` (the handler takes the current db and returns the new db), `reg-event-fx` (the handler takes a [coeffects](glossary.md#coeffect) map — facts the runtime gathered for you, the db among them — and returns an [effect map](glossary.md#effect-map) describing what should happen), and `reg-event-ctx` (the raw interceptor context). v2 collapses all three to a single [**`reg-event`**](glossary.md#register), shaped exactly like the old `reg-event-fx`: every handler takes the coeffects map and returns the closed effect map (`{:db … :fx […]}`).
+Highest-volume rewrite: `reg-event-db` is the most common registration in most v1 apps, and v2 doesn't have it. v1 had three forms: `reg-event-db` (db in, db out), `reg-event-fx` ([coeffects](glossary.md#coeffect) map in, [effect map](glossary.md#effect-map) out), and `reg-event-ctx` (raw interceptor context). v2 collapses all three to one [**`reg-event`**](glossary.md#register), shaped like old `reg-event-fx`: coeffects map in, closed effect map out (`{:db … :fx […]}`).
 
-The win is that there's no longer a db-only form that breaks the moment a handler needs an effect or a coeffect — adding the world becomes adding a key to a map you already return, not converting to a different registration.
-
-The mapping is deterministic, which is why it's codemod-able:
+There is no longer a db-only form that breaks the moment a handler needs an effect or coeffect — you add a key to the map you already return.
 
 ```clojure
 ;; v1                                  ;; v2
@@ -75,82 +69,79 @@ The mapping is deterministic, which is why it's codemod-able:
                                    =>  (rf/reg-event ID (fn [{:keys [db]} EV] {:db BODY}))
 ```
 
-`BODY` always evaluates to the new db (that *is* the `reg-event-db` contract), so wrapping it `{:db BODY}` is mechanical regardless of how complex it is. A first-class, tested codemod ships in [`migration/from-re-frame-v1/codemod/`](../../migration/from-re-frame-v1/codemod/README.md) (rule M-73) and the migration skill runs it for you. It renames `-fx` forms, rewrites simple `-db` forms, and **flags** two cases for human review rather than guessing:
+`BODY` always evaluates to the new db (`reg-event-db` contract), so wrapping `{:db BODY}` is mechanical. A tested codemod ships in [`migration/from-re-frame-v1/codemod/`](../../migration/from-re-frame-v1/codemod/README.md) (rule M-73); the skill runs it. It renames `-fx` forms, rewrites simple `-db` forms, and **flags** two cases for review:
 
-- a `-db` handler whose body can return `nil` (under v2 a bare `nil` is a clean no-op and `{:db nil}` coerces to `{:db {}}`, so you choose the reading you want), and
-- any `reg-event-ctx` (withdrawn from the public surface — full-context work moves to an [interceptor](glossary.md#interceptor) registered with `reg-interceptor` and referenced by id). A stale call doesn't limp along: it [fails loud](glossary.md#fail-loud-not-silent) with `:rf.error/reg-event-ctx-removed`, naming the replacement.
+- a `-db` handler whose body can return `nil` (under v2 bare `nil` is a clean no-op; `{:db nil}` coerces to `{:db {}}` — pick the reading you want), and
+- any `reg-event-ctx` (withdrawn from the public surface — full-context work moves to an [interceptor](glossary.md#interceptor) via `reg-interceptor`, referenced by id). A stale call [fails loud](glossary.md#fail-loud-not-silent) with `:rf.error/reg-event-ctx-removed`, naming the replacement.
 
-For the common pure-state handler, a nice habit on the way through is to lift the body into a plain `(defn step [db] …)` and register `(fn [{:keys [db]} _] {:db (step db)})` — the state transition stays bare and testable, the handler stays one line.
+For pure-state handlers, a common habit: lift the body into `(defn step [db] …)` and register `(fn [{:keys [db]} _] {:db (step db)})` — state transition stays bare and testable.
 
 ??? info "Coming from Redux Toolkit?"
 
-    This is the same instinct as `createSlice` collapsing reducer cases into one place. v1's `reg-event-db` was the convenient form that turned awkward the instant you needed a thunk; v2's single `reg-event` is the always-honest form — a handler is a function of the world that returns a *description* of the next world. You return `{:db …}` the way an RTK reducer mutates `state`, except it stays a pure value.
+    Same instinct as `createSlice` collapsing reducer cases. v1's `reg-event-db` was convenient until you needed a thunk; v2's single `reg-event` is always the same shape — a function of the world that returns a *description* of the next world. You return `{:db …}` the way an RTK reducer mutates `state`, except it stays a pure value.
 
 ### Registrar imports
 
-Some v1 code requires `re-frame.db`, `re-frame.router`, `re-frame.subs`, `re-frame.events`, `re-frame.registrar`, or `re-frame.alpha` directly. That reached past the front door, and v2 closes it. The single-import contract is `(:require [re-frame.core :as rf])`. Direct access to `re-frame.db/app-db` was always off-contract and is now firmly so. The accessor is `(rf/app-db-value frame-id)`, which names the [frame](glossary.md#frame) and returns a plain map.
+Some v1 code requires `re-frame.db`, `re-frame.router`, `re-frame.subs`, `re-frame.events`, `re-frame.registrar`, or `re-frame.alpha` directly. v2 closes that. Contract: `(:require [re-frame.core :as rf])`. Direct `re-frame.db/app-db` was always off-contract; the accessor is `(rf/app-db-value frame-id)`, which names the [frame](glossary.md#frame) and returns a plain map.
 
 ??? note "Going deeper"
 
-    This tightening is the same reason chapter 18's frames work at all: when there can be N isolated app-db instances, "the global `app-db` atom" stops being a coherent thing to reach for. The contract *has* to be a function call that names *which* frame you mean — [identity is carried, not found](glossary.md#frame-identity-is-carried-not-found), an argument rather than ambient global state.
+    Same reason frames work: when there can be N isolated app-db instances, "the global `app-db` atom" is not a coherent target. The contract is a call that names *which* frame — [identity is carried, not found](glossary.md#frame-identity-is-carried-not-found).
 
 ### Effect-map shape
 
-Top-level `:dispatch` / `:dispatch-later` / `:dispatch-n` shorthands fold into the `:fx` vector — an [effect](glossary.md#effect) being a description of a side-effect the runtime carries out for you. `:db` is unchanged. If you've internalised "effects are a vector of `[id arg]` pairs" from [chapter 07](effects.md), this is just that shape arriving where the shorthands used to be.
+Top-level `:dispatch` / `:dispatch-later` / `:dispatch-n` shorthands fold into the `:fx` vector — each [effect](glossary.md#effect) is a description of a side-effect the runtime runs. `:db` is unchanged. If you already use "effects are a vector of `[id arg]` pairs" from [Effects](effects.md), this is that shape where the shorthands used to be.
 
-!!! warning "Gotcha — `:dispatch` is the one place the *timing* genuinely changes"
+!!! warning "Gotcha — `:dispatch` is the one place *timing* changes"
 
-    This is the rare migration category that isn't strictness — it's a real behavioural shift, so it's flagged for you to think about, never rewritten blind. v2 [drains run-to-completion](glossary.md#drain--run-to-completion): every event dispatched *during* a handler (a `:dispatch` effect, or a bare `dispatch` from inside a handler body) drains to a fixed point **before any view re-renders**. In v1 those re-dispatches landed on a later tick, so a view could render the intermediate state in between. The vast majority of code doesn't notice. What does: an animation/wizard chain that *relied* on a flash of intermediate render between steps, and any test that peeked at the router queue after a dispatch (it's already drained — empty). Reframe such tests around the *resulting* app-db state or the effects observed, not queue contents. A pathologically long synchronous chain can also trip the per-frame drain-depth limit (default 100) with a `:rf.error/drain-depth-exceeded` error; raise it with `{:drain-depth N}` on the frame, or break the chain with `:dispatch-later`.
+    Not strictness — a real behavioural shift. Flagged for review; never rewritten blind. v2 [drains run-to-completion](glossary.md#drain--run-to-completion): every event dispatched *during* a handler (a `:dispatch` effect, or bare `dispatch` from a handler body) drains to a fixed point **before any view re-renders**. In v1 those re-dispatches landed on a later tick, so a view could render intermediate state between steps. Most code doesn't notice. What does: an animation/wizard chain that *relied* on a flash of intermediate render, and any test that peeked at the router queue after a dispatch (it's already drained — empty). Reframe such tests around resulting app-db or observed effects, not queue contents. A pathologically long synchronous chain can trip the per-frame drain-depth limit (default 100) with `:rf.error/drain-depth-exceeded`; raise with `{:drain-depth N}` on the frame, or break the chain with `:dispatch-later`.
 
 ### Framework keywords move to the `:rf/*` root
 
-v2 gathers every framework-owned keyword under a single reserved root, `:rf/*` (and its sub-namespaces `:rf.machine/*`, `:rf.route/*`, `:rf.nav/*`, …). So v1's `:re-frame/*`, `:machine/*`, `:route/*`, `:nav/*`, and `:registry/*` framework keywords rename to their `:rf.*` equivalents — a closed, mechanical table the skill applies. The flip side is a judgment call it *flags* rather than rewrites: any of *your own* registrations or app-db keys that happen to sit under a now-reserved namespace (a user `:rf/…` event id, a `:route` slice you own with a third-party router) collide with framework territory and need renaming to your own feature prefix — unless you're deliberately overriding a documented extension point.
+v2 gathers framework-owned keywords under reserved root `:rf/*` (and sub-namespaces `:rf.machine/*`, `:rf.route/*`, `:rf.nav/*`, …). v1's `:re-frame/*`, `:machine/*`, `:route/*`, `:nav/*`, and `:registry/*` framework keywords rename to `:rf.*` equivalents — a closed table the skill applies. Judgment call it *flags*: any of *your* registrations or app-db keys under a now-reserved namespace (a user `:rf/…` event id, a `:route` slice with a third-party router) need renaming to your feature prefix — unless you're deliberately overriding a documented extension point.
 
 ### Subscription input functions
 
-The two-function `reg-sub` form changes shape, not spirit. The first function declares what this [subscription](glossary.md#subscription) depends on. In v1 it *returned live signals* — it called `(rf/subscribe ...)` itself and handed back the running subscriptions. In v2 it instead returns plain data: a vector listing the [**query vectors**](glossary.md#query-vector) it wants (each query vector being a `[:sub-id arg …]` request), and the runtime does the actual subscribing. That keeps the input function pure and the subscription graph inspectable without running the app. The mechanical tell is the bracket count on the single-input case: v2 wants `[[:item/by-id id]]` — a one-element vector *containing* the query vector — not the bare `[:item/by-id id]`. [Chapter 05](subscriptions.md) carries the full grammar and the why. The migration skill rewrites the common shapes and flags the rest.
+The two-function `reg-sub` form changes shape, not spirit. The first function declares what the [subscription](glossary.md#subscription) depends on. In v1 it *returned live signals* — it called `(rf/subscribe ...)` and handed back running subscriptions. In v2 it returns plain data: a vector of [**query vectors**](glossary.md#query-vector) (`[:sub-id arg …]`); the runtime does the subscribing. That keeps the input function pure and the graph inspectable without running the app. Bracket count on the single-input case: v2 wants `[[:item/by-id id]]` — a one-element vector *containing* the query vector — not bare `[:item/by-id id]`. [Subscriptions](subscriptions.md) has the full grammar. The skill rewrites common shapes and flags the rest.
 
-!!! warning "Gotcha — this one fails *silently* until the sub is first read"
+!!! warning "Gotcha — fails *silently* until the sub is first read"
 
-    A v1 signal-function `reg-sub` still *registers* cleanly under v2 (it parses as a parametric sub), so the compile says nothing. The mismatch surfaces only at the *first* `subscribe`/deref of that sub, which raises `:rf.error/sub-input-fn-bad-return` — the input function returned live reactions where the runtime wanted a vector of query vectors. A view that swallows the error just renders nothing. Because the build is no help here, sweep every two-function `reg-sub` up front rather than waiting to trip over it at runtime, and smoke-test that each migrated sub actually derefs to a value.
+    A v1 signal-function `reg-sub` still *registers* under v2 (parses as a parametric sub), so compile says nothing. Mismatch surfaces at the first `subscribe`/deref: `:rf.error/sub-input-fn-bad-return` — input function returned live reactions where the runtime wanted a vector of query vectors. A view that swallows the error renders nothing. Sweep every two-function `reg-sub` up front; smoke-test that each migrated sub derefs to a value.
 
 ??? note "Going deeper"
 
-    In v1 the signal fn *ran* the subscription and handed back a live `Reaction` — it had to execute to produce its result. In v2 it hands back *data describing* which subscriptions it wants, and the runtime resolves them. A pure function returning a vector-of-vectors can be read, diffed, and graphed without ever mounting the app — which is exactly how [Xray](glossary.md#xray)'s dependency view draws the subscription DAG. The extra bracket pair is the seam where "do it" became "describe it."
+    In v1 the signal fn *ran* the subscription and returned a live `Reaction`. In v2 it returns *data describing* which subscriptions it wants; the runtime resolves them. A pure vector-of-vectors can be read, diffed, and graphed without mounting the app — how [Xray](glossary.md#xray)'s dependency view draws the subscription DAG. The extra bracket pair is where "do it" became "describe it."
 
 ### Removed surfaces, interceptors, and the test rename
 
-A handful of v1 affordances are gone, each with a defined replacement. None is a capability loss — they're consolidations: the same job done through one shape instead of several.
+v1 affordances gone, each with a replacement — consolidations, not capability loss:
 
-- `dispatch-with` / `dispatch-sync-with` fold into a two-arg `dispatch` with an opts map.
-- `reg-global-interceptor` is gone because interceptors are frame-scoped in v2 — register the behaviour with `reg-interceptor` and reference it from a frame's `:interceptors`.
-- `reg-sub-raw` gives way to `reg-sub` or the substrate adapter.
-- The `^:flush-dom` event metadata becomes `:dispatch-later {:ms 0}`.
-- `re-frame-test` becomes `re-frame.test-support` — the namespace moves; the test bodies usually don't change.
-- A `reg-fx` / `reg-cofx` that touches a browser global (`js/window`, `js/localStorage`, `js/document`) now needs an explicit `:platforms #{:client}`. v2 defaults effects to *universal* — runnable JVM-side, which is what lets the same handlers run under [SSR](../ssr/glossary.md#ssr) — so a browser-only side effect must say so, or it will try to fire during a server render and throw. A purely client-rendered app never trips this; it bites the moment you adopt SSR.
+- `dispatch-with` / `dispatch-sync-with` → two-arg `dispatch` with an opts map.
+- `reg-global-interceptor` gone — interceptors are frame-scoped; register with `reg-interceptor` and reference from a frame's `:interceptors`.
+- `reg-sub-raw` → `reg-sub` or the substrate adapter.
+- `^:flush-dom` event metadata → `:dispatch-later {:ms 0}`.
+- `re-frame-test` → `re-frame.test-support` (namespace moves; test bodies usually don't).
+- A `reg-fx` / `reg-cofx` that touches a browser global (`js/window`, `js/localStorage`, `js/document`) needs explicit `:platforms #{:client}`. v2 defaults effects to *universal* (JVM-side too, for [SSR](../ssr/glossary.md#ssr)); a browser-only side effect must say so or it fires during server render and throws. Pure client apps never trip this; SSR does.
 
-Six v1 *interceptors* are gone too — `debug`, `trim-v`, `on-changes`, `enrich`, `after`, and `inject-cofx` — each because v2 grew a better-shaped answer to the problem it solved. `debug` is subsumed by the [trace stream](glossary.md#trace-stream) ([chapter 16](observability.md)). `trim-v` is unnecessary because the canonical event shape is consistent now. `enrich` and `after` are replaced by [flows](glossary.md#flow) and [schemas](glossary.md#schema). `on-changes` becomes flows (its own section below). `inject-cofx` is replaced by the `:rf.cofx/requires` declaration ([chapter 07](coeffects.md)). The retained standard set is deliberately tiny: exactly one framework interceptor, `path`, referenced as `[:rf.interceptor/path <path-vector>]`. For anything else you register your own with `reg-interceptor` and reference it by id; chains carry references, not inline interceptor values. [Interceptors](interceptors.md) is the full model.
+Six v1 *interceptors* are gone — `debug`, `trim-v`, `on-changes`, `enrich`, `after`, `inject-cofx` — each replaced by a better-shaped answer. `debug` → [trace stream](glossary.md#trace-stream) ([Observability](observability.md)). `trim-v` unnecessary (canonical event shape is consistent). `enrich` / `after` → [flows](glossary.md#flow) and [schemas](glossary.md#schema). `on-changes` → flows (section below). `inject-cofx` → `:rf.cofx/requires` ([Coeffects](coeffects.md)). Retained standard set: exactly one framework interceptor, `path`, as `[:rf.interceptor/path <path-vector>]`. Anything else: `reg-interceptor` by id; chains carry references, not inline values. [Interceptors](interceptors.md) is the full model.
 
 ??? note "Going deeper"
 
-    Notice the pattern in *why* each interceptor left: `enrich` / `after` were "compute or assert a derived thing after the handler," which is now declarative (flows, schemas) and therefore tooling-visible; `inject-cofx` was a positional ctx→ctx function, now registration metadata the runtime resolves at context assembly (which also retires v1's cofx-ordering wart). v1's standard `unwrap` is gone for the same reason — ordinary handler destructuring covers it, and the `:event` coeffect stays the stable original vector for tracing and replay. The through-line: v2 prefers *declared facts the runtime can see* over *imperative entries in a chain*.
+    Why each left: `enrich` / `after` were "compute or assert a derived thing after the handler" — now declarative (flows, schemas) and tooling-visible. `inject-cofx` was a positional ctx→ctx function; now registration metadata resolved at context assembly (also retires v1's cofx-ordering wart). v1's standard `unwrap` is gone — ordinary handler destructuring covers it; the `:event` coeffect stays the original vector for tracing and replay. Pattern: v2 prefers *declared facts the runtime can see* over *imperative chain entries*.
 
-## The change most likely to bite: establish a root frame
+## Establish a root frame
 
-This is the one mechanical category that earns its own section, because it's the change most likely to bite a v1 codebase. [Chapter 18](frames.md) is the full story.
+The mechanical change most likely to bite a v1 codebase. Full story: [Frames](frames.md).
 
-A [**frame**](glossary.md#frame) is the isolated runtime context an operation runs under — it carries which app-db instance you're talking to. v1 gave you an ambient global `app-db` that every bare `dispatch` and `subscribe` resolved against. v2 does **not**. [Frame identity is carried, not found](glossary.md#frame-identity-is-carried-not-found): an operation reads its frame from the scope it runs under, and the runtime never synthesises one from absence. So a v1 app that calls `(rf/dispatch [:boot])` at top level with no frame established now fails loud with `:rf.error/no-frame-context`.
+A [**frame**](glossary.md#frame) is the isolated runtime context an operation runs under — which app-db instance you're talking to. v1 had an ambient global `app-db` that every bare `dispatch` and `subscribe` resolved against. v2 does **not**. [Frame identity is carried, not found](glossary.md#frame-identity-is-carried-not-found): an operation reads its frame from scope; the runtime never invents one from absence. A v1 app that calls `(rf/dispatch [:boot])` at top level with no frame established fails with `:rf.error/no-frame-context`.
 
-The fix is ceremony at your root: ensure a frame and scope your tree to it. Day-one
-shape is `frame-root` (ensure + scope). `make-frame` + `frame-provider` is for when
-construction must happen before render (tests, SSR, tooling) — see
-[Frames](frames.md).
+Fix at the root: ensure a frame and scope the tree to it. The usual shape is `frame-root` (ensure + scope). `make-frame` + `frame-provider` is when construction must happen before render (tests, SSR, tooling) — see [Frames](frames.md).
 
 ```clojure
 ;; Prefer: named seed event(s) on frame-root (same pipeline as every later change)
 (rdc/render root
   [rf/frame-root {:id :app/main
-                  :initial-events [[:app/initialise]   ;; your reg-event that returns {:db …}
+                  :initial-events [[:app/initialise]   ;; reg-event that returns {:db …}
                                    [:boot]]}
    [app-root]])
 
@@ -162,93 +153,85 @@ construction must happen before render (tests, SSR, tooling) — see
    [app-root]])
 ```
 
-Inside that tree, a bare `dispatch` / `subscribe` resolves the frame ambiently — *once the view it runs in can read the provider*. A view registered with `reg-view` can; a plain (unregistered) Reagent fn that dispatches or subscribes cannot, and fails loud with `:rf.error/no-frame-context` ([Views render under a frame scope](#views-render-under-a-frame-scope), below, has the fix). Rootless calls need attention too: async callbacks that lost their scope, and top-level boot code with no provider — exactly the wrong-frame footguns v1 used to swallow silently. The skill rewrites bare top-level call sites into a root provider and flags async callbacks for an explicit capture (next).
+Inside that tree, bare `dispatch` / `subscribe` resolve the frame ambiently *once the view can read the provider*. A `reg-view` can; a plain (unregistered) Reagent fn that dispatches or subscribes cannot, and fails with `:rf.error/no-frame-context` ([Views render under a frame scope](#views-render-under-a-frame-scope)). Rootless call sites also need attention: async callbacks that lost scope, top-level boot with no provider — the wrong-frame cases v1 swallowed. The skill rewrites bare top-level call sites into a root provider and flags async callbacks for explicit capture (next).
 
-!!! note "No `:initial-db` key, and that's deliberate (EP-0027)"
+!!! note "No `:initial-db` key (EP-0027)"
 
-    A v1 reflex is to reach for an `:initial-db` / `:db` config key to seed initial
-    state. v2 doesn't have one. **Every frame starts with `app-db = {}`**, and
-    seeding is *itself an event* in `:initial-events`. Prefer a **named** seed
-    handler — the same shape the Core guide uses:
+    A v1 reflex is `:initial-db` / `:db` config to seed state. v2 has neither. **Every frame starts with `app-db = {}`**; seeding is an event in `:initial-events`. Prefer a **named** seed handler:
 
     ```clojure
     (rf/reg-event :app/initialise
       (fn [_ _] {:db {:screen :home}}))
     ```
 
-    For a raw dump with no domain event, `[:rf/set-db {…}]` (built-in) is fine as
-    a first step. A v1 `(reg-event-db :initialise-db (fn [_ _] default-db))` maps
-    either to that named event or to `[:rf/set-db default-db]`. Setup is always
-    events — v1's `:on-create` callback is gone — so time-travel can rewind *to*
-    the initial state on the same pipeline as every later change.
+    For a raw dump with no domain event, `[:rf/set-db {…}]` (built-in) works as a first step. A v1 `(reg-event-db :initialise-db (fn [_ _] default-db))` maps either to that named event or to `[:rf/set-db default-db]`. Setup is always events — v1's `:on-create` is gone — so time-travel can rewind *to* the initial state on the same pipeline as every later change.
 
 !!! warning "Gotcha"
 
-    A common v1 shape is an `:initialize-db` / `:app/reset` handler that returns a whole fresh app-db — and in v1 that could clobber framework state stashed in the same map. Under v2 it can't: the framework keeps its own state in a separate [runtime-db](glossary.md#runtime-db) partition that a `:db` return cannot reach, so the wholesale-replace footgun is structurally gone — replace away. The one residual hazard is a fresh map that still carries the retired `:rf/runtime` app-db root (a v1-shaped runtime stash). That throws `:rf.error/legacy-runtime-root` on dispatch — loud, always-on, in production too. The fix is to delete the key; framework state isn't yours to seed.
+    A common v1 shape is `:initialize-db` / `:app/reset` that returns a whole fresh app-db — and in v1 that could clobber framework state stashed in the same map. Under v2 it can't: framework state lives in a separate [runtime-db](glossary.md#runtime-db) partition that a `:db` return cannot reach. The residual hazard: a fresh map that still carries the retired `:rf/runtime` app-db root (v1-shaped runtime stash). That throws `:rf.error/legacy-runtime-root` on dispatch — loud, always-on, production too. Delete the key; framework state isn't yours to seed.
 
-### The async-callback fix: capture a frame api
+### Async callbacks: capture a frame api
 
-The capture is one line, and it's worth seeing concretely because it's the most common Type B fix in a real codebase. `(rf/capture-frame)` snapshots the *current* frame and hands back a [**frame api**](glossary.md#capture-frame) — a small bundle with the keys `:frame`, `:dispatch`, `:dispatch-sync`, and `:subscribe`, whose `dispatch` always targets the frame it captured, even after the render scope that produced it has unwound. So you grab the frame api while the scope is still live (during render, or inside an event handler), close over it, and call its `:dispatch` from the callback:
+`(rf/capture-frame)` snapshots the *current* frame and returns a [**frame api**](glossary.md#capture-frame) — keys `:frame`, `:dispatch`, `:dispatch-sync`, `:subscribe` — whose `dispatch` always targets the captured frame after the render scope that produced it has unwound. Grab while the scope is live (during render or inside an event handler), close over it, call its `:dispatch` from the callback:
 
 ```clojure
-;; WRONG in v2 — the bare dispatch fires after the scope unwound → :rf.error/no-frame-context
+;; WRONG in v2 — bare dispatch after scope unwound → :rf.error/no-frame-context
 (defn poll! []
   (js/setTimeout #(rf/dispatch [:tick]) 1000))
 
-;; RIGHT — capture the frame api while the scope is live, dispatch through it later
+;; RIGHT — capture while scope is live; dispatch through it later
 (defn poll! []
-  (let [{:keys [dispatch]} (rf/capture-frame)]      ;; snapshot now, on the current frame
-    (js/setTimeout #(dispatch [:tick]) 1000)))      ;; the callback targets the captured frame
+  (let [{:keys [dispatch]} (rf/capture-frame)]
+    (js/setTimeout #(dispatch [:tick]) 1000)))
 ```
 
-You can also pass `(rf/capture-frame frame-id)` to capture a *named* frame rather than the ambient one. Read its app-db with `(rf/app-db-value (:frame h))` — the frame api carries operations, not state.
+`(rf/capture-frame frame-id)` captures a *named* frame rather than the ambient one. Read app-db with `(rf/app-db-value (:frame h))` — the frame api carries operations, not state.
 
 ??? info "Coming from React Context?"
 
-    The `frame-provider {:frame …}` *is* a context provider, and the "no-frame-context" error is the exact analogue of calling a hook outside its provider and getting `undefined` back from `useContext` — except v2 throws instead of silently handing you a stale default. The one wrinkle React people already know: context doesn't cross an async boundary on its own. A `setTimeout` callback in React loses nothing because closures capture; a re-frame2 callback that fires *after* its render scope unwound needs to have captured a frame api (`rf/capture-frame`) while the scope was live. Same lesson, louder failure.
+    `frame-provider {:frame …}` is a context provider; `:rf.error/no-frame-context` is the analogue of calling a hook outside its provider — except v2 throws instead of handing a stale default. Context doesn't cross async on its own: a re-frame2 callback that fires *after* its render scope unwound needs a frame api captured with `rf/capture-frame` while the scope was live.
 
 ### Views render under a frame scope
 
-A plain Reagent fn that only renders the props it's handed keeps working under any tree — it never touches a frame. What changes is a plain fn that *itself* dispatches or subscribes: it carries no `:contextType`, so it can't read the frame from an enclosing `frame-provider` (the provider hands its frame down through React context, and only a registered view is wired to receive it). The resolution falls through to nil and the bare call fails with `:rf.error/no-frame-context` — even with a provider right above it — rather than the silent default-frame routing v1 allowed. The clean fix is to register that view with [`reg-view`](glossary.md#view): it reads the provider's frame from React context and injects frame-bound `dispatch` / `subscribe` that survive callback boundaries. If you leave it a plain fn on purpose, carry the frame explicitly instead — `(rf/capture-frame frame-id)`, a `{:frame …}` opt on the call, or a captured frame api threaded down as a prop. Two moves that look like they'd help but re-raise the same error: wrapping the *returned subtree* in `with-frame` (its dynamic binding has unwound by the time React renders the descendant) and a bare no-arg `(rf/capture-frame)` from the unregistered fn (it repeats the lookup that already returned nil — it captures only when a real scope exists at render). What distinguishes them is liveness: a `with-frame` (or that same no-arg capture) around the *actual synchronous* dispatch/subscribe/capture — run before the scope unwinds — is a live inner binding and works; only the wrapper around returned Hiccup or a later render fails.
+A plain Reagent fn that only renders the props it's handed still works under any tree — it never touches a frame. What changes: a plain fn that *itself* dispatches or subscribes. It has no `:contextType`, so it can't read the frame from an enclosing `frame-provider` (provider hands frame through React context; only a registered view is wired to receive it). Resolution falls through to nil; the bare call fails with `:rf.error/no-frame-context` even with a provider above it — rather than v1's silent default-frame routing. Clean fix: register with [`reg-view`](glossary.md#view) — it reads the provider's frame and injects frame-bound `dispatch` / `subscribe` that survive callback boundaries. If you leave it a plain fn on purpose, carry the frame explicitly — `(rf/capture-frame frame-id)`, a `{:frame …}` opt on the call, or a captured frame api as a prop. Two moves that look helpful but re-raise the same error: wrapping the *returned subtree* in `with-frame` (dynamic binding has unwound by the time React renders the descendant), and bare no-arg `(rf/capture-frame)` from the unregistered fn (repeats the nil lookup — captures only when a real scope exists at render). What works: a `with-frame` (or that same no-arg capture) around the *actual synchronous* dispatch/subscribe/capture — run before the scope unwinds. Only the wrapper around returned Hiccup or a later render fails.
 
-## Paths and cache identity: mostly good news, one habit to drop
+## Paths and cache identity
 
-v2 treats a **path** — a vector addressing a value, the thing you hand `get-in` / `assoc-in` — as a precise, framework-wide concept ([chapter 02](app-db.md)). Your existing plain vector paths carry over unchanged: `[:cart :items]` means exactly what it always did. Three small adjustments are worth knowing:
+v2 treats a **path** — a vector addressing a value for `get-in` / `assoc-in` — as a precise, framework-wide concept ([app-db](app-db.md)). Existing plain vector paths carry over unchanged. Three adjustments:
 
-- **Plain vector paths stay valid.** Nothing to do. Where v2 stores a path for you (a flow's `:output-path`, a named declaration), it normalizes whatever sequence you gave it to a canonical vector — so a list or seq you passed for convenience comes back as a vector, but it's the same path.
-- **Drop hand-rolled cache keys.** A v1 codebase that built its own cache-key strings — `(str "user-" id "-" tab)`, a `pr-str` of a params map, an MD5 of a query — should move that identity onto the **scoped resource key**: a `[cache-scope resource-id canonical-params]` triple, the shape [server-state resources](../resources/concepts.md) use. Two reads share a cache entry only when their whole scoped key matches: same [resource](../resources/glossary.md#resource) id, same canonical [scope](../resources/glossary.md#scope), same canonical params (each canonical regardless of key order). Don't migrate a params-only key as if params alone were the identity — folding scope back in is what keeps per-user and per-tenant caches from leaking into one another.
-- **Make `nil`-vs-missing explicit.** v2 distinguishes an absent key from a key present with value `nil`, and that distinction is part of a value's identity. Code that leaned on "absent and `nil` are the same" should pick one on purpose: the two are now genuinely different facts — a different cache entry, a different identity. The fix is a `:params-schema` or a sentinel value, not an accident.
+- **Plain vector paths stay valid.** Where v2 stores a path for you (flow `:output-path`, a named declaration), it normalizes sequences to a canonical vector — a list or seq you passed for convenience comes back as a vector; same path.
+- **Drop hand-rolled cache keys.** A v1 codebase that built cache-key strings — `(str "user-" id "-" tab)`, `pr-str` of a params map, MD5 of a query — should move identity onto the **scoped resource key**: `[cache-scope resource-id canonical-params]`, the shape [server-state resources](../resources/concepts.md) use. Two reads share a cache entry only when the whole scoped key matches: same [resource](../resources/glossary.md#resource) id, same canonical [scope](../resources/glossary.md#scope), same canonical params (order-independent). Don't migrate a params-only key as if params alone were identity — folding scope in is what keeps per-user and per-tenant caches from leaking.
+- **Make `nil`-vs-missing explicit.** v2 distinguishes an absent key from a key present with value `nil`; that distinction is part of identity. Code that treated "absent and `nil` the same" should pick one on purpose. Fix with a `:params-schema` or a sentinel, not an accident.
 
-There's no automated rewrite for the cache-key habit. It's a judgement call about your own keying scheme, so the skill flags hand-built cache keys for review rather than guessing your intent.
+No automated rewrite for the cache-key habit. Type B: the skill flags hand-built cache keys for review.
 
 ??? info "Coming from TanStack Query?"
 
-    You already think in query keys, so this will feel native: the scoped resource key *is* a query key, and the same rule applies — two `useQuery` calls share a cache entry only when their keys are structurally equal. v2's one addition is that scope (which user, which tenant) is a first-class segment of the key, not something you splice into a string by hand. The `nil`-vs-missing distinction is the bit TanStack leaves to you and v2 makes explicit: `{tab: null}` and `{}` are *different* keys, so decide which one you mean.
+    Scoped resource key *is* a query key: two `useQuery` calls share a cache entry only when keys are structurally equal. v2's addition: scope (user, tenant) is a first-class segment, not spliced into a string. `nil`-vs-missing: `{tab: null}` and `{}` are *different* keys.
 
-## The deepest change: ambient world reads in durable handlers
+## Ambient world reads in durable handlers
 
-First, the idea that makes this section make sense. [Time-travel](glossary.md#time-travel) ([chapter 16](observability.md)) leans on one guarantee: replaying the recorded event stream from the start rebuilds the *exact same* app-db. That only holds if a handler is a clean fold over the stream — state-in, state-out, no peeking at the outside world. (A *fold* here is the functional-programming sense: `reduce` over the events, each folded into the running app-db.)
+[Time-travel](glossary.md#time-travel) ([Observability](observability.md)) needs one guarantee: replaying the recorded event stream rebuilds the *same* app-db. That holds only if a handler is a clean fold over the stream — state-in, state-out, no peeking at the outside world. (*Fold* = functional-programming sense: reduce over events into the running app-db.)
 
-This is the one category that genuinely *tightens* to protect that guarantee, and a v1 codebase trips it everywhere — so it's worth slowing down for. v1 let a handler reach straight into the world for a fact and write the result into state: `(js/Date.)` for a `:created-at`, `(random-uuid)` for an id, a v1 `:now` cofx injected via an interceptor entry, a boot handler reading `localStorage` to seed session state. Each of those is a peek at the outside world — and the outside world doesn't replay the same way twice.
+This category tightens to protect that guarantee, and v1 codebases trip it often. v1 let a handler reach into the world and write the result into state: `(js/Date.)` for `:created-at`, `(random-uuid)` for an id, a v1 `:now` cofx via interceptor, a boot handler reading `localStorage` to seed session. Each is a peek at a world that doesn't replay the same way twice.
 
-So v2 draws a bright line: **a fact that decides a durable write must be a fact the ledger recorded** ([recordable coeffects](coeffects.md)). Every world fact a handler consumes is now declared with `:rf.cofx/requires` and delivered flat under its own owner-qualified id. The declaration's *grade* — [recordable vs ambient](glossary.md#recordable-vs-ambient-coeffects): recordable (the runtime captures the value into the ledger, so replay re-feeds it) versus ambient (re-read fresh on every replay) — decides what happens on replay. The mapping is mechanical:
+v2 rule: **a fact that decides a durable write must be a fact the ledger recorded** ([recordable coeffects](coeffects.md)). Every world fact a handler consumes is declared with `:rf.cofx/requires` and delivered flat under its owner-qualified id. Grade — [recordable vs ambient](glossary.md#recordable-vs-ambient-coeffects): recordable (runtime captures into the ledger; replay re-feeds it) vs ambient (re-read fresh every replay) — decides replay behaviour. Mapping:
 
-- **Durable clock reads** — `js/Date.now`, `(.now js/Date)`, an `interop/now-ms` — become a declared `:rf/time-ms`: add `:rf.cofx/requires [:rf/time-ms]` to the handler and read the flat `time-ms` key. The runtime stamps `:rf/time-ms` on every dispatch envelope and records it. (It is the framework's one built-in recordable fact.)
-- **Generated ids** — `random-uuid` / host UUID calls feeding durable state — move to the event payload (mint at the dispatch site, `[:cart/add-item {:id (random-uuid) :sku "BK-1"}]`, the preferred route) or, for ids minted inside the fold, become a declared recordable cofx whose app-registered supplier generates the value.
-- **Random choices** — `rand` / `rand-int` / `rand-nth` whose result is written durably — become an app-registered recordable cofx (the supplier records produced choices, never seeds).
-- **Durable storage / location reads** — `localStorage` / `sessionStorage` / `js/location` / `navigator` reads that initialise durable state — become router/host events or a `{:recordable? true}` cofx, rather than ambient reads at the write site.
-- **Ambient `:now` cofx** — a v1 `(inject-cofx :now)` interceptor entry becomes a `:rf.cofx/requires [:rf/time-ms]` declaration. Reading only the recorded fact (never an ambient host read) means a scripted or replayed time returns exactly. If you genuinely want a distinct app-named clock id, register a recordable supplier under that id:
+- **Durable clock reads** — `js/Date.now`, `(.now js/Date)`, `interop/now-ms` — declare `:rf/time-ms`: add `:rf.cofx/requires [:rf/time-ms]` and read the flat `time-ms` key. Runtime stamps `:rf/time-ms` on every dispatch envelope and records it. (The framework's one built-in recordable fact.)
+- **Generated ids** — `random-uuid` / host UUID feeding durable state — move to the event payload (mint at dispatch, `[:cart/add-item {:id (random-uuid) :sku "BK-1"}]`, preferred) or, for ids minted inside the fold, a declared recordable cofx with an app-registered supplier.
+- **Random choices** — `rand` / `rand-int` / `rand-nth` written durably — app-registered recordable cofx (supplier records produced choices, never seeds).
+- **Durable storage / location reads** — `localStorage` / `sessionStorage` / `js/location` / `navigator` that initialise durable state — router/host events or `{:recordable? true}` cofx, not ambient reads at the write site.
+- **Ambient `:now` cofx** — v1 `(inject-cofx :now)` → `:rf.cofx/requires [:rf/time-ms]`. Reading only the recorded fact means a scripted or replayed time returns exactly. For a distinct app-named clock id, register a recordable supplier:
 
 ```clojure
-;; An app-named recordable clock fact — a value-returning supplier, recordable.
-;; (Most code just declares :rf/time-ms directly; reach for this only if you
-;;  want a domain-specific id rather than the framework's built-in.)
+;; App-named recordable clock — value-returning supplier.
+;; Most code declares :rf/time-ms; use this only for a domain-specific id.
 (rf/reg-cofx :app/now-ms
   {:recordable? true :doc "App-named durable wall clock."}
   (fn [] (.now js/Date)))
 ```
 
-One mechanical rewrite touches *every* `reg-cofx` a v1 app wrote, ambient or recordable: **custom cofx handlers lose the ctx wrapper.** A v1 cofx handler took the interceptor context and threaded a value into it — `(fn [ctx arg] (assoc-in ctx [:coeffects :id] v))`. v2 retires that ctx→ctx shape. A supplier is a plain **value-returning** function — `(fn [arg] v)` (or `(fn [] v)`) — and the runtime places the returned value into the coeffects map under the cofx's id. The matching consumer change: a v1 `[(rf/inject-cofx :viewport "main")]` interceptor entry becomes `:rf.cofx/requires [[:viewport "main"]]` registration metadata:
+One mechanical rewrite for *every* `reg-cofx` a v1 app wrote: **custom cofx handlers lose the ctx wrapper.** v1 took the interceptor context and threaded a value in — `(fn [ctx arg] (assoc-in ctx [:coeffects :id] v))`. v2 retires that ctx→ctx shape. A supplier is **value-returning** — `(fn [arg] v)` or `(fn [] v)` — and the runtime places the return under the cofx id. Consumer side: v1 `[(rf/inject-cofx :viewport "main")]` → `:rf.cofx/requires [[:viewport "main"]]` registration metadata:
 
 ```clojure
 ;; v1 — ctx→ctx handler, injected positionally
@@ -261,95 +244,93 @@ One mechanical rewrite touches *every* `reg-cofx` a v1 app wrote, ambient or rec
 ;; v2 — value-returning supplier, declared via :rf.cofx/requires
 (rf/reg-cofx :viewport
   {:doc "Ambient viewport width."}
-  (fn [] (.-innerWidth js/window)))           ;; just the value; no ctx, no assoc-in
+  (fn [] (.-innerWidth js/window)))
 (rf/reg-event :layout/measure
-  {:rf.cofx/requires [:viewport]}             ;; declaration metadata, not an interceptor
+  {:rf.cofx/requires [:viewport]}
   (fn [{:keys [db viewport]} _] ...))
 ```
 
-(`inject-cofx` itself doesn't quietly disappear, either — a stale call fails loud with `:rf.error/inject-cofx-removed`, naming `:rf.cofx/requires` as the replacement.)
+Stale `inject-cofx` fails with `:rf.error/inject-cofx-removed`, naming `:rf.cofx/requires` as the replacement.
 
-The same surgery applies on the way *out*: **`reg-fx` handlers gain a context argument.** A v1 effect handler was a one-arg `(fn [value] …)`; v2's contract is binary — `(fn [ctx args] …)`, where `ctx` carries `:frame` (the frame the originating event ran in) and `:event`, and `args` is the config your handlers build. A v1 handler pasted in unchanged destructures the ctx map as if it were its config and reads `nil`s — add the leading `_ctx` argument as you port each one.
+On the way *out*: **`reg-fx` handlers gain a context argument.** v1 was one-arg `(fn [value] …)`; v2 is binary — `(fn [ctx args] …)`, where `ctx` carries `:frame` and `:event`, and `args` is the config your handlers build. A v1 handler pasted in unchanged destructures the ctx map as config and reads `nil`s — add leading `_ctx` as you port each one.
 
-The signature change is *unconditional* — it applies whether or not the fact is recordable, and whether the supplier takes call-site arguments (`(fn [k] v)`, declared `[[:viewport k]]`) or none. A cofx that only measures a diagnostic or transient fact (a viewport width, a non-durable display preference) stays **ambient**: register it without `:recordable?` and it simply re-runs on replay. The `:recordable?` grade bites only when the value feeds a *durable* write.
+The signature change is *unconditional* — recordable or not, with or without call-site args (`(fn [k] v)`, declared `[[:viewport k]]`). A cofx that only measures a diagnostic or transient fact stays **ambient**: register without `:recordable?` and it re-runs on replay. `:recordable?` matters only when the value feeds a *durable* write.
 
 !!! note "Why this matters"
 
-    This is the deepest "why" on the page, and it's the replay promise from the top of this section, made concrete. A handler that secretly reads `(js/Date.)` and writes it to state breaks that promise the instant you replay: the clock moved, so the rebuilt app-db no longer matches. The bright line — a fact that decides a *durable* write must come through a *recorded* coeffect, never an ambient host read — is exactly what keeps the replay faithful. A diagnostic read that never lands in durable state stays ambient and re-runs freely; it can't poison anything. The skill flags these for review rather than rewriting blind, because "does this read decide durable state?" is a judgement about your code's intent, not something a tool can read off the syntax — the cardinal rule again, doing the things it's sure of and asking about the rest.
+    A handler that secretly reads `(js/Date.)` and writes it to state breaks replay the instant the clock moved. Rule: a fact that decides a *durable* write must come through a *recorded* coeffect, never an ambient host read. A diagnostic that never lands in durable state stays ambient. The skill flags these for review rather than rewriting blind — "does this read decide durable state?" is intent, not syntax.
 
-## Two changes worth understanding in depth
+## Two changes worth depth
 
-Most of the categories above are mechanical, and the skill handles them while you watch. Two are different enough that understanding them pays off. They're places where v2 isn't renaming a thing — it's offering a genuinely better shape.
+Most categories above are mechanical. Two offer a different shape, not just a rename.
 
 ### HTTP folds onto `:rf.http/managed`
 
-A v1 codebase that registered its own `:http` fx — or leaned on `re-frame-http-fx`, `re-frame-fetch-fx`, or a cousin — migrates onto the [`:rf.http/managed`](../resources/glossary.md#managed-http) effect ([Managed HTTP](../async/http.md)). The skill recognises the shape, and the rewrite is mostly mechanical:
+A v1 codebase with its own `:http` fx — or `re-frame-http-fx`, `re-frame-fetch-fx`, or a cousin — migrates onto [`:rf.http/managed`](../resources/glossary.md#managed-http) ([Managed HTTP](../async/http.md)). The skill recognises the shape; rewrite is mostly mechanical:
 
-1. Add the `day8/re-frame2-http` artefact and require it from the namespaces that issue requests.
+1. Add `day8/re-frame2-http` and require it from namespaces that issue requests.
 2. Replace `[:http {:url ... :on-success ... :on-error ...}]` with `[:rf.http/managed {:request {:url ...} :on-success ... :on-failure ...}]`. Wire-shape keys (`:method`, `:url`, `:body`, `:headers`, `:params`) move *inside* `:request`.
-3. Rename `:on-error` → `:on-failure`. The canonical [reply map](../resources/glossary.md#reply-map) appends as the last argument; destructure `{:keys [value]}` for success (reply `:status :ok`), `{:keys [error]}` for failure (reply `:status :error`, the failure map under `:error`).
-4. Adopt the closed `:rf.http/*` failure category set — code that branched on `(:status err)` becomes branching on the failure map's `:kind` (under the reply's `:error`).
+3. Rename `:on-error` → `:on-failure`. The canonical [reply map](../resources/glossary.md#reply-map) appends as the last argument; destructure `{:keys [value]}` for success (reply `:status :ok`), `{:keys [error]}` for failure (reply `:status :error`, failure map under `:error`).
+4. Adopt the closed `:rf.http/*` failure category set — code that branched on `(:status err)` branches on the failure map's `:kind` (under the reply's `:error`).
 
-There are exactly **eight** failure categories, in two groups. Five are *retryable* (a re-issue can plausibly change the outcome): `:rf.http/transport` (network / DNS / connection-reset), `:rf.http/cors`, `:rf.http/timeout`, `:rf.http/http-4xx`, and `:rf.http/http-5xx`. Three are *non-retryable by construction*: `:rf.http/aborted` (cancelled or superseded — abort always wins), `:rf.http/decode-failure` (a 2xx whose body failed schema validation / JSON parse / your decode fn threw), and `:rf.http/accept-failure` (your `:accept` normaliser projected a structurally-valid 200 to a domain `{:failure …}`). Putting a non-retryable category in `:retry :on` fails loud at the dispatch site with `:rf.error/http-bad-retry-on` — the runtime refuses to carry a retry policy that can never fire.
+Exactly **eight** failure categories, two groups. Five *retryable*: `:rf.http/transport` (network / DNS / connection-reset), `:rf.http/cors`, `:rf.http/timeout`, `:rf.http/http-4xx`, `:rf.http/http-5xx`. Three *non-retryable by construction*: `:rf.http/aborted` (cancelled or superseded — abort always wins), `:rf.http/decode-failure` (2xx whose body failed schema / JSON parse / decode fn threw), `:rf.http/accept-failure` (`:accept` normaliser projected a structurally valid 200 to domain `{:failure …}`). Putting a non-retryable category in `:retry :on` fails at the dispatch site with `:rf.error/http-bad-retry-on`.
 
-A v1 status-code `cond` becomes a `case` over these named kinds:
+A v1 status-code `cond` becomes a `case` over named kinds:
 
 ```clojure
 (rf/reg-event :article/load-error
-  (fn [{:keys [db]} [_ {:keys [error]}]]        ;; the failure map rides under :error
+  (fn [{:keys [db]} [_ {:keys [error]}]]
     {:db (assoc-in db [:article :error]
            (case (:kind error)
              :rf.http/timeout        "The server took too long — try again."
              :rf.http/http-4xx       "That article doesn't exist."
              :rf.http/http-5xx       "Something broke on our end."
              :rf.http/decode-failure "The server sent something we couldn't read."
-             "Couldn't load the article."))}))   ;; closed set → a total case with one default
+             "Couldn't load the article."))}))
 ```
 
-The skill applies steps 1–4 unprompted and stops at an optional step 5 (collapsing per-call success handlers into default reply addressing) for review. This is more than a rename because `:rf.http/managed` is a *managed* effect: it owns retries, aborts, double-submit suppression, the slow-loris timeout from [chapter 24](how-to/configure-dev-and-prod.md), and the eight-category failure taxonomy. Migrating onto it deletes a pile of hand-rolled request-lifecycle code that the framework now does correctly for you.
+The skill applies steps 1–4 unprompted and stops at optional step 5 (collapsing per-call success handlers into default reply addressing). More than a rename: `:rf.http/managed` owns retries, aborts, double-submit suppression, the slow-loris timeout from [configure dev and prod](how-to/configure-dev-and-prod.md), and the eight-category failure taxonomy — so you can delete hand-rolled request-lifecycle code the framework now owns.
 
 ??? info "Coming from TanStack Query or RTK Query?"
 
-    This is the same trade you made when you stopped writing raw `fetch` and `useState` / `useEffect` lifecycles by hand. A managed effect owns the retry, the in-flight dedup, the abort-on-unmount, the timeout — the unglamorous edge cases you keep re-implementing slightly wrong. The one re-frame-flavoured difference: failures arrive as a *closed* category set (`(:kind failure)`), so you `case` over named outcomes instead of pattern-matching HTTP status integers and praying the server is consistent.
+    Same trade as stopping raw `fetch` + `useState` / `useEffect` lifecycles. A managed effect owns retry, in-flight dedup, abort-on-unmount, timeout. re-frame difference: failures are a *closed* category set (`(:kind failure)`), so you `case` over named outcomes instead of pattern-matching status integers.
 
 ### `on-changes` becomes flows
 
-This is the one v1 concept that maps onto something with a genuinely new name and a slightly different shape. v1's `on-changes` interceptor said "when these in-paths change, compute and write to that out-path." v2's [**flows**](glossary.md#flow) say the same thing — same compute-on-input-change semantics — but the wiring moves. In v1 you bolted `on-changes` onto each event's interceptor chain by hand; in v2 you register a flow once with the runtime, and it runs the derivation automatically after *every* event handler, before the new `:db` lands. It's also toggleable at runtime, which `on-changes` never was.
+v1's `on-changes` interceptor said "when these in-paths change, compute and write to that out-path." v2's [**flows**](glossary.md#flow) keep the same compute-on-input-change semantics; the wiring moves. In v1 you bolted `on-changes` onto each event's interceptor chain; in v2 you register a flow once and it runs after *every* event handler, before the new `:db` lands. Also toggleable at runtime, which `on-changes` never was.
 
 ```clojure
 (rf/reg-flow :editor/word-count
-  {:inputs [[:editor :title] [:editor :body]]    ;; vector of app-db paths
-   :output-path [:editor :word-count]             ;; where the result is written
+  {:inputs [[:editor :title] [:editor :body]]
+   :output-path [:editor :word-count]
    :doc    "Live word count of the article being edited."}
-  (fn [title body]                                ;; pure: (in-1, in-2, ...) → output
+  (fn [title body]
     (count (re-seq #"\S+" (str title " " body)))))
 ```
 
-Internalise one thing before you reach for them, because the easy mistake is to treat flows as a sub replacement and end up with a smell.
+**Flows are a niche convenience, not a sub replacement.** Use them for derived values that are part of application *state*: visible to other event handlers, surviving SSR hydration, covered by registered schemas, queryable from the app-db inspector. If only views consume the value, use a [subscription](glossary.md#subscription) — lighter, sub-cache-native, no `app-db` write. A healthy re-frame2 app has dozens of subs and a handful of flows. Tens of flows usually means the wrong tool.
 
-**Flows are a niche convenience, not a sub replacement.** They're for derived values that are part of the application's *state*: visible to other event handlers, surviving SSR hydration, covered by registered schemas, queryable from the app-db inspector. If the derived value is consumed only by views, the right tool is a [subscription](glossary.md#subscription) — lighter, sub-cache-native, no `app-db` write. A healthy re-frame2 app has dozens of subs and a handful of flows. Tens of flows means you reached for the wrong tool.
+!!! note "Litmus test"
 
-!!! note "The litmus test"
+    Does anything other than a view need this value? Only views → subscription. Event handler reads it, or it must be in app-db for SSR hydration, or a schema asserts on it → flow. When in doubt, subscription. Full call: [where state lives](glossary.md#the-four-homes-where-state-lives).
 
-    Ask: *does anything other than a view need this value?* If only views read it → subscription. If an event handler reads it, or it must be in app-db so SSR hydrates it, or a schema asserts on it → flow. It's the same line a spreadsheet draws between a derived cell other cells reference (a flow) and a value you only glance at on screen (a sub). When in doubt, reach for a sub; flows are the exception, not the default. (The [where state lives](glossary.md#the-four-homes-where-state-lives) router is the full version of this call.)
+Flows can also do what `on-changes` couldn't. `on-changes` was statically wired into specific events at registration time, so conditional derivation (only while a wizard step is active, only under a feature gate) had no clean shape. Flows are runtime-registered and runtime-clearable via `:rf.fx/reg-flow` / `:rf.fx/clear-flow`. Migration sometimes improves the code: always-on becomes conditional.
 
-Flows can also reach what `on-changes` couldn't. `on-changes` was statically wired into specific events at registration time, so a derivation that should run conditionally — only while a wizard step is active, only when a feature gate is engaged — had no clean shape. Flows are runtime-registered and runtime-clearable via the `:rf.fx/reg-flow` / `:rf.fx/clear-flow` effects. So the migration sometimes *improves* the code it touches: a thing that was awkwardly always-on becomes cleanly conditional.
-
-The rewrite itself is Type B. Mechanically it's `(rf/on-changes f out-path & in-paths)` → `(rf/reg-flow flow-id {:inputs in-paths :output-path out-path} f)`, but the agent stops to ask about the `flow-id` (it suggests `:legacy/<event-id>` as a default) and whether the flow should be conditional rather than always-on. An app with no `on-changes` sees no migration here at all.
+Rewrite is Type B. Mechanical map: `(rf/on-changes f out-path & in-paths)` → `(rf/reg-flow flow-id {:inputs in-paths :output-path out-path} f)`. The agent stops for `flow-id` (suggests `:legacy/<event-id>`) and whether the flow should be conditional. Apps with no `on-changes` see nothing here.
 
 ## Growing into images and frames
 
-A v1 app registers everything at namespace load with `reg-*`, into one process-global [registrar](glossary.md#registrar). v2 keeps that path working: `reg-*` still registers, and the runtime assembles a standard frame over the global registrations for you. The mechanical migration changes nothing about how you register. Keep writing `reg-*`. You are using a frame without naming it, exactly as you've always used app-db without naming a frame.
+A v1 app registers everything at namespace load with `reg-*` into one process-global [registrar](glossary.md#registrar). v2 keeps that path: `reg-*` still registers, and the runtime assembles a standard frame over global registrations. Mechanical migration doesn't change how you register. Keep writing `reg-*`. You are using a frame without naming it, the way you've always used app-db without naming a frame.
 
-You reach past that only when v2 gives you a shape v1 didn't have. The public composition model is `image → frame → event stream`: an [**image**](glossary.md#image) (`rf/image`) is a value naming a set of registrations — you select them from loaded namespaces (`:select-ns`) or list them inline (`:registrations`). A [**frame**](glossary.md#frame) (`rf/make-frame`) is the live isolated execution context that runs one **generation** — the resolved registration set an image seals into — with its own app state, subscription cache, and adapter binding. Images and frames are the route for genuinely new structure — a packaged feature you assemble and run as a unit, a per-tenant or multi-frame process. They're a refinement you grow into, not a step the migration forces.
+Reach past that only when you need a shape v1 didn't have. Composition model: `image → frame → event stream`. An [**image**](glossary.md#image) (`rf/image`) is a value naming a set of registrations — select from loaded namespaces (`:select-ns`) or list inline (`:registrations`). A [**frame**](glossary.md#frame) (`rf/make-frame`) is the live isolated execution context that runs one **generation** — the resolved registration set an image seals into — with its own app state, subscription cache, and adapter binding. Images and frames are for new structure: a packaged feature as a unit, per-tenant or multi-frame process. Refinement you grow into, not a migration step.
 
 ??? note "Going deeper — build isolated contexts from images"
 
-    A frame built from `:images` runs exactly the registrations those images select — its own sealed registration set, validated for collisions and capability requirements at assembly. Two frames can hold different handlers for the same id without collision, which makes a frame the natural unit for a hermetic test or a parallel frame on the same page. You target a frame by its id — the public address is always the frame id, never an enclosing substrate.
+    A frame built from `:images` runs exactly the registrations those images select — sealed set, validated for collisions and capability requirements at assembly. Two frames can hold different handlers for the same id without collision — natural unit for a hermetic test or a parallel frame on the same page. Target a frame by id; the public address is always the frame id, never an enclosing substrate.
 
 !!! warning "Gotcha — don't select the same id twice in one image"
 
-    Within a *single* `rf/image`, `:select-ns` and `:registrations` must be **disjoint** — a `[kind id]` may not be both selected from a namespace and defined inline in the same image. Image assembly catches it and fails loud rather than silently merging. And the way to *override* a registration is **not** a `:replace` key — that key was retired in EP-0026, and `rf/image` rejects it (along with `:include-ns` / `:exclude-ns` / `:replace-standard`) with `:rf.error/invalid-image`. Instead, put the winning registration in a **later** image and compose — later image wins. The override is not silent: composition records every shadowing in a report you read off the frame's generation at `:rf.gen/shadows` (each entry names the registration, the image that originally defined it, and the image that shadowed it), so you can assert in a test that the override you intended is the override that happened.
+    Within a *single* `rf/image`, `:select-ns` and `:registrations` must be **disjoint** — a `[kind id]` may not be both selected from a namespace and defined inline in the same image. Assembly fails loud rather than silently merging. Override is **not** a `:replace` key — retired in EP-0026; `rf/image` rejects it (and `:include-ns` / `:exclude-ns` / `:replace-standard`) with `:rf.error/invalid-image`. Put the winning registration in a **later** image and compose — later image wins. Composition records every shadowing at `:rf.gen/shadows` on the frame's generation (registration, image that defined it, image that shadowed it), so tests can assert the override you intended is the one that happened.
 
 ```clojure
 (def base    (rf/image {:id :app/base   :select-ns {:include ["app.*"]}}))
@@ -360,8 +341,8 @@ You reach past that only when v2 gives you a shape v1 didn't have. The public co
 ;; => [{:registration [:cofx :clock], :image :app/base, :shadowed-by :app/doubles}]
 ```
 
-## The devtools moved house
+## Devtools
 
-One last orientation point that trips people who lived in v1's tooling. `re-frame-10x` — the v1 devtools panel — has been renamed and reimplemented as [**Xray**](glossary.md#xray) (`day8/re-frame2-xray`). Weight the word *reimplemented*: Xray is not 10x ported to v2, it's a from-scratch build against re-frame2's own [trace stream](glossary.md#trace-stream) and [epoch](glossary.md#epoch) history. The mental model carries over completely — events, subs, app-db diff, time-travel are all there — but the wiring underneath is new. If your v1 project depended on 10x during development, the v2 equivalent is Xray, and [the Xray tutorial](../xray/index.md) is where you meet it.
+`re-frame-10x` is renamed and reimplemented as [**Xray**](glossary.md#xray) (`day8/re-frame2-xray`). Not 10x ported — built against re-frame2's [trace stream](glossary.md#trace-stream) and [epoch](glossary.md#epoch) history. Events, subs, app-db diff, and time-travel are there; wiring underneath is new. If your v1 project used 10x in development, the v2 equivalent is Xray — start at [the Xray tutorial](../xray/index.md).
 
-That's the migration in one read. The architecture is the same architecture, the sweep is automated, and the few genuinely-new shapes (managed HTTP, flows, images/frames) are improvements you'll be glad to adopt, not taxes you'll resent paying. The one rule that keeps it all honest is *don't invent migration rules*: the tool does what it's sure of and asks about the rest. Once the migration settles, you operate from [the guide](introduction.md), the same as any re-frame2 developer.
+Architecture is the same; the sweep is automated; managed HTTP, flows, and images/frames are opt-in shapes. Rule that keeps the migration honest: don't invent migration rules — the tool does what it's sure of and asks about the rest. After the migration settles, operate from [the guide](introduction.md).

--- a/docs/core/AUTHORING.md
+++ b/docs/core/AUTHORING.md
@@ -40,13 +40,14 @@ below, know *why*.
    `mkdocs.yml`). Readers already get a left sidebar, section nesting, and
    prev/next from that build — do **not** re-implement navigation on the page.
    No "What's next" / "You can now" footers; no mini-TOCs that restate the left
-   nav. Useful cross-links go inline where relevant. A **day-one checklist** (what
-   the reader can do *now*) is not ceremony; a list of later chapters is.
+   nav. Useful cross-links go inline where relevant. A short "you can ship with
+   this" recap is not ceremony; a list of later chapters is.
 
 ## Voice
 
-One persona: a **friendly senior developer**, simple and direct. Register shifts by
-page kind; the person doesn't:
+One persona: a **friendly senior developer** — simple, direct, a little Yegge on
+teaching pages. Tight prose, not terse telegram. Register shifts by page kind; the
+person doesn't:
 
 | Register | Where |
 |---|---|
@@ -55,17 +56,34 @@ page kind; the person doesn't:
 | Argument | explanation shelf |
 | Terse reference | glossaries, `docs/api/` — boring on purpose |
 
-The test: would it sound natural said aloud, and could a tired engineer follow it at
-11pm? The reader knows React or Redux; meet them as a colleague.
+**Why "senior".** Not status — a **vocabulary filter**. Write the words a working
+senior would actually say in a PR review, stand-up, or whiteboard session. Domain
+terms and ordinary engineering English are in (`app-db`, coeffect, handler, queue,
+pure, race). Abstract coinages and consultant/AI-ish intensifiers are out when
+they aren't common human usage for that idea. If a tired colleague would raise an
+eyebrow at the *word choice* (not the concept), rephrase with the plain mechanism.
+
+The test: say it aloud at 11pm. Would a peer nod, or ask what you meant by the
+metaphor? The reader knows React or Redux; meet them as a colleague.
+
+Prefer operational claims ("X does Y / fails with Z") over status language ("this
+is the foundational / load-bearing / pivotal …"). Name the thing: boundary, API,
+handler, error id — not spine, seam, surface area, heart of the system, unless that
+phrase is already a re-frame term of art.
+
+**Yegge seasoning (teaching pages only).** Blunt, peer-to-peer, occasionally savage
+about *bad ideas*. Humor earns its keep by making a real failure mode stick — not by
+decorating. Shape: true claim → short rephrase with teeth → operational rule. One
+jab, then back to business. Keep the attitude; drop digressions and war-story length.
+If the sentence is only funny, cut it. A precise claim must survive if you delete the
+joke. **Never trade precision for charm.**
 
 Owned opinions are fine ("two copies of one truth is two chances to disagree");
 invented personal biography is not. Explain a short *why* after instructions. One
-committed metaphor per concept. Humor is seasoning in teaching registers only —
-escalate-then-deflate, then straight prose; the sentence must survive the joke's
-deletion. **Never trade precision for charm.**
+committed metaphor per concept — only if a senior would use it unprompted.
 
-Gloss load-bearing terms (`app-db`, frame, coeffect, …) at first use in a few plain
-words. Don't pack the reader off mid-flow for a basic word.
+Define key terms (`app-db`, frame, coeffect, …) at first use in a few plain words.
+Don't pack the reader off mid-flow for a basic word.
 
 ## What a concept page must carry
 
@@ -75,16 +93,34 @@ corpora) are incomplete until they have all five:
 | Piece | Role |
 |---|---|
 | **Problem open** | One or two sentences: what pain, what job |
-| **Happy path** | Working code first (live cell when it teaches more than reading) |
-| **Day-one stop** | Checklist or hard "Going further" break — reader may ship here |
-| **Unhappy path** | Short table: symptom → named error/recovery → fix |
+| **Required path** | Working code first (live cell when it teaches more than reading). This *is* the page — do not label it "basics" or "day one" |
+| **Troubleshooting** | Short table: symptom → named error/recovery → fix. Prefer this heading over "When things go wrong" |
 | **When *not*** | Situations where another tool is better (or "this is rare") |
+| **Advanced (if any)** | Optional depth after the reader can ship — only when the page needs it. Heading: **`## Advanced`** (not "Going further", "Day one", or "Basics") |
 
 Missing "when not" and missing named errors are the two most common ways a page
 looks finished and still strands the reader at 11pm.
 
-**Do not** bury the day-one payload under migration notes, full config maps, or
-optional forms. Collapse those (`??? note` / `??? info`) or put them after the stop.
+**Do not** bury what the reader must know under migration notes, full config maps,
+or optional forms. Collapse those (`??? note` / `??? info`) or put them after the
+required path — at the end under `## Advanced` if needed.
+
+### Don't label the required path
+
+The body of the page is what they have to know. No "Day one", "Basics",
+"Essential", or "Day-one checklist" banner over material that is simply the job of
+the page. If a short ship recap helps, write it as ordinary prose or bullets —
+not a second curriculum track. Optional depth goes at the end under **`## Advanced`**
+(or a specific topic heading). "Going further" is the old name for Advanced; use
+**Advanced**.
+
+### Standard headings (when present)
+
+| Use | Not |
+|---|---|
+| `## Troubleshooting` | "When things go wrong", "Unhappy path" |
+| `## Advanced` | "Going further", "Day one / Going further" two-speed openers |
+| (no label) | "Basics", "Day-one checklist", "Essential" |
 
 ## Progressive pacing
 
@@ -92,16 +128,19 @@ Teach like a good tutorial, not like a reference dump with anecdotes.
 
 1. **Happy path first.** One growing example (counter for pure Core; domain noun
    for batteries) that adds exactly one idea per step.
-2. **Two speeds on long pages.** Near the open: *"Day one: … Going further: … Open
-   a section only when a need appears."* Then a real structural break
-   (`## Day-one checklist` / `---` / `## Going further`), not a polite promise.
-3. **Unhappy paths as vocabulary tables**, not essays. Prefer
+2. **Required, then optional.** Long pages put what you need to ship first. Optional
+   depth (full config maps, Form-2/3, chain algebra, mint policies) comes **after**
+   under `## Advanced` — not a polite promise mid-page, not a "day one vs later
+   career" frame. Skip two-speed openers ("Day one: … Going further: …"); the
+   structure of the page does that job.
+3. **Troubleshooting as tables**, not essays. Prefer
    `:rf.error/no-such-handler` over "things might fail quietly." Recovery belongs
-   in the same row as the error.
+   in the same row as the error. Heading: **Troubleshooting**.
 4. **Depth is earned.** Argument-dependent input-fns, Form-2/3, full frame-config,
-   mint policies, interceptor chain algebra — after the stop, or collapsed.
-5. **Length is a smell, not a rule.** If day-one is still not visible after a scroll
-   of essay, the page is two pages or one page with a missing break.
+   mint policies, interceptor chain algebra — after the required path, or collapsed.
+5. **Length is a smell, not a rule.** If the reader still cannot ship after a scroll
+   of essay, the page is two pages or one page with optional depth mixed into the
+   required path.
 
 ### Slim model vs catalogue
 
@@ -176,7 +215,7 @@ mini-TOC of the whole guide.
 
 **Delta teaching.** Domain pages name the ecosystem anchor (Redux, TanStack Query,
 XState, re-frame v1, …) and the deliberate divergences. Persona deltas are collapsed
-`??? info` callouts — short, never load-bearing. A v1 callout is earned only where
+`??? info` callouts — short, never required reading. A v1 callout is earned only where
 the v1 instinct *misleads*; most pages need zero. Retired v1 surfaces
 (`inject-cofx`; the retired/renamed `:rf.world/inputs` → flat `:rf.cofx` map)
 appear **only** on the [migration page](25-from-re-frame-v1.md), marked
@@ -216,9 +255,9 @@ Use MkDocs admonitions, not bold-lead blockquotes, for asides:
 Budget them. Three boxes in a row means the prose is hiding structure. A page that
 is more box than prose has inverted itself.
 
-Teaching pages benefit from **one** load-bearing takeaway a reader could quote
-later. Prefer a single `> **…**` pull-quote near the open. That's craft, not a lint
-rule — better one clear sentence in prose than a forced slogan.
+Teaching pages benefit from **one** quotable takeaway — the sentence that sticks.
+Prefer a single `> **…**` pull-quote near the open. That's craft, not a lint rule —
+better one clear sentence in prose than a forced slogan.
 
 ## Reference
 
@@ -249,8 +288,8 @@ examples compile gate covers them.
 
 - [ ] One job, clear open; no `spec/` links
 - [ ] Happy path works (snippets true); anti-patterns labeled, not demoed as success
-- [ ] Day-one stop present on concept pages; going-further is actually after it
-- [ ] Unhappy-path table (or equivalent) with verified `:rf.error/*` / recovery ids
+- [ ] Required path is the unlabeled body; optional/advanced is after it (if any)
+- [ ] Troubleshooting table (or equivalent) with verified `:rf.error/*` / recovery ids
 - [ ] "When not" stated where a feature can be misapplied
 - [ ] Callouts not a wall of boxes; catalogue weight pushed to API if the page bloats
 - [ ] Pure-pipeline cells: `frame-root` + `reg-view` + named initialise (unless Frames is the topic)

--- a/docs/core/app-db.md
+++ b/docs/core/app-db.md
@@ -19,11 +19,11 @@ Almost everything else in re-frame2 stays simple *because* of that.
 
 ## A complete live counter
 
-The intro counter seeded `:value` explicitly through its `:initialise` event; the
+The intro counter seeded `:value` through its `:initialise` event; the
 `(:value db 0)` in its subscription was a defensive display fallback, not the
-initializer. Here we reuse that same initialization pattern and add a second fact —
-`:step-size` — so both begin explicit in one store. Click the buttons (edit the cell
-and press **`Ctrl-Enter`** / **`Cmd-Enter`** if you change the code):
+initializer. Here we reuse that pattern and add a second fact — `:step-size` — so
+both begin explicit in one store. Click the buttons (edit the cell and press
+**`Ctrl-Enter`** / **`Cmd-Enter`** if you change the code):
 
 ```cljs-rf2
 (require '[re-frame.core :as rf])
@@ -200,9 +200,9 @@ Poor:
         :empty? false}}
 ```
 
-`total` and `empty?` are conclusions. If you store them, they can drift from the
-items. Derive them so there is only one truth to update — that is the next page's
-job.
+`total` and `empty?` are conclusions. Store them next to the items and they will
+drift — two copies of one truth is two chances to disagree. Derive them so there is
+only one truth to update. That is the next page's job.
 
 ## Yours, and the framework's next door
 
@@ -214,7 +214,7 @@ framework's (read it via its subscriptions; influence it by dispatching its even
 never forge it by hand in app-db). An ordinary `:db` effect cannot wipe a machine
 snapshot. [Frames](frames.md) goes deeper.
 
-## When things go wrong
+## Troubleshooting
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
@@ -222,8 +222,6 @@ snapshot. [Frames](frames.md) goes deeper.
 | Two facts disagree | A conclusion was stored next to its facts | Derive in a [subscription](subscriptions.md) (or a [flow](flows.md) if handlers must read it) |
 | Initial UI shows empty before first paint | No seed event | List an initialise event in `:initial-events` |
 | Framework snapshot gone after your `:db` | You tried to own runtime keys in app-db | Leave runtime-db alone; dispatch the subsystem's events |
-
-## Day-one checklist
 
 With this page you can seed a frame, keep facts in one map, write only through
 events, and leave conclusions out of app-db. The left nav continues into how those

--- a/docs/core/coeffects.md
+++ b/docs/core/coeffects.md
@@ -10,13 +10,9 @@ would cost the handler its purity, so re-frame2 delivers them instead, as declar
 state of the world, as data, as presented to your handler. The recording is the
 point — it is what makes replay and time-travel honest.
 
-**On this page — two speeds.** Day one: declare `:rf.cofx/requires`, receive
-`:rf/time-ms`, keep the handler pure. Going further: grades, `reg-cofx`, minting
-ladder, the ledger, test supply. Ship after you can stamp time honestly.
-
 ## The counter learns the time
 
-Let's give the [app-db](app-db.md) counter one more feature: show when the button was last clicked. It looks like throwaway decoration. It's quietly one of the most important ideas in the framework, so it's worth slowing down for.
+Let's give the [app-db](app-db.md) counter one more feature: show when the button was last clicked. It looks like throwaway decoration. It is also the purity fix for every world fact that ends up in durable state — so it's worth slowing down for.
 
 Here's the constraint. A pure handler must not read the clock — if it did, replaying the same event tomorrow would compute different state, and the history the dev tools show you — a re-run of recorded events — would be a lie. So re-frame2 reads the time once, as the event enters the queue, and stamps it **onto the event**. A handler that wants the time *declares* it — one line of metadata — and receives it as a plain value:
 
@@ -56,8 +52,6 @@ Notes:
 
 That recorded-ness is what the dev tools cash in. Open [Xray](glossary.md#xray) on an app like this and every click is a row — the event, app-db before and after, and the recorded time; restore an older row and the counter returns to that exact moment. It falls out of three rules you're already following: state changes only through events, handlers stay pure, and world facts arrive recorded. Given those three, history *is* a list of `(event, recorded-facts)` pairs, and re-running any prefix reconstructs the exact state — there's nothing else for state to depend on. (The [Xray docs](../xray/index.md) are the tour.)
 
-## Day-one checklist
-
 You can declare world facts with `:rf.cofx/requires`, read them flat beside `:db`,
 and keep durable timestamps out of the handler body. That is the purity fix. The
 sections below are the full declaration grammar and the ledger argument.
@@ -73,7 +67,7 @@ Your handler needs the current time, a `localStorage` value, a fresh id — and 
     {:db (assoc-in db [:orders id] {:id id :items items :placed-at (js/Date.)})}))
 ```
 
-Now the handler isn't pure: same inputs, a different output every call. No test can pin it down without monkey-patching the global clock. And impure functions cause well-documented paper cuts, which have a way of accumulating non-linearly — except this one skips the accumulating and goes straight to the wound: replay breaks (the [replay-pair section below](#why-this-is-non-negotiable-the-replay-pair) makes the reason precise).
+Now the handler isn't pure: same inputs, a different output every call. No test can pin it down without monkey-patching the global clock. And impure functions cause well-documented paper cuts — except this one skips the accumulating and goes straight to the wound: replay breaks (the [replay-pair section below](#why-this-is-non-negotiable-the-replay-pair) makes the reason precise).
 
 These inputs-from-the-world are [**coeffects**](glossary.md#coeffect). The symmetry, stated plainly: an effect is data the handler *outputs* for the runtime to perform; a coeffect is data the runtime *delivers* for the handler to read.
 
@@ -86,11 +80,11 @@ These inputs-from-the-world are [**coeffects**](glossary.md#coeffect). The symme
 
 And here's the reveal: that `{:keys [db]}` you destructure in every handler *is* the coeffects map. You've been reading coeffects since your first handler. `:db` and `:event` are staged automatically; every other world fact is opt-in, through one declaration key.
 
-Sit with that map for a second, because it's grander than it looks. It is the handler's *entire observable universe*. Your app's state? In the map. The event being handled? In the map. The time, the storage read, the minted id? In the map — if declared. Everything your handler will ever know about anything arrives in its first argument, and as far as the handler is concerned, nothing else exists. (Too cosmic? Fine. It's a function argument. But it is the *only* place a handler may look, and holding that line is what the rest of this page is about.)
+That map is the handler's *entire* input. Your app's state? In the map. The event being handled? In the map. The time, the storage read, the minted id? In the map — if declared. Everything your handler will ever know about anything arrives in its first argument. As far as the handler is concerned, nothing else exists. That is not a slogan — it is the only place a handler may look, and holding that line is what the rest of this page is about.
 
 ### Declare what you read: `:rf.cofx/requires`
 
-Nothing reaches a handler implicitly — **not even the time**. No abracadabra. A handler declares the facts it consumes as registration metadata, and the runtime hands it exactly those, flat in the coeffects map beside `:db`:
+Nothing reaches a handler implicitly — **not even the time**. A handler declares the facts it consumes as registration metadata, and the runtime hands it exactly those, flat in the coeffects map beside `:db`:
 
 ```clojure
 (rf/reg-event :checkout/place-order
@@ -191,7 +185,7 @@ Recorded coeffects are the last rung, not the default. The `:checkout/place-orde
 
 ## The ledger
 
-Here's a reframing that, once it clicks, reorganises how you think about the whole app.
+Here's a picture that, once it clicks, reorganises how you think about the whole app.
 
 The reflex picture of state is a whiteboard: there's a current drawing, each event erases a bit and draws something new, and the old drawing is gone. The right picture is a **ledger**: each event is a line appended to the lines before it, and the app-db you see at any moment is the running total — the result of starting from the initial state and applying every event since, in order.
 

--- a/docs/core/derivations-and-algebra-views.md
+++ b/docs/core/derivations-and-algebra-views.md
@@ -1,30 +1,60 @@
 # One graph: derivations and their algebra views
 
-Everything flows; nothing stands still. Heraclitus said that, around 500 BC — a man who, being Greek, had never seen a frozen river — and it is still the best one-line description of a re-frame2 app.
+You're reading a re-frame2 app you didn't write. A tool has just drawn its dependency
+graph — subscriptions, a flow, a resource cache, a machine — as one picture, and you
+want to know what you're looking at. This page is the model that makes the picture
+legible, and the model fits in one sentence:
 
-Here's the scene this page exists for. You're reading a re-frame2 app you didn't write. A tool has just drawn its dependency graph — subscriptions, a flow, a resource cache, a machine — as one picture, and you want to know what you're looking at. This page is the model that makes the picture legible, and the model fits in one sentence:
+**A subscription, a flow, a resource, and a machine are the same thing seen four
+ways** — one node in one dependency graph rooted at your state, distinguished only by
+*where its value is kept* and *when it's recomputed*.
 
-**A subscription, a flow, a resource, and a machine are the same thing seen four ways** — one node in one dependency graph rooted at your state, distinguished only by *where its value is kept* and *when it's recomputed*.
-
-One thing before we start, so nobody sits through theory they don't need: you don't need this page to *write* an app. [Where should this value live?](where-state-lives.md) routes any value to the right home with four questions and no theory. This page is for *reading* apps — yours six months from now, or somebody else's tomorrow — when the graph a tool draws has to make sense without opening every source file.
+One thing before we start, so nobody sits through theory they don't need: you don't
+need this page to *write* an app. [Where should this value live?](where-state-lives.md)
+routes any value to the right home with four questions and no theory. This page is for
+*reading* apps — yours six months from now, or somebody else's tomorrow — when the
+graph a tool draws has to make sense without opening every source file.
 
 ## Start with a spreadsheet
 
-The anchor here is a spreadsheet — the same one the [subscriptions](subscriptions.md) page told you to hold onto, now asked to carry the whole framework. Every cell is either an entered value or a formula over other cells, and the engine recalculates exactly the cells downstream of an edit. That's the whole idea. A value declares its inputs, and it recomputes when those inputs move.
+The anchor here is a spreadsheet — the same one the
+[subscriptions](subscriptions.md) page told you to hold onto, now asked to carry the
+whole framework. Every cell is either an entered value or a formula over other cells,
+and the engine recalculates exactly the cells downstream of an edit. That's the whole
+idea. A value declares its inputs, and it recomputes when those inputs move.
 
-re-frame2's [subscriptions](subscriptions.md) are exactly spreadsheet cells. (A subscription lives in your app's render phase: it's a *derivation* — a value computed from other values by a pure function, which is all "derivation" means anywhere on this page.) You write a formula; the framework recomputes it when its inputs change; you never recompute it by hand.
+re-frame2's [subscriptions](subscriptions.md) are exactly spreadsheet cells. (A
+subscription lives in your app's render phase: it's a *derivation* — a value computed
+from other values by a pure function, which is all "derivation" means anywhere on this
+page.) You write a formula; the framework recomputes it when its inputs change; you
+never recompute it by hand.
 
 ??? info "Coming from Solid / Vue / Preact signals?"
 
-    The JS world rediscovered the spreadsheet as the **signals graph** — `createMemo`, `computed`, signals — where a derived value declares its inputs and recomputes when those inputs move. A re-frame2 subscription is one of those derived signals. If you've reached for `useMemo` to avoid recomputing a value on every render, you already have the intuition: declare the inputs, let the framework decide when to recompute.
+    The JS world rediscovered the spreadsheet as the **signals graph** —
+    `createMemo`, `computed`, signals — where a derived value declares its inputs and
+    recomputes when those inputs move. A re-frame2 subscription is one of those
+    derived signals. If you've reached for `useMemo` to avoid recomputing a value on
+    every render, you already have the intuition: declare the inputs, let the
+    framework decide when to recompute.
 
-This page adds one bigger claim, and it's the deliberate divergence from the signals world: **flows, resources, route state, and machines are nodes in the same graph.** A flow is a cell that writes its result back into the sheet. A resource is a cell whose authoritative value lives on a server — locally you hold a copy that can go stale. A machine is a cell with memory, where its next value depends on its current one. The signals ecosystem never wrote that unification down as one model. re-frame2 does.
+This page adds one bigger claim, and it's the deliberate divergence from the signals
+world: **flows, resources, route state, and machines are nodes in the same graph.** A
+flow is a cell that writes its result back into the sheet. A resource is a cell whose
+authoritative value lives on a server — locally you hold a copy that can go stale. A
+machine is a cell with memory, where its next value depends on its current one. The
+signals ecosystem never wrote that unification down as one model. re-frame2 does.
 
-re-frame2 calls this model the **derivation/process algebra**. Don't let "algebra" summon high-school equations — here it just means *a small fixed set of node kinds plus rules for how they combine into a graph*, the same sense in which "relational algebra" is the handful of operations you compose into a SQL query. The payoff is that one vocabulary describes every node. This page is the tour.
+re-frame2 calls this model the **derivation/process algebra**. Don't let "algebra"
+summon high-school equations — here it just means *a small fixed set of node kinds
+plus rules for how they combine into a graph*, the same sense in which "relational
+algebra" is the handful of operations you compose into a SQL query. The payoff is that
+one vocabulary describes every node. This page is the tour.
 
 ## The keystone: one function, two policies
 
-Here's the example that makes the whole idea click — a cart total, expressed twice, with the identical formula:
+Here's the example that makes the whole idea click — a cart total, expressed twice,
+with the identical formula:
 
 ```clojure
 ;; Source form A — a subscription.
@@ -41,7 +71,9 @@ Here's the example that makes the whole idea click — a cart total, expressed t
    :output-path [:cart :total]})
 ```
 
-`sum-cart` is one whole-value function. Both forms compute the cart total the same way. So what's different? Only the *policy* — where the answer is kept, and when it's recomputed:
+`sum-cart` is one whole-value function. Both forms compute the cart total the same
+way. So what's different? Only the *policy* — where the answer is kept, and when it's
+recomputed:
 
 | | Subscription | Flow |
 |---|---|---|
@@ -49,19 +81,31 @@ Here's the example that makes the whole idea click — a cart total, expressed t
 | When it recomputes | when something reads it | after each event, in that event's commit |
 | Who keeps it alive | a subscription-cache entry | the frame |
 
-The subscription stores nothing and recomputes on demand — a formula cell. The [flow](flows.md) stores its answer into [app-db](glossary.md#app-db) (your app's single immutable state map) and recomputes after each event — a cell that writes its result back into the sheet. The math is identical; the *policy over the graph* is what differs.
+The subscription stores nothing and recomputes on demand — a formula cell. The
+[flow](flows.md) stores its answer into [app-db](glossary.md#app-db) (your app's
+single immutable state map) and recomputes after each event — a cell that writes its
+result back into the sheet. The math is identical; the *policy over the graph* is what
+differs.
 
 That's the entire reason the algebra exists:
 
-> The difference between a subscription and a flow is **not the function; it is policy over the same dependency graph.**
+> The difference between a subscription and a flow is **not the function; it is policy
+> over the same dependency graph.**
 
-If you keep one sentence from this essay, keep that one. Everything below is it, visiting the other homes.
+If you keep one sentence from this page, keep that one. Everything below is it,
+visiting the other homes.
 
 ## The five questions every node answers
 
-Every declared fact in re-frame2 — subscription, flow, resource read, route fact, machine selector — answers the *same five questions*. Not five per family. Five, total, across every node kind a tool will ever draw for you: a plain sub, a flow writing back into the sheet, a resource mid-fetch, a machine mid-transition, the route sitting in your user's address bar. Learn to ask these five of any node and you can read any graph in any re-frame2 app — yours, your team's, the ones that haven't been written yet. **Any of them.**
+Every declared fact in re-frame2 — subscription, flow, resource read, route fact,
+machine selector — answers the *same five questions*. Not five per family. Five,
+total, across every node kind a tool will ever draw for you: a plain sub, a flow
+writing back into the sheet, a resource mid-fetch, a machine mid-transition, the route
+sitting in your user's address bar. Learn to ask these five of any node and you can
+read any graph in any re-frame2 app.
 
-Too much? Only slightly. Further down you'll meet *refinements* and some diagnostic dressing, but they only ever add colour to a node — never a sixth question. Here are the five:
+Further down you'll meet *refinements* and some diagnostic fields, but they only ever
+add colour to a node — never a sixth question. Here are the five:
 
 | Question | Field | Example answers |
 |---|---|---|
@@ -71,23 +115,51 @@ Too much? Only slightly. Further down you'll meet *refinements* and some diagnos
 | When does it run? | `:evaluation` | `:on-demand` · `:after-event` · `:on-reply` · `:on-route` · `:on-transition` · `:scheduled` |
 | Who keeps it alive? | `:lifecycle` | a cache entry · the frame · a route · a resource key · a machine instance |
 
-The cart keystone, in this vocabulary: the subscription is `:ephemeral` / `:on-demand` / cache-entry; the flow is `:app-db` / `:after-event` / frame. Same `:inputs`, same math — three policy fields differ. That's the whole trick, restated as a table.
+The cart keystone, in this vocabulary: the subscription is `:ephemeral` /
+`:on-demand` / cache-entry; the flow is `:app-db` / `:after-event` / frame. Same
+`:inputs`, same math — three policy fields differ. That's the whole trick, restated as
+a table.
 
-The four `:storage` classes are just the four places a value can sit, and you'll meet each one in context below: **`:ephemeral`** — nowhere durable, recomputed on demand (a subscription); **`:app-db`** — in your app's state map (a flow); **`:runtime-db`** — in the framework-owned partition beside app-db (paths under `:rf.db/runtime`), where route and machine state and the local copies of server data live; and **`:host-transient`** — outside durable state entirely, for things that can't be serialized like an in-flight request handle or a timer. For now just register that the column has four values; the resource and machine sections give each one a home.
+The four `:storage` classes are just the four places a value can sit, and you'll meet
+each one in context below: **`:ephemeral`** — nowhere durable, recomputed on demand
+(a subscription); **`:app-db`** — in your app's state map (a flow); **`:runtime-db`**
+— in the framework-owned partition beside app-db (paths under `:rf.db/runtime`), where
+route and machine state and the local copies of server data live; and
+**`:host-transient`** — outside durable state entirely, for things that can't be
+serialized like an in-flight request handle or a timer. For now just register that the
+column has four values; the resource and machine sections give each one a home.
 
-That's the whole vocabulary. The five source forms you actually write — `reg-sub`, `reg-flow`, `reg-resource`, `reg-route`, `reg-machine` — each **lower** to this one shape, called the node's **algebra view**. ("Lower" is borrowed from compilers: a higher-level form you wrote is translated down into a simpler, uniform shape a machine can reason about — here, the five questions above.)
+That's the whole vocabulary. The five source forms you actually write — `reg-sub`,
+`reg-flow`, `reg-resource`, `reg-route`, `reg-machine` — each **lower** to this one
+shape, called the node's **algebra view**. ("Lower" is borrowed from compilers: a
+higher-level form you wrote is translated down into a simpler, uniform shape a machine
+can reason about — here, the five questions above.)
 
 !!! note "You never write the algebra view"
 
-    There is no `reg-fact` and no `reg-derivation`. The view is *derived* from the registration you already wrote, and that's the point: a tool can answer "where does this value come from, when does it run, where does it live, who owns it?" without reading your function bodies. The source forms stay the things humans write; the algebra view is what a tool reads.
+    There is no `reg-fact` and no `reg-derivation`. The view is *derived* from the
+    registration you already wrote, and that's the point: a tool can answer "where
+    does this value come from, when does it run, where does it live, who owns it?"
+    without reading your function bodies. The source forms stay the things humans
+    write; the algebra view is what a tool reads.
 
 ??? note "Going deeper — two superkinds, nothing more"
 
-    "Derivation" and "process" are the two superkinds of the algebra. A **derivation** computes a fact from declared inputs with a pure function — it has no memory beyond its output. A **process** is a derivation that *also* has state, a lifecycle, and commands over time: it reacts to events, async replies, route changes, and timers. Subscriptions and flows are derivations; resources, routes, and machines are processes. The whole hierarchy is exactly those two — a tool that understands only `:derivation` and `:process` can still classify every node in the graph. Everything finer is a *refinement*, and refinements never invent a third superkind.
+    "Derivation" and "process" are the two superkinds of the algebra. A
+    **derivation** computes a fact from declared inputs with a pure function — it has
+    no memory beyond its output. A **process** is a derivation that *also* has state,
+    a lifecycle, and commands over time: it reacts to events, async replies, route
+    changes, and timers. Subscriptions and flows are derivations; resources, routes,
+    and machines are processes. The whole hierarchy is exactly those two — a tool that
+    understands only `:derivation` and `:process` can still classify every node in the
+    graph. Everything finer is a *refinement*, and refinements never invent a third
+    superkind.
 
 ## One node, opened up
 
-Here's the complete algebra view of that cart subscription — the shape every node in an inspected graph has. Don't memorize it. Just see that it's the five questions plus some labelling and diagnostics:
+Here's the complete algebra view of that cart subscription — the shape every node in
+an inspected graph has. Don't memorize it. Just see that it's the five questions plus
+some labelling and diagnostics:
 
 ```clojure
 {:id          :cart/total
@@ -109,15 +181,31 @@ Here's the complete algebra view of that cart subscription — the shape every n
 
 Notes:
 
-1. **`:kind`** is one of exactly two closed superkinds — `:derivation` or `:process`. A tool that understands only those two can still classify every node.
-2. **`:refinement`** carries the finer labels you'll meet below (`:resource-process`, `:route-fact`, `:machine-process`, `:machine-selector`). They never live in `:kind`, so a refinement always refines its node's superkind and never invents a third one.
-3. **`:derive`** is an opaque token. (`#'app.cart/sum-cart` is Clojure's var-quote — a reference *to* the function named `sum-cart`, not the function's source code.) The graph contract is about dependencies, storage, evaluation, and ownership; it never requires serializing your functions.
+1. **`:kind`** is one of exactly two closed superkinds — `:derivation` or
+   `:process`. A tool that understands only those two can still classify every node.
+2. **`:refinement`** carries the finer labels you'll meet below
+   (`:resource-process`, `:route-fact`, `:machine-process`, `:machine-selector`). They
+   never live in `:kind`, so a refinement always refines its node's superkind and
+   never invents a third one.
+3. **`:derive`** is an opaque token. (`#'app.cart/sum-cart` is Clojure's var-quote —
+   a reference *to* the function named `sum-cart`, not the function's source code.)
+   The graph contract is about dependencies, storage, evaluation, and ownership; it
+   never requires serializing your functions.
 
-The trailing fields — `:schema` (the output's Malli [schema](glossary.md#schema)), `:source` (namespace / file / line), plus a doc string — are the **diagnostic dressing**. They're optional; a node with none of them is still a complete node. But a good graph carries them, because "where is this defined and what shape does it produce?" is exactly the question a reader of an unfamiliar app asks first.
+The trailing fields — `:schema` (the output's Malli [schema](glossary.md#schema)),
+`:source` (namespace / file / line), plus a doc string — are the **diagnostic
+dressing**. They're optional; a node with none of them is still a complete node. But a
+good graph carries them, because "where is this defined and what shape does it
+produce?" is exactly the question a reader of an unfamiliar app asks first.
 
 ### Parametric nodes and the don't-execute rule
 
-Now, I haven't been entirely straight with you. So far the subscription's inputs were fixed, and I've let you believe they always are. But some subscriptions compute their inputs from the [query vector](glossary.md#query-vector) — `[:article/page "welcome"]` reads a different article than `[:article/page "intro"]`. The static graph can't know those edges before a concrete query exists, **and it must not guess**. So it reports `:parametric` and names the producer; the live graph reports the realized edges once a real query is in play:
+So far the subscription's inputs were fixed. But some subscriptions compute their
+inputs from the [query vector](glossary.md#query-vector) —
+`[:article/page "welcome"]` reads a different article than
+`[:article/page "intro"]`. The static graph can't know those edges before a concrete
+query exists, **and it must not guess**. So it reports `:parametric` and names the
+producer; the live graph reports the realized edges once a real query is in play:
 
 ```clojure
 ;; STATIC — derived from registrations alone
@@ -134,17 +222,34 @@ Now, I haven't been entirely straight with you. So far the subscription's inputs
  :lifecycle :subscription-cache-entry}
 ```
 
-This is the **don't-execute rule**: static inspection never runs your input, param, or scope functions. It reads declarations only — which is what makes a static graph safe to compute anywhere (tests, docs, an editor) with no side effects and no runtime assumptions. A `:parametric` edge set contributes no static edges; the realized ones appear only in the live graph, observed from the running app.
+This is the **don't-execute rule**: static inspection never runs your input, param, or
+scope functions. It reads declarations only — which is what makes a static graph safe
+to compute anywhere (tests, docs, an editor) with no side effects and no runtime
+assumptions. A `:parametric` edge set contributes no static edges; the realized ones
+appear only in the live graph, observed from the running app.
 
 ??? info "Coming from SQL?"
 
-    Think of `EXPLAIN` on a parameterized query versus the actual rows a given parameter binding returns. The static graph is the query plan — derived from declarations, runnable offline, the same for every parameter. The live graph is the result for a *concrete* binding — one node per realized query vector, edges and all. A `:parametric` node is the framework refusing to guess at plan time what only a real binding can answer.
+    Think of `EXPLAIN` on a parameterized query versus the actual rows a given
+    parameter binding returns. The static graph is the query plan — derived from
+    declarations, runnable offline, the same for every parameter. The live graph is
+    the result for a *concrete* binding — one node per realized query vector, edges
+    and all. A `:parametric` node is the framework refusing to guess at plan time what
+    only a real binding can answer.
 
 ## Processes: nodes with state and a lifecycle
 
-Subscriptions and flows are derivations — pure formulas. Now we cross into **processes**: nodes that carry state, have a lifecycle, and run commands over time. The first one is the **resource**.
+Subscriptions and flows are derivations — pure formulas. Now we cross into
+**processes**: nodes that carry state, have a lifecycle, and run commands over time.
+The first one is the **resource**.
 
-A resource is a fact whose authoritative value lives on a server, with a local cached copy ([Server state: resources](../resources/concepts.md)). Here's the wrinkle that makes resources more than a fancy subscription: one `reg-resource` declaration lowers to *more than one* node — a process node for the cache entry, plus its read selectors (`:rf/resource`, `:rf.resource/data`, `:rf.resource/loading?`, …), each an ordinary on-demand derivation over that entry. Reading a selector never starts work. It just reads the cache.
+A resource is a fact whose authoritative value lives on a server, with a local cached
+copy ([Server state: resources](../resources/concepts.md)). Here's the wrinkle that
+makes resources more than a fancy subscription: one `reg-resource` declaration lowers
+to *more than one* node — a process node for the cache entry, plus its read selectors
+(`:rf/resource`, `:rf.resource/data`, `:rf.resource/loading?`, …), each an ordinary
+on-demand derivation over that entry. Reading a selector never starts work. It just
+reads the cache.
 
 ```clojure
 ;; STATIC ALGEBRA VIEW of (rf/reg-resource :article/by-slug {…})
@@ -163,19 +268,45 @@ A resource is a fact whose authoritative value lives on a server, with a local c
                :rf.resource/loading? :rf.resource/error :rf.resource/has-data?]}
 ```
 
-The view makes a split explicit that folklore usually muddles — and it's the one place people reliably tie themselves in knots, so hear it plainly. **`:storage` always names the local home** — here, the runtime-db cache entry. **`:authority` names whose fact it really is** — an external server. "Remote" is not a storage class. Locally you *always* hold a representation; the truth living on a server doesn't move it out of your `:storage`. So `:storage` is `:runtime-db` (where your copy sits) and `:authority` is the remote server (whose fact it is) — two separate axes, never collapsed into one. A graph that printed "storage: remote" would be telling you nothing about where the bytes actually are.
+The view makes a split explicit that folklore usually muddles — and it's the one place
+people reliably get wrong, so hear it plainly. **`:storage` always names the local
+home** — here, the runtime-db cache entry. **`:authority` names whose fact it really
+is** — an external server. "Remote" is not a storage class. Locally you *always* hold
+a representation; the truth living on a server doesn't move it out of your
+`:storage`. So `:storage` is `:runtime-db` (where your copy sits) and `:authority` is
+the remote server (whose fact it is) — two separate axes, never collapsed into one. A
+graph that printed "storage: remote" would be telling you nothing about where the
+bytes actually are.
 
 ??? info "Coming from TanStack Query?"
 
-    Your query cache is exactly this split, just unnamed. The server is the `:authority`; the `queryCache` is the local `:storage`; `isLoading` / `data` / `error` are read selectors over one cache entry; and the staleness/refetch policy is the entry's `:evaluation`. re-frame2 writes those four facts down as fields instead of leaving them implicit in a hook's behaviour — which is the whole reason a tool can draw a resource the same way it draws a subscription.
+    Your query cache is exactly this split, just unnamed. The server is the
+    `:authority`; the `queryCache` is the local `:storage`; `isLoading` / `data` /
+    `error` are read selectors over one cache entry; and the staleness/refetch policy
+    is the entry's `:evaluation`. re-frame2 writes those four facts down as fields
+    instead of leaving them implicit in a hook's behaviour — which is the whole reason
+    a tool can draw a resource the same way it draws a subscription.
 
 ??? note "Going deeper — where the non-serializable leftovers go"
 
-    An in-flight request handle or a timer can't be serialized into durable state, so they're classed `:host-transient`: outside durable frame state, torn down at their lifecycle boundary. They never become the *only* copy of a fact — replay and restore depend on the durable `:runtime-db` entry, not the live socket. In a live resource view you'll see them surface as `:host-transient [[:rf.http/in-flight :work/id-123]]` and a `:work-ledger` summary (the in-flight attempt's identity, owners, causes, and transport) — present only while a fetch is actually in flight, gone once it settles.
+    An in-flight request handle or a timer can't be serialized into durable state, so
+    they're classed `:host-transient`: outside durable frame state, torn down at their
+    lifecycle boundary. They never become the *only* copy of a fact — replay and
+    restore depend on the durable `:runtime-db` entry, not the live socket. In a live
+    resource view you'll see them surface as
+    `:host-transient [[:rf.http/in-flight :work/id-123]]` and a `:work-ledger`
+    summary (the in-flight attempt's identity, owners, causes, and transport) — present
+    only while a fetch is actually in flight, gone once it settles.
 
 ### Buying back static visibility: named resolvers
 
-The don't-execute rule has a price. Static inspection won't *run* your scope function — so a resource scoped by an inline `(fn [route ctx] …)` reports the opaque marker `[:scope :rf.scope/resolver]` and nothing more. Fair enough. But there's an escape hatch that buys back static visibility: a **named scope resolver**. Declare the scope as a data reference — `{:from-db :session/current-tenant}` instead of an inline function — and the resolver's *declared inputs* are themselves declarations, so the static graph can read them without running anything:
+The don't-execute rule has a price. Static inspection won't *run* your scope function
+— so a resource scoped by an inline `(fn [route ctx] …)` reports the opaque marker
+`[:scope :rf.scope/resolver]` and nothing more. Fair enough. But there's an escape
+hatch that buys back static visibility: a **named scope resolver**. Declare the scope
+as a data reference — `{:from-db :session/current-tenant}` instead of an inline
+function — and the resolver's *declared inputs* are themselves declarations, so the
+static graph can read them without running anything:
 
 ```clojure
 ;; STATIC ALGEBRA VIEW — named-resolver scope
@@ -189,11 +320,20 @@ The don't-execute rule has a price. Static inspection won't *run* your scope fun
  :params      :parametric}
 ```
 
-The lesson generalizes, and it's the trade the whole algebra makes: **declaring a dependency as *data*, rather than burying it in a function body, is what lets a tool see it before the app runs.** An inline function is opaque to static analysis on purpose; a named, data-described resolver hands the same information to the graph for free. The more you say in data, the more a tool can answer without executing you.
+The lesson generalizes, and it's the trade the whole algebra makes: **declaring a
+dependency as *data*, rather than burying it in a function body, is what lets a tool
+see it before the app runs.** An inline function is opaque to static analysis on
+purpose; a named, data-described resolver hands the same information to the graph for
+free. The more you say in data, the more a tool can answer without executing you.
 
 ### Machines: a node with memory
 
-A [machine](../machines/glossary.md#machine) is the algebra's canonical process — a cell with memory, a stateful node whose *next* value depends on its *current* one. It's the feature that motivates the `:process` superkind in the first place: a pure derivation can't depend on its own previous value, so a machine simply isn't expressible as one. Its [snapshot](../machines/glossary.md#snapshot) is durable runtime-db state, written only by its own transitions.
+A [machine](../machines/glossary.md#machine) is the algebra's canonical process — a
+cell with memory, a stateful node whose *next* value depends on its *current* one.
+It's the feature that motivates the `:process` superkind in the first place: a pure
+derivation can't depend on its own previous value, so a machine simply isn't
+expressible as one. Its [snapshot](../machines/glossary.md#snapshot) is durable
+runtime-db state, written only by its own transitions.
 
 The view, side by side with one of its selectors:
 
@@ -215,21 +355,46 @@ The view, side by side with one of its selectors:
   (fn [snapshot _] (get-in snapshot [:data :progress] 0)))
 ```
 
-A machine's `:inputs` are the event ids its transition table listens for — every `:on` key across the whole state tree (flat, compound, hierarchical, and parallel regions), de-duplicated. (The framework's own reserved triggers — `:rf.machine/*`, the `:*` wildcard — are plumbing, not declared edges.) Its `:evaluation` is a *set*: always `:on-transition` (a transition is the only thing that advances a snapshot), plus `:scheduled` when the machine declares any `:after` delayed transition, plus `:on-reply` when it spawns child actors.
+A machine's `:inputs` are the event ids its transition table listens for — every
+`:on` key across the whole state tree (flat, compound, hierarchical, and parallel
+regions), de-duplicated. (The framework's own reserved triggers —
+`:rf.machine/*`, the `:*` wildcard — are plumbing, not declared edges.) Its
+`:evaluation` is a *set*: always `:on-transition` (a transition is the only thing that
+advances a snapshot), plus `:scheduled` when the machine declares any `:after` delayed
+transition, plus `:on-reply` when it spawns child actors.
 
-That `:checkout/progress` selector's algebra view is an `:ephemeral`, `:on-demand` derivation like any other. It carries the `:machine-selector` refinement and an edge back to the machine it reads — so machines never become a second subscription system. And the selector's target is *precise*: the graph mines the machine ids it reads from its static `[:rf/machine …]` inputs, so in a multi-machine app each `:selector` edge runs from exactly the machine the selector names, never the cross product of every machine against every selector ([State machines](../machines/concepts.md)).
+That `:checkout/progress` selector's algebra view is an `:ephemeral`, `:on-demand`
+derivation like any other. It carries the `:machine-selector` refinement and an edge
+back to the machine it reads — so machines never become a second subscription system.
+And the selector's target is *precise*: the graph mines the machine ids it reads from
+its static `[:rf/machine …]` inputs, so in a multi-machine app each `:selector` edge
+runs from exactly the machine the selector names, never the cross product of every
+machine against every selector ([State machines](../machines/concepts.md)).
 
 ??? note "Going deeper — spawned actors in the live graph"
 
-    The static graph reports one node per registered machine *type*. But a spawned actor has no per-instance registration — its liveness *is* the presence of its snapshot in runtime-db. So the live graph reports one node per *concrete* snapshot, resolving each instance's type from the snapshot's reserved type discriminator and surfacing its current `:state`. This is the machine version of the parametric/realized split you saw for subscriptions: the static graph knows the *types* you registered, the live graph knows the *instances* actually running.
+    The static graph reports one node per registered machine *type*. But a spawned
+    actor has no per-instance registration — its liveness *is* the presence of its
+    snapshot in runtime-db. So the live graph reports one node per *concrete*
+    snapshot, resolving each instance's type from the snapshot's reserved type
+    discriminator and surfacing its current `:state`. This is the machine version of
+    the parametric/realized split you saw for subscriptions: the static graph knows
+    the *types* you registered, the live graph knows the *instances* actually running.
 
 ### Routes: the same fact, every route
 
-A route lowers the same way, with a twist worth pausing on: every route materializes the *same* route fact — `:rf/route`, the one consumer-facing name for the route slice in runtime-db — with the per-route id recorded in `:source-form` and evaluation `:on-route`. Its `:inputs` are the framework route-transition events (`:rf.route/navigate`, `:rf.route/transitioned`, `:rf.route/handle-url-change`), the same across every route, because the same events materialize the slice no matter which route matched.
+A route lowers the same way, with a twist worth pausing on: every route materializes
+the *same* route fact — `:rf/route`, the one consumer-facing name for the route slice
+in runtime-db — with the per-route id recorded in `:source-form` and evaluation
+`:on-route`. Its `:inputs` are the framework route-transition events
+(`:rf.route/navigate`, `:rf.route/transitioned`, `:rf.route/handle-url-change`), the
+same across every route, because the same events materialize the slice no matter which
+route matched.
 
 Forty routes. One fact.
 
-A route's `:resources` declaration becomes a route-owned **activation edge** into the resource it ensures ([Routing: the URL is a sub](../routing/concepts.md)):
+A route's `:resources` declaration becomes a route-owned **activation edge** into the
+resource it ensures ([Routing: the URL is a sub](../routing/concepts.md)):
 
 ```clojure
 ;; one :resources entry → one route-owned activation edge under :resource-edges
@@ -240,11 +405,18 @@ A route's `:resources` declaration becomes a route-owned **activation edge** int
  :blocking? true}           ;; transition stays :loading until the resource settles
 ```
 
-The edge runs from the route's matched params into the resource's params, carries the static `:resource` id (so a tool shows *which* resource the route owns), and surfaces `:blocking?` when declared — whether the transition holds at `:loading` until the resource settles, or proceeds and lets the view render a spinner. The edge's concrete target stays `:parametric` in the static graph — the don't-execute rule again — and the realized owner edge (`[:route route-id nav-token]` → the concrete scoped key) appears only in the live graph, once a navigation has actually committed a match.
+The edge runs from the route's matched params into the resource's params, carries the
+static `:resource` id (so a tool shows *which* resource the route owns), and surfaces
+`:blocking?` when declared — whether the transition holds at `:loading` until the
+resource settles, or proceeds and lets the view render a spinner. The edge's concrete
+target stays `:parametric` in the static graph — the don't-execute rule again — and
+the realized owner edge (`[:route route-id nav-token]` → the concrete scoped key)
+appears only in the live graph, once a navigation has actually committed a match.
 
 ## Reading the assembled graph
 
-A tool stitches the per-family views into one value — a map of `:nodes` and a list of `:edges`:
+A tool stitches the per-family views into one value — a map of `:nodes` and a list of
+`:edges`:
 
 ```clojure
 {:mode  :live
@@ -266,52 +438,138 @@ A tool stitches the per-family views into one value — a map of `:nodes` and a 
 
 Read it with three rules.
 
-First, **a node's key is its canonical id, not its output address** — `[:sub <query>]`, `[:resource <scoped-key>]`, `:rf/route` for the live route slice. The runtime path a node writes to is recorded *inside* the node as `:output`, so the key is purely how you look it up.
+First, **a node's key is its canonical id, not its output address** —
+`[:sub <query>]`, `[:resource <scoped-key>]`, `:rf/route` for the live route slice.
+The runtime path a node writes to is recorded *inside* the node as `:output`, so the
+key is purely how you look it up.
 
-Second, **redaction preserves structure**. Graph payloads carry source coordinates and value *summaries*, never raw sensitive values, so a redacted param is still an edge and connectivity survives even when content is hidden. ([Data classification](glossary.md#data-classification) is the mechanism.)
+Second, **redaction preserves structure**. Graph payloads carry source coordinates and
+value *summaries*, never raw sensitive values, so a redacted param is still an edge
+and connectivity survives even when content is hidden.
+([Data classification](glossary.md#data-classification) is the mechanism.)
 
-Third, **the whole-value law**: every derivation must be correct as a function that recomputes its entire output from its declared inputs. Memoization, equality pruning, and (someday) deltas are optimizations that must not change the observed value. What you trust in a graph is the *structure* — who reads what, where it lives, when it runs — never a promise that any node can be re-executed on demand.
+Third, **the whole-value law**: every derivation must be correct as a function that
+recomputes its entire output from its declared inputs. Memoization, equality pruning,
+and (someday) deltas are optimizations that must not change the observed value. What
+you trust in a graph is the *structure* — who reads what, where it lives, when it runs
+— never a promise that any node can be re-executed on demand.
 
-And a fourth thing worth knowing when you read a *real* graph: **the families are optional, and a missing one just isn't there.** Flows, resources, routes, and machines each live in a separate artefact that core doesn't depend on. An app with no resources contributes no resource nodes; a no-machines app draws no machine processes. The graph you read is the union of whatever families that app actually loaded — so a sparse graph isn't a broken graph, it's an app that uses fewer of the homes.
+And a fourth thing worth knowing when you read a *real* graph: **the families are
+optional, and a missing one just isn't there.** Flows, resources, routes, and machines
+each live in a separate artefact that core doesn't depend on. An app with no resources
+contributes no resource nodes; a no-machines app draws no machine processes. The graph
+you read is the union of whatever families that app actually loaded — so a sparse
+graph isn't a broken graph, it's an app that uses fewer of the homes.
 
 ??? note "Going deeper — the whole-value law as a contract"
 
-    The law is what lets conformance tests verify a node by recomputing it, and lets a tool trust declared edges and classifications without executing your app code. It also pins down what optimizations are *allowed*: anything that preserves the observable value (memoization, equality pruning, dirty checks, deltas) is legal; anything that changes it is a bug, not a feature. The composer that stitches the per-family views together reaches each family through a contributor seam and simply skips any family that isn't present — which is why the graph degrades gracefully to whatever the app loaded.
+    The law is what lets conformance tests verify a node by recomputing it, and lets a
+    tool trust declared edges and classifications without executing your app code. It
+    also pins down what optimizations are *allowed*: anything that preserves the
+    observable value (memoization, equality pruning, dirty checks, deltas) is legal;
+    anything that changes it is a bug, not a feature. The composer that stitches the
+    per-family views together reaches each family through a contributor map and simply
+    skips any family that isn't present — which is why the graph degrades gracefully
+    to whatever the app loaded.
 
-To see one live, open [Xray](glossary.md#xray) on a running app. The panel that draws the dependency graph renders exactly this assembled view — one node per algebra view, one arrow per edge record — even though the mechanisms underneath are a subscription cache, a flow, a resource cache, a route slice, and a machine snapshot. [Debug with Xray](../xray/index.md) shows the workflow.
+To see one live, open [Xray](glossary.md#xray) on a running app. The panel that draws
+the dependency graph renders exactly this assembled view — one node per algebra view,
+one arrow per edge record — even though the mechanisms underneath are a subscription
+cache, a flow, a resource cache, a route slice, and a machine snapshot.
+[Debug with Xray](../xray/index.md) shows the workflow.
 
 ## When the graph is wrong: errors as graph facts
 
-Reading a healthy graph is the common case. But the algebra also shapes how the framework reports an *unhealthy* one — and because errors are attributed to **graph identities** rather than to low-level functions, the diagnostics speak the same node vocabulary you've been reading all page. When something goes wrong, the framework tells you *which node* and *which axis*, not just which function threw. The cases worth recognizing:
+Reading a healthy graph is the common case. But the algebra also shapes how the
+framework reports an *unhealthy* one — and because errors are attributed to **graph
+identities** rather than to low-level functions, the diagnostics speak the same node
+vocabulary you've been reading all page. When something goes wrong, the framework
+tells you *which node* and *which axis*, not just which function threw. The cases
+worth recognizing:
 
-- **Unknown input fact** — a derivation declares an input (`[:sub …]`, `[:db …]`, `[:resource …]`) that names a fact nothing produces. The graph has a dangling edge; the framework [fails loud](glossary.md#fail-loud-not-silent) rather than silently feeding `nil`.
-- **Cycle in an acyclic graph** — a flow whose inputs depend, transitively, on its own output. Flows are topologically sorted before they drain, so a cycle is a registration-time error (`:rf.error/flow-cycle`, thrown by `reg-flow` *before* any snapshot is created), not a hang at runtime. The error even carries the offending chain — a `:cycle` vector with a closing repeat, `[:a :b :a]` for `:a → :b → :a` — which a tool like Xray renders verbatim. (Subscriptions tolerate some shapes flows can't, because a flow must reach a fixed point inside one commit; the subscription graph stays dynamic at the view boundary and has no registration-time cycle gate.)
-- **Illegal storage write** — a source form tries to materialize where its storage class forbids. A flow writes app-db only; pointing one at a `:rf.db/runtime` output path is rejected. The storage class isn't decoration — it's an enforced contract.
-- **Missing lifecycle owner** — a process with no owner to keep it alive or release it. A graph that shows dependencies but hides ownership is *incomplete*, and the framework treats a missing owner as the error it is.
-- **Unresolved resource scope** — a scope resolver that can't produce a key (its `:from-db` source is absent, say), surfaced as `:rf.error/resource-sub-unresolved-scope`. The resource can't form its `[cache-scope resource-id canonical-params]` identity, so it can't cache — and a [scope](../resources/glossary.md#scope) that can't resolve raises rather than serving the wrong principal's data. (A resource registered with no scope policy at all is the sibling `:rf.error/resource-missing-scope-policy`.)
-- **Stale reply suppressed** — not an error so much as a *visible non-event*: an async reply arrived for a request a newer navigation or fetch already superseded, and the process dropped it by declared identity. The graph can show you that suppression happened — which is exactly the thing that's invisible (and maddening) when a framework swallows it silently.
+- **Unknown input fact** — a derivation declares an input (`[:sub …]`, `[:db …]`,
+  `[:resource …]`) that names a fact nothing produces. The graph has a dangling edge;
+  the framework [fails loud](glossary.md#fail-loud-not-silent) rather than silently
+  feeding `nil`.
+- **Cycle in an acyclic graph** — a flow whose inputs depend, transitively, on its
+  own output. Flows are topologically sorted before they drain, so a cycle is a
+  registration-time error (`:rf.error/flow-cycle`, thrown by `reg-flow` *before* any
+  snapshot is created), not a hang at runtime. The error even carries the offending
+  chain — a `:cycle` vector with a closing repeat, `[:a :b :a]` for
+  `:a → :b → :a` — which a tool like Xray renders verbatim. (Subscriptions tolerate
+  some shapes flows can't, because a flow must reach a fixed point inside one commit;
+  the subscription graph stays dynamic at the view boundary and has no
+  registration-time cycle gate.)
+- **Illegal storage write** — a source form tries to materialize where its storage
+  class forbids. A flow writes app-db only; pointing one at a `:rf.db/runtime` output
+  path is rejected. The storage class isn't decoration — it's an enforced contract.
+- **Missing lifecycle owner** — a process with no owner to keep it alive or release
+  it. A graph that shows dependencies but hides ownership is *incomplete*, and the
+  framework treats a missing owner as the error it is.
+- **Unresolved resource scope** — a scope resolver that can't produce a key (its
+  `:from-db` source is absent, say), surfaced as
+  `:rf.error/resource-sub-unresolved-scope`. The resource can't form its
+  `[cache-scope resource-id canonical-params]` identity, so it can't cache — and a
+  [scope](../resources/glossary.md#scope) that can't resolve raises rather than
+  serving the wrong principal's data. (A resource registered with no scope policy at
+  all is the sibling `:rf.error/resource-missing-scope-policy`.)
+- **Stale reply suppressed** — not an error so much as a *visible non-event*: an async
+  reply arrived for a request a newer navigation or fetch already superseded, and the
+  process dropped it by declared identity. The graph can show you that suppression
+  happened — which is exactly the thing that's invisible (and maddening) when a
+  framework swallows it silently.
 
 !!! note "Why this matters for reading apps"
 
-    The whole point of the algebra is that a tool can describe your app from declarations alone. That same property is what makes its errors legible: an "unknown input fact" message can name the *fact*, an illegal-write message can name the *storage class*, a missing-owner message can name the *lifecycle*. You debug against the model on this page, not against a stack trace through framework internals. The error vocabulary itself (`:rf.error/*`, `:rf.warning/*`) is the one closed catalogue [Errors](errors.md) teaches you to read; this page is just the map that makes those messages mean something.
+    The whole point of the algebra is that a tool can describe your app from
+    declarations alone. That same property is what makes its errors legible: an
+    "unknown input fact" message can name the *fact*, an illegal-write message can
+    name the *storage class*, a missing-owner message can name the *lifecycle*. You
+    debug against the model on this page, not against a stack trace through framework
+    internals. The error vocabulary itself (`:rf.error/*`, `:rf.warning/*`) is the one
+    closed catalogue [Errors](errors.md) teaches you to read; this page is just the
+    map that makes those messages mean something.
 
 !!! note "No public graph-accessor yet (pre-alpha)"
 
-    The assembled shape is consumed internally — by Xray and the conformance fixtures — and a public name ships only once the shape survives real use. What you can rely on today is the model: the classifications on this page are normative, and they are what the tools render.
+    The assembled shape is consumed internally — by Xray and the conformance fixtures
+    — and a public name ships only once the shape survives real use. What you can rely
+    on today is the model: the classifications on this page are normative, and they are
+    what the tools render.
 
 ## Advanced
 
-Everything above is what you need to *read* a graph. Two things sit one level deeper — the seam that lets families plug in, and a law about deltas that the framework states but does not yet execute. You can skip this section and lose nothing about reading apps.
+Everything above is what you need to *read* a graph. Two things sit one level deeper —
+how optional families plug in, and a law about deltas that the framework states but
+does not yet execute. You can skip this section and lose nothing about reading apps.
 
-### The contributor seam: how the optional families plug in
+### How optional families plug in
 
-The fourth rule above said a missing family just isn't there. The mechanism is worth a sentence for anyone wiring up tooling. Core can't `:require` flows, resources, routing, or machines — that would defeat their [bundle isolation](glossary.md#elide) and break a core-only build. So the composer reaches each optional family through a **contributor seam**: a `{family {:static-fn :live-fn …}}` map. On the JVM the default contributors auto-resolve whatever siblings are on the classpath; in the browser the tool that draws the graph (which already requires the families it has) supplies the map. A family whose artefact is absent contributes nothing — which is the same "no-flows app draws no flow nodes" story, just told from the composer's side. The composer is itself bundle-isolated and exports no public accessor; it's the internal shape the deferred public name will one day produce.
+The fourth rule above said a missing family just isn't there. The mechanism is worth a
+sentence for anyone wiring up tooling. Core can't `:require` flows, resources,
+routing, or machines — that would defeat their
+[bundle isolation](glossary.md#elide) and break a core-only build. So the composer
+reaches each optional family through a **contributor map**:
+`{family {:static-fn :live-fn …}}`. On the JVM the default contributors auto-resolve
+whatever siblings are on the classpath; in the browser the tool that draws the graph
+(which already requires the families it has) supplies the map. A family whose artefact
+is absent contributes nothing — which is the same "no-flows app draws no flow nodes"
+story, just told from the composer's side. The composer is itself bundle-isolated and
+exports no public accessor; it's the internal shape the deferred public name will one
+day produce.
 
 ### The optional delta law
 
-The whole-value law says every derivation must be correct as a function that recomputes its *entire* output. That's the floor, and today it's also the ceiling: re-frame2 ships **no executable delta protocol**. But the spec writes down the law a delta path *would* have to obey, so that if one ever lands it can't quietly change observed values.
+The whole-value law says every derivation must be correct as a function that
+recomputes its *entire* output. That's the floor, and today it's also the ceiling:
+re-frame2 ships **no executable delta protocol**. But the spec writes down the law a
+delta path *would* have to obey, so that if one ever lands it can't quietly change
+observed values.
 
-The idea: a derivation could one day declare a `:step-delta` companion beside its `:derive`, computing an *output* delta from an *input* delta instead of rebuilding the whole value — the optimization you'd want for, say, a hundred-thousand-row grid where one cell changed.
+The idea: a derivation could one day declare a `:step-delta` companion beside its
+`:derive`, computing an *output* delta from an *input* delta instead of rebuilding the
+whole value — the optimization you'd want for, say, a hundred-thousand-row grid where
+one cell changed.
 
 ```clojure
 {:id         :large-grid/visible-rows
@@ -319,14 +577,25 @@ The idea: a derivation could one day declare a `:step-delta` companion beside it
  :step-delta #'app.grid/visible-rows-delta} ;; delta: an optional fast path
 ```
 
-The binding rule is that the delta path must **commute** with whole-value recomputation — applying the input delta then deriving must equal deriving then applying the output delta. If a `:step-delta` is absent, disabled, or fails its conformance check, whole-value derivation remains correct; the delta is never load-bearing for correctness, only for speed. This is why the error list above has a quiet seventh member the healthy-reading cases never hit: **delta law check failed** — a declared `:step-delta` that disagreed with whole-value recompute, caught by conformance rather than shipped. Until a real performance case needs it, the practical takeaway is simply: trust the whole-value value; the delta is a deferred optimization with a law already waiting for it.
+The binding rule is that the delta path must **commute** with whole-value
+recomputation — applying the input delta then deriving must equal deriving then
+applying the output delta. If a `:step-delta` is absent, disabled, or fails its
+conformance check, whole-value derivation remains correct; the delta is never required
+for correctness, only for speed. This is why the error list above has a quiet seventh
+member the healthy-reading cases never hit: **delta law check failed** — a declared
+`:step-delta` that disagreed with whole-value recompute, caught by conformance rather
+than shipped. Until a real performance case needs it, the practical takeaway is
+simply: trust the whole-value value; the delta is a deferred optimization with a law
+already waiting for it.
 
 ## The rule worth carrying
 
 You don't memorize the tables. You carry the sentence the keystone example proved:
 
-> A subscription, a flow, a resource, a route fact, and a machine are the same dependency-graph node under different **storage** and **evaluation** policies. The source forms differ for good ergonomic reasons; the algebra view is what they share.
+> A subscription, a flow, a resource, a route fact, and a machine are the same
+> dependency-graph node under different **storage** and **evaluation** policies. The
+> source forms differ for good ergonomic reasons; the algebra view is what they share.
 
-When you just want to pick a home for a value, ask the four questions in [Where should this value live?](where-state-lives.md). This page is what sits underneath that router: *why* the four homes are four faces of one idea.
-
-Everything flows; nothing stands still — and now you can read the picture. Derived data, flowing.
+When you just want to pick a home for a value, ask the four questions in
+[Where should this value live?](where-state-lives.md). This page is what sits
+underneath that router: *why* the four homes are four faces of one idea.

--- a/docs/core/effects.md
+++ b/docs/core/effects.md
@@ -1,14 +1,10 @@
 # Effects: the way out
 
 So far, handlers mostly returned `{:db …}`. Real apps also need HTTP, storage,
-timers, and follow-up events — without turning handlers into impure mush.
+timers, and follow-up events — without stuffing `js/fetch` into the handler body.
 
 This page shows you how to write pure [event handlers](glossary.md#event-handler)
 that **side-effect**.
-
-**On this page — two speeds.** Day one: describe effects as data (`:fx`),
-run-to-completion, managed HTTP shape, the effect-map grammar. Going further:
-`reg-fx`, test overrides, platform skips. You can ship after the grammar.
 
 Yes. A surprising claim.
 
@@ -19,7 +15,7 @@ world. Neither demand bends.
 The move you've been leaning on since [events](events.md) and [app-db](app-db.md)
 is the answer: a handler never *does* anything. It returns a **to-do list** — a
 description of what should happen, in plain data — and the runtime does the dirty
-work. Hold onto that list; the whole page runs on it.
+work. That list is the whole page.
 
 ## The counter learns to act
 
@@ -127,7 +123,7 @@ All four steps appear **together**. The view never shows `[:submitted]` alone.
     click **submit** again. However deep the chain goes, the screen only ever sees
     the end of it.
 
-Three notes that keep the mental model honest:
+Three notes that keep the picture honest:
 
 1. **Each dequeued event is its own [epoch](glossary.md#epoch).** Parent and child
    are two rows in the record, even though they settled in one drain and rendered
@@ -166,15 +162,18 @@ Real apps reach outside themselves: servers, storage, timers. The counter never 
     {:db (assoc db :article/loading? true)}))
 ```
 
-A muddy monster truck has just parked in our field of white tulips.
-
-The inline fetch fails three ways, and the failures *are* the reasons for the architecture — not style points:
+That inline fetch fails three ways — and the failures *are* the architecture, not
+style points:
 
 - **The handler isn't pure anymore.** It calls `js/fetch`. Testing it now means mocking the network — and mocking should be mocked; it is a bad omen. You took the most testable function in the codebase and made it the least.
 - **The async path is a trap.** The `.then` callback fires *after* the handler returned. The `db` it closed over is the previous state, and the callback has no legal way to produce a new one. You've written a function that is half pure, half effectful, by accident.
-- **The history goes dark.** The fetch never appears in the event record. Reading the handler no longer tells you what the app will look like when the response lands. Replaying the app's events no longer reproduces its state. The inline fetch is a hole in the [ledger](coeffects.md#the-ledger) — the replayable record of everything that ever entered the app, and the asset this framework most refuses to give up.
+- **The history goes dark.** The fetch never appears in the event record. Reading the handler no longer tells you what the app will look like when the response lands. Replaying the app's events no longer reproduces its state. The inline fetch is a hole in the [ledger](coeffects.md#the-ledger) — the replayable record of everything that ever entered the app.
 
-So the rule is one line, and it is the load-bearing sentence of this page: **describe the effect, don't perform it.** Never call `js/fetch` — or any I/O — from a handler body; a handler that performs I/O directly stops being pure, captures a stale `db` in its async callback, and vanishes from the event record. Read the bolded sentence once more before moving on. Everything else on this page is that sentence wearing different clothes.
+So the rule is one line: **describe the effect, don't perform it.** Never call
+`js/fetch` — or any I/O — from a handler body. A handler that performs I/O
+directly stops being pure, captures a stale `db` in its async callback, and
+vanishes from the event record. Everything else on this page is that sentence in
+different clothes.
 
 ## Effects are data
 
@@ -214,7 +213,7 @@ The inline version **did** a fetch. This version **describes** one. The handler 
 
 That reply rides as the event's last argument in [the uniform reply](glossary.md#the-uniform-reply) shape — success carries `:value`, failure carries `:error` — and every managed async surface answers the same way.
 
-Read what that bought you. The entire fetch flow is three pure handlers you read top to bottom. No `.then` chains, no stale-`db` trap, and the failure path has a *name* instead of being a branch you forgot to write. Each handler tests as a plain function. The request tests as data: assert on the map, no network required.
+What that bought you: the entire fetch flow is three pure handlers you read top to bottom. No `.then` chains, no stale-`db` trap, and the failure path has a *name* instead of being a branch you forgot to write. Each handler tests as a plain function. The request tests as data: assert on the map, no network required.
 
 And this pattern should feel familiar, because you already program in it all day. A [view](views.md) is a pure function that returns hiccup — a *description* of DOM — and the framework does the mutating, efficiently and discreetly. Effects are the same trick pointed at everything else the app touches.
 
@@ -266,9 +265,11 @@ Because `:fx` is just a vector, you keep adding rows. A richer checkout is simpl
           [:dispatch [:notification/show "Order placed!"]]]}))
 ```
 
-A state change, an HTTP POST, a storage write, and a follow-up dispatch — still one pure map. Push that thought as far as it will go: every request your app will ever send, every byte it will ever store, every place it will ever navigate — its entire worldly conduct — is rows of plain data, returned from pure functions, sitting still and legible before anything happens. Your app never *does* anything. It writes lists, and the runtime works down them.
+A state change, an HTTP POST, a storage write, and a follow-up dispatch — still one pure map. Every request, storage write, and navigation your app performs is a row of plain data returned from a pure function — legible before anything happens. The handler writes the list; the runtime works it down.
 
-Too far? A little. One handler, one map. But "the app's conduct, as data" is not a slogan — it is exactly what the [trace stream](glossary.md#trace-stream) records and [Xray](glossary.md#xray) shows you when something goes weird at 4:45 on a Friday.
+When something goes weird at 4:45 on a Friday, that list is exactly what the
+[trace stream](glossary.md#trace-stream) records and [Xray](glossary.md#xray) shows
+you.
 
 ### Ordering and atomicity — what you can rely on
 
@@ -287,14 +288,12 @@ When a handler returns `{:db new-db :fx [[a 1] [b 2] [c 3]]}`, four rules hold. 
 
     Application handlers return those two keys — plus, when a write carries a privacy consequence, the commit-plane classification effects (`:sensitive`, `:large`, and their `clear-` counterparts) that [app-db](app-db.md) teaches. Anything else at the top level is a malformed effect map. The runtime doesn't throw — it [fails closed](glossary.md#fail-loud-not-silent): it emits `:rf.error/effect-map-shape` naming the offending key, **drops** that key, and applies the legal ones (so your `:db` still lands). This is the safety net under a typo (`:dn` for `:db`) and under the old v1 reflex of returning a top-level `[:dispatch …]` — which belongs in an `:fx` row.
 
-## Day-one checklist
-
 You can return `{:db … :fx [[id args] …]}`, chain follow-ups with `[:dispatch …]`,
 trust run-to-completion (a drain never paints halfway), and describe HTTP instead
 of calling `js/fetch` in a handler. Impurity is data until the runtime performs it.
-That is the whole of the day-one grammar — you can ship on it.
+That is the whole of the effect-map grammar — you can ship on it.
 
-## When things go wrong
+## Troubleshooting
 
 | Symptom | Error / behaviour | Fix |
 |---|---|---|
@@ -304,7 +303,7 @@ That is the whole of the day-one grammar — you can ship on it.
 | Bare `dispatch` in a handler | Breaks purity and the ledger | Return `:fx [[:dispatch …]]` |
 | Async callback has no frame | `:rf.error/no-frame-context` | Capture `(:frame m)` in the fx handler (or use managed fx) |
 
-## Going further
+## Advanced
 
 Everything above is enough to ship. The rest is here for when a need appears —
 registering your own effects, and swapping them out in tests.

--- a/docs/core/errors.md
+++ b/docs/core/errors.md
@@ -4,20 +4,33 @@ You know the pipeline through [effects](effects.md), [coeffects](coeffects.md),
 [frames](frames.md), and [flows](flows.md). Now: what happens when one of them
 breaks?
 
-You've caught a hundred errors with `console.error("something broke", e)`. It kept the message and the stack — and threw away the important half: *which [event](glossary.md#event) was in flight, which [frame](glossary.md#frame) owned it, which [handler](glossary.md#event-handler) was on the hook, what the [pipeline run](glossary.md#run) had already done*. Every one of those facts existed in the runtime, microseconds before the catch. Then the catch fired, kept two of them, and you spent the next hour rebuilding the rest by hand.
+You've caught a hundred errors with `console.error("something broke", e)`. It kept
+the message and the stack — and threw away the half that actually matters: *which
+[event](glossary.md#event) was in flight, which [frame](glossary.md#frame) owned it,
+which [handler](glossary.md#event-handler) was running, what the
+[pipeline run](glossary.md#run) had already done*. Every one of those facts existed
+in the runtime, microseconds before the catch. Then the catch kept two of them, and
+you rebuilt the rest by hand.
 
-re-frame2's rule is one sentence: **if the runtime knows it, the [error record](glossary.md#error-record) carries it.**
+re-frame2's rule is one sentence: **if the runtime knows it, the
+[error record](glossary.md#error-record) carries it.**
 
-**Day one on this page:** read a dossier (`:op-type`, `:operation`, `:recovery`),
-learn the four degradation defaults (handler throw, missing event, missing fx,
-missing cofx). The catalogue is consult-not-memorise; production shipping is the
-how-to [Report errors in production](how-to/report-errors-in-production.md).
+Read a dossier (`:op-type`, `:operation`, `:recovery`), and learn the four
+degradation defaults (handler throw, missing event, missing fx, missing cofx). The
+catalogue is consult-not-memorise; production shipping is the how-to
+[Report errors in production](how-to/report-errors-in-production.md).
 
-That one sentence is the whole model; the rest of this page is it, unpacked. Every error the framework detects becomes a structured map — fat on purpose — with the causal context already attached. This page teaches you to read that map, predict how your app degrades after each kind of failure, fix the error you'll hit first, and test the structure instead of the string.
+Every error the framework detects becomes a structured map — fat on purpose — with
+the causal context already attached. This page teaches you to read that map, predict
+how your app degrades after each kind of failure, fix the error you'll hit first,
+and test the structure instead of the string.
 
 ## The dossier
 
-When something breaks, the runtime is standing right there. It has the [event](glossary.md#event) in hand, the [event handler](glossary.md#event-handler) on the hook, the owning [frame](glossary.md#frame) in scope. It keeps all of it. Here's the shape:
+When something breaks, the runtime is standing right there. It has the
+[event](glossary.md#event) in hand, the [event handler](glossary.md#event-handler) on
+the hook, the owning [frame](glossary.md#frame) in scope. It keeps all of it. Here's
+the shape:
 
 ```clojure
 {:id        42                              ;; unique trace id
@@ -42,93 +55,213 @@ When something breaks, the runtime is standing right there. It has the [event](g
              :exception-message "Cannot read properties of undefined (reading 'price')"}}
 ```
 
-That's not a log line. That's a dossier. The offence, categorised. The severity, stamped. The suspect's registered address, an eyewitness placing the `dispatch` at the scene, and what the authorities did next — all filed before the stack trace hit your console. Too much? Okay, fine: it's a map. A plain map with a fixed shape, which is better than a dossier, because you can filter it.
+That's not a log line. It's a map with a fixed shape: severity, category, recovery,
+handler registration site, dispatch call-site, and a schema-checked `:tags` payload.
+Tools can filter it; string scrapers can't.
 
-Three fields do the heavy lifting, and once you know them you've learned most of the surface:
+Three fields do most of the work:
 
-- **`:op-type`** is severity. `:error` for genuine failures, `:warning` for misuse the runtime recovers from. Want "show me everything that failed"? Filter on `:op-type :error` — you don't need to know a single category name to ask that question.
-- **`:operation`** is the category — a namespaced keyword like `:rf.error/handler-exception` or `:rf.error/no-such-fx`. To narrow to "only handler exceptions", filter on it exactly.
-- **`:recovery`** is what the framework did *after* the error. This is the field that tells you whether your app is still standing — usually the first thing you want to know.
+- **`:op-type`** is severity. `:error` for genuine failures, `:warning` for misuse the
+  runtime recovers from. Want "show me everything that failed"? Filter on
+  `:op-type :error` — you don't need a single category name for that.
+- **`:operation`** is the category — a namespaced keyword like
+  `:rf.error/handler-exception` or `:rf.error/no-such-fx`. Narrow with an exact match.
+- **`:recovery`** is what the framework did *after* the error. That tells you whether
+  the app is still standing — usually the first thing you want to know.
 
-Two more slots turn a debugging session into a click. `:rf.trace/trigger-handler` carries the file and line where the failing handler was *registered*; `:rf.trace/call-site` carries the line of the [`dispatch`](glossary.md#dispatch) that triggered the [pipeline run](glossary.md#run). Tools render both as jump-to-source links. Everything else rides under `:tags`, with one fixed, schema-checked payload shape per category, so a consumer always knows what's in the envelope. (The payload is self-contained on purpose: `:category` restates `:operation`, and `:failing-id` names the culprit — here, the handler itself, which is why it matches `:handler-id`.)
+Two more slots turn a debugging session into a click.
+`:rf.trace/trigger-handler` carries the file and line where the failing handler was
+*registered*; `:rf.trace/call-site` carries the line of the
+[`dispatch`](glossary.md#dispatch) that triggered the
+[pipeline run](glossary.md#run). Tools render both as jump-to-source links.
+Everything else rides under `:tags`, with one fixed, schema-checked payload shape per
+category. The payload is self-contained on purpose: `:category` restates
+`:operation`, and `:failing-id` names the culprit (here the handler itself, which is
+why it matches `:handler-id`).
 
 ??? info "Coming from Sentry + React error boundaries?"
 
-    Two anchors will help. **Sentry's structured events:** an error is a rich record, not a string. **React error boundaries:** failures land in one designated place. Two things work differently here, though. You instrument *nothing* — the framework emits the structured record itself, with the causal context already attached, where Sentry needs you to wrap and tag by hand. And there's no boundary *component* to catch and steer: what the runtime does after each kind of error is fixed per category, so your code *observes* the failure rather than deciding what to do about it.
+    Two anchors will help. **Sentry's structured events:** an error is a rich record,
+    not a string. **React error boundaries:** failures land in one designated place.
+    Two things work differently here. You instrument *nothing* — the framework emits
+    the structured record itself, with the causal context already attached, where
+    Sentry needs you to wrap and tag by hand. And there's no boundary *component* to
+    catch and steer: what the runtime does after each kind of error is fixed per
+    category, so your code *observes* the failure rather than deciding what to do
+    about it.
 
 ??? note "Going deeper — it's a tagged union"
 
-    The dossier is a single product type with a closed tag set per category — a *sum type* keyed on `:operation`, where each variant carries a statically-known `:tags` payload. That's why a consumer can pattern-match on `:operation` and trust the shape of what follows: the catalogue *is* the type definition. The `:op-type`/`:operation` pair is a coarse-then-fine discriminator — severity first (for the "did anything fail?" fold), category second (for per-variant handling) — so you consume at whichever granularity your tool needs.
+    The dossier is a single product type with a closed tag set per category — a *sum
+    type* keyed on `:operation`, where each variant carries a statically-known
+    `:tags` payload. That's why a consumer can pattern-match on `:operation` and
+    trust the shape of what follows: the catalogue *is* the type definition. The
+    `:op-type`/`:operation` pair is a coarse-then-fine discriminator — severity first
+    (for the "did anything fail?" fold), category second (for per-variant handling) —
+    so you consume at whichever granularity your tool needs.
 
-One expectation to set before you get attached: the dossier is a development surface. Production builds [*elide*](glossary.md#elide) the [trace stream](glossary.md#trace-stream) — not disable it, *elide* it: dead-code elimination compiles the code clean out of the release bundle, dossiers and all. Errors that must still reach a monitor in production travel a separate always-on channel carrying a tight, unredacted record — covered at the end of this page.
+One expectation before you get attached: the dossier is a development surface.
+Production builds [*elide*](glossary.md#elide) the
+[trace stream](glossary.md#trace-stream) — not disable it, *elide* it: dead-code
+elimination compiles the code out of the release bundle, dossiers and all. Errors
+that must still reach a monitor in production travel a separate always-on channel
+carrying a tight record — covered at the end of this page.
 
 ## A catalogue you consult, not memorise
 
-How many categories are there? Dozens — covering handlers, subscriptions, effects, coeffects, schemas, frames, routing, machines, SSR. Don't memorise them. The set grows but never breaks, and it has a grammar you can learn in the time it takes to read three bullets.
+How many categories are there? Dozens — covering handlers, subscriptions, effects,
+coeffects, schemas, frames, routing, machines, SSR. Don't memorise them. The set
+grows but never breaks, and it has a grammar you can learn in three bullets.
 
 The prefix names the owning subsystem:
 
 - `:rf.error/*` — a genuine failure.
 - `:rf.warning/*` — recoverable misuse.
-- `:rf.fx/*` / `:rf.cofx/*` / `:rf.ssr/*` / `:rf.epoch/*` — not errors but lifecycle events from those subsystems, riding the same envelope (a platform-skipped [effect](glossary.md#effect), a [hydration mismatch](../ssr/glossary.md#hydration-mismatch)).
+- `:rf.fx/*` / `:rf.cofx/*` / `:rf.ssr/*` / `:rf.epoch/*` — not errors but lifecycle
+  events from those subsystems, riding the same envelope (a platform-skipped
+  [effect](glossary.md#effect), a
+  [hydration mismatch](../ssr/glossary.md#hydration-mismatch)).
 
-Existing categories are never renamed or repurposed: pin a test to `:rf.error/no-such-fx` and it still means that next year.
+Existing categories are never renamed or repurposed: pin a test to
+`:rf.error/no-such-fx` and it still means that next year.
 
-The catalogue itself — every category, its trigger, its `:tags` payload, its recovery default — is a closed reference table, and you never have to leave the failure in front of you to read it: **every dossier names its own catalogue entry.** The record carries `:operation` (the category), restates it under `:tags :category`, states what the runtime did next in `:recovery`, and hands you a one-sentence `:reason` — so the record *is* the catalogue row for the error you're holding, self-contained. Treat it like HTTP status codes: nobody memorises the table; you look a category up when you meet it — here by reading the fields off the dossier — and after a while you just know the ones you've met.
+The catalogue itself — every category, its trigger, its `:tags` payload, its recovery
+default — is a closed reference table. You never have to leave the failure in front of
+you to read it: **every dossier names its own catalogue entry.** The record carries
+`:operation` (the category), restates it under `:tags :category`, states what the
+runtime did next in `:recovery`, and hands you a one-sentence `:reason` — so the
+record *is* the catalogue row for the error you're holding. Treat it like HTTP status
+codes: nobody memorises the table; you look a category up when you meet it, and after
+a while you just know the ones you've met.
 
 ## Recovery is typed — and it isn't yours
 
-When an error fires, the runtime applies a typed, per-category default. That's the whole story. There is no app-steering error policy: no global error handler, no hook that swallows an exception or substitutes a result.
+When an error fires, the runtime applies a typed, per-category default. That's the
+whole story. There is no app-steering error policy: no global error handler, no hook
+that swallows an exception or substitutes a result.
 
-Why so rigid? Because the two things such a hook gets used for are both mistakes. Swallowing an exception masks a bug. Fabricating a replacement result invents something the thrown handler could not have produced. Genuine recovery belongs at the source, for *expected* failures, where "recovery" actually means something: [managed HTTP's](../async/http.md) `:retry` for a flaky network, or a defensive default at a read. And the framework never re-runs a failing handler behind your back — when you want to try again, you [dispatch](glossary.md#dispatch) a fresh event.
+Why so rigid? Because the two things such a hook gets used for are both mistakes.
+Swallowing an exception masks a bug. Fabricating a replacement result invents
+something the thrown handler could not have produced. Genuine recovery belongs at the
+source, for *expected* failures, where "recovery" actually means something:
+[managed HTTP's](../async/http.md) `:retry` for a flaky network, or a defensive
+default at a read. And the framework never re-runs a failing handler behind your back
+— when you want to try again, you [dispatch](glossary.md#dispatch) a fresh event.
 
 The `:recovery` vocabulary is small and readable on sight:
 
 - `:no-recovery` — the operation did not complete.
-- `:replaced-with-default` — an unresolved input is substituted (a `nil` for a missing sub input, say) and the body runs on.
+- `:replaced-with-default` — an unresolved input is substituted (a `nil` for a
+  missing sub input, say) and the body runs on.
 - `:logged-and-skipped` — the offending input is dropped; siblings still apply.
-- `:warned-and-replaced` — two writes conflict over the same target and the last one wins; advisory only.
+- `:warned-and-replaced` — two writes conflict over the same target and the last one
+  wins; advisory only.
 - `:skipped` — a platform-gated effect documented out, not really an error.
-- `:fix-registration` — the "you registered it wrong, here's how" verb covering typos and bad `reg-*` arguments (a `reg-sub` handed a malformed argument shape, a [resource](../resources/glossary.md#resource) subscribed before it's registered, a `reg-view` missing its args vector).
+- `:fix-registration` — the "you registered it wrong, here's how" verb covering typos
+  and bad `reg-*` arguments (a `reg-sub` handed a malformed argument shape, a
+  [resource](../resources/glossary.md#resource) subscribed before it's registered, a
+  `reg-view` missing its args vector).
 
-Plus a few category-specific verbs like `:supply-frame` on the missing-frame error below. Every category carries its assigned recovery verb in the dossier itself — read it off the record.
+Plus a few category-specific verbs like `:supply-frame` on the missing-frame error
+below. Every category carries its assigned recovery verb in the dossier itself — read
+it off the record.
 
 Four of those defaults shape how your app degrades, so they're worth knowing by heart:
 
-- **A throwing event handler halts its run with no half-applied state.** `:rf.error/handler-exception` means no [`:db` commit](glossary.md#commit) and no `:fx`. [app-db](glossary.md#app-db) is exactly as it was before the dispatch.
-- **A dispatch to an unregistered event id is a traced no-op.** `:rf.error/no-such-handler` (recovery `:replaced-with-default` — a do-nothing handler stands in) lets a feature module with a botched load order boot degraded instead of crashing. The trace names the exact id, so the bug announces itself instead of showing up as "huh, the button does nothing."
-- **A missing fx drops only itself.** Read this one twice, because people get it backwards. `:rf.error/no-such-fx` does *not* halt the run — the handler's `:db` change still applies and the sibling `:fx` entries still fire.
-- **A missing coeffect fails loud, before the handler runs.** `:rf.error/unregistered-cofx`. We'll see why this is the strict sibling of the missing-fx case below.
+- **A throwing event handler halts its run with no half-applied state.**
+  `:rf.error/handler-exception` means no [`:db` commit](glossary.md#commit) and no
+  `:fx`. [app-db](glossary.md#app-db) is exactly as it was before the dispatch.
+- **A dispatch to an unregistered event id is a traced no-op.**
+  `:rf.error/no-such-handler` (recovery `:replaced-with-default` — a do-nothing
+  handler stands in) lets a feature module with a botched load order boot degraded
+  instead of crashing. The trace names the exact id, so the bug announces itself
+  instead of showing up as "huh, the button does nothing."
+- **A missing fx drops only itself.** Read this one twice — people get it backwards.
+  `:rf.error/no-such-fx` does *not* halt the run — the handler's `:db` change still
+  applies and the sibling `:fx` entries still fire.
+- **A missing coeffect fails loud, before the handler runs.**
+  `:rf.error/unregistered-cofx`. We'll see why this is the strict sibling of the
+  missing-fx case below.
 
 !!! note "No app-policy error hook"
 
-    There is no `reg-event-error-handler` — on purpose, and this section just argued why. Observation lives on a [listener](glossary.md#listener) on the error channel — the `:errors` stream covered at the end of this page. Coming from a v1 app that installed an error hook, the [migration guide](25-from-re-frame-v1.md) maps the translation.
+    There is no `reg-event-error-handler` — on purpose, and this section just argued
+    why. Observation lives on a [listener](glossary.md#listener) on the error channel
+    — the `:errors` stream covered at the end of this page. Coming from a v1 app that
+    installed an error hook, the [migration guide](25-from-re-frame-v1.md) maps the
+    translation.
 
 ??? note "One category, three modes"
 
-    `:rf.error/no-such-handler` covers three [registrar](glossary.md#registrar) misses, discriminated by a mandatory `:kind` tag: `:kind :event` (the dispatch case above), `:kind :route` (a URL that matched no registered [route](../routing/glossary.md#route) pattern — see [routing](../routing/concepts.md)), and `:kind :frame` (a tool surface addressing a frame-id that isn't registered). Filter on the operation keyword alone for a single "registrar miss" view; route on `:kind` when you want per-mode handling.
+    `:rf.error/no-such-handler` covers three
+    [registrar](glossary.md#registrar) misses, discriminated by a mandatory `:kind`
+    tag: `:kind :event` (the dispatch case above), `:kind :route` (a URL that matched
+    no registered [route](../routing/glossary.md#route) pattern — see
+    [routing](../routing/concepts.md)), and `:kind :frame` (a tool surface addressing
+    a frame-id that isn't registered). Filter on the operation keyword alone for a
+    single "registrar miss" view; route on `:kind` when you want per-mode handling.
 
 !!! warning "Gotcha — schema checks fire only in dev"
 
-    If you guard an [app-db](glossary.md#app-db) path, an event, or an HTTP `:decode` step with a [schema](glossary.md#schema), a value that fails it emits `:rf.error/schema-validation-failure` to surface the bug *early*, where the bad value was produced. Recovery is **not uniform** — it follows the boundary named in the `:where` tag, and the list here is the *full* map (all eight boundaries the one category spans): an `:event` failure **skips the handler**; an `:app-db` or `:machine-data` failure **rolls the run back** (no commit); an `:fx-args` failure **skips just the offending fx** (siblings run); a `:sub-return` or `:sub-override` failure **surfaces `nil` and renders on**; `:flow-output` / `:machine-output` are **observational** — the value still commits. Read the recovery straight off the `:where` tag on the record; `:explain` carries the Malli explanation. The surprise is the asymmetry: production builds [*elide*](glossary.md#elide) the check entirely, so this category fires **only in dev**. Treat schema checks as a development assertion that hardens your data at its source, not a runtime gate you can lean on in production. (A structurally broken Malli form is the separate `:rf.error/malformed-schema`, which fails closed and rolls the commit back.)
+    If you guard an [app-db](glossary.md#app-db) path, an event, or an HTTP `:decode`
+    step with a [schema](glossary.md#schema), a value that fails it emits
+    `:rf.error/schema-validation-failure` to surface the bug *early*, where the bad
+    value was produced. Recovery is **not uniform** — it follows the boundary named
+    in the `:where` tag, and the list here is the *full* map (all eight boundaries the
+    one category spans): an `:event` failure **skips the handler**; an `:app-db` or
+    `:machine-data` failure **rolls the run back** (no commit); an `:fx-args` failure
+    **skips just the offending fx** (siblings run); a `:sub-return` or
+    `:sub-override` failure **surfaces `nil` and renders on**; `:flow-output` /
+    `:machine-output` are **observational** — the value still commits. Read the
+    recovery straight off the `:where` tag on the record; `:explain` carries the
+    Malli explanation. The surprise is the asymmetry: production builds
+    [*elide*](glossary.md#elide) the check entirely, so this category fires **only in
+    dev**. Treat schema checks as a development assertion that hardens your data at
+    its source, not a runtime gate you can lean on in production. (A structurally
+    broken Malli form is the separate `:rf.error/malformed-schema`, which fails closed
+    and rolls the commit back.)
 
-    One boundary is **not** on that list on purpose. A *recordable coeffect* (`:rf.cofx/requires`) whose supplied, replayed, or generated value fails its `reg-cofx` `:schema` is **not** a `:where :cofx` schema-validation trace. It is the separate, halting `:rf.error/cofx-value-invalid` — a **production hard error** that throws (`:recovery :no-recovery`) in prod as well as dev, because a recordable coeffect rides the durable causal record and a bad one silently corrupts replay, SSR, and [Xray](glossary.md#xray) (the dev inspector). Look the `:rf.error/cofx-value-invalid` row up in the catalogue when you meet it, and see [coeffects](coeffects.md) for why a coeffect value must stay recordable.
+    One boundary is **not** on that list on purpose. A *recordable coeffect*
+    (`:rf.cofx/requires`) whose supplied, replayed, or generated value fails its
+    `reg-cofx` `:schema` is **not** a `:where :cofx` schema-validation trace. It is
+    the separate, halting `:rf.error/cofx-value-invalid` — a **production hard error**
+    that throws (`:recovery :no-recovery`) in prod as well as dev, because a
+    recordable coeffect rides the durable causal record and a bad one silently
+    corrupts replay, SSR, and [Xray](glossary.md#xray) (the dev inspector). Look the
+    `:rf.error/cofx-value-invalid` row up in the catalogue when you meet it, and see
+    [coeffects](coeffects.md) for why a coeffect value must stay recordable.
 
 ## The failures you'll actually meet
 
-Read each category through the production incident it describes. Here are the four you'll meet first; the rest read the same way once you have the rhythm.
+Read each category through the production incident it describes. Here are the four
+you'll meet first; the rest read the same way once you have the rhythm.
 
 ### A dispatch with no frame in scope
 
-*You wrote a quick `(rf/dispatch [:cart/add-item {:id 7}])` at the REPL, or in a `setTimeout` callback, or in a promise `.then` — and instead of a run you got an error.* Nearly everyone trips on this once.
+*You wrote a quick `(rf/dispatch [:cart/add-item {:id 7}])` at the REPL, or in a
+`setTimeout` callback, or in a promise `.then` — and instead of a run you got an
+error.* Nearly everyone trips on this once.
 
-[`dispatch`](glossary.md#dispatch) and [`subscribe`](glossary.md#subscribe--derive) resolve their target [frame](glossary.md#frame) from the surrounding scope, but a deferred callback runs on a fresh stack, long after that scope has unwound. The runtime does not guess a default — [frame identity is carried, not found](glossary.md#frame-identity-is-carried-not-found). It emits `:rf.error/no-frame-context` (recovery: `:supply-frame`) and dispatches nothing.
+[`dispatch`](glossary.md#dispatch) and
+[`subscribe`](glossary.md#subscribe--derive) resolve their target
+[frame](glossary.md#frame) from the surrounding scope, but a deferred callback runs
+on a fresh stack, long after that scope has unwound. The runtime does not guess a
+default — [frame identity is carried, not found](glossary.md#frame-identity-is-carried-not-found).
+It emits `:rf.error/no-frame-context` (recovery: `:supply-frame`) and dispatches
+nothing.
 
-The fix is always the same: **carry the frame** across the async gap — capture `:frame` at fx-handler entry and pass it explicitly on the deferred dispatch (`{:frame frame}` in the opts), exactly as [Effects](effects.md) showed. `capture-frame` is the same move for app code, and [Frames](frames.md) is the pattern's canonical home. In a [view](glossary.md#view) you're already under the [frame-provider](glossary.md#frame-provider), so you rarely think about it; at the REPL or in a test, `with-frame` / `with-new-frame` pin the scope.
+The fix is always the same: **carry the frame** across the async gap — capture
+`:frame` at fx-handler entry and pass it explicitly on the deferred dispatch
+(`{:frame frame}` in the opts), exactly as [Effects](effects.md) showed.
+`capture-frame` is the same move for app code, and [Frames](frames.md) is the
+pattern's canonical home. In a [view](glossary.md#view) you're already under the
+[frame-provider](glossary.md#frame-provider), so you rarely think about it; at the
+REPL or in a test, `with-frame` / `with-new-frame` pin the scope.
 
 ### A handler throws
 
-*The user arrived on a deep link that bypassed your init event, so `:cart` was never seeded. The first click walks `update-in` straight into a `nil` and throws.*
+*The user arrived on a deep link that bypassed your init event, so `:cart` was never
+seeded. The first click walks `update-in` straight into a `nil` and throws.*
 
 ```clojure
 (rf/reg-event :cart/add-item
@@ -136,7 +269,9 @@ The fix is always the same: **carry the frame** across the async gap — capture
     {:db (update-in db [:cart :items] conj item)}))    ;; throws when :cart doesn't exist
 ```
 
-The runtime catches it and emits `:rf.error/handler-exception` with `:recovery :no-recovery`: run halted, nothing committed, app-db untouched. The fix is a defensive default at the point of access:
+The runtime catches it and emits `:rf.error/handler-exception` with
+`:recovery :no-recovery`: run halted, nothing committed, app-db untouched. The fix is
+a defensive default at the point of access:
 
 ```clojure
 (rf/reg-event :cart/add-item
@@ -144,34 +279,92 @@ The runtime catches it and emits `:rf.error/handler-exception` with `:recovery :
     {:db (update-in db [:cart :items] (fnil conj []) item)}))
 ```
 
-Do this once, deliberately, and you'll trust the machinery afterwards: make a handler throw on purpose in dev with [Xray](glossary.md#xray) open. The error lands *inside the run that produced it*. The dispatch that caused it sits right above. The category and recovery read straight off the error row. One click lands on the handler's registration site. Nothing about the failure is out-of-band — and that's the whole pitch.
+Do this once, deliberately, and you'll trust the machinery afterwards: make a handler
+throw on purpose in dev with [Xray](glossary.md#xray) open. The error lands *inside
+the run that produced it*. The dispatch that caused it sits right above. The category
+and recovery read straight off the error row. One click lands on the handler's
+registration site. Nothing about the failure is out-of-band — and that's the whole
+pitch.
 
 ??? note "Going deeper — the failure is attributed, not lumped"
 
-    `:rf.error/handler-exception` is scoped tight: it means the **event handler body itself** threw. The runtime knows the difference between that and the things standing around it. A throw from a [*coeffect*](glossary.md#coeffect) supplier during context assembly (a registered `reg-cofx` value-returning supplier whose body raised) emits `:rf.error/coeffect-exception`, attributed to the failing cofx id rather than mis-blamed on the handler. A throw from a *user [interceptor](glossary.md#interceptor)* you wired into the chain emits `:rf.error/interceptor-exception`, attributed to that interceptor's `:id` and the `:phase` (`:before` or `:after`) it threw in. All three share the recovery — `:no-recovery`, atomic abort, no `:db` install, no `:fx` — and all three halt the same run. What differs is the name on the dossier, so when the trace says `:rf.error/coeffect-exception` you go straight to the supplier instead of staring at a handler that never ran. (An `:after`-phase interceptor throw still aborts atomically: under the [deferred-commit](glossary.md#commit) contract, `:after` runs *before* the `:db` is installed, so a teardown throw discards the whole [effect map](glossary.md#effect-map) the same as any pre-install failure.)
+    `:rf.error/handler-exception` is scoped tight: it means the **event handler body
+    itself** threw. The runtime knows the difference between that and the things
+    standing around it. A throw from a [*coeffect*](glossary.md#coeffect) supplier
+    during context assembly (a registered `reg-cofx` value-returning supplier whose
+    body raised) emits `:rf.error/coeffect-exception`, attributed to the failing
+    cofx id rather than mis-blamed on the handler. A throw from a *user
+    [interceptor](glossary.md#interceptor)* you wired into the chain emits
+    `:rf.error/interceptor-exception`, attributed to that interceptor's `:id` and the
+    `:phase` (`:before` or `:after`) it threw in. All three share the recovery —
+    `:no-recovery`, atomic abort, no `:db` install, no `:fx` — and all three halt the
+    same run. What differs is the name on the dossier, so when the trace says
+    `:rf.error/coeffect-exception` you go straight to the supplier instead of staring
+    at a handler that never ran. (An `:after`-phase interceptor throw still aborts
+    atomically: under the [deferred-commit](glossary.md#commit) contract, `:after`
+    runs *before* the `:db` is installed, so a teardown throw discards the whole
+    [effect map](glossary.md#effect-map) the same as any pre-install failure.)
 
 ### A missing fx is not a missing cofx
 
-*You moved an fx-id behind a feature module, the load order shifted, and an event now fires before the fx registers.* The bogus entry emits `:rf.error/no-such-fx`, naming the fx-id (the `:rf.fx/id` tag) and the event that carried it. The rest of the handler's work proceeds: `:db` applies, sibling effects fire. The reason it's safe to drop is that an [effect](glossary.md#effect) is *output* — dropping one corrupts nothing the handler already computed.
+*You moved an fx-id behind a feature module, the load order shifted, and an event now
+fires before the fx registers.* The bogus entry emits `:rf.error/no-such-fx`, naming
+the fx-id (the `:rf.fx/id` tag) and the event that carried it. The rest of the
+handler's work proceeds: `:db` applies, sibling effects fire. The reason it's safe to
+drop is that an [effect](glossary.md#effect) is *output* — dropping one corrupts
+nothing the handler already computed.
 
-A missing [coeffect](glossary.md#coeffect) is the stricter sibling, because a cofx is *input*. If a handler's `:rf.cofx/requires` names an id with no `reg-cofx` registration, the framework emits `:rf.error/unregistered-cofx` and [fails loud](glossary.md#fail-loud-not-silent) — at registration where it can check statically, else at first processing, always *before* the handler runs. Running the handler anyway would mean computing new state from a silently-missing fact, and that's exactly the silent-`nil` coupling the [declared-coeffects model](coeffects.md) exists to kill.
+A missing [coeffect](glossary.md#coeffect) is the stricter sibling, because a cofx is
+*input*. If a handler's `:rf.cofx/requires` names an id with no `reg-cofx`
+registration, the framework emits `:rf.error/unregistered-cofx` and
+[fails loud](glossary.md#fail-loud-not-silent) — at registration where it can check
+statically, else at first processing, always *before* the handler runs. Running the
+handler anyway would mean computing new state from a silently-missing fact, and
+that's exactly the silent-`nil` coupling the
+[declared-coeffects model](coeffects.md) exists to kill.
 
 ??? note "Going deeper — the asymmetry is about data flow"
 
-    Output can be partial without lying: a dropped `:fx` is one less side-effect, and the state the handler computed is still true. Input cannot — a missing cofx means a *fact the handler asked for is absent*, so any state computed from it is fabricated. The runtime treats the two ends of the pipe differently on purpose: best-effort on the output side, fail-closed on the input side. It's the same discipline a total function applies to its domain versus its codomain.
+    Output can be partial without lying: a dropped `:fx` is one less side-effect, and
+    the state the handler computed is still true. Input cannot — a missing cofx means
+    a *fact the handler asked for is absent*, so any state computed from it is
+    fabricated. The runtime treats the two ends of the pipe differently on purpose:
+    best-effort on the output side, fail-closed on the input side. It's the same
+    discipline a total function applies to its domain versus its codomain.
 
 ### A subscription throws, or reads one that isn't there
 
-*The same `nil` that crashed your handler can crash a [sub](glossary.md#subscription) instead — a layer-2 sub maps over `(:items cart)` while `cart` is still `nil`.* The render phase has its own two categories, and they're the exact mirror of the event side:
+*The same `nil` that crashed your handler can crash a
+[sub](glossary.md#subscription) instead — a layer-2 sub maps over `(:items cart)`
+while `cart` is still `nil`.* The render phase has its own two categories, and they're
+the exact mirror of the event side:
 
-- **A throwing sub computation emits `:rf.error/sub-exception`** (recovery `:replaced-with-default`): the sub returns `nil`, the view sees no value, and the failure is named — not a blank panel with no clue. A `:where` tag (`:reactive` for the hot recompute path, `:compute-sub` for the on-demand path) tells you which resolution path threw. The fix is the same defensive default you'd apply in a handler.
-- **A `subscribe` to an unregistered sub-id — or a `:<-` input naming one — emits `:rf.error/no-such-sub`** (recovery `:replaced-with-default`): the unresolved input is substituted with `nil` and the sub's body still runs. This is the render-phase twin of `:rf.error/no-such-handler`: a botched load order degrades to a `nil` read with the exact id named in the trace, rather than crashing the render.
+- **A throwing sub computation emits `:rf.error/sub-exception`** (recovery
+  `:replaced-with-default`): the sub returns `nil`, the view sees no value, and the
+  failure is named — not a blank panel with no clue. A `:where` tag (`:reactive` for
+  the hot recompute path, `:compute-sub` for the on-demand path) tells you which
+  resolution path threw. The fix is the same defensive default you'd apply in a
+  handler.
+- **A `subscribe` to an unregistered sub-id — or a `:<-` input naming one — emits
+  `:rf.error/no-such-sub`** (recovery `:replaced-with-default`): the unresolved input
+  is substituted with `nil` and the sub's body still runs. This is the render-phase
+  twin of `:rf.error/no-such-handler`: a botched load order degrades to a `nil` read
+  with the exact id named in the trace, rather than crashing the render.
 
-For both, a missing or broken *derivation* yields `nil` and renders on, because a view that's missing one value is still a view. That's deliberately gentler than the event side: an `:rf.error/handler-exception` halts its whole run (`:no-recovery`), but a sub failure is contained to the one node and its dependents, leaving the rest of the [derivation graph](glossary.md#the-derivation-graph) intact.
+For both, a missing or broken *derivation* yields `nil` and renders on, because a view
+that's missing one value is still a view. That's deliberately gentler than the event
+side: an `:rf.error/handler-exception` halts its whole run (`:no-recovery`), but a
+sub failure is contained to the one node and its dependents, leaving the rest of the
+[derivation graph](glossary.md#the-derivation-graph) intact.
 
 ## Test the structure, not the string
 
-Errors are data, so asserting them is as boring as asserting anything else. Register a [listener](glossary.md#listener) on the [trace stream](glossary.md#trace-stream) with `rf/register-listener!` ([observability](observability.md) is its full story), do the thing that should fail, filter for the category, then pin the structured fields. This is the same shape the framework's own suite uses:
+Errors are data, so asserting them is as boring as asserting anything else. Register
+a [listener](glossary.md#listener) on the
+[trace stream](glossary.md#trace-stream) with `rf/register-listener!`
+([observability](observability.md) is its full story), do the thing that should fail,
+filter for the category, then pin the structured fields. This is the same shape the
+framework's own suite uses:
 
 ```clojure
 ;; Shape adapted from the framework's own error tests.
@@ -208,23 +401,58 @@ Errors are data, so asserting them is as boring as asserting anything else. Regi
 
 Notes — three of them, and each one generalises to every category:
 
-1. **The assertions are structural.** They pin `:operation`, `:op-type`, and the schema-checked `:tags` keys — the contract. They never touch `:reason`, the human-facing headline sentence, because its wording is allowed to change. String-shaped error tests rot; structural ones don't.
-2. **The listener is scoped to the test** and detached in `finally` — and detached with the *same* stream you registered on (`:trace` here), so a failing assertion can't leak it into the next test. When you'd rather drop every listener on a stream at once, that is a fixture-layer concern — `re-frame.test-support`'s reset clears the registries directly (there is no facade bulk-clear verb); production code never does this.
-3. **It runs on the JVM.** No browser, no DOM — you register, [dispatch-sync](glossary.md#dispatch-sync), emit, and assert, in milliseconds. [Test a pipeline run](testing/pipeline-runs.md) covers the fixture machinery for suites of these.
+1. **The assertions are structural.** They pin `:operation`, `:op-type`, and the
+   schema-checked `:tags` keys — the contract. They never touch `:reason`, the
+   human-facing headline sentence, because its wording is allowed to change.
+   String-shaped error tests rot; structural ones don't.
+2. **The listener is scoped to the test** and detached in `finally` — and detached
+   with the *same* stream you registered on (`:trace` here), so a failing assertion
+   can't leak it into the next test. When you'd rather drop every listener on a
+   stream at once, that is a fixture-layer concern — `re-frame.test-support`'s reset
+   clears the registries directly (there is no facade bulk-clear verb); production
+   code never does this.
+3. **It runs on the JVM.** No browser, no DOM — you register,
+   [dispatch-sync](glossary.md#dispatch-sync), emit, and assert, in milliseconds.
+   [Test a pipeline run](testing/pipeline-runs.md) covers the fixture machinery for
+   suites of these.
 
-The same move covers every category: `dispatch-sync` for event errors, a [sub](glossary.md#subscription) computation for sub errors, frame setup and teardown for lifecycle errors.
+The same move covers every category: `dispatch-sync` for event errors, a
+[sub](glossary.md#subscription) computation for sub errors, frame setup and teardown
+for lifecycle errors.
 
 !!! note "One verb, four streams"
 
-    That first argument to `register-listener!` is a stream selector. `:trace` is the dev tap you just used — [elided](glossary.md#elide) out of production builds, the firehose [Xray](glossary.md#xray) drinks from. `:errors` is the **always-on error channel** promised earlier: the same structured records, but it survives production, fans across every frame, and is not filtered by any frame's egress policy. That's why wiring Sentry in production is just `(rf/register-listener! :errors ::sentry report!)`. Mind one thing: nothing arrives redacted except the event vector, so scrubbing before shipping is on you — the [how-to](how-to/report-errors-in-production.md) walks it. The other two — `:events` (an always-on per-event integration hook) and `:epoch` ([epoch](glossary.md#epoch) records for time-travel tooling) — are [observability](observability.md)'s territory. One closed vocabulary; pass an unknown stream and you get a loud `:rf.error/unknown-listener-stream`, no silent default.
+    That first argument to `register-listener!` is a stream selector. `:trace` is the
+    dev tap you just used — [elided](glossary.md#elide) out of production builds, the
+    firehose [Xray](glossary.md#xray) drinks from. `:errors` is the **always-on error
+    channel** promised earlier: the same structured records, but it survives
+    production, fans across every frame, and is not filtered by any frame's egress
+    policy. That's why wiring Sentry in production is just
+    `(rf/register-listener! :errors ::sentry report!)`. Mind one thing: nothing
+    arrives redacted except the event vector, so scrubbing before shipping is on you
+    — the [how-to](how-to/report-errors-in-production.md) walks it. The other two —
+    `:events` (an always-on per-event integration hook) and `:epoch`
+    ([epoch](glossary.md#epoch) records for time-travel tooling) — are
+    [observability](observability.md)'s territory. One closed vocabulary; pass an
+    unknown stream and you get a loud `:rf.error/unknown-listener-stream`, no silent
+    default.
 
 ## Advanced
 
 ### The errors that throw, not trace
 
-Everything so far has been the *traced* dossier — a failure inside a running [pipeline run](glossary.md#run), where the runtime records the error and recovers. But a minority of failures don't ride the trace stream at all: they **throw**. A registration is rejected, an optional feature's artefact isn't on the classpath, an API entry point is called before [`init!`](glossary.md#init). These surface as an `ex-info` — the catalogue's "thrown ex-info" rows, mostly the registration-time family. You meet them at the REPL, in a `try`/`catch`, or as a red boot stack trace — not in Xray's epoch view.
+Everything so far has been the *traced* dossier — a failure inside a running
+[pipeline run](glossary.md#run), where the runtime records the error and recovers.
+But a minority of failures don't ride the trace stream at all: they **throw**. A
+registration is rejected, an optional feature's artefact isn't on the classpath, an
+API entry point is called before [`init!`](glossary.md#init). These surface as an
+`ex-info` — the catalogue's "thrown ex-info" rows, mostly the registration-time
+family. You meet them at the REPL, in a `try`/`catch`, or as a red boot stack trace —
+not in Xray's epoch view.
 
-They carry the *same* category vocabulary as the dossier, in a parallel shape, so one consumer path reads both surfaces. The discriminator moves from `:operation` to **`:rf.error/id`**, and it lives in `ex-data`:
+They carry the *same* category vocabulary as the dossier, in a parallel shape, so one
+consumer path reads both surfaces. The discriminator moves from `:operation` to
+**`:rf.error/id`**, and it lives in `ex-data`:
 
 ```clojure
 (try
@@ -233,19 +461,41 @@ They carry the *same* category vocabulary as the dossier, in a parallel shape, s
     (:rf.error/id (ex-data e))))                   ;; => :rf.error/resource-missing-scope-policy
 ```
 
-Four slots are guaranteed on every framework throw: **`:rf.error/id`** (the `:rf.error/*` category — the sole machine pivot), **`:where`** (the user-facing fn symbol that threw, e.g. `'rf/reg-resource` — unlike the traced `:where`, which names a boundary or resolution path), **`:recovery`** (the same vocabulary as the traced dossier, commonly `:fix-registration` here), and **`:reason`** (a one-sentence human description). Surface-specific keys (`:received`, `:resource-id`, `:cycle`, …) merge on top.
+Four slots are guaranteed on every framework throw: **`:rf.error/id`** (the
+`:rf.error/*` category — the sole machine pivot), **`:where`** (the user-facing fn
+symbol that threw, e.g. `'rf/reg-resource` — unlike the traced `:where`, which names
+a boundary or resolution path), **`:recovery`** (the same vocabulary as the traced
+dossier, commonly `:fix-registration` here), and **`:reason`** (a one-sentence human
+description). Surface-specific keys (`:received`, `:resource-id`, `:cycle`, …) merge
+on top.
 
 Two rules make these safe to branch on:
 
-- **Branch on `:rf.error/id`, never on the message.** `(:rf.error/id (ex-data e))` is the canonical discriminator — `case` / `condp` on it exactly as you'd match `:operation` on a traced record.
-- **The message is for humans, and its wording can change.** `(ex-message e)` leads with an actionable sentence and *trails* a bracketed `[:rf.error/<id>]` token — e.g. `"… require an adapter ns and install it before boot. [:rf.error/no-adapter-installed]"`. That token is greppable from a raw log line, but assert against it with a substring or `thrown-with-msg?` regex, never whole-string equality. The same discipline as `:reason` on the traced side: pin the structure, not the prose.
+- **Branch on `:rf.error/id`, never on the message.** `(:rf.error/id (ex-data e))` is
+  the canonical discriminator — `case` / `condp` on it exactly as you'd match
+  `:operation` on a traced record.
+- **The message is for humans, and its wording can change.** `(ex-message e)` leads
+  with an actionable sentence and *trails* a bracketed `[:rf.error/<id>]` token —
+  e.g. `"… require an adapter ns and install it before boot. [:rf.error/no-adapter-installed]"`.
+  That token is greppable from a raw log line, but assert against it with a substring
+  or `thrown-with-msg?` regex, never whole-string equality. The same discipline as
+  `:reason` on the traced side: pin the structure, not the prose.
 
-This is why the page can promise "one vocabulary across every surface": the traced dossier's `:operation` and the thrown error's `:rf.error/id` are the same catalogue keyword, so a tool — or your test — pivots on one closed set whether the failure recovered or aborted.
+This is why the page can promise "one vocabulary across every surface": the traced
+dossier's `:operation` and the thrown error's `:rf.error/id` are the same catalogue
+keyword, so a tool — or your test — pivots on one closed set whether the failure
+recovered or aborted.
 
 ## Where the boundaries are
 
-This page is the *model* — the record, the taxonomy, the recovery contract. Three adjacent concerns live elsewhere, on purpose:
+This page is the *model* — the record, the taxonomy, the recovery contract. Three
+adjacent concerns live elsewhere, on purpose:
 
-- **The wire itself** — the [trace stream](glossary.md#trace-stream) these records ride, the channel split, and how [Xray](glossary.md#xray) reads the same stream your one-line test listener just did — is [observability](observability.md).
-- **Production shipping** to a monitor is [a how-to](how-to/report-errors-in-production.md).
-- **The server boundary** — raw error records must never leak into an HTTP response — is handled by [SSR](../ssr/concepts.md), which projects them to a sanitised public shape before anything reaches the browser.
+- **The wire itself** — the [trace stream](glossary.md#trace-stream) these records
+  ride, the channel split, and how [Xray](glossary.md#xray) reads the same stream
+  your one-line test listener just did — is [observability](observability.md).
+- **Production shipping** to a monitor is
+  [a how-to](how-to/report-errors-in-production.md).
+- **The server boundary** — raw error records must never leak into an HTTP response —
+  is handled by [SSR](../ssr/concepts.md), which projects them to a sanitised public
+  shape before anything reaches the browser.

--- a/docs/core/events.md
+++ b/docs/core/events.md
@@ -1,8 +1,8 @@
 # Events
 
 The [introduction](introduction.md) walked the [event pipeline](glossary.md#event-pipeline)
-once. This page is the **language** of that pipeline: what events look like, how
-you announce them, and what handlers are allowed to do.
+once. This page is the **language** of that pipeline: what events look like, how you
+announce them, and what handlers are allowed to do.
 
 > **Nothing moves without an event. Design the event set and you design the app.**
 
@@ -23,8 +23,8 @@ Ids are the vocabulary of the application. Prefer names that say what *happened*
 implemented.
 
 There is no second channel. Timers, HTTP replies, route loaders, and button clicks
-all speak this shape. That uniformity is why tools can show one timeline for the
-whole app.
+all speak this shape. One shape, one timeline — tools can show the whole app without
+guessing which bus you meant.
 
 ## Dispatch
 
@@ -42,17 +42,17 @@ Inside a `reg-view`, `dispatch` is injected for you (same for `subscribe`):
 ```
 
 **Dispatch does not run the handler.** It enqueues the event on the frame's FIFO
-queue and returns immediately. The runtime dequeues later and runs the full
-pipeline for that event. That separation keeps UI handlers thin and keeps the
-write path single-threaded.
+queue and returns immediately. The runtime dequeues later and runs the full pipeline
+for that event. That split keeps UI handlers thin and keeps the write path
+single-threaded.
 
 ```text
 happens → enqueue → dequeue → event pipeline
 ```
 
 Need the pipeline to finish before your next line of code? Reach for
-`dispatch-sync` only when you must (boot, some interop). Prefer ordinary
-`dispatch` in views. (The full drain story lives with
+`dispatch-sync` only when you must (boot, some interop). Prefer ordinary `dispatch`
+in views. (The full drain story lives with
 [Effects](effects.md#run-to-completion).)
 
 !!! warning "No ambient frame"
@@ -75,7 +75,7 @@ map — at minimum `{:db current-app-db}`) and the event vector, and returns an
     {:db (update db :value inc)}))
 ```
 
-Rules that matter from day one:
+Rules that matter:
 
 1. **Pure.** Same inputs, same returned map. No `js/fetch`, no `swap!`, no reading
    the clock. Impurity is *described* and performed later ([Effects](effects.md);
@@ -85,7 +85,7 @@ Rules that matter from day one:
 3. **The runtime commits.** Your function proposes; the pipeline applies.
 
 A handler may return other effect keys (`:fx`, …) alongside or instead of `:db`.
-It may return no `:db` and leave state alone. The state doctrine lives on
+It may return no `:db` and leave state alone. The state rules live on
 [app-db](app-db.md); the to-do list beyond `:db` lives on [Effects](effects.md).
 
 ### Metadata when you need it
@@ -95,13 +95,11 @@ schemas, required coeffects, interceptors. Until you need that, the two-argument
 form is enough. The first useful metadata form is on
 [Coeffects](coeffects.md).
 
-## Day-one checklist
-
 You can design an event set, dispatch from a view, and write pure handlers that
 return `{:db …}`. Everything else on this page is recovery vocabulary — keep it
 nearby, don't memorise it.
 
-## When things go wrong
+## Troubleshooting
 
 Three failures you will meet early — each is **loud**, named, and recoverable:
 
@@ -111,7 +109,9 @@ Three failures you will meet early — each is **loud**, named, and recoverable:
 | Callback throws from a timer / fetch | Bare `dispatch` outside a frame | `:rf.error/no-frame-context` — carry the frame ([Frames](frames.md)) |
 | Handler can't be unit-tested | You called `js/fetch` / read the clock inside the body | Wrong place for impurity — describe it ([Effects](effects.md), [Coeffects](coeffects.md)) |
 
-Unregistered-id is intentional degrade: a botched feature load must not crash the whole app. The fix is still to register the handler (or fix the typo); the trace names the exact id so you never guess.
+Unregistered-id is intentional degrade: a botched feature load must not crash the
+whole app. The fix is still to register the handler (or fix the typo); the trace
+names the exact id so you never guess.
 
 ## What events are not
 

--- a/docs/core/flows.md
+++ b/docs/core/flows.md
@@ -18,12 +18,6 @@ handlers and other machinery read. For that you want a **[flow](glossary.md#flow
 write the result into app-db."* You declare the rule once; the framework holds the
 pen for that path.
 
-**On this page — two speeds.** Day one: the smallest possible flow, the registration
-map, and the judgment of when a value earns its place in app-db (and when it
-doesn't). Going further: deriving from route or machine state, validating and
-classifying output, toggling flows at runtime, and testing. You can ship after the
-first stop.
-
 **When *not* a flow.** If only views read the derivation, keep a
 [subscription](subscriptions.md). Reach for a flow when a **handler** (or schema,
 or another update- or commit-phase path) must read the answer as plain app-db data.
@@ -50,7 +44,7 @@ Here is the *same* label as a flow. Same pure function, no new domain:
   (fn [n] (if (odd? n) :odd :even)))           ;; pure: input values, in order → output
 ```
 
-Read it top to bottom and the shape is a sentence: *watch `[:value]`; when it changes, run `(fn [n] …)`; write the result to `[:parity]`.* That's the whole idea. The input values arrive at the derive fn — the third slot — positionally: one input here, so it takes one argument.
+Read it top to bottom: *watch `[:value]`; when it changes, run `(fn [n] …)`; write the result to `[:parity]`.* That's the whole idea. The input values arrive at the derive fn — the third slot — positionally: one input here, so it takes one argument.
 
 Here it is running — note the view reads parity with an ordinary app-db subscription, because the answer now *is* state. The seed event fires when the frame is created, before the flow registers, so the label is blank until your first click changes the input — recompute-on-change, live:
 
@@ -86,11 +80,11 @@ Here it is running — note the view reads parity with an ordinary app-db subscr
  [flow-counter]]
 ```
 
-From now on, every event that changes `:value` also recomputes `:parity`. And here's the part worth pausing on: the recompute is part of the *same write*. An [event pipeline](glossary.md#event-pipeline) run in re-frame2 doesn't dribble out a sequence of little app-db mutations; it gathers up everything it wants to change and installs it as one all-or-nothing write — the [**commit**](glossary.md#commit) you've met on every page since the introduction. A flow runs after the event's handler (and after any cross-cutting [interceptors](glossary.md#interceptor) — a later page — have finished shaping `:db`) and *before* that commit, so the handler's change and the fresh flow output land together. Views never see a half-updated state where the counter ticked but the label hasn't caught up.
+From now on, every event that changes `:value` also recomputes `:parity`. The recompute is part of the *same write*. An [event pipeline](glossary.md#event-pipeline) run in re-frame2 doesn't dribble out a sequence of little app-db mutations; it gathers everything it wants to change and installs it as one all-or-nothing write — the [**commit**](glossary.md#commit). A flow runs after the event's handler (and after any cross-cutting [interceptors](glossary.md#interceptor) — a later page — have finished shaping `:db`) and *before* that commit, so the handler's change and the fresh flow output land together. Views never see a half-updated state where the counter ticked but the label hasn't caught up.
 
-The flow also skips recomputing when its inputs didn't actually change value — write the same `:value` back and the flow stays quiet, which keeps the cost honest. (This input-changed test is the flow's **dirty-check** — the name comes back later.)
+The flow also skips recomputing when its inputs didn't actually change value — write the same `:value` back and the flow stays quiet. (This input-changed test is the flow's **dirty-check** — the name comes back later.)
 
-So what did we actually build? Here it is in one sentence: **a flow is the same pure function as a subscription; the only difference is where the answer lives — and because the answer lives in app-db, your handlers can read it.** Read that sentence again. It's the key concept on this page; everything below — the registration keys, the errors, the toggling — is that one idea, worked out.
+> **A flow is the same pure function as a subscription; the only difference is where the answer lives — and because the answer lives in app-db, your handlers can read it.**
 
 ### What changed, and what didn't
 
@@ -98,7 +92,7 @@ So what did we actually build? Here it is in one sentence: **a flow is the same 
 - **Handlers can now read it.** Any event handler can ask `(:parity db)` as plain data. With the sub version that answer was stranded in the view-cache — visible to views, invisible to handlers. A handler always sees the output as of the last completed event; if the handler itself changes an input, the recompute happens right after it, inside that same event's single commit.
 - **You never write the output path.** You keep writing `:value` through ordinary handlers. The runtime is the sole author of `[:parity]`.
 
-That last bullet is a trade, so let's name it honestly. Design is all tradeoffs: a flow buys you *"this value simply derives from these inputs; it simply changes when they do"* at the cost of a little spooky action at a distance — no particular handler is responsible for `[:parity]` any more. re-frame2 takes that trade with its eyes open, and then spends tooling on the spooky part: every flow write is attributed to the flow that made it, as you're about to see.
+That last bullet is a trade. A flow buys you *"this value simply derives from these inputs; it simply changes when they do"* at the cost of a little distance — no particular handler is responsible for `[:parity]` any more. re-frame2 takes that trade with its eyes open, and then spends tooling on the attribution: every flow write is tagged to the flow that made it, as you're about to see.
 
 ??? info "From re-frame v1"
 
@@ -118,7 +112,7 @@ One thing to know before you copy this, because it trips people up: a flow belon
 
 Outside any scope, `reg-flow` refuses with `:rf.error/no-frame-context` rather than guessing which frame you meant.
 
-Now dispatch `[:inc]` and open [Xray](glossary.md#xray). The event's row records the handler's change and, in the same commit, the flow's recompute — the write to `[:parity]` attributed to the flow that made it. There's the promised paper trail for the spooky action. Restore an older [epoch](glossary.md#epoch) — one of the per-event snapshots the runtime keeps — and parity travels back with the rest of app-db. Because a materialised value is ordinary state, [time-travel](glossary.md#time-travel) and the inspector get it for free.
+Now dispatch `[:inc]` and open [Xray](glossary.md#xray). The event's row records the handler's change and, in the same commit, the flow's recompute — the write to `[:parity]` attributed to the flow that made it. There's the paper trail. Restore an older [epoch](glossary.md#epoch) — one of the per-event snapshots the runtime keeps — and parity travels back with the rest of app-db. Because a materialised value is ordinary state, [time-travel](glossary.md#time-travel) and the inspector get it for free.
 
 The honest part: the counter's parity should *stay* a subscription. Nothing but the view reads it, so materialising it buys nothing and costs an app-db write per click. We re-expressed it only to learn the shape with familiar material. Next, a value that genuinely *earns* a flow.
 
@@ -149,7 +143,7 @@ Reach for a flow only when **all** of these hold:
 - It should **survive** [SSR hydration](../ssr/concepts.md), time-travel restore, and app-db serialisation — a sub-cache does not survive the wire.
 - The derivation is **stable enough to be worth registering** — not a one-off computation inside a single handler.
 
-Notice the shape those four bullets describe. Nearly every value that passes the test is doing *synchronisation* — maintaining an invariant inside a changing data structure. The RealWorld editor's submit gate is the canonical case. "Can the user submit?" means *the draft is valid AND differs from the loaded baseline*. The **submit handler** needs that answer, not just the button — and that single requirement is what tips the value from view-input to state:
+Nearly every value that passes the test is doing *synchronisation* — maintaining an invariant inside a changing data structure. The RealWorld editor's submit gate is the canonical case. "Can the user submit?" means *the draft is valid AND differs from the loaded baseline*. The **submit handler** needs that answer, not just the button — and that single requirement is what tips the value from view-input to state:
 
 ```clojure
 ;; Condensed from examples/real-apps/realworld_resources/article_editor.cljs
@@ -214,15 +208,13 @@ read the answer as plain app-db state. That is the whole bar.
     different *policy* (on-demand vs write into app-db after each event).
     [One graph: derivations and their algebra views](derivations-and-algebra-views.md).
 
-## Day-one checklist
-
 You can `reg-flow` a rule — `:inputs` to watch, an `:output-path` to write, a pure
 derive fn — and the framework recomputes it in the *same commit* whenever an input
 changes, so handlers read the answer as plain app-db data. Reach for one only when a
 handler, schema, or other update- or commit-phase path needs the value; otherwise keep a
 [subscription](subscriptions.md). That is enough to ship a flow.
 
-## Going further
+## Advanced
 
 The rest of the page is here for when a flow earns more: reading route or machine
 state, validating and classifying its output, toggling it at runtime, testing it,
@@ -242,7 +234,7 @@ Most flows read app-db with bare paths. But a flow's `:inputs` can also reach in
 
 Two things stay true no matter how many runtime inputs a flow reads. First, **the output is still app-db** — a flow never writes runtime-db, so `:rf.db/runtime`-led paths are an input-only privilege. Second, the dirty-check watches *both* partitions: a pure route transition that changes runtime-db but touches no app-db still re-fires this flow, because the resolved route-id is part of the flow's cached input vector. You get a materialised, time-travelling, handler-readable mirror of route state without writing a single sync handler.
 
-One spelling rule before you go looking for symmetry: there is no `[:rf.db/app …]` form, and no bare runtime path. The *only* way to read runtime-db is the partition-qualified `[:rf.db/runtime …]` input above — a bare path is *always* app-db. One prefix means runtime, everything else means app-db, no third case to remember.
+One spelling rule: there is no `[:rf.db/app …]` form, and no bare runtime path. The *only* way to read runtime-db is the partition-qualified `[:rf.db/runtime …]` input above — a bare path is *always* app-db. One prefix means runtime, everything else means app-db, no third case to remember.
 
 ## Validating a flow's output
 
@@ -279,7 +271,7 @@ A flow's output rides the [trace stream](glossary.md#trace-stream) to Xray and a
 
 Each of `:sensitive` and `:large` is a **vector of subpaths** *into the output shape* — each subpath itself a vector of keys. `[[]]` (a single empty subpath) classifies the whole output. `:large? true` is the whole-output shorthand for `:large`. These mark *which slices* of the output get redacted (sensitive) or elided (large) when the flow's trace event and the `:output-path` write cross a trust boundary.
 
-Two spellings look like cousins here, and one is a mistake, so hear this plainly: at this layer `:sensitive` means *a collection of sensitive paths*, and the boolean spelling `:sensitive true` is wrong. A malformed declaration — a non-vector axis, a non-path entry, the boolean spelling — is rejected fail-closed at registration with `:rf.error/flow-bad-marks`: loud, rather than silently shipping the secret. (The boolean `:sensitive?` an event *handler* carries is a separate device — see [keeping secrets out of traces](how-to/keep-secrets-out-of-traces.md); a *flow's* classification is the plural path-list.)
+Two spellings look like cousins here, and one is a mistake: at this layer `:sensitive` means *a collection of sensitive paths*, and the boolean spelling `:sensitive true` is wrong. A malformed declaration — a non-vector axis, a non-path entry, the boolean spelling — is rejected fail-closed at registration with `:rf.error/flow-bad-marks`: loud, rather than silently shipping the secret. (The boolean `:sensitive?` an event *handler* carries is a separate device — see [keeping secrets out of traces](how-to/keep-secrets-out-of-traces.md); a *flow's* classification is the plural path-list.)
 
 And classification does not flow from input to output. A flow that *reads* a sensitive app-db slice does **not** auto-classify its output — a derived secret is just a new path, and you classify it directly with the flow's own `:sensitive` / `:large`. There is no taint propagation to rely on, or to fight. One separate wrinkle: when a flow recomputes inside the settling pass of a handler that carries `:sensitive? true`, the *whole* flow trace event inherits that coarse, whole-event marker from the handler.
 
@@ -302,7 +294,7 @@ The same atomic rule covers a throw in a [coeffect](glossary.md#coeffect) suppli
 
 ## Toggling a derivation at runtime
 
-Here's the trick a materialised view in a database can't do: you can switch a flow on and off *while the app runs*. Because flows are registered against the runtime rather than compiled into event chains, they're data the framework holds in a registry — and data can be added or removed at any time. Two reserved [effects](glossary.md#effect) — actions the framework performs on a handler's behalf — do it: `:rf.fx/reg-flow` (register a flow — the same 3-slot triple) and `:rf.fx/clear-flow` (remove one by id). Use this for a wizard step's derived check, a feature gate, an "advanced mode" — derivations that should only run while something is engaged:
+Here's what a materialised view in a database can't do: you can switch a flow on and off *while the app runs*. Because flows are registered against the runtime rather than compiled into event chains, they're data the framework holds in a registry — and data can be added or removed at any time. Two reserved [effects](glossary.md#effect) — actions the framework performs on a handler's behalf — do it: `:rf.fx/reg-flow` (register a flow — the same 3-slot triple) and `:rf.fx/clear-flow` (remove one by id). Use this for a wizard step's derived check, a feature gate, an "advanced mode" — derivations that should only run while something is engaged:
 
 ```clojure
 ;; Condensed from examples/core/flows/core.cljs — a 10%-off feature gate
@@ -344,13 +336,13 @@ The fx variant is the common one because most toggling happens *inside* event ha
 (flows/clear-flow :editor/can-submit? {:frame :scratch})  ;; clear lives on re-frame.flows
 ```
 
-Notice which function lives where, because it catches people: `reg-flow` stays on `re-frame.core`, since registration must stay central (it captures the call-site source coordinates), but the lifecycle helper `clear-flow` lives on its owning namespace, `re-frame.flows` — reach it as `flows/clear-flow`, not `rf/clear-flow`. Most code never needs it directly anyway: prefer the `:rf.fx/clear-flow` effect from inside a handler.
+Notice which function lives where: `reg-flow` stays on `re-frame.core`, since registration must stay central (it captures the call-site source coordinates), but the lifecycle helper `clear-flow` lives on its owning namespace, `re-frame.flows` — reach it as `flows/clear-flow`, not `rf/clear-flow`. Most code never needs it directly anyway: prefer the `:rf.fx/clear-flow` effect from inside a handler.
 
 ## Re-registering a flow (and hot reload)
 
 Call `reg-flow` again with an already-registered id (on the same frame) and you get a **surgical update**, the same as re-registering any event or sub. The new definition replaces the old; the dirty-check resets, so the flow re-evaluates on the next event regardless of input change; the next pass's dependency sort picks up any changed edges automatically. This is what makes hot-reload-on-save work: edit a flow's `:derive`, save, and the running app swaps it in.
 
-One subtlety, and it's the pen again: if the replacement also **moves the `:output-path`** to a new slot, the framework vacates the *old* slot — the same `dissoc-in` cleanup `clear-flow` does — so a stale value from the previous definition never lingers at the abandoned path. Keep the same `:output-path` and nothing is vacated; the next recompute simply overwrites it in place.
+One subtlety: if the replacement also **moves the `:output-path`** to a new slot, the framework vacates the *old* slot — the same `dissoc-in` cleanup `clear-flow` does — so a stale value from the previous definition never lingers at the abandoned path. Keep the same `:output-path` and nothing is vacated; the next recompute simply overwrites it in place.
 
 ## Testing a flow
 
@@ -398,8 +390,8 @@ Flows [fail loud](glossary.md#fail-loud-not-silent) and early. Almost everything
 
 The **shape** errors are the ones you meet while you're still typing the call — each names the offending slot in its `ex-data` so you can fix it without a stack-trace dig. First, the 3-slot grammar itself is enforced: `:rf.error/invalid-flow-metadata` fires when the middle slot isn't a map, or when a `:derive` is left inside the metadata map. Then the reconstructed flow is checked in order, most-fundamental-first: `:rf.error/flow-missing-id` (a nil `flow-id`), `:rf.error/flow-bad-id` (a `flow-id` that isn't a keyword), `:rf.error/flow-bad-inputs` (`:inputs` isn't a vector of non-empty paths), `:rf.error/flow-bad-output` (the `derive-fn` isn't a function — a historical name: it guards the derive slot, not `:output-path`), and `:rf.error/flow-bad-path` (`:output-path` isn't a non-empty vector of path segments). You'll mostly hit these once, the first time you write a flow; they're listed here so a thrown `:rf.error/*` keyword is self-explaining when it lands.
 
-There's one more refusal, and if you meet it at all you'll meet it first. Flows ship in their own optional artefact, `day8/re-frame2-flows`, and the whole flow API (`reg-flow`, `clear-flow`, `:rf.fx/reg-flow`, `:rf.fx/clear-flow`) is published through a late-bind seam rather than baked into the core. If that artefact isn't on the classpath — or you forgot the one-time `(:require [re-frame.flows])` that loads its registration hooks — the *first* flow call throws `:rf.error/flows-artefact-missing` (a thrown ex-info naming the calling fn, not a trace) rather than silently no-opping. Add `day8/re-frame2-flows` to your deps and require it once, somewhere in your app. (Same require-to-register convention the schemas / machines / routing artefacts use.)
+There's one more refusal, and if you meet it at all you'll meet it first. Flows ship in their own optional artefact, `day8/re-frame2-flows`, and the whole flow API (`reg-flow`, `clear-flow`, `:rf.fx/reg-flow`, `:rf.fx/clear-flow`) is published through late binding rather than baked into the core. If that artefact isn't on the classpath — or you forgot the one-time `(:require [re-frame.flows])` that loads its registration hooks — the *first* flow call throws `:rf.error/flows-artefact-missing` (a thrown ex-info naming the calling fn, not a trace) rather than silently no-opping. Add `day8/re-frame2-flows` to your deps and require it once, somewhere in your app. (Same require-to-register convention the schemas / machines / routing artefacts use.)
 
 The one error that surfaces at *runtime* rather than registration is `:rf.error/flow-eval-exception` — a `:derive` function throwing — which aborts the event as described in [What happens when a derive throws](#what-happens-when-a-derive-throws). (A flow's `:schema` failing is *not* an error of this kind: it's the observational `:rf.error/schema-validation-failure` diagnostic — the value still commits; see [Validating a flow's output](#validating-a-flows-output).)
 
-And that's flows, whole: the derivation you already knew how to write, its answer moved into app-db — with the framework holding the pen.
+And that's flows: the derivation you already knew how to write, its answer moved into app-db — with the framework holding the pen.

--- a/docs/core/frames.md
+++ b/docs/core/frames.md
@@ -2,7 +2,7 @@
 
 Every pure-pipeline page used one [frame](glossary.md#frame) — one app-db, one queue —
 under `frame-root`, and never said much about it. That is the normal case. Until
-now that root was ambient magic. **This page owns isolation:** what a world is,
+now that root was ambient. **This page owns isolation:** what a world is,
 ensure vs scope, and *frame identity is carried, not found.*
 
 The **boot recipe** — `init!`, hot reload, host listeners, packaging a real entry
@@ -15,11 +15,6 @@ canvas with three states, many SSR requests, or a `setTimeout` that just raised
 **world**: one complete, running copy of your app, sealed off from every other
 copy. Most apps establish exactly one world at boot and never say its name again.
 We start there, then add a second world.
-
-**On this page — two speeds.** Day one: one `frame-root`, seed with
-`:initial-events`, two frames side by side, the carried rule. Going further: the
-full frame config, `capture-frame` from callbacks, ending or resetting a frame.
-Ship on one frame until you need a second.
 
 ## The counter, twice
 
@@ -38,7 +33,7 @@ Before any theory, the whole point of frames, running. One set of registrations 
    [:span @(subscribe [:value]) " "]
    [:button {:on-click #(dispatch [:inc])} "+"]])
 
-;; the new idea: the SAME code, mounted in two isolated worlds —
+;; the SAME code, two isolated worlds —
 ;; each frame-root ENSURES its frame (creates it at first mount, runs
 ;; :initial-events) and scopes it for the subtree
 [:div {:style {:display "flex" :gap "2em"}}
@@ -52,26 +47,26 @@ Click one. The other doesn't move. Nothing in `counter` names a frame — its in
 
 One running instance of your app. That's the definition; the rest is inventory. A frame owns the runtime state of its instance:
 
-- its **[app-db](glossary.md#app-db)** — the single map this instance's events read and write; the whole of this instance's state,
+- its **[app-db](glossary.md#app-db)** — the single map this instance's events read and write,
 - its **event queue** — the [dispatches](glossary.md#dispatch) waiting to run against this instance,
-- its **[subscription](glossary.md#subscription) cache** — the memoised graph of derived values computed over this instance's state.
+- its **[subscription](glossary.md#subscription) cache** — the memoised graph of derived values over this instance's state.
 
-Now notice what's missing from that list: the handlers. A frame deliberately does *not* own the functions you register with `reg-event` / `reg-sub` / `reg-view`. Those are shared. By default every `reg-*` in your program writes into one common table — the [**registrar**](glossary.md#registrar) — that all frames draw from, so two frames both running `[:counter/inc]` run the *same handler function* against *different app-dbs*.
+Notice what's missing: the handlers. A frame deliberately does *not* own the functions you register with `reg-event` / `reg-sub` / `reg-view`. Those are shared. By default every `reg-*` writes into one common table — the [**registrar**](glossary.md#registrar) — that all frames draw from, so two frames both running `[:counter/inc]` run the *same handler function* against *different app-dbs*.
 
-That's the whole trick. **Shared code, separate state.** A frame isolates state, not behaviour — which is why "show two of them side by side" never forces a rewrite. You mount the same app twice, each mount in its own world, and isolation is total.
+**Shared code, separate state.** A frame isolates state, not behaviour — which is why "show two of them side by side" never forces a rewrite. You mount the same app twice, each mount in its own world.
 
-(The selected set of registrations a frame resolves against has a name — the [**image**](glossary.md#image) — but you can park that word for now. It only earns its keep in the rare case where you want two frames to run *different* handlers, which we get to at the very end. Until then, "the handlers are shared" is the whole story.)
+(The selected set of registrations a frame resolves against has a name — the [**image**](glossary.md#image) — but park that word for now. It only earns its keep when you want two frames to run *different* handlers, at the very end. Until then, "the handlers are shared" is the whole story.)
 
 
 ??? info "Coming from Redux?"
 
-    A frame is a store instance and the frame provider is `<Provider store={...}>`. Creating a second store gives you a second state tree but the same reducers; frames work exactly that way — handlers are registered once, state is per-frame. The divergence: there is no default store. A dispatch that can't trace which frame it belongs to fails loud instead of landing somewhere conventional. (More on that below — it's the whole design.)
+    A frame is a store instance and the frame provider is `<Provider store={...}>`. Creating a second store gives you a second state tree but the same reducers; frames work the same way — handlers registered once, state per-frame. The divergence: there is no default store. A dispatch that can't trace which frame it belongs to fails loud instead of landing somewhere conventional. (More below — that's the design.)
 
 ## The normal case: one app, one frame
 
 Almost every app is a one-world app, and stays one. You register a frame at boot, establish it at the root of your view tree, and never name it again.
 
-One piece of syntax recurs on this page, so let's settle it once. Inside a `reg-view`, `dispatch` and `subscribe` arrive as injected functions — `dispatch` sends an [event](glossary.md#event) into the queue, `subscribe` reads a derived value (both detailed on the [views](views.md) page). And `@` is Clojure's deref — `@(subscribe [:screen])` reads the *current value* out of the reactive subscription. Both quietly target whichever frame this view is rendering under; you'll see how in a moment.
+Inside a `reg-view`, `dispatch` and `subscribe` arrive as injected functions — `dispatch` sends an [event](glossary.md#event) into the queue, `subscribe` reads a derived value (both detailed on the [views](views.md) page). `@` is Clojure's deref — `@(subscribe [:screen])` reads the *current value* of the reactive subscription. Both target whichever frame this view is rendering under.
 
 ```clojure
 (ns my-app.core
@@ -100,7 +95,7 @@ One piece of syntax recurs on this page, so let's settle it once. Inside a `reg-
 
 Two forms do the work. `init!` installs the [substrate](glossary.md#substrate) [adapter](glossary.md#adapter) — the one-time hookup between re-frame2 and your rendering library (Reagent here) — and creates *no* frame. Then `frame-root {:id :app …}` **ensures** the `:app` frame: it creates the frame the first time the view mounts (running its `:initial-events`) and establishes it for everything underneath, so inside that subtree every `dispatch` and `subscribe` resolves to `:app` without ever naming it.
 
-That last point is the payoff: the frame is **invisible inside its own scope**. It's why the injected `subscribe` in `main-view` above just *worked*, and it's exactly what lets you go multi-frame later without touching a line of app code.
+The frame is **invisible inside its own scope**. That's why the injected `subscribe` in `main-view` just *worked*, and exactly what lets you go multi-frame later without touching a line of app code.
 
 ??? info "For JavaScript developers"
 
@@ -112,7 +107,7 @@ That last point is the payoff: the frame is **invisible inside its own scope**. 
 
 ### Seeding initial state
 
-Notice there's no place to hand the frame config an initial app-db. That's on purpose.
+There's no place to hand the frame config an initial app-db. That's on purpose.
 
 !!! note "A frame's app-db always starts as `{}` — there is no `:db` config key"
 
@@ -136,14 +131,14 @@ Notice there's no place to hand the frame config an initial app-db. That's on pu
 
 ## When you want more than one
 
-Now the reason frames exist. The genuine multi-frame cases, roughly in the order you'll meet them:
+The genuine multi-frame cases, roughly in the order you'll meet them:
 
 - **The same widget twice on one page.** A split pane comparing today against last week. Two panes, two frames, zero shared state.
 - **Story canvases.** "Show this view empty, loading, and loaded, side by side" is one set of handlers and three frames, each seeded differently. The Story runner allocates them; you mostly don't see it.
 - **A fresh frame per test.** Each test gets its own frame, torn down after, so no test can leak state into the next — see [Test a pipeline run](testing/pipeline-runs.md).
 - **A frame per server request.** [Server-side rendering](../ssr/concepts.md) creates a frame per HTTP request, runs the app in it, serialises, destroys it. A hundred concurrent requests are a hundred isolated app-dbs.
 
-The shape is the same every time: **one app, mounted N times, each mount fully isolated.** Multi-frame is never "N half-apps stitched together" — each frame is a complete, self-sufficient world. Two panes: two worlds. Three Story variants: three. A hundred SSR requests: a hundred worlds, each with its own state, its own queue, its own private history, blinking in and out of existence as requests come and go — you're not running an app anymore, you're administering a multiverse. Too much? Fine: N hash maps and N event queues, rigorously fenced. But that fence is the entire point of this page.
+The shape is the same every time: **one app, mounted N times, each mount fully isolated.** Multi-frame is never "N half-apps stitched together" — each frame is a complete world. Two panes: two worlds. Three Story variants: three. A hundred SSR requests: a hundred worlds.
 
 Here's the split pane, end to end. Watch how little changes from the one-frame case:
 
@@ -172,11 +167,11 @@ Here's the split pane, end to end. Watch how little changes from the one-frame c
    [split-screen]])
 ```
 
-Notice what *isn't* there: no pane id threaded through the view, no atom per pane, no "which counter am I" argument on the handler. The view is identical to one you'd write for a single counter. Boundaries simply nest — each pane's `frame-root` overrides the root scope for its own subtree.
+Notice what *isn't* there: no pane id threaded through the view, no atom per pane, no "which counter am I" argument on the handler. The view is identical to one you'd write for a single counter. Boundaries nest — each pane's `frame-root` overrides the root scope for its own subtree.
 
 Click `+` on the left and only the left number moves. Open [Xray](glossary.md#xray), pick the left frame, and you see only that frame's events and app-db; the right frame's ledger never heard about the click. Frames are how every inspection tool partitions the world.
 
-Borderline case? This is where people hesitate, so here's the one question that settles it: *would these two things ever sensibly share a piece of state?* If yes, they are two views over slices of *one* frame's app-db — views on a page compose by sharing app-db, and that's the point of [having one place](app-db.md). If no — if they're genuinely two separate runs of the app — they're two frames. The two panes never want to share a counter. That "no" is the signal.
+Borderline case? One question settles it: *would these two things ever sensibly share a piece of state?* If yes, they are two views over slices of *one* frame's app-db — views on a page compose by sharing app-db, and that's the point of [having one place](app-db.md). If no — if they're genuinely two separate runs of the app — they're two frames. The two panes never want to share a counter. That "no" is the signal.
 
 ### frame-provider and frame-root
 
@@ -214,11 +209,11 @@ One behaviour to internalise before it surprises you: re-mounting `frame-root` i
 
 ## The one rule: frame identity is carried, not found
 
-Everything above rests on a single invariant — the rule that makes isolation *trustworthy*:
+Everything above rests on a single invariant:
 
 > **[Frame identity is a value that travels with the work](glossary.md#frame-identity-is-carried-not-found).** A dispatch, a subscription, a captured callback — each reads its frame from the context it was *given*: the provider above it, the handler it's running in, the frame api that carried it (the captured operations bundle you'll meet below). An operation never goes looking for a frame in the ambient world, and the runtime never invents one from absence.
 
-Stop on that sentence for a second. Everything below — the loud errors, the capture tool, the test macros — is that sentence, enforced.
+Everything below — the loud errors, the capture tool, the test macros — is that sentence, enforced.
 
 So a bare `(rf/dispatch [:counter/inc])` works when — and only when — something above it established a frame: the root provider, the event handler it's firing from, a `with-frame` block in a test or at the REPL. With no established scope and no carried frame, the operation fails loud:
 
@@ -229,7 +224,7 @@ So a bare `(rf/dispatch [:counter/inc])` works when — and only when — someth
  :recovery    :supply-frame}
 ```
 
-Why an error instead of a sensible default? Because a default would make distant code change meaning *silently* — the kind of bug that costs you a weekend.
+Why an error instead of a sensible default? Because a default would make distant code change meaning *silently* — the kind of bug that costs you a weekend. Silent defaults are how cross-frame leaks become production mysteries.
 
 ??? note "Why a default frame would be a trap"
 
@@ -250,9 +245,7 @@ From outside any scope — a test, a tool, the REPL — you name the frame expli
 
 There is no `dispatch-to` / `subscribe-to` sugar — the two-argument opts form is the one mechanism. It's also the right shape from non-Reagent contexts: server-side rendering, headless JVM tests, and tooling agents all address frames this way.
 
-One distinction will save you a confused half-hour, so draw it now. `:rf.error/no-frame-context` is reserved for **absence** — you carried no frame at all. The moment you *do* carry one (`{:frame :ghost}`), you've supplied an explicit target, and a bad target — a typo, or a frame already torn down — is the registry-lookup case instead: `dispatch` quietly no-ops, `subscribe` returns `nil`, and a `:rf.error/frame-destroyed` record lands on the always-on [error stream](glossary.md#error-record). (Same recovery as a [destroyed frame](#ending-and-resetting-a-frame) — the runtime can't tell a typo from a teardown race.) A missing scope and a bad target are two distinct failures. Branch on the category, not the absence.
-
-## Day-one checklist
+One distinction will save you a confused half-hour. `:rf.error/no-frame-context` is reserved for **absence** — you carried no frame at all. The moment you *do* carry one (`{:frame :ghost}`), you've supplied an explicit target, and a bad target — a typo, or a frame already torn down — is the registry-lookup case instead: `dispatch` quietly no-ops, `subscribe` returns `nil`, and a `:rf.error/frame-destroyed` record lands on the always-on [error stream](glossary.md#error-record). (Same recovery as a [destroyed frame](#ending-and-resetting-a-frame) — the runtime can't tell a typo from a teardown race.) A missing scope and a bad target are two distinct failures. Branch on the category, not the absence.
 
 You can wrap your app in one `frame-root {:id …}`, seed it with `:initial-events`,
 and mount the *same* registrations in as many frames as you like — each fully
@@ -265,7 +258,7 @@ second world actually appears.
 
 A [subscription](glossary.md#subscription) — a derived, cached read over app-db — belongs to one frame. It computes from that frame's app-db and from other subscriptions *in that frame*, never from another frame's state. There is no window between worlds: no "read frame B from a sub in frame A" affordance exists, and you must not build one by sneaking a cross-frame read into a sub's computation function. That's the anti-pattern, full stop.
 
-Why so hard a line? Because one cross-frame subscription breaks every per-frame guarantee at once. The reasoning is the same as the carried rule's: isolation is only worth having if it's total. Story variants are reproducible because nothing outside a frame can influence them. SSR requests can run concurrently because no request can observe another. A test frame is hermetic because *nothing* reaches in. One cross-frame sub quietly breaks all three — frame A's derived values now change when frame B does, and every tool that reasons per-frame (the [epoch](glossary.md#epoch) ledger, [time-travel](glossary.md#time-travel), replay) is lying to you about A.
+Why so hard a line? One cross-frame subscription breaks every per-frame guarantee at once. Story variants are reproducible because nothing outside a frame can influence them. SSR requests can run concurrently because no request can observe another. A test frame is hermetic because *nothing* reaches in. One cross-frame sub quietly breaks all three — frame A's derived values now change when frame B does, and every tool that reasons per-frame (the [epoch](glossary.md#epoch) ledger, [time-travel](glossary.md#time-travel), replay) is lying to you about A.
 
 If you feel the need for one, you've answered the discriminator question wrongly: two things that need to share derived state are one frame. Restructure — don't reach across.
 
@@ -279,11 +272,11 @@ If you feel the need for one, you've answered the discriminator question wrongly
 
     Everything on this page assumed the default: all frames draw their handlers from one shared registrar, so every frame runs the same handlers against different app-dbs. The selected slice a frame resolves against has a name — the [**image**](glossary.md#image) — and 99% of the time you never need to think about it. The 1% is when you want two frames to resolve `[:counter/inc]` to *different* handlers: two examples on one page, or an inspection tool sitting beside the app it inspects. Then you give those frames *different* images, and which image a frame points at is what decides its behaviour. That's the [Images](images.md) story; ignore it until you hit a case that needs it.
 
-## Going further
+## Advanced
 
 The rest of the page is here for when a second world makes you reach for it: the
 full frame config, capturing the frame across async boundaries, ending or resetting
-a frame, and the two advanced corners.
+a frame, and two corners of multi-frame drain behaviour.
 
 ## The rest of the frame config
 
@@ -312,7 +305,7 @@ Notes:
 
 The `:observability` sink policy — the production-telemetry key not shown above — is covered in [Observability](observability.md#consuming-production-telemetry-declare-a-sink); the full frame-config grammar is in the [API reference](../api/re-frame.core.md).
 
-One class of mistake is caught before it can hurt you, so know what the catch looks like. Hand the frame config a `:sensitive` or `:large` key (those belong on handler effects, not frame config — see [data classification](glossary.md#data-classification)) or a malformed `:observability` entry, and registration throws `:rf.error/bad-frame-classification` *before* any setup event runs — you never get a half-registered frame. A top-level shape mistake is caught the same way: `{:initial-events [:cart/init]}` — a bare event, not a *vector of* steps — is rejected with a diagnostic that names the fix (wrap it as `[[:cart/init]]`).
+Hand the frame config a `:sensitive` or `:large` key (those belong on handler effects, not frame config — see [data classification](glossary.md#data-classification)) or a malformed `:observability` entry, and registration throws `:rf.error/bad-frame-classification` *before* any setup event runs — you never get a half-registered frame. A top-level shape mistake is caught the same way: `{:initial-events [:cart/init]}` — a bare event, not a *vector of* steps — is rejected with a diagnostic that names the fix (wrap it as `[[:cart/init]]`).
 
 ??? note "Going deeper — three lanes meet at startup; keep them apart"
 
@@ -322,7 +315,7 @@ One class of mistake is caught before it can hurt you, so know what the catch lo
 
 There is exactly one place a frame gets lost: a callback built while a frame was in scope, fired later when the scope is gone. A `setTimeout` tick. A promise continuation. A WebSocket `onmessage`. A `window` listener. A third-party SDK calling you back.
 
-The reason follows straight from the carried rule. A provider's scope is render-time knowledge, and a handler's scope ends when the handler returns. So when the callback finally runs, it's on a fresh stack with no frame anywhere — and a bare `dispatch` inside it raises `:rf.error/no-frame-context`.
+A provider's scope is render-time knowledge, and a handler's scope ends when the handler returns. So when the callback finally runs, it's on a fresh stack with no frame anywhere — and a bare `dispatch` inside it raises `:rf.error/no-frame-context`.
 
 The fix is always the same move: **capture the frame as a value while it's still in scope, and close over it.** The capture tool is [`capture-frame`](glossary.md#capture-frame):
 
@@ -425,8 +418,6 @@ A test or REPL session is *outside* any provider, so there's no ambient scope �
 Note `dispatch-sync` rather than `dispatch`: from outside a running drain it runs the event to completion *before returning*, which is what a test wants to assert against. (Calling `dispatch-sync` from *inside* a handler is an error — `:rf.error/dispatch-sync-in-handler` — because the drain is already running synchronously; the in-handler shape is `:fx [[:dispatch …]]`.) The test-fixture idiom in full — seeding, stubs, and the two macros' argument-shape guards — is [Test a pipeline run](testing/pipeline-runs.md)'s territory.
 
 One cliff edge, before you walk off it: `with-frame` establishes the frame via a dynamic var, which evaporates the instant control crosses an async boundary. An async callback created inside a `with-frame` body that fires *after* the body returns is back in frameless territory — and `with-new-frame` has already destroyed its frame by then. It's the same async cliff as the WebSocket above, and the same fix applies: capture a frame api with `capture-frame` (or pass an explicit `{:frame …}`) before the boundary.
-
-## Advanced
 
 Two corners you can ignore until a multi-frame app makes you reach for them. Both follow from "frames are independent state machines" — the same root as everything above.
 

--- a/docs/core/glossary.md
+++ b/docs/core/glossary.md
@@ -1,14 +1,14 @@
 # Glossary
 
-A catalog of re-frame2's nouns, verbs, and concepts.
+re-frame2 nouns, verbs, and concepts. One term, definition first; short code when the spelling matters; Related points at the teaching page.
 
 ## The Nouns
 
 ### **adapter**
 
-re-frame2 renders through one of several React-family rendering libraries — Reagent or UIx (its [substrate](#substrate)). An **adapter** is the small map of "glue" functions that wires re-frame2's core to the substrate you picked. It's a *value*, not the library itself.
+A map of functions that binds re-frame2 core to a React-family [substrate](#substrate) (Reagent, UIx, …). A *value*, not the library itself.
 
-You install it once, at boot, by passing it to `init!`:
+Install once at boot via `init!`:
 
 ```clojure
 (ns app.core
@@ -18,17 +18,16 @@ You install it once, at boot, by passing it to `init!`:
 (rf/init! reagent-adapter/adapter)
 ```
 
-To switch substrate you change that one line — require `re-frame.adapter.uix` and pass *its* `adapter`. Nothing else moves: your events, subscriptions, and app-db are substrate-agnostic.
+To switch substrate, change that require and pass its `adapter`. Events, subscriptions, and app-db stay the same.
 
-Related: [Views](views.md), [Adapters](../api/re-frame.adapter.reagent.md). Don't confuse it with the [substrate](#substrate) — the substrate is the rendering library; the adapter is the value that binds re-frame2 to it.
+Related: [Views](views.md), [Adapters](../api/re-frame.adapter.reagent.md). Substrate = the rendering library; adapter = the value that binds re-frame2 to it.
 
 ### **app-db**
 
-The single, immutable map that holds your application's state — one per [frame](#frame), and the one source of truth your code owns. 
+The single immutable map of application state — one per [frame](#frame), the state your code owns.
 
-You design the map's shape to fit your app, and can optionally guard it with a schema (Malli by default). You never mutate it directly: an [event handler](#event-handler) returns a *new* app-db, the framework commits it atomically, and your [subscriptions](#subscription) re-derive the [views](#view) from the new value. State flows **in** through events and **out** through subscriptions — never the reverse.
+You choose the shape; optionally guard it with a schema (Malli by default). You never mutate it in place: an [event handler](#event-handler) returns a *new* app-db, the runtime commits it atomically, and [subscriptions](#subscription) re-derive [views](#view) from that value. State enters through events and leaves through subscriptions — never the reverse.
 
-An example shape:
 ```clojure
 {:cart  {:items [{:sku "BK-1" :qty 2}]
          :open? false}
@@ -36,30 +35,30 @@ An example shape:
  :route {:page :checkout}}
 ```
 
-Note: The framework keeps *its* own state separately in [runtime-db](#runtime-db) within a [frame](#frame); see [the two partitions](#the-two-partitions).
+Framework state lives separately in [runtime-db](#runtime-db) inside the same frame; see [the two partitions](#the-two-partitions).
 
 Related: [app-db](app-db.md), [Validate with schemas](how-to/validate-with-schemas.md).
 
 ### **path**
 
-A vector of keys addressing one location inside [app-db](#app-db), with `get-in` / `assoc-in` semantics — `[:auth :token]` names the `:token` entry inside the `:auth` map. Paths are the framework-wide addressing vocabulary: an app-db [schema](#schema) binds to a path, a [data-classification](#data-classification) mark names one, a [flow](#flow) writes its `:output-path`, and the `path` interceptor narrows a handler to one.
+A vector of keys into [app-db](#app-db), with `get-in` / `assoc-in` semantics — `[:auth :token]` is the `:token` under `:auth`. Paths are the addressing form used by schemas, [data-classification](#data-classification), flow `:output-path`, and the `path` interceptor.
 
 Related: [app-db](app-db.md).
 
 ### **coeffect**
 
-A fact about the world — the current time, a fresh UUID, a value from local storage — that the framework supplies to an [event handler](#event-handler) as data, so the handler stays a pure function and never reaches out to the world itself. A handler is a pure function from coeffects to an [effect map](#effect-map): the world flows *in* as coeffects and *out* as [effects](#effect).
+A fact about the world (current time, fresh UUID, localStorage value, …) the runtime supplies to an [event handler](#event-handler) as data so the handler stays pure and never reaches out itself. Handler shape: coeffects in → [effect map](#effect-map) out.
 
-A handler's first argument is its coeffects map. It always carries `:db` (the current value of [app-db](#app-db)). Any *other* fact must be declared up front in the event's metadata under `:rf.cofx/requires`, and the framework supplies it:
+The first argument is always a coeffects map with `:db` (current [app-db](#app-db)). Any other fact must be listed under `:rf.cofx/requires`; the runtime fills it in:
 
 ```clojure
 (rf/reg-event :order/place
-  {:rf.cofx/requires [:today]}           ;; :today is a required coeffect
-  (fn [{:keys [db today]} _]             ;; the key :today will appear in the coeffects map
+  {:rf.cofx/requires [:today]}
+  (fn [{:keys [db today]} _]
     {:db (assoc db :order/date today)}))
 ```
 
-You make a coeffect available by registering a supplier for it with [`reg-cofx`](../api/re-frame.core.md#reg-cofx):
+Register a supplier with [`reg-cofx`](../api/re-frame.core.md#reg-cofx):
 
 ```clojure
 (rf/reg-cofx :today
@@ -67,47 +66,47 @@ You make a coeffect available by registering a supplier for it with [`reg-cofx`]
     (subs (.toISOString (js/Date.)) 0 10)))
 ```
 
-Declaring the world this way — rather than reading it inside the handler — is what makes events pure, testable, and replayable.
+Declared input is what keeps events pure, testable, and replayable.
 
 Related: [Effects](effects.md), [Coeffects](coeffects.md).
 
 ### **effect**
 
-A single side effect, described as data for the framework to perform — an HTTP request, a navigation, a delayed dispatch, a write to local storage. An effect is a `[effect-id config]` pair, and effects ride in the `:fx` vector of an [effect map](#effect-map):
+One side effect described as data for the runtime — HTTP, navigation, delayed dispatch, localStorage write. Shape: `[effect-id config]`, listed in the `:fx` vector of an [effect map](#effect-map):
 
 ```clojure
-[:dispatch-later {:ms 500 :event [:cart/saved]}]   ;; one effect
+[:dispatch-later {:ms 500 :event [:cart/saved]}]
 ```
 
-The [event handler](#event-handler) only *describes* the effect; the runtime performs it, via the [effect handler](#effect-handler) you registered for that `effect-id` with [`reg-fx`](../api/re-frame.core.md#reg-fx). Effects are the output side of an event — the dual of its input [coeffects](#coeffect) — and keeping them as data, rather than doing them inline, is what makes events pure and testable.
+The [event handler](#event-handler) only *describes* the effect; the [effect handler](#effect-handler) registered with [`reg-fx`](../api/re-frame.core.md#reg-fx) performs it. Effects are the output dual of input [coeffects](#coeffect).
 
 Related: [Effects](effects.md), [Coeffects](coeffects.md).
 
 ### **effect handler**
 
-The function — registered with `reg-fx` for a given `effect-id` — that actually *performs* an [effect](#effect). The runtime calls it once for each effect in a handler's `:fx` vector, passing that effect's config. This is where the real, impure work happens (the HTTP call, the navigation, the `localStorage` write) — which is exactly why it's kept *out* of the pure [event handler](#event-handler): the event handler describes effects as data; the effect handler carries them out.
+The function registered with `reg-fx` for an `effect-id`. The runtime calls it once per matching entry in `:fx`, with that effect's config. Impure work lives here so the pure [event handler](#event-handler) stays data-only.
 
 ```clojure
-(rf/reg-fx :cart/save             ;; teach the runtime a new effect
-  (fn [_ctx {:keys [items]}]      ;; (fn [ctx args]) — args is the effect's config
-    (save-to-server! items)))     ;; and does the impure work
+(rf/reg-fx :cart/save
+  (fn [_ctx {:keys [items]}]
+    (save-to-server! items)))
 ```
 
-re-frame2 ships handlers for the common effects (`:dispatch`, `:dispatch-later`, `:rf.http/managed`, …); you register your own with `reg-fx`.
+Built-ins cover common effects (`:dispatch`, `:dispatch-later`, `:rf.http/managed`, …); add your own with `reg-fx`.
 
 Related: [Effects](effects.md), [Coeffects](coeffects.md).
 
 ### **effect map**
 
-The map an [event handler](#event-handler) — or a [machine](../machines/glossary.md#machine) action — returns to describe how the world should change. The handler never makes the change itself; it's a pure function that returns this *description*, and the framework carries it out.
+What an [event handler](#event-handler) — or a [machine](../machines/glossary.md#machine) action — returns: a *description* of change, not the change itself.
 
-It has two reserved keys. `:db` is the new [app-db](#app-db) value — "replace app-db with this":
+Two reserved keys. `:db` is the new [app-db](#app-db):
 
 ```clojure
 {:db new-db}
 ```
 
-`:fx` is a vector of [effects](#effect) — each a `[effect-id config]` pair describing one side effect to perform (an HTTP call, a delayed dispatch, navigation, local storage, …):
+`:fx` is a vector of [effects](#effect) — each `[effect-id config]`:
 
 ```clojure
 {:db new-db
@@ -115,119 +114,124 @@ It has two reserved keys. `:db` is the new [app-db](#app-db) value — "replace 
       [:dispatch-later {:ms 500 :event [:cart/saved]}]]}
 ```
 
-`:db` and `:fx` are the only top-level keys application code may return; an unknown key fails loud. Each effect is performed by an [effect handler](#effect-handler); register your own with [`reg-fx`](../api/re-frame.core.md#reg-fx).
+Only `:db` and `:fx` may appear at the top level; an unknown key fails loud. Each effect runs through an [effect handler](#effect-handler) (`reg-fx`).
 
-Related: [Effects](effects.md), [Coeffects](coeffects.md). The `:fx` key is why effects are often just called "fx".
+Related: [Effects](effects.md), [Coeffects](coeffects.md). Casual name for the `:fx` key: "fx".
 
 ### **error record**
 
-A failure the framework surfaces as a structured map rather than a thrown, silent, or swallowed error — it [fails loud](#fail-loud-not-silent), but as *data*. Every record is keyed by a reserved **`:rf.error/*` category** drawn from a fixed catalogue: traced/listener records carry it under `:operation`; the few construction-time errors that *throw* carry it as `:rf.error/id` in the exception's `ex-data`. Either way, **branch on the category**, never on the human-readable `:reason` (which is prose for people and can change).
+A failure the runtime surfaces as a structured map — [fails loud](#fail-loud-not-silent), as data. Every record carries a reserved **`:rf.error/*` category**: on traced/listener records under `:operation`; on construction-time throws as `:rf.error/id` in `ex-data`. **Branch on the category**, never on human-readable `:reason` (prose; can change).
 
 ```clojure
 {:operation :rf.error/no-frame-context
  :reason    "no frame in scope"}
 ```
 
-Error records fan out to your always-on error listeners (Sentry, Datadog, …), so — unlike the dev-only trace surface — they **survive production**. Build your monitoring on them.
+Error records reach always-on error listeners (Sentry, Datadog, …) and **survive production** (unlike the dev-only trace surface).
 
 Related: [Errors](errors.md).
 
 ### **event**
 
-An inert data vector recording a fact: *something happened*. You [dispatch](#dispatch) an event; a registered [event handler](#event-handler) decides what to do in response — the event itself does nothing.
+An inert data vector: *something happened*. You [dispatch](#dispatch) it; a registered [event handler](#event-handler) decides the response. The event itself does nothing.
 
-Most events are user intent — a click, a drag, a route change, a tab switch — but timers, browser APIs, WebSockets, and route loaders raise them too. The first element is an identifier (a namespaced keyword is the norm), optionally carrying facts:
+Most events are user intent (click, drag, route change); timers, browser APIs, WebSockets, and loaders raise them too. First element is the id (namespaced keyword is the norm), then optional facts:
 
 ```clojure
 [:event-id & facts]
 ```
 
-Prefer a single map payload over positional arguments — it's self-describing and stays stable as the event grows:
+Prefer one payload map over positional args:
 
 ```clojure
-[:cart/add-item {:sku "BK-1" :qty 1}]    ;; good — a named payload
-[:cart/add-item "BK-1" 1]                ;; placeful and fragile
+[:cart/add-item {:sku "BK-1" :qty 1}]    ;; good
+[:cart/add-item "BK-1" 1]                ;; placeful
 ```
 
-Because an event is just data, it can be logged, recorded, and replayed — the basis of re-frame2's testability and time-travel.
+Data means log, record, and replay.
 
 Related: [Introduction](introduction.md).
 
 <a id="event-cascade"></a>
 ### **event pipeline**
 
-The fixed stage sequence one dispatched [event](#event) traverses, in three **phases**: the [**update phase**](#update-phase) computes a *description* of the change, the [**commit phase**](#commit-phase) executes the declared effects — the `:db` write first, atomically — and the [**render phase**](#render-phase) brings the derivations and the screen up to date. The update and commit phases run per event — [assemble](#assemble) → [transform](#transform) → [commit](#commit) → [perform](#perform); the render phase runs once per [render batch](#render-batch), after the queue settles — [derive](#derive) → [render](#render).
+The fixed stage sequence one dispatched [event](#event) runs through, in three **phases**:
+
+- [**update phase**](#update-phase) — compute a *description* of the change
+- [**commit phase**](#commit-phase) — run declared effects; `:db` write first, atomically
+- [**render phase**](#render-phase) — bring derivations and the screen up to date
+
+Update and commit run per event — [assemble](#assemble) → [transform](#transform) → [commit](#commit) → [perform](#perform). Render runs once per [render batch](#render-batch) after the queue settles — [derive](#derive) → [render](#render).
 
 ```clojure
-;; update + commit phases (per event):  assemble → transform → commit → perform
-;; render phase    (per render batch):  derive → render
+;; update + commit (per event):  assemble → transform → commit → perform
+;; render         (per batch):   derive → render
 ```
 
-The `:db` write is the anchor: the pipeline is transactional up to it and best-effort after it, and the [view](#view) renders once, from the committed state — never mid-run.
+`:db` is the anchor: transactional up to that write, best-effort after. The [view](#view) renders from committed state, never mid-run.
 
-One traversal of the pipeline is a [**run**](#run); the record a run leaves behind is an [**epoch**](#epoch). Read the triple as **pipeline** (the structure) / **run** (one traversal) / **epoch** (the record). The to-fixed-point family — running the whole queue before the render phase — is a [**drain**](#drain--run-to-completion).
+One traversal is a [**run**](#run); the record it leaves is an [**epoch**](#epoch). Triple: **pipeline** (structure) / **run** (one trip) / **epoch** (record). Running the whole queue before render is a [**drain**](#drain--run-to-completion).
 
-Related: [Introduction](introduction.md). (Older prose called this the *event cascade*, a *turn of the loop*, or simply *the loop*; those spellings are retired for the event-traversal sense — prefer **event pipeline** / **pipeline run**. The machines *cancellation cascade* keeps its name.)
+Related: [Introduction](introduction.md). Older prose said *event cascade*, *turn of the loop*, or *the loop* for this traversal — prefer **event pipeline** / **pipeline run**. Machines *cancellation cascade* keeps its name.
 
 ### **run**
 
-One traversal of the [event pipeline](#event-pipeline) — a single dispatched [event](#event) carried through every stage: its update and commit phases, then the shared render phase of the [render batch](#render-batch) it settles into. It's the middle term of the triple: the [**pipeline**](#event-pipeline) is the fixed structure, a **run** is one trip through it, and the [**epoch**](#epoch) is the record that trip leaves. One dispatch = one run = one epoch. (A whole queue run to a fixed point before the render phase is a [drain](#drain--run-to-completion) — many runs, always sharing one render batch.)
+One traversal of the [event pipeline](#event-pipeline) for a single dispatched [event](#event): update and commit for that event, then the shared render of the [render batch](#render-batch) it settles into. [**Pipeline**](#event-pipeline) = structure; **run** = one trip; [**epoch**](#epoch) = the record. One dispatch = one run = one epoch. A [drain](#drain--run-to-completion) is many runs, one render batch.
 
 Related: [Introduction](introduction.md).
 
 <a id="write-side"></a>
 ### **update phase**
 
-The first phase of the [event pipeline](#event-pipeline) — [assemble](#assemble) → [transform](#transform) — the handler's **pure computation**, once per [event](#event): build the [world](#world), run the handler over it, and produce a *description* of the change (the new value and the declared effects). Nothing has happened yet — the phase yields intent, as data. A throwing handler installs nothing.
+First phase of the [event pipeline](#event-pipeline) — [assemble](#assemble) → [transform](#transform). Pure work once per [event](#event): build the [world](#world), run the handler, produce a description of change (new value + declared effects). Nothing has executed yet. A throwing handler installs nothing.
 
 Related: [Introduction](introduction.md).
 
 ### **commit phase**
 
-The second phase — [commit](#commit) → [perform](#perform) — where the declared effects **execute**, once per [event](#event). The `:db` write is one of those effects, special **only** in that it is guaranteed to run *first*: the new [app-db](#app-db) lands atomically, in one step, before any other effect fires; the remaining effects then run in source order, best-effort. **Pre-commit** and **post-commit** name positions relative to that first write. Nothing crosses to the [render phase](#render-phase) except the committed value.
+Second phase — [commit](#commit) → [perform](#perform). Declared effects **execute**, once per [event](#event). The `:db` write always runs *first*: new [app-db](#app-db) lands atomically before other effects; remaining effects then run in source order, best-effort. **Pre-commit** / **post-commit** are positions relative to that write. Only the committed value reaches the [render phase](#render-phase).
 
 Related: [Effects](effects.md), [Introduction](introduction.md).
 
 <a id="read-side"></a>
 ### **render phase**
 
-The final phase — [derive](#derive) → [render](#render) — the part that brings the screen up to date once the queue has settled. It runs once per [**render batch**](#render-batch), not once per event: it reads only the value the [commit](#commit) landed, it never sees a half-written [app-db](#app-db), and a [drain](#drain--run-to-completion) is never split across batches, however many events it settled.
+Final phase — [derive](#derive) → [render](#render). Brings the screen up to date after the queue settles. Once per [**render batch**](#render-batch), not once per event: reads only the committed value, never a half-written [app-db](#app-db). A [drain](#drain--run-to-completion) is never split across batches.
 
 Related: [Subscriptions](subscriptions.md), [Introduction](introduction.md).
 
 ### **render batch**
 
-The window of pending reads and renders the [render phase](#render-phase) works through in one go. Everything marked dirty since the last batch renders together, once — and the batch closes at the host's next microtask checkpoint, or, in headless tests, at an explicit flush.
+The window of pending reads and renders the [render phase](#render-phase) finishes in one go. Everything dirty since the last batch renders together. The batch closes at the host's next microtask checkpoint, or at an explicit flush in headless tests.
 
-The boundary belongs to the *host*, not to the [drain](#drain--run-to-completion): the UI scheduler takes no signal from the event queue and never observes a drain boundary at all. Two things follow, and both are what you want.
+The boundary is the *host*'s, not the [drain](#drain--run-to-completion)'s: the UI scheduler does not observe the event queue or drain edges.
 
-- **A drain can never be split across batches.** Every event a drain settles renders together, so no intermediate state ever reaches the screen. This is the promise you actually lean on.
-- **Drains that finish before the same checkpoint may share a batch.** Two back-to-back `dispatch-sync` calls in one JavaScript stack render once, together; drains separated by a real host yield render separately.
+- **A drain cannot split across batches.** Every event a drain settles renders together; no intermediate state hits the screen.
+- **Drains that finish before the same checkpoint may share a batch.** Two back-to-back `dispatch-sync` calls in one JS stack render once; drains separated by a real host yield render separately.
 
-In ordinary application code a yield falls between drains, so this reads as "one render per drain" — a fine working model, as long as you hold it as the common case rather than the rule.
+In ordinary app code a yield falls between drains, so "one render per drain" is a fine working model for the common case, not a hard rule.
 
 Related: [render phase](#read-side), [drain](#drain--run-to-completion), [Effects — run to completion](effects.md#run-to-completion).
 
 ### **world**
 
-The map of declared facts assembled for an [event handler](#event-handler) to read — everything from the outside the handler is allowed to see, gathered as data. [app-db](#app-db) is one entry (always present, under `:db`), not otherwise special; the clock, a fresh id, a storage read are other entries a handler declares with `:rf.cofx/requires`. The world is the handler's first argument — its [coeffects](#coeffect) map — assembled by the pipeline's [assemble](#assemble) stage before the handler runs.
+The map of declared facts assembled for an [event handler](#event-handler) — everything outside the handler is allowed to see, as data. [app-db](#app-db) is one entry (always present, under `:db`); clock, fresh id, storage reads are others declared via `:rf.cofx/requires`. The world is the handler's first argument — its [coeffects](#coeffect) map — built in the [assemble](#assemble) stage.
 
 ```clojure
-;; the assembled world a handler receives — app-db is just one fact in it
 {:db {…}  :today "2026-07-04"  :new-id #uuid "…"}
 ```
 
-A [**frame**](#frame) is a *running* world: a world plus the runtime machinery (queue, caches, lifecycle) that keeps it alive and re-assembles it per event.
+A [**frame**](#frame) is a *running* world: that map plus queue, caches, and lifecycle that re-assemble it per event.
 
 Related: [Effects](effects.md), [Coeffects](coeffects.md), [frame](#frame).
 
 ### **event envelope**
 
-The runtime package created when an [event](#event) is dispatched. This is a low level concept tied to the runtime.
+Runtime package created when an [event](#event) is dispatched. Low-level; mostly router-internal.
 
-App code `dispatches` an `event` (vector), sometimes with extra dispatch options. Before the event is queued, re-frame2 wraps those values into an event envelope. The envelope carries the event vector plus the runtime facts needed to process it: the target [frame](#frame), where the event came from, tracing ids, per-dispatch overrides, and the durable `:rf.cofx` record used for replayable coeffects such as `:rf/time-ms`.
+App code dispatches an event vector (optionally with dispatch opts). Before queueing, re-frame2 wraps those into an envelope: the event vector plus target [frame](#frame), origin, tracing ids, per-dispatch overrides, and the durable `:rf.cofx` record used for replayable coeffects such as `:rf/time-ms`.
 
-Most application code never reads an event envelope directly. It is the router's internal work item. Event handlers receive the envelope's event vector as their second argument, and receive an assembled map of [coeffects](#coeffect) as their first argument.
+Handlers get the event vector as their second argument and an assembled [coeffects](#coeffect) map as their first — not the envelope itself.
 
 ```clojure
 (rf/dispatch [:cart/add {:sku "BK-1"}]
@@ -235,7 +239,7 @@ Most application code never reads an event envelope directly. It is the router's
    :source :ui
    :trace-id :cart/add-click})
 
-;; The router queues an envelope shaped roughly like:
+;; Rough envelope shape:
 {:event    [:cart/add {:sku "BK-1"}]
  :frame    :checkout
  :source   :ui
@@ -248,15 +252,13 @@ Related: [Introduction](introduction.md), [Frames](frames.md), [Effects](effects
 
 ### **event handler**
 
-A **pure** function that computes how a dispatched [event](#event) should change the world. It takes two arguments — a map of [coeffects](#coeffect) (the facts it needs, `:db` among them) and the event vector — and returns an [effect map](#effect-map):
+A **pure** function that computes how a dispatched [event](#event) should change the world. Arguments: [coeffects](#coeffect) map (including `:db`) and the event vector; return: [effect map](#effect-map).
 
 ```text
 (coeffects, event-vector) -> effect-map
 ```
 
-It *describes* changes, it doesn't perform them: typically a `:db` value ("replace app-db with this") plus any `:fx` for other side effects. Because it's pure — no IO, no clock, no reading subscriptions; the world arrives only through declared coeffects — it's trivially testable and replayable.
-
-Register one with `reg-event`:
+It *describes* changes (`:db`, `:fx`); it does not perform them. No IO, no clock, no subscription reads inside — world arrives only through declared coeffects.
 
 ```clojure
 (rf/reg-event :cart/add
@@ -268,9 +270,9 @@ Related: [Introduction](introduction.md).
 
 ### **flow**
 
-A pure derivation that re-frame2 keeps materialised at a path in [app-db](#app-db). The point: because the derived value lives *in* app-db, your [event handlers](#event-handler) can read it as plain state — whereas a [subscription](#subscription)'s value is only available to [views](#view).
+A pure derivation re-frame2 keeps materialised at a path in [app-db](#app-db). Because the value lives *in* app-db, [event handlers](#event-handler) can read it as plain state — unlike a [subscription](#subscription), whose value is for [views](#view).
 
-You declare the `:inputs` to watch, a pure `:derive` function, and the `:output-path` to maintain; whenever an input changes, the framework re-runs `:derive` and writes the result, in step with the [event pipeline](#event-pipeline):
+Declare `:inputs`, a pure `:derive`, and `:output-path`. When an input changes, the runtime re-runs `:derive` and writes the result in step with the [event pipeline](#event-pipeline):
 
 ```clojure
 (rf/reg-flow
@@ -279,48 +281,48 @@ You declare the `:inputs` to watch, a pure `:derive` function, and the `:output-
    :output-path [:cart :total]})
 ```
 
-Reach for a flow to collate or collapse many facts into one — e.g. folding several error flags into a single `:any-errors?`. Inputs may also read framework state (a path under `:rf.db/runtime`), and flows can be [added and removed dynamically](../api/re-frame.flows.md) via effects.
+Use a flow to collate many facts into one (e.g. several error flags → `:any-errors?`). Inputs may read framework state under `:rf.db/runtime`. Flows can be [added and removed dynamically](../api/re-frame.flows.md) via effects.
 
 Related: [Flows](flows.md), [toggling a derivation at runtime](flows.md#toggling-a-derivation-at-runtime).
 
 ### **frame**
 
-An isolated, running instance of an app. **A frame is a running [world](#world)** — a world (the map of declared facts, [app-db](#app-db) among them) plus the runtime machinery that keeps it alive: its [runtime-db](#runtime-db), event queue, subscription cache, and lifecycle.
+An isolated running instance of an app. **A frame is a running [world](#world)** — declared facts ([app-db](#app-db) among them) plus runtime machinery: [runtime-db](#runtime-db), event queue, subscription cache, lifecycle.
 
-A frame supplies *state*; its *behaviour* comes from an [image](#image). Crucially, **a frame isolates state, not registrations** — the registry is process-global, so the *same* event handlers, subscriptions, views, effects, flows, and machines run in every frame, each against that frame's own state. Most frames use the default image (all registrations); advanced setups hand a frame a *selected* one.
+A frame supplies *state*; *behaviour* comes from an [image](#image). **A frame isolates state, not registrations** — the registry is process-global, so the same handlers, subs, views, effects, flows, and machines run in every frame against that frame's own state. Most frames use the default image (all registrations).
 
-Most apps create one frame at boot and then forget about it. But because frames are independent, you can run several app instances on one page: short-lived frames power tests, stories, and per-request server rendering, and a sidecar tool like [Xray](#xray) is just a separate app in its own frame. A frame's [identity is carried, not found](#frame-identity-is-carried-not-found) — each operation reads its frame from scope.
+Most apps create one frame at boot. Multiple frames on one page power tests, stories, per-request SSR, and tools like [Xray](#xray). [Identity is carried, not found](#frame-identity-is-carried-not-found) — each operation reads its frame from scope.
 
 ```clojure
 (rf/make-frame
   {:id :app
    :initial-events [[:app/initialise]]
-   :images [image1 image2]})    ;; optional: a selected composition of registrations
+   :images [image1 image2]})    ;; optional selected registrations
 ```
 
 Related: [Frames](frames.md).
 
 ### **capture-frame**
 
-`(rf/capture-frame)` captures a [frame](#frame) as a *value* — a **frame api**: a small bundle of that frame's `:dispatch` / `:dispatch-sync` / `:subscribe` ops, plus the captured `:frame` id. Carry it across an async boundary — grab one while the frame is in scope, and a later `setTimeout`, promise, or WebSocket callback can still dispatch into the right frame instead of raising `:rf.error/no-frame-context`. (`capture-frame` is the verb; the *frame api* is the value it returns — spelled lowercase so it never reads as the public re-frame2 API.)
+`(rf/capture-frame)` returns a **frame api**: a small map with that frame's `:dispatch` / `:dispatch-sync` / `:subscribe` plus the captured `:frame` id. Carry it across async — grab while the frame is in scope so a later `setTimeout`, promise, or WebSocket callback can still target it instead of raising `:rf.error/no-frame-context`. (*capture-frame* = verb; *frame api* = value returned.)
 
 Related: [Frames](frames.md).
 
 ### **frame-provider**
 
-The React component that *scopes* an existing [frame](#frame) to a view subtree, so `dispatch`/`subscribe` inside resolve to it. SCOPE-only — **roots ensure; providers scope**: `{:frame existing-id}` provides an already-created frame's id down through React context, creating and destroying nothing, and fails loud if the frame is absent. Given an `:id` (the ENSURE key) it fails loud naming its sibling [`frame-root`](#frame-root). (The everyday expression of [frame identity is carried, not found](#frame-identity-is-carried-not-found).)
+React component that *scopes* an existing [frame](#frame) to a view subtree so `dispatch`/`subscribe` resolve to it. SCOPE-only — **roots ensure; providers scope**: `{:frame existing-id}` provides an already-created id via React context; creates and destroys nothing; fails loud if the frame is missing. Given `:id` (ENSURE key) it fails loud naming sibling [`frame-root`](#frame-root). Everyday expression of [frame identity is carried, not found](#frame-identity-is-carried-not-found).
 
 Related: [Frames](frames.md).
 
 ### **frame-root**
 
-The React component that *ensures* a named [frame](#frame) for a view subtree's mounted lifetime — the ENSURE sibling of [`frame-provider`](#frame-provider). Keyed by `{:id …}` (plus any `make-frame` opts), it creates the frame if absent — at commit, in a client layout effect, so a render React discards creates nothing — reuses it without re-seeding if present (hot reload and StrictMode remounts preserve app-db and never replay `:initial-events`), and provides its id to descendants. It never destroys the frame on unmount; true ownership is explicit `make-frame` + `destroy-frame!`. Given a `:frame` it fails loud naming `frame-provider`.
+React component that *ensures* a named [frame](#frame) for a subtree's mounted lifetime — ENSURE sibling of [`frame-provider`](#frame-provider). Keyed by `{:id …}` (plus `make-frame` opts): creates if absent (at commit, in a client layout effect — discarded React renders create nothing), reuses without re-seeding if present (hot reload / StrictMode preserve app-db; never replay `:initial-events`), provides id to descendants. Does not destroy on unmount; ownership is explicit `make-frame` + `destroy-frame!`. Given `:frame` it fails loud naming `frame-provider`.
 
 Related: [Frames](frames.md).
 
 ### **hiccup**
 
-The plain Clojure data that describes your UI: nested vectors where `[:div.card {:on-click f} "Hi"]` is a `<div>`. Because markup is *data*, not a template language, a [view](#view) composes and diffs cheaply and even renders to a string on the server — and the [substrate](#substrate) turns it into real React elements.
+Clojure data for UI: nested vectors — `[:div.card {:on-click f} "Hi"]` is a `<div>`. Markup as data; a [view](#view) composes it; the [substrate](#substrate) turns it into React elements (or a server string).
 
 ```clojure
 [:ul.cart (for [item items] [:li {:key (:sku item)} (:name item)])]
@@ -330,11 +332,11 @@ Related: [Views](views.md).
 
 ### **image**
 
-The selected set of registrations a [frame](#frame) resolves its behaviour against — [event handlers](#event-handler), [subscriptions](#subscription), [views](#view), [effect handlers](#effect-handler), [flows](#flow), [machines](../machines/glossary.md#machine), and the rest. An image is a *value*: it's not a running app and holds no state.
+The selected set of registrations a [frame](#frame) resolves behaviour against — [event handlers](#event-handler), [subscriptions](#subscription), [views](#view), [effect handlers](#effect-handler), [flows](#flow), [machines](../machines/glossary.md#machine), and the rest. An image is a *value*: no state, not a running app.
 
-Most apps use the **default image** automatically — "all the registrations already loaded." You name an image explicitly only when different frames need different behaviour: a test frame with fake effects, two examples that reuse the same event ids, or a sidecar tool like [Xray](#xray).
+Most apps use the **default image** — all registrations already loaded. Name an image when frames need different behaviour (fake effects in tests, two examples sharing event ids, [Xray](#xray) sidecar).
 
-The rule that ties it to a frame: **the image supplies behaviour; the [frame](#frame) supplies state.** When a frame starts, its image is resolved into a sealed registration set (its *generation*) — but most of the time that rule is all you need.
+**Image supplies behaviour; [frame](#frame) supplies state.** On start, the image resolves into a sealed registration set (*generation*).
 
 ```clojure
 (def checkout-image
@@ -349,18 +351,18 @@ Related: [Images](images.md).
 
 ### **generation**
 
-The sealed registration set a [frame](#frame)'s [image](#image) selection resolves into when the frame is constructed — the concrete "which handler answers this id" table the frame runs against, frozen as a value. Every `make-frame` frame carries one (the default image seals into a generation too); re-calling `make-frame` against the same `:id` with a new `:images` vector swaps a frame onto a freshly resolved generation.
+The sealed registration set a [frame](#frame)'s [image](#image) resolves into at construction — the concrete "which handler answers this id" table, frozen as a value. Every `make-frame` frame carries one (default image included). Re-calling `make-frame` with the same `:id` and a new `:images` vector swaps the frame onto a newly resolved generation.
 
 Related: [Images](images.md).
 
 ### **interceptor**
 
-A named, reusable wrapper around an [event handler](#event-handler) — a pair of `:before` / `:after` functions for cross-cutting concerns (logging, validation, tracing, undo, injecting effects). Each is a `context → context` function:
+A named wrapper around an [event handler](#event-handler) — `:before` / `:after` functions for cross-cutting work (logging, validation, tracing, undo). Each is `context → context`:
 
-- `:before` runs before the handler and can read or adjust its [coeffects](#coeffect);
-- `:after` runs after and can read or adjust the [effect map](#effect-map) it returned.
+- `:before` runs before the handler; can read/adjust [coeffects](#coeffect)
+- `:after` runs after; can read/adjust the returned [effect map](#effect-map)
 
-Interceptors are registered by id with `reg-interceptor` (never written inline), and an event opts into them by id:
+Register by id with `reg-interceptor` (never inline). Events opt in by id:
 
 ```clojure
 (rf/reg-interceptor :my-app/logger
@@ -368,7 +370,7 @@ Interceptors are registered by id with `reg-interceptor` (never written inline),
    :after  (fn [ctx] ctx)})
 
 (rf/reg-event :cart/add
-  {:interceptors [:my-app/logger]}    ;; opt in by id
+  {:interceptors [:my-app/logger]}
   (fn [{:keys [db]} [_ item]]
     {:db (update db :cart/items conj item)}))
 ```
@@ -377,32 +379,33 @@ Related: [Interceptors](interceptors.md).
 
 ### **query vector**
 
-The vector you hand `subscribe` to read a [subscription](#subscription): an id plus any arguments — `[:article/page "abc"]`. The id picks the subscription; the rest are its arguments, and the whole vector keys the subscription cache, so two equal query vectors share one cached value.
+The vector passed to `subscribe` for a [subscription](#subscription): id plus optional args — `[:article/page "abc"]`. Id selects the sub; the whole vector keys the cache, so equal vectors share one cached value.
 
 ```clojure
-@(rf/subscribe [:cart/count])             ;; id only
-@(rf/subscribe [:article/by-id "BK-1"])   ;; id + argument
+@(rf/subscribe [:cart/count])
+@(rf/subscribe [:article/by-id "BK-1"])
 ```
 
 Related: [Subscriptions](subscriptions.md).
 
 ### **registrar**
 
-The single, process-wide table every `reg-*` form writes to and every lookup reads from, keyed by kind + id. It holds *all* your [registrations](#registration) — events, subs, effects, views, machines — and **every [frame](#frame) shares the one registrar** rather than keeping its own copy. That's the mechanism behind "a frame isolates state, not behaviour."
+The single process-wide table every `reg-*` writes and every lookup reads, keyed by kind + id. Holds all [registrations](#registration). **Every [frame](#frame) shares one registrar** — frames isolate state, not behaviour.
 
 ### **registration**
 
-An app's behaviour is defined by the registrations you provide.
+An app's behaviour is the set of registrations you provide.
 
-A single registration maps an `id`, usually a namespaced keyword, to a function or configuration the runtime can look up later.
+One registration maps an `id` (usually a namespaced keyword) to a function or config the runtime looks up later.
 
 At runtime:
 
 - a [frame](#frame) supplies isolated state and execution context
 - an [image](#image) supplies the selected registrations
-- a stream of [events](#event) drives the runtime, which uses those registrations to decide what to do
+- a stream of [events](#event) drives the runtime
 
-For example, this registration says: when the runtime sees the event id `:cart/add`, use this [event handler](#event-handler) function.
+Example: event id `:cart/add` → this [event handler](#event-handler):
+
 ```clojure
 (rf/reg-event :cart/add
   (fn [{:keys [db]} [_ item]]
@@ -411,52 +414,51 @@ For example, this registration says: when the runtime sees the event id `:cart/a
 
 [Core](../api/re-frame.core.md) registration:
 
-- `reg-event` registers an [event handler](#event-handler).
-- `reg-sub` registers a [subscription](#subscription).
-- `reg-fx` registers an [effect handler](#effect-handler).
-- `reg-cofx` registers a [coeffect](#coeffect) supplier.
-- `reg-interceptor` registers an event-handler wrapper.
-- `reg-view` and `reg-view*` register [views](#view).
+- `reg-event` — [event handler](#event-handler)
+- `reg-sub` — [subscription](#subscription)
+- `reg-fx` — [effect handler](#effect-handler)
+- `reg-cofx` — [coeffect](#coeffect) supplier
+- `reg-interceptor` — event-handler wrapper
+- `reg-view` / `reg-view*` — [views](#view)
 
-(Frame construction is deliberately NOT a `reg-*` member — a frame is a live runtime object, not a registered program member. `make-frame` creates a named [frame](#frame); `frame-root` is the ENSURE mount recipe.)
+Frame construction is not a `reg-*` member — a frame is a live runtime object. `make-frame` creates a named [frame](#frame); `frame-root` is the ENSURE mount recipe.
 
-Flows registration:
+Flows:
 
-- `reg-flow` registers a [flow](#flow).
+- `reg-flow` — [flow](#flow)
 
-[Machines](../machines/concepts.md) registration:
+[Machines](../machines/concepts.md):
 
-- `reg-machine` and `reg-machine*` register [machines](../machines/glossary.md#machine).
+- `reg-machine` / `reg-machine*` — [machines](../machines/glossary.md#machine)
 
-Routing registration:
+Routing:
 
-- `reg-route` registers a route.
+- `reg-route` — route
 
-Schema registration:
+Schema:
 
-- `reg-app-schema` and `reg-app-schemas` register Malli schemas for app-db paths.
+- `reg-app-schema` / `reg-app-schemas` — Malli schemas for app-db paths
 
-SSR registration:
+SSR:
 
-- `reg-head` registers an SSR head producer.
-- `reg-error-projector` registers an SSR error projector.
+- `reg-head` — SSR head producer
+- `reg-error-projector` — SSR error projector
 
-HTTP registration:
+HTTP:
 
-- `reg-http-interceptor` registers managed-HTTP middleware.
+- `reg-http-interceptor` — managed-HTTP middleware
 
-[Resource](../api/re-frame.resources.md) registration:
+[Resource](../api/re-frame.resources.md):
 
-- `reg-resource` registers a [resource](../resources/glossary.md#resource).
-- `reg-mutation` registers a [mutation](../resources/glossary.md#mutation).
-- `reg-resource-scope` registers a named resource-scope resolver.
-
+- `reg-resource` — [resource](../resources/glossary.md#resource)
+- `reg-mutation` — [mutation](../resources/glossary.md#mutation)
+- `reg-resource-scope` — named resource-scope resolver
 
 ### **runtime-db**
 
-The framework-owned half of a [frame](#frame)'s state — the other side of [the two partitions](#the-two-partitions), sitting beside the [app-db](#app-db) you own.
+Framework-owned half of a [frame](#frame)'s state — beside [app-db](#app-db) you own; see [the two partitions](#the-two-partitions).
 
-re-frame2 keeps its own durable state here: machine [snapshots](../machines/glossary.md#snapshot), the current route, [resource](../resources/glossary.md#resource) caches, [mutation](../resources/glossary.md#mutation) status, and similar machinery. App code reads it through subscriptions or accessors — never by editing `:rf.db/runtime` paths directly.
+Holds machine [snapshots](../machines/glossary.md#snapshot), current route, [resource](../resources/glossary.md#resource) caches, [mutation](../resources/glossary.md#mutation) status, and similar. App code reads via subscriptions or accessors — never by editing `:rf.db/runtime` paths directly.
 
 ```clojure
 [:rf.db/runtime :rf.runtime/machines :snapshots :auth.login/flow]
@@ -466,90 +468,82 @@ Related: [app-db](#app-db), [frame](#frame). Paths: `:rf.db/runtime`, children `
 
 ### **schema**
 
-A data description of a value's shape — `[:map [:sku :string] [:qty :int]]` — written in **Malli**, the data-driven schema library re-frame2 uses by default. Attach one to an [app-db](#app-db) path (`reg-app-schema`), an event, or an HTTP `:decode` step; the runtime checks it at a named boundary in dev and [elides](#elide) the check in production. Because a schema is itself data, it validates, coerces, and round-trips through tools.
+A data description of a value's shape — `[:map [:sku :string] [:qty :int]]` — in **Malli** (default). Attach to an [app-db](#app-db) path (`reg-app-schema`), an event, or an HTTP `:decode` step. Runtime checks at a named boundary in dev; [elides](#elide) the check in production. Schema-as-data supports validate, coerce, and tooling round-trips.
 
 Related: [Validate with schemas](how-to/validate-with-schemas.md).
 
 ### **subscription**
 
-A named, registered, pure, **cached** derivation of state — how a [view](#view) reads what it needs. You declare it with `reg-sub`; the framework recomputes it only when its inputs actually change (by `=`), so a view never re-renders for a value that didn't move. Subscriptions compose in layers: some read [app-db](#app-db) directly, others combine other subscriptions into a derivation graph.
+A named, registered, pure, **cached** derivation of state — how a [view](#view) reads what it needs. `reg-sub`; recomputes only when inputs change by `=`. Layers: some read [app-db](#app-db) directly; others combine other subscriptions.
 
 ```clojure
 (rf/reg-sub :cart/count (fn [db _] (count (:items (:cart db)))))
 ```
 
-Related: [Subscriptions](subscriptions.md). Casual "sub" is fine; not as a headword. (Need the value inside an [event handler](#event-handler)? Materialise it with a [flow](#flow).)
+Related: [Subscriptions](subscriptions.md). Casual "sub" is fine; not as a headword. Value inside an [event handler](#event-handler)? Materialise with a [flow](#flow).
 
 ### **substrate**
 
-The React-family rendering layer your app runs on — Reagent, UIx, or reagent-slim. You pick one and wire re-frame2 to it with an [adapter](#adapter). Because the core is substrate-agnostic, your events, subscriptions, and app-db are identical whichever you choose — only the rendering differs.
-
-```clojure
-;; substrate = the rendering library; the adapter is the value you pass to init!
-```
+The React-family rendering layer — Reagent, UIx, or reagent-slim. Wire re-frame2 to it with an [adapter](#adapter). Core is substrate-agnostic: events, subscriptions, and app-db stay the same; only rendering differs.
 
 Related: [Use UIx or slim](how-to/use-uix-or-slim.md).
 
 ### **view**
 
-A pure render function from [subscription](#subscription) values to **hiccup** — the Clojure data that describes your UI. Views read derived state and [dispatch](#dispatch) [events](#event) on interaction; they hold no business logic. The [substrate](#substrate) turns the hiccup into real React elements.
+A pure render function from [subscription](#subscription) values to **hiccup**. Reads derived state; [dispatches](#dispatch) [events](#event) on interaction; no business logic. The [substrate](#substrate) turns hiccup into React elements.
 
 ```clojure
 (rf/reg-view cart-badge []
   [:span.badge @(subscribe [:cart/count])])
 ```
 
-Related: [Views](views.md). Use "component" for React-analogy callouts only.
+Related: [Views](views.md). Use "component" only in React-analogy callouts.
 
 ## The Verbs
 
-The six pipeline stages — [**assemble → transform**](#write-side) (the [update phase](#write-side), per event), [**commit → perform**](#commit-phase) (the [commit phase](#commit-phase), per event) and [**derive → render**](#read-side) (the [render phase](#read-side), per [render batch](#render-batch)) — are the verbs of the [event pipeline](#event-pipeline); they lead this section, in pipeline order.
+The six pipeline stages — [**assemble → transform**](#write-side) ([update phase](#write-side), per event), [**commit → perform**](#commit-phase) ([commit phase](#commit-phase), per event), [**derive → render**](#read-side) ([render phase](#read-side), per [render batch](#render-batch)) — in pipeline order.
 
 ### **assemble**
 
-The pipeline's first stage: gather the [**world**](#world) an [event handler](#event-handler) will read — [app-db](#app-db) (`:db`) plus every fact the event declared with `:rf.cofx/requires` — into one [coeffects](#coeffect) map, before the handler runs. This is where declared facts (the clock, a fresh id, a storage read) enter as data, so the handler stays pure.
+First stage: gather the [**world**](#world) the [event handler](#event-handler) will read — [app-db](#app-db) (`:db`) plus every fact listed in `:rf.cofx/requires` — into one [coeffects](#coeffect) map before the handler runs.
 
 Related: [Effects](effects.md), [Coeffects](coeffects.md), [world](#world).
 
 ### **transform**
 
-The pipeline's second stage: run the pure [event handler](#event-handler) — the assembled [world](#world) and the [event](#event) in, an [effect map](#effect-map) out. It *transforms* the world into a description of the change (`{:db … :fx …}`) and performs none of it; the stages after the [commit](#commit) carry that description out.
+Second stage: run the pure [event handler](#event-handler) — assembled [world](#world) and [event](#event) in, [effect map](#effect-map) out. Transforms world into a description (`{:db … :fx …}`); performs none of it. Later stages after [commit](#commit) execute that description.
 
 Related: [Introduction](introduction.md), [event handler](#event-handler).
 
 ### **commit**
 
-The single, deferred, all-or-nothing write of the new [app-db](#app-db) — the **first effect of the [commit phase](#commit-phase)**, and its anchor. The `:db` write is an effect like any other, special *only* in that it is guaranteed to run first; it is the one point the committed value crosses to the [render phase](#read-side), and nothing else crosses. Everything before it (assemble, transform) is transactional — the `:db` your [event handler](#event-handler) returns is *staged* and lands once, atomically, after flows run, so a throwing handler or flow installs *nothing* — and everything after it ([perform](#perform)) is best-effort. No observer ever sees a half-written app-db.
-
-```clojure
-;; the :db you return is staged; it's committed once, atomically — the write/read seam
-```
+The single, deferred, all-or-nothing write of the new [app-db](#app-db) — **first effect of the [commit phase](#commit-phase)**, and its anchor. Special only in that it always runs first; it is the one point the committed value crosses to the [render phase](#read-side). Before it (assemble, transform): transactional — the `:db` the handler returns is *staged* and lands once, after flows run; a throwing handler or flow installs *nothing*. After it ([perform](#perform)): best-effort. No observer sees a half-written app-db.
 
 Related: [Introduction](introduction.md).
 
 ### **perform**
 
-The pipeline's fourth stage and the rest of the [commit phase](#commit-phase): run the `:fx` rows the [transform](#transform) returned, in source order, after the [commit](#commit). This is the *only* place the system touches the world — the HTTP call, the navigation, the follow-up dispatch — carried out by the [effect handler](#effect-handler) registered for each id. Past the `:db` write it's best-effort: an effect that throws doesn't un-commit the state.
+Fourth stage; rest of the [commit phase](#commit-phase): run `:fx` rows from [transform](#transform) in source order after [commit](#commit). Only place the system touches the outside world (HTTP, navigation, follow-up dispatch), via each id's [effect handler](#effect-handler). Past the `:db` write: best-effort — a throwing effect does not un-commit state.
 
 Related: [Effects](effects.md), [Coeffects](coeffects.md), [effect](#effect).
 
 ### **derive**
 
-The pipeline's fifth stage and the first of the [render phase](#read-side): recompute the [subscriptions](#subscription) (and the rest of [the derivation graph](#the-derivation-graph)) that watch the changed parts of the committed [app-db](#app-db). Values that come out equal (by `=`) to last time prune everything downstream. The render phase runs once per [render batch](#render-batch), so derivation happens against settled state, never mid-run. (The public verb you write is [`subscribe`](#subscribe--derive); *derive* names the stage.)
+Fifth stage; first of the [render phase](#read-side): recompute [subscriptions](#subscription) (and [the derivation graph](#the-derivation-graph)) that watch changed parts of committed [app-db](#app-db). Values equal by `=` to last time prune everything downstream. Once per [render batch](#render-batch), against settled state. Public verb: [`subscribe`](#subscribe--derive); *derive* names the stage.
 
 Related: [Subscriptions](subscriptions.md).
 
 ### **render**
 
-The pipeline's sixth and final stage: the [views](#view) that deref a *changed* [subscription](#subscription) re-run, producing fresh [hiccup](#hiccup), and the [substrate](#substrate) patches just the DOM that moved. Because it runs once per [render batch](#render-batch) from settled state — and a [drain](#drain--run-to-completion) is never split across batches — the screen never flickers through an intermediate value.
+Sixth stage: [views](#view) that deref a *changed* [subscription](#subscription) re-run, produce fresh [hiccup](#hiccup); the [substrate](#substrate) patches the DOM that moved. Once per [render batch](#render-batch) from settled state — a [drain](#drain--run-to-completion) is never split across batches — so the screen does not flash intermediate values.
 
 Related: [Views](views.md).
 
 ### **dispatch**
 
-Enqueue an [event](#event) for a [frame](#frame) to process.
+Enqueue an [event](#event) for a [frame](#frame).
 
-`dispatch` wraps the event in an [event envelope](#event-envelope) and returns immediately; the [event handler](#event-handler) runs later, during the [pipeline run](#event-pipeline) the event kicks off. (Its synchronous sibling `dispatch-sync` runs the pipeline *now* — mainly for tests and boot.)
+Wraps the event in an [event envelope](#event-envelope) and returns immediately; the [event handler](#event-handler) runs later in the [pipeline run](#event-pipeline) that event starts. Sibling `dispatch-sync` runs the pipeline *now* (tests, boot).
 
 ```clojure
 (rf/dispatch [:cart/add-item {:sku "BK-1"}]
@@ -560,20 +554,20 @@ Related: [event](#event), [event envelope](#event-envelope), [event pipeline](#e
 
 ### **dispatch-sync**
 
-Like [`dispatch`](#dispatch), but it runs the [event](#event) and normally drains the whole queue to completion *before returning*, instead of queuing for the next tick. A drain-depth halt or successful exact-incarnation destruction claim is terminal. At a destroy claim an authored callback already on the stack may return and entered authored interceptor `:after` callbacks may unwind, but its returned framework tail is inert and later ordinary events do not begin. The right call at boot, in tests, and at the REPL — never from inside a running handler (which raises `:rf.error/dispatch-sync-in-handler`).
+Like [`dispatch`](#dispatch), but runs the [event](#event) and normally drains the whole queue to completion *before returning*. A drain-depth halt or successful exact-incarnation destruction claim is terminal. At a destroy claim, an authored callback already on the stack may return and entered interceptor `:after` callbacks may unwind, but the returned framework tail is inert and later ordinary events do not begin. Use at boot, in tests, and at the REPL — never from inside a running handler (`:rf.error/dispatch-sync-in-handler`).
 
 ```clojure
-(rf/dispatch-sync [:app/initialise])   ;; app-db is committed before the next line
+(rf/dispatch-sync [:app/initialise])   ;; app-db committed before the next line
 ```
 
 Related: [Introduction](introduction.md).
 
 ### **drain / run-to-completion**
 
-The runtime normally drains the *whole* event queue to a fixed point — running the [update and commit phases](#write-side) of every queued [event](#event) to completion — before the [render phase](#read-side) runs. So update and commit run *per event*, everything the drain settles lands in one [render batch](#render-batch), and the UI updates once, from a settled state, never mid-flight. A drain-depth halt or successful exact-incarnation destruction claim is terminal. At a destroy claim an authored callback already on the stack may return and entered authored interceptor `:after` callbacks may unwind, but its returned framework tail is inert; later ordinary events do not begin and no render phase follows the interrupted event. A drain is normally many [pipeline runs](#event-pipeline) sharing one render phase.
+The runtime normally drains the *whole* event queue to a fixed point — [update and commit](#write-side) of every queued [event](#event) — before the [render phase](#read-side). Update and commit run *per event*; everything the drain settles lands in one [render batch](#render-batch); the UI updates once from settled state. A drain-depth halt or successful exact-incarnation destruction claim is terminal. At a destroy claim, authored callbacks already on the stack may return and entered interceptor `:after` callbacks may unwind; the returned framework tail is inert; later ordinary events do not begin and no render phase follows the interrupted event. A drain is normally many [pipeline runs](#event-pipeline) sharing one render phase.
 
 ```clojure
-;; every queued event's update + commit phases run, THEN — at the host's next
+;; every queued event's update + commit, THEN — at the host's next
 ;; checkpoint, once — subs recompute and views render
 ```
 
@@ -583,7 +577,7 @@ Hyphenate **run-to-completion** consistently.
 
 ### **elide**
 
-Compile dev-only code out of production via one flag (`goog.DEBUG` or `-Dre-frame.debug`). It removes the dev trace surface, the [epoch](#epoch) buffer, and schema *checks* — but the always-on `:errors` and `:events` streams survive, so production observability keeps working.
+Compile dev-only code out of production via one flag (`goog.DEBUG` or `-Dre-frame.debug`). Removes the dev trace surface, the [epoch](#epoch) buffer, and schema *checks*. Always-on `:errors` and `:events` streams survive.
 
 ```clojure
 ;; goog.DEBUG=false removes the dev trace surface and schema checks
@@ -593,33 +587,33 @@ Related: [Observability](observability.md). Name DCE once, then use **elide**.
 
 ### **init!**
 
-The one-time boot call that installs a [substrate](#substrate) [adapter](#adapter) into the runtime — `(rf/init! reagent-adapter/adapter)`. Idempotent, called once at startup. It does *not* create a default [frame](#frame) (identity is carried, not found); you register your root frame explicitly.
+One-time boot call that installs a [substrate](#substrate) [adapter](#adapter) — `(rf/init! reagent-adapter/adapter)`. Idempotent. Does *not* create a default [frame](#frame) (identity is carried, not found); you establish the root frame explicitly.
 
 Related: [Adapters](../api/re-frame.adapter.reagent.md).
 
 ### **project (egress)**
 
-Run a value through redaction before it leaves the app, via `project-egress`; direct reads are not auto-projected.
+Run a value through redaction before it leaves the app via `project-egress`. Direct reads are not auto-projected.
 
 ```clojure
-(rf/project-egress value {:frame :app/main :path [:auth]})  ;; redacts at the sink
+(rf/project-egress value {:frame :app/main :path [:auth]})
 ```
 
 Related: [Keep secrets out of traces](how-to/keep-secrets-out-of-traces.md).
 
 ### **register**
 
-Name your handlers and machinery at boot time with [registration](#registration) forms — `reg-event` for an [event handler](#event-handler), `reg-sub` for a [subscription](#subscription), and so on.
+Name handlers and machinery at boot with [registration](#registration) forms — `reg-event`, `reg-sub`, and so on.
 
 ```clojure
 (rf/reg-event :cart/clear (fn [{:keys [db]} _] {:db (dissoc db :cart)}))
 ```
 
-Related: [Introduction](introduction.md). There is **one** `reg-event`: `reg-event-db`/`-fx`/`-ctx` are gone.
+Related: [Introduction](introduction.md). There is **one** `reg-event`: `reg-event-db` / `-fx` / `-ctx` are gone.
 
 ### **subscribe / derive**
 
-Read derived state by name through a [subscription](#subscription); `@(subscribe …)` both reads the current value *and* subscribes, so the [view](#view) re-renders when it changes.
+Read derived state by name through a [subscription](#subscription). `@(subscribe …)` reads the current value *and* subscribes so the [view](#view) re-renders on change.
 
 ```clojure
 @(rf/subscribe [:cart/count])
@@ -631,7 +625,7 @@ Related: [Subscriptions](subscriptions.md).
 
 ### **Effects are data**
 
-An [event handler](#event-handler) returns a *description* of side-effects — an [effect map](#effect-map) of data — and the runtime performs them; a pure handler plus data effects is what makes replay, test, and trace possible.
+An [event handler](#event-handler) returns a *description* of side effects — an [effect map](#effect-map) of data — and the runtime performs them. Pure handler + data effects enable replay, test, and trace.
 
 ```clojure
 {:fx [[:http {:url "/api/login"}] [:dispatch [:ui/spinner true]]]}
@@ -641,27 +635,27 @@ Related: [Effects](effects.md), [Coeffects](coeffects.md).
 
 ### **Fail loud, not silent**
 
-A recognised input that can't be honoured raises a structured [error record](#error-record) (`:rf.error/*`), never a nil or no-op. Keep **fail-loud** (raise instead of swallow) distinct from **fail-closed** (deny by default at a boundary).
+A recognised input that cannot be honoured raises a structured [error record](#error-record) (`:rf.error/*`), never a nil or no-op. **Fail-loud** = raise instead of swallow. **Fail-closed** = deny by default at a boundary. Keep them distinct.
 
 ```clojure
-;; unregistered id, missing cofx, unknown fx → raises :rf.error/*, never returns nil
+;; unregistered id, missing cofx, unknown fx → :rf.error/*, never nil
 ```
 
 Related: [Errors](errors.md).
 
 ### **Frame identity is carried, not found**
 
-An operation reads its [frame](#frame) from its scope (provider / running handler / captured handle); the runtime never invents one. A rootless call is `:rf.error/no-frame-context`.
+An operation reads its [frame](#frame) from scope (provider / running handler / captured handle). The runtime never invents one. A rootless call is `:rf.error/no-frame-context`.
 
 ```clojure
-[rf/frame-provider {:frame :app} [app-root]]   ;; scope carries the frame downward
+[rf/frame-provider {:frame :app} [app-root]]
 ```
 
 Related: [Frames](frames.md).
 
 ### **The four homes (where state lives)**
 
-[Subscription](#subscription) → [flow](#flow) → [resource](../resources/glossary.md#resource) → [machine](../machines/glossary.md#machine): pick the cheapest that fits, decided by the where-state-lives router. Every other concept defers here for "which one do I use?".
+[Subscription](#subscription) → [flow](#flow) → [resource](../resources/glossary.md#resource) → [machine](../machines/glossary.md#machine): pick the cheapest that fits. Full router: [Where state lives](where-state-lives.md).
 
 ```clojure
 ;; cart total → sub (or flow); the article → resource; checkout → machine
@@ -671,17 +665,17 @@ Related: [Where state lives](where-state-lives.md).
 
 ### **The two partitions**
 
-A [frame](#frame) holds [app-db](#app-db) (yours) and [runtime-db](#runtime-db) (the framework's), addressed by the projection paths `:rf.db/app` and `:rf.db/runtime`; runtime subsystems live under `:rf.runtime/*`.
+A [frame](#frame) holds [app-db](#app-db) (yours) and [runtime-db](#runtime-db) (framework), addressed by `:rf.db/app` and `:rf.db/runtime`; subsystems under `:rf.runtime/*`.
 
 ```clojure
-[:rf.db/runtime :rf.runtime/resources]   ;; the resource cache IS a runtime-db subsystem
+[:rf.db/runtime :rf.runtime/resources]
 ```
 
 Related: [app-db](app-db.md).
 
 ### **The uniform reply**
 
-Every managed async surface (HTTP, resources, mutations, route loaders, machine async) completes by [dispatching](#dispatch) an [event](#event) carrying the one canonical reply map, never by an awaited value. Its discriminator is the closed `:status` field — `:ok` (value at `:value`), `:error` (failure at `:error`), `:cancelled`, or `:stale` — the *same* envelope on every surface, HTTP included. (Different from the resource *read sub's* `:status`, whose values are the five lifecycle states `:idle`/`:loading`/`:fetching`/`:loaded`/`:error`.)
+Every managed async surface (HTTP, resources, mutations, route loaders, machine async) completes by [dispatching](#dispatch) an [event](#event) with one canonical reply map — never an awaited value. Discriminator is closed `:status`: `:ok` (value at `:value`), `:error` (failure at `:error`), `:cancelled`, or `:stale`. Same envelope on every surface, HTTP included. Distinct from the resource *read sub*'s `:status` lifecycle (`:idle` / `:loading` / `:fetching` / `:loaded` / `:error`).
 
 ```clojure
 [:auth/login-reply {:status :ok :value {:token "…"}}]
@@ -689,73 +683,72 @@ Every managed async surface (HTTP, resources, mutations, route loaders, machine 
 
 Related: [Managed HTTP](../async/http.md).
 
-
 ### **The derivation graph**
 
-The directed graph of pure derivations rooted at [app-db](#app-db), with [views](#view) at the leaves. [Subscriptions](#subscription), [flows](#flow), resource reads, route facts, and machine selectors are all nodes on this one graph; the runtime recomputes only along edges whose value actually changed (by `=`), so an unchanged input prunes everything downstream of it.
+Directed graph of pure derivations rooted at [app-db](#app-db), [views](#view) at the leaves. [Subscriptions](#subscription), [flows](#flow), resource reads, route facts, and machine selectors are nodes. The runtime recomputes only along edges whose value changed by `=`; unchanged input prunes everything downstream.
 
 Related: [Subscriptions](subscriptions.md).
 
 ### **Data classification**
 
-Marking an [app-db](#app-db) path (or a payload slot) `:sensitive` or `:large` so the framework swaps in a redaction/size sentinel wherever that value would cross an egress boundary — a trace, [Xray](#xray), an SSR payload, an off-box log — while on-box rendering still sees the real value. Hygiene applied at the boundary (see [project (egress)](#project-egress)), not security.
+Marking an [app-db](#app-db) path (or payload slot) `:sensitive` or `:large` so the runtime swaps in a redaction/size sentinel wherever that value would cross an egress boundary (trace, [Xray](#xray), SSR payload, off-box log). On-box rendering still sees the real value. Hygiene at the boundary (see [project (egress)](#project-egress)), not security.
 
 Related: [Keep secrets out of traces](how-to/keep-secrets-out-of-traces.md).
 
 ### **Recordable vs ambient coeffects**
 
-Two grades of [coeffect](#coeffect). A *recordable* one (the clock, a fresh id) is captured onto the [event envelope](#event-envelope) before the handler runs, so the durable result depends on a recorded value and [replays](#time-travel) identically. An *ambient* one is read live and isn't recorded — fine for a display hint, never for anything that feeds a durable write.
+Two grades of [coeffect](#coeffect). *Recordable* (clock, fresh id) is captured onto the [event envelope](#event-envelope) before the handler runs so durable results [replay](#time-travel) identically. *Ambient* is read live and not recorded — fine for a display hint, never for a durable write.
 
 ```clojure
-{:rf.cofx/requires [:rf/time-ms]}   ;; :rf/time-ms is recordable — stamped on the envelope
+{:rf.cofx/requires [:rf/time-ms]}   ;; recordable; stamped on the envelope
 ```
 
 Related: [Effects](effects.md), [Coeffects](coeffects.md).
 
 ## Observability
 
-re-frame2's observability surface — everything tools read to show you the pipeline. The trace stream and [epoch](#epoch) history are dev-only (see [elide](#elide)); the always-on error and event streams survive production. See [Observability](observability.md).
+Tools read the pipeline through this surface. Trace stream and [epoch](#epoch) history are dev-only (see [elide](#elide)); always-on error and event streams survive production. See [Observability](observability.md).
 
 ### **trace stream**
 
-The live, in-process feed of [trace events](#trace-event) the runtime emits at every stage of the pipeline — event dispatched, handler run, sub recomputed, effect fired. Every tool ([Xray](#xray), Story, the pair MCP) is just a reader of it; there's no second source of truth. Dev-only — [elided](#elide) from production.
+Live in-process feed of [trace events](#trace-event) at every pipeline stage — dispatch, handler, sub recompute, effect. Tools ([Xray](#xray), Story, pair MCP) are readers of it. Dev-only — [elided](#elide) from production.
 
 ### **trace event**
 
-One immutable record on the [trace stream](#trace-stream): an `:operation` (what happened), an `:op-type` (its family), a timestamp, and tags — including the id that correlates a whole [pipeline run](#event-pipeline). Filter by `:op-type` to slice the stream; the always-on `:errors`/`:events` records are the production-surviving subset.
+One immutable record on the [trace stream](#trace-stream): `:operation`, `:op-type`, timestamp, tags (including the id that correlates a whole [pipeline run](#event-pipeline)). Filter by `:op-type`. Always-on `:errors` / `:events` records are the production-surviving subset.
 
 ### **listener**
 
-A callback you register (`register-listener!`) on a named stream — `:trace`, `:epoch`, `:events`, or `:errors` — fired on each matching emit. One registration is a complete tooling integration; but a listener sees data in the clear, so [project it](#project-egress) before sending anything off-box.
+Callback registered with `register-listener!` on a named stream — `:trace`, `:epoch`, `:events`, or `:errors` — fired on each matching emit. One registration is a tooling integration. Listeners see data in the clear — [project](#project-egress) before sending off-box.
 
 ### **epoch**
 
-The record one [pipeline run](#event-pipeline) leaves behind — its trigger event, the before/after [app-db](#app-db), and the run's [trace events](#trace-event). The epoch is re-frame2's **unit of time-travel**: [Xray](#xray) rewinds, replays, and inspects history one epoch at a time. It's the last term of the triple: [pipeline](#event-pipeline) (structure) / [run](#run) (one traversal) / **epoch** (the record).
+The record one [pipeline run](#event-pipeline) leaves — trigger event, before/after [app-db](#app-db), run's [trace events](#trace-event). Unit of time-travel: [Xray](#xray) rewinds, replays, and inspects one epoch at a time. Triple: [pipeline](#event-pipeline) / [run](#run) / **epoch**.
 
 ```clojure
-;; one dispatch = one run = one epoch (the record)
+;; one dispatch = one run = one epoch
 ```
 
-Epochs live on the dev-only observability surface — they're [elided](#elide) from production builds.
+Dev-only — [elided](#elide) from production.
 
 Related: [Observability](observability.md).
 
 ### **time-travel**
 
-Restoring a [frame](#frame) to the exact state it held at an earlier [epoch](#epoch) — both partitions, in one atomic write, no handlers re-run. It works because each epoch holds the real before/after immutable value; it's the superpower behind [Xray](#xray)'s scrubbing and undo.
+Restore a [frame](#frame) to the state it held at an earlier [epoch](#epoch) — both partitions, one atomic write, no handlers re-run. Each epoch holds real before/after immutable values. Powers [Xray](#xray) scrubbing and undo.
 
 ### **Xray**
 
-The dev inspector: an in-app panel that reads the [trace stream](#trace-stream) and per-frame [epoch](#epoch) history so you debug the pipeline, not the DOM.
+Dev inspector: in-app panel over the [trace stream](#trace-stream) and per-frame [epoch](#epoch) history. Debug the pipeline, not the DOM.
 
 ```clojure
-;; open Xray to step through epochs, inspect app-db, and read each pipeline run
+;; open Xray to step epochs, inspect app-db, read each pipeline run
 ```
 
 Related: [the Xray docs](../xray/index.md).
 
 ### **Story**
 
-The view workbench: render a [view](#view)'s loading, empty, error, and happy states as named variants, each in its own isolated [frame](#frame), then promote the good examples into tests. Reads the same [trace stream](#trace-stream) as every other tool.
+View workbench: render a [view](#view)'s loading, empty, error, and happy states as named variants, each in its own [frame](#frame); promote good examples into tests. Reads the same [trace stream](#trace-stream) as other tools.
 
 Related: [the Story tab](../story/index.md), [Observability](observability.md).

--- a/docs/core/hiccup.md
+++ b/docs/core/hiccup.md
@@ -1,17 +1,16 @@
 # Hiccup: HTML as data
 
-Before we discuss more about re-frame2, we need to understand **hiccup** — the
-notation we'll be using to create DOM. You've already seen it: the
-[Introduction](introduction.md)'s counter view returned nested vectors shaped
-like the screen. That's hiccup, and every view you write will return it.
+Before more re-frame2, you need **hiccup** — the notation for building DOM. You've
+already seen it: the [Introduction](introduction.md)'s counter view returned nested
+vectors shaped like the screen. That's hiccup, and every view you write will return
+it.
 
-There's no state and no clicks on this page — that machinery starts with
-[Events](events.md). Just the notation, live: every cell below renders its last
-form, and you can edit any of them. Press **Ctrl-Enter** (**Cmd-Enter** on
-macOS) after an edit to re-evaluate.
+No state and no clicks on this page — that machinery starts with [Events](events.md).
+Just the notation, live: every cell below renders its last form, and you can edit any
+of them. Press **Ctrl-Enter** (**Cmd-Enter** on macOS) after an edit to re-evaluate.
 
-> **Hiccup is HTML as data: a vector per element, a map for attributes, strings
-> for text.**
+> **Hiccup is HTML as data: a vector per element, a map for attributes, strings for
+> text.**
 
 ## An element is a vector
 
@@ -19,8 +18,8 @@ macOS) after an edit to re-evaluate.
 [:p "Hello from a vector"]
 ```
 
-The keyword at the head names the tag. Everything after it is content. Change
-`:p` to `:h1` and re-evaluate.
+The keyword at the head names the tag. Everything after it is content. Change `:p`
+to `:h1` and re-evaluate.
 
 ## Children follow, and they nest
 
@@ -34,9 +33,8 @@ The keyword at the head names the tag. Everything after it is content. Change
   [:li "Cheese"]]]
 ```
 
-Strings become text nodes; vectors become child elements; order is document
-order. The indentation is just formatting — the structure lives entirely in the
-nesting.
+Strings become text nodes; vectors become child elements; order is document order.
+The indentation is just formatting — the structure lives entirely in the nesting.
 
 ## Attributes are a map in second position
 
@@ -49,9 +47,9 @@ nesting.
  " in a styled box"]
 ```
 
-If an element's second slot is a map, those are its attributes — `:href`,
-`:title`, `:disabled`, anything the element takes. `:style` is itself a map:
-CSS properties as keywords, values as strings.
+If an element's second slot is a map, those are its attributes — `:href`, `:title`,
+`:disabled`, anything the element takes. `:style` is itself a map: CSS properties as
+keywords, values as strings.
 
 !!! tip "Try it"
 
@@ -68,8 +66,8 @@ keyword:
 
 ## It's data, so code writes it
 
-There is no template language to learn — the screen is a data structure, and
-all of ClojureScript already works on data:
+There is no template language to learn — the screen is a data structure, and all of
+ClojureScript already works on data:
 
 ```cljs-rf2
 (def fruits ["Apples" "Pears" "Plums" "Cherries"])
@@ -79,8 +77,8 @@ all of ClojureScript already works on data:
     [:li f]))
 ```
 
-`for` produces a `[:li ...]` per fruit; `into` pours them into the `[:ul]`.
-Add a fruit. Then make it `(for [f (sort fruits)] ...)`.
+`for` produces a `[:li ...]` per fruit; `into` pours them into the `[:ul]`. Add a
+fruit. Then make it `(for [f (sort fruits)] ...)`.
 
 Conditional markup is plain `when`, because a `nil` child renders as nothing:
 
@@ -92,20 +90,20 @@ Conditional markup is plain `when`, because a `nil` child renders as nothing:
    [:em {:style {:color "Tomato"}} "— on sale!"])]
 ```
 
-Change `true` to `false` and the emphasis vanishes — no special syntax for
-"render this conditionally", just an expression that is sometimes `nil`.
+Change `true` to `false` and the emphasis vanishes — no special syntax for "render
+this conditionally", just an expression that is sometimes `nil`.
 
 ??? info "For JavaScript developers"
 
-    Hiccup is JSX with the compiler deleted. Both describe a tree of elements,
-    but hiccup is literal data — vectors and maps you can `map`, `filter`,
-    `sort`, and pass to functions — with no build-time transform and no
-    `{}`-escape hatch, because you never left the language.
+    Hiccup is JSX with the compiler deleted. Both describe a tree of elements, but
+    hiccup is literal data — vectors and maps you can `map`, `filter`, `sort`, and
+    pass to functions — with no build-time transform and no `{}`-escape hatch,
+    because you never left the language.
 
 ## Naming a piece of screen: `reg-view`
 
-So far our hiccup has been anonymous. Real apps are built from *named* pieces,
-and you met the registration for that in the Introduction:
+So far our hiccup has been anonymous. Real apps are built from *named* pieces, and
+you met the registration for that in the Introduction:
 
 ```cljs-rf2
 (require '[re-frame.core :as rf])
@@ -116,16 +114,16 @@ and you met the registration for that in the Introduction:
 [greeting "world"]
 ```
 
-`reg-view` reads like `defn` — arguments in, hiccup out — and it also
-*registers* the view under an id derived from its name, so the framework and
-its tooling can find it. Notice how the view gets used: not called like a
-function, but placed at the **head of a vector**, where a tag keyword would
-go, with its arguments as the tail. `[greeting "world"]` is still just data.
+`reg-view` reads like `defn` — arguments in, hiccup out — and it also *registers*
+the view under an id derived from its name, so the framework and its tooling can find
+it. Notice how the view gets used: not called like a function, but placed at the
+**head of a vector**, where a tag keyword would go, with its arguments as the tail.
+`[greeting "world"]` is still just data.
 
 ## Views use views
 
-That head-of-vector rule is the composition rule. A view's hiccup can contain
-other views, exactly the way a `:div` contains a `:span`:
+That head-of-vector rule is the composition rule. A view's hiccup can contain other
+views, exactly the way a `:div` contains a `:span`:
 
 ```cljs-rf2
 (require '[re-frame.core :as rf])
@@ -146,13 +144,13 @@ other views, exactly the way a `:div` contains a `:span`:
 ```
 
 The same shape repeats at every level: `product-card` uses `price-tag` the way
-`:div` uses `:span`. A screen is a tree of views, and views bottom out in
-element keywords.
+`:div` uses `:span`. A screen is a tree of views, and views bottom out in element
+keywords.
 
 !!! tip "Try it"
 
-    View usage is data too, so the `for`/`into` trick from earlier composes
-    views as easily as `:li`s:
+    View usage is data too, so the `for`/`into` trick from earlier composes views as
+    easily as `:li`s:
 
     ```clojure
     (def products [{:title "Aeron chair" :price 1200}
@@ -171,13 +169,11 @@ element keywords.
 | `[:p "hi" {:style ...}]` | The attribute map must be **second**; anywhere later it's just another child | `[:p {:style ...} "hi"]` |
 | The cell reports a reader error | A bracket is unbalanced — hiccup is data before it is anything else | Balance the brackets |
 
-## Day-one checklist
-
-You can read the hiccup any view returns; write nested elements with
-attributes and inline styles; generate markup with `for`, `when`, and plain
-data; name a piece of screen with `reg-view`; and compose views inside views.
-That's all the notation the rest of this guide leans on.
+You can read the hiccup any view returns; write nested elements with attributes and
+inline styles; generate markup with `for`, `when`, and plain data; name a piece of
+screen with `reg-view`; and compose views inside views. That's all the notation the
+rest of this guide leans on.
 
 What hiccup can't do alone is *change*. Reacting to clicks and showing live
-application state is the [event pipeline](glossary.md#event-pipeline)'s job —
-and teaching it starts with [Events](events.md).
+application state is the [event pipeline](glossary.md#event-pipeline)'s job — and
+teaching it starts with [Events](events.md).

--- a/docs/core/images.md
+++ b/docs/core/images.md
@@ -13,9 +13,7 @@ The answer is the [**image**](glossary.md#image):
 
 > **An image is which registrations are loaded; a frame is the live run that resolves against them.**
 
-Don't skim past that one — it's the sentence this page hangs off, and everything below is the same line in different costumes.
-
-If you want something concrete to hold, hold a theatre. The image is the script: which characters exist, what their lines are. The frame is tonight's performance: live, on stage, with its own history of everything that has already happened. One script can play on two stages at once. Two different scripts can both contain a character called the King. Keep the theatre; the rest of the page will use it.
+If you want something concrete to hold: the image is the script (which characters exist, what their lines are). The frame is tonight's performance — live, on stage, with its own history. One script can play on two stages at once. Two different scripts can both contain a character called the King. Keep the theatre lightly; the rest of the page will use it sparingly.
 
 We'll build the idea up one step at a time, starting from code you've already written without realising an image was there at all.
 
@@ -34,7 +32,7 @@ Here is ordinary re-frame2. No image in sight:
 
 Those `reg-*` forms don't *run* anything. They write entries into the [**registrar**](glossary.md#registrar) — the process-global table holding every [registration](glossary.md#registration) you've authored, each tagged with the namespace it was written in (its registration source, `:rf.provenance/*`). Nothing has executed yet. You've just filled the registrar.
 
-When you then create a frame *without* naming an image, that frame resolves every lookup straight against the whole registrar — "everything I've registered." That implicit all-of-it selection is the **default image**: the conceptual zero-config selection you get for free. So an image, at its simplest, is just a *selection from the registrar*. The default selects all of it.
+When you then create a frame *without* naming an image, that frame resolves every lookup straight against the whole registrar — "everything I've registered." That implicit all-of-it selection is the **default image**: the zero-config selection you get for free. So an image, at its simplest, is just a *selection from the registrar*. The default selects all of it.
 
 !!! note "Heads-up — the default image is a real sealed generation"
 
@@ -52,7 +50,7 @@ One clarification before we move on, because the name invites the mistake: "defa
 
 The default image works only while ids are globally unique across everything that's loaded. The moment two loaded namespaces register the same `(kind, id)` with *different* implementations — two surfaces that both define `:counter/inc`, say — the default image refuses to assemble. The error names the colliding kind/id and both source namespaces.
 
-That refusal is a feature. Read it as one. The registrar kept *both* descriptors, and assembly won't guess which one wins. You have three explicit ways out, and we'll meet each below: rename one id; narrow each frame to its own slice with an explicit image; or compose a later image that declares an exact replacement winner. The one thing the framework will not do is silently pick a survivor and move on.
+That refusal is a feature. The registrar kept *both* descriptors, and assembly won't guess which one wins. You have three explicit ways out, and we'll meet each below: rename one id; narrow each frame to its own slice with an explicit image; or compose a later image that declares an exact replacement winner. The one thing the framework will not do is silently pick a survivor and move on.
 
 ??? info "From re-frame v1"
 
@@ -184,11 +182,11 @@ The reader sees one small vocabulary evolve across lessons instead of `:counter-
 
 ## The shape of every image decision
 
-Every situation on this page — every single one — reduces to one decision. An image holds *behaviour*: the registrations. A frame holds *state and history*: its own [app-db](glossary.md#app-db), evolving as events run. So:
+Every situation on this page reduces to one decision. An image holds *behaviour*: the registrations. A frame holds *state and history*: its own [app-db](glossary.md#app-db), evolving as events run. So:
 
 **Different behaviour means a different image; the same behaviour with a different lived history means the same image, just a different frame.**
 
-Two surfaces on one page? That rule. A tool inspecting a live app? That rule. Test doubles, library packaging, story canvases, progressive lessons, the thing you're building right now that isn't on this list? The rule, the rule, the rule, probably the rule. ...All right. One rule doesn't need a chant. Watch it produce every shape instead:
+That rule covers the shapes you'll actually meet:
 
 - **Two surfaces on one page.** A cart surface and a counter surface that both want simple local ids (`:boot/init`, `:item/add`). Give each its own image with disjoint `:select-ns` selectors; each frame resolves only its own.
 - **An inspection tool beside its target.** [Xray](glossary.md#xray) is itself a running surface with its own events, subs, and app-db paths. Run it in its own image and frame, and let it inspect the target frame *as data* — the tool never has to coordinate ids with the thing it inspects.
@@ -300,9 +298,9 @@ To override an existing `(kind, id)`, define the winning registration in a *late
 ;; => [{:registration [:fx :checkout.http/post] :image :app/main :shadowed-by :test/doubles}]
 ```
 
-The stub is an understudy: same part — `:checkout.http/post` — different actor, and the stage manager's log (the shadow report) says exactly who went on. An override is always a *separate* image, never a second key in the same one. A cross-image shadow resolves (later wins) and is reported; you read the report and apply whatever policy you want.
+The stub is an understudy: same part — `:checkout.http/post` — different actor, and the shadow report says exactly who went on. An override is always a *separate* image, never a second key in the same one. A cross-image shadow resolves (later wins) and is reported; you read the report and apply whatever policy you want.
 
-One boundary is absolute, so hear it plainly: **you cannot override a framework standard.** The one cross-image collision that still fails assembly is an app registration colliding with a framework standard. If it's application-owned, define the winner in a later image and read the shadow report. But if it's *how the frame executes registered entries* — queue ordering, the interceptor algorithm, app-db commit semantics — that's a protected standard (`:rf.error/image-standard-replacement-forbidden`), and no app image may shadow it. A standard encodes an execution invariant, not an app policy choice.
+One boundary is absolute: **you cannot override a framework standard.** The one cross-image collision that still fails assembly is an app registration colliding with a framework standard. If it's application-owned, define the winner in a later image and read the shadow report. But if it's *how the frame executes registered entries* — queue ordering, the interceptor algorithm, app-db commit semantics — that's a protected standard (`:rf.error/image-standard-replacement-forbidden`), and no app image may shadow it. A standard encodes an execution invariant, not an app policy choice.
 
 ## Hot reload swaps the image, keeps the memory
 
@@ -341,6 +339,6 @@ If you want the diff report the old `reload-images!` verb used to return, read `
 
     Re-`make-frame`-ing is the explicit knob; the automatic `reg-*` re-eval path is what you actually lean on. Save a file and the affected frames pick up the change with no call from you. Reach for the explicit re-`make-frame` reload only when you want to swap a frame's *whole composition* deliberately — a test that re-points a running frame at a different image stack, a tool driving a frame through several configurations, a story canvas trading one deck of registrations for another.
 
-And that's the whole shape. The same boundary that lets two examples on one page each own `:counter/inc` is the boundary that survives a file save: the image is a *value*, the runtime can diff two of them, and a frame can trade one for another without forgetting what it has lived through. The script can be revised mid-run; the performance keeps its memory.
+And that's the whole shape. The same boundary that lets two examples on one page each own `:counter/inc` is the boundary that survives a file save: the image is a *value*, the runtime can diff two of them, and a frame can trade one for another without forgetting what it has lived through.
 
-Behaviour is the image. State is the frame. The events are the program. Once those three are separate things, every situation above is one move in different clothes: *different behaviour means a different image; the same behaviour with a different history means the same image with a different frame.*
+Behaviour is the image. State is the frame. The events are the program. Once those three are separate things, every situation above is one move: *different behaviour means a different image; the same behaviour with a different history means the same image with a different frame.*

--- a/docs/core/interceptors.md
+++ b/docs/core/interceptors.md
@@ -30,10 +30,6 @@ map out.
 Interceptors earn their keep when the *same* chore genuinely applies across many
 handlers (logging, undo snapshot, boundary validation).
 
-**On this page — two speeds.** Day one: register a logger, attach by id, know the
-context map and the sandwich, use `path` if you need it. Going further: frame-wide
-attach, contribute-don't-perform, undo worked example, introspection, testing.
-
 ## A first interceptor: a logger
 
 Here's a complete, registered interceptor. It logs each event on the way in, and prints how long the handler took on the way out:
@@ -92,7 +88,7 @@ Tempted to skip the registration step and drop an interceptor *map* straight int
 
 ## The context map: two keys
 
-We've been reaching into `ctx` with `get-in [:coeffects :event]`. Time to look at what's actually in there. The context is one immutable map threading through the whole chain, and it has two load-bearing keys:
+We've been reaching into `ctx` with `get-in [:coeffects :event]`. Time to look at what's actually in there. The context is one immutable map threading through the whole chain, and it has two keys that matter:
 
 | Key | Holds | Filled by |
 |---|---|---|
@@ -109,18 +105,18 @@ Caught mid-chain, just after the handler has run, the map looks like this:
              :fx [[:dispatch [:toast/show "Added"]]]}}
 ```
 
-This is the same `:coeffects` / `:effects` pair you met in [effects](effects.md) and [coeffects](coeffects.md): coeffects are the world facts a handler reads, effects are the descriptions it writes. Interceptors live in the gap between them. So the whole mental model fits in one line:
+This is the same `:coeffects` / `:effects` pair you met in [effects](effects.md) and [coeffects](coeffects.md): coeffects are the world facts a handler reads, effects are the descriptions it writes. Interceptors live in the gap between them. So the whole picture fits in one line:
 
 - a **`:before`** sees only `:coeffects` — the outputs don't exist yet;
 - an **`:after`** sees both `:coeffects` *and* `:effects`.
 
-I'll pause while you read those two lines again. That's the key concept, right there: the way in is about the handler's inputs, the way out is about its outputs, and everything an interceptor will ever do for you happens on one of those two trips.
+That's the key concept: the way in is about the handler's inputs, the way out is about its outputs, and everything an interceptor will ever do for you happens on one of those two trips.
 
 That's why our logger's `:before` could read `:event` but our undo example (later) needs `:after` to compare the before-`:db` against the after-`:db`.
 
 ??? note "Going deeper"
 
-    The context is a *comonad*-flavoured value: every stage is a function `context -> context`, and composing the whole chain is just folding those functions over one threaded value. Because the value is immutable and each stage is total (`ctx` in, `ctx` out), the chain is a pure transformation — which is exactly what lets [replay, time-travel](glossary.md#time-travel), and deterministic tests re-run it against recorded inputs and get the same answer every time. The runtime also stages a few framework keys (the [dispatch envelope](glossary.md#event-envelope) among them) for generic tooling.
+    Every stage is a function `context -> context`, and composing the whole chain is folding those functions over one threaded value. Because the value is immutable and each stage is total (`ctx` in, `ctx` out), the chain is a pure transformation — which is exactly what lets [replay, time-travel](glossary.md#time-travel), and deterministic tests re-run it against recorded inputs and get the same answer every time. The runtime also stages a few framework keys (the [dispatch envelope](glossary.md#event-envelope) among them) for generic tooling.
 
 ## The sandwich: how a chain runs
 
@@ -150,9 +146,9 @@ If you'd rather see that as code, here it is — the whole execution is one thre
     ((:after  C)) ((:after  B)) ((:after  A)))
 ```
 
-(Morally, anyway — the runtime resolves the references and guards each call, but this is the shape. There's no machinery hiding under the machinery.)
+(Morally, anyway — the runtime resolves the references and guards each call, but this is the shape.)
 
-Two details carry weight. First, **the handler runs as the last `:before`.** The runtime wraps it as an interceptor too — even the ham gets wrapped — so there's exactly one kind of thing to execute, all the way down. Second, **the trip out mirrors the trip in.** Whatever `B:before` set up, `B:after` tears down — and teardown happens *after* everything that ran inside the setup, because the outer slice goes on first and comes off last. Every cleanup interceptor you write leans on this symmetry.
+Two details matter. First, **the handler runs as the last `:before`.** The runtime wraps it as an interceptor too — even the ham gets wrapped — so there's exactly one kind of thing to execute, all the way down. Second, **the trip out mirrors the trip in.** Whatever `B:before` set up, `B:after` tears down — and teardown happens *after* everything that ran inside the setup, because the outer slice goes on first and comes off last. Every cleanup interceptor you write leans on this symmetry.
 
 The handler doesn't know it's wrapped, and an interceptor doesn't know what it wraps. That mutual ignorance is exactly why the pattern scales: any interceptor can decorate any handler, because they only ever talk through one shared value. They never reach into each other.
 
@@ -280,7 +276,7 @@ When both a frame and a dispatch supply overrides, they **merge, and on any key 
 
 Here's the rule from the top of the page, made precise. The chain is part of the *step function* — the pure fold that replay, time-travel, and deterministic tests re-run against recorded inputs. So this is where discipline pays off.
 
-Don't do real work directly in an interceptor body. Not because it won't run — it will — but because it re-fires on every replay, and it escapes every seam: `:fx-overrides` (the effects-side sibling of the `:interceptor-overrides` you just met) redirects *registered effects*, not a stray `localStorage` write buried in an `:after`. The sanctioned pattern is **contribute, don't perform** — append [effect](glossary.md#effect) rows and let the [effect handler](glossary.md#effect-handler) execute them.
+Don't do real work directly in an interceptor body. Not because it won't run — it will — but because it re-fires on every replay, and it escapes every override path: `:fx-overrides` (the effects-side sibling of the `:interceptor-overrides` you just met) redirects *registered effects*, not a stray `localStorage` write buried in an `:after`. The sanctioned pattern is **contribute, don't perform** — append [effect](glossary.md#effect) rows and let the [effect handler](glossary.md#effect-handler) execute them.
 
 ```clojure
 ;; ❌ performs — re-fires on replay, invisible to :fx-overrides and the trace
@@ -303,8 +299,6 @@ So what *are* interceptors allowed to do? Two things. They **decide**: a `:befor
 
     A frame-wide interceptor runs on *every* event in that frame, [SSR](../ssr/glossary.md#ssr) included. That's another reason the contribute pattern matters: the `:localstorage/set` row above is safe under SSR because it's just a `:db`-derived effect row, and the `reg-fx` handler that performs it carries `:platforms #{:client}` — so the server's fx resolver simply skips it. An interceptor that instead pokes the host *directly* in its body (a `:before` that reads `js/localStorage`) has no such fence and throws on the JVM during a server render. Keep host access in the effect handler, where the platform gate lives.
 
-## Day-one checklist
-
 You can register an interceptor by id, attach it with `:interceptors […]`, read
 `:coeffects` on the way in and `:effects` on the way out, and prefer
 contribute-don't-perform over host I/O in the body. That is enough until a real
@@ -312,7 +306,7 @@ cross-cutting pain appears.
 
 ---
 
-## Going further
+## Advanced
 
 ## A real interceptor: undo
 

--- a/docs/core/introduction.md
+++ b/docs/core/introduction.md
@@ -2,14 +2,14 @@
 
 To understand re-frame2, you need to understand how it does computation.
 
-Which is an odd opening for a Single Page Application (SPA) library, I know, but bear with me.
+Odd opener for a Single Page Application (SPA) library — hang on.
 
 ## A working app
 
-To assist explanations, here's a tiny "counter" application. It has:
+Here's a tiny counter so the rest of this page has something real to point at:
 
 - an increment button
-- a displayed value (initially 3), incremented by each button click
+- a displayed value (initially 3), incremented by each click
 
 ```cljs-rf2
 ;; The re-frame2 core API namespace
@@ -26,26 +26,27 @@ To assist explanations, here's a tiny "counter" application. It has:
    [:button {:on-click #(dispatch [:inc])} "+"]])
 ```
 
-The entire application is 4 calls to functions starting with `reg-xxx` and all four of them have the form:
+The whole app is four calls to functions that start with `reg-xxx`, each of the form:
+
 ```clojure
 (reg-xxx id function)
 ```
 
-- `reg-event` is called twice (to register two event handlers, and, yes, more on this soon)
-- then, `reg-sub` is called once (to register a subscription handler)
-- and finally, `reg-view` is called once (to register a view)
+- `reg-event` twice (two event handlers — more on those soon)
+- `reg-sub` once (a subscription handler)
+- `reg-view` once (a view)
 
-**A re-frame2 app is a set of registrations**.
+**A re-frame2 app is a set of registrations.**
 
-Later, when your re-frame2 application is running, and the user is clicking buttons and seeing new DOM, etc., the re-frame2 runtime will look up these functions by their `id` and call them, and **THAT** is why you need to understand how re-frame2 does computation (the claim at the top of the page).  
-
-You need to understand how to write functions that slot into the re-frame2 runtime.
+When the app is running — user clicks, DOM updates — the re-frame2 runtime looks those
+functions up by `id` and calls them. That is the computation claim at the top of this
+page: you write the functions that slot into that runtime.
 
 ## Running Counter
 
-We might have created the Counter app (via those 4 registrations), but we haven't run it yet.
+We've registered the Counter; we haven't run it yet.
 
-To do that, we need to create a `frame`, which provides an isolated execution context. And, here's how:
+To run it, create a `frame` — an isolated execution context:
 
 ```cljs-rf2
 [:div {:style {:background "LavenderBlush"}}
@@ -53,58 +54,63 @@ To do that, we need to create a `frame`, which provides an isolated execution co
      [counter]]]
 ```
 
-This code is `hiccup` — a data structure representing DOM. And in this in-browser dev environment, hiccup at the end of an interactive block is rendered, which is why we see the DOM for the app above.
+This is `hiccup` — a data structure that represents DOM. In this in-browser dev
+environment, hiccup at the end of an interactive block is rendered, which is why the
+app appears above.
 
 That hiccup is:
 
-- a `<div>` which has a background style and which wraps ...
-- a `frame-root` node which injects an **ambient frame** into the DOM tree (think Provider)
-- a child `counter` view, previously registered above 
+- a `<div>` with a background style wrapping …
+- a `frame-root` node that injects an **ambient frame** into the DOM tree (think Provider)
+- a child `counter` view, registered above
 
-When you see `frame-root` think of **Provider** in the **React Context** sense. A `frame-root` is like a wrapping DOM node which provides context to its child views — in this case a `frame` (an isolated execution context) is ambiently available to the `counter` view beneath it.
+When you see `frame-root`, think **Provider** in the **React Context** sense: a wrapping
+DOM node that makes a `frame` ambiently available to the views beneath it.
 
 Experiment/edit this code:
 
 1. Change `"LavenderBlush"` to `"green"`
 2. Change `[:initialise 3]` to `[:initialise 4]`
 
-Press **`Ctrl-Enter`** / **`Cmd-Enter`** after doing your edits.
+Press **`Ctrl-Enter`** / **`Cmd-Enter`** after edits.
 
 ## Isolated execution context
 
-The isolated execution context provided by a `frame` reifies:
+A `frame` holds:
 
-- state — an immutable map which starts off as `{}`
+- state — an immutable map, starts as `{}`
 - a queue of events
-- some caches for performance
+- caches for performance
 
-In our Counter app, state starts as `{}`, and then immediately after frame creation becomes `{:value 3}` (in `:app1`) once `:initialise` runs. After the "+" button gets clicked the first time it is `{:value 4}`. Then `{:value 5}`, etc. re-frame2 calls this state `app-db` for reasons explained later.
+In the Counter, state starts as `{}`, then becomes `{:value 3}` in `:app1` once
+`:initialise` runs. First "+" click → `{:value 4}`, then `{:value 5}`, and so on.
+re-frame2 calls this state `app-db` (why, later).
 
 ## The event pipeline in one pass
 
 Click **+**. What actually happens is one trip through the
-[**event pipeline**](glossary.md#event-pipeline) — a fixed sequence of stages, not
-a free-form cycle of callbacks:
+[**event pipeline**](glossary.md#event-pipeline) — a fixed sequence of stages, not a
+pile of free-form callbacks:
 
-1. **Dispatch.** `#(dispatch [:inc])` puts the event vector `[:inc]` on a FIFO
-   queue and returns immediately. Dispatch does not run the handler.
+1. **Dispatch.** `#(dispatch [:inc])` puts `[:inc]` on a FIFO queue and returns
+   immediately. Dispatch does **not** run the handler.
 2. **Dequeue.** Shortly after, the runtime takes the next event from the queue.
 3. **Update phase.** It looks up the handler for `:inc`, builds a small **world** map
-   (at minimum today's [app-db](glossary.md#app-db) under `:db`), and calls the
-   handler: `(handler world event)`.
-4. **Effects as data.** The handler returns `{:db next-map}` — a *description* of
-   the next state. It does not mutate the old map.
-5. **Commit phase.** The runtime executes those effects: the `:db` effect runs first,
-   and the frame's app-db reference becomes the new map, atomically.
-6. **Render phase.** Subscriptions whose inputs changed recompute. Views that
-   depend on those values re-render. React reconciles the DOM.
+   (at minimum today's [app-db](glossary.md#app-db) under `:db`), and calls
+   `(handler world event)`.
+4. **Effects as data.** The handler returns `{:db next-map}` — a *description* of the
+   next state. It does not mutate the old map.
+5. **Commit phase.** The runtime executes those effects: `:db` runs first, and the
+   frame's app-db reference becomes the new map, atomically.
+6. **Render phase.** Subscriptions whose inputs changed recompute. Views that depend
+   on those values re-render. React reconciles the DOM.
 
 ```text
 click → dispatch → queue → handler → {:db …} → commit → subs → views → DOM
 ```
 
-Every re-frame2 app is that **pipeline**, run once per event. Nothing "happens"
-without an event. The app moves through time as:
+Every re-frame2 app is that **pipeline**, once per event. Nothing moves without an
+event. Time advances as:
 
 ```text
 event₁ → event₂ → event₃ → …
@@ -117,9 +123,9 @@ pipeline → pipeline → pipeline → …
 ```
 
 The pipeline is **fixed**. Every event — yours, the framework's, a timer at 3am —
-travels the same stages in the same order. Your functions are Turing-complete; the
-structure between them deliberately is not. That restriction is what later buys
-replay, time travel, and tests without mocks.
+travels the same stages in the same order. Your handlers are Turing-complete; the
+structure between them is not. That restriction is what later buys replay, time
+travel, and tests without mocks.
 
 ## Events are data
 
@@ -132,18 +138,18 @@ further elements carry facts — typically one payload map:
 [:route/changed {:page :about :params {...}}]
 ```
 
-Events are usually **user intent** (click, type, navigate), but anything can
-speak them: timers, HTTP replies, route loaders. The next page,
-[Events](events.md), is the vocabulary in full.
+Events are usually **user intent** (click, type, navigate), but anything can speak
+them: timers, HTTP replies, route loaders. The next page, [Events](events.md), is
+the vocabulary in full.
 
 ## One map of state: app-db
 
 Each running instance holds application state as one immutable Clojure map —
-**app-db**. In the counter it starts `{}`, then becomes `{:value 3}` after
-`:initialise`, then `{:value 4}` after the first `:inc`.
+**app-db**. In the counter it starts `{}`, becomes `{:value 3}` after `:initialise`,
+then `{:value 4}` after the first `:inc`.
 
 Handlers never "set state" as a side effect. They return the next map inside an
-effect description. [app-db](app-db.md) is the dedicated page for that doctrine.
+effect description. [app-db](app-db.md) owns that doctrine.
 
 ## Frames: one running world
 
@@ -182,25 +188,24 @@ One formula, applied one event at a time.
 
 ## How the Core track is organised
 
-The left nav is the learning order, and it owns the page roster — this page won't
-restate it. What's worth saying is the *shape* of that order, because each stage
-leans only on the one before it.
+The left nav is the learning order — this page won't restate the roster. What matters
+is the *shape* of that order: each stage leans only on the one before it.
 
-You start with the **pure pipeline** — the whole model, no impurity yet, and enough
-to build real screens. Then **impurity** lets handlers reach the world (HTTP,
-storage, timers, recorded facts) and stay pure doing it. **Structure** arrives once
-an app grows — isolating worlds, and moving derivations into event handlers (the update phase).
-**Operations** is for when something breaks. The **advanced** corners come last, and
-most apps never reach for them.
+You start with the **pure pipeline** — the whole model, no impurity yet, enough to
+build real screens. Then **impurity** lets handlers reach the world (HTTP, storage,
+timers, recorded facts) while staying pure about it. **Structure** arrives once an
+app grows — isolating worlds, moving derivations into event handlers (the update
+phase). **Operations** is for when something breaks. **Advanced** corners come last;
+most apps never need them.
 
-Every concept page opens a **day-one** path and marks its optional depth, so you can
-stop and ship at any stage. How-to recipes, testing, and the "why it's built this
-way" essays sit alongside those concepts — reach for them when you have a task or a
-design question, not as a first read-through.
+Every concept page teaches the rules that matter first and marks optional depth under
+**Advanced**, so you can stop and ship at any stage. How-to recipes, testing, and
+"why it's built this way" essays sit alongside — reach for them when you have a task
+or a design question, not as a first read-through.
 
-### Happy path and unhappy path
+### Working path and loud failures
 
-Every stage teaches the **happy path** first (a working counter grown one idea at
-a time). Each concept page also names the **loud failures** you will meet early —
-missing handler, missing sub, no frame on a callback, effect-map typos — so recovery
-is vocabulary, not archaeology.
+Every stage teaches a **working path** first (a counter grown one idea at a time).
+Each concept page also names the **loud failures** you'll meet early — missing
+handler, missing sub, no frame on a callback, effect-map typos — so recovery is
+vocabulary, not a midnight scavenger hunt.

--- a/docs/core/observability.md
+++ b/docs/core/observability.md
@@ -7,22 +7,40 @@ changed in [app-db](glossary.md#app-db), which subscriptions recomputed, which v
 re-rendered, what effects escaped. In most frontends that question has no clean
 answer — causality is smeared across components. Here it has a clean one.
 
-re-frame2 has a clean answer, and it isn't bolted on — it falls out of the architecture. Every event traverses the same fixed [event pipeline](glossary.md#event-pipeline) — the ordered run from a dispatched [event](glossary.md#event) through its [event handler](glossary.md#event-handler), the [commit](glossary.md#commit), and the [effects](glossary.md#effect) — so there is a single place to stand and watch the runtime go past. And as it runs, the framework narrates: it emits a small data record at every moment worth noticing. That stream of records is the **trace stream** — the **wire**, from here on — and it's the whole foundation. The fancy panels you'll meet at the end — [Xray](glossary.md#xray) (the dev inspector), Story (a view workbench), the pair MCP (a bridge that lets an AI inspect the running app) — are not the observability system. They are *readers* of it.
+Every event traverses the same fixed
+[event pipeline](glossary.md#event-pipeline) — the ordered run from a dispatched
+[event](glossary.md#event) through its
+[event handler](glossary.md#event-handler), the [commit](glossary.md#commit), and the
+[effects](glossary.md#effect) — so there is a single place to stand and watch the
+runtime go past. As it runs, the framework emits a small data record at every moment
+worth noticing. That stream of records is the **trace stream** — the **wire**, from
+here on. The panels you'll meet at the end — [Xray](glossary.md#xray) (the dev
+inspector), Story (a view workbench), the pair MCP (a bridge that lets an AI inspect
+the running app) — are not the observability system. They are *readers* of it.
 
-**Day one on this page:** one wire (the trace stream), correlated by
-`:rf.trace/dispatch-id`, and the ring buffer of recent history. Tools are thin
-readers of those facts — not a second truth.
-This page builds up from the smallest piece. First the shape of a single trace event. Then the buffer that remembers recent ones. Then a listener you can write in eight lines. Then what survives into production. Then the tools sitting on top.
+One wire (the trace stream), correlated by `:rf.trace/dispatch-id`, and the ring
+buffer of recent history. Tools are thin readers of those facts — not a second truth.
 
-If you take one idea away, take this one: **every tool is a thin presentation over the same runtime facts.** Xray, Story, the pair MCP, machines-viz, and any listener you write all read one trace stream and one [epoch](glossary.md#epoch) history. If two of them ever disagree about a run, one of them is broken — there is no second truth.
+This page builds up from the smallest piece. First the shape of a single trace event.
+Then the buffer that remembers recent ones. Then a listener you can write in eight
+lines. Then what survives into production. Then the tools sitting on top.
 
-Read that last sentence again; it's the load-bearing one. The rest of this page is just me showing you the machinery that makes it true.
+If you take one idea away, take this one: **every tool is a thin presentation over
+the same runtime facts.** Xray, Story, the pair MCP, machines-viz, and any listener
+you write all read one trace stream and one [epoch](glossary.md#epoch) history. If
+two of them ever disagree about a run, one of them is broken — there is no second
+truth.
+
+That last sentence is the rule the rest of the page is explaining.
 
 ## One wire: the trace stream
 
 A [trace event](glossary.md#trace-event) is just a map.
 
-The runtime emits one every time something worth noticing happens: an event dispatched, a handler run, app-db changed, a subscription recomputed, a view rendered, an effect fired, a [machine](../machines/glossary.md#machine) transitioned, an error caught. Here's the shape:
+The runtime emits one every time something worth noticing happens: an event
+dispatched, a handler run, app-db changed, a subscription recomputed, a view
+rendered, an effect fired, a [machine](../machines/glossary.md#machine) transitioned,
+an error caught. Here's the shape:
 
 ```clojure
 {:id        18342                       ;; auto-incrementing, unique per process
@@ -35,9 +53,11 @@ The runtime emits one every time something worth noticing happens: an event disp
              ,,,}}                      ;; the open bag of specifics
 ```
 
-You never construct these. The runtime emits them; your job (more often a tool's job) is to read them. Two fields carry the routing, and it helps to know which is which.
+You never construct these. The runtime emits them; your job (more often a tool's job)
+is to read them. Two fields carry the routing, and it helps to know which is which.
 
-`:op-type` is the coarse one: a small closed vocabulary you branch on to grab a slice of the stream. The families you'll meet most:
+`:op-type` is the coarse one: a small closed vocabulary you branch on to grab a slice
+of the stream. The families you'll meet most:
 
 | `:op-type` | What it covers |
 |---|---|
@@ -52,31 +72,67 @@ You never construct these. The runtime emits them; your job (more often a tool's
 | `:rf.registry` | A handler was registered (the `reg-*` calls themselves trace). |
 | `:error` / `:warning` / `:info` | The three severity tiers — anything caught, suspect, or worth a note. |
 
-`:operation` is the fine-grained identity within that slice — the specific emit site, like `:rf.event/dispatched`, `:rf.sub/skip`, or `:rf.machine/transition`. Everything else rides in `:tags`, an open map.
+`:operation` is the fine-grained identity within that slice — the specific emit site,
+like `:rf.event/dispatched`, `:rf.sub/skip`, or `:rf.machine/transition`. Everything
+else rides in `:tags`, an open map.
 
-Both fields are designed to grow without breaking anyone. New `:op-type` values get added over time, so a tool simply ignores what it doesn't recognise; new tag keys can arrive later without disturbing a tool that only reads the old ones.
+Both fields are designed to grow without breaking anyone. New `:op-type` values get
+added over time, so a tool simply ignores what it doesn't recognise; new tag keys can
+arrive later without disturbing a tool that only reads the old ones.
 
 ??? info "Coming from OpenTelemetry?"
 
-    The trace stream is the same idea — structured events on a wire, with interchangeable consumers reading them — with two differences. Delivery is synchronous and in-process (no collector, no network hop), and the whole wire is [elided](glossary.md#elide) from production builds. One instinct to unlearn: OTel gives you *spans*, a start/end pair with a `:duration` and a `:child-of` parent. re-frame2's trace is deliberately **event-at-a-time** — one map per moment, no separate end record. Correlation rides in the tags instead (next), which keeps the emit site cheap and the stream uniform: every entry is the same kind of thing.
+    The trace stream is the same idea — structured events on a wire, with
+    interchangeable consumers reading them — with two differences. Delivery is
+    synchronous and in-process (no collector, no network hop), and the whole wire is
+    [elided](glossary.md#elide) from production builds. One instinct to unlearn: OTel
+    gives you *spans*, a start/end pair with a `:duration` and a `:child-of` parent.
+    re-frame2's trace is deliberately **event-at-a-time** — one map per moment, no
+    separate end record. Correlation rides in the tags instead (next), which keeps the
+    emit site cheap and the stream uniform: every entry is the same kind of thing.
 
 ### Two properties that shape everything downstream
 
-**Delivery is synchronous.** When the runtime emits, every registered listener runs *right then*, mid-run, on the same call stack — no queue, no batching, no reordering.
+**Delivery is synchronous.** When the runtime emits, every registered listener runs
+*right then*, mid-run, on the same call stack — no queue, no batching, no reordering.
 
-"Hang on," you say. "I see a problem. Synchronous listeners, on the hot path?" What you see is a trade, and it's a deliberate one: perfect fidelity is the gift, and cheapness is the price. A listener has to be cheap. Grab the event, stash it, and return; defer anything expensive to a timer you own, so you never stretch out the run you're watching.
+Synchronous listeners on the hot path are a deliberate trade: perfect fidelity for
+cheapness. A listener has to be cheap. Grab the event, stash it, and return; defer
+anything expensive to a timer you own, so you never stretch out the run you're
+watching.
 
-**Runs are correlated, not inferred.** Every trace event emitted inside one event's run carries the same `:rf.trace/dispatch-id` in its tags. So "everything that click did" is a filter, not a guess. When a handler's effects dispatch a child event, the child run's opening `:rf.event/dispatched` carries `:rf.trace/parent-dispatch-id` pointing back at its cause. Walk those links and you have the causal tree: *this* dispatch happened because *that* one did. One dispatch = one run = one [epoch](glossary.md#epoch) — three names for the same unit of work, seen from three vantage points. (*Epoch* is just the name for the before-and-after state record one run leaves behind; we get to it [below](#the-epoch-history-what-the-app-was).)
+**Runs are correlated, not inferred.** Every trace event emitted inside one event's
+run carries the same `:rf.trace/dispatch-id` in its tags. So "everything that click
+did" is a filter, not a guess. When a handler's effects dispatch a child event, the
+child run's opening `:rf.event/dispatched` carries `:rf.trace/parent-dispatch-id`
+pointing back at its cause. Walk those links and you have the causal tree: *this*
+dispatch happened because *that* one did. One dispatch = one run = one
+[epoch](glossary.md#epoch) — three names for the same unit of work, seen from three
+vantage points. (*Epoch* is just the name for the before-and-after state record one
+run leaves behind; we get to it [below](#the-epoch-history-what-the-app-was).)
 
-And the wire isn't framework-only. If a tool you're writing wants its own milestones in the same stream the framework emits to, call `(rf/emit-trace-event! op-type operation tags)`. The runtime stamps `:id` and `:time`, routes it into the in-flight frame's history, and fans it out to every listener — exactly like a framework emit. Stay in your own namespace for `:op-type` and the tag keys — the `:rf.*` namespaces are framework-owned. Like every other trace emit, the call is elided in production.
+And the wire isn't framework-only. If a tool you're writing wants its own milestones
+in the same stream the framework emits to, call
+`(rf/emit-trace-event! op-type operation tags)`. The runtime stamps `:id` and
+`:time`, routes it into the in-flight frame's history, and fans it out to every
+listener — exactly like a framework emit. Stay in your own namespace for `:op-type`
+and the tag keys — the `:rf.*` namespaces are framework-owned. Like every other trace
+emit, the call is elided in production.
 
 ## The buffer: the last fifty things your app did
 
-Synchronous delivery has a catch. If you weren't listening when an event fired, you missed it. Forever.
+Synchronous delivery has a catch. If you weren't listening when an event fired, you
+missed it. Forever.
 
-That's fatal for any tool that attaches *after* the interesting thing happened: the devtools panel you opened three clicks too late, or the AI you summoned precisely because the app is already broken.
+That's fatal for any tool that attaches *after* the interesting thing happened: the
+devtools panel you opened three clicks too late, or the AI you summoned precisely
+because the app is already broken.
 
-So each [frame](glossary.md#frame) also keeps a ring buffer of recent history beside its own [app-db](glossary.md#app-db). The read surface is tool-facing, so it lives in its own namespace — `[re-frame.trace.tooling :as tooling]` — rather than on the app facade (on the JVM, `rf/trace-buffer` exists as a test-convenience alias). One read gets you the recent past:
+So each [frame](glossary.md#frame) also keeps a ring buffer of recent history beside
+its own [app-db](glossary.md#app-db). The read surface is tool-facing, so it lives in
+its own namespace — `[re-frame.trace.tooling :as tooling]` — rather than on the app
+facade (on the JVM, `rf/trace-buffer` exists as a test-convenience alias). One read
+gets you the recent past:
 
 ```clojure
 (tooling/trace-buffer :app)
@@ -87,9 +143,15 @@ So each [frame](glossary.md#frame) also keeps a ring buffer of recent history be
 ;;     :trace-events [,,,]}
 ```
 
-This is how a late-attaching tool bootstraps itself: read the buffer to learn where the app just came from, then register a listener (next section) to stay current. The buffer is "what just happened"; the live stream is "what's happening now."
+This is how a late-attaching tool bootstraps itself: read the buffer to learn where
+the app just came from, then register a listener (next section) to stay current. The
+buffer is "what just happened"; the live stream is "what's happening now."
 
-The unit of retention is the **event**, not the individual trace event, and that choice matters: one dispatch takes one slot whether its run emitted five trace events or fifty thousand, so a chatty run can't flood out the one you care about. It's per-frame on purpose, so a devtool mounted in its own frame can storm its own subscriptions without polluting your app frame's history.
+The unit of retention is the **event**, not the individual trace event, and that
+choice matters: one dispatch takes one slot whether its run emitted five trace events
+or fifty thousand, so a chatty run can't flood out the one you care about. It's
+per-frame on purpose, so a devtool mounted in its own frame can storm its own
+subscriptions without polluting your app frame's history.
 
 One knob sets the depth:
 
@@ -97,17 +159,33 @@ One knob sets the depth:
 (rf/configure! {:trace-buffer {:events-retained 50}})   ;; the default
 ```
 
-That sets the process default. A frame that wants its own retention sets `:rf.trace/events-retained` in its frame config. And when you want to start a session from a clean slate — between two recordings, say — `(tooling/clear-trace-buffer! :app)` empties the named frame's ring without touching anyone else's.
+That sets the process default. A frame that wants its own retention sets
+`:rf.trace/events-retained` in its frame config. And when you want to start a session
+from a clean slate — between two recordings, say —
+`(tooling/clear-trace-buffer! :app)` empties the named frame's ring without touching
+anyone else's.
 
 ??? info "Coming from Redux DevTools?"
 
-    This ring is the action log you scroll back through after something looks wrong — except it isn't a browser-extension bolt-on snooping on dispatches. It's a buffer the framework keeps natively, per isolated frame, and (the next section) it diffs state and time-travels too.
+    This ring is the action log you scroll back through after something looks wrong —
+    except it isn't a browser-extension bolt-on snooping on dispatches. It's a buffer
+    the framework keeps natively, per isolated frame, and (the next section) it diffs
+    state and time-travels too.
 
-Why hand back bundles instead of raw events? Because a per-event map — the raw trace events already folded into `:handler` / `:fx` / `:subs` / `:renders` slots — is the shape a tool actually wants to render. If you need the pre-grouped raw stream (you're re-folding it yourself, or chasing one specific emit), pass `{:flat true}` and you'll get plain trace events back instead. The storage is genuinely event-keyed either way; `:flat` just flattens the slots on the way out.
+Why hand back bundles instead of raw events? Because a per-event map — the raw trace
+events already folded into `:handler` / `:fx` / `:subs` / `:renders` slots — is the
+shape a tool actually wants to render. If you need the pre-grouped raw stream (you're
+re-folding it yourself, or chasing one specific emit), pass `{:flat true}` and you'll
+get plain trace events back instead. The storage is genuinely event-keyed either way;
+`:flat` just flattens the slots on the way out.
 
 ### Reading a slice, not the whole ring
 
-`(tooling/trace-buffer frame-id opts)` takes a filter map, so a tool doesn't have to pull the whole ring and sift it in JavaScript. The keys compose AND-wise — an absent key means "no constraint on that axis," and an unrecognised key is ignored (so a tool can probe a newer axis and degrade gracefully on an older runtime). The ones you'll reach for:
+`(tooling/trace-buffer frame-id opts)` takes a filter map, so a tool doesn't have to
+pull the whole ring and sift it in JavaScript. The keys compose AND-wise — an absent
+key means "no constraint on that axis," and an unrecognised key is ignored (so a tool
+can probe a newer axis and degrade gracefully on an older runtime). The ones you'll
+reach for:
 
 ```clojure
 ;; Just the runs dispatched from a :user/login event:
@@ -124,13 +202,27 @@ Why hand back bundles instead of raw events? Because a per-event map — the raw
 (tooling/trace-buffer :app {:pred (fn [run] (< 100 (count (:effects run))))})
 ```
 
-The full vocabulary is small: `:event-id`, `:origin`, `:dispatch-id`, `:between [t0 t1]`, `:since-ms`, `:pred`, and the `:flat`-only `:operation` / `:op-type` / `:severity` / `:since` / `:source` / `:handler-id` / `:sensitive?` keys. The event-level keys (`:event-id`, `:origin`, `:dispatch-id`, `:between`, `:since-ms`, `:pred`) work on bundle reads; the per-trace-event keys require `:flat true`.
+The full vocabulary is small: `:event-id`, `:origin`, `:dispatch-id`,
+`:between [t0 t1]`, `:since-ms`, `:pred`, and the `:flat`-only `:operation` /
+`:op-type` / `:severity` / `:since` / `:source` / `:handler-id` / `:sensitive?`
+keys. The event-level keys (`:event-id`, `:origin`, `:dispatch-id`, `:between`,
+`:since-ms`, `:pred`) work on bundle reads; the per-trace-event keys require
+`:flat true`.
 
-The corner cases are forgiving by design. Reading a frame that doesn't exist — or was already destroyed — returns `[]`, not an error, mirroring how `(rf/app-db-value <unknown>)` returns `nil`. And `{:events-retained 0}` turns the ring *off* without turning the surface off: `trace-buffer` returns `[]`, but live listeners keep firing. That's the right setting when you only ever consume the live stream and don't want to pay for retention.
+The corner cases are forgiving by design. Reading a frame that doesn't exist — or was
+already destroyed — returns `[]`, not an error, mirroring how
+`(rf/app-db-value <unknown>)` returns `nil`. And `{:events-retained 0}` turns the
+ring *off* without turning the surface off: `trace-buffer` returns `[]`, but live
+listeners keep firing. That's the right setting when you only ever consume the live
+stream and don't want to pay for retention.
 
 ### The epoch history: what the app *was*
 
-Next to the trace ring (what the app *did*) sits the **epoch history** (what the app *was*). That's one assembled record per run, carrying `:db-before` and `:db-after` snapshots plus structured `:sub-runs` / `:renders` / `:effects` projections, retained to its own depth. Read it with `(rf/epoch-history :app)`. Its config map carries a few more knobs than the trace ring:
+Next to the trace ring (what the app *did*) sits the **epoch history** (what the app
+*was*). That's one assembled record per run, carrying `:db-before` and `:db-after`
+snapshots plus structured `:sub-runs` / `:renders` / `:effects` projections, retained
+to its own depth. Read it with `(rf/epoch-history :app)`. Its config map carries a
+few more knobs than the trace ring:
 
 ```clojure
 (rf/configure! {:epoch-history {:depth            50    ;; how many epochs to keep (default)
@@ -138,21 +230,50 @@ Next to the trace ring (what the app *did*) sits the **epoch history** (what the
                                 :redact-fn        my-fn}});; runs at off-box egress, never at storage
 ```
 
-`:depth` is the obvious one — how far back time-travel reaches. `:trace-events-keep` caps how many of the most-recent records keep their raw trace events alongside the cheap structured projections; older records drop the raw events to bound memory. It defaults to the `:depth` value (so trace detail and epoch evict together); set it smaller — `5`, say — to bound a long dev session's heap more aggressively.
+`:depth` is the obvious one — how far back time-travel reaches. `:trace-events-keep`
+caps how many of the most-recent records keep their raw trace events alongside the
+cheap structured projections; older records drop the raw events to bound memory. It
+defaults to the `:depth` value (so trace detail and epoch evict together); set it
+smaller — `5`, say — to bound a long dev session's heap more aggressively.
 
-`:redact-fn` is the advanced safety valve, and where it runs matters: it is **projection-side, not storage-side**. The ring always stores the *raw* record, because an epoch record is causal replay material and mutating it at rest would corrupt `restore-epoch!`. The fn runs once per record at the **off-box egress boundary** — after the frame's normal `:sensitive` / `:large` classification has already projected the record — as a last scrub for something the declaration-driven projection can't prove (a sensitive slot no schema or classification covers). It is the rare escape hatch; ordinary redaction wants the [data classification](glossary.md#data-classification) model, not this. A throwing `redact-fn` falls back to the already-projected record rather than leaking.
+`:redact-fn` is the advanced safety valve, and where it runs matters: it is
+**projection-side, not storage-side**. The ring always stores the *raw* record,
+because an epoch record is causal replay material and mutating it at rest would
+corrupt `restore-epoch!`. The fn runs once per record at the **off-box egress
+boundary** — after the frame's normal `:sensitive` / `:large` classification has
+already projected the record — as a last scrub for something the declaration-driven
+projection can't prove (a sensitive slot no schema or classification covers). It is
+the rare escape hatch; ordinary redaction wants the
+[data classification](glossary.md#data-classification) model, not this. A throwing
+`redact-fn` falls back to the already-projected record rather than leaking.
 
-Because each record holds real before-and-after state, [time travel](glossary.md#time-travel) falls out for free: `(rf/restore-epoch! frame-id epoch-id)` rewinds a frame to exactly the state it held then — both partitions, [app-db](glossary.md#app-db) and [runtime-db](glossary.md#runtime-db) (machine snapshots, the route slice), in one atomic write. This isn't a special debug build; it's the direct consequence of state being one immutable value per frame.
+Because each record holds real before-and-after state,
+[time travel](glossary.md#time-travel) falls out for free:
+`(rf/restore-epoch! frame-id epoch-id)` rewinds a frame to exactly the state it held
+then — both partitions, [app-db](glossary.md#app-db) and
+[runtime-db](glossary.md#runtime-db) (machine snapshots, the route slice), in one
+atomic write. This isn't a special debug build; it's the direct consequence of state
+being one immutable value per frame.
 
 ??? info "Coming from Redux DevTools?"
 
-    This is the state-diff-and-time-travel feature — but it's not a wrapper that re-runs reducers from a recorded action log. Each epoch record *holds the actual immutable db value*, before and after, so a rewind is one assignment, not a replay. That's the payoff of [app-db](app-db.md) being a single immutable value per frame.
+    This is the state-diff-and-time-travel feature — but it's not a wrapper that
+    re-runs reducers from a recorded action log. Each epoch record *holds the actual
+    immutable db value*, before and after, so a rewind is one assignment, not a
+    replay. That's the payoff of [app-db](app-db.md) being a single immutable value
+    per frame.
 
-One refusal to know about, plainly: `restore-epoch!` declines any epoch whose run didn't settle cleanly — a halted or rolled-back run has no coherent "after" to rewind to, so the runtime refuses rather than restore a half-applied state. (Epoch records carry an `:outcome` field that says how the run ended; more on that below.)
+One refusal to know about, plainly: `restore-epoch!` declines any epoch whose run
+didn't settle cleanly — a halted or rolled-back run has no coherent "after" to rewind
+to, so the runtime refuses rather than restore a half-applied state. (Epoch records
+carry an `:outcome` field that says how the run ended; more on that below.)
 
 ## Your listener in eight lines
 
-Everything the fancy panels do starts with this one API, and the nice part is that anything Xray sees, your listener sees too. The verb is `register-listener!`, and its first argument names which **stream** you want — `:trace` for the raw event-at-a-time feed:
+Everything the fancy panels do starts with this one API, and the nice part is that
+anything Xray sees, your listener sees too. The verb is `register-listener!`, and its
+first argument names which **stream** you want — `:trace` for the raw event-at-a-time
+feed:
 
 ```clojure
 (rf/register-listener! :trace
@@ -164,32 +285,56 @@ Everything the fancy panels do starts with this one API, and the nice part is th
                (-> trace-event :tags :reason)))))
 ```
 
-That's a working error logger. It receives *every* trace event and prints the errors; `(rf/unregister-listener! :trace :my-app/error-logger)` removes it again.
+That's a working error logger. It receives *every* trace event and prints the errors;
+`(rf/unregister-listener! :trace :my-app/error-logger)` removes it again.
 
-That `:sensitive?` guard isn't decoration, so hear this now, plainly: a listener sees sensitive payloads in the clear — the runtime does not redact what it hands you. The moment your listener forwards data off-box (a network call, a third-party logger, even a console that gets captured into a log), check `:sensitive?` and drop or scrub the marked events. [Keep secrets out of traces](how-to/keep-secrets-out-of-traces.md) is the full story.
+That `:sensitive?` guard isn't decoration. A listener sees sensitive payloads in the
+clear — the runtime does not redact what it hands you. The moment your listener
+forwards data off-box (a network call, a third-party logger, even a console that gets
+captured into a log), check `:sensitive?` and drop or scrub the marked events.
+[Keep secrets out of traces](how-to/keep-secrets-out-of-traces.md) is the full story.
 
 Notes — three contract details that start to matter once tools stack up:
 
-1. **Same key replaces, atomically.** Re-registering under an existing key on the same stream swaps the callback between two emits, never mid-emit — which is exactly what hot reload needs.
-2. **Exceptions are isolated.** A throwing listener is caught; the app and the other listeners keep going. So you can attach a flaky experimental tool to a live app and the worst it can do is fail quietly.
-3. **Sibling order is unspecified.** Every listener sees every event, but never assume yours runs before another one.
+1. **Same key replaces, atomically.** Re-registering under an existing key on the
+   same stream swaps the callback between two emits, never mid-emit — which is
+   exactly what hot reload needs.
+2. **Exceptions are isolated.** A throwing listener is caught; the app and the other
+   listeners keep going. So you can attach a flaky experimental tool to a live app
+   and the worst it can do is fail quietly.
+3. **Sibling order is unspecified.** Every listener sees every event, but never
+   assume yours runs before another one.
 
-Dropping *every* listener on a stream at once is a test-isolation concern owned by the fixture layer, not a public-facade verb — the framework's own `re-frame.test-support` reset clears each registry through its lower-level sink directly (`re-frame.trace.tooling/clear-listeners!`, `re-frame.event-emit/clear-event-listeners!`, and so on). Ordinary application code unregisters its own listeners by key with `(rf/unregister-listener! stream id)`.
+Dropping *every* listener on a stream at once is a test-isolation concern owned by
+the fixture layer, not a public-facade verb — the framework's own
+`re-frame.test-support` reset clears each registry through its lower-level sink
+directly (`re-frame.trace.tooling/clear-listeners!`,
+`re-frame.event-emit/clear-event-listeners!`, and so on). Ordinary application code
+unregisters its own listeners by key with `(rf/unregister-listener! stream id)`.
 
 !!! warning "Gotcha — wrap dev-only listeners in the elision guard"
 
-    The `:trace` and `:epoch` streams are elided in production (next section), so registering against them there is dead weight at best. Match the framework's own posture and gate your registration site on the same flag the runtime uses, so the whole call drops out of an `:advanced` build:
+    The `:trace` and `:epoch` streams are elided in production (next section), so
+    registering against them there is dead weight at best. Match the framework's own
+    posture and gate your registration site on the same flag the runtime uses, so the
+    whole call drops out of an `:advanced` build:
 
     ```clojure
     (when ^boolean re-frame.interop/debug-enabled?
       (rf/register-listener! :trace :my-app/recorder my-callback))
     ```
 
-    The same guard belongs around `trace-buffer`, `clear-trace-buffer!`, the epoch reads, and the `configure!` calls — every dev-only call site in user code.
+    The same guard belongs around `trace-buffer`, `clear-trace-buffer!`, the epoch
+    reads, and the `configure!` calls — every dev-only call site in user code.
 
 ### The `:epoch` stream: assembled runs, not raw events
 
-The same verb drives three more streams, distinguished by that leading keyword. `:epoch` is the one you'll reach for most after `:trace`: it delivers one fully-assembled epoch record per run, *after* it settles, with `:db-before` / `:db-after` and the structured `:sub-runs` / `:renders` / `:effects` projection included — the right shape when you think in runs and don't want to re-fold the raw stream yourself.
+The same verb drives three more streams, distinguished by that leading keyword.
+`:epoch` is the one you'll reach for most after `:trace`: it delivers one
+fully-assembled epoch record per run, *after* it settles, with `:db-before` /
+`:db-after` and the structured `:sub-runs` / `:renders` / `:effects` projection
+included — the right shape when you think in runs and don't want to re-fold the raw
+stream yourself.
 
 ```clojure
 (rf/register-listener! :epoch
@@ -200,15 +345,45 @@ The same verb drives three more streams, distinguished by that leading keyword. 
              "/" (count (:sub-runs epoch-record)) "sub-runs")))
 ```
 
-One subtlety the run-shaped view buys you: the `:epoch` callback fires once per *dequeued event*, not once per drain. If a handler's `:fx` dispatched a child event, the parent and the child are two separate epochs, and your callback fires twice — once each. The exception is work a [state machine](../machines/concepts.md) does to itself: when a transition fires its own follow-up steps (an internal event it raises, or an automatic transition it takes immediately), those ride *inside* the triggering event's epoch rather than firing the callback again. So one user event stays one epoch, however much internal machinery it kicked off.
+One subtlety the run-shaped view buys you: the `:epoch` callback fires once per
+*dequeued event*, not once per drain. If a handler's `:fx` dispatched a child event,
+the parent and the child are two separate epochs, and your callback fires twice —
+once each. The exception is work a
+[state machine](../machines/concepts.md) does to itself: when a transition fires its
+own follow-up steps (an internal event it raises, or an automatic transition it takes
+immediately), those ride *inside* the triggering event's epoch rather than firing the
+callback again. So one user event stays one epoch, however much internal machinery it
+kicked off.
 
-One thing not to read into the word "fires", though: the callback is a *publication*, not a counter. The same epoch is re-published — same `:epoch-id` — when a late render, sub-run, or unmount back-fills into an already-settled run, and a `replace-frame-state!` write or a halt publishes a record no dequeued event produced. Because one listener sees every frame, and an `:epoch-id` is only unique within its own frame, key your own cache by the pair `[(:frame record) (:epoch-id record)]` and let a re-publication *replace* that entry — don't treat each call as a fresh event.
+One thing not to read into the word "fires", though: the callback is a *publication*,
+not a counter. The same epoch is re-published — same `:epoch-id` — when a late
+render, sub-run, or unmount back-fills into an already-settled run, and a
+`replace-frame-state!` write or a halt publishes a record no dequeued event produced.
+Because one listener sees every frame, and an `:epoch-id` is only unique within its
+own frame, key your own cache by the pair
+`[(:frame record) (:epoch-id record)]` and let a re-publication *replace* that entry
+— don't treat each call as a fresh event.
 
-Halted runs show up here too. The `:epoch` stream is the devtools surface for *failed* runs, not just clean ones — the callback fires for halted drains as well, and each record's `:outcome` field tells you how it ended: `:ok` for a clean settle, `:halted-depth` if the run hit the re-entrancy depth guard, `:halted-destroy` if the frame was torn down mid-run. A partial record still carries whatever the runtime captured up to the halt, plus a `:halt-reason` descriptor. That last one, `:halted-destroy`, only ever reaches the listener — a destroyed frame keeps no history, so it never lands in `epoch-history` to re-read or restore. Consumers that only care about successful drains filter on `(= :ok (:outcome record))` at the top of the callback — and remember `restore-epoch!` refuses anything that isn't `:ok`.
+Halted runs show up here too. The `:epoch` stream is the devtools surface for
+*failed* runs, not just clean ones — the callback fires for halted drains as well,
+and each record's `:outcome` field tells you how it ended: `:ok` for a clean settle,
+`:halted-depth` if the run hit the re-entrancy depth guard, `:halted-destroy` if the
+frame was torn down mid-run. A partial record still carries whatever the runtime
+captured up to the halt, plus a `:halt-reason` descriptor. That last one,
+`:halted-destroy`, only ever reaches the listener — a destroyed frame keeps no
+history, so it never lands in `epoch-history` to re-read or restore. Consumers that
+only care about successful drains filter on `(= :ok (:outcome record))` at the top of
+the callback — and remember `restore-epoch!` refuses anything that isn't `:ok`.
 
-(If you've read the Tool-Pair spec or the pair MCP code you'll also have met `register-epoch-listener!` / `unregister-epoch-listener!`. Those are just named aliases for the `:epoch` stream of `register-listener!` — same machinery, same semantics. Use whichever reads better at the call site; the stream-keyword form keeps the four observation feeds under one verb.)
+(If you've read the Tool-Pair contract or the pair MCP code you'll also have met
+`register-epoch-listener!` / `unregister-epoch-listener!`. Those are just named
+aliases for the `:epoch` stream of `register-listener!` — same machinery, same
+semantics. Use whichever reads better at the call site; the stream-keyword form keeps
+the four observation feeds under one verb.)
 
-The remaining two streams — `:events` and `:errors` — are different in kind: they're the **always-on** integration hooks that survive into production. That's the whole story of what ships and what doesn't, so it gets its own section.
+The remaining two streams — `:events` and `:errors` — are different in kind: they're
+the **always-on** integration hooks that survive into production. That's the whole
+story of what ships and what doesn't, so it gets its own section.
 
 ## Production: the wire disappears — errors don't
 
@@ -220,15 +395,38 @@ redacts classified paths when building traces and always-on records. The recipe 
 [Keep secrets out of traces](how-to/keep-secrets-out-of-traces.md); this page owns
 *why* classification exists (one wire, many consumers).
 
-Everything above is development machinery, and none of it ships. The whole dev wire is [**elided**](glossary.md#elide) from production builds — the `:trace` and `:epoch` streams, the rings, the epoch history, the listener registries behind them — all of it sitting behind one compile-time flag (`goog.DEBUG`, a constant the ClojureScript toolchain sets to `false` for production).
+Everything above is development machinery, and none of it ships. The whole dev wire is
+[**elided**](glossary.md#elide) from production builds — the `:trace` and `:epoch`
+streams, the rings, the epoch history, the listener registries behind them — all of
+it sitting behind one compile-time flag (`goog.DEBUG`, a constant the ClojureScript
+toolchain sets to `false` for production).
 
-In an `:advanced` production build, the Closure compiler — the optimising compiler ClojureScript ships through — sees the flag is constantly `false`, so dead-code elimination (DCE) removes every branch guarded by it. The emit calls don't just become no-ops; they're elided entirely, so production bundles carry zero trace code and zero trace cost.
+In an `:advanced` production build, the Closure compiler — the optimising compiler
+ClojureScript ships through — sees the flag is constantly `false`, so dead-code
+elimination (DCE) removes every branch guarded by it. The emit calls don't just become
+no-ops; they're elided entirely, so production bundles carry zero trace code and zero
+trace cost.
 
-One deployment gotcha before we go on: there's no Closure compiler on the JVM, so the same gate defaults *on* there — which is right for tests and the REPL, but means a production JVM process, an SSR host especially, must set `-Dre-frame.debug=false` explicitly. The flag also reads the `RE_FRAME_DEBUG` environment variable, and accepts the usual false-y vocabulary (`false`, `0`, `no`, `off`, empty) case-insensitively. See [configure dev and production builds](how-to/configure-dev-and-prod.md).
+One deployment gotcha before we go on: there's no Closure compiler on the JVM, so the
+same gate defaults *on* there — which is right for tests and the REPL, but means a
+production JVM process, an SSR host especially, must set
+`-Dre-frame.debug=false` explicitly. The flag also reads the `RE_FRAME_DEBUG`
+environment variable, and accepts the usual false-y vocabulary (`false`, `0`, `no`,
+`off`, empty) case-insensitively. See
+[configure dev and production builds](how-to/configure-dev-and-prod.md).
 
-What survives is deliberately narrow: an **always-on error substrate**, kept separate from the dev trace wire. It fires one tight structured [error record](glossary.md#error-record) per production-reachable runtime failure — the error's id, the event and frame context, but never raw values. This is how a handler exception in production reaches Sentry or Datadog *knowing what the user was doing*, instead of arriving as a bare `window.onerror`. (A sibling substrate emits one record per processed event, for throughput-and-latency dashboards.)
+What survives is deliberately narrow: an **always-on error substrate**, kept separate
+from the dev trace wire. It fires one tight structured
+[error record](glossary.md#error-record) per production-reachable runtime failure —
+the error's id, the event and frame context, but never raw values. This is how a
+handler exception in production reaches Sentry or Datadog *knowing what the user was
+doing*, instead of arriving as a bare `window.onerror`. (A sibling substrate emits one
+record per processed event, for throughput-and-latency dashboards.)
 
-These two always-on substrates are the `:events` and `:errors` streams of the same `register-listener!` verb — same shape, but they are *not* elided. Their records are intentionally tight, because they cross into production where the rich dev tags don't exist:
+These two always-on substrates are the `:events` and `:errors` streams of the same
+`register-listener!` verb — same shape, but they are *not* elided. Their records are
+intentionally tight, because they cross into production where the rich dev tags don't
+exist:
 
 ```clojure
 ;; :events — one record per processed event, after the run settles:
@@ -244,11 +442,21 @@ These two always-on substrates are the `:events` and `:errors` streams of the sa
  :exception #object[Error]  :elapsed-ms 7}
 ```
 
-The `:outcome` on an event record reports across *every* run-failure path, so a dispatch that aborted is never mis-reported as a clean `:ok`: `:ok` (committed, flows ran, `:fx` walked), `:error` (the handler or an interceptor threw), `:rolled-back` (schema validation rejected the candidate db before it installed — app-db kept its prior value), or `:flow-error` (a flow's output threw and halted the run). The `:event` vector in both records is run through the framework's wire-elider once before fan-out — a large value becomes `:rf.size/large-elided`, a sensitive one `:rf/redacted` — so the payload is safe to ship as-is. (The `:exception` object on an error record rides raw, deliberately, because off-box shippers need the host throwable and its stack.)
+The `:outcome` on an event record reports across *every* run-failure path, so a
+dispatch that aborted is never mis-reported as a clean `:ok`: `:ok` (committed, flows
+ran, `:fx` walked), `:error` (the handler or an interceptor threw), `:rolled-back`
+(schema validation rejected the candidate db before it installed — app-db kept its
+prior value), or `:flow-error` (a flow's output threw and halted the run). The
+`:event` vector in both records is run through the framework's wire-elider once before
+fan-out — a large value becomes `:rf.size/large-elided`, a sensitive one
+`:rf/redacted` — so the payload is safe to ship as-is. (The `:exception` object on an
+error record rides raw, deliberately, because off-box shippers need the host throwable
+and its stack.)
 
 ### Consuming production telemetry: declare a sink
 
-You consume both streams by declaring a sink in your frame's `:observability` config and registering it with `rf/register-observability-sink!`:
+You consume both streams by declaring a sink in your frame's `:observability` config
+and registering it with `rf/register-observability-sink!`:
 
 ```clojure
 ;; frame config declares which sink id handles errors / events,
@@ -266,9 +474,17 @@ You consume both streams by declaring a sink in your frame's `:observability` co
     (sentry/capture record)))  ;; privacy classification — no scrubbing needed here
 ```
 
-The `:rf.egress/profile` says *how far the data is allowed to travel* — `:rf.egress/off-box-observability` is the profile for a hosted back-end, and it governs how aggressively the runtime projects the record before your sink sees it. The runtime hands your sink records *already projected* through the frame's privacy classification, so a sensitive field arrives redacted before your code sees it — that's the difference from a `:trace` listener, which hands you everything in the clear and trusts you to gate.
+The `:rf.egress/profile` says *how far the data is allowed to travel* —
+`:rf.egress/off-box-observability` is the profile for a hosted back-end, and it
+governs how aggressively the runtime projects the record before your sink sees it. The
+runtime hands your sink records *already projected* through the frame's privacy
+classification, so a sensitive field arrives redacted before your code sees it —
+that's the difference from a `:trace` listener, which hands you everything in the
+clear and trusts you to gate.
 
-Which app-db paths count as sensitive isn't guessed — a handler classifies them as it writes, returning a `:sensitive` effect alongside its `:db` (the [data classification](glossary.md#data-classification) model):
+Which app-db paths count as sensitive isn't guessed — a handler classifies them as it
+writes, returning a `:sensitive` effect alongside its `:db` (the
+[data classification](glossary.md#data-classification) model):
 
 ```clojure
 (rf/reg-event :app/login-succeeded
@@ -277,23 +493,53 @@ Which app-db paths count as sensitive isn't guessed — a handler classifies the
      :sensitive [[:auth :token]]}))   ;; this path is sensitive; redact it on egress
 ```
 
-The wiring recipe is [report errors in production](how-to/report-errors-in-production.md); what counts as an error, and how the framework recovers, is [errors](errors.md).
+The wiring recipe is
+[report errors in production](how-to/report-errors-in-production.md); what counts as
+an error, and how the framework recovers, is [errors](errors.md).
 
 ??? info "Coming from the Sentry / Datadog SDKs?"
 
-    The mental split is: the dev trace wire is rich and elided, while the production error substrate is narrow and always-on. Don't reach for `register-listener!`'s `:trace` stream to feed a hosted monitor — it works in dev and hears *nothing* in production, because the emit sites it would listen to no longer exist. **For production telemetry, you want a sink, not a trace listener.** The sink is also the one that redacts for you, which a raw stream listener never does.
+    The mental split is: the dev trace wire is rich and elided, while the production
+    error substrate is narrow and always-on. Don't reach for `register-listener!`'s
+    `:trace` stream to feed a hosted monitor — it works in dev and hears *nothing* in
+    production, because the emit sites it would listen to no longer exist. **For
+    production telemetry, you want a sink, not a trace listener.** The sink is also
+    the one that redacts for you, which a raw stream listener never does.
 
-Which route, then — sink or raw `:errors` stream? The frame-owned `:observability :errors` sink is the normal production error route, and it's the safe one — projected per-frame before you see it. The raw `:errors` stream of `register-listener!` is the advanced corpus-wide alternative: one fan-out across *every* frame, delivering an *unprojected* record (the `:event` is elided but the `:exception` rides raw and no frame egress policy applies). Reach for it only when you genuinely need a single cross-frame hook or a record the sink route can't carry — and accept that you're then responsible for the trust boundary yourself.
+Which route, then — sink or raw `:errors` stream? The frame-owned
+`:observability :errors` sink is the normal production error route, and it's the safe
+one — projected per-frame before you see it. The raw `:errors` stream of
+`register-listener!` is the advanced corpus-wide alternative: one fan-out across
+*every* frame, delivering an *unprojected* record (the `:event` is elided but the
+`:exception` rides raw and no frame egress policy applies). Reach for it only when
+you genuinely need a single cross-frame hook or a record the sink route can't carry —
+and accept that you're then responsible for the trust boundary yourself.
 
-Want timing in production, too? There's a third production-survivable surface besides `:events` and `:errors`: a Performance API channel, off by default, that brackets the four hot paths (event dispatch, sub recompute, fx walk, render) in `performance.mark` / `performance.measure` calls. Flip it on at build time with `:closure-defines {re-frame.performance/enabled? true}` and any `PerformanceObserver` — including your APM's — reads the User-Timing entries. It's a compile-time flag distinct from `goog.DEBUG`, so you can ship timing without shipping the whole dev wire. [Find and fix a slow view](how-to/fix-a-slow-view.md) shows the entries in use.
+Want timing in production, too? There's a third production-survivable surface besides
+`:events` and `:errors`: a Performance API channel, off by default, that brackets the
+four hot paths (event dispatch, sub recompute, fx walk, render) in
+`performance.mark` / `performance.measure` calls. Flip it on at build time with
+`:closure-defines {re-frame.performance/enabled? true}` and any
+`PerformanceObserver` — including your APM's — reads the User-Timing entries. It's a
+compile-time flag distinct from `goog.DEBUG`, so you can ship timing without shipping
+the whole dev wire. [Find and fix a slow view](how-to/fix-a-slow-view.md) shows the
+entries in use.
 
 ## The tools: four presentations, zero second truths
 
 Now the payoff.
 
-The point isn't that re-frame2 has tools — every framework has tools. Most ecosystems have three, and they disagree with each other: the state tool keeps its own action log, the profiler keeps its own timeline, the error reporter keeps its own breadcrumbs, and when something breaks you sit there cross-examining three witnesses who never met, each with its own clock, each telling a slightly different story about the same afternoon. Too grim? Okay, fine. But notice exactly what makes it grim: more than one source of truth.
+The point isn't that re-frame2 has tools — every framework has tools. Most ecosystems
+have three, and they disagree with each other: the state tool keeps its own action
+log, the profiler keeps its own timeline, the error reporter keeps its own
+breadcrumbs, and when something breaks you sit there cross-examining three witnesses
+who never met. Notice exactly what makes that grim: more than one source of truth.
 
-These tools are different in kind, not just in polish: they are thin presentations over the wire you just met. None has a private back-channel; none patches the framework or instruments your handlers. They bootstrap from the buffer, listen to the stream, and read the epoch history — and because they read the same facts, they tell consistent stories.
+These tools are different in kind, not just in polish: they are thin presentations
+over the wire you just met. None has a private back-channel; none patches the
+framework or instruments your handlers. They bootstrap from the buffer, listen to the
+stream, and read the epoch history — and because they read the same facts, they tell
+consistent stories.
 
 ```mermaid
 flowchart LR
@@ -305,13 +551,32 @@ flowchart LR
     WIRE --> YOU[your listener]
 ```
 
-**Xray answers: what happened?** It's the Redux DevTools of this world, grown to the full run: the epoch ledger, app-db diffs per event, which subscriptions recomputed, which views rendered, effects, machine transitions, schema failures — and time-travel scrubbing via `restore-epoch`. It also assembles the registration facts into the [derivation graph](derivations-and-algebra-views.md): "where does this value come from?" drawn as a picture. Reach for it when you're debugging the running app — start with [debug with Xray](../xray/index.md).
+**Xray answers: what happened?** It's the Redux DevTools of this world, grown to the
+full run: the epoch ledger, app-db diffs per event, which subscriptions recomputed,
+which views rendered, effects, machine transitions, schema failures — and time-travel
+scrubbing via `restore-epoch`. It also assembles the registration facts into the
+[derivation graph](derivations-and-algebra-views.md): "where does this value come
+from?" drawn as a picture. Reach for it when you're debugging the running app — start
+with [debug with Xray](../xray/index.md).
 
-**Story answers: what states should this thing have?** It's the Storybook of this world. You render a [view](glossary.md#view)'s loading, empty, error, and happy states as named variants, each in its own isolated frame, without driving the whole app there by hand — then promote the good examples into tests. Story embeds Xray's panels for diagnosis rather than growing a second diff engine, and it has [its own tutorial track](../story/index.md) in its docs.
+**Story answers: what states should this thing have?** It's the Storybook of this
+world. You render a [view](glossary.md#view)'s loading, empty, error, and happy
+states as named variants, each in its own isolated frame, without driving the whole
+app there by hand — then promote the good examples into tests. Story embeds Xray's
+panels for diagnosis rather than growing a second diff engine, and it has
+[its own tutorial track](../story/index.md) in its docs.
 
-**The pair MCP answers: can an agent help?** It's an MCP server that lets an AI attach to your *running* app: read frames and app-db, follow epochs, dispatch events, dry-run a pipeline run, time-travel — all through the same structured surfaces, with the mutating tools flagged so the agent host can gate them. The agent sees the evidence a good human debugger would ask for, instead of guessing from source.
+**The pair MCP answers: can an agent help?** It's an MCP server that lets an AI attach
+to your *running* app: read frames and app-db, follow epochs, dispatch events, dry-run
+a pipeline run, time-travel — all through the same structured surfaces, with the
+mutating tools flagged so the agent host can gate them. The agent sees the evidence a
+good human debugger would ask for, instead of guessing from source.
 
-**machines-viz answers: what does this machine look like?** It's a statechart renderer (think Stately Studio) that turns a [machine definition](../machines/concepts.md) into an interactive chart with the live current state highlighted. It's presentation-only — both Xray's machine inspector and Story embed it.
+**machines-viz answers: what does this machine look like?** It's a statechart renderer
+(think Stately Studio) that turns a
+[machine definition](../machines/concepts.md) into an interactive chart with the live
+current state highlighted. It's presentation-only — both Xray's machine inspector and
+Story embed it.
 
 | Question | Open | Why |
 |---|---|---|
@@ -323,13 +588,28 @@ flowchart LR
 | "Can an AI inspect the live app?" | the pair MCP | The agent reads the same frame, trace, and epoch surfaces you do. |
 | "Can I ship telemetry to my APM?" | none of these | That's the always-on sink path above — production never has the dev panels. |
 
-And here's the rule for the tool you might write yourself — a domain monitor, a recorder, a release-health dashboard: consume the public substrate, don't invent a private one. What happened is in the trace and epoch records; what exists is in the [registrar](glossary.md#registrar); state reads respect frame identity and privacy markings. The framework owns the data shape, and tools own the rendering. That division is why one listener registration is a complete tooling integration, and why the ecosystem stays one truth instead of a pile of almost-right panels.
+And here's the rule for the tool you might write yourself — a domain monitor, a
+recorder, a release-health dashboard: consume the public substrate, don't invent a
+private one. What happened is in the trace and epoch records; what exists is in the
+[registrar](glossary.md#registrar); state reads respect frame identity and privacy
+markings. The framework owns the data shape, and tools own the rendering. That
+division is why one listener registration is a complete tooling integration, and why
+the ecosystem stays one truth instead of a pile of almost-right panels.
 
 ## Advanced
 
-If the tool you write *dispatches its own events* — a recorder that writes captured events into its own app-db, an inspector that drives a panel — you hit a circularity the moment your listener fires synchronously mid-run: your bookkeeping dispatch emits its own trace events, which re-enter your listener, which dispatches again. Two opt-out flags exist precisely for this, and they're how Xray, Story, and the pair MCP stay quiet on the very wire they watch.
+If the tool you write *dispatches its own events* — a recorder that writes captured
+events into its own app-db, an inspector that drives a panel — you hit a circularity
+the moment your listener fires synchronously mid-run: your bookkeeping dispatch emits
+its own trace events, which re-enter your listener, which dispatches again. Two
+opt-out flags exist precisely for this, and they're how Xray, Story, and the pair MCP
+stay quiet on the very wire they watch.
 
-**Silence one handler — `:rf.trace/no-emit?` in the registration meta.** A handler whose registration carries the flag produces no trace events for the work it does — the run still proceeds, commits, and walks its effects; it just doesn't narrate. The innermost in-scope handler wins, so a normal handler dispatched *from inside* a silenced one is visible again.
+**Silence one handler — `:rf.trace/no-emit?` in the registration meta.** A handler
+whose registration carries the flag produces no trace events for the work it does —
+the run still proceeds, commits, and walks its effects; it just doesn't narrate. The
+innermost in-scope handler wins, so a normal handler dispatched *from inside* a
+silenced one is visible again.
 
 ```clojure
 (rf/reg-event :my-tool/note-trace-event
@@ -338,9 +618,17 @@ If the tool you write *dispatches its own events* — a recorder that writes cap
     {:db (update db :captured (fnil conj []) ev)}))
 ```
 
-One subtlety with a production reach: the always-on `:events` stream honours this flag too — a `:rf.trace/no-emit?` handler is dropped from the production event-emit record as well, on the principle that a tool's internal bookkeeping isn't user-domain signal. (The `:errors` stream is unaffected; a real error still surfaces.)
+One subtlety with a production reach: the always-on `:events` stream honours this flag
+too — a `:rf.trace/no-emit?` handler is dropped from the production event-emit record
+as well, on the principle that a tool's internal bookkeeping isn't user-domain signal.
+(The `:errors` stream is unaffected; a real error still surfaces.)
 
-**Silence a whole frame — `:rf.trace/frame-no-emit?` in the frame config.** An inspector renders its *own* UI in a dedicated frame, and that UI's subscriptions and renders emit `:rf.sub/run` / `:rf.view/render` like any other — enough, on a busy panel, to evict every application run from the buffer the inspector is supposed to be showing you. Marking the tool's frame trace-disabled makes it emit nothing at all, while every application frame is untouched.
+**Silence a whole frame — `:rf.trace/frame-no-emit?` in the frame config.** An
+inspector renders its *own* UI in a dedicated frame, and that UI's subscriptions and
+renders emit `:rf.sub/run` / `:rf.view/render` like any other — enough, on a busy
+panel, to evict every application run from the buffer the inspector is supposed to be
+showing you. Marking the tool's frame trace-disabled makes it emit nothing at all,
+while every application frame is untouched.
 
 ```clojure
 (rf/make-frame
@@ -348,8 +636,24 @@ One subtlety with a production reach: the always-on `:events` stream honours thi
    :rf.trace/frame-no-emit? true})          ;; a tool frame: no trace from here
 ```
 
-This is the mechanism behind "a devtool in its own frame can storm its own subscriptions without polluting your app frame's history" — the per-frame ring isolates the *storage*, and this flag suppresses the tool frame's *emission* entirely. Both flags sit inside the same dev-only elision gate as everything else here, so they cost nothing in production (which emits no trace anyway).
+This is the mechanism behind "a devtool in its own frame can storm its own
+subscriptions without polluting your app frame's history" — the per-frame ring
+isolates the *storage*, and this flag suppresses the tool frame's *emission*
+entirely. Both flags sit inside the same dev-only elision gate as everything else
+here, so they cost nothing in production (which emits no trace anyway).
 
 ??? note "Going deeper"
 
-    The wire is a *free monoid* of trace events — an append-only sequence with one associative operation (concatenation) and an identity (the empty stream). Every tool is then a *fold* over that sequence: Xray folds it into an epoch ledger, a metrics sink folds it into counters, `group-by-event` folds the flat ring into bundles. Because a fold is determined entirely by its accumulator and step function — and the underlying sequence is the same for everyone — two correct folds over one stream *cannot* disagree about a shared question; they can only project different facets. "One truth, many presentations" isn't a discipline the tools agree to uphold. It's an algebraic property of building every reader as a fold over a single shared sequence. The dispatch-id correlation adds a second structure on top: it makes the stream not just a flat sequence but a *forest* (each run a tree rooted at its dispatched event, child runs hanging off `:parent-dispatch-id`), so causal queries are tree walks rather than scans.
+    The wire is a *free monoid* of trace events — an append-only sequence with one
+    associative operation (concatenation) and an identity (the empty stream). Every
+    tool is then a *fold* over that sequence: Xray folds it into an epoch ledger, a
+    metrics sink folds it into counters, `group-by-event` folds the flat ring into
+    bundles. Because a fold is determined entirely by its accumulator and step
+    function — and the underlying sequence is the same for everyone — two correct
+    folds over one stream *cannot* disagree about a shared question; they can only
+    project different facets. "One truth, many presentations" isn't a discipline the
+    tools agree to uphold. It's an algebraic property of building every reader as a
+    fold over a single shared sequence. The dispatch-id correlation adds a second
+    structure on top: it makes the stream not just a flat sequence but a *forest*
+    (each run a tree rooted at its dispatched event, child runs hanging off
+    `:parent-dispatch-id`), so causal queries are tree walks rather than scans.

--- a/docs/core/run-to-completion.md
+++ b/docs/core/run-to-completion.md
@@ -13,10 +13,10 @@ This page is **operational detail**: what happens when a drain runs away, how
 ## When the drain won't stop
 
 What if a handler dispatches an event whose handler dispatches the first one again?
-Stagehands queueing stagehands forever — a curtain that never rises. The runtime
-won't let it. Each frame carries a **`:drain-depth`** — the maximum number of events
-one drain may process (default `100`). When a drain reaches it, the runtime stops
-with a loud, machine-readable [error record](glossary.md#error-record):
+A cycle that never finishes. The runtime won't let it. Each frame carries a
+**`:drain-depth`** — the maximum number of events one drain may process (default
+`100`). When a drain reaches it, the runtime stops with a loud, machine-readable
+[error record](glossary.md#error-record):
 
 ```clojure
 {:operation :rf.error/drain-depth-exceeded

--- a/docs/core/subscriptions.md
+++ b/docs/core/subscriptions.md
@@ -13,12 +13,9 @@ derivation that turns facts into a conclusion, and re-runs only when it must.
 > **A UI is derived data. Subscriptions are how you name and share those
 > derivations.**
 
-**On this page — two speeds.**
-
-1. **Day one** (through the prune demo): derive-don't-store, what a subscription is,
-   layered graphs, the equality gate. **Stop there and ship.**
-2. **Going further**: argument-dependent inputs, metadata, lifecycle, framework
-   subs, wrong tool, recovery. Open a section only when a need appears.
+Through the prune demo you get derive-don't-store, what a subscription is, layered
+graphs, and the equality gate — enough to ship. Argument-dependent inputs, metadata,
+lifecycle, framework subs, wrong-tool cases, and recovery live under Advanced.
 
 ## Don't Store What You Can Derive
 
@@ -30,8 +27,8 @@ app-db and keep it updated alongside the value.
 
 Don't.
 
-Odd-or-even isn't a new *fact*. It's a *consequence* of a fact you already have,
-and two copies of one truth is two chances to disagree. Derive it, live:
+Odd-or-even isn't a new *fact*. It's a *consequence* of a fact you already have.
+Two copies of one truth is two chances to disagree. Derive it, live:
 
 ```cljs-rf2
 (require '[re-frame.core :as rf])
@@ -68,7 +65,7 @@ over it. That `:<-` line declares the dependency, and because the framework *kno
 the dependency, `:parity` recomputes only when `:value` changes, and anything
 watching `:parity` re-renders only when the *answer* changes.
 
-Hold onto the spreadsheet. It's the metaphor for the rest of the page.
+The spreadsheet is the metaphor for the rest of the page.
 
 ## What Is a Subscription, Exactly?
 
@@ -97,7 +94,7 @@ the sub destructures it from the same vector it was called with:
 ```
 
 Now, that little `@`. It is doing two jobs, and the second one is the entire trick
-of reactive programming, so let's not rush past it. Job one: unwrap the reactive
+of reactive programming, so don't rush past it. Job one: unwrap the reactive
 reference to a plain value. Job two: register the deref-ing view as a *dependent*,
 so the view re-renders when — and only when — that value changes.
 
@@ -139,10 +136,10 @@ repeated subscribes share one slot.
 
 Coming from Redux? A subscription is a selector — Reselect's `createSelector` with
 the memoisation built in. From Solid or Jotai? A derived signal. Three deliberate
-differences, all in your favour: subscriptions are *named* in a registry, so tools
-can draw the whole graph without running your app; change detection is deep value
-equality (`=`), never reference identity; and dependencies are declared as data,
-not discovered by watching a function run.
+differences: subscriptions are *named* in a registry, so tools can draw the whole
+graph without running your app; change detection is deep value equality (`=`),
+never reference identity; and dependencies are declared as data, not discovered by
+watching a function run.
 
 ## Three Layers, One Graph
 
@@ -191,13 +188,12 @@ Read `:<-` as "this sub's input comes from". Notice what changed between layers:
 deliver a vector, destructured above as `[items category]`. That's the only
 wrinkle in the syntax. Once you've seen it, you've seen it.
 
-And notice something quieter: the *shape of the registration* is the *shape of the
-graph*. `(fn [db _] ...)` is an extractor by construction. `:<-` is a composer by
-construction. The framework can read the registry and know your entire topology as
-data — which is exactly how [Xray](glossary.md#xray) draws your subscription
-graph without executing a single computation function (`re-frame.subs.tooling/sub-topology`
-is a literal read of the registry). Declared dependencies, not discovered ones.
-This will be a theme.
+The *shape of the registration* is the *shape of the graph*. `(fn [db _] ...)` is
+an extractor by construction. `:<-` is a composer by construction. The framework
+can read the registry and know your entire topology as data — which is exactly how
+[Xray](glossary.md#xray) draws your subscription graph without executing a single
+computation function (`re-frame.subs.tooling/sub-topology` is a literal read of the
+registry). Declared dependencies, not discovered ones.
 
 ## The Equality Gate
 
@@ -206,14 +202,13 @@ I said the graph is fast without tuning. Here is the entire mechanism. One rule:
 > **A subscription's cached value is invalidated only when one of its inputs
 > actually changes value — checked with `=`, deep value equality.**
 
-I'll pause while you read that again. It's the load-bearing sentence of this page.
+That rule is what makes layered subs cheap. Walk it through.
 
-Walk it through. App-db changes. The layer-1 extractors re-run — all of them, every
-time, because app-db is their input. Each one's new output is compared with its
-previous output by `=`. If the slice didn't change, the cached value stands and
-**propagation stops right there**. Downstream subs don't re-run. Views don't
-re-render. Nothing past the unchanged extractor even learns an
-[event](glossary.md#event) happened.
+App-db changes. The layer-1 extractors re-run — all of them, every time, because
+app-db is their input. Each one's new output is compared with its previous output
+by `=`. If the slice didn't change, the cached value stands and **propagation stops
+right there**. Downstream subs don't re-run. Views don't re-render. Nothing past
+the unchanged extractor even learns an [event](glossary.md#event) happened.
 
 That makes layer 1 a **circuit breaker** for everything behind it. Change
 `:cart/category-filter` and the `:cart/items` extractor re-runs, sees its slice is
@@ -314,8 +309,6 @@ with [Xray](glossary.md#xray) attached (one-line setup:
 event row, and open the **Views** tab: `:cart/count-label` is marked as the
 re-render's trigger while `:cart/currency-label` sits beside it, unmarked.
 
-## Day-one checklist
-
 You can:
 
 - keep facts in app-db and **derive** conclusions in named subs;
@@ -328,7 +321,7 @@ That is enough for real screens. The sections below are optional depth.
 
 ---
 
-## Going further
+## Advanced
 
 ## When the Inputs Depend on the Arguments
 
@@ -546,10 +539,9 @@ is [Where should this value live?](where-state-lives.md):
     `useQuery` both fetches and derives. re-frame2 splits those: resources own
     fetch-cache-invalidate; subscriptions derive over state already in hand.
 
-## When Things Go Wrong
+## Troubleshooting
 
-Three corners you won't need on day one. You'll want them the day something goes
-sideways, so here they are.
+Three corners you can skip until something goes sideways — then you'll want them.
 
 **A computation throws.** A `nil` where you assumed a map; a divide-by-zero in a
 derived total. re-frame2 treats it as a [fail-loud](glossary.md#fail-loud-not-silent)

--- a/docs/core/testing/views.md
+++ b/docs/core/testing/views.md
@@ -6,7 +6,7 @@ No browser for this one either. A [view](../glossary.md#view) is a pure function
 
 > **A view test calls the function and walks the returned data — no DOM, no JSDOM, no `act()`.**
 
-One honest framing before the recipe: **most "view bugs" are data bugs.** A view holds no state and decides nothing, so when the screen is wrong, the culprit is nearly always the [subscription](subscriptions.md) or [handler](event-handlers.md) upstream — pure functions with cheaper tests ([Views](../views.md#when-things-go-wrong) makes the case). A view test is for what a view genuinely *owns*: its structure, its text, and its wiring. That's the whole list.
+One honest framing before the recipe: **most "view bugs" are data bugs.** A view holds no state and decides nothing, so when the screen is wrong, the culprit is nearly always the [subscription](subscriptions.md) or [handler](event-handlers.md) upstream — pure functions with cheaper tests ([Views](../views.md#troubleshooting) makes the case). A view test is for what a view genuinely *owns*: its structure, its text, and its wiring. That's the whole list.
 
 The toolkit is `re-frame.test-helpers` — pure walks over hiccup, [catalogued in the API reference](../../api/re-frame.test-helpers.md) — alongside the `re-frame.test-support` fixtures you already use:
 

--- a/docs/core/views.md
+++ b/docs/core/views.md
@@ -18,16 +18,19 @@ centralised state. [Subscriptions](subscriptions.md) derive values from it. View
 sit at the end of the flow and render whatever arrives — a **window** onto the
 application, not the room itself.
 
-**On this page — two speeds.**
-
-1. **Day one:** composition, hiccup, subscribe-in / dispatch-out, `reg-view`,
-   compute-in-subs. After the live qty cell the **pure pipeline is complete**.
-2. **Going further:** Form-2/3, multi-frame targeting, substrate seam. Open only
-   when a need appears.
+After the live qty cell the **pure pipeline is complete**. Form-2/3, multi-frame
+targeting, and the substrate boundary live under Advanced — open them only when a
+need appears.
 
 ??? info "For JavaScript developers"
 
-    A re-frame2 view is a React function component with everything except rendering removed. No `useState` — state lives in [app-db](app-db.md), your app's single state map, and arrives through [subscriptions](subscriptions.md). No `useEffect` — anything that touches the world is an [effect](effects.md), produced as data by an [event handler](glossary.md#event-handler) and never run from a component. No JSX — a view returns plain Clojure data. The design here is in what got *subtracted*, not in anything added.
+    A re-frame2 view is a React function component with everything except rendering
+    removed. No `useState` — state lives in [app-db](app-db.md), your app's single
+    state map, and arrives through [subscriptions](subscriptions.md). No
+    `useEffect` — anything that touches the world is an [effect](effects.md),
+    produced as data by an [event handler](glossary.md#event-handler) and never run
+    from a component. No JSX — a view returns plain Clojure data. The design here is
+    in what got *subtracted*, not in anything added.
 
 ## The counter gets components
 
@@ -71,7 +74,8 @@ Notes:
 
 ## Hiccup: the screen is data
 
-A view returns [hiccup](hiccup.md) — the notation from early in the track: nested Clojure vectors shaped like the DOM they describe:
+A view returns [hiccup](hiccup.md) — the notation from early in the track: nested
+Clojure vectors shaped like the DOM they describe:
 
 ```clojure
 [:div.cart
@@ -81,30 +85,51 @@ A view returns [hiccup](hiccup.md) — the notation from early in the track: nes
 
 The rules are quick to learn:
 
-- A vector whose first element is a keyword is an **element**. `:div.cart` is a `<div class="cart">` — the `.class` shorthand comes from CSS selectors, and `:input#email.wide` adds an id too.
-- A map in second position is the **attributes**: `[:button {:on-click f :disabled true} "Go"]`.
-- Everything after that is **children**. Strings become text; nested vectors become nested elements.
-- A vector whose first element is a **view** (not a keyword) renders that view, with the rest of the vector as its arguments — `[counter-button "−" [:dec]]` above. That's the composition rule the counter used.
+- A vector whose first element is a keyword is an **element**. `:div.cart` is a
+  `<div class="cart">` — the `.class` shorthand comes from CSS selectors, and
+  `:input#email.wide` adds an id too.
+- A map in second position is the **attributes**:
+  `[:button {:on-click f :disabled true} "Go"]`.
+- Everything after that is **children**. Strings become text; nested vectors become
+  nested elements.
+- A vector whose first element is a **view** (not a keyword) renders that view, with
+  the rest of the vector as its arguments — `[counter-button "−" [:dec]]` above.
+  That's the composition rule the counter used.
 
-The important word is *data*. Not "data-like". Actual vectors, maps, and keywords — the same structures you manipulate everywhere else in the program. So you build screens with ordinary code and no template syntax:
+The important word is *data*. Not "data-like". Actual vectors, maps, and keywords —
+the same structures you manipulate everywhere else in the program. So you build
+screens with ordinary code and no template syntax:
 
 ```clojure
 (into [:ul] (for [item items] [:li (:name item)]))
 ```
 
-And because hiccup is just data, everything you already know how to do with data works on screens. A function can take hiccup and return hiccup. You can `pprint` a view's output and *read* it. A pure function that walks hiccup and emits an HTML string can run on the server — which is how [server-side rendering](../ssr/concepts.md) renders the *same* views without a browser in the building.
+And because hiccup is just data, everything you already know how to do with data
+works on screens. A function can take hiccup and return hiccup. You can `pprint` a
+view's output and *read* it. A pure function that walks hiccup and emits an HTML
+string can run on the server — which is how
+[server-side rendering](../ssr/concepts.md) renders the *same* views without a
+browser in the building.
 
 ??? info "For JavaScript developers"
 
-    Template strings can do none of this. They don't compose, they don't diff, and string-built markup is where injection bugs come from. Hiccup is closer in spirit to React's `createElement` calls — a tree of data describing the UI — except it's plain literals you can map, filter, and pass around, with no build-time transform.
+    Template strings can do none of this. They don't compose, they don't diff, and
+    string-built markup is where injection bugs come from. Hiccup is closer in spirit
+    to React's `createElement` calls — a tree of data describing the UI — except it's
+    plain literals you can map, filter, and pass around, with no build-time
+    transform.
 
 ??? note "Going deeper"
 
-    Hiccup is the ClojureScript render-tree — the shape that survives serialisation across the JVM/browser boundary. Other hosts use their own render-tree shape behind the same contract.
+    Hiccup is the ClojureScript render-tree — the shape that survives serialisation
+    across the JVM/browser boundary. Other hosts use their own render-tree shape
+    behind the same contract.
 
 ## Subscribe in, dispatch out
 
-A static screen isn't much use. A view needs to read live application state, and it needs to react to clicks and typing. Two jobs, exactly two openings — and both are one-way.
+A static screen isn't much use. A view needs to read live application state, and it
+needs to react to clicks and typing. Two jobs, exactly two openings — and both are
+one-way.
 
 **Reading state in: the view derefs a [subscription](glossary.md#subscription).**
 
@@ -112,28 +137,48 @@ A static screen isn't much use. A view needs to read live application state, and
 @(rf/subscribe [:cart/total])
 ```
 
-This declares "I depend on this derived value. Re-run me when it changes." That's the only way a view learns application state. It doesn't read [app-db](glossary.md#app-db) directly, and it doesn't receive the value as an argument threaded down through ten ancestors. It asks the [derivation graph](glossary.md#the-derivation-graph) for exactly the slice it needs, *by name* — via a [query vector](glossary.md#query-vector), the `[id & args]` shape that names the subscription and keys its cache. (More on subscriptions in [Subscriptions](subscriptions.md).)
+This declares "I depend on this derived value. Re-run me when it changes." That's the
+only way a view learns application state. It doesn't read
+[app-db](glossary.md#app-db) directly, and it doesn't receive the value as an
+argument threaded down through ten ancestors. It asks the
+[derivation graph](glossary.md#the-derivation-graph) for exactly the slice it needs,
+*by name* — via a [query vector](glossary.md#query-vector), the `[id & args]` shape
+that names the subscription and keys its cache. (More on subscriptions in
+[Subscriptions](subscriptions.md).)
 
-**Sending events out: the view [dispatches](glossary.md#dispatch).** Wire the view's `dispatch` to an [event handler](glossary.md#event-handler):
+**Sending events out: the view [dispatches](glossary.md#dispatch).** Wire the view's
+`dispatch` to an [event handler](glossary.md#event-handler):
 
 ```clojure
 [:button {:on-click #(dispatch [:cart/add id])} "Add"]
 ```
 
 (`dispatch` here is the local `reg-view` injects — bound to the view's
-[frame](glossary.md#frame), and captured so it still routes correctly when the
-click fires, *after* the render. More on that [below](#the-trap-a-callback-that-fires-after-render-has-no-frame).)
+[frame](glossary.md#frame), and captured so it still routes correctly when the click
+fires, *after* the render. More on that
+[below](#the-trap-a-callback-that-fires-after-render-has-no-frame).)
 
-A dispatch *announces that something happened* by handing the framework an [event](glossary.md#event) — a plain vector naming what occurred — and returns immediately. It does not change state. It does not know or care what the handler will do with it. The [event pipeline](glossary.md#event-pipeline) takes it from there: the handler runs, `app-db` moves, subscriptions repropagate, and at the very end this view re-renders to match. (The whole traversal is the [Introduction](introduction.md)'s subject.)
+A dispatch *announces that something happened* by handing the framework an
+[event](glossary.md#event) — a plain vector naming what occurred — and returns
+immediately. It does not change state. It does not know or care what the handler will
+do with it. The [event pipeline](glossary.md#event-pipeline) takes it from there: the
+handler runs, `app-db` moves, subscriptions repropagate, and at the very end this
+view re-renders to match. (The whole traversal is the
+[Introduction](introduction.md)'s subject.)
 
-Notice the shape of the round trip, because it's the whole idea. A click never mutates the number it sits next to. It dispatches an event that produces a *new* `app-db`, which flows back through a subscription. The view can't short-circuit that path, because it holds no state to short-circuit with. In window terms: you can see into the room, and you can knock. What happens after the knock is the room's business, not the window's.
+Notice the shape of the round trip — it's the whole idea. A click never mutates the
+number it sits next to. It dispatches an event that produces a *new* `app-db`, which
+flows back through a subscription. The view can't short-circuit that path, because it
+holds no state to short-circuit with. In window terms: you can see into the room, and
+you can knock. What happens after the knock is the room's business, not the window's.
 
 ??? info "Coming from Redux?"
 
-    `subscribe` is `useSelector` and `dispatch` is `dispatch` — the same unidirectional
-    dataflow. The difference is that the "selector" is a named, cached node in a
-    derivation graph (see [subscriptions](subscriptions.md)) rather than a function
-    you pass inline, and the event is dispatched as data rather than through a thunk.
+    `subscribe` is `useSelector` and `dispatch` is `dispatch` — the same
+    unidirectional dataflow. The difference is that the "selector" is a named, cached
+    node in a derivation graph (see [subscriptions](subscriptions.md)) rather than a
+    function you pass inline, and the event is dispatched as data rather than through
+    a thunk.
 
 ## A view, live
 
@@ -163,12 +208,12 @@ macOS) to evaluate, then click the buttons:
 ```
 
 Keep the `:demo` `frame-root` and change its child from `[qty-stepper]` to
-`[:div [qty-stepper] [qty-stepper]]`, then re-evaluate. Click either stepper:
-both move. Both mount under the same seeded `:demo` [frame](glossary.md#frame),
-so neither owns the number — each is a window onto the one app-db value. There is
-no local copy to fall out of sync. (Replacing the whole `frame-root` with the
-bare `[:div …]` would drop the `:demo` seed and land the steppers on an
-uninitialised frame — keep the wrapper.)
+`[:div [qty-stepper] [qty-stepper]]`, then re-evaluate. Click either stepper: both
+move. Both mount under the same seeded `:demo` [frame](glossary.md#frame), so neither
+owns the number — each is a window onto the one app-db value. There is no local copy
+to fall out of sync. (Replacing the whole `frame-root` with the bare `[:div …]` would
+drop the `:demo` seed and land the steppers on an uninitialised frame — keep the
+wrapper.)
 
 ### The pure pipeline is complete
 
@@ -193,8 +238,8 @@ isolation and carry are [Frames](frames.md); packaging a real entry point is
    `:my.app/qty-stepper`). Tooling lists the view, jumps to source, and names
    renders in the trace.
 2. **Frame-aware injection.** Unqualified `dispatch` and `subscribe` are locals
-   bound to the [frame](glossary.md#frame) the view renders under — so the same
-   view mounts in several worlds without renaming anything.
+   bound to the [frame](glossary.md#frame) the view renders under — so the same view
+   mounts in several worlds without renaming anything.
 
 ```clojure
 (rf/reg-view qty-stepper []
@@ -284,11 +329,15 @@ wrappers. The [TodoMVC example](../../examples/core/todomvc) follows this split.
 
 ## The one rule: views compute hiccup only
 
-Now the single discipline that keeps views fast, correct, and easy to debug. It pays for itself within a day of writing real screens:
+Now the single discipline that keeps views fast, correct, and easy to debug. It pays
+for itself within a day of writing real screens:
 
-> **Views compute hiccup only. Everything else — sorting, filtering, formatting, deriving, joining — happens in a subscription.**
+> **Views compute hiccup only. Everything else — sorting, filtering, formatting,
+> deriving, joining — happens in a subscription.**
 
-The temptation always looks innocent. The subscribed list is *almost* what the screen needs, so you reach for one little `sort-by` here, one `.toFixed` there. Don't. Here's the *before*, with the view quietly doing two jobs that aren't its own:
+The temptation always looks innocent. The subscribed list is *almost* what the screen
+needs, so you reach for one little `sort-by` here, one `.toFixed` there. Don't.
+Here's the *before*, with the view quietly doing two jobs that aren't its own:
 
 ```clojure
 ;; Before — the view computes. The sort and the price-format re-run on
@@ -299,7 +348,8 @@ The temptation always looks innocent. The subscribed list is *almost* what the s
      ^{:key (:id item)} [:li (:name item) " — $" (.toFixed (:price item) 2)])])
 ```
 
-And the *after*, with the derivation pushed up into a [subscription](subscriptions.md) where it belongs:
+And the *after*, with the derivation pushed up into a
+[subscription](subscriptions.md) where it belongs:
 
 ```clojure
 ;; After — the sub computes once per change to :cart/items; the view renders.
@@ -316,7 +366,8 @@ And the *after*, with the derivation pushed up into a [subscription](subscriptio
      ^{:key (:id item)} [:li (:name item) " — $" (:price item)])])
 ```
 
-Ask the "after" view what it does: all it does is walk the list and emit `<li>`s. That's a view that knows what it's for.
+Ask the "after" view what it does: all it does is walk the list and emit `<li>`s.
+That's a view that knows what it's for.
 
 Why so strict? Because a view re-runs whenever any value it derefs changes, and
 whenever a re-rendering parent hands it changed arguments — and a `sort-by` in the
@@ -339,12 +390,10 @@ most common way re-frame2 apps get accidentally slow; the hunt and the fix are i
     position. Key by durable data, never the loop index. Missing or colliding keys
     can silently keep stale DOM, drop a row, or duplicate one — not an error.
 
-## Day-one checklist
-
 You can compose registered views, subscribe in / dispatch out, keep computation in
 subs, and seed setup via `:initial-events`. That closes the pure pipeline stages.
 
-## When things go wrong
+## Troubleshooting
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
@@ -405,7 +454,7 @@ that survives any async hop. [Frames](frames.md) is that pattern's home.
 
 ---
 
-## Going further
+## Advanced
 
 ??? note "Targeting a different frame"
 
@@ -421,12 +470,12 @@ that survives any async hop. [Frames](frames.md) is that pattern's home.
     Escape hatch, not the daily path. For a whole subtree, `rf/with-frame` or
     `frame-provider` — [Frames](frames.md).
 
-??? note "The substrate seam"
+??? note "The substrate boundary"
 
     Handlers, subs, and app-db never name a rendering library. The adapter
-    (`(rf/init! reagent-adapter/adapter)`) is the seam where hiccup becomes pixels.
+    (`(rf/init! reagent-adapter/adapter)`) is where hiccup becomes pixels.
     Port substrates and only `init!` plus view notation change —
-    [Use UIx or reagent-slim](how-to/use-uix-or-slim.md). A more
-    radical, still-experimental option is [re-frame.ui](re-frame.ui/index.md), a
-    first-party *compiled* view substrate where views are macro-compiled rather
-    than interpreted at runtime.
+    [Use UIx or reagent-slim](how-to/use-uix-or-slim.md). A more radical,
+    still-experimental option is [re-frame.ui](re-frame.ui/index.md), a first-party
+    *compiled* view substrate where views are macro-compiled rather than
+    interpreted at runtime.

--- a/docs/core/where-state-lives.md
+++ b/docs/core/where-state-lives.md
@@ -27,7 +27,7 @@ That rule is the whole page; everything below is it, unpacked four times.
 
 ??? info "For JavaScript developers"
 
-    You already make this call — you just make it across four separate libraries. A selector (reselect) for a derived value, Redux for store state, TanStack Query for the server cache, XState for process state. re-frame2 keeps those same four territories inside one framework: one mental model instead of four, one trace stream instead of four devtools panels. As each home comes up below, we'll point at the JS tool it stands in for.
+    You already make this call — you just make it across four separate libraries. A selector (reselect) for a derived value, Redux for store state, TanStack Query for the server cache, XState for process state. re-frame2 keeps those same four territories inside one framework: one model instead of four, one trace stream instead of four devtools panels. As each home comes up below, we'll point at the JS tool it stands in for.
 
 ??? info "From re-frame v1"
 
@@ -35,9 +35,7 @@ That rule is the whole page; everything below is it, unpacked four times.
 
 ## One value, four homes: the cart
 
-The fastest way to feel the four questions is to follow a single value as a feature grows up — because a value moves house the way people do. It starts out owning nothing, recomputed fresh whenever anyone asks. Then it needs a fixed address other code can find it at. Then it's dealing with a landlord on another continent who can change the place while you're out. And eventually it has house rules, a timer on the porch light, and a homeowners' association with opinions about which room may follow which.
-
-Too much? Fine. Watch a shopping cart do it instead.
+The fastest way to feel the four questions is to follow a single value as a feature grows up. A value starts as a pure recompute. Then a handler needs it as data. Then the data comes from a server. Then you're modelling a process, not a number. Watch a shopping cart do it.
 
 ### Question 1 — can you recompute it? Then it's a subscription
 

--- a/skills/re-frame-migration/references/xray-replaces-10x.md
+++ b/skills/re-frame-migration/references/xray-replaces-10x.md
@@ -1,6 +1,6 @@
 # xray-replaces-10x
 
-The devtools swap. v1 ships `day8.re-frame-10x`; v2 ships **Xray** (`day8/re-frame2-xray`). **Xray IS the v2 devtools replacement for re-frame-10x** — a from-scratch reimplementation against re-frame2's own trace bus and epoch-history surfaces, not a port of 10x. The mental model (events, subs, app-db diff, time-travel) carries over; the wiring underneath does not. See [`docs/core/25-from-re-frame-v1.md` §The devtools moved house](../../../docs/core/25-from-re-frame-v1.md#the-devtools-moved-house) for the narrative version of this swap.
+The devtools swap. v1 ships `day8.re-frame-10x`; v2 ships **Xray** (`day8/re-frame2-xray`). **Xray IS the v2 devtools replacement for re-frame-10x** — a from-scratch reimplementation against re-frame2's own trace bus and epoch-history surfaces, not a port of 10x. The mental model (events, subs, app-db diff, time-travel) carries over; the wiring underneath does not. See [`docs/core/25-from-re-frame-v1.md` §Devtools](../../../docs/core/25-from-re-frame-v1.md#devtools) for the narrative version of this swap.
 
 **This is a STANDARD, first-class, EXPECTED migration step — not an optional adjunct.** **The rule: 10x present ⇒ swap to Xray (standard); no 10x ⇒ Xray optional.** The swap is triggered, and carried to completion, whenever the dep file holds a `day8.re-frame-10x` coord or a `day8.re-frame-10x.preload` `:preloads` entry; its **done-state is the app ON Xray**, not merely the dead preload removed — dropping 10x without restoring Xray leaves the author worse off than they started. If the app **never** had re-frame-10x, do **not** force devtools on it — Xray is then a genuine offer the author can decline.
 
@@ -212,7 +212,7 @@ Full panel inventory: [`tools/xray/spec/000-Vision.md`](../../../tools/xray/spec
 - [`tools/xray/README.md`](../../../tools/xray/README.md) — entry-point summary, spec index, file layout.
 - [`tools/xray/spec/API.md`](../../../tools/xray/spec/API.md) — the full user-facing surface (`configure!`, `popout!`, programmatic open/close, the layout-host contract, `--rf-xray-inline-width`).
 - [`tools/xray/spec/011-Launch-Modes.md`](../../../tools/xray/spec/011-Launch-Modes.md) — true-inline default + standalone-via-MCP for remote-attach scenarios.
-- [`docs/core/25-from-re-frame-v1.md` §The devtools moved house](../../../docs/core/25-from-re-frame-v1.md#the-devtools-moved-house) — the narrative version of the 10x → Xray swap.
+- [`docs/core/25-from-re-frame-v1.md` §Devtools](../../../docs/core/25-from-re-frame-v1.md#devtools) — the narrative version of the 10x → Xray swap.
 
 ---
 


### PR DESCRIPTION
## Summary

- **AUTHORING.md**: senior voice as a vocabulary filter (common engineer usage vs AI/consultant coinages); light Yegge seasoning on teaching pages; required path stays unlabeled (no Day-one / Basics); standard headings **Troubleshooting** and **Advanced** (replacing When things go wrong / Going further).
- **Top-level `docs/core/` pages**: voice pass to match — operational claims, less curriculum framing, same technical contracts and snippets.
- **Anchor fixes**: `testing/views.md` → `#troubleshooting`; migration skill → `#devtools`.

## Test plan

- [x] `python scripts/check_doc_slugs.py` green
- [ ] Spot-check a few concept pages in MkDocs preview if available
- [ ] Confirm no remaining Day-one checklist / Going further / When things go wrong H2s on top-level core pages

Bead: rf2-r8brg