### PR TITLE
ci(freehand): watch implementation/freehand/test/** in the conformance push trigger (rf2-drpa3.180)

### DIFF
--- a/.github/workflows/freehand-conformance.yml
+++ b/.github/workflows/freehand-conformance.yml
@@ -43,6 +43,7 @@ on:
     branches: [main]
     paths:
       - 'spec/conformance/freehand/**'
+      - 'implementation/freehand/test/**'   # the fixture tree the index cites
       - 'scripts/check_freehand_conformance_index.py'
       - 'scripts/check_donor_inventory.py'
       - 'scripts/check_doc_slugs.py'   # supplies the shared slug index


### PR DESCRIPTION
Closes rf2-drpa3.180.

The `freehand-conformance` gate's verdict depends on `implementation/freehand/test/**`. `_check_fixture` resolves every `active` row's fixture cell as a repo path and fails the row when that file is gone; the execution census added by rf2-drpa3.53 (PR #6907, still open) goes further and derives its manifest from the `(conf/fixture :FH-...)` sites in that tree, so a deleted test can turn a row UNPROVEN. The push trigger did not watch the tree, so a push to `main` touching only those fixtures did not re-run the job.

One path entry added to the push trigger's `paths` list. Nothing else changed.

**The `pull_request` trigger is untouched and remains UNFILTERED**, per the REQUIRED-CHECK SHAPE comment at the top of the workflow — that is deliberate and load bearing, since it keeps the `Freehand conformance index` status context present on every PR without the phantom-pending trap. No new job, no widened PR trigger, no path-derivation mechanism.

### Parsed push-trigger paths

Both lists produced by `yaml.safe_load` of the workflow, not read off the diff.

Before:

```json
[
  "spec/conformance/freehand/**",
  "scripts/check_freehand_conformance_index.py",
  "scripts/check_donor_inventory.py",
  "scripts/check_doc_slugs.py",
  "requirements.txt",
  ".github/workflows/freehand-conformance.yml"
]
```

After:

```json
[
  "spec/conformance/freehand/**",
  "implementation/freehand/test/**",
  "scripts/check_freehand_conformance_index.py",
  "scripts/check_donor_inventory.py",
  "scripts/check_doc_slugs.py",
  "requirements.txt",
  ".github/workflows/freehand-conformance.yml"
]
```

In both parses `pull_request` has no `paths` and no `paths-ignore` key — it is unfiltered before and after.

## Quality gates

| Gate | Result | Exit |
| --- | --- | --- |
| YAML object-model parse of `freehand-conformance.yml` (asserts trigger key set, push `branches`/`paths`, `pull_request` carries neither `paths` nor `paths-ignore`, single job `index` named `Freehand conformance index`, 7 steps) — run before and after the edit | 7 assertions passed, both runs | 0 / 0 |
| `node implementation/scripts/_lint-workflow-policy.test.cjs` | 4 passed, 0 failed | 0 |
| `node implementation/scripts/_docs-workflow-policy.test.cjs` | 5 passed, 0 failed | 0 |
| `python scripts/check_freehand_conformance_index.py --verbose` (no-regression) | OK — 92 rows across 15 area sections, 0 defects | 0 |

Severity is low by design: the `pull_request` trigger is unfiltered, so every PR already runs both guards and nothing reaches `main` unchecked — this only restores the post-merge confirmation run on `main`.
