### PR TITLE
fix(freehand): four defects on the compiled-browser runtime surface

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/compiled_react.cljs
+++ b/implementation/freehand/src/re_frame/freehand/compiled_react.cljs
@@ -244,10 +244,18 @@
   "Prove a compiled list site's keys, at the site. Keys compare after
   React's own string coercion, so `1` and `\"1\"` are one key — the
   structural tier's `node/keyed-run` rule, raised with the same
-  diagnostic, at the same place."
+  diagnostic, at the same place.
+
+  `seen` is a `js/Set`, which is prototype-free by construction: it holds
+  exactly what was put in it. An object used as a map would not be —
+  `\"toString\"`, `\"constructor\"`, `\"hasOwnProperty\"` and `\"__proto__\"`
+  are inherited from `Object.prototype`, so the FIRST row keyed by one of
+  them would read as already present and be refused. The structural
+  tier's Clojure set accepts those keys, and a view that renders under
+  `node/keyed-run` has to render in a browser too."
   [seen k]
   (let [s (if (number? k) (conv/js-number-str k) (str k))]
-    (when (gobj/containsKey seen s)
+    (when (.has ^js seen s)
       (error/throw-error!
         :rf.error/ui-duplicate-key
         're-frame.freehand/render
@@ -256,5 +264,5 @@
              "a key must be unique per list site.")
         {:recovery :key-each-row-uniquely
          :extra    {:key (error/diag-value-summary k)}}))
-    (gobj/set seen s true))
+    (.add ^js seen s))
   nil)

--- a/implementation/freehand/src/re_frame/freehand/compiler/emit_react.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/emit_react.cljc
@@ -451,7 +451,15 @@
   and the duplicate-key proof must name the exact same occurrence — and
   the DEV duplicate check mirrors the structural tier's `node/keyed-run`,
   so a colliding key fails at the compile-indexed list site rather than
-  as a React console warning at the wrong end of the pipeline."
+  as a React console warning at the wrong end of the pipeline.
+
+  The seen table is a `js/Set`, not an object used as a map: an object
+  inherits `toString`, `constructor` and friends from `Object.prototype`,
+  and a membership test that answers `key in obj` would reject the FIRST
+  row keyed by any of those inherited names. Those are ordinary domain
+  identifiers, and the structural tier's Clojure set accepts them — so an
+  object here would make the two tiers disagree about which pages are
+  legal."
   [e st node]
   (let [a       (gensym "rf-fh-run")
         seen    (gensym "rf-fh-seen")
@@ -462,7 +470,7 @@
                   (assoc-in body [:key :expr] row-key)
                   (assoc-in body [:props :key :expr] row-key))]
     `(let [~a    (cljs.core/array)
-           ~seen (cljs.core/js-obj)]
+           ~seen (js/Set.)]
        (doseq [~@(:seq-exprs node)]
          (let [~row-key ~kexpr]
            (when ~(with-meta 'js/goog.DEBUG {:tag 'boolean})

--- a/implementation/freehand/src/re_frame/freehand/root.cljs
+++ b/implementation/freehand/src/re_frame/freehand/root.cljs
@@ -762,25 +762,79 @@
 ;; React root options
 ;; ---------------------------------------------------------------------------
 
-(defn- report-error!
-  "React's own default reporting for an UNCAUGHT or a RECOVERABLE error:
-  hand it to the host `reportError` so a window error handler still sees it,
-  or `console.error` on a runtime without one. Replicated here because the
-  framework always installs a stable delegate for these keys (so a remount
-  can advance the callback), and once a delegate is set React no longer runs
-  its own default — a delegate that swallowed the no-callback case would be
-  a silent regression rather than the honest passthrough this is."
+(defn- report-globally!
+  "Hand `error*` to the host `reportError` so a window error handler still
+  sees it, or `console.error` on a runtime without one — React's own
+  `reportGlobalError`, which is the whole of its PRODUCTION default for an
+  uncaught or a recoverable error."
   [error*]
   (if (fn? (.-reportError js/globalThis))
     (js/reportError error*)
     (when (exists? js/console) (.error js/console error*))))
 
+;; React's defaults are two-tier, and the framework's replacements have to be
+;; too. `defaultOnUncaughtError` reports globally in every build and ALSO warns
+;; — in development only — that nothing contained the failure and where to read
+;; about boundaries; `defaultOnCaughtError` logs the error in every build and
+;; ALSO names, in development, the boundary that will recreate the subtree.
+;; Installing a stable delegate takes React's default off the table for every
+;; root, including one that authored no callback at all, so a delegate that
+;; replicated only the production tier would delete the development evidence a
+;; programmer actually debugs from. These replicate both tiers and gate the
+;; development one exactly where React gates it.
+;;
+;; The context comes off the PUBLIC `errorInfo` React hands the callback and is
+;; printed, never parsed: `componentStack` is a string React formats for humans,
+;; and `errorBoundary` is the boundary instance itself. No private React import
+;; and no stack parser — a component NAME would need one, so the stack stands in
+;; its place, which is the more useful half of that message anyway.
+
+(defn- component-stack
+  "The formatted component stack off the public `errorInfo`, or nil."
+  [error-info]
+  (let [s (some-> ^js error-info .-componentStack)]
+    (when (and (string? s) (seq s)) s)))
+
+(defn- error-boundary-name
+  "The name of the Error Boundary instance React names on the public
+  `errorInfo`. `\"Anonymous\"` when it has none — React's own wording."
+  [error-info]
+  (or (not-empty (str (some-> ^js error-info .-errorBoundary .-constructor .-name)))
+      "Anonymous"))
+
+(defn- report-uncaught!
+  "React's default for an UNCAUGHT error, both tiers."
+  [error* error-info]
+  (report-globally! error*)
+  (when (and interop/debug-enabled? (exists? js/console))
+    (.warn js/console
+           (str "An error occurred in one of your React components.\n\n"
+                "Consider adding an error boundary to your tree to customize error "
+                "handling behavior.\n"
+                "Visit https://react.dev/link/error-boundaries to learn more about "
+                "error boundaries.\n"
+                (component-stack error-info)))))
+
 (defn- report-caught!
-  "React's own default for an error an Error Boundary CAUGHT: the boundary
-  handled it, so the default is an informational `console.error`, not a
-  re-throw to the window the way an uncaught or recoverable error earns."
-  [error*]
-  (when (exists? js/console) (.error js/console error*)))
+  "React's default for an error an Error Boundary CAUGHT, both tiers. The
+  boundary handled it, so even the production tier is an informational
+  `console.error` rather than the re-throw to the window an uncaught or a
+  recoverable error earns."
+  [error* error-info]
+  (when (exists? js/console)
+    (if interop/debug-enabled?
+      (.error js/console error*
+              (str "\n\nThe above error occurred in one of your React components.\n\n"
+                   "React will try to recreate this component tree from scratch using "
+                   "the error boundary you provided, " (error-boundary-name error-info) ".\n"
+                   (component-stack error-info)))
+      (.error js/console error*))))
+
+(defn- report-recoverable!
+  "React's default for a RECOVERABLE error: report globally and say no more.
+  React adds no development tier here — the recovery already happened."
+  [error* _error-info]
+  (report-globally! error*))
 
 (defn- host-callback-delegate
   "A stable React error-option callback that dispatches to the CURRENT
@@ -791,11 +845,15 @@
   This is the whole of the remount-honesty mechanism: React fixes a root's
   options at creation, so the delegate object never changes, but the cell it
   reads is advanced by an accepted re-mount. A callback supplied on the
-  reload therefore takes effect and the first mount's is not silently kept."
+  reload therefore takes effect and the first mount's is not silently kept.
+
+  `default!` takes the SAME two arguments the authored callback does, so the
+  no-callback arm reports with the component context React would have had.
+  A default handed only the bare error could not."
   [callbacks k default!]
   (fn [error* error-info]
     (let [f (get @callbacks k)]
-      (if (fn? f) (f error* error-info) (default! error*)))))
+      (if (fn? f) (f error* error-info) (default! error* error-info)))))
 
 (defn- emit-hydration-mismatch!
   [root-id error*]
@@ -822,7 +880,7 @@
   Public so a mounted browser proof can drive the REAL callback across the
   window boundary rather than a stand-in shaped like it."
   [^js adoption root-id callbacks]
-  (let [delegate (host-callback-delegate callbacks :on-recoverable-error report-error!)]
+  (let [delegate (host-callback-delegate callbacks :on-recoverable-error report-recoverable!)]
     (fn on-recoverable [error* error-info]
       (when (.-adopting adoption)
         (emit-hydration-mismatch! root-id error*))
@@ -847,10 +905,10 @@
   [prefix callbacks recoverable]
   (let [o (js-obj)]
     (when prefix (aset o "identifierPrefix" prefix))
-    (aset o "onUncaughtError" (host-callback-delegate callbacks :on-uncaught-error report-error!))
+    (aset o "onUncaughtError" (host-callback-delegate callbacks :on-uncaught-error report-uncaught!))
     (aset o "onCaughtError"   (host-callback-delegate callbacks :on-caught-error report-caught!))
     (aset o "onRecoverableError"
-          (or recoverable (host-callback-delegate callbacks :on-recoverable-error report-error!)))
+          (or recoverable (host-callback-delegate callbacks :on-recoverable-error report-recoverable!)))
     o))
 
 (defn- root-element

--- a/implementation/freehand/src/re_frame/freehand/top_layer.cljc
+++ b/implementation/freehand/src/re_frame/freehand/top_layer.cljc
@@ -449,7 +449,12 @@
   SUCCESSOR down with it: a newer generation's enqueue has already
   replaced the entry and its owner, so the retiring one finds an entry
   that is not its own and leaves it exactly where it is — in whichever
-  order the host runs attach and detach."
+  order the host runs attach and detach.
+
+  This reaches into an OPEN flush as well as a merely queued batch:
+  [[flush-top-layer!]] drains the batch map entry by entry rather than
+  emptying it up front, so a generation retired by an earlier ordered host
+  call is withdrawn from work that has not happened yet."
   [owner]
   (when-some [^js m @pending]
     (.forEach m (fn [entry node]
@@ -475,21 +480,46 @@
 
   A node that left the document before the flush is SKIPPED: it took its
   top-layer state with it when it left, and asking a disconnected node to
-  open is the one call the browser refuses outright. An entry whose
-  generation retired is not here to skip at all — [[retire!]] withdrew it
-  when the generation let go."
+  open is the one call the browser refuses outright.
+
+  Generation ownership is re-read PER ENTRY, immediately before the host
+  call — not once as the flush opens. The batch is ordered, so the flush
+  is a loop, and every top-layer host call has a synchronous callback seam
+  (`beforetoggle` fires inside `showPopover()`, and Freehand permits a
+  plain handler there). An earlier ordered call can therefore retire a
+  later generation while this very loop is running. Sorting an entry into
+  a plain `[node fact]` pair up front would drop the owner before any host
+  call ran, leaving [[retire!]] nothing to withdraw and the stale
+  operation free to open a node its generation had already let go of.
+
+  So the batch map stays the batch map for the whole flush and each entry
+  is drained out of it as it is performed: an entry still standing in `m`
+  under the identity this loop sorted is one whose generation is still the
+  one that speaks, and anything [[retire!]] removed mid-flush is simply no
+  longer there to find. A SUCCESSOR that claimed the same node during the
+  flush replaced the entry, so the superseded operation is skipped for the
+  same reason and the successor's runs on its own batch — a predecessor's
+  retirement still cannot cancel it."
   []
   (reset! flush-scheduled? false)
   (when-some [^js m @pending]
-    (reset! pending nil)
     (let [entries (array)]
-      (.forEach m (fn [entry node] (.push entries #js [node (aget entry 0)])))
+      (.forEach m (fn [entry node] (.push entries #js [node entry])))
       (.sort entries (fn [a b] (doc-order (aget a 0) (aget b 0))))
       (.forEach entries
-                (fn [entry]
-                  (let [^js node (aget entry 0)]
-                    (when (.-isConnected node)
-                      (apply-desired! node (aget entry 1))))))))
+                (fn [sorted]
+                  (let [^js node (aget sorted 0)
+                        entry    (aget sorted 1)]
+                    ;; The fence, INSIDE the loop: still this generation's
+                    ;; entry, and not one an earlier host call withdrew.
+                    (when (identical? entry (.get m node))
+                      (.delete m node)
+                      (when (.-isConnected node)
+                        (apply-desired! node (aget entry 0)))))))
+      ;; Anything left is a batch a mid-flush commit opened; it owns the
+      ;; microtask that enqueue scheduled for it. Otherwise: retain nothing.
+      (when (zero? (.-size m))
+        (reset! pending nil))))
   nil)
 
 (defn- reconciling-handlers

--- a/implementation/freehand/test/re_frame/freehand/compiled_keyed_run_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/compiled_keyed_run_dom_cljs_test.cljs
@@ -1,0 +1,239 @@
+(ns re-frame.freehand.compiled-keyed-run-dom-cljs-test
+  "The compiled tier's DUPLICATE-KEY proof, in a real browser — and the one
+  class of key that only the browser lowering could ever have got wrong.
+
+  The structural tier proves a list site's keys with a Clojure set
+  (`node/keyed-run`). The compiled browser lowering has to prove the same
+  thing per row, at the site, with no Clojure collection in the emitted
+  code — and that is where a JS object used as a map is a trap: an object
+  inherits `toString`, `constructor`, `hasOwnProperty` and `__proto__` from
+  `Object.prototype`, so a membership test that asks `key in obj` answers
+  YES for a key nothing has put there. The FIRST row of a list keyed by any
+  of those names would then be refused as a duplicate.
+
+  Those are ordinary domain identifiers — a permissions table keyed by verb,
+  a column set keyed by field name, an object graph keyed by property. A
+  view keyed on them renders perfectly under `node/keyed-run`, renders
+  perfectly in every structural test, and dies when someone mounts it. So
+  the assertions here are the ones the structural tier cannot make: the
+  poison names accepted at a real compiled `for` site in a real browser, a
+  repeat of each still refused there, and the two tiers agreeing row for
+  row.
+
+  This file rides the browser lane through its `-dom-cljs-test` namespace
+  suffix. It also matches the node suites' broader regex, where it has no
+  DOM to mount and says so rather than passing quietly — the declarations
+  themselves still load, and the cross-tier agreement row still runs."
+  (:require ["react" :as react]
+            ["react-dom/client" :as rdc]
+            [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.error-emit :as error-emit]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.node :as node]
+            [re-frame.freehand.react :as fr]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       plain-atom/adapter
+     :ambient-frame nil
+     :async?        true
+     :init-fn       (fn []
+                      (fr/reset-boundaries!)
+                      (error-emit/clear-error-listeners!))}))
+
+;; ---------------------------------------------------------------------------
+;; The poison roster. Every one of these is an inherited `Object.prototype`
+;; name AND a plausible domain key — which is the entire reason this file
+;; exists rather than a note in a docstring.
+;; ---------------------------------------------------------------------------
+
+(def ^:private inherited-names
+  ["toString" "constructor" "hasOwnProperty" "__proto__"
+   "valueOf" "isPrototypeOf" "propertyIsEnumerable" "toLocaleString"])
+
+;; ---------------------------------------------------------------------------
+;; The declarations. Module-level, because `{:compiled true}` is a
+;; macro-expansion fact and a declaration cannot close over a test's locals —
+;; so this is exactly the `for` site a real application writes.
+;; ---------------------------------------------------------------------------
+
+(v/defview poison-list
+  "A compiled keyed list site whose row keys come from data. The `for` is
+  the emitted duplicate-key check's only home."
+  {:compiled true}
+  [{:keys [ids]}]
+  [:ul#poison
+   (for [k ids]
+     [:li {:key k :data-key (str k)} (str k)])])
+
+(defn- browser? []
+  (and (exists? js/document) (some? (.-createElement js/document))))
+
+(defn- skip! [why]
+  (is true (str "a real React mount needs a DOM host — " why)))
+
+(defn- act
+  "A React 19 `act` boundary as a promise, so assertions run after the
+  commit rather than racing it."
+  [thunk]
+  (try
+    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+    (js/Promise.resolve (react/act (fn [] (js/Promise.resolve (thunk)))))
+    (catch :default e
+      (js/Promise.reject e))))
+
+(defn- mount! []
+  (let [container (js/document.createElement "div")]
+    (.appendChild js/document.body container)
+    [container (rdc/createRoot container)]))
+
+(defn- teardown! [container root]
+  (.unmount root)
+  (.remove container)
+  nil)
+
+(defn- rendered-keys
+  "The `data-key` of every row the list site actually put on screen, in
+  document order."
+  [container]
+  (mapv #(.getAttribute % "data-key")
+        (array-seq (.querySelectorAll container "#poison > li"))))
+
+(defn- render-ids!
+  "Mount the compiled list over `ids` under a real error boundary, and
+  answer a promise of `{:keys [...] :error <thrown or nil>}`.
+
+  The boundary is what keeps a refusal from reaching the window: a render
+  throw with nothing above it re-throws at the host and fails the whole
+  browser run. The always-on egress carries the OPAQUE exception, so the
+  refusal can be named by its own diagnostic id rather than by the fact
+  that something, somewhere, went wrong."
+  [ids]
+  (let [[container root] (mount!)
+        egress           (atom [])]
+    (error-emit/register-error-listener! ::recorder (fn [r] (swap! egress conj r)))
+    (-> (act #(.render root
+                       (fr/element
+                         [v/error-boundary {:fallback [:p#fb "refused"] :reset-key 1}
+                          [poison-list {:ids ids}]])))
+        (.then (fn [_]
+                 (let [out {:keys  (rendered-keys container)
+                            :error (:exception (first @egress))
+                            :fallback? (some? (.querySelector container "#fb"))}]
+                   (error-emit/unregister-error-listener! ::recorder)
+                   (teardown! container root)
+                   out))
+               (fn [e]
+                 (error-emit/unregister-error-listener! ::recorder)
+                 (teardown! container root)
+                 (js/Promise.reject e))))))
+
+(defn- refusal-id [error*]
+  (:rf.error/id (ex-data error*)))
+
+;; ===========================================================================
+;; The first occurrence of an inherited name is a key like any other
+;; ===========================================================================
+
+(deftest an-inherited-object-name-is-a-legal-first-key-at-a-compiled-list-site
+  (testing "A compiled `for` site keyed by `toString`, `constructor`,
+            `hasOwnProperty`, `__proto__` and their siblings mounts and
+            renders every row. Nothing has put those keys in the seen table
+            — they are inherited from `Object.prototype`, and only a seen
+            table that is an object would ever say otherwise. A test using
+            ordinary keys cannot see this at all: the defect fires only on
+            names an object already answers for."
+    (if-not (browser?)
+      (skip! "the browser job owns the mounted keyed-run assertions")
+      (async done
+        (-> (render-ids! inherited-names)
+            (.then (fn [{:keys [keys error fallback?]}]
+                     (is (nil? error)
+                         (str "no row was refused. Saw: "
+                              (pr-str (some-> error refusal-id))))
+                     (is (false? fallback?)
+                         "so the boundary's fallback is not on screen")
+                     (is (= inherited-names keys)
+                         "and every poison-keyed row rendered, in order")
+                     (done)))
+            (.catch (fn [e]
+                      (is false (str "the poison-keyed mount rejected: " e))
+                      (done))))))))
+
+;; ===========================================================================
+;; A repeat of one is still a duplicate
+;; ===========================================================================
+
+(deftest a-repeated-inherited-name-is-still-refused-at-the-list-site
+  (testing "The correction is a prototype-free seen table, not a hole in the
+            rule. The SECOND occurrence of an inherited name is a duplicate
+            key and the site refuses it by its own diagnostic id — not by
+            some generic failure, and not at the wrong end of the pipeline as
+            a React console warning."
+    (if-not (browser?)
+      (skip! "the browser job owns the mounted keyed-run assertions")
+      (async done
+        (letfn [(step [remaining]
+                  (if-some [nm (first remaining)]
+                    (-> (render-ids! [nm nm])
+                        (.then (fn [{:keys [error fallback?]}]
+                                 (is (= :rf.error/ui-duplicate-key (refusal-id error))
+                                     (str "a repeated " (pr-str nm)
+                                          " is refused as a duplicate key. Saw: "
+                                          (pr-str (refusal-id error))))
+                                 (is (true? fallback?)
+                                     (str "and the boundary contained it — " nm))
+                                 (step (rest remaining)))))
+                    (js/Promise.resolve nil)))]
+          (-> (step inherited-names)
+              (.then (fn [_] (done)))
+              (.catch (fn [e]
+                        (is false (str "the duplicate sweep rejected: " e))
+                        (done)))))))))
+
+;; ===========================================================================
+;; React's string coercion is still the comparison
+;; ===========================================================================
+
+(deftest react-string-equivalent-keys-still-collide-at-a-compiled-list-site
+  (testing "Keys compare after React's own string coercion, so `1` and `\"1\"`
+            are ONE key. A prototype-free table must not become a table that
+            compares raw values: the structural tier's rule is the rule."
+    (if-not (browser?)
+      (skip! "the browser job owns the mounted keyed-run assertions")
+      (async done
+        (-> (render-ids! [1 "1"])
+            (.then (fn [{:keys [error]}]
+                     (is (= :rf.error/ui-duplicate-key (refusal-id error))
+                         "1 and \"1\" are one key at the compiled site")
+                     (render-ids! [1 2 "3"])))
+            (.then (fn [{:keys [keys error]}]
+                     (is (nil? error)
+                         "non-vacuous: keys that differ AFTER coercion do not collide")
+                     (is (= ["1" "2" "3"] keys) "and all three rendered")
+                     (done)))
+            (.catch (fn [e]
+                      (is false (str "the coercion sweep rejected: " e))
+                      (done))))))))
+
+;; ===========================================================================
+;; The two tiers agree, row for row (runs on every host)
+;; ===========================================================================
+
+(deftest the-structural-tier-reaches-the-same-verdict-on-every-poison-key
+  (testing "Agreement is the point. `node/keyed-run` accepts each inherited
+            name as a first key and refuses a repeat of it with the same
+            diagnostic id the compiled site raises — so a view that renders
+            structurally renders in a browser, which is exactly what the
+            object-as-map seen table broke."
+    (is (some? (node/keyed-run (mapv (fn [k] {:key k}) inherited-names)))
+        "the structural tier accepts the whole poison roster")
+    (doseq [nm inherited-names]
+      (let [thrown (try
+                     (node/keyed-run [{:key nm} {:key nm}])
+                     nil
+                     (catch :default e (:rf.error/id (ex-data e))))]
+        (is (= :rf.error/ui-duplicate-key thrown)
+            (str "and refuses a repeated " (pr-str nm) " by the same id"))))))

--- a/implementation/freehand/test/re_frame/freehand/pilot_field.cljc
+++ b/implementation/freehand/test/re_frame/freehand/pilot_field.cljc
@@ -386,6 +386,19 @@
   [line]
   (into {} (keep (fn [f] (when-let [p (field-problem line f)] [f p]))) text-fields))
 
+(defn- current-request?
+  "Does `token` name the normalisation request line `id` still has
+  outstanding?
+
+  A settled request holds NO token, and `nil` is not a request identity —
+  so a reply that carries no token is never current, whatever the line's
+  state. Both terminal outcomes ask this one question, which is what makes
+  them genuinely mutually exclusive: whichever lands first retires the
+  token, and every later or duplicate reply for that request fails here."
+  [db id token]
+  (and (some? token)
+       (= token (get-in db [:invoice id :normalise-token]))))
+
 (defn register-app!
   "The application's own registrations."
   []
@@ -490,7 +503,7 @@
   ;; refusal.
   (rf/reg-event :acme.invoice/reference-normalised
     (fn [{:keys [db]} [_ id token normalised]]
-      (if (= token (get-in db [:invoice id :normalise-token]))
+      (if (current-request? db id token)
         {:db (-> db
                  (assoc-in [:invoice id :normalising?] false)
                  (assoc-in [:invoice id :normalise-token] nil)
@@ -500,15 +513,17 @@
                  (update ::normalised (fnil conj []) normalised))}
         {})))
 
-  ;; THE REJECTION, and the other terminal outcome. The caller refuses the
-  ;; committed draft and stands by the value it already had — advancing the
+  ;; The two rejections are two EVENTS, because they answer two different
+  ;; questions and only one of them can be late.
+  ;;
+  ;; A DIRECT rejection is the caller deciding, right now, about the draft in
+  ;; front of it: it stands by the value it already had, and advancing the
   ;; revision is what says "this is a NEW baseline decision" in the one case
-  ;; value-equality cannot see. It also retires any outstanding token, so a
-  ;; success still in flight for the refused request cannot land afterwards
-  ;; and overwrite the refusal. With no request outstanding (the direct
-  ;; same-value rejection R-A3 exercises) the token is already nil and this
-  ;; is a no-op.
-  (rf/reg-event :acme.invoice/reference-refused
+  ;; value-equality cannot see (R-A3). There is no request to be current with,
+  ;; so there is no token to carry — and it retires any outstanding one,
+  ;; because a decision the caller has just taken supersedes a reply still in
+  ;; flight.
+  (rf/reg-event :acme.invoice/reference-rejected
     (fn [{:keys [db]} [_ id reason]]
       {:db (-> db
                (assoc-in [:invoice id :normalising?] false)
@@ -516,6 +531,27 @@
                (assoc-in [:invoice id :reference-error] reason)
                (update-in [:invoice id :reference-revision] inc)
                (update ::refused (fnil inc 0)))}))
+
+  ;; An ASYNCHRONOUS refusal is the OTHER terminal outcome of a submitted
+  ;; request, and it is symmetric with the success in every respect that
+  ;; matters — including the one that only shows up late. It names the request
+  ;; it answers, applies only while that token is still current, and retires
+  ;; the token as it lands. Whichever terminal outcome arrives first therefore
+  ;; settles the request, and every later or duplicate reply for it — refusal
+  ;; after success, refusal after supersession, refusal after refusal — finds
+  ;; no matching token and is exactly inert. A refusal that carried no token
+  ;; could not tell any of those apart from a first, current reply: it would
+  ;; reverse a settled success and re-count itself on every duplicate.
+  (rf/reg-event :acme.invoice/reference-refused
+    (fn [{:keys [db]} [_ id token reason]]
+      (if (current-request? db id token)
+        {:db (-> db
+                 (assoc-in [:invoice id :normalising?] false)
+                 (assoc-in [:invoice id :normalise-token] nil)
+                 (assoc-in [:invoice id :reference-error] reason)
+                 (update-in [:invoice id :reference-revision] inc)
+                 (update ::refused (fnil inc 0)))}
+        {})))
 
   (rf/reg-event :acme.invoice/theme-changed
     (fn [{:keys [db]} [_ theme]]

--- a/implementation/freehand/test/re_frame/freehand/pilot_field_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/pilot_field_cljs_test.cljc
@@ -354,7 +354,7 @@
           (is (= draft (:draft (record address))) "and is ordinary frame data")
 
           (let [before (get-in (app-db) [:invoice 1 :reference])]
-            (send! [:acme.invoice/reference-refused 1 "That reference is not on file."])
+            (send! [:acme.invoice/reference-rejected 1 "That reference is not on file."])
             (is (= before (get-in (app-db) [:invoice 1 :reference]))
                 "non-vacuous: the caller's VALUE did not move at all")
             (is (= "REF-1" (shown-buffered (render! (line-form mode 1)) "reference"))
@@ -609,7 +609,7 @@
           (is (nil? (record [:invoice 2 :reference])))
 
           (testing "rejecting line 1's draft leaves line 2 untouched"
-            (send! [:acme.invoice/reference-refused 1 "That reference is not on file."])
+            (send! [:acme.invoice/reference-rejected 1 "That reference is not on file."])
             (is (= "REF-1" (:value (t/attrs (control-of (buffered-node (first (roots)) "reference"))))))
             (is (= "REF-2" (:value (t/attrs (control-of (buffered-node (second (roots)) "reference"))))))))))))
 
@@ -781,7 +781,7 @@
                   for it cannot land afterwards and overwrite the refusal"
           (seed-line! 1)
           (send! [:acme.invoice/reference-submitted 1 "ref-x" :req-1])
-          (send! [:acme.invoice/reference-refused 1 "That reference is not on file."])
+          (send! [:acme.invoice/reference-refused 1 :req-1 "That reference is not on file."])
           (send! [:acme.invoice/reference-normalised 1 :req-1 "REF-LATE"])
           (is (= "REF-1" (get-in (app-db) [:invoice 1 :reference]))
               "the late success did not move the refused baseline")
@@ -791,13 +791,56 @@
                  (get-in (app-db) [:invoice 1 :reference-error]))
               "the refusal's message still stands"))
 
-        (testing "a current success clears a prior refusal's error as it
+        (testing "and the mirror order: a SUCCESS retires the request, so a
+                  refusal still in flight for it cannot land afterwards and
+                  reverse the settled success"
+          (seed-line! 1)
+          (send! [:acme.invoice/reference-submitted 1 "ref-w" :req-4])
+          (send! [:acme.invoice/reference-normalised 1 :req-4 "REF-W"])
+          (let [settled (app-db)]
+            (send! [:acme.invoice/reference-refused 1 :req-4 "Too late."])
+            (is (= settled (app-db))
+                "the late refusal moved no state at all")
+            (is (= "REF-W" (get-in (app-db) [:invoice 1 :reference]))
+                "non-vacuous: the success's value is the one still standing")
+            (is (nil? (get-in (app-db) [:invoice 1 :reference-error]))
+                "and it wrote no error over the settled success")
+            (is (nil? (::pilot/refused (app-db)))
+                "nor counted itself in the domain log")))
+
+        (testing "a duplicate refusal for an already-refused request is
+                  inert — applying the refusal twice equals applying it once"
+          (seed-line! 1)
+          (send! [:acme.invoice/reference-submitted 1 "ref-v" :req-5])
+          (send! [:acme.invoice/reference-refused 1 :req-5 "That reference is not on file."])
+          (let [after-first (app-db)]
+            (send! [:acme.invoice/reference-refused 1 :req-5 "That reference is not on file."])
+            (is (= after-first (app-db))
+                "the duplicate refusal moved no state at all")
+            (is (= 1 (::pilot/refused (app-db)))
+                "non-vacuous: the refusal was counted exactly once")
+            (is (= 1 (get-in (app-db) [:invoice 1 :reference-revision]))
+                "and advanced the revision exactly once")))
+
+        (testing "a refusal for a request the caller has already superseded
+                  lands nowhere — the same rule the success obeys"
+          (seed-line! 1)
+          (send! [:acme.invoice/reference-submitted 1 "ref-u" :req-6])
+          (send! [:acme.invoice/reference-submitted 1 "ref-u2" :req-7])
+          (let [before (app-db)]
+            (send! [:acme.invoice/reference-refused 1 :req-6 "Stale."])
+            (is (= before (app-db))
+                "the superseded refusal moved no state at all")
+            (is (true? (rf/subscribe-once [:acme.invoice/normalising? 1] {:frame fid}))
+                "non-vacuous: the CURRENT request is still in flight")))
+
+        (testing "a current success clears a prior rejection's error as it
                   stores the normalised value"
           (seed-line! 1)
-          (send! [:acme.invoice/reference-refused 1 "That reference is not on file."])
+          (send! [:acme.invoice/reference-rejected 1 "That reference is not on file."])
           (is (= "That reference is not on file."
                  (get-in (app-db) [:invoice 1 :reference-error]))
-              "the refusal set an error")
+              "the rejection set an error")
           (send! [:acme.invoice/reference-submitted 1 "ref-y" :req-2])
           (send! [:acme.invoice/reference-normalised 1 :req-2 "REF-Y"])
           (is (= "REF-Y" (get-in (app-db) [:invoice 1 :reference]))
@@ -816,6 +859,44 @@
                 "the duplicate settle moved no state at all")
             (is (= ["REF-Z"] (::pilot/normalised (app-db)))
                 "non-vacuous: the success was recorded exactly once")))))))
+
+(deftest r-a3-a-direct-rejection-is-not-a-late-reply
+  (testing "The direct baseline rejection and the asynchronous refusal are
+            two events because they answer two questions. A direct rejection
+            is the caller deciding NOW about the draft in front of it: there
+            is no request to be current with, so it always lands, restores
+            the baseline and advances the revision — R-A3's whole point. The
+            asynchronous refusal names the request it answers and lands only
+            while that request is outstanding. One event shape could not be
+            both without letting a late reply masquerade as a fresh decision."
+    (each-mode
+      (fn [_mode]
+        (seed-line! 1)
+        (send! [:acme.invoice/reference-rejected 1 "Not on file."])
+        (is (= 1 (::pilot/refused (app-db)))
+            "the direct rejection landed with no request outstanding")
+        (is (= "Not on file." (get-in (app-db) [:invoice 1 :reference-error])))
+
+        (testing "and it is idempotent in no sense at all — every direct
+                  rejection is a NEW baseline decision"
+          (send! [:acme.invoice/reference-rejected 1 "Not on file."])
+          (is (= 2 (::pilot/refused (app-db)))
+              "a second direct rejection is a second decision")
+          (is (= 2 (get-in (app-db) [:invoice 1 :reference-revision]))
+              "which the revision reports, exactly as R-A3 requires"))
+
+        (testing "while a direct rejection also supersedes a request in
+                  flight — a reply for it can no longer land"
+          (seed-line! 1)
+          (send! [:acme.invoice/reference-submitted 1 "ref-q" :req-9])
+          (send! [:acme.invoice/reference-rejected 1 "Not on file."])
+          (let [decided (app-db)]
+            (send! [:acme.invoice/reference-normalised 1 :req-9 "REF-Q"])
+            (is (= decided (app-db))
+                "the superseded success moved no state at all")
+            (send! [:acme.invoice/reference-refused 1 :req-9 "Also too late."])
+            (is (= decided (app-db))
+                "and neither did the superseded refusal")))))))
 
 ;; ===========================================================================
 ;; R-A10 — busy from the in-flight write's own state
@@ -1073,7 +1154,7 @@
              :on-input "REF-PARITY")
       (is (= (as-mode-ids (render! (line-form :interpreted 1)))
              (render! (line-form :compiled 1))))
-      (send! [:acme.invoice/reference-refused 1 "That reference is not on file."])
+      (send! [:acme.invoice/reference-rejected 1 "That reference is not on file."])
       (is (= (as-mode-ids (render! (line-form :interpreted 1)))
              (render! (line-form :compiled 1)))))))
 
@@ -1144,7 +1225,7 @@
             roster."
     (seed-line! 1 {:description ""})
     (send! [:acme.invoice/submit-attempted 1])
-    (send! [:acme.invoice/reference-refused 1 "That reference is not on file."])
+    (send! [:acme.invoice/reference-rejected 1 "That reference is not on file."])
     (each-mode
       (fn [mode]
         (let [tree (render! (line-form mode 1))]

--- a/implementation/freehand/test/re_frame/freehand/pilot_field_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/pilot_field_dom_cljs_test.cljs
@@ -388,7 +388,7 @@
               (is (= "REF-X1" (draft)) "and it is controller state, not host state")
 
               (let [reference-before (:reference (line))]
-                (-> (send! [:acme.invoice/reference-refused
+                (-> (send! [:acme.invoice/reference-rejected
                             line-id "That reference is not on file."])
                     (.then
                       (fn [_]
@@ -415,7 +415,7 @@
           (fn [container]
             (let [node (control container "reference")]
               (insert-at! node 4 "X")
-              (-> (send! [:acme.invoice/reference-refused line-id nil])
+              (-> (send! [:acme.invoice/reference-rejected line-id nil])
                   (.then
                     (fn [_]
                       (insert-at! node 0 "A")

--- a/implementation/freehand/test/re_frame/freehand/root_error_callbacks_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/root_error_callbacks_dom_cljs_test.cljs
@@ -39,6 +39,7 @@
   suffix. It also matches the node suites' broader regex, where it has no DOM
   to mount and says so rather than passing quietly."
   (:require ["react" :as react]
+            [clojure.string :as str]
             [cljs.test :refer-macros [async deftest is testing use-fixtures]]
             [re-frame.freehand :as v]
             [re-frame.freehand.react :as fr]
@@ -47,7 +48,8 @@
             ;; The SSR artefact's manifest namespace publishes the discovery
             ;; hook the recoverable arm's hydrate needs, and owns the wire form
             ;; the arm plants. A test-tree require of the seam being exercised.
-            [re-frame.ssr.manifest :as ssr-manifest]))
+            [re-frame.ssr.manifest :as ssr-manifest]
+            [re-frame.trace.tooling :as trace-tooling]))
 
 ;; ---------------------------------------------------------------------------
 ;; The declarations. Module-level, because a declared view cannot close over a
@@ -147,6 +149,291 @@
 
 (defn- fired? [calls tag kind]
   (boolean (some #{[tag kind]} @calls)))
+
+;; ---------------------------------------------------------------------------
+;; The DEFAULT arm's observation seams
+;; ---------------------------------------------------------------------------
+;;
+;; Installing a stable delegate takes React's own default off the table for
+;; every root, including one that authored no callback at all — so the
+;; framework owes that root React's default, both tiers of it: the global
+;; report a production build makes, AND the development guidance a programmer
+;; debugs from. What is observable is what the default REPORTS THROUGH, so the
+;; three host seams React's defaults use are redirected and read back.
+;;
+;; Two things make this non-vacuous where a React-warning assertion would not
+;; be. React's own development warnings latch once per process, so a test that
+;; asserted on one would pass or fail on what some earlier file rendered; every
+;; record below is produced by the ROOT'S OWN default handler, which has no
+;; latch and runs every time. And React's default and the framework's are told
+;; apart by the component stack: React's message carries none, the framework's
+;; carries the one React handed the delegate on the public `errorInfo`.
+;;
+;; Redirecting `reportError` is also what makes the no-callback arm safe to run
+;; at all: an uncaught error with nothing to swallow it re-throws at the window
+;; and fails the whole browser suite. The default arm IS the arm with no
+;; callback, so its report has to land in the recorder rather than the window.
+
+(defn- capture-reporting!
+  "Redirect global `reportError`, `console.warn` and `console.error` into a
+  record vector. Answers `[records restore!]`; `restore!` is idempotent."
+  []
+  (let [records  (atom [])
+        report-0 (.-reportError js/globalThis)
+        warn-0   (.-warn js/console)
+        error-0  (.-error js/console)
+        done?    (atom false)]
+    (set! (.-reportError js/globalThis) (fn [e] (swap! records conj [:report e])))
+    (set! (.-warn js/console)  (fn [& args] (swap! records conj (into [:warn] args))))
+    (set! (.-error js/console) (fn [& args] (swap! records conj (into [:error] args))))
+    [records (fn []
+               (when (compare-and-set! done? false true)
+                 (set! (.-reportError js/globalThis) report-0)
+                 (set! (.-warn js/console) warn-0)
+                 (set! (.-error js/console) error-0))
+               nil)]))
+
+(defn- said?
+  "Did ONE record of `kind` carry every `needle` across its string
+  arguments? One record, not one anywhere — a message assembled from two
+  unrelated logs is not the message."
+  [records kind & needles]
+  (boolean
+    (some (fn [r]
+            (and (= kind (first r))
+                 (let [t (str/join " " (filter string? (rest r)))]
+                   (every? #(str/includes? t %) needles))))
+          @records)))
+
+(defn- reported? [records]
+  (boolean (some #(= :report (first %)) @records)))
+
+(defn- carried-error?
+  "Did one record of `kind` carry the thrown value itself, rather than only
+  prose about it?"
+  [records kind]
+  (boolean (some (fn [r] (and (= kind (first r))
+                              (some #(instance? js/Error %) (rest r))))
+                 @records)))
+
+;; The two phrases React's own defaults exist to say, and the marker that says
+;; the framework's replacement said them WITH the context React gave it.
+(def ^:private uncaught-guidance "Consider adding an error boundary")
+(def ^:private caught-guidance   "React will try to recreate this component tree")
+(def ^:private stack-marker      "\n    at ")
+
+;; ===========================================================================
+;; The no-callback arm — uncaught
+;; ===========================================================================
+
+(deftest a-remount-that-omits-the-uncaught-callback-gets-reacts-whole-default
+  (testing "Per FH-ROOT-002 (browser): a mount that omits `:on-uncaught-error`
+            — a fresh root that never supplied one, or a reload that removed
+            the one it had — falls back to REACT'S DEFAULT, not to a stub
+            shaped like half of it. React's default reports globally AND, in a
+            development build, says that nothing contained this failure, where
+            to read about boundaries, and where in the tree it happened. A
+            delegate that answered only the global report would delete the
+            development half silently: the page still 'reports errors', and
+            the programmer loses the only message that says what to do about
+            it. The stale callback the reload removed must not run either."
+    (if-not (browser?)
+      (skip! "the browser job runs the default-diagnostic assertions")
+      (async done
+        (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+        (reset! poison? false)
+        (let [c       (host-node!)
+              calls   (atom [])
+              mounted (v/mount [cb-bare {}] c (cbs :A calls))]
+          (settle
+            (fn []
+              (let [[records restore!] (capture-reporting!)]
+                (reset! poison? true)
+                (v/mount [cb-bare {}] c {})
+                (poll-until
+                  #(reported? records)
+                  (fn []
+                    (restore!)
+                    (is (reported? records)
+                        "the global report React's default makes still happened")
+                    (is (said? records :warn uncaught-guidance "react.dev/link/error-boundaries")
+                        (str "and so did the development guidance. Saw: "
+                             (pr-str (mapv first @records))))
+                    (is (said? records :warn uncaught-guidance stack-marker)
+                        "carrying the component context React handed the delegate")
+                    (is (not (fired? calls :A :uncaught))
+                        "and the callback the reload removed did NOT run")
+                    (v/unmount! mounted)
+                    (.remove c)
+                    (done)))))))))))
+
+;; ===========================================================================
+;; The no-callback arm — caught
+;; ===========================================================================
+
+(deftest a-remount-that-omits-the-caught-callback-gets-reacts-whole-default
+  (testing "Per FH-ROOT-002 (browser): the same claim for `:on-caught-error`.
+            A boundary handled the failure, so React's default is
+            informational rather than a re-throw — but informational is not
+            the same as bare. React's development default names the component
+            tree and the boundary that will recreate it, and that is the whole
+            reason a programmer reads it. A remount that removes the callback
+            gets that message back, not just the Error object."
+    (if-not (browser?)
+      (skip! "the browser job runs the default-diagnostic assertions")
+      (async done
+        (let [c     (host-node!)
+              calls (atom [])]
+          (reset! poison? false)
+          (-> (act #(v/mount [cb-guarded {}] c (cbs :A calls)))
+              (.then (fn [mounted]
+                       (is (= "ok" (text c "#ok")) "the clean first mount rendered")
+                       (let [[records restore!] (capture-reporting!)]
+                         (reset! poison? true)
+                         (-> (act #(v/mount [cb-guarded {}] c {}))
+                             (.then (fn [_] (restore!) [mounted records])
+                                    (fn [e] (restore!) (js/Promise.reject e)))))))
+              (.then (fn [[mounted records]]
+                       (is (= "caught" (text c "#fb"))
+                           "the boundary caught the reload's throw")
+                       (is (carried-error? records :error)
+                           "the default logged the error itself")
+                       (is (said? records :error caught-guidance "error boundary you provided")
+                           (str "and named the boundary that will recreate the tree. Saw: "
+                                (pr-str (mapv first @records))))
+                       (is (said? records :error caught-guidance stack-marker)
+                           "with the component context React handed the delegate")
+                       (is (not (fired? calls :A :caught))
+                           "and the callback the reload removed did NOT run")
+                       (is (not (reported? records))
+                           "a CAUGHT error is not re-thrown to the window")
+                       (act #(v/unmount! mounted))))
+              (.then (fn [_] (.remove c) (done))
+                     (fn [e]
+                       (is false (str "the caught-default suite rejected: " e))
+                       (.remove c)
+                       (done)))))))))
+
+;; ===========================================================================
+;; A supplied callback REPLACES the default — it does not run beside it
+;; ===========================================================================
+
+(deftest a-supplied-caught-callback-replaces-the-default-rather-than-adding-to-it
+  (testing "Per FH-ROOT-002 (browser): restoring React's default for the
+            no-callback arm must not turn into reporting twice for the arm
+            that HAS one. An authored callback owns the failure: it runs, the
+            default does not, and the reload's callback is the one that runs.
+            Without this row a fix for the missing default could be a delegate
+            that always reports and then also calls the author's handler."
+    (if-not (browser?)
+      (skip! "the browser job runs the replacement assertions")
+      (async done
+        (let [c     (host-node!)
+              calls (atom [])]
+          (reset! poison? false)
+          (-> (act #(v/mount [cb-guarded {}] c (cbs :A calls)))
+              (.then (fn [mounted]
+                       (let [[records restore!] (capture-reporting!)]
+                         (reset! poison? true)
+                         (-> (act #(v/mount [cb-guarded {}] c (cbs :B calls)))
+                             (.then (fn [_] (restore!) [mounted records])
+                                    (fn [e] (restore!) (js/Promise.reject e)))))))
+              (.then (fn [[mounted records]]
+                       (is (fired? calls :B :caught)
+                           (str "the remount's caught callback ran. Saw: " (pr-str @calls)))
+                       (is (not (fired? calls :A :caught))
+                           "the stale one did not")
+                       (is (not (said? records :error caught-guidance))
+                           (str "and the default did NOT also report. Saw: "
+                                (pr-str (mapv first @records))))
+                       (is (not (reported? records))
+                           "nor did anything reach the window")
+                       (act #(v/unmount! mounted))))
+              (.then (fn [_] (.remove c) (done))
+                     (fn [e]
+                       (is false (str "the replacement suite rejected: " e))
+                       (.remove c)
+                       (done)))))))))
+
+;; ===========================================================================
+;; :on-recoverable-error across a real hydrate-then-remount
+;; ===========================================================================
+
+(deftest a-hydrated-roots-recoverable-callback-advances-and-then-falls-back
+  (testing "Per FH-ROOT-002/006 (browser): the recoverable key is the one a
+            single hydration can only exercise ONCE, so proving the delegate
+            fires on the initial hydrate proves nothing about a reload. This
+            drives the root's OWN live callback cell — the cell an accepted
+            `v/mount` advances, over the real composed hydration reporter —
+            across both remount shapes: a reload that CHANGES the callback,
+            and a reload that REMOVES it. The framework's own hydration
+            mismatch signal stays composed over both, because composing was
+            never the author's to switch off."
+    (if-not (browser?)
+      (skip! "the browser job runs the recoverable-remount assertions")
+      (async done
+        (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+        (let [root-id   :fh.root/cb-advance
+              prefix    "cb7-"
+              manifest  {:rf.root/schema-version 1
+                         :root-id                root-id
+                         :identifier-prefix      prefix}
+              node      (server-node!
+                          (str "<section id=\"greeting\"><h1 id=\"title\">Hello</h1>"
+                               "<p id=\"who\">SERVER</p></section>")
+                          manifest)
+              calls     (atom [])
+              mounted   (v/hydrate-root node [views/greeting {:name "client"}]
+                                        (cbs :A calls))]
+          (is (root/hydrated? mounted) "the container hydrated")
+          (poll-until
+            #(fired? calls :A :recoverable)
+            (fn []
+              (is (fired? calls :A :recoverable)
+                  (str "React's own hydration mismatch reached :A. Saw: " (pr-str @calls)))
+              ;; The reporter React installed reads the root's live cell. Build
+              ;; one over that SAME cell to drive the two remount shapes a
+              ;; single hydration cannot produce a second mismatch for.
+              (let [cell     (.-callbacks ^root/Root mounted)
+                    window   #js {:adopting true}
+                    reporter (root/hydration-reporter window root-id cell)
+                    signals  (atom [])
+                    k        (keyword (gensym "rf.fh-cb-advance-"))
+                    info     #js {:componentStack "\n    at greeting (root_views.cljc)"}]
+                (trace-tooling/register-listener!
+                  k (fn [ev] (when (= :rf.ssr/hydration-mismatch (:operation ev))
+                               (swap! signals conj ev))))
+                (try
+                  (reset! calls [])
+                  (v/mount [views/greeting {:name "client"}] node
+                           (assoc (cbs :B calls) :root-id root-id :identifier-prefix prefix))
+                  (reporter (js/Error. "recoverable probe B") info)
+                  (is (fired? calls :B :recoverable)
+                      (str "a reload that CHANGED the callback advanced it. Saw: "
+                           (pr-str @calls)))
+                  (is (not (fired? calls :A :recoverable))
+                      "and the stale callback did not run")
+                  (is (= 1 (count @signals))
+                      "the framework's mismatch signal composed over the author's")
+
+                  (let [[records restore!] (capture-reporting!)]
+                    (reset! calls [])
+                    (v/mount [views/greeting {:name "client"}] node
+                             {:root-id root-id :identifier-prefix prefix})
+                    (reporter (js/Error. "recoverable probe default") info)
+                    (restore!)
+                    (is (empty? @calls)
+                        (str "a reload that REMOVED the callback called neither. Saw: "
+                             (pr-str @calls)))
+                    (is (reported? records)
+                        "React's default for a recoverable error reported globally")
+                    (is (= 2 (count @signals))
+                        "and the framework's mismatch signal still composed"))
+                  (finally
+                    (trace-tooling/unregister-listener! k)
+                    (v/unmount! mounted)
+                    (remove-node! node)
+                    (done)))))))))))
 
 ;; ===========================================================================
 ;; :on-caught-error — a reload advances the caught callback (act, deterministic)

--- a/implementation/freehand/test/re_frame/freehand/top_layer_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/top_layer_dom_cljs_test.cljs
@@ -415,6 +415,113 @@
           (finally
             (.remove node)))))))
 
+(deftest fh-toplayer-004-a-generation-retiring-during-the-flush-does-not-act
+  (testing "Per FH-TOPLAYER-004: the ownership fence has to travel INTO the
+            ordered flush, not merely gate its entry. The batch is performed
+            in document order, so the flush is a LOOP — and every top-layer
+            host call has a synchronous callback seam: `beforetoggle` fires
+            inside `showPopover()`, and Freehand permits a plain handler
+            there. An earlier ordered call can therefore retire a later
+            generation while the loop is still running. A flush that dropped
+            the owner as it sorted would have nothing left to withdraw, and
+            the retired generation's node would be opened on behalf of a
+            generation that had already let go — before paint, one frame
+            after it stopped speaking for that node."
+    (if-not (browser?)
+      (skip! "the browser job owns the ordered-flush assertions")
+      (let [log    (atom [])
+            outer  (js/document.createElement "div")
+            inner  (js/document.createElement "div")
+            ref!   (fn []
+                     (gobj/get (top-layer/install! #js {} :div
+                                                   {:popover            :auto
+                                                    :on-toggle          identity
+                                                    ::web/popover-open? true})
+                               "ref"))
+            watch! (fn [^js node tag]
+                     ;; Only the OPEN transition: a browser-initiated close of
+                     ;; an ancestor is the platform reconciling, not a host
+                     ;; call this batch made.
+                     (.addEventListener node "beforetoggle"
+                                        (fn [^js e]
+                                          (when (= "open" (.-newState e))
+                                            (swap! log conj tag)))))]
+        ;; NESTED, so document order is unambiguous (an ancestor sorts ahead
+        ;; of its descendant) and both may legally be open at once.
+        (.setAttribute outer "popover" "auto")
+        (.setAttribute inner "popover" "auto")
+        (.appendChild outer inner)
+        (.appendChild js/document.body outer)
+        (watch! outer :outer)
+        (watch! inner :inner)
+        (try
+          (let [a (ref!)
+                b (ref!)]
+            ;; The seam: the FIRST ordered host call retires the SECOND
+            ;; generation, synchronously, from inside `showPopover()`.
+            (.addEventListener outer "beforetoggle" (fn [_] (b nil)))
+            (a outer)
+            (b inner)
+            (is (= 2 (top-layer/pending-count)) "both generations queued")
+            (top-layer/flush-top-layer!)
+            (is (= [:outer] @log)
+                (str "the retired generation's host call did not happen. Saw: "
+                     (pr-str @log)))
+            (is (true? (.matches outer ":popover-open"))
+                "the generation that still spoke opened its node")
+            (is (false? (.matches inner ":popover-open"))
+                "and the one that had let go left its node closed")
+            (is (zero? (top-layer/pending-count)) "the batch drained whole"))
+          (finally
+            (.remove outer)))))))
+
+(deftest fh-toplayer-004-a-mid-flush-retirement-spares-a-successors-claim
+  (testing "Per FH-TOPLAYER-004: the same identity check that cancels a
+            retired generation's own work is what stops it taking a NEWER
+            generation's claim on the same node down with it — and that has
+            to hold DURING the flush too, not only before it. A predecessor
+            retiring from inside an earlier ordered host call finds an entry
+            that is not its own, and the successor's operation happens."
+    (if-not (browser?)
+      (skip! "the browser job owns the ordered-flush assertions")
+      (let [log   (atom [])
+            outer (js/document.createElement "div")
+            inner (js/document.createElement "div")
+            ref!  (fn []
+                    (gobj/get (top-layer/install! #js {} :div
+                                                  {:popover            :auto
+                                                   :on-toggle          identity
+                                                   ::web/popover-open? true})
+                              "ref"))]
+        (.setAttribute outer "popover" "auto")
+        (.setAttribute inner "popover" "auto")
+        (.appendChild outer inner)
+        (.appendChild js/document.body outer)
+        (doseq [[^js node tag] [[outer :outer] [inner :inner]]]
+          (.addEventListener node "beforetoggle"
+                             (fn [^js e]
+                               (when (= "open" (.-newState e))
+                                 (swap! log conj tag)))))
+        (try
+          (let [a     (ref!)
+                older (ref!)
+                newer (ref!)]
+            (.addEventListener outer "beforetoggle" (fn [_] (older nil)))
+            (a outer)
+            (older inner)
+            (newer inner)                                  ; the successor's claim
+            (is (= 2 (top-layer/pending-count))
+                "one entry per node — the successor replaced the predecessor's")
+            (top-layer/flush-top-layer!)
+            (is (= [:outer :inner] @log)
+                (str "the successor's claim survived the mid-flush retirement. Saw: "
+                     (pr-str @log)))
+            (is (true? (.matches inner ":popover-open"))
+                "and its desired state is the one the node landed in")
+            (is (zero? (top-layer/pending-count)) "the batch drained whole"))
+          (finally
+            (.remove outer)))))))
+
 (deftest fh-toplayer-004-a-generation-retires-through-a-composed-release
   (testing "Per FH-TOPLAYER-004: retirement survives ref COMPOSITION. On an
             element sharing its node with another mechanism the install


### PR DESCRIPTION
Four defects on the compiled-browser runtime surface, one commit each.

## 1. A compiled list site's seen-key table is prototype-free

The compiled browser lowering proved a `for` site's keys with a plain `(js-obj)` and `goog.object/containsKey`, which is `key in obj` — so every name an object inherits from `Object.prototype` read as already present. The **first** row of a list keyed by `toString`, `constructor`, `hasOwnProperty` or `__proto__` was refused as a duplicate. Those are ordinary domain identifiers, and the structural tier's `node/keyed-run` accepts them: a view could pass every structural test and die the moment someone mounted it.

The seen table is now a `js/Set`, which holds exactly what is put in it. React's string coercion is untouched, so `1` and `"1"` still collide. No public API, no key registry.

New browser file `compiled_keyed_run_dom_cljs_test.cljs`: the whole inherited-name roster accepted at a real compiled `for` site and rendered in order; a repeat of each still refused by `:rf.error/ui-duplicate-key` at that site; the coercion rule intact both ways; and `node/keyed-run` reaching the same verdict row for row.

## 2. A root with no error callback keeps React's whole default

The framework always installs a stable delegate for the three host error keys so a remount can advance the callback React fixed at `createRoot`. That takes React's own default off the table for every root — including one that authored no callback — and the delegate replicated only half of it.

React's defaults are two-tier. `defaultOnUncaughtError` reports globally in every build **and**, in development, says that nothing contained the failure and where to read about error boundaries; `defaultOnCaughtError` logs the error in every build **and**, in development, names the boundary that will recreate the subtree. Only the production tier survived the delegate, so a fresh development root lost the diagnostics a programmer debugs from — and the claim in Spec 004C that omitting a callback restores React's own default reporting was untrue.

Both tiers are now replicated and gated exactly where React gates them, and the default takes the same two arguments the authored callback does, so the context comes off the **public** `errorInfo`: `componentStack` printed as the string React formats, `errorBoundary` named through its own constructor. No public API, no private React import, no stack parser, no logging framework.

Browser coverage adds the arms the merged proof never had: supplied → omitted for caught and uncaught, a supplied callback replacing the default without duplicating its report, and the recoverable key advanced and then dropped across a real hydrate-then-remount with the framework's mismatch signal still composed over it.

Note on the one-shot trap: React's own development warnings latch once per process, so an assertion on one would pass or fail on what an earlier file rendered. Every assertion here is on a call the root's own default handler makes, which has no latch — and React's message and the framework's are told apart by the component stack, which React's carries and the framework's does.

## 3. Top-layer generation ownership is re-checked during the flush

The batch is performed in document order, so the flush is a **loop** — and every top-layer host call has a synchronous callback seam (`beforetoggle` fires inside `showPopover()`, and Freehand permits a plain handler there). An earlier ordered call can retire a later generation while the loop is still running.

`flush-top-layer!` emptied the batch up front and sorted each entry into a plain `[node fact]` pair, dropping the owner before any host call ran. A retirement during the flush found nothing to withdraw, and the stale operation still opened a node its generation had already let go of — FH-TOPLAYER-004's ownership law violated at the publication boundary.

The batch map now stays the batch map for the whole flush and each entry is drained out of it as it is performed. An entry still standing under the identity the loop sorted is one whose generation still speaks; anything `retire!` removed mid-flush is no longer there to find. Document order, the single microtask batch and zero retention are unchanged; a successor's claim on the same node is still spared by the same identity check. No registry, observer, timer or public API.

## 4. The pilot's normalisation refusal is token-scoped and idempotent

Reference-normalisation claimed success and refusal were mutually exclusive terminal outcomes, but only the success carried and checked a token. The refusal mutated unconditionally: a refusal arriving after a settled success reversed it, and a duplicate refusal advanced the revision and the domain count a second time.

The two rejections are now two events, because they answer two questions. `:acme.invoice/reference-rejected` is the caller deciding **now** about the draft in front of it — R-A3's direct same-value baseline rejection, which has no request to be current with and always lands. The asynchronous `:acme.invoice/reference-refused` names the request it answers and applies only while that token is current, exactly as the success does; both now ask one predicate, under which `nil` is not a request identity. No general async abstraction, no new substrate API.

Both missing orders are covered in interpreted and compiled structural modes — success then late refusal, and refusal then duplicate refusal, asserted as byte-equal app-db — plus a superseded refusal, while the existing refusal → late success, duplicate-success and superseded-success rows stay green.

## Non-vacuity

Each fix was reverted in place and the full gate re-run; every failure named a new test and nothing else.

**Node lane, unguarded refusal restored** — exit `1`, 822 tests / 4921 assertions, **18 failures, 0 errors**, all in `r-a9-terminal-outcomes-are-mutually-exclusive` (the success-then-late-refusal, duplicate-refusal and superseded-refusal arms) and `r-a3-a-direct-rejection-is-not-a-late-reply`. Every pre-existing arm stayed green.

**Browser lane, the other three defects restored together** — exit `1`, 685 tests / 4209 assertions, **9 failures, 0 errors**:

| test | failures |
| --- | --- |
| `an-inherited-object-name-is-a-legal-first-key-at-a-compiled-list-site` | 3 |
| `a-remount-that-omits-the-uncaught-callback-gets-reacts-whole-default` | 2 |
| `a-remount-that-omits-the-caught-callback-gets-reacts-whole-default` | 2 |
| `fh-toplayer-004-a-generation-retiring-during-the-flush-does-not-act` | 2 |

No collateral failure anywhere else in either lane. Sources were then restored with `git checkout` — byte-identical to the committed content — and every gate re-run green.

## Quality gates

All run in the foreground to completion, captured to worktree-local logs, exit codes read from the runner rather than a pipe.

| gate | result | exit |
| --- | --- | --- |
| `implementation/freehand` → `clojure -M:test` | 807 tests / 5838 assertions, 0 failures, 0 errors | `0` |
| `npm run test:freehand` | 822 tests / 4921 assertions, 0 failures, 0 errors | `0` |
| `npm run test:cljs` | 10947 tests / 55046 assertions, 0 failures, 0 errors | `0` |
| `npm run test:browser` | 685 tests / 4209 assertions, 0 failures, 0 errors | `0` |
| `python scripts/check_freehand_conformance_index.py` | index valid | `0` |

The browser lane's shadow-cljs `config:` banner named this worktree on every run. The one compile warning (`fingerprint.cljc:130` `-write` redef) is pre-existing on `main` and untouched here.
