### PR TITLE
docs(freehand): reconcile root-ownership contract with the shipped live-incarnation-token rule (rf2-drpa3.110)

### DIFF
--- a/docs/api/re-frame.freehand.md
+++ b/docs/api/re-frame.freehand.md
@@ -152,7 +152,10 @@ elements — the child path is browser-only, like the mount verbs.
   (`:rf.error/duplicate-root-id`, `:rf.error/root-container-in-use`,
   `:rf.error/duplicate-identifier-prefix`) with the roots already on the page
   untouched. The `:frame` plan runs to completion before `createRoot`, so a body that
-  reads a subscription on its first render finds a frame that is already seeded.
+  reads a subscription on its first render finds a frame that is already seeded. A
+  config-bearing ENSURE meeting a frame already live whose incarnation this root cannot
+  prove it owns — a boot/external frame, or a same-id successor of the one it installed —
+  fails loud (`:scope-config-less-or-own-the-lifetime`) rather than taking it over.
   See [spec/004C-Roots-and-Mount.md](../../spec/004C-Roots-and-Mount.md#the-minimal-one-root-mount).
 - **Example**:
   ```clojure
@@ -214,8 +217,11 @@ elements — the child path is browser-only, like the mount verbs.
   unmounts, every ViewCell below it disconnects (releasing every dependency and
   retiring every published callback), and the root's reference to its frame is
   released. A frame the root **ENSUREd** is destroyed once no live root still
-  references it; a frame it merely **scoped** is left alone, because the root borrowed
-  it.
+  references it — and by the **exact incarnation** the install recorded, not the bare
+  frame-id, so a stale installer whose frame was already destroyed and re-created under
+  the same id, or a token-less legacy row a reload carried over, no-ops rather than
+  tearing down a successor it cannot prove it owns; a frame it merely **scoped** is left
+  alone, because the root borrowed it.
 
   **Guarded**, and a no-op rather than a throw when the guard fails: a root already
   unmounted, or superseded by a newer root claiming its id, has nothing left to

--- a/implementation/freehand/src/re_frame/freehand.cljc
+++ b/implementation/freehand/src/re_frame/freehand.cljc
@@ -660,8 +660,12 @@
   `:identifier-prefix`. Preflight: `:frame` — a frame-id keyword SCOPES a
   frame something else owns, a `make-frame` opts map carrying `:id`
   ENSUREs one the root owns for its lifetime, and either way the frame is
-  live before React sees anything. Host: React's `:on-uncaught-error` /
-  `:on-caught-error` / `:on-recoverable-error`.
+  live before React sees anything. A config-bearing ENSURE meeting a frame
+  already live whose incarnation this root cannot prove it owns — a
+  boot/external frame, or a same-id successor of the one it installed —
+  fails loud (`:scope-config-less-or-own-the-lifetime`) rather than taking
+  it over. Host: React's `:on-uncaught-error` / `:on-caught-error` /
+  `:on-recoverable-error`.
 
   A root claims its id, its container and its `identifierPrefix` in the
   per-document registry BEFORE it renders, so a collision on any of them
@@ -716,7 +720,11 @@
   below it disconnects (releasing every dependency, retiring every
   published callback), and the root's reference to its frame is released.
   A frame the root ENSUREd is DESTROYED once no live root still
-  references it; a frame the root merely scoped is left alone.
+  references it — and by the EXACT incarnation the install recorded, not
+  the bare frame-id, so a stale installer whose frame was already destroyed
+  and re-created under the same id, or a token-less legacy row a reload
+  carried over, no-ops rather than tearing down a successor it cannot prove
+  it owns; a frame the root merely scoped is left alone.
 
   GUARDED, and a no-op rather than a throw when the guard fails: a root
   already unmounted, or superseded by a newer root claiming its id, has

--- a/spec/004C-Roots-and-Mount.md
+++ b/spec/004C-Roots-and-Mount.md
@@ -505,9 +505,20 @@ root**. These are independent axes, and preflight keeps them independent: no pro
 may claim a root or its DOM committed merely because `root.render` returned, a host
 update was scheduled, or a frame remained live.
 
-**Authority — who may write the record.** An `:installed-by` record is root-OWNED: that
-root, and only that root, may refresh it (a same-root fingerprint change is the surgical
-HMR refresh above, not a conflict). An `:adopted-by` + `:adopted true` record merely
+**Authority — who may write the record.** An `:installed-by` record names the root that
+ENSUREd the frame, but that name alone does not prove the incarnation live under the id
+NOW is the one that root installed. Ownership is proven against the LIVE incarnation
+token: the value the install recorded carries the frame's `:rf.frame/incarnation-token`,
+and the record owns the current live frame only while that recorded token is identically
+the live frame's token. On that proof — and only on it — that root, and only that root,
+may refresh the record or take the ratified no-op (a same-root fingerprint change is the
+surgical HMR refresh above, not a conflict). A recorded token that names a torn-down
+incarnation — the installed frame was destroyed and re-created under the same id, so the
+row now names a same-id SUCCESSOR it never installed — proves nothing, and neither does a
+token-less legacy row a `defonce` ledger carried across a reload; a config-bearing plan
+that meets such a live-but-unprovable frame fails under the SAME
+`:scope-config-less-or-own-the-lifetime` recovery as the boot-authoritative case below.
+An `:adopted-by` + `:adopted true` record merely
 SCOPES a boot/external frame — adoption is create-if-absent scoping and never transfers
 ownership. A config-BEARING plan that meets a boot-authoritative frame (plan-less and
 live, or already adopted) therefore fails the arriving root with
@@ -850,13 +861,22 @@ different lifetimes:
 
 The ENSURE shape creates the frame if it is absent and drains its
 `:initial-events`; meeting the same plan again is the ratified idempotent
-no-op, and re-seeding is precisely what it must not do. The SCOPE shape
-creates nothing, and a target naming no live frame fails loud rather than
-scoping every read below the root to a frame that is not there.
+no-op, and re-seeding is precisely what it must not do — but the no-op is
+admitted only while the root can PROVE it still owns the incarnation live
+under the id (§7.1): the value its install recorded carries the live
+frame's current `:rf.frame/incarnation-token`. An equal fingerprint over a
+frame the root can no longer prove it owns — the installed incarnation was
+destroyed and re-created under the same id by external code, or a
+token-less legacy row survived a reload — is NOT a no-op; it fails loud
+under `:scope-config-less-or-own-the-lifetime`, before `make-frame` and
+before React, rather than silently adopting a successor the root never
+installed. The SCOPE shape creates nothing, and a target naming no live
+frame fails loud rather than scoping every read below the root to a frame
+that is not there.
 
 Plans meeting one frame are reconciled by the §7 rule, unchanged: an equal
-config fingerprint is the no-op, and a DIFFERENT fingerprint recorded by a
-DIFFERENT root fails **that root** with
+config fingerprint over a PROVEN-owned incarnation is the no-op, and a
+DIFFERENT fingerprint recorded by a DIFFERENT root fails **that root** with
 `:rf.error/frame-payload-conflict`, before install and before React. The
 installed frame and the roots already using it are untouched — a bad plan
 affects exactly the roots carrying it.
@@ -871,8 +891,16 @@ container or prefix claim; the host root is unmounted, so every ViewCell
 beneath it has disconnected and released every dependency it owned and
 retired every callback it published; and the root's reference to its frame
 is gone. A frame the root ENSUREd is DESTROYED once no live root still
-references it; a frame the root merely SCOPED is left exactly as it was
-found, because the root borrowed it.
+references it — and destroyed by the EXACT incarnation value the install
+recorded, never by the bare frame-id. The recorded value carries the
+installed incarnation's token, so teardown consumes precisely that
+incarnation: a stale installer whose frame was already destroyed and
+re-created under the same id no-ops rather than reaching through to kill
+the successor, and a token-less legacy row — one a `defonce` ledger carried
+across a reload without a recorded value — likewise leaves the live frame
+untouched rather than destroying an incarnation it cannot prove it owns. A
+frame the root merely SCOPED is left exactly as it was found, because the
+root borrowed it.
 
 The count that matters is zero, and it is asserted as zero — not as
 "small", and not as the absence of a visible symptom. A leak here is a


### PR DESCRIPTION
## What this reconciles

PR #6849 (commit c10815061c) changed Freehand root-frame ownership to be proven against the **live incarnation token** — the ledger row's recorded `:installed-value` must carry the frame's current `:rf.frame/incarnation-token`, identical to the live frame's token — not against a stored non-nil `:installed-by`. Several canonical/public docs still described the superseded installed-by rule and were **false** for a stale-token same-id successor or a token-less legacy row. This PR is documentation/spec honesty only — **no runtime, registry, migration, or API change**.

Reconciled surfaces (verified against the shipped `implementation/freehand/src/re_frame/freehand/root.cljs` — `owns-live-incarnation?`, the `preflight!` ownership arm, and `release-frame!` teardown):

- **`spec/004C` §7.1 (authority)** — an `:installed-by` record authorizes a same-root refresh or the ratified no-op **only while it can prove it owns the incarnation live under the id** (its recorded install value's token is identically the live frame's token). A recorded token naming a torn-down incarnation (a same-id successor) or a token-less legacy row proves nothing; a config-bearing plan meeting such a live-but-unprovable frame fails under `:scope-config-less-or-own-the-lifetime`.
- **`spec/004C` paved-path preflight** — the idempotent no-op is admitted only for a **proven-owned** incarnation; an equal fingerprint over a frame the root can no longer prove it owns fails loud (before `make-frame`, before React) rather than silently adopting a successor.
- **`spec/004C` Total teardown + the `re-frame.freehand` `mount` / `unmount!` docstrings + the `docs/api/re-frame.freehand.md` mirror** — teardown consumes the **exact recorded incarnation value**, never the bare frame-id, so a stale installer or a token-less legacy row **no-ops** rather than destroying an unproven successor.

No behaviour, arglists, or public vars changed; `spec/api-manifest.edn` is unmoved (drift `--check` clean, empty diff).

## Quality gates

All foreground, worktree-local, exit code is the verdict:

- `clojure -M -m re-frame.api-manifest.gen --check` — **EXIT=0** (`OK: spec/api-manifest.edn in sync (543 public vars)`; `spec/api-manifest.edn` diff empty — no regeneration needed).
- api-manifest `api-md-check` — **EXIT=0** (`OK: spec/API.md projection in sync (244 var-rows)`).
- api-manifest `doc-api-check` — **EXIT=0** (`OK: … docs/api/ … in sync (319 references)`; `docs/api page+member coverage in sync (221 vars)`).
- `python scripts/check_doc_slugs.py` — **EXIT=0**.
- `python -m mkdocs build --strict` — **EXIT=0** (documentation built; the emitted INFO lines are pre-existing and concern files not touched here).
