### PR TITLE
feat(freehand): id-taking tool reads over the declaration manifest (rf2-lvvl2 increment 1)

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -570,10 +570,16 @@ else
         # The narrow list stays honest because the ALWAYS-armed jvm-freehand
         # lane carries
         # `the-evidence-schema-reaches-the-render-path-only-through-the-dev-gated-seam`
-        # (evidence_boundary_jvm_test.clj), which asserts `cell` is the SOLE
-        # Freehand namespace mentioning the schema. A new schema-touching
-        # producer cannot appear without reddening that walk, so it cannot slip
-        # past this list unnoticed. Widen both together if that law is ever
+        # (evidence_boundary_jvm_test.clj), which asserts `cell` is the sole
+        # DOOR-REACHABLE Freehand namespace mentioning the schema — and, beside
+        # it, that the tool-tier read door `re-frame.freehand.tool` (which
+        # mentions the schema and is deliberately NOT reachable from the public
+        # door) stays off the render path (rf2-lvvl2). Those two rows together
+        # are the premise: a new schema-touching PRODUCER cannot appear without
+        # reddening that walk, so it cannot slip past this list unnoticed.
+        # Reachability is decided by whoever REQUIRES the tool tier rather than
+        # by the tier itself, which is why the off-path row — not the tool file —
+        # is what this list leans on. Widen both together if either row is ever
         # relaxed. What that walk canNOT see is a DELETED CALL edge: it proves
         # require-reachability, and both namespaces stay require-reachable after
         # `cell/commit!` is removed from the reconcile. That is precisely why

--- a/implementation/freehand/src/re_frame/freehand.cljc
+++ b/implementation/freehand/src/re_frame/freehand.cljc
@@ -80,6 +80,15 @@
             ;; sits BELOW this namespace (it reaches only the shell) and takes
             ;; nothing back from it.
             [re-frame.freehand.reactive]
+            ;; The DEV-ONLY declared-view index a `v/defview` expansion records
+            ;; itself in. Required here because the DECLARATION is what
+            ;; registers: a consuming namespace must not have to acquire a
+            ;; require to be inspectable, exactly as `node` and `reactive` are
+            ;; required here so promotion stays a one-line change. The index
+            ;; sits BELOW this door and takes nothing back from it, and the
+            ;; registration is gated on `interop/debug-enabled?` at the
+            ;; expansion so a production build reaches it not at all.
+            [re-frame.freehand.registry :as registry]
             [re-frame.freehand.route-link-seam :as route-link-seam]
             [re-frame.interop :as interop]
             #?@(:clj  [[re-frame.freehand.compiler :as compiler]
@@ -397,7 +406,24 @@
                   ;; one representation, published once, read by both.
                   schema?   (vary-meta assoc :re-frame.freehand/props-schema schema-form)
                   docstring (vary-meta assoc :doc docstring))
-            (descriptor/declare-view ~entry)))))))
+            ;; The declaration records itself in the DEV-ONLY declared-view
+            ;; index on its way into its own Var. A tool arriving over a wire
+            ;; holds an id, not a value, and every reader beneath the tool tier
+            ;; takes the value — so without this an MCP inspector could ask
+            ;; nothing at all about `:app.people/people-list`
+            ;; (`re-frame.freehand.registry`, rf2-lvvl2).
+            ;;
+            ;; Gated HERE rather than inside `register!`, for the reason the
+            ;; `:source` entry above is gated here: this is where
+            ;; `interop/debug-enabled?` folds to `false` under `:advanced`,
+            ;; taking the call, its argument and every path into the index with
+            ;; it, so a production build carries no tool registry. The entry map
+            ;; is named ONCE — a two-armed `if` would emit the whole declaration
+            ;; twice into the bundle.
+            (let [view# (descriptor/declare-view ~entry)]
+              (when interop/debug-enabled?
+                (registry/register! ~view-id view#))
+              view#)))))))
 
 #?(:clj
    (defmacro defview

--- a/implementation/freehand/src/re_frame/freehand/cell.cljc
+++ b/implementation/freehand/src/re_frame/freehand/cell.cljc
@@ -803,8 +803,17 @@
 
   The seam builds a record only when a sink is installed AND
   `interop/debug-enabled?` is true, so an application that installs no sink
-  pays nothing beyond the folded-away gate. Downstream tooling
-  (rf2-drpa3.167) installs the accumulator here."
+  pays nothing beyond the folded-away gate.
+
+  What installs here is a MINIMAL CURRENT-OCCURRENCE INDEX — insert-or-update
+  on the selected commit, remove on disconnect, one row per live occurrence
+  (rf2-xftdv), read by the bounded `explain-render` over Spec 009's existing
+  retained ring (rf2-cpfbg). NOT a cumulative per-cell accumulator: the donor's
+  per-occurrence evidence accumulator was ruled out permanently (rf2-drpa3.167,
+  REPLACE), so nothing crossing this seam keeps lifetime counts, an interval
+  ledger, or a second retention knob. This docstring used to say downstream
+  tooling \"installs the accumulator here\", which named the design that ruling
+  rejected."
   [f]
   (let [prev @evidence-sink]
     (reset! evidence-sink f)

--- a/implementation/freehand/src/re_frame/freehand/registry.cljc
+++ b/implementation/freehand/src/re_frame/freehand/registry.cljc
@@ -69,10 +69,11 @@
   "Record `view` as the declaration of `view-id`, answering `view`.
 
   Called from the `v/defview` expansion under the dev gate — see the
-  namespace docstring for why the gate is there and not here. Answering
-  `view` rather than the index keeps the call a pass-through, so the
-  expansion can register a declaration on its way into its own Var without
-  naming the value twice.
+  namespace docstring for why the gate is there and not here. It answers
+  `view` rather than the index so the call reads as a pass-through: what a
+  declaration does here is record itself and carry on being itself, and a
+  registrar that answered its own internal map would invite a caller to hold
+  one.
 
   Re-registration REPLACES: a reloaded declaration is the same view, and an
   index that appended would be a history store wearing an index's name."

--- a/implementation/freehand/src/re_frame/freehand/registry.cljc
+++ b/implementation/freehand/src/re_frame/freehand/registry.cljc
@@ -1,0 +1,103 @@
+(ns ^:no-doc re-frame.freehand.registry
+  "INTERNAL, DEV-ONLY. The index that answers a view ID with the declaration
+  carrying it.
+
+  ## Why an index has to exist at all
+
+  A Freehand declaration is a VALUE held in a Var, and every reader beneath
+  the tool tier takes that value: `v/manifest` and
+  [[re-frame.freehand.tool/view-manifest]] are asked about a view by code
+  that is holding one.
+
+  An MCP inspector is holding nothing. It arrives over a wire with a keyword
+  — `:app.people/people-list` — and asks what that view declares, which is a
+  question no value-taking reader can answer. So the id has to resolve to
+  something, and there are exactly two ways to arrange that: resolve the Var
+  by name at read time, or record the declaration at the moment it is made.
+
+  Var resolution is unavailable precisely where it is needed. An `:advanced`
+  build has no Vars at all, and a dev build's munged module objects are the
+  private host state a tool read exists to avoid reaching into. So the
+  declaration records itself, once, as it is declared — which also means an
+  inspector that ATTACHES LATE, to an already-running application, sees every
+  view the application declared before it arrived.
+
+  ## What this is not
+
+  One row per DECLARATION, replaced when that declaration is re-evaluated,
+  and nothing else. No occurrence, no mount, no generation, no counter, no
+  ordering and no history: two live occurrences of one view are ONE row here,
+  because a declaration is not a mount. The per-occurrence cumulative
+  evidence accumulator was ruled out permanently (rf2-drpa3.167, REPLACE),
+  and the live-occurrence index that answers \"what is mounted right now\" is
+  a separate structure keyed by runtime occurrence, with its own release
+  seam, under its own owner (rf2-xftdv).
+
+  A hot reload of a declaring namespace re-evaluates its declarations and so
+  replaces their rows. A reload that DELETES a declaration leaves that view's
+  last row behind: nothing runs to retract it. That is a known and bounded
+  staleness — one row per id, never a growing log — and it is stated here
+  rather than papered over, because the alternative is a per-namespace
+  eviction protocol with no caller asking for one.
+
+  ## DEV-ONLY, gated at the one call site
+
+  The gate lives in the `v/defview` EXPANSION
+  ([[re-frame.freehand/expand-defview]]), not in [[register!]]. That is where
+  `re-frame.interop/debug-enabled?` folds to `false` under `:advanced`,
+  taking the call, its argument and every path into this namespace with it —
+  so a production build carries no tool registry, because nothing reaches the
+  atom for Closure to keep it alive for. The declaration's `:source` entry is
+  gated in the same expansion for the same reason, and this namespace holds
+  no second gate of its own so there is exactly one place to read the policy
+  from.
+
+  Normative owner: [`spec/004-Views.md`](../../../../spec/004-Views.md); the
+  instrumentation contract the reads over this index serve is
+  [`spec/009-Instrumentation.md`](../../../../spec/009-Instrumentation.md).")
+
+#?(:clj (set! *warn-on-reflection* true))
+
+(defonce ^:private declared
+  ;; view-id -> the declared view value. An atom because declaring is a
+  ;; RUNTIME act (a namespace loading), never a compile-time one, and
+  ;; `defonce` so reloading THIS namespace does not drop the rows the
+  ;; application's own namespaces put here.
+  (atom {}))
+
+(defn register!
+  "Record `view` as the declaration of `view-id`, answering `view`.
+
+  Called from the `v/defview` expansion under the dev gate — see the
+  namespace docstring for why the gate is there and not here. Answering
+  `view` rather than the index keeps the call a pass-through, so the
+  expansion can register a declaration on its way into its own Var without
+  naming the value twice.
+
+  Re-registration REPLACES: a reloaded declaration is the same view, and an
+  index that appended would be a history store wearing an index's name."
+  [view-id view]
+  (swap! declared assoc view-id view)
+  view)
+
+(defn lookup
+  "The view declared under `view-id`, or `nil` — including in a production
+  build, where nothing was ever recorded.
+
+  `nil` says one thing and says it whether the id was never declared, was
+  declared in a namespace this build never loaded, or was declared in a
+  build that elided the index entirely: this index knows of no such
+  declaration. A caller that needs to tell those apart is asking a question
+  about the BUILD, not about a view."
+  [view-id]
+  (get @declared view-id))
+
+(defn view-ids
+  "Every view id currently indexed, sorted — the roster a sweep enumerates
+  when it has no ids of its own to start from.
+
+  Sorted because the order of a hash map is not a fact about an
+  application, and a tool that printed one would invite a reader to believe
+  in it."
+  []
+  (into (sorted-set) (keys @declared)))

--- a/implementation/freehand/src/re_frame/freehand/tool.cljc
+++ b/implementation/freehand/src/re_frame/freehand/tool.cljc
@@ -2,26 +2,45 @@
   "The Freehand TOOL-TIER reader door — what an inspector reads a
   declaration's compile-time analysis through.
 
-  One namespace, one question: **given a value, what did the compiler
-  statically learn about it?** The answer is the manifest the compiled tier
-  already builds — its subscription, event, render-slot, trusted-markup,
-  committed-frame and boundary-crossing rosters, its capability set, its
-  ViewCell verdict, and the compile-tier `:diagnostics` findings. Nothing here
-  computes anything; every read is a projection of a value the declaration is
-  already carrying.
+  One namespace, one question: **what did the compiler statically learn about
+  this view?** The answer is the manifest the compiled tier already builds —
+  its subscription, event, render-slot, trusted-markup, committed-frame and
+  boundary-crossing rosters, its capability set, its ViewCell verdict, and the
+  compile-tier `:diagnostics` findings. Nothing here computes anything; every
+  read is a projection of a value the declaration is already carrying.
+
+  ## Two doors, because there are two callers
+
+  [[view-manifest]] takes a VALUE, and is TOTAL over every value there is: a
+  sweep over a namespace's publics hands it strings, numbers, plain functions
+  and interpreted views, and each of those answers `nil` rather than throwing,
+  because a reader that throws on the first non-view is a reader that cannot
+  sweep. `nil` means \"nothing statically known\" in every case.
+
+  [[read-view-manifest]], [[read-view-dependencies]] and
+  [[read-view-event-sites]] take a view ID, because an MCP inspector holds no
+  values. It arrives over a wire with `:app.people/people-list` and asks what
+  that view declares — a question a value-taking reader cannot be asked. The id
+  resolves through the dev-only [[re-frame.freehand.registry]] index each
+  declaration records itself in, so an inspector that attaches LATE, to an
+  already-running application, still sees every view it declared.
+
+  Neither door is the other's arity. `(view-manifest :a/keyword)` answers `nil`
+  because a keyword is not a view, and it must keep answering that — the sweep
+  depends on it — so the id-taking reads carry their own names.
 
   ## Why it is not `v/manifest`
 
   [[re-frame.freehand/manifest]] is the APPLICATION's read: it is asked about a
-  view, by code that knows it has one. A tool is asked about whatever it is
-  holding — a var it swept out of a namespace, an id it was handed over a wire,
-  a value from a registry it does not own — and a reader that throws on the
-  first non-view is a reader that cannot sweep. So [[view-manifest]] is TOTAL:
-  every value has an answer, and `nil` means \"nothing statically known\",
-  whether that is because the value is not a view at all or because it is an
-  interpreted declaration with no analysis to report.
-
-  That is the whole of the difference, and it is the whole of this namespace.
+  view, by code that knows it has one, and it answers the manifest bare. The
+  reads here answer it inside the four-axis evidence projection every Freehand
+  evidence surface states — `:scope`, `:basis`, `:complete?`, `:loss` — because
+  a tool has to be able to tell an INTERPRETED declaration (no analysis, so
+  nothing knowable) from a compiled one whose rosters really are empty. That is
+  `:basis :static-proof` with `:loss nil` against `:basis :opaque` with
+  `{:reason :no-static-analysis :dropped :unknown}`, and it is the whole reason
+  the projection vocabulary exists: *unknown must not look like none*
+  ([[re-frame.freehand.evidence]], D012/D020).
 
   ## What this door deliberately is NOT
 
@@ -29,13 +48,35 @@
   per-occurrence evidence accumulator was ruled out permanently (rf2-drpa3.167,
   REPLACE), not merely deferred — no root registry, no interval log and no
   history store: retention is Spec 009's ring, and nothing here retains
-  anything at all. Live reads over mounted occurrences are a separate slice
-  (rf2-lvvl2) with a separate owner.
+  anything at all. The declared-view index it reads through holds ONE row per
+  declaration and no occurrence, generation or count.
+
+  So none of these reads can say what is MOUNTED, and none of them pretends
+  to. Current-occurrence reads (`mounted-views`, rf2-xftdv) and the bounded
+  `explain-render` over the Spec 009 ring (rf2-cpfbg) are separate slices with
+  separate owners and their own release seams.
+
+  ## DEV-ONLY
+
+  Every id-taking read is gated on `re-frame.interop/debug-enabled?` and
+  answers `nil` under `:advanced` + `goog.DEBUG=false`, which is also what the
+  index it reads holds there: nothing. A consumer distinguishes that from an
+  unregistered view the way it distinguishes any absence — by asking about a
+  view it knows the application declares.
 
   Normative owner: [`spec/004-Views.md`](../../../../spec/004-Views.md);
   the instrumentation contract these reads serve is
   [`spec/009-Instrumentation.md`](../../../../spec/009-Instrumentation.md)."
-  (:require [re-frame.freehand.descriptor :as descriptor]))
+  (:require [re-frame.freehand.descriptor :as descriptor]
+            [re-frame.freehand.evidence :as evidence]
+            [re-frame.freehand.registry :as registry]
+            [re-frame.interop :as interop]))
+
+#?(:clj (set! *warn-on-reflection* true))
+
+;; ---------------------------------------------------------------------------
+;; The value-taking read — total, because a sweep cannot afford otherwise
+;; ---------------------------------------------------------------------------
 
 (defn view-manifest
   "The compile-time manifest `x` carries, or `nil` when there is none.
@@ -65,3 +106,199 @@
   [x]
   (when (descriptor/view? x)
     (descriptor/manifest x)))
+
+;; ---------------------------------------------------------------------------
+;; The id-taking reads — the shape every one of them answers in
+;; ---------------------------------------------------------------------------
+
+(defn- static-proof
+  "The four axes a COMPILED declaration's roster read states: every site the
+  grammar can see, proved from what the compiler saw, complete and lossless.
+
+  Complete is a claim relative to `:scope` and to nothing else. The analyzer
+  walked the whole body and the grammar is finite, so the roster is every site
+  there CAN be — which is a different and much smaller claim than knowing which
+  of them ran."
+  [roster]
+  (evidence/projection
+    (assoc roster
+           :scope     :possible-sites
+           :basis     :static-proof
+           :complete? true
+           :loss      nil)))
+
+(defn- no-static-analysis
+  "The four axes an INTERPRETED declaration's roster read states: the same
+  scope, on an `:opaque` basis, INCOMPLETE, with the loss named.
+
+  This is the arm the projection vocabulary exists for. An interpreted body has
+  no analysis step, so the number of sites it could reach is not merely
+  uncounted — it is unknowable without running it, and an empty roster reported
+  as `:complete? true :loss nil` would be saying it found nothing where what it
+  means is that it never looked."
+  [roster]
+  (evidence/projection
+    (assoc roster
+           :scope     :possible-sites
+           :basis     :opaque
+           :complete? false
+           :loss      {:reason  :no-static-analysis
+                       :dropped evidence/unknown})))
+
+(defn- envelope
+  "Stamp a projection with what a consumer validates before it parses anything:
+  the schema version, WHICH read answered, the view it answered about, and the
+  lowering that decides how much the answer could have said.
+
+  `:lowering` is NAMED rather than inferred from the projection's basis, for the
+  reason one evidence schema covers both execution modes at all: a tool must not
+  have to reverse-engineer how a view was compiled out of how much its evidence
+  could claim."
+  [read-kind view-id view projection]
+  (assoc projection
+         :schema   evidence/schema
+         :read     read-kind
+         :view-id  view-id
+         :lowering (:lowering (descriptor/describe view))))
+
+(defn read-view-manifest
+  "What the compiler statically knows about the view declared as `view-id`,
+  inside the projection that says how far to trust it. `nil` for an id this
+  build declared no view under, and `nil` in a production build.
+
+      (tool/read-view-manifest :app.people/people-list)
+      ;; => {:schema    :re-frame.freehand.evidence/v1
+      ;;     :read      :view-manifest
+      ;;     :view-id   :app.people/people-list
+      ;;     :lowering  :compiled
+      ;;     :scope     :possible-sites
+      ;;     :basis     :static-proof
+      ;;     :complete? true
+      ;;     :loss      nil
+      ;;     :manifest  {…}}
+
+  The manifest rides VERBATIM under `:manifest` — the declaration's own data,
+  not a second projection of it. One value published twice cannot drift; two
+  projections of one value eventually do, and the reader has no way to tell
+  which they are holding. Its shape is documented once, on
+  [[re-frame.freehand.compiler/structural-manifest]], and the compile-tier
+  a11y findings ride inside it under `:diagnostics` — including the SUPPRESSED
+  ones, carrying the author's reason, which is a suppression's only trace.
+
+  An interpreted declaration answers `:manifest nil` with the `:opaque` basis
+  and an explicit `{:reason :no-static-analysis :dropped :unknown}` loss, never
+  an empty roster that would read as a clean bill of health."
+  [view-id]
+  (when interop/debug-enabled?
+    (when-some [view (registry/lookup view-id)]
+      (envelope :view-manifest view-id view
+                (evidence/manifest-projection view)))))
+
+;; ---- query-shape honesty ----------------------------------------------------
+
+(defn- literal-form?
+  "True when `x` is pure literal DATA — a scalar, a collection built wholly of
+  literals, or a `(quote …)` — with NO free symbol and NO call.
+
+  A subscription query that satisfies this IS the authored runtime shape and is
+  safe to project verbatim. Anything carrying a free symbol (a captured local:
+  `(v/sub [:person/by-id id])`) or a call is a form whose value does not exist
+  until the view renders, and showing it as though it were the query would be
+  showing a reader source code where they asked for data."
+  [x]
+  (cond
+    (or (nil? x) (boolean? x) (number? x) (char? x) (string? x) (keyword? x)) true
+    (symbol? x) false
+    (vector? x) (every? literal-form? x)
+    (set? x)    (every? literal-form? x)
+    (map? x)    (every? (fn [[k v]] (and (literal-form? k) (literal-form? v))) x)
+    (seq? x)    (= 'quote (first x))
+    :else       false))
+
+(defn- dependency-site
+  "One subscription site, with its query-shape honesty stated per entry.
+
+  A fully-literal query is projected as the value it is (`:dynamic? false`). A
+  query carrying a captured local is `:dynamic? true` and its literal
+  `:query-id` is still shown when the head is one — the part the compiler
+  really does know — while the runtime argument is left unsaid rather than
+  invented."
+  [{:keys [query] :as site}]
+  (merge (select-keys site [:sid :source-coord :path])
+         (if (literal-form? query)
+           {:dynamic? false :query query}
+           (cond-> {:dynamic? true}
+             (and (vector? query) (keyword? (first query)))
+             (assoc :query-id (first query))))))
+
+(defn read-view-dependencies
+  "The reactive dependency SITES the view declared as `view-id` declares — its
+  `v/sub` sites — read from the manifest and so available BEFORE anything
+  mounts. `nil` for an unknown id, and `nil` in a production build.
+
+      (tool/read-view-dependencies :app.people/people-list)
+      ;; => {:schema … :read :view-dependencies :view-id … :lowering :compiled
+      ;;     :scope :possible-sites :basis :static-proof
+      ;;     :complete? true :loss nil
+      ;;     :subscriptions [{:sid … :source-coord {…} :path [0]
+      ;;                      :dynamic? false :query [:person/by-id 7]}
+      ;;                     {:sid … :source-coord {…} :path [1]
+      ;;                      :dynamic? true :query-id :person/by-id}]}
+
+  SITES, not reads. The roster is one entry per LEXICAL site, so a site inside
+  a keyed list is one entry however many times it runs; what a render actually
+  subscribed to is a different quantity and is not derivable from this one.
+
+  `:source-coord` is total or absent — a whole `{:file :line :column}`, or
+  omitted entirely for a declaration that carries no reader location — never
+  partial and never invented."
+  [view-id]
+  (when interop/debug-enabled?
+    (when-some [view (registry/lookup view-id)]
+      (envelope :view-dependencies view-id view
+                (if-some [m (descriptor/manifest view)]
+                  (static-proof {:subscriptions (mapv dependency-site (:subscriptions m))})
+                  (no-static-analysis {:subscriptions []}))))))
+
+(def ^:private event-site-facts
+  "The per-entry facts an event site in the manifest CAN state today.
+
+  Published beside the roster because the analyzer records more than this and
+  the manifest does not carry it: `:prop`, `:classification`, `:serializable?`,
+  `:sync?` and the authored `:handler` are collected in the compiler's site
+  index and dropped by the manifest projection (rf2-z0blg — the same defect
+  rf2-hytu5 fixed for `:diagnostics`).
+
+  So a reader seeing no `:handler` on a site is seeing a fact this build does
+  not publish, NOT a site with no handler — and the difference has to be
+  legible from the answer rather than from a changelog. Naming what an entry
+  states is how an empty-handed roster says which hand is empty. The set
+  retires with the gap it names."
+  #{:sid :source-coord :path})
+
+(defn read-view-event-sites
+  "The event-handler SITES the view declared as `view-id` declares, read from
+  the manifest. `nil` for an unknown id, and `nil` in a production build.
+
+      (tool/read-view-event-sites :app.people/people-list)
+      ;; => {:schema … :read :view-event-sites :view-id … :lowering :compiled
+      ;;     :scope :possible-sites :basis :static-proof
+      ;;     :complete? true :loss nil
+      ;;     :event-sites [{:sid … :source-coord {…} :path [1 0]}]
+      ;;     :site-facts  #{:sid :source-coord :path}}
+
+  The ROSTER is complete and lossless: every event site the grammar can see is
+  here. What each entry can SAY is narrower than what the compiler knows, and
+  `:site-facts` states exactly how narrow — see [[event-site-facts]]. Nothing
+  is inferred to fill the gap: this read answers WHERE a view dispatches from,
+  and until the manifest publishes the classification it will not pretend to
+  answer WHAT it dispatches."
+  [view-id]
+  (when interop/debug-enabled?
+    (when-some [view (registry/lookup view-id)]
+      (envelope :view-event-sites view-id view
+                (if-some [m (descriptor/manifest view)]
+                  (static-proof {:event-sites (:events m)
+                                 :site-facts  event-site-facts})
+                  (no-static-analysis {:event-sites []
+                                       :site-facts  event-site-facts}))))))

--- a/implementation/freehand/src/re_frame/freehand/tool.cljc
+++ b/implementation/freehand/src/re_frame/freehand/tool.cljc
@@ -209,8 +209,9 @@
   (cond
     (or (nil? x) (boolean? x) (number? x) (char? x) (string? x) (keyword? x)) true
     (symbol? x) false
-    (vector? x) (every? literal-form? x)
-    (set? x)    (every? literal-form? x)
+    ;; Vectors and sets are one case, not two: both are literal exactly when
+    ;; every element is, and the element walk does not care which it is.
+    (or (vector? x) (set? x)) (every? literal-form? x)
     (map? x)    (every? (fn [[k v]] (and (literal-form? k) (literal-form? v))) x)
     (seq? x)    (= 'quote (first x))
     :else       false))

--- a/implementation/freehand/test/re_frame/freehand/evidence_boundary_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/evidence_boundary_jvm_test.clj
@@ -15,9 +15,19 @@
      schema IS reachable from the public door — by construction, and
      through exactly one namespace. Checked as REACHABILITY over the
      require graph, rooted at the door: the schema is reachable, and
-     `cell` is the SOLE Freehand namespace whose `ns` form mentions it,
-     so the seam is a single controlled entry point rather than a
-     scattered dependency.
+     `cell` is the sole DOOR-REACHABLE Freehand namespace whose `ns` form
+     mentions it, so the seam is a single controlled entry point rather
+     than a scattered dependency.
+
+     The qualifier earns its keep. `re-frame.freehand.tool` — the
+     tool-tier read door (rf2-lvvl2) — reads the schema's projections and
+     is deliberately NOT reachable from the public door: a tool tier is
+     loaded on purpose, into a dev build, by the inspector that wants it,
+     which is why it can name the schema without putting a second path
+     onto the shipping bundle. That is asserted rather than assumed — the
+     off-path claim is its own row — and the total mention roster stays
+     pinned CLOSED beside the path claim, so a THIRD reader of the schema
+     still reds here and has to be classified into one of the two.
 
   On (2) and what it is NOT: this is a require-graph assertion, not a
   bundle proof. It answers \"how does a render reach this code\" and not
@@ -218,9 +228,34 @@
                  "rf2-3naow emission seam is supposed to reach it under the dev gate; if the "
                  "seam was removed, remove this test too — do not leave it asserting a wiring "
                  "that is gone.")))
-      (testing "and it reaches the path through exactly one seam"
-        (let [seams (freehand-namespaces-mentioning graph 're-frame.freehand.evidence)]
+      (testing "and it reaches the RENDER PATH through exactly one seam"
+        (let [mentions (freehand-namespaces-mentioning graph 're-frame.freehand.evidence)
+              seams    (set (filter reachable mentions))]
+          ;; The claim is about the SHIPPING PATH, so it is asserted over the
+          ;; namespaces that path reaches. `re-frame.freehand.tool` is the
+          ;; tool-tier read door: it reads the schema's projections, and NOTHING
+          ;; reachable from the public door requires it — a tool loads it
+          ;; deliberately, into a dev build, exactly as an inspector loads any
+          ;; tool tier. So it mentions the schema without being a door onto the
+          ;; shipping path, and the row below proves that rather than assuming
+          ;; it.
           (is (= '#{re-frame.freehand.cell} seams)
-              (str "the evidence schema must reach the render path through cell alone — the one "
-                   "dev-gated commit seam. A second Freehand namespace mentioning it would be a "
-                   "second, ungated door onto the shipping path. Found: " (pr-str seams))))))))
+              (str "the evidence schema must reach the RENDER PATH through cell alone — the one "
+                   "dev-gated commit seam. A second door-reachable Freehand namespace mentioning "
+                   "it would be a second, ungated door onto the shipping path. Found: "
+                   (pr-str seams)))
+          ;; The mention roster is pinned CLOSED beside the path claim, so a
+          ;; third namespace reaching the schema still reds here even when it is
+          ;; off the render path. Off-path is a reason to be reviewed, not a
+          ;; licence to spread.
+          (is (= '#{re-frame.freehand.cell re-frame.freehand.tool} mentions)
+              (str "exactly two Freehand namespaces may name the evidence schema: `cell`, the "
+                   "dev-gated commit seam on the render path, and `tool`, the OFF-PATH read "
+                   "door. A third is a new reader of the schema and wants a deliberate decision "
+                   "about which of those two it is. Found: " (pr-str mentions)))
+          (is (not (contains? reachable 're-frame.freehand.tool))
+              (str "re-frame.freehand.tool became reachable from the public door. That is what "
+                   "makes the row above safe: the read door may reach the evidence schema "
+                   "precisely BECAUSE a shipping bundle never requires it. If the door now "
+                   "needs the tool tier, the schema has a second path onto the render path and "
+                   "this whole boundary needs re-deciding — do not simply delete this row.")))))))

--- a/implementation/freehand/test/re_frame/freehand/tool_reads_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/tool_reads_cljs_test.cljc
@@ -1,0 +1,289 @@
+(ns re-frame.freehand.tool-reads-cljs-test
+  "rf2-lvvl2 increment 1 — the ID-TAKING tool reads, and the dev-only
+  declared-view index that makes an id resolvable at all.
+
+  ## The gap these close
+
+  Every Freehand reader beneath the tool tier takes a declaration VALUE.
+  `v/manifest` and `tool/view-manifest` are asked about a view by code holding
+  one. An MCP inspector holds nothing: it arrives over a wire with
+  `:app.people/people-list`. Before this slice there was no way to get from that
+  keyword to the declaration, so the whole view-id-oriented half of the Tool-Pair
+  read surface had no producer.
+
+  ## What is asserted, and what deliberately is not
+
+  These are DECLARATION reads. They answer what CAN happen — the finite lexical
+  sites the compiler saw — and nothing about what DID. So the suite pins the
+  four-axis honesty (`:scope` / `:basis` / `:complete?` / `:loss`) hard, because
+  that is where a declaration read could lie: an INTERPRETED declaration has no
+  analysis step, and an empty roster reported as complete-and-lossless would be
+  claiming it found nothing where what it means is that it never looked.
+
+  Nothing here asserts an occurrence, a mount, a generation or a count. Those
+  are current-occurrence reads (rf2-xftdv) and the bounded `explain-render`
+  (rf2-cpfbg), with their own state and their own suites. The index this reads
+  through holds ONE row per declaration, which is asserted below — a
+  redeclaration replaces rather than appends, because an index that appended
+  would be a history store wearing an index's name.
+
+  ## Cross-host on purpose
+
+  The manifest is built at macro expansion — on the JVM for both hosts — but the
+  reads are what a BROWSER tool calls, so the door has to be a namespace
+  ClojureScript can compile and run. Proving it only under `clojure -M:test`
+  would leave the one host that matters to Pair unexercised, which is exactly
+  the defect rf2-hytu5 fixed for the value-taking reader. The expansion-shape
+  row is JVM-only, and says so: `expand-defview` is macro machinery and exists
+  on the JVM alone."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.registry :as registry]
+            [re-frame.freehand.tool :as tool]))
+
+;; ---------------------------------------------------------------------------
+;; The census — one compiled declaration carrying every roster under test,
+;; and one interpreted declaration that carries no analysis at all
+;; ---------------------------------------------------------------------------
+
+(v/defview basket
+  "A COMPILED declaration with a literal subscription, a captured-local
+  subscription and two event sites — so every honesty arm below has a real
+  entry to read, and the literal/dynamic split is a discrimination rather than
+  a tautology."
+  {:compiled true}
+  [{:keys [row-id]}]
+  [:section.basket
+   [:p (v/sub [:basket/total])]
+   [:p (v/sub [:basket/line row-id])]
+   [:button {:on-click [:basket/clear]} "Clear"]
+   [:button {:on-click [:basket/checkout 7]} "Buy"]])
+
+(v/defview plain-list
+  "The paved path: interpreted, so there is no analysis to report and no roster
+  that could be honestly claimed complete."
+  [{:keys [title]}]
+  [:ul [:li title]])
+
+(def ^:private basket-id
+  ::basket)
+
+(def ^:private plain-id
+  ::plain-list)
+
+;; ---------------------------------------------------------------------------
+;; The index — a declaration resolves by id, and holds one row
+;; ---------------------------------------------------------------------------
+
+(deftest a-declaration-records-itself-under-its-view-id
+  (testing "The fact the whole slice rests on: a `v/defview` puts itself in the
+            dev-only index as it is declared, so an inspector that ATTACHES
+            LATE — to an application that finished loading long before it
+            arrived — can still resolve an id it was handed over a wire."
+    (is (= basket (registry/lookup basket-id))
+        "the compiled declaration resolves to the declaration value itself")
+    (is (= plain-list (registry/lookup plain-id))
+        "and so does the interpreted one — both lowerings are inspectable")
+    (is (nil? (registry/lookup :nobody/declared-this))
+        "an id nothing declared answers nil rather than throwing")
+    (is (contains? (registry/view-ids) basket-id)
+        "and the roster a sweep enumerates carries it")))
+
+(deftest the-index-holds-one-row-per-declaration-not-a-history
+  (testing "Re-registration REPLACES. A reloaded declaration is the SAME view,
+            and an index that appended would be the cumulative store
+            rf2-drpa3.167 ruled out — under a different name. Asserted over the
+            roster's cardinality, which an appending index could not keep."
+    (let [before (count (registry/view-ids))]
+      (registry/register! basket-id basket)
+      (registry/register! basket-id basket)
+      (is (= before (count (registry/view-ids)))
+          "two more registrations of one id add no rows")
+      (is (= basket (registry/lookup basket-id))
+          "and the row still answers the declaration"))))
+
+;; ---------------------------------------------------------------------------
+;; read-view-manifest
+;; ---------------------------------------------------------------------------
+
+(deftest read-view-manifest-answers-the-manifest-inside-the-projection
+  (testing "The manifest rides VERBATIM under `:manifest` — the declaration's
+            own data, not a second projection of it — inside the envelope a
+            consumer validates before parsing anything."
+    (let [r (tool/read-view-manifest basket-id)]
+      (is (some? r) "a declared compiled view answers")
+      (is (= :re-frame.freehand.evidence/v1 (:schema r))
+          "stamped with the schema version a consumer checks FIRST")
+      (is (= :view-manifest (:read r))
+          "and with WHICH read answered, so two reads' answers cannot be confused")
+      (is (= basket-id (:view-id r)))
+      (is (= :compiled (:lowering r))
+          "the lowering is NAMED, never inferred from how much the evidence claims")
+      (is (= (v/manifest basket) (:manifest r))
+          "one value published twice — the tool read and the application read
+           cannot drift, because there is only one projection"))))
+
+(deftest a-compiled-declaration-claims-static-proof-and-no-loss
+  (testing "The analyzer walked the whole body and the grammar is finite, so the
+            roster is every site there CAN be: complete for `:possible-sites`,
+            and lossless."
+    (let [r (tool/read-view-manifest basket-id)]
+      (is (= :possible-sites (:scope r)))
+      (is (= :static-proof (:basis r)))
+      (is (true? (:complete? r)))
+      (is (nil? (:loss r))))))
+
+(deftest an-interpreted-declaration-reports-the-absence-of-analysis
+  (testing "The arm the projection vocabulary exists for. An interpreted body
+            has no analysis step, so what it could reach is not merely uncounted
+            — it is unknowable without running it. `:complete? true :loss nil`
+            here would be a clean bill of health nobody issued."
+    (let [r (tool/read-view-manifest plain-id)]
+      (is (some? r) "an interpreted declaration is still readable")
+      (is (= :interpreted (:lowering r)))
+      (is (nil? (:manifest r)) "with no manifest, because there is no analysis")
+      (is (= :opaque (:basis r)))
+      (is (false? (:complete? r)))
+      (is (= {:reason :no-static-analysis :dropped :unknown} (:loss r))
+          "and the loss NAMED, with an explicit :unknown — an absent :dropped
+           reads as none, which is the one shape this schema exists to refuse"))))
+
+(deftest an-undeclared-id-answers-nil-from-every-read
+  (testing "Absence is absence. A tool sweeping ids it was handed cannot assume
+            each one names a view in THIS build, and a read that invented an
+            empty answer would report a view that does not exist as a view with
+            nothing in it."
+    (doseq [read-fn [tool/read-view-manifest
+                     tool/read-view-dependencies
+                     tool/read-view-event-sites]]
+      (is (nil? (read-fn :nobody/declared-this))))))
+
+;; ---------------------------------------------------------------------------
+;; read-view-dependencies — the literal/dynamic split
+;; ---------------------------------------------------------------------------
+
+(deftest read-view-dependencies-projects-the-declared-subscription-sites
+  (testing "SITES, not reads: one entry per lexical `v/sub`, read from the
+            manifest and so available before anything mounts."
+    (let [r (tool/read-view-dependencies basket-id)]
+      (is (= :view-dependencies (:read r)))
+      (is (= 2 (count (:subscriptions r)))
+          "exactly the two `v/sub` sites the body carries")
+      (doseq [site (:subscriptions r)]
+        (is (string? (:sid site)) "under the compiler-minted stable site id")
+        (is (vector? (:path site)) "with its deterministic occurrence coordinate")
+        (is (contains? site :dynamic?)
+            "and its query-shape honesty stated on the entry, never left to be
+             inferred from whether :query happens to be present")))))
+
+(deftest a-literal-query-is-projected-as-the-value-it-is
+  (testing "A fully-literal query IS the authored runtime shape, so it is safe
+            to show verbatim."
+    (let [sites   (:subscriptions (tool/read-view-dependencies basket-id))
+          literal (first (filter (complement :dynamic?) sites))]
+      (is (some? literal) "the body carries a literal-query site")
+      (is (= [:basket/total] (:query literal))
+          "shown as data, because that is what it is"))))
+
+(deftest a-captured-local-is-dynamic-and-shows-only-what-is-known
+  (testing "`(v/sub [:basket/line row-id])` closes over a template local, so its
+            query does not exist until the view renders. Showing the form as
+            though it were the query would be handing a reader source code where
+            they asked for data — but the HEAD is genuinely known, so it is
+            still shown."
+    (let [sites   (:subscriptions (tool/read-view-dependencies basket-id))
+          dynamic (first (filter :dynamic? sites))]
+      (is (some? dynamic) "the body carries a captured-local site")
+      (is (not (contains? dynamic :query))
+          "no :query is offered, because there is no query yet")
+      (is (= :basket/line (:query-id dynamic))
+          "the literal query-id IS known and is shown — absence is reported
+           where it exists, not spread over the parts that are certain"))))
+
+(deftest the-literal-dynamic-split-is-a-discrimination
+  (testing "Non-vacuity for the two rows above: the census carries one of each,
+            so a projection that answered `:dynamic? true` to everything — or
+            `false` to everything — cannot pass both."
+    (let [sites (:subscriptions (tool/read-view-dependencies basket-id))]
+      (is (= #{true false} (set (map :dynamic? sites)))))))
+
+(deftest an-interpreted-declaration-has-no-dependency-roster-to-claim
+  (testing "Same honesty as the manifest read: an empty roster, and the reason
+            it is empty, rather than an empty roster presented as a survey."
+    (let [r (tool/read-view-dependencies plain-id)]
+      (is (= [] (:subscriptions r)))
+      (is (false? (:complete? r)))
+      (is (= :no-static-analysis (:reason (:loss r)))))))
+
+;; ---------------------------------------------------------------------------
+;; read-view-event-sites — complete roster, narrower entries, said so
+;; ---------------------------------------------------------------------------
+
+(deftest read-view-event-sites-projects-every-declared-event-site
+  (testing "The ROSTER is complete and lossless: every event site the grammar
+            can see is here."
+    (let [r (tool/read-view-event-sites basket-id)]
+      (is (= :view-event-sites (:read r)))
+      (is (= 2 (count (:event-sites r)))
+          "exactly the two `:on-click` sites the body carries")
+      (is (true? (:complete? r)))
+      (is (nil? (:loss r))))))
+
+(deftest an-event-site-says-which-facts-it-can-state
+  (testing "The analyzer records `:prop`, `:classification`, `:serializable?`,
+            `:sync?` and the authored `:handler` per site, and the manifest
+            projection drops all five (rf2-z0blg). So a reader seeing no
+            `:handler` is seeing a fact this build does not publish, NOT a site
+            with no handler — and `:site-facts` is what makes the difference
+            legible from the answer rather than from a changelog.
+
+            Asserted as an EQUALITY against the entries themselves, so the key
+            cannot drift into a decoration: if the manifest starts publishing
+            the classification and `:site-facts` is not updated, this reds."
+    (let [r (tool/read-view-event-sites basket-id)]
+      (is (= #{:sid :source-coord :path} (:site-facts r)))
+      (doseq [site (:event-sites r)]
+        (is (= (:site-facts r) (set (keys site)))
+            "every entry states exactly the facts the read says it states")))))
+
+(deftest an-interpreted-declaration-has-no-event-roster-to-claim
+  (testing "The third read's honesty arm, asserted rather than assumed to
+            follow from its siblings'."
+    (let [r (tool/read-view-event-sites plain-id)]
+      (is (= [] (:event-sites r)))
+      (is (= :opaque (:basis r)))
+      (is (= :unknown (:dropped (:loss r)))))))
+
+;; ---------------------------------------------------------------------------
+;; The dev gate — visible in the expansion, which is where it can fold away
+;; ---------------------------------------------------------------------------
+
+#?(:clj
+   (deftest the-registration-is-gated-in-the-expansion
+     (testing "The index must not ship. The gate is emitted INTO the declaration
+               rather than hidden inside `register!`, because a call site guarded
+               by `re-frame.interop/debug-enabled?` is what Closure folds to
+               `false` under `:advanced` — taking the call, its descriptor
+               argument and every path into the index with it. A gate one
+               function call deeper would leave the call site, and therefore the
+               namespace, alive in the bundle.
+
+               Checked over the emitted FORM (macro machinery, so JVM-only): the
+               expansion names both the gate and the registrar, and names the
+               declaration entry exactly ONCE — a two-armed `if` would emit the
+               whole declaration twice into every bundle."
+       (let [expanded (v/expand-defview {:line 1 :column 1}
+                                        "app/probe.cljs"
+                                        'app.probe
+                                        'probe
+                                        '([_] [:div.probe]))
+             symbols  (set (filter symbol? (tree-seq coll? seq expanded)))
+             text     (pr-str expanded)]
+         (is (contains? symbols 're-frame.interop/debug-enabled?)
+             "the expansion carries the dev gate itself, not a call to something
+              that checks one")
+         (is (contains? symbols 're-frame.freehand.registry/register!)
+             "and the registration it guards")
+         (is (= 1 (count (re-seq #"declare-view" text)))
+             "the declaration is constructed exactly once — the gate wraps the
+              registration, never a second copy of the entry")))))

--- a/implementation/freehand/test/re_frame/freehand/tool_reads_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/tool_reads_cljs_test.cljc
@@ -180,7 +180,7 @@
   (testing "A fully-literal query IS the authored runtime shape, so it is safe
             to show verbatim."
     (let [sites   (:subscriptions (tool/read-view-dependencies basket-id))
-          literal (first (filter (complement :dynamic?) sites))]
+          literal (first (remove :dynamic? sites))]
       (is (some? literal) "the body carries a literal-query site")
       (is (= [:basket/total] (:query literal))
           "shown as data, because that is what it is"))))

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -2565,9 +2565,23 @@ test('the SOLE-requirer law that keeps the narrow arm honest still exists (rf2-x
   // while a NEW schema-touching producer cannot appear silently — and what
   // forbids one is
   // `the-evidence-schema-reaches-the-render-path-only-through-the-dev-gated-seam`
-  // in the always-armed jvm-freehand lane, which asserts `cell` is the sole
-  // Freehand namespace mentioning the schema. Pin the premise with the routing:
-  // if that law is ever relaxed, this reds and the classifier arm must widen.
+  // in the always-armed jvm-freehand lane. Pin the premise with the routing: if
+  // that law is ever relaxed, this reds and the classifier arm must widen.
+  //
+  // The law is now TWO rows, and the narrow arm leans on BOTH (rf2-lvvl2). The
+  // tool-tier read door `re-frame.freehand.tool` mentions the schema without
+  // being a producer, because nothing reachable from the public door requires
+  // it — an inspector loads a tool tier deliberately, into a dev build. So:
+  //
+  //   1. `cell` is the sole DOOR-REACHABLE mentioner (the render-path claim);
+  //   2. `tool` is asserted NOT door-reachable (what makes (1) safe — a
+  //      `tool.cljc` edit cannot put the schema in the release bundle, because
+  //      the release bundle does not contain `tool`).
+  //
+  // Row (2) is the load-bearing one for this classifier: reachability is
+  // decided by whoever REQUIRES the tool tier, not by the tool tier itself, so
+  // without it a door-side require could ship the schema while the elision gate
+  // sat unarmed. Both rows are pinned here.
   const law = fs.readFileSync(
     path.join(
       REPO_ROOT,
@@ -2578,8 +2592,17 @@ test('the SOLE-requirer law that keeps the narrow arm honest still exists (rf2-x
   assert.match(
     law,
     /'#\{re-frame\.freehand\.cell\}\s+seams/,
-    'the boundary test must still pin cell as the SOLE namespace reaching the evidence schema — '
-      + 'without it, a new producer file could dodge the narrowly-armed elision gate',
+    'the boundary test must still pin cell as the sole DOOR-REACHABLE namespace reaching the '
+      + 'evidence schema — without it, a new producer file could dodge the narrowly-armed '
+      + 'elision gate',
+  );
+  assert.match(
+    law,
+    /not\s+\(contains\?\s+reachable\s+'re-frame\.freehand\.tool\)/,
+    'the boundary test must still pin the tool-tier read door OFF the render path — that is what '
+      + 'makes the door-reachable form of the sole-producer law safe for the narrow arm. If the '
+      + 'tool tier becomes door-reachable, the schema has a second path into the release bundle '
+      + 'and freehand_evidence_elision must widen to arm on the door and the tool tier too',
   );
 });
 

--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/gen.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/gen.clj
@@ -117,15 +117,25 @@
     ;; the supported six are the whole namespace by construction rather than
     ;; by carve-out. Its CLJS surface is reconciled by the probe.
     re-frame.freehand.test
-    ;; The Freehand substrate's TOOL-TIER READER DOOR (rf2-hytu5; contract in
-    ;; Spec 004, the instrumentation it serves in Spec 009). The third and last
-    ;; sanctioned `re-frame.freehand.*` namespace, publishing ONE name —
-    ;; `view-manifest`, a total projection of the compile-time analysis a value
-    ;; already carries. `.cljc` and host-neutral like the door and the test
-    ;; sibling, so `ns-publics` is authoritative here and the CLJS half is
-    ;; reconciled by the probe. It is a READER, not a tool framework: there is
-    ;; no accumulator, no registry and no history store, so the one name is the
-    ;; whole namespace by construction rather than by carve-out.
+    ;; The Freehand substrate's TOOL-TIER READER DOOR (rf2-hytu5, extended by
+    ;; rf2-lvvl2; contract in Spec 004, the instrumentation it serves in Spec
+    ;; 009). The third and last sanctioned `re-frame.freehand.*` namespace,
+    ;; publishing FOUR names: `view-manifest`, a TOTAL projection of the
+    ;; compile-time analysis a value already carries, plus the three ID-taking
+    ;; reads a wire-attached inspector needs — `read-view-manifest`,
+    ;; `read-view-dependencies`, `read-view-event-sites`. `.cljc` and
+    ;; host-neutral like the door and the test sibling, so `ns-publics` is
+    ;; authoritative here and the CLJS half is reconciled by the probe.
+    ;;
+    ;; It is a READER, not a tool framework: no accumulator, no interval log
+    ;; and no history store. The id-taking reads resolve an id through the
+    ;; INTERNAL dev-only declared-view index `re-frame.freehand.registry`,
+    ;; which is `^:no-doc`, holds one row per declaration and is absent from
+    ;; this list BY CONSTRUCTION — the same standing `re-frame.freehand.
+    ;; descriptor` has above, and for the same reason: its only caller is the
+    ;; `v/defview` expansion and nothing authors against it. So the supported
+    ;; four are the whole namespace by construction rather than by carve-out
+    ;; (the private helpers beneath them are `defn-`).
     re-frame.freehand.tool
     ;; Optional feature artefacts (public home namespaces).
     re-frame.schemas

--- a/spec/api-manifest-metadata.edn
+++ b/spec/api-manifest-metadata.edn
@@ -1515,9 +1515,30 @@
   ["re-frame.freehand.test" "text"]        {:tier :testing :owner "008" :status "EP-0036"}
 
   ;; =========================================================================
-  ;; re-frame.freehand.tool — the Freehand TOOL-TIER READER DOOR (rf2-hytu5;
-  ;; EP-0036). The third and last sanctioned `re-frame.freehand.*` namespace,
-  ;; and the smallest: ONE name, `view-manifest`.
+  ;; re-frame.freehand.tool — the Freehand TOOL-TIER READER DOOR (rf2-hytu5,
+  ;; extended by rf2-lvvl2; EP-0036). The third and last sanctioned
+  ;; `re-frame.freehand.*` namespace. FOUR names: the value-taking
+  ;; `view-manifest`, and the three ID-taking reads a wire-attached inspector
+  ;; needs — `read-view-manifest`, `read-view-dependencies`,
+  ;; `read-view-event-sites`.
+  ;;
+  ;; Why the split is two doors and not one function's arities: `view-manifest`
+  ;; is TOTAL over every value, because a sweep over a namespace's publics
+  ;; hands it strings, numbers and plain fns and a reader that threw on the
+  ;; first non-view could not sweep. So `(view-manifest :a/keyword)` answers
+  ;; `nil` — a keyword is not a view — and must keep answering that. An MCP
+  ;; inspector holds no values at all: it arrives over a wire with
+  ;; `:app.people/people-list`. Overloading one name to mean both "project this
+  ;; value" and "resolve this id" would break the totality the sweep depends
+  ;; on, so the id-taking reads carry their own names.
+  ;;
+  ;; All four are the SAME tier for the same reason, so the three new rows are
+  ;; not an escalation: each answers with inspection DATA and none is a
+  ;; dispatch surface. The id-taking three additionally answer inside the
+  ;; four-axis evidence projection (`:scope` / `:basis` / `:complete?` /
+  ;; `:loss`), which is what lets a tool tell an INTERPRETED declaration — no
+  ;; analysis step, so nothing knowable — from a compiled one whose rosters
+  ;; really are empty.
   ;;
   ;; TOOLING, the same tier `v/describe` and `v/manifest` sit in, and for the
   ;; same reason — it answers with inspection DATA and is never a dispatch
@@ -1540,15 +1561,35 @@
   ;;
   ;; DELIBERATELY NOT the donor `re-frame.ui.tool` surface, whose disposition
   ;; is REPLACE and whose per-occurrence evidence accumulator was ruled out
-  ;; PERMANENTLY (rf2-drpa3.167), not deferred. There is no accumulator, no
-  ;; root registry, no interval log and no history store here — retention is
-  ;; Spec 009's ring — so the one name is the whole namespace by construction,
-  ;; and live reads over mounted occurrences are a separate slice (rf2-lvvl2)
-  ;; with a separate owner. `.cljc` and host-neutral like the door and the
-  ;; test sibling, so the JVM generator owns tier/kind via `ns-publics` and
-  ;; the CLJS probe reconciles the same row, FULLY-ROWED in both directions.
+  ;; PERMANENTLY (rf2-drpa3.167), not deferred. There is still no accumulator,
+  ;; no interval log and no history store here — retention is Spec 009's ring.
+  ;; The id-taking reads resolve through a dev-only DECLARED-VIEW index
+  ;; (`re-frame.freehand.registry`): one row per declaration, replaced when
+  ;; that declaration is re-evaluated, carrying no occurrence, generation or
+  ;; count. That index is INTERNAL and `^:no-doc`, and is absent from this
+  ;; projection BY CONSTRUCTION rather than by carve-out — the same standing
+  ;; `re-frame.freehand.descriptor` has, and for the same reason: nothing
+  ;; authors against it. Its only caller is the `v/defview` expansion and its
+  ;; only reader is this namespace, so a row here would advertise an authoring
+  ;; surface that does not exist. It is also dev-gated and elides from release
+  ;; builds, so a public row would name something a shipped bundle does not
+  ;; contain. Promoting it would be a D001 change (the sanctioned
+  ;; `re-frame.freehand.*` siblings are a closed set), which a registry-shaped
+  ;; internal does not earn.
+  ;;
+  ;; Live reads over MOUNTED occurrences remain a separate slice — `mounted-
+  ;; views` (rf2-xftdv) and the bounded `explain-render` (rf2-cpfbg) — each
+  ;; with its own owner, its own state and its own release seam. Nothing below
+  ;; can say what is mounted, and none of it pretends to.
+  ;;
+  ;; `.cljc` and host-neutral like the door and the test sibling, so the JVM
+  ;; generator owns tier/kind via `ns-publics` and the CLJS probe reconciles
+  ;; the same rows, FULLY-ROWED in both directions.
   ;; =========================================================================
-  ["re-frame.freehand.tool" "view-manifest"] {:tier :tooling :owner "004" :status "EP-0036"}
+  ["re-frame.freehand.tool" "view-manifest"]          {:tier :tooling :owner "004" :status "EP-0036"}
+  ["re-frame.freehand.tool" "read-view-manifest"]     {:tier :tooling :owner "004" :status "EP-0036"}
+  ["re-frame.freehand.tool" "read-view-dependencies"] {:tier :tooling :owner "004" :status "EP-0036"}
+  ["re-frame.freehand.tool" "read-view-event-sites"]  {:tier :tooling :owner "004" :status "EP-0036"}
 
   ["re-frame.ui.test" "render"]    {:tier :testing :owner "008" :status "Spec-004 S1"}
   ["re-frame.ui.test" "text"]      {:tier :testing :owner "008" :status "Spec-004 S1"}

--- a/spec/api-manifest.edn
+++ b/spec/api-manifest.edn
@@ -6,7 +6,7 @@
  {:doc
  "GENERATED public-API manifest — do NOT hand-edit the :vars list. Regenerate with: clojure -M -m re-frame.api-manifest.gen (run from implementation/scripts/api-manifest/). The tier/owner/status axes are curated in spec/api-manifest-metadata.edn; existence + kind + facade? are derived from live public vars. See that generator ns for the design.",
  :keystone "rf2-3nbl5.2",
- :var-count 544,
+ :var-count 547,
  :tier-vocab
  [:front-porch
   :advanced
@@ -230,6 +230,9 @@
   {:namespace "re-frame.freehand.test", :var "render", :tier :testing, :kind :fn, :owner "008", :status "EP-0036", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.freehand.test", :var "text", :tier :testing, :kind :fn, :owner "008", :status "EP-0036", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.freehand.test", :var "with-render", :tier :testing, :kind :macro, :owner "008", :status "EP-0036", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.freehand.tool", :var "read-view-dependencies", :tier :tooling, :kind :fn, :owner "004", :status "EP-0036", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.freehand.tool", :var "read-view-event-sites", :tier :tooling, :kind :fn, :owner "004", :status "EP-0036", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.freehand.tool", :var "read-view-manifest", :tier :tooling, :kind :fn, :owner "004", :status "EP-0036", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.freehand.tool", :var "view-manifest", :tier :tooling, :kind :fn, :owner "004", :status "EP-0036", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.http", :var "delete", :tier :advanced, :kind :fn, :owner "014", :status "v1 (optional capability)", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.http", :var "get", :tier :advanced, :kind :fn, :owner "014", :status "v1 (optional capability)", :facade? false, :runtime-verified? true}


### PR DESCRIPTION
Increment 1 of **rf2-lvvl2** — source (1), STATIC DECLARATION FACTS. The bead
enumerates three sources and stays **OPEN**: this PR meets DONE WHEN 6 only,
and adds **no retained state of any kind**.

## The gap

Every Freehand reader beneath the tool tier takes a declaration **value**.
`v/manifest` and `tool/view-manifest` are asked about a view by code that is
holding one. An MCP inspector holds nothing — it arrives over a wire with
`:app.people/people-list` — so the whole view-id-oriented half of the Tool-Pair
read surface had no producer at all.

## The design call the bead flagged

Freehand had no browser-global descriptor registry, so the bead left one
decision open: add a small **dev-only registry keyed by view id**, or make the
descriptor an **explicit input**. I took the registry, which is the bead's own
stated default, for a concrete reason rather than by deferral: Pair's API is
view-id-oriented and an MCP client cannot hold a descriptor over a wire, so
"explicit input" has no caller that could supply it.

`re-frame.freehand.registry` is one row per **declaration** — view-id to the
declaration, replaced when that declaration is re-evaluated. No occurrence, no
generation, no count, no ordering, no history. Two live occurrences of one view
are one row, because a declaration is not a mount.

Var resolution was the alternative to an index and is unavailable exactly where
it is needed: an `:advanced` build has no Vars, and a dev build's munged module
objects are the private host state a tool read exists to avoid reaching into. So
the declaration records itself as it is declared — which is also what lets an
inspector **attaching late** see views declared before it arrived.

**Known, bounded staleness, stated rather than papered over:** a hot reload that
*deletes* a declaration leaves its last row behind, because nothing runs to
retract it. One row per id, never a growing log. The alternative was a
per-namespace eviction protocol with no caller asking for one.

## Where the dev gate lives, and why there

The registration is emitted **into the `v/defview` expansion** behind
`interop/debug-enabled?`, not hidden inside `register!`. A guarded call site is
what Closure folds away under `:advanced`, taking the call, its descriptor
argument and every path into the index with it; a gate one function call deeper
would leave the call site — and therefore the namespace — alive in the bundle.
The declaration entry is named exactly **once**: a two-armed `if` would emit the
whole declaration twice into every bundle. This is the same gating shape the
declaration's `:source` entry already used in that function.

Pinned by a JVM row over the emitted form: the expansion names the gate, names
the registrar, and constructs the declaration exactly once.

## The three reads

`read-view-manifest`, `read-view-dependencies` and `read-view-event-sites`
answer inside the four-axis evidence projection (`:scope` / `:basis` /
`:complete?` / `:loss`). That is not ceremony — it is the only way a tool can
tell an **interpreted** declaration (no analysis step, so nothing knowable) from
a **compiled** one whose rosters really are empty:

| lowering | basis | complete? | loss |
|---|---|---|---|
| compiled | `:static-proof` | `true` | `nil` |
| interpreted | `:opaque` | `false` | `{:reason :no-static-analysis :dropped :unknown}` |

*Unknown must not look like none.* The manifest rides **verbatim** under
`:manifest` — one value published twice cannot drift; two projections of one
value eventually do.

`read-view-dependencies` carries per-site query-shape honesty: a fully-literal
query *is* the authored runtime shape and is shown as data, while a query
closing over a template local is `:dynamic? true` with its literal `:query-id`
still shown — absence reported where it exists, not spread over the parts that
are certain.

`read-view-event-sites` publishes the complete site roster and states what an
entry *can* say. The analyzer records `:prop`, `:classification`,
`:serializable?`, `:sync?` and the authored `:handler` per site, and
`structural-manifest` drops all five — so this read answers **where** a view
dispatches from and will not pretend to answer **what**. `:site-facts` makes
that legible from the answer rather than from a changelog, and retires with the
gap it names. Filed as **rf2-z0blg**: the same defect rf2-hytu5 fixed for
`:diagnostics`, not done here because the exact-key-set assertions pin it to
`fh-struct-010.edn`, which was fenced for the analyzer/emitter serial lane.
A lane conflict, not a design question.

## The one-seam law is refined, not relaxed

The read door reaches `re-frame.freehand.evidence` for its projections, so
`evidence_boundary_jvm_test`'s single-seam assertion is restated as
**reachability** plus two rows beside it:

1. `cell` is the sole **door-reachable** mentioner — the render-path claim.
2. The total mention roster is pinned **closed** at `{cell, tool}`, so a third
   reader of the schema still reds and has to be classified into one of the two.
3. `tool` is asserted **not** reachable from the public door — which is what
   makes (1) safe. A `tool.cljc` edit cannot put the schema in the release
   bundle, because the release bundle does not contain `tool`.

That premise is load-bearing beyond this test. `freehand_evidence_elision` arms
**four files, not the tree**, and its honesty rests on the sole-producer law.
Reachability is decided by whoever *requires* the tool tier, not by the tier
itself, so the off-path row is what the narrow arm now leans on:
`_changed-surfaces.test.cjs` pins both rows, and the classifier comment states
the law as it now stands.

## Consumer / transitive surface

**`structural-manifest` is untouched — the manifest shape did not change.** The
F6 ledger consumer rewires (rows 392/393/394/395/397 — Xray
`viewcell_evidence.cljs`, the reactive panels, the evidence tests, and Pair's
`view_tool.cljs`) stay pending and are unaffected by this diff. Nothing under
`tools/` is touched, and Pair's tool catalogue is a closed world, so the wire
tools are deliberately not rewired here. The transitive surface was gated
through `:require` edges: the door, `cell`, the elision/reachability classifier
arms and the always-armed jvm-freehand lane are all covered below.

## Follow-ons filed

- **rf2-xftdv** — source (2): the minimal current-occurrence index and
  `mounted-views`. Carries the rf2-drpa3.167 hard fence verbatim (no lifetime
  counts, no target union, no interval ledger, no hide-vs-unmount labels, no
  weak-keyed store, no HMR migration, no cell-to-root attribution, no second
  retention knob) and the requirement that justifies any live state at all —
  **Pair attaches late**, so the fire-and-forget commit sink can never answer
  "what is mounted right now". Blocks rf2-lvvl2.
- **rf2-cpfbg** — source (3): the bounded `explain-render`. Carries the
  implementation hazard the bead calls worth the whole bead if missed — **Spec
  009 does not retain frameless events**, so evidence must join the frame/run
  correlation or use an equally explicit retained Freehand trace operation under
  the *same* ring and the *same* retention knob. Blocks rf2-lvvl2.
- **rf2-z0blg** — the manifest event-site publication gap described above.

`cell/set-evidence-sink!` no longer says downstream tooling "installs the
accumulator here" (the design rf2-drpa3.167 rejected); it now names rf2-xftdv
and rf2-cpfbg, per this bead's own audit note.

## Quality gates

| gate | result |
|---|---|
| Freehand JVM — `cd implementation/freehand && clojure -M:test` | **PASS** — 1020 tests, 7040 assertions, 0 failures, 0 errors |
| Freehand CLJS — `cd implementation && npm run test:freehand` | **PASS** — 1086 tests, 6071 assertions, 0 failures, 0 errors |
| `scripts/test-fast-pr.sh` — 17 always-on static/drift gates | **PASS** — all 17, 0 failures |
| `scripts/test-fast-pr.sh` — core JVM tier | **PASS** — 2105 tests, 10430 assertions, 0 failures, 0 errors |
| `scripts/test-fast-pr.sh` — node/CLJS/isolation tier | **STILL RUNNING AT HAND-OFF — relying on CI.** See the note below; a stated reliance, not an omission |
| `npm run test:freehand-evidence-elision` (armed by the `cell.cljc` change) | **NOT RUN LOCALLY — relying on CI.** Two `:advanced` builds; the `cell.cljc` change is docstring-only and docstrings do not ship |
| donor-boundary law (`git grep -e 're-frame\.ui' -e 're_frame/ui' -e 're-frame2-ui' -- implementation/freehand`, the test.yml jvm-freehand arm) | **PASS** — no matches, checked including the two new untracked files before staging |
| new suite alone — `clojure -M:test -n re-frame.freehand.tool-reads-cljs-test` | **PASS** — 15 tests, 55 assertions |
| refined boundary test alone — `clojure -M:test -n re-frame.freehand.evidence-boundary-jvm-test` | **PASS** — 4 tests, 49 assertions |
| **`Public-API manifest drift-check` — `clojure -M -m re-frame.api-manifest.gen --check`** (the CI failure) | **PASS — exit 0.** `OK: spec/api-manifest.edn in sync (547 public vars)` |
| same job step 2 — `... ui-context --check` | **PASS — exit 0.** `OK: ui-context.md in sync (98 ids, 32 authoring vars)` |
| same job step 3 — `... api-md-check` | **PASS — exit 0.** `OK: spec/API.md projection in sync (245 var-rows)` |
| `Lint required` | **resolved by the above** — it is an aggregator over `[detect, clj-kondo, splint, api-manifest]`; its log read `needs results: success, success, success, failure`, the 4th being api-manifest |
| clj-kondo, exactly as `lint.yml` runs it | **0 errors in any file I touched.** Local exit 3 comes from 9 pre-existing `Expected: throwable` errors in `implementation/ui/test/**` (donor tests, untouched by this diff); CI's clj-kondo job passes |
| Splint, exactly as `lint.yml` runs it | **PASS — exit 0** |
| Freehand JVM + CLJS re-run after the two Splint refactors | **PASS — exit 0 both.** 1020/7040 and 1086/6071, 0 failures |

### On the tier I did not see finish

Being explicit rather than quiet about this. The spine had reached the
**node/CLJS/isolation** tier when I opened this PR, so I am relying on CI for
that tier alone. Everything before it I watched finish green: the 17 always-on
static/drift gates, then the core JVM tier at 2105 tests / 10430 assertions,
0 failures.

The node tier is also the one that reddened on the *first* spine run, on
`_changed-surfaces.test.cjs` — the classifier harness pinning the sole-requirer
law this PR refines. That failure is **fixed here**, and the fix was verified
standalone rather than assumed: `node scripts/_changed-surfaces.test.cjs` →
**229 passed**. The rest of that tier (`test:cljs`, the JS harness helpers, the
per-namespace isolation gate) does not load Freehand, and this diff touches no
adapter, example, or core runtime surface.

So the node tier is expected green, but I did not watch it finish locally and CI
is the real gate. (The branch has since been rebased onto current `origin/main`,
so CI is re-running the whole matrix on the rebased head regardless.)

`freehand_evidence_elision` **will arm in CI** for this PR, because `cell.cljc`
is one of the four files that arms it. The change there is a docstring only, and
docstrings do not ship.

### The two red checks on the first CI run — fixed here

Both were **one root cause**. `Lint required` is an aggregator over
`[detect, clj-kondo, splint, api-manifest]` and its log read `needs results:
success, success, success, failure` — the fourth being the drift-check. clj-kondo
and Splint had already passed.

The drift-check wanted sidecar classifications for the three new public reads.
They are now `:tooling` / owner `004` / EP-0036 — the tier `view-manifest`,
`v/describe` and `v/manifest` already sit in, so not an escalation — and
`spec/api-manifest.edn` was **regenerated**, not hand-edited (544 → 547 vars).

I also ran the two later steps of that same job, which never got to run in CI
because step one aborted it. Both pass, and notably `api-md-check` passes
untouched — the `:tooling` tier is not among the 245 var-rows `spec/API.md`
projects — so **this PR needs no `spec/API.md` change**, keeping it clear of the
`:prefetch` prose edit in flight.

**Position taken: `re-frame.freehand.registry` is not public API and is not
rowed.** The generator's `jvm-namespaces` is an explicit allow-list, so its
absence is a decision, not an oversight. Nothing authors against it — its only
caller is the `v/defview` expansion and its only reader is
`re-frame.freehand.tool` — it is `^:no-doc` internal, and it is dev-gated and
elides from release builds, so a public row would name something a shipped
bundle does not contain. It takes the standing `re-frame.freehand.descriptor`
already has: absent **by construction**, not by carve-out. Promoting it would be
a D001 change, the sanctioned `re-frame.freehand.*` siblings being a closed set.

Two comment blocks claiming "ONE name, `view-manifest`" and "no registry" were
made false by this work and are corrected in the same commit.

**Cross-host is real, not assumed.** The new suite is `.cljc`, matched by the
`^re-frame\.freehand\..+-cljs-test$` ns-regexp, and its presence in
`out/node-test-freehand.js` was verified rather than inferred — the defect
rf2-hytu5 fixed for the value-taking reader was a tool door proved on one host
and shipped to the other. The expansion-shape row is JVM-only and says so:
`expand-defview` is macro machinery.

**Skipped, with reason:** mcp-conformance — nothing under `tools/` is touched by
this diff (verified against the changed-file list), and the Pair rewire is a
separate slice.

**One in-flight failure, fixed here rather than worked around:** the first spine
run reddened `_changed-surfaces.test.cjs` — the classifier's harness pins the
sole-requirer law textually, because the narrowly-armed elision gate depends on
it. That is a genuine transitive dependency of this change, so the pin was
widened to the two rows the law now has (and the classifier comment corrected)
rather than the Clojure being contorted to preserve a stale text match.

Closes nothing. rf2-lvvl2 stays open with criteria 1-5 and 7-9 outstanding; its
notes record what landed and point at the three beads above.

