### PR TITLE
fix(freehand): isolate a throwing evidence-sink from ViewCell commit completion (rf2-vxgfnd.73)

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/cell.cljc
+++ b/implementation/freehand/src/re_frame/freehand/cell.cljc
@@ -769,6 +769,25 @@
 ;; retained here, exactly as `re-frame.freehand.evidence` retains nothing (its
 ;; `retention` names Spec 009's per-frame ring and no second store). The
 ;; accumulator that folds these records is downstream (rf2-drpa3.167).
+;;
+;; TWO PLANES, split along the publication line. The installed sink is an
+;; observability CONSUMER of the commit, never an authority over it, so its
+;; behaviour must not decide whether the commit stands:
+;;
+;;   - The FRAMEWORK's record is built and VALIDATED through `evidence/record`
+;;     BEFORE the bundle is published. A malformed record — a bad occurrence, a
+;;     projection that claims more than it knows — fails loud from the evidence
+;;     door before anything is live, so the documented all-or-nothing boundary
+;;     holds: a commit the schema would refuse publishes NOTHING.
+;;   - The CONSUMER's sink is called only AFTER the publish, inside a guard. A
+;;     tool callback that throws is contained and reported — it can never turn a
+;;     live, connected, published commit into an exception at the caller, and a
+;;     normal sink still receives the pre-built record exactly once per commit.
+;;
+;; The report never routes back through the sink (no recursion): a contained
+;; throw is surfaced on the host console and in the single bounded
+;; `last-sink-escape` slot, both dev-gated so the whole plane DCEs in
+;; production alongside the record construction it guards.
 
 (defonce ^:private evidence-sink
   ;; The installed occurrence-record sink, or nil for the no-op default.
@@ -791,6 +810,30 @@
     (reset! evidence-sink f)
     prev))
 
+(defonce ^:private last-sink-escape
+  ;; The single bounded diagnostic slot for a CONTAINED evidence-sink throw
+  ;; (`{:view-id … :error e}` | nil), newest escape wins. The evidence sink is a
+  ;; DEBUG-only tool CONSUMER of the commit, never an authority over it: a
+  ;; throwing sink must not turn a published, connected commit into an exception
+  ;; at the caller. So `commit!` validates the record BEFORE it publishes, and
+  ;; DELIVERS it to the sink only AFTER, inside a guard that records any consumer
+  ;; throw here. Observable via [[last-evidence-sink-escape]] so a contained
+  ;; throw is never silent. An atom because it is written at RUNTIME (a tool
+  ;; callback throwing), never compile time — the same shape as `evidence-sink`,
+  ;; and like it a `defonce` so reloading this namespace keeps a recorded escape.
+  (atom nil))
+
+(defn last-evidence-sink-escape
+  "The most recent CONTAINED evidence-sink throw as `{:view-id … :error e}`, or
+  nil when no installed sink has thrown since load (and always nil in a
+  production build, where the whole dev evidence plane is elided).
+
+  A throwing DEBUG sink can never turn a published commit into an exception at
+  the caller — it is contained at the seam and surfaced HERE, plus one host
+  console report, so the escape is never silent. A tool/test read."
+  []
+  @last-sink-escape)
+
 (defn- occurrence-of
   "The runtime OCCURRENCE key for `cell` — the mounted boundary's own
   identity, never a query key or a lexical site id (D020). A root
@@ -802,21 +845,83 @@
    :key    #?(:clj  (System/identityHashCode cell)
               :cljs (goog/getUid cell))})
 
-(defn emit-commit-evidence!
-  "DEV-GATED render-path evidence seam: when a sink is installed, build the
-  commit occurrence-record for `cell` at `lowering` / `generation`,
-  validate it through `re-frame.freehand.evidence/record`, and deliver it.
+(defn- commit-evidence-record
+  "DEV-GATED, BEFORE publication: when a sink is installed, build the commit
+  occurrence-record for `cell` at `lowering` / `generation` and VALIDATE it
+  through `re-frame.freehand.evidence/record`. Answers `[sink record]` — the
+  captured sink and its validated record — for delivery once the bundle is
+  live, or nil when the seam is inert (no sink, or debug disabled).
 
-  Compiles out of production entirely — the `interop/debug-enabled?` gate
-  is a `goog.DEBUG` constant under `:advanced`, so the whole body (and the
-  evidence schema it reaches) DCEs when `goog.DEBUG=false`. A malformed
-  record throws from `evidence/record` at the seam rather than reaching a
-  reader; that is the point of validating here."
+  FAIL-LOUD on a malformed FRAMEWORK record: `evidence/commit-record` throws
+  HERE, before `commit!` publishes anything, so an emission the schema refuses
+  aborts the whole commit rather than reaching a reader or leaving a
+  half-published bundle. That is the framework plane and it stays loud — only
+  the CONSUMER's own failure (the sink throwing) is contained, downstream and
+  only after a selected publication.
+
+  The sink is captured together with its record so the tool that was installed
+  when the commit began is the one delivered to, even if a listener the publish
+  fires swaps the sink mid-flush.
+
+  The `interop/debug-enabled?` gate stands alone as the body's outermost form,
+  so under `:advanced` with `goog.DEBUG=false` Closure folds it to `false`, the
+  branch DCEs, and neither the record construction nor the evidence schema it
+  reaches survives into a production bundle."
   [^ViewCell cell lowering generation]
   (when interop/debug-enabled?
     (when-let [sink @evidence-sink]
-      (sink (evidence/commit-record (view-id cell) lowering
-                                    (occurrence-of cell) generation))))
+      [sink (evidence/commit-record (view-id cell) lowering
+                                    (occurrence-of cell) generation)])))
+
+(defn- report-sink-escape!
+  "Contain a THROWING evidence sink: record the escape in the single bounded
+  [[last-sink-escape]] slot (newest wins) and, on CLJS, emit ONE host
+  `console.error` naming the offending view. The bundle is already published
+  and live by the time this runs, so the report is a pure after-the-fact
+  account that can neither un-publish the commit nor reach the caller.
+
+  Reporting NEVER routes back through `evidence-sink` — it is the console and
+  escape-slot path, not another sink call — so a throwing sink cannot recurse
+  through the report. Called only from the debug-gated deliver branch, so the
+  whole helper DCEs under `goog.DEBUG=false`."
+  [view-id e]
+  (reset! last-sink-escape {:view-id view-id :error e})
+  #?(:cljs (when (exists? js/console)
+             (.error js/console
+                     (str "re-frame.freehand: the evidence sink (a DEBUG tool "
+                          "consumer — e.g. Xray) threw while consuming the "
+                          (pr-str view-id) " commit record. The throw was CONTAINED, "
+                          "so the commit is published and live and the caller was not "
+                          "affected — a debug observer cannot corrupt a commit. Fix the "
+                          "sink installed with (set-evidence-sink! …). Cause: "
+                          (error/ex-message-safe e))))
+     :clj nil)
+  nil)
+
+(defn emit-commit-evidence!
+  "DEV-GATED, AFTER publication: deliver the pre-built, pre-validated `captured`
+  record to the installed sink, CONTAINING any failure the sink CONSUMER
+  raises. `captured` is the `[sink record]` [[commit-evidence-record]] built
+  and validated BEFORE the publish, or nil when the seam is inert.
+
+  The sink is an observability consumer of the commit, not an authority over
+  it: a tool callback that throws must not turn a live, published, connected
+  commit into an exception at the caller. So a throw is caught and reported
+  through [[report-sink-escape!]] (the bounded escape slot and one host console
+  line), never rethrown and never routed back through the sink.
+
+  A normal (non-throwing) sink receives the captured record EXACTLY ONCE per
+  selected commit — the one `sink` call below. The `interop/debug-enabled?`
+  gate stands alone so the whole delivery-and-containment machinery DCEs under
+  `:advanced` with `goog.DEBUG=false`, alongside the record it consumes."
+  [^ViewCell cell captured]
+  (when interop/debug-enabled?
+    (when captured
+      (let [[sink record] captured]
+        (try
+          (sink record)
+          (catch #?(:clj Throwable :cljs :default) e
+            (report-sink-escape! (view-id cell) e))))))
   nil)
 
 (defn commit!
@@ -884,7 +989,25 @@
                                                    :frame-id (:frame-id (:target r))
                                                    :value    (:value (get readings k))
                                                    :owned?   (obs/owned? (:handle r))}))
-                                              order)}]
+                                              order)}
+                ;; Build and VALIDATE the dev evidence record BEFORE the publish
+                ;; below — the two-plane split: a malformed FRAMEWORK
+                ;; record fails loud here, so a commit the schema would refuse
+                ;; publishes nothing and the all-or-nothing boundary holds. The
+                ;; CONSUMER sink is not called yet — only after the bundle is
+                ;; live, where its failure is contained rather than fatal. Not
+                ;; callback-capable (it derefs the sink slot and validates a
+                ;; value — no app code), so it sits between the currency re-check
+                ;; and the publish without reopening that window. Like the
+                ;; acquisition and commit-read failures above, a throw here
+                ;; releases this candidate's freshly acquired handles in reverse
+                ;; order and RETHROWS — the fail-loud path leaks nothing, and the
+                ;; catch never swallows a framework error.
+                captured (try
+                           (commit-evidence-record owner-cell lowering (.-generation cand))
+                           (catch #?(:clj Throwable :cljs :default) e
+                             (release-all! (rseq (fresh-handles order staged)))
+                             (throw e)))]
             ;; ONE publication. Dependencies, frame and evidence become
             ;; live in a single write, and the event site table becomes
             ;; live against this exact frame with no host yield between
@@ -908,10 +1031,13 @@
             (when (some (fn [[k {:keys [evidence]}]] (moved? (get readings k) evidence)) staged)
               (advance-revision! owner-cell))
             ;; The dev-gated occurrence-record seam (rf2-3naow): a SELECTED
-            ;; commit is the one place the whole bundle is live, so it is
-            ;; where the record is emitted. Compiles out with the gate in
-            ;; production; an abandoned candidate reaches neither branch.
-            (emit-commit-evidence! owner-cell lowering (.-generation cand))
+            ;; commit is the one place the whole bundle is live, so it is where
+            ;; the record — built and validated above, before the publish — is
+            ;; DELIVERED to the consumer sink. A throwing sink is contained (the
+            ;; commit already stands), so delivery cannot turn `:published` into
+            ;; an exception. Compiles out with the gate in production; an
+            ;; abandoned candidate reaches neither branch.
+            (emit-commit-evidence! owner-cell captured)
             :published)))))))
 
 (defn disconnect!

--- a/implementation/freehand/test/re_frame/freehand/evidence_seam_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/evidence_seam_cljs_test.cljc
@@ -5,11 +5,23 @@
   The seam sits at the SELECTED commit — the one place a render's whole
   bundle is live — and, when a sink is installed under the dev gate, emits
   ONE evidence record per commit, validated through
-  `re-frame.freehand.evidence/record`. This suite pins the three things the
-  slice owes: that a real commit delivers a well-formed record naming the
-  occurrence's lowering and generation; that a malformed record is REFUSED
-  at the seam rather than reaching the sink; and that the seam is inert —
-  no throw, no delivery — when no sink is installed.
+  `re-frame.freehand.evidence/record`. This suite pins what the slice owes:
+  that a real commit delivers a well-formed record naming the occurrence's
+  lowering and generation; and that the seam is inert — no throw, no
+  delivery — when no sink is installed.
+
+  It also pins the TWO-PLANE invariant the seam holds along the publication
+  line. The installed sink is an observability CONSUMER of the commit, never
+  an authority over it, so the record is built and VALIDATED before the bundle
+  publishes and the sink is called only after:
+
+    - a CONSUMER sink that THROWS is contained — the commit still reports
+      `:published`, the cell owns its bundle, the sink ran exactly once (the
+      report never recurses through it), and the escape is surfaced rather than
+      swallowed; while
+    - a malformed FRAMEWORK record stays FAIL-LOUD and all-or-nothing — it
+      throws BEFORE publication, so the cell publishes nothing, and the
+      containment guard is proven NOT to have been over-broadened to swallow it.
 
   The PRODUCTION-ISOLATION half of the acceptance (the record and the
   evidence schema it reaches DCE out of the `:advanced` / `goog.DEBUG=false`
@@ -113,18 +125,99 @@
           "the lowering the commit was given rides the record"))))
 
 ;; ---------------------------------------------------------------------------
-;; A malformed record is refused AT the seam
+;; A throwing sink is CONTAINED — it cannot fail a published commit
 ;; ---------------------------------------------------------------------------
 
-(deftest a-malformed-record-is-refused-at-the-seam
-  (testing "The seam validates through `evidence/record`, so an occurrence
-            whose identity cannot form a legal record throws at the commit
-            rather than delivering junk to the sink. A cell minted under a
-            NON-qualified view-id is exactly that: `:view-id` must be a
-            namespace-qualified keyword, and a bare one fails the door. Driven
-            directly (not through `commit-under!`, whose own `:published`
-            assertion would intercept the throw) so the refusal reaches
-            `thrown?`."
+(deftest a-throwing-sink-does-not-fail-the-commit
+  (testing "The evidence sink is an observability CONSUMER of the commit, not an
+            authority over it. A sink that throws while consuming the record must
+            NOT make `commit!` throw: the record is built and validated before
+            the bundle publishes, the bundle publishes, and only THEN is the sink
+            called — behind a guard. The load-bearing proof is the ATTRIBUTED
+            terminal state, never merely 'no exception': a well-formed
+            `:published`, a `:connected` cell that owns exactly the dependency it
+            read, and its committed frame. On the unfixed seam the sink was
+            called AFTER the publish with no guard, so this same throw propagated
+            out of `commit!` — the regression this test pins."
+    (register!)
+    (seed! {:count 7})
+    (let [c    (cell/cell ::seam-throwing)
+          cand (cell/candidate c fid)
+          prev (cell/set-evidence-sink!
+                 (fn [_] (throw (ex-info "audit-sink-failure" {:probe true}))))]
+      (try
+        (cell/with-capture cand (fn [] (t/render [counter {}])))
+        (is (= :published (cell/commit! cand :interpreted))
+            "a throwing sink is contained; the commit still reports :published")
+        (is (= :connected (cell/lifecycle c))
+            "the cell is connected — it owns the published bundle")
+        (is (= [[::count]] (cell/dependency-queries c))
+            "and the published dependency is exactly the one the render read")
+        (is (some? (cell/committed-frame c))
+            "the frame was published too — the whole bundle is live")
+        (finally (cell/set-evidence-sink! prev))))))
+
+(deftest a-throwing-sink-is-invoked-once-and-cannot-recurse
+  (testing "The contained throw is reported through the bounded escape slot and
+            the host console, NEVER back through the sink. So a throwing sink is
+            invoked EXACTLY ONCE per commit — the report does not re-enter it —
+            and the escape is surfaced for a tool to read (`view-id` + cause)
+            rather than swallowed silently."
+    (register!)
+    (seed! {:count 1})
+    (let [calls (atom 0)
+          c     (cell/cell ::seam-once)
+          cand  (cell/candidate c fid)
+          prev  (cell/set-evidence-sink!
+                  (fn [_]
+                    (swap! calls inc)
+                    (throw (ex-info "audit-sink-failure" {}))))]
+      (try
+        (cell/with-capture cand (fn [] (t/render [counter {}])))
+        (is (= :published (cell/commit! cand :interpreted))
+            "the commit stands despite the throw")
+        (is (= 1 @calls)
+            "the sink ran exactly once — the report never routes back through it")
+        (let [escape (cell/last-evidence-sink-escape)]
+          (is (= ::seam-once (:view-id escape))
+              "the contained escape names the offending view")
+          (is (some? (:error escape))
+              "and carries the cause, so the escape is never silent"))
+        (finally (cell/set-evidence-sink! prev))))))
+
+(deftest a-normal-sink-receives-the-record-once-per-commit
+  (testing "Containment does not cost a normal sink its delivery: a
+            non-throwing sink still receives the captured pre-clear record
+            EXACTLY ONCE for each selected commit. Two commits on one cell hand
+            it two records, in order — once per flushed commit, never zero and
+            never twice."
+    (register!)
+    (seed! {:count 0})
+    (let [seen (with-capturing-sink
+                 (fn []
+                   (commit-under! ::seam-twice :interpreted)
+                   (commit-under! ::seam-twice :interpreted)))]
+      (is (= 2 (count seen)) "one record per commit — exactly once each")
+      (is (every? #(= ::seam-twice (:view-id %)) seen)
+          "each names the committing view"))))
+
+;; ---------------------------------------------------------------------------
+;; A malformed FRAMEWORK record stays FAIL-LOUD, before publication
+;; ---------------------------------------------------------------------------
+
+(deftest a-malformed-framework-record-fails-loud-before-publication
+  (testing "The FRAMEWORK plane stays fail-loud and all-or-nothing: a record the
+            evidence schema refuses — a cell minted under a NON-qualified
+            view-id, which `:view-id` rejects — throws from the seam BEFORE the
+            bundle is published. The containment guard is for the CONSUMER's
+            throw ONLY; it must not have been over-broadened to swallow a
+            framework error. Proof is the terminal state: the commit THREW, and
+            because validation runs before publication the cell owns nothing —
+            not `:connected`, no dependency, no committed frame. On the unfixed
+            seam the record was built AFTER the publish, so this same cell was
+            already `:connected` when it threw — an all-or-nothing violation this
+            test now pins. Driven directly (not through `commit-under!`, whose
+            own `:published` assertion would intercept the throw)."
     (register!)
     (seed! {:count 0})
     (let [c    (cell/cell :bare-unqualified)
@@ -134,7 +227,13 @@
       (try
         (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs :default)
               (cell/commit! cand :interpreted))
-            "the refused record throws at the seam, not past it")
+            "the malformed framework record fails loud at the seam")
+        (is (not= :connected (cell/lifecycle c))
+            "the cell never connected — publication did not happen")
+        (is (empty? (cell/dependency-queries c))
+            "and it published no dependency: a refused record publishes nothing")
+        (is (nil? (cell/committed-frame c))
+            "nor a frame — the all-or-nothing boundary held before publication")
         (finally (cell/set-evidence-sink! prev))))))
 
 ;; ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

`re-frame.freehand.cell/commit!` published the cell bundle, committed events,
released superseded handles, and only **then** synchronously called the dev
evidence sink. A throwing sink therefore made `commit!` throw **after** the
commit was irrevocably live — the caller was told the commit failed even though
the cell was `:connected` and owned the published bundle. The evidence sink is
an observability **consumer** of the commit, never an authority over it. This is
the same two-plane invariant that already shipped for `re-frame.ui`, now held on
the live Freehand commit seam.

## How

The seam is split along the publication line:

- The framework's occurrence-record is built and **validated** through
  `evidence/record` **before** the bundle publishes. A malformed record fails
  loud there — before anything is live — so the documented all-or-nothing
  boundary holds. Like the acquisition and commit-read failures in the same
  commit, that fail-loud path releases this candidate's freshly acquired handles
  before rethrowing; the catch never swallows a framework error.
- The consumer sink is called only **after** the publish, inside a guard. A
  throwing tool callback is contained and reported through a single bounded
  escape slot (`last-evidence-sink-escape`) plus one host `console.error` line —
  never rethrown, and never routed back through the sink, so it cannot recurse.
  A normal sink still receives the pre-built record exactly once per commit.

The whole plane stays behind `interop/debug-enabled?`, standing alone as each
helper's outermost form, so the record construction, the sink call, and the
containment machinery DCE together under `:advanced` / `goog.DEBUG=false`.

## Proof

The regression is load-bearing: run against the unfixed seam, the two new
assertions fail with the attributed defect — `commit!` throws
`audit-sink-failure` out of the sink call, and the malformed-record cell is
already `:connected` when it throws (all-or-nothing violated). Both go green
after the fix, on both hosts. New/updated coverage in
`evidence-seam-cljs-test` (`.cljc`, JVM + CLJS):

- a throwing sink leaves `commit!` reporting `:published` with a `:connected`
  cell owning exactly the dependency it read (attributed terminal state, not
  merely "no exception");
- the throwing sink is invoked exactly once and the contained escape is
  observable (`view-id` + cause) — the report never recurses through the sink;
- a normal sink is delivered the record exactly once per selected commit;
- a malformed **framework** record throws **before** publication, with the cell
  owning nothing — proving the containment catch was not over-broadened.

## Changed files

- `implementation/freehand/src/re_frame/freehand/cell.cljc` — split the seam
  (`commit-evidence-record` build-before-publish, `emit-commit-evidence!`
  contained delivery, `report-sink-escape!` + `last-evidence-sink-escape`);
  `commit!` builds the record before the publish and delivers after.
- `implementation/freehand/test/re_frame/freehand/evidence_seam_cljs_test.cljc`
  — containment + all-or-nothing regression tests.

## Quality gates

| Gate | Command | Result | Exit |
| --- | --- | --- | --- |
| Freehand JVM | `cd implementation/freehand && clojure -M:test` | 919 tests, 6548 assertions, 0 failures, 0 errors | 0 |
| Freehand node/CLJS | `npm run test:freehand` (from `implementation/`) | 996 tests, 5638 assertions, 0 failures, 0 errors | 0 |

The CLJS run's shadow-cljs `config:` banner named this worktree, and the
contained-sink `console.error` fired for both throwing-sink tests while the
suite stayed green — the report path is exercised on CLJS and containment holds.
