### PR TITLE
fix(api-manifest): classify namespace vs API-name heading spans in parse-var-rows (rf2-etj5i)

### DIFF
--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/api_md_check.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/api_md_check.clj
@@ -170,19 +170,48 @@
   [cells]
   (first (keep-indexed (fn [i c] (when (= "Tier" (str/trim c)) i)) cells)))
 
+(defn- namespace-shaped?
+  "True when a heading CODE SPAN NAMES a re-frame2 namespace, as opposed to an
+   ordinary API name, keyword, or other code a heading may carry. A namespace is
+   DOTTED — two or more `.`-separated lowercase identifier segments
+   (`re-frame.ui`, `re-frame.freehand`, `re-frame.freehand.test`). That shape
+   distinguishes it from a bare API-name span (`reg-sub`, `dispatch-*`,
+   `reg-flow` / `clear-flow`), a keyword span (`:rf.http/managed` — rejected by
+   its leading `:` and its `/`), or a wildcard (`dispatch-*` — rejected by the
+   `*`). So a heading whose only code span is an API name names NO namespace, and
+   an API-name child under it inherits its parent's namespace rather than adopting
+   the API name as a bogus namespace (rf2-etj5i)."
+  [span]
+  (boolean (re-matches #"[a-z][a-z0-9-]*(?:\.[a-z][a-z0-9-]*)+" span)))
+
 (defn- section-heading-namespace
   "The owning namespace a Markdown SECTION HEADING names in a back-tick code
    span — ``## Compiled views — `re-frame.ui` `` -> \"re-frame.ui\",
    ``## Freehand views — `re-frame.freehand` `` -> \"re-frame.freehand\" — or nil
-   for a non-heading line or a heading that carries no code-span namespace
-   (`## Registration`). A BARE var-row is attributed to the namespace of the
-   SECTION it sits under, never to its bare name alone: a bare root verb is a
-   `re-frame.ui` verb only inside the `re-frame.ui` section, so a future bare
-   Freehand row (the natural spelling once a section header already scopes the
-   table) can no longer be mis-attributed to `re-frame.ui` (rf2-etj5i)."
+   for a non-heading line, a heading with no code span, or a heading whose code
+   span(s) name NO namespace (`## Registration`, ``### `reg-sub` input modes``).
+
+   The heading's code spans are scanned IN ORDER and the FIRST NAMESPACE-SHAPED
+   one (`namespace-shaped?` — dotted `a.b.c`) is taken; an ORDINARY API-name span
+   is NOT a namespace, so a heading whose span is an API name
+   (``### Root lifecycle — `hydrate-root` ``, ``### `reg-sub` input-production
+   modes``) is namespace-LESS and its API-name children inherit the established
+   PARENT namespace. Blindly taking the FIRST span — the original bug — read such
+   a heading as a `hydrate-root` / `reg-sub` namespace, which then mis-excluded
+   the correct bare row and made the two-sided guard report it missing: a FALSE
+   gate failure. This is not exotic syntax — the real spec/API.md already carries
+   code-span headings for `reg-sub`, `dispatch-*`, `:rf.http/managed`, and
+   `reg-flow` / `clear-flow`, none of which name a namespace (rf2-etj5i).
+
+   A BARE var-row is attributed to the namespace of the SECTION it sits under,
+   never to its bare name alone: a bare root verb is a `re-frame.ui` verb only
+   inside the `re-frame.ui` section, so a bare Freehand row (the natural spelling
+   once a section header already scopes the table) can no longer be
+   mis-attributed to `re-frame.ui` (rf2-etj5i)."
   [line]
   (when (str/starts-with? (str/triml line) "#")
-    (second (re-find #"`([^`]+)`" line))))
+    (some (fn [[_ span]] (when (namespace-shaped? span) span))
+          (re-seq #"`([^`]+)`" line))))
 
 (defn- heading-level
   "The ATX heading LEVEL — the count of leading `#`s — of a Markdown heading

--- a/implementation/scripts/api-manifest/test/re_frame/api_manifest/api_md_check_test.clj
+++ b/implementation/scripts/api-manifest/test/re_frame/api_manifest/api_md_check_test.clj
@@ -534,6 +534,169 @@
       (is (= "hydrate-root" (:var (first problems)))))))
 
 ;; ---------------------------------------------------------------------------
+;; A code-span heading that NAMES an API name is NOT a namespace (rf2-etj5i,
+;; THIRD reopen — the last).
+;;
+;; PR #6838 added heading-level inheritance for a child heading with NO code
+;; span, but `section-heading-namespace` still took the FIRST back-tick span on
+;; ANY heading as the section namespace without checking WHAT it names. So an
+;; ordinary API-name code-span heading — ``### Root lifecycle — `hydrate-root` ``,
+;; ``### `reg-sub` input-production modes`` — set `:section-ns` to a BOGUS
+;; namespace ("hydrate-root" / "reg-sub"), which then mis-excluded the correct
+;; bare re-frame.ui row and made the two-sided guard report it MISSING: a FALSE
+;; gate failure. This is not exotic — the real spec/API.md already carries
+;; code-span headings for reg-sub, dispatch-*, :rf.http/managed and reg-flow /
+;; clear-flow, none of which name a namespace.
+;;
+;; The fix distinguishes a namespace-SHAPED span (dotted `a.b.c`) from an
+;; API-name span, and SELECTS the first namespace-shaped span rather than blindly
+;; the first span: an API-name heading is namespace-LESS (its API-name children
+;; inherit the established PARENT namespace), and a genuine dotted namespace span
+;; sets the namespace even when it is not the first span on the heading. These
+;; direct `parse-var-rows` cases cover BOTH doors (re-frame.ui and
+;; re-frame.freehand) and each is NON-VACUITY-probed: the asserted `:section-ns`
+;; is the PARENT / genuine namespace, never the heading's API-name span — so each
+;; assertion REDS against the buggy first-span parser and passes with the fix.
+;; ---------------------------------------------------------------------------
+
+;; -- Case 1 & 3: an API-NAME code-span child heading is namespace-LESS; its
+;;    bare API-name row inherits the established PARENT namespace (never the
+;;    heading's own API-name span). Covered under BOTH doors.
+
+(def ^:private ui-api-name-child-heading-lines
+  "A bare re-frame.ui `hydrate-root` row under an API-NAME code-span child
+   heading (``### Root lifecycle — `hydrate-root` ``) inside the `re-frame.ui`
+   section. The heading's only code span is an API NAME, not a namespace: the
+   buggy first-span parser set `:section-ns` to \"hydrate-root\"; the row must
+   instead INHERIT the parent re-frame.ui (the API-name heading is
+   namespace-less)."
+  [[1 "## Compiled views — `re-frame.ui`"]
+   [2 ""]
+   [3 "### Root lifecycle — `hydrate-root`"]
+   [4 ""]
+   [5 "| API | M/Fn | Tier | Notes |"]
+   [6 "|-----|------|------|-------|"]
+   [7 "| `hydrate-root` | M | advanced | the compiled door |"]])
+
+(deftest ui-api-name-code-span-heading-does-not-become-a-namespace
+  (testing "rf2-etj5i (3rd reopen), re-frame.ui: an API-NAME code-span child
+            heading (``### Root lifecycle — `hydrate-root` ``) is namespace-LESS —
+            its span is an API name, not a namespace — so the bare hydrate-root
+            row INHERITS re-frame.ui, never the bogus \"hydrate-root\" the buggy
+            first-span parser produced"
+    (let [parsed  (c/parse-var-rows ui-api-name-child-heading-lines)
+          by-line (into {} (map (juxt :line identity)) parsed)]
+      (is (= "re-frame.ui" (:section-ns (get by-line 7)))
+          "the bare hydrate-root inherits the parent re-frame.ui — NOT the API-name span \"hydrate-root\"")
+      (is (not= "hydrate-root" (:section-ns (get by-line 7)))
+          "the API-name heading span must NOT become the section namespace")
+      ;; The consequence the reopen names: with a bogus \"hydrate-root\" namespace
+      ;; the row is EXCLUDED from re-frame.ui and the guard reports the verb
+      ;; missing. Correctly attributed, exactly one re-frame.ui hydrate-root is
+      ;; seen and the guard is clean.
+      (let [rows     [{:namespace "re-frame.ui" :var "hydrate-root" :kind :macro}]
+            problems (c/root-verb-kind-problems {:rows rows :api-rows parsed})]
+        (is (empty? (filter #(= "hydrate-root" (:var %)) problems))
+            "no false gate failure — the correct bare re-frame.ui row is not mis-excluded")))))
+
+(def ^:private freehand-api-name-child-heading-lines
+  "The same API-NAME code-span child heading, but inside the `re-frame.freehand`
+   section — the bare row must inherit re-frame.freehand, never \"hydrate-root\"."
+  [[1 "## Freehand views — `re-frame.freehand`"]
+   [2 ""]
+   [3 "### Root lifecycle — `hydrate-root`"]
+   [4 ""]
+   [5 "| API | M/Fn | Tier | Notes |"]
+   [6 "|-----|------|------|-------|"]
+   [7 "| `hydrate-root` | Fn | front-porch | the freehand door |"]])
+
+(deftest freehand-api-name-code-span-heading-does-not-become-a-namespace
+  (testing "rf2-etj5i (3rd reopen), re-frame.freehand: the API-NAME code-span
+            child heading is likewise namespace-LESS — the bare hydrate-root row
+            inherits re-frame.freehand, not \"hydrate-root\", and is NOT
+            re-attributed to re-frame.ui"
+    (let [parsed  (c/parse-var-rows freehand-api-name-child-heading-lines)
+          by-line (into {} (map (juxt :line identity)) parsed)]
+      (is (= "re-frame.freehand" (:section-ns (get by-line 7)))
+          "the bare hydrate-root inherits the parent re-frame.freehand — NOT the API-name span \"hydrate-root\"")
+      (is (not= "hydrate-root" (:section-ns (get by-line 7)))
+          "the API-name heading span must NOT become the section namespace"))))
+
+;; -- Case 2: a genuine namespace-bearing heading SETS the namespace — even when
+;;    the namespace span is NOT the first code span on the heading (the fix
+;;    SELECTS the namespace-shaped span rather than blindly the first). Covered
+;;    under BOTH doors and non-vacuous: the buggy first-span parser would pick the
+;;    leading API-name span.
+
+(def ^:private ui-namespace-heading-namespace-not-first-lines
+  "A heading whose FIRST code span is an API name and whose SECOND is the genuine
+   namespace (``### `create-root` in `re-frame.ui` ``). The fix must SELECT the
+   namespace-shaped span; the buggy first-span parser picked \"create-root\"."
+  [[1 "### `create-root` in `re-frame.ui`"]
+   [2 ""]
+   [3 "| API | M/Fn | Tier | Notes |"]
+   [4 "|-----|------|------|-------|"]
+   [5 "| `create-root` | M | advanced | the compiled door |"]])
+
+(deftest ui-namespace-bearing-heading-sets-namespace-not-first-span
+  (testing "rf2-etj5i (3rd reopen), re-frame.ui: a genuine namespace-bearing
+            heading SETS the namespace even when the namespace span is not the
+            first code span — the fix selects the namespace-SHAPED span, so the
+            row resolves to re-frame.ui, never the leading API-name span
+            \"create-root\""
+    (let [parsed  (c/parse-var-rows ui-namespace-heading-namespace-not-first-lines)
+          by-line (into {} (map (juxt :line identity)) parsed)]
+      (is (= "re-frame.ui" (:section-ns (get by-line 5)))
+          "the namespace-shaped span re-frame.ui is selected — NOT the first span \"create-root\""))))
+
+(def ^:private freehand-namespace-heading-namespace-not-first-lines
+  "The same shape under the Freehand door — namespace span second, API-name span
+   first (``### `mount` in `re-frame.freehand` ``)."
+  [[1 "### `mount` in `re-frame.freehand`"]
+   [2 ""]
+   [3 "| API | M/Fn | Tier | Notes |"]
+   [4 "|-----|------|------|-------|"]
+   [5 "| `mount` | Fn | front-porch | the freehand door |"]])
+
+(deftest freehand-namespace-bearing-heading-sets-namespace-not-first-span
+  (testing "rf2-etj5i (3rd reopen), re-frame.freehand: the namespace-bearing
+            heading SETS re-frame.freehand even with a leading API-name span —
+            the row resolves to re-frame.freehand, never \"mount\""
+    (let [parsed  (c/parse-var-rows freehand-namespace-heading-namespace-not-first-lines)
+          by-line (into {} (map (juxt :line identity)) parsed)]
+      (is (= "re-frame.freehand" (:section-ns (get by-line 5)))
+          "the namespace-shaped span re-frame.freehand is selected — NOT the first span \"mount\""))))
+
+;; -- A tight direct proof over the REAL spec/API.md heading strings: every
+;;    code-span heading the live doc actually carries must classify correctly —
+;;    the four API-name/keyword/wildcard headings name NO namespace, the three
+;;    genuine dotted headings name theirs. This pins the exact headings the reopen
+;;    cited (reg-sub / dispatch-* / :rf.http/managed / reg-flow) and reds on the
+;;    buggy first-span parser for each API-name heading.
+
+(deftest real-api-md-code-span-headings-classify-correctly
+  (testing "rf2-etj5i (3rd reopen): the code-span headings the LIVE spec/API.md
+            carries classify correctly — API-name / keyword / wildcard headings
+            name NO namespace (nil), genuine dotted headings name theirs. The
+            buggy first-span parser returned the API name for each of the former"
+    (let [ns-of #'c/section-heading-namespace]
+      ;; API-name / keyword / wildcard spans → namespace-LESS (nil). Each of
+      ;; these REDS on the buggy first-span parser (it returned the bracketed
+      ;; span verbatim).
+      (is (nil? (ns-of "### Root lifecycle — `hydrate-root`")))
+      (is (nil? (ns-of "### `reg-sub` input-production modes")))
+      (is (nil? (ns-of "### `dispatch-*` family taxonomy")))
+      (is (nil? (ns-of "### Trace events emitted by `:rf.http/managed`")))
+      (is (nil? (ns-of "### `reg-flow` / `clear-flow` (Spec 013)")))
+      ;; genuine dotted namespace spans → the namespace (case 2, direct)
+      (is (= "re-frame.freehand" (ns-of "## Freehand views — `re-frame.freehand` (Spec 004)")))
+      (is (= "re-frame.freehand.test" (ns-of "### The structural test surface — `re-frame.freehand.test` (Spec 008)")))
+      (is (= "re-frame.ui" (ns-of "## Compiled views — `re-frame.ui` (Spec 004D)")))
+      ;; a non-heading line and a namespace-less prose heading name nothing
+      (is (nil? (ns-of "| `hydrate-root` | M | advanced | not a heading |")))
+      (is (nil? (ns-of "## Registration"))))))
+
+;; ---------------------------------------------------------------------------
 ;; END-TO-END parser disappearance (rf2-asxo3).
 ;;
 ;; The pure `parse-var-rows` core lets us feed synthetic indexed API.md lines.


### PR DESCRIPTION
Closes rf2-etj5i (third audit reopen — the last).

## The bug

`section-heading-namespace` in `api_md_check.clj` took the **FIRST** back-tick
code span on **any** heading as the section namespace, without checking what it
names. So an API-name code-span heading — `### Root lifecycle — `hydrate-root`` —
yielded `:section-ns "hydrate-root"` (a bogus namespace from an API-name span),
which then mis-excluded the correct bare `re-frame.ui` row and made the two-sided
root-verb guard report it missing: a **false gate failure**.

This is not exotic syntax. The real `spec/API.md` already carries code-span
headings for `reg-sub`, `dispatch-*`, `:rf.http/managed`, and `reg-flow` /
`clear-flow` — none of which name a namespace.

## The fix

Distinguish a **namespace-shaped** span from an ordinary API-name/code span, and
**select the first namespace-shaped span** rather than blindly the first span:

- `namespace-shaped?` — a namespace is **dotted** (`^[a-z][a-z0-9-]*(\.[a-z][a-z0-9-]*)+$`):
  two or more `.`-separated lowercase identifier segments (`re-frame.ui`,
  `re-frame.freehand`, `re-frame.freehand.test`). A bare API name (`reg-sub`,
  `dispatch-*`, `reg-flow`), a keyword (`:rf.http/managed`, rejected by its
  leading `:` and `/`), or a wildcard (`dispatch-*`, rejected by the `*`) is
  **not** namespace-shaped.
- A heading whose only code span is an API name is therefore **namespace-less**,
  and an API-name child under it **inherits the established parent namespace**
  (the level-aware inheritance from #6838 — unchanged). A genuine dotted
  namespace span sets the namespace even when it is not the first span on the
  heading.

The small level-aware inheritance loop in `parse-var-rows` is untouched; the
change is confined to `section-heading-namespace` plus the new `namespace-shaped?`
helper.

## Quality gates

- **api-manifest test suite** (`clojure -M:test`) — **EXIT=0**, `Ran 141 tests
  containing 334 assertions. 0 failures, 0 errors.` (green both before and after
  a rebase onto current `origin/main`).
- **Real `spec/API.md`, 0 regressions (the key proof)** — `api_md_check`'s `-main`
  run standalone against the committed `spec/API.md`:
  `OK: spec/API.md projection in sync (244 var-rows checked against the manifest).`
  **EXIT=0**. The real doc's `reg-sub` / `dispatch-*` / `:rf.http/managed` /
  `reg-flow` code-span headings now classify as namespace-less rather than as
  bogus namespaces.
- **New parser cases under both doors** — direct `parse-var-rows` cases under
  `re-frame.ui` **and** `re-frame.freehand`: (1) an API-name code-span heading
  must not become a namespace; (2) a genuine namespace-bearing heading sets the
  namespace even when the namespace span is not first; (3) an API-name child
  under a namespace-less descendant heading inherits the parent. Plus a direct
  classification proof over the actual `spec/API.md` heading strings.
- **Non-vacuity probe** — each new test was run with the buggy first-span parser
  swapped back in via `with-redefs`. Under the fix all 5 new tests pass
  (`fail=0`); under the buggy parser every new test reds (`3 + 2 + 1 + 1 + 5`
  assertion failures). Raw discrimination on the cited headings:

  | heading span | fixed | buggy |
  |---|---|---|
  | `` `hydrate-root` `` (API name) | `nil` | `"hydrate-root"` |
  | `` `reg-sub` `` | `nil` | `"reg-sub"` |
  | `` `dispatch-*` `` | `nil` | `"dispatch-*"` |
  | `` `:rf.http/managed` `` | `nil` | `":rf.http/managed"` |
  | `` `reg-flow` `` | `nil` | `"reg-flow"` |
  | `` `re-frame.ui` `` | `"re-frame.ui"` | `"re-frame.ui"` |
  | `` `create-root` `` then `` `re-frame.ui` `` | `"re-frame.ui"` | `"create-root"` |

## How a namespace span is classified vs an API-name span

A heading code span is treated as a **namespace** iff it is **dotted** — it
matches `[a-z][a-z0-9-]*(\.[a-z][a-z0-9-]*)+` (two or more lowercase,
hyphen-permitting segments joined by `.`). Everything else — a bare API name, a
`:`-led keyword, a `*` wildcard, a `/`-qualified var — is an ordinary code span
and names no namespace. The heading's spans are scanned in order and the first
namespace-shaped one wins; if none is namespace-shaped the heading is
namespace-less and its children inherit the parent namespace.
