### PR TITLE
bench(freehand): B5 shipped-cost measurement + B2 real matched mount (rf2-drpa3.52, .147)

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/bench/b5.cljs
+++ b/implementation/freehand/src/re_frame/freehand/bench/b5.cljs
@@ -1,0 +1,258 @@
+(ns re-frame.freehand.bench.b5
+  "B5 — the substrate's SHIPPED cost, measured off the release artefact.
+
+  D021's fifth required workload: what the Freehand substrate costs a page
+  that ships it — bundle bytes and the engine time to parse and compile
+  the script before any of it runs. Unlike B1–B4, whose subject is code
+  executing in the measuring process, B5's subject is a FILE on disk: the
+  `:advanced` release bundle `out/freehand-release/main.js`, built the way
+  a consumer ships it (`npm run build:freehand-release`,
+  `re-frame.freehand.release-app` — a real small app, not a require-only
+  stub that would DCE to a cost no consumer pays).
+
+  ## What this measures, and what it deliberately does not
+
+    - **bytes** — the artefact's on-disk size and its size under gzip
+      (levels 6 and 9) and brotli. Deterministic facts about the file,
+      published as evidence: D021's NON-GOALS bar a byte-size threshold,
+      so a byte reading has no route to a verdict, however far it moves.
+    - **parse + top-level compile time** — the wall time V8 spends in
+      `new vm.Script(source)`: it PARSES the whole bundle and compiles the
+      top level. It is EVIDENCE, host-dependent, and never gated.
+
+  It measures neither of two things it would be easy to claim:
+
+    - It is NOT eager function-body compilation. `new vm.Script` compiles
+      the top level; the bodies of functions compile lazily on first call.
+      `produceCachedData:true` does not change that — a prior B5 figure was
+      labelled \"eager\" on that assumption and was wrong (the inner body
+      stayed lazy after construction). So the reading is named for what it
+      is — parse plus top-level compilation — and `produceCachedData` is
+      deliberately unused.
+    - It is NOT eval/run time. The bundle is a `:browser` artefact that
+      references `window`, `self` and `document` at its top level, so it
+      cannot be executed in a Node sandbox without throwing. Running it is
+      not measured rather than measured wrongly.
+
+  ## The deterministic gate is elsewhere, on purpose
+
+  D021's B5 row also names a DETERMINISTIC reachability gate — that unused
+  runtime modules are absent from the production bundle, proven by the
+  F3d control-build technique. That gate needs a control build (the debug
+  flag flipped, everything else held) and lives in the build lane; it is
+  `rf2-drpa3.166`'s. This namespace is the EVIDENCE half only, and states
+  no pass/fail about a bundle at all: every measurement it declares is
+  `:bytes` or `:duration-ms`, which the harness can only publish.
+
+  ## Provenance ties each number to the artefact
+
+  A byte figure is only evidence about the file it was read from, so the
+  fixture carries the artefact path and its SHA-256: a rebuild that
+  changes the digest withdraws these specific numbers (D021 acceptance 3).
+  And the record's `:build` is NOT detected — `detect-build` would report
+  the MEASURING Node process (`:none`, instrumented), which is not the
+  `:advanced` artefact under the probe. The caller supplies the artefact's
+  own build via [[run-workload]]'s override, exactly as a build pipeline
+  that knows what it shipped is meant to.
+
+  Node-only: the readings are `fs`, `zlib` and `vm`, so this arm — like
+  [[re-frame.freehand.bench.b1-react]] — runs on the ClojureScript host,
+  not in the JVM `clojure -M:bench` suite. And like B4, it is driven by a
+  test rather than registered into the standing suite, because its subject
+  is an artefact a standing run has no reason to have built.
+
+  Normative owner: `docs/design/freehand/decisions/`
+  `D021-performance-budgets-and-release-evidence.md`."
+  (:require ["fs" :as fs]
+            ["zlib" :as zlib]
+            ["vm" :as vm]
+            ["crypto" :as crypto]
+            [re-frame.freehand.bench.measure :as m]))
+
+;; ---------------------------------------------------------------------------
+;; The artefact
+;; ---------------------------------------------------------------------------
+
+(def default-bundle-path
+  "Where `npm run build:freehand-release` lands the artefact, relative to
+  `implementation/` — the directory the Node lane runs from."
+  "out/freehand-release/main.js")
+
+(defn bundle-present?
+  "True when the release artefact is on disk. A B5 measurement of a bundle
+  that was never built is a number about nothing, so the driving test
+  skips rather than fabricates when this is false."
+  [path]
+  (.existsSync fs path))
+
+(defn read-bundle
+  "The artefact's bytes, as a Node Buffer — the on-disk bytes verbatim, so
+  the byte and digest readings are of the file a consumer would serve, not
+  of a re-encoding of it."
+  [path]
+  (.readFileSync fs path))
+
+;; ---------------------------------------------------------------------------
+;; The byte readings — deterministic facts about the file
+;; ---------------------------------------------------------------------------
+
+(defn raw-bytes
+  "The artefact's uncompressed size in bytes."
+  [^js buf]
+  (.-length buf))
+
+(defn gzip-bytes
+  "The artefact's size under gzip at `level` — the transfer size a server
+  sending `Content-Encoding: gzip` at that level would put on the wire."
+  [^js buf level]
+  (.-length (.gzipSync zlib buf #js {:level level})))
+
+(defn brotli-bytes
+  "The artefact's size under brotli at the library default quality — the
+  transfer size a server sending `Content-Encoding: br` would put on the
+  wire, and the smallest of the three encodings for a bundle this shape."
+  [^js buf]
+  (.-length (.brotliCompressSync zlib buf)))
+
+(defn sha256
+  "The artefact's SHA-256, lower-case hex. Ties every published figure to
+  the exact bytes it was read from: a rebuild that changes this digest
+  withdraws the numbers taken against the old one."
+  [^js buf]
+  (-> (.createHash crypto "sha256") (.update buf) (.digest "hex")))
+
+;; ---------------------------------------------------------------------------
+;; The parse/compile reading — evidence, host-dependent, never gated
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private compile-nonce (atom 0))
+
+(defn parse-compile-ms
+  "Wall time for V8 to PARSE `source` and compile its TOP LEVEL, via
+  `new vm.Script`.
+
+  This is the cost the engine pays before the script's own top level runs
+  — the relevant slice of a page's script-load budget that the substrate's
+  size drives. It is NOT eager whole-program compilation: function bodies
+  compile lazily on first call and are not included, and the bundle is not
+  executed. `produceCachedData` is deliberately not passed — it does not
+  force eager body compilation, so a figure taken with it would carry a
+  label its method does not support.
+
+  V8 keeps a per-isolate compilation cache keyed by SOURCE CONTENT, so a
+  second `new vm.Script` over the same string returns a cached compilation
+  in microseconds — measured, that would report the cache lookup and call
+  it a parse. Each call therefore appends a fresh nonce comment, which
+  changes the source enough to miss the cache and force a genuine cold
+  parse+compile, while adding a few bytes to a 744 KB artefact — a delta
+  far below the reading's own noise. Without this the figure collapses to
+  near zero after the first sample, the exact kind of mislabelled timing
+  D021's evidence discipline exists to prevent."
+  [source]
+  (let [unique (str source "\n//b5-parse-nonce-" (swap! compile-nonce inc))
+        t0     (m/now-ms)]
+    (vm/Script. unique)
+    (- (m/now-ms) t0)))
+
+;; ---------------------------------------------------------------------------
+;; Measuring the artefact once
+;; ---------------------------------------------------------------------------
+
+(defn measure-bundle
+  "Read the artefact at `path` and answer its byte facts, its digest, and
+  the source string the parse/compile reading is taken over.
+
+  The byte readings are taken once here — they are constant across
+  samples, so gzipping the artefact once per sample would burn the sample
+  budget re-deriving the same three numbers. Only [[parse-compile-ms]] is
+  re-measured per sample, because only it varies."
+  [path]
+  (let [buf    (read-bundle path)
+        source (.toString buf "utf8")]
+    {:path         path
+     :sha256       (sha256 buf)
+     :raw-bytes    (raw-bytes buf)
+     :gzip6-bytes  (gzip-bytes buf 6)
+     :gzip9-bytes  (gzip-bytes buf 9)
+     :brotli-bytes (brotli-bytes buf)
+     :source       source}))
+
+;; ---------------------------------------------------------------------------
+;; The workload
+;; ---------------------------------------------------------------------------
+
+(def measurement-method
+  "How the readings are taken, published verbatim in the fixture so a
+  reader knows exactly what each number is a number of."
+  (str "on-disk bytes of out/freehand-release/main.js and its size under "
+       "zlib gzip (levels 6 and 9) and brotli at the library default; "
+       "parse/compile is the wall time of new vm.Script over the source with "
+       "a per-call nonce comment appended to defeat V8's content-keyed "
+       "compilation cache — V8 parse plus top-level compilation, function "
+       "bodies excluded (lazy), the bundle not executed"))
+
+(defn workload
+  "Build the B5 workload from an already-[[measure-bundle]]d artefact,
+  under `id`, `doc` and `sampling`.
+
+  The byte readings ride the workload as constants and the `:run` answers
+  them unchanged every sample — an honest degenerate distribution, a file
+  whose size does not vary — while re-measuring [[parse-compile-ms]] over
+  the same source each sample so the parse/compile distribution is real.
+
+  The baseline is `:before-vs-after`: shipped bytes and parse/compile are
+  a regression signal tracked revision over revision — a promotion that
+  changes what ships moves them — and the reference is the same reading on
+  the preceding revision."
+  [{:keys [id doc sampling]}
+   {:keys [path sha256 raw-bytes gzip6-bytes gzip9-bytes brotli-bytes source]}]
+  {:id       id
+   :doc      doc
+   :fixture  {:artefact           path
+              :sha256             sha256
+              :raw-bytes          raw-bytes
+              :gzip6-bytes        gzip6-bytes
+              :gzip9-bytes        gzip9-bytes
+              :brotli-bytes       brotli-bytes
+              :measurement-method measurement-method}
+   :baseline {:kind      :before-vs-after
+              :reference {:revision :the-revision-before-this
+                          :note     (str "the same bundle's bytes and parse/compile on the "
+                                         "preceding revision — equal shape is what makes a "
+                                         "movement attributable to a change in what ships")}}
+   :sampling sampling
+   :measurements
+   [{:id         :B5/raw-bytes
+     :doc        "the release bundle's uncompressed on-disk size"
+     :observable :bytes}
+    {:id         :B5/gzip6-bytes
+     :doc        "the bundle's transfer size under gzip level 6 — a common server default"
+     :observable :bytes}
+    {:id         :B5/gzip9-bytes
+     :doc        "the bundle's transfer size under gzip level 9 — maximum gzip"
+     :observable :bytes}
+    {:id         :B5/brotli-bytes
+     :doc        "the bundle's transfer size under brotli — the smallest of the three encodings"
+     :observable :bytes}
+    {:id         :B5/parse-compile-ms
+     :doc        "wall time for V8 to parse the bundle and compile its top level (new vm.Script)"
+     :observable :duration-ms}]
+   :run
+   (fn [_]
+     {:B5/raw-bytes         raw-bytes
+      :B5/gzip6-bytes       gzip6-bytes
+      :B5/gzip9-bytes       gzip9-bytes
+      :B5/brotli-bytes      brotli-bytes
+      :B5/parse-compile-ms  (parse-compile-ms source)})})
+
+(def release-build
+  "The build the release artefact was compiled at, as a FACT about the
+  artefact rather than a detection of the process measuring it.
+
+  `:freehand-release` is declared `:advanced` with `goog.DEBUG` false in
+  `implementation/shadow-cljs.edn`, so an instrumented dev build cannot be
+  what is on disk. Passed as [[re-frame.freehand.bench/run-workload]]'s
+  `:build` override, because `detect-build` would otherwise report the
+  Node test process (`:none`, instrumented) — true of the measurer, false
+  of the measured."
+  {:optimizations :advanced :instrumentation? false})

--- a/implementation/freehand/test/re_frame/freehand/bench/b2_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b2_dom_cljs_test.cljs
@@ -274,20 +274,29 @@
   (:signature (get (fr/boundary-cache) (:view-id (v/describe view)))))
 
 (defn- shell-census
-  "The arm's RUNTIME shell census: each declaration's mounted occurrence
-  count, filed under the wrapper React reconciled for it.
+  "The arm's shell census: each declaration's mounted OCCURRENCE count,
+  filed under the wrapper React reconciled for it.
 
-  Both inputs are observations of a live page. Nothing here subtracts a
-  manifest verdict from a mount count — the manifest's own prediction is
-  compared against this total afterwards, which is the cross-check and
-  not the source."
+  Both inputs are observations of a live page — occurrences counted off
+  `document`, classified by the wrapper the emitter minted. Nothing here
+  subtracts a manifest verdict from a mount count; the manifest's own
+  prediction is compared against this total afterwards, which is the
+  cross-check and not the source.
+
+  What this is NOT: a count of live, allocated or retained ViewCell
+  OBJECTS. It counts DOM occurrences and classifies each by the wrapper
+  TYPE React selected for its declaration — an `-occurrences` count, not
+  an object-liveness reading. Retained-object evidence (allocation,
+  survival past unmount) would need a heap probe this bench deliberately
+  does not carry, and its keys say `-occurrences` so no reader mistakes
+  the one for the other."
   [container roster selectors]
   (reduce (fn [acc [view sel]]
             (let [n (.-length (.querySelectorAll container sel))]
               (if (= :elided (second (reconciled-wrapper view)))
-                (update acc :omitted-shells + n)
-                (update acc :retained-shells + n))))
-          {:omitted-shells 0 :retained-shells 0}
+                (update acc :omitted-shell-occurrences + n)
+                (update acc :retained-shell-occurrences + n))))
+          {:omitted-shell-occurrences 0 :retained-shell-occurrences 0}
           (map vector roster selectors)))
 
 ;; ---------------------------------------------------------------------------
@@ -297,7 +306,12 @@
 (defn evidence-record
   "The result record for one mounted arm — every provenance field D021
   requires that a browser can name, the mount-time distribution, and the
-  runtime census as a published property.
+  wrapper-classified occurrence census as a published property.
+
+  The census counts DOM occurrences classified by reconciled wrapper type;
+  it is not a live-object reading, and `:census-method` in the fixture
+  says so, so a reader never takes a `-occurrences` count for a
+  retained-ViewCell-object count.
 
   Public because a record nobody can build outside the assertion that
   publishes it is a record nobody can check."
@@ -311,9 +325,13 @@
                   :boundaries          (reduce + 0 counts)
                   :measurement-method
                   (str "wall time bracketing one v/mount inside a React act boundary, "
-                       "host node to committed DOM; shells are folded from two runtime "
-                       "readings — each declaration's occurrence count off document, and "
-                       "the wrapper signature React reconciled for it")}
+                       "host node to committed DOM")
+                  :census-method
+                  (str "each declaration's occurrence count off document, classified by "
+                       "the wrapper signature React reconciled for it — wrapper-classified "
+                       "DOM occurrences, NOT a count of live/allocated/retained ViewCell "
+                       "objects; retained-object liveness evidence would need a heap probe "
+                       "this bench does not carry and remains open")}
    :build        (prov/detect-build)
    :host         (prov/detect-host)
    :sampling     {:warmup warmup :samples (count times)}
@@ -330,15 +348,25 @@
 (defn- publish!
   "Write the record to the console as EDN, prefixed with whether it is
   citable. Evidence that is not attributable to a revision is still worth
-  reading and is not worth citing, and the line says which it is."
+  reading and is not worth citing, and the line says which it is.
+
+  A citable record goes through `provenance/result` — the ONE documented
+  emission door — so the same validation that governs the JVM lane governs
+  a browser record too, rather than a bypass that console-logs whatever it
+  was handed. A record missing only its revision (this build compiles none
+  in) is printed as NOT CITABLE without forcing it through the door, which
+  would throw; a release-lane build that sets the revision closure-define
+  makes it citable with no change here."
   [record]
   (let [ds (prov/defects record)]
-    (js/console.log
-      (str ";; B2 mounted-storm evidence — "
-           (if (seq ds)
-             (str "NOT CITABLE (" (count ds) " provenance field(s) unnamed by this build)")
-             "citable")
-           "\n" (pr-str record)))))
+    (if (seq ds)
+      (js/console.log
+        (str ";; B2 mounted-storm evidence — NOT CITABLE ("
+             (count ds) " provenance field(s) unnamed by this build)\n"
+             (pr-str record)))
+      (js/console.log
+        (str ";; B2 mounted-storm evidence — citable\n"
+             (pr-str (prov/result record)))))))
 
 ;; ===========================================================================
 ;; The storm, mounted — every deterministic claim at one scale
@@ -364,13 +392,13 @@
             (str id " / " sel ": React minted a boundary for this declaration"))
         (is (= [lowering view-cell] sig)
             (str id " / " sel ": React reconciled the wrapper this declaration earned"))))
-    (is (= (if elides? total 0) (:omitted-shells census))
-        (str id ": the shells the mount actually omitted"))
-    (is (= (if elides? 0 total) (:retained-shells census))
-        (str id ": the shells the mount actually retained"))
-    (is (= (b2/omitted plan) (:omitted-shells census))
+    (is (= (if elides? total 0) (:omitted-shell-occurrences census))
+        (str id ": the occurrences whose reconciled wrapper omitted the shell"))
+    (is (= (if elides? 0 total) (:retained-shell-occurrences census))
+        (str id ": the occurrences whose reconciled wrapper retained the shell"))
+    (is (= (b2/omitted plan) (:omitted-shell-occurrences census))
         (str id ": the manifest's static prediction and the mounted page agree "
-             "about how many shells this storm omits"))
+             "about how many occurrences omit the shell"))
     (publish! (evidence-record arm scale census counts samples))
     (.-innerHTML container)))
 
@@ -457,7 +485,7 @@
             a browser has no git and this test build does not compile one
             in. A record that quietly lost its scale or its build mode
             would red here."
-    (let [census {:omitted-shells 8 :retained-shells 0}
+    (let [census {:omitted-shell-occurrences 8 :retained-shell-occurrences 0}
           record (evidence-record (first arms) small-scale census [2 2 2 2] [1.0 2.0 3.0])]
       (is (empty? (remove #(= [:revision] (:path %)) (prov/defects record)))
           "every provenance field a browser can name is named")

--- a/implementation/freehand/test/re_frame/freehand/bench/b5_bundle_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b5_bundle_cljs_test.cljs
@@ -1,0 +1,217 @@
+(ns re-frame.freehand.bench.b5-bundle-cljs-test
+  "B5's shipped-cost readings, and the proof they are readings of the
+  artefact rather than of the process taking them.
+
+  [[re-frame.freehand.bench.b5]] measures the release bundle's bytes and
+  its parse/compile time. Two things make that honest, and both are tested
+  here without needing the bundle on disk:
+
+    - the byte and digest functions are exercised over a synthetic source,
+      so the measurement machinery has coverage on every `npm run
+      test:freehand` run, built bundle or not;
+    - the workload it produces routes through the standing harness, and
+      the record's `:build` is the ARTEFACT's (`:advanced`, uninstrumented)
+      supplied as an override — not the Node test process's detected
+      `:none`, which would be a provenance lie about what was measured.
+
+  The real artefact is measured only when it has been built. A B5 number
+  taken against a bundle that does not exist is a number about nothing, so
+  that test SKIPS when `out/freehand-release/main.js` is absent — the same
+  posture the DOM benches keep when there is no browser. To publish the
+  real figures:
+
+      npm run build:freehand-release
+      RF2_REVISION=$(git rev-parse HEAD) npm run test:freehand
+
+  Normative owner: `docs/design/freehand/decisions/`
+  `D021-performance-budgets-and-release-evidence.md`."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [clojure.string :as str]
+            [re-frame.freehand.bench :as bench]
+            [re-frame.freehand.bench.b5 :as b5]
+            [re-frame.freehand.bench.measure :as m]
+            [re-frame.freehand.bench.provenance :as prov]))
+
+;; ---------------------------------------------------------------------------
+;; A synthetic artefact — enough repeated, valid JS to be genuinely
+;; compressible, so the encodings really do come out smaller than raw
+;; ---------------------------------------------------------------------------
+
+(def ^:private synthetic-source
+  (str/join "\n"
+            (repeat 400
+                    "function bench_leaf(a, b){ return (a + b) * 2 - 1; } bench_leaf;")))
+
+(def ^:private synthetic-buf (js/Buffer.from synthetic-source "utf8"))
+
+(def ^:private sampling {:warmup 2 :samples 8})
+
+(def ^:private fixture-provenance
+  "The revision a TEST supplies. A ClojureScript test process is not the
+  build pipeline that produced the artefact, so it cannot truthfully
+  detect the revision the bundle was built from; a published run sets
+  `RF2_REVISION`. The `:build` is the artefact's own, because the thing
+  measured is the `:advanced` release bundle, not this `:none` test host."
+  {:revision "test-fixture-revision"
+   :build    b5/release-build})
+
+;; ---------------------------------------------------------------------------
+;; The byte and digest readings
+;; ---------------------------------------------------------------------------
+
+(deftest byte-readings-are-real-and-ordered
+  (testing "The three encodings measure the synthetic artefact, and a
+            compressible source really does shrink: gzip and brotli come
+            out under raw, maximum gzip is no larger than default gzip, and
+            brotli is the smallest — the ordering a bundle this shape has."
+    (let [raw    (b5/raw-bytes synthetic-buf)
+          gzip6  (b5/gzip-bytes synthetic-buf 6)
+          gzip9  (b5/gzip-bytes synthetic-buf 9)
+          brotli (b5/brotli-bytes synthetic-buf)]
+      (is (= (.-length synthetic-buf) raw) "raw bytes are the artefact's byte length")
+      (is (pos? raw) "the synthetic artefact is non-empty")
+      (is (< gzip6 raw) "gzip level 6 shrinks a compressible artefact")
+      (is (<= gzip9 gzip6) "maximum gzip is no larger than default gzip")
+      (is (< brotli raw) "brotli shrinks it too")
+      (is (<= brotli gzip9) "and brotli is the smallest of the three, for a bundle this shape"))))
+
+(deftest sha256-is-a-stable-digest-of-the-bytes
+  (testing "The digest that ties a figure to its artefact is a 64-hex
+            SHA-256, the same on the same bytes and different on different
+            bytes — so a rebuild that changed the bundle changes the digest
+            the numbers were filed under."
+    (let [d (b5/sha256 synthetic-buf)]
+      (is (= 64 (count d)) "SHA-256 is 64 hex characters")
+      (is (re-matches #"[0-9a-f]{64}" d) "lower-case hex")
+      (is (= d (b5/sha256 synthetic-buf)) "stable on the same bytes")
+      (is (not= d (b5/sha256 (js/Buffer.from (str synthetic-source "x") "utf8")))
+          "and different on different bytes"))))
+
+(deftest parse-compile-is-a-nonnegative-duration
+  (testing "The parse/compile reading is a wall-time duration — a
+            non-negative number, taken with a fresh vm.Script so nothing a
+            previous compile cached is billed to it. It gates nothing; it
+            is only asserted to have been observable."
+    (let [ms (b5/parse-compile-ms synthetic-source)]
+      (is (number? ms) "parse/compile answered a number")
+      (is (not (neg? ms)) "and a non-negative one"))))
+
+;; ---------------------------------------------------------------------------
+;; The workload routes through the standing harness
+;; ---------------------------------------------------------------------------
+
+(defn- synthetic-measured []
+  {:path         "synthetic"
+   :sha256       (b5/sha256 synthetic-buf)
+   :raw-bytes    (b5/raw-bytes synthetic-buf)
+   :gzip6-bytes  (b5/gzip-bytes synthetic-buf 6)
+   :gzip9-bytes  (b5/gzip-bytes synthetic-buf 9)
+   :brotli-bytes (b5/brotli-bytes synthetic-buf)
+   :source       synthetic-source})
+
+(deftest the-workload-is-all-evidence-no-gate
+  (testing "B5 states no pass/fail about a bundle — the deterministic
+            reachability gate is the build lane's. Every measurement it
+            declares observes bytes or a duration, so every one classes as
+            evidence and none can gate; the harness decides that from the
+            observable, and a byte figure dressed as a gate would be
+            refused at construction rather than here."
+    (let [w  (bench/workload (b5/workload {:id       :B5/synthetic
+                                           :doc      "a synthetic compressible artefact"
+                                           :sampling sampling}
+                                          (synthetic-measured)))
+          by (into {} (map (juxt :id identity)) (:measurements w))]
+      (doseq [mid [:B5/raw-bytes :B5/gzip6-bytes :B5/gzip9-bytes
+                   :B5/brotli-bytes :B5/parse-compile-ms]]
+        (is (m/evidence? (get by mid)) (str mid " is evidence")))
+      (is (empty? (filter m/gate? (:measurements w)))
+          "the workload declares no gate at all"))))
+
+(deftest the-record-names-the-artefacts-build-not-the-measurers
+  (testing "A B5 record must describe the `:advanced` artefact it measured,
+            not the `:none` instrumented Node process that measured it. The
+            build override carries the artefact's own build mode through to
+            the record; the digest and byte facts ride the fixture so each
+            figure is tied to the exact bytes; and the run reds nothing,
+            because it declared nothing that could."
+    (let [w      (b5/workload {:id       :B5/synthetic
+                               :doc      "a synthetic compressible artefact"
+                               :sampling sampling}
+                              (synthetic-measured))
+          record (bench/run-workload w fixture-provenance)]
+      (is (empty? (:gate-failures record)) "no deterministic property was violated")
+      (is (= :advanced (get-in record [:build :optimizations]))
+          "the record carries the ARTEFACT's optimization level, not the measurer's")
+      (is (false? (get-in record [:build :instrumentation?]))
+          "and the artefact is uninstrumented, as a shipped bundle is")
+      (is (= "test-fixture-revision" (:revision record)) "the supplied revision rides the record")
+      (is (= (b5/sha256 synthetic-buf) (get-in record [:fixture :sha256]))
+          "the digest ties the figures to the exact bytes measured")
+      (testing "the byte figures are published as degenerate distributions — a
+                file's size does not vary across samples — and parse/compile as
+                a real one"
+        (doseq [mid [:B5/raw-bytes :B5/gzip6-bytes :B5/gzip9-bytes :B5/brotli-bytes]]
+          (let [d (get-in record [:distribution mid])]
+            (is (some? d) (str mid " was published"))
+            (is (= (:min d) (:max d)) (str mid " is constant across samples"))
+            (is (not (contains? d :pass?)) (str mid " carries no verdict — it is evidence"))))
+        (let [d (get-in record [:distribution :B5/parse-compile-ms])]
+          (is (= (:samples sampling) (:n d)) "parse/compile summarises every measured sample")
+          (doseq [k [:p50 :p95 :p99 :min :max :mean]]
+            (is (number? (get d k)) (str "parse/compile carries " k))))))))
+
+;; ---------------------------------------------------------------------------
+;; The real artefact, when it has been built
+;; ---------------------------------------------------------------------------
+
+(defn- publish!
+  "Emit the real B5 record. A citable record — one that named every
+  provenance field — goes through `provenance/result`, the ONE documented
+  emission door, which validates it; an unattributable one is worth
+  reading and not worth citing, and the line says which."
+  [record]
+  (let [ds (prov/defects record)]
+    (if (seq ds)
+      (js/console.log (str ";; B5 shipped-cost evidence — NOT CITABLE ("
+                           (count ds) " provenance field(s) unnamed by this run)\n"
+                           (pr-str record)))
+      (js/console.log (str ";; B5 shipped-cost evidence — citable\n"
+                           (pr-str (prov/result record)))))))
+
+(deftest the-release-bundle-is-measured-when-it-has-been-built
+  (testing "The real artefact's shipped cost, measured off
+            out/freehand-release/main.js when it is on disk. The encodings
+            shrink it, the digest is a fact about it, and the record is
+            emitted through the provenance door — the same reading the
+            build lane publishes as the substrate's shipped cost. When the
+            bundle has not been built, this SKIPS rather than fabricate a
+            measurement of a file that is not there."
+    (if-not (b5/bundle-present? b5/default-bundle-path)
+      (is true (str "no release bundle on disk — run `npm run build:freehand-release` first; "
+                    "skipping the real-artefact measurement"))
+      (let [measured (b5/measure-bundle b5/default-bundle-path)
+            w        (b5/workload {:id       :B5/freehand-release
+                                   :doc      "the shipped Freehand release bundle"
+                                   :sampling sampling}
+                                  measured)
+            record   (bench/run-workload w (assoc fixture-provenance
+                                                  :revision (or (prov/detect-revision)
+                                                                "unattributed-local-build")))]
+        (is (< (:gzip6-bytes measured) (:raw-bytes measured))
+            "the shipped bundle compresses under gzip")
+        (is (<= (:brotli-bytes measured) (:gzip9-bytes measured))
+            "and brotli is at least as small as maximum gzip")
+        (is (= 64 (count (:sha256 measured))) "the artefact has a digest")
+        (is (empty? (:gate-failures record)) "the measurement reds nothing — it is all evidence")
+        (is (= :advanced (get-in record [:build :optimizations]))
+            "the record describes the advanced artefact")
+        ;; Method correctness, NOT a performance budget: a genuine cold parse
+        ;; of a multi-hundred-KB bundle is milliseconds; a V8 compilation-cache
+        ;; HIT is microseconds. This loose floor sits ~an order of magnitude
+        ;; below the real reading and ~25x above a cache hit, so it reds only
+        ;; if the nonce that defeats the cache were removed and the figure
+        ;; collapsed to a lookup — the exact regression the audit named. It
+        ;; does not, and cannot, red a release for being slow.
+        (is (> (get-in record [:distribution :B5/parse-compile-ms :p50]) 1.0)
+            "parse/compile is a real cold compile, not a compilation-cache lookup")
+        (publish! record)))))


### PR DESCRIPTION
Two beads of D021's Freehand B-spine, both on the bench surface only.

## rf2-drpa3.52 — B5 shipped cost (the evidence half)

A new `re-frame.freehand.bench.b5` measures the `:advanced` release bundle
(`out/freehand-release/main.js`, `npm run build:freehand-release`) and its
Node test drives it through the standing harness, emitting a record through
`provenance/result`. Following B4, B5 is a **test**, not a
`clojure -M:bench` workload — its subject is an artefact a standing run has
no reason to have built, so it skips when the bundle is absent.

Measured on this revision (Node v24.13.0, sha256
`d6141f0f53f2b05e9ab48077dc04d500d3f8099414fb7a6f595ab2677d285547`):

| reading | value |
| --- | --- |
| raw | 744,071 bytes |
| gzip-6 | 220,966 bytes |
| gzip-9 | 219,920 bytes |
| brotli | 183,238 bytes |
| parse + top-level compile | p50 16.82 ms, p95 23.72 ms (n=8) |

Two correctness points the prior (unmerged) B5 evidence got wrong:

- **Not eager compilation.** `new vm.Script` compiles the top level;
  function bodies stay lazy, and `produceCachedData` does not change that.
  The reading is named for what it is — parse + top-level compilation — and
  the bundle (a `:browser` artefact referencing `window`/`self`) is not
  executed, so eval time is not measured wrongly.
- **The compilation cache is defeated.** V8 caches scripts by source
  content; a second `new vm.Script` over the same string returns in
  microseconds. Each sample appends a nonce comment so every reading is a
  genuine cold compile — without it the figure collapses from ~17 ms to
  ~0.001 ms, and the real-bundle test floors against exactly that
  regression.

The record's `:build` is the artefact's (`:advanced`, uninstrumented),
supplied as the harness build override, not the Node measurer's detected
`:none`. Bytes and parse time are **evidence only** — no gate, no
threshold. The deterministic control-build reachability gate is out of the
bench surface (**rf2-drpa3.166**, build lane, in progress); no shadow build
is added, and the matched interpreted/compiled/mixed builds + per-promotion
delta remain a build-lane (hot-zone `shadow-cljs.edn`) slice.

## rf2-drpa3.147 — B2 real matched mount

The real matched mount already lands in `b2-dom-cljs-test` (PR #6777). This
closes the two defects the reopen named, within the bench surface:

- **`publish!` routes through the door.** A citable record now goes through
  `provenance/result` — the one documented emission door — rather than
  console-logging whatever it was handed.
- **The census is named honestly.** `:omitted-`/`:retained-shell-occurrences`
  with an explicit `:census-method` stating these are wrapper-classified DOM
  occurrences, **not** live/allocated/retained ViewCell objects.
  Retained-object liveness evidence remains open (no heap probe — the
  audit's endorsed answer under trust-the-programmer).

Residual out of the bench surface: injecting the revision closure-define
into the freehand browser test build and pinning an evidence lane both
touch `shadow-cljs.edn` (hot-zone) / `.github/workflows`.

## Quality gates

- `implementation/freehand` → `clojure -M:test`: **916 tests, 6533 assertions, 0 failures, 0 errors** (EXIT=0). `.cljs` tests correctly excluded from the JVM lane.
- `implementation/` → `npm run test:freehand`: **999 tests, 5671 assertions, 0 failures, 0 errors** (EXIT=0), 403 files compiled, 0 warnings. Includes the real-artefact B5 measurement (release bundle built) and its cache-defeat floor assertion.
- `implementation/` → `npm run build:freehand-release`: **174 files, 0 warnings** (EXIT=0).
