### PR TITLE
fix(freehand): a fresh incarnation records its creating root as author (rf2-2pvp7)

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/root.cljs
+++ b/implementation/freehand/src/re_frame/freehand/root.cljs
@@ -816,7 +816,8 @@
                                   :owns-live-incarnation false}
                       :arriving  {:config-fingerprint config-fingerprint
                                   :root-id            root-id}}}))
-      (let [installed-value
+      (let [created? (and owned? (nil? (frame/frame frame-id)))
+            installed-value
             (if owned?
               ;; ENSURE. `make-frame` is idempotent replacement: absent → created
               ;; and its :initial-events drain; present under the same plan → left
@@ -826,7 +827,7 @@
               ;; hands back the exact frame VALUE (the incarnation token) this
               ;; install produced; on the ratified no-op it returns nil and the
               ;; ledger keeps the value from the install that stands.
-              (when (or (nil? (frame/frame frame-id))
+              (when (or created?
                         (not= (:config-fingerprint record) config-fingerprint))
                 (live-frame/make-frame (assoc config :id frame-id)))
               ;; SCOPE. A frame this root does not own must already exist — there
@@ -846,7 +847,18 @@
         (swap! frame-ledger update frame-id
                (fn [r]
                  {:config-fingerprint (if owned? config-fingerprint (:config-fingerprint r))
-                  :installed-by       (if owned? (or (:installed-by r) root-id) (:installed-by r))
+                  ;; A fresh incarnation is a fresh ownership row: a CREATE records
+                  ;; the CREATING root as author, never `(or old …)` — the surviving
+                  ;; row of an externally-destroyed predecessor must not lend its
+                  ;; author to an incarnation it did not install, or the real
+                  ;; creator reads as foreign to its own frame and its next config
+                  ;; edit trips the differing-plan arm (rf2-2pvp7). The proven-owner
+                  ;; refresh keeps its author: the differing-plan arm already
+                  ;; refused a DIFFERENT root with a differing fingerprint, and the
+                  ;; same-fingerprint path never runs the plan.
+                  :installed-by       (if owned?
+                                        (if created? root-id (or (:installed-by r) root-id))
+                                        (:installed-by r))
                   ;; The install authority: the fresh value when the plan just ran
                   ;; (a create or a proven-owner config edit), else the value from
                   ;; the install that stands. The ownership arm above has already

--- a/implementation/freehand/test/re_frame/freehand/root_preflight_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/root_preflight_dom_cljs_test.cljs
@@ -718,3 +718,85 @@
                   (is false (str "same-id-successor refresh suite rejected: " e))
                   (.remove node)
                   (done)))))))))
+
+(deftest fh-root-004-a-fresh-incarnation-belongs-to-the-root-that-created-it
+  (testing "Per rf2-2pvp7 (browser): a fresh incarnation is a fresh ownership
+            row. R1 installs incarnation A; external code destroys A EXACTLY and
+            stands no successor — the frame is absent, but R1's row survives in
+            the defonce ledger, still naming R1. A DIFFERENT root R2 then runs a
+            config-bearing ENSURE for the same id: make-frame CREATES a fresh
+            incarnation C, and the ledger must record R2 — the creating root —
+            as the author, never lend R1's stale name to an incarnation R1 did
+            not install. The user-visible symptom pinned second: with the stale
+            author, R2's own config EDIT (differing fingerprint) trips the
+            differing-plan conflict arm against a root that installed nothing."
+    (if-not (browser?)
+      (skip! "the browser job runs the fresh-incarnation authorship assertions")
+      (async done
+        (reg!)
+        (let [node-1  (host-node!)
+              node-2  (host-node!)
+              fid     :fh.root/fresh-author
+              plan-1  {:root-id :fh.root/author-r1
+                       :frame   {:id fid :initial-events [[:root/seed 1]]}}
+              ;; SAME frame plan as R1's (equal fingerprint): the differing-plan
+              ;; arm carries no liveness check, so only an equal plan reaches the
+              ;; create at all — which is exactly the defect's setup.
+              plan-2  {:root-id :fh.root/author-r2
+                       :frame   {:id fid :initial-events [[:root/seed 1]]}}
+              plan-2' {:root-id :fh.root/author-r2
+                       :frame   {:id fid :initial-events [[:root/seed 1] [:root/noop]]}}
+              c-token (atom nil)
+              root-1  (atom nil)]
+          (rf/reg-event :root/noop (fn [{:keys [db]} _] {:db db}))
+          (-> (act #(v/mount [views/counter {}] node-1 plan-1))
+              (.then
+                (fn [installer-1]
+                  (reset! root-1 installer-1)
+                  ;; external: destroy A exactly; stand NO successor. The frame is
+                  ;; absent; R1's row survives, still naming R1.
+                  (rf/destroy-frame! fid)
+                  (is (nil? (frame/frame fid)) "A is gone and nothing replaced it")
+                  (is (= :fh.root/author-r1
+                         (:installed-by (get (root/frame-ledger-snapshot) fid)))
+                      "the surviving row still names R1")
+                  ;; R2's ENSURE finds the id absent and CREATES incarnation C.
+                  (act #(v/mount [views/counter {}] node-2 plan-2))))
+              (.then
+                (fn [root-2]
+                  (reset! c-token (frame/frame-incarnation-token fid))
+                  (is (= :fh.root/author-r2
+                         (:installed-by (get (root/frame-ledger-snapshot) fid)))
+                      "the fresh incarnation's author is the root that CREATED it —
+                       a create never wears the stale author of a dead predecessor")
+                  (is (identical? @c-token
+                                  (frame/frame-value-incarnation-token
+                                    (:installed-value (get (root/frame-ledger-snapshot) fid))))
+                      "and the recorded install value is C's exact token")
+                  ;; R2's own config EDIT must be a proven-owner refresh, not a
+                  ;; foreign-plan conflict blamed on R1.
+                  (act #(v/mount [views/counter {}] node-2 plan-2'))))
+              (.then
+                (fn [root-2]
+                  (is (identical? @c-token (frame/frame-incarnation-token fid))
+                      "the refresh was surgical — C's exact incarnation survived it")
+                  (-> (act #(v/unmount! @root-1))
+                      (.then (fn [_]
+                               (is (some? (frame/frame fid))
+                                   "R1's unmount released only its stale reference")
+                               (act #(v/unmount! root-2))))
+                      (.then
+                        (fn [_]
+                          (is (nil? (frame/frame fid))
+                              "the last reference destroyed C — exactly the
+                               incarnation R2 installed")
+                          (is (empty? (root/frame-ledger-snapshot)))
+                          (.remove node-1)
+                          (.remove node-2)
+                          (done))))))
+              (.catch
+                (fn [e]
+                  (is false (str "fresh-incarnation authorship suite rejected: " e))
+                  (.remove node-1)
+                  (.remove node-2)
+                  (done)))))))))


### PR DESCRIPTION
Closes rf2-2pvp7.

## Defect (verified at root.cljs:849)

The preflight ledger write kept `(or old-installed-by root-id)` on a CREATE. When a root-ensured frame is destroyed externally while its root is still mounted (the row survives; the frame is absent) and a different root later ensures the same id, make-frame creates a genuinely fresh incarnation — but the write merged the new handle with the dead predecessor's author. No takeover (the handle is exact, per #6849), but the row lies about provenance: the creating root reads as foreign to its own frame, and its next config edit (differing fingerprint) trips the differing-plan conflict arm with a message blaming a root that installed nothing.

## Fix

A fresh incarnation is a fresh ownership row: when the ENSURE plan ran make-frame because the frame was absent (`created?`), the write records the creating root as `:installed-by`. The proven-owner refresh path keeps its author — same root by construction (the differing-plan arm refuses a different root with a differing fingerprint, and the same-fingerprint path never runs the plan).

## Proof

- New browser test `fh-root-004-a-fresh-incarnation-belongs-to-the-root-that-created-it` pins the full sequence: install → external exact destroy (no successor) → different root's equal-plan create → author is the creator → its config edit refreshes without conflict → exact last-reference teardown.
- **Non-vacuity**: proven red against the unfixed write — exactly 2 failures (the author assertion and the conflict-on-refresh), then green with the fix: browser 743 tests / 4600 assertions / 0 failures; freehand node suite 960 tests / 5508 assertions / 0 failures.

Out of scope (pending the ownership design ruling): release-side loudness on unprovable rows, the ownership-tuple/plan-author refactor, and the destroy-hook diagnostics — see the design-review corpus under ai/findings (rf2-kpmzn).