### PR TITLE
docs(machines): tighten authoring voice across the corpus

### DIFF
--- a/docs/machines/actors.md
+++ b/docs/machines/actors.md
@@ -6,13 +6,24 @@ a job — a per-request protocol, a worker, a wizard step — via declarative
 child completion often uses [final states](concepts.md#final-states) and parent
 `:on-done`.
 
-A machine doesn't have to be a singleton. When a state needs to run some self-contained, asynchronous activity — an HTTP request, a websocket session, a worker grinding through a shard — you can **spawn a child machine** to do it, scoped to that state's lifetime. The child is a full machine instance with its own `:state` and `:data`; we call it an **actor**.
+When a state needs self-contained async work — an HTTP request, a websocket session,
+a worker on a shard — **spawn a child machine** scoped to that state's lifetime. The
+child is a full machine instance with its own `:state` and `:data`; we call it an
+**actor**.
 
-The pattern earns its keep when an activity has a *lifetime that should match a state's lifetime*: start it when you enter the state, and — this is the part that's easy to get wrong by hand — tear it down on **every** way out of the state, including the ones you forgot about. Declare the binding once and the runtime enforces it.
+The point is lifetime matching: start on entry, and tear down on **every** way out —
+including the exits you forgot. Declare the binding once; the runtime enforces it.
+Hand-rolling that is where leaks hide.
 
-A spawned child can be **state-bound** — alive for exactly as long as a state is active — or **dynamically created**; re-frame2 spells both as **`:spawn`**. There is **no actor object**: a spawned actor's *liveness is its snapshot* — a plain value at `[:rf.runtime/machines :snapshots <actor-id>]` in the [frame's runtime-db](glossary.md#snapshot). You address it by `dispatch`-ing to its id, exactly like any other handler, and it reverts with the frame on time-travel.
+A spawned child can be **state-bound** (alive while a state is active) or
+**dynamically created**; both spell **`:spawn`**. There is **no actor object**:
+liveness *is* the snapshot at
+`[:rf.runtime/machines :snapshots <actor-id>]` in
+[runtime-db](glossary.md#snapshot). Address it with `dispatch` to its id; it reverts
+with the frame on time-travel.
 
-This page assumes you've met the transition table and [guards and actions](concepts.md#guards-and-actions) from [Concepts](concepts.md), plus [`:after` timers](automatic-transitions.md) — they carry the timeout story below.
+Assumes the transition table and [guards and actions](concepts.md#guards-and-actions),
+plus [`:after` timers](automatic-transitions.md) for the timeout story below.
 
 ---
 
@@ -20,7 +31,10 @@ This page assumes you've met the transition table and [guards and actions](conce
 
 Put a `:spawn` map on a state node. While the machine sits in that state, a child actor of the named machine exists; on any transition out of the state, it's destroyed.
 
-Here's the heart of the [websocket example](../../examples/patterns/websocket/): a connection machine whose `:active` state owns a live socket. The socket is its own machine (`:websocket/socket`), spawned on the `:active` *parent* so one socket spans the `:connecting` → `:authenticating` → `:connected` leaves nested inside it.
+From the [websocket example](../../examples/patterns/websocket/): a connection
+machine whose `:active` state owns a live socket. The socket is its own machine
+(`:websocket/socket`), spawned on the `:active` *parent* so one socket spans the
+`:connecting` → `:authenticating` → `:connected` leaves nested inside it.
 
 ```clojure
 (rf/reg-machine :ws/connection
@@ -128,7 +142,7 @@ A freshly-spawned actor needs a first nudge. Two ways:
 
 You will reach for `:on-spawn` to "capture the child's id into `:data`" — and it won't work. `:on-spawn` is an **advisory observation hook**: the runtime calls it with `{:data <parent-data> :id <new-id>}` and **drops its return value**. Writing `(assoc data :pending id)` records nothing (and emits a `:rf.warning/on-spawn-return-ignored` in dev). The runtime already tracks the id for you — so there's no self-dispatch dance to write, and no side-channel atom either.
 
-There are **two** first-class mechanisms; reach for whichever fits.
+There are **two** mechanisms; reach for whichever fits.
 
 ### 1. The `:rf/spawned` `:data` slot (read the id in-snapshot)
 
@@ -223,13 +237,25 @@ A spawned child that genuinely *completes* — a one-shot protocol, a finished h
  :on    {:auth/cancelled :idle}}
 ```
 
-When `:auth-flow` enters `:done`, the runtime reads its `:token`, hands it to the parent's `:on-done` as `result`, then tears the child down — no stale id left behind. The details worth internalising:
+When `:auth-flow` enters `:done`, the runtime reads its `:token`, hands it to the
+parent's `:on-done` as `result`, then tears the child down — no stale id left
+behind:
 
-- **`:on-done` is a data-fold, not a transition.** It's `(fn [{:keys [data result]}] new-data)` — it returns the parent's next `:data`; the parent's state doesn't move.
-- **`:on-error` IS a transition.** A child that fails — it reaches a `:final?` leaf flagged `:error? true`, or one of its actions throws — routes the parent through the `:on`-shaped `:on-error` spec. Failure is control flow, not just observability.
-- **Completion is event-shaped.** The `:output-key` value flows to `:on-done` at the moment of completion, then the child is gone — there is no long-lived output slot to read later. Want a *computed* output? Write it into the final state's `:data` with a transition `:action`; there's no `:output-fn`.
-- **Final means final — even for a singleton.** A root-level `:final?` leaf auto-destroys *any* machine, spawned or not. A state a machine rests in indefinitely (an `:authed` end-screen) is an ordinary leaf with `:final?` omitted.
-- **Nested finals are different.** A `:final?` leaf *inside a compound state* doesn't end the machine — it signals "this sub-flow is done" to the enclosing compound's own `:on-done`, and the machine keeps running. That's the hierarchical pattern; see [Hierarchical states → When a sub-flow finishes](hierarchical-states.md#when-a-sub-flow-finishes-nested-final-states).
+- **`:on-done` is a data-fold, not a transition.** `(fn [{:keys [data result]}] new-data)`
+  — returns the parent's next `:data`; the parent's state doesn't move.
+- **`:on-error` IS a transition.** A child that fails — `:final?` leaf flagged
+  `:error? true`, or a thrown action — routes the parent through the `:on`-shaped
+  `:on-error` spec. Failure is control flow, not just observability.
+- **Completion is event-shaped.** `:output-key` flows to `:on-done` at completion,
+  then the child is gone — no long-lived output slot. Want a *computed* output?
+  Write it into the final state's `:data` with a transition `:action`; no
+  `:output-fn`.
+- **Final means final — even for a singleton.** A root-level `:final?` leaf
+  auto-destroys *any* machine. A resting end-screen (`:authed`) is an ordinary leaf
+  with `:final?` omitted.
+- **Nested finals are different.** A `:final?` leaf *inside a compound* signals
+  "this sub-flow is done" to the compound's `:on-done`; the machine keeps running.
+  See [Hierarchical states → When a sub-flow finishes](hierarchical-states.md#when-a-sub-flow-finishes-nested-final-states).
 
 ---
 
@@ -254,10 +280,14 @@ When `:auth-flow` enters `:done`, the runtime reads its `:token`, hands it to th
           [:rf.machine/destroy (re-frame.machines/machine-by-system-id :logger)]]}))
 ```
 
-`[:rf.machine/spawn <spec>]` and `[:rf.machine/destroy <actor-id>]` are the surface; the [API reference](../api/re-frame.machines.md) documents them in full. Two properties worth internalising:
+`[:rf.machine/spawn <spec>]` and `[:rf.machine/destroy <actor-id>]` are the surface;
+the [API reference](../api/re-frame.machines.md) documents them in full:
 
-- **Spawning an unregistered `:machine-id` fails closed.** No snapshot, no id, no `:start` — the spawn rejects with `:rf.error/machine-spawn-unregistered-type`. There is no "spec-less spawn."
-- **Destroy is silently idempotent.** Destroying an already-gone actor is a no-op — no error, no second trace. The actor has exactly one Active → Stopped transition.
+- **Spawning an unregistered `:machine-id` fails closed.** No snapshot, no id, no
+  `:start` — rejects with `:rf.error/machine-spawn-unregistered-type`. There is no
+  "spec-less spawn."
+- **Destroy is silently idempotent.** Destroying an already-gone actor is a no-op —
+  no error, no second trace. Exactly one Active → Stopped transition.
 
 For the rare case of spawning from outside a handler (true boot time), wrap the `:rf.machine/spawn` in a one-shot event and `dispatch-sync` it. Inside a machine, prefer declarative `:spawn`; inside an ordinary handler, the imperative fx is the canonical surface.
 
@@ -363,14 +393,26 @@ When a state needs to spawn **N children in parallel** and resume on a join cond
 
 The runtime intercepts these at the parent's boundary, updates join state, and once the condition resolves, fires the parent event (`:on-all-complete` here) **and** unconditionally cancels any siblings still in flight. The bookkeeping — who's done, who failed, the resolution latch — is **runtime-owned** at `[:rf.runtime/machines :spawned <parent-id> <invoke-id>]`; the parent keeps none of it in `:data`.
 
-A few rules worth knowing:
+Rules:
 
-- **Each child needs a unique `:id`** (the join key) on top of the usual spawn keys. Duplicate ids are a registration error.
-- **Join discriminators:** `:all` (default) or `:any`. `:on-all-complete` is required for `:all`; `:on-some-complete` is required for `:any`. A quorum ("N of M") join uses the data-only `:after` + `:done-guard` idiom, not a `:join` mode ([Spec 005 §Join semantics](../../spec/005-StateMachines.md#join-semantics)).
-- **Sibling cancellation on join resolution is unconditional** — when the join resolves, surviving siblings are torn down. A late result from an already-decided join fires no further parent event. A fan-out where each child is independently valuable is modelled as N independent single-`:spawn`s (fire-and-forget), not a non-cancelling join.
-- **An unregistered child type fails the whole invoke closed, atomically.** The runtime seeds a childless reject marker at the join slot (physically present, but with no children to wait on) and suppresses the registered siblings too — so a malformed fan-out spawns nothing rather than leaving orphans behind. A child that can never run can never deadlock an `:all` join.
-- **Wall-clock timeout:** same as single `:spawn` — an `:after` on the `:spawn-all`-bearing state. When it fires, the exit cascade cancels every surviving child.
+- **Each child needs a unique `:id`** (the join key) on top of the usual spawn keys.
+  Duplicate ids are a registration error.
+- **Join discriminators:** `:all` (default) or `:any`. `:on-all-complete` is
+  required for `:all`; `:on-some-complete` is required for `:any`. A quorum
+  ("N of M") join uses the data-only `:after` + `:done-guard` idiom, not a `:join`
+  mode.
+- **Sibling cancellation on join resolution is unconditional** — when the join
+  resolves, surviving siblings are torn down. A late result from an already-decided
+  join fires no further parent event. Independently valuable children: N single
+  `:spawn`s (fire-and-forget), not a non-cancelling join.
+- **An unregistered child type fails the whole invoke closed, atomically.** The
+  runtime seeds a childless reject marker and suppresses registered siblings too —
+  malformed fan-out spawns nothing rather than leaving orphans. A child that can
+  never run can never deadlock an `:all` join.
+- **Wall-clock timeout:** same as single `:spawn` — an `:after` on the
+  `:spawn-all`-bearing state. When it fires, the exit cascade cancels every
+  surviving child.
 
-`:spawn-all` packages the fan-out, the join condition, and the cancel-on-resolution cascade into one declaration.
+`:spawn-all` packages fan-out, join, and cancel-on-resolution into one declaration.
 
 ---

--- a/docs/machines/automatic-transitions.md
+++ b/docs/machines/automatic-transitions.md
@@ -5,15 +5,19 @@ Not every move is a user click. This page is the grammar for transitions the
 and named timeouts.
 
 You already met `:after` on the [login tutorial](tutorial.md#step-4--talk-to-a-real-server)
-(8s server deadline). Everything below works on **flat** machines
-([the model](concepts.md)) and the same keys nest inside
+(8s server deadline). The same keys work on **flat** machines
+([the model](concepts.md)) and nest inside
 [hierarchical](hierarchical-states.md) / [parallel](parallel-states.md) states.
 
-Most [transitions](glossary.md#transition) wait for the world: a user clicks, an HTTP reply lands, a timer you wired by hand goes off. An **automatic transition** is one the [machine](glossary.md#machine) takes *on its own*, with no external event — the instant a condition becomes true, or a deadline passes, the [snapshot](glossary.md#snapshot) moves.
+Most [transitions](glossary.md#transition) wait for the world — a click, an HTTP
+reply, a hand-rolled timer. An **automatic transition** is one the
+[machine](glossary.md#machine) takes *on its own*: when a condition holds or a
+deadline passes, the [snapshot](glossary.md#snapshot) moves. Without them you re-
+invent the same brittle pattern — `setTimeout` plus a cancel flag, or a synthetic
+`dispatch` from every place that could enable the next step. Each of those is one
+declarative key on a state node.
 
-These are the statechart features that let a machine *drive itself*: a form that routes the moment it's validated, a splash screen that dismisses after three seconds, a reconnect that backs off and retries, a request that gives up after ten. Without them you reach for the same fragile pattern every time — a `setTimeout` paired with a cancel flag, or a synthetic event you `dispatch` by hand from every place that could enable the next step. re-frame2 turns each of those into one declarative key on a state node.
-
-There are four authoring grammars, and underneath them just **two engines**:
+Four authoring grammars, **two engines**:
 
 | You want… | Reach for | Fires when |
 |---|---|---|
@@ -24,9 +28,14 @@ There are four authoring grammars, and underneath them just **two engines**:
 
 !!! note "Four grammars, two engines"
 
-    `:type :choice` is sugar that **desugars to `:always`**; `:timeout` / `:on-timeout` is sugar that **desugars to `:after`**. So everything on this page runs on one of two mechanisms: the **guard-driven microstep loop** (`:always`, `:choice`) and the **wall-clock timer** (`:after`, `:timeout`). One fact, one mechanism — the extra grammars exist only to *name the author's intent* so tools and diagrams can read it.
+    `:type :choice` **desugars to `:always`**; `:timeout` / `:on-timeout`
+    **desugars to `:after`**. Guard-driven microstep loop vs wall-clock timer. The
+    extra grammars *name intent* so tools and diagrams can read it.
 
-Everything below assumes the core loop from [the model](concepts.md#register-and-drive): a machine is registered with `reg-machine`, its transition table is data, a [guard](glossary.md#guard) returns a boolean, an [action](glossary.md#action) returns the data-shaped effect map `{:data … :fx …}` (the `:data` is *merged* into the snapshot, key by key), and the live value is a snapshot `{:state … :data … :tags …}`. New to all that? Read [The model → Guards and actions](concepts.md#guards-and-actions) first.
+Assumes [the model](concepts.md#register-and-drive): `reg-machine`, table as data,
+[guard](glossary.md#guard) → boolean, [action](glossary.md#action) →
+`{:data … :fx …}` (`:data` merged), snapshot `{:state … :data … :tags …}`. New to
+that? [Guards and actions](concepts.md#guards-and-actions) first.
 
 ## Eventless `:always` — fire the instant a condition holds
 
@@ -56,11 +65,17 @@ When you `(rf/dispatch [:quiz [:answer-correct]])`, two things happen inside **o
 
 External observers see `:asking → :winner` in one step. The "answer counted, still asking" intermediate state is **invisible** — exactly the property `:always` exists to provide.
 
-### The mental model: settle, then commit once
+### Settle, then commit once
 
-`:always` extends the event [pipeline](../core/run-to-completion.md): after the triggering transition, the runtime runs a **microstep loop** that keeps taking enabled `:always` transitions (and draining any [`:raise`](../api/re-frame.machines.md)d internal events) until it reaches a **fixed point** — no `:always` guard matches and no raised event is pending. Only then does it commit the snapshot, **once, atomically**, and emit the accumulated `:fx`.
+`:always` extends the event [pipeline](../core/run-to-completion.md): after the
+triggering transition, a **microstep loop** keeps taking enabled `:always`
+transitions (and draining any [`:raise`](../api/re-frame.machines.md)d internal
+events) until a **fixed point** — no `:always` matches, no raised event pending.
+Only then does the snapshot commit **once, atomically**, with the accumulated `:fx`.
 
-This is classic statechart **macrostep** semantics: the externally-observable transition is the *settled* result of an internal cascade of microsteps. Time-travel, [Xray](../core/observability.md), and undo all see the single committed transition; the inner microsteps ride the trace stream for tools that want them.
+That is statechart **macrostep** semantics: observers see the *settled* result.
+Time-travel, [Xray](../core/observability.md), and undo see one committed
+transition; inner microsteps ride the trace stream for tools.
 
 !!! note "It runs at birth, too"
 

--- a/docs/machines/coming-from-xstate.md
+++ b/docs/machines/coming-from-xstate.md
@@ -4,18 +4,36 @@ This page is a **translation**, not a tutorial. For a first machine in re-frame2
 use the [login tutorial](tutorial.md) and [the model](concepts.md). Here: how
 XState v5/v6 concepts map, and where re-frame2 deliberately diverges.
 
-If you've built statecharts with [XState](https://stately.ai/docs) — v5, or the v6 alpha — most of your mental model ports straight across. re-frame2's [machines](concepts.md) borrow XState's grammar on purpose: transition tables as data, guards, actions, tags, delayed transitions, final states, run-to-completion, internal-by-default self-transitions. You can read a re-frame2 machine spec on day one and a re-frame2 author can read yours. The *behaviour* is the contract re-frame2 tracks; what changes is the *expression* and one piece of *plumbing*.
+If you've built statecharts with [XState](https://stately.ai/docs) — v5, or the v6
+alpha — most of your mental model ports straight across. re-frame2's
+[machines](concepts.md) borrow XState's grammar on purpose: transition tables as
+data, guards, actions, tags, delayed transitions, final states, run-to-completion,
+internal-by-default self-transitions. You can read a re-frame2 machine table and a
+re-frame2 author can read yours. The *behaviour* is the contract; what changes is
+the *expression* and one piece of *plumbing*.
 
 Two things transfer almost untouched:
 
-- **The statechart itself.** States, nested states, parallel regions, guards on transitions, entry/exit actions, `after` timers, final states, history — same concepts, idiomatic spelling. If you can draw it, you can write it.
-- **The semantics you rely on.** Run-to-completion, internal-vs-external self-transitions, eventless (`always`) transitions firing on guard flips, an unknown event being a no-op rather than a crash. re-frame2 matches XState here deliberately, including the v5/v6 drop of strict mode.
+- **The statechart itself.** States, nested states, parallel regions, guards,
+  entry/exit actions, `after` timers, final states, history — same concepts,
+  idiomatic spelling. If you can draw it, you can write it.
+- **The semantics you rely on.** Run-to-completion, internal-vs-external
+  self-transitions, eventless (`always`) transitions on guard flips, an unknown
+  event as a no-op rather than a crash. re-frame2 matches XState here deliberately,
+  including the v5/v6 drop of strict mode.
 
 And one thing genuinely shifts:
 
-- **A machine is not an actor.** This is the load-bearing difference and the rest of this page keeps coming back to it. In XState you `createActor(machine)`, `.start()` it, and `.send()` events to a living object that owns its own state. In re-frame2 a machine is an [event handler](../core/glossary.md#event-handler) — registered like any other, fed by the same [`dispatch`](../core/glossary.md#dispatch), with its state living in the [frame](../core/glossary.md#frame) rather than in an object you hold a reference to. There's no `send`, no mailbox, no actor ref. There's one queue, and machines ride it like everything else.
+- **A machine is not an actor.** This is the real difference, and the rest of this
+  page keeps coming back to it. In XState you `createActor(machine)`, `.start()` it,
+  and `.send()` events to a living object that owns its own state. In re-frame2 a
+  machine is an [event handler](../core/glossary.md#event-handler) — registered like
+  any other, fed by the same [`dispatch`](../core/glossary.md#dispatch), with its
+  state living in the [frame](../core/glossary.md#frame) rather than in an object
+  you hold a reference to. There's no `send`, no mailbox, no actor ref. There's one
+  queue, and machines ride it like everything else.
 
-If you internalise just that last bullet, the table below is mostly vocabulary.
+Get that last bullet and the table below is mostly vocabulary.
 
 !!! note "Parity reference: the XState v6 direction"
 
@@ -263,7 +281,11 @@ In XState the parallel node's children sit under `states`; in re-frame2 they sit
 ;; => {:state {:data :nothing :form :neutral} :data {:items [] :error nil} :tags #{:data/idle :form/neutral}}
 ```
 
-Cross-region coordination — one region guarding on another region's active state (XState v5's `stateIn` / SCXML `In()`) — is expressed by predicating on a sibling region's [tag](#tags), not a combinator. (A region whose own tree is itself `:type :parallel` is rejected in v1 — nested parallel is a **deferred** divergence with a recorded reconsideration trigger; see [Spec 005 §Three non-substrate divergences, item 2](../../spec/005-StateMachines.md#three-non-substrate-divergences--ruled-and-recorded).) Worked example: [`examples/patterns/nine_states/`](../../examples/patterns/nine_states/).
+Cross-region coordination — one region guarding on another region's active state
+(XState v5's `stateIn` / SCXML `In()`) — is expressed by predicating on a sibling
+region's [tag](#tags), not a combinator. (A region whose own tree is itself
+`:type :parallel` is rejected in v1 — nested parallel is a **deferred** divergence.)
+Worked example: [`examples/patterns/nine_states/`](../../examples/patterns/nine_states/).
 
 ### History states
 
@@ -282,7 +304,13 @@ To re-enter a compound at the substate it last occupied, XState declares a `type
                               :mid-track {}}}}}}
 ```
 
-Same concept, idiomatic spelling: XState's `history: 'deep'` becomes `:deep? true` (shallow is the default — a missing `:deep?` reads as shallow), and `:default-target` is the never-yet-entered fallback. The pseudo-state is never an occupiable state — a transition *to* `:hist` resolves to the recorded (or default) leaf, which is what the snapshot records. The recording rides the snapshot's framework-owned `:rf/history` slot, so undo, time-travel, and SSR get history for free — no hand-rolled snapshot-as-value substitute.
+Same concept, idiomatic spelling: XState's `history: 'deep'` becomes `:deep? true`
+(shallow is the default — a missing `:deep?` reads as shallow), and
+`:default-target` is the never-yet-entered fallback. The pseudo-state is never
+occupiable — a transition *to* `:hist` resolves to the recorded (or default) leaf,
+which is what the snapshot records. The recording rides the snapshot's
+framework-owned `:rf/history` slot, so undo, time-travel, and SSR get history
+without extra wiring — no hand-rolled stash.
 
 ### Final states and output
 
@@ -398,7 +426,13 @@ re-frame2 already has exactly one of those — the [event pipeline](../core/glos
 
 [`reg-machine`](../core/glossary.md#registration) is sugar over `reg-event`: the registered handler interprets the table — read the current [snapshot](glossary.md#snapshot), compute the transition, write the new snapshot, return the [action](glossary.md#action)'s effects. The outer `:auth.login/flow` routes to the machine; the inner `[:auth.login/submit creds]` is the event the machine sees. No actor object to thread through your components, no parallel `send` API, no question of "where do I keep the running machine?" — the answer is the same place every other piece of state lives.
 
-**Why:** one mechanism is cheaper than two. An XState actor is a thing you must wire into your component tree, keep alive, and bridge to your data layer. A re-frame2 machine is reachable from anywhere `dispatch` is, traceable on the same [trace stream](../core/glossary.md#trace-stream), and composes with every other handler for free. The cost — and it's real — is that you give up `actor.send(...)` ergonomics and the sense of a machine as a tangible object. In exchange the machine stops being a special case.
+**Why:** one mechanism is cheaper than two. An XState actor is a thing you must wire
+into your component tree, keep alive, and bridge to your data layer. A re-frame2
+machine is reachable from anywhere `dispatch` is, traceable on the same
+[trace stream](../core/glossary.md#trace-stream), and composes with every other
+handler. The cost — and it's real — is that you give up `actor.send(...)` ergonomics
+and the sense of a machine as a tangible object. In exchange the machine stops being
+a special case.
 
 ### 2. The snapshot is a value in the frame, not state owned by an object
 
@@ -434,7 +468,15 @@ XState's `assign(...)` is an action *creator* that imperatively updates context,
 
 The returned `:data` is merged into the snapshot; the returned `:fx` is a *description* of work, handed to the effects machinery to actually run. No `assign` helper — re-frame2 never needed one, because returning `{:data ...}` is the assignment. ([XState v6 is removing `assign`'s special status](https://stately.ai/docs) and leaning toward plainer functions, which is roughly the shape re-frame2 started from.)
 
-**Why:** ["effects are data"](../core/glossary.md#effects-are-data) is the spine of re-frame2, not a machines feature. An action that *returns* a description of its side effects is pure, trivially testable, and replayable; an action that *performs* them is none of those. And the payoff compounds: because an effect is just data, a machine and an async surface compose with no glue. Note `:on-success [:auth.login/flow [:auth.login/success]]` above — the HTTP reply lands back *inside the machine* as an ordinary event ([the uniform reply](../core/glossary.md#the-uniform-reply) appends the payload to the inner vector). No `invoke`-promise bridge, no callback adapter — the reply is just the next event the machine handles.
+**Why:** ["effects are data"](../core/glossary.md#effects-are-data) is a core rule,
+not a machines feature. An action that *returns* a description of its side effects
+is pure, testable, and replayable; an action that *performs* them is none of those.
+Because an effect is just data, a machine and an async surface compose with no glue.
+Note `:on-success [:auth.login/flow [:auth.login/success]]` above — the HTTP reply
+lands back *inside the machine* as an ordinary event
+([the uniform reply](../core/glossary.md#the-uniform-reply) appends the payload to
+the inner vector). No `invoke`-promise bridge, no callback adapter — the reply is
+just the next event the machine handles.
 
 ### 4. The transition topology stays data — functions are confined to guards and actions
 

--- a/docs/machines/concepts.md
+++ b/docs/machines/concepts.md
@@ -81,7 +81,7 @@ source stamps are empty (dev warns `:rf.warning/machine-source-unstamped`).
 ```
 
 The snapshot lives in [runtime-db](../core/glossary.md#runtime-db) (framework half of
-the frame), so undo, time-travel, and SSR hydration apply for free.
+the frame), so undo, time-travel, and SSR hydration work without extra wiring.
 
 !!! note "Async composes"
 
@@ -270,8 +270,8 @@ rolls back a bad transition.
 <a id="validating-a-machines-data"></a>
 <a id="validating-a-machines-completion-output"></a>
 
-Full rules: see schemas section of
-[`re-frame.machines` API](../api/re-frame.machines.md) and Spec 005 (authors).
+Full rules: schemas section of the
+[`re-frame.machines` API](../api/re-frame.machines.md).
 
 ## Self-transitions and wildcards
 
@@ -372,4 +372,4 @@ macrostep with a loud error — not a silent no-op.
 **No:** plain data; two-state flags; server cache lifecycles ([resources](../resources/concepts.md));
 mere operation sequences (chained events).
 
-**Named states are the load-bearing concept — not named operations.**
+**Named states are the concept — not named operations.**

--- a/docs/machines/glossary.md
+++ b/docs/machines/glossary.md
@@ -1,26 +1,36 @@
 # Machines glossary
 
-re-frame2's optional state-machine capability — modelling a feature's lifecycle as an explicit statechart rather than a scatter of boolean flags. Every term below lives within a [machine](#machine), and each entry links to the page that teaches it in depth.
+re-frame2's optional state-machine capability. One term, definition first; short
+code when the spelling matters; *See* / Related points at the teaching page.
 
-Grouped by role: [the core loop](#the-core-loop), [state structure](#state-structure), [transitions and timing](#transitions-and-timing), [actors and composition](#actors-and-composition), [tags](#tags), and [the runtime model](#the-runtime-model).
+Grouped by role: [the core loop](#the-core-loop), [state structure](#state-structure),
+[transitions and timing](#transitions-and-timing), [actors and composition](#actors-and-composition),
+[tags](#tags), and [the runtime model](#the-runtime-model).
 
 ## The core loop
 
 ### **machine**
 
-A statechart-capable state machine, registered as an [event handler](../core/glossary.md#event-handler) with `reg-machine`. It models a feature's lifecycle as explicit [states](#state) and [transitions](#transition) — driven by dispatched [events](../core/glossary.md#event), with [guards](#guard), [actions](#action), timeouts, and child machines (see [spawn](#spawn)) — instead of a scatter of boolean flags in [app-db](../core/glossary.md#app-db).
+A statechart registered as an [event handler](../core/glossary.md#event-handler) with
+`reg-machine`. Models a feature's lifecycle as explicit [states](#state) and
+[transitions](#transition) — driven by `dispatch`, with [guards](#guard),
+[actions](#action), timers, and optional child machines ([spawn](#spawn)) — instead
+of boolean flags in [app-db](../core/glossary.md#app-db).
 
-Its live value is a [snapshot](#snapshot) (the current state plus its `:data`), held in [runtime-db](../core/glossary.md#runtime-db) and read like any other derived state.
+Live value is a [snapshot](#snapshot) in [runtime-db](../core/glossary.md#runtime-db).
 
 ```clojure
-(rf/reg-machine :auth.login/flow login-flow)   ;; login-flow is a defmachine value
+(rf/reg-machine :auth.login/flow login-flow)
 ```
 
-Related: [Machines](concepts.md); the [`reg-machine` API](../api/re-frame.machines.md#reg-machine).
+Related: [Machines](concepts.md); [`reg-machine`](../api/re-frame.machines.md#reg-machine).
 
 ### **transition table**
 
-The data a machine *is*: a map with `:initial`, the starting [`:data`](#data), the machine-local [`:guards`](#guard) / [`:actions`](#action) maps, an optional `:schemas`, and the `:states` tree. The event keys under each state's `:on` map are what move it. [`reg-machine`](../api/re-frame.machines.md#reg-machine) compiles this literal map into an ordinary [event handler](../core/glossary.md#event-handler) at registration, so the table is the whole specification — pretty-print it, diff it in review, render it as a diagram, or hand it to an AI in one piece.
+The data a machine *is*: `:initial`, starting [`:data`](#data), machine-local
+[`:guards`](#guard) / [`:actions`](#action), optional `:schemas`, and the `:states`
+tree. Event keys under each state's `:on` move it. [`reg-machine`](../api/re-frame.machines.md#reg-machine)
+compiles the map into an ordinary event handler at registration.
 
 ```clojure
 {:initial :idle
@@ -31,51 +41,71 @@ The data a machine *is*: a map with `:initial`, the starting [`:data`](#data), t
            :submitting {...}}}
 ```
 
-See [The idea](concepts.md#the-idea) / [The same flow as a transition table](concepts.md#the-same-flow-as-a-transition-table).
+See [The idea](concepts.md#the-idea).
 
 ### **snapshot**
 
-A [machine](#machine)'s live value at any moment — which state it's in, plus its `:data`. It lives in [runtime-db](../core/glossary.md#runtime-db), and you read it through a [subscription](../core/glossary.md#subscription) addressed by the machine's id.
+A machine's live value — current [state](#state) plus `:data` (and optional `:tags`).
+Lives in [runtime-db](../core/glossary.md#runtime-db); read via subscription.
 
 ```clojure
 @(rf/subscribe [:rf/machine :auth.login/flow])   ;; {:state :authed :data {...}}
 ```
 
-The snapshot is a plain, printable value (no functions or atoms), so [undo, time-travel](../core/glossary.md#time-travel), persistence, and SSR hydration all work on machines for free. Its `:state` takes one of three forms: a single keyword (flat machine), a vector path (`[:authenticated :cart :browsing]`, a [compound](#compound-state) machine), or a region → state map (a [parallel](#parallel-state) machine).
+Plain printable value (no functions or atoms), so undo, [time-travel](../core/glossary.md#time-travel),
+persistence, and SSR hydration work without extra wiring. `:state` is a keyword
+(flat), a path vector (compound), or a region → state map (parallel).
 
-Related: [Machines](concepts.md); the [`[:rf/machine machine-id]` sub](../api/re-frame.machines.md#rfmachine-machine-id).
+Related: [Machines](concepts.md); [`[:rf/machine machine-id]`](../api/re-frame.machines.md#rfmachine-machine-id).
 
 ### **:data**
 
-A machine's private working memory — the *extended state* that rides alongside the named [state](#state) in every [snapshot](#snapshot). Counters, the in-flight error string, captured credentials: anything that isn't itself a named mode. [Guards](#guard) and [actions](#action) read it from their context map (`{:data …}`); an action *updates* it by returning `{:data …}` (see [action effect map](#action-effect-map)). It must be a printable value so the snapshot round-trips through persistence and time-travel, and a machine sees **only its own** `:data` — never [app-db](../core/glossary.md#app-db).
+Machine-private working memory — counters, error strings, captured credentials —
+riding beside the named [state](#state) in every [snapshot](#snapshot). Guards and
+actions read it from their context map; an action updates it by returning
+`{:data …}` (see [action effect map](#action-effect-map)). Must be printable. A
+machine sees **only its own** `:data` — never [app-db](../core/glossary.md#app-db).
 
 Taught in [The idea](concepts.md#the-idea).
 
 ### **state**
 
-One of a [machine](#machine)'s fixed, named, mutually-exclusive modes — `:idle`, `:submitting`, `:authed`. A machine is always in exactly one (or, with [parallel regions](#parallel-state), one per region). A state with no nested `:states` is a *leaf* (or *atomic*) state; one that nests its own `:states` is a [compound state](#compound-state).
+One fixed, named, mutually exclusive mode — `:idle`, `:submitting`, `:authed`.
+With [parallel regions](#parallel-state), one per region. Leaf = no nested
+`:states`; [compound](#compound-state) = nests its own `:states`.
 
 ### **transition**
 
-The move from one [state](#state) to another in response to a dispatched [event](../core/glossary.md#event) — optionally gated by a [guard](#guard) and running an [action](#action) on the way. In the transition table it's an entry under a state's `:on` map. Transitions can also be *eventless* ([`:always`](#eventless-transition-always), taken on entry when its guard passes) or *timed* ([`:after`](#delayed-transition-after), taken after a delay that auto-cancels when the state exits).
+Move from one [state](#state) to another on a dispatched [event](../core/glossary.md#event),
+optionally gated by a [guard](#guard) and running an [action](#action). Written under
+a state's `:on`. Also *eventless* ([`:always`](#eventless-transition-always)) or
+*timed* ([`:after`](#delayed-transition-after)).
 
 ### **guard**
 
-A pure yes/no predicate that decides whether a [transition](#transition) fires. Referenced by name from the table and defined once in the machine's `:guards`, so a visualiser can read the condition right off the arrow. It receives the context map `{:data :event :state :meta}` (note: **no** app-db) and returns a boolean. There's no `{:and …}` combinator DSL — compound logic goes in one named function, so the *name* is what tools and AI read off the arrow.
+Pure yes/no predicate on a [transition](#transition). Named in `:guards`, referenced
+from the table. Receives `{:data :event :state :meta}` (**no** app-db); returns a
+boolean. No `{:and …}` combinator — compound logic is one named function.
 
-A guard runs *before* the transition's [action](#action), so it sees the pre-action snapshot: a counter the action is about to bump still holds its old value, and the boundary sits one below the total you want — `(< (:attempts d) 2)` for a three-attempt policy. See [Guards](concepts.md#guards).
+Runs *before* the transition's [action](#action), so it sees the pre-action snapshot
+— `(< (:attempts d) 2)` for a three-attempt policy. See [Guards](concepts.md#guards).
 
 ### **action**
 
-The side work a [transition](#transition) performs: it returns the same `{:data … :fx …}` shape an [event handler](../core/glossary.md#event-handler) returns — updating the machine's own `:data` or firing [effects](../core/glossary.md#effect) — and never writes [app-db](../core/glossary.md#app-db) directly. Defined once in the machine's `:actions`, named from the arrow. The three action slots a transition can run are the source state's `:exit`, the transition's own `:action`, and the target's `:entry`.
+Side work on a [transition](#transition): returns `{:data … :fx …}` like an
+[event handler](../core/glossary.md#event-handler); never writes [app-db](../core/glossary.md#app-db)
+directly. Named in `:actions`. Slots: source `:exit`, transition `:action`, target
+`:entry`.
 
 ### **action effect map**
 
-What an [action](#action) returns: the same `{:data … :fx …}` map a [`reg-event`](../core/glossary.md#event-handler) handler returns. `:data` is **merged** into the snapshot key-by-key (last write wins; a key returned as explicit `nil` *sets* it to `nil` rather than removing it); `:fx` is a vector of `[fx-id args]` pairs the runtime performs for you. Returning `nil` does nothing. Because the action *describes* effects rather than performing them, it stays pure, testable, and replayable.
+What an [action](#action) returns. `:data` is **merged** into the snapshot (explicit
+`nil` sets a key to nil; does not remove keys); `:fx` is a vector of `[fx-id args]`.
+`nil` / `{}` means no effects. Describes work rather than performing it.
 
 ```clojure
 :record-error
-(fn [{data :data [_ {:keys [error]}] :event}]        ;; failure map rides under :error
+(fn [{data :data [_ {:keys [error]}] :event}]
   {:data (-> data (update :attempts inc)
                   (assoc :error (:message error)))})
 ```
@@ -86,29 +116,44 @@ See [The effect map](concepts.md#the-effect-map-data-fx).
 
 ### **compound state**
 
-A [state](#state) that nests its own `:states` map plus a required `:initial` substate — a parent mode with child modes (`:authenticated` over `:browsing` / `:checkout`). Entering it cascades down the `:initial` chain to a leaf, and the snapshot's `:state` becomes a **vector path** like `[:authenticated :cart :browsing]`. The runtime resolves an event by walking from the active leaf up to the root — **deepest-wins with parent fallthrough** — so a parent can factor out a transition (`:logout`) that every descendant inherits, while a child can [opt out](#forbidden-transition) or override.
+A [state](#state) with its own `:states` map and required `:initial` — parent mode
+with child modes. Snapshot `:state` becomes a **vector path**
+(`[:authenticated :cart :browsing]`). Event resolution walks leaf → root
+(**deepest-wins with parent fallthrough**). Child can [opt out](#forbidden-transition)
+or override.
 
 See [Hierarchical states](hierarchical-states.md).
 
 ### **parallel state**
 
-A machine declared `:type :parallel` at its root, holding a **`:regions`** map (not `:states`) — the [regions](#region) are **all active at once** rather than one-at-a-time. Three orthogonal axes of three states each is three regions, not twenty-seven cross-product states. The snapshot's `:state` becomes a **map** of region-name → that region's state (`{:data :loading :form :neutral :mode :active}`); all regions share one [`:data`](#data) and their [tags](#state-tag) union across regions. When the axes *don't* share data, prefer N separate machines instead.
+Root `:type :parallel` with a **`:regions`** map — all [regions](#region) active at
+once. Snapshot `:state` is a region-name → state map; one shared [`:data`](#data);
+[tags](#state-tag) union across regions. If axes don't share data, use N machines.
 
-See the [nine_states example](../../examples/patterns/nine_states/) and [Parallel states](parallel-states.md).
+See [Parallel states](parallel-states.md); [nine_states](../../examples/patterns/nine_states/).
 
 ### **region**
 
-One orthogonal axis of a [parallel state](#parallel-state) — its own independent sub-state-tree, running concurrently with its sibling regions and sharing the machine's single [`:data`](#data). A dispatched [event](../core/glossary.md#event) broadcasts to every region, and each resolves it independently; a region's slice of the snapshot is keyed by its region-name. Cross-region coordination reads another region's [tags](#state-tag) — never reaching into its state directly.
+One orthogonal axis of a [parallel state](#parallel-state) — independent
+sub-state-tree, concurrent with siblings, sharing the machine's [`:data`](#data).
+Events broadcast to every region; each resolves independently. Cross-region
+coordination reads sibling [tags](#state-tag).
 
 ### **final state**
 
-A leaf marked **`:final? true`**: entering it **terminates the machine** — the runtime auto-destroys it, *even a top-level singleton*. It's for "this run is over," not "this is the last screen" — for a state the machine rests in indefinitely (like `:authed`), use an ordinary leaf and **omit** `:final?`. A final leaf can name an [`:output-key`](#on-done-and-output-key) to report a result, and can be flagged `:error? true` as a designated failure terminal. A final leaf *nested inside a compound* is different: it ends the sub-flow, not the machine.
+Leaf marked **`:final? true`**: entering it **terminates the machine** (auto-destroy,
+including top-level singletons). For a resting end-screen (`:authed`), omit
+`:final?`. May name [`:output-key`](#on-done-and-output-key); may set `:error? true`.
+A final *nested in a compound* ends the sub-flow, not the machine.
 
-See [Actors → When a child finishes](actors.md#when-a-child-finishes) and [Hierarchical states → nested final states](hierarchical-states.md#when-a-sub-flow-finishes-nested-final-states).
+See [Actors → When a child finishes](actors.md#when-a-child-finishes);
+[Hierarchical states → nested finals](hierarchical-states.md#when-a-sub-flow-finishes-nested-final-states).
 
 ### **history state**
 
-A `:type :history` **pseudo-state** you target to re-enter a [compound state](#compound-state) at whichever substate was active when you last left it — a paused player resuming mid-track. **Shallow** restores the immediate child; **deep** restores the full nested path; a `:default-target` covers the never-visited-yet case. The recording rides the [snapshot](#snapshot), so it survives undo and SSR hydration for free.
+`:type :history` **pseudo-state** targeted to re-enter a [compound](#compound-state)
+at the last active substate. Shallow = immediate child; deep = full path;
+`:default-target` for never-visited. Recording rides the [snapshot](#snapshot).
 
 See [History states](history.md).
 
@@ -116,35 +161,41 @@ See [History states](history.md).
 
 ### **self-transition**
 
-A [transition](#transition) back into the state you're already in. re-frame2 follows **internal-by-default**, with three distinct shapes:
+Transition back into the current state. re-frame2 is **internal-by-default**:
 
-- **Targetless** (omit `:target`) — a true internal no-op: the `:action` runs, but `:exit` / `:entry` don't, `:after` timers aren't restarted, [`:spawn`](#spawn) children aren't torn down. The way to mutate `:data` without disturbing anything.
-- **Explicit self-target, no `:reenter?`** — your own `:exit` / `:entry` still don't fire, but a compound **re-resolves its descendants** to `:initial`.
-- **External (`:reenter? true`)** — genuinely exits and re-enters: `:exit` → `:action` → `:entry`, and on a compound the whole subtree restarts (`:after` timers reset, `:spawn` children respawn).
+- **Targetless** (omit `:target`) — action only; no exit/entry; timers and spawns undisturbed.
+- **Self-target, no `:reenter?`** — own exit/entry still skip; compounds re-resolve descendants to `:initial`.
+- **`:reenter? true`** — full exit → action → entry (timers reset, spawns restart).
 
 See [Self-transitions and wildcards](concepts.md#self-transitions-and-wildcards).
 
 ### **wildcard transition**
 
-An `:on` entry that matches a *class* of events instead of one id. `:on` resolves **three tiers**, most-specific first: the **exact** id (`:mouse/down`), then the **namespace wildcard** `:ns/*` (`:mouse/*` catches every `mouse`-namespaced event and only those), then the **total wildcard** `:*` (anything). A guard-blocked exact match falls through to the coarser tiers.
+`:on` key matching a class of events. Three tiers, most-specific first: exact id →
+`:ns/*` → `:*`. Guard-blocked exact falls through to coarser tiers.
 
 ```clojure
-:tracking {:on {:mouse/down {:action :begin-drag}    ;; exact wins for :mouse/down
-                :mouse/*    {:action :note-move}      ;; any other :mouse/… event
-                :*          {:action :log-unknown}}}  ;; anything else
+:tracking {:on {:mouse/down {:action :begin-drag}
+                :mouse/*    {:action :note-move}
+                :*          {:action :log-unknown}}}
 ```
 
 See [Self-transitions and wildcards](concepts.md#self-transitions-and-wildcards).
 
 ### **forbidden transition**
 
-A present `:on` key whose value is the **empty map** (`{:on {:E {}}}`) or **`nil`** — a handler that *consumes* an event and stops the deepest-wins search without changing state. It's how a child [compound state](#compound-state) **opts out** of a transition its parent would otherwise inherit to it. Distinct from an *unhandled* event (which falls through to coarser tiers and up to ancestors): a forbidden block is itself a match, so the search stops there.
+Present `:on` key with value `{}` or `nil` — consumes the event and stops
+deepest-wins search without changing state. How a child opts out of a parent
+transition. Distinct from unhandled (missing key), which falls through.
 
 Covered with [wildcards](concepts.md#self-transitions-and-wildcards).
 
 ### **eventless transition (`:always`)**
 
-A state-node key holding a vector of guarded transitions that fire **with no event** — checked on entry (and after any transition landing in the state), first-passing-guard wins. The way to say "the snapshot just changed; if X is now true, move immediately." An `:always` may **not** target its own state (rejected at registration); the fixed-point pattern is a *targetless* guarded `:always` whose `:action` flips the guard.
+State-node key: vector of guarded transitions that fire **with no event** —
+checked on entry and after any landing transition; first-passing-guard wins. Must
+not target its own state (registration reject). Fixed-point form: targetless
+guarded `:always` whose action flips the guard.
 
 ```clojure
 :checking-form {:always [{:guard :form-valid?   :target :submitting}
@@ -155,60 +206,80 @@ Settled inside the [microstep](#microstep) loop. See [Automatic transitions](aut
 
 ### **delayed transition (`:after`)**
 
-The declarative timer: a state-node key mapping a delay to a transition. Enter the state and the timer arms; leave it and the timer cancels — no `setTimeout`-plus-cancel-flag to wire. A late-firing timer from an earlier visit is ignored (each visit is epoch-tagged), so you never get a ghost transition. The delay is a positive-integer millisecond count, a [subscription](../core/glossary.md#subscription) vector, or a `(fn [{:keys [snapshot]}] ms)`.
+Declarative timer: delay → transition. Enter arms; leave cancels. Epoch-tagged so
+late firings from earlier visits are ignored. Delay: positive-int ms, subscription
+vector, or `(fn [{:keys [snapshot]}] ms)`.
 
 ```clojure
-:reconnecting {:after {5000 {:target :connecting}}   ;; retry in 5s
+:reconnecting {:after {5000 {:target :connecting}}
                :on    {:net/give-up :failed}}
 ```
 
-(ISO-8601 durations and the `"5s"`-shorthand rejection belong to [`:timeout`](#timeout), not `:after` — an `:after` key is an ms int, a sub vector, or a fn.) See [Automatic transitions](automatic-transitions.md).
+ISO-8601 / `"5s"` shorthand belong to [`:timeout`](#timeout), not `:after`. See
+[Automatic transitions](automatic-transitions.md).
 
 ### **timeout**
 
-The named-intent spelling of "this state — or its spawned child — must finish before this deadline": a `:timeout` duration paired with an `:on-timeout` transition. It *lowers onto* the same [`:after`](#delayed-transition-after) timer machinery; it just reads as a deadline rather than a general delay. A duration is integer-ms (`5000`) or an ISO-8601 string (`"PT5S"`, `"PT1H30M"`) — `"5s"` is rejected, failing loud at registration.
+Named deadline: `:timeout` + `:on-timeout`. Lowers onto [`:after`](#delayed-transition-after).
+Duration: integer-ms or ISO-8601 (`"PT5S"`); `"5s"` rejected at registration.
 
 See [Automatic transitions](automatic-transitions.md).
 
 ### **choice state**
 
-A `:type :choice` **transient** routing node: enter it and it resolves *immediately* — same step, no event — to the first candidate whose `:guard` passes. It's [`:always`](#eventless-transition-always)'s decision pattern with a name, so a diagram renders an explicit fork. The candidate list is a **declarative array** that must include an unguarded default and must not declare ordinary state keys.
+`:type :choice` transient routing node: resolves immediately on entry to the first
+candidate whose guard passes. Declarative candidate **array** (must include unguarded
+default); no ordinary state keys. Desugars to [`:always`](#eventless-transition-always).
 
 See [Automatic transitions](automatic-transitions.md).
 
 ### **run-to-completion**
 
-The guarantee that a machine processes one event **to a settled, stable configuration before the next event is seen** — every [`:always`](#eventless-transition-always) microstep and every [`:raise`](#raise)d event drains, then the snapshot [commits](#commit) once. External observers (subs, other machines, tools) only ever see the settled state, never a mid-cascade intermediate. A non-converging `:always` / `:raise` loop can't hang the runtime: it's bounded (default depth 16) and aborts atomically with the snapshot unchanged.
+One event processes to a settled configuration before the next is seen — every
+[`:always`](#eventless-transition-always) microstep and [`:raise`](#raise) drains,
+then the snapshot [commits](#commit) once. External observers never see mid-cascade
+intermediates. Non-converging loops are depth-bounded (default 16) and abort with
+the snapshot unchanged.
 
-See [microstep](#microstep) and [macrostep](#macrostep).
+See [microstep](#microstep), [macrostep](#macrostep).
 
 ## Actors and composition
 
 ### **spawn**
 
-A declarative key that starts a *child* machine on entering a [state](#state) and tears it down on leaving; the child reports a result back through [`:on-done`](#on-done-and-output-key). (`:spawn-all` starts several in parallel and joins on completion.) Under the hood it's the reserved [`[:rf.machine/spawn …]`](../api/re-frame.machines.md#rfmachinespawn-spawn-spec) [effect](../core/glossary.md#effect); emit that directly from any handler when you need a dynamic count rather than one-child-per-state. The running instance it creates is an [actor](#actor).
+Declarative key that starts a child machine on state entry and tears it down on
+exit; result returns via [`:on-done`](#on-done-and-output-key). (`:spawn-all` starts
+several in parallel and joins.) Under the hood: reserved
+[`[:rf.machine/spawn …]`](../api/re-frame.machines.md#rfmachinespawn-spawn-spec)
+effect. Running instance is an [actor](#actor).
 
 See [Actors](actors.md).
 
 ### **actor**
 
-A *live machine instance* — a [snapshot](#snapshot) sitting at `[:rf.runtime/machines :snapshots <id>]` in [runtime-db](../core/glossary.md#runtime-db). Two kinds: a long-lived **singleton** (one per `reg-machine` id) and a dynamically **[spawned](#spawn)** child (a per-request protocol machine, a wizard's per-step subprocess). An actor's *liveness IS its snapshot's presence* — there's no parallel registry; destroying it removes the snapshot. Address a spawned actor by its allocated id (`<prefix>#<n>`, never `gensym`), or by role via a [system-id](#system-id).
-
-The live instance is just a value in the frame, so time-travel and SSR extend to it for free.
+Live machine instance — a [snapshot](#snapshot) at
+`[:rf.runtime/machines :snapshots <id>]` in [runtime-db](../core/glossary.md#runtime-db).
+Two kinds: long-lived **singleton** (`reg-machine` id) and dynamically
+**[spawned](#spawn)** child. Liveness *is* snapshot presence. Address by allocated
+id (`<prefix>#<n>`, never `gensym`) or [system-id](#system-id).
 
 ### **spawn-all**
 
-The fan-out sibling of [`:spawn`](#spawn): on entering a state it starts **N children in parallel** and **joins** on their completion, resolving when they've all finished (or on the first failure, with a cooperative cancellation cascade). Used for "spawn a worker per chunk and continue when all return."
+Fan-out sibling of [`:spawn`](#spawn): starts **N children in parallel** and
+**joins** on completion (or first failure with cooperative cancel).
 
-See the [long_running_work example](../../examples/patterns/long_running_work/) and [Actors → Fan-out and join](actors.md#fan-out-and-join-with-spawn-all).
+See [long_running_work](../../examples/patterns/long_running_work/);
+[Actors → Fan-out and join](actors.md#fan-out-and-join-with-spawn-all).
 
 ### **:on-done and :output-key**
 
-How a finishing child reports back. A [final state](#final-state) names an **`:output-key`** — the slot of its [`:data`](#data) to surface as its result. The parent's [`:spawn`](#spawn) declares **`:on-done`**, a `(fn [{:keys [data result]}] new-data)` that fires the instant the child enters its final state, receiving that value as `result`; the runtime then tears the child down. Completion is **event-shaped** — it *happens* and flows, rather than sitting in a readable `output` slot.
+How a finishing child reports back. Final state names **`:output-key`** (slot of
+[`:data`](#data) to surface). Parent's [`:spawn`](#spawn) declares **`:on-done`**
+`(fn [{:keys [data result]}] new-data)`; runtime then tears the child down.
+Completion is event-shaped — it *happens*, not a long-lived `output` slot.
 
 ```clojure
-:done {:final? true :output-key :token}             ;; child reports :data's :token
-;; parent:
+:done {:final? true :output-key :token}
 :authenticating {:spawn {:machine-id :auth-flow
                          :on-done (fn [{:keys [data result]}]
                                     (assoc data :token result))}}
@@ -218,27 +289,36 @@ See [Actors → When a child finishes](actors.md#when-a-child-finishes).
 
 ### **system-id**
 
-A stable **role name** (`:logger`, `:websocket`, `:retry-coordinator`) bound to a spawned [actor](#actor), so a parent can address its child by *role* instead of by allocated id. The action-side surface is the reserved `[:rf.machine/dispatch-to-system [system-id event]]` [effect](../core/glossary.md#effect) — a machine [action](#action) can't read app-db, so the fx tuple is how it messages a named child.
+Stable role name (`:logger`, `:websocket`) bound to a spawned [actor](#actor).
+Action-side: `[:rf.machine/dispatch-to-system [system-id event]]` — actions can't
+read app-db, so the fx is how they message a named child.
 
 ```clojure
 {:fx [[:rf.machine/dispatch-to-system [:logger [:logger/flush]]]]}
 ```
 
-The fx is a **parked named-addressing escape** — zero in-repo consumers as of 2026-07-10, retained for XState v6 actor-system parity (`systemId` addressing); the everyday send is plain `dispatch` to the id you hold (a machine *is* an event handler). See the [`machine-by-system-id`](../api/re-frame.machines.md#re-framemachinesmachine-by-system-id) lookup helper.
+Parked XState v6 parity escape (`systemId`); everyday send is plain `dispatch` to
+the id you hold. See [`machine-by-system-id`](../api/re-frame.machines.md#re-framemachinesmachine-by-system-id).
 
 ### **:raise**
 
-A reserved, **machine-only** fx-id. Inside an [action](#action)'s `:fx`, `[:raise [:some-event …]]` loops an event back into *this same machine* — **atomically, pre-commit**, drained FIFO through a local queue inside the one handler invocation (it never touches the router queue). Use it when one transition's outcome should immediately drive another, all inside one [macrostep](#macrostep). Contrast `:fx [[:dispatch [self-id …]]]`, which is a *separate*, post-commit [event](../core/glossary.md#event) (its own [epoch](../core/glossary.md#epoch)).
+Machine-only fx-id. Inside an action's `:fx`, `[:raise [:some-event …]]` loops an
+event into *this* machine — **atomically, pre-commit**, FIFO inside one handler
+invocation (never the router queue). Contrast `:fx [[:dispatch [self-id …]]]`
+(separate post-commit event / [epoch](../core/glossary.md#epoch)).
 
 ```clojure
 {:actions {:kick (fn [_] {:fx [[:raise [:tick]]]})}}
 ```
 
-See [`[:raise event-vec]`](../api/re-frame.machines.md#raise-event-vec) and [When the machine grows](concepts.md#when-the-machine-grows).
+See [`[:raise event-vec]`](../api/re-frame.machines.md#raise-event-vec);
+[When the machine grows](concepts.md#when-the-machine-grows).
 
 ### **:internal-events**
 
-A top-level **set** of event ids that are machine *plumbing* — events the machine [`:raise`](#raise)s at itself, not for a view or test to dispatch. An internal `:raise` of one is handled normally; an *external* dispatch is **refused** at the machine's boundary (no transition; a `:rf.error/machine-internal-event-external-dispatch` trace fires).
+Top-level **set** of event ids that are machine plumbing — raised at itself, not
+for external dispatch. External dispatch is refused
+(`:rf.error/machine-internal-event-external-dispatch` trace).
 
 ```clojure
 {:internal-events #{:check-complete}
@@ -251,7 +331,11 @@ See [When the machine grows](concepts.md#when-the-machine-grows).
 
 ### **state tag**
 
-A label like `:auth/busy` attached to several [machine](#machine) [states](#state); the active state's tags ride on the [snapshot](#snapshot), so a [view](../core/glossary.md#view) can ask "is it busy?" ([`[:rf.machine/has-tag? …]`](../api/re-frame.machines.md#rfmachinehas-tag-machine-id-tag)) instead of enumerating exact state names — *ask, don't tell*. Add a sixth busy state and no view changes. Across [parallel regions](#region), every active state's tags union onto the one snapshot.
+Label like `:auth/busy` on several [states](#state); active tags ride the
+[snapshot](#snapshot). Views ask
+[`[:rf.machine/has-tag? …]`](../api/re-frame.machines.md#rfmachinehas-tag-machine-id-tag)
+instead of enumerating names. Across [parallel regions](#region), tags union onto
+one snapshot.
 
 ```clojure
 (when @(rf/subscribe [:rf.machine/has-tag? :auth.login/flow :auth/busy])
@@ -262,24 +346,44 @@ See [Tags](tags.md).
 
 ## The runtime model
 
-These terms describe *how* a transition actually runs. You can build machines without them, but they're the vocabulary for reasoning about ordering and atomicity — and what the [trace stream](../core/glossary.md#trace-stream) shows you.
+Vocabulary for ordering and atomicity — and what the [trace stream](../core/glossary.md#trace-stream)
+shows. You can ship machines without memorising these.
 
 ### **drain**
 
-The deterministic ordering rules by which a machine's effects compose at four nested levels: within one action's `:fx` (vector order; `:data` lands before `:fx`); across the `:exit` → `:action` → `:entry` slots of one [transition](#transition); within one machine event (the [microstep](#microstep) loop over [`:always`](#eventless-transition-always) and [`:raise`](#raise)); and across the runtime's per-frame queue (FIFO, except machine-originated continuation events leap-frog to the front so a machine settles its [macrostep](#macrostep) before the next external event). The order in the source is the order at runtime — no reordering for "optimisation."
+Deterministic ordering of effects at four levels: within one action's `:fx`
+(`:data` before `:fx`); across `:exit` → `:action` → `:entry`; within one machine
+event ([microstep](#microstep) over [`:always`](#eventless-transition-always) and
+[`:raise`](#raise)); across the per-frame queue (FIFO, with machine continuations
+leap-frogging so a [macrostep](#macrostep) settles first). Source order is runtime
+order.
 
 ### **microstep**
 
-One iteration of the settle loop *inside* a single machine event: after the resolving transition, the runtime **prefers an enabled [`:always`](#eventless-transition-always)** transition; only when none is enabled does it **dequeue one [`:raise`](#raise)d event** (FIFO). It loops until no `:always` is enabled *and* the raise-queue is empty — the fixed point. Microsteps are **not** separately observable; they're the internal steps that compose one [macrostep](#macrostep). Bounded at depth 16 (`:always-depth-limit` / `:raise-depth-limit`).
+One settle-loop iteration inside a machine event: prefer an enabled
+[`:always`](#eventless-transition-always); else dequeue one [`:raise`](#raise)
+(FIFO). Loops to fixed point. Not separately observable; composes one
+[macrostep](#macrostep). Bounded at depth 16.
 
 ### **macrostep**
 
-The whole machine event — the resolving transition plus every [`:always`](#eventless-transition-always) [microstep](#microstep) and every [`:raise`](#raise)d sub-event — seen as **one logical step** from outside: one [commit](#commit), one trace row, one [epoch](../core/glossary.md#epoch). External observers only ever see the post-commit settled [snapshot](#snapshot), never an intermediate. This is what makes a machine [run-to-completion](#run-to-completion).
+Whole machine event — resolving transition plus every microstep and raise — as
+**one** logical step outside: one [commit](#commit), one trace row, one
+[epoch](../core/glossary.md#epoch). External observers see only the post-commit
+snapshot. This is [run-to-completion](#run-to-completion).
 
 ### **commit**
 
-The single, deferred [runtime-db](../core/glossary.md#runtime-db) write that lands a [macrostep](#macrostep)'s settled [snapshot](#snapshot) at `[:rf.runtime/machines :snapshots <id>]` — **once per transition**, no matter how many actions or microsteps fired. It's the boundary at which the [`:schemas :data`](concepts.md#validating-a-machines-data) check runs (a violation rolls the whole transition back) and the point a reading [subscription](../core/glossary.md#subscription) re-fires. (See the general framework [commit](../core/glossary.md#commit).)
+Single deferred [runtime-db](../core/glossary.md#runtime-db) write of a
+[macrostep](#macrostep)'s settled [snapshot](#snapshot) at
+`[:rf.runtime/machines :snapshots <id>]` — once per transition. Boundary for
+[`:schemas :data`](concepts.md#validating-a-machines-data) (violation rolls back)
+and for subscription re-fire. (Framework [commit](../core/glossary.md#commit).)
 
 ### **LCCA (least common compound ancestor)**
 
-Also written **LCA**. For a [transition](#transition) from source path A to target path B inside a [compound state](#compound-state), the LCCA is the deepest state that stays active across the move — it neither exits nor enters. The exit cascade runs `:exit` from A's leaf *up to (not including)* the LCCA (deepest-first); the entry cascade runs `:entry` from just below the LCCA *down to* B's leaf (shallowest-first); the transition `:action` fires once at the boundary. For the common case it's just the longest common prefix of A and B — *except* when B is on A's active path or a descendant the declaring compound names, where it pulls up to a **proper** ancestor so the targeted subtree actually re-resolves. For a flat machine the LCCA is the root, and the rule collapses to plain `:exit` → `:action` → `:entry`.
+Also **LCA**. For a [transition](#transition) from path A to B inside a
+[compound](#compound-state), the deepest state that stays active — neither exits
+nor enters. Exit cascade: leaf up to (not including) LCCA, deepest-first. Entry:
+just below LCCA down to B's leaf, shallowest-first. Transition `:action` once at
+the boundary. Flat machine: LCCA is the root → plain exit → action → entry.

--- a/docs/machines/hierarchical-states.md
+++ b/docs/machines/hierarchical-states.md
@@ -5,39 +5,34 @@ Flat machines ([the model](concepts.md)) put every state at one level. A
 cascade entry into an `:initial` child, and finish a sub-flow without ending the
 whole machine.
 
-A flat machine is a single list of states, one active at a time. That carries
-most flows. But some states are really a *cluster*: three leaves that share a
-resource, a sub-flow with its own beginning and end, a family of states that
-should all answer the same event the same way. A **compound state** is a state
-that contains its own `:states` map — a little machine nested inside one state
-of the bigger one.
+A flat list of states, one active at a time, carries most flows. Some states are
+really a *cluster*: three leaves that share a resource, a sub-flow with its own
+beginning and end, a family that should answer the same event the same way. A
+**compound state** contains its own `:states` map — a little machine nested inside
+one state of the bigger one.
 
-You reach for hierarchy when:
+Reach for hierarchy when:
 
 - **Several leaves share a lifecycle or a resource.** A WebSocket's
   `:connecting → :authenticating → :connected` happy path all ride *one* live
-  socket. They aren't independent states — they're three phases of being
-  *connected*. Nest them under one `:active` parent and the socket spans all
-  three.
+  socket — three phases of being *connected*. Nest them under one `:active` parent
+  and the socket spans all three.
 - **You want to factor a transition to a parent.** Every authenticated screen
   should honour `:logout` the same way. Declare it *once* on the parent; every
-  descendant inherits it (the [parent-fallthrough](#transition-resolution-deepest-wins-with-parent-fallthrough)
-  rule below). No restating, no drift.
-- **A sub-flow has a clear "done."** A checkout collects, submits, confirms —
-  then the outer flow moves on. Mark the sub-flow's terminal leaf and the
-  parent advances automatically (the [done signal](#when-a-sub-flow-finishes-nested-final-states) below).
+  descendant inherits it ([parent-fallthrough](#transition-resolution-deepest-wins-with-parent-fallthrough)).
+  No restating, no drift.
+- **A sub-flow has a clear "done."** A checkout collects, submits, confirms — then
+  the outer flow moves on. Mark the sub-flow's terminal leaf and the parent
+  advances ([done signal](#when-a-sub-flow-finishes-nested-final-states)).
 
-The grammar recurses and stays additive: a substate is either a **leaf** (no
-`:states`) or another **compound** (has `:states`, and must declare
-`:initial`). Flat machines stay flat — you only pay for hierarchy where you use
-it.
+The grammar recurses: a substate is a **leaf** (no `:states`) or another
+**compound** (has `:states` and must declare `:initial`). You only pay for
+hierarchy where you use it.
 
-The canonical worked example is the connection machine in
-[`../../examples/patterns/websocket/`](../../examples/patterns/websocket) — its
-`:active` state parents the three happy-path leaves. The snippets on this page
-are simplified from it. For the flat grammar this builds on, read
-[The model](concepts.md) first. Spawned sockets on a parent state are covered in
-[Actors](actors.md).
+Canonical example: the connection machine in
+[`../../examples/patterns/websocket/`](../../examples/patterns/websocket) — `:active`
+parents the three happy-path leaves. Snippets below are simplified from it. Flat
+grammar: [The model](concepts.md). Spawned sockets on a parent: [Actors](actors.md).
 
 ---
 
@@ -331,7 +326,7 @@ returning `{:data … :fx …}`. The `:fx` flow through the ordinary
 
 A compound state often *is* a sub-flow with a clear end: collect, submit, paid.
 re-frame2 ships the statechart pattern for "the sub-flow finished, now advance
-the outer flow" first-class — and **the machine keeps running**.
+the outer flow" — and **the machine keeps running**.
 
 Mark the sub-flow's terminal leaf `:final? true`. The moment a compound's active
 child becomes that final leaf, the engine raises a synthetic, transitionable
@@ -370,7 +365,7 @@ event, so an **ancestor** can catch it with an explicit
 ### Depth decides the meaning — embedded vs whole-machine final
 
 The same `:final?` key means two different things depending on **how deep the
-leaf sits.** This is the one subtlety worth internalising:
+leaf sits:**
 
 | `:final?` leaf placement | Meaning | Effect |
 |---|---|---|

--- a/docs/machines/history.md
+++ b/docs/machines/history.md
@@ -3,21 +3,35 @@
 Re-enter a [compound](hierarchical-states.md) at the substate you left — a media
 player resumes mid-track. History is a transition *target*, not a state you occupy.
 
-Some compound states have a memory. A media player you stop and restart should resume *mid-track*, not jump back to the first second. A wizard you step away from and return to should land on the step you left, not step one. A tabbed settings panel should remember which tab — and how far down each tab was scrolled — across a close/reopen. That "resume where I last was" behaviour is what a **history state** gives you, declaratively, for any [compound state](hierarchical-states.md).
+Without it you stash the last substate in `:data` on the way out, read it back on
+the way in, and wire the restore yourself. A **history state** is that pattern as
+one node — `:type :history` — and because record/restore live *inside the
+snapshot*, they ride undo, time-travel, persistence, and SSR without extra wiring.
 
-Without it you reach for the obvious workaround — stash the last substate in `:data` on the way out, read it back on the way in, and write the wiring to restore it. History states make that pattern a single node in the transition table — a first-class `:type :history` node — and (because the record/restore lives *inside the snapshot*) they ride undo, time-travel, persistence, and SSR for free.
-
-> History only applies to a **compound** state — a state with its own `:states` and `:initial`. If "which tab" or "which step" is a single flat value, just keep it in [`:data`](concepts.md#the-same-flow-as-a-transition-table) like any other state; that is ordinary modelling, not a feature you need to name. History earns its keep when a *non-trivial nested* configuration is worth remembering across a leave/return.
+> History only applies to a **compound** state — a state with its own `:states` and
+> `:initial`. If "which tab" is a single flat value, keep it in
+> [`:data`](concepts.md#the-same-flow-as-a-transition-table). History earns its keep
+> when a *non-trivial nested* configuration is worth remembering across a leave/return.
 
 ## A history state is a transition *target*, not a state you occupy
 
-The mental model to get right first: a history state is a **pseudo-state**. You declare it under a compound's `:states` map, right alongside the compound's real substates, but the machine *never sits in it*. Its only job is to be the **target of a transition** — and when a transition resolves to it, it stands in for "the substate this compound was in when control last left it." The runtime resolves it to a real leaf, the entry cascade enters *that* leaf, and the [snapshot](glossary.md#snapshot)'s `:state` records the resolved leaf — never the pseudo-state.
+A history state is a **pseudo-state**. You declare it under a compound's `:states`
+alongside real substates, but the machine *never sits in it*. Its only job is to be
+the **target of a transition** — when a transition resolves to it, it stands for
+"the substate this compound was in when control last left it." The runtime resolves
+it to a real leaf, the entry cascade enters *that* leaf, and the
+[snapshot](glossary.md#snapshot)'s `:state` records the resolved leaf — never the
+pseudo-state.
 
-So you write `[:player :hist]` as a transition target the same way you'd write any state path, and it resolves to a recorded (or default) configuration instead of to a fixed state.
+Write `[:player :hist]` as a target the same way you'd write any state path; it
+resolves to a recorded (or default) configuration.
 
 ## A worked example — a media player that resumes
 
-Here is a player with a `:tray` (no disc) and a `:player` compound (disc inserted). The `:player` compound owns a `:type :history` pseudo-state. `:eject` leaves `:player` for `:tray`; `:insert` comes back in *through history*, restoring whatever the player was doing when it was ejected:
+A player with a `:tray` (no disc) and a `:player` compound (disc inserted). The
+`:player` compound owns a `:type :history` pseudo-state. `:eject` leaves `:player`
+for `:tray`; `:insert` comes back *through history*, restoring whatever the player
+was doing when ejected:
 
 ```clojure
 (rf/reg-machine :media-player
@@ -45,7 +59,7 @@ Here is a player with a `:tray` (no disc) and a `:player` compound (disc inserte
       :paused  {:on {:resume [:player :playing]}}}}}})
 ```
 
-A machine **is an event handler** — there is no actor to `send` to — so you drive it with ordinary dispatched events and read it with an ordinary subscription:
+Drive it with ordinary dispatched events; read it with an ordinary subscription:
 
 ```clojure
 (rf/dispatch [:media-player [:insert]])  ;; :tray → nothing recorded yet → :default-target → [:player :stopped]
@@ -62,28 +76,32 @@ A machine **is an event handler** — there is no actor to `send` to — so you 
 ;;  union is omitted from the snapshot rather than stored as #{})
 ```
 
-You wrote no capture code, no "remember the last tab" action. The `[:player :hist]` target does the work.
+You wrote no capture code. The `[:player :hist]` target does the work.
 
 ## The three keys — and nothing else
 
-A `:type :history` pseudo-state carries **exactly** three keys, all owned by the history grammar:
+A `:type :history` pseudo-state carries **exactly** three keys:
 
 | Key | Value | Meaning |
 |---|---|---|
-| `:type` | `:history` | The discriminator that marks this node as a history pseudo-state rather than a real substate. **Required.** |
-| `:deep?` | boolean | `true` ⇒ **deep** history (restore the full recorded leaf path). `false` or **absent** ⇒ **shallow** (restore the recorded *direct child*, then cascade through *that* child's `:initial` chain). Default is shallow — a missing `:deep?` reads as `false`. |
-| `:default-target` | child keyword *or* absolute vector | Where to land the **first** time the compound is entered, before anything has been recorded. A direct-child keyword (`:stopped`) or an absolute path. **Absent** ⇒ falls back to the owning compound's `:initial`. |
+| `:type` | `:history` | Marks this node as a history pseudo-state. **Required.** |
+| `:deep?` | boolean | `true` ⇒ **deep** (full recorded leaf path). `false` or **absent** ⇒ **shallow** (recorded *direct child*, then that child's `:initial` chain). Default is shallow. |
+| `:default-target` | child keyword *or* absolute vector | Where the **first** entry lands before anything is recorded. **Absent** ⇒ owning compound's `:initial`. |
 
-It MUST NOT declare `:on` / `:entry` / `:exit` / `:always` / `:after` / `:spawn` / `:spawn-all` / `:states` / `:initial` / `:tags` / `:final?` — the machine never occupies it, so transition and lifecycle keys are meaningless on it. Any such key is a **registration error** (caught when you `reg-machine`, not on the unlucky dispatch that first reaches it).
+It MUST NOT declare `:on` / `:entry` / `:exit` / `:always` / `:after` / `:spawn` /
+`:spawn-all` / `:states` / `:initial` / `:tags` / `:final?` — the machine never
+occupies it. Any such key is a **registration error** at `reg-machine` time, not on
+first dispatch.
 
 ## Shallow vs deep — how *much* of the path is restored
 
-This is the one knob that trips people. Take the same player and eject from deep inside — `[:player :playing :mid-track]`:
+Eject from deep inside — `[:player :playing :mid-track]`:
 
-- **Deep** (`:deep? true`) records the **full leaf path** beneath the compound. On `:insert` it re-enters every level back down to the exact leaf — `[:player :playing :mid-track]`. The player resumes the exact track *and* its mid-track position.
-- **Shallow** (omit `:deep?`) records only the compound's **direct child** — here `:playing`. On `:insert` it restores that child and then cascades through *its* `:initial` chain. So it resumes `[:player :playing :at-start]` — the right top-level branch (we were playing), but its initial inner position, not `:mid-track`.
-
-So the recorded slot differs by kind:
+- **Deep** (`:deep? true`) records the **full leaf path**. On `:insert` it re-enters
+  every level back to that leaf — `[:player :playing :mid-track]`.
+- **Shallow** (omit `:deep?`) records only the compound's **direct child** — here
+  `:playing`. On `:insert` it restores that child and cascades through *its*
+  `:initial` — so `[:player :playing :at-start]` (right branch, initial inner position).
 
 ```clojure
 ;; after :eject, DEEP:
@@ -92,75 +110,113 @@ So the recorded slot differs by kind:
 :rf/history {[:player] :playing}                        ;; just the direct child keyword
 ```
 
-Reach for **deep** when the precise nested position matters (resume the exact track and scrub point); **shallow** when only the top-level branch matters (which tab, not the tab's inner scroll).
+Reach for **deep** when the precise nested position matters; **shallow** when only
+the top-level branch matters (which tab, not the tab's inner scroll).
 
 ## Recording happens on exit — the compound must actually be *left*
 
-Recording is automatic and happens on the way **out**: whenever the exit cascade *leaves* a compound that owns a history pseudo-state, the runtime writes that compound's last-active configuration into the snapshot. You never write capture code.
+Recording is automatic on the way **out**: when the exit cascade *leaves* a compound
+that owns a history pseudo-state, the runtime writes that compound's last-active
+configuration into the snapshot. You never write capture code.
 
-The owning compound must be **genuinely exited** to record. This is the [W3C SCXML](https://www.w3.org/TR/scxml/#history) exit-set rule: a `<history>` value is written only for states in the exit set. A transition that merely moves *between two children* of the compound keeps the compound as the [least-common ancestor](hierarchical-states.md#entryexit-cascading-along-the-lca) — the compound **survives**, was never left, and so records nothing (there is no "last config" to remember; it is still in one).
+The owning compound must be **genuinely exited**. This is the
+[W3C SCXML](https://www.w3.org/TR/scxml/#history) exit-set rule: a `<history>` value
+is written only for states in the exit set. A transition that merely moves *between
+two children* of the compound keeps the compound as the
+[least-common ancestor](hierarchical-states.md#entryexit-cascading-along-the-lca) —
+the compound **survives**, was never left, and records nothing.
 
-That is exactly why `:eject` targets `:tray` (a *sibling of* `:player`, outside it) rather than some inner state: only leaving `:player` puts it in the exit set. A common first mistake is to put the history node on a compound that nothing ever exits — then it silently never records and "restore" always falls to the default. If your history isn't sticking, check that *something leaves the owning compound.*
+That is why `:eject` targets `:tray` (a *sibling of* `:player`, outside it) rather
+than some inner state: only leaving `:player` puts it in the exit set. A common
+mistake is putting the history node on a compound that nothing ever exits — then it
+silently never records and "restore" always falls to the default. If history isn't
+sticking, check that *something leaves the owning compound.*
 
-Symmetrically, the restore transition — which *enters* the compound through `[:player :hist]` — records nothing for that compound; re-entry leaves the recorded slot untouched.
+Symmetrically, restoring through `[:player :hist]` records nothing for that
+compound; re-entry leaves the recorded slot untouched.
 
 ## Restoring — recorded, else default-target, else `:initial`
 
-When a transition resolves to the pseudo-state, the runtime resolves the target leaf in this order:
+When a transition resolves to the pseudo-state, the runtime picks a leaf in this
+order:
 
-1. **A valid recording exists** for the compound → restore it (deep = full leaf path; shallow = recorded child then its `:initial` cascade).
-2. **No recording** (the compound was never entered/exited) → resolve the pseudo-state's `:default-target`; if `:default-target` is absent, fall back to the compound's own `:initial` and cascade from there exactly as a first-ever entry would.
-3. **A recording exists but is no longer a valid path** in the current definition — a *dangling recorded path* after a hot reload removed that substate → the runtime discards it and falls back to `:default-target` / `:initial` per (2). It never enters a dead path; this is benign and raises no error.
+1. **A valid recording exists** → restore it (deep = full leaf path; shallow =
+   recorded child then its `:initial` cascade).
+2. **No recording** → resolve `:default-target`; if absent, the compound's
+   `:initial` and cascade from there.
+3. **Recording exists but is no longer a valid path** (hot reload removed a
+   substate) → discard it and fall back per (2). Never enters a dead path; benign,
+   no error.
 
-Once the pseudo-state resolves to a concrete leaf, nothing else about history is special: the standard LCA computation, exit/entry cascade ordering, `:always` settling, and `:after` timer scheduling all apply to the resolved leaf exactly as if you'd written that leaf as a literal `:target`. History is a *target-resolution step*, not a new cascade mechanism.
+Once resolved to a concrete leaf, history is just target resolution: standard LCA
+computation, exit/entry cascade, `:always` settling, and `:after` scheduling apply
+as if you'd written that leaf as a literal `:target`.
 
 ## The `:rf/history` snapshot slot
 
-The recording lives in a reserved, framework-owned slot at the root of the snapshot — a sibling of the other `:rf/*` runtime slots:
+Recording lives in a reserved framework-owned slot at the snapshot root:
 
 ```clojure
 {:state      [:player :stopped]
  :data       {…}
- :rf/history {[:player] [:player :playing :mid-track]}}   ;; map: compound decl-path → recorded config
+ :rf/history {[:player] [:player :playing :mid-track]}}   ;; compound decl-path → recorded config
 ```
 
-`:rf/history` is a **map**, keyed by the compound's **declaration path** (a vector of keywords) → that compound's recorded configuration (a full leaf path for deep, a direct-child keyword for shallow). It is a map because a machine can own several history-bearing compounds, each recorded independently. The slot is:
+`:rf/history` is a **map**, keyed by the compound's **declaration path** (keyword
+vector) → recorded configuration (full leaf path for deep, direct-child keyword for
+shallow). A machine can own several history-bearing compounds. The slot is:
 
-- **read-only for you** — the runtime owns it and writes it during the exit cascade; app code MUST NOT write under it;
-- **allocated lazily** — absent until a history-bearing compound is first exited; a machine with no history nodes never carries the key;
-- **EDN-clean** — vectors and keywords only, so it round-trips through `pr-str` / `read-string` like the rest of the snapshot.
+- **read-only for you** — runtime writes it during the exit cascade; app code MUST
+  NOT write under it;
+- **allocated lazily** — absent until a history-bearing compound is first exited;
+- **EDN-clean** — vectors and keywords only, so it round-trips with the rest of the
+  snapshot.
 
-Because the recording is *part of the snapshot value* — not a side-table — recorded history rides every path the snapshot rides, with no extra machinery: undo and [time-travel](../core/glossary.md#time-travel) (rewind to an earlier epoch and its `:rf/history` rewinds too, so "rewind, then re-enter the compound" replays deterministically), persistence, and SSR hydration. The snapshot lives in the frame's [runtime-db](../core/glossary.md#runtime-db), the framework's half of state — so, like everything else there, it is just a value that replay can reach.
+Because the recording is *part of the snapshot value*, it rides every path the
+snapshot rides: undo and [time-travel](../core/glossary.md#time-travel), persistence,
+SSR hydration. The snapshot lives in [runtime-db](../core/glossary.md#runtime-db).
 
 ## Per-region history under `:type :parallel`
 
-Under a [parallel](parallel-states.md) machine each region runs an independent state-tree, so **history is per-region**: a history node declared inside a region's compound records and restores *that region's* configuration on the region's own exit cascade, independently of its siblings. The `:rf/history` keys are **region-qualified** — the region name is the head segment of the declaration-path key — so two regions that each declare a history-bearing compound at structurally-identical paths never collide:
+Under a [parallel](parallel-states.md) machine each region runs an independent
+state-tree, so **history is per-region**: a history node inside a region's compound
+records and restores *that region's* configuration on the region's own exit cascade.
+`:rf/history` keys are **region-qualified** — region name is the head segment — so
+structurally identical paths in two regions never collide:
 
 ```clojure
 ;; Two regions, each with a history-bearing :on compound at the same shape.
-;; The region name heads the KEY (so recordings stay separate); the recorded
-;; VALUE is that region's own within-region path:
+;; The region name heads the KEY; the recorded VALUE is the within-region path:
 {:rf/history {[:left  :group :on] [:group :on :bright]
               [:right :group :on] [:group :on :dim]}}
 ```
 
-Restoring history in one region leaves the others untouched — the same per-region scoping that `:spawn`, `:after`, and `:always` follow under parallel.
+Restoring history in one region leaves the others untouched — same per-region
+scoping as `:spawn`, `:after`, and `:always` under parallel.
 
-## Why history is first-class, not a snapshot you stash yourself
+## Advanced
 
-You *could* hand-roll the equivalent: an `:exit` action that copies the current sub-path into `:data`, an entry that reads it back, plus the bookkeeping to know *which* compound (and, under parallel, *which region*). re-frame2 ships the declarative node instead, for four reasons:
+You *could* hand-roll the equivalent: an `:exit` action that copies the current
+sub-path into `:data`, an entry that reads it back, plus bookkeeping for which
+compound (and region). re-frame2 ships the declarative node instead:
 
-- **Declarative beats hand-rolled.** `{:type :history :deep? true}` is one node an AI agent (or a teammate) reads and writes confidently; the stash-and-restore version is bespoke per machine.
-- **Composition you'd otherwise re-derive.** Per-region history under parallel, deep nesting, and shallow-vs-deep depth all fall out of the grammar plus the existing cascade machinery — the hand-rolled form has to re-implement each, correctly, every time.
-- **Tooling legibility.** A `:type :history` node is visible to the machine inspector, the diagram exporter, and the SCXML corpus; hand-rolled `:data` shuffling is invisible to all of them.
-- **Parity.** SCXML (`<history>`) ships first-class history; matching that shape keeps the conformance corpus aligned.
+- **One node** — `{:type :history :deep? true}` is readable in review and to tools;
+  stash-and-restore is bespoke per machine.
+- **Composition falls out of the grammar** — per-region history, deep nesting,
+  shallow-vs-deep, without re-implementing cascade rules.
+- **Tooling** — a `:type :history` node is visible to the inspector and diagram
+  exporters; hand-rolled `:data` shuffling is not.
+- **SCXML parity** — `<history>` keeps the conformance corpus aligned.
 
-Revertibility is what makes history *cheap* (the recording rides the snapshot), but it's the foundation history is built on, not a reason to skip the feature.
+The recording rides the snapshot so revertibility is cheap; that is the foundation,
+not a reason to skip the feature.
 
-## Gotchas
+## Troubleshooting
 
-- **The owning compound must actually be exited** to record. A within-compound sibling move (the compound survives as the LCA) records nothing — give the compound an off-state to leave for (the `:tray` in the example).
-- **The pseudo-state is never in `:state`.** The machine's `:state` is never `[… :hist]`; a transition to `:hist` resolves to a real leaf. Don't `case` on the pseudo-state keyword in views.
-- **History only applies to a compound.** A `:type :history` node at the machine root (or under a `:type :parallel` root with no enclosing compound region) is a registration error — there is no configuration for it to record.
-- **At most one history node per compound.** Deep-vs-shallow is the single node's `:deep?`, not a reason for two nodes. Two history children under one compound is a registration error.
-- **`:default-target` (keyword form) names a *direct child*** of the owning compound, then cascades any `:initial` chain — not an arbitrary sibling elsewhere. Use the vector form for an absolute path. An unresolvable `:default-target` is a registration error.
+| Symptom | Cause | Fix |
+|---|---|---|
+| History never restores; always hits default | Owning compound never left (sibling moves keep it as LCA) | Give the compound an off-state outside it (the `:tray` pattern) |
+| View `case`s on `:hist` | Pseudo-state is never in `:state` | Transition to `:hist` resolves to a real leaf — case on that |
+| Registration error at root / bare parallel | History needs an enclosing compound | Nest under a compound with `:states` + `:initial` |
+| Two history children under one compound | At most one history node per compound | Use one node; deep-vs-shallow is `:deep?` |
+| Unresolvable `:default-target` | Keyword form must name a *direct child* | Use a direct-child keyword, or vector form for an absolute path |

--- a/docs/machines/index.md
+++ b/docs/machines/index.md
@@ -9,24 +9,23 @@ flows usually hide as enums and booleans scattered across handlers.
 
 <a id="first-class-support"></a>
 
-A **machine** makes that shape first-class: one data table of states and
-transitions, driven by ordinary `dispatch`, read by ordinary `subscribe`, living in
-the same [frame](../core/frames.md) as the rest of re-frame2. No second runtime.
+A **machine** makes that shape explicit: one data table of states and transitions,
+driven by ordinary `dispatch`, read by ordinary `subscribe`, living in the same
+[frame](../core/frames.md) as the rest of re-frame2. No second runtime.
 
 ## Start here
 
 1. **[Tutorial](tutorial.md)** — build a login machine in six steps (guard, action,
-   HTTP, view, pure test). Best first hour.
+   HTTP, view, pure test).
 2. **[The model](concepts.md)** — the flat grammar those steps rely on: register,
    snapshot, encapsulation, self-transitions, finals.
-3. Then open a growth page only when a need appears (tags for views, hierarchy for
-   nested flows, actors for workers, …). The left nav lists them in a sensible
-   order; MkDocs prev/next walks them.
+3. Open a growth page when a need appears (tags for views, hierarchy for nested
+   flows, actors for workers, …). The left nav lists them in dependency order.
 
 **Prerequisites.** The [Core introduction](../core/introduction.md) — events, app-db,
 subscriptions, effects. Machines plug into those; they do not replace them.
 
-Optional later: [examples](examples.md), [XState mapping](coming-from-xstate.md),
+Optional: [examples](examples.md), [XState mapping](coming-from-xstate.md),
 [glossary](glossary.md).
 
 ## A machine in four lines
@@ -61,5 +60,5 @@ SSR, and tests share the same pipeline as the rest of the app.
 | Server fetch / cache / invalidate | [resources](../resources/concepts.md) |
 | A fixed sequence of operations | chained events / effects |
 
-Reach for a machine when **named stages and legal transitions** are the load-bearing
-concept — not when the load-bearing concept is a value or a network cache.
+Reach for a machine when **named stages and legal transitions** are the thing you
+are modelling — not when the thing is a value or a network cache.

--- a/docs/machines/inspecting-machines.md
+++ b/docs/machines/inspecting-machines.md
@@ -3,22 +3,26 @@
 You can [author](tutorial.md) and [understand](concepts.md) machines. This page is
 how you **watch** one and **prove** the table.
 
-A machine is [just an event handler](concepts.md#register-and-drive) whose body
+A machine is [an event handler](concepts.md#register-and-drive) whose body
 interprets a transition table; its whole state is a plain value in runtime-db.
 There is **no parallel machine runtime** and **no second store**. Subscribe like
 any re-frame2 state; watch events in Xray; unit-test with a pure function call.
 
-You reach for the tools here in two situations:
+Two situations:
 
-- **A flow misbehaves and you need to see *why*.** Which transition fired? Did the guard pass? What did the action write? *Watch* the machine: open Xray's Machine Inspector and read the transition, or drop to the trace stream for the exact guard/action records.
-- **You want fast, headless confidence the table is correct.** *Test* the machine: feed a snapshot and an event to `machine-transition` and assert on what comes back — no frame, no browser, no network, microseconds per case on the JVM.
+- **A flow misbehaves and you need to see *why*.** Which transition fired? Did the
+  guard pass? What did the action write? Open Xray's Machine Inspector, or drop to
+  the trace stream for the exact guard/action records.
+- **Headless confidence the table is correct.** Feed a snapshot and an event to
+  `machine-transition` and assert on what comes back — no frame, no browser, no
+  network, microseconds per case on the JVM.
 
-Four surfaces, building from "read the value" to "prove the logic":
+Four surfaces, from "read the value" to "prove the logic":
 
 | Surface | Question it answers | Tool |
 |---|---|---|
 | `[:rf/machine id]` subscription | *What state is it in right now?* | `rf/subscribe` |
-| Xray Machine Inspector | *What did this event do to the machine?* / *What's the chart?* | Xray (Dynamic + Static) |
+| Xray Machine Inspector | *What did this event do?* / *What's the chart?* | Xray (Dynamic + Static) |
 | `:rf.machine/*` trace events + `handler-meta` | *Did this guard pass? Where is that action defined?* | trace bus / source-jump |
 | `machine-transition` | *Is the table correct?* (headless test) | pure function call |
 
@@ -80,7 +84,10 @@ This sub re-renders only when *this* tag's membership bit flips, so adding a fif
 
 !!! note "The snapshot is a value, not a live object"
 
-    It lives at `[:rf.runtime/machines :snapshots :auth.login/flow]` in runtime-db and is read through the ordinary subscription graph. The payoff is that time-travel, undo, persistence, and SSR hydration all extend to machines *for free*, because the snapshot rides the frame like any other state.
+    It lives at `[:rf.runtime/machines :snapshots :auth.login/flow]` in runtime-db
+    and is read through the ordinary subscription graph. Time-travel, undo,
+    persistence, and SSR hydration extend to machines without extra wiring — the
+    snapshot rides the frame like any other state.
 
 See [`[:rf/machine machine-id]`](../api/re-frame.machines.md#rfmachine-machine-id) and [`machine-has-tag?`](../api/re-frame.machines.md) in the API reference.
 
@@ -181,10 +188,10 @@ This is the surface Xray's focused-transition lens and the re-frame2 pair MCP us
 
 ## Unit-test transitions as pure function calls — `machine-transition`
 
-This is where machines pay you back hardest. A transition is a pure function of
-*(definition, snapshot, event)*, exposed as `re-frame.machines/machine-transition`.
-No frame, no browser, no mocks, no clock — table in, snapshot in, event in; result
-out. These tests run on the JVM in microseconds.
+A transition is a pure function of *(definition, snapshot, event)*, exposed as
+`re-frame.machines/machine-transition`. No frame, no browser, no mocks, no clock —
+table in, snapshot in, event in; result out. These tests run on the JVM in
+microseconds.
 
 Use the same `login-flow` value from the [tutorial](tutorial.md#the-complete-machine)
 (the `defmachine` binding, not the registered id):

--- a/docs/machines/parallel-states.md
+++ b/docs/machines/parallel-states.md
@@ -4,15 +4,31 @@ One machine, several **orthogonal** axes active at once — form validity × loa
 state × mode — without exploding a cross-product of flat states. Assumes the
 [flat model](concepts.md); pairs naturally with [tags](tags.md).
 
-Some lifecycles aren't *one* question — they're several, all live at once. A todos screen is *somewhere in its fetch* (nothing / loading / empty / some / too-many), *somewhere in its form* (neutral / valid / invalid), and *somewhere in its page mode* (active / archived). Those three axes are **orthogonal**: each moves on its own, and any combination is legal.
+Some lifecycles aren't *one* question — they're several, all live at once. A todos
+screen is *somewhere in its fetch*, *somewhere in its form*, and *somewhere in its
+page mode*. Those three axes are **orthogonal**: each moves on its own, and any
+combination is legal.
 
-Model that as one flat machine and the states multiply — three axes of three states each is `3 × 3 × 3 = 27` cross-product states, most of them named things like `:loading-and-invalid-and-active`. **Parallel regions** keep the axes apart. One machine declares `:type :parallel` and a `:regions` map; each region is a full little state-tree minding one axis; all regions are active simultaneously. Three axes of three states becomes **nine states across three regions**, not twenty-seven flat ones.
+Model that flat and the states multiply — three axes of three states each is
+`3 × 3 × 3 = 27` cross-product states named things like
+`:loading-and-invalid-and-active`. **Parallel regions** keep the axes apart: one
+machine, `:type :parallel`, a `:regions` map; each region is a full little
+state-tree; all regions active simultaneously. Three axes of three states becomes
+**nine states across three regions**, not twenty-seven flat ones.
 
 ## When to reach for parallel regions
 
-Reach for them when you have **multiple orthogonal axes of one feature** that share a domain: one form with data / validity / display-mode axes, one connection with auth + lifecycle + request-queue, one widget with display + interaction state. The giveaway is a single conceptual thing whose state is naturally a *tuple* of independent sub-states.
+Reach for them when you have **multiple orthogonal axes of one feature** that share
+a domain: one form with data / validity / display-mode axes, one connection with
+auth + lifecycle + request-queue. The giveaway is a single conceptual thing whose
+state is naturally a *tuple* of independent sub-states.
 
-The axes share a single [`:data`](concepts.md#the-same-flow-as-a-transition-table) map *because they're facets of one domain* — they read and write the *same* data, just sliced differently. If your axes are genuinely separate features that share nothing (a websocket connection plus an unrelated auth flow plus a route), that's not parallel regions — that's **N separate machines** colocated in [runtime-db](../core/glossary.md#runtime-db). Per-region `:data` is deliberately **not** supported; if your axes need encapsulated data, that's the substrate telling you to register N machines instead.
+The axes share a single
+[`:data`](concepts.md#the-same-flow-as-a-transition-table) map *because they're
+facets of one domain*. If your axes are genuinely separate features that share
+nothing (websocket + unrelated auth + route), that's **N separate machines** in
+[runtime-db](../core/glossary.md#runtime-db). Per-region `:data` is **not**
+supported; if axes need encapsulated data, register N machines instead.
 
 ## The shape: one machine, several regions
 
@@ -97,7 +113,9 @@ All three regions are alive at their initial states, and the `:tags` set already
 
 ## Broadcast: one event reaches every region
 
-This is the heart of it. Every event dispatched at a parallel machine is **broadcast to every region**. Each region's *currently-active* state independently decides whether the event matches one of its `:on` keys:
+Every event dispatched at a parallel machine is **broadcast to every region**. Each
+region's *currently-active* state independently decides whether the event matches
+one of its `:on` keys:
 
 - **The region has a matching transition whose guard passes** → that region transitions (exit cascade → action → entry cascade), and any `:fx` its action returns joins the macrostep.
 - **The region has no matching transition** (or its guard returns false) → that region stays put. No per-region complaint is raised.
@@ -142,11 +160,20 @@ When *several* regions handle the same event, each one's action runs against the
 
 If you wanted that event to count *once*, you'd register the coordinating action at the parent-machine level, or shape the regions so only one handles it.
 
-!!! note "A subtle, load-bearing rule — selection is order-independent"
+!!! note "Selection is order-independent"
 
-    The broadcast is **select-then-apply**: every region's enabled transition is *selected* against **one frozen pre-broadcast snapshot** of the configuration, and only *then* are the selected transitions *applied* in declaration order. Declaration order governs only the apply order (action / `:fx` order, `:data` accumulation) — **never** which transitions are selected. Reorder the regions and you get the *same* selected set, and the new configuration is computed **atomically** old→new: no region ever observes an intermediate state where some siblings have moved and others haven't. This matches SCXML, where a parallel macrostep selects against the pre-event configuration.
+    The broadcast is **select-then-apply**: every region's enabled transition is
+    *selected* against **one frozen pre-broadcast snapshot**, and only *then* are
+    the selected transitions *applied* in declaration order. Declaration order
+    governs apply order (action / `:fx`, `:data` accumulation) — **never** which
+    transitions are selected. Reorder the regions and you get the *same* selected
+    set; the new configuration is computed **atomically** old→new — no region
+    observes an intermediate where some siblings have moved and others haven't.
+    Matches SCXML: a parallel macrostep selects against the pre-event configuration.
 
-    The same select-then-apply shape governs `:always` too, once the event set has landed — the parent repeats it per [round](#always-stabilization-is-parent-owned) until the machine is quiescent. It's one idea, applied twice.
+    The same select-then-apply shape governs `:always` once the event set has
+    landed — the parent repeats it per [round](#always-stabilization-is-parent-owned)
+    until the machine is quiescent.
 
 ## The root `:on`: an ancestor fallback
 
@@ -332,4 +359,10 @@ The composed tag union also delivers the headline payoff: **collapsing N live ax
 
 ## A divergence to know: no nested parallel regions
 
-**Nested parallel regions are not supported in v1.** A region whose own tree declares `:type :parallel` is rejected at registration with `:rf.error/machine-parallel-nested-not-supported`. Model a would-be two-level cross-product as a flatter set of regions, or — more idiomatically — as multiple top-level parallel-region machines. A region *may* still be a compound (hierarchical) state-tree; it just can't itself be parallel. This is a **deferred** (not permanently-blessed) divergence — the spec records the reconsideration trigger that would un-defer it: a real two-level cross-product that genuinely cannot flatten. See [Spec 005 §Three non-substrate divergences, item 2](../../spec/005-StateMachines.md#three-non-substrate-divergences--ruled-and-recorded).
+**Nested parallel regions are not supported in v1.** A region whose own tree
+declares `:type :parallel` is rejected at registration with
+`:rf.error/machine-parallel-nested-not-supported`. Model a would-be two-level
+cross-product as a flatter set of regions, or as multiple top-level parallel
+machines. A region *may* still be a compound (hierarchical) state-tree; it just
+can't itself be parallel. This is a **deferred** divergence — reconsidered if a
+real two-level cross-product appears that genuinely cannot flatten.

--- a/docs/machines/tags.md
+++ b/docs/machines/tags.md
@@ -1,13 +1,12 @@
 # State tags
 
 You know the [flat model](concepts.md): states, transitions, snapshot. This page is
-the first growth feature — how views ask **what is true** without hard-coding state
-names.
+how views ask **what is true** without hard-coding state names.
 
 Some questions are not "which state?" but "is it *busy*?" across `:loading`,
 `:retrying`, `:reconnecting`, and whatever you add next month. A
-**[state tag](glossary.md#state-tag)** is a semantic label on a state so a view asks
-for intent — busy, read-only, terminal — instead of enumerating names. *Ask, don't
+**[state tag](glossary.md#state-tag)** is a label on a state so a view asks for
+intent — busy, read-only, terminal — instead of enumerating names. *Ask, don't
 tell.*
 
 Reach for tags when:
@@ -19,11 +18,12 @@ Reach for tags when:
   state.
 
 If a label would only ever match one state, skip it — compare `:state` directly.
-Tags earn their keep when one label covers many states.
 
 ## Declaring tags on a state
 
-`:tags` is a state-node key whose value is a **set of keywords**. There's no separate registration step — it's just another slot on the state, alongside `:on`, `:entry`, and `:after`:
+`:tags` is a state-node key whose value is a **set of keywords**. No separate
+registration — just another slot on the state, alongside `:on`, `:entry`, and
+`:after`:
 
 ```clojure
 (rf/reg-machine :todos/loader
@@ -41,7 +41,9 @@ Tags earn their keep when one label covers many states.
     :error    {:tags #{:data/error}}}})
 ```
 
-Both `:loading` and `:retrying` wear `:data/in-flight`. A view that wants "show the spinner while a request is in flight" consumes that one tag and never disjoins two state keywords — and the day you add a third in-flight state, it's one `:tags` entry and the view picks it up for free.
+Both `:loading` and `:retrying` wear `:data/in-flight`. A view that wants "show the
+spinner while a request is in flight" consumes that one tag — and a third in-flight
+state is one `:tags` entry with no view change.
 
 Two rules:
 
@@ -183,4 +185,6 @@ The worked example — a `:checkout` region whose `:submit` waits for the `:form
 - **Not an autonomous driver.** A tag appearing never fires a transition by itself — it's read by guards, it doesn't trigger them. For a state change that should follow a `:data` condition on its own, use a guarded eventless `:always`.
 - **Not user-writable.** An action can't return `:tags` in its `{:data :fx}` map — the slot is runtime-owned and derived from `:state`.
 - **Not the `:meta` slot.** A state's `:meta` (e.g. `{:terminal? true}`) is static, tooling-visible metadata; `:tags` is the runtime projection of the *active* configuration. Both can sit on the same state; they are not synonyms.
-- **Not a replacement for `[:rf/machine id]`.** When a view needs the whole snapshot it still subscribes to `:rf/machine`; `machine-has-tag?` is for the predicate-shaped question. Both are first-class.
+- **Not a replacement for `[:rf/machine id]`.** When a view needs the whole snapshot
+  it still subscribes to `:rf/machine`; `machine-has-tag?` is for the
+  predicate-shaped question.

--- a/docs/machines/tutorial.md
+++ b/docs/machines/tutorial.md
@@ -1,11 +1,11 @@
 # Tutorial: build a login machine
 
 Build one machine end to end — idle → submitting → authed / error / locked-out —
-adding one idea at a time. By the end you have a **complete, copy-pasteable** table
+one idea per step. By the end you have a **complete, copy-pasteable** table
 (guards, actions, HTTP, timeout, tags, lock-out) plus a view and a pure test.
 
 **Prerequisites.** [Core introduction](../core/introduction.md) (events, app-db,
-effects). Vocabulary after this walk-through: [The model](concepts.md).
+effects). Vocabulary for later pages: [The model](concepts.md).
 
 ## Step 0 — turn machines on
 


### PR DESCRIPTION
## Summary
- Surgical voice pass on all `docs/machines/**/*.md` against `docs/core/AUTHORING.md`
- Senior vocabulary filter; operational claims; Troubleshooting/Advanced headings; terse glossary
- Removed reader-facing `spec/` links; dropped Day-one framing; preserved error ids and XState delta teaching

## Test plan
- [x] `python scripts/check_doc_slugs.py` green
- [ ] `mkdocs build --strict` (CI)