### PR TITLE
fix(freehand): narrow the error-region identity domain to injective caller shapes (rf2-drpa3.146)

### DIFF
--- a/implementation/freehand/test/re_frame/freehand/pilot_field.cljc
+++ b/implementation/freehand/test/re_frame/freehand/pilot_field.cljc
@@ -227,19 +227,36 @@
   [s]
   (str/replace s #"[^A-Za-z0-9]" hex-escape))
 
-(defn- ordered-identity?
-  "Does `v`'s printed form carry its identity? An atom's does, and a
-  SEQUENTIAL collection recursively of such does — order IS identity there. An
-  unordered collection's does NOT: `=` ignores a map's or a set's element
-  order, but a printed id cannot, so two `=` maps differing only in insertion
-  order would print two ids for ONE identity. Those answer false and are
-  refused at the boundary rather than emitted as a silently unstable id."
+(defn- accepted-identity?
+  "Is `v` in the CLOSED roster of identity shapes this codec encodes
+  INJECTIVELY and CANONICALLY? The roster is exactly the shapes the pilot's
+  callers name an instance with — a string, a keyword, an integer, or a VECTOR
+  (recursively) of those: the controlled field's line-id `:instance`, the
+  buffered field's `[:invoice id :reference]` `:control` address, and the
+  readable `name`. Everything else answers false and is refused at the
+  boundary.
+
+  The roster is small ON PURPOSE, and that smallness is what makes `pr-str` an
+  HONEST identity over it where it is a false one over arbitrary EDN. Its
+  members print CANONICALLY — a keyword prints one way, a vector preserves the
+  order that IS its identity — so two `=` values print alike; and their prints
+  are TYPE-DISTINGUISHED — `1`, `\"1\"` and `:1` print three ways — so two
+  distinct values never print alike. The shapes deliberately left OUT are the
+  ones that break one half or the other: a LIST, whose `=`-equal vector prints
+  differently (`(= [1 2] '(1 2))`, yet `[1 2]` and `(1 2)` print two ways); a
+  SYMBOL or BOOLEAN, whose print a distinct value can share (`(symbol \"true\")`
+  and `true` both print `true`); a MAP or SET, whose `=` ignores an order its
+  print preserves; a float or a char, carrying no canonical, type-unique print.
+  None of those carries its identity into a print `pr-str` could make injective,
+  so all are refused rather than silently aliased onto — or split away from —
+  another identity's id."
   [v]
   (cond
-    (map? v)  false
-    (set? v)  false
-    (coll? v) (every? ordered-identity? v)
-    :else     true))
+    (string? v)  true
+    (keyword? v) true
+    (int? v)     true
+    (vector? v)  (every? accepted-identity? v)
+    :else        false))
 
 (defn- id-token
   "A DOM-safe, INJECTIVE, host-stable token for one part of a control's
@@ -252,34 +269,42 @@
 
   A string is escaped directly, so an ordinary name — `\"description\"` —
   stays itself and a single-instance field keeps its short, readable id. Any
-  other value carries a reserved `_v_` prefix ahead of its escaped `pr-str`:
-  the prefix is one a string can never produce — a string's own `_` escapes
-  to `_5f_`, so no bare `_` survives — meaning a typed value and a string of
-  the same characters never collide, and `pr-str` keeps distinct values
-  distinct (a `:control` vector address escapes as one unambiguous token).
+  other ACCEPTED value carries a reserved `_v_` prefix ahead of its escaped
+  `pr-str`: the prefix is one a string can never produce — a string's own `_`
+  escapes to `_5f_`, so no bare `_` survives — meaning a typed value and a
+  string of the same characters never collide, and over the accepted roster
+  `pr-str` keeps distinct values distinct (a `:control` vector address escapes
+  as one unambiguous token).
 
-  For that `pr-str` to BE an identity the value's print must be order-stable,
-  so a non-string identity is required to be `ordered-identity?`: an unordered
-  map or set — whose `=` ignores an order its print preserves — is refused
-  loudly rather than emitted as an id two equal identities would not share. A
-  supplied string is never dropped, so an empty-string identity stays distinct
-  from an absent one rather than silently aliasing it. Pure and stable: the
-  same supported identity yields the same token on every render and after a
-  list reorder, and nothing is allocated, counted or policed."
+  The accepted roster is CLOSED and small — a string, a keyword, an integer, or
+  a vector of them — and it is narrow precisely so `pr-str` is an equality-
+  faithful, injective identity over it: see [[accepted-identity?]]. `pr-str` is
+  neither over arbitrary EDN — a list prints unlike its `=`-equal vector, and a
+  symbol or boolean can print like a distinct value — so any identity outside
+  the roster is refused loudly at the boundary rather than emitted as an id two
+  equal identities would not share, or two distinct identities would. A supplied
+  string is never dropped, so an empty-string identity stays distinct from an
+  absent one rather than silently aliasing it. Pure and stable: the same
+  accepted identity yields the same token on every render and after a list
+  reorder, and nothing is allocated, counted or policed."
   [part]
   (when (some? part)
     (if (string? part)
       (dom-escape part)
-      (if (ordered-identity? part)
+      (if (accepted-identity? part)
         (str "_v_" (dom-escape (pr-str part)))
         (throw (ex-info
-                 (str "acme.ui: a field identity must be a value whose print "
-                      "is its identity — an atom or an ordered collection of "
-                      "them — but got an unordered collection: " (pr-str part)
-                      ". A map's or set's `=` ignores an element order its "
-                      "printed id cannot, so this identity could point two "
-                      "controls at two different error regions for one "
-                      "instance. Use an ordered identity such as a vector.")
+                 (str "acme.ui: a field identity must be one of the shapes this "
+                      "library encodes injectively — a string, a keyword, an "
+                      "integer, or a vector of them — but got: " (pr-str part)
+                      ". That shape has no canonical, type-unique print (a "
+                      "list prints unlike its equal vector; a symbol or boolean "
+                      "can print like a distinct value; a map's or set's `=` "
+                      "ignores an order its print preserves), so an id built "
+                      "from it could point two controls at two error regions for "
+                      "one instance, or two instances at one region. Name the "
+                      "instance with an accepted identity such as a keyword, an "
+                      "integer, or a vector of them.")
                  {:acme.ui/error    :unstable-field-identity
                   :acme.ui/identity part}))))))
 
@@ -293,11 +318,13 @@
   longer collide.
 
   The library trusts the caller's identity to be distinct — exactly as the
-  buffered controller trusts its `:control` address (D004) — and requires
-  only that it be order-stable, so its id is the same across a rerender and a
-  list reorder. It allocates, counts and polices nothing; an identity whose
-  print is not its identity (an unordered map or set) is refused loudly by
-  `id-token` rather than given an ambiguous id."
+  buffered controller trusts its `:control` address (D004) — and requires only
+  that it name an instance with an ACCEPTED shape (a string, keyword, integer,
+  or vector of them), so its id is injective and the same across a rerender and
+  a list reorder. It allocates, counts and polices nothing; an identity outside
+  that closed roster — one whose print is not a canonical, type-unique
+  identity, such as a list, a symbol, a boolean, or an unordered map or set — is
+  refused loudly by `id-token` rather than given an ambiguous id."
   [prefix & parts]
   (str/join "-" (concat [prefix] (keep id-token parts) ["error"])))
 

--- a/implementation/freehand/test/re_frame/freehand/pilot_field_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/pilot_field_cljs_test.cljc
@@ -799,6 +799,67 @@
              (pilot/error-region-id "acme-buffered" [:invoice 1 :reference]))
           "a vector address is a stable identity, refused nothing"))))
 
+(deftest the-accepted-identity-domain-is-injective-and-equality-faithful
+  (testing "rf2-drpa3.146, audit follow-up to #6832. `pr-str` is neither
+            canonical nor injective over arbitrary EDN, so encoding EVERY
+            non-collection plus every sequential collection through it still
+            broke the contract two ways. The repair NARROWS the accepted domain
+            to the closed roster the pilot's callers actually use — a string,
+            keyword, integer, or vector of them — over which `pr-str` IS both
+            equality-faithful and injective, and refuses everything else loudly.
+            The two exact probes the audit named are pinned below on both hosts."
+    (let [reason (fn [identity]
+                   (try (pilot/error-region-id "acme-buffered" identity)
+                        nil
+                        (catch #?(:clj Throwable :cljs :default) e
+                          (:acme.ui/error (ex-data e)))))
+          id     (fn [identity] (pilot/error-region-id "acme-buffered" identity))]
+
+      (testing "probe 1 — canonicity. `(= [1 2] '(1 2))`, so a `pr-str` id
+                would SPLIT one identity into two. The vector is accepted and
+                names one stable id; its equal list twin is out of the roster
+                and refused, so no second id is ever emitted for the identity"
+        (is (= [1 2] '(1 2))
+            "non-vacuous: the vector and list are `=`, the split a naive codec makes")
+        (is (= (id [1 2]) (id [1 2]))
+            "the accepted vector pins ONE stable id across calls")
+        (is (= :unstable-field-identity (reason '(1 2)))
+            "and its equal list twin is refused, not given a second id"))
+
+      (testing "probe 2 — injectivity. `(symbol \"true\")` and `true` are
+                distinct values whose `pr-str` both prints `true`, so a
+                `pr-str` id would ALIAS two identities onto one. Both are out of
+                the roster and refused, so neither collides; the ACCEPTED
+                look-alikes stay distinct instead"
+        (is (= "true" (pr-str (symbol "true")) (pr-str true))
+            "non-vacuous: a symbol, a boolean and a string all print `true`")
+        (is (= :unstable-field-identity (reason (symbol "true")))
+            "a symbol is refused — a distinct value shares its print")
+        (is (= :unstable-field-identity (reason true))
+            "and so is a boolean — neither can alias onto one id")
+        (is (not= (id :true) (id "true"))
+            "while the accepted look-alikes are two ids: keyword `:true` versus string \"true\""))
+
+      (testing "the roster's other exclusions are refused too, each for a print
+                that is not a canonical, type-unique identity"
+        (is (= :unstable-field-identity (reason 1.5))
+            "a float carries no type-unique integer/keyword/string print")
+        (is (= :unstable-field-identity (reason [:invoice '(1) :reference]))
+            "and a list NESTED inside an otherwise-accepted vector fails the whole")
+        (is (= :unstable-field-identity (reason #{:a}))
+            "an unordered set stays refused, as #6832 established"))
+
+      (testing "the roster's members — and vectors recursively of them — are
+                accepted, and pin distinct values to distinct ids"
+        (is (not= (id :invoice) (id "invoice"))
+            "a keyword and the string of its name are two ids")
+        (is (not= (id 1) (id "1"))
+            "an integer and the string of its digits are two ids")
+        (is (not= (id [:invoice 1]) (id [:invoice 2]))
+            "two vector addresses are two ids")
+        (is (= (id [:invoice [1 2] :ref]) (id [:invoice [1 2] :ref]))
+            "a nested-vector address is accepted and stable across calls")))))
+
 ;; ===========================================================================
 ;; R-A9 — asynchronous transform race safety
 ;; ===========================================================================

--- a/implementation/freehand/test/re_frame/freehand/pilot_field_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/pilot_field_dom_cljs_test.cljs
@@ -674,6 +674,56 @@
                         (teardown! container root)
                         (done)))))))))
 
+(deftest pilot-a-typed-instance-and-its-string-namesake-keep-distinct-mounted-ids
+  (testing "rf2-drpa3.146, audit follow-up (mounted). The narrowed codec keeps
+            the accepted roster TYPE-DISTINGUISHED: a keyword `:a` and the
+            string \"a\" are two distinct supported identities a codec that
+            ignored type would merge, and here they mount with DISTINCT
+            `aria-describedby` targets, each resolving by document id to its own
+            error region. The JVM/CLJS structural arm proves the encoding is
+            injective over the roster; this browser arm proves the two ids also
+            resolve to two regions in a real DOM."
+    (if-not (browser?)
+      (skip! "the browser job runs the mounted type-distinction regression")
+      (async done
+        (live-frame/make-frame {:id fid})
+        (frame/replace-app-db! fid {})
+        (pilot/register!)
+        (pilot/register-app!)
+        (let [[container root] (mount!)
+              field-form (fn [instance]
+                           [pilot/field {:name     "description"
+                                         :label    "Description"
+                                         :value    ""
+                                         :instance instance
+                                         :error    "A description is required."
+                                         :on-input [:noop]}])]
+          (-> (act #(.render root (shell/provide-frame
+                                    fid (fr/element [:div
+                                                     (field-form :a)
+                                                     (field-form "a")]))))
+              (.then
+                (fn [_]
+                  (let [controls (.querySelectorAll container "[data-part='control']")
+                        c1  (.item controls 0)
+                        c2  (.item controls 1)
+                        id1 (.getAttribute c1 "aria-describedby")
+                        id2 (.getAttribute c2 "aria-describedby")]
+                    (is (= 2 (.-length controls)) "non-vacuous: two fields mounted")
+                    (is (some? id1) "the keyword `:a` control names a region")
+                    (is (some? id2) "the string \"a\" control names a region")
+                    (is (not= id1 id2)
+                        "`:a` and \"a\" are two ids — the type tag keeps them apart")
+                    (is (some? (.getElementById js/document id1))
+                        "the `:a` region resolves by document id")
+                    (is (some? (.getElementById js/document id2))
+                        "the \"a\" region resolves by document id"))))
+              (.then (fn [_] (teardown! container root) (done)))
+              (.catch (fn [e]
+                        (is false (str "the mounted pilot rejected: " e))
+                        (teardown! container root)
+                        (done)))))))))
+
 ;; ===========================================================================
 ;; The compiled cell, re-opened — the pilot's compiled twin mounts
 ;; ===========================================================================


### PR DESCRIPTION
Reopened by the three-lens audit of merged PR #6832. That PR fixed the supplementary-Unicode collision, the empty-string distinction, and fail-loud on unordered maps/sets — but its `ordered-identity?` rule still used `pr-str` as the identity codec over "every non-collection plus every sequential collection recursively," and `pr-str` is neither canonical nor injective over that domain:

- **Canonicity break.** `(= [1 2] '(1 2))` is true, yet the two print differently, so one identity produced two DOM ids — `aria-describedby` could split across rerenders.
- **Injectivity break.** `(symbol "true")` and `true` are distinct supported values, yet both print `true`, so two identities produced one DOM id — `aria-describedby` could alias.

## What changed

Take the audit's simpler, posture-aligned option — **narrow + validate the accepted identity domain** rather than build a canonicalizing codec:

- `ordered-identity?` is replaced by a closed-roster `accepted-identity?`: a **string, keyword, integer, or vector (recursively) of them** — exactly the shapes the pilot's callers name an instance with (`:instance` line ids, the `[:invoice id :reference]` `:control` address, the readable `name`).
- Over that small roster `pr-str` **is** equality-faithful and injective, because each member prints canonically and type-distinguished (`1`, `"1"` and `:1` print three ways; a vector preserves the order that is its identity). So the `_v_`-prefixed `dom-escape(pr-str)` encoding is kept unchanged — it is now honest over the domain it accepts.
- Everything outside the roster — a **list** (whose `=`-equal vector prints differently), a **symbol** or **boolean** (whose print a distinct value can share), a **map**/**set** (whose `=` ignores an order its print preserves), a **float** or **char** — is refused loudly with the existing `:unstable-field-identity` diagnostic. No silent aliasing, no silent split.
- The readable-ASCII string fast path and the short single-instance id (`acme-field-<name>-error` when `:instance` is absent) are unchanged.

**Non-goals honoured (audit-forbidden):** no general serializer, no canonicalization framework, no allocator, no WeakMap/object registry, no duplicate scanner, no new substrate API. The change is one predicate plus docstrings — smaller and more truthful than a general codec.

## Regressions added

- Host-neutral (JVM + CLJS) structural regression for the two exact probes: the accepted vector `[1 2]` pins one stable id while its `=`-equal list twin `'(1 2)` is refused; `(symbol "true")` and `true` are both refused while the accepted look-alikes `:true` and `"true"` stay two ids. Each with an explicit non-vacuity premise (`(= [1 2] '(1 2))`, the shared `true` print).
- Mounted browser-parity row alongside the existing collision rows: a keyword `:a` and the string `"a"` mount with distinct `aria-describedby` targets, each resolving by document id to its own error region.

## Quality gates

All foreground, worktree-local logs, exit code is the verdict.

| Gate | Command | Result |
| --- | --- | --- |
| JVM freehand | `clojure -M:test` (from `implementation/freehand`) | 885 tests / 6369 assertions / **0 failures, 0 errors** — EXIT=0 |
| Node (CLJS) freehand | `npm run test:freehand` (from `implementation/`) | 915 tests / 5445 assertions / **0 failures, 0 errors** — EXIT=0 |
| Browser | `npm run test:browser` (from `implementation/`) | 702 tests / 4313 assertions / **0 failures, 0 errors** — EXIT=0 |

Browser build banner confirmed the `error-region-domain-146` worktree config. `node_modules` was junctioned from the mayor checkout for the npm gates.

Closes rf2-drpa3.146.
