### PR TITLE
refactor(impl): functional-style local-atom cleanups across core/http/ssr/schemas (rf2-b8goi)

### DIFF
--- a/implementation/core/src/re_frame/conformance.cljc
+++ b/implementation/core/src/re_frame/conformance.cljc
@@ -816,16 +816,16 @@
 
   Shared harness primitive (rf2-wy414k)."
   [steps]
-  (let [out (atom #{})]
-    ((fn walk [form]
-       (cond
-         (and (vector? form) (= :cofx-key (first form)))
-         (swap! out conj (second form))
-
-         (coll? form)
-         (doseq [x form] (walk x))))
-     steps)
-    @out))
+  ;; `tree-seq` flattens the step tree; the transducer picks the `[:cofx-key K]`
+  ;; nodes and takes their `K` (rf2-b8goi — was a scratch atom + `doseq` walk).
+  ;; `tree-seq` also descends INTO a matched node where the hand-rolled walk
+  ;; stopped, so a `[:cofx-key K]` whose K nested a further `[:cofx-key …]`
+  ;; would now also be collected. Unreachable under the DSL grammar (a cofx-id
+  ;; is a keyword), and a superset either way — never a miss.
+  (into #{}
+        (comp (filter #(and (vector? %) (= :cofx-key (first %))))
+              (map second))
+        (tree-seq coll? seq steps)))
 
 (defn realise-cofx-supplier
   "DSL body `steps` → a value-returning cofx supplier `(fn [] value)` (EP-0017


### PR DESCRIPTION
Per-surface functional-style review of LOCAL atom usage across four implementation surfaces. Parent audit: rf2-ro7e.

Beads: rf2-b8goi (core), rf2-h8gjv (http), rf2-pi2dc (ssr), rf2-sfqdd (schemas).

**23 enumerated sites reviewed. Exactly one was a genuine scratch-smell; it is the only line this PR changes.** The other 22 are ref-cells, registries, once-only latches and forward-reference cells that cross callback/async boundaries — refactoring any of them would be regression risk for no gain, so they are left untouched. That is the expected outcome for this bead family, not an under-delivery.

## The one change

`implementation/core/src/re_frame/conformance.cljc:819` — `collect-cofx-keys` accumulated a set into a local `out` atom across a recursive `doseq` walk. The atom never escaped the function and saw no concurrency, so it is pure scratch:

```clojure
;; before
(let [out (atom #{})]
  ((fn walk [form] ...(swap! out conj (second form))...) steps)
  @out)

;; after
(into #{}
      (comp (filter #(and (vector? %) (= :cofx-key (first %))))
            (map second))
      (tree-seq coll? seq steps))
```

**Documented divergence:** `tree-seq` descends INTO a matched `[:cofx-key K]` node where the hand-rolled walk stopped. So a `K` that itself nested a further `[:cofx-key …]` would now also be collected. That is unreachable under the DSL grammar (a cofx-id is a keyword), and it is a superset either way — never a miss. A comment at the site records this so the next reader does not re-derive it.

**Coverage:** `implementation/core/test/re_frame/conformance_dsl_cljs_test.cljc:175-188` — three assertions (nested steps across a body, empty-set case, duplicate collapse). Consumed by `conformance_runner.cljc:379` and `schemas_conformance_test.clj:292`, both of which run in the suites below. Green before and after.

**Equivalence evidence.** A recursive walk is exactly where a lost accumulator hides, so the two implementations were compared directly rather than trusted: old and new were run against **every subform of every fixture in the real conformance corpus** — 244 fixture files, **50,989 subforms compared, 0 mismatches** — plus ten targeted edge cases (`nil`, empty vector, no-cofx body, nested body, duplicates, map-valued steps, set-valued steps, string leaf, vector-valued `K`, deeply nested `[[[[[:cofx-key :deep]]]]]`), all identical. The nested-`[:cofx-key …]`-inside-`K` divergence noted above did not occur anywhere in the corpus, confirming it is unreachable in practice.

## Per-site classification

### rf2-b8goi — implementation/core (14 sites)

| Site | Binding | Class | Judgment |
|---|---|---|---|
| `conformance.cljc:819` | `out` | **SCRATCH-SMELL** | Local set accumulator over a recursive walk; never escapes, no concurrency. **Refactored.** |
| `frame.cljc:2290` | `captured` | LEGITIMATE | Written from a registered error-emit listener callback, read after the dispatch — crosses a callback boundary. |
| `frame.cljc:3328` | `captured` | LEGITIMATE | Same listener-capture shape for the `:on-destroy` throw watch. |
| `frame.cljc:3329` | `infra-fault?` | LEGITIMATE | Once-only latch set inside a `catch`, read after the `try`/`finally` to enforce the single-record contract. |
| `frame.cljc:3920` | `hook-failures` | LEGITIMATE | Bound into `*teardown-hook-failures*`; deliberately a side atom so a mid-teardown abort still flushes. Already carries its rationale comment. |
| `router.cljc:4317` | `teardown-router` | LEGITIMATE | Router queue cell threaded into `run-one-pass!` and bound into `*frame-destroy-cascade*`. |
| `router_transducer.cljc:275` | `state` | LEGITIMATE | Escapes into the three returned driver closures — the docstring calls it "closures over a single mutable cell". |
| `substrate/observation.cljc:1938` | `state` | LEGITIMATE | Backs the `->ObservationHandle` deftype; `add-watch`ed and mutated by the watch handler. |
| `substrate/plain_atom.cljc:78` | `on-dispose-fns` | LEGITIMATE | Callback registry living inside the `reify IDisposable`, across the object's whole lifetime. |
| `substrate/spine.cljs:392` | `deps` | LEGITIMATE | Escapes into the coord map stored in `source-coordinators`; read by the watch fan-out. |
| `substrate/spine.cljs:602` | `watchers` | LEGITIMATE | user-key → wrapper-fn registry backing `add-watch`/`remove-watch`. |
| `substrate/spine.cljs:603` | `on-dispose-fns` | LEGITIMATE | Callback registry read at `-dispose`. |
| `substrate/spine.cljs:615` | `own-keys` | LEGITIMATE | Per-source wire keys held for the derived value's lifetime, released at dispose. |
| `test_support.cljc:824` | `ctx-atom` | LEGITIMATE | Threads restore context from the async fixture's `:before` into its `:after`. |

### rf2-h8gjv — implementation/http (5 sites) — no change

| Site | Binding | Class | Judgment |
|---|---|---|---|
| `http/transport.cljc:1028` | `fired?` | LEGITIMATE | Once-only `compare-and-set!` latch racing a timer fire against an abort. |
| `http/transport.cljc:1029` | `timer-cell` | LEGITIMATE | Holds the host timer handle so the abort closure can clear it. |
| `http/transport.cljc:1036` | `handle-cell` | LEGITIMATE | Forward-reference cell: the abort-fn is built before `record-in-flight!` returns the handle, so it reads it lazily at fire time. |
| `http/transport.cljc:1633` | `handle-holder` | LEGITIMATE | Same forward-reference idiom in `run-attempt!` (rf2-lz7se). |
| `http/transport_cljs.cljc:156` | `timeout-handle` | LEGITIMATE | Host timeout handle cleared when the fetch→body-read chain settles. |

### rf2-pi2dc — implementation/ssr (3 sites) — no change

| Site | Binding | Class | Judgment |
|---|---|---|---|
| `ssr/streaming/client.cljs:790` | `seen` | LEGITIMATE | id-str → outcome map passed into `sweep!`/`finalize!` and mutated from MutationObserver callbacks; it is what makes re-sweeping idempotent. |
| `ssr/streaming/client.cljs:791` | `observer` | LEGITIMATE | Holds the live `MutationObserver` so `stop!` can disconnect it. |
| `ssr/streaming/client.cljs:792` | `ready?` | LEGITIMATE | Once-only finalization latch handed to `finalize!`. |

### rf2-sfqdd — implementation/schemas (1 site) — no change

| Site | Binding | Class | Judgment |
|---|---|---|---|
| `schemas/cache.cljc:38` | `cache` | LEGITIMATE | The memo cache itself — it backs both closures `clearable-memo` returns. A cache is legitimate by definition. |

## Quality gates

All run in the foreground to completion; logs captured worktree-locally under `gate-logs/`.

| Gate | Result | Counts |
|---|---|---|
| `implementation/core` JVM `clojure -M:test` — **before** the change (baseline) | PASS (exit 0) | 2104 tests, 10424 assertions, 0 failures, 0 errors |
| `implementation/core` JVM `clojure -M:test` — **after** the change | PASS (exit 0) | 2104 tests, 10424 assertions, 0 failures, 0 errors |
| `implementation/schemas` JVM `clojure -M:test` (direct consumer of the changed fn) | PASS (exit 0) | 363 tests, 19188 assertions, 0 failures, 0 errors |
| `scripts/test-fast-pr.sh` (repo root) — full spine | **PASS** (exit 0) — `PASS fast PR spine` | see the three rows below |
| ├─ core JVM leg | PASS | 2104 tests, 10424 assertions, 0 failures, 0 errors |
| ├─ CLJS node integration leg | PASS | 11151 tests, 55953 assertions, 0 failures, 0 errors |
| └─ per-ns test isolation leg | PASS | all 17 namespaces pass standalone |
| old-vs-new equivalence harness over the conformance corpus | PASS (exit 0) | 244 fixtures, 50989 subforms compared, 0 mismatches, 10/10 edge cases identical |

No gates were run against http, ssr or schemas source, because no source under those surfaces was changed.
