### PR TITLE
test(freehand): mount the data-* casing repair and pin SSR parse divergence (rf2-hl7hr)

### DIFF
--- a/implementation/freehand/test/re_frame/freehand/compiled_views.cljc
+++ b/implementation/freehand/test/re_frame/freehand/compiled_views.cljc
@@ -69,13 +69,20 @@
 (v/defview props-page
   "The composite the React prop-grammar assertion mounts: HTML author
   spellings that React canonicalises, an SVG attribute directly and
-  through a boundary, and a lowercase `data-*` name that reaches the DOM
-  verbatim (a mixed-case `data-*` is refused before it can mount — Spec
-  004B §Attribute names, option c — so the page carries only the lowercase
-  spelling)."
+  through a boundary, and two lowercase `data-*` names that reach the DOM
+  verbatim.
+
+  The second of those, `:data-foo-bar`, is the REPAIR the mixed-case
+  refusal teaches (Spec 004B §Attribute names, option c): a mixed-case
+  `data-*` is refused before it can mount, and this is the spelling the
+  diagnostic sends the author to. It is mounted here, rather than only
+  asserted structurally, because the claim the diagnostic makes is about
+  the DOM — the hyphen survives as the attribute name AND the platform
+  reads the word boundary back as `element.dataset.fooBar`. A refusal that
+  named a repair nobody had mounted would be a promise, not a fact."
   {:compiled true}
   [_]
-  [:section#props {:tab-index 3 :data-priority "high"}
+  [:section#props {:tab-index 3 :data-priority "high" :data-foo-bar "kept"}
    ;; contentEditable rides a CHILDLESS element on purpose: React warns
    ;; about a contentEditable subtree it also manages, and that warning is
    ;; about the declaration rather than about the prop spelling.

--- a/implementation/freehand/test/re_frame/freehand/data_attr_casing_probe_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/data_attr_casing_probe_dom_cljs_test.cljs
@@ -27,10 +27,20 @@
        `.dataset` — so the word the author segmented is unreachable there too.
        A mixed-case `data-*` cannot mean what it says on any of the three.
 
+    3. THE SSR DIVERGENCE. The ruling's last premise is not a fact about
+       mounting at all: it is that SERIALISE-THEN-PARSE lowercases a `data-*`
+       name in EVERY namespace. `react-dom/server` writes the authored
+       spelling verbatim, and the HTML parser then lowercases it — including
+       inside SVG and MathML foreign content, where a CLIENT mount of the very
+       same props preserves it. Same declaration, two hosts, two different
+       attribute names on a foreign element. That is the divergence, probed
+       here rather than reasoned about.
+
   Rides the browser lane through its `-dom-cljs-test` suffix; under node it has
   no real React DOM and says so."
   (:require ["react" :as react]
             ["react-dom/client" :as rdc]
+            ["react-dom/server" :as rds]
             [cljs.test :refer-macros [async deftest is testing use-fixtures]]
             [clojure.string :as str]
             [goog.object :as gobj]
@@ -203,4 +213,98 @@
                        (done)))
               (.catch (fn [e]
                         (ms/destroy-root! c1 r1) (ms/destroy-root! c2 r2) (ms/destroy-root! c3 r3)
+                        (is false (str "probe failed: " e)) (done)))))))))
+
+;; ===========================================================================
+;; Obligation 2, continued — the SSR serialise-then-parse divergence
+;; ===========================================================================
+
+(def ^:private html-ns "http://www.w3.org/1999/xhtml")
+
+(defn- attr-names
+  "EVERY attribute name the element carries, as a set. Read off the element
+  rather than probed one name at a time, so a name that is NOT there is part
+  of the value two hosts get compared on."
+  [el]
+  (set (array-seq (.getAttributeNames el))))
+
+(defn- parse-as-html
+  "Parse `markup` the way a browser parses an SSR response, and answer the
+  resulting `<body>`. `text/html` is the whole point: it is the HTML parser,
+  with its foreign-content rules, that a server's bytes actually meet — an XML
+  parse would preserve everything and prove nothing."
+  [markup]
+  (.-body (.parseFromString (js/DOMParser.) (str "<!doctype html><body>" markup) "text/html")))
+
+(deftest ssr-serialise-then-parse-lowercases-in-every-namespace
+  (testing "The ruling's last premise, probed rather than reasoned:
+            `react-dom/server` writes an authored mixed-case data-* name
+            VERBATIM, and parsing that markup as HTML lowercases it in ALL
+            THREE namespaces — including SVG and MathML foreign content, where
+            a client mount of the SAME props preserves it. So the identical
+            declaration yields one attribute name on the server and a
+            different one on the client, on exactly the elements React does
+            not reconcile the difference away. The HTML element is the
+            contrast that makes the claim namespace-specific: there the two
+            hosts agree, because both lowercase.
+
+            Non-vacuous by construction: every name is fresh, and the markup
+            assertion proves the server emitted the authored spelling — so
+            whatever the parsed DOM has lost, the PARSE lost."
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job owns the SSR serialise-then-parse probe")
+      (async done
+        (let [html-name (fresh-mixed)
+              svg-name  (fresh-mixed)
+              math-name (fresh-mixed)
+              tree      (react/createElement
+                          "div" nil
+                          (react/createElement "div" (js-props "ssrh" html-name))
+                          (react/createElement "svg" nil
+                            (react/createElement "rect" (js-props "ssrs" svg-name)))
+                          (react/createElement "math" nil
+                            (react/createElement "mi" (js-props "ssrm" math-name))))
+              markup    (rds/renderToStaticMarkup tree)
+              body      (parse-as-html markup)
+              [container root] (ms/create-root!)
+              check
+              (fn [where nm expect-ns selector client-preserves?]
+                (let [parsed (.querySelector body selector)
+                      client (.querySelector container selector)]
+                  (is (some? parsed) (str where ": the parsed markup carries the element"))
+                  (is (some? client) (str where ": the client mount carries the element"))
+                  (when (and parsed client)
+                    (is (= expect-ns (.-namespaceURI parsed))
+                        (str where ": the parser really put it in this namespace — otherwise"
+                             " \"lowercased in every namespace\" is a claim about three HTML"
+                             " elements"))
+                    (is (contains? (attr-names parsed) (lowered nm))
+                        (str where ": parsing LOWERCASED the authored name"))
+                    (is (not (contains? (attr-names parsed) nm))
+                        (str where ": and the authored spelling is gone from the parsed DOM"))
+                    (if client-preserves?
+                      (do (is (contains? (attr-names client) nm)
+                              (str where ": the CLIENT mount preserved the authored spelling"))
+                          (is (not= (attr-names client) (attr-names parsed))
+                              (str where ": so client and SSR carry DIFFERENT attribute names"
+                                   " from identical props — the divergence the refusal rests on")))
+                      (do (is (contains? (attr-names client) (lowered nm))
+                              (str where ": the client mount lowercased it too"))
+                          (is (= (attr-names client) (attr-names parsed))
+                              (str where ": so client and SSR agree here — the divergence is"
+                                   " specific to foreign content")))))))]
+          ;; The server emitted what the author wrote. Everything the parsed
+          ;; DOM has lost below, the PARSE lost.
+          (doseq [nm [html-name svg-name math-name]]
+            (is (str/includes? markup nm)
+                (str "react-dom/server serialises " nm " verbatim")))
+          (-> (render! root tree)
+              (.then (fn [_]
+                       (check "SSR/client HTML"   html-name html-ns   "#ssrh" false)
+                       (check "SSR/client SVG"    svg-name  svg-ns    "#ssrs" true)
+                       (check "SSR/client MathML" math-name mathml-ns "#ssrm" true)
+                       (ms/destroy-root! container root)
+                       (done)))
+              (.catch (fn [e]
+                        (ms/destroy-root! container root)
                         (is false (str "probe failed: " e)) (done)))))))))

--- a/implementation/freehand/test/re_frame/freehand/react_mount_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/react_mount_dom_cljs_test.cljs
@@ -42,7 +42,15 @@
       (js/Promise.reject e))))
 
 (defn- check-row!
-  [container {:keys [note selector selector-all tag text attrs] n :count}]
+  "Assert one `:dom` row against the mounted document.
+
+  `:attrs` is read with `getAttribute`; `:dataset` is read off
+  `element.dataset`, which is a DIFFERENT observable — the platform's own
+  projection of a `data-*` attribute NAME into a camelCase key. An attribute
+  can be present and its dataset entry absent (that is exactly what a
+  mixed-case `data-*` does), so a row that means to pin the lossless
+  round-trip has to read both."
+  [container {:keys [note selector selector-all tag text attrs dataset] n :count}]
   (if selector-all
     (is (= n (.-length (.querySelectorAll container selector-all))) note)
     (let [el (.querySelector container selector)]
@@ -52,7 +60,10 @@
         (when text (is (= text (.-textContent el)) note))
         (doseq [[attr-name expected] attrs]
           (is (= expected (.getAttribute el attr-name))
-              (str note " — " attr-name)))))))
+              (str note " — " attr-name)))
+        (doseq [[key expected] dataset]
+          (is (= expected (gobj/get (.-dataset el) key))
+              (str note " — element.dataset." key)))))))
 
 (deftest fh-struct-007-the-react-emitter-mounts-real-dom
   (testing "Per FH-STRUCT-007: a declared view mounted through
@@ -158,8 +169,15 @@
             The silence row proves React had nothing to complain about,
             and the control mount proves that silence is a fact about the
             props rather than about the build: the same browser, handed
-            the non-canonical spelling directly, does complain."
+            the non-canonical spelling directly, does complain.
+
+            One DOM row also reads `element.dataset`: the REPAIR the
+            mixed-case `data-*` refusal teaches, mounted through Freehand
+            and read back, so the diagnostic's promise is a fact about a
+            real element rather than a sentence (rf2-hl7hr)."
     (is (seq (:dom struct-009)) "the fixture's DOM table loaded")
+    (is (some :dataset (:dom struct-009))
+        "and it pins a dataset read-back — a row `check-row!` would otherwise skip silently")
     (is (true? (:react-console-silent struct-009)))
     (if-not (browser?)
       (is true "a real React mount needs a DOM host — the browser job runs the assertions")

--- a/implementation/freehand/test/re_frame/freehand/react_mount_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/react_mount_dom_cljs_test.cljs
@@ -61,9 +61,9 @@
         (doseq [[attr-name expected] attrs]
           (is (= expected (.getAttribute el attr-name))
               (str note " — " attr-name)))
-        (doseq [[key expected] dataset]
-          (is (= expected (gobj/get (.-dataset el) key))
-              (str note " — element.dataset." key)))))))
+        (doseq [[dataset-key expected] dataset]
+          (is (= expected (gobj/get (.-dataset el) dataset-key))
+              (str note " — element.dataset." dataset-key)))))))
 
 (deftest fh-struct-007-the-react-emitter-mounts-real-dom
   (testing "Per FH-STRUCT-007: a declared view mounted through

--- a/implementation/freehand/test/re_frame/freehand/tree_views.cljc
+++ b/implementation/freehand/test/re_frame/freehand/tree_views.cljc
@@ -60,12 +60,19 @@
 (v/defview props-page
   "The composite the React prop-grammar assertion mounts: HTML author
   spellings that React canonicalises, an SVG attribute directly and
-  through a boundary, and a lowercase `data-*` name that reaches the DOM
-  verbatim (a mixed-case `data-*` is refused before it can mount — Spec
-  004B §Attribute names, option c — so the page carries only the lowercase
-  spelling)."
+  through a boundary, and two lowercase `data-*` names that reach the DOM
+  verbatim.
+
+  The second of those, `:data-foo-bar`, is the REPAIR the mixed-case
+  refusal teaches (Spec 004B §Attribute names, option c): a mixed-case
+  `data-*` is refused before it can mount, and this is the spelling the
+  diagnostic sends the author to. It is mounted here, rather than only
+  asserted structurally, because the claim the diagnostic makes is about
+  the DOM — the hyphen survives as the attribute name AND the platform
+  reads the word boundary back as `element.dataset.fooBar`. A refusal that
+  named a repair nobody had mounted would be a promise, not a fact."
   [_]
-  [:section#props {:tab-index 3 :data-priority "high"}
+  [:section#props {:tab-index 3 :data-priority "high" :data-foo-bar "kept"}
    ;; contentEditable rides a CHILDLESS element on purpose: React warns
    ;; about a contentEditable subtree it also manages, and that warning is
    ;; about the declaration rather than about the prop spelling.

--- a/spec/conformance/freehand/fixtures/fh-struct-009.edn
+++ b/spec/conformance/freehand/fixtures/fh-struct-009.edn
@@ -43,6 +43,8 @@
   {:note "and so is the SVG viewBox"                              :attr :view-box         :prop "viewBox"}
   {:note "a lowercase data-* passes verbatim — a mixed-case data-* is REFUSED, not projected (Spec 004B §Attribute names, ruled option c; see :rejected)"
    :attr :data-priority :prop "data-priority"}
+  {:note "and so does the hyphenated REPAIR the refusal's diagnostic teaches"
+   :attr :data-foo-bar  :prop "data-foo-bar"}
   {:note "aria-* passes verbatim too"                             :attr :aria-hidden      :prop "aria-hidden"}
   {:note "an unrecognized name passes verbatim — React 16+ pass-through" :attr :my-thing   :prop "my-thing"}]
 
@@ -60,13 +62,27 @@
           :children [{:tag :rect :ns :svg :attrs {:stroke-width "2"}}]
           :rf.ui/tree-version 1}}]
 
- ;; Read off `document`, after a real react-dom/client mount of :view.
+ ;; Read off `document`, after a real react-dom/client mount of :view. A row
+ ;; may also carry `:dataset`, read off `element.dataset` — the platform's own
+ ;; projection of a `data-*` attribute name, which is a different observable
+ ;; from the attribute and the one a `data-*` author actually reads.
  :dom
  [{:note "tabIndex reaches the DOM as tabindex"
    :selector "#props" :attrs {"tabindex" "3"}}
 
   {:note "a data-* name passes verbatim"
    :selector "#props" :attrs {"data-priority" "high"}}
+
+  ;; The mounted REPAIR. Refusing `:data-fooBar` is only a repair if the
+  ;; spelling the diagnostic sends the author to is lossless in the DOM, and
+  ;; that is a claim about a mounted element rather than about a tree: the
+  ;; hyphenated name survives as the attribute AND the platform reads the word
+  ;; boundary back as `dataset.fooBar` — the very segmentation the mixed-case
+  ;; spelling loses (its `.dataset` entry is absent, and a silent lowercasing
+  ;; would have keyed off the unsegmented `foobar`). Mounted through Freehand,
+  ;; so the repair is proven on the substrate's own path (rf2-hl7hr).
+  {:note "the REPAIR mounts losslessly: :data-foo-bar reaches the DOM verbatim and reads back as element.dataset.fooBar"
+   :selector "#props" :attrs {"data-foo-bar" "kept"} :dataset {"fooBar" "kept"}}
 
   {:note "contentEditable is a booleanish attribute React writes as a string"
    :selector "#ce" :attrs {"contenteditable" "true"}}
@@ -214,7 +230,8 @@
   ;; casing cannot mean what it says on any host surface. Per the same
   ;; emitted-name law as the rows above, all four spellings are refused alike —
   ;; the diagnostic teaches the one-keystroke fix (write :data-foo-bar, read
-  ;; element.dataset.fooBar).
+  ;; element.dataset.fooBar), which the `:dom` table mounts and reads back
+  ;; rather than merely naming.
   {:note "a camelCase data-* name is refused — the HTML DOM cannot store the casing"
    :form [:div {:data-fooBar "x"}] :error-id :rf.error/ui-tree-malformed}
   {:note "a namespace does not escape it — the refusal reads the emitted name"


### PR DESCRIPTION
The mixed-case `data-*` refusal shipped in #6876. Its two evidence obligations
did not, and this PR discharges them. Test and fixture only — no runtime, no
policy, no spec prose, no new harness.

## 1. The repair is mounted, not merely promised

The refusal's diagnostic tells an author to write `:data-foo-bar` and read it
back as `element.dataset.fooBar`. That spelling was accepted structurally and
by the compiler, but the mounted FH-STRUCT-009 props-page still carried only
`:data-priority`, so the DOM half of the promise had never been observed.

- `tree_views.cljc` / `compiled_views.cljc` — the props-page (both twins) now
  mounts `:data-foo-bar "kept"`.
- `fh-struct-009.edn` — a `:dom` row pins the attribute **and** a new
  `:dataset` read-back; the projection table gains the repair's row.
- `check-row!` learns to read `element.dataset`. That is a *different*
  observable from `getAttribute`: an attribute can be present while its
  dataset entry is absent, which is exactly what a mixed-case `data-*` does.
  The mounted test asserts the DOM table actually carries a `:dataset` row, so
  a fixture edit that dropped it cannot leave `check-row!` skipping silently.

Incidental, as the bead asked: the props-page docstring no longer describes a
page that isn't there.

## 2. The SSR serialise-then-parse divergence is pinned

The browser probe only mounted. The ruling is premised on serialise-then-parse
lowercasing a `data-*` name in **every** namespace, which no test reached.

`ssr-serialise-then-parse-lowercases-in-every-namespace` server-renders fresh
mixed-case names through `react-dom/server`, asserts the markup carries the
authored spelling **verbatim**, parses it with the real HTML parser
(`DOMParser`, `text/html` — foreign-content rules and all), and compares the
parsed DOM against a client mount of the **identical props**:

| namespace | client mount | SSR parse | verdict |
|---|---|---|---|
| HTML | lowercased | lowercased | agree |
| SVG | **preserved** | lowercased | **diverge** |
| MathML | **preserved** | lowercased | **diverge** |

The HTML row is the contrast that makes the claim namespace-specific rather
than a general observation about parsing. Each parsed node's `namespaceURI` is
asserted, so "lowercased in every namespace" is not secretly a claim about
three HTML elements.

## How the pins were proven to go RED on known-bad input

React latches `warnedProperties[name] = true` once per prop name per browser
session, so a mounted assertion can pass vacuously. Every probed name here is
freshly `gensym`'d per assertion, and the existing `:react-warning-control` /
fresh-name control (obligation 1) already proves the console detector reds.

For the two NEW pins, a deliberate known-bad run was executed and its failures
read off the browser console. Both mutations were then reverted; the green run
below is the unmutated tree.

- **Mounted repair** — props-page mutated from `:data-foo-bar` to
  `:data-foobar`: the *unsegmented* name a silent lowercasing of
  `:data-fooBar` would produce (option (b)'s outcome, which the ruling
  rejects). Both halves of the row went red:
  - `… — data-foo-bar` → `(not (= "kept" nil))`
  - `… — element.dataset.fooBar` → `(not (= "kept" nil))`
- **SSR probe** — the SVG name swapped for an already-lowercase spelling, so
  nothing is left to lose:
  - `SSR/client SVG: and the authored spelling is gone from the parsed DOM` →
    `(not (not true))`
  - `SSR/client SVG: so client and SSR carry DIFFERENT attribute names …` →
    `(not (not= #{"id" "data-cdxprobe8830"} #{"id" "data-cdxprobe8830"}))`

That second mutation is the one that matters: it proves the probe is measuring
the **casing**, not an incidental difference between two DOM trees.

Run: `4 failures, 0 errors` — exactly the four assertions above, nothing else.

## Quality gates

All run in the foreground to completion, from the worker worktree.

| gate | command | result | exit |
|---|---|---|---|
| Freehand JVM | `cd implementation/freehand && clojure -M:test` | Ran 924 tests / 6641 assertions — **0 failures, 0 errors** | 0 |
| Freehand node (focused) | `cd implementation && npm run test:freehand` | Ran 1008 tests / 5757 assertions — **0 failures, 0 errors** | 0 |
| CLJS node integration | `cd implementation && npm run test:cljs` | Ran 11147 tests / 55936 assertions — **0 failures, 0 errors** | 0 |
| Browser lane (carries FH-STRUCT-009 + the SSR probe) | `cd implementation && npm run test:browser` | Ran 758 tests / 4753 assertions — **0 failures, 0 errors** | 0 |
| Red-proof (deliberate known-bad, reverted) | `npm run test:browser` | **4 failures, 0 errors** — exactly the four new assertions | 1 |

The SSR evidence rides the browser lane by construction: `react-dom/server`
resolves to `server.browser.js` there, so the serialise and the parse happen in
the same Chromium as the client mount they are compared against.

Two flakes were observed and cleared by an unchanged re-run, neither related to
this diff: a cold-start `page.goto` 30s timeout on the first compile, and the
Playwright `requestGC` handshake in the evidence-GC tests (`2 failures`,
green on immediate re-run with no edit).

Closes rf2-hl7hr.
