### PR TITLE
refactor(freehand): remove production-dead :plans/:descriptors build carrier (rf2-kl2pq)

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/compiler/build.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/build.cljc
@@ -45,15 +45,13 @@
   (:require [re-frame.freehand.eq :as eq]))
 
 ;; ---------------------------------------------------------------------------
-;; Registry ids (opaque keys naming the five build-scoped registries)
+;; Registry ids (opaque keys naming the build-scoped registries)
 ;; ---------------------------------------------------------------------------
 
 (def views       ::views)        ; view-id -> [template-fp hook-sig] (digest)
 (def ^:private view-declarations ::view-declarations) ; view-id -> [ns var]
 (def view-static ::view-static)  ; view-id -> {:caps #{..} :deps #{..}} (static-root proof, Spec 004C §3; plain-JVM/SSR slice, rf2-u53yy.1 S3)
 (def roots       ::roots)        ; Layer-1 root-site index
-(def plans       ::plans)        ; Layer-1 frame-plan index
-(def descriptors ::descriptors)  ; Root Descriptor index
 (def elements    ::elements)     ; compile-time custom-element declarations (plain-JVM/SSR slice)
 (def ^:private element-declarations ::element-declarations) ; tag -> owning ns
 
@@ -895,27 +893,29 @@
   (merge-with (fn [ra rb] (merge-with merge ra rb)) a b))
 
 ;; ---------------------------------------------------------------------------
-;; Root/plan/descriptor carrier (rf2-u53yy.1 S4 + S5)
+;; Root-site carrier (rf2-u53yy.1 S4)
 ;;
-;; Roots, plans, and Root Descriptors are CALL SITES (`v/mount` / `v/create-root`
-;; / `v/render!` / `v/hydrate-root`), not defs, so unlike views (S2) they carry NO
-;; generated def whose analyzer var-meta could hold their descriptor. On the Shadow
-;; build path each site is instead stamped onto a SYNTHETIC per-namespace descriptor
-;; in the analyzer namespace map (variant B, S0 proof rf2-u53yy.1.1): a single
-;; ns-level key `[::namespaces <ns> :rf.ui/root-plan-descriptor]` accumulating this
-;; namespace's `{:roots [..] :plans [..] :descriptors [..]}` sites — S5 folds the
-;; Root Descriptor index onto the SAME carrier (one carrier for all three call-site
-;; registries) rather than inventing a new key. Shadow persists the whole ns
-;; analyzer entry to its disk cache and RESTORES it under
-;; `[:compiler-env :cljs.analyzer/namespaces <ns>]` on a cache HIT, so the build
-;; hook harvests the roots/plans registries from it at compile-finish — present
-;; identically for a cached member and a freshly compiled one — instead of from a
-;; macro-expansion side effect a warm cache-hit source never re-runs. Eviction is
-;; automatic and identical to S2's def-meta carrier: Shadow's watch reset dissocs
-;; the WHOLE `[::namespaces <ns>]` entry for a modified source before it recompiles
-;; (`remove-output-by-id`, default `:watch-namespace-reset`), so a removed site
-;; simply vanishes from the re-analyzed carrier. This is the same decoupling S1
-;; gave elements and S2 gave views — the direction S6 needs to drop the blocker.
+;; Root sites are CALL SITES (`v/render-static`), not defs, so unlike views (S2)
+;; they carry NO generated def whose analyzer var-meta could hold their descriptor.
+;; On the Shadow build path each site is instead stamped onto a SYNTHETIC
+;; per-namespace descriptor in the analyzer namespace map (variant B, S0 proof
+;; rf2-u53yy.1.1): a single ns-level key
+;; `[::namespaces <ns> :rf.ui/root-plan-descriptor]` accumulating this namespace's
+;; `{:roots [..]}` sites. Shadow persists the whole ns analyzer entry to its disk
+;; cache and RESTORES it under `[:compiler-env :cljs.analyzer/namespaces <ns>]` on a
+;; cache HIT, so the build hook harvests the roots registry from it at
+;; compile-finish — present identically for a cached member and a freshly compiled
+;; one — instead of from a macro-expansion side effect a warm cache-hit source never
+;; re-runs. Eviction is automatic and identical to S2's def-meta carrier: Shadow's
+;; watch reset dissocs the WHOLE `[::namespaces <ns>]` entry for a modified source
+;; before it recompiles (`remove-output-by-id`, default `:watch-namespace-reset`),
+;; so a removed site simply vanishes from the re-analyzed carrier. This is the same
+;; decoupling S1 gave elements and S2 gave views.
+;;
+;; The `:plans`/`:descriptors` sub-keys this carrier once also held (S5) retired
+;; with the compiled-mount door (rf2-12p25): `register-plan-site!` /
+;; `register-descriptor!` were their only writers, so this carrier keeps the
+;; `:roots` path only (rf2-kl2pq).
 ;; ---------------------------------------------------------------------------
 
 (def ^{:private true
@@ -926,21 +926,20 @@
   :rf.ui/root-plan-descriptor)
 
 (defn stamp-root-plan-site!
-  "Accumulate one Layer-1 `site` under `sub-key` (`:roots` | `:plans` |
-  `:descriptors`) in the live analyzer map's SYNTHETIC per-namespace descriptor for
-  `ns-sym` — the S4 variant-B carrier, extended to carry the Root Descriptor index
-  too (rf2-u53yy.1 S5): all three call-site registries ride ONE carrier. Called at
-  macro expansion on a real Shadow build pass (`register-root-site!` gates on
-  `shadow-build-pass?`; on the Freehand door only the root-site registry has a live
-  writer) in place of the per-source slice contribution: the whole-build root-site
-  registry is then harvested from this carrier at compile-finish, present
-  identically for a cache-hit member and a freshly compiled one. A `:roots` site is
-  `{:root-id .. :row {:file .. :line .. :provenance ..}}`; a `:plans` site is
-  `{:frame-id .. :row {:config-fingerprint .. :file .. :line ..}}`; a `:descriptors`
-  site is `{:root-id .. :row <Root Descriptor v1>}` (the same row the slice path
-  contributes off the Shadow path). A direct `swap!` on the per-thread compiler env
-  (parallel builds each own theirs); a no-op when no compiler env is bound (never
-  reached — the caller gates on a live Shadow pass)."
+  "Accumulate one Layer-1 root `site` under `sub-key` — always `:roots`, the sole
+  Freehand-door call-site registry with a live writer. (The `:plans`/`:descriptors`
+  sub-keys this carrier once also accepted retired with the compiled-mount door,
+  rf2-12p25/rf2-kl2pq; only the `:roots` path survives.) The site is stamped into
+  the live analyzer map's SYNTHETIC per-namespace descriptor for `ns-sym` — the S4
+  variant-B carrier. Called at macro expansion on a real Shadow build pass
+  (`register-root-site!` gates on `shadow-build-pass?`) in place of the per-source
+  slice contribution: the whole-build root-site registry is then harvested from this
+  carrier at compile-finish, present identically for a cache-hit member and a
+  freshly compiled one. A `:roots` site is
+  `{:root-id .. :row {:file .. :line .. :provenance ..}}` (the same row the slice
+  path contributes off the Shadow path). A direct `swap!` on the per-thread compiler
+  env (parallel builds each own theirs); a no-op when no compiler env is bound
+  (never reached — the caller gates on a live Shadow pass)."
   [ns-sym sub-key site]
   #?(:clj (when-let [a (compiler-env-atom)]
             (swap! a update-in
@@ -956,41 +955,29 @@
   (select-keys row [:file :line]))
 
 (defn harvest-root-plan-registries
-  "PURE: fold the SYNTHETIC analyzer-map root/plan/descriptor sites of every
-  authoritative `members` namespace in `build-state` into per-source registry rows
-  `{source {::roots {root-id row} ::plans {frame-id row} ::descriptors {root-id
-  descriptor}}}`. Reads
+  "PURE: fold the SYNTHETIC analyzer-map root sites of every authoritative
+  `members` namespace in `build-state` into per-source registry rows
+  `{source {::roots {root-id row}}}`. Reads
   `[:compiler-env :cljs.analyzer/namespaces <ns> :rf.ui/root-plan-descriptor]` —
-  Shadow's disk-cache-durable variant-B carrier (rf2-u53yy.1 S4, extended to the
-  Root Descriptor index at S5), present identically for a cache-hit member and a
-  freshly compiled one. Same-namespace re-declaration replaces (a source's own later
-  site wins — watch/HMR tolerance); the cross-NAMESPACE Layer-1 laws run HERE (a
-  compile-finish error is still a build-time error): two namespaces resolving one
-  root-id THROW `::duplicate-root-id`; two namespaces carrying DIFFERING config
-  fingerprints for one frame-id THROW `::frame-payload-conflict` (matching
-  fingerprints are the ratified idempotent no-op). Root Descriptors ride alongside
-  their root sites keyed by the SAME root-id (every `:descriptors` site is stamped
-  at a site that also stamps a `:roots` site), so the `::duplicate-root-id` law above
-  is their cross-namespace conflict check — no separate descriptor check is needed.
-  Members are folded in sorted order so the reported evidence is stable under every
-  graph permutation. Empty (no root/plan/descriptor sites in the build) yields `{}`,
-  so the finish overlay is a no-op for a mount-free build."
+  Shadow's disk-cache-durable variant-B carrier (rf2-u53yy.1 S4), present
+  identically for a cache-hit member and a freshly compiled one. Same-namespace
+  re-declaration replaces (a source's own later site wins — watch/HMR tolerance);
+  the cross-NAMESPACE Layer-1 root-id law runs HERE (a compile-finish error is still
+  a build-time error): two namespaces resolving one root-id THROW
+  `::duplicate-root-id`. Members are folded in sorted order so the reported evidence
+  is stable under every graph permutation. Empty (no root sites in the build) yields
+  `{}`, so the finish overlay is a no-op for a mount-free build."
   [build-state members]
   (let [nss (get-in build-state [:compiler-env :cljs.analyzer/namespaces])]
     (loop [srcs        (sort-by str members)
            regs        {}
-           root-owners {}                ; root-id -> {:source ns :row row}
-           plan-owners {}]               ; frame-id -> {:source ns :row row}
+           root-owners {}]               ; root-id -> {:source ns :row row}
       (if-let [ns-sym (first srcs)]
         (let [d         (get (get nss ns-sym) root-plan-descriptor-key)
               ;; per-source fold: a namespace's own later site replaces its earlier
-              ;; one for the same key (same-ns re-declaration tolerance).
+              ;; one for the same root-id (same-ns re-declaration tolerance).
               src-roots (reduce (fn [m {:keys [root-id row]}] (assoc m root-id row))
-                                {} (:roots d))
-              src-plans (reduce (fn [m {:keys [frame-id row]}] (assoc m frame-id row))
-                                {} (:plans d))
-              src-descs (reduce (fn [m {:keys [root-id row]}] (assoc m root-id row))
-                                {} (:descriptors d))]
+                                {} (:roots d))]
           (doseq [[root-id row] src-roots]
             (when-let [{owner-row :row} (get root-owners root-id)]
               (throw
@@ -1004,33 +991,12 @@
                  :provenance [(:provenance owner-row) (:provenance row)]
                  :sites (vec (sort-by str [(site-coords owner-row) (site-coords row)]))
                  :recovery :make-root-ids-unique}))))
-          (doseq [[frame-id row] src-plans]
-            (when-let [{owner-row :row} (get plan-owners frame-id)]
-              (when (not= (:config-fingerprint owner-row) (:config-fingerprint row))
-                (throw
-                 (ex-info
-                  (str "re-frame.freehand found two root sites in one build carrying "
-                       "static frame plans for frame " frame-id " with DIFFERING "
-                       "config fingerprints while harvesting the build; refusing to "
-                       "publish a merge-order winner. One frame, one plan — align "
-                       "the configs, or drop the duplicate frame-root")
-                  {::error ::frame-payload-conflict
-                   :frame-id frame-id
-                   :fingerprints [(:config-fingerprint owner-row)
-                                  (:config-fingerprint row)]
-                   :sites (vec (sort-by str [(site-coords owner-row) (site-coords row)]))
-                   :recovery :align-frame-plan-config})))))
           (recur (rest srcs)
                  (cond-> regs
-                   (seq src-roots) (assoc-in [ns-sym roots] src-roots)
-                   (seq src-plans) (assoc-in [ns-sym plans] src-plans)
-                   (seq src-descs) (assoc-in [ns-sym descriptors] src-descs))
+                   (seq src-roots) (assoc-in [ns-sym roots] src-roots))
                  (into root-owners
                        (map (fn [[rid row]] [rid {:source ns-sym :row row}]))
-                       src-roots)
-                 (into plan-owners
-                       (map (fn [[fid row]] [fid {:source ns-sym :row row}]))
-                       src-plans)))
+                       src-roots)))
         regs))))
 
 ;; ---------------------------------------------------------------------------
@@ -1183,21 +1149,20 @@
           ;; directly through the slice — the analyzer map is empty and the slice
           ;; rows carry through unchanged.)
           view-registries (harvest-view-registries build-state members)
-          ;; Roots + plans + Root Descriptors ride the disk-cache-durable SYNTHETIC
-          ;; per-namespace analyzer-map descriptor on the Shadow path (rf2-u53yy.1
-          ;; S4 roots/plans, S5 folds descriptors onto the same carrier). The
+          ;; Root sites ride the disk-cache-durable SYNTHETIC per-namespace
+          ;; analyzer-map descriptor on the Shadow path (rf2-u53yy.1 S4). The
           ;; register-root-site! macro contributes NO slice row under a Shadow build
-          ;; pass, so harvest every authoritative member's
-          ;; root/plan/descriptor sites from the carrier and overlay them onto the
-          ;; slice-derived rows of the other registries — a cache-hit member
-          ;; contributes its RESTORED sites identically to a freshly compiled one. The
-          ;; cross-namespace Layer-1 laws run inside the harvest. (Off the Shadow path
-          ;; the analyzer carrier is empty and the slice rows carry through unchanged.)
-          root-plan-registries (harvest-root-plan-registries build-state members)
+          ;; pass, so harvest every authoritative member's root sites from the carrier
+          ;; and overlay them onto the slice-derived rows of the other registries — a
+          ;; cache-hit member contributes its RESTORED sites identically to a freshly
+          ;; compiled one. The cross-namespace Layer-1 root-id law runs inside the
+          ;; harvest. (Off the Shadow path the analyzer carrier is empty and the slice
+          ;; rows carry through unchanged.)
+          root-registries (harvest-root-plan-registries build-state members)
           snapshot {:build-id build-id
                     :registries (-> (:committed after)
                                     (merge-registries view-registries)
-                                    (merge-registries root-plan-registries))
+                                    (merge-registries root-registries))
                     :elements (:element-manifest scratch {})
                     :version (inc (long (or (:version accepted) 0)))}]
       {:snapshot snapshot})))


### PR DESCRIPTION
## Summary

PR #6821 (rf2-12p25) deleted the compiled-mount machinery, including `register-plan-site!` / `register-descriptor!` — the only writers of the freehand compiler build carrier's `:plans`/`:descriptors` sub-keys and of the `build/plans` + `build/descriptors` registries. On the Freehand door only `register-root-site!` (render-static) still writes the carrier (the `:roots` sub-key), so the `:plans`/`:descriptors` machinery was production-dead: no writer, no reader, no test coverage.

This strips it from `re-frame.freehand.compiler.build`:

- remove the `build/plans` and `build/descriptors` registry-id defs
- rewrite `harvest-root-plan-registries` to harvest `:roots` only — drop the plan/descriptor folds, `plan-owners`, and the `::frame-payload-conflict` law; keep the `::duplicate-root-id` root law and the `:roots` path `render-static` uses
- scope `stamp-root-plan-site!`'s docstring to the surviving `:roots` sub-key (its sole caller in `root.cljc` passes `:roots`); the signature is retained so the caller is untouched
- refresh the S4/S5 carrier prose to roots-only, with a note pointing at the retirement

### Verification (on current main)

- `register-plan-site!` / `register-descriptor!` are gone from `re-frame.freehand.compiler.root` (removed in rf2-12p25) — no freehand writer of the `:plans`/`:descriptors` sub-keys remains.
- No freehand production reader of the removed `build/plans` / `build/descriptors` vars exists (a `git grep` across `implementation/freehand` is empty). The donor package (kept, out of scope) still has its own live plan/descriptor writers; this PR is Freehand's copy only.
- The surviving `:rf.error/frame-payload-conflict` intra-form check lives in `root/check-plan-set!` (render-static AST path) and is unaffected.

### Scope

Confined to `implementation/freehand/src/re_frame/freehand/compiler/build.cljc` — disjoint from the in-flight emitter-parity work (`analyze.cljc` / `node.cljc` / `react.cljs`) and the root-ownership work (`root.cljc`). `stamp-root-plan-site!`'s signature and the `harvest-root-plan-registries` / `root-plan-descriptor-key` names are kept as-is so `root.cljc` (its sole caller plus docstring refs) is untouched; the write-side sub-key param is `:roots`-only in practice and is no longer dead-reachable through the harvest.

## Quality gates

Reproduced against a CLEAN build (deleted `implementation/.shadow-cljs` and the freehand `.cpcache`), rebased onto current `origin/main`:

| Gate | Result |
| --- | --- |
| `clojure -M:test` (from `implementation/freehand`, JVM, clean build) | 875 tests, 6293 assertions, 0 failures, 0 errors — **exit 0** |
| `npm run test:freehand` (from `implementation/`, node) | 902 tests, 5386 assertions, 0 failures, 0 errors (compile: 0 warnings) — exit 0 |
| EP-0036 donor guard (`git grep -e 're-frame\.ui' … -- implementation/freehand`) | no matches — **clean** |

**Test-count delta: 0.** No test file was touched — this PR removes production code only. The plan/descriptor carrier's tests were already removed as dead in rf2-12p25, so there were none left here to remove. (The remaining `frame-payload-conflict` test exercises the render-static AST `check-plan-set!`, not the build carrier.)

### CI fix (first push was red)

The initial push failed the **EP-0036 donor guard** step of the "JVM freehand" job — not the test run: a carrier-provenance comment I added named the donor namespace textually, which that guard forbids anywhere under `implementation/freehand`. Fix: reworded the comment to state the retirement without naming the donor. `clojure -M:test` never runs that guard step, which is why the local runs (warm and clean) were green while CI was red.

Closes rf2-kl2pq.
