### PR TITLE
fix(resources): edge-trigger the readiness error emit and correct contributor attribution (rf2-kqxe6.17)

### DIFF
--- a/implementation/resources/src/re_frame/resources/events.cljc
+++ b/implementation/resources/src/re_frame/resources/events.cljc
@@ -1279,24 +1279,19 @@
   :poll)
 
 (defn- entry-revalidation-in-flight?
-  "True iff `entry` already has a LIVE refetch in flight — its
-  `:current-work` points at a work-ledger record whose status is
-  non-terminal AND not `:abort-requested` (i.e. `:queued` / `:running`: work
-  that will produce a usable reply). Such an entry needs no new revalidation
-  refetch — one is already running. A `:current-work` pointer alone is NOT
-  proof of live work: the linked record may be terminal (a settled attempt
-  whose entry write has not yet cleared the pointer) or `:abort-requested`
-  (a doomed, owner-released attempt) — both fall through as NOT in-flight, so
-  revalidation can legitimately start fresh work. Mirrors the `joinable?`
-  gate in `ensure-load` (rf2-v4ygg5): only a genuinely live attempt blocks a
-  new generation. Per Spec 016 §Race / §Deferred slices (rf2-wankrd:
-  coalesce focus + visibility revalidation for in-flight stale entries)."
+  "True iff `entry` already has a LIVE refetch in flight — work that will
+  produce a usable reply. Such an entry needs no new revalidation refetch: one
+  is already running. Liveness is `work-ledger/live-work?`, the ONE definition
+  of that question (rf2-kqxe6.6) — a `:current-work` POINTER alone is not proof
+  of work, since the linked record may be terminal (a settled attempt whose
+  entry write has not yet cleared the pointer) or `:abort-requested` (a doomed,
+  owner-released attempt); both fall through as NOT in-flight, so revalidation
+  can legitimately start fresh work. The same predicate backs `ensure-load`'s
+  `joinable?` gate (rf2-v4ygg5), so only a genuinely live attempt blocks a new
+  generation. Per Spec 016 §Race / §Deferred slices (rf2-wankrd: coalesce focus
+  + visibility revalidation for in-flight stale entries)."
   [runtime-db entry]
-  (when-let [work-id (:current-work entry)]
-    (let [status (:status (work-ledger/get-record runtime-db work-id))]
-      (and (some? status)
-           (not (work-ledger/terminal? status))
-           (not= :abort-requested status)))))
+  (work-ledger/live-work? runtime-db (:current-work entry)))
 
 (defn- active-stale-scan
   "Pure scan: given the frame's `runtime-db` value and the live `clock-ms`,

--- a/implementation/resources/src/re_frame/resources/route.cljc
+++ b/implementation/resources/src/re_frame/resources/route.cljc
@@ -355,11 +355,18 @@
   is never consulted; `clear-blocking-slot` drops it wholesale on owner
   release.
 
-  EDGE-TRIGGERED: the slice is rewritten only when the projection actually
-  differs from what it already carries, so re-projecting on every resource
-  settle is idle for unrelated resources and the
-  `:rf.error/resource-route-blocking` error trace (rf2-u5aj91) fires once per
-  transition INTO `:error`, not once per settle. That trace is the one
+  EDGE-TRIGGERED, on two separate edges. The SLICE is rewritten only when the
+  projection actually differs from what it already carries, so re-projecting on
+  every resource settle is idle for unrelated resources. The
+  `:rf.error/resource-route-blocking` error TRACE (rf2-u5aj91) fires on the
+  narrower edge — only when the slice was not ALREADY `:error` — so it is one
+  trace per transition INTO `:error`, not one per settle. The two edges differ
+  because `:error` is a pure function of the CURRENT outstanding set: a second
+  blocking requirement failing later can change WHICH failure is deterministically
+  first (the slice value moves, correctly) without the route ever leaving
+  `:error` (so nothing new happened to report). Reading the PRE-write
+  `:transition` off `db'` is what makes this a pure edge test — no latch, no
+  remembered first failure, no extra state (rf2-kqxe6.17). That trace is the one
   out-of-band observability side effect — the same emit-inside-the-pure-
   transform discipline `route-resource-plan` uses for
   `:rf.error/resource-route-plan`. `:emit-error? false` suppresses it for the
@@ -390,7 +397,12 @@
                   (= err        (get-in db' (conj slice-path :error))))
            db'
            (do
-             (when (and err emit-error?)
+             (when (and err emit-error?
+                        ;; rf2-kqxe6.17 — the EDGE into `:error`. `db'` still
+                        ;; carries the PREVIOUS transition here, so an already-
+                        ;; `:error` route that merely re-picks a canonically
+                        ;; earlier failure updates the slice silently.
+                        (not= :error (get-in db' (conj slice-path :transition))))
                ;; rf2-u5aj91: the route slice carries the structured :error AND
                ;; the trace/error stream sees `:rf.error/resource-route-blocking`
                ;; (tags conform to ResourceRouteBlockingTags).
@@ -902,7 +914,7 @@
   (the route-entry app-db value — see the `:app-db` paragraph below), and
   `:runtime-db` (the pre-commit runtime-db, read for the AT-COMMIT resource
   facts that decide which blocking requirements still have to resolve —
-  `requirement-met?`). Returns `{:fx [...] :blocking #{<scoped-key> …}
+  `requirement-ready?`). Returns `{:fx [...] :blocking #{<scoped-key> …}
   :plan-error err?}`.
 
   FAIL-CLOSED structural inputs (rf2-ac71vm): a `nil` `ctx` or a missing

--- a/implementation/resources/src/re_frame/resources/route.cljc
+++ b/implementation/resources/src/re_frame/resources/route.cljc
@@ -656,13 +656,20 @@
 
   The ex-data is carried through verbatim (`:reason` / `:recovery` /
   `:resource-id` keep their site-specific values, so a nil-scope failure stays
-  self-explaining); the ORIGINAL ex is the cause. An already-attributed ex
-  passes through untouched — the innermost frame is the specific one."
+  self-explaining); the ORIGINAL ex is the cause.
+
+  `:contributor` is the ONE key the planner owns and always stamps. A `:when` /
+  `:params` / `:scope` resolver is programmer code that may throw any `ex-info`
+  it likes, including one carrying its own unnamespaced `:contributor` — and
+  honouring that would publish a FALSE attribution on the route slice and the
+  error trace, which is exactly what rule 3 forbids. The planner knows the
+  ACTUAL contributor here and wins; the caller's value stays reachable on the
+  cause (`(ex-data (ex-cause e))`). No idempotence guard is needed: the two call
+  sites are structurally disjoint (the `order-by-after` attribution happens in
+  the inner reduce's COLLECTION expression, before the per-entry catch can see
+  anything), so no exception is ever attributed twice."
   [ex contributor]
-  (let [data (ex-data ex)]
-    (if (:contributor data)
-      ex
-      (ex-info (ex-message ex) (assoc data :contributor contributor) ex))))
+  (ex-info (ex-message ex) (assoc (ex-data ex) :contributor contributor) ex))
 
 (defn- materialize-occurrences
   "Resolve every admitted occurrence across the parent-to-leaf `branch`

--- a/implementation/resources/src/re_frame/resources/subs.cljc
+++ b/implementation/resources/src/re_frame/resources/subs.cljc
@@ -583,22 +583,20 @@
   in-flight work record's `:page-index` — a load-more APPENDS at a POSITIVE
   index (the tail), a page-0 fetch / refetch fetches index 0. The sub joins
   the entry's `:current-work` pointer to its live work-ledger row and reads the
-  recorded page index. false when the feed is not fetching, has no live work,
-  or the live work is a page-0 fetch / whole-feed refresh. Per Spec 016
-  §Causal event — load-more (R2) / §Subscription contract."
+  recorded page index. Liveness is `work-ledger/live-work?`, the ONE definition
+  of that question (rf2-kqxe6.6); the row is re-read here only for its
+  `:page-index`. false when the feed is not fetching, has no live work, or the
+  live work is a page-0 fetch / whole-feed refresh. Per Spec 016 §Causal event
+  — load-more (R2) / §Subscription contract."
   [runtime-db entry]
   (boolean
     (when (and (some? entry) (= :fetching (:status entry)))
-      (let [work-id (:current-work entry)
-            record  (when work-id (work-ledger/get-record runtime-db work-id))
-            status  (:status record)]
-        (and (some? record)
-             ;; the work is genuinely LIVE (not terminal / doomed) …
-             (not (work-ledger/terminal? status))
-             (not= :abort-requested status)
+      (let [work-id (:current-work entry)]
+        ;; the work is genuinely LIVE (not terminal / doomed) …
+        (and (work-ledger/live-work? runtime-db work-id)
              ;; … and it is a load-more APPEND (a positive page index), not a
              ;; page-0 fetch / whole-feed refresh (index 0 / absent).
-             (let [pi (:page-index record)]
+             (let [pi (:page-index (work-ledger/get-record runtime-db work-id))]
                (and (integer? pi) (pos? pi))))))))
 
 (defn fetching-next?-sub-fn

--- a/implementation/resources/test/re_frame/resources_route_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_route_cljs_test.cljc
@@ -1035,6 +1035,79 @@
                           :error      {:rf.error/id :rf.error/resource-route-plan}}}}]
       (is (identical? rdb (route/reconcile-readiness rdb))))))
 
+;; ---- the error trace is EDGE-triggered (rf2-kqxe6.17) ----------------------
+
+(def ^:private pending-req
+  {:resource/id :article/by-slug :status :loading :data nil :attempt 1})
+
+(defn- failed-req
+  "A blocking FIRST-load failure whose envelope `:status` identifies it."
+  [http-status]
+  {:resource/id :article/by-slug :status :error :data nil :attempt 1
+   :error       {:kind :rf.http/server :status http-status}})
+
+(defn- blocking-error-traces [traces]
+  (errors-of traces :rf.error/resource-route-blocking))
+
+(deftest reconcile-readiness-emits-the-blocking-error-once-per-edge-into-error
+  ;; rf2-kqxe6.17 — `reconcile-readiness` re-picks the deterministic first
+  ;; failure over the CURRENT outstanding set on EVERY settle. When a second
+  ;; blocking requirement fails LATER but sorts canonically EARLIER, that pick
+  ;; legitimately moves — but the route never left `:error`, so there is no new
+  ;; transition to report. The trace is gated on the transition EDGE, not on
+  ;; value-inequality with the slice.
+  (testing "a second failure while ALREADY :error re-picks silently — one trace"
+    (let [[early late] (sort-by state/key-id [req-a req-b])
+          final  (volatile! nil)
+          traces (record-error-traces!
+                   (fn []
+                     ;; settle 1 — the canonically LATER requirement fails first,
+                     ;; taking the route from :loading INTO :error.
+                     (let [rdb1 (route/reconcile-readiness
+                                  (runtime-db-with "nav-1" :loading
+                                                   {early pending-req
+                                                    late  (failed-req 503)}))]
+                       ;; settle 2 — the canonically EARLIER one fails too. It
+                       ;; becomes the deterministic first failure.
+                       (vreset! final
+                                (route/reconcile-readiness
+                                  (assoc-in rdb1 (state/entry-path early)
+                                            (failed-req 500)))))))
+          rdb2   @final]
+      (is (= :error (get-in rdb2 [:rf.runtime/routing :current :transition])))
+      (is (= 500 (get-in rdb2 [:rf.runtime/routing :current :error :error :status]))
+          (str "the slice reports the CURRENT deterministic first failure — "
+               ":error is a pure function of the live outstanding set, NOT a "
+               "latched first observation that could go stale on refetch"))
+      (is (= #{early late} (get-in rdb2 (route/blocking-path "nav-1")))
+          "neither failed requirement is pruned")
+      (is (= 1 (count (blocking-error-traces traces)))
+          "ONE trace per transition INTO :error, not one per settle")))
+  (testing "a GENUINE re-entry into :error still emits — the edge gate does not over-suppress"
+    ;; The failed identity refetches successfully (route → :idle), then fails
+    ;; again. That is a real second transition into :error and must be reported.
+    (let [traces (record-error-traces!
+                   (fn []
+                     (let [rdb1 (route/reconcile-readiness
+                                  (runtime-db-with "nav-1" :loading
+                                                   {req-a (failed-req 503)}))
+                           ;; the retry lands: :error → :idle (and the now-ready
+                           ;; requirement is pruned from the slot)
+                           rdb2 (route/reconcile-readiness
+                                  (assoc-in rdb1 (state/entry-path req-a)
+                                            {:resource/id :article/by-slug
+                                             :status :loaded :data {:x 1}}))]
+                       (is (= :idle (get-in rdb2 [:rf.runtime/routing :current :transition]))
+                           "a successful load re-projects :idle — no stale error survives")
+                       ;; a fresh activation re-blocks on the same identity, which
+                       ;; fails again
+                       (route/reconcile-readiness
+                         (-> rdb2
+                             (assoc-in (route/blocking-path "nav-1") #{req-a})
+                             (assoc-in (state/entry-path req-a) (failed-req 500)))))))]
+      (is (= 2 (count (blocking-error-traces traces)))
+          "two distinct transitions INTO :error are two traces"))))
+
 ;; ---- 1. activation commit reads the facts AT COMMIT ------------------------
 
 (deftest fresh-blocking-resource-commits-idle-with-no-transient-loading

--- a/implementation/resources/test/re_frame/resources_route_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_route_cljs_test.cljc
@@ -1580,7 +1580,30 @@
                       {:route-id :route/leaf
                        :route-meta {:resources [{:resource :audit/leaf :id :lf
                                                  :params (fn [_] nil)}]}}])]
-      (is (= {:route-id :route/leaf :local-id :lf} (:contributor (:plan-error plan)))))))
+      (is (= {:route-id :route/leaf :local-id :lf} (:contributor (:plan-error plan))))))
+  (testing "a resolver throwing its OWN :contributor cannot publish a FALSE one"
+    ;; rf2-kqxe6.6 — `:contributor` is the PLANNER's key. A `:when` / `:params`
+    ;; / `:scope` resolver is arbitrary programmer code and may throw any
+    ;; `ex-info`, including one carrying an unnamespaced `:contributor` of its
+    ;; own. Treating that as authoritative published a fabricated attribution
+    ;; on BOTH the route slice and the error trace, defeating the whole point
+    ;; of Spec 016 §Effective parent-chain resource plans rule 3. The planner
+    ;; knows the actual contributor and always wins.
+    (let [[plan traces] (ancestor-plan-error
+                          (ancestor-branch
+                            {:resource :audit/ancestor :id :anc
+                             :params   (fn [_]
+                                         (throw (ex-info "boom"
+                                                  {:contributor {:route-id :wrong
+                                                                 :local-id :wrong}})))}))
+          err  (:plan-error plan)
+          tags (:tags (first (errors-of traces :rf.error/resource-route-plan)))]
+      (is (= {:route-id :route/ancestor :local-id :anc} (:contributor err))
+          "the ACTUAL contributing declaration, not the resolver's claim")
+      (is (some? tags))
+      (is (= {:route-id :route/ancestor :local-id :anc} (:contributor tags))
+          "the trace agrees with the slice — one source of truth")
+      (is (= :route/leaf (:route-id err)) "the leaf target is unchanged"))))
 
 (deftest r2-warm-prefetch-planning-failure-is-attributed-too
   ;; The warm plan shares `materialize-occurrences`, so the same attribution


### PR DESCRIPTION
Closes the two remaining EP-0037 R1/R2 defects. Both beads edit
`resources/route.cljc` and `resources_route_cljs_test.cljc` at disjoint
functions, so they land together — splitting them would guarantee a conflict
for no benefit. One commit per bead.

Beads: **rf2-kqxe6.17** (R1 completion — readiness projector) and
**rf2-kqxe6.6** (R2 follow-through — retained entries + contributor attribution).

Every change here is a deletion or a de-duplication. Nothing gained a latch, a
diagnostic key, or a second readiness decision.

## The four changes

| # | Bead | File:line | Change |
|---|------|-----------|--------|
| 1 | rf2-kqxe6.17 | `resources/route.cljc:400-405` | `reconcile-readiness` emits `:rf.error/resource-route-blocking` on the **edge into `:error`**, not on value-inequality with the slice |
| 2 | rf2-kqxe6.6 | `resources/route.cljc:642-672` | `attributed` **always** stamps the planner-owned `:contributor`; the idempotence guard is deleted |
| 3 | rf2-kqxe6.6 | `resources/events.cljc:1281-1294` | `entry-revalidation-in-flight?` routes liveness through `work-ledger/live-work?` |
| 4 | rf2-kqxe6.6 | `resources/subs.cljc:578-600` | `fetching-next?*` routes liveness through `work-ledger/live-work?`, keeping its own record read for `:page-index` |

Plus one word: `route-resource-plan`'s at-commit docstring paragraph
(`route.cljc:924`) named `requirement-met?`; the at-commit predicate has been
`requirement-ready?` since #6902.

### 1. The readiness error emit was not edge-triggered

`reconcile-readiness` re-picks the deterministic first failure over the current
outstanding set on every settle, and gated its trace emit on value-inequality
alone. With blocking requirements A and B, failing the canonically *later* key
first and the *earlier* key second flipped the reported failure and fired a
**second** `:rf.error/resource-route-blocking` trace, although the transition
never left `:error` — contradicting the function's own docstring guarantee of
one emit per transition *into* `:error`.

The fix is the guard, not the pick. `db'` still carries the previous transition
at that point, so `(not= :error (get-in db' (conj slice-path :transition)))` is a
pure edge test — no latch, no remembered first failure, no new state. The slice
value keeps tracking the current first failure, which is what keeps a pinned
identity that later refetches successfully from reporting a stale error.

### 2. A resolver could publish a false `:contributor`

`attributed` treated any pre-existing `:contributor` in caught ex-data as
authoritative and returned the exception unchanged. But `:when` / `:params` /
`:scope` resolvers are arbitrary programmer code that may throw any `ex-info`,
so an ancestor resolver carrying its own unnamespaced `:contributor` published a
**fabricated** attribution on both the plan-error slice and the
`:rf.error/resource-route-plan` trace — precisely what Spec 016 §Effective
parent-chain resource plans rule 3 exists to prevent.

The planner knows the actual contributor at that point, so it always wins. The
idempotence guard protected nothing real: the two call sites are structurally
disjoint, because the `order-by-after` attribution happens in the inner reduce's
*collection expression* and therefore runs before the per-entry catch can see
anything. No exception is ever attributed twice. The caller's own value stays
reachable on the cause via `(ex-data (ex-cause e))`; nothing new is carried into
`plan-error`, because no consumer wants it.

### 3-4. Two byte-equivalent liveness gates survived the consolidation

`work-ledger/live-work?` documents itself as *the* one definition of "is this
work genuinely live", and the R2 close record said three copies became one — but
`events/entry-revalidation-in-flight?` and `subs/fetching-next?*` both still
inlined the same non-terminal + not-`:abort-requested` pair. Both now ask the
shared predicate. Behaviour-preserving: both `entry-revalidation-in-flight?`
call sites (`events.cljc:1324` in `active-stale-scan`, `events.cljc:1465`)
consume it in boolean context, so the `nil` → `false` narrowing is invisible.

## Verified already satisfied — six clusters, re-fixed by nothing here

Each was re-derived against this branch rather than taken on trust:

1. **rf2-kqxe6.17 / #6895 finding 1 — settled-abort re-entry is blocking.**
   `requirement-ready?` (`route.cljc:263-276`) is the at-commit predicate and
   the plan seed at `route.cljc:1071-1074` is
   `(remove #(requirement-ready? (entry-of %)))`, so an `:inert` settled-abort
   identity the plan will `ensure` **is** recorded. Landed by #6902.
2. **rf2-kqxe6.17 / #6885 — the retired `:routing/route-blocking?` hook.**
   `git grep 'route-blocking?'` is empty repo-wide (tracked files, excluding the
   tracker export). Nothing left to reconcile.
3. **Hydration acceptance.** Reconciles through the one projector at
   `resources/ssr.cljc:1029`.
4. **Epoch-restore acceptance.** Reconciles at `resources/ssr.cljc:1606`, with
   `:emit-error?` correctly gated on `defer-traces?`.
5. **Adopt-owner acceptance.** `adopt-route-owner-handler` reconciles at
   `resources/events.cljc:1987` — no private has-data/error/else branch. The old
   `drain-blocking` is gone; only the unrelated SSR loop
   `drain-blocking-resources!` shares the name.
6. **rf2-kqxe6.6's `STATUS RECONCILIATION 2026-07-25` note — premise changed.**
   That note was written against a commit predating the #6902 merge. The planner
   no longer classifies on prior-plan membership alone: `route.cljc:1044-1046`
   is `(and (contains? prev-ids scoped-key) (adoptable? runtime-db (entry-of scoped-key)))`.
   The `events.cljc` adopt-owner nil branch survives only as a defensive no-op
   for a direct dispatch the planner can no longer reach.

## Two rejections

- **Do not latch the first failure.** The #6895 audit also asked
  `reconcile-readiness` to "preserve its recorded first failure" while the
  activation stays `:error`. Rejected: it needs a latch the projector does not
  have, and it is actively wrong — once the pinned identity refetches
  successfully the slice would keep reporting an error that is no longer true.
  Spec 012 §Route readiness defines `:error` as the deterministic first failure
  over the **current** outstanding set: a pure function of live facts, which is
  what the code already does. Only the double emit was a defect, and only the
  emit guard changed. The `once-per-edge` regression pins both halves — one
  trace, and a slice that still tracks the current failure.
- **Do not re-fix rf2-kqxe6.6's reconciliation-note finding.** Both defects that
  note names were fixed by #6902 (cluster 6 above). Re-fixing them would have
  reverted working code.

## Not taken: the Spec 012 prose divergence

`spec/012-Routing.md:897` says the deterministic first failure is picked "in
effective plan order", but the projector sorts by `state/key-id` (canonical
CEDN-1 bytes) because the blocking slot is a **set** and plan order is not
recoverable at reconcile time. The prose is the thing that is wrong, not the
code — persisting plan order would be machinery for nothing.

That file is hot-zone and fenced for this worker (an EP-0037 R4 worker holds the
Spec 012 / routing / SSR surface), so the fix is **not** in this PR. None of the
four code changes depend on it. It needs sequencing behind R4.

## Quality gates

All foreground, to completion, exit codes captured.

| Gate | Result | Exit |
|------|--------|------|
| `implementation/resources` JVM (`clojure -M:test`) | **704 tests / 6613 assertions, 0 failures, 0 errors** | 0 |
| `implementation/core` JVM (`clojure -M:test`) | **2104 tests / 10424 assertions, 0 failures, 0 errors** | 0 |
| `implementation/routing` JVM (`clojure -M:test`) | **467 tests / 2449 assertions, 0 failures, 0 errors** | 0 |
| `npm run test:cljs` (node-test, all artefacts) | **11160 tests / 56014 assertions, 0 failures, 0 errors** | 0 |
| `scripts/test-fast-pr.sh` (repo root) | **PASS fast PR spine** — all corpus/skill/lint/order guards, core JVM, node-test (11160 tests / 56014 assertions, 0 failures), per-ns isolation 17/17 | 0 |

Baseline on `origin/main` before any edit: `implementation/resources` =
**703 tests / 6603 assertions, 0 failures, exit 0** — matches the figure the
prep audit recorded, so the base is the one the obligations were derived
against. The suite gains 1 test and 10 assertions.

### Non-vacuity

The three new regressions were run against the pre-fix source (this branch's
tests with `route.cljc` reverted to `origin/main` — no stash) and all three
fail:

```
FAIL r2-ancestor-planning-failure-names-the-contributing-declaration
  the ACTUAL contributing declaration, not the resolver's claim
  expected: {:route-id :route/ancestor, :local-id :anc}
    actual: {:route-id :wrong, :local-id :wrong}

FAIL r2-ancestor-planning-failure-names-the-contributing-declaration
  the trace agrees with the slice — one source of truth
  expected: {:route-id :route/ancestor, :local-id :anc}
    actual: {:route-id :wrong, :local-id :wrong}

FAIL reconcile-readiness-emits-the-blocking-error-once-per-edge-into-error
  ONE trace per transition INTO :error, not one per settle
  expected: 1
    actual: 2

Ran 704 tests containing 6613 assertions.
3 failures, 0 errors.
```

A fourth new case — `reconcile-readiness` re-entering `:error` after the failed
identity recovers (`:error` → `:idle` → `:error`) — asserts **two** traces. It
passes both before and after by design: it is a fence proving the new edge gate
does not over-suppress a genuinely new transition, not a red witness.

Changes 3 and 4 are behaviour-preserving by construction (byte-equivalent
predicates), so no red witness is achievable for them and none was manufactured.
They are covered by the existing behavioural suites that already exercise both
paths — `poll-tick-coalesces-with-live-in-flight-work` (resources polling),
`fetching-next?-true-during-load-more` (infinite subs), and
`restore-fetching-next?-resolves-false-no-phantom-load-more` (infinite SSR
restore) — all green.
