### PR TITLE
fix(freehand): render a key-condition v/event branch on the structural host (rf2-7x0ge)

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/node.cljc
+++ b/implementation/freehand/src/re_frame/freehand/node.cljc
@@ -453,11 +453,73 @@
     ;; and composing it with nothing produced a copy of the sugar vector.
     (conv/class-string (if (zero? (count parts)) sugar (into (vec sugar) parts)))))
 
+(defn- fn-carried?
+  "Is `x` a value whose SPELLING is testable and whose BEHAVIOUR is not — a
+  bare function, or one of the declared roster callbacks (`v/event`,
+  `v/handler`, `v/raw-fn`)?
+
+  A roster callback carries a function rather than being one, so `fn?`
+  alone answers false for it. Asking both questions in one place is what
+  keeps the whole-handler position and the key-condition BRANCH position
+  answering the same thing about the same value."
+  [x]
+  (or (fn? x) (events/callback? x)))
+
+(defn- key-condition-map?
+  "Is this map at an event position the exact-key CONDITION form rather than
+  the listener OPTIONS map?
+
+  Decided by the PRESENCE of a string key, which is exactly how
+  [[re-frame.freehand.events/event-plan]] decides it at render and how the
+  compiled analyzer decides it at build: an options map's keys are the
+  closed keyword roster, so one string key already means the map is not
+  one. A map MIXING the two is refused at both of those places as the
+  authoring error it is; here it takes the branch reading, because this
+  function records what the element declared and does not re-police a
+  grammar two front ends already hold."
+  [m]
+  (boolean (some string? (keys m))))
+
+(defn- key-branch
+  "One BRANCH of a key-condition map, as the tree records it.
+
+  A branch is a SITE, not a value inside one. The closed exact-key form
+  (Spec 004 §Key-condition event maps) NAMES each branch and admits there
+  what the whole handler position admits, minus the roster forms that do
+  not dispatch: an event vector, an options map carrying `:event`, a
+  `v/event`, or nil. So the site rule reaches one level down with it — a
+  branch that IS a callback records the mode-neutral marker, exactly as a
+  whole handler carrying one does, while a non-data value nested INSIDE a
+  branch is still refused, at the branch that recorded it.
+
+  Walking a branch as ordinary data instead refused the whole element:
+  `{\"Enter\" (v/event [e] …)}` is a spelling the compiled tier deliberately
+  lowers to the dispatching roster callback, so the structural host answered
+  `:rf.error/ui-tree-malformed` for it in BOTH modes — no SSR and no
+  headless render for a form the substrate itself writes."
+  [tag k key-str branch]
+  (if (fn-carried? branch)
+    {:rf.ui/opaque :fn}
+    (do (when-let [[path bad] (non-data branch)]
+          (let [path (into [key-str] path)]
+            (malformed!
+              're-frame.freehand/render
+              (str "The " k " handler on " tag " carries a " (offender-name bad)
+                   (at-path path)
+                   " inside a key-condition branch. A branch names ONE intent and is "
+                   "recorded verbatim, so it is data through and through — a test "
+                   "compares it as data and the event system dispatches it as data. A "
+                   "function records as the opaque marker when it IS the branch; it "
+                   "cannot ride inside one.")
+              {:attr k :path path :value (shape bad)})))
+        branch)))
+
 (defn classify-event
   "One `:events` entry value, classified BY THE VALUE PRESENT AT RENDER
   (Spec 004B §Element fields): a vector is a literal event intent, a map is
-  an options map, a FN-CARRIED SITE is one whose spelling is testable and
-  whose behaviour is not, and nil drops the entry.
+  an options map or the exact-key condition form, a FN-CARRIED SITE is one
+  whose spelling is testable and whose behaviour is not, and nil drops the
+  entry.
 
   A fn-carried site is a bare function OR one of the declared roster
   callbacks — `v/event`, `v/handler`, `v/raw-fn` — exactly as 004B
@@ -473,7 +535,8 @@
   An intent and an options map are recorded VERBATIM, so they must already
   be data — a function riding as an event argument would record an intent
   that cannot be compared, printed, or dispatched as the site's own
-  (§Data)."
+  (§Data). A key-condition map is recorded branch by branch, because the
+  form names each branch as a site of its own ([[key-branch]])."
   [tag k v]
   (cond
     (nil? v)    nil
@@ -490,20 +553,25 @@
                              "value; it cannot ride inside the intent.")
                         {:attr k :path path :value (shape bad)}))
                     v)
-    (map? v)    (do (when-let [[path bad] (non-data v)]
-                      (malformed!
-                        're-frame.freehand/render
-                        (str "The " k " handler on " tag " carries a " (offender-name bad)
-                             (at-path path)
-                             " inside its options map. An options map is recorded verbatim "
-                             "and is data through and through — the structural tree prints "
-                             "and reads back EQUAL, so a value inside one has to survive "
-                             "that round trip. A function records as the opaque marker "
-                             "when it IS the handler value; it cannot ride inside the "
-                             "options.")
-                        {:attr k :path path :value (shape bad)}))
-                    v)
-    (or (fn? v) (events/callback? v))
+    (map? v)    (if (key-condition-map? v)
+                  (reduce-kv (fn [m key-str branch]
+                               (assoc m key-str (key-branch tag k key-str branch)))
+                             {}
+                             v)
+                  (do (when-let [[path bad] (non-data v)]
+                        (malformed!
+                          're-frame.freehand/render
+                          (str "The " k " handler on " tag " carries a " (offender-name bad)
+                               (at-path path)
+                               " inside its options map. An options map is recorded verbatim "
+                               "and is data through and through — the structural tree prints "
+                               "and reads back EQUAL, so a value inside one has to survive "
+                               "that round trip. A function records as the opaque marker "
+                               "when it IS the handler value; it cannot ride inside the "
+                               "options.")
+                          {:attr k :path path :value (shape bad)}))
+                      v))
+    (fn-carried? v)
     {:rf.ui/opaque :fn}
 
     :else

--- a/implementation/freehand/test/re_frame/freehand/key_condition_branch_structural_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/key_condition_branch_structural_cljs_test.cljc
@@ -1,0 +1,141 @@
+(ns re-frame.freehand.key-condition-branch-structural-cljs-test
+  "A key-condition map carrying a `v/event` BRANCH renders on the structural
+  host, in both modes, with the callback branch recorded OPAQUE rather than
+  walked as data.
+
+  Spec 004B §The opaque marker: a fn-carried SITE records the mode-neutral
+  `{:rf.ui/opaque :fn}`, and the rule reaches every position the grammar
+  NAMES a site at. A key-condition map names each exact-key branch as a site
+  of its own (Spec 004 §Key-condition event maps), and a branch admits the
+  dispatching roster — an event vector, an options map carrying `:event`, or
+  a `v/event`. So a `v/event` branch is a fn-carried site like a whole
+  handler, and it records the same marker.
+
+  The defect this pins closed: `node/classify-event`'s map arm walked a
+  key-condition map's branches as ORDINARY DATA. A `v/event` lowers to a
+  `Callback` record, which is not data, so the walk raised
+  `:rf.error/ui-tree-malformed` — \"carries a scalar at [\\\"Enter\\\"]\" —
+  for a form PR #6769 deliberately admits and dispatches. It fired in BOTH
+  modes, because both reach `node/classify-event` at render, so a
+  perfectly ordinary `[:input {:on-key-down {\"Enter\" (v/event [e] …)}}]`
+  had NO SSR and NO headless render. The whole-handler `v/event` was already
+  recorded opaque (rf2-berc2 / #6780); this is the same treatment for a
+  branch value.
+
+  Runs on both hosts: the structural tree is `.cljc` and its recorded value
+  is asserted against one expected map in two runtimes, exactly as the rest
+  of the structural corpus is. The JVM structural path is the one the bead
+  requires proved — `clojure -M:test` runs this file — and the compiled twin
+  reaches the SAME `node/classify-event` at render, so the marker is settled
+  in one place for both front ends."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.conformance :as conf]
+            [re-frame.freehand.tree :as tree]))
+
+;; ---------------------------------------------------------------------------
+;; The two front ends, one body
+;; ---------------------------------------------------------------------------
+;;
+;; Written the same characters in each declaration — a callback branch beside
+;; a DATA branch — so the callback records opaque while the vector stays
+;; verbatim, and both facts are asserted in both modes from one shape.
+
+(v/defview key-map-interpreted
+  [_]
+  [:input {:on-key-down {"Enter"  (v/event [e] [:app/accept e])
+                         "Escape" [:app/close]}}])
+
+(v/defview key-map-compiled
+  {:compiled true}
+  [_]
+  [:input {:on-key-down {"Enter"  (v/event [e] [:app/accept e])
+                         "Escape" [:app/close]}}])
+
+(def ^:private expected
+  "The ONE structural tree both declarations answer for their `:input`, with
+  the root's version stripped so the boundary wrappers compare. The `\"Enter\"`
+  branch is a `v/event`, a fn-carried site, so it records the mode-neutral
+  opaque marker; the `\"Escape\"` branch is an event vector, data, so it is
+  recorded verbatim."
+  {:tag :input
+   :events {:on-key-down {"Enter"  {:rf.ui/opaque :fn}
+                          "Escape" [:app/close]}}})
+
+(defn- rendered-input
+  "The `:input` node a declaration produced — the sole child of its view
+  boundary — with nothing about the boundary itself in view."
+  [view]
+  (first (:children (tree/render [view {}]))))
+
+(deftest a-v-event-branch-renders-on-the-structural-host-in-both-modes
+  (testing "The acceptance case, pinned as the ACTUAL recorded tree rather
+            than an absence of a throw. A test asserting `no error` would be
+            green against a version that dropped the whole `:on-key-down`
+            entry; asserting the events map proves the branch is RECORDED,
+            opaque, beside its data sibling."
+    (is (= expected (rendered-input key-map-interpreted)) "interpreted")
+    (is (= expected (rendered-input key-map-compiled)) "compiled — the same tree")
+    (is (= (rendered-input key-map-interpreted) (rendered-input key-map-compiled))
+        "and the two modes agree node-for-node, which is the whole claim")))
+
+(deftest the-callback-branch-is-opaque-and-the-data-branch-is-verbatim
+  (testing "The two branch verdicts, stated on their own so neither can be
+            lost inside the whole-tree comparison. A `v/event` branch is a
+            site whose spelling is testable and whose behaviour is not, so it
+            records the marker; an event vector is data and is recorded as it
+            was written, placeholders and all."
+    (doseq [[mode view] [["interpreted" key-map-interpreted]
+                         ["compiled"    key-map-compiled]]]
+      (let [branches (get-in (rendered-input view) [:events :on-key-down])]
+        (is (= {:rf.ui/opaque :fn} (get branches "Enter"))
+            (str mode " — the v/event branch is opaque, not walked as data"))
+        (is (= [:app/close] (get branches "Escape"))
+            (str mode " — the data branch is recorded verbatim"))))))
+
+;; ---------------------------------------------------------------------------
+;; The site rule still reaches INSIDE a branch
+;; ---------------------------------------------------------------------------
+;;
+;; Recording a callback branch opaque must not turn a branch into a
+;; free-for-all: the marker occupies the SITE, and a non-data value NESTED
+;; inside a branch's own data — an event vector or an options map — is still
+;; refused, at the branch that recorded it (Spec 004B §Data). These run the
+;; INTERPRETED structural walk over a raw form, because the offending value
+;; is a runtime host object no compiled build would carry as a literal.
+
+(def ^:private a-host-object
+  "An atom: a value with no EDN spelling, the canonical non-data leaf."
+  (atom 1))
+
+(def ^:private refused-branches
+  "One key-condition branch per way a non-data value can hide inside one,
+  each still refused with the walk's EXISTING malformed-tree id."
+  [["a non-data value inside a branch's event vector"
+    [:input {:on-key-down {"Enter" [:app/go a-host-object]}}]]
+   ["a non-data value inside a branch's options map"
+    [:input {:on-key-down {"Enter" {:event [:app/go a-host-object]}}}]]
+   ["a non-data value nested at depth in a branch"
+    [:input {:on-key-down {"Enter" [:app/go {:cell a-host-object}]}}]]])
+
+(deftest a-non-data-value-inside-a-branch-is-still-refused
+  (testing "The marker is for the SITE, never for a value inside it. A
+            branch is recorded verbatim wherever it is data, so a host
+            object riding inside a branch's intent breaks the round trip the
+            tree promises and is refused at the branch — the same rule, and
+            the same id, the whole-handler options map is held to."
+    (doseq [[note form] refused-branches]
+      (is (= :rf.error/ui-tree-malformed
+             (conf/caught-id #(tree/render form)))
+          (str note " — refused, not silently recorded")))))
+
+(deftest the-refusal-assertion-is-not-vacuous
+  (testing "The rows above are proven able to PASS as well as fail: a branch
+            whose vector is data all the way down renders, so the refusal is
+            about the non-data value and not about the shape of a branch."
+    (is (= conf/no-throw
+           (conf/caught-id #(tree/render [:input {:on-key-down {"Enter" [:app/go 1 "ok"]}}])))
+        "a data branch renders — the refusal above is not refusing every branch")
+    (is (= {:on-key-down {"Enter" [:app/go 1 "ok"]}}
+           (:events (tree/render [:input {:on-key-down {"Enter" [:app/go 1 "ok"]}}])))
+        "and it is recorded as the data it is")))


### PR DESCRIPTION
Two compiled-vs-interpreted divergences on the analyzer/node surface. One is fixed here (rf2-7x0ge); the other (rf2-ll1ah) needs an operator ruling and is deferred with a recommendation below.

## rf2-7x0ge — a key-condition `v/event` branch now renders on the structural host

`node/classify-event`'s map arm walked a key-condition map's branches as ordinary data. A `v/event` branch lowers to a `Callback` record, which is not data, so the walk raised `:rf.error/ui-tree-malformed` ("carries a scalar at `["Enter"]`") for a form PR #6769 deliberately admits and dispatches. It fired in **both** modes — both reach `node/classify-event` at render — so `[:input {:on-key-down {"Enter" (v/event [e] …)}}]` had no SSR and no headless render.

**Fix (node.cljc, my surface):** classify a key-condition map branch by branch. A fn-carried branch (a bare fn or a roster callback) records the mode-neutral `{:rf.ui/opaque :fn}` — the same marker a whole handler carrying one records (rf2-berc2 / #6780) — while a non-data value **nested inside** a branch's own data (an event vector or an options map) is still refused at the branch that recorded it. No per-role marker (`:v/event`/`:v/handler`) is reintroduced; `:fn` is the mode-neutral member both front ends already emit at a DOM site.

Proved on the JVM structural path (the bead's requirement) and the CLJS host, cross-mode via an interpreted `v/defview` and its `{:compiled true}` twin, asserting the **actual** recorded `:events` map — `"Enter"` opaque, `"Escape"` verbatim — not an absence of a throw. New test: `key_condition_branch_structural_cljs_test.cljc`.

## rf2-ll1ah — `#id` sugar dropped on a `v/spread` element — DEFERRED, ruling needed

`analyze-element-props`' spread branch returns `:attrs []`, so `[:div#x (v/spread attrs)]` loses the sugar id in both compiled emitters while both interpreted walks keep it. Silent, cross-mode.

I investigated and **implemented nothing** for this bead, because the fix is coupled to a genuine design call the bead flags, and its complete cross-mode implementation is blocked by the current surface fence.

**What the investigation found.** The interpreted refusal of the *conflict* pair (`#id` sugar + a runtime `:id` inside the forwarded map) is **not** a build-time refusal — it fires at **render**, in `tree.cljc`'s `with-attrs` (structural) and `react.cljs`'s `react-props` (React), each guarding on the emitted id *slot*, on **presence**. The compiled emitters' runtime folds (`node/element`'s `:dyn` fold; `compiled_react.cljs`'s `spread!`) do **not** carry that guard, so a spread `:id` silently overwrites the sugar there. So "compiled cannot reproduce the interpreted refusal" is only true at *build* time; at *render* both tiers have the merged map in hand.

**The design call.** Two internally-consistent readings:

- **Option A — runtime refusal (recommended).** Judge the `#id`-sugar-vs-forwarded-`:id` conflict at render, on **presence**, in the fold both modes reach, so both throw identically. Consistent with the established ruling that `#id` + `:id` is an *ambiguity refused, not ranked* (rf2-huf81, `structural_slot_alias_jvm_test`, 004B §`.class#id` sugar), and consistent with huf81's presence-not-truth rule extended one step further: a forwarded map's keys aren't visible at build, so the judgment simply moves to the render fold where they are. Keeps the legitimate no-`:id` case working (the reported defect: sugar id survives the forward).
- **Option B — spread precedence wins.** `v/spread` is contractually later-arg-wins and `#id` sugar is the earliest "argument", so a forwarded `:id` could be ruled to win over the sugar. Defensible on spread's own precedence model, but it *ranks* an id ambiguity the rest of the grammar *refuses*.

I recommend **Option A**. It is the only reading consistent with the id-ambiguity ruling and with huf81; Option B would make id-conflict semantics diverge between the direct-props path (refused) and the spread path (ranked).

**Why nothing is implemented now.** Fixing the reported drop requires keeping the sugar id in the spread branch (doable in `analyze.cljc`, my surface) — but that immediately exposes the conflict semantics, which per Option A must be enforced in the render fold of **both** compiled emitters. The React-compiled half lives in `compiled_react.cljs` (`spread!`/`forward-entry!`), which is **fenced** (held by PRs #6804/#6805/#6806). Landing only the JVM-structural half would create a *new* intra-compiled divergence (JVM structural throws, React compiled silently overrides). Per the bead's implement-fully-or-nothing discipline and the surface fence, this is left for a coordinated follow-up once `compiled_react.cljs` is free, with the ruling made and pinned in `spec/004-Views.md`. The pre-existing drop is unchanged by this PR (not made worse).

## Quality gates

All foreground, full runs, exit codes captured:

| Gate | Result | Exit |
|---|---|---|
| `clojure -M:test` (freehand JVM) | Ran 843 tests, 6094 assertions, 0 failures/0 errors | 0 |
| `npm run test:freehand` (CLJS) | Ran 851 tests, 5153 assertions, 0 failures/0 errors | 0 |
| `npm run test:cljs` | Ran 10976 tests, 55278 assertions, 0 failures/0 errors | 0 |
| `npm run test:browser` | Ran 675 tests, 4146 assertions, 0 failures/0 errors, no pageerror | 0 |
| `python scripts/check_freehand_conformance_index.py` | clean | 0 |

Non-vacuity: the new test's opaque-marker assertion was inverted (`:fn` → `:NOT-FN`), the full JVM gate went red naming both `a-v-event-branch-renders-on-the-structural-host-in-both-modes` failures, and the assertion was restored byte-identical. The refusal rows carry their own in-file non-vacuity control (a data branch renders and is recorded verbatim).

Surface touched: `implementation/freehand/src/re_frame/freehand/node.cljc` + a new test. No fenced file touched.
