### PR TITLE
fix(skills): point the ui-context omitted-var dispositions at live guide paths (rf2-zkee9)

### DIFF
--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/ui_context.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/ui_context.clj
@@ -447,9 +447,9 @@
    "render!"        [:omitted "imperative render under ui/mount; author uses ui/mount"]
    "unmount!"       [:omitted "teardown primitive paired with ui/mount"]
    "route-link"     [:omitted "router integration; see the routing docs + the route-link roster entry"]
-   "presence"       [:omitted "enter/exit presence choreography; see presence.md + the presence-* diagnostics"]
-   "presence-phase" [:omitted "presence phase accessor; see presence.md"]
-   "error-boundary" [:omitted "error-boundary form; see interop-and-limits.md + the bad-error-boundary diagnostic"]})
+   "presence"       [:omitted "enter/exit presence choreography; see docs/core/freehand/presence.md + the presence-* diagnostics"]
+   "presence-phase" [:omitted "presence phase accessor; see docs/core/freehand/presence.md"]
+   "error-boundary" [:omitted "error-boundary form; see docs/core/freehand/host-boundaries.md + the bad-error-boundary diagnostic"]})
 
 (defn- assert-disposition-covers-manifest!
   "Reds when `authoring-disposition` and the manifest's re-frame.ui var set

--- a/skills/re-frame2-ui/references/ui-context.md
+++ b/skills/re-frame2-ui/references/ui-context.md
@@ -256,7 +256,7 @@ The public `re-frame.ui` authoring API is **32 vars** (`spec/api-manifest.edn`).
 
 **Taught here:** `ui/->react`, `ui/adapter`, `ui/client-only`, `ui/custom-element`, `ui/defview`, `ui/dispatch-fn`, `ui/effect`, `ui/event`, `ui/frame`, `ui/frame-provider`, `ui/frame-root`, `ui/handler`, `ui/html`, `ui/hydrate-root`, `ui/local`, `ui/mount`, `ui/raw`, `ui/raw-fn`, `ui/ref`, `ui/render-fn`, `ui/render-static`, `ui/slot`, `ui/spread`, `ui/spread-safe`, `ui/sub`.
 
-**Out of scope** (use the API reference): `ui/create-root` — low-level root primitive; author mounts with ui/mount; `ui/error-boundary` — error-boundary form; see interop-and-limits.md + the bad-error-boundary diagnostic; `ui/presence` — enter/exit presence choreography; see presence.md + the presence-* diagnostics; `ui/presence-phase` — presence phase accessor; see presence.md; `ui/render!` — imperative render under ui/mount; author uses ui/mount; `ui/route-link` — router integration; see the routing docs + the route-link roster entry; `ui/unmount!` — teardown primitive paired with ui/mount.
+**Out of scope** (use the API reference): `ui/create-root` — low-level root primitive; author mounts with ui/mount; `ui/error-boundary` — error-boundary form; see docs/core/freehand/host-boundaries.md + the bad-error-boundary diagnostic; `ui/presence` — enter/exit presence choreography; see docs/core/freehand/presence.md + the presence-* diagnostics; `ui/presence-phase` — presence phase accessor; see docs/core/freehand/presence.md; `ui/render!` — imperative render under ui/mount; author uses ui/mount; `ui/route-link` — router integration; see the routing docs + the route-link roster entry; `ui/unmount!` — teardown primitive paired with ui/mount.
 
 ## Compile-rejection roster (GENERATED)
 


### PR DESCRIPTION
Closes the completeness gap the merged-PR audit of #6925 reopened rf2-zkee9 for.

#6925 repaired the explicit `docs/core/re-frame.ui/` pointers, but the same generator still emitted three donor-relative chapter pointers out of `authoring-disposition`: `implementation/scripts/api-manifest/src/re_frame/api_manifest/ui_context.clj` said "see presence.md" twice and "see interop-and-limits.md" once. Neither path resolves relative to the generated leaf, and `interop-and-limits.md` was deleted outright with the donor guide.

The three dispositions now name unambiguous live repo paths:

- `presence` → `docs/core/freehand/presence.md`
- `presence-phase` → `docs/core/freehand/presence.md`
- `error-boundary` → `docs/core/freehand/host-boundaries.md` (that page owns the error-boundary guide)

`skills/re-frame2-ui/references/ui-context.md` is generated from `ui_context.clj`, so the regenerated sheet lands in the same commit — otherwise the ui-context drift gate reds.

Why no gate caught it: the `--check` gate faithfully regenerates whatever the source says, so a stale string round-trips green. That is the same ungated-doc failure class the audit named; the repair is to fix the source of truth, not to add a checker.

`scripts/check_donor_inventory.py`'s `ESTABLISHED_ROWS` identity is untouched — rows are disposed, never deleted.

Closes rf2-zkee9.