### PR TITLE
docs: alpha truthing — CHANGELOG roster, deploy-ui drift, release-body link (rf2-vxgfnd.99.4)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,6 @@
 #                                         ├── deploy-reagent
 #                                         ├── deploy-reagent-slim
 #                                         ├── deploy-uix
-#                                         ├── deploy-ui
 #                                         ├── deploy-machines
 #                                         ├── deploy-routing
 #                                         ├── deploy-flows
@@ -587,12 +586,18 @@ jobs:
         # Mirrors re-frame v1's release-notes pattern — minimal body
         # with a link back to the CHANGELOG. Mike updates CHANGELOG.md
         # in the same release commit before tagging.
+        #
+        # The CHANGELOG link is pinned to the TAG ref, not `main`. A
+        # Maven version is immutable once Clojars has it, so the release
+        # body must keep pointing at the CHANGELOG as it stood when that
+        # version shipped; a `blob/main` link lets any later edit on main
+        # silently rewrite the historical account of a shipped release.
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
         with:
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}
           body: |
-            See [CHANGELOG.md](https://github.com/day8/re-frame2/blob/main/CHANGELOG.md) for release notes.
+            See [CHANGELOG.md](https://github.com/day8/re-frame2/blob/${{ github.ref_name }}/CHANGELOG.md) for release notes.
 
             Artefacts published to Clojars:
             - `day8/re-frame2` ${{ needs.deploy-core.outputs.version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,26 +2,37 @@
 
 All notable changes to re-frame2 are recorded in this file.
 
-The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the project uses pre-release suffixes (`.beta`, `.alpha`, `.rc`) on its way to a stable v1.0.0 line. Once stable, releases follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Pre-1.0 releases carry a pre-release suffix (`.alpha`, `.beta`, `.rc`) on the way to a stable v1.0.0 line; from 1.0.0 on, releases follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-Artefacts published per release (in lock-step — all 10 artefacts ship together at the same VERSION per [rf2-w05l](#) and [docs/release-process.md §Policy](docs/release-process.md#policy)):
+## What a release publishes
 
-| Artefact | Tier | Role |
+re-frame2 is not one jar. A `v*` tag publishes **thirteen** Maven coordinates to Clojars, and every one of them ships at the same version: the repo-root [`VERSION`](VERSION) file is the single source, and the release workflow refuses to deploy anything at all if an artefact has drifted off it. Pin them as a set.
+
+| Coordinate | Tier | What it gives you |
 |---|---|---|
-| `day8/re-frame2` | core | Registry, drain, fx, dispatch, subscribe, frame-provider, trace, the substrate-adapter contract, the headless plain-atom adapter |
-| `day8/re-frame2-schemas` | per-feature | Spec 010 — Malli-backed schema-attachment surface |
-| `day8/re-frame2-machines` | per-feature | Spec 005 — state machines |
-| `day8/re-frame2-routing` | per-feature | Spec 012 — routing |
-| `day8/re-frame2-flows` | per-feature | Spec 013 — flows |
-| `day8/re-frame2-http` | per-feature | Spec 014 — managed HTTP |
-| `day8/re-frame2-ssr` | per-feature | Spec 011 — SSR & hydration |
-| `day8/re-frame2-epoch` | per-feature | Tool-Pair §Time-travel — epoch / time-travel |
-| `day8/re-frame2-reagent` | per-substrate | Spec 006 — Reagent adapter (browser default) |
-| `day8/re-frame2-uix` | per-substrate | Spec 006 — UIx adapter ([rf2-3yij](#)) |
+| `day8/re-frame2` | core | The framework itself — registry, event drain, effects, `dispatch`, `subscribe`, frames, the trace surface, and the substrate-adapter contract. Everything below depends on this, and on nothing else in the set. |
+| `day8/re-frame2-reagent` | adapter | The Reagent adapter; the default browser substrate (Spec 006). |
+| `day8/reagent-slim` | adapter | Reagent re-implemented slim for React 19. It replaces stock Reagent rather than depending on it (Spec 006). |
+| `day8/re-frame2-uix` | adapter | The UIx adapter — hooks-shaped views over the same frames (Spec 006). |
+| `day8/re-frame2-schemas` | feature | Malli-backed schema attachment for app-db, events and subscriptions (Spec 010). |
+| `day8/re-frame2-machines` | feature | State machines (Spec 005). |
+| `day8/re-frame2-routing` | feature | Routes, navigation effects and the routing framework subs (Spec 012). |
+| `day8/re-frame2-flows` | feature | Flows — declarative derived state with a topology engine (Spec 013). |
+| `day8/re-frame2-http` | feature | The `:rf.http/managed` effect family, with retry, decode and abort semantics (Spec 014). |
+| `day8/re-frame2-ssr` | feature | Server-side rendering and hydration (Spec 011). |
+| `day8/re-frame2-ssr-ring` | feature | The Ring host adapter for SSR — a server frame per request, torn down every time. The one artefact that depends on a second framework artefact (`day8/re-frame2-ssr`) as well as core (Spec 011). |
+| `day8/re-frame2-resources` | feature | Declarative server state: the resource lifecycle, the work ledger, invalidation and GC (Spec 016). |
+| `day8/re-frame2-epoch` | feature | Epoch history and time-travel — the substrate the pair tools read (Tool-Pair §Time-travel). |
 
-A future Helix adapter (`day8/re-frame2-helix`, [rf2-2qit](#)) slots in alongside the existing per-substrate leaves when it ships.
+Everything past core is optional, and that is the point of the split: core reaches each feature through late-bound hooks, so an app that never registers a route carries none of the routing machinery on its classpath.
 
-Spec changes are tracked separately under `spec/` and referenced from each entry.
+Two things about that table are worth saying out loud.
+
+**`day8/reagent-slim` deliberately breaks the `re-frame2-*` naming pattern**, because it is a replacement for `reagent/reagent` rather than a re-frame2 feature. There is a second wrinkle behind it: in the monorepo its adapter namespace is `re-frame.adapter.reagent-slim`, so that both adapters can sit on one classpath, but the *published* jar renames it to the canonical `re-frame.adapter.reagent`. A consumer's `(:require [re-frame.adapter.reagent :as ra])` is therefore the same line whichever adapter they pinned.
+
+**The developer tools are not in the thirteen.** [`tools/`](tools/) — Xray, Story, the pair MCP servers, the app template — is versioned in lockstep with the framework and gated by the same script, but a `v*` tag does not publish it. `day8/re-frame2-xray` ships on an `xray-v*` tag and `day8/re-frame2-story` on a `story-v*` tag, each with its own release workflow.
+
+Spec changes are tracked under [`spec/`](spec/) and referenced from each entry below.
 
 ## [Unreleased]
 
@@ -35,35 +46,32 @@ Spec changes are tracked separately under `spec/` and referenced from each entry
 
 ### Spec
 
-## [0.0.1.alpha] — _unreleased_
+## [0.0.1.alpha] — unreleased
 
-First public pre-release. Mike fills in the release notes manually before tagging — this template lists the major themes that landed in the lead-up to the cut so the eventual notes have a starting point. None of these are commitments; the final list ships when the tag does.
+<!-- Maintainer note: the structural facts in this section — the artefact set, and
+     what is deliberately absent from it — are gated by CI and must stay true. The
+     narrative around them is written in the release commit, immediately before the
+     tag. Do not let this section outlive the machinery it describes. -->
 
-### Added
+The first public release, and an alpha in the honest sense: the shapes described in [`spec/`](spec/) are implemented and tested end-to-end, but the public API is not frozen. A later alpha may move it.
 
-- Reactive substrate machinery: `defn`-shape `reg-view`, frame-aware re-renders, and `frame-provider` for substrate-agnostic apps (Spec 006).
-- `:rf.http/managed` effect family with retry / decode / abort semantics (Spec 014).
-- Multi-instance frames and the `frame-provider` substrate boundary that lets adapters ship independently of the core (Spec 006 §Adapter shipping convention).
-- Production-elision contract (Spec 009): dev-only diagnostics drop out of advanced-compile bundles; CI gates on the elision probe (rf2-11hn).
-- Artefact split (rf2-0hxm + rf2-5vjj): `day8/re-frame2` ships substrate-agnostic; the seven per-feature artefacts (`-schemas`, `-machines`, `-routing`, `-flows`, `-http`, `-ssr`, `-epoch`) ship as separate Maven coordinates so a consumer who omits a feature does not pay for it on the classpath; the per-substrate artefacts (`-reagent`, `-uix`) keep substrate code out of any app that has chosen the other substrate. All 10 artefacts ship in lockstep at the same VERSION per [rf2-w05l](#).
-- `migration/from-re-frame-v1/README.md` for agent-driven migration of v1 codebases to v2.
+### What ships
 
-### Changed
+All thirteen coordinates in the table above, at `0.0.1.alpha`. Views are written against one of the three adapters — Reagent, reagent-slim, or UIx — and everything else is opt-in.
 
-- Public dependency coordinate moved from `re-frame/re-frame` to `day8/re-frame2`. The `re-frame.core` namespace and its public surface are unchanged for the migration core path; see `migration/from-re-frame-v1/README.md` for the full rule set.
-- Alpha-namespace dissolution: features that lived under `re-frame.alpha.*` in late v1 development are either promoted into the public surface, retired, or moved into a substrate-adapter ns. See the relevant spec sections for each feature.
+### Coming from re-frame v1
 
-### Removed
+The dependency coordinate is now `day8/re-frame2`, and v1 and v2 cannot share a classpath. There is no compatibility shim and there will not be one: the coordinate change makes the redesign visible to your dependency tooling instead of hiding it behind a name that no longer means what it did.
 
-- The `re-frame/re-frame` 1.x compatibility shim. v1 and v2 cannot coexist on a single classpath; the coordinate move makes the redesign visible to ops tooling. See `migration/from-re-frame-v1/README.md` §M-0.
+`re-frame.core` is still the entry namespace and much of the v1 surface survives unchanged — `reg-sub`, `reg-fx`, `reg-cofx`, `dispatch`, `subscribe`, `dispatch-sync` and their handler signatures. The breaks that do exist are real, though: the three event registrars collapse into one `reg-event`, coeffects are declared rather than injected, interceptors are registered by reference, and a frame is always explicit — the runtime never infers one from absence. The full rule set, written to be applied by an agent, is [`migration/from-re-frame-v1/README.md`](migration/from-re-frame-v1/README.md).
 
-### Spec
+### What this release does not promise
 
-- Spec 006 — Reactive Substrate (substrate-adapter contract, `frame-provider`, artefact-split shipping convention).
-- Spec 009 — Production builds and the elision contract.
-- Spec 014 — `:rf.http/managed` effect.
-- `spec/Conventions.md` — published Maven coordinates and the per-substrate dependency shape.
-- `migration/from-re-frame-v1/README.md` — v1 → v2 migration rules.
+**No compiled-view substrate, under any coordinate.** The compiled-view work is not published in this release. There is no `day8/re-frame2-ui` on Clojars and there never will be — it is donor code being absorbed into re-frame2's native view layer, **Freehand**, which arrives in a later release under its own name ([EP-0036](docs/EP/EP-0036-the-freehand-view-substrate-programme.md)). Views in this release go through an adapter.
+
+**No devtools panel on the UIx scaffold.** Xray mounts through the ratom-family substrates, so the Reagent scaffold wires it in and the UIx scaffold deliberately does not. An honest absence beats a panel that fails to mount.
+
+**No scaffold for `day8/reagent-slim`.** The app template's substrate menu is `:reagent` and `:uix`, so a slim consumer starts from the Reagent scaffold and swaps the adapter coordinate.
 
 [Unreleased]: https://github.com/day8/re-frame2/compare/v0.0.1.alpha...HEAD
 [0.0.1.alpha]: https://github.com/day8/re-frame2/releases/tag/v0.0.1.alpha

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -105,7 +105,7 @@ Before tagging:
 - [ ] All checks green on `main` (the `tests` workflow + any required reviews).
 - [ ] [`VERSION`](../VERSION) file updated to the target version. Single line, no trailing whitespace.
 - [ ] [`migration/from-re-frame-v1/README.md`](../migration/from-re-frame-v1/README.md) carries a fresh `M-NN` entry if the release contains a breaking change. (The migration corpus stays flat through 1.0; numbering is monotonic.)
-- [ ] [`CHANGELOG.md`](../CHANGELOG.md) updated for the release. The GitHub Release body links to it, so it is the canonical narrative.
+- [ ] [`CHANGELOG.md`](../CHANGELOG.md) updated for the release, **including its artefact roster**. The GitHub Release body links to it, so it is the canonical narrative — and that link is pinned to the tag, not to `main`, so the CHANGELOG has to be right at the moment of tagging. A later correction on `main` will not reach a release body that has already been cut.
 - [ ] The tag's commit is the same commit that updates VERSION + the migration corpus + CHANGELOG (one release commit).
 - [ ] Locally green: `./.github/scripts/verify-version-lockstep.sh` passes. (The CI gate runs the same script; running locally first surfaces drift in seconds.)
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -50,7 +50,6 @@ graph TD
   C --> R[deploy-reagent]
   C --> RS[deploy-reagent-slim]
   C --> U[deploy-uix]
-  C --> UI[deploy-ui]
   C --> M[deploy-machines]
   C --> RT[deploy-routing]
   C --> F[deploy-flows]
@@ -63,7 +62,6 @@ graph TD
   R --> GR
   RS --> GR
   U --> GR
-  UI --> GR
   M --> GR
   RT --> GR
   F --> GR
@@ -83,7 +81,6 @@ verify-version-lockstep ──► test ──► deploy-core
                                        ├── deploy-reagent
                                        ├── deploy-reagent-slim
                                        ├── deploy-uix
-                                       ├── deploy-ui
                                        ├── deploy-machines
                                        ├── deploy-routing
                                        ├── deploy-flows
@@ -97,9 +94,9 @@ verify-version-lockstep ──► test ──► deploy-core
                                         github-release
 ```
 
-**Why fan-out (not strict serial).** A strict topological linearization would suffice; the deps-graph data is wider — every leaf has core as its only re-frame2 dependency (the one exception is `ssr-ring`, which also depends on `ssr`; the release workflow rewrites both `:local/root` coordinates and resolves `ssr` from Clojars, so the leaves still fan out with no inter-leaf CI edge). The CI graph realises a valid topological sort that exploits the parallelism: leaves run concurrently after core, cutting wall-clock at the cost of a marginally wider failure surface (see Recovery below). The leaves group into per-feature artefacts (schemas, machines, routing, flows, http, ssr, ssr-ring, resources, epoch) and the view layer — the compiled-view substrate `ui` plus the adapter set (reagent default, reagent-slim, uix). The authoritative roster is always the `deploy-leaf` matrix in [`release.yml`](../.github/workflows/release.yml).
+**Why fan-out (not strict serial).** A strict topological linearization would suffice; the deps-graph data is wider — every leaf has core as its only re-frame2 dependency (the one exception is `ssr-ring`, which also depends on `ssr`; the release workflow rewrites both `:local/root` coordinates and resolves `ssr` from Clojars, so the leaves still fan out with no inter-leaf CI edge). The CI graph realises a valid topological sort that exploits the parallelism: leaves run concurrently after core, cutting wall-clock at the cost of a marginally wider failure surface (see Recovery below). The leaves group into per-feature artefacts (schemas, machines, routing, flows, http, ssr, ssr-ring, resources, epoch) and the view layer — the three substrate adapters (reagent, the default; reagent-slim; uix). The authoritative roster is always the `deploy-leaf` matrix in [`release.yml`](../.github/workflows/release.yml).
 
-**The view layer, as consumers meet it.** The app template (`tools/template/`, `day8/re-frame2-template`) scaffolds against this released view layer through its substrate menu: `:reagent` (the default), `:uix`, and the experimental `:ui` (re-frame.ui, offered alongside the adapters). The template menu and the view-layer rows of the `deploy-leaf` matrix move together.
+**The view layer, as consumers meet it.** The app template (`tools/template/`, `day8/re-frame2-template`) scaffolds against this released view layer through its substrate menu: `:reagent` (the default) and `:uix`. The menu is deliberately narrower than the adapter set — `day8/reagent-slim` is published but has no scaffold of its own, so a slim consumer starts from the Reagent variant and swaps the adapter coordinate. Adding a substrate to the `deploy-leaf` matrix does not automatically add a template variant; the two are decided separately.
 
 ## Pre-flight checklist
 

--- a/examples/ui/minimal-counter/README.md
+++ b/examples/ui/minimal-counter/README.md
@@ -49,13 +49,17 @@ npx shadow-cljs watch app    # dev loop + http://localhost:8280
 `npx` matters: shadow-cljs is a local devDependency, so a bare `shadow-cljs`
 is not on `PATH`.
 
-## Pre-publish coordinates
+## Why the coordinates are checkout-relative
 
-`day8/re-frame2` and `day8/re-frame2-ui` are not on Clojars yet, so
-`deps.edn` resolves them with `:local/root` relative to this checkout. Copying
-this directory *out* of the monorepo therefore requires repointing those two
-coords at your own checkout (or at published `:mvn/version` coords once they
-exist). Nothing else in the tree is checkout-relative.
+`deps.edn` resolves both framework artefacts with `:local/root` relative to
+this checkout, and that is permanent rather than a stopgap. `day8/re-frame2-ui`
+is donor-only: the release contract rules out a Clojars coordinate for it, now
+and for good, so a monorepo checkout is the only supported way to resolve it.
+`day8/re-frame2` does ship to Clojars with every release, but this scaffold
+takes it from the same checkout so that the two artefacts cannot drift apart.
+
+Copying this directory *out* of the monorepo therefore means repointing both
+coords at your own checkout. Nothing else in the tree is checkout-relative.
 
 ## What the CI gate proves
 

--- a/examples/ui/minimal-counter/deps.edn
+++ b/examples/ui/minimal-counter/deps.edn
@@ -1,10 +1,12 @@
 ;; minimal-counter — the smallest runnable re-frame.ui project.
 ;;
-;; PRE-PUBLISH COORDS. day8/re-frame2 and day8/re-frame2-ui are not on
-;; Clojars yet (repo-root README §Status), so this scaffold resolves them
-;; with :local/root against its enclosing monorepo checkout. That is the
-;; only route that works today. After publication these become
-;; :mvn/version coords and this file stops being checkout-relative.
+;; CHECKOUT-RELATIVE BY DESIGN, not pending a publish. day8/re-frame2-ui is
+;; donor-only: the release contract rules out a Clojars coordinate for it,
+;; now and permanently (see docs/release-process.md). Resolving it from an
+;; enclosing monorepo checkout is therefore the only supported shape, and it
+;; does not become an :mvn/version coord later. day8/re-frame2 does ship to
+;; Clojars with every release, but this scaffold resolves it from the same
+;; checkout so both artefacts come from one source and cannot drift apart.
 ;;
 ;; Both artefacts are named because the app :requires namespaces from
 ;; both -- re-frame.core and re-frame.ui -- and a direct :require deserves


### PR DESCRIPTION
Alpha truthing pass for `v0.0.1.alpha` (rf2-vxgfnd.99.4). Docs, comments and one workflow string — no runtime code, no deploy-matrix change, no tag.

`CHANGELOG.md` had not been touched since 2026-05-17 and is the document the GitHub Release body links to. Every claim below was re-derived from the tree rather than carried forward from the old prose.

## The roster

The CHANGELOG's artefact table is now exactly the thirteen coordinates a `v*` tag publishes.

```
$ node implementation/scripts/lib/publishable-runtimes.cjs "$PWD/implementation"
adapters/reagent
adapters/reagent-slim
adapters/uix
core
epoch
flows
http
machines
resources
routing
schemas
ssr
ssr-ring
```

Resolved through each `deps.edn`'s `:clein/build :lib`:

| Tier | Coordinates |
|---|---|
| core | `day8/re-frame2` |
| adapters | `day8/re-frame2-reagent`, `day8/reagent-slim`, `day8/re-frame2-uix` |
| features | `day8/re-frame2-schemas`, `-machines`, `-routing`, `-flows`, `-http`, `-ssr`, `-ssr-ring`, `-resources`, `-epoch` |

Three independent sources agree on that set, and the gates below assert it mechanically rather than by eye: the shipped publishable authority (13 subpaths), `release.yml`'s `deploy-core` plus its 12-value `deploy-leaf` matrix (13 coordinates), and the release body's own enumeration (13 rows). One gate asserts `sorted(CHANGELOG table) == sorted(authority)`, so a future artefact added without a CHANGELOG row fails here.

**13 vs 17 — the two numbers count different things.** `verify-version-lockstep.sh` reports `all 17 artefacts (13 implementation/ + 4 tools/) pinned to repo-root VERSION 0.0.1.alpha`. The extra four are the Clojars-publishable jars under `tools/` (xray, story, story-mcp, machines-viz). They share the repo-root `VERSION` and the same lockstep gate, but a `v*` tag does not publish them — `release-xray.yml` triggers on `xray-v*`, `release-story.yml` on `story-v*`. **The CHANGELOG roster is the 13**, because a CHANGELOG entry describes what a release published, and the release body it is linked from enumerates exactly those 13. The CHANGELOG says so explicitly so the next reader does not have to re-derive it.

## Every drift claim removed, and why it was false

| Claim | Where | Why it was false |
|---|---|---|
| "all 10 artefacts ship together" | `CHANGELOG.md:7` | The tag publishes 13. |
| "All 10 artefacts ship in lockstep" | `CHANGELOG.md:48` | Same count, restated. |
| Roster table omits `day8/reagent-slim`, `day8/re-frame2-resources`, `day8/re-frame2-ssr-ring` | `CHANGELOG.md:9-20` | All three carry a real `:clein/build`, sit in the `deploy-leaf` matrix, and appear in the release-body enumeration. A consumer reading the old table would not know two feature artefacts and an adapter existed. |
| "A future Helix adapter (`day8/re-frame2-helix`) slots in … when it ships" | `CHANGELOG.md:22` | Helix was deleted at S7/W13 (rf2-d6epb, PR #6674). It is not coming. |
| "Removed: the `re-frame/re-frame` 1.x compatibility shim" | `CHANGELOG.md:58` | Nothing was removed in this release — there has never been a shim in v2. The pre-alpha posture is "superseded, not propped up" (`migration/from-re-frame-v1/README.md`). Restated as a standing fact, not a change. |
| "`re-frame.core` … and its public surface are unchanged for the migration core path" | `CHANGELOG.md:53` | The migration corpus itself says the breaks are real: the three event registrars collapse into `reg-event` (EP-0018), `inject-cofx` is removed (EP-0017), interceptors are registered by reference (EP-0022), and a frame is always explicit (EP-0002). Rewritten to name the breaks and point at the corpus. |
| An "Added" list of internal machinery as first-release notes | `CHANGELOG.md:42-49` | A first release has no prior release to differ from, so the list read as internal refactor churn (artefact splits, elision gates, bead ids). Replaced by what a first-time reader actually needs: what ships, what a v1 migration meets, and what the release does not promise. |
| `├── deploy-ui` in the topological-DAG comment | `.github/workflows/release.yml:12` | There is no `deploy-ui` job. PR #6899 removed the leaf; the comment survived, thirty lines above the header that rules `ui` out. |
| `C --> UI[deploy-ui]` and the `UI --> GR` edge | `docs/release-process.md:53, :66` | The Mermaid DAG drew a job that does not exist, contradicting Policy 3 immediately above it. |
| `├── deploy-ui` in the ASCII fallback | `docs/release-process.md:86` | Same. |
| "the view layer — the compiled-view substrate `ui` plus the adapter set" | `docs/release-process.md:100` | `ui` is not in the deploy set and never will be. The view layer in the deploy set is the three adapters. |
| "substrate menu: `:reagent` (the default), `:uix`, and the experimental `:ui`" | `docs/release-process.md:102` | The `:ui` variant was retired (rf2-qmvep, PRs #6904/#6906). `tools/template/resources/day8/re_frame2_template/` carries `_reagent` and `_uix` only. |
| "The template menu and the view-layer rows of the `deploy-leaf` matrix move together" | `docs/release-process.md:102` | They demonstrably do not: `day8/reagent-slim` is a deploy-leaf row with no template variant. |
| "`day8/re-frame2` and `day8/re-frame2-ui` are not on Clojars **yet** … or at published `:mvn/version` coords once they exist" | `examples/ui/minimal-counter/README.md:52-57` | Directionally false for `ui` — there will never be a Clojars coordinate, so the `:local/root` shape is permanent rather than a stopgap. Rephrased to stay true after the tag ships `day8/re-frame2`. |
| "PRE-PUBLISH COORDS … After publication these become `:mvn/version` coords" | `examples/ui/minimal-counter/deps.edn:1-7` | The same claim in the header comment. |

## The release-body link

`.github/workflows/release.yml:595` pointed the GitHub Release body at `blob/main/CHANGELOG.md`. A Maven version is immutable once Clojars has it, so the body must keep pointing at the CHANGELOG as it stood when that version shipped; a `main` link lets any later edit silently rewrite the historical account of a shipped release. It is now `blob/${{ github.ref_name }}/CHANGELOG.md`, with the reasoning recorded in the step comment so it does not get "tidied" back. The 13-coordinate enumeration below it was already correct and is unchanged.

`docs/release-process.md`'s pre-flight checklist picks up the operational consequence: the CHANGELOG has to be right at the moment of tagging, because a later fix on `main` will not reach the release body.

## Quality gates

All run in the foreground to completion, logs captured worktree-locally, exit codes echoed.

| Gate | Result | Exit |
|---|---|---|
| `bash .github/scripts/verify-version-lockstep.sh` | PASS — `all 17 artefacts (13 implementation/ + 4 tools/) pinned to repo-root VERSION 0.0.1.alpha` | 0 |
| YAML parse of `release.yml` asserting on its object model | PASS — 5 jobs; trigger `v[0-9]+.[0-9]+.[0-9]+*` unchanged; `deploy-leaf` 12 leaves with no `ui`; body enumerates 13 coords; CHANGELOG link pinned to `${{ github.ref_name }}` with no `blob/main` survivor; body coords set-equal to `deploy-core` + matrix | 0 |
| CHANGELOG roster vs `publishable-runtimes.cjs` | PASS — 13 == 13, set-equal; no "all 10 artefacts", no Helix promise | 0 |
| `python -m mkdocs build --strict` | PASS — built in 23.9s. Run explicitly: `test-fast-pr.sh` soft-skips it when `mkdocs` is not on the bash PATH, which it is not here | 0 |
| `python scripts/check_doc_slugs.py --verbose` | PASS — 601 markdown files scanned, no broken links | 0 |
| `python scripts/check_readme_links.py` | PASS | 0 |
| `python scripts/check_readme_inventories.py` | PASS | 0 |
| `scripts/test-fast-pr.sh` | PASS — `PASS fast PR spine`; classified `docs=true jvm=false node=true`; CLJS node integration 11173 tests / 56181 assertions, 0 failures 0 errors; per-ns isolation all 17 namespaces pass standalone. Its own `mkdocs --strict` step soft-skipped (`mkdocs not on PATH`), which is why it was run separately above | 0 |
| word-boundary `git grep -nE "deploy-ui($\|[^x])"` over tracked files | zero hits (the three remaining matches are `deploy-uix`) | — |

## Out of scope, deliberately

`docs/core/how-to/install-re-frame-ui.md` is untouched — its deletion is owned by rf2-ote5u and its `rf2:shadow-ui-contract` / `rf2:shadow-ui-version` anchors are load-bearing for a JVM gate. No tag was created, pushed or prepared.

## One finding, filed rather than fixed

`tools/story-mcp` and `tools/machines-viz` each declare `:clein/build` (`day8/re-frame2-story-mcp`, `day8/re-frame2-machines-viz`) and are in the lockstep inventory's `TOOLS` list, but no workflow deploys them: `git grep -n "clein deploy" -- .github/` finds deploy steps only in `release.yml`, `release-xray.yml` and `release-story.yml`. Two publishable coordinates with no publish path. It is not a `v0.0.1.alpha` blocker — a `v*` tag does not touch `tools/` — so it is filed rather than fixed here, and the CHANGELOG's wording about the tools names only the two that genuinely have their own release tag.
