### PR TITLE
fix(freehand): normalize pre-#6871 flat ledger rows across the ownership-schema hot reload (rf2-4pvsy)

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/root.cljs
+++ b/implementation/freehand/src/re_frame/freehand/root.cljs
@@ -500,6 +500,75 @@
 ;; `frame-standing` stays the sole authority even if the hook never fired.
 (defonce ^:private frame-ledger (atom {}))
 
+;; The UPGRADE boundary — a pre-#6871 FLAT row across the ownership-schema reload.
+;;
+;; `frame-ledger` is `defonce`, so the FIRST reload onto the nested-`:ownership`
+;; code above meets a row the immediately previous build wrote in the FLAT shape
+;; `{:config-fingerprint :installed-by :installed-value :refs}`. That row is NOT
+;; unprovable legacy data: its `:installed-value` IS the exact incarnation handle
+;; `make-frame` handed back, so it migrates LOSSLESSLY — `:installed-value` →
+;; `:handle`, `:installed-by` → `:plan-author`, `:config-fingerprint` →
+;; `:plan-fingerprint`, refs unchanged. Left un-normalized, `frame-standing`
+;; reads `(:ownership row)` as nil and mis-verdicts a live OWNED frame
+;; `:unowned-live`, so the ordinary same-plan HMR remount fails
+;; `:scope-config-less-or-own-the-lifetime` and neither `release-frame!` nor the
+;; destroy hook can match the flat handle — the root-owned frame leaks LIVE.
+;;
+;; So the ONE known flat shape is normalized IN PLACE at the door (`ledger-row!`),
+;; before any verdict, release or hook read consumes it — never a versioned
+;; migration framework, never a public API. A genuinely tokenless pre-#6818 row
+;; (an `:installed-by` with no `:installed-value`) normalizes to `:ownership`
+;; WITHOUT a `:handle`, so `frame-standing` still verdicts it `:legacy-live` and
+;; it stays unprovable/fail-loud: the handle is never backfilled from a bare id.
+
+(defn- pre-6871-flat-row?
+  "True of a row still in the pre-#6871 FLAT shape a `defonce` ledger carried
+  across the ownership-schema hot reload — one carrying the top-level
+  `:installed-by` / `:installed-value` / `:config-fingerprint` keys the nested
+  `:ownership` tuple replaced. The nested shape carries none of them at the top
+  level, and an owned or tombstoned row carries `:ownership`, so a top-level
+  flat key with NO `:ownership` is the unambiguous reload-survivor signal."
+  [row]
+  (and (map? row)
+       (not (contains? row :ownership))
+       (or (contains? row :installed-by)
+           (contains? row :installed-value)
+           (contains? row :config-fingerprint))))
+
+(defn- normalize-flat-row
+  "Rewrite a pre-#6871 FLAT ledger row into the nested `{:ownership {:handle
+  :plan-author :plan-fingerprint} :refs}` tuple, LOSSLESSLY: the exact
+  incarnation `:handle` from `:installed-value`, the `:plan-author` from
+  `:installed-by`, the `:plan-fingerprint` from `:config-fingerprint`, and the
+  `:refs` set unchanged. A row that named an installer but never recorded a
+  value — a genuinely tokenless pre-#6818 row, `:installed-value` absent —
+  becomes `:ownership` WITHOUT a `:handle`, so it stays `:legacy-live` and the
+  migration never backfills a handle from a bare id. A borrowed flat row (no
+  installer) becomes a plain `{:refs …}` with no `:ownership`. Applied only to a
+  [[pre-6871-flat-row?]] (the caller guards), so it need not be idempotent."
+  [row]
+  (let [{:keys [config-fingerprint installed-by installed-value refs]} row
+        ownership (when (some? installed-by)
+                    (cond-> {:plan-author      installed-by
+                             :plan-fingerprint config-fingerprint}
+                      (some? installed-value) (assoc :handle installed-value)))]
+    (cond-> {:refs (or refs #{})}
+      (some? ownership) (assoc :ownership ownership))))
+
+(defn- ledger-row!
+  "The ledger row for `frame-id`, normalizing a pre-#6871 FLAT reload-survivor
+  in place FIRST — persisted, so every read that follows this tick (the verdict,
+  the preflight write-merge's `prior`, release's owner/refs, the destroy hook's
+  handle) sees the one canonical nested shape rather than a stale flat one. A
+  row already nested, a borrowed row, or nil is returned unchanged with no swap.
+  `frame-standing` and the destroy hook are its callers; the other ledger reads
+  run only AFTER `frame-standing` has already normalized the row through here."
+  [frame-id]
+  (let [row (get @frame-ledger frame-id)]
+    (if (pre-6871-flat-row? row)
+      (get (swap! frame-ledger update frame-id normalize-flat-row) frame-id)
+      row)))
+
 (defn ^:no-doc live-root-ids
   "Every root-id currently live in the document — a registry read for
   tests and tools, never application API."
@@ -539,6 +608,29 @@
   successor). Never application API."
   [frame-id]
   (swap! frame-ledger update-in [frame-id :ownership] dissoc :handle)
+  nil)
+
+(defn ^:no-doc flatten-ledger-row-to-pre-6871!
+  "Rewrite `frame-id`'s ledger row DOWN to the pre-#6871 FLAT shape a `defonce`
+  ledger carried across the ownership-schema hot reload — the flat
+  `{:config-fingerprint :installed-by :installed-value :refs}` tuple the nested
+  `:ownership` model replaced — a test-only seam. There is no other way to
+  produce that shape: current code always writes the nested tuple, so a suite
+  proving the upgrade-boundary normalization ([[normalize-flat-row]]) must seed
+  the flat shape from the nested row the mount just wrote. The exact install
+  `:handle` is preserved as `:installed-value` (the owned-with-handle row,
+  migratable losslessly); a row already stripped of its handle by
+  [[downgrade-ledger-row-to-pre-6818!]] flattens with NO `:installed-value` (a
+  genuinely tokenless pre-#6818 row, which must stay unprovable). The `:refs`
+  set is carried across unchanged. Never application API."
+  [frame-id]
+  (swap! frame-ledger update frame-id
+         (fn [row]
+           (let [{:keys [handle plan-author plan-fingerprint]} (:ownership row)]
+             (cond-> {:refs (:refs row)}
+               (some? plan-fingerprint) (assoc :config-fingerprint plan-fingerprint)
+               (some? plan-author)      (assoc :installed-by plan-author)
+               (some? handle)           (assoc :installed-value handle)))))
   nil)
 
 (defn- owner-of-container
@@ -789,9 +881,14 @@
   A config-bearing plan requires `:absent` (create) or `:owned-live` (own the
   live incarnation); every other verdict is loud. The discrimination lives in
   the VERDICT, so the arms do not each re-derive it — and none can skip the
-  join, because this is the only accessor that returns an ownership fact."
+  join, because this is the only accessor that returns an ownership fact.
+
+  It reads through [[ledger-row!]], which normalizes a pre-#6871 FLAT
+  reload-survivor into the nested shape in place first — so the verdict is taken
+  over the canonical tuple and a live OWNED frame whose row survived the
+  ownership-schema reload is no longer mis-verdicted `:unowned-live`."
   [frame-id]
-  (let [ownership (:ownership (get @frame-ledger frame-id))]
+  (let [ownership (:ownership (ledger-row! frame-id))]
     (cond
       (nil? (frame/frame frame-id))               :absent
       (owns-live-incarnation? ownership frame-id) :owned-live
@@ -1036,9 +1133,13 @@
   freshness, never the proof — `frame-standing`'s join stays the sole authority
   even if this hook never fired. (A frame's own orderly release dissocs its row
   BEFORE calling `destroy-frame!`, so this hook finds no row and no-ops — only an
-  EXTERNAL destroy reaches a still-referenced owned row.)"
+  EXTERNAL destroy reaches a still-referenced owned row.)
+
+  Reads through [[ledger-row!]], so a pre-#6871 FLAT reload-survivor is
+  normalized before the handle join — a frame destroyed externally before its
+  first remount still tombstones the migrated row rather than being missed."
   [frame-id dying-token]
-  (let [row   (get @frame-ledger frame-id)
+  (let [row   (ledger-row! frame-id)
         token (frame/frame-value-incarnation-token (:handle (:ownership row)))]
     (when (and (some? token) (identical? token dying-token))
       (swap! frame-ledger update frame-id

--- a/implementation/freehand/test/re_frame/freehand/root_teardown_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/root_teardown_dom_cljs_test.cljs
@@ -620,3 +620,196 @@
                   (is false (str "legacy-release loudness suite rejected: " e))
                   (.remove node)
                   (done)))))))))
+
+;; ===========================================================================
+;; FH-ROOT-005 — the UPGRADE boundary: a pre-#6871 FLAT ledger row across the
+;; ownership-schema hot reload (rf2-4pvsy)
+;;
+;; `frame-ledger` is `defonce`, so the FIRST reload onto the nested-`:ownership`
+;; code meets a row the immediately previous build wrote in the FLAT shape
+;; `{:config-fingerprint :installed-by :installed-value :refs}`. That row is NOT
+;; unprovable legacy data — its `:installed-value` IS the exact incarnation
+;; handle — so it must migrate LOSSLESSLY: `:installed-value` → `:handle`,
+;; `:installed-by` → `:plan-author`, `:config-fingerprint` → `:plan-fingerprint`,
+;; refs unchanged. Un-normalized, `frame-standing` reads `(:ownership row)` as nil
+;; and mis-verdicts a live OWNED frame `:unowned-live`, so the ordinary same-plan
+;; HMR remount fails `:scope-config-less-or-own-the-lifetime` and neither release
+;; nor the destroy hook can match the flat handle. The existing downgrade fixture
+;; removes `:handle` from the NEW nested shape and so cannot reach this UPGRADE
+;; boundary — these three rows do.
+;; ===========================================================================
+
+(deftest fh-root-005-a-pre-6871-flat-row-normalizes-across-the-ownership-schema-reload
+  (testing "Per FH-ROOT-005 / rf2-4pvsy (browser): a pre-#6871 FLAT defonce row
+            carrying its real :installed-value is normalized losslessly to the
+            nested :ownership tuple before any verdict reads it, so the ordinary
+            same-plan HMR remount SUCCEEDS as the idempotent no-op — durable state
+            is preserved (no reseed), the EXACT original incarnation survives
+            (make-frame never re-runs), and the migrated :handle is the identical
+            old incarnation token. The final unmount then destroys exactly that
+            incarnation and empties the ledger."
+    (if-not (browser?)
+      (skip! "the browser job runs the flat-row upgrade-boundary assertions")
+      (async done
+        (reg!)
+        (let [node       (host-node!)
+              fid        :fh.root/upgrade-owned
+              plan       {:frame {:id fid :initial-events [[:root/seed 11]]}}
+              orig-token (atom nil)
+              root-id    (atom nil)]
+          (-> (act #(v/mount [views/counter {}] node plan))
+              (.then
+                (fn [installer]
+                  (reset! orig-token (frame/frame-incarnation-token fid))
+                  (reset! root-id (:root-id (root/root-descriptor installer)))
+                  (is (= 11 (:n (frame/frame-app-db-value fid))) "the installer seeded the frame")
+                  ;; Seed the EXACT pre-#6871 FLAT row a defonce ledger carried
+                  ;; across the ownership-schema reload, with its real handle.
+                  (root/flatten-ledger-row-to-pre-6871! fid)
+                  (is (nil? (get-in (root/frame-ledger-snapshot) [fid :ownership]))
+                      "the seeded row is FLAT — no nested :ownership")
+                  (is (some? (get-in (root/frame-ledger-snapshot) [fid :installed-value]))
+                      "and it carries the exact install handle at :installed-value")
+                  ;; Mutate durable state, so a silent reseed to 11 would show. The
+                  ;; frame db value is read directly — timing-independent of the
+                  ;; reactive repaint, which is a substrate fact, not this fixture's.
+                  (act #(rf/dispatch-sync [:root/seed 99] {:frame fid}))))
+              (.then
+                (fn [_]
+                  (is (= 99 (:n (frame/frame-app-db-value fid))) "durable state is now 99")
+                  ;; The reloaded code re-runs the same-plan mount over the flat row.
+                  (act #(v/mount [views/counter {}] node plan))))
+              (.then
+                (fn [remounted]
+                  (is (root/root? remounted)
+                      "the same-plan HMR remount SUCCEEDED — no scope-or-own fail-loud")
+                  (is (= 99 (:n (frame/frame-app-db-value fid)))
+                      "durable state preserved — the idempotent no-op did NOT reseed to 11")
+                  (is (identical? @orig-token (frame/frame-incarnation-token fid))
+                      "the EXACT original incarnation survived — make-frame never re-ran")
+                  (let [owner (get-in (root/frame-ledger-snapshot) [fid :ownership])]
+                    (is (some? owner)
+                        "the flat row is normalized to the nested :ownership tuple")
+                    (is (identical? @orig-token
+                                    (frame/frame-value-incarnation-token (:handle owner)))
+                        "the migrated :handle is the identical old incarnation token — lossless")
+                    (is (= @root-id (:plan-author owner))
+                        "the author label is preserved (:installed-by → :plan-author)")
+                    (is (some? (:plan-fingerprint owner))
+                        "and the fingerprint (:config-fingerprint → :plan-fingerprint)"))
+                  (is (nil? (get-in (root/frame-ledger-snapshot) [fid :installed-value]))
+                      "the flat keys are gone — normalized in place, not shadowing the tuple")
+                  (act #(v/unmount! remounted))))
+              (.then
+                (fn [_]
+                  (is (nil? (frame/frame fid))
+                      "final unmount destroyed EXACTLY that original incarnation")
+                  (is (empty? (root/frame-ledger-snapshot)) "and emptied the ledger")
+                  (.remove node) (done))
+                (fn [e]
+                  (is false (str "flat-row upgrade-boundary suite rejected: " e))
+                  (.remove node) (done)))))))))
+
+(deftest fh-root-005-the-destroy-hook-tombstones-a-migrated-flat-row
+  (testing "Per FH-ROOT-005 / rf2-4pvsy (browser): a frame whose FLAT row survived
+            the reload is destroyed EXTERNALLY before its first remount. The
+            :freehand/on-frame-destroyed! hook normalizes the flat row first, so
+            it can match the migrated handle against the dying token — it
+            TOMBSTONES the row (drops the handle, stamps :destroyed-at) and, the
+            installer still referencing it, emits exactly one loud
+            :rf.warning/root-ensured-frame-destroyed-under-live-roots naming it.
+            Without the normalization the flat handle is unreachable and the row
+            is missed entirely."
+    (if-not (browser?)
+      (skip! "the browser job runs the migrated-flat destroy-hook assertions")
+      (async done
+        (reg!)
+        (let [node  (host-node!)
+              fid   :fh.root/upgrade-hook
+              plan  {:frame {:id fid :initial-events [[:root/seed 11]]}}
+              warns (atom [])
+              k     (listen! :rf.warning/root-ensured-frame-destroyed-under-live-roots warns)]
+          (-> (act #(v/mount [views/counter {}] node plan))
+              (.then
+                (fn [installer]
+                  ;; the pre-#6871 FLAT reload-survivor, carrying its real handle.
+                  (root/flatten-ledger-row-to-pre-6871! fid)
+                  (is (some? (get-in (root/frame-ledger-snapshot) [fid :installed-value]))
+                      "the seeded row is FLAT and carries the install handle")
+                  ;; external destroy while the installer is still a live ref.
+                  (rf/destroy-frame! fid)
+                  (is (= 1 (count @warns))
+                      "the migrated handle matched the dying token → exactly one loud diagnostic")
+                  (is (contains? (set (get-in (first @warns) [:tags :live-roots]))
+                                 (:root-id (root/root-descriptor installer)))
+                      "naming the live root that still referenced it")
+                  (let [owner (get-in (root/frame-ledger-snapshot) [fid :ownership])]
+                    (is (not (contains? owner :handle))
+                        "the tombstone dropped the migrated handle")
+                    (is (some? (:destroyed-at owner))
+                        "and stamped the destroy time — the flat row became a nested tombstone")
+                    (is (some? (:plan-author owner))
+                        "the author LABEL survives normalization"))
+                  (is (nil? (frame/frame fid)) "the frame is gone")
+                  (trace-tooling/unregister-listener! k)
+                  (act #(v/unmount! installer))))
+              (.then
+                (fn [_]
+                  (is (empty? (root/frame-ledger-snapshot))
+                      "final release of the tombstoned row empties the ledger, no re-alarm")
+                  (.remove node) (done)))
+              (.catch
+                (fn [e]
+                  (trace-tooling/unregister-listener! k)
+                  (is false (str "migrated-flat destroy-hook suite rejected: " e))
+                  (.remove node) (done)))))))))
+
+(deftest fh-root-005-a-tokenless-flat-row-stays-legacy-and-fails-loud
+  (testing "Per FH-ROOT-005 / rf2-4pvsy AC4 (browser): a genuinely tokenless
+            pre-#6818 row flattened to the FLAT shape — an :installed-by with NO
+            :installed-value — normalizes to :ownership WITHOUT a :handle, so it
+            stays :legacy-live: the config-bearing remount FAILS LOUD
+            (:scope-config-less-or-own-the-lifetime) before any mutation, the
+            exact live incarnation is untouched, and the migration NEVER backfills
+            a handle from the bare id."
+    (if-not (browser?)
+      (skip! "the browser job runs the tokenless-flat legacy assertions")
+      (async done
+        (reg!)
+        (let [node  (host-node!)
+              fid   :fh.root/upgrade-tokenless
+              plan  {:frame {:id fid :initial-events [[:root/seed 11]]}}
+              token (atom nil)]
+          (-> (act #(v/mount [views/counter {}] node plan))
+              (.then
+                (fn [installer]
+                  (reset! token (frame/frame-incarnation-token fid))
+                  ;; strip the handle (a genuinely tokenless pre-#6818 row), THEN
+                  ;; flatten it — an :installed-by with no :installed-value.
+                  (root/downgrade-ledger-row-to-pre-6818! fid)
+                  (root/flatten-ledger-row-to-pre-6871! fid)
+                  (is (nil? (get-in (root/frame-ledger-snapshot) [fid :ownership]))
+                      "the seeded row is FLAT")
+                  (is (contains? (get (root/frame-ledger-snapshot) fid) :installed-by)
+                      "and names an installer")
+                  (is (not (contains? (get (root/frame-ledger-snapshot) fid) :installed-value))
+                      "but carries NO install value — a genuinely tokenless legacy row")
+                  (let [data (error-data #(v/mount [views/counter {}] node plan))]
+                    (is (= :rf.error/frame-payload-conflict (:rf.error/id data))
+                        "normalized to :legacy-live (ownership, no handle), the remount fails loud")
+                    (is (= :scope-config-less-or-own-the-lifetime (:recovery data))
+                        "under scope-or-own — never a bare-id handle backfill")
+                    (is (identical? @token (frame/frame-incarnation-token fid))
+                        "the exact live incarnation is untouched — the guard fired before any mutation")
+                    (is (nil? (get-in (root/frame-ledger-snapshot) [fid :ownership :handle]))
+                        "the normalized legacy row carries no handle — unprovable, as the law requires"))
+                  (act #(v/unmount! installer))))
+              (.then
+                (fn [_]
+                  (is (some? (frame/frame fid))
+                      "the un-owned legacy row's teardown is a safe no-op — no address-directed destroy")
+                  (rf/destroy-frame! fid)
+                  (.remove node) (done))
+                (fn [e]
+                  (is false (str "tokenless-flat legacy suite rejected: " e))
+                  (.remove node) (done)))))))))


### PR DESCRIPTION
## What

`re-frame.freehand.root/frame-ledger` is deliberately `defonce`, so a namespace reload hands the reloaded code the same ledger a live root was registered in. #6871 (rf2-9lmky) changed the row from the flat `{:config-fingerprint :installed-by :installed-value :refs}` to the nested `{:ownership {:handle :plan-author :plan-fingerprint} :refs}` tuple — but did not normalize rows already alive across the reload.

On the FIRST reload under #6871 a pre-#6871 flat row survives the `defonce`. `frame-standing` reads `(:ownership row)` as nil and mis-verdicts a live OWNED frame `:unowned-live`, so the ordinary same-plan `v/mount` HMR path fails `:scope-config-less-or-own-the-lifetime`; `release-frame!` and the destroy hook likewise cannot match the flat handle, and the root-owned frame leaks LIVE. That flat row is **not** unprovable legacy data — its `:installed-value` **is** the exact incarnation handle, migratable losslessly.

## Fix (bounded)

The one known flat shape is normalized IN PLACE at the door (`ledger-row!`), before any verdict / release / hook read consumes it, preserving exact handle identity (`:installed-value` → `:handle`), author (`:installed-by` → `:plan-author`), fingerprint (`:config-fingerprint` → `:plan-fingerprint`) and refs. `frame-standing` and the destroy hook read through `ledger-row!`; the other ledger reads run only after `frame-standing` has already normalized the row in place (persisted).

A genuinely tokenless pre-#6818 row (an `:installed-by` with no `:installed-value`) normalizes to `:ownership` **without** a `:handle`, so it stays `:legacy-live` / fail-loud — the handle is never backfilled from a bare id. No ledger-version framework, no public API, no lease machinery: the change stays inside the one ledger and its `frame-standing` accessor.

Surface: `implementation/freehand/src/re_frame/freehand/root.cljs` (3 internal fns + 1 `^:no-doc` test seam + 2 one-line consumer routes) and its teardown DOM tests.

## Tests

Adds the upgrade-boundary DOM fixtures the existing downgrade fixture (which removes `:handle` from the NEW nested shape) cannot reach:

- **flat owned-with-handle row → same-plan HMR remount** succeeds as the idempotent no-op; durable state preserved (no reseed), the EXACT original incarnation survives (`make-frame` never re-runs), the migrated `:handle` is the identical old token, author/fingerprint preserved; final unmount destroys exactly that incarnation and empties the ledger.
- **destroy hook tombstones a migrated flat row** — an external destroy before the first remount matches the migrated handle, drops it, stamps `:destroyed-at`, and emits one loud diagnostic naming the live root.
- **tokenless flat row stays legacy / fail-loud** (AC4) — no bare-id handle backfill; the exact live incarnation is untouched.

Non-vacuity: flipping the normalization off reds the two discriminating fixtures **by name** (`fh-root-005-a-pre-6871-flat-row-normalizes-...` and `fh-root-005-the-destroy-hook-tombstones-a-migrated-flat-row`); the tokenless AC4 fixture correctly stays green since both paths fail loud.

## Quality gates

All FOREGROUND, run from the `worker/root-hmr-migrate-4pvsy` worktree; browser banner named the worktree.

| Gate | Command | Result |
| --- | --- | --- |
| Freehand JVM | `clojure -M:test` (`implementation/freehand`) | 916 tests / 6533 assertions — 0 failures, 0 errors |
| Node Freehand | `npm run test:freehand` (`implementation`) | 996 tests / 5626 assertions — 0 failures, 0 errors |
| Browser (DOM) | `npm run test:browser` (`implementation`) | 757 tests / 4724 assertions — 0 failures, 0 errors |
| Non-vacuity probe | normalization flipped off → re-run browser | 5 failures across the two upgrade fixtures, by name → restored → green |

Closes rf2-4pvsy.
