### PR TITLE
build(freehand): rename test-local Box record and drop the last :redef suppression (rf2-41igl)

### DIFF
--- a/implementation/freehand/test/re_frame/freehand/structural_data_round_trip_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/structural_data_round_trip_cljs_test.cljc
@@ -50,7 +50,7 @@
   [{:keys [label]}]
   [:span label])
 
-(defrecord Box [v])
+(defrecord RoundTripBox [v])
 
 (def ^:private a-queue
   "A persistent queue: a first-class collection on both hosts, and the
@@ -114,8 +114,8 @@
   [["a queue — a collection whose EDN status differs by host" a-queue]
    ["a queue nested in a map"                   {:jobs a-queue}]
    ["a queue nested in a vector"                [:a [:b a-queue]]]
-   ["a record — map?, and no EDN spelling"      (->Box 1)]
-   ["a record nested at depth"                  {:a {:b (->Box 1)}}]
+   ["a record — map?, and no EDN spelling"      (->RoundTripBox 1)]
+   ["a record nested at depth"                  {:a {:b (->RoundTripBox 1)}}]
    ["##NaN — reads back, never equal to itself" ##NaN]
    ["##NaN nested at depth"                     {:ratio {:value ##NaN}}]
    ["##NaN inside a vector"                     [1 ##NaN]]

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -819,16 +819,12 @@
    :main      re-frame.test-quiet.shadow-node/main
    ;; The load-bearing watch hook is inherited from :build-defaults.
    ;;
-   ;; rf2-41igl: :redef stays OFF on this build alone. With it ON the
-   ;; build reports exactly one warning — `->Box`, the positional
-   ;; constructor `(defrecord Box …)` generates in
-   ;; structural_data_round_trip_cljs_test.cljc, shadowing cljs.core/->Box.
-   ;; That is a test namespace, in scope here but not in :freehand-release,
-   ;; so the redef is a test-only artefact. shadow-cljs toggles :redef per
-   ;; build, not per symbol, so the class toggle scoped to this one build
-   ;; is the narrowest lever. (The bench build below no longer needs it.)
-   :compiler-options {:warnings      {:redef false}
-                      :infer-externs false}}
+   ;; rf2-41igl: this build carries no :redef suppression. The lone redef
+   ;; it once needed it for — the test-local `(defrecord Box …)`, whose
+   ;; generated `->Box` shadowed cljs.core/->Box — is gone: the fixture
+   ;; record is now `RoundTripBox`, so the build reports 0 warnings with
+   ;; the class toggle removed rather than silenced.
+   :compiler-options {:infer-externs false}}
 
   ;; rf2-8kas5 — the Freehand artefact's RELEASE build: the substrate
   ;; compiled the way a consumer ships it.


### PR DESCRIPTION
Follow-on from #6828, which narrowed the `:redef` suppression on `:node-test-freehand` to cover a single live redefinition: the test-local `(defrecord Box …)` in `structural_data_round_trip_cljs_test.cljc`, whose generated positional constructor `->Box` shadows `cljs.core/->Box`.

This is the clean-break finish (rf2-41igl):

- **Rename the fixture record** `Box` -> `RoundTripBox` (defined and used only within `structural_data_round_trip_cljs_test.cljc` — three sites, no external references), so no redef exists.
- **Remove `{:warnings {:redef false}}`** from the `:node-test-freehand` build in `implementation/shadow-cljs.edn`, and its now-obsolete justification comment. The build's `:compiler-options` now carries only `:infer-externs false`, matching `:freehand-bench-node`.

End state: **zero `:redef` suppression in any Freehand build** (`:node-test-freehand`, `:freehand-release`, `:freehand-bench-node` — the latter already dropped its copy in #6828) **and zero `:redef` warnings**. A build that suppresses a warning class it no longer needs teaches nothing and would quietly hide the next accidental redefinition.

## Quality gates

Run from the worktree with the suppression removed:

- `npm run test:freehand` -> `[:node-test-freehand] Build completed. (378 files, 377 compiled, **0 warnings**, 27.59s)`; `Ran 913 tests containing 5430 assertions. **0 failures, 0 errors.**` (EXIT=0). The build reports **0 redef warnings** with `{:redef false}` removed — the whole point.
- `shadow-cljs compile freehand-bench-node` -> `[:freehand-bench-node] Build completed. (141 files, 140 compiled, **0 warnings**, 21.05s)` (EXIT=0).

Scope note: the other `{:redef false}` entries in `shadow-cljs.edn` belong to non-Freehand builds (`:node-test`, `:node-test-perf-nightly`, `:node-test-security`, `:node-test-testbed-support`, `:node-test-ui`) and are untouched.

Closes rf2-41igl.