### PR TITLE
docs: drop Start here mini-TOCs from corpus indexes

### DIFF
--- a/docs/AUTHORING.md
+++ b/docs/AUTHORING.md
@@ -41,8 +41,10 @@ below, know *why*.
    `mkdocs.yml`). Readers already get a left sidebar, section nesting, and
    prev/next from that build — do **not** re-implement navigation on the page.
    No "What's next" / "You can now" footers; no mini-TOCs that restate the left
-   nav. Useful cross-links go inline where relevant. A short "you can ship with
-   this" recap is not ceremony; a list of later chapters is.
+   nav; no **`## Start here`** (or similar) reading-order lists — MkDocs already
+   puts those headings in the page TOC and they only restate the sidebar. Useful
+   cross-links go inline where relevant. A short "you can ship with this" recap is
+   not ceremony; a list of later chapters is.
 
 ## Voice
 
@@ -122,6 +124,7 @@ not a second curriculum track. Optional depth goes at the end under **`## Advanc
 | `## Troubleshooting` | "When things go wrong", "Unhappy path" |
 | `## Advanced` | "Going further", "Day one / Going further" two-speed openers |
 | (no label) | "Basics", "Day-one checklist", "Essential" |
+| (omit) | `## Start here`, on-page reading-order mini-TOCs |
 
 ## Progressive pacing
 
@@ -199,10 +202,11 @@ not re-teach it.
 Interceptors and images are **structure but rare** — open with when-not; do not
 imply every app needs them on day two.
 
-**Domain corpora** (machines, resources, async, routing, ssr): index with **Start
-here** (tutorial first when one exists, then model, then growth in dependency
-order) → tutorial → model/concepts → growth pages → operate / migrate. Index also
-states **prerequisites** and **when not to use this artefact**.
+**Domain corpora** (machines, resources, async, routing, ssr): **nav order** is the
+reading order (tutorial first when one exists, then model, then growth in dependency
+order) — do not restate it on the index under `## Start here`. Index states
+**prerequisites** and **when not to use this artefact**, then the page's own job
+(demo, scope table, …).
 
 **Canon apps.** Counter for Core model pages (no server). RealWorld once server data
 enters. Domain corpora keep their own anchors (XState / login+websocket; TanStack

--- a/docs/async/index.md
+++ b/docs/async/index.md
@@ -20,6 +20,8 @@ reply arrives later as an **ordinary [event](../core/events.md)**:
 No `await`, no callback nesting, no resumed stack frame. Success and failure each
 have a name on the same wire as everything else.
 
+<a id="in-this-section"></a>
+
 **Prerequisites.** [Effects](../core/effects.md) — returning an effect map from a
 handler. Managed HTTP plugs into that pipeline; it does not replace events or app-db.
 

--- a/docs/async/index.md
+++ b/docs/async/index.md
@@ -20,22 +20,8 @@ reply arrives later as an **ordinary [event](../core/events.md)**:
 No `await`, no callback nesting, no resumed stack frame. Success and failure each
 have a name on the same wire as everything else.
 
-<a id="in-this-section"></a>
-
-## Start here
-
-1. **[Tutorial](tutorial.md)** — smallest request → failures → view → schema → retry →
-   race cure → network-free test. Best first hour.
-2. **[Managed HTTP](http.md)** — the full model/reference: args map, reply envelope,
-   closed failure kinds, retry, cancel, testing.
-3. Production when you need it: [interceptors and secrets](http-going-further.md).
-
 **Prerequisites.** [Effects](../core/effects.md) — returning an effect map from a
 handler. Managed HTTP plugs into that pipeline; it does not replace events or app-db.
-
-Optional later: [your own async fx](custom-effects.md),
-[why no await](continuations-are-data.md), [Promises mapping](coming-from-promises.md),
-[examples](examples.md).
 
 ## Scope
 

--- a/docs/machines/index.md
+++ b/docs/machines/index.md
@@ -13,20 +13,8 @@ A **machine** makes that shape explicit: one data table of states and transition
 driven by ordinary `dispatch`, read by ordinary `subscribe`, living in the same
 [frame](../core/frames.md) as the rest of re-frame2. No second runtime.
 
-## Start here
-
-1. **[Tutorial](tutorial.md)** — build a login machine in six steps (guard, action,
-   HTTP, view, pure test).
-2. **[The model](concepts.md)** — the flat grammar those steps rely on: register,
-   snapshot, encapsulation, self-transitions, finals.
-3. Open a growth page when a need appears (tags for views, hierarchy for nested
-   flows, actors for workers, …). The left nav lists them in dependency order.
-
 **Prerequisites.** The [Core introduction](../core/introduction.md) — events, app-db,
 subscriptions, effects. Machines plug into those; they do not replace them.
-
-Optional: [examples](examples.md), [XState mapping](coming-from-xstate.md),
-[glossary](glossary.md).
 
 ## A machine in four lines
 

--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -40,24 +40,9 @@ leak boundary. Views *read* — they never fetch.
 ;; => {:status :loading …}  then  {:status :loaded :data …}
 ```
 
-## Start here
-
-1. **[Tutorial: Build RealWorld](tutorial/index.md)** — five parts growing a Medium-style
-   app (pages → resources → auth → mutations → tests). Best first path if you want a
-   full app.
-2. **[The model](concepts.md)** — the grammar behind Part 2 onward: register, cause,
-   project, five statuses, scope, mutations.
-3. **Task recipes** when you have one job: [Paginate a feed](how-to/paginate-a-feed.md),
-   [Invalidate after a mutation](how-to/invalidate-after-a-mutation.md).
-4. **[Testing](testing.md)** — cause with a dispatch, answer with canned HTTP, read the
-   cache projection.
-
 **Prerequisites.** The [Core introduction](../core/introduction.md). Resources plug into
 events, app-db, and effects; they do not replace them. The transport underneath is
 [managed HTTP](../async/index.md) (`:rf.http/managed`).
-
-Optional later: [examples](examples.md), [TanStack mapping](coming-from-tanstack-query.md),
-[glossary](glossary.md).
 
 ## Three lanes
 

--- a/docs/routing/index.md
+++ b/docs/routing/index.md
@@ -21,24 +21,8 @@ testable like everything else.
 Route [loaders](glossary.md#loader) run on the server too — one data-fetch story
 with [SSR](../ssr/index.md), no separate server router.
 
-<a id="in-this-section"></a>
-
-## Start here
-
-1. **[Tutorial](tutorial.md)** — three-page app grown step by step (routes, links,
-   params, loaders, 404, Back button, layout). Best first hour.
-2. **[The model](concepts.md)** — three moves (registry row, navigate event, route
-   sub), then loaders, guards, not-found, URL binding.
-3. **Task recipes** when you have one job:
-   [unsaved changes](how-to/guard-unsaved-changes.md) (leave guard),
-   [require sign-in](how-to/require-sign-in-on-a-route.md) (multi-route interceptor —
-   prefer [`:can-enter`](concepts.md#guarding-entry--can-enter) for one page).
-
 **Prerequisites.** [Core introduction](../core/introduction.md) — events, app-db,
 subscriptions, views. Routing plugs into those; it does not replace them.
-
-Optional later: [testing](testing.md), [examples](examples.md),
-[React Router mapping](coming-from-react-router.md), [glossary](glossary.md).
 
 ## When *not* to use routing
 

--- a/docs/routing/index.md
+++ b/docs/routing/index.md
@@ -21,6 +21,8 @@ testable like everything else.
 Route [loaders](glossary.md#loader) run on the server too — one data-fetch story
 with [SSR](../ssr/index.md), no separate server router.
 
+<a id="in-this-section"></a>
+
 **Prerequisites.** [Core introduction](../core/introduction.md) — events, app-db,
 subscriptions, views. Routing plugs into those; it does not replace them.
 

--- a/docs/ssr/index.md
+++ b/docs/ssr/index.md
@@ -18,20 +18,8 @@ in the browser; only genuinely one-sided code is fenced with `:platforms`.
 (ssr/hydrate! {:frame :app :render-tree-fn (fn [] ((rf/view :app/root)))})
 ```
 
-## Start here
-
-1. **[Tutorial](tutorial.md)** — build the lifecycle by hand (REPL → frame per request →
-   payload → hydrate → mismatch → platforms → Ring).
-2. **[The model](concepts.md)** — why the same code runs on a JVM; request lifecycle;
-   fail-closed payload; hydrate-then-verify; platform gates; error projection.
-3. Open only when a need appears:
-   [response](response.md) · [head](head.md) · [streaming](streaming.md).
-
 **Prerequisites.** [Core introduction](../core/introduction.md) — events, app-db, views,
 frames. SSR plugs into those; it does not replace them.
-
-Also: [testing](testing.md), [examples](examples.md),
-[Next.js mapping](coming-from-nextjs.md), [glossary](glossary.md).
 
 ## When *not* to use SSR
 


### PR DESCRIPTION
## Summary

- Remove `## Start here` reading-order lists from corpus index pages (`async`, `machines`, `ssr`, `routing`, `resources`). Those headings only restate the left nav and also appear as TOC noise under MkDocs Material.
- Drop the companion "optional later / also" chapter lists on those indexes.
- Keep **Prerequisites** and **When not** (real content, not nav).
- Update `docs/AUTHORING.md`: ban `## Start here` as navigation ceremony; domain corpora reading order lives in mkdocs nav, not on-page mini-TOCs.

## Test plan

- [x] `python scripts/check_doc_slugs.py`
- [ ] Spot-check one corpus index in MkDocs: no "Start here" in on-page TOC