### PR TITLE
fix(freehand): make the :freehand-release entry a runnable, representative app

### DIFF
--- a/implementation/freehand/test/re_frame/freehand/release_app.cljs
+++ b/implementation/freehand/test/re_frame/freehand/release_app.cljs
@@ -27,7 +27,8 @@
   while shadow-cljs — which carries `freehand/test` on `:source-paths` —
   can still compile it into a real production bundle."
   (:require [re-frame.core :as rf]
-            [re-frame.freehand :as v]))
+            [re-frame.freehand :as v]
+            [re-frame.adapter.uix :as uix]))
 
 ;; ---------------------------------------------------------------------------
 ;; The application's handlers. Ordinary re-frame2: the root's preflight plan
@@ -35,11 +36,11 @@
 ;; below reads a value that is already there.
 ;; ---------------------------------------------------------------------------
 
-(rf/reg-event-db ::seed (fn [_ _] {:count 0}))
+(rf/reg-event ::seed (fn [_ _] {:db {:count 0}}))
 
-(rf/reg-event-db ::bump (fn [db _] (update db :count inc)))
+(rf/reg-event ::bump (fn [{:keys [db]} _] {:db (update db :count inc)}))
 
-(rf/reg-sub ::count :-> :count)
+(rf/reg-sub ::count (fn [db _] (:count db)))
 
 ;; ---------------------------------------------------------------------------
 ;; One view, declared twice — the same body in both execution modes, which is
@@ -74,9 +75,21 @@
    [counter-compiled {:label "compiled"}]])
 
 (defn ^:export -main
-  "The build's `:init-fn`. Mounts the root into `#app`, owning the frame it
-  runs over so the bundle carries the whole preflight path."
+  "The build's `:init-fn`. Installs a substrate adapter, then mounts the
+  root into `#app`, owning the frame it runs over so the bundle carries the
+  whole preflight path.
+
+  The reactive substrate needs an adapter before the first frame is made
+  (Spec 006 §Adapter selection at boot): `make-state-container` raises
+  `:rf.error/no-adapter-installed` until `rf/init!` has run. This is an
+  INTERACTIVE mount — a click dispatches an event, app-db changes, and the
+  view re-renders — so the adapter has to bridge reactive change into
+  React's re-render, exactly as a shipped Freehand app would. The UIx
+  adapter is the React-integrated adapter Freehand's own interactive DOM
+  mounts run against; a real consumer ships one like it, so the cost it
+  adds is a cost the bundle should carry rather than hide."
   []
+  (rf/init! uix/adapter)
   (v/mount [app {}]
            (js/document.getElementById "app")
            {:frame {:id             ::frame


### PR DESCRIPTION
## What

The `:freehand-release` build shipped (PR #6787) with an entry —
`implementation/freehand/test/re_frame/freehand/release_app.cljs` — that
threw at namespace load, so the advanced bundle was dead on arrival and
useless as the shipped-cost measurement input it exists to be
(rf2-drpa3.52 is blocked on it).

Verifying the premise surfaced **three** stale/missing-API defects, each
masking the next at load:

1. `reg-event-db` (x2) — a **removed** throwing stub (EP-0018), confirmed
   in `re-frame.events`: calling it raises `:rf.error/reg-event-db-removed`.
   Replaced with the shipped `reg-event` shape returning explicit
   `{:db ...}` effects.
2. `reg-sub ::count :-> :count` — the `:->` sugar does **not** exist in
   this project's `subs.cljc`; it raises `:rf.error/reg-sub-bad-args`.
   Replaced with the layer-1 app-db reader `(fn [db _] (:count db))` used
   throughout the Freehand tests. (Masked behind #1 until that was fixed.)
3. The mount installed **no** substrate adapter, so `make-state-container`
   raised `:rf.error/no-adapter-installed`. `-main` now calls
   `(rf/init! uix/adapter)` before mounting — the React-integrated adapter
   Freehand's own interactive DOM mounts run against, so a click actually
   drives a re-render. (Masked behind #2.)

The build config (`:advanced`, `goog.DEBUG false`), output path
(`out/freehand-release/main.js`), npm entry (`build:freehand-release`),
and the test-only source location are unchanged. No B5 probes added —
this only makes rf2-drpa3.52's input artefact truthful.

## How I verified it RUNS in a browser (not just builds)

Rebuilt the exact advanced `:freehand-release` bundle, then served
`out/freehand-release/` over http and loaded `main.js` against a real
`<div id="app">` in **headless Chromium** (Playwright). Assertions are on
the rendered **DOM**, not console output:

- both counters mount and are visible: interpreted `0`, compiled `0`;
- clicking the interpreted `+` dispatches `::bump`; app-db updates and
  both counters re-render to `1` (one frame, one app-db, one `::count`
  sub, so a single bump advances both);
- **zero** page errors and **zero** console errors during load and click.

Rendered `#app` after the click:
`<main id="freehand-release"> … <output class="count">1</output> … <output class="count">1</output> …`

(An earlier diagnostic pass built the same target with `:pseudo-names`
to un-minify the `:advanced` runtime errors and read each defect's
`ex-info` message; the fix was then confirmed on the real `:advanced`
bundle above.)

## Quality gates

All foreground, to completion, config banner naming this worktree.

| Gate | Result |
| --- | --- |
| `npm run build:freehand-release` | exit 0 — 173 files, 0 warnings |
| browser load of `out/freehand-release/main.js` (headless Chromium, DOM asserts) | PASS — both counters mount at 0, click advances to 1, no page/console error |
| `npm run test:freehand` | exit 0 — 875 tests, 5291 assertions, 0 failures, 0 errors |
| `npm run test:cljs` | exit 0 — 11000 tests, 55416 assertions, 0 failures, 0 errors |
| `clojure -M:test` (implementation/freehand) | exit 0 — 864 tests, 6248 assertions, 0 failures, 0 errors |

rf2-8kas5
