### PR TITLE
core,adapters: stop calling the shipping adapters 'transition' (rf2-zrvnb)

### DIFF
--- a/docs/api/re-frame.core.md
+++ b/docs/api/re-frame.core.md
@@ -842,7 +842,7 @@ The surfaces that bring a re-frame2 process up and take it down. The one-line bo
   ```clojure
   (current-adapter) → discriminator keyword
   ```
-- **Description**: Which substrate is installed. Answers `:rf.adapter/reagent` / `:rf.adapter/reagent-slim` / `:rf.adapter/ui` / `:rf.adapter/uix` / `:rf.adapter/plain-atom` / `:rf.adapter/ssr` / `:custom` — or `nil` when no adapter is installed. For predicate / branch code.
+- **Description**: Which substrate is installed. Answers `:rf.adapter/freehand` / `:rf.adapter/reagent` / `:rf.adapter/reagent-slim` / `:rf.adapter/uix` / `:rf.adapter/plain-atom` / `:rf.adapter/ssr` / `:custom` — or `nil` when no adapter is installed. (`:rf.adapter/ui` is also reserved, but only donor in-tree code can produce it.) For predicate / branch code.
 - **Example**:
   ```clojure
   (rf/current-adapter)   ;; => :rf.adapter/reagent   (nil when no adapter is installed)

--- a/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
+++ b/implementation/adapters/uix/src/re_frame/adapter/uix.cljs
@@ -1,8 +1,11 @@
 (ns re-frame.adapter.uix
   "UIx 2.x adapter for the substrate contract in Spec 006.
 
-  The React machinery lives in `re-frame.substrate.spine`, shared with the
-  compiled-view substrate and any future React-wrapper adapter.
+  A first-class, actively-supported adapter: UIx is a permanent sibling of
+  Freehand and the Reagent adapters, not a transition path off any of them.
+
+  The React machinery lives in `re-frame.substrate.spine`, shared with
+  Freehand's observation adapter and any future React-wrapper adapter.
   This namespace supplies UIx's hooks and native `defui` `frame-provider`
   (SCOPE) + `frame-root` (ENSURE) components; keeping them native preserves
   UIx's CLJS prop and trailing-child marshalling."

--- a/implementation/core/src/re_frame/adapter/context.cljs
+++ b/implementation/core/src/re_frame/adapter/context.cljs
@@ -69,9 +69,9 @@
 (defn provider-element
   "Build a React element for the frame-context Provider with `frame-kw`
   as its value and `children` as its child elements. Substrate-agnostic
-  — the Reagent adapter (via `:>` interop), the UIx adapters (via
-  `$`), and the first-party re-frame.ui substrate's provider component
-  all wrap their element idiom around this primitive.
+  — the Reagent adapters (via `:>` interop), the UIx adapter (via
+  `$`), and Freehand's provider component all wrap their element idiom
+  around this primitive, as does the donor re-frame.ui substrate's in-tree.
 
   Returns a raw React element so callers don't pay for an extra
   reagent.core/as-element walk."
@@ -97,9 +97,11 @@
   Shared by `re-frame.substrate.spine/build-frame-provider-element` (the
   scope-only `frame-provider` core), `re-frame.views.frame-boundary`'s
   `frame-root-fc` / `frame-root-react-element` (the ENSURE `frame-root`
-  cores), and `re-frame.ui.substrate`'s `:register-context-provider`
-  component so the four element builders normalise children one identical
-  way — `(apply provider-element frame-kw (normalize-children children))`."
+  cores), and `re-frame.freehand.substrate`'s `:register-context-provider`
+  component so the four published element builders normalise children one
+  identical way — `(apply provider-element frame-kw (normalize-children
+  children))`. The donor `re-frame.ui.substrate` component is a fifth caller
+  in-tree, on the same path."
   [children]
   (cond
     (nil? children)        nil

--- a/implementation/core/src/re_frame/core.cljc
+++ b/implementation/core/src/re_frame/core.cljc
@@ -2763,11 +2763,11 @@
   destroy-adapter!     adapter/dispose-adapter!)
 
 (def ^{:doc "Return the discriminator keyword identifying the installed
-  adapter, or `nil` if none. One of `:rf.adapter/reagent`,
-  `:rf.adapter/reagent-slim`, `:rf.adapter/ui`, `:rf.adapter/uix`,
-  `:rf.adapter/plain-atom`, `:rf.adapter/ssr`, or `:custom` for
-  user-supplied adapters that didn't pick a canonical kind. Per Spec 006
-  §Adapter introspection."}
+  adapter, or `nil` if none. One of `:rf.adapter/freehand`,
+  `:rf.adapter/reagent`, `:rf.adapter/reagent-slim`, `:rf.adapter/uix`,
+  `:rf.adapter/plain-atom`, `:rf.adapter/ssr`, `:rf.adapter/ui` (donor
+  in-tree code only), or `:custom` for user-supplied adapters that didn't
+  pick a canonical kind. Per Spec 006 §Adapter introspection."}
   current-adapter      adapter/current-adapter)
 
 (def ^{:doc "Return the installed adapter spec map, or `nil` if none.

--- a/implementation/core/src/re_frame/substrate/adapter.cljc
+++ b/implementation/core/src/re_frame/substrate/adapter.cljc
@@ -2,9 +2,15 @@
   "The reactive substrate adapter contract. Per Spec 006.
 
   The runtime is substrate-agnostic; every host-specific reactivity concern
-  goes through these ten functions. The reference ships the first-party
-  re-frame.ui adapter plus the transition Reagent and UIx browser
-  adapters, and plain-atom for JVM / SSR / headless use.
+  goes through these ten functions. The reference ships FOUR first-class,
+  actively-supported browser adapters — Freehand's own observation adapter
+  (`re-frame.freehand`) plus the Reagent, reagent-slim and UIx renderer
+  adapters. None of the four is transitional, a fallback, or scheduled for
+  removal (EP-0036); they are permanent siblings. Alongside them, plain-atom
+  and ssr cover JVM / SSR / headless use. The DONOR `re-frame.ui`
+  compiled-view substrate carries a fifth adapter that is in-tree ONLY: it has
+  no published coordinate (`day8/re-frame2-ui` will never publish) and is
+  being absorbed into Freehand.
 
   Required functions (6):
     make-state-container, read-container, replace-container!,
@@ -18,16 +24,18 @@
 
   An adapter is a Clojure map with these keys plus a `:kind` discriminator
   keyword. Canonical framework members live under the reserved
-  `:rf.adapter/*` namespace (`:rf.adapter/reagent` / `:rf.adapter/reagent-slim`
-  / `:rf.adapter/ui` / `:rf.adapter/uix` / `:rf.adapter/plain-atom` /
-  `:rf.adapter/ssr`); user-supplied adapters report as `:custom` when they
+  `:rf.adapter/*` namespace (`:rf.adapter/freehand` / `:rf.adapter/reagent` /
+  `:rf.adapter/reagent-slim` / `:rf.adapter/uix` / `:rf.adapter/plain-atom` /
+  `:rf.adapter/ssr`, plus `:rf.adapter/ui` which only DONOR in-tree code can
+  produce); user-supplied adapters report as `:custom` when they
   don't pick a canonical kind. It is installed into the process via
   install-adapter! and introspected via current-adapter (keyword) and
   current-adapter-spec (the full map).
 
   There is no default-adapter registry and no ns-load side-effect.
-  Each adapter ns (`re-frame.ui`, re-frame.adapter.reagent / .uix,
-  re-frame.substrate.plain-atom, re-frame.ssr) exports an `adapter`
+  Each adapter ns (re-frame.freehand, re-frame.adapter.reagent /
+  .reagent-slim / .uix, re-frame.substrate.plain-atom, re-frame.ssr — and
+  `re-frame.ui` in donor in-tree code) exports an `adapter`
   var (the spec map); consumers require the ns and pass the var
   explicitly via `(rf/init! reagent/adapter)`. Explicit > implicit
   at the call site, and an app requiring only the adapter it needs
@@ -175,8 +183,9 @@
 (defn current-adapter
   "Return the discriminator keyword identifying the installed adapter, or
   nil if none. Per Spec 006 §Adapter introspection: one of
-  `:rf.adapter/reagent`, `:rf.adapter/reagent-slim`, `:rf.adapter/ui`, `:rf.adapter/uix`,
-  `:rf.adapter/plain-atom`, `:rf.adapter/ssr`, or
+  `:rf.adapter/freehand`, `:rf.adapter/reagent`, `:rf.adapter/reagent-slim`,
+  `:rf.adapter/uix`, `:rf.adapter/plain-atom`, `:rf.adapter/ssr`,
+  `:rf.adapter/ui` (donor in-tree code only), or
   `:custom` for user-supplied adapters that didn't pick a canonical kind.
 
   This answers \"what substrate am I on?\" — predicate / branch code.

--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -564,10 +564,11 @@
   + `re-frame.subs`, `source-containers` is a vector) so the recompute
   closure pays no per-tick `count`.
 
-  Single source of truth: the first-party re-frame.ui, Reagent,
-  reagent-slim, and UIx adapters all build their recompute
-  closure through this fn — one implementation, four adapters, zero
-  drift. The arity-spec lifted
+  Single source of truth: the Freehand, Reagent, reagent-slim, and UIx
+  adapters all build their recompute closure through this fn — one
+  implementation, four adapters, zero drift (the donor re-frame.ui substrate
+  rides the same path in-tree, making five closures in this repo). The
+  arity-spec lifted
   into the spine matches the `make-dispose-adapter!` shape
   (rf2-jcjul); sourced from the rf2-fzrav perf-sweep findings."
   [source-containers compute-fn]
@@ -2609,9 +2610,9 @@
 ;;     elided via `interop/debug-enabled?` per Spec 009 §Production builds.
 
 (defn make-react-adapter
-  "Assemble a React-hook adapter (the first-party re-frame.ui substrate
-  or UIx) from a `make-react-spine` result map plus the
-  substrate's config:
+  "Assemble a React-hook adapter (Freehand's observation adapter or UIx —
+  and, in-tree, the donor re-frame.ui substrate) from a
+  `make-react-spine` result map plus the substrate's config:
 
       :kind           — the adapter's `:kind` discriminator keyword
       :frame-provider — the substrate's NATIVE frame-provider component
@@ -2637,8 +2638,8 @@
   evaluates `(make-react-adapter spine-fns {:kind :rf.adapter/uix
   :frame-provider …})` at load), exactly as the hand-written wiring did.
 
-  Single source of truth (rf2-ee38b.1): the first-party re-frame.ui
-  substrate and UIx both call this with the same shape — the
+  Single source of truth (rf2-ee38b.1): Freehand and UIx both call this with
+  the same shape (as does the donor re-frame.ui substrate in-tree) — the
   only inputs are their already-substrate-specific
   `spine-fns` map, `:kind`, and native `:frame-provider`. The former
   hand-copied route-hook block + chained installs (byte-identical across


### PR DESCRIPTION
The fourth and last defect from the pre-alpha documentation audit (`rf2-ods8n`). Split out of #6966: that PR merged at my third commit while this one was still under gate, so it lands on its own branch.

## rf2-zrvnb — the shipping adapters are not "transition"

`re-frame.substrate.adapter`'s ns docstring — the doc a consumer reads to understand `rf/init!` — said the reference "ships the first-party re-frame.ui adapter plus the **transition** Reagent and UIx browser adapters". Both halves were wrong at the tag, and the second is positioning rather than provenance: it told an alpha consumer that the only view path they can actually install is a transitional stopgap.

**Found.** Confirmed as filed, and verified in source rather than from the manifest (`spec/api-manifest.edn` is not a complete existence authority — `re-frame.resources` is missing from the generator's roster, `rf2-ivuun`).

- `re-frame.ui` does not ship: `implementation/ui/deps.edn:19` carries no `:clein` alias and the artefact is absent from `release.yml`'s `deploy-leaf` matrix.
- Reagent, reagent-slim and UIx are first-class per `CLAUDE.md`, `docs/core/freehand/index.md:44-46` ("adapters stay permanent first-class siblings — not a fallback and not scheduled for deletion") and `rf2-drpa3.57`'s own non-goals.
- **One omission the bead did not name:** `:rf.adapter/freehand` was missing from *every* `:kind` roster in the codebase — `adapter.cljc:22`, `current-adapter` at `:178`, and the `re-frame.core` facade docstring — even though `spec/Conventions.md:102` lists it as canonical and `freehand/substrate.cljs:147` produces it. A consumer branching on `current-adapter` had no cue the Freehand case existed.

Every count was re-derived from source before being rewritten, rather than taken from the bead:

- `build-recompute-fn`'s four adapters are **Freehand, Reagent, reagent-slim, UIx** — the React path via `make-derived-value-fn` (`spine.cljs:2158`), the ratom path via `make-ratom-spine`. The count "four" happened to be right; the roster named the donor and omitted Freehand.
- `make-react-adapter`'s published callers are **Freehand** (`freehand/substrate.cljs:145`) and **UIx** (`uix.cljs:175`); the donor is a third, in-tree only.
- `normalize-children` has **four published callers** plus the donor as a fifth.

**Changed** — docstrings and comments only, no behaviour change (bead acceptance 4).

- `substrate/adapter.cljc`'s ns docstring names four first-class, actively-supported browser adapters and states outright that none is transitional, a fallback, or scheduled for removal (EP-0036); plain-atom and ssr cover JVM / SSR / headless; the donor `re-frame.ui` adapter is named as in-tree-only with no publishable coordinate.
- All three `:kind` rosters gain `:rf.adapter/freehand` and mark `:rf.adapter/ui` as producible only by donor in-tree code. Both keywords stay reserved per `spec/Conventions.md` — this is a **donor-context** mention, which `rf2-xoei9`'s reclassification makes the correct treatment, not a deletion. `docs/api/re-frame.core.md`'s `current-adapter` entry matches.
- `adapter.cljc`'s "each adapter ns exports an `adapter` var" list gains `re-frame.freehand` and `re-frame.adapter.reagent-slim`.
- `adapters/uix/…/uix.cljs` opens by stating UIx is a permanent sibling, and its spine sentence points at Freehand's observation adapter rather than the compiled-view substrate (acceptance 2).
- `spine.cljs` (`build-recompute-fn`, `make-react-adapter`) and `adapter/context.cljs` (`provider-element`, `normalize-children`) carry the corrected rosters, with the donor called out separately as an in-tree extra (acceptance 3).

**Scope fence honoured.** The bead excluded ~108 further `re-frame.ui` references across 20 files as legitimate engineering provenance for copied version-pinned tables. `ssr/ui_tree.cljc`, `ssr/manifest.cljc`, `core/frame.cljc`, `late_bind/directory.cljc`, `subs/override_schema.cljc` and `routing/link.cljc` are untouched.

## Quality gates

All run on this branch's exact tree (rebased onto `main` after #6966 merged). Each `rc` was captured immediately after its runner into a worktree-local log and cross-checked against that runner's own PASS/OK lines — no gate piped through `tail`/`grep`, no compound command's status trusted.

| Gate | Command | rc | Evidence |
|---|---|---|---|
| core JVM suite | `implementation/core` `clojure -M:test` | **0** | `Ran 2115 tests containing 10456 assertions. 0 failures, 0 errors.` |
| CLJS node integration | `implementation` `npm run test:cljs` | **0** | `Ran 11382 tests containing 56987 assertions. 0 failures, 0 errors.` |
| lint (all 5 edited files) | `clj-kondo --lint … --fail-level error` | **0** | `errors: 0`; the 21 warnings are pre-existing macro/protocol notes, none on a changed line |
| adapter disposition | `python scripts/check_adapter_disposition.py --verbose` | **0** | `adapter disposition intact across 7 authorities` |
| API-reference ↔ manifest | `clojure -M -m re-frame.api-manifest.doc-api-check` | **0** | `323 public-var references checked`; `223 eligible manifest vars each have a page + member entry` |
| manifest drift | `clojure -M -m re-frame.api-manifest.gen --check` | **0** | `spec/api-manifest.edn in sync (551 public vars)` |
| docs build | `python -m mkdocs build --strict` | **0** | `Documentation built in 25.76 seconds` |
| doc links + anchors | `python scripts/check_doc_slugs.py --verbose` | **0** | `no broken links` (600 markdown files) |
| donor ledger | `python scripts/check_donor_inventory.py --verbose` | **0** | ledger covers the diff; no row flipped |

**Note on `scripts/test-fast-pr.sh`.** It **soft-skips its own mkdocs step** when mkdocs is off `PATH` and still exits 0 (`SKIP mkdocs --strict build: mkdocs not on PATH`), so `python -m mkdocs build --strict` was run separately — it is the gate that actually covers a docs diff. On the pre-rebase tree the spine went green through every step except `CLJS node integration`, which failed only because a fresh worktree has no `implementation/node_modules` (`'shadow-cljs' is not recognized`); `npm ci` fixed that and `npm run test:cljs` is green standalone above. Worth flagging that the harness reported that failing run as "exit code 0" while the script itself printed `rc=1` — the compound-status trap.
