### PR TITLE
test(freehand): compiled-mode runtime twin for the buffered controller (rf2-ikpsx)

### DIFF
--- a/implementation/freehand/test/re_frame/freehand/buffered_controller_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/buffered_controller_cljs_test.cljc
@@ -61,8 +61,14 @@
 ;; path: the root below, the record shape and every event id are the
 ;; library's choices.
 
-(def ^:private kind
-  "The buffered controller family."
+(def kind
+  "The buffered controller family.
+
+  PUBLIC because the promoted twin in
+  [[re-frame.freehand.buffered-views-compiled]] addresses the SAME family.
+  A compiled control that restated its own kind would write its own
+  records, and the parity suite would be comparing two independent
+  controllers rather than one control in two modes."
   :my.ui/buffered-field)
 
 (def ^:private disclosure-kind
@@ -72,11 +78,20 @@
   paid by buffered controls alone."
   :my.ui/disclosure)
 
-(def ^:private records-root :my.ui/controllers)
+(def records-root
+  "Where the pilot library keeps its controller records. Public for the
+  same reason [[kind]] is: the parity suite reads the ONE record both
+  execution modes write."
+  :my.ui/controllers)
 
-(defn- register-library!
+(defn register-library!
   "The library's whole dataflow — two reads and four transitions — plus
-  the caller-side events an application writes around it."
+  the caller-side events an application writes around it.
+
+  Public so the parity suite starts from the same registrar these laws
+  do. It knows nothing about execution mode, which is itself part of what
+  promotion parity means: an interpreted control and its compiled twin
+  reach these same registrations."
   []
   ;; --- Reads ---------------------------------------------------------
 

--- a/implementation/freehand/test/re_frame/freehand/buffered_controller_parity_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/buffered_controller_parity_cljs_test.cljc
@@ -1,0 +1,393 @@
+(ns re-frame.freehand.buffered-controller-parity-cljs-test
+  "FH-CTRL-006 … FH-CTRL-010, applicability `common` — the RENDERED half.
+
+  The laws in `buffered-controller-cljs-test` bind BOTH execution modes,
+  and almost nothing about the fence could differ between them:
+  `v/controller-revision` and `v/controller-current?` are ordinary
+  functions, the second of them called from a `reg-sub` no view mode ever
+  sees, and the record is ordinary frame data. What promotion COULD move
+  is the SHAPE the pilot renders — so a JVM row over there already asserts
+  that the compiled tier's own analyzer accepts the control's shape
+  unchanged.
+
+  This suite closes the remaining gap, which is the difference between
+  ACCEPTED and EQUAL. It renders the promoted twin
+  ([[re-frame.freehand.buffered-views-compiled/buffered-field]]) beside the
+  interpreted control and compares what a buffered control actually
+  produces: the value it displays, the three intents it carries
+  (`:on-input`, `:on-blur`, `:on-click`), and the POSITION the generation
+  occupies inside each of them — at the three states the fence
+  distinguishes.
+
+  ## The three states, and why those three
+
+  - **idle** — the caller's baseline, no record. The generation the
+    control renders is the caller's current one.
+  - **drafting** — a live draft, stamped with the generation the render
+    that produced it displayed.
+  - **after a same-value rejection** — the caller refuses the draft and
+    stands by the value it already had. Value-equality is provably blind
+    to this (the two baselines are `=`); the generation is not. It is the
+    case the whole design exists for, so it is the case parity has to
+    cover.
+
+  ## Only the CONTROL is promoted
+
+  The pilot's caller reads `(v/sub [:invoice/amount id])` inside a `for`,
+  which the compiled grammar refuses as `:rf.ui.compile/sub-in-loop` — a
+  read inside a loop is not a finite lexical reactive site. Its catalogued
+  recovery is `[:extract-declared-child :keep-interpreted]`, and the pilot
+  already did the first half: the control IS the extracted declared child.
+  So the compiled arm here is an INTERPRETED caller driving a COMPILED
+  child, which is the composition the grammar is designed to produce. The
+  last row asserts that refusal directly, so the asymmetry is evidence
+  rather than an omission.
+
+  ## Why the render goes through a capture
+
+  Same reason as the laws themselves: `v/sub` is legal only during an
+  active declared render, and the structural surface `t/render` walks a
+  body but is not a host. [[render!]] composes the two — one candidate,
+  one walk, and NO commit — so every assertion here is also a statement
+  that rendering a buffered control in either mode publishes nothing."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [clojure.walk :as walk]
+            #?(:clj [clojure.java.io :as io])
+            #?(:clj [re-frame.freehand.compiler.check :as check])
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.buffered-controller-cljs-test :as pilot]
+            [re-frame.freehand.buffered-views-compiled :as compiled]
+            [re-frame.freehand.cell :as cell]
+            [re-frame.freehand.conformance :as conf]
+            [re-frame.freehand.test :as t]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+;; ---------------------------------------------------------------------------
+;; The compiled arm's caller — the pilot's own, with ONE symbol changed
+;; ---------------------------------------------------------------------------
+
+(v/defview compiled-caller
+  "`buffered-controller-cljs-test/invoice-form`, with one symbol changed:
+  the control it names is the promoted twin. Everything else — the props,
+  the `for`, the `:key`, the two reads — is the caller's own text.
+
+  INTERPRETED, deliberately and permanently. Promoting it is what the
+  compiled grammar refuses (`:rf.ui.compile/sub-in-loop`), and rewriting
+  the caller to satisfy the grammar would change the pilot the interpreted
+  laws render — which is the drift this whole arrangement exists to avoid."
+  [{:keys [ids]}]
+  [:form
+   (for [id ids]
+     [compiled/buffered-field {:key       id
+                               :control   [:invoice id :amount]
+                               :value     (v/sub [:invoice/amount id])
+                               :reset-key (v/sub [:invoice/amount-revision id])
+                               :on-commit [:invoice/amount-committed id]}])])
+
+;; ---------------------------------------------------------------------------
+;; Seams
+;; ---------------------------------------------------------------------------
+
+(def ctrl-007 (conf/fixture :FH-CTRL-007))
+
+(def ^:private fid :rf/default)
+
+(def ^:private interpreted-caller-id
+  :re-frame.freehand.buffered-controller-cljs-test/invoice-form)
+
+(def ^:private interpreted-control-id
+  :re-frame.freehand.buffered-controller-cljs-test/buffered-field)
+
+(defn- seed!  [db] (frame/replace-app-db! fid db))
+(defn- app-db []   (frame/frame-app-db-value fid))
+(defn- send!  [ev] (rf/dispatch-sync ev {:frame fid}))
+
+(defn- record
+  [address] (get-in (app-db) [pilot/records-root [pilot/kind address]]))
+
+(defn- commits [] (get (app-db) :re-frame.freehand.buffered-controller-cljs-test/commits 0))
+
+(defn- render!
+  "One structural render of `form` under cell `cell-id`'s candidate — one
+  walk, and NO commit. `v/sub` needs an active render; nothing is
+  published, because a render owns nothing."
+  [cell-id form]
+  (let [cand (cell/candidate (cell/cell cell-id) fid)]
+    (cell/with-capture cand (fn [] (t/render form)))))
+
+(defn- send-intent!
+  "Dispatch `event`, with `args` filling the projection positions a live
+  payload would. With no args the intent is dispatched exactly as
+  rendered."
+  [event & args]
+  (send! (if (seq args)
+           (into (vec (butlast event)) args)
+           event)))
+
+(defn- generation-at
+  "The POSITION `generation` occupies inside `event`, or nil. Asserted as
+  its own fact because it is what makes a stale intent detectable: a
+  handler reads the generation POSITIONALLY, so two intents that carried
+  the same values in a different order would agree on every equality above
+  and disagree about which argument is the fence."
+  [event generation]
+  (first (keep-indexed (fn [i x] (when (= generation x) i)) event)))
+
+(defn- facts
+  "Everything a buffered control's render publishes, for ONE rendered
+  occurrence: what it displays, the three intents it carries, and where
+  the generation sits inside each."
+  [tree generation]
+  (let [input  (t/find tree #(= :input (:tag %)))
+        button (t/find tree #(= :button (:tag %)))
+        ia     (t/attrs input)
+        ba     (t/attrs button)]
+    {:shown         (:value ia)
+     :on-input      (:on-input ia)
+     :on-blur       (:on-blur ia)
+     :on-click      (:on-click ba)
+     :generation-at {:on-input (generation-at (:on-input ia) generation)
+                     :on-blur  (generation-at (:on-blur ia) generation)
+                     :on-click (generation-at (:on-click ba) generation)}}))
+
+(defn- arms
+  "The two arms rendered at the CURRENT state, as comparable facts: the
+  pilot's own interpreted caller driving its interpreted control, and a
+  caller of the same shape driving the promoted twin."
+  [ids generation]
+  {:interpreted (facts (render! :my.ui/parity-interpreted
+                                [pilot/invoice-form {:ids ids}])
+                       generation)
+   :compiled    (facts (render! :my.ui/parity-compiled
+                                [compiled-caller {:ids ids}])
+                       generation)})
+
+(def ^:private id-substitutions
+  "The interpreted arm's view ids, rewritten onto the compiled arm's. A
+  view id names where a declaration LIVES, and living in another file is
+  the only difference these two have."
+  {interpreted-caller-id  ::compiled-caller
+   interpreted-control-id :re-frame.freehand.buffered-views-compiled/buffered-field})
+
+(defn- as-compiled-ids
+  [tree] (walk/postwalk #(get id-substitutions % %) tree))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter
+                                            :init-fn pilot/register-library!}))
+
+;; ===========================================================================
+;; The parity claim, at the three states the fence distinguishes
+;; ===========================================================================
+
+(deftest the-promoted-control-renders-what-the-interpreted-one-renders
+  (testing "Per FH-CTRL-006…010, applicability `common`: the promoted
+            control displays the same value and carries the same three
+            intents — with the generation at the same POSITION inside each
+            — as the interpreted one, at idle, while drafting, and after
+            the same-value rejection the whole design exists for. The state
+            both arms read is one app-db, so what is compared is the
+            RENDER and nothing else."
+    (let [{:keys [control baseline revision typed displayed-while-editing
+                  reasserted-value next-revision displayed-after-rejection]} ctrl-007
+          id  (second control)
+          ids [id]]
+      (seed! {:invoice {id {:amount baseline :amount-revision revision}}})
+
+      (testing "IDLE — the caller's baseline, no record"
+        (let [{:keys [interpreted compiled]} (arms ids revision)]
+          (is (= baseline (:shown interpreted))
+              "non-vacuous: the interpreted arm really rendered the baseline")
+          (is (= baseline (:shown compiled))
+              "non-vacuous: so did the compiled one — neither arm rendered nothing")
+          (is (= 4 (count (:on-input compiled)))
+              "non-vacuous: the intents are real event vectors, not nil")
+          (is (= interpreted compiled)
+              "displayed value and all three intents agree")
+          (is (= {:on-input 2 :on-blur 2 :on-click 2} (:generation-at compiled))
+              "with the generation at the same position in every intent")))
+
+      (testing "DRAFTING — and the draft is created by the COMPILED arm's
+                OWN :on-input, so the promoted intent is proven live rather
+                than merely equal-looking"
+        (send-intent! (:on-input (:compiled (arms ids revision))) typed)
+        (is (= {:reset-key revision :draft typed} (record control))
+            "the compiled control's intent wrote the record, stamped with
+             the generation its render displayed")
+        (let [{:keys [interpreted compiled]} (arms ids revision)]
+          (is (= displayed-while-editing (:shown compiled))
+              "the compiled arm displays the draft")
+          (is (not= baseline displayed-while-editing)
+              "non-vacuous: the draft really did move the display off the baseline")
+          (is (= interpreted compiled)
+              "and the interpreted arm displays and carries exactly the same")
+          (is (= {:on-input 2 :on-blur 2 :on-click 2} (:generation-at compiled)))))
+
+      (testing "AFTER A SAME-VALUE REJECTION — the caller refuses the draft
+                and stands by the value it already had"
+        (let [before (:amount (get-in (app-db) [:invoice id]))]
+          (send! [:invoice/baseline-replaced id reasserted-value next-revision])
+          (is (= before reasserted-value)
+              "non-vacuous: the caller really did reassert an EQUAL value")
+          (is (= before (:amount (get-in (app-db) [:invoice id])))
+              "so nothing derived from the value could have observed the rejection"))
+        (let [{:keys [interpreted compiled]} (arms ids next-revision)]
+          (is (= displayed-after-rejection (:shown compiled))
+              "the compiled arm shows the caller's baseline again")
+          (is (not= displayed-while-editing displayed-after-rejection)
+              "non-vacuous: the display actually moved off the draft")
+          (is (= interpreted compiled)
+              "and the two arms agree about the value AND the three intents")
+          (is (= next-revision (nth (:on-input compiled) 2))
+              "non-vacuous: the re-rendered intent carries the ADVANCED generation")
+          (is (= {:on-input 2 :on-blur 2 :on-click 2} (:generation-at compiled))
+              "still at the same position in each")
+          (is (= {:reset-key revision :draft typed} (record control))
+              "while the superseded record is ineligible, not erased"))))))
+
+(deftest the-promoted-control-denotes-the-same-whole-tree
+  (testing "Stated as a WHOLE-TREE equality beside the sampled facts, so a
+            change that moved something the facts do not sample — an
+            attribute, a child, an element the control renders — could not
+            pass quietly. The view-id namespace is the only mechanical
+            substitution, and it is not a difference promotion makes: it is
+            a difference LIVING IN ANOTHER FILE makes."
+    (let [{:keys [control baseline revision typed]} ctrl-007
+          id    (second control)
+          ids   [id]
+          both  (fn [] {:interpreted (render! :my.ui/parity-interpreted
+                                              [pilot/invoice-form {:ids ids}])
+                        :compiled    (render! :my.ui/parity-compiled
+                                              [compiled-caller {:ids ids}])})
+          same? (fn [label]
+                  (let [{:keys [interpreted compiled]} (both)]
+                    (is (= (as-compiled-ids interpreted) compiled)
+                        (str label ": the whole tree, not a sampled fact"))
+                    (is (not= interpreted compiled)
+                        (str label ": non-vacuous — the two trees differ BEFORE the "
+                             "id rewrite, so the comparison is doing work"))))]
+      (seed! {:invoice {id {:amount baseline :amount-revision revision}}})
+      (same? "idle")
+      ;; The user drafts between the two passes, so the second comparison is
+      ;; over a tree carrying a live draft rather than a repeat of the first.
+      (send-intent! (:on-input (t/attrs (t/find (:compiled (both))
+                                                #(= :input (:tag %)))))
+                    typed)
+      (same? "drafting"))))
+
+;; ===========================================================================
+;; The intents are LIVE — each of the three, fired from the compiled arm
+;; ===========================================================================
+
+(deftest the-promoted-controls-intents-move-the-same-state
+  (testing "Equality of two rendered event vectors is only half the claim:
+            the compiled arm's intents have to REACH the pilot's
+            registrations. Each of the three is fired from the compiled
+            arm's own render and the state it moves is asserted — the same
+            state the interpreted laws assert about."
+    (let [{:keys [control baseline revision typed]} ctrl-007
+          id      (second control)
+          ids     [id]
+          start!  (fn [] (seed! {:invoice {id {:amount baseline :amount-revision revision}}}))
+          compiled-input  (fn [] (t/attrs (t/find (render! :my.ui/parity-compiled
+                                                           [compiled-caller {:ids ids}])
+                                                  #(= :input (:tag %)))))
+          compiled-button (fn [] (t/attrs (t/find (render! :my.ui/parity-compiled
+                                                           [compiled-caller {:ids ids}])
+                                                  #(= :button (:tag %)))))]
+
+      (testing ":on-blur commits the draft the compiled arm's :on-input made"
+        (start!)
+        (send-intent! (:on-input (compiled-input)) typed)
+        (is (= 0 (commits)) "non-vacuous: no caller event has fired yet")
+        (send-intent! (:on-blur (compiled-input)))
+        (is (= typed (get-in (app-db) [:invoice id :amount]))
+            "the caller's domain event received the draft")
+        (is (= 1 (commits)) "exactly one caller event")
+        (is (nil? (record control)) "and the session was retired"))
+
+      (testing ":on-click cancels it — the Revert affordance, from the
+                compiled arm's own button"
+        (start!)
+        (send-intent! (:on-input (compiled-input)) typed)
+        (is (some? (record control)) "non-vacuous: a live draft really existed")
+        (send-intent! (:on-click (compiled-button)))
+        (is (nil? (record control)) "cancel retired the session")
+        (is (= baseline (get-in (app-db) [:invoice id :amount]))
+            "and the caller's amount never moved")))))
+
+;; ===========================================================================
+;; Non-vacuity: the two arms really are two lowerings
+;; ===========================================================================
+
+(deftest the-two-arms-really-are-two-lowerings
+  (testing "A parity proof where both sides are interpreted proves nothing,
+            so the lowering each declaration reports is asserted before its
+            output is trusted. The caller is interpreted on BOTH sides —
+            that is deliberate, and the row below says why."
+    (is (= :interpreted (:lowering (v/describe pilot/buffered-field)))
+        "the pilot's control is declared interpreted")
+    (is (= :compiled (:lowering (v/describe compiled/buffered-field)))
+        "and the twin is declared compiled")
+    (is (= :interpreted (:lowering (v/describe pilot/invoice-form))))
+    (is (= :interpreted (:lowering (v/describe compiled-caller)))
+        "both callers are interpreted — only the control was promoted"))
+
+  (testing "and the compiled control carries the analysis that makes it
+            statically knowable, which the interpreted twin honestly
+            reports it has none of"
+    (let [m (v/manifest compiled/buffered-field)]
+      (is (some? m) "the promoted declaration carries a manifest")
+      (is (nil? (v/manifest pilot/buffered-field))
+          "and the interpreted one reports none")
+      (is (= 1 (count (:subscriptions m)))
+          "exactly the one read the body carries")
+      (is (= '[:my.ui.field/text k g value] (:query (first (:subscriptions m))))
+          "the AUTHORED query, local symbols and all")
+      (is (= 3 (count (:events m)))
+          "and the three event sites the parity rows compare"))))
+
+;; ===========================================================================
+;; Why the caller is NOT promoted — the refusal, asserted
+;; ===========================================================================
+
+#?(:clj
+   (deftest the-caller-is-left-interpreted-because-the-grammar-refuses-it
+     (testing "The asymmetry above is a RULING of the compiled grammar, not
+               an omission. Pointed at the pilot's own file, so the
+               declaration checked is the one every law renders — there is
+               no copy to drift. The control is eligible with nothing to
+               say; the caller is refused, because it reads inside a `for`
+               and a read inside a loop is not a finite lexical reactive
+               site. The refusal's own catalogued recovery is
+               `[:extract-declared-child :keep-interpreted]`, and the pilot
+               already did the first half — the control IS the extracted
+               declared child — so an interpreted caller driving a compiled
+               child is the composition the grammar prescribes.
+
+               JVM-only because the checker resolves heads against a loaded
+               namespace, which only the JVM has."
+       (let [path    (.getPath (io/file (io/resource
+                                          "re_frame/freehand/buffered_controller_cljs_test.cljc")))
+             by-id   (into {} (map (juxt :view-id identity)) (check/check-file path))
+             control (get by-id interpreted-control-id)
+             caller  (get by-id interpreted-caller-id)]
+         (is (<= 3 (count by-id))
+             "non-vacuous: the checker really read this file's declarations")
+         (is (true? (:compile-eligible? control))
+             "the CONTROL's shape is inside the compiled grammar")
+         (is (= [] (:findings control))
+             "with nothing to change on the way — promotion is a keyword, not a rewrite")
+         (is (false? (:compile-eligible? caller))
+             "the CALLER is refused")
+         (is (= [:rf.ui.compile/sub-in-loop] (mapv :id (:findings caller)))
+             "for exactly one reason, and that reason is the loop")
+         (is (= :reactive-site-is-not-finite (:reason (first (:findings caller))))
+             "a read inside a loop is not a finite lexical site")
+         (is (= [:extract-declared-child :keep-interpreted]
+                (:recovery (first (:findings caller))))
+             "and the recovery is what this suite does")))))

--- a/implementation/freehand/test/re_frame/freehand/buffered_views_compiled.cljc
+++ b/implementation/freehand/test/re_frame/freehand/buffered_views_compiled.cljc
@@ -1,0 +1,53 @@
+(ns re-frame.freehand.buffered-views-compiled
+  "The buffered controller pilot's CONTROL, promoted.
+
+  Below is
+  [[re-frame.freehand.buffered-controller-cljs-test/buffered-field]] with
+  `{:compiled true}` added and nothing else changed: the same parameter
+  vector, the same `let`, the same read, the same three event sites, the
+  same literal markup. The library vocabulary is REFERRED rather than
+  restated (`kind`), so the body text is identical character for character
+  and the promoted control addresses the very same controller family — a
+  twin that named its own kind would write its own records, and the parity
+  suite would be comparing two independent controllers rather than one
+  control in two modes.
+
+  Separate namespace because a view id is derived from where a declaration
+  LIVES, so two declarations of one name cannot share a namespace.
+  `buffered-controller-parity-cljs-test` rewrites exactly that one
+  namespace component and asserts everything else is equal.
+
+  ## Only the CONTROL is promoted, and that is the finding
+
+  The pilot's caller — `invoice-form` — reads `(v/sub [:invoice/amount id])`
+  inside a `for`, and the compiled grammar refuses it
+  (`:rf.ui.compile/sub-in-loop`, because a read inside a loop is not a
+  finite, lexical reactive site). Its own catalogued recovery is
+  `[:extract-declared-child :keep-interpreted]`, and the pilot ALREADY did
+  the first half: the control is the extracted declared child. So the
+  caller stays interpreted and drives a compiled child, which is the
+  composition the grammar is designed to produce rather than a limitation
+  worked around.
+
+  The pilot's dataflow is NOT re-registered here.
+  `buffered-controller-cljs-test/register-library!` is ordinary re-frame
+  that knows nothing about execution mode, which is itself part of what
+  promotion parity means."
+  (:require [re-frame.freehand :as v]
+            [re-frame.freehand.buffered-controller-cljs-test :refer [kind]]))
+
+(v/defview buffered-field
+  "The pilot control, PROMOTED. It asks for its record key and its
+  generation FIRST — which is what makes it a writable, buffered
+  controller at all — then reads and emits through ordinary re-frame.
+  Every intent it renders carries the generation the render that produced
+  it displayed."
+  {:compiled true}
+  [{:keys [value on-commit] :as props}]
+  (let [k (v/controller-key kind props)
+        g (v/controller-revision kind props)]
+    [:span
+     [:input {:value    (v/sub [:my.ui.field/text k g value])
+              :on-input [:my.ui.field/edited k g ::v/value]
+              :on-blur  [:my.ui.field/committed k g on-commit]}]
+     [:button {:on-click [:my.ui.field/cancelled k g]} "Revert"]]))


### PR DESCRIPTION
Closes rf2-ikpsx.

FH-CTRL-006…010 are applicable `common` — both execution modes — and what
had landed for the compiled half was a static eligibility check
(`check/check-file` says the shape is accepted), not a rendered-output
comparison. This adds the rendered half.

## What landed

**`implementation/freehand/test/re_frame/freehand/buffered_views_compiled.cljc`** (new)
— the pilot CONTROL, promoted. `{:compiled true}` added and nothing else
changed: same parameter vector, same `let`, same read, same three event
sites, same literal markup. The library vocabulary is `:refer`red rather
than restated, so the body text is identical character for character and
the twin addresses the very same controller family — a twin that restated
its own `kind` would write its own records and the parity suite would be
comparing two independent controllers rather than one control in two modes.

**`implementation/freehand/test/re_frame/freehand/buffered_controller_parity_cljs_test.cljc`** (new)
— the parity suite. At **idle**, **drafting**, and **after a same-value
rejection** it compares the displayed value, all three intents
(`:on-input`, `:on-blur`, `:on-click`) and the POSITION the generation
occupies inside each. Plus a whole-tree equality (view-id namespace the
only mechanical substitution), a row that fires each of the three intents
from the compiled arm's OWN render and asserts the state it moves, a
lowering/manifest row, and the refusal row below.

**`implementation/freehand/test/re_frame/freehand/buffered_controller_cljs_test.cljc`**
— three names made public (`kind`, `records-root`, `register-library!`) so
the twin and the parity suite share the pilot's vocabulary instead of
copying it. No declaration moved, no body changed; the existing
`check-file` eligibility row is untouched.

## `invoice-form` is deliberately left interpreted

The pilot's caller reads `(v/sub [:invoice/amount id])` inside a `for`, and
the compiled grammar refuses that as `:rf.ui.compile/sub-in-loop` —
`:reason :reactive-site-is-not-finite`. That is the grammar working as
designed, not a gap, so the caller is **not** restructured to force
symmetry: rewriting it would change the pilot every interpreted law
renders.

The refusal's own catalogued recovery is
`[:extract-declared-child :keep-interpreted]`, and the pilot had already
done the first half — the control IS the extracted declared child. So the
compiled arm here is an **interpreted caller driving a compiled child**,
which is the composition the grammar prescribes. A JVM row asserts the
refusal directly (id, reason and recovery), so the asymmetry is evidence
rather than an omission.

## Quality gates

All run in the foreground to completion, exit codes captured explicitly.

| Gate | Command | Result | Exit |
|---|---|---|---|
| Freehand JVM suite | `cd implementation/freehand && clojure -M:test` | **929 tests / 6686 assertions, 0 failures, 0 errors** | 0 |
| CLJS node — freehand | `cd implementation && npm run test:freehand` | build 410 files / 0 warnings; **1016 tests / 5806 assertions, 0 failures, 0 errors** | 0 |
| CLJS node — full | `cd implementation && npm run test:cljs` | **11155 tests / 55991 assertions, 0 failures, 0 errors** | 0 |
| Browser (Chromium) | `cd implementation && npm run test:browser` | build 1043 files / 0 warnings; **758 tests / 4730 assertions, 0 failures, 0 errors** | 0 |
| New namespace alone | `clojure -M:test -n re-frame.freehand.buffered-controller-parity-cljs-test` | **5 tests / 45 assertions, 0 failures** | 0 |

The Freehand JVM suite moved 924 → 929 tests and 6641 → 6686 assertions:
the +5 / +45 is exactly this suite, nothing else changed.

The browser gate needed a **local-only** `page.goto` timeout bump
(`implementation/scripts/run-browser-tests.cjs:169` uses Playwright's
default 30s navigation timeout, and the cold dev bundle exceeds it on this
Windows box). That edit was reverted before committing and is **not** in
this diff; CI runs the same gate per-PR at `test.yml`.

## Non-vacuity

A parity test that passes because neither mode rendered anything is
worthless, so the suite was proven to red by perturbing the **compiled**
arm twice and re-running it:

1. **Displayed value** — `(v/sub [:my.ui.field/text k g value])` →
   `... (str value "!")` in the compiled twin. Result: **exit 1, 6
   failures**, including
   `(not (= {:shown "10.00" …} {:shown "10.00!" …}))` and the manifest row
   catching the changed authored query.
2. **Generation POSITION** — `[:my.ui.field/cancelled k g]` →
   `[:my.ui.field/cancelled g k]` in the compiled twin, i.e. the same
   values in a different order. Result: **exit 1, 9 failures**, including
   the position fact firing on its own —
   `(not (= {:on-input 2, :on-blur 2, :on-click 2} {:on-input 2, :on-blur 2, :on-click 1}))`
   — and the live-intent row catching that cancel no longer retires the
   session (`(not (nil? {:reset-key 4, :draft "bad"}))`).

Both perturbations were reverted; the committed tree is the unperturbed
one. Inside the suite itself, each state additionally asserts a
non-vacuity control: that the arm really rendered the baseline, that the
draft really moved the display off it, that the caller really reasserted
an EQUAL value, and that the two trees differ BEFORE the view-id rewrite.

## Scope

Test-only. Nothing under `implementation/freehand/src/**` is touched, no
spec change, no hot-zone file, no tracker-database path.
