### PR TITLE
feat(freehand): the minimal current-occurrence index and the bounded explain-render over the Spec 009 ring (rf2-xftdv, rf2-cpfbg)

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/cell.cljc
+++ b/implementation/freehand/src/re_frame/freehand/cell.cljc
@@ -79,6 +79,7 @@
             [re-frame.freehand.eq :as eq]
             [re-frame.freehand.events :as events]
             [re-frame.freehand.evidence :as evidence]
+            [re-frame.freehand.occurrences :as occurrences]
             [re-frame.interop :as interop]
             [re-frame.router :as router]
             [re-frame.substrate.observation :as obs]))
@@ -841,11 +842,26 @@
 ;; `false`, the branch DCEs, and neither the record construction nor the
 ;; evidence schema it reaches survives into a production bundle.
 ;;
-;; This is a SEAM, not an evidence framework: it validates a record and hands
-;; it to whatever sink is installed. The default sink is nil — nothing is
-;; retained here, exactly as `re-frame.freehand.evidence` retains nothing (its
-;; `retention` names Spec 009's per-frame ring and no second store). The
-;; accumulator that folds these records is downstream (rf2-drpa3.167).
+;; This is a SEAM, not an evidence framework: it validates the commit's facts,
+;; writes ONE row for the committing occurrence into the dev-only
+;; current-occurrence index (`re-frame.freehand.occurrences`, rf2-xftdv), and
+;; hands the validated record to whatever sink is installed. The default sink
+;; is nil. Neither half accumulates: the index REPLACES an occurrence's row on
+;; each commit and drops it at disconnect, and `re-frame.freehand.evidence`
+;; retains nothing at all (its `retention` names Spec 009's per-frame ring and
+;; no second store). The cumulative per-occurrence accumulator was ruled out
+;; permanently (rf2-drpa3.167, REPLACE), not deferred.
+;;
+;; WHY THE INDEX IS WRITTEN HERE AND NOT INSTALLED AS THE SINK. An MCP
+;; inspector attaches LATE, to an application that has been mounting and
+;; re-rendering for minutes. A sink installed at attach time sees only the
+;; commits that happen after it, so an index installed there could never
+;; answer "what is mounted right now" — the one question that justifies keeping
+;; any live state. And the sink is a SINGLE slot that `set-evidence-sink!`
+;; replaces, so an index occupying it would be evicted the moment a tool
+;; installed its own push consumer, silently. The substrate therefore maintains
+;; the index itself, under the same dev gate, and leaves the sink to the
+;; consumer it is for.
 ;;
 ;; TWO PLANES, split along the publication line. The installed sink is an
 ;; observability CONSUMER of the commit, never an authority over it, so its
@@ -878,19 +894,26 @@
   render path's evidence sink, and answer the PRIOR sink. `nil` restores
   the no-op default.
 
-  The seam builds a record only when a sink is installed AND
+  The seam builds a RECORD only when a sink is installed AND
   `interop/debug-enabled?` is true, so an application that installs no sink
-  pays nothing beyond the folded-away gate.
+  pays only the commit's own facts — the validated projection the
+  current-occurrence index rows — beyond the folded-away gate.
 
-  What installs here is a MINIMAL CURRENT-OCCURRENCE INDEX — insert-or-update
-  on the selected commit, remove on disconnect, one row per live occurrence
-  (rf2-xftdv), read by the bounded `explain-render` over Spec 009's existing
-  retained ring (rf2-cpfbg). NOT a cumulative per-cell accumulator: the donor's
-  per-occurrence evidence accumulator was ruled out permanently (rf2-drpa3.167,
-  REPLACE), so nothing crossing this seam keeps lifetime counts, an interval
-  ledger, or a second retention knob. This docstring used to say downstream
-  tooling \"installs the accumulator here\", which named the design that ruling
-  rejected."
+  What installs here is a PUSH CONSUMER: a tool that wants to be told about
+  each selected commit as it happens (Xray's live panels are the shape).
+  Nothing crossing this seam keeps lifetime counts, an interval ledger, or a
+  second retention knob — the donor's per-occurrence evidence accumulator was
+  ruled out permanently (rf2-drpa3.167, REPLACE).
+
+  The MINIMAL CURRENT-OCCURRENCE INDEX (rf2-xftdv) does NOT install here, and
+  an earlier draft of this docstring saying it did was wrong for two reasons.
+  A sink installed at attach time sees only later commits, so an index living
+  in this slot could not answer \"what is mounted right now\" for anything that
+  connected before the inspector arrived — the whole point of the index. And
+  this is one slot that `set-evidence-sink!` REPLACES, so the index would be
+  evicted the moment a push consumer installed itself. The substrate maintains
+  the index at the commit seam instead; `re-frame.freehand.tool/read-mounted-views`
+  and `explain-render` read it."
   [f]
   (let [prev @evidence-sink]
     (reset! evidence-sink f)
@@ -931,33 +954,82 @@
    :key    #?(:clj  (System/identityHashCode cell)
               :cljs (goog/getUid cell))})
 
-(defn- commit-evidence-record
-  "DEV-GATED, BEFORE publication: when a sink is installed, build the commit
-  occurrence-record for `cell` at `lowering` / `generation` and VALIDATE it
-  through `re-frame.freehand.evidence/record`. Answers `[sink record]` — the
-  captured sink and its validated record — for delivery once the bundle is
-  live, or nil when the seam is inert (no sink, or debug disabled).
+(defn- commit-facts
+  "The facts the SELECTED commit already has, read off the bundle it is about
+  to publish: the generation, the frame it bound to, and the subscription
+  sites it staged — WITHOUT the values those reads returned, which are
+  application data and not a fact about the view.
 
-  FAIL-LOUD on a malformed FRAMEWORK record: `evidence/commit-record` throws
-  HERE, before `commit!` publishes anything, so an emission the schema refuses
-  aborts the whole commit rather than reaching a reader or leaving a
-  half-published bundle. That is the framework plane and it stays loud — only
-  the CONSUMER's own failure (the sink throwing) is contained, downstream and
-  only after a selected publication.
+  Read off the bundle rather than off the cell because the bundle is the
+  commit's own truth a moment before it becomes the cell's: the cell still
+  holds the PRIOR commit's dependency set at this point in `commit!`, so
+  asking the cell would describe the render before this one."
+  [bundle]
+  {:generation (:generation bundle)
+   :frame      (:frame bundle)
+   :reads      (mapv #(select-keys % [:site-key :query :frame-id :owned?])
+                     (:observations bundle))})
+
+(defn- commit-evidence
+  "DEV-GATED, BEFORE publication: build and VALIDATE what the selected commit
+  publishes about itself. Answers `{:occurrence … :row … :sink … :record …}`,
+  or nil when the whole plane is off (debug disabled).
+
+    - `:row` is the current-occurrence index row — the occurrence's identity,
+      its lowering, and the validated [[re-frame.freehand.evidence/commit-projection]]
+      of this commit's facts. Built on EVERY commit, because the index is the
+      substrate's own and does not wait for a tool to attach.
+    - `:record` is the full evidence record, built ONLY when a sink is
+      installed, because it is the sink's contract and nobody else's.
+
+  FAIL-LOUD on a malformed FRAMEWORK emission: the evidence doors throw HERE,
+  before `commit!` publishes anything, so an emission the schema refuses aborts
+  the whole commit rather than reaching a reader or leaving a half-published
+  bundle. That is the framework plane and it stays loud — only the CONSUMER's
+  own failure (the sink throwing) is contained, downstream and only after a
+  selected publication.
 
   The sink is captured together with its record so the tool that was installed
   when the commit began is the one delivered to, even if a listener the publish
   fires swaps the sink mid-flush.
 
+  `:at` on the row is the commit's monotonic clock reading, on the same
+  `interop/now-ms` axis every trace event's `:time` carries. It is one number
+  about NOW, not an interval and not a ledger, and it is here because it is what
+  lets a later read PROVE eviction: a retained window whose oldest event is
+  younger than the commit cannot contain that commit's cause, and saying so is
+  the difference between reporting loss and inventing an explanation.
+
   The `interop/debug-enabled?` gate stands alone as the body's outermost form,
   so under `:advanced` with `goog.DEBUG=false` Closure folds it to `false`, the
-  branch DCEs, and neither the record construction nor the evidence schema it
-  reaches survives into a production bundle."
-  [^ViewCell cell lowering generation]
+  branch DCEs, and neither the row, the record, the index nor the evidence
+  schema they reach survives into a production bundle."
+  [^ViewCell cell lowering bundle]
   (when interop/debug-enabled?
-    (when-let [sink @evidence-sink]
-      [sink (evidence/commit-record (view-id cell) lowering
-                                    (occurrence-of cell) generation)])))
+    (let [occurrence (occurrence-of cell)
+          facts      (commit-facts bundle)
+          sink       @evidence-sink]
+      (cond-> {:occurrence occurrence
+               :row        {:view-id    (view-id cell)
+                            :occurrence occurrence
+                            :lowering   lowering
+                            :generation (:generation facts)
+                            :connection :connected
+                            ;; Root identity is not a fact this seam has: roots
+                            ;; own cells, cells do not own roots, and nothing on
+                            ;; the commit path carries the owning root's id. So
+                            ;; the row says so EXPLICITLY rather than omitting
+                            ;; the key — an absent key reads as "none" at a
+                            ;; glance, which is the one shape this schema exists
+                            ;; to refuse, and cell-to-root attribution is
+                            ;; precisely what rf2-drpa3.167 ruled would not be
+                            ;; built.
+                            :root       evidence/unknown
+                            :at         (interop/now-ms)
+                            :commit     (evidence/commit-projection facts)}}
+        sink (assoc :sink   sink
+                    :record (evidence/commit-record (view-id cell) lowering
+                                                    occurrence facts))))))
 
 (defn- report-sink-escape!
   "Contain a THROWING evidence sink: record the escape in the single bounded
@@ -985,10 +1057,17 @@
   nil)
 
 (defn emit-commit-evidence!
-  "DEV-GATED, AFTER publication: deliver the pre-built, pre-validated `captured`
-  record to the installed sink, CONTAINING any failure the sink CONSUMER
-  raises. `captured` is the `[sink record]` [[commit-evidence-record]] built
-  and validated BEFORE the publish, or nil when the seam is inert.
+  "DEV-GATED, AFTER publication: row the committing occurrence in the
+  current-occurrence index, then deliver the pre-built, pre-validated record to
+  the installed sink, CONTAINING any failure the sink CONSUMER raises.
+  `captured` is what [[commit-evidence]] built and validated BEFORE the publish,
+  or nil when the whole plane is off.
+
+  THE INDEX WRITE COMES FIRST, and outside the guard. It is the substrate's own
+  bookkeeping over a commit that is already live, so a sink reading
+  `re-frame.freehand.tool/read-mounted-views` from inside its own callback sees
+  the commit it was just handed — and a sink that throws cannot leave the index
+  disagreeing with the cell about what is connected.
 
   The sink is an observability consumer of the commit, not an authority over
   it: a tool callback that throws must not turn a live, published, connected
@@ -999,13 +1078,14 @@
   A normal (non-throwing) sink receives the captured record EXACTLY ONCE per
   selected commit — the one `sink` call below. The `interop/debug-enabled?`
   gate stands alone so the whole delivery-and-containment machinery DCEs under
-  `:advanced` with `goog.DEBUG=false`, alongside the record it consumes."
+  `:advanced` with `goog.DEBUG=false`, alongside the row and record it carries."
   [^ViewCell cell captured]
   (when interop/debug-enabled?
     (when captured
-      (let [[sink record] captured]
+      (occurrences/observe! (:occurrence captured) (:row captured))
+      (when-let [sink (:sink captured)]
         (try
-          (sink record)
+          (sink (:record captured))
           (catch #?(:clj Throwable :cljs :default) e
             (report-sink-escape! (view-id cell) e))))))
   nil)
@@ -1076,21 +1156,22 @@
                                                    :value    (:value (get readings k))
                                                    :owned?   (obs/owned? (:handle r))}))
                                               order)}
-                ;; Build and VALIDATE the dev evidence record BEFORE the publish
-                ;; below — the two-plane split: a malformed FRAMEWORK
+                ;; Build and VALIDATE the dev evidence BEFORE the publish below —
+                ;; the two-plane split: a malformed FRAMEWORK projection or
                 ;; record fails loud here, so a commit the schema would refuse
                 ;; publishes nothing and the all-or-nothing boundary holds. The
-                ;; CONSUMER sink is not called yet — only after the bundle is
-                ;; live, where its failure is contained rather than fatal. Not
-                ;; callback-capable (it derefs the sink slot and validates a
-                ;; value — no app code), so it sits between the currency re-check
-                ;; and the publish without reopening that window. Like the
-                ;; acquisition and commit-read failures above, a throw here
-                ;; releases this candidate's freshly acquired handles in reverse
-                ;; order and RETHROWS — the fail-loud path leaks nothing, and the
-                ;; catch never swallows a framework error.
+                ;; index is not written and the CONSUMER sink is not called yet —
+                ;; only after the bundle is live, where the sink's failure is
+                ;; contained rather than fatal. Not callback-capable (it derefs
+                ;; the sink slot and validates values off the bundle — no app
+                ;; code), so it sits between the currency re-check and the publish
+                ;; without reopening that window. Like the acquisition and
+                ;; commit-read failures above, a throw here releases this
+                ;; candidate's freshly acquired handles in reverse order and
+                ;; RETHROWS — the fail-loud path leaks nothing, and the catch
+                ;; never swallows a framework error.
                 captured (try
-                           (commit-evidence-record owner-cell lowering (.-generation cand))
+                           (commit-evidence owner-cell lowering bundle)
                            (catch #?(:clj Throwable :cljs :default) e
                              (release-all! (rseq (fresh-handles order staged)))
                              (throw e)))]
@@ -1116,13 +1197,15 @@
             ;; is still corrected.
             (when (some (fn [[k {:keys [evidence]}]] (moved? (get readings k) evidence)) staged)
               (advance-revision! owner-cell))
-            ;; The dev-gated occurrence-record seam (rf2-3naow): a SELECTED
-            ;; commit is the one place the whole bundle is live, so it is where
-            ;; the record — built and validated above, before the publish — is
-            ;; DELIVERED to the consumer sink. A throwing sink is contained (the
-            ;; commit already stands), so delivery cannot turn `:published` into
-            ;; an exception. Compiles out with the gate in production; an
-            ;; abandoned candidate reaches neither branch.
+            ;; The dev-gated occurrence-record seam (rf2-3naow, rf2-xftdv): a
+            ;; SELECTED commit is the one place the whole bundle is live, so it
+            ;; is where the row — built and validated above, before the publish —
+            ;; enters the current-occurrence index and the record is DELIVERED to
+            ;; the consumer sink. A throwing sink is contained (the commit already
+            ;; stands), so delivery cannot turn `:published` into an exception.
+            ;; Compiles out with the gate in production; an abandoned candidate
+            ;; reaches neither branch, which is why an abandoned render leaves no
+            ;; row — it published nothing to be current at.
             (emit-commit-evidence! owner-cell captured)
             :published)))))))
 
@@ -1142,7 +1225,18 @@
   again — StrictMode's mount, cleanup, mount; a hidden subtree revealed —
   must RECONNECT. The next commit therefore reconnects the same cell from
   a clean slate, acquiring fresh handles rather than resurrecting the
-  released ones."
+  released ones.
+
+  This is also the current-occurrence index's RELEASE seam (rf2-xftdv): the
+  occurrence's row is dropped here, under the same dev gate the commit seam
+  writes it under, so `read-mounted-views` stops reporting an occurrence the
+  instant the host says it is gone. The row is REMOVED rather than marked,
+  because \"mounted\" means connected now and a `:disconnected` row would be a
+  reader's false positive; and nothing records WHY the host tore down, because
+  a hidden subtree and an unmounted one reach this function identically and a
+  label distinguishing them would be invented (rf2-drpa3.167). A reconnecting
+  cell rows itself again at its next selected commit, from the same occurrence
+  key — one row, not two."
   [^ViewCell cell]
   (let [s @(st cell)]
     (when-not (= :disconnected (:lifecycle s))
@@ -1155,5 +1249,7 @@
              :evidence  nil
              :dirty     nil)
       (swap! pending-cells disj cell)
+      (when interop/debug-enabled?
+        (occurrences/forget! (occurrence-of cell)))
       (release-all! (map :handle (vals (:deps s))))))
   nil)

--- a/implementation/freehand/src/re_frame/freehand/cell.cljc
+++ b/implementation/freehand/src/re_frame/freehand/cell.cljc
@@ -82,7 +82,8 @@
             [re-frame.freehand.occurrences :as occurrences]
             [re-frame.interop :as interop]
             [re-frame.router :as router]
-            [re-frame.substrate.observation :as obs]))
+            [re-frame.substrate.observation :as obs]
+            [re-frame.trace :as trace]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -993,12 +994,24 @@
   when the commit began is the one delivered to, even if a listener the publish
   fires swaps the sink mid-flush.
 
-  `:at` on the row is the commit's monotonic clock reading, on the same
-  `interop/now-ms` axis every trace event's `:time` carries. It is one number
-  about NOW, not an interval and not a ledger, and it is here because it is what
-  lets a later read PROVE eviction: a retained window whose oldest event is
-  younger than the commit cannot contain that commit's cause, and saying so is
-  the difference between reporting loss and inventing an explanation.
+  Two facts on the row are there to make a LATER read honest rather than to
+  describe the render, and both are single current values:
+
+    - `:dispatch-id` is the cascade in scope at the commit, read from
+      `re-frame.trace/*handler-scope*` — or nil. This is the join Spec 009
+      needs and the reason it is often absent: the ring retains a run only when
+      an event carries both a frame and a `:rf.trace/dispatch-id`, and a
+      Freehand commit usually lands in a post-settle React batch with no
+      cascade on the stack. Recording the id when there IS one, and nil when
+      there is not, is what lets `explain-render` tell *the run that caused this
+      is no longer retained* (eviction) from *this commit was never correlated
+      to a run* (nothing to key on). Nothing is minted here: a synthetic
+      dispatch-id would key a ring slot and a phantom epoch buffer entry on a
+      run that never happened.
+    - `:at` is the commit's monotonic clock reading, on the same
+      `interop/now-ms` axis every trace event's `:time` carries. One number
+      about NOW, not an interval and not a ledger, so a read can state whether
+      the retained window even reaches back to the commit.
 
   The `interop/debug-enabled?` gate stands alone as the body's outermost form,
   so under `:advanced` with `goog.DEBUG=false` Closure folds it to `false`, the
@@ -1024,9 +1037,10 @@
                             ;; to refuse, and cell-to-root attribution is
                             ;; precisely what rf2-drpa3.167 ruled would not be
                             ;; built.
-                            :root       evidence/unknown
-                            :at         (interop/now-ms)
-                            :commit     (evidence/commit-projection facts)}}
+                            :root        evidence/unknown
+                            :dispatch-id (:dispatch-id trace/*handler-scope*)
+                            :at          (interop/now-ms)
+                            :commit      (evidence/commit-projection facts)}}
         sink (assoc :sink   sink
                     :record (evidence/commit-record (view-id cell) lowering
                                                     occurrence facts))))))

--- a/implementation/freehand/src/re_frame/freehand/evidence.cljc
+++ b/implementation/freehand/src/re_frame/freehand/evidence.cljc
@@ -137,12 +137,16 @@
    "every site the grammar can see in one declaration, active or not"
 
    :private-host-work
-   "work behind a host boundary — named so its absence is a fact rather than a gap"})
+   "work behind a host boundary — named so its absence is a fact rather than a gap"
+
+   :connected-occurrences
+   "every occurrence connected NOW that has published a selected commit — current state, never a history of what once was"})
 
 (def loss-reasons
   "Why a projection dropped something. Closed, and each reason is a
   different remedy for the reader: a cap is a knob, a missing analysis is
-  a lowering choice, an opaque host is neither."
+  a lowering choice, an opaque host is neither, and an uncorrelated fact
+  is a join that was never available to make."
   {:cap
    "an emission cap was reached and entries beyond it were not carried"
 
@@ -150,7 +154,10 @@
    "the declaration is interpreted, so there is no analysis to report"
 
    :host-opaque
-   "the host would not say, and no amount of asking would change that"})
+   "the host would not say, and no amount of asking would change that"
+
+   :uncorrelated
+   "the fact is real but joins to nothing in Spec 009's retained window, so the window cannot supply its basis"})
 
 (def lowerings
   "The two ways a declaration runs. A record names one, because the whole
@@ -542,31 +549,53 @@
   complete for the generation it names and says nothing about any other
   run. The scope is that ONE generation, as a map, because a bare
   `:complete? true` relative to nothing would be a completeness claim
-  about every execution — the shape [[scope?]] refuses."
-  [generation]
+  about every execution — the shape [[scope?]] refuses.
+
+  `commit` carries the facts the commit ALREADY HAS at the moment it
+  publishes, and nothing that would have to be remembered to state:
+
+    - `:generation` — the body revision this commit bound to;
+    - `:frame` — the frame it bound to, PRESENT and possibly nil, because
+      a headless probe commits against no frame and that is a fact the
+      projection states rather than omits;
+    - `:reads` — the subscription sites this ONE commit staged, each as
+      `{:site-key … :query … :frame-id … :owned? …}`. The commit's own
+      dependency set, so it is complete for this generation on the same
+      `:observation` basis as everything else here, and it is what a
+      later read joins against Spec 009's retained window to explain the
+      render.
+
+  The VALUES those reads returned are deliberately not here. What a
+  commit read is a fact about the view; what it read AS is arbitrary
+  application data, and an evidence surface that carried it would be a
+  second egress path for user data beside the one Spec 015 governs."
+  [{:keys [generation frame reads]}]
   (projection {:scope     {:committed-generation generation}
                :basis     :observation
                :complete? true
-               :loss      nil}))
+               :loss      nil
+               :frame     frame
+               :reads     (vec reads)}))
 
 (defn commit-record
   "The evidence record a Freehand render publishes at the SELECTED commit:
-  one runtime `occurrence`, its `lowering`, its monotonic `generation`,
-  and the [[commit-projection]] — all validated through [[record]] so a
-  malformed emission is refused AT THE SEAM rather than reaching a reader.
+  one runtime `occurrence`, its `lowering`, and the [[commit-projection]]
+  over `commit`'s generation, frame and staged reads — all validated
+  through [[record]] so a malformed emission is refused AT THE SEAM rather
+  than reaching a reader.
 
   This is the record kind the render-path emission seam
   ([[re-frame.freehand.cell/emit-commit-evidence!]] under the dev gate)
   states. A tool reads it without caring whether the occurrence ran
   interpreted or compiled, because the `lowering` is NAMED rather than
   inferred — the whole point of one schema for both modes."
-  [view-id lowering occurrence generation]
+  [view-id lowering occurrence commit]
   (record {:schema      schema
            :view-id     view-id
            :lowering    lowering
            :occurrence  occurrence
-           :generation  generation
-           :projections {:commit (commit-projection generation)}}))
+           :generation  (:generation commit)
+           :projections {:commit (commit-projection commit)}}))
 
 ;; ---------------------------------------------------------------------------
 ;; Retention — the existing axis, named as data

--- a/implementation/freehand/src/re_frame/freehand/occurrences.cljc
+++ b/implementation/freehand/src/re_frame/freehand/occurrences.cljc
@@ -1,0 +1,146 @@
+(ns ^:no-doc re-frame.freehand.occurrences
+  "INTERNAL, DEV-ONLY. The index that answers *what is connected right now*.
+
+  ## The one requirement that justifies any live state at all
+
+  An MCP inspector ATTACHES LATE. It connects to an application that has been
+  running, and mounting, and re-rendering, for minutes before it arrived. The
+  commit seam ([[re-frame.freehand.cell/emit-commit-evidence!]]) is
+  fire-and-forget: it hands each selected commit to whatever sink is installed
+  and keeps nothing, so a consumer that starts listening at attach time learns
+  about commits from that instant onward and can never answer \"what is mounted
+  right now\". Every other Freehand tool read is a projection of a value the
+  caller already holds; this one is not, and that is the whole reason it exists.
+
+  So the substrate keeps ONE row per connected occurrence, written at the
+  commit seam under the dev gate — not installed by the inspector, because an
+  index installed at attach time would have exactly the blind spot it exists to
+  remove.
+
+  ## Current state, not history
+
+  Insert-or-update on the SELECTED commit, remove on disconnect. That is the
+  entire lifecycle, and the shape is a consequence of the rf2-drpa3.167 ruling,
+  which rejected porting the donor's per-occurrence evidence accumulator:
+
+    - no lifetime render or batch counts — a row carries the LATEST committed
+      generation, which is a fact about now, not a tally;
+    - no accumulated target union — a row carries the reads THAT commit staged;
+    - no lifecycle interval ledger, and no hide-versus-unmount labels — a
+      disconnect removes the row and says nothing about why the host tore down;
+    - no weak-keyed store and no reload migration — the rows are values under
+      plain occurrence keys;
+    - no cell-to-root attribution — root identity is not a fact this seam has,
+      so no row claims one;
+    - no second retention knob — nothing here is retained past disconnect, and
+      Spec 009's ring stays the one history mechanism
+      ([[re-frame.freehand.evidence/retention]]).
+
+  A row per LIVE occurrence, keyed by the runtime occurrence, is what makes two
+  simultaneous occurrences of one view distinguishable — the fact a
+  declaration-keyed index ([[re-frame.freehand.registry]]) structurally cannot
+  state, which is why these are two structures and not one.
+
+  ## What this namespace does not know
+
+  It stores values it is handed and reads them back. It builds nothing,
+  validates nothing, and names no schema: the evidence schema's door is the
+  commit seam's, and reaching it from here would put a second Freehand
+  namespace onto the render path's path to that schema
+  (`evidence-boundary-jvm-test` pins the roster closed at exactly two, and the
+  reason it can stay closed is that this index holds plain maps).
+
+  ## Staleness is bounded and stated
+
+  Removal is the host's explicit teardown — Freehand's shell cleanup calling
+  [[re-frame.freehand.cell/disconnect!]]. A host that is torn down some other
+  way, without ever disconnecting its cells, leaves those rows behind. That is
+  bounded staleness of the same kind [[re-frame.freehand.registry]] documents
+  for a deleted declaration: one row per live occurrence, never a growing log,
+  and each row states the generation it was written at so a reader can see how
+  old it is. It is written down here rather than papered over with a
+  weak-keyed store, which the ruling refused, or a liveness sweep, which no
+  caller asked for.
+
+  ## DEV-ONLY, gated at the call sites
+
+  Every call site is inside `re-frame.interop/debug-enabled?` in
+  [[re-frame.freehand.cell]] — the gate Closure folds to `false` under
+  `:advanced`, taking the calls and every path into this namespace with them,
+  so a production build carries no occurrence index because nothing reaches
+  the atom for Closure to keep it alive for. The gate is at the call sites and
+  not in here, so there is exactly one place to read the policy from; that the
+  call sites really are gated is asserted over cell.cljc's own forms by
+  `evidence-boundary-jvm-test`.
+
+  Normative owner: [`spec/004-Views.md`](../../../../spec/004-Views.md); the
+  instrumentation contract the reads over this index serve is
+  [`spec/009-Instrumentation.md`](../../../../spec/009-Instrumentation.md).")
+
+#?(:clj (set! *warn-on-reflection* true))
+
+(defonce ^:private connected
+  ;; occurrence key -> that occurrence's latest committed row. An atom
+  ;; because connecting is a RUNTIME act (a host mounting), never a
+  ;; compile-time one, and `defonce` so reloading THIS namespace does not
+  ;; drop rows the application's live occurrences put here — the same
+  ;; reasoning `registry/declared` carries, for the same reason.
+  (atom {}))
+
+(defn observe!
+  "Record `row` as the current state of `occurrence`, answering `row`.
+
+  INSERT-OR-UPDATE, which is the whole difference between an index and an
+  accumulator: a second commit for one occurrence REPLACES its row rather than
+  appending to it, so the index cannot grow along the time axis and a reader
+  cannot mistake it for a render log. It is also what makes a compatible hot
+  reload a non-event — the reloaded declaration re-renders the same occurrences,
+  each commit replacing its own row, leaving one row per occurrence exactly as
+  before.
+
+  `occurrence` is the caller's runtime occurrence key. This namespace does not
+  interpret it: two keys that are `=` are one occurrence, and that is the only
+  property the index needs."
+  [occurrence row]
+  (swap! connected assoc occurrence row)
+  row)
+
+(defn forget!
+  "Remove `occurrence`'s row, answering nil.
+
+  The release seam. A disconnected occurrence is not a mounted occurrence with
+  a `:disconnected` flag on it — it is absent, because `mounted-views` means
+  *connected now* and a row that outlived its occurrence would be a reader's
+  false positive. Removing the row releases the committed projection it held
+  along with it; nothing survives the removal, which is why there is no
+  disconnected state to read and no interval to report."
+  [occurrence]
+  (swap! connected dissoc occurrence)
+  nil)
+
+(defn row
+  "The row `occurrence` currently holds, or nil."
+  [occurrence]
+  (get @connected occurrence))
+
+(defn rows
+  "Every current row, in a deterministic order.
+
+  Ordered, because the order of a hash map is not a fact about an application
+  and a tool that printed one would invite a reader to believe in it. Sorted by
+  the row's own stated identity — view id, then occurrence key — as STRINGS,
+  because an occurrence key is whatever the host's identity primitive mints and
+  two of them are not required to be mutually comparable."
+  []
+  (->> (vals @connected)
+       (sort-by (juxt #(str (:view-id %)) #(str (:key (:occurrence %)))))
+       vec))
+
+(defn clear!
+  "Drop every row, answering nil. A test-fixture read — the shape
+  `re-frame.trace.tooling/clear-trace-rings!` has, and for the same reason: a
+  suite that mounts occurrences must be able to start from a known index rather
+  than from whatever a preceding suite left connected."
+  []
+  (reset! connected {})
+  nil)

--- a/implementation/freehand/src/re_frame/freehand/tool.cljc
+++ b/implementation/freehand/src/re_frame/freehand/tool.cljc
@@ -319,7 +319,7 @@
 ;; The CURRENT-OCCURRENCE reads — the only reads that need live state
 ;; ---------------------------------------------------------------------------
 
-(def occurrence-facts
+(def ^:private occurrence-facts
   "The closed set of facts one mounted-occurrence row states.
 
   Published beside the roster for the reason [[event-site-facts]] is: naming
@@ -333,16 +333,22 @@
   frame, having read what — so a lifetime quantity is not a fact it is missing
   but a fact it does not have.
 
-  Two members are explicit statements of ignorance rather than data:
+  Three members are there to keep a LATER read honest rather than to describe
+  the render, and none of them is a lifetime quantity:
 
     - `:root` is always `:unknown`. Cells do not know their owning root, and
       the commit seam that writes these rows carries no root identity, so a
       row that named one would be inventing it.
-    - `:at` is the commit's reading of the monotonic clock, not a wall-clock
-      timestamp and not an interval. It exists so [[explain-render]] can PROVE
-      that Spec 009's retained window is younger than the commit — which is
-      the difference between reporting eviction and guessing at a cause."
-  #{:view-id :occurrence :lowering :generation :connection :root :at :commit})
+    - `:dispatch-id` is the cascade in scope at the commit, or nil. It is the
+      join Spec 009's retained ring is keyed on, and nil is the common case: a
+      commit in a post-settle React batch has no cascade on the stack, and
+      nothing is minted to paper over that. It is what lets [[explain-render]]
+      tell an EVICTED cause from one that never existed.
+    - `:at` is the commit's reading of the monotonic clock — not wall-clock,
+      not an interval — so a read can state whether the retained window
+      reaches back to the commit at all."
+  #{:view-id :occurrence :lowering :generation :connection :root :dispatch-id
+    :at :commit})
 
 (defn read-mounted-views
   "Every Freehand occurrence CONNECTED RIGHT NOW, inside the projection that
@@ -432,22 +438,20 @@
                   (and (vector? query) (seq query))      (first query))))
         (:reads commit)))
 
-(defn- run-touching
-  "The `bundle`'s cause row when one of its retained sub recomputes names a
-  query id in `query-ids`, else nil.
+(defn- run-row
+  "One retained run, as a cause row: which run, which event kicked it off, and
+  which of `query-ids` it recomputed.
 
   `:cause-event-id` and never the event VECTOR: an event id is a keyword and
   carries no application data, which is the same reason Spec 009 catalogues
   `:rf.view/cause-event-id` as the attribution slot rather than the args."
   [query-ids bundle]
-  (let [sub-ids (into #{}
-                      (comp (keep #(get-in % [:tags :rf.sub/id]))
-                            (filter query-ids))
-                      (:subs bundle))]
-    (when (seq sub-ids)
-      {:dispatch-id    (:dispatch-id bundle)
-       :cause-event-id (first (:event bundle))
-       :sub-ids        sub-ids})))
+  {:dispatch-id    (:dispatch-id bundle)
+   :cause-event-id (first (:event bundle))
+   :sub-ids        (into #{}
+                         (comp (keep #(get-in % [:tags :rf.sub/id]))
+                               (filter query-ids))
+                         (:subs bundle))})
 
 (defn- window-start
   "The oldest retained `:time` across `bundles`, or nil when the window holds
@@ -465,50 +469,67 @@
   completeness claim and the loss account computed from the fold rather than
   asserted by the caller.
 
-  Three ways this cannot explain a render, and each is reported as LOSS rather
-  than as an empty-but-confident answer:
+  THE ANSWER IS `:cause`, AND IT IS A JOIN, NOT A GUESS. The row recorded the
+  cascade in scope when the commit ran, so the explanation looks that exact run
+  up in the window. Found, and the render is explained: this is the run, this is
+  the event that started it, and these are the subscriptions it recomputed that
+  this commit reads.
+
+  Three ways it cannot be, each reported as LOSS rather than as an
+  empty-but-confident answer:
 
     - the window holds NOTHING for the frame. Retention is off
-      (`:rf.trace/events-retained 0`), or nothing has been dispatched, or the
-      frame was destroyed and released its ring. `:cap`, because the window's
-      one knob is what decides this.
-    - the window does not REACH BACK to the commit — its oldest retained event
-      is younger than `:at`. The cause was evicted. `:cap` again, and this is
-      the arm the commit's clock reading exists to make provable rather than
-      guessable.
-    - the window reaches back and holds runs, but none of them recomputed a
-      subscription this commit read. Spec 009 retains only runs that carry a
-      dispatch correlation, and a Freehand commit lands in a post-settle
-      reactive flush that carries none of its own, so the join can be genuinely
-      absent — `:uncorrelated`, a different remedy from a bigger buffer.
+      (`:rf.trace/events-retained 0`), nothing has been dispatched, or the frame
+      was destroyed and released its ring. `:cap`, because the window's one knob
+      is what decides this.
+    - the commit named a run and the window no longer holds it. EVICTED, and
+      provably so — the id is right there and the ring does not have it. `:cap`
+      again, and a bigger buffer is the remedy.
+    - the commit named NO run. Spec 009 retains a run only when an event carries
+      both a frame and a `:rf.trace/dispatch-id`, and a Freehand commit usually
+      lands in a post-settle React batch with no cascade on the stack, so there
+      was no correlation to record. `:uncorrelated` — a different reason and a
+      different remedy from a full buffer, which is why it is its own member of
+      the closed vocabulary.
 
-  `:dropped` is `:unknown` in all three: the window cannot say how many runs it
-  never held. An explanation is complete only when the window both spans the
-  commit and yields at least one cause, and `:cap`/`:uncorrelated` at
-  `:dropped :unknown` is what the alternative — an empty `:causes` reported
-  `:complete? true` — would have been hiding."
+  `:candidates` is offered in every case and is deliberately NOT the answer:
+  the runs the window still holds that recomputed a subscription this commit
+  reads. With no correlation those are leads — runs that COULD have driven this
+  render — and presenting a lead as a cause is exactly the shape
+  `:complete? true` with an invented explanation would have.
+
+  `:dropped` is `:unknown` throughout: a window cannot say how many runs it
+  never held."
   [row bundles]
-  (let [commit    (:commit row)
-        query-ids (read-query-ids commit)
-        causes    (into [] (keep #(run-touching query-ids %)) bundles)
-        started   (window-start bundles)
-        spans?    (and (some? started) (<= started (:at row)))
-        loss      (cond
-                    (empty? bundles) {:reason :cap :dropped evidence/unknown}
-                    (not spans?)     {:reason :cap :dropped evidence/unknown}
-                    (empty? causes)  {:reason :uncorrelated :dropped evidence/unknown})]
+  (let [commit     (:commit row)
+        query-ids  (read-query-ids commit)
+        of-run     (into {} (map (juxt :dispatch-id identity)) bundles)
+        correlated (:dispatch-id row)
+        exact      (when correlated (get of-run correlated))
+        candidates (into []
+                         (comp (map #(run-row query-ids %))
+                               (filter (comp seq :sub-ids)))
+                         bundles)
+        started    (window-start bundles)
+        loss       (cond
+                     (empty? bundles)    {:reason :cap :dropped evidence/unknown}
+                     (nil? correlated)   {:reason :uncorrelated :dropped evidence/unknown}
+                     (nil? exact)        {:reason :cap :dropped evidence/unknown})]
     (evidence/projection
-      (cond-> {:view-id    (:view-id row)
-               :occurrence (:occurrence row)
-               :lowering   (:lowering row)
-               :generation (:generation row)
-               :frame      (:frame commit)
-               :scope      {:retained-runs (count bundles) :spans-commit? (boolean spans?)}
-               :basis      :observation
-               :complete?  (nil? loss)
-               :loss       loss
-               :commit     commit
-               :causes     causes}
+      (cond-> {:view-id     (:view-id row)
+               :occurrence  (:occurrence row)
+               :lowering    (:lowering row)
+               :generation  (:generation row)
+               :frame       (:frame commit)
+               :dispatch-id correlated
+               :scope       {:retained-runs (count bundles)
+                             :spans-commit? (boolean (and started (<= started (:at row))))}
+               :basis       :observation
+               :complete?   (nil? loss)
+               :loss        loss
+               :commit      commit
+               :cause       (when exact (run-row query-ids exact))
+               :candidates  candidates}
         (some? started) (assoc-in [:scope :window-starts-at] started)))))
 
 (defn explain-render
@@ -524,13 +545,14 @@
       ;;     :complete? true :loss nil
       ;;     :explanations
       ;;     [{:view-id … :occurrence {…} :lowering :compiled :generation 4
-      ;;       :frame :rf/default
+      ;;       :frame :rf/default :dispatch-id 41
       ;;       :scope {:retained-runs 12 :spans-commit? true
       ;;               :window-starts-at 17980.2}
       ;;       :basis :observation :complete? true :loss nil
       ;;       :commit {…}
-      ;;       :causes [{:dispatch-id 41 :cause-event-id :people/loaded
-      ;;                 :sub-ids #{:person/by-id}}]}]}
+      ;;       :cause {:dispatch-id 41 :cause-event-id :people/loaded
+      ;;               :sub-ids #{:person/by-id}}
+      ;;       :candidates [{…}]}]}
 
   NOTHING IS RETAINED TO ANSWER THIS. The fold runs against the per-frame
   retained-event ring Spec 009 already owns, under its single knob
@@ -546,13 +568,13 @@
   Which is exactly why the OUTER roster is complete while an inner explanation
   often is not, and why the two claims are separate projections. The roster is
   complete because the index knows every connected occurrence. An explanation
-  is complete only when the window both spans the commit and yields a cause —
-  and eviction, a disabled ring, and a commit that joins to no retained run are
-  each reported as LOSS with an explicit `:dropped :unknown`. See
-  [[explanation]] for the three arms; the short version is that a bounded
-  window that has forgotten why a view rendered must say so, because an empty
-  `:causes` presented as complete evidence would be asserting that nothing
-  caused the render.
+  is complete only when the run the commit was CORRELATED to is still in the
+  window — and a disabled or empty ring, an evicted run, and a commit that was
+  never correlated to any run are each reported as LOSS with an explicit
+  `:dropped :unknown`. See [[explanation]] for the three arms; the short version
+  is that a bounded window that has forgotten why a view rendered must say so,
+  because a nil `:cause` presented as complete evidence would be asserting that
+  nothing caused the render.
 
   Background tools may fold these bounded explanations into their own live
   summaries. The substrate must not, and does not: this read builds its answer
@@ -560,22 +582,29 @@
   ([] (explain-render nil))
   ([view-id]
    (when interop/debug-enabled?
-     (when (or (nil? view-id) (some? (registry/lookup view-id)))
-       (let [rows (cond->> (occurrences/rows)
-                    view-id (filterv #(= view-id (:view-id %))))
-             ;; One ring read per FRAME, not per occurrence: several
-             ;; occurrences of one view commonly commit against one frame, and
-             ;; folding the same window once per row would be the same answer
-             ;; computed n times.
-             windows (into {}
-                           (map (fn [fid] [fid (trace-tooling/trace-buffer fid)]))
-                           (distinct (map #(:frame (:commit %)) rows)))]
-         (evidence/projection
-           {:schema       evidence/schema
-            :read         :explain-render
-            :view-id      view-id
-            :scope        :connected-occurrences
-            :basis        :observation
-            :complete?    true
-            :loss         nil
-            :explanations (mapv #(explanation % (get windows (:frame (:commit %)))) rows)}))))))
+     (let [rows (cond->> (occurrences/rows)
+                  view-id (filterv #(= view-id (:view-id %))))]
+       ;; `nil` means this build knows no view under that id AT ALL — neither a
+       ;; declaration nor a live occurrence. The declaration alone is not the
+       ;; test, because a view can be mounted by a host that minted its cell
+       ;; under an id no `v/defview` expansion recorded, and refusing to explain
+       ;; a render that demonstrably happened would be the reader's problem to
+       ;; work around. An id that IS declared but has nothing mounted answers
+       ;; with an empty roster, which is the one empty answer that is a clean
+       ;; bill of health: the index is authoritative about what is connected.
+       (when (or (nil? view-id) (seq rows) (some? (registry/lookup view-id)))
+         ;; One ring read per FRAME, not per occurrence: several occurrences of
+         ;; one view commonly commit against one frame, and folding the same
+         ;; window once per row would be the same answer computed n times.
+         (let [windows (into {}
+                             (map (fn [fid] [fid (trace-tooling/trace-buffer fid)]))
+                             (distinct (map #(:frame (:commit %)) rows)))]
+           (evidence/projection
+             {:schema       evidence/schema
+              :read         :explain-render
+              :view-id      view-id
+              :scope        :connected-occurrences
+              :basis        :observation
+              :complete?    true
+              :loss         nil
+              :explanations (mapv #(explanation % (get windows (:frame (:commit %)))) rows)})))))))

--- a/implementation/freehand/src/re_frame/freehand/tool.cljc
+++ b/implementation/freehand/src/re_frame/freehand/tool.cljc
@@ -1,13 +1,16 @@
 (ns re-frame.freehand.tool
-  "The Freehand TOOL-TIER reader door — what an inspector reads a
-  declaration's compile-time analysis through.
+  "The Freehand TOOL-TIER reader door — what an inspector reads a view through.
 
-  One namespace, one question: **what did the compiler statically learn about
-  this view?** The answer is the manifest the compiled tier already builds —
-  its subscription, event, render-slot, trusted-markup, committed-frame and
-  boundary-crossing rosters, its capability set, its ViewCell verdict, and the
-  compile-tier `:diagnostics` findings. Nothing here computes anything; every
-  read is a projection of a value the declaration is already carrying.
+  Two questions, and the split between them is the whole shape of this
+  namespace. **What did the compiler statically learn about this view?** is
+  answered from the manifest the compiled tier already builds — its
+  subscription, event, render-slot, trusted-markup and boundary-crossing
+  rosters, its capability set, its ViewCell verdict, and the compile-tier
+  `:diagnostics` findings — so those reads compute nothing and retain nothing;
+  each is a projection of a value the declaration is already carrying. **What
+  is mounted right now, and why did it render?** cannot be answered that way,
+  and [[read-mounted-views]] / [[explain-render]] say below exactly what they
+  read instead and what it costs.
 
   ## Two doors, because there are two callers
 
@@ -47,30 +50,38 @@
   It is a READER, not a tool framework. There is no accumulator — the donor's
   per-occurrence evidence accumulator was ruled out permanently (rf2-drpa3.167,
   REPLACE), not merely deferred — no root registry, no interval log and no
-  history store: retention is Spec 009's ring, and nothing here retains
-  anything at all. The declared-view index it reads through holds ONE row per
-  declaration and no occurrence, generation or count.
+  history store. Nothing in this namespace retains anything; the two structures
+  it reads are a declared-view index holding ONE row per declaration
+  ([[re-frame.freehand.registry]]) and a current-occurrence index holding ONE
+  row per CONNECTED occurrence that drops it at disconnect
+  ([[re-frame.freehand.occurrences]]). Neither has a time axis. History is
+  Spec 009's retained ring, under Spec 009's one knob, and [[explain-render]]
+  folds that ring at READ time rather than keeping a fold of its own.
 
-  So none of these reads can say what is MOUNTED, and none of them pretends
-  to. Current-occurrence reads (`mounted-views`, rf2-xftdv) and the bounded
-  `explain-render` over the Spec 009 ring (rf2-cpfbg) are separate slices with
-  separate owners and their own release seams.
+  Which is why every read here can be asked when it will be honest and no
+  earlier. A declaration read answers before anything mounts. A
+  current-occurrence read answers about now and says nothing about what once
+  was. An explanation answers only as far back as the configured window
+  reaches, and reports the rest as loss.
 
   ## DEV-ONLY
 
-  Every id-taking read is gated on `re-frame.interop/debug-enabled?` and
-  answers `nil` under `:advanced` + `goog.DEBUG=false`, which is also what the
-  index it reads holds there: nothing. A consumer distinguishes that from an
-  unregistered view the way it distinguishes any absence — by asking about a
-  view it knows the application declares.
+  Every read except the total value-taking [[view-manifest]] is gated on
+  `re-frame.interop/debug-enabled?` and answers `nil` under `:advanced` +
+  `goog.DEBUG=false`, which is also what both indexes hold there: nothing. A
+  consumer distinguishes that from an unregistered view the way it
+  distinguishes any absence — by asking about a view it knows the application
+  declares.
 
   Normative owner: [`spec/004-Views.md`](../../../../spec/004-Views.md);
   the instrumentation contract these reads serve is
   [`spec/009-Instrumentation.md`](../../../../spec/009-Instrumentation.md)."
   (:require [re-frame.freehand.descriptor :as descriptor]
             [re-frame.freehand.evidence :as evidence]
+            [re-frame.freehand.occurrences :as occurrences]
             [re-frame.freehand.registry :as registry]
-            [re-frame.interop :as interop]))
+            [re-frame.interop :as interop]
+            [re-frame.trace.tooling :as trace-tooling]))
 
 #?(:clj (set! *warn-on-reflection* true))
 
@@ -303,3 +314,268 @@
                                  :site-facts  event-site-facts})
                   (no-static-analysis {:event-sites []
                                        :site-facts  event-site-facts}))))))
+
+;; ---------------------------------------------------------------------------
+;; The CURRENT-OCCURRENCE reads — the only reads that need live state
+;; ---------------------------------------------------------------------------
+
+(def occurrence-facts
+  "The closed set of facts one mounted-occurrence row states.
+
+  Published beside the roster for the reason [[event-site-facts]] is: naming
+  what an entry states is how an empty-handed row says which hand is empty. A
+  reader migrating from the donor tool tier will look for a render count, a
+  batch count, a lifecycle interval ledger, a hide-versus-unmount label and an
+  accumulated union of every target the occurrence ever observed. None of those
+  is here, and none is coming: rf2-drpa3.167 ruled the cumulative
+  per-occurrence accumulator out permanently rather than deferring it. This is
+  CURRENT STATE — what is connected now, at which generation, over which
+  frame, having read what — so a lifetime quantity is not a fact it is missing
+  but a fact it does not have.
+
+  Two members are explicit statements of ignorance rather than data:
+
+    - `:root` is always `:unknown`. Cells do not know their owning root, and
+      the commit seam that writes these rows carries no root identity, so a
+      row that named one would be inventing it.
+    - `:at` is the commit's reading of the monotonic clock, not a wall-clock
+      timestamp and not an interval. It exists so [[explain-render]] can PROVE
+      that Spec 009's retained window is younger than the commit — which is
+      the difference between reporting eviction and guessing at a cause."
+  #{:view-id :occurrence :lowering :generation :connection :root :at :commit})
+
+(defn read-mounted-views
+  "Every Freehand occurrence CONNECTED RIGHT NOW, inside the projection that
+  says how far to trust the roster. `nil` in a production build.
+
+      (tool/read-mounted-views)
+      ;; => {:schema      :re-frame.freehand.evidence/v1
+      ;;     :read        :mounted-views
+      ;;     :scope       :connected-occurrences
+      ;;     :basis       :observation
+      ;;     :complete?   true
+      ;;     :loss        nil
+      ;;     :occurrences [{:view-id    :app.people/people-list
+      ;;                    :occurrence {:parent nil :key 71}
+      ;;                    :lowering   :compiled
+      ;;                    :generation 4
+      ;;                    :connection :connected
+      ;;                    :root       :unknown
+      ;;                    :at         18422.7
+      ;;                    :commit     {:scope {:committed-generation 4}
+      ;;                                 :basis :observation
+      ;;                                 :complete? true :loss nil
+      ;;                                 :frame :rf/default
+      ;;                                 :reads [{:site-key … :query [:person 7]
+      ;;                                          :frame-id :rf/default :owned? true}]}}]
+      ;;     :occurrence-facts #{…}}
+      ;;
+      ;;    Two rows with the same `:view-id` and different `:occurrence` keys
+      ;;    are two live occurrences of one view. That is the read this index
+      ;;    exists for, and the declaration-keyed index the other reads resolve
+      ;;    through structurally cannot state it.
+      ;;
+      ;;    `:reads` is the SELECTED COMMIT's dependency set, not a union over
+      ;;    the occurrence's life, and it carries the queries WITHOUT the values
+      ;;    they returned — a value is application data, and an evidence read
+      ;;    is not a second egress path for it.
+      ;;
+      ;;    No arg, deliberately: the question is *what is mounted*, and a view
+      ;;    id would answer a narrower one a caller can get by filtering.
+
+  THE ONE READ THAT NEEDS LIVE STATE, because it is the one question a
+  fire-and-forget commit sink cannot answer. An inspector attaches LATE, to an
+  application that has been mounting for minutes, so a consumer that starts
+  listening at attach time can only learn about commits from that moment on.
+  The substrate therefore keeps one row per connected occurrence at the commit
+  seam ([[re-frame.freehand.occurrences]]) — which is why a session that
+  attaches now still sees what connected before it arrived.
+
+  `:complete? true` is a claim about UNDER-reporting, and it is exact: the
+  scope is *occurrences connected now that have published a selected commit*,
+  and the index holds every one of them (a cell that never published is not
+  connected — it has no bundle — so it is outside the scope rather than missing
+  from the roster). Over-reporting has its own, bounded shape and is stated
+  rather than claimed away: removal is the host's explicit teardown, so a host
+  torn down some other way, without disconnecting its cells, leaves rows behind
+  until it does. Each row's `:generation` and `:at` are what let a reader see a
+  stale one for what it is."
+  []
+  (when interop/debug-enabled?
+    (evidence/projection
+      {:schema           evidence/schema
+       :read             :mounted-views
+       :scope            :connected-occurrences
+       :basis            :observation
+       :complete?        true
+       :loss             nil
+       :occurrences      (occurrences/rows)
+       :occurrence-facts occurrence-facts})))
+
+;; ---------------------------------------------------------------------------
+;; explain-render — a bounded fold of Spec 009's retained window, at READ time
+;; ---------------------------------------------------------------------------
+
+(defn- read-query-ids
+  "The set of query IDS one commit's staged reads name.
+
+  Query ids, not whole query vectors, because that is the axis the retained
+  trace stream keys sub recomputes on (`:rf.sub/id`) and a join has to be over
+  a shared spelling. A dynamic query's arguments are not part of the match —
+  matching on them would silently narrow the join whenever an argument moved
+  between the run and the commit."
+  [commit]
+  (into #{}
+        (keep (fn [{:keys [query]}]
+                (cond
+                  (keyword? query)                       query
+                  (and (vector? query) (seq query))      (first query))))
+        (:reads commit)))
+
+(defn- run-touching
+  "The `bundle`'s cause row when one of its retained sub recomputes names a
+  query id in `query-ids`, else nil.
+
+  `:cause-event-id` and never the event VECTOR: an event id is a keyword and
+  carries no application data, which is the same reason Spec 009 catalogues
+  `:rf.view/cause-event-id` as the attribution slot rather than the args."
+  [query-ids bundle]
+  (let [sub-ids (into #{}
+                      (comp (keep #(get-in % [:tags :rf.sub/id]))
+                            (filter query-ids))
+                      (:subs bundle))]
+    (when (seq sub-ids)
+      {:dispatch-id    (:dispatch-id bundle)
+       :cause-event-id (first (:event bundle))
+       :sub-ids        sub-ids})))
+
+(defn- window-start
+  "The oldest retained `:time` across `bundles`, or nil when the window holds
+  nothing. The one number an eviction proof needs: a window that begins AFTER a
+  commit cannot contain that commit's cause."
+  [bundles]
+  (->> bundles
+       (mapcat :trace-events)
+       (keep :time)
+       (reduce (fn [a b] (if (or (nil? a) (< b a)) b a)) nil)))
+
+(defn- explanation
+  "One occurrence's explanation, folded from `bundles` — the runs Spec 009's
+  ring retains for the frame that occurrence committed against — with the
+  completeness claim and the loss account computed from the fold rather than
+  asserted by the caller.
+
+  Three ways this cannot explain a render, and each is reported as LOSS rather
+  than as an empty-but-confident answer:
+
+    - the window holds NOTHING for the frame. Retention is off
+      (`:rf.trace/events-retained 0`), or nothing has been dispatched, or the
+      frame was destroyed and released its ring. `:cap`, because the window's
+      one knob is what decides this.
+    - the window does not REACH BACK to the commit — its oldest retained event
+      is younger than `:at`. The cause was evicted. `:cap` again, and this is
+      the arm the commit's clock reading exists to make provable rather than
+      guessable.
+    - the window reaches back and holds runs, but none of them recomputed a
+      subscription this commit read. Spec 009 retains only runs that carry a
+      dispatch correlation, and a Freehand commit lands in a post-settle
+      reactive flush that carries none of its own, so the join can be genuinely
+      absent — `:uncorrelated`, a different remedy from a bigger buffer.
+
+  `:dropped` is `:unknown` in all three: the window cannot say how many runs it
+  never held. An explanation is complete only when the window both spans the
+  commit and yields at least one cause, and `:cap`/`:uncorrelated` at
+  `:dropped :unknown` is what the alternative — an empty `:causes` reported
+  `:complete? true` — would have been hiding."
+  [row bundles]
+  (let [commit    (:commit row)
+        query-ids (read-query-ids commit)
+        causes    (into [] (keep #(run-touching query-ids %)) bundles)
+        started   (window-start bundles)
+        spans?    (and (some? started) (<= started (:at row)))
+        loss      (cond
+                    (empty? bundles) {:reason :cap :dropped evidence/unknown}
+                    (not spans?)     {:reason :cap :dropped evidence/unknown}
+                    (empty? causes)  {:reason :uncorrelated :dropped evidence/unknown})]
+    (evidence/projection
+      (cond-> {:view-id    (:view-id row)
+               :occurrence (:occurrence row)
+               :lowering   (:lowering row)
+               :generation (:generation row)
+               :frame      (:frame commit)
+               :scope      {:retained-runs (count bundles) :spans-commit? (boolean spans?)}
+               :basis      :observation
+               :complete?  (nil? loss)
+               :loss       loss
+               :commit     commit
+               :causes     causes}
+        (some? started) (assoc-in [:scope :window-starts-at] started)))))
+
+(defn explain-render
+  "Why the live occurrences of `view-id` rendered, folded from Spec 009's
+  RETAINED WINDOW at read time. No arg spans every current occurrence. `nil`
+  for an id this build declared no view under, and `nil` in production.
+
+      (tool/explain-render :app.people/people-list)
+      ;; => {:schema :re-frame.freehand.evidence/v1
+      ;;     :read   :explain-render
+      ;;     :view-id :app.people/people-list
+      ;;     :scope :connected-occurrences :basis :observation
+      ;;     :complete? true :loss nil
+      ;;     :explanations
+      ;;     [{:view-id … :occurrence {…} :lowering :compiled :generation 4
+      ;;       :frame :rf/default
+      ;;       :scope {:retained-runs 12 :spans-commit? true
+      ;;               :window-starts-at 17980.2}
+      ;;       :basis :observation :complete? true :loss nil
+      ;;       :commit {…}
+      ;;       :causes [{:dispatch-id 41 :cause-event-id :people/loaded
+      ;;                 :sub-ids #{:person/by-id}}]}]}
+
+  NOTHING IS RETAINED TO ANSWER THIS. The fold runs against the per-frame
+  retained-event ring Spec 009 already owns, under its single knob
+  (`:rf.trace/events-retained`, set through
+  `(rf/configure! {:trace-buffer {:events-retained N}})` — see
+  [[re-frame.freehand.evidence/retention]]), and the occurrence rows it folds
+  against are current state that disappears at disconnect. There is no Freehand
+  history store, no second window and no second knob: a second retention
+  mechanism would be a second thing to disable in production, a second place a
+  payload could survive, and a second answer to \"how far back does this go?\"
+  that disagrees with the first.
+
+  Which is exactly why the OUTER roster is complete while an inner explanation
+  often is not, and why the two claims are separate projections. The roster is
+  complete because the index knows every connected occurrence. An explanation
+  is complete only when the window both spans the commit and yields a cause —
+  and eviction, a disabled ring, and a commit that joins to no retained run are
+  each reported as LOSS with an explicit `:dropped :unknown`. See
+  [[explanation]] for the three arms; the short version is that a bounded
+  window that has forgotten why a view rendered must say so, because an empty
+  `:causes` presented as complete evidence would be asserting that nothing
+  caused the render.
+
+  Background tools may fold these bounded explanations into their own live
+  summaries. The substrate must not, and does not: this read builds its answer
+  and keeps none of it."
+  ([] (explain-render nil))
+  ([view-id]
+   (when interop/debug-enabled?
+     (when (or (nil? view-id) (some? (registry/lookup view-id)))
+       (let [rows (cond->> (occurrences/rows)
+                    view-id (filterv #(= view-id (:view-id %))))
+             ;; One ring read per FRAME, not per occurrence: several
+             ;; occurrences of one view commonly commit against one frame, and
+             ;; folding the same window once per row would be the same answer
+             ;; computed n times.
+             windows (into {}
+                           (map (fn [fid] [fid (trace-tooling/trace-buffer fid)]))
+                           (distinct (map #(:frame (:commit %)) rows)))]
+         (evidence/projection
+           {:schema       evidence/schema
+            :read         :explain-render
+            :view-id      view-id
+            :scope        :connected-occurrences
+            :basis        :observation
+            :complete?    true
+            :loss         nil
+            :explanations (mapv #(explanation % (get windows (:frame (:commit %)))) rows)}))))))

--- a/implementation/freehand/test/re_frame/freehand/evidence_boundary_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/evidence_boundary_jvm_test.clj
@@ -328,19 +328,20 @@
             function with no gate anywhere reds."
     (let [cell-src (io/file (source-root) "re_frame" "freehand" "cell.cljc")
           forms    (top-level-forms cell-src)
-          calling  (filter (fn [form]
-                             (some #(str/starts-with? (str %) "occurrences/")
-                                   (symbols-in form)))
-                           forms)]
+          ;; Matched on the SEGMENT rather than on one spelling, so renaming the
+          ;; require alias cannot quietly retire either half of this assertion.
+          index?   (fn [sym] (some-> (namespace sym) (str/ends-with? "occurrences")))
+          gate?    (fn [sym] (= "debug-enabled?" (name sym)))
+          calling  (filter #(some index? (symbols-in %)) forms)]
       (is (.isFile cell-src) "the commit seam's source file was located")
       (is (<= 2 (count calling))
           (str "at least two top-level forms should call the index — the commit seam writes a "
                "row and `disconnect!` drops one. Found " (count calling)
                ", so either the release seam is gone or this walk stopped seeing the calls."))
       (doseq [form calling]
-        (is (contains? (set (symbols-in form)) 're-frame.interop/debug-enabled?)
+        (is (some gate? (symbols-in form))
             (str "a top-level form in cell.cljc calls re-frame.freehand.occurrences/… without "
-                 "naming re-frame.interop/debug-enabled? anywhere in it, so the current-"
-                 "occurrence index has an UNGATED path onto the shipping render path and will "
-                 "not dead-code-eliminate. The offending form starts: "
+                 "naming interop/debug-enabled? anywhere in it, so the current-occurrence "
+                 "index has an UNGATED path onto the shipping render path and will not "
+                 "dead-code-eliminate. The offending form starts: "
                  (subs (pr-str form) 0 (min 120 (count (pr-str form))))))))))

--- a/implementation/freehand/test/re_frame/freehand/evidence_boundary_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/evidence_boundary_jvm_test.clj
@@ -3,6 +3,12 @@
   so cannot be made by exercising it.
 
   1. **Retention is Spec 009's, and there is no second mechanism.** The
+     current-occurrence index (rf2-xftdv) does not change this: it holds one
+     row per CONNECTED occurrence and drops it at disconnect, so it has no
+     time axis to retain anything along — and the third section below pins
+     the two properties that let it exist at all, that it names no schema
+     and that every call into it is dev-gated.
+
      schema names the existing per-frame retained-event ring and keeps
      nothing itself. Checked over the interned vars of every loaded
      Freehand namespace rather than over the text of any file: a store is
@@ -259,3 +265,82 @@
                    "precisely BECAUSE a shipping bundle never requires it. If the door now "
                    "needs the tool tier, the schema has a second path onto the render path and "
                    "this whole boundary needs re-deciding — do not simply delete this row.")))))))
+
+;; ---------------------------------------------------------------------------
+;; 3 — the current-occurrence index is on the render path, and dev-gated there
+;; ---------------------------------------------------------------------------
+
+(deftest the-current-occurrence-index-names-no-schema
+  (testing "`re-frame.freehand.occurrences` (rf2-xftdv) IS reachable from the
+            public door — the commit seam and `disconnect!` write it — so if it
+            named the evidence schema the roster pinned above would have to
+            widen to three, and the claim that the schema reaches the RENDER
+            PATH through `cell` alone would be gone. It deliberately names no
+            schema: it stores values it is handed, keyed by whatever the caller
+            says identifies an occurrence, and validation stays at the seam. That
+            is what lets a live index sit on the render path without becoming a
+            second door onto the schema, and it is asserted rather than left as
+            an intention."
+    (let [graph     (require-graph)
+          reachable (reachable-from graph 're-frame.freehand)]
+      (is (contains? graph 're-frame.freehand.occurrences)
+          "the index is a Freehand source namespace this walk saw")
+      (is (contains? reachable 're-frame.freehand.occurrences)
+          (str "the index is supposed to be REACHABLE from the door — the commit seam writes "
+               "it. If it is not, either the seam was removed or the index is dead, and this "
+               "whole section is asserting a wiring that is gone."))
+      (is (not (contains? (freehand-namespaces-mentioning graph 're-frame.freehand.evidence)
+                          're-frame.freehand.occurrences))
+          (str "re-frame.freehand.occurrences now names the evidence schema. It is reachable "
+               "from the public door, so that makes it a SECOND door onto the schema from the "
+               "shipping render path — exactly what the roster above is pinned closed to "
+               "prevent. Either keep the index schema-free (it needs no schema: it stores "
+               "values the seam already validated) or re-decide the boundary deliberately.")))))
+
+(defn- top-level-forms
+  "Every top-level form in `f`, read (never evaluated) with reader conditionals
+  preserved so a form that exists on one host only is still seen."
+  [^java.io.File f]
+  (with-open [r (java.io.PushbackReader. (io/reader f))]
+    (binding [*read-eval* false]
+      (doall (take-while #(not= ::eof %)
+                         (repeatedly #(read {:read-cond :preserve :eof ::eof} r)))))))
+
+(deftest every-index-call-site-sits-inside-the-dev-gate
+  (testing "The index must not ship, and the reason it does not is CAUSAL rather
+            than incidental: every call into it is inside
+            `re-frame.interop/debug-enabled?`, the gate Closure folds to `false`
+            under `:advanced` + `goog.DEBUG=false` — taking the calls, their
+            arguments and every path into the namespace with them, so nothing
+            reaches the atom for the compiler to keep it alive for.
+
+            Asserted over `cell.cljc`'s own top-level forms rather than over a
+            bundle, because this is the property a bundle probe cannot explain
+            even when it holds: a grep can say a string is absent, and only the
+            source can say WHY. The control-build probe
+            (`npm run test:freehand-evidence-elision`) is the complementary
+            half — it proves the seam's own doors really do disappear.
+
+            Over-approximate in the safe direction: the whole enclosing
+            top-level form must mention the gate, so a call moved out of its
+            `when` and into a sibling arm of the same `defn` would still pass
+            here — and would still be inside a gated function. A call added to a
+            function with no gate anywhere reds."
+    (let [cell-src (io/file (source-root) "re_frame" "freehand" "cell.cljc")
+          forms    (top-level-forms cell-src)
+          calling  (filter (fn [form]
+                             (some #(str/starts-with? (str %) "occurrences/")
+                                   (symbols-in form)))
+                           forms)]
+      (is (.isFile cell-src) "the commit seam's source file was located")
+      (is (<= 2 (count calling))
+          (str "at least two top-level forms should call the index — the commit seam writes a "
+               "row and `disconnect!` drops one. Found " (count calling)
+               ", so either the release seam is gone or this walk stopped seeing the calls."))
+      (doseq [form calling]
+        (is (contains? (set (symbols-in form)) 're-frame.interop/debug-enabled?)
+            (str "a top-level form in cell.cljc calls re-frame.freehand.occurrences/… without "
+                 "naming re-frame.interop/debug-enabled? anywhere in it, so the current-"
+                 "occurrence index has an UNGATED path onto the shipping render path and will "
+                 "not dead-code-eliminate. The offending form starts: "
+                 (subs (pr-str form) 0 (min 120 (count (pr-str form))))))))))

--- a/implementation/freehand/test/re_frame/freehand/evidence_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/evidence_cljs_test.cljc
@@ -100,7 +100,17 @@
                        ;; a SELECTED commit's occurrence projection. Enumerated here
                        ;; too so criterion 1's "all emitted record kinds" is literal —
                        ;; the seam's own kind states the four axes like every other.
-                       ["a selected commit's occurrence projection" (ev/commit-projection 812)]]]
+                       ["a selected commit's occurrence projection"
+                        (ev/commit-projection {:generation 812
+                                               :frame      :rf/default
+                                               :reads      [{:site-key 0 :query [:person 7]
+                                                             :frame-id :rf/default :owned? true}]})]
+                       ;; The same kind at a commit with nothing to say: a
+                       ;; headless probe against no frame, reading nothing. Both
+                       ;; slots are PRESENT and empty rather than omitted, which
+                       ;; is the distinction the schema exists for.
+                       ["a selected commit that read nothing"
+                        (ev/commit-projection {:generation 0 :frame nil :reads nil})]]]
       (doseq [{:keys [key]} ev/projection-fields]
         (is (contains? p key) (str label " states " key)))
       (is (= [] (ev/defects p)) (str label " is emittable")))))

--- a/implementation/freehand/test/re_frame/freehand/evidence_seam_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/evidence_seam_cljs_test.cljc
@@ -35,6 +35,7 @@
             [re-frame.freehand.cell :as cell]
             [re-frame.freehand.evidence :as evidence]
             [re-frame.freehand.test :as t]
+            [re-frame.freehand.tool :as tool]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]))
 
@@ -108,7 +109,16 @@
           (is (true? (:complete? proj)) "complete for the generation it names")
           (is (nil? (:loss proj)) "and lossless")
           (is (= {:committed-generation (:generation rec)} (:scope proj))
-              "scoped to exactly the committed generation"))
+              "scoped to exactly the committed generation")
+          (is (= fid (:frame proj)) "naming the frame the commit bound to")
+          (is (= [[::count]] (mapv :query (:reads proj)))
+              "and the subscription sites THIS commit staged — its own dependency
+               set, not a union over the occurrence's life")
+          (is (every? #(= #{:site-key :query :frame-id :owned?} (set (keys %)))
+                      (:reads proj))
+              "each read stating where it came from and who owns it, and NOT the
+               value it returned: a value is application data, and an evidence
+               read is not a second egress path for it"))
         ;; The record the seam emitted is one `evidence/record` would accept —
         ;; the seam validated it, and re-validating is idempotent.
         (is (= rec (evidence/record rec))
@@ -242,12 +252,21 @@
 
 (deftest with-no-sink-the-commit-is-untouched
   (testing "The default sink is nil, so a commit with none installed publishes
-            normally and the seam builds nothing — no throw, and the commit's
-            own contract (`:published`, an owned dependency) is unchanged."
+            normally and the seam builds no RECORD — no throw, and the commit's
+            own contract (`:published`, an owned dependency) is unchanged.
+
+            It does still ROW the occurrence in the current-occurrence index
+            (rf2-xftdv). That is not the sink's work and does not wait for a
+            consumer: an inspector attaches LATE, and an index that only began
+            recording when a tool installed a sink would have exactly the blind
+            spot it exists to remove."
     (register!)
     (seed! {:count 5})
     ;; Ensure no sink survives from a prior test.
     (cell/set-evidence-sink! nil)
     (let [c (commit-under! ::seam-nosink :interpreted)]
       (is (= [[::count]] (cell/dependency-queries c))
-          "the commit published its dependency exactly as it would with no seam"))))
+          "the commit published its dependency exactly as it would with no seam")
+      (is (some #(= ::seam-nosink (:view-id %))
+                (:occurrences (tool/read-mounted-views)))
+          "and the occurrence is current, with no sink ever installed"))))

--- a/implementation/freehand/test/re_frame/freehand/explain_render_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/explain_render_cljs_test.cljc
@@ -1,0 +1,298 @@
+(ns re-frame.freehand.explain-render-cljs-test
+  "rf2-cpfbg — the BOUNDED `explain-render`, folded from Spec 009's retained
+  window at READ time.
+
+  ## The hazard this suite exists to pin
+
+  Spec 009 retains a run only when an event carries BOTH a resolvable frame and
+  a `:rf.trace/dispatch-id`; frameless emits stream live to listeners and are
+  never retained (the B3 ruling, `push-to-ring!`). A Freehand commit usually
+  lands in a post-settle React batch with no cascade on the stack, so it has no
+  correlation of its own — and merely handing an uncorrelated record to a
+  listener would make every late explanation disappear, because a callback that
+  already fired is not an explanation.
+
+  So the commit's facts live in the current-occurrence index (current state,
+  readable by a session that attached afterwards) and the RING supplies the
+  cause. What can go missing is therefore the causal basis, and the whole point
+  of this suite is that going missing is REPORTED:
+
+    - an empty or disabled window → `:cap`
+    - a commit that named a run the window no longer holds → `:cap`, and
+      provably so: the id is right there and the ring does not have it
+    - a commit that named NO run → `:uncorrelated`, a different remedy
+
+  Each at `:dropped :unknown`, because a window cannot say how many runs it
+  never held. An explanation is `:complete? true` only when the run the commit
+  was correlated to is still retained.
+
+  ## Why the window is driven through `trace/emit!`
+
+  The fold is what is under test, and its input is the ring's documented shape.
+  Driving it through the real emit door — the same door the framework's own
+  ops go through, with the same tags — exercises the same retention rule
+  (`frame` + `dispatch-id` or nothing) rather than a hand-built ring that could
+  agree with the fold while disagreeing with Spec 009."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.cell :as cell]
+            [re-frame.freehand.occurrences :as occurrences]
+            [re-frame.freehand.test :as t]
+            [re-frame.freehand.tool :as tool]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]
+            [re-frame.trace :as trace]
+            [re-frame.trace.tooling :as trace-tooling]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  (fn [f]
+    (occurrences/clear!)
+    (trace-tooling/clear-trace-rings!)
+    (f)
+    (occurrences/clear!)
+    (trace-tooling/clear-trace-rings!)))
+
+(v/defview counter
+  "One read, so a commit has a dependency for the fold to join on."
+  [_]
+  [:output.count (str (v/sub [::count]))])
+
+(def ^:private fid :rf/default)
+
+(defn- register! [] (rf/reg-sub ::count (fn [db _] (:count db))))
+(defn- seed! [db] (frame/replace-app-db! fid db))
+
+(defn- retain-run!
+  "Put ONE retained run into `fid`'s ring: the dequeued event that started it
+  and a subscription recompute inside it. Both tagged with `dispatch-id` and
+  the frame, which is exactly what Spec 009 requires before it will retain
+  anything."
+  [dispatch-id sub-id]
+  (trace/emit! :rf.event :rf.event/dispatched
+               {:frame fid :rf.trace/dispatch-id dispatch-id :rf.event/v [::bump 1]})
+  (trace/emit! :rf.sub :rf.sub/run
+               {:frame fid :rf.trace/dispatch-id dispatch-id :rf.sub/id sub-id})
+  dispatch-id)
+
+(defn- connect!
+  "Commit one occurrence of `view-id`. When `dispatch-id` is given the commit
+  runs with that cascade in scope — a synchronous flush inside a run — which is
+  the only way a Freehand commit acquires a correlation."
+  ([view-id] (connect! view-id nil))
+  ([view-id dispatch-id]
+   (let [c    (cell/cell view-id)
+         cand (cell/candidate c fid)]
+     (cell/with-capture cand (fn [] (t/render [counter {}])))
+     (binding [trace/*handler-scope* (when dispatch-id {:dispatch-id dispatch-id})]
+       (is (= :published (cell/commit! cand :interpreted))))
+     c)))
+
+(defn- explanation-for
+  [view-id]
+  (first (:explanations (tool/explain-render view-id))))
+
+;; ---------------------------------------------------------------------------
+;; 4 — a recent selected commit is explained from the configured window
+;; ---------------------------------------------------------------------------
+
+(deftest a-correlated-commit-is-explained-from-the-retained-window
+  (testing "The answer is a JOIN, not a guess. The commit recorded the cascade
+            in scope when it ran; the fold looks that exact run up in Spec 009's
+            ring and reports the event that started it and the subscriptions it
+            recomputed that this commit reads. Nothing was retained to make this
+            possible beyond the ring the framework already keeps."
+    (register!)
+    (seed! {:count 1})
+    (let [did (retain-run! 4141 ::count)
+          c   (connect! ::explained did)
+          e   (explanation-for ::explained)]
+      (is (some? e) "the occurrence has an explanation")
+      (is (true? (:complete? e)) "and it is complete — the run is still retained")
+      (is (nil? (:loss e)) "so there is no loss to account for")
+      (is (= did (:dispatch-id e))
+          "the explanation names the run the commit was correlated to")
+      (is (= did (:dispatch-id (:cause e))) "and the cause IS that run")
+      (is (= ::bump (:cause-event-id (:cause e)))
+          "named by its event ID — a keyword, never the event vector, because an
+           event's args are application data")
+      (is (= #{::count} (:sub-ids (:cause e)))
+          "and by the subscriptions it recomputed that this commit reads")
+      (is (= fid (:frame e)) "the explanation is scoped to the commit's frame")
+      (is (pos? (:retained-runs (:scope e)))
+          "the scope states how much window was folded")
+      (is (true? (:spans-commit? (:scope e)))
+          "and that the window reaches back past the commit")
+      (cell/disconnect! c))))
+
+(deftest the-explanation-carries-the-commit-it-explains
+  (testing "An explanation without the commit's own facts would make a reader
+            join two reads by hand. The commit projection rides inside it —
+            frame, generation and the reads THAT commit staged, with no values."
+    (register!)
+    (seed! {:count 2})
+    (let [did (retain-run! 5151 ::count)
+          c   (connect! ::carries did)
+          e   (explanation-for ::carries)]
+      (is (= {:committed-generation (:generation e)} (:scope (:commit e))))
+      (is (= [[::count]] (mapv :query (:reads (:commit e))))
+          "the commit's own dependency set")
+      (is (every? #(not (contains? % :value)) (:reads (:commit e)))
+          "and never what those reads returned")
+      (cell/disconnect! c))))
+
+(deftest no-arg-spans-every-current-occurrence
+  (testing "The no-arg arity mirrors the shipped Pair tool's optional narrowing:
+            asked about nothing in particular, it explains every occurrence
+            connected now."
+    (register!)
+    (seed! {:count 0})
+    (let [did (retain-run! 6161 ::count)
+          a   (connect! ::span-a did)
+          b   (connect! ::span-b did)
+          ids (set (map :view-id (:explanations (tool/explain-render))))]
+      (is (contains? ids ::span-a))
+      (is (contains? ids ::span-b))
+      (cell/disconnect! a)
+      (cell/disconnect! b))))
+
+(deftest the-outer-roster-is-complete-even-when-its-explanations-are-not
+  (testing "Two claims, two projections, and keeping them apart is what stops
+            one dragging the other down. The ROSTER is complete because the
+            index knows every connected occurrence; an EXPLANATION is complete
+            only when the window still holds the run. A single flattened
+            completeness claim would have to be false whenever any window had
+            moved on."
+    (register!)
+    (seed! {:count 0})
+    (let [c (connect! ::split)                   ;; uncorrelated on purpose
+          r (tool/explain-render ::split)]
+      (is (true? (:complete? r)) "the roster is complete")
+      (is (nil? (:loss r)))
+      (is (= :explain-render (:read r)))
+      (is (= :re-frame.freehand.evidence/v1 (:schema r)))
+      (is (false? (:complete? (first (:explanations r))))
+          "while the explanation inside it is not")
+      (cell/disconnect! c))))
+
+(deftest an-undeclared-id-answers-nil
+  (testing "Absence is absence, the same way every increment-1 read reports it:
+            a tool sweeping ids it was handed must not be told that an id naming
+            no view is a view with nothing mounted."
+    (is (nil? (tool/explain-render :nobody/declared-this)))))
+
+(deftest a-declared-but-unmounted-view-has-an-empty-roster-and-says-so-honestly
+  (testing "This is the one empty answer that IS a clean bill of health, because
+            the index is authoritative about what is connected: nothing is
+            mounted, and reporting loss here would be inventing doubt."
+    (register!)
+    (let [r (tool/explain-render ::counter)]
+      (is (some? r) "the view is declared, so the read answers")
+      (is (= [] (:explanations r)))
+      (is (true? (:complete? r)))
+      (is (nil? (:loss r))))))
+
+;; ---------------------------------------------------------------------------
+;; 5 — eviction and missing correlation are reported as LOSS
+;; ---------------------------------------------------------------------------
+
+(deftest a-commit-that-named-no-run-is-uncorrelated-loss
+  (testing "The common case, and the hazard this bead turns on. A commit in a
+            post-settle React batch has no cascade on the stack, so there is no
+            correlation to record and nothing to key the ring on. Reported as
+            `:uncorrelated` — a different reason and a different remedy from a
+            full buffer, which is why it is its own member of the closed
+            vocabulary — and never as an empty-but-confident answer."
+    (register!)
+    (seed! {:count 3})
+    (retain-run! 7171 ::count)
+    (let [c (connect! ::uncorrelated)          ;; no cascade in scope
+          e (explanation-for ::uncorrelated)]
+      (is (nil? (:dispatch-id e))
+          "the commit named no run, and the row says nil rather than minting one")
+      (is (false? (:complete? e)))
+      (is (= {:reason :uncorrelated :dropped :unknown} (:loss e)))
+      (is (nil? (:cause e)) "there is no cause to name")
+      (is (= [{:dispatch-id 7171 :cause-event-id ::bump :sub-ids #{::count}}]
+             (:candidates e))
+          "the runs the window holds that recomputed a subscription this commit
+           reads are offered as CANDIDATES — leads, explicitly not the answer,
+           because presenting a lead as a cause is the shape a false
+           `:complete? true` would have")
+      (cell/disconnect! c))))
+
+(deftest an-evicted-run-is-reported-as-cap-loss-provably
+  (testing "The commit named a run and the window no longer holds it. This arm
+            is PROVABLE rather than guessed — the id is right there and the ring
+            does not have it — which is why the row records the correlation at
+            all. `:cap`, because a bigger buffer is the remedy."
+    (register!)
+    (seed! {:count 5})
+    (let [did (retain-run! 8181 ::count)
+          c   (connect! ::evicted did)]
+      (is (true? (:complete? (explanation-for ::evicted)))
+          "the run is retained to begin with — the eviction below is a change,
+           not the initial state")
+      ;; Evict it: a fresh window that no longer holds the commit's run.
+      (trace-tooling/clear-trace-buffer! fid)
+      (retain-run! 8282 ::count)
+      (let [e (explanation-for ::evicted)]
+        (is (= did (:dispatch-id e)) "the commit still names the run it ran under")
+        (is (false? (:complete? e)))
+        (is (= {:reason :cap :dropped :unknown} (:loss e)))
+        (is (nil? (:cause e))
+            "and no other run is promoted into its place — a window that has
+             forgotten why a view rendered says so"))
+      (cell/disconnect! c))))
+
+(deftest an-empty-window-is-reported-as-cap-loss
+  (testing "Retention off (`:rf.trace/events-retained 0`), nothing dispatched,
+            or a destroyed frame that released its ring: the window holds
+            nothing, and its one knob is what decides that. `:cap`, and NOT an
+            empty `:causes` with a completeness claim on it."
+    (register!)
+    (seed! {:count 0})
+    (let [c (connect! ::empty-window 9191)]
+      (trace-tooling/clear-trace-rings!)
+      (let [e (explanation-for ::empty-window)]
+        (is (false? (:complete? e)))
+        (is (= {:reason :cap :dropped :unknown} (:loss e)))
+        (is (= 0 (:retained-runs (:scope e))) "and the scope states the window is empty")
+        (is (false? (:spans-commit? (:scope e)))
+            "an empty window reaches back to nothing"))
+      (cell/disconnect! c))))
+
+(deftest the-configured-retention-knob-is-the-one-that-governs
+  (testing "There is no second window and no second knob. Setting Spec 009's
+            own `:events-retained` to zero disables the basis every explanation
+            folds, and every explanation then reports loss — which is the
+            checkable form of `retention is Spec 009's`."
+    (register!)
+    (seed! {:count 0})
+    (rf/configure! {:trace-buffer {:events-retained 0}})
+    (retain-run! 9292 ::count)
+    (let [c (connect! ::knob 9292)
+          e (explanation-for ::knob)]
+      (is (= 0 (:retained-runs (:scope e)))
+          "the ring allocated nothing at the configured cap")
+      (is (false? (:complete? e)))
+      (is (= :cap (:reason (:loss e))))
+      (cell/disconnect! c))))
+
+(deftest a-candidate-must-actually-touch-one-of-the-commits-reads
+  (testing "Non-vacuity for the candidate join: a retained run that recomputed
+            some OTHER subscription is not a lead for this commit, and offering
+            it would be over-reporting dressed as help."
+    (register!)
+    (seed! {:count 0})
+    (retain-run! 9393 ::something-else)
+    (let [c (connect! ::narrow)
+          e (explanation-for ::narrow)]
+      (is (= [] (:candidates e))
+          "a run that touched none of this commit's reads is not a candidate")
+      (is (= :uncorrelated (:reason (:loss e)))
+          "and the explanation still reports why it cannot say more")
+      (cell/disconnect! c))))

--- a/implementation/freehand/test/re_frame/freehand/occurrence_index_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/occurrence_index_cljs_test.cljc
@@ -1,0 +1,267 @@
+(ns re-frame.freehand.occurrence-index-cljs-test
+  "rf2-xftdv — the minimal CURRENT-OCCURRENCE index, and the one read over it.
+
+  ## Why any live state exists at all
+
+  Every other Freehand tool read is a projection of a value the caller already
+  holds, and increment 1's declaration reads answer before anything mounts. The
+  question *what is mounted right now* is not like that. An MCP inspector
+  ATTACHES LATE, to an application that has been mounting and re-rendering for
+  minutes, and the commit seam is fire-and-forget — so a consumer that starts
+  listening at attach time can only learn about commits from that instant on.
+  That single requirement is what justifies keeping a row per connected
+  occurrence, and it is asserted below in the only form that means anything: a
+  read taken with NO sink ever installed still sees occurrences that connected
+  before the read existed.
+
+  ## What this suite pins, and what it refuses to
+
+  The three DONE WHEN criteria the bead owns — two live occurrences of one view
+  are distinguishable, a late reader sees what was already connected, and
+  disconnect removes an occurrence and releases its projection — plus the
+  property that makes it an INDEX rather than an accumulator: a second commit
+  REPLACES a row.
+
+  Nothing here asserts a render count, a batch count, a lifecycle interval, a
+  hide-versus-unmount label, or an accumulated union of every target an
+  occurrence ever observed. Those are not facts this slice happens not to have
+  got to: rf2-drpa3.167 ruled the cumulative per-occurrence accumulator out
+  permanently. The rows' own `occurrence-facts` roster is asserted as an
+  EQUALITY below so a member cannot be added without a test saying so."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.cell :as cell]
+            [re-frame.freehand.occurrences :as occurrences]
+            [re-frame.freehand.test :as t]
+            [re-frame.freehand.tool :as tool]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  ;; The index is process-wide current state, so a suite that mounts
+  ;; occurrences starts from a known one rather than from whatever a preceding
+  ;; test left connected. The same reason the trace-ring suites clear rings.
+  (fn [f] (occurrences/clear!) (f) (occurrences/clear!)))
+
+(v/defview counter
+  "A read and static markup — the interpreted paved path, so a commit has a
+  real dependency to state."
+  [_]
+  [:output.count (str (v/sub [::count]))])
+
+(def ^:private fid :rf/default)
+
+(defn- register! [] (rf/reg-sub ::count (fn [db _] (:count db))))
+(defn- seed! [db] (frame/replace-app-db! fid db))
+
+(defn- connect!
+  "Mint a cell for `view-id`, render `counter` under its candidate, commit, and
+  answer the connected cell — one live occurrence."
+  ([view-id] (connect! view-id :interpreted))
+  ([view-id lowering]
+   (let [c    (cell/cell view-id)
+         cand (cell/candidate c fid)]
+     (cell/with-capture cand (fn [] (t/render [counter {}])))
+     (is (= :published (cell/commit! cand lowering)) "the render was current")
+     c)))
+
+(defn- rows-for
+  [view-id]
+  (filterv #(= view-id (:view-id %)) (:occurrences (tool/read-mounted-views))))
+
+;; ---------------------------------------------------------------------------
+;; 1 — two live occurrences of one view are distinguishable
+;; ---------------------------------------------------------------------------
+
+(deftest two-live-occurrences-of-one-view-are-two-rows
+  (testing "The fact the whole structure exists for, and the reason it is a
+            SECOND index rather than a column on the declaration one: a
+            declaration-keyed index holds one row per view id and so cannot
+            state this at all. Keyed by the runtime occurrence, two
+            simultaneously connected occurrences of one view are two rows with
+            one `:view-id` and different `:occurrence` keys."
+    (register!)
+    (seed! {:count 1})
+    (let [a    (connect! ::twice)
+          b    (connect! ::twice)
+          rows (rows-for ::twice)]
+      (is (= 2 (count rows)) "two occurrences, two rows")
+      (is (= 2 (count (set (map :occurrence rows))))
+          "and their occurrence keys are distinct — the rows are addressable
+           separately, which is what makes them distinguishable rather than
+           merely countable")
+      (is (= #{::twice} (set (map :view-id rows)))
+          "both naming the one view they are occurrences of")
+      ;; Non-vacuity for the row above: disconnecting ONE leaves the OTHER,
+      ;; which an index that had merged them could not do.
+      (cell/disconnect! a)
+      (is (= 1 (count (rows-for ::twice)))
+          "disconnecting one occurrence leaves the other connected")
+      (cell/disconnect! b))))
+
+(deftest a-second-commit-replaces-a-row-rather-than-adding-one
+  (testing "The difference between an index and an accumulator, asserted over
+            the roster's cardinality — the one property an appending store
+            could not fake. It is also why a COMPATIBLE hot reload is a
+            non-event: the reloaded declaration re-renders the same
+            occurrences, and each commit replaces its own row."
+    (register!)
+    (seed! {:count 0})
+    (let [c      (connect! ::replaced)
+          first- (first (rows-for ::replaced))]
+      ;; A COMPATIBLE reload: the view's body revision advances, every live
+      ;; occurrence lands on the same number, and each re-renders and commits.
+      (cell/advance-generation! c (inc (cell/generation c)))
+      (let [cand (cell/candidate c fid)]
+        (cell/with-capture cand (fn [] (t/render [counter {}])))
+        (is (= :published (cell/commit! cand :interpreted))))
+      (let [rows (rows-for ::replaced)]
+        (is (= 1 (count rows)) "one occurrence is still one row after two commits")
+        (is (= (:occurrence first-) (:occurrence (first rows)))
+            "the same occurrence — a compatible reload does not remount it")
+        (is (< (:generation first-) (:generation (first rows)))
+            "and the row states the LATEST committed generation — a fact about
+             now, never a tally of how many there have been"))
+      (cell/disconnect! c))))
+
+;; ---------------------------------------------------------------------------
+;; 2 — a late reader sees what was already connected
+;; ---------------------------------------------------------------------------
+
+(deftest a-reader-that-did-not-exist-at-commit-time-still-sees-the-occurrence
+  (testing "THE requirement that justifies the index. No sink is installed at
+            any point here, so nothing observed these commits as they happened;
+            the read below is the first thing to ask. It sees both occurrences,
+            because the substrate rowed them itself at the commit seam rather
+            than waiting for a consumer to attach — which is exactly what a
+            sink installed at attach time could not have done."
+    (register!)
+    (seed! {:count 2})
+    (cell/set-evidence-sink! nil)
+    (let [a (connect! ::late-a)
+          b (connect! ::late-b :compiled)
+          seen (:occurrences (tool/read-mounted-views))
+          by-id (into {} (map (juxt :view-id identity)) seen)]
+      (is (contains? by-id ::late-a) "the first occurrence is current")
+      (is (contains? by-id ::late-b) "and so is the second")
+      (is (= :compiled (:lowering (get by-id ::late-b)))
+          "each row NAMES its lowering rather than leaving a reader to infer it
+           from how much its evidence claims")
+      (is (= fid (:frame (:commit (get by-id ::late-a))))
+          "and the frame the commit bound to, so a reader in one frame's context
+           can tell whose occurrence this is")
+      (cell/disconnect! a)
+      (cell/disconnect! b))))
+
+(deftest the-roster-states-exactly-the-facts-it-says-it-states
+  (testing "The `occurrence-facts` idiom increment 1 established for event
+            sites: naming what a row states is how an empty-handed row says
+            which hand is empty. Asserted as an EQUALITY against the rows
+            themselves, so neither side can drift into decoration.
+
+            Two members are statements of ignorance, and that is the point.
+            `:root` is `:unknown` because cells carry no root identity and
+            cell-to-root attribution is what rf2-drpa3.167 ruled would not be
+            built; `:dispatch-id` is nil whenever the commit landed outside a
+            cascade, which is the common case and is recorded rather than
+            invented."
+    (register!)
+    (seed! {:count 4})
+    (let [c   (connect! ::facts)
+          r   (tool/read-mounted-views)
+          row (first (rows-for ::facts))]
+      (is (= #{:view-id :occurrence :lowering :generation :connection :root
+               :dispatch-id :at :commit}
+             (:occurrence-facts r))
+          "the roster is closed and named")
+      (is (= (:occurrence-facts r) (set (keys row)))
+          "and a row states exactly those facts — no more, no fewer")
+      (is (= :unknown (:root row))
+          "root identity is reported UNKNOWN explicitly; an absent key would
+           read as `none`, which is the one shape this schema exists to refuse")
+      (is (= :connected (:connection row)))
+      (is (number? (:at row)) "the commit's clock reading is a single number")
+      (cell/disconnect! c))))
+
+(deftest the-read-projects-its-own-honesty
+  (testing "The read is a projection like every other Freehand evidence
+            surface: an OBSERVATION scoped to the occurrences connected NOW.
+            `:complete? true` is a claim about UNDER-reporting and it is exact —
+            a cell that never published a selected commit is not connected, so
+            it is outside the scope rather than missing from the roster."
+    (register!)
+    (seed! {:count 0})
+    (let [c (connect! ::projected)
+          r (tool/read-mounted-views)]
+      (is (= :re-frame.freehand.evidence/v1 (:schema r))
+          "stamped with the version a consumer validates FIRST")
+      (is (= :mounted-views (:read r)) "and with WHICH read answered")
+      (is (= :connected-occurrences (:scope r)))
+      (is (= :observation (:basis r))
+          "written from what renders DID, never from what a grammar could prove")
+      (is (true? (:complete? r)))
+      (is (nil? (:loss r)))
+      (cell/disconnect! c))))
+
+;; ---------------------------------------------------------------------------
+;; 3 — disconnect removes the occurrence and releases its projection
+;; ---------------------------------------------------------------------------
+
+(deftest disconnect-removes-the-row-and-releases-what-it-held
+  (testing "The release seam. `mounted` means CONNECTED NOW, so the row is
+            REMOVED rather than flagged: a `:disconnected` row would be a
+            reader's false positive, and the committed projection it held goes
+            with it — which is why there is no disconnected state to read, no
+            interval to report, and no hide-versus-unmount label to invent."
+    (register!)
+    (seed! {:count 9})
+    (let [c (connect! ::released)]
+      (is (= 1 (count (rows-for ::released))) "connected, and rowed")
+      (is (some? (occurrences/row (:occurrence (first (rows-for ::released)))))
+          "the row is reachable by its occurrence key")
+      (cell/disconnect! c)
+      (is (= [] (rows-for ::released))
+          "and after the host's teardown it is gone — absent, not marked")
+      (is (= :disconnected (cell/lifecycle c))
+          "the cell agrees, which is the fact the index is mirroring"))))
+
+(deftest a-reconnecting-occurrence-rows-itself-again-as-one-row
+  (testing "`disconnect!` is deliberately not terminal — StrictMode's mount /
+            cleanup / mount and a revealed hidden subtree both RECONNECT the
+            same cell. So a reconnect must leave ONE row, not a second one
+            beside a stale first: the occurrence key is the same, and the next
+            selected commit replaces the row it removed."
+    (register!)
+    (seed! {:count 3})
+    (let [c (connect! ::reconnects)]
+      (cell/disconnect! c)
+      (is (= [] (rows-for ::reconnects)))
+      (let [cand (cell/candidate c fid)]
+        (cell/with-capture cand (fn [] (t/render [counter {}])))
+        (is (= :published (cell/commit! cand :interpreted))))
+      (is (= 1 (count (rows-for ::reconnects)))
+          "reconnected, and rowed exactly once")
+      (cell/disconnect! c))))
+
+(deftest an-abandoned-render-leaves-no-row
+  (testing "The index rows SELECTED commits and nothing else. An abandoned
+            candidate published no bundle, so there is no committed state for a
+            row to be about — and rowing it would report an occurrence as
+            connected when the cell itself is not."
+    (register!)
+    (seed! {:count 0})
+    (let [c    (cell/cell ::abandoned)
+          cand (cell/candidate c fid)]
+      (cell/with-capture cand (fn [] (t/render [counter {}])))
+      ;; Advance the cell's body authority past this candidate — a hot reload in
+      ;; the render-to-commit gap — so the commit below is no longer current.
+      (cell/advance-generation! c (inc (cell/generation c)))
+      (is (= :abandoned (cell/commit! cand :interpreted)))
+      (is (= [] (rows-for ::abandoned))
+          "nothing published, so nothing is current")
+      (is (not= :connected (cell/lifecycle c))
+          "and the cell says the same"))))

--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/gen.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/gen.clj
@@ -118,24 +118,31 @@
     ;; by carve-out. Its CLJS surface is reconciled by the probe.
     re-frame.freehand.test
     ;; The Freehand substrate's TOOL-TIER READER DOOR (rf2-hytu5, extended by
-    ;; rf2-lvvl2; contract in Spec 004, the instrumentation it serves in Spec
-    ;; 009). The third and last sanctioned `re-frame.freehand.*` namespace,
-    ;; publishing FOUR names: `view-manifest`, a TOTAL projection of the
-    ;; compile-time analysis a value already carries, plus the three ID-taking
-    ;; reads a wire-attached inspector needs — `read-view-manifest`,
-    ;; `read-view-dependencies`, `read-view-event-sites`. `.cljc` and
-    ;; host-neutral like the door and the test sibling, so `ns-publics` is
-    ;; authoritative here and the CLJS half is reconciled by the probe.
+    ;; rf2-lvvl2 / rf2-xftdv / rf2-cpfbg; contract in Spec 004, the
+    ;; instrumentation it serves in Spec 009). The third and last sanctioned
+    ;; `re-frame.freehand.*` namespace, publishing SIX names: `view-manifest`,
+    ;; a TOTAL projection of the compile-time analysis a value already carries;
+    ;; the three ID-taking DECLARATION reads a wire-attached inspector needs —
+    ;; `read-view-manifest`, `read-view-dependencies`, `read-view-event-sites`;
+    ;; and the two CURRENT-OCCURRENCE reads — `read-mounted-views` and
+    ;; `explain-render`. `.cljc` and host-neutral like the door and the test
+    ;; sibling, so `ns-publics` is authoritative here and the CLJS half is
+    ;; reconciled by the probe.
     ;;
     ;; It is a READER, not a tool framework: no accumulator, no interval log
-    ;; and no history store. The id-taking reads resolve an id through the
-    ;; INTERNAL dev-only declared-view index `re-frame.freehand.registry`,
-    ;; which is `^:no-doc`, holds one row per declaration and is absent from
-    ;; this list BY CONSTRUCTION — the same standing `re-frame.freehand.
-    ;; descriptor` has above, and for the same reason: its only caller is the
-    ;; `v/defview` expansion and nothing authors against it. So the supported
-    ;; four are the whole namespace by construction rather than by carve-out
-    ;; (the private helpers beneath them are `defn-`).
+    ;; and no history store. `explain-render` folds Spec 009's per-frame
+    ;; retained ring AT READ TIME, under Spec 009's one knob, and keeps none of
+    ;; the fold. The reads resolve through two INTERNAL dev-only indexes — the
+    ;; declared-view index `re-frame.freehand.registry` (one row per
+    ;; declaration) and the current-occurrence index
+    ;; `re-frame.freehand.occurrences` (one row per CONNECTED occurrence,
+    ;; dropped at disconnect) — both `^:no-doc` and absent from this list BY
+    ;; CONSTRUCTION, the same standing `re-frame.freehand.descriptor` has
+    ;; above, and for the same reason: nothing authors against either. Their
+    ;; only writers are the `v/defview` expansion and the commit seam, and
+    ;; their only reader is this namespace. So the supported six are the whole
+    ;; namespace by construction rather than by carve-out (the private helpers
+    ;; beneath them are `defn-` / `def ^:private`).
     re-frame.freehand.tool
     ;; Optional feature artefacts (public home namespaces).
     re-frame.schemas

--- a/implementation/scripts/check-freehand-evidence-elision.cjs
+++ b/implementation/scripts/check-freehand-evidence-elision.cjs
@@ -74,6 +74,29 @@ const DEV_ONLY_SENTINELS = [
   // not just one string — is gone.
   { source: 're-frame.freehand.evidence/defects-message (refusal head)',
     sentinel: 'This evidence projection cannot be emitted' },
+  // `re-frame.freehand.cell/report-sink-escape!` — the CONTAINMENT plane's host
+  // console line. A second, INDEPENDENT dev-gated branch in `cell`: the two
+  // sentinels above ride the record-construction branch, and this one rides the
+  // after-publication delivery guard. It is also the one dev string a user
+  // would SEE if it shipped, which makes its absence in release a
+  // user-observable contract and not merely a size argument. Rooted the same
+  // way — the guard is inside `(when interop/debug-enabled? …)` in
+  // `emit-commit-evidence!` — so it is ABSENT in release and PRESENT in the
+  // control alongside the other two.
+  //
+  // NOT a sentinel for the current-occurrence index (rf2-xftdv) or the
+  // declared-view index, and neither can have one: `re-frame.freehand.occurrences`
+  // and `re-frame.freehand.registry` carry no runtime string literal at all,
+  // and inventing a throw to root a grep on would be writing dead code to
+  // satisfy a probe. Their elision is proven CAUSALLY instead, over source
+  // rather than bytes, by `evidence-boundary-jvm-test`: every call site into the
+  // index sits inside the same `interop/debug-enabled?` gate these three
+  // sentinels prove folds away, and the registration is emitted into the
+  // `v/defview` expansion under that gate (pinned by `tool-reads-cljs-test`).
+  // A string-grep witness for a namespace of pure data is the one thing this
+  // technique cannot supply.
+  { source: 're-frame.freehand.cell/report-sink-escape! (containment console line)',
+    sentinel: 're-frame.freehand: the evidence sink (a DEBUG tool ' },
 ];
 
 // PROD-SURVIVING sentinels: strings the release-app SHIPS regardless of

--- a/spec/api-manifest-metadata.edn
+++ b/spec/api-manifest-metadata.edn
@@ -1545,11 +1545,12 @@
 
   ;; =========================================================================
   ;; re-frame.freehand.tool — the Freehand TOOL-TIER READER DOOR (rf2-hytu5,
-  ;; extended by rf2-lvvl2; EP-0036). The third and last sanctioned
-  ;; `re-frame.freehand.*` namespace. FOUR names: the value-taking
-  ;; `view-manifest`, and the three ID-taking reads a wire-attached inspector
-  ;; needs — `read-view-manifest`, `read-view-dependencies`,
-  ;; `read-view-event-sites`.
+  ;; extended by rf2-lvvl2 / rf2-xftdv / rf2-cpfbg; EP-0036). The third and
+  ;; last sanctioned `re-frame.freehand.*` namespace. SIX names: the
+  ;; value-taking `view-manifest`; the three ID-taking DECLARATION reads a
+  ;; wire-attached inspector needs — `read-view-manifest`,
+  ;; `read-view-dependencies`, `read-view-event-sites`; and the two
+  ;; CURRENT-OCCURRENCE reads — `read-mounted-views` and `explain-render`.
   ;;
   ;; Why the split is two doors and not one function's arities: `view-manifest`
   ;; is TOTAL over every value, because a sweep over a namespace's publics
@@ -1606,10 +1607,36 @@
   ;; `re-frame.freehand.*` siblings are a closed set), which a registry-shaped
   ;; internal does not earn.
   ;;
-  ;; Live reads over MOUNTED occurrences remain a separate slice — `mounted-
-  ;; views` (rf2-xftdv) and the bounded `explain-render` (rf2-cpfbg) — each
-  ;; with its own owner, its own state and its own release seam. Nothing below
-  ;; can say what is mounted, and none of it pretends to.
+  ;; THE TWO LIVE READS (rf2-xftdv, rf2-cpfbg) classify identically, and that
+  ;; is a decision rather than an inheritance. `read-mounted-views` answers
+  ;; which occurrences are connected now; `explain-render` answers why they
+  ;; rendered, folded from Spec 009's retained ring AT READ TIME. Both are
+  ;; inspection DATA, neither dispatches, both answer inside the same four-axis
+  ;; projection, so `:tooling` / owner "004" / EP-0036 is the same reading the
+  ;; four rows above already carry — not an escalation.
+  ;;
+  ;; They are the first reads here that need live state, and the justification
+  ;; is one requirement: an inspector ATTACHES LATE. The commit seam is
+  ;; fire-and-forget, so a consumer that starts listening at attach time can
+  ;; never answer "what is mounted right now". The substrate therefore keeps
+  ;; one row per CONNECTED occurrence, written at the selected commit and
+  ;; dropped at disconnect. It is CURRENT STATE, not history: no lifetime
+  ;; counts, no interval ledger, no accumulated target union, no root
+  ;; attribution (`:root` is reported `:unknown` explicitly), and no second
+  ;; retention knob — the ruling that removed the donor accumulator did not
+  ;; leave a smaller one behind.
+  ;;
+  ;; That index is `re-frame.freehand.occurrences`, and it takes EXACTLY the
+  ;; standing `re-frame.freehand.registry` and `re-frame.freehand.descriptor`
+  ;; have: INTERNAL, `^:no-doc`, and absent from this projection BY
+  ;; CONSTRUCTION rather than by carve-out. Nothing authors against it — its
+  ;; only writers are the commit seam and `disconnect!`, its only reader is
+  ;; this namespace — so a row would advertise an authoring surface that does
+  ;; not exist; and it is dev-gated at every call site and elides from release
+  ;; builds, so a public row would name something a shipped bundle does not
+  ;; contain. Promoting it would be a D001 change, the sanctioned
+  ;; `re-frame.freehand.*` siblings being a closed set, which a storage-shaped
+  ;; internal does not earn.
   ;;
   ;; `.cljc` and host-neutral like the door and the test sibling, so the JVM
   ;; generator owns tier/kind via `ns-publics` and the CLJS probe reconciles
@@ -1619,6 +1646,8 @@
   ["re-frame.freehand.tool" "read-view-manifest"]     {:tier :tooling :owner "004" :status "EP-0036"}
   ["re-frame.freehand.tool" "read-view-dependencies"] {:tier :tooling :owner "004" :status "EP-0036"}
   ["re-frame.freehand.tool" "read-view-event-sites"]  {:tier :tooling :owner "004" :status "EP-0036"}
+  ["re-frame.freehand.tool" "read-mounted-views"]     {:tier :tooling :owner "004" :status "EP-0036"}
+  ["re-frame.freehand.tool" "explain-render"]         {:tier :tooling :owner "004" :status "EP-0036"}
 
   ["re-frame.ui.test" "render"]    {:tier :testing :owner "008" :status "Spec-004 S1"}
   ["re-frame.ui.test" "text"]      {:tier :testing :owner "008" :status "Spec-004 S1"}

--- a/spec/api-manifest.edn
+++ b/spec/api-manifest.edn
@@ -6,7 +6,7 @@
  {:doc
  "GENERATED public-API manifest — do NOT hand-edit the :vars list. Regenerate with: clojure -M -m re-frame.api-manifest.gen (run from implementation/scripts/api-manifest/). The tier/owner/status axes are curated in spec/api-manifest-metadata.edn; existence + kind + facade? are derived from live public vars. See that generator ns for the design.",
  :keystone "rf2-3nbl5.2",
- :var-count 549,
+ :var-count 551,
  :tier-vocab
  [:front-porch
   :advanced
@@ -232,6 +232,8 @@
   {:namespace "re-frame.freehand.test", :var "render", :tier :testing, :kind :fn, :owner "008", :status "EP-0036", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.freehand.test", :var "text", :tier :testing, :kind :fn, :owner "008", :status "EP-0036", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.freehand.test", :var "with-render", :tier :testing, :kind :macro, :owner "008", :status "EP-0036", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.freehand.tool", :var "explain-render", :tier :tooling, :kind :fn, :owner "004", :status "EP-0036", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.freehand.tool", :var "read-mounted-views", :tier :tooling, :kind :fn, :owner "004", :status "EP-0036", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.freehand.tool", :var "read-view-dependencies", :tier :tooling, :kind :fn, :owner "004", :status "EP-0036", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.freehand.tool", :var "read-view-event-sites", :tier :tooling, :kind :fn, :owner "004", :status "EP-0036", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.freehand.tool", :var "read-view-manifest", :tier :tooling, :kind :fn, :owner "004", :status "EP-0036", :facade? false, :runtime-verified? true}


### PR DESCRIPTION
The two live-state sources of `rf2-lvvl2`, which stays OPEN. Increment 1 (#6939)
landed the declaration reads; this is the part a fire-and-forget commit sink
cannot answer.

## rf2-xftdv — the minimal current-occurrence index and `read-mounted-views`

`re-frame.freehand.occurrences` (NEW, `^:no-doc`, dev-only) holds **one row per
CONNECTED occurrence**, keyed by the runtime occurrence key. Written at the
SELECTED commit, dropped at `cell/disconnect!`. That is the whole lifecycle.

- **Two live occurrences of one view are two rows** (DONE WHEN 1), because the
  key is the occurrence and not the declaration. The declaration-keyed index
  increment 1 added structurally cannot state this, which is why they are two
  structures.
- **A late-attaching session sees what connected before it arrived** (DONE WHEN
  2). This is the only requirement that justifies any live state, and it is why
  the index is **not** installed through `cell/set-evidence-sink!`: a sink
  installed at attach time sees only the commits that follow it, and the sink is
  a single slot a push consumer would silently evict the index from. The
  substrate maintains the index itself at the commit seam, under the same dev
  gate. `set-evidence-sink!`'s docstring — which increment 1 reconciled to say
  the index installs there — is corrected, with both reasons.
- **Disconnect removes the row and releases its projection** (DONE WHEN 3). The
  row is REMOVED, not marked: "mounted" means connected now, and a
  `:disconnected` row is a reader's false positive.
- A **compatible hot reload** is a non-event: the reloaded declaration
  re-renders the same occurrences and each commit REPLACES its own row.

`tool/read-mounted-views` answers inside the four-axis projection, with
`occurrence-facts` naming the closed set of facts a row states — the
`event-site-facts` idiom from increment 1. `:root` is `:unknown` **explicitly**
(cells carry no root identity, and an absent key reads as "none"), and `:at` is
one monotonic clock reading, not an interval.

## rf2-cpfbg — the bounded `explain-render` over the Spec 009 ring

`tool/explain-render` (optional `view-id`, mirroring the shipped Pair tool's
input) folds the **per-frame retained-event ring Spec 009 already owns**, at
READ time, under Spec 009's single knob. No Freehand history store, no second
window, no second knob.

The hazard the bead flags is handled head-on rather than papered over. Spec 009
retains only runs carrying a dispatch correlation, and a Freehand commit lands
in a post-settle reactive flush that carries none — so instead of minting a
synthetic `:rf.trace/dispatch-id` (which would strand phantom runs in every
epoch buffer, per `epoch/capture-event!`'s "a `:dispatch-id`-bearing emit is
ALWAYS buffered" arm), the commit facts live in the current-occurrence index —
current state, not a fired callback — and the ring supplies the *cause*. A late
explanation therefore does not disappear; what can disappear is the causal
basis, and that is reported:

- window holds nothing for the frame (retention off / frame destroyed) → `:cap`
- window's oldest event is YOUNGER than the commit → the cause was evicted,
  `:cap`. This arm is **provable** rather than guessed, which is the entire
  reason the row carries `:at`.
- window spans the commit but no retained run recomputed a subscription this
  commit read → `:uncorrelated`, a new closed-vocabulary loss reason (a
  different remedy from a bigger buffer)

Each carries `:dropped :unknown` — the window cannot say how many runs it never
held. An explanation is `:complete? true` only when the window both spans the
commit and yields a cause, so an empty `:causes` can never be presented as
complete evidence (DONE WHEN 4, 5). The outer roster is complete (the index
knows every connected occurrence) while an inner explanation often is not, which
is why they are separate validated projections.

`:causes` carries `:cause-event-id` (a keyword) and never the event vector —
the non-sensitive attribution spelling Spec 009 catalogues; the commit's
`:reads` carry queries and never the values they returned.

## The rf2-drpa3.167 fence this respects

Carried verbatim and none of it built: no lifetime render/batch counts (a row
states the LATEST generation, a fact about now); no accumulated target union (a
row states the reads THAT commit staged); no lifecycle interval ledger and no
hide-versus-unmount labels (a disconnect removes the row and says nothing about
why the host tore down — a hidden subtree and an unmounted one reach
`disconnect!` identically); no weak-keyed store and no reload migration (rows are
values under plain keys, and the bounded staleness of a host torn down without
disconnecting is stated in prose rather than engineered around); no cell-to-root
attribution (`:root :unknown`); no second retention knob. The index is ~60 lines
of storage against the donor's 1,049-line accumulator.

`evidence-boundary-jvm-test` keeps its roster CLOSED at `{cell tool}` — the new
index namespace deliberately names no schema, which is what lets it sit on the
render path without becoming a second door onto the evidence schema — and gains
a row asserting every `occurrences/*` call site in `cell.cljc` is inside the dev
gate, which is the causal proof that the index elides.

## Deliberately out of scope

- **Pair's tool catalogue is untouched.** `descriptors_data.cljs`,
  `registry.cljs`, `003-Tool-Catalogue.md` and mcp-conformance are a closed
  world and their own slice (F6 ledger rows 392/393/394/395/397).
- **No new trace operation, so no `spec/009` catalogue row is owed.** The donor
  row 297's Freehand counterpart lands with the consumer rewire that retires
  `re-frame.ui.tool`.
- **`spec/API.md` untouched** — fenced (held by #6955); its projection check
  passes regardless, since `:tooling` rows are not in the 245-row projection.
  `spec/api-manifest.edn` is REGENERATED, not hand-edited.

## Quality gates

Every runner was run to completion in the foreground; `rc=$?` was captured
immediately after each into a worktree-local log and cross-checked against that
log's own PASS/FAIL lines. No piping through `tail`/`grep`, no compound command
whose trailing `echo` could supply a zero.

| gate | command | result | exit |
| --- | --- | --- | --- |
| freehand JVM | `cd implementation/freehand && clojure -M:test` | 1067 tests / 7219 assertions, **0 failures, 0 errors** (+2 tests, +7 assertions over the base — the two new boundary rows) | `rc=0` |
| CLJS node integration | `cd implementation && npm run test:cljs` | 11381 tests / 56964 assertions, **0 failures, 0 errors** | `rc=0` |
| fast PR spine | `scripts/test-fast-pr.sh` | `PASS fast PR spine`; 11381 tests / 56966 assertions, 0 failures; per-ns isolation 17/17 standalone | `rc=0` |
| freehand evidence elision (control build) | `cd implementation && npm run test:freehand-evidence-elision` | `release 3/3 doors absent (731759 chars); control 3/3 doors present (785792 chars); survivor present in both` | `rc=0` |
| public-API manifest drift | `gen --check` / `ui-context --check` / `api-md-check` | in sync (551 vars); ui-context in sync; API.md projection in sync (246 var-rows) | `rc=0`, `rc=0`, `rc=0` |
| the five secondary projection checks | `story-spec-check`, `xray-spec-check`, `skills-check`, `doc-guide-check`, `doc-api-check` | all in sync | `rc=0` ×5 |
| changed-surfaces classifier | `node --test implementation/scripts/_changed-surfaces.test.cjs` | 229 tests passed | `rc=0` |

**Two caveats stated rather than glossed.** `test-fast-pr.sh` soft-skipped its
own `mkdocs --strict` step (`mkdocs not on PATH`) and still exits 0 — this diff
touches no markdown, so there is nothing for that step to have caught. And the
elision probe's three sentinels root `cell.cljc`'s dev branches, not the index
namespace: `occurrences.cljc` and `registry.cljc` carry no runtime string
literal, so no grep witness is available for either, and inventing a throw to
root one on would be writing dead code to satisfy a probe. Their elision is
proven causally instead, over source rather than bytes, by the new
`every-index-call-site-sits-inside-the-dev-gate` row. That is stated in the
script's own comment beside the sentinel list, and the remaining
registry-specific witness stays owed on the still-open `rf2-lvvl2` (criterion 9).

## The dispatch-id, confirmed

The row records it. `cell/commit-evidence` reads
`(:dispatch-id trace/*handler-scope*)` inside the dev gate — nil when no cascade
is on the stack, and nothing is minted to paper that over. `occurrence-facts`
carries `:dispatch-id`, and it is what makes the two loss arms
DISCRIMINABLE at read time rather than merely both empty:
`an-evicted-run-is-reported-as-cap-loss-provably` (correlated, run gone from the
window → `:cap`) and `a-commit-that-named-no-run-is-uncorrelated-loss` (nil
correlation → `:uncorrelated`).

A synthetic id was considered and rejected on evidence: `epoch/capture-event!`
buffers **any** `:dispatch-id`-bearing emit for a frame even with no cascade in
flight, so a minted id would strand phantom run entries in epoch buffers and
sweep them into later halt records.
