### PR TITLE
fix(freehand): config-bearing ENSURE fails loud over a boot/external frame — AC4 (rf2-drpa3.110)

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/root.cljs
+++ b/implementation/freehand/src/re_frame/freehand/root.cljs
@@ -717,6 +717,39 @@
                                   :installed-by       (:installed-by record)}
                       :arriving  {:config-fingerprint config-fingerprint
                                   :root-id            root-id}}}))
+      ;; The AUTHORITY arm (Spec 004C §7). A config-BEARING ENSURE that meets a
+      ;; frame already LIVE but with no `:installed-by` recorded — a fresh
+      ;; boot/external frame, or one this page only SCOPED under a prior
+      ;; config-less row — is meeting a BOOT-AUTHORITATIVE frame. There is no
+      ;; installer to refresh, so proceeding would let `make-frame` reset the
+      ;; boot config, write `:installed-by root-id` + `:installed-value`, and
+      ;; hand this root address-directed teardown authority — the final
+      ;; `unmount!` then destroying a frame the page never owned. Ownership is
+      ;; the right to have CREATED the frame; scoping is the honest way to
+      ;; reference one you did not. So this fails BEFORE `make-frame` mutates,
+      ;; distinct from the differing-fingerprint arm above: that recovers by
+      ;; aligning configs, this by dropping to a config-less scope or owning the
+      ;; whole lifetime. A first-time ENSURE (frame not yet live) and a same-root
+      ;; refresh (`:installed-by` already this root) both fall through untouched.
+      (when (and owned?
+                 (nil? (:installed-by record))
+                 (some? (frame/frame frame-id)))
+        (error/throw-error!
+          :rf.error/frame-payload-conflict where
+          (str "frame " (pr-str frame-id) " is already LIVE and this page does not "
+               "own it — it was booted or created elsewhere, or is only being "
+               "scoped here. A config-bearing :frame {:id …} plan would take it "
+               "over: reset its config now, then DESTROY it at unmount, silently "
+               "tearing down state this root never installed. Boot the frame "
+               "config-less and SCOPE it with :frame " (pr-str frame-id) ", or drop "
+               "the external make-frame and let this root own the frame's whole "
+               "lifetime.")
+          {:recovery :scope-config-less-or-own-the-lifetime
+           :extra    {:frame-id  frame-id
+                      :installed {:config-fingerprint (:config-fingerprint record)
+                                  :adopted            true}
+                      :arriving  {:config-fingerprint config-fingerprint
+                                  :root-id            root-id}}}))
       (let [installed-value
             (if owned?
               ;; ENSURE. `make-frame` is idempotent replacement: absent → created

--- a/implementation/freehand/test/re_frame/freehand/root_preflight_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/root_preflight_dom_cljs_test.cljs
@@ -93,6 +93,24 @@
   (try (thunk) ::no-throw
        (catch :default e (:rf.error/id (ex-data e)))))
 
+(defn- error-data
+  "The whole ex-data of the error `thunk` raised, or nil when it returned
+  normally — for the authority assertions that read a diagnostic's
+  `:recovery` alongside its id."
+  [thunk]
+  (try (thunk) nil (catch :default e (ex-data e))))
+
+(defn- detached-container
+  "A container the config-bearing AUTHORITY guard never renders into: it
+  throws in preflight, before createRoot, so this only has to satisfy the
+  admission container check. A real element in the browser, a minimal
+  stand-in in node — the node lane runs the fail-loud test because the
+  throw precedes React."
+  []
+  (if (browser?)
+    (js/document.createElement "div")
+    #js {:nodeType 1}))
+
 (defn- text [container selector]
   (some-> (.querySelector container selector) .-textContent))
 
@@ -472,3 +490,104 @@
                        (is false (str "same-id re-entrancy suite rejected: " e))
                        (.remove node)
                        (done)))))))))
+
+;; ===========================================================================
+;; FH-ROOT-004 — the authority rule (Spec 004C §7, AC4): a boot/external frame
+;; is never silently converted into address-directed teardown authority
+;; ===========================================================================
+
+(deftest fh-root-004-config-bearing-ensure-over-a-live-external-frame-fails-loud
+  (testing "Per FH-ROOT-004 / Spec 004C §7 (AC4): a config-bearing :frame
+            {:id …} ENSURE meeting a frame already LIVE that this page does
+            NOT own — a fresh boot/external frame the ledger records no
+            :installed-by for — must FAIL before make-frame mutates. Letting
+            it through would reset the boot frame's config, write :installed-by
+            and :installed-value for the arriving root, and hand that root the
+            address-directed authority to DESTROY at unmount a frame it never
+            installed. The throw precedes React, so the node lane runs this too.
+            The proof straddles the throw: the diagnostic is the authority
+            conflict under the scope-or-own recovery, and on the other side the
+            external frame's EXACT incarnation is untouched — same live token,
+            no ledger authority, nothing registered."
+    (reg!)
+    (let [fid   :fh.root/external-boot
+          _     (rf/make-frame {:id fid :initial-events [[:root/seed 7]]})
+          token (frame/frame-incarnation-token fid)
+          data  (error-data #(v/mount [views/counter {}] (detached-container)
+                                      {:frame {:id             fid
+                                               :initial-events [[:root/seed 999]]}}))]
+      (is (= :rf.error/frame-payload-conflict (:rf.error/id data))
+          "the config-bearing plan over a boot-authoritative frame is refused")
+      (is (= :scope-config-less-or-own-the-lifetime (:recovery data))
+          "under the scope-config-less-or-own-the-lifetime recovery — distinct
+           from the differing-fingerprint arm's :align-frame-plan-config")
+      (is (= fid (:frame-id data))
+          "and the diagnostic names the frame at stake")
+      (is (some? (frame/frame fid))
+          "the external frame is still LIVE — the guard fired before make-frame")
+      (is (identical? token (frame/frame-incarnation-token fid))
+          "and is the EXACT same incarnation the boot created — no reset")
+      (is (nil? (get (root/frame-ledger-snapshot) fid))
+          "no ledger authority was written for the frame this root does not own")
+      (is (empty? (root/live-root-ids))
+          "and the refused mount registered nothing"))))
+
+(deftest fh-root-004-a-config-less-scope-over-an-external-frame-transfers-no-ownership
+  (testing "Per FH-ROOT-004 / Spec 004C §7 (AC4): the other side of the
+            authority rule. A config-less :frame keyword SCOPES a boot/external
+            frame — it borrows it, recording a reference but NO installer — and
+            unmounting the scoping root leaves the exact external incarnation
+            LIVE: scoping never transfers ownership. A config-bearing plan over
+            that SAME boot-authoritative frame — even from the very root that is
+            scoping it — is refused as the authority conflict, and its refusal
+            leaves the incumbent root, the frame's incarnation and the ledger
+            untouched: a borrow cannot be retroactively promoted to ownership."
+    (if-not (browser?)
+      (skip! "the browser job renders the scope + unmount")
+      (async done
+        (reg!)
+        (let [node  (host-node!)
+              fid   :fh.root/external-scoped]
+          (rf/make-frame {:id fid :initial-events [[:root/seed 4]]})
+          (let [token (frame/frame-incarnation-token fid)]
+            (-> (act #(v/mount [views/counter {}] node {:frame fid}))
+                (.then
+                  (fn [scoped]
+                    (is (= "4" (text node ".count"))
+                        "the scoping root borrowed the owner's seed")
+                    (is (nil? (:installed-by (get (root/frame-ledger-snapshot) fid)))
+                        "the ledger records the reference but NO installer — borrowed, not owned")
+                    (is (contains? (:refs (get (root/frame-ledger-snapshot) fid))
+                                   (:root-id (root/root-descriptor scoped)))
+                        "the scoping root's reference is recorded")
+                    ;; A config-bearing plan over the SAME boot-authoritative frame is
+                    ;; the authority conflict — refused, incumbent untouched.
+                    (let [data (error-data
+                                 #(v/mount [views/counter {}] node
+                                           {:frame {:id             fid
+                                                    :initial-events [[:root/seed 999]]}}))]
+                      (is (= :rf.error/frame-payload-conflict (:rf.error/id data))
+                          "a config-bearing plan cannot take over the borrowed frame")
+                      (is (= :scope-config-less-or-own-the-lifetime (:recovery data))
+                          "under the scope-config-less-or-own-the-lifetime recovery")
+                      (is (identical? token (frame/frame-incarnation-token fid))
+                          "the refusal left the EXACT incarnation untouched")
+                      (is (nil? (:installed-by (get (root/frame-ledger-snapshot) fid)))
+                          "and wrote no installer authority over the borrowed frame")
+                      (is (= "4" (text node ".count"))
+                          "the incumbent scoping root is still rendering its borrowed seed"))
+                    (act #(v/unmount! scoped))))
+                (.then
+                  (fn [_]
+                    (is (some? (frame/frame fid))
+                        "unmounting the SCOPING root leaves the external frame LIVE — no transfer")
+                    (is (identical? token (frame/frame-incarnation-token fid))
+                        "and it is the exact same incarnation the boot created")
+                    (is (empty? (root/live-root-ids))
+                        "the scoping root is gone, and it destroyed nothing it borrowed")
+                    (.remove node)
+                    (done))
+                  (fn [e]
+                    (is false (str "scope non-transfer suite rejected: " e))
+                    (.remove node)
+                    (done))))))))))


### PR DESCRIPTION
Closes rf2-drpa3.110 (AC4 residual after #6818).

## What

PR #6818 fixed most of root-ownership exactness, but **acceptance criterion 4** was still unmet: a config-bearing `:frame {:id …}` ENSURE could silently take ownership of a boot/external frame. When `frame/frame frame-id` was already live but the ledger row carried no `:installed-by` — a fresh externally-created frame, or one recorded only under a prior config-less SCOPE row — `preflight!`'s conflict guard did not fire. `make-frame` reset the boot config, the row was stamped with `:installed-by root-id` + `:installed-value`, and the final `v/unmount!` destroyed a frame the root never installed, converting borrowed/addressed state into address-directed teardown authority.

## How the guard now fires

Per **Spec 004C §7's authority rule**, `preflight!` gains the AUTHORITY arm alongside the existing differing-fingerprint arm:

```
(when (and owned?
           (nil? (:installed-by record))
           (some? (frame/frame frame-id)))
  … throw :rf.error/frame-payload-conflict
        recovery :scope-config-less-or-own-the-lifetime …)
```

- Fires when a **config-bearing** plan (`owned?`) meets a frame that is **live** but has **no recorded installer** — the boot-authoritative window.
- Throws **before `make-frame` mutates**, so the frame, the ledger authority, the incumbent Root, and the DOM are all untouched (the throw precedes `attempt!` and React entirely).
- Same error code as the existing conflict, **distinct recovery** (`:scope-config-less-or-own-the-lifetime`, vs `:align-frame-plan-config` for a differing fingerprint) — matching the spec's two distinct triggers.
- A **first-time ENSURE** (frame not yet live) and a **same-root refresh** (`:installed-by` already this root) both fall through untouched, so the no-reseed fast path and the same-root config-refresh path (AC5) are unchanged. The config-less scope path was already a non-transfer and stays one.

## Regression cases (both new, in the existing FH-ROOT-004 preflight suite)

1. `fh-root-004-config-bearing-ensure-over-a-live-external-frame-fails-loud` — creates an external frame with `rf/make-frame`, retains its incarnation token, attempts a config-bearing `v/mount` over it. Asserts the authority diagnostic + `:scope-config-less-or-own-the-lifetime` recovery, and that the external frame's **exact incarnation** stays live, no ledger authority is written, and nothing is registered. **Node-lane runnable** — the throw precedes `createRoot`.
2. `fh-root-004-a-config-less-scope-over-an-external-frame-transfers-no-ownership` — scopes the same boot frame config-less (borrow: no installer recorded), shows a config-bearing plan over it is refused with the incumbent untouched, then unmounts the scoping root and asserts the **exact external incarnation is still live** — scoping never transfers ownership.

## Quality gates

All foreground, to completion, on this worktree.

| Gate | Command | Result |
|---|---|---|
| Freehand JVM | `clojure -M:test` (from `implementation/freehand`) | **875 tests / 6293 assertions, 0 failures, 0 errors** |
| Freehand node | `npm run test:freehand` (from `implementation`) | **904 tests / 5394 assertions, 0 failures, 0 errors** |
| Freehand browser | `npm run test:browser` (from `implementation`) | **697 tests / 4285 assertions, 0 failures, 0 errors** |

**Non-vacuity probe:** flipping the guard's `:recovery` keyword red'd exactly the new tests, naming them, on both lanes — 1 failure in the node lane (the node-runnable case #1) and 2 failures in the browser lane (both cases assert the recovery), each `expected :scope-config-less-or-own-the-lifetime / actual :NONVACUITY-PROBE-FLIP…`. Restored byte-identical; all gates green again.

## Scope note

Surface is `implementation/freehand/src/re_frame/freehand/root.cljs` (the ownership ledger) and its preflight test file only. The reopen note's **second gap — the `defonce` frame-ledger HMR migration for pre-#6818 legacy rows without `:installed-value`** — is out of this dispatch's scope and is left for a follow-up (filed separately).
