### PR TITLE
fix(freehand): prove root ownership against the live incarnation token across same-id successors (rf2-drpa3.110)

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/root.cljs
+++ b/implementation/freehand/src/re_frame/freehand/root.cljs
@@ -459,6 +459,16 @@
 ;; scoped frame the page never owned), and refreshed to the current value on
 ;; every re-install (a same-incarnation surgical update keeps the same token, so
 ;; the identity is stable across a config edit).
+;;
+;; The token is also the OWNERSHIP PROOF preflight turns on (see
+;; `owns-live-incarnation?`). A non-nil `:installed-by` records who ran an
+;; install ONCE; it does not prove the frame live under the id NOW is that
+;; incarnation. A row owns the CURRENT live frame only while its
+;; `:installed-value` token is identically the live incarnation's token — a
+;; same-id successor carries a distinct token and is owned by no stale row, and
+;; a pre-#6818 LEGACY row that never recorded a value proves ownership of
+;; nothing. A config-bearing ENSURE that cannot prove ownership is refused
+;; before it can convert an address into address-directed teardown authority.
 (defonce ^:private frame-ledger (atom {}))
 
 (defn ^:no-doc live-root-ids
@@ -489,9 +499,12 @@
   installed row that still names its `:installed-by` but has NO
   `:installed-value` key — a test-only seam. There is no other way to
   produce that shape: current code always records the install value, so a
-  suite proving the HMR migration recovers the exact authority a `defonce`
-  ledger carried across a reload without it must seed the shape a prior
-  build wrote. Never application API."
+  suite proving how the ownership proof treats the shape a `defonce` ledger
+  carried across a reload WITHOUT a value must seed it directly. A legacy row
+  carries no incarnation token, so `owns-live-incarnation?` can prove nothing
+  about the live frame under the id — a config-bearing remount over it is
+  refused rather than bootstrapping ownership from the current address (which
+  could be a successor). Never application API."
   [frame-id]
   (swap! frame-ledger update frame-id dissoc :installed-value)
   nil)
@@ -697,38 +710,31 @@
                     "which the root ENSUREs and owns for its lifetime.")
                {:value (error/diag-value-summary frame-opt)})))
 
-(defn- installed-value-for
-  "The frame VALUE an owned ledger row carries as its incarnation-EXACT
-  teardown authority. Prefer the value the plan just produced (a fresh
-  install or a config-edit re-run); else the value the standing install
-  already recorded; else — and only else — reconstruct it from the live
-  frame's current incarnation token.
+(defn- owns-live-incarnation?
+  "True when `record` PROVES ownership of the frame incarnation currently live
+  under `frame-id` — the ledger's install authority, keyed on the incarnation
+  TOKEN rather than on a non-nil `:installed-by`.
 
-  That last arm is the pre-#6818 LEGACY migration. `frame-ledger` is
-  `defonce`, so a row written before `:installed-value` existed survives a
-  hot reload WITHOUT one. On the ordinary same-plan remount `make-frame`
-  does not run (the frame is live and the fingerprint matches), so no fresh
-  value arrives and the recorded value is nil — and left there, the final
-  `release-frame!` would `destroy-frame!` a nil: no incarnation token, no
-  teardown, the root-owned frame left LIVE and untracked past its last root.
-  The remount is where the reloaded code meets that row, so the remount is
-  where it heals it.
+  `:installed-by` records WHO ran an install once; it does not prove the frame
+  live under that id NOW is the one they installed. The core frame contract's id
+  is address-directed, so a same-id SUCCESSOR — the installed incarnation torn
+  down and re-created under the same id — is a DIFFERENT frame carrying a
+  DISTINCT incarnation token (its own `:drain-lock`). A row still naming the
+  original install VALUE owns that successor of nothing: its token no longer
+  identifies the live frame.
 
-  The recovered authority is EXACT, not address-directed. A same-id frame
-  that survives the reload keeps its `:drain-lock` by identity, so
-  `frame-incarnation-token` answers the very token the original `make-frame`
-  value carried; the reconstructed value therefore destroys EXACTLY that
-  incarnation and no-ops against a same-id successor reseated after it. A
-  row that already recorded its value short-circuits before the token read,
-  so only a legacy row ever reaches it, and a frame no longer live yields no
-  token — harmless, since teardown will not destroy an absent frame either."
-  [frame-id fresh-value recorded-value]
-  (or fresh-value
-      recorded-value
-      (when-let [token (frame/frame-incarnation-token frame-id)]
-        (frame/make-frame-value {:id          frame-id
-                                 :runnable-id frame-id
-                                 :token       token}))))
+  Ownership is proven the one way it can be: the recorded `:installed-value`
+  carries a `:rf.frame/incarnation-token`, and that token is `identical?` to the
+  live frame's current incarnation token. A row that never recorded a value — a
+  fresh boot/external frame this page only SCOPED, or a pre-#6818 LEGACY row a
+  `defonce` ledger carried across a reload without one — carries no token, so it
+  proves ownership of nothing and answers false. This is the SAME exact-token
+  discipline teardown destroys with; a mount that cannot prove ownership here
+  must not convert an address into it (`preflight!`)."
+  [record frame-id]
+  (let [token (frame/frame-value-incarnation-token (:installed-value record))]
+    (and (some? token)
+         (identical? token (frame/frame-incarnation-token frame-id)))))
 
 (defn- preflight!
   "Run `plan` to completion, and answer the frame-id it bound. Called
@@ -762,37 +768,52 @@
                                   :installed-by       (:installed-by record)}
                       :arriving  {:config-fingerprint config-fingerprint
                                   :root-id            root-id}}}))
-      ;; The AUTHORITY arm (Spec 004C §7). A config-BEARING ENSURE that meets a
-      ;; frame already LIVE but with no `:installed-by` recorded — a fresh
-      ;; boot/external frame, or one this page only SCOPED under a prior
-      ;; config-less row — is meeting a BOOT-AUTHORITATIVE frame. There is no
-      ;; installer to refresh, so proceeding would let `make-frame` reset the
-      ;; boot config, write `:installed-by root-id` + `:installed-value`, and
-      ;; hand this root address-directed teardown authority — the final
-      ;; `unmount!` then destroying a frame the page never owned. Ownership is
-      ;; the right to have CREATED the frame; scoping is the honest way to
-      ;; reference one you did not. So this fails BEFORE `make-frame` mutates,
-      ;; distinct from the differing-fingerprint arm above: that recovers by
-      ;; aligning configs, this by dropping to a config-less scope or owning the
-      ;; whole lifetime. A first-time ENSURE (frame not yet live) and a same-root
-      ;; refresh (`:installed-by` already this root) both fall through untouched.
+      ;; The OWNERSHIP arm (Spec 004C §7) — AC4 generalized to the incarnation
+      ;; TOKEN, so it also polices the same-id-successor residual. A config-
+      ;; BEARING ENSURE may take ownership of a frame only when it CREATES it
+      ;; (not yet live) or PROVES it already owns the incarnation live under the
+      ;; id (`owns-live-incarnation?` — its recorded install value's token is
+      ;; identically the live frame's current token). A frame that is LIVE but
+      ;; this row does not provably own is a boot/external frame or a same-id
+      ;; SUCCESSOR of the one this row installed; proceeding would let
+      ;; `make-frame` reset a frame the page never installed, write an install
+      ;; value carrying the SUCCESSOR's token, and hand this root the address-
+      ;; directed authority to DESTROY it at the final `unmount!`. Three
+      ;; unownable shapes reach here, one breach:
+      ;;   - no `:installed-by` at all — a fresh boot/external frame, or one a
+      ;;     prior config-less SCOPE row only referenced (the original AC4 case);
+      ;;   - an `:installed-by` whose recorded incarnation was torn down and
+      ;;     re-created under the same id — the token names a dead incarnation,
+      ;;     not the live successor;
+      ;;   - a pre-#6818 LEGACY row naming an installer but no value — no token to
+      ;;     compare, so ownership of the live incarnation cannot be proven at all
+      ;;     (a `defonce` reload must not bootstrap exact authority from the
+      ;;     current address, which could be a successor seated before it).
+      ;; Each fails BEFORE `make-frame` mutates, distinct from the
+      ;; differing-fingerprint arm above: that recovers by aligning configs, this
+      ;; by dropping to a config-less SCOPE or owning the whole lifetime. A
+      ;; first-time ENSURE (frame not yet live) and a same-root refresh on the
+      ;; SAME live incarnation both prove ownership and fall through untouched.
       (when (and owned?
-                 (nil? (:installed-by record))
-                 (some? (frame/frame frame-id)))
+                 (some? (frame/frame frame-id))
+                 (not (owns-live-incarnation? record frame-id)))
         (error/throw-error!
           :rf.error/frame-payload-conflict where
-          (str "frame " (pr-str frame-id) " is already LIVE and this page does not "
-               "own it — it was booted or created elsewhere, or is only being "
-               "scoped here. A config-bearing :frame {:id …} plan would take it "
-               "over: reset its config now, then DESTROY it at unmount, silently "
-               "tearing down state this root never installed. Boot the frame "
+          (str "frame " (pr-str frame-id) " is already LIVE and this page cannot "
+               "prove it owns the incarnation live under that id — it was booted "
+               "or created elsewhere, is only being scoped here, or the incarnation "
+               "this root installed was destroyed and re-created under the same id. "
+               "A config-bearing :frame {:id …} plan would take the live frame over: "
+               "reset its config now, then DESTROY it at unmount, silently tearing "
+               "down an incarnation this root does not own. Boot the frame "
                "config-less and SCOPE it with :frame " (pr-str frame-id) ", or drop "
                "the external make-frame and let this root own the frame's whole "
                "lifetime.")
           {:recovery :scope-config-less-or-own-the-lifetime
            :extra    {:frame-id  frame-id
-                      :installed {:config-fingerprint (:config-fingerprint record)
-                                  :adopted            true}
+                      :installed {:config-fingerprint    (:config-fingerprint record)
+                                  :installed-by          (:installed-by record)
+                                  :owns-live-incarnation false}
                       :arriving  {:config-fingerprint config-fingerprint
                                   :root-id            root-id}}}))
       (let [installed-value
@@ -826,14 +847,16 @@
                (fn [r]
                  {:config-fingerprint (if owned? config-fingerprint (:config-fingerprint r))
                   :installed-by       (if owned? (or (:installed-by r) root-id) (:installed-by r))
-                  ;; The install authority: the fresh value when the plan just ran,
-                  ;; else the value from the install that stands, else the exact
-                  ;; incarnation recovered for a pre-#6818 LEGACY row a `defonce`
-                  ;; ledger carried across a hot reload without one. A scoped mount
-                  ;; carries nothing of its own and leaves the row's value be.
+                  ;; The install authority: the fresh value when the plan just ran
+                  ;; (a create or a proven-owner config edit), else the value from
+                  ;; the install that stands. The ownership arm above has already
+                  ;; refused any owned ENSURE that reaches here without one of those
+                  ;; — a live frame this row cannot prove it owns never mutates the
+                  ;; ledger — so there is no address-directed recovery to fall back
+                  ;; to. A scoped mount carries nothing of its own and leaves the
+                  ;; row's value be.
                   :installed-value    (if owned?
-                                        (installed-value-for frame-id installed-value
-                                                             (:installed-value r))
+                                        (or installed-value (:installed-value r))
                                         (:installed-value r))
                   :refs               (conj (or (:refs r) #{}) root-id)})))
       frame-id)))

--- a/implementation/freehand/test/re_frame/freehand/root_preflight_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/root_preflight_dom_cljs_test.cljs
@@ -591,3 +591,130 @@
                     (is false (str "scope non-transfer suite rejected: " e))
                     (.remove node)
                     (done))))))))))
+
+;; ===========================================================================
+;; FH-ROOT-004 — the ownership proof is the incarnation TOKEN, not a non-nil
+;; :installed-by (rf2-drpa3.110, third reopen — the same-id-successor residual)
+;;
+;; The AC4 arm above refuses a config-bearing ENSURE over a frame with no
+;; :installed-by. But a non-nil :installed-by is not itself proof that the frame
+;; live under the id NOW is the one that root installed: the core frame id is
+;; address-directed, so a same-id SUCCESSOR (the installed incarnation torn down
+;; and re-created under the same id) is a distinct frame carrying a distinct
+;; token. A row still naming the original install value owns that successor of
+;; nothing. `owns-live-incarnation?` proves ownership by matching the recorded
+;; install-value token to the live frame's current token, so a stale row does
+;; NOT assert ownership of a successor — whatever the remount's fingerprint.
+;; ===========================================================================
+
+(deftest fh-root-004-a-config-bearing-remount-over-a-same-id-successor-fails-loud
+  (testing "Per FH-ROOT-004 / rf2-drpa3.110 (browser): install-own → same-id
+            teardown+reincarnation → remount. A root installs incarnation A (its
+            value token recorded); external code destroys A and stands a same-id
+            successor B; the root remounts under the SAME plan. :installed-by
+            still names the root, but its recorded token no longer identifies the
+            live frame, so the stale row does NOT assert ownership of B — the
+            remount fails loud before mutation, B is untouched, and the final
+            unmount of the original installer destroys exactly the original
+            incarnation (already gone), no-ops against B, and empties the ledger."
+    (if-not (browser?)
+      (skip! "the browser job runs the same-id-successor remount assertions")
+      (async done
+        (reg!)
+        (let [node    (host-node!)
+              fid     :fh.root/succ-same-plan
+              plan    {:frame {:id fid :initial-events [[:root/seed 1]]}}
+              a-token (atom nil)
+              b-token (atom nil)]
+          (-> (act #(v/mount [views/counter {}] node plan))
+              (.then
+                (fn [installer]
+                  (reset! a-token (frame/frame-incarnation-token fid))
+                  (is (identical? @a-token
+                                  (frame/frame-value-incarnation-token
+                                    (:installed-value (get (root/frame-ledger-snapshot) fid))))
+                      "the install recorded A's exact incarnation token")
+                  ;; external: destroy A, stand a same-id successor B.
+                  (rf/destroy-frame! fid)
+                  (rf/make-frame {:id fid :initial-events [[:root/seed 2]]})
+                  (reset! b-token (frame/frame-incarnation-token fid))
+                  (is (not (identical? @a-token @b-token))
+                      "B is a distinct incarnation")
+                  ;; same-plan remount over B — the recorded token no longer matches.
+                  (let [data (error-data #(v/mount [views/counter {}] node plan))]
+                    (is (= :rf.error/frame-payload-conflict (:rf.error/id data))
+                        "the stale row does not assert ownership of the successor")
+                    (is (= :scope-config-less-or-own-the-lifetime (:recovery data)))
+                    (is (= fid (:frame-id data))
+                        "and the diagnostic names the frame at stake")
+                    (is (identical? @b-token (frame/frame-incarnation-token fid))
+                        "B is untouched — the guard fired before any mutation"))
+                  (act #(v/unmount! installer))))
+              (.then
+                (fn [_]
+                  (is (some? (frame/frame fid))
+                      "final unmount destroyed EXACTLY the original incarnation
+                       (already gone) and no-opped against the successor")
+                  (is (identical? @b-token (frame/frame-incarnation-token fid))
+                      "so B — the successor — still stands, its exact incarnation")
+                  (is (empty? (root/frame-ledger-snapshot))
+                      "and the ledger is emptied: the installer released its own row")
+                  (rf/destroy-frame! fid)
+                  (.remove node)
+                  (done))
+                (fn [e]
+                  (is false (str "same-id-successor remount suite rejected: " e))
+                  (.remove node)
+                  (done)))))))))
+
+(deftest fh-root-004-a-config-refresh-over-a-same-id-successor-cannot-take-it-over
+  (testing "Per FH-ROOT-004 / rf2-drpa3.110 (browser): the CHANGED-fingerprint
+            arm of the same breach. With a config edit the remount's fingerprint
+            differs, so make-frame WANTS to run — and address-directed it would
+            run against the successor B, surgically rewriting B's config and
+            recording B's token as the install value: a silent takeover the final
+            unmount would consummate by destroying B. The ownership proof fires
+            FIRST, before make-frame: the recorded token names the dead original,
+            not B, so the refresh is refused and B is preserved exactly."
+    (if-not (browser?)
+      (skip! "the browser job runs the same-id-successor refresh assertions")
+      (async done
+        (reg!)
+        (let [node    (host-node!)
+              fid     :fh.root/succ-refresh
+              plan-x  {:frame {:id fid :initial-events [[:root/seed 1]]}}
+              plan-y  {:frame {:id fid :initial-events [[:root/seed 1] [:root/noop]]}}
+              b-token (atom nil)]
+          (rf/reg-event :root/noop (fn [{:keys [db]} _] {:db db}))
+          (-> (act #(v/mount [views/counter {}] node plan-x))
+              (.then
+                (fn [installer]
+                  ;; external: destroy A, stand a same-id successor B.
+                  (rf/destroy-frame! fid)
+                  (rf/make-frame {:id fid :initial-events [[:root/seed 2]]})
+                  (reset! b-token (frame/frame-incarnation-token fid))
+                  ;; a config EDIT (different fingerprint) over B — make-frame would
+                  ;; run address-directed against B if the guard did not precede it.
+                  (let [data (error-data #(v/mount [views/counter {}] node plan-y))]
+                    (is (= :rf.error/frame-payload-conflict (:rf.error/id data))
+                        "the config refresh cannot take over a frame it cannot prove it owns")
+                    (is (= :scope-config-less-or-own-the-lifetime (:recovery data)))
+                    (is (identical? @b-token (frame/frame-incarnation-token fid))
+                        "B's EXACT incarnation is untouched — the guard fired before
+                         make-frame could rewrite its config or record its token"))
+                  (act #(v/unmount! installer))))
+              (.then
+                (fn [_]
+                  (is (some? (frame/frame fid))
+                      "and the final unmount never reached B — the install value still
+                       named the original incarnation, so teardown no-opped against
+                       the successor rather than destroying it")
+                  (is (identical? @b-token (frame/frame-incarnation-token fid)))
+                  (is (empty? (root/frame-ledger-snapshot)))
+                  (rf/destroy-frame! fid)
+                  (.remove node)
+                  (done))
+                (fn [e]
+                  (is false (str "same-id-successor refresh suite rejected: " e))
+                  (.remove node)
+                  (done)))))))))

--- a/implementation/freehand/test/re_frame/freehand/root_teardown_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/root_teardown_dom_cljs_test.cljs
@@ -76,6 +76,13 @@
 (defn- text [container selector]
   (some-> (.querySelector container selector) .-textContent))
 
+(defn- error-data
+  "The whole ex-data of the error `thunk` raised, or nil when it returned
+  normally — the ownership-proof refusals throw synchronously in preflight,
+  BEFORE React, so a fail-loud remount is caught here without an `act`."
+  [thunk]
+  (try (thunk) nil (catch :default e (ex-data e))))
+
 ;; The live sub-cache, read directly. This is the observation that separates
 ;; "React took the DOM away" from "the ViewCell released what it owned".
 (defn- ref-count [fid q]
@@ -419,138 +426,127 @@
                   (done)))))))))
 
 ;; ===========================================================================
-;; FH-ROOT-005 — HMR migration of a pre-#6818 legacy ledger row (rf2-4pvsy)
+;; FH-ROOT-005 — a pre-#6818 legacy ledger row cannot bootstrap ownership
+;; (rf2-drpa3.110, third reopen — supersedes the rf2-4pvsy address-migration)
 ;;
 ;; `frame-ledger` is `defonce`, so a row a pre-#6818 build wrote survives a hot
-;; reload WITHOUT an `:installed-value`. The reloaded code meets that row on the
-;; ordinary same-plan remount, where `make-frame` does not run — so nothing
-;; supplies the install value, and left nil the final `release-frame!` would
-;; `destroy-frame!` a nil: no incarnation token, no teardown, the root-owned
-;; frame left LIVE and untracked past its last root. The remount must MIGRATE
-;; the row instead, recovering the frame's exact current incarnation as the
-;; teardown authority so the surrounding `defonce` hot-reload path stays honest.
+;; reload WITHOUT an `:installed-value` — an `:installed-by` but no incarnation
+;; token. An earlier fix MIGRATED that row on remount by reading the live frame's
+;; token by ADDRESS, but a token read by address is the CURRENT incarnation, not
+;; provably the one the installer created: if external code destroyed the
+;; original and stood a same-id SUCCESSOR before the reloaded remount, the
+;; migration silently recorded the successor's token and the final unmount
+;; destroyed a frame the programmer owns. The ownership proof
+;; (`owns-live-incarnation?`) is keyed on the token, and a legacy row has none,
+;; so it proves ownership of nothing: a config-bearing remount over it FAILS
+;; LOUD before any mutation rather than bootstrapping ownership from the address.
+;; The honest cost is that the un-owned row's teardown is a safe no-op — it never
+;; destroys a frame it cannot prove it owns.
 ;; ===========================================================================
 
-(deftest fh-root-005-a-legacy-row-is-migrated-on-remount-and-torn-down-exactly
-  (testing "Per FH-ROOT-005 / rf2-4pvsy (browser): a defonce ledger row a
-            pre-#6818 build carried across a hot reload has :installed-by but no
-            :installed-value. The same-plan remount MIGRATES it — recovering the
-            live frame's EXACT incarnation token as the row's install value
-            WITHOUT re-running the plan — so the final unmount destroys exactly
-            that incarnation and empties the ledger, where the un-migrated nil
-            would no-op the teardown and orphan the frame the root owns."
+(deftest fh-root-005-a-legacy-row-cannot-bootstrap-ownership-of-the-live-frame
+  (testing "Per FH-ROOT-005 / rf2-drpa3.110 (browser): a defonce ledger row a
+            pre-#6818 build carried across a reload has :installed-by but no
+            :installed-value — no incarnation token. On the config-bearing
+            remount the ownership proof cannot show the frame live under the id
+            is the one this root installed (there is no recorded token to
+            compare), so bootstrapping ownership from the current address could
+            silently take over whatever incarnation happens to be live. The
+            remount FAILS LOUD before any mutation, the exact live incarnation is
+            untouched, and the un-owned row's teardown is a safe no-op."
     (if-not (browser?)
-      (skip! "the browser job runs the legacy-migration assertions")
+      (skip! "the browser job runs the legacy-row ownership-proof assertions")
       (async done
         (reg!)
-        (let [node   (host-node!)
-              fid    :fh.root/legacy
-              seeded 11
-              setup  (atom 0)
-              token  (atom nil)
-              plan   {:frame {:id             fid
-                              :initial-events [[:root/seed seeded]
-                                               [:root/legacy-setup]]}}]
-          (rf/reg-event :root/legacy-setup (fn [_ _] {:fx [[:root/legacy-setup true]]}))
-          (rf/reg-fx :root/legacy-setup (fn [_ _] (swap! setup inc)))
+        (let [node  (host-node!)
+              fid   :fh.root/legacy-live
+              plan  {:frame {:id fid :initial-events [[:root/seed 11]]}}
+              token (atom nil)]
           (-> (act #(v/mount [views/counter {}] node plan))
               (.then
-                (fn [_mounted]
-                  (is (= (str seeded) (text node ".count")))
-                  (is (= 1 @setup) "the plan seeded once")
-                  ;; capture the frame that will survive the reload, so the
-                  ;; migration can be proved to recover THIS exact incarnation.
+                (fn [installer]
                   (reset! token (frame/frame-incarnation-token fid))
-                  (is (some? (frame/frame-value-incarnation-token
-                               (:installed-value (get (root/frame-ledger-snapshot) fid))))
-                      "a fresh install records an incarnation-bearing value")
-                  ;; simulate the pre-#6818 shape the defonce ledger carried
-                  ;; across the reload: installer kept, install value gone.
+                  ;; simulate the pre-#6818 shape the defonce ledger carried.
                   (root/downgrade-ledger-row-to-pre-6818! fid)
                   (is (some? (:installed-by (get (root/frame-ledger-snapshot) fid)))
                       "the legacy row still names its installer")
                   (is (nil? (:installed-value (get (root/frame-ledger-snapshot) fid)))
-                      "but carries no install value — the pre-#6818 shape")
-                  ;; the reloaded code re-runs mount over the surviving row.
-                  (act #(v/mount [views/counter {}] node plan))))
-              (.then
-                (fn [remounted]
-                  (is (= (str seeded) (text node ".count")) "the remount re-rendered")
-                  (is (= 1 @setup)
-                      "and did NOT re-seed — the same-plan remount is the ratified
-                       no-op even over a legacy row")
-                  (is (identical? @token (frame/frame-incarnation-token fid))
-                      "the frame is the SAME incarnation across the reload — the
-                       migration recovered it, it did not recreate it")
-                  (is (identical? @token
-                                  (frame/frame-value-incarnation-token
-                                    (:installed-value (get (root/frame-ledger-snapshot) fid))))
-                      "and the migrated row now carries that EXACT incarnation as its
-                       teardown authority — the healed row is indistinguishable from a
-                       normally-installed one")
-                  (act #(v/unmount! remounted))))
-              (.then
-                (fn [_]
-                  (is (nil? (frame/frame fid))
-                      "final unmount destroyed the frame the root owned — the migrated
-                       authority tore it down, where the un-migrated nil would have
-                       no-opped and left it live and untracked")
-                  (is (empty? (root/frame-ledger-snapshot))
-                      "and the ledger is empty")
-                  (.remove node)
-                  (done))
-                (fn [e]
-                  (is false (str "legacy-migration suite rejected: " e))
-                  (.remove node)
-                  (done)))))))))
-
-(deftest fh-root-005-a-migrated-legacy-authority-is-incarnation-exact
-  (testing "Per FH-ROOT-005 / rf2-4pvsy (browser): the migration recovers an
-            INCARNATION-EXACT authority, not an address-directed one. After the
-            legacy row is migrated on remount, tear the recovered incarnation
-            down and stand a same-id SUCCESSOR in its place; unmounting the now
-            stale root must destroy the incarnation it owned — already gone — and
-            never reach through the id to kill the successor. A migration that
-            recovered a bare id would destroy whatever is live now, leaving the
-            id naming nothing at all."
-    (if-not (browser?)
-      (skip! "the browser job runs the migrated-exactness assertions")
-      (async done
-        (reg!)
-        (let [node       (host-node!)
-              fid        :fh.root/legacy-exact
-              plan       {:frame {:id fid :initial-events [[:root/seed 1]]}}
-              succ-token (atom nil)]
-          (-> (act #(v/mount [views/counter {}] node plan))
-              (.then
-                (fn [_installer]
-                  ;; downgrade to the legacy shape, then remount to migrate it.
-                  (root/downgrade-ledger-row-to-pre-6818! fid)
-                  (act #(v/mount [views/counter {}] node plan))))
-              (.then
-                (fn [remounted]
-                  ;; tear down the migrated incarnation and reseat a same-id
-                  ;; successor, retaining ITS exact token, THEN unmount the now
-                  ;; stale root.
-                  (rf/destroy-frame! fid)
-                  (rf/make-frame {:id fid :initial-events [[:root/seed 2]]})
-                  (reset! succ-token (frame/frame-incarnation-token fid))
-                  (act #(v/unmount! remounted))))
+                      "but carries no install value — no token to prove ownership with")
+                  ;; the reloaded code re-runs the config-bearing mount over the row.
+                  (let [data (error-data #(v/mount [views/counter {}] node plan))]
+                    (is (= :rf.error/frame-payload-conflict (:rf.error/id data))
+                        "the remount cannot prove it owns the live frame, so it fails loud")
+                    (is (= :scope-config-less-or-own-the-lifetime (:recovery data))
+                        "under the scope-or-own recovery — a legacy row is not a licence
+                         to bootstrap ownership from the current address")
+                    (is (identical? @token (frame/frame-incarnation-token fid))
+                        "and the live frame is the EXACT same incarnation — the guard
+                         fired before make-frame or the ledger could touch it")
+                    (is (nil? (:installed-value (get (root/frame-ledger-snapshot) fid)))
+                        "the legacy row is unchanged — no address-directed value written"))
+                  (act #(v/unmount! installer))))
               (.then
                 (fn [_]
                   (is (some? (frame/frame fid))
-                      "the same-id successor is still live — the migrated authority
-                       tore down the incarnation it recovered, which was already gone,
-                       and never reached the successor")
-                  (is (identical? @succ-token (frame/frame-incarnation-token fid))
-                      "and it is the SUCCESSOR's exact incarnation, untouched — a
-                       bare-id migration would have destroyed it")
-                  (is (empty? (root/frame-ledger-snapshot))
-                      "the stale root released its own ledger reference")
+                      "the un-owned legacy row's teardown is a safe no-op — it proved
+                       no token, so it never destroys the frame (better a leak than an
+                       address-directed destroy of a frame it cannot prove it owns)")
                   (rf/destroy-frame! fid)
                   (.remove node)
                   (done))
                 (fn [e]
-                  (is false (str "migrated-exactness suite rejected: " e))
+                  (is false (str "legacy-row ownership-proof suite rejected: " e))
+                  (.remove node)
+                  (done)))))))))
+
+(deftest fh-root-005-a-legacy-row-refuses-a-same-id-successor-before-remount
+  (testing "Per FH-ROOT-005 / rf2-drpa3.110 (browser): the residual the third
+            reopen names — a successor seated BEFORE the reloaded remount, which
+            the earlier post-migration test could not reach. A legacy row
+            survives the reload; external code then tears the installed
+            incarnation down and stands a same-id SUCCESSOR B in its place. The
+            address-migration used to read B's live token and record it — a
+            silent takeover. Now the ownership proof has no token to compare, so
+            the remount FAILS LOUD before any mutation and B is preserved EXACTLY;
+            unmounting the stale installer never reaches B either."
+    (if-not (browser?)
+      (skip! "the browser job runs the legacy-successor assertions")
+      (async done
+        (reg!)
+        (let [node    (host-node!)
+              fid     :fh.root/legacy-successor
+              plan    {:frame {:id fid :initial-events [[:root/seed 11]]}}
+              b-token (atom nil)]
+          (-> (act #(v/mount [views/counter {}] node plan))
+              (.then
+                (fn [installer]
+                  ;; downgrade to the pre-#6818 shape,
+                  (root/downgrade-ledger-row-to-pre-6818! fid)
+                  ;; then, BEFORE the remount, external code reseats a same-id
+                  ;; successor — the case the post-migration test cannot reach.
+                  (rf/destroy-frame! fid)
+                  (rf/make-frame {:id fid :initial-events [[:root/seed 22]]})
+                  (reset! b-token (frame/frame-incarnation-token fid))
+                  (let [data (error-data #(v/mount [views/counter {}] node plan))]
+                    (is (= :rf.error/frame-payload-conflict (:rf.error/id data))
+                        "the remount cannot bootstrap ownership from the current address")
+                    (is (= :scope-config-less-or-own-the-lifetime (:recovery data)))
+                    (is (identical? @b-token (frame/frame-incarnation-token fid))
+                        "the same-id successor B is the EXACT untouched incarnation —
+                         no address-directed value recorded, no takeover")
+                    (is (nil? (:installed-value (get (root/frame-ledger-snapshot) fid)))
+                        "the legacy row is unchanged"))
+                  (act #(v/unmount! installer))))
+              (.then
+                (fn [_]
+                  (is (identical? @b-token (frame/frame-incarnation-token fid))
+                      "unmounting the stale installer never reached B — the un-owned
+                       legacy row's teardown is a safe no-op, not an address-directed
+                       destroy that would have killed the programmer's successor")
+                  (rf/destroy-frame! fid)
+                  (.remove node)
+                  (done))
+                (fn [e]
+                  (is false (str "legacy-successor suite rejected: " e))
                   (.remove node)
                   (done)))))))))


### PR DESCRIPTION
## What

The Freehand root frame ledger proved ownership from a non-nil `:installed-by`, which goes **stale across a same-id successor**. When the incarnation a root installed is torn down and re-created under the same id, the row still names the original installer — so a config-bearing remount could take the successor over (running `make-frame` against it on a changed fingerprint, or, for a pre-#6818 legacy row with no recorded value, reading the successor's token *by address*), and the final `unmount!` would destroy a frame the programmer owns.

This is the third audit reopen of rf2-drpa3.110. Fixing the **root cause generally**: ownership is now proven against the *current live incarnation's token*, not merely a non-nil `:installed-by`.

## How

- **New `owns-live-incarnation?`** — a row owns the current live frame only while its `:installed-value` token is `identical?` to the live incarnation's token. A same-id successor carries a distinct token and is owned by no stale row; a legacy row that never recorded a value carries no token and proves ownership of nothing.
- **Generalized the AC4 authority arm** to this proof. A config-bearing ENSURE over any live frame it cannot prove it owns — no installer (original AC4), a stale-token successor, or a token-less legacy row — fails loud with `:rf.error/frame-payload-conflict` / `:scope-config-less-or-own-the-lifetime`, **before `make-frame` mutates**. The differing-fingerprint conflict arm is unchanged.
- **Teardown stays incarnation-exact** via `:installed-value` (`destroy-frame!` on the recorded value no-ops against a different-token successor) — unchanged.
- **Retired the pre-#6818 address-directed legacy migration.** A `defonce` reload cannot bootstrap exact authority from the current address without risking a successor seated before it; where ownership is unprovable, the remount fails loud rather than taking over a programmer-owned frame (supersedes rf2-4pvsy's address-migration, which was the takeover vector this reopen names).

No new registry, lease framework, or public API — the one existing ledger and the core incarnation token (AC6).

## Ownership is now proven how

`preflight!` admits a config-bearing ENSURE as owner only when it **creates** the frame (not yet live) or **proves** it already owns the incarnation live under the id (recorded install-value token ≡ live token). A same-root refresh on the *same* live incarnation still proves ownership and stays the no-reseed fast path (AC5); anything else fails loud before mutation (AC4).

## Regressions added (browser lane)

- `fh-root-004-a-config-bearing-remount-over-a-same-id-successor-fails-loud` — post-#6818 row, same-plan remount over a successor refuses; final unmount destroys exactly the original (already gone), no-ops against the successor, ledger emptied.
- `fh-root-004-a-config-refresh-over-a-same-id-successor-cannot-take-it-over` — changed-fingerprint refresh over a successor is refused *before* `make-frame` runs; successor preserved exactly.
- `fh-root-005-a-legacy-row-cannot-bootstrap-ownership-of-the-live-frame` — legacy row (A still live) refuses the config-bearing remount; live incarnation untouched.
- `fh-root-005-a-legacy-row-refuses-a-same-id-successor-before-remount` — the exact residual: a successor seated *before* the reloaded remount is refused; B preserved exactly, teardown a safe no-op.

The two prior legacy address-migration tests are replaced by the fail-loud behavior.

## Quality gates

All foreground, worktree-local logs, `root-successor-110` worktree:

- `implementation/freehand $ clojure -M:test` → **885 tests, 6369 assertions, 0 failures, 0 errors** (EXIT=0)
- `implementation $ npm run test:freehand` → **919 tests, 5449 assertions, 0 failures, 0 errors** (EXIT=0)
- `implementation $ npm run test:browser` → **706 tests, 4340 assertions, 0 failures, 0 errors** (EXIT=0); serve banner confirms `.../re-frame2-worktrees/root-successor-110/implementation/out/browser-test`.
- **Non-vacuity**: flipping the exact-token check (`identical?` → negated) reds `fh-root-004-a-config-bearing-remount-over-a-same-id-successor-fails-loud` and `fh-root-004-a-config-refresh-over-a-same-id-successor-cannot-take-it-over` by name (plus the expected collateral `an-ordinary-re-mount-is-still-admitted`); restored byte-identical and re-greened.

## Scope

`implementation/freehand/src/re_frame/freehand/root.cljs` + its preflight/teardown test files only. No touch to `compiler/root.cljc`, `compiler/build.cljc`, emitters, or spec files. Builds on #6836's AC4 arm and #6841's HMR path already on main.

Closes rf2-drpa3.110.
