### PR TITLE
spec/conformance: the S4 profile stops claiming host-React escapes are enumerable (rf2-wjgle)

### DIFF
--- a/spec/conformance/S4-view-conformance-profile.md
+++ b/spec/conformance/S4-view-conformance-profile.md
@@ -191,11 +191,17 @@ React verbatim may be a **portal**, and a portal renders into whatever container
 the caller names, `document.head` included. Nodes placed that way are host
 behaviour the **caller owns** — outside head ordering, de-duplication,
 precedence, and every hydration guarantee, `:rf/head-hash` mismatch detection
-included. What survives is **enumerability**: every site declares the `:raw`
-capability and is recorded in the manifest, so the set of such escapes is finite
-and listable. The **JVM tree has no such route** — `:raw` raises
-`:rf.error/jvm-host-op` — so a server-rendered head still comes only from
-`reg-head` / `active-head`.
+included. **Enumerability is not what survives** (rf2-wjgle). The `:raw`
+capability makes `ui/raw`'s *own* sites listable in the manifest, but that hatch
+is not the only way into host React: a runtime **React element** reaching an
+ordinary dynamic child position is handed to React with nothing recorded at the
+site, so the escapes a manifest can list are a strict subset of the escapes that
+exist. The normative statement — and the open design question a real containment
+would have to answer — is
+[004D §The document head is host-owned](../004D-Freehand-Compiled-Grammar.md#the-document-head-is-host-owned).
+What *does* survive is the JVM's absence: the **JVM tree has no such route** —
+`:raw` raises `:rf.error/jvm-host-op` — so a server-rendered head still comes
+only from `reg-head` / `active-head`.
 
 **Normative ownership (ruled, `rf2-3i7tr`) — do not reopen.** Spec 004
 normatively owns the compiled-view *structural absence* (no `ui/head`, no head


### PR DESCRIPTION
Work in progress — rf2-wjgle landed, rf2-xoei9 (004D's retired Freehand frame
family) to follow on this branch. Body and gate exit codes are rewritten when the
second commit lands.

## rf2-wjgle — the S4 conformance profile repeated a corrected claim

PR #6942 corrected 004D's host-React enumerability argument, but §3 of
`spec/conformance/S4-view-conformance-profile.md` still carried the sentence it
corrected: *"every site declares the `:raw` capability and is recorded in the
manifest, so the set of such escapes is finite and listable."*

§3 now says enumerability is not what survives, names the unrecorded
React-element route, and points at 004D for the normative statement. The
host-owned-head ruling (rf2-3i7tr) and the JVM absence are preserved verbatim.

## Quality gates

Not yet run — this PR is opened at first commit per the dispatch protocol and
gated before review.
