### PR TITLE
skills(freehand): mechanical re-frame.ui de-reference across the skills tree, keep re-frame2-ui donor-maintenance (rf2-0rctd)

### DIFF
--- a/docs/skills/index.md
+++ b/docs/skills/index.md
@@ -1,6 +1,6 @@
 # Skills
 
-> Ten Claude Code skills that travel with the re-frame2 repo — for authoring code, authoring views on the experimental `re-frame.ui` compiled-view substrate, critiquing existing code, bootstrapping a project, migrating from v1, migrating Reagent views to the compiled-view substrate, building a new re-frame2 implementation, touring the Xray devtools panel, pair-programming with a running app, and running a retrospective on a pairing session.
+> Ten Claude Code skills that travel with the re-frame2 repo — for authoring code, maintaining donor views on the experimental `re-frame.ui` compiled-view substrate, critiquing existing code, bootstrapping a project, migrating from v1, migrating Reagent views to Freehand, building a new re-frame2 implementation, touring the Xray devtools panel, pair-programming with a running app, and running a retrospective on a pairing session.
 
 A **skill** is a small package of agent-shaped instructions plus optional scripts and reference leaves. When you load a skill into Claude Code (or any other Anthropic-skill-compatible agent), the model picks up its system prompt and its operating contract — so the same conversation that was *"help me write a re-frame2 event handler"* becomes a focused interaction that knows the canonical shapes, the cardinal rules, and where the depth lives.
 


### PR DESCRIPTION
## What & why

Residual mechanical `re-frame.ui` de-reference across the skills tree, after the earlier content-awareness pass retargeted the view-steering. Judgment per reference: **migrate references that steer toward `re-frame.ui` as a *target*; keep references that legitimately name it as the donor / migration source.**

The finding: every literal `re-frame.ui` reference in `skills/**` (outside `re-frame2-ui/`) already names the substrate as the **donor** — its real build-hook install contract, its real `re-frame.ui.tool` namespace, the compiled-view realization a port may implement, or a route to the donor-maintenance skill. Those are correct and are **kept unchanged**. So `skills/**` needed no migration.

The one genuinely stale spot was the docs-site landing summary, `docs/skills/index.md` line 3, whose intro clauses lagged the cards directly below them:

- **re-frame2-ui clause** — read "authoring views on the experimental `re-frame.ui` compiled-view substrate"; the card now frames that substrate as the donor being absorbed into Freehand ("new view work does not start here"), so the summary is realigned to donor-**maintenance** framing (the `re-frame.ui` donor token is kept — this is not a Freehand rename).
- **reagent-migration clause** — read "migrating Reagent views to the compiled-view substrate"; that skill already retargeted to Freehand (its card says so), so the summary is de-referenced to "migrating Reagent views to **Freehand**". A plain de-reference to already-retargeted state, not a re-steer of the migration skill.

`skills/re-frame2-ui/` (donor-maintenance) is untouched, per the standing ruling to keep it until donor deletion.

### Files migrated

- `docs/skills/index.md` — one line, two clause fixes (donor-maintenance framing for the `re-frame.ui` donor; Freehand for the Reagent-view migration path).

### Residual `re-frame.ui` in `skills/**` — kept, and why

`git grep 're-frame\.ui' -- 'skills/**' | grep -v 're-frame2-ui/'` returns only legitimate donor-source references:

- `skills/README.md` — describes / routes to the `re-frame2-ui` donor-maintenance skill ("the compiled-view substrate that is now the **donor**", "maintain donor compiled-view code", the donor compiler as the feedback loop).
- `skills/re-frame2/SKILL.md` — routes `defview` / donor-view work to `re-frame2-ui` ("the `re-frame.ui` donor substrate").
- `skills/re-frame2-setup/SKILL.md` — "Neither is the `re-frame.ui` donor substrate, which Freehand absorbs."
- `skills/re-frame2-setup/references/shadow-cljs.md` — the donor's real build-hook install contract (`re-frame.ui.compiler.build-hook/hook`), explicitly "for a project that already has it"; drift-gated against the shipped install-re-frame-ui how-to. Freehand has no compiled build hook to migrate this to.
- `skills/re-frame2-pair/{SKILL.md,references/ops.md}` — the five compiled-view inspection ops read the real `re-frame.ui.tool` namespace that ships in `day8/re-frame2-ui`; explicitly the donor being absorbed into Freehand, on which Freehand views answer `:view-tier-unavailable`.
- `skills/re-frame2-implementor/references/phase-2-impl-order.md` — the compiled `re-frame.ui` substrate as an EP-0030 realization a port may implement, with real `implementation/ui/` file paths and namespaces; explicitly "the machinery Freehand absorbs".

## Quality gates

All run foreground to completion in the worker worktree; exit codes are the verdict.

| Gate | Result |
|---|---|
| `python scripts/check_skill_migration_cites.py` | EXIT=0 |
| `python scripts/check_skill_migration_contract_drift.py` | EXIT=0 |
| `python scripts/check_skill_re_frame2_drift.py` | EXIT=0 |
| `python scripts/check_skill_mcp_drift.py` | EXIT=0 |
| `python scripts/check_skill_migration_o1617_router_drift.py` | EXIT=0 |
| `python scripts/check_skill_redirect_anchors.py` | EXIT=0 |
| `python scripts/check_doc_slugs.py` | EXIT=0 |
| `python -m mkdocs build --strict` | EXIT=0 |
| final residue grep (`re-frame.ui` in `skills/**`, excl `re-frame2-ui/`) | only donor-source references remain |
