### PR TITLE
test,fix: give the last nine lane-suffix-less .cljc tests an explicit lane; stop beads-checkpoint committing memory churn (rf2-lgozq, rf2-51uz1.1)

### DIFF
--- a/implementation/core/test/re_frame/router_front_of_queue_cljs_test.cljc
+++ b/implementation/core/test/re_frame/router_front_of_queue_cljs_test.cljc
@@ -1,4 +1,4 @@
-(ns re-frame.router-front-of-queue-test
+(ns re-frame.router-front-of-queue-cljs-test
   "Per rf2-j20a7 / Spec 005 §Level 4 — machine-internal continuation
   events insert at the FRONT of the per-frame router queue, while
   ordinary (external) dispatches stay plain-FIFO at the back.
@@ -7,7 +7,7 @@
   machines artefact: the marking flag is `:rf.machine/internal?`, which
   `re-frame.machines` stamps onto machine-originated child dispatches
   (covered end-to-end in
-  `re-frame.machine-front-of-queue-test` in the machines artefact). Here
+  `re-frame.machine-front-of-queue-cljs-test` in the machines artefact). Here
   we drive `re-frame.router/dispatch!` directly (the fn-form; call-site
   capture is irrelevant to queue-order semantics) with the flag set
   explicitly so the queue-insertion semantics are tested in isolation:
@@ -31,7 +31,12 @@
   an ordinary frame). The CHILD `dispatch!` calls inside the seed handler
   inherit the handler's frame binding, so they need no explicit frame —
   only the rootless top-level seed does (the carried-invariant contract:
-  no synthesised default floor)."
+  no synthesised default floor).
+
+  Dual-target (`.cljc`): the JVM runner selects it on `.*-test$`, Shadow's
+  `:node-test` build on `cljs-test$`. The `-cljs-test` suffix is therefore
+  load-bearing — a `.cljc` test whose ns ends in a plain `-test` compiles
+  nowhere but the JVM and reads as covered (rf2-dn6v7, rf2-lgozq)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.router :as router]

--- a/implementation/core/test/re_frame/router_transducer_cljs_test.cljc
+++ b/implementation/core/test/re_frame/router_transducer_cljs_test.cljc
@@ -1,11 +1,16 @@
-(ns re-frame.router-transducer-test
+(ns re-frame.router-transducer-cljs-test
   "Unit coverage for the v1.1 transducer-router Phase-1 scaffold
   (rf2-cl8me). Non-normative — these tests pin the scaffold's pure-fn
   surface so the design at spec/Design-TransducerRouter.md is exercisable.
 
   The scaffold does not touch the live runtime; these tests construct
   ad-hoc envelopes + frames and walk them through the transducer +
-  reducing functions directly. No registrar / no router / no substrate."
+  reducing functions directly. No registrar / no router / no substrate.
+
+  Dual-target (`.cljc`): the JVM runner selects it on `.*-test$`, Shadow's
+  `:node-test` build on `cljs-test$`. The `-cljs-test` suffix is therefore
+  load-bearing — a `.cljc` test whose ns ends in a plain `-test` compiles
+  nowhere but the JVM and reads as covered (rf2-dn6v7, rf2-lgozq)."
   (:require [clojure.test :refer [deftest is testing]]
             [re-frame.router-transducer :as rt]))
 

--- a/implementation/core/test/re_frame/source_coord_cljs_test.cljs
+++ b/implementation/core/test/re_frame/source_coord_cljs_test.cljs
@@ -1,7 +1,7 @@
 (ns re-frame.source-coord-cljs-test
   "Per rf2-ts1a — CLJS-side smoke check for `:rf.trace/call-site` on
   `:rf.error/*` trace events. JVM-side coverage lives in
-  `source_coord_test.cljc`; the macro-expansion path is identical
+  `source_coord_jvm_test.cljc`; the macro-expansion path is identical
   across both targets (the `.cljc` macros run on the Clojure side of
   the compiler in either case), so this file primarily verifies that
   the CLJS bundle wires up the dynamic-var read end-to-end without a

--- a/implementation/core/test/re_frame/source_coord_jvm_test.cljc
+++ b/implementation/core/test/re_frame/source_coord_jvm_test.cljc
@@ -1,4 +1,4 @@
-(ns re-frame.source-coord-test
+(ns re-frame.source-coord-jvm-test
   "Per rf2-ts1a — `:rf.trace/call-site` on `:rf.error/*` trace events.
 
   Complement to rf2-3nn8 (`:rf.trace/trigger-handler`). Where trigger-
@@ -21,7 +21,13 @@
   `source_coord_cljs_test.cljs`. Macro-expansion is JVM-side for both
   targets (the `.cljc` macros run on the Clojure side of the compiler
   in either case), so the call-site capture path itself is the same;
-  only the runtime delivery differs."
+  only the runtime delivery differs.
+
+  The `-jvm-test` suffix is deliberate, not the rf2-dn6v7 omission. Shadow's
+  `:node-test` build selects on `cljs-test$`; this file is the JVM half of a
+  DELIBERATE pair whose CLJS half is the `.cljs` mirror named above, so the
+  explicit lane suffix records that skipping the CLJS lane is the intent and
+  not an oversight (rf2-lgozq)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]

--- a/implementation/core/test/re_frame/source_coord_jvm_test.cljc
+++ b/implementation/core/test/re_frame/source_coord_jvm_test.cljc
@@ -221,5 +221,5 @@
       (is (integer? (:line cs)))
       (is (pos? (:line cs)))
       (is (string? (:file cs)))
-      (is (re-find #"source_coord_test" (:file cs))
+      (is (re-find #"source_coord_jvm_test" (:file cs))
           (str ":file should point at this test file — got " (:file cs))))))

--- a/implementation/machines/test/re_frame/after_timer_arm_publish_race_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/after_timer_arm_publish_race_cljs_test.cljc
@@ -1,4 +1,4 @@
-(ns re-frame.after-timer-arm-publish-race-test
+(ns re-frame.after-timer-arm-publish-race-cljs-test
   "Adversarial ordering regressions for the machine `:after` timer two-phase
   arm (rf2-j538f7.7). Two races the serial suite never exercised:
 
@@ -20,7 +20,12 @@
   here are driven with `with-redefs` — running the cleanup INSIDE the host-arm
   stub (between reserve and publish), or firing the captured thunk synchronously
   — so BOTH runtimes execute the identical reserve / publish / claim code and
-  the invariants hold on each. Per Spec 005 §Delayed `:after` transitions."
+  the invariants hold on each. Per Spec 005 §Delayed `:after` transitions.
+
+  Dual-target (`.cljc`): the JVM runner selects it on `.*-test$`, Shadow's
+  `:node-test` build on `cljs-test$`. The `-cljs-test` suffix is therefore
+  load-bearing — a `.cljc` test whose ns ends in a plain `-test` compiles
+  nowhere but the JVM and reads as covered (rf2-dn6v7, rf2-lgozq)."
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.core :as rf]

--- a/implementation/machines/test/re_frame/dispatch_to_system_fx_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/dispatch_to_system_fx_cljs_test.cljc
@@ -18,7 +18,7 @@
   arity-≥3 entries), matching `:rf.machine/spawn`'s single-map args and
   `:dispatch`'s single-event-vector args.
 
-  Deterministic harness (mirrors `machine_front_of_queue_test`): one
+  Deterministic harness (mirrors `machine_front_of_queue_cljs_test`): one
   `dispatch-sync` drain. The action's fx queues the child dispatch, which
   rides the in-progress sync drain and pops in queue order — so the assert
   reads post-drain state without async timing.

--- a/implementation/machines/test/re_frame/join_attempt_effect_path_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/join_attempt_effect_path_cljs_test.cljc
@@ -1,4 +1,4 @@
-(ns re-frame.join-attempt-effect-path-test
+(ns re-frame.join-attempt-effect-path-cljs-test
   "rf2-2lzk8a — keep the `:spawn-all` join-completion transport RESERVED and
   NON-REDIRECTABLE so the framework path can't be captured or suppressed (it is
   a fold-fence protection, not authentication — rf2-cpbjfp).
@@ -52,7 +52,12 @@
   fails the fallthrough folds; removing `:rf.machine/join-dispatch` from the
   reject set fails the capture + recursion guards; re-conflating the two policies
   (adding `:rf.machine/spawn` back to the target set) fails the redirect-target
-  case below."
+  case below.
+
+  Dual-target (`.cljc`): the JVM runner selects it on `.*-test$`, Shadow's
+  `:node-test` build on `cljs-test$`. The `-cljs-test` suffix is therefore
+  load-bearing — a `.cljc` test whose ns ends in a plain `-test` compiles
+  nowhere but the JVM and reads as covered (rf2-dn6v7, rf2-lgozq)."
   (:require
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])

--- a/implementation/machines/test/re_frame/join_reap_auth_test.clj
+++ b/implementation/machines/test/re_frame/join_reap_auth_test.clj
@@ -33,7 +33,7 @@
   DELIBERATE and stays. This fixture is not about the exact-attempt coordinate:
   the reap is verified against LIVE join state the caller cannot supply, so
   membership in `:done ∪ :failed` is genuinely authenticated. Contrast the join
-  coordinate (`join_attempt_effect_path_test`,
+  coordinate (`join_attempt_effect_path_cljs_test`,
   `join_parallel_attempt_select_test`, the recordable transport/control
   fixtures), which is caller-suppliable exact-current correlation evidence — a
   fold FENCE, not authentication — and therefore carries attempt/coordinate

--- a/implementation/machines/test/re_frame/machine_cascade_instrumentation_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/machine_cascade_instrumentation_cljs_test.cljc
@@ -1,4 +1,4 @@
-(ns re-frame.machine-cascade-instrumentation-test
+(ns re-frame.machine-cascade-instrumentation-cljs-test
   "The `:rf.machine/transition` trace carries a structured `:cascade` field:
   the ordered exit / transition-action / entry steps (+ initial-descent +
   `:always` microsteps + per-region structure) that explain HOW a transition
@@ -20,7 +20,12 @@
   The HVAC fixture mirrors the live machine-epochs testbed
   (`:hvac/controller`) whose own `:data :trail` records the cascade order
   — that trail is the ORACLE these tests cross-check the emitted cascade
-  against."
+  against.
+
+  Dual-target (`.cljc`): the JVM runner selects it on `.*-test$`, Shadow's
+  `:node-test` build on `cljs-test$`. The `-cljs-test` suffix is therefore
+  load-bearing — a `.cljc` test whose ns ends in a plain `-test` compiles
+  nowhere but the JVM and reads as covered (rf2-dn6v7, rf2-lgozq)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.machines.test-support :as mtest]

--- a/implementation/machines/test/re_frame/machine_cascade_instrumentation_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/machine_cascade_instrumentation_cljs_test.cljc
@@ -29,7 +29,15 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.machines.test-support :as mtest]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.substrate.plain-atom :as plain-atom])
+  ;; `mtest/with-trace-capture` is a `#?(:clj (defmacro …))` in a `.cljc`
+  ;; support ns, so the CLJS analyzer needs it required as a MACRO ns under
+  ;; the same alias; a plain `:require` leaves the call compiling to a
+  ;; function call on an undefined var. This is the JVM-only assumption the
+  ;; rf2-lgozq rename exposed — all seven tests here errored on the CLJS lane
+  ;; with `No protocol method IDeref.-deref defined for type undefined` until
+  ;; this line existed. Same shape as `observation_port_cljs_test.cljc`.
+  #?(:cljs (:require-macros [re-frame.machines.test-support :as mtest])))
 
 (use-fixtures :each
   (mtest/make-reset-runtime-fixture {:adapter plain-atom/adapter}))

--- a/implementation/machines/test/re_frame/machine_front_of_queue_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/machine_front_of_queue_cljs_test.cljc
@@ -1,11 +1,11 @@
-(ns re-frame.machine-front-of-queue-test
+(ns re-frame.machine-front-of-queue-cljs-test
   "Per Spec 005 §Level 4 — end-to-end coverage that a REAL
   machine's continuation dispatch (`:fx [[:dispatch …]]` emitted from an
   action) leap-frogs to the FRONT of the router queue, while an event
   that merely TARGETS a machine but originates externally stays FIFO.
 
   The router-level queue-insertion mechanism is pinned in
-  `re-frame.router-front-of-queue-test` (core). Here we exercise the
+  `re-frame.router-front-of-queue-cljs-test` (core). Here we exercise the
   marking SEAM: `re-frame.router/run-handler-pipeline!` tags the in-flight
   envelope `:rf.machine/internal? true` when the handler's registration
   meta carries `:rf/machine? true` (stamped by `reg-machine*`); that flag
@@ -16,7 +16,12 @@
 
   Deterministic harness: one `dispatch-sync` drain. The seed handler
   enqueues its events in its body; they ride the in-progress sync drain,
-  which pops them in queue order. Run-order is recorded into an atom."
+  which pops them in queue order. Run-order is recorded into an atom.
+
+  Dual-target (`.cljc`): the JVM runner selects it on `.*-test$`, Shadow's
+  `:node-test` build on `cljs-test$`. The `-cljs-test` suffix is therefore
+  load-bearing — a `.cljc` test whose ns ends in a plain `-test` compiles
+  nowhere but the JVM and reads as covered (rf2-dn6v7, rf2-lgozq)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.router :as router]

--- a/implementation/machines/test/re_frame/region_order_cljs_test.cljc
+++ b/implementation/machines/test/re_frame/region_order_cljs_test.cljc
@@ -1,4 +1,4 @@
-(ns re-frame.region-order-cljc-test
+(ns re-frame.region-order-cljs-test
   "Acceptance coverage for rf2-3fc89f.8 — parallel-region declaration order is
   an EXPLICIT registration contract (`:region-order`), normalised once, and is
   preserved across EVERY order-sensitive parallel operation once the region
@@ -15,7 +15,13 @@
   input, and asserts authored action-data, fx, cascade and spawn order, the
   birth entry cascade, the destroy exit cascade, and the root multi-target
   apply — plus the documented registration outcomes for missing/mismatched
-  order and the ≤8 small-map convenience derivation."
+  order and the ≤8 small-map convenience derivation.
+
+  The `-cljs-test` suffix is what MAKES that parity claim true. Shadow's
+  `:node-test` build selects on `cljs-test$`, so the original
+  `-cljc-test` ns — chosen to advertise dual-target — matched neither
+  lane's CLJS filter, and the CLJ/CLJS parity this file exists to pin had
+  never once been checked on CLJS (rf2-lgozq)."
   (:require [clojure.test :refer [deftest is testing]]
             [re-frame.machines.parallel :as parallel]
             [re-frame.machines.result :as result]))

--- a/implementation/machines/test/re_frame/region_order_lifecycle_test.clj
+++ b/implementation/machines/test/re_frame/region_order_lifecycle_test.clj
@@ -7,7 +7,7 @@
 
   The pure-engine matrix (action-data / fx / cascade / spawn / birth / destroy
   / root-multi-target / rejection / ≤8 convenience) lives in
-  region_order_cljc_test.cljc; this file pins the same core invariant through
+  region_order_cljs_test.cljc; this file pins the same core invariant through
   the registrar + router so the registration-time normalisation is exercised."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]

--- a/implementation/resources/test/re_frame/resources_timer_arm_publish_race_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_timer_arm_publish_race_cljs_test.cljc
@@ -1,4 +1,4 @@
-(ns re-frame.resources-timer-arm-publish-race-test
+(ns re-frame.resources-timer-arm-publish-race-cljs-test
   "Adversarial ordering regressions for the resource stale / GC / poll timer
   two-phase arm (rf2-j538f7.10). Two races the serial suite never exercised:
 
@@ -20,7 +20,12 @@
   interleavings here are driven with `with-redefs` — running the cleanup INSIDE
   the host-arm stub (between reserve and publish), or firing the captured thunk
   synchronously — so BOTH runtimes execute the identical reserve / publish /
-  claim code. Per Spec 016 §Stale and GC scheduling / §Polling."
+  claim code. Per Spec 016 §Stale and GC scheduling / §Polling.
+
+  Dual-target (`.cljc`): the JVM runner selects it on `.*-test$`, Shadow's
+  `:node-test` build on `cljs-test$`. The `-cljs-test` suffix is therefore
+  load-bearing — a `.cljc` test whose ns ends in a plain `-test` compiles
+  nowhere but the JVM and reads as covered (rf2-dn6v7, rf2-lgozq)."
   (:require
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])

--- a/scripts/beads-checkpoint.ps1
+++ b/scripts/beads-checkpoint.ps1
@@ -23,6 +23,10 @@
 # THE FIX: EXPORT FIRST. A checkpoint asks the Dolt database what the tracker
 # says (`bd export`) instead of trusting whatever sits in the working tree.
 #
+# The commit carries the rows that changed and nothing else: `bd export` does
+# not fix the order of the memory rows, so the file is written in minimal-diff
+# order first (rf2-51uz1.1, Write-MinimalDiffOrder below).
+#
 # Usage:
 #   powershell -ExecutionPolicy Bypass -File scripts/beads-checkpoint.ps1
 #   powershell -ExecutionPolicy Bypass -File scripts/beads-checkpoint.ps1 -Message "chore(beads): checkpoint (6931 merged)"
@@ -111,6 +115,74 @@ function Write-HeadCopy {
     }
 }
 
+# Write $Export's rows to $OutFile, but emit every row HEAD already carries in
+# HEAD's order first, and only then the rows that are genuinely new, in export
+# order.
+#
+# WHY (rf2-51uz1.1). Test-SameContent below already stops a reorder-ONLY export
+# from becoming a commit. It does nothing for the normal case: one real row
+# changed, so the checkpoint commits, and the raw export carries every unrelated
+# memory reorder along with it. Measured on the first real checkpoint after this
+# helper landed: 211 additions / 208 deletions staged, of which 200 added rows
+# were byte-identical to 200 removed rows. Pure relocation. Eleven added and
+# eight removed lines were the actual tracker change, buried.
+#
+# The output is the export's row MULTISET exactly - no row is invented, dropped
+# or edited, so `bd import` sees the same database either way. Only the line
+# ORDER differs, and JSONL row order carries no meaning to the importer. What it
+# buys is a diff that is exactly (rows HEAD had and the export does not) plus
+# (rows the export has and HEAD does not): no relocation lines at all.
+#
+# CRLF is stripped so a Windows checkout's `git checkout HEAD -- .beads` copy
+# still matches the LF rows `bd export` emits - the same reason
+# Test-SameContent strips it. Output is LF, byte-for-byte the export's own rows,
+# and UTF-8 WITHOUT a BOM: the tracker is 10 MB of other people's words and a
+# BOM would corrupt the first row.
+function Write-MinimalDiffOrder {
+    param([string]$Export, [string]$HeadCopy, [string]$OutFile)
+
+    $exportLines = foreach ($l in [System.IO.File]::ReadLines($Export)) { $l -replace "`r$", '' }
+    $exportLines = [string[]]$exportLines
+
+    # Remaining count per distinct row, consumed as rows are emitted. An
+    # ordinal comparer so this matches sh's byte comparison rather than the
+    # current culture's collation.
+    $remaining = New-Object 'System.Collections.Generic.Dictionary[string,int]' ([System.StringComparer]::Ordinal)
+    foreach ($l in $exportLines) {
+        if ($remaining.ContainsKey($l)) { $remaining[$l] = $remaining[$l] + 1 }
+        else { $remaining[$l] = 1 }
+    }
+
+    $out = New-Object 'System.Collections.Generic.List[string]' ($exportLines.Count)
+
+    # Pass 1: HEAD's rows, in HEAD's order, for every row the export still has.
+    if (Test-Path -LiteralPath $HeadCopy) {
+        foreach ($raw in [System.IO.File]::ReadLines($HeadCopy)) {
+            $l = $raw -replace "`r$", ''
+            if ($remaining.ContainsKey($l) -and $remaining[$l] -gt 0) {
+                $remaining[$l] = $remaining[$l] - 1
+                $out.Add($l)
+            }
+        }
+    }
+
+    # Pass 2: whatever the export has left over, in export order.
+    foreach ($l in $exportLines) {
+        if ($remaining[$l] -gt 0) {
+            $remaining[$l] = $remaining[$l] - 1
+            $out.Add($l)
+        }
+    }
+
+    $sw = New-Object System.IO.StreamWriter($OutFile, $false, (New-Object System.Text.UTF8Encoding $false))
+    try {
+        $sw.NewLine = "`n"
+        foreach ($l in $out) { $sw.WriteLine($l) }
+    } finally {
+        $sw.Dispose()
+    }
+}
+
 # Same SET of rows, regardless of order.
 #
 # Order matters here because `bd export` does not fix the order of the trailing
@@ -166,6 +238,8 @@ $tmpExport = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(),
                                        "rf2-bdchk-export-$PID.jsonl")
 $tmpHead   = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(),
                                        "rf2-bdchk-head-$PID.jsonl")
+$tmpOrdered = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(),
+                                        "rf2-bdchk-ordered-$PID.jsonl")
 
 try {
     # -----------------------------------------------------------------------
@@ -232,7 +306,24 @@ try {
 
     # The export is trustworthy - it is now the working tracker. From here on
     # the working file cannot be a stale revert, whatever it was a moment ago.
-    Copy-Item -LiteralPath $tmpExport -Destination $tracker -Force
+    #
+    # It is written in MINIMAL-DIFF order (rf2-51uz1.1) rather than raw export
+    # order, so the staged ledger shows the rows that changed and nothing else.
+    # The row-count check is the safety net: the rewrite must reproduce the
+    # export's rows exactly, and if it ever does not, the raw export wins.
+    # Losing a row to a cosmetic reordering would be a far worse bug than the
+    # churn it removes.
+    Write-MinimalDiffOrder -Export $tmpExport -HeadCopy $tmpHead -OutFile $tmpOrdered
+    $orderedRows = Get-RowCount -Path $tmpOrdered
+    if ($orderedRows -eq $exportRows) {
+        Copy-Item -LiteralPath $tmpOrdered -Destination $tracker -Force
+    } else {
+        [Console]::Error.WriteLine(
+            "beads-checkpoint: minimal-diff rewrite produced $orderedRows rows for a " +
+            "$exportRows-row export; committing the raw export instead (order churn, " +
+            'but no lost rows).')
+        Copy-Item -LiteralPath $tmpExport -Destination $tracker -Force
+    }
 
     if (Test-SameContent -A $tracker -B $tmpHead) {
         Write-Output "beads-checkpoint: nothing to checkpoint ($exportRows rows, unchanged)."
@@ -248,5 +339,5 @@ try {
     Write-Output "beads-checkpoint: committed $tracker ($exportRows rows, HEAD had $headRows)."
 }
 finally {
-    Remove-Item -LiteralPath $tmpExport, $tmpHead -Force -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $tmpExport, $tmpHead, $tmpOrdered -Force -ErrorAction SilentlyContinue
 }

--- a/scripts/beads-checkpoint.sh
+++ b/scripts/beads-checkpoint.sh
@@ -30,6 +30,9 @@
 #       Re-export the tracker from the database, sanity-check the result, and
 #       commit `.beads/issues.jsonl` if it changed. This is the checkpoint —
 #       run it BEFORE `git checkout HEAD -- .beads` and the pull, never after.
+#       The commit carries the rows that changed and nothing else: `bd export`
+#       does not fix the order of the memory rows, so the file is written in
+#       minimal-diff order first (rf2-51uz1.1, `minimal_diff_rewrite` below).
 #
 #   sh scripts/beads-checkpoint.sh --pre-pull
 #       Ask whether clearing `.beads` would discard tracker state that HEAD
@@ -102,9 +105,12 @@ fi
 
 TMP_EXPORT=""
 TMP_HEAD=""
+TMP_ORDERED=""
 TMP_A=""
 TMP_B=""
-cleanup() { rm -f "$TMP_EXPORT" "$TMP_HEAD" "$TMP_A" "$TMP_B" 2>/dev/null || true; }
+cleanup() {
+  rm -f "$TMP_EXPORT" "$TMP_HEAD" "$TMP_ORDERED" "$TMP_A" "$TMP_B" 2>/dev/null || true
+}
 trap cleanup EXIT INT TERM HUP
 
 rows() {
@@ -117,6 +123,41 @@ rows() {
 # path does not exist at HEAD (a first-ever checkpoint).
 head_copy() {
   git show "HEAD:$TRACKER" > "$1" 2>/dev/null || : > "$1"
+}
+
+# minimal_diff_rewrite EXPORT HEAD_COPY OUT — write EXPORT's rows to OUT, but
+# emit every row HEAD already carries in HEAD's order first, and only then the
+# rows that are genuinely new, in export order.
+#
+# WHY (rf2-51uz1.1). `same_content` below already stops a reorder-ONLY export
+# from becoming a commit. It does nothing for the normal case: one real row
+# changed, so the checkpoint commits — and the raw export carries every
+# unrelated memory reorder along with it. Measured on the first real checkpoint
+# after this helper landed: 211 additions / 208 deletions staged, of which 200
+# added rows were byte-identical to 200 removed rows. Pure relocation. Eleven
+# added and eight removed lines were the actual tracker change, buried.
+#
+# The output is the export's row MULTISET exactly — no row is invented, dropped
+# or edited, so `bd import` sees the same database either way. Only the line
+# ORDER differs, and JSONL row order carries no meaning to the importer. What it
+# buys is a diff that is exactly (rows HEAD had and the export does not) plus
+# (rows the export has and HEAD does not): no relocation lines at all, from the
+# first checkpoint onward.
+#
+# CRLF is stripped so a Windows checkout's `git checkout HEAD -- .beads` copy
+# still matches the LF rows `bd export` emits — the same reason `same_content`
+# strips it. Output is LF, byte-for-byte the export's own rows.
+minimal_diff_rewrite() {
+  awk '
+    FNR == NR { sub(/\r$/, ""); cnt[$0]++; order[++n] = $0; next }
+    { sub(/\r$/, ""); if (cnt[$0] > 0) { cnt[$0]--; print } }
+    END {
+      for (i = 1; i <= n; i++) {
+        line = order[i]
+        if (cnt[line] > 0) { cnt[line]--; print line }
+      }
+    }
+  ' "$1" "$2" > "$3"
 }
 
 # same_content FILE_A FILE_B — 0 when the two files carry the SAME SET of rows,
@@ -202,7 +243,22 @@ fi
 
 # The export is trustworthy — it is now the working tracker. From here on the
 # working file cannot be a stale revert, whatever it was a moment ago.
-cp -f "$TMP_EXPORT" "$TRACKER"
+#
+# It is written in MINIMAL-DIFF order (rf2-51uz1.1) rather than raw export
+# order, so the staged ledger shows the rows that changed and nothing else. The
+# row-count check is the safety net: the rewrite must reproduce the export's
+# rows exactly, and if it ever does not, the raw export wins. Losing a row to a
+# cosmetic reordering would be a far worse bug than the churn it removes.
+TMP_ORDERED=$(mktemp "${TMPDIR:-/tmp}/rf2-bdchk-ordered-XXXXXX")
+minimal_diff_rewrite "$TMP_EXPORT" "$TMP_HEAD" "$TMP_ORDERED"
+if [ "$(rows "$TMP_ORDERED")" = "$export_rows" ]; then
+  cp -f "$TMP_ORDERED" "$TRACKER"
+else
+  printf 'beads-checkpoint: minimal-diff rewrite produced %s rows for a %s-row export;\n' \
+    "$(rows "$TMP_ORDERED")" "$export_rows" >&2
+  printf '  committing the raw export instead (order churn, but no lost rows).\n' >&2
+  cp -f "$TMP_EXPORT" "$TRACKER"
+fi
 
 if same_content "$TRACKER" "$TMP_HEAD"; then
   printf 'beads-checkpoint: nothing to checkpoint (%s rows, unchanged).\n' "$export_rows"

--- a/scripts/git-hooks/test-pre-commit.sh
+++ b/scripts/git-hooks/test-pre-commit.sh
@@ -56,7 +56,8 @@
 #   8. The checkpoint helper (scripts/beads-checkpoint.sh, rf2-51uz1), driven
 #      against a stub `bd`: a close that lives only in the database survives the
 #      pre-pull checkout, a broken export commits nothing, and a memory reorder
-#      is not a commit.
+#      is not a commit — nor does one ride along with a real change
+#      (rf2-51uz1.1), while the >1/10 shrink guard still refuses.
 #
 # Usage:
 #   sh scripts/git-hooks/test-pre-commit.sh
@@ -1196,6 +1197,13 @@ rm -rf "$RBOX"
 # trusting the working file, which makes the revert unreachable. The cases
 # below drive it against a stub `bd` so the assertions are hermetic and the
 # real tracker is never touched.
+#
+# WHAT THE COMMIT CARRIES is the second axis (rf2-51uz1.1). `bd export` does not
+# fix the order of the memory rows, so a checkpoint that copies the raw export
+# buries the rows that changed under a few hundred relocation lines. 8f pins the
+# reorder-ONLY export producing no commit at all; 8h pins the normal case — one
+# real edit commits exactly that edit — and 8i pins the shrink guard that the
+# ordering work must not cost.
 # ----------------------------------------------------------------------------
 
 printf '\n[8] checkpoint helper: export from the database, never the working file\n'
@@ -1390,6 +1398,98 @@ case "$out" in
     fi ;;
 esac
 git -C "$CREPO" worktree remove --force "$CWORKER" >/dev/null 2>&1 || true
+
+# 8h: A REAL CHANGE COMMITS THE REAL CHANGE ONLY (rf2-51uz1.1). 8f covers the
+# reorder-ONLY export. The case that actually bit was the NORMAL one: a genuine
+# row edit makes the checkpoint commit, and the raw export then carried every
+# unrelated memory reorder along with it — 200 of 211 staged additions were
+# byte-identical to removed lines, so the eleven that mattered were invisible.
+#
+# Here rf2-a closes (the one real edit) while the four untouched memories are
+# shuffled. The commit must show the two rf2-a lines and NOTHING else: no
+# memory row may appear on either side of the diff.
+before=$(git -C "$CREPO" rev-parse HEAD)
+{
+  printf '{"_type":"issue","id":"rf2-a","status":"open"}\n'
+  printf '{"_type":"issue","id":"rf2-b","status":"closed"}\n'
+  printf '{"_type":"memory","key":"m1","value":"one"}\n'
+  printf '{"_type":"memory","key":"m2","value":"two"}\n'
+  printf '{"_type":"memory","key":"m3","value":"three"}\n'
+  printf '{"_type":"memory","key":"m4","value":"four"}\n'
+} > "$CBOX/db.jsonl"
+out=$(run_checkpoint "$CREPO")
+case "$out" in
+  EXIT=0) : ;;
+  *) fail "(8h-seed) could not establish the four-memory baseline ($out)"; cat "$CERR" >&2 ;;
+esac
+
+# Now: rf2-a closes, and the four untouched memories come back in a different
+# order — exactly what `bd export` does on every invocation.
+{
+  printf '{"_type":"issue","id":"rf2-a","status":"closed"}\n'
+  printf '{"_type":"issue","id":"rf2-b","status":"closed"}\n'
+  printf '{"_type":"memory","key":"m3","value":"three"}\n'
+  printf '{"_type":"memory","key":"m1","value":"one"}\n'
+  printf '{"_type":"memory","key":"m4","value":"four"}\n'
+  printf '{"_type":"memory","key":"m2","value":"two"}\n'
+} > "$CBOX/db.jsonl"
+before=$(git -C "$CREPO" rev-parse HEAD)
+out=$(run_checkpoint "$CREPO")
+after=$(git -C "$CREPO" rev-parse HEAD)
+case "$out" in
+  EXIT=0)
+    if [ "$before" = "$after" ]; then
+      fail "(8h) a real row edit produced no commit"
+      cat "$COUT" >&2
+    else
+      # Diff body only: added/removed rows, not the +++/--- headers.
+      cdiff=$(git -C "$CREPO" diff "$before" "$after" -- .beads/issues.jsonl \
+                | grep '^[+-]' | grep -v '^[+-][+-]')
+      churn=$(printf '%s\n' "$cdiff" | grep '"_type":"memory"' || true)
+      real=$(printf '%s\n' "$cdiff" | grep '"id":"rf2-a"' || true)
+      if [ -n "$churn" ]; then
+        fail "(8h) the commit carried memory-row churn alongside the real edit"
+        printf '%s\n' "$churn" >&2
+      elif [ -z "$real" ]; then
+        fail "(8h) the commit did not carry the real edit"
+        printf '%s\n' "$cdiff" >&2
+      elif [ "$(printf '%s\n' "$cdiff" | awk 'END{print NR}')" != "2" ]; then
+        fail "(8h) the commit carried more than the two rf2-a lines"
+        printf '%s\n' "$cdiff" >&2
+      else
+        pass "(8h) a real edit commits ONLY the changed rows; shuffled memories do not move"
+      fi
+      # The committed file must still be the export's row SET, whole — a
+      # cosmetic reordering that loses a row would be the worse bug.
+      if [ "$(git -C "$CREPO" show HEAD:.beads/issues.jsonl | LC_ALL=C sort)" \
+           = "$(LC_ALL=C sort < "$CBOX/db.jsonl")" ]; then
+        pass "(8h) and the committed rows are the export's rows exactly, none lost"
+      else
+        fail "(8h) the minimal-diff rewrite changed the committed ROW SET"
+      fi
+    fi ;;
+  *) fail "(8h) checkpoint failed on a real edit + reordered memories ($out)"; cat "$CERR" >&2 ;;
+esac
+
+# 8i: THE SHRINK GUARD STILL BITES. Not a new behaviour — a regression net for
+# the one it would be tempting to relax while making 8h pass. It fired for real
+# on a deliberate `bd gc` (2642 -> 2372 rows) and correctly refused, sending the
+# operator to a hand commit. A cosmetic-ordering change must not cost that.
+before=$(git -C "$CREPO" rev-parse HEAD)
+printf '{"_type":"issue","id":"rf2-a","status":"closed"}\n' > "$CBOX/db.jsonl"
+out=$(run_checkpoint "$CREPO")
+after=$(git -C "$CREPO" rev-parse HEAD)
+case "$out" in
+  EXIT=0) fail "(8i) a 6-of-7-row shrink was checkpointed; the guard is gone" ;;
+  *)
+    if [ "$before" = "$after" ] && grep -q 'tenth of the' "$CERR" \
+       && grep -q 'untouched' "$CERR"; then
+      pass "(8i) a >1/10 shrink is still refused, and the tracker is untouched"
+    else
+      fail "(8i) the shrink was refused for the wrong reason, or the tree moved"
+      cat "$CERR" >&2
+    fi ;;
+esac
 
 rm -rf "$CBOX"
 

--- a/spec/Design-TransducerRouter.md
+++ b/spec/Design-TransducerRouter.md
@@ -304,4 +304,4 @@ re-evaluated under the new code, but the envelope-seq is replayed verbatim.
 - [011-SSR](011-SSR.md) — frame-per-request + loader fan-in motivating `manual-driver`.
 - [009-Instrumentation](009-Instrumentation.md) — trace-emission sites become the transducer's xform boundaries.
 - `implementation/core/src/re_frame/router_transducer.cljc` — Phase-1 reference scaffold.
-- `implementation/core/test/re_frame/router_transducer_test.cljc` — scaffold unit tests.
+- `implementation/core/test/re_frame/router_transducer_cljs_test.cljc` — scaffold unit tests.

--- a/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
+++ b/tools/xray/src/day8/re_frame2_xray/panels/epoch/projection.cljc
@@ -1538,7 +1538,7 @@
 ;; per `:always` iteration (carrying its own nested exit/action/entry
 ;; `:steps` + `:microstep-index` / `:from` / `:to`). Spec 005 §The
 ;; structured transition cascade is the authoritative contract; the
-;; instrumentation test `re-frame.machine-cascade-instrumentation-test`
+;; instrumentation test `re-frame.machine-cascade-instrumentation-cljs-test`
 ;; pins the exact shape.
 ;;
 ;; This is the data rf2-52u5n renders under EVENT HANDLER. The pre-existing

--- a/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/panels/epoch/projection_cljs_test.cljc
@@ -1604,7 +1604,7 @@
 ;; it through the transition row + groups it per-region for the view.
 ;;
 ;; The HVAC `[:hvac/power-cycle]` cascade below is the contract shape the
-;; instrumentation test (`re-frame.machine-cascade-instrumentation-test`)
+;; instrumentation test (`re-frame.machine-cascade-instrumentation-cljs-test`)
 ;; pins: a parallel machine, climate region (deep compound, exits :idle →
 ;; action @ LCA → 3-level entry descent) + fan region (exit :off → action →
 ;; single entry).

--- a/tools/xray/testbeds/machine_epochs/machines.cljs
+++ b/tools/xray/testbeds/machine_epochs/machines.cljs
@@ -285,7 +285,7 @@
 ;;
 ;; The canonical HARD machine: deep compound nesting, parallel/orthogonal
 ;; regions, observable LCA ordering, internal vs external self-transitions.
-;; Mirrors the `machine_cascade_instrumentation_test` fixture exactly.
+;; Mirrors the `machine_cascade_instrumentation_cljs_test` fixture exactly.
 
 (defmachine hvac-controller-machine
   {:type :parallel


### PR DESCRIPTION
Two mechanical hygiene beads on disjoint surfaces.

## rf2-lgozq — the last nine lane-suffix-less `.cljc` test namespaces

`rf2-dn6v7` (PR #6946) fixed one instance of the repo's false-green class: a `.cljc` test whose namespace ends in a plain `-test`. The JVM runner selects on `.*-test$` and picks it up; Shadow's `:node-test` build selects on `:ns-regexp "cljs-test$"` and never compiles it. The file reads as covered and runs on one host. A census found nine more, and each got the per-file ruling the bead asked for rather than a blanket rename.

**The census is exactly the bead's nine.** A sweep of all 363 `.cljc` files under an `implementation/` test dir finds 59 namespaces without a lane suffix, but 50 of those are *support* namespaces whose ns does not end in `-test` at all (`re-frame.machines.test-support`, the freehand view fixtures, `re-frame.timer-probe`, …) — neither lane ever selected them as suites, so they are not in the class. Filter to "ns ends `-test`, suffix is neither `-cljs-test` nor `-jvm-test`" and the roster is the bead's nine, no more and no fewer. **Re-run after rebasing onto current `main`: 0 remaining.** The class is empty.

`core/test`, `machines/test` and `resources/test` are all already on the `:node-test` build's `:source-paths`, so the `cljs-test$` regexp was the only thing keeping these files off the CLJS lane.

### Eight were silently half-covered → `-cljs-test`

| file (artefact) | deftests | why it is dual-target |
| --- | --- | --- |
| `router_front_of_queue_cljs_test.cljc` (core) | 4 | pure router queue-insertion semantics, `plain-atom` substrate |
| `router_transducer_cljs_test.cljc` (core) | 12 | pure-fn scaffold: no registrar, no router, no substrate |
| `after_timer_arm_publish_race_cljs_test.cljc` (machines) | 5 | **authored** dual-target |
| `join_attempt_effect_path_cljs_test.cljc` (machines) | 9 | **authored** dual-target |
| `machine_cascade_instrumentation_cljs_test.cljc` (machines) | 7 | trace-shape assertions over a `plain-atom` frame |
| `machine_front_of_queue_cljs_test.cljc` (machines) | 3 | the marking seam, host-neutral |
| `region_order_cljs_test.cljc` (machines) | 13 | pure engine, no runtime/fixture |
| `resources_timer_arm_publish_race_cljs_test.cljc` (resources) | 4 | **authored** dual-target |
| | **57** | |

Three were *authored* dual-target — reader-conditional `clojure.test` / `cljs.test` requires, and docstrings asserting that "BOTH runtimes execute the identical reserve / publish / claim code". They had never executed on one of them.

**`region_order` is the sharpest case.** Its ns was `re-frame.region-order-cljc-test`: the `-cljc-` was chosen to advertise dual-target and matched no lane's CLJS filter. The file exists to pin CLJ/CLJS parity for `rf2-3fc89f.8`, whose bug *was* `(keys (:regions …))` hash order differing between the two hosts ("r7,r6,r8,r2,… in CLJ, a DIFFERENT order in CLJS", per its own docstring). Thirteen tests asserting cross-host parity, and the CLJS host had never run them. **All 13 pass on CLJS unmodified** — the parity claim was true, it had simply never been checked.

### One is legitimately JVM-only and now says so → `-jvm-test`

`source_coord_jvm_test.cljc` (core, 8 deftests). It is the JVM half of a **deliberate pair**: `source_coord_cljs_test.cljs` already exists beside it as the purpose-written CLJS half ("CLJS-side smoke check", 4 deftests), and the two docstrings cross-reference each other. Renaming this one to `-cljs-test` would have collided with that file's namespace and duplicated its coverage. The explicit `-jvm-test` records that skipping the CLJS lane is the intent, not the rf2-dn6v7 omission.

### Proof it now runs on both lanes, per file

A plain `clojure.test` require is **not** a barrier, worth stating because five of the nine have one and no reader conditionals at all. `cljs.analyzer/rewrite-cljs-aliases` ("Alias non-existing `clojure.*` namespaces to existing `cljs.*` namespaces if possible") rewrites `clojure.test` → `cljs.test` at analysis time. Verified in the ClojureScript 1.12.145 jar on the classpath, then empirically below — **no reader conditionals were added to any file**.

**CLJS lane** (`npm run test:cljs`, the `:node-test` build). A controlled pair — same box, same base commit (`41aed31d`), the renames the only variable:

| | tests | assertions | failures | errors | exit |
| --- | --- | --- | --- | --- | --- |
| before | 11251 | 56371 | 0 | 0 | 0 |
| after | 11308 | 56569 | 0 | 0 | 0 |
| **delta** | **+57** | +198 | — | — | — |

**+57 is exactly the deftest column above** (4+12+5+9+7+3+13+4). Every newly-selected test in every one of the eight files executes, none silently dropped — and the arithmetic also confirms `source_coord`'s 8 are correctly *not* on this lane, which is the `-jvm-test` ruling holding. Re-run after rebasing onto `f1aa71c3`: **11336 tests, 56707 assertions, 0 failures, 0 errors** — the absolute number is higher because 20 commits landed underneath, which is why the delta above is quoted from the single-base pair rather than across the rebase. Per-file confirmation each namespace is genuinely in the build, not merely renamed:

| namespace | in the `:node-test` build | deftests running |
| --- | --- | --- |
| `re-frame.router-front-of-queue-cljs-test` | yes | 4/4 |
| `re-frame.router-transducer-cljs-test` | yes | 12/12 |
| `re-frame.after-timer-arm-publish-race-cljs-test` | yes | 5/5 |
| `re-frame.join-attempt-effect-path-cljs-test` | yes | 9/9 |
| `re-frame.machine-cascade-instrumentation-cljs-test` | yes | 7/7 |
| `re-frame.machine-front-of-queue-cljs-test` | yes | 3/3 |
| `re-frame.region-order-cljs-test` | yes | 13/13 |
| `re-frame.resources-timer-arm-publish-race-cljs-test` | yes | 4/4 |
| `re-frame.source-coord-jvm-test` | **no, by ruling** | its `.cljs` mirror runs there |

**JVM lane** — a rename to either suffix keeps matching cognitect-test-runner's `.*-test$`, so the JVM count must be *unchanged*. That it is, is the no-regression half of the proof. Before = CI on `main` at `b23754d1` (pre-rename); after = this box, rebased:

| artefact | before — CI on `main` @ `b23754d1` | after — this box, rebased | exit |
| --- | --- | --- | --- |
| `implementation/core` | 2114 tests, 10449 assertions | **2114 tests, 10449 assertions** | 0 |
| `implementation/machines` | 1195 tests, 4164 assertions | **1195 tests, 4164 assertions** | 0 |
| `implementation/resources` | 704 tests, 6613 assertions | **704 tests, 6613 assertions** | 0 |

All three identical across the rename, which is the expected result and the one worth checking: nothing left the JVM lane. (PR #6946 reported resources JVM as 704 / 6613, matching exactly.) An earlier local run of core read 2111 / 10440 — that was the 20-commit-stale base, not a platform difference; on the rebased tree it agrees with CI to the assertion.

### Two lanes disagreed, and that is the bead working

The first push went red on exactly two gates — `CLJS (:node-test)` and `JVM core` — while JVM machines and JVM resources stayed green. Both causes were found and fixed. Neither was a stale `:require` or a runner-regex change: all nine ns forms match their paths, and both selectors still match both suffixes.

1. **JVM core** — `source_coord_jvm_test.cljc:224` asserted on its **own filename**: `(re-find #"source_coord_test" (:file cs))`, checking a captured `:rf.trace/call-site` points at this file. The rename falsified it. Regex updated to `source_coord_jvm_test`. A rename is the only thing that could have broken this assertion, and it caught it.

2. **CLJS** — all 7 tests in `machine_cascade_instrumentation_cljs_test.cljc` errored with `No protocol method IDeref.-deref defined for type undefined`. **This is the JVM-only assumption the rename exposed, and the point of the bead.** `mtest/with-trace-capture` is a `#?(:clj (defmacro …))` in a `.cljc` support ns, so the CLJS analyzer never saw it as a macro: the call compiled to a function call on an undefined var and `@seen` deref'd `undefined`. On the JVM the macro resolves directly, so the file had passed its whole life on the one host that could run it.

   Fixed by requiring the support ns as a **macro** ns under the same alias — `#?(:cljs (:require-macros [re-frame.machines.test-support :as mtest]))` — the same shape as `observation_port_cljs_test.cljc`, the existing precedent for a `.cljc` test consuming a `#?(:clj defmacro)` from elsewhere.

   **Not a weakening.** No assertion, fixture or expectation changed; the diff is one ns-form line making an existing macro visible to the second compiler. All 7 tests pass on both hosts on their original assertions. Nothing in this PR makes a single-host test pass by relaxing it — the one file that genuinely belongs to a single host (`source_coord`) was left there and labelled, not forced.

Also three stale extension-less doc references the first sweep missed (it matched the ns symbol and the filename *with* extension, not the bare stem): `join_reap_auth_test.clj`, `dispatch_to_system_fx_cljs_test.cljc`, and the Xray machine-epochs testbed. `.github/workflows/test.yml` and `machine_source_coord_cljs_test.cljs` also substring-match, but on `ssr_source_coord_test` / `machine_source_coord_test.clj` — different files, correctly left alone.

### On a mechanical guard for the class

**Not added, deliberately, and the bead sanctions saying so.** After this PR the census returns 0, and a checker would have to encode the `-jvm-test` ruling as an accept — so it can only catch the omission for someone who forgot a suffix entirely, which is the same author who would add `-jvm-test` to silence it. That converts a reviewable ruling into a lint suppression. The nine docstrings now each state which lane selects the file and why the suffix is load-bearing, which is the durable form of the same knowledge, sitting where the mistake gets made. If the class recurs, that is the moment to reconsider; the census query is three lines and is recorded above.

## rf2-51uz1.1 — `beads-checkpoint` no longer commits memory-row churn

`bd export` does not fix the order of the trailing memory rows, so two exports of an unchanged database differ by reordering alone. #6936 handled the reorder-**only** case: `same_content` / `Test-SameContent` compare sorted row sets, so a pure reorder produces no commit.

It did nothing for the normal case. Any genuine row change makes the checkpoint commit, and it then copied the **raw** export, carrying every unrelated memory reorder with it. Measured on the first real checkpoint after #6936: 211 additions / 208 deletions staged, of which 200 added rows were byte-identical to 200 removed rows. Pure relocation. The eleven added and eight removed lines that were the actual tracker change were buried in it.

Both helpers now write the tracker in **minimal-diff order** before the copy — `minimal_diff_rewrite` (awk, POSIX sh) and `Write-MinimalDiffOrder` (ordinal-comparer dictionary, PowerShell): every row HEAD already carries, in HEAD's order, then the rows that are genuinely new, in export order. The output is the export's row **multiset** exactly — no row invented, dropped or edited — so `bd import` sees the same database either way, and JSONL row order carries no meaning to the importer. The staged diff becomes exactly (rows HEAD had and the export does not) plus (rows the export has and HEAD does not): no relocation lines at all.

A row-count check is the safety net: if the rewrite ever fails to reproduce the export's row count, the raw export is committed instead and the mismatch printed. Losing a row to a cosmetic reordering would be far worse than the churn it removes.

### Decisions this implements

- **HEAD-order preservation, not a canonical sort.** The bead offered both. A canonical sort makes the file a pure function of database content, the more elegant property — but its *first* commit necessarily carries the whole one-time reorder, the exact diff this change exists to remove, and the acceptance criterion is "commit the real change without reorder-only diff lines". HEAD-order preservation is minimal from commit one. The cost: new rows land at the tail rather than in bd's canonical position, so file order drifts from a fresh export's over time. For a generated ledger whose only human use is `git diff` review, minimal-diff is the right target.
- **The >1/10 shrink guard is untouched, and now has a regression test.** It fired correctly on a deliberate `bd gc` (2642 → 2372 rows) and refused, directing a hand commit after the shrink was confirmed genuine. That is the guard working, not a bug. Layer 8i pins it so the ordering work cannot quietly cost it.
- **`--pre-pull` and the linked-worktree refusal are unchanged.**

### Layer 8 gains two cases, and the new one was proved to bite

- **8h** — one real edit (`rf2-a` closes) plus four *untouched* memories shuffled. The commit must carry exactly two lines, both `rf2-a`, and no memory row on either side; and the committed row set must still equal the export's, so a cosmetic reorder cannot lose a row.
- **8i** — the shrink guard still refuses a >1/10 shrink and leaves the tracker untouched.

**Negative control, both siblings.** Layer 8 harnesses only the `.sh` (as in #6936), so the `.ps1` was driven through the same two cases in a throwaway sandbox against a stub `bd`. Each was then re-run against `git show HEAD:` — the pre-fix script — to confirm the test fails without the fix rather than passing vacuously:

| script | pre-fix (control) | post-fix |
| --- | --- | --- |
| `beads-checkpoint.sh` | 8h **FAIL**, churn shown: `-m1 -m2 +m1 +m2` | 8h PASS |
| `beads-checkpoint.ps1` | ps-8h **FAIL**, same signature | ps-8h PASS |
| both, shrink guard | 8i / ps-8i PASS | 8i / ps-8i PASS |

The live tracker was never touched: every case runs in a `mktemp` sandbox repo against a stub `bd`, and `.beads/issues.jsonl` is not in this PR.

## Quality gates

Rebased onto `origin/main` (`f1aa71c3`) and re-run; exit codes captured directly from the runner, never through a pipe.

| gate | result | exit |
| --- | --- | --- |
| `npm run test:cljs` — CLJS lane, BEFORE the renames (base `41aed31d`) | 11251 tests, 56371 assertions, 0 failures, 0 errors | 0 |
| `npm run test:cljs` — CLJS lane, AFTER, same base | 11308 tests, 56569 assertions, 0 failures, 0 errors | 0 |
| `npm run test:cljs` — CLJS lane, rebased on `f1aa71c3` | 11336 tests, 56707 assertions, 0 failures, 0 errors | 0 |
| `clojure -M:test` in `implementation/core` (rebased) | 2114 tests, 10449 assertions, 0 failures, 0 errors | 0 |
| `clojure -M:test` in `implementation/machines` (rebased) | 1195 tests, 4164 assertions, 0 failures, 0 errors | 0 |
| `clojure -M:test` in `implementation/resources` (rebased) | 704 tests, 6613 assertions, 0 failures, 0 errors | 0 |
| `sh scripts/git-hooks/test-pre-commit.sh` (8 layers, +8h +8i), rebased | 59 passed, 0 failed | 0 |
| same suite against pre-fix `beads-checkpoint.sh` (negative control) | 58 passed, **1 failed** — 8h, as intended | 1 |
| `.ps1` sibling parity in a sandbox (ps-8h, ps-8i) | 3 assertions, all pass | 0 |
| `.ps1` parity against pre-fix `.ps1` (negative control) | ps-8h **FAIL**, as intended | 1 |
| census: lane-suffix-less `.cljc` test namespaces remaining | **0** | — |
| `scripts/test-fast-pr.sh` (28 gate steps, rebased) | `PASS fast PR spine` | 0 |

`mkdocs` is not on `PATH` on this box, so `test-fast-pr.sh` soft-skips only that one step by design (CI runs it); every other step of the spine ran and passed.

**CI on the pushed branch: 64 pass, 0 fail, 9 skipping.** Both gates that were red on the first push — `CLJS (shadow-cljs :node-test)` and `JVM core (clojure -M:test)` — now pass, as do `JVM machines`, `JVM resources` and `Freehand conformance index`.
