### PR TITLE
freehand: delete dead compiled-mount / Layer-1 machinery (fn mount door ratified)

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/compiler/build.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/build.cljc
@@ -930,10 +930,10 @@
   `:descriptors`) in the live analyzer map's SYNTHETIC per-namespace descriptor for
   `ns-sym` — the S4 variant-B carrier, extended to carry the Root Descriptor index
   too (rf2-u53yy.1 S5): all three call-site registries ride ONE carrier. Called at
-  macro expansion on a real Shadow build pass (`register-root-site!` /
-  `register-plan-site!` / `register-descriptor!` gate on `shadow-build-pass?`) in
-  place of the per-source slice contribution: the whole-build roots/plans/descriptor
-  registries are then harvested from this carrier at compile-finish, present
+  macro expansion on a real Shadow build pass (`register-root-site!` gates on
+  `shadow-build-pass?`; on the Freehand door only the root-site registry has a live
+  writer) in place of the per-source slice contribution: the whole-build root-site
+  registry is then harvested from this carrier at compile-finish, present
   identically for a cache-hit member and a freshly compiled one. A `:roots` site is
   `{:root-id .. :row {:file .. :line .. :provenance ..}}`; a `:plans` site is
   `{:frame-id .. :row {:config-fingerprint .. :file .. :line ..}}`; a `:descriptors`
@@ -1185,9 +1185,9 @@
           view-registries (harvest-view-registries build-state members)
           ;; Roots + plans + Root Descriptors ride the disk-cache-durable SYNTHETIC
           ;; per-namespace analyzer-map descriptor on the Shadow path (rf2-u53yy.1
-          ;; S4 roots/plans, S5 folds descriptors onto the same carrier). Their
-          ;; register-*-site! / register-descriptor! macros contribute NO slice row
-          ;; under a Shadow build pass, so harvest every authoritative member's
+          ;; S4 roots/plans, S5 folds descriptors onto the same carrier). The
+          ;; register-root-site! macro contributes NO slice row under a Shadow build
+          ;; pass, so harvest every authoritative member's
           ;; root/plan/descriptor sites from the carrier and overlay them onto the
           ;; slice-derived rows of the other registries — a cache-hit member
           ;; contributes its RESTORED sites identically to a freshly compiled one. The

--- a/implementation/freehand/src/re_frame/freehand/compiler/root.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/root.cljc
@@ -10,17 +10,17 @@
       double-mount), the deterministic root-id SLUG and the
       `identifierPrefix` default `\"rf2-\" + slug + \"-\"`;
     - the STATIC TOP-REGION scan over the analyzed root-form AST: the
-      mounted view (exactly one for derivation), the static frame plans
-      (`frame-root` `:id` + `config-fingerprint`), props-shape /
-      static-props extraction;
-    - ROOT DESCRIPTOR v1 assembly (`:rf.root/schema-version 1`) — the
-      compile-time static subset of the Stage-5 Root Manifest; S1 emits
-      descriptors only (manifests land S5);
-    - LAYER-1 duplicate detection (build tier): the per-build root-site
-      index (`:rf.error/duplicate-root-id`) and the frame-plan
-      config-fingerprint index (`:rf.error/frame-payload-conflict`);
-    - the macro bodies for `v/mount` / `v/create-root` / `v/render!` /
-      `v/hydrate-root` (JVM-only — they run at CLJS macro expansion).
+      mounted view (exactly one for derivation) and the static frame plans
+      (`frame-root` `:id` + `config-fingerprint`), with the intra-form
+      frame-plan conflict rejected at analysis
+      (`:rf.error/frame-payload-conflict`);
+    - LAYER-1 root-id indexing (build tier): the per-build root-site index
+      (`:rf.error/duplicate-root-id`). On the Freehand door the client mount
+      verbs are runtime fns (`v/mount` / `v/hydrate-root` / `v/unmount!`,
+      re-exported from `re-frame.freehand.root`), so `v/render-static` is the
+      ONLY entry point that indexes a root site through this half;
+    - the `v/render-static` macro body (JVM-only — it runs at CLJS/JVM macro
+      expansion; it is the sole compiler-side mount-surface entry point).
 
   ## Build scope of Layer 1 ([S1-CONFIRM] item 3 — resolved for S1)
 
@@ -40,8 +40,8 @@
 
   Pure analysis fns are host-neutral (resolution is injected via the env,
   the S1b pattern) so the conformance suites run under both
-  `clojure -M:test` and the node runner; only the macro bodies are
-  JVM-gated."
+  `clojure -M:test` and the node runner; only the `render-static` macro
+  body is JVM-gated."
   (:require [clojure.string :as str]
             [re-frame.error :as error]
             [re-frame.freehand.compiler.analyze :as ana]
@@ -215,70 +215,17 @@
          :provenance :derived}))))
 
 ;; ---------------------------------------------------------------------------
-;; Props extraction (contract §5) + Root Descriptor v1 (contract §2)
+;; Layer 1 — the build-tier root-site index (contract §7)
 ;; ---------------------------------------------------------------------------
 
-(defn- literal-edn? [v]
-  (cond
-    (ana/literal-scalar? v) true
-    (map? v)    (every? (fn [[k v']] (and (literal-edn? k) (literal-edn? v'))) v)
-    (vector? v) (every? literal-edn? v)
-    (set? v)    (every? literal-edn? v)
-    :else false))
-
-(defn props-shape-entry
-  "`:props-shape` / `:static-props` for the mounted view's call-site props
-  map (contract §5): every value a literal EDN datum -> `:literal` +
-  verbatim `:static-props`; any non-literal expression -> `:dynamic`, no
-  static props recorded (no guessing)."
-  [view-node]
-  (let [entries (get-in view-node [:props :entries])]
-    (if (every? (fn [en] (and (nil? (:marker en)) (literal-edn? (:value en))))
-                entries)
-      {:props-shape  :literal
-       :static-props (into {} (map (juxt :k :value)) entries)}
-      {:props-shape :dynamic})))
-
-(defn root-descriptor
-  "Assemble Root Descriptor v1 (`:rf.root/schema-version 1`) — the named,
-  versioned compile-time static SUBSET of the Stage-5 Root Manifest (same
-  key family; the manifest is a strict superset; readers ignore unknown
-  keys; additive keys do not bump the version). `:view-id` /
-  `:props-shape` / `:static-props` are present iff the root form has
-  exactly one top-region mounted view (an authored-id root may legally
-  mount zero or several); `:root-id-provenance` is dev-only and never
-  reaches shipped manifests. Identity keys are omitted when `root-id` is
-  nil (the `render!` descriptor-base — the client completes identity from
-  its Root, fixed at `create-root`).
-
-  This is Root Descriptor v1 (Spec 004C §2): the per-root static facts, baked
-  at expansion into the emitted CLJS and stored on the client live-root
-  registry entry. Every field is a per-root static fact resolvable at the
-  mount site's own expansion — the descriptor carries no whole-build
-  aggregate."
-  [{:keys [root-id provenance views plans ast]}]
-  (let [view (when (= 1 (count views)) (first views))]
-    (cond-> {:rf.root/schema-version 1
-             :frame-plans (mapv #(select-keys % [:frame-id :config-fingerprint])
-                                plans)
-             :template-fingerprint (fingerprint/template-fingerprint ast)}
-      (some? root-id)   (assoc :root-id root-id)
-      (some? provenance) (assoc :root-id-provenance provenance)
-      view (assoc :view-id (:view-id view))
-      view (merge (props-shape-entry view)))))
-
-;; ---------------------------------------------------------------------------
-;; Layer 1 — the build-tier duplicate/conflict indexes (contract §7)
-;; ---------------------------------------------------------------------------
-
-;; The Layer-1 / descriptor aggregates are keyed PER build id in the one
-;; build-scoped authority (`re-frame.freehand.compiler.build`, rf2-df9873) — no
+;; The Layer-1 root-site index is keyed PER build id in the one build-scoped
+;; authority (`re-frame.freehand.compiler.build`, rf2-df9873) — no
 ;; process-global atom to cross-contaminate between the builds one daemon
 ;; compiles in parallel. Consumers read the ambient build's aggregate through
-;; these accessors (a pure function of the current build inputs): a
+;; this accessor (a pure function of the current build inputs): a
 ;; recompiled / edited / renamed / removed source replaces its whole prior
-;; contribution atomically, so a deleted root or plan cannot linger to raise
-;; a FALSE cross-file duplicate/conflict.
+;; contribution atomically, so a deleted root cannot linger to raise a FALSE
+;; cross-file duplicate.
 
 (defn build-roots
   "The ambient build's Layer-1 root-site index: root-id ->
@@ -288,48 +235,16 @@
   ([] (build/aggregate build/roots))
   ([build-state] (build/accepted-aggregate build/roots build-state)))
 
-(defn build-plans
-  "The ambient build's Layer-1 frame-plan index: frame-id ->
-  {:config-fingerprint :file :line}. Two plans for one frame-id with
-  differing fingerprints from different namespaces fail the build
-  (:rf.error/frame-payload-conflict)."
-  ([] (build/aggregate build/plans))
-  ([build-state] (build/accepted-aggregate build/plans build-state)))
-
-(defn build-descriptors
-  "The ambient build's compile-emitted Root Descriptor index: root-id ->
-  descriptor — the build-artefact side of \"S1 emits descriptors\" (S5
-  tooling / Xray read compile output through here; the runtime copy rides the
-  live-root registry, dev-only)."
-  ([] (build/aggregate build/descriptors))
-  ([build-state] (build/accepted-aggregate build/descriptors build-state)))
-
 (defn reset-build-registries!
   "Hard-clear every build-scoped compiler registry (views, the Layer-1
-  root/plan indexes, the descriptor index, compile-time custom-elements)
-  and the contribution ledger — the clean-build / test-isolation boundary.
-  Delegates to the one build-scoped model; correctness across a watch
-  session comes from per-source replacement on `build/begin-build!`, not
-  from this wipe (rf2-vxgfnd.16 AC6)."
+  root-site index, compile-time custom-elements) and the contribution
+  ledger — the clean-build / test-isolation boundary. Delegates to the one
+  build-scoped model; correctness across a watch session comes from
+  per-source replacement on `build/begin-build!`, not from this wipe
+  (rf2-vxgfnd.16 AC6)."
   []
   (build/reset-build!)
   nil)
-
-#?(:clj
-   (defn descriptor-index
-     "The Root Descriptor v1 index projected for READING (the S5 tooling /
-     Xray / ui.test compiler-side read; Spec 004C §2): every stored per-root
-     descriptor. Outside a compiler binding, callers pass the explicit
-     retained Shadow build-state; no global latest build exists. Its CLIENT
-     counterpart is `re-frame.freehand.client/descriptor-index`, which reads the
-     same per-root static descriptors from the live-root registry."
-     ([]
-       ;; Reads must not mix effective open-pass descriptor rows with the
-       ;; accepted set. Compiler diagnostics may use `build-descriptors`;
-       ;; tooling sees one coherent snapshot.
-       (into {} (build/committed-aggregate build/descriptors)))
-     ([build-state]
-      (into {} (build-descriptors build-state)))))
 
 (defn- site-str [{:keys [file line]}]
   (str (or file "<unknown-file>") (when line (str ":" line))))
@@ -380,149 +295,12 @@
                 :sites      [(dissoc conflict :provenance) coords]}})))
   nil)
 
-(defn register-plan-site!
-  "Index one site's static frame plan (Layer 1), owned by its declaring
-  namespace `ns-sym`. A plan for the same frame-id with a DIFFERING config
-  fingerprint from a different namespace is the build-tier
-  `:rf.error/frame-payload-conflict` (same-namespace re-registration replaces
-  — watch tolerance; matching fingerprints are the ratified idempotent no-op).
-
-  On a real Shadow build PASS (rf2-u53yy.1 S4) the plan site is stamped onto the
-  SYNTHETIC per-namespace analyzer-map descriptor
-  (`build/stamp-root-plan-site!`) rather than the per-source slice, and the
-  cross-namespace frame-payload-conflict law runs at compile-finish over the
-  carrier — the same decoupling S4 gives roots. Off that path (plain-JVM / SSR,
-  REPL) the per-source slice contribution + this expansion-time check apply; the
-  check-then-write is ONE atomic transition."
-  [where {:keys [frame-id config-fingerprint]} ns-sym coords]
-  (if (build/shadow-build-pass?)
-    (build/stamp-root-plan-site!
-     ns-sym :plans
-     {:frame-id frame-id
-      :row {:config-fingerprint config-fingerprint
-            :file (:file coords) :line (:line coords)}})
-    (when-let [{:keys [conflict]}
-               (build/contribute-checked!
-                build/plans ns-sym frame-id
-                {:config-fingerprint config-fingerprint
-                 :file (:file coords) :line (:line coords)}
-                (fn [existing]
-                  (when (and existing
-                             (not= (:config-fingerprint existing) config-fingerprint))
-                    existing)))]
-      (error/throw-error!
-       :rf.error/frame-payload-conflict where
-       (str "two root sites in one build carry static frame plans for "
-            "frame " (pr-str frame-id) " with DIFFERING config "
-            "fingerprints — " (site-str conflict) " and " (site-str coords)
-            ". One frame, one plan: keep the frame's config in ONE "
-            "boot/root site, or align the configs")
-       {:recovery :align-frame-plan-config
-        :extra {:frame-id     frame-id
-                :fingerprints [(:config-fingerprint conflict) config-fingerprint]
-                :sites        [(dissoc conflict :config-fingerprint) coords]}})))
-  nil)
-
-(defn register-descriptor!
-  "Index one root site's compile-emitted Root Descriptor (the build-artefact the
-  S5 tooling / Xray read through `descriptor-index`), keyed by `root-id`, owned by
-  its declaring namespace `ns-sym`.
-
-  On a real Shadow build PASS (rf2-u53yy.1 S5) the descriptor rides the SAME
-  SYNTHETIC per-namespace analyzer-map carrier as roots/plans (S4), under a
-  `:descriptors` sub-key, via `build/stamp-root-plan-site!` — so a warm cache-hit
-  source's descriptor is RESTORED from the disk cache without the macro re-running,
-  and the whole-build descriptor index is harvested from the carrier at
-  compile-finish. It contributes NO per-source slice row on that path. Every
-  descriptor is registered at a mount / hydrate site that ALSO registers a root site
-  under the same `root-id`, so the cross-namespace `:rf.error/duplicate-root-id`
-  law (`register-root-site!` off the Shadow path, `harvest-root-plan-registries` at
-  compile-finish on it) is the descriptor's conflict check too — no separate one is
-  needed. Off the Shadow path (plain-JVM / SSR, REPL — no compile-finish harvest)
-  the per-source slice contribution applies, the read path `descriptor-index` uses."
-  [root-id descriptor ns-sym]
-  (if (build/shadow-build-pass?)
-    (build/stamp-root-plan-site!
-     ns-sym :descriptors {:root-id root-id :row descriptor})
-    (build/contribute! build/descriptors ns-sym root-id descriptor))
-  nil)
-
 ;; ---------------------------------------------------------------------------
-;; Root opts (contract §3)
-;; ---------------------------------------------------------------------------
-
-(def host-opt-keys #{:on-uncaught-error :on-caught-error :on-recoverable-error})
-
-(def create-root-opt-keys (into #{:root-id :identifier-prefix} host-opt-keys))
-
-(defn parse-root-opts!
-  "Validate a root opts map at compile time: literal map, CLOSED key set,
-  identity opts as compile-time literals (they feed the descriptor and
-  Layer-1 duplicate detection). Host-tier callback values stay opaque
-  runtime expressions. Returns opts."
-  [where opts allowed]
-  (when-not (map? opts)
-    (fail :rf.ui.compile/bad-root-opts
-          (str where ": the root opts map must be a LITERAL map at the "
-               "call site — identity opts (:root-id / :disambiguator / "
-               ":identifier-prefix) are compile-time literals; host "
-               "callbacks may be runtime expressions INSIDE the literal "
-               "map")
-          {:opts opts}))
-  (let [unknown (remove allowed (keys opts))]
-    (when (seq unknown)
-      (fail :rf.ui.compile/bad-root-opts
-            (str where ": unknown root opt" (when (next unknown) "s") " "
-                 (str/join ", " (map pr-str unknown))
-                 " — the opts map is CLOSED; " where " accepts "
-                 (str/join ", " (map pr-str (sort-by str allowed))))
-            {:unknown (vec unknown)})))
-  (when (and (contains? opts :root-id) (contains? opts :disambiguator))
-    (fail :rf.ui.compile/bad-root-opts
-          (str where ": :disambiguator is only meaningful when :root-id "
-               "is absent — it modifies DERIVATION; an authored :root-id "
-               "is already verbatim identity. Keep one")
-          {:root-id (:root-id opts) :disambiguator (:disambiguator opts)}))
-  (when (contains? opts :root-id)
-    (validate-authored-root-id! where (:root-id opts)))
-  (when (contains? opts :disambiguator)
-    (validate-disambiguator! where (:disambiguator opts)))
-  (when (contains? opts :identifier-prefix)
-    (when-not (string? (:identifier-prefix opts))
-      (fail :rf.ui.compile/bad-root-opts
-            (str where ": :identifier-prefix must be a literal string "
-                 "(fed to React's identifierPrefix); got "
-                 (pr-str (:identifier-prefix opts)))
-            {:identifier-prefix (:identifier-prefix opts)})))
-  opts)
-
-;; ---------------------------------------------------------------------------
-;; Macro bodies (JVM only — CLJS macro expansion)
+;; Macro body (JVM only — CLJS/JVM macro expansion)
 ;; ---------------------------------------------------------------------------
 
 #?(:clj
    (do
-
-(def ^:private goog-debug (with-meta 'js/goog.DEBUG {:tag 'boolean}))
-
-(defn- dbg-quoted
-  "Emit `x` as quoted data under the goog.DEBUG gate (production carries
-  no descriptors/site coords — I-12)."
-  [x]
-  `(when ~goog-debug (quote ~x)))
-
-(defn- expand-env!
-  "The mount-surface entry points are CLIENT entry points; expanding for
-  the JVM host is a compile error (JVM structural rendering is
-  ui.test/render (S1d) / render-static (S5))."
-  [where menv]
-  (when-not (:ns menv)
-    (fail :rf.ui.compile/client-entry-on-jvm
-          (str where " is a client entry point — there is no DOM on the "
-               "JVM. JVM structural rendering is ui.test/render (S1d) / "
-               "render-static (S5)")
-          {:where where}))
-  (env/make-env {:host :cljs :cljs-env menv :ns-sym (-> menv :ns :name)}))
 
 (defn- source-coords [form cljs?]
   (let [m (meta form)]
@@ -553,58 +331,6 @@
   (doseq [w @(:warnings e)]
     (binding [*out* *err*]
       (println (str "WARNING re-frame.freehand [" where "] " (:id w) ": " (:msg w))))))
-
-(defn- react-opts-form [prefix opts]
-  `(re-frame.freehand.client/root-options
-    ~prefix
-    ~(:on-uncaught-error opts)
-    ~(:on-caught-error opts)
-    ~(:on-recoverable-error opts)))
-
-;; The root-TEMPLATE entry points — `v/mount`, `v/render!`, `v/hydrate-root`
-;; — are not part of this artefact. Their transplanted macro bodies lowered
-;; their root form with the deleted second CLJS emitter and called into a
-;; `re-frame.freehand.client` namespace that does not exist, and no Freehand
-;; macro was ever wired to them; they were removed with that emitter rather
-;; than kept as bodies nothing could run. `create-root-form` below takes NO
-;; root form, so it survives them.
-
-(defn create-root-form
-  "`(v/create-root dom-node opts)` — identity is fixed HERE for the
-  Root's lifetime, and there is no root form to derive from, so an
-  authored `:root-id` is REQUIRED (the derivation default belongs to the
-  root-form-bearing entry points; `v/mount` is the one-liner path)."
-  [form menv dom-node opts]
-  (let [coords (source-coords form (some? (:ns menv)))
-        ns-sym (-> menv :ns :name)]
-    (anchored coords
-      (fn []
-        (expand-env! 'v/create-root menv)
-        (when (and (map? opts) (contains? opts :disambiguator))
-          (fail :rf.ui.compile/bad-root-opts
-                (str "v/create-root: :disambiguator modifies DERIVATION and "
-                     "create-root has no root form to derive from — author "
-                     ":root-id")
-                {:disambiguator (:disambiguator opts)}))
-        (let [opts    (parse-root-opts! 'v/create-root opts create-root-opt-keys)
-              root-id (:root-id opts)]
-          (when (nil? root-id)
-            (fail :rf.ui.compile/missing-root-id
-                  (str "v/create-root fixes root identity WITHOUT a root "
-                       "form — there is no mounted view to derive from; "
-                       "author :root-id (or use v/mount, the "
-                       "derivation-default path)")
-                  nil))
-          (let [prefix (or (:identifier-prefix opts)
-                           (default-identifier-prefix root-id))]
-            (register-root-site! 'v/create-root root-id :authored ns-sym coords)
-            `(re-frame.freehand.client/create-root*
-              {:root-id ~root-id
-               :provenance :authored
-               :identifier-prefix ~prefix
-               :site ~(dbg-quoted coords)}
-              ~dom-node
-              ~(react-opts-form prefix opts))))))))
 
 (defn declared-view
   "The DECLARED view value a Freehand view-id names, or nil.
@@ -720,9 +446,11 @@
   Four invariants, all reusing the mount-surface machinery:
 
     - LITERAL ROOT FORM — `analyze-root` rejects a runtime-assembled vector with
-      the SAME `:rf.ui.compile/runtime-root-form` compile error mount / render! /
-      hydrate-root / ui.test-render raise (a macro sees the literal form; a fn
-      cannot). This is the kind-label delta a fn could not honour.
+      the SAME `:rf.ui.compile/runtime-root-form` compile error `ui.test/render`
+      raises (a macro sees the literal form; a fn cannot). The runtime mount door
+      (`v/mount` / `v/hydrate-root`) cannot enforce this — the literal-form
+      guarantee is render-static's alone, the kind-label delta a fn could not
+      honour.
     - NO SILENT ELISION (Spec 004C §3, EP-0034 §2) — a runtime-requiring
       capability (subs, committed handlers, effects, refs, context, foreign / lazy
       heads) anywhere in the root's SERVER-REACHABLE view closure fails LOUD,
@@ -742,8 +470,10 @@
       single mounted view, so `resolve-root-identity` enforces exactly one view
       (`:rf.ui.compile/no-single-mounted-view` otherwise). The derived identity is
       RETAINED and registered into the Layer-1 build-tier duplicate-root-id index
-      via `register-root-site!`, exactly like mount / render! / hydrate-root — a
-      second site resolving to the same root-id is `:rf.error/duplicate-root-id`.
+      via `register-root-site!` — on the Freehand door render-static is the ONLY
+      entry point that registers here (the runtime mount verbs backstop duplicates
+      at the Layer-3 live-root registry); a second site resolving to the same
+      root-id is `:rf.error/duplicate-root-id`.
       Layer-2 duplicate detection (server render time, S5) is the SSR host's
       per-response registry, not the macro's.
     - INDEPENDENCE — the macro emits a call to the ui-side late-resolution seam
@@ -844,8 +574,9 @@
                     {:root-id root-id :offending-view view-id
                      :capabilities (vec (sort caps))})))
           ;; Layer-1 identity registration (§7): the static root participates in
-          ;; the build-tier duplicate-root-id index exactly like mount / render! /
-          ;; hydrate-root — the derived identity is retained, not discarded.
+          ;; the build-tier duplicate-root-id index — the derived identity is
+          ;; retained, not discarded. On the Freehand door render-static is the
+          ;; only entry point that registers here.
           (register-root-site! 'v/render-static root-id provenance ns-sym coords)
           ;; Emit a call to the ui-side late-resolution seam (NOT a bare
           ;; `re-frame.ssr/emit-ui-tree` reference) so the caller's namespace

--- a/implementation/freehand/test/re_frame/freehand/compiler_build_hook_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/compiler_build_hook_jvm_test.clj
@@ -8,8 +8,7 @@
   (:require [cljs.env :as cljs-env]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.freehand.compiler.build :as build]
-            [re-frame.freehand.compiler.build-hook :as build-hook]
-            [re-frame.freehand.compiler.root :as root]))
+            [re-frame.freehand.compiler.build-hook :as build-hook]))
 
 (use-fixtures :each
   (fn [f] (build/reset-build!) (try (f) (finally (build/reset-build!)))))
@@ -68,12 +67,6 @@
 
 (defn- declare-view [state source view-id fp]
   (in-compiler state #(build/contribute! build/views source view-id fp)))
-
-(defn- declare-descriptor [state source root-id label]
-  (in-compiler
-   state
-   #(build/contribute! build/descriptors source root-id
-                       {:rf.root/schema-version 1 :label label})))
 
 (defn- finish
   ([state member-nss] (finish state member-nss (set member-nss)))
@@ -318,21 +311,20 @@
               (get (views moved) :shared/card))
         "the new owner publishes its own view identity")))
 
-;; --- rf2-u53yy.1 S4: roots + plans ride the SYNTHETIC analyzer-map carrier -----
+;; --- rf2-u53yy.1 S4: root sites ride the SYNTHETIC analyzer-map carrier ---------
 ;;
-;; Root/plan CALL SITES carry no def (unlike views, S2), so on a real Shadow build
-;; PASS `register-root-site!` / `register-plan-site!` stamp a SYNTHETIC per-namespace
-;; descriptor `[::namespaces <ns> :rf.ui/root-plan-descriptor {:roots [..] :plans [..]}]`
-;; into the analyzer map (compiler.cljc-style gating on `build/shadow-build-pass?`),
-;; which Shadow persists to its disk cache and RESTORES on a warm hit (the S0 proof
-;; variant B, rf2-u53yy.1.1). `seed-analyzer-root`/`seed-analyzer-plan` stamp that
-;; carrier exactly where the analyzer stores it, so the build hook harvests the
-;; roots/plans registries from it at compile-finish — for a cache-hit member the
-;; macro never re-runs. Eviction is automatic: Shadow's watch reset dissocs the whole
-;; ns entry (`forget-analyzer-ns` models it), so a removed site vanishes.
+;; Root CALL SITES carry no def (unlike views, S2), so on a real Shadow build PASS
+;; `register-root-site!` stamps a SYNTHETIC per-namespace descriptor
+;; `[::namespaces <ns> :rf.ui/root-plan-descriptor {:roots [..]}]` into the analyzer
+;; map (compiler.cljc-style gating on `build/shadow-build-pass?`), which Shadow
+;; persists to its disk cache and RESTORES on a warm hit (the S0 proof variant B,
+;; rf2-u53yy.1.1). `seed-analyzer-roots` stamps that carrier exactly where the
+;; analyzer stores it, so the build hook harvests the roots registry from it at
+;; compile-finish — for a cache-hit member the macro never re-runs. Eviction is
+;; automatic: Shadow's watch reset dissocs the whole ns entry (`forget-analyzer-ns`
+;; models it), so a removed site vanishes.
 
 (defn- roots [state] (build/accepted-aggregate build/roots state))
-(defn- plans [state] (build/accepted-aggregate build/plans state))
 
 (defn- seed-analyzer-roots
   "Stamp `source`'s root sites onto `state`'s analyzer map the way the
@@ -347,53 +339,22 @@
                      :row {:file (str source ".cljs") :line 1 :provenance provenance}})
                   sites)))
 
-(defn- seed-analyzer-plans
-  "Stamp `source`'s frame-plan sites onto `state`'s analyzer map. `sites` is a coll
-  of `[frame-id config-fingerprint]`."
-  [state source sites]
-  (assoc-in state
-            [:compiler-env :cljs.analyzer/namespaces source
-             :rf.ui/root-plan-descriptor :plans]
-            (mapv (fn [[frame-id cf]]
-                    {:frame-id frame-id
-                     :row {:config-fingerprint cf
-                           :file (str source ".cljs") :line 1}})
-                  sites)))
-
-(defn- seed-analyzer-descriptors
-  "Stamp `source`'s Root Descriptor sites onto `state`'s analyzer map the way the
-  register-descriptor! macro does on a Shadow build pass (rf2-u53yy.1 S5 — the
-  descriptors ride the SAME synthetic carrier as roots/plans). `sites` is a coll of
-  `[root-id label]`; the row is a minimal Root Descriptor v1."
-  [state source sites]
-  (assoc-in state
-            [:compiler-env :cljs.analyzer/namespaces source
-             :rf.ui/root-plan-descriptor :descriptors]
-            (mapv (fn [[root-id label]]
-                    {:root-id root-id
-                     :row {:rf.root/schema-version 1 :root-id root-id :label label}})
-                  sites)))
-
-(deftest root-and-plan-descriptors-survive-a-cache-hit-via-the-analyzer-carrier
-  ;; The S4 analog of the S0 carrier proof (rf2-u53yy.1.1) for REAL root/plan sites:
-  ;; a warm cache-hit source's macro never re-runs, yet its root and plan survive
-  ;; because Shadow RESTORED the synthetic descriptor onto the analyzer map and the
-  ;; hook harvests the registries from there — not from a macro side effect.
+(deftest roots-survive-a-cache-hit-via-the-analyzer-carrier
+  ;; The S4 analog of the S0 carrier proof (rf2-u53yy.1.1) for REAL root sites:
+  ;; a warm cache-hit source's macro never re-runs, yet its root survives because
+  ;; Shadow RESTORED the synthetic descriptor onto the analyzer map and the hook
+  ;; harvests the registry from there — not from a macro side effect.
   (let [seed (graph-state :app :compile-prepare '#{app.a app.b})
-        ;; COLD: both compiled; each stamps its root/plan descriptor. Nothing is
+        ;; COLD: both compiled; each stamps its root descriptor. Nothing is
         ;; contributed to the slice (the macro is gated on the Shadow path), so a
         ;; harvested row here proves the analyzer-map carrier is the sole source.
         cold (-> (prepare seed '#{app.a app.b})
                  (seed-analyzer-roots 'app.a [[:page/a :authored]])
-                 (seed-analyzer-plans 'app.a [[:shop "cf-a"]])
                  (seed-analyzer-roots 'app.b [[:page/b :derived]])
                  (finish '#{app.a app.b}))]
     (is (= #{:page/a :page/b} (set (keys (roots cold))))
         "cold: both roots are harvested from the analyzer-map carrier")
     (is (= :authored (:provenance (get (roots cold) :page/a))))
-    (is (= {:shop "cf-a"}
-           (update-vals (plans cold) :config-fingerprint))
-        "cold: the plan is harvested from the analyzer-map carrier")
     ;; WARM: only app.b recompiles. app.a is a cache HIT — its macro does NOT run
     ;; (no re-seed this pass), but Shadow RESTORED its analyzer descriptor, which the
     ;; threaded build-state carries unchanged.
@@ -401,15 +362,12 @@
                    (seed-analyzer-roots 'app.b [[:page/b :derived]])
                    (finish '#{app.a app.b} '#{app.b}))]
       (is (= #{:page/a :page/b} (set (keys (roots warm))))
-          "warm: the cache-hit source's root is RESTORED without the macro re-running")
-      (is (= {:shop "cf-a"} (update-vals (plans warm) :config-fingerprint))
-          "warm: the cache-hit source's plan is RESTORED without the macro re-running"))))
+          "warm: the cache-hit source's root is RESTORED without the macro re-running"))))
 
-(deftest a-removed-root-or-plan-is-evicted-from-the-analyzer-carrier
+(deftest a-removed-root-is-evicted-from-the-analyzer-carrier
   (let [seed (graph-state :app :compile-prepare '#{app.a app.b})
         both (-> (prepare seed '#{app.a app.b})
                  (seed-analyzer-roots 'app.a [[:page/a :authored]])
-                 (seed-analyzer-plans 'app.a [[:shop "cf-a"]])
                  (seed-analyzer-roots 'app.b [[:page/b :authored]])
                  (finish '#{app.a app.b}))
         ;; app.a is recompiled with its mount removed: Shadow's watch reset dissocs
@@ -419,11 +377,8 @@
                     (forget-analyzer-ns 'app.a)
                     (finish '#{app.a app.b} '#{app.a}))]
     (is (= #{:page/a :page/b} (set (keys (roots both)))))
-    (is (= #{:shop} (set (keys (plans both)))))
     (is (= #{:page/b} (set (keys (roots removed))))
-        "a root removed from its recompiled source is evicted from the carrier")
-    (is (= {} (plans removed))
-        "the removed source's plan is evicted from the carrier")))
+        "a root removed from its recompiled source is evicted from the carrier")))
 
 (deftest cross-source-duplicate-root-id-fails-at-compile-finish
   ;; Two root sites in DIFFERENT namespaces resolving to one root-id fail when the
@@ -442,29 +397,6 @@
     (is (= :shared/root (:root-id (ex-data ex))))
     (is (= 2 (count (:sites (ex-data ex)))) "both sites named with coords")))
 
-(deftest cross-source-frame-payload-conflict-fails-at-compile-finish
-  (let [seed (graph-state :app :compile-prepare '#{app.a app.b})
-        collision (-> (prepare seed '#{app.a app.b})
-                      (seed-analyzer-plans 'app.a [[:shop "cf-a"]])
-                      (seed-analyzer-plans 'app.b [[:shop "cf-b"]]))
-        ex (try (finish collision '#{app.a app.b}) nil
-                (catch clojure.lang.ExceptionInfo e e))]
-    (is (some? ex) "differing fingerprints for one frame-id must fail the build")
-    (is (= :re-frame.freehand.compiler.build/frame-payload-conflict
-           (:re-frame.freehand.compiler.build/error (ex-data ex))))
-    (is (= :shop (:frame-id (ex-data ex))))
-    (is (= ["cf-a" "cf-b"] (:fingerprints (ex-data ex))))))
-
-(deftest cross-source-matching-plan-fingerprints-are-the-idempotent-no-op
-  ;; Two namespaces legitimately declaring the same frame plan (matching
-  ;; fingerprint) co-exist — the ratified idempotent no-op, re-derived at finish.
-  (let [seed (graph-state :app :compile-prepare '#{app.a app.b})
-        ok (-> (prepare seed '#{app.a app.b})
-               (seed-analyzer-plans 'app.a [[:shop "cf-same"]])
-               (seed-analyzer-plans 'app.b [[:shop "cf-same"]])
-               (finish '#{app.a app.b}))]
-    (is (= {:shop "cf-same"} (update-vals (plans ok) :config-fingerprint)))))
-
 (deftest a-root-id-transfers-cleanly-to-a-new-owner-via-the-carrier
   ;; app.old owned :shared/root; it is deleted and app.new takes it over. With
   ;; app.old absent from :build-sources the carrier fold sees only app.new's site,
@@ -480,65 +412,6 @@
     (is (= #{:shared/root} (set (keys (roots old)))))
     (is (= #{:shared/root} (set (keys (roots moved)))))))
 
-;; --- rf2-u53yy.1 S5: Root Descriptors ride the SAME synthetic carrier ----------
-;;
-;; The Root Descriptor index is the last registry folded onto the analyzer-map
-;; carrier (S5). `register-descriptor!` stamps `[::namespaces <ns>
-;; :rf.ui/root-plan-descriptor :descriptors]` at the same mount / hydrate site that
-;; stamps a `:roots` site, so the hook harvests the descriptor index from the carrier
-;; at compile-finish — for a cache-hit member the macro never re-runs, yet Shadow
-;; RESTORED the descriptor from disk, so `descriptor-index` reads it back.
-
-(deftest root-descriptors-survive-a-cache-hit-via-the-analyzer-carrier
-  ;; The S5 analog of the S4 root/plan carrier proof for the Root Descriptor index:
-  ;; a warm cache-hit source's macro never re-runs, yet its descriptor survives
-  ;; because Shadow RESTORED the synthetic carrier and the hook harvests the index
-  ;; from there — not from a macro side effect / the per-source slice.
-  (let [seed (graph-state :app :compile-prepare '#{app.a app.b})
-        ;; COLD: both compiled; each stamps its root + descriptor. Nothing is
-        ;; contributed to the slice (the macro is gated on the Shadow path), so a
-        ;; harvested descriptor here proves the analyzer-map carrier is the sole
-        ;; source.
-        cold (-> (prepare seed '#{app.a app.b})
-                 (seed-analyzer-roots 'app.a [[:page/a :authored]])
-                 (seed-analyzer-descriptors 'app.a [[:page/a :a]])
-                 (seed-analyzer-roots 'app.b [[:page/b :derived]])
-                 (seed-analyzer-descriptors 'app.b [[:page/b :b]])
-                 (finish '#{app.a app.b}))]
-    (is (= #{:page/a :page/b} (set (keys (root/descriptor-index cold))))
-        "cold: both descriptors are harvested from the analyzer-map carrier")
-    (is (= :a (:label (get (root/descriptor-index cold) :page/a)))
-        "cold: the harvested descriptor is the stamped Root Descriptor v1")
-    ;; WARM: only app.b recompiles. app.a is a cache HIT — its macro does NOT run
-    ;; (no re-seed this pass), but Shadow RESTORED its analyzer descriptor, which the
-    ;; threaded build-state carries unchanged.
-    (let [warm (-> (prepare cold '#{app.a app.b} '#{app.b})
-                   (seed-analyzer-roots 'app.b [[:page/b :derived]])
-                   (seed-analyzer-descriptors 'app.b [[:page/b :b]])
-                   (finish '#{app.a app.b} '#{app.b}))]
-      (is (= #{:page/a :page/b} (set (keys (root/descriptor-index warm))))
-          "warm: the cache-hit source's descriptor is RESTORED without the macro re-running")
-      (is (= :a (:label (get (root/descriptor-index warm) :page/a)))
-          "warm: the RESTORED descriptor is intact, byte-for-byte"))))
-
-(deftest a-removed-root-descriptor-is-evicted-from-the-analyzer-carrier
-  (let [seed (graph-state :app :compile-prepare '#{app.a app.b})
-        both (-> (prepare seed '#{app.a app.b})
-                 (seed-analyzer-roots 'app.a [[:page/a :authored]])
-                 (seed-analyzer-descriptors 'app.a [[:page/a :a]])
-                 (seed-analyzer-roots 'app.b [[:page/b :authored]])
-                 (seed-analyzer-descriptors 'app.b [[:page/b :b]])
-                 (finish '#{app.a app.b}))
-        ;; app.a is recompiled with its mount removed: Shadow's watch reset dissocs
-        ;; the whole ns entry, so its synthetic descriptor is gone. app.b is an
-        ;; untouched cache hit whose descriptor is restored.
-        removed (-> (prepare both '#{app.a app.b} '#{app.a})
-                    (forget-analyzer-ns 'app.a)
-                    (finish '#{app.a app.b} '#{app.a}))]
-    (is (= #{:page/a :page/b} (set (keys (root/descriptor-index both)))))
-    (is (= #{:page/b} (set (keys (root/descriptor-index removed))))
-        "a descriptor removed from its recompiled source is evicted from the carrier")))
-
 (deftest independent-build-states-never-cross-contribute
   (let [a (pass (graph-state :a :compile-prepare '#{app.view})
                 '#{app.view} [['app.view :app/view ["tf1-a" "hs1-a"]]])
@@ -546,39 +419,6 @@
                 '#{app.view} [['app.view :app/view ["tf1-b" "hs1-b"]]])]
     (is (= {:app/view ["tf1-a" "hs1-a"]} (views a)))
     (is (= {:app/view ["tf1-b" "hs1-b"]} (views b)))))
-
-(deftest descriptor-index-reads-one-coherent-explicit-accepted-snapshot
-  (let [a (-> (graph-state :a :compile-prepare '#{app.a})
-              (prepare '#{app.a})
-              (declare-view 'app.a :app.a/view ["tf1-a" "hs1-a"])
-              (declare-descriptor 'app.a :page/a :a)
-              (finish '#{app.a}))
-        b (-> (graph-state :b :compile-prepare '#{app.b})
-              (prepare '#{app.b})
-              (declare-view 'app.b :app.b/view ["tf1-b" "hs1-b"])
-              (declare-descriptor 'app.b :page/b :b)
-              (finish '#{app.b}))
-        a-index (root/descriptor-index a)
-        b-index (root/descriptor-index b)]
-    (is (= #{:page/a} (set (keys a-index))))
-    (is (= #{:page/b} (set (keys b-index))))
-
-    ;; A process-global fallback can contain unrelated data, but explicit
-    ;; retained-state reads remain build-local.
-    (build/begin-build! :fallback)
-    (build/contribute! build/descriptors 'fallback.ns :page/fallback
-                       {:rf.root/schema-version 1 :label :fallback})
-    (build/commit-build! :fallback)
-    (is (= #{:page/a} (set (keys (root/descriptor-index a)))))
-    (is (= #{:page/b} (set (keys (root/descriptor-index b)))))
-
-    ;; Stage a descriptor in disposable scratch. The ambient read must expose
-    ;; only accepted rows, never the candidate row from open scratch.
-    (let [open-a (-> a
-                     (prepare '#{app.a app.pending} '#{app.pending})
-                     (declare-descriptor 'app.pending :page/pending :pending))
-          ambient-index (read-in-compiler open-a #(root/descriptor-index))]
-      (is (= #{:page/a} (set (keys ambient-index)))))))
 
 ;; --- rf2-4vm19: the runtime removed-source projection wiring ----------------
 ;;

--- a/implementation/freehand/test/re_frame/freehand/compiler_build_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/compiler_build_jvm_test.clj
@@ -14,18 +14,18 @@
       source's contribution and keeps untouched sources; a WHOLE-build
       reconcile drops sources that did not re-declare; an ABORTED pass
       republishes the last-known-good, not a partial.
-    - ATOMICITY: `register-root-site!` / `register-plan-site!` check-then-write
-      inside ONE transition, so parallel compilation neither drops a
-      concurrent write nor misses a genuine duplicate.
+    - ATOMICITY: `register-root-site!` check-then-write inside ONE transition,
+      so parallel compilation neither drops a concurrent write nor misses a
+      genuine duplicate.
     - REPL UPSERT: with no pass open a contribution upserts one key straight
       into committed (no begin/commit cycle, no sibling eviction).
 
-  The mount-surface macros are client entry points (JVM-host expansion is a
-  compile error), so the Layer-1 / descriptor writes are driven the way
-  `re-frame.freehand.compiler.root/mount-form` drives them — `mount-site!` runs the
-  REAL assembly path. `defview` and `v/custom-element` run their real macro
-  bodies under a bound `*ns*` so distinct declaring namespaces (the ledger's
-  source key, rf2-df9873) are addressable."
+  On the Freehand door the client mount verbs (`v/mount` / `v/hydrate-root` /
+  `v/unmount!`) are runtime fns, so `v/render-static` is the only entry point
+  that indexes a root site — `register-root-site!` is driven directly here, the
+  way render-static drives it. `defview` and `v/custom-element` run their real
+  macro bodies under a bound `*ns*` so distinct declaring namespaces (the
+  ledger's source key, rf2-df9873) are addressable."
   (:require [cljs.env :as cljs-env]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.freehand.compiler :as compiler]
@@ -73,46 +73,22 @@
                                          {:line 1})
                               {} tag {:properties properties})))
 
-(def ^:private resolver
-  "Injected Q5 resolution stub for the root-form analyzer driven by
-  `mount-site!` (mirrors root-analysis-cljs-test's stub)."
-  (fn [sym]
-    (case sym
-      frame-root {:fqn 're-frame.freehand/frame-root :meta {}}
-      app-view   {:fqn 'app.views/app-view
-                  :meta {:rf.ui/view true :rf.ui/view-id :app.views/app-view}}
-      nil)))
-
-(defn- mount-site!
-  "Drive the REAL `mount-form` descriptor path for one root site owned by
-  `ns-sym` (file only feeds the error coords): analyze the LITERAL root form,
-  resolve identity, index the root-id + each EXTRACTED frame plan, and
-  contribute the Root Descriptor built by the actual `root/root-descriptor`
-  assembly — exactly the sequence a `v/mount` expansion performs."
-  [ns-sym file root-form opts]
-  (binding [*file* file]
-    (let [coords {:file file :line 1}
-          e (env/make-env {:host :clj :ns-sym 'app.test :resolver resolver})
-          {:keys [ast views plans]} (root/analyze-root e 'v/mount root-form)
-          {:keys [root-id provenance]} (root/resolve-root-identity
-                                        'v/mount opts views)]
-      (root/register-root-site! 'v/mount root-id provenance ns-sym coords)
-      (doseq [p plans] (root/register-plan-site! 'v/mount p ns-sym coords))
-      (root/register-descriptor! root-id
-                                 (root/root-descriptor
-                                  {:root-id root-id :provenance provenance
-                                   :views views :plans plans :ast ast})
-                                 ns-sym))))
+(defn- register-root!
+  "Index one root site owned by `ns-sym` the way `v/render-static` does — the
+  ONLY live Freehand entry point that indexes a root site (the client mount
+  verbs are runtime fns). `file` feeds the error coords."
+  [ns-sym file root-id provenance]
+  (root/register-root-site! 'v/render-static root-id provenance ns-sym
+                            {:file file :line 1}))
 
 (defn- snapshot
-  "The observable state of all five build registries for the ambient build.
-  The descriptor index is read through `root/descriptor-index`."
+  "The observable state of the build registries a live Freehand writer feeds:
+  views (`defview`), the Layer-1 root-site index (`v/render-static`), and the
+  custom-element property classification (`v/custom-element`)."
   []
-  {:views       (build/aggregate build/views)
-   :roots       (root/build-roots)
-   :plans       (root/build-plans)
-   :descriptors (root/descriptor-index)
-   :elements    (build/aggregate build/elements)})
+  {:views    (build/aggregate build/views)
+   :roots    (root/build-roots)
+   :elements (build/aggregate build/elements)})
 
 ;; ---------------------------------------------------------------------------
 ;; The pure-transition model itself (re-frame.freehand.compiler.build)
@@ -585,15 +561,15 @@
   (build/begin-build! :app)
   (build/begin-build! :node-test)
   (binding [build/*build-id* :app]
-    (root/register-root-site! 'v/mount :page/one :authored 'app.a
+    (root/register-root-site! 'v/render-static :page/one :authored 'app.a
                               {:file "app/a.cljs" :line 1}))
   ;; the node-test build compiles the SAME namespaces — its :page/one is a
   ;; different build's row, must not touch app's slice
   (binding [build/*build-id* :node-test]
-    (root/register-root-site! 'v/mount :page/one :authored 'ntest.x
+    (root/register-root-site! 'v/render-static :page/one :authored 'ntest.x
                               {:file "app/a.cljs" :line 1}))
   (binding [build/*build-id* :app]
-    (root/register-root-site! 'v/mount :page/two :authored 'app.b
+    (root/register-root-site! 'v/render-static :page/two :authored 'app.b
                               {:file "app/b.cljs" :line 1}))
   (is (= #{:page/one :page/two}
          (set (keys (build/aggregate build/roots :app))))
@@ -604,7 +580,7 @@
   (testing "app STILL detects its own cross-namespace duplicate"
     (is (thrown? clojure.lang.ExceptionInfo
                  (binding [build/*build-id* :app]
-                   (root/register-root-site! 'v/mount :page/one :authored 'app.c
+                   (root/register-root-site! 'v/render-static :page/one :authored 'app.c
                                              {:file "app/c.cljs" :line 1})))
         "a genuine duplicate in app fires — the interleaved build did not erase :page/one")))
 
@@ -649,7 +625,7 @@
                 (future
                   (binding [build/*build-id* b]
                     (root/register-root-site!
-                     'v/mount (keyword "page" (str (name b) "-" i))
+                     'v/render-static (keyword "page" (str (name b) "-" i))
                      :authored (symbol (str "ns." (name b) "." i))
                      {:file (str (name b) "-" i ".cljs") :line 1})))))]
     (run! deref futs)
@@ -671,7 +647,7 @@
                (future
                  (binding [build/*build-id* :app]
                    (try
-                     (root/register-root-site! 'v/mount :page/dup :authored
+                     (root/register-root-site! 'v/render-static :page/dup :authored
                                                (symbol (str "ns.dup." i))
                                                {:file (str "dup-" i ".cljs") :line 1})
                      :ok
@@ -688,27 +664,22 @@
         "exactly one root is committed")))
 
 ;; ---------------------------------------------------------------------------
-;; Integration — clean-vs-incremental parity across all five registries
+;; Integration — clean-vs-incremental parity across views, the root-site index,
+;; and custom-elements (the registries a live Freehand writer feeds)
 ;; ---------------------------------------------------------------------------
 
 (defn- declare-edited-source! []
-  ;; the EDITED namespace app.a: a renamed view, a different root + frame
-  ;; plan, a renamed custom-element (originally foo / :page/shop / :shop / :x-el)
+  ;; the EDITED namespace app.a: a renamed view, a different root, a renamed
+  ;; custom-element (originally foo / :page/shop / :x-el)
   (declare-view!   'app.a 'bar [:section "bar"])
-  (mount-site!     'app.a "app/a.cljs"
-                   '[frame-root {:id :cart :initial-events [[:cart/boot]]}
-                     [app-view {:promo :winter}]]
-                   {:root-id :page/cart})
+  (register-root!  'app.a "app/a.cljs" :page/cart :authored)
   (declare-element! 'app.a :y-el #{:label}))
 
 (deftest incremental-edit-equals-clean-build
   ;; 1) the ORIGINAL namespace app.a, built in this JVM
   (build/begin-build! :app)
   (declare-view!   'app.a 'foo [:div "foo"])
-  (mount-site!     'app.a "app/a.cljs"
-                   '[frame-root {:id :shop :initial-events [[:shop/boot]]}
-                     [app-view {:promo :spring}]]
-                   {:root-id :page/shop})
+  (register-root!  'app.a "app/a.cljs" :page/shop :authored)
   (declare-element! 'app.a :x-el #{:help-text})
   (build/commit-build! :app)
   ;; 2) EDIT app.a in the SAME JVM (no restart) — incremental rebuild
@@ -726,8 +697,6 @@
           "incremental output after edit/rename/delete EQUALS a clean build")
       (testing "no ghost of the pre-edit source survives"
         (is (= #{:page/cart} (set (keys (:roots incremental))))       "root :page/shop gone")
-        (is (= #{:cart} (set (keys (:plans incremental))))            "plan :shop gone")
-        (is (= #{:page/cart} (set (keys (:descriptors incremental)))) "descriptor :page/shop gone")
         (is (contains? (:elements incremental) :y-el))
         (is (not (contains? (:elements incremental) :x-el))          "custom-element :x-el gone")
         (is (= 1 (count (:views incremental)))                        "view foo gone, only bar")))))
@@ -738,73 +707,61 @@
   (dotimes [_ 25]
     (build/begin-build! :app)
     (declare-view! 'app.a 'only [:div "only"])
-    (mount-site!   'app.a "app/a.cljs" '[app-view {}] {:root-id :page/shop})
+    (register-root! 'app.a "app/a.cljs" :page/shop :authored)
     (build/commit-build! :app))
   (is (= 1 (count (build/aggregate build/views :app))) "views bounded across repeated rebuilds")
-  (is (= #{:page/shop} (set (keys (root/build-roots)))) "roots bounded")
-  (is (= #{:page/shop} (set (keys (build/aggregate build/descriptors :app)))) "descriptors bounded"))
+  (is (= #{:page/shop} (set (keys (root/build-roots)))) "roots bounded"))
 
 ;; ---------------------------------------------------------------------------
-;; The false cross-file duplicate/conflict from a DELETED site
+;; The false cross-file duplicate from a DELETED root site
 ;; ---------------------------------------------------------------------------
 
 (deftest deleted-root-site-does-not-falsely-duplicate-a-later-file
-  ;; original: app.a mounts :page/shop
+  ;; original: app.a registers :page/shop
   (build/begin-build! :app)
-  (root/register-root-site! 'v/mount :page/shop :authored 'app.a {:file "a.cljs" :line 1})
+  (register-root! 'app.a "a.cljs" :page/shop :authored)
   (build/commit-build! :app)
-  ;; edit app.a: the :page/shop site is DELETED (app.a now mounts :page/cart)
+  ;; edit app.a: the :page/shop site is DELETED (app.a now registers :page/cart)
   (build/begin-build! :app)
-  (root/register-root-site! 'v/mount :page/cart :authored 'app.a {:file "a.cljs" :line 1})
+  (register-root! 'app.a "a.cljs" :page/cart :authored)
   ;; app.b legitimately takes over the now-free :page/shop — the deleted
   ;; app.a site must NOT raise a false :rf.error/duplicate-root-id
-  (is (nil? (root/register-root-site! 'v/mount :page/shop :authored 'app.b
-                                      {:file "b.cljs" :line 1}))
+  (is (nil? (register-root! 'app.b "b.cljs" :page/shop :authored))
       "a deleted root site cannot fail a later file (rf2-df9873)")
   (build/commit-build! :app)
   (is (= #{:page/cart :page/shop} (set (keys (root/build-roots))))))
 
 (deftest genuine-current-cross-file-duplicate-still-fails
   (build/begin-build! :app)
-  (root/register-root-site! 'v/mount :page/dup :authored 'app.a {:file "a.cljs" :line 1})
-  (let [ex (try (root/register-root-site! 'v/mount :page/dup :authored 'app.b
-                                          {:file "b.cljs" :line 2})
+  (register-root! 'app.a "a.cljs" :page/dup :authored)
+  (let [ex (try (register-root! 'app.b "b.cljs" :page/dup :authored)
                 nil (catch clojure.lang.ExceptionInfo e e))]
     (is (some? ex) "two LIVE sites for one root-id still fail the build")
     (is (= :rf.error/duplicate-root-id (:rf.error/id (ex-data ex))))
     (is (= 2 (count (:sites (ex-data ex)))) "both current sites named with coords")))
 
-(deftest deleted-frame-plan-does-not-falsely-conflict-a-later-file
-  ;; original: app.a carries a :shop plan
-  (build/begin-build! :app)
-  (root/register-plan-site! 'v/mount {:frame-id :shop :config-fingerprint "cf1-a"}
-                            'app.a {:file "a.cljs" :line 1})
-  (is (contains? (root/build-plans) :shop))
-  (build/commit-build! :app)
-  ;; edit app.a: the :shop plan is DELETED — app.a now declares only a root
-  ;; (it no longer touches the plan registry at all). Re-touching app.a must
-  ;; still evict its stale :shop plan (cross-registry sweep at commit).
-  (build/begin-build! :app)
-  (root/register-root-site! 'v/mount :page/a :authored 'app.a {:file "a.cljs" :line 1})
-  (is (not (contains? (root/build-plans) :shop))
-      "re-touching the recompiled app.a evicted its dropped :shop plan")
-  ;; app.b now carries :shop with a DIFFERENT fingerprint — no false conflict
-  (is (nil? (root/register-plan-site! 'v/mount
-                                      {:frame-id :shop :config-fingerprint "cf1-b"}
-                                      'app.b {:file "b.cljs" :line 1}))
-      "a deleted plan cannot fail a later file's differing plan (rf2-df9873)")
-  (build/commit-build! :app)
-  (is (= "cf1-b" (:config-fingerprint (get (root/build-plans) :shop)))))
+;; ---------------------------------------------------------------------------
+;; Intra-form frame-plan conflict — the surviving compile-time frame-payload
+;; authority. The cross-FILE plan registry retired with the compiled mount door
+;; (no Freehand writer registers plan sites); `check-plan-set!` — reached by
+;; `v/render-static` through `analyze-root` — still rejects two plans for ONE
+;; frame-id carrying DIFFERING config fingerprints inside one root form. The
+;; runtime tier proves the same law at mount preflight
+;; (root_preflight_dom_cljs_test FH-ROOT-004).
+;; ---------------------------------------------------------------------------
 
-(deftest genuine-current-cross-file-plan-conflict-still-fails
-  (build/begin-build! :app)
-  (root/register-plan-site! 'v/mount {:frame-id :shop :config-fingerprint "cf1-a"}
-                            'app.a {:file "a.cljs" :line 1})
-  (let [ex (try (root/register-plan-site! 'v/mount
-                                          {:frame-id :shop :config-fingerprint "cf1-b"}
-                                          'app.b {:file "b.cljs" :line 2})
+(deftest intra-form-frame-plan-conflict-fails-in-check-plan-set
+  (is (= 1 (count (root/check-plan-set!
+                   'v/render-static
+                   [{:frame-id :shop :config {:a 1} :config-fingerprint "cf-a"}
+                    {:frame-id :shop :config {:a 1} :config-fingerprint "cf-a"}])))
+      "identical [frame-id fingerprint] pairs dedupe to one plan (idempotent no-op)")
+  (let [ex (try (root/check-plan-set!
+                 'v/render-static
+                 [{:frame-id :shop :config {:a 1} :config-fingerprint "cf-a"}
+                  {:frame-id :shop :config {:a 2} :config-fingerprint "cf-b"}])
                 nil (catch clojure.lang.ExceptionInfo e e))]
-    (is (some? ex) "two LIVE differing plans for one frame still fail the build")
+    (is (some? ex) "two DIFFERING plans for one frame-id in one root form fail")
     (is (= :rf.error/frame-payload-conflict (:rf.error/id (ex-data ex))))))
 
 ;; ---------------------------------------------------------------------------

--- a/spec/conformance/freehand/donor-inventory.md
+++ b/spec/conformance/freehand/donor-inventory.md
@@ -164,7 +164,7 @@ Every tracked file under `implementation/ui/src/`.
 | Donor row | What it is | Disposition | Slice | Status |
 |---|---|---|---|---|
 | `implementation/ui/src/re_frame/ui.cljc` | the donor public facade — `defview`, `custom-element`, `sub`, interop forms, `local`, `effect`, `ref`, `presence`, `route-link`, mount | REPLACE | F1 | pending |
-| `implementation/ui/src/re_frame/ui/client.cljs` | Root handle, live-root claim registry, mount / render! / hydrate-root / unmount! | MOVE | F1 | pending |
+| `implementation/ui/src/re_frame/ui/client.cljs` | Root handle, live-root claim registry, mount / render! / hydrate-root / unmount! — REPLACED by `re-frame.freehand.root`, which owns the whole client lifecycle behind the ratified runtime-fn mount door (no `create-root` / `render!`); the donor file stays as the re-frame.ui substrate's own | REPLACE | F1 | done |
 | `implementation/ui/src/re_frame/ui/compiler.cljc` | the declaration expansion pipeline: arity and options parsing, header analysis, manifest and fingerprint assembly, per-host emission | MOVE | F3 | done |
 | `implementation/ui/src/re_frame/ui/compiler/a11y.cljc` | compile-tier accessibility diagnostics minted from literal template facts | MOVE | F3 | done |
 | `implementation/ui/src/re_frame/ui/compiler/analyze.cljc` | the template-grammar analyzer and its closed normalized AST | MOVE | F3 | done |
@@ -187,7 +187,7 @@ Every tracked file under `implementation/ui/src/`.
 | `implementation/ui/src/re_frame/ui/reactive.cljc` | the ViewCell, the render-side probe/record protocol, the layout-commit reconciler, the lifecycle | MOVE | F2 | pending |
 | `implementation/ui/src/re_frame/ui/route_link_seam.cljc` | runtime helpers consuming the late-bound routing link-model and activate hooks | MOVE | F5 | pending |
 | `implementation/ui/src/re_frame/ui/rules.cljc` | the one DOM prop-conversion rule table shared by analyzers, emitters, and the JVM tree | MOVE | F3 | done |
-| `implementation/ui/src/re_frame/ui/runtime.cljs` | the small client vocabulary emitted code calls, including the one sanctioned runtime conversion | MOVE | F3 | pending |
+| `implementation/ui/src/re_frame/ui/runtime.cljs` | the small client vocabulary emitted code calls, including the one sanctioned runtime conversion — REPLACED by the shipped Freehand runtime; the donor file stays as the re-frame.ui substrate's own | REPLACE | F3 | done |
 | `implementation/ui/src/re_frame/ui/semantic.cljc` | semantic normalization — the parity and fingerprint input | MOVE | F1 | pending |
 | `implementation/ui/src/re_frame/ui/sub_overrides.cljs` | the React carriage for story-supplied subscription overrides | MOVE | F2 | pending |
 | `implementation/ui/src/re_frame/ui/substrate.cljs` | the first-party React adapter machinery, frame-context reader, and root-scoped adapter disposal | MOVE | F2 | pending |


### PR DESCRIPTION
Executes Mike's **DELETE** ruling (2026-07-24) on the Freehand mount surface.

## The ruling, reproduced

The runtime-fn mount door — `v/mount` / `v/hydrate-root` / `v/unmount!` as **fn** re-exports from `re-frame.freehand.root` (no `create-root`, no `render!`) — is the ratified Freehand architecture, and `re-frame.freehand.root` already owns the whole client lifecycle. The compiled mount surface it was measured against **was never wired**: its transplanted macro bodies lowered through the second CLJS emitter that a prior ruling already deleted (commit `8bd4560fe2`) and called into a `re-frame.freehand.client` namespace **that does not exist**, and no Freehand macro was ever bound to them. Ratifying the fn door therefore deletes a phantom, not a feature. `{:compiled true}` is a per-view declaration option that rides the view descriptor, so the runtime `v/mount` already renders compiled views through the compiled path (proven by the browser deftests) — there is no second mount engine for a compiled door to select.

The discriminator confirmed against the tree: **the only live caller of the compiler-root half from the facade is `render-static-form`.** Everything on the mount / create-root / hydrate-lowering path is dead.

## What this deletes (each confirmed zero live callers across `implementation/`)

`compiler/root.cljc`:
- `create-root-form` and its now-orphaned private helpers `parse-root-opts!`, `create-root-opt-keys`, the **compiler** `host-opt-keys` (the runtime `root.cljs` `host-opt-keys` is a separate def, untouched), `react-opts-form`, plus `goog-debug` / `dbg-quoted` / `expand-env!` orphaned by its removal;
- the production-dead Layer-1 plan/descriptor machinery: `register-plan-site!`, `register-descriptor!`, `build-plans`, `build-descriptors`, `descriptor-index`, the compile-time `root-descriptor` and its helpers `props-shape-entry` / `literal-edn?`.

**Kept** (live via `render-static`): `register-root-site!` + `build-roots`, `analyze-root` / `resolve-root-identity` / `check-plan-set!`, the `static-capability` proof chain, `render-static-form`. Stale docstrings claiming registration happens "exactly like mount / render! / hydrate-root" corrected — on this door only `render-static` registers a root site. The root-id grammar re-exports (`root-id-slug`, `default-identifier-prefix`, `scalar-disambiguator?`) are **kept**: a live two-tier parity test pins them, and they are not mount machinery.

## Tests re-anchored on the live writers (defview, custom-element, render-static)

- `compiler_build_jvm_test.clj`: removed the `mount-site!` helper whose docstring falsely claimed "exactly the sequence a v/mount expansion performs" (v/mount is a runtime fn and performs no expansion); the root-site index is now driven through `register-root-site!` the way `render-static` drives it, and the `where`-label `'v/mount` → `'v/render-static`. The two dead cross-**file** plan-conflict tests (they drove the deleted `register-plan-site!`) are replaced by one intra-form `check-plan-set!` test — the surviving compile-time frame-payload authority, the one `render-static` reaches through `analyze-root`. (The runtime tier still proves the same law at mount preflight: `root_preflight_dom_cljs_test` FH-ROOT-004.)
- `compiler_build_hook_jvm_test.clj`: the two mixed root+plan carrier tests reworked to roots-only; the plan-carrier and root-descriptor-carrier tests (which read through the deleted `register-plan-site!` / `register-descriptor!` / `descriptor-index`) removed.

## Donor ledger (F0c)

`ui/client.cljs` and `ui/runtime.cljs` re-rowed **REPLACE / done** — under this ruling they never move; `re-frame.freehand.root` owns the client lifecycle and the donor files stay as the re-frame.ui substrate's own. `check_donor_inventory.py` stays green.

## Out of scope (per the bead)

No facade / `spec/API.md` / api-manifest change — `spec/API.md` already ships `mount` / `hydrate-root` / `unmount!` as **Fn**, true of the tree. The `spec/004C` amendment is a separate hot-zone bead (rf2-d2pz3). Follow-up filed for the now-unfed `build.cljc` plan/descriptor carrier (register-plan-site!/register-descriptor! were its only writers).

## Quality gates

All foreground, on the current rebased base (`origin/main` `89b6291912`). Config banner confirmed each shadow-cljs run used this worktree.

| Gate | Result | Exit |
|---|---|---|
| freehand `clojure -M:test` (JVM) | 869 tests / 6269 assertions, 0 failures | 0 |
| `npm run test:freehand` (node CLJS) | 890 tests / 5342 assertions, 0 failures, 0 warnings | 0 |
| `npm run test:cljs` (node CLJS) | 11015 tests / 55467 assertions, 0 failures, 0 warnings | 0 |
| `npm run test:browser` (Playwright) | 691 tests / 4247 assertions, 0 failures | 0 |
| core `clojure -M:test` (error-catalogue) | 2104 tests / 10415 assertions, 0 failures | 0 |
| `check_donor_inventory.py` | green | 0 |
| `check_doc_slugs.py` | green | 0 |
| `python -m mkdocs build --strict` | built | 0 |

### Before / after test counts (the deletion's decrease, accounted exactly)

Directly measured on the freehand JVM suite at the pre-rebase base:
**before 865 tests / 6259 assertions → after 859 / 6233** — a decrease of **−6 tests / −26 assertions**, entirely from removing tests of the deleted dead machinery:

- `compiler_build_jvm_test.clj`: **−2** dead cross-file plan-conflict tests (`deleted-frame-plan-does-not-falsely-conflict-a-later-file`, `genuine-current-cross-file-plan-conflict-still-fails`, both driving the deleted `register-plan-site!`), **+1** new intra-form `check-plan-set!` test → net **−1**.
- `compiler_build_hook_jvm_test.clj`: **−5** tests exercising the deleted plan/descriptor analyzer-carrier (`cross-source-frame-payload-conflict-fails-at-compile-finish`, `cross-source-matching-plan-fingerprints-are-the-idempotent-no-op`, `root-descriptors-survive-a-cache-hit-via-the-analyzer-carrier`, `a-removed-root-descriptor-is-evicted-from-the-analyzer-carrier`, `descriptor-index-reads-one-coherent-explicit-accepted-snapshot`); the two mixed root+plan tests were reworked to roots-only (kept) → net **−5**.

On the current rebased base the same delta holds: the suite runs **869 / 6269** with this change (the 27 intervening merges added ~10 deftests / ~36 assertions to unrelated freehand tests; my files are untouched by those merges).

The browser gate's `pilot_virtual_table` scroll test failed only against a 27-commit-stale base; on the current base it passes — that surface is entirely outside this compiler-only diff.
