### PR TITLE
docs(re-frame.ui): voice-pass guide per AUTHORING

### DIFF
--- a/docs/core/re-frame.ui/build-a-view.md
+++ b/docs/core/re-frame.ui/build-a-view.md
@@ -4,7 +4,7 @@ This is the walkthrough the [API reference](../../api/re-frame.ui.md) can't be:
 one small view built up a step at a time, so each new form lands on its own. We'll
 build a counter that increments through an event and reveals a help line through
 local state — enough to touch `defview`, `sub`, an event handler, `local`, and
-the mount, which together are most of what day-to-day view work needs.
+the mount, which together are most of what ordinary view work needs.
 
 The setup this assumes — the dependency and the two Shadow settings — is the
 [Install re-frame.ui and configure Shadow](../how-to/install-re-frame-ui.md)
@@ -45,7 +45,7 @@ Here is the whole component, in its first form:
 empty — and returns a template. `(sub [:count])` is the current value of the
 subscription, dropped straight into the paragraph; when `[:count]` changes, this
 view re-renders and the number updates. No `@`, no deref, no ratom. That's the
-reactive spine of the whole thing, in one line.
+whole reactive path, in one line.
 
 ## Step 3 — an event
 
@@ -152,9 +152,9 @@ so your state survives edits.
 That's a complete, runnable re-frame.ui view: a subscription read as a value, an
 event dispatched as data, and ephemeral state kept local — mounted under an
 explicit frame. For a standalone project carrying exactly this shape plus the
-five load-bearing setup files, the
+five setup files the scaffold needs, the
 [`examples/ui/minimal-counter`](https://github.com/day8/re-frame2/tree/main/examples/ui/minimal-counter)
 scaffold is the thing to copy.
 
-Next: [why this stays reactive](reactivity-and-ownership.md) — what re-computes
+[Reactivity and ownership](reactivity-and-ownership.md) covers what re-computes
 when `[:count]` changes, and why the subscription never leaks.

--- a/docs/core/re-frame.ui/custom-elements.md
+++ b/docs/core/re-frame.ui/custom-elements.md
@@ -25,7 +25,7 @@ The rules, in full:
   (`:selected-id` → `selectedId`) — the same spelling philosophy as the rest of the
   DOM grammar.
 - **Undeclared names are attributes.** Undeclared *elements* need no declaration at
-  all — an element that only takes attributes works with zero ceremony.
+  all — an element that only takes attributes needs no declaration.
 - `:class`, `:style`, and booleans follow the ordinary DOM rules.
 - The `{:properties #{…}}` map is the entire declaration grammar — the options map
   is closed.
@@ -42,7 +42,7 @@ The rules, in full:
 - **On the JVM / SSR the emitter writes attributes only** — property props are
   applied at hydration, when a live element object exists to set them on.
 
-## When it goes wrong
+## Troubleshooting
 
 | If you write | What you see | The fix |
 |---|---|---|
@@ -54,6 +54,6 @@ The rules, in full:
 - If a wrapper library already exposes the component as a **React** component,
   embed it as a foreign head (`[TheComponent {…}]`) instead — that boundary and its
   callback rules live on the [interop page](interop-and-limits.md).
-- And the standing note: `re-frame.ui` is experimental — the retained adapters are
-  the default choice; under Reagent/UIx, custom elements follow those libraries'
-  own interop conventions.
+- Reminder: `re-frame.ui` is experimental — the retained adapters are the default
+  choice; under Reagent/UIx, custom elements follow those libraries' own interop
+  conventions.

--- a/docs/core/re-frame.ui/events-and-handlers.md
+++ b/docs/core/re-frame.ui/events-and-handlers.md
@@ -85,7 +85,7 @@ dispatch at such a site falls back to ordinary batching, and dev tells you so
 A whole form is fields over app-db — one event, one sub, every field; the
 [Build a form](../how-to/build-a-form.md) recipe carries the full pattern.
 **Uncommitted drafts stay in `local`**: when only this view cares until submit,
-hold the draft locally and dispatch on submit — the search-box seam in
+hold the draft locally and dispatch on submit — the search-box pattern in
 [State](state.md#local-ephemera-local).
 
 ## Forwarding intent through components
@@ -128,7 +128,7 @@ Three rules keep this honest:
 |---|---|---|
 | Dispatch intent (the 90%) | `[:event … :rf.ui/value]` | data; canonical |
 | The live event — forms, files, filtering | `(ui/event [e] … [:vector …])` | committed values + the event; `nil` filters |
-| Imperative work, stable identity | `(ui/handler [x] …)` | return ignored; foreign change-callbacks, internal fn-prop seams |
+| Imperative work, stable identity | `(ui/handler [x] …)` | return ignored; foreign change-callbacks, internal fn-prop sites |
 | A callback invoked **while rendering** — a row-key, a cell renderer | `(ui/render-fn [x] …)` | pure; current render; no dispatch/state inside |
 | Quick local work in a **native** `:on-*` | bare `#(…)` | legal there only — shorthand for `ui/handler` |
 | Any callback prop on a **foreign component** | one of the forms above, explicitly | a bare fn there is a compile error |
@@ -148,7 +148,7 @@ render callbacks see the **current** render. One function cannot promise both.
            :row-key (ui/render-fn [row] (:id row))}]
 ```
 
-`ui/render-fn` doubles as the value a library's `ui/slot` seam accepts — the
+`ui/render-fn` doubles as the value a library's `ui/slot` call site accepts — the
 [interop page](interop-and-limits.md) covers that library-author territory.
 
 ## Lists
@@ -184,7 +184,7 @@ visibility from domain transitions (a route match, a machine state, the event th
 opened the modal); synchronise with the host world in `effect`
 ([State](state.md#the-world-outside-effect-and-dispatch-fn)).
 
-## Safety nets
+## Troubleshooting
 
 Every rule on this page fails where you can see it — at build time, or at the
 first dev render. None of them becomes a handler that silently does nothing:
@@ -208,6 +208,5 @@ first dev render. None of them becomes a handler that silently does nothing:
 - The event *vocabulary* itself — naming, granularity, `dispatch` semantics — is
   core territory ([Events](../events.md)); this page only changes the spelling at
   the DOM site.
-- And the standing note: `re-frame.ui` is experimental — the retained adapters are
-  the default choice, where handlers are ordinary closures and this page does not
-  apply.
+- Reminder: `re-frame.ui` is experimental — the retained adapters are the default
+  choice, where handlers are ordinary closures and this page does not apply.

--- a/docs/core/re-frame.ui/index.md
+++ b/docs/core/re-frame.ui/index.md
@@ -18,10 +18,10 @@ recipe is the one-time setup.
 
 Pairing with an AI agent to write views? The
 [re-frame2-ui skill](https://github.com/day8/re-frame2/tree/main/skills/re-frame2-ui)
-is the canonical agent-facing authoring surface — teaching prose over the valid
+is the canonical agent-facing authoring guide — teaching prose over the valid
 `defview` forms, the state/subscription/event/effect decision table, and the
 foreign-boundary rules, with the full compile-rejection roster behind it as an
-on-demand reference. The roster is generated from the compiler's own didactic
+on-demand reference. The roster is generated from the compiler's own error
 messages, so it never drifts from what the compiler actually enforces.
 
 !!! warning "re-frame.ui is experimental"
@@ -29,7 +29,7 @@ messages, so it never drifts from what the compiler actually enforces.
     It is pre-alpha, delivered in staged slices, and some surfaces are still
     landing. The Maven coordinates aren't on Clojars yet. Treat it as a track you
     can *trial* today, not one to bet a shipping product on. The
-    [adapters](../how-to/use-uix-or-slim.md) are where the stable ground is.
+    [adapters](../how-to/use-uix-or-slim.md) are the stable path.
 
 ## What stays the same
 
@@ -69,8 +69,8 @@ Reach for it when you specifically want:
 
 Stay on the adapters when you need stability now, when you have an existing
 Reagent or re-com application (a migration wave lands later), or when you'd
-rather not ride pre-alpha churn. Choosing an adapter is not a fallback — it is a
-supported, first-class choice.
+rather not ride pre-alpha churn. Choosing an adapter is a supported, first-class
+choice — not a consolation prize.
 
 ## This section
 

--- a/docs/core/re-frame.ui/interop-and-limits.md
+++ b/docs/core/re-frame.ui/interop-and-limits.md
@@ -3,13 +3,13 @@
 `defview` does not *interpret* hiccup at runtime. It **lowers** the template at
 build time — direct React construction in the browser, a versioned structural tree
 on the JVM — which is what makes the memoisation, the elision, and the tooling
-sound. The price is a **closed template grammar**: anything the compiler cannot see
-through is a build failure, with a message that names the fix, rather than a silent
-runtime surprise.
+reliable. The price is a **closed template grammar**: anything the compiler cannot
+see through is a build failure, with a message that names the fix, rather than a
+silent runtime surprise.
 
-This page is the honest one. It catalogues what the compiler forbids, the explicit
-doors for when you genuinely need runtime structure, how foreign React fits in, and
-where this substrate is the wrong tool.
+This page catalogues what the compiler forbids, the explicit doors for when you
+genuinely need runtime structure, how foreign React fits in, and where this
+substrate is the wrong tool.
 
 ## The one-sentence rule
 
@@ -41,7 +41,7 @@ AST, so you are never forced into one linear template.
 Every `(sub …)` is a compile-indexed site on the view's single
 React bridge. A `sub` may sit in a branch — it is not a hook — but no site may
 appear inside an unbounded loop. The fix is the same shape as
-[State](state.md#when-you-get-it-wrong): extract a keyed child view that
+[State](state.md#troubleshooting): extract a keyed child view that
 subscribes for one row.
 
 Expression positions — prop values, condition tests, `for` collections — hold
@@ -163,7 +163,7 @@ arguments alone) and the library invokes it through `ui/slot`:
 ;; consumer hands the library a pure render callback:
 [data-grid {:rows rows :render-row (ui/render-fn [row] [:td (:name row)])}]
 
-;; inside the library, at the seam:
+;; inside the library, at the call site:
 (ui/slot render-row row)
 ```
 
@@ -217,7 +217,7 @@ island behind a thin `ui/raw` boundary, not a `defview` full of runtime structur
 | A hook at a foreign boundary | `re-frame.ui.react/*` | Interop tier — not for ordinary views |
 | Logic the template must not see | An ordinary function, or another `defview` | The preferred recovery for an unsupported form |
 
-## How errors show up
+## Troubleshooting
 
 - **Build time** for structure and site rules — dynamic heads, loops, missing
   keys, unsupported forms, missing required props on literal call sites. Messages
@@ -229,7 +229,7 @@ island behind a thin `ui/raw` boundary, not a `defview` full of runtime structur
   ids like `:rf.ui.compile/unsupported-form` and `:rf.ui.compile/dynamic-head` are
   part of the contract.
 
-## Planned and absent surfaces
+## Planned and absent APIs
 
 Honesty about what is *not* here yet, so you don't hunt for it:
 
@@ -254,8 +254,8 @@ The closed grammar is the bill for the machinery. Weigh it honestly:
 - **You want stable ground today.** `re-frame.ui` is pre-alpha, delivered in
   staged slices, and not on Clojars yet.
 
-In every one of those cases the answer is the same, and it bears repeating as this
-guide's standing note: **the retained adapters — Reagent, reagent-slim, UIx — are
-the default choice.** They are first-class and actively supported, not a fallback.
-Choosing one is a supported decision, and the dataflow you learned in the
-[core guide](../introduction.md) works identically behind all of them.
+In every one of those cases the answer is the same: **the retained adapters —
+Reagent, reagent-slim, UIx — are the default choice.** They are first-class and
+actively supported, not a fallback. Choosing one is a supported decision, and the
+dataflow you learned in the [core guide](../introduction.md) works identically
+behind all of them.

--- a/docs/core/re-frame.ui/mental-model.md
+++ b/docs/core/re-frame.ui/mental-model.md
@@ -16,15 +16,16 @@ That has three consequences worth internalising:
 
 - **The template grammar is closed.** Because the compiler has to *understand*
   your template — not just execute it — a few dynamic tricks that a runtime
-  walker tolerates are rejected at compile time, each with a didactic message: a
-  computed tag head (`[(if x :div :span) …]`), a `map` that returns markup,
-  keywords in child position, a `sub` inside a `for`. The fixes are always
-  small, and the payoff is that tools and the JVM emitter can rely on the shape.
+  walker tolerates are rejected at compile time, each with a message that names
+  the fix: a computed tag head (`[(if x :div :span) …]`), a `map` that returns
+  markup, keywords in child position, a `sub` inside a `for`. The fixes are
+  always small, and the payoff is that tools and the JVM emitter can rely on the
+  shape.
 - **Memoization is automatic.** Every view is memoized on its props, compared by
   value. Think "`React.memo`, except ClojureScript data compares by value" — a
   parent re-render doesn't re-run a child whose props are equal.
 - **Dev machinery vanishes from production.** The compiled path guards its
-  development affordances behind `goog.DEBUG`, so an advanced build carries no
+  development checks behind `goog.DEBUG`, so an advanced build carries no
   interpreter, no descriptors, no dev-only checks.
 
 ## 2. `defview` is the one component form
@@ -75,7 +76,7 @@ is explicit at the two edges and ambient in between:
   **committed** frame automatically — you don't thread it through props. To scope
   a subtree to a *different* live frame, wrap it in `frame-provider`.
 
-So frames are a first-class part of the model, but day to day you name one at the
+So frames are a first-class part of the model, but usually you name one at the
 root and forget about it.
 
 ## Handlers are data
@@ -134,5 +135,5 @@ cursors, or reactions (that's a second state model); no Form-2 / Form-3; no
 positional view args; no dynamic tag heads or runtime-interpreted hiccup. Closed
 grammars are precisely what let the compiler be honest about what a view reads
 and does — which is what makes the memoization, the elision, and the tooling
-sound. You trade a little runtime flexibility for a view layer that can be
+reliable. You trade a little runtime flexibility for a view layer that can be
 compiled, analysed, and taught without hedging.

--- a/docs/core/re-frame.ui/presence.md
+++ b/docs/core/re-frame.ui/presence.md
@@ -100,7 +100,7 @@ How it behaves:
 In tests, transitions advance on a fake clock with `ui.test/flush-presence!` —
 never a wall-clock sleep ([Testing](testing.md#mounted-tests--when-the-dom-is-the-point)).
 
-## When it goes wrong
+## Troubleshooting
 
 | If you write | What you see | The fix |
 |---|---|---|
@@ -115,5 +115,5 @@ never a wall-clock sleep ([Testing](testing.md#mounted-tests--when-the-dom-is-th
 - Anything beyond enter/exit retention — springs, orchestrated sequences, layout
   animation — is a foreign animation library's job, embedded at an explicit interop
   boundary ([Interop and the closed grammar](interop-and-limits.md)).
-- And the standing note: `re-frame.ui` is experimental — the retained adapters are
-  the default choice, with the React ecosystem's own transition tooling.
+- Reminder: `re-frame.ui` is experimental — the retained adapters are the default
+  choice, with the React ecosystem's own transition tooling.

--- a/docs/core/re-frame.ui/reactivity-and-ownership.md
+++ b/docs/core/re-frame.ui/reactivity-and-ownership.md
@@ -4,8 +4,7 @@ The [build-a-view walkthrough](build-a-view.md) leaned on one sentence — "when
 `[:count]` changes, the view re-renders" — without saying how. This page opens
 that up to the level a view author needs: what re-computes when, and why a
 compiled view's subscriptions never leak. You don't have to manage any of it, but
-knowing the shape makes the framework's behaviour predictable rather than
-magical.
+knowing the shape makes the framework's behaviour predictable.
 
 ## What re-computes when
 
@@ -41,24 +40,21 @@ bookkeeping.
 
 ## Why subscriptions never leak
 
-This is the part that earns the "compiled substrate designed for modern React"
-description, and it's worth understanding even though you never touch it.
+Worth understanding even though you never touch the machinery yourself.
 
 Under concurrent React a *render* is speculative: React may run it, restart it,
 or throw it away without ever showing it. Any design that grabs a resource —
-opens a subscription, takes a lock — *during* render is therefore wrong by
-construction, because the render that grabbed it might be abandoned, and the grab
-would leak.
+opens a subscription, takes a lock — *during* render is wrong by construction:
+the render that grabbed it might be abandoned, and the grab would leak.
 
 `re-frame.ui` sidesteps this with a strict rule: **render only reads; commit
 owns.** When a view renders, it *resolves and reads* its subscriptions but takes
 no ownership. Only when React *commits* that render — actually puts it on screen —
 does the view acquire its subscriptions, and it releases them when the view
 unmounts or is hidden. Because ownership is keyed to the commit, an abandoned
-render owns nothing to leak, and a StrictMode double-invoke balances out. This is
-why you can lean on subscriptions freely in a compiled view without ever thinking
-about cleanup — the leak classes that plague render-time ownership are closed off
-below the surface.
+render owns nothing to leak, and a StrictMode double-invoke balances out. That is
+why you can use subscriptions freely in a compiled view without thinking about
+cleanup — the leak classes that hit render-time ownership never open.
 
 ## Frames survive hot reload
 

--- a/docs/core/re-frame.ui/ssr.md
+++ b/docs/core/re-frame.ui/ssr.md
@@ -31,7 +31,7 @@ freely — two roots can reference one shared frame; one root can scope several.
 
 Every root has a **root-id**. You usually write none: a single-root page derives it
 from the mounted view's registered id — the [Build a view](build-a-view.md) counter
-path, zero ceremony. Author identity the moment a page outgrows that:
+path, no extra config. Author identity the moment a page outgrows that:
 
 ```clojure
 (ui/mount [ui/frame-root {:id :shop} [product-panel]] left-el
@@ -130,7 +130,7 @@ silently stripped by inference. The HTML folding itself lives in the SSR artefac
 calling it without `day8/re-frame2-ssr` on the classpath fails loud with
 `:rf.error/ssr-artefact-missing`.
 
-## When it goes wrong
+## Troubleshooting
 
 | Symptom | Named error | Fix |
 |---|---|---|
@@ -148,6 +148,6 @@ calling it without `day8/re-frame2-ssr` on the classpath fails loud with
 - Request handling, payload allowlists, response control, streaming, and the head
   grammar are the [SSR corpus](../../ssr/concepts.md)'s territory — don't rebuild
   them from view-layer parts.
-- And the standing note: `re-frame.ui` is experimental — the retained adapters are
-  the default choice, and their SSR path (the hash-verified hiccup tier) is covered
-  by the same SSR corpus.
+- Reminder: `re-frame.ui` is experimental — the retained adapters are the default
+  choice, and their SSR path (the hash-verified hiccup tier) is covered by the same
+  SSR corpus.

--- a/docs/core/re-frame.ui/state.md
+++ b/docs/core/re-frame.ui/state.md
@@ -98,7 +98,7 @@ destructuring, as above, stays valid when you don't need the updater.
 - Both are **host-only**: call them from a committed handler or an `effect`
   callback, never during render.
 
-Note the seam in the search box: the *keystroke* stays local; the *intent*
+Note the split in the search box: the *keystroke* stays local; the *intent*
 (`[:search/run text]`) is data — the moment the draft crosses into an event vector
 is exactly the moment it becomes product state. When another view must react to
 every keystroke, the keystroke already *is* product state — skip `local` and
@@ -137,7 +137,7 @@ bound in the top-region `let`, handed to `:ref`, and read via `(.-current node)`
 from the effect (it attaches at commit, *before* the effect fires). Assignment
 never re-renders (contrast `local`). For the expert case where the node's
 *identity* change must itself trigger work, a `(ui/raw-fn f)` callback ref is the
-honest seam.
+honest escape.
 
 Deps are **values** — a rebuilt-but-equal vector is the same dep. No identity
 traps, no `useCallback`, no stale closures. The returned cleanup runs on dep
@@ -188,7 +188,7 @@ The resource system itself — registration, caching, refetch, the transport, an
 the causal owners that keep an entry alive — is the
 [Resources corpus](../../resources/concepts.md).
 
-## When you get it wrong
+## Troubleshooting
 
 The three inputs have few rules, and the ones they have fail where you can see them:
 
@@ -206,7 +206,6 @@ The three inputs have few rules, and the ones they have fail where you can see t
   for `local` only for keystroke-latency ephemera.
 - `effect` is for the host world, not app logic — fetching in an `effect` bypasses
   events, epochs, and every tool that watches them.
-- And the standing note for this whole section: `re-frame.ui` is experimental. The
-  retained adapters (Reagent, reagent-slim, UIx) are the default choice, and this
-  same state discipline — app-db, events, narrow subscriptions — applies there
-  unchanged.
+- Reminder: `re-frame.ui` is experimental. The retained adapters (Reagent,
+  reagent-slim, UIx) are the default choice, and this same state discipline —
+  app-db, events, narrow subscriptions — applies there unchanged.

--- a/docs/core/re-frame.ui/testing.md
+++ b/docs/core/re-frame.ui/testing.md
@@ -172,7 +172,7 @@ Your tests cover *your* app; they get to assume the substrate. (For tooling and
 agents, the dev-only `re-frame.ui.tool` namespace exposes the same evidence Xray
 reads — view manifests, mounted views, render explanations.)
 
-## When it goes wrong
+## Troubleshooting
 
 | If you write | What you see | The fix |
 |---|---|---|


### PR DESCRIPTION
## Summary

Surgical voice pass on the full `docs/core/re-frame.ui/**` corpus to match `docs/core/AUTHORING.md` (same direction as the recent core guide voice pass).

- Renamed error sections to **`## Troubleshooting`** (was "When it goes wrong" / "When you get it wrong" / "Safety nets" / "How errors show up")
- Senior vocabulary filter: drop load-bearing / spine / seam / didactic / standing-note framing; prefer operational claims
- Remove "Next:" navigation ceremony and similar status language; keep technical content, APIs, error ids, code, and links intact
- Fix internal anchor that pointed at the renamed state troubleshooting heading

## Scope

Only `docs/core/re-frame.ui/**/*.md` (11 files). No `spec/` reader links introduced.

## Verification

- `python scripts/check_doc_slugs.py` — green