### PR TITLE
docs(freehand): stop teaching the deleted exact-key event map (rf2-rczed)

### DIFF
--- a/docs/core/freehand/accessibility.md
+++ b/docs/core/freehand/accessibility.md
@@ -72,10 +72,12 @@ Structural replacement of a labelled region uses the
 
 - Prefer **native** activators (`button`, `a`, `input`) so Enter/Space and tab order
   work without a custom handler.  
-- Exact-key maps on `:on-key-down` / `:on-key-up` are a **closed data form** for
-  common chords (see [Events](events-and-handlers.md)). Rich listbox/combobox
-  policy often needs `v/event` or a host widget — do not fake a full ARIA composite
-  with half a key map.  
+- Keyboard branching is an **ordinary event**. Send the key with the intent —
+  `[:menu/key-pressed ::v/key]` — and decide in the handler, or write
+  `(v/event [e] …)` at the site when `preventDefault` depends on which key it was
+  (see [Events](events-and-handlers.md#keyboard-branching)). Listbox and combobox
+  policy usually needs more than either: reach for a host widget rather than fake
+  a full ARIA composite out of a few key branches.  
 - IME composition must not commit partial text on Enter; Freehand’s controlled-input
   door already treats composition as a browser law.
 

--- a/docs/core/freehand/compilation.md
+++ b/docs/core/freehand/compilation.md
@@ -40,9 +40,9 @@ when debugging.
 When a view body is inside the finite subset, compilation can give you:
 
 - direct React lowering and a JVM structural emitter  
-- finite manifests for subscriptions, events, key maps, slots, host edges,
-  presence, and top-layer forms (static “what *can* happen,” not only what one
-  render observed)  
+- finite manifests for subscriptions, events, slots, host edges, presence, and
+  top-layer forms (static “what *can* happen,” not only what one render
+  observed)  
 - generated prop comparators and prebound handlers where the compiler can prove
   them  
 - static diagnostics with source coordinates  


### PR DESCRIPTION
D007 was discharged with outcome **DELETE** (PR #6900). A map at an event position
is the listener-options map and nothing else. The Freehand guide still taught the
exact-key map as a supported closed data form, so a reader following it hits a hard
failure on first mount — in the accessibility chapter, where readers follow
instructions most literally.

## What changed

`docs/core/freehand/accessibility.md` — the Keyboard bullet claimed exact-key maps
on `:on-key-down` / `:on-key-up` are a "closed data form". It now teaches the two
spellings the substrate actually has, which is what
[`spec/004-Views.md`](../blob/main/spec/004-Views.md) states ("Keyboard branching is
an ordinary event") and what `events-and-handlers.md#keyboard-branching` already
taught two pages earlier. The a11y point the bullet was really making — that a real
listbox or combobox wants a host widget, not a handful of key branches — is kept.

`docs/core/freehand/compilation.md` — "key maps" was listed among the finite
manifests compilation buys. The manifest rosters are `:subscriptions` / `:events` /
`:slots` / `:html-sites` / `:frame-ops` (`re-frame.freehand.descriptor/manifest`);
the deleted form is dropped from the list. Confirmed empirically — see the compiled
manifest printed below.

### Instances found

Four in the guide, of which **two are mine**:

| # | Site | Disposition |
|---|---|---|
| 1 | `accessibility.md:75` prose bullet | fixed here |
| 2 | `compilation.md:43` manifest roster | fixed here |
| 3 | `semantic-controllers.md:30` sample | already fixed on `origin/worker/guide-samples-qwsmv` (rf2-qwsmv, in flight) — left alone to avoid conflicting with a live worker |
| 4 | `semantic-controllers.md:446` sample | same |

Every other `:on-key-*` site in `docs/core/freehand/**` (`events-and-handlers.md`
lines 33/49/96/103/181/279, `state.md:115`) already uses `::v/key`, `[::v/read
:altKey]` or `v/event` and is correct.

## The old sample, rejected

The exact-key map the guide taught, run against the real
`implementation/freehand` classpath. **Interpreted tier** —
`re-frame.freehand.events/event-plan`:

```
{:rf.error/id :rf.error/view-bad-event,
 :where       v/event-site,
 :recovery    :use-the-closed-listener-options,
 :reason      "An event options map carries a vector :event plus the closed listener
               options [:capture :event :once :passive :prevent-default
               :stop-propagation]; this one also carries [\"Enter\" \"Escape\"].",
 :unknown-keys ["Enter" "Escape"],
 :legal-keys   [:capture :event :once :passive :prevent-default :stop-propagation]}
```

**Compiled tier** — the same form through `v/defview {:compiled true}`, refused at
build:

```
re-frame.freehand compile error: unknown handler options "Enter", "Escape" at
:on-key-down — the closed listener vocabulary is {:event :prevent-default
:stop-propagation :capture :passive :once}
{:prop :on-key-down, :form {"Enter" [:menu/activate], "Escape" [:menu/close]}}
```

## The new samples, verified

Both inline spellings in the repaired bullet were run — not eyeballed — against
`implementation/freehand`'s classpath. `rf2-qwsmv` owns the durable
executable-fixture home for guide samples, so these are inline (no new fenced
block) and add nothing for its coverage check to adopt.

| Sample | Verification | Exit |
|---|---|---|
| `[:menu/key-pressed ::v/key]` at `:on-key-down` | `event-plan` → `{:role :event-vector}`; `t/render` keeps the intent as data on the structural tree (`{:on-key-down [:menu/key-pressed :re-frame.freehand/key]}`); `v/materialize-event` with `{::v/key "ArrowDown"}` → `[:menu/key-pressed "ArrowDown"]`; compiled tier accepts it and emits one `:events` manifest site with `:capabilities #{:event}` | **0** |
| `(v/event [e] …)` at the site | `event-plan` → `{:role :event}`; `t/render` keeps the site on the structural tree | **0** |

Command for both (run from `implementation/freehand`):

```
clojure -M -e '(load-file "…/verify_samples.clj")'     # exit 0
clojure -M -e '(load-file "…/verify_compiled.clj")'    # exit 0
```

The scripts are evidence, not artefacts — they live under an untracked
`.worker-logs/` and are not committed.

## Quality gates

| Gate | Result |
|---|---|
| `python -m mkdocs build --strict` (repo root) | **PASS**, exit 0 — 0 warnings, built in 17.65s. Run **explicitly**: `test-fast-pr.sh` soft-skips mkdocs on this machine (`mkdocs not on PATH`), so a green spine alone does not prove the docs build |
| `python scripts/check_doc_slugs.py` | **PASS**, exit 0 |
| `python scripts/check_readme_links.py` | **PASS**, exit 0 |
| `python scripts/check_readme_inventories.py` | **PASS**, exit 0 |
| `python scripts/check_retired_spellings.py` | **PASS**, exit 0 |
| `sh scripts/test-fast-pr.sh` | **PASS**, exit 0 — includes the docs corpus anchor validator, which is what proves the new `events-and-handlers.md#keyboard-branching` anchor resolves |
| Sample verification (JVM, real classpath) | **PASS**, exit 0 — 2 new samples accepted in both tiers, old form rejected in both tiers |

No source changed, so the CLJS and JVM implementation lanes are untouched.

## Left for other beads

- **Host divergence — filed as `rf2-5xjxj` (P2, bug), not fixed here.** The JVM
  structural render passes a non-roster map at an event position straight through,
  unclassified, so `t/render` does not catch this class at all — only mount and the
  compiled build do. Reproduced on the real classpath:

  ```
  (t/attrs (t/find (t/render [menu-bad {}]) #(= :ul (:tag %))))
  ;; => {:on-key-down {"Enter" [:menu/activate], "Escape" [:menu/close]}}
  ```

  This is how the deleted form could sit behind a green `.cljc` structural suite.
  `implementation/freehand/**` is fenced to live workers this wave, so it is a
  separate bead. Distinct from `rf2-erqin` (presence-phase divergence).

Closes rf2-rczed.
