### PR TITLE
fix(freehand): make t/render of a presence-phase-reading view agree across hosts (rf2-erqin)

### DIFF
--- a/implementation/freehand/src/re_frame/freehand.cljc
+++ b/implementation/freehand/src/re_frame/freehand.cljc
@@ -1441,9 +1441,12 @@
 
 (def ^{:doc "(v/presence-phase) — the single presence-phase read: :mounting /
   :present / :unmounting inside a (v/presence …) boundary, :present outside one
-  (so presence-aware children stay reusable anywhere). A render-time read (a
-  React context read on ClojureScript); the JVM structural render always yields
-  :present.
+  (so presence-aware children stay reusable anywhere). A render-time read, and
+  which RENDERER is running decides how it is answered: a mounted host render
+  reads the boundary's React context, while the structural render — which has
+  no lifecycle — always yields :present, on both hosts. So a presence-aware
+  child renders under t/render, and a .cljc structural test of one is a
+  cross-host claim.
 
   Per [Spec 004 §Presence](../../../../spec/004-Views.md#presence)."
        :arglists '([])}

--- a/implementation/freehand/src/re_frame/freehand/node.cljc
+++ b/implementation/freehand/src/re_frame/freehand/node.cljc
@@ -207,6 +207,29 @@
   nil)
 
 ;; ---------------------------------------------------------------------------
+;; Which renderer is running
+;; ---------------------------------------------------------------------------
+;;
+;; A view body is ordinary code, and a couple of the reads it may make have
+;; ONE answer under the structural renderer and another under the host one —
+;; `(v/presence-phase)` is the case that exists today. On the JVM there is
+;; only ever the structural renderer, so a reader conditional answers the
+;; question; in ClojureScript BOTH renderers run in the same compiled code and
+;; a reader conditional answers the WRONG one (rf2-erqin). This binding is the
+;; right discriminator on both hosts: it says a structural render is in
+;; progress, not which compiler produced the code.
+;;
+;; It lives here for the same reason `*ns-context*` does — one binding both
+;; front ends see, established once at the structural entry
+;; ([[re-frame.freehand.tree/render]]) and read wherever the answer is needed.
+
+(def ^:dynamic *structural-render?*
+  "Is a STRUCTURAL render currently in progress (as against the host render,
+  or no render at all)? Bound true for the extent of
+  [[re-frame.freehand.tree/render]] and its literal-root-form sibling."
+  false)
+
+;; ---------------------------------------------------------------------------
 ;; Children — canonical form
 ;; ---------------------------------------------------------------------------
 ;;

--- a/implementation/freehand/src/re_frame/freehand/presence_runtime.cljc
+++ b/implementation/freehand/src/re_frame/freehand/presence_runtime.cljc
@@ -26,9 +26,11 @@
   Removal-then-reinsertion of a key interrupts the exit and re-enters at
   `:present`.
 
-  `(presence-phase)` is the single phase read — `react/useContext` on CLJS,
-  `:present` on the JVM structural subset. Outside a boundary it returns
-  `:present`, so presence-aware children stay reusable anywhere.
+  `(presence-phase)` is the single phase read, and WHICH RENDERER is running
+  decides how it is answered: the host render reads the boundary's React
+  context, the structural render — which has no lifecycle — answers
+  `:present` on both hosts. Outside a boundary it returns `:present` too, so
+  presence-aware children stay reusable anywhere.
 
   The runtime split:
 
@@ -47,7 +49,8 @@
 
   Normative owner:
   [`spec/004-Views.md`](../../../../../spec/004-Views.md) §Presence."
-  #?(:cljs (:require ["react" :as react])))
+  (:require [re-frame.freehand.node :as node]
+            #?@(:cljs [["react" :as react]])))
 
 ;; ---------------------------------------------------------------------------
 ;; reconcile — the PURE three-phase entry derivation (both hosts)
@@ -471,9 +474,27 @@
 
 (defn presence-phase
   "Read the current presence phase — `:mounting` / `:present` / `:unmounting`
-  inside a `(v/presence …)` boundary, `:present` outside one. A render-time
-  read (CLJS `react/useContext`); on the JVM structural subset it is always
-  `:present`."
+  inside a `(v/presence …)` boundary, `:present` outside one.
+
+  A render-time read, and WHICH RENDERER is running decides how it is
+  answered. The structural render has no lifecycle — its presence node says
+  `{:phase :present …}` — so it answers `:present`, on both hosts and in both
+  modes: a `.cljc` structural test of a presence-aware child is a cross-host
+  claim, which is the whole reason `t/render` exists. The host render reads
+  the phase the enclosing boundary published, through the React context.
+
+  The discriminator is the RENDERER, not the compiler. A reader conditional
+  looks like it would do, and on the JVM it does — there is only the
+  structural renderer there. In ClojureScript both renderers run in the same
+  compiled code, so it answered `react/useContext` for a structural render
+  too and a `t/render` of a phase-reading child threw `Invalid hook call`
+  (rf2-erqin).
+
+  Outside any render at all it is a hook called outside a component and React
+  says so, which is right: this is a render-time read and there is no render
+  to read."
   []
-  #?(:cljs (react/useContext presence-context)
+  #?(:cljs (if node/*structural-render?*
+             :present
+             (react/useContext presence-context))
      :clj  :present))

--- a/implementation/freehand/src/re_frame/freehand/tree.cljc
+++ b/implementation/freehand/src/re_frame/freehand/tree.cljc
@@ -405,7 +405,8 @@
   metadata-carried contract — so it prints and reads back losslessly, and
   `(tree-seq map? :children tree)` is the whole traversal API."
   [form]
-  (binding [node/*ns-context* nil]
+  (binding [node/*ns-context*         nil
+            node/*structural-render?* true]
     (let [kids (children [form])
           root (if (and (= 1 (count kids)) (map? (first kids)))
                  (first kids)
@@ -447,7 +448,8 @@
   — the reactive half of no-silent-elision (Spec 004C §3, EP-0034 §2). The
   capability half is [[emit-static-html]]'s."
   [thunk]
-  (binding [node/*ns-context* nil]
+  (binding [node/*ns-context*         nil
+            node/*structural-render?* true]
     (assoc (thunk) :rf.ui/tree-version tree-version)))
 
 ;; ---------------------------------------------------------------------------

--- a/implementation/freehand/test/re_frame/freehand/presence_parity_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/presence_parity_cljs_test.cljc
@@ -24,6 +24,7 @@
             [re-frame.freehand.descriptor :as descriptor]
             [re-frame.freehand.presence-views :as views]
             [re-frame.freehand.presence-views-compiled :as compiled]
+            [re-frame.freehand.test :as t]
             [re-frame.freehand.tree :as tree]))
 
 (def presence-001 (conf/fixture :FH-PRESENCE-001))
@@ -94,6 +95,70 @@
           "the root is the view boundary, wrapping the presence node")
       (is (contains? (first (:children t)) :rf.ui/presence)
           "the presence node is the boundary's child, not adopted away"))))
+
+;; ---------------------------------------------------------------------------
+;; The phase READ under a structural render — rf2-erqin
+;; ---------------------------------------------------------------------------
+;;
+;; The rows above pin the presence NODE. These pin the presence-aware CHILD:
+;; a view that reads its own `(v/presence-phase)` to stamp its exit class and
+;; `aria-hidden`, which is the shape Spec 004 §Presence tells an author to
+;; write and the shape a `.cljc` structural test is supposed to be able to
+;; render. A structural render carries no lifecycle — the presence node it
+;; builds says `{:phase :present …}` — so the read answers `:present`, and it
+;; answers it on BOTH hosts. It used to answer it only on the JVM: the
+;; ClojureScript arm was an unconditional `react/useContext`, and `t/render`
+;; opens no React render, so the identical declaration threw
+;; `TypeError: Cannot read properties of null (reading 'useContext')`.
+
+(v/defview toast-card
+  "The presence-aware child Spec 004 §Presence teaches: it owns its exit
+  styling and accessibility by reading its OWN phase. Nothing here is
+  host-bearing — the read is the whole point."
+  [{:keys [label]}]
+  (let [phase    (v/presence-phase)
+        exiting? (= :unmounting phase)]
+    [:div.toast {:class       (when exiting? "toast--exit")
+                 :aria-hidden (when exiting? "true")
+                 :data-phase  (name phase)}
+     label]))
+
+(v/defview toast-stack
+  "The same child under a real boundary — the whole declaration a consumer
+  writes, rendered structurally in one call."
+  [_]
+  [:div.stack
+   (v/presence {:timeout-ms 300}
+     [toast-card {:key "a" :label "saved"}])])
+
+(deftest a-presence-phase-reading-child-renders-structurally
+  (testing "A view that reads its own (v/presence-phase) renders under
+            t/render on both hosts, and reads :present — the one phase a
+            render with no retention machine can truthfully report."
+    (let [t    (t/render [toast-card {:label "saved"}])
+          card (t/find t #(= :div (:tag %)))]
+      (is (= "present" (:data-phase (t/attrs card)))
+          "the child stamped the phase it read")
+      (is (= "toast" (:class (t/attrs card)))
+          "and no exit class — a structural render is never :unmounting")
+      (is (not (contains? (t/attrs card) :aria-hidden))
+          "nor is the exiting subtree hidden from the a11y tree")
+      (is (= "saved" (t/text t))
+          "the child rendered its content rather than throwing"))))
+
+(deftest a-presence-phase-read-under-a-boundary-renders-structurally
+  (testing "The same child UNDER a (v/presence …) boundary renders too, and
+            agrees with the boundary's own marker: the node says :present and
+            so does every child that asks."
+    (let [t        (t/render [toast-stack {}])
+          presence (t/find t :rf.ui/presence)
+          card     (t/find t #(= :div (:tag %)))]
+      (is (= {:phase :present :timeout-ms 300} (:rf.ui/presence presence))
+          "the boundary node renders its children :present")
+      (is (= "present" (:data-phase (t/attrs (t/find presence #(= :div (:tag %))))))
+          "and the child's own read agrees with it")
+      (is (= :div (:tag card)) "the stack rendered")
+      (is (= "saved" (t/text presence))))))
 
 (deftest the-timeout-must-be-legal
   (testing "The interpreted `v/presence` enforces the same terminal-bound

--- a/implementation/freehand/test/re_frame/freehand/presence_parity_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/presence_parity_cljs_test.cljc
@@ -151,14 +151,17 @@
             agrees with the boundary's own marker: the node says :present and
             so does every child that asks."
     (let [t        (t/render [toast-stack {}])
+          stack    (t/find t #(= :div (:tag %)))
           presence (t/find t :rf.ui/presence)
-          card     (t/find t #(= :div (:tag %)))]
+          card     (t/find presence #(= :div (:tag %)))]
+      (is (= "stack" (:class (t/attrs stack)))
+          "the whole declaration rendered rather than throwing")
       (is (= {:phase :present :timeout-ms 300} (:rf.ui/presence presence))
           "the boundary node renders its children :present")
-      (is (= "present" (:data-phase (t/attrs (t/find presence #(= :div (:tag %))))))
+      (is (= "present" (:data-phase (t/attrs card)))
           "and the child's own read agrees with it")
-      (is (= :div (:tag card)) "the stack rendered")
-      (is (= "saved" (t/text presence))))))
+      (is (= "saved" (t/text presence))
+          "with its content in place"))))
 
 (deftest the-timeout-must-be-legal
   (testing "The interpreted `v/presence` enforces the same terminal-bound


### PR DESCRIPTION
Closes rf2-erqin.

`docs/core/freehand/presence.md` teaches a presence-aware child that reads
`(v/presence-phase)` to stamp its own exit class and `aria-hidden`, and
`testing.md` promises that "the same declaration answers the same tree on the
JVM and in ClojureScript, so a `.cljc` structural test is a cross-host claim".
Both claims could not hold at once: `t/render` of such a child rendered on the
JVM and threw in ClojureScript.

## The original throw

Reproduced by adding the two new tests to the pre-fix tree and running
`npm run test:freehand` (exit 1, `0 failures, 2 errors`):

```
Invalid hook call. Hooks can only be called inside of the body of a function component.
...
Testing re-frame.freehand.presence-parity-cljs-test

ERROR in (a-presence-phase-reading-child-renders-structurally) (TypeError:NaN:NaN)
Uncaught exception, not in assertion.
expected: nil
  actual: #object[TypeError TypeError: Cannot read properties of null (reading 'useContext')]

ERROR in (a-presence-phase-read-under-a-boundary-renders-structurally) (TypeError:NaN:NaN)
Uncaught exception, not in assertion.
expected: nil
  actual: #object[TypeError TypeError: Cannot read properties of null (reading 'useContext')]

Ran 1023 tests containing 5886 assertions.
0 failures, 2 errors.
```

The identical declaration on the JVM, at the same commit:

```
JVM t/render => {:view-id :user/toast-card,
                 :children [{:tag :div, :attrs {:class "toast"}, :children ["present"]}],
                 :rf.ui/tree-version 1}
```

## Which host was right, and why

**The JVM.** A structural render carries no lifecycle: no retention machine, no
timers, no time. The presence node it builds already says
`{:phase :present :timeout-ms n}`, so `:present` is the only phase such a render
can truthfully report — and it is the phase Spec 004 §Presence already documents
for a child outside a boundary. Matching it in ClojureScript is also what
restores the Spec 008 promise that a `.cljc` structural test is a cross-host
claim, and it is the same answer `v/render-static` needs: a server render of a
presence-aware child must produce markup, and `:present` is the only honest
phase for one.

Refusing on both hosts was considered and rejected. The phase *can* be read at
that point — the structural tree already carries the answer — and a refusal
would make every presence-aware child structurally untestable and unrenderable
by `render-static`.

## The change

`presence-phase` discriminated on the **compiler**. On the JVM that happens to
be the same question, because only the structural renderer exists there; in
ClojureScript both renderers run in the same compiled code, so a reader
conditional answers the wrong one.

It now discriminates on the **renderer**:

- `re-frame.freehand.node/*structural-render?*` — a walk-scoped dynamic
  binding alongside the existing `*ns-context*`, false by default;
- bound true for the extent of `tree/render` and `tree/render-root-tree`, on
  both hosts, so both structural entries carry the fact;
- the ClojureScript arm of `presence-phase` consults it before reaching for the
  React context.

Deliberately NOT a blanket "no React ⇒ `:present`" fallback. Outside any render
at all this is still a hook called outside a component, and React still says so
— a real programmer error that keeps reporting itself. Only the structural
renderer, which genuinely knows the answer, answers structurally.

No new lifecycle concept, no phase negotiation, no API shape change:
`v/presence-phase` keeps its arity, its return value and its manifest row, so
`spec/api-manifest.edn` and the conformance corpus are untouched.

## Non-vacuity

Both new tests live in `presence_parity_cljs_test.cljc`, which runs in **both**
lanes — JVM via `clojure -M:test`, ClojureScript via the
`^re-frame\.freehand\..+-cljs-test$` node build. A test that ran only where the
bug did not manifest would prove nothing.

- **RED before the fix, on the host that was broken**: `npm run test:freehand`
  exit **1**, `0 failures, 2 errors`, both the `useContext` TypeError quoted
  above. The JVM lane was green on the same two tests at the same commit —
  which is the divergence itself, stated as a test.
- **GREEN after the fix on both**: `clojure -M:test` exit **0**,
  `npm run test:freehand` exit **0**.

## Quality gates

Every gate run in the foreground to completion; exit codes captured directly,
never through a pipe.

| Gate | Result |
| --- | --- |
| `cd implementation/freehand && clojure -M:test` (JVM) | exit 0 — Ran 954 tests, 6848 assertions, 0 failures, 0 errors |
| `npm run test:freehand` (CLJS node) | exit 0 — Ran 1023 tests, 5892 assertions, 0 failures, 0 errors |
| `npm run test:cljs` (full CLJS node suite) | exit 0 — Ran 11179 tests, 56210 assertions, 0 failures, 0 errors |
| `npm run test:browser` (real React, real DOM) | exit 0 — Ran 762 tests, 4771 assertions, 0 failures, 0 errors |
| `scripts/test-fast-pr.sh` (repo-root spine) | exit 0 — `PASS fast PR spine` (22 stages) |

The browser lane is what proves the other direction: the mounted presence suites
(`presence_dom_cljs_test`, `presence_matrix_dom_cljs_test`,
`presence_commit_ownership_dom_cljs_test`, `presence_nil_key_dom_cljs_test`)
drive the real `useContext` path through `:mounting` → `:present` →
`:unmounting`, and they stay green — the fix does not make a mounted render
answer `:present`.

## Follow-on

The two guide fixtures rf2-qwsmv fenced to `#?(:clj …)` for this bead — in
`implementation/freehand/test/re_frame/freehand/guide/host_cljs_test.cljc`,
which has not landed on `main` yet — can be un-fenced once both PRs are in.
Filed as a separate bead rather than reached into from here.
