### PR TITLE
fix(freehand): emitter correctness — dead emit-view-def, compiled top-layer nil handler, compiled key-condition v/event (rf2-drpa3.108, .173, rf2-7x0ge)

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/compiler/emit_jvm.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/emit_jvm.cljc
@@ -479,11 +479,22 @@
                           :rf.ui/children? children?}
                    docstring   (assoc :doc docstring)
                    closed-keys (assoc :rf.ui/closed-prop-keys (vec closed-keys)))]
+    ;; The emitted view fn returns the structural `rendered` body directly.
+    ;; The donor's runtime boundary/registry wrappers —
+    ;; `re-frame.freehand.tree/view-boundary` and `.../register-view!` — were
+    ;; transplanted here with their CALL SITES, but the functions they name were
+    ;; never built: neither exists in `re-frame.freehand.tree`. Nothing on the
+    ;; live `v/defview` path reaches this emitter (it routes through
+    ;; `re-frame.freehand/expand-defview` -> `compile-structural-view` /
+    ;; `descriptor/declare-view`, which own boundary creation and view
+    ;; registration), so the two calls only ever rode this emitter's RETURNED
+    ;; FORM and were never in an evaluated one — which is why the compiled tier
+    ;; stayed green rather than failing at load with unresolved-var errors.
+    ;; Emitting a call to a function that does not exist violates this emitter's
+    ;; own law (emit only what can run, or refuse the shape loudly), so the dead
+    ;; wrappers are removed: the fn now returns the structural body, and
+    ;; registration/boundaries stay the live path's concern (rf2-drpa3.108).
     `(do
        (defn ~(vary-meta vname merge var-meta) [~props-sym]
-         (re-frame.freehand.tree/view-boundary
-          ~view-id
-          ~props-sym
-          ~(if bind `(let [~bind ~props-sym] ~rendered) rendered)))
-       (re-frame.freehand.tree/register-view! ~view-id ~vname (quote ~manifest))
+         ~(if bind `(let [~bind ~props-sym] ~rendered) rendered))
        (var ~vname))))

--- a/implementation/freehand/src/re_frame/freehand/compiler/emit_react.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/emit_react.cljc
@@ -99,16 +99,24 @@
   every promoted popover, and it reads no `:on-toggle` and accuses a
   declaration that does reconcile itself.
 
-  A handler rides as PRESENCE rather than as its callback. What the
-  advisory asks is whether the position is declared at all, and a
-  compiled site's callback is built inside the props form this map cannot
-  reach."
-  [props]
+  A reconciler handler rides as its runtime SOME?-VERDICT, not its callback
+  and not a bare compile-time presence: the site's dynamic body may evaluate
+  to nil, and the advisory judges reconciliation by `(some? (get attrs k))`.
+  So the context carries whether the runtime site actually produced a
+  handler — the `event-site` result the element's own `handler!` write
+  already computes, bound once and shared, so the callback itself never
+  rides the context and the expression is evaluated once (rf2-drpa3.173)."
+  [props reconciler-syms]
   (into (into {} (keep (fn [{:keys [k value]}]
                          (when (contains? top-layer/context-keys k) [k value])))
               (:attrs props))
         (keep (fn [{:keys [k]}]
-                (when (contains? top-layer/context-keys k) [k true])))
+                (when (contains? top-layer/context-keys k)
+                  ;; nil when the runtime site produced no handler, `true`
+                  ;; otherwise — the shared advisory asks `(some? (get attrs k))`,
+                  ;; so an absent handler must read as absent, not as a non-nil
+                  ;; `false`. The callback itself never rides the context.
+                  [k `(if (cljs.core/some? ~(get reconciler-syms k)) true nil)])))
         (:events props)))
 
 (defn- new-state [] (atom {:binds [] :n 0}))
@@ -274,13 +282,18 @@
      ~(:base safe) ~(:owned-handler-keys safe))))
 
 (defn- handler-writes
-  [o tag controlled? events]
+  "Attach each handler site's proxy. A reconciler handler on a promoted
+  top-layer element has already had its `event-site` bound (so its write and
+  the top-layer advisory context share ONE evaluation — rf2-drpa3.173);
+  reference that binding. Every other site builds its proxy inline."
+  [o tag controlled? events reconciler-syms]
   (mapv (fn [{:keys [k sid form] :as handler}]
           `(re-frame.freehand.compiled-react/handler!
             ~o
             ~(conv/react-event-name k)
-            (re-frame.freehand.reactive/event-site
-             ~sid ~form ~(element-facts tag controlled? handler))))
+            ~(or (get reconciler-syms k)
+                 `(re-frame.freehand.reactive/event-site
+                   ~sid ~form ~(element-facts tag controlled? handler)))))
         events))
 
 (defn- children-form
@@ -312,12 +325,32 @@
   [e st node]
   (let [{:keys [tag props children]} node
         all-attrs   (:attrs props)
-        top         (into {} (keep (fn [{:keys [k value]}]
+        top-pair    (into {} (keep (fn [{:keys [k value]}]
                                      (when (contains? top-layer-keys k) [k value])))
                           all-attrs)
-        top         (cond-> top (seq top) (into (top-layer-context props)))
         attrs       (remove (fn [{:keys [k]}] (contains? top-layer-keys k)) all-attrs)
         controlled? (controlled/controlled-props? (map :k attrs))
+        ;; A promoted top-layer element judges whether it reconciles its own
+        ;; native dismissal. On the compiled tier the reconciler handlers
+        ;; (:on-toggle / :on-before-toggle / :on-close / :on-cancel) are runtime
+        ;; SITES whose dynamic bodies may evaluate to nil, so their presence in
+        ;; the advisory context is a runtime some?-verdict, not a compile-time
+        ;; `true`. Bind each such site's `event-site` ONCE and share it with the
+        ;; `handler!` write, so the handler is evaluated once per render and the
+        ;; context reflects what actually reached the DOM (rf2-drpa3.173).
+        reconciler-events (when (seq top-pair)
+                            (filterv #(contains? top-layer/context-keys (:k %))
+                                     (:events props)))
+        reconciler-syms   (into {} (map (fn [{:keys [k]}] [k (gensym "rf-fh-top-h")]))
+                                reconciler-events)
+        reconciler-binds  (into []
+                                (mapcat (fn [{:keys [k sid form] :as h}]
+                                          [(get reconciler-syms k)
+                                           `(re-frame.freehand.reactive/event-site
+                                             ~sid ~form ~(element-facts tag controlled? h))]))
+                                reconciler-events)
+        top         (cond-> top-pair
+                      (seq top-pair) (into (top-layer-context props reconciler-syms)))
         ;; The multiple-select verdict for a LITERAL `multiple`, settled at
         ;; build time as the constant it is. It decides one thing: what an
         ;; EMPTY `<select>` value is. Acceptance of a collection value
@@ -390,7 +423,8 @@
                                        ~(if runtime-verdict? (nth dyn-syms i) value)
                                        ~multi-arg))
                                    dynamics))
-                      true (into (handler-writes o tag controlled? (:events props)))
+                      true (into (handler-writes o tag controlled? (:events props)
+                                                 reconciler-syms))
                       ;; Both forwards write LAST, and for the same reason: a
                       ;; forwarded map is folded against props that are already
                       ;; final. `v/spread` is the element's whole attribute map,
@@ -411,7 +445,9 @@
                       (conj `(cljs.core/unchecked-set ~o "key" ~(:expr key-info))))
         ;; Bindings, in evaluation order: owned dynamic values (source order),
         ;; then the guarded caller map (after the owned expressions), then the
-        ;; one verdict derived from both.
+        ;; one verdict derived from both — then each reconciler handler site,
+        ;; bound once so its `handler!` write and the top-layer advisory context
+        ;; share one evaluation (rf2-drpa3.173).
         binds       (cond-> []
                       runtime-verdict? (into (mapcat (fn [sym a] [sym (:value a)]) dyn-syms dynamics))
                       caller-sym       (conj caller-sym
@@ -424,7 +460,8 @@
                                   dyn-multi  (conj `(re-frame.freehand.controlled/multiple-select?
                                                      ~tag [[~(:k dyn-multi) ~dyn-multi-sym]] nil))
                                   caller-sym (conj `(re-frame.freehand.controlled/multiple-select?
-                                                     ~tag ~caller-sym nil))))))
+                                                     ~tag ~caller-sym nil)))))
+                      (seq reconciler-binds) (into reconciler-binds))
         props-form  (if (seq writes)
                       `(let [~o (cljs.core/js-obj ~@(mapcat identity literals))
                              ~@binds]

--- a/implementation/freehand/src/re_frame/freehand/node.cljc
+++ b/implementation/freehand/src/re_frame/freehand/node.cljc
@@ -487,16 +487,23 @@
   (boolean (some string? (keys m))))
 
 (defn- key-branch
-  "One BRANCH of a key-condition map, as the tree records it.
+  "Project one key-condition branch — ALREADY validated by
+  [[re-frame.freehand.events/event-plan]] against the one closed branch
+  grammar — into the value the tree records.
 
   A branch is a SITE, not a value inside one. The closed exact-key form
   (Spec 004 §Key-condition event maps) NAMES each branch and admits there
-  what the whole handler position admits, minus the roster forms that do
-  not dispatch: an event vector, an options map carrying `:event`, a
-  `v/event`, or nil. So the site rule reaches one level down with it — a
-  branch that IS a callback records the mode-neutral marker, exactly as a
-  whole handler carrying one does, while a non-data value nested INSIDE a
-  branch is still refused, at the branch that recorded it.
+  only the DISPATCHING forms: an event vector, an options map carrying
+  `:event`, a `v/event`, or nil. `v/handler`, a bare function, `v/render-fn`,
+  `v/raw-fn`, a nested key map, and a branch-local whole-listener option are
+  refused — but that refusal is the SHARED planner's, run by `classify-event`
+  before this projection, so the interpreted structural walk and the live
+  event planner cannot hold two branch grammars (rf2-7x0ge). Here the branch
+  is known legal, so this only decides how the tree RECORDS it: a `v/event`
+  carries a fn and records the mode-neutral opaque marker, exactly as a whole
+  handler carrying a callback does; an event vector, an options map, or nil
+  is data and is recorded verbatim, with a function nested INSIDE a data
+  branch still refused at the branch that recorded it.
 
   Walking a branch as ordinary data instead refused the whole element:
   `{\"Enter\" (v/event [e] …)}` is a spelling the compiled tier deliberately
@@ -504,7 +511,7 @@
   `:rf.error/ui-tree-malformed` for it in BOTH modes — no SSR and no
   headless render for a form the substrate itself writes."
   [tag k key-str branch]
-  (if (fn-carried? branch)
+  (if (events/callback? branch)
     {:rf.ui/opaque :fn}
     (do (when-let [[path bad] (non-data branch)]
           (let [path (into [key-str] path)]
@@ -560,10 +567,23 @@
                         {:attr k :path path :value (shape bad)}))
                     v)
     (map? v)    (if (key-condition-map? v)
-                  (reduce-kv (fn [m key-str branch]
-                               (assoc m key-str (key-branch tag k key-str branch)))
-                             {}
-                             v)
+                  ;; Validate the WHOLE key-condition map against the one closed
+                  ;; branch grammar through the shared planner (event-plan ->
+                  ;; branch-plan) BEFORE projecting it into the tree. Each branch
+                  ;; is an event vector, an options map carrying :event, a
+                  ;; v/event, or nil; v/handler, a bare fn, v/render-fn, v/raw-fn,
+                  ;; a nested key map, a branch-local whole-listener option, and a
+                  ;; mixed string/keyword map are all refused with the planner's
+                  ;; own typed :rf.error/view-bad-event category — not re-stated
+                  ;; here, so the interpreted structural walk (which reaches this
+                  ;; classify-event directly through tree/with-attrs) and the live
+                  ;; event planner cannot drift on what a branch admits (rf2-7x0ge).
+                  (do
+                    (events/event-plan v)
+                    (reduce-kv (fn [m key-str branch]
+                                 (assoc m key-str (key-branch tag k key-str branch)))
+                               {}
+                               v))
                   (do (when-let [[path bad] (non-data v)]
                         (malformed!
                           're-frame.freehand/render

--- a/implementation/freehand/test/re_frame/freehand/compiler_macro_resolution_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/compiler_macro_resolution_jvm_test.clj
@@ -346,6 +346,72 @@
                (emit-var-js aenv (symbol "cljs.user" (name verb))))
             (str "the qualified " verb " head resolves to the current-namespace Var"))))))
 
+;; ---------------------------------------------------------------------------
+;; rf2-drpa3.108 — the emitter may not name a re-frame.freehand var that does
+;; not exist. `emit-defview` used to wrap the view body in
+;; `re-frame.freehand.tree/view-boundary` and emit a
+;; `re-frame.freehand.tree/register-view!` call; NEITHER function was ever built
+;; (the donor's runtime was not transplanted with its call sites). The calls
+;; only ever rode `emit-defview`'s RETURNED form — the live `v/defview` path
+;; routes through `expand-defview` -> `compile-structural-view` /
+;; `descriptor/declare-view`, never here — so nothing evaluated the form and the
+;; tier stayed green rather than failing at load with unresolved-var errors.
+;; This positively enumerates the re-frame.freehand vars the emitter names and
+;; confirms each resolves, the method the bead asked for (absence of a failure
+;; was never evidence the emission could run).
+;; ---------------------------------------------------------------------------
+
+(defn- plain-emit-args
+  "emit-defview args for a plain (non-self) element template `[:div …]` in the
+  referred cljs.user namespace — the emitter under test, driven the way
+  `compiler/defview**` drives it, minus the self-recursion machinery."
+  [aenv vname template]
+  (let [e   (referred-env aenv vname)
+        ast (analyze/analyze e template)]
+    {:vname vname
+     :self-fqn (symbol "cljs.user" (name vname))
+     :view-id (keyword "cljs.user" (name vname))
+     :display-name (str "cljs.user/" (name vname))
+     :docstring nil
+     :header (header/parse-header [])
+     :slots []
+     :ast ast
+     :manifest {:view-id (keyword "cljs.user" (name vname)) :sites {} :children? false}
+     :closed-keys nil
+     :children? false}))
+
+(defn- freehand-qualified-syms
+  "Every namespace-qualified symbol in `form` whose namespace is one of
+  re-frame.freehand's own runtime namespaces — the class the emitter must not
+  name unless it resolves."
+  [form]
+  (let [acc (atom #{})]
+    (walk/postwalk
+     (fn [x]
+       (when (and (symbol? x)
+                  (some-> (namespace x) (.startsWith "re-frame.freehand")))
+         (swap! acc conj x))
+       x)
+     form)
+    @acc))
+
+(deftest emit-defview-names-no-unresolvable-freehand-var
+  (with-referred-cljs-env
+    (fn [aenv]
+      (let [form (emit-jvm/emit-defview
+                  (plain-emit-args aenv 'panel '[:div [:span "hi"]]))
+            fh   (freehand-qualified-syms form)]
+        (is (seq fh)
+            "the emitted view fn names re-frame.freehand runtime vars (node/element, node/children)")
+        (doseq [s fh]
+          (is (some? (requiring-resolve s))
+              (str s " must resolve — the emitter may not name a var that does not exist")))
+        (testing "the phantom donor wrappers are gone (rf2-drpa3.108)"
+          (is (not (contains? fh 're-frame.freehand.tree/view-boundary))
+              "the view-boundary wrapper that named a nonexistent fn is removed")
+          (is (not (contains? fh 're-frame.freehand.tree/register-view!))
+              "the register-view! call that named a nonexistent fn is removed"))))))
+
 ;; rf2-eukmp's rows analyzed and compiled the WHOLE emitted `(declare/defn/def)`
 ;; do-form through real cljs.analyzer + cljs.compiler, proving the view's own def
 ;; targeted the current-namespace Var rather than resolving its NAME through a

--- a/implementation/freehand/test/re_frame/freehand/key_condition_branch_structural_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/key_condition_branch_structural_cljs_test.cljc
@@ -31,6 +31,7 @@
   (:require [clojure.test :refer [deftest is testing]]
             [re-frame.freehand :as v]
             [re-frame.freehand.conformance :as conf]
+            [re-frame.freehand.events :as events]
             [re-frame.freehand.tree :as tree]))
 
 ;; ---------------------------------------------------------------------------
@@ -139,3 +140,45 @@
     (is (= {:on-key-down {"Enter" [:app/go 1 "ok"]}}
            (:events (tree/render [:input {:on-key-down {"Enter" [:app/go 1 "ok"]}}])))
         "and it is recorded as the data it is")))
+
+;; ---------------------------------------------------------------------------
+;; The branch grammar is the SHARED planner's, not a second local roster
+;; ---------------------------------------------------------------------------
+;;
+;; rf2-7x0ge AUDIT REOPEN. The first fix recorded EVERY fn-carried branch —
+;; bare functions and every Callback role — as the opaque marker, which admits
+;; declarations the live event planner refuses: a key branch names ONE intent,
+;; so `events/branch-plan` admits only an event vector, an options map carrying
+;; `:event`, a `v/event`, or nil, and refuses `v/handler`, a bare fn,
+;; `v/render-fn`, `v/raw-fn`, a nested key map, a branch-local whole-listener
+;; option, and a mixed string/keyword map. `classify-event` now validates the
+;; whole key-condition map through that SAME planner (`events/event-plan`)
+;; before projecting it, so the interpreted structural walk and the live event
+;; planner cannot hold two branch grammars. These exercise `tree/render`
+;; DIRECTLY — the path the missed upstream-validation assumption left
+;; unguarded — and pin it to the planner by proving the two agree id-for-id.
+
+(def ^:private refused-by-the-closed-branch-grammar
+  "One branch shape per way the closed grammar refuses a NON-dispatching or
+  malformed branch — each refused by the live `events/event-plan`, and now by
+  the structural walk with the SAME typed `:rf.error/view-bad-event` category."
+  [["a v/handler branch"           {"Enter" (v/handler [e] nil)}]
+   ["a bare-function branch"       {"Enter" (fn [_] nil)}]
+   ["a v/render-fn branch"         {"Enter" (v/render-fn [r] [:span r])}]
+   ["a nested key-map branch"      {"Enter" {"a" [:app/go]}}]
+   ["a branch-local :once option"  {"Enter" {:event [:app/go] :once true}}]
+   ["a mixed string/keyword map"   {"Enter" [:app/go] :once true}]])
+
+(deftest a-non-dispatching-branch-is-refused-with-the-shared-typed-category
+  (testing "The over-wide first fix opaqued any fn-carried branch and walked
+            the rest as data, so v/handler, a bare fn, and the mixed/nested
+            shapes rendered a clean structural tree the live event planner
+            rejects. Each is now refused with the planner's own typed category
+            — and the structural walk and the planner are proven to agree
+            id-for-id, so the grammar has ONE owner."
+    (doseq [[note branch-map] refused-by-the-closed-branch-grammar]
+      (let [form [:input {:on-key-down branch-map}]]
+        (is (= :rf.error/view-bad-event (conf/caught-id #(tree/render form)))
+            (str note " — refused structurally with the planner's typed category"))
+        (is (= :rf.error/view-bad-event (conf/caught-id #(events/event-plan branch-map)))
+            (str note " — the LIVE planner refuses the same value with the same id (no drift)"))))))

--- a/implementation/freehand/test/re_frame/freehand/react_lowering_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/react_lowering_jvm_test.clj
@@ -389,3 +389,76 @@
             "the :value write's verdict is the once-bound runtime verdict, not a constant")
         (is (not (false? verdict-arg))
             "and specifically NOT the build-time false the bug baked in")))))
+
+(deftest a-compiled-popover-carries-the-runtime-reconciliation-verdict
+  (testing "rf2-drpa3.173 — #6792 recorded every analyzed reconciler position
+            (:on-toggle / :on-close / …) as a compile-time `true` in the
+            top-layer advisory context. That is not the runtime predicate the
+            shared advisory uses: `reconciled?` asks `(some? (get attrs k))`,
+            and a DYNAMIC handler is allowed to evaluate to nil, in which case
+            `event-site` returns nil and `handler!` writes no DOM handler — yet
+            the compile-time `true` suppressed the advisory anyway, so the node
+            springs back open after native dismissal with nothing said. The
+            context must instead carry whether the runtime site produced a
+            handler, derived from the SAME bound site the handler write uses so
+            the authored expression is evaluated once."
+    (let [[e ast] (analyzed '[:div {:popover :auto
+                                    :re-frame.freehand.web/popover-open? true
+                                    :on-toggle (:on-tog props)}])
+          form    (emit-react/emit-react-body e '[props] ast)
+          nodes   (vec (tree-seq coll? seq form))
+          install (first (filter #(and (seq? %)
+                                       (= 're-frame.freehand.top-layer/install! (first %)))
+                                 nodes))
+          context (nth install 3 nil)
+          on-tog  (get context :on-toggle)
+          handler-writes (filter #(and (seq? %)
+                                       (= 're-frame.freehand.compiled-react/handler! (first %)))
+                                 nodes)
+          event-sites (filter #(and (seq? %)
+                                     (= 're-frame.freehand.reactive/event-site (first %)))
+                               nodes)]
+      (is (some? install) "the compiled popover installs the top-layer host call")
+      (is (map? context) "install! is handed the element-facts context map")
+      (testing "the reconciler position is a runtime some?-verdict, not a compile-time true"
+        (is (not (true? on-tog))
+            "a literal `true` (the #6792 shortcut) suppresses the advisory even for a nil handler")
+        (is (and (seq? on-tog) (= 'if (first on-tog)))
+            ":on-toggle carries `(if (some? <site>) true nil)` — nil when the runtime site produced no handler")
+        (is (some #(and (seq? %) (= 'cljs.core/some? (first %)))
+                  (tree-seq coll? seq on-tog))
+            "and the verdict is derived from (some? <bound-site>)"))
+      (testing "the handler expression is evaluated exactly once"
+        (is (= 1 (count (filter #(= '(:on-tog props) %) nodes)))
+            "the dynamic handler body appears once — not once for props and again for the context"))
+      (testing "the handler! write and the context share ONE bound site"
+        (is (= 1 (count event-sites))
+            "exactly one event-site is emitted for the sole handler")
+        (let [site-sym (nth (first handler-writes) 3 nil)]
+          (is (symbol? site-sym)
+              "handler! receives the pre-bound site symbol, not an inline event-site call")
+          (is (some #{site-sym} (tree-seq coll? seq on-tog))
+              "and that same bound site is what the context's verdict tests"))))))
+
+(deftest a-compiled-modal-dialog-carries-the-runtime-close-verdict
+  (testing "rf2-drpa3.173 — the dialog siblings. A modal `<dialog>` reconciles
+            its own dismissal through :on-close / :on-cancel, and a dynamic
+            :on-close may evaluate to nil exactly as :on-toggle can. The
+            compiled context must carry the same runtime some?-verdict for the
+            modal axis, so a nil close handler warns rather than being suppressed
+            by a compile-time `true`."
+    (let [[e ast] (analyzed '[:dialog {:re-frame.freehand.web/modal-open? true
+                                       :on-close (:on-cl props)}])
+          form    (emit-react/emit-react-body e '[props] ast)
+          nodes   (vec (tree-seq coll? seq form))
+          install (first (filter #(and (seq? %)
+                                       (= 're-frame.freehand.top-layer/install! (first %)))
+                                 nodes))
+          on-close (get (nth install 3 nil) :on-close)]
+      (is (some? install) "the compiled modal installs the top-layer host call")
+      (is (not (true? on-close))
+          "the modal close position is not a compile-time `true`")
+      (is (and (seq? on-close) (= 'if (first on-close)))
+          ":on-close carries the runtime some?-verdict, nil when no handler was produced")
+      (is (= 1 (count (filter #(= '(:on-cl props) %) nodes)))
+          "the dynamic close handler body is evaluated exactly once"))))


### PR DESCRIPTION
Three emitter-correctness fixes on the Freehand interpreted/compiled emitter surface. Each verified against current `main` (the `v/behavior` feature just landed), one commit per bead.

## rf2-drpa3.108 — the dead `emit-defview` path (dead-and-removed)

`compiler/emit_jvm.cljc`'s `emit-defview` wrapped its emitted view fn in `re-frame.freehand.tree/view-boundary` and emitted a `re-frame.freehand.tree/register-view!` call. **Neither function exists** in `re-frame.freehand.tree` (only `tree/emit-static-html` does — so "named but missing" is not uniform here, and each name was checked individually).

**Determination — dead, established positively (not by absence of a failure):** the live `v/defview` macro routes through `re-frame.freehand/expand-defview` → `compile-structural-view` (compiled) / `descriptor/declare-view` (interpreted), **never** through `compiler/defview*` → `defview**` → `emit-defview`. `emit-defview` is reached only from tests, and those tests assert the build-registry side effects produced in `defview**` (via `build/contribute-view-checked!`) or inspect the emitted form structurally — none of them **evaluates** it. The two phantom symbols live only inside the syntax-quoted returned form, so they never resolve. That is exactly why the compiled tier has been green rather than failing at load with unresolved-var errors.

**Remedy — removed.** The dead `view-boundary` wrapper and `register-view!` call are gone; the emitted fn now returns the structural body directly. This eliminates the latent crash the bead names (a declaration shape that reached an eval of this form would fail on the phantom vars) and honours the emitter's own law — emit only what can run, or refuse loudly.

**Follow-up noted (out of this surface):** the entire `defview*` → `defview**` → `emit-defview` chain plus `mark-host-root-annotation` is dead-from-authored-code donor vestige; full retirement (and retargeting the build-registry tests, which currently drive that chain, at a live producer) needs a `compiler.cljc` + build-test co-edit outside this bead's emitter surface. Recommend filing as a separate bead.

## rf2-drpa3.173 — compiled top-layer advisory mistakes a nil dynamic handler for reconciliation (bug fixed)

#6792's `emit_react.cljc`/`top-layer-context` recorded every analyzed reconciler position (`:on-toggle` / `:on-before-toggle` / `:on-close` / `:on-cancel`) as a compile-time `true`. That is not the runtime predicate the shared advisory uses: `top-layer/reconciled?` asks `(some? (get attrs handler-key))`, and a **dynamic handler is allowed to evaluate to nil** — `reactive/event-site` then returns nil and `compiled-react/handler!` writes no DOM handler, yet the compile-time `true` suppressed the advisory anyway. The committed node springs back open after native dismissal with nothing said; the interpreted twin correctly warns.

**Fix (kept local — no callback in the context, no registry, no broadened advisory):** for a promoted top-layer element, each reconciler handler's `event-site` is bound **once** and that binding is shared between the `handler!` write and the advisory context. The context now carries `(if (some? <site>) true nil)` — nil when the runtime site produced no handler (so `reconciled?` reads it as absent and warns, matching the interpreted twin), non-nil otherwise (suppressed). The handler expression is evaluated once per render, not once for props and again for diagnostics.

**Proof.** Foreground JVM emission tests (`react-lowering`) pin the emitted form: a compiled popover with a dynamic `:on-toggle` and a compiled modal `<dialog>` with a dynamic `:on-close` carry the runtime some?-verdict rather than a literal `true`; the dynamic body appears exactly once; `handler!` and the context share one bound site. The end-to-end advisory-at-commit is browser-only and covered transitively: the emission proof shows the compiled emitter produces the correct context, and the existing shared-advisory tests (`fh-toplayer-005`) already prove nil context → warn / present → suppress.

## rf2-7x0ge — compiled key-condition map with a `v/event` branch (bug fixed, audit-reopen scope)

The positive path (a `v/event` key branch renders and records `{:rf.ui/opaque :fn}`) already worked; this addresses the **audit reopen**. Making it render, `node/key-branch` recorded **every** `fn-carried?` branch — bare functions and every Callback role — as the opaque marker, admitting declarations the live event planner refuses. A key branch names one intent, so `events/branch-plan` admits only an event vector, an options map carrying `:event`, a `v/event`, or nil, and refuses `v/handler`, a bare fn, `v/render-fn`, `v/raw-fn`, a nested key map, a branch-local whole-listener option, and a mixed string/keyword map. SSR/headless render and structural tests were blessing forms the browser event path rejects.

**Bounded correction:** `classify-event` now validates the whole key-condition map through the **same** planner (`events/event-plan` → `branch-plan`) before projecting it into the tree, so refusals carry the planner's own typed `:rf.error/view-bad-event` category and the interpreted structural walk and the live planner cannot hold two branch grammars. `key-branch`'s opaque predicate tightens from `fn-carried?` to `callback?` — post-validation the only fn-carrier that reaches it is `v/event` (records the mode-neutral opaque marker); an event vector / options map / nil is data and recorded verbatim, with a function nested inside a data branch still refused at the branch. No new grammar, validator, callback role, or compatibility path; the whole-handler arm still admits a bare fn (a native `:on-*` site legitimately does). `events/event-plan` is public and `node.cljc` already requires `events`, so no `events.cljc` change was needed.

**Negative proof** exercises `tree/render` **directly** — the path the missed upstream-validation assumption left unguarded — and pins it to the planner by proving `tree/render` and `events/event-plan` refuse each shape id-for-id. The existing `v/event`-positive and nested-non-data acceptance rows still pass.

## Quality gates

Run foreground to completion from the worker worktree `emitter-correctness-173` (browser/elision/perf gates go to CI per dispatch policy; the `.173` end-to-end advisory-at-commit is browser-only and covered transitively as described above).

| Gate | Command | Result |
| --- | --- | --- |
| Freehand JVM | `clojure -M:test` (from `implementation/freehand`) | **894 tests, 6426 assertions, 0 failures, 0 errors** |
| Freehand node CLJS | `npm run test:freehand` (from `implementation`) | build 388 files, 0 warnings; **959 tests, 5507 assertions, 0 failures, 0 errors** |

The node CLJS gate compiles the compiled top-layer views, which exercises the `.173` emitter change at build time — confirming the new CLJS forms (`(if (cljs.core/some? …) true nil)` and the reordered `let` binds) compile clean.

**New adversarial/negative cases (one per bead):**
- `.108` — `emit-defview-names-no-unresolvable-freehand-var`: every re-frame.freehand-qualified symbol the emitter emits resolves, and the two phantom symbols are absent.
- `.173` — `a-compiled-popover-carries-the-runtime-reconciliation-verdict` and `a-compiled-modal-dialog-carries-the-runtime-close-verdict`: the context is a runtime some?-verdict, not a literal `true`; the handler evaluates once; `handler!` and the context share one bound site.
- `7x0ge` — `a-non-dispatching-branch-is-refused-with-the-shared-typed-category`: `v/handler`, a bare fn, `v/render-fn`, a nested key map, a branch-local `:once`, and a mixed map are each refused by `tree/render` with `:rf.error/view-bad-event`, id-for-id with `events/event-plan`.
