### PR TITLE
docs: repair pointers left dangling by the re-frame.ui guide deletion (rf2-zkee9)

### DIFF
--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/ui_context.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/ui_context.clj
@@ -504,8 +504,9 @@
   "The authored, machine-first prose — everything except the two generated
    slices (the compile-rejection roster and the authoring surface).
    Grounded in the re-frame.ui public surface
-   (implementation/ui/src/re_frame/ui.cljc) and the docs
-   (docs/core/re-frame.ui/)."
+   (implementation/ui/src/re_frame/ui.cljc) and the normative grammar
+   (spec/004-Views.md). The donor guide it was also drawn from is gone;
+   the Freehand guide at docs/core/freehand/ replaced it."
   "# re-frame.ui context sheet
 
 `re-frame.ui` is re-frame2's **compiled-view substrate**. You write views with
@@ -734,8 +735,11 @@ below carries the exact id + fix:
 
 ## Deep references
 
-- Docs: `docs/core/re-frame.ui/` (mental model, build-a-view, state,
-  events-and-handlers, interop-and-limits, testing, ssr, presence).
+- Docs: `docs/core/freehand/` — the Freehand guide, which replaced the donor
+  chapters (mental-model, build-a-view, state, events-and-handlers,
+  host-boundaries, limits-and-escapes, testing, ssr, presence). Freehand is the
+  view layer new work is written against; this sheet describes what an app
+  already on `re-frame.ui` has today.
 - Spec: `spec/004-Views.md` (the normative grammar).
 - API: the `re-frame.ui` / `re-frame.ui.test` API references.")
 

--- a/skills/re-frame2-ui/SKILL.md
+++ b/skills/re-frame2-ui/SKILL.md
@@ -492,7 +492,8 @@ Deep references, in the re-frame2 repo:
 - [`references/ui-context.md`](references/ui-context.md) — the generated
   context sheet: authoring-surface disposition + the full compile-rejection
   roster (regenerated from the compiler; drift-checked in CI).
-- `docs/core/re-frame.ui/` — the guide (mental model, build-a-view, state,
-  events-and-handlers, interop-and-limits, testing, ssr, presence).
+- `docs/core/freehand/` — the Freehand guide, which replaced the donor
+  chapters (mental-model, build-a-view, state, events-and-handlers,
+  host-boundaries, limits-and-escapes, testing, ssr, presence).
 - `skills/re-frame2-setup/references/shadow-cljs.md` — the Shadow settings, held against the real build config by a drift gate.
 - `spec/004-Views.md` — the normative grammar.

--- a/skills/re-frame2-ui/references/ui-context.md
+++ b/skills/re-frame2-ui/references/ui-context.md
@@ -242,8 +242,11 @@ below carries the exact id + fix:
 
 ## Deep references
 
-- Docs: `docs/core/re-frame.ui/` (mental model, build-a-view, state,
-  events-and-handlers, interop-and-limits, testing, ssr, presence).
+- Docs: `docs/core/freehand/` — the Freehand guide, which replaced the donor
+  chapters (mental-model, build-a-view, state, events-and-handlers,
+  host-boundaries, limits-and-escapes, testing, ssr, presence). Freehand is the
+  view layer new work is written against; this sheet describes what an app
+  already on `re-frame.ui` has today.
 - Spec: `spec/004-Views.md` (the normative grammar).
 - API: the `re-frame.ui` / `re-frame.ui.test` API references.
 


### PR DESCRIPTION
PR #6914 deleted the donor guide subtree `docs/core/re-frame.ui/` and installed the Freehand guide at `docs/core/freehand/` in its place. Three tracked files still sent readers at the deleted subtree. Nothing validates prose paths, so no gate was red — this one needed a human eye, and an alpha tag is exactly when people start following documentation links.

## What changed

| file | generated? |
|---|---|
| `implementation/scripts/api-manifest/src/re_frame/api_manifest/ui_context.clj` | source — two sites: the `prose-body` docstring, and the emitted **Deep references** block |
| `skills/re-frame2-ui/references/ui-context.md` | **GENERATED** from the `.clj` above — regenerated, not hand-edited |
| `skills/re-frame2-ui/SKILL.md` | authored |

The context sheet is generated, so editing it alone would have been undone by the next regeneration and the drift would return. The fix went into `ui_context.clj`, and the sheet was regenerated in the same commit:

```
cd implementation/scripts/api-manifest
clojure -M -m re-frame.api-manifest.ui-context          # regenerate  -> exit 0
clojure -M -m re-frame.api-manifest.ui-context --check  # drift check -> exit 0
```

The regeneration produced exactly the intended delta and nothing else, which is the evidence that the generator — not the artefact — was the thing fixed.

Pointers now name the real Freehand chapters (`mental-model`, `build-a-view`, `state`, `events-and-handlers`, `host-boundaries`, `limits-and-escapes`, `testing`, `ssr`, `presence`). The old list's `interop-and-limits` has no single counterpart; it is split across `host-boundaries` and `limits-and-escapes`. Every repo path referenced in both touched skill files was swept and now resolves to a real file.

No shims, no redirect stubs, no tombstone pages, no new guide prose. This is a pointer repair.

## Before / after

`git grep -n "docs/core/re-frame\.ui" -- . ':!.beads/'` — 10 hits before, 6 after, all six deliberate:

```
docs/EP/EP-0030-the-compiled-view-substrate-program.md:188,235,251,400
scripts/check_donor_inventory.py:1216
spec/conformance/freehand/donor-inventory.md:421
```

**Left on purpose:**

- **EP-0030 (4 sites)** — a historical programme record written in the past tense ("already shipped (rf2-b1wv9, #6544)"). Retconning an EP to describe a path that did not exist when it was written would falsify the record.
- **`check_donor_inventory.py:1216`** — an `ESTABLISHED_ROWS` identity. Inventory rows are disposed, never deleted.
- **`donor-inventory.md:421`** — the row itself, correctly marked `done`. The row *is* the record that the subtree was removed.

Prose that legitimately discusses re-frame.ui as the donor is untouched: it still exists as code until the EP-0036 F6e gate deletes it.

**Checked and found already correct**, so not touched:

- `docs/skills/re-frame2-ui.md:39` is an *authored* companion page, not generated from `SKILL.md`, and it already routes readers to the Freehand guide ("The donor guide chapters have been replaced by the [Freehand guide](../core/freehand/index.md)"). Its wording set the voice for the three repairs here.
- `docs/core/how-to/install-re-frame-ui.md` still exists (donor-inventory row `pending`), so the `SKILL.md` reference to it is live, not dangling. Its removal belongs to rf2-ote5u.
- `mkdocs.yml` has no nav entry under `core/re-frame.ui/` — PR #6914 removed those cleanly.

All three sites the bead named were real, and all three are fixed here. The bead's generated-file warning was also correct: `references/ui-context.md` is genuinely generated from `ui_context.clj`, which is why the fix went into the `.clj`.

## Quality gates

Every gate run in the foreground to completion, captured to worktree-local logs, exit code echoed. None piped.

| gate | exit | result |
|---|---|---|
| `ui-context --check` (generated-file drift) | 0 | in sync — 98 diagnostic ids, 32 authoring vars |
| `skills-check` | 0 | 560 public-var references reconciled against the manifest |
| `python -m mkdocs build --strict` | 0 | built in 19.3s, INFO only |
| `check_doc_slugs.py` | 0 | pass |
| `check_readme_links.py` | 0 | pass |
| `check_readme_inventories.py` | 0 | pass |
| `check_donor_inventory.py` | 0 | pass |
| `check_skill_package_refs.py` | 0 | pass |
| `check_skill_redirect_anchors.py` | 0 | pass |
| `check_skill_eval_docs.py` | 0 | pass |
| `check_skill_eval_packaging.py` | 0 | pass |
| `check_skill_mcp_drift.py` | 0 | pass |
| `check_skill_re_frame2_drift.py` | 0 | pass |
| `check_skill_implementor_order.py` | 0 | pass |
| `check_skill_implementor_partition_drift.py` | 0 | pass |
| `check_skill_migration_cites.py` | 0 | pass |
| `check_skill_migration_contract_drift.py` | 0 | pass |
| `check_skill_migration_o1617_router_drift.py` | 0 | pass |
| `check_skill_pair_authoring_drift.py` | 0 | pass |
| `check_skill_setup_counter_drift.py` | 0 | pass |
| `check_skill_xray_tab_inventory_drift.py` | 0 | pass |
| `scripts/test-fast-pr.sh` | 0 | `PASS fast PR spine` — 0 `FAIL` lines; CLJS node integration 11k+ assertions green; per-ns isolation 17/17 standalone |

**20 doc/skill gates green, 0 failed**, plus the two api-manifest Clojure gates and the full spine.

`test-fast-pr.sh` **soft-skips mkdocs on this machine** (`SKIP mkdocs --strict build: mkdocs not on PATH — CI will run this; local soft-skip OK`), so a green spine does *not* mean the docs build passed. `mkdocs build --strict` was therefore run explicitly and separately — exit 0.

Closes rf2-zkee9.
