### PR TITLE
fix(freehand): four diagnostic-truth and inertness fixes (drpa3 .141/.142/.146/.138)

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/errors.cljc
+++ b/implementation/freehand/src/re_frame/freehand/errors.cljc
@@ -256,10 +256,21 @@
      :cljs (and (some? thrown) (identical? thrown (js/Object thrown)))))
 
 (defn note-failing-view!
-  "Record `view-id` as the declared view whose render threw `thrown` —
-  called by the OCCURRENCE seam of each host (the React function component
-  the interpreted emitter builds, the structural walk's mount) as that throw
-  passes through it, and by nothing else.
+  "Record `view-id` as the declared view whose render threw `thrown`, at
+  `phase` — called by the OCCURRENCE seam of each host (the React function
+  component the interpreted emitter builds, the structural walk's mount) as
+  that throw passes through it, and by nothing else.
+
+  `phase` is the moment the failure arose AT THIS SEAM, and is knowable only
+  here: `:render` when the declared view BODY threw as it was called, and
+  `:normalize` when the body returned and the emitter's WALK of what it
+  returned threw — a lazy child realised by the walk, common prop/event
+  validation refusing a value. The catching boundary is several fibers or
+  frames above and, like the view identity, cannot tell the two apart from
+  the throwable alone; so the phase rides the thrown value from the seam that
+  observed it, exactly as the identity does. A seam that owns only a body
+  call (the compiled tier, whose body walks internally) uses the `:render`
+  default arity.
 
   The FIRST writer for a given throw wins, because the innermost occurrence
   is the one that threw: the throw unwinds outward through every enclosing
@@ -267,18 +278,20 @@
   overwrite the culprit with itself. First-writer-wins is scoped to the ONE
   throw — a concurrent or interleaved failure is a different key and neither
   claims nor clears the other's note."
-  [thrown view-id]
-  (when (attributable? thrown)
-    #?(:clj  (.putIfAbsent ^java.util.Map failing-views thrown view-id)
-       :cljs (when-not (.has ^js failing-views thrown)
-               (.set ^js failing-views thrown view-id))))
-  nil)
+  ([thrown view-id] (note-failing-view! thrown view-id :render))
+  ([thrown view-id phase]
+   (when (attributable? thrown)
+     (let [note {:view-id view-id :phase phase}]
+       #?(:clj  (.putIfAbsent ^java.util.Map failing-views thrown note)
+          :cljs (when-not (.has ^js failing-views thrown)
+                  (.set ^js failing-views thrown note)))))
+   nil))
 
 (defn- noted-failing-view
-  "The view noted for `thrown`, or nil when no occurrence noted one. Reading
-  is not consuming: the note belongs to the throw, so a host that catches
-  the same throw twice (StrictMode, an HMR re-render) reads the same
-  answer."
+  "The note recorded for `thrown` — `{:view-id … :phase …}` — or nil when no
+  occurrence noted one. Reading is not consuming: the note belongs to the
+  throw, so a host that catches the same throw twice (StrictMode, an HMR
+  re-render) reads the same answer."
   [thrown]
   (when (attributable? thrown)
     #?(:clj  (.get ^java.util.Map failing-views thrown)
@@ -286,8 +299,8 @@
 
 (defn attributed-failure
   "Answer `caught` — a host's raw material for one failure — carrying the
-  identity of the declared view that actually threw, resolved from the
-  occurrence seam's note on `caught`'s own `:exception`
+  identity AND the phase of the declared view that actually threw, resolved
+  from the occurrence seam's note on `caught`'s own `:exception`
   ([[note-failing-view!]]).
 
   This is the whole value of a failure report. A record that names the
@@ -298,12 +311,20 @@
   share a catcher. A record that named some OTHER failure's thrower is worse
   again: it is a confident identification of an innocent view.
 
+  The `:phase` travels the same failure-local route. The boundary can only
+  supply a DEFAULT phase — it caught the throw where nothing tells it whether
+  the view body threw or the walk of what the body returned did — so the
+  seam's observed phase, when there is one, wins. A normalization/walk
+  failure and a view-body failure under the same view therefore fingerprint
+  APART, which is the whole point of `:phase` being public diagnostic data.
+
   When nothing was noted for this throw the record says so —
   [[unknown-view-id]], evidence marked incomplete, and a `:loss` naming why
-  — rather than substituting an identity it does not have."
+  — rather than substituting an identity it does not have, and the host's
+  default `:phase` is kept."
   [{:keys [exception] :as caught}]
-  (if-let [failing (noted-failing-view exception)]
-    (assoc caught :view-id failing)
+  (if-let [{:keys [view-id phase]} (noted-failing-view exception)]
+    (assoc caught :view-id view-id :phase phase)
     (assoc caught
            :view-id   unknown-view-id
            :complete? false

--- a/implementation/freehand/src/re_frame/freehand/props_schema.cljc
+++ b/implementation/freehand/src/re_frame/freehand/props_schema.cljc
@@ -72,39 +72,64 @@
   `:children-policy`."
   #{:key :children})
 
+(defn- authored-schema
+  "The authored schema a published `:props` metadatum denotes, reading through
+  the inert wrapper [[inert-form]] emits.
+
+  A declaration publishes its schema quoted, so nested authored forms are
+  never evaluated. On the host whose analyzer carries Var metadata as a FORM,
+  a compiled parent reads that metadatum as the `(quote …)` the declaration
+  emitted; every other surface — the runtime descriptor projection, JVM Var
+  metadata — has already evaluated the quote away and hands the schema as
+  data, where this is the identity. Stripping exactly one such wrapper is the
+  inverse of publishing it, so the readers below see ONE schema wherever it is
+  read."
+  [schema]
+  (if (and (seq? schema) (= 'quote (first schema)) (= 2 (count schema)))
+    (second schema)
+    schema))
+
 (defn- map-schema-properties
   "The optional properties map of a literal `[:map {…} …]` schema."
   [schema]
-  (when (and (vector? schema) (= :map (first schema)))
-    (let [p (second schema)]
-      (when (map? p) p))))
+  (let [schema (authored-schema schema)]
+    (when (and (vector? schema) (= :map (first schema)))
+      (let [p (second schema)]
+        (when (map? p) p)))))
 
 (defn map-schema?
   "True when `schema` is a LITERAL `[:map …]` — the only shape whose top-level
   keys can be read at compile time. A schema behind a registry reference or a
   runtime expression is opaque here, and an opaque schema closes nothing: a
   guess about keys nobody can see would be worse than the open map it
-  replaced."
+  replaced. Reads through the published inert wrapper ([[authored-schema]])."
   [schema]
-  (and (vector? schema) (= :map (first schema))))
+  (let [schema (authored-schema schema)]
+    (and (vector? schema) (= :map (first schema)))))
 
 (defn inert-form
   "The form a DECLARATION emits to carry `schema` — inert data that yields the
   authored schema itself and never something the author did not write.
 
-  A literal `[:map …]` is already inert: it evaluates to itself, and it stays
-  unwrapped because a compiled parent reads a child's schema off Var metadata
-  at BUILD time, where that metadata is a FORM rather than a value.
+  Every schema is QUOTED, unconditionally. A literal `[:map …]` looks
+  self-evaluating, but only until an entry value is a nested authored FORM —
+  `[:map [:id (do (log!) :int)]]`, a registry reference, a function call. Left
+  unquoted, that form is executable code the declaration runs as it loads:
+  once building the Var metadata and once building the descriptor, publishing
+  the evaluated VALUE in place of the authored form on both surfaces. Quoting
+  the whole schema evaluates the author's expression exactly ZERO times, which
+  is what makes a schema inert data rather than a value the declaration
+  computes.
 
-  Anything else is an EXPRESSION, and evaluating it is how the one decision
-  becomes two. The compiled front end can only ever see the expression, so it
-  reads an opaque schema and leaves the map open; an evaluated expression hands
-  the runtime descriptor a literal `[:map …]` and closes the very same map at
-  render. Quoting keeps ONE schema at every surface — and evaluates the
-  author's expression exactly zero times, which is what makes a schema inert
-  data rather than a value the declaration computes."
+  The compiled front end reads a child's schema off Var metadata at BUILD
+  time, and on the host whose analyzer carries metadata as a FORM it therefore
+  sees this `(quote …)` wrapper; the runtime descriptor projection and JVM Var
+  metadata have already evaluated the quote away and carry the schema as data.
+  [[authored-schema]] reads through the wrapper — the exact inverse of
+  emitting it — so the roster derivation reads ONE schema the same at every
+  surface, and an opaque schema stays opaque there just as it does here."
   [schema]
-  (if (map-schema? schema) schema (list 'quote schema)))
+  (list 'quote schema))
 
 (defn declared-keys
   "The top-level prop keys a literal `[:map …]` schema names, in declaration
@@ -112,14 +137,16 @@
 
   This is the roster for ORDER-sensitive uses — slot layout, comparator
   order, catalogue listings. [[closing-keys]] answers the different question
-  of what the map is closed against."
+  of what the map is closed against. Reads through the published inert wrapper
+  ([[authored-schema]])."
   [schema]
-  (when (map-schema? schema)
-    (let [entries (rest schema)
-          entries (if (map? (first entries)) (rest entries) entries)]
-      (into []
-            (keep #(when (and (vector? %) (keyword? (first %))) (first %)))
-            entries))))
+  (let [schema (authored-schema schema)]
+    (when (map-schema? schema)
+      (let [entries (rest schema)
+            entries (if (map? (first entries)) (rest entries) entries)]
+        (into []
+              (keep #(when (and (vector? %) (keyword? (first %))) (first %)))
+              entries)))))
 
 (defn reserved-declared
   "The [[reserved-keys]] a literal `[:map …]` schema NAMES, in declaration

--- a/implementation/freehand/src/re_frame/freehand/react.cljs
+++ b/implementation/freehand/src/re_frame/freehand/react.cljs
@@ -444,21 +444,29 @@
                     (fn []
                       ;; The OCCURRENCE SEAM. React renders each declared
                       ;; view in its own component, so a throw arriving here
-                      ;; is THIS view's body's — the boundary that catches it
-                      ;; several fibers above has no other way to learn whose,
-                      ;; and the throwable carries no view identity. The note
-                      ;; rides the thrown value, which is the one thing this
-                      ;; render and that catch demonstrably share: React
-                      ;; finishes rendering every failed subtree of a commit
-                      ;; before it runs any `componentDidCatch`, so two
-                      ;; failures are routinely in flight at once.
-                      (try
-                        (emit cand
-                              (body (conv/forward-children
-                                      (gobj/get js-props "props"))))
-                        (catch :default e
-                          (eb/note-failing-view! e view-id)
-                          (throw e)))))))))]
+                      ;; is THIS view's — the boundary that catches it several
+                      ;; fibers above has no other way to learn whose, and the
+                      ;; throwable carries no view identity. The note rides the
+                      ;; thrown value, which is the one thing this render and
+                      ;; that catch demonstrably share: React finishes
+                      ;; rendering every failed subtree of a commit before it
+                      ;; runs any `componentDidCatch`, so two failures are
+                      ;; routinely in flight at once. The note also carries the
+                      ;; PHASE, equally unknowable at the catch: a throw while
+                      ;; CALLING the body is `:render`, and a throw while the
+                      ;; emitter WALKS what the body returned — a lazy child
+                      ;; realised by the walk — is `:normalize`.
+                      (let [form (try
+                                   (body (conv/forward-children
+                                           (gobj/get js-props "props")))
+                                   (catch :default e
+                                     (eb/note-failing-view! e view-id :render)
+                                     (throw e)))]
+                        (try
+                          (emit cand form)
+                          (catch :default e
+                            (eb/note-failing-view! e view-id :normalize)
+                            (throw e))))))))))]
     (gobj/set c "displayName" (str view-id))
     c))
 
@@ -563,10 +571,13 @@
                   (cell/with-capture
                     cand
                     (fn []
+                      ;; A behavior owns no body of its own — it WALKS the one
+                      ;; decorated element it was handed. A throw here is that
+                      ;; walk realising a lazy child, so it is `:normalize`.
                       (try
                         (behaviors/attach (emit cand (:child opts)) set-node)
                         (catch :default e
-                          (eb/note-failing-view! e view-id)
+                          (eb/note-failing-view! e view-id :normalize)
                           (throw e)))))))))]
     (gobj/set c "displayName" (str view-id))
     c))

--- a/implementation/freehand/src/re_frame/freehand/tree.cljc
+++ b/implementation/freehand/src/re_frame/freehand/tree.cljc
@@ -360,14 +360,28 @@
           ;; learn whose it was — the throwable carries no view identity, and
           ;; a boundary that guessed would name the guarded child or itself.
           ;; The note is against THIS throw, and is dropped if an inner
-          ;; occurrence already made one for it.
-          kids    (try
-                    (if-let [structural (descriptor/structural-body view)]
+          ;; occurrence already made one for it. The seam also records the
+          ;; PHASE, which is likewise unknowable at the catch: a compiled body
+          ;; walks internally, so its throw is `:render`; an interpreted body
+          ;; is called and then its result is walked, so a throw while CALLING
+          ;; is `:render` and a throw while WALKING what it returned — a lazy
+          ;; child realised here — is `:normalize`.
+          kids    (if-let [structural (descriptor/structural-body view)]
+                    (try
                       (node/children (structural props*))
-                      (children [((descriptor/render-body view) props*)]))
-                    (catch #?(:clj Throwable :cljs :default) e
-                      (eb/note-failing-view! e view-id)
-                      (throw e)))]
+                      (catch #?(:clj Throwable :cljs :default) e
+                        (eb/note-failing-view! e view-id :render)
+                        (throw e)))
+                    (let [form (try
+                                 ((descriptor/render-body view) props*)
+                                 (catch #?(:clj Throwable :cljs :default) e
+                                   (eb/note-failing-view! e view-id :render)
+                                   (throw e)))]
+                      (try
+                        (children [form])
+                        (catch #?(:clj Throwable :cljs :default) e
+                          (eb/note-failing-view! e view-id :normalize)
+                          (throw e)))))]
       (node/boundary view-id props keyed? key kids))))
 
 ;; ---------------------------------------------------------------------------

--- a/implementation/freehand/test/re_frame/freehand/behavior_throw_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/behavior_throw_cljs_test.cljc
@@ -155,7 +155,9 @@
       (is (= (:safe-summary-keys error-003) (set (keys summary)))
           "exactly the closed public field set")
       (is (= (:diagnostic-id error-003) (:diagnostic-id summary)))
-      (is (= (:phase error-003) (:phase summary)))
+      (is (= :normalize (:phase summary))
+          "the view body returned; the WALK realising the lazy child raised
+           the failure, so the phase is :normalize, not :render")
       (is (= (:basis error-003) (:basis (:evidence summary))))
       (is (empty? (set/intersection (:forbidden-keys error-003) (deep-keys summary)))
           "no exception, ex-data, props, app-db or event history")

--- a/implementation/freehand/test/re_frame/freehand/behavior_throw_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/behavior_throw_dom_cljs_test.cljs
@@ -281,9 +281,12 @@
                            "the evidence is complete — nothing about this failure was lost")
                        (is (nil? (:loss (:evidence summary)))
                            "so there is no loss to name")
-                       (is (= (eb/fingerprint behaviors/behavior-view-id :render)
+                       (is (= (eb/fingerprint behaviors/behavior-view-id :normalize)
                               (:fingerprint summary))
-                           "and the correlation token follows the attribution"))
+                           "and the correlation token follows the attribution AND
+                            the phase: the behavior body returned and the emitter's
+                            WALK of its decorated child raised the failure, so the
+                            token names the :normalize phase, not :render"))
                      (done))
                   (fn [e]
                     (is false (str "mount rejected: " e))
@@ -348,8 +351,10 @@
                        (is (= (:safe-summary-keys error-003) (set (keys summary)))
                            "the safe summary's field set is exactly the closed public set")
                        (is (= (:diagnostic-id error-003) (:diagnostic-id summary)))
-                       (is (= (:phase error-003) (:phase summary))
-                           "a Freehand body threw, so the phase is :render")
+                       (is (= :normalize (:phase summary))
+                           "the behavior body returned; the emitter WALK realising
+                            the lazy decorated child raised the failure, so the
+                            phase is :normalize, not :render")
                        (is (= (:basis error-003) (:basis (:evidence summary))))
                        (is (empty? (set/intersection (:forbidden-keys error-003)
                                                      (deep-keys summary)))

--- a/implementation/freehand/test/re_frame/freehand/phase_attribution_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/phase_attribution_cljs_test.cljc
@@ -1,0 +1,90 @@
+(ns re-frame.freehand.phase-attribution-cljs-test
+  "The error PHASE is public diagnostic data and part of the failure
+  fingerprint: `:render` means a declared view BODY threw, `:normalize` means
+  the emitter's walk of what the body returned threw (a lazy child realised, a
+  refused prop). A normalization defect reported as `:render` mislabels the
+  failure and — because the fingerprint derives from the view id and the phase
+  — collapses a body defect and a normalization defect in the SAME view onto
+  one correlation token.
+
+  This suite proves the discriminator on the host-neutral structural walk (it
+  is `.cljc`, so it runs on the JVM and in ClojureScript). The browser
+  realisation of the same law rides the React class boundary and is proven
+  beside the behavior-seam scenario in `behavior-throw-dom-cljs-test`."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test :refer-macros [deftest is testing]])
+            [re-frame.freehand :as v]
+            [re-frame.freehand.descriptor :as descriptor]
+            [re-frame.freehand.errors :as eb]
+            [re-frame.freehand.tree :as tree]))
+
+;; ONE declared view with two ways to fail, selected by a prop so the two
+;; failures share a view id and differ ONLY in phase. Each failure throws a
+;; FRESH exception: the attribution relay is keyed by the thrown value's
+;; identity and is first-writer-wins, so a single shared object reused across
+;; both renders would carry the first render's note into the second.
+(v/defview flaky
+  "Its body throws when asked (a `:render` failure), or it returns markup
+  whose lazy child throws only when the walk realises it (a `:normalize`
+  failure)."
+  [props]
+  (if (:in-body? props)
+    (throw (ex-info "flaky body threw" {}))
+    [:div.node (map (fn [_] (throw (ex-info "flaky walk threw" {}))) [:row])]))
+
+(defn- contained-summary
+  "The safe summary of the failure `form`'s walk produces under a fresh
+  boundary. The boundary can only supply a DEFAULT phase (`:render`); the
+  occurrence seam's observed phase is what must win."
+  [form]
+  (let [b (eb/boundary eb/boundary-view-id :rk)]
+    (:summary (eb/contain b #(tree/render form) {:phase :render :frame-id nil}))))
+
+(deftest a-view-body-throw-is-render-and-a-walk-throw-is-normalize
+  (testing "The same declared view fails two ways. Calling the body and having
+            it throw is a `:render` failure; the body returning markup whose
+            lazy child throws when the walk realises it is a `:normalize`
+            failure. The boundary passes `:render` as its default, so a summary
+            that reads `:render` for the walk case would be the boundary's
+            guess, not the seam's observation."
+    (let [body-summary (contained-summary [flaky {:in-body? true}])
+          walk-summary (contained-summary [flaky {:in-body? false}])]
+      (is (= :render (:phase body-summary))
+          "the body threw as it was called")
+      (is (= :normalize (:phase walk-summary))
+          "the body returned; the walk realising the lazy child threw")
+      (is (contains? eb/phases (:phase body-summary)))
+      (is (contains? eb/phases (:phase walk-summary))))))
+
+(deftest the-same-view-fingerprints-apart-by-phase
+  (testing "Because the fingerprint derives from the failing view id AND the
+            phase, a body defect and a normalization defect in ONE view carry
+            two correlation tokens. Were the phase hardcoded, they would
+            collapse onto a single token and a reader could not tell the two
+            failures apart."
+    (let [body-summary (contained-summary [flaky {:in-body? true}])
+          walk-summary (contained-summary [flaky {:in-body? false}])]
+      (is (= (:view-id body-summary) (:view-id walk-summary))
+          "the same declared view failed both times")
+      (is (not= (:fingerprint body-summary) (:fingerprint walk-summary))
+          "yet the two failures fingerprint apart, because :phase is part of
+           the token")
+      (is (= (eb/fingerprint (:view-id walk-summary) :normalize)
+             (:fingerprint walk-summary))
+          "and the normalization token names the normalization phase"))))
+
+(deftest non-vacuity-the-body-throws-when-called-and-the-walk-throws-when-realised
+  (testing "Non-vacuity: the `:render` variant really throws when the body is
+            CALLED, while the `:normalize` variant's body returns markup
+            without throwing and it is REALISING the returned lazy child that
+            throws — so the phases above are the two genuinely distinct moments
+            and not one moment relabelled."
+    (is (thrown? #?(:clj Throwable :cljs :default)
+                 ((descriptor/render-body flaky) {:in-body? true}))
+        "calling the body throws directly")
+    (let [form ((descriptor/render-body flaky) {:in-body? false})]
+      (is (vector? form)
+          "the walk variant's body returns markup without throwing")
+      (is (thrown? #?(:clj Throwable :cljs :default)
+                   (doall (last form)))
+          "and realising the returned lazy child is what throws"))))

--- a/implementation/freehand/test/re_frame/freehand/pilot_field.cljc
+++ b/implementation/freehand/test/re_frame/freehand/pilot_field.cljc
@@ -199,17 +199,47 @@
 ;; Instance-unique ids for a control's error region
 ;; ---------------------------------------------------------------------------
 
+(defn- hex-escape
+  "One non-alphanumeric character `c` as the reversible token `_<hex>_`."
+  [c]
+  (str "_"
+       #?(:clj  (Integer/toString (int (.charAt ^String c 0)) 16)
+          :cljs (.toString (.charCodeAt c 0) 16))
+       "_"))
+
+(defn- dom-escape
+  "Escape `s` to a DOM-safe token over `[A-Za-z0-9_]`, INJECTIVELY: an ASCII
+  alphanumeric passes through unchanged — so an ordinary name stays itself —
+  and every other character, INCLUDING `_` and the `-` the id join reserves
+  as its separator, becomes `_<hex>_`. Distinct strings therefore yield
+  distinct tokens, and a token never carries a bare `-`, so parts joined by
+  `-` cannot blur their boundary."
+  [s]
+  (str/replace s #"[^A-Za-z0-9]" hex-escape))
+
 (defn- id-token
-  "A DOM-safe token for one part of a control's identity, or nil when the
-  part is absent. `[:invoice 2 :reference]` becomes `invoice-2-reference`
-  and `\"description\"` stays `description`. Pure and stable, so the same
-  identity yields the same token on every render and after a list
-  reorder."
+  "A DOM-safe, INJECTIVE token for one part of a control's identity, or nil
+  when the part is absent. Distinct SUPPORTED identities yield distinct
+  tokens — the library promises the caller so and points an
+  `aria-describedby` at the result — so the encoding must not lose the
+  difference a lossy slug did: `\"a/b\"` and `\"a-b\"` are two identities,
+  `:invoice` and `\"invoice\"` are two, `1` and `\"1\"` are two, and `\"!\"`
+  and `\"@\"` are two rather than both nothing.
+
+  A string is escaped directly, so an ordinary name — `\"description\"` —
+  stays itself and a single-instance field keeps its short, readable id. Any
+  other value carries a reserved `_v_` prefix ahead of its escaped `pr-str`:
+  the prefix is one a string can never produce — a string's own `_` escapes
+  to `_5f_` — so a typed value and a string of the same characters never
+  collide, and `pr-str` keeps distinct values distinct (a `:control` vector
+  address escapes as one unambiguous token). Pure and stable: the same
+  identity yields the same token on every render and after a list reorder,
+  and nothing is allocated, counted or policed."
   [part]
   (when (some? part)
-    (let [t (-> (str part)
-                (str/replace #"[^A-Za-z0-9]+" "-")
-                (str/replace #"(^-+)|(-+$)" ""))]
+    (let [t (if (string? part)
+              (dom-escape part)
+              (str "_v_" (dom-escape (pr-str part))))]
       (when-not (str/blank? t) t))))
 
 (defn error-region-id

--- a/implementation/freehand/test/re_frame/freehand/pilot_field_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/pilot_field_cljs_test.cljc
@@ -701,6 +701,55 @@
                  (:id (t/attrs (error-of (field-node solo "description")))))
               "no :instance, so no instance segment"))))))
 
+(deftest error-region-ids-are-injective-over-supported-identities
+  (testing "rf2-drpa3.146. The id names ONE instance, and the library points
+            `aria-describedby` at it, so distinct SUPPORTED identities must
+            yield distinct ids. The lossy slug collapsed several onto one: it
+            replaced every non-alnum run with a single '-' and dropped a token
+            that trimmed to blank, so `\"a/b\"` and `\"a-b\"`, `1` and `\"1\"`,
+            and `\"!\"` and `\"@\"` all aliased. Line ids 1 and 2 never
+            exercised this — they slugged apart already."
+    (let [id (fn [instance] (pilot/error-region-id "acme-field" instance "description"))]
+      (is (not= (id "a/b") (id "a-b"))
+          "two string instances the slug collapsed are two ids")
+      (is (not= (id 1) (id "1"))
+          "a number and the string of its digits are two ids")
+      (is (not= (id "!") (id "@"))
+          "two punctuation-only identities are two ids, neither dropped")
+      (is (not= (id "!") (id nil))
+          "and a punctuation identity is not the same as no identity")
+      (is (not= (pilot/error-region-id "acme-field" "a" "b-c")
+                (pilot/error-region-id "acme-field" "a-b" "c"))
+          "the join cannot blur where one identity part ends and the next begins"))))
+
+(deftest a-buffered-control-address-is-injective-as-one-token
+  (testing "rf2-drpa3.146, acceptance 2. The buffered field slugs its whole
+            `:control` address as ONE token, so two distinct addresses must
+            still land on two ids — the same collision, at the surface the
+            controlled-instance fix does not touch."
+    (let [id (fn [control] (pilot/error-region-id "acme-buffered" control))]
+      (is (not= (id [:invoice 1 :reference]) (id [:invoice 2 :reference]))
+          "two line addresses are two ids")
+      (is (not= (id [:invoice 42 :reference]) (id [:invoice-42 :reference]))
+          "a boundary a lossy slug blurred — [:invoice 42 …] versus [:invoice-42 …]")
+      (is (not= (id [:invoice 1 :reference]) (id [:invoice 1 :ref]))
+          "and a different leaf is a different address"))))
+
+(deftest the-single-instance-short-id-and-purity-survive-the-fix
+  (testing "rf2-drpa3.146, acceptance 5. The fix adds no allocator and changes
+            neither the short single-instance id nor the purity the reorder
+            test relies on: an absent instance keeps the short readable form,
+            and the same identity yields the same id every call."
+    (is (= "acme-field-description-error"
+           (pilot/error-region-id "acme-field" nil "description"))
+        "no instance — the short, readable id is preserved")
+    (is (= (pilot/error-region-id "acme-field" "a/b" "description")
+           (pilot/error-region-id "acme-field" "a/b" "description"))
+        "pure: the same string identity yields the same id")
+    (is (= (pilot/error-region-id "acme-buffered" [:invoice 1 :reference])
+           (pilot/error-region-id "acme-buffered" [:invoice 1 :reference]))
+        "including a control-address identity")))
+
 ;; ===========================================================================
 ;; R-A9 — asynchronous transform race safety
 ;; ===========================================================================

--- a/implementation/freehand/test/re_frame/freehand/pilot_field_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/pilot_field_dom_cljs_test.cljs
@@ -574,6 +574,53 @@
                         (teardown! container root)
                         (done)))))))))
 
+(deftest pilot-two-instances-a-lossy-slug-collapsed-keep-distinct-mounted-ids
+  (testing "rf2-drpa3.146 (mounted). The collision the numeric line-id test
+            never reaches: two controlled fields with the same name and the
+            instances a lossy slug collapsed onto ONE id — \"a/b\" and
+            \"a-b\" — now mount with DISTINCT `aria-describedby` targets, each
+            resolving by document id to its own error region."
+    (if-not (browser?)
+      (skip! "the browser job runs the mounted collision regression")
+      (async done
+        (live-frame/make-frame {:id fid})
+        (frame/replace-app-db! fid {})
+        (pilot/register!)
+        (pilot/register-app!)
+        (let [[container root] (mount!)
+              field-form (fn [instance]
+                           [pilot/field {:name     "description"
+                                         :label    "Description"
+                                         :value    ""
+                                         :instance instance
+                                         :error    "A description is required."
+                                         :on-input [:noop]}])]
+          (-> (act #(.render root (shell/provide-frame
+                                    fid (fr/element [:div
+                                                     (field-form "a/b")
+                                                     (field-form "a-b")]))))
+              (.then
+                (fn [_]
+                  (let [controls (.querySelectorAll container "[data-part='control']")
+                        c1  (.item controls 0)
+                        c2  (.item controls 1)
+                        id1 (.getAttribute c1 "aria-describedby")
+                        id2 (.getAttribute c2 "aria-describedby")]
+                    (is (= 2 (.-length controls)) "non-vacuous: two fields mounted")
+                    (is (some? id1) "the \"a/b\" control names a region")
+                    (is (some? id2) "the \"a-b\" control names a region")
+                    (is (not= id1 id2)
+                        "\"a/b\" and \"a-b\" no longer collapse onto one id")
+                    (is (some? (.getElementById js/document id1))
+                        "the \"a/b\" region resolves by document id")
+                    (is (some? (.getElementById js/document id2))
+                        "the \"a-b\" region resolves by document id"))))
+              (.then (fn [_] (teardown! container root) (done)))
+              (.catch (fn [e]
+                        (is false (str "the mounted pilot rejected: " e))
+                        (teardown! container root)
+                        (done)))))))))
+
 ;; ===========================================================================
 ;; The compiled cell, re-opened — the pilot's compiled twin mounts
 ;; ===========================================================================

--- a/implementation/freehand/test/re_frame/freehand/props_schema_inert_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/props_schema_inert_cljs_test.cljc
@@ -1,0 +1,103 @@
+(ns re-frame.freehand.props-schema-inert-cljs-test
+  "PR #6752 promises every props schema is published AS AUTHORED, inert and
+  UNEVALUATED — an authored expression evaluated exactly ZERO times. A literal
+  [:map …] kept that promise only while it held nothing but self-evaluating
+  data: a nested authored FORM inside an entry is executable code, and the
+  pre-fix declaration ran it once building Var metadata and once building the
+  descriptor, publishing the evaluated value in place of the authored form on
+  both surfaces.
+
+  The probe COUNTS evaluations with a side effect, because 'looks unevaluated'
+  passes against the defect while 'was evaluated zero times' does not.
+
+  Host-neutral: the declaration expands on the JVM for both targets, and the
+  probe is read the same way under `clojure -M:test` and
+  `npm run test:freehand`."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test :refer-macros [deftest is testing]])
+            [re-frame.freehand :as v]
+            [re-frame.freehand.compiler.env :as env]
+            [re-frame.freehand.props-schema :as props-schema]))
+
+;; The eval probe. Defined BEFORE the view whose schema references it, so a
+;; pre-fix UNQUOTED nested form that runs at load can resolve it — the
+;; reproduction must be able to run before the fix makes the form inert.
+(defonce ^:private nested-schema-eval-count (atom 0))
+
+(v/defview nested-schema-row
+  "A literal [:map …] whose one entry value is a nested, side-effecting
+  authored form. This is the exact hole PR #6752 left: the map's top level IS
+  a literal [:map …], so the pre-fix inert-form left it UNQUOTED and the
+  (do …) ran while the declaration loaded."
+  {:props [:map [:id (do (swap! nested-schema-eval-count inc) :int)]]}
+  [{:keys [id]}]
+  [:li.row {:data-id id}])
+
+(def ^:private authored-schema
+  "The schema exactly as authored — the nested form intact and UNEVALUATED."
+  '[:map [:id (do (swap! nested-schema-eval-count inc) :int)]])
+
+(deftest a-nested-literal-map-schema-form-is-evaluated-zero-times
+  (testing "The nested authored form runs ZERO times across Var-metadata and
+            descriptor construction. The probe counts, so a side effect that
+            ran even once — as it ran TWICE before the fix — fails here."
+    (is (zero? @nested-schema-eval-count)
+        "the (do (swap! …)) inside the literal map ran zero times at load")))
+
+(deftest the-authored-nested-form-survives-on-every-published-surface
+  (testing "Inert also means AUTHORED: both surfaces carry the form the author
+            wrote, nested list intact, and never the value it would evaluate
+            to."
+    (is (= authored-schema (:props-schema (v/describe nested-schema-row)))
+        "the descriptor projection carries the authored form")
+    #?(:clj
+       (is (= authored-schema
+              (:re-frame.freehand/props-schema (meta #'nested-schema-row)))
+           "and the Var metadata carries the identical authored form"))))
+
+(deftest a-compiled-parent-still-derives-the-closing-roster-from-the-literal-map
+  (testing "The fix must not opacify an ordinary literal map. Its top-level
+            closing roster stays derivable — at the descriptor projection, and
+            at the surface a compiled PARENT reads: the analyzer of the host
+            that carries metadata as a FORM hands the reader the (quote …)
+            wrapper the declaration emitted, and the reader must see through
+            it just as it evaluates away everywhere else."
+    (is (props-schema/map-schema? (:props-schema (v/describe nested-schema-row)))
+        "the projection is a readable literal [:map …], not an opaque form")
+    (is (= [:id] (props-schema/declared-keys (:props-schema (v/describe nested-schema-row))))
+        "and its closing roster is [:id]")
+    ;; The published inert wrapper, as a compiled parent's analyzer sees it.
+    (is (props-schema/map-schema? '(quote [:map [:id :int]]))
+        "map-schema? reads through the published inert (quote …) wrapper")
+    (is (= [:id] (props-schema/declared-keys '(quote [:map [:id :int]])))
+        "and so does the roster derivation")
+    (is (= [:id] (props-schema/closing-keys '(quote [:map [:id :int]])))
+        "so a compiled parent closes the child's props on [:id]")
+    #?(:clj
+       (is (= [:id] (env/closed-prop-keys (meta #'nested-schema-row)))
+           "and the roster derived from the real Var is the same"))))
+
+(deftest an-opaque-schema-is-still-opaque-through-the-published-wrapper
+  (testing "The wrapper the readers see through is the declaration's OWN inert
+            quote, not an author's quoted expression: an opaque schema, whose
+            published form is the expression itself, still closes nothing at
+            every surface."
+    (is (not (props-schema/map-schema? '(identity [:map [:id :int]])))
+        "an opaque expression is not a literal map")
+    (is (nil? (props-schema/closing-keys '(identity [:map [:id :int]])))
+        "and so it closes nothing")
+    (is (nil? (props-schema/closing-keys 'registry-schema))
+        "as does a registry reference")))
+
+(deftest non-vacuity-the-schema-carries-genuinely-evaluable-side-effecting-code
+  (testing "Non-vacuity: the entry value is a real (do (swap! …) :int) form —
+            executable code with a side effect — so 'evaluated zero times' is a
+            claim about code that COULD have run, and did run twice before the
+            fix."
+    (let [entry-value (last (second authored-schema))]
+      (is (seq? entry-value)
+          "the entry value is a list form, not a self-evaluating literal")
+      (is (= 'do (first entry-value)))
+      (is (= 'swap! (first (second entry-value)))
+          "whose side effect is a swap! on the eval probe — code that runs iff
+           it is evaluated"))))


### PR DESCRIPTION
Four diagnostic-truth / inertness fixes on the Freehand substrate, one commit each. All land on isolated freehand surfaces (errors/props-schema/pilot-id/render-fn-arity). None touch the fenced `compiler/analyze.cljc` or `node.cljc`.

## rf2-drpa3.141 — error phase truthful for normalization failures
The error `:phase` was hardcoded `:render` at every catch, so a walk/normalization failure (a lazy child realised by the emitter) was mislabelled `:render` and collapsed onto the same fingerprint as a genuine view-body throw. Phase now rides the same failure-local relay as the failing view id: the occurrence seam records the phase it observed (`:render` for a body call, `:normalize` for the walk of what the body returned) and it wins over the boundary's default. The two behavior-throw reproductions (structural + browser) that pinned `:render` for the lazy-child walk now assert `:normalize`; a new host-neutral suite proves one view failing two ways fingerprints apart by phase alone.

## rf2-drpa3.142 — nested props-schema forms inert
(pending)

## rf2-drpa3.146 — distinct pilot identities in error-region DOM IDs
(pending)

## rf2-drpa3.138 — v/render-fn fixed arity honest on the interpreted path
(pending)

## Quality gates
(finalized after all four beads — running foreground, exit codes reported)
