### PR TITLE
fix(freehand): emit recursive defviews against their current-namespace Var (rf2-rr26cq)

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/compiler/emit_jvm.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/emit_jvm.cljc
@@ -187,6 +187,29 @@
 ;; Components
 ;; ---------------------------------------------------------------------------
 
+(defn self-fqn
+  "The canonical current-namespace Var of the view being compiled — `<ns>/<name>`
+  — or nil outside a defview (a root form carries no `:self`). Identical to the
+  `:fqn` `env/classify-head` stamps on an exact self component node."
+  [e]
+  (when (:self e) (symbol (str (:ns e)) (str (:self e)))))
+
+(defn self-view-head
+  "The symbol a `:view` component call is emitted AGAINST.
+
+  For the EXACT self-recursive head — the view currently being compiled — that
+  is the canonical current-namespace Var (the node's `:fqn`), never the raw
+  authored `:sym`. In a namespace that REFERS a same-named public authoring verb
+  (e.g. `(defview sub …)` where the ns refers `re-frame.freehand/sub`), the bare
+  authored spelling resolves through the refer to the AUTHORING Var, while the
+  qualified `:fqn` resolves to the view itself; the authored spelling stays
+  diagnostic only (rf2 self-Var invariant). Every other head — an unrelated
+  internal view, a foreign component, a local shadow — keeps its authored
+  spelling."
+  [e node]
+  (let [sf (self-fqn e)]
+    (if (and sf (= (:fqn node) sf)) (:fqn node) (:sym node))))
+
 (defn- prop-value-form [e {:keys [value marker render-fn]}]
   (case marker
     :foreign    `re-frame.freehand.tree/opaque-foreign
@@ -227,7 +250,7 @@
                         entries)
         props-map (cond-> props-map
                     (:present? key-info) (assoc :key (:expr key-info)))]
-    `(node/mount ~(:sym node) [~props-map ~@child-forms])))
+    `(node/mount ~(self-view-head e node) [~props-map ~@child-forms])))
 
 (defn- emit-behavior
   "A `v/behavior` attachment on the structural host: an INERT MARKER. It

--- a/implementation/freehand/src/re_frame/freehand/compiler/emit_react.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/emit_react.cljc
@@ -69,9 +69,23 @@
             [re-frame.freehand.controlled :as controlled]
             [re-frame.freehand.conversion :as conv]
             [re-frame.freehand.events :as events]
-            [re-frame.freehand.top-layer :as top-layer]))
+            [re-frame.freehand.top-layer :as top-layer]
+            ;; JVM-only: a self-recursive view completes the same-named `:refer`
+            ;; shadowing in the LIVE CLJS analyzer state so its `(def …)` and
+            ;; recursive head resolve to the current-namespace Var rather than
+            ;; the referred authoring Var (see `emit-react-body`). Never loaded
+            ;; on the CLJS host — the emitter only mutates analyzer state on the
+            ;; JVM macro-expansion path.
+            #?(:clj [cljs.env])))
 
 (declare emit-node)
+
+(defn- self-fqn
+  "The canonical current-namespace Var of the view being compiled — `<ns>/<name>`
+  — or nil outside a defview (a root form carries no `:self`). Identical to the
+  `:fqn` `env/classify-head` stamps on an exact self component node."
+  [e]
+  (when (:self e) (symbol (str (:ns e)) (str (:self e)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Hoisting — the constant subtrees
@@ -567,9 +581,20 @@
   (let [entries   (get-in node [:props :entries])
         key-info  (get-in node [:props :key])
         props-map (cond-> (into {} (map (fn [{:keys [k] :as en}] [k (prop-value-form e st en)])) entries)
-                    (:present? key-info) (assoc :key (:expr key-info)))]
+                    (:present? key-info) (assoc :key (:expr key-info)))
+        ;; The EXACT self-recursive head targets the current-namespace Var (its
+        ;; canonical `:fqn`), never the raw authored `:sym`: a bare self head in
+        ;; a namespace that REFERS a same-named public authoring verb (e.g.
+        ;; `(defview sub …)` refers `re-frame.freehand/sub`) resolves through the
+        ;; refer to the authoring Var, while the qualified `:fqn` resolves to the
+        ;; view. `emit-react-body` reads the recorded flag to complete the
+        ;; shadowing in the live analyzer state so the `(def …)` matches. Every
+        ;; other head keeps its authored spelling.
+        sf        (self-fqn e)
+        self?     (and sf (= (:fqn node) sf))]
+    (when self? (swap! st assoc :self-ref? true))
     `(re-frame.freehand.compiled-react/mount
-      ~(:sym node) ~props-map
+      ~(if self? (:fqn node) (:sym node)) ~props-map
       ~@(mapv #(emit-node e st %) (:children node)))))
 
 (defn- emit-for
@@ -725,4 +750,24 @@
   (let [st   (new-state)
         body `(fn ~params (re-frame.freehand.compiled-react/root ~(emit-node e st ast)))
         bs   (:binds @st)]
+    ;; A self-recursive view whose name collides with a same-named `:refer`
+    ;; (e.g. `(defview sub …)` where the ns refers `re-frame.freehand/sub`) must
+    ;; resolve its OWN `(def …)` and recursive head to the current-namespace Var,
+    ;; not the refer. The CLJS analyzer already signals this shadowing on the def
+    ;; (its `:redef` warning, and it adds the name to `:excludes`) — but
+    ;; `cljs.analyzer/resolve-var` ranks `:uses` (refers) ABOVE `:defs` and
+    ;; ignores `:excludes`, so a bare def name still resolves through the refer
+    ;; and BOTH clobbers the public authoring Var (`re_frame.freehand.sub = …`)
+    ;; and leaves the qualified self head (`<ns>.sub`) undefined — a split
+    ;; identity. Completing the shadowing the analyzer already intends — dropping
+    ;; the view's own name from the live ns `:uses` — makes the `(def …)`, its
+    ;; structural and React realisations, and every recursive head share the one
+    ;; canonical current-namespace Var. JVM-only: this is the macro-expansion
+    ;; path with the live compiler env; non-recursive views and the CLJS-host
+    ;; self-compile path are untouched, and no runtime code is added.
+    #?(:clj
+       (when (and (:self-ref? @st) (:self e) (some? cljs.env/*compiler*))
+         (swap! cljs.env/*compiler* update-in
+                [:cljs.analyzer/namespaces (:ns e) :uses]
+                dissoc (:self e))))
     (if (seq bs) `(let [~@bs] ~body) body)))

--- a/implementation/freehand/test/re_frame/freehand/compiler_macro_resolution_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/compiler_macro_resolution_jvm_test.clj
@@ -2,10 +2,15 @@
   "Real CLJS-analyzer resolution proofs for the expression macro barrier."
   (:require [cljs.analyzer :as cljs-analyzer]
             [cljs.analyzer.api :as cljs-api]
+            [cljs.compiler :as cljs-comp]
             [cljs.core]
             [cljs.env :as cljs-env]
+            [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
+            [clojure.walk :as walk]
             [re-frame.freehand.compiler.analyze :as analyze]
+            [re-frame.freehand.compiler.emit-jvm :as emit-jvm]
+            [re-frame.freehand.compiler.emit-react :as emit-react]
             [re-frame.freehand.compiler.env :as env]
             [re-frame.freehand.compiler.root :as root]))
 
@@ -245,4 +250,128 @@
       (testing "a legal element root still analyzes through the root compiler"
         (is (= :element
                (:op (:ast (root/analyze-root (referred-env aenv nil) 'v/mount '[:div "x"])))))))))
+
+;; ---------------------------------------------------------------------------
+;; self-Var emitters: recursive defviews mount + define their current-ns Var
+;; ---------------------------------------------------------------------------
+;;
+;; The .274 analyzer proofs above stop at classification (the self head is an
+;; internal :view). This block drives the REAL emitters and compiles the emitted
+;; self boundary to REAL JavaScript through cljs.compiler. The defect: both live
+;; emitters emitted the raw authored `:sym` for a self boundary, so in a ns that
+;; REFERS re-frame.freehand/{sub,frame} a compiled `(defview sub [] [sub {}])`
+;; mounted the AUTHORING verb (`re_frame.freehand.sub`) instead of recursing on
+;; its own current-namespace Var (`cljs.user.sub`). The emitters now carry the
+;; canonical `:fqn` for a self head, and the CLJS realisation completes the
+;; same-named-refer shadowing (dropping the name from the live ns `:uses`) so the
+;; `(def …)` DEFINES — and the head REFERENCES — the one current-namespace Var.
+;; These rows diff the emitted JS bytes; the counterfactual pins the delta so the
+;; discriminator is a compiled fact, not a reasoned AST shape.
+
+(defn- self-react-body
+  "The React realisation of `(defview <verb> [] [<verb> {}])` in the referred
+  cljs.user namespace — the self view named `verb` recurses on a bare `[verb {}]`
+  self head. Emitting it also completes the same-named-refer shadow in the live
+  analyzer state (the JVM-only `:uses` drop)."
+  [aenv verb]
+  (let [e   (referred-env aenv verb)
+        ast (analyze/analyze e [verb {}])]
+    (emit-react/emit-react-body e [] ast)))
+
+(defn- self-jvm-body
+  "The JVM structural realisation of the same self view."
+  [aenv verb]
+  (let [e   (referred-env aenv verb)
+        ast (analyze/analyze e [verb {}])]
+    (emit-jvm/emit-structural-body e [] ast)))
+
+(defn- mount-heads
+  "Every head symbol handed to a `…/mount` call in `form` — the structural
+  `node/mount` and the compiled `compiled-react/mount` both name the self
+  component call's target as their first argument."
+  [form]
+  (let [hits (atom [])]
+    (walk/postwalk
+     (fn [x]
+       (when (and (seq? x) (symbol? (first x))
+                  (str/ends-with? (name (first x)) "mount"))
+         (swap! hits conj (second x)))
+       x)
+     form)
+    @hits))
+
+(defn- compile-js
+  "Real cljs.compiler JavaScript for `form` analyzed in cljs.user (warnings
+  silenced — the point is the munged target, not the diagnostic)."
+  [aenv form]
+  (binding [cljs-analyzer/*cljs-warnings*
+            (zipmap (keys cljs-analyzer/*cljs-warnings*) (repeat false))]
+    (cljs-comp/emit-str
+     (cljs-analyzer/analyze (assoc aenv :context :expr) form))))
+
+(deftest real-cljs-self-head-emits-and-defines-current-namespace-var
+  ;; Accept rows. Reverting either emitter to the raw authored `:sym` re-captures
+  ;; re_frame.freehand.<verb> in the emitted JavaScript; dropping the `:uses`
+  ;; shadow completion leaves the `(def …)` clobbering the authoring Var and the
+  ;; qualified head undefined (the split identity). Every row below fails then.
+  (doseq [verb '[sub frame]]
+    (let [self-fqn  (symbol "cljs.user" (name verb))
+          author-re (re-pattern (str "re_frame\\.freehand\\." (name verb) "\\b"))
+          def-re    (re-pattern (str "cljs\\.user\\." (name verb) "\\s*="))
+          head-re   (re-pattern (str "mount\\(cljs\\.user\\." (name verb) ","))]
+      (testing (str "CLJS: (def " verb " …) DEFINES and recurses on the current-ns Var")
+        (with-referred-cljs-env
+          (fn [aenv]
+            (let [react-body (self-react-body aenv verb) ; side-effect: :uses drop
+                  js         (compile-js aenv (list 'def verb react-body))]
+              (is (re-find def-re js)
+                  "the def defines the current-namespace Var")
+              (is (re-find head-re js)
+                  "the recursive mount head references the current-namespace Var")
+              (is (not (re-find author-re js))
+                  "zero authoring-Var reference — not clobbered, not captured")))))
+      (testing (str "CLJS: the emitted self mount head is the current-ns fqn (" verb ")")
+        (with-referred-cljs-env
+          (fn [aenv]
+            (let [heads (mount-heads (self-react-body aenv verb))]
+              (is (seq heads) "a self component call is emitted")
+              (is (every? #(= self-fqn %) heads)
+                  "every self head is cljs.user/<verb>, never the bare refer")
+              (is (not-any? #(= verb %) heads)
+                  "the raw authored spelling never reaches the mount head")))))
+      (testing (str "JVM: the structural self call targets the current-ns fqn (" verb ")")
+        (with-referred-cljs-env
+          (fn [aenv]
+            (let [heads (mount-heads (self-jvm-body aenv verb))]
+              (is (seq heads) "a self component call is emitted")
+              (is (every? #(= self-fqn %) heads)
+                  "every JVM self call head is cljs.user/<verb>")
+              (is (not-any? #(= verb %) heads)
+                  "the raw authored spelling never reaches the JVM head"))))))))
+
+(deftest a-bare-authored-self-head-would-capture-the-authoring-var
+  ;; The counterfactual the fix defeats: a bare authored head compiles to the
+  ;; REFERRED authoring Var — the exact defect. Pins the JS delta so a regression
+  ;; is legible, not silent.
+  (with-referred-cljs-env
+    (fn [aenv]
+      (doseq [verb '[sub frame]]
+        (is (= (str "re_frame.freehand." (name verb)) (compile-js aenv verb))
+            "a bare head resolves through the refer to the authoring Var")
+        (is (= (str "cljs.user." (name verb))
+               (compile-js aenv (symbol "cljs.user" (name verb))))
+            "the qualified head resolves to the current-namespace Var")))))
+
+(deftest a-non-recursive-view-leaves-the-refer-and-heads-untouched
+  ;; Preserve unrelated behavior: a view that does NOT reference itself neither
+  ;; rewrites a head to an fqn nor mutates the ns `:uses` — a later referred
+  ;; (sub …) still resolves to the authoring Var, and an ordinary internal-view
+  ;; head keeps its authored spelling.
+  (with-referred-cljs-env
+    (fn [aenv]
+      (let [e   (referred-env aenv 'panel)
+            ast (analyze/analyze e [:div "x"])]
+        (emit-react/emit-react-body e [] ast)
+        (is (= "re_frame.freehand.sub" (compile-js aenv 'sub))
+            "a non-recursive view does not drop a referred verb from :uses")))))
 


### PR DESCRIPTION
## What

Both live Freehand emitters lowered a self-recursive component head using the raw authored `:sym` instead of the canonical `:fqn`. In a namespace that **refers** `re-frame.freehand/{sub,frame}`, a compiled `(defview sub [] [sub {}])` mounted the **authoring verb** (`re_frame.freehand.sub`) instead of recursing on its own current-namespace view (`cljs.user.sub`) — in **both** the JVM structural realisation (`emit-jvm/emit-structural-body`) and the React realisation (`emit-react/emit-react-body`). The analyzer already produces the correct `:fqn` on the self node; the emitters just weren't reading it.

## The fix (bounded)

- **Self head → current-namespace Var.** For the exact self-recursive head, both emitters now emit the node's canonical `:fqn` (the current-namespace Var), never the authored `:sym`. The raw authored spelling stays diagnostic only. Every other head — an unrelated internal view, a foreign component, a local shadow — keeps its authored spelling.
- **Declaration / order.** `cljs.analyzer/resolve-var` ranks `:uses` (refers) above `:defs` and ignores `:excludes`, so a bare `(def sub …)` both clobbers the public authoring Var (`re_frame.freehand.sub = …`) and leaves the qualified self head undefined — a split identity. `emit-react-body` completes the shadowing the analyzer already intends: for a self-recursive view it drops the view's own name from the live ns `:uses` in the CLJS macro-expansion compiler env, so the `(def …)`, its structural and React bodies, and every recursive head resolve to the one canonical current-namespace Var. JVM-only, guarded on a self reference plus a live compiler env; non-recursive views and the CLJS-host self-compile path are untouched, and no runtime code is added (production elision stays clean).

Scope is `compiler/emit_jvm.cljc` + `compiler/emit_react.cljc` + the regression namespace only. No emitter redesign, no compatibility layer. `compiler/analyze.cljc` is untouched — the `:fqn` was already in the AST.

## Proof

Real `cljs.analyzer` + `cljs.compiler` JavaScript-output regression (referred `sub`, `frame`): the compiled `(def <verb> …)` defines `cljs.user.<verb>`, the recursive mount head references `cljs.user.<verb>`, and the emitted JavaScript carries **zero** `re_frame.freehand.<verb>` reference — asserted across both the JVM structural and the React emitters by diffing the emitted JS bytes, not the AST shape. A counterfactual pins the bare-head capture (`re_frame.freehand.<verb>`) so a regression is legible, and a non-recursive view proves the machinery inert (no `:uses` mutation, authored spelling preserved).

**Load-bearing:** against the unfixed emitters the new accept rows RED with 14 failures (the emitted JS shows `re_frame.freehand.frame = …mount(re_frame.freehand.frame,…)`); green after the fix. The counterfactual and non-recursive rows stay green in both states.

## Quality gates

| Gate | Command | Result | Exit |
|------|---------|--------|------|
| Freehand JVM | `cd implementation/freehand && clojure -M:test` | 919 tests, 6561 assertions, 0 failures, 0 errors | 0 |
| Node / CLJS | `npm run test:freehand` (from `implementation/`) | 993 tests, 5628 assertions, 0 failures, 0 errors; build 397/398 files, 0 warnings | 0 |
| Targeted regression (fix applied) | `clojure -M:test -n re-frame.freehand.compiler-macro-resolution-jvm-test` | 9 tests, 69 assertions, 0 failures | 0 |
| Same regression vs. unfixed emitters (RED-before proof) | reverted src, re-ran | 14 failures (accept rows), counterfactual + non-recursive green | — |

Node/CLJS gate confirmed compiling against this worktree's `shadow-cljs.edn`.
