### PR TITLE
build(freehand): add the artefact's release build

### DIFF
--- a/implementation/freehand/test/re_frame/freehand/release_app.cljs
+++ b/implementation/freehand/test/re_frame/freehand/release_app.cljs
@@ -1,0 +1,83 @@
+(ns re-frame.freehand.release-app
+  "The entry of the Freehand artefact's RELEASE build (`:freehand-release`).
+
+  Until this namespace existed the artefact had exactly one shadow build,
+  `:node-test-freehand`, and it is a test build. Nothing in the repo
+  compiled Freehand the way a consumer ships it — `:advanced`,
+  `goog.DEBUG` false — so anything wanting to state what the substrate
+  COSTS on a page (bundle bytes, parse/eval, what survives dead-code
+  elimination) had no artefact to point at. Not a thin measurement: no
+  measurement at all, because there was nothing built.
+
+  So this is a small Freehand APPLICATION rather than a require-only
+  stub. A namespace that merely required the door would compile to almost
+  nothing under `:advanced` — Closure keeps what is reachable, and an
+  unused require is not — and a bundle measuring an empty graph would
+  report a cost no consumer pays. Everything below is therefore reached
+  from the mount: a declared view whose body READS a subscription and
+  DISPATCHES an event (the reactive substrate, the event materializer and
+  the ViewCell shell), its `{:compiled true}` twin (the compiled tier's
+  emitted body and its own lowering), and a root that composes both
+  through `v/mount` (root identity, the live-root registry and the frame
+  preflight).
+
+  It lives under `test/` rather than `src/` for the reason the sibling
+  bundle probes do: `deps.edn` publishes `src` alone, so a fixture that
+  exists to be measured stays out of the artefact a consumer resolves,
+  while shadow-cljs — which carries `freehand/test` on `:source-paths` —
+  can still compile it into a real production bundle."
+  (:require [re-frame.core :as rf]
+            [re-frame.freehand :as v]))
+
+;; ---------------------------------------------------------------------------
+;; The application's handlers. Ordinary re-frame2: the root's preflight plan
+;; seeds app-db through `:initial-events`, so the first render of the view
+;; below reads a value that is already there.
+;; ---------------------------------------------------------------------------
+
+(rf/reg-event-db ::seed (fn [_ _] {:count 0}))
+
+(rf/reg-event-db ::bump (fn [db _] (update db :count inc)))
+
+(rf/reg-sub ::count :-> :count)
+
+;; ---------------------------------------------------------------------------
+;; One view, declared twice — the same body in both execution modes, which is
+;; what the two-mode substrate claims and therefore what a shipped bundle has
+;; to carry. The declarations are separate namespaced ids, so they are
+;; separate views; the bodies are deliberately identical.
+;; ---------------------------------------------------------------------------
+
+(v/defview counter
+  "The interpreted paved path: a read, a dispatch and static markup."
+  [{:keys [label]}]
+  [:div.counter
+   [:span.label label]
+   [:output.count (str (v/sub [::count]))]
+   [:button.bump {:on-click [::bump]} "+"]])
+
+(v/defview counter-compiled
+  "The compiled hot tier over the same body — `{:compiled true}` and
+  nothing else changed."
+  {:compiled true}
+  [{:keys [label]}]
+  [:div.counter
+   [:span.label label]
+   [:output.count (str (v/sub [::count]))]
+   [:button.bump {:on-click [::bump]} "+"]])
+
+(v/defview app
+  "The mounted root: both tiers on one page, over one frame."
+  [_]
+  [:main#freehand-release
+   [counter {:label "interpreted"}]
+   [counter-compiled {:label "compiled"}]])
+
+(defn ^:export -main
+  "The build's `:init-fn`. Mounts the root into `#app`, owning the frame it
+  runs over so the bundle carries the whole preflight path."
+  []
+  (v/mount [app {}]
+           (js/document.getElementById "app")
+           {:frame {:id             ::frame
+                    :initial-events [[::seed]]}}))

--- a/implementation/package.json
+++ b/implementation/package.json
@@ -29,6 +29,7 @@
     "test:security": "shadow-cljs compile node-test-security && node out/node-test-security.js",
     "test:testbed-support": "shadow-cljs compile node-test-testbed-support && node out/node-test-testbed-support.js",
     "test:freehand": "shadow-cljs compile node-test-freehand && node out/node-test-freehand.js",
+    "build:freehand-release": "shadow-cljs release freehand-release",
     "test:ui": "npm run test:ui-isolation && node out/node-test-ui.js",
     "test:ui-isolation": "node scripts/check-ui-adapter-isolation.cjs --self-test && shadow-cljs compile node-test-ui && node scripts/check-ui-adapter-isolation.cjs",
     "test:ui-warm-watch": "node scripts/check-ui-warm-watch.cjs",

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -821,6 +821,39 @@
    :compiler-options {:warnings      {:redef false}
                       :infer-externs false}}
 
+  ;; rf2-8kas5 — the Freehand artefact's RELEASE build: the substrate
+  ;; compiled the way a consumer ships it.
+  ;;
+  ;; The build above is a test build, and until this one existed it was
+  ;; the artefact's only one. So nothing anywhere compiled Freehand under
+  ;; `:advanced` with `goog.DEBUG` false, and any claim about what the
+  ;; substrate COSTS on a page — bundle bytes, parse/eval, what survives
+  ;; DCE — had no artefact to measure. Not a thin measurement: no
+  ;; measurement at all.
+  ;;
+  ;; Shape follows the sibling advanced builds (:proof-pack-single,
+  ;; :ui-g13-prod): both settings pinned rather than left to `release`'s
+  ;; defaults, so the build says what it is at the point a reader is
+  ;; looking. `re-frame.freehand.release-app` mounts a small real
+  ;; application — a subscription read, a dispatch, the compiled twin of
+  ;; the same body, and a root that owns its frame — because an entry that
+  ;; only REQUIRED the door would be DCE'd to nearly nothing and would
+  ;; report a cost no consumer pays. The entry sits under `freehand/test/`
+  ;; (on :source-paths above, outside the artefact's published :paths),
+  ;; exactly where the sibling bundle probes live.
+  ;;
+  ;; Built by `npm run build:freehand-release`; the bundle lands at
+  ;; out/freehand-release/main.js. No :dev-http — like every other
+  ;; advanced build here it is compiled and inspected, never served.
+  :freehand-release
+  {:target     :browser
+   :output-dir "out/freehand-release"
+   :asset-path "."
+   :compiler-options {:optimizations :advanced
+                      :infer-externs :auto
+                      :closure-defines {goog.DEBUG false}}
+   :modules {:main {:init-fn re-frame.freehand.release-app/-main}}}
+
   ;; rf2-vxgfnd.6 — the G-1 direct-render parity gate (07 §5) for the
   ;; re-frame.ui compiled-view substrate. A :node-script RELEASE build
   ;; (:advanced — the gate measures + inspects PRODUCTION emission):


### PR DESCRIPTION
The Freehand artefact had exactly one shadow build, `:node-test-freehand`, and it is a test build. Nothing in the repo compiled the substrate the way a consumer ships it — `:advanced`, `goog.DEBUG` false — so any claim about what Freehand COSTS on a page (bundle bytes, parse/eval, what survives dead-code elimination) had no artefact to point at. That is not a thin measurement; it is no measurement at all, because there was nothing built. The premise was re-verified against `origin/main` at the start of this branch and still held.

## What lands

**`:freehand-release`** — the artefact's release build, shaped after the sibling advanced builds (`:proof-pack-single`, `:ui-g13-prod`): `:optimizations :advanced`, `:infer-externs :auto`, `:closure-defines {goog.DEBUG false}`, all pinned rather than left to `release`'s defaults so the build says what it is where a reader is looking. No `:dev-http` — like every other advanced build in this file it is compiled and inspected, never served.

- build id: `:freehand-release`
- produced artefact: `implementation/out/freehand-release/main.js`
- npm script: `npm run build:freehand-release`

**`re-frame.freehand.release-app`** — the entry. It is a small Freehand *application* rather than a require-only stub, because an entry that merely required the door would be eliminated to nearly nothing under `:advanced` (Closure keeps what is reachable) and would report a cost no consumer pays. So the mount reaches a declared view that reads a subscription and dispatches an event, its `{:compiled true}` twin of the same body, and a root that owns the frame it runs over. It lives under `freehand/test/` — on shadow-cljs's source paths, outside the artefact's published `:paths` — exactly where the sibling bundle probes (`core/test/…/elision_probe.cljs`, `schemas/test/…/schemas_bundle_probe.cljs`) live.

## What deliberately does not land

The shipped-cost probes. This is the build id and its wiring only; the measurement is a separate piece of work that unblocks the moment this merges, and keeping them apart keeps occupancy of the hot-zone build file as short as possible. No checker, no gate, no workflow change — in particular no naive bundle oracle, since the ones that suggest themselves (counting a debug flag's occurrences, grepping a small function name) have both been measured wrong in this repo.

`implementation/shadow-cljs.edn` is hot-zone and this branch is its sole holder for the wave.

## Quality gates

All run in the foreground to completion, in this worktree (`shadow-cljs - config:` banner confirmed on each shadow run).

| gate | result | exit |
| --- | --- | --- |
| `npm run build:freehand-release` | `[:freehand-release] Build completed. (159 files, 104 compiled, 1 warnings, 18.15s)` → `out/freehand-release/main.js`, 704,453 bytes raw / 208,250 gzipped | 0 |
| `cd implementation/freehand && clojure -M:test` | 830 tests, 5,882 assertions, 0 failures, 0 errors | 0 |
| `npm run test:cljs` | 10,939 tests, 54,994 assertions, 0 failures, 0 errors | 0 |
| `npm run test:bundle-isolation` | 23 artefact entries; 39 internal sentinels absent; 39 positive-control sentinels present; 12 browser-optional runtimes covered | 0 |
| `npm run test:elision` | production 60/60 absent; control 60/60 present; EP-0023 provenance + assembly-DCE ok | 0 |
| `npm run test:script-policy` | full policy sweep green (`package.json` is touched, so the rigorous-local inventory lockstep is in scope) | 0 |

The one build warning is pre-existing and comes from artefact source this PR does not touch (`freehand/src/re_frame/freehand/fingerprint.cljc:130`, a `:redef` of `-write` against `cljs.core/-write`); the sibling `:node-test-freehand` build silences the same warning class explicitly.
