### PR TITLE
build(fast-pr): skip irrelevant runtime suites on docs-only diffs via the changed-surface classifier (rf2-r6x1t)

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -58,7 +58,7 @@ The classifier maps "what files changed" → "which expensive jobs fire." The fu
 
 ## The 4 tier scenarios
 
-1. **Agent pre-checkin** — `scripts/test-fast-pr.sh` plus the surface-specific commands for the files touched (find them in the Kinds table).
+1. **Agent pre-checkin** — `scripts/test-fast-pr.sh` plus the surface-specific commands for the files touched (find them in the Kinds table). The spine tiers itself the same way PR CI does: it reuses the changed-surface classifier below to decide which runtime suites its diff owns (`implementation_jvm` → core JVM; `cljs_node_test` → the npm/CLJS/JS-harness/isolation suites), runs the documentation gates when the diff touches documentation content, and keeps the cheap static/drift checks always-on. A documentation- or EP-only diff therefore runs static + doc gates and skips every runtime suite; `--all` (or `RF2_FAST_PR_ALL=1`) runs the complete spine regardless (rf2-r6x1t).
 2. **PR CI** — `.github/workflows/test.yml`. Always: lockstep + skill/MCP drift, core JVM, CLJS node integration, JS harness self-tests, docs link validation on docs PRs. Expensive jobs fire only on their changed surface, and browser gates run their smoke tiers.
 3. **Nightly / manual** — `.github/workflows/expensive-tests.yml`. The rigorous browser/bundle matrix, unconditional all-examples compile, full Story/Xray sweeps, template smoke, live MCP conformance.
 4. **Release** — `.github/workflows/release.yml` plus the latest green expensive run on the release candidate.
@@ -84,7 +84,7 @@ This axis is revisited at API-freeze / external-alpha prep, alongside the facade
 
 | Command | Scope |
 |---|---|
-| `scripts/test-fast-pr.sh` | The fast PR spine: lockstep, skill/MCP drift, core JVM, JS harness self-tests, CLJS node integration. |
+| `scripts/test-fast-pr.sh` | The fast PR spine: always-on lockstep + skill/MCP + drift checks, plus the documentation gates and the runtime suites (core JVM, JS harness self-tests, CLJS node integration, per-namespace isolation) **tiered on the changed-surface classifier** — a docs/EP-only diff skips the runtime suites. `--all` / `RF2_FAST_PR_ALL=1` forces the complete spine; `--plan` prints the tier decision without running anything. |
 | `scripts/test-jvm-implementation.sh` | All implementation JVM artefacts (including adapter probes). |
 | `scripts/test-jvm-tools.sh` | Tool JVM artefacts. |
 | `scripts/test-rigorous-local.sh` | Local mirror of the nightly sweep (spine + JVM + browser/bundle/Story/Xray + examples-compile; inventory pinned by a self-test). Use before release-sized changes. |
@@ -131,6 +131,8 @@ To see exactly what a diff fires, run the script — it is executable truth, and
 .github/scripts/report-changed-surfaces.sh implementation/core/src/foo.cljs
 .github/scripts/report-changed-surfaces.sh --all
 ```
+
+**The local fast spine reuses this same script**, not a second map: `scripts/test-fast-pr.sh` gathers its diff (committed vs `origin/main` + staged + unstaged + untracked), feeds the paths to the classifier as explicit args, and gates the core JVM suite on `implementation_jvm` and the npm/CLJS/JS-harness/isolation suites on `cljs_node_test` — the same outputs test.yml's `jvm-core` and `cljs` jobs gate on. Local selection stays aligned with CI by construction; run `scripts/test-fast-pr.sh --plan` to see the tier decision for the current diff.
 
 ## Diagnostic / skip-ok gates
 

--- a/scripts/_test_fixtures/test_fast_pr_docs_gate/README.md
+++ b/scripts/_test_fixtures/test_fast_pr_docs_gate/README.md
@@ -1,27 +1,39 @@
-# test_fast_pr_docs_gate self-test (rf2-lwweq)
+# test_fast_pr_docs_gate self-test (rf2-lwweq, extended rf2-r6x1t)
 
-Self-test for the markdown-change detection logic in
-`scripts/test-fast-pr.sh`.  Run with:
+Self-test for the changed-surface tiering in `scripts/test-fast-pr.sh`.
+Run with:
 
 ```bash
 bash scripts/_test_fixtures/test_fast_pr_docs_gate/run-self-test.sh
 ```
 
+The harness drives the **real** spine in `--plan` mode (which classifies the
+change set, prints one `PLAN docs=… jvm=… node=…` line, and runs nothing) via
+`--repo-root DIR` against disposable git repos. It does **not** replicate the
+detection logic — the earlier harness copied the markdown-diff block inline,
+which could drift from the spine.
+
 The harness covers:
 
-* Detection-logic cases (A–D) — committed `.md` diff vs `origin/main`,
-  unstaged `.md` changes, `--no-docs` override, `--with-docs` override.
-* Gate-has-teeth cases (E–F) — `check_doc_slugs.py` + `check_readme_links.py`
-  exit non-zero on bundled broken fixtures.
-* Motivating-miss reproductions — minimal mkdocs-rooted repos that
-  reproduce the defect shapes from #2232
-  (`#trace-events-1` vs pymdownx's `#trace-events_1` underscore-N
-  disambiguation) and #2233 (anchor missing the `-rf2-XXX` suffix the
-  heading actually carries).  Both must trip `check_doc_slugs.py`.
+* **Git-state cases (A–D)** — committed docs diff vs `origin/main`, staged code,
+  unstaged docs, untracked docs — the four states the change-set gathering must
+  handle deterministically.
+* **Tiering cases (E–H)** — an unknown surface falls back to the full runtime
+  run; a clean tree runs static checks only; a missing `origin/main` base falls
+  back conservatively; a mixed docs+code diff runs both tiers.
+* **Override cases (I–L)** — `--all` and `RF2_FAST_PR_ALL=1` run the complete
+  spine regardless of classification; `--with-docs` / `--no-docs` force the
+  documentation tier on/off.
+* **Gate-has-teeth cases (M–N)** — `check_doc_slugs.py` + `check_readme_links.py`
+  exit non-zero on the bundled broken fixtures.
+* **Motivating-miss reproductions (O–P)** — minimal mkdocs-rooted repos that
+  reproduce the defect shapes from #2232 (`#trace-events-1` vs pymdownx's
+  `#trace-events_1` underscore-N disambiguation) and #2233 (anchor missing the
+  `-rf2-XXX` suffix the heading actually carries). Both must trip
+  `check_doc_slugs.py`.
 
-Why a hand-rolled harness instead of extending an existing test
-runner? The spine is plain bash invoked from POSIX environments
-(Mac/Linux CI + Windows Git Bash workers); pulling in pytest or the JS
-harness for a 200-line detection check would add more surface than the
-test exercises.  Keep dependencies to bash + python + git + the
-already-present link validators.
+Why a hand-rolled bash harness instead of extending the JS test runner? The
+spine is plain bash invoked from POSIX environments (Mac/Linux CI + Windows Git
+Bash workers); pulling in pytest or the JS harness for a change-set tiering
+check would add more surface than the test exercises. Keep dependencies to
+bash + python + git + the already-present link validators.

--- a/scripts/_test_fixtures/test_fast_pr_docs_gate/run-self-test.sh
+++ b/scripts/_test_fixtures/test_fast_pr_docs_gate/run-self-test.sh
@@ -1,19 +1,27 @@
 #!/usr/bin/env bash
-# Self-test for the markdown-change detection in scripts/test-fast-pr.sh
-# (rf2-lwweq).
+# Self-test for the changed-surface tiering in scripts/test-fast-pr.sh
+# (rf2-r6x1t, extends rf2-lwweq).
 #
-# This isolates the detection-and-conditional-run logic — it does NOT
-# invoke the full spine (which would re-run lockstep + CLJS tests for
-# many minutes).  Instead we extract the detection block + the
-# conditional invocations into a tiny harness and assert four cases:
+# It drives the REAL spine in `--plan` mode against disposable git repos —
+# NOT a replicated copy of the detection logic (the previous harness copied
+# the markdown-diff block inline, which could silently drift from the spine).
+# `--plan` classifies the change set and prints one machine-readable line —
+#   PLAN docs=<bool> jvm=<bool> node=<bool>
+# — then exits without running any gate, so the assertions are fast and
+# deterministic.  `--repo-root DIR` points the change-set gathering at a
+# disposable fixture repo while the real gate scripts stay put.
 #
-#   case A — no markdown diff, --auto      → markdown gates skipped
-#   case B — markdown diff present, --auto → markdown gates run
-#   case C — --no-docs flag → markdown gates skipped regardless of diff
-#   case D — --with-docs flag → markdown gates run regardless of diff
-#
-# We also assert the gates actually catch a known-broken anchor (case E)
-# and a broken README target (case F), proving the gate has teeth.
+# Cases:
+#   committed docs / staged code / unstaged docs / untracked docs  — the four
+#     git states the change-set gathering must handle deterministically;
+#   unknown surface                — conservative fallback runs the full runtime;
+#   no changes                     — static checks only;
+#   no origin/main base            — conservative fallback (indeterminate);
+#   --all / RF2_FAST_PR_ALL / --with-docs / --no-docs — the overrides;
+#   gate-has-teeth (E/F)           — the doc validators exit non-zero on the
+#     bundled broken fixtures;
+#   motivating misses (#2232/#2233) — the pymdownx slug shapes that first
+#     motivated the doc gate still trip check_doc_slugs.py.
 #
 # Run from any cwd:
 #   bash scripts/_test_fixtures/test_fast_pr_docs_gate/run-self-test.sh
@@ -50,45 +58,19 @@ assert() {
   fi
 }
 
-# ---------------------------------------------------------------------------
-# Detection-logic harness.
-#
-# We replicate the detection block from test-fast-pr.sh against a clean
-# disposable git repo so the spine's behaviour on a real diff is testable
-# without actually running the expensive gates.
-# ---------------------------------------------------------------------------
-
 tmp_root="$(mktemp -d 2>/dev/null || mktemp -d -t 'test-fast-pr-detect')"
 trap 'rm -rf "$tmp_root"' EXIT
 
-detect_md_change() {
-  # Args: $1 = repo path; $2 = with_docs mode (auto|force|skip)
-  local repo="$1"
-  local with_docs="$2"
-  if [ "$with_docs" = "force" ]; then
-    printf 'true\n'
-    return
-  fi
-  if [ "$with_docs" = "skip" ]; then
-    printf 'false\n'
-    return
-  fi
-  local markdown_changed=false
-  if git -C "$repo" rev-parse --verify origin/main >/dev/null 2>&1; then
-    if git -C "$repo" diff --name-only origin/main HEAD 2>/dev/null | grep -qE '\.md$'; then
-      markdown_changed=true
-    fi
-  fi
-  if git -C "$repo" status --porcelain 2>/dev/null | grep -qE '\.md$'; then
-    markdown_changed=true
-  fi
-  printf '%s\n' "$markdown_changed"
+# The spine's PLAN line for a disposable repo (extra args pass through to it).
+plan() {
+  local root="$1"; shift
+  bash "$spine" --plan --repo-root "$root" "$@" 2>/dev/null | grep '^PLAN ' || printf 'PLAN <none>\n'
 }
 
-# Build a fake repo with origin/main fixed at HEAD and one non-md committed
-# change on top — represents a "no markdown diff vs origin/main, no
-# unstaged md" state.
-init_repo_no_md() {
+# Disposable repo with origin/main pinned at an initial commit, so the
+# committed-branch diff (origin/main...HEAD) and the working-tree/untracked
+# signals are all exercisable.
+mkrepo() {
   local r="$1"
   mkdir -p "$r"
   git -C "$r" init -q -b main 2>/dev/null
@@ -97,107 +79,113 @@ init_repo_no_md() {
   # Silence CRLF auto-conversion warnings on Windows Git Bash.
   git -C "$r" config core.autocrlf false
   git -C "$r" config core.safecrlf false
-  printf 'first\n' > "$r/initial.txt"
-  git -C "$r" add initial.txt
-  git -C "$r" commit -q -m 'initial'
-  # Fake origin/main pointing at this commit.
+  mkdir -p "$r/seed"
+  printf 'x\n' > "$r/seed/f.txt"
+  git -C "$r" add seed/f.txt
+  git -C "$r" commit -q -m 'init'
   git -C "$r" update-ref refs/remotes/origin/main HEAD
-  # One non-md change on top.
-  printf 'second\n' >> "$r/initial.txt"
-  git -C "$r" add initial.txt
-  git -C "$r" commit -q -m 'non-md change'
 }
 
-# Build a fake repo with a committed .md change on top of origin/main.
-init_repo_committed_md() {
-  local r="$1"
-  init_repo_no_md "$r"
-  printf '# changed\n' > "$r/notes.md"
-  git -C "$r" add notes.md
-  git -C "$r" commit -q -m 'add markdown'
-}
+# ---- Case A: committed docs-only diff vs origin/main → docs only ----
+r="$tmp_root/committed-docs"; mkrepo "$r"
+mkdir -p "$r/docs/core"; printf '# h\n' > "$r/docs/core/x.md"
+git -C "$r" add docs/core/x.md; git -C "$r" commit -q -m docs
+assert "A committed docs-only → docs only" "PLAN docs=true jvm=false node=false" "$(plan "$r")"
 
-# Build a fake repo with an UNSTAGED .md change (worktree dirty, no
-# commit beyond origin/main).
-init_repo_unstaged_md() {
-  local r="$1"
-  init_repo_no_md "$r"
-  printf '# unstaged\n' > "$r/dirty.md"
-  # Deliberately do NOT git add; we want porcelain to show '??'.
-}
+# ---- Case B: staged code diff → runtime suites ----
+r="$tmp_root/staged-code"; mkrepo "$r"
+mkdir -p "$r/implementation/core/src/re_frame"
+printf 'x\n' > "$r/implementation/core/src/re_frame/core.cljc"
+git -C "$r" add implementation/core/src/re_frame/core.cljc   # staged, not committed
+assert "B staged core code → runtime" "PLAN docs=false jvm=true node=true" "$(plan "$r")"
 
-# ---- Case A: no md, --auto ----
-case_a="$tmp_root/case-a"
-init_repo_no_md "$case_a"
-assert "case A (no md, --auto)" "false" "$(detect_md_change "$case_a" auto)"
+# ---- Case C: unstaged docs change (tracked, modified, not staged) → docs ----
+r="$tmp_root/unstaged-docs"; mkrepo "$r"
+mkdir -p "$r/spec"; printf '# a\n' > "$r/spec/006.md"
+git -C "$r" add spec/006.md; git -C "$r" commit -q -m addmd
+git -C "$r" update-ref refs/remotes/origin/main HEAD
+printf '# a\nmore\n' > "$r/spec/006.md"                       # unstaged modify
+assert "C unstaged docs → docs only" "PLAN docs=true jvm=false node=false" "$(plan "$r")"
 
-# ---- Case B1: committed md vs origin/main, --auto ----
-case_b1="$tmp_root/case-b1"
-init_repo_committed_md "$case_b1"
-assert "case B1 (committed md vs origin/main, --auto)" "true" "$(detect_md_change "$case_b1" auto)"
+# ---- Case D: untracked docs file → docs ----
+r="$tmp_root/untracked-docs"; mkrepo "$r"
+printf '# u\n' > "$r/NOTES.md"                                # untracked, never added
+assert "D untracked docs → docs only" "PLAN docs=true jvm=false node=false" "$(plan "$r")"
 
-# ---- Case B2: unstaged md, --auto ----
-case_b2="$tmp_root/case-b2"
-init_repo_unstaged_md "$case_b2"
-assert "case B2 (unstaged md, --auto)" "true" "$(detect_md_change "$case_b2" auto)"
+# ---- Case E: unknown surface → conservative full runtime ----
+r="$tmp_root/unknown"; mkrepo "$r"
+printf 'x\n' > "$r/weird.xyz"; git -C "$r" add weird.xyz
+assert "E unknown surface → conservative runtime" "PLAN docs=false jvm=true node=true" "$(plan "$r")"
 
-# ---- Case C: md present, --no-docs ----
-case_c="$tmp_root/case-c"
-init_repo_committed_md "$case_c"
-assert "case C (md present, --no-docs)" "false" "$(detect_md_change "$case_c" skip)"
+# ---- Case F: no changes vs origin/main, clean tree → static only ----
+r="$tmp_root/clean"; mkrepo "$r"
+assert "F no changes → static only" "PLAN docs=false jvm=false node=false" "$(plan "$r")"
 
-# ---- Case D: no md, --with-docs ----
-case_d="$tmp_root/case-d"
-init_repo_no_md "$case_d"
-assert "case D (no md, --with-docs)" "true" "$(detect_md_change "$case_d" force)"
+# ---- Case G: no origin/main base → conservative fallback ----
+r="$tmp_root/nobase"; mkdir -p "$r"
+git -C "$r" init -q -b main 2>/dev/null
+git -C "$r" config user.email "self-test@local"; git -C "$r" config user.name "self-test"
+git -C "$r" config core.autocrlf false; git -C "$r" config core.safecrlf false
+printf 'x\n' > "$r/f.txt"; git -C "$r" add -A; git -C "$r" commit -q -m init
+assert "G no origin/main → conservative runtime" "PLAN docs=false jvm=true node=true" "$(plan "$r")"
+
+# ---- Case H: mixed docs + code → both tiers ----
+r="$tmp_root/mixed"; mkrepo "$r"
+mkdir -p "$r/docs" "$r/implementation/core/src/re_frame"
+printf '# h\n' > "$r/docs/x.md"
+printf 'x\n' > "$r/implementation/core/src/re_frame/core.cljc"
+git -C "$r" add -A; git -C "$r" commit -q -m mix
+assert "H mixed docs+code → both tiers" "PLAN docs=true jvm=true node=true" "$(plan "$r")"
+
+# ---- Case I: --all override runs the complete spine on a docs-only diff ----
+r="$tmp_root/override-all"; mkrepo "$r"
+mkdir -p "$r/docs"; printf '# h\n' > "$r/docs/x.md"; git -C "$r" add -A; git -C "$r" commit -q -m d
+assert "I --all override → everything" "PLAN docs=true jvm=true node=true" "$(plan "$r" --all)"
+
+# ---- Case J: RF2_FAST_PR_ALL=1 override runs the complete spine ----
+assert "J RF2_FAST_PR_ALL=1 override → everything" "PLAN docs=true jvm=true node=true" \
+  "$(RF2_FAST_PR_ALL=1 bash "$spine" --plan --repo-root "$r" 2>/dev/null | grep '^PLAN ')"
+
+# ---- Case K: --with-docs forces docs on for a code-only diff ----
+r="$tmp_root/with-docs"; mkrepo "$r"
+mkdir -p "$r/implementation/core/src/re_frame"
+printf 'x\n' > "$r/implementation/core/src/re_frame/core.cljc"; git -C "$r" add -A; git -C "$r" commit -q -m c
+assert "K --with-docs on code diff → docs forced on" "PLAN docs=true jvm=true node=true" "$(plan "$r" --with-docs)"
+
+# ---- Case L: --no-docs forces docs off for a docs diff ----
+r="$tmp_root/no-docs"; mkrepo "$r"
+mkdir -p "$r/docs"; printf '# h\n' > "$r/docs/x.md"; git -C "$r" add -A; git -C "$r" commit -q -m d
+assert "L --no-docs on docs diff → docs forced off" "PLAN docs=false jvm=false node=false" "$(plan "$r" --no-docs)"
 
 # ---------------------------------------------------------------------------
-# Gate-has-teeth tests.
-#
-# We exercise the actual link/anchor validators against the bundled
-# broken fixtures and assert they exit non-zero — proving that when the
-# detection block decides "run the gates", the gates would actually
-# catch the motivating regressions.
+# Gate-has-teeth tests.  When the tiering decides "run the doc gates", the
+# validators must actually catch the motivating regressions.
 # ---------------------------------------------------------------------------
-
 slugs_script="$repo_root/scripts/check_doc_slugs.py"
 readme_script="$repo_root/scripts/check_readme_links.py"
 
-# ---- Case E: check_doc_slugs catches a broken anchor ----
 broken_anchor_fixture="$repo_root/scripts/_test_fixtures/check_doc_slugs/broken_anchor"
 if [ -d "$broken_anchor_fixture" ]; then
   python "$slugs_script" --repo-root "$broken_anchor_fixture" >/dev/null 2>&1
-  rc=$?
-  assert "case E (check_doc_slugs catches broken anchor)" "1" "$rc"
+  assert "M check_doc_slugs catches broken anchor" "1" "$?"
 else
-  printf '  SKIP case E: fixture %s not found\n' "$broken_anchor_fixture"
+  printf '  SKIP M: fixture %s not found\n' "$broken_anchor_fixture"
 fi
 
-# ---- Case F: check_readme_links catches a broken target ----
 broken_readme_fixture="$repo_root/scripts/_test_fixtures/check_readme_links/broken_internal_link"
 if [ -d "$broken_readme_fixture" ]; then
   python "$readme_script" --repo-root "$broken_readme_fixture" --ci >/dev/null 2>&1
-  rc=$?
-  assert "case F (check_readme_links catches broken target)" "1" "$rc"
+  assert "N check_readme_links catches broken target" "1" "$?"
 else
-  printf '  SKIP case F: fixture %s not found\n' "$broken_readme_fixture"
+  printf '  SKIP N: fixture %s not found\n' "$broken_readme_fixture"
 fi
 
 # ---------------------------------------------------------------------------
-# Motivating-miss verification.
-#
-# Build a tiny mkdocs-rooted repo that reproduces #2232's defect shape
-# (anchor #trace-events-1 vs heading-derived slug trace-events_1) and
-# #2233's defect shape (anchor without the (rf2-XXX) suffix the heading
-# carries), then assert the validators flag both.
+# Motivating-miss verification.  Reproduce #2232 (pymdownx `_1` disambiguation
+# vs GitHub `-1`) and #2233 (anchor missing the `-rf2-XXX` heading suffix); both
+# must trip check_doc_slugs.py.
 # ---------------------------------------------------------------------------
-
-# #2232 reproduction — duplicate "Trace events" heading where the
-# second occurrence gets pymdownx's `_1` suffix; an author referencing
-# it with GitHub-style `-1` would slip through GitHub preview but fail
-# on the MkDocs build.
-case_2232="$tmp_root/case-2232"
-mkdir -p "$case_2232/docs"
+case_2232="$tmp_root/case-2232"; mkdir -p "$case_2232/docs"
 cat > "$case_2232/mkdocs.yml" <<'EOF'
 site_name: test
 EOF
@@ -218,14 +206,9 @@ First occurrence — slug is `trace-events`.
 Second occurrence — pymdownx slug is `trace-events_1` (underscore N).
 EOF
 python "$slugs_script" --repo-root "$case_2232" >/dev/null 2>&1
-rc_2232=$?
-assert "#2232 motivating miss (trace-events-1 vs trace-events_1)" "1" "$rc_2232"
+assert "O #2232 (trace-events-1 vs trace-events_1)" "1" "$?"
 
-# #2233 reproduction — heading with bead suffix `## Foo (rf2-2qit)`,
-# pymdownx slug is `foo-rf2-2qit`; an author who writes `#foo` (without
-# the suffix) gets a broken anchor.
-case_2233="$tmp_root/case-2233"
-mkdir -p "$case_2233/docs"
+case_2233="$tmp_root/case-2233"; mkdir -p "$case_2233/docs"
 cat > "$case_2233/mkdocs.yml" <<'EOF'
 site_name: test
 EOF
@@ -243,8 +226,7 @@ Body — heading slug is `cljs-reference-helix-as-alternative-substrate-rf2-2qit
 NOT `cljs-reference-helix-as-alternative-substrate`.
 EOF
 python "$slugs_script" --repo-root "$case_2233" >/dev/null 2>&1
-rc_2233=$?
-assert "#2233 motivating miss (anchor missing -rf2-XXX suffix)" "1" "$rc_2233"
+assert "P #2233 (anchor missing -rf2-XXX suffix)" "1" "$?"
 
 # ---- Summary ----
 total=$((pass_count + fail_count))

--- a/scripts/test-fast-pr.sh
+++ b/scripts/test-fast-pr.sh
@@ -3,52 +3,119 @@ set -euo pipefail
 
 # Fast pre-checkin spine for the canonical agent quality gate.
 #
-# Mirrors CI's PR-gate matrix so workers see local failures BEFORE pushing.
-# When the working tree's diff vs origin/main (or unstaged changes) touches
-# any .md file, the spine additionally runs the markdown link/anchor
-# validators that CI runs.  Workers were repeatedly pushing green-locally
-# branches that failed on CI link/anchor breaks (#2232 + #2233 in one
-# hour on 2026-05-27) — this gate closes that gap (rf2-lwweq).
+# Mirrors CI's PR-gate matrix so workers see local failures BEFORE pushing —
+# and mirrors CI's *tiering* too: the heavy runtime suites (core JVM, the
+# CLJS node-test build, the JS harness self-tests, per-namespace isolation)
+# and the documentation gates run ONLY when the changed surface actually
+# owns them, exactly as test.yml job-gates them on the changed-surface
+# classifier.  A documentation- or EP-only diff therefore runs the cheap
+# always-on static/drift checks plus the documentation gates and NOTHING
+# heavier — no JVM, no npm/CLJS, no per-namespace runtime (rf2-r6x1t).
+#
+# HOW THE TIERING IS DECIDED — no second map.  The runtime tier is delegated
+# WHOLESALE to the very classifier CI uses,
+# `.github/scripts/report-changed-surfaces.sh`, invoked with the changed-file
+# list as explicit paths (it prints `key=value` to stdout when GITHUB_OUTPUT
+# is unset).  `implementation_jvm` gates the core JVM suite exactly as it
+# gates test.yml's jvm-core job; `cljs_node_test` gates the npm/CLJS/JS-harness/
+# isolation suites exactly as it gates test.yml's cljs job.  Reusing that one
+# script — rather than re-deriving a divergent surface map here — is what keeps
+# local selection aligned with test.yml by construction.  The documentation
+# tier keys on documentation CONTENT (Markdown + the MkDocs config + the
+# doc-checker scripts those gates run); it is deliberately separate from the
+# runtime classifier because the doc gates validate prose, not code.
 #
 # Usage:
-#   scripts/test-fast-pr.sh              auto-detect markdown diff
-#   scripts/test-fast-pr.sh --with-docs  force-run the markdown gates
-#   scripts/test-fast-pr.sh --no-docs    skip markdown gates even if .md changed
+#   scripts/test-fast-pr.sh              classify the diff; run only the
+#                                        owning tiers (+ always-on checks)
+#   scripts/test-fast-pr.sh --all        run the COMPLETE spine regardless of
+#                                        classification (env: RF2_FAST_PR_ALL=1)
+#   scripts/test-fast-pr.sh --with-docs  force the documentation gates on
+#   scripts/test-fast-pr.sh --no-docs    force the documentation gates off
+#   scripts/test-fast-pr.sh --plan       print the tier decision and exit,
+#                                        running nothing (deterministic dry-run)
 #
-# Markdown-gate components:
-#   1. python scripts/check_readme_links.py     — README anchor + target validator
-#   2. python scripts/check_doc_slugs.py        — docs corpus anchor validator
-#   3. python scripts/check_ep_status_sync.py   — docs/EP index status-sync guard
-#   4. mkdocs build --strict (when mkdocs on PATH; soft-skip on Windows when not)
+# The change set is gathered deterministically from every git state: the
+# committed branch diff vs origin/main (three-dot merge-base), the staged +
+# unstaged working tree (`git diff HEAD`), and untracked files
+# (`git ls-files --others`).  If origin/main cannot be resolved, or the change
+# set contains a file no known surface recognises, the spine falls back
+# conservatively to the COMPLETE runtime run rather than risk under-testing.
+#
+# Documentation-gate components (run when a documentation surface changes):
+#   1. python scripts/check_readme_links.py            — README anchor + target
+#   2. python scripts/check_doc_slugs.py               — docs corpus anchors
+#   3. python scripts/check_ep_status_sync.py          — docs/EP index status-sync
+#   4. python scripts/check_runtime_subsystem_grading.py — EP-0006 grading table
+#   5. mkdocs build --strict (when mkdocs on PATH; soft-skip when not)
 
-repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# The spine's own tree (scripts, gate commands, the shared classifier) is
+# always derived from this script's location.  `--repo-root` overrides ONLY
+# the tree the change set is gathered from — used by the self-test harness to
+# classify disposable fixture repos without moving the real gate scripts.
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+spine_root="$(cd "$script_dir/.." && pwd)"
+diff_root="$spine_root"
+classifier="$spine_root/.github/scripts/report-changed-surfaces.sh"
 
-with_docs="auto"
-for arg in "$@"; do
-  case "$arg" in
+with_docs="auto"     # auto | force | skip
+run_all=false
+plan_only=false
+if [ "${RF2_FAST_PR_ALL:-}" = "1" ]; then
+  run_all=true
+fi
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -a|--all)    run_all=true ;;
     --with-docs) with_docs="force" ;;
     --no-docs)   with_docs="skip" ;;
+    --plan|--dry-run) plan_only=true ;;
+    --repo-root)
+      shift
+      if [ "$#" -eq 0 ]; then
+        printf 'error: --repo-root requires a directory argument\n' >&2
+        exit 2
+      fi
+      diff_root="$(cd "$1" && pwd)"
+      ;;
     -h|--help)
       cat <<EOF
-fast PR pre-checkin spine
+fast PR pre-checkin spine (rf2-r6x1t)
 
 Usage:
-  $(basename "$0") [--with-docs|--no-docs]
+  $(basename "$0") [--all] [--with-docs|--no-docs] [--plan] [--repo-root DIR]
+
+Runtime tiers are gated on the SAME changed-surface classifier CI uses
+(.github/scripts/report-changed-surfaces.sh): the core JVM suite runs when
+implementation_jvm is set, and the npm/CLJS/JS-harness/isolation suites run
+when cljs_node_test is set.  The documentation gates run when the diff
+touches documentation content.  The cheap static/drift checks always run.
 
 Flags:
-  --with-docs   always run the markdown link/anchor + mkdocs --strict gates
-  --no-docs     skip markdown gates even when the diff touches .md
-  (default)     auto-detect: run markdown gates iff diff vs origin/main
-                OR unstaged changes touch any .md file
+  --all, -a     run the COMPLETE spine regardless of classification
+                (also enabled by RF2_FAST_PR_ALL=1) — the explicit override
+  --with-docs   force the documentation gates on
+  --no-docs     force the documentation gates off
+  --plan        print the tier decision (docs/jvm/node) and exit; run nothing
+  --repo-root DIR   gather the change set from DIR instead of the spine tree
+                    (test hook; does not move the real gate scripts)
+  (default)     classify the diff and run only the owning tiers
 EOF
       exit 0
       ;;
     *)
-      printf 'unknown flag: %s\n' "$arg" >&2
+      printf 'unknown flag: %s\n' "$1" >&2
       exit 2
       ;;
   esac
+  shift
 done
+
+if [ ! -x "$classifier" ] && [ ! -f "$classifier" ]; then
+  printf 'error: changed-surface classifier not found at %s\n' "$classifier" >&2
+  exit 2
+fi
 
 run() {
   local surface="$1"
@@ -81,43 +148,174 @@ run_soft() {
   fi
 }
 
-# ---- markdown-change detection ----
-# Two signals:
-#   1. committed diff vs origin/main touches *.md
-#   2. unstaged or staged working-tree changes touch *.md
-# Either signal → markdown gates run (unless --no-docs).
-markdown_changed=false
-if [ "$with_docs" = "force" ]; then
-  markdown_changed=true
-elif [ "$with_docs" = "skip" ]; then
-  markdown_changed=false
-else
-  if git -C "$repo_root" rev-parse --verify origin/main >/dev/null 2>&1; then
-    if git -C "$repo_root" diff --name-only origin/main HEAD 2>/dev/null | grep -qE '\.md$'; then
-      markdown_changed=true
+# ---------------------------------------------------------------------------
+# Change-set gathering — deterministic across every git state.
+#
+#   committed branch : git diff --no-renames origin/main...HEAD  (merge-base)
+#   staged + unstaged: git diff --no-renames HEAD                (worktree vs HEAD)
+#   untracked        : git ls-files --others --exclude-standard
+#
+# `--no-renames` matches the CI classifier: a pure rename emits BOTH endpoints
+# (a deletion of the old surface + an addition of the new), so a rename OUT of
+# a runtime surface still arms that surface's gate.
+# ---------------------------------------------------------------------------
+base_resolved=false
+if git -C "$diff_root" rev-parse --verify origin/main >/dev/null 2>&1; then
+  base_resolved=true
+fi
+
+gather_changed_files() {
+  {
+    if [ "$base_resolved" = true ]; then
+      git -C "$diff_root" diff --no-renames --name-only origin/main...HEAD 2>/dev/null || true
     fi
-  fi
-  if git -C "$repo_root" status --porcelain 2>/dev/null | grep -qE '\.md$'; then
-    markdown_changed=true
+    git -C "$diff_root" diff --no-renames --name-only HEAD 2>/dev/null || true
+    git -C "$diff_root" ls-files --others --exclude-standard 2>/dev/null || true
+  } | sed '/^[[:space:]]*$/d' | sort -u
+}
+
+changed_files="$(gather_changed_files)"
+
+# Documentation-surface predicate.  A gate that validates documentation CONTENT
+# runs when the diff touches Markdown, the MkDocs toolchain config, or one of
+# the doc-checker scripts / fixtures the gates themselves execute.  This mirrors
+# how the classifier arms a gate whenever its own gate-script changes, and how
+# docs.yml keys the MkDocs build on documentation paths.
+is_doc_surface_path() {
+  case "$1" in
+    *.md) return 0 ;;
+    mkdocs.yml|mkdocs_hooks.py|requirements.txt) return 0 ;;
+    scripts/check_readme_links.py|scripts/check_doc_slugs.py) return 0 ;;
+    scripts/check_ep_status_sync.py|scripts/check_runtime_subsystem_grading.py) return 0 ;;
+    scripts/_test_fixtures/check_readme_links/*|scripts/_test_fixtures/check_doc_slugs/*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+doc_surface=false
+if [ -n "$changed_files" ]; then
+  while IFS= read -r file; do
+    [ -z "$file" ] && continue
+    if is_doc_surface_path "$file"; then
+      doc_surface=true
+      break
+    fi
+  done <<< "$changed_files"
+fi
+
+# ---- runtime tier, delegated to the CI classifier ----
+# Feed the changed-file list to report-changed-surfaces.sh as explicit paths;
+# it prints `key=value` for every surface when GITHUB_OUTPUT is unset.  We read
+# `implementation_jvm` (core JVM) and `cljs_node_test` (npm/CLJS/JS-harness/
+# isolation), and note whether ANY surface was recognised at all.
+impl_jvm=false
+cljs_node=false
+recognised_surface=false
+classifier_failed=false
+
+if [ -n "$changed_files" ]; then
+  # Build the argv array portably (avoid `mapfile` — bash 4 only; macOS ships
+  # bash 3.2).  One path per line; the change set never contains blank lines.
+  _changed_arr=()
+  while IFS= read -r _f; do
+    [ -n "$_f" ] && _changed_arr+=("$_f")
+  done <<< "$changed_files"
+  if classify_out="$(GITHUB_OUTPUT='' bash "$classifier" "${_changed_arr[@]}" 2>/dev/null)"; then
+    while IFS='=' read -r key value; do
+      case "$key" in
+        implementation_jvm) impl_jvm="$value" ;;
+        cljs_node_test)     cljs_node="$value" ;;
+      esac
+    done <<< "$classify_out"
+    if printf '%s' "$classify_out" | grep -q '=true'; then
+      recognised_surface=true
+    fi
+  else
+    classifier_failed=true
   fi
 fi
 
+# ---- resolve the three tiers, honouring overrides + conservative fallback ----
+run_jvm=false
+run_node=false
+run_docs=false
+plan_reason="classified"
 
-# ---- existing gates ----
+if [ "$run_all" = true ]; then
+  run_jvm=true
+  run_node=true
+  run_docs=true
+  plan_reason="override (--all)"
+elif [ "$base_resolved" != true ] || [ "$classifier_failed" = true ]; then
+  # Indeterminate: no origin/main base to diff against, or the classifier
+  # itself failed.  Fall back to the complete runtime run rather than risk
+  # under-testing.  (Documentation gates still key on the doc surface.)
+  run_jvm=true
+  run_node=true
+  run_docs="$doc_surface"
+  if [ "$base_resolved" != true ]; then
+    plan_reason="conservative fallback (origin/main unresolved)"
+  else
+    plan_reason="conservative fallback (classifier error)"
+  fi
+elif [ -z "$changed_files" ]; then
+  # Nothing changed vs origin/main and a clean working tree — only the cheap
+  # always-on static checks are meaningful.
+  plan_reason="no changes (static checks only)"
+elif [ "$recognised_surface" != true ] && [ "$doc_surface" != true ]; then
+  # Unknown surface: the change set is non-empty but matches no runtime surface
+  # AND no documentation surface.  Conservatively run the full runtime spine.
+  run_jvm=true
+  run_node=true
+  plan_reason="conservative fallback (unknown surface)"
+else
+  [ "$impl_jvm" = true ] && run_jvm=true
+  [ "$cljs_node" = true ] && run_node=true
+  run_docs="$doc_surface"
+fi
+
+# Documentation-gate overrides apply last, on top of any decision above.
+case "$with_docs" in
+  force) run_docs=true ;;
+  skip)  run_docs=false ;;
+esac
+
+if [ "$plan_only" = true ]; then
+  printf 'fast-pr plan\n'
+  printf '  documentation gates: %s\n' "$([ "$run_docs" = true ] && echo run || echo skip)"
+  printf '  core JVM suite:      %s\n' "$([ "$run_jvm" = true ] && echo run || echo skip)"
+  printf '  node/CLJS suite:     %s\n' "$([ "$run_node" = true ] && echo run || echo skip)"
+  printf '  reason:              %s\n' "$plan_reason"
+  printf 'PLAN docs=%s jvm=%s node=%s\n' "$run_docs" "$run_jvm" "$run_node"
+  exit 0
+fi
+
+printf '=== fast PR spine: docs=%s jvm=%s node=%s (%s) ===\n' \
+  "$run_docs" "$run_jvm" "$run_node" "$plan_reason"
+
+# ---------------------------------------------------------------------------
+# ALWAYS-ON static / drift checks.
+#
+# Cheap, repo-wide, pure-Python (plus the version-lockstep shell guard).  These
+# mirror CI's always-on jobs (verify-version-lockstep, the repo-invariant
+# python job, verify-readme-links) and run on every diff regardless of tier —
+# the drift they catch can be introduced by a directory add/remove or a source
+# rename that never touches the tier that owns it.
+# ---------------------------------------------------------------------------
 run "lockstep version drift" "./.github/scripts/verify-version-lockstep.sh" \
-  bash -lc "tmp='$repo_root/.github/scripts/.verify-version-lockstep.tmp.'\$\$; trap 'rm -f \"\$tmp\"' EXIT; tr -d '\r' < '$repo_root/.github/scripts/verify-version-lockstep.sh' > \"\$tmp\"; bash \"\$tmp\""
+  bash -lc "tmp='$spine_root/.github/scripts/.verify-version-lockstep.tmp.'\$\$; trap 'rm -f \"\$tmp\"' EXIT; tr -d '\r' < '$spine_root/.github/scripts/verify-version-lockstep.sh' > \"\$tmp\"; bash \"\$tmp\""
 
 run "skill/MCP allowed-tools drift" "python scripts/check_skill_mcp_drift.py --verbose --ci" \
-  python "$repo_root/scripts/check_skill_mcp_drift.py" --verbose --ci
+  python "$spine_root/scripts/check_skill_mcp_drift.py" --verbose --ci
 
 # Cite-integrity guard (rf2-1nb8k): every M-id the re-frame-migration skill
 # cites must name a consistent rule in MIGRATION.md.  Catches the id-collision /
 # phantom-cite class (skill cited M-66/M-67 for rules MIGRATION.md assigned to
 # History-states / Xray-static-mode).  Runs unconditionally — fast pure-Python,
 # and the drift can be introduced by a MIGRATION.md *heading* edit that the
-# markdown-diff gate below also sees but doesn't semantically check.
+# documentation-surface gate below also sees but doesn't semantically check.
 run "skill migration cite-integrity" "python scripts/check_skill_migration_cites.py --verbose --ci" \
-  python "$repo_root/scripts/check_skill_migration_cites.py" --verbose --ci
+  python "$spine_root/scripts/check_skill_migration_cites.py" --verbose --ci
 
 # Foundation-order guard (rf2-708nm): the re-frame2-implementor skill must keep
 # Spec 015 (Data Classification — v1-required) inside the core-complete gate.
@@ -126,10 +324,10 @@ run "skill migration cite-integrity" "python scripts/check_skill_migration_cites
 # without the required privacy/large-payload elision surface.  Self-test first
 # (proves the guard fires on the drift shapes), then the live scan.
 run "implementor order-guard self-test" "python scripts/check_skill_implementor_order.py --self-test" \
-  python "$repo_root/scripts/check_skill_implementor_order.py" --self-test
+  python "$spine_root/scripts/check_skill_implementor_order.py" --self-test
 
 run "implementor foundation-order" "python scripts/check_skill_implementor_order.py --verbose --ci" \
-  python "$repo_root/scripts/check_skill_implementor_order.py" --verbose --ci
+  python "$spine_root/scripts/check_skill_implementor_order.py" --verbose --ci
 
 # Eval-docs drift guard (rf2-r2xswa; generalised rf2-xw7ra9): each packaged
 # skill's eval harness README carries a hand-maintained coverage table, total
@@ -141,17 +339,17 @@ run "implementor foundation-order" "python scripts/check_skill_implementor_order
 # both README shapes), then the live scan asserts each README agrees with its
 # JSON.
 run "eval-docs guard self-test" "python scripts/check_skill_eval_docs.py --self-test" \
-  python "$repo_root/scripts/check_skill_eval_docs.py" --self-test
+  python "$spine_root/scripts/check_skill_eval_docs.py" --self-test
 
 run "skill eval-docs match evals.json" "python scripts/check_skill_eval_docs.py --verbose --ci" \
-  python "$repo_root/scripts/check_skill_eval_docs.py" --verbose --ci
+  python "$spine_root/scripts/check_skill_eval_docs.py" --verbose --ci
 
 # README inventory ratchet (rf2-198k3): layout-map<->disk bijection +
 # 'N <noun>' count-numeral claims.  Runs unconditionally (not gated on a
-# markdown diff) because the drift it catches can be triggered by a *dir*
+# documentation diff) because the drift it catches can be triggered by a *dir*
 # add/remove that never touches an .md file.  Fast + pure-Python.
 run "README inventory ratchet" "python scripts/check_readme_inventories.py" \
-  python "$repo_root/scripts/check_readme_inventories.py"
+  python "$spine_root/scripts/check_readme_inventories.py"
 
 # EP-0007 §Enforcement retired-spelling gate (rf2-ziak6w): a retired spelling
 # reappearing in framework source is a CI failure, not a doc note.  Catches
@@ -165,10 +363,10 @@ run "README inventory ratchet" "python scripts/check_readme_inventories.py" \
 # stays green on every sanctioned counterpart), then the live scan asserts
 # framework source is clean.  See scripts/check_retired_spellings.py.
 run "retired-spelling gate self-test" "python scripts/check_retired_spellings.py --self-test" \
-  python "$repo_root/scripts/check_retired_spellings.py" --self-test
+  python "$spine_root/scripts/check_retired_spellings.py" --self-test
 
 run "retired-spelling gate (EP-0007)" "python scripts/check_retired_spellings.py --verbose" \
-  python "$repo_root/scripts/check_retired_spellings.py" --verbose
+  python "$spine_root/scripts/check_retired_spellings.py" --verbose
 
 # Thrown-error human-message corpus gate (rf2-6bb3pg, Spec 009 §The thrown-error
 # shape / rf2-vvixub): a framework `(ex-info …)` whose MESSAGE is a bare
@@ -180,10 +378,10 @@ run "retired-spelling gate (EP-0007)" "python scripts/check_retired_spellings.py
 # the conformant counterparts), then the live scan asserts framework source is
 # clean.  See scripts/check_thrown_error_messages.py.
 run "thrown-error message gate self-test" "python scripts/check_thrown_error_messages.py --self-test" \
-  python "$repo_root/scripts/check_thrown_error_messages.py" --self-test
+  python "$spine_root/scripts/check_thrown_error_messages.py" --self-test
 
 run "thrown-error message gate (rf2-vvixub)" "python scripts/check_thrown_error_messages.py --verbose" \
-  python "$repo_root/scripts/check_thrown_error_messages.py" --verbose
+  python "$spine_root/scripts/check_thrown_error_messages.py" --verbose
 
 # re-frame.ui Root lifecycle projection guard (rf2-vxgfnd.291): the exact
 # failed-first-mount rollback ordering, three-state settlement law, three
@@ -192,10 +390,10 @@ run "thrown-error message gate (rf2-vvixub)" "python scripts/check_thrown_error_
 # intentional (not a general prose parser). Self-test first mutates every tooth
 # independently, then the live scan catches code/spec/doc drift.
 run "UI Root lifecycle drift self-test" "python scripts/check_ui_root_lifecycle_drift.py --self-test" \
-  python "$repo_root/scripts/check_ui_root_lifecycle_drift.py" --self-test
+  python "$spine_root/scripts/check_ui_root_lifecycle_drift.py" --self-test
 
 run "UI Root lifecycle drift" "python scripts/check_ui_root_lifecycle_drift.py --ci" \
-  python "$repo_root/scripts/check_ui_root_lifecycle_drift.py" --ci
+  python "$spine_root/scripts/check_ui_root_lifecycle_drift.py" --ci
 
 # EP-0010 §Validation/Conformance ambient-durable-read gate (rf2-f2t151): a
 # direct ambient host read (clock / RNG / browser fact) written into a DURABLE
@@ -211,53 +409,37 @@ run "UI Root lifecycle drift" "python scripts/check_ui_root_lifecycle_drift.py -
 # sanctioned counterpart), then the live scan asserts the durable-write
 # namespaces are clean.  See scripts/check_ambient_durable_reads.py.
 run "ambient-durable-read gate self-test" "python scripts/check_ambient_durable_reads.py --self-test" \
-  python "$repo_root/scripts/check_ambient_durable_reads.py" --self-test
+  python "$spine_root/scripts/check_ambient_durable_reads.py" --self-test
 
 run "ambient-durable-read gate (EP-0010)" "python scripts/check_ambient_durable_reads.py --verbose" \
-  python "$repo_root/scripts/check_ambient_durable_reads.py" --verbose
+  python "$spine_root/scripts/check_ambient_durable_reads.py" --verbose
 
-run "core JVM" "cd implementation/core && clojure -M:test" \
-  bash -lc "cd '$repo_root/implementation/core' && clojure -M:test"
-
-run "implementation JS harness helpers" "cd implementation && npm run test:script-policy && npm run test:script-helpers" \
-  bash -lc "cd '$repo_root/implementation' && npm run test:script-policy && npm run test:script-helpers"
-
-run "CLJS node integration" "cd implementation && npm run test:cljs" \
-  bash -lc "cd '$repo_root/implementation' && npm run test:cljs"
-
-# Per-namespace test-isolation gate (rf2-32siq3.44).  The consolidated
-# node-test bundle shares ONE runtime, so a test ns whose fixture forgets to
-# install its own substrate adapter is masked: it passes whenever a sibling
-# left an adapter installed (suite ORDERING hides a self-incomplete fixture).
-# This gate re-runs the curated EP-0023 image/frame runtime-construction
-# namespaces EACH ALONE; a fixture leaning on bundle pollution goes red
-# standalone.  Self-test first (proves the red/green classification), then the
-# live run (reuses the bundle test:cljs just compiled).
-run "per-ns isolation self-test" "cd implementation && node scripts/check-per-ns-isolation.cjs --self-test" \
-  bash -lc "cd '$repo_root/implementation' && node scripts/check-per-ns-isolation.cjs --self-test"
-
-run "per-ns test isolation" "cd implementation && node scripts/check-per-ns-isolation.cjs" \
-  bash -lc "cd '$repo_root/implementation' && node scripts/check-per-ns-isolation.cjs"
-
-# ---- conditional markdown gates ----
-if [ "$markdown_changed" = "true" ]; then
-  printf '\n--- markdown changes detected → running link/anchor gates ---\n'
+# ---------------------------------------------------------------------------
+# Documentation gates (run when a documentation surface changes).
+#
+# The local mirror of CI's verify-readme-links (always-on) + docs.yml
+# (MkDocs / link / status-sync / grading) — validators of documentation
+# CONTENT.  Skipped on a code-only diff; forced on/off with --with-docs /
+# --no-docs.
+# ---------------------------------------------------------------------------
+if [ "$run_docs" = true ]; then
+  printf '\n--- documentation surface changed → running link/anchor/status gates ---\n'
 
   run "README link/anchor validator" "python scripts/check_readme_links.py --ci" \
-    python "$repo_root/scripts/check_readme_links.py" --ci
+    python "$spine_root/scripts/check_readme_links.py" --ci
 
   run "docs corpus anchor validator" "python scripts/check_doc_slugs.py" \
-    python "$repo_root/scripts/check_doc_slugs.py"
+    python "$spine_root/scripts/check_doc_slugs.py"
 
   # EP index status-sync guard (rf2-8cw3m7): docs/EP/README.md restates each
   # EP's Status: line in its index table; the two drift by hand (EP-0001 sat at
   # `accepted` while the index still said `proposal`).  Self-test first (proves
   # the guard fires on mismatch / missing-row / orphan-row), then the live scan.
   run "EP status-sync self-test" "python scripts/check_ep_status_sync.py --self-test" \
-    python "$repo_root/scripts/check_ep_status_sync.py" --self-test
+    python "$spine_root/scripts/check_ep_status_sync.py" --self-test
 
   run "EP status-sync" "python scripts/check_ep_status_sync.py" \
-    python "$repo_root/scripts/check_ep_status_sync.py"
+    python "$spine_root/scripts/check_ep_status_sync.py"
 
   # Runtime-subsystem grading drift guard (rf2-ba5acq, EP-0006): every reserved
   # `:rf.runtime/*` key (spec/Conventions.md §Reserved runtime-db keys) MUST
@@ -268,16 +450,57 @@ if [ "$markdown_changed" = "true" ]; then
   # extra-row / missing-clause / ungraded-clause / clause-order), then the live
   # scan.  See scripts/check_runtime_subsystem_grading.py.
   run "runtime-subsystem grading self-test" "python scripts/check_runtime_subsystem_grading.py --self-test" \
-    python "$repo_root/scripts/check_runtime_subsystem_grading.py" --self-test
+    python "$spine_root/scripts/check_runtime_subsystem_grading.py" --self-test
 
   run "runtime-subsystem grading drift" "python scripts/check_runtime_subsystem_grading.py" \
-    python "$repo_root/scripts/check_runtime_subsystem_grading.py"
+    python "$spine_root/scripts/check_runtime_subsystem_grading.py"
 
   run_soft "mkdocs --strict build" "mkdocs build --strict" mkdocs \
-    bash -lc "cd '$repo_root' && mkdocs build --strict"
+    bash -lc "cd '$spine_root' && mkdocs build --strict"
 else
-  printf '\n--- no markdown changes → skipping link/anchor gates (override with --with-docs) ---\n'
+  printf '\n--- documentation surface unchanged → skipping doc gates (override with --with-docs) ---\n'
 fi
 
+# ---------------------------------------------------------------------------
+# Core JVM suite — gated on implementation_jvm (test.yml's jvm-core).
+# ---------------------------------------------------------------------------
+if [ "$run_jvm" = true ]; then
+  run "core JVM" "cd implementation/core && clojure -M:test" \
+    bash -lc "cd '$spine_root/implementation/core' && clojure -M:test"
+else
+  printf '\n--- implementation_jvm surface unchanged → skipping core JVM (override with --all) ---\n'
+fi
+
+# ---------------------------------------------------------------------------
+# npm / CLJS / JS-harness / per-namespace isolation — gated on cljs_node_test
+# (test.yml's cljs job + the always-on js-harness-self-tests job).  CI keeps
+# the JS harness self-tests always-on as its safety net; locally we group them
+# with the node tier so a documentation- or code-elsewhere diff does not pay to
+# spin up node/npm, per the rf2-r6x1t DESIGN (JS suites run only when their
+# owning scripts / build config change — exactly the cljs_node_test surface).
+# ---------------------------------------------------------------------------
+if [ "$run_node" = true ]; then
+  run "implementation JS harness helpers" "cd implementation && npm run test:script-policy && npm run test:script-helpers" \
+    bash -lc "cd '$spine_root/implementation' && npm run test:script-policy && npm run test:script-helpers"
+
+  run "CLJS node integration" "cd implementation && npm run test:cljs" \
+    bash -lc "cd '$spine_root/implementation' && npm run test:cljs"
+
+  # Per-namespace test-isolation gate (rf2-32siq3.44).  The consolidated
+  # node-test bundle shares ONE runtime, so a test ns whose fixture forgets to
+  # install its own substrate adapter is masked: it passes whenever a sibling
+  # left an adapter installed (suite ORDERING hides a self-incomplete fixture).
+  # This gate re-runs the curated EP-0023 image/frame runtime-construction
+  # namespaces EACH ALONE; a fixture leaning on bundle pollution goes red
+  # standalone.  Self-test first (proves the red/green classification), then the
+  # live run (reuses the bundle test:cljs just compiled).
+  run "per-ns isolation self-test" "cd implementation && node scripts/check-per-ns-isolation.cjs --self-test" \
+    bash -lc "cd '$spine_root/implementation' && node scripts/check-per-ns-isolation.cjs --self-test"
+
+  run "per-ns test isolation" "cd implementation && node scripts/check-per-ns-isolation.cjs" \
+    bash -lc "cd '$spine_root/implementation' && node scripts/check-per-ns-isolation.cjs"
+else
+  printf '\n--- cljs_node_test surface unchanged → skipping npm/CLJS/isolation (override with --all) ---\n'
+fi
 
 printf 'PASS fast PR spine\n'


### PR DESCRIPTION
Aligns the local fast pre-checkin spine (`scripts/test-fast-pr.sh`) with CI's changed-surface tiering, so documentation / EP-only work is genuinely fast without weakening relevant coverage (rf2-r6x1t).

## What changed

- **Runtime tier delegated to the same classifier CI uses.** The spine gathers its diff and passes the changed-file list as explicit paths to `.github/scripts/report-changed-surfaces.sh` (which prints `key=value` to stdout when `GITHUB_OUTPUT` is unset). `implementation_jvm` gates the core JVM suite; `cljs_node_test` gates the npm / CLJS node-test / JS-harness / per-namespace-isolation suites — the **same outputs** `test.yml`'s `jvm-core` and `cljs` jobs gate on. There is no second surface map: local selection stays aligned with `test.yml` by construction.
- **Always-on static/drift checks stay always-on** (lockstep, skill/MCP drift, retired-spelling, thrown-error, ambient-durable-read, README inventory, …) — the cheap repo-wide invariants, mirroring CI's always-on jobs.
- **Documentation gates run only when the diff touches documentation content** (Markdown / MkDocs config / the doc-checker scripts those gates run).
- **Explicit full-run override:** `--all` (or `RF2_FAST_PR_ALL=1`) runs the complete spine regardless of classification. A new `--plan` prints the tier decision without running anything.
- **Deterministic change-set gathering** across committed (`origin/main...HEAD`), staged + unstaged (`git diff HEAD`), and untracked (`git ls-files --others`) states, with `--no-renames` matching the CI classifier. Conservative fallback to the full runtime run when `origin/main` is unresolved or a surface is unrecognised.
- Self-test rewritten to drive the **real** spine via `--plan --repo-root` (no more replicated detection block), plus `TESTING.md` + script help/comments updated.

**How classification is shared with CI:** the spine reuses `.github/scripts/report-changed-surfaces.sh` verbatim — the same classifier `test.yml`'s `detect_changed_surfaces` job runs — rather than maintaining a divergent map. The runtime tiers key on the identical `implementation_jvm` / `cljs_node_test` outputs.

## Quality gates

All run foreground from the worktree; exit codes are the verdict.

**Case (a) — docs-only diff skips runtime, runs doc + static gates** (real end-to-end run against a docs-only diff):

```
=== fast PR spine: docs=true jvm=false node=false (classified) ===
--- documentation surface changed → running link/anchor/status gates ---
--- implementation_jvm surface unchanged → skipping core JVM (override with --all) ---
--- cljs_node_test surface unchanged → skipping npm/CLJS/isolation (override with --all) ---
PASS fast PR spine
EXIT=0
```

23 gate invocations = the always-on static checks + the 5 documentation gates; **no** core JVM, **no** npm/CLJS.

**Case (b) — code diff runs the owning runtime suite** (`--plan` on an `implementation/core` diff):

```
PLAN docs=false jvm=true node=true   → EXIT=0
```

**Case (c) — override runs everything** (`--plan --all` on a docs-only diff):

```
PLAN docs=true jvm=true node=true   (reason: override (--all))   → EXIT=0
```

**Self-test harness** `scripts/_test_fixtures/test_fast_pr_docs_gate/run-self-test.sh` — committed / staged / unstaged / untracked git states, unknown-surface fallback, no-base fallback, mixed diff, `--all` / `RF2_FAST_PR_ALL` / `--with-docs` / `--no-docs`, gate-has-teeth, and the #2232/#2233 motivating misses:

```
16/16 self-test cases passed.   → EXIT=0
```

**Classifier contract** (unchanged, reused) — `node implementation/scripts/_changed-surfaces.test.cjs`:

```
changed-surfaces tests: 209 passed.   → EXIT=0
```

**Portability guard** — `sh scripts/check-no-hardcoded-paths.sh` → `Portability gate OK` (EXIT=0).

_Note: `implementation/node_modules` was not provisioned in this worktree, so the full `npm run test:script-policy` was represented by running its classifier arm (`_changed-surfaces.test.cjs`, Node built-ins only) directly; CI's always-on `js-harness-self-tests` job runs the complete `test:script-policy`._
