### PR TITLE
fix(freehand): resolve or fail-loud the analyzer's nonexistent re-frame.freehand.hooks/* host-hook lowerings (rf2-1a9au)

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/compiler/analyze.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/analyze.cljc
@@ -61,9 +61,14 @@
 ;; The frozen re-frame.freehand.react interop tier (Spec 004 §The React interop tier)
 ;; plus the promoted substrate host hook `re-frame.freehand/ref` (rf2-u53yy.9). All are
 ;; recognised in expression (let-binding value) position by the same finite-site
-;; machinery as `local`, position-checked, and lowered to `re-frame.freehand.hooks/*`
-;; (ref's lowering target stays the `use-ref` runtime fn). `lazy` is def-level
-;; only — recognised in a view body solely to reject it.
+;; machinery as `local`, position-checked, and — once the host-hook runtime slice
+;; lands — lowered to it. That slice HAS NOT LANDED (Spec 004B §refs "arrive with
+;; the host-lifecycle slice"; there is no host-hook runtime yet), so the analyzer
+;; recognises and position-checks these forms but REFUSES to lower them with an
+;; intentional Freehand diagnostic rather than emitting a call to a runtime var
+;; that is defined nowhere (rf2-1a9au — the same class as the dead JVM host-op arms
+;; rf2-drpa3.174 replaced with `env/fail!`). `lazy` is def-level only — recognised
+;; in a view body solely to reject it.
 (def ^:private ui-ref-fqns                 #{'re-frame.freehand/ref})
 (def ^:private react-use-effect-fqns       #{'re-frame.freehand.react/use-effect})
 (def ^:private react-use-layout-effect-fqns #{'re-frame.freehand.react/use-layout-effect})
@@ -72,19 +77,21 @@
 (def ^:private react-use-id-fqns           #{'re-frame.freehand.react/use-id})
 (def ^:private react-lazy-fqns             #{'re-frame.freehand.react/lazy})
 ;; :authored = the full authored head spelling used in diagnostics; :kind keyword
-;; + runtime lowering target + call arity, keyed by fqn set.
+;; + call arity, keyed by fqn set. No `:runtime` lowering target: the host-hook
+;; runtime slice has not landed, so a recognised hook is REFUSED, never lowered
+;; (rf2-1a9au).
 (def ^:private react-hook-specs
-  [{:fqns ui-ref-fqns                 :kind :ref          :runtime 're-frame.freehand.hooks/use-ref
+  [{:fqns ui-ref-fqns                 :kind :ref
     :min-args 0 :max-args 1 :authored "v/ref"}
-   {:fqns react-use-effect-fqns       :kind :effect       :runtime 're-frame.freehand.hooks/use-effect
+   {:fqns react-use-effect-fqns       :kind :effect
     :min-args 1 :max-args 2 :authored "react/use-effect" :deferred-cb 0 :deps-arg 1}
-   {:fqns react-use-layout-effect-fqns :kind :layout-effect :runtime 're-frame.freehand.hooks/use-layout-effect
+   {:fqns react-use-layout-effect-fqns :kind :layout-effect
     :min-args 1 :max-args 2 :authored "react/use-layout-effect" :deferred-cb 0 :deps-arg 1}
-   {:fqns react-use-effect-event-fqns :kind :effect-event :runtime 're-frame.freehand.hooks/use-effect-event
+   {:fqns react-use-effect-event-fqns :kind :effect-event
     :min-args 1 :max-args 1 :authored "react/use-effect-event" :deferred-cb 0}
-   {:fqns react-use-context-fqns      :kind :context      :runtime 're-frame.freehand.hooks/use-context
+   {:fqns react-use-context-fqns      :kind :context
     :min-args 1 :max-args 1 :authored "react/use-context"}
-   {:fqns react-use-id-fqns           :kind :id           :runtime 're-frame.freehand.hooks/use-id
+   {:fqns react-use-id-fqns           :kind :id
     :min-args 0 :max-args 0 :authored "react/use-id"}])
 
 (defn- react-hook-spec-for
@@ -365,10 +372,13 @@
 
 (def ^:private runtime-sub-fqn 're-frame.freehand.reactive/sub-read)
 (def ^:private runtime-frame-ops-fqn 're-frame.freehand.frames/frame-ops)
-(def ^:private runtime-local-fqn 're-frame.freehand.hooks/local-state)
-(def ^:private runtime-effect-value-fqn 're-frame.freehand.hooks/effect-value)
-(def ^:private runtime-effect-connect-fqn 're-frame.freehand.hooks/effect-connect)
-(def ^:private runtime-dispatch-fn-fqn 're-frame.freehand.hooks/dispatch-fn)
+;; The `local` / `effect` / `dispatch-fn` / react-interop lowering targets that
+;; used to live here named `re-frame.freehand.hooks/*` — a runtime namespace that
+;; is defined nowhere (its slice has not landed). Emitting them produced an
+;; unresolved host-op var in every compiled/structural view that used a host hook.
+;; They are GONE: the analyzer now refuses a recognised host hook with an
+;; intentional Freehand diagnostic instead of lowering to a phantom var
+;; (rf2-1a9au). The targets return with the host-hook runtime slice.
 (def ^:private deferred-scope ::deferred-scope)
 (def ^:private transparent-macro-fqns
   "Closed macro set whose arguments are host-independent expression slots,
@@ -734,6 +744,26 @@
                   "part MOUNTS a defview that owns its own state")
              {:form form}))
 
+(defn- host-hook-unavailable!
+  "Refuse a recognised host-hook form whose runtime lowering target does not exist
+  yet. The `local` / `effect` / `dispatch-fn` / `re-frame.freehand.react` interop
+  forms are real Freehand grammar, position-checked by the finite-site machinery,
+  but their runtime — a per-host lowering target — arrives with the host-hook /
+  host-lifecycle slice, which HAS NOT LANDED (Spec 004B §refs: they \"arrive with
+  the host-lifecycle slice\"). Until it does, the analyzer refuses the form with an
+  intentional compile diagnostic rather than lowering it to a var that is defined
+  nowhere — the unresolved host-op symbol rf2-1a9au closed, the same class of bug
+  rf2-drpa3.174 fixed on the JVM emitter's dead host-op arms. `authored` is the
+  head spelling for the diagnostic; `kind` is the reserved capability keyword."
+  [e authored kind form]
+  (env/fail! e :rf.ui.compile/unsupported-form
+             (str "(" authored " …) is a host hook, but Freehand's host-hook "
+                  "runtime slice has not landed — there is no lowering target for "
+                  "it yet, so the analyzer recognises and position-checks the form "
+                  "but cannot compile it. Remove the host-hook use until the "
+                  "host-lifecycle slice ships.")
+             {:form form :host-hook kind}))
+
 (defn rewrite-expr
   "Rewrite an opaque expression, lowering resolved unshadowed `(sub q)` calls
   to the serialized two-argument runtime shape and recording stable lexical
@@ -1029,14 +1059,11 @@
                                           "callback, render-fn slot, or root expression "
                                           "(host hooks run once per render in fixed order)")
                                      {:form f})))
-                      (let [sid (lexical-site-id e :local f p)]
-                        (env/next-hook-ordinal! e) ; a local advances the shared body-hook ordinal
-                        (env/add-site! e :locals {:sid sid :path (:path e)
-                                                  :expr-path (vec p)})
-                        (with-same-meta
-                          f
-                          (list runtime-local-fqn
-                                (rw (second f) locals (conj p 1))))))
+                      ;; Position is legal, but the `local` runtime lowering target
+                      ;; (the host-hook slice) has not landed — refuse the form
+                      ;; loudly rather than lower it to a var defined nowhere
+                      ;; (rf2-1a9au).
+                      (host-hook-unavailable! e "local" :local f))
 
                     ;; Host hooks — the substrate `v/ref` and the re-frame.freehand.react
                     ;; interop hooks (use-effect / use-layout-effect /
@@ -1044,10 +1071,11 @@
                     ;; host hooks obeying the SAME position law as `local`: legal
                     ;; only where they evaluate unconditionally, once per render
                     ;; (the straight-line top region — an outer let binding).
-                    ;; Lowered to hooks/*.
+                    ;; Recognised and position-checked, then REFUSED — the runtime
+                    ;; lowering target has not landed (rf2-1a9au).
                     (and (symbol? head) (not (contains? locals head))
                          (react-hook-spec-for e* head))
-                    (let [{:keys [kind runtime min-args max-args authored deps-arg]}
+                    (let [{:keys [kind min-args max-args authored deps-arg]}
                           (react-hook-spec-for e* head)
                           call-args (rest f)
                           argc      (count call-args)]
@@ -1082,24 +1110,11 @@
                                         "literal vector (compared by rf= value equality); "
                                         "got " (pr-str (nth call-args deps-arg)))
                                    {:form f}))
-                      (let [sid   (lexical-site-id e kind f p)
-                            order (env/next-hook-ordinal! e)
-                            args* (map-indexed
-                                   (fn [i a]
-                                     (if (and deps-arg (= i deps-arg))
-                                       ;; deps vector: walk each slot in ambient
-                                       ;; scope (render-time values).
-                                       (with-same-meta a
-                                         (mapv (fn [j d] (rw d locals (conj p (inc i) j)))
-                                               (range) a))
-                                       ;; setup fn / ctx / initial: ordinary
-                                       ;; expressions (a setup fn is a deferred
-                                       ;; callback — rw-fn rejects reactive sites).
-                                       (rw a locals (conj p (inc i)))))
-                                   call-args)]
-                        (env/add-site! e :react {:sid sid :kind kind :order order
-                                                 :path (:path e) :expr-path (vec p)})
-                        (with-same-meta f (apply list runtime args*))))
+                      ;; Position/arity/deps are legal, but the interop hook's
+                      ;; runtime lowering target (the host-hook slice) has not landed
+                      ;; — refuse the form loudly rather than lower it to a var
+                      ;; defined nowhere (rf2-1a9au).
+                      (host-hook-unavailable! e authored kind f))
 
                     ;; (react/lazy …) is DEF-LEVEL only — recognised in a body
                     ;; solely to reject it (per-render construction remount-loops).
@@ -1137,10 +1152,11 @@
                                           "expression. Capture it in the view body and use "
                                           "it from an (effect …) or foreign callback")
                                      {:form f})))
-                      (let [sid (lexical-site-id e :dispatch-fn f p)]
-                        (env/add-site! e :dispatch-fns {:sid sid :path (:path e)
-                                                        :expr-path (vec p)})
-                        (with-same-meta f (list runtime-dispatch-fn-fqn))))
+                      ;; Position is legal, but the `dispatch-fn` runtime lowering
+                      ;; target (the host-hook slice) has not landed — refuse the
+                      ;; form loudly rather than lower it to a var defined nowhere
+                      ;; (rf2-1a9au).
+                      (host-hook-unavailable! e "v/dispatch-fn" :dispatch-fn f))
 
                     ;; (effect …) is a leading STATEMENT, spliced before the
                     ;; final template by analyze-hooks-body. Reaching rw means it
@@ -3601,10 +3617,12 @@
        (env/resolves-to? e (first form) effect-fqns)))
 
 (defn- analyze-effect-statement
-  "Analyze one leading `(effect …)` statement -> the lowered runtime call form.
-  `(effect [deps…] body…)` compares deps by rf= (value deps); `(effect :connect
-  body…)` runs at each connect. The body is a DEFERRED callback (sub/frame
-  inside are rejected); it is spliced before the template by `analyze-hooks-body`."
+  "Analyze one leading `(effect …)` statement. `(effect [deps…] body…)` compares
+  deps by rf= (value deps); `(effect :connect body…)` runs at each connect. The
+  position and deps SHAPE are still validated, but the `effect` runtime lowering
+  target (the host-hook slice) has not landed, so a well-formed statement is
+  REFUSED with an intentional Freehand diagnostic rather than lowered to a var
+  that is defined nowhere (rf2-1a9au)."
   [e index form]
   ;; The purity fence is TRANSITIVE: a render-fn slot body inherits the enclosing
   ;; hooks region, so a leading (effect …) would otherwise reach this seam and be
@@ -3624,37 +3642,22 @@
                     "defview's UNCONDITIONAL top region (or a top-region let/do "
                     "body), before the final template")
                {:form form}))
-  (let [[_ deps-or-kw & body] form
-        sid (lexical-site-id e :effect form [:effect index])]
+  (let [[_ deps-or-kw & body] form]
     (when (empty? body)
       (env/fail! e :rf.ui.compile/bad-effect
                  (str "(effect [deps…] body…) / (effect :connect body…) needs a "
                       "body form after the deps")
                  {:form form}))
-    (letfn [(body-fn [] ; the deferred callback fn — the fn walk rejects sub/frame
-              (walk-expr e [:effect index :body]
-                         (with-meta (apply list 'fn [] body) (meta form))))]
-      (cond
-        (= :connect deps-or-kw)
-        (do
-          (env/add-site! e :effects {:sid sid :kind :connect :index index
-                                     :path (:path e) :expr-path [:effect index]})
-          (with-meta (list runtime-effect-connect-fqn (body-fn)) (meta form)))
-
-        (vector? deps-or-kw)
-        (let [deps* (mapv (fn [i d] (walk-expr e [:effect index :dep i] d))
-                          (range) deps-or-kw)]
-          (env/add-site! e :effects {:sid sid :kind :deps :index index
-                                     :path (:path e) :expr-path [:effect index]})
-          (with-meta (list runtime-effect-value-fqn (body-fn) (vec deps*))
-            (meta form)))
-
-        :else
-        (env/fail! e :rf.ui.compile/bad-effect
-                   (str "(effect …) first argument must be a literal deps VECTOR "
-                        "(value deps compared by rf=) or the keyword :connect; got "
-                        (pr-str deps-or-kw))
-                   {:form form})))))
+    (when-not (or (= :connect deps-or-kw) (vector? deps-or-kw))
+      (env/fail! e :rf.ui.compile/bad-effect
+                 (str "(effect …) first argument must be a literal deps VECTOR "
+                      "(value deps compared by rf=) or the keyword :connect; got "
+                      (pr-str deps-or-kw))
+                 {:form form}))
+    ;; Position and deps shape are legal, but the `effect` runtime lowering target
+    ;; (the host-hook slice) has not landed — refuse the statement loudly rather
+    ;; than lower it to a var defined nowhere (rf2-1a9au).
+    (host-hook-unavailable! e "effect" :effect form)))
 
 (defn- analyze-hooks-body
   "Analyze a hooks-region body: zero or more leading `(effect …)` STATEMENTS,

--- a/implementation/freehand/test/re_frame/freehand/host_hook_unavailable_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/host_hook_unavailable_cljs_test.cljc
@@ -1,0 +1,124 @@
+(ns re-frame.freehand.host-hook-unavailable-cljs-test
+  "Host hooks fail LOUD, never lower to a phantom runtime var.
+
+  `local`, `effect`, `v/dispatch-fn` and the `re-frame.freehand.react` interop
+  hooks (`v/ref` / `use-effect` / `use-layout-effect` / `use-effect-event` /
+  `use-context` / `use-id`) are real Freehand grammar the analyzer recognises and
+  position-checks. Their runtime lowering targets — a host-hook slice — have NOT
+  landed, so the analyzer used to lower each authored form to a symbol under
+  `re-frame.freehand.hooks/*`, a namespace defined nowhere. Every compiled or
+  structural view that used a host hook then failed with an UNRESOLVED HOST-OP VAR:
+  the `re-frame.freehand.reactive/sub-read` twin of the dead JVM host-op arms
+  rf2-drpa3.174 replaced with `env/fail!`.
+
+  This suite proves the repair (rf2-1a9au): a recognised, WELL-POSITIONED host
+  hook now raises an intentional Freehand compile diagnostic
+  (`:rf.ui.compile/unsupported-form`, ex-data `:host-hook <kind>`) at analysis time
+  — NOT a lowered `re-frame.freehand.hooks/*` symbol, and NOT a symbol that fails
+  to resolve downstream. The position grammar is intact: a MISPLACED or MALFORMED
+  host hook still raises its own specific diagnostic first (the arm's checks run
+  before the not-landed refusal), so the machinery stays ready for the slice.
+
+  It runs the analyzer on the JVM against an injected resolver — the same shape as
+  `analyze-accept` — because the qualified/aliased host-hook spellings resolve to
+  their canonical fqns under a real ClojureScript compile even though the runtime
+  vars do not yet exist; the injected resolver reproduces exactly that."
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.walk :as walk]
+            [re-frame.freehand.compiler.analyze :as ana]
+            [re-frame.freehand.compiler.env :as env]))
+
+(def resolver
+  "Resolves the host-hook authoring spellings to their canonical fqns — exactly
+  what a real ClojureScript compile does for the qualified/aliased forms, even
+  though the runtime vars are not defined anywhere yet."
+  (fn [sym]
+    (case sym
+      re-frame.freehand/local       {:fqn 're-frame.freehand/local :meta {}}
+      re-frame.freehand/ref         {:fqn 're-frame.freehand/ref :meta {}}
+      re-frame.freehand/effect      {:fqn 're-frame.freehand/effect :meta {}}
+      re-frame.freehand/dispatch-fn {:fqn 're-frame.freehand/dispatch-fn :meta {}}
+      re-frame.freehand.react/use-effect        {:fqn 're-frame.freehand.react/use-effect :meta {}}
+      re-frame.freehand.react/use-layout-effect {:fqn 're-frame.freehand.react/use-layout-effect :meta {}}
+      re-frame.freehand.react/use-effect-event  {:fqn 're-frame.freehand.react/use-effect-event :meta {}}
+      re-frame.freehand.react/use-context       {:fqn 're-frame.freehand.react/use-context :meta {}}
+      re-frame.freehand.react/use-id            {:fqn 're-frame.freehand.react/use-id :meta {}}
+      nil)))
+
+(defn- mk-env []
+  (-> (env/make-env {:host :clj :cljs-env nil :ns-sym 'app.test
+                     :self 'self-view :self-id :app.test/self-view
+                     :resolver resolver :template-anchor "host-hook"})
+      (assoc :self-children? true :hooks-region? true)))
+
+(defn- analyze!
+  "Analyze a well-positioned host-hook view BODY (a vector of body forms) and
+  return the throw's ex-data, or `::no-throw` with the analysed AST attached."
+  [body]
+  (try
+    (let [ast (ana/analyze-view-body (mk-env) body)]
+      {:result ::no-throw :ast ast})
+    (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) t
+      (assoc (or (ex-data t) {}) :message (ex-message t)))))
+
+(defn- hooks-phantoms
+  "Every `re-frame.freehand.hooks/*` symbol anywhere in `x` — the phantom
+  lowering targets this fix removed."
+  [x]
+  (let [found (volatile! #{})]
+    (walk/postwalk
+     (fn [y] (when (and (symbol? y) (= "re-frame.freehand.hooks" (namespace y)))
+               (vswap! found conj y)) y)
+     x)
+    @found))
+
+;; One WELL-POSITIONED authoring form per host hook. `:kind` is the reserved
+;; capability keyword the refusal carries in ex-data.
+(def host-hooks
+  [{:kind :local         :body ['(let [[a s! u!] (re-frame.freehand/local 0)] [:div a])]}
+   {:kind :ref           :body ['(let [r (re-frame.freehand/ref)] [:div])]}
+   {:kind :effect        :body ['(let [_ (re-frame.freehand.react/use-effect (fn [] nil) [])] [:div])]}
+   {:kind :layout-effect :body ['(let [_ (re-frame.freehand.react/use-layout-effect (fn [] nil) [])] [:div])]}
+   {:kind :effect-event  :body ['(let [h (re-frame.freehand.react/use-effect-event (fn [] nil))] [:div])]}
+   {:kind :context       :body ['(let [c (re-frame.freehand.react/use-context :ctx)] [:div])]}
+   {:kind :id            :body ['(let [i (re-frame.freehand.react/use-id)] [:div])]}
+   {:kind :effect        :body ['(re-frame.freehand/effect [] (fn [] nil)) '[:div]]}
+   {:kind :effect        :body ['(re-frame.freehand/effect :connect (fn [] nil)) '[:div]]}
+   {:kind :dispatch-fn   :body ['(let [d (re-frame.freehand/dispatch-fn)] [:div])]}])
+
+(deftest a-recognised-host-hook-fails-loud-not-a-phantom-symbol
+  (testing "every well-positioned host hook raises a Freehand diagnostic — never lowers"
+    (doseq [{:keys [kind body]} host-hooks]
+      (let [d (analyze! body)]
+        (is (not= ::no-throw (:result d))
+            (str kind " must be REFUSED, not lowered (was: " (pr-str (:ast d)) ")"))
+        (is (= :rf.ui.compile/unsupported-form (:rf.ui.compile/error d))
+            (str kind " raises the Freehand unsupported-form diagnostic"))
+        (is (contains? d :host-hook)
+            (str kind " carries the :host-hook capability keyword in ex-data"))
+        (is (re-find #"host-hook runtime slice has not landed" (:message d))
+            (str kind " names the un-landed slice"))
+        ;; The adversarial core: the message and ex-data name NO phantom
+        ;; re-frame.freehand.hooks/* symbol — the failure is a compile diagnostic,
+        ;; not a lowered var that fails to resolve downstream.
+        (is (empty? (hooks-phantoms d))
+            (str kind " leaks no re-frame.freehand.hooks/* symbol"))
+        (is (not (re-find #"re-frame\.freehand\.hooks" (:message d)))
+            (str kind "'s diagnostic does not spell the phantom namespace"))))))
+
+(deftest the-position-grammar-still-fires-first
+  (testing "a MALFORMED or MISPLACED host hook raises its own diagnostic before the not-landed refusal"
+    ;; Bad arity: the arity check runs before the not-landed refusal, so the
+    ;; diagnostic is the arity one (no :host-hook key), never the not-landed one.
+    (let [d (analyze! ['(let [x (re-frame.freehand/local 0 1)] [:div x])])]
+      (is (= :rf.ui.compile/unsupported-form (:rf.ui.compile/error d)))
+      (is (not (contains? d :host-hook))
+          "an arity failure fires before the not-landed refusal")
+      (is (re-find #"takes exactly one" (:message d))))
+    ;; A react interop hook in a deferred callback (a fn body) is MISPLACED:
+    ;; React hook order must be static. The misplacement diagnostic fires first.
+    (let [d (analyze! ['(let [f (fn [] (re-frame.freehand.react/use-id))] [:div])])]
+      (is (= :rf.ui.compile/react-hook-misplaced (:rf.ui.compile/error d))
+          "a react hook in a deferred callback is misplaced, caught before not-landed")
+      (is (empty? (hooks-phantoms d))
+          "a misplacement diagnostic also leaks no phantom symbol"))))


### PR DESCRIPTION
Closes rf2-1a9au (discovered-from rf2-drpa3.177 while retiring the dead defview chain, #6879).

## The bug

`implementation/freehand/src/re_frame/freehand/compiler/analyze.cljc` lowered every recognised host hook to a symbol under `re-frame.freehand.hooks/*` — a runtime namespace **defined nowhere**. Ten distinct lowering targets across four arms:

| authored form | phantom lowering target |
|---|---|
| `(local init)` | `re-frame.freehand.hooks/local-state` |
| `(v/dispatch-fn)` | `re-frame.freehand.hooks/dispatch-fn` |
| `(v/ref …)` | `re-frame.freehand.hooks/use-ref` |
| `(react/use-effect …)` | `re-frame.freehand.hooks/use-effect` |
| `(react/use-layout-effect …)` | `re-frame.freehand.hooks/use-layout-effect` |
| `(react/use-effect-event …)` | `re-frame.freehand.hooks/use-effect-event` |
| `(react/use-context …)` | `re-frame.freehand.hooks/use-context` |
| `(react/use-id)` | `re-frame.freehand.hooks/use-id` |
| `(effect [deps] …)` | `re-frame.freehand.hooks/effect-value` |
| `(effect :connect …)` | `re-frame.freehand.hooks/effect-connect` |

Same class as the dead JVM host-op arms rf2-drpa3.174 replaced with `env/fail!`, but on the analyze / host-hook path.

## Reachability — established, not assumed

- **`local`, `v/dispatch-fn`, and the six `re-frame.freehand.react` interop hooks (8)** lower into admitted `:let` / `:expr` AST nodes, so `grammar/check!` (`compiler.cljc`, which runs before **both** emitters) passes them and `emit-jvm` **and** `emit-react` emit the phantom symbol verbatim — a **live unresolved host-op var** in any compiled/structural view that uses one. Proven by driving the analyzer + `emit-react` over a well-positioned body of each and finding `re-frame.freehand.hooks/*` in the emitted react body. **REACHABLE.**
- **The two `effect` lowerings (`effect-value` / `effect-connect`)** land in a `:hook-prefix` node, which `grammar/check!` refuses before emission on the compiled path — but the phantom symbol was still produced into the AST and `emit-jvm` carries a live `:hook-prefix` arm, so they are fixed identically for uniformity.

No genuinely-dead arm to remove: every lowering is reachable through at least one emitter.

## Fix

The host-hook runtime slice **has not landed** (Spec 004B: refs "arrive with the host-lifecycle slice"; there is no host-hook runtime, and Freehand is forbidden — `deps.edn` — from referencing the donor's). So there is no real target to point at. Per the rf2-drpa3.174 model, the analyzer now **refuses** a recognised host hook with an intentional Freehand diagnostic (`:rf.ui.compile/unsupported-form`, ex-data `:host-hook <kind>`) instead of lowering it to a var defined nowhere.

The recognition + arity + position grammar is **kept intact** — the ready starting point for when the slice lands — so a malformed or misplaced host hook still raises its own specific diagnostic first. Every `re-frame.freehand.hooks/*` symbol is gone from `analyze.cljc`.

`host-hook-unavailable-cljs-test` pins the refusal (all ten forms fail loud, name the un-landed slice, and leak no phantom symbol) and that the position grammar still fires first for a bad-arity / misplaced hook. Host-neutral (`:clj` analyzer, injected resolver reproducing ClojureScript's resolution of the qualified spellings).

Scope: `analyze.cljc` + its test only. `client/create-root*` (confirmed non-existent / out of scope), `self-fqn`, `evidence.cljc`/`cell.cljc`, `root.cljs`, routing, and `spec/004*` untouched.

## Quality gates

- freehand JVM (`clojure -M:test`): **918 tests / 6598 assertions, 0 failures, 0 errors**
- freehand node (`npm run test:freehand`): **995 tests / 5688 assertions, 0 failures, 0 warnings**