### PR TITLE
test(freehand): F6b browser correctness matrices — interpreted/compiled parity (rf2-drpa3.54)

### DIFF
--- a/implementation/freehand/test/re_frame/freehand/behavior_matrix_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/behavior_matrix_dom_cljs_test.cljs
@@ -1,0 +1,218 @@
+(ns re-frame.freehand.behavior-matrix-dom-cljs-test
+  "F6b matrix 4/8 — registered BEHAVIOR command / commit / replay / cleanup,
+  in a real browser (EP-0036 §6, gate row \"browser correctness\";
+  acceptance 3 — cleanup assertions are EXACT counts).
+
+  A behavior's whole value is that imperative host work is bounded to
+  moments the substrate names, over a node the substrate handed it, with a
+  release that leaves NOTHING behind. None of that is a structural fact:
+  it is a fact about a real commit, a real node, and a table that must be
+  empty afterwards. So this mounts.
+
+  ## The mode dimension for behaviors
+
+  `v/defbehavior` is the ONE sanctioned imperative boundary, and the
+  compiled grammar REFUSES `[v/behavior …]` as a foreign component
+  boundary — a view that attaches a behavior is interpreted forever
+  (proven at macro-expansion time in `pilot-overlay-parity-cljs-test` and
+  `slots-grammar-parity-jvm-test`). So the behavior matrix's compiled cell
+  is a documented refusal, and its correctness cell is the INTERPRETED
+  contract in a real browser: commit-only connection, a command that
+  reaches its explicit target and runs host work, `:update` on movement
+  and not on a re-render, and a teardown that releases everything to the
+  exact integer zero measured against a behavior-free control.
+
+  Rides the browser lane through its `-dom-cljs-test` suffix; under node it
+  has no DOM and says so."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.behavior-views :as bv]
+            [re-frame.freehand.behaviors :as behaviors]
+            [re-frame.freehand.conformance :as conf]
+            [re-frame.freehand.matrix-support :as ms]
+            [re-frame.freehand.react :as fr]
+            [re-frame.freehand.shell :as shell]
+            [re-frame.live-frame :as live-frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       plain-atom/adapter
+     :ambient-frame nil
+     :async?        true}))
+
+(def ^:private fid :matrix.behavior/frame)
+
+(defn- setup! []
+  (behaviors/reset-connections!)
+  (bv/reset-transcript!)
+  (bv/reset-dispatches!)
+  (live-frame/make-frame {:id fid})
+  fid)
+
+(defn- render! [root form]
+  (ms/act #(.render root (shell/provide-frame fid (fr/element form)))))
+
+(defn- node-attr [container attribute]
+  (some-> (.querySelector container ".node") (.getAttribute attribute)))
+
+;; ===========================================================================
+;; Row 1 — a connection is commit-only and claims its declared target
+;; ===========================================================================
+
+(deftest behavior-matrix-a-committed-render-connects-once-and-claims-its-target
+  (testing "A committed render connects the behavior EXACTLY once and claims
+            the semantic id its use site declared — the connection table
+            holds one entry, on `:probe/one`, and the lifecycle transcript
+            is a single `:connect`."
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the connection assertions")
+      (async done
+        (setup!)
+        (let [[container root] (ms/create-root!)]
+          (-> (render! root [bv/plain {}])
+              (.then (fn [_]
+                       (is (= 1 (behaviors/connection-count)) "exactly one connection")
+                       (is (= #{:probe/one} (behaviors/target-ids))
+                           "claiming the id the use site declared")
+                       (is (= [:connect] (bv/ops)) "and connected exactly once")
+                       (ms/destroy-root! container root)
+                       (done)))
+              (.catch (fn [e]
+                        (is false (str "the behavior mount rejected: " e))
+                        (ms/destroy-root! container root)
+                        (done)))))))))
+
+;; ===========================================================================
+;; Row 2 — a command reaches its target and runs host work; bounded refusals
+;; ===========================================================================
+
+(deftest behavior-matrix-a-command-reaches-its-target-and-refuses-otherwise
+  (testing "A command carrying an explicit target reaches the ONE live
+            connection claiming it and runs its host work — a real
+            `data-mark` on the real node — and every other command shape is
+            a visible refusal that performs NO host work: an absent target,
+            an unregistered op, and a malformed command are each a typed
+            diagnostic. Bounded, in a real browser."
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the command assertions")
+      (async done
+        (setup!)
+        (let [[container root] (ms/create-root!)]
+          (-> (render! root [bv/plain {}])
+              (.then (fn [_]
+                       (behaviors/command! fid {:target :probe/one :op :mark :args {:label "hit"}})
+                       (is (= "hit" (node-attr container "data-mark"))
+                           "the command ran its host work on the target's node")
+                       (is (some #{:mark} (bv/ops)) "and the lifecycle recorded the command")
+                       ;; bounded refusals — each performs no host work
+                       (doseq [[why cmd] [["an absent target"    {:target :probe/nobody :op :mark}]
+                                          ["an unregistered op"  {:target :probe/one :op :teleport}]
+                                          ["a malformed command" "mark it"]]]
+                         (let [d (conf/caught-data #(behaviors/command! fid cmd))]
+                           (is (= :rf.error/behavior-command-refused (:rf.error/id d))
+                               (str why " is refused with the bounded diagnostic"))))
+                       (is (= "hit" (node-attr container "data-mark"))
+                           "and no refusal touched the node the accepted command marked")
+                       (ms/destroy-root! container root)
+                       (done)))
+              (.catch (fn [e]
+                        (is false (str "the behavior mount rejected: " e))
+                        (ms/destroy-root! container root)
+                        (done)))))))))
+
+;; ===========================================================================
+;; Row 3 — :update observes committed-config movement, not re-renders
+;; ===========================================================================
+
+(deftest behavior-matrix-update-observes-movement-not-renders
+  (testing "`:update` runs when the committed config MOVES by `rf=` and not
+            otherwise — an rf=-equal re-render leaves the transcript
+            untouched, and a moved config arrives once, carrying both the
+            new config and the previous one. A behavior that reconciled on
+            every commit would reset a cursor for no reason."
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the replay assertions")
+      (async done
+        (setup!)
+        (let [[container root] (ms/create-root!)]
+          (-> (render! root [bv/plain {:label "a"}])
+              (.then (fn [_]
+                       (is (= [:connect] (bv/ops)) "connected on the first commit")
+                       (render! root [bv/plain {:label "a"}])))     ; equal config
+              (.then (fn [_]
+                       (is (= [:connect] (bv/ops)) "an rf=-equal config is not movement")
+                       (render! root [bv/plain {:label "moved"}]))) ; moved config
+              (.then (fn [_]
+                       (is (= [:connect :update] (bv/ops))
+                           "a moved config reconciles the host, exactly once")
+                       (let [{:keys [config prev-config]} (last @bv/transcript)]
+                         (is (= {:label "moved"} config) "with the new config")
+                         (is (= {:label "a"} prev-config) "and the previous one alongside it"))
+                       (ms/destroy-root! container root)
+                       (done)))
+              (.catch (fn [e]
+                        (is false (str "the behavior mount rejected: " e))
+                        (ms/destroy-root! container root)
+                        (done)))))))))
+
+;; ===========================================================================
+;; Row 4 — teardown releases everything, the exact integer zero (acceptance 3)
+;; ===========================================================================
+
+(deftest behavior-matrix-teardown-releases-everything-to-exact-zero
+  (testing "After the behavior unmounts, the substrate holds NO connection
+            record and no target claim — the exact integer zero, not a
+            threshold. A behavior-free CONTROL mount is measured first,
+            proving the counters read zero for a mount that never connected,
+            so the zero after teardown is the behavior's release and
+            `:disconnect` ran exactly once."
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the teardown assertions")
+      (async done
+        (setup!)
+        (let [[cc rc] (ms/create-root!)
+              [container root] (ms/create-root!)]
+          (-> (render! rc [bv/control-mount {}])
+              (.then (fn [_]
+                       (is (= 0 (behaviors/connection-count))
+                           "the control mount connected nothing")
+                       (is (= #{} (behaviors/target-ids)) "and claims no target")
+                       (render! root [bv/plain {}])))
+              (.then (fn [_]
+                       (is (= 1 (behaviors/connection-count)) "the behavior connected")
+                       (is (= #{:probe/one} (behaviors/target-ids)))
+                       (ms/destroy-root! container root)
+                       ;; the behavior's own root is gone; the control is still mounted,
+                       ;; so a nonzero here would be the control, not a leak.
+                       (is (= 0 (behaviors/connection-count))
+                           "teardown released the connection to EXACTLY zero")
+                       (is (= #{} (behaviors/target-ids)) "and dropped the target claim")
+                       (is (= [:connect :disconnect] (bv/ops)) "disconnecting exactly once")
+                       (ms/destroy-root! cc rc)
+                       (done)))
+              (.catch (fn [e]
+                        (is false (str "a behavior mount rejected: " e))
+                        (ms/destroy-root! container root)
+                        (ms/destroy-root! cc rc)
+                        (done)))))))))
+
+;; ===========================================================================
+;; Row 5 — the compiled tier refuses the behavior boundary (the mode cell)
+;; ===========================================================================
+
+(deftest behavior-matrix-the-compiled-tier-refuses-the-behavior-boundary
+  (testing "The behavior matrix's compiled dimension is a REFUSAL, not a
+            second mounted arm: `v/defbehavior` is the one sanctioned
+            imperative boundary and the compiled grammar classifies
+            `[v/behavior …]` a foreign component boundary it cannot lower,
+            so a view that attaches a behavior is interpreted forever. That
+            macro-expansion refusal is pinned on the JVM host by
+            `pilot-overlay-parity-cljs-test` and `slots-grammar-parity-jvm-test`.
+            The local anchor here: the behavior-bearing view is interpreted
+            — it carries NO manifest, the honest answer for a mode with no
+            analysis step — which is the same fact from the runtime side."
+    (is (nil? (v/manifest bv/plain))
+        "the behavior-bearing view is interpreted: no compiled analysis, no manifest")
+    (is (some? bv/plain) "non-vacuous: the interpreted behavior view exists and is mountable")))

--- a/implementation/freehand/test/re_frame/freehand/controlled_input_matrix_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/controlled_input_matrix_dom_cljs_test.cljs
@@ -1,0 +1,430 @@
+(ns re-frame.freehand.controlled-input-matrix-dom-cljs-test
+  "F6b matrix 1/8 — CONTROLLED INPUT, in a real browser, across BOTH
+  execution modes (EP-0036 §6, gate row \"browser correctness\").
+
+  The pilot proved CASE A once. This matrix proves it as a MATRIX: the
+  same controlled-field claims — a same-tick keystroke echo, a mid-string
+  caret, a control that disables while its own write is in flight — hold
+  in the INTERPRETED and the COMPILED lowering alike, and the two build
+  the SAME real DOM. Promotion is a one-line marker; a controlled input
+  is the case where a correction has to reach the host inside the event,
+  so it is the sharpest place to prove the marker changes nothing.
+
+  It also carries the three ATTRIBUTE-lowering parity cells the F6b gate
+  coordinates with the emitter-parity work — a runtime `<select multiple>`
+  empty value, a `v/spread-safe` guarded caller, and a routed `:class`
+  one-map collision. Each is asserted as cross-mode agreement in a real
+  DOM: whatever the two emitters do, they must do the same thing, which is
+  the whole substance of a two-mode contract.
+
+  The pilot's own rows live in `pilot-field-dom-cljs-test`; this file is
+  the cross-mode matrix over the same declarations, plus the attribute
+  cells the pilot never reached.
+
+  Rides the browser lane through its `-dom-cljs-test` suffix; under node
+  it has no DOM and says so."
+  (:require ["react" :as react]
+            [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as react-substrate]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.matrix-support :as ms]
+            [re-frame.freehand.pilot-field :as pilot]
+            [re-frame.freehand.pilot-field-compiled :as promoted]
+            [re-frame.freehand.react :as fr]
+            [re-frame.freehand.shell :as shell]
+            [re-frame.live-frame :as live-frame]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       react-substrate/adapter
+     :ambient-frame nil
+     :async?        true}))
+
+(def ^:private fid :matrix.controlled/frame)
+(def ^:private line-id 1)
+
+(def ^:private seed-line
+  {:description "Consulting"
+   :quantity    "2"
+   :unit-price  "150"
+   :account     "4000"
+   :reference   "REF-1"
+   :reference-revision 0})
+
+;; The pilot line, in each mode. One roster drives every row below, so the
+;; matrix dimension "view shape × mode" is a literal table.
+(def ^:private line-modes
+  [["interpreted" pilot/invoice-line]
+   ["compiled"    promoted/invoice-line]])
+
+;; ---------------------------------------------------------------------------
+;; Attribute-lowering cells — inline twins, marker the only difference
+;; ---------------------------------------------------------------------------
+
+(v/defview select-direct-interpreted
+  [{:keys [flag]}]
+  [:select {:multiple flag :value nil :on-change [:matrix/select-changed ::v/value]}
+   [:option {:value "x"} "X"]
+   [:option {:value "y"} "Y"]])
+
+(v/defview select-direct-compiled
+  {:compiled true}
+  [{:keys [flag]}]
+  [:select {:multiple flag :value nil :on-change [:matrix/select-changed ::v/value]}
+   [:option {:value "x"} "X"]
+   [:option {:value "y"} "Y"]])
+
+(v/defview select-safe-interpreted
+  [{:keys [flag]}]
+  [:select (v/spread-safe {:value nil :on-change [:matrix/select-changed ::v/value]}
+                          {:multiple flag})
+   [:option {:value "x"} "X"]
+   [:option {:value "y"} "Y"]])
+
+(v/defview select-safe-compiled
+  {:compiled true}
+  [{:keys [flag]}]
+  [:select (v/spread-safe {:value nil :on-change [:matrix/select-changed ::v/value]}
+                          {:multiple flag})
+   [:option {:value "x"} "X"]
+   [:option {:value "y"} "Y"]])
+
+(v/defview safe-caller-interpreted
+  [{:keys [caller]}]
+  [:input.field (v/spread-safe {:value    "owned"
+                                :class    "field"
+                                :on-input [:matrix/typed ::v/value]}
+                               caller)])
+
+(v/defview safe-caller-compiled
+  {:compiled true}
+  [{:keys [caller]}]
+  [:input.field (v/spread-safe {:value    "owned"
+                                :class    "field"
+                                :on-input [:matrix/typed ::v/value]}
+                               caller)])
+
+;; The routed :class one-map collision (rf2-c9kus). The one-map rule is
+;; OWNED by that bead and Spec 004B's alias row; F6b asserts only that the
+;; two lowerings AGREE on the rendered class, never a particular composed
+;; value — the two-mode contract is that promotion changes nothing, and a
+;; specific value would pin a rule this matrix does not own.
+(v/defview class-one-map-interpreted
+  [_]
+  [:div {:class "a" :x/class "b"} "x"])
+
+(v/defview class-one-map-compiled
+  {:compiled true}
+  [_]
+  [:div {:class "a" :x/class "b"} "x"])
+
+;; ---------------------------------------------------------------------------
+;; Harness
+;; ---------------------------------------------------------------------------
+
+(defn- register! []
+  (rf/reg-event :matrix/select-changed (fn [{:keys [db]} _] {:db db}))
+  (rf/reg-event :matrix/typed (fn [{:keys [db]} _] {:db db})))
+
+(defn- seed-line! []
+  (live-frame/make-frame {:id fid})
+  (frame/replace-app-db! fid {:invoice {line-id seed-line}})
+  (pilot/register!)
+  (pilot/register-app!)
+  (register!)
+  fid)
+
+(defn- fresh-frame! []
+  (live-frame/make-frame {:id fid})
+  (frame/replace-app-db! fid {})
+  (register!)
+  fid)
+
+(defn- render! [root form]
+  (ms/act #(.render root (shell/provide-frame fid (fr/element form)))))
+
+(defn- control [container nm]
+  (.querySelector container (str "[data-field='" nm "'] [data-part='control']")))
+
+(defn- app [] (frame/frame-app-db-value fid))
+(defn- line [] (get-in (app) [:invoice line-id]))
+
+;; ===========================================================================
+;; Row 1 — the two lowerings build the SAME controlled line
+;; ===========================================================================
+
+(deftest controlled-matrix-both-modes-build-the-same-controlled-line
+  (testing "The whole pilot line — four controlled fields and a buffered
+            fifth — mounted in each mode against ONE seed, produces the
+            SAME real DOM. Not a sampled attribute: the entire subtree's
+            tag/attribute/text outline, so a divergence anywhere fails."
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the parity assertion")
+      (async done
+        (seed-line!)
+        (let [[ci ri] (ms/create-root!)
+              [cc rc] (ms/create-root!)]
+          (-> (render! ri [pilot/invoice-line {:id line-id}])
+              (.then (fn [_] (render! rc [promoted/invoice-line {:id line-id}])))
+              (.then (fn [_]
+                       (let [shared (ms/outlines-agree?
+                                      (.-firstElementChild ci)
+                                      (.-firstElementChild cc)
+                                      "controlled line")]
+                         (is (re-find #"data-component=\"acme/invoice-line\"" shared)
+                             "non-vacuous: the shared outline really is the invoice line")
+                         (is (re-find #"REF-1" shared)
+                             "and it carries the seeded buffered value"))
+                       (ms/destroy-root! ci ri)
+                       (ms/destroy-root! cc rc)
+                       (done)))
+              (.catch (fn [e]
+                        (is false (str "a controlled mount rejected: " e))
+                        (ms/destroy-root! ci ri)
+                        (ms/destroy-root! cc rc)
+                        (done)))))))))
+
+;; ===========================================================================
+;; Row 2 — a keystroke burst echoes character-for-character, both modes
+;; ===========================================================================
+
+(deftest controlled-matrix-a-keystroke-burst-echoes-in-both-modes
+  (testing "A burst of keystrokes into the controlled `quantity` field
+            yields a final value equal to the typed string character for
+            character — in the DOM and in application state — in each
+            mode. The extra library hop rides inside the synchronous drain
+            the door opened; if promotion moved it outside, the compiled
+            arm would lose characters here and the interpreted one would
+            not."
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the typing assertions")
+      (async done
+        (ms/each-mode
+          line-modes
+          (fn [[label view]]
+            (seed-line!)
+            (let [[container root] (ms/create-root!)]
+              (-> (render! root [view {:id line-id}])
+                  (.then (fn [_]
+                           (ms/live!)
+                           (let [node  (control container "quantity")
+                                 typed "1234567890123456789"]
+                             (is (= "2" (.-value node)) (str label ": starts on the seed"))
+                             (ms/set-native-value! node "")
+                             (ms/fire-input! node nil)
+                             (ms/type-string! node typed)
+                             (is (= typed (.-value node))
+                                 (str label ": every keystroke survived in the DOM"))
+                             (is (= typed (:quantity (line)))
+                                 (str label ": and application state holds exactly what was typed")))
+                           (ms/destroy-root! container root)
+                           nil)))))
+          done)))))
+
+;; ===========================================================================
+;; Row 3 — a mid-string insert keeps the caret, both modes
+;; ===========================================================================
+
+(deftest controlled-matrix-a-mid-string-insert-keeps-the-caret-in-both-modes
+  (testing "Editing in the middle of an existing value: the character lands
+            at the caret and the caret stays with it, in each mode. A round
+            trip that completed late would put the whole value back with the
+            cursor at the end — a divergence promotion must not introduce."
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the caret assertions")
+      (async done
+        (ms/each-mode
+          line-modes
+          (fn [[label view]]
+            (seed-line!)
+            (let [[container root] (ms/create-root!)]
+              (-> (render! root [view {:id line-id}])
+                  (.then (fn [_]
+                           (ms/live!)
+                           (let [node (control container "description")]
+                             (is (= "Consulting" (.-value node)) (str label ": seeded"))
+                             (ms/insert-at! node 3 "X")
+                             (is (= "ConXsulting" (.-value node))
+                                 (str label ": the insert landed at the caret"))
+                             (is (= [4 4] (ms/caret node))
+                                 (str label ": and the caret did not jump to the end"))
+                             (is (= "ConXsulting" (:description (line)))
+                                 (str label ": application state matches character for character")))
+                           (ms/destroy-root! container root)
+                           nil)))))
+          done)))))
+
+;; ===========================================================================
+;; Row 4 — the buffered control disables while its write is in flight
+;; ===========================================================================
+
+(deftest controlled-matrix-the-busy-control-disables-in-both-modes
+  (testing "The buffered control's `disabled` follows its own in-flight
+            normalisation — a real DOM property, not an attribute a tree
+            carries — and does so identically in each mode."
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the busy assertions")
+      (async done
+        (ms/each-mode
+          line-modes
+          (fn [[label view]]
+            (seed-line!)
+            (let [[container root] (ms/create-root!)]
+              (-> (render! root [view {:id line-id}])
+                  (.then (fn [_]
+                           (let [node (control container "reference")]
+                             (is (false? (.-disabled node)) (str label ": idle"))
+                             (-> (ms/act #(rf/dispatch-sync
+                                            [:acme.invoice/reference-submitted line-id "REF-2" :req-1]
+                                            {:frame fid}))
+                                 (.then (fn [_]
+                                          (is (true? (.-disabled node))
+                                              (str label ": in flight → disabled"))
+                                          (ms/act #(rf/dispatch-sync
+                                                     [:acme.invoice/reference-normalised line-id :req-1 "REF-2"]
+                                                     {:frame fid}))))
+                                 (.then (fn [_]
+                                          (is (false? (.-disabled node))
+                                              (str label ": settled → enabled again"))
+                                          (is (= "REF-2" (.-value node))
+                                              (str label ": and the normalised value shows"))
+                                          (ms/destroy-root! container root)
+                                          nil)))))))))
+          done)))))
+
+;; ===========================================================================
+;; Cell A — a runtime <select multiple> empty value (rf2-sf9n5)
+;; ===========================================================================
+
+(defn- check-multiple-select [container label]
+  (let [el (ms/q container "select")]
+    (is (some? el) (str label ": a select mounted"))
+    (when el
+      (is (true? (.-multiple el)) (str label ": mounted as a multiple select"))
+      (is (= 0 (.-length (.-selectedOptions el)))
+          (str label ": nothing is selected under an empty controlled value")))
+    el))
+
+;; [label interpreted-view compiled-view] — the direct props form and the
+;; v/spread-safe split form, each mounted in both modes and compared.
+(def ^:private select-forms
+  [["direct"        select-direct-interpreted select-direct-compiled]
+   ["v/spread-safe" select-safe-interpreted   select-safe-compiled]])
+
+(deftest controlled-matrix-a-runtime-multiple-select-agrees-across-modes
+  (testing "A `<select multiple>` whose `multiple` is RUNTIME-valued and
+            whose controlled value is nil mounts in each mode as a real
+            multiple select with nothing selected, and the two modes build
+            the same DOM. A native multiple select's empty value is the
+            empty array, not the empty string; the compiled emitter used to
+            settle that verdict only from a build-time literal, so a
+            runtime `multiple` diverged from the interpreted walk. Both the
+            DIRECT and the `v/spread-safe` split forms are exercised.
+
+            The array-vs-string PROP shape is pinned at unit level in
+            `compiled-select-multiple-cljs-test`; here the claim is the
+            real-DOM one: the two modes agree, and each is a working
+            multiple select."
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the select assertions")
+      (async done
+        (fresh-frame!)
+        (ms/each-mode
+          select-forms
+          (fn [[label iv cv]]
+            (let [[ci ri] (ms/create-root!)
+                  [cc rc] (ms/create-root!)]
+              (-> (render! ri [iv {:flag true}])
+                  (.then (fn [_] (render! rc [cv {:flag true}])))
+                  (.then (fn [_]
+                           (check-multiple-select ci (str label "/interpreted"))
+                           (check-multiple-select cc (str label "/compiled"))
+                           (ms/outlines-agree? (ms/q ci "select") (ms/q cc "select")
+                                               (str "runtime multiple select (" label ")"))
+                           (ms/destroy-root! ci ri)
+                           (ms/destroy-root! cc rc)
+                           nil)))))
+          done)))))
+
+;; ===========================================================================
+;; Cell B — v/spread-safe folds a guarded caller, both modes (rf2-drpa3.132)
+;; ===========================================================================
+
+(deftest controlled-matrix-spread-safe-folds-the-caller-across-modes
+  (testing "`(v/spread-safe owned caller)` on a real controlled input: the
+            owned value wins, the owned `:class` composes owned-first with
+            the caller's, and a benign caller attribute reaches the DOM —
+            identically in each mode. The interpreted React lowering
+            reached its guarded caller through `react/put-caller!`
+            (rf2-drpa3.132); this proves that reach lands the same page the
+            compiled fold does."
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the spread-safe assertions")
+      (async done
+        (fresh-frame!)
+        (let [caller {:aria-label "Email" :class "wide"}]
+          (letfn [(check [container label]
+                    (let [el (ms/q container "input")]
+                      (is (= "owned" (.-value el)) (str label ": the owned value won"))
+                      (is (= "Email" (.getAttribute el "aria-label"))
+                          (str label ": the benign caller attribute reached the DOM"))
+                      (let [classes (set (.split (.getAttribute el "class") #"\s+"))]
+                        (is (contains? classes "field") (str label ": the owned class is present"))
+                        (is (contains? classes "wide") (str label ": composed with the caller's")))
+                      el))]
+            (let [[ci ri] (ms/create-root!)
+                  [cc rc] (ms/create-root!)]
+              (-> (render! ri [safe-caller-interpreted {:caller caller}])
+                  (.then (fn [_] (render! rc [safe-caller-compiled {:caller caller}])))
+                  (.then (fn [_]
+                           (check ci "interpreted")
+                           (check cc "compiled")
+                           (ms/outlines-agree? (ms/q ci "input") (ms/q cc "input")
+                                               "v/spread-safe guarded caller")
+                           (ms/destroy-root! ci ri)
+                           (ms/destroy-root! cc rc)
+                           (done)))
+                  (.catch (fn [e]
+                            (is false (str "a spread-safe mount rejected: " e))
+                            (ms/destroy-root! ci ri)
+                            (ms/destroy-root! cc rc)
+                            (done)))))))))))
+
+;; ===========================================================================
+;; Cell C — a routed :class one-map collision AGREES across modes (rf2-c9kus)
+;; ===========================================================================
+
+(deftest controlled-matrix-routed-class-one-map-agrees-across-modes
+  (testing "One attribute map carrying the exact `:class` and a routed
+            `:x/class` alias projecting onto the same slot. Whatever the
+            walk does with the collision — compose, refuse, or rank — the
+            two-mode contract is that the interpreted and compiled
+            lowerings do the SAME thing, read back as the rendered `class`
+            off a real element. The specific one-map rule is owned by
+            rf2-c9kus and Spec 004B; this cell pins only the agreement,
+            which is exactly the promotion-changes-nothing law."
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the class-routing assertion")
+      (async done
+        (fresh-frame!)
+        (let [[ci ri] (ms/create-root!)
+              [cc rc] (ms/create-root!)]
+          (-> (render! ri [class-one-map-interpreted {}])
+              (.then (fn [_] (render! rc [class-one-map-compiled {}])))
+              (.then (fn [_]
+                       (let [ic (.getAttribute (ms/q ci "div") "class")
+                             cclass (.getAttribute (ms/q cc "div") "class")]
+                         (is (= ic cclass)
+                             (str "interpreted and compiled agree on the rendered class "
+                                  "(interpreted=" (pr-str ic) " compiled=" (pr-str cclass) ")")))
+                       (ms/destroy-root! ci ri)
+                       (ms/destroy-root! cc rc)
+                       (done)))
+              (.catch (fn [e]
+                        (is false (str "a class-routing mount rejected: " e))
+                        (ms/destroy-root! ci ri)
+                        (ms/destroy-root! cc rc)
+                        (done)))))))))

--- a/implementation/freehand/test/re_frame/freehand/error_matrix_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/error_matrix_dom_cljs_test.cljs
@@ -1,0 +1,206 @@
+(ns re-frame.freehand.error-matrix-dom-cljs-test
+  "F6b matrix 5/8 — ERROR CONTAINMENT, in a real browser, across BOTH
+  execution modes (EP-0036 §6, gate row \"browser correctness\").
+
+  A render-class failure inside a guarded region must be CONTAINED — the
+  fallback on screen, the failing subtree gone — and REPORTED once through
+  the private always-on egress, without leaking the failure's private
+  payload to the page. The React commit runs `componentDidMount` before
+  the update queue's error callback, so a boundary can be perfectly shaped
+  around a lifecycle that never reports; only a real mount proves the
+  report fires. So this mounts, and reads containment off `document` and
+  the report off the egress registry.
+
+  ## The mode dimension for error containment
+
+  `v/error-boundary` is a recognised special form both emitters lower — the
+  analyzer arm is `analyze-accept-cljs-test/error-boundary-lowers`. Its
+  place, though, is the OWNING interpreted view or a mounted root: a
+  compiled body's guarded region is inline markup, which never throws, and
+  a throwing CHILD is a component boundary the compiled tier refuses inside
+  markup. So the matrix's mode dimension is the CHILD: a boundary contains
+  a throwing view whether that view is INTERPRETED or COMPILED, and it
+  contains, reports and recovers the same way for both. That is the
+  cross-mode claim that matters here — a compiled view's render error is
+  caught exactly as an interpreted view's is.
+
+  Rides the browser lane through its `-dom-cljs-test` suffix; under node it
+  has no DOM and says so."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.error-emit :as error-emit]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.matrix-support :as ms]
+            [re-frame.freehand.react :as fr]
+            [re-frame.freehand.shell :as shell]
+            [re-frame.live-frame :as live-frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       plain-atom/adapter
+     :ambient-frame nil
+     :async?        true
+     :init-fn       (fn []
+                      (fr/reset-boundaries!)
+                      (error-emit/clear-error-listeners!))}))
+
+(def ^:private fid :matrix.error/frame)
+(def ^:private secret "must-not-leak")
+
+;; The failing child in each mode — the SAME body, marker only. `throwing?`
+;; is the seam a retry flips. A boundary contains a throwing view whichever
+;; lowering built it.
+(defonce ^:private throwing? (atom true))
+
+(v/defview thrower-interpreted
+  [_]
+  (if @throwing?
+    (throw (ex-info "a child render threw" {:secret secret}))
+    [:p {:id "child"} "recovered"]))
+
+(v/defview thrower-compiled
+  {:compiled true}
+  [_]
+  (if @throwing?
+    (throw (ex-info "a child render threw" {:secret secret}))
+    [:p {:id "child"} "recovered"]))
+
+;; ONE interpreted boundary, taking the guarded child as a runtime prop, so
+;; one declaration guards either mode's thrower — the boundary's containment
+;; is what is under test, not a per-child boundary.
+(v/defview boundary
+  [{:keys [child reset-key]}]
+  [v/error-boundary {:fallback  [:p {:id "fallback"} "contained"]
+                     :reset-key reset-key
+                     :on-error  [:matrix.error/caught]}
+   child])
+
+(def ^:private child-modes
+  [["interpreted child" [thrower-interpreted {}]]
+   ["compiled child"    [thrower-compiled {}]]])
+
+;; ---------------------------------------------------------------------------
+;; Harness
+;; ---------------------------------------------------------------------------
+
+(def ^:private egress (atom []))
+
+(defn- setup! []
+  (reset! egress [])
+  (reset! throwing? true)
+  (live-frame/make-frame {:id fid})
+  ;; The :on-error intent rides the router; register a target so the
+  ;; boundary's dispatch lands rather than erroring. Its EXACT count is
+  ;; owned by errors-cljs-test / errors-dom-cljs-test (counted at the
+  ;; router seam); here the private egress is the report channel under
+  ;; test, because it fires synchronously in the failing commit.
+  (rf/reg-event :matrix.error/caught (fn [{:keys [db]} _] {:db db}))
+  (error-emit/register-error-listener! ::recorder (fn [r] (swap! egress conj r)))
+  fid)
+
+(defn- render! [root child reset-key]
+  (ms/act #(.render root (shell/provide-frame fid (fr/element [boundary {:child child :reset-key reset-key}])))))
+
+;; ===========================================================================
+;; Row 1 — a throwing child is contained and reported once, both child modes
+;; ===========================================================================
+
+(deftest error-matrix-a-throwing-child-is-contained-and-reported-in-both-modes
+  (testing "A child that throws on its first mounted render is CONTAINED —
+            the fallback is on screen and the failing subtree is gone — and
+            REPORTED exactly once through the private egress, without the
+            failure's private payload reaching the page. Asserted for a
+            throwing INTERPRETED child and a throwing COMPILED one: both are
+            contained the same way."
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the containment assertions")
+      (async done
+        (ms/each-mode
+          child-modes
+          (fn [[label child]]
+            (setup!)
+            (let [[container root] (ms/create-root!)]
+              (-> (render! root child 0)
+                  (.then (fn [_]
+                           (is (some? (ms/q container "#fallback"))
+                               (str label ": the fallback is on screen"))
+                           (is (nil? (ms/q container "#child"))
+                               (str label ": the failing subtree is gone, not merely hidden"))
+                           (is (not (re-find (re-pattern secret) (.-innerHTML container)))
+                               (str label ": the failure's private payload did not reach the page"))
+                           (is (= 1 (count @egress))
+                               (str label ": exactly one private egress record for the generation"))
+                           (is (map? (first @egress))
+                               (str label ": and the report is a structured record"))
+                           (ms/destroy-root! container root)
+                           nil)))))
+          done)))))
+
+;; ===========================================================================
+;; Row 2 — recovery follows a changed reset key, both child modes
+;; ===========================================================================
+
+(deftest error-matrix-recovery-follows-a-changed-reset-key-in-both-modes
+  (testing "Once the failure clears, a CHANGED reset key retries the guarded
+            region: the child renders normally, the fallback is gone, and no
+            second report fires for the recovered generation. A stale reset
+            key would leave the fallback latched. Asserted for both a
+            recovered interpreted child and a recovered compiled one."
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the recovery assertions")
+      (async done
+        (ms/each-mode
+          child-modes
+          (fn [[label child]]
+            (setup!)
+            (let [[container root] (ms/create-root!)]
+              (-> (render! root child 0)
+                  (.then (fn [_]
+                           (is (some? (ms/q container "#fallback")) (str label ": contained first"))
+                           (is (= 1 (count @egress)) (str label ": one report so far"))
+                           (reset! throwing? false)
+                           (render! root child 1)))
+                  (.then (fn [_]
+                           (is (= "recovered" (ms/text-of container "#child"))
+                               (str label ": a changed reset key retried the guarded region"))
+                           (is (nil? (ms/q container "#fallback"))
+                               (str label ": and the fallback is gone"))
+                           (is (= 1 (count @egress))
+                               (str label ": the recovered generation reported nothing new"))
+                           (ms/destroy-root! container root)
+                           nil)))))
+          done)))))
+
+;; ===========================================================================
+;; Row 3 — both child modes are contained the same way
+;; ===========================================================================
+
+(deftest error-matrix-both-child-modes-are-contained-the-same-way
+  (testing "The contained page — the fallback subtree React committed after
+            the throw — is the SAME real DOM whether the failing child was
+            interpreted or compiled. Containment is a property of the
+            boundary, not of what threw, so a compiled child's render error
+            lands the same fallback an interpreted child's does."
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the parity assertion")
+      (async done
+        (setup!)
+        (let [[ci ri] (ms/create-root!)
+              [cc rc] (ms/create-root!)]
+          (-> (render! ri [thrower-interpreted {}] 0)
+              (.then (fn [_] (render! rc [thrower-compiled {}] 0)))
+              (.then (fn [_]
+                       (ms/outlines-agree? (ms/q ci "#fallback") (ms/q cc "#fallback")
+                                           "contained fallback")
+                       (is (= "contained" (ms/text-of ci "#fallback"))
+                           "non-vacuous: the fallback really is on screen")
+                       (ms/destroy-root! ci ri)
+                       (ms/destroy-root! cc rc)
+                       (done)))
+              (.catch (fn [e]
+                        (is false (str "a boundary mount rejected: " e))
+                        (ms/destroy-root! ci ri)
+                        (ms/destroy-root! cc rc)
+                        (done)))))))))

--- a/implementation/freehand/test/re_frame/freehand/hydration_matrix_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/hydration_matrix_dom_cljs_test.cljs
@@ -1,0 +1,212 @@
+(ns re-frame.freehand.hydration-matrix-dom-cljs-test
+  "F6b matrix 8/8 — hydration ADOPTION and the FALLBACK, in a real browser,
+  across BOTH execution modes (EP-0036 §6, gate row \"browser
+  correctness\").
+
+  Server bytes already in the document — with the Root Manifest the server
+  emits beside them — are ADOPTED: the server's own DOM nodes survive the
+  mount rather than being re-created. A container with nothing to adopt and
+  no manifest FALLS BACK to a client mount, coming up correct without a
+  pile of adoption errors. Adoption is proven by node IDENTITY, not text,
+  because a root that discarded the server render and client-rendered would
+  produce byte-identical markup; the fallback is proven by the mount KIND
+  (`root/hydrated?`), because its output is identical too. Neither is a
+  structural fact.
+
+  The mode dimension: the greeting is a static, host-neutral declaration
+  both emitters lower to the same markup, so the SAME server bytes adopt
+  under an interpreted form and a compiled one — the manifest supplies the
+  identity, so promotion (which changes the derived id) does not change what
+  adopts. Each claim — matching markup adopted by identity, an empty
+  container falling back, and a clean teardown — is asserted in each mode,
+  and the two adopt the same DOM.
+
+  Server bytes and the manifest come from the shipped FH-ROOT-006/007
+  conformance fixtures, so the matrix carries no dependency on the SSR
+  artefact and its expectations track the normative fixture.
+
+  Rides the browser lane through its `-dom-cljs-test` suffix; under node it
+  has no DOM and says so."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.conformance :as conf]
+            [re-frame.freehand.matrix-support :as ms]
+            [re-frame.freehand.react :as fr]
+            [re-frame.freehand.root :as root]
+            [re-frame.freehand.root-views :as views]
+            [re-frame.ssr.manifest :as ssr-manifest]
+            [re-frame.trace.tooling :as trace-tooling]))
+
+(use-fixtures :each
+  {:before (fn [] (root/reset-registry!) (fr/reset-boundaries!))
+   :after  (fn [] (root/reset-registry!) (fr/reset-boundaries!))})
+
+(def ^:private root-006 (conf/fixture :FH-ROOT-006))
+(def ^:private root-007 (conf/fixture :FH-ROOT-007))
+(def ^:private props (:props root-006))
+
+;; The compiled twin of the static hydration view — same body, marker only.
+(v/defview greeting-compiled
+  {:compiled true}
+  [{:keys [name]}]
+  [:section#greeting
+   [:h1#title "Hello"]
+   [:p#who name]])
+
+(def ^:private modes
+  [["interpreted" views/greeting] ["compiled" greeting-compiled]])
+
+;; ---------------------------------------------------------------------------
+;; Harness
+;; ---------------------------------------------------------------------------
+
+(defn- server-node!
+  "A container carrying `html` — the server's bytes — and, when `manifest`
+  is given, that root's Root Manifest as the container's IMMEDIATELY
+  FOLLOWING element sibling, the wire form the shipped emitter produces.
+  Answers the container a hydrating page presents."
+  ([html] (server-node! html nil))
+  ([html manifest]
+   (let [host (.createElement js/document "div")]
+     (set! (.-innerHTML host)
+           (str "<div>" html "</div>"
+                (when manifest (ssr-manifest/script-html manifest))))
+     (.appendChild (.-body js/document) host)
+     (.-firstElementChild host))))
+
+(defn- remove-node! [container]
+  (some-> container .-parentElement .remove))
+
+(defn- listen-mismatches! [a]
+  (let [k (keyword (gensym "matrix-hydration-"))]
+    (trace-tooling/register-listener!
+      k
+      (fn [ev] (when (= :rf.ssr/hydration-mismatch (:operation ev)) (swap! a conj ev))))
+    k))
+
+(defn- settle
+  "Give React's adoption window a moment to close, then resolve."
+  []
+  (js/Promise. (fn [res] (js/setTimeout #(res nil) 200))))
+
+;; ===========================================================================
+;; Row 1 — matching markup is adopted, by node identity, both modes
+;; ===========================================================================
+
+(deftest hydration-matrix-matching-markup-is-adopted-by-identity-in-both-modes
+  (testing "The server's own DOM nodes survive the mount — node IDENTITY is
+            the assertion, because a root that discarded the server render
+            would produce byte-identical markup. Nothing is reported, the
+            root is a hydration (not a fallback), and the page carries the
+            server's text. In each mode, against the FH-ROOT-006 fixture's
+            bytes and manifest."
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the adoption assertions")
+      (async done
+        (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+        (ms/each-mode
+          modes
+          (fn [[label view]]
+            (let [node       (server-node! (:server-html root-006) (:manifest root-006))
+                  match      (:match root-006)
+                  before     (into {} (map (juxt identity #(ms/q node %))) (:same-nodes match))
+                  mismatches (atom [])
+                  k          (listen-mismatches! mismatches)
+                  mounted    (v/hydrate-root node [view props])]
+              (-> (settle)
+                  (.then (fn [_]
+                           (trace-tooling/unregister-listener! k)
+                           (doseq [[selector node*] before]
+                             (is (some? node*) (str label ": the server rendered " selector))
+                             (is (identical? node* (ms/q node selector))
+                                 (str label ": " selector " is the SAME node object — adopted, not re-created")))
+                           (is (= (:adopted match) (root/hydrated? mounted))
+                               (str label ": the root adopted — it is a hydration"))
+                           (is (= (:name props) (ms/text-of node "#who"))
+                               (str label ": and the page carries the server's text"))
+                           (is (= (:mismatches match) (count @mismatches))
+                               (str label ": a clean adoption reports nothing. Saw: " (pr-str @mismatches)))
+                           (v/unmount! mounted)
+                           (remove-node! node)
+                           nil)))))
+          done)))))
+
+;; ===========================================================================
+;; Row 2 — an empty container with no manifest falls back, both modes
+;; ===========================================================================
+
+(deftest hydration-matrix-an-empty-container-falls-back-in-both-modes
+  (testing "A container with nothing to adopt and no manifest beside it is
+            the client-only first load, not a degraded adoption: the root
+            recognises the empty input before React is involved, mounts
+            client-side (`hydrated?` is false), comes up correct anyway,
+            reports NO adoption errors, and claims and releases its
+            live-root id like any other root. In each mode, per FH-ROOT-007."
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the fallback assertions")
+      (async done
+        (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+        (ms/each-mode
+          modes
+          (fn [[label view]]
+            (let [empty*     (:empty-container root-007)
+                  node       (server-node! "")
+                  mismatches (atom [])
+                  k          (listen-mismatches! mismatches)
+                  mounted    (v/hydrate-root node [view (:props root-007)])]
+              (is (= 1 (count (root/live-root-ids)))
+                  (str label ": a fallback root claims its id like any other"))
+              (-> (settle)
+                  (.then (fn [_]
+                           (trace-tooling/unregister-listener! k)
+                           (is (= (:hydrated empty*) (root/hydrated? mounted))
+                               (str label ": an empty container did not hydrate — it fell back"))
+                           (is (= (:text empty*) (ms/text-of node "#who"))
+                               (str label ": and the root came up correct anyway"))
+                           (is (= (:mismatches empty*) (count @mismatches))
+                               (str label ": with no adoption errors at all. Saw: " (pr-str @mismatches)))
+                           (v/unmount! mounted)
+                           (is (= 0 (count (root/live-root-ids)))
+                               (str label ": a fallback root tears down the same way"))
+                           (remove-node! node)
+                           nil)))))
+          done)))))
+
+;; ===========================================================================
+;; Row 3 — both modes adopt the same DOM
+;; ===========================================================================
+
+(deftest hydration-matrix-both-modes-adopt-the-same-dom
+  (testing "The same server bytes adopt to the SAME real DOM under an
+            interpreted form and a compiled one. The greeting is a static
+            declaration; promotion must not change the page hydration
+            produces. The two are hydrated in SEQUENCE — the fixture
+            manifest names one page-unique root-id, so both cannot be live
+            at once — and their adopted outlines compared."
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the parity assertion")
+      (async done
+        (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+        (ms/run-async
+          (fn []
+            (let [ni (server-node! (:server-html root-006) (:manifest root-006))
+                  mi (v/hydrate-root ni [views/greeting props])]
+              (-> (settle)
+                  (.then (fn [_]
+                           (let [outline-i (ms/outline (ms/q ni "#greeting"))]
+                             (is (true? (root/hydrated? mi)) "the interpreted root adopted")
+                             (v/unmount! mi)
+                             (remove-node! ni)
+                             outline-i)))
+                  (.then (fn [outline-i]
+                           (let [nc (server-node! (:server-html root-006) (:manifest root-006))
+                                 mc (v/hydrate-root nc [greeting-compiled props])]
+                             (-> (settle)
+                                 (.then (fn [_]
+                                          (is (= outline-i (ms/outline (ms/q nc "#greeting")))
+                                              "interpreted and compiled adopt the same real DOM")
+                                          (is (true? (root/hydrated? mc)) "and the compiled root adopted")
+                                          (v/unmount! mc)
+                                          (remove-node! nc)
+                                          nil)))))))))
+          done)))))

--- a/implementation/freehand/test/re_frame/freehand/matrix_support.cljs
+++ b/implementation/freehand/test/re_frame/freehand/matrix_support.cljs
@@ -1,0 +1,254 @@
+(ns re-frame.freehand.matrix-support
+  "Shared plumbing for the F6b browser correctness MATRICES (EP-0036 §6,
+  the donor deletion gate row \"browser correctness\").
+
+  The matrices each prove one of the eight areas — controlled input,
+  presence, top layer, behaviors, errors, routing, roots, hydration —
+  green in a real browser, and (where both modes are meaningful) prove
+  the INTERPRETED and COMPILED lowerings AGREE. Two claims per shape:
+  each mode is individually correct, and the two produce the same DOM.
+
+  Everything here is host-bearing — a real `react-dom/client` mount, a
+  real `document` node, real keystrokes — so nothing in this namespace is
+  a structural fact. The mode-agnostic pieces live here so eight matrix
+  files assert against ONE mount discipline and ONE parity primitive
+  rather than eight subtly different ones.
+
+  The matrices ride the browser lane through their `-dom-cljs-test`
+  suffix. They also match the node suites' broader regex, where there is
+  no DOM to mount; each matrix says so rather than passing quietly, and
+  the support here is written so its browser-only bodies are never CALLED
+  under node (only referenced), so the namespace loads on both targets.
+
+  NOT a test namespace (no `-cljs-test` suffix): it is required by the
+  matrix files and carries no `deftest` of its own."
+  (:require ["react" :as react]
+            ["react-dom/client" :as rdc]
+            [clojure.string :as str]
+            [cljs.test :refer [is]]))
+
+;; ---------------------------------------------------------------------------
+;; Runtime discrimination
+;; ---------------------------------------------------------------------------
+
+(defn browser?
+  "True only where a real DOM the matrices can mount into exists."
+  []
+  (and (exists? js/document) (some? (.-createElement js/document))))
+
+(defn skip!
+  "The node arm of a browser matrix — records the reason the assertions
+  did not run rather than passing an empty test silently."
+  [why]
+  (is true (str "a real browser mount is required — " why)))
+
+;; ---------------------------------------------------------------------------
+;; The act boundary
+;; ---------------------------------------------------------------------------
+
+(defn act
+  "A React 19 `act` boundary as a promise, so assertions run after the
+  commit and its flushed effects rather than racing them."
+  [thunk]
+  (try
+    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+    (js/Promise.resolve (react/act (fn [] (js/Promise.resolve (thunk)))))
+    (catch :default e
+      (js/Promise.reject e))))
+
+(defn live!
+  "Leave React's act environment. A keystroke has to reach React as a
+  genuine DISCRETE event, and a dependency-driven repaint must flush where
+  the browser flushes it — both are diverted inside act."
+  []
+  (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+  nil)
+
+(defn tick!
+  "Yield one browser task, so React has flushed what a notification
+  scheduled before anything is read off `document`."
+  []
+  (js/Promise. (fn [resolve] (js/setTimeout #(resolve nil) 0))))
+
+;; ---------------------------------------------------------------------------
+;; A React-DOM host, and a raw mount for frame-scoped forms
+;; ---------------------------------------------------------------------------
+
+(defn host-node!
+  "A fresh container attached to the document body. Scoped to its own
+  element on purpose — the browser runner renders its report into the
+  page, so a matrix that reached for `document.body` would erase the
+  thing reporting on it."
+  []
+  (let [container (.createElement js/document "div")]
+    (.appendChild (.-body js/document) container)
+    container))
+
+(defn create-root!
+  "A `react-dom/client` root over a fresh host; answers `[container root]`."
+  []
+  (let [container (host-node!)]
+    [container (rdc/createRoot container)]))
+
+(defn destroy-root!
+  "Unmount `root` (inside the act environment, where React expects the
+  teardown) and detach its container."
+  [container root]
+  (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+  (.unmount root)
+  (.remove container)
+  nil)
+
+;; ---------------------------------------------------------------------------
+;; Typing, as the browser delivers it
+;; ---------------------------------------------------------------------------
+
+(defn set-native-value!
+  "Write `s` through `HTMLInputElement`'s own prototype setter, so React's
+  value tracker sees the mutation exactly as it does for a real keystroke.
+  Assigning `.-value` directly leaves the tracker's record unchanged and
+  React skips the change event."
+  [node s]
+  (.call (.-set (js/Object.getOwnPropertyDescriptor
+                  (.-prototype js/HTMLInputElement) "value"))
+         node s))
+
+(defn fire-input!
+  "A real bubbling `input` event carrying `data`."
+  ([node] (fire-input! node nil))
+  ([node data]
+   (.dispatchEvent node (js/InputEvent. "input"
+                                        #js {:bubbles true :cancelable false :data data}))))
+
+(defn keystroke!
+  "One keystroke: APPEND `ch` to whatever the node holds, then fire a real
+  bubbling `input`. Appending is what makes a dropped character visible as
+  a loss rather than papered over."
+  [node ch]
+  (set-native-value! node (str (.-value node) ch))
+  (fire-input! node ch))
+
+(defn type-string!
+  "Type `s` one appended keystroke at a time."
+  [node s]
+  (doseq [ch (seq s)] (keystroke! node (str ch))))
+
+(defn insert-at!
+  "Insert `ch` at offset `at`, the way a browser does: the text grows at
+  the caret, the caret follows it, then `input` fires."
+  [node at ch]
+  (let [text (.-value node)]
+    (.focus node)
+    (.setSelectionRange node at at)
+    (set-native-value! node (str (subs text 0 at) ch (subs text at)))
+    (.setSelectionRange node (inc at) (inc at))
+    (fire-input! node ch)))
+
+(defn caret [node] [(.-selectionStart node) (.-selectionEnd node)])
+
+;; ---------------------------------------------------------------------------
+;; Reading the DOM back
+;; ---------------------------------------------------------------------------
+
+(defn q
+  "The first descendant of `container` matching `selector`, or nil."
+  [container selector]
+  (.querySelector container selector))
+
+(defn text-of
+  "The text content at `selector`, or nil when nothing matched."
+  [container selector]
+  (some-> (q container selector) .-textContent))
+
+(defn attrs-of
+  "EVERY attribute the matched element carries, as a plain map keyed by
+  attribute name. Read off `document` rather than named one by one, so an
+  attribute that should not be there fails a comparison too."
+  [el]
+  (when el
+    (into {} (map (fn [a] [(.-name a) (.-value a)])) (array-seq (.-attributes el)))))
+
+;; ---------------------------------------------------------------------------
+;; The parity primitive — a canonical outline of a real subtree
+;; ---------------------------------------------------------------------------
+
+(defn outline
+  "A canonical, comparable string for the real subtree rooted at `el`:
+  tag name, attributes in NAME ORDER, and text, recursing into element
+  children. Two mode renders that denote the same page produce the same
+  outline; a divergence in tag, attribute, attribute value, text or child
+  order is a difference the string carries.
+
+  Attribute order is normalized (sorted) because the DOM's attribute
+  order is an artefact of how each emitter wrote them, not a fact about
+  the page. Everything else is preserved verbatim — this is the DOM the
+  two lowerings actually built, not a projection that could hide a
+  divergence the way a sampled assertion can."
+  [el]
+  (letfn [(node-str [n]
+            (case (.-nodeType n)
+              3 (.-nodeValue n)                     ; TEXT_NODE
+              1 (let [tag   (str/lower-case (.-tagName n))
+                      attrs (->> (array-seq (.-attributes n))
+                                 (map (fn [a] [(.-name a) (.-value a)]))
+                                 (sort-by first)
+                                 (map (fn [[k v]] (str k "=" (pr-str v))))
+                                 (str/join " "))
+                      head  (if (str/blank? attrs) tag (str tag " " attrs))
+                      kids  (str/join (map node-str (array-seq (.-childNodes n))))]
+                  (str "<" head ">" kids "</" tag ">"))
+              ""))]                                 ; comments etc. contribute nothing
+    (node-str el)))
+
+(defn outlines-agree?
+  "Assert the two mode renders produce the SAME canonical outline —
+  the load-bearing parity claim. Returns the shared outline on success so
+  a caller can assert the render was non-empty too."
+  [interpreted-el compiled-el note]
+  (let [a (outline interpreted-el)
+        b (outline compiled-el)]
+    (is (= a b) (str note " — interpreted and compiled build the same real DOM"))
+    a))
+
+;; ---------------------------------------------------------------------------
+;; The matrix sequencer — one mode, then the next, then done
+;; ---------------------------------------------------------------------------
+
+(defn each-mode
+  "Run `f` (which returns a promise) for each entry in `modes`, in sequence,
+  then call `done` EXACTLY ONCE. A rejection in one mode is caught as an
+  assertion failure named by that mode and does NOT break the chain or the
+  `done` accounting — a single broken cell can neither hang the suite nor
+  double-fire `done` (which corrupts cljs.test's async state and stalls the
+  whole run). This is the shape a matrix ROW takes: the same claim,
+  asserted once per mode, named by the mode label."
+  [modes f done]
+  (-> (reduce (fn [p mode]
+                (.then p (fn [_]
+                           (-> (js/Promise.resolve (f mode))
+                               (.catch (fn [e]
+                                         (is false (str "mode " (pr-str (first mode))
+                                                        " rejected: " e))
+                                         nil))))))
+              (js/Promise.resolve nil)
+              modes)
+      (.then (fn [_] (done)))
+      (.catch (fn [e]
+                (is false (str "a matrix row rejected: " e))
+                (done)))))
+
+(defn run-async
+  "Run `thunk` (which returns a promise) and then call `done` EXACTLY ONCE.
+  A rejection — or a SYNCHRONOUS throw inside `thunk` — is a named assertion
+  failure followed by the single `done`. `thunk` runs inside a `.then` so a
+  synchronous throw becomes a rejection rather than escaping the chain and
+  stranding `done`. The terminal shape for a cross-mode cell that mounts
+  both modes itself: the body never calls `done`, so it cannot double-fire
+  it."
+  [thunk done]
+  (-> (js/Promise.resolve nil)
+      (.then (fn [_] (thunk)))
+      (.then (fn [_] (done)))
+      (.catch (fn [e]
+                (is false (str "an async matrix cell rejected: " e))
+                (done)))))

--- a/implementation/freehand/test/re_frame/freehand/presence_matrix_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/presence_matrix_dom_cljs_test.cljs
@@ -1,0 +1,231 @@
+(ns re-frame.freehand.presence-matrix-dom-cljs-test
+  "F6b matrix 2/8 — KEYED PRESENCE re-entry and ACCESSIBILITY, in a real
+  browser, across BOTH execution modes (EP-0036 §6, gate row \"browser
+  correctness\"; acceptance 2 — dynamic accessibility is owned by
+  real-browser tests).
+
+  A presence boundary RETAINS a departed keyed child so it can leave on
+  its own terms, and the child owns its exit accessibility by reading its
+  own `(v/presence-phase)`. None of that is a structural fact: a reconcile
+  that is perfectly shaped can still leave a departed child in the DOM
+  forever, never let it read `:unmounting`, or unmount it twice. So this
+  mounts, and reads every claim back off `document`.
+
+  The matrix dimension is mode. The presence RUNTIME is a shared,
+  mode-independent substrate; the emitters differ only in how the boundary
+  and its children are BUILT. So each claim below is asserted in the
+  interpreted AND the compiled lowering — a departed key retained
+  `:unmounting` with `aria-hidden`/`inert` stamped by the child's own
+  phase read, a terminal flush that removes it exactly once, and a
+  re-entry that cancels the pending exit — proving promotion feeds the
+  presence runtime the same page either way.
+
+  Retention is driven by the deterministic `flush-presence!` clock — the
+  real `setTimeout` arm is disabled — so a window closes exactly when the
+  test says and the run carries no wall-clock flake.
+
+  Rides the browser lane through its `-dom-cljs-test` suffix; under node
+  it has no DOM and says so."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.matrix-support :as ms]
+            [re-frame.freehand.presence-runtime :as presence]
+            [re-frame.freehand.react :as fr]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       plain-atom/adapter
+     :ambient-frame nil
+     :async?        true}))
+
+;; ---------------------------------------------------------------------------
+;; Twins — the phase-aware child, and the boundary, in each mode. The child
+;; reads its OWN phase and, while :unmounting, hides itself from assistive
+;; technology and leaves the interaction tree. The boundary carries a
+;; literal keyed child and a CONDITIONAL keyed child, so the second can
+;; leave the presence list and be retained — the compiled grammar takes a
+;; literal/conditional presence child (a dynamic `for` is interpreted-only).
+;; ---------------------------------------------------------------------------
+
+(v/defview toast-interpreted
+  [{:keys [label]}]
+  (let [phase    (v/presence-phase)
+        exiting? (= :unmounting phase)]
+    [:div.toast {:data-label  (str label)
+                 :data-phase  (name phase)
+                 :aria-hidden (when exiting? true)
+                 :inert       (when exiting? true)}
+     (str label)]))
+
+(v/defview toast-compiled
+  {:compiled true}
+  [{:keys [label]}]
+  (let [phase    (v/presence-phase)
+        exiting? (= :unmounting phase)]
+    [:div.toast {:data-label  (str label)
+                 :data-phase  (name phase)
+                 :aria-hidden (when exiting? true)
+                 :inert       (when exiting? true)}
+     (str label)]))
+
+;; The terminal `:timeout-ms` is a LITERAL: the compiled presence grammar
+;; settles it at analysis time. It is irrelevant to the run — retention is
+;; driven by the deterministic `flush-presence!` clock below, never the
+;; wall clock — but it must be a literal number in both twins for the
+;; declarations to be byte-identical bar the marker.
+(v/defview toaster-interpreted
+  [{:keys [show-b?]}]
+  [:div#stack
+   (v/presence {:timeout-ms 300}
+     [toast-interpreted {:key "a" :label "a"}]
+     (when show-b? [toast-interpreted {:key "b" :label "b"}]))])
+
+(v/defview toaster-compiled
+  {:compiled true}
+  [{:keys [show-b?]}]
+  [:div#stack
+   (v/presence {:timeout-ms 300}
+     [toast-compiled {:key "a" :label "a"}]
+     (when show-b? [toast-compiled {:key "b" :label "b"}]))])
+
+(def ^:private modes
+  [["interpreted" toaster-interpreted]
+   ["compiled"    toaster-compiled]])
+
+;; ---------------------------------------------------------------------------
+;; Reading the stack
+;; ---------------------------------------------------------------------------
+
+(defn- toast-el [container label]
+  (.querySelector container (str ".toast[data-label='" label "']")))
+
+(defn- phase-of [container label]
+  (some-> (toast-el container label) (.getAttribute "data-phase")))
+
+(defn- present? [container label] (some? (toast-el container label)))
+
+(defn- render! [root view show-b?]
+  (ms/act #(.render root (fr/element [view {:show-b? show-b?}]))))
+
+;; ===========================================================================
+;; Row 1 — both lowerings mount the same stack
+;; ===========================================================================
+
+(deftest presence-matrix-both-modes-mount-the-same-stack
+  (testing "The presence boundary and its two phase-aware children mount to
+            the SAME real DOM in each mode — same keyed children, same
+            settled `:present` phase, same absence of exit accessibility."
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the parity assertion")
+      (async done
+        (presence/reset-clock!)
+        (presence/set-wall-clock! false)
+        (let [[ci ri] (ms/create-root!)
+              [cc rc] (ms/create-root!)]
+          (-> (render! ri toaster-interpreted true)
+              (.then (fn [_] (render! rc toaster-compiled true)))
+              (.then (fn [_]
+                       (ms/outlines-agree? (ms/q ci "#stack") (ms/q cc "#stack")
+                                           "presence stack")
+                       (doseq [[label container] [["interpreted" ci] ["compiled" cc]]]
+                         (is (present? container "a") (str label ": a mounted"))
+                         (is (present? container "b") (str label ": b mounted"))
+                         (is (= "present" (phase-of container "a")) (str label ": a is :present"))
+                         (is (nil? (.getAttribute (toast-el container "b") "aria-hidden"))
+                             (str label ": a present child is not hidden")))
+                       (ms/destroy-root! ci ri)
+                       (ms/destroy-root! cc rc)
+                       (done)))
+              (.catch (fn [e]
+                        (is false (str "a presence mount rejected: " e))
+                        (ms/destroy-root! ci ri)
+                        (ms/destroy-root! cc rc)
+                        (done)))))))))
+
+;; ===========================================================================
+;; Row 2 — a departed key is retained, hides itself, and flushes once
+;; ===========================================================================
+
+(deftest presence-matrix-a-departed-key-is-retained-and-hides-itself-in-both-modes
+  (testing "Removing key b RETAINS its child `:unmounting`, the child hides
+            itself from assistive technology and leaves the interaction tree
+            by reading its own phase, and the deterministic timeout removes
+            it exactly once — in each mode. This is acceptance 2's dynamic
+            accessibility, owned by a real-browser test."
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the retention assertions")
+      (async done
+        (ms/each-mode
+          modes
+          (fn [[label view]]
+            (presence/reset-clock!)
+            (presence/set-wall-clock! false)
+            (let [[container root] (ms/create-root!)]
+              (-> (render! root view true)
+                  (.then (fn [_]
+                           (is (= "present" (phase-of container "b")) (str label ": b starts :present"))
+                           (is (= 0 (presence/pending-count)) (str label ": nothing pending"))
+                           (render! root view false)))     ; b departs
+                  (.then (fn [_]
+                           (is (present? container "b")
+                               (str label ": b is RETAINED in the DOM while exiting"))
+                           (is (= "unmounting" (phase-of container "b"))
+                               (str label ": b's own phase read reaches :unmounting"))
+                           (is (= "true" (.getAttribute (toast-el container "b") "aria-hidden"))
+                               (str label ": the exiting child hid itself from assistive tech"))
+                           (is (some? (.getAttribute (toast-el container "b") "inert"))
+                               (str label ": and took itself out of the interaction tree"))
+                           (is (= 1 (presence/pending-count)) (str label ": exactly one exit retained"))
+                           (ms/act #(presence/flush-presence!))))
+                  (.then (fn [_]
+                           (is (present? container "a") (str label ": a is untouched"))
+                           (is (not (present? container "b"))
+                               (str label ": the timeout removed b terminally"))
+                           (is (= 0 (presence/pending-count))
+                               (str label ": the exit fired exactly once"))
+                           (ms/destroy-root! container root)
+                           nil)))))
+          done)))))
+
+;; ===========================================================================
+;; Row 3 — re-entry before the flush cancels the exit
+;; ===========================================================================
+
+(deftest presence-matrix-re-entry-before-the-flush-cancels-removal-in-both-modes
+  (testing "Re-adding key b BEFORE its timeout fires interrupts the exit —
+            the child returns to `:present`, drops its exit accessibility,
+            and the pending removal is cancelled so a later flush never
+            unmounts it — in each mode."
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the re-entry assertions")
+      (async done
+        (ms/each-mode
+          modes
+          (fn [[label view]]
+            (presence/reset-clock!)
+            (presence/set-wall-clock! false)
+            (let [[container root] (ms/create-root!)]
+              (-> (render! root view true)
+                  (.then (fn [_] (render! root view false)))    ; b departs -> :unmounting
+                  (.then (fn [_]
+                           (is (= "unmounting" (phase-of container "b"))
+                               (str label ": b is retained :unmounting"))
+                           (is (= 1 (presence/pending-count)) (str label ": its exit is scheduled"))
+                           (render! root view true)))            ; b re-enters before the flush
+                  (.then (fn [_]
+                           (is (present? container "b") (str label ": b is still in the DOM"))
+                           (is (= "present" (phase-of container "b"))
+                               (str label ": re-entry flipped b back to :present"))
+                           (is (nil? (.getAttribute (toast-el container "b") "aria-hidden"))
+                               (str label ": b dropped its exit accessibility on re-entry"))
+                           (is (= 0 (presence/pending-count))
+                               (str label ": the pending exit was cancelled"))
+                           (ms/act #(presence/flush-presence!))))
+                  (.then (fn [_]
+                           (is (present? container "b")
+                               (str label ": a flush after re-entry leaves b mounted"))
+                           (ms/destroy-root! container root)
+                           nil)))))
+          done)))))

--- a/implementation/freehand/test/re_frame/freehand/root_matrix_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/root_matrix_dom_cljs_test.cljs
@@ -1,0 +1,226 @@
+(ns re-frame.freehand.root-matrix-dom-cljs-test
+  "F6b matrix 7/8 — ROOT ergonomics and TEARDOWN, in a real browser, across
+  BOTH execution modes (EP-0036 §6, gate row \"browser correctness\";
+  acceptance 3 — cleanup assertions are EXACT counts).
+
+  A root is where a declared view meets the host: `v/mount` puts a tree on
+  a real container against a frame it either OWNS (ensured for the root's
+  lifetime) or merely SCOPES (borrowed), and `v/unmount!` must leave
+  exactly nothing of an owned root behind — no registry claim, no ledger
+  record, no live subscription. `v/mount` is a browser fact and teardown is
+  an ABSENCE, so this mounts and reads every count off a different place.
+
+  The mode dimension: the same declaration mounts through the same
+  `v/mount` in each mode. Each claim — a minimal root on screen, an owned
+  frame torn down to the exact integer zero, and two roots of one
+  declaration keeping independent per-occurrence identity — is asserted
+  interpreted AND compiled, and the two build the same root DOM.
+
+  Rides the browser lane through its `-dom-cljs-test` suffix; under node it
+  has no DOM and says so."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.matrix-support :as ms]
+            [re-frame.freehand.root :as root]
+            [re-frame.freehand.root-views :as views]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+(def ^:private runtime-fixture
+  (test-support/make-reset-runtime-fixture
+    {:adapter       plain-atom/adapter
+     :ambient-frame nil
+     :async?        true}))
+
+(use-fixtures :each
+  {:before (fn [] (root/reset-registry!) ((:before runtime-fixture)))
+   :after  (fn [] ((:after runtime-fixture)) (root/reset-registry!))})
+
+;; ---------------------------------------------------------------------------
+;; Compiled twins of the host-neutral root views (same body, marker only)
+;; ---------------------------------------------------------------------------
+
+(v/defview app-compiled
+  {:compiled true}
+  [{:keys [label]}]
+  [:main#app label])
+
+(v/defview counter-compiled
+  {:compiled true}
+  [_]
+  [:p.count (str (v/sub [:root/n]))])
+
+(v/defview panel-compiled
+  {:compiled true}
+  [{:keys [label seed]}]
+  [:section.panel
+   [:span.label label]
+   [:input.field {:type "text" :default-value seed}]])
+
+(def ^:private app-modes
+  [["interpreted" views/app] ["compiled" app-compiled]])
+
+(def ^:private counter-modes
+  [["interpreted" views/counter] ["compiled" counter-compiled]])
+
+(def ^:private panel-modes
+  [["interpreted" views/panel] ["compiled" panel-compiled]])
+
+;; ---------------------------------------------------------------------------
+;; Harness
+;; ---------------------------------------------------------------------------
+
+(defn- reg! []
+  (rf/reg-sub :root/n (fn [db _] (:n db)))
+  (rf/reg-event :root/seed (fn [{:keys [db]} [_ n]] {:db (assoc db :n n)})))
+
+(defn- ref-count [fid q]
+  (some-> (frame/frame fid) :sub-cache deref (get q) :ref-count))
+
+(defn- mount! [form node opts]
+  (ms/act #(v/mount form node opts)))
+
+;; ===========================================================================
+;; Row 1 — a minimal root mounts and tears down, both modes
+;; ===========================================================================
+
+(deftest root-matrix-a-minimal-root-mounts-and-tears-down-in-both-modes
+  (testing "The minimal single-root spelling puts a plain element on a real
+            container and claims exactly one live root; `v/unmount!` removes
+            the tree and drops the claim to zero. In each mode."
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the root assertions")
+      (async done
+        (ms/each-mode
+          app-modes
+          (fn [[label view]]
+            (reg!)
+            (let [node (ms/host-node!)]
+              (-> (mount! [view {:label "hello"}] node {:frame {:id (keyword "matrix.root" (str "app-" label))}})
+                  (.then (fn [mounted]
+                           (is (= "hello" (ms/text-of node "#app")) (str label ": the root rendered"))
+                           (is (= 1 (count (root/live-root-ids))) (str label ": exactly one live root"))
+                           (-> (ms/act #(v/unmount! mounted))
+                               (.then (fn [_]
+                                        (is (= 0 (count (root/live-root-ids)))
+                                            (str label ": the claim dropped to zero"))
+                                        (is (= 0 (.-childElementCount node))
+                                            (str label ": and the container is empty"))
+                                        (.remove node)
+                                        nil))))))))
+          done)))))
+
+;; ===========================================================================
+;; Row 2 — an owned frame tears down to the exact integer zero, both modes
+;; ===========================================================================
+
+(deftest root-matrix-an-owned-frame-tears-down-to-exact-zero-in-both-modes
+  (testing "A root that ENSURES its own frame reads the seed on its first
+            render — the frame was live before React saw anything — and,
+            after `v/unmount!`, the registry holds no claim, the frame ledger
+            no record, the ensured frame is destroyed, and the subscription
+            the view held is released from the live sub-cache. Each is the
+            exact integer zero read from a different place. In each mode."
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the owned-teardown assertions")
+      (async done
+        (ms/each-mode
+          counter-modes
+          (fn [[label view]]
+            (reg!)
+            (let [node (ms/host-node!)
+                  fid  (keyword "matrix.root" (str "owned-" label))
+                  q    [:root/n]]
+              (-> (mount! [view {}] node {:frame {:id fid :initial-events [[:root/seed 7]]}})
+                  (.then (fn [mounted]
+                           (is (= "7" (ms/text-of node ".count")) (str label ": the seed read on first render"))
+                           (is (= 1 (count (root/live-root-ids))) (str label ": one live root"))
+                           (is (= 1 (count (root/frame-ledger-snapshot))) (str label ": one ledger record"))
+                           (is (some? (ref-count fid q)) (str label ": a live sub-cache node while mounted"))
+                           (-> (ms/act #(v/unmount! mounted))
+                               (.then (fn [_]
+                                        (is (= 0 (count (root/live-root-ids)))
+                                            (str label ": zero registry claims"))
+                                        (is (= 0 (count (root/frame-ledger-snapshot)))
+                                            (str label ": zero ledger records"))
+                                        (is (nil? (frame/frame fid))
+                                            (str label ": the ensured frame is destroyed"))
+                                        (is (nil? (ref-count fid q))
+                                            (str label ": and no sub-cache node holds a released dependency"))
+                                        (.remove node)
+                                        nil))))))))
+          done)))))
+
+;; ===========================================================================
+;; Row 3 — two roots of one declaration keep independent identity, both modes
+;; ===========================================================================
+
+(deftest root-matrix-multi-root-identity-in-both-modes
+  (testing "One declaration mounted TWICE on one page is two roots, not one:
+            each occurrence's per-occurrence state (an uncontrolled field
+            seeded differently) is its own, and the registry holds two live
+            claims. Two roots that shared identity would show one field's
+            seed in both. In each mode."
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the multi-root assertions")
+      (async done
+        (ms/each-mode
+          panel-modes
+          (fn [[label view]]
+            (reg!)
+            (let [n1 (ms/host-node!)
+                  n2 (ms/host-node!)]
+              (-> (mount! [view {:label "one" :seed "alpha"}] n1
+                          {:frame {:id (keyword "matrix.root" (str "p1-" label))}
+                           :disambiguator :one})
+                  (.then (fn [m1]
+                           (-> (mount! [view {:label "two" :seed "beta"}] n2
+                                       {:frame {:id (keyword "matrix.root" (str "p2-" label))}
+                                        :disambiguator :two})
+                               (.then (fn [m2]
+                                        (is (= 2 (count (root/live-root-ids)))
+                                            (str label ": two live roots"))
+                                        (is (= "alpha" (.-value (ms/q n1 ".field")))
+                                            (str label ": occurrence one holds its own seed"))
+                                        (is (= "beta" (.-value (ms/q n2 ".field")))
+                                            (str label ": occurrence two holds its own — identity is not shared"))
+                                        (-> (ms/act #(v/unmount! m1))
+                                            (.then (fn [_] (ms/act #(v/unmount! m2))))
+                                            (.then (fn [_]
+                                                     (is (= 0 (count (root/live-root-ids)))
+                                                         (str label ": both roots released"))
+                                                     (.remove n1) (.remove n2)
+                                                     nil)))))))))))
+          done)))))
+
+;; ===========================================================================
+;; Row 4 — both modes build the same root DOM
+;; ===========================================================================
+
+(deftest root-matrix-both-modes-build-the-same-root-dom
+  (testing "The mounted root is the SAME real DOM in each mode — same
+            element, same id, same text. `v/mount` is one door; promotion
+            must not change what lands on the container."
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the parity assertion")
+      (async done
+        (reg!)
+        (let [ni (ms/host-node!)
+              nc (ms/host-node!)]
+          (-> (mount! [views/app {:label "same"}] ni {:frame {:id :matrix.root/parity-i}})
+              (.then (fn [mi]
+                       (-> (mount! [app-compiled {:label "same"}] nc {:frame {:id :matrix.root/parity-c}})
+                           (.then (fn [mc]
+                                    (ms/outlines-agree? (ms/q ni "#app") (ms/q nc "#app") "root element")
+                                    (is (= "same" (ms/text-of ni "#app")) "non-vacuous: the root really rendered")
+                                    (-> (ms/act #(v/unmount! mi))
+                                        (.then (fn [_] (ms/act #(v/unmount! mc))))
+                                        (.then (fn [_]
+                                                 (.remove ni) (.remove nc)
+                                                 (done)))))))))
+              (.catch (fn [e]
+                        (is false (str "a root mount rejected: " e))
+                        (.remove ni) (.remove nc)
+                        (done)))))))))

--- a/implementation/freehand/test/re_frame/freehand/route_link_matrix_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/route_link_matrix_dom_cljs_test.cljs
@@ -1,0 +1,244 @@
+(ns re-frame.freehand.route-link-matrix-dom-cljs-test
+  "F6b matrix 6/8 — `v/route-link` NATIVE behaviour, in a real browser,
+  across BOTH execution modes (EP-0036 §6, gate row \"browser
+  correctness\").
+
+  `v/route-link` is a framework-supplied VIEW, not an intrinsic — it
+  renders a real `<a>` with a routing-owned href and intercepts ONLY the
+  plain-navigation click, leaving a modifier click, a `:download` and a
+  non-default `:target` to the browser. None of that is structural: it is
+  whether a real anchor resolves a real URL, and whether a real
+  `MouseEvent` is intercepted or left native.
+
+  The mode dimension: route-link is an ordinary declared view, so a
+  compiled PARENT that contains `[v/route-link …]` composes it exactly as
+  an interpreted parent does. Each claim — a real resolved anchor, a plain
+  click that navigates, and a modifier / download / target click left
+  native — is asserted with the route-link mounted under an interpreted
+  parent AND a compiled one, and the two build the same anchor.
+
+  Navigation is suppressed by a document-level guard so a click the
+  framework leaves native does not navigate the harness page; interception
+  is read from the routing dispatch (`:rf.route/url-requested`), which
+  fires exactly when route-link intercepts.
+
+  Rides the browser lane through its `-dom-cljs-test` suffix; under node it
+  has no DOM and says so."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.matrix-support :as ms]
+            [re-frame.freehand.react :as fr]
+            [re-frame.freehand.shell :as shell]
+            [re-frame.routing :as routing]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [re-frame.trace.tooling :as trace-tooling]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :async?  true
+     :init-fn routing/reset-counters!}))
+
+(def ^:private host-frame :matrix.route-link/frame)
+
+;; ---------------------------------------------------------------------------
+;; Twins — a route-link under an interpreted parent and a compiled one,
+;; one nav per scenario, props LITERAL so the compiled parent composes the
+;; child boundary at build time.
+;; ---------------------------------------------------------------------------
+
+(v/defview nav-plain-interpreted
+  [_]
+  [:nav [v/route-link {:to :matrix.route/article :params {:slug "the-intro"} :class "title"} "Read"]])
+
+(v/defview nav-plain-compiled
+  {:compiled true}
+  [_]
+  [:nav [v/route-link {:to :matrix.route/article :params {:slug "the-intro"} :class "title"} "Read"]])
+
+(v/defview nav-download-interpreted
+  [_]
+  [:nav [v/route-link {:to :matrix.route/article :params {:slug "the-intro"} :download "intro.pdf"} "Download"]])
+
+(v/defview nav-download-compiled
+  {:compiled true}
+  [_]
+  [:nav [v/route-link {:to :matrix.route/article :params {:slug "the-intro"} :download "intro.pdf"} "Download"]])
+
+(v/defview nav-target-interpreted
+  [_]
+  [:nav [v/route-link {:to :matrix.route/article :params {:slug "the-intro"} :target "_blank"} "New tab"]])
+
+(v/defview nav-target-compiled
+  {:compiled true}
+  [_]
+  [:nav [v/route-link {:to :matrix.route/article :params {:slug "the-intro"} :target "_blank"} "New tab"]])
+
+(def ^:private plain-modes
+  [["interpreted" nav-plain-interpreted]
+   ["compiled"    nav-plain-compiled]])
+
+(def ^:private native-scenarios
+  ;; [label view event-init why]
+  [["modifier/interpreted" nav-plain-interpreted    #js {:metaKey true} "a modifier click"]
+   ["modifier/compiled"    nav-plain-compiled       #js {:metaKey true} "a modifier click"]
+   ["download/interpreted" nav-download-interpreted #js {}             "a :download anchor"]
+   ["download/compiled"    nav-download-compiled    #js {}             "a :download anchor"]
+   ["target/interpreted"   nav-target-interpreted   #js {}             "a non-default :target"]
+   ["target/compiled"      nav-target-compiled      #js {}             "a non-default :target"]])
+
+;; ---------------------------------------------------------------------------
+;; Harness
+;; ---------------------------------------------------------------------------
+
+(defn- setup! []
+  (routing/reg-route :matrix.route/article {} "/articles/:slug")
+  (rf/make-frame {:id host-frame :initial-events [[:rf/set-db {}]]})
+  host-frame)
+
+(defn- render! [root view]
+  (ms/act #(.render root (shell/provide-frame host-frame (fr/element [view {}])))))
+
+(defn- anchor [container] (.querySelector container "a"))
+
+(defn- with-nav-guard
+  "Suppress real navigation for `thunk` — a click the framework leaves
+  native must not navigate the harness page — then run it."
+  [thunk]
+  (let [guard (fn [e] (.preventDefault e))]
+    (.addEventListener js/document "click" guard)
+    (try (thunk) (finally (.removeEventListener js/document "click" guard)))))
+
+(defn- dispatched?
+  "Fire a real `MouseEvent` at `a` and answer whether route-link
+  INTERCEPTED it — a routing `:rf.route/url-requested` dispatch. Interception
+  and `preventDefault` are one decision in route-link, so the dispatch is a
+  faithful proxy for 'the framework took the click'."
+  [a event-init]
+  (let [hit (atom false)
+        k   (keyword (gensym "matrix-route-"))]
+    (trace-tooling/register-listener!
+      k
+      (fn [ev]
+        (when (and (= :rf.event/dispatched (:operation ev))
+                   (vector? (-> ev :tags :rf.event/v))
+                   (= :rf.route/url-requested (-> ev :tags :rf.event/v first)))
+          (reset! hit true))))
+    (try
+      (with-nav-guard
+        #(.dispatchEvent a (js/MouseEvent. "click"
+                                           (js/Object.assign #js {:bubbles true :cancelable true}
+                                                             event-init))))
+      @hit
+      (finally (trace-tooling/unregister-listener! k)))))
+
+;; ===========================================================================
+;; Row 1 — a real anchor with a resolved href, both modes
+;; ===========================================================================
+
+(deftest route-link-matrix-mounts-a-real-anchor-with-a-resolved-href-in-both-modes
+  (testing "The mounted node is an `HTMLAnchorElement` — not a div wearing a
+            click handler — whose href is the route's synthesised URL and
+            whom the browser resolves to a real absolute URL. In each mode."
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the anchor assertions")
+      (async done
+        (ms/each-mode
+          plain-modes
+          (fn [[label view]]
+            (setup!)
+            (let [[container root] (ms/create-root!)]
+              (-> (render! root view)
+                  (.then (fn [_]
+                           (let [a (anchor container)]
+                             (is (instance? js/HTMLAnchorElement a)
+                                 (str label ": a real anchor element"))
+                             (is (= "/articles/the-intro" (.getAttribute a "href"))
+                                 (str label ": the href is synthesised from the route"))
+                             (is (= (str (.-origin js/location) "/articles/the-intro") (.-href a))
+                                 (str label ": and the browser resolves it against the document")))
+                           (ms/destroy-root! container root)
+                           nil)))))
+          done)))))
+
+;; ===========================================================================
+;; Row 2 — a plain click navigates, both modes
+;; ===========================================================================
+
+(deftest route-link-matrix-a-plain-click-navigates-in-both-modes
+  (testing "A plain left click on a same-origin route-link is INTERCEPTED —
+            the framework takes it and dispatches a routing request rather
+            than letting the browser reload. This is the positive control
+            for the native rows below. In each mode."
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the plain-click assertions")
+      (async done
+        (ms/each-mode
+          plain-modes
+          (fn [[label view]]
+            (setup!)
+            (let [[container root] (ms/create-root!)]
+              (-> (render! root view)
+                  (.then (fn [_]
+                           (is (true? (dispatched? (anchor container) #js {}))
+                               (str label ": a plain click dispatched a routing request"))
+                           (ms/destroy-root! container root)
+                           nil)))))
+          done)))))
+
+;; ===========================================================================
+;; Row 3 — native clicks keep their native behaviour, both modes
+;; ===========================================================================
+
+(deftest route-link-matrix-native-clicks-keep-native-behaviour-in-both-modes
+  (testing "A modifier click, a `:download` anchor and a non-default
+            `:target` are LEFT to the browser — route-link intercepts none
+            of them, so no routing request is dispatched and the native
+            action stands. Each scenario is asserted in each mode."
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the native-behaviour assertions")
+      (async done
+        (ms/each-mode
+          native-scenarios
+          (fn [[label view event-init why]]
+            (setup!)
+            (let [[container root] (ms/create-root!)]
+              (-> (render! root view)
+                  (.then (fn [_]
+                           (is (false? (dispatched? (anchor container) event-init))
+                               (str label ": " why " is left native — nothing dispatched"))
+                           (ms/destroy-root! container root)
+                           nil)))))
+          done)))))
+
+;; ===========================================================================
+;; Row 4 — both modes build the same anchor
+;; ===========================================================================
+
+(deftest route-link-matrix-both-modes-build-the-same-anchor
+  (testing "The route-link anchor — its href, its class, its text — is the
+            SAME real DOM whether composed by an interpreted parent or a
+            compiled one. route-link is a shared declared view; promotion of
+            its caller must not change the anchor it renders."
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the parity assertion")
+      (async done
+        (setup!)
+        (let [[ci ri] (ms/create-root!)
+              [cc rc] (ms/create-root!)]
+          (-> (render! ri nav-plain-interpreted)
+              (.then (fn [_] (render! rc nav-plain-compiled)))
+              (.then (fn [_]
+                       (ms/outlines-agree? (anchor ci) (anchor cc) "route-link anchor")
+                       (is (= "/articles/the-intro" (.getAttribute (anchor ci) "href"))
+                           "non-vacuous: the shared anchor really carries the route href")
+                       (ms/destroy-root! ci ri)
+                       (ms/destroy-root! cc rc)
+                       (done)))
+              (.catch (fn [e]
+                        (is false (str "a route-link mount rejected: " e))
+                        (ms/destroy-root! ci ri)
+                        (ms/destroy-root! cc rc)
+                        (done)))))))))

--- a/implementation/freehand/test/re_frame/freehand/top_layer_matrix_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/top_layer_matrix_dom_cljs_test.cljs
@@ -1,0 +1,233 @@
+(ns re-frame.freehand.top-layer-matrix-dom-cljs-test
+  "F6b matrix 3/8 — DOM TOP LAYER reconciliation and layout timing, in a
+  real browser, across BOTH execution modes (EP-0036 §6, gate row
+  \"browser correctness\").
+
+  A qualified `::web/popover-open?` / `::web/modal-open?` is a DESIRED
+  STATE the substrate reconciles against the element's real top-layer
+  membership — `showPopover` / `showModal` and their inverses — inside the
+  commit, before the browser paints. A structural tree can only record
+  what was ASKED FOR; whether the element actually joined the top layer is
+  a browser question, and whether it did so at layout time rather than a
+  frame later is a timing question. So this mounts and asks the real top
+  layer.
+
+  The matrix dimension is mode. The top-layer intrinsics are recognised at
+  `node/element`, reached by both emitters, so each claim — a popover
+  promoted to the real top layer at layout time, a modal opened as a real
+  `:modal` dialog, and reconciliation that FOLLOWS a flipped desired state
+  — is asserted interpreted AND compiled, and the two build the same
+  element.
+
+  Guarded on `showPopover`: a real top layer, not merely a DOM. Rides the
+  browser lane through its `-dom-cljs-test` suffix; under node it has no
+  top layer and says so."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.matrix-support :as ms]
+            [re-frame.freehand.react :as fr]
+            [re-frame.freehand.shell :as shell]
+            [re-frame.freehand.web :as web]
+            [re-frame.live-frame :as live-frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       plain-atom/adapter
+     :ambient-frame nil
+     :async?        true}))
+
+(def ^:private fid :matrix.top-layer/frame)
+(def ^:private menu-id "matrix-menu")
+(def ^:private modal-id "matrix-modal")
+
+;; ---------------------------------------------------------------------------
+;; Twins — a popover and a modal, each parametrised by its desired state so
+;; a reconcile is a re-render with a flipped prop.
+;; ---------------------------------------------------------------------------
+
+(v/defview popover-interpreted
+  [{:keys [open?]}]
+  [:div {:id                    menu-id
+         :popover               :auto
+         ::web/popover-open?    open?
+         :on-toggle             [:matrix.top-layer/toggled]}
+   "Account"])
+
+(v/defview popover-compiled
+  {:compiled true}
+  [{:keys [open?]}]
+  [:div {:id                    menu-id
+         :popover               :auto
+         ::web/popover-open?    open?
+         :on-toggle             [:matrix.top-layer/toggled]}
+   "Account"])
+
+(v/defview modal-interpreted
+  [{:keys [open?]}]
+  [:dialog {:id                menu-id
+            ::web/modal-open?  open?
+            :on-close          [:matrix.top-layer/closed]}
+   [:p "Delete this?"]])
+
+(v/defview modal-compiled
+  {:compiled true}
+  [{:keys [open?]}]
+  [:dialog {:id                menu-id
+            ::web/modal-open?  open?
+            :on-close          [:matrix.top-layer/closed]}
+   [:p "Delete this?"]])
+
+(def ^:private popover-modes
+  [["interpreted" popover-interpreted]
+   ["compiled"    popover-compiled]])
+
+(def ^:private modal-modes
+  [["interpreted" modal-interpreted]
+   ["compiled"    modal-compiled]])
+
+;; ---------------------------------------------------------------------------
+;; Harness
+;; ---------------------------------------------------------------------------
+
+(defn- top-layer? []
+  (some? (.-showPopover (.-prototype js/HTMLElement))))
+
+(defn- setup! []
+  (live-frame/make-frame {:id fid})
+  (rf/reg-event :matrix.top-layer/toggled (fn [{:keys [db]} _] {:db db}))
+  (rf/reg-event :matrix.top-layer/closed  (fn [{:keys [db]} _] {:db db}))
+  fid)
+
+(defn- render! [root view open?]
+  (ms/act #(.render root (shell/provide-frame fid (fr/element [view {:open? open?}])))))
+
+(defn- el [container] (.querySelector container (str "#" menu-id)))
+(defn- popover-open? [container] (.matches (el container) ":popover-open"))
+(defn- modal-open? [container] (.matches (el container) ":modal"))
+
+;; ===========================================================================
+;; Row 1 — both lowerings build the same top-layer element
+;; ===========================================================================
+
+(deftest top-layer-matrix-both-modes-build-the-same-popover-element
+  (testing "The popover element — its `popover` mode, its id, its text —
+            is the SAME real DOM in each mode. The desired-state property is
+            a reserved fact the tree carries, not an authored attribute, so
+            it does not appear on the element; what appears is the ordinary
+            markup, and it must match."
+    (if-not (and (ms/browser?) (top-layer?))
+      (ms/skip! "the browser job runs the top-layer assertions")
+      (async done
+        (setup!)
+        (let [[ci ri] (ms/create-root!)
+              [cc rc] (ms/create-root!)]
+          (-> (render! ri popover-interpreted false)
+              (.then (fn [_] (render! rc popover-compiled false)))
+              (.then (fn [_]
+                       (ms/outlines-agree? (el ci) (el cc) "popover element")
+                       (is (= "auto" (.getAttribute (el ci) "popover"))
+                           "non-vacuous: it really is an auto popover")
+                       (ms/destroy-root! ci ri)
+                       (ms/destroy-root! cc rc)
+                       (done)))
+              (.catch (fn [e]
+                        (is false (str "a popover mount rejected: " e))
+                        (ms/destroy-root! ci ri)
+                        (ms/destroy-root! cc rc)
+                        (done)))))))))
+
+;; ===========================================================================
+;; Row 2 — a popover promotes to the real top layer at layout time
+;; ===========================================================================
+
+(deftest top-layer-matrix-a-popover-promotes-at-layout-time-in-both-modes
+  (testing "A popover whose desired state is open joins the real top layer
+            — `:popover-open` is true the instant the commit's act boundary
+            resolves, before any extra task, which is the layout-time
+            reconcile the intrinsic promises — while a closed desired state
+            leaves it out. Both are asserted, so a view that always opened
+            (or never did) fails. In each mode."
+    (if-not (and (ms/browser?) (top-layer?))
+      (ms/skip! "the browser job runs the promotion assertions")
+      (async done
+        (ms/each-mode
+          popover-modes
+          (fn [[label view]]
+            (setup!)
+            (let [[container root] (ms/create-root!)]
+              (-> (render! root view false)
+                  (.then (fn [_]
+                           (is (false? (popover-open? container))
+                               (str label ": a closed desired state stays out of the top layer"))
+                           (render! root view true)))
+                  (.then (fn [_]
+                           (is (true? (popover-open? container))
+                               (str label ": an open desired state joined the top layer at layout time"))
+                           (ms/destroy-root! container root)
+                           nil)))))
+          done)))))
+
+;; ===========================================================================
+;; Row 3 — reconciliation follows a flipped desired state
+;; ===========================================================================
+
+(deftest top-layer-matrix-reconciliation-follows-the-desired-state-in-both-modes
+  (testing "The element's top-layer membership FOLLOWS its declared desired
+            state across re-renders: open, then closed, then open again —
+            the substrate reconciles each flip rather than latching. In each
+            mode."
+    (if-not (and (ms/browser?) (top-layer?))
+      (ms/skip! "the browser job runs the reconciliation assertions")
+      (async done
+        (ms/each-mode
+          popover-modes
+          (fn [[label view]]
+            (setup!)
+            (let [[container root] (ms/create-root!)]
+              (-> (render! root view true)
+                  (.then (fn [_]
+                           (is (true? (popover-open? container)) (str label ": opened"))
+                           (render! root view false)))
+                  (.then (fn [_]
+                           (is (false? (popover-open? container))
+                               (str label ": a closed desired state reconciled it OUT"))
+                           (render! root view true)))
+                  (.then (fn [_]
+                           (is (true? (popover-open? container))
+                               (str label ": and an open desired state reconciled it back IN"))
+                           (ms/destroy-root! container root)
+                           nil)))))
+          done)))))
+
+;; ===========================================================================
+;; Row 4 — a modal opens as a real :modal dialog
+;; ===========================================================================
+
+(deftest top-layer-matrix-a-modal-opens-and-closes-in-both-modes
+  (testing "A `<dialog>` whose desired state is open is a real MODAL — it
+            matches `:modal` and reports `open` — and a closed desired state
+            reconciles it shut. A modal is a distinct top-layer intrinsic
+            from a popover, so it earns its own row. In each mode."
+    (if-not (and (ms/browser?) (top-layer?))
+      (ms/skip! "the browser job runs the modal assertions")
+      (async done
+        (ms/each-mode
+          modal-modes
+          (fn [[label view]]
+            (setup!)
+            (let [[container root] (ms/create-root!)]
+              (-> (render! root view true)
+                  (.then (fn [_]
+                           (is (true? (.-open (el container))) (str label ": the dialog reports open"))
+                           (is (true? (modal-open? container))
+                               (str label ": and it is a real :modal dialog in the top layer"))
+                           (render! root view false)))
+                  (.then (fn [_]
+                           (is (false? (.-open (el container)))
+                               (str label ": a closed desired state reconciled the modal shut"))
+                           (ms/destroy-root! container root)
+                           nil)))))
+          done)))))


### PR DESCRIPTION
F6b, Gate 2 of the Freehand donor-deletion gate (EP-0036 §6, the "browser correctness" row): comprehensive **real-browser** correctness matrices validating Freehand view correctness across a matrix of **view shapes × BOTH execution modes** (interpreted vs compiled), so the two modes are proven to agree and each is individually correct.

All eight matrices are new browser-test files under `implementation/freehand/test/re_frame/freehand/` (namespaces end `-dom-cljs-test`, so they ride the Playwright browser lane in CI), plus one shared support namespace `matrix_support.cljs`. They exercise the **shipped emitters** — no emitter, `root.cljs`, or `spec/API.md` change. Rebased onto the settled emitter-parity cluster (#6847) and green against it.

## Matrix dimensions covered

- **Areas (8):** controlled input · keyed presence + accessibility · DOM top layer + layout timing · registered behaviors (command/commit/replay/cleanup) · error containment · route-link native behavior · roots + teardown · fallback hydration.
- **Execution mode:** interpreted vs compiled, per shape. Where both modes are meaningful the two lowerings are mounted and their real DOM compared for parity (a canonical tag/attribute/text `outline`). Where a form is refused by the compiled grammar the honest cell is documented: `v/behavior` is interpreted-only (compiled refusal proven in `pilot-overlay-parity` / `slots-grammar-parity`); `v/error-boundary` guards a throwing view only in an interpreted/owning view, so its mode dimension is the **child** (a throwing interpreted vs compiled child, contained identically).
- **Attribute-lowering parity (validates the #6847 cluster):** runtime `<select multiple>` empty value (`rf2-sf9n5`, direct + `v/spread-safe` split), `v/spread-safe` guarded caller (`rf2-drpa3.132`), routed `:class` one-map collision (`rf2-c9kus`). The class-compose cell asserts only **cross-mode agreement** on the rendered `class` — not a pinned value — since the one-map rule is owned by `rf2-c9kus` / Spec 004B; green against the settled emitter and stays green whatever that bead rules.
- **Cleanup is EXACT counts** (behaviors: `connection-count`/`target-ids` -> exactly 0 vs a behavior-free control; roots: `live-root-ids`/`frame-ledger-snapshot`/sub-cache ref-count -> exactly 0). **Accessibility** (dynamic `aria-hidden`/`inert`/roles, focus) is owned by the real-browser presence and controlled-input cells per acceptance 2.

## The eight matrices (named tests, enumerated individually)

**1. Controlled input** — `controlled-input-matrix-dom-cljs-test`
- `controlled-matrix-both-modes-build-the-same-controlled-line`
- `controlled-matrix-a-keystroke-burst-echoes-in-both-modes`
- `controlled-matrix-a-mid-string-insert-keeps-the-caret-in-both-modes`
- `controlled-matrix-the-busy-control-disables-in-both-modes`
- `controlled-matrix-a-runtime-multiple-select-agrees-across-modes` (direct + `v/spread-safe`)
- `controlled-matrix-spread-safe-folds-the-caller-across-modes`
- `controlled-matrix-routed-class-one-map-agrees-across-modes`

**2. Keyed presence + accessibility** — `presence-matrix-dom-cljs-test`
- `presence-matrix-both-modes-mount-the-same-stack`
- `presence-matrix-a-departed-key-is-retained-and-hides-itself-in-both-modes`
- `presence-matrix-re-entry-before-the-flush-cancels-removal-in-both-modes`

**3. DOM top layer + layout timing** — `top-layer-matrix-dom-cljs-test`
- `top-layer-matrix-both-modes-build-the-same-popover-element`
- `top-layer-matrix-a-popover-promotes-at-layout-time-in-both-modes`
- `top-layer-matrix-reconciliation-follows-the-desired-state-in-both-modes`
- `top-layer-matrix-a-modal-opens-and-closes-in-both-modes`

**4. Registered behaviors (command/commit/replay/cleanup)** — `behavior-matrix-dom-cljs-test`
- `behavior-matrix-a-committed-render-connects-once-and-claims-its-target`
- `behavior-matrix-a-command-reaches-its-target-and-refuses-otherwise`
- `behavior-matrix-update-observes-movement-not-renders`
- `behavior-matrix-teardown-releases-everything-to-exact-zero` (EXACT counts)
- `behavior-matrix-the-compiled-tier-refuses-the-behavior-boundary` (mode cell: documented refusal)

**5. Error containment** — `error-matrix-dom-cljs-test`
- `error-matrix-a-throwing-child-is-contained-and-reported-in-both-modes`
- `error-matrix-recovery-follows-a-changed-reset-key-in-both-modes`
- `error-matrix-both-child-modes-are-contained-the-same-way`

**6. Route-link native behavior** — `route-link-matrix-dom-cljs-test`
- `route-link-matrix-mounts-a-real-anchor-with-a-resolved-href-in-both-modes`
- `route-link-matrix-a-plain-click-navigates-in-both-modes`
- `route-link-matrix-native-clicks-keep-native-behaviour-in-both-modes` (modifier / download / target)
- `route-link-matrix-both-modes-build-the-same-anchor`

**7. Roots + teardown** — `root-matrix-dom-cljs-test`
- `root-matrix-a-minimal-root-mounts-and-tears-down-in-both-modes`
- `root-matrix-an-owned-frame-tears-down-to-exact-zero-in-both-modes` (EXACT counts)
- `root-matrix-multi-root-identity-in-both-modes`
- `root-matrix-both-modes-build-the-same-root-dom`

**8. Fallback hydration** — `hydration-matrix-dom-cljs-test`
- `hydration-matrix-matching-markup-is-adopted-by-identity-in-both-modes`
- `hydration-matrix-an-empty-container-falls-back-in-both-modes`
- `hydration-matrix-both-modes-adopt-the-same-dom`

## Quality gates

All run foreground to completion in the worker worktree, after rebasing onto current `origin/main` (with the #6847 emitter-parity cluster merged); the browser shadow-cljs `config:` banner names this worktree.

- `npm run test:browser` (the F6b lane — these matrices are browser tests): **Ran 737 tests containing 4565 assertions. 0 failures, 0 errors.** EXIT=0
- `npm run test:freehand` (node): **Ran 950 tests containing 5481 assertions. 0 failures, 0 errors.** EXIT=0
- `clojure -M:test` (JVM freehand): **Ran 885 tests containing 6369 assertions. 0 failures, 0 errors.** EXIT=0

No new correctness beads filed — the matrices are green across both modes against the settled emitter; no cell needed a post-#6847 expectation change.

Closes rf2-drpa3.54.
