### PR TITLE
spec(012): EP-0037 R0a — route-address/destination schemas, extraction law, planning pipeline, diagnostic contract (rf2-kqxe6.2)

### DIFF
--- a/spec/012-Routing.md
+++ b/spec/012-Routing.md
@@ -86,6 +86,8 @@ Both live in `re-frame.routing` — they are **not** on the `rf/` (`re-frame.cor
 - `:rf/route-rank` — structural rank tuple (see [Spec-Schemas.md](Spec-Schemas.md#rfroute-rank)).
 - `:rf/route-slice` — the `:rf/route` slice shape (see [Spec-Schemas.md](Spec-Schemas.md#rfroute-slice)).
 - `:rf/pending-navigation` — the pending-nav slot shape (see [Spec-Schemas.md §`:rf/pending-navigation`](Spec-Schemas.md#rfpending-navigation)).
+- `:rf/route-address` — the closed caller-authored address `{:to :params :query :fragment}` every door resolves through (EP-0037 R0; see [Spec-Schemas.md §`:rf/route-address`](Spec-Schemas.md#rfroute-address) and [§The RouteAddress value](#the-routeaddress-value)).
+- `:rf/route-destination` — the address / raw-URL replay union used by pending-leave and entry-denial payloads (EP-0037 R0; see [Spec-Schemas.md §`:rf/route-destination`](Spec-Schemas.md#rfroute-destination)).
 
 ### Trace events
 
@@ -729,6 +731,102 @@ The three validation paths surface failures through **three different error/no-e
 The split is principled (per [§Param validation at the call site](#param-validation-at-the-call-site) above): caller-bug paths throw, event-boundary paths reject with a structured error, URL-driven paths route to the canonical not-found id. A consumer reading "the user tried to reach a route they can't parse" therefore branches differently per source: a caller-bug surfaces as an exception in dev (and as a substrate error in production); an event-boundary failure surfaces via the standard error substrate; a URL-driven failure surfaces via the not-found view's `:reason :validation` branch.
 
 **Asymmetry with flows.** Flows' validation surface is **flat by comparison** — `reg-flow` rejects a malformed flow map with one of **six** explicit error ids that all fire at registration time, all under `:rf.error/flow-*`: `:rf.error/flow-missing-id`, `:rf.error/flow-bad-id`, `:rf.error/flow-bad-inputs`, `:rf.error/flow-bad-output`, `:rf.error/flow-bad-path`, and `:rf.error/flow-bad-marks` (the registration-validation family, owned by [Spec-Schemas §FlowMeta](Spec-Schemas.md) and catalogued in [009 §Error event catalogue](009-Instrumentation.md#error-event-catalogue); reference implementation `implementation/flows/src/re_frame/flows/registry.cljc`). These are distinct from flows' **runtime** error ids (`:rf.error/flow-cycle`, `:rf.error/flow-path-overlap`, `:rf.error/flow-eval-exception`, per [013 §Failure semantics](013-Flows.md#failure-semantics)). Flows have a single validation time for the registration family (registration) and a single surface (registration-throw); routing has three validation times (caller-fn invocation / event-boundary interceptor / URL-driven match) and three surfaces (synchronous throw / structured error / not-found route). The asymmetry is **not a bug** — it is principled per the table above — but it does mean that an AI scanning routing for "validation error ids" does not see one closed family, and a tool building an aggregate "show me all validation failures" surface needs to subscribe to two distinct error ids plus a slice-write predicate. The split is the cost of routing's caller-bug-vs-user-input distinction; flows have no such distinction (registration is always caller code).
+
+<a id="the-routeaddress-and-the-shared-planning-pipeline"></a>
+## The `RouteAddress` and the shared planning pipeline (EP-0037 R0)
+
+[EP-0037](../docs/EP/EP-0037-route-planning-and-activation-ownership.md) makes routing one inspectable planning boundary: a caller-authored **address** is resolved once into a target, an active branch, and navigation policy, and every navigation door executes that one plan. This section is the R0 contract — the address value, the law that extracts it from the flat public maps each door accepts, the ordered planning pipeline every door lowers to, and the resolved-target / plan diagnostic projection. The stages that graduate later (honest readiness, the parent-to-leaf branch plan, terminal entry) are named to their EP-0037 sections and land in EP-0037's later slices; existing runtime behaviour is otherwise preserved.
+
+<a id="the-routeaddress-value"></a>
+### The `RouteAddress` value
+
+A registered destination is one closed, ordinary EDN map — caller *intent* for one named route (EP-0037 §Terms, §Canonical `RouteAddress`):
+
+```clojure
+{:to       :route/article
+ :params   {:slug "routing-as-data"}
+ :query    {:tab :comments}
+ :fragment "reply-42"}
+```
+
+Its schema id is `:rf/route-address` ([Spec-Schemas §`:rf/route-address`](Spec-Schemas.md#rfroute-address)): a closed `[:map {:closed true} [:to :keyword] [:params {:optional true} :map] [:query {:optional true} :map] [:fragment {:optional true} [:maybe :string]]]`. `:to` is required; omitted `:params` / `:query` normalise to `{}`, an omitted or `nil` `:fragment` to no fragment. There is no record, constructor, builder, relative-address language, or redirect object — an application names address constants and pure functions with ordinary Clojure values.
+
+The same four fields are consumed wherever an address is stored, printed, linked, navigated to, denied, returned to, or prefetched: `rf.routing/route-url`, `rf/route-link` / `v/route-link` (as control fields inside the larger props map), the destination branch of `:rf.route/navigate`, the named destination carried by entry-denied and pending-leave data, application redirect / return-to state, and `:rf.route/prefetch`. Two companion values complete the vocabulary (EP-0037 §Terms):
+
+- **`RouteDestination`** ([`:rf/route-destination`](Spec-Schemas.md#rfroute-destination)) — the closed replay union of a `RouteAddress` and the raw-URL escape, used where runtime state must replay a destination that may have no named spelling. It never absorbs navigation policy.
+- **`ResolvedTarget`** — planner output (`:route-id`, `:params`, `:query`, `:fragment`, `:url`) after matching, defaults, and validation. It is a *fact*, not another accepted input spelling; facts say `:route-id`, intent says `:to`.
+
+Policy and edits are deliberately **not** part of the address. Navigation policy (`:replace?`, `:scroll`, and the leave-only `:bypass-leave?`) and the in-place edit `:query-merge` travel in the same flat map but keep their own shapes, so no future feature can make a policy or edit key serialisable as a destination (EP-0037 §Navigation policy and in-place edits). Public call sites stay flat — a `:rf.route/navigate` request is an address plus navigation policy; a `route-link` props map is an address plus link behaviour and ordinary DOM attributes — and no nested `{:address … :policy …}` envelope is introduced to encode the separation.
+
+<a id="the-extraction-law"></a>
+### The extraction law
+
+Every door extracts and validates the address through **one** shared law over closed key classes (EP-0037 §Normative extraction from flat public maps):
+
+```clojure
+address keys       #{:to :params :query :fragment}
+policy keys        #{:replace? :scroll :bypass-leave?}
+edit keys          #{:query :query-merge :fragment}
+link behavior keys #{:prefetch}
+```
+
+Key **presence** selects the request branch *before* any validation:
+
+1. **`:to` present** — the extractor selects exactly the address keys and validates that extracted map against `:rf/route-address`. `:query` and `:fragment` are destination facts in this branch.
+2. **`:url` present** — the extractor selects the raw destination and validates it against the raw arm of `:rf/route-destination`. `:to`, `:params`, `:query`, and `:query-merge` are forbidden beside it; an explicit `:fragment` overrides the URL-embedded one under the existing fragment rule.
+3. **neither `:to` nor `:url`** — `:query`, `:query-merge`, and `:fragment` are **in-place edits**. They are never validated or stored as a `RouteAddress`. A `:params` key in this branch retains the named `:rf.error/navigate-bad-request` reason `:params-requires-destination`: changing path params always requires a destination (see [§In-place navigation](#in-place-navigation)).
+
+Policy keys are extracted and validated **separately** from the address. Every closed control-map boundary — navigation, URL generation, prefetch, stored-destination replay — validates its **whole accepted-key roster before extraction**, so extraction can never silently discard a misspelled address, policy, or edit key; the navigate structural gate's `:unknown-keys` rejection (namespaced keys included) is exactly this whole-roster check (see [§Validity rules](#validity-rules--the-always-on-structural-gate)). Because only the extracted address reaches the closed schema, a flat wrapper carrying `{:to … :params … :replace? true}` navigates to the same target and URL whether or not the policy key is present — the policy changes the *effect* (`replaceState` vs `pushState`), not the destination. (The set-valued `:bypass-guards?` is retired in favour of the boolean `:bypass-leave?` in EP-0037 R4; see [§Navigation blocking](#navigation-blocking--pending-nav-protocol).)
+
+`route-link` is the one deliberate exception, because its props map is *also* an open DOM-attribute map: it validates the recognised routing controls (including `:prefetch`), strips the exact address and behaviour keys before DOM emission, and passes the remaining attributes and children to the view substrate. It does not ask routing to classify every misspelled control against a caller-authored DOM attribute; host / view DOM diagnostics own unknown attributes. The schema is therefore closed over the *extracted address*, not over the convenient flat props map a link accepts (EP-0037 §Normative extraction from flat public maps).
+
+<a id="raw-url-escape"></a>
+#### The raw-URL escape
+
+`{:url "/partner/supplied/path"}` remains a stringly escape accepted by navigation doors that must handle an already-authored URL (deep-link handlers, server-redirect targets, a programmatic redirect from a string). It is **not** a `RouteAddress`, cannot combine with `:params` / `:query`, and is not accepted by `route-url` or prefetch. If it matches a registered route the planner produces the same resolved target and canonical named address it would from `:to`; if it does not, the existing same-origin / not-found rules apply (see [§Target form](#target-form--route-id-or-url-string)). Where runtime state must replay either form, `:rf/route-destination` is the closed union of a `RouteAddress` and this raw map; a matching raw URL normalises to the named branch, and only a destination that cannot be reified without changing the requested URL stays raw (EP-0037 §Raw URL escape).
+
+<a id="the-one-planning-pipeline"></a>
+### The one planning pipeline
+
+Every navigation door — a `route-link` click, `:rf.route/navigate`, Back / Forward, initial load, and SSR — lowers to the **same** ordered stages. Doors differ in cause and history / scroll policy, not in target, entry, resource, or readiness semantics (EP-0037 §One planning pipeline for every door):
+
+| Stage | Result | Failure / short-circuit |
+|---|---|---|
+| 1. Validate intent | accepted address / raw URL / in-place edit plus policy | a malformed request rejects before any guard or history effect |
+| 2. Resolve target | canonical target, URL, named address when possible, parent branch | schema / URL failures follow the existing not-found or caller-error contract |
+| 3. Classify transition | full, fragment-only, or no-op | a no-op terminates before guards, pending state, history, scroll, or activation |
+| 4. Decide leave | allow, or a leave-only pending navigation | full and fragment-only transitions consult the current route; pending leave preserves it, and popstate restores its URL |
+| 5. Decide entry | allow, or a terminal entry denial | full and fragment-only transitions consult the target route; denial commits no target and creates no pending entry |
+| 6. Build activation plan | for a full transition, the effective resource plan and old/new identity diff | fragment-only skips activation planning; a planning failure produces a failed plan and no partial resource plan executes |
+| 7. Commit and activate | route facts / plan ownership, history / scroll effects, resource ensures, activation events | stale completions stay fenced by token / generation |
+
+Classification precedes the guards deliberately: an exact **no-op** evaluates neither guard — nothing is being left or entered, and a redundant request must not create pending or denied state. A **full** transition evaluates `:can-leave` then `:can-enter`, including a same-route activation whose canonical `:params` or `:query` changed; query is data-bearing, so the in-place request form is not an implicit guard bypass. A **fragment-only** transition preserves 012's existing both-guard [fragment contract](#fragments) and skips only resource planning and activation. Initial load has no current leave guard but evaluates target entry normally. Transition kind is derived from resolved **facts**, not request spelling (EP-0037 §Resolved target and route plan): *full* when there is no current target or `:route-id` / `:params` / `:query` differ, *fragment-only* when those three are equal and only `:fragment` differs, *no-op* when all four are equal. A changed in-place `:query` / `:query-merge` is therefore a full, data-bearing activation, not a weaker path.
+
+The programmatic, link, URL-change, initial-load, and SSR handlers may remain separate public events for cause-specific tests and host integration, but they call the **same** resolver, decisions, planner, and commit assembler — no door reimplements guard coverage or resource planning. The existing [state-first ordering](#state-first-url-second-update-order-is-locked) holds: the frame's committed route facts and next plan ownership are established before any client history effect and before activation events; a URL-driven door performs no push (the browser has already moved), and a blocked or denied popstate restores the current route's URL by replace.
+
+<a id="failed-activation"></a>
+#### Failed activation
+
+A resource-planning failure is a committed **failed activation**, not a return to the prior page (EP-0037 §One planning pipeline for every door, §Honest activation and readiness): the target and URL **commit**, route readiness projects `:error`, and **no** resource ensure from the invalid plan runs. The target's `:on-match` events do **not** run — committing target facts makes the failure addressable and gives client and SSR error views stable route context, but a failed activation is not a successful activation boundary for analytics, host notification, or state seeding. The structured planning error and its trace are the causal facts an application observes; a retry is a fresh navigation and dispatches `:on-match` only after its plan forms successfully.
+
+Plan execution is atomic at this boundary: a failed plan contributes an empty next-ownership set, so after the failed target / error facts are installed every owner held only by the previous route plan is released, no partially planned next owner is attached, and no partial ensure is dispatched. A committed full activation allocates a fresh nav-token; a fragment-only transition and a no-op allocate none, and prefetch (not an activation) allocates none. The full readiness projection — `:rf.route/transition` / `:rf.route/error` as a resource-derived value — graduates in EP-0037 R1, and the parent-to-leaf branch plan in R2; the terminal-entry protocol that retires the resumable enter machinery graduates in R4. R0 fixes the stage order and the failed-activation rule above; existing runtime behaviour is otherwise preserved.
+
+<a id="resolved-target-and-the-plan-diagnostic-projection"></a>
+### Resolved target and the plan diagnostic projection
+
+Planning turns the caller's address into resolved **facts** — a `ResolvedTarget`:
+
+```clojure
+{:route-id :route/article
+ :params   {:slug "routing-as-data"}
+ :query    {:tab :comments}
+ :fragment "reply-42"
+ :url      "/articles/routing-as-data?tab=comments#reply-42"}
+```
+
+It is passed to guard subscriptions, recorded in diagnostics, and used to derive the parent chain. The internal **route plan** is plain data carrying at least the source address or raw-URL request, the resolved target, the cause (`:link`, `:navigate`, `:popstate`, `:initial`, or `:ssr`), the parent-to-leaf branch, the effective resource requirements and their contributors, the transition kind, history / scroll policy, and the old/new resource-identity diff for ownership handoff. It is an implementation and tooling seam — this contract adds no public `RoutePlan` constructor or promise-returning router object; its observable laws are public and its diagnostic projection is visible in trace / Xray (EP-0037 §Resolved target and route plan).
+
+The plan must be legible without executing view code, and its diagnostic projection graduates with the planner (EP-0037 §Tooling and observability): **R0 exposes only the source address and cause, the resolved target, the parent-to-leaf branch, and the behaviour-preserving leaf resource plan** — the minimum needed to prove the shared spine. R2 adds occurrence / dependency groups, contributor dedupe advisories, the grouped order, and the identity diff; later slices prove the integrated view. No slice is licence to build a second Xray graph or a general-purpose public plan debugger.
 
 ## Per-route data loading
 

--- a/spec/Spec-Schemas.md
+++ b/spec/Spec-Schemas.md
@@ -3569,6 +3569,44 @@ The structural-rank tuple `match-url` computes for each registered route, per [0
 
 Implementations rank candidates by descending `route-rank` then by ascending registration time (stable sort) — the **earlier** registration wins an equal-score tie. Equal-score candidates **whose patterns can match a common URL** (the [012 §Route ranking algorithm](012-Routing.md#route-ranking-algorithm) rule-6 "same URL family" — co-matchability, decided by language intersection over the patterns' segment automata) emit `:rf.warning/route-shadowed-by-equal-score` at registration time per [API.md §Error contract](API.md#error-contract). Equal rank alone MUST NOT warn — rank tuples ignore literal segment text, so `/x/:id` and `/y/:slug` tie structurally yet never co-match (rf2-6gzobp). The warning's `:tags` carry `{:route-id <the NEW, shadowed route> :shadowed-by <the existing winner> :rank <the tied structural RouteRank>}`.
 
+### `:rf/route-address`
+
+> **Layer:** Public
+> **Owner:** [012-Routing §The RouteAddress value](012-Routing.md#the-routeaddress-value)
+> **Status:** v1-required
+
+The caller-authored **address** of one registered named destination — the closed `{:to :params :query :fragment}` map every navigation door, `route-url`, `rf/route-link`, and `v/route-link` resolves through ([EP-0037](../docs/EP/EP-0037-route-planning-and-activation-ownership.md) §Terms, §Canonical `RouteAddress`). It is destination *intent*, never navigation policy (`:replace?` / `:scroll` / `:bypass-leave?`) and never an in-place edit (`:query-merge`); those travel beside the address in the same flat public map but keep their own shapes, so a future feature cannot make a policy or edit key serialisable as a destination. The resolved *fact* is the [`:rf/route-slice`](#rfroute-slice) — facts say `:route-id`, intent says `:to`.
+
+```clojure
+(def RouteAddress
+  [:map {:closed true}
+   [:to       :keyword]                                                    ;; required — the registered route id
+   [:params   {:optional true} :map]                                       ;; path params; omitted normalises to {}
+   [:query    {:optional true} :map]                                       ;; query params; omitted normalises to {}
+   [:fragment {:optional true} [:maybe :string]]])                         ;; #fragment; omitted / nil normalises to no fragment
+```
+
+The map is **closed**: an unknown address key fails at the authoring or event boundary in every build (dev *and* prod) — the same closure the navigate structural gate enforces (`:rf.error/navigate-bad-request`, `:reason :unknown-keys`; see [012 §The extraction law](012-Routing.md#the-extraction-law)). `:to` is required; omitted `:params` / `:query` normalise to `{}`, an omitted or `nil` `:fragment` to no fragment. Route param / query validation, canonical EDN identity, query defaults, URL encoding, and not-found behaviour remain owned by [012](012-Routing.md#the-routeaddress-value). The value is **extracted** from the flat public map each door accepts *before* validation, so only the four address keys ever reach this schema — never the convenient flat props/request map a door accepts. There is no record, constructor, builder, relative-address language, or redirect object; applications name address constants with ordinary Clojure values. Implementations register it via `reg-app-schema [:rf/route-address]`.
+
+### `:rf/route-destination`
+
+> **Layer:** Runtime
+> **Owner:** [012-Routing §The raw-URL escape](012-Routing.md#raw-url-escape)
+> **Status:** v1-required
+
+The closed **replay union** of a `:rf/route-address` and the raw-URL escape — the shape runtime state uses when it must preserve a requested destination that may have no named-route spelling ([EP-0037](../docs/EP/EP-0037-route-planning-and-activation-ownership.md) §Terms, §Raw URL escape). Leave-only pending-navigation and entry-denial payloads carry it; a matching raw URL normalises to the named branch, and only a destination that cannot be reified without changing the requested URL stays raw. It never absorbs navigation policy — a pending leave stores explicit policy beside it (see [§`:rf/pending-navigation`](#rfpending-navigation)).
+
+```clojure
+(def RouteDestination
+  [:or
+   RouteAddress                                                            ;; the named-destination branch (:rf/route-address)
+   [:map {:closed true}
+    [:url      :string]                                                    ;; the raw-URL escape; a raw URL IS the address
+    [:fragment {:optional true} [:maybe :string]]]])                       ;; explicit #fragment override of a URL-embedded one
+```
+
+The raw branch is a required string `:url` plus an optional string-or-`nil` `:fragment`; it excludes `:to`, `:params`, `:query`, and `:query-merge` (a raw URL IS the address). It is a *replay* shape only — it does **not** give `route-url` or prefetch a second accepted input spelling; those take a `:rf/route-address`.
+
 ### `:rf/route-slice`
 
 > **Layer:** Runtime

--- a/spec/conformance/fixtures/routing-address-extraction.edn
+++ b/spec/conformance/fixtures/routing-address-extraction.edn
@@ -1,0 +1,109 @@
+;; Conformance fixture: routing/address-extraction
+;;
+;; EP-0037 R0 — conformance row 1 (address parity, incl. flat-wrapper
+;; extraction proof). Per Spec 012 §The extraction law: every navigation
+;; door extracts and validates the RouteAddress (`{:to :params :query
+;; :fragment}`) from the flat public request map BEFORE validation, over
+;; closed key classes. Only the extracted address reaches the closed
+;; `:rf/route-address` schema; navigation policy (`:replace?`) and in-place
+;; edits (`:query`) are separate classes.
+;;
+;; The fixture pins the R0 arms of address parity:
+;;   1. FLAT-WRAPPER EXTRACTION — a request carrying an address plus the
+;;      policy key `:replace?` navigates to the target the ADDRESS names;
+;;      the policy changes only the EFFECT (`:rf.nav/replace-url` vs
+;;      `:rf.nav/push-url`), never the resolved target/URL. `route-url`
+;;      builds the SAME URL from the same address fields (parity across
+;;      surfaces).
+;;   2. `:params-requires-destination` — an in-place request carrying
+;;      `:params` (no `:to`/`:url`) rejects with `:rf.error/navigate-bad-
+;;      request`; changing path params always requires a destination.
+;;   3. EDIT-BRANCH complement — an in-place `{:query ...}` request follows
+;;      the edit branch: it PATCHES the current location (route-id + params
+;;      carried, query replaced) and is never validated/stored as a
+;;      RouteAddress.
+;;   4. WHOLE-ROSTER validation before extraction — a misspelled/foreign key
+;;      (namespaced included) rejects with `:reason :unknown-keys` even when
+;;      `:to` is present, so extraction can never silently discard a key.
+;;
+;; Per [012 §The extraction law] (#the-extraction-law) and
+;; [§Validity rules] (#validity-rules--the-always-on-structural-gate).
+
+{:fixture/id           :routing/address-extraction
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:routing/match-url :core/event-handler :core/fx :core/error :core/trace}
+ :fixture/doc          "EP-0037 R0 address parity (row 1): a flat wrapper carrying an address plus the policy key :replace? navigates to the address's target — policy changes only the effect (replace-url vs push-url), not the resolved target/URL, and route-url builds the same URL. In-place :params rejects with :params-requires-destination; an in-place {:query} follows the edit branch (route-id + params carried, query replaced); an unknown key (namespaced included) rejects with :unknown-keys before extraction."
+
+ :fixture/registry
+ {:event {:rf/init           {:doc "Seed the current route."}
+          :rf.route/navigate {:doc "Navigate to a registered route."}}
+  :route {:route/home    {:path "/"}
+          :route/article {:path   "/articles/:slug"
+                          :params [:map [:slug :string]]}}
+  :fx    {:rf.nav/push-url    {:platforms #{:client}}
+          :rf.nav/replace-url {:platforms #{:client}}
+          :rf.nav/scroll      {:platforms #{:client}}}}
+
+ ;; The fixture does NOT override :rf.route/navigate — the runtime's built-in
+ ;; handler (per Spec 012) extracts the address, applies policy, and emits the
+ ;; push/replace effect, which is exactly what :effects-routed asserts.
+ :fixture/handlers
+ {:event {:rf/init [[:set-runtime [:rf.runtime/routing :current] {:route-id :route/home :params {}}]]}
+  :fx    {:rf.nav/push-url    [[:noop]]
+          :rf.nav/replace-url [[:noop]]
+          :rf.nav/scroll      [[:noop]]}}
+
+ :fixture/frame-config {:initial-events [[:rf/init]] :platform :client}
+
+ :fixture/dispatches
+ [;; (1) Flat wrapper: address (:to/:params/:query) + policy (:replace?).
+  ;;     Extracts to route/article; :replace? honoured as REPLACE, not part
+  ;;     of the address.
+  [:rf.route/navigate {:to :route/article :params {:slug "routing-as-data"} :query {:tab "comments"} :replace? true}]
+
+  ;; (2) In-place :params (no :to/:url) — REJECTS. Changing path params is a
+  ;;     destination, never an in-place edit.
+  [:rf.route/navigate {:params {:slug "x"}}]
+
+  ;; (3) In-place {:query} — EDIT branch. Stays on route/article, carries the
+  ;;     slug, replaces the query wholesale. Never validated as a RouteAddress.
+  [:rf.route/navigate {:query {:tab "history"}}]
+
+  ;; (4) Unknown namespaced key beside a valid :to — REJECTS before
+  ;;     extraction (whole-roster validation), so a misspelled/foreign key is
+  ;;     never silently discarded.
+  [:rf.route/navigate {:to :route/article :params {:slug "x"} :my-app/replace? true}]]
+
+ :fixture/calls
+ ;; Address parity across surfaces: route-url builds the SAME URL from the
+ ;; same address fields the flat wrapper carried in dispatch (1) — the policy
+ ;; key is absent here yet the URL is identical, so policy is not address.
+ [{:call :route-url :route-id :route/article :params {:slug "routing-as-data"} :query {:tab "comments"}
+   :expect "/articles/routing-as-data?tab=comments"}]
+
+ :fixture/expect
+ ;; Final slice after all four dispatches: the in-place edit (3) left
+ ;; route/article + slug intact and replaced the query; (2) and (4) rejected
+ ;; and changed nothing. Submap match tolerates :transition/:nav-token/etc.
+ {:final-runtime-db
+  {:rf.runtime/routing
+   {:current {:route-id :route/article
+              :params   {:slug "routing-as-data"}
+              :query    {:tab "history"}
+              :fragment nil}}}
+
+  ;; Policy honoured separately from the address: (1) REPLACES (:replace?
+  ;; true), (3) PUSHES (default, edit branch). The resolved URLs come from the
+  ;; extracted address only.
+  :effects-routed
+  [{:fx-id :rf.nav/replace-url :args "/articles/routing-as-data?tab=comments"}
+   {:fx-id :rf.nav/push-url    :args "/articles/routing-as-data?tab=history"}]
+
+  ;; Both rejections ride the always-on structural gate BEFORE any extraction.
+  :trace-emissions
+  [{:operation :rf.error/navigate-bad-request
+    :op-type   :error
+    :tags      {:where :event :reason :params-requires-destination :keys [:params]}}
+   {:operation :rf.error/navigate-bad-request
+    :op-type   :error
+    :tags      {:where :event :reason :unknown-keys :keys [:my-app/replace?]}}]}}

--- a/spec/conformance/fixtures/routing-door-parity.edn
+++ b/spec/conformance/fixtures/routing-door-parity.edn
@@ -1,0 +1,92 @@
+;; Conformance fixture: routing/door-parity
+;;
+;; EP-0037 R0 — conformance row 2 (door parity, the R0 target spine). Per
+;; Spec 012 §The one planning pipeline: every navigation door lowers to the
+;; SAME resolver — a named address, a matching raw URL, and the URL-driven
+;; door (popstate / initial / SSR) all resolve to one canonical target.
+;; Doors differ only in cause-specific history/scroll effects.
+;;
+;; The fixture pins the R0 arms of door parity:
+;;   1. NAMED-ADDRESS door — a programmatic `{:to ... :params ...}` navigate
+;;      commits the target and PUSHES the URL.
+;;   2. RAW-URL door — a programmatic `{:url ...}` navigate to the SAME
+;;      destination resolves to an IDENTICAL target and is therefore a rule-3
+;;      no-op (returns {}): no second push, no token. The no-op is the strict
+;;      oracle — the raw-URL door could only be identical if it resolved to
+;;      exactly the target the named-address door committed.
+;;   3. URL-DRIVEN door — `[:rf.route/handle-url-change url]` (the shared
+;;      popstate / initial / SSR entry) lands the SAME target from the URL and
+;;      does NOT push (the URL already came from the browser).
+;;
+;; The pure resolver parity is proven directly by the calls: match-url (the
+;; raw-URL door's resolver) and route-url (the named-address door's URL
+;; builder) are inverse and converge on the same target/URL; round-trip pins
+;; the identity.
+;;
+;; Per [012 §The one planning pipeline] (#the-one-planning-pipeline) and
+;; [§URL changes are events] (#url-changes-are-events).
+
+{:fixture/id           :routing/door-parity
+ :fixture/spec-version "1.0"
+ :fixture/capabilities #{:routing/match-url :core/event-handler :core/fx}
+ :fixture/doc          "EP-0037 R0 door parity (row 2): a named-address navigate, a matching raw-URL navigate, and the URL-driven handle-url-change door all resolve to one canonical target. The raw-URL navigate to the already-current target is a strict rule-3 no-op (proving it resolved identically to the named-address door); the URL-driven door lands the same target without a history push. Only the named-address door pushes. match-url and route-url are inverse and converge (calls)."
+
+ :fixture/registry
+ {:event {:rf/init                    {:doc "Seed the current route."}
+          :rf.route/navigate          {:doc "Programmatic navigation door."}
+          :rf.route/handle-url-change {:doc "URL-driven door (popstate / initial / SSR)."}}
+  :route {:route/home    {:path "/"}
+          :route/article {:path   "/articles/:slug"
+                          :params [:map [:slug :string]]}}
+  :fx    {:rf.nav/push-url    {:platforms #{:client}}
+          :rf.nav/replace-url {:platforms #{:client}}
+          :rf.nav/scroll      {:platforms #{:client}}}}
+
+ ;; No door handler is overridden — the runtime's built-in handlers (per Spec
+ ;; 012) share one resolver, which is the parity being asserted.
+ :fixture/handlers
+ {:event {:rf/init [[:set-runtime [:rf.runtime/routing :current] {:route-id :route/home :params {}}]]}
+  :fx    {:rf.nav/push-url    [[:noop]]
+          :rf.nav/replace-url [[:noop]]
+          :rf.nav/scroll      [[:noop]]}}
+
+ :fixture/frame-config {:initial-events [[:rf/init]] :platform :client}
+
+ :fixture/dispatches
+ [;; (1) Named-address door — commits route/article, PUSHES the URL.
+  [:rf.route/navigate {:to :route/article :params {:slug "routing-as-data"}}]
+
+  ;; (2) Raw-URL door to the SAME destination — resolves to an identical
+  ;;     target, so it is a rule-3 no-op ({}). No second push. The absence of
+  ;;     a change strictly proves the raw URL resolved to exactly the named
+  ;;     target committed by (1).
+  [:rf.route/navigate {:url "/articles/routing-as-data"}]
+
+  ;; (3) URL-driven door (popstate / initial / SSR) — lands the SAME target
+  ;;     from the URL; does NOT push (the URL came from the browser).
+  [:rf.route/handle-url-change "/articles/routing-as-data"]]
+
+ :fixture/calls
+ ;; Pure resolver parity: the raw-URL door's resolver (match-url) and the
+ ;; named-address door's URL builder (route-url) are inverse and converge on
+ ;; the same target/URL; round-trip pins the identity.
+ [{:call :match-url :url "/articles/routing-as-data"
+   :expect {:route-id :route/article :params {:slug "routing-as-data"} :query {} :fragment nil :validation-failed? false}}
+  {:call :route-url :route-id :route/article :params {:slug "routing-as-data"}
+   :expect "/articles/routing-as-data"}
+  {:call :round-trip :url "/articles/routing-as-data"}]
+
+ :fixture/expect
+ ;; All three doors converge on one canonical target. Submap match tolerates
+ ;; :transition/:nav-token/etc.
+ {:final-runtime-db
+  {:rf.runtime/routing
+   {:current {:route-id :route/article
+              :params   {:slug "routing-as-data"}
+              :query    {}
+              :fragment nil}}}
+
+  ;; Only the named-address door (1) drives a history push. The raw-URL door
+  ;; (2) no-ops; the URL-driven door (3) never pushes.
+  :effects-routed
+  [{:fx-id :rf.nav/push-url :args "/articles/routing-as-data"}]}}


### PR DESCRIPTION
Delivers the contract half of EP-0037 slice R0 (the epic's graduation slices). Ships **contract + fixtures only** — existing runtime behaviour is preserved; the shared implementation seam is the next bead (R0b). Cites EP-0037 sections rather than restating them.

## What this delivers

**`spec/Spec-Schemas.md`** — two registered framework schemas:
- `:rf/route-address` — the closed, extracted caller-authored address `{:to :params :query :fragment}` (`[:map {:closed true} …]`).
- `:rf/route-destination` — the closed replay union of a `RouteAddress` and the raw-URL escape (used by leave-only pending-navigation / entry-denial payloads).

**`spec/012-Routing.md`** — a new normative section, *The `RouteAddress` and the shared planning pipeline (EP-0037 R0)*:
- the `RouteAddress` value + the `RouteDestination` / `ResolvedTarget` companion terms (per EP §Terms, §Canonical `RouteAddress`);
- the **extraction law** — address / policy / edit key classes, presence-based branch selection, whole-roster validation *before* extraction, `:params-requires-destination` retained, the raw-URL escape, and `route-link`'s open-props exception;
- the **one seven-stage planning pipeline** (validate → resolve → classify → leave → entry → build-plan → commit) every door lowers to, with the **failed-activation rule** (target + URL commit, readiness `:error`, `:on-match` does **not** run, atomic ownership handoff);
- the **ResolvedTarget / plan diagnostic projection** contract (R0 exposes source+cause, resolved target, branch, and the behaviour-preserving leaf plan).

Note on stage order: the EP's canonical pipeline table places **classify at stage 3 (before the guards)** — an explicit EP ruling ("an exact no-op must evaluate neither guard"). This PR reproduces the EP table faithfully; the bead's parenthetical shorthand transposed classify with leave/entry.

**Conformance fixtures** (`spec/conformance/fixtures/`, host-neutral EDN):
- `routing-address-extraction.edn` — EP conformance **row 1** (address parity incl. flat-wrapper extraction proof): a flat wrapper carrying an address + the policy key `:replace?` navigates to the address's target (policy changes only the effect, not the target/URL; `route-url` builds the same URL); in-place `:params` rejects with `:params-requires-destination`; in-place `{:query}` follows the edit branch; an unknown namespaced key rejects with `:unknown-keys` before extraction.
- `routing-door-parity.edn` — EP conformance **row 2** (door parity): named-address, matching raw-URL, and URL-driven (`handle-url-change`) doors converge on one target; the raw-URL door to an already-current target is a strict rule-3 no-op (proving identical resolution); only the named-address door pushes; `match-url` ∘ `route-url` parity is pinned by the pure calls.

Row 3 (passive render) is **fenced** — owned by the parallel R0c worker and intentionally not created here.

## Quality gates

Run foreground from the worktree; logs captured under `gate-*.log`.

| Gate | Result |
|---|---|
| `python scripts/check_doc_slugs.py` | **PASS** (EXIT=0) — all new anchors/links resolve |
| `python -m mkdocs build --strict` | **PASS** (EXIT=0) |
| `scripts/test-fast-pr.sh` — static/lockstep/drift gates | **PASS** |
| `scripts/test-fast-pr.sh` — README link/anchor + docs corpus anchor validators | **PASS** |
| `scripts/test-fast-pr.sh` — **core JVM suite** (incl. routing conformance corpus with both new fixtures) | **PASS** — Ran 2104 tests / 10415 assertions, 0 failures, 0 errors |
| `scripts/test-fast-pr.sh` — JS harness self-tests | **PASS** |
| Both new fixtures via `run-fixture` (JVM leaf) | **PASS** — `:passed? true` each |
| `scripts/test-fast-pr.sh` — `npm run test:cljs` (CLJS node integration) | **skipped (ENV)** — `shadow-cljs` not installed in this fresh worktree (no `npm install`); CI runs it. Fixtures are host-neutral (submap runtime-db, subset effects/traces, pure `route-url`/`match-url` calls) and green on the byte-identical JVM leaf. |
| `scripts/test-fast-pr.sh` — EP status-sync | **pre-existing FAIL, not in scope** — `docs/EP/README.md:51` still lists EP-0037 as `proposal` though the EP's `Status:` is `accepted` (drift already on `main` from the acceptance commit). This PR does not touch `docs/EP` (fenced: the EP-authoring worktrees own that surface); numstat confirms zero changes there. |

The only two spine failures are both outside this PR's diff: the fenced `docs/EP` index drift and the missing `shadow-cljs` binary. The deliverable's own gates — doc anchors/slugs, mkdocs, the JVM conformance corpus carrying both fixtures — are green.
