### PR TITLE
fix(examples,docs): the cold-boot deep-link race, and the guide recipe that never restored the user (rf2-k85nd, rf2-tgh45)

### DIFF
--- a/examples/real-apps/realworld_http/auth.cljs
+++ b/examples/real-apps/realworld_http/auth.cljs
@@ -161,6 +161,24 @@
         (assoc-in [:auth :user] nil)
         (assoc-in [:auth :token] nil))}))
 
+;; ONE definition of "we don't know who this is yet", used from two places that
+;; must not be allowed to drift: the `:auth/restoring-session?` sub (views) and
+;; the `:rf.route/entry-denied` handler (routing.cljs), which needs the same
+;; answer from inside an ordinary event handler where subs aren't available. Two
+;; copies of this predicate is how you get a deep link that is deferred by one
+;; site and never settled by the other.
+;;
+;; It reads the two DURABLE paths rather than the machine's `:restoring` state
+;; on purpose: the machine snapshot lives in runtime-db and is not reachable
+;; from a `:db` value, and the durable slice is the thing the guard judges.
+(defn restoring-session?
+  "True when a saved JWT is present but the user it stands for has not been
+   restored yet — the cold-boot window in which identity is genuinely unknown.
+   PURE: takes an app-db value, reads nothing ambient."
+  [db]
+  (and (nil? (get-in db [:auth :user]))
+       (not (str/blank? (get-in db [:auth :token])))))
+
 (rf/reg-event :auth/post-login-redirect
   {:doc "Drop the freshly-signed-in user back where they were headed before
          the auth guard sent them to login (`[:auth :return-to]`, stashed in
@@ -181,6 +199,66 @@
        :fx [[:dispatch (if return-to
                          [:rf.route/navigate (assoc return-to :replace? true)]
                          [:rf.route/navigate {:to :realworld/home}])]]})))
+
+;; ----------------------------------------------------------------------------
+;; THE COLD-BOOT DEEP-LINK WINDOW  (the one genuinely subtle bit of this app)
+;; ----------------------------------------------------------------------------
+;;
+;; Here is the sequence that has to work, and it is worth spelling out because
+;; getting it wrong is invisible until someone bookmarks `/settings`.
+;;
+;; The frame runs its `:initial-events` first, so `:auth/initialise` has put the
+;; saved JWT in app-db before the URL-bound frame's first URL→slice sync (core.cljs
+;; §MOUNT). But the IDENTITY that token stands for arrives from `GET /user`, and
+;; frame setup settles only SYNCHRONOUS work — it does not await an in-flight
+;; request (EP-0027 §Construction). So the first URL resolution judges a reader
+;; whose token is known and whose user is not yet.
+;;
+;; `:can-enter` is a closed boolean — there is no third "ask me again later"
+;; answer, and there should not be: a guard that could return `:pending` would
+;; put a tri-state in every app's auth sub. Instead the guard says the honest
+;; `false` (no user, no entry), entry denial does what it always does — commits
+;; NOTHING, parks nothing, terminal — and the DENIAL HANDLER decides what that
+;; refusal means. During the restore window it means "wait", not "go to login":
+;; routing.cljs stashes the destination and stays put. Then whichever way restore
+;; settles, this event resolves the stash:
+;;
+;;   restore succeeds → a FRESH navigate at the stashed destination. Denial was
+;;                      terminal, so this is an ordinary new attempt the guard
+;;                      re-evaluates from scratch — no bypass flag, no resume.
+;;   restore fails    → the reader is parked on a URL nothing committed, so land
+;;                      them on login and KEEP the stash for the return trip.
+;;
+;; A PUBLIC deep link never enters this window at all: its route commits on the
+;; first sync, no denial fires, nothing is stashed, and this event is a no-op.
+(rf/reg-event :auth/settle-deferred-entry
+  {:doc "Resolve the protected deep link `:rf.route/entry-denied` DEFERRED while
+         cold-boot identity was unknown. Dispatched once restore has settled, by
+         BOTH outcomes — `:auth/session-restored` (success) and the machine's
+         `:abandon-restore` action (failure) — and it reads the settled auth slice
+         rather than being told which happened. No stash → nothing to settle, and
+         the deep link the reader cold-booted on stays exactly where it is."}
+  (fn handler-auth-settle-deferred-entry [{:keys [db]} _]
+    (let [return-to (get-in db [:auth :return-to])
+          restored? (some? (get-in db [:auth :user]))]
+      (cond
+        ;; No deferred entry: a public deep link, or no deep link at all.
+        (nil? return-to)
+        {}
+
+        ;; Identity restored — take the fresh attempt. Read AND clear the stash
+        ;; in one step, exactly as `:auth/post-login-redirect` does, so a later
+        ;; interactive login can't get bounced to a stale target.
+        restored?
+        {:db (update db :auth dissoc :return-to)
+         :fx [[:dispatch [:rf.route/navigate (assoc return-to :replace? true)]]]}
+
+        ;; Restore failed (expired / revoked / unreachable). The stash SURVIVES:
+        ;; a successful interactive sign-in returns the reader to the exact
+        ;; destination via `:auth/post-login-redirect`.
+        :else
+        {:fx [[:dispatch [:rf.route/navigate {:to       :realworld.auth/login
+                                              :replace? true}]]]}))))
 
 ;; ============================================================================
 ;; AUTH STATE MACHINE
@@ -262,7 +340,27 @@
     (fn [{[_ {:keys [error]}] :event}]
       {:data {:error (rh/failure->message error)}})
 
+    :abandon-restore
+    ;; Cold-boot restore FAILED — the saved JWT was rejected (expired, revoked)
+    ;; or the server was unreachable. Clear the now-invalid session and the
+    ;; persisted token, then STAY PUT: a deep link to a PUBLIC page must remain
+    ;; readable as an anonymous visitor. Being yanked home is the price of a
+    ;; deliberate LOGOUT (`:clear-session` below), not of a failed restore.
+    ;; `:auth/settle-deferred-entry` is what handles the one case where staying
+    ;; put would strand the reader on a blank page — a PROTECTED deep link the
+    ;; guard deferred, for which nothing was ever committed. It runs after
+    ;; `:auth/clear-session` has committed, so it sees a confirmed-anonymous
+    ;; slice and takes its login branch.
+    (fn [_]
+      {:data {:error nil}
+       :fx [[:dispatch [:auth/clear-session]]
+            [:auth.session/persist {:token nil}]
+            [:dispatch [:auth/settle-deferred-entry]]]})
+
     :clear-session
+    ;; Interactive LOGOUT (from :authed): clear the session and the persisted
+    ;; token, then navigate home — signing out deliberately lands you on the
+    ;; public home page. A FAILED RESTORE uses `:abandon-restore` above instead.
     (fn [_]
       {:data {:error nil}
        :fx [[:dispatch [:auth/clear-session]]
@@ -285,7 +383,7 @@
 
     :restoring
     {:on {:auth/success        {:target :authed}
-          :auth/restore-failed {:target :idle   :action :clear-session}}}
+          :auth/restore-failed {:target :idle   :action :abandon-restore}}}
 
     :authed
     {:on {:auth/logout {:target :idle :action :clear-session}
@@ -342,16 +440,20 @@
 
 (rf/reg-event :auth/session-restored
   {:doc       "Cold-boot session restore succeeded (a saved JWT was present
-               and accepted): store the session and re-persist the JWT
-               defensively (in case the server rotated it), but do NOT
-               navigate — a deep link must stay put. The reply rides a map
-               payload classified :sensitive so the token is redacted at
-               event egress."
+               and accepted): store the session, re-persist the JWT
+               defensively (in case the server rotated it), and settle any
+               protected deep link the guard DEFERRED while identity was
+               unknown. It never navigates on its own account — a public deep
+               link must stay put. The reply rides a map payload classified
+               :sensitive so the token is redacted at event egress."
    :sensitive [[:value :user :token]]}
   (fn handler-auth-session-restored [{:keys [db]} [_ {:keys [value]}]]
     (let [user (:user value)]
       {:db (store-session-db db user)
+       ;; `:db` commits before `:fx` runs, so `:auth/settle-deferred-entry`
+       ;; below reads the RESTORED user and takes its "let them in" branch.
        :fx [[:auth.session/persist {:token (:token user)}]
+            [:dispatch [:auth/settle-deferred-entry]]
             [:dispatch [:auth/flow [:auth/success]]]]})))
 
 ;; ============================================================================
@@ -538,6 +640,15 @@
 
 (rf/reg-sub :auth/token
   (fn [db _] (get-in db [:auth :token])))
+
+(rf/reg-sub :auth/restoring-session?
+  {:doc "True for the ONE window where the reader's identity is genuinely
+         unknown: a saved JWT is in app-db but the user it stands for has not
+         come back from `GET /user` yet. The view layer's door onto
+         `restoring-session?`; the `:rf.route/entry-denied` handler
+         (routing.cljs) calls the same predicate directly, because an event
+         handler has a db value but no subs."}
+  (fn [db _] (restoring-session? db)))
 
 (rf/reg-sub :auth/flow-state
   {:doc "The current auth machine snapshot."}

--- a/examples/real-apps/realworld_http/core.cljs
+++ b/examples/real-apps/realworld_http/core.cljs
@@ -241,18 +241,28 @@
   [:div.app
    [header]
    [pending-nav-dialog]
-   (case @(subscribe [:rf.route/id])
-     :realworld/home              [articles/home-page]
-     :realworld/home-tag          [articles/home-page]
-     :realworld.auth/login             [auth/login-page]
-     :realworld.auth/register          [auth/register-page]
-     :realworld.article/show           [comments/article-page]
-     :realworld.editor/new            [editor/editor-page]
-     :realworld.editor/edit       [editor/editor-page]
-     :realworld.profile/show           [profile/profile-page]
-     :realworld.profile/favorites [profile/profile-page]
-     :realworld.user/settings          [settings/settings-page]
-     [not-found-page])
+   ;; The cold-boot deferred-entry window (see auth.cljs §THE COLD-BOOT DEEP-LINK
+   ;; WINDOW). A protected deep link whose session restore is still in flight has
+   ;; no committed route — entry denial commits nothing — so the `case` below
+   ;; would fall through to "Page not found" and tell a signed-in reader they
+   ;; mistyped their own bookmark. Say what is actually happening instead, for the
+   ;; one tick it takes `GET /user` to land. A PUBLIC deep link commits its route
+   ;; and renders normally throughout.
+   (if @(subscribe [:realworld.routing/deferred-entry?])
+     [:div.container.page {:data-testid "session-restoring"}
+      [:p "Restoring your session…"]]
+     (case @(subscribe [:rf.route/id])
+       :realworld/home              [articles/home-page]
+       :realworld/home-tag          [articles/home-page]
+       :realworld.auth/login        [auth/login-page]
+       :realworld.auth/register     [auth/register-page]
+       :realworld.article/show      [comments/article-page]
+       :realworld.editor/new        [editor/editor-page]
+       :realworld.editor/edit       [editor/editor-page]
+       :realworld.profile/show      [profile/profile-page]
+       :realworld.profile/favorites [profile/profile-page]
+       :realworld.user/settings     [settings/settings-page]
+       [not-found-page]))
    [footer]])
 
 ;; ============================================================================
@@ -385,12 +395,23 @@
     ;;     `:app/initialise` so the token is sitting in app-db before the
     ;;     bearer-auth interceptor needs to send anything authenticated.
     ;;   - `:app/initialise` — fans out to all the per-feature initialisers.
+    ;;
     ;; `:url-bound? true` performs the initial URL→slice sync after every
-    ;; `:initial-events` step above. That ordering is load-bearing: session
-    ;; restore completes before a deep link to a `:requires-auth` route runs its
-    ;; `:can-enter` gate, so the gate judges the restored user rather than an
-    ;; uninitialised auth slice. No explicit `:rf.route/handle-url-change`
-    ;; initial event is needed.
+    ;; `:initial-events` step above, so the saved TOKEN is in app-db before a
+    ;; deep link runs its `:can-enter` gate. The IDENTITY is a different story,
+    ;; and it is worth being exact rather than reassuring: frame setup settles
+    ;; only SYNCHRONOUS work and does not await an in-flight request (EP-0027
+    ;; §Construction), and this app's restore is an asynchronous `GET /user`
+    ;; (the Conduit contract persists a bearer token, not a cached profile).
+    ;; So the first URL resolution genuinely can run while `[:auth :user]` is
+    ;; still nil, and a deep link to a `:requires-auth` route IS refused at that
+    ;; moment. What makes that correct rather than a bug is where the refusal
+    ;; goes: entry denial is terminal (nothing commits), and routing.cljs's
+    ;; `:rf.route/entry-denied` handler DEFERS the login bounce while restore is
+    ;; in flight, stashing the destination for `:auth/settle-deferred-entry` to
+    ;; act on the moment `GET /user` lands (auth.cljs §THE COLD-BOOT DEEP-LINK
+    ;; WINDOW has the full sequence; rf2-k85nd is the bug that taught us).
+    ;; No explicit `:rf.route/handle-url-change` initial event is needed.
     (rdc/render @react-root
                 [rf/frame-root {:id              :rf/default
                                 :doc             "Realworld demo frame."

--- a/examples/real-apps/realworld_http/routing.cljs
+++ b/examples/real-apps/realworld_http/routing.cljs
@@ -25,7 +25,13 @@
             ;; `url-strategy` off `routing/with-base-path` +
             ;; `routing/history-url-strategy`. See the routing guide:
             ;; ../../../docs/routing/index.md
-            [re-frame.routing :as routing]))
+            [re-frame.routing :as routing]
+            ;; For `auth/restoring-session?` — the ONE definition of the
+            ;; cold-boot window in which identity is not yet known, shared with
+            ;; the `:auth/restoring-session?` sub so the denial handler below
+            ;; and the view layer can never disagree about it. (No cycle: auth
+            ;; requires schema + http, neither of which requires this ns.)
+            [realworld-http.auth :as auth]))
 
 ;; ============================================================================
 ;; ROUTES
@@ -140,10 +146,16 @@
 ;; routing rather than duplicating them for each navigation entry point.
 
 ;; The guard sub. `true` → OK to enter. It reads the durable `[:auth :user]`
-;; presence (not the machine's `:authed` state), so a deep-link that arrives
-;; DURING session restore judges a logged-in user correctly. `:can-enter` subs
+;; presence, not the machine's `:authed` state, because the durable slice is the
+;; thing a reload rebuilds and the machine snapshot is not. `:can-enter` subs
 ;; receive the pending target as a second arg — unused here, since the answer is
 ;; the same for every protected route (are you signed in?).
+;;
+;; Note what it does NOT try to do: report "still finding out". `:can-enter` is a
+;; closed boolean by design, and a tri-state guard would push "maybe" into every
+;; app's auth sub. Mid-restore the honest answer is `false` — there is no user —
+;; and the DENIAL HANDLER below is where "no user YET" is told apart from "no
+;; user, full stop".
 (rf/reg-sub :realworld.routing/authed?
   {:doc "The :can-enter auth guard: true when a user is signed in. Read by the
          :requires-auth routes' :can-enter slot."}
@@ -176,15 +188,52 @@
 ;; Registering this handler is optional: the framework ships a no-op default,
 ;; so a denial without it would simply be a hard deny (the visitor stays put).
 ;; We register it because a login bounce is friendlier than a dead click.
+;;
+;; THE ONE BRANCH. A refusal has two quite different meanings, and only the
+;; handler can tell them apart, because `:can-enter` deliberately answers a
+;; closed boolean:
+;;
+;;   "you are not signed in"    → bounce to login. The ordinary case.
+;;   "we don't know yet"        → STAY PUT and wait. A cold boot with a saved JWT
+;;                                whose `GET /user` is still in flight: the
+;;                                reader may well be signed in, and bouncing them
+;;                                to login here is the bug this branch exists to
+;;                                prevent (rf2-k85nd). Nothing has committed —
+;;                                denial is terminal — so no protected page,
+;;                                `:on-match`, or data has been exposed while we
+;;                                wait. `:auth/settle-deferred-entry` (auth.cljs)
+;;                                picks the stash up the moment restore settles:
+;;                                a FRESH navigate on success, login on failure.
+;;
+;; Both branches stash the destination first, so either way the reader ends up at
+;; the exact address they asked for. And both are fail-CLOSED: the deferred branch
+;; grants nothing, it only declines to give up.
 (rf/reg-event :rf.route/entry-denied
   {:doc "Steer a logged-out visitor who tried to enter a :requires-auth route to
          login, remembering the FULL destination they were headed for (route,
-         params, query, and #fragment) so the post-login return lands on the
-         exact URL."}
+         params, query, and #fragment) so the return lands on the exact URL.
+         While a cold-boot session restore is still in flight the visitor's
+         identity is unknown, so the bounce is DEFERRED rather than taken —
+         `:auth/settle-deferred-entry` resolves the stash once restore settles."}
   (fn [{:keys [db]} [_ {:keys [destination]}]]
-    {:db (assoc-in db [:auth :return-to] destination)
-     :fx [[:dispatch [:rf.route/navigate {:to       :realworld.auth/login
-                                          :replace? true}]]]}))
+    (cond-> {:db (assoc-in db [:auth :return-to] destination)}
+      (not (auth/restoring-session? db))
+      (assoc :fx [[:dispatch [:rf.route/navigate {:to       :realworld.auth/login
+                                                  :replace? true}]]]))))
+
+;; The shell's cue for the deferred window. A protected deep link that is waiting
+;; on restore has NO committed route (denial commits nothing), so a `case` over
+;; `:rf.route/id` would fall through to "Page not found" — a lie to tell a reader
+;; who is, in fact, signed in. A PUBLIC deep link commits its route and never
+;; trips this, so it keeps rendering normally while restore finishes.
+(rf/reg-sub :realworld.routing/deferred-entry?
+  {:doc "True while a protected deep link is parked waiting on a cold-boot
+         session restore: identity unknown AND no route committed. The app shell
+         (core.cljs) reads it to show a brief 'restoring your session' state."}
+  :<- [:auth/restoring-session?]
+  :<- [:rf.route/id]
+  (fn [[restoring? route-id] _]
+    (and restoring? (nil? route-id))))
 
 ;; ============================================================================
 ;; ROUTER WIRING


### PR DESCRIPTION
Fixes the same defect in two places: the RealWorld apps' cold-boot deep-link race
(`rf2-k85nd`) and the two guide pages that teach the boot recipe (`rf2-tgh45`).

Closes rf2-k85nd. Closes rf2-tgh45.

## The defect

A URL-bound frame runs its `:initial-events` and *then* does its first URL→slice
sync (`frame.cljc` runs setup at the create branch, the routing POST-CREATE hook
syncs after it). Setup settles only **synchronous** work — it does not await an
in-flight request (EP-0027 §Construction). RealWorld's session restore is an
asynchronous `GET /user`, so the first URL resolution judges a reader whose token
is known and whose `[:auth :user]` is not yet. `:can-enter` refuses, and the
denial handler replace-navigated to `/login` — permanently stranding a
perfectly-signed-in reader who bookmarked `/settings`.

The guide pages had the same hole plus a second one: `add-auth.md` restored the
**token** and never the **user** the guard reads, and its boundary
`dispatch-sync` ran *after* `make-frame {:url-bound? true}`, so the first URL
decision preceded even the token write.

## Quality gates

_(filled in at the end)_
