### PR TITLE
test(freehand): B2 bench EDN tag reader + B5 shipped-cost evidence (rf2-drpa3.168, .52)

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/bench/b2.cljc
+++ b/implementation/freehand/src/re_frame/freehand/bench/b2.cljc
@@ -185,6 +185,21 @@
   [views scale]
   (mapv (fn [view] [view scale]) views))
 
+(defn- id-plan
+  "The PUBLISHED form of a mount plan: `[[view-id mount-count] …]`, view
+  IDS rather than descriptors.
+
+  A descriptor prints as a `#re-frame.freehand/view` tagged literal, so a
+  fixture that published the raw plan would force every reader of the
+  evidence artefact to register a tag handler before it could read the
+  file back at all — which no reader of a benchmark artefact expects.
+  The id is the plain datum that names the same declaration and round-trips
+  through `clojure.edn/read-string` with none. It is exactly the id the
+  decomposition line for that declaration carries, so the two published
+  views of a plan name the same declarations."
+  [views scale]
+  (mapv (fn [view] [(:view-id (v/manifest view)) scale]) views))
+
 (defn- verdict
   [view]
   (:view-cell (v/manifest view)))
@@ -252,10 +267,17 @@
 (defn observe
   "Run one B2 iteration over `fixture` and answer its observations: the
   exact omitted-ViewCell count of each arm, read off the manifests the
-  plan's declarations carry."
-  [{:keys [free-plan read-plan]}]
-  {:B2/free-arm-omitted-cells (omitted free-plan)
-   :B2/read-arm-omitted-cells (omitted read-plan)})
+  plan's declarations carry.
+
+  Rebuilds the descriptor plan from the rosters and the fixture's `:scale`
+  rather than reading it back from the fixture. The published fixture
+  carries each arm's plan as view IDS — plain data an evidence reader can
+  read without a tag handler — and an id cannot be asked for its manifest.
+  The rosters are the same [[free-views]] / [[read-views]] the browser
+  mount builds its plan from, so both instruments measure one roster."
+  [{:keys [scale]}]
+  {:B2/free-arm-omitted-cells (omitted (plan free-views scale))
+   :B2/read-arm-omitted-cells (omitted (plan read-views scale))})
 
 ;; ---------------------------------------------------------------------------
 ;; The workloads
@@ -264,18 +286,22 @@
 (defn workload
   "Build the B2 workload for `scale`, under `id` and `sampling`.
 
-  The fixture carries the mount plans the `:run` reads and, published
-  beside them, the mount decomposition and the retained-object counts D021
-  asks B2 to publish — every one a per-declaration static fact, so the two
-  gated totals trace back to the declarations that produced them."
+  The fixture publishes each arm's mount plan as view IDS, and beside them
+  the mount decomposition and the retained-object counts D021 asks B2 to
+  publish — every one a per-declaration static fact, so the two gated
+  totals trace back to the declarations that produced them, and the whole
+  record reads back with plain `clojure.edn/read-string`. The `:run` does
+  not read the published plan: it rebuilds the descriptor plan from the
+  same rosters (see [[observe]]), because a manifest is read off a
+  descriptor, not off its id."
   [{:keys [id doc scale sampling]}]
   (let [free-plan (plan free-views scale)
         read-plan (plan read-views scale)]
     {:id       id
      :doc      doc
      :fixture  {:scale     scale
-                :free-plan free-plan
-                :read-plan read-plan
+                :free-plan (id-plan free-views scale)
+                :read-plan (id-plan read-views scale)
                 :free-arm  (arm-decomposition free-plan)
                 :read-arm  (arm-decomposition read-plan)}
      :baseline {:kind      :interpreted-vs-compiled

--- a/implementation/freehand/src/re_frame/freehand/bench/runner.cljc
+++ b/implementation/freehand/src/re_frame/freehand/bench/runner.cljc
@@ -125,6 +125,26 @@
           :report    (assoc outcome :command :suite)})))))
 
 ;; ---------------------------------------------------------------------------
+;; Stdout
+;; ---------------------------------------------------------------------------
+
+(defn render
+  "The exact bytes [[-main]] writes to stdout for a [[run-cli]] answer: the
+  human summary as leading `;;` comment lines, a blank `;;` separator, then
+  the report map pretty-printed.
+
+  Everything above the map is an EDN comment and the map is the datum, so
+  the whole string reads back with plain `clojure.edn/read-string` — no
+  `:default` tag handler, no reader registry. Pure, so that round-trip
+  contract is a test over a value rather than a claim about a process: a
+  future fixture carrying an opaque host value is caught here, at the door,
+  rather than by the first reader who tries to slurp the artefact."
+  [{:keys [summary report]}]
+  (str (reduce str "" (map #(str ";; " % "\n") summary))
+       ";;\n"
+       (with-out-str (pp/pprint report))))
+
+;; ---------------------------------------------------------------------------
 ;; Process
 ;; ---------------------------------------------------------------------------
 
@@ -135,10 +155,7 @@
 
 (defn -main
   [& args]
-  (let [{:keys [exit-code summary report]} (run-cli args)]
-    (doseq [line summary]
-      (println (str ";; " line)))
-    (println ";;")
-    (pp/pprint report)
+  (let [{:keys [exit-code] :as answer} (run-cli args)]
+    (print (render answer))
     (flush)
     (exit! exit-code)))

--- a/implementation/freehand/test/re_frame/freehand/bench/runner_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/bench/runner_cljs_test.cljc
@@ -1,0 +1,68 @@
+(ns re-frame.freehand.bench.runner-cljs-test
+  "The stdout contract: everything the runner writes is EDN a PLAIN reader
+  can read.
+
+  [[re-frame.freehand.bench.runner]]'s docstring promises the same bytes
+  are both the thing a reviewer reads and the artefact a release cites —
+  `clojure -M:bench > out/freehand-bench.edn`, read back with
+  `clojure.edn/read-string`. A fixture that published a host value with no
+  EDN print form keeps that promise SYNTACTICALLY — a view descriptor
+  prints as a `#re-frame.freehand/view` tagged literal, and a tagged
+  literal is EDN — while breaking it operationally: the reader must
+  register a tag handler before the file will open at all, which no reader
+  of a benchmark artefact expects to.
+
+  So this suite reads the artefact the only way a consumer should have to:
+  with no `:default` handler and no tag registry. A future fixture that
+  smuggles an opaque host value is caught here, at the door, rather than by
+  the first reader who slurps the file. The discrimination test proves the
+  guard is real by putting a descriptor back and watching the same read
+  throw."
+  (:require [clojure.edn :as edn]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [re-frame.freehand.bench.b2 :as b2]
+            [re-frame.freehand.bench.runner :as runner]))
+
+(def ^:private provenance
+  "The revision a TEST supplies. A ClojureScript test process is not a
+  build pipeline: no environment variable, no git, and nothing it could
+  truthfully detect. The published run detects its own."
+  {:revision "test-fixture-revision"})
+
+;; ---------------------------------------------------------------------------
+;; The artefact reads back with a plain reader
+;; ---------------------------------------------------------------------------
+
+(deftest the-suite-artefact-reads-back-with-a-plain-edn-reader
+  (testing "the whole `clojure -M:bench` artefact — the summary as leading
+            `;;` comments and the report map beneath — reads back with
+            `clojure.edn/read-string`, no `:default` tag handler and no
+            reader registry, and to exactly the value it published."
+    (let [answer (runner/run-cli [] provenance)
+          stdout (runner/render answer)]
+      (is (not (str/includes? stdout "#re-frame.freehand/view"))
+          "no view descriptor rode the artefact as a tagged literal")
+      (let [parsed (edn/read-string stdout)]   ;; deliberately no {:default …}
+        (is (= (:report answer) parsed)
+            "the artefact reads back to exactly the report it published")))))
+
+;; ---------------------------------------------------------------------------
+;; …and the guard discriminates
+;; ---------------------------------------------------------------------------
+
+(deftest a-descriptor-in-a-fixture-would-red-this-very-guard
+  (testing "put a view DESCRIPTOR back into a published fixture — exactly
+            what B2 used to publish — and the same plain read throws. So the
+            first test passing is a real absence, not a reader quietly
+            tolerating a tag no one registered."
+    (let [descriptor (first b2/free-views)
+          leaked     (assoc-in (runner/run-cli [] provenance)
+                               [:report :results 0 :fixture :free-plan]
+                               [[descriptor 1]])
+          stdout     (runner/render leaked)]
+      (is (str/includes? stdout "#re-frame.freehand/view")
+          "a descriptor prints as a tagged literal — the print form the fix removes")
+      (is (thrown? #?(:clj Exception :cljs js/Error)
+                   (edn/read-string stdout))
+          "and a plain reader cannot read it back — which is the whole bug"))))


### PR DESCRIPTION
Two beads on the Freehand B-spine bench surface: a bench-EDN round-trip fix (rf2-drpa3.168, code) and the unblocked half of the B5 shipped-cost evidence (rf2-drpa3.52, measurement).

## rf2-drpa3.168 — B2 bench plans publish view IDs, not descriptors

`re-frame.freehand.bench.runner`'s docstring promises the same bytes are both the thing a reviewer reads and the artefact a release cites — `clojure -M:bench > out/freehand-bench.edn`, read back with `clojure.edn/read-string`. B2 weakened that: its `:fixture` published `:free-plan` / `:read-plan` as `[[<ViewDescriptor> mount-count] …]`, and a descriptor prints as a `#re-frame.freehand/view` tagged literal. Syntactically still EDN; operationally a consumer had to register a `:default` tag handler before the file would open at all (14 occurrences across the two B2 workloads).

**Fix** (`b2.cljc`): publish view **IDs** in the plan. The IDs are exactly the ones each decomposition line already carries, so the published record still names which declaration earned which verdict. `observe` rebuilds the descriptor plan from the same rosters (`free-views` / `read-views`) the browser mount builds from — a manifest is read off a descriptor, not off its id — so the gate's arithmetic is unchanged and both arms still measure one roster. Only the *published* copy changed; `b2/plan` still returns descriptors for the browser mount.

**Durability** (`runner.cljc` + `runner_cljs_test.cljc`): extracted `runner/render` as the pure stdout bytes so the round-trip is a test over a value, not a claim about a process. The new test reads the whole artefact with plain `clojure.edn/read-string` — no `:default` handler, no tag registry — and the guard discriminates: putting a descriptor back into a fixture reds the same read. So a future fixture carrying an opaque host value is caught at the door.

## rf2-drpa3.52 — B5 shipped-cost evidence (bundle bytes + parse/compile)

Scoped to the bead's currently-unblocked slice: *"the bundle-bytes / reachability half can proceed against `out/freehand-release/main.js` now."* Measured the one release build on main, `:freehand-release` (a **mixed** shape — an interpreted `counter`, its `{:compiled true}` twin, and a root that mounts both over one frame).

**Evidence — each figure tied to the artefact by its sha256, so a rebuild that changes the sha withdraws these specific numbers:**

| Metric | Value |
|---|---|
| artefact | `out/freehand-release/main.js` (build `:freehand-release`, `:advanced`, `goog.DEBUG false`) |
| revision | `f7cdcada67` (this branch, on origin/main) |
| **sha256** | `a581ddc97f5ec33a66cbe459047c36b98e8263a634a2dcd9d78f7d28c8de54eb` |
| raw bytes | **736,157** |
| gzip (zlib default, level 6) | **218,032** |
| gzip (level 9) | **217,046** |
| brotli | **180,786** |
| V8 parse+compile, eager (n=25, Node v24.13.0) | **p50 2.51 ms**, p95 2.89 ms, min 2.20 ms, max 3.83 ms |

Parse/compile is measured with `new vm.Script(code, {produceCachedData:true})`, which forces eager compilation of every function body (a bare `new vm.Script` only pre-parses and defers the rest lazily). Bytes and parse/compile are **evidence only** — no threshold, no verdict (D021; `NON-GOALS: a byte-size threshold`).

Genuinely `:advanced`: zero un-mangled CLJS function names (`re_frame$freehand$…$…` → 0 matches), live identifiers mangled (the keyword constructor compiles to `y`), and every surviving `freehand` token is a string constant (keyword namespace / error text), so the bytes reflect real shipped cost.

### What this bead still owes, and why it is not in this PR

The remainder is genuinely blocked, not skipped — measuring it here would fabricate an artefact that does not exist:

- **Three bundle shapes + per-promotion delta** (acceptance #2's interpreted-only / compiled-only builds and the promotion delta): main has exactly one Freehand release build. Splitting it into matched interpreted / compiled / mixed builds lands in `implementation/shadow-cljs.edn`, a hot-zone file — a sequential build-lane slice, out of this evidence-lane worker's bench surface.
- **Initial-mount time**: needs the mixed bundle mounted in a browser (the release build has no `:dev-http` and is inspected, never served). Belongs with the browser-harness slice above.
- **Deterministic reachability gate** (acceptance #1, control-build technique): blocked on **rf2-3naow** (the dev-gated emission seam, still OPEN) — there is no gate for a control build to toggle yet, so the isolation proof is not buildable. The naive oracles are known-wrong here (a debug flag survives 225× in docstrings; Closure inlines small function names), so this is deliberately not attempted.

rf2-drpa3.52 is therefore left OPEN with these measurements recorded; only the bundle-bytes/parse-compile evidence is delivered.

## Quality gates

All foreground, worktree-local logs, from `implementation/freehand` unless noted.

| Gate | Command | Result |
|---|---|---|
| Bench suite EDN round-trip (JVM) | `clojure -M:bench` → `clojure.edn/read-string` (no `:default`) | **EXIT 0**; 6 workloads; 0 `#re-frame.freehand/view` tags; reads back to a `:suite` map; `:free-plan` = `[[:re-frame.freehand.bench.b2/free-label 650] …]` |
| Bench suite EDN round-trip (Node) | `npm run --silent bench:freehand-node` (`RF2_REVISION` set) → plain read | **EXIT 0**; 8 workloads; 0 tags; reads back to an 8-result `:suite` map |
| Falsifiability proof | `clojure -M:bench --prove` | **EXIT 0**; proven both ways |
| Freehand JVM suite | `clojure -M:test` | **EXIT 0**; 877 tests, 6297 assertions, 0 failures, 0 errors |
| New round-trip test (isolated) | `clojure -M:test -n …bench.runner-cljs-test` | **EXIT 0**; 2 tests, 4 assertions, 0 failures |
| Release build (B5 artefact) | `npm run build:freehand-release` | **EXIT 0**; 173 files, 0 warnings |

The Node bench lane requires a revision to emit a provenance-complete record (`detect-revision` returns nil under a bare `node` run, no `RF2_REVISION`/`GITHUB_SHA`); it was run with `RF2_REVISION` set to HEAD. This is pre-existing provenance policy, not a change here.

Closes rf2-drpa3.168.
Refs rf2-drpa3.52 (bundle-bytes/parse-compile evidence), rf2-3naow (blocks the reachability gate).
