### PR TITLE
spec(006): Freehand body-authority fence returns :abandoned, not :stale (rf2-drpa3.84)

### DIFF
--- a/spec/006-ReactiveSubstrate.md
+++ b/spec/006-ReactiveSubstrate.md
@@ -1885,9 +1885,20 @@ narrowest publication boundary — after the callback-capable staging work, with
 callback-capable between the check and the publish. A candidate abandoned at the second
 point releases **only** what its own staging acquired.
 
-Reload that replaces a whole declaration is the ordinary case and needs no fence: a
-declared view is a descriptor VALUE, so a redeclared view is a different boundary, the
-host remounts it, and the old cell's teardown releases exactly what the old body owned.
+The live cell the fence protects is the **compatible** reload, and it is the ordinary
+case. A declared view is a descriptor VALUE, so an edit mints a fresh descriptor object;
+but the emitter keys its boundary on the qualified view id, not on that object, and hands
+the host the component type it already mounted. The cell and everything below it survive,
+and only the published body revision advances. That surviving cell is what makes a
+candidate rendered against the superseded revision reachable at all — abandoning it is the
+fence's whole job.
+
+A reload sidesteps the fence only when the redefinition is **incompatible** — when it
+moves the boundary's hook skeleton, as a mode promotion (adding `{:compiled true}` and
+reloading) does. That mints a new boundary, so the host remounts once, cleanly, and the
+old cell's teardown releases exactly what the old body owned.
+[Spec 004C §Compatible shell versus clean remount](004C-Roots-and-Mount.md#compatible-shell-versus-clean-remount)
+owns that compatible/incompatible boundary law.
 
 ### Frame binding and retarget
 


### PR DESCRIPTION
## Summary

Fixes rf2-drpa3.84. The `:stale` → `:abandoned` outcome was already corrected in the two-point-fence section by PR #6785; this PR closes the second contradiction that reopened the bead.

Spec 006's `Body authority across a live cell` section claimed that replacing a whole declaration "is the ordinary case and needs no fence" because "a redeclared view is a different boundary, the host remounts it." That is the exact design Freehand deliberately rejects. The emitter keys its boundary on the qualified view id, not on the descriptor value, so a **compatible** reload hands the host the component type it already mounted — the Fiber, the ViewCell, and the DOM below it survive, and only the published body revision advances (`component-for`'s compatible branch + `publish-body!` in `implementation/freehand/src/re_frame/freehand/react.cljs`). That surviving cell is *precisely* what the two-point fence exists to guard; a candidate rendered against the superseded revision is reachable exactly because the cell was not remounted.

A clean remount is reserved for the **incompatible** case — a change of lowering (mode promotion), which moves the boundary's hook skeleton. Only then does the old cell tear down and release what the old body owned. That boundary law is owned by Spec 004C §Compatible shell versus clean remount, which the corrected passage now points to.

The paragraph is replaced with the compatible/incompatible split; no runtime behaviour, status value, or API surface changes. Documentation-only, scoped to the one paragraph.

## Quality gates

| Gate | Result |
| --- | --- |
| `python scripts/check_doc_slugs.py` | EXIT=0 (new 004C anchor resolves) |
| `python -m mkdocs build --strict` | EXIT=0 (only pre-existing INFO notes on unrelated files) |