### PR TITLE
test,ci,docs: run the prefetch test on both lanes; gate :query-retain; document the SSR 403 floor and the replaceable-default category (rf2-dn6v7, rf2-jlmgt, rf2-b5cz0, rf2-l4qro)

### DIFF
--- a/docs/core/images.md
+++ b/docs/core/images.md
@@ -36,7 +36,7 @@ When you then create a frame *without* naming an image, that frame resolves ever
 
 !!! note "Heads-up — the default image is a real sealed generation"
 
-    "The whole registrar sealed into one set" is not just the concept — mechanically it is exactly what you get. `make-frame` with no `:images` key resolves a sealed **default generation** over the whole active store (framework standards included): the implicit selector over everything. It runs the same assembly gate as an explicit selection, so even the default path fails loud on a cross-namespace `[kind id]` collision (`:rf.error/image-duplicate-id`) rather than letting load order silently pick a survivor. Every frame therefore carries a generation and resolves through it.
+    "The whole registrar sealed into one set" is not just the concept — mechanically it is exactly what you get. `make-frame` with no `:images` key resolves a sealed **default generation** over the whole active store (framework standards included): the implicit selector over everything. It runs the same assembly gate as an explicit selection, so even the default path fails loud on a cross-namespace `[kind id]` collision (`:rf.error/image-duplicate-id`) rather than letting load order silently pick a survivor. One kind of framework registration is carved out — a [replaceable framework default](#framework-standards-and-the-defaults-youre-meant-to-replace) such as `:rf.route/entry-denied`, whose own copy stops being projected once your app registers the same id, because it was never an app registration. Every frame therefore carries a generation and resolves through it.
 
 The common case stays boring, on purpose. You never name an image. New registrations show up the moment you write them. Hot reload keeps working. You meet the image concept *explicitly* only when "everything that's loaded, ids assumed globally unique" stops being the boundary you want.
 
@@ -215,6 +215,7 @@ A *within*-image collision is still an error — an image must resolve cleanly t
     | What's wrong | Error id |
     |---|---|
     | Two selected descriptors for one `(kind, id)` (different source namespaces) inside one image | `:rf.error/image-duplicate-id` |
+    | …except one app registration over the framework's own copy of a [replaceable default](#framework-standards-and-the-defaults-youre-meant-to-replace) — that resolves. *Two* app registrations of one default id still collide, and the mark is only honoured on a descriptor with no registration provenance | *not an error* |
     | An inline entry colliding with a selected one (or two inline entries) in one image | `:rf.error/image-within-image-collision` |
     | An `:include` glob that matches no loaded source namespace | `:rf.error/image-zero-match` |
     | Two images sharing an `:id` in one composition | `:rf.error/image-duplicate-image-id` |
@@ -301,6 +302,18 @@ To override an existing `(kind, id)`, define the winning registration in a *late
 The stub is an understudy: same part — `:checkout.http/post` — different actor, and the shadow report says exactly who went on. An override is always a *separate* image, never a second key in the same one. A cross-image shadow resolves (later wins) and is reported; you read the report and apply whatever policy you want.
 
 One boundary is absolute: **you cannot override a framework standard.** The one cross-image collision that still fails assembly is an app registration colliding with a framework standard. If it's application-owned, define the winner in a later image and read the shadow report. But if it's *how the frame executes registered entries* — queue ordering, the interceptor algorithm, app-db commit semantics — that's a protected standard (`:rf.error/image-standard-replacement-forbidden`), and no app image may shadow it. A standard encodes an execution invariant, not an app policy choice.
+
+### Framework standards, and the defaults you're meant to replace
+
+Not everything the framework registers is a standard, and the difference decides whether your registration of the same id is a violation or the documented recipe.
+
+- A **framework standard** encodes an execution invariant — `:rf/set-db`, the interceptor algorithm, queue ordering. Protected: an app registration of the same id fails assembly with `:rf.error/image-standard-replacement-forbidden`. There is no opt-in.
+- A **replaceable framework default** is the opposite kind of registration: the framework's stand-in for a decision *your application* makes, seeded so the feature is safe when you register nothing. Today's two are `:rf.route/entry-denied` and `:rf.route/navigation-blocked` — both ship as no-ops, so a `:can-enter` denial or a `:can-leave` block always resolves, and the [auth recipe](../routing/how-to/require-sign-in-on-a-route.md) is you registering your own. Marked with the reserved `:rf/framework-default?` key ([spec/Conventions.md §Reserved registration metadata](../../spec/Conventions.md#reserved-registration-metadata-framework-owned)).
+
+So `(rf/reg-event :rf.route/entry-denied …)` in your own namespace is *not* a duplicate-id collision, even though your namespace and the framework's are different source namespaces. Once your registration is in the pool, assembly simply stops projecting the framework's own copy into the app layer — it was never an app registration in the first place. This is not a winner rule and not a precedence tier; two things follow from that, and both matter:
+
+- **Order still decides nothing.** *Two* app registrations of one framework-default id are still `:rf.error/image-duplicate-id`, exactly like any other duplicate.
+- **The mark is unforgeable.** It is honoured only together with an absent registration provenance, which is what identifies the framework's own internally-seeded copy. Your `reg-*` always captures the namespace it was written in, so stamping the reserved key on your own descriptor does nothing — it stays an ordinary app registration.
 
 ## Hot reload swaps the image, keeps the memory
 

--- a/docs/core/images.md
+++ b/docs/core/images.md
@@ -214,8 +214,7 @@ A *within*-image collision is still an error — an image must resolve cleanly t
 
     | What's wrong | Error id |
     |---|---|
-    | Two selected descriptors for one `(kind, id)` (different source namespaces) inside one image | `:rf.error/image-duplicate-id` |
-    | …except one app registration over the framework's own copy of a [replaceable default](#framework-standards-and-the-defaults-youre-meant-to-replace) — that resolves. *Two* app registrations of one default id still collide, and the mark is only honoured on a descriptor with no registration provenance | *not an error* |
+    | Two selected descriptors for one `(kind, id)` (different source namespaces) inside one image — one carve-out: an app registration over the framework's own copy of a [replaceable default](#framework-standards-and-the-defaults-youre-meant-to-replace) resolves instead, because that copy is not an app registration. *Two* app registrations of one default id still collide, and the mark is honoured only on a descriptor with no registration provenance | `:rf.error/image-duplicate-id` |
     | An inline entry colliding with a selected one (or two inline entries) in one image | `:rf.error/image-within-image-collision` |
     | An `:include` glob that matches no loaded source namespace | `:rf.error/image-zero-match` |
     | Two images sharing an `:id` in one composition | `:rf.error/image-duplicate-image-id` |

--- a/docs/ssr/concepts.md
+++ b/docs/ssr/concepts.md
@@ -307,7 +307,7 @@ A server-side exception must never reach the wire as a stack trace — crawlers 
 {:status 500 :code :internal-error :message "Something went wrong" :retryable? false}
 ```
 
-The framework ships a default projector that maps the obvious cases — a routing miss to `404 :not-found`, a *client-surface* schema-validation failure to `400 :bad-request`, anything else to `500 :internal-error`. You register your own to add app conventions (`401`/`403` for auth):
+The framework ships a default projector that maps the obvious cases — a routing miss to `404 :not-found`, a *client-surface* schema-validation failure to `400 :bad-request`, anything else to `500 :internal-error`. You register your own to add app conventions — mapping *thrown* auth failures to `401`/`403`, say:
 
 ```clojure
 (rf/reg-error-projector :myapp/public-error
@@ -317,6 +317,14 @@ The framework ships a default projector that maps the obvious cases — a routin
       :auth/unauthorised {:status 401 :code :unauthorised :message "Sign in"  :retryable? false}
       {:status 500 :code :internal-error :message "Something went wrong" :retryable? false})))
 ```
+
+!!! note "Route-level refusal is not a projector concern"
+
+    A projector maps a **thrown** error. A route whose `:can-enter` guard simply
+    *refuses* throws nothing — it is the app working correctly — so the runtime
+    stamps `403` on the response directly, before your `:rf.route/entry-denied`
+    handler drains. Nothing for you to project; see
+    [the entry-denial `403` floor](response.md#one-status-the-framework-writes-for-you-the-entry-denial-403).
 
 The wiring facts, one at a time:
 

--- a/docs/ssr/response.md
+++ b/docs/ssr/response.md
@@ -56,6 +56,45 @@ Last-write-wins on multiple redirects, with a `:rf.warning/multiple-redirects` t
     (`:rf.error/safe-redirect-host-disallowed`). An attacker-controlled `?next=…` cannot
     bounce a freshly-authed user off-origin.
 
+## One status the framework writes for you: the entry-denial `403`
+
+Everything above is a status *your* handler writes. There is exactly one the
+**framework** writes on your behalf.
+
+When a route's [`:can-enter`](../routing/concepts.md#guarding-entry--can-enter) guard rejects on a
+server frame, the runtime writes `:status 403` to the accumulator **before**
+`:rf.route/entry-denied` is dispatched. It is an ordinary `:rf.server/set-status`
+write, so it plays by the rules on this page — including last-write-wins and the
+`:rf.warning/multiple-status-set` trace. Think of it as a floor, not a decision:
+denial has an HTTP meaning even when your app says nothing, and the framework
+ships that meaning rather than leaving each adapter to guess.
+
+The denial handler drains *before* the render step, so you have two ways to
+supersede it:
+
+- **`[:rf.server/redirect {:location "/login"}]`** — the login bounce. Redirect
+  precedence (above) truncates the HTML *and* replaces the status.
+- **`[:rf.server/set-status 404]`** — or any other status, winning by last-write.
+  Use `404` when you would rather hide that the route exists at all.
+
+Rendering the login route inside the same server frame is *not* one of them: the
+response stays `403` unless the handler also writes one of the two.
+
+!!! info "An unreplaced denial produces no data for the denied target"
+
+    With the framework's no-op default handler — or any handler that establishes
+    neither a redirect nor another status — the protected route stays
+    **uncommitted**. The host renders your ordinary application shell under `403`.
+    No `:on-match` runs, no route resource plan is built or awaited, and **no
+    resource or hydration data for the denied target is produced**. There is
+    nothing to leak because nothing was activated.
+
+The floor is server-only — a client frame has no response to stamp. The routing
+contract itself (what makes a guard reject, what the denial value carries, the
+client-side recipe) is [`:can-enter`](../routing/how-to/require-sign-in-on-a-route.md)'s;
+`403` is what this page adds to it. Normative:
+[spec/011-SSR.md §Route entry denial — the default 403](../../spec/011-SSR.md#route-entry-denial--the-default-403).
+
 ## Header injection fails loud
 
 A `\r` or `\n` smuggled into a header value is a response-splitting attack. The
@@ -74,6 +113,7 @@ Fail-fast over strip-and-warn — silent normalisation masks the bug.
 | Symptom | Error / behaviour | Fix |
 |---|---|---|
 | Status set twice in one drain | Last write wins; `:rf.warning/multiple-status-set` | One intentional status, or accept last-write |
+| A protected page renders the shell under `403` and you didn't set it | The framework's [entry-denial floor](#one-status-the-framework-writes-for-you-the-entry-denial-403) | Intended. Emit `:rf.server/redirect` or an explicit `:rf.server/set-status` from `:rf.route/entry-denied` |
 | Multiple redirects | Last write wins; `:rf.warning/multiple-redirects` | One intentional redirect |
 | CR/LF in a header value | `:rf.error/header-invalid-value` | Sanitize before `:set-header` / `:append-header` |
 | CR/LF/NUL in redirect location | `:rf.error/redirect-invalid-location` | Don't pass raw user input to `:redirect` |
@@ -85,4 +125,7 @@ Fail-fast over strip-and-warn — silent normalisation masks the bug.
 - Form POST success → `[:rf.server/redirect {:status 303 :location …}]` — see
   [The model → two patterns](concepts.md#two-patterns-in-brief)
 - Server throws / 4xx / 5xx → [When the server throws](concepts.md#when-the-server-throws)
+- Route refuses entry → the [`403` floor](#one-status-the-framework-writes-for-you-the-entry-denial-403),
+  and [Require sign-in on a route](../routing/how-to/require-sign-in-on-a-route.md)
+  for the guard itself
 - Full arg schemas → [re-frame.ssr](../api/re-frame.ssr.md) / [re-frame.ssr.ring](../api/re-frame.ssr.ring.md)

--- a/docs/ssr/response.md
+++ b/docs/ssr/response.md
@@ -72,8 +72,9 @@ ships that meaning rather than leaving each adapter to guess.
 The denial handler drains *before* the render step, so you have two ways to
 supersede it:
 
-- **`[:rf.server/redirect {:location "/login"}]`** — the login bounce. Redirect
-  precedence (above) truncates the HTML *and* replaces the status.
+- **`[:rf.server/redirect {:location "/login"}]`** — the login bounce.
+  [Redirect precedence](#redirects-truncate-the-render) truncates the HTML *and*
+  replaces the status.
 - **`[:rf.server/set-status 404]`** — or any other status, winning by last-write.
   Use `404` when you would rather hide that the route exists at all.
 

--- a/implementation/resources/test/re_frame/resources_route_prefetch_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_route_prefetch_cljs_test.cljc
@@ -1,4 +1,4 @@
-(ns re-frame.resources-route-prefetch-test
+(ns re-frame.resources-route-prefetch-cljs-test
   "EP-0037 R3 — the Resources-side WARM-mode prefetch plan
   (`re-frame.resources.route/route-resource-warm-plan` + `on-route-prefetch-fx`,
   published as `:routing/on-route-prefetch`).
@@ -13,7 +13,9 @@
   prefetch — warm-mode.
 
   Dual-target (`.cljc`): the JVM runner picks it up via the `.*-test$` ns regex;
-  Shadow's `:node-test` via `cljs-test$` — the warm plan is host-neutral."
+  Shadow's `:node-test` via `cljs-test$` — the warm plan is host-neutral. The
+  `-cljs-test` suffix is load-bearing: a dual-target file whose ns ends in a
+  plain `-test` compiles nowhere but the JVM and reads as covered (rf2-dn6v7)."
   (:require
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])

--- a/scripts/_test_fixtures/check_retired_spellings/negative/query_retain_lookalikes.cljc
+++ b/scripts/_test_fixtures/check_retired_spellings/negative/query_retain_lookalikes.cljc
@@ -1,0 +1,28 @@
+(ns fixture.negative.query-retain-lookalikes
+  "NEGATIVE fixture: the surviving query vocabulary plus every near-miss
+  spelling. Must stay GREEN — the rule matches the retired keyword TOKEN
+  `:query-retain` exactly, so a namespaced or suffixed lookalike is a
+  different key and none of them is retired.")
+
+(defn register! [rf]
+  (rf/reg-route :route/cart
+                {;; the surviving two-slot promotion vocabulary
+                 :query          [:map [:sort {:optional true} :keyword]]
+                 :query-defaults {:sort :recent}
+                 ;; app-namespaced keys are always accepted (open map for
+                 ;; NAMESPACED keys), and none of these is the retired key
+                 :myapp/query-retain-policy :shell-keys
+                 :myapp/query-retains       #{:locale}}
+                "/cart"))
+
+;; Suffixed / qualified spellings that CONTAIN the retired token's characters
+;; but are not the token: the rule's trailing boundary rejects both.
+(def ^:private not-the-retired-key
+  {:query-retains     #{:locale}
+   :query-retain/mode :shell-keys})
+
+;; The in-place request keys — the causal primitive for "same page, different
+;; query" — are untouched by the retirement.
+(defn shell-nav [current-query]
+  {:to          :route/cart
+   :query-merge (select-keys current-query [:locale :tenant])})

--- a/scripts/_test_fixtures/check_retired_spellings/negative/query_retain_sanctioned_mentions.cljc
+++ b/scripts/_test_fixtures/check_retired_spellings/negative/query_retain_sanctioned_mentions.cljc
@@ -1,0 +1,36 @@
+(ns fixture.negative.query-retain-sanctioned-mentions
+  "NEGATIVE fixture: the retirement NOTES that name :query-retain as retired.
+  Reproduces the framework-source mentions verbatim — two `;;` comments and
+  one docstring passage from
+  implementation/routing/src/re_frame/routing/{registry,navigate}.cljc plus
+  the classification advisory note. Must stay GREEN: a rule that fires on the
+  notes explaining the retirement would make the retirement undocumentable.")
+
+;; EP-0037 R5: route `:query-retain` is RETIRED with no alias — a route
+;; declaring it is now rejected as an unknown bare key. Carrying query
+;; state across routes is an APPLICATION policy spelled as an ordinary
+;; pure function over the destination address (Spec 012 §Carrying query
+;; state across routes); the framework no longer folds ambient current
+;; query into a destination the caller authored.
+(def ^:private reserved-route-keys
+  #{:doc :path :params :query :query-defaults
+    :tags :parent :on-match :scroll :can-leave :can-enter
+    :sensitive :large
+    :head})
+
+;; EP-0037 R5 shrank the promotion vocabulary from three sources to two: the
+;; retired `:query-retain` no longer promotes anything, so a key that was only
+;; keyword-promoted through it now WARNS until the route declares it.
+(defn- promoted-query-keys [metadata]
+  (into #{}
+        (mapcat (fn [slot] (keys (get metadata slot))))
+        [:query :query-defaults]))
+
+(defn coerce-query
+  "Authors who want keyword keys declare them via `:query` / `:query-defaults`
+  — author-named intent is the trust boundary. EP-0037 R5 made those the ONLY
+  two slots — a key that used to be keyword-promoted solely because the retired
+  `:query-retain` named it must now be declared in `:query` or
+  `:query-defaults` to keep its keyword form."
+  [metadata query]
+  (select-keys query (promoted-query-keys metadata)))

--- a/scripts/_test_fixtures/check_retired_spellings/positive/query_retain_accepted_key_roster.cljc
+++ b/scripts/_test_fixtures/check_retired_spellings/positive/query_retain_accepted_key_roster.cljc
@@ -1,0 +1,12 @@
+(ns fixture.positive.query-retain-accepted-key-roster
+  "POSITIVE fixture: the retired :query-retain key back in the accepted
+  route-metadata key roster (EP-0037 R5, rf2-jlmgt). Mirrors
+  re-frame.routing.registry's `reserved-route-keys` set — reinstating the key
+  there is what would let `reg-route` accept it again as a bare key.")
+
+(def ^:private reserved-route-keys
+  "Route-metadata keys reg-route accepts as bare (unqualified) keys."
+  #{:doc :path :params :query :query-defaults :query-retain
+    :tags :parent :on-match :scroll :can-leave :can-enter
+    :sensitive :large
+    :head})

--- a/scripts/_test_fixtures/check_retired_spellings/positive/query_retain_promotion_vocabulary.cljc
+++ b/scripts/_test_fixtures/check_retired_spellings/positive/query_retain_promotion_vocabulary.cljc
@@ -1,0 +1,10 @@
+(ns fixture.positive.query-retain-promotion-vocabulary
+  "POSITIVE fixture: the retired :query-retain key back in the query-key
+  PROMOTION vocabulary (EP-0037 R5, rf2-jlmgt). R5 shrank the vocabulary from
+  three sources to two — :query and :query-defaults — so a third source
+  widening it (and thereby suppressing the promotion advisory) is drift.")
+
+(defn- promoted-query-keys [metadata]
+  (into #{}
+        (mapcat (fn [slot] (keys (get metadata slot))))
+        [:query :query-defaults :query-retain]))

--- a/scripts/_test_fixtures/check_retired_spellings/positive/query_retain_reg_route_meta.cljc
+++ b/scripts/_test_fixtures/check_retired_spellings/positive/query_retain_reg_route_meta.cljc
@@ -1,0 +1,11 @@
+(ns fixture.positive.query-retain-reg-route-meta
+  "POSITIVE fixture: the retired :query-retain key in a reg-route metadata
+  map (EP-0037 R5, rf2-jlmgt). A destination address is taken literally;
+  cross-route query carry is an application-side pure function.")
+
+(defn register! [rf]
+  ;; RETIRED: the router no longer folds ambient query into a destination.
+  (rf/reg-route :route/cart
+                {:query-retain #{:theme :locale}
+                 :query        [:map [:sort {:optional true} :keyword]]}
+                "/cart"))

--- a/scripts/check_retired_spellings.py
+++ b/scripts/check_retired_spellings.py
@@ -3,8 +3,8 @@
 
 EP-0007 rule 2 ("no stable accepted synonyms") gets the no-floor-lint
 treatment "where shapes allow": a *retired* spelling reappearing in
-framework source is a CI failure, not a doc note. Two renames have merged,
-so two retired spellings are now lintable:
+framework source is a CI failure, not a doc note. Three renames have merged,
+so three retired spellings are now lintable:
 
   (a) The bare `:frame` event-context COEFFECT (sweep item 1, rf2-1m6rf1).
       EP-0002 R3 "one carrier, one name" retired the duplicate `:frame`
@@ -18,6 +18,14 @@ so two retired spellings are now lintable:
       header, so it uses header vocabulary — the canonical (and only)
       target key is `:location`. `:url` / `:to` are retired and now throw
       `:rf.error/redirect-retired-target-key`.
+
+  (c) Route metadata `:query-retain` (EP-0037 R5, rf2-jlmgt). A destination
+      address is taken LITERALLY: the router no longer folds ambient
+      current-route query state into a route the caller authored. The key is
+      retired with NO alias — `reg-route` rejects it as an unknown bare key —
+      and it no longer widens the query-key promotion vocabulary. Carrying
+      query state across routes is application policy spelled as a pure
+      function over the destination address.
 
 WHY THE SHAPES ARE SCOPED PRECISELY (the "where shapes allow" caveat)
 
@@ -56,6 +64,30 @@ retired SHAPES:
       `{:fx [[:rf.server/redirect {:to "/x"}]]}` reintroduction without
       firing on `(navigate {:url "/x"})` client-nav, where no
       `:rf.server/*redirect` tag is present.
+
+  (c) `:query-retain` as a Clojure KEYWORD TOKEN — the keyword delimited on
+      both sides (start-of-line or one of `(`/`[`/`{`/whitespace/`,` before;
+      a closing delimiter, whitespace or end-of-line after). Unlike (a) and
+      (b) the retired key has NO sanctioned code use whatsoever, so the three
+      USE shapes EP-0037 row 9 enumerates all reduce to that one token shape:
+
+        - a `reg-route` metadata map    `{:query-retain #{:theme :locale}}`
+        - the accepted-key roster       `#{... :query-defaults :query-retain}`
+        - the promotion vocabulary      `[:query :query-defaults :query-retain]`
+
+      What the token boundary buys is prose safety. Every legitimate in-tree
+      mention NAMES the key as retired, and every one of them spells it as
+      backticked prose — `` `:query-retain` `` — so the opening backtick
+      denies the token-start boundary and the rule cannot fire on a retirement
+      note even where comment/string masking does not reach. The mentions:
+      `implementation/routing/src/re_frame/routing/{classification,navigate,
+      registry}.cljc` (comments + one docstring, masked as well as
+      backticked), `skills/re-frame2/references/tooling/routing.md`,
+      `spec/Spec-Schemas.md`, and
+      `spec/conformance/fixtures/routing-query-keyword-discipline.edn`. The
+      last three are outside this gate's scan surface (see SCAN SURFACE) —
+      the boundary is what keeps the rule correct if it is ever pointed at
+      them, and the self-test pins all five verbatim.
 
 WHERE A SHAPE IS TOO AMBIGUOUS TO LINT WITHOUT NOISE (documented, not shipped)
 
@@ -186,6 +218,18 @@ _SSR_REDIRECT_FX_RE = re.compile(r":rf\.server/(?:safe-)?redirect\b")
 # `(?=\s)` + `\b` ensure `:url` not `:urls`/`:url/x`, and `:to` not
 # `:token`/`:to/x`. Matched only inside an SSR-redirect window (see below).
 _RETIRED_REDIRECT_KEY_RE = re.compile(r":(?:url|to)\b(?!/)\s")
+
+# (c) The retired route-metadata key `:query-retain` (EP-0037 R5). Matched as a
+#     delimited Clojure KEYWORD TOKEN, which is what every USE shape has in
+#     common — a `reg-route` metadata-map key, a member of the accepted-key
+#     roster, a member of the promotion vocabulary — and what no retirement
+#     NOTE has, since those spell it as backticked prose. The trailing
+#     lookahead also rejects `:query-retain/x` and `:query-retains`.
+_RETIRED_QUERY_RETAIN_RE = re.compile(
+    r"(?:^|(?<=[\s(\[{,]))"      # keyword-token start (a backtick denies it)
+    r":query-retain"
+    r"(?=[\s)\]},]|$)"           # keyword-token end
+)
 
 
 class Finding(NamedTuple):
@@ -362,6 +406,16 @@ def _scan_text(path: Path, text: str) -> list[Finding]:
                 Finding(path, line_no, "retired-redirect-target-key",
                         raw_snippet(line_no))
             )
+
+    # (c) The retired `:query-retain` route-metadata key — line-local, and no
+    #     enclosing-form window is needed: the key has no sanctioned code use,
+    #     so a delimited keyword token IS the violation wherever it appears.
+    for line_no, line in enumerate(masked, start=1):
+        if _RETIRED_QUERY_RETAIN_RE.search(line):
+            findings.append(
+                Finding(path, line_no, "retired-query-retain-key",
+                        raw_snippet(line_no))
+            )
     return findings
 
 
@@ -397,6 +451,17 @@ _FIX_HINTS = {
         "still the canonical key on CLIENT navigation surfaces — different "
         "concept, different word, per spec/Conventions.md §The naming rules.)"
     ),
+    "retired-query-retain-key": (
+        "Route metadata `:query-retain` was retired by EP-0037 R5 with no "
+        "alias — `reg-route` rejects it as an unknown bare key, it is not in "
+        "the accepted-key roster, and it no longer widens the query-key "
+        "promotion vocabulary. A destination address is taken LITERALLY. "
+        "Declare the keys the route owns in `:query` / `:query-defaults`; "
+        "carry query state across routes with an ordinary pure function over "
+        "the destination address at the call site (Spec 012 §Carrying query "
+        "state across routes). To edit the CURRENT route's query, use the "
+        "in-place `:query` / `:query-merge` request."
+    ),
 }
 
 
@@ -427,7 +492,8 @@ def main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(
         description=(
             "EP-0007 §Enforcement: fail on a retired spelling reappearing in "
-            "framework source (the bare :frame coeffect; redirect :url/:to)."
+            "framework source (the bare :frame coeffect; redirect :url/:to; "
+            "route :query-retain)."
         ),
     )
     parser.add_argument(
@@ -510,6 +576,27 @@ _SELF_TEST_FIXTURE_ROOT = (
     Path(__file__).resolve().parent / "_test_fixtures" / "check_retired_spellings"
 )
 
+# Sanctioned `:query-retain` mentions that live OUTSIDE this gate's scan surface
+# (a skill reference, a spec schema comment, a conformance fixture). Pinned
+# VERBATIM and scanned as raw single lines rather than as `.cljc` fixtures,
+# because that is the point: a Markdown bullet gets no comment/string masking,
+# so only the keyword-token boundary keeps the rule off it. If the surface ever
+# widens to these trees, this phase is what says it stayed correct.
+_SANCTIONED_PROSE_MENTIONS: tuple[tuple[str, str], ...] = (
+    ("skills/re-frame2/references/tooling/routing.md",
+     "and never gains query keys from whichever route was current. There is no "
+     "`:query-retain` (retired, no alias; declaring it is rejected as an "
+     "unknown bare key), no query middleware, no per-route carry policy."),
+    ("spec/Spec-Schemas.md",
+     "   [:query-defaults  {:optional true} [:map-of :keyword :any]]  "
+     ";; Destination-LOCAL. EP-0037 R5 retired `:query-retain`; cross-route "
+     "carry is the application's pure fold over the destination address."),
+    ("spec/conformance/fixtures/routing-query-keyword-discipline.edn",
+     ";;      EP-0037 R5 retired the third source, `:query-retain`: a key that "
+     "was keyword-promoted solely by its `:query-retain #{:theme}` declaration "
+     "must now be declared in `:query` / `:query-defaults`."),
+)
+
 
 def _run_self_tests(verbose: bool = False) -> int:
     """Scan each fixture file and assert the expected finding count.
@@ -519,6 +606,10 @@ def _run_self_tests(verbose: bool = False) -> int:
     that MUST stay green (expected=0). Fixtures live under a `negative`/`positive`
     dir; we scan with --include-tests semantics (direct-file mode) so the
     test-dir exclusion does not hide them.
+
+    A second phase scans `_SANCTIONED_PROSE_MENTIONS` — verbatim retirement
+    notes from trees this gate does not scan, where no masking applies — as raw
+    lines, so the shape scoping is proven independently of the masking.
     """
     cases: list[tuple[str, int]] = [
         # (fixture-file relative to fixture-root, expected finding count)
@@ -529,6 +620,10 @@ def _run_self_tests(verbose: bool = False) -> int:
         ("positive/redirect_url_key.cljc",          1),
         ("positive/safe_redirect_to_key.cljc",      1),
         ("positive/redirect_url_multiline.cljc",    1),
+        # EP-0037 R5 `:query-retain` — the three USE shapes row 9 enumerates.
+        ("positive/query_retain_reg_route_meta.cljc",     1),
+        ("positive/query_retain_accepted_key_roster.cljc", 1),
+        ("positive/query_retain_promotion_vocabulary.cljc", 1),
         # --- negatives: every sanctioned counterpart must stay GREEN ---
         ("negative/public_frame_opt.cljc",          0),
         ("negative/frame_trace_tag.cljc",           0),
@@ -539,6 +634,10 @@ def _run_self_tests(verbose: bool = False) -> int:
         ("negative/frame_in_comment.cljc",          0),
         ("negative/frame_in_docstring.cljc",        0),
         ("negative/retired_keys_def.cljc",          0),
+        # EP-0037 R5 `:query-retain` — every sanctioned in-tree mention names
+        # the key as RETIRED; none of them may fire the rule.
+        ("negative/query_retain_sanctioned_mentions.cljc", 0),
+        ("negative/query_retain_lookalikes.cljc",   0),
     ]
 
     failures = 0
@@ -562,11 +661,25 @@ def _run_self_tests(verbose: bool = False) -> int:
             )
             failures += 1
 
+    # Phase 2: the out-of-surface sanctioned prose mentions, scanned raw.
+    for origin, line in _SANCTIONED_PROSE_MENTIONS:
+        got = len(_scan_text(Path(origin), line))
+        if got == 0:
+            if verbose:
+                sys.stderr.write(f"self-test PASS: prose mention in {origin}\n")
+        else:
+            sys.stderr.write(
+                f"self-test FAIL: sanctioned prose mention in {origin} fired "
+                f"{got} finding(s):\n      {line}\n"
+            )
+            failures += 1
+
     if failures:
         sys.stderr.write(f"\n{failures} self-test failure(s).\n")
         return 1
     if verbose:
-        sys.stderr.write(f"all {len(cases)} self-tests passed.\n")
+        total = len(cases) + len(_SANCTIONED_PROSE_MENTIONS)
+        sys.stderr.write(f"all {total} self-tests passed.\n")
     return 0
 
 


### PR DESCRIPTION
Four small beads from the EP-0037 R6 integrated-proof pass, on disjoint surfaces: one test rename, one CI gate rule, two documentation gaps. One commit each.

## rf2-dn6v7 — the route-prefetch warm-plan test ran JVM-only

`implementation/resources/test/re_frame/resources_route_prefetch_test.cljc` was written `.cljc` to run on both hosts, but its namespace ended in a plain `-test`. The shadow-cljs `:node-test` build selects on `:ns-regexp "cljs-test$"`, so the CLJS lane never compiled it, while the JVM runner's `.*-test$` did. The file read as covered and was half-covered: the three warm-mode planner contract arms had no CLJS unit arm.

Renamed to `resources_route_prefetch_cljs_test.cljc` / `re-frame.resources-route-prefetch-cljs-test`. Nothing else in the tree referenced the old name, and the docstring now records that the suffix is load-bearing.

**Proof it now runs on both lanes**, not just that it was renamed:

- **JVM** (`clojure -M:test` in `implementation/resources`) — 704 tests, 6613 assertions, 0 failures, 0 errors.
- **CLJS** (`npm run test:cljs`) — 11237 tests, 56369 assertions, 0 failures, 0 errors, and the namespace is in the build: `implementation/.shadow-cljs/builds/node-test/dev/out/cljs-runtime/re_frame.resources_route_prefetch_cljs_test.js` carries all three deftest vars (`warm_plan_ensures_are_ownerless_cause_only_and_blocking_inert`, `warm_plan_branch_error_is_a_prefetch_planning_failure`, `warm_plan_is_a_noop_when_no_branch_contributor_declares_resources`).
- The selection itself, old ns vs new, against each lane's regex:

  | ns | `:node-test` `cljs-test$` | JVM `.*-test$` |
  | --- | --- | --- |
  | `re-frame.resources-route-prefetch-test` | **no** | yes |
  | `re-frame.resources-route-prefetch-cljs-test` | yes | yes |

No JVM-only assumption surfaced — the warm plan really is host-neutral and the file passes unchanged on CLJS.

**Acceptance criterion 3 (a gate for the class) is deliberately not in this PR.** A census found nine more `.cljc` test namespaces in `implementation/` with neither a `-cljs-test` nor a `-jvm-test` suffix, so the class does recur and the gate is cheap — but each of the nine needs a per-file ruling (silently half-covered, or legitimately JVM-only and wanting an explicit suffix), which is a different size of change from one rename. Filed as **rf2-lgozq** with the roster enumerated.

## rf2-jlmgt — `:query-retain` completeness now has a mechanical gate

A third rule in the existing `scripts/check_retired_spellings.py` (no new script). It matches `:query-retain` as a **delimited Clojure keyword token** — start-of-line or one of `(`/`[`/`{`/whitespace/`,` before; a closing delimiter, whitespace or end-of-line after.

That one shape is what all three USE shapes EP-0037 row 9 enumerates have in common:

- a `reg-route` metadata map — `{:query-retain #{:theme :locale}}`
- the accepted-key roster — `#{… :query-defaults :query-retain}`
- the promotion vocabulary — `[:query :query-defaults :query-retain]`

and what no retirement **note** has: every legitimate in-tree mention names the key as retired and spells it as backticked prose, and the opening backtick denies the token-start boundary. The trailing boundary also rejects `:query-retain/x` and `:query-retains`.

Self-test gains three positives (one per USE shape) and two negatives (the framework-source retirement notes reproduced verbatim; the surviving `:query` / `:query-defaults` vocabulary plus suffixed and namespaced lookalikes), plus a second phase that scans the three sanctioned prose mentions living **outside** this gate's scan surface — `skills/re-frame2/references/tooling/routing.md`, `spec/Spec-Schemas.md`, `spec/conformance/fixtures/routing-query-keyword-discipline.edn` — as raw lines. Markdown gets no comment or string masking, so that phase proves the shape scoping independently of the masking, and says the rule stayed correct if the surface ever widens to those trees.

Scan surface is unchanged (`implementation/**`, tests excluded), so the gate's invocation in `scripts/test-fast-pr.sh` and `.github/workflows/test.yml` needs no edit. Under `--include-tests` the new rule fires on `routing_registry_test.clj`'s deliberate rejection assertions — exactly as the existing `:url`/`:to` rule fires on the SSR end-to-end throw fixtures, which is the documented reason test trees are excluded by default.

## rf2-b5cz0 — the SSR guides now document the entry-denial `403` floor

**Verified against the code before writing anything.** `implementation/routing/src/re_frame/routing/decisions.cljc` conj's `[:rf.server/set-status 403]` into the denial fx vector ahead of `[:dispatch [:rf.route/entry-denied denial]]`, gated on `server-frame?` (the frame's own `:platform`, never the host default). That is exactly what `spec/011-SSR.md:1500-1511` locks, so the bead's description held and there was nothing to correct.

`docs/ssr/response.md` gains a section: the floor as a floor rather than a decision, both supersession paths (`:rf.server/redirect` via redirect precedence, which truncates HTML *and* replaces the status; an explicit `:rf.server/set-status` winning by last-write), the fact that rendering the login route in the same frame is *not* one of them, the no-resource-and-no-hydration-data consequence for the denied target, and the server-only scoping. Plus a troubleshooting row for "a protected page renders the shell under 403 and I didn't set it → intended".

`docs/ssr/concepts.md` no longer implies `401`/`403` are exclusively application-projector concerns: a projector maps a **thrown** error, and a route refusal throws nothing.

The routing contract is cross-referenced, never restated — the guard itself stays `docs/routing/how-to/require-sign-in-on-a-route.md`'s job, `403` is what the SSR page adds to it.

## rf2-l4qro — the images page names the replaceable-default category

PR #6932 introduced a third registration category and `docs/core/images.md` never mentioned it, which had made two claims on the page untrue for exactly the case the documented auth recipe relies on.

- The default-image **fail-loud** claim and the assembly **error-table** row both carry the carve-out: an app registration over the framework's own copy of a replaceable default resolves, because that copy was never an app registration and stops being projected once yours is in the pool.
- Both restatements keep the invariants that are still exactly true: *two* app registrations of one framework-default id remain `:rf.error/image-duplicate-id` (order still decides nothing), and the marker is honoured only together with an absent registration provenance, so an app descriptor stamping the reserved key on itself is still an ordinary app registration.
- A short subsection teaches the distinction the page was missing — standard = protected execution invariant (`:rf/set-db`), replaceable default = a safe no-op the framework expects you to replace — with `:rf.route/entry-denied` and `:rf.route/navigation-blocked` as the two live instances and `:rf/framework-default?` cited to `spec/Conventions.md`.

The framework-standard boundary stays stated as absolute. No precedence-tier or metadata-inheritance vocabulary is introduced, and the page deliberately says nothing about what metadata survives such an override — that is `rf2-kqxe6.20`'s surface, still in flight. `docs/core/images.md:307` (a `reg-*` re-eval resolving fresh sealed generations) was checked and is correct, so it is untouched.

## Quality gates

| gate | result | exit |
| --- | --- | --- |
| `scripts/test-fast-pr.sh` (docs + JVM + node tiers, all three classified in) | 28 gates, all green; core JVM 2111 tests / 10440 assertions, CLJS node 11237 tests / 56369 assertions, 0 failures / 0 errors in both | 0 |
| `clojure -M:test` in `implementation/resources` (JVM lane, rf2-dn6v7) | 704 tests, 6613 assertions, 0 failures, 0 errors | 0 |
| `npm run test:cljs` (CLJS `:node-test` lane, rf2-dn6v7) | 11237 tests, 56369 assertions, 0 failures, 0 errors | 0 |
| `python scripts/check_retired_spellings.py --self-test --verbose` | 23/23 passed (20 fixtures + 3 prose mentions) | 0 |
| `python scripts/check_retired_spellings.py --verbose` (live scan) | 405 files scanned, no retired spellings | 0 |
| `python -m mkdocs build --strict` | built in 22.98s, zero warnings; no warning or unresolved link on any of the three touched pages | 0 |
| `python scripts/check_doc_slugs.py` (doc-slug gate) | clean | 0 |

`mkdocs` is not on `PATH` on this Windows box, so `test-fast-pr.sh` soft-skips its mkdocs step by design; it was run separately as `python -m mkdocs build --strict` (row above, exit 0). Everything ran in the foreground to completion, with output captured to worktree-local `gate-logs/` and exit codes read from the runner rather than through a pipe. The merge decision is still CI's.
