### PR TITLE
fix(core): make supersede-distinct-work-ids trace test wait on the signal, not a fixed timeout (rf2-xagmz)

### DIFF
--- a/implementation/http/test/re_frame/http_reply_lowering_test.clj
+++ b/implementation/http/test/re_frame/http_reply_lowering_test.clj
@@ -488,12 +488,28 @@
         (rf/dispatch-sync [:search/go])
         (rf/dispatch-sync [:search/go])
         (.countDown gate)
+        ;; Wait on the SIGNAL, not the clock (rf2-xagmz). The supersede is a
+        ;; real async round-trip: transport reply → reply lowering → app
+        ;; dispatch → stale-suppression trace. `poll-until` returns the
+        ;; instant the pred below is truthy — a delivered app reply AND the
+        ;; superseded attempt's `:rf.http/stale-suppressed` trace row have
+        ;; both landed. So the wait is bounded by the supersede signal, never
+        ;; a fixed sleep; the `:timeout-ms` is a pure backstop that fires only
+        ;; if the signal genuinely never arrives (a real regression). The old
+        ;; 5 s backstop was comfortable idle but marginal under this machine's
+        ;; six concurrent worker agents (each running shadow-cljs + JVM +
+        ;; Chromium) and a loaded CI runner — the async supersede landed
+        ;; AFTER the window, timing the machine, not the canonicalisation
+        ;; (it redded unrelated PRs, e.g. #6817). A generous, load-tolerant
+        ;; bound makes that false timeout unreachable while still failing
+        ;; fast on a genuinely stuck supersede. The probe interval is gentled
+        ;; so the poll itself adds little contention on a saturated JVM.
         (test-support/poll-until
           (fn []
             (when (and (seq @replies)
                        (some (fn [ev] (= :rf.http/stale-suppressed (:operation ev))) @traces))
               true))
-          {:timeout-ms 5000 :label "supersede-stale"})
+          {:timeout-ms 30000 :interval-ms 25 :label "supersede-stale"})
         (Thread/sleep 200)
         ;; Exactly one DELIVERED app reply — request #2's; #1 suppressed.
         (is (= 1 (count @replies))


### PR DESCRIPTION
Closes rf2-xagmz.

## What

The JVM test `supersede-distinct-work-ids-and-canonical-stale-trace`
(in `implementation/http`'s reply-lowering suite) drives a **real** HTTP
round-trip through `java.net.http.HttpClient`, supersedes the in-flight
request, then waits for the superseded attempt's canonical stale
reply-envelope trace before asserting. Its `poll-until` already awaits the
**real supersede signal** — a delivered app reply **and** the
`:rf.http/stale-suppressed` trace row — but the timeout backstop was a
fixed **5 s**. That was comfortable on an idle runner and marginal under
this machine's six concurrent worker agents (each running shadow-cljs +
JVM + Chromium) and a loaded CI runner: under saturation the async
supersede landed **after** the 5 s window, so the poll threw
`:rf.error/poll-until-timeout — supersede-stale`. That is a **machine-speed
measurement, not a correctness failure** — it redded unrelated PRs whose
diffs cannot reach trace superseding (e.g. #6817, an `events.cljc`
render-fn-arity change).

Sibling of rf2-eq2vx (the scroll-settle flake); same shape of fix — only
the **wait** changes.

## The change

One call site, one deftest. The pred (the real supersede signal) is
**unchanged**. The assertions are **unchanged and still exact** — distinct
carried/current `:work/id` (`[:rf.work/http :search 1 1]` vs
`[:rf.work/http :search 2 1]`), `:stale` status, `:suppressed` work-status,
`:rf.http/request-id-superseded` reason, and the canonical join key. Only
the backstop moved:

    - {:timeout-ms 5000 :label "supersede-stale"}
    + {:timeout-ms 30000 :interval-ms 25 :label "supersede-stale"}

`poll-until` returns the **instant** its pred is truthy, so the wait stays
bounded by the supersede signal, never a fixed sleep. The `:timeout-ms` is a
pure backstop that now fires only on a genuinely stuck supersede (a real
regression), not on scheduler jitter. The probe interval is gentled
(5 ms → 25 ms) so the poll itself adds little contention on a saturated JVM.
No production source changed.

## Quality gates

`clojure -M:test` from `implementation/core` is the nominal core lane, but
this test lives in the **http** artefact, so the gate that actually
exercises it is `implementation/http`'s JVM suite (`clojure -M:test`, the
test-quiet runner). All runs below are that suite. Exit code is the verdict.

**Full http JVM suite (warm):** `EXIT=0` — Ran 493 tests / 3787 assertions,
0 failures, 0 errors.

**10× full http JVM suite under induced CPU saturation** (28 CPU burners on
24 cores — reproducing the loaded-runner / six-concurrent-workers
condition the flake needs):

```
RUN 1  EXIT=0 ELAPSED=48s :: 0 failures, 0 errors.
RUN 2  EXIT=0 ELAPSED=48s :: 0 failures, 0 errors.
RUN 3  EXIT=0 ELAPSED=53s :: 0 failures, 0 errors.
RUN 4  EXIT=0 ELAPSED=57s :: 0 failures, 0 errors.
RUN 5  EXIT=0 ELAPSED=52s :: 0 failures, 0 errors.
RUN 6  EXIT=0 ELAPSED=47s :: 0 failures, 0 errors.
RUN 7  EXIT=0 ELAPSED=57s :: 0 failures, 0 errors.
RUN 8  EXIT=0 ELAPSED=60s :: 0 failures, 0 errors.
RUN 9  EXIT=0 ELAPSED=52s :: 0 failures, 0 errors.
RUN 10 EXIT=0 ELAPSED=62s :: 0 failures, 0 errors.
DONE loaded-runs=10 fails=0
```

Every one of the 10 saturated runs was green — 493 tests / 3787 assertions
each, 0 failures, 0 errors — the target test included. (Each run wraps the
whole suite; the runs stretched to 47–62 s under the 28-burner load vs 41 s
warm-idle, confirming the machine really was saturated.)

### Unreachability proof — delay injection (the eq2vx-style proof)

A few green runs prove nothing, so I proved the timeout is **unreachable**,
not merely unobserved, by **injecting a 7 s-late signal** into the pred
(the real signal made to arrive 7 s after the poll starts — modelling a
saturated runner where the async supersede lands late) and running the
target test both ways. Same injected lateness; only the bound differs:

- **E1 — injected 7 s-late signal + the OLD 5 s bound → `EXIT=1`**, a
  deterministic reproduction of the exact reported flake:
  `ERROR in (supersede-distinct-work-ids-and-canonical-stale-trace)
  (error.cljc:120) … poll-until timed out — supersede-stale
  [:rf.error/poll-until-timeout] {… :elapsed-ms 5010 :label "supersede-stale"}`.
- **E2 — injected 7 s-late signal + the shipped 30 s bound → `EXIT=0`**,
  Ran 1 test / **10 assertions**, 0 failures, 0 errors. The poll waited out
  the full ~7 s for the signal, then **all ten result assertions passed**.

E1 shows the old bound made the timeout *reachable* for a 7 s-late signal;
E2 shows the shipped bound makes that same lateness *green*, and that the
wait **tracks the signal** (it returned as soon as the delayed signal
condition was met and still asserted the exact supersede result — the
assertion is not loosened and a throw would **not** satisfy it). The
injection was a throwaway experiment on top of the committed fix and was
reverted with `git checkout` before pushing; the committed diff is the
one-line bound change above.

### Signal-bound structural argument

`poll-until` (`re-frame.test-support`, JVM arm) loops `(pred)` every
`interval-ms` and returns the truthy value the moment the pred is truthy;
it only throws once `System/currentTimeMillis >= deadline`. The pred here
**is** the supersede signal (delivered app reply ∧ observed
`:rf.http/stale-suppressed` trace), and that is exactly the state the
subsequent assertions read. Therefore the happy-path wait is bounded by the
**signal**, not the clock; raising the backstop from 5 s → 30 s strictly
shrinks the false-timeout window (the machine-speed measurement E1
reproduces) toward zero while preserving fast-fail on a genuinely stuck
supersede — a defect still reds, just at 30 s instead of 5 s.

## Scope

Sole file touched: `implementation/http/test/re_frame/http_reply_lowering_test.clj`
(the one deftest + its wait). The `poll-until` helper contract is unchanged
— only this call site's opts. No freehand file, no production source.
