### PR TITLE
fix(freehand): emitter-lane cluster — recursive defview vars, unreachable analyzer heads, tool reader (rf2-rr26cq)

### DIFF
--- a/implementation/freehand/src/re_frame/freehand.cljc
+++ b/implementation/freehand/src/re_frame/freehand.cljc
@@ -121,6 +121,44 @@
 ;; ---------------------------------------------------------------------------
 
 #?(:clj
+   (defn- shadow-same-named-refer!
+     "Complete the shadowing a `defview` DECLARATION already intends, in the
+     live CLJS analyzer state: drop `sym` from the declaring namespace's
+     `:uses` so the `(def sym …)` below defines — and every reference to the
+     bare name resolves to — the CURRENT-namespace Var.
+
+     A namespace that `:refer`s a same-named public authoring verb
+     (`(:require [re-frame.freehand :refer [sub]])` and then `(v/defview sub
+     …)`) is the case. The CLJS analyzer already signals the shadowing on the
+     `def` — it warns `:redef` and adds the name to `:excludes` — but
+     `cljs.analyzer/resolve-var` ranks `:uses` (refers) ABOVE `:defs` and
+     ignores `:excludes`. So without this the bare def name resolves through
+     the refer and the declaration BOTH clobbers the public authoring Var
+     (`re_frame.freehand.sub = …`) and leaves the qualified current-namespace
+     Var (`<ns>.sub`) undefined: one declaration, two identities.
+
+     This runs at the DECLARATION boundary, not at an emitter's, because the
+     `(def …)` is what needs the shadow. Every declaration gets it — compiled
+     or interpreted, recursive or not — since whether a body happens to
+     mention its own name cannot decide which Var the definition lands in
+     (rf2-rr26cq).
+
+     CLJS macro expansion only (`&env` carries a `:ns`), where the
+     ClassLoader definitionally has ClojureScript, so `cljs.env` is reached by
+     late resolution and this door keeps no compile-time dependency on it. A
+     `.clj`/JVM declaration has no analyzer state and nothing to shadow: the
+     Clojure reader refuses a `def` of a referred name outright."
+     [menv ns-sym sym]
+     (when (some? (:ns menv))
+       (let [ns'     (or (get-in menv [:ns :name]) ns-sym)
+             compiler (some-> (requiring-resolve 'cljs.env/*compiler*) deref)]
+         (when (some? compiler)
+           (swap! compiler update-in
+                  [:cljs.analyzer/namespaces ns' :uses]
+                  dissoc sym))))
+     nil))
+
+#?(:clj
    (defn ^:no-doc parse-defview-args
      "Parse `(defview name docstring? opts? [props] body+)` into
      `{:docstring :opts :params :body}`, or nil when the shape is not one
@@ -314,6 +352,13 @@
                            react (assoc :react react)))
                        (assoc entry :render
                               `(fn ~(symbol (str sym "-render")) ~params ~@body)))]
+         ;; The declaration DEFINES its current-namespace Var, whatever the
+         ;; consuming namespace happens to refer under the same name — see
+         ;; [[shadow-same-named-refer!]]. It runs HERE, once, for both
+         ;; lowerings: the `(def …)` below is the boundary that needs it, and
+         ;; a body's recursion (or lack of it) is not what decides which Var a
+         ;; definition lands in.
+         (shadow-same-named-refer! &env ns-sym sym)
          ;; The var metadata is what a COMPILE-TIME head classifier reads: a
          ;; compiled body resolves `[panel {…}]` before any descriptor exists,
          ;; so view-ness, the children policy and the LOWERING have to be

--- a/implementation/freehand/src/re_frame/freehand/compiler.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler.cljc
@@ -324,6 +324,18 @@
     are the view's finite reactive, intent, render-slot, trusted-markup
     and committed-frame site rosters — the same lexical sites the
     analyzer indexed, projected to their statically knowable facts.
+  - `:diagnostics` is the compile-tier finding roster
+    ([[re-frame.freehand.compiler.a11y]]) — every a11y finding the
+    declaration produced, INCLUDING the suppressed ones, each with the
+    compiler-minted `:sid` its warning names and a `:reason` where one was
+    given. Findings were collected in the compiler env and published
+    nowhere, so a suppressed finding — the whole point of which is that it
+    stays an inspectable fact while printing nothing — was unreachable by
+    any reader (rf2-hytu5). Unlike the site rosters a finding is not a
+    lexical site and carries no `:source-coord`: it names the `:tag` and
+    `:path` of the node it was minted from, which is the coordinate its
+    warning quotes. Readers reach it through
+    [[re-frame.freehand.tool/view-manifest]].
   - A roster entry's `:source-coord` is TOTAL OR ABSENT — a whole
     `{:file :line :column}` of the form that produced it, or of the
     enclosing declaration when the reader anchored no narrower position;
@@ -371,6 +383,8 @@
      :slots         (mapv #(select-keys % [:sid :inline? :source-coord :path]) (:slots sites))
      :html-sites    (mapv #(select-keys % [:source-coord :path]) (:htmls sites))
      :frame-ops     (mapv #(select-keys % [:sid :source-coord :path]) (:frame-ops sites))
+     :diagnostics   (mapv #(select-keys % [:sid :id :tag :path :suppressed? :reason])
+                          (:diagnostics sites))
      :capabilities  (compiled-capabilities ast sites)
      :reactive?     (not elided?)
      :view-cell     (if elided? :elided :present)

--- a/implementation/freehand/src/re_frame/freehand/compiler/a11y.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/a11y.cljc
@@ -43,8 +43,15 @@
   Every finding — suppressed or not — is recorded as a `:diagnostics` manifest
   site carrying the compiler-minted stable site id, so a suppressed finding
   stays an inspectable fact (with its reason) while printing nothing. Tools
-  read it through `re-frame.freehand.tool/view-manifest`; nothing re-derives site
-  identity downstream."
+  read it through [[re-frame.freehand.tool/view-manifest]]; nothing re-derives
+  site identity downstream.
+
+  Until rf2-hytu5 that last sentence named two things that did not exist:
+  `structural-manifest` carried no `:diagnostics` key, and there was no
+  `re-frame.freehand.tool` namespace at all. Findings were collected in the
+  compiler env and reached no reader, which made a SUPPRESSED finding — whose
+  entire purpose is to remain inspectable while silent — simply lost. Both
+  ends now exist, and this docstring describes them."
   (:require [clojure.string :as str]
             [re-frame.freehand.compiler.env :as env]))
 

--- a/implementation/freehand/src/re_frame/freehand/compiler/analyze.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/analyze.cljc
@@ -66,8 +66,26 @@
 ;; the vars — recognition and lowering landing together, which is the only
 ;; order in which either is testable through the door.
 ;;
-;; `lazy` is def-level only — recognised in a view body solely to reject it.
-(def ^:private react-lazy-fqns             #{'re-frame.freehand.react/lazy})
+;; `re-frame.freehand.react/lazy` went the same way (rf2-tb5yq): the namespace
+;; is browser-only and defines no `lazy`, so the def-level-only rejection arm
+;; that recognised `(react/lazy …)` in a body could never fire. It returns with
+;; the slice that ships the verb. The FOREIGN-head lazy handling in
+;; `compiler.env/classify-head` is untouched — that keys on `:rf.ui/lazy` var
+;; metadata and on the marked runtime value, not on an unpublished authoring
+;; var, so it is reachable on its own terms.
+;;
+;; FIVE unpublished heads REMAIN recognised below — `frame`, `raw`, `html`,
+;; `frame-root`, `frame-provider` — and every one is likewise unreachable
+;; through the production door. They are deliberately still standing: each is
+;; entangled with a surface a conformance row already pins (`:frame-ops` and
+;; `:html-sites` are manifest rosters in `FH-STRUCT-010`; `raw` mints the
+;; `:foreign` crossing-prop marker; `frame-root` drives the root-identity static
+;; frame-plan scan), so removing one is a change to the conformance contract and
+;; not merely to this file. `re-frame.freehand.unpublished-head-absence-jvm-test`
+;; pins the fact — the six vars unpublished on both hosts, production resolution
+;; nil for each, and the `re-frame.freehand.frames/*` lowerings naming a
+;; namespace that does not exist — so the state is asserted rather than
+;; rediscovered.
 (def ^:private frame-root-fqns #{'re-frame.freehand/frame-root})
 (def ^:private frame-provider-fqns #{'re-frame.freehand/frame-provider})
 
@@ -1007,18 +1025,6 @@
                                           :path (:path e)
                                           :expr-path (vec p)}))
                         (with-same-meta f (list runtime-frame-ops-fqn))))
-
-                    ;; (react/lazy …) is DEF-LEVEL only — recognised in a body
-                    ;; solely to reject it (per-render construction remount-loops).
-                    (and (symbol? head) (not (contains? locals head))
-                         (env/resolves-to? e* head react-lazy-fqns))
-                    (env/fail! e :rf.ui.compile/react-lazy-misplaced
-                               (str "(react/lazy …) is DEF-LEVEL only — bind it at the top "
-                                    "level: (def HeavyChart (react/lazy load-thunk "
-                                    "{:fallback tpl})), then use the component as a foreign "
-                                    "head [HeavyChart {…}]. Calling it inside a view body "
-                                    "mints a new component type per render and remount-loops")
-                               {:form f})
 
                    (fn-form? f) (rw-fn f locals p)
                    (contains? #{'let 'let* 'loop 'loop*} head) (rw-let f locals p)

--- a/implementation/freehand/src/re_frame/freehand/compiler/emit_react.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/emit_react.cljc
@@ -69,14 +69,7 @@
             [re-frame.freehand.controlled :as controlled]
             [re-frame.freehand.conversion :as conv]
             [re-frame.freehand.events :as events]
-            [re-frame.freehand.top-layer :as top-layer]
-            ;; JVM-only: a self-recursive view completes the same-named `:refer`
-            ;; shadowing in the LIVE CLJS analyzer state so its `(def …)` and
-            ;; recursive head resolve to the current-namespace Var rather than
-            ;; the referred authoring Var (see `emit-react-body`). Never loaded
-            ;; on the CLJS host — the emitter only mutates analyzer state on the
-            ;; JVM macro-expansion path.
-            #?(:clj [cljs.env])))
+            [re-frame.freehand.top-layer :as top-layer]))
 
 (declare emit-node)
 
@@ -587,12 +580,11 @@
         ;; a namespace that REFERS a same-named public authoring verb (e.g.
         ;; `(defview sub …)` refers `re-frame.freehand/sub`) resolves through the
         ;; refer to the authoring Var, while the qualified `:fqn` resolves to the
-        ;; view. `emit-react-body` reads the recorded flag to complete the
-        ;; shadowing in the live analyzer state so the `(def …)` matches. Every
-        ;; other head keeps its authored spelling.
+        ;; view. The DECLARATION completes the matching shadow on its own
+        ;; `(def …)` (`re-frame.freehand/shadow-same-named-refer!`), so both
+        ;; halves name one Var. Every other head keeps its authored spelling.
         sf        (self-fqn e)
         self?     (and sf (= (:fqn node) sf))]
-    (when self? (swap! st assoc :self-ref? true))
     `(re-frame.freehand.compiled-react/mount
       ~(if self? (:fqn node) (:sym node)) ~props-map
       ~@(mapv #(emit-node e st %) (:children node)))))
@@ -750,24 +742,4 @@
   (let [st   (new-state)
         body `(fn ~params (re-frame.freehand.compiled-react/root ~(emit-node e st ast)))
         bs   (:binds @st)]
-    ;; A self-recursive view whose name collides with a same-named `:refer`
-    ;; (e.g. `(defview sub …)` where the ns refers `re-frame.freehand/sub`) must
-    ;; resolve its OWN `(def …)` and recursive head to the current-namespace Var,
-    ;; not the refer. The CLJS analyzer already signals this shadowing on the def
-    ;; (its `:redef` warning, and it adds the name to `:excludes`) — but
-    ;; `cljs.analyzer/resolve-var` ranks `:uses` (refers) ABOVE `:defs` and
-    ;; ignores `:excludes`, so a bare def name still resolves through the refer
-    ;; and BOTH clobbers the public authoring Var (`re_frame.freehand.sub = …`)
-    ;; and leaves the qualified self head (`<ns>.sub`) undefined — a split
-    ;; identity. Completing the shadowing the analyzer already intends — dropping
-    ;; the view's own name from the live ns `:uses` — makes the `(def …)`, its
-    ;; structural and React realisations, and every recursive head share the one
-    ;; canonical current-namespace Var. JVM-only: this is the macro-expansion
-    ;; path with the live compiler env; non-recursive views and the CLJS-host
-    ;; self-compile path are untouched, and no runtime code is added.
-    #?(:clj
-       (when (and (:self-ref? @st) (:self e) (some? cljs.env/*compiler*))
-         (swap! cljs.env/*compiler* update-in
-                [:cljs.analyzer/namespaces (:ns e) :uses]
-                dissoc (:self e))))
     (if (seq bs) `(let [~@bs] ~body) body)))

--- a/implementation/freehand/src/re_frame/freehand/tool.cljc
+++ b/implementation/freehand/src/re_frame/freehand/tool.cljc
@@ -1,0 +1,67 @@
+(ns re-frame.freehand.tool
+  "The Freehand TOOL-TIER reader door — what an inspector reads a
+  declaration's compile-time analysis through.
+
+  One namespace, one question: **given a value, what did the compiler
+  statically learn about it?** The answer is the manifest the compiled tier
+  already builds — its subscription, event, render-slot, trusted-markup,
+  committed-frame and boundary-crossing rosters, its capability set, its
+  ViewCell verdict, and the compile-tier `:diagnostics` findings. Nothing here
+  computes anything; every read is a projection of a value the declaration is
+  already carrying.
+
+  ## Why it is not `v/manifest`
+
+  [[re-frame.freehand/manifest]] is the APPLICATION's read: it is asked about a
+  view, by code that knows it has one. A tool is asked about whatever it is
+  holding — a var it swept out of a namespace, an id it was handed over a wire,
+  a value from a registry it does not own — and a reader that throws on the
+  first non-view is a reader that cannot sweep. So [[view-manifest]] is TOTAL:
+  every value has an answer, and `nil` means \"nothing statically known\",
+  whether that is because the value is not a view at all or because it is an
+  interpreted declaration with no analysis to report.
+
+  That is the whole of the difference, and it is the whole of this namespace.
+
+  ## What this door deliberately is NOT
+
+  It is a READER, not a tool framework. There is no accumulator — the donor's
+  per-occurrence evidence accumulator was ruled out permanently (rf2-drpa3.167,
+  REPLACE), not merely deferred — no root registry, no interval log and no
+  history store: retention is Spec 009's ring, and nothing here retains
+  anything at all. Live reads over mounted occurrences are a separate slice
+  (rf2-lvvl2) with a separate owner.
+
+  Normative owner: [`spec/004-Views.md`](../../../../spec/004-Views.md);
+  the instrumentation contract these reads serve is
+  [`spec/009-Instrumentation.md`](../../../../spec/009-Instrumentation.md)."
+  (:require [re-frame.freehand.descriptor :as descriptor]))
+
+(defn view-manifest
+  "The compile-time manifest `x` carries, or `nil` when there is none.
+
+      (tool/view-manifest people-list)
+      ;; => {:view-id       :app.people/people-list
+      ;;     :grammar       :re-frame.freehand/v1
+      ;;     :subscriptions [{:sid … :query [:person 7] :source-coord {…} :path [0]}]
+      ;;     :events [] :slots [] :html-sites [] :frame-ops []
+      ;;     :diagnostics   [{:sid … :id :rf.ui.compile/a11y-click-non-interactive
+      ;;                      :tag :div :path [0] :suppressed? false}]
+      ;;     :capabilities  #{:sub}
+      ;;     :reactive?     true
+      ;;     :view-cell     :present
+      ;;     :crossings     [{:view-id … :lowering :compiled :source-coord {…} :path [1]}]}
+
+  TOTAL over every value, which is what makes it a tool read rather than an
+  application one: a sweep over a namespace's publics hands this function
+  strings, numbers, plain functions and interpreted views, and each of those
+  answers `nil` rather than throwing. `nil` means the same thing in every
+  case — the compiler knows nothing statically about this value — and a caller
+  that needs to tell an interpreted DECLARATION from a non-view asks
+  [[re-frame.freehand/view?]], which is the predicate that question belongs to.
+
+  The manifest is the declaration's own data, returned as-is. Its shape is
+  documented once, on [[re-frame.freehand.compiler/structural-manifest]]."
+  [x]
+  (when (descriptor/view? x)
+    (descriptor/manifest x)))

--- a/implementation/freehand/test/re_frame/freehand/compiler_macro_resolution_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/compiler_macro_resolution_jvm_test.clj
@@ -288,6 +288,14 @@
   (v/expand-defview nil aenv probe-meta probe-file 'cljs.user verb
                     (list {:compiled true} '[_] body)))
 
+(defn- interpreted-declaration-form
+  "The same production door with NO `{:compiled true}` — the paved path. It
+  emits the same `(def …)`, so it has the same Var to define and the same
+  same-named refer standing in front of it."
+  [aenv verb body]
+  (v/expand-defview nil aenv probe-meta probe-file 'cljs.user verb
+                    (list '[_] body)))
+
 (defn- self-react-body
   "The React realisation of `(defview <verb> [] [<verb> {}])` in the referred
   cljs.user namespace — the self view named `verb` recurses on a bare `[verb {}]`
@@ -398,6 +406,22 @@
         (is (= "cljs.user.sub" (compile-js aenv 'sub))
             "after the declaration the bare name resolves to the declared view,
              not through the refer — ordinary def-shadows-refer semantics")))))
+
+(deftest an-interpreted-declaration-defines-its-current-ns-var-too
+  ;; The audit's "check the interpreted declaration path too if it shares the
+  ;; same `(def …)` resolution boundary" — it does. An interpreted `v/defview`
+  ;; has no analysis and no emitter, but it emits the SAME `(def …)`, so it had
+  ;; the same split identity and no emitter-hosted repair could ever have
+  ;; reached it. This is the row that says the shadow belongs at the
+  ;; declaration.
+  (doseq [verb '[sub frame]]
+    (with-referred-cljs-env
+      (fn [aenv]
+        (let [js (compile-js aenv (interpreted-declaration-form aenv verb [:div "x"]))]
+          (is (re-find (re-pattern (str "cljs\\.user\\." (name verb) "\\s*=")) js)
+              (str verb " — the interpreted declaration defines the current-namespace Var"))
+          (is (not (re-find (re-pattern (str "re_frame\\.freehand\\." (name verb) "\\b")) js))
+              (str verb " — and emits zero authoring-Var definition or reference")))))))
 
 (deftest a-declaration-leaves-unrelated-refers-and-heads-untouched
   ;; Preserve unrelated behavior: the shadow is exactly one name wide. A view

--- a/implementation/freehand/test/re_frame/freehand/compiler_macro_resolution_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/compiler_macro_resolution_jvm_test.clj
@@ -8,6 +8,7 @@
             [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
             [clojure.walk :as walk]
+            [re-frame.freehand :as v]
             [re-frame.freehand.compiler.analyze :as analyze]
             [re-frame.freehand.compiler.emit-jvm :as emit-jvm]
             [re-frame.freehand.compiler.emit-react :as emit-react]
@@ -252,27 +253,45 @@
                (:op (:ast (root/analyze-root (referred-env aenv nil) 'v/mount '[:div "x"])))))))))
 
 ;; ---------------------------------------------------------------------------
-;; self-Var emitters: recursive defviews mount + define their current-ns Var
+;; self-Var: a defview DEFINES its current-namespace Var, and a recursive head
+;; REFERENCES it
 ;; ---------------------------------------------------------------------------
 ;;
 ;; The .274 analyzer proofs above stop at classification (the self head is an
-;; internal :view). This block drives the REAL emitters and compiles the emitted
-;; self boundary to REAL JavaScript through cljs.compiler. The defect: both live
-;; emitters emitted the raw authored `:sym` for a self boundary, so in a ns that
-;; REFERS re-frame.freehand/{sub,frame} a compiled `(defview sub [] [sub {}])`
-;; mounted the AUTHORING verb (`re_frame.freehand.sub`) instead of recursing on
-;; its own current-namespace Var (`cljs.user.sub`). The emitters now carry the
-;; canonical `:fqn` for a self head, and the CLJS realisation completes the
-;; same-named-refer shadowing (dropping the name from the live ns `:uses`) so the
-;; `(def …)` DEFINES — and the head REFERENCES — the one current-namespace Var.
-;; These rows diff the emitted JS bytes; the counterfactual pins the delta so the
-;; discriminator is a compiled fact, not a reasoned AST shape.
+;; internal :view). This block drives the REAL declaration door and the REAL
+;; emitters, and compiles the result to REAL JavaScript through cljs.compiler.
+;;
+;; Two halves, and they were fixed in two changes. (1) Both live emitters
+;; emitted the raw authored `:sym` for a self boundary, so in a ns that REFERS
+;; re-frame.freehand/{sub,frame} a compiled `(defview sub [] [sub {}])` MOUNTED
+;; the authoring verb instead of recursing on itself. (2) The `(def …)` had the
+;; same split identity, and it did NOT depend on recursion: the shadow was
+;; completed by the React emitter and only when the body happened to mention its
+;; own name, so a NON-recursive `(defview sub …)` still compiled its definition
+;; against the authoring Var and left `cljs.user.sub` undefined (rf2-rr26cq,
+;; #6886 audit). The shadow now lands at the DECLARATION boundary, for every
+;; declaration in both lowerings.
+;;
+;; These rows diff the emitted JS bytes; the counterfactual below pins the delta
+;; so the discriminator is a compiled fact, not a reasoned AST shape.
+
+(def ^:private probe-file "app/probe.cljc")
+(def ^:private probe-meta {:line 12 :column 3})
+
+(defn- declaration-form
+  "The REAL `v/defview` expansion of `(v/defview <verb> {:compiled true} [_]
+  <body>)` in the referred cljs.user namespace — the PRODUCTION declaration
+  door, `re-frame.freehand/expand-defview`, which is what the `defview` macro
+  calls and where the same-named-refer shadow is completed. Answers the `(def
+  …)` form the macro would have returned."
+  [aenv verb body]
+  (v/expand-defview nil aenv probe-meta probe-file 'cljs.user verb
+                    (list {:compiled true} '[_] body)))
 
 (defn- self-react-body
   "The React realisation of `(defview <verb> [] [<verb> {}])` in the referred
   cljs.user namespace — the self view named `verb` recurses on a bare `[verb {}]`
-  self head. Emitting it also completes the same-named-refer shadow in the live
-  analyzer state (the JVM-only `:uses` drop)."
+  self head."
   [aenv verb]
   (let [e   (referred-env aenv verb)
         ast (analyze/analyze e [verb {}])]
@@ -310,20 +329,20 @@
      (cljs-analyzer/analyze (assoc aenv :context :expr) form))))
 
 (deftest real-cljs-self-head-emits-and-defines-current-namespace-var
-  ;; Accept rows. Reverting either emitter to the raw authored `:sym` re-captures
-  ;; re_frame.freehand.<verb> in the emitted JavaScript; dropping the `:uses`
-  ;; shadow completion leaves the `(def …)` clobbering the authoring Var and the
-  ;; qualified head undefined (the split identity). Every row below fails then.
+  ;; Accept rows, driven through the PRODUCTION declaration door. Reverting either
+  ;; emitter to the raw authored `:sym` re-captures re_frame.freehand.<verb> in the
+  ;; emitted JavaScript; dropping the declaration's `:uses` shadow completion leaves
+  ;; the `(def …)` clobbering the authoring Var and the qualified head undefined
+  ;; (the split identity). Every row below fails then.
   (doseq [verb '[sub frame]]
     (let [self-fqn  (symbol "cljs.user" (name verb))
           author-re (re-pattern (str "re_frame\\.freehand\\." (name verb) "\\b"))
           def-re    (re-pattern (str "cljs\\.user\\." (name verb) "\\s*="))
           head-re   (re-pattern (str "mount\\(cljs\\.user\\." (name verb) ","))]
-      (testing (str "CLJS: (def " verb " …) DEFINES and recurses on the current-ns Var")
+      (testing (str "CLJS: (v/defview " verb " …) DEFINES and recurses on the current-ns Var")
         (with-referred-cljs-env
           (fn [aenv]
-            (let [react-body (self-react-body aenv verb) ; side-effect: :uses drop
-                  js         (compile-js aenv (list 'def verb react-body))]
+            (let [js (compile-js aenv (declaration-form aenv verb [verb {}]))]
               (is (re-find def-re js)
                   "the def defines the current-namespace Var")
               (is (re-find head-re js)
@@ -362,16 +381,42 @@
                (compile-js aenv (symbol "cljs.user" (name verb))))
             "the qualified head resolves to the current-namespace Var")))))
 
-(deftest a-non-recursive-view-leaves-the-refer-and-heads-untouched
-  ;; Preserve unrelated behavior: a view that does NOT reference itself neither
-  ;; rewrites a head to an fqn nor mutates the ns `:uses` — a later referred
-  ;; (sub …) still resolves to the authoring Var, and an ordinary internal-view
-  ;; head keeps its authored spelling.
+(deftest a-non-recursive-colliding-declaration-still-defines-the-current-ns-var
+  ;; The #6886 audit row, and the one the shipped fix originally missed. A
+  ;; `(v/defview sub …)` whose body never mentions `sub` is STILL a declaration
+  ;; of `sub` in cljs.user: whether the body happens to recurse cannot decide
+  ;; which Var the definition lands in. Before the repair this compiled its
+  ;; `(def …)` against the referred authoring Var — clobbering
+  ;; re_frame.freehand.sub and leaving cljs.user.sub undefined.
+  (with-referred-cljs-env
+    (fn [aenv]
+      (let [js (compile-js aenv (declaration-form aenv 'sub [:div "x"]))]
+        (is (re-find #"cljs\.user\.sub\s*=" js)
+            "a non-recursive colliding declaration defines the current-namespace Var")
+        (is (not (re-find #"re_frame\.freehand\.sub\b" js))
+            "and emits zero authoring-Var definition or reference")
+        (is (= "cljs.user.sub" (compile-js aenv 'sub))
+            "after the declaration the bare name resolves to the declared view,
+             not through the refer — ordinary def-shadows-refer semantics")))))
+
+(deftest a-declaration-leaves-unrelated-refers-and-heads-untouched
+  ;; Preserve unrelated behavior: the shadow is exactly one name wide. A view
+  ;; declared under a name that collides with NOTHING drops no refer, and an
+  ;; ordinary head keeps its authored spelling.
+  (with-referred-cljs-env
+    (fn [aenv]
+      (let [form (declaration-form aenv 'panel [:div "x"])]
+        (is (= "re_frame.freehand.sub" (compile-js aenv 'sub))
+            "declaring `panel` does not drop the unrelated referred `sub`")
+        (is (= "re_frame.freehand.frame" (compile-js aenv 'frame))
+            "nor the unrelated referred `frame`")
+        (is (some? form) "the declaration still expands"))))
   (with-referred-cljs-env
     (fn [aenv]
       (let [e   (referred-env aenv 'panel)
             ast (analyze/analyze e [:div "x"])]
         (emit-react/emit-react-body e [] ast)
         (is (= "re_frame.freehand.sub" (compile-js aenv 'sub))
-            "a non-recursive view does not drop a referred verb from :uses")))))
+            "and the EMITTER mutates no analyzer state at all — the shadow is
+             the declaration's, not an emitter side effect")))))
 

--- a/implementation/freehand/test/re_frame/freehand/manifest_census_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/manifest_census_cljs_test.cljc
@@ -111,17 +111,33 @@
             present on every entry on every host."
     (let [required (:required-keys struct-010)
           coord-ks (:source-coord-keys struct-010)]
-      ;; The dissoc list is the manifest's NON-roster keys — single facts about
-      ;; the declaration rather than per-site entries, so none of them owns a
-      ;; source coordinate. `:static-facts` is one of them: the render-static
-      ;; `{:caps :deps}` closure is a summary OVER the sites, not a roster of
-      ;; them, and asking it for a per-entry `:source-coord` would be asking a
-      ;; set of capability tokens where its lines are.
+      ;; What the fixture governs is the manifest's LEXICAL-SITE rosters — the
+      ;; ones whose entries name a form the compiler read, and therefore own a
+      ;; source coordinate. Two kinds of key are excluded, for two different
+      ;; reasons, and both are stated rather than lumped:
+      ;;
+      ;;   - `:view-id` / `:grammar` / `:capabilities` / `:reactive?` /
+      ;;     `:view-cell` / `:static-facts` are NOT rosters at all — single
+      ;;     facts about the declaration. `:static-facts` is the clearest case:
+      ;;     the render-static `{:caps :deps}` closure is a summary OVER the
+      ;;     sites, and asking it for a per-entry `:source-coord` would be
+      ;;     asking a set of capability tokens where its lines are.
+      ;;   - `:diagnostics` IS a roster, but its entries are compile-tier
+      ;;     FINDINGS, not sites: a finding names the `:tag` and `:path` of the
+      ;;     node it was minted from and carries no `:source-coord`, so the
+      ;;     per-entry coordinate law below cannot govern it. Its own fixture
+      ;;     row is a conformance change and is sequenced separately
+      ;;     (rf2-hytu5); `re-frame.freehand.tool-reader-jvm-test` pins the
+      ;;     roster's shape and non-emptiness meanwhile.
       (is (= (set (keys required))
              (set (keys (dissoc (v/manifest (census-view :label))
                                 :view-id :grammar :capabilities
-                                :reactive? :view-cell :static-facts))))
-          "the fixture names every roster the manifest carries and no other")
+                                :reactive? :view-cell :static-facts
+                                :diagnostics))))
+          "the fixture names every lexical-site roster the manifest carries and no other")
+      (is (contains? (v/manifest (census-view :label)) :diagnostics)
+          "and the finding roster is present — excluded from the coordinate law
+           above, never from the manifest")
       (doseq [[nm view] mv/by-name
               [roster ks] required
               entry       (get (v/manifest view) roster)]

--- a/implementation/freehand/test/re_frame/freehand/manifest_census_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/manifest_census_cljs_test.cljc
@@ -127,7 +127,7 @@
       ;;     node it was minted from and carries no `:source-coord`, so the
       ;;     per-entry coordinate law below cannot govern it. Its own fixture
       ;;     row is a conformance change and is sequenced separately
-      ;;     (rf2-hytu5); `re-frame.freehand.tool-reader-jvm-test` pins the
+      ;;     (rf2-hytu5); `re-frame.freehand.tool-reader-cljs-test` pins the
       ;;     roster's shape and non-emptiness meanwhile.
       (is (= (set (keys required))
              (set (keys (dissoc (v/manifest (census-view :label))

--- a/implementation/freehand/test/re_frame/freehand/tool_reader_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/tool_reader_cljs_test.cljc
@@ -1,4 +1,4 @@
-(ns re-frame.freehand.tool-reader-jvm-test
+(ns re-frame.freehand.tool-reader-cljs-test
   "rf2-hytu5 — the Freehand tool-tier reader door, and the compile-tier
   findings it exists to reach.
 
@@ -17,7 +17,13 @@
 
   Everything below reads a REAL `v/defview {:compiled true}` declaration
   through the production door. The findings ride SUPPRESSED so the suite is
-  silent on stderr, which is also the arm that was unreachable."
+  silent on stderr, which is also the arm that was unreachable.
+
+  Cross-host on purpose. The manifest is built at macro expansion — on the JVM
+  for both hosts — but the reader is what a BROWSER tool calls, so the door has
+  to be a namespace ClojureScript can actually compile and run. Proving it only
+  under `clojure -M:test` would leave the one host that matters to Pair
+  unexercised."
   (:require [clojure.test :refer [deftest is testing]]
             [re-frame.freehand :as v]
             [re-frame.freehand.tool :as tool]))
@@ -66,7 +72,7 @@
             data the declaration is already carrying."
     (let [m (tool/view-manifest clean-view)]
       (is (map? m))
-      (is (= :re-frame.freehand.tool-reader-jvm-test/clean-view (:view-id m)))
+      (is (= :re-frame.freehand.tool-reader-cljs-test/clean-view (:view-id m)))
       (is (= :re-frame.freehand/v1 (:grammar m)))
       (is (= m (v/manifest clean-view))
           "the tool door reads the same value the application door does — one

--- a/implementation/freehand/test/re_frame/freehand/tool_reader_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/tool_reader_jvm_test.clj
@@ -1,0 +1,113 @@
+(ns re-frame.freehand.tool-reader-jvm-test
+  "rf2-hytu5 — the Freehand tool-tier reader door, and the compile-tier
+  findings it exists to reach.
+
+  Two defects, one seam. `re-frame.freehand.tool` did not exist at all — its
+  only mention in the tree was a docstring in
+  `re-frame.freehand.compiler.a11y` promising `tool/view-manifest` to a reader
+  that could not resolve it — and `structural-manifest` carried no
+  `:diagnostics` key, so every a11y finding was collected in the compiler env
+  and published nowhere.
+
+  Suppression is what makes that second half matter. A SUPPRESSED finding is
+  deliberately silent: it prints nothing, and the manifest fact carrying its
+  reason was its only trace. With no `:diagnostics` on the manifest, a
+  suppressed finding was simply lost — the author's reason recorded into a map
+  that no reader could ever open.
+
+  Everything below reads a REAL `v/defview {:compiled true}` declaration
+  through the production door. The findings ride SUPPRESSED so the suite is
+  silent on stderr, which is also the arm that was unreachable."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.tool :as tool]))
+
+(def ^:private suppress-reason
+  "drag surface; the keyboard path is the toolbar button")
+
+(v/defview clean-view
+  "A compiled declaration the a11y roster has nothing to say about."
+  {:compiled true}
+  [{:keys [title]}]
+  [:section.panel [:h2 title]])
+
+(v/defview flagged-view
+  "A compiled declaration carrying one SUPPRESSED a11y finding — the case whose
+  only trace is the manifest fact."
+  {:compiled true}
+  [_]
+  [:div
+   ^{:rf.ui/suppress
+     {:rf.ui.compile/a11y-click-non-interactive
+      "drag surface; the keyboard path is the toolbar button"}}
+   [:div {:on-click [:row/open]} "Open"]])
+
+(v/defview interpreted-view
+  "The paved path: no analysis, so nothing statically known."
+  [{:keys [title]}]
+  [:section title])
+
+;; ---------------------------------------------------------------------------
+;; The door is total
+;; ---------------------------------------------------------------------------
+
+(deftest view-manifest-answers-nil-for-everything-that-has-no-analysis
+  (testing "A tool reads whatever it is holding — a var swept out of a
+            namespace, a value from a registry it does not own. A reader that
+            threw on the first non-view could not sweep at all, so every value
+            has an answer and `nil` means 'nothing statically known'."
+    (doseq [x [nil 42 "a string" :a/keyword [] {} identity]]
+      (is (nil? (tool/view-manifest x)) (pr-str x)))
+    (is (nil? (tool/view-manifest interpreted-view))
+        "an interpreted declaration has no analysis to report")))
+
+(deftest view-manifest-answers-the-compiled-declarations-own-manifest
+  (testing "The read itself: a compiled declaration's manifest, returned as the
+            data the declaration is already carrying."
+    (let [m (tool/view-manifest clean-view)]
+      (is (map? m))
+      (is (= :re-frame.freehand.tool-reader-jvm-test/clean-view (:view-id m)))
+      (is (= :re-frame.freehand/v1 (:grammar m)))
+      (is (= m (v/manifest clean-view))
+          "the tool door reads the same value the application door does — one
+           manifest, two callers, never two projections that could drift"))))
+
+;; ---------------------------------------------------------------------------
+;; :diagnostics reaches a reader
+;; ---------------------------------------------------------------------------
+
+(deftest the-manifest-publishes-the-compile-tier-finding-roster
+  (testing "The key that did not exist. Every compiled declaration carries a
+            `:diagnostics` roster, empty when the a11y checks found nothing —
+            present either way, so a reader can tell 'no findings' from 'this
+            manifest predates the roster'."
+    (is (contains? (tool/view-manifest clean-view) :diagnostics)
+        "a clean declaration still publishes the roster")
+    (is (= [] (:diagnostics (tool/view-manifest clean-view)))
+        "and it is empty rather than absent")))
+
+(deftest a-suppressed-finding-survives-to-the-reader-with-its-reason
+  (testing "The fact this Bead exists for. A suppressed finding prints nothing
+            — that is what suppression IS — so the manifest entry carrying the
+            author's reason is its only trace. Before `:diagnostics` was
+            published it had none: the reason went into the compiler env and
+            stopped there."
+    (let [findings (:diagnostics (tool/view-manifest flagged-view))]
+      (is (= 1 (count findings))
+          "the finding reaches the reader through the production door")
+      (let [d (first findings)]
+        (is (= :rf.ui.compile/a11y-click-non-interactive (:id d)))
+        (is (true? (:suppressed? d)))
+        (is (= suppress-reason (:reason d))
+            "carrying the author's REASON — the whole content of a suppression")
+        (is (= :div (:tag d)) "and the node it was minted from")
+        (is (string? (:sid d))
+            "under the compiler-minted stable site id its warning would name")
+        (is (vector? (:path d)))))))
+
+(deftest an-unflagged-declaration-is-the-control
+  (testing "Non-vacuity for the row above: the two declarations differ, so a
+            roster that answered `[]` to everything — or one that answered the
+            same thing to everything — cannot pass both."
+    (is (not= (:diagnostics (tool/view-manifest clean-view))
+              (:diagnostics (tool/view-manifest flagged-view))))))

--- a/implementation/freehand/test/re_frame/freehand/unpublished_head_absence_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/unpublished_head_absence_jvm_test.clj
@@ -1,0 +1,193 @@
+(ns re-frame.freehand.unpublished-head-absence-jvm-test
+  "rf2-tb5yq — the analyzer heads whose authoring vars `re-frame.freehand`
+  does not publish, proved through the PRODUCTION resolution path.
+
+  Six analyzer fqn sets named vars that are interned nowhere:
+
+      re-frame.freehand/frame            (frame-fqns)          — still recognised
+      re-frame.freehand/raw              (ui-raw-fqns)         — still recognised
+      re-frame.freehand/html             (ui-html-fqns)        — still recognised
+      re-frame.freehand/frame-root       (frame-root-fqns)     — still recognised
+      re-frame.freehand/frame-provider   (frame-provider-fqns) — still recognised
+      re-frame.freehand.react/lazy       — arm REMOVED with this suite
+
+  Recognition for each runs off `env/resolves-to?`, and production
+  `env/resolve-sym` answers nil for a var that does not exist, so no compiled
+  declaration can reach any of those arms through the door. Nothing here
+  injects a `:resolver`: a test resolver MANUFACTURES the missing definitions
+  and can make an unreachable arm look reachable, which is the synthetic proof
+  the rf2-1a9au audit rejected and the whole reason this suite exists.
+
+  The `react/lazy` arm went, being self-contained — one rejection, no site
+  bucket, no manifest roster, no emitter arm. The other five are entangled with
+  surfaces a conformance row already pins, so their removal is a change to the
+  conformance contract and is sequenced separately; every one of them is
+  asserted unreachable HERE meanwhile, which is what stops the state being
+  rediscovered a third time. All six stay in the roster below: the tripwire is
+  about the VARS, and it must red whether an arm is standing or not.
+
+  ## Why the JVM probe alone is not the proof
+
+  `re-frame.freehand` is `.cljc`, so a var published under `#?(:cljs …)` — as
+  `v/mount` is — is genuinely absent from a JVM `ns-resolve` while being fully
+  public. A JVM-only probe therefore cannot tell an unpublished var from a
+  browser-only one, and `mount` is carried below as the CONTROL that makes that
+  gap visible rather than assumed.
+
+  What closes it is `spec/api-manifest.edn`: the generated roster of live
+  public vars, reconciled against the real surface in BOTH directions on both
+  hosts (`implementation/scripts/api-manifest/probe/`, and see
+  `re-frame.freehand.public-surface-jvm-test`). A name absent from that roster
+  is published on NEITHER host. The two probes together are the fact this Bead
+  rests on.
+
+  ## Doubly dead: the lowerings name a phantom namespace
+
+  Three of the arms lower to `re-frame.freehand.frames/*`, a namespace that
+  exists nowhere in the tree — the same defect class as the
+  `re-frame.freehand.hooks/*` lowerings rf2-1a9au removed. So even a published
+  authoring var would not make those arms lowerable; recognition and lowering
+  have to land together, with the slice that owns them.
+
+  ## Tripwire
+
+  Like `re-frame.freehand.host-hook-absence-jvm-test`, this suite is a
+  TRIPWIRE. The day a slice publishes one of these authoring vars, or defines
+  the runtime namespace behind it, a row here goes red — and that is the signal
+  that the arm's recognition, position law and lowering must land in the SAME
+  change, because a compiler that recognises a form it cannot lower is exactly
+  the state these Beads exist to remove."
+  (:require [clojure.edn :as edn]
+            [clojure.test :refer [deftest is testing]]
+            [re-frame.build.spec-resource :as spec-resource]
+            [re-frame.freehand]
+            [re-frame.freehand.compiler.env :as env]))
+
+(def ^:private unpublished-heads
+  "The six authoring heads the analyzer recognises and the door does not
+  publish, as the fully-qualified symbols an author's `(frame)` / `(v/html s)`
+  would have to resolve to."
+  '[re-frame.freehand/frame
+    re-frame.freehand/raw
+    re-frame.freehand/html
+    re-frame.freehand/frame-root
+    re-frame.freehand/frame-provider
+    re-frame.freehand.react/lazy])
+
+(def ^:private phantom-runtime-targets
+  "The runtime vars the `frame` / `frame-root` / `frame-provider` arms lower
+  to. Their NAMESPACE does not exist, so the lowering could not evaluate even
+  if the authoring var were published."
+  '[re-frame.freehand.frames/frame-ops
+    re-frame.freehand.frames/jvm-root-scope
+    re-frame.freehand.frames/jvm-provider-scope])
+
+(def ^:private published-on-both-hosts
+  "Published `re-frame.freehand` vars that the JVM also interns — the control
+  for the nils below."
+  '[re-frame.freehand/sub
+    re-frame.freehand/slot
+    re-frame.freehand/raw-fn])
+
+(defn- production-env
+  "The env the JVM structural door builds — `:clj` host, this namespace, no
+  `:resolver`. `re-frame.freehand` is required above, so a resolution failure
+  here is a MISSING VAR and not a missing namespace."
+  []
+  (env/make-env {:host    :clj
+                 :ns-sym  're-frame.freehand.unpublished-head-absence-jvm-test
+                 :self    'probe
+                 :self-id :re-frame.freehand.unpublished-head-absence-jvm-test/probe}))
+
+(defn- interned? [sym]
+  (some? (try (ns-resolve 're-frame.freehand.unpublished-head-absence-jvm-test sym)
+              (catch Exception _ nil))))
+
+(def ^:private manifest-vars
+  "Every `{:namespace :var}` pair in the generated public-API roster."
+  (->> (edn/read-string (spec-resource/slurp-resource nil "api-manifest.edn"))
+       :vars
+       (into #{} (map (fn [{:keys [namespace var]}] (symbol namespace var))))))
+
+;; ---------------------------------------------------------------------------
+;; The vars are unpublished, on BOTH hosts
+;; ---------------------------------------------------------------------------
+
+(deftest the-generated-api-roster-is-readable-and-carries-the-door
+  (testing "Non-vacuity for every roster assertion below: the manifest read
+            really produced the published surface. An empty or unreadable
+            roster would make every absence claim true for the wrong reason."
+    (is (< 100 (count manifest-vars))
+        "the generated roster loaded")
+    (is (contains? manifest-vars 're-frame.freehand/defview)
+        "and it carries the Freehand door")))
+
+(deftest no-unpublished-head-appears-in-the-public-api-roster
+  (testing "The host-independent half. `spec/api-manifest.edn` is generated
+            from live public vars and reconciled in both directions, so a name
+            absent from it is published on NEITHER host — which is what
+            distinguishes these six from a browser-only var."
+    (doseq [sym unpublished-heads]
+      (is (not (contains? manifest-vars sym))
+          (str sym " has no public-API row — when it gains one, the slice that "
+               "publishes it must land its analyzer recognition, position law "
+               "and lowering in the same change")))))
+
+(deftest a-browser-only-published-var-is-the-control-for-that-claim
+  (testing "`v/mount` is published under `#?(:cljs …)`: absent from a JVM
+            `ns-resolve` and absent from `:clj` production resolution, yet
+            fully public. Without this row the nils below would look like proof
+            of absence when they are only proof of host."
+    (is (not (interned? 're-frame.freehand/mount))
+        "the JVM does not intern it")
+    (is (nil? (env/resolve-sym (production-env) 're-frame.freehand/mount))
+        "and :clj production resolution answers nil for it")
+    (is (contains? manifest-vars 're-frame.freehand/mount)
+        "yet it IS published — so the JVM probe alone never proves absence")))
+
+(deftest no-unpublished-head-is-interned-on-the-jvm
+  (testing "The JVM half, which is the door the structural compile really
+            runs. Neither `re-frame.freehand` nor `re-frame.freehand.react`
+            interns any of the six."
+    (doseq [sym unpublished-heads]
+      (is (not (interned? sym)) (str sym " is not interned")))))
+
+(deftest production-resolution-answers-nil-for-every-unpublished-head
+  (testing "Through the resolution the compiled door actually performs —
+            `env/resolve-sym` over a production env with NO injected resolver —
+            every one of the six answers nil. An arm gated on
+            `env/resolves-to?` therefore cannot run, whatever body is compiled."
+    (let [e (production-env)]
+      (doseq [sym unpublished-heads]
+        (is (nil? (env/resolve-sym e sym))
+            (str "production resolution of " sym))))))
+
+(deftest production-resolution-still-sees-the-vars-that-do-exist
+  (testing "The control that makes the nils above mean something: the SAME env
+            resolves the authoring vars the analyzer really does recognise. A
+            resolver answering nil to everything would pass every row above
+            while proving nothing."
+    (let [e (production-env)]
+      (doseq [sym published-on-both-hosts]
+        (is (= sym (:fqn (env/resolve-sym e sym))) (str sym))
+        (is (contains? manifest-vars sym)
+            (str sym " is published, and the roster agrees"))))))
+
+;; ---------------------------------------------------------------------------
+;; The lowerings name a namespace that does not exist
+;; ---------------------------------------------------------------------------
+
+(deftest the-frame-arm-lowerings-name-a-phantom-namespace
+  (testing "`(frame)`, `[frame-root …]` and `[frame-provider …]` lower to
+            `re-frame.freehand.frames/*`. That namespace is defined nowhere, so
+            those three arms are dead at BOTH ends — the authoring var they
+            recognise and the runtime var they emit. Publishing the authoring
+            half alone would turn an unresolvable symbol into a compiled view
+            that cannot load, which is strictly worse."
+    (is (nil? (find-ns 're-frame.freehand.frames))
+        "re-frame.freehand.frames is not a loaded namespace")
+    (is (nil? (try (require 're-frame.freehand.frames) :loaded
+                   (catch Exception _ nil)))
+        "and there is no such namespace on the classpath to load")
+    (doseq [sym phantom-runtime-targets]
+      (is (not (interned? sym)) (str sym " names no var")))))


### PR DESCRIPTION
Three beads on the Freehand emitter/analyzer serial lane, taken by one agent
because the lane cannot be parallelised. One commit each, P1 first.

- **rf2-rr26cq** (P1, bug) — emit recursive defviews against their current-namespace Var
- **rf2-tb5yq** (P2, bug) — analyzer heads whose authoring vars the door does not publish
- **rf2-hytu5** (P2) — the Freehand tool reader door + `:diagnostics` on the manifest

---

## rf2-rr26cq — the #6886 audit obligation, which was still unmet

The earlier PR delivered half of this bead: an exact self-recursive head now
emits its canonical current-namespace `:fqn`. The audit reopened it for the
other half, and that half was still missing on main.

The matching `:uses` shadow completion sat in `emit-react-body`, gated on
`:self-ref?` — so it ran **only when a body happened to mention its own name**.
A *non-recursive* `(v/defview sub {:compiled true} [_] [:div "x"])` in a
namespace referring `re-frame.freehand/sub` therefore still compiled its
`(def …)` against the **authoring** Var. Real `cljs.compiler` output on the
pre-fix tree:

```js
re_frame.freehand.sub = re_frame.freehand.descriptor.declare_view(… mount(cljs.user.sub, …) …)
```

`re_frame.freehand.sub` clobbered, `cljs.user.sub` never defined — one
declaration, two identities.

**The repair.** Whether a body recurses cannot decide which Var a definition
lands in, so the shadow moves to the **declaration boundary**:
`shadow-same-named-refer!`, called once from `expand-defview`, for every
declaration in **both** lowerings (the `(def …)` is identical in each, so the
interpreted path had the same defect). `cljs.env` is reached by late resolution
under a `(:ns &env)` guard, so the door keeps no compile-time dependency on
ClojureScript.

The emitter loses its analyzer-state mutation, its `:self-ref?` bookkeeping and
its `cljs.env` require. Emitting a form is not the place to move a Var. The
exact-self `:fqn` emission is unchanged.

**Which door was exercised:** the tests now drive
`re-frame.freehand/expand-defview` — the production expansion the `defview`
macro itself calls — and compile the result through real `cljs.analyzer` +
`cljs.compiler`, asserting on emitted JavaScript bytes. The row that pinned the
wrong behaviour (`a-non-recursive-view-leaves-the-refer-and-heads-untouched`) is
inverted, and the audit's "check the interpreted declaration path too" is
answered by proving it rather than arguing it: an interpreted `v/defview` has no
analysis and no emitter but emits the same `(def …)`, so it carried the same
split identity and no emitter-hosted repair could ever have reached it.

**Mutation check:** commenting out `shadow-same-named-refer!` reds **11**
assertions across the compiled and interpreted rows.

## rf2-tb5yq — six heads, one production-door proof

Every suite that exercised these arms injected a `:resolver` that
**manufactures** the missing definitions — the synthetic-proof pattern the
rf2-1a9au audit rejected. The new
`re-frame.freehand.unpublished-head-absence-jvm-test` injects nothing.

Per head it proves the JVM interns nothing, that `:clj` production
`env/resolve-sym` answers nil, and — the half a JVM probe **cannot** do alone —
that `spec/api-manifest.edn` carries no public-API row. That last check is what
separates an unpublished var from a browser-only one: `re-frame.freehand` is
`.cljc`, so `v/mount` is genuinely absent from a JVM `ns-resolve` while being
fully public. `v/mount` rides as the control that makes that gap visible rather
than assumed; the vars that *do* exist ride as the control that stops a
nil-to-everything resolver passing.

It also pins a second, worse fact the bead had not recorded: the `frame` /
`frame-root` / `frame-provider` arms lower to `re-frame.freehand.frames/*`, and
**that namespace does not exist anywhere in the tree** — the same phantom
lowering class as the `re-frame.freehand.hooks/*` vars rf2-1a9au removed. So
publishing the authoring half alone would turn an unresolvable symbol into a
compiled view that cannot load.

### Per-head disposition

| head | disposition | reason |
|---|---|---|
| `re-frame.freehand.react/lazy` | **removed** | `re-frame.freehand.react` is browser-only and defines no `lazy`. The arm is a bare rejection: no site bucket, no manifest roster, no emitter arm, and its only conformance row is the **donor's** S3 profile (gated by `implementation/ui/test/…/s3_conformance_profile_jvm_test.clj`), not Freehand's. Fully self-contained → gone, to return with the slice that ships the verb. The `classify-head` foreign-lazy path is untouched: it keys on `:rf.ui/lazy` var metadata and the marked runtime value, not on an unpublished authoring var. |
| `re-frame.freehand/frame` | **deferred** → rf2-h1ae3 | Doubly dead (unpublished head *and* phantom lowering), but `:frame-ops` is a manifest roster pinned by `fh-struct-010.edn`, is one of the three inputs to `view-cell-elided?`, and appears in `runtime-requiring-site-caps`. Removal is a conformance-contract change; the F6a lane holds those fixtures this wave. |
| `re-frame.freehand/frame-root` | **deferred** → rf2-h1ae3 | Same, plus it drives `root.cljc`'s static frame-plan scan, `check-plan-set!` and `:rf.error/frame-payload-conflict`. |
| `re-frame.freehand/frame-provider` | **deferred** → rf2-h1ae3 | Same. The bead's own recorded analysis is "add only if a concrete Freehand use case cannot be expressed by root frame scope", so the expected disposition is removal, sequenced. |
| `re-frame.freehand/html` | **deferred** → rf2-rrosy (needs a ruling) | The bead's notes recorded that both prior reviewers recommended **shipping** `v/html`. That recommendation does not survive contact with the emitters: **neither one lowers it.** `emit-jvm` has `:html nil` and never reads the carrier, `emit-react` has no arm at all, and `:html` is outside `grammar/admitted-ops`. Publishing the var alone would make a compiled `(v/html s)` analyze, record a site, and render **nothing** — trusted markup silently dropped, strictly worse than today's unresolved symbol. Shipping it properly is a slice (grammar admission + both emitters + SSR); `:html-sites` is also fixture-pinned. The real invariant to restore is that `rules.cljc` currently *recommends* `(v/html …)` for every `dangerouslySetInnerHTML` spelling — a diagnostic must not recommend a form that does not exist. |
| `re-frame.freehand/raw` | **deferred** → rf2-4gnrs | Inert at every stage, but `raw-form?` has a second call site that mints the `:foreign` **crossing-prop marker**, a member of the pinned `crossing-prop-markers` roster. Removing recognition removes a marker from a conformance-pinned roster. |

**No public API was added to make any arm reachable.** Where the choice was
"publish a var so a diagnostic can fire" the answer was no, and the reason is
recorded on the bead and at the site in `analyze.cljc`.

## rf2-hytu5 — the reader door, and the findings it exists to reach

Two defects, one seam. `re-frame.freehand.tool` did not exist — its only
mention in the tree was a docstring in `compiler/a11y.cljc` promising
`tool/view-manifest` to a reader that could not resolve it — and
`structural-manifest` carried no `:diagnostics` key, so every compile-tier a11y
finding was collected in the compiler env and published nowhere.

Suppression is what makes the second half matter. A suppressed finding is
silent *by design*; the manifest entry carrying the author's reason was its only
trace. With no `:diagnostics` on the manifest, that reason went into a map no
reader could open.

`view-manifest` is the whole door, and it is **total**: every value has an
answer and `nil` means "nothing statically known", whether the value is not a
view or is an interpreted declaration. That totality is the only difference from
`v/manifest` — a tool is handed whatever it swept, and a reader that throws on
the first non-view cannot sweep. It returns the declaration's own manifest, so
the two doors cannot drift.

**Fence honoured:** no accumulator (ruled out permanently by rf2-drpa3.167), no
root registry, no history store, no port of the donor `re-frame.ui.tool`
surface. Retention stays Spec 009's ring; nothing here retains anything. One
namespace, one function, one manifest key.

`:diagnostics` entries are findings, not lexical sites — they carry `:tag` and
`:path` but no `:source-coord` — so the census suite's coordinate law is
restated to say exactly that rather than lumping the new roster in with the
non-roster keys. Giving `:diagnostics` its own `FH-STRUCT-010` row is a
conformance change: rf2-085ai.

---

## Conformance fences respected

Nothing under `spec/conformance/**` is touched — the F6a completion worker holds
it. Four of the six rf2-tb5yq dispositions and the `:diagnostics` fixture row
are blocked on conformance edits and are filed for the mayor to sequence, not
taken here.

## Follow-on beads filed

| bead | what |
|---|---|
| rf2-h1ae3 (P2) | retire the `frame` / `frame-root` / `frame-provider` arms + phantom `re-frame.freehand.frames/*` lowerings (needs FH-STRUCT-010 rows) |
| rf2-rrosy (P2) | rule on `v/html` — ship it as a real slice, or retire it and fix the recovery strings |
| rf2-4gnrs (P3) | rule on `v/raw` recognition — the `:foreign` crossing-prop marker is the entanglement |
| rf2-085ai (P2) | give the manifest `:diagnostics` roster its own FH-STRUCT-010 row |
| rf2-j3evb (P3) | classify `re-frame.freehand.tool` on the published API surface |

## Quality gates

All run in the foreground to completion, captured to worktree-local logs, exit
code echoed. No gate was piped through `tail`/`grep`.

| gate | result | exit |
|---|---|---|
| `cd implementation/freehand && clojure -M:test` (after rf2-rr26cq) | 925 tests / 6606 assertions, 0 failures, 0 errors | 0 |
| `cd implementation/freehand && clojure -M:test` (after rf2-tb5yq) | 932 tests / 6640 assertions, 0 failures, 0 errors | 0 |
| `cd implementation/freehand && clojure -M:test` (final tree) | 938 tests / 6667 assertions, 0 failures, 0 errors | 0 |
| `npm run test:freehand` | 1009 tests / 5710 assertions, 0 failures, 0 errors (final tree) | 0 |
| `npm run test:cljs` (final tree) | 11163 tests / 56017 assertions, 0 failures, 0 errors | 0 |
| `npm run test:browser` | 759 tests / 4759 assertions, 0 failures, 0 errors (green first run; no flake, no timeout override) | 0 |
| `scripts/test-fast-pr.sh` | `PASS fast PR spine` — core JVM, CLJS node integration (11158/55995), per-ns test isolation, and every static gate | 0 |
| `python scripts/check_donor_inventory.py --ci --report` | clean | 0 |
| `python scripts/check_freehand_conformance_index.py --verbose` | OK: 92 rows across 15 area sections | 0 |
| freehand donor-spelling gate (`git grep -e 're-frame\.ui' … -- implementation/freehand`) | no matches | — |

**Mutation evidence (non-vacuity).** Commenting out the `shadow-same-named-refer!`
call reds 7 assertions in
`re-frame.freehand.compiler-macro-resolution-jvm-test`, with the emitted
JavaScript showing the exact split identity (`re_frame.freehand.sub = …
declare_view` with the recursive head already correctly `cljs.user.sub`).
Restored and re-verified green.

The spine compiled its `test:cljs` arm just before the tool-reader suite was
made cross-host, so that arm is re-run standalone on the final tree above —
11163/56017, the +5/+22 being exactly the tool-reader assertions now executing
on the ClojureScript host as well.

**Which door, per reachability claim.** Every rf2-tb5yq claim goes through
production `env/resolve-sym` with **no injected `:resolver`**, plus JVM
`ns-resolve`, plus the generated `spec/api-manifest.edn` roster for the
host-independent half. Every rf2-rr26cq claim goes through
`re-frame.freehand/expand-defview` — the real macro expansion — compiled by real
`cljs.compiler`. Every rf2-hytu5 claim goes through a real
`v/defview {:compiled true}` declaration read back via `tool/view-manifest`,
on BOTH hosts — the reader ships in browser bundles and no CLJS build was
compiling it, so the suite is `.cljc`.
