### PR TITLE
freehand,spec: t/find applies its predicate to node maps only; correct the 004D host-React enumerability claim (rf2-per51, rf2-wjgle)

### DIFF
--- a/docs/api/re-frame.freehand.test.md
+++ b/docs/api/re-frame.freehand.test.md
@@ -120,6 +120,12 @@ signature change or an accidental export turns the public-API gate red on both h
 Clojure — `(tree-seq map? :children tree)` and a predicate over `(:tag %)` (element
 tag) or `(:view-id %)` (view boundary). There is deliberately no selector language.
 
+Both hand `pred` **node maps only**. Text content is a host string rather than a node,
+and a raw walk yields those strings as leaves, so a membership test like
+`#(contains? % :rf.ui/presence)` reads the same on the JVM and in ClojureScript. Read
+text with `t/text` on the owning node; walk with `tree-seq` directly if you want the
+raw leaves.
+
 ### `find`
 
 - **Kind**: function
@@ -147,7 +153,7 @@ tag) or `(:view-id %)` (view boundary). There is deliberately no selector langua
   ```
 - **Description**: every node under `tree` (the root included) for which `pred` is
   truthy, in document order; an empty vector when nothing matches. `pred` reads node
-  **fields**, the same way `find`'s does.
+  **fields**, over node **maps only**, the same way `find`'s does.
 - **Example**:
   ```clojure
   (count (t/find-all tree #(= :li (:tag %))))

--- a/docs/core/freehand/testing.md
+++ b/docs/core/freehand/testing.md
@@ -48,7 +48,10 @@ language.
 | `(tree-seq map? :children tree)` when you want the raw walk | |
 
 `nil` threads through a missed match, so `(t/attrs (t/find tree p))` nil-puns
-rather than throwing.
+rather than throwing. Your predicate is handed **node maps only** — text content is
+a host string, not a node, so a membership test like `#(contains? % :rf.ui/presence)`
+reads the same on both hosts. Reach for the raw walk when you want the leaves
+themselves.
 
 ```clojure
 (t/find tree #(= :button (:tag %)))                ; by element tag

--- a/implementation/freehand/src/re_frame/freehand/test.cljc
+++ b/implementation/freehand/src/re_frame/freehand/test.cljc
@@ -40,7 +40,10 @@
 
   `find` / `find-all` are conveniences over the whole traversal API, which
   is ordinary Clojure — `(tree-seq map? :children tree)` and a predicate
-  over `(:tag %)` (element tag) or `(:view-id %)` (view boundary).
+  over `(:tag %)` (element tag) or `(:view-id %)` (view boundary). They hand
+  the predicate NODE MAPS ONLY. Text content is a host string rather than a
+  node, and a raw walk yields those strings as leaves, so a caller who wants
+  the leaves themselves walks with `tree-seq` directly.
 
   ## Frame scope, and what runs headlessly
 
@@ -191,15 +194,24 @@
 (defn find-all
   "Every node under `tree` (the root included) for which `pred` is truthy,
   in document order. Empty vector when nothing matches. `pred` reads node
-  fields — `(:tag %)` for an element, `(:view-id %)` for a view boundary."
+  fields — `(:tag %)` for an element, `(:view-id %)` for a view boundary.
+
+  `pred`'s domain is NODE MAPS ONLY. A raw `(tree-seq map? :children tree)`
+  walk yields text content — host strings — as leaves, and those are dropped
+  before the predicate runs, so a MEMBERSHIP test reads the same on both
+  hosts: `#(contains? % :rf.ui/presence)` answers the marker node rather
+  than throwing on the JVM and answering in ClojureScript (rf2-per51). Text
+  is read with [[text]] on the owning node, or reached through its
+  `:children`; a caller who genuinely wants the raw leaves walks with
+  `tree-seq` directly."
   [tree pred]
-  (filterv pred (tree-seq map? :children tree)))
+  (filterv pred (filter map? (tree-seq map? :children tree))))
 
 (defn find
   "The FIRST node under `tree` (the root included, document order) for which
   `pred` is truthy, or nil. `nil` threads through a missed match, so
   `(t/attrs (t/find tree p))` nil-puns rather than throwing when nothing
-  matched."
+  matched. `pred`'s domain is [[find-all]]'s — node maps only, never text."
   [tree pred]
   (first (find-all tree pred)))
 

--- a/implementation/freehand/test/re_frame/freehand/presence_parity_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/presence_parity_cljs_test.cljc
@@ -81,7 +81,15 @@
             it round-trips as EDN. A consumer (SSR, a tool) reads
             `:rf.ui/presence` off the tree the same way on either host."
     (let [t        (tree/render [views/rooted {}])
+          ;; The `map?` filter is load-bearing, not decoration: a raw
+          ;; `tree-seq` yields text content as host strings too, and
+          ;; `contains?` on a String throws on the JVM. Without it this walk
+          ;; passes only by the ACCIDENT of laziness reaching the marker
+          ;; before the first string (rf2-per51) — `t/find` applies its
+          ;; predicate to node maps only, and a hand-rolled walk asserting
+          ;; the same reachability has to say so itself.
           presence (->> (tree-seq map? :children t)
+                        (filter map?)
                         (filter #(contains? % :rf.ui/presence))
                         first)]
       (is (some? presence) "the presence node is reachable by an ordinary tree walk")

--- a/implementation/freehand/test/re_frame/freehand/structural_test_surface_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/structural_test_surface_cljs_test.cljc
@@ -38,6 +38,16 @@
   [_]
   nil)
 
+(v/defview marked
+  "A marker-bearing node with a text leaf in FRONT of it — the shape a
+  membership predicate meets. `tree-seq` yields the string too, so this is
+  the tree that proves `find` never hands one to `pred` (rf2-per51)."
+  [_]
+  [:div.marked
+   "before"
+   (v/presence {:timeout-ms 250}
+     [:span {:key "x"} "inside"])])
+
 ;; ---------------------------------------------------------------------------
 ;; The surface — render / find / find-all / text / attrs
 ;; ---------------------------------------------------------------------------
@@ -68,6 +78,24 @@
           "find returns the first match")
       (is (nil? (t/find tree #(= :never (:tag %)))) "no match is nil")
       (is (= [] (t/find-all tree #(= :never (:tag %)))) "no match is the empty vector"))))
+
+(deftest the-predicate-sees-node-maps-only
+  (testing "find / find-all apply `pred` to MAP NODES ONLY — the text leaves
+            `tree-seq` yields never reach it. So a MEMBERSHIP predicate, the
+            shape a marker-node query takes, answers the same on the JVM and
+            in ClojureScript instead of throwing on one host and answering on
+            the other (rf2-per51: contains? on a String is an
+            IllegalArgumentException on the JVM and total in ClojureScript)."
+    (let [tree (t/render [marked {}])]
+      (is (= "beforeinside" (t/text tree))
+          "the tree really does carry text leaves — the case is not vacuous")
+      (is (= {:phase :present :timeout-ms 250}
+             (:rf.ui/presence (t/find tree #(contains? % :rf.ui/presence))))
+          "a membership predicate finds the marker node on either host")
+      (is (= 1 (count (t/find-all tree #(contains? % :rf.ui/presence))))
+          "and find-all answers the one marker node, never a string leaf")
+      (is (nil? (t/find tree #(contains? % :absent)))
+          "a membership predicate matching nothing is a miss, not a throw"))))
 
 (deftest attrs-projects-every-node-variant
   (testing "attrs is total over the node schema: element merges :attrs and

--- a/spec/004D-Freehand-Compiled-Grammar.md
+++ b/spec/004D-Freehand-Compiled-Grammar.md
@@ -1415,14 +1415,25 @@ way are host behaviour the caller owns: they sit outside head ordering,
 de-duplication, precedence, and every hydration guarantee this Spec and
 [011](011-SSR.md) make, `:rf/head-hash` mismatch detection included. The posture is
 trusted markup's — the framework names the boundary and does not inspect what crosses
-it — and the containment that survives is enumerability: every site declares the
-`:raw` capability and is recorded in the manifest, so the set of such escapes is
-finite and listable. The **JVM tree has no such route**: `:raw` raises
-`:rf.error/jvm-host-op` (§The JVM structural subset), so a server-rendered head still
-comes only from `reg-head` / `active-head` — which remains the path to reach for when
-the head is app state, rather than a portal no part of the substrate can see. The
-Wave-2 `ui/portal` row in §Interop would inherit the same caveat, its target being a
-caller-supplied node.
+it. The **JVM tree has no such route**: `:raw` raises `:rf.error/jvm-host-op` (§The
+JVM structural subset), so a server-rendered head still comes only from `reg-head` /
+`active-head` — which remains the path to reach for when the head is app state,
+rather than a portal no part of the substrate can see. The Wave-2 `ui/portal` row in
+§Interop would inherit the same caveat, its target being a caller-supplied node.
+
+**Enumerability is not a containment this substrate has** (rf2-wjgle). A
+capability-declaring hatch makes *its own* sites listable in the manifest, but it is
+not the only way into host React: a runtime **React element** reaching an ordinary
+child position is passed through to React untouched, gated only by
+`React.isValidElement` — React *elements*, so a portal or an array is a React node
+but not an element — and that arm sits outside the interpreted/compiled language
+gate, which is what lets it serve a compiled body's child seam as well as the
+interpreted walk. Nothing is recorded at such a site, so the escapes a manifest can
+list are a strict subset of the escapes that exist, and adding a capability-declaring
+hatch beside the unrecorded route would not change that. Making host-React escapes
+enumerable is therefore an open design question needing its own mechanism —
+recording at the element pass-through site — rather than a capability bit on one
+spelling.
 
 The reasoning is that head elements are document-global singletons with
 de-duplication, ordering, and precedence semantics that no part of the compiled

--- a/spec/008-Testing.md
+++ b/spec/008-Testing.md
@@ -697,7 +697,12 @@ state-reading view needs; none simulates behaviour.
 
 `find` / `find-all` are conveniences over the whole traversal API, which is ordinary
 Clojure — `(tree-seq map? :children tree)` and a predicate over `(:tag %)` (element
-tag) or `(:view-id %)` (view boundary). **Node reading is the ruled projection**:
+tag) or `(:view-id %)` (view boundary). **The predicate's domain is node maps only**
+(rf2-per51): text content is a host string rather than a node, and a raw `tree-seq`
+walk yields those strings as leaves, so `find` / `find-all` drop them before the
+predicate runs and a membership test — `#(contains? % :rf.ui/presence)` — answers
+identically on both hosts instead of throwing on one. A caller who wants the raw
+leaves walks with `tree-seq` directly. **Node reading is the ruled projection**:
 `(:on-click node)` is a *field* miss — event intent lives under `:events`, read
 through `attrs`, so "what does this button do" is an equality check on data
 (`(is (= [:cart/add 42] (:on-click (t/attrs node))))`) with no browser, no click


### PR DESCRIPTION
Two beads, both closed by this PR.

## rf2-wjgle (P4) — `spec/004D`: the enumerability claim for host-React escapes

`spec/004D` §The document head is host-owned argued that a host-React escape stays
contained because it stays **enumerable** — "every site declares the `:raw` capability
and is recorded in the manifest, so the set of such escapes is finite and listable."

Verified against what Freehand actually enumerates today, and the claim is untrue:

- `implementation/freehand/src/re_frame/freehand/compiler.cljc` `capabilities` records
  a capability per AST op (`:raw` / `:html` / `:foreign` / `:slot` / `:behavior` / …),
  so a *declared* hatch is indeed listable.
- But `implementation/freehand/src/re_frame/freehand/react.cljs:889-894` passes a
  runtime **React element** in an ordinary child position straight through to React,
  and that arm sits **outside** the `walk?` language gate — so it serves the compiled
  child seam as well as the interpreted walk. No capability is recorded at that site.

So the escapes a manifest can list are a strict subset of the escapes that exist, and
publishing a capability-declaring hatch would not buy the property back — the
unrecorded route stays open beside it. The passage now states that, and names the
mechanism a real fix would need (recording at the element pass-through site) as an
open design question rather than pretending the property holds.

Also fixes the imprecision the bead calls out: the gate is `React.isValidElement`,
which accepts React **elements** — a portal or an array is a React *node* but not an
element. The text says "React element pass-through" accordingly.

Per the fence, the edit is confined to the enumerability claim. The `ui/raw` framing,
the JVM-route sentence and the document structure are untouched, so `spec/004B`,
`spec/API.md` and `spec/api-manifest*.edn` are all unmodified and the queued `v/html`
slice (rf2-rrosy) still finds 004D as it expects it.

## rf2-per51 (P3) — `t/find` applies its predicate to node maps only

`find` / `find-all` were `(filterv pred (tree-seq map? :children tree))`. `tree-seq`
yields text content — host strings — as leaves, so the caller's predicate was handed
strings as well as nodes. A keyword-lookup predicate nil-puns and survives; a
**membership** predicate does not, and diverged by host.

Implemented as ruled on the bead — **option (a)**, predicate applied to node maps only.
(b) documents the trap and keeps the divergence; (c) makes both hosts refuse and buys
nothing. Both rejected on the bead, neither implemented here.

```clojure
(filterv pred (filter map? (tree-seq map? :children tree)))
```

Subtraction of a trap: no new `t/` verb, no predicate-arity dispatch, no coercion of
text into a node, no options map, and no change to `tree-seq` branching for any other
`t/` surface. The public API manifest is unchanged — no var added, renamed or removed.

**Docstrings corrected in the same change**, which the ruling requires: they said the
traversal API *is* `(tree-seq map? :children tree)` and left the reader to infer that
text therefore reaches `pred` — the thing that made option (a) look self-contradictory.
`pred`'s domain is now stated plainly as node maps, with text read via `t/text` on the
owning node or through its `:children`, and one sentence pointing a caller who
genuinely wants raw leaves at `tree-seq` directly. The same correction lands in the
normative owner (`spec/008` §the `t` surface) and in the two pages that mirror the
docstring (`docs/api/re-frame.freehand.test.md`, `docs/core/freehand/testing.md` —
prose only, no fenced block touched, so the guide sample digests are unaffected).

### The regression: failed before, passes after, on both hosts

One cross-host regression, `the-predicate-sees-node-maps-only` in
`implementation/freehand/test/re_frame/freehand/structural_test_surface_cljs_test.cljc`,
pinning the exact call from the bead report — `(t/find tree #(contains? % :rf.ui/presence))`
— over a tree whose text leaf sits **in front of** the marker node.

| Host | Before the fix | After the fix |
|---|---|---|
| JVM (`clojure -M:test`) | **RED — 3 errors**, all `java.lang.IllegalArgumentException: contains? not supported on type: java.lang.String` | **green** — 1006 tests, 6986 assertions, 0 failures, 0 errors |
| CLJS (`npm run test:freehand`) | green — `contains?` on a string is total in CLJS, and that *is* the divergence | **green** — 1073 tests, 6023 assertions, 0 failures, 0 errors |

The before-state is the bug: identical author code, two behaviours by host, in a test
helper — the one place a cross-host divergence is least tolerable, because it makes the
tests themselves lie by host.

Because the CLJS arm was green both before and after, it cannot on its own prove it
executed the path. So it was **rigged and confirmed falsifiable**: changing the
expected `:timeout-ms` from 250 to 999 produced
`FAIL in (the-predicate-sees-node-maps-only) (…structural_test_surface_cljs_test.cljc:92:11)`,
1 failure over the same 1073 tests. Reverted, and green again.

### Caller sweep

No existing caller depended on text leaves reaching `pred`, so nothing needed migrating
to `:children`. The sweep found the opposite — five callers already *defending* against
the trap with an explicit `(and (map? %) …)` guard:

- `behaviors_cljs_test.cljc:171`, `pilot_react_interop_cljs_test.cljc:84`
- `pilot_field_cljs_test.cljc:98`
- `pilot_overlay_cljs_test.cljc:607`, `pilot_overlay_parity_cljs_test.cljc:93`

Those guards are now redundant but still correct, and are deliberately left alone —
sweeping five files for zero behaviour change is diff and conflict surface, not value.

The sibling `presence-survives-as-a-marker-node` in `presence_parity_cljs_test.cljc`
**was** tightened, per the bead's note: it hand-rolls the same predicate over a raw
`tree-seq` and escaped the bug only by the accident of laziness reaching the marker
before the first string. It now filters to maps itself, with a comment saying why that
filter is load-bearing rather than decorative.

## Quality gates

| Gate | Result |
|---|---|
| Freehand artefact JVM suite — `clojure -M:test` from `implementation/freehand` | **PASS** — `Ran 1006 tests containing 6986 assertions. 0 failures, 0 errors.` (3 errors before the fix) |
| Freehand CLJS suite — `npm run test:freehand` from `implementation/` (`node-test-freehand`, ns-regexp `^re-frame\.freehand\..+-cljs-test$`) | **PASS** — `Ran 1073 tests containing 6023 assertions. 0 failures, 0 errors.` |
| CLJS regression falsifiability (rigged expected value) | **PASS** — reds as `1 failures` and names the deftest; reverted and re-run green |
| `mkdocs build --strict` from repo root | **PASS** — exit 0, `Documentation built in 90.61 seconds`, INFO only, no warnings. Run as `python -m mkdocs` (the bash `mkdocs` shim is not on PATH on this host, which is why the spine soft-skips it below) |
| `scripts/test-fast-pr.sh` — always-on static/drift tier | **PASS** — lockstep version drift, skill↔MCP allowed-tools drift, skill migration cite-integrity, implementor order-guard + foundation-order, eval-docs drift, README inventory ratchet, retired-spelling gate, thrown-error message gate, UI Root lifecycle drift, ambient-durable-read gate |
| `scripts/test-fast-pr.sh` — documentation tier | **PASS** — README link/anchor, docs corpus anchor, EP status-sync, runtime-subsystem grading. Its own `mkdocs --strict` step soft-skipped (`mkdocs not on PATH`); covered by the standalone `python -m mkdocs build --strict` row above |
| `scripts/test-fast-pr.sh` — core JVM + node/CLJS tiers | **RELYING ON CI.** Classified `docs=true jvm=true node=true` and started; still in its `core JVM` phase when this PR was opened, so it is declared rather than silently omitted. The two suites that own this diff (Freehand JVM + Freehand CLJS) both ran to completion above, and this PR touches no core or adapter source — the remaining tiers exercise surfaces the diff does not modify. Any red is fixed on this branch |

The two Freehand suites above were read from their console verdict lines. They are
**re-run at the rebased base** with the runner's own exit code captured to a
worktree-local log (`gate-logs/`, untracked) rather than inferred through a pipe, and
reported in a follow-up comment on this PR.
