### PR TITLE
fix(freehand): migrate pre-#6818 legacy ledger rows lacking :installed-value across HMR (rf2-4pvsy)

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/root.cljs
+++ b/implementation/freehand/src/re_frame/freehand/root.cljs
@@ -484,6 +484,18 @@
   (reset! frame-ledger {})
   nil)
 
+(defn ^:no-doc downgrade-ledger-row-to-pre-6818!
+  "Rewrite `frame-id`'s ledger row to the pre-#6818 LEGACY shape — an
+  installed row that still names its `:installed-by` but has NO
+  `:installed-value` key — a test-only seam. There is no other way to
+  produce that shape: current code always records the install value, so a
+  suite proving the HMR migration recovers the exact authority a `defonce`
+  ledger carried across a reload without it must seed the shape a prior
+  build wrote. Never application API."
+  [frame-id]
+  (swap! frame-ledger update frame-id dissoc :installed-value)
+  nil)
+
 (defn- owner-of-container
   [dom-node]
   (some (fn [[rid ^Root r]]
@@ -685,6 +697,39 @@
                     "which the root ENSUREs and owns for its lifetime.")
                {:value (error/diag-value-summary frame-opt)})))
 
+(defn- installed-value-for
+  "The frame VALUE an owned ledger row carries as its incarnation-EXACT
+  teardown authority. Prefer the value the plan just produced (a fresh
+  install or a config-edit re-run); else the value the standing install
+  already recorded; else — and only else — reconstruct it from the live
+  frame's current incarnation token.
+
+  That last arm is the pre-#6818 LEGACY migration. `frame-ledger` is
+  `defonce`, so a row written before `:installed-value` existed survives a
+  hot reload WITHOUT one. On the ordinary same-plan remount `make-frame`
+  does not run (the frame is live and the fingerprint matches), so no fresh
+  value arrives and the recorded value is nil — and left there, the final
+  `release-frame!` would `destroy-frame!` a nil: no incarnation token, no
+  teardown, the root-owned frame left LIVE and untracked past its last root.
+  The remount is where the reloaded code meets that row, so the remount is
+  where it heals it.
+
+  The recovered authority is EXACT, not address-directed. A same-id frame
+  that survives the reload keeps its `:drain-lock` by identity, so
+  `frame-incarnation-token` answers the very token the original `make-frame`
+  value carried; the reconstructed value therefore destroys EXACTLY that
+  incarnation and no-ops against a same-id successor reseated after it. A
+  row that already recorded its value short-circuits before the token read,
+  so only a legacy row ever reaches it, and a frame no longer live yields no
+  token — harmless, since teardown will not destroy an absent frame either."
+  [frame-id fresh-value recorded-value]
+  (or fresh-value
+      recorded-value
+      (when-let [token (frame/frame-incarnation-token frame-id)]
+        (frame/make-frame-value {:id          frame-id
+                                 :runnable-id frame-id
+                                 :token       token}))))
+
 (defn- preflight!
   "Run `plan` to completion, and answer the frame-id it bound. Called
   BEFORE `createRoot`, so a body that reads a subscription on its first
@@ -782,10 +827,13 @@
                  {:config-fingerprint (if owned? config-fingerprint (:config-fingerprint r))
                   :installed-by       (if owned? (or (:installed-by r) root-id) (:installed-by r))
                   ;; The install authority: the fresh value when the plan just ran,
-                  ;; else the value from the install that stands. A scoped mount
+                  ;; else the value from the install that stands, else the exact
+                  ;; incarnation recovered for a pre-#6818 LEGACY row a `defonce`
+                  ;; ledger carried across a hot reload without one. A scoped mount
                   ;; carries nothing of its own and leaves the row's value be.
                   :installed-value    (if owned?
-                                        (or installed-value (:installed-value r))
+                                        (installed-value-for frame-id installed-value
+                                                             (:installed-value r))
                                         (:installed-value r))
                   :refs               (conj (or (:refs r) #{}) root-id)})))
       frame-id)))

--- a/implementation/freehand/test/re_frame/freehand/root_teardown_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/root_teardown_dom_cljs_test.cljs
@@ -417,3 +417,140 @@
                   (is false (str "shared-frame suite rejected: " e))
                   (.remove installer-node) (.remove borrower-node)
                   (done)))))))))
+
+;; ===========================================================================
+;; FH-ROOT-005 — HMR migration of a pre-#6818 legacy ledger row (rf2-4pvsy)
+;;
+;; `frame-ledger` is `defonce`, so a row a pre-#6818 build wrote survives a hot
+;; reload WITHOUT an `:installed-value`. The reloaded code meets that row on the
+;; ordinary same-plan remount, where `make-frame` does not run — so nothing
+;; supplies the install value, and left nil the final `release-frame!` would
+;; `destroy-frame!` a nil: no incarnation token, no teardown, the root-owned
+;; frame left LIVE and untracked past its last root. The remount must MIGRATE
+;; the row instead, recovering the frame's exact current incarnation as the
+;; teardown authority so the surrounding `defonce` hot-reload path stays honest.
+;; ===========================================================================
+
+(deftest fh-root-005-a-legacy-row-is-migrated-on-remount-and-torn-down-exactly
+  (testing "Per FH-ROOT-005 / rf2-4pvsy (browser): a defonce ledger row a
+            pre-#6818 build carried across a hot reload has :installed-by but no
+            :installed-value. The same-plan remount MIGRATES it — recovering the
+            live frame's EXACT incarnation token as the row's install value
+            WITHOUT re-running the plan — so the final unmount destroys exactly
+            that incarnation and empties the ledger, where the un-migrated nil
+            would no-op the teardown and orphan the frame the root owns."
+    (if-not (browser?)
+      (skip! "the browser job runs the legacy-migration assertions")
+      (async done
+        (reg!)
+        (let [node   (host-node!)
+              fid    :fh.root/legacy
+              seeded 11
+              setup  (atom 0)
+              token  (atom nil)
+              plan   {:frame {:id             fid
+                              :initial-events [[:root/seed seeded]
+                                               [:root/legacy-setup]]}}]
+          (rf/reg-event :root/legacy-setup (fn [_ _] {:fx [[:root/legacy-setup true]]}))
+          (rf/reg-fx :root/legacy-setup (fn [_ _] (swap! setup inc)))
+          (-> (act #(v/mount [views/counter {}] node plan))
+              (.then
+                (fn [_mounted]
+                  (is (= (str seeded) (text node ".count")))
+                  (is (= 1 @setup) "the plan seeded once")
+                  ;; capture the frame that will survive the reload, so the
+                  ;; migration can be proved to recover THIS exact incarnation.
+                  (reset! token (frame/frame-incarnation-token fid))
+                  (is (some? (frame/frame-value-incarnation-token
+                               (:installed-value (get (root/frame-ledger-snapshot) fid))))
+                      "a fresh install records an incarnation-bearing value")
+                  ;; simulate the pre-#6818 shape the defonce ledger carried
+                  ;; across the reload: installer kept, install value gone.
+                  (root/downgrade-ledger-row-to-pre-6818! fid)
+                  (is (some? (:installed-by (get (root/frame-ledger-snapshot) fid)))
+                      "the legacy row still names its installer")
+                  (is (nil? (:installed-value (get (root/frame-ledger-snapshot) fid)))
+                      "but carries no install value — the pre-#6818 shape")
+                  ;; the reloaded code re-runs mount over the surviving row.
+                  (act #(v/mount [views/counter {}] node plan))))
+              (.then
+                (fn [remounted]
+                  (is (= (str seeded) (text node ".count")) "the remount re-rendered")
+                  (is (= 1 @setup)
+                      "and did NOT re-seed — the same-plan remount is the ratified
+                       no-op even over a legacy row")
+                  (is (identical? @token (frame/frame-incarnation-token fid))
+                      "the frame is the SAME incarnation across the reload — the
+                       migration recovered it, it did not recreate it")
+                  (is (identical? @token
+                                  (frame/frame-value-incarnation-token
+                                    (:installed-value (get (root/frame-ledger-snapshot) fid))))
+                      "and the migrated row now carries that EXACT incarnation as its
+                       teardown authority — the healed row is indistinguishable from a
+                       normally-installed one")
+                  (act #(v/unmount! remounted))))
+              (.then
+                (fn [_]
+                  (is (nil? (frame/frame fid))
+                      "final unmount destroyed the frame the root owned — the migrated
+                       authority tore it down, where the un-migrated nil would have
+                       no-opped and left it live and untracked")
+                  (is (empty? (root/frame-ledger-snapshot))
+                      "and the ledger is empty")
+                  (.remove node)
+                  (done))
+                (fn [e]
+                  (is false (str "legacy-migration suite rejected: " e))
+                  (.remove node)
+                  (done)))))))))
+
+(deftest fh-root-005-a-migrated-legacy-authority-is-incarnation-exact
+  (testing "Per FH-ROOT-005 / rf2-4pvsy (browser): the migration recovers an
+            INCARNATION-EXACT authority, not an address-directed one. After the
+            legacy row is migrated on remount, tear the recovered incarnation
+            down and stand a same-id SUCCESSOR in its place; unmounting the now
+            stale root must destroy the incarnation it owned — already gone — and
+            never reach through the id to kill the successor. A migration that
+            recovered a bare id would destroy whatever is live now, leaving the
+            id naming nothing at all."
+    (if-not (browser?)
+      (skip! "the browser job runs the migrated-exactness assertions")
+      (async done
+        (reg!)
+        (let [node       (host-node!)
+              fid        :fh.root/legacy-exact
+              plan       {:frame {:id fid :initial-events [[:root/seed 1]]}}
+              succ-token (atom nil)]
+          (-> (act #(v/mount [views/counter {}] node plan))
+              (.then
+                (fn [_installer]
+                  ;; downgrade to the legacy shape, then remount to migrate it.
+                  (root/downgrade-ledger-row-to-pre-6818! fid)
+                  (act #(v/mount [views/counter {}] node plan))))
+              (.then
+                (fn [remounted]
+                  ;; tear down the migrated incarnation and reseat a same-id
+                  ;; successor, retaining ITS exact token, THEN unmount the now
+                  ;; stale root.
+                  (rf/destroy-frame! fid)
+                  (rf/make-frame {:id fid :initial-events [[:root/seed 2]]})
+                  (reset! succ-token (frame/frame-incarnation-token fid))
+                  (act #(v/unmount! remounted))))
+              (.then
+                (fn [_]
+                  (is (some? (frame/frame fid))
+                      "the same-id successor is still live — the migrated authority
+                       tore down the incarnation it recovered, which was already gone,
+                       and never reached the successor")
+                  (is (identical? @succ-token (frame/frame-incarnation-token fid))
+                      "and it is the SUCCESSOR's exact incarnation, untouched — a
+                       bare-id migration would have destroyed it")
+                  (is (empty? (root/frame-ledger-snapshot))
+                      "the stale root released its own ledger reference")
+                  (rf/destroy-frame! fid)
+                  (.remove node)
+                  (done))
+                (fn [e]
+                  (is false (str "migrated-exactness suite rejected: " e))
+                  (.remove node)
+                  (done)))))))))


### PR DESCRIPTION
Migrates pre-#6818 legacy `defonce` frame-ledger rows that lack `:installed-value` so the Freehand root ownership model holds across an HMR carrying a legacy row (split from rf2-drpa3.110's second reopen).

## Defect

`re-frame.freehand.root/frame-ledger` is `defonce`, so a row written by pre-#6818 code survives a hot reload WITHOUT an `:installed-value`. On the ordinary same-plan remount the frame is live and the fingerprint matches, so `make-frame` never runs and no install value is produced; the ledger swap's `(or installed-value (:installed-value r))` therefore keeps nil. The final `release-frame!` then `destroy-frame!`s a nil — no incarnation token, so it no-ops — leaving the root-owned frame LIVE and untracked past its last root.

## Migration approach

The remount is where the reloaded code meets the surviving row, so the remount heals it. A new pure helper `installed-value-for` computes the owned row's teardown authority as `fresh-value → recorded-value → recovered`. The recovery arm — reached only for a legacy row (a fresh install has `fresh-value`; a normal row has `recorded-value`) — reconstructs the exact authority from the live frame's current incarnation token:

```clojure
(when-let [token (frame/frame-incarnation-token frame-id)]
  (frame/make-frame-value {:id frame-id :runnable-id frame-id :token token}))
```

A same-id frame that survives the reload keeps its `:drain-lock` by identity, so `frame-incarnation-token` returns the very token the original `make-frame` value carried — the reconstructed value destroys EXACTLY that incarnation and no-ops against a same-id successor reseated after it. The healed row is byte-indistinguishable from a normally-installed one. No `make-frame` re-run, so no re-seed; stays in the one existing ledger — no parallel registry, lease, or public API.

Surface: `implementation/freehand/src/re_frame/freehand/root.cljs` (helper + a `^:no-doc` test seam `downgrade-ledger-row-to-pre-6818!`, the only way to construct the legacy shape current code never writes) and a regression in `root_teardown_dom_cljs_test.cljs`.

## Quality gates

All run foreground to completion in the worker worktree; exit codes are the verdict.

| Gate | Command | Result |
| --- | --- | --- |
| Freehand JVM | `clojure -M:test` (implementation/freehand) | 884 tests, 6355 assertions, 0 failures, 0 errors — **EXIT=0** |
| Freehand node CLJS | `npm run test:freehand` | 915 tests, 5432 assertions, 0 failures, 0 errors — **EXIT=0** |
| Browser (DOM lifecycle) | `npm run test:browser` | 703 tests, 4321 assertions, 0 failures, 0 errors — **EXIT=0** |

**Regression** (browser lane, `root_teardown_dom_cljs_test.cljs`): two `deftest`s —
- `fh-root-005-a-legacy-row-is-migrated-on-remount-and-torn-down-exactly`: mounts an owned frame, seeds durable state through a setup-counter fx, downgrades the row to the pre-#6818 shape, runs the same-plan remount, then proves (a) the plan did NOT re-seed (`@setup == 1`), (b) the frame is the SAME incarnation across the reload, (c) the migrated row now carries that EXACT token, and (d) final unmount destroys the frame and empties the ledger.
- `fh-root-005-a-migrated-legacy-authority-is-incarnation-exact`: after migration, tears the recovered incarnation down and stands a same-id successor; unmounting the stale root leaves the successor's exact incarnation untouched — proving the recovered authority is incarnation-scoped, not address-directed.

**Non-vacuity** (two targeted flips, each recompiled + rerun in the browser, then restored byte-identical):
- Recovery arm disabled (legacy row keeps nil) → 2 failures naming `...-torn-down-exactly` (the owned frame left LIVE holding its seeded `:n 11`, exactly the defect) — **EXIT=1**.
- Recovery arm returns a bare frame-id (address-directed) → 3 failures naming BOTH tests (`...-torn-down-exactly` token-identity assertion + `...-incarnation-exact` successor destroyed) — **EXIT=1**.

Closes rf2-4pvsy.
