### PR TITLE
fix(freehand): classify event-position maps on the JVM structural render (rf2-5xjxj)

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/node.cljc
+++ b/implementation/freehand/src/re_frame/freehand/node.cljc
@@ -496,6 +496,31 @@
     ;; and composing it with nothing produced a copy of the sugar vector.
     (conv/class-string (if (zero? (count parts)) sugar (into (vec sugar) parts)))))
 
+(defn- reject-non-data!
+  "Refuse a handler value that cannot be RECORDED — an event intent or an
+  options map carrying a function or a host object somewhere inside it —
+  and answer the value when it is clean.
+
+  This is the structural tree's own law rather than the event grammar's:
+  both shapes are recorded VERBATIM, so a value inside one has to print and
+  read back EQUAL or the tree stops being the comparable data a test
+  asserts against (§Data). A function records as the opaque marker when it
+  IS the handler value; it cannot ride inside one. `slot` names the
+  offending position in the author's own words."
+  [tag k v slot]
+  (when-let [[path bad] (non-data v)]
+    (malformed!
+      're-frame.freehand/render
+      (str "The " k " handler on " tag " carries a " (offender-name bad)
+           (at-path path)
+           " inside its " slot ". An " slot " is recorded verbatim and is data "
+           "through and through — a test compares it as data and the event system "
+           "dispatches it as data, so a value inside one has to print and read back "
+           "EQUAL. A function records as the opaque marker when it IS the handler "
+           "value; it cannot ride inside the " slot ".")
+      {:attr k :path path :value (shape bad)}))
+  v)
+
 (defn- fn-carried?
   "Is `x` a value whose SPELLING is testable and whose BEHAVIOUR is not — a
   bare function, or one of the declared roster callbacks (`v/event`,
@@ -526,38 +551,36 @@
   emit at a DOM site — so promotion moves nothing.
 
   An intent and an options map are recorded VERBATIM, so they must already
-  be data — a function riding as an event argument would record an intent
-  that cannot be compared, printed, or dispatched as the site's own
-  (§Data)."
+  be data ([[reject-non-data!]]) — a function riding as an event argument
+  would record an intent that cannot be compared, printed, or dispatched as
+  the site's own (§Data).
+
+  A MAP is additionally held to the CLOSED listener-options roster, and the
+  verdict is not taken here: [[re-frame.freehand.events/event-plan]] owns
+  the event grammar and is total over it, so this canonicaliser CONSULTS
+  that one classification rather than running a second one beside it
+  (rf2-5xjxj). Without it a map was recorded verbatim whatever its keys,
+  and the tier a consumer TESTS on silently accepted what the tier they
+  ship on rejects — the mounted walk raises `:rf.error/view-bad-event` from
+  the same roster and the compiled build raises
+  `:rf.ui.compile/bad-handler-options` at the same map. `.cljc` structural
+  tests are a cross-host claim (FH-EVENT-002, whose modes are `common jvm
+  browser`), so one authored mistake must get one verdict on every host.
+
+  The PLAN is discarded, deliberately. What this seam takes from
+  `event-plan` is its VERDICT, never its normalization: the plan drops a
+  listener option authored `false` while the structural tree records the
+  authored map exactly as written (FH-STRUCT-002), and recording the plan
+  would change the tree that every promoted declaration is compared
+  against."
   [tag k v]
   (cond
     (nil? v)    nil
-    (vector? v) (do (when-let [[path bad] (non-data v)]
-                      (malformed!
-                        're-frame.freehand/render
-                        (str "The " k " handler on " tag " carries a " (offender-name bad)
-                             (at-path path)
-                             " inside its event intent. An event vector is recorded "
-                             "verbatim and is data through and through — a test compares "
-                             "it as data and the event system dispatches it as data, so "
-                             "an argument inside it has to print and read back EQUAL. A "
-                             "function records as the opaque marker when it IS the handler "
-                             "value; it cannot ride inside the intent.")
-                        {:attr k :path path :value (shape bad)}))
+    (vector? v) (reject-non-data! tag k v "event intent")
+    (map? v)    (do (reject-non-data! tag k v "options map")
+                    (events/event-plan v)
                     v)
-    (map? v)    (do (when-let [[path bad] (non-data v)]
-                      (malformed!
-                        're-frame.freehand/render
-                        (str "The " k " handler on " tag " carries a " (offender-name bad)
-                             (at-path path)
-                             " inside its options map. An options map is recorded verbatim "
-                             "and is data through and through — the structural tree prints "
-                             "and reads back EQUAL, so a value inside one has to survive "
-                             "that round trip. A function records as the opaque marker "
-                             "when it IS the handler value; it cannot ride inside the "
-                             "options.")
-                        {:attr k :path path :value (shape bad)}))
-                    v)
+
     (fn-carried? v)
     {:rf.ui/opaque :fn}
 
@@ -567,6 +590,7 @@
       (str "The " k " handler site on " tag " carries a " (type-name v)
            ". A handler is an event vector, an options map carrying one, or a function.")
       {:attr k :value (shape v)})))
+
 
 (defn- dyn-attr-entry
   "Fold one author-space attribute entry into the

--- a/implementation/freehand/test/re_frame/freehand/events_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/events_cljs_test.cljc
@@ -18,6 +18,7 @@
             [re-frame.freehand :as v]
             [re-frame.freehand.conformance :as conf]
             [re-frame.freehand.events :as events]
+            [re-frame.freehand.test :as t]
             [re-frame.router :as router]
             #?(:clj [re-frame.core])))
 
@@ -293,6 +294,74 @@
           "the ordinary closed-roster recovery, not a key-condition one")
       (is (= ["Enter"] (:unknown-keys (conf/caught-data run)))
           "the string key is reported as the unknown OPTION it is"))))
+
+(v/defview menu-with-a-key-condition-map [_]
+  [:ul {:on-key-down {"Enter" [:menu/activate] "Escape" [:menu/close]}} [:li "Open"]])
+
+(defn- structural-key-down-verdict
+  "The STRUCTURAL render's verdict on the same non-roster map, taken through
+  the public `t/render` a consumer's own structural test calls."
+  []
+  #(t/render [menu-with-a-key-condition-map {}]))
+
+(deftest fh-event-002-the-structural-render-classifies-a-map-at-an-event-position
+  (testing "Per FH-EVENT-002, whose modes are `common jvm browser`: the
+            STRUCTURAL render reaches the same verdict as a committed site
+            for the same authored map, because it consults the same
+            `events/event-plan` roster rather than recording whatever it
+            was handed.
+
+            This is the tier a consumer TESTS on. It used to record a
+            non-roster map verbatim while the mounted walk raised
+            `:rf.error/view-bad-event` and the compiled build raised
+            `:rf.ui.compile/bad-handler-options` for that same
+            declaration — so a green `.cljc` structural suite certified a
+            view neither shipping tier would accept, which is exactly how
+            the deleted D007 key-condition map survived in the guide
+            (rf2-5xjxj)."
+    (let [run (structural-key-down-verdict)]
+      (is (= :rf.error/view-bad-event (conf/caught-id run))
+          "the structural render refuses it")
+      (is (= :use-the-closed-listener-options (:recovery (conf/caught-data run)))
+          "with the closed-roster recovery, not a structural one")
+      (is (= ["Enter" "Escape"] (:unknown-keys (conf/caught-data run)))
+          "naming the string keys as the unknown OPTIONS they are"))))
+
+(deftest fh-event-002-the-structural-and-mounted-tiers-agree-on-one-map
+  (testing "Per FH-EVENT-002: the same authored value gets the SAME verdict
+            whichever tier reads it. Asserted as an EQUALITY between the two
+            tiers rather than as two independent expectations, so the claim
+            is agreement itself — a later change that moved one diagnostic
+            without the other fails here even if both are individually
+            defensible."
+    (let [value      {"Enter" [:menu/activate] "Escape" [:menu/close]}
+          mounted    #(events/site (events/candidate (events/owner :app/menu))
+                                   :on-key-down value events/payload-map
+                                   {:tag :ul :controlled? false :slot "onKeyDown"})
+          structural (structural-key-down-verdict)]
+      (is (= (conf/caught-id mounted) (conf/caught-id structural))
+          "one error id across the two tiers")
+      (is (= (:recovery (conf/caught-data mounted))
+             (:recovery (conf/caught-data structural)))
+          "one recovery across the two tiers")
+      (is (= (:unknown-keys (conf/caught-data mounted))
+             (:unknown-keys (conf/caught-data structural)))
+          "and one report of what was wrong"))))
+
+(deftest fh-event-002-the-structural-render-still-records-a-roster-options-map
+  (testing "NON-VACUITY for the two rows above: the structural render
+            refuses a NON-ROSTER map and nothing more. A legal options map
+            still renders, and still records VERBATIM — the authored map,
+            not the normalized plan, which is the tree FH-STRUCT-002 pins
+            and the value a promoted declaration is compared against."
+    (let [options {:event [:cart/checkout] :prevent-default true}
+          tree    (t/render [:form {:on-submit options}])]
+      (is (= options (:on-submit (:events tree)))
+          "the authored options map is recorded exactly as written")
+      (is (= conf/no-throw
+             (conf/caught-id #(t/render [:button {:on-click [:cart/open 7]}])))
+          "and an ordinary event vector still renders"))))
+
 
 (deftest fh-event-002-a-site-yields-one-event-or-nil
   (testing "Per FH-EVENT-002: a committed site's callback yields exactly

--- a/implementation/freehand/test/re_frame/freehand/guide/host_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/guide/host_cljs_test.cljc
@@ -306,36 +306,31 @@
       (is (= "Open cart"
              (:aria-label (t/attrs (t/find good #(= :button (:tag %))))))))))
 
-;; The next two are JVM-only ASSERTIONS, and the declarations above are not:
-;; `toast-card`, `toast-card-case` and `toast-tray` compile on both hosts, so a
-;; rename of `v/presence` or `v/presence-phase` reds in ClojureScript exactly as
-;; it does here. What does not cross is the structural RENDER of a view that
-;; reads the phase: `presence-phase` is `react/useContext` on ClojureScript, and
-;; `t/render` opens no React render, so the read throws "Invalid hook call"
-;; outside a mounted tree. The JVM arm answers `:present` unconditionally, which
-;; is the behaviour `presence.md` describes. Filed as rf2-erqin.
-#?(:clj
-   (deftest presence-phase-reads-present-outside-a-boundary
-     (testing "presence.md's reusability claim — a presence-aware child renders
-               anywhere, and the JVM structural render always yields :present,
-               so the exit class and `inert` are absent here."
-       (let [tree (t/render [toast-card {:toast {:id 1 :message "saved"}}])
-             div  (t/find tree #(= :div (:tag %)))]
-         (is (= "saved" (t/text div)))
-         (is (nil? (:inert (t/attrs div))) "not exiting — no inert")
-         (is (nil? (:aria-hidden (t/attrs div)))))
-       (is (= "saved" (t/text (t/render [toast-card-case {:toast {:message "saved"}}])))
-           "the `case` spelling reads the same phase"))))
+;; The next two run on BOTH hosts. `v/presence-phase` discriminates on the
+;; RENDERER rather than on the host — `node/*structural-render?*`, bound for the
+;; extent of `t/render` — so a structural render answers `:present` in
+;; ClojureScript exactly as it does on the JVM, and these read the phase through
+;; the same public surface `presence.md` documents (rf2-erqin).
+(deftest presence-phase-reads-present-outside-a-boundary
+  (testing "presence.md's reusability claim — a presence-aware child renders
+            anywhere, and a structural render always yields :present, so the
+            exit class and `inert` are absent here."
+    (let [tree (t/render [toast-card {:toast {:id 1 :message "saved"}}])
+          div  (t/find tree #(= :div (:tag %)))]
+      (is (= "saved" (t/text div)))
+      (is (nil? (:inert (t/attrs div))) "not exiting — no inert")
+      (is (nil? (:aria-hidden (t/attrs div)))))
+    (is (= "saved" (t/text (t/render [toast-card-case {:toast {:message "saved"}}])))
+        "the `case` spelling reads the same phase")))
 
-#?(:clj
-   (deftest a-presence-boundary-inserts-no-wrapper-node
-     (testing "presence.md — the boundary is DOM-agnostic: keyed children, no
-               wrapper element, no stamped attributes."
-       (seed! {:toasts [{:id 1 :message "one"} {:id 2 :message "two"}]})
-       (let [tree (t/with-render (t/render [toast-tray {}]))]
-         (is (= ["one" "two"]
-                (mapv t/text (t/find-all tree #(= :div (:tag %)))))
-             "both children render, in first-appearance order")))))
+(deftest a-presence-boundary-inserts-no-wrapper-node
+  (testing "presence.md — the boundary is DOM-agnostic: keyed children, no
+            wrapper element, no stamped attributes."
+    (seed! {:toasts [{:id 1 :message "one"} {:id 2 :message "two"}]})
+    (let [tree (t/with-render (t/render [toast-tray {}]))]
+      (is (= ["one" "two"]
+             (mapv t/text (t/find-all tree #(= :div (:tag %)))))
+          "both children render, in first-appearance order"))))
 
 (deftest a-behavior-is-an-inert-marker-on-the-jvm
   (testing "host-boundaries.md block 3 — the use site records the behavior


### PR DESCRIPTION
Two beads on the Freehand render path, one lane.

## rf2-5xjxj — the structural render passed a non-roster map at an event position through unclassified

`node/classify-event` recorded a MAP at an event position verbatim whatever its keys. So one authored declaration got two answers depending on which tier read it:

```clojure
(v/defview menu-bad [_]
  [:ul {:on-key-down {"Enter" [:menu/activate] "Escape" [:menu/close]}} [:li "Open"]])
```

| tier | reader | before | after |
|---|---|---|---|
| mounted / browser | `events/event-plan` | `:rf.error/view-bad-event` | unchanged |
| compiled build | `compiler/analyze` | `:rf.ui.compile/bad-handler-options` | unchanged |
| **structural** (`t/render`) | `node/classify-event` | **ACCEPTED, recorded verbatim** | **`:rf.error/view-bad-event`** |

Reproduction, on the real classpath:

```
--- TIER: interpreted browser/mount (events/event-plan) ---
BEFORE: REFUSED {:recovery :use-the-closed-listener-options}
AFTER:  REFUSED {:recovery :use-the-closed-listener-options}

--- TIER: structural render (t/render) ---
BEFORE: ACCEPTED {:on-key-down {"Enter" [:menu/activate], "Escape" [:menu/close]}}
AFTER:  REFUSED {:recovery :use-the-closed-listener-options}
        "An event options map carries a vector :event plus the closed listener
         options [:capture :event :once :passive :prevent-default
         :stop-propagation]; this one also carries ["Enter" "Escape"]."
        [:rf.error/view-bad-event]

--- control: a LEGAL options map must still render ---
BEFORE: {:on-click {:event [:save], :prevent-default true}}
AFTER:  {:on-click {:event [:save], :prevent-default true}}
```

**Cross-host verdict comparison.** The structural tier now answers exactly what the mounted tier answers for the same input — same error id, same recovery, same `:unknown-keys`:

| | error id | recovery | `:unknown-keys` |
|---|---|---|---|
| mounted (`events/site`) | `:rf.error/view-bad-event` | `:use-the-closed-listener-options` | `["Enter" "Escape"]` |
| structural (`t/render`) | `:rf.error/view-bad-event` | `:use-the-closed-listener-options` | `["Enter" "Escape"]` |

That agreement is asserted as an **equality between the two tiers** rather than as two independent expectations, so the claim under test is agreement itself: a later change that moves one diagnostic without the other reds here even if both are individually defensible.

### Why it matters more than the instance

`testing.md` promises that a `.cljc` structural test is a cross-host claim. For event positions it was not — the tier a consumer *tests* on accepted what the tiers they *ship* on reject. This is the exact mechanism by which the D007-deleted key-condition map sat in the shipped guide behind a green `.cljc` suite. Fixing it closes a class.

### The fix

`events/event-plan` already owns the closed event grammar and is total over it, so the canonicaliser now **consults** that classification instead of growing a second one beside it. The plan is discarded deliberately: what this seam takes is the **verdict**, never the normalization — the plan drops a listener option authored `false`, while the structural tree records the authored map exactly as written (FH-STRUCT-002).

The two recordability checks (a function or host object inside an intent or an options map) were duplicated bodies; they extract to `reject-non-data!`, which answers the value so each arm reads as the one thing it does.

`reject-non-data!` runs *before* the roster consult. When a map fails both laws the deeper fault is reported: a value that could never be recorded under **any** spelling is not fixed by renaming the key it rode in on.

### Deliberately not in this PR

The `:else` arm — a string, number, keyword or set at an event position — still raises `:rf.error/ui-tree-malformed` on the structural tier while the mounted tier raises `:rf.error/view-bad-event`. Both tiers **refuse** it, so this is a diagnostic-id divergence rather than the acceptance divergence this bead was about. Collapsing it requires editing two conformance fixture rows (`fh-struct-002.edn:73`, `fh-struct-003.edn:92`) which were fenced from this wave. Filed with the full remedy, including the ideal `case`-over-`event-plan` shape that was written and backed out, as **rf2-uvcm3**.

## rf2-7z78v — un-fence the two guide presence rows

`presence-phase-reads-present-outside-a-boundary` and `a-presence-boundary-inserts-no-wrapper-node` were `#?(:clj …)` because `v/presence-phase` was `react/useContext` in ClojureScript and `t/render` opens no React render, so the read threw "Invalid hook call".

PR #6927 (rf2-erqin) moved the discrimination to the **renderer** — `node/*structural-render?*`, bound for the extent of `tree/render` — so a structural render answers `:present` on both hosts. The fence named a condition that no longer exists.

**Proof the rows RUN in the node lane, not merely compile:**

- `npm run test:freehand` went **1070 → 1072 tests, 6014 → 6019 assertions** — exactly the two deftests and their five `is` forms. A compiled-but-unrun test contributes zero to both counts.
- A deliberate-break probe (changing two expected strings) reds under ClojureScript at `host_cljs_test.cljc:320` and `:331`, one failure per row.
- The JVM lane is unchanged at 1005 / 6982, so the rows still pass where they always ran.

## Quality gates

All foreground to completion, captured to worktree-local logs.

| gate | command | result | exit |
|---|---|---|---|
| Freehand JVM | `cd implementation/freehand && clojure -M:test` | Ran 1005 tests, 6982 assertions — 0 failures, 0 errors | 0 |
| Freehand node | `cd implementation && npm run test:freehand` | Ran 1072 tests, 6019 assertions — 0 failures, 0 errors | 0 |
| CLJS node integration | `cd implementation && npm run test:cljs` | Ran 11228 tests, 56339 assertions — 0 failures, 0 errors | 0 |
| Browser | `cd implementation && npm run test:browser` | Ran 762 tests, 4771 assertions — 0 failures, 0 errors | 0 |
| Fast PR spine | `scripts/test-fast-pr.sh` | PASS fast PR spine | 0 |

### Non-vacuity

Every claim above was proven able to fail.

- **rf2-5xjxj, JVM:** with the one-line consult removed, 6 assertions fail — exactly the new rows, at `events_cljs_test.cljc:323/325/327` and `:342/344/347`. Nothing else moves.
- **rf2-5xjxj, node:** the same revert reds the same 6 assertions in the ClojureScript lane at the same lines, so the fix is cross-host rather than JVM-only (the structural walk is `.cljc` and runs on both hosts).
- **rf2-5xjxj, control:** the third new row proves a roster-legal options map still renders and still records verbatim, so the refusal refuses something and not everything. It stays green under both reverts.
- **rf2-7z78v:** the test/assertion count delta plus the deliberate-break probe above.
