### PR TITLE
bench,ci: settle B5's build lane — per-encoding causal isolation, arm build-map census, and the two-arm reading (rf2-x4jda, rf2-rhg4q)

### DIFF
--- a/.github/workflows/freehand-bench.yml
+++ b/.github/workflows/freehand-bench.yml
@@ -221,12 +221,24 @@ jobs:
           if-no-files-found: error
           retention-days: 90
 
-      # B5's matched build row. The three shapes hold the entry structure,
-      # the optimisation level and `goog.DEBUG` still and vary only lowering,
-      # so the delta between the outer two is a reading of promotion. (Not
-      # exclusively: the twins are two namespaces and each ships its own ids.
-      # The published fixture names that confound — see
-      # re-frame.freehand.bench.b5/not-matched-on.)
+      # B5's build row: TWO MATCHED ARMS and one REPRESENTATIVE mixed bundle,
+      # which is D021's B5 row read as written ("representative interpreted,
+      # compiled, and mixed production bundles", plus a per-promoted-view
+      # delta). Only the pair is matched — one source in two states, same
+      # `:advanced`, same `goog.DEBUG` — and the delta is taken over the pair
+      # alone, because a delta needs two arms held still against each other and
+      # never needed three. `:freehand-release` is the SHIPPED-COST artefact,
+      # built from its own entry with its own ids: measured here for the
+      # headline absolute, deliberately not byte-matched, and
+      # `interpreted < mixed < compiled` is NOT a lowering series (rf2-rhg4q).
+      #
+      # What the pair's delta is attributable to depends on the encoding, and
+      # the published fixture says so per encoding rather than claiming "only
+      # lowering" across the board: raw is exact (the arms' identity tokens are
+      # the same length, and the measurement test proves the raw delta
+      # invariant under renaming them), gzip is exact to within a handful of
+      # bytes, and brotli is identity-sensitive at the hundred-byte scale. See
+      # re-frame.freehand.bench.b5/causal-isolation.
       #
       # Through the npm script, not a bare `npx shadow-cljs release` over the
       # three ids: the script clears the three shapes' build caches and output
@@ -237,7 +249,7 @@ jobs:
       # stable only because of that, an unstated property of this job's cache
       # configuration; now it is stable because the entry point says so, and
       # a local re-measurement gets the same number instead of a different one.
-      - name: Build the three matched release bundles
+      - name: Build the matched pair and the mixed shipped-cost bundle
         run: npm run build:freehand-matched
 
       # `test:freehand` is the artefact here: the B5 rows publish their
@@ -272,9 +284,9 @@ jobs:
             echo "RF2_REVISION was '${RF2_REVISION}'." >&2
             exit 1
           fi
-          shapes=$(grep -c 'B5 matched shape' "$log" || true)
+          shapes=$(grep -c 'B5 release shape' "$log" || true)
           if [ "$shapes" -ne 3 ]; then
-            echo "Expected 3 matched-shape records, found ${shapes}. The B5" >&2
+            echo "Expected 3 release-shape records, found ${shapes}. The B5" >&2
             echo "matched-build test SKIPS unless all three bundles are on" >&2
             echo "disk, so a green suite with no records means the release" >&2
             echo "builds above did not produce them." >&2
@@ -286,8 +298,8 @@ jobs:
               exit 1
             fi
           done
-          echo "Published 3 matched shapes, the shipped-cost row and the"
-          echo "promotion delta at ${RF2_REVISION}."
+          echo "Published 3 release shapes, the shipped-cost row and the"
+          echo "matched-pair promotion delta at ${RF2_REVISION}."
 
       - name: Upload the B5 matched-build records
         if: always()

--- a/implementation/freehand/src/re_frame/freehand/bench/b5.cljs
+++ b/implementation/freehand/src/re_frame/freehand/bench/b5.cljs
@@ -352,9 +352,19 @@
 
   Several, not one, because the quantity being probed is SENSITIVE — one token
   samples one point of it and reads like a constant. The #6909 audit published
-  a single-token brotli figure of −16 bytes; sweeping seven tokens at
+  a single-token brotli figure of −16 bytes; a seven-token exploratory sweep at
   `ba27e74a9e` found a 227-byte spread, so that figure was one sample of
-  something an order of magnitude larger. See [[causal-isolation]]."
+  something an order of magnitude larger.
+
+  THREE ship, not the seven that were explored: the three span nearly the whole
+  observed spread, and the invariant these tokens are used to assert on every
+  run — that the RAW delta does not move — held identically for all seven.
+
+  What ships is also the CHEAP half. The standing assertion counts bytes and
+  compresses nothing; the compressed figures in [[causal-isolation]] came from
+  an exploratory sweep, and are recorded as a revision-stamped reading rather
+  than re-derived per run, because brotli over a 730 KB artefact costs about
+  1.8 seconds per arm per token and a gate that slow gets skipped."
   ["arm0" "aaaa" "same"])
 
 (defn canonicalise-arm-identity

--- a/implementation/freehand/src/re_frame/freehand/bench/b5.cljs
+++ b/implementation/freehand/src/re_frame/freehand/bench/b5.cljs
@@ -73,6 +73,7 @@
             ["zlib" :as zlib]
             ["vm" :as vm]
             ["crypto" :as crypto]
+            [clojure.string :as string]
             [re-frame.freehand.bench.measure :as m]))
 
 ;; ---------------------------------------------------------------------------
@@ -109,13 +110,17 @@
   identical character for character once the three `{:compiled true}` markers
   are dropped and the equal-length `lowered-none`/`lowered-full` segment is
   renamed, which `b5-matched-builds-cljs-test` asserts on every run — under
-  the same `:advanced` and the same `goog.DEBUG` false. A byte that differs
-  between them differs because of lowering.
+  the same `:advanced` and the same `goog.DEBUG` false. A RAW byte that
+  differs between them differs because of lowering; the compressed encodings
+  carry a small residue of the arm identity itself, and [[causal-isolation]]
+  states which claim holds for which encoding.
 
   `:mixed` is the SHIPPED-COST artefact (`:freehand-release`, one interpreted
-  leaf and its compiled twin under one root). It is built from its own entry
-  with its own registered ids and its own prose, so it is measured here for
-  context and is NOT byte-matched to the pair: no delta is taken against it."
+  leaf and its compiled twin under one root) — D021's `mixed production
+  bundle`, and a REPRESENTATIVE one rather than a third matched arm. It is
+  built from its own entry with its own registered ids and its own prose, so
+  it is measured here for context and is NOT byte-matched to the pair: no
+  delta is taken against it, because the delta only ever needed two arms."
   {:interpreted interpreted-bundle-path
    :mixed       default-bundle-path
    :compiled    compiled-bundle-path})
@@ -241,6 +246,11 @@
   not a per-view one. [[promotion-delta-workload]] publishes both, and names
   the per-view figure for the mean it is.
 
+  And it is attributable to lowering EXACTLY in raw bytes and only
+  APPROXIMATELY under the compressed encodings — [[causal-isolation]] carries
+  the measured difference, and rides the fixture so the distinction travels
+  with the numbers instead of living in this docstring.
+
   Lowering is the only variable across the pair. The two entries are one
   source in two states: identical character for character once the three
   `{:compiled true}` markers are dropped and the `lowered-none`/`lowered-full`
@@ -262,7 +272,11 @@
   `d5794fded8` (1.4%). That denominator is a past reading at a named
   revision, not this record's own figure — the record carries its own, and a
   caveat quoting a stale one beside a live measurement reads as an
-  inconsistency in the evidence (`rf2-hce4p`). The pair now measures 0.
+  inconsistency in the evidence (`rf2-hce4p`). The pair now measures 0 in RAW
+  bytes, and `b5-matched-builds-cljs-test` proves that on the artefacts
+  themselves every run rather than inferring it from the sources: rename the
+  arm token to any other token of the same length and the raw delta comes back
+  bit-identical ([[canonicalise-arm-identity]]).
 
   ## The bytes are only comparable under one build posture
 
@@ -321,18 +335,105 @@
        "under any other posture is a different measurement and not comparable "
        "with this one"))
 
+(def arm-identity-pattern
+  "The two arms' distinguishing IDENTITY TOKEN as it reaches the artefacts —
+  `lowered-none` / `lowered-full` in the hyphen spelling every id derived from
+  the namespace carries, and `lowered_none` / `lowered_full` in the underscore
+  spelling the compiled tier's source coordinates carry.
+
+  All four are twelve characters, which is the fixture property the raw delta's
+  causal isolation rests on. See [[canonicalise-arm-identity]]."
+  #"lowered([-_])(?:none|full)")
+
+(def arm-identity-probe-tokens
+  "Four-character replacement tokens the identity probe substitutes for the
+  arms' own `none` / `full`, deliberately unalike: a neutral label, a
+  single-character run, and a real word both arms could plausibly have shared.
+
+  Several, not one, because the quantity being probed is SENSITIVE — one token
+  samples one point of it and reads like a constant. The #6909 audit published
+  a single-token brotli figure of −16 bytes; sweeping seven tokens at
+  `babc7fb540` found a 227-byte spread, so that figure was one sample of
+  something an order of magnitude larger. See [[causal-isolation]]."
+  ["arm0" "aaaa" "same"])
+
+(defn canonicalise-arm-identity
+  "`source` with the arms' identity token replaced by `token`, in both
+  spellings, so a reading taken over the result cannot be told which arm it
+  came from.
+
+  This is the control for the delta's one remaining fixture asymmetry: the two
+  arms are two NAMESPACES, so every id, manifest entry and source coordinate
+  derived from the namespace differs in CONTENT between them. `token` must be
+  four characters — the length of the `none` / `full` it stands in for — which
+  is what makes the substitution byte-neutral per arm however many times it
+  occurs, and therefore what makes the RAW delta invariant under it.
+
+  Occurrence counts are NOT equal between the arms and are not meant to be: at
+  `babc7fb540` the interpreted arm shipped 23 and the compiled arm 29, and the
+  six extra are compiled-tier source coordinates that exist BECAUSE the views
+  were lowered. Those bytes are lowering's own and belong in the delta. What
+  this controls for is the token's CONTENT, not its census."
+  [source token]
+  (string/replace source arm-identity-pattern (str "lowered$1" token)))
+
+(def causal-isolation
+  "WHICH of the delta's encodings is attributable to lowering, and how
+  exactly — the audit finding this fixture exists to carry (`rf2-x4jda`,
+  merged-PR audit #6909).
+
+  The pair holds lowering as the only variable in the SOURCES, but a compressed
+  size is not a sum of its input's parts: the same bytes in a different
+  arrangement compress differently, so the arms' differing identity CONTENT
+  reaches the compressed deltas even though its LENGTH is controlled. Measured
+  by substituting equal-length probe tokens into both artefacts
+  ([[canonicalise-arm-identity]]) and re-taking the delta:
+
+    - RAW — the contribution is EXACTLY zero, for every probe token, by
+      construction. Asserted on the real artefacts on every built-bundle run,
+      so this is the one figure the pair may present as lowering and nothing
+      else.
+    - GZIP (6 and 9) — the delta moved by at most 9 bytes across seven probe
+      tokens at `babc7fb540`, against deltas of 4,794 and 4,738: ≤0.2%.
+      Attributable to lowering to within a handful of bytes.
+    - BROTLI — the delta moved across a 227-byte spread (−198 to +29) at the
+      same revision, against a 3,781-byte delta: up to ≈5%. The brotli figure
+      is a real fact about the two artefacts, but it may NOT be read as a
+      lowering-only number.
+
+  Those percentages are a reading at a NAMED revision, and the revision is
+  named because that is the only thing that keeps an absolute honest as the
+  bundles move. The stable claim is the ordering — raw exact, gzip within a
+  handful, brotli sensitive at the hundred-byte scale — and it is the ordering
+  a reader should carry away."
+  (str "attribution to lowering holds EXACTLY for the raw delta and only "
+       "approximately for the compressed ones. The two arms are two "
+       "namespaces, so their ids, manifests and source coordinates differ in "
+       "identity CONTENT; the tokens are the same LENGTH, which makes the raw "
+       "delta provably invariant under renaming them (asserted every built "
+       "run) but does not make a compressed delta invariant, because "
+       "compression is not a sum of its input's parts. Substituting "
+       "equal-length probe tokens at babc7fb540 moved the gzip-6/gzip-9 "
+       "deltas by at most 9 bytes of 4,794/4,738 (≤0.2%) and the brotli delta "
+       "across a 227-byte spread of 3,781 (up to ~5%). Read raw as lowering, "
+       "gzip as lowering within a handful of bytes, and brotli as "
+       "identity-sensitive"))
+
 (def not-matched-on
   "What the two arms do NOT hold still, stated so a reader can discount it.
 
   Published in the delta's fixture because a caveat that lives only in a
-  reviewer's memory is not part of the evidence. See [[promotion-delta]]."
+  reviewer's memory is not part of the evidence. See [[promotion-delta]] and
+  [[causal-isolation]], which carries the measured size of the residue."
   (str "they remain two NAMESPACES, so the identity strings each ships — the "
        "registered event/sub/frame ids, the view manifest, the compiled tier's "
        "source coordinates — differ in CONTENT: lowered-none against "
-       "lowered-full. The two segments are the same length, so the raw delta "
-       "carries none of that; differing content can still move a few bytes "
-       "under gzip and brotli. The per-view figures are a MEAN over the "
-       "promoted view count, not a per-declaration observation"))
+       "lowered-full. The two segments are the same length, so the RAW delta "
+       "carries none of that (proved on the artefacts every built run, not "
+       "inferred); differing content still moves the compressed deltas, and "
+       ":causal-isolation states by how much per encoding. The per-view "
+       "figures are a MEAN over the promoted view count, not a "
+       "per-declaration observation"))
 
 (defn promotion-delta-workload
   "The per-promotion byte delta as a WORKLOAD, so it reaches the SAME door
@@ -371,9 +472,10 @@
                     "; the per-view figures are that total divided by the "
                     promoted-views " view declarations the two entries promote "
                     "together — a MEAN, not a per-declaration observation")
-               :matched-on     matched-on
-               :not-matched-on not-matched-on
-               :build-posture  matched-build-posture}
+               :matched-on       matched-on
+               :not-matched-on   not-matched-on
+               :causal-isolation causal-isolation
+               :build-posture    matched-build-posture}
      :baseline {:kind      :interpreted-vs-compiled
                 :reference {:arm  :interpreted
                             :note (str "the interpreted-only twin " (:path interpreted)

--- a/implementation/freehand/src/re_frame/freehand/bench/b5.cljs
+++ b/implementation/freehand/src/re_frame/freehand/bench/b5.cljs
@@ -521,7 +521,7 @@
   "How the readings over `path` were taken, published verbatim in the fixture
   so a reader knows exactly what each number is a number of.
 
-  A function of the artefact, not a constant. The three matched shapes route
+  A function of the artefact, not a constant. All three release shapes route
   through this same probe, and a method line that named
   `out/freehand-release/main.js` while its own fixture's `:artefact` named a
   different file described a measurement that did not happen — the exact

--- a/implementation/freehand/src/re_frame/freehand/bench/b5.cljs
+++ b/implementation/freehand/src/re_frame/freehand/bench/b5.cljs
@@ -353,7 +353,7 @@
   Several, not one, because the quantity being probed is SENSITIVE — one token
   samples one point of it and reads like a constant. The #6909 audit published
   a single-token brotli figure of −16 bytes; sweeping seven tokens at
-  `babc7fb540` found a 227-byte spread, so that figure was one sample of
+  `ba27e74a9e` found a 227-byte spread, so that figure was one sample of
   something an order of magnitude larger. See [[causal-isolation]]."
   ["arm0" "aaaa" "same"])
 
@@ -370,7 +370,7 @@
   occurs, and therefore what makes the RAW delta invariant under it.
 
   Occurrence counts are NOT equal between the arms and are not meant to be: at
-  `babc7fb540` the interpreted arm shipped 23 and the compiled arm 29, and the
+  `ba27e74a9e` the interpreted arm shipped 23 and the compiled arm 29, and the
   six extra are compiled-tier source coordinates that exist BECAUSE the views
   were lowered. Those bytes are lowering's own and belong in the delta. What
   this controls for is the token's CONTENT, not its census."
@@ -394,7 +394,7 @@
       so this is the one figure the pair may present as lowering and nothing
       else.
     - GZIP (6 and 9) — the delta moved by at most 9 bytes across seven probe
-      tokens at `babc7fb540`, against deltas of 4,794 and 4,738: ≤0.2%.
+      tokens at `ba27e74a9e`, against deltas of 4,794 and 4,738: ≤0.2%.
       Attributable to lowering to within a handful of bytes.
     - BROTLI — the delta moved across a 227-byte spread (−198 to +29) at the
       same revision, against a 3,781-byte delta: up to ≈5%. The brotli figure
@@ -413,7 +413,7 @@
        "delta provably invariant under renaming them (asserted every built "
        "run) but does not make a compressed delta invariant, because "
        "compression is not a sum of its input's parts. Substituting "
-       "equal-length probe tokens at babc7fb540 moved the gzip-6/gzip-9 "
+       "equal-length probe tokens at ba27e74a9e moved the gzip-6/gzip-9 "
        "deltas by at most 9 bytes of 4,794/4,738 (≤0.2%) and the brotli delta "
        "across a 227-byte spread of 3,781 (up to ~5%). Read raw as lowering, "
        "gzip as lowering within a handful of bytes, and brotli as "

--- a/implementation/freehand/test/re_frame/freehand/bench/b5_matched_builds_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b5_matched_builds_cljs_test.cljs
@@ -322,8 +322,12 @@
               "raw is the one figure presented as lowering and nothing else")
           (is (re-find #"identity-sensitive" ci)
               "and brotli is named for what it is")
-          (is (re-find #"babc7fb540" ci)
-              "with the revision the percentages were read at — an unstamped absolute goes stale silently")))
+          (is (re-find #"at [0-9a-f]{10}" ci)
+              (str "with the revision the percentages were read at — an unstamped "
+                   "absolute goes stale silently. The SHAPE is asserted, not a "
+                   "particular sha: pinning one would mean a test edit every time "
+                   "the sweep is re-taken, and a check that has to be edited to "
+                   "re-measure is a check that discourages re-measuring"))))
       (testing "and it names the BUILD POSTURE the two artefacts were produced
                 under. :advanced is held still as a setting by the two build
                 definitions; the posture is what holds it still as an outcome,
@@ -369,7 +373,7 @@
   `:raw-bytes` is in.
 
   Not `count`, which answers UTF-16 code units. The bundles carry non-ASCII
-  characters in their string literals, so the two differ: at `babc7fb540` the
+  characters in their string literals, so the two differ: at `ba27e74a9e` the
   raw delta is 17,373 bytes and 17,363 code units. Comparing an invariance in
   one unit against a delta in the other fails by exactly that gap, which reads
   like a broken invariant rather than a mismatched ruler."
@@ -555,7 +559,12 @@
                   (str (name k) " shape reds nothing — it is all evidence"))
               (is (= :advanced (get-in record [:build :optimizations]))
                   (str (name k) " shape is an advanced artefact"))
-              (publish! (str "B5 matched shape — " (name k)) record)))
+              ;; "release shape", not "matched shape": all three are release
+              ;; artefacts and each is published, but only :interpreted and
+              ;; :compiled are MATCHED to each other. The label is what a reader
+              ;; of the transcript sees, so it may not claim the mixed shape
+              ;; into the pair (rf2-rhg4q).
+              (publish! (str "B5 release shape — " (name k)) record)))
           ;; The three digests are distinct: three different bundles.
           (is (= 3 (count (set (map (comp :sha256 :measured val) results))))
               "the three shapes are three distinct artefacts")

--- a/implementation/freehand/test/re_frame/freehand/bench/b5_matched_builds_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b5_matched_builds_cljs_test.cljs
@@ -535,7 +535,7 @@
             files that are not there."
     (let [present (into {} (filter (comp b5/bundle-present? val)) b5/matched-bundle-paths)]
       (if-not (= 3 (count present))
-        (is true (str "not all three matched bundles are on disk — build "
+        (is true (str "not all three release bundles are on disk — build "
                       "freehand-release-interpreted, freehand-release and "
                       "freehand-release-compiled first; skipping the matched "
                       "build-lane measurement (present: " (keys present) ")"))

--- a/implementation/freehand/test/re_frame/freehand/bench/b5_matched_builds_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b5_matched_builds_cljs_test.cljs
@@ -20,23 +20,50 @@
   between two hand-copied entries, and prose in a docstring cannot catch it
   coming back.
 
-  Three things keep it honest, and the first two need no bundle on disk:
+  Five things keep it honest, and only the last needs a bundle on disk:
 
     - the matched-entry CENSUS proves the two arms differ only in lowering,
       and that neither carries a namespace docstring — `:advanced` does not
       strip one and the view manifest ships it once per declared view, which
       is how +339 bytes of prose used to ride the delta;
+    - the BUILD-MAP census proves the other half of the same premise. The two
+      arms' shadow build maps are hand-copied neighbours, and moving one arm's
+      `:target`, `:optimizations`, `:infer-externs` or `goog.DEBUG` would leave
+      the source census green while turning the delta into a reading of a
+      compiler flag. One structural equality over the two maps, excluding only
+      `:output-dir` and the module `:init-fn`, closes that (#6909 audit);
     - [[re-frame.freehand.bench.b5/promotion-delta]] is exercised over
       synthetic measured artefacts, so the delta arithmetic has coverage on
       every `npm run test:freehand` run, built bundles or not;
     - the three artefacts route through the SAME probe the mixed lane uses —
       [[re-frame.freehand.bench.b5/measure-bundle]] and
       [[re-frame.freehand.bench.b5/workload]] — so no new bench framework is
-      introduced; the three shapes are just three inputs to it.
+      introduced; the three shapes are just three inputs to it;
+    - the IDENTITY CONTROL proves the raw delta owes nothing to the fixture's
+      own naming: rename the arms' identity token to any other of the same
+      length in both artefacts and the raw delta comes back bit-identical
+      ([[re-frame.freehand.bench.b5/canonicalise-arm-identity]]). Asserted for
+      RAW only, because for the compressed encodings it is measurably false —
+      `b5/causal-isolation` carries how false, per encoding.
+
+  ## Two matched arms, and one representative mixed bundle
 
   The `:mixed` shape is the SHIPPED-COST artefact, built from its own entry
   with its own ids and prose. It is measured here for context; no delta is
-  taken against it.
+  taken against it, and it is deliberately NOT byte-matched to the pair.
+
+  D021's B5 row asks for `representative interpreted, compiled, and mixed
+  production bundles` and a `per-promoted-view delta`. A delta needs two arms
+  held still against each other; it never needed three. So the pair carries the
+  delta and the mixed shape carries the headline shipped cost — which is the
+  thing a consumer actually pays, and it is a real small app rather than a
+  fixture built to be subtractable. Folding the mixed entry into the matched
+  shape would buy a middle reading nothing asks for at the cost of rewriting
+  the four surfaces that name `re-frame.freehand.release-app` by sentinel
+  (`check-freehand-reachability.cjs`, `check-freehand-evidence-elision.cjs`,
+  `b5-reachability-control-app`, `_changed-surfaces.test.cjs`). Recorded on
+  `rf2-rhg4q`; `interpreted < mixed < compiled` is NOT a lowering series and
+  nothing here reads it as one.
 
   The real bundles are measured only when all three have been built. A delta
   taken against a shape that was never built is a number about nothing, so
@@ -85,6 +112,7 @@
   `D021-performance-budgets-and-release-evidence.md`."
   (:require ["fs" :as fs]
             [clojure.string :as string]
+            [clojure.edn :as edn]
             [cljs.test :refer-macros [deftest is testing]]
             [re-frame.freehand.bench :as bench]
             [re-frame.freehand.bench.b5 :as b5]
@@ -279,8 +307,23 @@
         (is (= "compiled" (get-in record [:fixture :compiled-artefact])))
         (is (re-find #"character for character" (get-in record [:fixture :matched-on]))
             "the matched claim travels with the record, in the terms the census checks")
-        (is (re-find #"gzip and brotli" (get-in record [:fixture :not-matched-on]))
-            "and so does what is left over — a caveat in a reviewer's memory is not evidence"))
+        (let [left-over (get-in record [:fixture :not-matched-on])]
+          (is (re-find #"differ in CONTENT" left-over)
+              "and so does what is left over — a caveat in a reviewer's memory is not evidence")
+          (is (re-find #"causal-isolation states by how much" left-over)
+              "and it hands the reader on to the per-encoding measurement rather than waving at it")))
+      (testing "and it says WHICH encodings the lowering attribution holds for.
+                The #6909 audit's finding was that the source claim said `only
+                lowering` while the compressed deltas measurably carried the
+                arms' identity content; the repair is not a softer adjective but
+                a per-encoding statement that rides every record."
+        (let [ci (get-in record [:fixture :causal-isolation])]
+          (is (re-find #"EXACTLY for the raw delta" ci)
+              "raw is the one figure presented as lowering and nothing else")
+          (is (re-find #"identity-sensitive" ci)
+              "and brotli is named for what it is")
+          (is (re-find #"babc7fb540" ci)
+              "with the revision the percentages were read at — an unstamped absolute goes stale silently")))
       (testing "and it names the BUILD POSTURE the two artefacts were produced
                 under. :advanced is held still as a setting by the two build
                 definitions; the posture is what holds it still as an outcome,
@@ -316,6 +359,112 @@
       (is (= 3 (count (set (vals paths)))) "the three artefacts are distinct files")
       (is (= b5/default-bundle-path (:mixed paths))
           "the mixed shape is the existing :freehand-release bundle"))))
+
+;; ---------------------------------------------------------------------------
+;; The identity control — no bundle required for the substitution's own law
+;; ---------------------------------------------------------------------------
+
+(defn- utf8-bytes
+  "How many BYTES `s` occupies as UTF-8 — the unit `b5/measure-bundle`'s
+  `:raw-bytes` is in.
+
+  Not `count`, which answers UTF-16 code units. The bundles carry non-ASCII
+  characters in their string literals, so the two differ: at `babc7fb540` the
+  raw delta is 17,373 bytes and 17,363 code units. Comparing an invariance in
+  one unit against a delta in the other fails by exactly that gap, which reads
+  like a broken invariant rather than a mismatched ruler."
+  [s]
+  (.byteLength js/Buffer s "utf8"))
+
+(deftest canonicalising-the-arm-identity-is-byte-neutral-per-arm
+  (testing "The substitution the raw delta's causal isolation rests on. Each
+            arm's identity token is twelve characters in both spellings, and
+            the probe tokens are four, so replacing one with another cannot
+            change a single arm's byte count however many times it occurs — and
+            therefore cannot change the DELTA between two arms either. Asserted
+            here on strings so the law is covered on every run, and asserted on
+            the real artefacts below when they exist."
+    (doseq [token b5/arm-identity-probe-tokens]
+      (is (= 4 (count token)) "every probe token is the length of the none/full it replaces")
+      (doseq [original ["lowered-none" "lowered_none" "lowered-full" "lowered_full"]]
+        (let [s (str "a:" original "/bump b:" original ".cljs c:" original)
+              c (b5/canonicalise-arm-identity s token)]
+          (is (= (utf8-bytes s) (utf8-bytes c))
+              (str "substituting " token " into " original " preserves byte length"))
+          (is (not (string/includes? c original))
+              "and leaves no occurrence of the arm's own token behind")
+          (is (= 3 (dec (count (.split c (str "lowered" (subs original 7 8) token)))))
+              "every occurrence is substituted, not just the first"))))
+    (testing "and the two arms canonicalise to the SAME string — which is the
+              whole point: a reading taken over the result cannot tell which
+              arm produced it"
+      (let [i (b5/canonicalise-arm-identity "id:lowered-none/bump src:lowered_none.cljs" "arm0")
+            c (b5/canonicalise-arm-identity "id:lowered-full/bump src:lowered_full.cljs" "arm0")]
+        (is (= i c))))))
+
+;; ---------------------------------------------------------------------------
+;; The BUILD MAPS — the other half of the matched premise, censused
+;; ---------------------------------------------------------------------------
+
+(defn- shadow-config
+  "`implementation/shadow-cljs.edn` as data, read from the directory the Node
+  lane runs in.
+
+  The file carries build-time reader tags (`#shadow/env`), which are shadow's
+  to resolve and none of this census's business — `:default` folds each to its
+  literal argument so the read succeeds without this test knowing what any tag
+  means. Through the `opts` arity deliberately, NOT
+  `cljs.reader/register-default-tag-parser!`: that mutates a global the whole
+  suite shares, and a sibling bench test asserts that an unregistered tag still
+  THROWS for a plain reader. Registering one here made that test pass
+  vacuously."
+  []
+  (edn/read-string {:default (fn [_tag value] value)}
+                   (.readFileSync fs "shadow-cljs.edn" "utf8")))
+
+(def ^:private arm-build-ids
+  {:interpreted :freehand-release-interpreted
+   :compiled    :freehand-release-compiled})
+
+(deftest the-two-arm-build-maps-differ-only-in-output-dir-and-entry
+  (testing "The census above proves the two ENTRY SOURCES differ only in
+            lowering. This proves the other half of the same premise, which
+            that census cannot see: that the two BUILD MAPS agree. They are
+            hand-copied neighbours in shadow-cljs.edn, and the #6909 audit
+            noted that moving one arm's :target, :optimizations,
+            :infer-externs or goog.DEBUG would leave every other check in this
+            file green while destroying acceptance #1 — the delta would then
+            be a reading of a compiler flag wearing lowering's name.
+
+            One structural equality, excluding exactly the two slots that MUST
+            differ: :output-dir (each arm needs its own) and the module's
+            :init-fn (which names the arm's entry, the variable itself)."
+    (let [builds (:builds (shadow-config))
+          arm    #(get builds (get arm-build-ids %))
+          [i c]  [(arm :interpreted) (arm :compiled)]]
+      (is (map? i) "the interpreted arm's build is declared")
+      (is (map? c) "the compiled arm's build is declared")
+      (is (= (dissoc i :output-dir :modules) (dissoc c :output-dir :modules))
+          (str "the two arm builds agree on everything but :output-dir and the "
+               "entry; they differ in " (pr-str (->> (dissoc i :output-dir :modules)
+                                                     (remove (fn [[k v]] (= v (get c k))))
+                                                     (map first)))))
+      (is (= [:main] (keys (:modules i))) "one module each")
+      (is (= (keys (:modules i)) (keys (:modules c))))
+      (is (= (dissoc (get-in i [:modules :main]) :init-fn)
+             (dissoc (get-in c [:modules :main]) :init-fn))
+          "and the module maps agree on everything but the entry fn")
+      (testing "and the equality is not vacuous — the settings the delta's
+                comparability actually rests on are present and are the ones a
+                release build is meant to have"
+        (is (= :browser (:target i)))
+        (is (= :advanced (get-in i [:compiler-options :optimizations])))
+        (is (false? (get-in i [:compiler-options :closure-defines 'goog.DEBUG]))
+            "goog.DEBUG is pinned false rather than left to release's default")
+        (is (not= (:output-dir i) (:output-dir c)) "each arm has its own output dir")
+        (is (not= (get-in i [:modules :main :init-fn])
+                  (get-in c [:modules :main :init-fn]))
+            "and its own entry — the one variable")))))
 
 ;; ---------------------------------------------------------------------------
 ;; The real matched artefacts, when all three have been built
@@ -420,6 +569,29 @@
                   (str "the " (name arm) " bundle names nothing of the " (name other) " arm"))
               (is (zero? (occurrences source (arm-entry-file other)))
                   (str "nor cites its source file in a coordinate"))))
+          ;; And the RAW delta's causal isolation, proved on the artefacts
+          ;; rather than inferred from the sources. The two arms are two
+          ;; namespaces, so their ids, manifests and source coordinates differ
+          ;; in identity CONTENT. Rename that token to any other of the same
+          ;; length in BOTH bundles and the raw delta must come back
+          ;; bit-identical — which is what earns the raw figure the right to be
+          ;; presented as lowering and nothing else. It is not asserted for the
+          ;; compressed encodings, because it is measurably false there:
+          ;; b5/causal-isolation carries the measured size per encoding.
+          (doseq [token b5/arm-identity-probe-tokens]
+            (let [ci (b5/canonicalise-arm-identity (:source interp) token)
+                  cc (b5/canonicalise-arm-identity (:source compiled) token)]
+              (is (= (:raw-bytes delta) (- (utf8-bytes cc) (utf8-bytes ci)))
+                  (str "the raw delta is invariant under renaming the arm identity to "
+                       token " — so no part of it is the fixture's own naming"))))
+          ;; Non-vacuous: the token really is in both artefacts. The counts are
+          ;; deliberately NOT compared — the compiled arm ships more, and the
+          ;; extra are its own source coordinates, which exist because the
+          ;; views were lowered and so belong in the delta.
+          (doseq [[arm src] {:interpreted (:source interp) :compiled (:source compiled)}]
+            (is (pos? (count (re-seq b5/arm-identity-pattern src)))
+                (str "the " (name arm) " bundle really does carry its arm identity — "
+                     "an invariance over zero occurrences would prove nothing")))
           ;; The delta is a fact about the two artefacts; it gates nothing.
           (is (number? (:raw-bytes delta)) "the per-promotion raw delta is a number")
           (is (= (:raw-bytes delta) (- (:raw-bytes compiled) (:raw-bytes interp)))


### PR DESCRIPTION
B5's build lane. `rf2-na9p0` shipped separately in #6940; this PR is those two beads alone.

Every byte figure below was taken **from a cleared cache** on this branch's own tree, via `npm run build:freehand-matched`. The stable claim is the **delta**; the absolutes are revision-stamped provenance, because a bare absolute goes stale silently.

## rf2-x4jda — the promotion delta is exact in one encoding, not all four

The source claim said lowering was the only variable across the matched pair and let every encoding inherit that. It is exactly true of the **raw** delta and measurably false of the compressed ones: the two arms are two namespaces, so every id, manifest entry and source coordinate differs in identity **content**, and a compressed size is not a sum of its input's parts. Equal token *lengths* control raw and nothing else.

Measured by substituting equal-length probe tokens into both artefacts and re-taking the delta:

| Encoding | Delta | Identity contribution | Verdict |
|---|---|---|---|
| raw | 17,373 | **exactly 0**, every token, by construction | lowering and nothing else |
| gzip-6 | 4,794 | ≤ 9 B (≤0.2%) | lowering to within a handful of bytes |
| gzip-9 | 4,738 | ≤ 9 B (≤0.2%) | lowering to within a handful of bytes |
| brotli | 3,781 | 227 B spread, −198 to +29 (up to ~5%) | **identity-sensitive** — not a lowering-only figure |

The #6909 audit recorded the brotli contribution as −16 B from a single probe token. **It does not reproduce**: sweeping seven equal-length tokens found a 227-byte spread, so −16 was one sample of something an order of magnitude larger. That is why the probe sweeps several tokens rather than one.

`b5/causal-isolation` states the per-encoding claim and rides the delta's fixture, so it travels with every published record. The raw invariance is now **proved on the artefacts** on every built-bundle run rather than inferred from the sources.

**Build-map census.** The source census could not see the other half of its own premise: the two arms' shadow build maps are hand-copied neighbours, so moving one arm's `:target`, `:optimizations`, `:infer-externs` or `goog.DEBUG` would leave every existing check green while turning the delta into a reading of a compiler flag. One structural equality over the two maps, excluding exactly `:output-dir` and the module `:init-fn`, plus a non-vacuity check that the settings the comparison rests on are present. `implementation/shadow-cljs.edn` is **read, not modified** — the hot-zone file is untouched by this PR.

Two traps worth naming, both hit while writing this:

- the census must **not** reach `#shadow/env` via `cljs.reader/register-default-tag-parser!` — that mutates a suite-wide global, and a sibling bench test asserts an unregistered tag still *throws* for a plain reader. Registering one made that test pass vacuously. It uses `clojure.edn/read-string`'s call-scoped `:default` instead.
- `count` on a bundle source answers UTF-16 code units, not bytes. The bundles carry non-ASCII literals, so the raw delta is 17,373 bytes and 17,363 code units — comparing an invariance in one unit against a delta in the other fails by exactly that gap and reads like a broken invariant.

### R5 — declined a third time, and this is the reason

The initial-mount figure is still a `goog.DEBUG` browser-test recompilation of the mixed shape, not `out/freehand-release/main.js` loaded. Measuring the real artefact needs it served, plus an in-page `MutationObserver` started before the script tag and a driver to read it back — a new measurement harness, which this dispatch's fence and D021's non-goals both bar. The record already carries `:subject :recompiled-shape-not-the-release-artefact` and the reason in its own measurement-method prose, so no reader of the record can mistake it for the production bundle's load cost. **Recommend closing R5 as declined-with-reason** rather than carrying it as a rolling residual; flagging rather than deciding, since it is the third declination.

## rf2-rhg4q — decision taken: two matched arms, one representative mixed bundle

The bead asked the mayor to either amend acceptance #1 or fold `release-app` in as a third matched arm. **I took the first**, and the grounds are in the normative owner rather than in convenience:

> D021's B5 row asks for *"representative interpreted, compiled, and mixed production bundles"* and a *"per-promoted-view delta"*.

**Representative**, not matched. A delta needs two arms held still against each other; it never needed three. Acceptance #1's *"three matched … same entry app"* was a bead-local restatement stricter than the document it cites. So the pair carries the delta and the mixed shape carries the headline shipped cost — which is what a consumer actually pays, and it is a real small app rather than a fixture built to be subtractable.

The fold-in path is also **blocked by this dispatch's fence**: it requires rewriting the four surfaces that name `re-frame.freehand.release-app` by sentinel, two of which (`check-freehand-reachability.cjs`, `_changed-surfaces.test.cjs`) I am fenced out of. Reversible if the mayor prefers the third arm — nothing here forecloses it.

Reconciled the stale authority the bead named: `.github/workflows/freehand-bench.yml` called all three bundles matched and said all three vary only in lowering. The step is renamed and the comment now states the two-arm reading. `interpreted < mixed < compiled` is **not** a lowering series and nothing reads it as one.

## Quality gates

All figures below taken **from a cleared cache** on the rebased tree (`ba27e74a9e`, on top of `d0d9728536`).

| Gate | Result |
|---|---|
| `npm run build:freehand-matched` (from clean) | **pass** — 3 builds, 0 warnings, exit 0 |
| `npm run test:freehand`, real `RF2_REVISION` | **pass** — 1074 tests / 6105 assertions / 0 failures / 0 errors; 3 citable release-shape records + a citable promotion delta |
| `npm run test:freehand`, **no** revision | **pass** — 1074 / 6095 / 0 failures; nothing citable published, `unattributed-local-build` 0 occurrences |
| workflow evidence floor, simulated against the real transcript | **pass** — no `NOT CITABLE`, 3 release-shape records, both named labels citable (proves the relabelled grep still has teeth) |
| `freehand-bench.yml` YAML parse | **pass** |
| `mkdocs build --strict` | **pass** — exit 0 |
| `api-md-check` | **pass** — 245 var-rows in sync |
| `scripts/test-fast-pr.sh` | **running in the foreground to completion**; result appended below. It exceeds a single 10-minute tool window, so it is running detached — not skipped. |

Both cache postures were exercised for the measurement itself (cleared-cache build via the npm script is the pinned posture; the identity sweep was re-taken after the rebase and reproduced byte-identical, so the delta is stable and the absolutes are stamped). The **build invocation is unchanged** by this PR — `build:freehand-matched` is untouched — so there is no new posture to cross-check.

### Hot-zone note

`implementation/shadow-cljs.edn` is **read** by the new build-map census and **not modified**. `.github/workflows/freehand-bench.yml` **is** touched (comment, one step name, and the evidence-floor grep label in lockstep with the test's publish label) — flagged per the dispatch rules.

Untouched, per fence: `verify-version-lockstep.sh`, the 17-artefact inventory, the four-entry `TOOLS` array, `check-freehand-reachability.cjs`, `spec/012-Routing.md`, `spec/004D`, `implementation/routing/**`, the Freehand compiler tree, and the conformance fixtures.
