### PR TITLE
docs: drop a stale test-count numeral from the fast-PR spine header (rf2-dgzaf)

### DIFF
--- a/implementation/test-quiet/src/re_frame/test_quiet/runner.clj
+++ b/implementation/test-quiet/src/re_frame/test_quiet/runner.clj
@@ -498,7 +498,8 @@
       (close []))))
 
 ;; ----------------------------------------------------------------------
-;; Whole-suite test-count floor (rf2-qqzmf).
+;; What a lane claims, and what it must therefore prove (rf2-qqzmf) — the
+;; coverage floor for a suite lane, `probe-flag` for a resolution lane.
 ;;
 ;; The project already holds this standard in two places and had not
 ;; generalised it:

--- a/scripts/test-fast-pr.sh
+++ b/scripts/test-fast-pr.sh
@@ -18,8 +18,10 @@ set -euo pipefail
 #              ssr, security, ssr-ring, epoch, resources, freehand,
 #              spec-resource, the three conformance artefacts, and test-quiet
 #              — run in CI and NOT here, so a change under
-#              `implementation/routing/src` gets NONE of routing's 487 JVM
-#              tests from this script.  Run `scripts/test-jvm-implementation.sh` for
+#              `implementation/routing/src` gets NONE of routing's several
+#              hundred JVM tests from this script.  (No count is quoted: a
+#              number in a comment is exactly the kind of claim that goes
+#              stale.)  Run `scripts/test-jvm-implementation.sh` for
 #              those (it is the whole set, and it is what CI's per-artefact
 #              jobs collectively cover);
 #   node tier  the npm/CLJS `:node-test` build, the JS harness self-tests, and


### PR DESCRIPTION
Follow-up to #6975 (`rf2-qqzmf` / `rf2-dgzaf`). Two prose corrections that missed
that PR's merge window. Comment-only — no behaviour change.

## 1. A count in a comment that had already drifted

`scripts/test-fast-pr.sh`'s new header said a routing change "gets NONE of
routing's **487** JVM tests from this script". 487 was the measured figure when
the line was written; routing measured **494** an hour later, on the rebase onto
`origin/main`.

A number baked into a comment is exactly the kind of claim that goes stale — the
defect both of those beads exist to remove. The header now makes the point
qualitatively and says why no number is quoted. Measurements belong in a PR's
gate evidence, where they carry a date.

## 2. A section title narrower than its contents

The runner's floor section was titled `Whole-suite test-count floor`, but after
the coverage-versus-resolution fix it also holds `probe-flag` and the reasoning
for scoping the floor to lanes that claim coverage. Retitled to say so.

## Quality gates

| Gate | rc | Result |
| --- | --- | --- |
| `scripts/_test_fixtures/test_fast_pr_docs_gate/run-self-test.sh` | 0 | `18/18 self-test cases passed.` — including Q/R, which pin that `--plan` still names the JVM tier as core-only and still points at the full sweep |
| `cd implementation/test-quiet && clojure -M:test -n re-frame.test-quiet-pin-test` | 0 | `Ran 1 tests containing 1 assertions. / 0 failures, 0 errors.` — the runner compiles, and a focused single-namespace run still clears the floor |

`rc` captured immediately after each runner, not through a pipe. The full JVM
sweep, node lane, browser lane and the rest of #6975's evidence are unaffected by
a comment edit; that PR's gate table stands.
