### PR TITLE
fix(template)!: drop the unresolvable re-frame.ui build hook from the shared scaffold (rf2-vwum3)

### DIFF
--- a/scripts/check_donor_inventory.py
+++ b/scripts/check_donor_inventory.py
@@ -148,12 +148,16 @@ _SECTION = re.compile(r"^##+\s+(.*?)\s*$")
 # is deleted. Nothing looser: incidental prose is deliberately not policed.
 #
 #   require     a Clojure/EDN libspec naming a `re-frame.ui…` namespace —
-#               `[re-frame.ui :as ui]`, `[re-frame.ui.tree :as tree]`, or a
-#               build's `:entries [re-frame.ui.g13.dev]` vector.
+#               `[re-frame.ui :as ui]`, `[re-frame.ui.tree :as tree]`, a
+#               build's `:entries [re-frame.ui.g13.dev]` vector, or a
+#               shadow-cljs `:build-hooks [(re-frame.ui.compiler.build-hook/hook)]`
+#               entry. That last shape needs the optional `(` and the `/`
+#               terminator: without them the census silently missed every
+#               shadow-cljs.edn that wires the donor's build hook (rf2-vwum3).
 #   coordinate  the donor artifact coordinate in DEPENDENCY position —
 #               `day8/re-frame2-ui {…}` in a deps.edn, a generated scaffold, or
 #               an install instruction. A bare mention in prose does not match.
-CENSUS_REQUIRE_RE = re.compile(r"\[re-frame\.ui[A-Za-z0-9._-]*[\s\]]")
+CENSUS_REQUIRE_RE = re.compile(r"\[\(?re-frame\.ui[A-Za-z0-9._-]*[\s\]/]")
 CENSUS_COORD_RE = re.compile(r"day8/re-frame2-ui\s+\{")
 
 # The require signal only means anything in a file that can carry a libspec.
@@ -756,6 +760,19 @@ def _run_self_tests(*, verbose: bool = False) -> int:
     expect("H3 signals are named",
            census["implementation/ssr/test/re_frame/ssr/hydrate_cljs_test.cljs"],
            ("require",))
+
+    # The shadow-cljs build-hook shape (rf2-vwum3): `[(re-frame.ui…/hook)]`.
+    # The leading paren and the `/` terminator both used to defeat the require
+    # signal, so a generated scaffold wiring the donor's build hook was invisible
+    # to the census.
+    hook_tracked = ["app/shadow-cljs.edn"]
+    hook_read = _fixture_reader({
+        "app/shadow-cljs.edn":
+            "{:build-defaults {:build-hooks [(re-frame.ui.compiler.build-hook/hook)]}}",
+    })
+    expect("H3a census sees a wired build hook",
+           live_consumers(hook_tracked, hook_read),
+           {"app/shadow-cljs.edn": ("require",)})
 
     rows, _ = parse_ledger(full)
     problems = check_consumers(rows, census)

--- a/tools/template/resources/day8/re_frame2_template/_shared/shadow-cljs.edn
+++ b/tools/template/resources/day8/re_frame2_template/_shared/shadow-cljs.edn
@@ -14,15 +14,6 @@
 
  :dev-http {8280 "resources/public"}
 
- ;; re-frame.ui compiles your views (reg-view / defui / defnc). The build hook
- ;; harvests its whole-build registries (view digests, root/plan indexes, Root
- ;; Descriptors, custom-element declarations) from cache-durable per-namespace
- ;; analyzer data at build time. This ONE setting is load-bearing — without it
- ;; the app throws on namespace load. Because the registries no longer depend on
- ;; macro-expansion side effects, a warm daemon start REUSES Shadow's disk cache
- ;; (no cache blocker needed).
- :build-defaults {:build-hooks [(re-frame.ui.compiler.build-hook/hook)]}
-
  :builds
  {:app
   {:target     :browser

--- a/tools/template/test/day8/re_frame2_template/template_test.clj
+++ b/tools/template/test/day8/re_frame2_template/template_test.clj
@@ -119,20 +119,22 @@
             :uix     (is (nil? (get-in app [:devtools :preloads]))
                          ":uix shadow-cljs :app build wires NO preloads —
                           no Xray on the element substrates (rf2-p6f6u)"))
-          ;; re-frame.ui build-hook — the ONE re-frame.ui build setting,
-          ;; REQUIRED for any browser build to boot. re-frame.ui compiles the
-          ;; views and the hook harvests its whole-build registries from
-          ;; cache-durable analyzer data; without the hook the :app bundle
-          ;; throws on namespace load. The old top-level :cache-blockers tax was
-          ;; removed at the S6 cut-over (rf2-u53yy.1): the registries no longer
-          ;; depend on macro-expansion side effects, so a warm daemon reuses the
-          ;; disk cache and no cache blocker is needed.
+          ;; NO build hooks (rf2-vwum3). Both scaffolds used to wire the
+          ;; compiled-view substrate's compiler build hook into
+          ;; `:build-defaults`, but that hook's namespace ships inside
+          ;; `day8/re-frame2-ui` and NEITHER emitted deps.edn declares a
+          ;; coordinate that provides it — the adapter
+          ;; substrates render through Reagent / UIx, not through the
+          ;; compiled-view substrate. Shadow does not fail on an unloadable
+          ;; hook (it warns and continues, exit 0), so the scaffold shipped a
+          ;; hook that silently did nothing. A scaffold names a build hook only
+          ;; when its own deps.edn carries the artefact that supplies it.
           (is (not (contains? (set (keys scs)) :cache-blockers))
               "shadow-cljs.edn no longer carries the removed :cache-blockers tax")
-          (is (some #{'(re-frame.ui.compiler.build-hook/hook)}
-                    (get-in scs [:build-defaults :build-hooks]))
-              "shadow-cljs.edn wires the re-frame.ui compiler build-hook into
-               every build (else a browser build throws on namespace load)"))
+          (is (empty? (get-in scs [:build-defaults :build-hooks]))
+              "shadow-cljs.edn wires NO build hooks — the scaffold's deps.edn
+               supplies no artefact carrying one, and shadow only warns on a
+               hook it cannot load (rf2-vwum3)"))
 
         ;; -- Xray coord in deps.edn — REAGENT-ONLY (rf2-p6f6u) --
         (let [deps (read-edn (io/file root "deps.edn"))]


### PR DESCRIPTION
Closes rf2-vwum3.

The shared scaffold emitted, for **both** remaining substrates:

```clojure
:build-defaults {:build-hooks [(re-frame.ui.compiler.build-hook/hook)]}
```

That namespace ships inside `day8/re-frame2-ui`, and neither emitted `deps.edn` declares a coordinate that provides it. shadow-cljs does not fail on an unloadable build hook — it warns and continues to exit 0 — so the default scaffold shipped a hook that silently did nothing, and every gate stayed green throughout.

## What the hook actually does, and whether anything needed it

`re-frame.ui.compiler.build-hook/hook` is purely `re-frame.ui` compiler state. At `:compile-prepare` it harvests every authoritative member's literal `(ui/custom-element …)` declarations into an all-members manifest, coarse-invalidates the UI literal-consumer set when that manifest changed on a warm build, and wires the runtime removed-source projection; at `:compile-finish` it folds each member's descriptor into the whole-build registries (view digests, Layer-1 root/plan indexes, Root Descriptors). Every one of those is a compiled-view-substrate concern.

**Neither remaining scaffold has compiled views.** `_reagent/views.cljs` uses core's `rf/reg-view` — the macro lives in `implementation/core/src/re_frame/core.cljc:741`, not in the donor. `_uix/views.cljs` uses `uix.core/defui`. So nothing in either scaffold is load-bearing on the hook, and the removed comment's claim that "without it the app throws on namespace load" is false for these substrates — disproven below by a real browser boot of both.

This is subtraction, not replacement. Consumers who genuinely install `re-frame.ui` already have the documented path in `docs/core/how-to/install-re-frame-ui.md`, and `skills/re-frame2-setup/references/shadow-cljs.md` already states the rule this change brings the scaffold into line with: *"Only add it once `day8/re-frame2-ui` is actually on the classpath … not a setting to add speculatively to a project that has no compiled views."*

### Why the Reagent variant looked fine

`:uix` had nothing supplying the namespace at all. `:reagent` resolved it **only in-repo, transitively**, through `tools/xray/deps.edn:51`'s `day8/re-frame2-ui {:local/root "../../implementation/ui"}` — an edge no Clojars consumer of `day8/re-frame2-xray` can follow, since `day8/re-frame2-ui` is never published. Confirmed directly on the generated Reagent app's classpath:

```
$ clojure -Spath | tr ';' '\n' | grep implementation.ui
C:\...\template-hook-vwum3\implementation\ui\src
```

That is also the sequencing risk: when F6e (`rf2-drpa3.57`) deletes `implementation/ui/`, that edge disappears and the Reagent scaffold degrades from a silent no-op into the same hard warning `:uix` already had.

## Cold consumer-shaped compile, before and after

Both variants generated **outside any harness** via the documented `-Tnew` command, then `npm install` and `npx shadow-cljs compile app` in the generated project. Framework coords resolved through the repo's standard `:local/root` rewrite (the published alpha channel does not exist yet); the dependency **set** is exactly what the scaffold emits.

**`:uix` BEFORE** — the faithful consumer case, since nothing in its dependency set supplies `re-frame.ui`:

```
[:app] Compiling ...
[2026-07-25 08:06:59.418 - WARNING] :shadow.build/hook-config-ex - {:hook-idx 0, :hook-sym re-frame.ui.compiler.build-hook/hook, :build-id :app}
FileNotFoundException Could not locate re_frame/ui/compiler/build_hook__init.class, re_frame/ui/compiler/build_hook.clj or re_frame/ui/compiler/build_hook.cljc on classpath.
	clojure.lang.RT.load (RT.java:482)
	...
build hook: re-frame.ui.compiler.build-hook/hook failed to load and will not be used
[:app] Build completed. (172 files, 171 compiled, 0 warnings, 11.91s)
```

exit **0** — the silent no-op this bead is about.

**`:uix` AFTER:**

```
[:app] Compiling ...
[:app] Build completed. (172 files, 171 compiled, 0 warnings, 12.52s)
```

exit **0**, zero matches for `hook-config-ex` or `failed to load and will not be used`. Identical file counts — the hook contributed nothing.

**`:reagent` BEFORE** — clean at `532 files, 531 compiled, 0 warnings`, exit 0, but only because `implementation/ui/src` rode in on the in-repo classpath edge shown above.

**`:reagent` AFTER:**

```
[:app] Compiling ...
[:app] Build completed. (532 files, 531 compiled, 0 warnings, 24.84s)
```

exit **0**, zero marker matches, and no longer dependent on that edge at all.

Neither AFTER build emits either line. Both then compiled the `:test` build, ran their emitted node tests green, and — the direct disproof of the "throws on namespace load" claim — booted in real Chromium:

```
dev-page boot proof PASS (reagent-app): the emitted index.html booted the dev bundle,
  #app painted the counter, the click moved it 0 -> 1, and Chromium reported zero uncaught pageerrors.
dev-page boot proof PASS (uix-app): ... zero uncaught pageerrors.
```

## The census regex

`CENSUS_REQUIRE_RE` in `scripts/check_donor_inventory.py` required the namespace to sit directly after `[` and to terminate on whitespace or `]`. A build-hook entry is `[(re-frame.ui.compiler.build-hook/hook)]`, so the leading paren and the `/` terminator each defeated it independently — which is why this real donor consumer carried no ledger row. Widened to `\[\(?re-frame\.ui[A-Za-z0-9._-]*[\s\]/]`, plus one self-test case pinning the shape.

Proof the fix bites: with the regex widened and the hook still present, the gate named exactly the missed file and nothing else —

```
DONOR-LEDGER-UNCOVERED-CONSUMER: tools/template/resources/day8/re_frame2_template/_shared/shadow-cljs.edn
  still consumes the donor (require) and no row of spec/conformance/freehand/donor-inventory.md claims it.
```

**No ledger row was needed**, and `spec/conformance/freehand/donor-inventory.md` is untouched: removing the hook removes the consumer, so the census demands nothing. Row count is unchanged at 203 / 152 undisposed. The widened regex newly matches `implementation/shadow-cljs.edn` and `examples/ui/minimal-counter/*` too, and both are already claimed by `pending` rows, so neither trips the gate.

## Quality gates

All run in the foreground to completion, logs captured worktree-local.

| Gate | Result | Exit |
|---|---|---|
| `cd tools/template && clojure -M:test` | 59 tests, 611 assertions, **0 failures, 0 errors** | 0 |
| `cd tools/template && RF2_TEMPLATE_RUN_EMITTED_TESTS=1 clojure -M:test` | 59 tests, 696 assertions, **0 failures, 0 errors** | 0 |
| `python scripts/check_donor_inventory.py` | 203 rows, 152 undisposed, no defects | 0 |
| `python scripts/check_donor_inventory.py --self-test` | all cases passed | 0 |
| cold `-Tnew` generate + `npm install` + `compile app` — `:reagent` | 532 files, 531 compiled, 0 warnings; no hook markers | 0 |
| cold `-Tnew` generate + `npm install` + `compile app` — `:uix` | 172 files, 171 compiled, 0 warnings; no hook markers | 0 |
| `npx shadow-cljs compile app test` — both variants | app + test builds green | 0 |
| `node out/node-test.js` — both variants | 3 tests, 3 assertions, 0 failures, 0 errors each | 0 |
| `dev-page-boot-proof.cjs` — both variants | PASS: mounted, counter 0 → 1, zero pageerrors | 0 |

`mkdocs build --strict` not run: no docs or template spec prose changed (the diff is one resource, one test, one script).
