### PR TITLE
fix(freehand): reject variadic & in an interpreted v/render-fn (rf2-drpa3.138)

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/events.cljc
+++ b/implementation/freehand/src/re_frame/freehand/events.cljc
@@ -317,6 +317,25 @@
               (value-tag params) " where the parameter vector belongs.")
          :fix-the-callback-declaration
          {:params (error/diag-value-summary params)}))
+     ;; A `:render-fn` carries a host-independent FIXED-arity contract with
+     ;; `v/slot`: the compiled analyzer already refuses variadic `&`
+     ;; (`analyze-render-fn` → `:rf.ui.compile/bad-render-fn`), so the
+     ;; interpreted authoring path must reach the SAME verdict rather than
+     ;; recording `(count params)`. For `[x & xs]` that count is 3 — an arity
+     ;; the generated function does not accept, and one `check-slot-arity!`
+     ;; would then enforce against a valid one-argument `v/slot` call. The
+     ;; refusal is role-specific: `v/event` / `v/handler` have no slot-arity
+     ;; contract, so their variadic forms are untouched.
+     (when (and (= role :render-fn) (some #{'&} params))
+       (bad-event!
+         where
+         (str where " parameters are a FIXED arg list — variadic & is not "
+              "permitted, because a v/slot invokes a render-fn with a fixed "
+              "number of arguments and the declaration must say exactly how "
+              "many. Name the parameters the slot supplies; a render-fn is not "
+              "a variadic function.")
+         :fix-the-render-fn-parameter-vector
+         {:params (error/diag-value-summary params)}))
      `(callback ~role (fn ~params ~@body) ~(count params))))
 
 ;; ---------------------------------------------------------------------------

--- a/implementation/freehand/test/re_frame/freehand/analyze_reject_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/analyze_reject_cljs_test.cljc
@@ -37,6 +37,17 @@
     (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) ex
       (:rf.ui.compile/error (ex-data ex)))))
 
+(deftest render-fn-fixed-arity
+  ;; rf2-drpa3.138. A v/render-fn is FIXED-arity — v/slot invokes it with a
+  ;; fixed number of arguments — so variadic & is refused at build, the SAME
+  ;; verdict the interpreted authoring path gives (`events-cljs-test`
+  ;; `a-variadic-render-fn-is-refused-on-the-interpreted-path`).
+  (is (= :rf.ui.compile/bad-render-fn
+         (reject-id '[:ul (slot (render-fn [x & xs] [:span x xs]) item)]))
+      "variadic & in a compiled render-fn is refused")
+  (is (nil? (reject-id '[:ul (slot (render-fn [x] [:span x]) item)]))
+      "the fixed-arity control is accepted"))
+
 (deftest heads
   (is (= :rf.ui.compile/dynamic-head
          (reject-id '[(if x :div :span) "y"]))

--- a/implementation/freehand/test/re_frame/freehand/events_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/events_cljs_test.cljc
@@ -376,6 +376,58 @@
         (is (= called (count @calls)) (str form " invoked its body " called " time(s)"))))))
 
 ;; ---------------------------------------------------------------------------
+;; rf2-drpa3.138 — a v/render-fn's carried arity is HONEST
+;; ---------------------------------------------------------------------------
+
+(deftest render-fn-fixed-arity-is-recorded-honestly
+  (testing "rf2-drpa3.138. A v/render-fn carries its declared arity so v/slot
+            enforces one host-independent contract. A FIXED parameter vector
+            records exactly its positional count — the arity the generated
+            function truly accepts — and v/slot honours it. (Host-neutral: the
+            accepted forms build a real Callback in both modes.)"
+    (is (= 0 (events/callback-arity (v/render-fn [] [:span "x"]))) "nullary → 0")
+    (is (= 1 (events/callback-arity (v/render-fn [x] [:span x]))) "unary → 1")
+    (is (= 2 (events/callback-arity (v/render-fn [x y] [:span x y]))) "two params → 2")
+    (is (= 1 (events/callback-arity (v/render-fn [{:keys [a]}] [:span a])))
+        "a destructured parameter is still ONE positional argument → 1")
+    (let [rf (v/render-fn [x] [:span x])]
+      (is (nil? (events/check-slot-arity! rf 1))
+          "a one-argument v/slot call matches a one-parameter render-fn")
+      (is (= :rf.error/ui-tree-malformed
+             (conf/caught-id #(events/check-slot-arity! rf 2)))
+          "and a two-argument call to it is the didactic arity mismatch"))))
+
+#?(:clj
+   (deftest a-variadic-render-fn-is-refused-on-the-interpreted-path
+     (testing "rf2-drpa3.138. `[x & xs]` is NOT a fixed arity: the function
+               accepts one-or-more arguments, so recording `(count params)` = 3
+               is a FALSE arity — a valid one-argument v/slot call would then be
+               refused as `expected 3, actual 1`. The interpreted authoring path
+               refuses variadic & didactically, the SAME verdict the compiled
+               analyzer gives (`:rf.ui.compile/bad-render-fn`, exercised in
+               `analyze-reject-cljs-test`), rather than carrying a contract the
+               function does not honour."
+       ;; `v/render-fn` is a thin macro over `expand-callback` (freehand.cljc),
+       ;; so its rejection IS this expansion refusing to build the callback —
+       ;; tested directly because `macroexpand` wraps a macro's throw and hides
+       ;; the diagnostic id under the wrapper's cause.
+       (is (= :rf.error/view-bad-event
+              (conf/caught-id
+                #(events/expand-callback :render-fn 'v/render-fn '[x & xs] '([:span x xs]))))
+           "a variadic render-fn is refused at authoring, not recorded as arity 3")
+       (is (thrown-with-msg?
+             clojure.lang.ExceptionInfo #"FIXED arg list"
+             (events/expand-callback :render-fn 'v/render-fn '[x & xs] '([:span x xs])))
+           "expand-callback refuses to build the callback, so the false arity-3
+            record cannot silently return")
+       (testing "the refusal is render-fn's alone — v/event and v/handler have
+                 no slot-arity contract, so their variadic forms are untouched"
+         (is (some? (events/expand-callback :handler 'v/handler '[x & xs] '([x xs])))
+             "a variadic v/handler still expands")
+         (is (some? (events/expand-callback :event 'v/event '[x & xs] '(nil)))
+             "and so does a variadic v/event")))))
+
+;; ---------------------------------------------------------------------------
 ;; FH-EVENT-004 — per-site committed slots and stable identity
 ;; ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Makes `v/render-fn`'s carried fixed arity honest on the interpreted authoring path. Isolated to `implementation/freehand/src/re_frame/freehand/events.cljc` (`expand-callback`) plus two test files — no analyzer (`analyze.cljc`/`node.cljc`) change: the compiled path already refuses variadic `&`.

## rf2-drpa3.138 — v/render-fn fixed arity honest on the interpreted path

**Premise verified against main.** The compiled analyzer refuses variadic `&` in a render-fn (`analyze-render-fn` → `:rf.ui.compile/bad-render-fn`, `analyze.cljc:2522`). The interpreted `expand-callback` only checked that params was a vector and stored `(count params)`. For `[x & xs]` that records arity **3** — a count the generated function does not accept (it takes one-or-more args) — so a valid one-argument `(v/slot rf 1)` was refused as `expected 3, actual 1`. Reproduced: with the fix reverted, the new interpreted test REDs, `caught-id` returning `no-throw` (the pre-fix path silently builds the callback with the false arity-3 record).

**Fix.** `expand-callback` now refuses variadic `&` for the `:render-fn` role with a didactic `:rf.error/view-bad-event` — the same verdict the compiled analyzer gives, on the interpreted authoring axis. The refusal is role-specific: `v/event` / `v/handler` have no slot-arity contract and their variadic forms are untouched. Nullary/unary/multi/destructured fixed vectors keep their true declared count and slot behaviour.

**Coverage.** `events-cljs-test`: the interpreted path refuses `[x & xs]` (and cannot silently return to the arity-3 record), fixed vectors record honest arities, `check-slot-arity!` honours them, and variadic `v/event`/`v/handler` still expand. `analyze-reject-cljs-test` (host-neutral): the compiled path refuses the same form — so the two authoring paths give one verdict on both hosts. Non-vacuity: each new interpreted assertion REDs against the reverted source; source restored byte-identical.

## Quality gates
All foreground, run in this worktree (shadow-cljs `config:` banner named this worktree on every build); exit codes captured to worktree-local logs.

| Gate | Command | Result | Exit |
|------|---------|--------|------|
| JVM (events + analyze-reject) | `clojure -M:test -n …events-cljs-test -n …analyze-reject-cljs-test` | 70 tests, 487 assertions, 0 failures | 0 |
| CLJS node (freehand) | `npm run test:freehand` | 892 tests, 5350 assertions, 0 failures, 0 warnings | 0 |
| CLJS node (full) | `npm run test:cljs` | 11017 tests, 55475 assertions, 0 failures | 0 |
| Browser | `npm run test:browser` | 691 tests, 4247 assertions, 0 failures, no pageerror | 0 |
| Conformance index | `python scripts/check_freehand_conformance_index.py` | clean | 0 |
