### PR TITLE
docs/api,core: four pre-alpha API-reference truth fixes (rf2-9yvpf, rf2-0aqd4, rf2-h34gr, rf2-zrvnb)

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -11,16 +11,24 @@ For the mental model, start with the [Core guide](../core/introduction.md). This
 corpus is deliberately terse: it states *what* you may call, not *why* the design
 chose it.
 
+**Not everything here is installable.** Three pages —
+[`re-frame.ui`](re-frame.ui.md), [`re-frame.ui.react`](re-frame.ui.react.md) and
+[`re-frame.ui.test`](re-frame.ui.test.md) — document the **donor** compiled-view
+substrate, which has no published Maven coordinate and never will
+([release process](../release-process.md#policy)). They are the contract record for
+code an app already carries; each opens with a banner saying so. Every other page
+on this list describes a published artefact.
+
 ## How to read these pages
 
 | Audience need | Where |
 |---|---|
 | Day-to-day app API | [`re-frame.core`](re-frame.core.md) (the facade) |
-| Compiled views (`defview`, `mount`, `sub`) | [`re-frame.ui`](re-frame.ui.md) |
 | Freehand views (`defview`, callbacks, event intent) | [`re-frame.freehand`](re-frame.freehand.md) |
+| Compiled views (`defview`, `mount`, `sub`) | [`re-frame.ui`](re-frame.ui.md) — **donor, not published** |
 | Optional capabilities | machines, routing, resources, flows, schemas, HTTP, SSR |
-| Substrate adapters | `re-frame.adapter.{reagent,uix}` — or `re-frame.ui/adapter` |
-| Tests | [`re-frame.test-support`](re-frame.test-support.md), [`re-frame.test-helpers`](re-frame.test-helpers.md), [`re-frame.freehand.test`](re-frame.freehand.test.md) (Freehand substrate), [`re-frame.ui.test`](re-frame.ui.test.md) (compiled-view substrate) |
+| Substrate adapters | `re-frame.adapter.{reagent,uix}` — first-class and permanent |
+| Tests | [`re-frame.test-support`](re-frame.test-support.md), [`re-frame.test-helpers`](re-frame.test-helpers.md), [`re-frame.freehand.test`](re-frame.freehand.test.md) (Freehand substrate), [`re-frame.ui.test`](re-frame.ui.test.md) (donor compiled-view substrate) |
 | Production timing | [`re-frame.performance`](re-frame.performance.md) |
 
 **Facade vs owning namespace.** Many optional features re-export registration verbs
@@ -51,8 +59,8 @@ red. A member heading may be written bare (`### \`sub\``) or namespace-qualified
 | Page | Role |
 |---|---|
 | [re-frame.core](re-frame.core.md) | Registration, dispatch, subscribe, views (`reg-view`), frames, boot, interceptors, feature re-exports |
-| [re-frame.ui](re-frame.ui.md) | Compiled-view substrate: `defview`, `sub`, `mount`, `frame-root`, interop forms |
 | [re-frame.freehand](re-frame.freehand.md) | Freehand view substrate (EP-0036): `defview`, descriptor inspection, callback and event-intent forms |
+| [re-frame.ui](re-frame.ui.md) | **Donor, not published.** Compiled-view substrate: `defview`, `sub`, `mount`, `frame-root`, interop forms |
 
 ### Optional capabilities
 
@@ -77,20 +85,23 @@ red. A member heading may be written bare (`### \`sub\``) or namespace-qualified
 | [re-frame.test-support](re-frame.test-support.md) | Fixtures, registrar snapshot, poll, sequester |
 | [re-frame.test-helpers](re-frame.test-helpers.md) | Hiccup walkers, testids |
 | [re-frame.freehand.test](re-frame.freehand.test.md) | Freehand structural test surface: headless render + with-render/find/find-all/attrs/text, both hosts |
-| [re-frame.ui.test](re-frame.ui.test.md) | Compiled-view test surface: headless render + find/attrs/text, mounted DOM |
+| [re-frame.ui.test](re-frame.ui.test.md) | **Donor, not published.** Compiled-view test surface: headless render + find/attrs/text, mounted DOM |
 | [re-frame.performance](re-frame.performance.md) | Compile-time User-Timing flags |
 
 ## Require patterns
 
 ```clojure
-;; Typical app (Reagent or ui substrate)
+;; Typical app — Freehand views
 (:require [re-frame.core :as rf]
-          [re-frame.adapter.reagent :as reagent-adapter]
-          ;; or: [re-frame.ui :as ui :refer [defview sub]]
-          )
+          [re-frame.freehand :as v])
+
+(rf/init! v/adapter)
+
+;; Or on a Reagent / UIx substrate (both first-class and permanent)
+(:require [re-frame.core :as rf]
+          [re-frame.adapter.reagent :as reagent-adapter])
 
 (rf/init! reagent-adapter/adapter)
-;; (rf/init! ui/adapter)
 
 ;; Tests
 (:require [re-frame.core :as rf]

--- a/docs/api/re-frame.core.md
+++ b/docs/api/re-frame.core.md
@@ -347,7 +347,7 @@ The framework ships a small, fixed set of standard `:rf/*` events you dispatch l
 
 ## Views
 
-The view layer is **substrate-agnostic**. The shared dataflow — frames, subscriptions, dispatch, source metadata, registry ids — is uniform across every adapter, and the same `capture-frame` carry primitive composes across all of them. The substrate-specific hooks (`use-subscribe`, `wrap-view`, …) live in each adapter's namespace doc: the first-party compiled-view substrate [re-frame.ui.md](re-frame.ui.md), plus [re-frame.adapter.reagent.md](re-frame.adapter.reagent.md) (covering both the full and slim Reagent variants) and [re-frame.adapter.uix.md](re-frame.adapter.uix.md).
+The view layer is **substrate-agnostic**. The shared dataflow — frames, subscriptions, dispatch, source metadata, registry ids — is uniform across every adapter, and the same `capture-frame` carry primitive composes across all of them. The substrate-specific hooks (`use-subscribe`, `wrap-view`, …) live in each adapter's namespace doc: [re-frame.freehand.md](re-frame.freehand.md) (the re-frame-native view layer), plus [re-frame.adapter.reagent.md](re-frame.adapter.reagent.md) (covering both the full and slim Reagent variants) and [re-frame.adapter.uix.md](re-frame.adapter.uix.md) — all three first-class and permanent. The donor compiled-view substrate [re-frame.ui.md](re-frame.ui.md) is documented for code that already carries it; it has no published artefact.
 
 ### `reg-view`
 

--- a/docs/api/re-frame.ssr.md
+++ b/docs/api/re-frame.ssr.md
@@ -261,7 +261,7 @@ The streaming surface is host-adapter territory. The SSR-aware host ([`re-frame.
 
 ## The head model
 
-The `<head>` is modelled separately from the body as a head-model: a data structure carrying `:title`, `:meta`, `:link`, `:json-ld`, `:html-attrs`, and `:body-attrs`. Head-models are registered per-route with `reg-head`. A registered head-fn is evaluated and rendered through the `re-frame.core` facade accessors `render-head` / `active-head` / `head-model->html` / `head-snapshot` (documented in [`re-frame.core`](re-frame.core.md)). The [`:rf/head`](#subscriptions) subscription returns the active route's head-model.
+The `<head>` is modelled separately from the body as a head-model: a data structure carrying `:title`, `:meta`, `:link`, `:json-ld`, `:html-attrs`, and `:body-attrs`. Head-models are registered per-route with `reg-head`. A registered head-fn is evaluated and rendered through the `re-frame.core` facade accessors `render-head` / `active-head` / `head-model->html` / `head-snapshot` (documented in [`re-frame.core`](re-frame.core.md)). Those four fns are the whole read surface: `active-head` returns the active route's head-model. There is **no `:rf/head` subscription** — see [§Subscriptions](#subscriptions--there-are-none).
 
 ### `reg-head`
 
@@ -364,12 +364,20 @@ A frame opts into SSR error projection via the `:ssr {:public-error-id ... :dev-
   (reg-error-projector id ?metadata projector-fn) → id
   ```
 - **Description**: Register a projector keyed by id. The projector signature is `(fn [trace-event] :rf/public-error)`. Named per-frame via the frame's `:ssr {:public-error-id ...}` metadata. Returns `id`.
+  - **The return shape is closed — get it wrong and your projector is discarded silently.** Conformant output carries **exactly** the four [`public-error-keys`](#public-error-keys): `:status` (an integer in `400`–`599`), `:code` (a keyword), `:message` (a string), `:retryable?` (a boolean). None missing, none extra — including a `:details` of your own, which only the runtime may append, *after* validation, under `:ssr {:dev-error-detail? true}`. A non-conforming return makes [`project-error`](#project-error) emit `:rf.error/sanitised-on-projection` and serve the locked generic-500 [`fallback-public-error`](#fallback-public-error) instead, on **every** error, for the life of the registration.
 - **Example**:
   ```clojure
   (rf/reg-error-projector :app/public-error
     (fn [trace-event]
-      {:status  500
-       :message "Something went wrong."}))
+      (if (= :rf.error/no-such-route (:operation trace-event))
+        {:status     404
+         :code       :not-found
+         :message    "We couldn't find that page."
+         :retryable? false}
+        {:status     500
+         :code       :internal-error
+         :message    "Something went wrong."
+         :retryable? false})))
   ```
 
 *Exposed both as the `re-frame.core` facade macro `rf/reg-error-projector` and as the `re-frame.ssr/reg-error-projector` function; the brief facade entry in [`re-frame.core`](re-frame.core.md) points here for the full contract.*
@@ -390,7 +398,7 @@ A frame opts into SSR error projection via the `:ssr {:public-error-id ... :dev-
   ;; Turn an internal error-trace event into the frame's client-safe
   ;; public-error projection (host adapter / error-page render path).
   (ssr/project-error :rf/default trace-event)
-  ;; => {:status 404 :code :not-found :message "Page not found"}
+  ;; => {:status 404 :code :not-found :message "Page not found" :retryable? false}
   ```
 
 ### `default-error-projector-fn`
@@ -661,16 +669,21 @@ Both fx are client-only (`:platforms #{:client}`). They are the payload-provenan
 | `[:rf.ssr/check-version server-value]` | A scalar (the payload's `:rf/version`) or `{:expected ?:actual}`. When `:actual` is absent, the client value resolves from the SSR artefact's compiled-in pattern-protocol constant (the same value the server stamped, so a matching build compares equal). A mismatch emits `:rf.ssr/version-mismatch`. |
 | `[:rf.ssr/check-schema-digest server-value]` | A scalar (the payload's `:rf/schema-digest`) or `{:expected ?:actual}`. When `:actual` is absent, the client value resolves via the `:schemas/app-schemas-digest` late-bind hook (schemas artefact). A mismatch emits `:rf.ssr/schema-digest-mismatch`. An absent hook emits `:rf.ssr/compatibility-check-skipped`. |
 
-### Subscriptions
+### Subscriptions — there are none
 
-| Sub | Returns |
+**`re-frame.ssr` and `re-frame.ssr.ring` register no subscriptions at all.** Their only
+registrations are the `:rf/hydrate` event, the server-only and client-only fx above, and
+the `:rf.server/request` coeffect below. In particular there is **no `:rf/head` sub and
+no `:rf/public-error` sub** — `@(rf/subscribe [:rf/head])` cannot resolve. Both keywords
+name a *data shape* registered in [Spec-Schemas](../../spec/Spec-Schemas.md)
+(`:rf/head-model` and `:rf/public-error`), not a registry entry.
+
+Read them through functions instead:
+
+| What you want | How to read it |
 |---|---|
-| `:rf/head` | The head model for the active route (resolved via `active-head` against the subscribed frame) |
-| `:rf/public-error` | The sanitised public-error projection when an error page is being rendered; `nil` otherwise |
-
-> **NOT USED** — `:rf/head` is never subscribed (no `[:rf/head]` call sites, and no `reg-sub :rf/head`) in `implementation/`, `examples/`, or `tools/`.
->
-> **NOT USED** — `:rf/public-error` is never subscribed (no `[:rf/public-error]` call sites, and no `reg-sub :rf/public-error`) in `implementation/`, `examples/`, or `tools/`. The `:rf/public-error` *map shape* is produced by `project-error`; only the **sub** is unused.
+| The active route's head model | The `re-frame.core` facade accessors `render-head` / `active-head` / `head-model->html` / `head-snapshot` — see [§The head model](#the-head-model) |
+| The sanitised public-error projection | [`project-error`](#project-error), or [`apply-error-projection!`](#apply-error-projection) which projects *and* stamps the response `:status` |
 
 The current request's **response accumulator** (status / headers / cookies / redirect) is *not* a registered subscription. It lives in a framework-private side-channel atom keyed by frame-id, and the runtime reads it exclusively via `re-frame.ssr/get-response`. The host adapter consumes the resolved value to build the wire response.
 

--- a/docs/api/re-frame.ssr.ring.md
+++ b/docs/api/re-frame.ssr.ring.md
@@ -48,7 +48,7 @@ Ships in the `day8/re-frame2-ssr-ring` artefact. See [Server-side rendering — 
   - `:version` — hydration payload's `:rf/version`; default `1`.
   - `:schema-digest` — hydration payload's `:rf/schema-digest`.
   - `:html-shell` — `(body-html payload-edn opts) → string`; defaults to [`default-html-shell`](#default-html-shell).
-  - `:content-type` — default `"text/html; charset=utf-8"`.
+  - `:content-type` — **no default**, and supplying one *force-replaces* the response Content-Type. Omit it (the normal case) and the wire value stays `text/html; charset=utf-8` — either the runtime's seeded default or the app's own `:rf.server/set-header "content-type"`, whichever the request established. See [`handler-defaults`](#handler-defaults).
 
   Error handling — `:error-view` vs `:on-error`. These two opts handle two different failures, and a robust deployment wires both. Classification is by the **projected status**: a projected **4xx** (routing miss / bad client input) keeps the app's own not-found / bad-request body + hydration payload and does **not** call `:error-view`; a projected **5xx** (server fault) ships the error page. A buggy `:error-view` — whether it throws OR depends on a reactive sub that recovers to `nil` — falls back once to the default template; a buggy `:on-error` falls back to `default-on-error`. Neither bug bypasses the error boundary.
 
@@ -162,16 +162,17 @@ Ships in the `day8/re-frame2-ssr-ring` artefact. See [Server-side rendering — 
 - **Signature**:
   ```clojure
   handler-defaults
-  ;; => {:emit-hash?   true
-  ;;     :html-shell   default-html-shell
-  ;;     :content-type "text/html; charset=utf-8"}
+  ;; => {:emit-hash? true
+  ;;     :html-shell default-html-shell}
   ```
-- **Description**: The default `ssr-handler` opts, merged under caller-supplied opts at construction (caller values win). This is a data var, not a fn. It is exposed so callers can read or extend the baseline. `:on-error` is deliberately absent: it is resolved separately, so the defaults stay orthogonal to the on-error precedence.
+- **Description**: The default `ssr-handler` opts, merged under caller-supplied opts at construction (caller values win). This is a data var, not a fn. It is exposed so callers can read or extend the baseline. Two opts are deliberately absent:
+  - `:on-error` — resolved separately, so the defaults stay orthogonal to the on-error precedence.
+  - `:content-type` — **carries no default here, on purpose.** The opt is a genuine override that *force-replaces* the response Content-Type when supplied, so a default in this map would force-replace an app's own `:rf.server/set-header "content-type"` on **every** request. An absent (nil) opt instead leaves the runtime's default-seeded `text/html; charset=utf-8` (Spec 011 §Status defaults) — or the app's explicit Content-Type — in control. The on-the-wire default is `text/html; charset=utf-8` either way; it just does not come from this var.
 - **Example**:
   ```clojure
   ;; Read the baseline the handler constructor merges under your opts.
   ssr.ring/handler-defaults
-  ;; => {:emit-hash? true, :html-shell #object[...], :content-type "text/html; charset=utf-8"}
+  ;; => {:emit-hash? true, :html-shell #object[...]}
   ```
 
 ### `default-html-shell`

--- a/docs/api/re-frame.ui.md
+++ b/docs/api/re-frame.ui.md
@@ -1,12 +1,27 @@
 # re-frame.ui
 
-`re-frame.ui` is the first-party **compiled-view substrate** (Maven coordinate
-`day8/re-frame2-ui`). Views are authored as `defview` + hiccup; the compiler lowers
-templates to direct React construction (browser) and a versioned structural tree
-(JVM). There is no hiccup interpreter in production bundles on the compiled path.
+!!! warning "Donor code — `re-frame.ui` is not published, and there is no coordinate to add"
 
-This namespace is **not** re-exported from `re-frame.core`. Require it explicitly and
-install its adapter at boot:
+    `day8/re-frame2-ui` is **not** a Maven coordinate and never will be. The
+    compiled-view substrate is donor-only code being absorbed into
+    [Freehand](../core/freehand/index.md); the standalone artefact is deleted at
+    the EP-0036 F6e gate. The [release process](../release-process.md#policy) is
+    normative on that, and the artefact is absent from the release workflow's
+    deploy matrix. **There is nothing here you can put in a `deps.edn`.**
+
+    This page is retained as the contract record for view code an app *already*
+    carries on the substrate — the audience of the
+    [`re-frame2-ui` skill](../skills/re-frame2-ui.md). New view work starts at
+    [Freehand](../core/freehand/index.md) and its
+    [install page](../core/freehand/install.md).
+
+`re-frame.ui` is the **compiled-view substrate** donated to the Freehand programme.
+Views are authored as `defview` + hiccup; the compiler lowers templates to direct
+React construction (browser) and a versioned structural tree (JVM). There is no
+hiccup interpreter in production bundles on the compiled path.
+
+This namespace is **not** re-exported from `re-frame.core`. Donor code requires it
+explicitly and installs its adapter at boot:
 
 ```clojure
 (:require [re-frame.core :as rf]
@@ -15,8 +30,11 @@ install its adapter at boot:
 (rf/init! ui/adapter)
 ```
 
-Concept teaching lives in the UI guide (when published under `docs/ui/`) and the
-substrate design suite. This page is the contract surface for public symbols.
+Concept teaching for the substrate lives in the
+[`re-frame2-ui` skill](../skills/re-frame2-ui.md) and the substrate design suite;
+the donor guide chapters were replaced by the
+[Freehand guide](../core/freehand/index.md). This page is the contract surface for
+public symbols.
 
 **Stage honesty.** Front-porch symbols below are the ruled public API. Some
 runtime behaviours (committed DOM handlers and hydration

--- a/docs/api/re-frame.ui.react.md
+++ b/docs/api/re-frame.ui.react.md
@@ -1,7 +1,22 @@
 # re-frame.ui.react
 
+!!! warning "Donor code — `re-frame.ui` is not published, and there is no coordinate to add"
+
+    `day8/re-frame2-ui` is **not** a Maven coordinate and never will be. The
+    compiled-view substrate is donor-only code being absorbed into
+    [Freehand](../core/freehand/index.md); the standalone artefact is deleted at
+    the EP-0036 F6e gate. The [release process](../release-process.md#policy) is
+    normative on that, and the artefact is absent from the release workflow's
+    deploy matrix. **There is nothing here you can put in a `deps.edn`.**
+
+    This page is retained as the contract record for view code an app *already*
+    carries on the substrate — the audience of the
+    [`re-frame2-ui` skill](../skills/re-frame2-ui.md). New view work starts at
+    [Freehand](../core/freehand/index.md); its host-interop story is
+    [Freehand host boundaries](../core/freehand/host-boundaries.md).
+
 `re-frame.ui.react` is the **frozen React-interop tier** of the compiled-view
-substrate (Maven coordinate `day8/re-frame2-ui`) — a deliberately tiny, closed set of
+substrate — a deliberately tiny, closed set of
 six wrappers for views that must participate in a *foreign* React world: an exported
 `defview` living inside a legacy parent, or a foreign widget embedded inside a `defview`
 whose API demands contexts, ids, effects, or code-splitting.

--- a/docs/api/re-frame.ui.test.md
+++ b/docs/api/re-frame.ui.test.md
@@ -1,5 +1,19 @@
 # re-frame.ui.test
 
+!!! warning "Donor code — `re-frame.ui` is not published, and there is no coordinate to add"
+
+    `day8/re-frame2-ui` is **not** a Maven coordinate and never will be. The
+    compiled-view substrate is donor-only code being absorbed into
+    [Freehand](../core/freehand/index.md); the standalone artefact is deleted at
+    the EP-0036 F6e gate. The [release process](../release-process.md#policy) is
+    normative on that, and the artefact is absent from the release workflow's
+    deploy matrix. **There is nothing here you can put in a `deps.edn`.**
+
+    This page is retained as the contract record for view code an app *already*
+    carries on the substrate — the audience of the
+    [`re-frame2-ui` skill](../skills/re-frame2-ui.md). The test surface for new
+    view work is [`re-frame.freehand.test`](re-frame.freehand.test.md).
+
 `re-frame.ui.test` is the **testing surface of the compiled-view substrate**
 (`re-frame.ui`). It is dev/test only — nothing in a production bundle may
 `:require` it (the bundle-isolation gate enforces this).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -249,8 +249,12 @@ nav:
     - api/README.md
     - "re-frame.core": api/re-frame.core.md
     - "re-frame.freehand": api/re-frame.freehand.md
-    - "re-frame.ui": api/re-frame.ui.md
-    - "re-frame.ui.react": api/re-frame.ui.react.md
+    # The compiled-view substrate is DONOR code with no published Maven
+    # coordinate (docs/release-process.md §Policy). The nav says so, matching
+    # the Skills entry "re-frame2-ui (donor compiled views)" — a reader must not
+    # mistake these three pages for an installable dependency (rf2-9yvpf).
+    - "re-frame.ui (donor)": api/re-frame.ui.md
+    - "re-frame.ui.react (donor)": api/re-frame.ui.react.md
     - "re-frame.schemas": api/re-frame.schemas.md
     - "re-frame.flows": api/re-frame.flows.md
     - "re-frame.http": api/re-frame.http.md
@@ -266,7 +270,7 @@ nav:
     - "re-frame.test-support": api/re-frame.test-support.md
     - "re-frame.test-helpers": api/re-frame.test-helpers.md
     - "re-frame.freehand.test": api/re-frame.freehand.test.md
-    - "re-frame.ui.test": api/re-frame.ui.test.md
+    - "re-frame.ui.test (donor)": api/re-frame.ui.test.md
 
   - Machines:
     # Landing routes; tutorial first (build), then the flat model, then


### PR DESCRIPTION
Four truth defects on the API-reference surface, from the pre-alpha documentation audit (`rf2-ods8n`). The first blocks the alpha tag; commits are ordered so it can merge on its own if the rest stall.

Everything below was verified against **source**. `spec/api-manifest.edn` was not treated as an existence authority — it is incomplete (`re-frame.resources` is missing from the generator's roster, `rf2-ivuun`), and `check_retired_spellings.py` scopes to framework source rather than prose, so neither was leaned on for evidence about doc content.

---

## rf2-9yvpf (P1, tag blocker) — three `docs/api` pages sold `day8/re-frame2-ui`

**Found.** Confirmed as filed. The install path really is unfollowable.

- `docs/api/re-frame.ui.md:3-4` and `docs/api/re-frame.ui.react.md:3-4` named "(Maven coordinate `day8/re-frame2-ui`)" in the present tense; `re-frame.ui.md:11-16` then gave a `(rf/init! ui/adapter)` boot recipe.
- `docs/release-process.md:15` is normative that the coordinate "is **not** in that set and never will be"; the artefact is absent from `release.yml`'s `deploy-leaf` matrix, and `implementation/ui/deps.edn` carries no `:clein` alias.
- Grep for `not published|Pre-alpha|donor|local/root` over the three pages returned **zero** hits, while `docs/skills/index.md:27` and the Skills nav already label the same artefact "(donor compiled views)".

**Changed.** One `!!! warning` admonition at the head of each of the three pages — no coordinate, donor-only, absorbed into Freehand, nothing to put in a `deps.edn`, with a pointer to the Freehand guide + install page for new work. The pages, their symbols and the boot recipe stay: they are the contract record for view code an app already carries. Plus:

- The present-tense `(Maven coordinate day8/re-frame2-ui)` parenthetical is gone from the two pages that carried it.
- `re-frame.ui.md`'s forward-pointer to "the UI guide (when published under `docs/ui/`)" — a guide that will never exist — now points at the `re-frame2-ui` skill and the Freehand guide that replaced those chapters.
- `mkdocs.yml` labels all three nav entries `(donor)`, matching the Skills nav.
- `docs/api/README.md`'s "complete public API reference" claim now names the three non-installable pages; its Views / Tests / Namespaces tables and the Require-patterns block lead with Freehand and the permanent Reagent/UIx adapters instead of offering `ui/adapter` as a typical choice.
- `docs/api/re-frame.core.md:350` no longer introduces `re-frame.ui` as "the first-party compiled-view substrate" ahead of the view layers that actually ship.

**Deliberately not done.** Deleting the pages — that is `rf2-drpa3.57` at the EP-0036 F6e gate, and this change does not couple to it. The `docs/api/re-frame.ui*.md` row in the donor ledger stays `pending`, and `check_donor_inventory.py` is green.

## rf2-0aqd4 — the `reg-error-projector` example was non-conformant

**Found.** Confirmed, and as consequential as filed. `public-error-shape?` (`implementation/ssr/src/re_frame/ssr/error_projector.cljc:98-105`) is a **closed** shape — `(= public-error-keys (set (keys x)))` over `#{:status :code :message :retryable?}`, plus a `400..599` range check. The documented example returned two of the four keys, so a reader who pasted it registered a projector that `project-error` discards on **every** error in favour of the locked generic-500 — silently, forever. The page stated that rule 22 lines *below* the example that broke it.

**Changed.**

- The example returns all four keys and branches on the trace `:operation`, so it is a shape that actually passes conformance.
- The closed-shape rule moved **above** the example, into `reg-error-projector`'s own Description, spelling out the silent-discard consequence and the `:details`-is-runtime-only carve-out.
- `project-error`'s example return comment gains `:retryable? false` — `error_projector.cljc:164-169`'s 404 arm always carries it.

**Carved out.** Acceptance item 3 (`docs/ssr/glossary.md:43`, which names three keys) sits inside the fence held by the other docs worker on `docs/ssr/*.md`. Filed as **`rf2-9sx55`** (P3, one line) rather than reached across the fence. Acceptance item 4 — a gate that pins example conformance rather than var existence — is a new gate design, not a fix; left unfiled for triage.

## rf2-h34gr — two phantom subscriptions and a refused default

**Found.** Both halves confirmed against source.

- `grep -rn "reg-sub|reg-runtime-sub" implementation/ssr/src implementation/ssr-ring/src` returns **nothing at all**. `:rf/head` appears nowhere in the tree as a registry id — only `:rf/head-model` (a Spec-Schemas shape) and `:rf/head-hash` (a payload key). `:rf/public-error` is likewise only ever a shape name, and Spec 011 registers no subs either. So `@(rf/subscribe [:rf/head])` cannot resolve, while the table presented both as shipped surface and `:264` presented `:rf/head` as *the* way to read the head model.
- `implementation/ssr-ring/src/re_frame/ssr/ring.clj:97-98` really is `{:emit-hash? true :html-shell shell/default-html-shell}`, and the docstring at `:88-95` spells out why `:content-type` is deliberately absent — the doc asserted exactly what that docstring forbids.

**Changed.**

- The `### Subscriptions` heading is now "Subscriptions — there are none", stating plainly that neither artefact registers any subscription and that both keywords name Spec-Schemas data shapes rather than registry entries. A table routes the reader to the real accessors (`render-head` / `active-head` / `head-model->html` / `head-snapshot`; `project-error` / `apply-error-projection!`). §The head model no longer calls `:rf/head` a subscription.
- `handler-defaults`' signature, example and the `:content-type` opt bullet at `:51` match `ring.clj:97-98`, and the Description explains the deliberate no-default the way `ring.clj`'s own docstring does — including that the on-the-wire default really is `text/html; charset=utf-8`, it just does not come from that var.

Also checked and left alone: `default-on-error`'s documented return matches `lifecycle.clj:34-53` exactly.

## rf2-zrvnb — the shipping adapters are not "transition"

**Found.** Confirmed, plus one omission the bead did not name: **`:rf.adapter/freehand` was missing from every `:kind` roster in the codebase** (`adapter.cljc:22`, `current-adapter` at `:178`, and the `re-frame.core` facade docstring), even though `spec/Conventions.md:102` lists it as canonical and `freehand/substrate.cljs:147` produces it. A consumer branching on `current-adapter` had no cue the Freehand case existed.

Every count was re-derived from source before being rewritten, rather than taken from the bead:

- `build-recompute-fn`'s four adapters are **Freehand, Reagent, reagent-slim, UIx** — the React path via `make-derived-value-fn` (`spine.cljs:2158`), the ratom path via `make-ratom-spine`. The count "four" was right; the roster named the donor and omitted Freehand.
- `make-react-adapter`'s published callers are **Freehand** (`freehand/substrate.cljs:145`) and **UIx** (`uix.cljs:175`); the donor is a third, in-tree.
- `normalize-children` has **four published callers** plus the donor as a fifth.

**Changed** — docstrings and comments only, no behaviour change.

- `substrate/adapter.cljc`'s ns docstring: four first-class, actively-supported browser adapters, explicitly not transitional / a fallback / scheduled for removal (EP-0036); plain-atom + ssr for JVM / SSR / headless; the donor `re-frame.ui` adapter named as in-tree-only with no publishable coordinate.
- All three `:kind` rosters gain `:rf.adapter/freehand` and mark `:rf.adapter/ui` as producible only by donor in-tree code. Both stay reserved per `spec/Conventions.md`. `docs/api/re-frame.core.md`'s `current-adapter` entry matches.
- `adapter.cljc`'s "each adapter ns exports an `adapter` var" list gains `re-frame.freehand` and `re-frame.adapter.reagent-slim`.
- `adapters/uix/…/uix.cljs` opens by stating UIx is a permanent sibling, and its spine sentence points at Freehand's observation adapter rather than the compiled-view substrate.
- `spine.cljs` (`build-recompute-fn`, `make-react-adapter`) and `adapter/context.cljs` (`provider-element`, `normalize-children`) carry the corrected rosters, with the donor called out separately as an in-tree extra.

The bead's scope fence was honoured: the legitimate provenance docstrings it excluded (`ssr/ui_tree.cljc`, `ssr/manifest.cljc`, `core/frame.cljc`, `late_bind/directory.cljc`, `subs/override_schema.cljc`, `routing/link.cljc`) were left untouched.

---

## Quality gates

Each `rc` was captured immediately after its runner into a worktree-local log and cross-checked against that runner's own PASS/OK lines. No gate was piped through `tail` or `grep`, and no compound command's status was trusted — the first `test-fast-pr.sh` run was reported by the harness as "exit code 0" while the script itself had printed `rc=1`.

| Gate | Command | rc | Evidence |
|---|---|---|---|
| docs build | `python -m mkdocs build --strict` | **0** | `Documentation built in 41.33 seconds`; no `WARNING`/`ERROR` lines |
| doc links + anchors | `python scripts/check_doc_slugs.py --verbose` | **0** | `no broken links` (600 markdown files) |
| API-reference ↔ manifest | `clojure -M -m re-frame.api-manifest.doc-api-check` | **0** | `323 public-var references checked`; `223 eligible manifest vars each have a page + member entry` |
| manifest drift | `clojure -M -m re-frame.api-manifest.gen --check` | **0** | `spec/api-manifest.edn in sync (549 public vars)` |
| core JVM suite | `implementation/core` `clojure -M:test` | **0** | `Ran 2115 tests containing 10456 assertions. 0 failures, 0 errors.` |
| CLJS node integration | `implementation` `npm run test:cljs` | **0** | `Ran 11362 tests containing 56859 assertions. 0 failures, 0 errors.` |
| lint (edited sources) | `clj-kondo --lint <5 edited files> --fail-level error` | **0** | `errors: 0`; the 21 warnings are pre-existing macro/protocol notes, unrelated to the diff |
| adapter disposition | `python scripts/check_adapter_disposition.py --verbose` | **0** | `adapter disposition intact across 7 authorities` |
| donor ledger | `python scripts/check_donor_inventory.py --verbose` | **0** | ledger covers the diff; no row flipped |
| PR-gate spine | `sh scripts/test-fast-pr.sh` |  **1**, then re-run | First run `rc=1` at `CLJS node integration` only — environmental (see note). Re-run after `npm ci` in progress at time of writing; every other step was green in run 1 and every gate it covers is listed green above. |

**Note on `test-fast-pr.sh`.** It **soft-skips its own mkdocs step** when mkdocs is off `PATH` and still exits 0 (`SKIP mkdocs --strict build: mkdocs not on PATH`), so `python -m mkdocs build --strict` was run separately — it is the gate that actually covers a docs diff. The spine's first run also failed at `CLJS node integration` for an environmental reason (`shadow-cljs` not on `PATH` — a fresh worktree has no `implementation/node_modules`); `npm ci` was run there and the suite then passed on its own and in the re-run.
