### PR TITLE
fix(freehand): emitter-parity residuals — for-body diagnostic, id-slot conflict, select-multiple callers (rf2-drpa3.164, rf2-5r1af, rf2-sf9n5)

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/compiler/analyze.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/analyze.cljc
@@ -2320,7 +2320,13 @@
                             :sync? false})
           {:key {:present? false} :class (analyze-class e (:classes tag-info) nil)
            :style nil :attrs [] :events []
-           :spread (merge identity {:base base* :overrides overrides*})
+           ;; The `#id` sugar fact rides the spread slot so the compiled
+           ;; lowering can thread it into `node/spread-attrs` — a forwarded id
+           ;; beside `#id` sugar is the same two-spelling ambiguity the literal
+           ;; path refuses, but a spread never reaches the literal analyzer, so
+           ;; the runtime seam holds it with the sugar in hand (rf2-5r1af).
+           :spread (merge identity {:base base* :overrides overrides*
+                                    :sugar-id (:id tag-info)})
            :safe-spread nil
            :ref nil :property-props #{} :static? false}))
 
@@ -3727,7 +3733,7 @@
   A body of one of these kinds is a candidate for the `indirect-list-body`
   sentence rather than the missing-`:key` one, but only once
   [[wraps-markup-node?]] confirms a markup row is actually in there: the
-  mistake that sentence names is a keyed row with something standing between
+  mistake that sentence names is a markup row with something standing between
   it and the `for`, and a wrapper bottoming out at an `:expr`/`:text`/`:slot`
   has no row to stand in front of and keeps the general message."
   #{:let :letfn :if :case})
@@ -3736,12 +3742,16 @@
   "Does this analyzed `for`-body wrapper reach a MARKUP ROW — an element,
   view, foreign or fragment — in a rendered position?
 
-  That is the fact the `indirect-list-body` diagnostic asserts (\"the keyed
-  row is present, one form deeper\"), so it is established BEFORE the
-  diagnostic claims it. A `:let`/`:letfn`/`:if`/`:case` bottoming out at an
-  `:expr`/`:text`/`:slot` carries no row at all, and reporting it as a
-  wrapper around a keyed node would state a fact the analyzer has not proved
-  (rf2-drpa3.164). The walk mirrors [[presence-keyed-child?]]'s node shapes:
+  That is the fact the `indirect-list-body` diagnostic asserts (\"markup is
+  present, one form deeper — the body wraps it rather than being it\"), so it
+  is established BEFORE the diagnostic claims it. Whether that markup carries
+  its own `:key` is a separate requirement the sentence STATES but does not
+  verify through the wrapper (rf2-drpa3.164 #6837 audit); a keyed and an
+  unkeyed markup wrapper are the same mistake and get the same sentence. A
+  `:let`/`:letfn`/`:if`/`:case` bottoming out at an `:expr`/`:text`/`:slot`
+  carries no row at all, and reporting it as a wrapper around a row would
+  state a fact the analyzer has not proved (rf2-drpa3.164). The walk mirrors
+  [[presence-keyed-child?]]'s node shapes:
   a branch reaches markup when ANY rendered arm does — one wrapped row is
   enough to make the wrapper the thing between the `for` and it."
   [ast]
@@ -3827,27 +3837,33 @@
             body-ast  (analyze e-body body-form)]
         ;; The WRAPPED body is its own rejection, because it is its own
         ;; mistake (rf2-drpa3.164). `(for [i is] (let [r (nth rows i)] [:div
-        ;; {:key (:id r)} …]))` is the natural Clojure spelling, and the row
-        ;; inside it IS keyed — reporting a missing key sends the author to a
-        ;; line that has one. The rule they need is that the body must BE the
-        ;; node, and the fix is `for`'s own `:let` modifier, which this
-        ;; grammar fully supports. But the sentence claims a row is present
-        ;; one form deeper, so it is raised only once `wraps-markup-node?`
-        ;; proves one is: `(for [x xs] (let [y x] (str y)))` wraps a scalar,
-        ;; not a keyed node, and keeps the general unkeyed-list-item answer
-        ;; rather than a sentence about a row that isn't there.
+        ;; {:key (:id r)} …]))` is the natural Clojure spelling — reporting a
+        ;; missing key when the row inside it has one sends the author to a
+        ;; line that already keys it. The rule they need is that the body
+        ;; must BE the row node, and the fix is `for`'s own `:let` modifier,
+        ;; which this grammar fully supports. The sentence only claims what
+        ;; `wraps-markup-node?` establishes — that MARKUP sits one form
+        ;; deeper — and NOT that the markup is keyed, which the analyzer does
+        ;; not inspect through the wrapper (rf2-drpa3.164 #6837 audit). So a
+        ;; keyed and an unkeyed markup wrapper get the same honest sentence,
+        ;; while `(for [x xs] (let [y x] (str y)))` wraps a scalar — no row
+        ;; is one form deeper — and keeps the general unkeyed-list-item
+        ;; answer rather than a sentence about a row that isn't there.
         (when (and (contains? wrapper-body-ops (:op body-ast))
                    (wraps-markup-node? body-ast))
           (env/fail! e :rf.ui.compile/indirect-list-body
-                     (str "a for body must BE the keyed node — an element, a "
-                          "view or a fragment, with nothing standing between "
-                          "the for and it — and this body is a "
-                          (name (:op body-ast)) " wrapping one. A keyed list "
-                          "lowers to a direct JS array of rows, so the row has "
-                          "to be what the body evaluates to."
+                     (str "a for body must BE the row node — an element, a "
+                          "view or a fragment carrying its own :key — "
+                          "directly, with nothing standing between the for "
+                          "and it. This body is a "
+                          (name (:op body-ast)) " with the markup one form "
+                          "deeper. A keyed list lowers to a direct JS array "
+                          "of rows, so the body has to evaluate to that row "
+                          "node itself."
                           (if (= :let (:op body-ast))
                             (str " Bind the row's values with for's OWN :let "
-                                 "modifier: (for [i (range start end) "
+                                 "modifier so the body stays the keyed row: "
+                                 "(for [i (range start end) "
                                  ":let [r (nth rows i)]] [:div {:key (:id r)} …])")
                             (str " Extract a declared child view that does the "
                                  "wrapping, and key it at the call site")))

--- a/implementation/freehand/src/re_frame/freehand/compiler/emit_jvm.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/emit_jvm.cljc
@@ -173,8 +173,12 @@
          (seq dyn)        (assoc :dyn dyn)
          ;; The forwarded maps go through the SAME constructors the public door
          ;; calls in an interpreted body — one merge, one deny law, one fold.
+         ;; The element's `#id` sugar fact rides along so the seam refuses a
+         ;; forwarded id beside the sugar, the ambiguity the literal path guards
+         ;; but a spread walks round (rf2-5r1af).
          spread           (assoc :dyn `(node/spread-attrs ~(:base spread)
-                                                          ~(:overrides spread)))
+                                                          ~(:overrides spread)
+                                                          ~tag ~(:sugar-id spread)))
          (contains? cls :class)  (assoc :class (:class cls) :sugar (:sugar cls))
          (contains? sty :style)  (assoc :style (:style sty))
          (seq events)     (assoc :events events)

--- a/implementation/freehand/src/re_frame/freehand/compiler/emit_react.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/emit_react.cljc
@@ -265,7 +265,12 @@
   [o tag cls spread]
   `(re-frame.freehand.compiled-react/spread!
     ~o ~tag ~(vec (:sugar cls)) ~(:sid spread)
-    (re-frame.freehand.node/spread-attrs ~(:base spread) ~(:overrides spread))))
+    ;; The element's `#id` sugar fact rides into the shared seam so a forwarded
+    ;; id beside `#id` refuses here at runtime, exactly as the interpreted
+    ;; element fold does — the compiled react path never reaches that fold
+    ;; (rf2-5r1af).
+    (re-frame.freehand.node/spread-attrs ~(:base spread) ~(:overrides spread)
+                                         ~tag ~(:sugar-id spread))))
 
 (defn- safe-spread-write
   "The runtime fold of `(v/spread-safe owned caller)`'s guarded caller map,
@@ -390,6 +395,16 @@
                       (first (filter #(= (controlled/prop-slot (:k %))
                                          (controlled/prop-slot :multiple))
                                      dynamics)))
+        ;; Whether the OWNED props declare the `multiple` slot at all — by
+        ;; presence, over every owned attr, literal or dynamic. The v/spread-
+        ;; safe caller folds UNDER the owned props (owned wins), so it settles
+        ;; the verdict only when the owned props are silent on the slot. An
+        ;; owned literal `:multiple false` is build-time (so it is NOT in
+        ;; `dynamics`, and `dyn-multi` misses it) yet still an owned decision
+        ;; that must silence a caller's true (rf2-sf9n5 #6847 audit).
+        owned-multi? (boolean (some #(= (controlled/prop-slot (:k %))
+                                        (controlled/prop-slot :multiple))
+                                    attrs))
         ;; The verdict is a runtime fact only where there is an owned dynamic
         ;; write to shape (a nil `value`/`checked`) AND a runtime source that
         ;; could flip it: a dynamic `:multiple`, or a safe-spread caller on a
@@ -454,13 +469,27 @@
                                              `(re-frame.freehand.node/safe-caller-attrs
                                                ~(:base safe-spread) ~(:owned-handler-keys safe-spread)))
                       runtime-verdict?
+                      ;; EFFECTIVE-source precedence, not a union. The verdict is
+                      ;; the owned declaration's when the owned props declare the
+                      ;; slot — a dynamic owned `:multiple` reads its bound value,
+                      ;; a literal owned one is the compile-time constant, false
+                      ;; here (a literal TRUE keeps the constant path and never
+                      ;; reaches this binding). Only a slot the owned props leave
+                      ;; undeclared hands the decision to the safe-spread caller.
+                      ;; ORing them shaped an owned nil `value` as the empty
+                      ;; collection though the caller's `multiple` loses to owned
+                      ;; at `caller-spread!` (rf2-sf9n5 #6847 audit).
                       (conj mverdict
-                            `(cljs.core/or
-                              ~@(cond-> []
-                                  dyn-multi  (conj `(re-frame.freehand.controlled/multiple-select?
-                                                     ~tag [[~(:k dyn-multi) ~dyn-multi-sym]] nil))
-                                  caller-sym (conj `(re-frame.freehand.controlled/multiple-select?
-                                                     ~tag ~caller-sym nil)))))
+                            (cond
+                              dyn-multi
+                              `(re-frame.freehand.controlled/multiple-select?
+                                ~tag [[~(:k dyn-multi) ~dyn-multi-sym]] nil)
+                              owned-multi?
+                              literal-multi?
+                              caller-sym
+                              `(re-frame.freehand.controlled/multiple-select?
+                                ~tag ~caller-sym nil)
+                              :else false))
                       (seq reconciler-binds) (into reconciler-binds))
         props-form  (if (seq writes)
                       `(let [~o (cljs.core/js-obj ~@(mapcat identity literals))

--- a/implementation/freehand/src/re_frame/freehand/controlled.cljc
+++ b/implementation/freehand/src/re_frame/freehand/controlled.cljc
@@ -214,6 +214,26 @@
     (and (= :select tag)
          (boolean (or (flagged? attrs) (flagged? more-attrs))))))
 
+(defn multiple-declared?
+  "Do any of these attribute sources DECLARE the `multiple` slot — by
+  PRESENCE, the value irrelevant?
+
+  The v/spread-safe precedence turns on declaration, not truth. `multiple`
+  is legal in a spread-safe caller, but it folds UNDER the owned props
+  (owned wins), so the whole-element multiple verdict must read the
+  EFFECTIVE source: an owned `:multiple false` is a decision that silences a
+  caller's `:multiple true`, and the caller is consulted ONLY when the owned
+  props do not declare the slot at all. [[multiple-select?]] answers truth
+  and cannot make that distinction — an owned false and an absent owned key
+  are both un-flagged — so the precedence needs this presence question
+  beside it (rf2-sf9n5). Read through the same [[prop-slot]] projection, so
+  `:x/multiple` counts exactly as `:multiple` does; each source is a map or
+  any seqable of `[key value]` pairs."
+  [& sources]
+  (boolean (some (fn [entries]
+                   (some (fn [[k _]] (= multiple-slot (prop-slot k))) entries))
+                 sources)))
+
 (defn controlled-props?
   "Does this element's authored attribute key sequence make it controlled
   — do any of the keys normalize onto a [[controlled-slots]] slot?

--- a/implementation/freehand/src/re_frame/freehand/node.cljc
+++ b/implementation/freehand/src/re_frame/freehand/node.cljc
@@ -746,25 +746,47 @@
   spelling-dependent split: the interpreted walk answered the BASE and
   the compiled one the override, for one declaration whose only stated
   rule is later-arg-wins. Projecting first makes the collision visible to
-  the merge, which is the one place the rule is written down."
-  [base overrides]
-  (assert-forwardable-attrs! 're-frame.freehand/spread base)
-  (assert-forwardable-attrs! 're-frame.freehand/spread overrides)
-  ;; Always a MAP, so `(v/spread nil)` is an element with no attributes in
-  ;; both modes rather than an attribute map in one and an absent child in
-  ;; the other — the two happen to render the same tree, and agreement by
-  ;; coincidence is the thing this whole slice is written against.
-  (let [merged (merge (canonical-slot-keys base) (canonical-slot-keys overrides))]
-    ;; The id-slot CARDINALITY, over the MERGED map both front ends fold onto
-    ;; the element. A spread carries no tag, so its only id ambiguity is two
-    ;; distinct spellings surviving the merge — `(v/spread {:id "a"} {:x/id
-    ;; "b"})`; two exact `:id` writes are later-arg-wins and merge to one, no
-    ;; conflict. This is the ONE seam BOTH modes reach, so the compiled spread
-    ;; — which bypasses the literal analyzer's id guard — refuses the pair
-    ;; here at runtime exactly as the interpreted walk does (rf2-5r1af).
-    (when-some [{:keys [message]} (conv/id-conflict nil nil (keys merged))]
-      (malformed! 're-frame.freehand/spread message {:value (shape merged)}))
-    merged))
+  the merge, which is the one place the rule is written down.
+
+  `tag`/`sugar-id` are the element's `#id` sugar fact, supplied ONLY by the
+  compiled lowering (the interpreted public seam has no element in hand and
+  passes neither). A compiled `v/spread` bypasses the literal analyzer's id
+  guard AND folds through this seam without reaching the element-fold id
+  check the interpreted walks apply, so the sugar-vs-forwarded-id ambiguity
+  would slip through both — `[:div#sugar (v/spread {:id \"a\"})]` emitting a
+  single id where its interpreted twin refuses. Threading the fact here holds
+  it identically, in the same two-step ORDER the interpreted walks reach it:
+  the spread's own cardinality first (tag-less, exactly what the public seam
+  throws), then the element's sugar (rf2-5r1af)."
+  ([base overrides] (spread-attrs base overrides nil nil))
+  ([base overrides tag sugar-id]
+   (assert-forwardable-attrs! 're-frame.freehand/spread base)
+   (assert-forwardable-attrs! 're-frame.freehand/spread overrides)
+   ;; Always a MAP, so `(v/spread nil)` is an element with no attributes in
+   ;; both modes rather than an attribute map in one and an absent child in
+   ;; the other — the two happen to render the same tree, and agreement by
+   ;; coincidence is the thing this whole slice is written against.
+   (let [merged (merge (canonical-slot-keys base) (canonical-slot-keys overrides))]
+     ;; The id-slot CARDINALITY, over the MERGED map both front ends fold onto
+     ;; the element. A spread carries no tag, so its only id ambiguity is two
+     ;; distinct spellings surviving the merge — `(v/spread {:id "a"} {:x/id
+     ;; "b"})`; two exact `:id` writes are later-arg-wins and merge to one, no
+     ;; conflict. This is the ONE seam BOTH modes reach, and the interpreted
+     ;; public seam throws HERE, tag-less, before any element is built — so
+     ;; the compiled seam checks it tag-less FIRST too, for one message.
+     (when-some [{:keys [message]} (conv/id-conflict nil nil (keys merged))]
+       (malformed! 're-frame.freehand/spread message {:value (shape merged)}))
+     ;; Then the element's `#id` sugar against the surviving forwarded id —
+     ;; the check the interpreted walks make at the ELEMENT fold, replayed at
+     ;; the compiled seam that never reaches that fold. Gated on `sugar-id`,
+     ;; so the public interpreted seam (which passes none) is untouched and a
+     ;; sugar-less spread is unaffected. A spread that already tripped the
+     ;; cardinality check above never arrives here, so this fires only for the
+     ;; discriminating shape: one forwarded id beside the sugar (rf2-5r1af).
+     (when sugar-id
+       (when-some [{:keys [message]} (conv/id-conflict tag sugar-id (keys merged))]
+         (malformed! 're-frame.freehand/spread message {:value (shape merged)})))
+     merged)))
 
 (defn- owned-handler-keys
   "The `on-*` keys of a `v/spread-safe` OWNED props map — the handler families
@@ -917,9 +939,17 @@
         ;; only after this verdict decides what an owned nil `value` means, so
         ;; the caller is a THIRD source settled here — before the fold, not
         ;; after it (rf2-sf9n5).
-        multi?     (or (controlled/multiple-select? tag attrs dyn)
-                       (and (some? caller)
-                            (controlled/multiple-select? tag caller nil)))
+        ;; EFFECTIVE-source precedence, not a union: `v/spread-safe` folds the
+        ;; caller UNDER the owned props (owned wins), so an owned `:multiple`
+        ;; declaration decides the verdict even when it is false — the caller
+        ;; is consulted only when the owned props do not declare the slot at
+        ;; all. ORing the two sources let a caller's `:multiple true` shape an
+        ;; owned nil `value` as the empty collection though the element's final
+        ;; `multiple` was owned-false (rf2-sf9n5 #6847 audit).
+        multi?     (if (controlled/multiple-declared? attrs dyn)
+                     (controlled/multiple-select? tag attrs dyn)
+                     (and (some? caller)
+                          (controlled/multiple-select? tag caller nil)))
         ;; `:class` and `:style` ride the accumulator because an ALIASED
         ;; spelling of either arrives through `:dyn` — the front end
         ;; discriminates on the exact keyword — and has to reach the one

--- a/implementation/freehand/src/re_frame/freehand/react.cljs
+++ b/implementation/freehand/src/re_frame/freehand/react.cljs
@@ -266,7 +266,14 @@
         ;; and it folds UNDER the owned props (`put-caller!`) only after the
         ;; owned nil `value` is normalized here — so the caller is settled
         ;; into this one verdict, before that normalization (rf2-sf9n5).
-        multi?      (controlled/multiple-select? tag attrs caller)
+        ;; EFFECTIVE source, not a union: an owned `:multiple` declaration
+        ;; wins even when false (owned wins), and the caller decides only when
+        ;; the owned props are silent on the slot. ORing them shaped an owned
+        ;; nil `value` as the empty collection under an owned-false element
+        ;; whose caller happened to carry `:multiple true` (rf2-sf9n5 #6847).
+        multi?      (if (controlled/multiple-declared? attrs)
+                      (controlled/multiple-select? tag attrs nil)
+                      (controlled/multiple-select? tag caller nil))
         ;; The exact `:class` and any alias projecting onto the class slot
         ;; COMPOSE — sugar first, then the exact `:class`, then the aliases —
         ;; rather than the last one written winning. They are collected

--- a/implementation/freehand/test/re_frame/freehand/analyze_reject_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/analyze_reject_cljs_test.cljc
@@ -96,7 +96,7 @@
       (is (= :rf.ui.compile/indirect-list-body (reject-id wrapped))
           "the wrapped body is its own id, not the missing-key one")
       (let [msg (reject-msg wrapped)]
-        (is (str/includes? msg "must BE the keyed node")
+        (is (str/includes? msg "must BE the row node")
             "the sentence states the real rule")
         (is (str/includes? msg ":let")
             "and names for's :let modifier as the fix")
@@ -119,8 +119,38 @@
                             [:div {:key (:id r)} r])))))
   (testing "a wrapper that :let cannot fix is told to extract a child view"
     (let [msg (reject-msg '(for [x xs] (if x [:li {:key x} 1] [:li {:key x} 2])))]
-      (is (str/includes? msg "must BE the keyed node"))
+      (is (str/includes? msg "must BE the row node"))
       (is (str/includes? msg "Extract a declared child view"))))
+  (testing "rf2-drpa3.164 audit (#6837): the wrapper sentence must not
+            claim the wrapped markup is KEYED — the analyzer never inspects
+            the key one form deeper, so an unkeyed markup wrapper gets the
+            SAME id and the SAME sentence as a keyed one. Asserting a key it
+            never proved sent an author who took the recovery into a second
+            build failure for the missing key. `wraps-markup-node?`
+            establishes only that markup is one form deeper; keyedness is a
+            requirement the sentence STATES, not a fact it claims."
+    (let [keyed   '(for [x xs] (let [y x] [:li {:key x} y]))
+          unkeyed '(for [x xs] (let [y x] [:li y]))]
+      (is (= :rf.ui.compile/indirect-list-body (reject-id unkeyed))
+          "an unkeyed markup wrapper is still the wrapper diagnostic")
+      (is (= (reject-msg keyed) (reject-msg unkeyed))
+          "and the sentence is byte-identical either way — it never
+           depended on, nor asserted, a key one form deeper")
+      (is (not (str/includes? (reject-msg unkeyed) "wrapping one"))
+          "the retired sentence claimed the body was 'wrapping one' keyed
+           node; the honest one names only the markup that is there")))
+  (testing "rf2-drpa3.164 audit (#6837): a mixed markup/scalar branch —
+            one arm renders markup, the other a scalar — is still the
+            wrapper diagnostic (markup IS one form deeper on a rendered
+            arm) and never claims that markup is keyed"
+    (let [mixed '(for [x xs] (if x [:li x] (str x)))]
+      (is (= :rf.ui.compile/indirect-list-body (reject-id mixed))
+          "the if wraps markup on its then-arm, so it is the wrapper case")
+      (let [msg (reject-msg mixed)]
+        (is (str/includes? msg "must BE the row node"))
+        (is (str/includes? msg "Extract a declared child view"))
+        (is (not (str/includes? msg "missing :key"))
+            "and never reports a missing key it did not check for"))))
   (testing "a body carrying no row at all keeps the general message —
             whether the scalar is bare or wrapped. rf2-drpa3.164 audit: a
             wrapper is a CANDIDATE for indirect-list-body, not a verdict.

--- a/implementation/freehand/test/re_frame/freehand/compiled_select_multiple_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/compiled_select_multiple_cljs_test.cljs
@@ -141,3 +141,55 @@
                      [:attrs :value])
              (react-value [:select (v/spread-safe {:value nil} {:multiple true})]))
           "the cross-mode claim: structural and interpreted React agree on the shape"))))
+
+;; ---------------------------------------------------------------------------
+;; Owned wins over the caller — rf2-sf9n5 #6847 audit
+;; ---------------------------------------------------------------------------
+;;
+;; A `v/spread-safe` caller folds UNDER the owned props, so an owned `:multiple`
+;; declaration decides the whole-element verdict even when it is FALSE — the
+;; caller is consulted only when the owned props are silent on the slot. PR
+;; #6847 brought the caller into the verdict but ORed it with the owned source,
+;; so an owned `:multiple false` beside a caller `:multiple true` shaped the
+;; owned nil `value` as the empty COLLECTION though the element's final
+;; `multiple` (owned wins) was false — a value React reports as the wrong shape,
+;; and a shape the interpreted-vs-compiled agreement was supposed to forbid.
+
+(deftest an-owned-multiple-wins-over-the-safe-spread-caller
+  (testing "The verdict reads the EFFECTIVE multiple source after safe-spread
+            precedence: an owned declaration wins even when false, and the
+            caller decides only when the owned props do not declare the slot.
+            Proved structurally (tree/render) and in interpreted React, exact
+            and normalized-alias spellings, both directions of the conflict."
+    (letfn [(struct-value [form k] (get-in (tree/render form) [:attrs k]))
+            (react-value  [form] (as-data (gobj/get (.-props (fr/element form)) "value")))]
+      ;; owned false wins over caller true — the exact #6847 reproduction
+      (is (= "" (struct-value [:select (v/spread-safe {:value nil :multiple false}
+                                                      {:multiple true})]
+                              :value))
+          "owned :multiple false wins over caller true -> empty string, structural")
+      (is (= "" (react-value [:select (v/spread-safe {:value nil :multiple false}
+                                                     {:multiple true})]))
+          "and identically in interpreted React")
+      ;; the normalized alias reaches the same verdict
+      (is (= "" (struct-value [:select (v/spread-safe {:x/value nil :x/multiple false}
+                                                      {:x/multiple true})]
+                              :x/value))
+          "the alias spellings reach the same owned-wins verdict, structural")
+      (is (= "" (react-value [:select (v/spread-safe {:x/value nil :x/multiple false}
+                                                     {:x/multiple true})]))
+          "and in interpreted React")
+      ;; owned true wins over caller false — the symmetric direction
+      (is (= [] (struct-value [:select (v/spread-safe {:value nil :multiple true}
+                                                      {:multiple false})]
+                              :value))
+          "owned :multiple true wins over caller false -> empty array, structural")
+      (is (= [] (react-value [:select (v/spread-safe {:value nil :multiple true}
+                                                     {:multiple false})]))
+          "and identically in interpreted React")
+      ;; the caller still decides when the owned props are SILENT — the guard
+      ;; must not have turned the caller off entirely (non-vacuity)
+      (is (= [] (struct-value [:select (v/spread-safe {:value nil} {:multiple true})] :value))
+          "owned silent on multiple -> the caller's true still decides, structural")
+      (is (= [] (react-value [:select (v/spread-safe {:value nil} {:multiple true})]))
+          "and in interpreted React"))))

--- a/implementation/freehand/test/re_frame/freehand/react_lowering_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/react_lowering_jvm_test.clj
@@ -202,6 +202,24 @@
       (is (.contains ^String (emitted body) ^String reaches)
           (str carrier " — the emitted body reaches " reaches)))))
 
+(deftest the-react-spread-lowering-threads-the-id-sugar-fact
+  (testing "rf2-5r1af #6837 audit. The compiled React path folds `v/spread`
+            through `node/spread-attrs` and never reaches the element-fold id
+            check the interpreted React walk makes, so a forwarded id beside
+            `#id` sugar slipped through — the sugar id silently dropped, no
+            refusal. The fix threads the element's sugar fact into the shared
+            seam, where the runtime refusal lives. Here we prove the WIRING:
+            the emitted spread-attrs call carries the tag and the sugar id, so
+            the seam has what it needs to refuse. Before the fix the sugar id
+            was absent from the emission entirely — a non-vacuous oracle."
+    (let [text (emitted '[:div#hero (v/spread (:attrs props))])]
+      (is (.contains ^String text "re-frame.freehand.node/spread-attrs")
+          "the react lowering still folds through the shared seam")
+      (is (.contains ^String text "\"hero\"")
+          "and threads the #id sugar value into it — dropped before the fix")
+      (is (.contains ^String text ":div \"hero\"")
+          "the tag and sugar id ride together as the seam's element context"))))
+
 (deftest the-react-emitter-lowers-every-crossing-prop-marker
   (testing "A marked crossing prop carries ANALYSED CONTENT under its own
             key rather than a plain `:value`, which is exactly the shape an
@@ -389,6 +407,49 @@
             "the :value write's verdict is the once-bound runtime verdict, not a constant")
         (is (not (false? verdict-arg))
             "and specifically NOT the build-time false the bug baked in")))))
+
+(deftest an-owned-multiple-wins-over-the-safe-spread-caller-in-the-lowering
+  (testing "rf2-sf9n5 #6847 audit — a v/spread-safe caller folds UNDER the
+            owned props, so an owned :multiple declaration settles the whole-
+            element verdict and the caller is consulted only when the owned
+            props are silent on the slot. PR #6847 ORed the caller into the
+            verdict, so an owned :multiple false beside a caller :multiple true
+            shaped the owned nil :value as the empty collection though owned-
+            false won at caller-spread!. These prove the emitted verdict now
+            reads the EFFECTIVE owned source, never the caller."
+    (testing "owned literal :multiple false — the exact reproduction. The
+              verdict is the compile-time constant, so NO runtime verdict call
+              over the caller is emitted at all (before the fix an `or` with a
+              `(multiple-select? … caller …)` call was)."
+      (let [[e ast]  (analyzed '[:select (v/spread-safe {:value nil :multiple false}
+                                                        {:multiple true})])
+            form     (emit-react/emit-react-body e '[props] ast)
+            nodes    (tree-seq coll? seq form)
+            verdicts (filter #(and (seq? %)
+                                   (= 're-frame.freehand.controlled/multiple-select? (first %)))
+                             nodes)
+            callers  (filter #(and (seq? %)
+                                   (= 're-frame.freehand.node/safe-caller-attrs (first %)))
+                             nodes)]
+        (is (= 1 (count callers))
+            "the guarded caller map is still evaluated once — it is written, just not consulted")
+        (is (empty? verdicts)
+            "no multiple-select? verdict call is emitted: owned false is the constant verdict")))
+    (testing "owned DYNAMIC :multiple — the verdict reads the owned expression,
+              over the [[:multiple …]] owned source, never the caller map."
+      (let [[e ast]  (analyzed '[:select (v/spread-safe {:value nil :multiple (:m props)}
+                                                        {:multiple true})])
+            form     (emit-react/emit-react-body e '[props] ast)
+            nodes    (tree-seq coll? seq form)
+            verdicts (filter #(and (seq? %)
+                                   (= 're-frame.freehand.controlled/multiple-select? (first %)))
+                             nodes)]
+        (is (= 1 (count verdicts))
+            "exactly one runtime verdict is derived")
+        (is (vector? (nth (first verdicts) 2 nil))
+            "and it reads the OWNED [[:multiple …]] source (a vector), not the caller map (a symbol)")
+        (is (= 1 (count (filter #(= '(:m props) %) nodes)))
+            "the owned :multiple expression is evaluated exactly once")))))
 
 (deftest a-compiled-popover-carries-the-runtime-reconciliation-verdict
   (testing "rf2-drpa3.173 — #6792 recorded every analyzed reconciler position

--- a/implementation/freehand/test/re_frame/freehand/structural_slot_alias_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/structural_slot_alias_jvm_test.clj
@@ -512,6 +512,18 @@
           (is (= :rf.error/ui-tree-malformed (:rf.error/id (ex-data ex)))
               "through the interpreted seam's diagnostic — a runtime map, so a runtime refusal"))))))
 
+(defn- refusal-id
+  "The `:rf.error/id` of the ExceptionInfo `thunk` throws, or nil if it
+  returns. Used to prove a compiled lowering refuses at RUNTIME."
+  [thunk]
+  (try (thunk) nil
+       (catch clojure.lang.ExceptionInfo e (:rf.error/id (ex-data e)))))
+
+(defn- refusal-msg
+  [thunk]
+  (try (thunk) nil
+       (catch clojure.lang.ExceptionInfo e (ex-message e))))
+
 (deftest id-sugar-beside-a-spread-that-carries-an-id-is-refused
   (testing "rf2-5r1af probed defect. `#id` sugar wrote the element's id, and a
             forwarded map spells it again. Interpreted, the post-spread map
@@ -530,7 +542,53 @@
                   nil (catch clojure.lang.ExceptionInfo e e))]
       (is (some? ex) "and compiled, the two-id spread map is refused at the shared seam")
       (when ex
-        (is (= :rf.error/ui-tree-malformed (:rf.error/id (ex-data ex))))))))
+        (is (= :rf.error/ui-tree-malformed (:rf.error/id (ex-data ex)))))))
+  (testing "rf2-5r1af #6837 audit — the DISCRIMINATING case the prior fix
+            missed: `#id` sugar beside a spread that carries exactly ONE id.
+            The spread's own cardinality guard passes (one id merges to one),
+            so nothing catches it until the element fold — which the compiled
+            lowering never reaches. The earlier test used a spread that was
+            ITSELF two ids, so `spread-attrs` refused before the sugar was ever
+            compared. Threading the sugar fact into the compiled seam refuses
+            it in both compiled structural and compiled React, the diagnostic
+            and message identical to the interpreted element fold. The
+            interpreted arms are UNQUOTED so the spread actually runs to the
+            map the element fold refuses; the compiled arms are QUOTED so the
+            compiler lowers the form."
+    (is (= :rf.error/ui-tree-malformed
+           (refusal-id #(compiled-tree '[:div#sugar (v/spread {:id "a"})])))
+        "exact :id — the compiled structural spread refuses at the shared seam")
+    (is (= (refusal-msg #(tree/render [:div#sugar (v/spread {:id "a"})]))
+           (refusal-msg #(compiled-tree '[:div#sugar (v/spread {:id "a"})])))
+        "exact :id — interpreted and compiled name the collision identically")
+    (is (= :rf.error/ui-tree-malformed
+           (refusal-id #(compiled-tree '[:div#sugar (v/spread {:x/id "a"})])))
+        "alias :x/id — the compiled structural spread refuses at the shared seam")
+    (is (= (refusal-msg #(tree/render [:div#sugar (v/spread {:x/id "a"})]))
+           (refusal-msg #(compiled-tree '[:div#sugar (v/spread {:x/id "a"})])))
+        "alias :x/id — interpreted and compiled name the collision identically")
+    ;; The parity messages name the ELEMENT and its two spellings ("The element
+    ;; :div … #sugar sugar … :id"), the interpreted element-fold sentence — not
+    ;; the tag-less "forwarded attribute map" one the spread's own two-id
+    ;; conflict throws. That is what proves the compiled seam replays the FOLD.
+    (is (re-find #"element :div"
+                 (or (refusal-msg #(compiled-tree '[:div#sugar (v/spread {:id "a"})])) ""))
+        "the sentence names the element, matching the fold it replays")
+    (is (re-find #"twice"
+                 (or (refusal-msg #(compiled-tree '[:div#sugar (v/spread {:id "a"})])) ""))
+        "and says the id is spelled twice"))
+  (testing "non-vacuity controls — the guard refuses only the CONFLICT, not the
+            act of forwarding an id. A single forwarded id with NO sugar is an
+            ordinary attribute in both modes, and two EXACT :id writes in one
+            standalone spread are later-arg-wins (one id survives)."
+    (is (map? (compiled-tree '[:div (v/spread {:id "a"})]))
+        "no sugar, one forwarded id — accepted, compiled")
+    (is (nil? (refusal-id #(compiled-tree '[:div (v/spread {:id "a"})])))
+        "and it does not throw")
+    (is (= {:id "b"} (v/spread {:id "a"} {:id "b"}))
+        "two EXACT :id writes merge to one — later-arg-wins, no conflict")
+    (is (map? (compiled-tree '[:div#sugar (v/spread {:class "c"})]))
+        "sugar with a forwarded NON-id attr — no id ambiguity, accepted")))
 
 ;; ---------------------------------------------------------------------------
 ;; The scope fence


### PR DESCRIPTION
Three audit-reopen residuals on the Freehand emitter surface (single owner). Each fixes precisely what the prior parity fix missed or over-claimed.

## rf2-drpa3.164 — the compiled for-body refusal claimed a key it never checked
The `indirect-list-body` wrapper diagnostic asserted the wrapped markup was "the keyed node", but `wraps-markup-node?` only establishes that markup sits one form deeper — it never inspects the key through the wrapper. So `(for [x xs] (let [y x] [:li y]))` and `(for [x xs] (if x [:li x] (str x)))` were told the body wraps *the keyed node* though neither `[:li …]` carries `:key`, sending an author who took the recovery into a second build failure.

Fix: the sentence now names only what the analyzer proves — markup one form deeper — and states keyedness as a requirement of the row node the body must *be*, not a fact about the wrapper. A keyed and an unkeyed markup wrapper get the same honest message; a genuine scalar wrapper still keeps `unkeyed-list-item`. Docstrings corrected to match.

## rf2-5r1af — #id sugar beside a compiled spread carrying one id
`[:div#sugar (v/spread {:id "a"})]` refused interpreted but compiled emitted a single id with the sugar silently dropped. The spread's own cardinality guard passes (one id merges to one), and the compiled lowering never reaches the element-fold id check the interpreted walks apply. The earlier test only used a spread that was *itself* two ids, so `spread-attrs` refused before the sugar was ever compared.

Fix: thread the element's `#id` sugar fact into the shared `node/spread-attrs` seam (both compiled structural via `emit_jvm` and compiled React via `emit_react`). It refuses at runtime in the same two-step order the interpreted walks reach it — the spread's own cardinality first (tag-less, exactly what the public seam throws), then the element's sugar — so the message is byte-identical to the interpreted element fold. `:rf.error/ui-tree-malformed`, no new id. Later-arg-wins for two exact `:id` writes in a standalone spread is retained; the public interpreted seam is untouched.

## rf2-sf9n5 — the select-multiple verdict ORed the safe-spread caller
`[:select (v/spread-safe {:value nil :multiple false} {:multiple true})]` shaped the owned nil `value` as the empty collection though the element's final `multiple` (owned wins) was false — React's wrong-shape error. The verdict ORed caller and owned sources instead of applying `v/spread-safe`'s owned-wins law.

Fix: derive the verdict from the EFFECTIVE source after precedence — an owned `:multiple` declaration wins even when false (new `controlled/multiple-declared?` presence predicate), the caller decides only when the owned props are silent on the slot. Applied at the structural `node/element` fold (covers both structural modes), the interpreted React `react-props` fold, and the compiled React `mverdict`. An owned literal false is build-time so `dyn-multi` missed it; the compiled `mverdict` now reads the effective owned source. Once-only source-order evaluation preserved. No form model or general collection grammar.

`spec/004` unchanged: the id-slot cardinality law (004B) and the owned-wins law (004) already cover these cases — the residuals were implementation gaps against existing prose.

## Quality gates
- **freehand JVM** (`clojure -M:test`): 896 tests / 6451 assertions, 0 failures, 0 errors (baseline was 875/6293; ~21 added tests pass).
- **node cljs** (`npm run test:freehand`): 960 tests / 5522 assertions, 0 failures, 0 errors — validates the `react.cljs` owned-wins change and the cljs select-multiple parity/non-vacuity tests.
- **browser** (`npm run test:browser`): to CI.

Each bead carries a negative/adversarial case and a non-vacuity probe: unkeyed-vs-keyed wrapper message equality; the discriminating one-id sugar+spread with cross-mode message parity plus accept-controls (one forwarded id no sugar, two exact ids merge-to-one); owned-false-wins-over-caller-true both modes plus the caller-still-decides-when-owned-silent control and an emitted-form assertion that no caller verdict call is emitted when owned declares the slot.
