### PR TITLE
feat(freehand): the evidence schema, B3, and a ClojureScript lane for the React arm

### DIFF
--- a/.github/workflows/freehand-bench.yml
+++ b/.github/workflows/freehand-bench.yml
@@ -34,12 +34,23 @@ name: freehand bench
 # (re-frame.freehand.bench.provenance/detect-hardware-class) — a result
 # record never carries a literal naming one machine.
 #
-# WHAT RUNS TODAY. The evidence suite is empty: B1–B5 are separate slices
-# and each registers its workload when the implementation that can run it
-# lands. An empty suite prints an empty report and exits 0, which is the
-# honest answer. The falsifiability proof runs here too — not as a duplicate
-# of the PR gate but because a harness whose gate direction has rotted would
-# otherwise publish evidence nobody should trust.
+# WHAT RUNS TODAY. B1–B5 are separate slices and each registers its
+# workloads when the implementation that can run them lands, so the suite
+# grows as the programme does. The falsifiability proof runs here too — not
+# as a duplicate of the PR gate but because a harness whose gate direction
+# has rotted would otherwise publish evidence nobody should trust.
+#
+# TWO LANES, ONE HARNESS. `clojure -M:bench` is a JVM process and reaches
+# every `.cljc` workload; the React arm measures the interpreted React
+# emitter, which is ClojureScript-only. So there is a second job below
+# running the same registry, the same provenance record and the same
+# gate/evidence split through a Node entry
+# (`re-frame.freehand.bench.node`), and uploading its EDN beside the JVM
+# one. Two artefacts because they are two hosts — a result record names
+# its own `:host` and `:build`, and pooling a V8 `:none` number with a
+# JIT-warmed JVM one would be the pooling D021 forbids — but ONE harness,
+# because a second report shape is a second place a threshold could be
+# added.
 
 on:
   schedule:
@@ -115,5 +126,68 @@ jobs:
         with:
           name: freehand-bench-${{ github.sha }}
           path: implementation/freehand/out/freehand-bench.edn
+          if-no-files-found: error
+          retention-days: 90
+
+  # The ClojureScript half of the same suite. See TWO LANES, ONE HARNESS
+  # above: this job adds a host, not a harness.
+  react-evidence:
+    name: Freehand B-spine evidence — ClojureScript lane (pinned worker)
+    # PINNED for the same reason the JVM lane is. See THE PIN above.
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: implementation
+    env:
+      # The same configured class, so the two lanes' records are labelled
+      # with the same comparability claim about the machine — the HOST
+      # difference between them stays visible in `:host`, where it belongs.
+      RF2_HARDWARE_CLASS: release-worker
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: implementation/package-lock.json
+
+      - name: Cache Maven / gitlibs (shadow-cljs deps)
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+          key: ${{ runner.os }}-cljs-${{ hashFiles('implementation/shadow-cljs.edn', 'implementation/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-cljs-
+
+      - name: npm install
+        run: npm ci
+
+      # `--silent` and the script's own `>&2` keep npm's banner and the
+      # shadow-cljs compile chatter off stdout, so the redirected bytes are
+      # the EDN artefact and nothing else. The lane refuses to publish at
+      # all if the ClojureScript-only workloads stopped registering.
+      - name: Run the ClojureScript evidence lane and publish its result records
+        run: |
+          mkdir -p out
+          npm run --silent bench:freehand-node > out/freehand-bench-node.edn
+          cat out/freehand-bench-node.edn
+
+      - name: Upload the ClojureScript result records
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: freehand-bench-node-${{ github.sha }}
+          path: implementation/out/freehand-bench-node.edn
           if-no-files-found: error
           retention-days: 90

--- a/implementation/freehand/src/re_frame/freehand/bench/b3.cljc
+++ b/implementation/freehand/src/re_frame/freehand/bench/b3.cljc
@@ -1,0 +1,514 @@
+(ns re-frame.freehand.bench.b3
+  "B3 — ten thousand keyed records, a window of about forty, and the exact
+  number of rows a mutation touches.
+
+  D021's third required workload: *10,000 keyed rows with `rf=`-stable
+  props; repeat with a window of about 40 under updates*, compared
+  *generic versus generated comparator*, publishing *parent render time,
+  skipped/committed rows, comparator time and end-to-end latency*, to
+  decide *whether comparator specialization matters after windowing*.
+
+  The decision that question serves is a spending decision, and it is
+  worth stating plainly because it is what keeps this workload honest:
+  once a window is in place, the comparator runs over FORTY rows, not ten
+  thousand. Whatever specialization buys, it buys it on that forty. So
+  B3's gated half is the size of the thing being compared, and its
+  published half is what comparing it costs.
+
+  ## What gates, and why these are counts
+
+  `:B3/records` is ten thousand and `:B3/rows-compared` is in the
+  hundreds. Both are exact integers; together they ARE the isolation
+  claim, and neither is a duration. The rest of the gated half is the
+  arithmetic of one scripted mutation sequence:
+
+    - `:B3/committed-rows` — rows the comparator says must re-render,
+      summed over the script. A row commits because it ARRIVED in the
+      window (it has no counterpart to compare against) or because its
+      props changed.
+    - `:B3/skipped-rows` — rows present in both windows whose props
+      compare `rf=` equal, and which a memoized boundary therefore does
+      not re-render.
+    - `:B3/comparator-agreement` — the generic and the generated
+      comparator named the SAME rows changed, on every step. This is the
+      load-bearing half of D021's question: specialization is allowed to
+      change what comparing costs and is not allowed to change what
+      commits.
+
+  Each is checked against [[expectation]] — combinatorics over the script,
+  written without records, props or `rf=` anywhere in it — so the gate
+  expects what the script MEANS rather than what the run happened to
+  produce.
+
+  ## What is published, and can never gate
+
+  Comparator self time for each arm, parent render time, and the
+  end-to-end latency of the whole scripted sequence. Every one is a
+  duration, so [[re-frame.freehand.bench.measure]] classes it as a
+  distribution and the harness publishes it with no threshold, no
+  comparator and no route to the exit code. A B3 that could red on a slow
+  comparator would be the folklore threshold D021 forbids, dressed as a
+  windowing claim.
+
+  ## The two comparators
+
+  Both are `rf=` per slot — the ruled per-slot equality
+  ([[re-frame.freehand.eq]]) — and they differ in exactly one thing,
+  which is the thing compilation decides:
+
+    - [[generic-equal?]] knows no slot roster. It walks the union of both
+      maps' keys, which is what a props-map view gets: the compiler could
+      not name the slots, so the comparator has to discover them.
+    - [[generated-equal?]] is straight-line over a WRITTEN roster,
+      [[row-slots]] — one `rf=` per declared slot, no key walk, no set
+      union. That is the shape `emit-cljs`'s generated comparator has.
+
+  Modelled here rather than harvested from a compiled declaration, and
+  said out loud rather than implied: this workload measures the SHAPE of
+  the two comparators over the props a windowed table hands them. It does
+  not measure the emitted JavaScript, which needs a browser and a mounted
+  React tree, and it does not claim to. What it does measure is
+  host-neutral, which is why the same numbers are readable from the JVM
+  lane and the ClojureScript one.
+
+  ## Keyed, and why that is the whole workload
+
+  Rows are matched between two renders BY KEY, never by position. That is
+  what makes a scroll cheap: sliding the window by twenty rows leaves
+  twenty rows matched — same key, same props, skipped — and twenty
+  arriving with no counterpart. Match by position instead and a
+  one-row scroll would commit the entire window. The script below scrolls
+  by half a window, back again, and then clean past it, so all three
+  cases are in the gated arithmetic rather than in a paragraph.
+
+  ## A small case beside the stress case
+
+  D021: *\"Include at least one small realistic case beside each stress
+  case so optimization is not tuned only to synthetic extremes.\"* Hence
+  two registered workloads over one script shape and one `:run`, differing
+  only in `:total` and `:window` — sizes are fixture parameters, not
+  language constants.
+
+  Normative owner: `docs/design/freehand/decisions/`
+  `D021-performance-budgets-and-release-evidence.md`."
+  (:require [re-frame.freehand :as v]
+            [re-frame.freehand.bench :as bench]
+            [re-frame.freehand.bench.measure :as m]
+            [re-frame.freehand.eq :as eq]
+            [re-frame.freehand.tree :as tree]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+;; ---------------------------------------------------------------------------
+;; The dataset and the window
+;; ---------------------------------------------------------------------------
+
+(defn records
+  "`n` generated keyed records.
+
+  Generated rather than fixtured, for the reason ten thousand literal maps
+  is not a fixture. Each carries a stable `:id` — the key rows are matched
+  by — and one mutable field."
+  [n]
+  (mapv (fn [i] {:id (str "r" i) :code (str "AC-" i) :amount (* 3 i)})
+        (range n)))
+
+(def row-slots
+  "The row boundary's prop slots, in declaration order.
+
+  Written once and read twice — by [[record-row]]'s destructuring and by
+  [[generated-equal?]] — because the generated comparator's whole nature
+  is that it knows this roster before the render, and a roster that could
+  drift from the view it compares would be comparing something else."
+  [:id :code :amount :index])
+
+(defn window-rows
+  "The props of the `window` rows visible from `first-row`, in order.
+
+  `:index` is the record's ABSOLUTE position, so a row that survives a
+  scroll carries the same index as well as the same key — which is why a
+  scroll's overlapping rows compare equal rather than merely nearly
+  equal.
+
+  Public because the isolation claim is about this function as much as
+  about the workload: what the comparator sees is exactly what a windowed
+  table hands a row boundary."
+  [recs first-row window]
+  (mapv (fn [i]
+          (let [r (nth recs i)]
+            {:id (:id r) :code (:code r) :amount (:amount r) :index i}))
+        (range first-row (+ first-row window))))
+
+(defn- by-key
+  [rows]
+  (persistent! (reduce (fn [m r] (assoc! m (:id r) r)) (transient {}) rows)))
+
+;; ---------------------------------------------------------------------------
+;; The two comparators
+;; ---------------------------------------------------------------------------
+
+(defn generated-equal?
+  "The GENERATED comparator: straight-line `rf=` over [[row-slots]].
+
+  What a compiled boundary earns — the slots are known before the render,
+  so the comparison is a fixed conjunction with nothing to discover."
+  [a b]
+  (and (eq/rf= (:id a) (:id b))
+       (eq/rf= (:code a) (:code b))
+       (eq/rf= (:amount a) (:amount b))
+       (eq/rf= (:index a) (:index b))))
+
+(defn generic-equal?
+  "The GENERIC comparator: `rf=` over the union of both maps' keys.
+
+  What a boundary with no compile-time slot roster gets. It answers the
+  same verdict as [[generated-equal?]] on these props — that agreement is
+  gated, not assumed — and it reaches it by discovering the slots on every
+  call."
+  [a b]
+  (let [ks (into (set (keys a)) (keys b))]
+    (reduce (fn [_ k] (if (eq/rf= (get a k) (get b k)) true (reduced false)))
+            true
+            ks)))
+
+;; ---------------------------------------------------------------------------
+;; The scripted mutation sequence
+;; ---------------------------------------------------------------------------
+
+(defn script
+  "The scripted mutation sequence for a fixture, as data.
+
+  Nine steps over three kinds of movement, chosen so every case the
+  isolation claim rests on is inside the gated arithmetic:
+
+    - an idle step — nothing changed, so nothing commits;
+    - an edit INSIDE the window — exactly one row commits;
+    - an edit OUTSIDE the window — nothing commits, which is the
+      strongest form of \"the comparison isolates rows\": a mutation to one
+      of ten thousand records that the window does not show is not
+      compared and is not rendered;
+    - a half-window slide and its return — half the window matched by key
+      and skipped, half arriving;
+    - a jump clean past the window — nothing matched, so the whole window
+      commits, which is the honest upper bound windowing does not avoid.
+
+  A function of the fixture rather than a literal, so the small case is
+  the same script at a smaller size. Every target is inside the dataset by
+  construction: `far` is capped at the last legal first-row, so no step
+  needs clamping and the arithmetic below needs no clamp either."
+  [{:keys [total window]}]
+  (let [far (min (- total window) (* 4 window))]
+    [{:op :idle}
+     {:op :edit   :row 0}
+     {:op :edit   :row (dec total)}
+     {:op :scroll :to (quot window 2)}
+     {:op :edit   :row (quot window 2)}
+     {:op :scroll :to 0}
+     {:op :scroll :to far}
+     {:op :edit   :row far}
+     {:op :idle}]))
+
+;; ---------------------------------------------------------------------------
+;; The script's counts, as arithmetic
+;; ---------------------------------------------------------------------------
+
+(defn- overlap
+  "How many rows two windows of `window` rows, starting at `a` and `b`,
+  share — the number of keys present in both, and therefore the number of
+  comparisons the next render performs."
+  [a b window]
+  (let [d (- a b)]
+    (max 0 (- window (if (neg? d) (- d) d)))))
+
+(defn- visible?
+  [row first-row window]
+  (and (<= first-row row) (< row (+ first-row window))))
+
+(defn expectation
+  "The exact counts [[script]] produces for `fixture`, stated as
+  arithmetic.
+
+      {:compared n :committed n :skipped n :rendered n}
+
+  Written rather than measured, so the gates expect what the script MEANS.
+  There is no record, no props map and no `rf=` in this function: it walks
+  the script counting window overlaps, which is a claim about the script,
+  and the run walks real props with the real comparator, which is a claim
+  about the substrate. A gate is only a gate when those two are
+  independent.
+
+  Per step, with `W` the window size:
+
+    - the rows both windows hold are `W - |shift|`, floored at zero —
+      those are the COMPARISONS;
+    - the rest of the new window ARRIVED, has no counterpart, and commits
+      without being compared;
+    - an edit to a row visible in both windows changes exactly one of the
+      compared rows; an edit anywhere else changes none;
+    - so `committed = arrivals + changed` and `skipped = compared -
+      changed`, and the two always sum to `W`.
+
+  `:rendered` counts the initial window too: the run renders the window
+  once before the script starts, because a first render has nothing to
+  compare against and would otherwise be an unbounded case hiding inside
+  step one."
+  [{:keys [window] :as fixture}]
+  (let [steps (script fixture)
+        seed  {:first-row 0 :compared 0 :committed 0 :skipped 0}
+        end   (reduce
+                (fn [acc {:keys [op row to]}]
+                  (let [p        (:first-row acc)
+                        n        (if (= :scroll op) to p)
+                        compared (overlap p n window)
+                        arrivals (- window compared)
+                        changed  (if (and (= :edit op)
+                                          (visible? row p window)
+                                          (visible? row n window))
+                                   1
+                                   0)]
+                    (-> acc
+                        (assoc :first-row n)
+                        (update :compared + compared)
+                        (update :committed + arrivals changed)
+                        (update :skipped + (- compared changed)))))
+                seed
+                steps)]
+    (-> end
+        (dissoc :first-row)
+        (assoc :rendered (* window (inc (count steps)))))))
+
+;; ---------------------------------------------------------------------------
+;; The rendered window
+;; ---------------------------------------------------------------------------
+
+(v/defview record-row
+  "One windowed row. Its props are exactly [[row-slots]] — the roster the
+  generated comparator compares."
+  [{:keys [id code amount index]}]
+  [:tr.b3-row {:data-row-key id :aria-rowindex (inc index)}
+   [:td.b3-cell code]
+   [:td.b3-cell (str amount)]])
+
+(v/defview windowed-table
+  "The parent. It renders the WINDOW it is handed and knows nothing about
+  the collection the window came from — which is the property `:B3/records`
+  beside `:B3/rows-compared` states as two integers."
+  [{:keys [rows]}]
+  [:table.b3-table {:role "grid"}
+   [:tbody
+    (for [r rows]
+      [record-row (assoc r :key (:id r))])]])
+
+(def ^:private row-tag :tr)
+
+(defn rendered-rows
+  "The row elements one structural render actually built.
+
+  Counted off the tree rather than off the props vector handed in: the
+  claim is that the parent renders the window, and a count of the input
+  would be a claim about the input."
+  [t]
+  (count (filter #(and (map? %) (= row-tag (:tag %)))
+                 (tree-seq map? :children t))))
+
+;; ---------------------------------------------------------------------------
+;; One step
+;; ---------------------------------------------------------------------------
+
+(defn- timed-pass
+  "One pass of `equal?` over the rows `prev` and `next-rows` share, timed.
+
+  Answers `{:compared n :equal n :ms ms}`. It counts rather than
+  discarding, because a pass whose result is thrown away is a pass a JIT
+  may delete — and the number it returns is also the comparison count the
+  gate is about. Nothing else happens inside the clock: the key index was
+  built before it, and the changed-key set below is collected after it."
+  [equal? prev next-rows]
+  (let [n  (count next-rows)
+        t0 (m/now-ms)]
+    (loop [i 0 compared 0 equal 0]
+      (if (< i n)
+        (let [r (nth next-rows i)
+              p (get prev (:id r))]
+          (cond
+            (nil? p)     (recur (inc i) compared equal)
+            (equal? p r) (recur (inc i) (inc compared) (inc equal))
+            :else        (recur (inc i) (inc compared) equal)))
+        (let [t1 (m/now-ms)]
+          {:compared compared :equal equal :ms (- t1 t0)})))))
+
+(defn changed-keys
+  "The keys `equal?` says changed between `prev` and `next-rows` — the
+  rows a memoized boundary would re-render, named rather than counted.
+
+  Untimed on purpose. The agreement gate needs the identities and the
+  published comparator time needs a pass that does nothing but compare, so
+  they are two passes rather than one pass doing both."
+  [equal? prev next-rows]
+  (into #{}
+        (comp (filter #(contains? prev (:id %)))
+              (remove #(equal? (get prev (:id %)) %))
+              (map :id))
+        next-rows))
+
+(defn- step-state
+  "Apply one script step, answering the records and first row it leaves."
+  [{:keys [recs first-row]} {:keys [op row to]}]
+  (case op
+    :idle   {:recs recs :first-row first-row}
+    :edit   {:recs (update-in recs [row :amount] inc) :first-row first-row}
+    :scroll {:recs recs :first-row to}))
+
+;; ---------------------------------------------------------------------------
+;; One iteration
+;; ---------------------------------------------------------------------------
+
+(defn observe
+  "Run one B3 iteration over `dataset` and `fixture`, answering its
+  observations.
+
+  The dataset arrives as an argument rather than out of the fixture: ten
+  thousand records are the thing being windowed, not a parameter a reader
+  should have to scroll past in the published record, and regenerating
+  them every iteration would bill the generator to the substrate."
+  [dataset {:keys [window] :as fixture}]
+  (let [steps (script fixture)
+        e0    (m/now-ms)
+        ;; The initial window. There is nothing to compare it against, so
+        ;; it renders and is counted and no comparator runs.
+        seed  (window-rows dataset 0 window)
+        r0    (m/now-ms)
+        tree0 (tree/render [windowed-table {:rows seed}])
+        r1    (m/now-ms)
+        final (reduce
+                (fn [acc step]
+                  (let [{:keys [recs first-row]} (step-state (:state acc) step)
+                        rows      (window-rows recs first-row window)
+                        rt0       (m/now-ms)
+                        t         (tree/render [windowed-table {:rows rows}])
+                        rt1       (m/now-ms)
+                        prev      (:index acc)
+                        generated (timed-pass generated-equal? prev rows)
+                        generic   (timed-pass generic-equal? prev rows)
+                        changed   (changed-keys generated-equal? prev rows)
+                        arrivals  (- (count rows) (:compared generated))]
+                    (-> acc
+                        (assoc :state {:recs recs :first-row first-row}
+                               :index (by-key rows))
+                        (update :rendered + (rendered-rows t))
+                        (update :render-ms + (- rt1 rt0))
+                        (update :compared + (:compared generated))
+                        (update :committed + arrivals (count changed))
+                        (update :skipped + (- (:compared generated) (count changed)))
+                        (update :generated-ms + (:ms generated))
+                        (update :generic-ms + (:ms generic))
+                        (update :agree?
+                                #(and % (= changed (changed-keys generic-equal? prev rows)))))))
+                {:state     {:recs dataset :first-row 0}
+                 :index     (by-key seed)
+                 :rendered  (rendered-rows tree0)
+                 :render-ms (- r1 r0)
+                 :compared  0
+                 :committed 0
+                 :skipped   0
+                 :generated-ms 0.0
+                 :generic-ms   0.0
+                 :agree?    true}
+                steps)
+        e1    (m/now-ms)]
+    {:B3/records                 (count dataset)
+     :B3/rows-rendered           (:rendered final)
+     :B3/rows-compared           (:compared final)
+     :B3/committed-rows          (:committed final)
+     :B3/skipped-rows            (:skipped final)
+     :B3/comparator-agreement    (:agree? final)
+     :B3/generated-comparator-ms (:generated-ms final)
+     :B3/generic-comparator-ms   (:generic-ms final)
+     :B3/parent-render-ms        (:render-ms final)
+     :B3/end-to-end-ms           (- e1 e0)}))
+
+;; ---------------------------------------------------------------------------
+;; The workloads
+;; ---------------------------------------------------------------------------
+
+(defn workload
+  "Build the B3 workload for `total` records through a `window`, under
+  `id` and `sampling`.
+
+  The dataset is built ONCE and captured by `:run`; the fixture carries
+  the parameters and the script, which is everything a reader needs to
+  re-derive the gated counts and nothing they would have to scroll past."
+  [{:keys [id doc total window sampling]}]
+  (let [fixture  {:total total :window window :script (script {:total total :window window})}
+        expected (expectation fixture)
+        dataset  (records total)]
+    {:id       id
+     :doc      doc
+     :fixture  (merge fixture expected)
+     :baseline {:kind :interpreted-vs-compiled
+                :reference
+                {:arm  :generic-comparator
+                 :note (str "the comparator a boundary gets when the slots were not known "
+                            "before the render — it discovers them on every call, where the "
+                            "generated one is a straight line over a roster the compiler "
+                            "already had. Both answer the same verdict; only the cost differs, "
+                            "and only over the rows the window shows")}}
+     :sampling sampling
+     :measurements
+     [{:id         :B3/records
+       :doc        "the keyed records the window is drawn from — the denominator of the isolation claim"
+       :observable :count
+       :expect     total}
+      {:id         :B3/rows-rendered
+       :doc        "the row elements every render of the script actually built"
+       :observable :count
+       :expect     (:rendered expected)}
+      {:id         :B3/rows-compared
+       :doc        "the comparisons the whole scripted sequence performed — the numerator"
+       :observable :count
+       :expect     (:compared expected)}
+      {:id         :B3/committed-rows
+       :doc        "the exact rows the comparator says must re-render across the script"
+       :observable :count
+       :expect     (:committed expected)}
+      {:id         :B3/skipped-rows
+       :doc        "the exact rows that compared equal and are skipped across the script"
+       :observable :count
+       :expect     (:skipped expected)}
+      {:id         :B3/comparator-agreement
+       :doc        "the generic and generated comparators named the same rows changed, every step"
+       :observable :flag
+       :expect     true}
+      {:id         :B3/generated-comparator-ms
+       :doc        "self time of the straight-line comparator over the whole script"
+       :observable :duration-ms}
+      {:id         :B3/generic-comparator-ms
+       :doc        "self time of the key-walking comparator over the whole script"
+       :observable :duration-ms}
+      {:id         :B3/parent-render-ms
+       :doc        "self time of the parent's renders of the window — never of the collection"
+       :observable :duration-ms}
+      {:id         :B3/end-to-end-ms
+       :doc        "the whole scripted sequence, render and comparison together"
+       :observable :duration-ms}]
+     :run      (fn [f] (observe dataset f))}))
+
+(def workloads
+  "B3's registered workloads: D021's ten thousand keyed records through a
+  window of about forty, and the small realistic case it requires beside
+  it."
+  [(workload {:id       :B3/windowed-ledger
+              :doc      "10,000 keyed records rendered repeatedly through a window of 40"
+              :total    10000
+              :window   40
+              :sampling {:warmup 5 :samples 40}})
+   (workload {:id       :B3/small-windowed-ledger
+              :doc      "the same script at a realistic small size — the control on the stress case"
+              :total    400
+              :window   12
+              :sampling {:warmup 5 :samples 40}})])
+
+(def registered
+  "Registering at load: requiring this namespace puts B3 in the standing
+  evidence suite `clojure -M:bench` runs."
+  (mapv bench/register! workloads))

--- a/implementation/freehand/src/re_frame/freehand/bench/node.cljs
+++ b/implementation/freehand/src/re_frame/freehand/bench/node.cljs
@@ -1,0 +1,101 @@
+(ns re-frame.freehand.bench.node
+  "The ClojureScript/Node entry to the B-spine — the same runner, on the
+  host the React arm can actually run on.
+
+      npm run --silent bench:freehand-node > out/freehand-bench-node.edn
+
+  ## Why a second entry, and why it is not a second harness
+
+  `clojure -M:bench` is a JVM process. Every workload it can reach is
+  `.cljc`, which is the whole of B1's structural arm and B2's elision
+  census — but [[re-frame.freehand.bench.b1-react]] measures the
+  interpreted React emitter, and [[re-frame.freehand.react]] is
+  ClojureScript-only. A workload that registers itself at load into a
+  suite no command loads is an instrument nobody can read: the counters
+  exist, the tests exercise them, and a programmer weighing a candidate
+  change to the emitter still has no standing command to run and no
+  published artefact to compare against.
+
+  So this namespace is an ENTRY, not a harness. It requires the
+  ClojureScript-only workloads, then delegates to
+  [[re-frame.freehand.bench.runner/-main]] — the same registry, the same
+  provenance, the same gate/evidence split, the same `;;`-commented EDN
+  on stdout, and the same exit-code law where 1 means a deterministic
+  property was violated and nothing else. There is no second report
+  shape to keep in step and no second place a threshold could be added.
+
+  ## What this lane publishes that the JVM lane cannot
+
+  The React arm, plus the `.cljc` workloads AS THE BROWSER'S ENGINE RUNS
+  THEM. The second half is not a duplicate of the JVM lane: a result
+  record names its `:host` and its `:build`, and a V8 number under
+  `:optimizations :none` is a different measurement from the same
+  workload on a JIT-warmed JVM. Publishing both is how D021's fourth
+  baseline — substrate self time versus end-to-end host time — stays
+  answerable on the host applications actually ship to.
+
+  ## The lane's one guard, held down from both ends
+
+  [[lane-workloads]] names the workloads this entry EXISTS to publish,
+  and [[absent-lane-workloads]] is checked before the suite runs. The two
+  ways that could silently stop being true are closed separately:
+
+    - the require is deleted — the roster below is read off the arm's own
+      `workloads`, so the require is load-bearing and its removal is a
+      compile error, not a quieter report;
+    - the arm loads but no longer registers — the runtime check fails the
+      command with the ids it could not find.
+
+  Which is the same posture as
+  [[re-frame.freehand.bench.provenance/result]]: a report missing the
+  thing it was run for is refused, not quietly emitted.
+
+  Normative owner: `docs/design/freehand/decisions/`
+  `D021-performance-budgets-and-release-evidence.md`."
+  (:require [re-frame.freehand.bench :as bench]
+            ;; The ClojureScript-only arm. Requiring it is what registers
+            ;; it, exactly as the JVM runner requires the `.cljc` ones —
+            ;; one line per arm, nothing discovered by scanning.
+            [re-frame.freehand.bench.b1-react :as b1-react]
+            [re-frame.freehand.bench.runner :as runner]))
+
+(def lane-workloads
+  "The workload ids this lane exists to publish — the ones no JVM process
+  can reach.
+
+  Read off the arm rather than transcribed from it, so the require above
+  cannot become decorative: delete it and this namespace stops compiling.
+  The transcription lives in the suite instead, where a workload that
+  quietly changed its id is a failing sentence naming both spellings."
+  (mapv :id b1-react/workloads))
+
+(defn absent-lane-workloads
+  "The ids in [[lane-workloads]] that `registry` does not hold, in
+  declaration order — empty when the lane is whole.
+
+  Takes the registry rather than reading it, so the guard is testable
+  against a registry that is deliberately missing an arm. A guard only
+  ever exercised against the live registry is a guard nobody has seen
+  fail."
+  [registry]
+  (into [] (remove #(contains? registry %)) lane-workloads))
+
+(defn lane-defect-message
+  "The one-line sentence a broken lane fails with."
+  [absent]
+  (str "This ClojureScript evidence lane exists to publish " (count absent)
+       (if (= 1 (count absent)) " workload" " workloads")
+       " that no JVM process can reach, and the registry holds "
+       (if (= 1 (count absent)) "it" "them") " not: "
+       (pr-str absent)
+       ". Requiring a workload namespace is what registers it, so the require was "
+       "dropped or the workload no longer registers under this id. Refusing rather "
+       "than publishing a shorter report that still looks like evidence."))
+
+(defn -main
+  [& args]
+  (let [absent (absent-lane-workloads (bench/registered))]
+    (if (seq absent)
+      (do (js/console.error (lane-defect-message absent))
+          (js/process.exit 1))
+      (apply runner/-main args))))

--- a/implementation/freehand/src/re_frame/freehand/bench/runner.cljc
+++ b/implementation/freehand/src/re_frame/freehand/bench/runner.cljc
@@ -30,6 +30,7 @@
             ;; it lands, and nothing discovered by scanning.
             [re-frame.freehand.bench.b1]
             [re-frame.freehand.bench.b2]
+            [re-frame.freehand.bench.b3]
             [re-frame.freehand.bench.falsifiability :as falsifiability]
             #?(:clj [clojure.pprint :as pp] :cljs [cljs.pprint :as pp])))
 

--- a/implementation/freehand/src/re_frame/freehand/evidence.cljc
+++ b/implementation/freehand/src/re_frame/freehand/evidence.cljc
@@ -65,6 +65,17 @@
   application id may ride along as ordinary public props data; it does not
   replace runtime identity.
 
+  ## Every id here spells its namespace in full
+
+  `:re-frame.freehand.evidence/v1`, `:re-frame.freehand.evidence/defect`
+  — Freehand's reserved keyword root is the public namespace written out
+  rather than an `:rf.<area>/*` segment, so an id names its substrate
+  wherever it surfaces: source, data keywords, a refused record's
+  ex-data, generated documentation, AI context. Nothing here reaches for
+  the donor's `:rf.ui.evidence/*` spelling, which belongs to a different
+  artefact's projection and would make this schema look like a
+  continuation of it.
+
   ## Retention is Spec 009's, and this namespace holds nothing
 
   [[retention]] names the existing per-frame retained-event ring and its
@@ -311,7 +322,7 @@
   (let [ds (defects p)]
     (when (seq ds)
       (throw (ex-info (defects-message ds)
-                      {:rf.evidence/defect :incomplete-projection :defects ds})))
+                      {:re-frame.freehand.evidence/defect :incomplete-projection :defects ds})))
     p))
 
 (defn capped
@@ -380,7 +391,7 @@
                            (if (= 1 (count ds)) " problem" " problems")
                            " — " (str/join "; " (map defect-line ds))
                            ". A diagnostic is a stable id, a coordinate, and a way out.")
-                      {:rf.evidence/defect :incomplete-diagnostic :defects ds})))
+                      {:re-frame.freehand.evidence/defect :incomplete-diagnostic :defects ds})))
     d))
 
 ;; ---------------------------------------------------------------------------
@@ -441,14 +452,14 @@
                            (if (= 1 (count ds)) " field is" " fields are")
                            " missing or malformed — " (str/join "; " (map defect-line ds))
                            ". One versioned, occurrence-keyed schema (D020).")
-                      {:rf.evidence/defect :incomplete-record :defects ds})))
+                      {:re-frame.freehand.evidence/defect :incomplete-record :defects ds})))
     (doseq [[kind p] (:projections r)]
       (try
         (projection p)
         (catch #?(:clj Exception :cljs :default) e
           (throw (ex-info (str "The " kind " projection of this evidence record cannot be "
                                "emitted: " #?(:clj (.getMessage ^Exception e) :cljs (.-message e)))
-                          {:rf.evidence/defect :incomplete-projection
+                          {:re-frame.freehand.evidence/defect :incomplete-projection
                            :projection         kind
                            :view-id            (:view-id r)
                            :defects            (:defects (ex-data e))})))))

--- a/implementation/freehand/src/re_frame/freehand/evidence.cljc
+++ b/implementation/freehand/src/re_frame/freehand/evidence.cljc
@@ -1,0 +1,543 @@
+(ns re-frame.freehand.evidence
+  "ONE versioned, occurrence-keyed evidence schema — and the four things
+  every projection in it has to say about itself.
+
+  D020 rules that Freehand exposes one read-only evidence surface shared
+  by interpreted and compiled execution, keyed by a runtime occurrence,
+  and that it uses D012's vocabulary throughout: *every evidence
+  projection states its scope, basis, completeness relative to that scope,
+  and loss.* The sentence that ruling turns on is the shortest one in
+  either document:
+
+  > **\"Unknown\" must not look like \"none\".**
+
+  Which is what this namespace is for. Breadth is not the problem — a
+  tool can always ask for another roster. The problem is a projection that
+  reports what it happened to see as though it were what there is, and
+  every field here exists to make that shape impossible to write down.
+
+  ## The four axes
+
+      {:scope     :possible-sites          ; what this covers
+       :basis     :static-proof            ; how it knows
+       :complete? true                     ; only ever RELATIVE to :scope
+       :loss      nil}                     ; or {:reason … :dropped …}
+
+  `:scope` and `:basis` are separate on purpose, because a single ranking
+  such as *proven > declared > observed* is wrong. A runtime capture can
+  be complete for one committed generation and incomplete as a claim about
+  all executions; a static manifest can completely list possible sites
+  without saying which ran. Neither dominates, and a projection that
+  named only one of them would be making the other claim silently.
+
+  `:complete?` means nothing on its own — it is always completeness FOR
+  the stated scope. And `:loss` is the honest half: `nil` says nothing
+  was dropped, and a loss map says a reason and a `:dropped` count that is
+  either a number or the explicit `:unknown`. An ABSENT `:dropped` is
+  refused, because that is exactly the shape in which unknown comes to
+  look like none.
+
+  ## What is refused, and why each refusal is the ruling
+
+  [[projection]] is the only door, and it throws rather than emitting when
+
+    - a cap was hit and the projection still claims completeness. Any cap
+      sets `:complete? false` and records explicit loss (D020) — a
+      truncated roster reported as total is the failure mode this whole
+      schema exists to prevent;
+    - an `:opaque` basis claims completeness. A projection that cannot see
+      inside a host boundary cannot be complete about what is inside it;
+    - a `:declaration` basis claims completeness without naming what
+      ENFORCES the declaration. An unenforced annotation is a claim, not
+      proof (D012);
+    - a loss is stated without a `:dropped` count, or with a reason
+      outside [[loss-reasons]].
+
+  ## Occurrence-keyed
+
+  A record is keyed by a runtime OCCURRENCE plus a monotonic
+  `:generation`, never by a query key, a lexical site id, or a
+  caller-supplied controller id. Those are three different things and the
+  reason to keep them apart is that the first two are implementation
+  detail — an interpreted cell knows a query key, a compiled one knows a
+  lexical site — so a tool keyed on either would be a tool that behaves
+  differently depending on how a view was lowered. A caller-supplied
+  application id may ride along as ordinary public props data; it does not
+  replace runtime identity.
+
+  ## Retention is Spec 009's, and this namespace holds nothing
+
+  [[retention]] names the existing per-frame retained-event ring and its
+  one knob. There is no Freehand history store, no root-level retention
+  option, and no state of any kind in this namespace — it is values and
+  the functions that refuse malformed ones. Mounted occurrence records are
+  live projections, and when an emission cap is hit the loss is reported
+  in data rather than silently truncated. Freehand adds evidence records
+  and loss markers, not another observability product.
+
+  Normative owner: `docs/design/freehand/decisions/`
+  `D020-tool-evidence-retention-and-warning-policy.md`, with the
+  scope/basis/completeness/loss vocabulary from
+  `D012-declared-reads-and-evidence-levels.md`."
+  (:require [clojure.string :as str]
+            [re-frame.freehand.descriptor :as descriptor]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+;; ---------------------------------------------------------------------------
+;; The version
+;; ---------------------------------------------------------------------------
+
+(def schema
+  "The schema version every record carries.
+
+  A consumer validates this FIRST and refuses a record it does not
+  recognise, exactly as a structural tree consumer validates
+  `:rf.ui/tree-version`. Versioning an evidence surface is not ceremony:
+  the alternative is tools inferring the shape from the fields that happen
+  to be present, which makes every field an accidental ABI."
+  :re-frame.freehand.evidence/v1)
+
+;; ---------------------------------------------------------------------------
+;; The vocabularies — closed, because an open one is not a claim
+;; ---------------------------------------------------------------------------
+
+(def basis-kinds
+  "How a projection knows what it says. D012's four, and no fifth.
+
+  Closed because a basis is what a reader uses to decide how far to trust
+  the projection, and a vocabulary anyone may extend cannot carry that
+  weight."
+  {:static-proof
+   "proved from what the compiler can see — complete for compiler-visible sites"
+
+   :declaration
+   "asserted by the author — proof only where something enforces the assertion"
+
+   :observation
+   "seen happening — complete for the run or corpus it names, never for all runs"
+
+   :opaque
+   "deliberately unavailable: work behind a boundary this substrate does not own"})
+
+(def scopes
+  "The NAMED scopes, beside the map-shaped ones [[scope?]] also accepts."
+  {:possible-sites
+   "every site the grammar can see in one declaration, active or not"
+
+   :private-host-work
+   "work behind a host boundary — named so its absence is a fact rather than a gap"})
+
+(def loss-reasons
+  "Why a projection dropped something. Closed, and each reason is a
+  different remedy for the reader: a cap is a knob, a missing analysis is
+  a lowering choice, an opaque host is neither."
+  {:cap
+   "an emission cap was reached and entries beyond it were not carried"
+
+   :no-static-analysis
+   "the declaration is interpreted, so there is no analysis to report"
+
+   :host-opaque
+   "the host would not say, and no amount of asking would change that"})
+
+(def lowerings
+  "The two ways a declaration runs. A record names one, because the whole
+  point of one schema is that a tool does NOT have to care — and it can
+  only afford not to care if the difference is stated rather than
+  inferred."
+  #{:interpreted :compiled})
+
+(def unknown
+  "The explicit `:dropped` value for a projection that knows it lost
+  something and cannot say how much.
+
+  A named value rather than `nil` or an absent key, because both of those
+  read as \"none\" at a glance and one of them reads as \"none\" to
+  `(get loss :dropped)` as well."
+  :unknown)
+
+;; ---------------------------------------------------------------------------
+;; The predicates behind the ledger
+;; ---------------------------------------------------------------------------
+
+(defn scope?
+  "True when `s` is a scope a projection may claim: one of [[scopes]], or
+  a NON-EMPTY map naming the run it covers — `{:committed-generation 812}`,
+  `{:corpus :component-gallery :runs 240}`.
+
+  An empty map is refused. `{}` is a scope that says nothing, and a
+  completeness claim relative to nothing is a completeness claim about
+  everything."
+  [s]
+  (or (contains? scopes s)
+      (and (map? s) (seq s) (not (record? s)))))
+
+(defn loss?
+  "True when `l` is a legal loss: `nil`, or a map naming a reason from
+  [[loss-reasons]] and a `:dropped` that is a count or [[unknown]].
+
+  `nil` is legal and is not the same as incomplete: a projection honestly
+  scoped to one corpus is incomplete as a claim about all runs while
+  having dropped nothing at all."
+  [l]
+  (or (nil? l)
+      (and (map? l)
+           (contains? loss-reasons (:reason l))
+           (let [d (get l :dropped ::absent)]
+             (or (nat-int? d) (= unknown d))))))
+
+(defn occurrence?
+  "True when `o` is a runtime occurrence key — a map naming its `:parent`
+  occurrence (nil at a root) and the `:key` distinguishing it among that
+  parent's children.
+
+  Both keys must be PRESENT and either may be nil, because a root has no
+  parent and an unkeyed only-child has no key, and those are facts the
+  record states rather than omits."
+  [o]
+  (and (map? o) (contains? o :parent) (contains? o :key)))
+
+(defn- non-blank? [v] (and (string? v) (not (str/blank? v))))
+
+;; ---------------------------------------------------------------------------
+;; The projection ledger
+;; ---------------------------------------------------------------------------
+
+(def projection-fields
+  "The four axes, as data.
+
+  A vector rather than a `when-not` cascade for the same reason
+  `re-frame.freehand.bench.provenance` uses one: the suite that proves
+  every axis is required ENUMERATES this, so a fifth axis added later is
+  covered without anyone remembering to cover it, and a reader can check
+  the whole obligation against D012 on one screen."
+  [{:key      :scope
+    :names    "the scope"
+    :valid?   scope?
+    :expected (str "one of " (pr-str (vec (sort (keys scopes))))
+                   ", or a non-empty map naming the generation, corpus or run this covers")}
+
+   {:key      :basis
+    :names    "the basis"
+    :valid?   #(contains? basis-kinds %)
+    :expected (str "one of " (pr-str (vec (sort (keys basis-kinds)))))}
+
+   {:key      :complete?
+    :names    "the completeness claim"
+    :valid?   boolean?
+    :expected "true or false — completeness RELATIVE to the stated scope, never absolute"}
+
+   {:key      :loss
+    :names    "the loss account"
+    :valid?   loss?
+    :expected (str "nil when nothing was dropped, or {:reason <one of "
+                   (pr-str (vec (sort (keys loss-reasons))))
+                   "> :dropped <count or " unknown ">} — an absent :dropped reads as none")}])
+
+(def projection-invariants
+  "The cross-field rules. Each one is a shape in which a projection would
+  claim more than it knows, stated as a predicate so it cannot be
+  forgotten at a call site."
+  [{:holds?  (fn [{:keys [complete? loss]}] (not (and complete? (some? loss))))
+    :message (str "it claims completeness and also reports loss. Any cap sets "
+                  ":complete? false and records explicit loss — a truncated roster "
+                  "reported as total is the one failure this schema exists to prevent")}
+
+   {:holds?  (fn [{:keys [basis complete?]}] (not (and (= :opaque basis) complete?)))
+    :message (str "it claims completeness on an :opaque basis. A projection that "
+                  "cannot see inside a boundary cannot be complete about what is "
+                  "inside it — name the absence, do not claim to have surveyed it")}
+
+   {:holds?  (fn [{:keys [basis complete?] :as p}]
+               (not (and (= :declaration basis) complete? (not (contains? p :enforced-by)))))
+    :message (str "it claims completeness on a :declaration basis without naming "
+                  "what enforces the declaration. An unenforced annotation is a "
+                  "claim, not proof — add :enforced-by, or say :complete? false")}])
+
+(defn- field-defects
+  [p]
+  (into []
+        (keep (fn [{:keys [key names valid? expected]}]
+                (if-not (contains? p key)
+                  {:defect :missing :key key :names names :expected expected}
+                  (let [v (get p key)]
+                    (when-not (valid? v)
+                      {:defect :invalid :key key :names names :expected expected :observed v})))))
+        projection-fields))
+
+(defn defects
+  "Answer a vector of defects in the projection `p` — empty when it may be
+  emitted.
+
+  Field defects first, then the cross-field invariants, and the
+  invariants are only consulted once every field is well formed: an
+  invariant over a missing field would report a second, derived complaint
+  about the same mistake."
+  [p]
+  (let [ds (field-defects p)]
+    (if (seq ds)
+      ds
+      (into [] (keep (fn [{:keys [holds? message]}]
+                       (when-not (holds? p) {:defect :incoherent :message message})))
+            projection-invariants))))
+
+(defn- defect-line
+  [{:keys [defect key names expected observed message]}]
+  (case defect
+    :missing    (str key " (" names ") is missing; expected " expected)
+    :invalid    (str key " (" names ") is invalid — " (pr-str observed)
+                     "; expected " expected)
+    :incoherent message))
+
+(defn defects-message
+  "The one-line human sentence a refused projection throws with."
+  [ds]
+  (str "This evidence projection cannot be emitted: " (count ds)
+       (if (= 1 (count ds)) " problem" " problems")
+       " — " (str/join "; " (map defect-line ds))
+       ". Every evidence projection states its scope, basis, completeness relative to "
+       "that scope, and loss; \"unknown\" must not look like \"none\" (D012, D020)."))
+
+(defn projection
+  "Answer `p` when it states all four axes coherently, otherwise throw
+  naming everything that does not hold.
+
+  The ONLY door. There is no lenient variant and no `:strict?` flag,
+  because a projection that may be emitted without its completeness claim
+  is a projection that eventually is — and the reader has no way to tell
+  which one they are holding."
+  [p]
+  (let [ds (defects p)]
+    (when (seq ds)
+      (throw (ex-info (defects-message ds)
+                      {:rf.evidence/defect :incomplete-projection :defects ds})))
+    p))
+
+(defn capped
+  "Answer `p` with `k`'s collection truncated to `limit` and the loss
+  stated — or `p` unchanged, and still validated, when nothing was
+  dropped.
+
+  This is the honest half made cheap. A cap enforced at the call site
+  is a cap someone will one day apply without also flipping
+  `:complete?`; applied here it cannot be, because the truncation and the
+  loss account are the same expression."
+  [p k limit]
+  (let [xs (get p k)
+        n  (count xs)]
+    (if (<= n limit)
+      (projection p)
+      (projection (assoc p
+                         k         (vec (take limit xs))
+                         :complete? false
+                         :loss      {:reason :cap :dropped (- n limit)})))))
+
+;; ---------------------------------------------------------------------------
+;; Diagnostics — stable id, a coordinate, and a way out
+;; ---------------------------------------------------------------------------
+
+(defn- source-coord?
+  [s]
+  (and (map? s) (non-blank? (:file s)) (pos-int? (:line s))))
+
+(def diagnostic-fields
+  "What a diagnostic owes its reader, as data.
+
+  Three things, and the third is the one that is usually missing. An id
+  makes the finding addressable across releases; a coordinate makes it
+  reachable; a recovery makes it actionable. A diagnostic with the first
+  two is a search result."
+  [{:key      :id
+    :names    "the stable diagnostic id"
+    :valid?   qualified-keyword?
+    :expected "a namespaced keyword that does not change between releases, so a suppression, a lint config and a search still resolve"}
+
+   {:key      :source
+    :names    "the source coordinate"
+    :valid?   source-coord?
+    :expected "{:file \"…\" :line n} pointing at the form the finding is about"}
+
+   {:key      :recovery
+    :names    "the recovery"
+    :valid?   non-blank?
+    :expected "one sentence saying what to do instead — a finding that cannot say that is a complaint"}])
+
+(defn diagnostic
+  "Answer `d` when it carries a stable id, a source coordinate and a
+  recovery, otherwise throw naming what it lacks."
+  [d]
+  (let [ds (into []
+                 (keep (fn [{:keys [key names valid? expected]}]
+                         (let [v (get d key ::absent)]
+                           (cond
+                             (= ::absent v) {:defect :missing :key key :names names :expected expected}
+                             (not (valid? v)) {:defect :invalid :key key :names names
+                                               :expected expected :observed v}))))
+                 diagnostic-fields)]
+    (when (seq ds)
+      (throw (ex-info (str "This diagnostic cannot be emitted: " (count ds)
+                           (if (= 1 (count ds)) " problem" " problems")
+                           " — " (str/join "; " (map defect-line ds))
+                           ". A diagnostic is a stable id, a coordinate, and a way out.")
+                      {:rf.evidence/defect :incomplete-diagnostic :defects ds})))
+    d))
+
+;; ---------------------------------------------------------------------------
+;; The record
+;; ---------------------------------------------------------------------------
+
+(def record-fields
+  "Everything an evidence record names before it may be emitted."
+  [{:key      :schema
+    :names    "the schema version"
+    :valid?   #(= schema %)
+    :expected (str "exactly " schema " — a consumer validates this first and refuses what it does not recognise")}
+
+   {:key      :view-id
+    :names    "the authoring view"
+    :valid?   qualified-keyword?
+    :expected "the declaration's id — the namespace-qualified keyword the view was declared under"}
+
+   {:key      :lowering
+    :names    "the lowering"
+    :valid?   #(contains? lowerings %)
+    :expected (str "one of " (pr-str (vec (sort lowerings)))
+                   " — one schema for both modes means the mode is stated, not inferred")}
+
+   {:key      :occurrence
+    :names    "the runtime occurrence"
+    :valid?   occurrence?
+    :expected "{:parent <occurrence or nil> :key <any>} — runtime identity, never a query key, a lexical site id, or a caller-supplied controller id"}
+
+   {:key      :generation
+    :names    "the generation"
+    :valid?   nat-int?
+    :expected "the monotonic generation this record is keyed to, so two records about one occurrence are orderable"}
+
+   {:key      :projections
+    :names    "the projections"
+    :valid?   #(and (map? %) (seq %))
+    :expected "a non-empty map of projection-kind to projection — a record that projects nothing is not evidence"}])
+
+(defn record
+  "Answer `r` when it is a well-formed evidence record, otherwise throw.
+
+  Every projection under `:projections` goes through [[projection]], so
+  \"every evidence record carries scope, basis, completeness and loss\" is
+  a structural property of this door rather than a convention record kinds
+  are asked to follow."
+  [r]
+  (let [ds (into []
+                 (keep (fn [{:keys [key names valid? expected]}]
+                         (let [v (get r key ::absent)]
+                           (cond
+                             (= ::absent v) {:defect :missing :key key :names names :expected expected}
+                             (not (valid? v)) {:defect :invalid :key key :names names
+                                               :expected expected :observed v}))))
+                 record-fields)]
+    (when (seq ds)
+      (throw (ex-info (str "This evidence record cannot be emitted: " (count ds)
+                           (if (= 1 (count ds)) " field is" " fields are")
+                           " missing or malformed — " (str/join "; " (map defect-line ds))
+                           ". One versioned, occurrence-keyed schema (D020).")
+                      {:rf.evidence/defect :incomplete-record :defects ds})))
+    (doseq [[kind p] (:projections r)]
+      (try
+        (projection p)
+        (catch #?(:clj Exception :cljs :default) e
+          (throw (ex-info (str "The " kind " projection of this evidence record cannot be "
+                               "emitted: " #?(:clj (.getMessage ^Exception e) :cljs (.-message e)))
+                          {:rf.evidence/defect :incomplete-projection
+                           :projection         kind
+                           :view-id            (:view-id r)
+                           :defects            (:defects (ex-data e))})))))
+    r))
+
+;; ---------------------------------------------------------------------------
+;; The record kinds Freehand can state today
+;; ---------------------------------------------------------------------------
+
+(defn manifest-projection
+  "What a declaration's analysis makes statically knowable, stated with
+  its scope, basis, completeness and loss.
+
+  A COMPILED declaration answers `:possible-sites` on a `:static-proof`
+  basis, complete and lossless: the analyzer saw the whole body, the
+  grammar is finite, and the roster is every site there can be.
+
+  An INTERPRETED declaration answers the same scope on an `:opaque` basis,
+  INCOMPLETE, and reports `{:reason :no-static-analysis :dropped :unknown}`.
+  That is the shape of honesty this schema exists for. There is no analysis
+  step, so the number of sites the declaration could reach is not merely
+  large or uncounted — it is unknowable without running it, and a
+  projection that answered `:loss nil` there would be saying it dropped
+  nothing when what it means is that it never looked."
+  [view]
+  (if-let [m (descriptor/manifest view)]
+    (projection {:scope     :possible-sites
+                 :basis     :static-proof
+                 :complete? true
+                 :loss      nil
+                 :manifest  m})
+    (projection {:scope     :possible-sites
+                 :basis     :opaque
+                 :complete? false
+                 :loss      {:reason :no-static-analysis :dropped unknown}
+                 :manifest  nil})))
+
+(def a11y-basis
+  "The basis a static accessibility finding is emitted under, and the
+  reason there is exactly one.
+
+  `re-frame.freehand.compiler.a11y` fires only where the defect is
+  PROVABLE from the literal AST the compiler already built, and goes
+  silent the instant a dynamic child, a foreign component, a spread or a
+  runtime-computed aria value introduces information it cannot see. So a
+  finding is `:static-proof` and can be nothing else: there is no
+  heuristic tier to be `:observation` about and no annotation to be
+  `:declaration` about."
+  :static-proof)
+
+(defn a11y-projection
+  "The static accessibility findings for one declaration, honestly scoped.
+
+  The scope is the sites this GRAMMAR can prove, never \"accessibility\":
+  the roster is complete for what static proof reaches and says nothing
+  whatever about what it does not, and stating that as the scope is what
+  stops an empty roster reading as a clean bill of health.
+
+  Every finding goes through [[diagnostic]], so a finding that cannot name
+  a coordinate and a recovery is refused here rather than shipped to a
+  reader who then has to guess."
+  [findings]
+  (projection {:scope     {:provable-in :re-frame.freehand/v1}
+               :basis     a11y-basis
+               :complete? true
+               :loss      nil
+               :findings  (mapv diagnostic findings)}))
+
+;; ---------------------------------------------------------------------------
+;; Retention — the existing axis, named as data
+;; ---------------------------------------------------------------------------
+
+(def retention
+  "Where evidence history lives: the existing per-frame retained-event
+  ring specified by Spec 009, and nowhere else.
+
+  Data rather than a paragraph, because the claim is checkable and the
+  suite checks it. This namespace holds no atom, no ring, no cache and no
+  configuration of its own; a projection is a value a caller built and
+  handed to a reader. The knob is `:rf.trace/events-retained` — one
+  number, per frame, overridable through
+  `(rf/configure! {:trace-buffer {:events-retained N}})` — and Freehand
+  adds no second one.
+
+  There is a reason beyond tidiness. A second retention mechanism would
+  be a second thing to disable in production, a second place a payload
+  could survive a request, and a second answer to \"how far back does this
+  go?\" that disagrees with the first."
+  {:owner        :spec-009
+   :mechanism    :per-frame-retained-event-ring
+   :knob         :rf.trace/events-retained
+   :configure-at [:trace-buffer :events-retained]})

--- a/implementation/freehand/test/re_frame/freehand/bench/b3_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/bench/b3_cljs_test.cljc
@@ -1,0 +1,265 @@
+(ns re-frame.freehand.bench.b3-cljs-test
+  "B3's DETERMINISTIC half, run on both hosts.
+
+  B3's correctness claim is four exact integers and one flag: ten thousand
+  records exist, a few hundred rows are compared, an exact number commits
+  and an exact number is skipped, and the two comparators name the same
+  rows. This suite proves those are the WRITTEN arithmetic — spelled out
+  step by step below, independently of the arithmetic function the
+  workload uses — that the isolation the counts claim is real (a mutation
+  outside the window commits nothing), that the comparators DISCRIMINATE
+  (they notice a row that changed), and that the workloads run green and
+  publish the distributions D021 asks B3 for.
+
+  The half this suite does NOT touch: how big any timing is. B3 publishes
+  four durations and this file asserts they were published, never that any
+  was fast. Whether comparator specialization pays is a judgement made
+  from those numbers by a person, which is why nothing here compares
+  them."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.freehand.bench :as bench]
+            [re-frame.freehand.bench.b3 :as b3]
+            [re-frame.freehand.bench.measure :as m]
+            [re-frame.freehand.tree :as tree]))
+
+(def ^:private provenance
+  "The revision a TEST supplies. A ClojureScript test process is not a
+  build pipeline: no environment variable, no git, and nothing it could
+  truthfully detect. The published run detects its own."
+  {:revision "test-fixture-revision"})
+
+(def ^:private stress
+  {:total 10000 :window 40})
+
+(def ^:private small
+  {:total 400 :window 12})
+
+;; ---------------------------------------------------------------------------
+;; The counts are the written arithmetic — written HERE, step by step
+;; ---------------------------------------------------------------------------
+
+(def ^:private stress-steps
+  "The stress script's nine steps, with the counts each one produces,
+  worked out by hand from a window of forty over ten thousand records.
+
+  This table is the anchor under every count B3 gates. The workload
+  derives its expectation from [[re-frame.freehand.bench.b3/expectation]],
+  which walks the script; if that function and this table ever disagree,
+  one of them is wrong and the suite says so — which is the only way a
+  written expectation stays written rather than becoming a second copy of
+  the code."
+  [{:step :idle              :compared 40 :committed 0  :skipped 40}
+   {:step :edit-row-0        :compared 40 :committed 1  :skipped 39}
+   {:step :edit-row-9999     :compared 40 :committed 0  :skipped 40}
+   {:step :scroll-to-20      :compared 20 :committed 20 :skipped 20}
+   {:step :edit-row-20       :compared 40 :committed 1  :skipped 39}
+   {:step :scroll-to-0       :compared 20 :committed 20 :skipped 20}
+   {:step :scroll-to-160     :compared 0  :committed 40 :skipped 0}
+   {:step :edit-row-160      :compared 40 :committed 1  :skipped 39}
+   {:step :idle              :compared 40 :committed 0  :skipped 40}])
+
+(defn- total-of [k] (reduce + 0 (map k stress-steps)))
+
+(deftest b3-the-expectation-is-the-hand-written-arithmetic
+  (testing "The workload's expectation function answers what the script
+            means, step by step. Every step's committed and skipped counts
+            sum to the window, because every visible row either commits or
+            is skipped — there is no third outcome and no row unaccounted
+            for."
+    (doseq [{:keys [step compared committed skipped]} stress-steps]
+      (is (= 40 (+ committed skipped))
+          (str step ": every visible row either commits or is skipped"))
+      (is (<= compared 40)
+          (str step ": the comparison never touches more than the window")))
+    (let [e (b3/expectation stress)]
+      (is (= (total-of :compared) (:compared e)) "comparisons")
+      (is (= (total-of :committed) (:committed e)) "committed rows")
+      (is (= (total-of :skipped) (:skipped e)) "skipped rows")
+      (is (= (* 40 (inc (count stress-steps))) (:rendered e))
+          "rows rendered — the initial window plus one window per step"))))
+
+(deftest b3-the-run-produces-exactly-those-counts
+  (testing "And the measured run — real records, real props, the real `rf=`
+            comparator — answers the same integers the arithmetic
+            predicted. That agreement is the gate; the arithmetic knows
+            nothing about records or `rf=`, and the run knows nothing about
+            the arithmetic."
+    (doseq [fixture [stress small]]
+      (let [e     (b3/expectation fixture)
+            obs   (b3/observe (b3/records (:total fixture)) fixture)
+            label (str (:total fixture) "/" (:window fixture) ": ")]
+        (is (= (:total fixture) (:B3/records obs)) (str label "records"))
+        (is (= (:rendered e) (:B3/rows-rendered obs)) (str label "rows rendered"))
+        (is (= (:compared e) (:B3/rows-compared obs)) (str label "rows compared"))
+        (is (= (:committed e) (:B3/committed-rows obs)) (str label "rows committed"))
+        (is (= (:skipped e) (:B3/skipped-rows obs)) (str label "rows skipped"))
+        (is (true? (:B3/comparator-agreement obs)) (str label "the comparators agreed"))))))
+
+;; ---------------------------------------------------------------------------
+;; The comparison isolates rows
+;; ---------------------------------------------------------------------------
+
+(deftest b3-the-comparison-touches-the-window-and-not-the-collection
+  (testing "The isolation claim as two integers side by side: ten thousand
+            records exist, and the whole scripted sequence performs a few
+            hundred comparisons over them. Windowing is what makes the
+            second number a function of the window rather than of the
+            dataset — so the same script over twenty-five times fewer
+            records compares only as many rows as its own window holds."
+    (let [big   (b3/expectation stress)
+          tiny  (b3/expectation small)]
+      (is (< (:compared big) (:total stress))
+          "the stress case compares far fewer rows than it holds records")
+      (is (<= (:compared big) (* 40 (count stress-steps)))
+          "and never more than one window per step")
+      (is (= (:compared tiny) (* (/ (:compared big) 40) 12))
+          "the comparison count scales with the WINDOW, not with the dataset"))))
+
+(deftest b3-a-mutation-outside-the-window-commits-nothing
+  (testing "The sharpest form of the claim, isolated from the script: edit
+            a record the window does not show, and the next render's rows
+            are identical — nothing changed, nothing commits. This is what
+            a table of ten thousand rows buys."
+    (let [recs   (b3/records 10000)
+          window 40
+          before (b3/window-rows recs 0 window)
+          after  (b3/window-rows (update-in recs [9999 :amount] inc) 0 window)
+          index  (into {} (map (juxt :id identity)) before)]
+      (is (= before after) "the window did not move and its rows did not change")
+      (is (= #{} (b3/changed-keys b3/generated-equal? index after))
+          "so the generated comparator names no row changed")
+      (is (= #{} (b3/changed-keys b3/generic-equal? index after))
+          "and neither does the generic one"))))
+
+(deftest b3-the-comparison-would-notice-a-row-that-changed
+  (testing "The discrimination behind that zero. A comparator that always
+            answered `equal` would produce the same empty set above, so the
+            same two comparators are shown naming exactly the row that DID
+            change — and naming only it."
+    (let [recs   (b3/records 10000)
+          window 40
+          before (b3/window-rows recs 0 window)
+          index  (into {} (map (juxt :id identity)) before)]
+      (doseq [row [0 17 39]]
+        (let [after (b3/window-rows (update-in recs [row :amount] inc) 0 window)
+              id    (:id (nth recs row))]
+          (is (= #{id} (b3/changed-keys b3/generated-equal? index after))
+              (str "row " row ": the generated comparator names exactly it"))
+          (is (= #{id} (b3/changed-keys b3/generic-equal? index after))
+              (str "row " row ": and so does the generic one")))))))
+
+(deftest b3-a-scroll-keeps-the-rows-it-still-shows
+  (testing "Matching by KEY is what makes a scroll cheap, and it is checked
+            as an identity rather than as a count: slide the window by half
+            its height and the rows it still shows are the same rows, so
+            neither comparator names any of them changed. Matching by
+            POSITION would name every one."
+    (let [recs   (b3/records 10000)
+          window 40
+          before (b3/window-rows recs 0 window)
+          after  (b3/window-rows recs 20 window)
+          index  (into {} (map (juxt :id identity)) before)]
+      (is (= 20 (count (filter #(contains? index (:id %)) after)))
+          "half the new window is rows the old one also showed")
+      (is (= #{} (b3/changed-keys b3/generated-equal? index after))
+          "and none of them changed")
+      (is (= (mapv :id (subvec before 20)) (mapv :id (subvec after 0 20)))
+          "they are the same rows, in order, addressed by key"))))
+
+;; ---------------------------------------------------------------------------
+;; The parent renders the window
+;; ---------------------------------------------------------------------------
+
+(deftest b3-the-parent-renders-the-window-not-the-collection
+  (testing "Counted off the rendered tree rather than off the props handed
+            in: one row element per visible row, whatever the dataset
+            behind it is."
+    (doseq [{:keys [total window]} [stress small {:total 10000 :window 1}]]
+      (let [rows (b3/window-rows (b3/records total) 0 window)
+            t    (tree/render [b3/windowed-table {:rows rows}])]
+        (is (= window (b3/rendered-rows t))
+            (str total "/" window ": the render built one row element per visible row"))))))
+
+;; ---------------------------------------------------------------------------
+;; The registered workloads
+;; ---------------------------------------------------------------------------
+
+(deftest b3-registers-the-stress-case-and-the-small-case
+  (testing "D021 requires a small realistic case beside the stress case.
+            Both are registered into the standing evidence suite, both run
+            one script shape, and the stress case is the ten thousand keyed
+            records D021 names for B3 under the baseline it names."
+    (let [registered (bench/registered)]
+      (doseq [id [:B3/windowed-ledger :B3/small-windowed-ledger]]
+        (is (contains? registered id) (str id " is in the standing evidence suite"))))
+    (let [big (first (filter #(= :B3/windowed-ledger (:id %)) b3/workloads))
+          sm  (first (filter #(= :B3/small-windowed-ledger (:id %)) b3/workloads))]
+      (is (= 10000 (get-in big [:fixture :total])) "ten thousand keyed records")
+      (is (= 40 (get-in big [:fixture :window])) "through a window of about forty")
+      (is (< (get-in sm [:fixture :total]) 1000) "and the small case is genuinely small")
+      (is (= :interpreted-vs-compiled (:kind (:baseline big)))
+          "under the baseline D021 names for B3"))))
+
+(deftest b3-runs-green-and-publishes-its-evidence
+  (testing "Each registered workload runs, its six deterministic properties
+            hold, and every duration it declared is published as a
+            distribution carrying no verdict."
+    (doseq [w b3/workloads]
+      (let [record (bench/run-workload w provenance)
+            label  (str (:id w) ": ")]
+        (is (empty? (:gate-failures record)) (str label "no deterministic property was violated"))
+        (doseq [mid [:B3/records :B3/rows-rendered :B3/rows-compared
+                     :B3/committed-rows :B3/skipped-rows :B3/comparator-agreement]]
+          (is (true? (get-in record [:properties mid :pass?]))
+              (str label mid " held"))
+          (is (= (get-in record [:properties mid :expected])
+                 (get-in record [:properties mid :observed]))
+              (str label mid " observed exactly what the arithmetic expected")))
+        (is (= (get-in record [:fixture :total])
+               (get-in record [:properties :B3/records :observed]))
+            (str label "the gated record count is the fixture's dataset size"))
+        (doseq [mid [:B3/generated-comparator-ms :B3/generic-comparator-ms
+                     :B3/parent-render-ms :B3/end-to-end-ms :bench/iteration-ms]]
+          (let [d (get-in record [:distribution mid])]
+            (is (some? d) (str label mid " was published"))
+            (is (= (:samples (:sampling w)) (:n d))
+                (str label mid " summarises every measured iteration"))
+            (is (not (contains? d :pass?))
+                (str label mid " carries no verdict — it is evidence"))))))))
+
+(deftest b3-carries-the-provenance-a-published-result-needs
+  (testing "A count without its environment is not release evidence. The
+            record names its revision, its fixture parameters — including
+            the script the counts are counts OF — its build mode, runtime
+            and hardware class."
+    (let [w      (first b3/workloads)
+          record (bench/run-workload w provenance)]
+      (is (= "test-fixture-revision" (:revision record)))
+      (is (= 10000 (get-in record [:fixture :total])))
+      (is (= 40 (get-in record [:fixture :window])))
+      (is (= 9 (count (get-in record [:fixture :script])))
+          "the scripted mutation sequence rides the record")
+      (is (keyword? (get-in record [:build :optimizations])))
+      (is (boolean? (get-in record [:build :instrumentation?])))
+      (is (seq (get-in record [:host :runtime])))
+      (is (keyword? (get-in record [:host :hardware-class])))
+      (is (= :evidence (:status record))))))
+
+;; ---------------------------------------------------------------------------
+;; The counts gate; the timings cannot
+;; ---------------------------------------------------------------------------
+
+(deftest b3-counts-gate-and-no-duration-can
+  (testing "The asymmetry, read off B3's own declarations. Every count and
+            the agreement flag class as gates; every duration classes as
+            evidence. A future edit reaching for a latency budget would be
+            refused when the workload is CONSTRUCTED, not here — which is
+            why this file compares no milliseconds."
+    (let [by-id (into {} (map (juxt :id identity))
+                      (:measurements (bench/workload (first b3/workloads))))]
+      (doseq [mid [:B3/records :B3/rows-rendered :B3/rows-compared
+                   :B3/committed-rows :B3/skipped-rows :B3/comparator-agreement]]
+        (is (m/gate? (get by-id mid)) (str mid " gates")))
+      (doseq [mid [:B3/generated-comparator-ms :B3/generic-comparator-ms
+                   :B3/parent-render-ms :B3/end-to-end-ms :bench/iteration-ms]]
+        (is (m/evidence? (get by-id mid)) (str mid " is evidence"))))))

--- a/implementation/freehand/test/re_frame/freehand/bench/node_lane_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/node_lane_cljs_test.cljs
@@ -1,0 +1,114 @@
+(ns re-frame.freehand.bench.node-lane-cljs-test
+  "The ClojureScript evidence lane, checked as a LANE.
+
+  The React arm's own counters are checked next door
+  (`re-frame.freehand.bench.b1-react-cljs-test`). What is checked here is
+  the thing that suite cannot see: whether the workloads it exercises are
+  reachable from a command anyone can run, and whether that command
+  notices when they stop being.
+
+  The distinction is the whole reason this file exists. A workload
+  registers itself at load, so a test namespace that requires it directly
+  makes it present in the test registry whether or not any RUNNER requires
+  it — which is exactly how two registered React workloads came to have
+  full test coverage and no runnable lane at all. So the guard below is
+  tested against a registry handed to it, including registries that are
+  deliberately missing an arm, rather than against the ambient one only."
+  (:require [cljs.test :refer [deftest is testing]]
+            [re-frame.freehand.bench :as bench]
+            ;; The ENTRY, and deliberately not the workload namespace. If
+            ;; this require were `…bench.b1-react`, every assertion below
+            ;; would hold with the lane's own require deleted.
+            [re-frame.freehand.bench.node :as node]))
+
+(def ^:private provenance
+  "The revision a TEST supplies. A ClojureScript test process is not a
+  build pipeline: no environment variable, no git, and nothing it could
+  truthfully detect. The published run detects its own."
+  {:revision "test-fixture-revision"})
+
+;; ---------------------------------------------------------------------------
+;; The lane is whole
+;; ---------------------------------------------------------------------------
+
+(deftest the-lane-names-the-two-react-workloads
+  (testing "The roster the entry publishes, transcribed here and read off
+            the arm there. The entry reads its ids from the workload
+            namespace so the require cannot become decorative; this is the
+            other end of that — an arm that quietly renamed a workload
+            would leave the entry compiling and this sentence failing with
+            both spellings in it."
+    (is (= [:B1/react-template :B1/react-small-template] node/lane-workloads))))
+
+(deftest the-node-entry-loads-the-cljs-only-workloads
+  (testing "Requiring the entry is what puts the ClojureScript-only
+            workloads in the registry — that is the entry's whole job, and
+            the assertion is over the registry the entry produced rather
+            than over its require form."
+    (is (= [] (node/absent-lane-workloads (bench/registered)))
+        (str "the entry namespace is loaded, so every id in "
+             (pr-str node/lane-workloads) " should be registered"))))
+
+(deftest the-guard-names-the-arm-that-stopped-registering
+  (testing "The guard, driven from the failing side. An empty registry
+            loses both arms and says so in declaration order; a registry
+            missing one loses exactly that one. This is what makes the
+            check above non-vacuous: the guard is demonstrated to answer
+            differently when the lane is broken."
+    (is (= node/lane-workloads (node/absent-lane-workloads {}))
+        "a registry holding nothing is missing every lane workload")
+    (doseq [id node/lane-workloads]
+      (is (= [id] (node/absent-lane-workloads (dissoc (bench/registered) id)))
+          (str "dropping " id " from the registry leaves exactly it absent")))))
+
+(deftest a-broken-lane-says-which-arm-it-could-not-find
+  (testing "And it says so in a sentence naming the ids, because the
+            operator reading a failed scheduled run has the command's
+            stderr and nothing else."
+    (let [msg (node/lane-defect-message (node/absent-lane-workloads {}))]
+      (doseq [id node/lane-workloads]
+        (is (re-find (re-pattern (str ":" (namespace id) "/" (name id))) msg)
+            (str "the refusal names " id))))))
+
+;; ---------------------------------------------------------------------------
+;; The lane publishes evidence, through the one runner
+;; ---------------------------------------------------------------------------
+
+(defn- lane-outcome
+  "Run exactly the lane's workloads, read out of the live registry by the
+  ids the entry declares — so a renamed or vanished workload is a failure
+  here rather than a quietly shorter report."
+  []
+  (bench/run (mapv #(get (bench/registered) %) node/lane-workloads) provenance))
+
+(deftest the-lane-publishes-both-react-records-with-their-provenance
+  (testing "Both arms answer a full result record: the provenance a
+            published number needs, at least one distribution, and at
+            least one deterministic property. This is the artefact the
+            scheduled workflow uploads, minus the printing."
+    (let [{:keys [results]} (lane-outcome)]
+      (is (= node/lane-workloads (mapv :benchmark results))
+          "one record per lane workload, in declaration order")
+      (doseq [r results]
+        (let [label (str (:benchmark r) ": ")]
+          (is (= "test-fixture-revision" (:revision r)) (str label "names its revision"))
+          (is (seq (:fixture r)) (str label "names its fixture parameters"))
+          (is (keyword? (get-in r [:build :optimizations])) (str label "names its build mode"))
+          (is (boolean? (get-in r [:build :instrumentation?])) (str label "names its instrumentation mode"))
+          (is (string? (get-in r [:host :runtime])) (str label "names its runtime"))
+          (is (keyword? (get-in r [:host :hardware-class])) (str label "names its hardware class"))
+          (is (pos-int? (get-in r [:sampling :samples])) (str label "names its sample policy"))
+          (is (contains? #{:before-vs-after :interpreted-vs-compiled
+                           :absorbed-vs-donor :self-vs-end-to-end}
+                         (get-in r [:baseline :kind]))
+              (str label "names one of D021's four baselines"))
+          (is (seq (:distribution r)) (str label "publishes at least one distribution"))
+          (is (seq (:properties r)) (str label "gates at least one deterministic property")))))))
+
+(deftest the-lane-obeys-the-one-exit-code-law
+  (testing "Green means every deterministic property held, and that is the
+            only thing the exit code reads. The lane adds no verdict of
+            its own — it delegates to the same runner the JVM lane uses."
+    (let [{:keys [exit-code gate-failures]} (lane-outcome)]
+      (is (= [] gate-failures) "no deterministic property was violated")
+      (is (zero? exit-code) "so the lane exits 0"))))

--- a/implementation/freehand/test/re_frame/freehand/evidence_boundary_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/evidence_boundary_jvm_test.clj
@@ -1,0 +1,189 @@
+(ns re-frame.freehand.evidence-boundary-jvm-test
+  "Two claims about the evidence schema that are claims about ABSENCE, and
+  so cannot be made by exercising it.
+
+  1. **Retention is Spec 009's, and there is no second mechanism.** The
+     schema names the existing per-frame retained-event ring and keeps
+     nothing itself. Checked over the interned vars of every loaded
+     Freehand namespace rather than over the text of any file: a store is
+     a mutable container, and a mutable container is a value you can look
+     at.
+
+  2. **The evidence surface is not on the shipping render path.** Checked
+     as REACHABILITY over the require graph, rooted at the public door —
+     not as a search for a string. The graph is built by reading each
+     source file's `ns` form, reader conditionals and all, so a require
+     that exists only on one host is an edge like any other.
+
+  On (2) and what it is not: this is a require-graph assertion, not a
+  bundle proof. It answers \"can a production render reach this code\"
+  and not \"did this code survive `:advanced`\". The two coincide today
+  because nothing emits evidence yet — the schema is values and the
+  functions that refuse malformed ones, reachable from no render. When
+  the emission slice lands and a dev-gated call site appears on the path,
+  this assertion is the wrong one and a control-build probe is the right
+  one; it should be REPLACED then, not relaxed.
+
+  JVM-only because both claims are about the whole source tree, and the
+  JVM is where a test can read it."
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            ;; The public door, required for its LOADING: the corpus walk
+            ;; below is over the namespaces this process has loaded, and
+            ;; requiring the door is what makes that set the substrate
+            ;; rather than whatever a preceding suite happened to touch.
+            [re-frame.freehand]
+            [re-frame.freehand.evidence :as ev])
+  (:import [clojure.lang IAtom IDeref IPending IRef]))
+
+;; ---------------------------------------------------------------------------
+;; 1 — no second retention mechanism
+;; ---------------------------------------------------------------------------
+
+(defn- store?
+  "True when `v` is a mutable container — the shape a retention store has,
+  whatever it is called."
+  [v]
+  (or (instance? IAtom v)
+      (instance? IRef v)
+      (instance? IPending v)
+      (instance? clojure.lang.Volatile v)))
+
+(deftest the-evidence-schema-holds-nothing
+  (testing "Not \"holds no retention\" — holds NOTHING. Every public var in
+            the schema is a value or a function over values, so there is
+            no slot in which a record could survive the call that made it,
+            and therefore nothing to disable in production, nothing to
+            clear on teardown, and nothing to bound."
+    (let [interns (ns-interns 're-frame.freehand.evidence)]
+      (is (seq interns) "the namespace has public vars — the walk below is not over an empty set")
+      (doseq [[sym var*] interns]
+        (is (not (store? (deref var*)))
+            (str "re-frame.freehand.evidence/" sym " is a mutable container"))))))
+
+(defn- freehand-namespaces
+  []
+  (filter #(str/starts-with? (str (ns-name %)) "re-frame.freehand") (all-ns)))
+
+(def ^:private retention-ish
+  #"(?i)retain|retention|history|ring-buffer")
+
+(deftest no-freehand-namespace-publishes-a-second-retention-store
+  (testing "The corpus half of the same claim, over interned vars rather
+            than over file text: any Freehand var whose NAME suggests it
+            keeps history is checked to be an immutable value. The one
+            that matches is a pointer at Spec 009's knob, which is the
+            shape a reference has and not the shape a store has."
+    (let [nss     (freehand-namespaces)
+          matches (for [n nss
+                        [sym var*] (ns-publics n)
+                        :when (re-find retention-ish (name sym))]
+                    [(symbol (str (ns-name n)) (name sym)) var*])]
+      (is (< 10 (count nss))
+          "the Freehand tree is loaded — the walk below is not over an empty set")
+      (is (seq matches)
+          "and at least one var matched, so the predicate above is not vacuous")
+      (doseq [[qualified var*] matches]
+        (is (not (store? (deref var*)))
+            (str qualified " keeps history of its own"))))))
+
+(deftest retention-points-at-re-frames-own-axis
+  (testing "The knob the schema names belongs to re-frame's reserved
+            `:rf.trace/*` namespace and is applied through re-frame's own
+            configurator. Freehand could not have minted it: a
+            Freehand-minted knob would be in a Freehand namespace, and
+            this one is not."
+    (is (= "rf.trace" (namespace (:knob ev/retention)))
+        "the knob lives in re-frame's reserved trace namespace")
+    (is (not (str/includes? (str (:knob ev/retention)) "freehand"))
+        "and not in a Freehand-minted one")
+    (is (some? (requiring-resolve 're-frame.core/configure!))
+        "the configurator the schema points at exists")
+    (is (= 1 (count (first (:arglists (meta (requiring-resolve 're-frame.core/configure!))))))
+        "and takes the single nested config map the retention path is expressed against")))
+
+;; ---------------------------------------------------------------------------
+;; 2 — the schema is not reachable from the shipping render path
+;; ---------------------------------------------------------------------------
+
+(defn- source-root
+  "The `src` directory this artefact's namespaces are compiled from,
+  located through the classpath rather than through a relative path, so
+  the suite does not depend on the directory it was started in."
+  []
+  (-> (io/resource "re_frame/freehand.cljc") .toURI io/file .getParentFile .getParentFile))
+
+(defn- source-files
+  []
+  (->> (file-seq (source-root))
+       (filter #(.isFile ^java.io.File %))
+       (filter #(re-find #"\.clj[cs]?$" (.getName ^java.io.File %)))))
+
+(defn- symbols-in
+  "Every symbol in `form`, descending through reader conditionals so a
+  require that exists only on one host is still seen."
+  [form]
+  (cond
+    (symbol? form)                                  [form]
+    (instance? clojure.lang.ReaderConditional form) (symbols-in (.form ^clojure.lang.ReaderConditional form))
+    (coll? form)                                    (mapcat symbols-in form)
+    :else                                           []))
+
+(defn- ns-form
+  [^java.io.File f]
+  (with-open [r (java.io.PushbackReader. (io/reader f))]
+    (read {:read-cond :preserve :eof nil} r)))
+
+(defn- require-graph
+  "Freehand namespace -> the Freehand namespaces its `ns` form mentions.
+
+  Deliberately over-approximate: every Freehand-shaped symbol anywhere in
+  the `ns` form is an edge, whether it sits in a `:require`, an `:import`
+  or a docstring's code sample. Over-approximating can only make the
+  reachable set LARGER, so a namespace this graph says is unreachable is
+  unreachable."
+  []
+  (into {}
+        (keep (fn [f]
+                (let [form (ns-form f)]
+                  (when (and (seq? form) (= 'ns (first form)) (symbol? (second form)))
+                    (let [self (second form)]
+                      [self (into #{}
+                                  (comp (filter #(str/starts-with? (str %) "re-frame.freehand"))
+                                        (remove #(= self %)))
+                                  (symbols-in (drop 2 form)))])))))
+        (source-files)))
+
+(defn- reachable-from
+  [graph root]
+  (loop [seen #{} queue [root]]
+    (if-let [n (first queue)]
+      (if (contains? seen n)
+        (recur seen (rest queue))
+        (recur (conj seen n) (into (vec (rest queue)) (get graph n))))
+      seen)))
+
+(deftest the-evidence-schema-is-not-reachable-from-the-public-door
+  (testing "Rooted at `re-frame.freehand`, the substrate's one public door,
+            and followed transitively. Nothing an application mounts can
+            reach the evidence schema, which is why there is no evidence
+            code in an application's bundle to elide — an absence
+            established by construction rather than by a switch."
+    (let [graph     (require-graph)
+          reachable (reachable-from graph 're-frame.freehand)]
+      (testing "the graph is real — the positive control"
+        (is (< 20 (count graph)) "every Freehand source file contributed a node")
+        (is (< 10 (count reachable)) "and the door reaches a substantial tree")
+        (doseq [on-the-path '[re-frame.freehand.tree
+                              re-frame.freehand.descriptor
+                              re-frame.freehand.node]]
+          (is (contains? reachable on-the-path)
+              (str on-the-path " is reachable from the door — if it were not, the walk is broken "
+                   "and the absence below would be meaningless"))))
+      (testing "and the evidence schema is not in it"
+        (is (not (contains? reachable 're-frame.freehand.evidence))
+            (str "re-frame.freehand.evidence became reachable from the public door. If an "
+                 "emission site was added deliberately, this assertion is the wrong one from "
+                 "now on: replace it with a control-build probe that proves the emission "
+                 "elides, rather than relaxing it."))))))

--- a/implementation/freehand/test/re_frame/freehand/evidence_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/evidence_cljs_test.cljc
@@ -1,0 +1,344 @@
+(ns re-frame.freehand.evidence-cljs-test
+  "The evidence schema, checked at the door it can only be entered by.
+
+  Every claim here is about a REFUSAL. That is deliberate: a schema whose
+  suite only ever builds well-formed values proves that the happy path
+  exists, and the whole point of this one is the shapes it will not let
+  you write down — a truncated roster reported as total, an `:opaque`
+  basis claiming completeness, a loss with no count, a record with no
+  version.
+
+  The a11y half of the ruling — a finding is emitted only where it is
+  statically PROVABLE, so a dynamic name or role produces none — is
+  proved over real declarations in
+  `re-frame.freehand.a11y-diagnostics-cljs-test`. What is proved here is
+  the schema consequence of that: a static accessibility finding's basis
+  can only be `:static-proof`, and the roster's scope is the sites this
+  grammar can prove rather than \"accessibility\", so an empty roster is
+  never readable as a clean bill of health."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.evidence :as ev]))
+
+;; ---------------------------------------------------------------------------
+;; Fixtures
+;; ---------------------------------------------------------------------------
+
+(v/defview compiled-probe
+  "A compiled declaration — analyzed, so its site roster is provable."
+  {:compiled true}
+  [{:keys [id]}]
+  [:span.probe (v/sub [:probe/value id])])
+
+(v/defview interpreted-probe
+  "The same shape, interpreted — no analysis step, so nothing to report."
+  [{:keys [id]}]
+  [:span.probe (str id)])
+
+(def ^:private well-formed
+  {:scope :possible-sites :basis :static-proof :complete? true :loss nil})
+
+(def ^:private a-finding
+  {:id       :rf.ui.compile/a11y-missing-accessible-name
+   :source   {:file "src/app/toolbar.cljc" :line 42}
+   :recovery "give the control a visible label, an :aria-label, or an :aria-labelledby"})
+
+(defn- refused
+  "The defect data a refused value throws, or nil when it was accepted."
+  [f]
+  (try (f) nil
+       (catch #?(:clj Exception :cljs :default) e (ex-data e))))
+
+(defn- refused-keys
+  [f]
+  (set (keep :key (:defects (refused f)))))
+
+;; ---------------------------------------------------------------------------
+;; 1 — every projection states all four axes
+;; ---------------------------------------------------------------------------
+
+(deftest the-ledger-is-exactly-the-four-axes
+  (testing "Scope, basis, completeness and loss — the four D012 names, and
+            no fifth. Pinned as a set rather than described, so adding an
+            axis is a deliberate edit here and not a silent widening of
+            what a projection is allowed to leave unsaid."
+    (is (= #{:scope :basis :complete? :loss}
+           (set (map :key ev/projection-fields))))))
+
+(deftest a-projection-missing-any-axis-is-refused
+  (testing "Enumerated from the ledger rather than restated from it: drop
+            each axis in turn and the door names exactly that one. A fifth
+            axis added to the ledger is therefore covered without anyone
+            remembering to cover it."
+    (doseq [{:keys [key names]} ev/projection-fields]
+      (let [without (dissoc well-formed key)
+            data    (refused #(ev/projection without))]
+        (is (some? data) (str "a projection with no " names " is refused"))
+        (is (= #{key} (set (map :key (:defects data))))
+            (str "and the refusal names " key))
+        (is (= #{:missing} (set (map :defect (:defects data))))
+            (str key " is reported missing, not merely invalid"))))))
+
+(deftest a-nil-loss-is-a-statement-and-an-absent-loss-is-not
+  (testing "The one axis whose legal value is nil, which is exactly why it
+            has to be PRESENT. `:loss nil` says nothing was dropped; an
+            absent `:loss` says nothing at all, and reads as the first."
+    (is (= well-formed (ev/projection well-formed)) "a stated nil loss is accepted")
+    (is (= #{:loss} (refused-keys #(ev/projection (dissoc well-formed :loss))))
+        "an absent loss is refused")))
+
+(deftest every-record-kind-freehand-can-state-today-states-all-four
+  (testing "The schema validation over the record kinds that actually
+            exist. Each is built by its own constructor and then re-read
+            through the door, so a constructor that stopped stating an axis
+            would fail here rather than in whatever tool read it next."
+    (doseq [[label p] [["a compiled declaration's manifest" (ev/manifest-projection compiled-probe)]
+                       ["an interpreted declaration's manifest" (ev/manifest-projection interpreted-probe)]
+                       ["a static accessibility roster" (ev/a11y-projection [a-finding])]
+                       ["an empty accessibility roster" (ev/a11y-projection [])]]]
+      (doseq [{:keys [key]} ev/projection-fields]
+        (is (contains? p key) (str label " states " key)))
+      (is (= [] (ev/defects p)) (str label " is emittable")))))
+
+;; ---------------------------------------------------------------------------
+;; 2 — an incomplete projection says so, rather than reporting a partial set
+;;     as total
+;; ---------------------------------------------------------------------------
+
+(deftest a-cap-turns-into-an-explicit-loss-and-cannot-not
+  (testing "The fixture that deliberately loses information. Five entries
+            capped to three: the payload really is three, the completeness
+            claim really is false, and the two that were dropped are
+            counted in the record rather than left to be inferred from a
+            length."
+      (let [full   (assoc well-formed :basis :observation :sites [1 2 3 4 5])
+            capped (ev/capped full :sites 3)]
+        (is (= [1 2 3] (:sites capped)) "the roster was truncated")
+        (is (false? (:complete? capped)) "and it no longer claims to be complete")
+        (is (= {:reason :cap :dropped 2} (:loss capped))
+            "and the exact number dropped is in the record")))
+  (testing "And a cap that dropped nothing changes nothing — the helper is
+            not a way to mark everything incomplete."
+    (let [under (assoc well-formed :basis :observation :sites [1 2])]
+      (is (= under (ev/capped under :sites 3))
+          "an under-cap roster is unchanged, and still validated"))))
+
+(deftest a-truncated-roster-cannot-be-reported-as-total
+  (testing "The failure this whole schema exists to prevent, refused at
+            the door: a projection cannot claim completeness while
+            reporting loss, whichever order a caller sets the two fields
+            in."
+    (let [data (refused #(ev/projection (assoc well-formed :loss {:reason :cap :dropped 17})))]
+      (is (some? data) "complete-and-lossy is refused")
+      (is (= [:incoherent] (map :defect (:defects data)))
+          "as an incoherence between two fields, not a bad field"))))
+
+(deftest a-loss-with-no-count-is-refused-and-unknown-is-how-you-say-so
+  (testing "\"Unknown must not look like none\", mechanised. A loss without
+            a `:dropped` is refused; a loss that cannot be counted says so
+            with the explicit marker, and is accepted."
+    (is (= #{:loss} (refused-keys #(ev/projection (assoc well-formed
+                                                        :complete? false
+                                                        :loss {:reason :cap}))))
+        "a loss with no count is refused")
+    (is (some? (ev/projection (assoc well-formed
+                                     :complete? false
+                                     :loss {:reason :host-opaque :dropped ev/unknown})))
+        "and an uncountable loss is stated rather than omitted")))
+
+(deftest an-interpreted-declaration-reports-a-loss-it-cannot-quantify
+  (testing "The record kind where that matters most. An interpreted
+            declaration has no analysis step, so the number of sites it
+            could reach is not merely uncounted — it is unknowable without
+            running it. The projection says `:opaque`, says incomplete, and
+            says the loss is unknown; `:loss nil` there would be claiming
+            it dropped nothing when it means it never looked."
+    (let [p (ev/manifest-projection interpreted-probe)]
+      (is (= :opaque (:basis p)))
+      (is (false? (:complete? p)))
+      (is (= {:reason :no-static-analysis :dropped :unknown} (:loss p)))
+      (is (nil? (:manifest p)) "and there is no roster behind the claim")))
+  (testing "beside the compiled arm, which really is complete and lossless
+            — the discrimination that the honest answer above is a
+            property of interpretation and not of this function"
+    (let [p (ev/manifest-projection compiled-probe)]
+      (is (= :static-proof (:basis p)))
+      (is (true? (:complete? p)))
+      (is (nil? (:loss p)))
+      (is (= :re-frame.freehand.evidence-cljs-test/compiled-probe
+             (:view-id (:manifest p)))
+          "and the roster it is complete about is this declaration's"))))
+
+;; ---------------------------------------------------------------------------
+;; The other two shapes that claim more than they know
+;; ---------------------------------------------------------------------------
+
+(deftest an-opaque-basis-cannot-claim-completeness
+  (testing "A projection that cannot see inside a boundary cannot be
+            complete about what is inside it. Naming the absence is the
+            supported move; claiming to have surveyed it is not."
+    (is (some? (refused #(ev/projection {:scope :private-host-work
+                                         :basis :opaque
+                                         :complete? true
+                                         :loss nil}))))
+    (is (some? (ev/projection {:scope :private-host-work
+                               :basis :opaque
+                               :complete? false
+                               :loss nil}))
+        "the same projection, honestly incomplete, is fine")))
+
+(deftest an-unenforced-declaration-is-a-claim-not-proof
+  (testing "A `:declaration` basis earns completeness only when something
+            enforces the declaration. Unenforced, it is an annotation
+            wearing proof's clothes — so the door asks what enforces it."
+    (is (some? (refused #(ev/projection {:scope :possible-sites
+                                         :basis :declaration
+                                         :complete? true
+                                         :loss nil}))))
+    (is (some? (ev/projection {:scope :possible-sites
+                               :basis :declaration
+                               :complete? true
+                               :loss nil
+                               :enforced-by :the-analyzer-rejects-an-undeclared-read}))
+        "naming the enforcement is what makes the claim proof")
+    (is (some? (ev/projection {:scope :possible-sites
+                               :basis :declaration
+                               :complete? false
+                               :loss nil}))
+        "and an unenforced declaration is perfectly emittable as incomplete")))
+
+(deftest a-scope-that-says-nothing-is-refused
+  (testing "Completeness is always RELATIVE to the scope, so a scope of
+            `{}` would make every completeness claim a claim about
+            everything."
+    (is (= #{:scope} (refused-keys #(ev/projection (assoc well-formed :scope {})))))
+    (is (= #{:scope} (refused-keys #(ev/projection (assoc well-formed :scope :everything)))))
+    (is (some? (ev/projection (assoc well-formed
+                                     :basis :observation
+                                     :scope {:committed-generation 812})))
+        "a generation is a scope")
+    (is (some? (ev/projection (assoc well-formed
+                                     :basis :observation
+                                     :complete? false
+                                     :scope {:corpus :component-gallery :runs 240})))
+        "and so is a named corpus with its run count")))
+
+;; ---------------------------------------------------------------------------
+;; 5 — the schema is versioned, and the version is asserted
+;; ---------------------------------------------------------------------------
+
+(deftest the-schema-is-versioned-and-a-record-carries-the-version
+  (testing "One version, on every record, validated FIRST — the same
+            posture the structural tree takes with its own version. A
+            consumer that recognises the version knows the shape; one that
+            does not refuses rather than guessing from the fields present."
+    (is (= :re-frame.freehand.evidence/v1 ev/schema))
+    (let [r {:schema      ev/schema
+             :view-id     :app.todo/todo-row
+             :lowering    :compiled
+             :occurrence  {:parent nil :key 17}
+             :generation  9
+             :projections {:reads (ev/manifest-projection compiled-probe)}}]
+      (is (= r (ev/record r)) "a versioned record is emittable")
+      (is (= #{:schema} (refused-keys #(ev/record (dissoc r :schema))))
+          "an unversioned record is refused")
+      (is (= #{:schema} (refused-keys #(ev/record (assoc r :schema :some.other/v3))))
+          "and so is one carrying a version this schema does not own"))))
+
+;; ---------------------------------------------------------------------------
+;; Occurrence-keyed
+;; ---------------------------------------------------------------------------
+
+(deftest a-record-is-keyed-by-a-runtime-occurrence-and-a-generation
+  (testing "Runtime identity, and both halves of it. An occurrence names
+            its parent and its key — either may be nil, because a root has
+            no parent and an unkeyed only-child has no key, and those are
+            facts a record states rather than omits."
+    (let [base {:schema ev/schema :view-id :app/row :lowering :interpreted
+                :occurrence {:parent nil :key nil} :generation 0
+                :projections {:reads (ev/manifest-projection interpreted-probe)}}]
+      (is (= base (ev/record base)) "a root occurrence with no key is legal")
+      (is (= #{:occurrence} (refused-keys #(ev/record (assoc base :occurrence {:key 3}))))
+          "an occurrence that does not name its parent is refused")
+      (is (= #{:occurrence} (refused-keys #(ev/record (assoc base :occurrence [:app/row 3]))))
+          "and so is one that is not an occurrence map at all")
+      (is (= #{:generation} (refused-keys #(ev/record (dissoc base :generation))))
+          "a record with no generation is refused — two records about one occurrence must be orderable")
+      (is (= #{:lowering} (refused-keys #(ev/record (assoc base :lowering :transpiled))))
+          "and the lowering is one of the two, stated rather than inferred"))))
+
+(deftest a-record-validates-every-projection-it-carries
+  (testing "\"Every evidence record carries scope, basis, completeness and
+            loss\" is a property of this door, not a convention record
+            kinds are asked to follow: a malformed projection is refused
+            through the record that holds it, named by its kind."
+    (let [bad  (assoc well-formed :loss {:reason :cap :dropped 4})
+          data (refused #(ev/record {:schema ev/schema :view-id :app/row :lowering :compiled
+                                     :occurrence {:parent nil :key 0} :generation 1
+                                     :projections {:event-sites bad}}))]
+      (is (some? data) "the record is refused")
+      (is (= :event-sites (:projection data)) "and the refusal names which projection")
+      (is (= :app/row (:view-id data)) "and which view it was about"))
+    (is (= #{:projections}
+           (refused-keys #(ev/record {:schema ev/schema :view-id :app/row :lowering :compiled
+                                      :occurrence {:parent nil :key 0} :generation 1
+                                      :projections {}})))
+        "and a record that projects nothing is not evidence")))
+
+;; ---------------------------------------------------------------------------
+;; 4 — accessibility findings are provable-only, in schema terms
+;; ---------------------------------------------------------------------------
+
+(deftest a-static-accessibility-finding-has-exactly-one-basis
+  (testing "The compile-tier roster fires only where the defect is
+            provable from the literal AST and goes silent the instant a
+            dynamic child, a spread or a runtime-computed aria value
+            appears. So there is no heuristic tier to be `:observation`
+            about and no annotation to be `:declaration` about."
+    (is (= :static-proof ev/a11y-basis))
+    (is (= :static-proof (:basis (ev/a11y-projection [a-finding]))))))
+
+(deftest an-empty-accessibility-roster-is-not-a-clean-bill-of-health
+  (testing "Which is why the scope names the grammar rather than
+            \"accessibility\". The roster is complete for what static proof
+            reaches and says nothing whatever about what it does not — and
+            a reader can see which of those they are holding, because the
+            scope says so."
+    (let [p (ev/a11y-projection [])]
+      (is (= {:provable-in :re-frame.freehand/v1} (:scope p))
+          "the scope is the sites this grammar can prove")
+      (is (not= :possible-sites (:scope p))
+          "and deliberately not the every-site-in-the-declaration scope, which would over-claim")
+      (is (true? (:complete? p)) "complete for that scope")
+      (is (= [] (:findings p)) "with nothing found"))))
+
+(deftest a-finding-is-a-stable-id-a-coordinate-and-a-way-out
+  (testing "A finding with an id and a coordinate is a search result. The
+            third field is the one that makes it a diagnostic, so it is
+            required rather than encouraged."
+    (is (= a-finding (ev/diagnostic a-finding)))
+    (doseq [{:keys [key names]} ev/diagnostic-fields]
+      (is (= #{key} (refused-keys #(ev/diagnostic (dissoc a-finding key))))
+          (str "a finding with no " names " is refused")))
+    (is (= #{:source} (refused-keys #(ev/diagnostic (assoc a-finding :source {:file "x.cljc"}))))
+        "a coordinate with no line is not a coordinate")
+    (is (= #{:recovery} (refused-keys #(ev/diagnostic (assoc a-finding :recovery "   "))))
+        "and a blank recovery is not a recovery"))
+  (testing "and the roster refuses them one at a time, so a malformed
+            finding cannot ride into a projection behind well-formed ones"
+    (is (some? (refused #(ev/a11y-projection [a-finding (dissoc a-finding :recovery)]))))))
+
+;; ---------------------------------------------------------------------------
+;; 3 — retention rides the existing axis
+;; ---------------------------------------------------------------------------
+
+(deftest retention-names-the-existing-axis-and-adds-none
+  (testing "One knob, and it is not Freehand's. The schema names where
+            history lives rather than keeping any: a second retention
+            mechanism would be a second thing to disable in production, a
+            second place a payload could outlive a request, and a second
+            answer to \"how far back does this go?\"."
+    (is (= :spec-009 (:owner ev/retention)))
+    (is (= :rf.trace/events-retained (:knob ev/retention)))
+    (is (= [:trace-buffer :events-retained] (:configure-at ev/retention))
+        "the configure! path is named, so the claim is checkable rather than asserted")))

--- a/implementation/package.json
+++ b/implementation/package.json
@@ -24,6 +24,7 @@
   },
   "scripts": {
     "dev": "node scripts/dev-testbed.cjs",
+    "bench:freehand-node": "shadow-cljs compile freehand-bench-node >&2 && node out/freehand-bench-node.js",
     "test:cljs": "shadow-cljs compile node-test && node out/node-test.js",
     "test:cljs-isolation": "shadow-cljs compile node-test && node scripts/check-per-ns-isolation.cjs",
     "test:security": "shadow-cljs compile node-test-security && node out/node-test-security.js",

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -854,6 +854,37 @@
                       :closure-defines {goog.DEBUG false}}
    :modules {:main {:init-fn re-frame.freehand.release-app/-main}}}
 
+  ;; The ClojureScript/Node lane of the Freehand B-spine (D021).
+  ;;
+  ;; `clojure -M:bench` is a JVM process, so it reaches every `.cljc`
+  ;; workload and none of the ClojureScript-only ones — the React arm
+  ;; measures the interpreted React emitter, which exists only here. This
+  ;; build is the ENTRY that loads them and delegates to the SAME runner:
+  ;; one registry, one provenance record, one gate/evidence split, one
+  ;; report shape, and the same exit-code law where 1 means a
+  ;; deterministic property was violated and nothing else.
+  ;;
+  ;; A development compile, deliberately, and NOT the :freehand-release
+  ;; build above: this one runs workloads, that one is the artefact a
+  ;; consumer ships. The result record names its own `:optimizations`
+  ;; and `:instrumentation?`, so a `:none` run is honestly labelled
+  ;; rather than silently pooled with an `:advanced` one — which is
+  ;; also why B5, when it measures shipped cost, will measure the
+  ;; release bundle rather than this.
+  ;;
+  ;;   npm run --silent bench:freehand-node > out/freehand-bench-node.edn
+  ;;
+  ;; Stdout is the artefact (the human summary rides as `;;` comments),
+  ;; which is why the package script sends the compile chatter to stderr
+  ;; and why the command is run with `--silent`.
+  :freehand-bench-node
+  {:target    :node-script
+   :main      re-frame.freehand.bench.node/-main
+   :output-to "out/freehand-bench-node.js"
+   ;; The load-bearing hook is inherited from :build-defaults.
+   :compiler-options {:warnings      {:redef false}
+                      :infer-externs false}}
+
   ;; rf2-vxgfnd.6 — the G-1 direct-render parity gate (07 §5) for the
   ;; re-frame.ui compiled-view substrate. A :node-script RELEASE build
   ;; (:advanced — the gate measures + inspects PRODUCTION emission):


### PR DESCRIPTION
Three slices on the evidence/bench surface: one versioned occurrence-keyed
evidence schema, B3, and a runnable ClojureScript lane for the React B-arm.

Rebased onto `main` after the Freehand release build landed. The
`implementation/shadow-cljs.edn` conflict was resolved by keeping BOTH build
ids — `:freehand-release` first, then `:freehand-bench-node` beside it — and the
bench lane's comment now points at the release build as the thing B5 will
measure, rather than at a future one. `git diff --numstat` on that file is
31 / 0: only the new block, no whitespace normalisation.

---

## One versioned, occurrence-keyed evidence schema

D020 rules that Freehand exposes one read-only evidence surface shared by
interpreted and compiled execution, keyed by a runtime occurrence, using D012's
vocabulary throughout: every projection states its **scope**, **basis**,
**completeness relative to that scope**, and **loss**. The sentence the whole
ruling turns on is the shortest one in either document:

> "Unknown" must not look like "none".

Breadth was never the problem — a tool can always ask for another roster. The
problem is a projection that reports what it happened to see as though it were
what there is, so `re-frame.freehand.evidence` is mostly a set of refusals, each
closing one shape of that:

- a cap that was hit cannot coexist with a completeness claim;
- an `:opaque` basis cannot be complete about what it cannot see;
- a `:declaration` basis earns completeness only by naming what *enforces* the
  declaration;
- a loss must carry a `:dropped` that is a count or the explicit `:unknown` — an
  absent one reads as none, which is the exact failure the ruling names;
- a scope of `{}` is refused, because completeness relative to nothing is
  completeness about everything.

Two record kinds Freehand can already state, and the second is the interesting
one. A **compiled** declaration's manifest is `:static-proof`, complete and
lossless. An **interpreted** declaration's is `:opaque`, incomplete, and reports
`{:reason :no-static-analysis :dropped :unknown}` — there is no analysis step, so
the number of sites it could reach is not merely uncounted but unknowable without
running it, and `:loss nil` there would be claiming it dropped nothing when it
means it never looked. Static accessibility findings ride the same schema with
exactly one basis and a scope naming the **grammar** rather than "accessibility",
so an empty roster is never readable as a clean bill of health.

Scope kept deliberately narrow, per the bead's non-goals: no `:reads` declaration
language, no automatic app-db capture, no telemetry apparatus, and no widening of
the privacy boundary. The schema is values and the functions that refuse
malformed ones.

## B3

Ten thousand keyed records through a window of forty, under a nine-step scripted
mutation sequence. D021's question is whether comparator specialization matters
after windowing, and the honest framing is that the comparator runs over forty
rows, not ten thousand — so the gated half is the *size* of the thing being
compared and the published half is what comparing it costs.

Gated: 10,000 records exist; 280 comparisons are performed across the script; 83
rows commit and 277 are skipped; 400 row elements are rendered; and the generic
and generated comparators name the **same** rows changed on every step. The
script covers an edit inside the window (one row commits), an edit outside it
(nothing commits and nothing is even compared), and scrolls of half a window,
back, and clean past it — matched by KEY, which is what makes a slide cost half a
window rather than a whole one.

## The React arm gets a lane

The two `:B1/react-*` workloads registered themselves into the standing suite at
load, and nothing loaded them. `re-frame.freehand.bench.node` is an ENTRY, not a
harness: it requires the ClojureScript-only arm and delegates to the same
`bench.runner` — one registry, one provenance record, one gate/evidence split,
the same `;;`-commented EDN on stdout, the same exit-code law.

```
npm run --silent bench:freehand-node > out/freehand-bench-node.edn
```

The scheduled workflow gains a second job running it and uploading its EDN beside
the JVM one. Two artefacts because they are two hosts (a record names its own
`:host` and `:build`; a V8 `:none` number is not poolable with a JIT-warmed JVM
one). One harness, because a second report shape is a second place a threshold
could be added.

The lane's guard is closed at both ends: its roster is read off the arm's own
`workloads` var, so deleting the require is a compile error; and the ids are
checked against the live registry before the suite runs, so an arm that loads but
no longer registers fails the command naming the ids rather than publishing a
shorter report that still looks like evidence.

---

## Deterministic vs evidence, per artefact

| Artefact | Side of the line |
|---|---|
| `:B3/records`, `:B3/rows-rendered`, `:B3/rows-compared`, `:B3/committed-rows`, `:B3/skipped-rows` | **Deterministic gate** — exact integers, checked against written arithmetic |
| `:B3/comparator-agreement` | **Deterministic gate** — a `:flag`; specialization may change cost, never what commits |
| `:B3/generated-comparator-ms`, `:B3/generic-comparator-ms`, `:B3/parent-render-ms`, `:B3/end-to-end-ms` | **Evidence only** — `:duration-ms`, published with provenance, no threshold, no route to the exit code |
| The ClojureScript lane's guard (`absent-lane-workloads`) | **Deterministic gate** — reachability presence/absence, not a duration |
| Everything the lane publishes | Whatever the workload declared; the lane adds no measurement and no verdict of its own |
| Evidence-schema validation (`projection`, `record`, `diagnostic`) | **Deterministic gate** — structural/provenance completeness, refused at the door |
| Evidence-schema require-graph reachability | **Deterministic gate** — reachability presence/absence |
| Evidence retention | **Not measured at all.** The schema names Spec 009's axis and keeps nothing; there is no retention volume to publish because there is nothing retained |

No timing-derived value reaches an exit code anywhere in this PR. The
gate/evidence split is a total function of the declared `:observable` in
`re-frame.freehand.bench.measure`, so a latency budget on a B3 duration would be
refused when the workload is *constructed*.

## Non-vacuity

Each deterministic assertion was inverted, the full gate confirmed red naming the
test, and the source restored byte-identically.

1. **B3's counts.** Dropped the mutated slot from the row props the comparator
   sees. `clojure -M:bench` → **EXIT=1**, naming
   `GATE FAILED: :B3/committed-rows … Expected 83, observed 80` and
   `:B3/skipped-rows … Expected 277, observed 280` on both workloads.
   `clojure -M:test` → **EXIT=1**, naming
   `b3-the-run-produces-exactly-those-counts`,
   `b3-runs-green-and-publishes-its-evidence`, and
   `b3-the-comparison-would-notice-a-row-that-changed`.
2. **The lane's guard.** Deleted the `b1-react` require from the entry.
   `npm run --silent bench:freehand-node` → **EXIT=1**, zero bytes on stdout, and
   on stderr: *"This ClojureScript evidence lane exists to publish 2 workloads
   that no JVM process can reach, and the registry holds them not:
   [:B1/react-template :B1/react-small-template]…"*.
3. **The evidence schema's central invariant.** Removed the rule that a
   projection cannot claim completeness while reporting loss. `clojure -M:test`
   → **EXIT=1**, naming `a-truncated-roster-cannot-be-reported-as-total` and
   `a-record-validates-every-projection-it-carries`.
4. **The require-graph reachability gate.** Added a require of
   `re-frame.freehand.evidence` to `re-frame.freehand.tree`, which is on the
   door's path. The gate → **FAIL**, naming
   `the-evidence-schema-is-not-reachable-from-the-public-door`. Restored with
   `git checkout` (clean status afterwards).

The remaining assertions are non-vacuous by construction rather than by
inversion: the projection-ledger suite enumerates `projection-fields` and drops
each axis in turn, and the reachability test carries its own positive control
(it requires the walk to reach `tree`, `descriptor` and `node`, so a broken graph
cannot pass by finding nothing).

## Stale claims flipped

`.github/workflows/freehand-bench.yml` asserted *"the evidence suite is empty:
B1–B5 are separate slices and each registers its workload when the
implementation that can run it lands"*. B1, B2 and now B3 register today, so the
note is retired and replaced with what actually runs, plus the TWO LANES rubric.

## Keyword contract

The keyword-drift gate flagged the evidence schema's refusal ex-data as minting
`:rf.evidence/*`, a new `:rf.<area>/*` namespace with no reserved row. The fix is
a spelling change, not a reservation: `spec/Conventions.md` §Freehand rules that
Freehand's reserved keyword root is the public namespace written out —
`:re-frame.freehand/*` — rather than an `:rf.<area>/*` segment, precisely so a
Freehand id names its substrate wherever it surfaces. The schema's own version
already spelled it that way (`:re-frame.freehand.evidence/v1`); the defect key
now does too. **No new `:rf.*` namespace is minted, so no reserved-namespace row
is owed and the hot-zone Conventions table is untouched.**

`python scripts/check_keyword_catalogue_drift.py --verbose` → **EXIT=0**
(`check A findings=0, check B findings=0`). The rest of that CI job's
source-policy steps were run locally too, since a multi-step job stops at its
first failure and the reported one is not necessarily the only one — all exit 0:

| Step | Exit |
|---|---|
| `check_retired_spellings.py --self-test --verbose` / `--verbose` | 0 / 0 |
| `check_ambient_durable_reads.py --self-test --verbose` / `--verbose` | 0 / 0 |
| `check_thrown_error_messages.py --self-test --verbose` / `--verbose` | 0 / 0 |
| `check_keyword_catalogue_drift.py --self-test --verbose` / `--verbose` | 0 / 0 |
| `npm run test:script-policy` | 0 |

## Quality gates

All foreground, all to completion, all re-taken **after** the rebase onto the
post-`:freehand-release` `main`. Captured to worktree-local logs; the shadow-cljs
`config:` banner names this worktree on every CLJS run.

| Gate | Result | Exit |
|---|---|---|
| `cd implementation/freehand && clojure -M:test` | Ran **863** tests, **6157** assertions, 0 failures, 0 errors (baseline on `origin/main` before this branch: 826 / 5852) | 0 |
| `clojure -M:bench` | 6 workloads; all deterministic properties held | 0 |
| `clojure -M:bench --prove` | PROVEN both ways — violated gate → 1, wall clock moved 23.5× → 0 | 0 |
| `npm run test:freehand` | Ran **849** tests, **5124** assertions, 0 failures, 0 errors, 0 warnings | 0 |
| `npm run test:cljs` | Ran **10974** tests, **55249** assertions, 0 failures, 0 errors | 0 |
| `npm run test:browser` | Ran **671** tests, **4115** assertions, 0 failures, 0 errors | 0 |
| `npm run --silent bench:freehand-node` (new) | 8 workloads incl. both React arms, on Node v24; stdout parses as EDN | 0 |
| `npm run test:script-policy` | all launcher/inventory policy suites pass | 0 |
| `python scripts/check_keyword_catalogue_drift.py --verbose` | check A findings=0, check B findings=0 | 0 |

Nothing skipped.

## What is NOT in here, and why

**The evidence bead's production-isolation criterion asks for the F3d
control-build technique; this PR does not deliver that.** What it delivers
instead is a *require-graph reachability* assertion — built by reading each
source file's `ns` form, reader conditionals and all, rooted at the public door —
showing that nothing an application mounts can reach the evidence schema. That is
the honest available claim today, because there is no emission site yet: the
schema is pure values, so there is no evidence code in a bundle to elide. The
test says so in its own docstring and says what should happen next: when the
emission slice lands and a dev-gated call site appears on the render path, this
assertion becomes the wrong one and must be **replaced** by a control-build
probe, not relaxed.

The same bead's donor disposition (moving `re-frame.ui.tool` and
`re-frame.ui.tool.evidence` under Freehand ownership, ~1350 lines, plus the F0c
ledger update) is not here either. That is the emission half of the slice and it
collides with the donor-retirement work; this PR is the schema those records will
have to satisfy.

## Note for a follow-up

`clojure -M:bench`'s stdout contains `#re-frame.freehand/view` tagged literals —
B2 publishes its mount plans into `:fixture`, and those hold view descriptors.
Syntactically valid EDN, but `clojure.edn/read-string` needs a `:default` handler
to read the artefact back. Pre-existing on `main`, untouched here, worth a small
repair (publish view *ids* in the plan, not descriptors).
