### PR TITLE
docs(freehand): a render-fn caller must be compiled too (rf2-ynq9h)

### DIFF
--- a/docs/core/freehand/compilation.md
+++ b/docs/core/freehand/compilation.md
@@ -325,12 +325,25 @@ events” or “you may not branch.”
       [:tr {:key (:id item)}
        (v/slot row item)])]])
 
-;; caller — pure, visible body
-[data-table
- {:rows people
-  :row  (v/render-fn [person]
-          [:td (:name person)])}]
+;; caller — pure, visible body, and compiled itself
+(v/defview people-table
+  {:compiled true}
+  [{:keys [people]}]
+  [data-table
+   {:rows people
+    :row  (v/render-fn [person]
+            [:td (:name person)])}])
 ```
+
+Note the caller’s own `{:compiled true}`. A slot is the one place the **caller**
+must be compiled too — the exception to
+[interpreted parent → compiled child: fine](#crossing-modes-and-seam-laws-author-facing)
+below, which still holds for ordinary child views. A `v/render-fn` written in an
+interpreted body answers raw Hiccup, and the compiled parent’s child collector
+refuses that value with `:rf.error/ui-tree-malformed` — “A compiled view produced
+a vector where a child was expected.” So the usual one-leaf promotion (mark the
+child `{:compiled true}`, leave callers untouched) does not reach a slot: promote
+the calling view as well, or leave both interpreted.
 
 If the row needs a subscription or its own events, extract
 `[person-row {:key … :id …}]`. Do not smuggle `sub` inside an opaque function

--- a/implementation/freehand/test/re_frame/freehand/guide/compilation_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/guide/compilation_cljs_test.cljc
@@ -122,12 +122,11 @@
       [:tr {:key (:id item)}
        (v/slot row item)])]])
 
-;; The block prints the caller as a bare fragment under a compiled-mode
-;; heading, so it is hosted in a COMPILED declaration here — which is the
-;; faithful reading and the only one that renders. A `v/render-fn` authored
-;; in an INTERPRETED body answers with raw hiccup, and a compiled parent's
-;; child collector refuses it (`:rf.error/ui-tree-malformed`); authored in a
-;; compiled body it lowers to nodes and the slot fills.
+;; The block prints the caller as a COMPILED declaration of its own, and
+;; annotates why (rf2-ynq9h): a `v/render-fn` authored in an INTERPRETED
+;; body answers with raw hiccup, and a compiled parent's child collector
+;; refuses it (`:rf.error/ui-tree-malformed`); authored in a compiled body
+;; it lowers to nodes and the slot fills. This declaration is that caller.
 (v/defview data-table-compiled-call
   {:compiled true}
   [{:keys [people]}]

--- a/implementation/freehand/test/re_frame/freehand/guide/samples_coverage_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/guide/samples_coverage_jvm_test.clj
@@ -268,7 +268,7 @@
     [ 5 "8ed7b69a0185" compilation/item-row]
     [ 6 "63ff086fcdd5" compilation/field-help]
     [ 7 "0eb044ab4a85" compilation/markup-child]
-    [ 8 "d03e66cc655d" compilation/data-table-compiled]
+    [ 8 "6eca931fc482" compilation/data-table-compiled]
     [ 9 "ab5df8171160" compilation/todo-row-with-props-schema]]
    "composition.md"
    [[ 1 "6e08b04edd36" composition/panel]


### PR DESCRIPTION
Closes rf2-ynq9h.

## The defect

`docs/core/freehand/compilation.md`, under "Parameterized content (`render-fn` / `slot`)", showed a compiled `data-table` and then a **bare caller fragment**:

```clojure
[data-table
 {:rows people
  :row  (v/render-fn [person]
          [:td (:name person)])}]
```

That caller renders only when it is itself inside a `{:compiled true}` body. A `v/render-fn` authored in an **interpreted** body answers raw Hiccup, and a compiled parent's child collector refuses that value with `:rf.error/ui-tree-malformed` ("A compiled view produced a vector where a child was expected"). The block sits under a compiled-mode heading so it is not plainly wrong, but the reader most likely to copy it is the one promoting one leaf while the parent stays interpreted — which is the guide's own advice everywhere else.

## What this does

Per the ruling on rf2-ynq9h: **annotate the guide**, do not build the interpreted → compiled slot crossing. Making the crossing work is a substrate slice (the compiled child collector would have to accept raw Hiccup from an interpreted `v/render-fn`) with conformance consequences, and conflating the two leaves the documentation lying while a slice is designed.

The ruling offered two acceptable shapes; this PR takes both halves, because the code is what a reader copies:

1. The caller is now hosted in **its own compiled declaration** (`people-table`), mirroring `implementation/freehand/test/re_frame/freehand/guide/compilation_cljs_test.cljc`'s `data-table-compiled-call`, which already proves that shape renders.
2. A paragraph **at the block** names the constraint and the failure mode, links to the seam-laws section, and says why the usual one-leaf promotion does not reach a slot.

The page's "Interpreted parent → compiled child: fine" promise is untouched and still holds for ordinary child views; `render-fn` is now marked as the exception to it rather than a silent counterexample.

## Coupled files (both required, not scope creep)

- `implementation/freehand/test/re_frame/freehand/guide/samples_coverage_jvm_test.clj` — the guide-sample roster pins a **SHA digest of each fenced block's exact text**, so editing a sample reds `every-guide-sample-is-owned-and-unchanged` until the row is repasted. `compilation.md` block 8: `d03e66cc655d` → `6eca931fc482`. The owner symbol is unchanged (`compilation/data-table-compiled` is still the block's first declaration, per the roster's stated convention).
- `implementation/freehand/test/re_frame/freehand/guide/compilation_cljs_test.cljc` — comment only. Its comment explained that the guide printed a bare fragment "so it is hosted in a COMPILED declaration here". The guide no longer diverges, so that explanation was itself stale prose about a file that had moved — the exact defect class this bead family exists to end.

## Same-defect sweep of the page (requested)

Checked every other fenced block on `compilation.md` for a fragment that only works from a `{:compiled true}` parent or that would trip `:rf.error/ui-tree-malformed` when copied into an interpreted body. **This was the only instance.** Specifically:

- `[v/markup {:value some-hiccup-value}]` (the other bare fragment on the page) is safe in both modes — `v/markup` is an ordinary interpreted `defview` mounted as a statically named descriptor (`implementation/freehand/src/re_frame/freehand.cljc:1637`), not a value crossing a collector.
- The "illegal when compiled" `for` + `sub` fragment and the `field-help` opaque-helper block are both **labelled** as their mode and correct as printed.
- Every other block is a complete `v/defview` declaration carrying its own mode, or a data shape (the refusal map) that is not code to copy.
- `composition.md`'s `v/render-fn` block does **not** carry the defect: there both `data-table` and the caller are interpreted, and `composition/data-table-call` proves that pairing renders.

`v/render-fn` / `v/slot` is the only value-crossing form in the guide, which is why there is exactly one instance.

## Gates (foreground, to completion)

- `clojure -M:test` in `implementation/freehand` — **1005 tests, 6982 assertions, 0 failures, 0 errors** (includes the guide-sample digest roster and the CLJS guide fixtures).
- `mkdocs build --strict` from repo root — **exit 0**, no warnings. Also verified the new same-page anchor resolves against a real heading id in the built HTML.

## Notes

- rf2-zkee9 was dropped from this PR mid-flight and released back to `open` — PR #6933 (recovered branch `worker/audit-followups-zkee9`) owns it. This PR touches neither `ui_context.clj` nor `skills/re-frame2-ui/**`, so it cannot conflict with #6933 on the generated sheet.
- Fence respected: docs only on the substrate side. No grammar change, no new diagnostic, no cross-mode slot crossing, no new guide page. `scripts/check_donor_inventory.py` untouched.


## Quality gates

| Gate | Command | Result |
|---|---|---|
| Freehand artefact JVM suite | `clojure -M:test` in `implementation/freehand` | 1005 tests, 6982 assertions — **0 failures, 0 errors** |
| Docs strict build | `mkdocs build --strict` | **exit 0**, no warnings; new same-page anchor verified to resolve to a real heading id in the built HTML |
| Guide sample digest gate | `samples_coverage_jvm_test.clj` (inside the JVM suite above) | green — `compilation.md` block 8 digest updated `d03e66cc655d` → `6eca931fc482` in the same commit |

No gates skipped.

_Section added by the mayor: the worker ran and reported all three, but predated the requirement that every PR body carry this verbatim heading for automated PR audits._
