### PR TITLE
test(epoch): mirror the leak-critical egress-redaction arms onto the CLJS lane (rf2-p4515)

### DIFF
--- a/implementation/epoch/test/re_frame/epoch_egress_redaction_cljs_test.cljc
+++ b/implementation/epoch/test/re_frame/epoch_egress_redaction_cljs_test.cljc
@@ -283,6 +283,66 @@
           "fixture control: `:epoch-id` is actually populated, so the
            equality checks above are not comparing nil to nil"))))
 
+(deftest large-sub-output-value-slot-elides-at-egress
+  (testing "rf2-at60h — a whole-output `:large?` subscription's computed value
+            rides the structured `:sub-runs` row's `:value` / `:prev-value`.
+            The raw on-box row keeps the exact value (Xray diff and
+            `restore-epoch!` need it) but egress MUST substitute the marker;
+            shipping it raw was the pre-fix leak. This is a DISTINCT slot
+            from `:db-after` — and `epoch_cljs_test.cljs` exercises no
+            subscriptions at all, so the CLJS lane had no `:sub-runs` egress
+            coverage of any kind."
+    (fresh-frame!)
+    (rf/reg-event :egress/seed (fn [_ _] {:db {:n 0}}))
+    (rf/reg-sub :egress/big {:large? true} (fn [_ _] (big-string payload-size)))
+    (rf/reg-sub :egress/small (fn [_ _] benign))
+    (rf/reg-event :egress/read-subs
+      (fn [_ _]
+        (rf/subscribe-once [:egress/big]   {:frame frame-id})
+        (rf/subscribe-once [:egress/small] {:frame frame-id})
+        {}))
+    (rf/dispatch-sync [:egress/seed]      {:frame frame-id})
+    (rf/dispatch-sync [:egress/read-subs] {:frame frame-id})
+    (let [raw       (last-record)
+          row-of    (fn [rec id] (->> (:sub-runs rec) (filter #(= id (:sub-id %))) first))
+          raw-row   (row-of raw :egress/big)
+          proj      (epoch/projected-record raw)
+          proj-row  (row-of proj :egress/big)
+          small-row (row-of proj :egress/small)]
+      (is (some? raw-row)  "fixture: the `:large?` sub produced a `:sub-runs` row")
+      (is (= payload-size (count (:value raw-row)))
+          "fixture: the raw row carries the full computed value")
+      (is (some? proj-row) "the projected record keeps the row")
+      (is (elision/marker? (:value proj-row))
+          "the projected `:value` is a `:rf.size/large-elided` marker")
+      (is (not (contains? proj-row :large?))
+          "the now-spent `:large?` row flag is stripped from the projection")
+      (is (= (:sub-id raw-row) (:sub-id proj-row))
+          "the value-free row metadata is preserved for tool display")
+      (is (= benign (:value small-row))
+          "NEGATIVE CONTROL — an UNMARKED sub's value rides through RAW, so
+           the elision above is driven by the registration marker")
+      ;; NOT asserted: `(zero? (count-leaves-at-least payload-size proj))`.
+      ;; Writing that scan is how this suite FOUND rf2-irwsq: the whole-output
+      ;; `:large?` value ALSO rides the `:rf.sub/run` trace tag at
+      ;; `[:trace-events <i> :tags :rf.sub/value]`, and egress elides only the
+      ;; structured `:sub-runs` row — so the raw payload does still egress
+      ;; there today. Pinning the leak as expected would be worse than
+      ;; leaving it visible; the bead carries the repro. Privacy is NOT
+      ;; affected (per-path `:sensitive` sub marks are substituted at the
+      ;; EMIT site, so they are already redacted in both slots) — this is the
+      ;; token-budget axis only.
+      (is (= payload-size (count (get-in (->> (:trace-events proj)
+                                              (filter #(= :rf.sub/run (:operation %)))
+                                              (filter #(= :egress/big
+                                                          (get-in % [:tags :rf.sub/id])))
+                                              first)
+                                         [:tags :rf.sub/value])))
+          "rf2-irwsq CHARACTERISATION (not an endorsement): the trace-tag twin
+           of the elided row value still egresses raw. If this assertion goes
+           RED because the projector learned to elide the tag too, DELETE it —
+           that is the fix landing."))))
+
 (deftest nil-and-non-map-input-projects-to-nil
   (testing "`projected-record` returns nil for non-map input — a forwarder
             mapping over a ring that contains a nil hole must not throw

--- a/implementation/epoch/test/re_frame/epoch_egress_redaction_cljs_test.cljc
+++ b/implementation/epoch/test/re_frame/epoch_egress_redaction_cljs_test.cljc
@@ -108,9 +108,15 @@
 
 (defn- big-string [n] (apply str (repeat n "X")))
 
-(def ^:private frame-id :epoch-egress-redaction/frame)
+(def ^:private frame-id         :epoch-egress-redaction/frame)
+;; A second, never-classified frame — the control arms make a FRESH frame
+;; rather than re-`make-frame`ing `frame-id`, whose app-db would still carry
+;; the secret in `:db-before` and roll the badge up true.
+(def ^:private control-frame-id :epoch-egress-redaction/control-frame)
 
-(defn- last-record [] (last (rf/epoch-history frame-id)))
+(defn- last-record
+  ([] (last-record frame-id))
+  ([fid] (last (rf/epoch-history fid))))
 
 (defn- classify!
   "Declare `[:auth :password]` sensitive and `[:blob :payload]` large against
@@ -128,14 +134,11 @@
   nil)
 
 (defn- fresh-frame!
-  "Make the suite's frame. `classify?` false is the NEGATIVE-CONTROL arm: the
-  identical cascade with NO classification registered, so the same bytes must
-  survive projection RAW."
-  ([] (fresh-frame! true))
-  ([classify?]
-   (rf/make-frame {:id frame-id})
-   (when classify? (classify!))
-   nil))
+  "Make the suite's frame with the classification registered."
+  []
+  (rf/make-frame {:id frame-id})
+  (classify!)
+  nil)
 
 (defn- contains-secret?
   "True when `secret` appears ANYWHERE in a nested EDN value — the recursive
@@ -525,13 +528,38 @@
       (let [proj (epoch/projected-record raw {:include-sensitive? true})]
         (is (= secret (get-in proj [:db-after :auth :password])))
         (is (elision/marker? (get-in proj [:db-after :blob :payload]))
-            "large stays elided under the sensitive opt-in"))
+            "large stays elided under the sensitive opt-in")
+        (is (zero? (count-leaves-at-least payload-size proj))
+            "and no raw payload bytes egress anywhere in the record"))
       (let [proj (epoch/projected-record raw {:include-large? true})]
         (is (= :rf/redacted (get-in proj [:db-after :auth :password]))
             "sensitive stays redacted under the large opt-in")
-        (is (= payload-size (count (get-in proj [:db-after :blob :payload])))
-            "NEGATIVE CONTROL — `:include-large? true` DOES reveal the full
-             payload, so the elision assertions are not vacuous")))))
+        (is (not (elision/marker? (get-in proj [:db-after :blob :payload])))
+            "NEGATIVE CONTROL — `:include-large? true` DOES lift the slot")
+        (is (pos? (count-leaves-at-least payload-size proj))
+            "and the raw payload bytes ARE present, so the elision
+             assertions above are not vacuous")))))
+
+(deftest include-sensitive-still-applies-the-redact-fn-override
+  (testing "the app-installed `:redact-fn` is the SECOND stage of the
+            projection. A raw-record bypass on `:include-sensitive?` (the
+            original rf2-m9duxl bug) skipped it entirely, so an app relying
+            on the override to scrub material the classification registry
+            cannot prove would have leaked. The override must still run."
+    (fresh-frame!)
+    (reg-login!)
+    (rf/configure! {:epoch-history
+                    {:redact-fn (fn [r] (assoc r :rf.test/redact-fn-ran true))}})
+    (rf/dispatch-sync [:egress/login secret] {:frame frame-id})
+    (let [raw  (last-record)
+          proj (epoch/projected-record raw {:include-sensitive? true})]
+      (is (= secret (get-in proj [:db-after :auth :password]))
+          "the sensitive opt-in is in force")
+      (is (true? (:rf.test/redact-fn-ran proj))
+          "the override still ran — the post-projection stage is never skipped")
+      (is (not (contains? raw :rf.test/redact-fn-ran))
+          "NEGATIVE CONTROL — the RAW ring record is untouched, so the
+           override is projection-side only"))))
 
 ;; ============================================================================
 ;;  5. `:trigger-event` event-args fail-closed (rf2-nm611o)
@@ -621,10 +649,10 @@
             the projection silently blanket-redacted, this arm reds. It also
             documents the actual contract — the projection redacts what the
             app CLASSIFIED, nothing more."
-    (fresh-frame! false)
+    (rf/make-frame {:id control-frame-id})
     (reg-login!)
-    (rf/dispatch-sync [:egress/login secret] {:frame frame-id})
-    (let [proj (epoch/projected-record (last-record))]
+    (rf/dispatch-sync [:egress/login secret] {:frame control-frame-id})
+    (let [proj (epoch/projected-record (last-record control-frame-id))]
       (is (= secret (get-in proj [:db-after :auth :password]))
           "with no classification declared the value rides through RAW")
       (is (contains-secret? proj)
@@ -639,18 +667,23 @@
             record would collapse to a constant."
     (fresh-frame!)
     (reg-login!)
-    (rf/reg-event :egress/inc (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
     (rf/dispatch-sync [:egress/login secret] {:frame frame-id})
-    (let [proj (epoch/projected-record (last-record))]
-      (is (true? (:rf.epoch/sensitive? proj))
-          "a cascade whose classified path holds a non-nil leaf rolls up true
-           and the flag survives projection"))
-    (fresh-frame! false)
-    (rf/reg-event :egress/plain (fn [_ _] {:db {:n 0}}))
-    (rf/dispatch-sync [:egress/plain] {:frame frame-id})
-    (is (false? (:rf.epoch/sensitive? (epoch/projected-record (last-record))))
-        "NEGATIVE CONTROL — a non-sensitive cascade reads strict false, so
-         the flag is not hardcoded true")))
+    (is (true? (:rf.epoch/sensitive? (epoch/projected-record (last-record))))
+        "a cascade whose classified path holds a non-nil leaf rolls up true
+         and the flag survives projection")))
+
+(deftest sensitive-rollup-badge-reads-strict-false-without-classification
+  (testing "NEGATIVE CONTROL for the badge — the identical projection call on
+            a frame with NO classification declared reads strict `false`, so
+            the sibling assertion is not passing against a hardcoded true.
+            (A separate frame id: `make-frame` on an id whose app-db already
+            holds the secret would roll up true from `:db-before` alone.)"
+    (rf/make-frame {:id control-frame-id})
+    (rf/reg-event :egress/plain (fn [_ _] {:db {:n 0 :audit {:note benign}}}))
+    (rf/dispatch-sync [:egress/plain] {:frame control-frame-id})
+    (is (false? (:rf.epoch/sensitive? (epoch/projected-record
+                                        (last-record control-frame-id))))
+        "strict false, not nil and not true")))
 
 (deftest trace-events-retention-cap-bounds-what-egresses
   (testing "`:trace-events-keep` is a retention bound on the most

--- a/implementation/epoch/test/re_frame/epoch_egress_redaction_cljs_test.cljc
+++ b/implementation/epoch/test/re_frame/epoch_egress_redaction_cljs_test.cljc
@@ -1,0 +1,729 @@
+(ns re-frame.epoch-egress-redaction-cljs-test
+  "rf2-p4515 — the epoch **egress-redaction** contract, proved on the host its
+  consumers actually run on.
+
+  ## Why this file exists
+
+  The epoch privacy / egress tier is a DATA-LEAK guard: it is the thing that
+  stops a `:sensitive`-classified value leaving the process. Before this suite
+  that guard was proved by 136 deftests across six `.clj` files — **JVM-only**.
+  Every real consumer of the projection is ClojureScript:
+
+    - `day8.re-frame2-xray.runtime/egress-record` calls
+      `re-frame.core/projected-record` in the browser;
+    - `re-frame2-pair-mcp`'s `watch-epochs` / `trace-window` / `snapshot` tools
+      emit CLJS forms that call `re-frame.core/projected-record` **inside the
+      running app**;
+    - the browser Tool-Pair time-travel path reads the same projected shape.
+
+  So the assertions lived on the one host where no consumer runs. That
+  asymmetry — not the raw coverage number — is the defect, and this area has
+  already produced one documented false green on exactly this surface (see
+  `.github/scripts/report-changed-surfaces.sh`: \"a PR that broke the epoch
+  egress/redaction contract merged GREEN at PR time … surfacing only in the
+  nightly cron\").
+
+  ## What is mirrored here (and what is deliberately not)
+
+  Mirrored: the arms whose failure means a sensitive value **actually escapes
+  to a CLJS consumer** —
+
+    1. the app-db `:sensitive` / `:large` substitution table at egress
+       (`:db-before` / `:db-after`, precedence, bookkeeping pass-through);
+    2. the **facade** path (`re-frame.core/projected-record`), which is what
+       the consumers call — the JVM tier drives the artefact-internal
+       `re-frame.epoch/projected-record` almost exclusively, so the
+       `late-bind` seam the browser crosses was untested on this host;
+    3. the forwarder / bulk-egress shapes the consumers run
+       (`register-listener! :epoch` + `projected-history`), including the
+       whole-structure \"no secret bytes anywhere\" scan and double-projection
+       idempotence;
+    4. axis orthogonality — `:include-sensitive?` must not lift the fx-args,
+       runtime-db partition, or large axes (the rf2-m9duxl / rf2-5w06uu
+       Xray + Pair-MCP bypass leaks, both CLJS-side bugs);
+    5. `:trigger-event` event-args fail-closed (rf2-nm611o);
+    6. classification RETENTION — a path classified once keeps redacting on
+       later, unrelated cascades, and the `:rf.epoch/sensitive?` rollup badge
+       survives projection;
+    7. the `:redact-fn` egress override, including the fail-closed fallback
+       when it throws (`catch #?(:clj Throwable :cljs :default)` is one of the
+       few reader conditionals in this tier — CLJS `:default` catches
+       non-`Error` throws too, so the arm is genuinely host-shaped).
+
+  NOT mirrored, and why: see the PR body. In short — HTTP/resource response
+  assembly (`epoch_egress_trace_events_test.clj`,
+  `epoch_egress_resource_trace_test.clj`) is server-side shape,
+  `configure!` argument validation is host-neutral plumbing already proved
+  once, and the JVM `debug-enabled?` gate arms are by definition JVM-shaped.
+
+  ## Non-vacuity
+
+  Every redaction assertion is paired with a control that would break it:
+  either an in-suite **unclassified control path** carrying the same bytes
+  RAW through the same projection call, or the explicit `:include-*` opt-in
+  revealing the value. A fixture that silently stopped writing the secret, or
+  a classification that silently stopped registering, reds the control.
+
+  Dual-lane `.cljc`: the ns ends `-cljs-test` so the shadow-cljs `:node-test`
+  build (`npm run test:cljs`, `:ns-regexp \"cljs-test$\"`) selects it, and it
+  also matches cognitect test-runner's `.*-test$` under the artefact's
+  `clojure -M:test`. The contract is therefore pinned on BOTH hosts from one
+  source of truth."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+               :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+            [clojure.string :as str]
+            [re-frame.core :as rf]
+            [re-frame.elision :as elision]
+            [re-frame.epoch :as epoch]
+            [re-frame.frame :as frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+;; ---- fixtures --------------------------------------------------------------
+;;
+;; Same canonical capture/restore fixture the JVM privacy suites use
+;; (rf2-yw1w1u): registrar snapshot/restore around each test plus the epoch
+;; reset-hook table (history / listeners / config-to-default). The `:init-fn`
+;; re-applies this suite's non-default `:trace-events-keep 5` through the
+;; PUBLIC `configure!` boundary — no reach into the private `state/config`.
+;; plain-atom is the right substrate on both hosts (no DOM under :node-test).
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter plain-atom/adapter
+     :init-fn (fn [] (rf/configure! {:epoch-history {:trace-events-keep 5}}))}))
+
+;; ---- helpers ---------------------------------------------------------------
+
+;; A UNIQUE sentinel: it appears nowhere else in the corpus, so a whole-record
+;; scan that finds it can only be hitting THIS suite's secret.
+(def ^:private secret "EPOCH-EGRESS-SECRET-p4515")
+
+;; A benign string of the same shape, written at an UNCLASSIFIED path. Every
+;; redaction assertion has a sibling asserting this one rides RAW — the
+;; negative control that makes the suite non-vacuous (over-redaction and
+;; under-redaction both fail loudly).
+(def ^:private benign "EPOCH-EGRESS-BENIGN-p4515")
+
+(def ^:private payload-size 25000)
+
+(defn- big-string [n] (apply str (repeat n "X")))
+
+(def ^:private frame-id :epoch-egress-redaction/frame)
+
+(defn- last-record [] (last (rf/epoch-history frame-id)))
+
+(defn- classify!
+  "Declare `[:auth :password]` sensitive and `[:blob :payload]` large against
+  the frame. EP-0025: durable app-db classification rides the commit-plane
+  classification effects, so this is seeded through
+  `elision/apply-classification-effects` (`:source :effect`) — the same
+  registry write a `reg-event` returning `:sensitive` / `:large` performs.
+  Classification is value-independent, so a cascade that leaves either path
+  absent is a harmless no-op."
+  []
+  (frame/swap-runtime-db! frame-id
+    (fn [rt] (elision/apply-classification-effects
+               rt {:sensitive [[:auth :password]]
+                   :large     [[:blob :payload]]})))
+  nil)
+
+(defn- fresh-frame!
+  "Make the suite's frame. `classify?` false is the NEGATIVE-CONTROL arm: the
+  identical cascade with NO classification registered, so the same bytes must
+  survive projection RAW."
+  ([] (fresh-frame! true))
+  ([classify?]
+   (rf/make-frame {:id frame-id})
+   (when classify? (classify!))
+   nil))
+
+(defn- contains-secret?
+  "True when `secret` appears ANYWHERE in a nested EDN value — the recursive
+  scan an off-box forwarder's wire payload is subject to. `clojure.string`
+  is host-neutral, so no reader conditional is needed (the JVM originals used
+  `.contains`, which is JVM interop and would not compile under CLJS)."
+  [x]
+  (cond
+    (string? x) (str/includes? x secret)
+    (map? x)    (boolean (or (some contains-secret? (keys x))
+                             (some contains-secret? (vals x))))
+    (coll? x)   (boolean (some contains-secret? x))
+    :else       false))
+
+(defn- contains-benign?
+  "Sibling of `contains-secret?` for the unclassified control value."
+  [x]
+  (cond
+    (string? x) (str/includes? x benign)
+    (map? x)    (boolean (or (some contains-benign? (keys x))
+                             (some contains-benign? (vals x))))
+    (coll? x)   (boolean (some contains-benign? x))
+    :else       false))
+
+(defn- count-leaves-at-least
+  "Count leaf strings of length >= `n` — bounds the \"no raw large bytes on the
+  wire\" claim."
+  [n x]
+  (let [c (atom 0)]
+    ((fn walk [v]
+       (cond
+         (string? v) (when (>= (count v) n) (swap! c inc))
+         (map? v)    (do (run! walk (keys v)) (run! walk (vals v)))
+         (coll? v)   (run! walk v)))
+     x)
+    @c))
+
+(defn- reg-login!
+  "One event that writes the classified sensitive path AND an unclassified
+  sibling path carrying the control value in the same cascade."
+  []
+  (rf/reg-event :egress/login
+    (fn [{:keys [db]} [_ pw]]
+      {:db (-> db
+               (assoc-in [:auth :password] pw)
+               (assoc-in [:audit :note] benign))})))
+
+;; ============================================================================
+;;  1. The app-db substitution table at egress
+;; ============================================================================
+
+(deftest db-after-sensitive-leaf-redacts-at-egress
+  (testing "a frame-declared sensitive path in `:db-after` lands as
+            `:rf/redacted` in the projected record, while the RAW ring record
+            keeps the value (on-box replay fidelity). The unclassified
+            sibling path rides through RAW — the control that proves the
+            walker is discriminating, not blanket-redacting."
+    (fresh-frame!)
+    (reg-login!)
+    (rf/dispatch-sync [:egress/login secret] {:frame frame-id})
+    (let [raw  (last-record)
+          proj (epoch/projected-record raw)]
+      (is (= secret (get-in raw [:db-after :auth :password]))
+          "fixture: the raw ring record carries the unredacted secret")
+      (is (= :rf/redacted (get-in proj [:db-after :auth :password]))
+          "projected `:db-after` substitutes `:rf/redacted` at the sensitive leaf")
+      (is (= benign (get-in proj [:db-after :audit :note]))
+          "NEGATIVE CONTROL — the unclassified sibling value survives
+           projection RAW, so the assertion above cannot pass by
+           blanket-redaction or by an empty `:db-after`")
+      (is (not (contains-secret? proj))
+          "and the secret is absent from the WHOLE projected record, not just
+           the slot we probed"))))
+
+(deftest db-before-sensitive-leaf-redacts-at-egress
+  (testing "`:db-before` is walked too — a value present pre-cascade must not
+            escape just because the cascade under egress did not write it."
+    (fresh-frame!)
+    (reg-login!)
+    (rf/reg-event :egress/inc (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
+    (rf/dispatch-sync [:egress/login secret] {:frame frame-id})
+    (rf/dispatch-sync [:egress/inc]          {:frame frame-id})
+    (let [raw  (last-record)
+          proj (epoch/projected-record raw)]
+      (is (= secret (get-in raw [:db-before :auth :password]))
+          "fixture: raw `:db-before` carries the value")
+      (is (= :rf/redacted (get-in proj [:db-before :auth :password]))
+          "projected `:db-before` substitutes `:rf/redacted`")
+      (is (not (contains-secret? proj))
+          "no secret bytes anywhere in the projected record"))))
+
+(deftest large-leaf-elides-to-marker-at-egress
+  (testing "a frame-declared `:large` path egresses as a
+            `:rf.size/large-elided` marker, never as raw bytes — the
+            token-budget claim the MCP wire boundary depends on."
+    (fresh-frame!)
+    (rf/reg-event :egress/upload
+      (fn [{:keys [db]} [_ payload]] {:db (assoc-in db [:blob :payload] payload)}))
+    (rf/dispatch-sync [:egress/upload (big-string payload-size)] {:frame frame-id})
+    (let [raw  (last-record)
+          proj (epoch/projected-record raw)]
+      (is (= payload-size (count (get-in raw [:db-after :blob :payload])))
+          "fixture: the raw record carries the full payload")
+      (is (elision/marker? (get-in proj [:db-after :blob :payload]))
+          "the projected slot is a `:rf.size/large-elided` marker")
+      (is (pos? (count-leaves-at-least payload-size raw))
+          "fixture control: the raw ring DOES contain a large leaf")
+      (is (zero? (count-leaves-at-least payload-size proj))
+          "the projected record contains ZERO leaves of the payload's size"))))
+
+(deftest sensitive-wins-over-large-at-egress
+  (testing "a path declared BOTH sensitive and large egresses as
+            `:rf/redacted`, not as a size marker — the size marker carries
+            structural indicators (`:bytes`, `:digest`) that must not
+            describe a sensitive value."
+    (rf/make-frame {:id frame-id})
+    (frame/swap-runtime-db! frame-id
+      (fn [rt] (elision/apply-classification-effects
+                 rt {:sensitive [[:both :slot]] :large [[:both :slot]]})))
+    (rf/reg-event :egress/both
+      (fn [{:keys [db]} _] {:db (assoc-in db [:both :slot] (str secret (big-string 30000)))}))
+    (rf/dispatch-sync [:egress/both] {:frame frame-id})
+    (let [proj (epoch/projected-record (last-record))]
+      (is (= :rf/redacted (get-in proj [:db-after :both :slot]))
+          "sensitive takes precedence over large at the same path")
+      (is (not (contains-secret? proj))
+          "and the secret bytes are gone"))))
+
+(deftest bookkeeping-slots-survive-projection
+  (testing "the slots a CLJS consumer navigates by — `:epoch-id` (Xray /
+            watch-epochs resume cursor), `:frame` (scoped tool routing),
+            `:event-id`, `:outcome`, `:rf.epoch/sensitive?` (the badge) —
+            are byte-identical after projection. Over-redaction here breaks
+            every tool as surely as under-redaction leaks."
+    (fresh-frame!)
+    (reg-login!)
+    (rf/dispatch-sync [:egress/login secret] {:frame frame-id})
+    (let [raw  (last-record)
+          proj (epoch/projected-record raw)]
+      (doseq [k [:epoch-id :frame :committed-at :event-id :outcome
+                 :halt-reason :schema-digest :rf.epoch/sensitive?]]
+        (is (= (get raw k) (get proj k))
+            (str "bookkeeping slot " k " passes through unchanged")))
+      (is (some? (:epoch-id proj))
+          "fixture control: `:epoch-id` is actually populated, so the
+           equality checks above are not comparing nil to nil"))))
+
+(deftest nil-and-non-map-input-projects-to-nil
+  (testing "`projected-record` returns nil for non-map input — a forwarder
+            mapping over a ring that contains a nil hole must not throw
+            mid-egress on either host."
+    (is (nil? (epoch/projected-record nil)))
+    (is (nil? (epoch/projected-record :not-a-record)))))
+
+;; ============================================================================
+;;  2. The FACADE path — what the browser consumers actually call
+;; ============================================================================
+
+(deftest facade-projected-record-redacts-through-late-bind
+  (testing "Xray's `egress-record` and every Pair-MCP epoch tool call
+            `re-frame.core/projected-record`, NOT the artefact-internal
+            `re-frame.epoch/projected-record`. That crosses the `late-bind`
+            seam (`:epoch/projected-record`, `:on-absent :nil`). This arm
+            pins the seam on the consumers' host: the facade must produce the
+            SAME redacted shape the artefact fn does — a seam that silently
+            fell through to identity would leak everything."
+    (fresh-frame!)
+    (reg-login!)
+    (rf/dispatch-sync [:egress/login secret] {:frame frame-id})
+    (let [raw     (last-record)
+          via-fac (rf/projected-record raw)
+          via-art (epoch/projected-record raw)]
+      (is (some? via-fac)
+          "the late-bound hook is published (a nil here would mean the
+           artefact was not seen, and every consumer would silently egress
+           nothing)")
+      (is (= via-art via-fac)
+          "facade and artefact projections are identical")
+      (is (= :rf/redacted (get-in via-fac [:db-after :auth :password]))
+          "the facade path redacts the sensitive leaf")
+      (is (not (contains-secret? via-fac))
+          "no secret bytes anywhere in the facade-projected record")
+      (is (not (contains-secret? (rf/projected-history frame-id)))
+          "`projected-history` through the facade is likewise clean")
+      (is (contains-secret? (rf/epoch-history frame-id))
+          "NEGATIVE CONTROL — the RAW ring the facade reads from DOES carry
+           the secret, so the two clean assertions above are proving
+           redaction rather than an empty ring"))))
+
+(deftest facade-threads-egress-opts-through-late-bind
+  (testing "the consumers pass an opts map through the facade
+            (`{:include-sensitive? …}`, `:rf.egress/profile`). The 2-arity
+            must thread it — a dropped opts map would silently downgrade a
+            trusted-local read, or worse, silently ignore a fail-closed
+            profile choice."
+    (fresh-frame!)
+    (reg-login!)
+    (rf/dispatch-sync [:egress/login secret] {:frame frame-id})
+    (let [raw (last-record)]
+      (is (= secret (get-in (rf/projected-record raw {:include-sensitive? true})
+                            [:db-after :auth :password]))
+          "the opts map reaches the artefact through the facade")
+      (is (= :rf/redacted (get-in (rf/projected-record raw {})
+                                  [:db-after :auth :password]))
+          "and an empty opts map keeps the fail-closed default")
+      (is (= (epoch/projected-record raw {:rf.egress/profile :rf.egress/off-box-tool})
+             (rf/projected-record raw {:rf.egress/profile :rf.egress/off-box-tool}))
+          "the named `:rf.egress/off-box-tool` boundary (the MCP wire) agrees
+           across facade and artefact"))))
+
+;; ============================================================================
+;;  3. The forwarder + bulk-egress shapes the CLJS consumers run
+;; ============================================================================
+
+(deftest epoch-listener-forwarder-egresses-no-secret-bytes
+  (testing "the `register-listener! :epoch` + `projected-record`-in-ship!
+            pattern is exactly what an off-box forwarder runs. The listener
+            fan-out delivers the RAW record on purpose (Xray diff /
+            `restore-epoch!` need it), so the forwarder's own projection call
+            is the ONLY thing between a sensitive value and the wire."
+    (fresh-frame!)
+    (reg-login!)
+    (rf/reg-event :egress/upload
+      (fn [{:keys [db]} [_ p]] {:db (assoc-in db [:blob :payload] p)}))
+    (let [raw-seen (atom [])
+          shipped  (atom [])]
+      (rf/register-listener! :epoch ::raw-tap  (fn [r] (swap! raw-seen conj r)))
+      (rf/register-listener! :epoch ::forwarder
+                            (fn [r] (swap! shipped conj (epoch/projected-record r))))
+      (rf/dispatch-sync [:egress/login secret] {:frame frame-id})
+      (rf/dispatch-sync [:egress/upload (big-string payload-size)] {:frame frame-id})
+      (rf/unregister-listener! :epoch ::raw-tap)
+      (rf/unregister-listener! :epoch ::forwarder)
+      (is (= 2 (count @shipped)) "the forwarder saw both cascades")
+      (is (contains-secret? @raw-seen)
+          "NEGATIVE CONTROL — listener fan-out delivers the RAW record
+           (secret present), which is what makes the next assertion a real
+           test of the forwarder's projection call")
+      (is (not (contains-secret? @shipped))
+          "no shipped record carries the secret anywhere in its structure")
+      (is (zero? (count-leaves-at-least payload-size @shipped))
+          "and no shipped record carries the large payload as raw bytes"))))
+
+(deftest projected-history-is-mapv-projected-record-and-ordered
+  (testing "`projected-history` is the bulk-egress shape a `watch-epochs`
+            initial snapshot ships. It must be fn-equivalent to
+            `(mapv projected-record (epoch-history …))` and preserve
+            oldest-first order — the resume cursor's `:after-id` depends on
+            the ordering, and any divergence between the two entry points is
+            a second, unproved redaction path."
+    (fresh-frame!)
+    (reg-login!)
+    (rf/reg-event :egress/seed (fn [_ _] {:db {:n 0}}))
+    (rf/reg-event :egress/inc  (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
+    (rf/dispatch-sync [:egress/seed]          {:frame frame-id})
+    (rf/dispatch-sync [:egress/login secret]  {:frame frame-id})
+    (rf/dispatch-sync [:egress/inc]           {:frame frame-id})
+    (let [raw  (rf/epoch-history frame-id)
+          bulk (epoch/projected-history frame-id)]
+      (is (= 3 (count bulk)) "one projected record per raw record")
+      (is (= (mapv epoch/projected-record raw) bulk)
+          "bulk egress is fn-equivalent to per-record egress")
+      (is (= (mapv :epoch-id raw) (mapv :epoch-id bulk))
+          "oldest-first order is preserved")
+      (is (not (contains-secret? bulk))
+          "the bulk shape leaks no secret bytes")
+      (is (= [] (epoch/projected-history :epoch-egress-redaction/no-such-frame))
+          "an unknown frame yields the empty vector, not a throw"))))
+
+(deftest double-projection-is-idempotent-for-both-substitutions
+  (testing "middleware composition and tool-then-watcher fan-out can project
+            the same record twice. Both substitutions must be irreversible
+            across passes: `:rf/redacted` is a non-matchable scalar, and the
+            wire-elision walker is marker-aware for `:rf.size/large-elided`
+            (rf2-fq8ep) so `:bytes` / `:digest` do not drift."
+    (fresh-frame!)
+    (reg-login!)
+    (rf/reg-event :egress/upload
+      (fn [{:keys [db]} [_ p]] {:db (assoc-in db [:blob :payload] p)}))
+    (rf/dispatch-sync [:egress/login secret] {:frame frame-id})
+    (rf/dispatch-sync [:egress/upload (big-string payload-size)] {:frame frame-id})
+    (let [raw    (rf/epoch-history frame-id)
+          once   (mapv epoch/projected-record raw)
+          twice  (mapv epoch/projected-record once)
+          thrice (mapv epoch/projected-record twice)]
+      (is (= once twice thrice)
+          "projection reaches a fixpoint on the first pass — no drift in the
+           large marker's `:bytes` / `:digest` across passes")
+      (is (not (contains-secret? thrice))
+          "the secret is still absent after three passes"))))
+
+(deftest projection-does-not-mutate-the-ring
+  (testing "a forwarder projects on every cascade; a side effect would
+            compound. The raw ring must be untouched — otherwise
+            `restore-epoch!` on the browser Tool-Pair path would time-travel
+            to redacted state."
+    (fresh-frame!)
+    (reg-login!)
+    (rf/dispatch-sync [:egress/login secret] {:frame frame-id})
+    (let [before (rf/epoch-history frame-id)]
+      (dotimes [_ 10]
+        (mapv epoch/projected-record before)
+        (epoch/projected-history frame-id))
+      (is (= before (rf/epoch-history frame-id))
+          "the ring is structurally unchanged after 20 projection calls")
+      (is (contains-secret? (rf/epoch-history frame-id))
+          "and still carries the raw replay material a restore needs"))))
+
+;; ============================================================================
+;;  4. Axis orthogonality — the CLJS-side bypass leaks (rf2-m9duxl, rf2-5w06uu)
+;; ============================================================================
+
+(deftest include-sensitive-keeps-fx-args-redacted
+  (testing "rf2-m9duxl was a CLJS bug: the Pair-MCP epoch tools treated an
+            operator's `:include-sensitive true` as a FULL raw-epoch bypass,
+            shipping raw fx args off-box. `{:include-sensitive? true}` lifts
+            the APP-DB sensitive axis ONLY; `:effects[*].args` is a different
+            keyspace governed by `:include-fx-args?`."
+    (fresh-frame!)
+    (rf/reg-fx :egress/login-fx (fn [_ _] nil))
+    (rf/reg-event :egress/do-login
+      (fn [_ [_ creds]]
+        {:db {:auth {:password (:password creds)}}
+         :fx [[:egress/login-fx creds]]}))
+    (rf/dispatch-sync [:egress/do-login {:password secret :token "tok-abc"}]
+                      {:frame frame-id})
+    (let [raw    (last-record)
+          proj   (epoch/projected-record raw {:include-sensitive? true})
+          fx-row (some #(when (= :egress/login-fx (:fx-id %)) %) (:effects proj))]
+      (is (= secret (get-in proj [:db-after :auth :password]))
+          "`:include-sensitive? true` reveals the app-db sensitive leaf
+           (which also proves the opt-in is threaded at all)")
+      (is (some? fx-row) "fixture: the cascade produced a payload-bearing fx row")
+      (is (= :rf/redacted (:args fx-row))
+          "`:effects[*].args` STAY redacted — orthogonal axis")
+      (is (= :egress/login-fx (:fx-id fx-row))
+          "the value-free `:fx-id` is preserved for tool display")
+      (is (= :rf/redacted (:args (some #(when (= :egress/login-fx (:fx-id %)) %)
+                                       (:effects (epoch/projected-record raw)))))
+          "and the bare off-box default redacts the fx args too"))))
+
+(deftest include-sensitive-keeps-runtime-db-partition-redacted
+  (testing "rf2-5w06uu was the Xray-side twin: opting in to sensitive APP-DB
+            values used to walk the RAW record, lifting the orthogonal
+            `:rf.db/runtime` partition (machine snapshots, route slice, SSR
+            metadata) off-box as a side effect. The partition stays
+            `:rf/redacted` unless `:include-runtime-db? true` is passed."
+    (fresh-frame!)
+    (rf/reg-event :egress/seed-both
+      (fn [{rt :rf.db/runtime} _]
+        {:db            {:auth {:password secret}}
+         :rf.db/runtime (assoc-in (or rt {})
+                                  [:rf.runtime/machines :snapshots :m/x]
+                                  {:state :live})}))
+    (rf/dispatch-sync [:egress/seed-both] {:frame frame-id})
+    (let [raw  (last-record)
+          proj (epoch/projected-record raw {:include-sensitive? true})]
+      (is (= {:state :live}
+             (get-in raw [:frame-state-after :rf.db/runtime
+                          :rf.runtime/machines :snapshots :m/x]))
+          "fixture: the raw record carries a populated runtime-db partition")
+      (is (= secret (get-in proj [:frame-state-after :rf.db/app :auth :password]))
+          "`:include-sensitive? true` reveals the app-db partition's leaf")
+      (is (= :rf/redacted (get-in proj [:frame-state-after :rf.db/runtime]))
+          "the `:rf.db/runtime` partition STAYS redacted under
+           include-sensitive alone")
+      (is (not= :rf/redacted
+                (get-in (epoch/projected-record raw {:include-sensitive?  true
+                                                     :include-runtime-db? true})
+                        [:frame-state-after :rf.db/runtime]))
+          "NEGATIVE CONTROL — the explicit `:include-runtime-db? true` opt DOES
+           lift it, proving the axis is independently governed and the
+           assertion above is not passing because the partition is empty"))))
+
+(deftest include-sensitive-keeps-large-elision-independent
+  (testing "`:include-sensitive?` and `:include-large?` are independent axes:
+            asking for sensitive values must not pull a bulk payload onto the
+            wire (the token-budget claim), and vice versa."
+    (fresh-frame!)
+    (reg-login!)
+    (rf/reg-event :egress/both
+      (fn [{:keys [db]} [_ pw p]]
+        {:db (-> db (assoc-in [:auth :password] pw)
+                    (assoc-in [:blob :payload] p))}))
+    (rf/dispatch-sync [:egress/both secret (big-string payload-size)] {:frame frame-id})
+    (let [raw (last-record)]
+      (let [proj (epoch/projected-record raw {:include-sensitive? true})]
+        (is (= secret (get-in proj [:db-after :auth :password])))
+        (is (elision/marker? (get-in proj [:db-after :blob :payload]))
+            "large stays elided under the sensitive opt-in"))
+      (let [proj (epoch/projected-record raw {:include-large? true})]
+        (is (= :rf/redacted (get-in proj [:db-after :auth :password]))
+            "sensitive stays redacted under the large opt-in")
+        (is (= payload-size (count (get-in proj [:db-after :blob :payload])))
+            "NEGATIVE CONTROL — `:include-large? true` DOES reveal the full
+             payload, so the elision assertions are not vacuous")))))
+
+;; ============================================================================
+;;  5. `:trigger-event` event-args fail-closed (rf2-nm611o)
+;; ============================================================================
+
+(deftest trigger-event-positional-secret-fails-closed
+  (testing "the dispatched event vector's args are registration-owned
+            transient payloads, not app-db-rooted, so the classification
+            walker cannot prove them safe. Off-box egress fails CLOSED: head
+            event-id retained, every arg `:rf/redacted`."
+    (fresh-frame!)
+    (reg-login!)
+    (rf/dispatch-sync [:egress/login secret] {:frame frame-id})
+    (let [proj (epoch/projected-record (last-record))]
+      (is (= [:egress/login :rf/redacted] (:trigger-event proj))
+          "head id retained, positional arg redacted")
+      (is (= :egress/login (:event-id proj))
+          "the `:event-id` summary slot is intact for tool display")
+      (is (not (contains-secret? proj))
+          "no secret bytes anywhere"))))
+
+(deftest trigger-event-map-arg-secret-fails-closed
+  (testing "a secret NESTED in a map arg also fails closed — the whole arg
+            redacts, because the walker cannot descend a keyspace it cannot
+            classify."
+    (fresh-frame!)
+    (rf/reg-event :egress/auth-login
+      (fn [{:keys [db]} [_ {:keys [password]}]]
+        {:db (assoc-in db [:auth :password] password)}))
+    (rf/dispatch-sync [:egress/auth-login {:password secret}] {:frame frame-id})
+    (let [proj (epoch/projected-record (last-record))]
+      (is (= [:egress/auth-login :rf/redacted] (:trigger-event proj)))
+      (is (not (contains-secret? (:trigger-event proj)))))))
+
+(deftest include-event-args-is-orthogonal-to-app-db-axes
+  (testing "`:include-event-args?` reveals the raw trigger-event args YET is
+            orthogonal to the app-db sensitive axis, and vice versa. Two
+            opt-ins, two keyspaces; neither implies the other."
+    (fresh-frame!)
+    (reg-login!)
+    (rf/dispatch-sync [:egress/login secret] {:frame frame-id})
+    (let [raw (last-record)]
+      (let [proj (epoch/projected-record raw {:include-event-args? true})]
+        (is (= [:egress/login secret] (:trigger-event proj))
+            "NEGATIVE CONTROL — the opt-in reveals the raw args, so the
+             fail-closed assertions above are testing redaction")
+        (is (= :rf/redacted (get-in proj [:db-after :auth :password]))
+            "the app-db sensitive leaf stays redacted"))
+      (let [proj (epoch/projected-record raw {:include-sensitive? true})]
+        (is (= secret (get-in proj [:db-after :auth :password])))
+        (is (= [:egress/login :rf/redacted] (:trigger-event proj))
+            "the event args stay redacted under the app-db opt-in")))))
+
+;; ============================================================================
+;;  6. Classification RETENTION
+;; ============================================================================
+
+(deftest classification-is-retained-across-later-cascades
+  (testing "classification is registered ONCE (commit-plane effect) and lives
+            in the frame's runtime-db. Every LATER epoch — including cascades
+            that never touch the classified path — must still redact it at
+            egress. A registry that only applied to the writing cascade would
+            leak the value from every subsequent record, which is exactly
+            what a `watch-epochs` stream ships."
+    (fresh-frame!)
+    (reg-login!)
+    (rf/reg-event :egress/inc (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
+    (rf/dispatch-sync [:egress/login secret] {:frame frame-id})
+    (dotimes [_ 4] (rf/dispatch-sync [:egress/inc] {:frame frame-id}))
+    (let [raw  (rf/epoch-history frame-id)
+          bulk (epoch/projected-history frame-id)]
+      (is (= 5 (count bulk)) "fixture: five records in the ring")
+      (is (contains-secret? raw)
+          "fixture control: the raw ring carries the secret in every
+           post-login record's `:db-before` / `:db-after`")
+      (is (every? #(= :rf/redacted (get-in % [:db-after :auth :password]))
+                  (rest bulk))
+          "every record AFTER the writing cascade still redacts — the
+           classification is retained, not per-cascade")
+      (is (not (contains-secret? bulk))
+          "no secret bytes anywhere in the whole projected ring"))))
+
+(deftest classification-retention-negative-control-unclassified-frame
+  (testing "the SAME cascade with NO classification registered egresses the
+            value RAW. This is the suite's load-bearing negative control: if
+            `apply-classification-effects` silently stopped registering, or
+            the projection silently blanket-redacted, this arm reds. It also
+            documents the actual contract — the projection redacts what the
+            app CLASSIFIED, nothing more."
+    (fresh-frame! false)
+    (reg-login!)
+    (rf/dispatch-sync [:egress/login secret] {:frame frame-id})
+    (let [proj (epoch/projected-record (last-record))]
+      (is (= secret (get-in proj [:db-after :auth :password]))
+          "with no classification declared the value rides through RAW")
+      (is (contains-secret? proj)
+          "so a redaction assertion against this fixture would go red —
+           the classified arms are provably not vacuous"))))
+
+(deftest sensitive-rollup-badge-survives-projection
+  (testing "`:rf.epoch/sensitive?` is derived from the RAW record inside
+            `build-record`, so it stays a trustworthy off-box branch signal
+            after projection. Xray renders the sensitivity badge from it and
+            a forwarder may route on it — a rollup that read the projected
+            record would collapse to a constant."
+    (fresh-frame!)
+    (reg-login!)
+    (rf/reg-event :egress/inc (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
+    (rf/dispatch-sync [:egress/login secret] {:frame frame-id})
+    (let [proj (epoch/projected-record (last-record))]
+      (is (true? (:rf.epoch/sensitive? proj))
+          "a cascade whose classified path holds a non-nil leaf rolls up true
+           and the flag survives projection"))
+    (fresh-frame! false)
+    (rf/reg-event :egress/plain (fn [_ _] {:db {:n 0}}))
+    (rf/dispatch-sync [:egress/plain] {:frame frame-id})
+    (is (false? (:rf.epoch/sensitive? (epoch/projected-record (last-record))))
+        "NEGATIVE CONTROL — a non-sensitive cascade reads strict false, so
+         the flag is not hardcoded true")))
+
+(deftest trace-events-retention-cap-bounds-what-egresses
+  (testing "`:trace-events-keep` is a retention bound on the most
+            payload-dense slot: records older than the window drop
+            `:trace-events` entirely, while the structured `:sub-runs` /
+            `:renders` / `:effects` projections survive. This caps what a
+            bulk `projected-history` egress can carry at all."
+    (fresh-frame!)
+    (rf/reg-event :egress/seed (fn [_ _] {:db {:n 0}}))
+    (rf/reg-event :egress/inc  (fn [{:keys [db]} _] {:db (update db :n inc)}))
+    (is (= 5 (:trace-events-keep (epoch/current-config)))
+        "fixture override — the shipped runtime default is 50")
+    (rf/dispatch-sync [:egress/seed] {:frame frame-id})
+    (dotimes [_ 6] (rf/dispatch-sync [:egress/inc] {:frame frame-id}))
+    (let [bulk (epoch/projected-history frame-id)
+          n    (count bulk)]
+      (is (= 7 n) "fixture: seven records")
+      (is (every? #(contains? % :sub-runs) bulk)
+          "the structured projections survive on every projected record")
+      (is (every? #(contains? % :trace-events) (subvec bulk (- n 5) n))
+          "the most-recent 5 keep `:trace-events`")
+      (is (every? #(not (contains? % :trace-events)) (subvec bulk 0 (- n 5)))
+          "older records dropped `:trace-events` — the retention bound holds
+           through the egress projection too"))))
+
+;; ============================================================================
+;;  7. The `:redact-fn` egress override
+;; ============================================================================
+
+(deftest redact-fn-runs-at-egress-not-at-storage
+  (testing "the `:redact-fn` advanced override is PROJECTION-side only.
+            Storage mutation would corrupt causal replay material, so the
+            ring and the listener fan-out stay raw and the override runs
+            inside `projected-record`."
+    (fresh-frame!)
+    (reg-login!)
+    (rf/configure! {:epoch-history
+                    {:redact-fn (fn [r] (assoc r :db-after :rf/redacted))}})
+    (let [seen (atom [])]
+      (rf/register-listener! :epoch ::tap (fn [r] (swap! seen conj r)))
+      (rf/dispatch-sync [:egress/login secret] {:frame frame-id})
+      (rf/unregister-listener! :epoch ::tap))
+    (is (= secret (get-in (last-record) [:db-after :auth :password]))
+        "the RING record is untouched by the override — restore fidelity")
+    (is (= :rf/redacted (:db-after (epoch/projected-record (last-record))))
+        "the override IS applied at the egress boundary")))
+
+(deftest throwing-redact-fn-falls-back-to-the-projected-record
+  (testing "failure isolation, and a genuinely host-shaped arm: the catch is
+            `#?(:clj Throwable :cljs :default)`, and CLJS `:default` catches
+            non-`Error` throws (a thrown map, string, keyword) that no JVM
+            `Throwable` clause has an analogue for. A throwing override must
+            fall back to the frame/profile-PROJECTED record — never to the
+            raw one, which would turn a buggy app-supplied fn into a leak."
+    (fresh-frame!)
+    (reg-login!)
+    (rf/configure! {:epoch-history
+                    {:redact-fn (fn [_] (throw (ex-info "redact-fn blew up" {})))}})
+    (rf/dispatch-sync [:egress/login secret] {:frame frame-id})
+    (let [proj (epoch/projected-record (last-record))]
+      (is (some? proj) "egress still produces a record")
+      (is (= :rf/redacted (get-in proj [:db-after :auth :password]))
+          "the fallback is the PROJECTED record — the sensitive leaf is
+           still redacted")
+      (is (not (contains-secret? proj))
+          "and no secret bytes escape through the failure path"))
+    ;; A non-Error throw — reachable only under CLJS's `:default` catch.
+    (rf/configure! {:epoch-history {:redact-fn (fn [_] (throw #?(:clj (Exception. "raw")
+                                                                 :cljs "a bare string")))}})
+    (let [proj (epoch/projected-record (last-record))]
+      (is (= :rf/redacted (get-in proj [:db-after :auth :password]))
+          "a non-`Error` throw is caught too and still falls back closed")
+      (is (not (contains-secret? proj))))
+    (is (fn? (:redact-fn (epoch/current-config)))
+        "and the throwing override stays registered — failure isolation is
+         per-call, not a silent de-registration")))

--- a/implementation/epoch/test/re_frame/epoch_egress_redaction_cljs_test.cljc
+++ b/implementation/epoch/test/re_frame/epoch_egress_redaction_cljs_test.cljc
@@ -42,19 +42,26 @@
        runtime-db partition, or large axes (the rf2-m9duxl / rf2-5w06uu
        Xray + Pair-MCP bypass leaks, both CLJS-side bugs);
     5. `:trigger-event` event-args fail-closed (rf2-nm611o);
-    6. classification RETENTION — a path classified once keeps redacting on
+    6. the `:trace-events` slot — the t1/t2 pending-db tag re-root (a leak the
+       whole rest of the tier would pass green on) and the off-box
+       `:rf.http/off-box-body :omit` fail-closed. Both are read by Xray's
+       Issues lens and the Pair-MCP `trace-window` tool, and a browser XHR
+       reply lands there the same way a server's does;
+    7. classification RETENTION — a path classified once keeps redacting on
        later, unrelated cascades, and the `:rf.epoch/sensitive?` rollup badge
        survives projection;
-    7. the `:redact-fn` egress override, including the fail-closed fallback
+    8. the `:redact-fn` egress override, including the fail-closed fallback
        when it throws (`catch #?(:clj Throwable :cljs :default)` is one of the
        few reader conditionals in this tier — CLJS `:default` catches
        non-`Error` throws too, so the arm is genuinely host-shaped).
 
-  NOT mirrored, and why: see the PR body. In short — HTTP/resource response
-  assembly (`epoch_egress_trace_events_test.clj`,
-  `epoch_egress_resource_trace_test.clj`) is server-side shape,
-  `configure!` argument validation is host-neutral plumbing already proved
-  once, and the JVM `debug-enabled?` gate arms are by definition JVM-shaped.
+  NOT mirrored, and why (the full list, with reasons, is in the PR body): the
+  resource / mutation trace family's egress projector is OWNED by the
+  resources artefact behind a late-bound hook and belongs to that artefact's
+  test tree; `configure!` argument validation is registry plumbing with no
+  egress path; and the `debug-enabled?`-false gate arms are JVM-shaped by
+  construction (CLJS has the separate, already-covered
+  `epoch_elision_prod_test.cljs` + `check-elision.cjs` DCE gate).
 
   ## Non-vacuity
 
@@ -151,16 +158,6 @@
     (map? x)    (boolean (or (some contains-secret? (keys x))
                              (some contains-secret? (vals x))))
     (coll? x)   (boolean (some contains-secret? x))
-    :else       false))
-
-(defn- contains-benign?
-  "Sibling of `contains-secret?` for the unclassified control value."
-  [x]
-  (cond
-    (string? x) (str/includes? x benign)
-    (map? x)    (boolean (or (some contains-benign? (keys x))
-                             (some contains-benign? (vals x))))
-    (coll? x)   (boolean (some contains-benign? x))
     :else       false))
 
 (defn- count-leaves-at-least
@@ -614,7 +611,90 @@
             "the event args stay redacted under the app-db opt-in")))))
 
 ;; ============================================================================
-;;  6. Classification RETENTION
+;;  6. The `:trace-events` slot — the densest payload a CLJS consumer reads
+;; ============================================================================
+;;
+;; Xray's Issues / Schema-timeline lens and the Pair-MCP `trace-window` tool
+;; both read `:trace-events` off the PROJECTED record, so this slot is as
+;; leak-exposed as `:db-after`. Two arms whose failure is a leak and whose
+;; shape is host-neutral (hand-built records — no HTTP artefact, no router
+;; timing), mirrored from `epoch_egress_trace_events_test.clj`.
+
+(defn- synthetic-record
+  "A minimal `:rf/epoch-record` shell. Hand-building it isolates the egress
+  projector from whatever traces the live router happens to emit."
+  [fid trace-events]
+  {:epoch-id            1
+   :frame               fid
+   :committed-at        0
+   :event-id            :egress/synthetic
+   :trigger-event       [:egress/synthetic]
+   :db-before           {}
+   :db-after            {}
+   :outcome             :ok
+   :rf.epoch/sensitive? false
+   :trace-events        trace-events
+   :sub-runs            []
+   :renders             []
+   :effects             []})
+
+(deftest trace-events-db-pending-tag-is-rerooted-and-redacted
+  (testing "the t1 / t2 pending-db traces (`:rf.event/db-pending`,
+            `:rf.event/db-pending-post-flow`) carry the FULL pending app-db
+            nested under `[:tags :rf.event/db]`. The bulk wire walk would
+            root that nested db at `[<i> :tags :rf.event/db …]`, where a
+            frame-declared `[:auth :password]` never matches — so egress
+            re-roots the walk at the frame's app-db. Delete the re-root and
+            the raw secret survives inside the projected trace while every
+            `:db-after` assertion stays green; that is precisely the
+            false-green shape this whole PR is about."
+    (fresh-frame!)
+    (let [tags {:rf.event/db {:auth {:password secret} :audit {:note benign}}}
+          rec  (synthetic-record
+                 frame-id
+                 [{:op-type :rf.event :operation :rf.event/db-pending          :tags tags}
+                  {:op-type :rf.event :operation :rf.event/db-pending-post-flow :tags tags}])
+          [t1 t2] (:trace-events (epoch/projected-record rec))]
+      (is (= :rf/redacted (get-in t1 [:tags :rf.event/db :auth :password]))
+          "t1's nested sensitive leaf is re-rooted and redacted")
+      (is (= :rf/redacted (get-in t2 [:tags :rf.event/db :auth :password]))
+          "t2's nested sensitive leaf likewise")
+      (is (= benign (get-in t1 [:tags :rf.event/db :audit :note]))
+          "NEGATIVE CONTROL — the unclassified sibling inside the SAME nested
+           db survives, so the re-root is redacting by classification rather
+           than blanking the tag")
+      (is (not (contains-secret? (epoch/projected-record rec)))
+          "and no secret bytes survive anywhere in the projected record"))))
+
+(deftest off-box-omits-an-unschematized-http-response-body
+  (testing "an HTTP response body with no schema is whole-sensitive off-box:
+            the transport stamps `:rf.http/off-box-body :omit` and the egress
+            projector replaces the body slot with `:rf/redacted`. This is
+            NOT server-shaped — a browser app's XHR replies land in
+            `:trace-events` exactly the same way, and a bearer token in an
+            unschematized reply body is the canonical leak."
+    (fresh-frame!)
+    (let [body {:token secret :user-id 42}
+          omit (synthetic-record
+                 frame-id
+                 [{:op-type   :rf.trace
+                   :operation :rf.http/replied
+                   :tags      {:value body :rf.http/off-box-body :omit}}])
+          ev   (first (:trace-events (epoch/projected-record omit)))]
+      (is (= :rf/redacted (:value (:tags ev)))
+          "the unschematized body slot is omitted off-box (fail-closed)")
+      (is (not (contains-secret? (epoch/projected-record omit)))
+          "the raw token appears nowhere in the projected record")
+      (is (contains-secret? omit)
+          "NEGATIVE CONTROL — the unprojected record DOES carry the token")
+      (is (= body (:value (:tags (first (:trace-events
+                                          (epoch/projected-record
+                                            omit {:include-sensitive? true}))))))
+          "and the trusted-local `:include-sensitive?` opt-in lifts the
+           omission, proving the assertion is about the disposition stamp"))))
+
+;; ============================================================================
+;;  7. Classification RETENTION
 ;; ============================================================================
 
 (deftest classification-is-retained-across-later-cascades
@@ -710,7 +790,7 @@
            through the egress projection too"))))
 
 ;; ============================================================================
-;;  7. The `:redact-fn` egress override
+;;  8. The `:redact-fn` egress override
 ;; ============================================================================
 
 (deftest redact-fn-runs-at-egress-not-at-storage


### PR DESCRIPTION
`rf2-p4515`. The epoch privacy / egress-redaction tier was **136 deftests across six `.clj` files, JVM-only** — while **every consumer of that projection runs in ClojureScript**: Xray's `runtime/egress-record`, the `re-frame2-pair-mcp` `watch-epochs` / `trace-window` / `snapshot` tools (which emit CLJS forms evaluated *inside the running browser app*), story-mcp, and the browser Tool-Pair time-travel path. The guard that stops a `:sensitive` value leaving the process was proved only on the host where no consumer runs. This area has already produced one documented false green on exactly that surface — `.github/scripts/report-changed-surfaces.sh` still carries the note.

One new dual-lane `.cljc` suite closes the asymmetry: **29 deftests, 110 assertions**, running on **both** lanes from one source of truth. Nothing else in the tree changes.

`implementation/epoch/test/re_frame/epoch_egress_redaction_cljs_test.cljc`

---

## The arms I mirrored

Chosen by one test: *would its failure mean a sensitive value actually escapes to a CLJS consumer?*

| # | Arm group | What breaks if it regresses |
|---|---|---|
| 1 | App-db substitution table — `:db-after` / `:db-before` sensitive → `:rf/redacted`, `:large` → `:rf.size/large-elided`, sensitive-dominates-large precedence, bookkeeping pass-through, nil/non-map input | The primary leak, plus its inverse: over-redacting `:epoch-id` / `:frame` breaks every tool's cursor and routing |
| 2 | **The facade path** — `re-frame.core/projected-record` / `projected-history`, and opts threading through the 2-arity | This is what the consumers actually call. The JVM tier drives the artefact-internal `re-frame.epoch/projected-record` almost exclusively, so the `late-bind` seam (`:epoch/projected-record`, `:on-absent :nil`) the browser crosses had **no** coverage on the consumers' host. A seam falling through to identity leaks everything; falling through to nil silently ships nothing |
| 3 | Forwarder + bulk-egress shapes — `register-listener! :epoch` + project-in-ship!, `projected-history` == `mapv projected-record`, oldest-first order, double/triple-projection fixpoint, ring immutability | The listener fan-out delivers the RAW record on purpose, so the forwarder's own projection call is the only thing between a secret and the wire. Ring mutation would make browser `restore-epoch!` time-travel to redacted state |
| 4 | Axis orthogonality — `:include-sensitive?` must not lift `:effects[*].args`, the `:rf.db/runtime` partition, or `:large` slots; `:include-event-args?` must not lift app-db | **Both original bugs were CLJS-side.** rf2-m9duxl was the Pair-MCP tools treating `:include-sensitive true` as a full raw-epoch bypass; rf2-5w06uu was Xray walking the raw record on opt-in and lifting the orthogonal runtime-db partition. Each has an explicit negative control proving the axis is independently governed |
| 5 | `:trigger-event` event-args fail-closed (rf2-nm611o) — positional and map-nested secrets, head id retained, `:include-event-args?` orthogonality | Event args are registration-owned transients the app-db walker cannot prove safe |
| 6 | `:trace-events` — the t1/t2 pending-db tag **re-root**, and off-box `:rf.http/off-box-body :omit` fail-closed | Delete the re-root and a secret nested at `[:tags :rf.event/db :auth :password]` survives while every `:db-after` assertion stays green — the exact false-green shape this PR is about. The HTTP arm is **not** server-shaped: a browser XHR reply with an unschematized body lands in `:trace-events` the same way, and a bearer token there is the canonical leak. Both slots are read by Xray's Issues lens and pair-mcp `trace-window` |
| 7 | Classification **retention** — a path classified once keeps redacting on later, unrelated cascades; `:rf.epoch/sensitive?` rollup survives projection; the `:trace-events-keep` window bounds what a bulk egress can carry | A registry that only applied to the writing cascade would leak from every subsequent record — which is precisely what a `watch-epochs` stream ships |
| 8 | `:redact-fn` egress override — runs at egress not storage, still runs under `:include-sensitive?`, and **falls back to the PROJECTED record when it throws** | Genuinely host-shaped: the catch is `#?(:clj Throwable :cljs :default)`, and CLJS `:default` catches non-`Error` throws (a bare string, a map) for which no JVM `Throwable` clause is an analogue. The arm throws both an `ex-info` and a bare non-`Error` value. A fallback to the *raw* record would turn a buggy app fn into a leak |
| 9 | Large **sub-output** `:sub-runs` value slot (rf2-at60h) | `epoch_cljs_test.cljs` exercises no subscriptions at all, so the CLJS lane had zero `:sub-runs` egress coverage of any kind |

### Non-vacuity is structural, not asserted

Every redaction claim is paired with something that would break it:

- an **unclassified sibling path** (`[:audit :note]`) carrying a benign twin string through the *same* projection call — so blanket-redaction and an empty `:db-after` both go red;
- a **dedicated never-classified control frame** running the identical cascade, where the secret rides through RAW (`classification-retention-negative-control-unclassified-frame`);
- the explicit **`:include-*` opt-in** revealing the value, proving the fail-closed assertion is about the default and not about an absent path;
- the **raw ring** asserted to still contain the secret wherever a "projected output is clean" claim is made, so no clean-scan can pass against an empty ring.

---

## The arms I judged JVM-legitimate — and why

This list is the other half of the work. Ordered by strength of reason.

**A. Genuinely JVM-shaped — 3 arms.** `epoch_privacy_test.clj` `projected-record-handles-empty-history-under-disabled-gate` + `projected-record-pure-fn-survives-disabled-gate`, and `epoch_egress_trace_events_test.clj` `off-box-http-fail-closed-survives-cold-gate-false`. All three drive `interop/debug-enabled?` **false** by rebinding a JVM var. CLJS has no runtime analogue — the gate is compile-time `goog.DEBUG` DCE, and that is already covered on the CLJS side by `epoch_elision_prod_test.cljs` (6 deftests, run under the dedicated `:browser-test-prod-elision` build via `npm run test:browser-prod-elision`, `:advanced` + `goog.DEBUG false`) plus the `implementation/scripts/check-elision.cjs` sentinel sweep. Mirroring these would test a var-rebind that does not exist where the consumers run.

**B. Owned by a different artefact — 16 arms, all of `epoch_egress_resource_trace_test.clj`.** Every arm routes through `:resources/project-scope-resolved-egress` / `:resources/project-resource-trace-egress` — late-bound hooks the **resources** artefact publishes and owns. The epoch side is a nil-safe two-line delegation. I checked rather than assumed: `implementation/resources/test/re_frame/resources_from_db_scope_cljs_test.cljc` calls `scope-registry/project-scope-resolved-egress` directly (lines 468, 503), and `resources/test` carries **47** `.cljc` `*-cljs-test` suites including `resources_classification_cljs_test.cljc`, `resources_derived_scope_sensitivity_cljs_test.cljc` and `resources_invalid_params_redaction_cljs_test.cljc`. The projector is already proved on the CLJS lane by its owner; mirroring it into epoch would put the assertions on the wrong artefact.

**C. No egress path at all — 5 arms.** `epoch_redact_fn_test.clj` `configure-accepts-fn` / `-accepts-nil-to-clear` / `-rejects-non-fn` / `-absent-slot-preserves-existing-fn` / `-partial-update-mixed-validity`. Registry validation on `rf/configure!`. A host divergence here cannot leak — a rejected or absent `:redact-fn` means the built-in frame/profile projection runs, which *is* the fail-closed default. What matters off-box is that an installed fn runs at egress and a throwing one falls back closed; both mirrored.

**D. On-box lifecycle, not egress — 4 arms.** `wiring-settle-stores-raw-record`, `wiring-replace-app-db-stores-raw-record`, `wiring-halted-destroy-stores-raw-record`, `restore-replays-raw-value-under-redact-fn`. These pin *which* wiring stored the record and that restore replays raw material. Record assembly and restore already have CLJS coverage (`epoch_cljs_test.cljs` §1/§2, `epoch_committed_at_clock_cljs_test.cljs`), and the projection applies at egress regardless of the storing wiring.

**E. Same code path, different input — the bulk (~55 arms).** Mirrored representatively, not ported as a table:

- 5 of 6 `rollup-*` variants — one `true` and one strict-`false` mirrored; the rest vary the input to one computation inside `build-record`.
- 4 of 5 `elides-fx-args-*` row shapes (`:skipped-on-platform`, `:no-such-fx`, `:handler-exception`, idempotence) — one projector, one `:args` keyspace, four row keywords. The default-redacted success row is mirrored.
- 12 of 13 HTTP-body arms (`:accept-failure`, `4xx`, `5xx`, decode-failure, nested retry-attempt, on-box-preserved, no-stamp pass-through) — one `omit-off-box-http-bodies` projector reading one `:rf.http/off-box-body` stamp across different operation keywords. One representative plus its `:include-sensitive?` lift.
- 7 of 8 db-pending re-root arms (large-leaf variant, scalar-sentinel input, non-t1/t2 scoping, idempotency, three end-to-end live shapes). The central unit re-root and its sibling control are mirrored.
- All 7 `G1`–`G7` changed-sensitive-path **counter** arms — arithmetic over the raw record; not an egress path.
- 2 of 3 `retention-cap-*` (`keep 0`, `keep >= depth`) — same clamp as the mirrored window arm.
- `share-redaction-vocabulary`, `handles-mixed-nil-and-real-records`, both `pure-no-side-effects` arms, `tool-profile-includes-structural-digest`, `unknown-profile-rejected` — subsumed by the bulk-equals-per-record arm, the nil arm, the single purity arm, and, for the profile enum, `core/test/re_frame/projection_cljs_test.cljc`, which already proves the closed `:rf.egress/*` enum and its throw on the CLJS lane (33 deftests).

**One thing I did not accept.** `epoch_mcp_egress_conformance_test.clj`'s own docstring argues it belongs on the JVM because "the framework's epoch artefact owns the projection emission site … pinning conformance from the artefact side keeps the test on the JVM next to the contract owner." The premise does not hold: the emission site is `tool_pair.cljc` — a `.cljc`. "Next to the contract owner" and "on the JVM" are independent, which is why a dual-lane `.cljc` in the same directory is the right answer rather than a test in an MCP tree.

---

## What writing the scan found: `rf2-irwsq` (P1, filed, not fixed here)

Putting a whole-record "no raw large bytes anywhere" scan on the whole-output `:large?` **sub** shape immediately went red, and the projection is genuinely incomplete. On `origin/main`, a `(rf/reg-sub :big {:large? true} …)` read inside a cascade puts its value in two slots:

```
RAW  big-leaf paths: [[:sub-runs 0 :value] [:trace-events 2 :tags :rf.sub/value]]
PROJ big-leaf paths: [[:trace-events 2 :tags :rf.sub/value]]
```

`projected-record` elides the structured `:sub-runs` row (correctly, to a `:rf.size/large-elided` marker) and leaves the `:rf.sub/run` **trace tag** carrying the full 25 KB string — with `:large? true` sitting beside it in the same tags map. Off-box consumers reading `:trace-events` (Xray-MCP `watch-epochs`, pair-mcp `trace-window` / `snapshot`, hosted shippers) get the raw payload, and under the shipped `:trace-events-keep 50` every record in the ring keeps it.

Why 136 arms miss it: `epoch_mcp_egress_conformance_test.clj` *does* own the cross-cutting token-budget claim via `count-leaf-strings-at-least`, but its fixture declares `:large` as an **app-db path**, a shape the walker substitutes inside the db slots. The whole-output `:large?` sub shape is exercised only by `projected-record-elides-large-sub-output`, which probes the row by hand and never scans the record. Neither arm can see the twin.

**Privacy is not affected.** EP-0025 dropped the whole-output `:sensitive?` overload (`classification.cljc:147` — "silently dropped if present"); sub-output sensitivity is path-based and substituted at the **emit** site by `classification/redact-with-paths`, so it is already redacted in both slots. This is the token-budget axis only.

Fixing it is an egress-projector behaviour change that wants its own bead and a ruling on whether the trace tag should carry the marker or be dropped, so I filed **`rf2-irwsq`** with the full mechanism and repro rather than widening this PR. The suite carries a clearly-labelled **characterisation** assertion pinning today's raw tag, with an in-code instruction to delete it when the fix lands — I would rather the gap be impossible to forget than invisible. Flagging it explicitly because a reviewer may prefer the assertion dropped instead; say the word and I will.

---

## Mirroring is real — the five same-day traps, checked

- **Lane suffix.** The ns ends `-cljs-test`, so shadow-cljs `:node-test` selects it via `:ns-regexp "cljs-test$"`, and it also matches cognitect test-runner's default `.*-test$` under `implementation/epoch`'s `clojure -M:test`. Both lanes are demonstrated below with real counts, and the focused CLJS selector run is the positive proof: `re-frame.test-quiet.shadow-node` **exits nonzero on an unmatched `--test=` selector**, so a green focused run is proof the node lane really discovers the namespace rather than silently skipping it. `implementation/epoch/test` was already on the `:node-test` source paths (`shadow-cljs.edn:111`) — no build-config change, and the hot-zone file is untouched.
- **CLJ-only macros.** No macro is defined in this file. The one JVM helper I needed — the JVM suites' `contains-secret?` — uses `.contains` interop, which does not compile under CLJS; it is rewritten on `clojure.string/includes?`, host-neutral with no reader conditional. The file's only reader conditional is the `clojure.test` / `cljs.test` require.
- **Vacuity.** See "Non-vacuity is structural" above, plus the mutation below.
- **Exit codes.** Every runner's `rc=$?` was captured immediately into a worktree-local log under `ai-logs/` (untracked) and cross-checked against that log's own `Ran … / N failures, N errors` line. No runner was piped through `tail` or `grep`; no compound-command trailing `echo` was trusted.
- **`.beads`.** Untouched.

### Mutation control

Single-line inversion of the sensitive substitution in the shared walker — `implementation/core/src/re_frame/elision.cljc`, `walk-decider`'s decider:

```clojure
(and sensitive? (not include-s?))   ;; shipped
(and sensitive? include-s?)         ;; mutated — off-box default stops redacting
```

Recompiled the `:node-test` bundle and re-ran the new suite alone on the CLJS lane:

| | deftests | assertions | failures | rc |
|---|---|---|---|---|
| **before** (shipped) | 29 | 110 | **0** | **0** |
| **mutated** | 29 | 110 | **30** | **1** |
| **after revert** | 29 | 110 | **0** | **0** |

30 assertion failures across **17 distinct deftests**:

```
classification-is-retained-across-later-cascades
db-after-sensitive-leaf-redacts-at-egress
db-before-sensitive-leaf-redacts-at-egress
double-projection-is-idempotent-for-both-substitutions
epoch-listener-forwarder-egresses-no-secret-bytes
facade-projected-record-redacts-through-late-bind
facade-threads-egress-opts-through-late-bind
include-event-args-is-orthogonal-to-app-db-axes
include-sensitive-keeps-fx-args-redacted
include-sensitive-keeps-large-elision-independent
include-sensitive-keeps-runtime-db-partition-redacted
include-sensitive-still-applies-the-redact-fn-override
projected-history-is-mapv-projected-record-and-ordered
sensitive-wins-over-large-at-egress
throwing-redact-fn-falls-back-to-the-projected-record
trace-events-db-pending-tag-is-rerooted-and-redacted
trigger-event-positional-secret-fails-closed
```

The remaining 12 are the arms that do not depend on the sensitive substitution (large elision, bookkeeping pass-through, retention window, sub-output, nil input, the rollup badge) — they stayed green, which is the right answer and shows the suite is not one undifferentiated smoke test.

Tree after revert: `git diff --stat` empty, `git status` shows only the untracked local PR body. The mutation never left the worktree; the mayor checkout was verified untouched before and after.

## Quality gates

All run in the worker worktree `C:/Users/miket/code/re-frame2-worktrees/epoch-redaction-cljs` (`WORKTREE_ROOT` confirmed by `scripts/assert-worker-worktree.ps1`). `rc` captured with `rc=$?` immediately after each runner into a worktree-local log, then cross-checked against that log's own `Ran … / N failures, N errors` line. Nothing piped through `tail`/`grep`.

| Gate | Result | rc |
|---|---|---|
| `implementation/epoch` `clojure -M:test` — **baseline** (pre-change) | `Ran 441 tests containing 6291 assertions. 0 failures, 0 errors.` | **0** |
| `implementation/epoch` `clojure -M:test` — **with this PR** | `Ran 470 tests containing 6401 assertions. 0 failures, 0 errors.` | **0** |
| `npm run test:cljs` — **baseline** (pre-change) | `Ran 11382 tests containing 56987 assertions. 0 failures, 0 errors.` | **0** |
| `npm run test:cljs` — **with this PR** | `Ran 11411 tests containing 57097 assertions. 0 failures, 0 errors.` | **0** |
| `node out/node-test.js --test=re-frame.epoch-egress-redaction-cljs-test` (focused CLJS) | `Ran 29 tests containing 110 assertions. 0 failures, 0 errors.` | **0** |
| Same selector with a deliberate typo (proves the guard) | `ERROR: no tests matched --test= selector(s): …-typo` | **1** |
| Mutation control (focused CLJS, sensitive substitution inverted) | `Ran 29 tests containing 110 assertions. 30 failures, 0 errors.` | **1** |
| Mutation reverted, recompiled, focused CLJS re-run | `Ran 29 tests containing 110 assertions. 0 failures, 0 errors.` | **0** |
| `scripts/test-fast-pr.sh` — **run 1** (classified `docs=true jvm=true node=true`) | `mkdocs --strict` **soft-skipped** (not on PATH — CI runs it); `core JVM` `Ran 2115 tests containing 10456 assertions. 0 failures, 0 errors.`; **`CLJS node integration` FAILED on a shadow-cljs par-compile abort** — see below | **1** |
| `scripts/test-fast-pr.sh` — **run 2 (re-run, same commit)** | every step PASS; `core JVM` `Ran 2115 tests containing 10456 assertions. 0 failures, 0 errors.`; `CLJS node integration` `Ran 11411 tests containing 57097 assertions. 0 failures, 0 errors.`; per-ns isolation PASS. `mkdocs` soft-skipped again | **0** |
| **CI on this PR's head `c08d47a4`** — the independent verdict | **73 checks, 0 failing, 0 pending.** `CLJS (shadow-cljs :node-test)` **pass** 10m27s · `JVM epoch (clojure -M:test)` **pass** 39s · `JVM core` **pass** 3m54s · `All required checks passed` | **0** |

**Deltas are exact on both lanes.** JVM `441 → 470` (+29 deftests) and `6291 → 6401` (+110 assertions); CLJS `11382 → 11411` (+29) and `56987 → 57097` (+110). Identical counts on both hosts because it is literally one file — and the CLJS delta being non-zero is itself the proof that the node lane selects the namespace rather than skipping it on a suffix mismatch.

### The one non-green local step, reported as it happened

`scripts/test-fast-pr.sh` exited **1**. I am not rounding that to green. The failing step is `CLJS node integration`, and it did not fail on an assertion — it failed in the **compiler**:

```
[:node-test] Compiling ...
Multiple files failed to compile.
aborted par-compile, "day8/re_frame2_xray/realworld_ui_evidence_cljs_test.cljs"
  still waiting for #{realworld-resources.ui-counter}
aborted par-compile, "realworld_resources/ui_counter.cljc"
  still waiting for #{re-frame.ui}
```

Two cascade aborts off one root: `re-frame.ui` died in a par-compile worker (its own exception swallowed), so `realworld-resources.ui-counter` waited forever, so the xray evidence suite waited forever. Six workers were running shadow-cljs concurrently on this machine at the time. Why I am confident it is contention and not this diff:

1. `npm run test:cljs` passed **twice** standalone in this same worktree, at this same commit, within the preceding ~30 minutes — `Ran 11411 tests … 0 failures, 0 errors.`, rc 0 both times.
2. No zombie shadow server (`.shadow-cljs/server.pid` absent), so it is not the stale-server class.
3. **CI ran the same step on this exact SHA and it passed** — `CLJS (shadow-cljs :node-test)`, 10m27s, green, alongside 72 other green checks and zero failures.
4. The diff structurally cannot reach `re-frame.ui`, `realworld-resources.ui-counter`, or the xray evidence suite: it is one new test file under `implementation/epoch/test/` that requires only `clojure.string`, `re-frame.core`, `re-frame.elision`, `re-frame.epoch`, `re-frame.frame`, `re-frame.substrate.plain-atom`, `re-frame.test-support`.

**Re-run verdict: green.** A full re-run of the spine on the same commit exited **0**, with the `CLJS node integration` step reporting the identical `Ran 11411 tests containing 57097 assertions. 0 failures, 0 errors.` So the first red was machine contention, confirmed by re-run rather than assumed — and independently corroborated by CI passing the same step on the same SHA. The only step still not exercised locally is `mkdocs --strict`, which soft-skips on this Windows box (mkdocs not on PATH) and **exits 0 regardless**; CI's `MkDocs build` job is the real gate for it, and this diff touches no documentation surface.

`.beads/issues.jsonl` and every other database-derived `.beads` path untouched. Branch pushed at every commit; PR opened at the first.
