### PR TITLE
fix(freehand): emitter tail — batching-claim drift, #id-on-spread, interpreted v/client-only phase (rf2-ll1ah, rf2-pv0ne, rf2-drpa3.103)

### DIFF
--- a/implementation/freehand/src/re_frame/freehand.cljc
+++ b/implementation/freehand/src/re_frame/freehand.cljc
@@ -1413,11 +1413,17 @@
   ([Spec 011 §Phase flip](../../../../spec/011-SSR.md#phase-flip)).
 
   Both arms are ordinary Clojure expressions, so an interpreted body
-  EVALUATES both and renders one. Evaluating markup is building a vector; it
-  is the WALK that touches a host, and the walk enters only the selected arm.
-  Reach for a real host object in the argument itself — rather than inside
-  the view the argument names — and you have moved the browser call outside
-  the boundary that exists to contain it.
+  EVALUATES both and renders one. Evaluating markup is building a vector; a
+  host is touched only when an element is RENDERED, and only the
+  phase-selected arm is ever rendered. The two walks reach that guarantee by
+  different routes: the structural render enters ONLY the fallback and never
+  the client subtree, while the browser React walk builds BOTH arms into
+  elements — recording each arm's event sites under the body that wrote them
+  — and hands them to the phase-conditional boundary, which mounts one.
+  Building the unselected arm's element is not rendering it: it costs one vdom
+  construction and runs nothing. Reach for a real host object in the argument
+  itself — rather than inside the view the argument names — and you have moved
+  the browser call outside the boundary that exists to contain it.
 
   Per [Spec 004 §Client-only subtrees](../../../../spec/004-Views.md#client-only-subtrees)."
   [opts client-tpl]

--- a/implementation/freehand/src/re_frame/freehand/node.cljc
+++ b/implementation/freehand/src/re_frame/freehand/node.cljc
@@ -755,9 +755,13 @@
   check the interpreted walks apply, so the sugar-vs-forwarded-id ambiguity
   would slip through both — `[:div#sugar (v/spread {:id \"a\"})]` emitting a
   single id where its interpreted twin refuses. Threading the fact here holds
-  it identically, in the same two-step ORDER the interpreted walks reach it:
-  the spread's own cardinality first (tag-less, exactly what the public seam
-  throws), then the element's sugar (rf2-5r1af)."
+  it identically, in the same ORDER the interpreted walks reach it: the
+  spread's own cardinality first (tag-less, exactly what the public seam
+  throws), then the element's sugar against the surviving forwarded id
+  (rf2-5r1af), and — when that leaves the id slot free — the sugar id
+  RESTORED onto the map, so a sugar-less spread keeps the `#id` in the
+  compiled tier exactly as the interpreted element fold does rather than
+  silently dropping it (rf2-ll1ah)."
   ([base overrides] (spread-attrs base overrides nil nil))
   ([base overrides tag sugar-id]
    (assert-forwardable-attrs! 're-frame.freehand/spread base)
@@ -786,7 +790,20 @@
      (when sugar-id
        (when-some [{:keys [message]} (conv/id-conflict tag sugar-id (keys merged))]
          (malformed! 're-frame.freehand/spread message {:value (shape merged)})))
-     merged)))
+     ;; The surviving `#id` sugar RESTORED onto the forwarded map, the last of
+     ;; the same two-step order. The conflict check above already refused a
+     ;; forwarded id beside the sugar, so reaching here with a `sugar-id` means
+     ;; the id slot is free — write it, the same `:id` the interpreted element
+     ;; fold writes from the sugar for a sugar-less spread. Without this the
+     ;; compiled lowering (which returns `:attrs []` and threads the sugar fact
+     ;; ONLY through this seam) silently DROPPED the id while every interpreted
+     ;; walk kept it — `[:div#sugar (v/spread {:class "c"})]` answering
+     ;; `{:class "c"}` compiled against `{:id "sugar" :class "c"}` interpreted.
+     ;; Gated on `sugar-id`, so the interpreted public seam (which passes none)
+     ;; is untouched, and its own element fold still owns the interpreted id
+     ;; (rf2-ll1ah).
+     (cond-> merged
+       sugar-id (assoc :id sugar-id)))))
 
 (defn- owned-handler-keys
   "The `on-*` keys of a `v/spread-safe` OWNED props map — the handler families

--- a/implementation/freehand/src/re_frame/freehand/phase.cljs
+++ b/implementation/freehand/src/re_frame/freehand/phase.cljs
@@ -117,10 +117,12 @@
   ;; presentable UI the reader has been looking at since first paint — so
   ;; there is nothing to race and no `flushSync` here.
   ;;
-  ;; The same `:server` commit CLOSES the root's adoption window, which is the
-  ;; job `re-frame.freehand.root/adoption-window-closer` does for a root that
-  ;; installs no flipper: the hydration commit has landed, so a later
-  ;; recoverable error is no longer a hydration mismatch.
+  ;; The same `:server` commit CLOSES the root's adoption window: the hydration
+  ;; commit has landed, so a later recoverable error is no longer a hydration
+  ;; mismatch. A hydrating root installs this flipper unconditionally on
+  ;; adoption, so closing the window and scheduling the flip are the one effect
+  ;; here — there is no separate no-flipper hydration path that would need
+  ;; another closer.
   ;;
   ;; A root that FAILS to boot never commits this component, so its effect
   ;; never runs and it never flips: its server fallback markup stays on the
@@ -168,8 +170,10 @@
 
   `adoption` is the root-local `#js {:adopting true}` window flag the
   hydration-mismatch reporter reads: the flipper clears it on its `:server`
-  commit, which is the same moment `adoption-window-closer` would have
-  cleared it for a root without a flipper."
+  commit — the hydration commit — after which the reporter still delegates but
+  no longer labels a recoverable error a hydration mismatch. Every hydrating
+  root installs this flipper, so its `:server` commit is the one path that
+  closes the window."
   [root-id element adoption]
   (react/createElement PhaseFlipper
                        #js {:key "rf-phase" :rfRootId root-id :rfAdoption adoption}

--- a/implementation/freehand/test/re_frame/freehand/structural_slot_alias_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/structural_slot_alias_jvm_test.clj
@@ -588,7 +588,29 @@
     (is (= {:id "b"} (v/spread {:id "a"} {:id "b"}))
         "two EXACT :id writes merge to one — later-arg-wins, no conflict")
     (is (map? (compiled-tree '[:div#sugar (v/spread {:class "c"})]))
-        "sugar with a forwarded NON-id attr — no id ambiguity, accepted")))
+        "sugar with a forwarded NON-id attr — no id ambiguity, accepted"))
+  (testing "rf2-ll1ah #6863 audit — the accepted no-id spread must RETAIN the
+            sugar id, not merely not-throw. The prior control asserted only
+            `map?`, so it stayed green while the compiled emitters DROPPED the
+            `#id` the interpreted walk keeps: `[:div#sugar (v/spread {:class
+            \"c\"})]` answered `{:class \"c\"}` compiled against `{:id \"sugar\"
+            :class \"c\"}` interpreted. The fix restores the surviving sugar id
+            at the shared `node/spread-attrs` seam both emitters call, so the
+            two modes pin to ONE tree — value, not mere non-throwing."
+    (is (= {:tag :div :attrs {:id "sugar" :class "c"}}
+           (compiled-tree '[:div#sugar (v/spread {:class "c"})]))
+        "the compiled spread RETAINS the #id beside the forwarded attr")
+    (is (= (interpreted-tree [:div#sugar (v/spread {:class "c"})])
+           (compiled-tree '[:div#sugar (v/spread {:class "c"})]))
+        "and interpreted and compiled answer the identical tree")
+    ;; An empty forwarded map is the same law: nothing to forward, the sugar id
+    ;; still survives in both modes rather than vanishing in the compiled one.
+    (is (= {:tag :div :attrs {:id "sugar"}}
+           (compiled-tree '[:div#sugar (v/spread nil)]))
+        "an empty spread keeps the sugar id, compiled")
+    (is (= (interpreted-tree [:div#sugar (v/spread nil)])
+           (compiled-tree '[:div#sugar (v/spread nil)]))
+        "and matches the interpreted tree")))
 
 ;; ---------------------------------------------------------------------------
 ;; The scope fence

--- a/spec/004D-Freehand-Compiled-Grammar.md
+++ b/spec/004D-Freehand-Compiled-Grammar.md
@@ -825,7 +825,7 @@ fact, and re-running the build reproduces the id.
 |---|---|
 | `:rf.ui.compile/placeholder-not-top-level` | a `:rf.ui/*` placeholder keyword is nested inside an event-vector argument, where it dispatches as an ordinary keyword instead of splicing |
 | `:rf.ui.compile/bare-fn-in-loop` | a bare `fn` handler is authored inside a `for` row — it works, at a per-row closure cost, and defeats the data idiom |
-| `:rf.ui.compile/controlled-input-async-handler` | a controlled `:value`/`:checked` input's change handler is neither a literal event vector nor `(ui/event …)`, so it misses the controlled-input sync door |
+| `:rf.ui.compile/controlled-input-async-handler` | a controlled `:value`/`:checked` input's change handler is neither a literal event vector nor `v/event` — the sync door still opens at commit, decided from the runtime handler value, but nothing static pins the handler's class, so the site is **opaque**: its intent is absent from the compiled manifest and no structural test or tool can say what it dispatches before it fires |
 
 **Accessibility diagnostics.** Four checks, and the boundary around them is the
 point: **re-frame2 is not an accessibility framework.** These do not replace an


### PR DESCRIPTION
Three emitter-correctness beads on the Freehand interpreted/compiled surface. Each is a merged-PR audit reopen: the earlier PR fixed the bulk and the audit relayed a precise residue. Verified against current `origin/main` first; fixed exactly what each note names.

## rf2-pv0ne — the stale batching claim's last site

The three sites originally enumerated (`analyze.cljc` diagnostic, the two `pilot_field` docstrings) were already corrected by PR #6791 — confirmed on current main. The merged-PR audit relayed a **fourth** site still present: the `004D` warning-table row for `:rf.ui.compile/controlled-input-async-handler` claimed the handler "misses the controlled-input sync door". In the Freehand compiled tier the door still opens **at commit**, decided from the runtime handler value; what a forwarded handler loses is **static evidence** — the site is opaque, its intent absent from the manifest. Corrected the consequence to the shipped opacity/evidence semantics and migrated the donor spelling `(ui/event …)` to the Freehand `v/event`, matching the live `analyze.cljc` message. Donor `re-frame.ui` docs left out of scope per the bead.

## rf2-ll1ah — `#id` sugar dropped on a `v/spread` element

`analyze`'s spread branch returns `:attrs []` and threads the `#id` sugar fact only through the shared `node/spread-attrs` seam, which #6863 taught to **refuse** a forwarded id beside the sugar but not to **restore** the sugar when the forwarded map carries no id. So `[:div#sugar (v/spread {:class "c"})]` answered `{:class "c"}` in both compiled emitters while every interpreted walk kept `{:id "sugar" :class "c"}` — a silent, cross-mode drop.

Fix: after the conflict check passes (id slot provably free), fold `:id sugar-id` back onto the merged map in `node/spread-attrs` — the one seam both emitters call, so the compiled structural and compiled React paths get it identically. Gated on `sugar-id`, so the interpreted public seam (which passes none) is untouched and its own element fold still owns the interpreted id. The now-correct sugar+forwarded-id refusal is preserved. Strengthened the acceptance control from a bare `map?` assertion to an exact-tree cross-mode pin, plus the empty-spread case.

## rf2-drpa3.103 — truthful `v/client-only` walk + phase-flipper commentary

The F5g feature itself is complete and its behaviour/tests are sound (PR #6790). Two shipped-contract residues:

1. The public `v/client-only` docstring said "the walk enters only the selected arm". The browser React walk does the opposite — `client-only-node` emits **both** arms to build elements and record their event sites, and the phase-conditional boundary mounts one; only the structural walk enters a single arm (the fallback). Rewrote the sentence to state that a host is touched only at render, only the selected arm renders, and the two walks reach that guarantee by different routes.
2. `phase.cljs` still described the deleted private `root/adoption-window-closer` as though a no-flipper hydration path remained. #6790 deleted that helper and installs the flipper unconditionally on adoption. Replaced the archaeology with the direct invariant: the flipper's `:server` (hydration) commit is the one path that closes the adoption window and schedules the flip.

## Quality gates

Run foreground to completion from the worker worktree on this branch:

| Gate | Command | Result |
|---|---|---|
| Freehand JVM | `clojure -M:test` (from `implementation/freehand`) | **901 tests, 6473 assertions, 0 failures, 0 errors** |
| Freehand CLJS (node) | `npm run test:freehand` (from `implementation/`) | **963 tests, 5532 assertions, 0 failures, 0 errors** (388 files compiled, 0 warnings) |

The `rf2-ll1ah` fix lives in the shared pure `node/spread-attrs` seam both emitters call, so both node gates exercise it (structural via the JVM `structural-slot-alias` test; compiled React via the CLJS node build). The doc-only beads (`rf2-pv0ne`, `rf2-drpa3.103`) change no behaviour; the CLJS compile validates that the `phase.cljs` and `freehand.cljc` edits build cleanly. The browser DOM smoke and full `test:cljs` sweep run in CI.

Adversarial coverage: the strengthened `structural-slot-alias` test pins the exact retained-id tree cross-mode and keeps the sugar+forwarded-id **refusal** green (the discriminating conflict still throws in both modes); the empty-spread `(v/spread nil)` case is pinned too.
