### PR TITLE
fix(ci): invariant-job reproduce commands honour self-test mode + exhaustive step guard (rf2-m6kdb)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -554,8 +554,16 @@ jobs:
       # (minus any `_selftest`) equals the script stem, and that an id ends
       # `_selftest` IFF its real command carries `--self-test` (so both the
       # derived command and the id-only fallback pick the same live-vs-self-test
-      # mode). Self-test first (proves it fires on the mode-mismatch + drift
-      # shapes), then the live scan asserts this workflow is clean. See
+      # mode). Because the guard exists to protect the aggregation contract, it
+      # discovers checker steps INDEPENDENTLY of their id (by their
+      # `python scripts/check_*.py` run shape within this job) and additionally
+      # requires every one to carry a unique `check_*` id and
+      # `continue-on-error: true` — a checker with no id is invisible to
+      # `toJSON(steps)` so its failure is unreported (the job goes green), and
+      # one missing `continue-on-error` restores short-circuiting so the later
+      # invariants never run. Self-test first (proves it fires on the
+      # mode-mismatch, no-id, missing-continue-on-error, and drift shapes), then
+      # the live scan asserts this workflow is clean. See
       # scripts/check_ci_reproduce_commands.py.
       - name: Self-test the reproduce-command integrity guard
         id: check_ci_reproduce_commands_selftest

--- a/scripts/check_ci_reproduce_commands.py
+++ b/scripts/check_ci_reproduce_commands.py
@@ -4,10 +4,10 @@ each checker step's real invocation.
 
 Provenance: rf2-m6kdb. The aggregated invariant job
 (`.github/workflows/test.yml`, job id `verify-skill-mcp-drift`, displayed as
-"Repo invariant checks (...)") runs ~35 `python scripts/check_*.py` checkers,
-each with `continue-on-error: true` and an `id`; a final step prints every
-failure with a local "reproduce with" command. The first cut derived that
-command from the step id alone:
+"Repo invariant checks (...)") runs ~37 `python scripts/check_*.py` checkers,
+each with `continue-on-error: true` and an `id`; a final step reads
+`toJSON(steps)` and prints every failure with a local "reproduce with" command.
+The first cut derived that command from the step id alone:
 
     script="scripts/${id%_selftest}.py"
     ... reproduce with: python $script
@@ -25,7 +25,19 @@ The durable fix has two halves, both in `.github/workflows/test.yml`:
      it cannot drift from what the step runs, because it is read from the step.
 
   2. STRUCTURAL GUARD (this script's default `--check` mode, wired as its own
-     checker in the same job). It asserts, over every checker step, that:
+     checker in the same job). The guard's whole job is to protect the
+     aggregation contract, so it must see EVERY checker step -- including a
+     malformed one that would slip past the aggregator. It therefore discovers
+     checker steps INDEPENDENTLY of their id: a step is a checker if it carries a
+     `check_*` id OR its inline `run:` is a `python scripts/check_*.py`
+     invocation (so a checker that FORGOT its id is still seen). Over every such
+     step it asserts:
+       * a unique `check_*` id -- a checker with no id (or a duplicate id) never
+         appears in GitHub's `toJSON(steps)` map, so a `continue-on-error`
+         failure there is invisible to the aggregator and the job goes GREEN;
+       * `continue-on-error: true` -- a checker missing it restores `bash -e`
+         short-circuiting, so a failure there stops the job and the later
+         invariant checkers never run (the report is then incomplete);
        * the `run:` is a single-line `python scripts/<name>.py ...` invocation
          (so `--emit` can always resolve it -- a block-scalar run would leave the
          aggregator unable to derive a command);
@@ -72,9 +84,16 @@ _STEP_RE = re.compile(r"^      - ")
 _ID_RE = re.compile(r"^        id:\s*(\S+)\s*$")
 _RUN_INLINE_RE = re.compile(r"^        run:\s*(\S.*?)\s*$")
 _RUN_BLOCK_RE = re.compile(r"^        run:\s*[|>][-+0-9]*\s*$")
+_CONTINUE_RE = re.compile(r"^        continue-on-error:\s*(\S+)\s*$")
 
 # scripts/<name>.py somewhere in a run command.
 _SCRIPT_RE = re.compile(r"\bscripts/([A-Za-z0-9_]+)\.py\b")
+
+# The run shape that identifies a checker step INDEPENDENTLY of its id: an inline
+# `python scripts/check_<name>.py ...` invocation. This is the "explicit
+# boundary" that lets the guard see a checker even when it FORGOT its id -- the
+# exact hole the id-only filter left open (rf2-m6kdb audit reopen, PR #6815).
+_CHECKER_RUN_RE = re.compile(r"^python scripts/check_[A-Za-z0-9_]+\.py(?:\s|$)")
 
 
 def _slurp_job_lines(text: str) -> list[str] | None:
@@ -95,15 +114,18 @@ def _slurp_job_lines(text: str) -> list[str] | None:
     return lines[start:end]
 
 
-def parse_checker_steps(text: str) -> tuple[bool, list[dict]]:
-    """Parse the invariant job's checker steps.
+def parse_job_steps(text: str) -> tuple[bool, list[dict]]:
+    """Parse EVERY step of the invariant job block.
 
     Returns (job_found, steps). Each step is a dict with keys `id`, `run`
-    (the inline command string, or None), and `run_is_block` (True when the
-    step used a block-scalar `run:` we deliberately refuse to flatten).
+    (the inline command string, or None), `run_is_block` (True when the step
+    used a block-scalar `run:` we deliberately refuse to flatten), and
+    `continue_on_error` (True only when the step declared
+    `continue-on-error: true`).
 
-    Only steps whose `id` starts with `check_` are returned -- those are the
-    invariant checkers. The final report step has no `id`, so it is excluded.
+    Unlike a filter-by-id parse, this returns the checkout/setup/report steps
+    too -- discovery of which steps are *checkers* is a separate concern (see
+    `discover_checker_steps`) so a checker that forgot its id is still visible.
     """
     job = _slurp_job_lines(text)
     if job is None:
@@ -115,13 +137,22 @@ def parse_checker_steps(text: str) -> tuple[bool, list[dict]]:
         if _STEP_RE.match(line):
             if cur is not None:
                 steps.append(cur)
-            cur = {"id": None, "run": None, "run_is_block": False}
+            cur = {
+                "id": None,
+                "run": None,
+                "run_is_block": False,
+                "continue_on_error": False,
+            }
             continue
         if cur is None:
             continue
         m = _ID_RE.match(line)
         if m:
             cur["id"] = m.group(1)
+            continue
+        m = _CONTINUE_RE.match(line)
+        if m:
+            cur["continue_on_error"] = m.group(1) == "true"
             continue
         if _RUN_BLOCK_RE.match(line):
             cur["run_is_block"] = True
@@ -134,16 +165,40 @@ def parse_checker_steps(text: str) -> tuple[bool, list[dict]]:
     if cur is not None:
         steps.append(cur)
 
-    checkers = [
-        s for s in steps if s["id"] and s["id"].startswith(CHECKER_ID_PREFIX)
-    ]
-    return (True, checkers)
+    return (True, steps)
+
+
+def is_checker_step(step: dict) -> bool:
+    """A step is a checker iff it carries a `check_*` id OR its inline `run:` is
+    a `python scripts/check_*.py` invocation.
+
+    The run-shape arm is what makes the guard exhaustive: it catches a checker
+    that forgot its id (invisible to an id-only filter), while still excluding
+    the id-less block-scalar report step and the checkout/setup steps (which
+    have no inline `python scripts/check_*.py` run)."""
+    sid = step.get("id")
+    if sid and sid.startswith(CHECKER_ID_PREFIX):
+        return True
+    run = step.get("run")
+    return bool(run) and not step.get("run_is_block") and bool(_CHECKER_RUN_RE.match(run))
+
+
+def discover_checker_steps(steps: list[dict]) -> list[dict]:
+    """The checker steps among all of the job's steps, discovered by shape."""
+    return [s for s in steps if is_checker_step(s)]
+
+
+# Back-compat alias: earlier callers spoke of "checker steps" as the parse unit.
+def parse_checker_steps(text: str) -> tuple[bool, list[dict]]:
+    """(found, checker_steps) -- parse the job, then keep only the checkers."""
+    found, steps = parse_job_steps(text)
+    return (found, discover_checker_steps(steps) if found else [])
 
 
 def emit_command(step_id: str, text: str) -> str | None:
     """The exact single-line `run:` command for `step_id`, or None if it has no
-    single-line checker run (unknown id, or a block-scalar run)."""
-    found, steps = parse_checker_steps(text)
+    single-line run (unknown id, or a block-scalar run)."""
+    found, steps = parse_job_steps(text)
     if not found:
         return None
     for s in steps:
@@ -168,18 +223,59 @@ def fallback_command(step_id: str) -> str:
 
 
 def audit_steps(steps: list[dict], exists=None) -> list[str]:
-    """Return a list of human-readable problems (empty == clean)."""
+    """Return a list of human-readable problems over the given CHECKER steps
+    (empty == clean). Pass the output of `discover_checker_steps` -- the steps
+    are audited as-is; discovery is the caller's job (or use `audit_job`)."""
     if exists is None:
         exists = lambda p: pathlib.Path(p).exists()
 
     problems: list[str] = []
-    for s in steps:
-        sid = s["id"]
-        run = s["run"]
 
-        if s["run_is_block"] or not run:
+    # Duplicate `check_*` ids collide in GitHub's `toJSON(steps)` map, so only
+    # one outcome survives -- a failure in the shadowed twin is unreported.
+    counts: dict[str, int] = {}
+    for s in steps:
+        sid = s.get("id")
+        if sid:
+            counts[sid] = counts.get(sid, 0) + 1
+    for dup in sorted(i for i, n in counts.items() if n > 1):
+        problems.append(
+            f"{dup}: duplicate checker id (appears {counts[dup]}x); ids must be "
+            f"unique so toJSON(steps) records every checker's outcome"
+        )
+
+    for s in steps:
+        sid = s.get("id")
+        run = s.get("run")
+        label = sid if sid else f"<no-id step: {run!r}>"
+
+        # (1) A unique `check_*` id. A checker with no id (or a non-check id)
+        # never appears in toJSON(steps), so a continue-on-error failure there is
+        # invisible to the aggregator and the job goes green (rf2-m6kdb).
+        has_valid_id = bool(sid) and sid.startswith(CHECKER_ID_PREFIX)
+        if not has_valid_id:
             problems.append(
-                f"{sid}: checker step has a block-scalar/empty `run:`; the "
+                f"{label}: checker step has no `id: check_*` (run {run!r}); "
+                f"without an id it is absent from toJSON(steps), so a "
+                f"continue-on-error failure here is invisible to the aggregator "
+                f"and the job goes green"
+            )
+
+        # (2) `continue-on-error: true`. A checker missing it restores bash
+        # short-circuiting, so a failure there stops the job and the later
+        # invariant checkers never run (rf2-m6kdb).
+        if not s.get("continue_on_error"):
+            problems.append(
+                f"{label}: checker step is missing `continue-on-error: true`; "
+                f"without it a failure short-circuits the job and the later "
+                f"invariant checkers never run"
+            )
+
+        # (3) A single-line `python scripts/<name>.py ...` run the aggregator's
+        # --emit can parse into a reproduce command.
+        if s.get("run_is_block") or not run:
+            problems.append(
+                f"{label}: checker step has a block-scalar/empty `run:`; the "
                 f"aggregator cannot derive a reproduce command from it. Make it "
                 f"a single-line `run: python scripts/<x>.py ...`, or teach "
                 f"scripts/check_ci_reproduce_commands.py the new shape."
@@ -188,20 +284,25 @@ def audit_steps(steps: list[dict], exists=None) -> list[str]:
 
         if not run.startswith("python scripts/"):
             problems.append(
-                f"{sid}: `run:` is not a `python scripts/...` invocation: {run!r}"
+                f"{label}: `run:` is not a `python scripts/...` invocation: {run!r}"
             )
             continue
 
         m = _SCRIPT_RE.search(run)
         if not m:
             problems.append(
-                f"{sid}: no scripts/<name>.py found in `run:` {run!r}"
+                f"{label}: no scripts/<name>.py found in `run:` {run!r}"
             )
             continue
         script_stem = m.group(1)
         script_path = f"scripts/{script_stem}.py"
         if not exists(script_path):
-            problems.append(f"{sid}: referenced {script_path} does not exist")
+            problems.append(f"{label}: referenced {script_path} does not exist")
+
+        # The remaining checks are id-derived; a no-id step is already flagged
+        # by (1), so skip them rather than double-reporting on a missing id.
+        if not has_valid_id:
+            continue
 
         id_base = (
             sid[: -len(SELFTEST_SUFFIX)] if sid.endswith(SELFTEST_SUFFIX) else sid
@@ -234,26 +335,34 @@ def audit_steps(steps: list[dict], exists=None) -> list[str]:
     return problems
 
 
+def audit_job(steps: list[dict], exists=None) -> list[str]:
+    """Discover the checker steps among ALL of the job's steps, then audit them.
+    This is the entry point the live scan and self-tests use -- it exercises the
+    id-independent discovery that makes the guard exhaustive."""
+    return audit_steps(discover_checker_steps(steps), exists=exists)
+
+
 def run_live(verbose: bool) -> int:
     if not WORKFLOW.exists():
         sys.stderr.write(f"ERROR: {WORKFLOW} not found (run from the repo root)\n")
         return 1
     text = WORKFLOW.read_text(encoding="utf-8")
-    found, steps = parse_checker_steps(text)
+    found, steps = parse_job_steps(text)
     if not found:
         sys.stderr.write(
             f"ERROR: job id '{JOB_ID}' not found in {WORKFLOW}; the parser "
             f"cannot locate the invariant checkers.\n"
         )
         return 1
-    if len(steps) < 2:
+    checkers = discover_checker_steps(steps)
+    if len(checkers) < 2:
         sys.stderr.write(
-            f"ERROR: found only {len(steps)} checker step(s) under '{JOB_ID}'; "
-            f"the parser is almost certainly broken.\n"
+            f"ERROR: found only {len(checkers)} checker step(s) under "
+            f"'{JOB_ID}'; the parser is almost certainly broken.\n"
         )
         return 1
 
-    problems = audit_steps(steps)
+    problems = audit_steps(checkers)
     if problems:
         sys.stderr.write(
             f"{len(problems)} reproduce-command mismatch(es) in {WORKFLOW}:\n"
@@ -264,14 +373,15 @@ def run_live(verbose: bool) -> int:
 
     if verbose:
         print(
-            f"{len(steps)} checker steps; every reproduce command matches its "
+            f"{len(checkers)} checker steps; every one carries a unique check_* "
+            f"id + continue-on-error, and every reproduce command matches its "
             f"step's script + live-vs-self-test mode:"
         )
-        for s in steps:
+        for s in checkers:
             print(f"  {s['id']}: {s['run']}")
     else:
         print(
-            f"reproduce-command contract clean: {len(steps)} checker steps in sync."
+            f"reproduce-command contract clean: {len(checkers)} checker steps in sync."
         )
     return 0
 
@@ -291,56 +401,105 @@ def run_self_tests(verbose: bool) -> int:
     # A fake on-disk oracle so fixtures need no real script files.
     exists_ok = lambda p: p in {"scripts/check_foo.py", "scripts/check_bar.py"}
 
-    def step(sid, run=None, block=False):
-        return {"id": sid, "run": run, "run_is_block": block}
+    def step(sid, run=None, block=False, coe=True):
+        return {
+            "id": sid,
+            "run": run,
+            "run_is_block": block,
+            "continue_on_error": coe,
+        }
 
     # Conformant: a live checker + its self-test twin.
     conformant = [
         step("check_foo", "python scripts/check_foo.py --verbose --ci"),
         step("check_foo_selftest", "python scripts/check_foo.py --self-test"),
     ]
-    check("conformant live+selftest pair passes", audit_steps(conformant, exists_ok) == [])
+    check("conformant live+selftest pair passes", audit_job(conformant, exists_ok) == [])
 
     # A bare live checker with no flags (the check_skill_redirect_anchors shape).
     check(
         "bare live checker (no flags) passes",
-        audit_steps([step("check_foo", "python scripts/check_foo.py")], exists_ok) == [],
+        audit_job([step("check_foo", "python scripts/check_foo.py")], exists_ok) == [],
     )
 
     # THE rf2-m6kdb DEFECT: a `_selftest` id whose run drops `--self-test`.
     check(
         "selftest id missing --self-test FIRES",
-        len(audit_steps([step("check_foo_selftest", "python scripts/check_foo.py --verbose")], exists_ok)) >= 1,
+        len(audit_job([step("check_foo_selftest", "python scripts/check_foo.py --verbose")], exists_ok)) >= 1,
     )
 
     # The mirror: a live id whose run carries `--self-test`.
     check(
         "live id carrying --self-test FIRES",
-        len(audit_steps([step("check_foo", "python scripts/check_foo.py --self-test")], exists_ok)) >= 1,
+        len(audit_job([step("check_foo", "python scripts/check_foo.py --self-test")], exists_ok)) >= 1,
     )
 
     # id stem does not match the script it runs.
     check(
         "id/script stem mismatch FIRES",
-        len(audit_steps([step("check_foo", "python scripts/check_bar.py --verbose")], exists_ok)) >= 1,
+        len(audit_job([step("check_foo", "python scripts/check_bar.py --verbose")], exists_ok)) >= 1,
     )
 
     # Referenced script does not exist on disk.
     check(
         "missing script file FIRES",
-        len(audit_steps([step("check_missing", "python scripts/check_missing.py --verbose")], exists_ok)) >= 1,
+        len(audit_job([step("check_missing", "python scripts/check_missing.py --verbose")], exists_ok)) >= 1,
     )
 
     # A block-scalar run the aggregator could not derive a command from.
     check(
         "block-scalar run FIRES",
-        len(audit_steps([step("check_foo", None, block=True)], exists_ok)) >= 1,
+        len(audit_job([step("check_foo", None, block=True)], exists_ok)) >= 1,
     )
 
     # A run that is not a python-scripts invocation at all.
     check(
         "non python-scripts run FIRES",
-        len(audit_steps([step("check_foo", "bash -c true")], exists_ok)) >= 1,
+        len(audit_job([step("check_foo", "bash -c true")], exists_ok)) >= 1,
+    )
+
+    # --- rf2-m6kdb EXHAUSTIVENESS (audit reopen, PR #6815) ---------------------
+    # The guard must catch a checker discovered INDEPENDENTLY of its id. These
+    # are the two exact negative fixtures the bead names.
+    #
+    # (A) A python checker with `continue-on-error: true` but NO id. An id-only
+    # filter never sees it, so a failure there is absent from toJSON(steps) and
+    # the job goes green. Discovery-by-run-shape must surface it; the audit then
+    # fires on the missing id.
+    check(
+        "no-id python checker FIRES (discovered by run shape)",
+        len(audit_job([step(None, "python scripts/check_foo.py --verbose", coe=True)], exists_ok)) >= 1,
+    )
+    # (B) An id'd `check_bar` with NO `continue-on-error`. It restores bash
+    # short-circuiting, so later invariants never run. The audit must fire even
+    # though every other property (id, script, mode) is conformant.
+    check(
+        "checker missing continue-on-error FIRES",
+        len(audit_job([step("check_bar", "python scripts/check_bar.py", coe=False)], exists_ok)) >= 1,
+    )
+    # Control: the no-id + continue-on-error step above, but with a valid id and
+    # continue-on-error, must stay green (the guard fires on the DEFECT, not the
+    # shape of a bare invocation).
+    check(
+        "no-id fixture with an id + continue-on-error passes",
+        audit_job([step("check_foo", "python scripts/check_foo.py --verbose", coe=True)], exists_ok) == [],
+    )
+    # A duplicate checker id shadows a twin in toJSON(steps).
+    check(
+        "duplicate checker id FIRES",
+        len(audit_job([
+            step("check_foo", "python scripts/check_foo.py"),
+            step("check_foo", "python scripts/check_foo.py"),
+        ], exists_ok)) >= 1,
+    )
+    # The id-less block-scalar report step (and checkout/setup steps) must NOT be
+    # mistaken for a checker -- discovery excludes them, so a clean job of one
+    # conformant checker plus a report step audits clean.
+    report = step(None, None, block=True)
+    check(
+        "id-less block-scalar report step is not a discovered checker",
+        discover_checker_steps([step("check_foo", "python scripts/check_foo.py"), report])
+        == [step("check_foo", "python scripts/check_foo.py")],
     )
 
     # fallback_command is mode-correct for both shapes.
@@ -357,13 +516,24 @@ def run_self_tests(verbose: bool) -> int:
     # the live audit is clean, and --emit round-trips a real selftest + live id.
     if WORKFLOW.exists():
         text = WORKFLOW.read_text(encoding="utf-8")
-        found, real_steps = parse_checker_steps(text)
+        found, all_steps = parse_job_steps(text)
+        real_checkers = discover_checker_steps(all_steps)
         check("parser locates the job in the real workflow", found)
-        check("parser finds >= 30 checker steps in the real workflow", len(real_steps) >= 30)
-        check("real workflow audit is clean", audit_steps(real_steps) == [])
+        check("parser finds >= 30 checker steps in the real workflow", len(real_checkers) >= 30)
+        check("every real checker has a check_* id", all(
+            s["id"] and s["id"].startswith(CHECKER_ID_PREFIX) for s in real_checkers
+        ))
+        check("every real checker is continue-on-error: true", all(
+            s["continue_on_error"] for s in real_checkers
+        ))
+        check("real workflow audit is clean", audit_steps(real_checkers) == [])
+        # The id-less report step must not be discovered as a checker.
+        check("real workflow: no discovered checker lacks an id", all(
+            s["id"] for s in real_checkers
+        ))
 
-        sel = next((s["id"] for s in real_steps if s["id"].endswith(SELFTEST_SUFFIX)), None)
-        liv = next((s["id"] for s in real_steps if not s["id"].endswith(SELFTEST_SUFFIX)), None)
+        sel = next((s["id"] for s in real_checkers if s["id"].endswith(SELFTEST_SUFFIX)), None)
+        liv = next((s["id"] for s in real_checkers if not s["id"].endswith(SELFTEST_SUFFIX)), None)
         check(
             "emit(real selftest id) includes --self-test",
             sel is not None and _has_selftest_flag(emit_command(sel, text) or ""),


### PR DESCRIPTION
Closes rf2-m6kdb (second audit reopen, PR #6815). Sole owner of `.github/workflows/*` this wave.

## What the bead asked (two residuals)

1. **Self-test reproduce-command mismatch** — the aggregator dropped `--self-test` for `_selftest` ids, so a red self-test was reported as a live-scan command that could pass.
2. **Structural guard not exhaustive** — `parse_checker_steps` filtered to steps whose id already began `check_`, and never read `continue-on-error`, so two failure modes it exists to prevent slipped past it.

## Verified against current main before fixing

- **Residual 1 is ALREADY FIXED** (delivered by the merged PR #6815). The aggregator derives each failure's reproduce command from the step's real `run:` via `check_ci_reproduce_commands.py --emit`, and the shell fallback appends `--self-test` for `_selftest` ids. Confirmed live: `--emit check_keyword_catalogue_drift_selftest` prints `... --self-test --verbose`; `--emit check_keyword_catalogue_drift` prints `... --verbose`. No change needed here.
- **Residual 2 was STILL LIVE.** Feeding the bead's exact two synthetic steps — a `run: python scripts/check_foo.py --verbose` step with `continue-on-error: true` but no id, and an id'd `check_bar` with no `continue-on-error` — to the merged guard, `parse_checker_steps` discovered only `check_bar` (the no-id checker was invisible) and `audit_steps` returned `[]` (clean). Both shapes it exists to prevent certified green.

## The fix (Python guard only; residual 1 already landed)

Discover checker steps **independently of their id**: a step is a checker if it carries a `check_*` id **OR** its inline `run:` is a `python scripts/check_*.py` invocation within this job. This surfaces a checker that forgot its id, while still excluding the id-less block-scalar report step and the checkout/setup steps (no inline `python scripts/check_*.py` run). Over every discovered checker the guard now additionally requires:

- a **unique `check_*` id** — a no-id (or duplicate-id) checker never appears in GitHub's `toJSON(steps)`, so a `continue-on-error` failure there is unreported and the job goes green;
- **`continue-on-error: true`** — a checker missing it restores `bash -e` short-circuiting, so the later invariants never run;

in addition to the existing single-line parseable `python scripts/<name>.py` run, on-disk script existence, id/script-stem agreement, and live-vs-self-test agreement.

Added the two exact negative fixtures the bead names, plus duplicate-id and report-step-exclusion coverage. **Single job, step order, final aggregator, and derive-from-run behaviour are unchanged** — no jobs split, no YAML framework, no reporting subsystem. The `test.yml` change is the guard step's descriptive comment only.

## Quality gates

All run foreground from the worktree, exit code echoed (exit code is the verdict):

- `python scripts/check_ci_reproduce_commands.py --self-test --verbose` -> **EXIT 0** — 23 self-tests pass, including the two new negatives: `no-id python checker FIRES (discovered by run shape)` and `checker missing continue-on-error FIRES`.
- `python scripts/check_ci_reproduce_commands.py --check --verbose` -> **EXIT 0** — live audit of this workflow: `37 checker steps; every one carries a unique check_* id + continue-on-error, and every reproduce command matches its step's script + live-vs-self-test mode`.
- `python scripts/check_ci_reproduce_commands.py --emit <id>` -> **EXIT 0** — selftest id emits `--self-test --verbose`, live id emits `--verbose` (residual-1 mode-correctness preserved).
- Independent YAML-level negative-fixture proof (full parse -> discover -> audit over the bead's exact synthetic job) -> **EXIT 0** — both fixtures now FIRE; the `other-job` checker did not leak into discovery (job scoping intact).
- `sh scripts/check-no-hardcoded-paths.sh` -> **EXIT 0** — portability gate clean.
- `python -c "import yaml; yaml.safe_load(...)"` on `test.yml` -> **YAML OK**.

The rest of the PR spine runs in CI on this diff (which touches one job's guard helper plus that job's comment).
