### PR TITLE
fix(freehand): refuse :class/:style in a v/custom-element :properties set (rf2-oazgv)

### DIFF
--- a/docs/api/re-frame.freehand.md
+++ b/docs/api/re-frame.freehand.md
@@ -141,9 +141,13 @@ elements — the child path is browser-only, like the mount verbs.
   Top-level and compile-resolvable, and it registers the way `v/defview` does. The
   tag is an unqualified keyword containing `-`, the options map is **literal**, and
   `:properties` is the **whole** v1 grammar — an unknown key, a namespaced tag or a
-  runtime map raises `:rf.ui.compile/bad-custom-element`. Declaring is only ever the
-  exception: undeclared names are attributes, and an undeclared *element* needs no
-  declaration at all.
+  runtime map raises `:rf.ui.compile/bad-custom-element`. So does `:class` or
+  `:style` in the set: those two are *attributes* with grammars of their own —
+  `:class` composes with the `.class#id` tag sugar, `:style` carries the CSS map —
+  and because a property is omitted from markup, classifying one would render the
+  element with that value dropped from the HTML. They are refused rather than
+  quietly rewritten. Declaring is only ever the exception: undeclared names are
+  attributes, and an undeclared *element* needs no declaration at all.
 
   One tag has one property manifest. Two sources declaring it differently is
   `:rf.ui.compile/custom-element-conflict` at build time and

--- a/implementation/freehand/src/re_frame/freehand.cljc
+++ b/implementation/freehand/src/re_frame/freehand.cljc
@@ -602,6 +602,11 @@
      does. The tag is an unqualified keyword containing `-`, the options map
      is LITERAL, and `:properties` is the WHOLE v1 grammar — an unknown key,
      a namespaced tag or a runtime map is `:rf.ui.compile/bad-custom-element`.
+     So is `:class` or `:style` in `:properties`: those two are ATTRIBUTES
+     with grammars of their own — `:class` composes with the `.class#id` tag
+     sugar and `:style` carries the CSS map — and since a property is omitted
+     from markup, classifying one would render the element with that value
+     dropped from the HTML. They are refused rather than quietly rewritten.
      Undeclared names are attributes and an undeclared ELEMENT needs no
      declaration at all, so declaring is only ever the exception. One tag has
      one property manifest: two sources declaring it differently is

--- a/implementation/freehand/src/re_frame/freehand/compiler.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler.cljc
@@ -515,6 +515,33 @@
                  "property names (kebab; :help-text -> the helpText JS "
                  "property); got " (pr-str props))
             {:tag tag :properties props}))
+    ;; The v1 refusal roster (rf2-oazgv): `:class` and `:style` are ATTRIBUTES,
+    ;; and a property-classified name is OMITTED from markup by contract — so
+    ;; accepting this declaration rendered an element with its class and style
+    ;; silently missing from the server's HTML while the structural fold still
+    ;; carried them. Refused at the DECLARATION rather than coerced: doing what
+    ;; the author probably meant, quietly, is the same fault as dropping it.
+    ;; Sorted so the diagnostic and its evidence read identically whichever
+    ;; order the author wrote the set in.
+    (let [refused (vec (sort (filter build/refused-property-names props)))
+          many?   (boolean (next refused))]
+      (when (seq refused)
+        (fail :rf.ui.compile/bad-custom-element
+              (str ":properties may not name "
+                   (str/join ", " (map pr-str refused))
+                   " — " (if many? "they are ATTRIBUTES, not JS properties"
+                                   "it is an ATTRIBUTE, not a JS property")
+                   ". :class composes with the .class#id tag sugar and :style "
+                   "carries the CSS map; on a custom element both follow DOM "
+                   "rules exactly as they do on a <div>. A property-classified "
+                   "name is OMITTED from server markup and applied at "
+                   "hydration, so this declaration renders the element with "
+                   (if many? "those values" "that value")
+                   " DROPPED from the HTML. Remove "
+                   (if many? "them" "it")
+                   " from :properties — an undeclared name already travels the "
+                   "attribute grammar, which is the whole answer here.")
+              {:tag tag :properties props :refused refused})))
     ;; compile-time registration (this JVM performs macroexpansion for
     ;; both hosts) routed through the build-scoped model so a removed /
     ;; renamed declaration drops its stale property classification with

--- a/implementation/freehand/src/re_frame/freehand/compiler/build.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/build.cljc
@@ -72,6 +72,43 @@
 ;; and REPL paths (no `:compile-prepare` hook) keep populating the per-source
 ;; `::elements` slice through the macro + lazy own-source harvest below.
 
+(def refused-property-names
+  "The author-space names a `(v/custom-element tag {:properties #{…}})`
+  declaration may never classify as JS properties — `:class` and `:style`.
+
+  Both are ATTRIBUTES with grammars of their own: `:class` composes with the
+  `.class#id` tag sugar and `:style` carries the CSS map, and 004B/004D say so
+  outright — on a custom element, \"booleans/`:class`/`:style` follow DOM
+  rules\" exactly as they do on a `<div>`. Declaring one as a property is a
+  category error rather than an unusual-but-meaningful choice.
+
+  It had to become a REFUSAL because the substrate's answer was silent WRONG
+  OUTPUT. A property-classified name lands in the node's
+  `:rf.ui/property-props` set, and the serialiser omits exactly those names
+  from markup (a server cannot run a property setter; the client applies them
+  at hydration) — so the declaration was accepted and the element rendered
+  with its class and style absent from the HTML, while the structural fold,
+  reading the same declaration but serialising nothing, still carried them.
+  One declaration, two answers, and no diagnostic anywhere, because both
+  answers are structurally well-formed (rf2-oazgv).
+
+  TWO NAMES, and deliberately only two. This is NOT a general
+  attribute-versus-property taxonomy: the declaration remains the sole
+  classifier for every other name, including one that is also a standard HTML
+  attribute spelling (`:tab-index` is the JS property on a tag that declares
+  it). Nor is it a coercion — silently rewriting `:class` into an attribute
+  would be the same sin as silently dropping it. Extending this roster is
+  formally a RULING (rf2-5gliq ruled the v1 `:properties` grammar), not a
+  maintenance edit; a candidate name needs evidence that it is demonstrably a
+  category error, on its own bead.
+
+  Read by the two doors that recognise a declaration: the `v/custom-element`
+  macro validator (`re-frame.freehand.compiler/custom-element**`, which
+  refuses with `:rf.ui.compile/bad-custom-element`) and the syntactic
+  prepare-time harvest (`re-frame.freehand.compiler.harvest`, which declines
+  to SEED what the macro will refuse)."
+  #{:class :style})
+
 ;; `::view-static` is similarly DECOUPLED from the Shadow build path (rf2-u53yy.1
 ;; S3), but by the simplest mechanism of all: its ONLY reader, `v/render-static`,
 ;; is JVM-only (a CLJS expansion is rejected), so a real Shadow build never reads

--- a/implementation/freehand/src/re_frame/freehand/compiler/harvest.clj
+++ b/implementation/freehand/src/re_frame/freehand/compiler/harvest.clj
@@ -95,15 +95,25 @@
   (and (keyword? tag) (nil? (namespace tag))
        (clojure.string/includes? (name tag) "-")))
 
-(defn- valid-properties? [props]
+(defn- valid-properties?
+  "The macro's `:properties` grammar, mirrored: a literal set of unqualified
+  keywords, none of them on the v1 refusal roster
+  (`build/refused-property-names` — `:class`/`:style` are attributes, and
+  classifying one as a property drops it from markup; rf2-oazgv). The roster is
+  READ rather than respelled so the two doors cannot drift: a name this
+  recogniser seeded but the macro refuses would classify props against a
+  declaration the build is about to reject."
+  [props]
   (and (set? props)
-       (every? #(and (keyword? %) (nil? (namespace %))) props)))
+       (every? #(and (keyword? %) (nil? (namespace %))) props)
+       (not-any? build/refused-property-names props)))
 
 (defn- declaration
   "If `form` is a recognized, LITERAL `(<v>/custom-element <tag> <opts>)` — the
   exact shape the macro accepts — return `{:tag tag :properties #{…}}`, else
   nil. Anything the macro would reject (non-literal tag, non-map opts, unknown
-  option, non-literal `:properties`) is NOT recognized here: the macro still
+  option, non-literal `:properties`, a REFUSED property name) is NOT
+  recognized here: the macro still
   expands the form and reports the error with its own coordinates, so the
   declaration never silently seeds a bad classification (rf2-vxgfnd.141)."
   [heads form]

--- a/implementation/freehand/test/re_frame/freehand/custom_element_grammar_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/custom_element_grammar_jvm_test.clj
@@ -1,0 +1,190 @@
+(ns re-frame.freehand.custom-element-grammar-jvm-test
+  "`:class` and `:style` are ATTRIBUTES — a `v/custom-element` declaration may
+  not classify them as JS properties (`:rf.ui.compile/bad-custom-element`).
+
+  WHY THIS IS A REFUSAL AND NOT A CURIOSITY. A property-classified name is
+  omitted from server markup by contract — the serialiser reads the node's
+  `:rf.ui/property-props` set and drops exactly those names, because a server
+  cannot run a property setter and the client applies them at hydration. So
+  `(v/custom-element :x {:properties #{:class :style}})` was ACCEPTED and then
+  rendered `<x ok=\"a\">`: the element's class and style silently absent from
+  the HTML, while the structural fold — which reads the same declaration but
+  serialises nothing — still carried them. One declaration, two answers, wrong
+  output, and no diagnostic anywhere, because both answers are structurally
+  well-formed (rf2-oazgv).
+
+  THE RULING (rf2-oazgv, delegated authority 2026-07-25) is to refuse the
+  declaration rather than to coerce it: `:class` and `:style` join the v1
+  refusal roster and the compiler rejects them at DECLARATION time with a
+  diagnostic naming the attribute-versus-property distinction. Auto-coercing
+  them into attributes would be the same class of sin as dropping them —
+  silently doing what the author probably meant. Two names is the whole
+  remedy: this is not a general attribute-versus-property taxonomy, and every
+  other kebab name on a custom element remains a legitimate property the
+  declaration is the sole classifier for.
+
+  BOTH DOORS ARE TESTED, because the macro is not the only reader of a
+  declaration. `re-frame.freehand.compiler.harvest` re-recognises the literal
+  form SYNTACTICALLY at `:compile-prepare` so a view above its declaration
+  still classifies correctly, and it promises to recognise exactly what the
+  macro accepts. A refusal the harvest did not mirror would seed the very
+  classification the macro is about to reject.
+
+  JVM-only because macroexpansion is: the CLJS lowering paths of an ADMITTED
+  declaration are `custom-element-cljs-test` / `-dom-cljs-test` /
+  `-ssr-jvm-test` (FH-STRUCT-011), and the acceptance rows below exist to
+  prove this refusal did not narrow them."
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.freehand.compiler :as compiler]
+            [re-frame.freehand.compiler.build :as build]
+            [re-frame.freehand.compiler.harvest :as harvest]))
+
+(use-fixtures :each
+  (fn [f] (build/reset-build!) (try (f) (finally (build/reset-build!)))))
+
+;; ---------------------------------------------------------------------------
+;; Harness — the REAL macro body, off any Shadow pass (the plain-JVM door)
+;; ---------------------------------------------------------------------------
+
+(defn- declare-element!
+  "Run the real `v/custom-element` macro body for `tag`/`properties`. `nil`
+  when admitted; the thrown `ExceptionInfo` when refused."
+  [tag properties]
+  (binding [*ns* (create-ns 'grammar.probe.ns)]
+    (try
+      (compiler/custom-element*
+       (with-meta (list 'custom-element tag {:properties properties}) {:line 1})
+       {} tag {:properties properties})
+      nil
+      (catch clojure.lang.ExceptionInfo ex ex))))
+
+(defn- refusal
+  "The `:rf.ui.compile/bad-custom-element` evidence of a refused declaration —
+  `nil` when the declaration was ADMITTED, and nil rather than a half-answer
+  when it was refused under some OTHER id, so a row cannot pass by throwing
+  for an unrelated reason."
+  [ex]
+  (when ex
+    (let [d (ex-data ex)]
+      (when (= :rf.ui.compile/bad-custom-element (:rf.ui.compile/error d))
+        {:message (ex-message ex)
+         :tag (:tag d)
+         :refused (:refused d)}))))
+
+(defn- refuses
+  "Declare `tag` with `properties`, asserting it is REFUSED as a bad
+  declaration, that the diagnostic names the attribute-versus-property
+  distinction and every offending name, and that NOTHING was seeded — a
+  refusal that had already written would leave the build classifying props
+  against a manifest nobody authored. Returns the evidence map."
+  [tag properties expected-refused]
+  (let [ev (refusal (declare-element! tag properties))]
+    (is (some? ev)
+        (str tag " " (pr-str properties)
+             " must be refused as :rf.ui.compile/bad-custom-element"))
+    (when ev
+      (is (= expected-refused (:refused ev))
+          "the evidence names every refused property, in a pinned order")
+      (is (= tag (:tag ev)) "the evidence names the declared tag")
+      (let [msg (:message ev)
+            lower (str/lower-case msg)]
+        (is (str/includes? lower "attribute")
+            (str "the diagnostic names the ATTRIBUTE half of the distinction: " msg))
+        (is (str/includes? lower "propert")
+            (str "the diagnostic names the PROPERTY half of the distinction: " msg))
+        (doseq [k expected-refused]
+          (is (str/includes? msg (str k))
+              (str "the diagnostic spells the offending name " k ": " msg)))))
+    (is (= #{} (build/element-properties tag))
+        (str tag " must not be seeded by a refused declaration"))
+    ev))
+
+;; ---------------------------------------------------------------------------
+;; The refusal
+;; ---------------------------------------------------------------------------
+
+(deftest class-declared-as-a-property-is-refused
+  (testing ":class is an attribute that composes with the `.class#id` tag
+            sugar. Classified as a property it is dropped from markup, so
+            the declaration is refused at the declaration."
+    (refuses :ce-grammar-class #{:class} [:class])))
+
+(deftest style-declared-as-a-property-is-refused
+  (testing ":style is an attribute carrying the CSS grammar. Classified as a
+            property it is dropped from markup, so the declaration is refused
+            at the declaration."
+    (refuses :ce-grammar-style #{:style} [:style])))
+
+(deftest both-refused-names-are-reported-together
+  (testing "a declaration naming both is ONE refusal naming both — an author
+            fixing a diagnostic that reported only the first would be told
+            about the second on the next build"
+    (refuses :ce-grammar-both #{:class :style} [:class :style])))
+
+(deftest a-refused-name-beside-legitimate-properties-refuses-the-WHOLE-declaration
+  (testing "the offending name is not quietly dropped from an otherwise fine
+            set: partial admission would leave the element carrying the
+            property lowering for its real properties and no record that the
+            author asked for something impossible"
+    (let [ev (refuses :ce-grammar-mixed #{:help-text :scale :class} [:class])]
+      (when ev
+        (is (not (str/includes? (:message ev) ":help-text"))
+            "and the diagnostic accuses only the refused name")))))
+
+;; ---------------------------------------------------------------------------
+;; The refusal did not narrow the grammar — a legitimate declaration is
+;; still admitted, and still classifies
+;; ---------------------------------------------------------------------------
+
+(deftest a-legitimate-properties-set-is-still-admitted-and-still-classifies
+  (testing "the roster is two names, not a policy about kebab props: an
+            ordinary declaration is admitted and its compile-path
+            classification (`build/element-properties`, what the template
+            analyzer reads) is unchanged"
+    (is (nil? (declare-element! :ce-grammar-ok #{:accent-color :help-text :scale}))
+        "an ordinary declaration is admitted")
+    (is (= #{:accent-color :help-text :scale}
+           (build/element-properties :ce-grammar-ok))
+        "and the compile-path read carries its declared properties")))
+
+(deftest a-property-name-that-merely-LOOKS-attribute-ish-is-still-admitted
+  (testing "the declaration remains the SOLE classifier for every other name.
+            `:tab-index` is a standard HTML attribute spelling and
+            `:class-name` shares a prefix with the refused `:class`; both are
+            legitimate properties of an element whose author says so, and
+            refusing them would be the general taxonomy this ruling excludes."
+    (is (nil? (declare-element! :ce-grammar-attrish #{:tab-index :class-name :style-map}))
+        "an attribute-ish or class/style-prefixed name is not the refused name")
+    (is (= #{:tab-index :class-name :style-map}
+           (build/element-properties :ce-grammar-attrish))
+        "and it classifies as the property it was declared to be")))
+
+;; ---------------------------------------------------------------------------
+;; The harvest mirrors the refusal
+;; ---------------------------------------------------------------------------
+
+(def ^:private refused-source
+  "A well-formed source whose ONLY defect is the refused property name — so a
+  harvest that recognised it would be seeding a declaration the macro is
+  about to reject, and a view expanded before the declaration form would bake
+  the property lowering for `:class`."
+  (str "(ns probe.refused (:require [re-frame.freehand :as v]))\n"
+       "(v/custom-element :ce-harvest-refused {:properties #{:class :style}})\n"))
+
+(def ^:private admitted-source
+  "The positive control: the SAME shape with a legitimate property name. Its
+  recognition is what proves the row above failed on the refused name rather
+  than on the harness."
+  (str "(ns probe.admitted (:require [re-frame.freehand :as v]))\n"
+       "(v/custom-element :ce-harvest-ok {:properties #{:help-text}})\n"))
+
+(deftest the-syntactic-harvest-does-not-seed-a-refused-declaration
+  (testing "`harvest/declarations-in-source` promises to recognise exactly
+            what the macro accepts — the macro stays the authority and
+            reports the error with the declaration's own coordinates"
+    (is (= [] (harvest/declarations-in-source refused-source))
+        "a declaration the macro refuses is not harvested")
+    (is (= [{:tag :ce-harvest-ok :properties #{:help-text}}]
+           (harvest/declarations-in-source admitted-source))
+        "and the recogniser still reads an ordinary declaration")))


### PR DESCRIPTION
## The defect

`(v/custom-element :x {:properties #{:class :style}})` was **accepted**, and the
serialiser then omitted both from markup — observed `<ce-edge ok="a">` with class
and style dropped. A property-classified name is omitted from server HTML *by
contract* (a server cannot run a property setter; the client applies properties at
hydration), so the declaration quietly bought wrong output. The structural fold
reads the same declaration but serialises nothing, so it still carried them: one
declaration, two answers, and no diagnostic anywhere, because both answers are
structurally well-formed.

## The ruling this implements

**rf2-oazgv, mayor ruling (delegated authority, 2026-07-25): REFUSE the
declaration.** `:class` and `:style` join the v1 refusal roster; the compiler
rejects them at declaration time with a diagnostic naming the
attribute-versus-property distinction. `class` and `style` are attributes, not JS
properties — `:class` composes with the `.class#id` tag sugar, `:style` carries the
CSS map, and 004B/004D already say both "follow DOM rules" on a custom element —
so declaring them as `:properties` is a category error, and the substrate's
previous response was wrong markup with nothing reported. Trust-the-programmer
means an ergonomic API with **loud** failures.

Fences honoured, per the ruling's own non-goals:

- **No general attribute-versus-property taxonomy.** Two well-known names is the
  whole remedy. A name that merely *looks* attribute-ish is still admitted, and the
  suite pins that: `:tab-index`, `:class-name` and `:style-map` all remain
  legitimate properties of an element whose author declares them.
- **No coercion.** `:class`/`:style` are not rewritten into attributes. Silently
  doing what the author probably meant is the same class of sin as silently
  dropping it.
- **Roster not widened.** Exactly `#{:class :style}`, with the roster's own
  docstring recording that extending it is formally a ruling (rf2-5gliq ruled the
  v1 `:properties` grammar) and needs a separate bead with evidence.

## The change

| File | What |
|---|---|
| `compiler/build.cljc` | `refused-property-names` — the roster, `#{:class :style}`, with the reason and the not-a-taxonomy fence in its docstring |
| `compiler.cljc` | the refusal in `custom-element**`, under the **existing** `:rf.ui.compile/bad-custom-element` id; evidence `:refused` is sorted so the message reads identically whichever order the author wrote the set in |
| `compiler/harvest.clj` | `valid-properties?` **reads** the roster, so the prepare-time syntactic recogniser declines to seed a declaration the macro will refuse — it promises to recognise exactly what the macro accepts, and a refusal it did not mirror would seed the very classification the build is about to reject |
| `freehand.cljc` | the published macro docstring states the refusal |
| `custom_element_grammar_jvm_test.clj` | new JVM suite (macroexpansion is JVM-only, as its sibling `custom-element-conflict-jvm-test` is) |

No new diagnostic id, no new machinery, no api-manifest row (arglists and public
surface unchanged), no spec edit — 004D §Template grammar already says
`:class`/`:style` follow DOM rules on a custom element, which is exactly what this
enforces. **Nothing under the fenced paths is touched**: no `spec/004D`,
`spec/API.md`, `spec/api-manifest*.edn`, `spec/conformance/freehand/fixtures/**`,
`freehand/{tool,registry}.clj*`, or `implementation/routing/**`.

Deliberately **no conformance row**: this is a declaration-time grammar refusal,
sibling to the un-rowed `custom-element-conflict` macro law, and the fixtures root
is fenced on PR #6963. FH-STRUCT-011 is about the lowering paths of an *admitted*
declaration and stays exactly as it was — the acceptance rows below exist to prove
this refusal did not narrow it. Nothing in the corpus declared `:class`/`:style` as
properties, so no call site changed. The PR #6955 guard fix (`build/element-properties`
keying its fallback on the same fact the read uses) is untouched.

## Proven both ways

The new suite was written and run **before** the fix:

```
before  clojure -M:test -n re-frame.freehand.custom-element-grammar-jvm-test
        Ran 7 tests containing 14 assertions. 9 failures, 0 errors.   rc=1
after   clojure -M:test -n re-frame.freehand.custom-element-grammar-jvm-test
        Ran 7 tests containing 36 assertions. 0 failures, 0 errors.   rc=0
```

The nine pre-fix failures are the refusal rows (`:class`, `:style`, both together,
mixed with legitimate names, and the harvest mirror, which pre-fix returned
`[{:tag :ce-harvest-refused :properties #{:style :class}}]`). The acceptance rows
passed before and after — the suite can tell admission from refusal, so a
green run is not an artefact of everything throwing.

The emitted diagnostic, with the declaration's own source coordinates:

```
re-frame.freehand compile error: :properties may not name :class, :style — they are
ATTRIBUTES, not JS properties. :class composes with the .class#id tag sugar and
:style carries the CSS map; on a custom element both follow DOM rules exactly as
they do on a <div>. A property-classified name is OMITTED from server markup and
applied at hydration, so this declaration renders the element with those values
DROPPED from the HTML. Remove them from :properties — an undeclared name already
travels the attribute grammar, which is the whole answer here.

{:line 7, :rf.ui.compile/error :rf.ui.compile/bad-custom-element, :tag :ce-x,
 :properties #{:style :class}, :refused [:class :style]}
```

## Quality gates

Every runner in the foreground, `rc=$?` captured immediately after it (never
through a pipe), each log cross-checked against its own PASS/FAIL lines.

| Gate | Result | rc |
|---|---|---|
| `implementation/freehand` `clojure -M:test` | 1053 tests / 7141 assertions, 0 failures, 0 errors | **0** |
| `implementation/ssr` `clojure -M:test` (the serialiser/markup path) | 528 tests / 2539 assertions, 0 failures, 0 errors | **0** |
| `npm run test:cljs` | 11362 tests / 56859 assertions, 0 failures, 0 errors | **0** |
| `scripts/test-fast-pr.sh` | `PASS fast PR spine` — JVM spine 2115/10456 and CLJS node 11362/56859, both 0 failures | **0** |
| `python scripts/check_freehand_conformance_index.py --verbose` | 96 rows OK (95 active, 1 retired); census OK, 95 applicable rows | **0** |

Because the `docs/api/` page changed after the spine run above (which classified
the diff as code-only and soft-skipped its own doc gates — the documented
`--with-docs` behaviour), the documentation surface was gated explicitly rather
than left to that skip:

| Gate | Result | rc |
|---|---|---|
| `python -m mkdocs build --strict` | built in 44.8s, no warnings | **0** |
| `clojure -M -m re-frame.api-manifest.doc-api-check` | 322 references in sync; 223 eligible vars each have a page + member entry | **0** |
| `clojure -M -m re-frame.api-manifest.gen --check` | `spec/api-manifest.edn` in sync (549 public vars) — unchanged, as expected | **0** |
| `check_readme_links.py` / `check_doc_slugs.py` / `check_ep_status_sync.py` / `check_runtime_subsystem_grading.py` | all clean | **0** each |
| `clj-kondo` over the five changed Clojure files | errors: 0 (19 warnings, every one pre-existing in these files and informational under the job's `--fail-level error`) | — |

The custom-element acceptance path specifically: FH-STRUCT-011's four suites
(`custom-element-cljs-test`, `-dom-cljs-test`, `-ssr-jvm-test`, plus
`custom-element-conflict-jvm-test` and `-warm-staleness-jvm-test`) are inside the
freehand and `test:cljs` runs above and are unchanged — a legitimate `:properties`
set is still accepted and still produces the property lowering on every path.

Closes rf2-oazgv.
