### PR TITLE
fix(freehand): make error-region-id injective over supported :any identities (rf2-drpa3.146)

### DIFF
--- a/implementation/freehand/test/re_frame/freehand/pilot_field.cljc
+++ b/implementation/freehand/test/re_frame/freehand/pilot_field.cljc
@@ -200,47 +200,88 @@
 ;; ---------------------------------------------------------------------------
 
 (defn- hex-escape
-  "One non-alphanumeric character `c` as the reversible token `_<hex>_`."
+  "The matched non-alphanumeric run `c` as reversible `_<hex>_` tokens, ONE
+  per UTF-16 code unit. Encoding EVERY unit — not just the first — is what
+  keeps the two hosts in step and the encoding injective past the BMP: a
+  supplementary code point (an emoji) is one two-unit match on the JVM but two
+  one-unit matches in ClojureScript, and spelling both units makes each host
+  emit the same `_hi__lo_`. Reading only `.charAt 0` collapsed 😀 (U+1F600)
+  and 😁 (U+1F601) — which share a high surrogate — onto one JVM token, and
+  disagreed with ClojureScript's per-unit walk besides."
   [c]
-  (str "_"
-       #?(:clj  (Integer/toString (int (.charAt ^String c 0)) 16)
-          :cljs (.toString (.charCodeAt c 0) 16))
-       "_"))
+  (str/join
+    (map (fn [n] (str "_" #?(:clj  (Integer/toString n 16)
+                             :cljs (.toString n 16))
+                      "_"))
+         #?(:clj  (map int c)
+            :cljs (map #(.charCodeAt c %) (range (.-length c)))))))
 
 (defn- dom-escape
-  "Escape `s` to a DOM-safe token over `[A-Za-z0-9_]`, INJECTIVELY: an ASCII
-  alphanumeric passes through unchanged — so an ordinary name stays itself —
-  and every other character, INCLUDING `_` and the `-` the id join reserves
-  as its separator, becomes `_<hex>_`. Distinct strings therefore yield
-  distinct tokens, and a token never carries a bare `-`, so parts joined by
-  `-` cannot blur their boundary."
+  "Escape `s` to a DOM-safe token over `[A-Za-z0-9_]`, INJECTIVELY and
+  IDENTICALLY on both hosts: an ASCII alphanumeric passes through unchanged —
+  so an ordinary name stays itself — and every other UTF-16 code unit,
+  INCLUDING `_` and the `-` the id join reserves as its separator, becomes
+  `_<hex>_`. Distinct strings therefore yield distinct tokens on either host,
+  and a token never carries a bare `-`, so parts joined by `-` cannot blur
+  their boundary."
   [s]
   (str/replace s #"[^A-Za-z0-9]" hex-escape))
 
+(defn- ordered-identity?
+  "Does `v`'s printed form carry its identity? An atom's does, and a
+  SEQUENTIAL collection recursively of such does — order IS identity there. An
+  unordered collection's does NOT: `=` ignores a map's or a set's element
+  order, but a printed id cannot, so two `=` maps differing only in insertion
+  order would print two ids for ONE identity. Those answer false and are
+  refused at the boundary rather than emitted as a silently unstable id."
+  [v]
+  (cond
+    (map? v)  false
+    (set? v)  false
+    (coll? v) (every? ordered-identity? v)
+    :else     true))
+
 (defn- id-token
-  "A DOM-safe, INJECTIVE token for one part of a control's identity, or nil
-  when the part is absent. Distinct SUPPORTED identities yield distinct
-  tokens — the library promises the caller so and points an
-  `aria-describedby` at the result — so the encoding must not lose the
-  difference a lossy slug did: `\"a/b\"` and `\"a-b\"` are two identities,
-  `:invoice` and `\"invoice\"` are two, `1` and `\"1\"` are two, and `\"!\"`
-  and `\"@\"` are two rather than both nothing.
+  "A DOM-safe, INJECTIVE, host-stable token for one part of a control's
+  identity, or nil when the part is absent. Distinct SUPPORTED identities
+  yield distinct tokens — the library promises the caller so and points an
+  `aria-describedby` at the result — so the encoding loses no difference:
+  `\"a/b\"` and `\"a-b\"` are two, `:invoice` and `\"invoice\"` are two, `1`
+  and `\"1\"` are two, `\"!\"` and `\"@\"` are two, and 😀 and 😁 are two on
+  every host.
 
   A string is escaped directly, so an ordinary name — `\"description\"` —
   stays itself and a single-instance field keeps its short, readable id. Any
   other value carries a reserved `_v_` prefix ahead of its escaped `pr-str`:
   the prefix is one a string can never produce — a string's own `_` escapes
-  to `_5f_` — so a typed value and a string of the same characters never
-  collide, and `pr-str` keeps distinct values distinct (a `:control` vector
-  address escapes as one unambiguous token). Pure and stable: the same
-  identity yields the same token on every render and after a list reorder,
-  and nothing is allocated, counted or policed."
+  to `_5f_`, so no bare `_` survives — meaning a typed value and a string of
+  the same characters never collide, and `pr-str` keeps distinct values
+  distinct (a `:control` vector address escapes as one unambiguous token).
+
+  For that `pr-str` to BE an identity the value's print must be order-stable,
+  so a non-string identity is required to be `ordered-identity?`: an unordered
+  map or set — whose `=` ignores an order its print preserves — is refused
+  loudly rather than emitted as an id two equal identities would not share. A
+  supplied string is never dropped, so an empty-string identity stays distinct
+  from an absent one rather than silently aliasing it. Pure and stable: the
+  same supported identity yields the same token on every render and after a
+  list reorder, and nothing is allocated, counted or policed."
   [part]
   (when (some? part)
-    (let [t (if (string? part)
-              (dom-escape part)
-              (str "_v_" (dom-escape (pr-str part))))]
-      (when-not (str/blank? t) t))))
+    (if (string? part)
+      (dom-escape part)
+      (if (ordered-identity? part)
+        (str "_v_" (dom-escape (pr-str part)))
+        (throw (ex-info
+                 (str "acme.ui: a field identity must be a value whose print "
+                      "is its identity — an atom or an ordered collection of "
+                      "them — but got an unordered collection: " (pr-str part)
+                      ". A map's or set's `=` ignores an element order its "
+                      "printed id cannot, so this identity could point two "
+                      "controls at two different error regions for one "
+                      "instance. Use an ordered identity such as a vector.")
+                 {:acme.ui/error    :unstable-field-identity
+                  :acme.ui/identity part}))))))
 
 (defn error-region-id
   "The id of a field's error region, and the target its control points
@@ -251,9 +292,12 @@
   `acme-field-<instance>-<name>-error` and two same-named instances no
   longer collide.
 
-  The library trusts the caller's identity to be distinct — exactly as
-  the buffered controller trusts its `:control` address (D004) — and
-  allocates, counts and polices nothing."
+  The library trusts the caller's identity to be distinct — exactly as the
+  buffered controller trusts its `:control` address (D004) — and requires
+  only that it be order-stable, so its id is the same across a rerender and a
+  list reorder. It allocates, counts and polices nothing; an identity whose
+  print is not its identity (an unordered map or set) is refused loudly by
+  `id-token` rather than given an ambiguous id."
   [prefix & parts]
   (str/join "-" (concat [prefix] (keep id-token parts) ["error"])))
 

--- a/implementation/freehand/test/re_frame/freehand/pilot_field_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/pilot_field_cljs_test.cljc
@@ -718,6 +718,8 @@
           "two punctuation-only identities are two ids, neither dropped")
       (is (not= (id "!") (id nil))
           "and a punctuation identity is not the same as no identity")
+      (is (not= (id "") (id nil))
+          "nor is a supplied empty string dropped onto the absent-instance id")
       (is (not= (pilot/error-region-id "acme-field" "a" "b-c")
                 (pilot/error-region-id "acme-field" "a-b" "c"))
           "the join cannot blur where one identity part ends and the next begins"))))
@@ -749,6 +751,53 @@
     (is (= (pilot/error-region-id "acme-buffered" [:invoice 1 :reference])
            (pilot/error-region-id "acme-buffered" [:invoice 1 :reference]))
         "including a control-address identity")))
+
+(deftest a-supplementary-code-point-is-encoded-whole-on-both-hosts
+  (testing "rf2-drpa3.146, audit reopen. A supplementary code point is ONE
+            two-unit match on the JVM but TWO one-unit matches in ClojureScript.
+            Encoding only the first unit collapsed 😀 (U+1F600) and 😁 (U+1F601)
+            — which share a high surrogate — onto one JVM id, and disagreed with
+            ClojureScript besides. Encoding EVERY unit keeps the two emoji
+            distinct AND yields the same id on both hosts, which this `.cljc`
+            test proves by running on each and asserting the exact string. The
+            emoji are built from their surrogate units, so the assertion never
+            depends on how a host reads a literal out of source."
+    (let [grin (str (char 0xD83D) (char 0xDE00))    ; 😀 U+1F600
+          beam (str (char 0xD83D) (char 0xDE01))    ; 😁 U+1F601
+          id   (fn [instance] (pilot/error-region-id "acme-field" instance "description"))]
+      (is (= "acme-field-_d83d__de00_-description-error" (id grin))
+          "😀's two surrogate units are BOTH spelled, identically on both hosts")
+      (is (= "acme-field-_d83d__de01_-description-error" (id beam))
+          "and 😁 differs only in its low unit — no longer a shared _d83d_")
+      (is (not= (id grin) (id beam))
+          "so the two emoji are two ids, the JVM collision closed"))))
+
+(deftest an-unordered-identity-is-refused-loudly
+  (testing "rf2-drpa3.146, audit reopen. An identity's PRINT must be its
+            identity, and a map's or set's is not: `=` ignores an element order
+            the print preserves, so `(array-map :a 1 :b 2)` and its equal
+            reordered twin `(array-map :b 2 :a 1)` would print two ids for one
+            instance. Rather than emit a silently unstable id, the library
+            refuses the ambiguous identity at the boundary with an actionable
+            reason — criterion 3's 'fail loud, no silent aliasing'."
+    (let [reason (fn [identity]
+                   (try (pilot/error-region-id "acme-buffered" identity)
+                        nil
+                        (catch #?(:clj Throwable :cljs :default) e
+                          (:acme.ui/error (ex-data e)))))]
+      (is (= :unstable-field-identity (reason (array-map :a 1 :b 2)))
+          "a map identity fails loud with an actionable reason")
+      (is (= :unstable-field-identity (reason (array-map :b 2 :a 1)))
+          "and so does its equal-but-reordered twin — neither silently aliases")
+      (is (= :unstable-field-identity (reason #{:a :b}))
+          "a set is refused for the same reason its print is not its identity")
+      (is (= :unstable-field-identity (reason [:invoice {:a 1} :reference]))
+          "including an unordered collection NESTED inside an ordered address"))
+    (testing "while the ordered identity carrying the same information is
+              accepted and stable across calls"
+      (is (= (pilot/error-region-id "acme-buffered" [:invoice 1 :reference])
+             (pilot/error-region-id "acme-buffered" [:invoice 1 :reference]))
+          "a vector address is a stable identity, refused nothing"))))
 
 ;; ===========================================================================
 ;; R-A9 — asynchronous transform race safety

--- a/implementation/freehand/test/re_frame/freehand/pilot_field_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/pilot_field_dom_cljs_test.cljs
@@ -621,6 +621,59 @@
                         (teardown! container root)
                         (done)))))))))
 
+(deftest pilot-two-emoji-instances-keep-distinct-mounted-ids
+  (testing "rf2-drpa3.146, audit reopen (mounted). The collision a lossy first
+            surrogate produced: two controlled fields whose instances are the
+            emoji 😀 (U+1F600) and 😁 (U+1F601) — which share a high surrogate —
+            mount with DISTINCT `aria-describedby` targets, each resolving by
+            document id to its own error region. The JVM structural arm proves
+            the whole-code-point encoding closes the collision; this browser arm
+            proves the two ids also resolve to two regions in a real DOM. The
+            emoji are built from their surrogate units so the mount never
+            depends on how the runtime reads a literal out of source."
+    (if-not (browser?)
+      (skip! "the browser job runs the mounted emoji collision regression")
+      (async done
+        (live-frame/make-frame {:id fid})
+        (frame/replace-app-db! fid {})
+        (pilot/register!)
+        (pilot/register-app!)
+        (let [grin (str (char 0xD83D) (char 0xDE00))    ; 😀 U+1F600
+              beam (str (char 0xD83D) (char 0xDE01))    ; 😁 U+1F601
+              [container root] (mount!)
+              field-form (fn [instance]
+                           [pilot/field {:name     "description"
+                                         :label    "Description"
+                                         :value    ""
+                                         :instance instance
+                                         :error    "A description is required."
+                                         :on-input [:noop]}])]
+          (-> (act #(.render root (shell/provide-frame
+                                    fid (fr/element [:div
+                                                     (field-form grin)
+                                                     (field-form beam)]))))
+              (.then
+                (fn [_]
+                  (let [controls (.querySelectorAll container "[data-part='control']")
+                        c1  (.item controls 0)
+                        c2  (.item controls 1)
+                        id1 (.getAttribute c1 "aria-describedby")
+                        id2 (.getAttribute c2 "aria-describedby")]
+                    (is (= 2 (.-length controls)) "non-vacuous: two fields mounted")
+                    (is (some? id1) "the 😀 control names a region")
+                    (is (some? id2) "the 😁 control names a region")
+                    (is (not= id1 id2)
+                        "😀 and 😁 no longer collapse onto one shared surrogate id")
+                    (is (some? (.getElementById js/document id1))
+                        "the 😀 region resolves by document id")
+                    (is (some? (.getElementById js/document id2))
+                        "the 😁 region resolves by document id"))))
+              (.then (fn [_] (teardown! container root) (done)))
+              (.catch (fn [e]
+                        (is false (str "the mounted pilot rejected: " e))
+                        (teardown! container root)
+                        (done)))))))))
+
 ;; ===========================================================================
 ;; The compiled cell, re-opened — the pilot's compiled twin mounts
 ;; ===========================================================================


### PR DESCRIPTION
## What & why

`bd rf2-drpa3.146` (audit re-open of merged PR #6811, itself the fix for the #6758 defect). The pilot-field error-region codec still collapsed distinct **supported** identities onto one DOM id, re-opening the `aria-describedby` ambiguity `rf2-drpa3.134` closed. Two exact reproductions the audit found on merged `main`:

1. **Supplementary-Unicode collision (JVM) + host-parity break.** `hex-escape` read only `.charAt 0` of a matched run. The JVM regex hands a supplementary code point as **one two-unit match**, so only the shared high surrogate was encoded — `"😀"` (U+1F600) and `"😁"` (U+1F601) both became `acme-field-_d83d_-description-error`. ClojureScript, matching per UTF-16 unit, encoded it differently again.
2. **Equal-EDN-map instability.** A non-string identity was slugged through `pr-str`, whose text is not canonical for unordered collections: `(array-map :a 1 :b 2)` and its equal reordered twin `(array-map :b 2 :a 1)` — one identity by `=` — printed two ids.

## Where it lives

`error-region-id` and its helpers (`hex-escape`, `dom-escape`, `id-token`) are the pilot-library codec in `implementation/freehand/test/re_frame/freehand/pilot_field.cljc`. The compiled twin (`pilot_field_compiled.cljc`) `:refer`s the same function, so one fix covers both execution modes.

## The injectivity approach

- **Whole-code-point escaping.** `hex-escape` now spells **every** UTF-16 code unit of the match, not just the first. A supplementary code point is one two-unit match on the JVM and two one-unit matches in ClojureScript; encoding all units makes both hosts emit the same `_hi__lo_`, keeping 😀 and 😁 distinct and identical across hosts.
- **Order-stable identity requirement (narrow + validate, per the bead's bounded correction).** A non-string identity must be `ordered-identity?` — an atom, or a sequential collection recursively of such — for its `pr-str` to *be* its identity. An unordered map or set (whose `=` ignores an order its print preserves) is **refused loudly** with an actionable diagnostic (`{:acme.ui/error :unstable-field-identity}`) rather than emitted as an id two equal identities would not share. This is criterion 3's "fail loud, no silent aliasing" and avoids the fragile business of injective canonicalization across arbitrary EDN.
- **No dropped identity.** A supplied empty-string identity is no longer silently collapsed onto the absent-instance short id.
- **Unchanged:** the short single-instance id (absent `:instance`), the readable ASCII fast path, and the purity the reorder test relies on. No allocator, registry, duplicate scanner, or substrate API added.

## Tests

Host-neutral structural regressions in `pilot_field_cljs_test.cljc` (run on JVM **and** ClojureScript):
- `a-supplementary-code-point-is-encoded-whole-on-both-hosts` — asserts the exact `_d83d__de00_` / `_d83d__de01_` ids on both hosts (built from surrogate units, so the assertion never depends on how a host reads a literal from source).
- `an-unordered-identity-is-refused-loudly` — both array-map orders, a set, and a map nested in an ordered address fail loud; the ordered twin is accepted and stable.
- empty-string vs absent distinctness added to the existing injectivity test.

Mounted browser regression in `pilot_field_dom_cljs_test.cljs`:
- `pilot-two-emoji-instances-keep-distinct-mounted-ids` — two fields keyed 😀/😁 mount with distinct `aria-describedby`, each resolving by `getElementById` to its own region.

## Quality gates

All foreground, worktree-local logs, banners name the worktree `error-region-id-146`; exit codes are the verdict.

| Gate | Command (cwd) | Result |
| --- | --- | --- |
| JVM freehand | `clojure -M:test` (`implementation/freehand`) | Ran 877 tests, 6302 assertions — **0 failures, 0 errors** — EXIT=0 |
| Node CLJS freehand | `npm run test:freehand` (`implementation`) | Ran 905 tests, 5396 assertions — **0 failures, 0 errors** — EXIT=0 |
| Browser (Chromium) | `npm run test:browser` (`implementation`) | Ran 696 tests, 4273 assertions — **0 failures, 0 errors** — EXIT=0 |

Direct JVM probe on the collision host: `"😀"→_d83d__de00_`, `"😁"→_d83d__de01_`, `1→_v_1` vs `"1"→1`, `""` distinct from absent, and both array-map orders → `:unstable-field-identity`.

Closes rf2-drpa3.146.
