### PR TITLE
feat(freehand): publish the per-event-site facts the analyzer records (rf2-z0blg)

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/compiler.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler.cljc
@@ -310,7 +310,10 @@
        :grammar       :re-frame.freehand/v1
        :subscriptions [{:sid \"…\" :query [:person/by-id 7]
                         :source-coord {…} :path [0]}]
-       :events        [{:sid \"…\" :source-coord {…} :path [1 0]}]
+       :events        [{:sid \"…\" :prop :on-click :classification :vector
+                        :serializable? true :sync? false
+                        :handler [:person/selected 7]
+                        :source-coord {…} :path [1 0]}]
        :slots         [{:sid \"…\" :inline? true :source-coord {…} :path [2]}]
        :html-sites    []
        :capabilities  #{:sub :event}
@@ -325,6 +328,21 @@
     are the view's finite reactive, intent, render-slot and trusted-markup
     site rosters — the same lexical sites the
     analyzer indexed, projected to their statically knowable facts.
+  - An `:events` entry states WHAT it dispatches, not only where from:
+    `:prop` (the authored handler prop), `:classification` (`:vector` /
+    `:options` / the dynamic kinds), `:serializable?`, `:sync?` (the
+    controlled-input synchronous door) and `:handler` — the handler form
+    the analyzer recorded, or the `:opaque` marker where the handler is
+    CODE rather than data (a `v/event` / `v/handler` body, a bare fn, a
+    dynamic expression, a spread). Those five were collected in the
+    analyzer's site index and published nowhere a reader could reach
+    (rf2-z0blg — the same defect rf2-hytu5 fixed for `:diagnostics`),
+    which left an event-site read able to count lines and not to say what
+    a view does. `:handler` is the analyzer's recorded form, so a
+    reader-facing surface applies the literal/dynamic honesty split over
+    it rather than showing source code where a reader asked for data —
+    [[re-frame.freehand.tool/read-view-event-sites]] does exactly that,
+    with the predicate it already applies to a subscription's `:query`.
   - `:diagnostics` is the compile-tier finding roster
     ([[re-frame.freehand.compiler.a11y]]) — every a11y finding the
     declaration produced, INCLUDING the suppressed ones, each with the
@@ -380,7 +398,10 @@
     {:view-id       view-id
      :grammar       grammar/version
      :subscriptions (mapv #(select-keys % [:sid :query :source-coord :path]) (:subs sites))
-     :events        (mapv #(select-keys % [:sid :source-coord :path]) (:events sites))
+     :events        (mapv #(select-keys % [:sid :source-coord :path :prop
+                                          :classification :serializable? :sync?
+                                          :handler])
+                          (:events sites))
      :slots         (mapv #(select-keys % [:sid :inline? :source-coord :path]) (:slots sites))
      :html-sites    (mapv #(select-keys % [:source-coord :path]) (:htmls sites))
      :diagnostics   (mapv #(select-keys % [:sid :id :tag :path :suppressed? :reason])

--- a/implementation/freehand/src/re_frame/freehand/compiler/analyze.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/analyze.cljc
@@ -2360,9 +2360,17 @@
                               (with-meta (apply list 'fn bindings body) (meta form)))]
       (check-loop-capture! (update e :loop-syms #(reduce disj % binders))
                            (str verb " at prop " k) form)
+      ;; `:sync?` is stated, not omitted. The controlled-input synchronous door
+      ;; is a property of a DOM element's own handler prop, so a COMPONENT prop
+      ;; is factually not one — and a site that left the key absent would carry
+      ;; a narrower key set than its siblings, which is what the manifest's
+      ;; per-entry key law is asserted against (rf2-z0blg). The spread sites say
+      ;; `false` here for the same reason; the DOM sites get theirs back-filled
+      ;; by `record-event-sync!`.
       (add-event-site! e identity
                        {:prop k :handler :opaque
-                        :classification kind :serializable? false})
+                        :classification kind :serializable? false
+                        :sync? false})
       (merge identity
              {:k k
               :slot (prop-slot-name k)

--- a/implementation/freehand/src/re_frame/freehand/tool.cljc
+++ b/implementation/freehand/src/re_frame/freehand/tool.cljc
@@ -280,25 +280,24 @@
   decoration beside them. Naming what an entry states is how a row says which
   hand is empty.
 
-  The narrow set this used to name — coordinates and nothing else — was the gap
-  itself: `:prop`, `:classification`, `:serializable?`, `:sync?` and `:handler`
-  were recorded in the analyzer's site index and dropped by the manifest
-  projection, so an event-site read could say WHERE a view dispatches from and
-  not WHAT it dispatches (rf2-z0blg). The manifest publishes them now, so the
-  set names the whole vocabulary and the gap it used to name is closed.
+  The narrow set this used to name — coordinates and nothing else — WAS the gap:
+  `:prop`, `:classification`, `:serializable?`, `:sync?` and `:handler` were
+  recorded in the analyzer's site index and dropped by the manifest projection,
+  so an event-site read could say WHERE a view dispatches from and not WHAT it
+  dispatches (rf2-z0blg). The manifest publishes them now, so this names the
+  whole vocabulary rather than the remainder of an unpublished one.
 
-  A fact that is genuinely unknown is stated as an absence rather than left out:
-  `:handler` is the `:opaque` marker and `:event-id` is `nil` exactly where the
-  handler is not statically known data — see [[event-site]]. A reader therefore
-  never has to decide whether a missing key means this build does not publish
-  the fact or the site does not have it."
+  An unknown fact is STATED unknown rather than left out — `:handler` is the
+  `:opaque` marker and `:event-id` is `nil` exactly where the handler is not
+  statically known data ([[event-site]]) — so a reader never has to work out
+  whether a missing key means the site lacks the fact or the build lacks it."
   #{:sid :source-coord :path :prop :classification :serializable? :sync?
     :handler :event-id})
 
 (defn- event-site
   "One event site, with its handler-shape honesty stated per entry — the rule
-  [[dependency-site]] applies to a subscription's `:query`, applied to the
-  handler form the manifest records.
+  [[dependency-site]] applies to a subscription's `:query`, over the handler
+  form the manifest records.
 
   A fully-literal handler IS the shape that will dispatch, so it is projected
   verbatim. A handler carrying a captured local or a call is a form whose value

--- a/implementation/freehand/src/re_frame/freehand/tool.cljc
+++ b/implementation/freehand/src/re_frame/freehand/tool.cljc
@@ -273,20 +273,58 @@
                   (no-static-analysis {:subscriptions []}))))))
 
 (def ^:private event-site-facts
-  "The per-entry facts an event site in the manifest CAN state today.
+  "The CLOSED set of facts one event-site row states.
 
-  Published beside the roster because the analyzer records more than this and
-  the manifest does not carry it: `:prop`, `:classification`, `:serializable?`,
-  `:sync?` and the authored `:handler` are collected in the compiler's site
-  index and dropped by the manifest projection (rf2-z0blg — the same defect
-  rf2-hytu5 fixed for `:diagnostics`).
+  Every member is present on every entry, which is what lets this set be
+  asserted as an EQUALITY against the entries themselves rather than as a
+  decoration beside them. Naming what an entry states is how a row says which
+  hand is empty.
 
-  So a reader seeing no `:handler` on a site is seeing a fact this build does
-  not publish, NOT a site with no handler — and the difference has to be
-  legible from the answer rather than from a changelog. Naming what an entry
-  states is how an empty-handed roster says which hand is empty. The set
-  retires with the gap it names."
-  #{:sid :source-coord :path})
+  The narrow set this used to name — coordinates and nothing else — was the gap
+  itself: `:prop`, `:classification`, `:serializable?`, `:sync?` and `:handler`
+  were recorded in the analyzer's site index and dropped by the manifest
+  projection, so an event-site read could say WHERE a view dispatches from and
+  not WHAT it dispatches (rf2-z0blg). The manifest publishes them now, so the
+  set names the whole vocabulary and the gap it used to name is closed.
+
+  A fact that is genuinely unknown is stated as an absence rather than left out:
+  `:handler` is the `:opaque` marker and `:event-id` is `nil` exactly where the
+  handler is not statically known data — see [[event-site]]. A reader therefore
+  never has to decide whether a missing key means this build does not publish
+  the fact or the site does not have it."
+  #{:sid :source-coord :path :prop :classification :serializable? :sync?
+    :handler :event-id})
+
+(defn- event-site
+  "One event site, with its handler-shape honesty stated per entry — the rule
+  [[dependency-site]] applies to a subscription's `:query`, applied to the
+  handler form the manifest records.
+
+  A fully-literal handler IS the shape that will dispatch, so it is projected
+  verbatim. A handler carrying a captured local or a call is a form whose value
+  does not exist until the view renders, and a handler that is a callback BODY
+  is code with no event vector at all; both project as the `:opaque` marker the
+  analyzer already uses for the second, because what a reader can do with them
+  is the same — nothing. `:event-id` still shows the literal event-id where the
+  authored form has one, the part the compiler really does know, while the
+  runtime arguments are left unsaid rather than invented.
+
+  `:classification` sits beside them and keeps the two apart: an `:opaque`
+  handler on a `:vector` or `:options` site is an event vector with a runtime
+  argument, and on any other classification it is a callback."
+  [{:keys [handler] :as site}]
+  (let [;; The event VECTOR the handler carries, under either spelling that
+        ;; carries one — the bare vector (`:vector`) or the options map that
+        ;; wraps it (`:options`) — and nil where the handler is code.
+        event (cond
+                (vector? handler) handler
+                (map? handler)    (:event handler)
+                :else             nil)]
+    (assoc (select-keys site [:sid :source-coord :path :prop :classification
+                              :serializable? :sync?])
+           :handler  (if (and (some? event) (literal-form? handler)) handler :opaque)
+           :event-id (when (and (vector? event) (keyword? (first event)))
+                       (first event)))))
 
 (defn read-view-event-sites
   "The event-handler SITES the view declared as `view-id` declares, read from
@@ -296,21 +334,34 @@
       ;; => {:schema … :read :view-event-sites :view-id … :lowering :compiled
       ;;     :scope :possible-sites :basis :static-proof
       ;;     :complete? true :loss nil
-      ;;     :event-sites [{:sid … :source-coord {…} :path [1 0]}]
-      ;;     :site-facts  #{:sid :source-coord :path}}
+      ;;     :event-sites [{:sid … :source-coord {…} :path [1 0]
+      ;;                    :prop :on-click :classification :vector
+      ;;                    :serializable? true :sync? false
+      ;;                    :handler [:person/selected 7]
+      ;;                    :event-id :person/selected}
+      ;;                   {:sid … :source-coord {…} :path [2 0]
+      ;;                    :prop :on-click :classification :vector
+      ;;                    :serializable? true :sync? false
+      ;;                    :handler :opaque :event-id :person/removed}]
+      ;;     :site-facts  #{:sid :source-coord :path :prop :classification
+      ;;                    :serializable? :sync? :handler :event-id}}
 
-  The ROSTER is complete and lossless: every event site the grammar can see is
-  here. What each entry can SAY is narrower than what the compiler knows, and
-  `:site-facts` states exactly how narrow — see [[event-site-facts]]. Nothing
-  is inferred to fill the gap: this read answers WHERE a view dispatches from,
-  and until the manifest publishes the classification it will not pretend to
-  answer WHAT it dispatches."
+  SITES, not dispatches. The roster is one entry per LEXICAL site, so a site
+  inside a keyed list is one entry however many times it runs; what a render
+  actually dispatched is a different quantity and is not derivable from this one.
+
+  Complete and lossless: every event site the grammar can see is here, each
+  saying WHERE it dispatches from AND what it dispatches — with the
+  literal/dynamic split its sibling [[read-view-dependencies]] applies to a
+  query stated per entry, so a handler whose value does not exist until render
+  is marked rather than shown as source code. `:site-facts` names the closed set
+  of facts a row states — see [[event-site-facts]]."
   [view-id]
   (when interop/debug-enabled?
     (when-some [view (registry/lookup view-id)]
       (envelope :view-event-sites view-id view
                 (if-some [m (descriptor/manifest view)]
-                  (static-proof {:event-sites (:events m)
+                  (static-proof {:event-sites (mapv event-site (:events m))
                                  :site-facts  event-site-facts})
                   (no-static-analysis {:event-sites []
                                        :site-facts  event-site-facts}))))))

--- a/implementation/freehand/test/re_frame/freehand/analyze_accept_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/analyze_accept_cljs_test.cljc
@@ -553,6 +553,36 @@
     (is (= :opaque (:handler (second (:events sites)))))
     (is (false? (:serializable? (second (:events sites)))))))
 
+(deftest the-sync-door-fact-is-total-over-event-sites
+  (testing "`:sync?` is recorded on EVERY event site, whichever arm produced it,
+            because the manifest publishes it per entry and a site that left the
+            key absent would carry a narrower key set than its siblings — a
+            green over an uninhabited case rather than a proof (rf2-z0blg). The
+            DOM arms get theirs back-filled by `record-event-sync!` once every
+            prop is classified; the spread arms and the COMPONENT-PROP arm state
+            `false` at the site, which a component prop factually is: the
+            synchronous door belongs to a DOM element's own handler."
+    (let [{:keys [sites]}
+          (ana-full '[:div
+                      [:button {:on-click [:a/b 1]} "x"]
+                      [:input {:value v :on-input [:a/typed :rf.ui/value]}]
+                      [:button {:on-click (event [e] [:a/c e])} "y"]
+                      [:button {:on-click (fn [e] e)} "z"]
+                      [:span (spread forwarded)]
+                      [child-view {:on-pick (event [e] [:a/picked e])}]])]
+      (is (= 6 (count (:events sites)))
+          "one site per arm, so the totality claim below is over all of them")
+      (doseq [site (:events sites)]
+        (is (contains? site :sync?)
+            (str (:prop site) " / " (:classification site)
+                 " — states its synchronous-door fact rather than omitting it")))
+      (is (= #{true false} (set (map :sync? (:events sites))))
+          "and the fact DISCRIMINATES — a controlled `:on-input` literal vector
+           opens the one sync door, so a projection hard-coding false would pass
+           the totality row above and fail here")
+      (is (false? (:sync? (last (:events sites))))
+          "the component-prop arm in particular: false, not absent"))))
+
 (deftest event-sites-carry-runtime-and-tool-identity
   (let [{:keys [ast sites]}
         (analyze-site-fixture

--- a/implementation/freehand/test/re_frame/freehand/tool_reads_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/tool_reads_cljs_test.cljc
@@ -46,18 +46,30 @@
 ;; and one interpreted declaration that carries no analysis at all
 ;; ---------------------------------------------------------------------------
 
+(v/defview basket-row
+  "A child declaration [[basket]] mounts, so the parent's event roster carries a
+  COMPONENT-PROP committed callback beside its DOM handler sites. That is the
+  arm whose `:sync?` was absent rather than false until rf2-z0blg, which the
+  per-entry key law below could not have caught over a census without one."
+  {:compiled true}
+  [{:keys [label on-remove]}]
+  [:li [:button {:on-click on-remove} label]])
+
 (v/defview basket
   "A COMPILED declaration with a literal subscription, a captured-local
-  subscription and two event sites — so every honesty arm below has a real
-  entry to read, and the literal/dynamic split is a discrimination rather than
-  a tautology."
+  subscription, and one event site of each honesty class — a literal event
+  vector, a vector carrying a captured local, and an opaque committed callback
+  at a child's prop — so every honesty arm below has a real entry to read, and
+  each split is a discrimination rather than a tautology."
   {:compiled true}
   [{:keys [row-id]}]
   [:section.basket
    [:p (v/sub [:basket/total])]
    [:p (v/sub [:basket/line row-id])]
    [:button {:on-click [:basket/clear]} "Clear"]
-   [:button {:on-click [:basket/checkout 7]} "Buy"]])
+   [:button {:on-click [:basket/checkout 7]} "Buy"]
+   [:button {:on-click [:basket/remove row-id]} "Remove"]
+   [basket-row {:label "Line" :on-remove (v/event [_] [:basket/removed row-id])}]])
 
 (v/defview plain-list
   "The paved path: interpreted, so there is no analysis to report and no roster
@@ -224,27 +236,89 @@
             can see is here."
     (let [r (tool/read-view-event-sites basket-id)]
       (is (= :view-event-sites (:read r)))
-      (is (= 2 (count (:event-sites r)))
-          "exactly the two `:on-click` sites the body carries")
+      (is (= 4 (count (:event-sites r)))
+          "exactly the four event sites the body carries — three `:on-click`
+           handlers and one committed callback at the child's prop")
       (is (true? (:complete? r)))
       (is (nil? (:loss r))))))
 
-(deftest an-event-site-says-which-facts-it-can-state
+(deftest an-event-site-states-the-closed-set-of-facts-it-carries
   (testing "The analyzer records `:prop`, `:classification`, `:serializable?`,
-            `:sync?` and the authored `:handler` per site, and the manifest
-            projection drops all five (rf2-z0blg). So a reader seeing no
-            `:handler` is seeing a fact this build does not publish, NOT a site
-            with no handler — and `:site-facts` is what makes the difference
-            legible from the answer rather than from a changelog.
+            `:sync?` and `:handler` per site, and the manifest now PUBLISHES all
+            five (rf2-z0blg) — so a row says what a view dispatches, not only
+            where from. `:site-facts` names the closed set of facts a row states,
+            with `:event-id` beside `:handler` for the honesty split.
 
-            Asserted as an EQUALITY against the entries themselves, so the key
-            cannot drift into a decoration: if the manifest starts publishing
-            the classification and `:site-facts` is not updated, this reds."
+            Asserted as an EQUALITY against the entries themselves, so neither
+            side can drift: a manifest that stopped publishing a fact reds here,
+            and so does one that starts publishing a fact this set does not
+            name."
     (let [r (tool/read-view-event-sites basket-id)]
-      (is (= #{:sid :source-coord :path} (:site-facts r)))
+      (is (= #{:sid :source-coord :path :prop :classification :serializable?
+               :sync? :handler :event-id}
+             (:site-facts r)))
       (doseq [site (:event-sites r)]
         (is (= (:site-facts r) (set (keys site)))
             "every entry states exactly the facts the read says it states")))))
+
+(deftest a-literal-handler-is-projected-as-the-event-vector-it-is
+  (testing "A fully-literal handler IS the vector that will dispatch, so it is
+            safe to show verbatim — the same rule a fully-literal query gets."
+    (let [sites (:event-sites (tool/read-view-event-sites basket-id))
+          site  (first (filter #(= :basket/clear (:event-id %)) sites))]
+      (is (some? site) "the body carries a literal-handler site")
+      (is (= [:basket/clear] (:handler site))
+          "shown as data, because that is what it is")
+      (is (= :on-click (:prop site)) "under the prop the author wrote it at")
+      (is (= :vector (:classification site)))
+      (is (true? (:serializable? site)))
+      (is (false? (:sync? site))
+          "a `:button` `:on-click` is not the controlled-input synchronous
+           door — the fact is STATED, not left to be assumed from absence"))))
+
+(deftest a-captured-local-in-an-event-vector-shows-only-what-is-known
+  (testing "`[:basket/remove row-id]` closes over a template local, so the vector
+            that will dispatch does not exist until the view renders. Showing the
+            form would be handing a reader source code where they asked for data
+            — but the event-id is genuinely known, so it is still shown."
+    (let [sites (:event-sites (tool/read-view-event-sites basket-id))
+          site  (first (filter #(= :basket/remove (:event-id %)) sites))]
+      (is (some? site) "the body carries a captured-local handler site")
+      (is (= :opaque (:handler site))
+          "no handler value is offered, because there is no event vector yet")
+      (is (= :vector (:classification site))
+          "and the classification keeps it apart from a callback body: this IS
+           an event vector, with one argument that is not known yet"))))
+
+(deftest an-opaque-callback-claims-nothing-about-its-body
+  (testing "A `v/event` body is CODE. It carries no event vector, so there is no
+            event-id either — and that absence is STATED rather than left as a
+            missing key a reader has to interpret. It is also the component-prop
+            arm, whose `:sync?` was absent rather than false until rf2-z0blg."
+    (let [sites (:event-sites (tool/read-view-event-sites basket-id))
+          site  (first (filter #(= :ui-event (:classification %)) sites))]
+      (is (some? site) "the body mounts a child with a committed callback prop")
+      (is (= :on-remove (:prop site)))
+      (is (= :opaque (:handler site)))
+      (is (nil? (:event-id site)) "no event vector, so no head to name")
+      (is (false? (:serializable? site)))
+      (is (false? (:sync? site))
+          "a component prop is not a DOM controlled-input door site — false is
+           the fact, and stating it is what makes the row's key set whole"))))
+
+(deftest the-handler-honesty-split-is-a-discrimination
+  (testing "Non-vacuity for the three rows above: the census carries one site of
+            each class, so a projection that answered `:opaque` to everything —
+            or showed every recorded handler verbatim — cannot pass all three."
+    (let [sites (:event-sites (tool/read-view-event-sites basket-id))]
+      (is (= 2 (count (remove #(= :opaque (:handler %)) sites)))
+          "two literal handlers, projected verbatim")
+      (is (= 1 (count (filter #(and (= :opaque (:handler %)) (some? (:event-id %)))
+                              sites)))
+          "one dynamic event vector — opaque handler, known event-id")
+      (is (= 1 (count (filter #(and (= :opaque (:handler %)) (nil? (:event-id %)))
+                              sites)))
+          "and one callback body — opaque handler, and no event-id to know"))))
 
 (deftest an-interpreted-declaration-has-no-event-roster-to-claim
   (testing "The third read's honesty arm, asserted rather than assumed to

--- a/spec/conformance/freehand/fixtures/fh-struct-010.edn
+++ b/spec/conformance/freehand/fixtures/fh-struct-010.edn
@@ -78,7 +78,8 @@
   :crossings     {:surface :public   :entries 1}}
  :required-keys
  {:subscriptions #{:sid :query :source-coord :path}
-  :events        #{:sid :source-coord :path}
+  :events        #{:sid :source-coord :path :prop :classification
+                   :serializable? :sync? :handler}
   :slots         #{:sid :inline? :source-coord :path}
   :html-sites    #{:source-coord :path}
   :crossings     #{:view-id :lowering :source-coord :path}}


### PR DESCRIPTION
Closes rf2-z0blg.

`re-frame.freehand.compiler.analyze` records five facts per event site beyond its
coordinates — `:prop` (the authored handler prop), `:classification`
(`:vector` / `:options` / the dynamic kinds), `:serializable?`, `:sync?` (the
controlled-input synchronous door) and `:handler` — and
`compiler/structural-manifest` projected `(select-keys % [:sid :source-coord
:path])`, dropping all five. So `tool/read-view-event-sites` could say WHERE a
view dispatches from and not WHAT it dispatches. That is the same defect
rf2-hytu5 fixed for `:diagnostics`: a fact the compiler already computes,
collected in the analyzer's site index and published nowhere a reader can reach.

### What changed

1. **`compiler.cljc`** — the `:events` projection carries
   `[:sid :source-coord :path :prop :classification :serializable? :sync? :handler]`.
2. **`fh-struct-010.edn`** — `:required-keys {:events ..}` moves with it. Both
   `manifest_census_cljs_test` and `manifest_roster_coverage_cljs_test` assert an
   EXACT per-entry key set, so the projection and the fixture row are one edit.
   Only that row changed; the rest of the fixture, the index row and `spec/004D`
   are untouched (fenced this wave — follow-up filed as rf2-itpbd).
3. **`tool.cljc`** — a private `event-site` projection beside `dependency-site`,
   applying the honesty rule its sibling already applies to a subscription's
   `:query`, through the same existing `literal-form?` predicate (no second one
   was written). A fully-literal handler is projected verbatim; anything else is
   `:handler :opaque` — the marker the analyzer itself uses for a handler that is
   code — with the literal `:event-id` still shown where the authored form has
   one. `:classification` sitting beside them is what keeps the two apart: an
   `:opaque` handler on a `:vector` / `:options` site is an event vector with a
   runtime argument; on any other classification it is a callback body.
4. **`tool.cljc`** — `:site-facts` (scope item 4) stops naming a gap and names
   the closed set of facts a row states:
   `#{:sid :source-coord :path :prop :classification :serializable? :sync?
   :handler :event-id}`. Every member is present on every entry, so the set stays
   assertable as an equality. It is NOT derived from an entry — that would make
   the assertion a tautology — it is a literal set the suite pins from both sides.
5. **`analyze.cljc`** — the latent totality gap the previous attempt found:
   `analyze-component-callback-prop` (a `v/event` / `v/handler` at a view or
   foreign-component PROP) recorded no `:sync?` at all. `select-keys` drops an
   absent key, so such a site carried a narrower key set than its siblings and
   the exact-key-set law passed over an uninhabited case. It states `:sync? false`
   now — factually false, a component prop is not a DOM controlled-input door
   site — matching what the spread sites already do.

### The assertion was not weakened

`tool_reads_cljs_test.cljc`'s per-entry law is still
`(= (:site-facts r) (set (keys site)))` — an exact key-set equality over the
SHIPPED projection, asserted for every entry. The two failures the previous
attempt measured at that line pass because the projection now carries the facts
and `event-site-facts` names them, not because the assertion was relaxed. Both
sides were falsified rather than assumed:

- Removing `:sync? false` from `analyze.cljc` → **rc 1, 5 failures**: 3 in the new
  analyzer totality row, 2 in `an-event-site-states-the-closed-set-of-facts-it-carries`
  and `an-opaque-callback-claims-nothing-about-its-body`. So the fix is over an
  INHABITED case, and the key law reaches it.
- Reverting the fixture's `:required-keys {:events ..}` row → **rc 1, 6 failures**,
  3 event entries × both manifest suites.

The census declaration in `tool_reads_cljs_test` grew from two literal `:on-click`
sites to four — one literal vector, one carrying a captured local, and one
committed callback at a child declaration's prop — so all three honesty classes
and the component-prop `:sync?` arm are inhabited, and a new
`the-handler-honesty-split-is-a-discrimination` row proves a projection that
answered `:opaque` to everything (or showed every handler verbatim) cannot pass.
The new analyzer row asserts `:sync?` is total over all six site-producing arms
AND that it discriminates (`#{true false}`), so a hard-coded `false` would fail it.

### Design note

The analyzer still records `:handler` as the ANALYZED form, not the authored one.
Deliberate: `re-frame.ui.tool/view-event-sites` — the sibling substrate, and what
the MCP `read-view-event-sites` descriptor documents — records the same way and
already established `:handler :opaque` as the marker for "not statically known
data". Freehand stays aligned with it and goes FURTHER by applying `literal-form?`
at the read. The ui tier still publishes a `:serializable? true` handler verbatim
even when it carries a runtime argument; filed as rf2-qe9xk rather than fixed here.

## Quality gates

Every runner foreground to completion, with `rc=$?` captured immediately into a
worktree-local log and cross-checked against the runner's own PASS/FAIL lines.
Nothing was read through a pipe's exit status.

| Gate | Result | rc |
|---|---|---|
| `implementation/freehand` `clojure -M:test` | 1080 tests / 7307 assertions, 0 failures, 0 errors | 0 |
| `npm run test:cljs` | 11387 tests / 57016 assertions, 0 failures, 0 errors | 0 |
| Freehand census self-test | all 71 self-tests passed | 0 |
| Freehand census (live, structural + execution) | 97 rows (96 active, 1 retired), 96 applicable rows each witnessed | 0 |
| Freehand census `--report` vs `origin/main` | byte-identical — `cmp` rc 0, both 11607 B, md5 `bdb95d24524b6a460a687b408a7b1a48` | 0 |
| `scripts/test-fast-pr.sh` | `PASS fast PR spine` — core JVM 2115/10456, CLJS node 11387/57016, per-ns isolation 17/17, docs tier correctly skipped | 0 |

Falsification runs (deliberately red, then reverted): `:sync?` removed → rc 1 /
5 failures; fixture row reverted → rc 1 / 6 failures.
