### PR TITLE
test(freehand): cover the options-map spelling of an event site's handler (rf2-z0blg)

### DIFF
--- a/implementation/freehand/test/re_frame/freehand/tool_reads_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/tool_reads_cljs_test.cljc
@@ -71,6 +71,15 @@
    [:button {:on-click [:basket/remove row-id]} "Remove"]
    [basket-row {:label "Line" :on-remove (v/event [_] [:basket/removed row-id])}]])
 
+(v/defview print-button
+  "A COMPILED declaration whose one event site is spelled as the listener
+  OPTIONS map. That is the SECOND of the two spellings carrying an event vector,
+  so it is the second arm of the handler projection — held apart from [[basket]]
+  so the cardinality and split rows there stay about the classes they name."
+  {:compiled true}
+  [{:keys [label]}]
+  [:button {:on-click {:event [:basket/print] :prevent-default true}} label])
+
 (v/defview plain-list
   "The paved path: interpreted, so there is no analysis to report and no roster
   that could be honestly claimed complete."
@@ -79,6 +88,9 @@
 
 (def ^:private basket-id
   ::basket)
+
+(def ^:private options-id
+  ::print-button)
 
 (def ^:private plain-id
   ::plain-list)
@@ -289,6 +301,25 @@
       (is (= :vector (:classification site))
           "and the classification keeps it apart from a callback body: this IS
            an event vector, with one argument that is not known yet"))))
+
+(deftest an-options-map-handler-carries-the-vector-it-wraps
+  (testing "The listener OPTIONS map is the other spelling that carries an event
+            vector. A fully-literal one is projected verbatim — options included,
+            because `:prevent-default` is part of what the site DOES — and the
+            `:event-id` is read from the vector the map wraps rather than from
+            the map's own keys, which have no head to name."
+    (let [r     (tool/read-view-event-sites options-id)
+          sites (:event-sites r)
+          site  (first sites)]
+      (is (= 1 (count sites)) "one event site, hand-countable from the body")
+      (is (= :options (:classification site)))
+      (is (= {:event [:basket/print] :prevent-default true} (:handler site))
+          "the authored options map, verbatim")
+      (is (= :basket/print (:event-id site))
+          "read from the wrapped vector, not from the map")
+      (is (true? (:serializable? site)))
+      (is (= (:site-facts r) (set (keys site)))
+          "and the closed key set holds over this classification too"))))
 
 (deftest an-opaque-callback-claims-nothing-about-its-body
   (testing "A `v/event` body is CODE. It carries no event vector, so there is no


### PR DESCRIPTION
Follow-up to #6971 (rf2-z0blg), which landed the widened event-site projection.

That PR gave `tool/read-view-event-sites` a per-entry honesty split: a fully
literal handler is projected verbatim, anything else is `:handler :opaque` with
the literal `:event-id` still shown. Two spellings carry an event vector — the
bare vector (`:classification :vector`) and the listener OPTIONS map
(`:options`) — and no census declaration used the second one. So `event-site`'s
`map?` arm, which reads `:event-id` out of the vector the map WRAPS rather than
out of the map's own keys, shipped untested.

An untested branch in an honesty projection is the same class of gap as the
`:sync?` totality hole #6971 closed: the exact-key-set law still passes with that
arm broken, because a missing `:event-id` is `nil` either way, and `nil` is a
legitimate value for a site that has no event vector. Nothing would have gone red.

Adds one small compiled declaration whose single site is spelled that way, plus a
row asserting the options map projects verbatim (options included — a
`:prevent-default` IS part of what the site does), that `:event-id` comes from
the wrapped vector, and that the closed key set holds over this classification
too. Held apart from `basket` on purpose, so the cardinality and honesty-split
rows there stay about the classes they name.

No production code changes.

## Quality gates

Foreground to completion, `rc=$?` captured immediately into a worktree-local log
and cross-checked against each runner's own PASS/FAIL lines. Nothing was read
through a pipe's exit status.

FALSIFICATION FIRST, since this PR is a test: removing the `map?` arm from
`event-site` in `tool.cljc` reds exactly this new row — rc 1, 2 failures at
`tool_reads_cljs_test.cljc:316` and `:318`. The arm was then restored and every
gate below run against the restored tree.

| Gate | Result | rc |
|---|---|---|
| `implementation/freehand` `clojure -M:test` | 1083 tests / 7319 assertions, 0 failures, 0 errors | 0 |
| `npm run test:cljs` | 11423 tests / 57158 assertions, 0 failures, 0 errors | 0 |
| Freehand census self-test | all 85 self-tests passed | 0 |
| Freehand census (live, structural + execution) | 97 rows (96 active, 1 retired), 96 applicable rows each witnessed | 0 |
| Freehand census `--report` vs `origin/main` | byte-identical — `cmp` rc 0, md5 `bdb95d24524b6a460a687b408a7b1a48` | 0 |
| `scripts/test-fast-pr.sh` | `PASS fast PR spine` — core JVM 2115/10456, CLJS node 11387/57016, per-ns isolation 17/17 | 0 |

Two things stated rather than glossed:

- The FIRST `npm run test:cljs` on this base returned **rc 1, 2 failures**, both
  `spawnSync … ETIMEDOUT` in `re-frame.test-quiet-shadow-node-cljs-test` — the
  harness's own subprocess self-test, which re-spawns the built runner under a 60s
  ceiling its docstring describes as generous for a child that "returns in well
  under a second". A single freehand test file cannot reach that surface, and the
  box was running a JVM suite and a shadow compile concurrently. The retry was
  green at the IDENTICAL test count (11423 / 57158), so the delta was exactly the
  two timeouts: load, not behaviour. The rc 0 above is that retry.
- The `test-fast-pr.sh` row was measured on the pre-advance base (the tree this
  branch was cut from). The re-run on the rebased base was cut off mid-flight when
  the worktree was reaped after this PR merged, so it is reported from the earlier
  run rather than claimed twice. CI is the authority for the merged state: all 38
  non-skipped checks SUCCESS, including the unfiltered required
  `Freehand conformance index` job.
