### PR TITLE
chore: pin beads issue-prefix + functional-style atom review for adapters and pair-mcp (rf2-cchlf)

### DIFF
--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -6,7 +6,15 @@
 # Issue prefix for this repository (used by bd init)
 # If not set, bd init will auto-detect from directory name
 # Example: issue-prefix: "myproject" creates issues like "myproject-1", "myproject-2", etc.
-# issue-prefix: ""
+#
+# PINNED (rf2-cchlf). Every bead id in this repo is `rf2-*` — in the tracker,
+# in commit messages, in PR titles and in spec cross-references. The live value
+# has until now existed ONLY in the Dolt database, so a rebuild from the
+# git-tracked .beads/issues.jsonl (the documented bd bootstrap fallback and our
+# accepted recovery floor, rf2-4l67v) would auto-detect the prefix from the
+# DIRECTORY name and come up "re-frame2". Pinning it here makes the recovery
+# path reproduce the ids we already have. Do not change this value.
+issue-prefix: "rf2"
 
 # Use no-db mode: JSONL-only, no Dolt database
 # When true, bd will use .beads/issues.jsonl as the source of truth


### PR DESCRIPTION
A small-misc cluster of three independent beads. **The only file changed is `.beads/config.yaml`** — both atom reviews concluded no-change, which is the expected and correct outcome for these two surfaces.

Beads: **rf2-cchlf**, **rf2-3n3rv**, **rf2-tn1aw**.

## rf2-cchlf — pin the tracker issue-prefix (the only code/config change)

The tracker prefix has until now lived **only in the Dolt database**. Rebuilding the tracker from the git-tracked `.beads/issues.jsonl` — the documented `bd` bootstrap fallback and our accepted recovery floor (rf2-4l67v) — would have `bd init` auto-detect the prefix from the **directory name** and come up `re-frame2`. Every one of the 2,326 existing bead ids, and every reference to them in commit messages, PR titles and spec cross-references, is `rf2-*`. A mismatched prefix on rebuild would be a silent, entirely avoidable mess.

One line, plus a comment explaining why it must not be changed:

```yaml
issue-prefix: "rf2"
```

No behaviour change in an existing checkout, where the database already answers `rf2` — the file is read by `bd init`. `.beads/config.yaml` is human-authored config and is explicitly allow-listed for commit from a worker branch (`scripts/git-hooks/lib/check-beads-boundary.sh:77`); no database-derived `.beads` path is touched by this PR.

## rf2-3n3rv — functional-style atom review: `implementation/adapters`

**Verdict: no change needed.** Both enumerated sites are LEGITIMATE.

| Site | Binding | Classification | Judgment |
|---|---|---|---|
| `implementation/adapters/reagent-slim/src/reagent2/impl/template.cljs:420` | `warned-keyword-prop` | **LEGITIMATE** (detection false positive) | Not a local atom — a top-level `defonce` warn-once dedupe registry whose documented contract is "warn once per `[k name-of-v]` pair for the **process** lifetime". `clear-warned-keyword-prop!` exists solely so test fixtures can re-arm it, confirming the scope is deliberate. |
| `implementation/adapters/test-react/src/re_frame/adapter/test_react.cljc:256` | `self-ref` | **LEGITIMATE** | Explicit forward-reference cell: `unmount-thunk` closes over it so the thunk `disj`s the **final** record from `active-mounts` (record equality includes `:unmount-fn`, so a skeleton would not match and would leak the registration). Escapes into a closure outliving `mount-tree!`; there is no `reduce`/`loop` formulation of a self-reference. |

Enumeration verified complete: an independent sweep found 11 `(atom ` occurrences under `implementation/adapters/**/src/`. The 9 beyond the bead's list are top-level `defonce` cells (`component.cljs:63`, `test_react.cljc:81`/`:86`/`:103`/`:326`) or `MountedComponent` record **fields** built at `test_react.cljc:259-262` and mutated by lifecycle callbacks across the mount's lifetime — all LEGITIMATE, none local-scratch.

## rf2-tn1aw — functional-style atom review: `tools/re-frame2-pair-mcp`

**Verdict: no change needed.** All five enumerated sites are LEGITIMATE. Every one either crosses an async/callback boundary or is a `compare-and-set!` latch.

| Site | Binding | Classification | Judgment |
|---|---|---|---|
| `nrepl.cljs:477` | `frames*` | **LEGITIMATE** (swap!-inner-value extraction) | The rubric's named idiom. The single atomic `swap!` on `conn-atom` concatenates **and** decodes in one CAS — the docstring is explicit that splitting them opens a double-decode window — so decoded frames can only reach the outer scope through a side cell. |
| `nrepl.cljs:683` | `state` | **LEGITIMATE** (async accumulator) | Per-op response accumulator, mutated from the `on-frame` socket callback across unboundedly many async frames, read as `@state` to resolve the Promise once `"done"` lands, and raced against a `setTimeout` deadline. |
| `shadow_discovery.cljs:128` | `settled?` | **LEGITIMATE** (once-only latch) | `compare-and-set!` settle-once guard shared by four independent async settle paths (non-200 reject, body-`end` resolve, request `error`, timeout destroy+reject). A concurrency guard, not an accumulator. |
| `tools/subscribe.cljs:546` | `terminated?` | **LEGITIMATE** (idempotence latch) | `compare-and-set!` first-wins guard on `terminate`; without it a double-fire releases the resource-controls stream slot twice and double-resolves the outer `tools/call` Promise. Closed over by both `terminate` and `poll`. |
| `tools/subscribe.cljs:554` | `drain-errors` | **LEGITIMATE** (async counter) | Consecutive-rejected-drain counter (rf2-ajhwbm): `reset!` in the drain `.then` (:613), `swap! inc` in the drain `.catch` (:687) — both async continuations of a self-rescheduling poll loop. Spans poll cycles, so no `loop/recur` applies. |

Enumeration verified complete: 21 `(atom ` occurrences under `tools/re-frame2-pair-mcp/src/`; the 16 beyond the bead's list are top-level `def`/`defonce` session state (LRU cache, editor config, connection atom, server state, resource-controls counters), the shared stream accumulator passed at `subscribe.cljs:744`, and one docstring mention. As expected of an MCP server, it is essentially all connection and session state.

Full per-site reasoning is recorded on rf2-3n3rv and rf2-tn1aw as no-change findings.

## Quality gates

Both atom-review surfaces were left **unchanged**, so no artefact suite applies to them — there is no source diff to regress. The only diff is `.beads/config.yaml`, which no build or test path parses (`git grep config.yaml` over `scripts/ .github/ tools/ implementation/` returns only the hook allow-list that names it as a permitted path). Gates were therefore scoped to the one real risk: a config change that breaks the tracker.

| Gate | Command | Result | Exit |
|---|---|---|---|
| Beads PR-boundary (CI arm) | `GITHUB_EVENT_NAME=pull_request sh scripts/check-beads-pr-boundary.sh origin/main` | **PASS** — "No beads-database paths in this PR diff." | `0` |
| Pre-commit hook suite | `sh scripts/git-hooks/test-pre-commit.sh` | **PASS — 33 passed, 0 failed**, including case (g) "worker commit: `.beads/config.yaml` -> passed (allow-listed)" | `0` |
| YAML parse | `yaml.safe_load(.beads/config.yaml)` | **PASS** — parses to `{'issue-prefix': 'rf2'}` | `0` |
| Tracker still resolves the prefix | `bd config list` | **PASS** — `issue_prefix = rf2` | `0` |
| `bd` still operates in-checkout | `bd show rf2-cchlf` / `bd ready --limit 1` | **PASS** — both resolve `rf2-*` ids normally | `0` / `0` |

`scripts/test-fast-pr.sh` was not run: the diff contains zero source changes, and no build or test path reads `.beads/config.yaml`. CI will run the full spine on this PR regardless.
