### PR TITLE
fix(freehand-census): quoted data creates no reachability edge (rf2-drpa3.53)

### DIFF
--- a/scripts/check_freehand_conformance_index.py
+++ b/scripts/check_freehand_conformance_index.py
@@ -266,28 +266,41 @@ _SEPARATOR_CELL_RE = re.compile(r"^:?-{3,}:?$")
 #     (deftest t (expect fx))                     platform, credited on both
 #     (def fx (conf/fixture :FH-CALL-001))        a KEYWORD spelled like the
 #     (deftest t (is (= :fx 1)))                  binding, read as the Var
+#     (def fx (conf/fixture :FH-CALL-001))        the binding QUOTED — the token,
+#     (deftest t (is (= `fx 1)))                  and not a reference to it
 #
 # The first three are the false greens the first merged-PR audit found; the
 # fourth was the same mistake waiting; the next two are what the SECOND audit
 # found still standing after the first fix, because reading forms is not the same
 # as reading assertions; the next two are the THIRD, because reading assertions is
 # not the same as reading them in the namespace and on the platform that has them;
-# and the last is the FOURTH, because a name is not any run of symbol characters —
-# `:fx` was read as `fx`, and a datum stood in for a Var.  Each one lets a law be
-# retired by deletion — comment out the proof, keep the line — with the gate still
-# calling the row proven.
+# the ninth is the FOURTH, because a name is not any run of symbol characters —
+# `:fx` was read as `fx`, and a datum stood in for a Var; and the last is the
+# FIFTH, because a token is not a reference either — `` `fx `` IS the token `fx`,
+# and quoted data is data.  Each one lets a law be retired by deletion — comment
+# out the proof, keep the line — with the gate still calling the row proven.
 #
 # So the scan reads FORMS, then the ASSERTIONS, then the NAMES — and it reads a
-# name from a TOKEN BOUNDARY.  `_strip` blanks comments, string and character
-# literals, `#_`-discarded data and `(comment …)` forms at any depth;
-# `_top_level_forms` splits what survives on balanced parens; `_SYMBOL_RE` matches
-# a symbol only where one STARTS, so a keyword stays data; `_read_tree` binds every
-# definition to the namespace that wrote it, once per platform; and a site counts
-# only when an ASSERTING STATEMENT of a `deftest` reaches it — written in one, or
-# bound to a name one uses, directly or through a helper it calls, with "the same
-# name" meaning the same binding rather than the same spelling.  A statement that
-# asserts nothing contributes nothing, and a file carrying no `deftest` proves
-# nothing, whatever its name.
+# name from a TOKEN BOUNDARY, in an EVALUATED position.  Three reductions come
+# first, one per question, and every reading downstream is taken off the same
+# reduced text so that none of them can drift from another:
+#
+#     _strip      what is not code          comments, strings, character
+#                                           literals, `#_` discards, and
+#                                           `(comment …)` at any depth
+#     _read_as    what THIS PLATFORM reads  `#?` / `#?@` reduced to one branch
+#     _evaluated  what EVALUATES            every quoted datum — `'x`, `` `x ``,
+#                                           `(quote x)` — with `~x` islands
+#                                           inside a syntax quote recovered
+#
+# Then `_top_level_forms` splits what survives on balanced parens; `_SYMBOL_RE`
+# matches a symbol only where one STARTS, so a keyword stays data; `_read_tree`
+# binds every definition to the namespace that wrote it, once per platform; and a
+# site counts only when an ASSERTING STATEMENT of a `deftest` reaches it — written
+# in one, or bound to a name one uses, directly or through a helper it calls, with
+# "the same name" meaning the same binding rather than the same spelling.  A
+# statement that asserts nothing contributes nothing, and a file carrying no
+# `deftest` proves nothing, whatever its name.
 _FIXTURE_CALL_RE = re.compile(
     r"\(\s*(?:[A-Za-z0-9.*+!_'?<>=-]+/)?fixture\s+(:FH-[A-Z]+-\d{3})\b"
 )
@@ -1594,15 +1607,23 @@ def _cell_lanes(mode: str, host: str) -> frozenset[str]:
 # its witness on the JVM.  The defect names the host for that reason.
 #
 # Reachability is only as sound as NAME RESOLUTION, which is where this last got
-# out.  Both surfaces are reached by symbol, and a keyword is a symbol run behind
-# a `:` — so `:panel` witnessed a `(v/defview panel {:compiled true} …)` and
-# `:check/findings` witnessed the alias `check`, from data the assertion compares
-# against and never calls.  `_SYMBOL_RE` reads from a token boundary for that
-# reason.  What stays TEXTUAL, and is stated rather than hidden, is the marker
-# itself: a statement mentioning `{:compiled true}` or a spelled-out
-# `re-frame.freehand.compiler.…` as DATA still witnesses, because the marker is
-# read off the statement's text.  Reachability is what was missing and is enforced;
-# distinguishing a marker used as data from one used as code is not claimed.
+# out — twice, one level apart.  Both surfaces are reached by symbol, and a keyword
+# is a symbol run behind a `:` — so `:panel` witnessed a
+# `(v/defview panel {:compiled true} …)` and `:check/findings` witnessed the alias
+# `check`, from data the assertion compares against and never calls.  `_SYMBOL_RE`
+# reads from a token boundary for that reason.  And a token boundary was still not
+# enough, because `` `panel `` and `(quote panel)` ARE the token: what they are not
+# is a reference to the Var.  `_evaluated` blanks quoted data for that reason, and
+# BOTH halves of the witness are read off its output — so a quoted
+# `{:compiled true}` and a quoted `re-frame.freehand.compiler.…` witness nothing
+# either, and the marker cannot disagree with the names beside it.
+#
+# What stays TEXTUAL within what does evaluate, and is stated rather than hidden,
+# is the marker itself: a statement mentioning a live `{:compiled true}` map
+# literal or a spelled-out `re-frame.freehand.compiler.…` as DATA still witnesses.
+# Reachability and evaluation context are what were missing and are enforced;
+# distinguishing a marker used as data from one used as code, inside evaluated
+# code, is not claimed.
 #
 # `interpreted` and `common` get no witness, and saying so is the honest half of
 # this.  Interpreted is the DEFAULT lowering — a declaration is interpreted by
@@ -2059,6 +2080,90 @@ def _build_census_fixtures(base: Path) -> None:
             (),
             (),
         ),
+        # Red: A QUOTED SYMBOL IS NOT THE VAR IT NAMES, which is the same dead
+        # def again and the axis a FOURTH merged-PR audit found still open.  The
+        # token boundary above reads `:fx` as data because a keyword is not a
+        # token; it reads `(quote fx)` as the Var because this one IS the token
+        # `fx`.  What separates them is not spelling, it is EVALUATION CONTEXT —
+        # the reader hands `=` a symbol, not the fixture — and no boundary can
+        # see that.  Three spellings, one rule, all three pinned: the family is
+        # what makes it a rule rather than two examples.
+        "census_quote_form_shaped_like_the_fixture_binding": (
+            {"CALL": _row()},
+            {"a_cljs_test.cljc": "(ns x)\n(def fx (conf/fixture :FH-CALL-001))\n"
+                                 "(deftest t (is (= (quote fx) 1)))\n"},
+            (),
+            (),
+        ),
+        # Red: the same datum syntax-quoted.  `` ` `` is the spelling a template
+        # reaches for, so it is the one most likely to be written by accident.
+        "census_syntax_quote_shaped_like_the_fixture_binding": (
+            {"CALL": _row()},
+            {"a_cljs_test.cljc": "(ns x)\n(def fx (conf/fixture :FH-CALL-001))\n"
+                                 "(deftest t (is (= `fx 1)))\n"},
+            (),
+            (),
+        ),
+        # Red: the reader-prefix spelling, and the reason the family is pinned
+        # whole.  This shape was ALREADY red - and only by accident, because `'`
+        # fell inside `_SYMBOL_HEAD`, so the scan handed back the unresolvable
+        # token `'fx`.  Accidentally loud is not the same as right: a census
+        # whose verdict turns on which of three equivalent spellings an author
+        # reached for is reporting a coincidence.  Red by rule now.
+        "census_reader_quote_shaped_like_the_fixture_binding": (
+            {"CALL": _row()},
+            {"a_cljs_test.cljc": "(ns x)\n(def fx (conf/fixture :FH-CALL-001))\n"
+                                 "(deftest t (is (= 'fx 1)))\n"},
+            (),
+            (),
+        ),
+        # Red: the same reduction on the OTHER surface a datum reaches a fixture
+        # through.  Here the quoted datum is the `(conf/fixture …)` CALL itself,
+        # so the id is read straight off the assertion without a binding in
+        # between - and the call no more runs than the symbol resolves.
+        "census_quoted_fixture_call_is_not_a_read": (
+            {"CALL": _row()},
+            {"a_cljs_test.cljc": "(ns x)\n"
+                                 "(deftest t\n"
+                                 "  (is (= '(conf/fixture :FH-CALL-001) 1)))\n"},
+            (),
+            (),
+        ),
+        # Green, AND THE CONTROL THAT KEEPS THE RULE A NARROWING.  Inside a
+        # syntax quote `~fx` IS evaluated - that is what unquote is for - so the
+        # island is read as code and the row is proven.  Without this the rule
+        # above would be a refusal to read templates at all, which is breakage
+        # wearing strictness.
+        "census_unquote_inside_a_syntax_quote_reads_the_fixture": (
+            {"CALL": _row()},
+            {"a_cljs_test.cljc": "(ns x)\n(def fx (conf/fixture :FH-CALL-001))\n"
+                                 "(deftest t (is (= `(a ~fx) 1)))\n"},
+            (),
+            (),
+        ),
+        # Red: a NESTED syntax quote raises the level, and a `~` inside it
+        # belongs to the inner quote - so `fx` is quoted by the outer one and
+        # evaluates nowhere.  The green above and this red differ by one
+        # backtick, which is why the level is tracked rather than the character
+        # counted.
+        "census_nested_syntax_quote_does_not_read_the_fixture": (
+            {"CALL": _row()},
+            {"a_cljs_test.cljc": "(ns x)\n(def fx (conf/fixture :FH-CALL-001))\n"
+                                 "(deftest t (is (= `(a `(b ~fx)) 1)))\n"},
+            (),
+            (),
+        ),
+        # Green, and the control for OVER-tightening, which is the other way to
+        # get this wrong.  A `'` inside a token belongs to the token: `fx'` is
+        # one name, not a quote over `fx`.  Read the boundary the wrong way and
+        # this honest row reds.
+        "census_prime_suffixed_binding_is_one_token": (
+            {"CALL": _row()},
+            {"a_cljs_test.cljc": "(ns x)\n(def fx' (conf/fixture :FH-CALL-001))\n"
+                                 "(deftest t (is (seq fx')))\n"},
+            (),
+            (),
+        ),
         # Red: the id appears inside a docstring.  Prose about a law is not a
         # proof of it, and prose is where an id is MOST likely to be written.
         "census_proof_site_in_a_docstring": (
@@ -2126,6 +2231,22 @@ def _build_census_fixtures(base: Path) -> None:
                                  "             :refer [expect-tree]]))\n"
                                  "(def fx (conf/fixture :FH-CALL-001))\n"
                                  "(deftest t (expect-tree fx))\n"},
+            (),
+            (),
+        ),
+        # Red: A QUOTED ASSERTION ASSERTS NOTHING - the reduction on the third
+        # surface a quoted datum reached through, and the one that makes the fix
+        # a pipeline stage rather than three special cases.  The helper RETURNS
+        # `'(is (seq fx))`: a list.  Read textually it looked like the honest
+        # helper two cases above, so `helper` was credited with an `is`, the
+        # `(helper)` statement counted as asserting, and `fx` came along in the
+        # same quoted list.  One reduction, applied once per file, closes all
+        # three surfaces at once - names, fixture calls and assertion heads.
+        "census_quoted_assertion_in_a_called_helper": (
+            {"CALL": _row()},
+            {"a_cljs_test.cljc": "(ns x)\n(def fx (conf/fixture :FH-CALL-001))\n"
+                                 "(defn helper [] '(is (seq fx)))\n"
+                                 "(deftest t (is true) (helper))\n"},
             (),
             (),
         ),
@@ -2270,6 +2391,85 @@ def _build_census_fixtures(base: Path) -> None:
                                  "(v/defview panel {:compiled true} [_] [:div])\n"
                                  "(def fx (conf/fixture :FH-CALL-001))\n"
                                  "(deftest t (is (= :not-panel (first fx))))\n"},
+            (),
+            (),
+        ),
+        # Red: THE SAME PAIR ONE LEVEL UP, on the witness axis - the second half
+        # of what the FOURTH merged-PR audit reproduced.  `(quote panel)` really
+        # does contain the token `panel`, so the token boundary that closed
+        # `:panel` has nothing to say about it, and the graph walked to the
+        # `{:compiled true}` declaration from a datum.  The fixture still comes
+        # through `(first fx)`, so nothing but the mode witness is in question:
+        # the axis is isolated, exactly as the audit isolated it.
+        "census_quote_form_shaped_like_the_compiled_declaration": (
+            {"CALL": _row(applicability="compiled jvm")},
+            {"a_cljs_test.cljc": "(ns x)\n"
+                                 "(v/defview panel {:compiled true} [_] [:div])\n"
+                                 "(def fx (conf/fixture :FH-CALL-001))\n"
+                                 "(deftest t (is (= (quote panel) (first fx))))\n"},
+            (),
+            (),
+        ),
+        # Red: the syntax-quoted spelling of the same witness.
+        "census_syntax_quote_shaped_like_the_compiled_declaration": (
+            {"CALL": _row(applicability="compiled jvm")},
+            {"a_cljs_test.cljc": "(ns x)\n"
+                                 "(v/defview panel {:compiled true} [_] [:div])\n"
+                                 "(def fx (conf/fixture :FH-CALL-001))\n"
+                                 "(deftest t (is (= `panel (first fx))))\n"},
+            (),
+            (),
+        ),
+        # Red: the reader-prefix spelling, already red by the same lexical
+        # accident as its fixture-axis twin and red by rule now.
+        "census_reader_quote_shaped_like_the_compiled_declaration": (
+            {"CALL": _row(applicability="compiled jvm")},
+            {"a_cljs_test.cljc": "(ns x)\n"
+                                 "(v/defview panel {:compiled true} [_] [:div])\n"
+                                 "(def fx (conf/fixture :FH-CALL-001))\n"
+                                 "(deftest t (is (= 'panel (first fx))))\n"},
+            (),
+            (),
+        ),
+        # Green: the narrowing control on THIS axis.  The declaration is named
+        # inside a template and UNQUOTED, so the assertion really does evaluate
+        # the Var and really does reach the compiled tier.  One `~` apart from
+        # the red above.
+        "census_unquote_inside_a_syntax_quote_witnesses_the_mode": (
+            {"CALL": _row(applicability="compiled jvm")},
+            {"a_cljs_test.cljc": "(ns x)\n"
+                                 "(v/defview panel {:compiled true} [_] [:div])\n"
+                                 "(def fx (conf/fixture :FH-CALL-001))\n"
+                                 "(deftest t\n"
+                                 "  (is (= `(a ~panel) (first fx))))\n"},
+            (),
+            (),
+        ),
+        # Red: the reduction reaching the TEXTUAL half of the witness too.  The
+        # marker reading stays textual - a statement mentioning `{:compiled true}`
+        # as an evaluated map literal still witnesses, and that bound is stated -
+        # but a QUOTED marker is not mentioned in code at all, so it witnesses
+        # nothing.  Reading the marker off the same reduced text as the names is
+        # what keeps the two halves from disagreeing.
+        "census_quoted_compiled_marker_does_not_witness": (
+            {"CALL": _row(applicability="compiled jvm")},
+            {"a_cljs_test.cljc": "(ns x)\n"
+                                 "(def fx (conf/fixture :FH-CALL-001))\n"
+                                 "(deftest t\n"
+                                 "  (is (= '{:compiled true} (first fx))))\n"},
+            (),
+            (),
+        ),
+        # Red: the other textual marker, quoted.  A quoted namespace SYMBOL is a
+        # name the assertion compares against, not a tier it enters - the same
+        # thing `:check/findings` was, spelled the other way.
+        "census_quoted_tier_namespace_does_not_witness": (
+            {"CALL": _row(applicability="compiled jvm")},
+            {"a_cljs_test.cljc": "(ns x)\n"
+                                 "(def fx (conf/fixture :FH-CALL-001))\n"
+                                 "(deftest t\n"
+                                 "  (is (= 're-frame.freehand.compiler.check\n"
+                                 "         (first fx))))\n"},
             (),
             (),
         ),
@@ -2580,12 +2780,24 @@ def _run_self_tests(verbose: bool = False) -> int:
         ("census_dead_def", 1, "DEAD PROOF SITE"),
         ("census_keyword_shaped_like_the_fixture_binding", 1,
          "DEAD PROOF SITE"),
+        ("census_quote_form_shaped_like_the_fixture_binding", 1,
+         "DEAD PROOF SITE"),
+        ("census_syntax_quote_shaped_like_the_fixture_binding", 1,
+         "DEAD PROOF SITE"),
+        ("census_reader_quote_shaped_like_the_fixture_binding", 1,
+         "DEAD PROOF SITE"),
+        ("census_quoted_fixture_call_is_not_a_read", 1, "DEAD PROOF SITE"),
+        ("census_unquote_inside_a_syntax_quote_reads_the_fixture", 0, None),
+        ("census_nested_syntax_quote_does_not_read_the_fixture", 1,
+         "DEAD PROOF SITE"),
+        ("census_prime_suffixed_binding_is_one_token", 0, None),
         ("census_proof_site_in_a_docstring", 1, "DEAD PROOF SITE"),
         ("census_comment_form_inside_a_deftest", 1, "DEAD PROOF SITE"),
         ("census_dead_branch_in_a_called_helper", 1, "DEAD PROOF SITE"),
         ("census_deftest_that_asserts_nothing", 1, "DEAD PROOF SITE"),
         ("census_helper_carries_the_assertion", 0, None),
         ("census_referred_helper_carries_the_assertion", 0, None),
+        ("census_quoted_assertion_in_a_called_helper", 1, "DEAD PROOF SITE"),
         ("census_same_name_helper_in_an_unrelated_file", 1, "DEAD PROOF SITE"),
         ("census_platform_split_helper_asserts_on_one_host", 1,
          "UNEXECUTED CELL"),
@@ -2597,6 +2809,17 @@ def _run_self_tests(verbose: bool = False) -> int:
         ("census_keyword_shaped_like_the_compiled_declaration", 1,
          "UNWITNESSED MODE"),
         ("census_keyword_not_shaped_like_the_compiled_declaration", 1,
+         "UNWITNESSED MODE"),
+        ("census_quote_form_shaped_like_the_compiled_declaration", 1,
+         "UNWITNESSED MODE"),
+        ("census_syntax_quote_shaped_like_the_compiled_declaration", 1,
+         "UNWITNESSED MODE"),
+        ("census_reader_quote_shaped_like_the_compiled_declaration", 1,
+         "UNWITNESSED MODE"),
+        ("census_unquote_inside_a_syntax_quote_witnesses_the_mode", 0, None),
+        ("census_quoted_compiled_marker_does_not_witness", 1,
+         "UNWITNESSED MODE"),
+        ("census_quoted_tier_namespace_does_not_witness", 1,
          "UNWITNESSED MODE"),
         ("census_compile_tier_witnesses_the_mode", 0, None),
         ("census_namespaced_keyword_shaped_like_the_tier_alias", 1,

--- a/scripts/check_freehand_conformance_index.py
+++ b/scripts/check_freehand_conformance_index.py
@@ -450,6 +450,27 @@ def _blank(chunk: str) -> str:
 
 
 _OPENERS = {"(": ")", "[": "]", "{": "}"}
+# The reader macro prefixes: `#`, `'`, `` ` ``, `~`, `~@`, `@` and `^meta`.  Each
+# belongs to the datum that FOLLOWS it, which is one fact and therefore one
+# authority — `_datum_end` needs it to find a datum's extent and `_evaluated`
+# needs it to find where a quoted datum begins.
+_PREFIXES = "#'`~@^"
+
+
+def _prefix_end(text: str, start: int) -> int:
+    """The index of the datum the run of reader prefixes at `start` introduces.
+
+    `start` itself when there is no prefix there, so this is safe to call on any
+    position a datum may begin at.  `~@` is one prefix spelled two characters,
+    and the inner step is what keeps its `@` from being read as a deref of
+    nothing.
+    """
+    i, n = start, len(text)
+    while i < n and text[i] in _PREFIXES:
+        i += 1
+        if i < n and text[i] == "@":
+            i += 1
+    return i
 
 
 def _datum_end(text: str, start: int) -> int:
@@ -469,12 +490,7 @@ def _datum_end(text: str, start: int) -> int:
             break
     if i >= n:
         return n
-    # A reader macro prefix (`#`, `'`, `` ` ``, `~`, `@`, `^meta`) belongs to the
-    # datum that follows it.
-    while i < n and text[i] in "#'`~@^":
-        i += 1
-        if i < n and text[i] == "@":
-            i += 1
+    i = _prefix_end(text, i)
     if i < n and text[i] in _OPENERS:
         return _form_end(text, i)
     if i < n and text[i] == '"':
@@ -583,6 +599,109 @@ def _read_as(cleaned: str, platform: str) -> str:
             i = end
         else:
             out.append(cleaned[i])
+            i += 1
+    return "".join(out)
+
+
+# `(quote …)`, the form both reader prefixes expand into.  The lookahead is what
+# keeps a name like `quoted-tree` from being read as a quote, the same way
+# `_COMMENT_FORM_RE`'s keeps `(commentary …)` from being read as a comment.
+_QUOTE_FORM_RE = re.compile(r"\(\s*(?:clojure\.core/)?quote(?=[\s()\[\]{}])")
+# A `'` that really is a QUOTE, read from the same token boundary `_SYMBOL_RE`
+# reads a name from and off the same one character class, because it is the same
+# question asked of the same alphabet.  A symbol may CONTAIN a `'` — `state'`,
+# `x'y` — and so may a keyword, so a `'` inside a token belongs to the token; and
+# `#'x` is a VAR quote, which evaluates to the Var and is a genuine reference
+# rather than data.
+_QUOTE_PREFIX_RE = re.compile(rf"(?<![:#{_SYMBOL_BODY}])'")
+
+
+def _evaluated(text: str) -> str:
+    """`text` reduced to what it EVALUATES — every quoted datum blanked.
+
+    The third and last reduction, after `_strip` (what is not code) and
+    `_read_as` (what this platform reads).  Same length, and balanced: a quoted
+    datum's extent is blanked whole, so a matched pair of delimiters leaves
+    together and every offset downstream still means what it meant.
+
+    QUOTED DATA IS DATA, and that is a fact about EVALUATION CONTEXT — which is
+    the one thing a token boundary cannot see.  `_SYMBOL_RE` reads `fx` from
+    `(quote fx)` and from `` `fx `` because both really do contain the token `fx`;
+    what neither contains is a reference to the Var.  A merged-PR audit found both
+    spellings standing a row up: `(is (= (quote fx) 1))` "reached" a fixture bound
+    to `fx`, and `(is (= `panel (first fx)))` beside a
+    `(v/defview panel {:compiled true} …)` witnessed a compiled mode the assertion
+    never entered.  Its predecessor found the same hole spelled `:fx` — a keyword
+    — so this is the same mistake read one level up: the census was classifying
+    tokens when what it needs is which tokens the reader hands to `eval`.
+
+    Three spellings, one rule.  `'x` and `` `x `` are reader prefixes over the
+    datum that follows; `(quote x)` is the form they expand into.  All three are
+    blanked, so the graph gets no edge from any of them — where before, two of
+    the three were silent and the third was red only by lexical accident (the
+    `'` fell inside `_SYMBOL_HEAD`, so `'fx` came back as the unresolvable token
+    `'fx`).  Accidentally loud is not the same as right.
+
+    AND IT IS A NARROWING, NOT A REFUSAL, which is the half that keeps it honest.
+    Inside a syntax quote, `~x` and `~@x` ARE evaluated — that is what they are
+    for — so those islands are recovered and read as code, recursively.  A
+    genuinely evaluated reference stays a reference however deep in a template it
+    is written.
+
+    Two residues, both missed edges rather than spurious ones, so both cost a
+    noisy defect on an honest row instead of a silent green:
+
+      * A nested syntax quote raises the level, and `~x` inside it belongs to the
+        INNER quote — data at this one.  Read that way here, which is correct; the
+        double-unquote that would climb back out (`` `(a `(b ~~c)) ``) is not
+        modelled, and yields nothing.
+      * `#'x` is a var quote and a real reference.  It resolved to nothing before
+        this change and resolves to nothing after — the leading `'` is not a
+        symbol head any binding is written with — so no edge is lost, and none is
+        invented.
+    """
+    out: list[str] = []
+    i, n = 0, len(text)
+    while i < n:
+        c = text[i]
+        if c == "`":
+            end = _datum_end(text, i)
+            out.append(_syntax_quoted(text[i:end]))
+            i = end
+        elif c == "'" and _QUOTE_PREFIX_RE.match(text, i):
+            end = _datum_end(text, i)
+            out.append(_blank(text[i:end]))
+            i = end
+        elif c == "(" and _QUOTE_FORM_RE.match(text, i):
+            end = _form_end(text, i)
+            out.append(_blank(text[i:end]))
+            i = end
+        else:
+            out.append(c)
+            i += 1
+    return "".join(out)
+
+
+def _syntax_quoted(chunk: str) -> str:
+    """One syntax-quoted datum, blanked but for the islands it evaluates.
+
+    `chunk` starts at the `` ` ``.  Everything in it is data except what a `~` or
+    `~@` unquotes, and each of those is code again — so it goes back through
+    `_evaluated`, which is what makes `` `(a ~(b 'c)) `` read `b` and not `c`.
+    """
+    out = list(_blank(chunk))
+    i, n = _prefix_end(chunk, 0), len(chunk)
+    while i < n:
+        if chunk[i] == "`":
+            # A nested syntax quote: its `~`s are its own, and data at this
+            # level.  Skipped whole rather than walked into.
+            i = _datum_end(chunk, i)
+        elif chunk[i] == "~":
+            at = _prefix_end(chunk, i)
+            end = _datum_end(chunk, at)
+            out[at:end] = _evaluated(chunk[at:end])
+            i = end
+        else:
             i += 1
     return "".join(out)
 
@@ -787,7 +906,9 @@ def _read_tree(repo_root: Path, platform: str) -> _Graph:
     for path in sorted(test_root.rglob("*")):
         if path.suffix not in _CLJ_SUFFIXES or platform not in _platforms(path):
             continue
-        cleaned = _read_as(_strip(path.read_text(encoding="utf-8")), platform)
+        cleaned = _evaluated(
+            _read_as(_strip(path.read_text(encoding="utf-8")), platform)
+        )
         source[path] = cleaned
         ns, ctx = _ns_context(cleaned, path.as_posix())
         ns_of[path] = ns

--- a/spec/conformance/freehand/README.md
+++ b/spec/conformance/freehand/README.md
@@ -170,7 +170,7 @@ reaches it — written in one, or bound to a name such a statement uses, directl
 or through a helper it calls. A statement that asserts nothing contributes
 nothing, and a `deftest` whose statements never assert proves nothing at all.
 
-Nine shapes name a law and prove nothing:
+Ten shapes name a law and prove nothing:
 
 ```clojure
 ;; (def props-003 (conf/fixture :FH-PROPS-003))   a comment
@@ -187,6 +187,8 @@ Nine shapes name a law and prove nothing:
 (deftest t (check props-003))                     platform, credited on both
 (def props-003 (conf/fixture :FH-PROPS-003))      a KEYWORD spelled like the
 (deftest t (is (= :props-003 1)))                 binding, read as the Var
+(def props-003 (conf/fixture :FH-PROPS-003))      the binding QUOTED — data the
+(deftest t (is (= `props-003 1)))                 assertion compares against
 ```
 
 The first four are invisible to a scan that reads characters. The next two are
@@ -194,13 +196,14 @@ invisible to a scan that reads forms but seeds from the whole `deftest`: the id
 is mentioned where a test can see it and where nothing evaluates it, so the suite
 stays green with the fixture broken — which is the one thing the row's green is
 supposed to rule out. The next two are invisible to a scan that reads assertions
-but not the *names* carrying them. The last is invisible to one that reads names
+but not the *names* carrying them. The ninth is invisible to one that reads names
 but not their *boundaries*: a keyword is a run of symbol characters behind a `:`,
 so a scan starting wherever such a character appears reads `props-003` out of
-`:props-003` and resolves the datum to the Var. Each is a way to delete a law's
-proof and leave its row standing, so each is a `DEAD PROOF SITE` — or, where the
-lost assertion is one platform's, an `UNEXECUTED CELL` on the lane that platform
-serves.
+`:props-003` and resolves the datum to the Var. The tenth is invisible to a
+boundary as well, because `` `props-003 `` genuinely *is* the token — what it is
+not is a reference to the Var. Each is a way to delete a law's proof and leave
+its row standing, so each is a `DEAD PROOF SITE` — or, where the lost assertion
+is one platform's, an `UNEXECUTED CELL` on the lane that platform serves.
 
 What this establishes is bounded, and the bound is worth stating: the assertion
 is *co-located* with the fixture read, in one statement. It is not a proof that
@@ -224,6 +227,31 @@ reading the tails of tokens, not tokens: `(is (= :panel (first fx)))` yields
 resolves to the Var and witnesses a compiled tier the assertion never enters. A
 keyword is data; a Var reference is a symbol; the character *before* the token is
 what separates them.
+
+And a name is read only where it is **evaluated**, which a boundary cannot tell
+you. `(quote fx)` and `` `fx `` really do contain the token `fx`; what neither
+contains is a reference to the Var, because quoted data is data. So the census
+performs three reductions before it reads anything, and each answers one question:
+
+| Reduction | The question it answers | What it removes |
+|---|---|---|
+| `_strip` | what is not code | comments, strings, character literals, `#_` discards, `(comment …)` at any depth |
+| `_read_as` | what *this platform* reads | every `#?` / `#?@` conditional but one branch |
+| `_evaluated` | what **evaluates** | every quoted datum — `'x`, `` `x ``, `(quote x)` |
+
+One reduction per question, applied once per file, so names, fixture calls,
+assertion heads and the mode marker are all read off the same text and none can
+drift from another: a quoted `(conf/fixture :FH-…)` is not a fixture read, and a
+helper returning `'(is (seq fx))` returns a list rather than asserting.
+
+It is a narrowing, not a refusal. Inside a syntax quote `~x` and `~@x` *are*
+evaluated, so those islands are read as code and a genuine reference stays one
+however deep in a template it is written. Two residues remain, and both are
+*missed* edges rather than invented ones, so both cost a noisy defect on an honest
+row instead of a silent green: a nested syntax quote raises the level, so the
+double unquote that would climb back out of it (`` `(a `(b ~~c)) ``) is not
+modelled; and `#'x` is a var quote — a real reference — that resolves to nothing,
+as it did before the reduction existed.
 
 The census also reads the **reader**. A `.cljc` suite is discovered by the JVM
 runner *and* the node runner, but a `#?(:clj (deftest …))` inside it asserts in
@@ -258,12 +286,17 @@ neither, so keeping the require and asserting on the raw fixture instead kept th
 row's `compiled` claim standing while nothing compiled ran. Presence is not
 proof, in the same way and for the same reason that a fixture named in a file is
 not a fixture a test reads. Reachability is only as sound as name resolution, so
-the witness is reached by a symbol read from a token boundary: `:panel` is a datum,
-not the declaration it is spelled like, and neither is `:check/findings` the alias.
-What stays textual, and is claimed as nothing more, is the marker itself — a
-statement mentioning `{:compiled true}` or a spelled-out
-`re-frame.freehand.compiler.…` as data still witnesses. Reachability is enforced;
-telling a marker used as data from one used as code is not.
+the witness is reached by a symbol read from a token boundary and from an
+*evaluated* position: `:panel` is a datum, not the declaration it is spelled like;
+neither is `:check/findings` the alias; and neither are `` `panel `` or
+`(quote panel)`, which name the declaration without evaluating it. Both halves of
+the witness are read off the same reduced text as the names, so a quoted
+`{:compiled true}` and a quoted `re-frame.freehand.compiler.…` witness nothing
+either. What stays textual, and is claimed as nothing more, is the marker within
+what does evaluate — a statement mentioning `{:compiled true}` as a live map
+literal still witnesses, whatever it does with it. Reachability is enforced;
+telling a marker used as data from one used as code, inside evaluated code, is
+not.
 
 And the witness is only evidence where it *runs*. A compile-tier reference inside
 a `#?(:cljs …)` branch vouches for the node lane and says nothing about the JVM,


### PR DESCRIPTION
Closes the merged-PR audit of #6956 on `rf2-drpa3.53` — **F6a conformance completion, gate 1 of the donor-deletion gate and the head of EP-0036's serial chain.** `rf2-drpa3.55`, `.56` and `.57` are blocked on this owner.

## The defect, reproduced before anything was changed

The audit found that #6956's token boundary correctly closed the keyword and numeric axes and left the *evaluation-context* axis open. Reproduced hermetically against the merged script with the audit's own two mutations, plus three more of the same class found while fixing it. Each row below is one census mini-repo differing from its neighbour by a single datum:

| assertion, on a row bound to `fx` / declaring `panel` | merged script | this PR |
|---|---|---|
| `(is (= :fx 1))` — the shipped red | 1 DEAD PROOF SITE | 1 DEAD PROOF SITE |
| `(is (= (quote fx) 1))` | **defects=0** | 1 DEAD PROOF SITE |
| ``(is (= `fx 1))`` | **defects=0** | 1 DEAD PROOF SITE |
| `(is (= 'fx 1))` | 1 DEAD PROOF SITE *(by accident — below)* | 1 DEAD PROOF SITE |
| `(is (= :panel (first fx)))` — the shipped red | 1 UNWITNESSED MODE | 1 UNWITNESSED MODE |
| `(is (= (quote panel) (first fx)))` | **defects=0** | 1 UNWITNESSED MODE |
| ``(is (= `panel (first fx)))`` | **defects=0** | 1 UNWITNESSED MODE |
| `(is (= 'panel (first fx)))` | 1 UNWITNESSED MODE *(by accident)* | 1 UNWITNESSED MODE |
| `(is (= '(conf/fixture :FH-CALL-001) 1))` | **defects=0** | 1 DEAD PROOF SITE |
| `(is (= '{:compiled true} (first fx)))` | **defects=0** | 1 UNWITNESSED MODE |
| `(is (= 're-frame.freehand.compiler.check (first fx)))` | **defects=0** | 1 UNWITNESSED MODE |
| `(defn helper [] '(is (seq fx)))` + `(deftest t (is true) (helper))` | **defects=0** | 1 DEAD PROOF SITE |

The reader-quote spelling `'fx` was already red — and only by lexical accident: `'` falls inside `_SYMBOL_HEAD`, so the scan returned the unresolvable token `'fx`. Accidentally loud is not the same as right, and it is why the family had to be closed as a family rather than as the two examples named. A census whose verdict turns on which of three equivalent spellings an author reached for is reporting a coincidence.

The last four rows are the same mistake on the other surfaces a quoted datum vouched through — the fixture-call read, the textual mode marker, and the assertion head. They were found by asking where else the reduction was missing rather than only where the audit pointed, and they are pinned here rather than filed as a follow-up bead.

## The repair, inside the existing lightweight reader

`_SYMBOL_RE` really does find the token `fx` in `(quote fx)`. What a token boundary cannot see is that the reader hands the enclosing form a *datum* rather than a reference to the Var — that is evaluation context, one level up from lexing.

So the reduction pipeline gains its third and last stage, beside the two it already had:

| Reduction | The question it answers | What it removes |
|---|---|---|
| `_strip` | what is not code | comments, strings, character literals, `#_` discards, `(comment …)` at any depth |
| `_read_as` | what *this platform* reads | every `#?` / `#?@` conditional but one branch |
| `_evaluated` | what **evaluates** | every quoted datum — `'x`, `` `x ``, `(quote x)` |

`_evaluated` blanks the extent of every quoted datum in all three spellings — the two reader prefixes and the `(quote x)` form both expand into. It is length- and balance-preserving (a quoted extent's matched delimiters leave together), and it is applied **once per file**, at the single point `_strip` and `_read_as` were already applied. That is the whole diff to the reader: two functions and one regex, no parse, no AST, no dependency. The `'` boundary reuses `_SYMBOL_BODY`, the same character class `_SYMBOL_RE` reads a name from, because it is the same question asked of the same alphabet.

Applying it once rather than at each reading site is the point, not a convenience: `refs`, fixture `ids`, assertion heads and the `{:compiled true}` / compile-tier marker are then all read off the same text, so no two of them can disagree about what the code says. That is what closes the last four rows of the table above in the same stroke as the first eight.

**It is a narrowing, not a refusal.** Inside a syntax quote, `~x` and `~@x` *are* evaluated — that is what they are for — so those islands are recovered and read as code, recursively, and a genuine reference stays a reference however deep in a template it is written. Two green controls pin this, one per axis.

Two residues, both **missed** edges rather than spurious ones, so both cost a noisy defect on an honest row instead of a silent green — the same posture as the unresolved libspec in `_ns_context`:

* A nested syntax quote raises the level, so `~x` inside it belongs to the inner quote and is data at this one. Read that way, which is correct; the double unquote that would climb back out (`` `(a `(b ~~c)) ``) is not modelled and yields nothing.
* `#'x` is a var quote and a genuine reference. It resolved to nothing before this change and resolves to nothing after, so no edge is lost and none is invented.

Both are written into `_evaluated`'s docstring, the module docstring, the `THE MODE WITNESS` block and the spec README, beside the granularity, libspec, textual-marker and no-interpreted-witness bounds that were already stated there.

## The new pins are falsified in both directions

This is the failure mode that reopened this bead four times, so it is demonstrated rather than asserted. Self-tests **71 → 85**, fourteen new cases, each pinning a defect *kind* and not merely a count:

* **DEAD PROOF SITE, fixture-reachability axis** — `census_quote_form_shaped_like_the_fixture_binding`, `census_syntax_quote_shaped_like_the_fixture_binding`, `census_reader_quote_shaped_like_the_fixture_binding`, `census_quoted_fixture_call_is_not_a_read`, `census_nested_syntax_quote_does_not_read_the_fixture`, `census_quoted_assertion_in_a_called_helper`.
* **UNWITNESSED MODE, compiled-witness axis** — `census_quote_form_shaped_like_the_compiled_declaration`, `census_syntax_quote_shaped_like_the_compiled_declaration`, `census_reader_quote_shaped_like_the_compiled_declaration`, `census_quoted_compiled_marker_does_not_witness`, `census_quoted_tier_namespace_does_not_witness`.
* **Green controls** — `census_unquote_inside_a_syntax_quote_reads_the_fixture` and `census_unquote_inside_a_syntax_quote_witnesses_the_mode` keep the rule a narrowing on both axes; `census_prime_suffixed_binding_is_one_token` is the control for over-tightening, which is the other way to get a boundary wrong — `fx'` is one name, not a quote over `fx`.

**Reverting only `_evaluated`** — splicing `cleaned = _read_as(_strip(…))` back into the pipeline with the self-tests untouched — reds **9 of the 11 new red cases** at `expected defects=1, got 0`:

```
self-test FAIL: census_quote_form_shaped_like_the_fixture_binding expected defects=1, got 0
self-test FAIL: census_syntax_quote_shaped_like_the_fixture_binding expected defects=1, got 0
self-test FAIL: census_quoted_fixture_call_is_not_a_read expected defects=1, got 0
self-test FAIL: census_nested_syntax_quote_does_not_read_the_fixture expected defects=1, got 0
self-test FAIL: census_quoted_assertion_in_a_called_helper expected defects=1, got 0
self-test FAIL: census_quote_form_shaped_like_the_compiled_declaration expected defects=1, got 0
self-test FAIL: census_syntax_quote_shaped_like_the_compiled_declaration expected defects=1, got 0
self-test FAIL: census_quoted_compiled_marker_does_not_witness expected defects=1, got 0
self-test FAIL: census_quoted_tier_namespace_does_not_witness expected defects=1, got 0
```

The two that stay red are the reader-quote pair, which were already red before this change — and that is exactly their job: they show that their twins differed from them by one character of a datum. Every green beside them is unmoved, including the three new controls, which would have reddened had the boundary been drawn wrong.

## Nothing honest was reddened and nothing was reclassified

Both scripts run over the **same** tree: the per-row `--report` table is **byte-identical**, `md5 bdb95d24524b6a460a687b408a7b1a48` on both, 102 lines / 96 applicable rows, all reached by an assertion in a lane serving every cell they claim, all 4 `compiled` rows still carrying a reachable, lane-scoped witness. No row narrowed, no row marked inapplicable.

Row accounting on this branch: **97 rows total; 96 active = applicable; 1 retired** (FH-EVENT-005, an addressed id that does not bind); 0 planned. **15/15** roster areas populated. By mode: 64 common, 28 interpreted, 4 compiled. (The bead's last note recorded 95/94 — `main` gained two rows since, from the fixture-row work on `rf2-uvcm3` / `rf2-nxykb`. The census derives every count; no number is asserted anywhere in the gate.)

## Whether a fifth axis is likely — the mayor asked, and the answer is two-sided

**On this axis, no, and for a structural reason rather than an optimistic one.** The four rounds so far were four *different* kinds of mistake — presence not proof, bare-word helper identity, cross-platform OR-ing, token boundaries — and each needed its own idea. This one is not a fifth idea of that kind; it is the completion of a set. There are exactly three things that make code-shaped text not evaluate in Clojure, and the reader now handles all three, at one place, in one pass: it never runs (`_strip`), it is not read on this platform (`_read_as`), it is read as data (`_evaluated`). That closure is why the fix is a pipeline stage rather than a fourth special case, and it is why I would expect the *data-versus-code* question to be settled rather than merely quieter.

**But the reader is at the limit of what it should be asked to own, and the next axis will not be lexical.** What remains open is not spelling, it is *dataflow*, and the existing bounds already name it: granularity is the statement, so `(let [x fx] (is (= 1 1)))` counts as a read and `(when false (is …))` counts as an assertion. Neither is reachable by a smarter lexer. Closing either means knowing which subexpression's value flows into the assertion — real binding forms, real macro semantics, a real analyzer. Four rounds of hardening have each been justified because each closed a *silent* green; a fifth round aimed at dataflow would not close one. It would build a second Clojure front-end inside a conformance gate, and the gate's own correctness then becomes the thing nobody audits.

**So the alternative, if you want this ended rather than hardened again: narrow what the fixture format accepts, so the ambiguous shape cannot be written.** Constrain the input grammar once instead of teaching the reader to disambiguate ever-subtler ones. Concretely — and this is a sketch, deliberately **not implemented here**:

Require every proof site to be one call to one declared prover, and let the row's proof be that call rather than a fixture mentioned somewhere in the file:

```clojure
(deftest fh-call-001
  (conf/proves :FH-CALL-001 {:mode :compiled}   ; one call, one row, one statement
    (is (= … (v/render …)))))                   ; the assertion IS the macro's body
```

The census then stops asking *"does some assertion somewhere reach this fixture through a graph of names?"* and asks *"is there exactly one `conf/proves` form for this row, and is its body an assertion?"* That is a question about **shape**, decidable by reading one form: no name resolution, no transitive closure, no per-platform helper identity, no marker reachability, and no data-versus-code distinction to get wrong — because a datum cannot occupy the position at all. The mode witness becomes a declared argument that the macro itself enforces, rather than something inferred from a marker's reachability. The lane stays derived from the file, exactly as it is today.

The cost is real and worth stating plainly: it is a corpus-wide edit across every Freehand suite; `conf/proves` has to exist as a macro on both platforms; and it trades a census that reads *any* idiomatic test for one that reads *one* idiom. That is the trade on offer — a constrained input grammar once, in exchange for retiring the reachability graph and every bound stated around it. I would file it as its own bead against the F6 gate rather than fold it into an audit discharge.

## Quality gates

All foreground to completion, `rc=$?` captured immediately after each runner into a **worktree-local** log and cross-checked against that log's own PASS/FAIL lines. Nothing piped through `tail`/`grep`, nothing backgrounded, no trailing `echo` supplying a status, and `mkdocs` run separately as well as inside fast-PR because that script soft-skips its own mkdocs step when mkdocs is off PATH (it did soft-skip here — log line `SKIP mkdocs --strict build: mkdocs not on PATH`).

**Re-run in full after rebasing onto current `main` (`53c46b3841`), and reported from that run.** Main had moved eight commits, none of them touching either changed file; every number below is post-rebase and matches the pre-rebase run exactly.

| gate | result | rc |
|---|---|---|
| census self-tests, `--self-test --verbose` | **85/85 passed**, 0 FAIL (was 71) | 0 |
| the same 85 with `_evaluated` spliced out | **9 FAIL** at `expected defects=1, got 0` — intended | 1 |
| live index + census, `--verbose`, full index | index OK **97 rows** (96 active, 1 retired), 15 area sections; census OK **96 applicable, 0 defects**, 15/15 areas non-empty, 4/4 `compiled` rows witnessed | 0 |
| `--report`, `main` vs branch over the same tree | **byte-identical**, `md5 bdb95d24524b6a460a687b408a7b1a48`, 102 lines / 96 rows both; `diff` empty | 0 / 0 |
| `implementation/freehand` `clojure -M:test` | **1068 tests, 7242 assertions, 0 failures, 0 errors** | 0 |
| `scripts/test-fast-pr.sh` | **PASS fast PR spine**; classifier `docs=true jvm=false node=false` | 0 |
| `python -m mkdocs build --strict` | clean, run separately | 0 |
| `check_doc_slugs` / `check_readme_links` | clean | 0 / 0 |
| `check_donor_inventory --self-test --verbose` / `--ci --report` | all cases passed / clean | 0 / 0 |

The unfiltered required **`Freehand conformance index`** job runs this very change on every PR — the same two commands as above, in the same order — so the repair is exercised by CI immediately rather than only by its author.

`npm run test:cljs` / `test:browser` **not run and not applicable**: the diff is one Python script plus one spec README. No CLJS source, fixture or index row changed; `report-changed-surfaces.sh` reports `implementation_jvm=false cljs_node_test=false` for it, which `test-fast-pr.sh --plan` confirms; and the byte-identical `--report` table is the evidence that no row's suite or lane moved.

`rf2-49upn` remains the one split-out residue (no single CI job binds the lane RUNS to the rows) and was not touched. **The bead is deliberately left open** — it has been closed on PR-open once and on merge twice and reopened by a merged-PR audit each time. The mayor closes it on the merged SHA.
