### PR TITLE
ci(freehand): arm the evidence-elision gate on the current-occurrence index (rf2-xftdv)

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -531,7 +531,7 @@ else
         bundle_isolation=true
         ui_smoke=true
         ;;
-      implementation/freehand/src/re_frame/freehand/evidence.cljc|implementation/freehand/src/re_frame/freehand/cell.cljc|implementation/freehand/src/re_frame/freehand/shell.cljs|implementation/freehand/test/re_frame/freehand/release_app.cljs)
+      implementation/freehand/src/re_frame/freehand/evidence.cljc|implementation/freehand/src/re_frame/freehand/cell.cljc|implementation/freehand/src/re_frame/freehand/occurrences.cljc|implementation/freehand/src/re_frame/freehand/shell.cljs|implementation/freehand/test/re_frame/freehand/release_app.cljs)
         # rf2-xwa4n — the F4g evidence-elision gate's Freehand PRODUCER
         # surfaces. `npm run test:freehand-evidence-elision` (rf2-drpa3.166)
         # builds `:freehand-release` and its goog.DEBUG=true control twin
@@ -551,6 +551,14 @@ else
         #     catches — but only if the gate RUNS).
         #   - cell.cljc      — `emit-commit-evidence!`, the sole dev gate. Move
         #     it out from behind `interop/debug-enabled?` and the schema ships.
+        #     It also carries the third sentinel (the containment console line)
+        #     and both call sites into the occurrence index.
+        #   - occurrences.cljc — the dev-only CURRENT-OCCURRENCE index
+        #     (rf2-xftdv): a `defonce` atom holding one row per connected
+        #     occurrence. It carries no runtime string literal, so it can root
+        #     no sentinel of its own; its production absence follows from
+        #     cell.cljc's gate, which is exactly why a change to the index is
+        #     worth re-running the proof that the gate really does fold away.
         #   - shell.cljs     — the SOLE mounted commit edge: `cell/commit!` in
         #     the useLayoutEffect reconcile (shell.cljs:165). That call is what
         #     ROOTS `emit-commit-evidence!`, and through it BOTH positive-control

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -2464,6 +2464,13 @@ test('the standalone freehand-artefact workflow is gone (one owner, not two) (rf
 const FREEHAND_EVIDENCE_PRODUCERS = [
   'implementation/freehand/src/re_frame/freehand/evidence.cljc',
   'implementation/freehand/src/re_frame/freehand/cell.cljc',
+  // rf2-xftdv — the dev-only CURRENT-OCCURRENCE index the commit seam writes
+  // and `disconnect!` drops from. It is a `defonce` atom on the render path,
+  // which is exactly the kind of state that must not ship, and it carries no
+  // runtime string literal so it can root no sentinel of its own: its absence
+  // follows from cell.cljc's gate. A change here is therefore a change to what
+  // the gate is holding back, and worth re-running the proof.
+  'implementation/freehand/src/re_frame/freehand/occurrences.cljc',
   // rf2-xwa4n, merged-PR audit of #6888 — the SOLE mounted commit edge
   // (`cell/commit!` in the useLayoutEffect reconcile) is what ROOTS
   // `emit-commit-evidence!` and both positive-control door strings. It was


### PR DESCRIPTION
Follow-on to #6961, which merged while this was in flight. One routing change,
no runtime code.

`implementation/freehand/src/re_frame/freehand/occurrences.cljc` — the dev-only
current-occurrence index #6961 added — is now armed as a producer surface of the
F4g evidence-elision control-build proof (`freehand_evidence_elision`).

**Why it belongs on that narrow list.** The list is deliberately not the whole
`implementation/freehand/**` tree — two `:advanced` builds per PR is cost the
rf2-xwa4n ruling declined — so it carries the probe's *direct inputs* only. The
index is one: a `defonce` atom that the commit seam writes and `disconnect!`
drops from, i.e. exactly the kind of live state that must not ship. It carries
no runtime string literal, so it can root no sentinel of its own; its production
absence follows from `cell.cljc`'s `interop/debug-enabled?` gate. That makes a
change to the index a change to *what the gate is holding back*, which is worth
re-running the proof that the gate really does fold away.

The always-armed causal half is already on main: `evidence-boundary-jvm-test`'s
`every-index-call-site-sits-inside-the-dev-gate` asserts over `cell.cljc`'s own
top-level forms that every call into the index sits inside that gate, and
`the-current-occurrence-index-names-no-schema` keeps the schema-mention roster
pinned closed at `{cell tool}`.

## Quality gates

| gate | command | result | exit |
| --- | --- | --- | --- |
| changed-surfaces classifier | `node --test implementation/scripts/_changed-surfaces.test.cjs` | 229 tests passed | `rc=0` |
| script policy (full suite, 26 checkers incl. the classifier and both workflow-policy gates) | `cd implementation && npm run test:script-policy` | pass | `rc=0` |
| freehand evidence elision (the gate this arms) | `cd implementation && npm run test:freehand-evidence-elision` | `release 3/3 doors absent (731759 chars); control 3/3 doors present (785792 chars); survivor present in both` | `rc=0` |
| fast PR spine | `scripts/test-fast-pr.sh` | `PASS fast PR spine`; 11381 tests / 56966 assertions, 0 failures (mkdocs step soft-skipped locally — not on PATH; this diff touches no markdown) | `rc=0` |

Each runner's `rc` was captured immediately after the runner into a
worktree-local log and cross-checked against the log's own PASS/FAIL lines — no
piping through `tail`, no trailing `echo` supplying a zero.

**.167 fence.** Nothing runtime here, so nothing to fence: no lifetime counts,
no interval ledger, no accumulated target union, no weak-keyed store, no HMR
migration, no cell-to-root attribution, no second retention knob. The change
makes the *absence* of that state cheaper to keep proving.
