### PR TITLE
fix(bench): make B2/B5 evidence citable — build-revision injection + browser bench lane (rf2-drpa3.147)

### DIFF
--- a/.github/workflows/freehand-bench.yml
+++ b/.github/workflows/freehand-bench.yml
@@ -40,17 +40,27 @@ name: freehand bench
 # as a duplicate of the PR gate but because a harness whose gate direction
 # has rotted would otherwise publish evidence nobody should trust.
 #
-# TWO LANES, ONE HARNESS. `clojure -M:bench` is a JVM process and reaches
+# THREE LANES, ONE HARNESS. `clojure -M:bench` is a JVM process and reaches
 # every `.cljc` workload; the React arm measures the interpreted React
-# emitter, which is ClojureScript-only. So there is a second job below
-# running the same registry, the same provenance record and the same
-# gate/evidence split through a Node entry
-# (`re-frame.freehand.bench.node`), and uploading its EDN beside the JVM
-# one. Two artefacts because they are two hosts — a result record names
-# its own `:host` and `:build`, and pooling a V8 `:none` number with a
-# JIT-warmed JVM one would be the pooling D021 forbids — but ONE harness,
-# because a second report shape is a second place a threshold could be
-# added.
+# emitter, which is ClojureScript-only; and B2's mounted storm, B4's latency
+# row and B5's initial-mount reading only exist in a real browser. So there
+# are three jobs below running the same registry, the same provenance record
+# and the same gate/evidence split, each uploading its own artefact. Three
+# artefacts because they are three hosts — a result record names its own
+# `:host` and `:build`, and pooling a Chromium number with a V8 `:none` one
+# or a JIT-warmed JVM one would be the pooling D021 forbids — but ONE
+# harness, because a second report shape is a second place a threshold could
+# be added.
+#
+# THE REVISION. A browser has no environment and no git, so a mounted
+# workload can only learn the revision it was compiled from at BUILD time,
+# through the closure-define `re-frame.freehand.bench.provenance` documents.
+# The browser lane's build reads it from `RF2_REVISION` via `#shadow/env`
+# and this workflow sets that to `github.sha`. Without it every record the
+# mount publishes prints NOT CITABLE and is worth reading but not citing —
+# which is why the lane asserts on the WORD, not on any number: a lane that
+# publishes unattributable evidence has failed at its one job, while a
+# distribution that moved has not.
 
 on:
   schedule:
@@ -189,5 +199,137 @@ jobs:
         with:
           name: freehand-bench-node-${{ github.sha }}
           path: implementation/out/freehand-bench-node.edn
+          if-no-files-found: error
+          retention-days: 90
+
+  # The BROWSER half of the same suite (rf2-drpa3.147, rf2-drpa3.52). See
+  # THREE LANES, ONE HARNESS and THE REVISION above: this job adds a host and
+  # the revision that host cannot otherwise learn.
+  #
+  # B2's mounted storm, B4's contended-latency row and B5's initial-mount
+  # reading each mount real components over `react-dom/client` and publish a
+  # result record from inside the page. Neither lane above runs them: a JVM
+  # has no DOM and Node has no browser, so before this job existed the three
+  # rows were asserted on every PR and their evidence was never captured
+  # anywhere.
+  #
+  # THE ARTEFACT IS THE CONSOLE. A browser has no stdout, so the records are
+  # published to the console as EDN (`;;`-prefixed headers, exactly the
+  # comment convention the other two lanes' stdout artefacts use). The
+  # Playwright runner buffers every console line and flushes it under
+  # RF2_VERBOSE_TESTS=1, so the lane asks for the trail and keeps it verbatim
+  # — the artefact and the thing a reviewer reads are the same bytes.
+  browser-evidence:
+    name: Freehand B-spine evidence — browser lane (pinned worker)
+    # PINNED for the same reason the other two lanes are. See THE PIN above.
+    runs-on: ubuntu-24.04
+    timeout-minutes: 40
+    defaults:
+      run:
+        working-directory: implementation
+    env:
+      # The same configured class as the sibling lanes; the HOST difference
+      # stays visible in each record's `:host`, where it belongs.
+      RF2_HARDWARE_CLASS: release-worker
+      # What makes a mounted record CITABLE. Read at compile time by the
+      # :browser-test-freehand-bench build's `#shadow/env`, baked into the
+      # bundle as the provenance namespace's `build-revision` define, and
+      # answered by `detect-revision` in a page that has no git and no
+      # environment of its own.
+      RF2_REVISION: ${{ github.sha }}
+      # The runner buffers the browser console and flushes it only on failure
+      # or under this flag. Here the console IS the evidence, so it is always
+      # wanted.
+      RF2_VERBOSE_TESTS: '1'
+      # The default 120s covers a normal DOM suite; this page mounts B2's
+      # storm at two scales through four arms, B4's contended row and B5's
+      # sampled mounts, so it is given room rather than raced.
+      BROWSER_TEST_TIMEOUT_MS: '300000'
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: '24'
+          cache: npm
+          cache-dependency-path: implementation/package-lock.json
+
+      - name: Cache Maven / gitlibs (shadow-cljs deps)
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gitlibs
+          key: ${{ runner.os }}-cljs-${{ hashFiles('implementation/shadow-cljs.edn', 'implementation/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-cljs-
+
+      - name: npm install
+        run: npm ci
+
+      # Keyed on the locked Playwright version, so a Playwright bump busts it
+      # — the same cache the PR-time browser gates use.
+      - name: Cache Playwright browser binary
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('implementation/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
+      - name: Install Playwright (Chromium + system deps)
+        run: npx playwright install --with-deps chromium
+
+      # The buffered console arrives on stderr; stdout carries the runner's
+      # one-line summary. The log is kept whatever the exit code, so a red
+      # run's trail is still uploaded, and the runner's own status is what
+      # this step exits with.
+      - name: Mount the browser workloads and capture the published records
+        run: |
+          mkdir -p out
+          status=0
+          npm run bench:freehand-browser 2> out/freehand-bench-browser.log || status=$?
+          cat out/freehand-bench-browser.log
+          exit $status
+
+      # The one thing this lane is allowed to fail on, and it is not a
+      # number. D021 forbids an automatic numeric pass/fail, and nothing here
+      # asserts a millisecond or a byte. What it asserts is PROVENANCE: a
+      # record that cannot name its revision is not evidence anyone may cite,
+      # so a lane that published only unattributable records did not do its
+      # job — most likely because RF2_REVISION never reached the compile.
+      - name: Refuse to publish unattributable evidence
+        run: |
+          log=out/freehand-bench-browser.log
+          if grep -q 'NOT CITABLE' "$log"; then
+            echo "This lane published unattributable evidence:" >&2
+            grep -n 'NOT CITABLE' "$log" >&2
+            echo "RF2_REVISION was '${RF2_REVISION}'. It is read at COMPILE time by" >&2
+            echo "the :browser-test-freehand-bench build and reaches the page as the" >&2
+            echo "provenance namespace's build-revision define." >&2
+            exit 1
+          fi
+          citable=$(grep -c 'citable$' "$log" || true)
+          if [ "$citable" -eq 0 ]; then
+            echo "This lane published no result records at all — the workloads" >&2
+            echo "either did not run or stopped publishing. An empty evidence" >&2
+            echo "artefact is worse than a red one, because it looks green." >&2
+            exit 1
+          fi
+          echo "Published $citable citable result record(s) at ${RF2_REVISION}."
+
+      - name: Upload the browser result records
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: freehand-bench-browser-${{ github.sha }}
+          path: implementation/out/freehand-bench-browser.log
           if-no-files-found: error
           retention-days: 90

--- a/implementation/freehand/src/re_frame/freehand/bench/provenance.cljc
+++ b/implementation/freehand/src/re_frame/freehand/bench/provenance.cljc
@@ -76,6 +76,12 @@
    ;;
    ;;   :closure-defines {re-frame.freehand.bench.provenance/build-revision "<sha>"}
    ;;
+   ;; The `:browser-test-freehand-bench` build in implementation/shadow-cljs.edn
+   ;; is the one that does — reading the sha from `RF2_REVISION` through
+   ;; `#shadow/env` rather than holding a literal, so the define says which
+   ;; commit the bundle was compiled from and not which commit someone last
+   ;; edited the config on.
+   ;;
    ;; Left empty, a browser run cannot emit a result record — which is the
    ;; correct outcome, not an inconvenience: an unattributable bundle
    ;; measurement is a number about nothing.

--- a/implementation/freehand/test/re_frame/freehand/bench/b2_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b2_dom_cljs_test.cljs
@@ -53,17 +53,23 @@
   A browser has no environment and no git. `re-frame.freehand.bench.provenance`
   says what to do about that: a bundle that is going to be measured names
   its revision at compile time through the documented closure-define, and
-  a bundle that does not cannot emit a citable record. This test build
-  does not set it, so the record published below is complete in every
-  field EXCEPT the revision — which is gated, so a record that lost its
-  fixture scale, build mode or host would red. A release-lane run sets
-  the define and the record becomes emittable with no change here.
+  a bundle that does not cannot emit a citable record. The default
+  `:browser-test` build — the per-PR correctness gate — sets none, so a
+  record published under it is complete in every field EXCEPT the revision.
+  Every other field is gated either way, so a record that quietly lost its
+  fixture scale, build mode or host reds under both builds.
+
+  The EVIDENCE lane sets it. `:browser-test-freehand-bench` reads the sha
+  from `RF2_REVISION` through `#shadow/env` and compiles it in, so the code
+  below publishes a citable record with no change here — which is the whole
+  reason that define exists rather than a literal.
 
   The records go to the browser console as EDN, which the browser runner
   buffers and flushes on failure or under `RF2_VERBOSE_TESTS=1`. A run
   that wants the evidence therefore asks for it:
 
-      RF2_VERBOSE_TESTS=1 npm run test:browser
+      RF2_REVISION=$(git rev-parse HEAD) RF2_VERBOSE_TESTS=1 \\
+        npm run bench:freehand-browser
 
   Normative owner: `docs/design/freehand/decisions/`
   `D021-performance-budgets-and-release-evidence.md`."
@@ -353,10 +359,10 @@
   A citable record goes through `provenance/result` — the ONE documented
   emission door — so the same validation that governs the JVM lane governs
   a browser record too, rather than a bypass that console-logs whatever it
-  was handed. A record missing only its revision (this build compiles none
-  in) is printed as NOT CITABLE without forcing it through the door, which
-  would throw; a release-lane build that sets the revision closure-define
-  makes it citable with no change here."
+  was handed. A record missing only its revision (a build that compiles
+  none in) is printed as NOT CITABLE without forcing it through the door,
+  which would throw; the evidence lane's build sets the revision
+  closure-define and the very same call becomes citable."
   [record]
   (let [ds (prov/defects record)]
     (if (seq ds)
@@ -476,19 +482,29 @@
     (is (zero? (b2/omitted (b2/plan b2i/free-views stress-scale)))
         "and an interpreted plan predicts no omissions at all")))
 
-(deftest the-published-record-names-everything-but-the-revision
+(deftest the-published-record-names-every-field-its-build-can
   (testing "The published evidence is gated on its PROVENANCE, which is
             the one thing about a number that is deterministic. Every
             field D021 requires must be named — fixture scale, build
             mode, runtime, hardware class, sampling policy, baseline,
             distribution — and only the revision may be missing, because
-            a browser has no git and this test build does not compile one
-            in. A record that quietly lost its scale or its build mode
-            would red here."
+            a browser has no git and only a build that compiles one in can
+            name one. A record that quietly lost its scale or its build
+            mode would red here.
+
+            The second assertion is the citability claim itself, and it
+            fires only under a build that named a revision: given one,
+            the record must survive `provenance/result` — the one
+            emission door — unchanged. Under the plain `:browser-test`
+            gate there is no revision to have, and the claim is correctly
+            not made rather than faked."
     (let [census {:omitted-shell-occurrences 8 :retained-shell-occurrences 0}
           record (evidence-record (first arms) small-scale census [2 2 2 2] [1.0 2.0 3.0])]
       (is (empty? (remove #(= [:revision] (:path %)) (prov/defects record)))
           "every provenance field a browser can name is named")
+      (when (prov/detect-revision)
+        (is (= record (prov/result record))
+            "and a build that names the revision publishes a CITABLE record"))
       (is (= 3 (:n (:B2/mount-ms (:distribution record))))
           "the distribution summarises the samples it was given")
       (is (= :duration-ms (:observable (:B2/mount-ms (:distribution record))))

--- a/implementation/freehand/test/re_frame/freehand/bench/b5_bundle_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b5_bundle_cljs_test.cljs
@@ -178,6 +178,26 @@
       (js/console.log (str ";; B5 shipped-cost evidence — citable\n"
                            (pr-str (prov/result record)))))))
 
+(defn- unattributable!
+  "Report the byte facts of an artefact this run cannot attribute to a
+  revision, and build NO result record for it.
+
+  A run with no `RF2_REVISION`, no `GITHUB_SHA` and no compiled-in
+  `build-revision` genuinely does not know which commit produced the bundle
+  on disk. The provenance door promises no default that invents a field the
+  run did not observe, so there is no revision to substitute — not a
+  placeholder, not the string `unattributed-local-build`, which reads as a
+  named revision to `defects` and quietly turns an unattributable
+  measurement into a citable-looking one. The bytes are still a true fact
+  about a file and are printed as exactly that, under a header that says
+  they are not evidence anyone may cite."
+  [measured]
+  (js/console.log
+    (str ";; B5 shipped-cost — NOT CITABLE (this run cannot name the source revision; "
+         "set RF2_REVISION, or run in CI). Byte facts only: no result record was built, "
+         "because a record must name the revision its artefact was compiled from.\n"
+         (pr-str (dissoc measured :source)))))
+
 (deftest the-release-bundle-is-measured-when-it-has-been-built
   (testing "The real artefact's shipped cost, measured off
             out/freehand-release/main.js when it is on disk. The encodings
@@ -190,28 +210,30 @@
       (is true (str "no release bundle on disk — run `npm run build:freehand-release` first; "
                     "skipping the real-artefact measurement"))
       (let [measured (b5/measure-bundle b5/default-bundle-path)
-            w        (b5/workload {:id       :B5/freehand-release
-                                   :doc      "the shipped Freehand release bundle"
-                                   :sampling sampling}
-                                  measured)
-            record   (bench/run-workload w (assoc fixture-provenance
-                                                  :revision (or (prov/detect-revision)
-                                                                "unattributed-local-build")))]
+            revision (prov/detect-revision)]
         (is (< (:gzip6-bytes measured) (:raw-bytes measured))
             "the shipped bundle compresses under gzip")
         (is (<= (:brotli-bytes measured) (:gzip9-bytes measured))
             "and brotli is at least as small as maximum gzip")
         (is (= 64 (count (:sha256 measured))) "the artefact has a digest")
-        (is (empty? (:gate-failures record)) "the measurement reds nothing — it is all evidence")
-        (is (= :advanced (get-in record [:build :optimizations]))
-            "the record describes the advanced artefact")
-        ;; Method correctness, NOT a performance budget: a genuine cold parse
-        ;; of a multi-hundred-KB bundle is milliseconds; a V8 compilation-cache
-        ;; HIT is microseconds. This loose floor sits ~an order of magnitude
-        ;; below the real reading and ~25x above a cache hit, so it reds only
-        ;; if the nonce that defeats the cache were removed and the figure
-        ;; collapsed to a lookup — the exact regression the audit named. It
-        ;; does not, and cannot, red a release for being slow.
-        (is (> (get-in record [:distribution :B5/parse-compile-ms :p50]) 1.0)
-            "parse/compile is a real cold compile, not a compilation-cache lookup")
-        (publish! record)))))
+        (if-not revision
+          (unattributable! measured)
+          (let [w      (b5/workload {:id       :B5/freehand-release
+                                     :doc      "the shipped Freehand release bundle"
+                                     :sampling sampling}
+                                    measured)
+                record (bench/run-workload w (assoc fixture-provenance :revision revision))]
+            (is (empty? (:gate-failures record))
+                "the measurement reds nothing — it is all evidence")
+            (is (= :advanced (get-in record [:build :optimizations]))
+                "the record describes the advanced artefact")
+            ;; Method correctness, NOT a performance budget: a genuine cold parse
+            ;; of a multi-hundred-KB bundle is milliseconds; a V8 compilation-cache
+            ;; HIT is microseconds. This loose floor sits ~an order of magnitude
+            ;; below the real reading and ~25x above a cache hit, so it reds only
+            ;; if the nonce that defeats the cache were removed and the figure
+            ;; collapsed to a lookup — the exact regression the audit named. It
+            ;; does not, and cannot, red a release for being slow.
+            (is (> (get-in record [:distribution :B5/parse-compile-ms :p50]) 1.0)
+                "parse/compile is a real cold compile, not a compilation-cache lookup")
+            (publish! record)))))))

--- a/implementation/freehand/test/re_frame/freehand/bench/b5_matched_builds_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b5_matched_builds_cljs_test.cljs
@@ -129,17 +129,28 @@
            "\n" (pr-str (if (seq ds) record (prov/result record)))))))
 
 (defn- measure-and-record
-  "Measure one shape's bundle and run it through the SAME B5 workload the
-  mixed lane uses, answering the measured map and the harness record."
+  "Measure one shape's bundle and, when this run can name the revision it
+  was built from, run it through the SAME B5 workload the mixed lane uses.
+
+  `revision` may be nil — a local run with no `RF2_REVISION` and no
+  `GITHUB_SHA` genuinely does not know which commit produced the bundles on
+  disk. No record is built in that case and none is faked: the provenance
+  door promises no default that invents a field the run did not observe, and
+  a placeholder string reads to `defects` as a named revision, which is
+  precisely how an unattributable measurement comes to look citable. The
+  bytes are true about the files either way, so they are always answered."
   [shape-key path revision]
-  (let [measured (b5/measure-bundle path)
-        w        (b5/workload {:id       (keyword "B5" (str "freehand-release-" (name shape-key)))
-                               :doc      (str "the " (name shape-key)
-                                              "-shape Freehand release bundle")
-                               :sampling sampling}
-                              measured)
-        record   (bench/run-workload w (assoc fixture-provenance :revision revision))]
-    {:measured measured :record record}))
+  (let [measured (b5/measure-bundle path)]
+    (cond-> {:measured measured}
+      revision
+      (assoc :record
+             (bench/run-workload
+               (b5/workload {:id       (keyword "B5" (str "freehand-release-" (name shape-key)))
+                             :doc      (str "the " (name shape-key)
+                                            "-shape Freehand release bundle")
+                             :sampling sampling}
+                            measured)
+               (assoc fixture-provenance :revision revision))))))
 
 (deftest the-three-shapes-and-their-delta-are-measured-when-built
   (testing "The matched build lane's real reading, published when the three
@@ -157,7 +168,7 @@
                       "freehand-release-interpreted, freehand-release and "
                       "freehand-release-compiled first; skipping the matched "
                       "build-lane measurement (present: " (keys present) ")"))
-        (let [revision (or (prov/detect-revision) "unattributed-local-build")
+        (let [revision (prov/detect-revision)
               results  (into {}
                              (map (fn [[k p]] [k (measure-and-record k p revision)]))
                              b5/matched-bundle-paths)
@@ -165,16 +176,19 @@
               compiled (get-in results [:compiled :measured])
               mixed    (get-in results [:mixed :measured])
               delta    (b5/promotion-delta interp compiled)]
-          ;; Every shape's own readings are honest facts about its file.
+          ;; Every shape's own readings are honest facts about its file. The
+          ;; RECORD claims are made only when the run could name a revision;
+          ;; without one there is nothing to publish and nothing is invented.
           (doseq [[k {:keys [measured record]}] results]
             (is (< (:gzip6-bytes measured) (:raw-bytes measured))
                 (str (name k) " shape compresses under gzip"))
             (is (= 64 (count (:sha256 measured))) (str (name k) " shape has a digest"))
-            (is (empty? (:gate-failures record))
-                (str (name k) " shape reds nothing — it is all evidence"))
-            (is (= :advanced (get-in record [:build :optimizations]))
-                (str (name k) " shape is an advanced artefact"))
-            (publish! (str "B5 matched shape — " (name k)) record))
+            (when record
+              (is (empty? (:gate-failures record))
+                  (str (name k) " shape reds nothing — it is all evidence"))
+              (is (= :advanced (get-in record [:build :optimizations]))
+                  (str (name k) " shape is an advanced artefact"))
+              (publish! (str "B5 matched shape — " (name k)) record)))
           ;; The three digests are distinct: three different bundles.
           (is (= 3 (count (set (map (comp :sha256 :measured val) results))))
               "the three shapes are three distinct artefacts")
@@ -187,7 +201,12 @@
           (is (= (:sha256 compiled) (:compiled-sha256 delta))
               "and to the compiled bundle")
           (js/console.log
-            (str ";; B5 per-promotion byte delta (compiled minus interpreted) — evidence, no threshold\n"
+            (str ";; B5 per-promotion byte delta (compiled minus interpreted) — "
+                 (if revision
+                   "evidence, no threshold"
+                   (str "NOT CITABLE (this run cannot name the source revision; set "
+                        "RF2_REVISION, or run in CI)"))
+                 "\n"
                  (pr-str {:revision      revision
                           :interpreted   {:raw    (:raw-bytes interp)
                                           :gzip6  (:gzip6-bytes interp)

--- a/implementation/freehand/test/re_frame/freehand/bench/b5_mount_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b5_mount_dom_cljs_test.cljs
@@ -30,9 +30,20 @@
   non-vacuity: the shape actually mounted, both tiers reached the DOM, and
   the timer moved.
 
+  ## Citable there, readable here
+
+  A browser has no environment and no git, so the revision a record must
+  name can only be compiled in — `re-frame.freehand.bench.provenance`'s
+  `build-revision` define. The per-PR `:browser-test` gate sets none and the
+  record it publishes is honestly marked NOT CITABLE; the evidence lane's
+  `:browser-test-freehand-bench` build reads the sha from `RF2_REVISION` and
+  the same record becomes citable, validated through `provenance/result`
+  with no change here.
+
   Node has no browser to mount into, so under the node lane this SKIPS
   cleanly on `(browser?)` — the same posture the other `*-dom` benches keep.
-  It runs for real under `npm run test:browser`.
+  It runs for real under `npm run test:browser`, and for the record under
+  `npm run bench:freehand-browser`.
 
   Normative owner: `docs/design/freehand/decisions/`
   `D021-performance-budgets-and-release-evidence.md`."
@@ -161,14 +172,24 @@
     (.remove (:container arm)))
   nil)
 
-(defn- publish! [record]
+(defn- publish!
+  "Write the record to the console as EDN, prefixed with whether it is
+  citable.
+
+  A citable record goes through `provenance/result` — the ONE documented
+  emission door — so a browser record is validated by exactly what validates
+  a JVM one, rather than by a bypass that logs whatever it was handed. An
+  unattributable one (a build that compiled no revision in) is printed as it
+  stands rather than forced through the door, which would throw; it is still
+  worth reading and is not worth citing, and the line says which."
+  [record]
   (let [ds (prov/defects record)]
     (js/console.log
       (str ";; B5 initial-mount evidence — "
            (if (seq ds)
-             (str "NOT CITABLE (" (count ds) " provenance field(s) unnamed by this run)")
+             (str "NOT CITABLE (" (count ds) " provenance field(s) unnamed by this build)")
              "citable")
-           "\n" (pr-str record)))))
+           "\n" (pr-str (if (seq ds) record (prov/result record)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The reading

--- a/implementation/package.json
+++ b/implementation/package.json
@@ -25,6 +25,7 @@
   "scripts": {
     "dev": "node scripts/dev-testbed.cjs",
     "bench:freehand-node": "shadow-cljs compile freehand-bench-node >&2 && node out/freehand-bench-node.js",
+    "bench:freehand-browser": "shadow-cljs compile browser-test-freehand-bench && node scripts/serve-and-run-browser-tests.cjs --root out/browser-test-freehand-bench --port 8024",
     "test:cljs": "shadow-cljs compile node-test && node out/node-test.js",
     "test:cljs-isolation": "shadow-cljs compile node-test && node scripts/check-per-ns-isolation.cjs",
     "test:security": "shadow-cljs compile node-test-security && node out/node-test-security.js",

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -1149,6 +1149,55 @@
    :devtools  {:http-port 8023
                :http-root "out/browser-test-prod-elision"}}
 
+  ;; rf2-drpa3.147 / rf2-drpa3.52 — the Freehand B-spine's BROWSER evidence
+  ;; lane, and the only build in the repo that names the revision its bundle
+  ;; was compiled from.
+  ;;
+  ;; WHY A BUILD AT ALL. B2's mounted storm, B4's latency row and B5's
+  ;; initial-mount reading publish their result records from inside a real
+  ;; browser, and `re-frame.freehand.bench.provenance` refuses to call any
+  ;; record citable that cannot name the revision it was built from. A
+  ;; browser has no environment and no git, so the revision can only arrive
+  ;; at COMPILE time, through the closure-define the provenance namespace
+  ;; documents. The default `:browser-test` build sets none — deliberately:
+  ;; it is the per-PR correctness gate, its bundle is cached across runs,
+  ;; and baking a per-commit constant into it would bust that cache on every
+  ;; push to buy evidence nobody captures. So the evidence lane gets its own
+  ;; build, and the PR gate is left alone.
+  ;;
+  ;; THE REVISION IS READ, NEVER WRITTEN. `#shadow/env` — the same mechanism
+  ;; the testbed builds use for `checkout-root` — reads `RF2_REVISION` from
+  ;; the environment the compile runs in (the workflow sets it to
+  ;; `github.sha`; a local run exports its own `git rev-parse HEAD`). Its
+  ;; default is the EMPTY STRING, which `detect-revision` reads as "this
+  ;; build cannot name one" and which makes every record it publishes print
+  ;; NOT CITABLE. That is the honest degrade the provenance door exists for:
+  ;; an unset environment produces an unattributable record, never an
+  ;; invented revision.
+  ;;
+  ;; The ns-regexp selects the bench's own DOM suites and nothing else, so
+  ;; the captured console is the evidence rather than a 757-test transcript
+  ;; to sift. Those same namespaces still run under the broader
+  ;; `:browser-test` gate on every PR — this build adds a revision, not a
+  ;; second copy of the coverage.
+  ;;
+  ;; Run by `npm run bench:freehand-browser`; the workflow's browser lane
+  ;; captures its console and uploads it beside the JVM and Node artefacts.
+  :browser-test-freehand-bench
+  {:target    :browser-test
+   :ns-regexp "^re-frame\\.freehand\\.bench\\..+-dom-cljs-test$"
+   :test-dir  "out/browser-test-freehand-bench"
+   :runner-ns shadow.test.browser
+   ;; cljs-test-display.core/printing for the same reason :browser-test sets
+   ;; it — without it the "Ran N tests" summary never reaches the console the
+   ;; Playwright runner watches, and a green suite presents as a hang.
+   :compiler-options
+   {:closure-defines
+    {cljs-test-display.core/printing                   true
+     re-frame.freehand.bench.provenance/build-revision #shadow/env ["RF2_REVISION" ""]}}
+   :devtools  {:http-port 8024
+               :http-root "out/browser-test-freehand-bench"}}
+
   ;; Production-elision probe (Spec 009 §Production builds, bead rf2-11hn).
   ;;
   ;; Compiles re-frame.elision-probe under :advanced with goog.DEBUG=false.


### PR DESCRIPTION
Beads: rf2-drpa3.147, rf2-drpa3.52, rf2-x4jda (partial — see *What this does not close*).

## The defect

A browser has no environment and no git, so the revision a Freehand bench record must
name can only arrive at **compile** time — through the `build-revision` closure-define
`re-frame.freehand.bench.provenance` documents. Nothing anywhere set it. Every record
B2's mounted storm, B4's contended-latency row and B5's initial-mount reading published
therefore printed:

```
;; B2 mounted-storm evidence — NOT CITABLE (1 provenance field(s) unnamed by this build)
```

and no lane captured them anyway: `freehand-bench.yml` had a JVM job and a Node job, no
browser job, and no B2/B5 artefact. The two node-lane B5 tests had the mirror-image
fault — rather than degrade honestly they substituted the string
`unattributed-local-build` for a revision the run never observed, which `prov/defects`
reads as a *named* revision, so an unattributable measurement printed as citable and
passed through `prov/result`.

## What lands

- **`:browser-test-freehand-bench`** — the bench DOM suites compiled with the revision
  read from `RF2_REVISION` through `#shadow/env`, the same mechanism the testbed builds
  use for `checkout-root`. Its default is the empty string, which `detect-revision`
  reads as "this build cannot name one": an unset environment yields an unattributable
  record, never an invented revision. The per-PR `:browser-test` gate is deliberately
  left alone — baking a per-commit constant into it would bust its compile cache on
  every push to buy evidence nobody captures.
- **`npm run bench:freehand-browser`** drives it, and a third `freehand-bench.yml` job
  captures the published console and uploads it beside the two EDN artefacts. A browser
  has no stdout, so the console *is* the artefact — `;;`-prefixed headers, the same
  comment convention the sibling lanes' stdout artefacts use.
- **The lane's one failure condition is provenance, never a number.** D021 forbids an
  automatic numeric pass/fail and nothing here asserts a millisecond or a byte. The lane
  reds if a record printed `NOT CITABLE`, or if no record was published at all — an
  empty evidence artefact is worse than a red one, because it looks green.
- **B5's mount `publish!`** now routes its citable branch through `provenance/result`,
  the one documented emission door, as B2's already did.
- **No invented revisions.** `b5_bundle_cljs_test` and `b5_matched_builds_cljs_test`
  drop `unattributed-local-build`. Without a revision the byte facts — true about the
  files either way — are still reported, under a header that says no result record was
  built and why.

## Before / after

Same code, same page, same suite; the only variable is whether the build named a
revision.

```
# before — npm run bench:freehand-browser, RF2_REVISION unset
NOT CITABLE: 13    citable: 0
;; B2 mounted-storm evidence — NOT CITABLE (1 provenance field(s) unnamed by this build)
;; B4 evidence — NOT CITABLE (1 provenance field(s) unnamed by this build)
;; B5 initial-mount evidence — NOT CITABLE (1 provenance field(s) unnamed by this build)

# after — RF2_REVISION=$(git rev-parse HEAD)
NOT CITABLE: 0     citable: 13
;; B2 mounted-storm evidence — citable
;; B4 evidence — citable
;; B5 initial-mount evidence — citable
:revision "6470659d87f9d142e044b7793a79b324ec126303"
```

The node lane moves the same way: with a revision, all four B5 records
(shipped-cost, and the interpreted/mixed/compiled matched shapes) print citable and
carry the real sha; without one they print `NOT CITABLE` and no record is built. The
string `unattributed-local-build` no longer appears in any output.

## Quality gates

All run locally to completion, foreground, exit code echoed.

| Gate | Result | Exit |
| --- | --- | --- |
| `npm run bench:freehand-browser` (new lane, RF2_REVISION unset) | Ran 14 tests / 225 assertions — 0 failures, 0 errors; 13 records, all NOT CITABLE | 0 |
| `npm run bench:freehand-browser` (new lane, RF2_REVISION set) | Ran 14 tests / 226 assertions — 0 failures, 0 errors; 13 records, all citable | 0 |
| `npm run test:freehand` (node, no bundles) | Ran 1012 tests / 5768 assertions — 0 failures, 0 errors | 0 |
| `npm run test:freehand` (node, 3 release bundles built, no revision) | Ran 1012 tests / 5780 assertions — 0 failures, 0 errors; B5 rows honestly NOT CITABLE | 0 |
| `npm run test:freehand` (node, 3 release bundles built, revision set) | Ran 1012 tests / 5790 assertions — 0 failures, 0 errors; 4 B5 records citable | 0 |
| `clojure -M:test` (implementation/freehand, JVM) | Ran 924 tests / 6641 assertions — 0 failures, 0 errors | 0 |
| `npm run test:script-policy` | all suites passed | 0 |
| `shadow-cljs release freehand-release{,-interpreted,-compiled}` | 3 builds, 0 warnings | 0 |
| `freehand-bench.yml` parse | 3 jobs, browser lane's 10 steps resolve | 0 |

## What this does not close

`rf2-x4jda`'s reopen carries more than the revision defect, and the rest is a fixture
rework rather than plumbing, so it stays **open**. Closed here: the fabricated
non-blank revision at `b5_bundle_cljs_test.cljs:199` and
`b5_matched_builds_cljs_test.cljs:160`, and the "workflow retains no B5 mount record"
half — `b5-mount-dom-cljs-test` now runs and is captured in the browser lane's
artefact. Still open on that bead: the three "matched" release entries are three
namespaces whose keywords, DOM ids and labels drift, so the compiled-minus-interpreted
delta is not attributable to lowering alone; the delta map bypasses `prov/result`; each
twin inherits `measurement-method` prose hard-coded to the mixed bundle's path; the
mount figure is a debug recompilation of a duplicated shape rather than the advanced
artefact; and no lane builds the three bundles and retains the matched-shape records.

Deliberately not built, per the ruling already on rf2-drpa3.147: no ViewCell-liveness
tracker, no heap or allocation framework, no teardown instrumentation, no timing or
memory threshold. The B2 census stays named `-occurrences` — wrapper-classified DOM
occurrences, not retained objects — and retained-object evidence stays open by design.
