### PR TITLE
fix(freehand): fence typeahead replies against the latest token before query reuse

### DIFF
--- a/implementation/freehand/test/re_frame/freehand/pilot_typeahead.cljc
+++ b/implementation/freehand/test/re_frame/freehand/pilot_typeahead.cljc
@@ -170,17 +170,29 @@
   ;; schedule is ordinary `:dispatch-later`, and the token is what makes a
   ;; superseded one inert. An empty query schedules nothing — there is no
   ;; question to ask.
+  ;;
+  ;; It also REVOKES the in-flight claim, because the request that claim
+  ;; names has just been superseded — the keystroke moved the record past
+  ;; its token. The claim is the request token stamped into the slot it
+  ;; wrote, so dropping the slot drops the token with it: existence and
+  ;; identity stay one question. Without this the claim outlives its
+  ;; request until the NEXT debounce fires, and in that window a reply for
+  ;; the superseded token still names the standing claim and is believed —
+  ;; visible corruption the moment the query returns to what that reply
+  ;; answered. Supersession is the keystroke, not the next timer; the claim
+  ;; is revoked the instant the keystroke lands, leaving no acceptance gap.
   (rf/reg-event :acme.ui.typeahead/typed
     (fn [{:keys [db]} [_ k revision ms on-search text]]
       (let [r     (record db k)
             token (inc (:token r 0))
-            r*    (assoc (or r {})
-                         :reset-key revision
-                         :query     text
-                         :open?     true
-                         :active    0
-                         :token     token
-                         :error     nil)]
+            r*    (-> (or r {})
+                      (assoc :reset-key revision
+                             :query     text
+                             :open?     true
+                             :active    0
+                             :token     token
+                             :error     nil)
+                      (dissoc :in-flight))]
         (cond-> {:db (assoc-in db [records-root k] r*)}
           (not (str/blank? text))
           (assoc :fx [[:dispatch-later

--- a/implementation/freehand/test/re_frame/freehand/pilot_typeahead_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/pilot_typeahead_cljs_test.cljc
@@ -188,6 +188,59 @@
         (is (= "an" (:results-for (record)))
             "the visible answer still answers the current question")))))
 
+(deftest race-3b-an-obsolete-request-is-inert-before-any-newer-debounce-fires
+  (testing "RACE 3, the window RACE 3 does not close. RACE 3 lets the
+            newer keystroke's debounce FIRE — so the newer request claims
+            `:in-flight` and the older reply names a token nothing is
+            waiting for. But typing supersedes the older request the
+            instant the keystroke lands, not when the next debounce fires;
+            between them the older request must ALREADY be inert. A reply
+            that lands in that window, for a query the user has since typed
+            over and RETURNED to, must not be believed just because the
+            text matches again.
+
+            Drive it exactly: type `a` (token 1), fire its debounce so
+            token 1 is the claimed request, type `an` then `a` again
+            WITHOUT firing either newer debounce, then deliver token 1's
+            reply. It answers a question three keystrokes stale; it is
+            dropped, and nothing of its becomes visible merely because the
+            current text is `a` once more."
+    (seed! {})
+    (type! "a")
+    (fire-debounce! (:token (record)))
+    (let [req-1 (first (requests))]
+      (is (= 1 (:token (:in-flight (record)))) "token 1 is the claimed request")
+
+      (type! "an")
+      (type! "a")
+      (is (= 3 (:token (record))) "two more keystrokes moved the record past token 1")
+      (is (= "a" (:query (record))) "and the current query is `a` once more")
+
+      ;; The obsolete reply lands in the window before either newer
+      ;; debounce has fired. It names token 1 — which the record has left.
+      (reply! req-1 {:results results-a})
+      (is (nil? (:results-for (record)))
+          "the obsolete reply tagged NO answer — it was inert, not stored")
+      (is (empty? (:results (record)))
+          "and left no results behind")
+      (let [st (rf/subscribe-once [:acme.ui.typeahead/status k 0] {:frame fid})]
+        (is (empty? (:results st))
+            "nothing of token 1's answer is visible, though the text is `a` again")
+        (is (not (some #{"Amir Haddad"} (map :label (:results st))))
+            "specifically the token-1 results (results-a) are NOT shown"))
+
+      ;; Non-vacuity, same row: the LATEST token's due and reply land and
+      ;; become visible normally, so the drop above is selective, not a
+      ;; blanket refusal.
+      (fire-debounce! (:token (record)))
+      (let [req-2 (last (requests))]
+        (is (= 3 (:token (:in-flight (record)))) "the latest keystroke's request is now in flight")
+        (reply! req-2 {:results results-an})
+        (is (= results-an (:results (record))) "the current token's answer lands")
+        (is (= "a" (:results-for (record))) "tagged with the question it answers")
+        (let [st (rf/subscribe-once [:acme.ui.typeahead/status k 0] {:frame fid})]
+          (is (= results-an (:results st)) "and becomes visible normally"))))))
+
 (deftest race-4-stale-completion-cannot-clobber-what-the-user-typed
   (testing "RACE 4 — STALE COMPLETION, which is R-C1 exactly. A settle
             arrives while the user is mid-word. The baseline FAILS this:


### PR DESCRIPTION
Fixes rf2-vofuz (gh-6749).

## The defect

The typeahead pilot's `typed` event mints a fresh token on every keystroke but left `:in-flight` naming the *superseded* request. `replied` accepts a reply when its token equals the in-flight claim's token — so until the next debounce fired and overwrote the claim, a reply for the older token still matched the standing claim and was believed. When the query had returned to the text that reply answers, its `:results-for` matched the current query and the stale results became visible: a stale reply reused as current.

Existence (`:pending?`, "is there a claim?") and identity ("whose request?") had drifted into two questions with two answers — the claim could exist while naming a request the record had already left.

## What I observed reproducing the premise

I drove the exact interleaving from the bead as a headless row against current `main`, before the fix:

1. type `a` → token 1;
2. fire token 1's debounce → `:in-flight {:token 1 :query "a"}`, request 1 out;
3. type `an` → token 2, then `a` → token 3, **without** firing either newer debounce (the record's token is now 3, but `:in-flight` still names token 1);
4. deliver token 1's reply.

Observed on unpatched `main`: the reply was **accepted** — `:results-for` was stored as `"a"`, `:results` became `[amir, anna]`, and the status sub rendered "Amir Haddad" as a visible suggestion, purely because the current query was `"a"` again. Four assertions in the new row failed on exactly that (the obsolete reply tagged an answer and became visible). This contradicts the pilot's Race 3/4, R-C1 and R-C4 claims.

## The fix

Supersession is the keystroke, not the next timer. `typed` now `dissoc`s `:in-flight` as it mints the new token. The claim is the request token stamped into the slot it wrote, so dropping the slot drops the token with it — existence and identity become one question with one answer, and a reply for a superseded token finds no standing claim and is inert. There is no acceptance gap: the claim is revoked the instant the keystroke lands, not when the next debounce fires. `:in-flight` is only ever written by `due` for the current token, so `replied`'s existing exact-token match against the claim is now sufficient on its own.

No cancellation handle, hidden timer/channel, resources coupling, transport abstraction, public API or async-control framework was added. The event-layer debounce and its traceability are untouched.

## The regression

New headless row `race-3b-an-obsolete-request-is-inert-before-any-newer-debounce-fires` (in `pilot_typeahead_cljs_test.cljc`) drives the interleaving above and asserts the **attributed** result, not merely "something is empty":

- after token 1's reply lands, `:results-for` is **nil** (no answer tagged) and the token-1 results (`Amir Haddad`) are **not** among the visible suggestions, though the text is `a` again;
- non-vacuity in the same row: the latest token's due and reply then land and become visible normally.

No existing row pinned the stale-wins behaviour, so nothing was flipped or loosened. Non-vacuity was confirmed by inverting the `:results-for` drop assertion (full run reds naming this test) and restoring byte-identical.

## Quality gates

All foreground, to completion, captured to worktree-local logs; shadow-cljs config banner named this worktree on every build.

| Gate | Result |
| --- | --- |
| `cd implementation/freehand && clojure -M:test` (JVM) | 856 tests / 6189 assertions, 0 failures, 0 errors — EXIT 0 |
| `npm run test:freehand` (node) | 868 tests / 5238 assertions, 0 failures, 0 errors — EXIT 0 |
| `npm run test:cljs` | 10993 tests / 55363 assertions, 0 failures, 0 errors — EXIT 0 |
| `npm run test:browser` | 687 tests / 4217 assertions, 0 failures, 0 errors — EXIT 0 |

The known virtual-table scroll flake did not appear; the `:redef` warning in `fingerprint.cljc` is pre-existing and untouched by this change.