### PR TITLE
fix(freehand): virtual-table pilot restores its persisted scroll state (rf2-g5xxv)

### DIFF
--- a/implementation/freehand/test/re_frame/freehand/pilot_virtual_table.cljc
+++ b/implementation/freehand/test/re_frame/freehand/pilot_virtual_table.cljc
@@ -99,7 +99,17 @@
 (def tables-root
   "Where this library keeps its per-instance scroll state — a library
   decision, and ordinary app-db, so every table's position is visible to
-  tools, serialisable, and restored by time travel like anything else."
+  tools and serialisable.
+
+  The VALUE time-travels like any other state; whether a MOUNTED viewport
+  follows it is a separate question the table answers with `:restore-scroll?`
+  (see [[data-table]]). Without restoration the entry is a DOM-DERIVED CACHE —
+  the viewport writes it on scroll and reads it to pick the window, but
+  nothing writes it back, so a fresh or time-travelled state renders a remote
+  window while the viewport still sits at scrollTop 0. A table that needs the
+  reverse direction opts into the `:layout` [[restore-scroll]] behavior, which
+  is the honest cost: a viewport a behavior restores cannot be promoted,
+  because the compiled grammar admits no behavior form."
   :acme.ui/tables)
 
 (def default-overscan
@@ -170,6 +180,62 @@
       {:db (update db tables-root dissoc k)})))
 
 ;; ---------------------------------------------------------------------------
+;; Restoring the offset — the one imperative seam, and its cost
+;; ---------------------------------------------------------------------------
+;;
+;; The dataflow above is a ONE-WAY street: a scroll event writes the offset
+;; into app-db, and render reads it back to pick the window. That is all a
+;; DOM-DERIVED CACHE needs — the viewport is the source of truth and app-db
+;; trails it. But a cache cannot be RESTORED. Seed the offset before a mount,
+;; or move it by time travel under a mounted table, and render picks the
+;; remote window while the fresh viewport still sits at scrollTop 0: the rows
+;; are painted at 3072px and the box shows blank.
+;;
+;; Writing the persisted offset BACK onto the viewport is host work — it reads
+;; and mutates a live DOM node before the browser paints — which is exactly
+;; what `v/behavior`'s `:layout` timing is for and the ONE seam the substrate
+;; sanctions for it. The cost is explicit, and it is the point: a viewport a
+;; behavior restores cannot be PROMOTED, because the compiled grammar admits
+;; no behavior form. So restoration is OPT-IN (`:restore-scroll?`), the default
+;; table stays a compilable cache, and a table that needs the reverse
+;; direction takes it knowing it has chosen the interpreted tier.
+
+(defn- restore-scroll-top!
+  "Move `node`'s `scrollTop` to `top`, but ONLY when they differ — so a write
+  that would change nothing fires no spurious scroll event, and the behavior
+  never overwrites an offset the viewport already holds (the ordinary
+  user-scroll path, where the DOM already carries the value app-db just
+  learned)."
+  [node top]
+  #?(:cljs
+     (let [top (max 0 (long (or top 0)))]
+       (when (not= (.-scrollTop node) top)
+         (set! (.-scrollTop node) top))))
+  nil)
+
+(v/defbehavior restore-scroll
+  "Write the persisted scroll offset back onto the viewport, before paint.
+
+  `:config` carries `{:scroll-top n}` — the offset app-db holds for this
+  table. `:connect` restores it into a freshly mounted viewport; `:update`
+  follows it when the stored value MOVES (a time-travel restore, a
+  programmatic set) while the DOM has not. Both write through
+  [[restore-scroll-top!]], which touches the node only when it disagrees with
+  the state, so an ordinary user scroll — where app-db is merely trailing the
+  DOM — moves no host state at all.
+
+  `:layout`, because a restore that ran after paint would show the wrong rows
+  for one frame. Attaching this behavior is what makes a restoring table
+  interpreted-only: it is the promotion cost the [[tables-root]] note names."
+  {:timing  :layout
+   :connect (fn [{:keys [node config]}]
+              (restore-scroll-top! node (:scroll-top config))
+              nil)
+   :update  (fn [{:keys [node config]}]
+              (restore-scroll-top! node (:scroll-top config))
+              nil)})
+
+;; ---------------------------------------------------------------------------
 ;; The component
 ;; ---------------------------------------------------------------------------
 
@@ -192,7 +258,16 @@
   place in the window.
 
   `:row` may be absent, and then the table renders its rows empty: a
-  component may offer content it does not require."
+  component may offer content it does not require.
+
+  `:restore-scroll?` turns the app-db offset from a DOM-derived cache into
+  CONTROLLED, restorable state: the viewport is wrapped in the `:layout`
+  [[restore-scroll]] behavior, which writes the persisted offset back onto a
+  freshly mounted or time-travelled viewport before paint. It is off by
+  default because attaching a behavior makes the table interpreted-only — the
+  compiled grammar has no behavior form — so a caller opts in for a table
+  whose scroll position must survive a mount or a restore, and pays the
+  promotion cost knowingly."
   {:props [:map
            [:table-key :any]
            [:rows :any]
@@ -201,8 +276,10 @@
            [:label :string]
            [:row {:optional true} :any]
            [:row-key {:optional true} :any]
-           [:overscan {:optional true} :int]]}
-  [{:keys [table-key rows row row-h viewport-h label row-key overscan]}]
+           [:overscan {:optional true} :int]
+           [:restore-scroll? {:optional true} :boolean]]}
+  [{:keys [table-key rows row row-h viewport-h label row-key overscan
+           restore-scroll?]}]
   (let [total  (count rows)
         top    (v/sub [:acme.ui.table/scroll-top table-key])
         key-of (or row-key :id)
@@ -212,39 +289,52 @@
                         :scroll-top top
                         :overscan   overscan})
         start  (:start w)
-        end    (:end w)]
+        end    (:end w)
+        ;; The scrolling box, bound so the `:restore-scroll?` decision can
+        ;; wrap it in the restore behavior without duplicating it. The
+        ;; behavior owns exactly ONE node (`v/behavior`'s one-node rule), and
+        ;; the viewport — the element that carries `scrollTop` — is that node.
+        viewport
+        [:div {:data-part     "viewport"
+               :role          "grid"
+               :aria-label    label
+               :aria-rowcount total
+               :style         {:height viewport-h :overflow-y "auto"}
+               :on-scroll     [:acme.ui.table/scrolled table-key ::v/scroll-top]}
+         [:div {:data-part "canvas"
+                :style     {:height (* total row-h) :position "relative"}}
+          ;; Two spellings the grammar decides for you, and both are worth
+          ;; naming because a Reagent-shaped hand reaches for the other one:
+          ;;
+          ;;   * the `:let` MODIFIER, not a `let` wrapping the body — a
+          ;;     compiled `for` body is a keyed element, view or fragment
+          ;;     DIRECTLY, with nothing in between; and
+          ;;   * `:key` in the PROPS MAP, not `^{:key …}` metadata — the
+          ;;     tree carries no metadata contract, so the key is an
+          ;;     ordinary reserved prop slot in both modes.
+          (for [i (range start end)
+                :let [r (nth rows i)]]
+            [:div {:key           (key-of r)
+                   :data-part     "row"
+                   :role          "row"
+                   :aria-rowindex (inc i)
+                   :data-row-key  (str (key-of r))
+                   :style         {:position "absolute"
+                                   :top      (* i row-h)
+                                   :height   row-h}}
+             (v/slot row r i)])]]]
     [:div {:data-component component-id
            :data-part      "root"
            :style          {:--acme-table-row-h      (str row-h "px")
                             :--acme-table-viewport-h (str viewport-h "px")}}
-     [:div {:data-part     "viewport"
-            :role          "grid"
-            :aria-label    label
-            :aria-rowcount total
-            :style         {:height viewport-h :overflow-y "auto"}
-            :on-scroll     [:acme.ui.table/scrolled table-key ::v/scroll-top]}
-      [:div {:data-part "canvas"
-             :style     {:height (* total row-h) :position "relative"}}
-       ;; Two spellings the grammar decides for you, and both are worth
-       ;; naming because a Reagent-shaped hand reaches for the other one:
-       ;;
-       ;;   * the `:let` MODIFIER, not a `let` wrapping the body — a
-       ;;     compiled `for` body is a keyed element, view or fragment
-       ;;     DIRECTLY, with nothing in between; and
-       ;;   * `:key` in the PROPS MAP, not `^{:key …}` metadata — the
-       ;;     tree carries no metadata contract, so the key is an
-       ;;     ordinary reserved prop slot in both modes.
-       (for [i (range start end)
-             :let [r (nth rows i)]]
-         [:div {:key           (key-of r)
-                :data-part     "row"
-                :role          "row"
-                :aria-rowindex (inc i)
-                :data-row-key  (str (key-of r))
-                :style         {:position "absolute"
-                                :top      (* i row-h)
-                                :height   row-h}}
-          (v/slot row r i)])]]]))
+     (if restore-scroll?
+       ;; Restorable: the viewport follows the persisted offset before paint.
+       ;; `:config` is DATA — the offset alone — and the behavior reads it on
+       ;; connect and on every move, which is what closes the reverse
+       ;; direction render alone cannot.
+       [v/behavior {:use restore-scroll :config {:scroll-top top}} viewport]
+       ;; Cache-only: the offset trails the DOM and nothing writes it back.
+       viewport)]))
 
 ;; ===========================================================================
 ;; THE APPLICATIONS — two callers, two shapes of row content

--- a/implementation/freehand/test/re_frame/freehand/pilot_virtual_table_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/pilot_virtual_table_dom_cljs_test.cljs
@@ -183,6 +183,22 @@
                   :row        (v/render-fn [r i]
                                 [ui/ledger-row-cells {:record r :index i}])}])
 
+(v/defview restoring-ledger
+  "The pilot's caller with scroll RESTORATION on — `:restore-scroll? true`,
+  the interpreted-only variant that writes its persisted offset back onto the
+  viewport before paint. Otherwise identical to [[live-ledger]], so the two
+  differ by exactly the option under test."
+  [_]
+  [ui/data-table {:table-key       ui/ledger-key
+                  :rows            (v/sub [:dom/rows])
+                  :row-key         :id
+                  :row-h           ui/row-h
+                  :viewport-h      ui/viewport-h
+                  :label           "Q3 ledger"
+                  :restore-scroll? true
+                  :row             (v/render-fn [r i]
+                                     [ui/ledger-row-cells {:record r :index i}])}])
+
 (defn- seed! [n]
   (live-frame/make-frame {:id fid})
   (ui/register!)
@@ -211,6 +227,22 @@
   signature the deterministic settle waits out)."
   []
   (get-in (frame/frame-app-db-value fid) [ui/tables-root ui/ledger-key :scroll-top]))
+
+(defn- viewport-scroll-top
+  "The live DOM `scrollTop` of the mounted viewport — the number the
+  restoration is about. It is what a fresh mount leaves at 0 and a restore
+  moves, so it is the discriminating reading: render alone cannot change it."
+  [container]
+  (.-scrollTop (viewport container)))
+
+(defn- seed-offset!
+  "Persist an offset into app-db BEFORE any table is mounted — the reserved
+  `::v/scroll-top` event, dispatched synchronously with NO viewport in the
+  document to move. This is the restore that a remount or a time-travel
+  produces: app-db holds a non-zero offset that no live DOM node put there."
+  [top]
+  (rf/dispatch-sync [:acme.ui.table/scrolled ui/ledger-key top] {:frame fid})
+  nil)
 
 ;; ===========================================================================
 ;; The mount
@@ -459,3 +491,149 @@
                   (unmount! container mounted)
                   (done)))
               (.catch (fn [e] (is false (str "mount threw " e)) (done)))))))))
+
+;; ===========================================================================
+;; RESTORATION — the reverse direction, and its promotion cost (rf2-g5xxv)
+;; ===========================================================================
+;;
+;; The pilot's dataflow is one-way: a scroll writes app-db, render reads it to
+;; pick the window. That is a DOM-DERIVED CACHE, and a cache cannot be
+;; restored. `:restore-scroll?` attaches the `:layout` restore behavior, which
+;; writes the persisted offset back onto the viewport before paint — the ONE
+;; sanctioned imperative seam, and the reason a restoring table is
+;; interpreted-only (the compiled grammar has no behavior form). These three
+;; suites prove the write happens, prove it is what moves the viewport, and —
+;; through a cache-only CONTROL seeded identically — prove they diverge exactly
+;; where the write is. The discipline is the deterministic settle the
+;; user-scroll suites use, never a single-tick race.
+
+(deftest a-seeded-offset-is-restored-into-a-fresh-viewport-before-paint
+  (testing "The restore the headline turns on: an offset persisted BEFORE any
+            table exists — the shape a remount or a time-travel leaves in
+            app-db — is written back onto the fresh viewport, so the DOM
+            scrollTop, the rendered row window and the app-db value all agree
+            at the first commit. Nothing scrolls the DOM; the only thing that
+            can move the viewport off zero is the restoration, which is what
+            makes this discriminating — strip the :layout write and the window
+            still reads r96…r124 while the viewport sits at 0."
+    (if-not (browser?)
+      (skip! "the browser job runs the restore assertions")
+      (async done
+        (let [container (host-node!)
+              state     (atom {})]
+          (seed! total)
+          (seed-offset! 3200)
+          (-> (act #(v/mount [restoring-ledger {}] container {:frame fid}))
+              (.then (fn [mounted]
+                       (swap! state assoc :mounted mounted)
+                       (live!)
+                       ;; The restore rides the mount's own layout commit; poll
+                       ;; the same way the user-scroll suites do, so the read is
+                       ;; off a state known to have settled rather than a race.
+                       (await-settle!
+                         #(and (= 3200 (viewport-scroll-top container))
+                               (= 3200 (ledger-scroll-top))
+                               (= 29 (count (row-nodes container))))
+                         "a seeded offset restores into the fresh viewport")))
+              (.then (fn [_]
+                       (is (= 3200 (viewport-scroll-top container))
+                           "the fresh viewport was moved to the persisted offset —
+                            the restoration wrote the DOM, nothing scrolled it")
+                       (is (= 3200 (ledger-scroll-top))
+                           "and app-db still holds that offset")
+                       (is (= 29 (count (row-nodes container)))
+                           "the window is the 29 rows the offset selects")
+                       (is (= (mapv #(str "r" %) (range 96 125)) (row-keys container))
+                           "r96 … r124 — the rows now under the restored viewport")
+                       (unmount! container (:mounted @state))
+                       (done)))
+              (.catch (fn [e]
+                        (is false (str "the restore pass threw " e))
+                        (done)))))))))
+
+(deftest time-travel-on-a-mounted-table-moves-the-viewport-not-only-the-window
+  (testing "The reverse direction the one-way dataflow never exercised: a
+            MOUNTED restoring table whose app-db offset is moved by an EVENT —
+            a time-travel restore, a programmatic set — and not by a scrollbar.
+            Render moves the window and the behavior's :update moves the
+            viewport to match, so the two never disagree. The existing mounted
+            suites move the DOM first; this one never touches it, so it fails
+            the moment the reverse write is removed."
+    (if-not (browser?)
+      (skip! "the browser job runs the time-travel assertions")
+      (async done
+        (let [container (host-node!)
+              state     (atom {})]
+          (seed! total)
+          (-> (act #(v/mount [restoring-ledger {}] container {:frame fid}))
+              (.then (fn [mounted]
+                       (swap! state assoc :mounted mounted)
+                       (is (= 0 (viewport-scroll-top container))
+                           "the fresh viewport starts at the top")
+                       (is (= (mapv #(str "r" %) (range 0 25)) (row-keys container))
+                           "showing the first window")
+                       (live!)
+                       ;; Move the STATE, not the DOM — the offset arrives the
+                       ;; way a restore-epoch leaves it, with the viewport at 0.
+                       (seed-offset! 3200)
+                       (await-settle!
+                         #(and (= 3200 (viewport-scroll-top container))
+                               (= "r96" (first (row-keys container))))
+                         "a state-only offset move drags the viewport after it")))
+              (.then (fn [_]
+                       (is (= 3200 (viewport-scroll-top container))
+                           "the viewport followed the state — the reverse
+                            direction render alone cannot produce")
+                       (is (= 3200 (ledger-scroll-top))
+                           "app-db and the DOM agree")
+                       (is (= (mapv #(str "r" %) (range 96 125)) (row-keys container))
+                           "and the window is the one that offset selects")
+                       (unmount! container (:mounted @state))
+                       (done)))
+              (.catch (fn [e]
+                        (is false (str "the time-travel pass threw " e))
+                        (done)))))))))
+
+(deftest without-restoration-a-seeded-offset-leaves-the-viewport-at-zero
+  (testing "The adversarial CONTROL that makes the restore load-bearing: the
+            SAME offset seeded before the SAME mount, but through
+            [[live-ledger]] — the cache-only table, `:restore-scroll?` absent.
+            Render still picks the remote window from the persisted offset, but
+            nothing writes it back, so the fresh viewport stays at scrollTop 0
+            while it paints r96…r124 at 3072px — the internally inconsistent
+            state the bug describes. This is the restore test with the :layout
+            write removed, and it must DIVERGE: a restoring table reads 3200
+            here, a cache-only one reads 0."
+    (if-not (browser?)
+      (skip! "the browser job runs the control assertions")
+      (async done
+        (let [container (host-node!)
+              state     (atom {})]
+          (seed! total)
+          (seed-offset! 3200)
+          (-> (act #(v/mount [live-ledger {}] container {:frame fid}))
+              (.then (fn [mounted]
+                       (swap! state assoc :mounted mounted)
+                       (live!)
+                       ;; Allow the same settle window the restore test grants,
+                       ;; so a slow restore could not pass here as its absence:
+                       ;; the window commits from the offset, then the viewport
+                       ;; is read on a table that never moved it.
+                       (await-settle!
+                         #(and (= 3200 (ledger-scroll-top))
+                               (= 29 (count (row-nodes container))))
+                         "the cache table renders the remote window from the offset")))
+              (.then (fn [_]
+                       (is (= 3200 (ledger-scroll-top))
+                           "app-db holds the seeded offset")
+                       (is (= (mapv #(str "r" %) (range 96 125)) (row-keys container))
+                           "and render picked the remote window from it")
+                       (is (= 0 (viewport-scroll-top container))
+                           "but the cache-only viewport was never moved — it sits
+                            at 0 under a window painted at 3072px, the exact
+                            inconsistency :restore-scroll? closes")
+                       (unmount! container (:mounted @state))
+                       (done)))
+              (.catch (fn [e]
+                        (is false (str "the control pass threw " e))
+                        (done)))))))))


### PR DESCRIPTION
Fixes **rf2-g5xxv**.

## The problem

The virtual-table pilot stored its per-instance scroll offset in app-db but the dataflow was **one-way**: the viewport's `on-scroll` copied the live DOM `scrollTop` into app-db, render read that value back to choose the row window, and *nothing ever wrote the stored value onto the viewport*. So a restored or programmatically-changed state was internally inconsistent — seed `3200` before a mount and render paints r96…r124 at ~3072px while the fresh viewport still sits at `scrollTop 0`, showing blank. The `tables-root` claim that the offset is "restored by time travel like anything else" was false for the DOM.

## The fix — restore at the viewport boundary, opt-in

An opt-in `:restore-scroll?` on `data-table` wraps the viewport in a `:layout` `v/behavior` (`restore-scroll`) — the one sanctioned imperative seam for before-paint host work:

- **`:connect`** restores the persisted offset into a freshly mounted viewport before paint.
- **`:update`** follows a state-only move (a time-travel restore, a programmatic set) when the DOM has not moved.
- The write is guarded to fire **only when the DOM disagrees with the state**, so the ordinary user-scroll path (app-db merely trailing the DOM) touches no host state and never fights the user.

### The acknowledged promotion cost

Restoration is **off by default**, deliberately: attaching a behavior makes the table **interpreted-only**, because the compiled grammar admits no behavior form. The default table stays a compilable DOM-derived cache, and the **compiled twin + promotion-parity suite are untouched**. A caller whose scroll must survive a mount or a restore opts in and pays the promotion cost knowingly. The `tables-root` and `data-table` docstrings now state this honestly (no general scroll registry, measurement protocol, or virtualization service was added — the change is one optional prop and one small behavior).

## Discriminating proof

Three real-browser regressions, all using the file's deterministic-settle discipline (`await-settle!` / `ledger-scroll-top`, no single-tick race):

1. `a-seeded-offset-is-restored-into-a-fresh-viewport-before-paint` — seeds the offset **before mount** and proves DOM `scrollTop`, rendered window and app-db value all agree.
2. `time-travel-on-a-mounted-table-moves-the-viewport-not-only-the-window` — moves the **state** under a mounted table (never the DOM) and proves the viewport follows — the reverse direction the one-way flow never exercised.
3. `without-restoration-a-seeded-offset-leaves-the-viewport-at-zero` — the adversarial **control**: the same offset, same mount, through the cache-only `live-ledger`; render still picks the remote window but the viewport stays at `0`. This is the restore test with the DOM write removed, and it diverges.

A **mutation probe** (DOM write neutered to a no-op) redded **exactly the two restore suites** (poll-timeout waiting for `scrollTop == 3200`) and left the control green — confirming the proof fails when the restoration step is removed, not because the DOM was moved first.

## Quality gates

All foreground, worktree-local, config banner confirmed naming this worktree.

| Gate | Command | Result |
|---|---|---|
| JVM freehand | `clojure -M:test` (from `implementation/freehand`) | **EXIT 0** — 875 tests, 6293 assertions, 0 failures, 0 errors |
| Node CLJS freehand | `npm run test:freehand` (from `implementation/`) | **EXIT 0** — 905 tests, 5389 assertions, 0 failures, 0 errors |
| Browser (DOM/scroll) | `npm run test:browser` (from `implementation/`) | **EXIT 0** — 698 tests, 4279 assertions, 0 failures, 0 errors |
| Mutation probe (adversarial) | `test:browser` with the DOM write neutered | **EXIT 1** — 2 failures (exactly the two restore suites), control green |

Surface: only `implementation/freehand/test/re_frame/freehand/pilot_virtual_table.cljc` and its `pilot_virtual_table_dom_cljs_test.cljs`. No `analyze.cljc`/`node.cljc`/`react.cljs`/`compiler/build.cljc` touched; compiled twin and parity suite unchanged.
