### PR TITLE
docs(routing): tighten authoring voice across the corpus

### DIFF
--- a/docs/routing/coming-from-react-router.md
+++ b/docs/routing/coming-from-react-router.md
@@ -1,72 +1,157 @@
 # Coming from React Router
 
-If you've used React Router's data APIs — `createBrowserRouter`, loaders, `useNavigate`, `useLoaderData`, `useBlocker` — you already hold most of the ideas re-frame2 routing is built on. React Router spent its last few major versions migrating *toward* this worldview: routes as data, data-fetching declared per route, the URL treated as a first-class input rather than a thing you read out of `window.location` by hand. re-frame2 starts there and doesn't bolt anything on.
+If you've used React Router's data APIs — `createBrowserRouter`, loaders,
+`useNavigate`, `useLoaderData`, `useBlocker` — you already hold most of the ideas
+re-frame2 routing is built on. React Router spent recent major versions migrating
+*toward* this worldview: routes as data, data-fetching declared per route, the URL
+as a first-class input. re-frame2 starts there and doesn't bolt anything on.
 
-So this page is mostly good news. The translation is honest and direct, with one structural difference that explains all the smaller ones: **React Router is a system that lives beside your app — its own context, its own component tree, its own lifecycle. re-frame2 routing isn't a system at all.** It's three things you already have ([events](../core/glossary.md#event), [subscriptions](../core/glossary.md#subscription), [registrations](../core/glossary.md#registration)) pointed at the URL. There's no router object, no `<RouterProvider>`, no context to thread. Once that lands, every row in the table below stops looking like a port and starts looking like a deletion.
+The translation is direct, with one structural difference that explains the smaller
+ones: **React Router is a system beside your app** — its own context, component tree,
+lifecycle. **re-frame2 routing isn't a separate system.** It's three things you
+already have ([events](../core/glossary.md#event),
+[subscriptions](../core/glossary.md#subscription),
+[registrations](../core/glossary.md#registration)) pointed at the URL. No router
+object, no `<RouterProvider>`, no context to thread. Once that lands, every row below
+stops looking like a port and starts looking like a deletion.
 
-For the full model from scratch, read [The model](concepts.md); this page assumes you'd rather start from what you know.
+For the full model from scratch, read [The model](concepts.md); this page assumes
+you'd rather start from what you know.
 
 ## The mapping
 
 | React Router | re-frame2 | Notes |
 |---|---|---|
 | `createBrowserRouter([...])` / `<Route>` config | [`reg-route`](concepts.md#move-1-a-route-is-a-registry-entry) entries | Each route is one row in a process-global table, registered like any other handler — not a node in a JSX tree. |
-| Route object (`path`, `loader`, `errorElement`…) | The [route](glossary.md#route)'s metadata map | Same idea — a route's behaviour declared as data — but a plain Clojure map, queryable from anywhere. |
-| `:slug` path param, `useParams()` | `:id` in the path + `@(subscribe [:rf.route/params])` | [Route params](glossary.md#route-params) are a [subscription](../core/glossary.md#subscription) read, validated *and coerced* by a schema. |
-| `useSearchParams()` | `@(subscribe [:rf.route/query])` | A separate map from path params — never merged into one bag. `?page=2` arrives as the integer `2`. |
-| `loader` function | [`:on-match`](concepts.md#loaders-declaring-a-pages-data) (events) / `:resources` (data) | The [loader](glossary.md#loader) — but as *data* (a vector of event vectors, or a list of resource decls), not a function you call. |
-| `useLoaderData()` | An ordinary [subscription](../core/glossary.md#subscription) | The loader writes to [app-db](../core/glossary.md#app-db); your [view](../core/glossary.md#view) reads it like any other state. No special hook. |
-| `useNavigate()` → `navigate("/x")` | `(dispatch [:rf.route/navigate {:to :route :params params}])` | [Navigation is an event](concepts.md#move-2-navigation-is-an-event) — traceable, interceptable, and rewound by time-travel. |
-| `<Link to>` / `<NavLink>` | `[route-link {:to :route}]` | Renders a real `<a href>`, intercepts plain clicks, *defers* cmd/shift/middle-click to the browser. |
-| `useNavigation().state` (`"loading"`) | `@(subscribe [:rf.route/transition])` | A global `:idle`/`:loading`/`:error` you read anywhere — never threaded through a component. |
-| `errorElement` / `useRouteError()` | `:on-error` + `@(subscribe [:rf.route/error])` | A structured [error record](../core/glossary.md#error-record) in state, plus an optional event to respond. |
-| `useBlocker()` / `usePrompt()` | `:can-leave` guard + `@(rf/subscribe [:rf/pending-navigation])` | A [route guard](glossary.md#route-guard) sub (boolean) and a *pending navigation you render from* — your confirm dialog is an ordinary view. |
-| Splat route `path="*"`, no-match route | The reserved [`:rf.route/not-found`](glossary.md#not-found) route | An ordinary route you register and design; it carries its own loaders, scroll, and a `:reason` discriminator. |
-| `<Outlet/>` + nested route config | `:parent` + `@(subscribe [:rf.route/chain])` | Nesting is data; you walk the chain and compose layout shells yourself (no render-slot machinery — see [below](#theres-no---layouts-are-data-you-compose), and [The model → Nested layouts](concepts.md#nested-layouts) for the worked code). |
+| Route object (`path`, `loader`, `errorElement`…) | The [route](glossary.md#route)'s metadata map | Same idea — behaviour declared as data — but a plain Clojure map, queryable from anywhere. |
+| `:slug` path param, `useParams()` | `:id` in the path + `@(subscribe [:rf.route/params])` | [Route params](glossary.md#route-params) are a [subscription](../core/glossary.md#subscription), validated *and coerced* by a schema. |
+| `useSearchParams()` | `@(subscribe [:rf.route/query])` | Separate map from path params — never merged. `?page=2` arrives as integer `2`. |
+| `loader` function | [`:on-match`](concepts.md#loaders-declaring-a-pages-data) (events) / `:resources` (data) | The [loader](glossary.md#loader) as *data* (vector of event vectors, or resource decls), not a function you call. |
+| `useLoaderData()` | An ordinary [subscription](../core/glossary.md#subscription) | The loader writes to [app-db](../core/glossary.md#app-db); the [view](../core/glossary.md#view) reads it like any other state. No special hook. |
+| `useNavigate()` → `navigate("/x")` | `(dispatch [:rf.route/navigate {:to :route :params params}])` | [Navigation is an event](concepts.md#move-2-navigation-is-an-event) — traceable, interceptable, rewound by time-travel. |
+| `<Link to>` / `<NavLink>` | `[route-link {:to :route}]` | Real `<a href>`, intercepts plain clicks, *defers* cmd/shift/middle-click to the browser. |
+| `useNavigation().state` (`"loading"`) | `@(subscribe [:rf.route/transition])` | Global `:idle`/`:loading`/`:error` you read anywhere — never threaded through a component. |
+| `errorElement` / `useRouteError()` | `:on-error` + `@(subscribe [:rf.route/error])` | Structured [error record](../core/glossary.md#error-record) in state, plus an optional event to respond. |
+| `useBlocker()` / `usePrompt()` | `:can-leave` guard + `@(rf/subscribe [:rf/pending-navigation])` | [Route guard](glossary.md#route-guard) sub (boolean) and a *pending navigation you render from* — confirm dialog is an ordinary view. |
+| Splat route `path="*"`, no-match route | Reserved [`:rf.route/not-found`](glossary.md#not-found) route | Ordinary route you register and design; carries loaders, scroll, and a `:reason` discriminator. |
+| `<Outlet/>` + nested route config | `:parent` + `@(subscribe [:rf.route/chain])` | Nesting is data; you walk the chain and compose layout shells yourself (no render-slot machinery — see [below](#theres-no---layouts-are-data-you-compose), and [The model → Nested layouts](concepts.md#nested-layouts)). |
 | `<RouterProvider router>` / router context | nothing | The route lives in [runtime-db](../core/glossary.md#runtime-db); any [view](../core/glossary.md#view) reads it via subscription. No provider, no context. |
-| Framework-mode (v7 / Remix) server loaders | The *same* `:on-match` / `:resources` | One loader runs on client **and** server. There's no second "server loader" to keep in sync. |
+| Framework-mode (v7 / Remix) server loaders | The *same* `:on-match` / `:resources` | One loader runs on client **and** server. No second "server loader" to keep in sync. |
 
-If a row reads as "the same idea, minus the apparatus," you're reading it right. That's the whole point.
+If a row reads as "the same idea, minus the apparatus," you're reading it right.
 
 ## Where it diverges
 
-The table makes the two look like dialects of one language. They mostly are — but a handful of differences are deliberate, and they're the part worth your attention, because each one is re-frame2 deleting a category of bug or a category of ceremony rather than renaming it.
+A handful of differences are deliberate — each deletes a category of bug or
+ceremony rather than renaming it.
 
 ### There are no hooks, because there's no component-local anything
 
-`useNavigate`, `useLoaderData`, `useSearchParams`, `useBlocker`, `useNavigation` — every one of these is a hook because in React the router's state is reachable *only* from inside the render of a component that React Router is currently rendering. That coupling is the thing re-frame2 doesn't have. The active route lives in [runtime-db](../core/glossary.md#runtime-db); it's read with the same `subscribe` you use for everything else, from a [view](../core/glossary.md#view), an [event handler](../core/glossary.md#event-handler) (via a coeffect), a test, or the REPL. Nothing has to be "inside the router" to see the URL, because there's no inside.
+`useNavigate`, `useLoaderData`, `useSearchParams`, `useBlocker`, `useNavigation` —
+each is a hook because in React the router's state is reachable *only* from inside a
+component React Router is currently rendering. re-frame2 doesn't have that coupling.
+The active route lives in [runtime-db](../core/glossary.md#runtime-db); it's read with
+the same `subscribe` you use for everything else — from a [view](../core/glossary.md#view),
+an [event handler](../core/glossary.md#event-handler) (via a coeffect), a test, or the
+REPL. Nothing has to be "inside the router" to see the URL, because there's no inside.
 
-The practical payoff is that the awkward cases stop being awkward. A loading bar that needs `useNavigation().state` no longer has to live high enough in the tree to be a router descendant — it's a one-line view over `:rf.route/transition`. An auth guard doesn't need a wrapper component rendered around the protected subtree; it's an [interceptor](../core/glossary.md#interceptor) that reads a tag off the route table. The router's reach was always a tax, and removing the router removes the tax.
+A loading bar that needs `useNavigation().state` no longer has to live high enough
+in the tree to be a router descendant — it's a one-line view over
+`:rf.route/transition`. An auth guard doesn't need a wrapper around the protected
+subtree; it's an [interceptor](../core/glossary.md#interceptor) that reads a tag off
+the route table.
 
 ### Navigation is an event, so it shows up on the wire
 
-`navigate("/cart")` is an imperative call into React Router's internals. You can't log it without wrapping it, can't replay it, can't see it next to the click that caused it. In re-frame2 a navigation is `(dispatch [:rf.route/navigate …])` — the *same verb* as every other state change in the app. (Dry aside: yes, your back button is now technically a `dispatch`. The popstate fires, an event runs, the route slice updates. It was always state change; re-frame2 just stopped pretending the browser was a special case.)
+`navigate("/cart")` is an imperative call into React Router's internals — hard to
+log without wrapping, hard to replay, hard to see next to the click that caused it.
+In re-frame2 a navigation is `(dispatch [:rf.route/navigate …])` — the *same verb*
+as every other state change. (Yes: your back button is a `dispatch`. Popstate fires,
+an event runs, the route slice updates. It was always state change; re-frame2 stopped
+pretending the browser was special.)
 
-Because it travels the same wire as your business events, a navigation appears in [Xray](../core/glossary.md#xray) inline with the click that triggered it, and [time-travel](../core/glossary.md#time-travel) rewinds it for free — the URL rewinds *with* the [frame](../core/glossary.md#frame), because the URL was never the source of truth, only a projection of it. That last clause is the deep version of the divergence: React Router treats the URL as truth and your data as a reaction to it; re-frame2 treats your state as truth and the URL as a print-out. Hence "the URL is a sub."
+Because it travels the same wire as business events, a navigation appears in
+[Xray](../core/glossary.md#xray) inline with the click that triggered it, and
+[time-travel](../core/glossary.md#time-travel) rewinds it for free — the URL rewinds
+*with* the [frame](../core/glossary.md#frame), because the URL was never the source of
+truth, only a projection of it. React Router treats the URL as truth and your data as
+a reaction; re-frame2 treats your state as truth and the URL as a print-out. Hence
+"the URL is a sub."
 
 ### The loader is data, not a function
 
-This is the difference that looks cosmetic and isn't. React Router's `loader` is a function — to know what a route fetches, you read its body or run it. re-frame2's [loader](glossary.md#loader) is `:on-match` (a vector of [event](../core/glossary.md#event) vectors) or `:resources` (a list of declarations). Being *data* means you can read it, test it, and draw a route's data-dependency graph from it **without executing it** — `(rf/handler-meta :route :app/cart)` hands you the list. A function can't tell you what it does until it runs; a data structure can.
+React Router's `loader` is a function — to know what a route fetches, you read its
+body or run it. re-frame2's [loader](glossary.md#loader) is `:on-match` (a vector of
+[event](../core/glossary.md#event) vectors) or `:resources` (a list of declarations).
+Being *data* means you can read it, test it, and draw a route's data-dependency graph
+**without executing it** — `(rf/handler-meta :route :app/cart)` hands you the list.
 
-And `:resources` quietly fixes the click-away race for you. On route entry each resource is owned by *this* navigation's nav-token; when a newer navigation supersedes it, a late-landing reply is *suppressed* rather than written. That's the classic bug where you navigate away, an old fetch resolves a beat too late, and clobbers the page you're now looking at — fixed once in the substrate instead of in every loader you'll ever write. React Router's loaders are abortable, which helps, but abort isn't guaranteed to win the race; suppression is the correctness boundary, abort is the bandwidth optimisation on top.
+And `:resources` closes the click-away race: on route entry each resource is owned by
+*this* navigation's nav-token; when a newer navigation supersedes it, a late reply is
+*suppressed* rather than written. Classic bug — navigate away, old fetch resolves a
+beat too late, clobbers the page you're on — fixed once, not in every loader. React
+Router's loaders are abortable, which helps, but abort isn't guaranteed to win the
+race; suppression is the correctness boundary, abort is the bandwidth optimisation on
+top.
 
 ### The leave-guard is a subscription and the prompt is a view
 
-React Router's `useBlocker` hands you an imperative `blocker` object with a state machine you drive by hand, and historically the "unsaved changes?" prompt bottomed out in `window.confirm` or the `beforeunload` hack. re-frame2 splits the job along its natural seam: [`:can-leave`](glossary.md#route-guard) is a boolean *subscription* (declarative, derives from state — `true` allows, `false` blocks), and the blocked navigation parks in `:rf/pending-navigation`, which is *state you render from*. So your confirm dialog is an ordinary view that reads `@(rf/subscribe [:rf/pending-navigation])`, with two buttons that `dispatch` `:rf.route/continue` or `:rf.route/cancel`. No imperative blocker to manage, no native dialog, no modal-automation flakiness in tests — the whole flow asserts with zero DOM.
+React Router's `useBlocker` hands you an imperative `blocker` object with a state
+machine you drive by hand; historically the "unsaved changes?" prompt bottomed out
+in `window.confirm` or `beforeunload`. re-frame2 splits the job:
+[`:can-leave`](glossary.md#route-guard) is a boolean *subscription* (`true` allows,
+`false` blocks), and the blocked navigation parks in `:rf/pending-navigation` — *state
+you render from*. Confirm dialog is an ordinary view that reads
+`@(rf/subscribe [:rf/pending-navigation])`, with two buttons that `dispatch`
+`:rf.route/continue` or `:rf.route/cancel`. No imperative blocker, no native dialog,
+no modal-automation flakiness in tests — the whole flow asserts with zero DOM.
 
 ### One loader runs on both client and server
 
-React Router's framework mode (v7, formerly Remix) gives you server loaders — a real achievement, and the same instinct as re-frame2. The difference is structural: there, the server story is a *mode* the framework provides, with its own build and runtime. Here there is no second router to be a server version *of*. The request URL is fed to the same pure `match-url`, against a per-request frame; the same `:on-match` and `:resources` run; the state ships to the client and hydrates **without re-fetching**. SSR isn't a parallel implementation kept in sync with the client — it's the *same* implementation pointed at a different event source. The seam between server and client routing doesn't exist because there was never a second router to seam against. (See [Routing on the server](concepts.md#the-same-handler-runs-on-the-server).)
+React Router's framework mode (v7, formerly Remix) gives you server loaders — same
+instinct. The difference is structural: there, the server story is a *mode* with its
+own build and runtime. Here there is no second router to be a server version *of*.
+The request URL is fed to the same pure `match-url`, against a per-request frame; the
+same `:on-match` and `:resources` run; state ships to the client and hydrates
+**without re-fetching**. SSR isn't a parallel implementation kept in sync — it's the
+*same* implementation pointed at a different event source. (See
+[Routing on the server](concepts.md#the-same-handler-runs-on-the-server).)
 
 ### There's no `<Outlet/>` — layouts are data you compose
 
-Here's the one place re-frame2 asks *more* of you, and it's honest to say so. React Router's `<Outlet/>` is a genuinely nice ergonomic: declare nested routes and the parent layout renders its active child into a slot automatically. re-frame2 has no render-slot machinery. Nesting is still expressed as data — a route declares a `:parent`, and `@(subscribe [:rf.route/chain])` gives you the parent chain of the active route — but you walk that chain and compose the layout shells yourself in your root view. The trade is deliberate: it keeps composition in plain Clojure (the same `case`/`cond` you'd write for any conditional view) rather than introducing a routing-specific rendering primitive. Whether that's a feature or a chore depends on how much you liked `<Outlet/>`. Pre-alpha; this edge is on the list. ([The model → Nested layouts](concepts.md#nested-layouts) has the worked `reduce`-over-the-chain code; the [tutorial](tutorial.md#step-7--a-shared-layout) builds it up step by step.)
+Here's the one place re-frame2 asks *more* of you, and it's honest to say so. React
+Router's `<Outlet/>` is a genuinely nice ergonomic: declare nested routes and the
+parent layout renders its active child into a slot automatically. re-frame2 has no
+render-slot machinery. Nesting is still data — a route declares a `:parent`, and
+`@(subscribe [:rf.route/chain])` gives you the parent chain — but you walk that chain
+and compose the layout shells yourself in the root view. The trade is deliberate:
+composition stays in plain Clojure (the same `case`/`cond` you'd write for any
+conditional view) rather than a routing-specific rendering primitive. Whether that's
+a feature or a chore depends on how much you liked `<Outlet/>`. Pre-alpha; this edge
+is on the list. ([The model → Nested layouts](concepts.md#nested-layouts) has the
+worked `reduce`-over-the-chain code; the [tutorial](tutorial.md#step-7--a-shared-layout)
+builds it step by step.)
 
-### A grab-bag of smaller, on-purpose differences
+### Smaller, on-purpose differences
 
-- **Plain `[:a {:href}]` anchors are *not* intercepted** — they do a native full-page navigation. Site-wide anchor interception is a host-adapter concern, not framework magic, so you opt in per link with `route-link` (or install your own document-level handler). React Router intercepts via `<Link>`; re-frame2 just refuses to do it silently behind your back.
-- **404 is a route you must register.** No-match doesn't fall to a built-in default you'd ship to users — the reserved [`:rf.route/not-found`](glossary.md#not-found) is yours to design, and its `:params` carry a `:reason` so you can tell a plain miss from a schema failure from a malformed URL.
-- **Schema failures fail in opposite directions by entry point.** A bad URL from the world (a deep link, a back-button) is *user input* → 404, never an exception. A bad `route-url`/`navigate` call is *your code* → it throws/rejects. Same schemas, opposite failure modes: the world 404s, your bugs are loud.
-- **Routes are queryable data.** Because the route table is a plain table, auth guards, breadcrumb generators, sitemap builders, and analytics all just `filter` and `map` over it — the inverse of reading a route by being rendered inside its `<Route>`.
+- **Plain `[:a {:href}]` anchors are *not* intercepted** — they do a native full-page
+  navigation. Site-wide anchor interception is a host-adapter concern, not framework
+  magic: opt in per link with `route-link` (or install your own document-level
+  handler). React Router intercepts via `<Link>`; re-frame2 refuses to do it silently
+  behind your back.
+- **404 is a route you must register.** No-match doesn't fall to a built-in default
+  you'd ship to users — the reserved [`:rf.route/not-found`](glossary.md#not-found)
+  is yours to design, and its `:params` carry a `:reason` so you can tell a plain miss
+  from a schema failure from a malformed URL.
+- **Schema failures fail in opposite directions by entry point.** A bad URL from the
+  world (deep link, back-button) is *user input* → 404, never an exception. A bad
+  `route-url`/`navigate` call is *your code* → it throws/rejects. Same schemas,
+  opposite failure modes: the world 404s, your bugs are loud.
+- **Routes are queryable data.** Auth guards, breadcrumb generators, sitemap builders,
+  and analytics `filter` and `map` over the table — the inverse of reading a route by
+  being rendered inside its `<Route>`.
 
-If you internalise one thing: in React Router the router is a *thing you're inside of*, and the hooks are how you ask it questions. In re-frame2 the route is just *state*, and you read state the one way you always do. Every divergence above is a consequence of that single move.
+Internalise one thing: in React Router the router is a *thing you're inside of*, and
+the hooks are how you ask it questions. In re-frame2 the route is just *state*, and
+you read state the one way you always do. Every divergence above is a consequence of
+that single move.

--- a/docs/routing/concepts.md
+++ b/docs/routing/concepts.md
@@ -2,9 +2,9 @@
 
 <a id="routing-the-url-is-a-sub"></a>
 
-This page is the **routing model** — three moves, then the refinements you hit next
-(loaders, guards, not-found, URL binding). Full recipes for leave/enter guards live
-in the how-tos; API signatures live in [re-frame.routing](../api/re-frame.routing.md).
+This page is the **routing model** — three moves, then loaders, guards, not-found,
+and URL binding. Full leave/enter recipes live in the how-tos; signatures live in
+[re-frame.routing](../api/re-frame.routing.md).
 
 To *build* a three-page app step by step, use the [tutorial](tutorial.md).
 
@@ -104,7 +104,7 @@ for a single-route auth gate ([below](#guarding-entry--can-enter)); use an
 interceptor when one policy spans many routes (and attach it so all three entry
 doors are covered).
 
-### Metadata map (map of the territory)
+### Metadata keys
 
 <a id="the-metadata-map-in-full"></a>
 <a id="metadata-map-map-of-the-territory"></a>
@@ -129,7 +129,7 @@ ranking cascade: [API `reg-route`](../api/re-frame.routing.md#reg-route).
 ```clojure
 (rf/dispatch [:rf.route/navigate {:to :app/article :params {:id "intro"}}])
 
-;; One request map — address, policy, and edit keys all sit side by side:
+;; One request map — address, policy, and edit keys side by side:
 (rf/dispatch [:rf.route/navigate {:to :app/search :query {:q "clojure" :page 2}}])
 (rf/dispatch [:rf.route/navigate {:to :app/login :replace? true}])
 (rf/dispatch [:rf.route/navigate {:to :app/article :params {:id "intro"} :fragment "section-2"}])
@@ -155,9 +155,8 @@ ranking cascade: [API `reg-route`](../api/re-frame.routing.md#reg-route).
 (rf/dispatch [:rf.route/navigate {:query-merge {:page 2}}])
 ```
 
-A request with no `:to` / `:url` patches the current location: `:query-merge` folds
-into the current query, `:query` replaces it wholesale, `:fragment` moves the anchor.
-The route and its params carry over untouched.
+No `:to` / `:url`: `:query-merge` folds into the current query, `:query` replaces it
+wholesale, `:fragment` moves the anchor. Route and params carry over untouched.
 
 ### Linking from views
 
@@ -170,18 +169,17 @@ The route and its params carry over untouched.
 
 Real `<a href>` — hover, copy-link, cmd/middle-click work. Plain left-click becomes
 dispatch. `:target "_blank"` / `:download` are **not** SPA-intercepted (browser owns
-them). That interception is [`route-link`](#linking-from-views)'s job: its view body is
-the only thing that calls `.preventDefault` and dispatches `:rf.route/url-requested`,
-the seam the router listens on.
+them). That interception is [`route-link`](#linking-from-views)'s job: its view body
+is the only thing that calls `.preventDefault` and dispatches
+`:rf.route/url-requested`, the event the router listens on.
 
-A plain `[:a {:href …}]` you hand-write does **not** reach that seam — nothing dispatches
-`:rf.route/url-requested` for it, so it does a full page navigation. Installing a handler
-*on* `:rf.route/url-requested` can't change that: the event never fires for a plain anchor.
-Two honest ways to keep such a click in-app: render the link with
-[`route-link`](#linking-from-views) instead, or install one **document-level** click
-listener that decides eligibility itself — plain primary-button click, no modifier keys,
-no `:target`/`:download`, a same-origin in-app `href` — and dispatches
-`:rf.route/url-requested` on a match, letting the browser follow every click it rejects.
+A plain `[:a {:href …}]` you hand-write does **not** fire that event — full page
+navigation. Two honest ways to keep the click in-app: use
+[`route-link`](#linking-from-views), or install one **document-level** click listener
+that decides eligibility itself — plain primary-button click, no modifier keys, no
+`:target`/`:download`, same-origin in-app `href` — and dispatches
+`:rf.route/url-requested` on a match, letting the browser follow every click it
+rejects.
 
 <a id="what-happens-in-order"></a>
 
@@ -209,7 +207,7 @@ The current route lives in **runtime-db** (not app-db). You read; you never writ
 @(rf/subscribe [:rf.route/transition])   ;; :idle | :loading | :error
 @(rf/subscribe [:rf.route/error])
 @(rf/subscribe [:rf.route/chain])        ;; :parent ancestry (nested layouts)
-@(rf/subscribe [:rf/pending-navigation]) ;; blocked leave, or nil
+@(rf/subscribe [:rf/pending-navigation]) ;; blocked leave/enter, or nil
 ```
 
 `:transition` drives a global progress bar without per-page loading flags:
@@ -296,48 +294,6 @@ Ownership is nav-token keyed: leave or supersede → release; late replies
 **suppressed**. Per-user data uses a scope resolver (`{:from-db …}`) — fails closed
 when logged out. Full story: [Resources model](../resources/concepts.md).
 
-### A hand-rolled async loader — capture the nav-token
-
-<a id="a-hand-rolled-async-loader"></a>
-
-`:on-match` and `:resources` are the everyday loaders. Roll your own async fetch instead
-and you inherit the one race they close for you: a reader opens article A, navigates to B
-before A's reply lands, and A's late reply overwrites B's page. Guard it by capturing the
-**navigation token** — the epoch the current navigation minted — when the load starts, and
-gating delivery on it. Two framework hooks do the work: the `:rf.route/nav-token` **cofx**
-injects the live token into an `:on-match`-reached handler, and the
-`:rf.route/with-nav-token` **fx** delivers a reply only while that captured token still
-matches the current slice — otherwise it suppresses the reply and fires
-`:rf.route.nav-token/stale-suppressed`.
-
-```clojure
-;; The loader: capture the live token, kick off your own fetch, and carry the
-;; token into the reply event.
-(rf/reg-event :app/load-article
-  {:rf.cofx/requires [:rf.route/nav-token]}            ;; inject the current epoch token
-  (fn [{:rf.route/keys [nav-token] rt :rf.db/runtime} _]
-    (let [{:keys [id]} (get-in rt [:rf.runtime/routing :current :params])]
-      ;; :app/fetch-article is YOUR async effect; on reply it dispatches
-      ;; :app/article-arrived with the captured token + the fetched payload.
-      {:fx [[:app/fetch-article {:id id :on-reply [:app/article-arrived nav-token id]}]]})))
-
-;; The completion: hand the CAPTURED token to :rf.route/with-nav-token. Fresh
-;; token → the :rf/reply-to target runs; stale (a newer navigation superseded it)
-;; → the reply is dropped before it can touch app-db.
-(rf/reg-event :app/article-arrived
-  (fn [_ [_ captured-token id payload]]
-    {:fx [[:rf.route/with-nav-token
-           {:rf/reply-to [:app/article-loaded id payload]
-            :nav-token   captured-token}]]}))
-
-(rf/reg-event :app/article-loaded
-  (fn [{:keys [db]} [_ id payload]]
-    {:db (assoc db :article/current payload)}))
-```
-
-`:resources` already does all of this — declare it and the race is closed for you.
-Hand-roll only when you need something the resource layer doesn't give you.
-
 ## Blocking a navigation
 
 <a id="blocking-a-navigation"></a>
@@ -377,7 +333,7 @@ bar, Back/Forward). On block → `:rf.route/entry-blocked` (redirect to login th
 ```
 
 Non-boolean guard return → block + `:rf.error/can-leave-non-boolean` /
-`:rf.error/can-enter-non-boolean` (fail closed, fail loud).
+`:rf.error/can-enter-non-boolean` (deny the move, raise the error).
 
 **Prefer `:can-enter` for per-route auth** (see
 [realworld_http](../../examples/real-apps/realworld_http)). Use an interceptor only
@@ -400,20 +356,6 @@ Register reserved id `:rf.route/not-found`. Offending URL lands in `:params`
 Missing registration → warning + built-in placeholder. Programmatic schema miss is
 loud (`route-url` throws; navigate rejects); URL-driven miss is 404.
 
-## Keeping tokens off the wire
-
-<a id="keeping-tokens-off-the-wire"></a>
-
-```clojure
-(rf/reg-route :app/oauth-callback
-  {:query     [:map [:token :string] [:code :string]]
-   :sensitive [[:query :token] [:query :code]]}
-  "/oauth/callback")
-```
-
-Egress-only redaction while the route is active. Full story:
-[Keep secrets out of traces](../core/how-to/keep-secrets-out-of-traces.md).
-
 ## The browser is just another event source
 
 <a id="the-browser-is-just-another-event-source"></a>
@@ -426,33 +368,6 @@ Egress-only redaction while the route is active. Full story:
 `:rf.error/duplicate-url-binding` if two claim). Installs listener + initial sync;
 no separate install API. Frames without the flag still route **in memory** (Story,
 tests).
-
-### URL strategies
-
-<a id="url-strategies"></a>
-
-```clojure
-(rf/make-frame {:id           :app
-                :url-bound?   true
-                :url-strategy rf.routing/hash-url-strategy})  ;; default: history-url-strategy
-```
-
-`route-url` / `match-url` stay path-form; strategy encodes `#` at the edges.
-`rf.routing/with-base-path` for deploy under a subpath. SSR ignores strategies (path
-form on the wire; client re-encodes on hydrate).
-
-<a id="converting-routes--urls-by-hand"></a>
-
-### Codec by hand
-
-```clojure
-(rf.routing/route-url {:to :app/article :params {:id "intro"}})
-;; => "/articles/intro"
-(rf.routing/match-url "/articles/intro")
-;; => {:route-id :app/article :params {:id "intro"} …}
-```
-
-Pure, JVM + CLJS. `nil` path param → throw; `nil` query param → elided.
 
 ## The same handler runs on the server
 
@@ -498,7 +413,109 @@ Copy-paste shape (pages and loaders are stubs — fill in as the tutorial does):
                [root-view]]))
 ```
 
-## When the table grows
+## Troubleshooting
+
+| Symptom | What happened | Error / recovery |
+|---|---|---|
+| First `reg-route` throws | Forgot `(:require [re-frame.routing])` | `:rf.error/routing-artefact-missing` |
+| Registration throws on metadata | `:path` inside the map, or unknown bare key | `:rf.error/route-bad-metadata` — path is the **third** slot |
+| Two frames both claim the address bar | Two `:url-bound? true` | `:rf.error/duplicate-url-binding` — one owner |
+| Leave/enter always blocks | Guard sub returned non-boolean | `:rf.error/can-leave-non-boolean` / `:rf.error/can-enter-non-boolean` — return strict `true`/`false` |
+| `route-url` blows up | Missing path param | `:rf.error/missing-route-param` (nil query keys are elided, not thrown) |
+| Navigate rejected | Bad request map | `:rf.error/navigate-bad-request` |
+| Unmatched URL is a bare placeholder | Never registered `:rf.route/not-found` | Register it; params carry `:url` and optional `:reason` |
+| Plain `[:a {:href …}]` full-reloads | Not going through `route-link` | Use `route-link`, or a document-level click → `:rf.route/url-requested` |
+
+## When *not* to use routing
+
+| Situation | Prefer |
+|---|---|
+| Single-screen app, no shareable URLs | No routing artefact (zero cost) |
+| In-memory UI steps with no URL | app-db flags / a [machine](../machines/index.md) |
+| Server-only redirects | Host middleware or [SSR](../ssr/concepts.md) response effects |
+
+## Advanced
+
+### Hand-rolled async loader — capture the nav-token
+
+<a id="a-hand-rolled-async-loader"></a>
+
+`:on-match` and `:resources` are the everyday loaders. Roll your own async fetch and
+you inherit the race they close: open article A, navigate to B before A's reply
+lands, late A overwrites B. Capture the **navigation token** when the load starts
+and gate delivery on it.
+
+Two hooks: `:rf.route/nav-token` **cofx** injects the live token into an
+`:on-match` handler; `:rf.route/with-nav-token` **fx** delivers a reply only while
+that token still matches the current slice — otherwise suppresses and fires
+`:rf.route.nav-token/stale-suppressed`.
+
+```clojure
+;; Capture the live token, kick off your fetch, carry the token into the reply.
+(rf/reg-event :app/load-article
+  {:rf.cofx/requires [:rf.route/nav-token]}
+  (fn [{:rf.route/keys [nav-token] rt :rf.db/runtime} _]
+    (let [{:keys [id]} (get-in rt [:rf.runtime/routing :current :params])]
+      ;; :app/fetch-article is YOUR async effect; on reply it dispatches
+      ;; :app/article-arrived with the captured token + payload.
+      {:fx [[:app/fetch-article {:id id :on-reply [:app/article-arrived nav-token id]}]]})))
+
+;; Hand the CAPTURED token to :rf.route/with-nav-token. Fresh → :rf/reply-to runs;
+;; stale (newer navigation) → reply dropped before it can touch app-db.
+(rf/reg-event :app/article-arrived
+  (fn [_ [_ captured-token id payload]]
+    {:fx [[:rf.route/with-nav-token
+           {:rf/reply-to [:app/article-loaded id payload]
+            :nav-token   captured-token}]]}))
+
+(rf/reg-event :app/article-loaded
+  (fn [{:keys [db]} [_ id payload]]
+    {:db (assoc db :article/current payload)}))
+```
+
+`:resources` already does this — declare it and the race is closed. Hand-roll only
+when the resource layer doesn't cover you.
+
+### Keeping tokens off the wire
+
+<a id="keeping-tokens-off-the-wire"></a>
+
+```clojure
+(rf/reg-route :app/oauth-callback
+  {:query     [:map [:token :string] [:code :string]]
+   :sensitive [[:query :token] [:query :code]]}
+  "/oauth/callback")
+```
+
+Egress-only redaction while the route is active. Full story:
+[Keep secrets out of traces](../core/how-to/keep-secrets-out-of-traces.md).
+
+### URL strategies
+
+<a id="url-strategies"></a>
+
+```clojure
+(rf/make-frame {:id           :app
+                :url-bound?   true
+                :url-strategy rf.routing/hash-url-strategy})  ;; default: history-url-strategy
+```
+
+`route-url` / `match-url` stay path-form; strategy encodes `#` at the edges.
+`rf.routing/with-base-path` for deploy under a subpath. SSR ignores strategies (path
+form on the wire; client re-encodes on hydrate).
+
+<a id="converting-routes--urls-by-hand"></a>
+
+### Codec by hand
+
+```clojure
+(rf.routing/route-url {:to :app/article :params {:id "intro"}})
+;; => "/articles/intro"
+(rf.routing/match-url "/articles/intro")
+;; => {:route-id :app/article :params {:id "intro"} …}
+```
+
+Pure, JVM + CLJS. `nil` path param → throw; `nil` query param → elided.
 
 | Need | Where |
 |---|---|

--- a/docs/routing/glossary.md
+++ b/docs/routing/glossary.md
@@ -1,10 +1,14 @@
 # Routing glossary
 
-re-frame2's optional routing capability — the URL is an *input* to your app, the active route is ordinary state you read through subscriptions, and navigation is just an [event](../core/glossary.md#event). See [The model](concepts.md).
+Optional routing capability: the URL is an *input*, the active route is ordinary
+state via subscriptions, and navigation is an [event](../core/glossary.md#event).
+See [The model](concepts.md).
 
 ### **navigate**
 
-Change the route by dispatching navigation — the URL is an input, the active [route](#route) a [subscription](../core/glossary.md#subscription) you read like any other. Because it's an event, navigation is traceable, interceptable, and rewound by time-travel.
+Change the route by dispatching navigation. The active [route](#route) is a
+[subscription](../core/glossary.md#subscription) you read like any other. Because
+navigation is an event, it is traceable, interceptable, and rewound by time-travel.
 
 ```clojure
 (rf/dispatch [:rf.route/navigate {:to :app/article :params {:id "abc"}}])
@@ -14,36 +18,64 @@ Related: [The model](concepts.md).
 
 ### **route**
 
-A URL pattern registered (`reg-route`) under an id, paired with what should happen when it matches — `:params`/`:query` schemas, a [loader](#loader) for the data it needs, a [`:can-leave`](#route-guard) guard, scroll behaviour. The route table is your app's URL map.
+A URL pattern registered with `reg-route` under an id, paired with match behaviour —
+`:params`/`:query` schemas, a [loader](#loader), a [`:can-leave`](#route-guard) /
+`:can-enter` guard, scroll policy. The route table is the app's URL map.
 
 ### **route params**
 
-The active URL surfaced as state: read `:rf.route/id`, `:rf.route/params`, and `:rf.route/query` through subscriptions like any other derived value. Path params and `?query=` values (coerced and defaulted) drive your handlers and views — so `?page=2` survives the back button for free.
+The active URL as state: read `:rf.route/id`, `:rf.route/params`, and
+`:rf.route/query` through subscriptions. Path params and `?query=` values (coerced
+and defaulted) drive handlers and views; `?page=2` survives Back for free.
 
 ### **loader**
 
-What a [route](#route) declares it needs on entry — `:on-match` [events](../core/glossary.md#event) the runtime dispatches, and `:resources` it ensures are loaded — so a page's data requirement lives next to its URL. Loaders run on the server too, so there's no separate SSR data-fetch to keep in sync.
+What a [route](#route) declares it needs on entry — `:on-match` [events](../core/glossary.md#event)
+dispatched by the runtime, and/or `:resources` ensured loaded — so a page's data
+requirement sits next to its URL. Loaders also run on the server; no separate SSR
+data-fetch to keep in sync.
 
 ### **route chain**
 
-The active route's ancestry. A route names a `:parent`, and `@(subscribe [:rf.route/chain])` returns the lineage root-most first — on `/articles/intro`, `[:app/articles :app/article]`. It's how shared layouts work without an `<Outlet/>`: the leaf is the page, and each ancestor wraps a shell around it. See [Nested layouts](concepts.md#nested-layouts).
+The active route's ancestry. A route names a `:parent`; `@(subscribe [:rf.route/chain])`
+returns the lineage root-most first — on `/articles/intro`,
+`[:app/articles :app/article]`. Shared layouts without `<Outlet/>`: the leaf is the
+page; each ancestor wraps a shell. See [Nested layouts](concepts.md#nested-layouts).
 
 ### **transition**
 
-The route slice's loading state — `:idle`, `:loading` (a [loader](#loader) is still running), or `:error` (one failed) — read via `:rf.route/transition`. One global fact instead of per-page loading flags: a progress bar or an error banner is a single view over it.
+Route-slice loading state — `:idle`, `:loading` (a [loader](#loader) still running),
+or `:error` (one failed) — via `:rf.route/transition`. One global fact for a progress
+bar or error banner, not per-page loading flags.
 
 ### **nav-token**
 
-The counter that identifies one navigation. Route-declared resources are owned by the token that planned them, so a reply that lands after a newer navigation is quietly dropped instead of overwriting the page you're now on — the classic click-away race, fixed in the substrate. Hand-rolled loaders opt in via the `:rf.route/nav-token` coeffect.
+Counter that identifies one navigation. Route-declared resources are owned by the
+token that planned them; a reply after a newer navigation is dropped instead of
+overwriting the page you are on. Hand-rolled loaders opt in via the
+`:rf.route/nav-token` coeffect and `:rf.route/with-nav-token` fx.
 
 ### **route guard**
 
-A boolean subscription on a [route](#route): **`:can-leave`** (`true` = leave is fine) or **`:can-enter`** (`true` = enter is fine). A `false` parks the attempt in `[:rf/pending-navigation]`; your [view](../core/glossary.md#view) resolves it with `[:rf.route/continue <id>]` or `[:rf.route/cancel <id>]` (the pending-nav id). Unsaved-changes → leave guard ([recipe](how-to/guard-unsaved-changes.md)); per-route auth → enter guard; multi-route policy → optional interceptor ([recipe](how-to/require-sign-in-on-a-route.md)).
+A boolean subscription on a [route](#route): **`:can-leave`** (`true` = leave is fine)
+or **`:can-enter`** (`true` = enter is fine). `false` parks the attempt in
+`[:rf/pending-navigation]`; your [view](../core/glossary.md#view) resolves it with
+`[:rf.route/continue <id>]` or `[:rf.route/cancel <id>]` (the pending-nav id).
+Unsaved changes → leave guard ([recipe](how-to/guard-unsaved-changes.md)); per-route
+auth → enter guard; multi-route policy → optional interceptor
+([recipe](how-to/require-sign-in-on-a-route.md)).
 
 ### **not-found**
 
-The reserved [route](#route) (`:rf.route/not-found`) the runtime activates when no pattern matches — or when a URL's params fail their schema — with the offending URL in its params. It's an ordinary route you register and design; forget it and unmatched URLs get a bare placeholder.
+Reserved [route](#route) id `:rf.route/not-found`. The runtime activates it when no
+pattern matches — or when URL params fail their schema — with the offending URL in
+params. Ordinary route you register and design; skip it and unmatched URLs get a bare
+placeholder.
 
 ### **url-bound?**
 
-The flag declaring that *this* [frame](../core/glossary.md#frame) owns the browser address bar. At most one frame is url-bound at a time (none is legal — URL pushes then no-op); its navigations write the URL and back/forward (popstate) dispatch to it, while other frames route in-memory only — which is how a sidecar like [Xray](../core/glossary.md#xray) coexists without fighting over the URL.
+Flag that *this* [frame](../core/glossary.md#frame) owns the browser address bar. At
+most one frame is url-bound (none is legal — URL pushes then no-op). Its navigations
+write the URL; Back/Forward (popstate) dispatch to it. Other frames route in memory
+only — how a sidecar like [Xray](../core/glossary.md#xray) coexists without fighting
+over the URL.

--- a/docs/routing/how-to/guard-unsaved-changes.md
+++ b/docs/routing/how-to/guard-unsaved-changes.md
@@ -11,7 +11,9 @@ in `[:rf/pending-navigation]` → dialog dispatches `:rf.route/continue` or
 
 ## 1. Write the "is it safe to leave?" sub
 
-The guard is an ordinary [subscription](../../core/subscriptions.md) that answers one yes/no question. Read it positively: **`true` means leaving is fine.** Here, leaving is fine when the editor's draft matches what was last saved (nothing unsaved to lose):
+Ordinary [subscription](../../core/subscriptions.md). Read it positively: **`true`
+means leaving is fine.** Here, leaving is fine when the draft matches what was last
+saved:
 
 ```clojure
 (rf/reg-sub :editor/can-leave?
@@ -20,11 +22,13 @@ The guard is an ordinary [subscription](../../core/subscriptions.md) that answer
        (get-in db [:editor :saved]))))   ;; true when clean ⇒ safe to leave
 ```
 
-> **Gotcha — the contract is a strict boolean.** `true` allows, `false` blocks. Return anything else — a `nil`, a map, a truthy non-boolean — and the runtime **blocks the navigation** *and* emits `:rf.error/can-leave-non-boolean`. It fails closed (deny the leave) and fails loud (raise), never open. Keep the sub returning a real `true`/`false`.
+!!! warning "Strict boolean"
+
+    `true` allows, `false` blocks. Anything else (`nil`, map, truthy non-boolean) →
+    runtime **blocks** *and* emits `:rf.error/can-leave-non-boolean`. Deny the leave,
+    raise the error. Keep a real `true`/`false`.
 
 ## 2. Declare the guard on the route
-
-Name that sub in the route's `:can-leave`. From now on the runtime consults it before *any* navigation away from this route:
 
 ```clojure
 (rf/reg-route :app/article-editor
@@ -33,11 +37,15 @@ Name that sub in the route's `:can-leave`. From now on the runtime consults it b
   "/articles/:id/edit")
 ```
 
-When the guard returns `false`, nothing happens to the URL or to state — the navigation simply doesn't commit. Instead the attempt is parked, and the runtime also dispatches `:rf.route/navigation-blocked` (with a matching trace) so you can react beyond the dialog — a toast, an analytics ping.
+When the guard returns `false`, URL and state stay put — the navigation does not
+commit. The attempt parks, and the runtime dispatches `:rf.route/navigation-blocked`
+(with a matching trace) so you can react beyond the dialog (toast, analytics).
 
 ## 3. Render the prompt from the pending slot
 
-The blocked navigation lands in `:rf/pending-navigation`. Subscribe to it: when it's non-`nil`, a navigation is waiting on the reader's decision, so render your dialog. There's no imperative `window.confirm`, no `beforeunload` — it's an ordinary [view](../../core/views.md) over state:
+Blocked navigation lands in `:rf/pending-navigation`. Non-`nil` → show the dialog.
+No `window.confirm`, no `beforeunload` — ordinary [view](../../core/views.md) over
+state:
 
 ```clojure
 (rf/reg-view leave-guard-dialog []
@@ -49,21 +57,21 @@ The blocked navigation lands in `:rf/pending-navigation`. Subscribe to it: when 
      [:button {:on-click #(dispatch [:rf.route/continue (:id pending)])} "Discard & leave"]]))
 ```
 
-(`@(subscribe [:rf/pending-navigation])` is an ordinary framework sub.) The reader's
-choice is a dispatch carrying **`(:id pending)`**:
+Choice is a dispatch carrying **`(:id pending)`**:
 
-- `[:rf.route/continue <id>]` — proceed with the parked navigation (re-runs
-  `:can-enter` on the target if any).
+- `[:rf.route/continue <id>]` — proceed (re-runs `:can-enter` on the target if any).
 - `[:rf.route/cancel <id>]` — drop it; stay put.
 
-A bare `[:rf.route/continue]` / `[:rf.route/cancel]` without the id is wrong — the
+Bare `[:rf.route/continue]` / `[:rf.route/cancel]` without the id is wrong — the
 runtime keys the pending slot by that id (stale ids are safe no-ops).
 
-Mount `leave-guard-dialog` once near your root view and it covers every guarded route — it renders nothing until something is pending.
+Mount `leave-guard-dialog` once near the root; it covers every guarded route and
+renders nothing until something is pending.
 
 ## 4. Add a "save, then leave" path
 
-A "Save & close" button should leave *without* the prompt — the changes aren't being discarded, they're being saved. Save first, then navigate with `:bypass-guards? #{:leave}` so this one navigation skips the leave guard:
+"Save & close" should leave without the prompt. Save first, then navigate with
+`:bypass-guards? #{:leave}`:
 
 ```clojure
 (rf/reg-event :editor/save-and-close
@@ -71,33 +79,31 @@ A "Save & close" button should leave *without* the prompt — the changes aren't
     {:db (assoc-in db [:editor :saved] (get-in db [:editor :draft]))   ;; now clean
      :fx [[:dispatch [:rf.route/navigate {:to     :app/article
                                           :params {:id (get-in db [:editor :id])}
-                                          :bypass-guards? #{:leave}}]]]}))    ;; skip the prompt
+                                          :bypass-guards? #{:leave}}]]]}))
 ```
 
-Saving makes the draft and saved snapshots equal, so the guard would pass anyway — but `:bypass-guards? #{:leave}` makes the intent explicit and is the right tool whenever you *know* it's safe to leave. (The set form also lets you skip the target's `:can-enter` — `#{:enter}` — or both — `#{:leave :enter}`.)
+Saving would make the guard pass anyway — `:bypass-guards? #{:leave}` makes the
+intent explicit. Same set form skips the target's `:can-enter` (`#{:enter}`) or both
+(`#{:leave :enter}`).
 
 ## Test it with zero DOM
-
-Because the whole flow is events and a subscription, the test needs no browser, no `beforeunload`, no flaky modal automation:
 
 ```clojure
 ;; Land on the editor and make the draft dirty.
 (rf/dispatch-sync [:rf.route/navigate {:to :app/article-editor :params {:id "intro"}}])
 (rf/dispatch-sync [:editor/edit-field :title "changed"])   ;; draft ≠ saved
 
-;; Try to leave — it should be blocked and parked, not committed.
+;; Try to leave — blocked and parked, not committed.
 (rf/dispatch-sync [:rf.route/navigate {:to :app/home}])
-(is (= :app/article-editor @(rf/subscribe [:rf.route/id])))     ;; still here
-(is (some?                  @(rf/subscribe [:rf/pending-navigation])))  ;; parked
+(is (= :app/article-editor @(rf/subscribe [:rf.route/id])))
+(is (some?                  @(rf/subscribe [:rf/pending-navigation])))
 
-;; The reader confirms — continue takes the pending id.
+;; Reader confirms — continue takes the pending id.
 (rf/dispatch-sync [:rf.route/continue
                    (:id @(rf/subscribe [:rf/pending-navigation]))])
 (is (= :app/home @(rf/subscribe [:rf.route/id])))
 (is (nil?        @(rf/subscribe [:rf/pending-navigation])))
 ```
 
-That's the payoff of a guard that's *state*, not a side effect: every branch —
-blocked, confirmed, cancelled, bypassed — is a dispatch and an assertion.
-
-Also covered under [Testing routes](../testing.md).
+Every branch — blocked, confirmed, cancelled, bypassed — is a dispatch and an
+assertion. Also under [Testing routes](../testing.md).

--- a/docs/routing/how-to/require-sign-in-on-a-route.md
+++ b/docs/routing/how-to/require-sign-in-on-a-route.md
@@ -1,14 +1,14 @@
 # Require sign-in on a route
 
 You know routes are [queryable data](../concepts.md#routes-are-queryable-data). This
-page is one job: **one interceptor that bounces logged-out readers** off every
-route tagged `:requires-auth`.
+page is one job: **one interceptor that bounces logged-out readers** off every route
+tagged `:requires-auth`.
 
 **Prefer `:can-enter` first.** A single protected page should declare
-`{:can-enter [:auth/signed-in?]}` and handle `:rf.route/entry-blocked` — that is
-what [realworld_http](../../../examples/real-apps/realworld_http) does, and it covers
-all three entry doors without an interceptor. Use **this recipe** when one policy
-must span *many* routes uniformly (a whole admin section, a maintenance lockout).
+`{:can-enter [:auth/signed-in?]}` and handle `:rf.route/entry-blocked` — that is what
+[realworld_http](../../../examples/real-apps/realworld_http) does, and it covers all
+three entry doors without an interceptor. Use **this recipe** when one policy must
+span *many* routes (a whole admin section, a maintenance lockout).
 
 Full auth system (form, token, logout): [Add authentication](../../core/how-to/add-auth.md).
 
@@ -16,12 +16,9 @@ Full auth system (form, token, logout): [Add authentication](../../core/how-to/a
 
     Navigate, `route-link`, and URL-bar/reload/Back are three events. Guard only
     `:rf.route/navigate` and a logged-out paste of `/settings` walks in. Steps 2–3
-    normalise all three. (`:can-enter` already does that for free.)
+    normalise all three. (`:can-enter` already does that.)
 
 ## 1. Tag the protected routes
-
-Mark routes that need a session with **`:tags`**. Free-form — the framework attaches
-no meaning to `:requires-auth`; *you* do, in the guard:
 
 ```clojure
 (rf/reg-route :app/login    {} "/login")
@@ -29,56 +26,50 @@ no meaning to `:requires-auth`; *you* do, in the guard:
 (rf/reg-route :app/admin    {:tags #{:requires-auth}} "/admin")
 ```
 
-Readable anywhere: `(rf/handler-meta :route :app/settings)` → metadata including
-`:tags`.
+Free-form tags — the framework attaches no meaning to `:requires-auth`; *you* do in
+the guard. Readable anywhere: `(rf/handler-meta :route :app/settings)`.
 
-## 2. Know the three navigation entry points
+## 2. Normalise the three navigation entry points
 
-A reader reaches a route three different ways, each a different event:
-
-| Event | How it's triggered |
+| Event | Trigger |
 |---|---|
-| `:rf.route/navigate` | A programmatic push — `(dispatch [:rf.route/navigate …])`. |
-| `:rf.route/url-requested` | A `route-link` click. |
-| `:rf.route/handle-url-change` | The URL bar, a reload, Back/Forward (popstate). |
+| `:rf.route/navigate` | Programmatic push — `(dispatch [:rf.route/navigate …])` |
+| `:rf.route/url-requested` | A `route-link` click |
+| `:rf.route/handle-url-change` | URL bar, reload, Back/Forward (popstate) |
 
-Guard `:rf.route/navigate` alone and the third row defeats you: a logged-out reader pasting `/settings` into the address bar, or reloading a protected page, never goes through `navigate`. So the guard normalises **all three** to one "where are we headed?" target, then decides once:
+Normalise all three to one `{:id <route-id> :params <map>}` target (or `nil`), then
+decide once:
 
 ```clojure
 (:require [re-frame.routing :as rf.routing])   ;; match-url lives here, not on rf/
 
 (defn- matched-id
-  "match-url → {:id <route-id> :params <map>}, or nil for a non-match OR a
-   schema-invalid match (:validation-failed? true) — which the runtime routes
-   to not-found, so the guard must not tag-check a route it will never land on."
+  "match-url → {:id :params}, or nil for non-match / schema-invalid match
+   (:validation-failed? true — runtime sends those to not-found)."
   [url]
   (when-let [{:keys [route-id params validation-failed?]} (rf.routing/match-url url)]
     (when-not validation-failed?
       {:id route-id :params (or params {})})))
 
 (defn- nav-target
-  "Normalise any navigation event to {:id <route-id> :params <map>}, or nil —
-  for a non-navigation event, a non-match, or a malformed request the runtime's
-  own structural gate will reject (:rf.error/navigate-bad-request). `current` is
-  the current route slice ([:rf.runtime/routing :current]) — an in-place
-  navigate request (no :to / :url) means the route you are already on, so pass
-  it in and the guard resolves it exactly as the runtime does."
+  "Normalise any navigation event to {:id :params}, or nil.
+   `current` is [:rf.runtime/routing :current] — needed for in-place navigate
+   (no :to / :url): target is the route you are already on."
   [[ev-id a] current]
   (case ev-id
     :rf.route/navigate
-    (let [{:keys [to url params]} a]                     ;; a is the request map
+    (let [{:keys [to url params]} a]
       (cond
-        to  {:id to :params (or params {})}              ;; route-id destination
+        to  {:id to :params (or params {})}
 
-        url (matched-id url)                             ;; {:url ...} escape hatch
+        url (matched-id url)
 
-        ;; in-place: no :to/:url/:params, at least one query/fragment edit —
-        ;; stay on the current route (its id is what the tag check needs).
+        ;; in-place: query/fragment edit only — stay on current route
         (and (nil? params)
              (or (contains? a :query) (contains? a :query-merge) (contains? a :fragment)))
         {:id (:route-id current) :params (or (:params current) {})}
 
-        :else nil))                                      ;; malformed → router rejects
+        :else nil))   ;; malformed → router rejects with :rf.error/navigate-bad-request
 
     :rf.route/url-requested
     (let [{:keys [to params]} a]
@@ -91,49 +82,27 @@ Guard `:rf.route/navigate` alone and the third row defeats you: a logged-out rea
     nil))
 ```
 
-`match-url` is pure: URL string → match map, or `nil` when nothing resolves. `matched-id`
-wraps it in the two rejections a guard needs: a URL that matches nothing (`nil`) **and** a
-URL that matches but fails the route's `:params`/`:query` schema (`:validation-failed? true`)
-are *both* non-matches — the runtime routes a validation-failed URL to not-found, so the guard
-must not tag-check a route it will never land on. Either way the guard short-circuits rather
-than crash. Note the `:rf.route/navigate` branch
-also leans on it: navigate accepts a `{:url "/settings"}` **escape-hatch target** (deep
-links, server-side redirects, any URL the app didn't build itself), and a raw URL is not a
-route id — so the guard resolves it through `match-url` exactly as the runtime does before
-reading the route's `:tags`. Guard only the route-id form and a logged-out
-`[:rf.route/navigate {:url "/settings"}]` walks straight in.
+Misses that matter:
 
-`:rf.route/navigate` carries a **third** shape: an *in-place* request — no `:to` and no
-`:url` — which means *stay on the current route; change only the query* (search, pagination,
-tab switches). It names no route id, so the runtime resolves the target from the current
-route slice, and the guard must too. Miss it and the check fails **open** in the one place it
-matters most: a reader whose session has expired *while sitting on a protected route* can
-navigate in place (a `?page=2`, a tab switch) and the guard, seeing a request with no route
-id to check, waves it through. Resolving the in-place request against the current slice —
-`(:route-id current)` — makes the guard see `:app/settings`'s `:requires-auth` tag and fail
-**closed**, bouncing the expired session to login. That's why the interceptor reads the
-current slice out of the `:rf.db/runtime` coeffect and threads it into `nav-target`.
-
-One more distinction the normaliser must draw: a request that is *neither* a destination
-(`:to` / `:url`) *nor* a valid in-place edit (a `:query` / `:query-merge` / `:fragment`
-change) — say a bare `{:params …}` or a stray key — resolves to `nil`, not to the current
-route. Such a request is malformed, and the runtime's own always-on structural gate rejects it
-with `:rf.error/navigate-bad-request` before any navigation happens; the guard stands aside and
-lets it, rather than reclassifying a request that will never navigate as a valid guarded
-destination.
+- **`{:url …}` navigate** — resolve through `match-url` or a logged-out
+  `[:rf.route/navigate {:url "/settings"}]` walks in.
+- **In-place navigate** — resolve against `current` or an expired session on a
+  protected page can change `?page=` and the guard fails open.
+- **Neither destination nor in-place edit** — leave as `nil`; the runtime rejects
+  with `:rf.error/navigate-bad-request`. Do not reclassify as "current route."
+- **Schema-invalid URL** — treat as non-match (`nil`); not-found handles it.
 
 ## 3. Redirect with skip-and-dispatch
 
-Now the guard itself: one interceptor, registered once, that runs `:before` every event. For a navigation toward a `:requires-auth` route with no signed-in user, it **skips** the original handler (so the protected route never commits and its loaders never fire) and dispatches the login navigation instead:
+One interceptor, registered once, `:before` every event. Toward a `:requires-auth`
+route with no signed-in user: **skip** the original handler (protected route never
+commits; loaders never fire) and dispatch login:
 
 ```clojure
 (rf/reg-interceptor :app/auth-guard
   {:doc "Redirect logged-out readers away from :requires-auth routes."}
   {:before
    (fn [ctx]
-     ;; The current route slice is framework runtime-db state — read it from
-     ;; the :rf.db/runtime coeffect so an in-place navigate request resolves
-     ;; to the protected route the reader is already on.
      (if-let [{:keys [id]} (nav-target (get-in ctx [:coeffects :event])
                                        (get-in ctx [:coeffects :rf.db/runtime
                                                     :rf.runtime/routing :current]))]
@@ -141,27 +110,32 @@ Now the guard itself: one interceptor, registered once, that runs `:before` ever
              signed-in?  (some? (get-in ctx [:coeffects :db :auth :user]))]
          (if (and needs-auth? (not signed-in?))
            (-> ctx
-               (assoc :rf/skip-handler? true)                    ;; protected route never commits
+               (assoc :rf/skip-handler? true)
                (assoc-in [:effects :fx]
                          [[:dispatch [:rf.route/navigate {:to :app/login}]]]))
            ctx))
-       ctx))})              ;; not a navigation ⇒ pass through untouched
+       ctx))})
 ```
 
-Two reads do the work, both pure: `rf/handler-meta` pulls the route's `:tags`, and the `:db` in `:coeffects` says whether anyone's signed in. `:rf/skip-handler?` is the public short-circuit primitive — set it in a `:before` and the original handler is skipped.
+Two pure reads: `rf/handler-meta` for `:tags`, `:db` in coeffects for the session.
+`:rf/skip-handler?` is the public short-circuit — set it in `:before` and the
+original handler is skipped.
 
-> **Gotcha — redirect, don't rewrite.** The runtime picks the handler from the *original* event id, so editing the event in `:before` would just run the wrong handler. Skip the original and dispatch a fresh navigation, as above.
+!!! warning "Redirect, don't rewrite"
+
+    The runtime picks the handler from the *original* event id. Editing the event in
+    `:before` runs the wrong handler. Skip and dispatch a fresh navigation.
 
 ## 4. Attach the guard to the frame
-
-Register the guard once, then name it by id in the frame's `:interceptors`. It short-circuits in a single `case` for every non-navigation event, so the cost on ordinary traffic is negligible:
 
 ```clojure
 (rf/make-frame
   {:id :rf/default
    :doc          "The app frame."
    :url-bound?   true
-   :interceptors [:app/auth-guard]})    ;; reference the registered guard by id
+   :interceptors [:app/auth-guard]})
 ```
 
-That's the routing half done: protected routes are tagged, all three entry points are gated, and a logged-out reader is bounced to `/login`. The rest of the auth flow — the login form, the token, logout — is [Add authentication](../../core/how-to/add-auth.md), whose route guard is exactly this one.
+Non-navigation events short-circuit in one `case` — cost on ordinary traffic is
+negligible. Protected routes tagged, all three doors gated, logged-out reader bounced
+to `/login`. Rest of the auth flow: [Add authentication](../../core/how-to/add-auth.md).

--- a/docs/routing/testing.md
+++ b/docs/routing/testing.md
@@ -10,7 +10,10 @@ touches the address bar — the route slice is state you assert on.
 
 > **The URL codec is a pure function you call; a navigation is a dispatch you drive; the slice is state you read.**
 
-The setup is the same as the [core testing pages](../core/testing/index.md): a JVM test namespace that requires the app namespaces (loading them performs the `reg-route` calls) plus the reset fixture, since routes live in the process-global registrar and the runtime keeps per-process routing state the fixture knows how to reset:
+Same setup as the [core testing pages](../core/testing/index.md): a JVM test namespace
+that requires the app namespaces (loading them runs the `reg-route` calls) plus the
+reset fixture — routes live in the process-global registrar and the runtime keeps
+per-process routing state the fixture knows how to reset:
 
 ```clojure
 (ns my-app.routing-test
@@ -25,7 +28,8 @@ The setup is the same as the [core testing pages](../core/testing/index.md): a J
 
 ## 1. The URL codec: two pure functions
 
-`route-url` and `match-url` are pure, JVM-runnable, and exact inverses — so the URL grammar of your whole route table unit-tests as plain function calls:
+`route-url` and `match-url` are pure, JVM-runnable, and exact inverses — the URL
+grammar of the whole route table unit-tests as plain function calls:
 
 ```clojure
 (deftest article-urls-round-trip
@@ -37,18 +41,25 @@ The setup is the same as the [core testing pages](../core/testing/index.md): a J
   (let [m (rf.routing/match-url "/search?q=clojure&page=2")]
     (is (= :app/search (:route-id m)))
     (is (= 2 (get-in m [:query :page]))))
-  ;; and the misses are values, not exceptions
+  ;; misses are values, not exceptions
   (is (nil? (rf.routing/match-url "/no/such/page")))
   (is (:validation-failed? (rf.routing/match-url "/search?q=x&page=abc"))))
 ```
 
-!!! warning "Gotcha — the nil-policy asymmetry is worth a test of its own"
+!!! warning "Nil-policy asymmetry"
 
-    A `nil` **path** param is a hard error — `route-url` throws `:rf.error/missing-route-param`, because there's no URL to build without the segment; a `nil` **query** param is *silently elided* (`{:page nil}` just omits the key). If your app leans on the elision — "only add `?sort=` when chosen" — pin it: `(is (= "/search?q=x" (rf.routing/route-url {:to :app/search :query {:q "x" :sort nil}})))`.
+    A `nil` **path** param is a hard error — `route-url` throws
+    `:rf.error/missing-route-param`. A `nil` **query** param is *silently elided*
+    (`{:page nil}` omits the key). If the app leans on elision — "only add `?sort=`
+    when chosen" — pin it:
+    `(is (= "/search?q=x" (rf.routing/route-url {:to :app/search :query {:q "x" :sort nil}})))`.
 
 ## 2. Navigation through a test frame
 
-The wiring — navigate event in, slice out — is a [pipeline-run test](../core/testing/pipeline-runs.md): dispatch into a fresh frame, read the route subs. Inside `with-new-frame` the plain subs resolve against the test frame:
+Wiring — navigate event in, slice out — is a
+[pipeline-run test](../core/testing/pipeline-runs.md): dispatch into a fresh frame,
+read the route subs. Inside `with-new-frame` the plain subs resolve against the test
+frame:
 
 ```clojure
 (deftest navigate-writes-the-slice
@@ -58,11 +69,17 @@ The wiring — navigate event in, slice out — is a [pipeline-run test](../core
     (is (= {:id "intro"} @(rf/subscribe [:rf.route/params])))))
 ```
 
-If the route declares `:on-match` loaders, they dispatch inside the same drain — so a loader that fires a [managed HTTP](../async/http.md) request wants the same canned-reply stubs a pipeline-run test uses, and `@(rf/subscribe [:rf.route/transition])` gives you the `:idle` / `:loading` / `:error` fact to assert. A loader failure lands the structured error in `@(rf/subscribe [:rf.route/error])` — assert on its category, [never its prose](../core/errors.md#test-the-structure-not-the-string).
+If the route declares `:on-match` loaders, they dispatch inside the same drain — a
+loader that fires [managed HTTP](../async/http.md) wants the same canned-reply stubs
+a pipeline-run test uses. `@(rf/subscribe [:rf.route/transition])` is the
+`:idle` / `:loading` / `:error` fact; loader failure lands a structured error in
+`@(rf/subscribe [:rf.route/error])` — assert on its category,
+[never its prose](../core/errors.md#test-the-structure-not-the-string).
 
 ## 3. Deep links, and the 404
 
-The URL-entry path — a pasted link, a reload, back/forward, and the SSR request — all funnel through one event, `:rf.route/handle-url-change`, and you can drive it directly:
+Pasted link, reload, back/forward, and the SSR request all funnel through
+`:rf.route/handle-url-change` — drive it directly:
 
 ```clojure
 (deftest deep-link-resolves
@@ -74,30 +91,33 @@ The URL-entry path — a pasted link, a reload, back/forward, and the SSR reques
   (rf/with-new-frame [f (rf/make-frame {})]
     (rf/dispatch-sync [:rf.route/handle-url-change "/no/such/page"])
     (is (= :rf.route/not-found @(rf/subscribe [:rf.route/id])))
-    ;; the params carry the offending URL — and a :reason for the other misses
+    ;; params carry the offending URL — and a :reason for other misses
     (is (= "/no/such/page" (:url @(rf/subscribe [:rf.route/params]))))))
 ```
 
-The `:reason` discriminator distinguishes a plain miss from a schema failure (`:validation`) from malformed percent-encoding (`:malformed-url`) — each worth one assertion if your not-found view branches on it.
+`:reason` distinguishes plain miss, schema failure (`:validation`), and malformed
+percent-encoding (`:malformed-url`) — one assertion each if the not-found view
+branches on it.
 
 ## 4. The leave guard, with zero DOM
 
-The `:can-leave` flow is deliberately testable without a browser: the guard is a subscription, the blocked navigation is *state*, and the user's choice is a dispatch. So the whole are-you-sure flow is four asserts:
+`:can-leave` is a subscription; blocked navigation is *state*; the user's choice is a
+dispatch. Whole flow, four asserts:
 
 ```clojure
 (deftest leave-guard-parks-and-continues
-  ;; the frame BOOTS on the guarded editor with unsaved changes — that's setup,
-  ;; so it rides :initial-events; the body dispatches only the moves under test
+  ;; frame BOOTS on the guarded editor with unsaved changes — setup rides
+  ;; :initial-events; body dispatches only the moves under test
   (rf/with-new-frame [f (rf/make-frame
                           {:initial-events
                            [[:rf.route/navigate {:to :app/article-editor :params {:id "intro"}}]
                             [:editor/typed "draft text"]]})]
-    ;; try to leave: the navigation parks, the slice doesn't move
+    ;; try to leave: navigation parks, slice doesn't move
     (rf/dispatch-sync [:rf.route/navigate {:to :app/home}])
     (is (some? @(rf/subscribe [:rf/pending-navigation])))
     (is (= :app/article-editor @(rf/subscribe [:rf.route/id])))
 
-    ;; the user chooses: continue takes the pending-nav id
+    ;; user chooses: continue takes the pending-nav id
     (rf/dispatch-sync [:rf.route/continue
                        (:id @(rf/subscribe [:rf/pending-navigation]))])
     (is (nil? @(rf/subscribe [:rf/pending-navigation])))
@@ -105,13 +125,17 @@ The `:can-leave` flow is deliberately testable without a browser: the guard is a
 ```
 
 Dispatch `[:rf.route/cancel <id>]` instead and the pending slot clears with the slice
-unmoved — one more test, same shape. A `{:bypass-guards? #{:leave}}` navigate opt
-skips the park entirely. The `:can-enter` mirror tests the same way — guarded target,
-signed-out sub, assert pending fills with `:direction :enter`, then flip the sub and
-`[:rf.route/continue <id>]` (re-runs `:can-enter`).
+unmoved. `{:bypass-guards? #{:leave}}` skips the park. The `:can-enter` mirror tests
+the same way — guarded target, signed-out sub, assert pending fills with
+`:direction :enter`, then flip the sub and `[:rf.route/continue <id>]` (re-runs
+`:can-enter`).
 
 ## What lives elsewhere
 
-- **Auth-guard interceptors** over the navigation events are ordinary [interceptors — tested like any other](../core/interceptors.md#testing-an-interceptor); [Require sign-in on a route](how-to/require-sign-in-on-a-route.md) is the recipe they guard.
-- **Route-declared `:resources`** are the resources artefact's territory — [Testing resources](../resources/testing.md) covers ensuring, stubbing, and reading them; the route is just the cause.
-- **The server side** needs no separate route tests: the same `handle-url-change` event you drove above is what SSR feeds the request URL to — [Testing SSR](../ssr/testing.md).
+- **Auth-guard interceptors** over navigation events are ordinary
+  [interceptors — tested like any other](../core/interceptors.md#testing-an-interceptor);
+  [Require sign-in on a route](how-to/require-sign-in-on-a-route.md) is the recipe.
+- **Route-declared `:resources`** — [Testing resources](../resources/testing.md)
+  covers ensuring, stubbing, and reading; the route is just the cause.
+- **Server side** needs no separate route tests: the same `handle-url-change` event
+  is what SSR feeds the request URL to — [Testing SSR](../ssr/testing.md).

--- a/docs/routing/tutorial.md
+++ b/docs/routing/tutorial.md
@@ -10,7 +10,9 @@ Vocabulary after this walk-through: [The model](concepts.md). From React Router:
 
 ## Step 0 — turn routing on
 
-Routing ships as its own package, `day8/re-frame2-routing`, so an app with no shareable URLs pays nothing for it. Add the dependency, then require the namespace once at boot:
+Routing ships as its own package, `day8/re-frame2-routing`, so an app with no
+shareable URLs pays nothing for it. Add the dependency, then require the namespace
+once at boot:
 
 ```clojure
 (ns app.core
@@ -18,11 +20,16 @@ Routing ships as its own package, `day8/re-frame2-routing`, so an app with no sh
             [re-frame.routing]))   ;; ← requiring it is what turns routing on
 ```
 
-That bare `[re-frame.routing]` require has a side effect: it wires up `reg-route`, the route subscriptions, and `route-link`. Forget it and your first `reg-route` throws `:rf.error/routing-artefact-missing` — a loud error that names exactly what to require, not a silent no-op.
+That bare `[re-frame.routing]` require has a side effect: it wires up `reg-route`,
+the route subscriptions, and `route-link`. Forget it and the first `reg-route` throws
+`:rf.error/routing-artefact-missing` — a loud error that names exactly what to
+require, not a silent no-op.
 
 ## Step 1 — your first route, on screen
 
-A route is one row in a table: an **id**, a **metadata map**, and a **path**. Register the home page, give the root view a `case` to pick pages with, and mount the app so you can watch every step from here on:
+A route is one row in a table: an **id**, a **metadata map**, and a **path**.
+Register the home page, give the root view a `case` over the active route, and mount
+so you can watch every step from here on:
 
 ```clojure
 ;; 1. Register the route: id, metadata, path.
@@ -30,16 +37,15 @@ A route is one row in a table: an **id**, a **metadata map**, and a **path**. Re
 
 ;; 2. The root view reads the active route id and picks a page.
 ;;    Inside reg-view you call `subscribe` unprefixed — the macro binds it
-;;    to this view's frame for you. (Outside a view, reach through the facade:
-;;    `rf/subscribe`, `rf/dispatch`.)
+;;    to this view's frame. (Outside a view: `rf/subscribe`, `rf/dispatch`.)
 (rf/reg-view root-view []
   (case @(subscribe [:rf.route/id])
     :app/home [:h1 "Home"]
     [:h1 "Nothing here yet"]))   ;; any URL we haven't routed — Step 5 retires this
 
-;; 3. Mount it — the standard mount from the Quickstart, plus one routing
-;;    flag that Step 6 explains properly. (Also requires:
-;;    [reagent.dom.client :as rdc] [re-frame.adapter.reagent :as reagent-adapter])
+;; 3. Mount — standard Quickstart mount, plus one routing flag Step 6 explains.
+;;    (Also requires: [reagent.dom.client :as rdc]
+;;     [re-frame.adapter.reagent :as reagent-adapter])
 (defn run []
   (rf/init! reagent-adapter/adapter)
   (rdc/render (rdc/create-root (js/document.getElementById "app"))
@@ -47,15 +53,20 @@ A route is one row in a table: an **id**, a **metadata map**, and a **path**. Re
                [root-view]]))
 ```
 
-`@(subscribe [:rf.route/id])` reads the id of the route that matches the current URL. The root view is a plain `case` over that id — pick a page, render it. That's the entire "router": no `<Routes>`, no `<Switch>`, no nesting.
+`@(subscribe [:rf.route/id])` is the id of the route that matches the current URL.
+The root view is a plain `case` over that id — pick a page, render it. That's the
+entire "router": no `<Routes>`, no `<Switch>`, no nesting.
 
-The routing flag in the mount is `:url-bound? true`, which says this frame is the one that owns the browser address bar. Take it on faith for now — Step 6 comes back to it when we wire the Back button.
+`:url-bound? true` says this frame owns the browser address bar. Take it on faith
+for now — Step 6 comes back when we wire the Back button.
 
-**What you see:** at `/`, the page shows **Home**. Any other URL shows the placeholder — for now.
+**What you see:** at `/`, the page shows **Home**. Any other URL shows the
+placeholder — for now.
 
 ## Step 2 — a second page, and a link between them
 
-Add an articles page, and a link to reach it. Links use `route-link`, which renders a real `<a href>` and turns a plain click into navigation:
+Add an articles page and a link. `route-link` renders a real `<a href>` and turns a
+plain click into navigation:
 
 ```clojure
 (rf/reg-route :app/home     {} "/")
@@ -76,11 +87,16 @@ Add an articles page, and a link to reach it. Links use `route-link`, which rend
     [:h1 "Nothing here yet"]))
 ```
 
-`route-link` builds the URL from the route id, so you never hand-write `href="/articles"`. Change the route's path later and every link follows — there's one place the URL is synthesised.
+`route-link` builds the URL from the route id — you never hand-write
+`href="/articles"`. Change the path later and every link follows.
 
-**What you see:** Home shows a link; clicking it swaps to **Articles** with no full-page reload, and the address bar reads `/articles`.
+**What you see:** Home shows a link; clicking it swaps to **Articles** with no
+full-page reload, and the address bar reads `/articles`.
 
-> **Why a real `<a>`?** Because hover-preview, copy-link, and — crucially — cmd/ctrl/middle-click-to-open-in-new-tab all keep working. `route-link` intercepts only the plain left-click; modifier clicks defer to the browser. A hand-rolled `[:div {:on-click …}]` quietly breaks all of that.
+> **Why a real `<a>`?** Hover-preview, copy-link, and cmd/ctrl/middle-click-to-open
+> in a new tab keep working. `route-link` intercepts only the plain left-click;
+> modifier clicks defer to the browser. A hand-rolled `[:div {:on-click …}]` quietly
+> breaks all of that.
 
 ## Step 3 — a page per item: dynamic segments
 
@@ -92,7 +108,10 @@ A detail page needs the article's id *in the URL*. A colon segment captures it:
   "/articles/:id")
 ```
 
-The `:id` in `/articles/:id` is a hole the matcher fills. The `:params` [schema](../core/how-to/validate-with-schemas.md) both validates it and coerces it — declare `[:id :int]` and `/articles/42` arrives as the number `42`, not the string `"42"`. Read the captured params with a subscription:
+The `:id` in `/articles/:id` is a hole the matcher fills. The `:params`
+[schema](../core/how-to/validate-with-schemas.md) validates and coerces — declare
+`[:id :int]` and `/articles/42` arrives as the number `42`, not `"42"`. Read captured
+params with a subscription:
 
 ```clojure
 (rf/reg-view article-page []
@@ -100,28 +119,36 @@ The `:id` in `/articles/:id` is a hole the matcher fills. The `:params` [schema]
     [:h1 (str "Article " id)]))
 ```
 
-Link to it by passing `:params`:
+Link by passing `:params`:
 
 ```clojure
 [rf/route-link {:to :app/article :params {:id "intro"}} "Read intro"]
 ```
 
-**What you see:** clicking the link lands on `/articles/intro`, and the page reads **Article intro**. (Add `:app/article [article-page]` to the root view's `case` — each new page gets its row.)
+**What you see:** click lands on `/articles/intro`, page reads **Article intro**.
+(Add `:app/article [article-page]` to the root `case`.)
 
-> **Path params vs query params.** `:params` are the `/segments/` of the path. Query-string values (`?page=2`) are a *separate* map you declare with `:query` and read with `@(subscribe [:rf.route/query])` — the two never merge into one bag. [The model → Move 1](concepts.md#move-1-a-route-is-a-registry-entry) covers `:query`, defaults, and carrying global state like `?theme=dark` across pages.
+> **Path params vs query params.** `:params` are the `/segments/` of the path.
+> Query-string values (`?page=2`) are a *separate* map — declare with `:query`, read
+> with `@(subscribe [:rf.route/query])`. The two never merge. [The model → Move 1](concepts.md#move-1-a-route-is-a-registry-entry)
+> covers `:query`, defaults, and carrying global state like `?theme=dark` across pages.
 
 ## Step 4 — give a page its data
 
-Most pages need data when they open. Declare it next to the route with `:on-match` — a list of ordinary events the runtime dispatches whenever the route activates:
+Most pages need data when they open. Declare it next to the route with `:on-match` —
+events the runtime dispatches whenever the route activates:
 
 ```clojure
 (rf/reg-route :app/article
   {:params   [:map [:id :string]]
-   :on-match [[:app/load-article]]}   ;; dispatched on entry, and on every :id change
+   :on-match [[:app/load-article]]}   ;; on entry, and on every :id change
   "/articles/:id")
 ```
 
-Now the loader itself. It's a normal event handler, with one new thing to learn: it needs the article's `:id`, and that lives in the **route slice**, which the framework keeps in [runtime-db](../core/glossary.md#runtime-db) — its own partition beside your app-db. Handlers receive that partition under the `:rf.db/runtime` key, right next to `:db`:
+The loader is a normal event handler. It needs the article `:id`, which lives in the
+**route slice** in [runtime-db](../core/glossary.md#runtime-db) — the framework
+partition beside app-db. Handlers receive that partition under `:rf.db/runtime`, next
+to `:db`:
 
 ```clojure
 (def sample-articles                            ;; stand-in for your server
@@ -140,7 +167,7 @@ Now the loader itself. It's a normal event handler, with one new thing to learn:
 (rf/reg-sub :article/current (fn [db _] (:article/current db)))
 ```
 
-And the detail page from Step 3 now reads the loaded article, like any other state:
+Detail page from Step 3 now reads the loaded article like any other state:
 
 ```clojure
 (rf/reg-view article-page []
@@ -148,15 +175,27 @@ And the detail page from Step 3 now reads the loaded article, like any other sta
     [:h1 (or (:title article) "Loading…")]))
 ```
 
-There's no special "loader data" hook, because the loader just wrote to [app-db](../core/app-db.md) like every other event. And `:on-match` re-fires when the `:id` changes but *not* when you navigate to the same route with identical params, so you never get an accidental double-load.
+No special "loader data" hook — the loader wrote to [app-db](../core/app-db.md) like
+every other event. `:on-match` re-fires when `:id` changes, not when you re-navigate
+to the same route with identical params — no accidental double-load.
 
-**What you see:** click through to `/articles/intro` and the title appears. Navigate to another article and the loader fires again with the new id; re-navigate to the *same* one and it doesn't. Open [Xray](../xray/index.md) and you'll see exactly those dispatches on the wire.
+**What you see:** click through to `/articles/intro` and the title appears. Navigate
+to another article and the loader fires again; re-navigate to the *same* one and it
+doesn't. Open [Xray](../xray/index.md) and you'll see those dispatches on the wire.
 
-> **This is the loader — as data.** Because `:on-match` is a vector of event vectors rather than a function, you can read it, test it, and draw a route's data-dependency graph from it without running it: `(rf/handler-meta :route :app/article)` hands you the list. The same events run on the server during [SSR](../ssr/concepts.md) — there's no separate server loader to keep in sync. For server *state* (cached, deduplicated fetches with a built-in click-away race fix), declare `:resources` instead — see [The model → Loaders](concepts.md#loaders-declaring-a-pages-data). Hand-rolling your own async fetch means owning that race yourself: capture the navigation token when the load starts and gate delivery on it, or a slow reply for one article overwrites the one you navigated to next — see [a hand-rolled async loader](concepts.md#a-hand-rolled-async-loader).
+> **Loader as data.** `:on-match` is a vector of event vectors, not a function — you
+> can read it, test it, and draw a data-dependency graph without running it:
+> `(rf/handler-meta :route :app/article)`. The same events run on the server during
+> [SSR](../ssr/concepts.md). For cached server state, declare `:resources` instead —
+> [The model → Loaders](concepts.md#loaders-declaring-a-pages-data). Hand-rolling your
+> own async fetch means owning the click-away race: capture the navigation token and
+> gate delivery, or a slow reply overwrites the page you navigated to next —
+> [hand-rolled async loader](concepts.md#a-hand-rolled-async-loader).
 
 ## Step 5 — when nothing matches: the 404
 
-When no route matches a URL, the runtime activates a reserved id, `:rf.route/not-found`, with the missed URL dropped into its params. You register it like any other route — you own the design:
+When no route matches, the runtime activates reserved id `:rf.route/not-found`, with
+the missed URL in its params. Register it like any other route:
 
 ```clojure
 (rf/reg-route :rf.route/not-found {} "/_404")
@@ -176,15 +215,19 @@ When no route matches a URL, the runtime activates a reserved id, `:rf.route/not
     :rf.route/not-found [not-found-page]))
 ```
 
-The "Nothing here yet" placeholder arm is gone — and that's the point. Now that `:rf.route/not-found` is registered, every URL lands on a real route id, so the `case` always has a page to pick.
+The "Nothing here yet" arm is gone. Every URL lands on a real route id, so the `case`
+always has a page.
 
-**What you see:** visit `/nonsense` and your own 404 renders, with `/nonsense` shown back to the reader.
+**What you see:** visit `/nonsense` and your own 404 renders, with `/nonsense` shown
+back.
 
-> Register it. Skip it and unmatched URLs fall to a bare built-in placeholder (plus a warning) — something renders, but not your design. The not-found params also carry a `:reason` so you can tell a plain miss from a malformed URL from a failed schema; see [The model → Not found](concepts.md#not-found-is-a-route-you-register).
+> Register it. Skip it and unmatched URLs fall to a bare built-in placeholder (plus a
+> warning). Not-found params also carry a `:reason` so you can tell a plain miss from
+> a malformed URL from a failed schema; see [The model → Not found](concepts.md#not-found-is-a-route-you-register).
 
 ## Step 6 — the Back button and deep links
 
-Back in Step 1, the mount had one routing flag you took on faith. Time to cash that in — it's what makes the Back button, refreshes, and shared links work:
+Step 1's mount flag is what makes Back, refreshes, and shared links work:
 
 ```clojure
 (defn run []
@@ -195,24 +238,36 @@ Back in Step 1, the mount had one routing flag you took on faith. Time to cash t
                [root-view]]))
 ```
 
-`:url-bound? true` says *this* [frame](../core/frames.md) owns the browser URL. When it navigates, the address bar updates; a frame without the flag routes purely in memory, which is exactly what a test frame wants.
+`:url-bound? true` says *this* [frame](../core/frames.md) owns the browser URL. When
+it navigates, the address bar updates; a frame without the flag routes purely in
+memory — what a test frame wants.
 
-Declaring it also does two jobs automatically, the moment the frame is created — no separate call to make. At startup, it syncs the current URL into state — so a deep link or a refresh lands on the right page instead of always starting at home. From then on, every Back/Forward press is delivered to the owning frame as an ordinary dispatch. It's idempotent, so hot-reload is safe.
+At startup it syncs the current URL into state — deep link or refresh lands on the
+right page. From then on every Back/Forward press is an ordinary dispatch. Idempotent,
+so hot-reload is safe.
 
-**What you see:** paste `/articles/intro` straight into the address bar and the app boots onto that article. Then navigate Home → Articles → an article and press Back twice — each press steps the page back, because a Back press is now, literally, a dispatch.
+**What you see:** paste `/articles/intro` into the address bar and the app boots onto
+that article. Navigate Home → Articles → an article and press Back twice — each press
+steps the page back, because Back is a dispatch.
 
-> **One mount shape, two spellings.** `frame-root {:id …}` *creates* the frame if it doesn't exist — handy for a small app that boots everything in one spot. Elsewhere you'll see the two-step spelling: `make-frame` first, then `frame-provider {:frame …}` to scope it. Same frame, same result; the second form just makes the construction explicit.
+> **One mount shape, two spellings.** `frame-root {:id …}` *creates* the frame if it
+> doesn't exist — handy for a small app. Elsewhere: `make-frame` first, then
+> `frame-provider {:frame …}` to scope it. Same frame, same result.
 
-> **The inversion.** In most routers the URL is the source of truth and your app reacts to it. Here your frame's state is the truth and the URL is a *print-out* of it — which is why [time-travel](../xray/index.md) rewinds the URL for free. [The model → The browser is just another event source](concepts.md#the-browser-is-just-another-event-source) goes deeper.
+> **The inversion.** Most routers treat the URL as truth and the app as a reaction.
+> Here the frame's state is truth and the URL is a *print-out* — which is why
+> [time-travel](../xray/index.md) rewinds the URL for free. [The model → The browser is just another event source](concepts.md#the-browser-is-just-another-event-source).
 
 ## Step 7 — a shared layout
 
-Our article pages should sit inside a shell — a section header, a "back to all articles" nav — without each page repeating it. In re-frame2, nesting is **data**: a child route names a `:parent`, and a subscription hands you the chain so you compose the shells yourself.
+Article pages should sit inside a shell — section header, "back to all articles" —
+without each page repeating it. Nesting is **data**: a child route names a
+`:parent`, and a subscription hands you the chain so you compose the shells yourself.
 
 Point the detail page at a parent — and **carry the whole metadata map forward**.
 `reg-route` is full replacement, not a merge: re-registering `:app/article` with only
-`:parent` and `:params` would silently drop the `:on-match` loader you added in Step 4.
-Keep every key you still want:
+`:parent` and `:params` would drop the `:on-match` loader from Step 4. Keep every key
+you still want:
 
 ```clojure
 (rf/reg-route :app/articles {} "/articles")
@@ -222,7 +277,9 @@ Keep every key you still want:
   "/articles/:id")
 ```
 
-Now `@(subscribe [:rf.route/chain])` returns the active route's ancestry, **root-most first** — on `/articles/intro` it's `[:app/articles :app/article]`. Two jobs fall out of that vector:
+`@(subscribe [:rf.route/chain])` returns the active route's ancestry, **root-most
+first** — on `/articles/intro` it's `[:app/articles :app/article]`. Two jobs fall out
+of that vector:
 
 ```clojure
 ;; The LEAF of the chain is the page you're on.
@@ -243,25 +300,32 @@ Now `@(subscribe [:rf.route/chain])` returns the active route's ancestry, **root
   [:div.site
    [:header "My Site"]                       ;; site-wide chrome needs no routing
    (let [chain @(subscribe [:rf.route/chain])]
-     ;; Fold from the leaf outward: the page becomes the child of its parent's
-     ;; shell, which becomes the child of its parent's shell, and so on.
+     ;; Fold from the leaf outward: page becomes child of parent's shell, etc.
      (reduce (fn [inner ancestor] (ancestor-shell ancestor inner))
              (page-for (last chain))         ;; start: the leaf page
              (reverse (butlast chain))))])   ;; wrap: ancestors, innermost first
 ```
 
-If the fold feels abstract, trace it once. On `/articles/intro` the chain is `[:app/articles :app/article]`, so the `reduce` computes:
+If the fold feels abstract, trace it once. On `/articles/intro` the chain is
+`[:app/articles :app/article]`, so the `reduce` computes:
 
 ```clojure
 (ancestor-shell :app/articles (page-for :app/article))
 ;; ⇒ [:div.articles-section [:nav "← All articles"] [article-page]]
 ```
 
-One wrap, from the inside out. A deeper chain just wraps more times.
+One wrap, from the inside out. A deeper chain wraps more times.
 
-**What you see:** on `/articles/intro`, the article renders inside the `← All articles` section nav, under the site header — and every article detail page shares that frame with no copy-paste. Plain `/articles` (no parent above it) shows the bare list; `/` shows the home page. Note the split: truly *global* chrome (the `My Site` header) is just rendered in the root view — you only reach for the chain when a shell wraps a *subtree*.
+**What you see:** on `/articles/intro`, the article renders inside the
+`← All articles` section nav, under the site header — every article detail page
+shares that frame with no copy-paste. Plain `/articles` shows the bare list; `/`
+shows home. Global chrome (the `My Site` header) is just rendered in the root view —
+reach for the chain only when a shell wraps a *subtree*.
 
-> **Coming from React Router?** This is the job `<Outlet/>` does there. The trade is deliberate: instead of a routing-specific render slot, you compose plain Clojure with the `case`/`reduce` you'd write for any conditional view. It's the one place routing asks a little more of you — and the only routing-specific piece is the one `:rf.route/chain` read. [The model → Nested layouts](concepts.md#nested-layouts) has the reference version.
+> **Coming from React Router?** This is the job `<Outlet/>` does there. The trade is
+> deliberate: instead of a routing-specific render slot, you compose plain Clojure
+> with the `case`/`reduce` you'd write for any conditional view. The only
+> routing-specific piece is the one `:rf.route/chain` read. [The model → Nested layouts](concepts.md#nested-layouts).
 
 ## The complete shape
 


### PR DESCRIPTION
## Summary

Surgical authoring-voice pass over `docs/routing/**/*.md`, matching the core guide brief (`docs/core/AUTHORING.md`):

- **Senior vocab filter** — operational claims over status language; cut consultant-ish intensifiers while keeping peer teaching register on tutorial / model pages
- **Troubleshooting / Advanced** — model page gains a Troubleshooting table with named `:rf.error/*` recoveries; optional depth (hand-rolled nav-token loader, `:sensitive`, URL strategies, codec) moved under `## Advanced`
- **How-tos as tight recipes** — unsaved-changes and require-sign-in trimmed to steps + code; long re-teaching essays collapsed to miss bullets
- **Glossary as terse reference** — definition-first, less teaching prose
- **No Day-one framing**, no `spec/` reader links; compat anchors preserved (`python scripts/check_doc_slugs.py` green)

## Files

- `docs/routing/concepts.md`
- `docs/routing/tutorial.md`
- `docs/routing/coming-from-react-router.md`
- `docs/routing/glossary.md`
- `docs/routing/testing.md`
- `docs/routing/how-to/guard-unsaved-changes.md`
- `docs/routing/how-to/require-sign-in-on-a-route.md`

(`index.md` / `examples.md` already matched the brief; no content delta.)

## Test plan

- [x] `python scripts/check_doc_slugs.py`
- [ ] Docs CI (`mkdocs build --strict`, link/anchor gate) on the PR