### PR TITLE
fix(freehand): a promoted popover reaches the top layer, and the overlay pilot's browser cell with it

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/compiler/emit_react.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/emit_react.cljc
@@ -84,6 +84,33 @@
   commit-time host call instead, exactly as the interpreted walk does."
   #{top-layer/popover-open?-key top-layer/modal-open?-key})
 
+(defn- top-layer-context
+  "The element facts that ride WITH the desired-state pair into
+  [[re-frame.freehand.top-layer/install!]]:
+  [[re-frame.freehand.top-layer/context-keys]], read off this element.
+
+  The install judges a declaration against the element that made it —
+  `popover-open?` is legal only on a valid `:popover` mode, and the
+  dismissal advisory asks whether the element handles the browser's own
+  report. The interpreted walk hands it the whole authored attribute map,
+  so it has both. A compiled element's props are written imperatively
+  onto a JS object and there is no such map, so without this the install
+  judges an EMPTY element: it reads a popover mode of nil and refuses
+  every promoted popover, and it reads no `:on-toggle` and accuses a
+  declaration that does reconcile itself.
+
+  A handler rides as PRESENCE rather than as its callback. What the
+  advisory asks is whether the position is declared at all, and a
+  compiled site's callback is built inside the props form this map cannot
+  reach."
+  [props]
+  (into (into {} (keep (fn [{:keys [k value]}]
+                         (when (contains? top-layer/context-keys k) [k value])))
+              (:attrs props))
+        (keep (fn [{:keys [k]}]
+                (when (contains? top-layer/context-keys k) [k true])))
+        (:events props)))
+
 (defn- new-state [] (atom {:binds [] :n 0}))
 
 (defn- hoist!
@@ -288,6 +315,7 @@
         top         (into {} (keep (fn [{:keys [k value]}]
                                      (when (contains? top-layer-keys k) [k value])))
                           all-attrs)
+        top         (cond-> top (seq top) (into (top-layer-context props)))
         attrs       (remove (fn [{:keys [k]}] (contains? top-layer-keys k)) all-attrs)
         controlled? (controlled/controlled-props? (map :k attrs))
         ;; The multiple-select verdict, from the LITERAL `multiple` — the

--- a/implementation/freehand/src/re_frame/freehand/top_layer.cljc
+++ b/implementation/freehand/src/re_frame/freehand/top_layer.cljc
@@ -120,6 +120,28 @@
   both onto `auto`."
   #{true "" "auto" "manual" "hint"})
 
+(def ^:private popover-reconcilers
+  "The event positions that reconcile a POPOVER's own dismissal."
+  [:on-toggle :on-before-toggle])
+
+(def ^:private modal-reconcilers
+  "The event positions that reconcile a modal DIALOG's own dismissal."
+  [:on-close :on-cancel])
+
+(def context-keys
+  "Beyond the desired-state pair itself, the element facts a top-layer
+  declaration is judged AGAINST: the `:popover` mode that makes
+  `popover-open?` legal at all, and the event positions that reconcile
+  the browser's own dismissal.
+
+  An interpreted element hands the whole authored attribute map to the
+  emitter, so it reads these for free. A COMPILED element has no runtime
+  attribute map — its props are written imperatively onto a JS object —
+  so its emitter carries exactly these facts alongside the pair. The list
+  living here, with the rules that consume it, is what keeps two modes
+  judging one declaration by one rule."
+  (into #{:popover} cat [popover-reconcilers modal-reconcilers]))
+
 (defn present?
   "Does `attrs` carry either desired-state property? The one question asked
   on every element of every render, so it is two map lookups and nothing
@@ -475,8 +497,8 @@
   the popover's toggle pair, or the dialog's close pair."
   [fact]
   (if (contains? fact :popover-open?)
-    [:on-toggle :on-before-toggle]
-    [:on-close :on-cancel]))
+    popover-reconcilers
+    modal-reconcilers))
 
 (defn- reconciled?
   "Does the element handle the browser's own dismissal? Native dismissal —

--- a/implementation/freehand/test/re_frame/freehand/pilot_overlay_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/pilot_overlay_dom_cljs_test.cljs
@@ -27,6 +27,16 @@
   measures the anchor and promotes the panel — so that row is what says
   the split is a modelling choice rather than an avoidance.
 
+  Two rows are about PROMOTION rather than about the platform. The
+  overlay markup's compiled twin is mounted beside the interpreted one:
+  it reaches the real top layer, dispatches a live click from its
+  compiled event site, builds the same document attribute for attribute
+  — and is judged by the dismissal advisory exactly as its interpreted
+  twin is. The structural rows in `pilot-overlay-parity-cljs-test` prove
+  the two declarations DENOTE the same node; only a page can say the
+  promoted one reaches a browser, because promotion's whole cost is paid
+  at a commit.
+
   This file rides the browser lane through its `-dom-cljs-test` suffix. It
   also matches the node suites' broader regex, where it has no top layer to
   drive and says so rather than passing quietly."
@@ -39,13 +49,16 @@
             [re-frame.frame :as frame]
             [re-frame.freehand :as v]
             [re-frame.freehand.behaviors :as behaviors]
+            [re-frame.freehand.conformance :as conf]
             [re-frame.freehand.pilot-overlay :as ui]
+            [re-frame.freehand.pilot-overlay-compiled :as compiled]
             [re-frame.freehand.react :as fr]
             [re-frame.freehand.shell :as shell]
             [re-frame.freehand.top-layer :as top-layer]
             [re-frame.freehand.web :as web]
             [re-frame.live-frame :as live-frame]
-            [re-frame.test-support :as test-support]))
+            [re-frame.test-support :as test-support]
+            [re-frame.trace.tooling :as trace-tooling]))
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture
@@ -228,6 +241,48 @@
                 :on-toggle          [:probe/toggled :inner]
                 :style              (nest-panel-style)}
           [:div {:role "option"} "This page"]]]]]]]))
+
+(v/defview interpreted-panel
+  "The BROWSER CONTROL for promotion parity: `pilot-overlay-compiled/panel`
+  with `{:compiled true}` removed and nothing else changed. Declared here
+  rather than borrowed, because a view id is derived from where a
+  declaration lives and this file has to mount both twins itself."
+  {:props [:map
+           [:open? :boolean]
+           [:control :any]]}
+  [{:keys [open? control]}]
+  [:div {:data-component "acme/dropdown"
+         :data-part      "root"
+         :style          {:display "inline-block" :position "relative"}}
+   [:button {:data-part     "anchor"
+             :type          "button"
+             :aria-expanded (if open? "true" "false")
+             :on-click      [:acme.ui.dropdown/anchor-clicked control]}
+    "Export as…"]
+   [:div {:data-part          "panel"
+          :role               "listbox"
+          :popover            :auto
+          ::web/popover-open? open?
+          :on-toggle          [:acme.ui.dropdown/toggle-reported control]
+          :style              {:position "fixed"
+                               :inset    "auto"
+                               :top      "var(--acme-anchor-y)"
+                               :left     "var(--acme-anchor-x)"
+                               :margin   0}}
+    "PDF"]])
+
+(v/defview unreconciled-promoted
+  "The POSITIVE CONTROL for the dismissal advisory: a promoted popover
+  asking to be open with nothing listening for the browser's own closing
+  report. It is the mistake the pilot's dropdown does not make, declared
+  in the same mode, so \"the pilot is not accused\" is a reading of the
+  advisory rather than of a channel that was never live."
+  {:compiled true}
+  [_]
+  [:div {:id                 "unreconciled-promoted"
+         :popover            :auto
+         ::web/popover-open? true}
+   "menu"])
 
 ;; ---------------------------------------------------------------------------
 ;; Harness
@@ -897,3 +952,199 @@
                        (teardown! container root)
                        (done)))
               (.catch (fn [e] (is false (str "browser run failed: " e)) (done)))))))))
+
+;; ===========================================================================
+;; PROMOTION PARITY, MOUNTED — the compiled twin reaches the top layer
+;; ===========================================================================
+
+(defn- dom-shape
+  "A mounted subtree as comparable data: every element, its attribute
+  names and values, its text, and its children in document order.
+
+  Deliberately NOT `outerHTML`. The two emitters write the same
+  attributes to an element in a different ORDER, which nothing in a
+  browser can observe but which makes string equality a false negative.
+  Comparing the attribute SET is the parity question that means
+  something, and it is stricter than `outerHTML` everywhere else: a
+  missing attribute, a changed value, an extra node or a reordered child
+  all still fail."
+  [node]
+  (if (= 3 (.-nodeType node))
+    (.-nodeValue node)
+    {:tag      (.-tagName node)
+     :attrs    (into (sorted-map)
+                     (map (fn [a] [(.-name a) (.-value a)]))
+                     (js/Array.from (.-attributes node)))
+     :children (mapv dom-shape (js/Array.from (.-childNodes node)))}))
+
+(defn- overlay-arm!
+  "Drive ONE twin through closed → open → a real click on its anchor, and
+  hand back what the document said at each step.
+
+  The two arms run one at a time, on their own mount, rather than side by
+  side in one commit. That is the platform's rule rather than a
+  convenience: sibling `:auto` popovers are mutually exclusive, so asking
+  both twins to be open at the same moment would light-dismiss the first
+  and the comparison would be reading the exclusivity contract instead of
+  the promotion one."
+  [form]
+  (let [[container root] (mount!)
+        render    (fn [open?]
+                    (act #(.render root (element [form {:open? open? :control k}]))))
+        panel     (fn [] (.querySelector container "[data-part='panel']"))
+        promoted? (fn [] (some-> (panel) (.matches ":popover-open")))
+        root-node (fn [] (.-firstElementChild container))
+        seen      (atom {})]
+    (frame/replace-app-db! fid {})
+    (-> (render false)
+        (.then (fn [_] (settle)))
+        (.then (fn [_]
+                 (swap! seen assoc :closed {:shape    (dom-shape (root-node))
+                                            :promoted (promoted?)})
+                 (render true)))
+        (.then (fn [_] (settle)))
+        (.then (fn [_]
+                 (swap! seen assoc :open {:shape    (dom-shape (root-node))
+                                          :promoted (promoted?)})
+                 (act #(.click (.querySelector container "[data-part='anchor']")))))
+        (.then (fn [_]
+                 (swap! seen assoc :clicked (record))
+                 (teardown! container root)
+                 @seen)))))
+
+(deftest promotion-puts-the-panel-in-the-top-layer-on-a-real-page
+  (testing "Promotion parity, read off the document instead of off a tree.
+
+            The structural rows in `pilot-overlay-parity-cljs-test` prove
+            the two declarations DENOTE the same node. They cannot prove
+            that the promoted one reaches a page, because a structural
+            render has no host to call: `:popover-open` is a platform
+            state, and the reserved desired-state property only becomes
+            one when an emitter turns it into a host call at a commit.
+
+            So each twin is mounted, driven closed → open, and clicked.
+            Three things follow that no structural row can state: the
+            compiled emitter really installs the top-layer host call, so
+            a promoted panel is genuinely IN the top layer; the compiled
+            event site really dispatches a live DOM event into app-db;
+            and the document the compiled emitter builds is the document
+            the interpreted one builds, attribute for attribute and
+            character for character, in both states.
+
+            What is still NOT provable here is the measure-then-place
+            half. A compiled body may not attach a behavior, so the
+            placement the pilot's real dropdown gets from `anchor-box`
+            has no promoted form to compare — that refusal is pinned,
+            with its diagnostic, in `pilot-overlay-parity-cljs-test`."
+    (if-not (browser?)
+      (skip! "the browser job runs the promotion-parity assertions")
+      (async done
+        (setup!)
+        (let [seen (atom {})]
+          (-> (overlay-arm! interpreted-panel)
+              (.then (fn [a]
+                       (swap! seen assoc :interpreted a)
+                       (overlay-arm! compiled/panel)))
+              (.then (fn [b]
+                       (swap! seen assoc :promoted b)
+                       (let [i (:interpreted @seen)
+                             c (:promoted @seen)]
+                         (is (false? (get-in i [:closed :promoted]))
+                             "non-vacuous: the interpreted panel is NOT in the top layer
+                              before it is asked to be")
+                         (is (false? (get-in c [:closed :promoted]))
+                             "non-vacuous: neither is the compiled one")
+                         (is (true? (get-in i [:open :promoted]))
+                             "asked to be open, the interpreted panel is in the top layer")
+                         (is (true? (get-in c [:open :promoted]))
+                             "AND SO IS THE COMPILED ONE — the promoted declaration's
+                              reserved desired state became a host call at the commit")
+                         (is (= (get-in i [:closed :shape]) (get-in c [:closed :shape]))
+                             "closed, the two emitters build the same document: every
+                              element, every attribute, every character of text, in order")
+                         (is (= (get-in i [:open :shape]) (get-in c [:open :shape]))
+                             "and open, they still do")
+                         (is (= {:open? true :active 0} (:clicked c))
+                             (str "the COMPILED anchor's event site dispatched a live "
+                                  "browser click into app-db — " (pr-str (:clicked c))))
+                         (is (= (:clicked i) (:clicked c))
+                             "exactly as the interpreted twin's site does"))
+                       (done)))
+              (.catch (fn [e]
+                        (is false (str "the promotion pass threw " e))
+                        (done)))))))))
+
+(def ^:private fx-005 (conf/fixture :FH-TOPLAYER-005))
+
+(defn- advisories!
+  "The dismissal advisories the trace diagnostic bus carried while `f`'s
+  promise settled, in order. The advisory is published from the COMMITTED
+  ref, so the capture has to span the commit rather than the render call."
+  [f]
+  (let [records (atom [])
+        key*    (keyword (gensym "fh-overlay-advisory-"))]
+    (trace-tooling/register-listener!
+      key* (fn [ev] (when (= (:unreconciled-id fx-005) (:operation ev))
+                      (swap! records conj ev))))
+    (-> (f)
+        (.then (fn [_]
+                 (trace-tooling/unregister-listener! key*)
+                 @records))
+        (.catch (fn [e]
+                  (trace-tooling/unregister-listener! key*)
+                  (js/Promise.reject e))))))
+
+(deftest promotion-does-not-change-what-the-dismissal-advisory-says
+  (testing "The other half of the promoted install: an advisory is a
+            judgement about the ELEMENT, and a compiled element has no
+            runtime attribute map to judge — its props are written
+            imperatively onto a JS object. So the facts the judgement
+            needs travel with the desired state, and this row is what says
+            they arrived.
+
+            The pilot's dropdown reconciles its own dismissal (that is
+            what `:on-toggle` and the counting handshake are for), so
+            neither mode may accuse it. A promoted popover that really
+            declares no reconciliation IS accused, in the same mode, at
+            the same commit — which is what makes the pilot's silence a
+            reading rather than a dead channel."
+    (if-not (browser?)
+      (skip! "the browser job runs the advisory assertions")
+      (async done
+        (setup!)
+        (let [seen (atom {})
+              once (fn [form]
+                     (let [[container root] (mount!)]
+                       (-> (advisories!
+                             (fn [] (act #(.render root (element form)))))
+                           (.then (fn [records]
+                                    (teardown! container root)
+                                    records)))))]
+          (-> (once [compiled/panel {:open? true :control k}])
+              (.then (fn [r] (swap! seen assoc :compiled r)
+                       (once [interpreted-panel {:open? true :control k}])))
+              (.then (fn [r] (swap! seen assoc :interpreted r)
+                       (once [unreconciled-promoted {}])))
+              (.then (fn [r]
+                       (swap! seen assoc :control r)
+                       (let [{c :compiled i :interpreted ctl :control} @seen]
+                         (is (= 1 (count ctl))
+                             (str "non-vacuous: the channel is live — a promoted popover "
+                                  "with no dismissal handler IS accused, from a COMPILED "
+                                  "declaration (" (pr-str (mapv :operation ctl)) ")"))
+                         (when-some [ev (first ctl)]
+                           (is (= :popover (:mechanism (:tags ev)))
+                               "naming the mechanism")
+                           (is (= [:on-toggle :on-before-toggle] (:handlers (:tags ev)))
+                               "and the positions that would reconcile it"))
+                         (is (= [] i)
+                             "the pilot's panel reconciles its own dismissal, so the
+                              interpreted twin is not accused")
+                         (is (= [] c)
+                             "AND NEITHER IS THE COMPILED ONE — the `:on-toggle` it
+                              declares reached the judgement that promotion could
+                              have hidden"))
+                       (done)))
+              (.catch (fn [e]
+                        (is false (str "the advisory pass threw " e))
+                        (done)))))))))

--- a/implementation/freehand/test/re_frame/freehand/pilot_overlay_parity_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/pilot_overlay_parity_cljs_test.cljc
@@ -16,11 +16,11 @@
   and its recovery, because a refusal a pilot met is worth more as a
   reproduction than as prose.
 
-  Promotion cannot be proven in a BROWSER today either: a compiled
-  declaration is emitted through the JVM emitter on both hosts and the
-  browser runtime refuses a compiled descriptor outright. So the compiled
-  mode's browser cell is BLOCKED rather than claimed, and every row here
-  is structural."
+  Promotion reaches a BROWSER too — the promoted panel in a real top
+  layer, building the interpreted twin's document, and its anchor
+  dispatching a live click — but that row needs a live `document` and a
+  real commit, so it lives in `pilot-overlay-dom-cljs-test`. Every row
+  here is structural, which is what these rows are for."
   (:require #?(:clj  [clojure.test :refer [deftest is testing]]
                :cljs [cljs.test :refer-macros [deftest is testing]])
             [clojure.string :as str]


### PR DESCRIPTION
## What this is

The overlay pilot documented its compiled browser cell as BLOCKED because
"the browser runtime refuses a compiled descriptor outright". That reason had
been false since compiled views became browser-mountable, but the conclusion
might still have been right for a different reason — a compiled body cannot
attach a behavior, so a view that MEASURES is interpreted forever, and an
overlay measures. The bead exists because inheriting the conclusion would be
the same mistake as trusting the sentence, so the cell was RUN rather than
reasoned about.

It turned out to be neither. The cell was blocked by a **defect**, not by a
bound.

## The finding

The compiled emitter handed `top-layer/install!` only the desired-state pair.
The install judges a declaration against the ELEMENT that made it —
`popover-open?` is legal only on a valid `:popover` mode, and the dismissal
advisory asks whether the element handles the browser's own report. An
interpreted element hands over its whole authored attribute map, so it has
both for free. A compiled element's props are written imperatively onto a JS
object, so the install was judging an EMPTY element:

- it read a popover mode of `nil` and **refused every promoted popover
  outright** — no compiled view could put a popover on a page;
- it read no `:on-toggle` and **accused declarations that do reconcile
  themselves**.

Nothing said so, because no compiled top-layer view had ever been mounted:
`top-layer-views-compiled` is exercised structurally only, and
`top-layer-dom-cljs-test` mounts the interpreted twins.

The first run of the new browser row is the evidence, and it is quoted rather
than paraphrased:

```
the promotion pass threw #error {:message "The element :div declares
:re-frame.freehand.web/popover-open? without a valid :popover mode. …",
:data {… :attr :re-frame.freehand.web/popover-open?, :popover nil}}
```

## The fix

The facts the judgement needs now ride with the pair, named once in
`top-layer/context-keys` beside the rules that consume them, so the two modes
judge one declaration by one rule. A handler rides as PRESENCE rather than as
its callback: what the advisory asks is whether the position is declared at
all, and a compiled site's callback is built inside the props form the map
cannot reach. `reconciling-handlers` now reads the same two vectors the set is
built from, so the four keywords are written once.

## The rebuilt arm

With that, the pilot's browser cell exists — the F5h precedent, applied:

- `promotion-puts-the-panel-in-the-top-layer-on-a-real-page` mounts the
  promoted panel beside its interpreted twin. It reaches the real top layer,
  dispatches a live click from its compiled event site into app-db, and builds
  the same document attribute for attribute in BOTH states. The oracle is a DOM
  shape, not `outerHTML`, for the reason the F5h row gives.
- The arms run one at a time, and say why: sibling `:auto` popovers are
  mutually exclusive, so asking both twins to be open at one moment would read
  the exclusivity contract instead of the promotion one.
- `promotion-does-not-change-what-the-dismissal-advisory-says` pins the other
  half, with a promoted popover that really declares no reconciliation as the
  positive control — so the pilot's silence is a reading rather than a dead
  channel.

The stale sentence is deleted rather than re-pointed. The BEHAVIOR boundary
finding is untouched and still refused; that is what the JVM rows in
`pilot-overlay-parity-cljs-test` pin, and it is why the new docstring says the
measure-then-place half still has no promoted form to compare.

## Design decisions

- **The context travels with the pair, it does not become a second argument.**
  `install!`'s signature already takes the element's attribute map; a compiled
  element simply has no such map, so the emitter supplies the subset the rules
  actually read. Naming that subset in `top-layer/context-keys`, in the
  namespace that owns the rules, is what stops the two modes drifting again.
- **Handlers as presence, not as callbacks.** `reconciled?` asks `some?`, not
  what the handler does. Carrying the callback would be a lie about what the
  compiled tier can reach and would buy nothing.
- **The interpreted browser twin is declared locally.** The file already
  restates the pilot's panel markup for attribution (`nest-structured`), and
  `compiled-mount-dom-cljs-test` declares its twins side by side; a view id is
  derived from where a declaration lives, so the twins cannot share a name.

## Quality gates

Every gate foregrounded, captured to a branch-distinctive worktree-local log,
exit code echoed. The shadow-cljs `config:` banner named this worktree.

| gate | result | exit |
| --- | --- | --- |
| `cd implementation/freehand && clojure -M:test` | Ran 830 tests containing 5882 assertions. 0 failures, 0 errors. | 0 |
| `npm run test:freehand` (from `implementation/`) | Ran 816 tests containing 4871 assertions. 0 failures, 0 errors. | 0 |
| `npm run test:cljs` | Ran 10941 tests containing 54996 assertions. 0 failures, 0 errors. | 0 |
| `npm run test:browser` (`RF2_VERBOSE_TESTS=1`) | Ran 673 tests containing 4128 assertions. 0 failures, 0 errors. | 0 |

**Non-vacuity.** One assertion inverted in each new test; the FULL browser gate
red, naming both:

```
FAIL in (promotion-puts-the-panel-in-the-top-layer-on-a-real-page)
FAIL in (promotion-does-not-change-what-the-dismissal-advisory-says)
2 failures, 0 errors.   EXIT=1
```

Both restored byte-identical. Stronger still: the promotion row was written
BEFORE the emitter fix and failed on the unfixed emitter with the popover-mode
refusal quoted above — the fix is load-bearing for a row that already existed.

**One flake observed, not reproduced.** One browser run showed 4 failures in
`pilot-virtual-table-dom-cljs-test`
(`a-real-scroll-moves-the-window-and-leaves-the-surviving-rows-alone`): the
viewport's `scrollTop` assertion passed and the app-db assertion did not, so the
real scroll happened and its dispatch did not land inside the settle window. Two
further full runs of the same tree were green. Nothing in this diff can reach
that path — the emitter change is gated on an element carrying a top-layer key,
and the table carries none.

## Not in this PR

`rf2-drpa3.165` (controller schemas admit nil where the verbs reject it as
missing) was the second bead on this dispatch. It is STOPPED on the surface
fence: its acceptance criteria require the three public docstrings in
`implementation/freehand/src/re_frame/freehand.cljc` and the generated
`docs/api/**` to state the contract, and both are held by the live
api-manifest lane. The premise was re-verified on this checkout rather than
inherited, and the ruling is written up in the handoff.
