### PR TITLE
fix(api-manifest): protect re-frame.freehand.test call signatures like re-frame.ui.test (rf2-drpa3.99)

### DIFF
--- a/implementation/scripts/api-manifest/probe/src/re_frame/api_manifest/cljs_publics.clj
+++ b/implementation/scripts/api-manifest/probe/src/re_frame/api_manifest/cljs_publics.clj
@@ -270,3 +270,18 @@
    so an edit to the sidecar recompiles this call site."
   []
   (-> (read-sidecar &env) :ui-test-signatures))
+
+(defmacro emit-signature-contract
+  "Expand to the sidecar's signature authority map under `sidecar-key`
+   (a keyword literal) — the generalisation of `emit-ui-test-signature-contract`
+   to any host-aware signature block (rf2-drpa3.99 added
+   `:freehand-test-signatures` alongside `:ui-test-signatures`; both are the
+   same `{:namespace :vars {var {:kind :clj #{..} :cljs #{..}}}}` shape and are
+   reconciled by the same `cljs-probe/signature-problems`). Read from
+   `spec/api-manifest-metadata.edn` at macro-expansion time, so — like the
+   sibling emitters — the value is pinned to the same committed sidecar the JVM
+   lane joins against with no runtime filesystem dependency, and in
+   ClojureScript carries a build dependency so a sidecar edit recompiles this
+   call site."
+  [sidecar-key]
+  (-> (read-sidecar &env) (get sidecar-key)))

--- a/implementation/scripts/api-manifest/probe/test/re_frame/api_manifest/cljs_manifest_probe_cljs_test.cljs
+++ b/implementation/scripts/api-manifest/probe/test/re_frame/api_manifest/cljs_manifest_probe_cljs_test.cljs
@@ -84,7 +84,8 @@
   (:require-macros [re-frame.api-manifest.cljs-publics
                     :refer [emit-ns-publics emit-cljs-only-rows
                             emit-classification-rows emit-ns-surface
-                            emit-ui-test-signature-contract]])
+                            emit-ui-test-signature-contract
+                            emit-signature-contract]])
   (:require [cljs.test :refer-macros [deftest is testing]]
             [clojure.string :as str]
             [re-frame.api-manifest.cljs-probe :as probe]
@@ -546,3 +547,109 @@
         "the fixture really does carry the host difference")
     (is (empty? (probe/signature-problems synthetic-contract
                                           synthetic-live-in-sync)))))
+
+;; ---------------------------------------------------------------------------
+;; re-frame.freehand.test HOST-SIGNATURE guard — CLJS (:cljs) lane (rf2-drpa3.99).
+;;
+;; The SIBLING of the re-frame.ui.test CLJS lane above, reusing the SAME pure
+;; reconciler `probe/signature-problems`. The manifest + the enrolment probe
+;; carry name + :kind but NO arity, so a freehand.test fn/macro could reshape a
+;; supported arity and stay green (the reproduction: `render` grew a second
+;; `[form opts]` arity while name/kind held and every gate stayed green — so
+;; `(t/render form)` could silently break). This enumerates the live CLJS
+;; analyzer surface of re-frame.freehand.test and reconciles the FUNCTION
+;; arities against the `:cljs` half of the sidecar :freehand-test-signatures
+;; authority; `with-render` is host-invariant (pinned on the JVM lane, its two
+;; halves required equal). All six names are host-identical `.cljc` — no
+;; CLJS-only (`:clj nil`) verb, unlike ui.test's flush verbs.
+;; ---------------------------------------------------------------------------
+
+(def live-freehand-test-surface
+  "`{var-name {:kind kw :arities (#{arity} | nil)}}` for re-frame.freehand.test's
+   live CLJS public surface, enumerated off the analyzer at compile time — the
+   live classification (kind) + host arities the signature contract is
+   reconciled against."
+  (emit-ns-surface re-frame.freehand.test))
+
+(def freehand-test-signature-contract
+  "The sidecar `:freehand-test-signatures` authority, embedded at compile time
+   (no runtime filesystem). `:vars` is the per-var host-aware contract."
+  (emit-signature-contract :freehand-test-signatures))
+
+(deftest freehand-test-cljs-signatures-in-sync
+  (testing "the live CLJS classification + function arities of
+            re-frame.freehand.test match the signature contract (kind
+            reconciled; render/find/find-all/attrs/text arities pinned)"
+    (let [problems (probe/signature-problems (:vars freehand-test-signature-contract)
+                                             live-freehand-test-surface)]
+      (is (empty? problems) (probe/signature-report problems)))))
+
+(deftest freehand-test-signature-contract-is-non-vacuous
+  (testing "the embedded contract carries the SIX blessed freehand.test vars and
+            the analyzer surfaced render's live CLJS :fn 1-arity — guards against
+            a vacuous green from an unread sidecar or un-analysed namespace"
+    (is (= "re-frame.freehand.test" (:namespace freehand-test-signature-contract)))
+    (is (= 6 (count (:vars freehand-test-signature-contract))))
+    (is (= freehand-test-names (set (keys (:vars freehand-test-signature-contract))))
+        "the signature authority names exactly the six blessed vars")
+    (is (= :fn (get-in live-freehand-test-surface ["render" :kind]))
+        "render must be classified :fn by the live analyzer — the kind authority")
+    (is (= #{[1]} (get-in live-freehand-test-surface ["render" :arities]))
+        "render must be observed 1-arity on CLJS — the contract the reproduction broke")
+    (is (= :macro (get-in live-freehand-test-surface ["with-render" :kind]))
+        "with-render must be classified :macro by the live analyzer")))
+
+(deftest freehand-test-cljs-render-arity-reshape-goes-red
+  (testing "THE REPRODUCTION (rf2-drpa3.99): render reshaped from 1-arity to
+            2-arity ([form] → [form opts]) fails against the contract's
+            :cljs #{[1]}, while its name + :kind (a :fn) are unchanged — the
+            exact false-green every prior gate let through"
+    (let [problems (probe/signature-problems
+                    (:vars freehand-test-signature-contract)
+                    (assoc-in live-freehand-test-surface ["render" :arities] #{[1] [2]}))]
+      (is (= [:arity-mismatch] (map :kind problems)))
+      (is (= "render" (:var (first problems))))
+      (is (= #{[1]} (:expected (first problems))))
+      (is (= #{[1] [2]} (:got (first problems)))))))
+
+(deftest freehand-test-cljs-added-arity-goes-red
+  (testing "ADDING a CLJS arity (text gains a 2-arity) fails — a superset is
+            drift, not a pass"
+    (let [problems (probe/signature-problems
+                    (:vars freehand-test-signature-contract)
+                    (assoc-in live-freehand-test-surface ["text" :arities] #{[1] [2]}))]
+      (is (= [:arity-mismatch] (map :kind problems)))
+      (is (= "text" (:var (first problems)))))))
+
+(deftest freehand-test-cljs-with-render-host-variance-goes-red
+  (testing "with-render is one .cljc defmacro, so its :clj and :cljs halves
+            cannot differ — mutating the :cljs half alone is host-variance a
+            single defmacro cannot have, and is RED (the JVM lane pins :clj to
+            the live macro :arglists)"
+    (let [problems (probe/signature-problems
+                    (assoc-in (:vars freehand-test-signature-contract)
+                              ["with-render" :cljs] #{[3 :&]})
+                    live-freehand-test-surface)]
+      (is (= [:macro-host-variance] (map :kind problems)))
+      (is (= "with-render" (:var (first problems))))
+      (is (= #{[0 :&]} (:expected (first problems))) "the :clj half")
+      (is (= #{[3 :&]} (:got (first problems)))      "the mutated :cljs half"))))
+
+(deftest freehand-test-cljs-sidecar-kind-flip-goes-red
+  (testing "a sidecar entry whose :kind was flipped :fn→:macro is REJECTED
+            against the live analyzer kind (:fn) — the declared kind is
+            reconciled, never trusted to select checks"
+    (let [problems (probe/signature-problems
+                    (assoc-in (:vars freehand-test-signature-contract)
+                              ["render" :kind] :macro)
+                    live-freehand-test-surface)]
+      (is (= [:kind-mismatch] (map :kind problems)))
+      (is (= "render" (:var (first problems))))
+      (is (= :macro (:declared (first problems))))
+      (is (= :fn (:live-kind (first problems)))))))
+
+(deftest freehand-test-cljs-restored-surface-is-green
+  (testing "POSITIVE CONTROL: the UNMUTATED live surface reconciles clean, so
+            the reds above are the mutation talking and not a standing failure"
+    (is (empty? (probe/signature-problems (:vars freehand-test-signature-contract)
+                                          live-freehand-test-surface)))))

--- a/implementation/scripts/api-manifest/test/re_frame/api_manifest/freehand_test_signature_test.clj
+++ b/implementation/scripts/api-manifest/test/re_frame/api_manifest/freehand_test_signature_test.clj
@@ -1,0 +1,210 @@
+(ns re-frame.api-manifest.freehand-test-signature-test
+  "The JVM (:clj) lane of the `re-frame.freehand.test` HOST-SIGNATURE guard
+  (rf2-drpa3.99) — the SIBLING of the `re-frame.ui.test` signature guard
+  (rf2-5bcdi / rf2-d7sso), reusing the SAME pure reconciler.
+
+  THE HOLE. `re-frame.freehand.test` is enrolled in the manifest (its
+  `freehand-test-enrolment-test` sibling proves a rename / removal / accidental
+  export reddens the gate). But the generated row reduces every var to
+  `[namespace var tier kind]` — it carries NO arity. So a freehand.test fn or
+  macro could keep its NAME and its `:kind` while losing, adding, or reshaping a
+  supported arity, and the manifest / `gen --check` / enrolment gates all stayed
+  green. The live-generator reproduction changed `render`'s metadata from
+  `([form])` to `([form opts])` and every gate stayed green — so `(t/render
+  form)` could silently become a compile/runtime break the public-API boundary
+  never detected. The namespace's own docstring promises that a signature change
+  reddens the gate; before this lane, it did not.
+
+  THE MECHANISM, REUSED. This does NOT build a second reconciler. It reads the
+  live JVM surface of the six blessed vars (`ns-publics` — the surface runs
+  headless on the JVM, so it is on the generator classpath) and hands it, with
+  the committed `:freehand-test-signatures` authority, to the SAME pure
+  reconciler the ui.test lane uses — `api-md-check/ui-test-arity-problems` — plus
+  the same kind-aware `api-md-check/arglists->arity` normalization. The sidecar's
+  declared `:kind` is reconciled against the live Var kind (never trusted to
+  select checks); a `:fn` arity reshape / add / removal is `:arity-mismatch` /
+  `:var-absent`; a fresh uncontracted export is `:uncontracted-var`; and the one
+  macro (`with-render`) has its `:clj` pinned to the live `:arglists` and its
+  `:cljs` required equal (`:macro-host-variance`).
+
+  All six names are host-identical `.cljc` (Spec 008) — no CLJS-only (`:clj nil`)
+  verb, unlike ui.test's `flush!` / `flush-presence!` — so every var is JVM-live
+  and every `:clj` arity is reconciled here. The CLJS half of the same guard
+  lives in the api-manifest probe (`probe/test/.../cljs_manifest_probe_cljs_test.cljs`)."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.api-manifest.api-md-check :as c]
+            [re-frame.api-manifest.gen :as gen]))
+
+(def ^:private freehand-test-ns "re-frame.freehand.test")
+
+(def ^:private blessed-names
+  "The six blessed names — the whole public surface (everything beneath them is
+   `defn-`). The five queries are `defn`s; `with-render` is the `defmacro`
+   bracket."
+  #{"render" "find" "find-all" "attrs" "text" "with-render"})
+
+;; ---------------------------------------------------------------------------
+;; Live JVM surface — the freehand.test twin of api-md-check/live-ui-test-surface,
+;; built by REUSING api-md-check's public kind-aware arity normalization
+;; (`arglists->arities`). The `:kind` derivation mirrors gen/kind-of exactly (both
+;; gen/kind-of and api-md-check/live-kind-of are private, so the three-line cond
+;; is replicated — the arity MECHANISM, the part that matters, is reused verbatim).
+;; ---------------------------------------------------------------------------
+
+(defn- kind-of
+  "The manifest `:kind` of a live JVM Var (mirrors `gen/kind-of` /
+   `api-md-check/live-kind-of` — the AUTHORITATIVE live classification the
+   sidecar's declared kind is reconciled against)."
+  [v]
+  (let [m (meta v)]
+    (cond
+      (:macro m)                  :macro
+      (or (:arglists m) (fn? @v)) :fn
+      :else                       :var)))
+
+(defn live-freehand-test-surface
+  "Live JVM `{var-name-string {:kind kw :arities #{arity-vector ...}}}` for the
+   public, non-`^:no-doc` vars of `re-frame.freehand.test`. `:kind` is the live-Var
+   classification; `:arities` is derived KIND-AWARELY via the reused
+   `api-md-check/arglists->arities`."
+  []
+  (let [ns-sym (symbol freehand-test-ns)]
+    (require ns-sym)
+    (into {}
+          (for [[sym v] (ns-publics ns-sym)
+                :when (not (:no-doc (meta v)))
+                :let  [kind (kind-of v)]]
+            [(name sym) {:kind    kind
+                         :arities (c/arglists->arities kind (:arglists (meta v)))}]))))
+
+(defn- contract []
+  (:vars (:freehand-test-signatures (gen/read-sidecar))))
+
+;; ---------------------------------------------------------------------------
+;; In-sync + non-vacuity.
+;; ---------------------------------------------------------------------------
+
+(deftest live-jvm-signature-matches-the-committed-contract
+  (testing "the committed :freehand-test-signatures contract reconciles clean
+            against the LIVE re-frame.freehand.test JVM surface — no live drift.
+            All six names are host-identical (every `:clj` non-nil), so the live
+            JVM surface is EXACTLY the contract's vars"
+    (let [contract (contract)
+          surface  (live-freehand-test-surface)]
+      (is (= 6 (count contract))
+          "the signature authority carries the six blessed vars")
+      (is (= blessed-names (set (keys contract)))
+          "the contract names exactly the blessed surface")
+      (is (every? some? (map :clj (vals contract)))
+          "every freehand.test var is host-identical — no CLJS-only (:clj nil) verb")
+      (is (= blessed-names (set (keys surface)))
+          "the live JVM surface is exactly the six blessed vars")
+      (is (= #{[1]} (get-in surface ["render" :arities]))
+          "render is live 1-arity — the contract the reproduction ([form opts]) broke")
+      (is (= :macro (get-in surface ["with-render" :kind]))
+          "with-render is the live defmacro bracket")
+      (is (= #{[0 :&]} (get-in surface ["with-render" :arities]))
+          "with-render's compiler-internal &form/&env are stripped to the visible [0 :&]")
+      (is (empty? (c/ui-test-arity-problems contract surface))
+          "live drift: a freehand.test var's JVM signature disagrees with the contract"))))
+
+;; ---------------------------------------------------------------------------
+;; The mutation controls — every direction goes RED, restored stays green.
+;; Each mutates the LIVE surface (or the contract) and reconciles it through the
+;; reused pure reconciler, so name + :kind stay put while the arity/kind drifts.
+;; ---------------------------------------------------------------------------
+
+(deftest render-arity-reshape-goes-red
+  (testing "THE REPRODUCTION (rf2-drpa3.99): render reshaped from 1-arity to
+            2-arity ([form] → [form opts]) fails against :clj #{[1]}, while its
+            name + :kind (a :fn) are unchanged — the exact false-green every
+            prior gate let through"
+    (let [problems (c/ui-test-arity-problems
+                    (contract)
+                    (assoc-in (live-freehand-test-surface) ["render" :arities] #{[1] [2]}))]
+      (is (= [:arity-mismatch] (map :kind problems)))
+      (is (= "render" (:var (first problems))))
+      (is (= #{[1]} (:expected (first problems))))
+      (is (= #{[1] [2]} (:got (first problems)))))))
+
+(deftest added-jvm-arity-goes-red
+  (testing "ADDING a supported arity (text gains a 2-arity) fails — a superset is
+            drift, not a pass"
+    (let [problems (c/ui-test-arity-problems
+                    (contract)
+                    (assoc-in (live-freehand-test-surface) ["text" :arities] #{[1] [2]}))]
+      (is (= [:arity-mismatch] (map :kind problems)))
+      (is (= "text" (:var (first problems)))))))
+
+(deftest binary-finder-arity-drop-goes-red
+  (testing "find losing its second parameter (a `[tree pred]` → `[tree]` reshape)
+            fails against :clj #{[2]} — the finder call contract the manifest
+            cannot see"
+    (let [problems (c/ui-test-arity-problems
+                    (contract)
+                    (assoc-in (live-freehand-test-surface) ["find" :arities] #{[1]}))]
+      (is (= [:arity-mismatch] (map :kind problems)))
+      (is (= "find" (:var (first problems))))
+      (is (= #{[2]} (:expected (first problems))))
+      (is (= #{[1]} (:got (first problems)))))))
+
+(deftest with-render-macro-losing-variadic-goes-red
+  (testing "with-render reshaped from variadic [0 :&] to a fixed [1] fails — the
+            `& body` grammar drift the tier/kind reconcile cannot see, pinned
+            against the live macro :arglists"
+    (let [problems (c/ui-test-arity-problems
+                    (contract)
+                    (assoc-in (live-freehand-test-surface) ["with-render" :arities] #{[1]}))]
+      (is (= [:arity-mismatch] (map :kind problems)))
+      (is (= "with-render" (:var (first problems))))
+      (is (= #{[0 :&]} (:expected (first problems))))
+      (is (= #{[1]} (:got (first problems)))))))
+
+(deftest with-render-cljs-only-mutation-goes-red
+  (testing "with-render is one .cljc defmacro, so its :clj and :cljs halves cannot
+            differ — mutating the :cljs half alone is host-variance a single
+            defmacro cannot have, and is RED (the live :clj arities still match,
+            so ONLY the host-variance fires)"
+    (let [problems (c/ui-test-arity-problems
+                    (assoc-in (contract) ["with-render" :cljs] #{[3 :&]})
+                    (live-freehand-test-surface))]
+      (is (= [:macro-host-variance] (map :kind problems)))
+      (is (= "with-render" (:var (first problems))))
+      (is (= #{[0 :&]} (:expected (first problems))) "the :clj half")
+      (is (= #{[3 :&]} (:got (first problems)))      "the mutated :cljs half"))))
+
+(deftest jvm-sidecar-kind-flip-goes-red
+  (testing "a sidecar entry whose :kind was flipped :fn→:macro is REJECTED against
+            the live JVM Var kind (:fn) — the declared kind is reconciled, never
+            trusted (its arities still match, so ONLY the kind mismatch fires)"
+    (let [problems (c/ui-test-arity-problems
+                    (assoc-in (contract) ["render" :kind] :macro)
+                    (live-freehand-test-surface))]
+      (is (= [:kind-mismatch] (map :kind problems)))
+      (is (= "render" (:var (first problems))))
+      (is (= :macro (:declared (first problems))))
+      (is (= :fn (:live-kind (first problems)))))))
+
+(deftest removed-var-flagged-absent
+  (testing "a contract var whose live Var no longer resolves is :var-absent
+            (belt-and-braces alongside the enrolment existence guard)"
+    (let [problems (c/ui-test-arity-problems
+                    (contract)
+                    (dissoc (live-freehand-test-surface) "attrs"))]
+      (is (= [:var-absent] (map :kind problems)))
+      (is (= "attrs" (:var (first problems)))))))
+
+(deftest new-uncontracted-var-flagged
+  (testing "a NEW live blessed var with no signature entry is :uncontracted-var —
+            a fresh export cannot escape arity coverage silently"
+    (let [problems (c/ui-test-arity-problems
+                    (contract)
+                    (assoc (live-freehand-test-surface) "click!" {:kind :fn :arities #{[1]}}))]
+      (is (= [:uncontracted-var] (map :kind problems)))
+      (is (= "click!" (:var (first problems)))))))
+
+(deftest restored-surface-is-green
+  (testing "POSITIVE CONTROL: the committed contract reconciles clean against the
+            live surface, so the reds above are the mutation talking and not a
+            standing failure"
+    (is (empty? (c/ui-test-arity-problems (contract) (live-freehand-test-surface))))))

--- a/spec/api-manifest-metadata.edn
+++ b/spec/api-manifest-metadata.edn
@@ -104,6 +104,37 @@
    "with-root" {:kind :macro :clj #{[1 :&]}  :cljs #{[1 :&]}}}}
 
  ;; --------------------------------------------------------------------------
+ ;; :freehand-test-signatures — the host-aware signature authority for
+ ;; re-frame.freehand.test (rf2-drpa3.99), the SIBLING guard to
+ ;; :ui-test-signatures above, consumed by the SAME two reconcilers
+ ;; (api-md-check/ui-test-arity-problems on the JVM lane, cljs-probe/
+ ;; signature-problems on the CLJS lane — the mechanism is reused, not
+ ;; duplicated). The manifest carries name + :kind but NO arity, so a
+ ;; freehand.test fn/macro could keep its NAME and :kind while losing / adding
+ ;; / reshaping a supported arity and every ordinary manifest / gen --check /
+ ;; enrolment gate stayed green — the false-green rf2-drpa3.99 closes
+ ;; (`(t/render form)` silently becoming a two-arity call is a compile/runtime
+ ;; break the API boundary must catch).
+ ;;
+ ;; Unlike ui.test, ALL SIX names are host-identical `.cljc` — the surface
+ ;; runs headlessly on both hosts (Spec 008), so there is no `:clj nil`
+ ;; CLJS-only verb: every var carries the same `:clj` and `:cljs` arities. The
+ ;; five queries are plain `defn`s; `with-render` is the single `.cljc`
+ ;; `defmacro` bracket, host-invariant like ui.test's `render` / `with-root`
+ ;; (its `:clj` = `:cljs`, enforced by :macro-host-variance). The macro's
+ ;; `&form`/`&env` are stripped to the programmer-visible `[0 :&]`.
+ :freehand-test-signatures
+ {:namespace "re-frame.freehand.test"
+  :vars
+  {"render"      {:kind :fn    :clj #{[1]}    :cljs #{[1]}}
+   "find"        {:kind :fn    :clj #{[2]}    :cljs #{[2]}}
+   "find-all"    {:kind :fn    :clj #{[2]}    :cljs #{[2]}}
+   "attrs"       {:kind :fn    :clj #{[1]}    :cljs #{[1]}}
+   "text"        {:kind :fn    :clj #{[1]}    :cljs #{[1]}}
+   ;; The discardable-render bracket — one `.cljc` defmacro, host-invariant.
+   "with-render" {:kind :macro :clj #{[0 :&]} :cljs #{[0 :&]}}}}
+
+ ;; --------------------------------------------------------------------------
  ;; CLJS-ONLY surfaces — public vars in ClojureScript-only namespaces that
  ;; cannot be `require`d on the JVM, so the generator carries them verbatim.
  ;; Each row is the FULL manifest row, and carries its own


### PR DESCRIPTION
## Problem

PR #6729 enrolled `re-frame.freehand.test` in the canonical manifest and its docstring promises that a signature change reddens the public-API gate on both hosts. But the generated row carries `namespace/name/kind/tier/owner/status` and **no arity**, so a freehand.test fn/macro could keep its name and `:kind` while losing, adding, or reshaping a supported arity with every manifest / `gen --check` / enrolment gate green. The live-generator reproduction changed `render` from `([form])` to `([form opts])` and the gate stayed **green** — so `(t/render form)` could silently become a compile/runtime failure the API boundary never detected.

## Fix

Extend the **existing** host-aware signature reconciliation built for `re-frame.ui.test` (rf2-5bcdi / rf2-d7sso) to the six `re-frame.freehand.test` names, **reusing the mechanism, not duplicating it**:

- **Sidecar** `:freehand-test-signatures` authority — the sibling of `:ui-test-signatures`. All six names are host-identical `.cljc` (no CLJS-only `:clj nil` verb, unlike ui.test's flush verbs). Consumed **only** by the signature guards, so the generated `spec/api-manifest.edn` is byte-unchanged.
- **JVM lane** — a new test reconciles the live JVM surface against the contract via the reused `api-md-check/ui-test-arity-problems` + `arglists->arities` (`api_md_check.clj` untouched — the reconciler is already generic/public).
- **CLJS lane** — a generic `emit-signature-contract` macro + a probe-test lane reconciling the live analyzer surface via the reused `cljs-probe/signature-problems`.
- **Mutation controls** on both hosts prove an arity-only change reds while name and kind hold, and the unmutated surface stays green.

No manifest redesign, no prose parsing, no second namespace inventory.

## Quality gates

All run foreground from `implementation/scripts/api-manifest/` (JVM) and `implementation/` (CLJS), exit code is the verdict.

| Gate | Result |
| --- | --- |
| `clojure -M -m re-frame.api-manifest.gen` (plain regen) | `Wrote … (543 public vars).` — **EXIT 0** |
| `git diff spec/api-manifest.edn` after regen | **empty** (the signature block does not perturb the generated manifest) |
| `clojure -M -m re-frame.api-manifest.gen --check` | `OK: spec/api-manifest.edn in sync (543 public vars).` — **EXIT 0** |
| `clojure -M:test` (JVM api-manifest suite, incl. `api_md_check` vs real spec/API.md) | `Ran 144 tests … 0 failures, 0 errors` · `OK: spec/API.md projection in sync (244 var-rows)` — **EXIT 0** |
| `npm run test:cljs` (CLJS node-test, incl. the probe) | `Ran 11042 tests containing 55550 assertions. 0 failures, 0 errors.` — **EXIT 0** |

### Proof the fix bites — an arity change now reds on BOTH hosts

Temporarily reshaping `render`'s live arity (the exact reproduction), then restored byte-identical:

- **JVM** (`([form])` → `([form opts])`): `clojure -M:test` → **EXIT 1**
  ```
  FAIL in (live-jvm-signature-matches-the-committed-contract)
    actual: (not (empty? ({:kind :arity-mismatch, :var "render", :expected #{[1]}, :got #{[2]}})))
  ```
- **CLJS** (`render` made two-arity `([form] …) ([form opts] …)` — keeps 1-arity callers working, so **0 errors**, no collateral): `npm run test:cljs` → **EXIT 1**
  ```
  FAIL in (freehand-test-cljs-signatures-in-sync)
    actual: (not (empty? [{:kind :arity-mismatch, :var "render", :expected #{[1]}, :got #{[1] [2]}}]))
  ```

Both name `render` and the arity drift while name + `:kind` (a `:fn`) are unchanged — the exact false-green every prior gate let through. Restoring `render` returns both suites to green.

Closes rf2-drpa3.99.
