### PR TITLE
fix(freehand): compiled browser emitter — refuse runtime Hiccup, eager slot args, runtime select-multiple verdict

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/compiled_react.cljs
+++ b/implementation/freehand/src/re_frame/freehand/compiled_react.cljs
@@ -126,8 +126,12 @@
   "Write ONE entry of a forwarded author-space attribute map.
   `sugar` composes with a forwarded `:class` — `put-attr!`'s own `:class`
   arm composes with nothing, which is right for a per-attribute write and
-  wrong here, where the element's `.class` sugar has to survive the map."
-  [o tag sugar site-id controlled? k raw]
+  wrong here, where the element's `.class` sugar has to survive the map.
+
+  `multiple?` is the WHOLE forwarded map's multiple-select verdict, settled
+  once by the caller — the one fact that decides what an EMPTY `<select>`
+  value is."
+  [o tag sugar site-id controlled? multiple? k raw]
   (let [k (conv/attr-key k)]
     (cond
       (conv/handler-key? k)
@@ -143,7 +147,7 @@
           (gobj/set o slot proxy)))
 
       (= :class k) (fr/put-class! o tag sugar raw)
-      :else        (fr/put-attr! o tag k raw)))
+      :else        (fr/put-attr! o tag k raw multiple?)))
   o)
 
 (defn ^:no-doc spread!
@@ -158,8 +162,15 @@
   arrived, exactly as the interpreted walk decides it."
   [o tag sugar site-id m]
   (let [attrs       (top-layer/without m)
-        controlled? (controlled/controlled-props? (keys attrs))]
-    (reduce-kv (fn [_ k raw] (forward-entry! o tag sugar site-id controlled? k raw) nil)
+        controlled? (controlled/controlled-props? (keys attrs))
+        ;; The multiple-select verdict is a property of the WHOLE forwarded
+        ;; map, settled over it once — the interpreted walk settles it over
+        ;; the same merged map before writing any attribute. Without it a
+        ;; forwarded `<select multiple>`'s explicitly nil `value` writes the
+        ;; scalar empty string React reports as a shape error (rf2-sf9n5).
+        multiple?   (controlled/multiple-select? tag attrs nil)]
+    (reduce-kv (fn [_ k raw]
+                 (forward-entry! o tag sugar site-id controlled? multiple? k raw) nil)
                nil attrs)
     ;; The DOM top layer's desired-state pair is Freehand vocabulary, not an
     ;; attribute, so a forwarded one becomes the commit-time host call here

--- a/implementation/freehand/src/re_frame/freehand/compiler/emit_jvm.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/emit_jvm.cljc
@@ -257,11 +257,19 @@
     (into [] (for [~@(:seq-exprs node)] ~(emit-node e (:body node))))))
 
 (defn- emit-slot
-  "A `v/slot` invocation: gate the render-fn value (nil renders nothing; a
+  "A `v/slot` invocation: evaluate the slot value and every argument ONCE
+  in source order, then gate the render-fn value (nil renders nothing; a
   bare fn — anything that is not a render-fn — is the didactic
-  `invalid-slot!`), then invoke the carrier's compiled body with the runtime
-  args — a fixed-arity call whose args evaluate only when the slot renders.
-  The rendered output is an ordinary tree child.
+  `invalid-slot!`) and invoke the carrier's compiled body with the
+  already-evaluated args — a fixed-arity call. The rendered output is an
+  ordinary tree child.
+
+  The arguments are bound BEFORE the gate, not inlined inside it, so each
+  runs exactly once whether or not the slot renders — the eager
+  function-call semantics an interpreted `v/slot` has, preserved across
+  promotion (rf2-drpa3.133). Gating the args away for a nil slot dropped a
+  `v/sub` the analyzer attributes to the enclosing view, silently changing
+  dependency capture between modes.
 
   The gate is the COMPILED half of the mode asymmetry the interpreted
   `v/slot` widens: an interpreted body may pass an ordinary pure function as
@@ -273,11 +281,14 @@
                   `(events/callback :render-fn
                                     (fn [~@params] ~(emit-node e body))
                                     ~(count params))
-                  (:slot-value node))]
-    `(let [~rf ~slotval]
+                  (:slot-value node))
+        args    (:args node)
+        argsyms (mapv (fn [_] (gensym "rf-ui-arg")) args)]
+    `(let [~rf ~slotval
+           ~@(interleave argsyms args)]
        (when (events/slot-ready? ~rf)
-         (events/check-slot-arity! ~rf ~(count (:args node)))
-         ((events/callback-fn ~rf) ~@(:args node))))))
+         (events/check-slot-arity! ~rf ~(count args))
+         ((events/callback-fn ~rf) ~@argsyms)))))
 
 (defn emit-node
   "AST node -> the form that builds it (nil for a statically-absent child).

--- a/implementation/freehand/src/re_frame/freehand/compiler/emit_react.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/emit_react.cljc
@@ -318,14 +318,13 @@
         top         (cond-> top (seq top) (into (top-layer-context props)))
         attrs       (remove (fn [{:keys [k]}] (contains? top-layer-keys k)) all-attrs)
         controlled? (controlled/controlled-props? (map :k attrs))
-        ;; The multiple-select verdict, from the LITERAL `multiple` — the
-        ;; only spelling a build-time constant can be read from. It decides
-        ;; one thing: what an EMPTY `<select>` value is. Acceptance of a
-        ;; collection value deliberately does NOT turn on it (see
-        ;; `controlled/select-value-slot?`), so a `multiple` this tier
-        ;; cannot see can cost React's own shape warning on an explicitly
-        ;; nil value and can never refuse a declaration the interpreted
-        ;; walk renders.
+        ;; The multiple-select verdict for a LITERAL `multiple`, settled at
+        ;; build time as the constant it is. It decides one thing: what an
+        ;; EMPTY `<select>` value is. Acceptance of a collection value
+        ;; deliberately does NOT turn on it (see
+        ;; `controlled/select-value-slot?`). A RUNTIME `multiple` — a value
+        ;; this constant cannot read — is settled at render time instead,
+        ;; by `dyn-multi` below; this arm is the literal case only.
         multi?      (controlled/multiple-select?
                       tag
                       (keep (fn [{:keys [k value] :as attr}]
@@ -343,13 +342,31 @@
                       (and sty (:static? sty) (static-style-obj sty))
                       (conj ["style" (static-style-obj sty)]))
         dynamics    (remove build-time-attr? attrs)
+        ;; A `<select>`'s `multiple` may be a value only the render knows.
+        ;; When it is, the multiple-select verdict — the one fact that
+        ;; decides what an EMPTY value is — is itself a RUNTIME fact, so it
+        ;; is bound once beside the props object and shared by the `multiple`
+        ;; write and every nil-value normalization, the way the structural
+        ;; builder settles it over both attribute sources. A fully literal
+        ;; `multiple` keeps the build-time constant `multi?` above; a runtime
+        ;; `multiple` this tier could not see used to settle it `false` and
+        ;; mis-shape an explicitly nil value (rf2-sf9n5).
+        dyn-multi   (when (= :select tag)
+                      (first (filter #(= (controlled/prop-slot (:k %))
+                                         (controlled/prop-slot :multiple))
+                                     dynamics)))
+        mval        (when dyn-multi (gensym "rf-fh-multi-val"))
+        mverdict    (when dyn-multi (gensym "rf-fh-multi?"))
+        multi-arg   (if dyn-multi mverdict multi?)
         o           (gensym "rf-fh-props")
         writes      (cond-> []
                       (and cls (not (:static? cls))) (conj (dynamic-class-form o tag cls))
                       (and sty (not (:static? sty))) (conj (style-write o tag sty))
-                      true (into (map (fn [{:keys [k value]}]
+                      true (into (map (fn [{:keys [k value] :as a}]
                                         `(re-frame.freehand.compiled-react/attr!
-                                          ~o ~tag ~k ~value ~multi?))
+                                          ~o ~tag ~k
+                                          ~(if (identical? a dyn-multi) mval value)
+                                          ~multi-arg))
                                       dynamics))
                       true (into (handler-writes o tag controlled? (:events props)))
                       ;; Both forwards write LAST, and for the same reason: a
@@ -366,8 +383,13 @@
                                         ~o ~tag ~top))
                       (:present? key-info)
                       (conj `(cljs.core/unchecked-set ~o "key" ~(:expr key-info))))
+        multi-binds (when dyn-multi
+                      [mval     (:value dyn-multi)
+                       mverdict `(re-frame.freehand.controlled/multiple-select?
+                                  ~tag [[~(:k dyn-multi) ~mval]] nil)])
         props-form  (if (seq writes)
-                      `(let [~o (cljs.core/js-obj ~@(mapcat identity literals))]
+                      `(let [~o (cljs.core/js-obj ~@(mapcat identity literals))
+                             ~@multi-binds]
                          ~@writes
                          ~o)
                       `(cljs.core/js-obj ~@(mapcat identity literals)))]

--- a/implementation/freehand/src/re_frame/freehand/compiler/emit_react.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/emit_react.cljc
@@ -485,9 +485,10 @@
 (defn- emit-slot
   "A `v/slot` invocation — the BROWSER half of the lowering
   [[re-frame.freehand.compiler.emit-jvm/emit-slot]] states structurally,
-  and the same three runtime calls in the same order: the carrier is
-  gated (nil renders nothing), its declared arity is checked against the
-  argument count, and its body is invoked with the runtime arguments.
+  and the same runtime calls in the same order: the slot value and every
+  argument evaluate ONCE, in source order; then the carrier is gated (nil
+  renders nothing), its declared arity is checked against the argument
+  count, and its body is invoked with the already-evaluated arguments.
 
   Only the render-fn's BODY differs, and it differs the way every other
   arm does: it is emitted through this emitter, so an inline slot builds
@@ -497,19 +498,26 @@
   slot gate and the boundary's opaque prop record are one implementation
   across both modes and both hosts (rf2-ckviw).
 
-  The arguments are inlined at the CALL rather than collected into a
-  sequence, so a slot that does not render evaluates none of them."
+  The arguments are bound in the `let` BEFORE the gate rather than inlined
+  at the call, so each evaluates exactly once whether or not the slot
+  renders — the eager function-call semantics an interpreted `v/slot` has,
+  preserved across promotion (rf2-drpa3.133). Inlining them inside the gate
+  made an absent slot skip a `v/sub` the analyzer attributes to the
+  enclosing view, silently changing dependency capture between modes."
   [e st node]
   (let [rf      (gensym "rf-fh-slot")
         slotval (if-let [{:keys [params body]} (:render-fn node)]
                   `(events/callback :render-fn
                                     (fn [~@params] ~(emit-node e st body))
                                     ~(count params))
-                  (:slot-value node))]
-    `(let [~rf ~slotval]
+                  (:slot-value node))
+        args    (:args node)
+        argsyms (mapv (fn [_] (gensym "rf-fh-arg")) args)]
+    `(let [~rf ~slotval
+           ~@(interleave argsyms args)]
        (when (events/slot-ready? ~rf)
-         (events/check-slot-arity! ~rf ~(count (:args node)))
-         ((events/callback-fn ~rf) ~@(:args node))))))
+         (events/check-slot-arity! ~rf ~(count args))
+         ((events/callback-fn ~rf) ~@argsyms)))))
 
 (defn- emit-presence
   [e st node]

--- a/implementation/freehand/src/re_frame/freehand/node.cljc
+++ b/implementation/freehand/src/re_frame/freehand/node.cljc
@@ -244,10 +244,16 @@
     (string? (peek acc))  (conj (pop acc) (str (peek acc) s))
     :else                 (conj acc s)))
 
-(defn- opaque-child!
+(defn ^:no-doc opaque-child!
   "The rejection every child value that is not content lands on. `vector?`
   gets D010's ladder by name: a runtime value is not a template, and the
-  compiled tier has no interpreter to hand it to."
+  compiled tier has no interpreter to hand it to.
+
+  Public so the compiled tier's BROWSER child seam
+  ([[re-frame.freehand.react/child-elements]]) refuses a runtime markup
+  value with the SAME sentence the structural tier raises — one D010
+  refusal, reached from both hosts, rather than a second one that could
+  drift (rf2-drpa3.130)."
   [where form]
   (malformed!
     where

--- a/implementation/freehand/src/re_frame/freehand/react.cljs
+++ b/implementation/freehand/src/re_frame/freehand/react.cljs
@@ -773,37 +773,56 @@
                         "shapes land with the host-lifecycle slice.")
                    {:value (shape head)})))))
 
-(defn- collect [cand acc form]
-  (cond
-    (nil? form)     acc
-    (boolean? form) acc
-    (string? form)  (conj acc form)
-    (number? form)  (conj acc (conv/js-number-str form))
-    (conv/child-run? form) (reduce (fn [a f] (collect cand a f)) acc form)
-    ;; `^{:key …}` metadata is refused by the SHARED sentence the structural
-    ;; walk raises, not by a second one here — one source has one answer,
-    ;; and a key that reached React through a spelling the JVM tree drops
-    ;; would be exactly the divergence this walk exists to not have.
-    (vector? form)  (do (node/refuse-metadata-key!
-                          're-frame.freehand.react/element form)
-                        (conj acc (node cand form)))
-    (seq? form)     (reduce (fn [a f] (collect cand a f)) acc form)
-    ;; A React element in a child position is markup a COMPILED body
-    ;; already lowered — the shape a compiled parent forwards to an
-    ;; interpreted child. It is finished work, so it passes through
-    ;; untouched: this walk has nothing left to decide about it, and
-    ;; entering it is not possible in any case.
-    (react/isValidElement form) (conj acc form)
-    :else
-    (malformed!
-      (str "A view body produced a " (type-name form) " where a child was expected. "
-           "A child is markup (a vector), text (a string or a number), a seq of "
-           "children, or nothing (nil / false).")
-      {:value (shape form)})))
+(defn- collect
+  "Fold one child value into the children accumulator.
+
+  `walk?` is the LANGUAGE BOUNDARY. The interpreted front end passes true:
+  a vector is markup, and it is walked into a React element. The compiled
+  tier's child seam ([[child-elements]]) passes false: a compiled body
+  resolved its structure at build time and produces no markup, so a runtime
+  vector is a value with nowhere to go — D010 gives the compiled tier no
+  dynamic-markup valve and no interpreter to walk one — and it is refused by
+  the SAME [[re-frame.freehand.node/opaque-child!]] sentence the structural
+  children canonicalizer raises, never interpreted here. That is what keeps
+  a compiled view from acquiring an interpreter through its browser
+  lowering (rf2-drpa3.130)."
+  ([cand acc form] (collect cand true acc form))
+  ([cand walk? acc form]
+   (cond
+     (nil? form)     acc
+     (boolean? form) acc
+     (string? form)  (conj acc form)
+     (number? form)  (conj acc (conv/js-number-str form))
+     (conv/child-run? form) (reduce (fn [a f] (collect cand walk? a f)) acc form)
+     (vector? form)
+     (if walk?
+       ;; `^{:key …}` metadata is refused by the SHARED sentence the structural
+       ;; walk raises, not by a second one here — one source has one answer,
+       ;; and a key that reached React through a spelling the JVM tree drops
+       ;; would be exactly the divergence this walk exists to not have.
+       (do (node/refuse-metadata-key! 're-frame.freehand.react/element form)
+           (conj acc (node cand form)))
+       (node/opaque-child! 're-frame.freehand/render form))
+     (seq? form)     (reduce (fn [a f] (collect cand walk? a f)) acc form)
+     ;; A React element in a child position is markup a COMPILED body
+     ;; already lowered — the shape a compiled parent forwards to an
+     ;; interpreted child. It is finished work, so it passes through
+     ;; untouched: this walk has nothing left to decide about it, and
+     ;; entering it is not possible in any case.
+     (react/isValidElement form) (conj acc form)
+     :else
+     (if walk?
+       (malformed!
+         (str "A view body produced a " (type-name form) " where a child was expected. "
+              "A child is markup (a vector), text (a string or a number), a seq of "
+              "children, or nothing (nil / false).")
+         {:value (shape form)})
+       (node/opaque-child! 're-frame.freehand/render form)))))
 
 (defn- children
-  [cand forms]
-  (reduce (fn [acc f] (collect cand acc f)) [] forms))
+  ([cand forms] (children cand true forms))
+  ([cand walk? forms]
+   (reduce (fn [acc f] (collect cand walk? acc f)) [] forms)))
 
 (defn- emit
   [cand form]
@@ -840,20 +859,20 @@
 ;; step.
 
 (defn ^:no-doc child-elements
-  "Classify ONE runtime value in a child position, and answer the React
-  children it denotes, in order.
+  "Classify ONE runtime value in a COMPILED body's child position, and
+  answer the React children it denotes, in order.
 
-  The candidate is this render's AMBIENT one, because a compiled body is
-  straight-line code with no walk between the shell and the value to
-  thread one through. Inside a compiled view that kept its ViewCell the
-  ambient candidate is that view's, so declarative intent in a forwarded
-  subtree is recorded on the same commit an interpreted body would have
-  recorded it on. Under a view whose ViewCell its own analysis ELIDED
-  there is no candidate — and no commit for such intent to belong to,
-  which is the sentence `react-props` already writes for markup with no
-  boundary above it."
+  A compiled body resolved its markup at build time, so a runtime value
+  here is text, a number, nothing, an already-lowered React child, or a
+  run of those — never a template. A runtime VECTOR is refused by name:
+  D010 gives the compiled tier no dynamic-markup valve and no interpreter
+  to walk one, so a Hiccup value in a compiled child position raises the
+  same [[re-frame.freehand.node/opaque-child!]] refusal the structural
+  children canonicalizer raises, rather than being silently interpreted
+  here (rf2-drpa3.130). No candidate is threaded, because with no walk
+  there is nothing to open or record against."
   [form]
-  (children (cell/current-candidate) [form]))
+  (children nil false [form]))
 
 (defn ^:no-doc mount-view
   "Cross a declared boundary from a compiled body. `args` is the call's

--- a/implementation/freehand/test/re_frame/freehand/compiled_child_refusal_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/compiled_child_refusal_cljs_test.cljs
@@ -1,0 +1,93 @@
+(ns re-frame.freehand.compiled-child-refusal-cljs-test
+  "A compiled view's BROWSER lowering may not interpret a runtime markup
+  value — the behavioural half of D010, in React.
+
+  The compiled React emitter lowers every dynamic child expression to
+  `re-frame.freehand.compiled-react/child`, which classifies one runtime
+  value through `re-frame.freehand.react/child-elements`. D010 gives the
+  compiled tier no dynamic-markup valve and no automatic fallback: a value
+  that turns out to be a Hiccup vector has nowhere to go, because a
+  compiled body carries no interpreter to walk one. So the seam REFUSES it
+  by name — the same `re-frame.freehand.node/opaque-child!` refusal the
+  structural children canonicalizer raises — rather than silently
+  interpreting it inside compiled markup.
+
+  The structural half of this claim is
+  `compiled-grammar-jvm-test/compiled-markup-refuses-a-runtime-markup-value`,
+  over `node/children`. That test stayed green while the React lowering
+  gained the forbidden reachability, because it never exercised the browser
+  seam; this file closes that gap on the seam a mounted compiled view
+  actually calls for a dynamic child (rf2-drpa3.130).
+
+  Normative owner:
+  [`spec/004D-Freehand-Compiled-Grammar.md`](../../../../../spec/004D-Freehand-Compiled-Grammar.md)
+  §No interpreted fallback inside compiled markup, and
+  [D010](../../../../../docs/design/freehand/decisions/D010-compiled-dynamic-markup-crossing.md)."
+  (:require ["react" :as react]
+            [cljs.test :refer [deftest is testing]]
+            [clojure.string :as str]
+            [re-frame.freehand.compiled-react :as cr]
+            [re-frame.freehand.react :as fr]))
+
+(defn- refusal
+  "The ex-data of the D010 refusal `thunk` raises (with its message folded
+  in), or nil when `thunk` does not throw one."
+  [thunk]
+  (try
+    (thunk)
+    nil
+    (catch :default e
+      (when-let [d (ex-data e)] (assoc d :message (ex-message e))))))
+
+(deftest a-runtime-hiccup-vector-in-a-compiled-child-is-refused-not-interpreted
+  (testing "rf2-drpa3.130 — the browser lowering sends every dynamic child
+            through compiled-react/child. A value that turns out to be a
+            Hiccup vector must be REFUSED by name (D010: no dynamic-markup
+            valve, no interpreter inside a compiled view to walk one), the
+            same typed refusal the structural children canonicalizer raises
+            — never walked into React by the interpreted arm."
+    (doseq [markup [[:span "hi"]
+                    [:div.card {:id "x"} "y"]
+                    ;; The original elided-boundary symptom: forwarded Hiccup
+                    ;; carrying declarative event intent must fail LOUDLY here,
+                    ;; not have its handler silently dropped by a walk that ran
+                    ;; with no ambient candidate to own the site (acceptance 3).
+                    [:button {:on-click [:app/go]} "go"]]]
+      (let [d (refusal #(cr/child markup))]
+        (is (some? d)
+            (str (pr-str markup) " is refused, not interpreted"))
+        (is (= :rf.error/ui-tree-malformed (:rf.error/id d))
+            (str (pr-str markup) " — the canonical typed D010 refusal id"))
+        (is (str/includes? (or (:message d) "") "compiled, not interpreted")
+            (str (pr-str markup) " — the diagnostic names the language boundary"))
+        (is (str/includes? (or (:message d) "") "keep this view interpreted")
+            (str (pr-str markup) " — and names the always-available recovery"))))))
+
+(deftest the-compiled-child-seam-itself-refuses-a-runtime-vector
+  (testing "compiled-react/child delegates to fr/child-elements, so the
+            refusal lives at the seam: a compiled body cannot reach the
+            interpreted walk through any caller of it (acceptance 2)."
+    (let [d (refusal #(fr/child-elements [:span "x"]))]
+      (is (= :rf.error/ui-tree-malformed (:rf.error/id d))
+          "the seam raises the shared refusal")
+      (is (str/includes? (or (:message d) "") "compiled, not interpreted")
+          "with the D010 sentence"))))
+
+(deftest a-legitimate-compiled-child-still-renders
+  (testing "The refusal is exactly for runtime markup, and no wider
+            (acceptance 4). Everything a compiled body legitimately produces
+            in a child position still passes: nil/false render nothing, text
+            and numbers become React text, an already-lowered React child
+            passes through untouched, and a run of them splices in order."
+    (is (nil? (cr/child nil)) "nil renders nothing")
+    (is (nil? (cr/child false)) "false renders nothing")
+    (is (= "text" (cr/child "text")) "a string is text")
+    (is (= "3" (cr/child 3)) "a number takes React's own number formatting")
+    (let [el (react/createElement "span" nil "x")]
+      (is (react/isValidElement (cr/child el))
+          "an already-lowered React child stays a React element")
+      (is (identical? el (cr/child el))
+          "…the very one it was handed, untouched"))
+    (let [run (cr/child (list "a" "b"))]
+      (is (array? run) "a seq of children splices into a run")
+      (is (= ["a" "b"] (vec run)) "…in document order"))))

--- a/implementation/freehand/test/re_frame/freehand/compiled_select_multiple_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/compiled_select_multiple_cljs_test.cljs
@@ -1,0 +1,90 @@
+(ns re-frame.freehand.compiled-select-multiple-cljs-test
+  "A `<select multiple>` whose empty `value` React reads as an ARRAY — in the
+  compiled browser runtime, and with a RUNTIME-valued `multiple`.
+
+  A native `<select multiple>`'s selection is a list of option values, so its
+  controlled EMPTY value is the empty array, not the empty string; React
+  reports the wrong shape loudly. The interpreted emitter settles that verdict
+  over the runtime attribute map every render. The compiled React emitter had
+  settled it only from a BUILD-TIME literal `multiple`, so a runtime-valued
+  `:multiple` wrote the scalar empty string for an explicitly nil value — in
+  the direct-props path AND in `compiled-react/spread!`'s forwarded map.
+
+  This file pins the compiled RUNTIME shapes both fixes now produce, against
+  the interpreted walk's shape for the same map (rf2-sf9n5). The emitter half —
+  that the direct-props lowering derives and threads the runtime verdict — is
+  `react-lowering-jvm-test/a-runtime-valued-select-multiple-settles-its-empty-value-at-render`.
+
+  Normative owner:
+  [`spec/004-Views.md`](../../../../../spec/004-Views.md) §Controlled inputs,
+  and [`spec/004D-Freehand-Compiled-Grammar.md`](../../../../../spec/004D-Freehand-Compiled-Grammar.md)."
+  (:require [cljs.test :refer [deftest is testing]]
+            [goog.object :as gobj]
+            [re-frame.freehand.compiled-react :as cr]
+            [re-frame.freehand.controlled :as controlled]
+            [re-frame.freehand.react :as fr]))
+
+(defn- as-data
+  "A `value` prop read back as ordinary Clojure data — a JS array becomes a
+  vector — so a row can say what it means; that it WAS an array is asserted
+  separately, because the array is React's own contract here."
+  [v]
+  (if (array? v) (vec v) v))
+
+(deftest a-runtime-multiple-verdict-shapes-the-nil-value-in-the-direct-props-path
+  (testing "The compiled emitter now derives the multiple-select verdict from
+            the RUNTIME :multiple and threads it to the nil-value
+            normalization — the exact runtime sequence the emitted body runs.
+            A true verdict makes an explicitly nil <select> value the empty JS
+            ARRAY React requires; a false verdict the empty string."
+    (doseq [{:keys [flag value]} [{:flag true :value []} {:flag false :value ""}]]
+      (let [verdict (controlled/multiple-select? :select [[:multiple flag]] nil)
+            o       (js-obj)]
+        (cr/attr! o :select :value nil verdict)
+        (is (= value (as-data (gobj/get o "value")))
+            (str ":multiple " flag " — the nil value takes its controlled empty shape"))
+        (when flag
+          (is (array? (gobj/get o "value"))
+              "and a multiple select's empty value is a JS array, not a string"))))
+    ;; The aliased spellings reach the same verdict and the same value slot.
+    (let [verdict (controlled/multiple-select? :select [[:x/multiple true]] nil)
+          o       (js-obj)]
+      (cr/attr! o :select :x/value nil verdict)
+      (is (array? (gobj/get o "value"))
+          ":x/multiple decides, and :x/value reaches the same empty-array shape"))))
+
+(deftest a-forwarded-select-multiple-shapes-the-nil-value-in-the-spread-path
+  (testing "compiled-react/spread! settled controlledness from the forwarded
+            map but wrote the nil value through the arity that DEFAULTS the
+            verdict to false, so a forwarded <select multiple> value=nil wrote
+            the scalar empty string. It now settles the verdict over the whole
+            forwarded map, matching the interpreted walk."
+    (doseq [{:keys [m value]} [{:m {:multiple true :value nil}   :value []}
+                               {:m {:multiple false :value nil}  :value ""}
+                               {:m {:x/multiple true :value nil} :value []}]]
+      (let [o (js-obj)]
+        (cr/spread! o :select [] "sid" m)
+        (is (= value (as-data (gobj/get o "value")))
+            (str (pr-str m) " — the forwarded nil value takes its controlled empty shape"))))
+    (let [o (js-obj)]
+      (cr/spread! o :select [] "sid" {:multiple true :value nil})
+      (is (array? (gobj/get o "value"))
+          "a forwarded multiple select's empty value is a JS array, not a string"))))
+
+(deftest the-compiled-runtime-shapes-match-the-interpreted-walk
+  (testing "The cross-mode claim: the compiled runtime writes the SAME value
+            shape the interpreted emitter writes for the same runtime map —
+            the empty array when multiple is truthy, the empty string when it
+            is not."
+    (letfn [(interp [form] (as-data (gobj/get (.-props (fr/element form)) "value")))
+            (spread [m] (let [o (js-obj)]
+                          (cr/spread! o :select [] "s" m)
+                          (as-data (gobj/get o "value"))))]
+      (is (= (interp [:select {:multiple true :value nil :on-change [:e]}])
+             (spread {:multiple true :value nil})
+             [])
+          "empty multiple select: both modes write the empty array")
+      (is (= (interp [:select {:multiple false :value nil :on-change [:e]}])
+             (spread {:multiple false :value nil})
+             "")
+          "single select: both modes write the empty string"))))

--- a/implementation/freehand/test/re_frame/freehand/react_lowering_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/react_lowering_jvm_test.clj
@@ -298,3 +298,35 @@
           "and the slot body was lowered through the React emitter")
       (is (not (.contains emitted ":row nil"))
           "so the boundary is not handed an absent slot"))))
+
+(deftest a-runtime-valued-select-multiple-settles-its-empty-value-at-render
+  (testing "rf2-sf9n5 — the React emitter settled the multiple-select verdict
+            only from a build-time literal, so a runtime-valued :multiple wrote
+            the constant `false` and mis-shaped an explicitly nil value. It is
+            now settled at RENDER: the :multiple value is bound once, the
+            verdict is derived from it once, and BOTH the :multiple write and
+            the nil :value normalization read that one runtime verdict —
+            never the constant false the bug baked in. Asserted on the emitted
+            FORM; the runtime value shape is `compiled-select-multiple-cljs-test`."
+    (let [[e ast]  (analyzed '[:select {:multiple (:flag props) :value nil}])
+          form     (emit-react/emit-react-body e '[props] ast)
+          nodes    (tree-seq coll? seq form)
+          attr!s   (filter #(and (seq? %)
+                                 (= 're-frame.freehand.compiled-react/attr! (first %)))
+                           nodes)
+          value-write   (first (filter #(= :value (nth % 3 nil)) attr!s))
+          verdict-forms (filter #(and (seq? %)
+                                      (= 're-frame.freehand.controlled/multiple-select?
+                                         (first %)))
+                                nodes)]
+      (is (= 1 (count verdict-forms))
+          "the runtime multiple-select verdict is computed exactly once")
+      (is (some? value-write)
+          "the explicitly nil :value is written at runtime")
+      (let [verdict-arg (nth value-write 5 nil)]
+        (is (symbol? verdict-arg)
+            "the :value write's verdict is the once-bound runtime verdict, not a constant")
+        (is (not (false? verdict-arg))
+            "and specifically NOT the build-time constant false the bug baked in"))
+      (is (= 1 (count (filter #(= '(:flag props) %) nodes)))
+          "and the runtime :multiple expression is evaluated exactly once"))))

--- a/implementation/freehand/test/re_frame/freehand/react_lowering_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/react_lowering_jvm_test.clj
@@ -250,6 +250,37 @@
       (is (.contains emitted "re-frame.freehand.compiled-react/el")
           "and the render-fn's own body was lowered through the React emitter"))))
 
+(deftest a-compiled-slot-evaluates-its-arguments-before-the-gate
+  (testing "rf2-drpa3.133 — an interpreted `v/slot` is an ordinary eager
+            call, so its arguments evaluate before the nil-slot gate is
+            even reached. Promotion must not move that evaluation inside the
+            gate: the emitted body binds each argument in the `let` BEFORE
+            the `slot-ready?` `when`, so a side-effecting argument — a
+            `v/sub` the analyzer attributes to the enclosing view — runs
+            whether or not the slot renders. Asserted on the emitted FORM,
+            so the React lowering is pinned without the deferred
+            compiled-browser runtime; the behavioural cross-mode oracle is
+            `slots-grammar-parity-jvm-test`."
+    (let [[e ast] (analyzed '[:div (v/slot (:slot props) (probe-arg))])
+          form    (emit-react/emit-react-body e '[props] ast)
+          nodes   (tree-seq coll? seq form)
+          gate    (first (filter (fn [x]
+                                   (and (seq? x)
+                                        (= 'clojure.core/when (first x))
+                                        (some (fn [y]
+                                                (and (seq? y)
+                                                     (= 're-frame.freehand.events/slot-ready?
+                                                        (first y))))
+                                              (tree-seq coll? seq x))))
+                                 nodes))]
+      (is (some? gate)
+          "the slot lowers to a slot-ready? gate")
+      (is (some #{'(probe-arg)} nodes)
+          "the argument expression is emitted at all")
+      (is (not (some #{'(probe-arg)} (tree-seq coll? seq gate)))
+          "and it is NOT evaluated inside the gate — it is bound before it,
+           so a nil slot still runs it once"))))
+
 (deftest a-call-site-render-fn-prop-carries-the-slot-across-the-boundary
   (testing "The library seam — content authored at the CALL SITE and
             invoked by the callee through `v/slot`. The analyzer records

--- a/implementation/freehand/test/re_frame/freehand/slots_grammar_parity_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/slots_grammar_parity_jvm_test.clj
@@ -351,3 +351,60 @@
       (let [[i c] (rendered view props)]
         (is (= i (read-string (pr-str i))) "interpreted")
         (is (= c (read-string (pr-str c))) "compiled")))))
+
+;; ---------------------------------------------------------------------------
+;; A slot argument evaluates once in both modes — even when the slot is absent
+;; ---------------------------------------------------------------------------
+;;
+;; The parity table above compares OUTPUT, and output cannot see an evaluation
+;; that produced nothing. `v/slot` is an ordinary eager call interpreted, so
+;; every argument runs before the gate ever sees a nil slot; both compiled
+;; emitters used to inline the arguments INSIDE the `slot-ready?` gate, so an
+;; absent slot skipped them. With an optional slot, that dropped a `v/sub` the
+;; analyzer attributes to the enclosing view's own render — a promotion changing
+;; dependency capture at the exact composition seam. So the oracle here is the
+;; evaluation COUNT, not the tree (rf2-drpa3.133).
+
+(def ^:private slot-arg-evals (atom 0))
+
+(defn- counted-arg
+  "A side-effecting slot ARGUMENT: bumps a shared counter and answers a
+  value. Stands in for a `v/sub` the analyzer treats as the enclosing
+  view's own render-time read — an evaluation the two modes must agree on."
+  []
+  (swap! slot-arg-evals inc)
+  "arg")
+
+(v/defview eager-slot-arg-interpreted
+  [{:keys [slot]}]
+  [:div (v/slot slot (counted-arg))])
+
+(v/defview eager-slot-arg-compiled
+  {:compiled true}
+  [{:keys [slot]}]
+  [:div (v/slot slot (counted-arg))])
+
+(deftest a-slot-argument-evaluates-the-same-number-of-times-in-both-modes
+  (testing "rf2-drpa3.133 — promoting a view to {:compiled true} must not
+            change how many times a slot argument runs. Over both an ABSENT
+            slot and a present one, a side-effecting argument evaluates the
+            SAME number of times in each mode — the eager function-call
+            semantics the interpreted `v/slot` has, preserved across
+            promotion. The count is the oracle: 'the output looks the same'
+            passes against a skipped or doubled evaluation."
+    ;; The present-slot row's render-fn answers TEXT, not markup: it is an
+    ;; interpreted render-fn passed as a runtime prop, so a Hiccup body would
+    ;; be a raw vector child the compiled parent rightly refuses (D010). The
+    ;; oracle here is the ARGUMENT's evaluation count, not the slot's output.
+    (doseq [{:keys [note slot]} [{:note "absent slot"  :slot nil}
+                                 {:note "present slot" :slot (v/render-fn [x] (str "got-" x))}]]
+      (reset! slot-arg-evals 0)
+      (tree/render [eager-slot-arg-interpreted {:slot slot}])
+      (let [interpreted @slot-arg-evals]
+        (reset! slot-arg-evals 0)
+        (tree/render [eager-slot-arg-compiled {:slot slot}])
+        (let [compiled @slot-arg-evals]
+          (is (= interpreted compiled)
+              (str note " — the argument evaluates the same number of times in both modes"))
+          (is (= 1 interpreted)
+              (str note " — non-vacuous: the interpreted arm really evaluated it once")))))))


### PR DESCRIPTION
Three compiled-tier correctness fixes on the Freehand browser emitter, one commit each. Each premise was reproduced against current `main` before the fix (emitted-form probe + the existing test blind spots).

## rf2-drpa3.130 — Refuse runtime Hiccup in compiled browser expressions (P1)

The compiled React lowering sends every dynamic `:expr` child through `compiled-react/child`, which delegated to the interpreted walk via `fr/child-elements` and **interpreted** a runtime Hiccup vector inside compiled markup. That contradicts ruled D010 and `spec/004D` §"No interpreted fallback inside compiled markup": v1 has no dynamic-markup valve and no automatic fallback — a runtime value that turns out to be markup must be refused, by name.

The interpreted `collect`/`children` now take their walker as a parameter (as the structural `node/collect` already does); `child-elements` passes none, so a vector in a compiled child position raises the shared `node/opaque-child!` refusal rather than being walked. Legal compiled children — nil/false, text, numbers, already-lowered React children, and runs — are untouched (asserted, so the fix does not over-refuse).

**Refusal id: `:rf.error/ui-tree-malformed`** (recovery `:no-recovery`; the message names the escapes — extract a declared child view, keep the view interpreted). This is **reused, not minted**: `spec/009-Instrumentation.md` already carries the `:rf.error/ui-tree-malformed` row, which explicitly covers "a dynamic child producing a raw vector/seq/keyword (hiccup is compiled, not interpreted…)" and already names `re-frame.freehand.react` as an emitter. So there is **no spec/009 catalogue edit and no Spec-Schemas edit**. `spec/004D` is likewise unchanged — its level-3 rule ("the canonical children builder takes its markup walker as a parameter, and compiled code passes none; a runtime value that IS a hiccup vector is therefore refused inside compiled markup, by name") already specifies exactly this behaviour; the fix makes the React tier conform to it.

The existing absence oracle (`compiled-grammar-jvm-test`) only walks the structural `:body` and lists structural walk entry points, so it stayed green while the React lowering gained the forbidden reachability. A new behavioural CLJS test closes that gap on the seam a mounted compiled view actually calls, and asserts the typed refusal (id + D010 sentence) plus that a legitimate compiled child still renders.

## rf2-drpa3.133 — Preserve v/slot argument evaluation across promotion (P2)

Both compiled emitters inlined a `v/slot`'s argument forms **inside** the `(when (slot-ready? rf) …)` gate, so a nil slot evaluated none of them. An interpreted `v/slot` is an ordinary function call — it evaluates the slot value and every argument before `invoke-slot` sees the slot is nil. Promotion therefore changed *when* slot arguments run; with an optional slot absent, that drops a `v/sub` the analyzer attributes to the enclosing view, silently changing dependency capture between modes.

Both `emit-slot` lowerings (React and JVM structural) now bind the slot value and every argument in the `let` **before** the gate, in source order, so each evaluates exactly once whether or not the slot renders. Arity check and nil-renders-nothing are unchanged. Proven by a JVM eval-count oracle (an atom incremented per eval; compiled and interpreted counts asserted **equal**, not merely that the output looks right) plus an emitted-form assertion on the React lowering.

## rf2-sf9n5 — Compiled React mis-shapes nil when select multiple is runtime-valued (P2)

The compiled React emitter settled the `<select multiple>` verdict only from a build-time literal `:multiple`, so `[:select {:multiple (:flag props) :value nil}]` baked in `false` and wrote the scalar empty string for an explicitly nil value — where the interpreted emitter, on the same runtime map, writes React's required empty **array**. `compiled-react/spread!` had the same gap on a forwarded map.

The emitter now binds a runtime `:multiple`'s value once, derives the verdict from it once, and threads that one verdict to both the `:multiple` write and the nil-value normalization; a fully literal `:multiple` keeps the build-time constant path. `spread!` settles the verdict over the whole forwarded map. Exact and aliased spellings (`:multiple`/`:x/multiple`, `:value`/`:x/value`) reach the same result. Proven by an emitted-form assertion (the runtime verdict reaches the value write; the `:multiple` expression is evaluated once) and a CLJS runtime test asserting the actual React value shape (empty array vs empty string), cross-checked against the interpreted walk.

## Quality gates

All foreground, run from this branch. Every new test was checked for non-vacuity (one assertion inverted → the full gate reds naming the test → restored byte-identical).

| Gate | Command | Result | Exit |
|---|---|---|---|
| Freehand JVM | `cd implementation/freehand && clojure -M:test` | 868 tests, 6271 assertions, 0 failures, 0 errors | 0 |
| Freehand node | `npm run test:freehand` | 882 tests, 5334 assertions, 0 failures, 0 errors | 0 |
| Node CLJS | `npm run test:cljs` | 11007 tests, 55459 assertions, 0 failures, 0 errors | 0 |
| Browser | `npm run test:browser` | 688 tests, 4224 assertions, 0 failures, 0 errors | 0 |
| Conformance index | `python scripts/check_freehand_conformance_index.py` | ok | 0 |

Surface touched: `compiler/analyze.cljc` unchanged; `compiler/emit_react.cljc`, `compiler/emit_jvm.cljc`, `compiled_react.cljs`, `react.cljs`, `node.cljc` and their tests. No facade/`spec/004D`/`spec/009` change (hot-zone untouched).
