### PR TITLE
docs(claude-md): cut the derivable layout tour, keep the bundle-isolation prohibition

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,13 +111,10 @@ Docs build from repo root with `mkdocs build --strict` (config in `mkdocs.yml`).
 
 **The spec is the artefact; the code is downstream.** The normative description of re-frame2 lives in [`spec/`](spec/) (~22K lines across 35+ documents); [`implementation/`](implementation/) is a CLJS reference that validates the spec end-to-end. See the repo-root [`README.md`](README.md) for the marketing-voice introduction and the project-layout map, and [`spec/README.md`](spec/README.md) for the spec index.
 
-Top-level layout:
+Status that the directory tree does not tell you: under `implementation/`, `ui/` (re-frame.ui) is the **EXPERIMENTAL** compiled-view substrate, offered alongside the `adapters/` (Reagent, reagent-slim, UIx), which are **first-class and actively supported**.
 
-- `implementation/` — CLJS reference: `core/` + `ui/` (re-frame.ui, the EXPERIMENTAL compiled-view substrate, offered alongside the adapters) + per-substrate `adapters/` (Reagent, reagent-slim, UIx — first-class, actively supported) + per-feature artefacts (machines, schemas, resources, …). The top-level `implementation/shadow-cljs.edn` + `implementation/deps.edn` coordinate the cross-artefact classpath.
-- `tools/` — dev/inspection tools that consume the Spec 009 instrumentation API and Tool-Pair contract (`template/`, `story/`, `story-mcp/`, `re-frame2-pair-mcp/`, `xray/`, `machines-viz/`, `testbed-support/`, `mcp-base/`, `mcp-conformance/`). Bundle-isolated from production builds; nothing in `implementation/` may `:require` from `tools/`.
+`tools/` holds dev/inspection tools consuming the Spec 009 instrumentation API and Tool-Pair contract. They are bundle-isolated from production builds: **nothing in `implementation/` may `:require` from `tools/`.**
 
 ## Conventions & Patterns
 
 Normative conventions are catalogued in [`spec/Conventions.md`](spec/Conventions.md) — reserved namespaces (the `:rf/*` single-root scheme), reserved fx-ids, reserved app-db keys, the feature-modularity id-prefix convention, and packaging conventions. [`spec/Principles.md`](spec/Principles.md) carries the nine AI-first practical principles. [`spec/Ownership.md`](spec/Ownership.md) maps every contract surface to its owning spec — the "where does X live?" reference.
-
-Hot-zone files (sequential, never parallel — see the Workflow section above for the list) and isolated surfaces (safe to parallel) are documented in the dispatch rules above; new beads should respect that split to minimise merge conflicts.


### PR DESCRIPTION
A small, already-approved `CLAUDE.md` trim from a `/doctor` pass: 2 insertions, 5 deletions, nothing else in the file changes. It lands from a worker branch rather than the mayor checkout because `CLAUDE.md` is a worker-tracked surface and the mayor-boundary pre-commit hook (`rf2-ydl2p`) allows only `.beads/issues.jsonl` and `MEMORY.md` from the primary checkout.

## What changed

**`## Architecture Overview`** — the `Top-level layout:` heading and its two bullets are replaced by two paragraphs carrying only the non-derivable content.

**`## Conventions & Patterns`** — the closing paragraph is deleted.

## Rationale

Every session pays for `CLAUDE.md` on the way in, so the test for a line is whether a session could get the same information from the repo itself.

- **The layout bullets duplicated `README.md`**, which the paragraph immediately above them already points at for "the project-layout map". A session can reconstruct a directory listing; it cannot reconstruct *which substrate is experimental versus first-class*. So the derivable enumeration goes and the status claim stays — now stated as exactly that: status the directory tree does not tell you.
- **The bundle-isolation prohibition is preserved verbatim** — `nothing in implementation/ may :require from tools/`. Safety-critical prohibitions are keep-always, so it was deliberately lifted out of the deleted bullet into its own paragraph rather than lost along with it.
- **The Conventions paragraph was purely self-referential**: it described the hot-zone split and then pointed at this same file's own Workflow section for the actual list. The Workflow section carries both the list and the rule; the summary added nothing a reader of that section did not already have.

Two other candidate cuts were considered and **rejected**:

- The `bd` **Quick Reference** sits inside a tool-generated block (`<!-- BEGIN BEADS INTEGRATION v:1 ... hash:ca08a54f -->`). Editing it would drift the content hash, so it stays untouched.
- The **test-script block's annotations** ("fast pre-checkin spine" vs "expensive local/release-sized sweep") are non-guessable command knowledge. `ls scripts/` gives you the filenames but not which one to reach for before a checkin.

## Quality gates

Three separate things read `CLAUDE.md`, so all of them ran in this worktree, foreground, with the exit code captured directly (never through a pipe).

| Gate | Exit code |
| --- | --- |
| `python -m mkdocs build --strict` | **0** |
| `scripts/check_retired_composition_vocab.py` | **0** |
| `scripts/check-ai-tracking-ratchet.sh` | **0** |
| `scripts/test-fast-pr.sh` | **0** |

`mkdocs build --strict` was run **directly** rather than relying on `scripts/test-fast-pr.sh`, because that script soft-skips its own mkdocs step when mkdocs is off `PATH` and still exits 0 — its exit code does not cover the docs build.
