### PR TITLE
fix(freehand): make the spread-safe caller carrier unforgeable

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/node.cljc
+++ b/implementation/freehand/src/re_frame/freehand/node.cljc
@@ -650,16 +650,57 @@
 (def caller-attrs-key
   "The reserved key `v/spread-safe` hands the guarded caller map to the
   interpreted walk under, riding IN the owned attr map the element already
-  reads. Reserved-namespaced, so an authored attribute can never collide with
-  it, and visible in the value rather than hidden in metadata a `merge` would
+  reads. Visible in the value rather than hidden in metadata a `merge` would
   quietly drop.
 
   A carried marker rather than a pre-merged map because the fold is
   [[element]]'s: the compiled front end reaches it with the owned props it
   analysed at build time and the caller map it could not, and the interpreted
   front end has to reach the SAME fold or the two modes would be two
-  implementations of one policy."
+  implementations of one policy.
+
+  Reserved-namespaced, but a reserved NAMESPACE is not on its own a reserved
+  key: Freehand's namespaced-attribute law makes `:rf.ui/caller` a perfectly
+  ordinary authored attribute, so the name is ALSO refused as an attribute
+  spelling ([[re-frame.freehand.rules/rejected-prop-spellings]]) and the
+  transport is marked at the value ([[carry-caller]]). The two together are
+  what make the carrier unforgeable: an authored key is refused before it can
+  be mistaken for transport, and a value that is not [[carry-caller]]'s is
+  never read as one."
   :rf.ui/caller)
+
+;; The transport MARK. An authored `:rf.ui/caller` cannot be one of these,
+;; whatever it carries, so the splitter below never has to guess whether the
+;; map it found is `v/spread-safe`'s or the author's — which is the guess that
+;; folded an authored string as a map (a raw class cast) and an authored map as
+;; a caller (forged attributes on an element that never asked for them).
+(deftype CarriedCaller [attrs])
+
+(defn carry-caller
+  "Mark the guarded caller map `m` as `v/spread-safe`'s TRANSPORT, so
+  [[split-caller]] can tell it from an authored attribute of the same name."
+  [m]
+  (CarriedCaller. m))
+
+(defn split-caller
+  "Split an element's authored props map into the attributes it folds and the
+  guarded `v/spread-safe` caller map it may be carrying — `[attrs caller]`.
+
+  The one splitter both interpreted front ends call, because the fold on the
+  other side of it (caller under owned, `:class` composing owned-first) is one
+  policy and reading the carrier is half of applying it.
+
+  A `caller-attrs-key` entry that is NOT [[carry-caller]]'s mark is left in the
+  attribute map, where the ordinary refusal
+  ([[re-frame.freehand.conversion/attr-key-refusal]]) names it. That is the
+  whole forgery answer: the transport is identified by the mark, and the name
+  is identified as not-an-attribute, so neither reading can be reached by
+  writing the other."
+  [authored]
+  (let [carried (get authored caller-attrs-key)]
+    (if (instance? CarriedCaller carried)
+      [(dissoc authored caller-attrs-key) (.-attrs ^CarriedCaller carried)]
+      [authored nil])))
 
 (defn spread-safe-attrs
   "`(v/spread-safe owned caller)` — the owned props map carrying its guarded
@@ -675,7 +716,7 @@
       {:value (shape owned)}))
   (let [caller* (safe-caller-attrs caller (owned-handler-keys owned))]
     (cond-> (or owned {})
-      (some? caller*) (assoc caller-attrs-key caller*))))
+      (some? caller*) (assoc caller-attrs-key (carry-caller caller*)))))
 
 (defn- fold-caller
   "Fold a guarded `v/spread-safe` caller map UNDER the element's already-final

--- a/implementation/freehand/src/re_frame/freehand/react.cljs
+++ b/implementation/freehand/src/re_frame/freehand/react.cljs
@@ -672,9 +672,10 @@
         ;; not to either front end. Left in the attribute map it is not an
         ;; attribute at all: it reached the plain-attribute path and refused the
         ;; whole element, so `v/spread-safe` did not render in an interpreted
-        ;; browser view. Split here, exactly as `tree/element-attrs` splits it.
-        caller    (get authored node/caller-attrs-key)
-        attrs     (dissoc authored node/caller-attrs-key)
+        ;; browser view. Split through the ONE splitter the structural walk uses,
+        ;; so an authored key of the same name is refused identically on both.
+        [attrs
+         caller]  (node/split-caller authored)
         kid-forms (if attrs? (rest args) args)
         ;; The DOM top layer's desired-state pair never reaches React as a
         ;; prop — an emitter drops the namespace that is the whole of its

--- a/implementation/freehand/src/re_frame/freehand/rules.cljc
+++ b/implementation/freehand/src/re_frame/freehand/rules.cljc
@@ -346,13 +346,26 @@
 (def rejected-prop-spellings
   "One spelling per name — ambiguities removed at compile time (conversion
   table §Attribute names; template grammar). The value is the didactic
-  replacement the compile error names."
+  replacement the compile error names.
+
+  The last entry is a different kind of name. `:rf.ui/caller` is the
+  RESERVED slot `(v/spread-safe owned caller)` hands its guarded caller map
+  to an element under, and the element walks read it as transport rather
+  than as an attribute. Freehand's own namespaced-attribute law makes
+  `[:div {:rf.ui/caller …}]` an ordinary authored attribute, so without an
+  entry here the two readings collide: an authored string was folded as a
+  map and threw a raw class cast, and an authored MAP was folded silently,
+  injecting caller attributes into an element that never asked for them.
+  Refusing the NAME — every spelling of it, on the direct attribute path
+  and inside a forwarded runtime map alike — leaves the transport with
+  exactly one producer, `v/spread-safe` itself."
   {:class-name                  ":class"
    :html-for                    ":for"
    :dangerously-set-inner-html  "(v/html ...)"
    :dangerouslySetInnerHTML     "(v/html ...)"
    :inner-html                  "(v/html ...)"
-   :children                    "positional children"})
+   :children                    "positional children"
+   :rf.ui/caller                "(v/spread-safe owned caller)"})
 
 (defn- collapsed [n] (str/replace n "-" ""))
 

--- a/implementation/freehand/src/re_frame/freehand/tree.cljc
+++ b/implementation/freehand/src/re_frame/freehand/tree.cljc
@@ -197,19 +197,6 @@
     m
     attrs))
 
-(defn- element-attrs
-  "Split an element's authored props map into the attributes it folds and the
-  `v/spread-safe` caller map it may be carrying.
-
-  `(v/spread-safe owned caller)` answers the owned map with the GUARDED caller
-  riding under [[re-frame.freehand.node/caller-attrs-key]], because the fold —
-  caller under owned, `:class` composing owned-first — belongs to the one
-  canonicaliser rather than to either front end. The compiled emitter hands
-  the same two values to the same slot from the other side."
-  [authored]
-  [(dissoc authored node/caller-attrs-key)
-   (get authored node/caller-attrs-key)])
-
 (defn- element-node
   [tag-kw args]
   (when (namespace tag-kw)
@@ -223,8 +210,14 @@
                       (str "The element head " tag-kw " carries only .class#id sugar and no tag.")
                       {:value (shape tag-kw)}))
         attrs?    (map? (first args))
+        ;; `(v/spread-safe owned caller)` answers the owned map with the GUARDED
+        ;; caller riding under a reserved carrier key, because the fold — caller
+        ;; under owned, `:class` composing owned-first — belongs to the one
+        ;; canonicaliser rather than to either front end. The compiled emitter
+        ;; hands the same two values to the same slot from the other side, and
+        ;; the sibling React walk reads the carrier through this same splitter.
         [authored
-         caller]  (if attrs? (element-attrs (first args)) [nil nil])
+         caller]  (if attrs? (node/split-caller (first args)) [nil nil])
         kid-forms (if attrs? (rest args) args)]
     (node/element
       (with-attrs (cond-> {:tag      tag

--- a/implementation/freehand/test/re_frame/freehand/caller_carrier_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/caller_carrier_cljs_test.cljc
@@ -1,0 +1,170 @@
+(ns re-frame.freehand.caller-carrier-cljs-test
+  "`(v/spread-safe owned caller)`'s internal transport, and the fact that an
+  author cannot write it.
+
+  The guarded caller map rides to the element inside the owned attribute map,
+  under a reserved key, because the fold that puts it UNDER the owned props
+  belongs to the canonicaliser rather than to either front end. That leaves one
+  key with two readings — transport to the walks, an ordinary namespaced
+  attribute to Freehand's own attribute law — and both readings were reachable
+  by writing the key:
+
+    [:div {:rf.ui/caller \"authored\"}]        threw a raw ClassCastException,
+                                             folding a string as a map;
+    [:div {:rf.ui/caller {:data-x \"1\"}}]      rendered a PERFECTLY WELL-FORMED
+                                             element carrying `data-x` — caller
+                                             attributes forged onto an element
+                                             that never asked for them.
+
+  The second is why the rows below assert the RESULT rather than that something
+  went wrong: a test that only demanded a throw, or a non-empty render, passed
+  against the defect.
+
+  Three walks read one roster, so all three are asked here — the interpreted
+  structural walk, the interpreted React walk, and the compiled analyzer — plus
+  the two runtime forwarding verbs, because `v/spread` could hand the same key
+  to the same seam from the other side."
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.analyze-reject-cljs-test :refer [reject-id]]
+            [re-frame.freehand.conformance :as conf]
+            [re-frame.freehand.tree :as tree]
+            #?(:cljs [goog.object :as gobj])
+            #?(:cljs [re-frame.freehand.react :as fr])))
+
+(def ^:private spellings
+  "Every representation of the reserved carrier NAME. The walks classify an
+  attribute key by the prop name they are about to emit — the namespace is
+  dropped on the way to the DOM — so a qualified keyword, a plain keyword, a
+  string and a symbol are one name written four ways, and a guard that read the
+  raw key would leave three of them outside it."
+  [:rf.ui/caller :caller :x/caller "caller" 'caller])
+
+(def ^:private forged-values
+  "What an authored carrier could carry. The MAP is the dangerous one — it is
+  the shape the fold expects, so it produced an element rather than an error."
+  ["authored" {:data-forged "yes"} nil])
+
+;; ---------------------------------------------------------------------------
+;; The interpreted structural walk
+;; ---------------------------------------------------------------------------
+
+(deftest an-authored-carrier-key-is-refused-by-the-structural-walk
+  (testing "Every spelling of the reserved name, carrying every shape an
+            author could give it, is refused with the grammar's own typed
+            diagnostic — including the map, which used to be folded."
+    (doseq [k spellings
+            raw forged-values]
+      (is (= :rf.error/ui-tree-malformed
+             (conf/caught-id #(tree/render [:div {k raw}])))
+          (str (pr-str k) " carrying " (pr-str raw) " is refused, not folded"))))
+
+  (testing "and the diagnostic names the verb that owns the transport"
+    (is (str/includes? (conf/caught-message
+                         #(tree/render [:div {:rf.ui/caller {:data-forged "yes"}}]))
+                       "(v/spread-safe owned caller)")))
+
+  (testing "the forged attributes are the point: this exact element, with this
+            exact attribute map, is what the defect rendered from an authored
+            carrier — and it is reachable ONLY through the verb"
+    (is (= {:data-forged "yes"}
+           (:attrs (tree/render [:div (v/spread-safe {} {:data-forged "yes"})])))
+        "non-vacuous: the guarded carrier still delivers exactly these attrs"))
+
+  (testing "not over-broad — an ordinary qualified attribute whose name is not
+            the reserved one keeps its authored spelling"
+    (is (= {:x/title "t"} (:attrs (tree/render [:div {:x/title "t"}]))))
+    (is (= {"rf.ui/caller" "s"} (:attrs (tree/render [:div {"rf.ui/caller" "s"}])))
+        "a STRING key has no namespace to drop, so its emitted name is the whole
+         string and it is a different attribute from the reserved one")))
+
+(deftest a-guarded-caller-still-folds-under-the-owned-props
+  (testing "The transport itself is untouched by the refusal: owned wins,
+            `:class` composes sugar-then-owned-then-caller, and the caller's
+            own attributes arrive."
+    (is (= {:aria-label "L"
+            :data-x     "1"
+            :class      "field owned-class caller-class"
+            :value      "owned"}
+           (:attrs (tree/render
+                     [:input.field (v/spread-safe {:value "owned" :class "owned-class"}
+                                                  {:aria-label "L" :class "caller-class"
+                                                   :data-x "1"})]))))))
+
+;; ---------------------------------------------------------------------------
+;; The runtime forwarding verbs
+;; ---------------------------------------------------------------------------
+
+(deftest a-forwarded-runtime-map-cannot-smuggle-the-carrier
+  (testing "`v/spread` reaches the element through the same seam, so a
+            runtime-assembled map carrying the reserved key is refused where a
+            literal one is — at the verb, before anything renders."
+    (is (= :rf.error/ui-tree-malformed
+           (conf/caught-id #(v/spread {} {:rf.ui/caller {:data-forged "yes"}}))))
+    (is (str/includes? (conf/caught-message
+                         #(v/spread {} {:rf.ui/caller {:data-forged "yes"}}))
+                       "A forwarded attribute map carries :rf.ui/caller")))
+
+  (testing "and a CALLER map handed to `v/spread-safe` cannot carry it either —
+            the guard canonicalizes the key to its name first, so the qualified
+            spelling is refused as the plain one is"
+    (is (= :rf.error/ui-tree-malformed
+           (conf/caught-id #(v/spread-safe {} {:rf.ui/caller {:data-forged "yes"}})))))
+
+  (testing "non-vacuous: an ordinary forwarded key passes both verbs"
+    (is (= {:title "t"} (v/spread {} {:title "t"})))
+    (is (= {:data-x "1"}
+           (:attrs (tree/render [:div (v/spread-safe {} {:data-x "1"})]))))))
+
+;; ---------------------------------------------------------------------------
+;; The compiled analyzer
+;; ---------------------------------------------------------------------------
+
+(deftest the-compiled-analyzer-refuses-the-carrier-spelling-too
+  (testing "One roster, three readers: the analyzer answers a literal carrier
+            key at build time with its own rejected-spelling error, so a
+            declaration cannot compile into the shape the interpreted walks
+            refuse."
+    (doseq [k [:rf.ui/caller :caller :x/caller]]
+      (is (= :rf.ui.compile/rejected-prop-spelling (reject-id [:div {k "authored"}]))
+          (str (pr-str k) " projects onto the reserved carrier slot"))))
+
+  (testing "not over-broad — a neighbouring qualified prop still compiles"
+    (is (nil? (reject-id '[:div {:x/title "ok"}])))))
+
+;; ---------------------------------------------------------------------------
+;; The interpreted React walk
+;; ---------------------------------------------------------------------------
+
+#?(:cljs
+   (deftest an-authored-carrier-key-is-refused-by-the-react-walk
+     (testing "The sibling emitter reads the carrier through the same splitter,
+               so an authored key is refused there with the same typed
+               diagnostic rather than reaching React as a props object entry."
+       (doseq [k spellings
+               raw forged-values]
+         (is (= :rf.error/ui-tree-malformed
+                (conf/caught-id #(fr/element [:div {k raw}])))
+             (str (pr-str k) " carrying " (pr-str raw) " is refused by the React walk"))))))
+
+#?(:cljs
+   (deftest a-guarded-caller-reaches-the-react-props-object
+     (testing "The interpreted React path is the one this transport was invisible
+               on: the carrier reached the plain-attribute path and refused the
+               whole element. What is asserted is the props object React is
+               handed — owned value, caller `aria-*`/`data-*`, classes composed
+               owned-first — and that no transport entry rides along."
+       (let [props (.-props (fr/element
+                              [:input.field
+                               (v/spread-safe {:value "owned" :class "owned-class"}
+                                              {:aria-label "L" :class "caller-class"
+                                               :data-x "1"})]))]
+         (is (= "owned" (gobj/get props "value")))
+         (is (= "field owned-class caller-class" (gobj/get props "className")))
+         (is (= "L" (gobj/get props "aria-label")))
+         (is (= "1" (gobj/get props "data-x")))
+         (is (false? (gobj/containsKey props "caller"))
+             "no internal caller prop reaches React")
+         (is (false? (gobj/containsKey props "rf.ui/caller"))
+             "and neither does the reserved key under its own name")))))


### PR DESCRIPTION
This was dispatched as a **verify-or-close** task on a bead with two halves and
strong evidence that both had already shipped. One had. The other had not, and
the reproduction below is what separated them.

## What was reproduced against unmodified `origin/main`

The regression file in this PR was placed on top of `origin/main`'s **untouched**
sources and both lanes were run, so every claim below is a test result rather
than a reading of the tree.

**Half (a) — the interpreted React reach: ALREADY DELIVERED.** `v/spread-safe`
does reach the interpreted React emitter. `react/put-caller!` folds the guarded
caller under the owned props, and `react/element-node` splits the carrier out of
the authored map before `react-props` ever sees it. Against unmodified sources
the two rows that assert this — the React props object and the structural fold —
**passed**, and the browser lane was **fully green (671 tests / 4115 assertions)**,
which includes the row that mounts an INTERPRETED `v/spread-safe` view in a real
browser and pins its sorted DOM attribute map against its compiled twin. Nothing
in this PR implements that half.

**Half (b) — the forgery guard: NOT DELIVERED.** Against the same unmodified
sources, **27 failures and 2 errors**, in every tier the roster is supposed to
cover:

| written | before |
|---|---|
| `[:div {:rf.ui/caller "authored"}]` | raw `ClassCastException` — a string folded as a map, no diagnostic id at all |
| `[:div {:rf.ui/caller {:data-forged "yes"}}]` | rendered `{:tag :div, :attrs {:data-forged "yes"}}` — a **perfectly well-formed element carrying forged caller attributes** |
| `(v/spread {} {:rf.ui/caller {…}})` | the same forgery, from the other side of the seam |
| `:caller`, `:x/caller`, `"caller"`, `'caller` | all reached the same two readings |
| the compiled analyzer | compiled the literal key happily |

The second row is why the new tests assert the attribute map and the error id
rather than "it threw" or "it rendered something": a test demanding a throw, or a
non-empty render, **passes against the defect**.

## The fix

One key had two readings — transport to the walks, an ordinary namespaced
attribute under Freehand's own attribute law — and both were reachable by writing
it. Neither half of the answer works alone, so both are here:

- **The transport is marked at the value.** `node/carry-caller` wraps the guarded
  caller map, and `node/split-caller` — the ONE splitter both interpreted front
  ends now call, replacing `tree`'s private copy and `react`'s inline pair —
  reads a carrier only when it finds the mark. An authored value can never be
  one, so the walk no longer has to guess.
- **The reserved NAME is refused as an attribute.** It joins
  `rules/rejected-prop-spellings`, the single roster already read by
  `conv/attr-key-refusal`, `analyze/check-rejected-spelling!` and
  `node/assert-forwardable-attrs!` — so the structural walk, the React walk, a
  forwarded runtime map and the compiler all answer from one place, and none of
  those three readers needed editing. The refusal compares the emitted SLOT, so
  `:caller`, `:x/caller`, `"caller"` and `'caller` are refused **with** the
  qualified spelling rather than around it.

Together: an authored key is refused before it can be mistaken for transport, and
a value that is not the mark is never read as one.

No new public verb, no forwarding framework, no carrier protocol. The compiled
browser ABI boundary is untouched — the compiled tier passes its caller to
`node/element` directly and never builds a carrier. View call-site props named
`:caller` are unaffected: a call site normalizes through the descriptor, never
through the attribute rules.

A `"rf.ui/caller"` STRING key stays an ordinary attribute, deliberately: a string
has no namespace to drop, so the name it emits is the whole string — a different
attribute from `caller`, and not the reserved one.

## Quality gates

Every gate foreground, to completion, captured to a branch-distinctive log, exit
code echoed. All four run against the final commit; the shadow-cljs `config:`
banner named this worktree in each.

| gate | exit | result |
|---|---|---|
| `implementation/freehand` → `clojure -M:test` | 0 | 834 tests / 5911 assertions, 0 failures, 0 errors |
| `implementation` → `npm run test:freehand` | 0 | 820 tests / 4919 assertions, 0 failures, 0 errors |
| `implementation` → `npm run test:cljs` | 0 | 10945 tests / 55044 assertions, 0 failures, 0 errors |
| `implementation` → `npm run test:browser` | 0 | 671 tests / 4115 assertions, 0 failures, 0 errors |

**Non-vacuity.** One assertion inverted in each lane the new file runs in — the
structural fold's owned `:value`, and the React props object's composed
`className`. The JVM gate went red naming
`a-guarded-caller-still-folds-under-the-owned-props` (exit 1, 1 failure); the node
gate went red naming that row **and**
`a-guarded-caller-reaches-the-react-props-object` (exit 1). Both restored
byte-identical before the commit.

**Stronger than an inversion, for the refusal rows**: they were run against
`origin/main`'s own sources, where they red with the defect's actual signatures —
`::no-id` for the raw class cast, `::no-throw` for the silent forgery.

## Coverage

New: `implementation/freehand/test/re_frame/freehand/caller_carrier_cljs_test.cljc`
— cross-host, so it runs on the JVM and in the node CLJS lane. Five rows: the
structural walk's refusal of every spelling × every forgeable value, the runtime
verbs, the compiled analyzer, and (CLJS) the React walk's refusal plus the props
object a genuine carrier produces. Each refusal row is paired with a
non-vacuity row proving the same attributes still arrive through the verb itself.

Half (a) needs no new coverage. It is held by
`a-compiled-v-spread-safe-folds-the-guarded-caller-under-the-owned-props` in
`implementation/freehand/test/re_frame/freehand/compiled_mount_dom_cljs_test.cljs`,
which mounts `safe-probe-interpreted` alongside its compiled twin in a real
browser and compares sorted DOM attribute maps rather than `outerHTML`.
