### PR TITLE
fix(api-manifest): parse-var-rows preserves owning namespace across namespace-less headings (rf2-etj5i)

### DIFF
--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/api_md_check.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/api_md_check.clj
@@ -184,6 +184,19 @@
   (when (str/starts-with? (str/triml line) "#")
     (second (re-find #"`([^`]+)`" line))))
 
+(defn- heading-level
+  "The ATX heading LEVEL — the count of leading `#`s — of a Markdown heading
+   line, or nil for a non-heading line (``## Compiled views`` -> 2,
+   ``### Root lifecycle`` -> 3). Used to decide whether a namespace-less heading
+   is a DESCENDANT of the heading that established the current owning namespace
+   (strictly deeper -> inherit) or a sibling/ancestor (same-or-shallower -> clear
+   it), so an intervening namespace-less subsection can no longer drop the owning
+   namespace a bare row is attributed to (rf2-etj5i)."
+  [line]
+  (let [t (str/triml line)]
+    (when (str/starts-with? t "#")
+      (count (take-while #(= \# %) t)))))
+
 (defn parse-var-rows
   "Pure var-row parser over `[[line-no line-text] ...]` indexed API.md lines
    (rf2-asxo3 — extracted from `parse-api-md-var-rows` so parser DISAPPEARANCE
@@ -194,35 +207,53 @@
    such heading), the context a BARE row is attributed to rather than its bare
    name (rf2-etj5i).
 
+   HEADING-LEVEL–AWARE NAMESPACE INHERITANCE (rf2-etj5i). A section heading that
+   NAMES a namespace establishes it, and records the heading LEVEL it was
+   established at. A following NAMESPACE-LESS heading (``### Root lifecycle``)
+   INHERITS that owning namespace when it is a DESCENDANT — strictly deeper than
+   the establishing heading — so a bare root verb under an ordinary nested
+   subsection stays attributed to its section's namespace; a namespace-less
+   heading at the SAME-OR-SHALLOWER level is a sibling/ancestor and CLEARS the
+   namespace (a new sibling section owns no inherited namespace). Without this, an
+   intervening namespace-less child heading dropped `section-ns` to nil and a bare
+   Freehand root verb under it was silently re-attributed to `re-frame.ui`.
+
    A row whose `M/Fn` cell is NOT a recognised var-kind marker (`var-kind-
    marker?` — e.g. the marker drifted to an unknown spelling like `Macro`) is
    SKIPPED: it never becomes a var-row. That is the disappearance the two-sided
    root-verb kind guard must not silently pass — it turns a dropped root-verb
    row into a caught `:kind-row-missing`, not a green (rf2-asxo3)."
   [indexed-lines]
-  (loop [lines      indexed-lines
-         tier-idx   nil
-         section-ns nil
-         acc        (transient [])]
+  (loop [lines            indexed-lines
+         tier-idx         nil
+         section-ns       nil
+         section-ns-level nil
+         acc              (transient [])]
     (if-let [[[n line] & more] (seq lines)]
       (let [cells (table-row-cells line)]
         (cond
           (nil? cells)
-          ;; A non-table line ends the current table's column context; a
-          ;; SECTION HEADING additionally re-establishes the owning namespace a
-          ;; bare row is attributed to (rf2-etj5i). A non-heading line (prose,
-          ;; blank, blockquote) keeps the current section namespace.
-          (recur more nil
-                 (if (str/starts-with? (str/triml line) "#")
-                   (section-heading-namespace line)
-                   section-ns)
-                 acc)
+          ;; A non-table line ends the current table's column context. A SECTION
+          ;; HEADING additionally re-establishes the owning namespace a bare row
+          ;; is attributed to (rf2-etj5i): a heading that NAMES a namespace sets
+          ;; it (recording the level it was established at); a NAMESPACE-LESS
+          ;; heading INHERITS the current owning namespace when it is a DESCENDANT
+          ;; (strictly deeper than the establishing heading) and CLEARS it when it
+          ;; is a sibling/ancestor (same-or-shallower level). A non-heading line
+          ;; (prose, blank, blockquote) keeps the current section context.
+          (if-let [level (heading-level line)]
+            (if-let [ns' (section-heading-namespace line)]
+              (recur more nil ns' level acc)
+              (if (and section-ns (> level section-ns-level))
+                (recur more nil section-ns section-ns-level acc)
+                (recur more nil nil nil acc)))
+            (recur more nil section-ns section-ns-level acc))
 
           (header-row? cells)
-          (recur more (tier-col-index cells) section-ns acc)
+          (recur more (tier-col-index cells) section-ns section-ns-level acc)
 
           (separator-row? cells)
-          (recur more tier-idx section-ns acc)
+          (recur more tier-idx section-ns section-ns-level acc)
 
           :else
           (let [first-cell (first cells)
@@ -232,7 +263,7 @@
                      (< tier-idx (count cells)))
               (if-let [tier (first-tier-token (nth cells tier-idx))]
                 (let [[qualifier bare] (parse-first-cell-ident (second m))]
-                  (recur more tier-idx section-ns
+                  (recur more tier-idx section-ns section-ns-level
                          (conj! acc {:var        bare
                                      :qualifier  qualifier
                                      :tier       tier
@@ -240,8 +271,8 @@
                                      :section-ns section-ns
                                      :line       n
                                      :raw        (second m)})))
-                (recur more tier-idx section-ns acc))
-              (recur more tier-idx section-ns acc)))))
+                (recur more tier-idx section-ns section-ns-level acc))
+              (recur more tier-idx section-ns section-ns-level acc)))))
       (persistent! acc))))
 
 (defn parse-api-md-var-rows

--- a/implementation/scripts/api-manifest/test/re_frame/api_manifest/api_md_check_test.clj
+++ b/implementation/scripts/api-manifest/test/re_frame/api_manifest/api_md_check_test.clj
@@ -440,6 +440,100 @@
             "exactly one re-frame.ui hydrate-root is seen — the bare Freehand row is not counted, so no duplicate false-red")))))
 
 ;; ---------------------------------------------------------------------------
+;; Namespace-less CHILD heading preserves the owning namespace (rf2-etj5i,
+;; PR #6819 residual). PR #6819 attributed a bare row to its section heading's
+;; namespace, but every heading — including a namespace-LESS one — replaced
+;; `section-ns`. So an ORDINARY nested subsection (`### Root lifecycle`) between
+;; a `## … re-frame.freehand` heading and a bare `hydrate-root` row dropped the
+;; owning namespace to nil, and `root-ui-row?` defaulted nil back to
+;; re-frame.ui — re-attributing the Freehand verb to re-frame.ui. These two
+;; END-TO-END parser fixtures each carry an intervening namespace-less child
+;; heading and cover BOTH failure directions: a FALSE-RED (a correct Freehand
+;; row counted as a duplicate re-frame.ui row) and a FALSE-GREEN (a re-frame.ui
+;; deletion masked by the mis-attributed Freehand row). The fix is heading-
+;; LEVEL-aware: a namespace-less DESCENDANT heading (strictly deeper) INHERITS
+;; the section namespace; a sibling/ancestor clears it.
+;; ---------------------------------------------------------------------------
+
+(def ^:private freehand-child-heading-false-red-lines
+  "A bare Freehand `hydrate-root` (Fn) under an ORDINARY nested namespace-less
+   child heading (`### Root lifecycle`) inside the `re-frame.freehand` section,
+   alongside a fully in-sync re-frame.ui root table (all four verbs). The
+   intervening namespace-less heading is exactly the residual case PR #6819
+   missed: it must NOT drop the owning `re-frame.freehand` namespace to nil."
+  [[1  "## Freehand views — `re-frame.freehand`"]
+   [2  ""]
+   [3  "### Root lifecycle"]
+   [4  ""]
+   [5  "| API | M/Fn | Tier | Notes |"]
+   [6  "|-----|------|------|-------|"]
+   [7  "| `hydrate-root` | Fn | front-porch | the freehand door |"]
+   [8  ""]
+   [9  "## Compiled views — `re-frame.ui`"]
+   [10 ""]
+   [11 "| API | M/Fn | Tier | Notes |"]
+   [12 "|-----|------|------|-------|"]
+   [13 "| `create-root`  | M  | advanced | compiled |"]
+   [14 "| `render!`      | M  | advanced | compiled |"]
+   [15 "| `hydrate-root` | M  | advanced | compiled |"]
+   [16 "| `unmount!`     | Fn | advanced | compiled |"]])
+
+(deftest namespace-less-child-heading-does-not-false-red-a-ui-row
+  (testing "FALSE-RED, END-TO-END (rf2-etj5i residual): a bare Freehand
+            hydrate-root under an intervening namespace-less `### Root lifecycle`
+            child heading INHERITS re-frame.freehand — not re-frame.ui — so it is
+            not counted as a second re-frame.ui hydrate-root; the in-sync
+            re-frame.ui root table stays green rather than reddening as a
+            :kind-row-duplicated"
+    (let [parsed  (c/parse-var-rows freehand-child-heading-false-red-lines)
+          by-line (into {} (map (juxt :line identity)) parsed)]
+      (is (= "re-frame.freehand" (:section-ns (get by-line 7)))
+          "the bare hydrate-root under the namespace-less child heading inherits re-frame.freehand")
+      (is (= "re-frame.ui" (:section-ns (get by-line 15)))
+          "the re-frame.ui hydrate-root is attributed to re-frame.ui")
+      (is (empty? (c/root-verb-kind-problems {:rows root-manifest-rows :api-rows parsed}))
+          "exactly one re-frame.ui row per verb — the Freehand row is not a duplicate; no false-red"))))
+
+(def ^:private freehand-child-heading-false-green-lines
+  "Same intervening namespace-less child heading, but the re-frame.ui section is
+   MISSING its hydrate-root row (a deletion). Before the level-aware fix the bare
+   Freehand hydrate-root — mis-attributed to re-frame.ui with the SAME :macro
+   kind — silently SATISFIED the requirement, masking the deletion (false-green).
+   The bare Freehand row carries `M` so kind alone cannot distinguish it."
+  [[1  "## Freehand views — `re-frame.freehand`"]
+   [2  ""]
+   [3  "### Root lifecycle"]
+   [4  ""]
+   [5  "| API | M/Fn | Tier | Notes |"]
+   [6  "|-----|------|------|-------|"]
+   [7  "| `hydrate-root` | M | front-porch | the freehand door |"]
+   [8  ""]
+   [9  "## Compiled views — `re-frame.ui`"]
+   [10 ""]
+   [11 "| API | M/Fn | Tier | Notes |"]
+   [12 "|-----|------|------|-------|"]
+   [13 "| `create-root`  | M  | advanced | compiled |"]
+   [14 "| `render!`      | M  | advanced | compiled |"]
+   [15 "| `unmount!`     | Fn | advanced | compiled |"]])
+
+(deftest namespace-less-child-heading-does-not-false-green-a-deleted-ui-row
+  (testing "FALSE-GREEN, END-TO-END (rf2-etj5i residual): with the re-frame.ui
+            hydrate-root row DELETED, a bare Freehand hydrate-root of the SAME
+            :macro kind under an intervening namespace-less `### Root lifecycle`
+            child heading does NOT satisfy the re-frame.ui requirement — it
+            inherits re-frame.freehand, so the deletion is caught
+            :kind-row-missing rather than silently adopted as green"
+    (let [parsed   (c/parse-var-rows freehand-child-heading-false-green-lines)
+          by-line  (into {} (map (juxt :line identity)) parsed)
+          problems (c/root-verb-kind-problems {:rows root-manifest-rows :api-rows parsed})]
+      (is (= "re-frame.freehand" (:section-ns (get by-line 7)))
+          "the bare hydrate-root under the namespace-less child heading inherits re-frame.freehand, not re-frame.ui")
+      (is (= 1 (count problems))
+          "the re-frame.ui hydrate-root deletion is the sole problem — the Freehand row does not mask it")
+      (is (= :kind-row-missing (:kind (first problems))))
+      (is (= "hydrate-root" (:var (first problems)))))))
+
+;; ---------------------------------------------------------------------------
 ;; END-TO-END parser disappearance (rf2-asxo3).
 ;;
 ;; The pure `parse-var-rows` core lets us feed synthetic indexed API.md lines.


### PR DESCRIPTION
## Problem (rf2-etj5i, PR #6819 audit residual)

PR #6819 taught `parse-var-rows` to attribute a bare API.md var-row to the namespace its Markdown section heading names in a code span. But every heading — including a **namespace-less** one — replaced `section-ns`. So an ordinary nested subsection between a `## Freehand views — \`re-frame.freehand\`` heading and a bare root-verb row dropped the owning namespace:

```
## Freehand views — `re-frame.freehand`   → section-ns = re-frame.freehand
### Root lifecycle                          → section-ns = nil   ← the bug
| `hydrate-root` | Fn | … |                 → parsed with :section-ns nil
```

`root-ui-row?` defaults `nil` back to `re-frame.ui`, so the bare Freehand verb was silently re-attributed to `re-frame.ui`:
- **false-red** — a correct Freehand row judged against re-frame.ui's verb kinds / counted as a duplicate re-frame.ui row; or
- **false-green** — a real re-frame.ui deletion masked by the mis-attributed Freehand row.

Confirmed through the shipped pure parser before the fix: the bare row parsed with `:section-ns nil` and `root-ui-row?` returned `true`.

## Fix (chosen approach: INHERIT, heading-level-aware)

`parse-var-rows` now tracks the heading **level** at which the current owning namespace was established:

- a heading that **names** a namespace establishes it and records its level;
- a **namespace-less DESCENDANT** heading (strictly deeper than the establishing heading) **inherits** the owning namespace;
- a namespace-less **sibling/ancestor** heading (same-or-shallower level) **clears** it (a new sibling section owns no inherited namespace).

Bounded repair — a small `heading-level` helper plus one extra loop accumulator (`section-ns-level`). No Markdown framework. A bare Freehand root verb under `### Root lifecycle` now resolves to `re-frame.freehand`, so it is neither counted as a re-frame.ui row nor able to prove/contradict the real re-frame.ui row.

Two end-to-end parser cases added, each with an intervening namespace-less child heading, covering **both** directions:
- `namespace-less-child-heading-does-not-false-red-a-ui-row`
- `namespace-less-child-heading-does-not-false-green-a-deleted-ui-row`

## Quality gates

- `clojure -M:test` (api-manifest full suite): **EXIT=0**, 136 tests / 317 assertions, 0 failures, 0 errors (was 134/310 — +2 tests, +7 assertions).
- Full `api_md_check/-main` against the **real** `spec/API.md`: **EXIT=0**, `OK: spec/API.md projection in sync (244 var-rows checked against the manifest)` — 0 regressions.
- **Non-vacuity probe**: reintroducing the bug (namespace-less heading always clears) reds **exactly** the two new tests (6 assertion failures, EXIT=1) naming `namespace-less-child-heading-does-not-false-red-a-ui-row` and `...-false-green-...`; source restored byte-identical (md5 verified) and the suite is green again.

Surface: `implementation/scripts/api-manifest/src/re_frame/api_manifest/api_md_check.clj` (the `parse-var-rows` parser) and its test file only. Synthetic markdown fixtures — `spec/API.md` itself is untouched.

Closes rf2-etj5i.