### PR TITLE
fix(freehand): deterministic scroll-settle in pilot_virtual_table (rf2-eq2vx)

### DIFF
--- a/implementation/freehand/test/re_frame/freehand/pilot_virtual_table_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/pilot_virtual_table_dom_cljs_test.cljs
@@ -91,6 +91,27 @@
   (cell/flush!)
   (tick))
 
+(defn- await-settle!
+  "Deterministic scroll-settle. A REAL scrollbar drag dispatches an
+  ASYNC re-frame event; a single `settle!` tick was comfortable on an
+  idle CI runner but marginal on this machine's six concurrent worker
+  agents (shadow-cljs + Chromium) and on a loaded CI runner — so the old
+  assertion was timing the MACHINE, not the window (rf2-eq2vx: scroll-top
+  nil, 25 rows not 29, window unmoved).
+
+  Instead of assuming the settle happened after one macrotask, flush the
+  cells' pending window on every probe and POLL — up to a generous bound —
+  until `pred` reports the scroll's dispatch has landed in app-db AND the
+  next paint has committed the expected window to the document. The
+  caller then asserts the EXACT window off a state it KNOWS has settled,
+  rather than racing it. Returns a `js/Promise` that composes with the
+  `.then` chain; on a genuinely stuck state it rejects after the bound
+  and the caller's `.catch` reds with the timeout label."
+  [pred label]
+  (test-support/poll-until
+    (fn [] (cell/flush!) (pred))
+    {:timeout-ms 8000 :interval-ms 10 :label label}))
+
 (defn- host-node! []
   (let [container (js/document.createElement "div")]
     (.appendChild js/document.body container)
@@ -183,6 +204,14 @@
   (.dispatchEvent node (js/Event. "scroll" #js {:bubbles false :cancelable false}))
   nil)
 
+(defn- ledger-scroll-top
+  "The offset the `::v/scroll-top` projection has committed to app-db for
+  the ledger table — the signal a real scroll's async dispatch has
+  actually landed. `nil` until it does (which is exactly the flake
+  signature the deterministic settle waits out)."
+  []
+  (get-in (frame/frame-app-db-value fid) [ui/tables-root ui/ledger-key :scroll-top]))
+
 ;; ===========================================================================
 ;; The mount
 ;; ===========================================================================
@@ -241,7 +270,14 @@
                        (swap! state assoc :mounted mounted)
                        (live!)
                        (scroll-to! (viewport container) 3200)
-                       (settle!)))
+                       ;; Wait for the settle rather than assuming it: the
+                       ;; async dispatch must reach app-db (offset 3200) and
+                       ;; the paint must commit the 29-row window before the
+                       ;; assertions read it.
+                       (await-settle!
+                         #(and (= 3200 (ledger-scroll-top))
+                               (= 29 (count (row-nodes container))))
+                         "real scroll to 3200 settles into a 29-row window")))
               (.then (fn [_]
                        (is (= 3200 (.-scrollTop (viewport container)))
                            "the viewport really did scroll to 3200")
@@ -258,7 +294,13 @@
                        ;; twenty-eight elements.
                        (swap! state assoc :before (rows-by-key container))
                        (scroll-to! (viewport container) 3232)
-                       (settle!)))
+                       ;; Same discipline for the one-row advance: wait until
+                       ;; the offset reaches 3232 and the window's first row
+                       ;; is r97, then assert the exact advanced window.
+                       (await-settle!
+                         #(and (= 3232 (ledger-scroll-top))
+                               (= "r97" (first (row-keys container))))
+                         "one more row of scroll advances the window to r97")))
               (.then (fn [_]
                        (let [before (:before @state)
                              after  (rows-by-key container)
@@ -360,7 +402,16 @@
                        (live!)
                        (scroll-to! (viewport a) 3200)
                        (scroll-to! (viewport b) 3200)
-                       (settle!)))
+                       ;; Both arms drag a real scrollbar to the same offset;
+                       ;; wait for that offset to land in app-db and for both
+                       ;; documents to hold their 29-row window before the
+                       ;; parity assertion reads them (same flake class as
+                       ;; rf2-eq2vx — deterministic settle, not a fixed tick).
+                       (await-settle!
+                         #(and (= 3200 (ledger-scroll-top))
+                               (= 29 (count (row-nodes a)))
+                               (= 29 (count (row-nodes b))))
+                         "both arms scroll to 3200 and settle into 29-row windows")))
               (.then (fn [_]
                        (is (= 3200 (get-in (frame/frame-app-db-value fid)
                                            [ui/tables-root ui/ledger-key :scroll-top]))


### PR DESCRIPTION
Fixes the intermittent browser-lane failure `rf2-eq2vx`: the real-scroll assertions in `pilot_virtual_table_dom_cljs_test.cljs` dragged a REAL scrollbar to a fixed offset and asserted the resulting window after a single `settle!` macrotask. That one tick was comfortable on an idle CI runner but marginal under concurrent load (six worker agents each running shadow-cljs + Chromium, plus a loaded CI runner), so the scroll's **async** dispatch had not reached app-db when the assertions ran. The signature was always identical — scroll-top `nil`, 25 rows instead of 29, window unmoved at r0..r24 — and it redded three unrelated PRs at merge time (#6804, #6812, #6815).

## The fix

Make the settle **deterministic** instead of assuming it happened. A new local `await-settle!` helper flushes the cells' pending window on every probe and polls (via the existing `re-frame.test-support/poll-until`, generous 8s bound / 10ms interval) until the scroll's dispatch has actually reached app-db through the `::v/scroll-top` projection **and** the next paint has committed the expected window to the document. Only then does the caller assert the EXACT window.

The failure mode is now **unreachable, not merely unobserved**: the assertion reads the real app-db `[tables-root ledger-key :scroll-top]` projection and waits for it to equal the dragged offset before proceeding — the very value whose absence (`nil`) was the flake. The window assertions are unchanged and still exact (25/29 rows, keys `r96..r124` / `r97..r125`, committed row count, element identity across a re-render). The test now *waits* for the settle rather than racing it.

Applied to both real-scroll tests in the file: the reported `a-real-scroll-moves-the-window-and-leaves-the-surviving-rows-alone`, and the structurally identical `promotion-changes-nothing-about-the-mounted-table` (promotion-parity), which shared the same latent hazard and would have been the next flake on the merge path. No production source changed — the fix lives entirely in the test's wait discipline (`pilot_virtual_table.cljc` is untouched).

## Quality gates

Run from the `scroll-flake-eq2vx` worktree; the shadow-cljs `config:` banner in every log names that worktree.

- **`npm run test:browser` (full gate, post-rebase onto origin/main): EXIT=0** — `Ran 695 tests containing 4267 assertions. 0 failures, 0 errors.`
- **10 consecutive browser run-phase executions against the compiled build: the pilot scroll test passed in all 10.** The only failure anywhere in the sweep was run 7's unrelated `query-cycles-are-collectible-in-the-real-browser-heap`, which failed because the Playwright `requestGC` handshake was absent — an infrastructure hiccup, not a scroll assertion. Run 7 was also the only run to hit a `page.goto: Timeout 30000ms exceeded` at startup, i.e. that run was demonstrably under load, and the scroll test stayed green through it. That GC-collectibility flake is a separate test outside this change's surface.
- **Structural proof the wait is real (delay injection):** with a 600ms artificial delay injected into every scroll-event dispatch — which under the old single-tick `settle!` reproduces the exact flake signature (scroll-top `nil`, 25 rows) — the full suite is **still green (EXIT=0, 0 failures)**. The poll waited out the delay and then asserted the correct window; it does not assert early.
- **Non-vacuity proof:** temporarily changing the window assertion to expect 30 rows (while the poll predicate still waits for the correct 29-row settle) reds with exactly `1 failures, 0 errors` at `FAIL in (a-real-scroll-moves-the-window...) expected: (= 30 (count (row-nodes container)))`. The wait did not make the test accept anything — it still asserts the exact window. Restored byte-identical.

Counting the post-rebase full gate plus the 10 run-phase executions, the scroll test was green across 11 consecutive real-browser runs (12 including the pre-rebase baseline), including one run under demonstrable load.
