### PR TITLE
fix(freehand): four analyzer-parity fixes — for-body refusal, stale batching claim, select value, metadata key

### DIFF
--- a/docs/design/freehand/draft-guide/vs-reagent.md
+++ b/docs/design/freehand/draft-guide/vs-reagent.md
@@ -149,6 +149,28 @@ Freehand’s growth path is: write freely interpreted → measure → optionally
 tests stay the same. That is different from both “always interpret” and from
 re-frame.ui’s compile-first day-one feel.
 
+### 8. A key is a prop, never metadata
+
+`^{:key (:id r)} [row-view r]` is *the* Reagent spelling for a list row, and it is
+the habit most likely to survive a rewrite unnoticed. Freehand does not read it.
+Nothing in this substrate carries a contract in metadata, so a key written there
+reaches neither the structural tree nor React, and the list renders silently
+unkeyed — which surfaces much later, as rows that reuse each other's state.
+
+Both modes therefore refuse the metadata spelling outright rather than dropping
+it, and the key goes where every other prop goes:
+
+```clojure
+;; Reagent
+(for [r rows] ^{:key (:id r)} [row-view r])
+
+;; Freehand
+(for [r rows] [row-view {:key (:id r) :row r}])
+```
+
+Content with no props map of its own takes a keyed fragment instead:
+`[:<> {:key k} (v/slot row r)]`.
+
 ## Side-by-side: a tiny screen
 
 ```clojure

--- a/implementation/freehand/src/re_frame/freehand/compiler/analyze.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/analyze.cljc
@@ -3585,6 +3585,17 @@
          :body (analyze (update e* :path conj :body) body-form)
          :static? false :path (:path e)}))))
 
+(def ^:private wrapper-body-ops
+  "Analyzed node kinds that WRAP markup rather than being it — the shapes a
+  `for` body can take where the keyed row is present but one form deeper.
+
+  They are refused with their own sentence rather than with the
+  missing-`:key` one, because they are a different mistake with a
+  different fix: the row is keyed, and what is wrong is that something
+  stands between the `for` and it. A body that is an `:expr`, a `:text` or
+  a `:slot` carries no row at all and keeps the general message."
+  #{:let :letfn :if :case})
+
 (defn- analyze-for [e form]
   (let [[_ seq-exprs & body] form]
     (when-not (and (vector? seq-exprs) (even? (count seq-exprs)) (seq seq-exprs))
@@ -3656,6 +3667,28 @@
                                         "list site (Q6 pin)")
                                    {:form form}))
             body-ast  (analyze e-body body-form)]
+        ;; The WRAPPED body is its own rejection, because it is its own
+        ;; mistake (rf2-drpa3.164). `(for [i is] (let [r (nth rows i)] [:div
+        ;; {:key (:id r)} …]))` is the natural Clojure spelling, and the row
+        ;; inside it IS keyed — reporting a missing key sends the author to a
+        ;; line that has one. The rule they need is that the body must BE the
+        ;; node, and the fix is `for`'s own `:let` modifier, which this
+        ;; grammar fully supports.
+        (when (contains? wrapper-body-ops (:op body-ast))
+          (env/fail! e :rf.ui.compile/indirect-list-body
+                     (str "a for body must BE the keyed node — an element, a "
+                          "view or a fragment, with nothing standing between "
+                          "the for and it — and this body is a "
+                          (name (:op body-ast)) " wrapping one. A keyed list "
+                          "lowers to a direct JS array of rows, so the row has "
+                          "to be what the body evaluates to."
+                          (if (= :let (:op body-ast))
+                            (str " Bind the row's values with for's OWN :let "
+                                 "modifier: (for [i (range start end) "
+                                 ":let [r (nth rows i)]] [:div {:key (:id r)} …])")
+                            (str " Extract a declared child view that does the "
+                                 "wrapping, and key it at the call site")))
+                     {:form form :op (:op body-ast)}))
         (when-not (contains? #{:element :view :foreign :fragment} (:op body-ast))
           (env/fail! e :rf.ui.compile/unkeyed-list-item
                      (str "for body must be a keyed element/view/fragment — got "

--- a/implementation/freehand/src/re_frame/freehand/compiler/analyze.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/analyze.cljc
@@ -2057,6 +2057,16 @@
                                    ;; shape. A site the door can never admit
                                    ;; (`:on-before-input`, a `:div`) gets no
                                    ;; unactionable nag.
+                                   ;;
+                                   ;; What it reports is the loss of STATIC
+                                   ;; EVIDENCE, not a change of dispatch lane.
+                                   ;; The emitted element facts (tag,
+                                   ;; controlled?, slot) are constants and
+                                   ;; `controlled/door?` decides at COMMIT from
+                                   ;; the runtime handler value, so a forwarded
+                                   ;; vector reaches the door in both modes.
+                                   ;; What it cannot do is prove anything
+                                   ;; beforehand.
                                    (when (and controlled?
                                               (contains? controlled/controlled-tags tag)
                                               (controlled/door-slot? (door-slot handler))
@@ -2066,16 +2076,23 @@
                                       {:id :rf.ui.compile/controlled-input-async-handler
                                        :msg (str (:k handler)
                                                  " is paired with a controlled "
-                                                 ":value/:checked prop, but its "
-                                                 "handler outcome is not synchronously "
-                                                 "known, so it stays on the ordinary "
-                                                 "batched path. Open the controlled-input "
-                                                 "sync door with a literal event vector, "
+                                                 ":value/:checked prop, but nothing "
+                                                 "static pins this handler's class, so "
+                                                 "the site is OPAQUE: its intent is "
+                                                 "absent from the compiled manifest, and "
+                                                 "no structural test or tool can say what "
+                                                 "this control dispatches before it "
+                                                 "fires. The door itself still opens — it "
+                                                 "is decided at commit, from the runtime "
+                                                 "handler value, in both modes; what is "
+                                                 "lost is the proof. Keep the site "
+                                                 "readable with a literal event vector, "
                                                  "an options map carrying one, or a "
                                                  "(v/event …) handler when the native "
-                                                 "payload must flow — and not behind a "
-                                                 ":capture/:passive listener, which is a "
-                                                 "different native attachment lane")
+                                                 "payload must be converted — and not "
+                                                 "behind a :capture/:passive listener, "
+                                                 "which is a different native attachment "
+                                                 "lane")
                                        :form (:form handler)}))
                                    (assoc handler :sync? sync?)))
                                events0)

--- a/implementation/freehand/src/re_frame/freehand/compiler/analyze.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/analyze.cljc
@@ -2100,19 +2100,52 @@
                                   (let [v (get m* k)
                                         n (name k)
                                         property? (boolean (and properties (properties k)))
+                                        ;; The ONE attribute whose authored
+                                        ;; value may be collection-shaped — a
+                                        ;; native <select>'s value IS the list
+                                        ;; of chosen option values. Asked of
+                                        ;; the tag and the emitted slot, never
+                                        ;; of `multiple`, which may be a
+                                        ;; runtime value this tier cannot see.
+                                        select-value? (controlled/select-value-slot? tag k)
                                         v* (if (literal-scalar? v)
                                              v
                                              (walk-expr e [:prop k] v))]
                                    ;; literal collection VALUES only — seq forms
                                    ;; are dynamic expressions (runtime-normalized)
                                    (when (and (or (vector? v) (map? v) (set? v))
-                                              (not property?))
+                                              (not property?)
+                                              ;; A LITERAL selection was the one
+                                              ;; corner this guard still refused
+                                              ;; while the interpreted twin
+                                              ;; rendered it, and while a
+                                              ;; COMPUTED selection compiled
+                                              ;; (rf2-b6poy). It rides the same
+                                              ;; runtime path a computed one
+                                              ;; does, so nothing downstream
+                                              ;; has to learn a new shape.
+                                              (not (and select-value? (sequential? v))))
                                      (env/fail! e :rf.ui.compile/collection-attr-value
-                                                (str "collection value for attribute " k
-                                                     " — collections are only meaningful "
-                                                     "for :class/:style (React renders "
-                                                     "\"[object Object]\" garbage). Pass "
-                                                     "a string, e.g. (str/join \" \" xs)")
+                                                (if select-value?
+                                                  (str "collection value for " k " on "
+                                                       "<select> — a select's value is the "
+                                                       "SEQUENTIAL list of chosen option "
+                                                       "values, and a " (cond (set? v) "set"
+                                                                              (map? v) "map"
+                                                                              :else "value")
+                                                       " is not one. A set is refused "
+                                                       "deliberately: its order is not a "
+                                                       "value the two hosts agree on, so "
+                                                       "one declaration would answer two "
+                                                       "trees. Write a vector, e.g. "
+                                                       "[\"a\" \"b\"]")
+                                                  (str "collection value for attribute " k
+                                                       " — collections are only meaningful "
+                                                       "for :class/:style and a <select>'s "
+                                                       ":value (React renders "
+                                                       "\"[object Object]\" garbage "
+                                                       "elsewhere). Pass a string, e.g. "
+                                                       "(str/join \" \" xs)"))
                                                 {:prop k :value v}))
                                    (when (fn-form? v)
                                      (env/fail! e :rf.ui.compile/bare-fn-prop

--- a/implementation/freehand/src/re_frame/freehand/compiler/analyze.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/analyze.cljc
@@ -3891,6 +3891,26 @@
                                {:form form})
     (vector? form)
     (let [head (nth form 0 nil)]
+      ;; `^{:key …}` is the Reagent spelling, and it is refused HERE — at
+      ;; the form that carries it — rather than where its absence is later
+      ;; noticed (rf2-drpa3.163). A `for` body written this way used to be
+      ;; reported as MISSING a key while the author was looking at one, and
+      ;; the same metadata on an ordinary child was ignored outright while
+      ;; the interpreted walk silently dropped it. One rule, one sentence,
+      ;; every position.
+      (when (contains? (meta form) :key)
+        (env/fail! e :rf.ui.compile/metadata-key
+                   (str "a :key in METADATA — ^{:key …} — on " (pr-str form)
+                        ". Freehand reads no metadata-carried contract, so "
+                        "this key reaches neither the tree nor React. A key "
+                        "is a PROPS slot here, in both modes and on both "
+                        "hosts: write [:li {:key k} …], or [:<> {:key k} …] "
+                        "around content with no props map of its own. "
+                        "(Reagent honours the metadata spelling; this "
+                        "substrate has one spelling for a key, and the "
+                        "interpreted walk refuses the other rather than "
+                        "dropping it.)")
+                   {:form form}))
       (cond
         (= :<> head)     (analyze-fragment e form)
         (keyword? head)  (analyze-element e form)

--- a/implementation/freehand/src/re_frame/freehand/compiler/check.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/check.cljc
@@ -149,6 +149,7 @@
    :rf.ui.compile/constant-list-key    :list-key-does-not-vary
    :rf.ui.compile/nested-for-body      :iteration-is-not-lexically-flat
    :rf.ui.compile/indirect-list-body   :iteration-is-not-lexically-flat
+   :rf.ui.compile/metadata-key         :key-is-in-metadata
    :rf.ui.compile/sub-in-loop          :reactive-site-is-not-finite
    :rf.ui.compile/frame-in-loop        :reactive-site-is-not-finite
    :rf.ui.compile/void-children        :void-element-carries-children

--- a/implementation/freehand/src/re_frame/freehand/compiler/check.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/check.cljc
@@ -148,6 +148,7 @@
    :rf.ui.compile/unkeyed-list-item    :list-row-carries-no-key
    :rf.ui.compile/constant-list-key    :list-key-does-not-vary
    :rf.ui.compile/nested-for-body      :iteration-is-not-lexically-flat
+   :rf.ui.compile/indirect-list-body   :iteration-is-not-lexically-flat
    :rf.ui.compile/sub-in-loop          :reactive-site-is-not-finite
    :rf.ui.compile/frame-in-loop        :reactive-site-is-not-finite
    :rf.ui.compile/void-children        :void-element-carries-children

--- a/implementation/freehand/src/re_frame/freehand/compiler/grammar.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/grammar.cljc
@@ -111,6 +111,7 @@
    :rf.ui.compile/lazy-seq-child      [:make-template-visible :pass-computed-value]
    :rf.ui.compile/unkeyed-list-item   [:key-each-row :extract-declared-child]
    :rf.ui.compile/indirect-list-body  [:bind-with-for-let :extract-declared-child]
+   :rf.ui.compile/metadata-key        [:key-in-the-props-map]
    :rf.ui.compile/constant-list-key   [:key-each-row]
    :rf.ui.compile/nested-for-body     [:make-template-visible]
    :rf.ui.compile/sub-in-loop         [:extract-declared-child]
@@ -147,6 +148,8 @@
    "give every row of the list a :key that varies with the row"
    :bind-with-for-let
    "bind the row's values with for's own :let modifier — (for [x xs :let [y (f x)]] …) — so the body stays the keyed row"
+   :key-in-the-props-map
+   "move the key out of ^{:key …} metadata and into the props map — [:li {:key k} …]"
    :scope-the-frame-above-the-view
    "scope the frame above this view rather than inside it"
    :keep-interpreted

--- a/implementation/freehand/src/re_frame/freehand/compiler/grammar.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/grammar.cljc
@@ -110,6 +110,7 @@
    :rf.ui.compile/markup-returning-map [:make-template-visible :extract-declared-child]
    :rf.ui.compile/lazy-seq-child      [:make-template-visible :pass-computed-value]
    :rf.ui.compile/unkeyed-list-item   [:key-each-row :extract-declared-child]
+   :rf.ui.compile/indirect-list-body  [:bind-with-for-let :extract-declared-child]
    :rf.ui.compile/constant-list-key   [:key-each-row]
    :rf.ui.compile/nested-for-body     [:make-template-visible]
    :rf.ui.compile/sub-in-loop         [:extract-declared-child]
@@ -144,6 +145,8 @@
    "name the element or view literally; heads are not runtime values"
    :key-each-row
    "give every row of the list a :key that varies with the row"
+   :bind-with-for-let
+   "bind the row's values with for's own :let modifier — (for [x xs :let [y (f x)]] …) — so the body stays the keyed row"
    :scope-the-frame-above-the-view
    "scope the frame above this view rather than inside it"
    :keep-interpreted

--- a/implementation/freehand/src/re_frame/freehand/node.cljc
+++ b/implementation/freehand/src/re_frame/freehand/node.cljc
@@ -263,6 +263,37 @@
            "nothing (nil / false)."))
     {:value (shape form)}))
 
+(defn refuse-metadata-key!
+  "Refuse a markup vector carrying `^{:key …}` METADATA.
+
+  Freehand reads no metadata-carried contract, so nothing on either
+  interpreted walk looked for one and the key was simply GONE: the tree
+  came out well-formed, unkeyed, and silent, and the only symptom was
+  React reusing the wrong rows at run time. It is the Reagent spelling, so
+  it is the one a hand arriving from re-frame v1 reaches for first, and
+  the compiled tier had been refusing it as a build failure all along —
+  one source, two answers.
+
+  Both walks refuse it here instead, with the same sentence: a key is a
+  PROPS slot in this substrate, and there is exactly one spelling of it.
+
+  `where` names the raising site. Cheap enough to sit in the child fold:
+  a vector with no metadata answers `nil` and the `contains?` never runs."
+  [where form]
+  (when (contains? (meta form) :key)
+    (malformed!
+      where
+      (str "A child carries a :key in its METADATA — ^{:key …}. Freehand "
+           "reads no metadata-carried contract, so this key would reach "
+           "neither the tree nor React, and the list it belongs to would "
+           "render silently unkeyed. A key is a PROPS slot here, in both "
+           "modes and on both hosts: write [:li {:key k} …], or "
+           "[:<> {:key k} …] around content that has no props map of its "
+           "own. (Reagent honours the metadata spelling; this substrate "
+           "has one spelling for a key, and refuses the other rather than "
+           "dropping it.)")
+      {:value (shape form)})))
+
 (defn collect
   "Fold one child value into the canonical children accumulator `acc`.
 
@@ -284,7 +315,8 @@
     (conv/child-run? form) (reduce #(collect walk where %1 %2) acc form)
     (node? form)           (conj acc form)
     (seq? form)            (reduce #(collect walk where %1 %2) acc form)
-    (and walk (vector? form)) (conj acc (walk form))
+    (and walk (vector? form)) (do (refuse-metadata-key! where form)
+                                  (conj acc (walk form)))
     :else                  (opaque-child! where form)))
 
 (defn children

--- a/implementation/freehand/src/re_frame/freehand/react.cljs
+++ b/implementation/freehand/src/re_frame/freehand/react.cljs
@@ -759,7 +759,13 @@
     (string? form)  (conj acc form)
     (number? form)  (conj acc (conv/js-number-str form))
     (conv/child-run? form) (reduce (fn [a f] (collect cand a f)) acc form)
-    (vector? form)  (conj acc (node cand form))
+    ;; `^{:key …}` metadata is refused by the SHARED sentence the structural
+    ;; walk raises, not by a second one here — one source has one answer,
+    ;; and a key that reached React through a spelling the JVM tree drops
+    ;; would be exactly the divergence this walk exists to not have.
+    (vector? form)  (do (node/refuse-metadata-key!
+                          're-frame.freehand.react/element form)
+                        (conj acc (node cand form)))
     (seq? form)     (reduce (fn [a f] (collect cand a f)) acc form)
     ;; A React element in a child position is markup a COMPILED body
     ;; already lowered — the shape a compiled parent forwards to an

--- a/implementation/freehand/test/re_frame/freehand/analyze_accept_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/analyze_accept_cljs_test.cljc
@@ -636,7 +636,7 @@
           (ana-full '[:div {:value value :on-input [:form/typed :rf.ui/value]}])]
       (is (false? (get-in ast [:props :events 0 :sync?])))
       (is (empty? warnings) "a :div has no value React restores, so no advisory")))
-  (testing "ordinary sites and non-data handlers stay batched"
+  (testing "ordinary sites and non-data handlers leave :sync? unproven"
     (is (false? (-> (ana* '[:button {:value value :on-click [:form/go]}])
                     (get-in [:props :events 0 :sync?]))))
     (let [{:keys [ast warnings]}
@@ -655,8 +655,17 @@
         (is (re-find #"literal event vector" msg)
             "the diagnostic still names the literal-event-vector door")
         (is (re-find #"v/event" msg)
-            "the diagnostic ALSO names the (v/event …) door")))
-    (testing "a bare fn at a controlled site still batches with the diagnostic"
+            "the diagnostic ALSO names the (v/event …) door")
+        ;; rf2-pv0ne — the advisory reports the loss of STATIC EVIDENCE, not
+        ;; a change of dispatch lane. The emitted element facts are constants
+        ;; and `controlled/door?` decides at COMMIT from the runtime handler
+        ;; value, so a site the analyzer cannot classify still reaches the
+        ;; door in both modes; what it cannot do is prove anything first.
+        (is (re-find #"(?i)opaque" msg)
+            "the diagnostic names the opaque site")
+        (is (not (re-find #"(?i)batch" msg))
+            "and never claims the site moves to the batched path")))
+    (testing "a bare fn at a controlled site is unprovable with the diagnostic"
       (let [{:keys [ast warnings]}
             (ana-full '[:input {:value value :on-input (fn [e] (js/console.log e))}])]
         (is (false? (get-in ast [:props :events 0 :sync?])))

--- a/implementation/freehand/test/re_frame/freehand/analyze_reject_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/analyze_reject_cljs_test.cljc
@@ -142,6 +142,35 @@
             exactly the site the metadata one was refused"
     (is (nil? (reject-id '(for [x xs] [:li {:key x} x]))))))
 
+(deftest a-select-value-admits-a-literal-selection
+  (testing "rf2-b6poy. A native `<select>`'s value is the ONE attribute
+            whose authored value may be collection-shaped, and the guard
+            refused a LITERAL one — so
+            `[:select {:multiple true :value [\"a\" \"b\"]}]` failed to
+            compile while its interpreted twin rendered it, and a COMPUTED
+            selection of the same shape compiled. Asserted on BOTH hosts,
+            because the guard lives in a .cljc the two targets share."
+    (is (nil? (reject-id '[:select {:multiple true :value ["a" "b"]}]))
+        "the literal selection compiles")
+    (is (nil? (reject-id '[:select {:value ["a"]}]))
+        "acceptance is the TAG and the SLOT, never `multiple` — which may be
+         a runtime value the compiler cannot see")
+    (is (nil? (reject-id '[:select {:multiple true :x/value ["a"]}]))
+        "and an aliased value slot is the same slot"))
+  (testing "the widening is one slot on one tag, and a set stays refused"
+    (is (= :rf.ui.compile/collection-attr-value
+           (reject-id '[:select {:multiple true :value #{"a"}}]))
+        "a set has no order the two hosts agree on")
+    (is (= :rf.ui.compile/collection-attr-value
+           (reject-id '[:select {:multiple true :value {:a 1}}]))
+        "and a map has no members to convert")
+    (is (= :rf.ui.compile/collection-attr-value
+           (reject-id '[:select {:title ["a"]}]))
+        "an ordinary attribute on a select is untouched")
+    (is (= :rf.ui.compile/collection-attr-value
+           (reject-id '[:input {:value ["a"]}]))
+        "and so is a value slot on any other tag")))
+
 (deftest finite-sites
   (is (= :rf.ui.compile/sub-in-loop
          (reject-id '(for [x xs] [:li {:key x} (sub [:q x])]))))

--- a/implementation/freehand/test/re_frame/freehand/analyze_reject_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/analyze_reject_cljs_test.cljc
@@ -5,6 +5,8 @@
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
             [re-frame.freehand.compiler.analyze :as ana]
+            [re-frame.freehand.compiler.check :as check]
+            [re-frame.freehand.compiler.grammar :as grammar]
             [re-frame.freehand.analyze-accept-cljs-test :refer [mk-env mk-self-env]]))
 
 (defn reject-id
@@ -15,6 +17,16 @@
     nil
     (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) ex
       (:rf.ui.compile/error (ex-data ex)))))
+
+(defn reject-msg
+  "nil when accepted; the compile error's human MESSAGE when rejected —
+  for the rows where the SENTENCE is the contract and not only the id."
+  [form]
+  (try
+    (ana/analyze (mk-env) form)
+    nil
+    (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) ex
+      (ex-message ex))))
 
 (defn reject-id-in
   "reject-id against a supplied env (for self-head precedence rows)."
@@ -60,6 +72,46 @@
   (is (= :rf.ui.compile/bad-for
          (reject-id '(for [x xs :unknown y] [:li {:key x} x])))
       "the modifier subgrammar is :let/:when/:while (Q6)"))
+
+(deftest a-wrapped-for-body-is-its-own-rejection
+  (testing "rf2-drpa3.164. `(for [i is] (let [r (nth rows i)] [:div {:key
+            (:id r)} …]))` is the natural Clojure spelling for binding the
+            record beside the index, and the row inside it IS keyed. Naming
+            a missing key sent the author to a line that has one, and the
+            ladder advised keying every row — advice already taken. The
+            rule they need is that the body must BE the node; the fix is
+            `for`'s own `:let` modifier."
+    (let [wrapped '(for [i is] (let [r (nth rows i)] [:div {:key (:id r)} r]))]
+      (is (= :rf.ui.compile/indirect-list-body (reject-id wrapped))
+          "the wrapped body is its own id, not the missing-key one")
+      (let [msg (reject-msg wrapped)]
+        (is (str/includes? msg "must BE the keyed node")
+            "the sentence states the real rule")
+        (is (str/includes? msg ":let")
+            "and names for's :let modifier as the fix")
+        (is (str/includes? msg "(for [i (range start end) :let [r (nth rows i)]]")
+            "with the spelling, not just the name")
+        (is (not (str/includes? msg "missing :key"))
+            "and never reports a key as missing when one is present"))))
+  (testing "the recovery the message names is on the LADDER too, so a
+            checker report carries it without reading prose"
+    (is (= [:bind-with-for-let :extract-declared-child :keep-interpreted]
+           (grammar/recovery :rf.ui.compile/indirect-list-body)))
+    (is (str/includes? (get grammar/recoveries :bind-with-for-let) ":let")
+        "and the rung's own sentence spells the modifier")
+    (is (= :iteration-is-not-lexically-flat
+           (check/reason :rf.ui.compile/indirect-list-body))
+        "a wrapper between the for and its row is the flatness reason"))
+  (testing "the recovery this diagnostic advises actually compiles — the
+            whole point of naming it"
+    (is (nil? (reject-id '(for [i is :let [r (nth rows i)]]
+                            [:div {:key (:id r)} r])))))
+  (testing "a wrapper that :let cannot fix is told to extract a child view"
+    (let [msg (reject-msg '(for [x xs] (if x [:li {:key x} 1] [:li {:key x} 2])))]
+      (is (str/includes? msg "must BE the keyed node"))
+      (is (str/includes? msg "Extract a declared child view"))))
+  (testing "a body carrying no row at all keeps the general message"
+    (is (= :rf.ui.compile/unkeyed-list-item (reject-id '(for [x xs] (str x)))))))
 
 (deftest finite-sites
   (is (= :rf.ui.compile/sub-in-loop

--- a/implementation/freehand/test/re_frame/freehand/analyze_reject_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/analyze_reject_cljs_test.cljc
@@ -113,6 +113,35 @@
   (testing "a body carrying no row at all keeps the general message"
     (is (= :rf.ui.compile/unkeyed-list-item (reject-id '(for [x xs] (str x)))))))
 
+(deftest a-metadata-key-is-refused-where-it-is-written
+  (testing "rf2-drpa3.163. `^{:key …}` is the Reagent spelling, so it is
+            the one a v1 hand writes first. It used to be a hard build
+            failure reported as a MISSING key — pointing the author at a
+            row that has one — while the interpreted walk dropped it in
+            silence. It is refused HERE now, at the form that carries it,
+            with the sentence that names metadata."
+    (let [row (with-meta '[:li x] {:key 'x})]
+      (is (= :rf.ui.compile/metadata-key (reject-id row))
+          "the form carrying the metadata is the form refused")
+      (let [msg (reject-msg row)]
+        (is (str/includes? msg "METADATA") "the sentence names metadata")
+        (is (str/includes? msg "[:li {:key k} …]")
+            "and gives the props-slot spelling")
+        (is (not (str/includes? msg "missing :key"))
+            "and never reports as missing a key that is present"))))
+  (testing "a for body written the Reagent way reports the metadata, not
+            an absent key — the two diagnostics no longer contradict each
+            other about the same source"
+    (is (= :rf.ui.compile/metadata-key
+           (reject-id (list 'for '[x xs] (with-meta '[:li x] {:key 'x}))))))
+  (testing "the ladder says the one thing there is to do"
+    (is (= [:key-in-the-props-map :keep-interpreted]
+           (grammar/recovery :rf.ui.compile/metadata-key)))
+    (is (= :key-is-in-metadata (check/reason :rf.ui.compile/metadata-key))))
+  (testing "and the recovery compiles — the props spelling is accepted at
+            exactly the site the metadata one was refused"
+    (is (nil? (reject-id '(for [x xs] [:li {:key x} x]))))))
+
 (deftest finite-sites
   (is (= :rf.ui.compile/sub-in-loop
          (reject-id '(for [x xs] [:li {:key x} (sub [:q x])]))))

--- a/implementation/freehand/test/re_frame/freehand/controlled_structural_value_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/controlled_structural_value_cljs_test.cljc
@@ -180,13 +180,11 @@
   emitter's own last step."
   [{:note "an authored vector of option values is retained, in order"
     :body '[:select {:multiple true :value ["a" "b"]}]
-    :tree {:tag :select :attrs {:multiple true :value ["a" "b"]}}
-    :literal-collection? true}
+    :tree {:tag :select :attrs {:multiple true :value ["a" "b"]}}}
 
    {:note "and its members take the ordinary attribute-value conversion"
     :body '[:select {:multiple true :value [:a 1]}]
-    :tree {:tag :select :attrs {:multiple true :value ["a" "1"]}}
-    :literal-collection? true}
+    :tree {:tag :select :attrs {:multiple true :value ["a" "1"]}}}
 
    {:note "an EMPTY selection is an empty vector, not the empty string"
     :body '[:select {:multiple true :value nil}]
@@ -206,8 +204,7 @@
 
    {:note "an empty authored vector is already the empty selection"
     :body '[:select {:multiple true :value []}]
-    :tree {:tag :select :attrs {:multiple true :value []}}
-    :literal-collection? true}])
+    :tree {:tag :select :attrs {:multiple true :value []}}}])
 
 (deftest a-multiple-selects-value-is-collection-shaped-in-the-tree
   (testing "The empty value is the fact `multiple` decides, and it is
@@ -220,15 +217,17 @@
 #?(:clj
    (deftest the-compiled-tree-agrees-about-the-collection-shape
      (testing "One canonicaliser, so a compiled declaration answers the tree
-               its interpreted twin answers. The rows carrying a LITERAL
-               collection are absent on purpose — the compiled analyzer
-               refuses a literal collection attribute value before either
-               emitter sees it, which is a rule of its own and not this
-               canonicaliser's — so what is proved here is every shape a
-               compiled declaration can actually reach."
-       (doseq [{:keys [note body tree]} (remove (fn [{:keys [literal-collection?]}]
-                                                  literal-collection?)
-                                                multiple-select-rows)]
+               its interpreted twin answers — for EVERY row, literal
+               selections included. The literal rows used to be excluded
+               here: the analyzer refused a literal collection attribute
+               value before either emitter ran, so
+               `[:select {:multiple true :value [\"a\" \"b\"]}]` failed to
+               compile while its interpreted twin rendered it, and a
+               COMPUTED selection of the same shape compiled fine
+               (rf2-b6poy). The guard admits the select value slot now, and
+               the literal rides the same runtime path the computed one
+               always did."
+       (doseq [{:keys [note body tree]} multiple-select-rows]
          (is (= tree (compiled-tree body)) (str note " — compiled"))))))
 
 #?(:clj
@@ -271,6 +270,42 @@
         (when ex
           (is (= :rf.error/ui-tree-malformed (:rf.error/id (ex-data ex)))
               (str (pr-str body) " — the walk's existing diagnostic, not a new one")))))))
+
+#?(:clj
+   (defn- compile-refusal
+     "The `{:rf.ui.compile/error id, :msg …}` a compiled declaration of
+     `body` is refused with, or nil when it compiles."
+     [body]
+     (try
+       (compiled-tree body)
+       nil
+       (catch clojure.lang.ExceptionInfo ex
+         (when-let [id (:rf.ui.compile/error (ex-data ex))]
+           {:id id :msg (ex-message ex)})))))
+
+#?(:clj
+   (deftest the-compiled-tier-refuses-exactly-what-the-walk-refuses
+     (testing "The widening is ONE slot on ONE tag, and it is the same slot
+               in both modes. A set stays refused in the compiled tier for
+               the reason the walk refuses it — the tree is one value on two
+               hosts and a set has no order they agree on — and every
+               ordinary attribute keeps the general refusal."
+       (doseq [body ['[:select {:multiple true :value #{"a"}}]
+                     '[:select {:multiple true :value {:a 1}}]
+                     '[:select {:multiple true :title ["a"]}]
+                     '[:input {:value ["a"]}]
+                     '[:div {:value ["a"]}]]]
+         (is (= :rf.ui.compile/collection-attr-value (:id (compile-refusal body)))
+             (str (pr-str body) " — refused compiled, as it is interpreted"))))
+     (testing "and the refusal at the widened slot says why a set is not a
+               selection, rather than claiming collections are only for
+               :class/:style"
+       (let [msg (:msg (compile-refusal '[:select {:multiple true :value #{"a"}}]))]
+         (is (re-find #"SEQUENTIAL" msg))
+         (is (re-find #"order is not a value the two hosts agree on" msg))))
+     (testing "the literal selection itself compiles — the corner this
+               widening was about"
+       (is (nil? (compile-refusal '[:select {:multiple true :value ["a" "b"]}]))))))
 
 (deftest a-single-selects-scalar-value-is-untouched
   (testing "The control that makes the widening mean something. A `<select>`

--- a/implementation/freehand/test/re_frame/freehand/metadata_key_refusal_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/metadata_key_refusal_cljs_test.cljc
@@ -1,0 +1,93 @@
+(ns re-frame.freehand.metadata-key-refusal-cljs-test
+  "`^{:key …}` is the REAGENT spelling, and it is refused — in both modes,
+  on both hosts, and by both interpreted walks.
+
+  It used to be silently DROPPED interpreted. The structural tree carries
+  no metadata contract, nothing on either walk looked for one, and the
+  result was a well-formed tree with the wrong content: no `:key`, no
+  diagnostic, and a list whose only symptom was React reusing the wrong
+  rows several interactions later. The compiled tier meanwhile refused the
+  identical source as a hard build failure — and reported it as a MISSING
+  key, while the author was looking at one.
+
+  So the assertions below never settle for \"something went wrong\". A
+  refusal is asserted beside the ATTRIBUTED RESULT of the spelling that
+  works: the props-slot key really is on the node, at the same site, in
+  the same walk. An assertion that only proved a throw would have passed
+  against the defect just as happily as against the fix, because the
+  defective path threw nothing and rendered fine."
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [re-frame.freehand.tree :as tree]
+            #?@(:cljs [[re-frame.freehand.react :as fr]])))
+
+(defn- refusal
+  "The `ex-message` of the `:rf.error/ui-tree-malformed` `thunk` raises, or
+  nil when it raises nothing — so a SILENT pass is distinguishable from a
+  refusal, which is the whole point here."
+  [thunk]
+  (try
+    (thunk)
+    nil
+    (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) ex
+      (ex-message ex))))
+
+;; ---------------------------------------------------------------------------
+;; The structural walk — both hosts
+;; ---------------------------------------------------------------------------
+
+(deftest the-structural-walk-refuses-a-metadata-key
+  (testing "The spelling a Reagent-shaped hand reaches for first is
+            refused rather than dropped."
+    (let [msg (refusal #(tree/render [:ul ^{:key "a"} [:li "a"]]))]
+      (is (some? msg) "the walk refuses it — it does not render an unkeyed list")
+      (is (str/includes? msg "METADATA") "the sentence names metadata")
+      (is (str/includes? msg "[:li {:key k} …]")
+          "and gives the props-slot spelling")))
+  (testing "The ATTRIBUTED RESULT of the recovery — not merely that
+            something threw. The props spelling puts the key on the very
+            node the metadata spelling left bare."
+    (let [tree (tree/render [:ul [:li {:key "a"} "a"] [:li {:key "b"} "b"]])]
+      (is (= [{:tag :li :key "a" :children ["a"]}
+              {:tag :li :key "b" :children ["b"]}]
+             (:children tree))
+          "each row carries the key it was written with")))
+  (testing "and an ordinary unkeyed child is untouched — the refusal is
+            about the metadata, not about keys being compulsory"
+    (is (= [{:tag :li :children ["a"]}]
+           (:children (tree/render [:ul [:li "a"]]))))))
+
+(deftest the-refusal-reaches-every-child-position
+  (testing "A `for` row is where this is written, but the rule is about
+            the SPELLING and not about lists — the walk folds every child
+            through one collector."
+    (is (some? (refusal #(tree/render [:ul (for [x ["a" "b"]]
+                                             (with-meta [:li x] {:key x}))])))
+        "a keyed-by-metadata for row")
+    (is (some? (refusal #(tree/render ^{:key "r"} [:div "solo"])))
+        "and the root form itself"))
+  (testing "the recovery for a for row, attributed"
+    (is (= [{:tag :li :key "a" :children ["a"]}
+            {:tag :li :key "b" :children ["b"]}]
+           (:children (tree/render [:ul (for [x ["a" "b"]] [:li {:key x} x])])))
+        "the rows are keyed, by the value the row was built from")))
+
+;; ---------------------------------------------------------------------------
+;; The interpreted React walk — the other emitter, ClojureScript only
+;; ---------------------------------------------------------------------------
+;;
+;; The two interpreted walks are separate implementations by design, so a
+;; refusal proved on one of them is not a refusal on the other. This is the
+;; browser half, and it raises the SAME sentence because it calls the same
+;; refusal rather than restating it.
+
+#?(:cljs
+   (deftest the-react-walk-refuses-the-same-spelling
+     (testing "the browser emitter refuses it too, with the same sentence"
+       (let [msg (refusal #(fr/element [:ul ^{:key "a"} [:li "a"]]))]
+         (is (some? msg) "the React walk refuses it")
+         (is (str/includes? msg "METADATA") "with the shared sentence")))
+     (testing "and the props spelling reaches React's own key at the same site"
+       (let [row (.. (fr/element [:ul [:li {:key "a"} "a"]]) -props -children)]
+         (is (= "a" (.-key row))
+             "the row's React key is the key the props map carried")))))

--- a/implementation/freehand/test/re_frame/freehand/pilot_field.cljc
+++ b/implementation/freehand/test/re_frame/freehand/pilot_field.cljc
@@ -48,15 +48,17 @@
   ## The one thing the library does NOT do
 
   It never forwards the caller's event vector into a controlled `:on-input`
-  position. A forwarded vector is a DYNAMIC handler expression: the
-  interpreted walk classifies it at render time and opens the synchronous
-  door, but the compiled analyzer can only classify it `:dynamic`, which
-  no door roster admits — so the identical library would take the
-  synchronous round trip interpreted and batch once promoted. The library
-  therefore owns a LITERAL vector at every door site and carries the
-  caller's event as an ARGUMENT inside it. The site proof stays static,
-  the prefix stays a runtime value, and promotion cannot move the field
-  from synchronous to batched.
+  position. A forwarded vector is a DYNAMIC handler expression, and nothing
+  static pins its class. The DOOR is not what that costs — the compiled
+  element's facts are constants and the door is decided at commit from the
+  runtime handler value, so a forwarded vector reaches it in both modes.
+  What it costs is the EVIDENCE: the site is opaque, its intent is absent
+  from the compiled manifest, and no structural test or tool can say what
+  the field dispatches before it fires. The library therefore owns a
+  LITERAL vector at every door site and carries the caller's event as an
+  ARGUMENT inside it. The site's proof stays static, the prefix stays a
+  runtime value, and a caller can read the intent off the declaration in
+  either mode.
 
   ## The domain it is piloted against
 

--- a/implementation/freehand/test/re_frame/freehand/pilot_field_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/pilot_field_cljs_test.cljc
@@ -257,12 +257,15 @@
 
             The library owns that literal vector deliberately. Forwarding
             the caller's event vector into the `:on-input` position would
-            leave the site a DYNAMIC handler expression, which the
-            interpreted walk classifies at render time and the compiled
-            analyzer cannot classify at all — the one promotion parity
-            break D009 names. Carrying the caller's event as an ARGUMENT
-            inside the library's own literal vector keeps the site's proof
-            static and the prefix a runtime value.
+            leave the site a DYNAMIC handler expression the compiled
+            analyzer cannot classify. The door is not what that costs —
+            it is decided at commit from the runtime handler value, in
+            both modes — but the EVIDENCE is: the site would be opaque,
+            its intent absent from the compiled manifest, and none of the
+            four facts below assertable before it fires. Carrying the
+            caller's event as an ARGUMENT inside the library's own literal
+            vector keeps the site's proof static and the prefix a runtime
+            value.
 
             The user-visible half — that a keystroke's state change lands
             before the browser restores the node — is owed to

--- a/implementation/freehand/test/re_frame/freehand/pilot_react_interop.cljc
+++ b/implementation/freehand/test/re_frame/freehand/pilot_react_interop.cljc
@@ -371,19 +371,25 @@
 (v/defview headless-table
   "A headless table core rendered as ORDINARY Freehand markup. No behavior,
   no leaf, no bridge, no wrapper — the integration needed no host shape at
-  all, which is the honest answer for this whole class of library."
+  all, which is the honest answer for this whole class of library.
+
+  Every row is keyed through the PROPS slot. This pilot was written with
+  the Reagent `^{:key …}` metadata spelling, which is what a hand arriving
+  from v1 reaches for — and which both interpreted walks dropped in
+  silence, leaving this table unkeyed while every assertion below stayed
+  green (rf2-drpa3.163). Both modes refuse the metadata spelling now, so
+  the correction is here rather than in a future adopter's tree."
   [_]
   (let [{:keys [header rows]} (v/sub [:ledger/table])]
     [:table.ledger
      [:thead
       [:tr (for [{:keys [key label]} header]
-             ^{:key key} [:th [:button.sort {:on-click [:ledger/sorted key]} label]])]]
+             [:th {:key key} [:button.sort {:on-click [:ledger/sorted key]} label]])]]
      [:tbody
       (for [{:keys [id cells]} rows]
-        ^{:key id}
-        [:tr {:data-row-id (str id)}
+        [:tr {:key id :data-row-id (str id)}
          (for [{:keys [key value]} cells]
-           ^{:key key} [:td {:data-col (name key)} (str value)])])]]))
+           [:td {:key key :data-col (name key)} (str value)])])]]))
 
 ;; ===========================================================================
 ;; Refusal probes — the shapes that are NOT reachable

--- a/implementation/freehand/test/re_frame/freehand/pilot_react_interop_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/pilot_react_interop_cljs_test.cljc
@@ -469,9 +469,15 @@
             nothing to promote. What cost something was the view around it:
             the compiled grammar refused `[:th {:on-click [:ledger/sorted
             key]}]` because the event vector captures a `for` binding, and
-            refused `^{:key k}` metadata because a compiled list row carries
-            a literal `:key` PROP. Both refusals are right and both messages
+            refused `^{:key k}` metadata because a list row carries a
+            literal `:key` PROP. Both refusals are right and both messages
             are excellent. Neither is a one-line change.
+
+            The metadata refusal was the compiled tier's ALONE when this
+            pilot was written, and the interpreted twin above therefore
+            rendered an unkeyed table with every assertion here green
+            (rf2-drpa3.163). Both modes refuse it now, and the interpreted
+            declaration keys through the props slot like its twin.
 
             The trees are therefore text-equal rather than shape-equal: the
             recovery introduced child boundaries the interpreted twin does


### PR DESCRIPTION
Four beads on the compiled analyzer surface, one commit each. Two are diagnostic-wording fixes; two are real cross-mode divergences.

Closes rf2-drpa3.164, rf2-pv0ne, rf2-b6poy, rf2-drpa3.163.

## What changed

**rf2-pv0ne — the controlled-input advisory reports lost evidence, not a lane change.**
A forwarded caller vector at a controlled `:on-input` does not move the field between dispatch lanes: the React emitter writes the element facts (tag, `controlled?`, slot) as compile-time constants, and `controlled/door?` decides at COMMIT from the runtime handler value, so the vector reaches the synchronous door in both modes. What forwarding actually costs is the STATIC EVIDENCE — the site is opaque, its intent is absent from the compiled manifest, nothing about it is assertable before it fires. The advisory keeps firing; only what it claims changed. Three sites: the user-facing `:rf.ui.compile/controlled-input-async-handler` message and two pilot docstrings. The accept suite now pins both halves (names the opaque site; never says "batch").

**rf2-drpa3.164 — a wrapped `for` body is its own rejection.** `(for [i is] (let [r (nth rows i)] [:div {:key (:id r)} …]))` was refused with a MISSING-KEY sentence pointing at a row that has one, and the ladder then advised keying every row — advice already taken. Wrapper bodies (`let`, `letfn`, `if`, `case`) take their own id, `:rf.ui.compile/indirect-list-body`, whose sentence states the real rule (the body must BE the keyed node) and, for a `let`, gives the fix in full: `for`'s own `:let` modifier. Its ladder leads with a new `:bind-with-for-let` rung so a checker report carries the recovery without reading prose. A body carrying no row at all — `(str x)` — is a different mistake and keeps the message it had.

**rf2-drpa3.163 — `^{:key …}` is refused in both modes, at the form that carries it.** Interpreted, the metadata key was silently DROPPED (no `:key`, no `:keyed?`, no diagnostic — a well-formed tree with the wrong content); compiled, the identical source was a hard build failure reported as a MISSING key. Both interpreted walks now refuse it through one shared sentence (`node/refuse-metadata-key!`), and the analyzer refuses it at the vector that carries it. Recovery: `:key-in-the-props-map`. The interop pilot was itself written the Reagent way and had been rendering an unkeyed table with every assertion green — corrected here. The Reagent comparison in the Freehand draft guide says it once, plainly.

**rf2-b6poy — the compiled tier admits a literal selection on a `<select>` value.** `[:select {:multiple true :value ["a" "b"]}]` rendered interpreted and failed to compile, while a COMPUTED selection of the same shape compiled fine. One widening at the guard, keyed on the same tag-and-slot question the runtime asks — never on `multiple`, which may be a value the compiler cannot see. **No emitter change was needed and none was made:** a literal vector is not a literal SCALAR, so it already rides the dynamic path the computed selection rides, through the one canonicaliser both modes reach. Sets stay refused, and the refusal at the widened slot now says why (one value, two hosts, no agreed order) rather than claiming collections are only meaningful for `:class`/`:style`. The compiled rows in the structural suite were excluded from the literal selections on purpose; they run over every row now.

## Design decisions

**A new diagnostic id is how a case gets its own ladder.** Recovery ladders are keyed by diagnostic id (`grammar/recovery`), and `check/finding` derives a report's `:recovery` from the id alone. rf2-drpa3.164 acceptance 2 asks for a ladder that names the `:let` modifier "for that case", which is only reachable with a distinct id. Hence `:rf.ui.compile/indirect-list-body` and `:rf.ui.compile/metadata-key`, each one row in three closed rosters (id-recoveries, recoveries, reasons). `indirect-list-body` reuses the existing `:iteration-is-not-lexically-flat` reason — a wrapper between the `for` and its row is exactly that.

**The metadata refusal fires EARLIER than rf2-drpa3.163 acceptance 2 asked, and more generally.** That acceptance asked the compiled `unkeyed-list-item` message to name metadata when the offending form carries `:key` in its meta. It is refused at the `analyze` vector branch instead, for two reasons. First, scoping it to the `for` body would have left a NEW divergence in place of the old one: `[:ul ^{:key 1} [:li "a"]]` is refused by the repaired interpreted walk but was silently ignored compiled. One rule in every position is the honest answer. Second, `analyze` runs on the body form before `analyze-for` inspects the resulting op, so a metadata branch inside `analyze-for` would be provably unreachable — dead code, which is what rf2-9g159 correctly declined to ship. The acceptance's intent is fully met: "missing :key" is never reported for a key that is present in metadata, and the sentence names metadata and the props-slot spelling.

**Refuse, don't honour.** rf2-drpa3.163 offered a ruling that metadata keys be honoured in both modes as the alternative. Honouring means the analyzer reading `(meta form)` and threading a key into props through both emitters, plus a second spelling of `:key` living beside the first — the same ambiguity the `#id` sugar conflict refuses by name. Refusing is one predicate in each walk and one `when` in the analyzer, and it is what 004B already implies. Blast radius interpreted was three call sites in one pilot, all in this repo.

## Non-vacuity

Each new claim was inverted, the FULL gate confirmed red naming the test, and the assertion restored byte-identical:

- `a-wrapped-for-body-is-its-own-rejection` — expected id flipped to `unkeyed-list-item`; JVM gate red at `analyze_reject_cljs_test.cljc:85`, EXIT=1.
- `the-react-walk-refuses-the-same-spelling` — `some?` → `nil?`; freehand CLJS gate red at `metadata_key_refusal_cljs_test.cljc:88`, EXIT=1.
- `a-select-value-admits-a-literal-selection` — `nil?` → `some?`; freehand CLJS gate red at `analyze_reject_cljs_test.cljc:153`, EXIT=1.
- `the-compiled-tier-refuses-exactly-what-the-walk-refuses` — the literal-compiles row flipped; JVM gate red at `controlled_structural_value_cljs_test.cljc:308`, EXIT=1.

The rf2-drpa3.163 assertions deliberately pin the ATTRIBUTED RESULT — the actual `:key` on the actual node, and React's own `.-key` — beside each refusal. The defective path threw nothing and rendered fine, so a test asserting only a throw or a non-empty render would have passed against the defect.

## Quality gates

All foreground, all to completion; each captured to a worktree-local log. The shadow-cljs `config:` banner named this worktree on every CLJS run.

| Gate | Result | Exit |
|---|---|---|
| `cd implementation/freehand && clojure -M:test` | Ran 836 tests, 5945 assertions. 0 failures, 0 errors. | 0 |
| `npm run test:freehand` (from `implementation/`) | Ran 820 tests, 4922 assertions. 0 failures, 0 errors. | 0 |
| `npm run test:cljs` | Ran 10945 tests, 55047 assertions. 0 failures, 0 errors. | 0 |
| `npm run test:browser` | Ran 671 tests, 4115 assertions. 0 failures, 0 errors. | 0 |
| `python scripts/check_freehand_conformance_index.py` | clean | 0 |

Nothing skipped. The browser build emits one pre-existing `:redef` warning in `freehand/fingerprint.cljc` (`-write` vs `cljs.core/-write`), untouched by this branch.

Cross-mode coverage: the analyzer guards are `.cljc` and are asserted on BOTH hosts (`analyze_reject_cljs_test.cljc` runs JVM + node CLJS). The metadata refusal is asserted against the structural walk on both hosts and against the separate interpreted React walk in CLJS. The select-value widening is proved interpreted-vs-compiled on the JVM structural tree, which is where the computed case was proved; past the guard the literal takes the identical `dynamics`/`attr!` path the computed value already takes, so no new React code path exists to cover.

## Fences respected

`re_frame/freehand.cljc`, `spec/api-manifest*.edn`, `spec/API.md`, `docs/api/**`, `compiler/emit_cljs.cljc`, `compiler.cljc`, `compiler/build.cljc`, `compiler/emit_jvm.cljc`, `compiler/root.cljc` and the bench tree are all untouched. `emit_jvm.cljc` needed no change for the select widening; the analysis of why is in the rf2-b6poy commit message.

## Relayed, not actioned

- `spec/004D-Freehand-Compiled-Grammar.md` carries the same stale batching claim rf2-pv0ne corrected, in its warning table: "…so it misses the controlled-input sync door". The bead enumerated three sites and the spec half was said to be done; this is a fourth. Worth a follow-up rather than a widened diff.
- The `v/slot` docstring in `re_frame/freehand.cljc` (FENCED) documents `^{:key (:id r)} (v/slot row r)` as the way to key a slot row. Metadata on a seq form does not survive evaluation, so that key was never reaching anything; the working spelling is a keyed fragment, `[:<> {:key (:id r)} (v/slot row r)]`. Not edited — the file belongs to the api-manifest lane.
