### PR TITLE
fix(freehand): stop shipping the namespace docstring per declared view (rf2-9y9uv)

### DIFF
--- a/implementation/freehand/src/re_frame/freehand.cljc
+++ b/implementation/freehand/src/re_frame/freehand.cljc
@@ -205,7 +205,25 @@
      ([form-meta file ns-sym sym more]
       (expand-defview nil nil form-meta file ns-sym sym more))
      ([&form &env form-meta file ns-sym sym more]
-     (let [{:keys [docstring opts params body]} (or (parse-defview-args more)
+     (let [;; The declaration's `:source` QUOTES this symbol into emitted code,
+           ;; and a quoted symbol carries its METADATA into the bundle
+           ;; (`cljs.analyzer/analyze-wrap-meta` elides only reader/analyzer
+           ;; keys). shadow-cljs hangs the whole namespace DOCSTRING off the
+           ;; ns-name symbol (`shadow.build.ns-form/parse` merges `:doc` into
+           ;; it), so a namespace declaring N views shipped its docstring N
+           ;; times into `:advanced` — and this substrate's own door shipped
+           ;; ITS docstring into every consumer bundle. Measured on
+           ;; `:freehand-release` (rf2-9y9uv): 3 x 1,643 bytes for the release
+           ;; entry, 2 x 1,960 for `re-frame.freehand` itself, 9,136 bytes of
+           ;; 739,938 once Closure's `with-meta` scaffolding went with them.
+           ;; `re-frame.core-reg-macros` states the same caller contract for
+           ;; every `reg-*` macro (rf2-xnym): pass the METADATA-FREE ns symbol.
+           ;; Normalised HERE rather than at the `defview` macro so every
+           ;; expansion path — the macro, and the programmatic arity a wrapper
+           ;; macro reaches for — honours it. Pinned by
+           ;; `re-frame.freehand.ns-docstring-absence-jvm-test`.
+           ns-sym    (symbol (str ns-sym))
+           {:keys [docstring opts params body]} (or (parse-defview-args more)
                                                     (error/throw-error!
                                                       :rf.error/defview-bad-args
                                                       'v/defview

--- a/implementation/freehand/src/re_frame/freehand/compiler.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler.cljc
@@ -575,7 +575,13 @@
   anchored with the declaration form's source coordinates (S1e)."
   [form menv tag opts]
   (let [coords (source-coords form (some? (:ns menv)))
-        ns-sym (if (:ns menv) (-> menv :ns :name) (ns-name *ns*))]
+        ;; METADATA-FREE, for the reason `re-frame.freehand/expand-defview`
+        ;; spells out (rf2-9y9uv, rf2-xnym): [[custom-element**]] QUOTES this
+        ;; symbol into the emitted `register-custom-element!` call, and
+        ;; shadow-cljs hangs the declaring namespace's whole DOCSTRING off its
+        ;; ns-name symbol — which a quoted symbol then carries into the
+        ;; `:advanced` bundle.
+        ns-sym (symbol (str (if (:ns menv) (-> menv :ns :name) (ns-name *ns*))))]
     (anchored coords
               #(custom-element** coords ns-sym tag opts))))
 

--- a/implementation/freehand/test/re_frame/freehand/control_boundary_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/control_boundary_jvm_test.clj
@@ -1,0 +1,154 @@
+(ns re-frame.freehand.control-boundary-jvm-test
+  "`re-frame.freehand` IS THE SOLE REQUIRER OF `re-frame.freehand.control`
+  (rf2-qimh0).
+
+  ## What this law is holding up
+
+  The B5 reachability gate (`npm run test:freehand-reachability`, the
+  required `cljs-freehand-reachability` job) proves an UNUSED RUNTIME
+  MODULE is absent from the production bundle: it builds
+  `:freehand-release` and its strict-superset twin
+  `:freehand-release-reachability-control` — same `:advanced`, same
+  `goog.DEBUG false`, the control's entry additionally calling
+  `v/controller-key` — and greps for the controller's refusal doors,
+  ABSENT in production and PRESENT in the control.
+
+  Two `:advanced` builds is real PR time, so the gate is armed on a NARROW
+  set of producer surfaces rather than on `implementation/freehand/**`:
+  `control.cljc`, the facade, the two build entries, the checker and the
+  build-config trio. That narrowness is honest only while a FOURTH
+  producer cannot appear silently. A new `:require` of `control` from
+  anywhere else in `freehand/src` — a paved path that starts resolving a
+  controller record — would root the module in production, falsify the
+  reachability claim, and arm none of those surfaces. The nightly would
+  catch it, red on main, after the fact.
+
+  So the requirer set is pinned HERE, in the always-armed jvm-freehand
+  lane, where a would-be second requirer meets it on its own PR. The
+  sibling claim — `cell` is the sole namespace mentioning the evidence
+  schema — does the same job for the sibling gate in
+  `re-frame.freehand.evidence-boundary-jvm-test`, and
+  `implementation/scripts/_changed-surfaces.test.cjs` pins both premises
+  against the routing, so relaxing either law reds the classifier tests
+  and forces the arm to widen.
+
+  ## Why the walk is here rather than shared with the sibling
+
+  Deliberate. The two laws guard different gates and must be able to fail
+  independently; a shared walk would let a change made for one silently
+  re-scope the other. This is thirty lines of `ns`-form reading, not a
+  dependency framework, and the cost of keeping it separate is lower than
+  the cost of coupling two required lanes together.
+
+  ## What it is NOT
+
+  A require-graph assertion, not a bundle proof. It answers \"can
+  production code reach the controller\" and never \"did the controller
+  survive `:advanced`\" — that is the control-build probe's job, and a
+  source walk cannot see what dead-code elimination removed.
+
+  JVM-only because the claim is about the whole source tree, and the JVM
+  is where a test can read it."
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            ;; The public door, required for its LOADING — and because it is
+            ;; the subject: the law below says this namespace, and only this
+            ;; namespace, reaches the controller.
+            [re-frame.freehand]))
+
+(def ^:private controller
+  're-frame.freehand.control)
+
+(def ^:private sole-requirer
+  're-frame.freehand)
+
+(defn- source-root
+  "The `src` directory this artefact's namespaces are compiled from,
+  located through the classpath rather than through a relative path, so
+  the suite does not depend on the directory it was started in."
+  []
+  (-> (io/resource "re_frame/freehand.cljc") .toURI io/file .getParentFile .getParentFile))
+
+(defn- source-files
+  []
+  (->> (file-seq (source-root))
+       (filter #(.isFile ^java.io.File %))
+       (filter #(re-find #"\.clj[cs]?$" (.getName ^java.io.File %)))))
+
+(defn- symbols-in
+  "Every symbol in `form`, descending through reader conditionals so a
+  require that exists only on one host is still seen."
+  [form]
+  (cond
+    (symbol? form)                                  [form]
+    (instance? clojure.lang.ReaderConditional form) (symbols-in (.form ^clojure.lang.ReaderConditional form))
+    (coll? form)                                    (mapcat symbols-in form)
+    :else                                           []))
+
+(defn- ns-form
+  [^java.io.File f]
+  (with-open [r (java.io.PushbackReader. (io/reader f))]
+    (read {:read-cond :preserve :eof nil} r)))
+
+(defn- mention-graph
+  "Freehand namespace -> the Freehand namespaces its `ns` form mentions.
+
+  Deliberately over-approximate: every Freehand-shaped symbol anywhere in
+  the `ns` form is an edge, whether it sits in a `:require`, an `:import`
+  or a docstring's code sample. Over-approximating can only make a
+  requirer set LARGER, so a set this graph reports as a singleton really
+  is one."
+  []
+  (into {}
+        (keep (fn [f]
+                (let [form (ns-form f)]
+                  (when (and (seq? form) (= 'ns (first form)) (symbol? (second form)))
+                    (let [self (second form)]
+                      [self (into #{}
+                                  (comp (filter #(str/starts-with? (str %) "re-frame.freehand"))
+                                        (remove #(= self %)))
+                                  (symbols-in (drop 2 form)))])))))
+        (source-files)))
+
+(defn- namespaces-mentioning
+  [graph target]
+  (into #{} (keep (fn [[self edges]] (when (contains? edges target) self))) graph))
+
+(deftest re-frame-freehand-is-the-sole-requirer-of-the-controller
+  (let [graph (mention-graph)]
+    (testing "the walk is real — the positive control. Everything below is a
+              claim about a SET being small, and a broken walk answers every
+              such claim with the empty set."
+      (is (< 20 (count graph))
+          "every Freehand source file contributed a node")
+      (is (contains? graph controller)
+          (str controller " has a source file of its own — if it were renamed or "
+               "removed, this whole test is asserting nothing and should go with it"))
+      (is (contains? (get graph sole-requirer) controller)
+          (str sole-requirer " must still mention " controller " — it owns the single "
+               "production call edge (`controller-key` is `def`'d to `control/record-key`), "
+               "and a law that held because NOBODY reached the controller would be "
+               "guarding an empty claim")))
+    (testing "and the controller is reached from exactly one namespace"
+      (let [requirers (namespaces-mentioning graph controller)]
+        (is (= '#{re-frame.freehand} requirers)
+            (str "the controller must be reached from the public door alone. A second "
+                 "Freehand namespace requiring it roots the module in production and "
+                 "FALSIFIES the B5 reachability claim — and the `freehand_reachability` "
+                 "classifier arm does not watch the rest of the tree, so the required PR "
+                 "gate would not even run. If the new edge is intended, widen the arm in "
+                 "implementation/scripts/_changed-surfaces.cjs to the real requirer set "
+                 "and update this law to match — do not relax it. Found: "
+                 (pr-str requirers)))))
+    (testing "`re-frame.freehand.controlled` is a DIFFERENT namespace, and the
+              walk must not confuse the two. Its name extends the controller's
+              character for character, so a substring or prefix test would
+              report half the tree as requirers and the law would read as
+              already-broken — or, matched the other way, would let a real
+              `control` require hide behind a `controlled` one."
+      (is (contains? graph 're-frame.freehand.controlled)
+          "the near-miss namespace exists — this guard is not hypothetical")
+      (is (< 1 (count (namespaces-mentioning graph 're-frame.freehand.controlled)))
+          (str "and it is required broadly, unlike the controller — so the singleton "
+               "above is a real discrimination and not an artefact of exact matching")))))

--- a/implementation/freehand/test/re_frame/freehand/ns_docstring_absence_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/ns_docstring_absence_jvm_test.clj
@@ -1,0 +1,163 @@
+(ns re-frame.freehand.ns-docstring-absence-jvm-test
+  "A DECLARATION DOES NOT CARRY ITS NAMESPACE'S DOCSTRING INTO EMITTED CODE
+  (rf2-9y9uv).
+
+  ## The defect this pins shut
+
+  `v/defview` stamps every declaration with a `:source` map, and that map's
+  `:ns` is a QUOTED SYMBOL. A quoted symbol is a compiled constant that
+  carries its own METADATA: `cljs.analyzer/analyze-wrap-meta` elides only
+  reader and analyzer keys, so anything else on a quoted symbol is emitted
+  beside it as a real `cljs.core/with-meta` call over a real map.
+
+  shadow-cljs hangs the whole namespace DOCSTRING off the ns-name symbol —
+  `shadow.build.ns-form/parse` merges `{:doc <docstring>}` into it and that
+  symbol becomes `cljs.analyzer/*cljs-ns*`, which macroexpansion binds
+  `*ns*` to. So `(ns-name *ns*)` inside a macro answers a symbol dragging
+  the consuming namespace's entire prose behind it, and a namespace
+  declaring N views shipped its docstring N TIMES into `:advanced`.
+
+  It was measured, not suspected: the B5 release entry (three declared
+  views) shipped its 1,643-byte namespace docstring three times, and
+  `re-frame.freehand`'s own 1,960-byte docstring twice, for 9,136 bytes of
+  a 739,938-byte production bundle. Per-VIEW docstrings never shipped —
+  they live in var metadata, which ClojureScript drops — so the cost fell
+  entirely on the one docstring an author is most likely to write well.
+
+  `re-frame.core-reg-macros` states the same caller contract for every
+  `reg-*` macro (rf2-xnym); Freehand simply was not honouring it.
+
+  ## Why the test builds its namespace the way it does
+
+  The subject is created with `(create-ns (with-meta 'fresh.ns {:doc …}))`
+  — which is exactly the shape shadow-cljs hands the macro, reproduced
+  without a ClojureScript build. A namespace symbol carrying no metadata
+  would make every assertion below pass for the wrong reason, so each
+  deftest first proves its own subject really is contaminated.
+
+  JVM-only because macroexpansion is a JVM act: this is the compiler's
+  OUTPUT under inspection, before any host runs it. The bytes half of the
+  claim — that the docstring is absent from a real `:advanced` artefact —
+  belongs to a build, not to a test, and is the measurement recorded above."
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.walk :as walk]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.compiler :as compiler]))
+
+(def ^:private sentinel
+  "Distinctive enough that finding it anywhere in an expansion is proof,
+  and long enough that shipping it would be a real cost."
+  (str "SENTINEL namespace prose that no declaration has any business "
+       "carrying into a production bundle."))
+
+(defn- contaminated-ns
+  "A namespace whose NAME SYMBOL carries a `:doc`, the way shadow-cljs
+  leaves it. `create-ns` keeps the symbol it was handed, so the name must
+  be one this JVM has not seen — an existing namespace would be returned
+  unchanged and the subject would be clean."
+  []
+  (create-ns (with-meta (gensym "re-frame.freehand.ns-docstring-probe-")
+               {:doc sentinel})))
+
+(defn- metadatas
+  "Every metadata map hanging off any node of `form`, the emitted form
+  included. `clojure.walk` visits the collections; symbols and keywords
+  are visited as themselves, which is where the contamination rides."
+  [form]
+  (let [found (atom [])]
+    (walk/postwalk (fn [x]
+                     (when-let [m (meta x)] (swap! found conj m))
+                     x)
+                   form)
+    @found))
+
+(defn- carries-sentinel?
+  [form]
+  (boolean (some #(some (fn [v] (and (string? v) (= sentinel v))) (vals %))
+                 (metadatas form))))
+
+;; ---------------------------------------------------------------------------
+;; The positive control: the finder can SEE the contamination
+;; ---------------------------------------------------------------------------
+
+(deftest the-contamination-finder-is-not-vacuous
+  (testing "Everything below asserts an ABSENCE, so the finder is proven to
+            report a PRESENCE first. Both halves matter: the namespace this
+            test builds really does carry the docstring on its name symbol
+            (which is the defect's whole mechanism), and a form quoting that
+            symbol really does test positive."
+    (let [ns-obj (contaminated-ns)
+          ns-sym (ns-name ns-obj)]
+      (is (= sentinel (:doc (meta ns-sym)))
+          "the subject namespace's NAME SYMBOL carries the docstring — this is
+           the shadow-cljs shape the defect rode in on, and without it every
+           assertion below would pass for the wrong reason")
+      (is (carries-sentinel? {:source {:ns (list 'quote ns-sym)}})
+          "and a form that quotes that symbol tests POSITIVE — the finder works")
+      (is (not (carries-sentinel? {:source {:ns (list 'quote (symbol (str ns-sym)))}}))
+          "while the metadata-free spelling tests negative — the finder is not
+           merely matching on the symbol's name"))))
+
+;; ---------------------------------------------------------------------------
+;; The law
+;; ---------------------------------------------------------------------------
+
+(deftest defview-emits-no-namespace-docstring
+  (testing "The declaration's `:source` map is where the ns symbol reaches
+            emitted code, and it must reach it BARE. This is asserted over
+            the whole expansion rather than over the `:source` entry alone:
+            the claim is that the declaration ships none of its namespace's
+            prose, not that one particular key was cleaned."
+    (let [ns-sym   (ns-name (contaminated-ns))
+          expanded (v/expand-defview {:line 42 :column 1}
+                                     "app/probe.cljs"
+                                     ns-sym
+                                     'probe
+                                     '("The view's OWN docstring, which never shipped."
+                                       [_]
+                                       [:div.probe "hello"]))]
+      (is (not (carries-sentinel? expanded))
+          (str "a v/defview expansion carries its namespace's docstring into "
+               "emitted code. A quoted symbol carries its metadata into the "
+               "bundle, so this is one ns docstring shipped PER DECLARED VIEW "
+               "(rf2-9y9uv). Pass the metadata-free ns symbol — "
+               "`(symbol (str ns-sym))` — as re-frame.core-reg-macros does "
+               "for every reg-* macro (rf2-xnym).")))))
+
+(deftest defview-still-emits-the-source-namespace
+  (testing "The removal is of the METADATA, never of the coordinate. A
+            declaration that stopped naming its namespace would satisfy the
+            law above by deleting the thing it exists to protect."
+    (let [ns-sym   (ns-name (contaminated-ns))
+          expanded (v/expand-defview {:line 42 :column 1}
+                                     "app/probe.cljs"
+                                     ns-sym
+                                     'probe
+                                     '([_] [:div.probe]))
+          quoted   (->> (tree-seq coll? seq expanded)
+                        (filter #(and (seq? %) (= 'quote (first %))))
+                        (map second)
+                        (filter symbol?)
+                        set)]
+      (is (contains? quoted (symbol (str ns-sym)))
+          "the `:source` map still names the declaring namespace")
+      (is (every? #(nil? (meta %)) quoted)
+          "and every symbol the expansion quotes is metadata-free"))))
+
+(deftest custom-element-emits-no-namespace-docstring
+  (testing "`v/custom-element` quotes the declaring namespace into its
+            emitted `register-custom-element!` call for hot-reload eviction,
+            which is the same emission shape and therefore the same defect.
+            One declaration form fixed and its sibling left open would be a
+            fix that only held while nobody used the other one."
+    (let [ns-obj   (contaminated-ns)
+          expanded (binding [*ns* ns-obj]
+                     (compiler/custom-element* nil nil
+                                               (keyword (str (gensym "probe-el-")))
+                                               {:properties #{:help-text}}))]
+      (is (not (carries-sentinel? expanded))
+          (str "a v/custom-element expansion carries its namespace's docstring "
+               "into emitted code — see the defview law above (rf2-9y9uv)."))
+      (is (some #(and (symbol? %) (= (str (ns-name ns-obj)) (str %)))
+                (tree-seq coll? seq expanded))
+          "and it still names the declaring namespace — the eviction key"))))

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -2717,6 +2717,31 @@ test('the reachability CONTROL build is a controlled comparison (rf2-zl8ao)', ()
   );
 });
 
+test('the SOLE-requirer law that keeps the reachability arm honest still exists (rf2-qimh0)', () => {
+  // The classifier arms the controller, the facade, the two build entries, the
+  // checker and the build-config trio — not the Freehand tree. That is only
+  // safe while a NEW production requirer of `re-frame.freehand.control` cannot
+  // appear silently, and what forbids one is
+  // `re-frame-freehand-is-the-sole-requirer-of-the-controller` in the
+  // always-armed jvm-freehand lane. Pin the premise with the routing: if that
+  // law is ever relaxed, this reds and the classifier arm must widen. Exactly
+  // the shape of the sibling pin one gate up (rf2-xwa4n).
+  const law = fs.readFileSync(
+    path.join(
+      REPO_ROOT,
+      'implementation/freehand/test/re_frame/freehand/control_boundary_jvm_test.clj',
+    ),
+    'utf8',
+  );
+  assert.match(
+    law,
+    /'#\{re-frame\.freehand\}\s+requirers/,
+    'the boundary test must still pin re-frame.freehand as the SOLE requirer of the controller — '
+      + 'without it, a new production requirer could root the module in the release bundle and '
+      + 'dodge the narrowly-armed reachability gate',
+  );
+});
+
 test('cljs-freehand-reachability is gated on its output and runs the probe (rf2-zl8ao)', () => {
   const workflow = fs.readFileSync(WORKFLOW, 'utf8');
   const block = jobBlock(workflow, 'cljs-freehand-reachability');


### PR DESCRIPTION
Two beads on the Freehand source lane, one PR because the lane is serial.

## rf2-9y9uv — stop shipping the namespace docstring per declared view

A `v/defview` declaration stamps a `:source` map whose `:ns` is a **quoted symbol**, and a quoted symbol is a compiled constant that carries its own metadata into the bundle: `cljs.analyzer/analyze-wrap-meta` elides only reader and analyzer keys and emits everything else beside the symbol as a real `cljs.core/with-meta` call over a real map.

shadow-cljs hangs the whole namespace **docstring** off the ns-name symbol — `shadow.build.ns-form/parse` does `:name (vary-meta name merge meta)` with `{:doc <docstring>}` in `meta` — and that symbol becomes `cljs.analyzer/*cljs-ns*`, which macroexpansion binds `*ns*` to. So `(ns-name *ns*)` inside `defview` answered a symbol dragging the consuming namespace's entire prose behind it, once per declared view.

`re-frame.core-reg-macros` already states this caller contract for every `reg-*` macro (rf2-xnym: "pass the metadata-free ns symbol"). Freehand simply was not honouring it. The fix is that one-token removal, applied inside `expand-defview` (so every expansion path honours it, not just the macro) and at `custom-element*`, which quotes the declaring namespace into its emitted `register-custom-element!` call for hot-reload eviction — same emission shape, same defect.

**No stripping pass, no elision framework, no change to the authoring surface.** Per-VIEW docstrings are untouched: they live in var metadata, which ClojureScript drops, and never shipped (verified 0 occurrences before and after). The `:source` map still names its declaring namespace — the removal is of the accidental metadata, never of the coordinate.

### The measurement

`npm run build:freehand-release` — `:freehand-release`, `:optimizations :advanced`, `:closure-defines {goog.DEBUG false}`, `out/freehand-release/main.js`. Same worktree, same commit base, fix the only variable.

| | bytes | release-app ns docstring (1,643 B) | `re-frame.freehand` ns docstring (1,960 B) |
|---|---:|---:|---:|
| before | 739,938 | 3 occurrences | 2 occurrences |
| after | **730,802** | **0** | **0** |
| delta | **−9,136 (−1.23%)** | | |

3 × 1,643 + 2 × 1,960 = 8,849 bytes of docstring; the remaining 287 is Closure's `with-meta` scaffolding going with them. The substrate's **own door** was shipping its docstring into every consumer bundle, so this was a cost every consumer app paid — and it penalised exactly the authoring behaviour the project wants to encourage. It also inflated B5's own headline shipped-cost figure until rf2-x4jda R1 removed docstrings from the matched-pair fixture, so the defect was masking itself.

### The law

`re-frame.freehand.ns-docstring-absence-jvm-test` builds a namespace the way shadow-cljs leaves one — `(create-ns (with-meta 'fresh.ns {:doc sentinel}))` — expands both declaration forms against it, and asserts the prose reaches no emitted node. It proves its own subject contaminated first (the finder tests positive on a contaminated form and negative on a clean one), so the absence claims cannot pass vacuously.

Red-proof: with the fix reverted, all three laws fail and the positive control stays green.

```
FAIL defview-emits-no-namespace-docstring        expected: (not (carries-sentinel? expanded))
FAIL defview-still-emits-the-source-namespace    #{re-frame.freehand.ns-docstring-probe-10540} carries meta
FAIL custom-element-emits-no-namespace-docstring expected: (not (carries-sentinel? expanded))
Ran 4 tests containing 8 assertions. 3 failures, 0 errors.
```

The test is necessary but is not the proof — the proof is the bytes above.

## rf2-qimh0 — pin `re-frame.freehand` as the sole requirer of `freehand.control`

The B5 reachability gate is armed on a narrow set of producer surfaces (`control.cljc`, the facade, the two build entries, the checker, the build-config trio) because two `:advanced` builds per PR is real time. That narrowness is honest only while a **fourth** production requirer of `re-frame.freehand.control` cannot appear silently: a new `:require` from elsewhere in `freehand/src` would root the module in the release bundle, falsify the reachability claim, and arm none of those surfaces — the nightly would catch it, red on main, after the fact.

The sibling gate has exactly such a law (`cell` is the sole namespace mentioning the evidence schema, pinned from the routing by rf2-xwa4n). The controller had no counterpart. This adds the one that was missing, in the same shape — one law, one pin, no new framework, no widening of the gate's arm:

- `re-frame-freehand-is-the-sole-requirer-of-the-controller` in the always-armed jvm-freehand lane, over the same source tree and with the same over-approximate `ns`-form walk (every Freehand-shaped symbol anywhere in an `ns` form counts as an edge, so a set this reports as a singleton really is one);
- the routing pin in `_changed-surfaces.test.cjs`, mirroring the sibling's, so relaxing the law reds the classifier tests and forces the arm to widen.

The premise holds today: `re-frame.freehand` is the only Freehand namespace whose `ns` form mentions `re-frame.freehand.control`, so no arm-widening was needed.

The walk is deliberately **not** shared with the sibling test — the two laws guard different gates and must be able to fail independently.

### Red-proof (both directions)

Adding a second `:require` of `control` to `re-frame.freehand.tool` reds the law:

```
FAIL in (re-frame-freehand-is-the-sole-requirer-of-the-controller)
  expected: (= '#{re-frame.freehand} requirers)
    actual: (not (= #{re-frame.freehand} #{re-frame.freehand re-frame.freehand.tool}))
```

Relaxing the law's assertion to `(is (seq requirers) …)` reds the routing pin:

```
FAIL the SOLE-requirer law that keeps the reachability arm honest still exists (rf2-qimh0)
changed-surfaces tests: 1 failed.
```

Both probes reverted; neither is in the diff.

Non-vacuity is also built into the law itself: it proves its graph is populated, proves the facade really does reach the controller (a law that held because nobody reached it would guard nothing), and guards the `re-frame.freehand.controlled` near-miss explicitly — that name extends the controller's character for character, so exact matching is load-bearing.

## Quality gates

All foreground, all to completion, exit codes captured.

| gate | result | exit |
|---|---|---:|
| `implementation/freehand $ clojure -M:test` | 948 tests, 6,819 assertions, 0 failures, 0 errors | 0 |
| `npm run test:freehand` | 1,017 tests, 5,862 assertions, 0 failures, 0 errors | 0 |
| `npm run test:cljs` | 11,172 tests, 56,169 assertions, 0 failures, 0 errors | 0 |
| `npm run test:browser` | 762 tests, 4,771 assertions, 0 failures, 0 errors | 0 |
| `npm run test:freehand-reachability` | PASS — control 2/2 doors present (734,369 chars); production 2/2 doors absent (730,435 chars); survivor present in both | 0 |
| `npm run test:freehand-evidence-elision` | PASS — release 2/2 doors absent (730,435 chars); control 2/2 doors present (781,737 chars); survivor present in both | 0 |
| `node scripts/_changed-surfaces.test.cjs` | 227 passed | 0 |
| `npm run build:freehand-release` (the measurement) | 739,938 → 730,802 bytes | 0 |
| `scripts/test-fast-pr.sh` | `PASS fast PR spine` — 296 checks, per-ns isolation 17/17 standalone, 0 failures | 0 |

The browser lane needed no local timeout raise.

Beads: rf2-9y9uv, rf2-qimh0.
