### PR TITLE
fix(freehand): compiled v/behavior residuals — opaque-child runtime guard + manifest/render-static visibility (rf2-drpa3.127, .116)

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/behaviors.cljc
+++ b/implementation/freehand/src/re_frame/freehand/behaviors.cljc
@@ -358,6 +358,28 @@
       (or (nil? rest*)
           (and (map? (first rest*)) (nil? (next rest*)))))))
 
+(defn- opaque-child!
+  "Raise the opaque-child law for behavior `use`: it is declared
+  `{:opaque true}`, so it owns its node's descendants and the node it decorates
+  carries no Freehand children — children declared there would render and then
+  be overwritten the moment the host connects.
+
+  The three paths reach ONE diagnostic once each has decided, in the child
+  representation it actually holds, that the decorated node is non-empty: the
+  JVM structural render and the interpreted browser walk through
+  [[read-opts]]'s [[childless?]] over a form or a structural node, and the
+  compiled browser path through [[element-childless?]] over the already-built
+  React element. One raise, so the modes agree rather than merely coincide."
+  [use]
+  (bad-args!
+    'v/behavior
+    (str "Behavior " use " is declared {:opaque true} — it owns the node's "
+         "descendants — so the node it decorates carries no Freehand children. "
+         "Children declared here would be rendered and then overwritten by the "
+         "host the moment it connects.")
+    :leave-an-opaque-behaviors-node-empty
+    {:use use}))
+
 (defn check-attach-opts!
   "Validate the closed option roster and the `:use`/`:config` values of one
   `[v/behavior {…} node]` call, and answer `{:use :target :config}` — every
@@ -449,14 +471,7 @@
           :decorate-exactly-one-element
           {:child (shape child)}))
       (when (and (:opaque (definition use)) (not (childless? child)))
-        (bad-args!
-          'v/behavior
-          (str "Behavior " use " is declared {:opaque true} — it owns the node's "
-               "descendants — so the node it decorates carries no Freehand children. "
-               "Children declared here would be rendered and then overwritten by the "
-               "host the moment it connects.")
-          :leave-an-opaque-behaviors-node-empty
-          {:use use}))
+        (opaque-child! use))
       {:use use :target target :config config :child child})))
 
 ;; ---------------------------------------------------------------------------
@@ -867,19 +882,49 @@
 ;; needs no walk and no candidate of its own here: the element's event sites
 ;; were already committed under the compiled view's candidate, and its
 ;; one-element shape was proven by the compiled analyzer. What is left is
-;; exactly the lifecycle — and that is the interpreted boundary's own
-;; `use-attachment!`/`attach`/`check-attach-opts!`, reached identically, so a
-;; compiled attachment connects, updates, commands and tears down the same as
-;; its interpreted twin (D013). The difference from `behavior-component` is the
-;; difference between the two modes and nothing else: the interpreted boundary
-;; WALKS its child from markup, this one is HANDED it already built — exactly
-;; the split `presence-boundary` has across `presence-node` and `emit-presence`.
+;; exactly the lifecycle PLUS the one child-dependent law the build could not
+;; settle — and that is the interpreted boundary's own
+;; `use-attachment!`/`attach`/`check-attach-opts!` plus the opaque-child guard,
+;; reached identically, so a compiled attachment connects, updates, commands,
+;; tears down AND refuses the same as its interpreted twin (D013). The
+;; difference from `behavior-component` is the difference between the two modes
+;; and nothing else: the interpreted boundary WALKS its child from markup, this
+;; one is HANDED it already built — exactly the split `presence-boundary` has
+;; across `presence-node` and `emit-presence`.
+
+(defn- element-childless?
+  "Does the already-built React element carry no Freehand children of its own?
+  The browser arm of the opaque-child law for a COMPILED attachment.
+
+  A compiled body resolved the decorated element at build, so there is no markup
+  form to walk here as [[childless?]] does — React holds the element's
+  descendants under `props.children`, undefined for the childless
+  `createElement(tag, props)` the emitter produces
+  ([[re-frame.freehand.compiled-react/el]]) and present otherwise. This is
+  [[childless?]]'s counterpart on the one child representation the compiled
+  browser path actually has: an element, not a form or a structural node."
+  [element]
+  (let [props (.-props element)]
+    (or (nil? props)
+        (nil? (unchecked-get props "children")))))
 
 (defn ^:no-doc behavior-el
   [js-props]
   (let [opts     (unchecked-get js-props "opts")
         child    (unchecked-get js-props "child")
         _        (check-attach-opts! opts)
+        ;; The child-dependent OPAQUE law, enforced at runtime for both a
+        ;; literal and a runtime-selected :use. `check-attach-opts!` proved the
+        ;; use and the config and `analyze-behavior` proved the one-element
+        ;; shape at build, but neither can prove an {:opaque true} behavior's
+        ;; element carries no children — the opacity is the REGISTERED
+        ;; definition's, resolvable only now. So the compiled browser path runs
+        ;; the same guard the other hosts run through `read-opts`, BEFORE
+        ;; `use-attachment!` installs a lifecycle arm: no connection opens and no
+        ;; host overwrites already-declared children (D013, FH-BEHAVIOR-002).
+        _        (when (and (:opaque (definition (:use opts)))
+                            (not (element-childless? child)))
+                   (opaque-child! (:use opts)))
         set-node (use-attachment! opts)]
     (attach child set-node)))
 

--- a/implementation/freehand/src/re_frame/freehand/compiler.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler.cljc
@@ -109,6 +109,13 @@
                   :html    (vswap! caps conj :html)
                   :foreign (vswap! caps conj :foreign)
                   :slot    (vswap! caps conj :render-slot)
+                  ;; v/behavior — the ONE sanctioned imperative host boundary
+                  ;; (D013). A live host lifecycle (connect / update / command /
+                  ;; disconnect over a real node) is as much a runtime capability
+                  ;; as an effect or a ref, so the boundary is a named capability
+                  ;; rather than invisible — a behavior-bearing view must not
+                  ;; report an empty roster (rf2-drpa3.116).
+                  :behavior (vswap! caps conj :behavior)
                   :element (do (when (:custom? n) (vswap! caps conj :custom-element))
                                (when (get-in n [:props :spread])
                                  (vswap! caps conj :spread))
@@ -130,8 +137,8 @@
   "The full capability roster a compiled declaration carries: the
   STRUCTURAL capabilities its AST names (`:raw` / `:html` / `:foreign` /
   `:render-slot` / `:render-fn` / `:custom-element` / `:spread` /
-  `:spread-safe`) unioned with the REACTIVE and host-hook capabilities its
-  lexical `sites` own. The reactive four — `:sub`, `:event`, `:frame`,
+  `:spread-safe` / `:behavior`) unioned with the REACTIVE and host-hook
+  capabilities its lexical `sites` own. The reactive four — `:sub`, `:event`, `:frame`,
   `:dispatch-fn` — are exactly the set whose emptiness proves the ViewCell
   shell elidable ([[view-cell-elided?]]); `:local` / `:effect` and the
   folded interop-hook kinds are ordinary React machinery that ride a plain
@@ -200,9 +207,10 @@
   (-> `:ref`) and the re-frame.freehand.react host hooks (use-context -> `:context`,
   use-effect family -> `:effect`; `use-id` is EXEMPT — an inert deterministic id
   is static-safe), authored element/component `:ref` slots (a commit-phase host
-  hook a static render cannot honour -> `:ref`), and foreign heads (`:foreign`,
-  which a `react/lazy` head folds into). `:deps` are the view references to close
-  over transitively.
+  hook a static render cannot honour -> `:ref`), a `v/behavior` boundary (a live
+  host lifecycle a :server render owns no node for -> `:behavior`), and foreign
+  heads (`:foreign`, which a `react/lazy` head folds into). `:deps` are the view
+  references to close over transitively.
 
   SERVER REACHABILITY governs BOTH the dependency walk AND the capability
   collection: a `v/client-only` subtree is browser-only — the JVM emitter
@@ -214,10 +222,11 @@
   recorded and a site whose `:path` descends from one is excluded — the capability
   proof only counts the SERVER-REACHABLE sites, mirroring the dependency walk."
   [ast sites]
-  (let [deps     (volatile! #{})
-        foreign? (volatile! false)
-        ref?     (volatile! false)
-        co-paths (volatile! [])]
+  (let [deps      (volatile! #{})
+        foreign?  (volatile! false)
+        ref?      (volatile! false)
+        behavior? (volatile! false)
+        co-paths  (volatile! [])]
     (letfn [(walk [n]
               (when (map? n)
                 (if (= :client-only (:op n))
@@ -229,6 +238,15 @@
                   (do
                     (when (= :view (:op n))    (vswap! deps conj (:view-id n)))
                     (when (= :foreign (:op n)) (vreset! foreign? true))
+                    ;; a v/behavior boundary is a live host lifecycle (connect /
+                    ;; update / command / disconnect over a real node) — a pure
+                    ;; :server render owns no node and cannot honour it, so a
+                    ;; server-reachable behavior is a runtime-requiring
+                    ;; capability the JVM emitter would otherwise fold to an inert
+                    ;; marker and silently drop. Reached HERE by the same walk
+                    ;; that excludes a client-only subtree, so a behavior only in
+                    ;; a client arm is never counted (rf2-drpa3.116).
+                    (when (= :behavior (:op n)) (vreset! behavior? true))
                     ;; an authored `:ref` (element OR component props) is a
                     ;; commit-phase host hook — a static render cannot honour it,
                     ;; so a server-reachable ref is a runtime-requiring capability
@@ -256,8 +274,9 @@
                            (keep {:ref :ref :context :context :effect :effect
                                   :layout-effect :effect :effect-event :effect})
                            (map :kind (reachable :react)))
-               @foreign? (conj :foreign)
-               @ref?     (conj :ref))
+               @foreign?  (conj :foreign)
+               @ref?      (conj :ref)
+               @behavior? (conj :behavior))
        :deps @deps})))
 
 (defn build-view-static

--- a/implementation/freehand/src/re_frame/freehand/tree.cljc
+++ b/implementation/freehand/src/re_frame/freehand/tree.cljc
@@ -54,6 +54,7 @@
   [`spec/004B-UI-Tree-and-Conversion.md`](../../../../../spec/004B-UI-Tree-and-Conversion.md)."
   (:require [clojure.string :as str]
             [re-frame.error :as error]
+            [re-frame.freehand.behaviors :as behaviors]
             [re-frame.freehand.conversion :as conv]
             [re-frame.freehand.descriptor :as descriptor]
             [re-frame.freehand.errors :as eb]
@@ -476,19 +477,36 @@
   :mount-in-the-browser-or-move-the-live-subtree-behind-client-only)
 
 (defn- live-capability-site
-  "The FIRST live capability in `tree` the static HTML fold would drop, as
-  `{:view-id .. :tag .. :handlers [..]}`, or nil when the tree folds losslessly.
+  "The FIRST live capability in `tree` the static HTML fold would drop, as a map
+  naming it, or nil when the tree folds losslessly:
 
-  `:view-id` is the nearest ENCLOSING view boundary — the declaration an author
-  can go and edit — rather than the element, which is a position inside it."
+    {:capability :handler  :view-id .. :tag .. :handlers [..]}   a committed
+        event handler no hydration payload will reinstall on this path;
+    {:capability :behavior :view-id .. :behavior ..}             a v/behavior
+        attachment — a live host lifecycle (connect / command / disconnect over
+        a real node) a :server render owns no node for, folded here to an inert
+        marker nothing downstream restores (rf2-drpa3.116).
+
+  `:view-id` is the nearest ENCLOSING author view boundary — the declaration an
+  author can go and edit — rather than the element or the reserved behavior
+  boundary node, each a position inside it."
   [tree]
   (letfn [(scan [n view-id]
             (when (map? n)
-              (let [view-id (or (:view-id n) view-id)]
-                (or (when (seq (:events n))
-                      {:view-id  view-id
-                       :tag      (:tag n)
-                       :handlers (vec (sort (keys (:events n))))})
+              (let [behavior? (= behaviors/behavior-view-id (:view-id n))
+                    ;; the behavior boundary's own :view-id is the reserved
+                    ;; attachment id, not an author view — keep the enclosing
+                    ;; view for attribution and report the behavior separately.
+                    view-id   (if behavior? view-id (or (:view-id n) view-id))]
+                (or (when behavior?
+                      {:capability :behavior
+                       :view-id    view-id
+                       :behavior   (:use (:props n))})
+                    (when (seq (:events n))
+                      {:capability :handler
+                       :view-id    view-id
+                       :tag        (:tag n)
+                       :handlers   (vec (sort (keys (:events n))))})
                     (some #(scan % view-id) (:children n))))))]
     (scan tree nil)))
 
@@ -504,25 +522,43 @@
      The two recoveries are the ones the build-time arm names for a compiled
      view, because it is the same law: mount the tree in the browser with
      `v/mount` / `v/hydrate-root`, or move the live subtree behind a
-     `v/client-only` whose fallback is capability-free."
+     `v/client-only` whose fallback is capability-free.
+
+     A v/behavior attachment is refused on the SAME law and recovery: it is a
+     live host lifecycle over a real node, and folding it to its inert JVM
+     marker on a non-hydrating page ships a node whose behavior never connects
+     (rf2-drpa3.116)."
      [tree]
-     (if-let [{:keys [view-id tag handlers]} (live-capability-site tree)]
+     (if-let [{:keys [capability view-id tag handlers behavior]}
+              (live-capability-site tree)]
        (error/throw-error!
         :rf.error/static-render-requires-runtime
         'v/render-static
-        (str "v/render-static rendered a live event handler it cannot honour: "
-             (str/join ", " (map str handlers))
-             (when tag (str " on " tag))
+        (str "v/render-static rendered a "
+             (case capability
+               :handler  (str "live event handler it cannot honour: "
+                              (str/join ", " (map str handlers))
+                              (when tag (str " on " tag)))
+               :behavior (str "v/behavior attachment it cannot honour"
+                              (when behavior (str " (" behavior ")"))))
              (when view-id (str " in view " view-id))
              ". render-static is the pure :server static-HTML path — it emits no "
-             "hydration payload, so no client ever reinstalls the handler and "
-             "folding it away would ship a control that does nothing. Mount this "
-             "tree in the browser with v/mount / v/hydrate-root, or move the live "
-             "subtree behind a v/client-only with a capability-free fallback.")
+             "hydration payload, so "
+             (case capability
+               :handler  (str "no client ever reinstalls the handler and folding "
+                              "it away would ship a control that does nothing. ")
+               :behavior (str "no client ever connects the behavior and folding it "
+                              "to an inert marker would ship a node whose host "
+                              "lifecycle never runs. "))
+             "Mount this tree in the browser with v/mount / v/hydrate-root, or "
+             "move the live subtree behind a v/client-only with a capability-free "
+             "fallback.")
         {:recovery static-render-recovery
-         :extra    (cond-> {:capability :handler :handlers handlers}
-                     view-id (assoc :view-id view-id)
-                     tag     (assoc :tag tag))})
+         :extra    (cond-> {:capability capability}
+                     view-id  (assoc :view-id view-id)
+                     tag      (assoc :tag tag)
+                     handlers (assoc :handlers handlers)
+                     behavior (assoc :behavior behavior))})
        tree)))
 
 #?(:clj

--- a/implementation/freehand/test/re_frame/freehand/behavior_compiled_parity_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/behavior_compiled_parity_dom_cljs_test.cljs
@@ -196,3 +196,67 @@
                         (is false (str "mount rejected: " e))
                         (teardown! container root)
                         (done)))))))))
+
+;; ===========================================================================
+;; The opaque-child law holds at RUNTIME in the compiled browser path
+;; ===========================================================================
+
+(defn- mount-outcome!
+  "Mount `view` and resolve with `{:id .. :connections ..}` — `::no-throw` when
+  it mounted, else the caught `:rf.error/id`. A render refusal rejects the act
+  promise (there is no error boundary), and because a behavior connects only on
+  COMMIT, a refused render leaves the connection table untouched — so the
+  companion count proves the refusal came BEFORE any attachment."
+  [view]
+  (let [[container root] (mount!)]
+    (-> (act #(.render root (element [view {}])))
+        (.then (fn [_]
+                 (let [n (behaviors/connection-count)]
+                   (teardown! container root)
+                   {:id ::no-throw :connections n}))
+               (fn [e]
+                 (let [n (behaviors/connection-count)]
+                   (.remove container)
+                   (try (.unmount root) (catch :default _ nil))
+                   {:id (or (:rf.error/id (ex-data e)) ::no-id) :connections n}))))))
+
+(deftest the-compiled-browser-path-enforces-the-opaque-child-law
+  (testing "rf2-drpa3.127, the discriminating case. An {:opaque true} behavior
+            owns its node's descendants, so a node carrying Freehand children is
+            refused — and the compiled build cannot prove that, because the
+            opacity is a REGISTERED fact and the child may carry a runtime-
+            selected :use. So the COMPILED BROWSER path enforces the opaque-child
+            law at runtime, raising :rf.error/behavior-bad-args BEFORE any
+            connection opens or the host overwrites already-rendered children. The
+            positive control — the same opaque behavior over an EMPTY node —
+            mounts and connects. The interpreted browser twin agrees on both, so
+            the compiled path is proven equal, not merely non-crashing."
+    (if-not (browser?)
+      (skip! "the browser job runs the opaque-child runtime refusal")
+      (async done
+        (setup!)
+        (-> (mount-outcome! bv/opaque-host-compiled)
+            (.then (fn [host]
+                     (is (= ::no-throw (:id host))
+                         "the compiled opaque behavior over an EMPTY node mounts (positive control)")
+                     (reset-lifecycle!)
+                     (mount-outcome! bv/opaque-with-children-compiled)))
+            (.then (fn [kids]
+                     (is (= :rf.error/behavior-bad-args (:id kids))
+                         "the compiled opaque behavior over a node WITH children is refused at runtime")
+                     (is (zero? (:connections kids))
+                         "and refused BEFORE any connection opened — no child-host overwrite")
+                     (reset-lifecycle!)
+                     (mount-outcome! bv/opaque-host)))
+            (.then (fn [i-host]
+                     (is (= ::no-throw (:id i-host))
+                         "the INTERPRETED opaque behavior over an empty node mounts too")
+                     (reset-lifecycle!)
+                     (mount-outcome! bv/opaque-with-children)))
+            (.then (fn [i-kids]
+                     (is (= :rf.error/behavior-bad-args (:id i-kids))
+                         "and the interpreted twin refuses on the SAME diagnostic — the two browser modes agree")
+                     (done)))
+            (.catch (fn [e]
+                      (is false (str "an opaque-child mount chain rejected unexpectedly: " e))
+                      (done))))))))

--- a/implementation/freehand/test/re_frame/freehand/behavior_views.cljc
+++ b/implementation/freehand/test/re_frame/freehand/behavior_views.cljc
@@ -211,6 +211,24 @@
   [:section.host
    [:div.node "content"]])
 
+(v/defview opaque-host-compiled
+  "The compiled twin of `opaque-host` — an opaque behavior over an EMPTY node,
+  the positive control the discriminating opaque-child case is measured against
+  (rf2-drpa3.127)."
+  {:compiled true}
+  [_]
+  [v/behavior {:use canvas :target :probe/canvas}
+   [:div.node]])
+
+(v/defview opaque-with-children-compiled
+  "The compiled twin of `opaque-with-children` — an opaque behavior over a node
+  that carries Freehand children. The build cannot prove opacity (a registered
+  fact), so the compiled BROWSER path must refuse this at runtime, exactly as
+  the interpreted browser walk and the JVM structural render do (rf2-drpa3.127)."
+  {:compiled true}
+  [_]
+  [v/behavior {:use canvas} [:div.node "content the host would overwrite"]])
+
 ;; ---------------------------------------------------------------------------
 ;; Refused use sites — one view per arm of the closed grammar
 ;; ---------------------------------------------------------------------------

--- a/implementation/freehand/test/re_frame/freehand/behaviors_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/behaviors_cljs_test.cljc
@@ -103,7 +103,9 @@
    :view-child                bv/view-child
    :fragment-child            bv/fragment-child
    :text-child                bv/text-child
-   :opaque-with-children      bv/opaque-with-children})
+   :opaque-with-children      bv/opaque-with-children
+   :opaque-host-compiled      bv/opaque-host-compiled
+   :opaque-with-children-compiled bv/opaque-with-children-compiled})
 
 (deftest fh-behavior-002-the-use-site-is-data-and-owns-one-node
   (testing "Per FH-BEHAVIOR-002: the `[v/behavior {…} node]` option roster is
@@ -188,6 +190,26 @@
             (str note " — the compiled marker equals the interpreted one"))))
     (is (= [] (bv/ops))
         "and NOTHING ran on either side — the compiled marker is inert too")))
+
+(deftest the-compiled-manifest-names-the-behavior-capability
+  (testing "Per rf2-drpa3.116: a compiled behavior view is no longer invisible to
+            capability analysis. A `v/behavior` boundary is a live host lifecycle
+            — connect / command / disconnect over a real node — as much a runtime
+            capability as an effect or a ref, so it appears under ONE documented
+            token, `:behavior`, in BOTH the finite manifest's `:capabilities`
+            roster and render-static's server-reachable `:static-facts`. Before
+            this slice both sets were empty for a behavior-bearing view, telling a
+            tool it had no capability and letting render-static silently drop the
+            attachment."
+    (let [m (v/manifest bv/plain-compiled)]
+      (is (some? m) "the compiled behavior view carries a manifest")
+      (is (contains? (:capabilities m) :behavior)
+          "the capability roster names the behavior boundary")
+      (is (contains? (:caps (:static-facts m)) :behavior)
+          "and so does the server-reachable static-facts projection render-static walks")
+      (is (not= #{} (:capabilities m))
+          "so the manifest can no longer report an EMPTY capability roster for a
+           behavior-bearing view (the rf2-drpa3.116 reproduction)"))))
 
 (deftest fh-behavior-003-a-command-with-no-live-connection-is-refused
   (testing "Per FH-BEHAVIOR-003: a command crosses into a live host object,

--- a/implementation/freehand/test/re_frame/freehand/render_static_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/render_static_jvm_test.clj
@@ -16,6 +16,7 @@
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
             [re-frame.freehand :as v]
+            [re-frame.freehand.behavior-views :as bv]
             [re-frame.freehand.compiler :as compiler]
             [re-frame.freehand.compiler.root :as root]
             [re-frame.freehand.node :as node]
@@ -52,6 +53,37 @@
   [_]
   [interactive-card {:label "x"}])
 
+;; A compiled view attaching a server-reachable v/behavior — a live host
+;; lifecycle (connect / command / disconnect over a real node) a pure :server
+;; render owns no node for. rf2-drpa3.116's adversary: before the capability
+;; walks learned the behavior marker, this folded to inert HTML that silently
+;; dropped the attachment. `bv/probe` is the conformance corpus's registered
+;; behavior, reused rather than re-declared.
+(v/defview static-behavior-card
+  {:compiled true}
+  [_]
+  [:section [v/behavior {:use bv/probe :target :static/probe} [:div.node "x"]]])
+
+;; A compiled parent whose only child is the behavior-bearing view — the
+;; behavior capability is NESTED, visible only through the transitive closure.
+(v/defview static-behavior-parent
+  {:compiled true}
+  [_]
+  [static-behavior-card {}])
+
+;; A view whose ONLY behavior lives in a v/client-only CLIENT arm — the JVM
+;; render produces only the capability-free fallback, so the behavior is never
+;; server-reachable and render-static must RENDER, not refuse. The negative
+;; control for the server-reachability rule (rf2-drpa3.116). Interpreted, because
+;; v/client-only is a browser-only subtree the compiled grammar does not admit —
+;; the interpreted render is where a client-only arm is legitimately dropped, so
+;; it is exactly where the "renders, does not refuse" control belongs.
+(v/defview client-only-behavior-card
+  [_]
+  [:section
+   (v/client-only {:fallback [:div.fallback "server"]}
+     [v/behavior {:use bv/probe :target :static/probe} [:div.node "x"]])])
+
 ;; ---------------------------------------------------------------------------
 ;; The PAVED PATH (rf2-drpa3.159) — the default `v/defview`, with no options map
 ;; at all. An interpreted declaration has no analysis, no finite grammar and no
@@ -83,6 +115,13 @@
 (v/defview plain-parent
   [_]
   [:section [plain-interactive-card {:label "x"}]])
+
+;; An INTERPRETED view attaching a v/behavior — an interpreted body carries no
+;; analysis, so this half of no-silent-elision is proved at RENDER: the fold
+;; refuses to drop the live host boundary the interpreted tree actually carries.
+(v/defview plain-behavior-card
+  [_]
+  [:section [v/behavior {:use bv/probe :target :static/probe} [:div.node "x"]]])
 
 (defn- caught-id
   "Run `f`; -> the thrown compile-error id (`:rf.ui.compile/error` ex-data),
@@ -134,6 +173,13 @@
 (def ^:private reads-state-outcome   (capture-render-static '[reads-state {}]))
 (def ^:private static-parent-outcome (capture-render-static '[static-parent]))
 (def ^:private static-card-expansion (expand-render-static '[static-card {:title "x"}]))
+
+;; The compiled behavior rejections are a BUILD-time verdict (static-capability-
+;; offender over the server-reachable {:caps :deps}), so they are captured at
+;; ns-load like reads-state / static-parent, while the index still carries the
+;; freshly-contributed facts (rf2-drpa3.116).
+(def ^:private behavior-card-outcome   (capture-render-static '[static-behavior-card {}]))
+(def ^:private behavior-parent-outcome (capture-render-static '[static-behavior-parent {}]))
 
 ;; The ambient build's `view-static` index AS IT STOOD at ns-load, for the same
 ;; reason: a clojure.test RUN can clear the per-build index before the deftests
@@ -217,6 +263,22 @@
             is an interactive view fails through the direct-view-dependency closure
             (checking the root view alone would silently ship inert UI)"
     (is (= :rf.ui.compile/static-root-requires-runtime (:id static-parent-outcome)))))
+
+(deftest render-static-rejects-a-compiled-behavior
+  (testing "rf2-drpa3.116: a compiled `v/behavior` attachment is a live host
+            lifecycle a pure :server render cannot honour — its server-reachable
+            :behavior capability is a loud BUILD error, never an inert marker
+            silently dropped from a non-hydrating page"
+    (is (= :rf.ui.compile/static-root-requires-runtime (:id behavior-card-outcome))))
+  (testing "the build error names the runtime-requiring behavior capability"
+    (is (str/includes? (str (:msg behavior-card-outcome)) "behavior"))))
+
+(deftest render-static-rejects-a-nested-compiled-behavior
+  (testing "the behavior capability proof is TRANSITIVE too — a compiled parent
+            whose only child is a behavior-bearing view fails through the
+            direct-view-dependency closure, exactly as a nested subscription or
+            handler does (rf2-drpa3.116)"
+    (is (= :rf.ui.compile/static-root-requires-runtime (:id behavior-parent-outcome)))))
 
 ;; ---------------------------------------------------------------------------
 ;; The independence wall — the emitted code names NO compile-time re-frame.ssr
@@ -351,6 +413,35 @@
             before it probes anything — never silently rendered as an empty slot"
     (is (= :rf.error/view-read-outside-render
            (:id (static-render-error #(v/render-static [plain-reads-state {}])))))))
+
+(deftest render-static-rejects-an-interpreted-behavior
+  (let [{:keys [id msg data]}
+        (static-render-error #(v/render-static [plain-behavior-card {}]))]
+    (testing "rf2-drpa3.116: a v/behavior in an INTERPRETED body is proved at
+              RENDER — the interpreted tree carries the live host boundary and the
+              fold refuses to drop it, the same law the compiled arm proves at
+              build. So render-static, interpreted browser and compiled browser
+              agree: the behavior is honoured or the page fails loud, never
+              silently inert"
+      (is (= :rf.error/static-render-requires-runtime id)))
+    (testing "the diagnostic names the behavior capability and the shared recovery"
+      (is (str/includes? (str msg) "behavior"))
+      (is (= :mount-in-the-browser-or-move-the-live-subtree-behind-client-only
+             (:recovery data)))
+      (is (str/includes? (str msg) "v/client-only")))))
+
+(deftest render-static-renders-a-behavior-only-in-a-client-only-arm
+  (testing "the NEGATIVE control (rf2-drpa3.116): a behavior reachable ONLY in a
+            v/client-only client arm is NOT server-reachable — the JVM emitter
+            renders the capability-free fallback, so render-static admits the root
+            and folds it to HTML rather than refusing. Server reachability is what
+            separates a dropped live capability from a legitimately client-only one"
+    (let [html (v/render-static [client-only-behavior-card {}])]
+      (is (string? html) "the client-only behavior root renders, it does not refuse")
+      (is (str/includes? html "server")
+          "the capability-free fallback is what reaches the static output")
+      (is (not (str/includes? html "node"))
+          "and the client arm's behavior node never reaches the :server render"))))
 
 ;; ---------------------------------------------------------------------------
 ;; Cross-build / AOT resolution — the ambient index is a per-build convenience;

--- a/spec/conformance/freehand/fixtures/fh-behavior-002.edn
+++ b/spec/conformance/freehand/fixtures/fh-behavior-002.edn
@@ -73,4 +73,15 @@
 
   {:note "an opaque behavior owns the descendants, so declared children are refused
           rather than rendered and silently overwritten"
-   :view :opaque-with-children :outcome :rf.error/behavior-bad-args}]}
+   :view :opaque-with-children :outcome :rf.error/behavior-bad-args}
+
+  {:note "the COMPILED twin of the empty opaque host renders — the positive control
+          the discriminating opaque-child case is measured against (rf2-drpa3.127)"
+   :view :opaque-host-compiled :outcome :renders}
+
+  {:note "and the COMPILED twin of the opaque-with-children host refuses on the same
+          diagnostic — the build cannot prove opacity (a registered fact), so the
+          compiled marker enforces the opaque-child law at render exactly as the
+          interpreted twin does. JVM, interpreted browser and compiled browser agree
+          (rf2-drpa3.127)"
+   :view :opaque-with-children-compiled :outcome :rf.error/behavior-bad-args}]}


### PR DESCRIPTION
The compiled-tier `v/behavior` residuals from PR #6856, verified against current `main`. Two coupled fixes on the compiled-v/behavior machinery, each kept small — no second behavior runtime, no new SSR mode, no new public API/verb/hydration mechanism.

## rf2-drpa3.127 — opaque-child validation + complete parity

The compiled browser path (`behaviors/behavior-el`) called `check-attach-opts!` but never ran `read-opts`' child-dependent OPAQUE guard. So an `{:opaque true}` behavior whose element carried Freehand children: interpreted/JVM correctly REFUSED with `:rf.error/behavior-bad-args`, but the compiled browser path CONNECTED and let the host overwrite already-rendered children — contradicting FH-BEHAVIOR-002 and Spec 009's identical-host-refusal claim.

- The opaque-child raise is extracted to a shared `opaque-child!`; `read-opts` now calls it, and the compiled browser path enforces the same law at runtime for **both a literal and a runtime-selected `:use`**, via `element-childless?` over the already-built React element — raising `:rf.error/behavior-bad-args` **before** `use-attachment!` installs a lifecycle arm, so no connection opens and no host overwrites already-declared children.
- FH-BEHAVIOR-002 gains a discriminating compiled-browser opaque-child case (`opaque-with-children-compiled`) plus a positive empty-opaque-host control (`opaque-host-compiled`). JVM (`t/render` via the fixture), interpreted browser and compiled browser (a new discriminating DOM test that also proves nothing connected) now agree on both.
- The existing corpus is reused/parameterized — one shared `re-frame.freehand.behaviors` runtime, existing public surface, no parallel lifecycle/command-bus/wrapper API.

## rf2-drpa3.116 — manifest / render-static visibility

The new `:op :behavior` was absent from `compiler/capabilities` and `view-static-facts`, so `(v/manifest bv/plain-compiled)` reported empty `:capabilities`/`:static-facts` and `(v/render-static [bv/plain {}])` (and its compiled twin) returned ordinary HTML instead of refusing — silently dropping a browser behavior from a non-hydrating static page (Spec 011 no-silent-elision).

- The capability walk, the server-reachable static-facts walk, and the interpreted static fold (`tree/live-capability-site`) now know the existing behavior marker under one documented capability token, `:behavior`, respecting SERVER REACHABILITY.
- A server-reachable `v/behavior` site appears in `:capabilities` + `:static-facts`; `v/render-static` refuses a server-reachable behavior in BOTH compiled (build-time `static-capability-offender`) and interpreted (render-time `assert-static-renderable!`) declarations through the existing typed no-silent-elision paths.
- A behavior reachable ONLY in `v/client-only`'s client arm stays EXCLUDED, and the capability-free fallback still renders. (rf2-drpa3.176, the normative prose, already shipped — this is CODE only.)

Focused regressions pin: the manifest fact, direct compiled rejection, transitive-dependency rejection, interpreted rejection, and the client-only negative control.

## Quality gates

All run foreground to completion in the worker worktree; the browser banner names this worktree.

| Gate | Command | Result |
| --- | --- | --- |
| Freehand JVM | `clojure -M:test` (from `implementation/freehand`) | 901 tests, 6469 assertions — **0 failures, 0 errors** |
| CLJS node | `npm run test:freehand` (from `implementation`) | 963 tests, 5532 assertions — **0 failures, 0 errors** (388 files compiled, 0 warnings) |
| Browser (Chromium) | `npm run test:browser` (from `implementation`) | 744 tests, 4605 assertions — **0 failures, 0 errors** (1034 files compiled, 0 warnings) |

The opaque-child runtime refusal is a browser fact: the compiled-browser DOM case asserts `:rf.error/behavior-bad-args` and zero connections after the refusal, so it fails without the guard rather than merely visiting the path.
