### PR TITLE
feat(routing): EP-0037 R0b — shared address extractor + single resolved-target/plan seam behind every door (rf2-kqxe6.3)

### DIFF
--- a/implementation/routing/src/re_frame/routing.cljc
+++ b/implementation/routing/src/re_frame/routing.cljc
@@ -47,10 +47,8 @@
             [re-frame.registrar :as registrar]
             [re-frame.source-coords :as source-coords]
             [re-frame.subs :as subs]
-            [re-frame.routing.address :as address]
             [re-frame.routing.can-leave :as can-leave]
             [re-frame.routing.events :as routing-events]
-            [re-frame.routing.resolve :as resolver]
             [re-frame.routing.history :as history]
             [re-frame.routing.link :as link]
             [re-frame.routing.nav-counters :as nav-counters]
@@ -87,17 +85,14 @@
 (def route-ids                  registry/route-ids)
 (def route-meta                 registry/route-meta)
 
-;; EP-0037 R0 — the shared RouteAddress extraction law + the one
-;; resolved-target / route-plan seam every navigation door lowers to. These
-;; are owned-namespace operations (not re-exported from `re-frame.core`); the
-;; plan-projection is the pure on-demand view a tool (Xray / trace tooling)
-;; reads to prove the shared spine (Spec 012 §Resolved target and the plan
-;; diagnostic projection).
-(def extract-address            address/extract-address)
-(def valid-address?             address/valid-address?)
-(def resolved-target            resolver/resolved-target)
-(def route-plan                 resolver/route-plan)
-(def plan-projection            resolver/plan-projection)
+;; EP-0037 R0 — the shared RouteAddress extraction law
+;; (`re-frame.routing.address`) and the one resolved-target / route-plan seam
+;; (`re-frame.routing.resolve`) are INTERNAL routing seams the navigation
+;; doors consume; they are deliberately NOT re-exported here. A tool that
+;; needs the R0 plan diagnostic projection (`resolve/plan-projection`) requires
+;; the internal namespace directly, exactly as CLJS tools require
+;; `re-frame.routing.tooling` — routing adds no public `RoutePlan` constructor
+;; (Spec 012 §Resolved target and the plan diagnostic projection).
 
 ;; Scroll positions are host-side transient state, not runtime-db state.
 (def scroll-positions-cap       scroll/scroll-positions-cap)

--- a/implementation/routing/src/re_frame/routing.cljc
+++ b/implementation/routing/src/re_frame/routing.cljc
@@ -22,6 +22,8 @@
 
   - `re-frame.routing.url`            — URL %-encode / %-decode primitives
   - `re-frame.routing.match`          — pattern parsing + match-against
+  - `re-frame.routing.address`        — the shared RouteAddress extraction law (closed key classes) every door resolves through (EP-0037 R0)
+  - `re-frame.routing.resolve`        — the one resolved-target / route-plan seam + its R0 diagnostic projection (EP-0037 R0)
   - `re-frame.routing.registry`       — reg-route + match-url + route-url + route-table cache
   - `re-frame.routing.classification` — projection-relative route data classification
   - `re-frame.routing.scroll`         — scroll-restoration helpers + :rf.nav/scroll + :rf.nav/capture-scroll fxs
@@ -45,8 +47,10 @@
             [re-frame.registrar :as registrar]
             [re-frame.source-coords :as source-coords]
             [re-frame.subs :as subs]
+            [re-frame.routing.address :as address]
             [re-frame.routing.can-leave :as can-leave]
             [re-frame.routing.events :as routing-events]
+            [re-frame.routing.resolve :as resolver]
             [re-frame.routing.history :as history]
             [re-frame.routing.link :as link]
             [re-frame.routing.nav-counters :as nav-counters]
@@ -82,6 +86,18 @@
 ;; are not re-exported from `re-frame.core`.
 (def route-ids                  registry/route-ids)
 (def route-meta                 registry/route-meta)
+
+;; EP-0037 R0 — the shared RouteAddress extraction law + the one
+;; resolved-target / route-plan seam every navigation door lowers to. These
+;; are owned-namespace operations (not re-exported from `re-frame.core`); the
+;; plan-projection is the pure on-demand view a tool (Xray / trace tooling)
+;; reads to prove the shared spine (Spec 012 §Resolved target and the plan
+;; diagnostic projection).
+(def extract-address            address/extract-address)
+(def valid-address?             address/valid-address?)
+(def resolved-target            resolver/resolved-target)
+(def route-plan                 resolver/route-plan)
+(def plan-projection            resolver/plan-projection)
 
 ;; Scroll positions are host-side transient state, not runtime-db state.
 (def scroll-positions-cap       scroll/scroll-positions-cap)

--- a/implementation/routing/src/re_frame/routing/address.cljc
+++ b/implementation/routing/src/re_frame/routing/address.cljc
@@ -1,0 +1,221 @@
+(ns re-frame.routing.address
+  "The shared RouteAddress extraction law for re-frame2 routing (EP-0037 R0b).
+
+  Per Spec 012 §The extraction law and Spec-Schemas §`:rf/route-address`:
+  every navigation door extracts and validates the caller-authored
+  **address** from the flat public map it accepts through ONE shared law
+  over CLOSED key classes, so a policy / edit / DOM value can never leak
+  into the address and a misspelled control key can never hide.
+
+  The closed key classes (Spec 012 §The extraction law):
+
+      address keys        #{:to :params :query :fragment}
+      raw-URL escape      #{:url}
+      policy keys         #{:replace? :scroll :bypass-guards?}
+      edit keys           #{:query :query-merge :fragment}
+      link behaviour keys #{:on-click}
+
+  (Spec R0 names the policy set `#{:replace? :scroll :bypass-leave?}` and the
+  link-behaviour set `#{:prefetch}`; both graduate in later EP-0037 slices —
+  the set-valued `:bypass-guards?` is retired for the boolean `:bypass-leave?`
+  in R4, and `:prefetch` lands in R3. R0b preserves the CURRENT vocabulary, so
+  the constants here spell `:bypass-guards?` / `:on-click` — the extraction
+  MECHANISM is what R0 ratifies, not those two key names.)
+
+  Two operations make up the law:
+
+    - `classify` — the always-on STRUCTURAL GATE: it validates the WHOLE
+      accepted-key roster BEFORE any extraction (so an unknown / misspelled
+      key — namespaced included — rejects rather than being silently
+      discarded) and selects the request branch by key PRESENCE (a `:to` /
+      `:url` DESTINATION vs an in-place EDIT). Returns nil when well-formed,
+      else `{:reason <kw> :keys [...]}`. This is the SAME closure the
+      `:rf/route-address` schema declares — `:reason :unknown-keys` is exactly
+      the closed-map rejection.
+    - `extract-address` — selects EXACTLY the address keys off the flat map,
+      so ONLY the extracted address (never the convenient flat request /
+      props map) reaches `:rf/route-address` validation.
+
+  Consumed by `:rf.route/navigate` (`navigate.cljc`), `route-url`
+  (`registry.cljc`), and `rf/route-link` / `v/route-link` (`link.cljc`) so
+  the four public surfaces share ONE definition of what an address is and
+  which keys are policy / edit / behaviour.
+
+  Internal namespace; the public facade is `re-frame.routing`."
+  (:require [clojure.set :as set]
+            [re-frame.identity :as identity]))
+
+;; ---- the closed key classes (Spec 012 §The extraction law) ----------------
+
+(def address-keys
+  "The closed RouteAddress key class — `{:to :params :query :fragment}`. Only
+  these keys ever reach `:rf/route-address` validation (Spec-Schemas
+  §`:rf/route-address`). `:to` names the destination route; facts spell it
+  `:route-id`, intent spells it `:to`."
+  #{:to :params :query :fragment})
+
+(def raw-url-keys
+  "The raw-URL escape destination form — `{:url ...}`. Not a RouteAddress: a
+  raw URL IS the address (Spec 012 §The raw-URL escape). Accepted by
+  navigation doors that must handle an already-authored URL; NOT by
+  `route-url` / prefetch."
+  #{:url})
+
+(def policy-keys
+  "Navigation POLICY key class — `:replace?` / `:scroll` (and the leave-only
+  `:bypass-guards?`). Policy travels beside the address in the same flat map
+  but keeps its own shape and is extracted / validated SEPARATELY, so no
+  policy key is ever serialisable as a destination (Spec 012 §The extraction
+  law). `:bypass-guards?` becomes the boolean `:bypass-leave?` in EP-0037 R4."
+  #{:replace? :scroll :bypass-guards?})
+
+(def edit-keys
+  "In-place EDIT key class — `:query` / `:query-merge` / `:fragment`. When no
+  destination (`:to` / `:url`) is present these PATCH the current location and
+  are NEVER validated or stored as a RouteAddress (Spec 012 §The extraction
+  law rule 3). Key PRESENCE — not truthiness — discriminates: `:query {}`
+  clears the query, `:fragment nil` clears the fragment."
+  #{:query :query-merge :fragment})
+
+(def link-behavior-keys
+  "`route-link` BEHAVIOUR key class — `:on-click`. Stripped from the props
+  map before DOM emission alongside the address keys (Spec 012 §The
+  extraction law — route-link's open-props exception). `:prefetch` joins this
+  class in EP-0037 R3."
+  #{:on-click})
+
+(def navigate-request-roster
+  "The closed set of keys a `:rf.route/navigate` request map may carry — the
+  WHOLE accepted-key roster the structural gate validates before extraction:
+  address ∪ raw-URL escape ∪ policy ∪ edit. Any other key (namespaced or not)
+  is rejected `:reason :unknown-keys`. The runtime's own resume rider
+  `:rf.route/enter-attempts` is stripped BEFORE the gate (continuation
+  bookkeeping, absent from the published grammar)."
+  (set/union address-keys raw-url-keys policy-keys edit-keys))
+
+;; ---- the closed `:rf/route-address` value ---------------------------------
+
+(def RouteAddress
+  "The closed `:rf/route-address` Malli schema DATA (Spec-Schemas
+  §`:rf/route-address`) — the caller-authored address of one registered named
+  destination. Held as data so the routing artefact carries the contract's
+  schema shape without a hot-path Malli-artefact dependency; `valid-address?`
+  is the pure structural check the extractor applies to the EXTRACTED
+  address."
+  [:map {:closed true}
+   [:to       :keyword]
+   [:params   {:optional true} :map]
+   [:query    {:optional true} :map]
+   [:fragment {:optional true} [:maybe :string]]])
+
+(defn valid-address?
+  "Pure structural predicate for the closed `:rf/route-address` shape
+  (Spec-Schemas §`:rf/route-address`): a map whose keys are a subset of
+  `address-keys`, with a keyword `:to`, map `:params` / `:query` when
+  present, and a string-or-nil `:fragment` when present. `:to` is required;
+  omitted `:params` / `:query` / `:fragment` are legal (they normalise
+  downstream). Applied to the EXTRACTED address (post `extract-address`), so
+  a policy / edit / DOM key can never be the reason it fails — the structural
+  gate has already rejected those on the whole request."
+  [address]
+  (boolean
+    (and (map? address)
+         (empty? (set/difference (set (keys address)) address-keys))
+         (keyword? (:to address))
+         (or (not (contains? address :params))   (map? (:params address)))
+         (or (not (contains? address :query))    (map? (:query address)))
+         (or (not (contains? address :fragment)) (nil? (:fragment address))
+             (string? (:fragment address))))))
+
+;; ---- extraction -----------------------------------------------------------
+
+(defn extract-address
+  "Select EXACTLY the address keys off a flat public map, discarding every
+  policy / edit / behaviour / DOM key. This is the guarantee that ONLY the
+  extracted address (never the convenient flat request / props map a door
+  accepts) reaches `:rf/route-address` validation (Spec 012 §The extraction
+  law). Pure `select-keys` over the closed `address-keys` class."
+  [flat-map]
+  (select-keys flat-map address-keys))
+
+(defn destination?
+  "True when `request` names a DESTINATION — a `:to` route id or the `:url`
+  raw-URL escape. Presence (not truthiness) discriminates."
+  [request]
+  (or (contains? request :to) (contains? request :url)))
+
+(defn in-place?
+  "True when `request` carries an in-place EDIT key (`:query` / `:query-merge`
+  / `:fragment`). Presence (not truthiness) discriminates — `:query {}` and
+  `:fragment nil` are valid lone in-place requests."
+  [request]
+  (boolean (seq (set/intersection (set (keys request)) edit-keys))))
+
+(defn classify
+  "The always-on STRUCTURAL GATE for a `:rf.route/navigate` request map
+  (Spec 012 §The extraction law, §Validity rules — the always-on structural
+  gate). Validates the WHOLE `navigate-request-roster` BEFORE extraction so a
+  misspelled / foreign key can never be silently discarded, then selects the
+  request branch by key PRESENCE. Returns nil when well-formed, else
+  `{:reason <kw> :keys [<offending keys>]}` naming the first violation. Plain
+  set logic, total over the roster; rejects BEFORE any guard evaluation so a
+  malformed request never consumes a `:can-leave` run. `current` is the
+  current route slice (nil before the first navigation).
+
+  The rules (Spec 012 §Validity rules):
+  1. `:to` xor `:url`.
+  2. `:url` excludes `:params` / `:query` / `:query-merge` — a raw URL IS the
+     address. `:url` + `:fragment` is legal.
+  3. `:params` requires a destination (`:to` / `:url`) — it names path params
+     for a FRESH address, so it is NEVER accepted in-place (changing params is
+     a destination): `:reason :params-requires-destination`.
+  4. `:query` xor `:query-merge`.
+  5. `:query-merge` requires an in-place request (no `:to` / `:url`).
+  6. A destination (`:to` / `:url`) OR an in-place change is required;
+     PRESENCE discriminates. Empty maps and pure-policy maps reject loud.
+  7. An in-place request before any current route exists rejects loud.
+  8. Unknown keys reject (namespaced included), reported in a total canonical
+     order (`identity/canonical-bytes`) so heterogeneous EDN keys never trip a
+     `compare`-based `sort`.
+
+  This is the byte-for-byte gate `:rf.route/navigate` ran inline before R0b;
+  moving it here makes it the ONE definition every door's whole-roster
+  closure is measured against."
+  [request current]
+  (let [ks           (set (keys request))
+        unknown      (set/difference ks navigate-request-roster)
+        dest?        (destination? request)
+        edit?        (in-place? request)
+        present      (fn [& kws] (vec (filter #(contains? request %) kws)))
+        ;; Total, host-symmetric key order over heterogeneous EDN keys — a
+        ;; plain `sort` throws when a request carries mixed-kind keys (a
+        ;; keyword beside a string / number), so the offending-key report is
+        ;; ordered by the shared CEDN-1 identity the whole prism sorts by.
+        sorted-keys  (fn [kws] (vec (sort-by identity/canonical-bytes kws)))]
+    (cond
+      (seq unknown)
+      {:reason :unknown-keys :keys (sorted-keys unknown)}
+
+      (and (contains? request :to) (contains? request :url))
+      {:reason :to-url-exclusive :keys [:to :url]}
+
+      (and (contains? request :url)
+           (some #(contains? request %) [:params :query :query-merge]))
+      {:reason :url-excludes-address :keys (present :params :query :query-merge)}
+
+      (and (contains? request :params) (not dest?))
+      {:reason :params-requires-destination :keys [:params]}
+
+      (and (contains? request :query) (contains? request :query-merge))
+      {:reason :query-exclusive :keys [:query :query-merge]}
+
+      (and (contains? request :query-merge) dest?)
+      {:reason :query-merge-in-place-only :keys [:query-merge]}
+
+      (not (or dest? edit?))
+      {:reason :no-destination-or-change :keys (sorted-keys ks)}
+
+      (and (not dest?) edit? (nil? current))
+      {:reason :no-current-route :keys (sorted-keys ks)}
+
+      :else nil)))

--- a/implementation/routing/src/re_frame/routing/link.cljc
+++ b/implementation/routing/src/re_frame/routing/link.cljc
@@ -11,6 +11,7 @@
   (JVM/SSR) wiring so a `:reload` re-wires both on a fresh registrar."
   (:require [re-frame.router :as router]
             [re-frame.frame :as frame]
+            [re-frame.routing.address :as address]
             [re-frame.routing.registry :as registry]
             [re-frame.routing.strategy :as strategy]))
 
@@ -35,10 +36,17 @@
   strategy `:encode`; the SSR render passes `identity` (SSR ignores
   strategies — the path-form href is the server shell, and the hydrated
   CLJS render fn re-encodes on the client)."
-  [{:keys [to params query fragment] :as props} encode]
-  (let [path-url (registry/route-url {:to to :params (or params {}) :query (or query {}) :fragment fragment})]
-    [path-url (-> props
-                  (dissoc :to :params :query :fragment :on-click)
+  [props encode]
+  ;; EP-0037 R0b: select the address through the ONE shared extractor
+  ;; (`address/extract-address`, the closed `:to`/`:params`/`:query`/`:fragment`
+  ;; key class) rather than a bespoke destructuring, and strip the address +
+  ;; behaviour keys via the shared key-class constants — so route-link cannot
+  ;; drift from what an address IS, and a policy / DOM attr can never leak into
+  ;; the synthesised href. The remaining props are the open DOM-attribute map
+  ;; (route-link's deliberate exception — Spec 012 §The extraction law).
+  (let [{:keys [to params query fragment]} (address/extract-address props)
+        path-url (registry/route-url {:to to :params (or params {}) :query (or query {}) :fragment fragment})]
+    [path-url (-> (apply dissoc props (concat address/address-keys address/link-behavior-keys))
                   (assoc :href (encode path-url)))]))
 
 #?(:cljs
@@ -254,8 +262,14 @@
   source stamping) as separate hooks. The JVM branch encodes path-form (SSR has
   no address bar); on hydration the CLJS render re-encodes through the frame
   strategy. Per Spec 012 §Linking from views and the rf2-5yovjt ruling."
-  [{:keys [to params query fragment] :as target} render-frame]
-  (let [path-url (registry/route-url {:to to :params (or params {}) :query (or query {}) :fragment fragment})
+  [target render-frame]
+  ;; EP-0037 R0b: select the address through the ONE shared extractor
+  ;; (`address/extract-address`) — the same closed key class `rf/route-link`,
+  ;; `route-url`, and `:rf.route/navigate` resolve through. `native-anchor?`
+  ;; still reads the FULL `target` (the `:target` / `:download` DOM attrs live
+  ;; outside the address class).
+  (let [{:keys [to params query fragment]} (address/extract-address target)
+        path-url (registry/route-url {:to to :params (or params {}) :query (or query {}) :fragment fragment})
         encode   #?(:cljs (:encode (strategy/url-strategy-for-frame-id render-frame))
                     :clj  identity)]
     {:href    (encode path-url)

--- a/implementation/routing/src/re_frame/routing/navigate.cljc
+++ b/implementation/routing/src/re_frame/routing/navigate.cljc
@@ -13,37 +13,19 @@
   Internal namespace; the public facade is `re-frame.routing`. The
   facade owns the `events/reg-event :rf.route/navigate` call so a
   `:reload` re-wires it on a fresh registrar."
-  (:require [clojure.set :as set]
-            [re-frame.frame :as frame]
-            [re-frame.identity :as identity]
+  (:require [re-frame.frame :as frame]
             [re-frame.late-bind :as late-bind]
             [re-frame.privacy :as privacy]
             [re-frame.registrar :as registrar]
+            [re-frame.routing.address :as address]
             [re-frame.routing.can-leave :as can-leave]
             [re-frame.routing.events :as routing-events]
             [re-frame.routing.plan :as plan]
             [re-frame.routing.registry :as registry]
+            [re-frame.routing.resolve :as resolver]
             [re-frame.routing.scroll :as scroll]
             [re-frame.routing.url :as url]
             [re-frame.trace :as trace]))
-
-(def ^:private request-roster
-  "The closed set of keys a `:rf.route/navigate` request map may carry:
-  address (`:to` `:url` `:params` `:query` `:fragment`), policy
-  (`:replace?` `:scroll` `:bypass-guards?`), and the in-place edit key
-  `:query-merge`. Any other key -- namespaced or not -- is rejected by the
-  structural gate (`:reason :unknown-keys`). The runtime's own resume rider
-  `:rf.route/enter-attempts` is stripped BEFORE the gate (it is
-  continuation bookkeeping, absent from the published grammar)."
-  #{:to :url :params :query :fragment :replace? :scroll :bypass-guards? :query-merge})
-
-(def ^:private in-place-change-keys
-  "The request keys whose PRESENCE marks an in-place change (a patch of the
-  current location) when no destination (`:to` / `:url`) is supplied. Key
-  PRESENCE -- not truthiness -- discriminates: `:query {}` clears the query,
-  `:fragment nil` clears the fragment; both are valid lone in-place
-  requests."
-  #{:query :query-merge :fragment})
 
 (defn- validate-event-shape
   "The event-VECTOR shape gate for `:rf.route/navigate`, run BEFORE the
@@ -68,70 +50,6 @@
     {:reason :request-not-a-map :keys []}
 
     :else nil))
-
-(defn- validate-request
-  "The always-on structural gate for a `:rf.route/navigate` request map
-  (Spec 012 Enforcement). Returns nil when the request is well-formed,
-  else `{:reason <kw> :keys [<offending keys>]}` naming the first
-  violation. Plain set logic, total over `request-roster`; rejects BEFORE
-  any guard evaluation so a malformed request never consumes a `:can-leave`
-  run. `current` is the current route slice (nil before the first
-  navigation). Runs AFTER `validate-event-shape`, so `request` is a map.
-
-  The rules (Spec 012 Validity rules):
-  1. `:to` xor `:url`.
-  2. `:url` excludes `:params` / `:query` / `:query-merge` -- a raw URL IS
-     the address. `:url` + `:fragment` is legal.
-  3. `:params` requires a destination (`:to` / `:url`) -- it names path
-     params for a FRESH address, so it is NEVER accepted in-place (changing
-     params is a destination).
-  4. `:query` xor `:query-merge`.
-  5. `:query-merge` requires an in-place request (no `:to` / `:url`).
-  6. A destination (`:to` / `:url`) OR an in-place change is required;
-     PRESENCE discriminates. Empty maps and pure-policy maps reject loud.
-  7. An in-place request before any current route exists rejects loud.
-  8. Unknown keys reject (namespaced included), reported in a total
-     canonical order (`identity/canonical-bytes`) so heterogeneous EDN keys
-     never trip a `compare`-based `sort` -- the key report is TOTAL on both
-     hosts."
-  [request current]
-  (let [ks           (set (keys request))
-        unknown      (set/difference ks request-roster)
-        destination? (or (contains? request :to) (contains? request :url))
-        in-place?    (boolean (seq (set/intersection ks in-place-change-keys)))
-        present      (fn [& kws] (vec (filter #(contains? request %) kws)))
-        ;; Total, host-symmetric key order over heterogeneous EDN keys -- a
-        ;; plain `sort` throws when a request carries mixed-kind keys (a
-        ;; keyword beside a string / number), so the offending-key report is
-        ;; ordered by the shared CEDN-1 identity the whole prism sorts by.
-        sorted-keys  (fn [kws] (vec (sort-by identity/canonical-bytes kws)))]
-    (cond
-      (seq unknown)
-      {:reason :unknown-keys :keys (sorted-keys unknown)}
-
-      (and (contains? request :to) (contains? request :url))
-      {:reason :to-url-exclusive :keys [:to :url]}
-
-      (and (contains? request :url)
-           (some #(contains? request %) [:params :query :query-merge]))
-      {:reason :url-excludes-address :keys (present :params :query :query-merge)}
-
-      (and (contains? request :params) (not destination?))
-      {:reason :params-requires-destination :keys [:params]}
-
-      (and (contains? request :query) (contains? request :query-merge))
-      {:reason :query-exclusive :keys [:query :query-merge]}
-
-      (and (contains? request :query-merge) destination?)
-      {:reason :query-merge-in-place-only :keys [:query-merge]}
-
-      (not (or destination? in-place?))
-      {:reason :no-destination-or-change :keys (sorted-keys ks)}
-
-      (and (not destination?) in-place? (nil? current))
-      {:reason :no-current-route :keys (sorted-keys ks)}
-
-      :else nil)))
 
 (defn- route-schema-sensitive?
   "True iff the route's `:params` OR `:query` Malli schema declares ANY
@@ -268,7 +186,7 @@
 
   Per Spec 012 the event carries ONE flat request map. The handler:
     1. strips the internal resume rider (`:rf.route/enter-attempts`) BEFORE
-       the always-on structural gate (`validate-request`);
+       the shared always-on structural gate (`re-frame.routing.address/classify`);
     2. rejects a malformed request with `:rf.error/navigate-bad-request`
        BEFORE any guard runs (slice unchanged, no push);
     3. resolves a DESTINATION request (`:to` / `:url`) into a FRESH address,
@@ -315,7 +233,7 @@
           ;; then the request-MAP structural gate. Both surface the same
           ;; `:rf.error/navigate-bad-request` channel.
           bad     (or (validate-event-shape event-vec)
-                      (validate-request request current))]
+                      (address/classify request current))]
       (if bad
         ;; Spec 012 §Error surfaces #1: the always-on structural gate rejected
         ;; the request. `:rf.error/navigate-bad-request` is a DISTINCT channel
@@ -332,7 +250,7 @@
                                       :recovery :no-recovery}
                                frame (assoc :frame frame)))
           {})
-        (let [destination? (or (contains? request :to) (contains? request :url))
+        (let [destination? (address/destination? request)
               url-target   (:url request)
               {:keys [route-id path-params query-params matched-fragment unmatched-url
                       throw-reason requested-url external-url-target?]}
@@ -536,7 +454,29 @@
                                          :params           path-params
                                          :query            query-params
                                          :fragment         fragment
-                                         :url              url})]
+                                         :url              url})
+                      ;; EP-0037 R0b: the programmatic door lowers to the ONE
+                      ;; resolved-target / route-plan seam. `:cause :navigate`;
+                      ;; the source is the extracted address (a `:to` request),
+                      ;; the raw-URL escape (`{:url ...}`), or the in-place edit.
+                      ;; The plan's `:target` is the ResolvedTarget the commit
+                      ;; publishes — byte-identical to the slice this door
+                      ;; committed before R0b — so the seam is load-bearing, not
+                      ;; a parallel diagnostic copy. Its `:branch` / `:leaf-plan`
+                      ;; are the R0 diagnostic projection (Spec 012 §Resolved
+                      ;; target and the plan diagnostic projection).
+                      route-plan (resolver/route-plan
+                                   {:cause  :navigate
+                                    :source (cond
+                                              url-target              {:url url-target}
+                                              (contains? request :to) (address/extract-address request)
+                                              :else                   (select-keys request address/edit-keys))
+                                    :target (resolver/resolved-target
+                                              {:route-id route-id
+                                               :params   path-params
+                                               :query    query-params
+                                               :fragment fragment
+                                               :url      url})})]
                   ;; Shared fail-closed telemetry (rf2-2zyvj / rf2-u8qe7y): a
                   ;; match-url throw on a `:url` target surfaces
                   ;; `:rf.warning/malformed-url`; an unmatched URL that resolved
@@ -552,14 +492,12 @@
                   ;; commit-navigation: nav-token alloc, allocated/activation
                   ;; traces, slice publish, fx assembly -- the shared commit
                   ;; shape. The programmatic path is the only one that drives the
-                  ;; browser URL, so it passes `push-fx`.
+                  ;; browser URL, so it passes `push-fx`. The slice is the plan's
+                  ;; resolved `:target` (facts) plus the resolved transition.
                   (routing-events/commit-navigation
                     rdb
-                    {:route-id   route-id
-                     :params     path-params
-                     :query      query-params
-                     :fragment   fragment
-                     :transition (if (seq on-match-vec) :loading :idle)}
+                    (assoc (:target route-plan)
+                           :transition (if (seq on-match-vec) :loading :idle))
                     on-match-vec
                     {:prev-id        (get-in rdb [:rf.runtime/routing :current :route-id])
                      :prev-nav-token (get-in rdb [:rf.runtime/routing :current :nav-token])

--- a/implementation/routing/src/re_frame/routing/registry.cljc
+++ b/implementation/routing/src/re_frame/routing/registry.cljc
@@ -20,6 +20,7 @@
             [re-frame.identity :as identity]
             [re-frame.registrar :as registrar]
             [re-frame.late-bind :as late-bind]
+            [re-frame.routing.address :as address]
             [re-frame.routing.classification :as classification]
             [re-frame.routing.match :as match]
             [re-frame.routing.url :as url]
@@ -1580,7 +1581,12 @@
    ;; trip this; a direct misuse of the public `route-url` fails fast. Bad
    ;; keys are reported in TOTAL canonical order (`identity/canonical-bytes`)
    ;; so a heterogeneous EDN-key set never trips `compare`.
-   (when-let [bad (seq (remove #{:to :params :query :fragment} (keys address)))]
+   ;; EP-0037 R0b: the address-only key class is the ONE shared
+   ;; `address/address-keys` constant every door measures the address against
+   ;; (Spec 012 §The extraction law). route-url takes an already-extracted
+   ;; address, so a non-address key here (`:url` / `:query-merge` / policy /
+   ;; unknown) is a direct-misuse caller bug and rejects LOUD.
+   (when-let [bad (seq (remove address/address-keys (keys address)))]
      (let [bad (vec (sort-by identity/canonical-bytes bad))]
        (throw (route-error
                 :rf.error/route-url-validation

--- a/implementation/routing/src/re_frame/routing/resolve.cljc
+++ b/implementation/routing/src/re_frame/routing/resolve.cljc
@@ -1,0 +1,146 @@
+(ns re-frame.routing.resolve
+  "The ONE resolved-target / route-plan seam every navigation door lowers to
+  (EP-0037 R0b).
+
+  Per Spec 012 §Resolved target and the plan diagnostic projection: planning
+  turns a caller's address into resolved **facts** — a `ResolvedTarget` — and
+  the internal **route plan** every door executes. Doors differ in cause and
+  history / scroll policy, not in target, entry, resource, or readiness
+  semantics (Spec 012 §The one planning pipeline). The programmatic, link,
+  URL-change, initial-load, and SSR handlers stay separate public events for
+  cause-specific tests and host integration, but they all shape their resolved
+  target and build their plan through THIS seam — so no door reinvents the
+  ResolvedTarget shape or the plan projection.
+
+  Guard coverage (`re-frame.routing.can-leave/maybe-block-navigation`) and
+  leaf-only planning + commit (`re-frame.routing.events/commit-navigation`) are
+  each already ONE definition every door calls; this namespace adds the third:
+  the ResolvedTarget fact shape and the plan's diagnostic projection.
+
+    - `resolved-target` — the `ResolvedTarget` facts `{:route-id :params
+      :query :fragment :url}`. Facts say `:route-id`; intent says `:to`. It is
+      the value the door commits (it feeds `commit-navigation`'s slice) — so
+      the seam is load-bearing, not a parallel diagnostic copy.
+    - `route-plan` — the internal route plan the door executes, carrying the
+      R0 diagnostic projection: the source address / raw-URL request, the
+      cause, the resolved target, the parent-to-leaf branch, and the
+      behaviour-preserving leaf resource plan.
+    - `plan-projection` — the R0 diagnostic projection of a plan (the minimum
+      needed to prove the shared spine), the pure on-demand view a tool
+      (Xray / trace tooling) reads. Later EP-0037 slices widen it (R2 adds
+      occurrence / dependency groups, the grouped order, and the identity
+      diff); R0 exposes only the source + cause, the resolved target, the
+      branch, and the leaf plan. This adds no public `RoutePlan` constructor
+      or promise-returning router object — its observable laws are public and
+      its projection is a pure derivation.
+
+  Everything here is PURE. Internal namespace; the public facade is
+  `re-frame.routing`."
+  (:require [re-frame.registrar :as registrar]
+            [re-frame.routing.subs :as routing-subs]))
+
+;; ---- the R0 causes --------------------------------------------------------
+
+(def causes
+  "The closed set of navigation CAUSES an R0 route plan may carry (Spec 012
+  §Resolved target and the plan diagnostic projection): a `route-link` click
+  (`:link`), programmatic `:rf.route/navigate` (`:navigate`), Back / Forward
+  (`:popstate`), initial load (`:initial`), and SSR (`:ssr`). Doors differ in
+  cause and history / scroll policy, not in target / entry / resource
+  semantics."
+  #{:link :navigate :popstate :initial :ssr})
+
+;; ---- the ResolvedTarget ---------------------------------------------------
+
+(defn resolved-target
+  "Shape the `ResolvedTarget` facts (Spec 012 §Resolved target and the plan
+  diagnostic projection):
+
+      {:route-id :route/article
+       :params   {:slug \"routing-as-data\"}
+       :query    {:tab :comments}
+       :fragment \"reply-42\"
+       :url      \"/articles/routing-as-data?tab=comments#reply-42\"}
+
+  after matching, defaults, and validation. It is a FACT, not another accepted
+  input spelling — facts say `:route-id`, intent says `:to`. The values are
+  reflected verbatim from what the door already resolved (route-id / params /
+  query / fragment / the committed URL); this reshaping never re-normalises,
+  so the target a door commits through here is byte-identical to the slice it
+  committed before R0b."
+  [{:keys [route-id params query fragment url]}]
+  {:route-id route-id
+   :params   params
+   :query    query
+   :fragment fragment
+   :url      url})
+
+;; ---- the parent-to-leaf branch + the leaf resource plan -------------------
+
+(defn branch-of
+  "The parent-to-leaf branch for a resolved target's `route-id` — the vector
+  `[parent-most ... leaf]` derived from the routes' `:parent` chain (Spec 012
+  §Nested layouts). The plan's branch field. Shares the ONE `:parent`-chain
+  walk the `:rf.route/chain` sub reduces over (`routing-subs/chain-from-meta`),
+  so the plan branch and the public chain sub can never disagree. The full
+  parent-to-leaf branch PLAN (per-segment resource requirements) graduates in
+  EP-0037 R2; R0 exposes the branch itself."
+  [route-id]
+  (routing-subs/chain-from-meta route-id))
+
+(defn leaf-plan-of
+  "The behaviour-preserving LEAF resource plan for a resolved target's
+  `route-id` — the route's declarative `:on-match` loader vector (Spec 012
+  §Per-route data loading), the events the runtime dispatches when the route
+  becomes active. This is the leaf plan `commit-navigation` already executes;
+  exposing it on the route plan is the R0 diagnostic projection of it (Spec
+  012 §Resolved target and the plan diagnostic projection — 'the
+  behaviour-preserving leaf resource plan'). The honest resource-derived
+  readiness projection graduates in EP-0037 R1; R0 reflects the loaders that
+  already fire, unchanged. Empty vector when the route declares no `:on-match`."
+  [route-id]
+  (vec (or (:on-match (registrar/lookup :route route-id)) [])))
+
+;; ---- the route plan -------------------------------------------------------
+
+(defn route-plan
+  "Build the internal route plan a door executes (Spec 012 §Resolved target
+  and the plan diagnostic projection). `source` is the caller's source address
+  or raw-URL request (`{:to ...}` / `{:url ...}`); `cause` is one of `causes`;
+  `target` is the `resolved-target` facts. The plan derives the parent-to-leaf
+  `:branch` and the behaviour-preserving `:leaf-plan` from the resolved
+  `route-id`, so a door constructs the plan from just its source, cause, and
+  resolved target — the ONE place the branch + leaf plan are derived.
+
+  Plain data — this contract adds no public `RoutePlan` constructor or
+  promise-returning router object; its diagnostic projection is
+  `plan-projection`."
+  [{:keys [source cause target]}]
+  (let [route-id (:route-id target)]
+    {:source    source
+     :cause     cause
+     :target    target
+     :branch    (branch-of route-id)
+     :leaf-plan (leaf-plan-of route-id)}))
+
+;; ---- the diagnostic projection --------------------------------------------
+
+(def r0-projection-keys
+  "The keys the R0 plan diagnostic projection exposes (Spec 012 §Resolved
+  target and the plan diagnostic projection): the minimum needed to prove the
+  shared spine — the source address and cause, the resolved target, the
+  parent-to-leaf branch, and the behaviour-preserving leaf resource plan.
+  Later EP-0037 slices widen the projection (R2 adds occurrence / dependency
+  groups, contributor dedupe advisories, the grouped order, and the identity
+  diff)."
+  [:source :cause :target :branch :leaf-plan])
+
+(defn plan-projection
+  "The R0 diagnostic projection of a route `plan` — the pure, on-demand view a
+  tool (Xray / trace tooling) reads to prove the shared spine, exposing ONLY
+  `r0-projection-keys`. No slice is licence to build a second Xray graph or a
+  general-purpose public plan debugger (Spec 012 §Resolved target and the plan
+  diagnostic projection); this is a `select-keys` over the plan the doors
+  already build."
+  [plan]
+  (select-keys plan r0-projection-keys))

--- a/implementation/routing/src/re_frame/routing/url_change.cljc
+++ b/implementation/routing/src/re_frame/routing/url_change.cljc
@@ -21,6 +21,7 @@
             [re-frame.routing.events :as routing-events]
             [re-frame.routing.plan :as plan]
             [re-frame.routing.registry :as registry]
+            [re-frame.routing.resolve :as resolver]
             [re-frame.routing.scroll :as scroll]
             [re-frame.trace :as trace]))
 
@@ -104,8 +105,13 @@
    unchanged into `commit-navigation` and the
    `:routing/on-route-entry` hook so a cross-feature `{:from-db …}`
    route-resource scope resolves db-derived viewer identity at route
-   entry. Routing never reads it."
-  [rdb url default-scroll frame nav-allocation app-db]
+   entry. Routing never reads it.
+
+   `cause` is the R0 navigation cause the door represents (`:link` for the
+   forward `:rf.route/transitioned` door, `:popstate` for the URL-driven
+   `:rf.route/handle-url-change` door — popstate / initial / SSR). It is
+   carried on the route plan built at the commit branch (EP-0037 R0b)."
+  [rdb url default-scroll frame nav-allocation app-db cause]
   (let [rdb (or rdb {})
         ;; rf2-6t1xb: any unexpected throw out of `match-url` must not
         ;; crash the event drain. `match-url-fail-closed` catches the
@@ -272,13 +278,26 @@
         ;; and the fx assembly are the shared commit shape. The
         ;; URL-driven path passes NO `push-fx` — the browser URL already
         ;; changed (popstate / initial / link-click pushState).
+        ;;
+        ;; EP-0037 R0b: the URL-driven door lowers to the SAME resolved-target
+        ;; / route-plan seam as the programmatic door. The plan's `:target` is
+        ;; the ResolvedTarget the commit publishes (byte-identical to the slice
+        ;; this door committed before R0b — the seam is load-bearing); its
+        ;; `:cause` / `:branch` / `:leaf-plan` are the R0 diagnostic projection
+        ;; (Spec 012 §Resolved target and the plan diagnostic projection). The
+        ;; raw URL IS the source here.
         (routing-events/commit-navigation
           rdb
-          {:route-id   route-id
-           :params     params
-           :query      query
-           :fragment   fragment
-           :transition transition}
+          (assoc (:target (resolver/route-plan
+                            {:cause  cause
+                             :source {:url url}
+                             :target (resolver/resolved-target
+                                       {:route-id route-id
+                                        :params   params
+                                        :query    query
+                                        :fragment fragment
+                                        :url      url})}))
+                 :transition transition)
           on-match-vec
           {:prev-id        (get-in rdb [:rf.runtime/routing :current :route-id])
            ;; rf2-vdyrls: the prior route's nav-token — the second half of the
@@ -341,7 +360,9 @@
         ;; `:rf.warning/no-not-found-route`. The carried `:frame` (the
         ;; cascade cofx supplies it) tags those traces. EP-0001 (rf2-vzld77):
         ;; the route slice is durable routing runtime-db state.
-        (url-change-fx rdb url :top frame nav-allocation app-db))))
+        ;; EP-0037 R0b: the forward `:rf.route/transitioned` door's plan cause
+        ;; is `:link`.
+        (url-change-fx rdb url :top frame nav-allocation app-db :link))))
 
 (defn handle-url-change-handler
   "`:rf.route/handle-url-change` event handler. Registered by the
@@ -376,4 +397,6 @@
                   pending-nav-allocation)]
     (or blocked
         ;; EP-0001 (rf2-vzld77): the route slice is durable routing runtime-db state.
-        (url-change-fx rdb url :restore frame nav-allocation app-db))))
+        ;; EP-0037 R0b: the URL-driven `:rf.route/handle-url-change` door
+        ;; (popstate / initial / SSR) carries the `:popstate` plan cause.
+        (url-change-fx rdb url :restore frame nav-allocation app-db :popstate))))

--- a/implementation/routing/test/re_frame/routing_address_extraction_test.clj
+++ b/implementation/routing/test/re_frame/routing_address_extraction_test.clj
@@ -1,0 +1,129 @@
+(ns re-frame.routing-address-extraction-test
+  "Focused tests for the shared RouteAddress extraction law
+  `re-frame.routing.address` (EP-0037 R0b).
+
+  Pins the extraction law directly at the seam — the closed key classes, the
+  whole-roster structural gate (`classify`), the address-only selection
+  (`extract-address`), and the closed `:rf/route-address` predicate
+  (`valid-address?`) — plus the consumption proof that `route-url` and
+  `link-model` (rf/route-link + v/route-link) resolve their address through
+  this ONE definition. Per Spec 012 §The extraction law and Spec-Schemas
+  §`:rf/route-address`."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [clojure.set :as set]
+            [re-frame.routing :as routing]
+            [re-frame.routing.address :as address]
+            [re-frame.routing.link :as link]
+            [re-frame.routing-test-support :as rts]))
+
+(use-fixtures :each rts/reset-runtime)
+
+;; ---- the closed key classes (Spec 012 §The extraction law) ----------------
+
+(deftest key-classes-are-the-closed-spec-sets
+  (testing "the address key class is exactly {:to :params :query :fragment}"
+    (is (= #{:to :params :query :fragment} address/address-keys)))
+  (testing "the edit key class is exactly {:query :query-merge :fragment}"
+    (is (= #{:query :query-merge :fragment} address/edit-keys)))
+  (testing "policy keys are extracted separately and never overlap the address destination keys"
+    (is (empty? (set/intersection address/policy-keys #{:to :url}))
+        "a policy key can never be a destination")
+    (is (contains? address/policy-keys :replace?))
+    (is (contains? address/policy-keys :scroll)))
+  (testing "the navigate roster is address ∪ raw-URL ∪ policy ∪ edit"
+    (is (= #{:to :params :query :fragment :url :replace? :scroll :bypass-guards? :query-merge}
+           address/navigate-request-roster))))
+
+;; ---- classify: whole-roster gate BEFORE extraction ------------------------
+
+(deftest classify-accepts-well-formed-branches
+  (testing "a :to destination is well-formed (nil = no violation)"
+    (is (nil? (address/classify {:to :route/article :params {:slug "x"}} nil))))
+  (testing "a :url destination is well-formed"
+    (is (nil? (address/classify {:url "/articles/x"} nil))))
+  (testing "an in-place :query edit against a current route is well-formed"
+    (is (nil? (address/classify {:query {:tab "history"}}
+                                {:route-id :route/article :params {:slug "x"}})))))
+
+(deftest classify-rejects-unknown-keys-before-extraction
+  (testing "a misspelled / foreign key rejects :unknown-keys even when :to is present —
+            extraction can never silently discard it (Spec 012 §The extraction law)"
+    (is (= {:reason :unknown-keys :keys [:my-app/replace?]}
+           (address/classify {:to :route/article :params {:slug "x"} :my-app/replace? true} nil))))
+  (testing "a misspelled control key (bare) rejects the same way"
+    (is (= :unknown-keys (:reason (address/classify {:to :route/article :replac? true} nil))))))
+
+(deftest classify-enforces-the-branch-rules
+  (testing ":params without a destination → :params-requires-destination (a path-param change is a destination)"
+    (is (= {:reason :params-requires-destination :keys [:params]}
+           (address/classify {:params {:slug "x"}} {:route-id :route/home}))))
+  (testing ":to xor :url"
+    (is (= :to-url-exclusive (:reason (address/classify {:to :route/home :url "/x"} nil)))))
+  (testing ":url excludes address keys (a raw URL IS the address)"
+    (is (= :url-excludes-address (:reason (address/classify {:url "/x" :query {:a 1}} nil)))))
+  (testing ":query xor :query-merge"
+    (is (= :query-exclusive (:reason (address/classify {:query {} :query-merge {}}
+                                                       {:route-id :route/home})))))
+  (testing ":query-merge requires an in-place request (no destination)"
+    (is (= :query-merge-in-place-only
+           (:reason (address/classify {:to :route/home :query-merge {:a 1}} nil)))))
+  (testing "a pure-policy map (no destination, no edit) rejects loud"
+    (is (= :no-destination-or-change (:reason (address/classify {:replace? true} {:route-id :route/home})))))
+  (testing "an in-place edit before any current route rejects loud"
+    (is (= :no-current-route (:reason (address/classify {:query {:a 1}} nil))))))
+
+;; ---- extract-address: only the extracted address is an address ------------
+
+(deftest extract-address-selects-only-the-address-key-class
+  (testing "a flat wrapper carrying an address + policy + a DOM attr extracts to ONLY the address keys"
+    (is (= {:to :route/article :params {:slug "x"} :query {:tab "c"}}
+           (address/extract-address {:to       :route/article
+                                     :params   {:slug "x"}
+                                     :query    {:tab "c"}
+                                     :replace? true         ;; policy — dropped
+                                     :on-click identity     ;; behaviour — dropped
+                                     :class    "nav"})))))  ;; DOM attr — dropped
+
+(deftest valid-address?-is-the-closed-schema-over-the-extracted-address
+  (testing "a well-formed extracted address is valid"
+    (is (address/valid-address? {:to :route/article :params {:slug "x"} :query {} :fragment nil})))
+  (testing "the FLAT wrapper (address + policy) is NOT a valid address — extraction is required first"
+    (is (not (address/valid-address? {:to :route/article :replace? true}))
+        "a policy key makes the flat map fail the closed :rf/route-address shape"))
+  (testing "a missing :to is invalid (:to is required)"
+    (is (not (address/valid-address? {:params {:slug "x"}}))))
+  (testing "the extracted address of a policy-carrying wrapper IS valid — policy never reached the schema"
+    (is (address/valid-address?
+          (address/extract-address {:to :route/article :params {:slug "x"} :replace? true})))))
+
+;; ---- consumption: route-url resolves through the shared address class -----
+
+(deftest route-url-rejects-non-address-keys-via-the-shared-class
+  (routing/reg-route :route/article {} "/articles/:slug")
+  (testing "route-url is address-only over the SHARED address-keys class: a policy key rejects loud"
+    (let [ex (try (routing/route-url {:to :route/article :params {:slug "x"} :replace? true})
+                  (catch clojure.lang.ExceptionInfo e e))]
+      (is (some? ex) "route-url rejects a non-address (policy) key")
+      (is (= :bad-address-keys (:reason (ex-data ex))))
+      (is (= [:replace?] (:keys (ex-data ex))))))
+  (testing "the extracted address builds the same URL whether or not policy rode alongside it"
+    (is (= "/articles/x"
+           (routing/route-url (address/extract-address
+                                {:to :route/article :params {:slug "x"} :replace? true}))))))
+
+;; ---- consumption: route-link (link-model) resolves through the extractor --
+
+(deftest link-model-selects-the-address-through-the-shared-extractor
+  (routing/reg-route :route/article {} "/articles/:slug")
+  (testing "link-model builds the href from the extracted address and never lets a DOM attr into it"
+    (let [model (link/link-model {:to       :route/article
+                                  :params   {:slug "x"}
+                                  :target   "_blank"     ;; DOM attr — outside the address
+                                  :download true}        ;; DOM attr — outside the address
+                                 :rf/default)]
+      (is (= "/articles/x" (:href model))
+          "the DOM attrs did not leak into the synthesised href")
+      (is (= [:rf.route/url-requested {:url "/articles/x" :to :route/article :params {:slug "x"}}]
+             (:payload model)))
+      (is (true? (:native? model))
+          "native-anchor? still reads the FULL target (target=_blank / download)"))))

--- a/implementation/routing/test/re_frame/routing_plan_seam_test.clj
+++ b/implementation/routing/test/re_frame/routing_plan_seam_test.clj
@@ -1,0 +1,104 @@
+(ns re-frame.routing-plan-seam-test
+  "Focused tests for the ONE resolved-target / route-plan seam
+  `re-frame.routing.resolve` (EP-0037 R0b).
+
+  Pins the ResolvedTarget fact shape, the route-plan every door builds
+  (`:source` / `:cause` / `:target` / `:branch` / `:leaf-plan`), the
+  parent-to-leaf branch derivation (shared with the `:rf.route/chain` sub),
+  the behaviour-preserving leaf resource plan (the route's `:on-match`
+  loaders), and the R0 diagnostic projection. Per Spec 012 §The one planning
+  pipeline and §Resolved target and the plan diagnostic projection."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.routing :as routing]
+            [re-frame.routing.resolve :as resolver]
+            [re-frame.routing.subs :as routing-subs]
+            [re-frame.routing-test-support :as rts]))
+
+(use-fixtures :each rts/reset-runtime)
+
+;; ---- ResolvedTarget: facts, not intent ------------------------------------
+
+(deftest resolved-target-reflects-facts-verbatim
+  (testing "the ResolvedTarget carries the resolved FACTS (facts say :route-id, intent says :to)"
+    (is (= {:route-id :route/article
+            :params   {:slug "routing-as-data"}
+            :query    {:tab "comments"}
+            :fragment "reply-42"
+            :url      "/articles/routing-as-data?tab=comments#reply-42"}
+           (resolver/resolved-target
+             {:route-id :route/article
+              :params   {:slug "routing-as-data"}
+              :query    {:tab "comments"}
+              :fragment "reply-42"
+              :url      "/articles/routing-as-data?tab=comments#reply-42"}))))
+  (testing "resolved-target never re-normalises — an empty :query stays {} exactly as the door resolved it"
+    (is (= {} (:query (resolver/resolved-target {:route-id :route/home :params {} :query {}}))))))
+
+;; ---- branch + leaf plan ---------------------------------------------------
+
+(deftest branch-of-is-the-parent-to-leaf-chain
+  (routing/reg-route :route/dashboard {} "/dashboard")
+  (routing/reg-route :route/reports {:parent :route/dashboard} "/dashboard/reports")
+  (routing/reg-route :route/report {:parent :route/reports} "/dashboard/reports/:id")
+  (testing "the plan branch is [parent-most … leaf], shared with the :rf.route/chain sub reduction"
+    (is (= [:route/dashboard :route/reports :route/report]
+           (resolver/branch-of :route/report)))
+    (is (= (routing-subs/chain-from-meta :route/report)
+           (resolver/branch-of :route/report))
+        "branch-of and the chain sub can never disagree — one :parent walk")))
+
+(deftest leaf-plan-of-is-the-behaviour-preserving-on-match-loader
+  (routing/reg-route :route/article
+    {:on-match [[:article/load] [:comments/load]]} "/articles/:slug")
+  (routing/reg-route :route/home {} "/")
+  (testing "the leaf plan is the route's :on-match loader vector (the loaders that already fire)"
+    (is (= [[:article/load] [:comments/load]] (resolver/leaf-plan-of :route/article))))
+  (testing "a route with no :on-match has an empty leaf plan"
+    (is (= [] (resolver/leaf-plan-of :route/home))))
+  (testing "an unregistered / not-found target has an empty leaf plan"
+    (is (= [] (resolver/leaf-plan-of :rf.route/not-found)))))
+
+;; ---- the route plan every door builds -------------------------------------
+
+(deftest route-plan-carries-source-cause-target-branch-leaf-plan
+  (routing/reg-route :route/section {} "/section")
+  (routing/reg-route :route/article
+    {:parent :route/section :on-match [[:article/load]]} "/section/:slug")
+  (let [target (resolver/resolved-target
+                 {:route-id :route/article :params {:slug "x"} :query {}
+                  :fragment nil :url "/section/x"})
+        plan   (resolver/route-plan {:source {:to :route/article :params {:slug "x"}}
+                                     :cause  :navigate
+                                     :target target})]
+    (testing "the plan carries the caller's source and cause"
+      (is (= {:to :route/article :params {:slug "x"}} (:source plan)))
+      (is (= :navigate (:cause plan))))
+    (testing "the plan's :target IS the ResolvedTarget the door commits (load-bearing, not a copy)"
+      (is (= target (:target plan))))
+    (testing "the plan derives the parent-to-leaf branch and the leaf resource plan from the target"
+      (is (= [:route/section :route/article] (:branch plan)))
+      (is (= [[:article/load]] (:leaf-plan plan))))))
+
+(deftest route-plan-is-cause-parametric-across-the-doors
+  (routing/reg-route :route/home {} "/")
+  (let [target (resolver/resolved-target {:route-id :route/home :params {} :query {} :url "/"})]
+    (testing "every door builds the plan through the same fn, differing ONLY in cause"
+      (doseq [cause resolver/causes]
+        (let [plan (resolver/route-plan {:source {:url "/"} :cause cause :target target})]
+          (is (= cause (:cause plan)))
+          (is (= target (:target plan)))
+          (is (= [:route/home] (:branch plan))))))))
+
+;; ---- the R0 diagnostic projection -----------------------------------------
+
+(deftest plan-projection-exposes-only-the-r0-keys
+  (routing/reg-route :route/home {} "/")
+  (let [plan (resolver/route-plan
+               {:source {:url "/"} :cause :popstate
+                :target (resolver/resolved-target {:route-id :route/home :params {} :query {} :url "/"})})
+        proj (resolver/plan-projection plan)]
+    (testing "the projection is exactly the R0 keys — the minimum needed to prove the shared spine"
+      (is (= #{:source :cause :target :branch :leaf-plan} (set (keys proj))))
+      (is (= (set resolver/r0-projection-keys) (set (keys proj)))))
+    (testing "the projection is a pure view of the plan the doors already build"
+      (is (= (select-keys plan resolver/r0-projection-keys) proj)))))


### PR DESCRIPTION
Implements the ratified 012 R0a contract (PR #6865) in `implementation/routing/` — the implementation half of EP-0037 slice R0. Behaviour-preserving: a refactor with new validation reach, not a semantics change (R1+ change semantics).

## What lands

**`re-frame.routing.address` — the ONE shared address extractor** (Spec 012 §The extraction law, Spec-Schemas §`:rf/route-address`). Owns the closed key classes (address / raw-URL escape / policy / edit / link-behaviour), the always-on structural gate `classify` (whole-roster validation **before** extraction, so a misspelled control key — namespaced included — rejects `:unknown-keys` rather than being silently discarded; presence-based branch selection), `extract-address` (selects **only** the address key class, so policy/edit/DOM values neither leak into the address nor hide a misspelled key), and the closed `:rf/route-address` value + `valid-address?` predicate. `classify` is the byte-for-byte gate `:rf.route/navigate` ran inline before R0b, relocated so it is the one definition every surface's closure is measured against. **Consumed by** `:rf.route/navigate`, `route-url`, and `rf/route-link` / `v/route-link`.

**`re-frame.routing.resolve` — the ONE resolved-target / route-plan seam** (Spec 012 §The one planning pipeline, §Resolved target and the plan diagnostic projection). Owns `resolved-target` (the `ResolvedTarget` facts — **load-bearing**: it feeds `commit-navigation`'s slice), `route-plan` (`:source` / `:cause` / `:target` / `:branch` / `:leaf-plan`), `branch-of` (the parent-to-leaf branch, sharing the `:rf.route/chain` sub's one `:parent` walk), `leaf-plan-of` (the behaviour-preserving `:on-match` leaf loader plan), and `plan-projection` (the R0 diagnostic projection — the pure on-demand Xray/trace view). **Every door** lowers to it: programmatic (`:rf.route/navigate` → `:navigate`), link/forward (`:rf.route/transitioned` → `:link`), popstate/initial/SSR (`:rf.route/handle-url-change` → `:popstate`).

Both are **internal** routing seams — they are NOT re-exported on the `re-frame.routing` public facade (a tool that needs the plan projection requires `re-frame.routing.resolve` directly, exactly as CLJS tools require `re-frame.routing.tooling`); routing adds no public `RoutePlan` constructor. Guard coverage (`can-leave/maybe-block-navigation`) and leaf planning + commit (`events/commit-navigation`) were **already** one definition every door calls; R0b adds the extractor and the resolved-target/plan seam so no door reimplements any of the four.

## Byte-preservation

`navigate.cljc` shrinks by 95 lines (the inline gate relocated to `address.cljc`) and both doors now shape their committed slice as the plan's resolved `:target` — the target's `:url` field is inert in `commit-navigation` (it destructures only `:route-id`/`:params`/`:query`/`:fragment`/`:transition`), so the committed slice is byte-identical. Empirically: the JVM conformance corpus (EP rows 1-3 R0 fixtures) and the pre-existing 458 routing JVM tests are unchanged green; the 14 added tests are net-new.

## Grep proof — no door reimplements guard coverage or leaf-only planning (single seam)

```
GUARD COVERAGE — one def, every door calls it
  def:     can_leave.cljc  (defn maybe-block-navigation
  callers: navigate.cljc, url_change.cljc (transitioned + handle-url-change)

LEAF PLANNING / COMMIT — one def, every door calls it
  def:     events.cljc     (defn commit-navigation
  callers: navigate.cljc, url_change.cljc

ADDRESS EXTRACTOR — one def each, consumed by every intent surface
  defs:    address.cljc: classify / extract-address / valid-address?
  navigate:  address/classify (gate) + address/extract-address (source)
  route-url: address/address-keys (address-only gate, registry.cljc)
  route-link:address/extract-address (href-attrs + link-model, link.cljc)

RESOLVED-TARGET / PLAN SEAM — one def each, every door calls it
  defs:    resolve.cljc: resolved-target / route-plan / plan-projection
  callers: navigate.cljc, url_change.cljc
```

## Quality gates

| Gate | Result |
|---|---|
| Public-API manifest drift-check (`clojure -M -m re-frame.api-manifest.gen --check`, `implementation/scripts/api-manifest/`) | **EXIT=0** — `spec/api-manifest.edn` in sync (543 public vars), `git diff spec/api-manifest*.edn` clean. The R0b seams are internal, so no new public var and no manifest change. |
| clj-kondo (`--fail-level error`) | **0 errors** (EXIT=0). |
| Routing JVM suite (`clojure -M:test`, `implementation/routing/`) | **472 tests, 2442 assertions, 0 failures / 0 errors** (EXIT=0) — 14 net-new. |
| Conformance corpus JVM — EP rows 1-3 R0 fixtures (`re-frame.conformance-test/run-conformance-corpus`) | **0 failures / 0 errors** (EXIT=0); `routing-address-extraction` / `routing-door-parity` / `routing-passive-render` green through the new seam. |
| CLJS parity (`npm run test:cljs`) | **CI.** The worktree carries no `node_modules` and junctioning it risks the documented mayor-`node_modules` deletion hazard; all changes are host-neutral `.cljc`, and the CLJS conformance corpus runs the byte-identical fixtures + the routing `*_cljs_test` suites in CI. |

Surface is `implementation/routing/` only — no `spec/012-Routing.md` / `spec/Spec-Schemas.md`, no conformance fixtures, no freehand.

Closes rf2-kqxe6.3.
