### PR TITLE
fix(bench): discharge the B2/B5 evidence residuals from the #6887/#6891 audits (rf2-drpa3.147)

### DIFF
--- a/.github/workflows/freehand-bench.yml
+++ b/.github/workflows/freehand-bench.yml
@@ -45,12 +45,14 @@ name: freehand bench
 # emitter, which is ClojureScript-only; and B2's mounted storm, B4's latency
 # row and B5's initial-mount reading only exist in a real browser. So there
 # are three jobs below running the same registry, the same provenance record
-# and the same gate/evidence split, each uploading its own artefact. Three
-# artefacts because they are three hosts — a result record names its own
-# `:host` and `:build`, and pooling a Chromium number with a V8 `:none` one
-# or a JIT-warmed JVM one would be the pooling D021 forbids — but ONE
-# harness, because a second report shape is a second place a threshold could
-# be added.
+# and the same gate/evidence split, each uploading what it published. They
+# are separate artefacts because they are separate hosts — a result record
+# names its own `:host` and `:build`, and pooling a Chromium number with a
+# V8 `:none` one or a JIT-warmed JVM one would be the pooling D021 forbids
+# — but ONE harness, because a second report shape is a second place a
+# threshold could be added. The ClojureScript lane uploads two: its standing
+# registry run, and B5's matched-build row, whose subject is three
+# `:advanced` bundles rather than the process measuring them.
 #
 # WHAT THE BROWSER CANNOT READ. A page has no environment and no git, so
 # every environment-derived provenance field a mounted workload publishes
@@ -146,13 +148,23 @@ jobs:
           if-no-files-found: error
           retention-days: 90
 
-  # The ClojureScript half of the same suite. See TWO LANES, ONE HARNESS
+  # The ClojureScript half of the same suite. See THREE LANES, ONE HARNESS
   # above: this job adds a host, not a harness.
+  #
+  # It carries TWO Node readings. The first is the standing registry run
+  # (`bench:freehand-node`). The second is B5's MATCHED BUILD row
+  # (rf2-x4jda): three `:advanced` release bundles measured for bytes and
+  # parse/compile, plus the byte delta between the interpreted and compiled
+  # shapes. Those bundles are artefacts nothing else in CI builds, and the
+  # two B5 Node tests SKIP when they are absent — so until this job built
+  # them the matched figures existed only in a developer's terminal and a
+  # pull-request body, which is not a durable publication with provenance.
   react-evidence:
     name: Freehand B-spine evidence — ClojureScript lane (pinned worker)
     # PINNED for the same reason the JVM lane is. See THE PIN above.
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    # Room for three `:advanced` compiles on top of the two Node runs.
+    timeout-minutes: 35
     defaults:
       run:
         working-directory: implementation
@@ -206,6 +218,73 @@ jobs:
         with:
           name: freehand-bench-node-${{ github.sha }}
           path: implementation/out/freehand-bench-node.edn
+          if-no-files-found: error
+          retention-days: 90
+
+      # B5's matched build row. The three shapes hold the entry structure,
+      # the optimisation level and `goog.DEBUG` still and vary only lowering,
+      # so the delta between the outer two is a reading of promotion. (Not
+      # exclusively: the twins are two namespaces and each ships its own ids
+      # and namespace docstring. The published fixture names that confound —
+      # see re-frame.freehand.bench.b5/not-matched-on.)
+      - name: Build the three matched release bundles
+        run: npx shadow-cljs release freehand-release freehand-release-interpreted freehand-release-compiled
+
+      # `test:freehand` is the artefact here: the B5 rows publish their
+      # records to stdout as `;;`-headed EDN, exactly as the sibling lanes
+      # do, and the transcript around them is the run that produced them.
+      - name: Measure the matched bundles and capture the B5 records
+        env:
+          # Node can read this one at run time, unlike the browser lane —
+          # set explicitly so the record does not depend on GITHUB_SHA
+          # happening to be exported.
+          RF2_REVISION: ${{ github.sha }}
+        run: |
+          status=0
+          npm run test:freehand > out/freehand-bench-b5.log 2>&1 || status=$?
+          grep -A1 '^;; B5' out/freehand-bench-b5.log || true
+          tail -5 out/freehand-bench-b5.log
+          exit $status
+
+      # PROVENANCE, not numbers — the same law the browser lane keeps. Two
+      # ways this row can quietly publish nothing, and both red here: a run
+      # that could not name its revision (every record prints NOT CITABLE),
+      # and a run where the bundles were not built (both B5 tests SKIP, the
+      # log is green, and no matched figure exists). The second is exactly
+      # what happened before this job built them, so the floor counts the
+      # three shapes rather than trusting the exit code.
+      - name: Refuse to publish unattributable or absent B5 evidence
+        run: |
+          log=out/freehand-bench-b5.log
+          if grep -q 'NOT CITABLE' "$log"; then
+            echo "The B5 row published unattributable evidence:" >&2
+            grep -n 'NOT CITABLE' "$log" >&2
+            echo "RF2_REVISION was '${RF2_REVISION}'." >&2
+            exit 1
+          fi
+          shapes=$(grep -c 'B5 matched shape' "$log" || true)
+          if [ "$shapes" -ne 3 ]; then
+            echo "Expected 3 matched-shape records, found ${shapes}. The B5" >&2
+            echo "matched-build test SKIPS unless all three bundles are on" >&2
+            echo "disk, so a green suite with no records means the release" >&2
+            echo "builds above did not produce them." >&2
+            exit 1
+          fi
+          for label in 'B5 shipped-cost evidence' 'B5 per-promotion byte delta'; do
+            if ! grep -F "$label" "$log" | grep -q 'citable$'; then
+              echo "No citable record for: ${label}" >&2
+              exit 1
+            fi
+          done
+          echo "Published 3 matched shapes, the shipped-cost row and the"
+          echo "promotion delta at ${RF2_REVISION}."
+
+      - name: Upload the B5 matched-build records
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: freehand-bench-b5-${{ github.sha }}
+          path: implementation/out/freehand-bench-b5.log
           if-no-files-found: error
           retention-days: 90
 

--- a/.github/workflows/freehand-bench.yml
+++ b/.github/workflows/freehand-bench.yml
@@ -52,15 +52,22 @@ name: freehand bench
 # harness, because a second report shape is a second place a threshold could
 # be added.
 #
-# THE REVISION. A browser has no environment and no git, so a mounted
-# workload can only learn the revision it was compiled from at BUILD time,
-# through the closure-define `re-frame.freehand.bench.provenance` documents.
-# The browser lane's build reads it from `RF2_REVISION` via `#shadow/env`
-# and this workflow sets that to `github.sha`. Without it every record the
-# mount publishes prints NOT CITABLE and is worth reading but not citing —
-# which is why the lane asserts on the WORD, not on any number: a lane that
-# publishes unattributable evidence has failed at its one job, while a
-# distribution that moved has not.
+# WHAT THE BROWSER CANNOT READ. A page has no environment and no git, so
+# every environment-derived provenance field a mounted workload publishes
+# has to arrive at BUILD time, through the closure-defines
+# `re-frame.freehand.bench.provenance` documents. Two fields do:
+# `RF2_REVISION` (which commit the bundle was compiled from) and
+# `RF2_HARDWARE_CLASS` (which class its numbers may be compared within).
+# The browser lane's build reads BOTH via `#shadow/env`; this workflow sets
+# the first to `github.sha` and the second to the same class the sibling
+# lanes configure. Setting them in a job's `env:` alone configures the
+# RUNNER, not the page — which is exactly how this lane's first run
+# published thirteen correctly-revisioned records that all named
+# `:developer-workstation`.
+#
+# So the lane asserts on WORDS, never on numbers: a record that cannot name
+# its revision, or that names a machine class the lane is not, has failed
+# at the one job evidence has. A distribution that moved has not.
 
 on:
   schedule:
@@ -229,7 +236,11 @@ jobs:
         working-directory: implementation
     env:
       # The same configured class as the sibling lanes; the HOST difference
-      # stays visible in each record's `:host`, where it belongs.
+      # stays visible in each record's `:host`, where it belongs. Unlike the
+      # sibling lanes, setting it here is not enough on its own — the
+      # :browser-test-freehand-bench build reads it at COMPILE time through
+      # `#shadow/env` into the provenance namespace's `build-hardware-class`
+      # define, because the page it ends up in cannot read this environment.
       RF2_HARDWARE_CLASS: release-worker
       # What makes a mounted record CITABLE. Read at compile time by the
       # :browser-test-freehand-bench build's `#shadow/env`, baked into the
@@ -302,10 +313,20 @@ jobs:
       # The one thing this lane is allowed to fail on, and it is not a
       # number. D021 forbids an automatic numeric pass/fail, and nothing here
       # asserts a millisecond or a byte. What it asserts is PROVENANCE: a
-      # record that cannot name its revision is not evidence anyone may cite,
-      # so a lane that published only unattributable records did not do its
-      # job — most likely because RF2_REVISION never reached the compile.
-      - name: Refuse to publish unattributable evidence
+      # record that cannot name its revision, or that names the wrong
+      # machine, is not evidence anyone may cite — so a lane that published
+      # only unattributable or mislabelled records did not do its job.
+      #
+      # BOTH environment-derived provenance fields are checked, because both
+      # cross the same compile-time boundary and either can be dropped in
+      # silence. A page cannot read `process.env`: setting RF2_HARDWARE_CLASS
+      # in this job's `env:` configures the RUNNER, and only the build's
+      # `#shadow/env` define carries it into the page. The first time this
+      # lane ran it published thirteen records with the right revision and
+      # `:developer-workstation` for the class — certified by
+      # `provenance/result`, because the ledger asks for a keyword and got
+      # one. A wrong keyword is what the ledger cannot see and this step can.
+      - name: Refuse to publish unattributable or mislabelled evidence
         run: |
           log=out/freehand-bench-browser.log
           if grep -q 'NOT CITABLE' "$log"; then
@@ -323,7 +344,26 @@ jobs:
             echo "artefact is worse than a red one, because it looks green." >&2
             exit 1
           fi
-          echo "Published $citable citable result record(s) at ${RF2_REVISION}."
+          wrong=$(grep -o ':hardware-class :[A-Za-z0-9_-]*' "$log" \
+                  | grep -v ":hardware-class :${RF2_HARDWARE_CLASS}\$" | sort -u || true)
+          if [ -n "$wrong" ]; then
+            echo "This lane published records naming a hardware class it is not:" >&2
+            echo "$wrong" >&2
+            echo "RF2_HARDWARE_CLASS was '${RF2_HARDWARE_CLASS}'. It is read at COMPILE" >&2
+            echo "time by the :browser-test-freehand-bench build and reaches the page as" >&2
+            echo "the provenance namespace's build-hardware-class define — a browser" >&2
+            echo "cannot read this job's environment, so the define is the only route." >&2
+            exit 1
+          fi
+          classed=$(grep -c ":hardware-class :${RF2_HARDWARE_CLASS}" "$log" || true)
+          if [ "$classed" -eq 0 ]; then
+            echo "No record named a hardware class at all — the :host provenance" >&2
+            echo "field stopped being published, so the 'no wrong class' check above" >&2
+            echo "passed vacuously." >&2
+            exit 1
+          fi
+          echo "Published $citable citable result record(s) at ${RF2_REVISION},"
+          echo "$classed of them naming hardware class ${RF2_HARDWARE_CLASS}."
 
       - name: Upload the browser result records
         if: always()

--- a/implementation/freehand/src/re_frame/freehand/bench/b5.cljs
+++ b/implementation/freehand/src/re_frame/freehand/bench/b5.cljs
@@ -37,12 +37,18 @@
   ## The deterministic gate is elsewhere, on purpose
 
   D021's B5 row also names a DETERMINISTIC reachability gate — that unused
-  runtime modules are absent from the production bundle, proven by the
-  F3d control-build technique. That gate needs a control build (the debug
-  flag flipped, everything else held) and lives in the build lane; it is
-  `rf2-drpa3.166`'s. This namespace is the EVIDENCE half only, and states
-  no pass/fail about a bundle at all: every measurement it declares is
-  `:bytes` or `:duration-ms`, which the harness can only publish.
+  runtime modules are absent from the production bundle, proven by the F3d
+  control-build technique. That gate needs a control build and a validated
+  oracle, so it is not a measurement and does not live here: it is
+  `implementation/scripts/check-freehand-reachability.cjs`, run by `npm run
+  test:freehand-reachability`, which holds `goog.DEBUG` still and moves the
+  APP. (Its sibling `check-freehand-evidence-elision.cjs` does the reverse —
+  holds the app and moves the flag — and proves a different thing: that the
+  dev-gated evidence seam elides.)
+
+  This namespace is the EVIDENCE half only, and states no pass/fail about a
+  bundle at all: every measurement it declares is `:bytes` or
+  `:duration-ms`, which the harness can only publish.
 
   ## Provenance ties each number to the artefact
 

--- a/implementation/freehand/src/re_frame/freehand/bench/b5.cljs
+++ b/implementation/freehand/src/re_frame/freehand/bench/b5.cljs
@@ -206,7 +206,7 @@
 ;; ---------------------------------------------------------------------------
 
 (defn promotion-delta
-  "The per-promotion BYTE delta between an interpreted-shape and a
+  "The WHOLE-APP BYTE delta between an interpreted-shape and a
   compiled-shape [[measure-bundle]]d artefact: `compiled` minus
   `interpreted`, per encoding.
 
@@ -215,9 +215,26 @@
   replaces — and a negative one means promotion shrank the bundle. Which way
   it falls, and how far, is a fact about the two artefacts, published as
   evidence: D021's NON-GOALS bar a byte-size threshold, so a delta has no
-  route to a verdict however large it is. Because the two artefacts differ
-  ONLY in lowering (same entry app, same `:advanced`, same `goog.DEBUG`
-  false), this delta is attributable to lowering and nothing else.
+  route to a verdict however large it is.
+
+  ## What this delta is, and is not, attributable to
+
+  It is a WHOLE-APP figure over every view the two entries promote together,
+  not a per-view one. [[promotion-delta-workload]] publishes both, and names
+  the per-view figure for the mean it is.
+
+  And lowering is the DOMINANT variable across the twins, not the only one.
+  The two entries are two namespaces, so each carries its own namespace name
+  into the bundle — through the ids the registrar keys on
+  (`…release-app-interpreted/bump` against `…release-app-compiled/bump`), the
+  root's DOM id, and the namespace docstring, which `:advanced` does NOT
+  strip: it ships once per declared view in both bundles. That prose differs
+  between the twins because it describes different things. Holding it still
+  needs one shared entry shape, which is `rf2-x4jda`'s remaining work; until
+  then the confound is NAMED in the published fixture rather than papered
+  over, and it is small — measured at merge `7ce0788d7e`, +297 raw bytes
+  against a raw delta of 18,475 (1.6%), of which +345 is docstring prose and
+  −48 the shorter identifiers.
 
   Both maps must be from the same [[measure-bundle]] shape; the raw, gzip
   (6 and 9) and brotli deltas are answered, plus each side's digest so the
@@ -230,14 +247,115 @@
    :interpreted-sha256 (:sha256 interpreted)
    :compiled-sha256    (:sha256 compiled)})
 
+(def matched-on
+  "What the two twins genuinely hold still — the claim the delta rests on."
+  (str "same entry structure (a root over two counter leaves), same handlers, "
+       "same view bodies character-for-character, same :advanced optimisation, "
+       "same goog.DEBUG false, same output shape"))
+
+(def not-matched-on
+  "What the two twins do NOT hold still, stated so a reader can discount it.
+
+  Published in the delta's fixture because a caveat that lives only in a
+  reviewer's memory is not part of the evidence. See [[promotion-delta]]."
+  (str "the two entries are two NAMESPACES, so each ships its own namespace "
+       "name: the registered event/sub/frame ids, the root's DOM id, and the "
+       "namespace docstring, which :advanced does not strip and which differs "
+       "in prose between the twins. Measured at 7ce0788d7e this accounted for "
+       "+297 raw bytes of an 18,475-byte raw delta (1.6%). Removing it needs "
+       "one shared entry shape across the three builds (rf2-x4jda)"))
+
+(defn promotion-delta-workload
+  "The per-promotion byte delta as a WORKLOAD, so it reaches the SAME door
+  every other B5 figure does.
+
+  The delta was previously printed straight to the console as a bare map: it
+  bypassed `provenance/result`, carried none of the record shape the ledger
+  requires, and so was published under weaker discipline than the readings it
+  was derived from. It is a derived byte fact, which is a thing this harness
+  already knows how to publish — the byte readings ride
+  [[workload]] as constants too — so it needs no new machinery, only the
+  existing one.
+
+  `promoted-views` is the number of view declarations the two entries promote
+  together, and is a FIXTURE PARAMETER supplied by the caller: this namespace
+  measures files and does not read the entries that produced them. It is what
+  makes the per-view figure meaningful, and the figure is published as the
+  MEAN it is — this app's promoted views are the same body twice under one
+  root, so their individual costs are not separately observable from bytes.
+
+  Baseline `:interpreted-vs-compiled`, referencing the interpreted arm: this
+  is precisely D021's first named comparator."
+  [{:keys [id doc sampling promoted-views]} interpreted compiled]
+  (let [d       (promotion-delta interpreted compiled)
+        per-view #(/ (get d %) promoted-views)]
+    {:id      id
+     :doc     doc
+     :fixture {:interpreted-artefact (:path interpreted)
+               :compiled-artefact    (:path compiled)
+               :interpreted-sha256   (:sha256 interpreted)
+               :compiled-sha256      (:sha256 compiled)
+               :promoted-views       promoted-views
+               :measurement-method
+               (str "compiled-minus-interpreted on-disk and compressed bytes over "
+                    (:path interpreted) " and " (:path compiled)
+                    "; the per-view figures are that total divided by the "
+                    promoted-views " view declarations the two entries promote "
+                    "together — a MEAN, not a per-declaration observation")
+               :matched-on     matched-on
+               :not-matched-on not-matched-on}
+     :baseline {:kind      :interpreted-vs-compiled
+                :reference {:arm  :interpreted
+                            :note (str "the interpreted-only twin " (:path interpreted)
+                                       ", sha256 " (:sha256 interpreted))}}
+     :sampling sampling
+     :measurements
+     [{:id         :B5/promotion-delta-raw-bytes
+       :doc        "whole-app uncompressed byte delta, compiled minus interpreted"
+       :observable :bytes}
+      {:id         :B5/promotion-delta-gzip6-bytes
+       :doc        "whole-app gzip-6 byte delta, compiled minus interpreted"
+       :observable :bytes}
+      {:id         :B5/promotion-delta-gzip9-bytes
+       :doc        "whole-app gzip-9 byte delta, compiled minus interpreted"
+       :observable :bytes}
+      {:id         :B5/promotion-delta-brotli-bytes
+       :doc        "whole-app brotli byte delta, compiled minus interpreted"
+       :observable :bytes}
+      {:id         :B5/promotion-delta-raw-bytes-mean-per-view
+       :doc        "the raw delta divided by the promoted view count — a mean, not a per-declaration reading"
+       :observable :bytes}
+      {:id         :B5/promotion-delta-gzip6-bytes-mean-per-view
+       :doc        "the gzip-6 delta divided by the promoted view count — a mean"
+       :observable :bytes}
+      {:id         :B5/promotion-delta-brotli-bytes-mean-per-view
+       :doc        "the brotli delta divided by the promoted view count — a mean"
+       :observable :bytes}]
+     :run
+     (fn [_]
+       {:B5/promotion-delta-raw-bytes                  (:raw-bytes d)
+        :B5/promotion-delta-gzip6-bytes                (:gzip6-bytes d)
+        :B5/promotion-delta-gzip9-bytes                (:gzip9-bytes d)
+        :B5/promotion-delta-brotli-bytes               (:brotli-bytes d)
+        :B5/promotion-delta-raw-bytes-mean-per-view    (per-view :raw-bytes)
+        :B5/promotion-delta-gzip6-bytes-mean-per-view  (per-view :gzip6-bytes)
+        :B5/promotion-delta-brotli-bytes-mean-per-view (per-view :brotli-bytes)})}))
+
 ;; ---------------------------------------------------------------------------
 ;; The workload
 ;; ---------------------------------------------------------------------------
 
-(def measurement-method
-  "How the readings are taken, published verbatim in the fixture so a
-  reader knows exactly what each number is a number of."
-  (str "on-disk bytes of out/freehand-release/main.js and its size under "
+(defn measurement-method
+  "How the readings over `path` were taken, published verbatim in the fixture
+  so a reader knows exactly what each number is a number of.
+
+  A function of the artefact, not a constant. The three matched shapes route
+  through this same probe, and a method line that named
+  `out/freehand-release/main.js` while its own fixture's `:artefact` named a
+  different file described a measurement that did not happen — the exact
+  drift the #6887 audit found on the two twins' records."
+  [path]
+  (str "on-disk bytes of " path " and its size under "
        "zlib gzip (levels 6 and 9) and brotli at the library default; "
        "parse/compile is the wall time of new vm.Script over the source with "
        "a per-call nonce comment appended to defeat V8's content-keyed "
@@ -267,7 +385,7 @@
               :gzip6-bytes        gzip6-bytes
               :gzip9-bytes        gzip9-bytes
               :brotli-bytes       brotli-bytes
-              :measurement-method measurement-method}
+              :measurement-method (measurement-method path)}
    :baseline {:kind      :before-vs-after
               :reference {:revision :the-revision-before-this
                           :note     (str "the same bundle's bytes and parse/compile on the "

--- a/implementation/freehand/src/re_frame/freehand/bench/provenance.cljc
+++ b/implementation/freehand/src/re_frame/freehand/bench/provenance.cljc
@@ -87,6 +87,24 @@
    ;; measurement is a number about nothing.
    (goog-define build-revision ""))
 
+#?(:cljs
+   ;; The hardware class crosses the SAME compile-time boundary, and for the
+   ;; same reason: a page cannot read `process.env`, so a lane that configures
+   ;; `RF2_HARDWARE_CLASS` in the runner's environment configures nothing the
+   ;; browser can see. Carrying only the revision across and leaving this to
+   ;; `detect-hardware-class`'s fallback is how the pinned release worker came
+   ;; to publish thirteen records labelled `:developer-workstation` — records
+   ;; `result` certified, because the ledger asks for a keyword and got one.
+   ;;
+   ;;   :closure-defines {re-frame.freehand.bench.provenance/build-hardware-class "release-worker"}
+   ;;
+   ;; The `:browser-test-freehand-bench` build reads it from
+   ;; `RF2_HARDWARE_CLASS` through `#shadow/env`, so the define says which
+   ;; class the LANE configured rather than which class someone typed into a
+   ;; config file. Left empty, detection falls back exactly as before — an
+   ;; unconfigured local browser run is a developer workstation, and says so.
+   (goog-define build-hardware-class ""))
+
 (defn detect-revision
   "The source revision the measured code was built from.
 
@@ -106,19 +124,38 @@
                  (catch Exception _ nil))
          :cljs (blank->nil build-revision))))
 
+(defn hardware-class
+  "The class implied by a `configured` value and whether the run is in CI.
+
+  Pure, and public, so the precedence is provable without an environment:
+  a configured class wins, an unconfigured CI run is a `:shared-ci-runner`
+  — honest, because a shared runner's distribution is comparable with other
+  shared-runner distributions and with nothing else — and anything else is
+  a developer workstation."
+  [configured ci?]
+  (if-let [c (blank->nil configured)]
+    (keyword c)
+    (if ci? :shared-ci-runner :developer-workstation)))
+
 (defn detect-hardware-class
   "The hardware class this run's numbers may be compared within.
 
-  Configured (`RF2_HARDWARE_CLASS`) or detected — never a literal naming
-  one machine. In CI without an explicit class the runner is a
-  `:shared-ci-runner`, which is honest: a shared runner's distribution is
-  comparable with other shared-runner distributions and with nothing
-  else. D021's pinned scheduled worker sets `RF2_HARDWARE_CLASS` to say
-  so."
+  Configured or detected — never a literal naming one machine. The
+  configuration reaches the run by whichever route its host has:
+  `RF2_HARDWARE_CLASS` where there is an environment to read, and the
+  compile-time [[build-hardware-class]] define where there is not. A
+  browser has no `process.env`, so a lane that exports the variable and
+  stops there has told the runner and not the page — which is how a pinned
+  release worker published a page's numbers under
+  `:developer-workstation`.
+
+  D021's pinned scheduled worker sets `RF2_HARDWARE_CLASS`; the browser
+  lane's build reads that same variable at COMPILE time into the define."
   []
-  (if-let [configured (blank->nil (env "RF2_HARDWARE_CLASS"))]
-    (keyword configured)
-    (if (blank->nil (env "CI")) :shared-ci-runner :developer-workstation)))
+  (hardware-class (or (blank->nil (env "RF2_HARDWARE_CLASS"))
+                      #?(:cljs (blank->nil build-hardware-class)
+                         :clj  nil))
+                  (some? (blank->nil (env "CI")))))
 
 (defn detect-host
   "The browser/runtime and hardware class this run happened on."

--- a/implementation/freehand/test/re_frame/freehand/bench/b5_matched_builds_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b5_matched_builds_cljs_test.cljs
@@ -43,10 +43,17 @@
   It states no pass/fail about any bundle. Every reading is a byte count or a
   byte delta, which the harness can only publish — D021's NON-GOALS bar a
   byte-size threshold, so no matched-build figure has a route to a verdict.
-  The DETERMINISTIC reachability gate that DOES red is a different lane
-  (`scripts/check-freehand-evidence-elision.cjs`, over the goog.DEBUG control
-  pair): it flips the flag and holds lowering; this file flips lowering and
-  holds the flag. Complementary, not the same.
+  The gates that DO red are different lanes over the same release build, each
+  moving one variable and holding the rest:
+
+    `scripts/check-freehand-reachability.cjs`      moves the APP — an unused
+                                                   runtime module is absent
+    `scripts/check-freehand-evidence-elision.cjs`  moves `goog.DEBUG` — the
+                                                   dev-gated seam is absent
+    this file                                      moves LOWERING — and
+                                                   asserts nothing
+
+  Complementary, none of them the same claim.
 
   Node-only (`fs`/`zlib`/`vm` via b5). Like the mixed bundle test it is
   driven by a test rather than registered into the standing suite, because

--- a/implementation/freehand/test/re_frame/freehand/bench/b5_matched_builds_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b5_matched_builds_cljs_test.cljs
@@ -4,11 +4,20 @@
 
   The evidence half of B5 ([[re-frame.freehand.bench.b5-bundle-cljs-test]])
   measures the ONE mixed `:freehand-release` bundle. This file measures all
-  THREE matched shapes — interpreted-only, mixed, compiled-only — that differ
-  ONLY in view lowering (`:freehand-release-interpreted`, `:freehand-release`,
+  THREE matched shapes — interpreted-only, mixed, compiled-only
+  (`:freehand-release-interpreted`, `:freehand-release`,
   `:freehand-release-compiled` in `implementation/shadow-cljs.edn`: same entry
-  app, same `:advanced`, same `goog.DEBUG` false), and publishes the
-  per-promotion BYTE DELTA between the interpreted and compiled shapes.
+  structure, same `:advanced`, same `goog.DEBUG` false), and publishes the
+  BYTE DELTA between the interpreted and compiled shapes as a whole-app total
+  and a per-promoted-view mean.
+
+  Lowering is the dominant variable across the twins and not the only one:
+  they are two namespaces, so each ships its own registered ids, root DOM id
+  and namespace docstring — `:advanced` strips none of those. The confound is
+  named in the published fixture
+  ([[re-frame.freehand.bench.b5/not-matched-on]]) and measured at +297 raw
+  bytes of an 18,475-byte raw delta. Holding it still needs one shared entry
+  shape across the three builds, which is `rf2-x4jda`'s remaining work.
 
   Two things keep it honest, and both are tested here without any bundle on
   disk:
@@ -48,6 +57,7 @@
   (:require [cljs.test :refer-macros [deftest is testing]]
             [re-frame.freehand.bench :as bench]
             [re-frame.freehand.bench.b5 :as b5]
+            [re-frame.freehand.bench.measure :as m]
             [re-frame.freehand.bench.provenance :as prov]))
 
 (def ^:private sampling {:warmup 2 :samples 8})
@@ -90,6 +100,45 @@
       (is (= 50  (:brotli-bytes d)) "brotli delta")
       (is (= "interp-sha"   (:interpreted-sha256 d)) "the interpreted side's digest rides the delta")
       (is (= "compiled-sha" (:compiled-sha256 d))    "and the compiled side's"))))
+
+(deftest the-delta-is-published-as-a-record-not-a-bare-map
+  (testing "The delta routes through the SAME door every other B5 figure
+            does. It used to be printed straight to the console as a map:
+            no `:host`, no `:build`, no `:sampling`, no `:baseline`, and no
+            visit to `provenance/result` — published under weaker discipline
+            than the readings it was derived from. As a workload it carries
+            the whole record shape, gets validated at the one door, and
+            still states no verdict: every measurement it declares observes
+            bytes, which the harness can only publish."
+    (let [interp   (synthetic-measured "interp" 1000 400 380 300)
+          compiled (synthetic-measured "compiled" 1150 460 430 350)
+          w        (bench/workload
+                     (b5/promotion-delta-workload
+                       {:id :B5/synthetic-promotion-delta
+                        :doc "the delta over two synthetic artefacts"
+                        :sampling {:warmup 0 :samples 1}
+                        :promoted-views 3}
+                       interp compiled))
+          record   (bench/run-workload w (assoc fixture-provenance :revision "r"))]
+      (is (empty? (filter m/gate? (:measurements w)))
+          "the delta declares no gate at all — a byte figure has no route to a verdict")
+      (is (empty? (:gate-failures record)) "and reds nothing")
+      (is (= :interpreted-vs-compiled (get-in record [:baseline :kind]))
+          "the delta names D021's interpreted-versus-compiled comparator")
+      (is (= :interpreted (get-in record [:baseline :reference :arm]))
+          "measured against the interpreted arm")
+      (is (= 150 (get-in record [:distribution :B5/promotion-delta-raw-bytes :p50]))
+          "the whole-app raw delta rides the record")
+      (is (= 50 (get-in record [:distribution :B5/promotion-delta-raw-bytes-mean-per-view :p50]))
+          "and the per-view figure is that total over the promoted view count")
+      (testing "the fixture states what the two artefacts hold still and what
+                they do not, so the delta's attribution travels with it"
+        (is (= 3 (get-in record [:fixture :promoted-views])))
+        (is (= "interp" (get-in record [:fixture :interpreted-artefact])))
+        (is (= "compiled" (get-in record [:fixture :compiled-artefact])))
+        (is (string? (get-in record [:fixture :matched-on])))
+        (is (re-find #"namespace docstring" (get-in record [:fixture :not-matched-on]))
+            "the confound is named, not implied")))))
 
 (deftest promotion-delta-can-be-negative-when-promotion-shrinks
   (testing "The delta is evidence, not a threshold: when the compiled shape
@@ -152,16 +201,28 @@
                             measured)
                (assoc fixture-provenance :revision revision))))))
 
+(def ^:private promoted-views
+  "How many view declarations the interpreted and compiled entries promote
+  together — `counter-a`, `counter-b` and the `app` root
+  (`re-frame.freehand.release-app-interpreted` against
+  `…-compiled`, which adds `{:compiled true}` to all three).
+
+  A FIXTURE PARAMETER, stated here because this is where the fixture is
+  known; `b5` measures files and does not read the entries that produced
+  them. It is what makes the per-view figure mean anything, and the figure
+  is published as the MEAN it is."
+  3)
+
 (deftest the-three-shapes-and-their-delta-are-measured-when-built
   (testing "The matched build lane's real reading, published when the three
             bundles are on disk. Each shape's bytes and parse/compile are
             measured off its own artefact through the shared probe, and the
-            per-promotion delta between the interpreted and compiled shapes is
-            published as evidence — the byte cost of promoting the app's
-            views, attributable to lowering because that is the only thing
-            that differs across the three. When any shape is unbuilt this
-            SKIPS rather than fabricate a delta between files that are not
-            there."
+            byte delta between the interpreted and compiled shapes is
+            published as evidence — the cost of promoting the app's views,
+            as a whole-app total and a per-view mean, with the fixture naming
+            both what the twins hold still and what they do not. When any
+            shape is unbuilt this SKIPS rather than fabricate a delta between
+            files that are not there."
     (let [present (into {} (filter (comp b5/bundle-present? val)) b5/matched-bundle-paths)]
       (if-not (= 3 (count present))
         (is true (str "not all three matched bundles are on disk — build "
@@ -200,24 +261,26 @@
               "the delta is tied to the interpreted bundle it was taken over")
           (is (= (:sha256 compiled) (:compiled-sha256 delta))
               "and to the compiled bundle")
-          (js/console.log
-            (str ";; B5 per-promotion byte delta (compiled minus interpreted) — "
-                 (if revision
-                   "evidence, no threshold"
-                   (str "NOT CITABLE (this run cannot name the source revision; set "
-                        "RF2_REVISION, or run in CI)"))
-                 "\n"
-                 (pr-str {:revision      revision
-                          :interpreted   {:raw    (:raw-bytes interp)
-                                          :gzip6  (:gzip6-bytes interp)
-                                          :brotli (:brotli-bytes interp)
-                                          :sha256 (:sha256 interp)}
-                          :mixed         {:raw    (:raw-bytes mixed)
-                                          :gzip6  (:gzip6-bytes mixed)
-                                          :brotli (:brotli-bytes mixed)
-                                          :sha256 (:sha256 mixed)}
-                          :compiled      {:raw    (:raw-bytes compiled)
-                                          :gzip6  (:gzip6-bytes compiled)
-                                          :brotli (:brotli-bytes compiled)
-                                          :sha256 (:sha256 compiled)}
-                          :promotion-delta delta}))))))))
+          ;; And the delta is published the way every other B5 figure is —
+          ;; through the workload harness and out the ONE provenance door,
+          ;; not console-logged as a bare map beside the records it derives
+          ;; from. Without a revision there is nothing to publish and nothing
+          ;; is invented; the three shapes' bytes above are still true.
+          (if-not revision
+            (js/console.log
+              (str ";; B5 per-promotion byte delta — NOT CITABLE (this run cannot name "
+                   "the source revision; set RF2_REVISION, or run in CI). Byte facts "
+                   "only: no result record was built.\n"
+                   (pr-str (assoc delta :promoted-views promoted-views
+                                        :mixed-sha256 (:sha256 mixed)))))
+            (publish! "B5 per-promotion byte delta (compiled minus interpreted)"
+                      (bench/run-workload
+                        (b5/promotion-delta-workload
+                          {:id             :B5/promotion-delta
+                           :doc            (str "the byte cost of promoting the release app's "
+                                                promoted-views " views, interpreted shape to "
+                                                "compiled shape")
+                           :sampling       {:warmup 0 :samples 1}
+                           :promoted-views promoted-views}
+                          interp compiled)
+                        (assoc fixture-provenance :revision revision)))))))))

--- a/implementation/freehand/test/re_frame/freehand/bench/b5_mount_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b5_mount_dom_cljs_test.cljs
@@ -236,12 +236,19 @@
                     :fixture   {:shape :mixed
                                 :leaves 2
                                 :tiers [:interpreted :compiled]
+                                :subject :recompiled-shape-not-the-release-artefact
                                 :measurement-method
                                 (str "wall time across act(v/mount) resolution — mount into a "
                                      "fresh container under a fresh owned frame whose "
                                      ":initial-events seed app-db, to React's first committed "
                                      "render; " warmup " warmup mounts discarded, " samples
-                                     " measured, one mount in flight at a time")}
+                                     " measured, one mount in flight at a time. The SUBJECT is "
+                                     "this namespace's recompilation of the mixed shape in the "
+                                     "browser-test build, NOT out/freehand-release/main.js: the "
+                                     "release build has no :dev-http and nothing serves it. So "
+                                     "this is the mount cost of the SHAPE under the build the "
+                                     "record's :build names, and is not the production bundle's "
+                                     "initial-mount cost")}
                     :build     (prov/detect-build)
                     :host      (prov/detect-host)
                     :sampling  {:warmup warmup :samples samples}

--- a/implementation/freehand/test/re_frame/freehand/bench/b5_reachability_control_app.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b5_reachability_control_app.cljs
@@ -1,0 +1,79 @@
+(ns re-frame.freehand.bench.b5-reachability-control-app
+  "The CONTROL entry of B5's reachability probe (`rf2-drpa3.52` acceptance 1).
+
+  D021's B5 row names a DETERMINISTIC gate beside the byte and timing
+  evidence: unused runtime modules are ABSENT from the production bundle.
+  That is a claim about what `:advanced` dead-code elimination removed, and
+  the only honest way to check it is a CONTROL BUILD — because the naive
+  oracles have both been MEASURED WRONG in this repository. Counting a
+  debug flag's occurrences reported 225 survivors in a bundle where the
+  whole surface had been eliminated (they were prose, not code), and
+  grepping a small function's name can never go red because Closure inlines
+  it. A grep with no control is a grep that cannot fail.
+
+  So this namespace is `re-frame.freehand.release-app` PLUS ONE THING: a
+  view that calls `v/controller-key`, the public door onto the semantic
+  controller infrastructure (`re-frame.freehand.control`). The production
+  entry declares no controller anywhere, so that module is unreachable
+  there and Closure removes it; here it is reached from the mount and
+  Closure must keep it. A string that lives only behind that door is
+  therefore a DISCRIMINATOR:
+
+    ABSENT  in out/freehand-release          — the module did not ship
+    PRESENT in out/freehand-release-reachability-control — the grep has teeth
+
+  The control side is the half that makes the gate falsifiable. Without it,
+  `absent` is indistinguishable from `misspelled`, `renamed`, `inlined` or
+  `never in this bundle to begin with`, and the gate would pass forever
+  while proving nothing.
+
+  ## Rooted BY CALL, never by export
+
+  `-main` CALLS `release-app/-main` and then mounts a view whose body calls
+  the door. Exporting a var instead would keep an empty function alive and
+  report a leak no consumer has — the other oracle mistake this repository
+  has already made once. Nothing here is `^:export` except the build's own
+  entry point.
+
+  This bundle is COMPILED AND GREPPED, never served and never run. It lives
+  under `freehand/test/` for the reason the sibling bundle probes do:
+  `deps.edn` publishes `src` alone, so a fixture that exists to be measured
+  stays out of the artefact a consumer resolves.
+
+  Normative owner: `docs/design/freehand/decisions/`
+  `D021-performance-budgets-and-release-evidence.md`."
+  (:require [re-frame.freehand :as v]
+            [re-frame.freehand.release-app :as release-app]))
+
+;; ---------------------------------------------------------------------------
+;; The one thing the production entry does not do
+;; ---------------------------------------------------------------------------
+
+(v/defview controlled-field
+  "A view that asks for a controller record key — the ONE call that makes
+  `re-frame.freehand.control` reachable. Its refusal doors (`:control`
+  absent, `:control` nil) carry the strings the gate discriminates on, and
+  the runtime cannot prove at compile time that neither refusal fires, so
+  `:advanced` keeps them."
+  [props]
+  [:output.control-probe (pr-str (v/controller-key ::field props))])
+
+(v/defview probe-root
+  "The probe's own root, mounted beside the production app's."
+  [_]
+  [:main#freehand-reachability-probe
+   [controlled-field {:control [:probe 1]}]])
+
+(defn ^:export -main
+  "The control build's `:init-fn`: everything the release entry roots, plus
+  the controller door.
+
+  Calling `release-app/-main` rather than re-declaring its views is what
+  keeps the two bundles comparable — the control is a strict SUPERSET of
+  production, so a string present here and absent there is present BECAUSE
+  of the controller and nothing else."
+  []
+  (release-app/-main)
+  (let [el (js/document.createElement "div")]
+    (.appendChild js/document.body el)
+    (v/mount [probe-root {}] el {:frame {:id ::frame}})))

--- a/implementation/freehand/test/re_frame/freehand/bench/provenance_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/bench/provenance_cljs_test.cljc
@@ -142,3 +142,23 @@
     (let [build (prov/detect-build)]
       (is (keyword? (:optimizations build)))
       (is (boolean? (:instrumentation? build))))))
+
+(deftest a-configured-hardware-class-beats-the-fallback
+  (testing "The precedence [[prov/hardware-class]] enforces, proved without
+            an environment. A configured class WINS — whatever route it
+            arrived by, an environment variable where the host has one or the
+            compile-time define where it does not. This is the rule the
+            browser lane broke: the runner exported RF2_HARDWARE_CLASS, the
+            page could not read it, nothing was configured as far as the page
+            was concerned, and thirteen release-worker records were published
+            labelled :developer-workstation."
+    (is (= :release-worker (prov/hardware-class "release-worker" false))
+        "a configured class wins over the workstation fallback")
+    (is (= :release-worker (prov/hardware-class "release-worker" true))
+        "and over the CI fallback — a pinned worker is not a shared runner")
+    (is (= :shared-ci-runner (prov/hardware-class nil true))
+        "unconfigured in CI, the runner is shared and the record says so")
+    (is (= :developer-workstation (prov/hardware-class nil false))
+        "and unconfigured off CI it is a developer workstation")
+    (is (= :developer-workstation (prov/hardware-class "   " false))
+        "a blank configuration is no configuration, not a class named \"   \"")))

--- a/implementation/package.json
+++ b/implementation/package.json
@@ -46,6 +46,8 @@
     "test:browser-prod-elision": "shadow-cljs release browser-test-prod-elision && node scripts/check-ui-mounted-prod-elision.cjs && node scripts/serve-and-run-browser-tests.cjs --root out/browser-test-prod-elision --port 8023",
     "test:elision": "shadow-cljs release elision-probe elision-probe-control && node scripts/check-elision.cjs",
     "test:freehand-evidence-elision": "shadow-cljs release freehand-release freehand-release-control && node scripts/check-freehand-evidence-elision.cjs",
+    "test:freehand-reachability": "shadow-cljs release freehand-release freehand-release-reachability-control && node scripts/check-freehand-reachability.cjs",
+    "build:freehand-matched": "shadow-cljs release freehand-release freehand-release-interpreted freehand-release-compiled",
     "test:perf-bundle": "shadow-cljs release examples/counter examples/counter-perf && node scripts/check-perf-bundle.cjs",
     "test:schemas-bundle": "shadow-cljs release schemas-bundle-probe schemas-bundle-probe-malli && node scripts/check-schemas-bundle.cjs",
     "test:bundle-isolation": "shadow-cljs release examples/counter examples/counter-uix examples/login examples/login-uix examples/realworld-resources bundle-isolation-positive-control && node scripts/check-bundle-isolation.test.cjs && node scripts/check-bundle-isolation.cjs && node scripts/check-uix-reagent-free.cjs && node scripts/check-login-bundle-isolation.cjs",

--- a/implementation/scripts/check-freehand-reachability.cjs
+++ b/implementation/scripts/check-freehand-reachability.cjs
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+/*
+ * B5 REACHABILITY — unused runtime modules are absent from the production
+ * bundle (rf2-drpa3.52, acceptance 1; D021 measurement B5).
+ *
+ * D021's B5 row splits in two. Bundle BYTES and parse/compile TIME are
+ * evidence, published with provenance and never thresholded — that half is
+ * `re-frame.freehand.bench.b5`. This is the other half, and it is a hard
+ * DETERMINISTIC gate: a page that ships Freehand does not pay for the parts
+ * of Freehand it does not use.
+ *
+ * WHY A CONTROL BUILD AND NOT A GREP
+ *
+ * Both naive oracles have been MEASURED WRONG in this repository:
+ *
+ *   - counting a debug flag's occurrences in a release bundle reported 225
+ *     survivors in a build where the entire gated surface had been
+ *     eliminated. They were prose, not code.
+ *   - grepping for a small function's name can never go red, because the
+ *     Closure compiler inlines the function and the name disappears whether
+ *     the code shipped or not.
+ *
+ * What both mistakes share is the absence of a POSITIVE CONTROL. A grep that
+ * has never been observed to fire cannot distinguish `absent` from
+ * `misspelled`, `renamed`, `inlined`, or `never in this bundle to begin
+ * with`. So the oracle is validated FIRST, in the same build configuration,
+ * against a bundle where the symbol is known to be present.
+ *
+ * THE PAIR
+ *
+ *   out/freehand-release                        PRODUCTION — what ships.
+ *                                               Entry: release-app/-main.
+ *   out/freehand-release-reachability-control   CONTROL — a strict SUPERSET.
+ *                                               Entry: the same -main CALLED,
+ *                                               plus one view that calls
+ *                                               `v/controller-key`.
+ *
+ * Same `:advanced`, same `goog.DEBUG false`, same everything else. The ONLY
+ * variable is that the control's app reaches the semantic-controller
+ * infrastructure (`re-frame.freehand.control`) and the production app does
+ * not. So a string that lives only behind that door is a DISCRIMINATOR:
+ *
+ *   ABSENT  in production  — the unused module did not ship (the claim)
+ *   PRESENT in the control — the grep has teeth (the oracle's validation)
+ *
+ * Note what this does NOT share with `check-freehand-evidence-elision.cjs`.
+ * That gate moves `goog.DEBUG` and holds the app still, proving a DEV-GATED
+ * seam elides. This one holds the flag still and moves the APP, proving an
+ * unused MODULE elides. Two different claims, and neither substitutes for
+ * the other: the controller strings below are absent from the goog.DEBUG=true
+ * control too, which is exactly why that build cannot prove this.
+ *
+ * Strategy: grep, not parse — Closure renames symbols but does not rewrite
+ * string literals. No byte assertion anywhere: D021's NON-GOALS bar a
+ * byte-size threshold, and this states only present/absent.
+ *
+ * Exit 0 on PASS, 1 on FAIL.
+ */
+
+'use strict';
+
+const path = require('path');
+const { createGateReporter } = require('./lib/gate-report.cjs');
+const { classifyReleaseBundle } = require('./lib/read-release-bundle.cjs');
+const { assertSentinelSet } = require('./lib/sentinel-scan.cjs');
+
+const ROOT   = path.resolve(__dirname, '..');
+const report = createGateReporter();
+
+// ----- the reachability contract ---------------------------------------------
+
+// UNUSED-MODULE sentinels: exact runtime string literals from
+// `re-frame.freehand.control`, the semantic-controller infrastructure. They
+// are the refusal messages of `record-key`'s two doors — an absent `:control`
+// and an explicit `nil` one — and `record-key` is what `v/controller-key`
+// resolves to. Any view that asks for a controller key reaches both; a bundle
+// whose app never asks reaches neither.
+//
+// They are error-path strings on purpose. An error message must fire in
+// production, so it is not behind `goog.DEBUG` and its absence is a
+// REACHABILITY result rather than a flag result. They are also not
+// docstrings (those do ship — see the 225-survivor trap above) and not
+// fragments synthesised from keywords, so the grep is unambiguous.
+//
+// TWO independent doors, not one, so a single message being reworded cannot
+// silently halve the gate: both must move together, and the control half
+// reds if either stops being reachable.
+const UNUSED_MODULE_SENTINELS = [
+  { source: 're-frame.freehand.control/missing-address! + nil-address! (shared head)',
+    sentinel: 'A writable controller of kind ' },
+  { source: 're-frame.freehand.control/nil-address! (refusal tail)',
+    sentinel: 'was rendered with :control nil' },
+];
+
+// PROD-SURVIVING sentinels: strings the release app ships regardless. Present
+// in BOTH bundles, and the non-vacuity floor for the methodology itself —
+// proof that the production bundle is a real, inspected artefact in which the
+// unused module's ABSENCE is a DCE result and not an accident of reading the
+// wrong file, an empty file, or a broken build.
+const PROD_SURVIVING_SENTINELS = [
+  { source: 're-frame.freehand.release-app (registered id survives :advanced)',
+    sentinel: 're-frame.freehand.release-app/bump' },
+];
+
+// ----- helpers ---------------------------------------------------------------
+
+function assertSentinels(blob, sentinels, mustContain) {
+  return assertSentinelSet(blob, sentinels, {
+    mustContain,
+    emit: (line) => report.detail(line),
+    formatLine: ({ source, sentinel, present, tag }) => {
+      const expected = mustContain ? 'PRESENT' : 'ABSENT';
+      const actual   = present     ? 'PRESENT' : 'ABSENT';
+      return `          [${tag}] ${source}: sentinel ${JSON.stringify(sentinel)} expected ${expected}, was ${actual}`;
+    },
+  });
+}
+
+// Read a bundle dir, rejecting a missing or present-but-empty dir. An empty
+// bundle satisfies every ABSENCE check and would false-GREEN the whole gate.
+function readBundle(label, dir) {
+  const { status, blob } = classifyReleaseBundle(dir);
+  if (status === 'missing') {
+    console.error(`[freehand-reachability] ${label}: bundle path missing — ${dir}`);
+    console.error('         Run "npm run test:freehand-reachability".');
+    return { ok: false, blob: null, bytes: null };
+  }
+  if (status === 'empty') {
+    console.error(`[freehand-reachability] ${label}: bundle present but empty (zero top-level JS) — ${dir}`);
+    console.error('         An empty bundle proves nothing got inspected. Rebuild with');
+    console.error('         "npm run test:freehand-reachability" or clear the stale dir.');
+    return { ok: false, blob: null, bytes: 0 };
+  }
+  report.detail(`[freehand-reachability] ${label}: ${dir}`);
+  report.detail(`          bundle size: ${blob.length} chars`);
+  return { ok: true, blob, bytes: blob.length };
+}
+
+// ----- main ------------------------------------------------------------------
+
+function main() {
+  report.detail('=== B5 reachability probe — unused runtime modules (rf2-drpa3.52) ===');
+
+  const releaseDir = path.join(ROOT, 'out', 'freehand-release');
+  const controlDir = path.join(ROOT, 'out', 'freehand-release-reachability-control');
+
+  const release = readBundle('production (release-app)          ', releaseDir);
+  const control = readBundle('control    (release-app + control)', controlDir);
+
+  if (!release.ok || !control.ok) {
+    report.flushDetails();
+    console.error('=== FAIL: a bundle was missing or empty (see above) ===');
+    process.exit(1);
+  }
+
+  // THE ORACLE IS VALIDATED FIRST. The control must PRESENT every sentinel;
+  // until it does, the production ABSENCE result below means nothing, and
+  // saying so in this order is the difference between a gate and a habit.
+  report.detail('[freehand-reachability] CONTROL — the doors must be PRESENT (oracle validation):');
+  const controlPresent  = assertSentinels(control.blob, UNUSED_MODULE_SENTINELS, true);
+  report.detail('[freehand-reachability] CONTROL — app survivor must be PRESENT:');
+  const controlSurvives = assertSentinels(control.blob, PROD_SURVIVING_SENTINELS, true);
+
+  // PRODUCTION: the same doors must be ABSENT (the module was not reachable
+  // and Closure removed it), and the application survivor must be PRESENT
+  // (the bundle really is the artefact, really was read, really was scanned).
+  report.detail('[freehand-reachability] PRODUCTION — the doors must be ABSENT (unused module DCE):');
+  const releaseAbsent   = assertSentinels(release.blob, UNUSED_MODULE_SENTINELS, false);
+  report.detail('[freehand-reachability] PRODUCTION — app survivor must be PRESENT (non-vacuity floor):');
+  const releaseSurvives = assertSentinels(release.blob, PROD_SURVIVING_SENTINELS, true);
+
+  const ok = controlPresent.ok && controlSurvives.ok
+          && releaseAbsent.ok  && releaseSurvives.ok;
+
+  if (ok) {
+    report.pass(
+      'freehand-reachability',
+      `oracle validated: control ${controlPresent.passed}/${controlPresent.checked} doors present ` +
+      `(${control.bytes} chars); production ${releaseAbsent.passed}/${releaseAbsent.checked} doors absent ` +
+      `(${release.bytes} chars); survivor present in both`
+    );
+    process.exit(0);
+  }
+
+  report.flushDetails();
+  console.error('=== FAIL ===');
+  if (!controlPresent.ok) {
+    console.error('The ORACLE IS NOT VALID: the control bundle is missing a controller');
+    console.error('door, so the production ABSENCE result below proves nothing. Most');
+    console.error('likely the control entry stopped reaching the door (the');
+    console.error('v/controller-key call removed or made unreachable), or a refusal');
+    console.error('message was reworded. Fix the control entry, or update');
+    console.error('UNUSED_MODULE_SENTINELS to track a deliberate rename — but do NOT');
+    console.error('relax this half: it is the only thing making the gate falsifiable.');
+  }
+  if (!releaseAbsent.ok) {
+    console.error('REACHABILITY BROKE: the semantic-controller runtime survived into the');
+    console.error('production bundle, whose app declares no controller. Something now');
+    console.error('reaches re-frame.freehand.control from the release entry, so a page');
+    console.error('that uses no controller pays for the controller infrastructure.');
+    console.error('Find the new edge — a render path calling controller-key, a registry');
+    console.error('holding the module live, an eagerly-rooted var — and cut it.');
+  }
+  if (!releaseSurvives.ok || !controlSurvives.ok) {
+    console.error('A PROD-SURVIVING survivor was absent — the bundle scanned is not the');
+    console.error('artefact expected, so the ABSENCE result is not trustworthy. Confirm');
+    console.error('the build entry (re-frame.freehand.release-app/-main) still ships its');
+    console.error('registrations, or update PROD_SURVIVING_SENTINELS.');
+  }
+  process.exit(1);
+}
+
+main();

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -924,6 +924,40 @@
                       :closure-defines {goog.DEBUG true}}
    :modules {:main {:init-fn re-frame.freehand.release-app/-main}}}
 
+  ;; rf2-drpa3.52 acceptance 1 — the REACHABILITY control, and the second
+  ;; control twin of :freehand-release. D021's B5 row asks for a
+  ;; deterministic proof that UNUSED RUNTIME MODULES are absent from the
+  ;; production bundle, and the naive oracles have both been measured wrong
+  ;; here (a debug flag survived 225 times inside prose; Closure inlines a
+  ;; small function's name, so grepping for it can never go red). The
+  ;; technique that works is a control build.
+  ;;
+  ;; The two controls differ in WHICH variable they move, and that is the
+  ;; whole difference between the two claims:
+  ;;
+  ;;   :freehand-release-control               goog.DEBUG moves — proves the
+  ;;                                           dev-gated EVIDENCE SEAM elides
+  ;;   :freehand-release-reachability-control  the APP moves — proves an
+  ;;                                           unused runtime MODULE elides
+  ;;
+  ;; Same :advanced, same goog.DEBUG false, same everything the release build
+  ;; sets. The entry is a strict SUPERSET of the release entry: it CALLS
+  ;; `release-app/-main` and additionally mounts a view that calls
+  ;; `v/controller-key`, the public door onto `re-frame.freehand.control`. So
+  ;; a string present here and absent from the release bundle is present
+  ;; BECAUSE of the controller and nothing else.
+  ;;
+  ;; Built and grep'd by `npm run test:freehand-reachability`
+  ;; (scripts/check-freehand-reachability.cjs), never served.
+  :freehand-release-reachability-control
+  {:target     :browser
+   :output-dir "out/freehand-release-reachability-control"
+   :asset-path "."
+   :compiler-options {:optimizations :advanced
+                      :infer-externs :auto
+                      :closure-defines {goog.DEBUG false}}
+   :modules {:main {:init-fn re-frame.freehand.bench.b5-reachability-control-app/-main}}}
+
   ;; The ClojureScript/Node lane of the Freehand B-spine (D021).
   ;;
   ;; `clojure -M:bench` is a JVM process, so it reaches every `.cljc`

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -1175,6 +1175,15 @@
   ;; an unset environment produces an unattributable record, never an
   ;; invented revision.
   ;;
+  ;; THE HARDWARE CLASS CROSSES THE SAME BOUNDARY, and for the same reason a
+  ;; page cannot read `process.env`. Exporting `RF2_HARDWARE_CLASS` in the
+  ;; runner's environment configures the RUNNER; until this define existed
+  ;; the page itself saw nothing, `detect-hardware-class` fell through to its
+  ;; `:developer-workstation` default, and the pinned release worker
+  ;; published records labelled with a machine class it was not running on.
+  ;; Read from the same variable, through the same `#shadow/env`, with the
+  ;; same empty default that degrades honestly on an unconfigured local run.
+  ;;
   ;; The ns-regexp selects the bench's own DOM suites and nothing else, so
   ;; the captured console is the evidence rather than a 757-test transcript
   ;; to sift. Those same namespaces still run under the broader
@@ -1193,8 +1202,9 @@
    ;; Playwright runner watches, and a green suite presents as a hang.
    :compiler-options
    {:closure-defines
-    {cljs-test-display.core/printing                   true
-     re-frame.freehand.bench.provenance/build-revision #shadow/env ["RF2_REVISION" ""]}}
+    {cljs-test-display.core/printing                        true
+     re-frame.freehand.bench.provenance/build-revision      #shadow/env ["RF2_REVISION" ""]
+     re-frame.freehand.bench.provenance/build-hardware-class #shadow/env ["RF2_HARDWARE_CLASS" ""]}}
    :devtools  {:http-port 8024
                :http-root "out/browser-test-freehand-bench"}}
 


### PR DESCRIPTION
Three bench-evidence beads on one surface, each reopened by a merged-PR audit that named a specific unmet obligation. This discharges the ones whose repair site is inside this PR's surface, and records precisely why the rest stay open.

- **rf2-drpa3.147** — reopened by the #6891 audit. **CLOSED.**
- **rf2-x4jda** — reopened by the #6887 audit. **LEFT OPEN**: 4 of 6 residuals discharged.
- **rf2-drpa3.52** — acceptance 1, the control-build reachability gate, never delivered. **LEFT OPEN**: the gate exists and is green, but runs in no CI job (rf2-zl8ao).

## rf2-drpa3.147 — the browser lane was labelling the wrong machine

The #6891 audit found the lane publishing thirteen correctly-revisioned records that all named `:developer-workstation`, on a runner whose `env:` said `release-worker`. A page cannot read `process.env`, so setting the variable configured the runner and nothing else. `provenance/result` certified every one of them, because the ledger asks for a keyword and got one — a *wrong* keyword is exactly what it cannot see.

The hardware class now crosses the same compile-time boundary the revision already did: a `build-hardware-class` goog-define, read from `RF2_HARDWARE_CLASS` through `#shadow/env`. `detect-hardware-class` grows a pure `hardware-class` core so the precedence is provable without an environment, and the lane refuses a record naming a class it is not — with a floor that reds if `:host` stops being published at all.

No new harness, no machine-inventory layer, no numeric gate — exactly the bounded repair the audit specified. Retained-object evidence stays open by design (the census remains honestly named wrapper-classified occurrences, per the mayor's ruling and the #6881 audit that accepted it); nothing here adds ViewCell liveness or heap machinery.

## rf2-x4jda — the matched-build row gets a record, a method and a lane

- **The delta is a record.** It was console-logged as a bare map beside the records it derives from: no `:host`, `:build`, `:sampling` or `:baseline`, and no visit to `provenance/result`. `b5/promotion-delta-workload` makes it a workload, so it goes out the one door with the full record shape. Baseline `:interpreted-vs-compiled`, referencing the interpreted arm.
- **Total *and* per-view.** The whole-app figure is named as one, beside the per-promoted-view figure D021 asks for — named for the **mean** it is, since this app's promoted views are the same body twice under one root. The promoted-view count is a fixture parameter supplied by the test, because `b5` measures files and does not read the entries that produced them.
- **The method follows the artefact.** `measurement-method` was a constant naming `out/freehand-release/main.js`, inherited verbatim by twins whose own `:artefact` named a different file. It is a function of the path.
- **A lane that builds the bundles.** The three `:advanced` shapes were artefacts nothing in CI built, and both B5 Node tests skip without them — so the matched figures existed only in a terminal and a PR body.

### The attribution claim was false, and is now measured

The code said the delta was "attributable to lowering and nothing else". It is not, and the reason is bigger than identifier names: **`:advanced` does not strip the namespace docstring.** It ships three times in each twin, once per declared view, and the two docstrings are different prose because they describe different things.

| difference | direction |
|---|---|
| ns docstring, 1486 B × 3 vs 1601 B × 3 | **+345** |
| ns-qualified ids and root DOM id | **−48** |
| **net non-lowering** | **+297 raw B of an 18,475 B raw delta — 1.6 %** |

(Per-*view* docstrings do not ship; checked, 0 occurrences.) The false claim is gone, and `b5/matched-on` / `b5/not-matched-on` now travel **with the published record** instead of living in a reviewer's memory.

## rf2-drpa3.52 — the control-build reachability gate

`npm run test:freehand-reachability`. This is **not** rf2-drpa3.166's gate: that one holds the app still and moves `goog.DEBUG` (the dev-gated seam elides); this one holds the flag still and moves the **app** (an unused runtime module elides). The distinction is measurable, not rhetorical — the controller strings this gate uses are absent from the `goog.DEBUG=true` control too, which is precisely why that build cannot prove this.

`:freehand-release-reachability-control` is a strict **superset** of production: same `:advanced`, same `goog.DEBUG false`, and its entry *calls* `release-app/-main` then mounts one extra view calling `v/controller-key`. Both known-wrong oracles are avoided by construction: the sentinels are error-path strings (not docstrings — this PR confirms docstrings ship), not small function names (Closure inlines those), and the probe is rooted by call, never by exporting a var.

Production 744,100 chars, 2/2 doors **absent**. Control 752,791 chars, 2/2 doors **present**. The controller runtime is 8,691 chars a page declaring no controller does not ship.

## Quality gates

Every gate run in the foreground to completion, captured to a worktree-local log, exit code echoed.

| gate | result | exit |
|---|---|---|
| `clojure -M:test` (implementation/freehand) | 939 tests / 6692 assertions, 0 failures, 0 errors | **0** |
| `npm run test:freehand` (RF2_REVISION set, 3 bundles built) | 1020 tests / 5810 assertions, 0 failures, 0 errors; 5 citable B5 records | **0** |
| `npm run test:freehand` (no RF2_REVISION) | 1020 / 5800, 0 failures; every B5 line `NOT CITABLE` | **0** |
| `npm run bench:freehand-browser` (revision only) | 14 tests / 226 assertions, 0 failures; 13 citable, 13 `:developer-workstation` | **0** |
| `npm run bench:freehand-browser` (revision + class) | 14 / 226, 0 failures; 13 citable, 13 `:release-worker` | **0** |
| `npm run test:freehand-reachability` | PASS — oracle validated, 2/2 present in control, 2/2 absent in production | **0** |
| `npm run test:freehand-evidence-elision` (regression) | PASS — 2/2 absent, 2/2 present, survivor in both | **0** |
| `.github/workflows/freehand-bench.yml` | YAML parses; 3 jobs, steps as intended | **0** |
| `implementation/package.json` | parses | **0** |

### Non-vacuity — every gate shown red on known-bad input

No assertion here passes because nothing was measured.

- **Hardware-class check.** Red on the real log from the run without the define (`:hardware-class :developer-workstation` → exit 1). Green on the log with it. Red again on a log with `:hardware-class` stripped out, so the "no wrong class" check cannot pass by finding nothing.
- **B5 lane check.** Red on a real run taken with one bundle removed — the suite is **green, exit 0**, and publishes zero matched-shape records; the check exits 1 with `expected 3 matched-shape records, found 0`. Red on the no-revision log. Green on the good one.
- **Reachability gate.** Red three ways with the correct diagnostic each time: a production bundle that *does* reach the module (`REACHABILITY BROKE`); a control bundle that has *lost* the door (`The ORACLE IS NOT VALID`); an empty production bundle (non-vacuity floor). Green on the real pair.

## Residual by residual

| bead | residual | disposition |
|---|---|---|
| **rf2-drpa3.147** | browser records name a hardware class the lane is not | **discharged** — compile-time define + lane check, both directions reproduced |
| rf2-drpa3.147 | retained runtime-object evidence | **open by design** — ruled resolved as wrapper-classified occurrences; no liveness or heap machinery added |
| **rf2-x4jda** R3 | delta bypasses `prov/result` | **discharged** — it is a workload now |
| **rf2-x4jda** R2 | whole-app delta, no per-view figure | **discharged** — both published; per-view named as a mean |
| **rf2-x4jda** R4 | `measurement-method` hard-coded to one path | **discharged** — a function of the artefact |
| **rf2-x4jda** R6 | no lane builds the three bundles | **discharged** — ClojureScript lane builds, runs and uploads them |
| **rf2-x4jda** R1 | three namespaces, so the delta is not lowering alone | **left open** — repair site is `freehand/test/re_frame/freehand/release_app*.cljs`, fenced to the concurrent D007-deletion worker. The false claim is removed and the confound measured (+297 B, 1.6 %) and published; the fix needs one shared entry shape |
| **rf2-x4jda** R5 | mount figure is a DEBUG recompilation | **left open** — loading the advanced artefact needs it served and driven, i.e. a browser harness this PR deliberately did not build. The record now carries `:subject :recompiled-shape-not-the-release-artefact` and the reason, so it cannot be mistaken for the production bundle's load cost |
| **rf2-drpa3.52** acc. 1 | control-build reachability gate | **discharged** — gate ships, oracle validated first, falsified three ways |
| rf2-drpa3.52 | the gate runs in no CI job | **left open** — `test.yml` and `expensive-tests.yml` are outside this PR's surface. **rf2-zl8ao** filed and linked as a blocker |

## Fenced, and honoured

`implementation/freehand/src/**` outside `bench/`, `implementation/freehand/test/**` outside `bench/`, `spec/**`, `tools/**`, `implementation/resources/**`, `.github/workflows/test.yml`, `.github/workflows/expensive-tests.yml`, `.github/workflows/release.yml`. Two residuals (x4jda R1, and .52's CI wiring) land outside the surface and are recorded rather than reached for.

Beads: **rf2-drpa3.147** (closed), **rf2-x4jda** (open), **rf2-drpa3.52** (open), **rf2-zl8ao** (filed).
