### PR TITLE
build(shadow): drop dead :redef silencing in :node-test-freehand / :freehand-bench-node (rf2-41igl)

### DIFF
--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -818,6 +818,15 @@
    :ns-regexp "^re-frame\\.freehand\\..+-cljs-test$"
    :main      re-frame.test-quiet.shadow-node/main
    ;; The load-bearing watch hook is inherited from :build-defaults.
+   ;;
+   ;; rf2-41igl: :redef stays OFF on this build alone. With it ON the
+   ;; build reports exactly one warning — `->Box`, the positional
+   ;; constructor `(defrecord Box …)` generates in
+   ;; structural_data_round_trip_cljs_test.cljc, shadowing cljs.core/->Box.
+   ;; That is a test namespace, in scope here but not in :freehand-release,
+   ;; so the redef is a test-only artefact. shadow-cljs toggles :redef per
+   ;; build, not per symbol, so the class toggle scoped to this one build
+   ;; is the narrowest lever. (The bench build below no longer needs it.)
    :compiler-options {:warnings      {:redef false}
                       :infer-externs false}}
 
@@ -882,8 +891,7 @@
    :main      re-frame.freehand.bench.node/-main
    :output-to "out/freehand-bench-node.js"
    ;; The load-bearing hook is inherited from :build-defaults.
-   :compiler-options {:warnings      {:redef false}
-                      :infer-externs false}}
+   :compiler-options {:infer-externs false}}
 
   ;; rf2-vxgfnd.6 — the G-1 direct-render parity gate (07 §5) for the
   ;; re-frame.ui compiled-view substrate. A :node-script RELEASE build


### PR DESCRIPTION
Follow-on from PR #6807, which renamed `fingerprint.cljc`'s private `-write` to `canonical-token` — the one known Freehand redef the release build used to report. That made the class-level `{:warnings {:redef false}}` on the two Freehand builds possibly dead. This checks each honestly and acts on what it reports.

## What the build reported with the suppression OFF

Flipped `{:redef false}` off in each build and compiled:

- **`:freehand-bench-node`** → `Build completed. (141 files, 140 compiled, 0 warnings)`. Its only ever redef was `-write`, now gone, and this `:node-script` build compiles the bench entry, not the test namespaces. The silencing is **dead** → removed (kept `:infer-externs false`).

- **`:node-test-freehand`** → `Build completed. (377 files, 1 warnings)`, exactly one `:redef`:
  ```
  ->Box already refers to: cljs.core/->Box being replaced by:
  re-frame.freehand.structural-data-round-trip-cljs-test/->Box
  freehand/test/re_frame/freehand/structural_data_round_trip_cljs_test.cljc:53
  ```
  This is the positional constructor `(defrecord Box [v])` generates, shadowing `cljs.core/->Box`. It lives in a **test** namespace — in scope for this test build, **not** for `:freehand-release`, exactly the test-scope case the bead anticipated. So the suppression is **not** dead here; it covers a live, named, test-only redef.

  `shadow-cljs` toggles `:redef` **per build, not per symbol**, so the class toggle scoped to this one build is the narrowest lever available. Kept, now with a comment naming exactly what it covers (previously it named nothing). The narrowing this PR delivers is: the suppression is gone from the build where it's dead, and documented to the exact symbol where it's live.

Neither warning ever failed compile (both exit 0), so this is about honesty and future signal — with bench's toggle dropped, a future accidental redef in the bench path will now surface rather than be silently swallowed.

## Quality gates

- `npm run test:freehand` (final state, suppression kept only on `:node-test-freehand`): **EXIT=0**, `:node-test-freehand` `Build completed. (377 files, 0 warnings)`, **Ran 902 tests containing 5386 assertions. 0 failures, 0 errors.**
- `shadow-cljs compile freehand-bench-node` (final state, suppression removed): **EXIT=0**, `Build completed. (141 files, 0 warnings)`.

Scope: `implementation/shadow-cljs.edn` only (sole-owner hot-zone). No source touched.

Closes rf2-41igl.
