### PR TITLE
docs(resources): authoring voice pass

### DIFF
--- a/docs/resources/coming-from-tanstack-query.md
+++ b/docs/resources/coming-from-tanstack-query.md
@@ -8,7 +8,7 @@ If you've shipped a React app in the last few years, you've almost certainly rea
 
 re-frame2's [resources](concepts.md) capability is that instinct, ported to a data-oriented Clojure world. The core idea transfers almost completely: **a keyed cache of server reads, with staleness, request deduplication, tag-based invalidation, and garbage collection.** If you hold that model, you already understand 80% of resources. This page maps the vocabulary so the remaining 20% lands fast — and then spends most of its words on the handful of places re-frame2 deliberately walked away from the TanStack design, because *that's* the interesting part.
 
-The honest framing up front: TanStack Query is a *hook* library. Its primitives live inside a component's render and reach back out into the cache. re-frame2's primitives live in the [event](../core/glossary.md#event)/[subscription](../core/glossary.md#subscription) substrate, and the cache is just another piece of [runtime-db](../core/glossary.md#runtime-db). So the cache *behaviour* maps cleanly; the *seams* — where the cache touches your components — are drawn in a different place on purpose. Most of the friction you'll feel moving over is one fact restated three ways: **a read never causes a fetch.**
+The honest framing up front: TanStack Query is a *hook* library. Its primitives live inside a component's render and reach back out into the cache. re-frame2's primitives live in the [event](../core/glossary.md#event)/[subscription](../core/glossary.md#subscription) substrate, and the cache is just another piece of [runtime-db](../core/glossary.md#runtime-db). So the cache *behaviour* maps cleanly; the *boundaries* — where the cache touches your components — are drawn in a different place on purpose. Most of the friction you'll feel moving over is one fact restated three ways: **a read never causes a fetch.**
 
 ## The mapping
 
@@ -49,7 +49,7 @@ The table gets you fluent. These five decisions are why the table isn't a one-to
 
 ### 1. A read never fetches. One hook becomes three jobs.
 
-This is the big one, and everything else is downstream of it. `useQuery` does three things at once: it *declares* the query, it *triggers* the fetch (on mount), and it *reads* the result (on every render). That bundling is convenient and it's why the seam lands where it does — the fetch is a side effect hiding inside your render.
+This is the big one, and everything else is downstream of it. `useQuery` does three things at once: it *declares* the query, it *triggers* the fetch (on mount), and it *reads* the result (on every render). That bundling is convenient and it's why the boundary lands where it does — the fetch is a side effect hiding inside your render.
 
 re-frame2 splits those into three lanes that never blur:
 
@@ -132,7 +132,7 @@ re-frame2 inverts the responsibility: you declare *only the forward change*, and
     :patch (fn [article] (update-favorite article true))}])
 ```
 
-Two forward forms: `:optimistic` patches **exact** keys (the twin of `:populates`), `:optimistic-tags` patches **every** entry carrying a tag in its scope (the cross-view-consistency case you can't enumerate by key — the heart, the detail page, every list, and the session feed flip at once). Both fail closed: a `{:from-db …}` scope resolving to `nil` *drops* that target rather than writing globally, so an optimistic write can't leak across viewers either.
+Two forward forms: `:optimistic` patches **exact** keys (the twin of `:populates`), `:optimistic-tags` patches **every** entry carrying a tag in its scope (the cross-view-consistency case you can't enumerate by key — the favorite control, the detail page, every list, and the session feed flip at once). Both fail closed: a `{:from-db …}` scope resolving to `nil` *drops* that target rather than writing globally, so an optimistic write can't leak across viewers either.
 
 The genuinely *different* behaviour — not just a different spelling — is the **contested rollback**. Suppose a concurrent write lands on the same entry between your optimistic apply and your failure. TanStack restores your captured `context` unconditionally, which can clobber the newer write's value. re-frame2's default `:on-conflict :invalidate` *declines* to restore a now-stale inverse and instead marks the entry stale so the read path refetches the authoritative value. It compares a per-entry `:revision` recorded at apply time, so the decision is deterministic, not a wall-clock race. `:force` is the single-writer escape that restores anyway (with a tooling warning). This is a real semantic departure: re-frame2 would rather refetch the truth than restore a value it knows is contested.
 
@@ -144,7 +144,7 @@ In re-frame2 the cache is a subsystem of [runtime-db](../core/glossary.md#runtim
 
 ## Where do auth headers go?
 
-Every example here hits a bare `/api/...` URL, which raises the obvious migrant question: where do auth headers, tracing headers, the base URL, and tenant headers live? **Not on the resource.** A resource's (or mutation's) `:request` fn describes the *domain* request only — method, url, params, body, `:decode`. Cross-cutting decoration belongs to the [managed-HTTP](../async/http.md) layer the resource lowers through, applied once by a frame-registered `reg-http-interceptor` that decorates *every* `:rf.http/managed` request the frame issues — reads, writes, and plain managed calls alike ([Interceptors: stamp every request once](../async/http-going-further.md#interceptors-stamp-every-request-once) is that seam's own page):
+Every example here hits a bare `/api/...` URL, which raises the obvious migrant question: where do auth headers, tracing headers, the base URL, and tenant headers live? **Not on the resource.** A resource's (or mutation's) `:request` fn describes the *domain* request only — method, url, params, body, `:decode`. Cross-cutting decoration belongs to the [managed-HTTP](../async/http.md) layer the resource lowers through, applied once by a frame-registered `reg-http-interceptor` that decorates *every* `:rf.http/managed` request the frame issues — reads, writes, and plain managed calls alike ([Interceptors: stamp every request once](../async/http-going-further.md#interceptors-stamp-every-request-once)):
 
 ```clojure
 (rf/reg-http-interceptor :realworld/auth
@@ -168,7 +168,7 @@ The mapping above is the vocabulary; this is the exhaustive reference card, each
 | Status | Meaning |
 |---|---|
 | **Landed** | Shipped in the reference implementation (`re-frame.resources`) and pinned by tests. |
-| **Different by design** | A capability the query libraries have, expressed differently here on purpose — usually because re-frame2 already has a more general mechanism (the subscription graph, the re-frame2 loop) that subsumes it. |
+| **Different by design** | A capability the query libraries have, expressed differently here on purpose — usually because re-frame2 already has a more general mechanism (the subscription graph, the event pipeline) that subsumes it. |
 | **Out of scope** | Deliberately not a resources concern — a different artefact, a different phase, or a non-goal. |
 | **Deferred (later slice)** | A real parity gap, deliberately held for a later slice, with no shipped contract yet. |
 
@@ -189,7 +189,7 @@ The mapping above is the vocabulary; this is the exhaustive reference card, each
 | **Optimistic updates + rollback** | `onMutate` snapshot + `onError` rollback | `updateQueryData` + `undo` patch | `optimisticData` + `rollbackOnError` | `:optimistic` (exact-target) / `:optimistic-tags` (tag-addressed) plan applied pre-request; runtime records the inverse; deterministic commit / rollback / reconcile on settle, with `:on-conflict` governing a contested rollback | **Landed** |
 | **Polling / refetch interval** | `refetchInterval` | `pollingInterval` | `refreshInterval` | `:poll-interval-ms` — revalidates every N ms while the entry is *actively owned* and the tab is visible | **Landed** |
 | **Refetch on window focus / reconnect** | `refetchOnWindowFocus` / `refetchOnReconnect` | `refetchOnFocus` / `refetchOnReconnect` | `revalidateOnFocus` / `revalidateOnReconnect` | `install-revalidation-listeners!` per frame; refetches only entries that are *stale AND owned* | **Landed** |
-| **Prefetch / route-plan preload** | `queryClient.prefetchQuery` / `<Link prefetch>` (Router) | `prefetch` endpoint action | `preload` | per-resource warm `ensure` works today (ownerless, cause-only); a **route-plan-level** prefetch verb (`[:rf.route/prefetch target]` in WARM mode) is deferred to post-v1 — the resources side is already warm-capable ([spec/016 §Warm-mode prefetch](../../spec/016-Resources.md#warm-mode-prefetch--a-route-plan-preload-verb-over-ownerless-ensure--post-v1-tracked); [spec/012 §Route-plan prefetch](../../spec/012-Routing.md#route-plan-prefetch--warm-mode-on-hover-preload-post-v1)) | **Deferred (later slice)** |
+| **Prefetch / route-plan preload** | `queryClient.prefetchQuery` / `<Link prefetch>` (Router) | `prefetch` endpoint action | `preload` | per-resource warm `ensure` works today (ownerless, cause-only); a **route-plan-level** prefetch verb (`[:rf.route/prefetch target]` in WARM mode) is deferred to post-v1 — the resources side is already warm-capable | **Deferred (later slice)** |
 | **Infinite / load-more** | `useInfiniteQuery` | `infiniteQuery` (recent) | `useSWRInfinite` | `:infinite true` + `:next-page-param` — one scoped feed entry accumulates an ordered page vector; a causal `:rf.resource/load-more` extends it; `:rf.resource/items` is the merged read | **Landed** |
 | **Keep-previous-data while paging** | `placeholderData: keepPreviousData` | n/a (manual) | `keepPreviousData` | `:keep-previous?` on the route/resource; `:rf/resource` projects `:previous-data` / `:previous-key` | **Landed** |
 | **SSR / hydration** | `dehydrate` / `HydrationBoundary` | `getRunningQueries` + preload | fallback data | per-request frames; blocking route resources are the render wait point; allowlist projection serialized + hydrated under freshness rules | **Landed** |
@@ -201,11 +201,11 @@ Every "Landed" claim is pinned by tests in the reference implementation.
 
 **The honest gaps — out of scope on purpose.** The bottom two rows are the deliberate non-goals of this HTTP-only phase: **normalized / GraphQL caches** (Apollo / Relay / normalizr) are a separate later artefact gated on a GraphQL phase, not a resources gap; and **offline persistence / cross-tab broadcast** is a deferred later slice. Don't let the rest of this page's confidence obscure them.
 
-## The public surface, at a glance
+## The public API, at a glance
 
 re-frame2 keeps three lanes strictly separate, and the lane a symbol lives in tells you what it does (the same split [Concepts](concepts.md#three-lanes--registering-causing-projecting) teaches on the way up):
 
-| Lane | What it is | The surface | Who calls it |
+| Lane | What it is | Symbols | Who calls it |
 |---|---|---|---|
 | **Registration** (functions, at boot) | Declare a handler once — it does not fetch or read | `rf/reg-resource`, `rf/reg-mutation`, `rf/reg-resource-scope` (+ their `clear-*`) | app code, once, at startup |
 | **Commands** (causal event vectors, dispatched) | *Cause* work — they are not reads | `[:rf.resource/ensure …]`, `[:rf.resource/refetch …]`, `[:rf.resource/invalidate-tags …]`, `[:rf.resource/release-owner …]`, `[:rf.resource/clear-scope …]`, `[:rf.resource/remove …]`, `[:rf.resource/load-more …]`, `[:rf.mutation/execute …]` | routes, events, machines |
@@ -213,7 +213,7 @@ re-frame2 keeps three lanes strictly separate, and the lane a symbol lives in te
 
 The two whole-view-model reads are `@(rf/subscribe [:rf/resource query])` and `@(rf/subscribe [:rf/mutation {:instance instance-id}])`; in a view that's the form you'd reach for. The narrower projection subs (`[:rf.resource/data …]`) and the single-fact reads are read the same way — every framework read is a subscription vector, one grammar.
 
-!!! note "The whole `rf/` resource surface is the optional Resources artefact"
+!!! note "The whole `rf/` resource API is the optional Resources artefact"
 
     — late-bound by `day8/re-frame2-resources`, absent from an app that never requires it. The introspection accessors (`rf/resource-meta`, `rf/resource-state`, `rf/resources`) are the tool/test projection lane, not an app-read API; a view that reaches for them instead of a subscription is a category error (they take a one-shot snapshot and never re-render).
 

--- a/docs/resources/concepts.md
+++ b/docs/resources/concepts.md
@@ -323,15 +323,24 @@ writes: [Invalidate after a mutation](how-to/invalidate-after-a-mutation.md).
     Invalidation is **causal** — a declared consequence of the mutation, visible on
     the event record.
 
-## When things fail loud
+## Troubleshooting
 
 <a id="when-it-fails-loud--the-errors-and-warnings"></a>
 
 Registration and use-time errors fail closed (missing scope policy, bad request
-shape, unresolved scope on sub, …). The property: there is no path from "forgot
-the viewer" to "served another user's cache." Named ids live in the
+shape, unresolved scope on sub, …). There is no path from "forgot the viewer" to
+"served another user's cache." Named ids live in the
 [API](../api/re-frame.resources.md) and error catalogue; [testing](testing.md)
 turns the same failures into assertions.
+
+| Symptom | Signal | Fix |
+|---|---|---|
+| Permanent `:idle` / skeleton | No cause fired | Route `:resources` or `[:rf.resource/ensure …]` |
+| `:rf.error/resource-missing-scope-policy` | Scope omitted on `reg-resource` | Add `:scope` (`:rf.scope/global` or a resolver) |
+| `:rf.error/resource-sub-unresolved-scope` | Scope resolver returned `nil` | Resolve only when logged in, or don't subscribe |
+| `:rf.warning/resource-sub-scope-mismatch` | Sub scope ≠ active ensure scope | One named resolver for register, route, and sub |
+| Invalidation refreshes nothing | Wrong scope on `:invalidates` | Name the matching scope per descriptor; watch the dev warning |
+| `:rf.error/resources-artefact-missing` | Forgot the require | `(:require [re-frame.resources])` at boot |
 
 ## A complete read loop
 
@@ -407,5 +416,5 @@ Register → route causes → view projects. Copy-paste skeleton:
 | Named stage machine | [Machines](../machines/index.md) |
 | No server yet | app-db + events |
 
-**Cached server reads that multiply** are the load-bearing concept — not every
-network call.
+**Cached server reads that multiply** are the reason to reach for this artefact —
+not every network call.

--- a/docs/resources/how-to/invalidate-after-a-mutation.md
+++ b/docs/resources/how-to/invalidate-after-a-mutation.md
@@ -61,7 +61,7 @@ Two reads, sharing tags on purpose. The detail read tags itself with its own ide
 
 ## 2. Declare what the write breaks
 
-A [mutation](../glossary.md#mutation) is a managed server-state *write* — the write counterpart to a resource read. Its `:invalidates` key names the tags this write makes stale on success. That single key is the causal heart of the whole page.
+A [mutation](../glossary.md#mutation) is a managed server-state *write* — the write counterpart to a resource read. Its `:invalidates` key names the tags this write makes stale on success. That single key is the whole causal story of this page.
 
 ```clojure
 (rf/reg-mutation :article/save
@@ -335,7 +335,7 @@ A descriptor can only name scopes you already know. Occasionally you need the op
                  :cause        [:admin/article-purged article-id]}])
 ```
 
-Because it can stale or refetch data across *every* user, tenant, story frame, and SSR request, it's load-bearing to spell out and is treated as a privacy-relevant operation:
+Because it can stale or refetch data across *every* user, tenant, story frame, and SSR request, spell it out — the runtime treats it as a privacy-relevant operation:
 
 - it **must** carry `:cause` evidence — a cross-scope invalidation with no `:cause` is a loud `:rf.error/resource-cross-scope-cause-required`, never a silent unaudited sweep (the mutation engine stamps `:cause` for you when you supply one on the descriptor);
 - it shows up as a privacy-relevant [trace event](../../core/glossary.md#trace-event), recording that a mutation reached outside its own scope;

--- a/docs/resources/how-to/paginate-a-feed.md
+++ b/docs/resources/how-to/paginate-a-feed.md
@@ -105,13 +105,13 @@ Two more keys earn their place on real tables:
 - **`:when`** — a `(fn [route _ctx] …)` predicate; the resource is only ensured when it returns truthy. Use it for a list that should only load under a condition (a search that waits for a non-empty `?q=`) rather than ensuring with sentinel-`nil` params.
 - **`:scope`** — for a *scoped* list, a named-resolver reference like `{:from-db :app/session}` so the route ensures under the same principal the view subscribes under. (A global list omits it; the resource's own `:scope :rf.scope/global` resolves sub-side too.)
 
-!!! warning "Gotcha — both seams must compute the same key"
+!!! warning "Gotcha — route and sub must compute the same key"
 
-    Params identity is *exact*. `{:page nil}` and `{:page 1}` are different cache entries. If a view subscribes under one *params* key while the route ensured the other, the view reads `:idle` forever — a miserable bug to chase, because everything *looks* wired up. So normalise the same way everywhere: `(or page 1)` on the route side (above) and on the sub side (next step). Same fallback, both seams.
+    Params identity is *exact*. `{:page nil}` and `{:page 1}` are different cache entries. If a view subscribes under one *params* key while the route ensured the other, the view reads `:idle` forever — a miserable bug to chase, because everything *looks* wired up. So normalise the same way everywhere: `(or page 1)` on the route side (above) and on the sub side (next step). Same fallback on both sides.
 
 !!! warning "Gotcha"
 
-    Once you go scoped (step 2's `:scope {:from-db :app/session}` list, or the session-scoped feed below), the same-key rule has a second half. A sub that **can't resolve a scope at all** (logged out; the resolver returns `nil`) fails loud with `:rf.error/resource-sub-unresolved-scope` — never a silent shared-cache read. A sub that resolves a *valid but wrong* scope reads `:idle` forever, but in dev `:rf.warning/resource-sub-scope-mismatch` names the active scope you probably meant. Either way the cure is one named resolver — registration, route, and sub all pointing at `{:from-db :app/session}`. ([When it fails loud](../concepts.md#when-it-fails-loud--the-errors-and-warnings) is the full signal table; a global list sidesteps all of this, since `:rf.scope/global` resolves identically on both seams.)
+    Once you go scoped (step 2's `:scope {:from-db :app/session}` list, or the session-scoped feed below), the same-key rule has a second half. A sub that **can't resolve a scope at all** (logged out; the resolver returns `nil`) fails loud with `:rf.error/resource-sub-unresolved-scope` — never a silent shared-cache read. A sub that resolves a *valid but wrong* scope reads `:idle` forever, but in dev `:rf.warning/resource-sub-scope-mismatch` names the active scope you probably meant. Either way the cure is one named resolver — registration, route, and sub all pointing at `{:from-db :app/session}`. ([Troubleshooting](../concepts.md#when-it-fails-loud--the-errors-and-warnings) is the full signal table; a global list sidesteps all of this, since `:rf.scope/global` resolves identically on both sides.)
 
 ### 3. Page by navigating, not by fetching
 
@@ -128,7 +128,7 @@ Here's the mental shift, and it's the whole numbered-pages trick: **changing pag
   (fn [q _] (or (:page q) 1)))
 ```
 
-Notice the event has *no fetch in it* — no HTTP, no resource call. It just navigates. The route declaration from step 2 turns that navigation into the right `ensure`. That's the seam doing its job, and it's why the [event handler](../../core/glossary.md#event-handler) stays a pure function returning a tiny [effect map](../../core/glossary.md#effect-map).
+Notice the event has *no fetch in it* — no HTTP, no resource call. It just navigates. The route declaration from step 2 turns that navigation into the right `ensure`. That's the split doing its job, and it's why the [event handler](../../core/glossary.md#event-handler) stays a pure function returning a tiny [effect map](../../core/glossary.md#effect-map).
 
 A filter — a tag, a search term — is just one more params key and one more query param. Carry it across page changes with the route's `:query-retain` (a set of query keys the router threads through subsequent navigations even when the caller didn't supply them). But reset to page 1 when the *filter* changes, because a new filter is a fresh list, and "page 2 of the old filter" means nothing. That reset is just a navigation that drops `:page` while setting the new filter:
 
@@ -140,7 +140,7 @@ A filter — a tag, a search term — is just one more params key and one more q
                                           :query (cond-> {} tag (assoc :tag tag))}]]]}))
 ```
 
-The filter then joins the resource's `:params-schema` and the route's `:query` schema, and the route's `:params` fn threads it through alongside the page — one more key on each of the two seams, no new machinery.
+The filter then joins the resource's `:params-schema` and the route's `:query` schema, and the route's `:params` fn threads it through alongside the page — one more key on the route and the sub, no new machinery.
 
 ### 4. Show the old page while the new one loads
 
@@ -381,7 +381,7 @@ Every single-key sub from the numbered family applies to a feed too — but `:rf
 
 ### What the runtime does that you no longer write
 
-This is the load-bearing payoff. Itemised, here's what just disappeared from your codebase:
+This is the payoff. Itemised, here's what just disappeared from your codebase:
 
 - **The cursor.** `:next-page-param` derives the next page's param from the loaded tail; the runtime stores it on the entry and passes it to the next `:request`. You never thread a cursor through app-db.
 - **The append.** A page success appends to the one entry's page vector with structural sharing — prior pages stay *identical* (`=` and `identical?`). You write no append handler.
@@ -391,7 +391,7 @@ This is the load-bearing payoff. Itemised, here's what just disappeared from you
 
 ### Refetch and reset
 
-`:rf.resource/refetch` on a feed is **window-preserving by default**: the accumulated pages stay rendered until their replacement succeeds, so a focus/reconnect/invalidation-driven refetch never collapses a loaded feed back to page 0. Two opt-ins ship from day one if you want different behaviour, declared on the resource's `:refetch` policy:
+`:rf.resource/refetch` on a feed is **window-preserving by default**: the accumulated pages stay rendered until their replacement succeeds, so a focus/reconnect/invalidation-driven refetch never collapses a loaded feed back to page 0. Two opt-ins ship if you want different behaviour, declared on the resource's `:refetch` policy:
 
 - `:refetch {:refetch-all-pages? true}` — re-fetch every accumulated page (TanStack parity).
 - `:refetch {:refetch-window n}` — bound how much of the accumulation is refreshed.
@@ -437,7 +437,7 @@ So what *is* a fact? The page number (in the URL), the accumulated pages (the in
 
 ## Advanced
 
-Two things you won't reach for on day one, but that the paginated/feed shapes support the moment you need them.
+Optional depth the paginated/feed shapes already support when you need it:
 
 ### Keep a list fresh on an interval
 

--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -61,7 +61,7 @@ Optional later: [examples](examples.md), [TanStack mapping](coming-from-tanstack
 
 ## Three lanes
 
-Hold this split and the whole surface stays clear:
+Hold this split and the API stays clear:
 
 | Lane | Job | Spelling |
 |---|---|---|
@@ -81,6 +81,6 @@ The model page ends with a [complete register + route + view skeleton](concepts.
 | Named lifecycle stages (login, websocket) | [machines](../machines/index.md) |
 | No server yet | Tutorial [Part 1](tutorial/01-pages-and-state.md) only |
 
-Reach for resources when **cached server reads start multiplying** — not on day one of
-a counter. [Where should this value live?](../core/where-state-lives.md) has the full
+Reach for resources when **cached server reads start multiplying** — not for a
+local counter. [Where should this value live?](../core/where-state-lives.md) has the full
 decision table.

--- a/docs/resources/tutorial/01-pages-and-state.md
+++ b/docs/resources/tutorial/01-pages-and-state.md
@@ -5,9 +5,9 @@ arrive in [Part 2](02-server-data.md).
 
 You left [the setup page](index.md) with an empty Conduit shell. By the end of this part it has two real pages — the home feed and the article page — and the URL decides which one you see. Type `/article/welcome-to-conduit` into the address bar and that article renders; press Back and the feed returns. Along the way you'll write your first [event](../../core/glossary.md#event), your first [subscriptions](../../core/glossary.md#subscription), and your first [views](../../core/glossary.md#view).
 
-That trio — events write, subs read, views render — is the loop everything else in re-frame2 builds on. Get comfortable with it here and the rest of the guide is variations on a theme.
+That trio — events write, subs read, views render — is the pure pipeline everything else in re-frame2 builds on. Get comfortable with it here and the rest of the guide is variations on a theme.
 
-Real server data arrives in [Part 2](02-server-data.md). This part is offline: nothing fetches, nothing ticks, so you can watch the state loop run on its own with nothing else moving around it.
+Real server data arrives in [Part 2](02-server-data.md). This part is offline: nothing fetches, nothing ticks, so you can watch that pipeline run on its own with nothing else moving around it.
 
 **The takeaway: the URL is a sub, and a page is just a view of it.**
 
@@ -46,7 +46,7 @@ So even seeding canned data is an event — there's no back door for "the first 
     :author      {:username "octocat"}}
    {:slug        "events-write-subs-read"
     :title       "Events write, subs read"
-    :description "The one-way loop at the heart of the app."
+    :description "The one-way event pipeline that drives the app."
     :body        "Views dispatch events. Handlers compute new state. Subs deliver it back."
     :tagList     ["re-frame2"]
     :createdAt   "2026-06-02T09:00:00Z"
@@ -68,7 +68,7 @@ So even seeding canned data is an event — there's no back door for "the first 
                      :error  nil}}}))
 ```
 
-`reg-event` registers an [event handler](../../core/glossary.md#event-handler): a pure function, two arguments in, one map out. Let's take both sides in turn, because they're the load-bearing shape you'll write a hundred times.
+`reg-event` registers an [event handler](../../core/glossary.md#event-handler): a pure function, two arguments in, one map out. Let's take both sides in turn, because this is the shape you'll write a hundred times.
 
 **The two arguments in** are the [**coeffects**](../../core/glossary.md#coeffect) and the event. Coeffects are the facts the handler is *handed* so it can stay pure — it never reaches out to the world itself; the world is delivered to it. The one you'll reach for constantly is `:db`, the current app-db. (This particular handler ignores both arguments, written `_cofx` and `_event`. The leading underscore is the Clojure convention for "yes, I know this parameter is here; no, I'm not using it" — it keeps the linter quiet and signals intent to the next reader.)
 
@@ -300,7 +300,7 @@ Then the chrome and the root view:
      [not-found-page])])
 ```
 
-This `case` is the whole router, and it's the heart of this part: **the root view subscribes to `:rf.route/id` and maps route ids to pages.** No route components, no `<Outlet>`, no nesting tree — a page is just the view your `case` picks for the current value of a sub. The trailing `[not-found-page]` is the `case` default, catching any route id you haven't wired in yet — register a route but forget to add its page and it lands here, rather than rendering a blank screen and leaving you guessing.
+This `case` is the whole router, and it's the point of this part: **the root view subscribes to `:rf.route/id` and maps route ids to pages.** No route components, no `<Outlet>`, no nesting tree — a page is just the view your `case` picks for the current value of a sub. The trailing `[not-found-page]` is the `case` default, catching any route id you haven't wired in yet — register a route but forget to add its page and it lands here, rather than rendering a blank screen and leaving you guessing.
 
 Three route subscriptions cover most needs:
 

--- a/docs/resources/tutorial/02-server-data.md
+++ b/docs/resources/tutorial/02-server-data.md
@@ -108,7 +108,7 @@ Most of the config map is optional knobs you reach for later. Four keys carry th
 - **`:params-schema`** is the read's *identity*. Every variable that changes the server's answer belongs in params, because params are exactly what the cache keys on. `:conduit/article` with `{:slug "hello"}` and `{:slug "world"}` are two distinct cache entries; that's not configuration, it's just what "identity" means here.
 - **`:scope`** is an explicit, auditable claim about *who shares the answer*. `:rf.scope/global` says "this read is the same for everyone" — a public article list. A [scope](../glossary.md#scope) that isn't global is a *leak boundary*, and you'll meet those in Part 3.
 - **`:stale-after-ms`** is the freshness policy. Fresh for a minute, then the next ensure refetches in the background.
-- **`:tags`** name the *facts* the data contains. The two `:tags` lines look like dead weight right now; they're load-bearing in Part 4, where a later write invalidates exactly the reads it broke. Read past them for now — we'll come back and collect on them.
+- **`:tags`** name the *facts* the data contains. The two `:tags` lines look like dead weight right now; they earn their keep in Part 4, where a later write invalidates exactly the reads it broke. Read past them for now — we'll come back and collect on them.
 
 ??? info "Coming from TanStack Query?"
 
@@ -214,7 +214,7 @@ Here's the rewritten home page. Read the resource, branch on its state:
            [article-preview {:article article}])])]]))
 ```
 
-That `cond` is the heart of this step. Each branch handles one state the feed can genuinely be in. Let's look at what the subscription handed you.
+That `cond` is the whole of this step. Each branch handles one state the feed can genuinely be in. Let's look at what the subscription handed you.
 
 ### The view-model: one fixed map
 
@@ -232,7 +232,7 @@ That `cond` is the heart of this step. Each branch handles one state the feed ca
  :previous?     <bool>}  ;; :keep-previous? is showing the prior key's data
 ```
 
-The five `:status` values are the heart of it:
+The five `:status` values are the model:
 
 | `:status` | Meaning | Show |
 |---|---|---|

--- a/docs/resources/tutorial/03-auth-and-forms.md
+++ b/docs/resources/tutorial/03-auth-and-forms.md
@@ -9,7 +9,7 @@ You'll add a sign-in page, a sign-up page, a session that survives reload, route
 that refuse to open while signed out, and a clean sign-out. Most of it lands in one
 new namespace, `conduit/auth.cljs`.
 
-Here's the idea the whole part rests on. **A form is a tiny state machine wearing a trenchcoat.** Strip away the inputs and login is `idle → submitting → submitted | error`, plus a draft and an error map. Build that *once*, and every later form is a fill-in-the-blanks job.
+Here's the idea the whole part rests on. **A form is a tiny state machine.** Strip away the inputs and login is `idle → submitting → submitted | error`, plus a draft and an error map. Build that *once*, and every later form is a fill-in-the-blanks job.
 
 re-frame2 ships no forms library and no auth plugin on purpose — you'll see why in a moment. What it gives you instead is a convention: one map shape, a small event lifecycle, one error-visibility rule. It's built from the same [events](../../core/glossary.md#event) and [subscriptions](../../core/glossary.md#subscription) as everything else, so nothing here is a new *kind* of thing to learn.
 
@@ -48,7 +48,7 @@ Here's the event that seeds it. An [event](../../core/glossary.md#event) in re-f
                     :submit-error      nil})}))  ;; transport failure (network down)
 ```
 
-A quick tour of the seven keys, because each earns its place. `:draft` is what's being typed right now. `:status` is the machine under the trenchcoat. `:errors` holds renderable validation results — they can be client- or server-produced, and the [view](../../core/glossary.md#view) won't care which. `:_form` is reserved for complaints that no single field owns. `:submit-error` stays separate, because a transport failure has nothing field-shaped to render. And `:submitted` holds the last server-accepted draft — that's what we'll compare against to tell whether the form has unsaved changes (the `dirty?` sub, a section from now).
+A quick tour of the seven keys, because each earns its place. `:draft` is what's being typed right now. `:status` is the lifecycle (`:idle` / `:submitting` / …). `:errors` holds renderable validation results — they can be client- or server-produced, and the [view](../../core/glossary.md#view) won't care which. `:_form` is reserved for complaints that no single field owns. `:submit-error` stays separate, because a transport failure has nothing field-shaped to render. And `:submitted` holds the last server-accepted draft — that's what we'll compare against to tell whether the form has unsaved changes (the `dirty?` sub, a section from now).
 
 This shape is the whole convention — [Build a form](../../core/how-to/build-a-form.md) carries it as a reusable recipe.
 
@@ -291,7 +291,7 @@ The reason this reads cleanly is the framework's classification order. On a 4xx 
 
 !!! warning "Gotcha — a 5xx with an HTML error page is *not* a decode failure"
 
-    If you'd reached for `:decode (schema …)` expecting the failure handler to see a decode error, note that the runtime classifies by status *before* it touches the body: a 503 with a CloudFront HTML page classifies as `:rf.http/http-5xx` with the HTML at `:body`, never as `:rf.http/decode-failure`. The HTTP status is the load-bearing fact; surfacing a decode error there would hide it. Decode-failure only ever describes a malformed *2xx* body.
+    If you'd reached for `:decode (schema …)` expecting the failure handler to see a decode error, note that the runtime classifies by status *before* it touches the body: a 503 with a CloudFront HTML page classifies as `:rf.http/http-5xx` with the HTML at `:body`, never as `:rf.http/decode-failure`. The HTTP status is what matters; surfacing a decode error there would hide it. Decode-failure only ever describes a malformed *2xx* body.
 
 ## The login page
 
@@ -579,7 +579,7 @@ You register the guard once, under the id `:conduit/auth-guard` — exactly like
 
 - **`routing/match-url`** is the URL codec from `re-frame.routing` (`(:require [re-frame.routing :as routing])`) — **not** the `rf/` front porch. It's a pure function, `url → {:route-id :params :query :fragment :validation-failed?}` (or `nil` for a URL that matches nothing), and it runs on both hosts. `matched-address` wraps it in the two rejections the guard needs: a `nil` (unknown route) **and** a `:validation-failed? true` map (a match whose path/query params fail the route's schema) are *both* non-matches — the runtime routes a validation-failed URL to not-found, so the guard must not tag-check a route it will never land on. `nav-target` uses it for the two cases that arrive as a raw URL string.
 - **The current route slice** (`current`, read from the `:rf.db/runtime` coeffect at `[:rf.runtime/routing :current]`) is what resolves an *in-place* navigate request — no `:to`/`:url` means "the route I'm already on," so the guard reads that route's id from the slice, exactly as the runtime does, then folds any `:query`/`:query-merge` edit onto the current query (`in-place-query`) before checking `:tags`. A request that is neither a destination nor a valid in-place edit resolves to `nil`, so the guard stands aside and lets the runtime's structural gate reject it with `:rf.error/navigate-bad-request` rather than reclassifying a malformed request as a valid guarded destination.
-- **`rf/handler-meta :route (:to target)`** reads the route's [registration](../../core/glossary.md#registration) metadata — including its `:tags` — without activating it. It's the introspection seam pair tools use too, so the guard asks the registry the same question Xray would.
+- **`rf/handler-meta :route (:to target)`** reads the route's [registration](../../core/glossary.md#registration) metadata — including its `:tags` — without activating it. It's the same introspection path tools use, so the guard asks the registry the same question Xray would.
 - **`:rf/skip-handler? true`** tells the runtime to skip the event's own handler. For a navigation that means the protected route never commits and its `:on-match` loads (`[:settings/load]`) never fire — a signed-out user can't even trigger the route's data fetch.
 - **The stash** lands the *resolved address* — `{:to :params :query :fragment}`, the full route state — at `[:auth :return-to]`, the same spot `submit-success` read earlier, so the bounce-back returns to the exact URL (query string and `#fragment` included). The guard dispatches the login navigation instead.
 
@@ -630,10 +630,8 @@ Nothing else to unhook, which is the nice part. The bearer interceptor reads app
 
     Logout clears `:auth`, but Part 2's [resource](../glossary.md#resource) caches (the feed, the profile) still hold the departed user's data until they're re-fetched or evicted. If a fresh sign-in could show a flash of the old user's content, clear those caches in the same logout event — one more named, traced step, not a scattered checklist. The how-to [Add authentication](../../core/how-to/add-auth.md) covers the cache-teardown shape in full.
 
-## Taking the trenchcoat off
+## When a machine is the better tool
 
-An honest closing note. This part hand-rolled the `:status` transitions, and at this size that's the right call.
+This part hand-rolled the `:status` transitions, and at this size that's the right call.
 
-!!! note "When to reach for a real state machine"
-
-    The shipped example implements this same flow as an explicit [state machine](../../machines/glossary.md#machine). Once "submitting" is enterable from three places and "error" needs retry rules, scattered status flips stop scaling — you lose track of which transitions are legal. The slice stays identical; only the transition logic moves into a machine that names every legal edge. The same boundary draws the line on *retry*: transport retry (back off and re-issue on a 5xx) belongs in `:rf.http/managed`'s `:retry` slot, but *semantic* retry — "refresh the token on a 401, then replay the original request" — is a state-machine transition, not a config map. When you feel that pull, [State machines](../../machines/concepts.md) is the step up, and the example's [`auth.cljs`](../../../examples/real-apps/realworld_http) shows the finished machine.
+Once "submitting" is enterable from three places and "error" needs retry rules, scattered status flips stop scaling — you lose track of which transitions are legal. The shipped example implements this same flow as an explicit [state machine](../../machines/glossary.md#machine): the slice stays identical; only the transition logic moves into a machine that names every legal edge. Transport retry (back off and re-issue on a 5xx) still belongs in `:rf.http/managed`'s `:retry` slot; *semantic* retry — "refresh the token on a 401, then replay the original request" — is a state-machine transition, not a config map. When you feel that pull, [State machines](../../machines/concepts.md) is the step up, and the example's [`auth.cljs`](../../../examples/real-apps/realworld_http) shows the finished machine.

--- a/docs/resources/tutorial/04-mutations-and-invalidation.md
+++ b/docs/resources/tutorial/04-mutations-and-invalidation.md
@@ -188,9 +188,12 @@ One more command rounds out the surface, alongside `:rf.mutation/execute`. **`:r
 
     One spelling to file away early: the instance sub stores the decoded result under `:result`. The transient [reply map](../glossary.md#reply-map) a `:reply-to` continuation receives — coming up in the **Publish** section — spells the same value `:value`. Same data, two layers; we'll meet `:value` again there.
 
-## Going further with mutations
+## Advanced
 
-The basic loop — register, fire, watch — is the whole story for most writes. This section is the depth: the other two cache-consequence arms, partial replies, scope correctness, timing, and optimistic updates. Read it when you hit the matching need; the favorite above already works without any of it.
+The basic loop — register, fire, watch — is enough for most writes. This section
+is the depth: the other two cache-consequence arms, partial replies, scope
+correctness, timing, and optimistic updates. Read it when you hit the matching
+need; the favorite above already works without any of it.
 
 ### The other two consequence arms: `:patches` and `:removes`
 

--- a/docs/resources/tutorial/index.md
+++ b/docs/resources/tutorial/index.md
@@ -1,18 +1,19 @@
 # Build RealWorld — what you'll make, and setup
 
-The [Core introduction](../../core/introduction.md) taught the loop in a browser
-cell. This tutorial grows it into **Conduit** — a Medium-style app with feeds,
-auth, favoriting, and a production build — on the real toolchain. Server-cache
-vocabulary lives in [the model](../concepts.md); this path is **do → observe → explain**.
+The [Core introduction](../../core/introduction.md) taught the pure pipeline in a
+browser cell. This tutorial grows it into **Conduit** — a Medium-style app with
+feeds, auth, favoriting, and a production build — on the real toolchain.
+Server-cache vocabulary lives in [the model](../concepts.md); this path is
+**do → observe → explain**.
 
 This page orients you (five parts) and scaffolds the project. Budget five minutes
 from `npm install` to pixels.
 
-Conduit follows the [RealWorld spec](https://github.com/gothinkster/realworld), the ecosystem's shared benchmark — which means the same app already exists in React, Vue, Svelte, Solid, and Elm. So every pattern you write here has a direct counterpart in a stack you already know. By the end of Part 5 you'll have built a real app, not a toy: **one app, grown a part at a time.** And you'll grow it the same way you worked the quickstart — *do* a thing, *observe* what the app actually did, *explain* why. (That **do → observe → explain** loop is the spine of this whole tutorial; the *observe* step is where [Xray](../../core/glossary.md#xray), the inspector you'll set up below, earns its keep.)
+Conduit follows the [RealWorld spec](https://github.com/gothinkster/realworld), the ecosystem's shared benchmark — which means the same app already exists in React, Vue, Svelte, Solid, and Elm. So every pattern you write here has a direct counterpart in a stack you already know. By the end of Part 5 you'll have built a real app, not a toy: **one app, grown a part at a time.** And you'll grow it the same way you worked the quickstart — *do* a thing, *observe* what the app actually did, *explain* why. That **do → observe → explain** rhythm runs through the whole tutorial; the *observe* step is where [Xray](../../core/glossary.md#xray), the inspector you'll set up below, earns its keep.
 
 !!! note "Haven't done the Core intro yet?"
 
-    [Start with the introduction](../../core/introduction.md) (and [app-db](../../core/app-db.md)). They teach the loop — [events](../../core/glossary.md#event) → [app-db](../../core/glossary.md#app-db) → [subs](../../core/glossary.md#subscription) → [views](../../core/glossary.md#view) — right in your browser, with nothing installed. This page assumes you've felt that rhythm at least once.
+    [Start with the introduction](../../core/introduction.md) (and [app-db](../../core/app-db.md)). They teach the pure pipeline — [events](../../core/glossary.md#event) → [app-db](../../core/glossary.md#app-db) → [subs](../../core/glossary.md#subscription) → [views](../../core/glossary.md#view) — right in your browser, with nothing installed. This page assumes you've felt that rhythm at least once.
 
 ## One app, five parts
 
@@ -190,7 +191,7 @@ Your page owns the layout; Xray owns only the content inside `[data-rf-xray-host
      [shell]]))
 ```
 
-The events, subs, and views here are just the quickstart's loop again — an [event](../../core/glossary.md#event) updates [app-db](../../core/glossary.md#app-db) (your app's single state map), a [subscription](../../core/glossary.md#subscription) reads from it, and a [view](../../core/glossary.md#view) renders that read. Two bits of syntax look new only because the browser cells smoothed them over:
+The events, subs, and views here are just the quickstart's pipeline again — an [event](../../core/glossary.md#event) updates [app-db](../../core/glossary.md#app-db) (your app's single state map), a [subscription](../../core/glossary.md#subscription) reads from it, and a [view](../../core/glossary.md#view) renders that read. Two bits of syntax look new only because the browser cells smoothed them over:
 
 - **`reg-view`** is a macro (that's why it's `:require-macros`'d at the top, not plain `:require`'d). It defines a view *and* wires its body to the current frame, so inside `header` you can write a bare `subscribe` / `dispatch` and it just finds the right app-db — no frame argument to thread through. The functions-only browser cells couldn't run macros, so the quickstart used plain `defn` views with an explicit `rf/subscribe`; on the real toolchain `reg-view` is the idiomatic shape.
 - **`@(subscribe …)`** — a subscription doesn't hand you a value, it hands you a *reactive reference* that re-runs the view whenever its slice of app-db changes. The leading `@` (Clojure's deref) reads the current value out of it. Read `@(subscribe [:session/user])` as "the live value of who's signed in."
@@ -203,7 +204,7 @@ What's genuinely new beyond syntax is the **boot**, the part the quickstart's br
 
 **Move 3 — `with-frame` + `dispatch-sync` seeds state.** Out here, outside the rendered tree, there's no provider in scope, so `with-frame` scopes the dispatch lexically to `:rf/default`. And it's [`dispatch-sync`](../../core/glossary.md#dispatch-sync) — a dispatch that runs the [event pipeline](../../core/glossary.md#event-pipeline) immediately rather than queuing it — because plain [`dispatch`](../../core/glossary.md#dispatch) would let the first render race it and paint an empty app-db. Seeding synchronously at the boot boundary is one of the handful of legitimate uses of `dispatch-sync`; the others are tests and REPL exploration. What they share is that they all run *outside* any handler — `dispatch-sync` from inside a running handler is rejected with `:rf.error/dispatch-sync-in-handler`, because the pipeline is already draining synchronously and a second one would convey nothing.
 
-**Move 4 — `frame-provider` wraps the tree.** The [provider](../../core/glossary.md#frame-provider) carries the already-registered `:rf/default` frame down through React context, so every bare `dispatch` / `subscribe` inside a `reg-view` body resolves to it without naming it. The `{:frame …}` config shape is load-bearing: handed a `:frame` key, the provider **scopes** the tree to a frame that already exists (you registered it in Move 2). It creates nothing and destroys nothing — it only routes ambient calls. It's the React-side counterpart to `with-frame`, which can't reach across React's render boundary because a child renders *after* the `with-frame` form has already returned. (`defonce` guards the root because a hot reload must not call `create-root` twice on the same element.)
+**Move 4 — `frame-provider` wraps the tree.** The [provider](../../core/glossary.md#frame-provider) carries the already-registered `:rf/default` frame down through React context, so every bare `dispatch` / `subscribe` inside a `reg-view` body resolves to it without naming it. The `{:frame …}` config shape is the one that matters: handed a `:frame` key, the provider **scopes** the tree to a frame that already exists (you registered it in Move 2). It creates nothing and destroys nothing — it only routes ambient calls. It's the React-side counterpart to `with-frame`, which can't reach across React's render boundary because a child renders *after* the `with-frame` form has already returned. (`defonce` guards the root because a hot reload must not call `create-root` twice on the same element.)
 
 That's the whole boot. Four moves: install the substrate, register the frame, seed it, scope the tree to it.
 
@@ -246,9 +247,9 @@ There are two frame-boundary components, one verb each — **roots ensure; provi
 
     `frame-root` ensures and takes `:id`; `frame-provider` scopes and takes `:frame`. Cross them and each fails loud naming its sibling: a `frame-provider` given `:id` raises `:rf.error/frame-provider-given-id`, a `frame-root` given `:frame` raises `:rf.error/frame-root-given-frame`, and a `frame-root` with no keyword `:id` raises `:rf.error/frame-root-missing-id`. The fix is in the message: `frame-provider {:frame …}` to *scope* an existing frame, or `frame-root {:id …}` to *ensure* one.
 
-### When the boot goes wrong
+### Troubleshooting
 
-Each of the four moves has a named way of failing. The good news: every failure arrives as a *structured* [error record](../../core/glossary.md#error-record) — in the console **and** as a row in Xray, under a stable `:rf.error/*` category — so you're never reduced to guessing ([fail loud, not silent](../../core/glossary.md#fail-loud-not-silent) is the whole posture). If you hit an error on first run, match its category here:
+Each of the four moves has a named way of failing. Every failure arrives as a *structured* [error record](../../core/glossary.md#error-record) — in the console **and** as a row in Xray, under a stable `:rf.error/*` category — so you're never reduced to guessing ([fail loud, not silent](../../core/glossary.md#fail-loud-not-silent)). If you hit an error on first run, match its category here:
 
 | `:rf.error/*` category | What happened | The fix |
 |---|---|---|
@@ -272,7 +273,7 @@ When the build reports `Build completed`, open **<http://localhost:8020>**. You 
 
 Xray auto-opened with the app, and `Ctrl+Shift+C` toggles it. Take a moment to look at what minute one already gives you, before you've written a single line of feature code:
 
-- **The event spine** shows one row: `:app/initialise`. That's not a log line you wrote — it's the runtime's own record of the only thing that has happened so far.
+- **The event timeline** shows one row: `:app/initialise`. That's not a log line you wrote — it's the runtime's own record of the only thing that has happened so far.
 - **app-db** shows `{:session {:user nil}}` — exactly the value the boot event returned.
 
-One event, one state, nothing else. **Keep Xray open for the whole tutorial.** This is the *observe* step of the do → observe → explain loop in the flesh — so when something misbehaves later, you won't reach for print statements, you'll just read what the app actually did. (The framework keeps *its* own state in a separate partition, [runtime-db](../../core/glossary.md#runtime-db), which Xray will also show you once routing and resources start using it.) [Debug with Xray](../../xray/index.md) is the deeper tour when you want it.
+One event, one state, nothing else. **Keep Xray open for the whole tutorial.** This is the *observe* step of do → observe → explain in the flesh — so when something misbehaves later, you won't reach for print statements, you'll just read what the app actually did. (The framework keeps *its* own state in a separate partition, [runtime-db](../../core/glossary.md#runtime-db), which Xray will also show you once routing and resources start using it.) [Debug with Xray](../../xray/index.md) is the deeper tour when you want it.


### PR DESCRIPTION
## Summary
- Apply the guide authoring voice brief to `docs/resources/**`: senior vocabulary filter, standard **Troubleshooting** / **Advanced** headings, less curriculum/"day one" framing
- Surgical only — no bulk rewrap; anchors kept for existing links; technical content and code samples preserved
- Drop a `spec/` link from the TanStack parity table (standalone corpus rule)

## Test plan
- [x] `python scripts/check_doc_slugs.py` (green)
- [ ] Spot-check rendered pages under Resources in MkDocs if desired
