### PR TITLE
test(routing): make the door-parity fixture bite — positive footprints per door (rf2-kqxe6.2)

### DIFF
--- a/implementation/core/test/re_frame/conformance_test.clj
+++ b/implementation/core/test/re_frame/conformance_test.clj
@@ -224,6 +224,48 @@
                 {:fixture/expect {:final-app-db {} :epoch-records []}}))
       "corpus-checked expectation keys must NOT be flagged unknown"))
 
+;; ---- rf2-kqxe6.2 NEUTER PROBE for routing/door-parity ---------------------
+;;
+;; The door-parity fixture claims all three navigation doors lower to ONE
+;; resolver. It used to assert doors 2 and 3 purely by the ABSENCE of a further
+;; history push — and both `check-effects-routed` and `check-trace-emissions`
+;; are ORDER-PRESERVING SUBSET matchers ("extras are tolerated"), so no
+;; `:fixture/expect` key in this runner can grade an absence. The fixture
+;; therefore passed with doors 2 and 3 DELETED, proving nothing it advertised.
+;; The repair gives every door a distinct destination and thus a positive
+;; footprint; this probe is what holds the repair in place.
+
+(defn- door-parity-fixture []
+  (or (some (fn [[n f]] (when (= n "routing-door-parity.edn") f)) (all-fixtures))
+      (throw (ex-info "routing-door-parity.edn is missing from the corpus" {}))))
+
+(defn- without-doors
+  "The fixture with the 0-based `:fixture/dispatches` indices in `idxs` removed."
+  [fixture idxs]
+  (let [drop? (set idxs)]
+    (update fixture :fixture/dispatches
+            #(vec (keep-indexed (fn [i d] (when-not (drop? i) d)) %)))))
+
+(deftest door-parity-fixture-bites
+  (let [fixture (door-parity-fixture)
+        passes? (fn [f] (:passed? (runner/run-fixture f host)))]
+    (is (passes? fixture)
+        "the door-parity fixture must pass as shipped")
+    (doseq [[door idx] [["named-address" 0] ["raw-URL" 1] ["URL-driven" 2]]]
+      (is (not (passes? (without-doors fixture [idx])))
+          (str "deleting the " door " door MUST red the door-parity fixture")))
+    (is (not (passes? (without-doors fixture [1 2])))
+        "the named-address door alone MUST NOT satisfy the door-parity fixture")
+    ;; The `:fixture/calls` leg cannot be probed by DELETION — removing an
+    ;; expectation can never fail a subset-matching runner. Perturbing one
+    ;; proves the pure-resolver leg is graded rather than silently skipped.
+    (is (not (passes? (assoc fixture :fixture/calls
+                            [{:call     :route-url
+                              :route-id :route/article
+                              :params   {:slug "raw-url"}
+                              :expect   "/articles/DELIBERATELY-WRONG"}])))
+        "a wrong :fixture/calls expectation MUST red the door-parity fixture")))
+
 ;; ---- rf2-ska8zk NEGATIVE self-test for the :expect-graph guard ------------
 ;;
 ;; The broad derivation-graph fixture pins the live graph's {:mode :live

--- a/spec/conformance/fixtures/routing-door-parity.edn
+++ b/spec/conformance/fixtures/routing-door-parity.edn
@@ -6,30 +6,58 @@
 ;; door (popstate / initial / SSR) all resolve to one canonical target.
 ;; Doors differ only in cause-specific history/scroll effects.
 ;;
-;; The fixture pins the R0 arms of door parity:
-;;   1. NAMED-ADDRESS door — a programmatic `{:to ... :params ...}` navigate
-;;      commits the target and PUSHES the URL.
-;;   2. RAW-URL door — a programmatic `{:url ...}` navigate to the SAME
-;;      destination resolves to an IDENTICAL target and is therefore a rule-3
-;;      no-op (returns {}): no second push, no token. The no-op is the strict
-;;      oracle — the raw-URL door could only be identical if it resolved to
-;;      exactly the target the named-address door committed.
-;;   3. URL-DRIVEN door — `[:rf.route/handle-url-change url]` (the shared
-;;      popstate / initial / SSR entry) lands the SAME target from the URL and
-;;      does NOT push (the URL already came from the browser).
+;; EVERY DOOR LEAVES A POSITIVE FOOTPRINT. This fixture deliberately sends
+;; each door to a DISTINCT destination, so each door's contribution is
+;; asserted by the PRESENCE of a distinguishable effect rather than by the
+;; absence of one. That is not a stylistic choice — it is forced by the
+;; harness. `check-effects-routed` and `check-trace-emissions` are both
+;; ORDER-PRESERVING SUBSET matchers ("extras are tolerated"), so no
+;; `:fixture/expect` key in this runner can assert that an effect did NOT
+;; fire. A fixture that pins a door by "no second push" therefore pins
+;; nothing: deleting that door leaves every assertion satisfied. The three
+;; destinations below (`named` → `raw-url` → `url-driven`) make each door
+;; independently load-bearing:
+;;
+;;   1. NAMED-ADDRESS door — `{:to :route/article :params {:slug "named"}}`
+;;      commits `named` and PUSHES `/articles/named`.
+;;   2. RAW-URL door — `{:url "/articles/raw-url"}` commits `raw-url` and
+;;      PUSHES `/articles/raw-url`. Forward navigation, so `:strategy :top`.
+;;   3. URL-DRIVEN door — `[:rf.route/handle-url-change "/articles/url-driven"]`
+;;      (the shared popstate / initial / SSR entry) commits `url-driven` and
+;;      does NOT push (the URL already came from the browser); the popstate
+;;      default `:strategy :restore` is its signature.
+;;
+;; CONVERGENCE IS ASSERTED POSITIVELY by the `:rf.nav/scroll` `:from` / `:to`
+;; descriptors. Each door's `:to` is the SAME canonical `{:id :params}` target
+;; shape reached from a different door input, and each door's `:from` is the
+;; previous door's `:to` — so the chain pins both the shared resolver output
+;; and the order the doors ran in. Delete door 1 and `/articles/named` is
+;; never pushed; delete door 2 and `/articles/raw-url` is never pushed AND
+;; door 3's `:from` is wrong; delete door 3 and the final target is `raw-url`
+;; instead of `url-driven` AND the `:restore` scroll never fires.
 ;;
 ;; The pure resolver parity is proven directly by the calls: match-url (the
 ;; raw-URL door's resolver) and route-url (the named-address door's URL
 ;; builder) are inverse and converge on the same target/URL; round-trip pins
 ;; the identity.
 ;;
+;; NOT ASSERTED HERE: the rule-3 no-op (a raw-URL navigate to the
+;; already-current target returning `{}`). It is inherently an absence claim
+;; and this runner cannot grade one; it has its own coverage in
+;; routing-on-match-no-rerun-on-identical.edn and
+;; implementation/routing/test/re_frame/routing_classification_test.clj.
+;;
+;; The neuter probe that proves this fixture bites — deleting any one door
+;; reds it — lives in implementation/core/test/re_frame/conformance_test.clj
+;; (`door-parity-fixture-bites`).
+;;
 ;; Per [012 §The one planning pipeline] (#the-one-planning-pipeline) and
 ;; [§URL changes are events] (#url-changes-are-events).
 
 {:fixture/id           :routing/door-parity
  :fixture/spec-version "1.0"
- :fixture/capabilities #{:routing/match-url :core/event-handler :core/fx}
- :fixture/doc          "EP-0037 R0 door parity (row 2): a named-address navigate, a matching raw-URL navigate, and the URL-driven handle-url-change door all resolve to one canonical target. The raw-URL navigate to the already-current target is a strict rule-3 no-op (proving it resolved identically to the named-address door); the URL-driven door lands the same target without a history push. Only the named-address door pushes. match-url and route-url are inverse and converge (calls)."
+ :fixture/capabilities #{:routing/match-url :core/event-handler :core/fx :core/trace}
+ :fixture/doc          "EP-0037 R0 door parity (row 2): a named-address navigate, a raw-URL navigate, and the URL-driven handle-url-change door all lower to ONE resolver. Each door drives a DISTINCT destination so it leaves a positive, independently load-bearing footprint: doors 1 and 2 each push their own URL; door 3 commits its target and never pushes, carrying the popstate-default :restore scroll. The chained :rf.nav/scroll :from/:to descriptors assert convergence on the one canonical target shape — and the door ordering — by presence rather than absence. match-url and route-url are inverse and converge (calls)."
 
  :fixture/registry
  {:event {:rf/init                    {:doc "Seed the current route."}
@@ -53,40 +81,63 @@
  :fixture/frame-config {:initial-events [[:rf/init]] :platform :client}
 
  :fixture/dispatches
- [;; (1) Named-address door — commits route/article, PUSHES the URL.
-  [:rf.route/navigate {:to :route/article :params {:slug "routing-as-data"}}]
+ [;; (1) Named-address door — commits `named`, PUSHES /articles/named.
+  [:rf.route/navigate {:to :route/article :params {:slug "named"}}]
 
-  ;; (2) Raw-URL door to the SAME destination — resolves to an identical
-  ;;     target, so it is a rule-3 no-op ({}). No second push. The absence of
-  ;;     a change strictly proves the raw URL resolved to exactly the named
-  ;;     target committed by (1).
-  [:rf.route/navigate {:url "/articles/routing-as-data"}]
+  ;; (2) Raw-URL door — a DIFFERENT destination, so it must resolve the URL
+  ;;     through the same resolver and commit it: PUSHES /articles/raw-url.
+  [:rf.route/navigate {:url "/articles/raw-url"}]
 
-  ;; (3) URL-driven door (popstate / initial / SSR) — lands the SAME target
-  ;;     from the URL; does NOT push (the URL came from the browser).
-  [:rf.route/handle-url-change "/articles/routing-as-data"]]
+  ;; (3) URL-driven door (popstate / initial / SSR) — commits `url-driven`
+  ;;     from the URL and does NOT push (the URL came from the browser).
+  [:rf.route/handle-url-change "/articles/url-driven"]]
 
  :fixture/calls
  ;; Pure resolver parity: the raw-URL door's resolver (match-url) and the
  ;; named-address door's URL builder (route-url) are inverse and converge on
  ;; the same target/URL; round-trip pins the identity.
- [{:call :match-url :url "/articles/routing-as-data"
-   :expect {:route-id :route/article :params {:slug "routing-as-data"} :query {} :fragment nil :validation-failed? false}}
-  {:call :route-url :route-id :route/article :params {:slug "routing-as-data"}
-   :expect "/articles/routing-as-data"}
-  {:call :round-trip :url "/articles/routing-as-data"}]
+ [{:call :match-url :url "/articles/raw-url"
+   :expect {:route-id :route/article :params {:slug "raw-url"} :query {} :fragment nil :validation-failed? false}}
+  {:call :route-url :route-id :route/article :params {:slug "raw-url"}
+   :expect "/articles/raw-url"}
+  {:call :round-trip :url "/articles/raw-url"}]
 
  :fixture/expect
- ;; All three doors converge on one canonical target. Submap match tolerates
- ;; :transition/:nav-token/etc.
+ ;; The URL-driven door ran last, so the canonical target it resolved is the
+ ;; committed one. Load-bearing on door 3: without it the slug is "raw-url".
  {:final-runtime-db
   {:rf.runtime/routing
    {:current {:route-id :route/article
-              :params   {:slug "routing-as-data"}
+              :params   {:slug "url-driven"}
               :query    {}
               :fragment nil}}}
 
-  ;; Only the named-address door (1) drives a history push. The raw-URL door
-  ;; (2) no-ops; the URL-driven door (3) never pushes.
+  ;; The full ordered navigation-effect chain. Each push names the door that
+  ;; produced it; each scroll's :from/:to pins the canonical target shape both
+  ;; the door before and the door itself resolved to.
   :effects-routed
-  [{:fx-id :rf.nav/push-url :args "/articles/routing-as-data"}]}}
+  [;; (1) named-address door
+   {:fx-id :rf.nav/push-url :args "/articles/named"}
+   {:fx-id :rf.nav/scroll
+    :args  {:strategy :top
+            :from     {:id :route/home}
+            :to       {:id :route/article :params {:slug "named"}}}}
+   ;; (2) raw-URL door — same resolver, distinct destination
+   {:fx-id :rf.nav/push-url :args "/articles/raw-url"}
+   {:fx-id :rf.nav/scroll
+    :args  {:strategy :top
+            :from     {:id :route/article :params {:slug "named"}}
+            :to       {:id :route/article :params {:slug "raw-url"}}}}
+   ;; (3) URL-driven door — no push; popstate-default :restore
+   {:fx-id :rf.nav/scroll
+    :args  {:strategy :restore
+            :from     {:id :route/article :params {:slug "raw-url"}}
+            :to       {:id :route/article :params {:slug "url-driven"}}}}]
+
+  ;; Both matchers CONSUME each match, so listing :rf.route/navigate twice
+  ;; requires two actual run-starts — the duplicate entry is load-bearing.
+  :trace-emissions
+  [{:operation :rf.event/run-start :tags {:rf.trace/event-id :rf/init}}
+   {:operation :rf.event/run-start :tags {:rf.trace/event-id :rf.route/navigate}}
+   {:operation :rf.event/run-start :tags {:rf.trace/event-id :rf.route/navigate}}
+   {:operation :rf.event/run-start :tags {:rf.trace/event-id :rf.route/handle-url-change}}]}}


### PR DESCRIPTION
Discharges the PR #6865 audit obligation on `rf2-kqxe6.2` (EP-0037 R0a). The contract half of R0a already shipped; this is the residual — making the door-parity fixture actually prove what it advertises.

## The defect

`spec/conformance/fixtures/routing-door-parity.edn` claimed all three navigation doors converge through one spine. It proved none of it. Run against `main`, it passed unchanged, with door 2 deleted, with door 3 deleted, and with **only door 1** left — the last producing a byte-identical `:actual-effects` list to the baseline. Doors 2 and 3 contributed zero observable difference across the fixture's entire observation surface.

Worse than the original audit reported: deleting door **1** also passed, because door 2 pushed the same URL door 1 was supposed to.

## Why absence-based assertions cannot work in this runner

This is structural, not a typo, and it is the whole constraint on the fix.

`check-effects-routed` (`implementation/core/test/re_frame/conformance_runner.cljc`) is an **order-preserving subset match** — its own docstring says *"Extras are tolerated."* `check-trace-emissions` (`re-frame.conformance`) has the same shape. Consequently **no `:fixture/expect` key in this runner can assert that an effect did NOT fire.**

The old fixture pinned doors 2 and 3 purely by absence: door 2 was a rule-3 no-op ("no second push") and door 3 never pushes ("no third push"). Both claims are unobservable to a subset matcher, so deleting either door left every assertion satisfied. A fixture that pins a door by what *doesn't* happen pins nothing.

The runner is deliberately **not** changed here. Adding an absence matcher is framework work this bead does not own.

## The fix — fixture-only, positive footprints per door

Each door now drives a **distinct** destination, so each leaves a footprint that can be asserted by presence:

| door | dispatch | footprint |
|---|---|---|
| 1 named address | `[:rf.route/navigate {:to :route/article :params {:slug "named"}}]` | commits `named`, **pushes** `/articles/named` |
| 2 raw URL | `[:rf.route/navigate {:url "/articles/raw-url"}]` | commits `raw-url`, **pushes** `/articles/raw-url` |
| 3 URL-driven | `[:rf.route/handle-url-change "/articles/url-driven"]` | commits `url-driven`, **no push**, `:strategy :restore` |

Convergence is asserted **positively** by the chained `:rf.nav/scroll` `:from`/`:to` descriptors. Each door's `:to` is the same canonical `{:id :params}` target shape reached from a different door input, and each door's `:from` is the previous door's `:to` — so the chain pins both the shared resolver output and the order the doors ran in. That is the row-2 convergence claim restated as presence rather than absence.

Each door is now independently load-bearing:

- delete door 1 → `/articles/named` is never pushed;
- delete door 2 → `/articles/raw-url` is never pushed **and** door 3's scroll `:from` is wrong;
- delete door 3 → the final target is `raw-url` not `url-driven` **and** the `:restore` scroll never fires.

`:final-runtime-db` pins the `url-driven` slug, which is load-bearing on door 3 alone. `:fixture/calls` keeps its role unchanged as the pure-resolver leg (`match-url` / `route-url` / `round-trip`).

The expected effect and scroll shapes were **read off the live runtime** via a throwaway probe and cross-checked against `routing-history-popstate.edn` (which pins `:strategy :restore` for the URL-driven door) — not hand-written.

## Five-variant non-vacuity table

A green fixture is not evidence — this bead exists precisely because a green fixture proved nothing. Each variant below was run through `run-fixture` on the JVM host, old fixture (`origin/main`) beside new.

| variant | OLD `passed?` | NEW `passed?` |
|---|---|---|
| BASELINE (all 3 doors) | `true` | `true` |
| DELETE door 1 (named address) | `true` (vacuous) | **`false`** |
| DELETE door 2 (raw URL) | `true` (vacuous) | **`false`** |
| DELETE door 3 (handle-url-change) | `true` (vacuous) | **`false`** |
| ONLY door 1 | `true` (vacuous) | **`false`** |
| DELETE `:fixture/calls` | `true` | `true` — see below |
| MUTATE a `:fixture/calls` entry | `false` | `false` |

**On the `:fixture/calls` row.** Deleting `:fixture/calls` cannot be made to fail, and that is not a defect in the fixture: removing an expectation can never turn a pass into a fail under any subset-matching runner. The meaningful probe for that leg is **perturbation**, not deletion — and a wrong `:route-url` expectation reds the fixture on both old and new (call failures throw and are graded). The last row is the honest analogue of the audit's fourth variant.

## The neuter probe

`door-parity-fixture-bites` in `implementation/core/test/re_frame/conformance_test.clj`, sitting beside the existing runner self-tests (`epoch-records-checked-on-jvm`, `unknown-expect-key-fails-loud`). It loads the fixture from `all-fixtures`, runs `run-fixture` with each door deleted in turn plus the only-door-1 variant, asserts `(not (:passed? result))` for each, then perturbs a call. ~30 lines, one deftest, for this fixture only. **No general neuter harness was built.**

## Deliberately dropped arm

The old fixture's **rule-3 no-op** arm — a raw-URL navigate to the already-current target returning `{}` — is dropped from the parity proof. It is inherently an absence claim and this runner cannot grade one, so keeping it would re-introduce exactly the vacuity being fixed. It keeps its own coverage elsewhere, named in a non-oracle comment in the fixture header:

- `spec/conformance/fixtures/routing-on-match-no-rerun-on-identical.edn`
- `implementation/routing/test/re_frame/routing_classification_test.clj`

## Quality gates

All run foreground to completion; exit codes echoed.

| gate | command | result | exit |
|---|---|---|---|
| conformance namespace | `cd implementation/core && clojure -M:test -n re-frame.conformance-test` | 5 tests, 18 assertions — **0 failures, 0 errors** | 0 |
| core JVM suite | `cd implementation/core && clojure -M:test` | 2105 tests, 10430 assertions — **0 failures, 0 errors** | 0 |
| routing JVM suite | `cd implementation/routing && clojure -M:test` | 467 tests, 2449 assertions — **0 failures, 0 errors** | 0 |
| fast-PR spine | `scripts/test-fast-pr.sh` | `PASS fast PR spine` — incl. CLJS node integration (11159 tests, 56004 assertions, **0 failures, 0 errors**), which runs the same fixture on the CLJS host | 0 |

Scope: two files. No runner change, no absence matcher, no general harness, no spec edit — `spec/012-Routing.md` and `spec/Spec-Schemas.md` are untouched (their half of R0a shipped in #6865).
