### PR TITLE
test(freehand): durable executable-sample harness for the guide (rf2-qwsmv)

### DIFF
--- a/docs/core/freehand/semantic-controllers.md
+++ b/docs/core/freehand/semantic-controllers.md
@@ -27,12 +27,18 @@ This is valid Freehand and does **not** use a semantic controller:
 [:input {:value   (v/sub [:lines/draft id])
          :on-input [:lines/draft-changed id ::v/value]
          :on-blur  [:lines/label-committed id]
-         :on-key-down {"Enter"  [:lines/label-committed id]
-                       "Escape" [:lines/draft-cancelled id]}}]
+         :on-key-down (v/event [e]
+                        (case (.-key e)
+                          "Enter"  [:lines/label-committed id]
+                          "Escape" [:lines/draft-cancelled id]
+                          nil))}]
 ```
 
 Use the same event on blur and Enter (commit). Use a **different** event on
-`on-input` (draft) — keystroke is draft; commit is accept.
+`on-input` (draft) — keystroke is draft; commit is accept. A handler slot holds
+**one** handler form, so the Enter/Escape branch is `v/event` at the site or
+`[:lines/draft-key id ::v/key]` into a handler that branches — see
+[Events](events-and-handlers.md#keyboard-branching).
 
 A semantic controller is only worth it when that protocol must be **correct and
 shared** across many call sites — for example stale blur after cancel, a required
@@ -443,8 +449,11 @@ substrate special form.
       :placeholder placeholder
       :on-input    [:fh.buffer/edited control reset-key ::v/value]
       :on-blur     [:fh.buffer/committed control reset-key on-commit]
-      :on-key-down {"Enter"  [:fh.buffer/committed control reset-key on-commit]
-                    "Escape" [:fh.buffer/cancelled control reset-key]}}]))
+      :on-key-down (v/event [e]
+                     (case (.-key e)
+                       "Enter"  [:fh.buffer/committed control reset-key on-commit]
+                       "Escape" [:fh.buffer/cancelled control reset-key]
+                       nil))}]))
 ```
 
 ### Behaviour timeline

--- a/implementation/freehand/test/re_frame/freehand/guide/compilation_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/guide/compilation_cljs_test.cljc
@@ -1,0 +1,241 @@
+(ns re-frame.freehand.guide.compilation-cljs-test
+  "Executable fixtures for `docs/core/freehand/compilation.md` and
+  `docs/core/freehand/debugging.md`.
+
+  Compilation is the chapter with the sharpest failure mode. `{:compiled
+  true}` submits a body to a closed grammar, so a sample that drifts out of
+  that grammar does not read wrong — it stops building, at the consumer's
+  site rather than ours. Transcribing each compiled declaration here means
+  the grammar's edge is proved against the page every run, in both
+  execution modes and on both hosts.
+
+  Two page-specific notes on transcription:
+
+  - **Elided bodies get a real one.** The guide writes `…` where the body is
+    beside the point (`(v/defview people-list {:compiled true} [props] …)`).
+    A fixture supplies the smallest body inside the grammar; what the block
+    is claiming is the DECLARATION shape, and that is what stays verbatim.
+  - **Anti-examples are not transcribed as code.** Two blocks open with a
+    commented-out illegal spelling and then show the recovery. Only the
+    recovery is code here; the illegal half is already owned, executably, by
+    `re-frame.freehand.analyze-reject-cljs-test`.
+
+  Filed under rf2-qwsmv."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.core :as rf]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.test :as t]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+;; ---------------------------------------------------------------------------
+;; compilation.md — the promotion ladder
+;; ---------------------------------------------------------------------------
+
+;; block 1 — the promotion recipe. The guide elides the body; the
+;; declaration shape is the claim.
+(v/defview people-list-promotion-recipe
+  {:compiled true}
+  [props]
+  [:ul [:li (:label props)]])
+
+;; block 2 — selecting compiled mode on an ordinary row. Call sites stay
+;; `[todo-row props]`, and the var still holds a descriptor.
+(v/defview todo-row-compiled
+  {:compiled true}
+  [{:keys [id]}]
+  (let [{:keys [title completed]} (v/sub [:todo/by-id id])]
+    [:li {:class {:completed completed}}
+     [:input {:type :checkbox
+              :checked completed
+              :on-change [:todo/toggle id]}]
+     title]))
+
+;; block 4 — the mini promotion transcript. The interpreted starting point,
+;; then the two declarations the build's recoveries produce.
+(defn person-row-markup [p] [:li (:name p)])
+
+;; 1) interpreted, fails check — opaque helper + map markup
+(v/defview people-list-interpreted [_]
+  [:ul (map (fn [p] (person-row-markup p)) (v/sub [:people]))])
+
+;; 2) after taking the build's named recoveries — keyed for + declared child
+(v/defview person-row-compiled
+  {:compiled true}
+  [{:keys [person]}]
+  [:li (:name person)])
+
+(v/defview people-list-compiled
+  {:compiled true}
+  [_]
+  [:ul
+   (for [p (v/sub [:people])]
+     [person-row-compiled {:key (:id p) :person p}])])
+
+;; block 5 — reactive sites must be finite: the recovery is a keyed child
+;; that subscribes for one row.
+(v/defview item-row
+  {:compiled true}
+  [{:keys [id]}]
+  [:li (:title (v/sub [:item id]))])
+
+(v/defview item-list
+  {:compiled true}
+  [_]
+  [:ul
+   (for [id (v/sub [:item-ids])]
+     [item-row {:key id :id id}])])
+
+;; block 6 — an opaque helper returning markup, which interpreted mode is
+;; perfectly happy with. The guide's own comment says so.
+(defn field-help [{:keys [error hint]}]
+  (if error [:p.error error] [:p.hint hint]))
+
+(v/defview editor [_]
+  [:section (field-help {:error (v/sub [:e]) :hint "…"})])  ; fine interpreted
+
+;; block 7 — the recovery when the markup is already in hand as a value:
+;; a visible interpreted child, counted in the manifest.
+(def some-hiccup-value [:em "late-transformed markup"])
+
+(def markup-child
+  [v/markup {:value some-hiccup-value}])
+
+(v/defview compiled-parent-with-markup-child
+  {:compiled true}
+  [_]
+  [:section
+   [v/markup {:value some-hiccup-value}]])
+
+;; block 8 — parameterized content in a compiled body: `v/slot` at the site,
+;; `v/render-fn` at the caller, both lexically visible.
+(v/defview data-table-compiled
+  {:compiled true}
+  [{:keys [rows row]}]
+  [:table
+   [:tbody
+    (for [item rows]
+      [:tr {:key (:id item)}
+       (v/slot row item)])]])
+
+;; The block prints the caller as a bare fragment under a compiled-mode
+;; heading, so it is hosted in a COMPILED declaration here — which is the
+;; faithful reading and the only one that renders. A `v/render-fn` authored
+;; in an INTERPRETED body answers with raw hiccup, and a compiled parent's
+;; child collector refuses it (`:rf.error/ui-tree-malformed`); authored in a
+;; compiled body it lowers to nodes and the slot fills.
+(v/defview data-table-compiled-call
+  {:compiled true}
+  [{:keys [people]}]
+  ;; caller — pure, visible body
+  [data-table-compiled
+   {:rows people
+    :row  (v/render-fn [person]
+            [:td (:name person)])}])
+
+;; block 9 — a props schema, which is optional in the grammar and mandatory
+;; by policy for a shipped library leaf. The guide elides the body.
+(v/defview todo-row-with-props-schema
+  {:compiled true
+   :props [:map [:id :int]]}   ; vector-form Malli; closed by default for maps
+  [{:keys [id]}]
+  [:li (str id)])
+
+;; ---------------------------------------------------------------------------
+;; debugging.md — the two inspection reads
+;; ---------------------------------------------------------------------------
+;;
+;; Blocks 3 and 4 (`v/active-connections` / `v/command-log`) are browser-only
+;; by the page's own statement — "absent on the JVM exactly like the mount
+;; verbs". They are covered from
+;; `re-frame.freehand.guide.host-cljs-test`, alongside `v/mount`, so the
+;; whole browser-only half of the door is proved present in one place.
+
+;; ---------------------------------------------------------------------------
+;; The samples, executed
+;; ---------------------------------------------------------------------------
+
+(defn- seed!
+  [db]
+  (rf/reg-sub :todo/by-id (fn [d [_ id]] (get-in d [:todos id])))
+  (rf/reg-sub :people (fn [d _] (:people d)))
+  (rf/reg-sub :item (fn [d [_ id]] (get-in d [:items id])))
+  (rf/reg-sub :item-ids (fn [d _] (:item-ids d)))
+  (rf/reg-sub :e (fn [d _] (:error d)))
+  (rf/dispatch-sync [:rf/set-db db]))
+
+(deftest promotion-is-a-declaration-edit-and-nothing-else
+  (testing "compilation.md's call-site-invariance law: the promoted row
+            renders the same tree the interpreted spelling would, and the
+            var still holds a descriptor rather than a function."
+    (seed! {:todos {1 {:title "Ship it" :completed true}}})
+    (is (v/view? todo-row-compiled) "the public var remains a descriptor")
+    (is (= :compiled (:lowering (v/describe todo-row-compiled))))
+    (let [tree  (t/with-render (t/render [todo-row-compiled {:id 1}]))
+          input (t/find tree #(= :input (:tag %)))]
+      (is (= "Ship it" (t/text (t/find tree #(= :li (:tag %))))))
+      (is (true? (:checked (t/attrs input))))
+      (is (= [:todo/toggle 1] (:on-change (t/attrs input)))
+          "event intent is the same data in either mode"))))
+
+(deftest the-transcript-recoveries-both-build-and-render
+  (testing "compilation.md's mini transcript — the recovered spelling is a
+            keyed `for` over a visible `sub` plus a declared child, and it
+            renders one child per person."
+    (seed! {:people [{:id 1 :name "Ada"} {:id 2 :name "Bob"}]})
+    (let [tree (t/with-render (t/render [people-list-compiled {}]))]
+      (is (= ["Ada" "Bob"] (mapv t/text (t/find-all tree #(= :li (:tag %))))))))
+  (testing "and the interpreted starting point still renders, because
+            interpreted mode runs full Clojure — the helper is only a
+            problem once the declaration claims the grammar."
+    (seed! {:people [{:id 1 :name "Ada"}]})
+    (is (= ["Ada"] (mapv t/text (t/find-all
+                                  (t/with-render (t/render [people-list-interpreted {}]))
+                                  #(= :li (:tag %))))))))
+
+(deftest a-finite-site-in-the-child-is-the-recovery-for-a-loop-read
+  (testing "compilation.md's finiteness rule — the parent reads the id set,
+            the child reads one row, and both are compiled."
+    (seed! {:item-ids [:a :b] :items {:a {:title "alpha"} :b {:title "beta"}}})
+    (is (= ["alpha" "beta"]
+           (mapv t/text (t/find-all (t/with-render (t/render [item-list {}]))
+                                    #(= :li (:tag %))))))))
+
+(deftest a-slot-in-a-compiled-body-renders-the-callers-visible-row
+  (testing "compilation.md's parameterized-content block — `v/render-fn` at
+            the caller, `v/slot` at the site, both inside the grammar."
+    (let [tree (t/render [data-table-compiled-call {:people [{:id 1 :name "Ada"}]}])]
+      (is (= ["Ada"] (mapv t/text (t/find-all tree #(= :td (:tag %)))))))))
+
+(deftest describe-projects-exactly-the-keys-the-page-prints
+  (testing "debugging.md block 1 — `v/describe` is a plain map, and
+            `:props-schema` is ABSENT rather than `:any` when none was
+            declared. Absence is the claim; a nil would blur two facts."
+    (let [d (v/describe todo-row-compiled)]
+      (is (true? (:re-frame.freehand/view d)))
+      (is (= ::todo-row-compiled (:view-id d)))
+      (is (= :compiled (:lowering d)))
+      (is (= :optional (:children-policy d)))
+      (is (map? (:source d)))
+      (is (not (contains? d :props-schema))
+          "no schema declared — the key is absent, not nil and not :any"))
+    (is (contains? (v/describe todo-row-with-props-schema) :props-schema)
+        "and present the moment one is declared")))
+
+(deftest manifest-is-nil-for-interpreted-and-names-its-crossings-when-compiled
+  (testing "debugging.md block 2 — `nil` is the honest answer for an
+            interpreted declaration, and a compiled one says where the
+            compiled tier STOPS."
+    (is (nil? (v/manifest editor))
+        "interpreted — nil, which is an answer rather than an omission")
+    (let [m (v/manifest compiled-parent-with-markup-child)]
+      (is (= :re-frame.freehand/v1 (:grammar m))
+          "the artifact-wide grammar version rides on the manifest")
+      (is (= ::compiled-parent-with-markup-child (:view-id m)))
+      (is (= [{:view-id :re-frame.freehand/markup :lowering :interpreted}]
+             (mapv #(select-keys % [:view-id :lowering]) (:crossings m)))
+          "one crossing, into the interpreted child the page names"))))

--- a/implementation/freehand/test/re_frame/freehand/guide/composition_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/guide/composition_cljs_test.cljc
@@ -1,0 +1,337 @@
+(ns re-frame.freehand.guide.composition-cljs-test
+  "Executable fixtures for the Freehand guide's COMPOSITION chapters —
+  `docs/core/freehand/composition.md`, `state.md` and
+  `reactivity-and-ownership.md`.
+
+  These pages carry the vocabulary a component library lives on: trailing
+  children and `:children-policy`, `v/slot` / `v/render-fn`, and the two
+  props-forwarding forms `v/spread-safe` and `v/spread` with their asymmetric
+  bargains. Those are exactly the verbs a refactor moves and prose cannot
+  notice — so each sample is transcribed here, where a move is a compile
+  failure.
+
+  The two transcription conventions are the ones stated in
+  `re-frame.freehand.guide.first-view-cljs-test`: a bare markup fragment is
+  hosted in a one-line `v/defview`, and a fragment's free names arrive as
+  props. Where two blocks on one page declare the same name with different
+  bodies, the later fixture var is suffixed — the roster names the fixture
+  var, and the comment above it names the block.
+
+  Filed under rf2-qwsmv."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.core :as rf]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.test :as t]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(declare app-page workspace)
+
+;; ---------------------------------------------------------------------------
+;; composition.md — the children ladder
+;; ---------------------------------------------------------------------------
+
+(v/defview details [{:keys [id]}]
+  [:p.details (str "details for " id)])
+
+;; composition.md block 1 (and state.md block 3) — trailing children, and the
+;; call site that supplies them.
+(v/defview panel [{:keys [title children]}]
+  [:section.panel
+   [:h2 title]
+   children])
+
+(def panel-call
+  (let [panel-id :p1]
+    [panel {:key panel-id :title "Details"}
+     [details {:id panel-id}]]))
+
+;; composition.md block 2 — the three children policies, declared.
+(v/defview icon-glyph [{:keys [name]}]
+  [:i.icon {:data-name name}])
+
+(v/defview icon-button
+  {:children-policy :none}
+  [{:keys [event label]}]
+  [:button {:on-click event :aria-label label}
+   [icon-glyph {:name label}]])
+
+(v/defview card-optional-children
+  {:children-policy :optional}
+  [{:keys [title children]}]
+  [:article.card
+   (when title [:header title])
+   (when (seq children) [:div.card-body children])])
+
+(v/defview dialog-shell
+  {:children-policy :required}
+  [{:keys [title children]}]
+  [:section.dialog
+   [:h2 title]
+   [:div.dialog-body children]])
+
+;; composition.md block 3 — a default region, plus a caller passing two
+;; children into it.
+(v/defview line-items [{:keys [invoice-id]}]
+  [:ul.line-items [:li (str "lines for " invoice-id)]])
+
+(v/defview totals [{:keys [invoice-id]}]
+  [:p.totals (str "total for " invoice-id)])
+
+(v/defview card [{:keys [title children]}]
+  [:article.card
+   (when title [:header title])
+   [:div.card-body children]])
+
+(def card-call
+  (let [id 7]
+    [card {:title "Invoice"}
+     [line-items {:invoice-id id}]
+     [totals {:invoice-id id}]]))
+
+;; composition.md block 4 — the library shape: a fixed region carried as
+;; children, placed where the component decides.
+(v/defview disclosure [{:keys [id label children]}]
+  (let [open? (v/sub [:disclosure/open? id])]
+    [:div.disclosure
+     [:button {:aria-expanded open?
+               :on-click      [:disclosure/toggled id]}
+      label]
+     (when open? [:div.body children])]))
+
+;; composition.md block 5 — parameterized rows through `v/render-fn` /
+;; `v/slot`, interpreted.
+(v/defview data-table [{:keys [rows row]}]
+  [:table
+   [:tbody
+    (for [item rows]
+      [:tr {:key (:id item)}
+       (v/slot row item)])]])
+
+(def data-table-call
+  (let [people [{:id 1 :name "Ada" :email "ada@example.com"}]]
+    [data-table
+     {:rows people
+      :row  (v/render-fn [person]
+              [:<>
+               [:td (:name person)]
+               [:td (:email person)]])}]))
+
+;; composition.md block 6 — a keyed child that subscribes for one row.
+(v/defview person-row [{:keys [id]}]
+  (let [person (v/sub [:person/by-id id])]
+    [:tr
+     [:td (:name person)]
+     [:td [:button {:on-click [:person/edit id]} "Edit"]]]))
+
+(v/defview person-rows [{:keys [ids]}]
+  [:tbody
+   (for [id ids]
+     [person-row {:key id :id id}])])
+
+;; composition.md block 7 (and reactivity-and-ownership.md block 1) — the
+;; canonical keyed list.
+(v/defview todo-row [{:keys [id]}]
+  [:li.todo (str "todo " id)])
+
+(v/defview todo-list [_]
+  [:ul.todo-list
+   (for [id (v/sub [:todo/visible-ids])]
+     [todo-row {:key id :id id}])])
+
+;; composition.md block 8 — the two forwarding forms, side by side. Not a
+;; declaration, so it is hosted in a function: the block's claim is the
+;; SHAPE of the two calls, and a function is the smallest thing that holds
+;; the free names the page left in scope.
+(defn spread-forms
+  [{:keys [value on-change caller-attrs date props]}]
+  [;; owned literals first, caller (or part) map second
+   (v/spread-safe
+     {:data-part "control"
+      :value value
+      :on-input (conj on-change ::v/value)}
+     caller-attrs)
+
+   ;; foreign leaf — open remainder, owned contract wins
+   (v/spread
+     {:selected date
+      :on-change (v/event [v] [:picker/picked v])}
+     (dissoc props :date :on-pick))])
+
+;; composition.md blocks 9 and 12 — the worked library field. The two blocks
+;; show the same declaration (block 9 with its caller, block 12 alone), so
+;; both roster rows name this one var.
+(v/defview field
+  [{:keys [label value on-change parts]}]
+  [:label {:data-component "my.lib/field"
+           :data-part "root"
+           :class "my-lib-field"}
+   [:span (v/spread-safe
+           {:data-part "label"}
+           (get parts :label))
+    label]
+   [:input
+    (v/spread-safe
+     {:data-part "control"
+      :value value
+      :on-input (conj on-change ::v/value)}
+     (get parts :control))]])
+
+(def field-call
+  (let [email "ada@example.com"]
+    [field {:label "Email"
+            :value email
+            :on-change [:account/email-changed]
+            :parts {:control {:class "wide-control"
+                              :data-analytics "signup-email"}}}]))
+
+;; composition.md block 10 — the foreign-widget sketch. `DatePicker` stands
+;; in for whatever npm component the consumer imported: the block is a
+;; sketch the guide never renders, and what it pins here is `v/spread` and
+;; `v/event` at a foreign head.
+(def DatePicker "some-date-picker/DatePicker")
+
+(v/defview date-field [{:keys [date on-pick] :as props}]
+  [DatePicker
+   (v/spread {:selected date
+              :on-change (v/event [v] (on-pick v))}
+             (dissoc props :date :on-pick))])
+
+;; composition.md block 13 — the caller reaching both parts.
+(def field-call-with-parts
+  (let [email "ada@example.com"]
+    [field {:label "Email"
+            :value email
+            :on-input [:account/email-changed ::v/value]
+            :parts {:label   {:class "quiet-label"}
+                    :control {:class "wide-control"
+                              :data-analytics "signup-email"}}}]))
+
+;; ---------------------------------------------------------------------------
+;; state.md — where state lives, and how far down it travels
+;; ---------------------------------------------------------------------------
+
+;; state.md block 1 — read narrowly, at the boundary that needs it.
+(v/defview order-summary [{:keys [order-id]}]
+  (let [order (v/sub [:orders/by-id order-id])
+        total (v/sub [:orders/total order-id])]
+    [:div
+     [:h3 (:title order)]
+     [:strong (str "$" total)]]))
+
+;; state.md block 2 — the opposite arrangement: one read at the top, props
+;; the rest of the way down.
+(v/defview app-root [_]
+  [app-page {:model (v/sub [:app/view-model])}])
+
+(v/defview app-page [{:keys [model]}]
+  [workspace {:model model}])   ; no sub below if the model is complete
+
+(v/defview workspace [{:keys [model]}]
+  [:div.workspace (:title model)])
+
+;; state.md block 4 — the live domain field.
+(v/defview email-controlled-input [_]
+  [:input {:value    (v/sub [:form/email])
+           :on-input [:form/set-email ::v/value]}])
+
+;; state.md block 5 — the app-owned draft, committed on blur or Enter.
+(v/defview email-draft-input [_]
+  [:input {:value       (v/sub [:form/email-draft])
+           :on-input    [:form/email-drafted ::v/value]
+           :on-blur     [:form/email-committed]
+           :on-key-down [:form/email-key ::v/key]}])
+
+;; ---------------------------------------------------------------------------
+;; reactivity-and-ownership.md — windowing before compiling
+;; ---------------------------------------------------------------------------
+
+;; reactivity-and-ownership.md block 2 — the parent reads the window, each
+;; row reads itself.
+(v/defview people-page [_]
+  (let [ids (v/sub [:people/visible-window-ids])]  ; e.g. ~40 rows for the viewport
+    [:ul.people
+     (for [id ids]
+       [person-row {:key id :id id}])]))
+
+;; ---------------------------------------------------------------------------
+;; The samples, executed
+;; ---------------------------------------------------------------------------
+
+(defn- seed!
+  [db]
+  (rf/reg-sub :disclosure/open? (fn [d [_ id]] (get-in d [:open id])))
+  (rf/reg-sub :person/by-id (fn [d [_ id]] (get-in d [:people id])))
+  (rf/reg-sub :todo/visible-ids (fn [d _] (:todo-ids d)))
+  (rf/reg-sub :people/visible-window-ids (fn [d _] (:window d)))
+  (rf/reg-sub :orders/by-id (fn [d [_ id]] (get-in d [:orders id])))
+  (rf/reg-sub :orders/total (fn [d [_ id]] (get-in d [:totals id])))
+  (rf/reg-sub :app/view-model (fn [d _] (:view-model d)))
+  (rf/reg-sub :form/email (fn [d _] (:email d)))
+  (rf/reg-sub :form/email-draft (fn [d _] (:email-draft d)))
+  (rf/dispatch-sync [:rf/set-db db]))
+
+(deftest trailing-children-reach-the-region-the-parent-placed
+  (testing "composition.md's ladder rung one — children are content the
+            caller supplies and the parent positions."
+    (let [tree (t/render panel-call)]
+      (is (= "Details" (t/text (t/find tree #(= :h2 (:tag %)))))
+          "the parent's own markup renders")
+      (is (some? (t/find tree #(= :p (:tag %))))
+          "and the caller's child renders inside it"))
+    (let [tree (t/render card-call)]
+      (is (= 2 (count (t/find-all tree #(#{:ul :p} (:tag %)))))
+          "two trailing children, both placed in the body region"))))
+
+(deftest a-render-fn-fills-the-slot-the-table-owns
+  (testing "composition.md's parameterized rows — the caller supplies a pure
+            body, the component decides where it runs."
+    (let [tree (t/render data-table-call)
+          tds  (t/find-all tree #(= :td (:tag %)))]
+      (is (= ["Ada" "ada@example.com"] (mapv t/text tds))
+          "both cells of the caller's row body rendered, in order"))))
+
+(deftest spread-safe-keeps-the-owned-contract-and-composes-class
+  (testing "composition.md's merge law, executed: the caller restyles and
+            annotates, and cannot reach the controlled keys."
+    (let [tree  (t/render field-call)
+          input (t/find tree #(= :input (:tag %)))
+          attrs (t/attrs input)]
+      (is (= "ada@example.com" (:value attrs)) "the owned :value survives")
+      (is (= [:account/email-changed ::v/value] (:on-input attrs))
+          "and so does the owned handler, with the marker conj'd on")
+      (is (= "signup-email" (:data-analytics attrs))
+          "the caller's annotation landed")
+      (is (= "control" (:data-part attrs))
+          "under the component's own part name"))))
+
+(deftest a-narrow-read-stays-at-the-boundary-that-needs-it
+  (testing "state.md's first claim — a view reads what it shows, and the
+            page's two arrangements both render."
+    (seed! {:orders {7 {:title "Widgets"}} :totals {7 42}
+            :view-model {:title "W"}})
+    (let [tree (t/with-render (t/render [order-summary {:order-id 7}]))]
+      (is (= "Widgets" (t/text (t/find tree #(= :h3 (:tag %))))))
+      (is (= "$42" (t/text (t/find tree #(= :strong (:tag %)))))))
+    (is (= "W" (t/text (t/with-render (t/render [app-root {}]))))
+        "one read at the top, props the rest of the way down")))
+
+(deftest a-keyed-list-mounts-one-child-per-id
+  (testing "composition.md and reactivity-and-ownership.md share this claim:
+            the parent reads the ids, each child reads itself."
+    (seed! {:todo-ids [1 2 3]
+            :window [:a :b]
+            :people {:a {:name "Ada"} :b {:name "Bob"}}})
+    (is (= 3 (count (t/find-all (t/with-render (t/render [todo-list {}]))
+                                #(= :li (:tag %)))))
+        "one row per visible id")
+    (let [tree (t/with-render (t/render [people-page {}]))]
+      (is (= ["Ada" "Bob"]
+             (mapv t/text (t/find-all tree #(and (= :td (:tag %))
+                                                 (seq (t/text %))
+                                                 (not= "Edit" (t/text %))))))
+          "and the windowed page mounts only the window"))))

--- a/implementation/freehand/test/re_frame/freehand/guide/controllers_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/guide/controllers_cljs_test.cljc
@@ -1,0 +1,326 @@
+(ns re-frame.freehand.guide.controllers-cljs-test
+  "Executable fixtures for `docs/core/freehand/semantic-controllers.md`.
+
+  That page is the one a component-library author reads, and it is the one
+  place the guide teaches three verbs an application never touches:
+  `v/controller-key`, `v/controller-revision` and `v/controller-current?`.
+  Their contracts are subtle — the key is a PAIR, the revision is the
+  caller's and must not be the value, and the fence is total and SAFE IN THE
+  MISSING DIRECTION — so the page's claims are asserted here against the real
+  functions rather than restated.
+
+  Transcription conventions are the ones in
+  `re-frame.freehand.guide.first-view-cljs-test`. Two extra notes:
+
+  - The page shows `rf/reg-sub` / `rf/reg-event` at a consumer namespace's
+    top level. Here they are hosted in a `register-…!` function, because a
+    test namespace's runtime is minted per test rather than at load.
+  - Two blocks declare `line-row` / `lines-table` with different bodies (the
+    live-domain wiring, then the buffered one). The fixture vars are
+    suffixed `-live` / `-buffered`; the roster names the fixture var.
+
+  Filed under rf2-qwsmv."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.core :as rf]
+            [re-frame.freehand :as v :refer [sub]]
+            [re-frame.freehand.test :as t]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+;; ---------------------------------------------------------------------------
+;; The library sketch the whole page builds toward
+;; ---------------------------------------------------------------------------
+
+;; semantic-controllers.md block 14 — `buffered-field`, which is a normal
+;; `v/defview` plus ordinary library events and subs, and NOT a substrate
+;; special form. Declared first here so the earlier call-site blocks can name
+;; it; the page introduces it last because it earns it last.
+(defn register-buffered-field-dataflow!
+  []
+  ;; ---- library dataflow ------------------------------------------------
+  (rf/reg-sub :fh.buffer/value
+    (fn [db [_ control reset-key external-value]]
+      (let [rec (get-in db [:fh.buffer/by-control control])]
+        (if (and rec (= (:reset-key rec) reset-key))
+          (:draft rec)
+          (or external-value "")))))
+
+  (rf/reg-event :fh.buffer/edited
+    (fn [{:keys [db]} [_ control reset-key text]]
+      {:db (assoc-in db [:fh.buffer/by-control control]
+                     {:reset-key reset-key :draft text})}))
+
+  (rf/reg-event :fh.buffer/committed
+    (fn [{:keys [db]} [_ control reset-key on-commit]]
+      (let [rec (get-in db [:fh.buffer/by-control control])]
+        (if (and rec (= (:reset-key rec) reset-key))
+          {:db (update db :fh.buffer/by-control dissoc control)
+           :fx [[:dispatch (conj (vec on-commit) (:draft rec))]]}
+          {}))))   ; stale / already cancelled → no-op
+
+  (rf/reg-event :fh.buffer/cancelled
+    (fn [{:keys [db]} [_ control reset-key]]
+      (let [rec (get-in db [:fh.buffer/by-control control])]
+        (if (and rec (= (:reset-key rec) reset-key))
+          {:db (update db :fh.buffer/by-control dissoc control)}
+          {})))))
+
+;; ---- the control ---------------------------------------------------------
+(v/defview buffered-field
+  [{:keys [control value reset-key on-commit placeholder]}]
+  (let [text (sub [:fh.buffer/value control reset-key value])]
+    [:input
+     {:value       text
+      :placeholder placeholder
+      :on-input    [:fh.buffer/edited control reset-key ::v/value]
+      :on-blur     [:fh.buffer/committed control reset-key on-commit]
+      :on-key-down (v/event [e]
+                     (case (.-key e)
+                       "Enter"  [:fh.buffer/committed control reset-key on-commit]
+                       "Escape" [:fh.buffer/cancelled control reset-key]
+                       nil))}]))
+
+;; ---------------------------------------------------------------------------
+;; semantic-controllers.md — the page in order
+;; ---------------------------------------------------------------------------
+
+;; block 1 — you can just use `on-blur`: valid Freehand, no controller.
+(v/defview keymap-field [{:keys [id]}]
+  [:input {:value   (v/sub [:lines/draft id])
+           :on-input [:lines/draft-changed id ::v/value]
+           :on-blur  [:lines/label-committed id]
+           :on-key-down (v/event [e]
+                          (case (.-key e)
+                            "Enter"  [:lines/label-committed id]
+                            "Escape" [:lines/draft-cancelled id]
+                            nil))}])
+
+;; block 2 — most controls should be props-only / controlled, and a
+;; disclosure is the archetype.
+(v/defview disclosure [{:keys [open? on-toggle label children]}]
+  [:section.disclosure
+   [:button {:aria-expanded open? :on-click on-toggle} label]
+   (when open? [:div.body children])])
+
+(v/defview faq-disclosure [{:keys [question-id]}]
+  [disclosure
+   {:open?     (v/sub [:faq/open? question-id])
+    :on-toggle [:faq/toggled question-id]
+    :label     "Why?"}])
+
+;; block 3 — a debounced, generation-fenced search, entirely in ordinary
+;; re-frame2: the view holds no protocol state at all.
+(defn register-search-dataflow!
+  []
+  ;; Each keystroke updates the query string (controlled field A) and kicks search.
+  ;; re-frame2: :dispatch-later is an fx id; the map key for the event is :event
+  ;; (not v1's :dispatch).
+  (rf/reg-event :search/query-typed
+    (fn [{:keys [db]} [_ text]]
+      (let [gen (inc (get-in db [:search :generation] 0))]
+        {:db (-> db
+                 (assoc-in [:search :query] text)
+                 (assoc-in [:search :generation] gen)
+                 (assoc-in [:search :status] :pending))
+         :fx [[:dispatch-later
+               {:ms 200
+                :event [:search/run gen text]}]]})))
+
+  (rf/reg-event :search/run
+    (fn [{:keys [db]} [_ gen text]]
+      (if (not= gen (get-in db [:search :generation]))
+        {}   ; superseded — do nothing
+        {:fx [[:search/fetch {:q text :gen gen}]]})))
+
+  (rf/reg-event :search/results-arrived
+    (fn [{:keys [db]} [_ gen results]]
+      (if (not= gen (get-in db [:search :generation]))
+        {}   ; stale network reply
+        {:db (-> db
+                 (assoc-in [:search :results] results)
+                 (assoc-in [:search :status] :ready))}))))
+
+;; block 4 — and the view that drives it stays an ordinary controlled field.
+(v/defview result-row [{:keys [id]}]
+  [:li.result (str "result " id)])
+
+(v/defview search-box [_]
+  [:div.search
+   [:input {:value (v/sub [:search/query])
+            :on-input [:search/query-typed ::v/value]
+            :aria-autocomplete :list}]
+   [:ul
+    (for [id (v/sub [:search/result-ids])]
+      [result-row {:key id :id id}])]])
+
+;; block 7 (and state.md block 6) — the call site a semantic controller
+;; earns: an address, a value, a generation and an intent.
+(v/defview buffered-field-call [{:keys [invoice-id]}]
+  [buffered-field
+   {:control   [:invoice invoice-id :amount]
+    :value     (v/sub [:invoice/amount invoice-id])
+    :reset-key (v/sub [:invoice/amount-revision invoice-id])
+    :on-commit [:invoice/amount-committed invoice-id]}])
+
+;; block 8 — the live-domain wiring, per row.
+(v/defview line-row-live [{:keys [line-id]}]
+  (let [label (v/sub [:lines/label line-id])]
+    [:tr
+     [:td
+      [:input {:value    label
+               :on-input [:lines/set-label line-id ::v/value]}]]]))
+
+(v/defview lines-table-live [_]
+  [:table
+   [:tbody
+    (for [id (v/sub [:lines/visible-ids])]
+      [line-row-live {:key id :line-id id}])]])
+
+;; block 9 — the same table with the buffered controller, and the `:control`
+;; address that is unique per row while `:key` answers list identity.
+(v/defview line-row-buffered [{:keys [line-id]}]
+  (let [label    (v/sub [:lines/label line-id])
+        revision (v/sub [:lines/label-revision line-id])]
+    [:tr
+     [:td
+      [buffered-field
+       {:control   [:line line-id :label]   ;; unique per row
+        :value     label
+        :reset-key revision
+        :on-commit [:lines/label-committed line-id]}]]]))
+
+(v/defview lines-table-buffered [_]
+  [:table
+   [:tbody
+    (for [id (v/sub [:lines/visible-ids])]
+      [line-row-buffered {:key id :line-id id}])]])
+
+;; block 13 — the fence at both boundaries of a buffered controller. The
+;; READ is a registration; the WRITE is a fragment of an event handler, so
+;; it is hosted in the function whose free names the page left in scope.
+(def records-root :acme.buffered/by-control)
+
+(defn register-acme-buffered-text!
+  []
+  ;; the READ — display the draft only while it is current
+  (rf/reg-sub :acme.buffered/text
+    (fn [db [_ k revision baseline]]
+      (let [record (get-in db [records-root k])]
+        (if (v/controller-current? (:reset-key record) revision)
+          (:draft record)
+          baseline)))))
+
+(defn commit-when-current
+  [record revision on-commit]
+  ;; the WRITE — only a current record may produce the caller's intent
+  (when (v/controller-current? (:reset-key record) revision)
+    {:fx [[:dispatch (conj on-commit (:draft record))]]}))
+
+;; ---------------------------------------------------------------------------
+;; The samples, executed
+;; ---------------------------------------------------------------------------
+
+(defn- seed!
+  [db]
+  (register-buffered-field-dataflow!)
+  (register-acme-buffered-text!)
+  (rf/reg-sub :lines/draft (fn [d [_ id]] (get-in d [:drafts id])))
+  (rf/reg-sub :lines/label (fn [d [_ id]] (get-in d [:labels id])))
+  (rf/reg-sub :lines/label-revision (fn [d [_ id]] (get-in d [:revisions id])))
+  (rf/reg-sub :lines/visible-ids (fn [d _] (:line-ids d)))
+  (rf/reg-sub :faq/open? (fn [d [_ id]] (get-in d [:open id])))
+  (rf/reg-sub :search/query (fn [d _] (get-in d [:search :query])))
+  (rf/reg-sub :search/result-ids (fn [d _] (get-in d [:search :result-ids])))
+  (rf/reg-sub :invoice/amount (fn [d [_ id]] (get-in d [:invoices id :amount])))
+  (rf/reg-sub :invoice/amount-revision (fn [d [_ id]] (get-in d [:invoices id :rev])))
+  (rf/dispatch-sync [:rf/set-db db]))
+
+(deftest the-controller-key-is-the-pair-of-kind-and-address
+  (testing "semantic-controllers.md block 10 — the key is the library's own
+            kind PAIRED with the caller's `:control` address, so two
+            controllers at one domain identity read two records."
+    (let [props {:control [:invoice 42 :amount] :reset-key 0}]
+      (is (= [::buffered-field [:invoice 42 :amount]]
+             (v/controller-key ::buffered-field props))
+          "exactly the pair the page prints")
+      (is (not= (v/controller-key ::buffered-field props)
+                (v/controller-key ::some-dropdown props))
+          "the kind is half the key — a dropdown does not read the field's record"))))
+
+(deftest the-controller-revision-is-the-callers-reset-key
+  (testing "semantic-controllers.md block 11 — the generation is the
+            CALLER's `:reset-key`, whatever EDN it likes, and it is
+            required rather than optional."
+    (is (= 7 (v/controller-revision ::buffered-field
+                                    {:control [:invoice 42 :amount] :reset-key 7})))
+    (is (= [:decision 3] (v/controller-revision ::buffered-field
+                                                 {:control [:x] :reset-key [:decision 3]}))
+        "any EDN — the fence only ever asks whether two are equal")
+    (is (thrown? #?(:clj Exception :cljs :default)
+                 (v/controller-revision ::buffered-field {:control [:x]}))
+        "absent is refused, because optional would ship a defect that only
+         shows up at the first rejection")))
+
+(deftest the-generation-fence-is-total-and-safe-when-the-stamp-is-missing
+  (testing "semantic-controllers.md block 12 — one predicate at both
+            boundaries, and the half a hand-rolled `(= a b)` gets wrong."
+    (is (true? (v/controller-current? 3 3)) "equal generations are current")
+    (is (false? (v/controller-current? 2 3)) "a superseded stamp is not")
+    (is (false? (v/controller-current? nil 3))
+        "an absent stamp is NOT current — two nils must not compare equal here")))
+
+(deftest the-fence-decides-what-the-read-shows
+  (testing "block 13's READ, run through the registration the page shows:
+            a current record displays its draft, a superseded one falls
+            through to the baseline and is invisible rather than erased."
+    (seed! {records-root {[:k] {:reset-key 1 :draft "mid-edit"}}})
+    (is (= "mid-edit" @(rf/subscribe [:acme.buffered/text [:k] 1 "baseline"]))
+        "current — the draft shows")
+    (is (= "baseline" @(rf/subscribe [:acme.buffered/text [:k] 2 "baseline"]))
+        "the caller moved on — the draft is invisible, the baseline shows")
+    (is (= "baseline" @(rf/subscribe [:acme.buffered/text [:missing] 1 "baseline"]))
+        "no record at all — total, and safe in the missing direction")))
+
+(deftest the-write-half-asks-the-same-question
+  (testing "block 13's WRITE — only a current record produces the caller's
+            intent, and the draft rides on the end of the prefix."
+    (is (= {:fx [[:dispatch [:lines/label-committed 5 "Alpha"]]]}
+           (commit-when-current {:reset-key 1 :draft "Alpha"} 1
+                                [:lines/label-committed 5])))
+    (is (nil? (commit-when-current {:reset-key 1 :draft "Alpha"} 2
+                                   [:lines/label-committed 5]))
+        "a superseded record commits nothing")))
+
+(deftest a-buffered-row-addresses-its-own-record
+  (testing "blocks 8 and 9 side by side — the live table writes the domain
+            value per keystroke, the buffered one addresses a per-row
+            record and commits on blur."
+    (seed! {:line-ids [5 12]
+            :labels {5 "five" 12 "twelve"}
+            :revisions {5 0 12 2}})
+    (let [live (t/with-render (t/render [lines-table-live {}]))]
+      (is (= [[:lines/set-label 5 ::v/value] [:lines/set-label 12 ::v/value]]
+             (mapv #(:on-input (t/attrs %))
+                   (t/find-all live #(= :input (:tag %)))))
+          "the live wiring writes the domain value straight from the site"))
+    (let [buffered (t/with-render (t/render [lines-table-buffered {}]))
+          inputs   (t/find-all buffered #(= :input (:tag %)))]
+      (is (= [[:fh.buffer/edited [:line 5 :label] 0 ::v/value]
+              [:fh.buffer/edited [:line 12 :label] 2 ::v/value]]
+             (mapv #(:on-input (t/attrs %)) inputs))
+          "each row edits its OWN record, under its own generation")
+      (is (= ["five" "twelve"] (mapv #(:value (t/attrs %)) inputs))
+          "and with no draft in flight both fall through to the domain value"))))
+
+(deftest a-props-only-disclosure-needs-no-controller
+  (testing "block 2 — the page's own advice, executed: open state is the
+            caller's, and the control holds nothing."
+    (seed! {:open {:q1 true}})
+    (let [tree (t/with-render (t/render [faq-disclosure {:question-id :q1}]))
+          btn  (t/find tree #(= :button (:tag %)))]
+      (is (true? (:aria-expanded (t/attrs btn))))
+      (is (= [:faq/toggled :q1] (:on-click (t/attrs btn)))))))

--- a/implementation/freehand/test/re_frame/freehand/guide/events_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/guide/events_cljs_test.cljc
@@ -1,0 +1,336 @@
+(ns re-frame.freehand.guide.events-cljs-test
+  "Executable fixtures for the Freehand guide's EVENT chapters —
+  `docs/core/freehand/events-and-handlers.md` and `forms.md`.
+
+  This is the pair of pages with the most surface per line: the five named
+  projection markers and the general `[::v/read path]` door, the options-map
+  vocabulary, `v/event`, the controlled door, and the three ways to wire a
+  text field. Every one of those is a spelling a consumer copies verbatim,
+  and every one of them is invisible to prose review once it moves.
+
+  Transcription conventions, as in
+  `re-frame.freehand.guide.first-view-cljs-test`: a markup fragment that
+  reads state is hosted in a one-line `v/defview` (a `def` would call
+  `v/sub` at load time, outside any render); a fragment that reads nothing
+  is held as data in a `def`; free names arrive as props.
+
+  Filed under rf2-qwsmv."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.core :as rf]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.test :as t]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+;; ---------------------------------------------------------------------------
+;; events-and-handlers.md — the paved path and its escapes
+;; ---------------------------------------------------------------------------
+
+;; events-and-handlers.md block 1 — the whole paved path, in one line.
+(v/defview add-to-cart-button [{:keys [product-id]}]
+  [:button {:on-click [:cart/add product-id]} "Add to cart"])
+
+;; events-and-handlers.md block 2 — the three everyday named markers. Held as
+;; data: nothing here reads state, and the block's claim is the spelling.
+(def projection-marker-sites
+  [[:input {:on-input  [:form/typed :email ::v/value]}]
+   [:input {:type :checkbox :on-change [:prefs/set :dark ::v/checked]}]
+   [:div   {:on-key-down [:editor/key ::v/key]}]])   ; "Enter", "a", …
+
+;; events-and-handlers.md block 4 — the general read door the named markers
+;; are sugar for.
+(def general-read-sites
+  [[:div {:on-scroll [:pane/scrolled [::v/read [:target :scrollLeft]]]}]
+   [:div {:on-key-down [:editor/chord [::v/read :altKey]]}]])
+
+;; events-and-handlers.md block 5 — listener mechanics as data.
+(v/defview submit-options-map [_]
+  [:form {:on-submit {:event [:signup/requested] :prevent-default true}}])
+
+;; events-and-handlers.md block 6 — send the key, branch in the handler.
+(v/defview key-pressed-site [_]
+  [:input {:on-key-down [:picker/key-pressed ::v/key]}])
+
+;; events-and-handlers.md block 7 — or branch at the site, when the browser
+;; mechanics depend on which key it was.
+(v/defview key-branch-site [_]
+  [:input {:on-key-down (v/event [e]
+                          (case (.-key e)
+                            "Enter"  [:picker/accept]
+                            "Escape" [:picker/close]
+                            nil))}])
+
+;; events-and-handlers.md block 8 — the controlled door.
+(v/defview controlled-email-field [_]
+  [:input {:value (v/sub [:form/email])
+           :on-input [:form/typed :email ::v/value]}])
+
+;; events-and-handlers.md block 9 — pattern A: the keystroke IS the value.
+(v/defview live-domain-field [{:keys [id]}]
+  [:input {:value    (v/sub [:lines/label id])
+           :on-input [:lines/set-label id ::v/value]}])
+
+;; events-and-handlers.md block 10 — pattern B: an app-owned draft, committed
+;; on blur or Enter.
+(v/defview draft-then-commit-field [{:keys [id]}]
+  [:input {:value       (v/sub [:lines/draft id])
+           :on-input    [:lines/draft-changed id ::v/value]
+           :on-blur     [:lines/label-committed id]
+           :on-key-down [:lines/draft-key id ::v/key]}])
+
+;; events-and-handlers.md block 11 — pattern B's branch point is an ordinary
+;; handler, and the decision sees application state.
+(defn register-draft-key-handler!
+  []
+  (rf/reg-event :lines/draft-key
+    (fn [{:keys [db]} [_ id k]]
+      (case k
+        "Enter"  {:fx [[:dispatch [:lines/label-committed id]]]}
+        "Escape" {:fx [[:dispatch [:lines/draft-cancelled id]]]}
+        {:db db}))))
+
+;; events-and-handlers.md block 12 — the deliberate escape: uncontrolled.
+(v/defview uncontrolled-cell-input [{:keys [id raw]}]
+  ;; Uncontrolled: no :value key — not on the Freehand door
+  [:input {:default-value raw
+           :auto-focus    true
+           :on-blur       [:cells/commit-edit id ::v/value]
+           :on-key-down   (v/event [e]
+                            (case (.-key e)
+                              "Enter"  [:cells/commit-edit id (.. e -target -value)]
+                              "Escape" [:cells/cancel-edit id]
+                              nil))}])
+
+;; events-and-handlers.md block 13 — a parent passes intent as data; the
+;; child's own site dispatches it.
+(v/defview icon-button [{:keys [event label]}]
+  [:button {:aria-label label :on-click event}
+   label])
+
+(def icon-button-call
+  (let [item-id 42]
+    [icon-button {:event [:item/deleted item-id] :label "Delete"}]))
+
+;; events-and-handlers.md block 14 — the event-PREFIX convention a library
+;; control uses when it cannot know the caller's grammar.
+(v/defview text-field [{:keys [value on-change]}]
+  ;; inside text-field
+  [:input {:value value
+           :on-input (conj on-change ::v/value)}])
+
+(def text-field-call
+  (let [email "ada@example.com"]
+    ;; caller
+    [text-field {:value email :on-change [:form/set-email]}]))
+
+;; ---------------------------------------------------------------------------
+;; forms.md — drafts, errors, and the touched set
+;; ---------------------------------------------------------------------------
+
+;; forms.md block 2 — the field, reading its own error.
+(v/defview email-field [_]
+  (let [draft  (v/sub [:editor/draft])
+        error  (v/sub [:editor/field-error :email])
+        text   (:email draft)]
+    [:label
+     "Email"
+     [:input {:value    (or text "")
+              :on-input [:editor/edit-field :email ::v/value]
+              :on-blur  [:editor/blur-field :email]}]
+     (when error [:p.error error])]))
+
+;; forms.md block 3 — errors show only once the user has been there.
+(defn register-field-error-sub!
+  []
+  (rf/reg-sub :editor/field-error
+    (fn [db [_ field]]
+      (let [{:keys [errors touched submit-attempted?]} (:editor db)]
+        (when (or submit-attempted? (contains? touched field))
+          (get errors field))))))
+
+;; forms.md block 4 — a late server value must not clobber what the user typed.
+(defn register-article-loaded!
+  []
+  (rf/reg-event :editor/article-loaded
+    (fn [{:keys [db]} [_ slug article]]
+      (let [{:keys [draft touched]} (get db :editor)
+            seeded (reduce-kv
+                    (fn [d k v]
+                      (if (contains? touched k)
+                        d                 ; user already typed here — keep it
+                        (assoc d k v)))   ; otherwise take server value
+                    draft
+                    article)]
+        {:db (assoc db :editor {:slug     slug
+                                :draft    seeded
+                                :baseline article
+                                :touched  (or touched #{})})}))))
+
+(defn- validate-editor
+  "The page names this helper without showing it; a form's validation is the
+  application's, not the substrate's."
+  [{:keys [draft]}]
+  (if (seq (:title draft)) {} {:title "Title is required"}))
+
+;; forms.md block 5 — busy is a mutation fact, and submit is one event.
+(defn register-editor-submit!
+  []
+  ;; Busy is commonly a mutation/resource fact, not a form-slice key
+  (rf/reg-sub :editor/busy?
+    (fn [db _]
+      (boolean (get-in db [:mutations :editor-save :pending?]))))
+
+  (rf/reg-sub :editor/can-submit?
+    (fn [db _]
+      (let [{:keys [draft errors]} (:editor db)
+            busy? (get-in db [:mutations :editor-save :pending?])]
+        (and (not busy?)
+             (seq (:title draft))
+             (empty? errors)))))
+
+  (rf/reg-event :editor/submit
+    (fn [{:keys [db]} _]
+      (let [editor (assoc (:editor db) :submit-attempted? true)
+            errors (validate-editor editor)]
+        (if (seq errors)
+          {:db (assoc db :editor (assoc editor :errors errors))}
+          {:db (assoc db :editor (assoc editor :errors {}))
+           :fx [[:dispatch [:editor/save (:draft editor)]]]})))))
+
+;; forms.md block 6 — the submit button reads the two derived facts.
+(v/defview editor-actions [_]
+  (let [busy?    (v/sub [:editor/busy?])
+        can-save (v/sub [:editor/can-submit?])]
+    [:button {:disabled (or busy? (not can-save))
+              :on-click [:editor/submit]}
+     (if busy? "Saving…" "Save")]))
+
+(defn- f->c-string [f-text] (str (/ (- (parse-long (str f-text)) 32) 2)))
+(defn- c->f-string [c-text] (str (+ (* 2 (parse-long (str c-text))) 32)))
+
+;; forms.md block 7 — the two-way conversion pair: the active field echoes
+;; raw text, the other shows the derived display.
+(def temperature-slice
+  ;; Conceptual slice
+  {:c-text "22" :f-text "71.6" :active :c})
+
+(defn register-temperature-dataflow!
+  []
+  ;; Subs: active field echoes raw text; the other shows derived display
+  (rf/reg-sub :temp/c-display
+    (fn [db _]
+      (let [{:keys [c-text f-text active]} (:temp db)]
+        (if (= active :c) c-text (f->c-string f-text)))))
+
+  ;; Events: typing sets :active + raw text; optional derive of the sibling raw
+  (rf/reg-event :temp/c-typed
+    (fn [{:keys [db]} [_ text]]
+      {:db (update db :temp
+                   #(assoc % :active :c :c-text text
+                             :f-text (c->f-string text)))})))
+
+;; forms.md block 8 — both fields, each controlled by its own display sub.
+(v/defview temperature-inputs [_]
+  [:<>
+   [:input {:value (v/sub [:temp/c-display])
+            :on-input [:temp/c-typed ::v/value]}]
+   [:input {:value (v/sub [:temp/f-display])
+            :on-input [:temp/f-typed ::v/value]}]])
+
+;; ---------------------------------------------------------------------------
+;; The samples, executed
+;; ---------------------------------------------------------------------------
+
+(defn- seed!
+  [db]
+  (rf/reg-sub :form/email (fn [d _] (:email d)))
+  (rf/reg-sub :lines/label (fn [d [_ id]] (get-in d [:labels id])))
+  (rf/reg-sub :lines/draft (fn [d [_ id]] (get-in d [:drafts id])))
+  (rf/reg-sub :editor/draft (fn [d _] (get-in d [:editor :draft])))
+  (rf/reg-sub :temp/c-display (fn [d _] (get-in d [:temp :c-text])))
+  (rf/reg-sub :temp/f-display (fn [d _] (get-in d [:temp :f-text])))
+  (register-field-error-sub!)
+  (register-editor-submit!)
+  (rf/dispatch-sync [:rf/set-db db]))
+
+(deftest the-named-projection-roster-is-the-five-the-page-lists
+  (testing "events-and-handlers.md block 3 states the whole named roster;
+            `v/projections` is where the claim is settled, and this is the
+            assertion that notices when it moves."
+    (is (= #{::v/value ::v/checked ::v/key ::v/scroll-top ::v/new-state}
+           v/projections)
+        "five markers carry names — no more, no fewer")))
+
+(deftest a-marker-rides-the-tree-unfilled-and-materializes-once
+  (testing "the page's core mechanic: the site carries the marker as data,
+            and `v/materialize-event` is the ONE thing that fills it."
+    (seed! {:email "ada@example.com"})
+    (let [tree  (t/with-render (t/render [controlled-email-field {}]))
+          input (t/find tree #(= :input (:tag %)))
+          site  (:on-input (t/attrs input))]
+      (is (= [:form/typed :email ::v/value] site)
+          "the tree holds the marker, unfilled")
+      (is (= [:form/typed :email "hi"]
+             (v/materialize-event site {::v/value "hi"}))
+          "and materializing fills exactly the top-level marker"))))
+
+(deftest listener-mechanics-ride-as-data-not-as-a-wrapper-function
+  (testing "events-and-handlers.md's options map — the closed vocabulary
+            sits beside the event rather than wrapping it in a closure."
+    (let [tree (t/render [submit-options-map {}])
+          site (:on-submit (t/attrs (t/find tree #(= :form (:tag %)))))]
+      (is (= {:event [:signup/requested] :prevent-default true} site))
+      (is (= [:signup/requested] (v/materialize-event (:event site) {}))
+          "the event under :event is the ordinary vector every path materializes")
+      (is (true? (:prevent-default site))
+          "and the mechanics ride beside it as data, not inside a closure"))))
+
+(deftest an-event-prefix-takes-the-marker-by-conj
+  (testing "the library-control convention on the page's last block: the
+            caller supplies a prefix, the control's own site appends the
+            live scalar."
+    (let [tree  (t/render text-field-call)
+          input (t/find tree #(= :input (:tag %)))]
+      (is (= [:form/set-email ::v/value] (:on-input (t/attrs input)))
+          "the prefix and the marker are one vector at the site")
+      (is (= [:form/set-email "typed"]
+             (v/materialize-event (:on-input (t/attrs input))
+                                  {::v/value "typed"}))))))
+
+(deftest the-three-text-field-wirings-render-as-the-page-describes
+  (testing "patterns A and B differ in exactly one way — B has draft, commit
+            and cancel sites where A has one."
+    (seed! {:labels {7 "live"} :drafts {7 "drafted"}})
+    (let [a (t/attrs (t/find (t/with-render (t/render [live-domain-field {:id 7}]))
+                             #(= :input (:tag %))))
+          b (t/attrs (t/find (t/with-render (t/render [draft-then-commit-field {:id 7}]))
+                             #(= :input (:tag %))))]
+      (is (= "live" (:value a)))
+      (is (= [:lines/set-label 7 ::v/value] (:on-input a)))
+      (is (nil? (:on-blur a)) "pattern A has no commit transition")
+      (is (= "drafted" (:value b)))
+      (is (= [:lines/label-committed 7] (:on-blur b))
+          "pattern B commits on blur")
+      (is (= [:lines/draft-key 7 ::v/key] (:on-key-down b))
+          "and branches on the key in the handler"))))
+
+(deftest an-error-shows-only-once-the-field-is-touched
+  (testing "forms.md's touched/submit-attempted rule, run through the real
+            subscription the page registers."
+    (seed! {:editor {:draft {:email "x"}
+                     :errors {:email "Not an email"}
+                     :touched #{}}})
+    (is (nil? (t/find (t/with-render (t/render [email-field {}]))
+                      #(= :p (:tag %))))
+        "untouched and unsubmitted — no error shown")
+    (seed! {:editor {:draft {:email "x"}
+                     :errors {:email "Not an email"}
+                     :touched #{:email}}})
+    (is (= "Not an email"
+           (t/text (t/find (t/with-render (t/render [email-field {}]))
+                           #(= :p (:tag %)))))
+        "touched — the error appears")))

--- a/implementation/freehand/test/re_frame/freehand/guide/first_view_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/guide/first_view_cljs_test.cljc
@@ -1,0 +1,248 @@
+(ns re-frame.freehand.guide.first-view-cljs-test
+  "Executable fixtures for the Freehand guide's OPENING chapters —
+  `docs/core/freehand/index.md`, `build-a-view.md`, `mental-model.md` and
+  `vs-reagent.md`.
+
+  Every var here is one fenced code block from those pages, transcribed. The
+  roster in `re-frame.freehand.guide.samples-coverage-jvm-test` names it, so
+  the link between a page's sample and the code that proves it is checked
+  rather than remembered.
+
+  ## What a fixture is for
+
+  The guide is written against a deliberately UNFROZEN door. Its value
+  depends on `v/defview`, `v/sub`, `::v/value` and the rest still spelling
+  what the page says they spell — and prose cannot notice a rename. A
+  fixture can: transcribing the sample onto the real classpath makes a moved
+  verb a compile failure on both hosts, named at the line of the sample it
+  broke.
+
+  ## Two transcription conventions
+
+  A fenced block is not always a top-level form, so two conventions carry the
+  ones that are not, and neither invents API:
+
+  - **A bare markup fragment is hosted in a one-line `v/defview`.** The
+    guide often shows an element in isolation (`[:button {:on-click …} \"+\"]`).
+    A `def` would not do: markup carrying `(v/sub …)` calls it at load time,
+    outside any render. The declaration is the smallest honest host, and it
+    makes the fragment renderable through `t/render` besides.
+  - **Free names in a fragment become props.** `product-id` in the guide's
+    `[:button {:on-click [:cart/add product-id]}]` is whatever the
+    surrounding view had in scope; here it arrives as a prop, which is what
+    the surrounding view would have had to do.
+
+  Filed under rf2-qwsmv; the durability argument is that bead's."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.core :as rf]
+            [re-frame.freehand :as v :refer [sub]]
+            [re-frame.freehand.test :as t]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+;; ---------------------------------------------------------------------------
+;; index.md — the headline view
+;; ---------------------------------------------------------------------------
+
+;; index.md block 1 — the page's one sample, and the whole pitch in three lines.
+(v/defview cart-badge [_]
+  [:button {:on-click [:cart/open]}
+   "Cart (" (v/sub [:cart/count]) ")"])
+
+;; ---------------------------------------------------------------------------
+;; build-a-view.md — the counter, grown one step at a time
+;; ---------------------------------------------------------------------------
+
+;; build-a-view.md block 2 — the dataflow half, which is plain re-frame2 and
+;; deliberately not a Freehand concern.
+(defn register-counter-dataflow!
+  []
+  (rf/reg-event :app/init  (fn [_ _] {:db {:count 0 :note ""}}))
+  (rf/reg-event :count/inc (fn [{:keys [db]} _] {:db (update db :count inc)}))
+  (rf/reg-event :note/set
+    (fn [{:keys [db]} [_ text]]
+      {:db (assoc db :note text)}))
+
+  (rf/reg-sub :count (fn [db _] (:count db)))
+  (rf/reg-sub :note  (fn [db _] (:note db))))
+
+;; build-a-view.md block 3 — step one: structure and one read.
+(v/defview counter-v1 [_]
+  [:div.counter
+   [:p "Count: " (sub [:count])]])
+
+;; build-a-view.md block 4 — step two: intent as data on a button.
+(v/defview counter-v2 [_]
+  [:div.counter
+   [:p "Count: " (sub [:count])]
+   [:button {:on-click [:count/inc]} "Increment"]])
+
+;; build-a-view.md block 5 — step three: a controlled field and `::v/value`.
+(v/defview counter-v3 [_]
+  [:div.counter
+   [:p "Count: " (sub [:count])]
+   [:button {:on-click [:count/inc]} "Increment"]
+   [:input {:value       (sub [:note])
+            :on-input    [:note/set ::v/value]
+            :placeholder "A note…"}]])
+
+;; build-a-view.md block 6 — a keyed child per row, each reading its own slice.
+(v/defview note-row [{:keys [id]}]
+  (let [text (sub [:notes/by-id id])]
+    [:li
+     [:input {:value    text
+              :on-input [:notes/set id ::v/value]}]]))
+
+(v/defview note-list [_]
+  [:ul
+   (for [id (sub [:notes/ids])]
+     [note-row {:key id :id id}])])
+
+;; ---------------------------------------------------------------------------
+;; mental-model.md — the vocabulary, one form at a time
+;; ---------------------------------------------------------------------------
+
+;; mental-model.md block 1 (and vs-reagent.md block 1) — a declaration.
+(v/defview greeting [{:keys [name]}]
+  [:p "Hello, " name])
+
+;; mental-model.md block 2 — a call site: a vector, never `(greeting …)`.
+(def greeting-call
+  [greeting {:name "Ada"}])
+
+;; mental-model.md block 3 — a pure helper is fine in interpreted markup; a
+;; declared child is what a boundary is for.
+(defn- money [amount] (str "$" amount))
+
+(defn price-line [{:keys [label amount]}]
+  [:div.price-line [:span label] [:span (money amount)]])
+
+(v/defview tax-summary [{:keys [invoice-id]}]
+  [:div.tax (str "tax for " invoice-id)])
+
+(v/defview invoice [{:keys [id]}]
+  [:section
+   (price-line {:label "Subtotal"
+                :amount (v/sub [:invoice/subtotal id])})
+   [tax-summary {:invoice-id id}]])
+
+;; mental-model.md block 5 — a read, in place, with no deref.
+(v/defview count-span [_]
+  [:span "Count: " (v/sub [:count])])
+
+;; mental-model.md block 6 — the one-shot read outside a render, which is
+;; re-frame's, not Freehand's.
+(defn basket-total-once
+  []
+  (rf/subscribe-once [:basket/total] {:frame :app/main}))
+
+;; mental-model.md block 7 (and vs-reagent.md block 3) — intent as data.
+(v/defview inc-button [_]
+  [:button {:on-click [:count/inc]} "+"])
+
+;; mental-model.md block 8 — the controlled door, with a projection marker.
+(v/defview email-input [{:keys [email]}]
+  [:input {:value email
+           :on-input [:form/edit :email ::v/value]}])
+
+;; ---------------------------------------------------------------------------
+;; vs-reagent.md — the Freehand half of each comparison
+;; ---------------------------------------------------------------------------
+;;
+;; Each block on that page shows a Reagent-ish spelling beside the Freehand
+;; one. Only the Freehand half is transcribed: the Reagent half names an
+;; artefact this one takes no dependency on, and deliberately so.
+
+;; vs-reagent.md block 2 — the read, with no deref and no ceremony.
+(v/defview count-span-bare [_]
+  [:span (v/sub [:count])])
+
+;; vs-reagent.md block 4 — the controlled field.
+(v/defview email-input-vs-reagent [_]
+  [:input {:value (v/sub [:email])
+           :on-input [:form/set-email ::v/value]}])
+
+;; vs-reagent.md block 5 — keys ride in props, not in metadata.
+(v/defview row-view [{:keys [row]}]
+  [:li (:label row)])
+
+(v/defview keyed-rows [{:keys [rows]}]
+  [:ul
+   (for [r rows]
+     [row-view {:key (:id r) :row r}])])
+
+;; vs-reagent.md block 6 — the side-by-side counter, Freehand half.
+(v/defview counter-vs-reagent [_]
+  [:div
+   [:p "Count: " (v/sub [:count])]
+   [:button {:on-click [:count/inc]} "Inc"]
+   [:input {:value (v/sub [:note])
+            :on-input [:note/set ::v/value]}]])
+
+;; ---------------------------------------------------------------------------
+;; The samples, executed
+;; ---------------------------------------------------------------------------
+
+(defn- seed!
+  "Run the guide's own dataflow, then set the state the page's prose assumes."
+  [db]
+  (register-counter-dataflow!)
+  (rf/reg-sub :cart/count (fn [d _] (:cart-count d)))
+  (rf/reg-sub :notes/ids (fn [d _] (:note-ids d)))
+  (rf/reg-sub :notes/by-id (fn [d [_ id]] (get-in d [:notes id])))
+  (rf/dispatch-sync [:rf/set-db db]))
+
+(deftest the-counter-grows-exactly-as-the-page-says
+  (testing "each step of build-a-view.md renders, and the step that adds a
+            button adds the intent the page claims."
+    (seed! {:count 7 :note "hi"})
+    (is (= "Count: 7" (t/text (t/with-render (t/render [counter-v1 {}]))))
+        "step one shows the read")
+    (let [tree (t/with-render (t/render [counter-v2 {}]))]
+      (is (= [:count/inc]
+             (:on-click (t/attrs (t/find tree #(= :button (:tag %))))))
+          "step two carries the increment intent as data"))
+    (let [tree  (t/with-render (t/render [counter-v3 {}]))
+          input (t/find tree #(= :input (:tag %)))]
+      (is (= "hi" (:value (t/attrs input))) "step three is controlled")
+      (is (= [:note/set ::v/value] (:on-input (t/attrs input)))
+          "and carries the projection marker, unfilled, on the tree"))))
+
+(deftest a-keyed-child-reads-its-own-row
+  (testing "build-a-view.md's note list — one child per id, each subscribing
+            for itself, which is the page's whole point about boundaries."
+    (seed! {:note-ids [:a :b] :notes {:a "alpha" :b "beta"}})
+    (let [tree   (t/with-render (t/render [note-list {}]))
+          inputs (t/find-all tree #(= :input (:tag %)))]
+      (is (= 2 (count inputs)) "one row per id")
+      (is (= ["alpha" "beta"] (mapv #(:value (t/attrs %)) inputs))
+          "each row read its own slice")
+      (is (= [:notes/set :a ::v/value] (:on-input (t/attrs (first inputs))))
+          "and carries its own id in the intent"))))
+
+(deftest a-call-site-is-a-vector-and-a-declaration-is-a-descriptor
+  (testing "mental-model.md's central claim: the var holds a descriptor, the
+            call site is data, and `(greeting {})` is never written."
+    (is (v/view? greeting) "the var holds a descriptor")
+    (is (= [greeting {:name "Ada"}] greeting-call) "the call site is a vector")
+    (is (= "Hello, Ada" (t/text (t/render greeting-call)))
+        "and the vector renders")))
+
+(deftest the-headline-badge-renders
+  (testing "index.md's sample is a real view that reads real state."
+    (seed! {:cart-count 3})
+    (is (= "Cart (3)" (t/text (t/with-render (t/render [cart-badge {}])))))))
+
+(deftest the-vs-reagent-half-is-the-paved-path
+  (testing "vs-reagent.md contrasts spellings; the Freehand half is the
+            ordinary one, and it renders with no adapter in sight."
+    (seed! {:count 2 :note "n"})
+    (is (= "2" (t/text (t/with-render (t/render [count-span-bare {}])))))
+    (let [tree (t/with-render (t/render [keyed-rows {:rows [{:id 1 :label "one"}
+                                                            {:id 2 :label "two"}]}]))]
+      (is (= ["one" "two"] (mapv t/text (t/find-all tree #(= :li (:tag %)))))
+          "keys ride in props and the rows still render in order"))))

--- a/implementation/freehand/test/re_frame/freehand/guide/host_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/guide/host_cljs_test.cljc
@@ -1,0 +1,402 @@
+(ns re-frame.freehand.guide.host-cljs-test
+  "Executable fixtures for the Freehand guide's HOST-EDGE chapters —
+  `docs/core/freehand/host-boundaries.md`, `js-libraries.md`, `presence.md`,
+  `accessibility.md`, `ssr.md`, `install.md` and `adoption.md`.
+
+  These pages carry the verbs that only exist because a browser does:
+  `v/defbehavior` and `[v/behavior …]`, `v/client-only`, `v/error-boundary`,
+  `v/presence` / `v/presence-phase`, the `::web/` top-layer keys, the
+  `:re-frame.freehand.host/command` effect, `v/route-link` — and the four
+  browser-only door verbs `v/mount`, `v/unmount!`, `v/->react`,
+  `v/active-connections` and `v/command-log`.
+
+  ## How the browser-only half is covered
+
+  Five of those names are `#?(:cljs …)` on the door — absent on the JVM by
+  design, as `debugging.md` says of the last two. A JVM fixture cannot
+  reference them at all, so they are covered twice over from one place:
+
+  - each sample is transcribed into a reader-conditional wrapper, so the
+    ClojureScript build compiles the guide's exact call; and
+  - `the-browser-only-door-verbs-are-present` asserts each one is a live
+    function at run time, which is what actually REDS when one is renamed —
+    a missing CLJS var is a warning at compile and `undefined` at run time,
+    and only the second is a failing gate.
+
+  A sample that needs a real DOM node, an npm module, or `js/document` is
+  NOT transcribed; those are the roster's declared unexecutable classes.
+
+  Filed under rf2-qwsmv."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.core :as rf]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.test :as t]
+            [re-frame.freehand.web :as web]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+;; ---------------------------------------------------------------------------
+;; accessibility.md
+;; ---------------------------------------------------------------------------
+
+(v/defview icon-cart [_] [:i.icon-cart])
+
+;; accessibility.md block 1 — the icon-only button, and the accessible name
+;; that fixes it.
+(def a11y-cart-buttons
+  [;; bad — icon-only, no name
+   [:button {:on-click [:cart/open]} [icon-cart {}]]
+
+   ;; good — visible text or aria-label
+   [:button {:on-click [:cart/open]
+             :aria-label "Open cart"}
+    [icon-cart {}]]])
+
+;; ---------------------------------------------------------------------------
+;; presence.md / js-libraries.md — enter and exit retention
+;; ---------------------------------------------------------------------------
+
+;; accessibility.md block 2, presence.md block 5 — a presence-aware child
+;; owns its own exit styling and accessibility.
+(v/defview toast-card [{:keys [toast]}]
+  (let [exiting? (= :unmounting (v/presence-phase))]
+    [:div.toast {:class       (when exiting? "toast--exit")
+                 :inert       (when exiting? true)
+                 :aria-hidden (when exiting? true)}
+     (:message toast)]))
+
+;; presence.md block 4 — the same read, spelled as a `case`.
+(v/defview toast-card-case [{:keys [toast]}]
+  (case (v/presence-phase)
+    :unmounting [:div.toast.toast--exit {:inert true} (:message toast)]
+    [:div.toast (:message toast)]))
+
+;; presence.md block 2, js-libraries.md block 1 — the boundary, with its
+;; MANDATORY terminal bound.
+(v/defview toast-tray [_]
+  (v/presence {:timeout-ms 300}
+    (for [t (v/sub [:toasts/visible])]
+      [toast-card {:key (:id t) :toast t}])))
+
+;; ---------------------------------------------------------------------------
+;; host-boundaries.md — behaviors, commands, client-only, error boundaries
+;; ---------------------------------------------------------------------------
+
+(defn- fit!
+  "The page names this helper without showing it — measuring and resizing a
+  textarea is the application's host work, not the substrate's."
+  [_node _config]
+  nil)
+
+;; host-boundaries.md block 3 — the ONE sanctioned way to own a DOM node,
+;; and the use site that attaches it as data.
+(v/defbehavior autosize
+  "Grow the textarea to fit its content."
+  {:timing     :layout
+   :connect    (fn [{:keys [node config]}] (fit! node config))
+   :update     (fn [{:keys [node config]}] (fit! node config))
+   :disconnect (fn [{:keys [memory]}] (some-> memory .disconnect))
+   :commands   {:refit (fn [{:keys [node config]}] (fit! node config))}})
+
+(v/defview composer [{:keys [draft]}]
+  [v/behavior {:use    autosize
+               :target :composer/body
+               :config {:max-rows 8}}
+   [:textarea.composer {:value draft :on-input [:composer/typed ::v/value]}]])
+
+;; host-boundaries.md block 4 — a command reaches a connection through an
+;; ordinary effect, addressed by the semantic `:target`.
+(defn register-refit-requested!
+  []
+  (rf/reg-event :composer/refit-requested
+    (fn [_ _]
+      {:fx [[:re-frame.freehand.host/command
+             {:target :composer/body :op :refit}]]})))
+
+(v/defview chart-host [{:keys [spec]}]
+  [:div.chart {:data-spec (str spec)}])
+
+;; host-boundaries.md block 2 — a browser-only subtree, and the
+;; capability-free markup that stands in for it everywhere else.
+(v/defview chart-client-only [{:keys [spec]}]
+  (v/client-only
+   {:fallback [:div.chart-placeholder "Chart loads in the browser"]}
+   [chart-host {:spec spec}]))
+
+;; host-boundaries.md block 6 — the DOM top layer: desired OPEN state, with
+;; the `::web/` qualification that says these are browser facts.
+(v/defview top-layer-sites [{:keys [open? on-open-change]}]
+  [:<>
+   [:div {:popover :auto
+          ::web/popover-open? open?
+          :on-toggle
+          (v/event [e]
+            (conj on-open-change (= "open" (.-newState e))))}]
+
+   [:dialog {::web/modal-open? open?
+             :on-cancel [:dialog/cancelled]}]])
+
+(v/defview broken-page [_] [:p.broken "Something went wrong"])
+(v/defview workspace-page [{:keys [workspace-id]}]
+  [:main.workspace (str "workspace " workspace-id)])
+
+;; host-boundaries.md block 7 — the boundary, its reset key, and the bounded
+;; diagnostic that leaves by `:on-error`.
+(v/defview workspace-error-boundary [{:keys [route-revision workspace-id]}]
+  [v/error-boundary
+   {:reset-key route-revision
+    :fallback  [broken-page {}]
+    :on-error  [:telemetry/ui-render-failed]}
+   [workspace-page {:workspace-id workspace-id}]])
+
+;; host-boundaries.md block 8 — prefer the platform; reach for a behavior
+;; only when you must call the node.
+(v/defview autofocus-input [_]
+  ;; Often enough — platform autofocus when the node mounts with the tree
+  [:input {:value (v/sub [:rename/draft])
+           :auto-focus true
+           :on-input [:rename/drafted ::v/value]}])
+
+;; When you must call .focus() after connect — an ordinary registered behavior
+(v/defbehavior focus-on-connect
+  {:connect (fn [{:keys [node]}] (.focus node) nil)})
+
+(v/defview rename-field [{:keys [draft]}]
+  [v/behavior {:use focus-on-connect}
+   [:input {:value draft
+            :on-input [:rename/drafted ::v/value]}]])
+
+;; ---------------------------------------------------------------------------
+;; js-libraries.md — a behavior is the animation seam too
+;; ---------------------------------------------------------------------------
+
+(defn- start-fade! [_node _config] {:handle :fade})
+(defn- retarget-fade! [_node _config _prev _memory] {:handle :fade})
+(defn- cancel! [_handle] nil)
+
+;; js-libraries.md block 5 — every lifecycle entry takes ONE context map,
+;; and `:update` runs only when `:config` moves by `rf=`.
+(v/defbehavior fade-panel
+  {:connect    (fn [{:keys [node config]}]
+                 ;; return value becomes this connection's private memory
+                 {:anim (start-fade! node config)})
+   :update     (fn [{:keys [node config prev-config memory]}]
+                 ;; runs only when :config moved by rf=
+                 (retarget-fade! node config prev-config memory))
+   :disconnect (fn [{:keys [memory]}]
+                 (some-> (:anim memory) cancel!))})
+
+(v/defview animated-panel [{:keys [title]}]
+  (let [open? (v/sub [:ui/panel-open?])]
+    [v/behavior {:use    fade-panel
+                 :target :ui/fade-panel
+                 :config {:open? open? :duration-ms 280}}
+     [:div.panel
+      [:h2 title]
+      (when open? [:div.body "…"])]]))
+
+;; ---------------------------------------------------------------------------
+;; ssr.md
+;; ---------------------------------------------------------------------------
+
+;; ssr.md block 1 — the same boundary, reading its spec from a subscription.
+(v/defview chart-client-only-sub [_]
+  (v/client-only
+   {:fallback [:div.chart-placeholder "Chart available after load"]}
+   [chart-host {:spec (v/sub [:chart/spec])}]))
+
+;; ssr.md block 4 — a real anchor, so copy-link and open-in-new-tab work.
+(v/defview article-route-link [{:keys [slug title]}]
+  [v/route-link {:to :article :params {:slug slug} :class "title"}
+   title])
+
+;; ---------------------------------------------------------------------------
+;; The browser-only half of the door
+;; ---------------------------------------------------------------------------
+;;
+;; `v/mount`, `v/unmount!`, `v/->react`, `v/active-connections` and
+;; `v/command-log` are `#?(:cljs …)` on the door. Each wrapper below is the
+;; guide's own call, reader-conditionalised so the ClojureScript build
+;; compiles it and the JVM build simply does not see it.
+
+(v/defview counter-placeholder [_] [:p "counter"])
+(v/defview app-root [_] [:main [counter-placeholder {}]])
+(v/defview panel [{:keys [side]}] [:section.panel (str side)])
+(v/defview panel-a [_] [:section.a])
+(v/defview panel-b [_] [:section.b])
+(v/defview person-cell [{:keys [person-id]}] [:td (str person-id)])
+
+;; install.md block 3 — total teardown of a root.
+(defn unmount-root!
+  [root]
+  #?(:cljs (v/unmount! root)
+     :clj  ::browser-only))
+
+;; install.md block 4 — two roots on one page, each claiming its identity a
+;; different way.
+(defn mount-panels!
+  [left right]
+  #?(:cljs (do (v/mount [panel {:side :left}]  left  {:disambiguator :left})
+               (v/mount [panel {:side :right}] right {:root-id :shop/right}))
+     :clj  ::browser-only))
+
+;; ssr.md block 3 — an illustrative multi-root: same frame, two containers.
+(defn mount-two-roots!
+  [left-el right-el f]
+  #?(:cljs (do (v/mount [panel-a {}] left-el  {:root-id :panel/left  :frame f})
+               (v/mount [panel-b {}] right-el {:root-id :panel/right :frame f}))
+     :clj  ::browser-only))
+
+;; adoption.md block 1, mental-model.md block 10 — the outward React bridge:
+;; a Freehand view handed to a foreign parent as a component.
+(defn person-cell-renderer-props
+  []
+  #?(:cljs {:cellRenderer (v/->react person-cell)}
+     :clj  ::browser-only))
+
+;; host-boundaries.md block 5 — the same bridge, plus the ONE named
+;; projection a foreign parameter object earns.
+(defn person-cell-react
+  []
+  #?(:cljs (v/->react person-cell)
+     :clj  ::browser-only))
+
+(defn cell-props [params]
+  #?(:cljs {:person-id (.. params -data -id)
+            :column-id (.. params -column getColId)}
+     :clj  {:person-id (:id params)}))
+
+(defn person-cell-mapped
+  []
+  #?(:cljs (v/->react person-cell {:map-props cell-props})
+     :clj  ::browser-only))
+
+;; debugging.md block 3 — every live connection, oldest first.
+(defn active-connections-read
+  []
+  #?(:cljs (v/active-connections)
+     :clj  ::browser-only))
+
+;; debugging.md block 4 — recent command traffic as a bounded window.
+(defn command-log-read
+  []
+  #?(:cljs (v/command-log)
+     :clj  ::browser-only))
+
+;; ---------------------------------------------------------------------------
+;; The samples, executed
+;; ---------------------------------------------------------------------------
+
+(defn- seed!
+  [db]
+  (rf/reg-sub :toasts/visible (fn [d _] (:toasts d)))
+  (rf/reg-sub :rename/draft (fn [d _] (:draft d)))
+  (rf/reg-sub :ui/panel-open? (fn [d _] (:panel-open? d)))
+  (rf/reg-sub :chart/spec (fn [d _] (:spec d)))
+  (rf/dispatch-sync [:rf/set-db db]))
+
+(deftest an-accessible-name-is-an-ordinary-attribute
+  (testing "accessibility.md block 1 — the fix is a prop, not a mechanism."
+    (let [[bad good] (mapv t/render a11y-cart-buttons)]
+      (is (nil? (:aria-label (t/attrs (t/find bad #(= :button (:tag %)))))))
+      (is (= "Open cart"
+             (:aria-label (t/attrs (t/find good #(= :button (:tag %))))))))))
+
+(deftest presence-phase-reads-present-outside-a-boundary
+  (testing "presence.md's reusability claim — a presence-aware child renders
+            anywhere, and the JVM structural render always yields :present,
+            so the exit class and `inert` are absent here."
+    (let [tree (t/render [toast-card {:toast {:id 1 :message "saved"}}])
+          div  (t/find tree #(= :div (:tag %)))]
+      (is (= "saved" (t/text div)))
+      (is (nil? (:inert (t/attrs div))) "not exiting — no inert")
+      (is (nil? (:aria-hidden (t/attrs div)))))
+    (is (= "saved" (t/text (t/render [toast-card-case {:toast {:message "saved"}}])))
+        "the `case` spelling reads the same phase")))
+
+(deftest a-presence-boundary-inserts-no-wrapper-node
+  (testing "presence.md — the boundary is DOM-agnostic: keyed children, no
+            wrapper element, no stamped attributes."
+    (seed! {:toasts [{:id 1 :message "one"} {:id 2 :message "two"}]})
+    (let [tree (t/with-render (t/render [toast-tray {}]))]
+      (is (= ["one" "two"]
+             (mapv t/text (t/find-all tree #(= :div (:tag %)))))
+          "both children render, in first-appearance order"))))
+
+(deftest a-behavior-is-an-inert-marker-on-the-jvm
+  (testing "host-boundaries.md block 3 — the use site records the behavior
+            id, the target and the public config as DATA; the code stays in
+            the registry, and the JVM connects nothing."
+    (is (= ::autosize autosize)
+        "the var holds the REGISTERED ID, not the implementation")
+    (let [tree (t/render [composer {:draft "hello"}])
+          node (t/find tree #(= :textarea (:tag %)))]
+      (is (= "hello" (:value (t/attrs node)))
+          "the decorated element renders as itself")
+      (is (some? (t/find tree #(= ::autosize (:use (:props %)))))
+          "and the boundary records the behavior id in the tree"))))
+
+(deftest client-only-renders-its-mandatory-fallback-on-the-structural-host
+  (testing "host-boundaries.md block 2 and ssr.md block 1 — the structural
+            render is `:server` phase, so it produces the fallback and never
+            enters the client subtree."
+    (let [tree (t/render [chart-client-only {:spec {:kind :line}}])]
+      (is (= "Chart loads in the browser" (t/text tree)))
+      (is (nil? (t/find tree #(= :data-spec (:tag %))))))
+    (seed! {:spec {:kind :bar}})
+    (is (= "Chart available after load"
+           (t/text (t/with-render (t/render [chart-client-only-sub {}])))))))
+
+(deftest the-error-boundary-guards-a-child-and-carries-a-reset-key
+  (testing "host-boundaries.md block 7 — the guarded child arrives as
+            children, and the options roster is closed."
+    (let [tree (t/render [workspace-error-boundary {:route-revision 3
+                                                    :workspace-id 42}])]
+      (is (= "workspace 42" (t/text tree))
+          "the guarded child renders when nothing has failed"))))
+
+(deftest the-top-layer-keys-are-qualified-browser-facts
+  (testing "host-boundaries.md block 6 — `::web/` says, at the use site,
+            that these are DOM-platform desired state and not neutral
+            substrate grammar."
+    (let [tree (t/render [top-layer-sites {:open? true
+                                           :on-open-change [:menu/open-changed]}])
+          div  (t/find tree #(= :div (:tag %)))
+          dlg  (t/find tree #(= :dialog (:tag %)))]
+      (is (= "auto" (:popover (t/attrs div)))
+          "the platform attribute rides as an ordinary attribute")
+      (is (= {:popover-open? true} (:rf.ui/top-layer div))
+          "and the desired-state key lands on the node's own top-layer
+           field, unqualified there because the node schema owns the plane")
+      (is (= {:modal-open? true} (:rf.ui/top-layer dlg)))
+      (is (= [:dialog/cancelled] (:on-cancel (t/attrs dlg)))))))
+
+(deftest route-link-is-a-declared-view-like-any-other
+  (testing "ssr.md block 4 — a framework-supplied view is not a privileged
+            one; it holds the same descriptor an application's does."
+    (is (v/view? v/route-link))
+    (is (v/view? article-route-link))))
+
+#?(:cljs
+   (deftest the-browser-only-door-verbs-are-present
+     (testing "install.md, ssr.md, adoption.md, host-boundaries.md and
+               debugging.md all call door verbs that exist only in
+               ClojureScript. This is the assertion that REDS when one is
+               renamed — a missing CLJS var compiles to `undefined`, so
+               only a run-time check catches it."
+       (is (fn? v/mount)              "v/mount — install.md, ssr.md, build-a-view.md")
+       (is (fn? v/unmount!)           "v/unmount! — install.md, ssr.md")
+       (is (fn? v/->react)            "v/->react — adoption.md, host-boundaries.md")
+       (is (fn? v/active-connections) "v/active-connections — debugging.md")
+       (is (fn? v/command-log)        "v/command-log — debugging.md"))))
+
+#?(:cljs
+   (deftest the-two-tool-plane-reads-answer-collections
+     (testing "debugging.md blocks 3 and 4 — both are ordinary reads that
+               answer a value; neither is an event stream."
+       (is (sequential? (active-connections-read)))
+       (is (sequential? (command-log-read))))))

--- a/implementation/freehand/test/re_frame/freehand/guide/host_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/guide/host_cljs_test.cljc
@@ -306,26 +306,36 @@
       (is (= "Open cart"
              (:aria-label (t/attrs (t/find good #(= :button (:tag %))))))))))
 
-(deftest presence-phase-reads-present-outside-a-boundary
-  (testing "presence.md's reusability claim — a presence-aware child renders
-            anywhere, and the JVM structural render always yields :present,
-            so the exit class and `inert` are absent here."
-    (let [tree (t/render [toast-card {:toast {:id 1 :message "saved"}}])
-          div  (t/find tree #(= :div (:tag %)))]
-      (is (= "saved" (t/text div)))
-      (is (nil? (:inert (t/attrs div))) "not exiting — no inert")
-      (is (nil? (:aria-hidden (t/attrs div)))))
-    (is (= "saved" (t/text (t/render [toast-card-case {:toast {:message "saved"}}])))
-        "the `case` spelling reads the same phase")))
+;; The next two are JVM-only ASSERTIONS, and the declarations above are not:
+;; `toast-card`, `toast-card-case` and `toast-tray` compile on both hosts, so a
+;; rename of `v/presence` or `v/presence-phase` reds in ClojureScript exactly as
+;; it does here. What does not cross is the structural RENDER of a view that
+;; reads the phase: `presence-phase` is `react/useContext` on ClojureScript, and
+;; `t/render` opens no React render, so the read throws "Invalid hook call"
+;; outside a mounted tree. The JVM arm answers `:present` unconditionally, which
+;; is the behaviour `presence.md` describes. Filed as rf2-erqin.
+#?(:clj
+   (deftest presence-phase-reads-present-outside-a-boundary
+     (testing "presence.md's reusability claim — a presence-aware child renders
+               anywhere, and the JVM structural render always yields :present,
+               so the exit class and `inert` are absent here."
+       (let [tree (t/render [toast-card {:toast {:id 1 :message "saved"}}])
+             div  (t/find tree #(= :div (:tag %)))]
+         (is (= "saved" (t/text div)))
+         (is (nil? (:inert (t/attrs div))) "not exiting — no inert")
+         (is (nil? (:aria-hidden (t/attrs div)))))
+       (is (= "saved" (t/text (t/render [toast-card-case {:toast {:message "saved"}}])))
+           "the `case` spelling reads the same phase"))))
 
-(deftest a-presence-boundary-inserts-no-wrapper-node
-  (testing "presence.md — the boundary is DOM-agnostic: keyed children, no
-            wrapper element, no stamped attributes."
-    (seed! {:toasts [{:id 1 :message "one"} {:id 2 :message "two"}]})
-    (let [tree (t/with-render (t/render [toast-tray {}]))]
-      (is (= ["one" "two"]
-             (mapv t/text (t/find-all tree #(= :div (:tag %)))))
-          "both children render, in first-appearance order"))))
+#?(:clj
+   (deftest a-presence-boundary-inserts-no-wrapper-node
+     (testing "presence.md — the boundary is DOM-agnostic: keyed children, no
+               wrapper element, no stamped attributes."
+       (seed! {:toasts [{:id 1 :message "one"} {:id 2 :message "two"}]})
+       (let [tree (t/with-render (t/render [toast-tray {}]))]
+         (is (= ["one" "two"]
+                (mapv t/text (t/find-all tree #(= :div (:tag %)))))
+             "both children render, in first-appearance order")))))
 
 (deftest a-behavior-is-an-inert-marker-on-the-jvm
   (testing "host-boundaries.md block 3 — the use site records the behavior

--- a/implementation/freehand/test/re_frame/freehand/guide/samples_coverage_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/guide/samples_coverage_jvm_test.clj
@@ -1,0 +1,512 @@
+(ns re-frame.freehand.guide.samples-coverage-jvm-test
+  "The ONE coverage check that keeps `docs/core/freehand/` and the guide
+  fixtures beside it honest.
+
+  ## Why this exists
+
+  The Freehand guide is written against a door that is deliberately NOT
+  frozen. Every sample it prints is a claim about a spelling — `v/sub`,
+  `::v/value`, `v/spread-safe`, `t/with-render` — and prose cannot notice
+  when one of those moves. The fixture namespaces under
+  `re-frame.freehand.guide.*` fix that half: they transcribe the samples
+  onto the real classpath, so a renamed verb is a compile failure.
+
+  This namespace fixes the OTHER half, which fixtures alone cannot: the
+  relationship between a page and the fixture that proves it. Without it,
+  a sample added to the guide is covered by nothing and nobody notices, and
+  a sample EDITED in the guide leaves its fixture proving the old spelling
+  while the page teaches the new one. Both are silent, and both are exactly
+  the staleness rf2-qwsmv exists to end.
+
+  ## The rule, and why it is this one
+
+  **Every fenced block in `docs/core/freehand/` carries a roster row naming
+  either the fixture var that proves it or the reason it cannot be run, and
+  the row pins a digest of the block's exact text.**
+
+  Three consequences, which are the whole point:
+
+  - **Adding a sample reds.** A new block has no row, so the roster and the
+    corpus disagree and the run fails naming the page and the ordinal. The
+    author must either point it at a fixture or state a reason.
+  - **Editing a sample reds.** The digest is over the block's text, so any
+    change to it — code or the `;; =>` commentary that states an expected
+    value — forces a look at the fixture that claims to prove it. The
+    digest is deliberately NOT normalised past line endings and trailing
+    whitespace: a comment inside a sample often carries the claim (see
+    `events-and-handlers.md`'s projection roster), and a rule that ignored
+    comments would ignore those.
+  - **Deleting a fixture reds.** Each row's symbol is resolved, so a
+    fixture var that is renamed or removed fails here even when nothing
+    else references it.
+
+  The check is deliberately NOT a markdown interpreter. It does not parse,
+  evaluate, or understand a single line of Clojure in the guide — it splits
+  on fences, hashes bytes, and compares two sets. Executing a sample is the
+  fixtures' job, and this namespace never tries to do it for them. That
+  boundary is what keeps the mechanism cheap enough to be trusted.
+
+  ## The unexecutable classes
+
+  A sample earns a reason keyword only from [[unexecutable-reasons]], which
+  is closed. Anything genuinely runnable belongs to a fixture, and the
+  reasons are for the classes that have no JVM or node counterpart at all:
+  a CSS or ASCII-diagram fence, an illustrative data shape, a consumer's
+  `ns` form naming an adapter artefact this one does not depend on, a boot
+  function that needs `js/document`, an npm import, or a `deps.edn` /
+  `shadow-cljs.edn` fragment.
+
+  ## Extending the guide
+
+  Add the page's block, run this suite, and paste the row it prints. That is
+  the whole workflow, and it is one line per sample.
+
+  Filed under rf2-qwsmv."
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]])
+  (:import [java.security MessageDigest]))
+
+;; ---------------------------------------------------------------------------
+;; Locating the corpus
+;; ---------------------------------------------------------------------------
+
+(defn- repo-root
+  "The repository root, found by walking up for the `AGENTS.md` marker
+  rather than by a hardcoded relative path — this suite runs from
+  `implementation/freehand` locally and from the repo root in CI."
+  []
+  (or (some (fn [candidate]
+              (let [root (.getCanonicalFile (io/file candidate))]
+                (when (.isFile (io/file root "AGENTS.md"))
+                  root)))
+            (take 6 (iterate #(io/file % "..") (io/file "."))))
+      (throw (ex-info "Could not locate repository root" {}))))
+
+(def ^:private guide-dir "docs/core/freehand")
+
+;; ---------------------------------------------------------------------------
+;; Splitting a page into blocks, and digesting one
+;; ---------------------------------------------------------------------------
+
+(defn- sha12
+  "The first 12 hex digits of the SHA-256 of `s` — short enough to read in
+  a diff, long enough that a collision is not a thing that happens."
+  [^String s]
+  (let [d (.digest (MessageDigest/getInstance "SHA-256")
+                   (.getBytes s "UTF-8"))]
+    (apply str (map #(format "%02x" %) (take 6 d)))))
+
+(defn- normalise
+  "Line endings and trailing whitespace only. A `.md` checked out with CRLF
+  on Windows and LF on Linux is the same sample, and an editor stripping a
+  trailing space did not change what the page teaches. NOTHING else is
+  normalised — see the rule in this namespace's docstring."
+  [lines]
+  (->> lines
+       (map str/trimr)
+       (reverse)
+       (drop-while str/blank?)
+       (reverse)
+       (str/join "\n")))
+
+(defn blocks
+  "Every fenced block in `text`, in document order, as
+  `[{:n ordinal :digest … :lang … :first-line …}]`.
+
+  A fence is a line opening with three backticks; the block runs to the
+  next such line. That is the whole parser."
+  [text]
+  (let [lines (vec (str/split (str/replace text "\r\n" "\n") #"\n" -1))
+        fence? #(str/starts-with? ^String % "```")]
+    (loop [i 0, n 0, acc []]
+      (cond
+        (>= i (count lines)) acc
+
+        (not (fence? (nth lines i))) (recur (inc i) n acc)
+
+        :else
+        (let [lang  (str/trim (subs (nth lines i) 3))
+              close (or (first (keep-indexed #(when (fence? %2) (+ i 1 %1))
+                                             (subvec lines (inc i))))
+                        (count lines))
+              body  (subvec lines (inc i) close)]
+          (recur (inc close)
+                 (inc n)
+                 (conj acc {:n          (inc n)
+                            :lang       (if (str/blank? lang) "none" lang)
+                            :digest     (sha12 (normalise body))
+                            :first-line (first (remove str/blank? body))})))))))
+
+(defn corpus
+  "`{page-filename [block …]}` for every `.md` page in the guide."
+  []
+  (let [dir (io/file (repo-root) guide-dir)]
+    (into (sorted-map)
+          (for [^java.io.File f (sort-by #(.getName ^java.io.File %) (.listFiles dir))
+                :when (str/ends-with? (.getName f) ".md")]
+            [(.getName f) (blocks (slurp f))]))))
+
+;; ---------------------------------------------------------------------------
+;; What a row may say
+;; ---------------------------------------------------------------------------
+
+(def ^:private fixture-namespaces
+  "The chapter fixture namespaces, by the short alias the roster uses. This
+  map is also the CLOSED set of namespaces a row may name: a roster row
+  pointing anywhere else is rejected, so coverage cannot quietly be claimed
+  by some unrelated suite that happens to mention a verb."
+  '{first-view  re-frame.freehand.guide.first-view-cljs-test
+    composition re-frame.freehand.guide.composition-cljs-test
+    events      re-frame.freehand.guide.events-cljs-test
+    controllers re-frame.freehand.guide.controllers-cljs-test
+    compilation re-frame.freehand.guide.compilation-cljs-test
+    host        re-frame.freehand.guide.host-cljs-test
+    testing     re-frame.freehand.guide.testing-cljs-test})
+
+(def ^:private unexecutable-reasons
+  "The CLOSED set of reasons a fenced block may carry instead of a fixture.
+  Each names a class with no JVM or node counterpart — not a class that is
+  merely inconvenient, which is what keeps the set from growing into an
+  excuse column."
+  {:non-clojure   "a CSS or ASCII-diagram fence — not Clojure at all"
+   :prose-shape   "an illustrative data shape (an app-db slice, a build
+                   diagnostic) with no verb in it to move"
+   :app-scaffold  "a consumer `ns` form or full application listing naming
+                   an adapter artefact this one takes no dependency on"
+   :host-boot     "a boot function needing a real `js/document` container"
+   :foreign-npm   "an `ns` requiring an npm module that is on no classpath
+                   here"
+   :build-config  "a `deps.edn` / `shadow-cljs.edn` fragment"})
+
+;; ---------------------------------------------------------------------------
+;; Comparing the roster against the corpus
+;; ---------------------------------------------------------------------------
+
+(defn- row-str
+  [page [n digest by]]
+  (format "%s block %d  →  [%2d \"%s\" %s]" page n n digest by))
+
+(defn roster-drift
+  "The pure comparison, so it can be fed synthetic input by
+  [[the-check-has-teeth]]. Answers a map of problem-kind → seq of
+  human-readable lines; an empty map means the roster and the corpus agree.
+
+  Kept total and data-in/data-out deliberately: a gate whose own logic
+  cannot be exercised is a gate nobody can trust to fail."
+  [corpus roster]
+  (let [pages    (set (concat (keys corpus) (keys roster)))
+        problems (for [page (sort pages)
+                       :let [found (vec (get corpus page))
+                             rows  (vec (get roster page))]
+                       problem
+                       (concat
+                         (when-not (contains? corpus page)
+                           [[:unknown-page (str page " — the roster names a page that is not in "
+                                                guide-dir)]])
+                         (when-not (contains? roster page)
+                           [[:unrostered-page (str page " — a guide page with no roster entry")]])
+                         (when (and (contains? corpus page) (contains? roster page))
+                           (concat
+                             (when (not= (count found) (count rows))
+                               [[:count (format "%s — %d fenced blocks on the page, %d roster rows"
+                                                page (count found) (count rows))]])
+                             (for [[block row] (map vector found rows)
+                                   :when (not= (:digest block) (second row))]
+                               [:digest (format "%s block %d has changed — paste [%2d \"%s\" %s] (was \"%s\"); first line: %s"
+                                                page (:n block) (:n block) (:digest block)
+                                                (nth row 2) (second row)
+                                                (pr-str (:first-line block)))])
+                             (for [block (drop (count rows) found)]
+                               [:unowned (format "%s block %d has no roster row — first line: %s"
+                                                 page (:n block) (pr-str (:first-line block)))])
+                             (for [row (drop (count found) rows)]
+                               [:stale (str "roster row for a block that is gone — " (row-str page row))])))) ]
+                   problem)]
+    (reduce (fn [m [k line]] (update m k (fnil conj []) line)) {} problems)))
+
+;; ---------------------------------------------------------------------------
+;; The roster
+;; ---------------------------------------------------------------------------
+;;
+;; `page → [[block-ordinal digest owner] …]`, block ordinals in document
+;; order. `owner` is either `alias/var-name` — the fixture that proves the
+;; block, resolved through `fixture-namespaces` — or one of
+;; `unexecutable-reasons`.
+;;
+;; One block, one row, one owner. Several blocks may name the SAME fixture
+;; var: the guide repeats its `toast-card` on three pages and its `panel` on
+;; two, and a fixture that already proves the spelling proves it again.
+;;
+;; Where a block declares more than one var, the row names the one carrying
+;; the block's claim — usually its first declaration. Where the block is a
+;; bare markup fragment, the row names the one-line `v/defview` that hosts
+;; it. Both conventions are stated in the fixture namespaces themselves.
+
+(def ^:private roster
+  '{
+   "accessibility.md"
+   [[ 1 "cf922cd60399" host/a11y-cart-buttons]
+    [ 2 "168c79423b66" host/toast-card]]
+   "adoption.md"
+   [[ 1 "465c90a78f6e" host/person-cell-renderer-props]]
+   "build-a-view.md"
+   [[ 1 "943078a18a20" :app-scaffold]
+    [ 2 "1ffd888b3d3f" first-view/register-counter-dataflow!]
+    [ 3 "d2d23ba805b8" first-view/counter-v1]
+    [ 4 "c7ca85a039f7" first-view/counter-v2]
+    [ 5 "e848116f474a" first-view/counter-v3]
+    [ 6 "c7ecf21136ef" first-view/note-row]
+    [ 7 "08cf75dd886e" :host-boot]
+    [ 8 "2736f15805d1" :app-scaffold]]
+   "compilation.md"
+   [[ 1 "2ed0def9d890" compilation/people-list-promotion-recipe]
+    [ 2 "0e709b251a18" compilation/todo-row-compiled]
+    [ 3 "441eba0cabf9" :prose-shape]
+    [ 4 "baf0226b671c" compilation/people-list-interpreted]
+    [ 5 "8ed7b69a0185" compilation/item-row]
+    [ 6 "63ff086fcdd5" compilation/field-help]
+    [ 7 "0eb044ab4a85" compilation/markup-child]
+    [ 8 "d03e66cc655d" compilation/data-table-compiled]
+    [ 9 "ab5df8171160" compilation/todo-row-with-props-schema]]
+   "composition.md"
+   [[ 1 "6e08b04edd36" composition/panel]
+    [ 2 "f1f241908c1f" composition/icon-button]
+    [ 3 "04fc59833fc3" composition/card]
+    [ 4 "1a6b78ff632e" composition/disclosure]
+    [ 5 "80cf85b09bce" composition/data-table]
+    [ 6 "2de09c0bef52" composition/person-row]
+    [ 7 "f01963c823bb" composition/todo-list]
+    [ 8 "b90b69b28756" composition/spread-forms]
+    [ 9 "2e9534754389" composition/field]
+    [10 "d885456ac680" composition/date-field]
+    [11 "7ca003669260" :non-clojure]
+    [12 "143ffc47edc9" composition/field]
+    [13 "5741c8ca53dc" composition/field-call-with-parts]
+    [14 "538ba8b3f20d" :prose-shape]]
+   "debugging.md"
+   [[ 1 "edafd4232c9e" compilation/describe-projects-exactly-the-keys-the-page-prints]
+    [ 2 "1e6adbe055e5" compilation/manifest-is-nil-for-interpreted-and-names-its-crossings-when-compiled]
+    [ 3 "6a368565f741" host/active-connections-read]
+    [ 4 "69279406eee9" host/command-log-read]]
+   "events-and-handlers.md"
+   [[ 1 "603f633abe5a" events/add-to-cart-button]
+    [ 2 "987032f4a387" events/projection-marker-sites]
+    [ 3 "ce57d8c6132c" events/the-named-projection-roster-is-the-five-the-page-lists]
+    [ 4 "6190439f02be" events/general-read-sites]
+    [ 5 "32a862906cbe" events/submit-options-map]
+    [ 6 "a23aaa2dace6" events/key-pressed-site]
+    [ 7 "3a02de0cc196" events/key-branch-site]
+    [ 8 "782b6e3d7e3a" events/controlled-email-field]
+    [ 9 "61dc3b641bbb" events/live-domain-field]
+    [10 "6f9f23aedc3a" events/draft-then-commit-field]
+    [11 "73ff51badb9b" events/register-draft-key-handler!]
+    [12 "59a361023b4c" events/uncontrolled-cell-input]
+    [13 "f4c566df3500" events/icon-button]
+    [14 "f1487c436d64" events/text-field]]
+   "forms.md"
+   [[ 1 "76b9d90f3f40" :prose-shape]
+    [ 2 "b79d37ae76c4" events/email-field]
+    [ 3 "a6379d0556c8" events/register-field-error-sub!]
+    [ 4 "d6209ce60e2d" events/register-article-loaded!]
+    [ 5 "9654384295ab" events/register-editor-submit!]
+    [ 6 "5ec85f9349ea" events/editor-actions]
+    [ 7 "cf8ffa56a3d3" events/register-temperature-dataflow!]
+    [ 8 "67c6b1269513" events/temperature-inputs]
+    [ 9 "a166f137df6a" :prose-shape]]
+   "host-boundaries.md"
+   [[ 1 "1188cc22d0f4" :foreign-npm]
+    [ 2 "1fc6ecc0cd84" host/chart-client-only]
+    [ 3 "8bf62d0dddd5" host/autosize]
+    [ 4 "7fc18b64ff4c" host/register-refit-requested!]
+    [ 5 "5f2b2ed14f93" host/person-cell-react]
+    [ 6 "61e4193ba86b" host/top-layer-sites]
+    [ 7 "df50f54e87dd" host/workspace-error-boundary]
+    [ 8 "3ec49de3e0d3" host/autofocus-input]]
+   "index.md"
+   [[ 1 "c00fd3636ace" first-view/cart-badge]
+    [ 2 "5eca60041a06" :non-clojure]]
+   "install.md"
+   [[ 1 "5bc803547be4" :build-config]
+    [ 2 "9730c941c63b" :app-scaffold]
+    [ 3 "54ad15b06540" host/unmount-root!]
+    [ 4 "0673f40834e8" host/mount-panels!]
+    [ 5 "ea8536be30aa" :build-config]]
+   "js-libraries.md"
+   [[ 1 "c27c0a28d420" host/toast-tray]
+    [ 2 "5bff52a6aa37" :foreign-npm]
+    [ 3 "d68ceeefd07a" :foreign-npm]
+    [ 4 "cd2f51ac304d" :foreign-npm]
+    [ 5 "aa248d525737" host/fade-panel]]
+   "limits-and-escapes.md"
+   []
+   "mental-model.md"
+   [[ 1 "207fd114bc23" first-view/greeting]
+    [ 2 "0618d0abdbe2" first-view/greeting-call]
+    [ 3 "3cf72f2f1362" first-view/invoice]
+    [ 4 "a58a02b83260" compilation/todo-row-compiled]
+    [ 5 "58778e69f919" first-view/count-span]
+    [ 6 "2827bb2ccfc3" first-view/basket-total-once]
+    [ 7 "2d2a7aa15596" first-view/inc-button]
+    [ 8 "b6b64c99bd63" first-view/email-input]
+    [ 9 "e69077c3dbb9" :host-boot]
+    [10 "306c67de7ea3" host/person-cell-renderer-props]]
+   "presence.md"
+   [[ 1 "fcb73466d44d" :non-clojure]
+    [ 2 "c27c0a28d420" host/toast-tray]
+    [ 3 "80e6e0d3305d" :non-clojure]
+    [ 4 "08ba0a5e6fa4" host/toast-card-case]
+    [ 5 "168c79423b66" host/toast-card]]
+   "reactivity-and-ownership.md"
+   [[ 1 "f01963c823bb" composition/todo-list]
+    [ 2 "1b29393aaea1" composition/people-page]]
+   "semantic-controllers.md"
+   [[ 1 "8bdf175ef483" controllers/keymap-field]
+    [ 2 "977f3334fec6" controllers/disclosure]
+    [ 3 "c56fcf222c65" controllers/register-search-dataflow!]
+    [ 4 "c6d982c86ffd" controllers/search-box]
+    [ 5 "f9f6f210d596" :non-clojure]
+    [ 6 "c686e38abce7" :prose-shape]
+    [ 7 "1d2a72ca0224" controllers/buffered-field-call]
+    [ 8 "2f55fd8a5dfd" controllers/line-row-live]
+    [ 9 "50ad6419c733" controllers/line-row-buffered]
+    [10 "0465b1254454" controllers/the-controller-key-is-the-pair-of-kind-and-address]
+    [11 "86f1f8b0a35b" controllers/the-controller-revision-is-the-callers-reset-key]
+    [12 "6c7f63421374" controllers/the-generation-fence-is-total-and-safe-when-the-stamp-is-missing]
+    [13 "dbe82da73aae" controllers/register-acme-buffered-text!]
+    [14 "98155b34ebf3" controllers/buffered-field]]
+   "ssr.md"
+   [[ 1 "7d7c6d77a52d" host/chart-client-only-sub]
+    [ 2 "b0412ac0fb48" :host-boot]
+    [ 3 "dc23499554e7" host/mount-two-roots!]
+    [ 4 "2ae2d5c8a43a" host/article-route-link]]
+   "state.md"
+   [[ 1 "d904aba9124a" composition/order-summary]
+    [ 2 "fc9c3bd71d12" composition/app-root]
+    [ 3 "6e08b04edd36" composition/panel]
+    [ 4 "3cc3502b4ebf" composition/email-controlled-input]
+    [ 5 "096d667e0233" composition/email-draft-input]
+    [ 6 "1d2a72ca0224" controllers/buffered-field-call]]
+   "testing.md"
+   [[ 1 "386f631342f6" testing/add-button-carries-intent]
+    [ 2 "849437c5725e" testing/tree-reading-forms]
+    [ 3 "c082e508ecc6" testing/the-badge-shows-the-basket-count]
+    [ 4 "96e443410112" testing/cart-badge-shows-count-after-add]
+    [ 5 "7d7d9c74abc1" testing/adding-to-the-cart-updates-the-badge]
+    [ 6 "030cd0fec46c" testing/typing-carries-the-text]]
+   "vs-reagent.md"
+   [[ 1 "f97158f9fe1c" first-view/greeting]
+    [ 2 "a087fe4506fc" first-view/count-span-bare]
+    [ 3 "970add7a063f" first-view/inc-button]
+    [ 4 "76bdaa9a72ca" first-view/email-input-vs-reagent]
+    [ 5 "86baf68565fd" first-view/keyed-rows]
+    [ 6 "3d8b88701b0e" first-view/counter-vs-reagent]]
+  })
+
+;; ---------------------------------------------------------------------------
+;; The checks
+;; ---------------------------------------------------------------------------
+
+(deftest every-guide-sample-is-owned-and-unchanged
+  (testing "each fenced block in docs/core/freehand/ carries a roster row,
+            and the row's digest still matches the block's text. A failure
+            here means the guide moved and its proof did not — paste the
+            printed row after checking the fixture still proves the sample."
+    (let [drift (roster-drift (corpus) roster)]
+      (is (= {} drift)
+          (str "\n" (str/join "\n" (mapcat val (sort-by key drift))) "\n")))))
+
+(deftest every-owner-resolves-to-a-fixture-var-or-a-declared-reason
+  (testing "a row names either a var that exists in one of the chapter
+            fixture namespaces, or a reason from the closed set. A renamed
+            or deleted fixture reds here even when nothing else refers to
+            it."
+    (let [bad (for [[page rows] roster
+                    [n _ by]    rows
+                    :let [problem
+                          (cond
+                            (keyword? by)
+                            (when-not (contains? unexecutable-reasons by)
+                              (str "reason " by " is not in the closed set "
+                                   (pr-str (vec (sort (keys unexecutable-reasons))))))
+
+                            (symbol? by)
+                            (let [ns-alias (some-> (namespace by) symbol)
+                                  target   (get fixture-namespaces ns-alias)]
+                              (cond
+                                (nil? ns-alias)
+                                "owner symbol is not namespace-qualified"
+
+                                (nil? target)
+                                (str "unknown fixture alias " ns-alias " — the roster may name only "
+                                     (pr-str (vec (sort (keys fixture-namespaces)))))
+
+                                (nil? (try (requiring-resolve
+                                             (symbol (str target) (name by)))
+                                           (catch Exception e (str "load failed: " (ex-message e)))))
+                                (str "no var " target "/" (name by))))
+
+                            :else "owner is neither a symbol nor a keyword")]
+                    :when problem]
+                (format "%s block %d — %s" page n problem))]
+      (is (= [] (vec bad)) (str "\n" (str/join "\n" bad) "\n")))))
+
+(deftest the-check-has-teeth
+  (testing "a gate that cannot fail is the staleness it was built to end.
+            Every way this check is supposed to red is exercised against
+            synthetic input, so a future simplification that quietly
+            neuters it fails here first."
+    (let [page   "x.md"
+          block  (fn [n d] {:n n :digest d :first-line "(v/sub [:x])"})
+          base   {page [(block 1 "aaaaaaaaaaaa") (block 2 "bbbbbbbbbbbb")]}
+          rows   {page [[1 "aaaaaaaaaaaa" 'host/toast-card]
+                        [2 "bbbbbbbbbbbb" :non-clojure]]}]
+      (is (= {} (roster-drift base rows)) "agreement is silence")
+
+      (testing "an EDITED sample is caught"
+        (is (contains? (roster-drift (assoc base page [(block 1 "cccccccccccc")
+                                                       (block 2 "bbbbbbbbbbbb")])
+                                     rows)
+                       :digest)))
+
+      (testing "an ADDED sample with no row is caught"
+        (let [drift (roster-drift (update base page conj (block 3 "dddddddddddd")) rows)]
+          (is (contains? drift :unowned))
+          (is (contains? drift :count))))
+
+      (testing "a REMOVED sample leaves a stale row, and that is caught"
+        (let [drift (roster-drift (assoc base page [(block 1 "aaaaaaaaaaaa")]) rows)]
+          (is (contains? drift :stale))
+          (is (contains? drift :count))))
+
+      (testing "a WHOLE PAGE added to the guide is caught"
+        (is (contains? (roster-drift (assoc base "new.md" [(block 1 "eeeeeeeeeeee")]) rows)
+                       :unrostered-page)))
+
+      (testing "a whole page REMOVED from the guide is caught"
+        (is (contains? (roster-drift base (assoc rows "gone.md" [[1 "ffffffffffff" :non-clojure]]))
+                       :unknown-page))))
+
+    (testing "and the digest is content-sensitive in the way the rule claims"
+      (let [d #(-> % vector normalise sha12)]
+        (is (not= (d "(v/sub [:x])") (d "(v/subscribe [:x])"))
+            "a moved verb changes the digest")
+        (is (not= (d ";; => #{::v/value}") (d ";; => #{::v/text}"))
+            "so does an expected value stated only in a comment")
+        (is (= (d "(v/sub [:x])  ") (d "(v/sub [:x])"))
+            "trailing whitespace does not")))))
+
+(deftest the-coverage-numbers-are-reported
+  (testing "not an assertion about the count — a census, printed so a
+            reviewer can see at a glance how much of the guide is executed
+            and which classes are deliberately not."
+    (let [rows    (for [[page rows] roster, row rows] [page row])
+          by      (map (comp last second) rows)
+          covered (count (filter symbol? by))
+          reasons (frequencies (filter keyword? by))]
+      (println (format "\nFreehand guide sample coverage: %d of %d fenced blocks"
+                       covered (count rows)))
+      (doseq [[reason n] (sort-by key reasons)]
+        (println (format "  %-14s %2d  %s" reason n
+                         (str/replace (get unexecutable-reasons reason) #"\s+" " "))))
+      (is (pos? covered) "the census found fixtures"))))

--- a/implementation/freehand/test/re_frame/freehand/guide/samples_coverage_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/guide/samples_coverage_jvm_test.clj
@@ -221,7 +221,8 @@
                                [:unowned (format "%s block %d has no roster row — first line: %s"
                                                  page (:n block) (pr-str (:first-line block)))])
                              (for [row (drop (count found) rows)]
-                               [:stale (str "roster row for a block that is gone — " (row-str page row))])))) ]
+                               [:stale (str "roster row for a block that is gone — "
+                                            (row-str page row))]))))]
                    problem)]
     (reduce (fn [m [k line]] (update m k (fnil conj []) line)) {} problems)))
 
@@ -441,10 +442,13 @@
                                 (str "unknown fixture alias " ns-alias " — the roster may name only "
                                      (pr-str (vec (sort (keys fixture-namespaces)))))
 
-                                (nil? (try (requiring-resolve
-                                             (symbol (str target) (name by)))
-                                           (catch Exception e (str "load failed: " (ex-message e)))))
-                                (str "no var " target "/" (name by))))
+                                :else
+                                (let [full (symbol (str target) (name by))
+                                      seen (try {:var (requiring-resolve full)}
+                                                (catch Exception e {:error (ex-message e)}))]
+                                  (cond
+                                    (:error seen) (str "loading " target " failed — " (:error seen))
+                                    (nil? (:var seen)) (str "no var " full)))))
 
                             :else "owner is neither a symbol nor a keyword")]
                     :when problem]

--- a/implementation/freehand/test/re_frame/freehand/guide/samples_coverage_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/guide/samples_coverage_jvm_test.clj
@@ -209,7 +209,7 @@
                          (when (and (contains? corpus page) (contains? roster page))
                            (concat
                              (when (not= (count found) (count rows))
-                               [[:count (format "%s — %d fenced blocks on the page, %d roster rows"
+                               [[:count (format "%s — the page has %d fenced blocks; the roster has %d rows"
                                                 page (count found) (count rows))]])
                              (for [[block row] (map vector found rows)
                                    :when (not= (:digest block) (second row))]

--- a/implementation/freehand/test/re_frame/freehand/guide/testing_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/guide/testing_cljs_test.cljc
@@ -1,0 +1,152 @@
+(ns re-frame.freehand.guide.testing-cljs-test
+  "Executable fixtures for `docs/core/freehand/testing.md`.
+
+  Every fenced block on that page is a test, so this namespace is the one
+  place where transcription is exact: each of the guide's four `deftest`s
+  keeps its own name, its own body and its own assertions, run against real
+  views instead of the page's imaginary `shop.ui`.
+
+  That exactness is worth having. `testing.md` teaches the six names a
+  consumer's whole test suite is written in — `t/render`, `t/find`,
+  `t/find-all`, `t/attrs`, `t/text`, `t/with-render` — plus the two re-frame
+  brackets that scope them. If any of those moves, thousands of consumer
+  tests break, and this namespace is what says so first.
+
+  The one substitution: the page's `shop.ui` namespace does not exist, so
+  the views it names (`add-button`, `basket-badge`, `cart-badge`,
+  `email-field`) are declared here with the bodies the page's assertions
+  imply. Everything else — including the deftest names — is the page's.
+
+  Filed under rf2-qwsmv."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.core :as rf]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.test :as t]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+;; ---------------------------------------------------------------------------
+;; The application under test — the page's `shop.ui`, made real
+;; ---------------------------------------------------------------------------
+
+(v/defview add-button [{:keys [product-id]}]
+  [:button {:on-click [:cart/add product-id]} "Add"])
+
+(v/defview basket-badge [_]
+  [:span (str (v/sub [:basket/count]))])
+
+(v/defview cart-badge [_]
+  [:span (str (v/sub [:cart/count]))])
+
+(v/defview email-field [_]
+  [:input {:value (v/sub [:account/email])
+           :on-input [:account/email-edited ::v/value]}])
+
+(v/defview product-card [{:keys [id]}]
+  [:li.product (str id)])
+
+(v/defview product-list [{:keys [ids]}]
+  [:ul (for [id ids] [product-card {:key id :id id}])])
+
+(defn- register-shop-dataflow!
+  []
+  (rf/reg-event :cart/add
+    (fn [{:keys [db]} [_ id]] {:db (update db :cart (fnil conj #{}) id)}))
+  (rf/reg-event :basket/add
+    (fn [{:keys [db]} [_ id]] {:db (update db :basket (fnil conj #{}) id)}))
+  (rf/reg-sub :cart/count (fn [db _] (count (:cart db))))
+  (rf/reg-sub :basket/count (fn [db _] (count (:basket db))))
+  (rf/reg-sub :account/email (fn [db _] (:email db))))
+
+;; ---------------------------------------------------------------------------
+;; testing.md block 1 — tier 1, the daily driver
+;; ---------------------------------------------------------------------------
+
+(deftest add-button-carries-intent
+  (let [tree   (t/render [add-button {:product-id 42}])
+        button (t/find tree #(= :button (:tag %)))]
+    (is (= "Add" (t/text button)))
+    (is (= [:cart/add 42] (:on-click (t/attrs button))))))
+
+;; ---------------------------------------------------------------------------
+;; testing.md block 2 — reading the tree
+;; ---------------------------------------------------------------------------
+
+(defn tree-reading-forms
+  "The page's three finder spellings — by element tag, by view boundary, and
+  a count over `find-all`. Hosted in a function because the block is three
+  expressions over a `tree` the page left in scope."
+  [tree]
+  [(t/find tree #(= :button (:tag %)))                ; by element tag
+   (t/find tree #(= ::product-card (:view-id %)))     ; by view boundary
+   (count (t/find-all tree #(= :li (:tag %))))])
+
+(deftest the-three-finder-spellings-answer-what-the-page-says
+  (testing "testing.md block 2 — `find` is first-match-or-nil, `find-all` is
+            every match in document order, and a view boundary is found by
+            `:view-id` exactly as an element is found by `:tag`."
+    (let [tree            (t/render [product-list {:ids [1 2 3]}])
+          [button card n] (tree-reading-forms tree)]
+      (is (nil? button) "no button in this tree — find answers nil, not a throw")
+      (is (some? card) "a view boundary is an ordinary node with a :view-id")
+      (is (= 3 n) "find-all counts every match")
+      (is (nil? (t/attrs (t/find tree #(= :never (:tag %)))))
+          "nil threads through a missed match rather than throwing"))))
+
+;; ---------------------------------------------------------------------------
+;; testing.md block 3 — a view that reads state renders inside `t/with-render`
+;; ---------------------------------------------------------------------------
+
+(deftest the-badge-shows-the-basket-count
+  (register-shop-dataflow!)
+  (rf/dispatch-sync [:basket/add 42])
+  (let [tree (t/with-render (t/render [basket-badge {}]))]
+    (is (= "1" (t/text tree)))))
+
+(deftest rendering-a-subscribing-view-bare-is-refused-and-names-the-bracket
+  (testing "testing.md's stated refusal — `t/render` alone is a walk, not a
+            host, so `v/sub` outside the bracket raises
+            `:rf.error/view-read-outside-render`."
+    (register-shop-dataflow!)
+    (is (thrown? #?(:clj Exception :cljs :default)
+                 (t/render [basket-badge {}])))))
+
+;; ---------------------------------------------------------------------------
+;; testing.md blocks 4 and 5 — tier 2, a real frame
+;; ---------------------------------------------------------------------------
+
+(deftest cart-badge-shows-count-after-add
+  (register-shop-dataflow!)
+  (rf/with-new-frame
+    [_ (rf/make-frame
+        {:initial-events [[:rf/set-db {:cart #{}}]
+                          [:cart/add 42]]})]
+    (let [tree (t/with-render (t/render [cart-badge {}]))]
+      (is (= "1" (t/text (t/find tree #(= :span (:tag %)))))))))
+
+(deftest adding-to-the-cart-updates-the-badge
+  (register-shop-dataflow!)
+  (rf/with-new-frame
+    [f (rf/make-frame {:initial-events [[:rf/set-db {:cart #{}}]]})]
+    (let [before (t/with-render (t/render [cart-badge {}]))]
+      (is (= "0" (t/text (t/find before #(= :span (:tag %)))))))
+    (rf/dispatch-sync [:cart/add 42] {:frame f})
+    (let [after (t/with-render (t/render [cart-badge {}]))]
+      (is (= "1" (t/text (t/find after #(= :span (:tag %)))))))))
+
+;; ---------------------------------------------------------------------------
+;; testing.md block 6 — asserting a projected event
+;; ---------------------------------------------------------------------------
+
+(deftest typing-carries-the-text
+  (register-shop-dataflow!)
+  (rf/dispatch-sync [:rf/set-db {:email ""}])
+  (let [tree  (t/with-render (t/render [email-field {}]))
+        input (t/find tree #(= :input (:tag %)))]
+    (is (= [:account/email-edited "mike@example.com"]
+           (v/materialize-event (:on-input (t/attrs input))
+                                {::v/value "mike@example.com"})))))


### PR DESCRIPTION
PR #6914 landed the 21-page Freehand guide, and its worker verified 68 of its
samples by compiling two scratch `.cljc` fixtures against the real
`implementation/freehand` classpath. That verification is what caught the draft
being materially wrong — but the fixtures could not be committed, because
`implementation/**` was fenced that wave. So the guide is written against a
deliberately unfrozen door and nothing tells us when a verb moves.

This lands the fixtures, and one check that ties them to the pages.

## What is here

Seven chapter fixture namespaces under `implementation/freehand/test/re_frame/freehand/guide/`,
transcribing the guide's fenced blocks onto the real classpath:

| Fixture | Pages |
|---|---|
| `first_view_cljs_test.cljc` | index, build-a-view, mental-model, vs-reagent |
| `composition_cljs_test.cljc` | composition, state, reactivity-and-ownership |
| `events_cljs_test.cljc` | events-and-handlers, forms |
| `controllers_cljs_test.cljc` | semantic-controllers |
| `compilation_cljs_test.cljc` | compilation, debugging |
| `host_cljs_test.cljc` | host-boundaries, js-libraries, presence, accessibility, ssr, install, adoption |
| `testing_cljs_test.cljc` | testing |

Plus `samples_coverage_jvm_test.clj` — the one coverage check.

They are `.cljc`, so every transcription compiles and runs on **both** hosts.
The five browser-only door verbs (`v/mount`, `v/unmount!`, `v/->react`,
`v/active-connections`, `v/command-log`) are covered by reader-conditional
wrappers plus one run-time presence assertion, because a missing CLJS var is a
compile *warning* and `undefined` at run time — only the second reds a gate.

## The coverage rule, and why this one

> **Every fenced block in `docs/core/freehand/` carries a roster row naming
> either the fixture var that proves it or the reason it cannot be run, and the
> row pins a digest of the block's exact text.**

Three consequences, which are the point:

- **Adding a sample reds** — a new block has no row; the run fails naming page
  and ordinal and prints the row to paste.
- **Editing a sample reds** — the digest is over the block's text, so any change
  forces a look at the fixture claiming to prove it.
- **Deleting a fixture reds** — each row's symbol is resolved, so a renamed
  fixture var fails here even when nothing else references it.

**Why the digest covers comments too.** The tempting normalisation is to strip
`;;` lines before hashing, so prose edits inside a sample don't churn the
roster. Rejected: a comment in these samples frequently *is* the claim —
`events-and-handlers.md` states the whole projection roster as
`;; => #{::v/value …}`, and `debugging.md` states `v/describe`'s projection the
same way. A rule that ignored comments would ignore exactly the assertions most
likely to go stale. Only line endings and trailing whitespace are normalised,
which is platform noise and nothing else.

**What it deliberately is not.** The check never parses, evaluates or
understands a line of Clojure in the guide. It splits on fences, hashes bytes,
and compares two sets. Executing a sample is the fixtures' job. That boundary is
what keeps it cheap enough to trust — and it is why this is not the markdown
interpreter rf2-fby7o already rejected.

**Unexecutable classes are a closed set** (`:non-clojure`, `:prose-shape`,
`:app-scaffold`, `:host-boot`, `:foreign-npm`, `:build-config`), so a reason
cannot be invented to dodge writing a fixture.

## Coverage

**112 of 134 fenced blocks** are proved by a fixture. The 22 that are not:

| Reason | n | What |
|---|---|---|
| `:non-clojure` | 5 | CSS and ASCII-diagram fences |
| `:prose-shape` | 5 | illustrative data (an app-db slice, a build diagnostic) with no verb in it to move |
| `:foreign-npm` | 4 | `ns` forms requiring `react-sparkline`, `framer-motion`, `some-date-picker` |
| `:app-scaffold` | 3 | consumer `ns` forms / full listings naming the UIx adapter |
| `:host-boot` | 3 | `(defn ^:export run [] … (js/document.getElementById "app"))` |
| `:build-config` | 2 | `deps.edn` and `shadow-cljs.edn` fragments |

## Guide corrections found by building this

**`semantic-controllers.md` taught a spelling the substrate refuses** (fixed
here). Blocks 1 and 14 wrote an exact-key map at an event site:

```clojure
:on-key-down {"Enter"  [:lines/label-committed id]
              "Escape" [:lines/draft-cancelled id]}
```

`re-frame.freehand.events/event-plan` classifies a map at an event position as
the **options** map and nothing else, against the closed roster
`#{:event :prevent-default :stop-propagation :once :passive :capture}` — so that
site raises `:rf.error/view-bad-event` at mount. `events-and-handlers.md` says
so explicitly two pages earlier: *"There is no key-condition map."* Both samples
now use the `v/event` branch that page teaches. Note the JVM structural render
passes the map through unclassified, so `t/render` does **not** catch this — a
consumer would find out in the browser.

Filed, not fixed here (outside a sample-correction write surface):

- **rf2-rczed** (P2) — `accessibility.md` still asserts in prose that exact-key
  maps are "a **closed data form**". Same defect, prose rather than sample.
- **rf2-erqin** (P2) — `t/render` of a view reading `(v/presence-phase)` renders
  on the JVM and **throws** in CLJS (`useContext` outside a React render), while
  `testing.md` promises a `.cljc` structural test is a cross-host claim. The two
  presence *render* assertions are fenced to `#?(:clj …)` with a comment naming
  the bead; the declarations stay cross-host, so a rename still reds on both.
- **rf2-ynq9h** (P3) — `compilation.md`'s `v/render-fn` caller renders only from
  a **compiled** parent; from an interpreted one the identical spelling raises
  `:rf.error/ui-tree-malformed`.

## The red-proof

A harness that cannot fail is the silent staleness this bead exists to end, so
each way it is supposed to red was run for real.

**1. A moved door verb (JVM).** Renamed `v/spread-safe` → `v/spread-bounded` in
`freehand.cljc`:

```
Syntax error compiling at (re_frame/freehand/guide/composition_cljs_test.cljc:153:4).
No such var: v/spread-safe
```

— line 153 is `spread-forms`, i.e. `composition.md` block 8. Reverted.

**2. A moved browser-only verb (CLJS).** Renamed the `mount` re-export:

```
FAIL in (the-browser-only-door-verbs-are-present) (host_cljs_test.cljc:401:12)
v/mount — install.md, ssr.md, build-a-view.md
expected: (fn? v/mount)
  actual: (not (fn? nil))
```

plus compile warnings naming `install.md` block 4 and `ssr.md` block 3.
Reverted.

**3. An edited guide sample.** Changed `:on-click` → `:on-press` in
`events-and-handlers.md` block 1:

```
events-and-handlers.md block 1 has changed — paste [ 1 "bedffe1cf560" events/add-to-cart-button]
  (was "603f633abe5a"); first line: "[:button {:on-press [:cart/add product-id]} \"Add to cart\"]"
```

Reverted.

**4. An added guide sample.** Appended a fence to `adoption.md`:

```
adoption.md — the page has 2 fenced blocks; the roster has 1 rows
adoption.md block 2 has no roster row — first line: "[:button {:on-click [:brand/new]} \"New sample\"]"
```

Reverted.

**5. The check's own logic.** `the-check-has-teeth` drives `roster-drift`
against synthetic input for every failure mode above plus page add/remove, and
asserts the digest is sensitive to a moved verb and to an expected value stated
only in a comment, and insensitive to trailing whitespace.

## Quality gates

| Gate | Result |
|---|---|
| `cd implementation/freehand && clojure -M:test` | **exit 0** — 991 tests, 6931 assertions, 0 failures, 0 errors |
| `npm run test:freehand` | **exit 0** — 1061 tests, 5974 assertions, 0 failures, 0 errors |
| `npm run test:cljs` | **exit 0** — 11217 tests, 56291 assertions, 0 failures, 0 errors |
| `scripts/test-fast-pr.sh` | **exit 0** |

Coverage census, printed by the suite on every run:

```
Freehand guide sample coverage: 112 of 134 fenced blocks
  :app-scaffold   3  a consumer `ns` form or full application listing naming an adapter artefact this one takes no dependency on
  :build-config   2  a `deps.edn` / `shadow-cljs.edn` fragment
  :foreign-npm    4  an `ns` requiring an npm module that is on no classpath here
  :host-boot      3  a boot function needing a real `js/document` container
  :non-clojure    5  a CSS or ASCII-diagram fence — not Clojure at all
  :prose-shape    5  an illustrative data shape (an app-db slice, a build diagnostic) with no verb in it to move
```

Closes rf2-qwsmv.
