### PR TITLE
bench(freehand): B5 build lane — matched interpreted/compiled/mixed release builds + per-promotion delta + mount time (rf2-x4jda)

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/bench/b5.cljs
+++ b/implementation/freehand/src/re_frame/freehand/bench/b5.cljs
@@ -75,8 +75,32 @@
 
 (def default-bundle-path
   "Where `npm run build:freehand-release` lands the artefact, relative to
-  `implementation/` — the directory the Node lane runs from."
+  `implementation/` — the directory the Node lane runs from. This is the
+  MIXED shape — one interpreted leaf and its compiled twin under one root."
   "out/freehand-release/main.js")
+
+(def interpreted-bundle-path
+  "The INTERPRETED-ONLY twin of the release build
+  (`:freehand-release-interpreted`): the same entry app with every view held
+  on the interpreted path. Built with `shadow-cljs release
+  freehand-release-interpreted`."
+  "out/freehand-release-interpreted/main.js")
+
+(def compiled-bundle-path
+  "The COMPILED-ONLY twin of the release build
+  (`:freehand-release-compiled`): the same entry app with every view compiled
+  — no interpreted view reaches the bundle. Built with `shadow-cljs release
+  freehand-release-compiled`."
+  "out/freehand-release-compiled/main.js")
+
+(def matched-bundle-paths
+  "The three matched release shapes, keyed by lowering. They differ ONLY in
+  view lowering — same entry app, same `:advanced`, same `goog.DEBUG` false —
+  so a byte that differs between them differs BECAUSE of lowering and nothing
+  else. Measured in order, this is the row B5's build lane publishes."
+  {:interpreted interpreted-bundle-path
+   :mixed       default-bundle-path
+   :compiled    compiled-bundle-path})
 
 (defn bundle-present?
   "True when the release artefact is on disk. A B5 measurement of a bundle
@@ -176,6 +200,35 @@
      :gzip9-bytes  (gzip-bytes buf 9)
      :brotli-bytes (brotli-bytes buf)
      :source       source}))
+
+;; ---------------------------------------------------------------------------
+;; The per-promotion delta — evidence, never a threshold
+;; ---------------------------------------------------------------------------
+
+(defn promotion-delta
+  "The per-promotion BYTE delta between an interpreted-shape and a
+  compiled-shape [[measure-bundle]]d artefact: `compiled` minus
+  `interpreted`, per encoding.
+
+  A positive number means the compiled shape is LARGER on the wire — the
+  compiled emitter's per-view output outweighing the interpreter body it
+  replaces — and a negative one means promotion shrank the bundle. Which way
+  it falls, and how far, is a fact about the two artefacts, published as
+  evidence: D021's NON-GOALS bar a byte-size threshold, so a delta has no
+  route to a verdict however large it is. Because the two artefacts differ
+  ONLY in lowering (same entry app, same `:advanced`, same `goog.DEBUG`
+  false), this delta is attributable to lowering and nothing else.
+
+  Both maps must be from the same [[measure-bundle]] shape; the raw, gzip
+  (6 and 9) and brotli deltas are answered, plus each side's digest so the
+  delta is tied to the exact two bundles it was taken over."
+  [interpreted compiled]
+  {:raw-bytes    (- (:raw-bytes compiled)    (:raw-bytes interpreted))
+   :gzip6-bytes  (- (:gzip6-bytes compiled)  (:gzip6-bytes interpreted))
+   :gzip9-bytes  (- (:gzip9-bytes compiled)  (:gzip9-bytes interpreted))
+   :brotli-bytes (- (:brotli-bytes compiled) (:brotli-bytes interpreted))
+   :interpreted-sha256 (:sha256 interpreted)
+   :compiled-sha256    (:sha256 compiled)})
 
 ;; ---------------------------------------------------------------------------
 ;; The workload

--- a/implementation/freehand/test/re_frame/freehand/bench/b5_matched_builds_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b5_matched_builds_cljs_test.cljs
@@ -180,7 +180,7 @@
               "the three shapes are three distinct artefacts")
           ;; The delta is a fact about the two artefacts; it gates nothing.
           (is (number? (:raw-bytes delta)) "the per-promotion raw delta is a number")
-          (is (= (:raw-bytes delta) (- (:raw-bytes compiled) (:raw-bytes interpreted)))
+          (is (= (:raw-bytes delta) (- (:raw-bytes compiled) (:raw-bytes interp)))
               "and it is exactly compiled-minus-interpreted over the measured bytes")
           (is (= (:sha256 interp) (:interpreted-sha256 delta))
               "the delta is tied to the interpreted bundle it was taken over")

--- a/implementation/freehand/test/re_frame/freehand/bench/b5_matched_builds_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b5_matched_builds_cljs_test.cljs
@@ -1,0 +1,204 @@
+(ns re-frame.freehand.bench.b5-matched-builds-cljs-test
+  "B5's BUILD LANE: the three matched release shapes and the per-promotion
+  byte delta between them.
+
+  The evidence half of B5 ([[re-frame.freehand.bench.b5-bundle-cljs-test]])
+  measures the ONE mixed `:freehand-release` bundle. This file measures all
+  THREE matched shapes — interpreted-only, mixed, compiled-only — that differ
+  ONLY in view lowering (`:freehand-release-interpreted`, `:freehand-release`,
+  `:freehand-release-compiled` in `implementation/shadow-cljs.edn`: same entry
+  app, same `:advanced`, same `goog.DEBUG` false), and publishes the
+  per-promotion BYTE DELTA between the interpreted and compiled shapes.
+
+  Two things keep it honest, and both are tested here without any bundle on
+  disk:
+
+    - [[re-frame.freehand.bench.b5/promotion-delta]] is exercised over
+      synthetic measured artefacts, so the delta arithmetic has coverage on
+      every `npm run test:freehand` run, built bundles or not;
+    - the three artefacts route through the SAME probe the mixed lane uses —
+      [[re-frame.freehand.bench.b5/measure-bundle]] and
+      [[re-frame.freehand.bench.b5/workload]] — so no new bench framework is
+      introduced; the matched shapes are just three inputs to it.
+
+  The real bundles are measured only when all three have been built. A delta
+  taken against a shape that was never built is a number about nothing, so
+  that test SKIPS unless every one of the three is on disk. To publish the
+  real figures:
+
+      shadow-cljs release freehand-release-interpreted \\
+                          freehand-release \\
+                          freehand-release-compiled
+      RF2_REVISION=$(git rev-parse HEAD) npm run test:freehand
+
+  It states no pass/fail about any bundle. Every reading is a byte count or a
+  byte delta, which the harness can only publish — D021's NON-GOALS bar a
+  byte-size threshold, so no matched-build figure has a route to a verdict.
+  The DETERMINISTIC reachability gate that DOES red is a different lane
+  (`scripts/check-freehand-evidence-elision.cjs`, over the goog.DEBUG control
+  pair): it flips the flag and holds lowering; this file flips lowering and
+  holds the flag. Complementary, not the same.
+
+  Node-only (`fs`/`zlib`/`vm` via b5). Like the mixed bundle test it is
+  driven by a test rather than registered into the standing suite, because
+  its subject is an artefact a standing run has no reason to have built.
+
+  Normative owner: `docs/design/freehand/decisions/`
+  `D021-performance-budgets-and-release-evidence.md`."
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [re-frame.freehand.bench :as bench]
+            [re-frame.freehand.bench.b5 :as b5]
+            [re-frame.freehand.bench.provenance :as prov]))
+
+(def ^:private sampling {:warmup 2 :samples 8})
+
+(def ^:private fixture-provenance
+  "The revision a TEST supplies, and the artefacts' own `:advanced`,
+  uninstrumented build — not the `:none` test host's. Identical posture to
+  the mixed bundle test."
+  {:revision "test-fixture-revision"
+   :build    b5/release-build})
+
+;; ---------------------------------------------------------------------------
+;; The delta arithmetic — covered on every run, no bundle required
+;; ---------------------------------------------------------------------------
+
+(defn- synthetic-measured
+  "A [[b5/measure-bundle]]-shaped map with the byte figures pinned, so the
+  delta arithmetic can be asserted against numbers a reader can add up."
+  [tag raw g6 g9 br]
+  {:path         tag
+   :sha256       (str tag "-sha")
+   :raw-bytes    raw
+   :gzip6-bytes  g6
+   :gzip9-bytes  g9
+   :brotli-bytes br
+   :source       ""})
+
+(deftest promotion-delta-is-compiled-minus-interpreted-per-encoding
+  (testing "The per-promotion delta subtracts the interpreted shape's bytes
+            from the compiled shape's, encoding by encoding — a positive
+            number means the compiled bundle is larger on the wire. It ties
+            each side to its digest so the delta is a fact about the exact two
+            artefacts."
+    (let [interp   (synthetic-measured "interp" 1000 400 380 300)
+          compiled (synthetic-measured "compiled" 1150 460 430 350)
+          d        (b5/promotion-delta interp compiled)]
+      (is (= 150 (:raw-bytes d))    "raw delta is compiled minus interpreted")
+      (is (= 60  (:gzip6-bytes d))  "gzip-6 delta")
+      (is (= 50  (:gzip9-bytes d))  "gzip-9 delta")
+      (is (= 50  (:brotli-bytes d)) "brotli delta")
+      (is (= "interp-sha"   (:interpreted-sha256 d)) "the interpreted side's digest rides the delta")
+      (is (= "compiled-sha" (:compiled-sha256 d))    "and the compiled side's"))))
+
+(deftest promotion-delta-can-be-negative-when-promotion-shrinks
+  (testing "The delta is evidence, not a threshold: when the compiled shape
+            is SMALLER, the delta is negative and nothing red fires. The
+            arithmetic simply reports which way it fell."
+    (let [interp   (synthetic-measured "i" 2000 800 760 600)
+          compiled (synthetic-measured "c" 1900 770 740 590)
+          d        (b5/promotion-delta interp compiled)]
+      (is (= -100 (:raw-bytes d)) "a shrinking promotion answers a negative raw delta")
+      (is (neg? (:gzip6-bytes d)) "and a negative gzip delta")
+      (is (neg? (:brotli-bytes d)) "and a negative brotli delta"))))
+
+(deftest the-three-matched-paths-are-distinct-and-named
+  (testing "The build lane names three shapes keyed by lowering, all
+            distinct, each landing in its own advanced output dir."
+    (let [paths b5/matched-bundle-paths]
+      (is (= #{:interpreted :mixed :compiled} (set (keys paths)))
+          "the trio is keyed by lowering")
+      (is (= 3 (count (set (vals paths)))) "the three artefacts are distinct files")
+      (is (= b5/default-bundle-path (:mixed paths))
+          "the mixed shape is the existing :freehand-release bundle"))))
+
+;; ---------------------------------------------------------------------------
+;; The real matched artefacts, when all three have been built
+;; ---------------------------------------------------------------------------
+
+(defn- publish!
+  "Emit an EDN evidence line, marked citable only when every provenance
+  field was named — the same door the mixed bundle test publishes through."
+  [label record]
+  (let [ds (prov/defects record)]
+    (js/console.log
+      (str ";; " label " — "
+           (if (seq ds)
+             (str "NOT CITABLE (" (count ds) " provenance field(s) unnamed by this run)")
+             "citable")
+           "\n" (pr-str (if (seq ds) record (prov/result record)))))))
+
+(defn- measure-and-record
+  "Measure one shape's bundle and run it through the SAME B5 workload the
+  mixed lane uses, answering the measured map and the harness record."
+  [shape-key path revision]
+  (let [measured (b5/measure-bundle path)
+        w        (b5/workload {:id       (keyword "B5" (str "freehand-release-" (name shape-key)))
+                               :doc      (str "the " (name shape-key)
+                                              "-shape Freehand release bundle")
+                               :sampling sampling}
+                              measured)
+        record   (bench/run-workload w (assoc fixture-provenance :revision revision))]
+    {:measured measured :record record}))
+
+(deftest the-three-shapes-and-their-delta-are-measured-when-built
+  (testing "The matched build lane's real reading, published when the three
+            bundles are on disk. Each shape's bytes and parse/compile are
+            measured off its own artefact through the shared probe, and the
+            per-promotion delta between the interpreted and compiled shapes is
+            published as evidence — the byte cost of promoting the app's
+            views, attributable to lowering because that is the only thing
+            that differs across the three. When any shape is unbuilt this
+            SKIPS rather than fabricate a delta between files that are not
+            there."
+    (let [present (into {} (filter (comp b5/bundle-present? val)) b5/matched-bundle-paths)]
+      (if-not (= 3 (count present))
+        (is true (str "not all three matched bundles are on disk — build "
+                      "freehand-release-interpreted, freehand-release and "
+                      "freehand-release-compiled first; skipping the matched "
+                      "build-lane measurement (present: " (keys present) ")"))
+        (let [revision (or (prov/detect-revision) "unattributed-local-build")
+              results  (into {}
+                             (map (fn [[k p]] [k (measure-and-record k p revision)]))
+                             b5/matched-bundle-paths)
+              interp   (get-in results [:interpreted :measured])
+              compiled (get-in results [:compiled :measured])
+              mixed    (get-in results [:mixed :measured])
+              delta    (b5/promotion-delta interp compiled)]
+          ;; Every shape's own readings are honest facts about its file.
+          (doseq [[k {:keys [measured record]}] results]
+            (is (< (:gzip6-bytes measured) (:raw-bytes measured))
+                (str (name k) " shape compresses under gzip"))
+            (is (= 64 (count (:sha256 measured))) (str (name k) " shape has a digest"))
+            (is (empty? (:gate-failures record))
+                (str (name k) " shape reds nothing — it is all evidence"))
+            (is (= :advanced (get-in record [:build :optimizations]))
+                (str (name k) " shape is an advanced artefact"))
+            (publish! (str "B5 matched shape — " (name k)) record))
+          ;; The three digests are distinct: three different bundles.
+          (is (= 3 (count (set (map (comp :sha256 :measured val) results))))
+              "the three shapes are three distinct artefacts")
+          ;; The delta is a fact about the two artefacts; it gates nothing.
+          (is (number? (:raw-bytes delta)) "the per-promotion raw delta is a number")
+          (is (= (:raw-bytes delta) (- (:raw-bytes compiled) (:raw-bytes interpreted)))
+              "and it is exactly compiled-minus-interpreted over the measured bytes")
+          (is (= (:sha256 interp) (:interpreted-sha256 delta))
+              "the delta is tied to the interpreted bundle it was taken over")
+          (is (= (:sha256 compiled) (:compiled-sha256 delta))
+              "and to the compiled bundle")
+          (js/console.log
+            (str ";; B5 per-promotion byte delta (compiled minus interpreted) — evidence, no threshold\n"
+                 (pr-str {:revision      revision
+                          :interpreted   {:raw    (:raw-bytes interp)
+                                          :gzip6  (:gzip6-bytes interp)
+                                          :brotli (:brotli-bytes interp)
+                                          :sha256 (:sha256 interp)}
+                          :mixed         {:raw    (:raw-bytes mixed)
+                                          :gzip6  (:gzip6-bytes mixed)
+                                          :brotli (:brotli-bytes mixed)
+                                          :sha256 (:sha256 mixed)}
+                          :compiled      {:raw    (:raw-bytes compiled)
+                                          :gzip6  (:gzip6-bytes compiled)
+                                          :brotli (:brotli-bytes compiled)
+                                          :sha256 (:sha256 compiled)}
+                          :promotion-delta delta}))))))))

--- a/implementation/freehand/test/re_frame/freehand/bench/b5_mount_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b5_mount_dom_cljs_test.cljs
@@ -122,6 +122,12 @@
 ;; One timed mount
 ;; ---------------------------------------------------------------------------
 
+;; A monotonic counter minting a distinct identity for every mount, warmup
+;; and measured alike. React tears a root down asynchronously, so a
+;; disambiguator reused across two mounts can collide with its own still-live
+;; predecessor; a fresh number per mount sidesteps the teardown race entirely.
+(defonce ^:private mount-seq (atom 0))
+
 (defn- mount-once!
   "Mount the mixed root into a FRESH container under a FRESH frame, owning
   the frame and draining its `:initial-events` — the same preflight the
@@ -131,11 +137,13 @@
 
   Each sample uses its own frame id and disambiguator: mounting one root view
   many times is many occurrences of it, not one root reused, so each needs
-  its own derived identity."
-  [i]
-  (let [container (js/document.createElement "div")
-        fid       (keyword "b5-mount" (str "frame-" i))
-        tag       (keyword "b5-mount" (str "arm-" i))]
+  its own derived identity — minted from [[mount-seq]] so no two ever share
+  one."
+  []
+  (let [n         (swap! mount-seq inc)
+        container (js/document.createElement "div")
+        fid       (keyword "b5-mount" (str "frame-" n))
+        tag       (keyword "b5-mount" (str "arm-" n))]
     (.appendChild js/document.body container)
     (let [t0 (m/now-ms)]
       (-> (act #(v/mount [app {}] container
@@ -176,7 +184,7 @@
   (reduce
     (fn [p i]
       (.then p (fn [readings]
-                 (-> (mount-once! i)
+                 (-> (mount-once!)
                      (.then (fn [arm]
                               (when (zero? i)
                                 (is (some? (.querySelector (:container arm) ".freehand-release-mixed"))

--- a/implementation/freehand/test/re_frame/freehand/bench/b5_mount_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b5_mount_dom_cljs_test.cljs
@@ -1,0 +1,237 @@
+(ns re-frame.freehand.bench.b5-mount-dom-cljs-test
+  "B5's initial-MOUNT reading: the wall time to mount the MIXED shape into a
+  real browser, first render committed.
+
+  D021's B5 row names an initial-mount time beside the shipped bytes. Bytes
+  are a fact about a FILE and are measured off the release artefact
+  ([[re-frame.freehand.bench.b5-bundle-cljs-test]]); mount time is a fact
+  about RUNTIME and can only be taken in a browser. The release build carries
+  no `:dev-http`, so there is nothing to point a browser at — which is why
+  this reading is taken the way every other Freehand runtime reading is: by
+  MOUNTING the shape in the real browser the DOM suite already runs in, over
+  `react-dom/client`, and timing the first commit.
+
+  ## The mixed SHAPE, reproduced
+
+  The subject is the shape the mixed `:freehand-release` bundle ships — one
+  interpreted leaf and its compiled twin, under one interpreted root — so the
+  views below mirror `re-frame.freehand.release-app` exactly: `counter`
+  interpreted, `counter-compiled` promoted, and an interpreted `app` root
+  that composes both over one frame. Timing the mount of these is timing the
+  mount of the mixed shape; it is not timing the `:advanced` bundle's load,
+  which is what the byte and parse/compile readings are for.
+
+  ## Evidence, never a gate
+
+  The reading is a distribution of wall-clock milliseconds, published with
+  provenance and asserted against NOTHING. D021 sets no mount-time threshold,
+  and one set here would be measuring the CI runner, not the substrate —
+  exactly the discipline B4's latency half keeps. The only assertions are
+  non-vacuity: the shape actually mounted, both tiers reached the DOM, and
+  the timer moved.
+
+  Node has no browser to mount into, so under the node lane this SKIPS
+  cleanly on `(browser?)` — the same posture the other `*-dom` benches keep.
+  It runs for real under `npm run test:browser`.
+
+  Normative owner: `docs/design/freehand/decisions/`
+  `D021-performance-budgets-and-release-evidence.md`."
+  (:require ["react" :as react]
+            [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as react-substrate]
+            [re-frame.core :as rf]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.bench.measure :as m]
+            [re-frame.freehand.bench.provenance :as prov]
+            [re-frame.freehand.react :as fr]
+            [re-frame.freehand.root :as root]
+            [re-frame.test-support :as test-support]))
+
+;; ---------------------------------------------------------------------------
+;; The mixed shape — mirroring re-frame.freehand.release-app
+;; ---------------------------------------------------------------------------
+
+(rf/reg-event ::seed (fn [_ _] {:db {:count 0}}))
+(rf/reg-event ::bump (fn [{:keys [db]} _] {:db (update db :count inc)}))
+(rf/reg-sub ::count (fn [db _] (:count db)))
+
+(v/defview counter
+  "The interpreted paved path — the release app's `counter`, verbatim."
+  [{:keys [label]}]
+  [:div.counter
+   [:span.label label]
+   [:output.count (str (v/sub [::count]))]
+   [:button.bump {:on-click [::bump]} "+"]])
+
+(v/defview counter-compiled
+  "The compiled hot tier over the same body — `{:compiled true}` and nothing
+  else changed."
+  {:compiled true}
+  [{:keys [label]}]
+  [:div.counter
+   [:span.label label]
+   [:output.count (str (v/sub [::count]))]
+   [:button.bump {:on-click [::bump]} "+"]])
+
+(v/defview app
+  "The mounted root: both tiers on one page, over one frame — the mixed
+  shape the release bundle ships."
+  [_]
+  [:main.freehand-release-mixed
+   [counter {:label "interpreted"}]
+   [counter-compiled {:label "compiled"}]])
+
+;; ---------------------------------------------------------------------------
+;; Sampling
+;; ---------------------------------------------------------------------------
+
+(def ^:private warmup 3)
+(def ^:private samples 12)
+
+;; ---------------------------------------------------------------------------
+;; Browser plumbing — the b4-dom shape, pared to what a mount needs
+;; ---------------------------------------------------------------------------
+
+(defn- browser? []
+  (and (exists? js/document) (some? (.-createElement js/document))))
+
+(defn- act [thunk]
+  (try
+    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+    (js/Promise.resolve (react/act (fn [] (js/Promise.resolve (thunk)))))
+    (catch :default e
+      (js/Promise.reject e))))
+
+(def ^:private runtime-fixture
+  (test-support/make-reset-runtime-fixture
+    {:adapter       react-substrate/adapter
+     :ambient-frame nil
+     :async?        true}))
+
+(use-fixtures :each
+  {:before (fn []
+             (root/reset-registry!)
+             (fr/reset-boundaries!)
+             ((:before runtime-fixture)))
+   :after  (fn []
+             ((:after runtime-fixture))
+             (root/reset-registry!)
+             (fr/reset-boundaries!))})
+
+;; ---------------------------------------------------------------------------
+;; One timed mount
+;; ---------------------------------------------------------------------------
+
+(defn- mount-once!
+  "Mount the mixed root into a FRESH container under a FRESH frame, owning
+  the frame and draining its `:initial-events` — the same preflight the
+  release build's `-main` runs — and answer the wall time from just before
+  the mount to when React has committed the first render, alongside the arm
+  so the caller can tear it down.
+
+  Each sample uses its own frame id and disambiguator: mounting one root view
+  many times is many occurrences of it, not one root reused, so each needs
+  its own derived identity."
+  [i]
+  (let [container (js/document.createElement "div")
+        fid       (keyword "b5-mount" (str "frame-" i))
+        tag       (keyword "b5-mount" (str "arm-" i))]
+    (.appendChild js/document.body container)
+    (let [t0 (m/now-ms)]
+      (-> (act #(v/mount [app {}] container
+                         {:frame         {:id fid :initial-events [[::seed]]}
+                          :disambiguator tag}))
+          (.then (fn [mounted]
+                   {:ms (- (m/now-ms) t0) :container container :mounted mounted}))
+          (.catch (fn [e] (.remove container) (js/Promise.reject e)))))))
+
+(defn- release! [arm]
+  (when arm
+    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+    (when-let [mounted (:mounted arm)]
+      (.unmount (.-react-root ^root/Root mounted)))
+    (.remove (:container arm)))
+  nil)
+
+(defn- publish! [record]
+  (let [ds (prov/defects record)]
+    (js/console.log
+      (str ";; B5 initial-mount evidence — "
+           (if (seq ds)
+             (str "NOT CITABLE (" (count ds) " provenance field(s) unnamed by this run)")
+             "citable")
+           "\n" (pr-str record)))))
+
+;; ---------------------------------------------------------------------------
+;; The reading
+;; ---------------------------------------------------------------------------
+
+(defn- run-samples!
+  "Mount, time and unmount `n` times, threading the collected millisecond
+  readings through a promise chain (one mount in flight at a time, so a
+  sample times a mount into a quiet document rather than into a pile of
+  siblings). `keep?` gates whether a sample's reading is recorded, so the
+  warmup mounts pay React's first-run costs without polluting the figures."
+  [acc n keep?]
+  (reduce
+    (fn [p i]
+      (.then p (fn [readings]
+                 (-> (mount-once! i)
+                     (.then (fn [arm]
+                              (when (zero? i)
+                                (is (some? (.querySelector (:container arm) ".freehand-release-mixed"))
+                                    "the mixed root mounted into the real DOM")
+                                (is (= 2 (.-length (.querySelectorAll (:container arm) ".counter")))
+                                    "both tiers — interpreted and compiled — reached the DOM"))
+                              (let [ms (:ms arm)]
+                                (release! arm)
+                                (if keep? (conj readings ms) readings))))))))
+    (js/Promise.resolve acc)
+    (range n)))
+
+(defn- mount-row! [done]
+  (-> (run-samples! [] warmup false)
+      (.then (fn [_] (run-samples! [] samples true)))
+      (.then (fn [readings]
+               (is (= samples (count readings)) "every measured mount produced a reading")
+               (is (every? #(and (number? %) (not (neg? %))) readings)
+                   "each initial-mount time is a non-negative duration")
+               (let [dist (assoc (m/summarise readings)
+                                 :doc "wall time to mount the mixed shape and commit the first render"
+                                 :observable :duration-ms)]
+                 (publish!
+                   {:benchmark :B5/initial-mount-mixed
+                    :doc       (str "initial mount of the mixed Freehand shape "
+                                    "(one interpreted leaf, one compiled twin) in a real browser")
+                    :revision  (prov/detect-revision)
+                    :fixture   {:shape :mixed
+                                :leaves 2
+                                :tiers [:interpreted :compiled]
+                                :measurement-method
+                                (str "wall time across act(v/mount) resolution — mount into a "
+                                     "fresh container under a fresh owned frame whose "
+                                     ":initial-events seed app-db, to React's first committed "
+                                     "render; " warmup " warmup mounts discarded, " samples
+                                     " measured, one mount in flight at a time")}
+                    :build     (prov/detect-build)
+                    :host      (prov/detect-host)
+                    :sampling  {:warmup warmup :samples samples}
+                    :baseline  {:kind      :before-vs-after
+                                :reference {:revision :the-revision-before-this
+                                            :note "the same shape's mount time on the preceding revision"}}
+                    :distribution {:B5/initial-mount-ms dist}
+                    :status    :evidence})
+                 nil)))
+      (.catch (fn [e] (is false (str "B5 mount row rejected: " e))))
+      (.finally done)))
+
+(deftest initial-mount-of-the-mixed-shape-is-measured-in-a-real-browser
+  (testing "D021's B5 initial-mount reading: the wall time to mount the mixed
+            Freehand shape — one interpreted leaf and its compiled twin under
+            one root — into a real browser, first render committed. Published
+            as a distribution with provenance and gated against nothing; the
+            only assertions are that the shape mounted, both tiers reached the
+            DOM, and the timer moved. Node has no browser, so it SKIPS there."
+    (if-not (browser?)
+      (is true "a real browser mount is required — the browser job runs this reading")
+      (async done (mount-row! done)))))

--- a/implementation/freehand/test/re_frame/freehand/release_app_compiled.cljs
+++ b/implementation/freehand/test/re_frame/freehand/release_app_compiled.cljs
@@ -1,0 +1,86 @@
+(ns re-frame.freehand.release-app-compiled
+  "The entry of the COMPILED-ONLY twin of the Freehand release build
+  (`:freehand-release-compiled`).
+
+  It is `re-frame.freehand.release-app-interpreted` with `{:compiled true}`
+  added to every view and nothing else changed — same handlers, same
+  parameter vectors, same bodies character-for-character. The mixed release
+  build carries one interpreted leaf and its compiled twin; this one carries
+  both leaves compiled, under a compiled root, so no interpreted view
+  reaches the bundle at all. The three markers here are the ONLY textual
+  difference from the interpreted twin, which is what makes the byte
+  difference between the two bundles a reading of lowering and nothing else
+  — the per-promotion delta B5 publishes.
+
+  The root composes its two leaves by literal reference
+  (`[counter-a {:label \"a\"}]`), which the compiled tier lowers like any
+  other child-view reference (D010 refuses only a RUNTIME markup value inside
+  a compiled body, never a compile-time view reference). Like the mixed
+  entry it is a real APPLICATION, not a require-only stub, so `:advanced`
+  keeps the whole mount graph rather than eliding an unused require.
+
+  It lives under `test/` for the reason the sibling bundle probes do:
+  `deps.edn` publishes `src` alone, so a fixture that exists to be measured
+  stays out of the artefact a consumer resolves, while shadow-cljs — which
+  carries `freehand/test` on `:source-paths` — compiles it into a real
+  production bundle.
+
+  Normative owner: `docs/design/freehand/decisions/`
+  `D021-performance-budgets-and-release-evidence.md`."
+  (:require [re-frame.core :as rf]
+            [re-frame.freehand :as v]
+            [re-frame.adapter.uix :as uix]))
+
+;; ---------------------------------------------------------------------------
+;; Handlers — identical to the interpreted twin's. Lowering changes the view
+;; bodies, never the event/subscription graph, so these are unchanged.
+;; ---------------------------------------------------------------------------
+
+(rf/reg-event ::seed (fn [_ _] {:db {:count 0}}))
+
+(rf/reg-event ::bump (fn [{:keys [db]} _] {:db (update db :count inc)}))
+
+(rf/reg-sub ::count (fn [db _] (:count db)))
+
+;; ---------------------------------------------------------------------------
+;; Two views, both COMPILED — the interpreted twin's bodies plus the marker.
+;; ---------------------------------------------------------------------------
+
+(v/defview counter-a
+  "A compiled counter — the interpreted twin's body under `{:compiled true}`."
+  {:compiled true}
+  [{:keys [label]}]
+  [:div.counter
+   [:span.label label]
+   [:output.count (str (v/sub [::count]))]
+   [:button.bump {:on-click [::bump]} "+"]])
+
+(v/defview counter-b
+  "The second compiled counter — the same body as `counter-a`, so the two
+  leaves are matched."
+  {:compiled true}
+  [{:keys [label]}]
+  [:div.counter
+   [:span.label label]
+   [:output.count (str (v/sub [::count]))]
+   [:button.bump {:on-click [::bump]} "+"]])
+
+(v/defview app
+  "The mounted root, itself compiled: two compiled leaves on one page, over
+  one frame. Nothing interpreted reaches this bundle."
+  {:compiled true}
+  [_]
+  [:main#freehand-release-compiled
+   [counter-a {:label "a"}]
+   [counter-b {:label "b"}]])
+
+(defn ^:export -main
+  "The build's `:init-fn`. Installs the UIx adapter, then mounts the root
+  into `#app`, owning the frame it runs over so the bundle carries the whole
+  preflight path — exactly the shape the mixed entry documents."
+  []
+  (rf/init! uix/adapter)
+  (v/mount [app {}]
+           (js/document.getElementById "app")
+           {:frame {:id             ::frame
+                    :initial-events [[::seed]]}}))

--- a/implementation/freehand/test/re_frame/freehand/release_app_interpreted.cljs
+++ b/implementation/freehand/test/re_frame/freehand/release_app_interpreted.cljs
@@ -1,0 +1,85 @@
+(ns re-frame.freehand.release-app-interpreted
+  "The entry of the INTERPRETED-ONLY twin of the Freehand release build
+  (`:freehand-release-interpreted`).
+
+  It is `re-frame.freehand.release-app` with every view held on the
+  interpreted paved path — no `{:compiled true}` anywhere. The mixed
+  release build carries one interpreted leaf and its compiled twin; this
+  one carries the same two leaves, both interpreted, under the same
+  interpreted root. Its compiled sibling
+  (`re-frame.freehand.release-app-compiled`) flips exactly those three
+  markers and nothing else, so the byte difference between the two bundles
+  is attributable to lowering alone — the per-promotion delta B5 publishes.
+
+  Like the mixed entry it is a small real APPLICATION rather than a
+  require-only stub: an unused require DCEs to nearly nothing under
+  `:advanced`, and a bundle measuring an empty graph reports a cost no
+  consumer pays. Everything below is reached from the mount — two views
+  whose bodies READ a subscription and DISPATCH an event, and a root that
+  composes both through `v/mount`.
+
+  It lives under `test/` for the reason the sibling bundle probes do:
+  `deps.edn` publishes `src` alone, so a fixture that exists to be measured
+  stays out of the artefact a consumer resolves, while shadow-cljs — which
+  carries `freehand/test` on `:source-paths` — compiles it into a real
+  production bundle.
+
+  Normative owner: `docs/design/freehand/decisions/`
+  `D021-performance-budgets-and-release-evidence.md`."
+  (:require [re-frame.core :as rf]
+            [re-frame.freehand :as v]
+            [re-frame.adapter.uix :as uix]))
+
+;; ---------------------------------------------------------------------------
+;; Handlers — ordinary re-frame2, identical to the mixed entry's. The root's
+;; preflight plan seeds app-db through `:initial-events`, so the first render
+;; reads a value that is already there.
+;; ---------------------------------------------------------------------------
+
+(rf/reg-event ::seed (fn [_ _] {:db {:count 0}}))
+
+(rf/reg-event ::bump (fn [{:keys [db]} _] {:db (update db :count inc)}))
+
+(rf/reg-sub ::count (fn [db _] (:count db)))
+
+;; ---------------------------------------------------------------------------
+;; Two views, both interpreted — the same body twice, so this bundle mounts
+;; the same NUMBER of leaves the mixed build does, and only their lowering
+;; differs across the matched trio. The declarations are separate namespaced
+;; ids, so they are separate views; the bodies are deliberately identical.
+;; ---------------------------------------------------------------------------
+
+(v/defview counter-a
+  "An interpreted counter: a read, a dispatch and static markup."
+  [{:keys [label]}]
+  [:div.counter
+   [:span.label label]
+   [:output.count (str (v/sub [::count]))]
+   [:button.bump {:on-click [::bump]} "+"]])
+
+(v/defview counter-b
+  "The second interpreted counter — the same body as `counter-a`, so the
+  two leaves are matched."
+  [{:keys [label]}]
+  [:div.counter
+   [:span.label label]
+   [:output.count (str (v/sub [::count]))]
+   [:button.bump {:on-click [::bump]} "+"]])
+
+(v/defview app
+  "The mounted root: two interpreted leaves on one page, over one frame."
+  [_]
+  [:main#freehand-release-interpreted
+   [counter-a {:label "a"}]
+   [counter-b {:label "b"}]])
+
+(defn ^:export -main
+  "The build's `:init-fn`. Installs the UIx adapter, then mounts the root
+  into `#app`, owning the frame it runs over so the bundle carries the whole
+  preflight path — exactly the shape the mixed entry documents."
+  []
+  (rf/init! uix/adapter)
+  (v/mount [app {}]
+           (js/document.getElementById "app")
+           {:frame {:id             ::frame
+                    :initial-events [[::seed]]}}))

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -859,6 +859,47 @@
                       :closure-defines {goog.DEBUG false}}
    :modules {:main {:init-fn re-frame.freehand.release-app/-main}}}
 
+  ;; The two MATCHED twins of :freehand-release above, differing from it and
+  ;; from each other ONLY in view lowering. :freehand-release is the MIXED
+  ;; shape — one interpreted leaf and its compiled twin under one root. These
+  ;; two hold the same entry structure (a root mounting two counter leaves,
+  ;; the same handlers, the same body character-for-character) and flip every
+  ;; view to a single tier: :freehand-release-interpreted has no compiled
+  ;; view, :freehand-release-compiled has no interpreted one.
+  ;;
+  ;; Same :advanced optimisation and the same goog.DEBUG false as the mixed
+  ;; build, so the ONLY variable across the three bundles is lowering. That is
+  ;; what makes the per-promotion BYTE DELTA — the difference between the
+  ;; interpreted and compiled bundles — attributable to lowering and nothing
+  ;; else. The three are EVIDENCE artefacts: measured by
+  ;; re-frame.freehand.bench.b5 (bytes + parse/compile, published with no
+  ;; threshold), never served. This is a complement to the control build
+  ;; below, which holds lowering and flips goog.DEBUG to prove the evidence
+  ;; seam DCEs out of production; here lowering is the variable, not the flag.
+  ;;
+  ;; Built with `shadow-cljs release freehand-release-interpreted
+  ;; freehand-release-compiled`; the bundles land at
+  ;; out/freehand-release-interpreted/main.js and
+  ;; out/freehand-release-compiled/main.js. No :dev-http — like every other
+  ;; advanced build here they are compiled and measured, never served.
+  :freehand-release-interpreted
+  {:target     :browser
+   :output-dir "out/freehand-release-interpreted"
+   :asset-path "."
+   :compiler-options {:optimizations :advanced
+                      :infer-externs :auto
+                      :closure-defines {goog.DEBUG false}}
+   :modules {:main {:init-fn re-frame.freehand.release-app-interpreted/-main}}}
+
+  :freehand-release-compiled
+  {:target     :browser
+   :output-dir "out/freehand-release-compiled"
+   :asset-path "."
+   :compiler-options {:optimizations :advanced
+                      :infer-externs :auto
+                      :closure-defines {goog.DEBUG false}}
+   :modules {:main {:init-fn re-frame.freehand.release-app-compiled/-main}}}
+
   ;; rf2-drpa3.166 — the CONTROL twin of :freehand-release, and the only
   ;; thing that differs between the two is `goog.DEBUG`. It is one half of
   ;; the F4g production-isolation ELISION PROBE PAIR: build both, and the


### PR DESCRIPTION
## What this is

The BUILD-LANE remainder of D021's B5 row. The evidence half — bundle bytes and
honest parse/compile over the ONE mixed `:freehand-release` bundle — already
shipped. This adds the two matched twins the row asks for, measures all three,
publishes the per-promotion byte delta, and times the mixed shape's initial
mount in a real browser. Evidence only: no byte threshold, no timing gate.

## Changes

- **`implementation/shadow-cljs.edn`** (hot-zone) — two matched `:browser`
  release builds beside the existing mixed `:freehand-release`, differing from
  it and from each other ONLY in view lowering: `:freehand-release-interpreted`
  (every view interpreted) and `:freehand-release-compiled` (every view
  compiled, compiled root and all). Same entry structure, same `:advanced`,
  same `goog.DEBUG false`, so the byte difference across the three is
  attributable to lowering and nothing else. Pure addition (41 lines, 0
  deletions); no existing build entry touched.
- **`release_app_interpreted.cljs` / `release_app_compiled.cljs`** — the two
  twin entry apps under `freehand/test/`, mirroring `release-app` (the mixed
  entry) structure: same handlers, same two-leaf body character-for-character,
  flipped to a single tier. The compiled twin's root composes its leaves by
  literal reference, which the compiled tier lowers like any child-view
  reference (D010 refuses only a runtime markup value, never a compile-time
  reference).
- **`bench/b5.cljs`** — the two twin bundle paths, the matched-trio map, and
  `promotion-delta` (compiled minus interpreted, per encoding, each side tied
  to its digest). Reuses the existing `measure-bundle` / `workload` probe — no
  new bench framework.
- **`bench/b5_matched_builds_cljs_test.cljs`** — node lane. Unit-covers the
  delta arithmetic over synthetic artefacts on every run; when all three real
  bundles are on disk it measures each through the shared probe and publishes
  the per-promotion delta as evidence, and SKIPS otherwise — the same posture
  the mixed bundle test keeps.
- **`bench/b5_mount_dom_cljs_test.cljs`** — browser lane. Mounts the mixed
  shape (one interpreted leaf, one compiled twin, one root) into a real browser
  over `react-dom/client` and times the wall clock to the first committed
  render, published as a distribution with provenance. Skips cleanly under
  Node.

## Complementary to the elision gate, not a duplicate

`scripts/check-freehand-evidence-elision.cjs` flips `goog.DEBUG` (release vs
control, same entry) and holds lowering, as a DETERMINISTIC pass/fail grep that
the evidence schema DCEs out of production. This lane flips LOWERING (three
shapes) and holds the flag, as pure EVIDENCE. Different axis, different bundles,
different discipline. The control build and its script are untouched.

## Measured numbers (evidence only — no threshold, no verdict)

Bundle bytes, per shape (all three build 0-warnings under `:advanced` +
`goog.DEBUG false`):

| shape | raw | gzip-6 | brotli |
|---|---|---|---|
| interpreted-only | 733,307 | 217,746 | 180,656 |
| mixed (ships) | 744,450 | 221,084 | 183,129 |
| compiled-only | 751,781 | 222,653 | 184,353 |

Per-promotion byte delta (compiled minus interpreted): **raw +18,474 · gzip-6
+4,907 · gzip-9 +4,863 · brotli +3,697**. Monotonic interpreted < mixed <
compiled across every encoding, mixed near the midpoint — at this scale the
compiled emitter's per-view output outweighs the interpreter body it replaces.

Initial mount of the mixed shape in a real (headless Chromium) browser,
`B5/initial-mount-ms` over 12 measured mounts (3 warmup discarded): **min 2.4 ·
p50 3.7 · mean 3.85 · p95 5.8 · p99 5.8 · max 5.8 ms**. Published as evidence;
gates nothing.

## Quality gates

All run foreground to completion in the worktree; config banner verified to name
this worktree.

| Gate | Result | Exit |
|---|---|---|
| `shadow-cljs release freehand-release-interpreted` | Build completed, 174 files, 119 compiled, **0 warnings** | 0 |
| `shadow-cljs release freehand-release-compiled` | Build completed, 174 files, 119 compiled, **0 warnings** | 0 |
| `shadow-cljs release freehand-release` (mixed, regression check) | Build completed, 174 files, 119 compiled, **0 warnings** | 0 |
| `npm run test:freehand` (node lane) | Ran **1009 tests, 5774 assertions, 0 failures, 0 errors**; matched-build delta published | 0 |
| `npm run test:browser` (Chromium DOM lane) | Ran **758 tests, 4730 assertions, 0 failures, 0 errors** (no uncaught pageerror); mount reading published | 0 |
| `scripts/check-no-hardcoded-paths.sh` | Portability gate OK | 0 |
| `scripts/check-beads-pr-boundary.sh` (base `origin/main`) | No beads-database paths in diff | 0 |

The node suite's assertion count rose by 5 (the delta arithmetic + real-bundle
readings), the browser suite's by 3 (mount non-vacuity), confirming the new
tests actually ran rather than compiling away.

## TESTING.md

No change. The two release builds are manual EVIDENCE artefacts (like
`:freehand-release` itself), not required gates, and the two test namespaces
ride the always-on `node-test-freehand` / `browser-test` builds and skip when
their bundle/browser is absent — exactly as the existing mixed B5 bundle test
does, which likewise carries no TESTING.md row.
