### PR TITLE
fix(freehand): keep root frame ownership incarnation-exact across remounts and same-id successors

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/root.cljs
+++ b/implementation/freehand/src/re_frame/freehand/root.cljs
@@ -440,12 +440,25 @@
 (defonce ^:private live-roots (atom {}))
 
 ;; The frame ledger:
-;;   frame-id -> {:config-fingerprint … :installed-by root-id :refs #{root-id}}
+;;   frame-id -> {:config-fingerprint … :installed-by root-id
+;;                :installed-value <frame-value> :refs #{root-id}}
 ;;
 ;; `:installed-by` names the root that ENSUREd the frame (a `{:id …}` plan)
 ;; and is nil for a frame this page only SCOPES; `:refs` is every live root
 ;; that referenced it, which is what makes teardown able to destroy an
 ;; installed frame exactly when the last of them goes.
+;;
+;; `:installed-value` is the exact frame VALUE `make-frame` handed back when
+;; the frame was installed — the lifecycle token carrying its
+;; `:rf.frame/incarnation-token`. It is the AUTHORITY teardown destroys with,
+;; not the bare frame-id: an id is address-directed and would destroy whichever
+;; same-id incarnation happens to be live, so a stale installer whose frame was
+;; torn down and re-created under the same id would reach through and kill the
+;; SUCCESSOR. Destroying the exact value instead is incarnation-scoped — a token
+;; whose incarnation is gone no-ops. Present only on an INSTALLED row (nil for a
+;; scoped frame the page never owned), and refreshed to the current value on
+;; every re-install (a same-incarnation surgical update keeps the same token, so
+;; the identity is stable across a config edit).
 (defonce ^:private frame-ledger (atom {}))
 
 (defn ^:no-doc live-root-ids
@@ -456,7 +469,8 @@
 
 (defn ^:no-doc frame-ledger-snapshot
   "The preflight ledger projected for reading: frame-id →
-  `{:config-fingerprint :installed-by :refs}`. A test and diagnostic seam."
+  `{:config-fingerprint :installed-by :installed-value :refs}`. A test and
+  diagnostic seam."
   []
   @frame-ledger)
 
@@ -703,33 +717,44 @@
                                   :installed-by       (:installed-by record)}
                       :arriving  {:config-fingerprint config-fingerprint
                                   :root-id            root-id}}}))
-      (if owned?
-        ;; ENSURE. `make-frame` is idempotent replacement: absent → created
-        ;; and its :initial-events drain; present under the same plan → left
-        ;; exactly as it is. The same-root differing fingerprint is a config
-        ;; edit, so the plan re-runs — durable state survives, because that
-        ;; is what idempotent replacement means.
-        (when (or (nil? (frame/frame frame-id))
-                  (not= (:config-fingerprint record) config-fingerprint))
-          (live-frame/make-frame (assoc config :id frame-id)))
-        ;; SCOPE. A frame this root does not own must already exist — there
-        ;; is no config here to create one from, and scoping a frame that
-        ;; is not there would leave every read below the root silently
-        ;; frameless.
-        (when (nil? (frame/frame frame-id))
-          (error/throw-error!
-            :rf.error/frame-provider-frame-absent where
-            (str where ": :frame " (pr-str frame-id) " names no live frame. A "
-                 "keyword :frame SCOPES a frame something else owns; pass a "
-                 "make-frame opts map carrying :id for the root to own it, or "
-                 "create the frame before mounting.")
-            {:recovery :ensure-or-create-the-frame
-             :extra    {:root-id root-id :frame frame-id}})))
-      (swap! frame-ledger update frame-id
-             (fn [r]
-               {:config-fingerprint (if owned? config-fingerprint (:config-fingerprint r))
-                :installed-by       (if owned? (or (:installed-by r) root-id) (:installed-by r))
-                :refs               (conj (or (:refs r) #{}) root-id)}))
+      (let [installed-value
+            (if owned?
+              ;; ENSURE. `make-frame` is idempotent replacement: absent → created
+              ;; and its :initial-events drain; present under the same plan → left
+              ;; exactly as it is. The same-root differing fingerprint is a config
+              ;; edit, so the plan re-runs — durable state survives, because that
+              ;; is what idempotent replacement means. Whenever the plan RUNS it
+              ;; hands back the exact frame VALUE (the incarnation token) this
+              ;; install produced; on the ratified no-op it returns nil and the
+              ;; ledger keeps the value from the install that stands.
+              (when (or (nil? (frame/frame frame-id))
+                        (not= (:config-fingerprint record) config-fingerprint))
+                (live-frame/make-frame (assoc config :id frame-id)))
+              ;; SCOPE. A frame this root does not own must already exist — there
+              ;; is no config here to create one from, and scoping a frame that
+              ;; is not there would leave every read below the root silently
+              ;; frameless.
+              (do (when (nil? (frame/frame frame-id))
+                    (error/throw-error!
+                      :rf.error/frame-provider-frame-absent where
+                      (str where ": :frame " (pr-str frame-id) " names no live frame. A "
+                           "keyword :frame SCOPES a frame something else owns; pass a "
+                           "make-frame opts map carrying :id for the root to own it, or "
+                           "create the frame before mounting.")
+                      {:recovery :ensure-or-create-the-frame
+                       :extra    {:root-id root-id :frame frame-id}}))
+                  nil))]
+        (swap! frame-ledger update frame-id
+               (fn [r]
+                 {:config-fingerprint (if owned? config-fingerprint (:config-fingerprint r))
+                  :installed-by       (if owned? (or (:installed-by r) root-id) (:installed-by r))
+                  ;; The install authority: the fresh value when the plan just ran,
+                  ;; else the value from the install that stands. A scoped mount
+                  ;; carries nothing of its own and leaves the row's value be.
+                  :installed-value    (if owned?
+                                        (or installed-value (:installed-value r))
+                                        (:installed-value r))
+                  :refs               (conj (or (:refs r) #{}) root-id)})))
       frame-id)))
 
 (defn- frame-ref-held?
@@ -749,16 +774,23 @@
 
   A scoped frame is never destroyed — the root borrowed it. An installed
   frame outlives its root only while a sibling still references it, which
-  is the same rule that makes install idempotent in the first place."
+  is the same rule that makes install idempotent in the first place.
+
+  The teardown is INCARNATION-EXACT. It destroys the frame VALUE the install
+  recorded (`:installed-value`), not the bare frame-id: the value carries the
+  installed incarnation's token, so `destroy-frame!` tears down EXACTLY that
+  incarnation and a stale installer whose frame was already torn down and
+  re-created under the same id no-ops instead of reaching through to kill the
+  successor. A bare id would be address-directed and do precisely that."
   [frame-id root-id]
   (when (some? frame-id)
-    (let [{:keys [installed-by refs]} (get @frame-ledger frame-id)
-          remaining                   (disj (or refs #{}) root-id)]
+    (let [{:keys [installed-by installed-value refs]} (get @frame-ledger frame-id)
+          remaining                                   (disj (or refs #{}) root-id)]
       (if (seq remaining)
         (swap! frame-ledger update frame-id assoc :refs remaining)
         (do (swap! frame-ledger dissoc frame-id)
             (when (and (some? installed-by) (some? (frame/frame frame-id)))
-              (frame/destroy-frame! frame-id))))))
+              (frame/destroy-frame! installed-value))))))
   nil)
 
 ;; ---------------------------------------------------------------------------
@@ -938,6 +970,24 @@
   (swap! live-roots assoc root-id root)
   root)
 
+(defn- frame-ref-held-by-live-root?
+  "True when `root-id`'s CURRENT registry entry is a live root that references
+  `frame-id`.
+
+  The give-back below asks it exactly one question: did a SUCCESSOR take over
+  this root-id and inherit the frame reference while this attempt ran? An
+  `:initial-events` handler can re-enter `mount` under the SAME root-id
+  (`:frame` scoping the just-published frame) and register a fresh Root that is
+  now the legitimate holder of the id — and, because a reference is keyed by
+  root-id, of the very frame reference this attempt is about to give back. The
+  reference is not this attempt's to release once the live root under the id is
+  someone else that names the same frame; yanking it would destroy a frame the
+  successor is rendering against. So a rollback releases the reference only when
+  no live root under the id still names the frame."
+  [frame-id root-id]
+  (when-let [^Root cur (get @live-roots root-id)]
+    (= frame-id (.-frame-id cur))))
+
 (defn- attempt!
   "Run the post-preflight half of a mount, giving back exactly what this
   attempt took if it throws.
@@ -951,6 +1001,15 @@
   never reported, because a failed re-render must leave the incumbent
   rendering exactly as it was.
 
+  `acquired?` is a snapshot taken BEFORE preflight, and preflight runs
+  arbitrary `:initial-events` — so by give-back time the reference it named
+  may belong to a SUCCESSOR that re-entered under this root-id. The reference
+  is keyed by root-id, so this attempt and a same-id successor share the one
+  set member: releasing it on the stale snapshot alone would tear a live
+  successor's frame out from under it. So the give-back releases only when
+  `acquired?` AND no live root under the id still names the frame — the
+  successor keeps what it legitimately holds.
+
   The original failure stays primary: the give-back is best-effort, and
   the throw is re-raised unchanged."
   [frame-id root-id acquired? body]
@@ -960,7 +1019,9 @@
       (catch :default e
         (when-some [react-root @host]
           (try (.unmount react-root) (catch :default _ nil)))
-        (when acquired? (release-frame! frame-id root-id))
+        (when (and acquired?
+                   (not (frame-ref-held-by-live-root? frame-id root-id)))
+          (release-frame! frame-id root-id))
         (throw e)))))
 
 (defn- client-render!
@@ -1031,31 +1092,47 @@
      ;; over cross-root prefix ownership, so a refused re-mount has run no
      ;; plan and given nothing away.
      (preflight! 'v/mount plan root-id)
-     (attempt!
-       frame-id root-id acquired?
-       (fn [keep!]
-         (recheck-claim! 'v/mount dom-node root-id prefix existing)
-         (if (some? existing)
-           ;; The reload path: the same host root, re-rendered. No createRoot,
-           ;; so nothing downstream is reseeded; the descriptor snapshot is
-           ;; refreshed because the mounted view object may be a fresh
-           ;; generation, but the identity it keys on is unchanged. That host
-           ;; root belongs to the INCUMBENT, so it is not handed to `keep!`:
-           ;; a re-render that fails leaves the incumbent rendering.
-           (let [react-root (.-react-root existing)
-                 callbacks  (.-callbacks existing)
-                 root       (->Root desc dom-node react-root prefix frame-id
-                                    (.-hydrated existing) callbacks)]
-             ;; Advance the live host-callback cell to THIS mount's callbacks
-             ;; before re-rendering. React fixed the error delegates at
-             ;; createRoot, so a reload's fresh :on-*-error closures reach
-             ;; React only through the cell those delegates read; keeping the
-             ;; incumbent's cell object is what makes the already-fixed
-             ;; delegates see the new target instead of the stale one.
-             (vreset! callbacks (select-keys opts host-opt-keys))
-             (.render react-root element)
-             (register! root-id root))
-           (client-render! desc dom-node prefix opts frame-id element keep!)))))))
+     (let [result
+           (attempt!
+             frame-id root-id acquired?
+             (fn [keep!]
+               (recheck-claim! 'v/mount dom-node root-id prefix existing)
+               (if (some? existing)
+                 ;; The reload path: the same host root, re-rendered. No createRoot,
+                 ;; so nothing downstream is reseeded; the descriptor snapshot is
+                 ;; refreshed because the mounted view object may be a fresh
+                 ;; generation, but the identity it keys on is unchanged. That host
+                 ;; root belongs to the INCUMBENT, so it is not handed to `keep!`:
+                 ;; a re-render that fails leaves the incumbent rendering.
+                 (let [react-root (.-react-root existing)
+                       callbacks  (.-callbacks existing)
+                       root       (->Root desc dom-node react-root prefix frame-id
+                                          (.-hydrated existing) callbacks)]
+                   ;; Advance the live host-callback cell to THIS mount's callbacks
+                   ;; before re-rendering. React fixed the error delegates at
+                   ;; createRoot, so a reload's fresh :on-*-error closures reach
+                   ;; React only through the cell those delegates read; keeping the
+                   ;; incumbent's cell object is what makes the already-fixed
+                   ;; delegates see the new target instead of the stale one.
+                   (vreset! callbacks (select-keys opts host-opt-keys))
+                   (.render react-root element)
+                   (register! root-id root))
+                 (client-render! desc dom-node prefix opts frame-id element keep!))))]
+       ;; The reload's frame TRANSITION. A re-mount can name a different frame
+       ;; from the one the incumbent held — an owned A to an owned B, or A to no
+       ;; frame at all. Preflight has already taken the new reference; the stale
+       ;; one is still on the ledger, so drop it now the new render has committed
+       ;; and this root is registered against the new frame. Releasing A here is
+       ;; the same last-reference rule as teardown: an owned A no live root still
+       ;; names is destroyed, incarnation-exact; a sibling still holding it keeps
+       ;; it. A same-frame reload (old = new, the ordinary hot reload) moves
+       ;; nothing and leaves its one reference untouched. Runs only past a
+       ;; successful attempt — `attempt!` re-raises a failed re-render, which
+       ;; leaves the incumbent and its frame exactly as they were.
+       (when (and (some? existing)
+                  (not= (.-frame-id existing) frame-id))
+         (release-frame! (.-frame-id existing) root-id))
+       result))))
 
 ;; ---------------------------------------------------------------------------
 ;; hydrate-root

--- a/implementation/freehand/test/re_frame/freehand/root_preflight_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/root_preflight_dom_cljs_test.cljs
@@ -414,3 +414,61 @@
                        (is false (str "idempotent re-mount suite rejected: " e))
                        (.remove node)
                        (done)))))))))
+
+(deftest fh-root-004-a-same-id-re-entrant-successor-keeps-its-frame
+  (testing "Per FH-ROOT-004 (browser): the re-entrancy fence from its hardest
+            side. The outer plan's `:initial-events` re-enter `v/mount` under
+            the OUTER's own derived id, on the outer's container, SCOPING the
+            frame the outer just published — so the inner root is the live
+            root under the id AND the legitimate holder of the frame
+            reference, a reference keyed by id that the outer attempt and this
+            successor now share. The outer refuses (its container is taken),
+            and the give-back must NOT release the shared reference: a stale
+            `acquired?` snapshot taken before preflight would yank it and
+            destroy the frame the inner root is rendering against. So the inner
+            root, its DOM, the frame, and the id -> frame ledger reference all
+            stay live — the assertion that the exact successor's claim stands,
+            not merely that the outer threw."
+    (if-not (browser?)
+      (skip! "the browser job runs the same-id re-entrancy assertions")
+      (async done
+        (reg!)
+        (let [node  (host-node!)
+              re    (:re-entrant-same-id boundary)
+              fid   (:frame-id re)
+              inner (atom nil)]
+          (rf/reg-event :root/mount-inner-same (fn [_ _] {:fx [[:root/mount-inner-same true]]}))
+          (rf/reg-fx :root/mount-inner-same
+                     ;; same derived root-id (same view) + same container,
+                     ;; SCOPING the just-published frame.
+                     (fn [_ _]
+                       (reset! inner (v/mount [views/counter {}] node {:frame fid}))))
+          (-> (act
+                (fn []
+                  (is (= (:error re)
+                         (error-id
+                           (fn []
+                             (v/mount [views/counter {}] node
+                                      {:frame {:id             fid
+                                               :initial-events [[:root/seed (:seeded re)]
+                                                                [:root/mount-inner-same]]}}))))
+                      "the outer mount refuses the container its own plan gave to a
+                       same-id successor")))
+              (.then
+                (fn [_]
+                  (is (= (:frame-live re) (some? (frame/frame fid)))
+                      "the frame the successor scopes is still live — the outer
+                       give-back did not yank the shared reference")
+                  (is (= (:ledger-entries re) (count (root/frame-ledger-snapshot)))
+                      "and its id -> frame ledger reference stands, held by the successor")
+                  (is (contains? (root/live-root-ids)
+                                 (:root-id (root/root-descriptor @inner)))
+                      "the inner successor is the live root under the id")
+                  (is (= (:inner-text re) (text node ".count"))
+                      "and is rendering the scoped frame's seed")
+                  (act #(v/unmount! @inner))))
+              (.then (fn [_] (.remove node) (done))
+                     (fn [e]
+                       (is false (str "same-id re-entrancy suite rejected: " e))
+                       (.remove node)
+                       (done)))))))))

--- a/implementation/freehand/test/re_frame/freehand/root_teardown_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/root_teardown_dom_cljs_test.cljs
@@ -234,3 +234,186 @@
                        (is false (str "stale-handle suite rejected: " e))
                        (.remove node) (.remove fresh)
                        (done)))))))))
+
+;; ===========================================================================
+;; FH-ROOT-005 — ownership is INCARNATION-EXACT: a stale installer never
+;; reaches a same-id successor
+;; ===========================================================================
+
+(deftest fh-root-005-a-stale-installer-does-not-destroy-a-same-id-successor
+  (testing "Per FH-ROOT-005 (browser): a root installs a frame VALUE, not a
+            frame id. The id is address-directed authority — it destroys
+            whichever same-id incarnation is live NOW — so a root that
+            installed one incarnation, watched it torn down, and unmounts
+            while a same-id SUCCESSOR is live must NOT reach through the id
+            and kill the successor. It tears down the exact incarnation it
+            installed, which is already gone, so the successor stands. This is
+            the load-bearing assertion: it asserts the successor's EXACT
+            incarnation token is untouched, not merely that some frame is
+            there — an address-directed teardown would leave the id naming
+            nothing at all."
+    (if-not (browser?)
+      (skip! "the browser job runs the same-id-successor assertions")
+      (async done
+        (reg!)
+        (let [node       (host-node!)
+              succ       (:same-id-successor root-005)
+              fid        (:frame-id succ)
+              succ-token (atom nil)]
+          (-> (act #(v/mount [views/counter {}] node
+                             {:frame {:id             fid
+                                      :initial-events [[:root/seed (:installed succ)]]}}))
+              (.then
+                (fn [installer]
+                  ;; Tear down the installed incarnation and stand a same-id
+                  ;; successor in its place, retaining its EXACT incarnation
+                  ;; token, THEN unmount the now-stale installer.
+                  (rf/destroy-frame! fid)
+                  (rf/make-frame {:id fid :initial-events [[:root/seed (:successor succ)]]})
+                  (reset! succ-token (frame/frame-incarnation-token fid))
+                  (act #(v/unmount! installer))))
+              (.then
+                (fn [_]
+                  (is (= (:frame-live succ) (some? (frame/frame fid)))
+                      "the same-id successor is still live — the stale installer
+                       tore down the incarnation it installed, which was already
+                       gone, and never reached the successor")
+                  (is (identical? @succ-token (frame/frame-incarnation-token fid))
+                      "and it is the SUCCESSOR's exact incarnation, untouched — an
+                       address-directed teardown would have destroyed it, leaving the
+                       id naming nothing")
+                  (is (= (:ledger-after succ) (count (root/frame-ledger-snapshot)))
+                      "the stale installer released its own ledger reference")
+                  (rf/destroy-frame! fid)
+                  (.remove node)
+                  (done))
+                (fn [e]
+                  (is false (str "same-id-successor suite rejected: " e))
+                  (.remove node)
+                  (done)))))))))
+
+;; ===========================================================================
+;; FH-ROOT-005 — a re-mount TRANSITIONS its frame reference; the stale one
+;; leaves, it never leaks
+;; ===========================================================================
+
+(deftest fh-root-005-a-re-mount-transitions-its-frame-reference
+  (testing "Per FH-ROOT-005 (browser): a re-mount can name a different frame
+            from the one the incumbent held — an owned A to an owned B, or A
+            to no frame at all. Preflight takes the new reference; the stale
+            one has to leave with the move, or it leaks a ledger row and an
+            owned frame past the root that abandoned it. A destroyed when the
+            root moves off it, only B's ledger row survives the A->B move, and
+            dropping the frame entirely leaves the ledger empty."
+    (if-not (browser?)
+      (skip! "the browser job runs the frame-transition assertions")
+      (async done
+        (reg!)
+        (let [node1 (host-node!)
+              node2 (host-node!)
+              tr    (:transition root-005)
+              a     (:frame-a tr)
+              b     (:frame-b tr)]
+          ;; Part 1 — A -> B, with `counter` so the moved reference also shows
+          ;; on screen: the first render read A's seed, the re-mount reads B's.
+          (-> (act #(v/mount [views/counter {}] node1
+                             {:frame {:id a :initial-events [[:root/seed (:seeded-a tr)]]}}))
+              (.then
+                (fn [_]
+                  (act #(v/mount [views/counter {}] node1
+                                 {:frame {:id b :initial-events [[:root/seed (:seeded-b tr)]]}}))))
+              (.then
+                (fn [remounted]
+                  (is (= (:a-live-after tr) (some? (frame/frame a)))
+                      "A is destroyed when the root moves off it — its last reference left")
+                  (is (= (:b-live-after tr) (some? (frame/frame b)))
+                      "B is live")
+                  (is (= (:ledger-remount tr) (count (root/frame-ledger-snapshot)))
+                      "only B's ledger row survives the move — A's did not leak")
+                  (is (= b (root/root-frame-id remounted))
+                      "and the root now references B")
+                  (is (= (:b-text tr) (text node1 ".count"))
+                      "the re-render read B's seed, not A's")
+                  (act #(v/unmount! remounted))))
+              (.then
+                (fn [_]
+                  ;; Part 2 — A -> no frame, with `app` (no subscription read),
+                  ;; so a frameless re-mount renders cleanly.
+                  (act #(v/mount [views/app {:label "x"}] node2
+                                 {:frame {:id a :initial-events [[:root/seed (:seeded-a tr)]]}}))))
+              (.then
+                (fn [_]
+                  (act #(v/mount [views/app {:label "x"}] node2 {}))))
+              (.then
+                (fn [dropped]
+                  (is (nil? (root/root-frame-id dropped))
+                      "re-mounting with no :frame drops the frame binding")
+                  (is (= (:a-live-after tr) (some? (frame/frame a)))
+                      "and A — the frame it abandoned — is destroyed, not orphaned")
+                  (is (= (:ledger-drop tr) (count (root/frame-ledger-snapshot)))
+                      "the ledger is empty: the reference left with the move")
+                  (act #(v/unmount! dropped))))
+              (.then
+                (fn [_]
+                  (is (= (:ledger-final tr) (count (root/frame-ledger-snapshot)))
+                      "final teardown leaves nothing behind")
+                  (.remove node1) (.remove node2)
+                  (done))
+                (fn [e]
+                  (is false (str "frame-transition suite rejected: " e))
+                  (.remove node1) (.remove node2)
+                  (done)))))))))
+
+;; ===========================================================================
+;; FH-ROOT-005 — an installed frame survives its installer while a sibling
+;; still references it
+;; ===========================================================================
+
+(deftest fh-root-005-an-installed-frame-outlives-its-installer-until-the-last-ref
+  (testing "Per FH-ROOT-005 (browser): two roots reference one installed
+            frame — the installer owns it, a second root borrows it by
+            SCOPE. The installer leaving is not the last reference, so the
+            frame survives; the borrower leaving is, so it is destroyed. Each
+            root removes only its OWN reference."
+    (if-not (browser?)
+      (skip! "the browser job runs the shared-frame assertions")
+      (async done
+        (reg!)
+        (let [installer-node (host-node!)
+              borrower-node  (host-node!)
+              tr             (:two-refs root-005)
+              fid            (:frame-id tr)
+              installer-root (atom nil)
+              borrower-root  (atom nil)]
+          (-> (act #(v/mount [views/counter {}] installer-node
+                             {:root-id (:installer tr)
+                              :frame   {:id fid :initial-events [[:root/seed (:seeded tr)]]}}))
+              (.then
+                (fn [installer]
+                  (reset! installer-root installer)
+                  (act #(v/mount [views/counter {}] borrower-node
+                                 {:root-id (:borrower tr) :frame fid}))))
+              (.then
+                (fn [borrower]
+                  (reset! borrower-root borrower)
+                  ;; the installer leaves first — not the last reference
+                  (act #(v/unmount! @installer-root))))
+              (.then
+                (fn [_]
+                  (is (= (:live-after-1 tr) (some? (frame/frame fid)))
+                      "the installer's departure is not the last reference — the
+                       borrower still holds one, so the frame survives")
+                  (act #(v/unmount! @borrower-root))))
+              (.then
+                (fn [_]
+                  (is (= (:live-after-2 tr) (some? (frame/frame fid)))
+                      "the borrower's departure is the last legitimate reference, so
+                       the installed frame is destroyed")
+                  (is (empty? (root/frame-ledger-snapshot))
+                      "and the ledger is empty")
+                  (.remove installer-node) (.remove borrower-node)
+                  (done))
+                (fn [e]
+                  (is false (str "shared-frame suite rejected: " e))
+                  (.remove installer-node) (.remove borrower-node)
+                  (done)))))))))

--- a/spec/conformance/freehand/fixtures/fh-root-004.edn
+++ b/spec/conformance/freehand/fixtures/fh-root-004.edn
@@ -122,4 +122,20 @@
                :setup-runs     1
                :live-roots     1
                :ledger-entries 1
-               :frame-live     true}}}
+               :frame-live     true}
+
+  ;; After, fresh root, the SAME id. The plan's `:initial-events` re-enter
+  ;; `v/mount` under the OUTER's own derived id, on the outer's container,
+  ;; SCOPING the frame the outer just published. That inner root becomes the
+  ;; live root under the id and the legitimate holder of the frame reference
+  ;; — a reference keyed by id, so the outer attempt and this successor share
+  ;; the one set member. The outer refuses (its container is taken), and the
+  ;; give-back must NOT release the shared reference: yanking it would destroy
+  ;; the frame the inner root is rendering against. So the inner root, its
+  ;; DOM, the frame, and the id -> frame ledger reference all stay live.
+  :re-entrant-same-id {:frame-id       :fh.root/boundary-same-id
+                       :seeded         5
+                       :inner-text     "5"
+                       :error          :rf.error/root-container-in-use
+                       :frame-live     true
+                       :ledger-entries 1}}}

--- a/spec/conformance/freehand/fixtures/fh-root-005.edn
+++ b/spec/conformance/freehand/fixtures/fh-root-005.edn
@@ -43,4 +43,58 @@
 
  ;; Unmounting a stale handle is a no-op, not a teardown of the successor.
  :stale-handle {:successor-still-live true
-                :successor-text       "3"}}
+                :successor-text       "3"}
+
+ ;; ---------------------------------------------------------------------
+ ;; Ownership is INCARNATION-EXACT, and the reference is the ROOT's own.
+ ;;
+ ;; A root installs a frame VALUE, not a frame id. The id is address-
+ ;; directed authority — it destroys whichever same-id incarnation is live
+ ;; NOW — so a root that installed one incarnation, watched it torn down,
+ ;; and unmounts while a same-id SUCCESSOR is live must not reach through
+ ;; the id and kill the successor. It tears down the exact incarnation it
+ ;; installed, which is already gone, so the successor stands.
+ ;;
+ ;; A re-mount can also move the root from one owned frame to another, or
+ ;; to none. Preflight takes the new reference; the stale one has to leave
+ ;; too, or it leaks a ledger row and an owned frame past the root that
+ ;; abandoned it.
+ ;;
+ ;; And an installed frame outlives its installer for as long as a sibling
+ ;; still references it: the last legitimate reference is what destroys it,
+ ;; not the first departure.
+ ;; ---------------------------------------------------------------------
+
+ ;; A root installs one incarnation; it is torn down and a same-id
+ ;; successor is created; the stale installer unmounts. The successor is
+ ;; the live frame under that id, and the stale installer's own ledger row
+ ;; is gone.
+ :same-id-successor {:frame-id     :fh.root/successor
+                     :installed    3
+                     :successor    8
+                     :frame-live   true
+                     :ledger-after 0}
+
+ ;; A re-mount that moves the root from owned frame A to owned frame B, and
+ ;; then off frames entirely. A is destroyed when the root leaves it; only
+ ;; B's ledger row survives the move; dropping the frame leaves nothing.
+ :transition {:frame-a        :fh.root/transition-a
+              :frame-b        :fh.root/transition-b
+              :seeded-a       4
+              :seeded-b       6
+              :b-text         "6"
+              :a-live-after   false
+              :b-live-after   true
+              :ledger-remount 1
+              :ledger-drop    0
+              :ledger-final   0}
+
+ ;; Two roots reference one installed frame — the installer owns it, a
+ ;; second root borrows it. The installer leaving is not the last
+ ;; reference, so the frame survives; the borrower leaving is, so it goes.
+ :two-refs {:frame-id     :fh.root/shared
+            :installer    :fh.root/installer-root
+            :borrower     :fh.root/borrower-root
+            :seeded       9
+            :live-after-1 true
+            :live-after-2 false}}


### PR DESCRIPTION
Closes rf2-drpa3.110. Records the rf2-drpa3.172 audit finding (below).

## What changed (rf2-drpa3.110)

The root frame ledger recorded only `frame-id` / `installed-by` / `refs`, and
teardown destroyed by **bare frame-id**. In the core frame contract an id is
address-directed authority — it destroys whichever same-id incarnation is live
*now* — so a stale installer whose frame was torn down and re-created under the
same id reached through and destroyed the **successor**. The same id-only ledger
also lost references on a re-mount that moved frames, and the post-preflight
give-back released on a stale `acquired?` snapshot.

Three coupled corrections, all in the **one existing ledger** — no parallel
registry, no lease framework, no public API (the core frame value already *is*
the token):

1. **Incarnation-exact teardown.** The ledger retains the exact frame VALUE
   `make-frame` handed back (`:installed-value`, carrying its
   `:rf.frame/incarnation-token`). `release-frame!` destroys *that value*, so
   `destroy-frame!` tears down exactly the installed incarnation and a stale
   token whose incarnation is gone **no-ops** instead of killing a successor.
   Verified against current main (root.cljs @ `c25078470c`): the bare-id path
   `(frame/destroy-frame! frame-id)` resolves through frame.cljc:3871's
   address-directed arm `(frame-incarnation-token id)` = the *currently-live*
   token → destroys the successor.

2. **Re-mount frame transition.** A re-mount naming a different frame (owned A →
   owned B, or A → no frame) now transitions the root's reference: preflight
   takes the new one, and the stale one is released once the new render commits
   — an owned A no live root still names is destroyed, incarnation-exact.
   Previously A's ledger row and frame leaked past the root that abandoned them.

3. **Give-back fence for a same-id successor.** `attempt!` no longer releases on
   the pre-preflight `acquired?` snapshot alone. `:initial-events` can re-enter
   `mount` under the **same** root-id (scoping the just-published frame) and
   register a successor that now holds the id → frame reference — a reference
   keyed by root-id, so the failed attempt and the successor share the one set
   member. The give-back releases only when no live root under the id still
   names the frame (`frame-ref-held-by-live-root?`), so the successor keeps the
   frame it is rendering against.

Tests are browser DOM laws extending FH-ROOT-004 / FH-ROOT-005. Each **asserts
whose claim stands**, never merely that nothing crashed: the same-id-successor
test asserts the successor's *exact incarnation token* is identical after the
stale unmount (an address-directed teardown would leave the id naming nothing);
the transition test asserts A destroyed / only B's row survives / the root now
references B; the re-entrant test asserts the successor Root, its DOM, the frame,
and the id → frame ledger reference all stay live. Non-vacuity was proven by
reverting only `root.cljs` to main and re-running the browser gate: the three
defect-catchers red (8 assertions), naming each test.

## Quality gates

All foreground, run to completion in this worktree (shadow-cljs `config:` banner
confirmed naming `root-ownership-110`; browser lane reds on any uncaught
pageerror):

| Gate | Result | Exit |
|---|---|---|
| `clojure -M:test` (freehand JVM) | 865 tests / 6259 assertions, 0 failures, 0 errors | 0 |
| `npm run test:freehand` (node) | 881 tests / 5307 assertions, 0 failures, 0 errors | 0 |
| `npm run test:cljs` (node core) | 11006 tests / 55432 assertions, 0 failures, 0 errors | 0 |
| `npm run test:browser` (Chromium) | 693 tests / 4252 assertions, 0 failures, 0 errors, no pageerror | 0 |
| `python scripts/check_freehand_conformance_index.py` | valid | 0 |
| Non-vacuity (root.cljs reverted to main, browser lane) | 3 defect-catchers red, 8 failures, each named | 1 (expected) |

Known flake `pilot_virtual_table_dom_cljs_test` (scroll-top nil / 25 rows,
rf2-eq2vx) did not appear.

## rf2-drpa3.172 audit — does re-frame.freehand.root's simpler model cover the donor windows?

Method: read `re-frame.freehand.root` and `re-frame.ui.client` (the donor),
constructed each failure scenario, and classified each unabsorbed donor
mechanism as **correct-absence** (Freehand's architecture makes the window
impossible) or **real-gap** (Freehand can hit it and lacks the guard).

**The governing architectural fact.** The donor is the **compiled** substrate:
its ViewCells own reactive observation state registered in a per-incarnation
ownership registry, its render lifecycle carries a layout-effect commit
*reporter* that finalizes a preflight *receipt*, and it hardens against
react-dom 19.2's refusal to unmount synchronously from inside render/commit.
Freehand is **interpreted**: it has no preflight receipt object and no
per-incarnation cell-ownership registry, and it delegates cell teardown to
React's own structural fact — *"the host runs no effect for a Fiber it has
unmounted"* (cell.cljc). Its fencing already rides the **core** frame-incarnation
token (`frame/frame-incarnation-live?` in cell.cljc), the same mechanism .110
now extends to the root's teardown authority.

Per mechanism:

- **Incarnation fences (0/102) — SPLIT.** The donor's `:root-incarnation` token
  reaps exactly the compiled ViewCells a root *generation* owns. **Correct
  absence** of that form: a Freehand re-mount **reuses** its React root (the
  reload path), so there is no old-vs-new incarnation of cells to reap — React
  reconciles, and layout cleanups release deps (pinned by FH-ROOT-005). BUT the
  **frame**-incarnation analogue — a stale root reaching a same-id successor
  frame — **can occur and was a real gap**. That is exactly rf2-drpa3.110, fixed
  here with the same core incarnation-token discipline Freehand already uses at
  the cell layer. So the "102 vs 0" count is misleading: the donor's is
  root-cell reaping (correctly absent); Freehand's real need is frame-incarnation
  teardown authority (now present).

- **Consumed-container quarantine (0/49) — CORRECT ABSENCE (interpreted model),
  one narrow theoretical residue (below).** The donor fail-closes a node whose
  host `.unmount` **threw** because react-dom 19.2 can consume the handle and
  leave queued DOM work unobservable. Freehand's `attempt!` swallows a throwing
  `.unmount` on a failed *first* mount, but a Freehand descendant throw is caught
  by its own error boundary (`:re-frame.freehand/error-boundary`) rather than
  propagating to `.render`, so the failed-first-mount-via-descendant-throw path
  that the donor's quarantine chiefly guards does not reach `attempt!`'s catch.
  No poisoned-node reuse window is reachable through the ordinary public path.

- **`:tearing-down` state (0/47) — CORRECT ABSENCE for the reachable paths; one
  candidate residue.** The donor marks the claim `:tearing-down` **before**
  `.unmount` and releases at a settlement boundary, to fence a reentrant mount
  across react-dom's **deferred** teardown window. Freehand's `unmount!` releases
  the registry claim **before** `.unmount`. For the window to bite, a React
  layout cleanup running *inside* `.unmount` would have to synchronously
  `v/mount` onto the very container being torn down — pathological app code a
  cleanup never writes. Under the trust-the-programmer / no-gold-plating posture
  this window does not deserve a guard; I did **not** resurrect the state
  machine. (Candidate for the mayor, not filed blind: see below.)

- **release-root (0/5) — CORRECT ABSENCE.** The donor's identity-guarded
  unregister-at-settlement exists to release only at the deferred boundary.
  Freehand's `unmount!` already identity-guards
  (`(identical? root (get @live-roots root-id))`) and the FH-ROOT-005
  stale-handle law proves a superseded handle is a no-op, not a successor
  teardown. The synchronous release is sufficient because Freehand does not defer.

- **phase-flip (0/2) — MISCOUNT, not a gap.** Freehand **has** the phase flip;
  it lives in `re-frame.freehand.phase/with-phase-flip` and is installed by
  root.cljs's `adopt!` for hydration. Zero occurrences *in root.cljs* only
  reflects factoring, not absence.

- **Failed-first-mount settlement transaction (seat/settle/abort pending
  render-attempt) (0/x) — CORRECT ABSENCE.** This settles a preflight **receipt**
  that never committed (host error / abandonment / supersession). Freehand has no
  receipt object — its preflight is a synchronous frame ENSURE + `:initial-events`
  drain with no deferred evidence to finalize — so there is nothing to leave
  provisional. `attempt!` gives back exactly the host root and the frame reference
  (now fenced by this PR), which is the whole of what a Freehand first-mount can
  leave outstanding. The `004C carries stronger settlement language than
  root.cljs implements` note in the bead is, on this reading, the donor's
  compiled-receipt lifecycle, not an interpreted obligation.

**Verdict.** The donor machinery is overwhelmingly compiled-substrate-specific
(root-generation cell reaping + preflight-receipt settlement) and is **correctly
absent** from Freehand's interpreted model, which leans on React's structural
lifecycle and the core frame-incarnation token. The **one** window that provably
occurs — a stale root's teardown reaching a same-id **frame** successor, plus its
re-mount-leak and re-entrant-give-back siblings — is the real gap, and rf2-drpa3.110
(this PR) closes it. No donor machinery was ported to guard a window that cannot
occur.

**One candidate for the mayor (NOT filed — surfaced per the bead's "list, don't
file blind").** Freehand's `unmount!` releases the registry claim *before*
`(.unmount react-root)`. If react-dom ever defers that `.unmount` and a layout
cleanup synchronously re-mounts onto the same container during the deferred
window, the claim would already read free. I assess this as **not reachable
through non-pathological app code** and therefore **not worth a guard** under the
current posture — recording it only so the decision is on the record rather than
silent. If the mayor disagrees, the minimal honest guard is to release the claim
*after* `.unmount` returns (mirroring the donor's settlement ordering) without
importing the `:tearing-down` state machine.
