### PR TITLE
docs,examples,skills: align the corpus with the ratified EP-0037 routing surface (rf2-kqxe6.11)

### DIFF
--- a/docs/api/re-frame.routing.md
+++ b/docs/api/re-frame.routing.md
@@ -61,8 +61,8 @@ Colon-prefixed path segments capture into `:params`. `:on-match` is the event ve
 | `:query` | Schemas for query-string keys. |
 | `:query-defaults` | Default values for query keys absent from the URL. |
 | `:tags` | Free-form classification, e.g. `#{:auth-required :admin-only :public}`. |
-| `:parent` | Another route id; builds a chain readable via `:rf.route/chain`. |
-| `:on-match` | Event vector(s) to dispatch when the route activates. |
+| `:parent` | Another route id. Builds a chain readable via `:rf.route/chain`, **and** composes the ancestors' `:resources` into this route's effective plan (parent-to-leaf, with identical requirements deduped). `:parent` is itself the opt-in; nothing else — `:on-match`, `:scroll`, `:head`, `:tags`, the guards — is inherited. |
+| `:on-match` | Event vector(s) the runtime **fires and forgets** when the route activates. It is not a readiness mechanism: it never moves `:rf.route/transition` / `:rf.route/error`, never awaits the async work its events start, and never rewrites their failures into route state — a throwing handler surfaces on the ordinary event error channel. Managed page reads belong in `:resources`. |
 | `:can-leave` | Guard sub-query run before leaving the route. Closed boolean contract: `true` allows, `false` blocks. Any non-boolean also blocks and emits `:rf.error/can-leave-non-boolean`. The name reads positively, so `false` means "can NOT leave". The sub receives the pending target as an argument. See [Routing → Blocking a navigation](../routing/concepts.md#blocking-a-navigation). |
 | `:can-enter` | Guard sub-query run before entering the route (the auth-gate mirror of `:can-leave`). Closed boolean contract: `true` allows entry, `false` blocks. Any non-boolean also blocks and emits `:rf.error/can-enter-non-boolean`. A rejection is TERMINAL — nothing commits, no pending value is created, and the runtime dispatches `:rf.route/entry-denied` once. See [Routing → Guarding entry](../routing/concepts.md#guarding-entry--can-enter). |
 | `:scroll` | Scroll-restoration behaviour for this route. |
@@ -449,15 +449,16 @@ The `:route/link` registered view renders an `<a href=...>` from a route id. It 
 - **Signature**:
   ```clojure
   [route-link {:to :route-id :params {...} :query {...} :fragment "..."
-               :on-click f & html-attrs}
+               :prefetch :intent :on-click f & html-attrs}
    & children]
   ```
 - **Description**: The registered `:route/link` view.
 
-  - `:to` is the only required key. `:params`, `:query`, and `:fragment` are forwarded to `route-url` for href synthesis. Every other props key passes through to the `<a>` element.
+  - `:to` is the only required key. `:params`, `:query`, and `:fragment` are forwarded to `route-url` for href synthesis. `:prefetch` is the one behaviour key (below). Every other props key passes through to the `<a>` element — including `:aria-current` and `:class`, which is how an "active link" is styled: `route-link` computes **no** active state, so compare `:to` against `:rf.route/id` (or `:rf.route/chain`) in your own view. See [Routing → Highlighting the active link](../routing/concepts.md#highlighting-the-active-link).
   - A plain primary-button click (no modifier keys, `defaultPrevented` false) is intercepted. The view calls `preventDefault`, then dispatches `[:rf.route/url-requested {:url ... :to ...}]` targeted at the frame that rendered the link.
   - Modifier-key / middle-button clicks, and anchors carrying native-handling attributes (`:target` other than `_self`, or `:download`), defer to the browser.
   - A caller-supplied `:on-click` runs first. If it calls `preventDefault`, the framework's interception is skipped.
+  - `:prefetch :intent` warms the destination on hover, focus, or touch by dispatching [`:rf.route/prefetch`](#events) with the link's own address (`:fragment` excluded — a fragment is never a resource input). `:intent` is the only accepted value; any other value, including `true`, opts out. Caller-supplied `:on-mouse-enter` / `:on-focus` / `:on-touch-start` handlers still run — the framework composes rather than replaces. CLJS only; SSR renders the anchor with no intent handlers.
   - The rendered href is encoded through the rendering frame's `:url-strategy`.
   - On the JVM the `:route/link` registration renders via [`route-link-render-ssr`](#route-link-render-ssr).
 - **Example**:
@@ -500,10 +501,11 @@ Standard events the runtime dispatches (or you dispatch) around routing.
 | `:rf.route/handle-url-change` | URL-change handler for popstate / initial load / SSR (default scroll `:restore`). A co-equal sibling of `:rf.route/transitioned`: same slice-rewrite logic, not a delegate. Override it for custom URL-change handling. |
 | `:rf.route/transitioned` | URL-change handler for forward navigation — a link click or programmatic push (default scroll `:top`). The runtime dispatches this; you read it. |
 | `:rf.route/url-requested` | The user clicked a framework-owned link. `route-link` synthesises this event; you usually let the default handler take it. |
-| `:rf.route/navigation-blocked` | A `:can-leave` (leave) guard rejected a navigation. The pending nav slot carries the rejected navigation (`:direction :leave`). |
+| `:rf.route/navigation-blocked` | A `:can-leave` guard rejected a navigation. The pending-nav slot carries the rejected attempt as `{:id :destination :target :cause :policy :requested-url :rejecting-route :rejecting-guard :url-restored?}`. The slot is **leave-only** — no direction discriminator, because there is only one thing it can be. |
 | `:rf.route/entry-denied` | A `:can-enter` guard rejected a navigation. **Terminal** — nothing commits and no pending value is created; dispatched exactly once per attempt with `{:destination :target :cause :requested-url :guard}`. The natural place to redirect (e.g. to login); a framework no-op default ships, so registering one is optional. |
-| `:rf.route/continue` | User-dispatched event proceeding a blocked navigation — "yes, leave the page." Re-runs `:can-enter` on resume. |
-| `:rf.route/cancel` | User-dispatched event abandoning a blocked navigation — "stay here, drop the pending nav." |
+| `:rf.route/continue` | User-dispatched event proceeding a blocked navigation — "yes, leave the page." Replays the pending value's `:destination` and `:policy` through the normal pipeline with a one-shot `:bypass-leave? true`, so the target's `:can-enter` is still evaluated. Event vector: `[:rf.route/continue pending-nav-id]`. |
+| `:rf.route/cancel` | User-dispatched event abandoning a blocked navigation — "stay here, drop the pending nav." Event vector: `[:rf.route/cancel pending-nav-id]`. |
+| `:rf.route/prefetch` | Warm a destination's effective resource plan without navigating: `[:rf.route/prefetch {:to :route/article :params {:slug "x"}}]`. Accepts a **named** address only (never `:url`); an invalid one rejects before planning with `:rf.error/prefetch-bad-address`. Runs the same parent-to-leaf plan a navigation would, in warm mode — every ensure ownerless, `:blocking?` inert, no route state, no guards, no `:on-match`. Frame-scoped, and a no-op beyond its `:rf.route/prefetched` summary trace when the resources artefact is absent or the plan is empty. `[route-link {… :prefetch :intent}]` dispatches it for you on hover / focus / touch. |
 
 ### Subscriptions
 
@@ -515,11 +517,11 @@ The full `:rf/route` slice is `{:route-id :params :query :fragment :transition :
 | `:rf.route/id` | Current route id (the slice's `:route-id`) |
 | `:rf.route/params` | Current path params |
 | `:rf.route/query` | Current query params |
-| `:rf.route/transition` | `:idle` / `:loading` / `:error` |
-| `:rf.route/error` | Current error map (when `:transition = :error`) |
+| `:rf.route/transition` | `:idle` / `:loading` / `:error` — a projection over the **blocking `:resources`** in the effective route plan. `:loading` while a blocking first load is pending; `:error` on a blocking first-load failure or a plan that could not be built; `:idle` otherwise (and always, with no resources artefact loaded). A background refresh, a non-blocking read, an intent prefetch, and `:on-match` never move it. |
+| `:rf.route/error` | The structured failure when `:transition` is `:error` — `:rf.error/resource-route-blocking` for a blocking first-load failure, `:rf.error/resource-route-plan` for a plan that could not be built; `nil` otherwise |
 | `:rf.route/fragment` | Current URL fragment (string or `nil`) |
 | `:rf.route/chain` | Vector of route ids from parent-most to current (per `:parent` links) |
-| `:rf/pending-navigation` | The pending-nav slot (per `:rf/pending-navigation` schema) when a navigation is blocked; `nil` otherwise. Read with `@(rf/subscribe [:rf/pending-navigation])`. |
+| `:rf/pending-navigation` | The pending-nav slot (per `:rf/pending-navigation` schema) when a `:can-leave` guard has parked a navigation; `nil` otherwise. Leave-only — a denied entry is terminal and parks nothing. Read with `@(rf/subscribe [:rf/pending-navigation])`. |
 
 ### Effects (`fx`)
 
@@ -531,7 +533,7 @@ The full `:rf/route` slice is `{:route-id :params :query :fragment :transition :
 | `[:rf.nav/capture-scroll {:url url-string}]` | `{:url ...}` map | `:client` | Capture the current scroll position into the host-side per-frame scroll-position cache (keyed by `url`) before leaving a route. |
 | `[:rf.route/with-nav-token {:rf/reply-to <reply-target> :nav-token <token>}]` | see notes | universal | Name an async-completion continuation by its canonical `:rf/reply-to` reply target and guard it with a navigation token. On a token match, the target is completed with the `:status :ok` reply map. If the token has been superseded by a later navigation, the completion is suppressed and `:rf.route.nav-token/stale-suppressed` fires. Optional args keys: `:route-id` (the captured route id, for the work-id), `:value` (rides the `:status :ok` reply map), `:completed-at`. |
 
-The nav-token wrapper guards against "user navigates away mid-load". The older load's reply carries the stale token. The runtime suppresses it, so the older page's data does not overwrite the newer page's state. Full semantics in [Routing → Loaders](../routing/concepts.md#loaders-declaring-a-pages-data).
+The nav-token wrapper guards against "user navigates away mid-load". The older load's reply carries the stale token. The runtime suppresses it, so the older page's data does not overwrite the newer page's state. Full semantics in [Routing → Activation work and page data](../routing/concepts.md#loaders-declaring-a-pages-data).
 
 ### Coeffects (`cofx`)
 

--- a/docs/routing/coming-from-react-router.md
+++ b/docs/routing/coming-from-react-router.md
@@ -26,17 +26,21 @@ you'd rather start from what you know.
 | Route object (`path`, `loader`, `errorElement`…) | The [route](glossary.md#route)'s metadata map | Same idea — behaviour declared as data — but a plain Clojure map, queryable from anywhere. |
 | `:slug` path param, `useParams()` | `:id` in the path + `@(subscribe [:rf.route/params])` | [Route params](glossary.md#route-params) are a [subscription](../core/glossary.md#subscription), validated *and coerced* by a schema. |
 | `useSearchParams()` | `@(subscribe [:rf.route/query])` | Separate map from path params — never merged. `?page=2` arrives as integer `2`. |
-| `loader` function | [`:on-match`](concepts.md#loaders-declaring-a-pages-data) (events) / `:resources` (data) | The [loader](glossary.md#loader) as *data* (vector of event vectors, or resource decls), not a function you call. |
-| `useLoaderData()` | An ordinary [subscription](../core/glossary.md#subscription) | The loader writes to [app-db](../core/glossary.md#app-db); the [view](../core/glossary.md#view) reads it like any other state. No special hook. |
+| `loader` function | [`:resources`](concepts.md#declaring-resources-instead) (data a page needs) / [`:on-match`](concepts.md#loaders-declaring-a-pages-data) (activation work) | The [loader](glossary.md#loader) as *data* — resource declarations, or a vector of event vectors — not a function you call. The two jobs are separate keys here; see [below](#one-loader-splits-into-two-honest-keys). |
+| `useLoaderData()` | An ordinary [subscription](../core/glossary.md#subscription) | The loaded data lands in the resource cache or [app-db](../core/glossary.md#app-db); the [view](../core/glossary.md#view) reads it like any other state. No special hook. |
 | `useNavigate()` → `navigate("/x")` | `(dispatch [:rf.route/navigate {:to :route :params params}])` | [Navigation is an event](concepts.md#move-2-navigation-is-an-event) — traceable, interceptable, rewound by time-travel. |
-| `<Link to>` / `<NavLink>` | `[route-link {:to :route}]` | Real `<a href>`, intercepts plain clicks, *defers* cmd/shift/middle-click to the browser. |
-| `useNavigation().state` (`"loading"`) | `@(subscribe [:rf.route/transition])` | Global `:idle`/`:loading`/`:error` you read anywhere — never threaded through a component. |
-| `errorElement` / `useRouteError()` | `:on-error` + `@(subscribe [:rf.route/error])` | Structured [error record](../core/glossary.md#error-record) in state, plus an optional event to respond. |
-| `useBlocker()` / `usePrompt()` | `:can-leave` guard + `@(rf/subscribe [:rf/pending-navigation])` | [Route guard](glossary.md#route-guard) sub (boolean) and a *pending navigation you render from* — confirm dialog is an ordinary view. |
-| Splat route `path="*"`, no-match route | Reserved [`:rf.route/not-found`](glossary.md#not-found) route | Ordinary route you register and design; carries loaders, scroll, and a `:reason` discriminator. |
-| `<Outlet/>` + nested route config | `:parent` + `@(subscribe [:rf.route/chain])` | Nesting is data; you walk the chain and compose layout shells yourself (no render-slot machinery — see [below](#theres-no---layouts-are-data-you-compose), and [The model → Nested layouts](concepts.md#nested-layouts)). |
+| `<Link to>` | `[route-link {:to :route}]` | Real `<a href>`, intercepts plain clicks, *defers* cmd/shift/middle-click to the browser. |
+| `<NavLink>`'s `isActive` | Compare `:to` against `@(subscribe [:rf.route/id])` in your own view | `route-link` computes **no** active state. "Am I on this page?" is a comparison against a route sub, and it becomes a four-line wrapper that sets `:aria-current` and a class — [the idiom](concepts.md#highlighting-the-active-link). |
+| `<Link prefetch="intent">` (Remix / framework mode) | `[route-link {:to :route :prefetch :intent}]` | Hover / focus / touch warms the destination's resource plan without navigating — [intent prefetch](concepts.md#warming-a-destination-before-the-click). `:intent` is the only mode; there is no render or viewport preloading. |
+| `useNavigation().state` (`"loading"`) | `@(subscribe [:rf.route/transition])` | Global `:idle`/`:loading`/`:error` you read anywhere — never threaded through a component. It reports the route's *blocking data*, not whether a router state machine is mid-flight. |
+| `errorElement` / `useRouteError()` | A blocking `:resources` entry + `@(subscribe [:rf.route/error])` | Declare the read the page can't do without as `:blocking? true` and its failure projects onto `:rf.route/transition :error` with a structured [error record](../core/glossary.md#error-record) on `:rf.route/error`. There is no route-level error *callback*: a route never manufactures an error out of activation work it merely started. |
+| `useBlocker()` / `usePrompt()` | `:can-leave` guard + `@(rf/subscribe [:rf/pending-navigation])` | [Route guard](glossary.md#route-guard) sub (boolean) and a *pending navigation you render from* — confirm dialog is an ordinary view. Leave-only; the entry guard is terminal ([below](#leaving-asks-the-user-entering-asks-the-app)). |
+| Route-level auth in a `loader` (`throw redirect(...)`) | `:can-enter` guard + a `:rf.route/entry-denied` handler | The guard runs in the one planning pipeline, so it covers programmatic navigation, link clicks, the URL bar, Back/Forward, initial load, and SSR without per-door plumbing. Denial is terminal — [Require sign-in](how-to/require-sign-in-on-a-route.md). |
+| Splat route `path="*"`, no-match route | Reserved [`:rf.route/not-found`](glossary.md#not-found) route | Ordinary route you register and design; carries activation events, scroll, and a `:reason` discriminator. |
+| `<Outlet/>` + nested route config | `:parent` + `@(subscribe [:rf.route/chain])` | Nesting is data; you walk the chain and compose layout shells yourself (no render-slot machinery — see [below](#theres-no---layouts-are-data-you-compose), and [The model → Nested layouts](concepts.md#nested-layouts)). A parent's `:resources` *do* compose into the child's plan, so a shared shell read is declared once. |
+| `state={{backgroundLocation}}` modal routing | An ordinary app-db flag beside the route | The URL names the thing being shown; whether it is shown *over* the list is a rendering decision your root view makes. Nothing masks the route, so Back, refresh, and deep-link all agree — [below](#modals-over-a-page-are-a-state-model-not-a-masked-route). |
 | `<RouterProvider router>` / router context | nothing | The route lives in [runtime-db](../core/glossary.md#runtime-db); any [view](../core/glossary.md#view) reads it via subscription. No provider, no context. |
-| Framework-mode (v7 / Remix) server loaders | The *same* `:on-match` / `:resources` | One loader runs on client **and** server. No second "server loader" to keep in sync. |
+| Framework-mode (v7 / Remix) server loaders | The *same* `:resources` / `:on-match` | One declaration runs on client **and** server. No second "server loader" to keep in sync. |
 
 If a row reads as "the same idea, minus the apparatus," you're reading it right.
 
@@ -81,10 +85,11 @@ a reaction; re-frame2 treats your state as truth and the URL as a print-out. Hen
 ### The loader is data, not a function
 
 React Router's `loader` is a function — to know what a route fetches, you read its
-body or run it. re-frame2's [loader](glossary.md#loader) is `:on-match` (a vector of
-[event](../core/glossary.md#event) vectors) or `:resources` (a list of declarations).
-Being *data* means you can read it, test it, and draw a route's data-dependency graph
-**without executing it** — `(rf/handler-meta :route :app/cart)` hands you the list.
+body or run it. re-frame2's [loader](glossary.md#loader) is `:resources` (a list of
+declarations) or `:on-match` (a vector of [event](../core/glossary.md#event)
+vectors). Being *data* means you can read it, test it, and draw a route's
+data-dependency graph **without executing it** —
+`(rf/handler-meta :route :app/cart)` hands you the list.
 
 And `:resources` closes the click-away race: on route entry each resource is owned by
 *this* navigation's nav-token; when a newer navigation supersedes it, a late reply is
@@ -94,7 +99,29 @@ Router's loaders are abortable, which helps, but abort isn't guaranteed to win t
 race; suppression is the correctness boundary, abort is the bandwidth optimisation on
 top.
 
-### The leave-guard is a subscription and the prompt is a view
+### One loader splits into two honest keys
+
+A React Router `loader` carries two jobs that pull in opposite directions: fetching
+the data the page cannot render without, and starting work that merely *begins* when
+you arrive — analytics, a host notification, a background sync. Because both live in
+one function, the router's `"loading"` state and its error surface answer for both,
+and a failed analytics beacon can redden a page whose content arrived fine.
+
+re-frame2 keeps them apart. `:resources` declares what the page needs, and it alone
+drives `:rf.route/transition` / `:rf.route/error`. `:on-match` is fire-and-forget
+activation: the runtime dispatches its events and never waits on them, correlates
+them, or rewrites their failures into route state — an `:on-match` handler that
+throws surfaces on the ordinary event error channel, attributed to the event that
+threw. So the progress bar means "this page's data isn't here yet" and nothing else,
+and work that owns its own status keeps it.
+
+The nesting story follows the same split. Declaring `:parent` composes the
+ancestors' `:resources` into the child's plan — a shell read is written once, and
+identical requirements across the branch dedupe to one fetch. Nothing else is
+inherited, because `:on-match`, `:scroll`, `:tags`, and the guards would each want
+a different merge rule.
+
+### Leaving asks the user, entering asks the app
 
 React Router's `useBlocker` hands you an imperative `blocker` object with a state
 machine you drive by hand; historically the "unsaved changes?" prompt bottomed out
@@ -105,6 +132,40 @@ you render from*. Confirm dialog is an ordinary view that reads
 `@(rf/subscribe [:rf/pending-navigation])`, with two buttons that `dispatch`
 `:rf.route/continue` or `:rf.route/cancel`. No imperative blocker, no native dialog,
 no modal-automation flakiness in tests — the whole flow asserts with zero DOM.
+
+The entry guard is deliberately *not* symmetric. "Really discard your draft?" is a
+question to the user, so it parks and waits. "Is this visitor signed in?" is a
+question to application state, answered the same way every time it's asked — so a
+`:can-enter` refusal is **terminal**: it commits nothing, parks nothing, and
+dispatches `:rf.route/entry-denied` once. The post-login return is an ordinary fresh
+navigation whose guard re-evaluates naturally, which is why nothing can loop and why
+there is no "enter anyway" flag to punch a hole through the gate.
+
+### Modals over a page are a state model, not a masked route
+
+React Router's idiom for "open the photo in a dialog over the feed" is to navigate
+to the photo route while stashing a `backgroundLocation` in history state, so the
+router renders the *old* match underneath the new one. It works, but the URL and the
+match now disagree, and the disagreement lives in history state — invisible to
+anything that reads the route.
+
+Here the URL still names the thing being shown, and whether it is shown *over* the
+list is an ordinary rendering decision:
+
+```clojure
+(rf/reg-view root-view []
+  (let [id @(subscribe [:rf.route/id])]
+    [:div
+     [page-for (if (= id :app/photo) :app/feed id)]   ;; the feed stays mounted
+     (when (= id :app/photo)
+       [photo-dialog])]))
+```
+
+The route is never masked, so Back, refresh, and a pasted deep link all agree on
+what the URL means — a deep link to the photo can render the dialog over the feed,
+or the full page, and that is your call rather than a consequence of how the visitor
+got there. If "came from the feed" genuinely matters, it is app state you write down
+on purpose, not a hidden field on a history entry.
 
 ### One loader runs on both client and server
 

--- a/docs/routing/concepts.md
+++ b/docs/routing/concepts.md
@@ -2,9 +2,9 @@
 
 <a id="routing-the-url-is-a-sub"></a>
 
-This page is the **routing model** — three moves, then loaders, guards, not-found,
-and URL binding. Full leave/enter recipes live in the how-tos; signatures live in
-[re-frame.routing](../api/re-frame.routing.md).
+This page is the **routing model** — three moves, then page data, guards,
+not-found, and URL binding. Full leave/enter recipes live in the how-tos;
+signatures live in [re-frame.routing](../api/re-frame.routing.md).
 
 To *build* a three-page app step by step, use the [tutorial](tutorial.md).
 
@@ -154,8 +154,8 @@ doors are covered).
 | Group | Keys | Controls |
 |---|---|---|
 | **Shape** | `:params`, `:query`, `:query-defaults` | URL ↔ maps |
-| **Lifecycle** | `:on-match`, `:can-leave`, `:can-enter` | Activate / guards |
-| **Layout** | `:doc`, `:parent`, `:tags`, `:scroll` | Nesting, grouping, scroll |
+| **Lifecycle** | `:on-match`, `:can-leave`, `:can-enter` | Fire-and-forget activation work / guards |
+| **Layout** | `:doc`, `:parent`, `:tags`, `:scroll` | Nesting (and `:resources` composition), grouping, scroll |
 | **Classification** | `:sensitive`, `:large` | Egress redaction of the route slice |
 | **Borrowed** | `:resources` (resources artefact), `:head` ([SSR head](../ssr/head.md)) | Server state / head model |
 
@@ -200,6 +200,28 @@ ranking cascade: [API `reg-route`](../api/re-frame.routing.md#reg-route).
 No `:to` / `:url`: `:query-merge` folds into the current query, `:query` replaces it
 wholesale, `:fragment` moves the anchor. Route and params carry over untouched.
 
+That one request covers most of what a list page needs, and each spelling says
+exactly what it means:
+
+```clojure
+;; Pagination — change one key, keep the filters.
+(rf/dispatch [:rf.route/navigate {:query-merge {:page 2}}])
+
+;; A new filter resets the page — nil removes a key rather than writing a blank.
+(rf/dispatch [:rf.route/navigate {:query-merge {:tag "clojure" :page nil}}])
+
+;; Clear every filter — replace the query wholesale.
+(rf/dispatch [:rf.route/navigate {:query {}}])
+
+;; A tab the user shouldn't be able to Back through — replace, don't push.
+(rf/dispatch [:rf.route/navigate {:query-merge {:tab "comments"} :replace? true}])
+```
+
+Reading it back is one sub — `@(subscribe [:rf.route/query])` — and the route's
+`:query` schema has already coerced the values, so `:page` is the number `2` rather
+than `"2"`. Declare `:query-defaults` and a deep link to the bare `/search` arrives
+with `:page 1` filled in, because defaults are applied when a URL is matched.
+
 ### Linking from views
 
 <a id="linking-from-views"></a>
@@ -223,12 +245,41 @@ that decides eligibility itself — plain primary-button click, no modifier keys
 `:rf.route/url-requested` on a match, letting the browser follow every click it
 rejects.
 
+Every prop `route-link` doesn't claim is passed through to the `<a>`, so styling,
+`:data-*`, and ARIA attributes work as they do on any anchor. Two behaviour props
+it does claim: `:prefetch :intent`
+([warming a destination](#warming-a-destination-before-the-click)) and the address
+keys used to build the `href`.
+
+<a id="highlighting-the-active-link"></a>
+
+#### Highlighting the active link
+
+`route-link` computes **no** active state — it renders one anchor and nothing else.
+"Am I on this page?" is a comparison against a route sub, which is the same
+question a breadcrumb or a tab strip asks, so it belongs in your view:
+
+```clojure
+(rf/reg-view nav-link [props label]
+  (let [active? (= (:to props) @(subscribe [:rf.route/id]))]
+    [rf/route-link (cond-> props
+                     active? (assoc :aria-current "page"
+                                    :class (str (:class props) " is-active")))
+     label]))
+```
+
+Compare `[:rf.route/id]` for "this section is active" and the whole
+`[:rf.route/chain]` when a parent tab should light up for any of its children.
+For an exact-URL match — one entry in a filter strip, say — compare `:params` or
+`:query` too. `:aria-current "page"` is what a screen reader announces; the class
+is what you style.
+
 <a id="what-happens-in-order"></a>
 
 ### Order of effects
 
 Navigate runs in a **locked order**: update route slice in runtime-db → push URL →
-dispatch loaders. State before URL on purpose.
+dispatch activation events. State before URL on purpose.
 
 <a id="navigating-to-a-raw-url-string"></a>
 
@@ -249,10 +300,13 @@ The current route lives in **runtime-db** (not app-db). You read; you never writ
 @(rf/subscribe [:rf.route/transition])   ;; :idle | :loading | :error
 @(rf/subscribe [:rf.route/error])
 @(rf/subscribe [:rf.route/chain])        ;; :parent ancestry (nested layouts)
-@(rf/subscribe [:rf/pending-navigation]) ;; blocked leave/enter, or nil
+@(rf/subscribe [:rf/pending-navigation]) ;; a leave the user hasn't answered, or nil
 ```
 
-`:transition` drives a global progress bar without per-page loading flags:
+`:transition` drives a global progress bar without per-page loading flags. It is a
+projection over the route's blocking `:resources`
+([details](#when-a-loader-fails)), so the bar is honest about page data and quiet
+about everything else:
 
 ```clojure
 (rf/reg-view progress-bar []
@@ -291,32 +345,42 @@ No `<Outlet/>` — nesting is data. Child names `:parent`; compose shells from
             (reverse (butlast chain)))))
 ```
 
+`:parent` earns its keep twice over: it gives you the chain to fold, and it
+composes the ancestors' `:resources` into the child's plan
+([below](#parent-resources-compose-to-the-child)). Nothing else is inherited.
+
 Tutorial builds this: [Step 7](tutorial.md#step-7--a-shared-layout).
 
-## Loaders: declaring a page's data
+## Activation work and page data
 
 <a id="loaders-declaring-a-pages-data"></a>
 
-**`:on-match`** — vector of event vectors on activate (including same route with
+Two different jobs live next to a route, and keeping them apart is the whole trick.
+
+**`:on-match`** is the *activation hook* — a vector of event vectors the runtime
+fires and forgets whenever the route becomes active (including the same route with
 changed params; identical params don't re-fire):
 
 ```clojure
 (rf/reg-route :app/cart
-  {:on-match [[:cart/load-items] [:user/load-prefs]]
-   :on-error [:app/cart-load-failed]}
+  {:on-match [[:analytics/viewed-cart] [:cart/seed-ui-state]]}
   "/cart")
 ```
 
-<a id="when-a-loader-fails"></a>
+It runs client- and server-side, after the route slice is written and before any
+view renders off it. What it is *not* is a readiness mechanism: `:on-match` never
+moves `:rf.route/transition`, never waits for the async work its events start, and
+never turns a handler's failure into a route error. Work that `:on-match` merely
+kicks off keeps its status in the subsystem that owns it. A handler that throws
+surfaces on the ordinary [event error channel](../core/errors.md), attributed to
+the event that threw.
 
-Runs client- and server-side. On loader failure, `:transition` → `:error`; optional
-`:on-error` event fires once (first error wins; later loaders still run).
-
-### Declaring resources instead
+### Declaring the data a page needs
 
 <a id="declaring-resources-instead"></a>
 
-With the resources artefact, declare cached server reads on the route:
+Managed server reads that must be present before the page is honest are declared
+with `:resources`, from the resources artefact:
 
 ```clojure
 (rf/reg-route :realworld.article/show
@@ -335,6 +399,86 @@ With the resources artefact, declare cached server reads on the route:
 Ownership is nav-token keyed: leave or supersede → release; late replies
 **suppressed**. Per-user data uses a scope resolver (`{:from-db …}`) — fails closed
 when logged out. Full story: [Resources model](../resources/concepts.md).
+
+<a id="when-a-loader-fails"></a>
+
+### Readiness is a projection over the blocking resources
+
+`:rf.route/transition` and `:rf.route/error` report one honest fact: whether the
+blocking reads the active route plan declares are present, still on their first
+load, or failed.
+
+| Plan state | `:transition` | `:error` |
+|---|---|---|
+| A blocking first load is still pending | `:loading` | `nil` |
+| A blocking first load failed | `:error` | the first failure (`:rf.error/resource-route-blocking`) |
+| The plan could not be built at all | `:error` | `:rf.error/resource-route-plan` |
+| Every blocking read has usable data, or there are none | `:idle` | `nil` |
+
+A background refresh over data already on screen is not `:loading`, and a refresh
+failure stays on the resource's own channel rather than reddening the route. A
+non-blocking read, an [intent prefetch](#warming-a-destination-before-the-click),
+and `:on-match` never change either value. With no resources artefact loaded the
+route is always `:idle` — there is nothing to be honest about.
+
+### Parent resources compose to the child
+
+<a id="parent-resources-compose-to-the-child"></a>
+
+Naming a `:parent` opts the child into its ancestors' `:resources`. Activation
+plans the effective parent-to-leaf branch, so a shell read is declared **once** on
+the parent instead of restated in every tab:
+
+```clojure
+(rf/reg-route :app/profile
+  {:params    [:map [:username :string]]
+   :resources [{:resource  :app/profile
+                :params    (fn [route] {:username (get-in route [:params :username])})
+                :blocking? true}]}
+  "/profile/:username")
+
+(rf/reg-route :app/profile-favorites
+  {:parent    :app/profile                    ;; inherits the profile read above
+   :params    [:map [:username :string]]
+   :resources [{:resource  :app/favorited-articles
+                :params    (fn [route] {:username (get-in route [:params :username])})
+                :blocking? false}]}
+  "/profile/:username/favorites")
+```
+
+`:parent` *is* the opt-in — there is no separate inherit flag. Only `:resources`
+fold this way; `:on-match`, `:scroll`, `:head`, `:tags`, and the guards are not
+inherited, because unrelated metadata wants incompatible merge rules. Identical
+requirements contributed by more than one route in the branch are deduped to one
+fetch, and a child that restates a requirement its parent already contributes gets
+an advisory rather than a second fetch. Composing resources does not compose
+rendering: the layout chain is still yours to walk
+([Nested layouts](#nested-layouts)).
+
+<a id="warming-a-destination-before-the-click"></a>
+
+### Warming a destination before the click
+
+A link can warm its destination's data on hover, focus, or touch, so the click
+lands on a fetch already in flight:
+
+```clojure
+[rf/route-link {:to :app/article :params {:id "intro"} :prefetch :intent}
+ "Read more"]
+```
+
+`:intent` is the only accepted value — there is no render mode, viewport mode, or
+hover delay, and a passive render dispatches nothing. Under the hood the link
+dispatches `[:rf.route/prefetch {:to :app/article :params {:id "intro"}}]`, which
+you can also dispatch yourself from any event.
+
+A prefetch runs the *same* effective branch plan a real navigation would, in warm
+mode: every ensure is ownerless, `:blocking?` is inert, and no route state moves —
+no slice write, no URL, no scroll, no guards, no `:on-match`. Click through
+afterwards and the ordinary resource dedupe reuses the warmed work; never click and
+it stays garbage-collectable. Prefetch is a performance hint, not an authorization
+boundary — warming a destination whose `:can-enter` would deny is permitted and
+means nothing, because activation still evaluates the guard.
 
 ## Blocking a navigation
 
@@ -500,10 +644,10 @@ Copy-paste shape (pages and loaders are stubs — fill in as the tutorial does):
 
 <a id="a-hand-rolled-async-loader"></a>
 
-`:on-match` and `:resources` are the everyday loaders. Roll your own async fetch and
-you inherit the race they close: open article A, navigate to B before A's reply
-lands, late A overwrites B. Capture the **navigation token** when the load starts
-and gate delivery on it.
+`:resources` is the everyday way to load a page. Roll your own async fetch from
+`:on-match` and you inherit the race it closes: open article A, navigate to B
+before A's reply lands, late A overwrites B. Capture the **navigation token** when
+the load starts and gate delivery on it.
 
 Two hooks: `:rf.route/nav-token` **cofx** injects the live token into an
 `:on-match` handler; `:rf.route/with-nav-token` **fx** delivers a reply only while

--- a/docs/routing/glossary.md
+++ b/docs/routing/glossary.md
@@ -30,10 +30,27 @@ and defaulted) drive handlers and views; `?page=2` survives Back for free.
 
 ### **loader**
 
-What a [route](#route) declares it needs on entry — `:on-match` [events](../core/glossary.md#event)
-dispatched by the runtime, and/or `:resources` ensured loaded — so a page's data
-requirement sits next to its URL. Loaders also run on the server; no separate SSR
-data-fetch to keep in sync.
+What a [route](#route) declares it needs on entry — `:resources` ensured loaded — so
+a page's data requirement sits next to its URL. Loaders also run on the server; no
+separate SSR data-fetch to keep in sync. A route's `:on-match` events are its
+*activation work*, not its loader: the runtime fires and forgets them, and they never
+touch route readiness. See [Activation work and page data](concepts.md#loaders-declaring-a-pages-data).
+
+### **effective route plan**
+
+The resource requirements a navigation actually runs: every `:resources` entry
+contributed by the route's [chain](#route-chain), parent-most to leaf, with identical
+requirements deduped to one fetch. Naming a `:parent` is what opts a child in, so a
+shared shell read is declared once instead of restated per tab. Only `:resources`
+compose this way.
+
+### **intent prefetch**
+
+Warming a destination's [effective route plan](#effective-route-plan) before the user
+commits, via `[route-link {… :prefetch :intent}]` or a direct
+`[:rf.route/prefetch <address>]` dispatch. Hover, focus, or touch runs the same plan
+a navigation would — ownerless, non-blocking, and with no route state, guards, or
+`:on-match`. Click through and the ordinary resource dedupe reuses the warmed work.
 
 ### **route chain**
 
@@ -44,9 +61,13 @@ page; each ancestor wraps a shell. See [Nested layouts](concepts.md#nested-layou
 
 ### **transition**
 
-Route-slice loading state — `:idle`, `:loading` (a [loader](#loader) still running),
-or `:error` (one failed) — via `:rf.route/transition`. One global fact for a progress
-bar or error banner, not per-page loading flags.
+Route readiness — `:idle`, `:loading`, or `:error` — via `:rf.route/transition`, with
+the structured failure on `:rf.route/error`. It is a projection over the blocking
+`:resources` in the [effective route plan](#effective-route-plan): pending on a first
+load, `:error` on a blocking first-load failure or a plan that could not be built,
+`:idle` otherwise. A background refresh, a non-blocking read, an
+[intent prefetch](#intent-prefetch), and `:on-match` never move it. One global fact
+for a progress bar or error banner, not per-page loading flags.
 
 ### **nav-token**
 
@@ -58,12 +79,24 @@ overwriting the page you are on. Hand-rolled loaders opt in via the
 ### **route guard**
 
 A boolean subscription on a [route](#route): **`:can-leave`** (`true` = leave is fine)
-or **`:can-enter`** (`true` = enter is fine). `false` parks the attempt in
-`[:rf/pending-navigation]`; your [view](../core/glossary.md#view) resolves it with
-`[:rf.route/continue <id>]` or `[:rf.route/cancel <id>]` (the pending-nav id).
-Unsaved changes → leave guard ([recipe](how-to/guard-unsaved-changes.md)); per-route
-auth → enter guard; multi-route policy → optional interceptor
-([recipe](how-to/require-sign-in-on-a-route.md)).
+or **`:can-enter`** (`true` = enter is fine). The two refusals are deliberately
+asymmetric. A `:can-leave` `false` **parks** the attempt in
+`[:rf/pending-navigation]` — a question to the user — and your
+[view](../core/glossary.md#view) resolves it with `[:rf.route/continue <id>]` or
+`[:rf.route/cancel <id>]` (the pending-nav id). A `:can-enter` `false` is
+[terminal](#terminal-entry): a question to application state, answered the same way
+every time, so nothing commits and nothing parks. Unsaved changes → leave guard
+([recipe](how-to/guard-unsaved-changes.md)); per-route auth → enter guard
+([recipe](how-to/require-sign-in-on-a-route.md)); multi-route policy → optional
+interceptor.
+
+### **terminal entry**
+
+What a refused `:can-enter` does: commit no route slice, URL, scroll, resource, or
+`:on-match`; park no pending value; and dispatch `:rf.route/entry-denied` exactly
+once with the replayable `:destination`. There is nothing to resume and no entry
+bypass — the return after signing in is a fresh navigation whose guard re-evaluates
+naturally. Under SSR the same refusal renders the shell under a `403`.
 
 ### **not-found**
 

--- a/docs/routing/how-to/guard-unsaved-changes.md
+++ b/docs/routing/how-to/guard-unsaved-changes.md
@@ -82,9 +82,33 @@ renders nothing until something is pending.
                                           :bypass-leave? true}]]]}))
 ```
 
-Saving would make the guard pass anyway — `:bypass-leave? true` makes the
-intent explicit. Same set form skips the target's `:can-enter` (`#{:enter}`) or both
-(`#{:leave :enter}`).
+Saving would make the guard pass anyway — `:bypass-leave? true` makes the intent
+explicit, and it is the only bypass there is. It skips *this* route's `:can-leave`
+for *this* one navigation; the target's `:can-enter` still runs, because an "enter
+anyway" flag would be a hole straight through the auth gate.
+
+## 5. Cover the hard exit too
+
+A pending value is a fact inside your app, so it cannot stop the browser closing the
+tab, following an external link, or reloading. That is a host concern, and the honest
+pairing is a `beforeunload` listener reading the *same* dirty state the guard reads:
+
+```clojure
+(defn install-unload-warning!
+  "Ask the browser to confirm a hard exit while the draft is dirty.
+   Same source of truth as :editor/can-leave? — one dirty flag, two exits."
+  []
+  (.addEventListener js/window "beforeunload"
+    (fn [e]
+      (when-not @(rf/subscribe [:editor/can-leave?])
+        (.preventDefault e)
+        (set! (.-returnValue e) "")))))   ;; the browser owns the wording
+```
+
+Call it once at boot. Routing deliberately does not wrap this: the browser shows its
+own non-customisable dialog, only when the user has interacted with the page, and
+only on a real unload — a second confirmation API pretending otherwise would be
+lying. Deriving both exits from one sub is what keeps them from disagreeing.
 
 ## Test it with zero DOM
 

--- a/docs/routing/testing.md
+++ b/docs/routing/testing.md
@@ -33,9 +33,9 @@ grammar of the whole route table unit-tests as plain function calls:
 
 ```clojure
 (deftest article-urls-round-trip
-  ;; route → URL
+  ;; route → URL — query keys print in canonical order, not the order you wrote them
   (is (= "/articles/intro" (rf.routing/route-url {:to :app/article :params {:id "intro"}})))
-  (is (= "/search?q=clojure&page=2#results"
+  (is (= "/search?page=2&q=clojure#results"
          (rf.routing/route-url {:to :app/search :query {:q "clojure" :page 2} :fragment "results"})))
   ;; URL → route — schemas validate AND coerce, so :page comes back an int
   (let [m (rf.routing/match-url "/search?q=clojure&page=2")]
@@ -69,12 +69,19 @@ frame:
     (is (= {:id "intro"} @(rf/subscribe [:rf.route/params])))))
 ```
 
-If the route declares `:on-match` loaders, they dispatch inside the same drain — a
-loader that fires [managed HTTP](../async/http.md) wants the same canned-reply stubs
-a pipeline-run test uses. `@(rf/subscribe [:rf.route/transition])` is the
-`:idle` / `:loading` / `:error` fact; loader failure lands a structured error in
-`@(rf/subscribe [:rf.route/error])` — assert on its category,
-[never its prose](../core/errors.md#test-the-structure-not-the-string).
+If the route declares `:on-match` events, they dispatch inside the same drain — one
+that fires [managed HTTP](../async/http.md) wants the same canned-reply stubs a
+pipeline-run test uses. Assert on what those events *did*: they never move
+`@(rf/subscribe [:rf.route/transition])`, so a test that watches the transition to
+prove an `:on-match` handler ran is watching the wrong thing.
+
+`:rf.route/transition` and `:rf.route/error` report the route's **blocking
+`:resources`**. Drive them by stubbing the resource read — a blocking read still on
+its first load holds `:loading`, and a failed one lands a structured error in
+`@(rf/subscribe [:rf.route/error])`. Assert on its category,
+[never its prose](../core/errors.md#test-the-structure-not-the-string). Route
+resources ensure, stub, and read exactly as they do anywhere else:
+[Testing resources](../resources/testing.md).
 
 ## 3. Deep links, and the 404
 
@@ -99,10 +106,10 @@ Pasted link, reload, back/forward, and the SSR request all funnel through
 percent-encoding (`:malformed-url`) — one assertion each if the not-found view
 branches on it.
 
-## 4. The leave guard, with zero DOM
+## 4. The guards, with zero DOM
 
-`:can-leave` is a subscription; blocked navigation is *state*; the user's choice is a
-dispatch. Whole flow, four asserts:
+`:can-leave` is a subscription; the blocked navigation is *state*; the user's choice
+is a dispatch. Whole flow, four asserts:
 
 ```clojure
 (deftest leave-guard-parks-and-continues
@@ -125,10 +132,31 @@ dispatch. Whole flow, four asserts:
 ```
 
 Dispatch `[:rf.route/cancel <id>]` instead and the pending slot clears with the slice
-unmoved. `{:bypass-leave? true}` skips the park. The `:can-enter` counterpart tests
-the same way — guarded target, signed-out sub, assert pending fills with
-`:direction :enter`, then flip the sub and `[:rf.route/continue <id>]` (re-runs
-`:can-enter`).
+unmoved. `{:bypass-leave? true}` skips the park entirely.
+
+The **entry** guard asserts differently, because a refusal is terminal — it parks
+nothing, so there is no pending value to look for. Register a spy handler for
+`:rf.route/entry-denied`, attempt the navigation signed out, and check that the
+slice did not move and the denial fired exactly once:
+
+```clojure
+(deftest entry-denied-commits-nothing
+  (rf/with-new-frame [f (rf/make-frame {})]
+    (let [denials (atom [])]
+      (rf/reg-event :rf.route/entry-denied
+        (fn [_ [_ denial]] (swap! denials conj denial) {}))
+      (rf/dispatch-sync [:rf.route/navigate {:to :app/settings}])
+      (is (not= :app/settings @(rf/subscribe [:rf.route/id])))
+      (is (nil? @(rf/subscribe [:rf/pending-navigation])))   ;; terminal: nothing parked
+      (is (= 1 (count @denials)))
+      (is (= {:to :app/settings} (:destination (first @denials)))))))
+```
+
+`:destination` is the replayable address, so the return-after-sign-in path is
+another `dispatch-sync` of `[:rf.route/navigate destination]` with the guard's sub
+flipped — an ordinary fresh attempt, not a resume. Note the shape: the destination
+omits an empty `:params` / `:query` and a `nil` `:fragment`, so compare it against
+`{:to :app/settings}`, not a fully-spelled address map.
 
 ## What lives elsewhere
 

--- a/docs/routing/tutorial.md
+++ b/docs/routing/tutorial.md
@@ -327,6 +327,12 @@ reach for the chain only when a shell wraps a *subtree*.
 > with the `case`/`reduce` you'd write for any conditional view. The only
 > routing-specific piece is the one `:rf.route/chain` read. [The model → Nested layouts](concepts.md#nested-layouts).
 
+> **`:parent` does one more thing.** Once you start declaring a page's data with
+> `:resources`, a child inherits its ancestors' declarations automatically — so a
+> shell read is written once on the parent instead of restated in every child.
+> Nothing else is inherited; `:on-match`, `:scroll`, and the guards stay per-route.
+> [The model → Parent resources compose to the child](concepts.md#parent-resources-compose-to-the-child).
+
 ## The complete shape
 
 | Piece | Surface | You supply |

--- a/examples/capabilities/resources/infinite_feed/README.md
+++ b/examples/capabilities/resources/infinite_feed/README.md
@@ -104,6 +104,17 @@ than guesses**: hand it a non-vector page with no accessor and it raises
 silently producing a list of nothing. (A feed whose pages are already bare
 vectors needs no accessor — those flatten by identity.)
 
+**The home page's link warms the feed on intent.** The one link into the timeline
+carries `:prefetch :intent`, so hovering (or focusing, or touching) it runs the
+destination's resource plan *without navigating* — the click then lands on page 0
+already in flight or cached rather than on the first-load skeleton. Warm mode is
+deliberately narrow: the ensure is **ownerless**, `:blocking?` is inert, and no
+route state moves — no slice write, no URL, no `:on-match`, no guards. Follow the
+link and ordinary dedupe reuses the warmed work; never follow it and the warmed
+entry stays garbage-collectable, owned by nobody. `:intent` is the only mode there
+is — a passive render dispatches nothing. See
+[intent prefetch](../../../../docs/routing/concepts.md#warming-a-destination-before-the-click).
+
 **Scope is the fail-closed leak boundary.** This feed is public — the same rows
 for every viewer — so it carries the explicit, auditable
 [`:scope`](../../../../docs/resources/glossary.md#scope) `:rf.scope/global` claim.

--- a/examples/capabilities/resources/infinite_feed/core.cljs
+++ b/examples/capabilities/resources/infinite_feed/core.cljs
@@ -253,7 +253,17 @@
         merged list passively and dispatches a causal load-more. No app-db
         list slice, no cursor threading, no append reducer — the runtime owns
         it all."]
+   ;; `:prefetch :intent` warms the destination on hover / focus / touch, so the
+   ;; click lands on page 0 already in flight or cached instead of on the
+   ;; first-load skeleton. It runs the SAME plan the navigation would, in warm
+   ;; mode: the ensure is ownerless, `:blocking?` is inert, and no route state
+   ;; moves — no slice, no URL, no `:on-match`, no guards. Follow the link and
+   ;; ordinary resource dedupe reuses the warmed work rather than refetching;
+   ;; never follow it and nothing is left owned. `:intent` is the only mode —
+   ;; a passive render dispatches nothing. See
+   ;; ../../../../docs/routing/concepts.md#warming-a-destination-before-the-click
    [:p [rf/route-link {:to :infinite-feed.app/timeline
+                       :prefetch :intent
                        :data-testid "route-link-timeline"}
         "Open the timeline →"]]])
 

--- a/scripts/check_doc_slugs.py
+++ b/scripts/check_doc_slugs.py
@@ -415,13 +415,14 @@ _HANDBOOK_DOC_LINK_RE = re.compile(
 # The set is deliberately tiny and each key MUST be a real manifest anchor (a
 # self-test enforces that), so placement and the anchor manifest stay in lock-step.
 COMPAT_ANCHOR_PLACEMENT = {
-    # The loader-failure bookmark names the two-line "On loader failure ..."
-    # explanation, which sits between the "Loaders" heading and the unrelated
-    # "Declaring resources instead" heading. The anchor must precede that
-    # explanation so `#when-a-loader-fails` lands ON it, not on the resources
-    # section below it (the rf2-zq5i6 bug).
+    # The loader-failure bookmark names the explanation of what a failed page
+    # read does to the route. EP-0037 R1 retired route `:on-error`, so the
+    # passage it names is now the resource-derived readiness projection and its
+    # failure rows, not the old "On loader failure ..." lines. The anchor must
+    # still precede that passage so `#when-a-loader-fails` lands ON it rather
+    # than scrolling past onto the next section (the rf2-zq5i6 bug).
     ("docs/routing/concepts.md", "when-a-loader-fails"):
-        re.compile(r"On loader failure"),
+        re.compile(r"A blocking first load failed"),
 }
 
 

--- a/skills/re-frame2/patterns/resources.md
+++ b/skills/re-frame2/patterns/resources.md
@@ -188,7 +188,11 @@ Routes are not required, but when a load is route-scoped, declare it on the rout
   "/articles/:slug")
 ```
 
-`:blocking?` keeps the route transition pending and gives SSR a wait point; `:when` gates conditional resources (use it, not sentinel `nil` params); `:keep-previous?` keeps the prior page visible while a new page/filter first-loads. `:after #{local-id}` orders **ensure-dispatch only** — it is **not** a data waterfall (a later entry's params come from the *route*, not an earlier entry's loaded data). `:on-match` remains canonical for arbitrary route-entry work — `:resources` is declarative server-state beside it, not a second router.
+`:blocking?` keeps the route transition pending and gives SSR a wait point; `:when` gates conditional resources (use it, not sentinel `nil` params); `:keep-previous?` keeps the prior page visible while a new page/filter first-loads. `:after #{local-id}` orders **ensure-dispatch only** — it is **not** a data waterfall (a later entry's params come from the *route*, not an earlier entry's loaded data).
+
+**Do not restate a parent's reads in every child.** Declaring `:parent` composes the ancestors' `:resources` into the child's plan: activation runs the effective parent-to-leaf branch, identical requirements dedupe to one fetch, and a child that restates a requirement its parent already contributes earns an advisory rather than a second fetch. So a shared shell read (the profile banner behind three profile tabs) is declared **once** on the parent, and the tabs cannot drift its `:blocking?`. Gate a leaf-only entry with `:when` on the route id rather than moving it down. `:parent` is itself the opt-in — nothing else about it is inherited.
+
+**`:resources` drives route readiness; `:on-match` does not.** `:rf.route/transition` / `:rf.route/error` are a projection over the *blocking* requirements in the effective plan, so they mean "this page's data isn't here yet" and nothing else. `:on-match` is fire-and-forget activation work beside them — arbitrary route-entry events the runtime dispatches and never awaits, correlates, or turns into route error state. There is no route `:on-error`.
 
 ## When to use vs plain managed HTTP
 

--- a/skills/re-frame2/references/tooling/routing.md
+++ b/skills/re-frame2/references/tooling/routing.md
@@ -1,15 +1,16 @@
 # Routing — re-frame2 binding
 
-> Authoring `reg-route`, programmatic navigation, link wiring, and the `:can-leave` pending-nav protocol. Assumes you already know what client-side routing is — this leaf only covers re-frame2's specific declarations.
+> Authoring `reg-route`, programmatic navigation, link wiring, and the asymmetric guard protocol (resumable leave, terminal entry). Assumes you already know what client-side routing is — this leaf only covers re-frame2's specific declarations.
 
 ## When to load
 
 - Author or edit route registrations (`reg-route`).
 - Wire programmatic navigation (`:rf.route/navigate`) or anchor clicks (`:rf.route/url-requested`).
-- Add a leave-guard (`:can-leave`), `:on-match` data loading, or scroll behaviour.
+- Add a leave-guard (`:can-leave`) or entry-guard (`:can-enter`), declare a page's `:resources`, or set scroll behaviour.
 - Read the active route in a view via `:rf.route/id` / `:rf.route/params`.
+- Carry query state across routes, warm a destination on intent, or style an active link.
 
-Do **not** load this leaf to learn what routing is — that is training knowledge. Load it for: the route-metadata key set, the slice shape, the event vocabulary, and the can-leave pending-nav protocol that distinguishes re-frame2 from hook-based routers like React Router's `useBlocker`.
+Do **not** load this leaf to learn what routing is — that is training knowledge. Load it for: the route-metadata key set, the slice shape, the event vocabulary, and the guard protocol that distinguishes re-frame2 from hook-based routers like React Router's `useBlocker` — a leave rejection parks a resumable pending value, an entry rejection is terminal.
 
 ## Canonical signatures
 
@@ -48,7 +49,8 @@ The runtime maintains one slice in the runtime-db partition at `[:rf.runtime/rou
  :params     {:id "intro"}
  :query      {:tab :comments}
  :fragment   "section-2"        ;; URL #fragment, or nil
- :transition :idle              ;; :idle | :loading | :error
+ :transition :idle              ;; :idle | :loading | :error — a projection over the
+                                ;;   blocking :resources, NOT the :on-match drain
  :error      nil                ;; structured error map when :transition = :error
  :nav-token  "nav-42"}          ;; per-navigation epoch token
 ```
@@ -74,7 +76,7 @@ Distilled from `examples/capabilities/routing/routing/core.cljs`.
 (rf/reg-route :route/article-detail
   {:doc "One article."
    :params [:map [:id :string]]
-   :on-match [[:article/load]]}            ;; runs after every match; sets :transition :loading
+   :on-match [[:article/load]]}            ;; fire-and-forget activation work; does NOT drive :transition
   "/articles/:id")
 
 (rf/reg-route :rf.route/not-found              ;; canonical fallback id
@@ -119,7 +121,7 @@ Distilled from `examples/capabilities/routing/routing/core.cljs`.
            [root-view]]))
 ```
 
-## `:can-leave` — the pending-nav protocol
+## The guards — resumable leave, terminal entry
 
 A route may declare a leave-guard sub. The sub returns `true` when leaving is OK, `false` to block. Convention: the *sub name* describes the positive case, so `false` means "can NOT leave".
 
@@ -133,22 +135,35 @@ A route may declare a leave-guard sub. The sub returns `true` when leaving is OK
   (fn [dirty? _] (not dirty?)))              ;; true means "OK to leave"
 ```
 
-`:can-enter` is the entry guard, declared on the **target** route. The pipeline decides leave-then-enter: the current route's `:can-leave` first, then the target's `:can-enter`. The two rejections are asymmetric — a leave rejection parks one resumable pending value (`:rf.route/continue` / `:rf.route/cancel`), while an entry rejection is **terminal**: it commits nothing, parks nothing, and dispatches `:rf.route/entry-denied` once. The auth recipe is a fresh return: stash the denial's `:destination`, replace-navigate to login, and after sign-in dispatch a fresh `[:rf.route/navigate <destination>]`.
+`:can-enter` is the entry guard, declared on the **target** route, and it runs in the one planning pipeline — so it covers every door (programmatic navigate, link click, URL bar, Back/Forward, initial load, SSR) with no per-door plumbing. A hand-rolled interceptor attached only to `:rf.route/navigate` fails OPEN through the other two; prefer `:can-enter` for a per-route gate and reach for an interceptor only when one policy genuinely spans many routes.
+
+The pipeline decides leave-then-enter: the current route's `:can-leave` first, then the target's `:can-enter`. Both take the closed boolean contract — any non-boolean refuses AND emits `:rf.error/can-leave-non-boolean` / `:rf.error/can-enter-non-boolean`, so write `(boolean …)` rather than leaning on truthiness. Each guard sub also receives the resolved target appended to its query vector — `(fn [inputs [_ target] …])`, where `target` is `{:route-id :params :query :fragment :url}` — so one shared guard can branch on where the visitor was headed.
+
+The two rejections are deliberately asymmetric, because the two questions are not the same shape. *Leaving* asks the user ("really discard your draft?"), so it parks one resumable pending value resolved by `:rf.route/continue` / `:rf.route/cancel`. *Entering* asks application state ("is this visitor signed in?"), answered the same way every time it is asked, so a rejection is **terminal**: it commits nothing (no slice, URL, scroll, resource, or `:on-match`), parks nothing, and dispatches `[:rf.route/entry-denied denial]` exactly once with `{:destination :target :cause :requested-url :guard}`. A framework no-op default ships, so a denial with no handler is a plain hard deny (and a `403` under SSR).
+
+The auth recipe is a **fresh return**, not a resume: register `:rf.route/entry-denied`, stash the denial's `:destination`, replace-navigate to login, and after sign-in dispatch a fresh `[:rf.route/navigate <destination>]` whose guard re-evaluates naturally. Nothing can loop, because nothing was left pending. `:destination` is already a valid navigate request — do not re-derive it from `:requested-url` — but note it omits an empty `:params` / `:query` and a nil `:fragment`, so a bare stash reads `{:to :account}`.
 
 Flow on `:rf.route/url-requested`:
 
 1. Runtime evaluates the **current** route's `:can-leave` sub.
-2. **`true`** → proceed; new URL becomes active; `:on-match` runs; nav-token allocates.
-3. **`false`** → block: write the pending-nav slot at `[:rf.runtime/routing :pending-navigation]` with `{:id "pn-N" :requested-url … :requested-by-event … :reason … :direction … :rejecting-route … :rejecting-guard …}`; emit `:rf.route/navigation-blocked` trace; do NOT push the URL or update the slice.
+2. **`true`** → proceed to the target's `:can-enter`; on pass the new URL becomes active, `:on-match` runs, nav-token allocates.
+3. **`false`** → block: write the pending-nav slot at `[:rf.runtime/routing :pending-navigation]` with `{:id "pn-N" :destination … :target … :cause … :policy … :requested-url … :rejecting-route … :rejecting-guard … :url-restored?}`; emit `:rf.route/navigation-blocked`; do NOT push the URL or update the slice. The slot is **leave-only** — there is no `:reason` / `:direction` discriminator, because there is only one thing it can be.
 4. UI subscribes to `:rf/pending-navigation` (the framework-shipped sub over the slot), renders a confirm dialog.
-5. User dispatches `[:rf.route/continue pn-id]` (re-issues the original nav, bypassing the guard for this one shot) or `[:rf.route/cancel pn-id]` (clears the slot).
+5. User dispatches `[:rf.route/continue pn-id]` — which replays the stored `:destination` plus `:policy` through the normal pipeline with a one-shot `:bypass-leave? true`, so the target's `:can-enter` is still evaluated — or `[:rf.route/cancel pn-id]` (clears the slot). Both ignore a non-matching id.
+
+`:bypass-leave? true` on a `:rf.route/navigate` request is the only bypass: it skips the CURRENT route's `:can-leave` for that one navigation. There is no entry bypass — entry is terminal, so there is nothing to wave through, and an "enter anyway" flag would be a hole through the auth gate.
 
 ## Common gotchas — re-frame2-specific
 
 - **Routing is a separate artefact.** `re-frame.core` does not transitively require `re-frame.routing`. The consuming app `:require`s it at boot; otherwise `reg-route` throws `:rf.error/routing-artefact-missing`. The reserved `:rf.route/*` and `:rf.nav/*` keyword strings therefore drop out of bundles that don't use routing.
 - **Navigation is an event, not a fn call.** Use `(rf/dispatch [:rf.route/navigate {:to :route/articles}])` (programmatic) or `(rf/dispatch [:rf.route/url-requested {:url ...}])` (anchor clicks). The navigate request is one map — address keys `:to` / `:url` / `:params` / `:query` / `:fragment`, policy keys `:replace?` / `:scroll` / `:bypass-leave?`, edit key `:query-merge`; omit `:to` and `:url` for an in-place patch of the current location. Do NOT call `pushState` directly.
-- **`:on-match` runs every time the route becomes active.** Including first match. It is a vector of event vectors (not fns). On entering a route with `:on-match`, the slice's `:transition` field (at `[:rf.runtime/routing :current :transition]`) flips to `:loading`; runtime resets it to `:idle` after the events drain (or `:error` on `:on-error`).
+- **`:on-match` is fire-and-forget activation work, NOT a loader.** It runs every time the route becomes active (including the first match, and again when `:params` / `:query` change), and it is a vector of event vectors, not fns. It never touches `:transition` / `:error`: the runtime dispatches its events, does not await the async work they start, and does not rewrite their failures into route state — a throwing handler surfaces on the ordinary event error channel, attributed to the event that threw. Data a page cannot render without belongs in `:resources`. There is **no** route `:on-error` key (retired, no alias — a route declaring it is rejected as an unknown bare key).
+- **Route readiness is a projection over the blocking `:resources`.** `:rf.route/transition` is `:loading` while a blocking first load is pending, `:error` on a blocking first-load failure (`:rf.error/resource-route-blocking` on `:rf.route/error`) or a plan that could not be built (`:rf.error/resource-route-plan`), `:idle` otherwise — and always `:idle` when no resources artefact is loaded. A background refresh over data already on screen, a non-blocking read, and an intent prefetch never move it.
 - **`:on-match` order is locked.** State-update first (slice + nav-token), URL push second, `:on-match` dispatches and `:rf.nav/scroll` third. If the URL update fails, the slice is still consistent.
+- **`:parent` composes `:resources`, and nothing else.** Declaring `:parent` opts the child into its ancestors' `:resources`: activation plans the effective parent-to-leaf branch, identical requirements dedupe to one fetch, and a child restating a parent's requirement gets an advisory rather than a second fetch. `:parent` is itself the opt-in — there is no `:inherit-resources?` marker. `:on-match`, `:scroll`, `:head`, `:tags`, and the guards are NOT inherited. Composing resources does not compose rendering: layout is still `[:rf.route/chain]` folded by hand.
+- **Carrying query state across routes is application policy, not a route key.** A destination address is taken literally — `{:to :route/cart}` navigates to exactly `/cart` and never gains query keys from whichever route was current. There is no `:query-retain` (retired, no alias; declaring it is rejected as an unknown bare key), no query middleware, no per-route carry policy. Spell the policy as an ordinary pure function over the address and apply it at the call site (or inside the app's own navigation event): `(defn with-shell-query [current-query address] (update address :query #(merge (select-keys current-query [:locale :tenant]) (or % {}))))`. Tolerate an absent `:query` — a destination replayed out of a pending-leave value omits an empty `:params` / `:query` and a nil `:fragment`, so never compare a stashed destination by `=` against a fully-spelled address map. To change the CURRENT route's query, use the in-place request (`:query-merge` / `:query`), which is the causal primitive for "same page, different query".
+- **`:prefetch :intent` warms a destination without navigating.** `[rf/route-link {:to … :prefetch :intent} …]` dispatches `[:rf.route/prefetch {address}]` on hover / focus / touch; you can dispatch that event yourself from any handler. It accepts a NAMED address only (never `:url`), runs the same effective parent-to-leaf plan a navigation would in warm mode — every ensure ownerless, `:blocking?` inert, no slice / URL / scroll / guards / `:on-match` — and a later activation reuses the warmed work through ordinary dedupe. `:intent` is the only accepted value: no render mode, viewport mode, global default, or hover-delay knob, and a passive render dispatches nothing. Prefetch is a performance hint, not an authorization boundary.
+- **`route-link` computes no active state.** It renders one `<a href>` and passes every unclaimed prop through, so "am I on this page?" is a comparison you write: `(= (:to props) @(subscribe [:rf.route/id]))` (or a membership test against `[:rf.route/chain]` when a parent tab should light up for its children), then set `:aria-current "page"` and a class on the link. There is no `<NavLink>` equivalent and no `isActive` callback.
 - **`:params` and `:query` are separate maps.** Path params come from segments; query params come from `?k=v`. Validated by separate Malli schemas on `reg-route` (`:params` and `:query`). Build a merged map in a derived sub if you want one.
 - **Query coercion is per-key, Malli-driven.** When `:query` is a Malli `[:map [:tab :keyword] [:page :int]]`, string values get coerced (`:int`, `:keyword`, `:boolean`). `:query-defaults` populates absent keys. Canonical identity applies *after* coercion (EP-0012).
 - **Routes are prisms — canonical query order BOTH directions.** A route is a lawful round trip: `match-url(route-url(…))` returns canonical route data. `route-url` emits query keys in **deterministic canonical order** (host map iteration order never leaks; the same query map written two ways yields byte-identical URLs); `match-url` returns the `:query` map in that **same canonical key order** for an arbitrary inbound URL — so `?b=2&a=1` and `?a=1&b=2` resolve to one identical `:query` value (a stable `:rf.route/query` sub identity / no-op key / SSR-hydration parity). A `nil`-valued query param is **elided by policy** before printing (absent after `match-url`); `false` / `0` / `""` round-trip; an **out-of-domain param fails closed** (a required path param that is `nil` / absent / empty, or a coerced value not representable as canonical EDN, fails the match/print rather than inventing an identity via `str` or object identity). See [`../cross-cutting/path-and-identity.md`](../cross-cutting/path-and-identity.md).
@@ -164,8 +179,10 @@ Flow on `:rf.route/url-requested`:
 - Worked three-page example (home / list / detail, popstate, headless tests) → `examples/capabilities/routing/routing/`.
 - Slice schema (`:rf/route-slice`), pattern schema (`:rf/route-pattern`), rank schema (`:rf/route-rank`) → `SKILL-REDIRECT.md` → *Spec schemas*.
 - Interceptor-based guards (`auth-guard`, redirects), tags-driven policies → *EP — Routing (012)* §Redirects and guards.
+- Effective parent-to-leaf resource plans, grouped identity dedupe, the redundant-child advisory, attach-before-release owner handoff → *EP — Resources (016)* §Effective parent-chain resource plans.
+- Warm-mode prefetch contract (`:rf.route/prefetch`, the `:rf.route/prefetched` trace, bad-address vs planning failure) → *EP — Routing (012)* §Route-plan prefetch.
 - SSR routing (server frame handles `:rf.route/handle-url-change` on the request URL) → `SKILL-REDIRECT.md` → *EP — SSR (011)*.
 
 ---
 
-*Derived from `implementation/routing/` (artefact source) and `examples/capabilities/routing/routing/` @ main `89bd9c3`. Re-verify after route-metadata or `:can-leave` protocol changes.*
+*Derived from `implementation/routing/` (artefact source) and `examples/capabilities/routing/routing/` @ main `a8b836f`. Re-verify after route-metadata, guard-protocol, readiness-projection, or prefetch changes.*


### PR DESCRIPTION
Three EP-0037 corpus waves in one PR — **rf2-kqxe6.11** (docs), **rf2-kqxe6.12** (examples), **rf2-kqxe6.13** (skills). They share one body of knowledge, the ratified routing surface, and differ only in target tree. Branched off `origin/main` at `fe42368` (after R5 / #6924).

## What was actually wrong

The retirement roster was already clean in `examples/` and almost clean in `docs/` — R4 and R5 migrated their own call sites as they landed. The real drift was **semantic**: the corpus still described a runtime that no longer exists, and R2's branch plans and R3's intent prefetch had no presence in it at all.

- Route `:on-error` was still taught as a loader-failure hook in `docs/routing/concepts.md`, in the `errorElement` row of the React Router mapping, and in the authoring skill. R1 retired it with no alias; `reg-route` now rejects it as an unknown bare key.
- `:rf.route/transition` was described as an `:on-match` drain state ("on entering a route with `:on-match` the slice's `:transition` flips to `:loading` … or `:error` on `:on-error`"). It is a projection over the blocking `:resources`; `:on-match` never touches it.
- `docs/routing/testing.md` told you to assert a refused entry by looking for a pending value with `:direction :enter`, and the authoring skill documented `:reason` / `:direction` fields on the pending-nav slot. The slot is leave-only and has neither; entry is terminal.
- `docs/routing/how-to/guard-unsaved-changes.md` still offered `#{:enter}` / `#{:leave :enter}` as bypass spellings — the retired `:bypass-guards?` set form.
- Parent-to-leaf `:resources` composition (R2) and `:prefetch :intent` (R3) appeared nowhere outside the EP.

Two further defects surfaced while spot-running the samples: `docs/routing/testing.md` asserted `route-url` output in *authoring* query order (`?q=clojure&page=2`) when the codec prints canonical order (`?page=2&q=clojure`), and `docs/routing/concepts.md`'s new query cookbook initially over-promised `:query-defaults` (they fill at match time, not on a programmatic navigate).

## Per-symbol grep table

Counts are literal string occurrences at the merge base `fe42368` vs `HEAD`, over `docs/routing/**` + `docs/api/re-frame.routing.md`, `examples/**`, and `skills/**`.

| Symbol | docs before → after | examples before → after | skills before → after |
|---|---|---|---|
| `query-retain` | 0 → 0 | 0 → 0 | 0 → **1** (justified below) |
| `bypass-guards` | 0 → 0 | 0 → 0 | 0 → 0 |
| `#{:enter}` / `#{:leave :enter}` bypass set | 2 → 0 | 0 → 0 | 0 → 0 |
| `rf.route/entry-blocked` | 0 → 0 | 0 → 0 | 0 → 0 |
| `enter-attempts` | 0 → 0 | 0 → 0 | 0 → 0 |
| `route-guard-loop` | 0 → 0 | 0 → 0 | 0 → 0 |
| route `:on-error` | 3 → 0 | 0 → 0 | 1 → **1** (justified below) |
| pending-nav `:direction` | 2 → 0 | 0 → 0 | 1 → **1** (justified below) |
| `:direction :enter` (semantic) | 1 → 0 | 0 → 0 | 0 → 0 |

Every hit outside these trees is in `docs/EP/EP-0037-route-planning-and-activation-ownership.md`, which is the design record and legitimately historical — it was not touched.

**The three surviving hits are all negative space, not instruction.** `skills/re-frame2/references/tooling/routing.md` now says there is no `:query-retain` (line 164), no route `:on-error` (line 160), and no `:reason` / `:direction` discriminator on the pending slot (line 150). A model trained before these cuts will reach for them; naming them as gone is the whole point of a skill leaf, and it is the one place in the corpus where saying the word is the correction rather than the defect. `skills/re-frame2/patterns/resources.md` line 195 carries the same "there is no route `:on-error`" sentence.

## What changed, per tree

**`docs/` (rf2-kqxe6.11)** — `concepts.md` separates activation work from page data, states the readiness projection as a table, and gains sections for parent `:resources` composition, intent prefetch, active-link projection, and the in-place query cookbook (pagination / filter reset / clear / tab). `coming-from-react-router.md` fixes the `errorElement` and `<NavLink>` rows, adds rows for `<Link prefetch="intent">`, loader-side auth, and `backgroundLocation` modal routing, and gains prose on why one `loader` becomes two keys, why the guards are asymmetric, and why a modal over a page is a state model rather than a masked route. `testing.md` replaces the `:on-match`-drives-transition claim and the resumable-entry assertion with a terminal-denial test. `glossary.md` corrects `transition` / `loader` / `route guard` and adds `effective route plan`, `intent prefetch`, `terminal entry`. `guard-unsaved-changes.md` drops the retired bypass set form and pairs `:can-leave` with a host `beforeunload` listener over the same dirty sub. `docs/api/re-frame.routing.md` gains the `:rf.route/prefetch` row and the `:prefetch` link prop, and its `:parent` / `:on-match` / `:transition` / `:error` / pending-nav rows now match the shipped contract.

`scripts/check_doc_slugs.py` moves with the docs: the `#when-a-loader-fails` compat anchor names the readiness passage now that "On loader failure …" is gone, so its placement regex follows it. The anchor itself is preserved, so inbound deep links still land on the content they named.

**`examples/` (rf2-kqxe6.12)** — the residue greps were already empty, so the deliverable was the R3 gap: `:prefetch :intent` had no runnable demonstration anywhere in the tree. It went on exactly one link, the infinite-feed home page's single link into a timeline whose route declares a `:blocking? true` first load behind a 140 ms canned delay — the one place where warming on hover visibly changes what the click lands on. No other example got one: RealWorld is R4/R6's, the routing example declares no resources so a prefetch there would warm nothing, and the resources example frames its links around a four-way owner-versus-cause taxonomy that an ownerless warm does not belong in.

**`skills/` (rf2-kqxe6.13)** — `references/tooling/routing.md` had the worst drift of the three trees, since an agent authoring from it produces code the substrate rejects. Corrected the `:transition` / `:on-error` / pending-slot claims, rewrote the guard section around the leave-vs-entry asymmetry with the fresh-return auth recipe, and added the four surfaces an agent would otherwise invent: `:parent` composing `:resources` (and nothing else), explicit query carry, `:prefetch :intent`, and the fact that `route-link` computes no active state. `patterns/resources.md` now tells an author not to restate a parent's reads in every child. No skill file in scope is generated — `skills/re-frame2-ui/references/ui-context.md` is, but its only routing content is an out-of-scope pointer, so nothing needed regenerating (and its generator lives under the fenced `implementation/`).

No routing residue was found in `skills/re-frame-migration`, `skills/reagent-migration`, `skills/re-frame2-pair`, `skills/re-frame2-xray`, or `skills/README.md`: their `:route/*` material is the M-20 keyword-rename table and skill-routing prose, both of which still name live ids.

## Samples executed

A scratch namespace ran **22 assertions** against the shipped surface on the JVM (`implementation/routing`, plain-atom substrate, resources artefact loaded so `:resources` is accepted) covering: the concepts.md route table and `:parent` chain; `route-url` for the documented addresses; `reg-route` rejecting both `:query-retain` and `:on-error`; the R5 carry helper including the absent-`:query` case; all four in-place query-cookbook requests; `:query-defaults` at match time; `route-url` canonical ordering; `[:rf.route/prefetch …]` writing no route state; `route-link` passing `:aria-current` through and stripping `:prefetch`; the terminal-entry test from `testing.md` including the bare `{:to :app/settings}` destination shape; and the leave-guard park / continue / `:bypass-leave?` flow. All 22 pass. That run is what caught the canonical-ordering and `:query-defaults` errors above.

The `beforeunload` snippet is browser interop and was not executed; it is plain host-listener code with no framework surface.

## FINDING — needs code, not fixed here (`implementation/**` was fenced)

**The documented `:rf.route/entry-denied` recipe does not run.** Registering the handler from an application namespace through the public `rf/reg-event` collides with the framework's shipped no-op default at the next `rf/make-frame`:

```
rf/image assembly: id [:event :rf.route/entry-denied] is selected from 2 distinct
source namespaces with different implementations within image nil ...
Colliding source coordinates: [{:ns nil} {:ns "probe"}].   [:rf.error/image-duplicate-id]
```

The failing order is the ordinary one — namespaces load and register, then `frame-root` creates the frame. Registering *after* frame creation passes assembly, which is why it was missed. It was missed for a second reason too: `implementation/routing/test/re_frame/routing_entry_denied_test.clj` registers its recorder through the internal `re-frame.events/reg-event`, with a comment already naming the problem, so the whole R4 entry-denial suite only exercises the non-public path. Blast radius includes `examples/real-apps/realworld_http/routing.cljs:179`, which does the public thing.

Filed as **rf2-0r6q4** (P1, bug) with the minimal repro, the likely cause (the default-image standard-shadow filter only exempts `[kind id]` pairs contributed to the framework-*standard* registry; `:rf.route/entry-denied` ships via `events/reg-event` + `framework-authority-meta`), and the decision it needs. This PR deliberately keeps teaching the intended public recipe rather than writing around the defect.

**Out of write surface, reported not fixed:** `migration/from-re-frame-v1/README.md` §O-8 step 2 still says "Move per-route data fetches into `:on-match`", which is the retired role. That file is a hot-zone path outside this worker's trees; it wants its own sequenced bead against the migration corpus.

## Quality gates

Foreground, to completion, exit codes captured. Nothing piped through `tail`/`grep`.

| Gate | Result |
|---|---|
| `npm run test:examples-compile` | **PASS** (0) — all 42 example builds compiled, 0 warnings, including `:examples/infinite-feed` |
| `python -m mkdocs build --strict` | **PASS** (0) — run explicitly; the spine soft-skips mkdocs on this machine |
| `python scripts/check_doc_slugs.py` | **PASS** (0) — plus `--self-test` **PASS** (0) |
| `python scripts/check_readme_links.py` | **PASS** (0) |
| `python scripts/check_readme_inventories.py` | **PASS** (0) |
| `python scripts/check_retired_spellings.py` | **PASS** (0) |
| Skill drift gates — 15 checkers | **PASS** (0 each): `check_skill_re_frame2_drift`, `check_skill_mcp_drift`, `check_skill_migration_cites`, `check_skill_migration_contract_drift`, `check_skill_migration_o1617_router_drift`, `check_skill_package_refs`, `check_skill_redirect_anchors`, `check_skill_eval_docs`, `check_skill_eval_packaging`, `check_skill_implementor_order`, `check_skill_implementor_partition_drift`, `check_skill_pair_authoring_drift`, `check_skill_setup_counter_drift`, `check_skill_xray_tab_inventory_drift`, `check_keyword_catalogue_drift` |
| `scripts/test-fast-pr.sh` | **PASS** (0) — "PASS fast PR spine", 17/17 per-ns isolation |
| Doc-sample spot-run (JVM, 22 assertions) | **PASS** (0) |

**Failures: 0.**
