### PR TITLE
fix(conformance): read `^` as the two-datum prefix it is, so a quoted annotated datum is data (rf2-drpa3.53)

### DIFF
--- a/scripts/check_freehand_conformance_index.py
+++ b/scripts/check_freehand_conformance_index.py
@@ -249,7 +249,7 @@ _SEPARATOR_CELL_RE = re.compile(r"^:?-{3,}:?$")
 # it does not exist.
 #
 # But a site is not a proof.  What makes a row proven is that an ASSERTION runs
-# against the fixture, and nine shapes are indistinguishable from a proof to a
+# against the fixture, and ten shapes are indistinguishable from a proof to a
 # scan that stops short of the assertions:
 #
 #     ;; (conf/fixture :FH-CALL-001)              a comment
@@ -268,6 +268,8 @@ _SEPARATOR_CELL_RE = re.compile(r"^:?-{3,}:?$")
 #     (deftest t (is (= :fx 1)))                  binding, read as the Var
 #     (def fx (conf/fixture :FH-CALL-001))        the binding QUOTED — the token,
 #     (deftest t (is (= `fx 1)))                  and not a reference to it
+#     (def fx (conf/fixture :FH-CALL-001))        the quoted datum ANNOTATED, so
+#     (deftest t (is (vector? '^{:a 1} [fx])))    the quote's EXTENT was miscounted
 #
 # The first three are the false greens the first merged-PR audit found; the
 # fourth was the same mistake waiting; the next two are what the SECOND audit
@@ -275,10 +277,12 @@ _SEPARATOR_CELL_RE = re.compile(r"^:?-{3,}:?$")
 # as reading assertions; the next two are the THIRD, because reading assertions is
 # not the same as reading them in the namespace and on the platform that has them;
 # the ninth is the FOURTH, because a name is not any run of symbol characters —
-# `:fx` was read as `fx`, and a datum stood in for a Var; and the last is the
-# FIFTH, because a token is not a reference either — `` `fx `` IS the token `fx`,
-# and quoted data is data.  Each one lets a law be retired by deletion — comment
-# out the proof, keep the line — with the gate still calling the row proven.
+# `:fx` was read as `fx`, and a datum stood in for a Var; the tenth is the FIFTH,
+# because a token is not a reference either — `` `fx `` IS the token `fx`, and
+# quoted data is data; and the last is the SIXTH, because knowing WHICH datum is
+# quoted still leaves HOW FAR it reaches, and `^` reaches over two datums rather
+# than one.  Each one lets a law be retired by deletion — comment out the proof,
+# keep the line — with the gate still calling the row proven.
 #
 # So the scan reads FORMS, then the ASSERTIONS, then the NAMES — and it reads a
 # name from a TOKEN BOUNDARY, in an EVALUATED position.  Three reductions come
@@ -292,6 +296,13 @@ _SEPARATOR_CELL_RE = re.compile(r"^:?-{3,}:?$")
 #     _evaluated  what EVALUATES            every quoted datum — `'x`, `` `x ``,
 #                                           `(quote x)` — with `~x` islands
 #                                           inside a syntax quote recovered
+#
+# All three ask `_datum_end` how far a datum reaches, so its arithmetic is the one
+# place a mistake reaches all of them: `#_` discards a datum, a reader conditional
+# pairs its arms as datums, and a quote blanks one.  `^` is the shape that gets
+# that arithmetic wrong if it is filed with the one-datum prefixes, because it
+# consumes its metadata AND the target that metadata annotates — see
+# `_META_PREFIX`.
 #
 # Then `_top_level_forms` splits what survives on balanced parens; `_SYMBOL_RE`
 # matches a symbol only where one STARTS, so a keyword stays data; `_read_tree`
@@ -463,26 +474,37 @@ def _blank(chunk: str) -> str:
 
 
 _OPENERS = {"(": ")", "[": "]", "{": "}"}
-# The reader macro prefixes: `#`, `'`, `` ` ``, `~`, `~@`, `@` and `^meta`.  Each
-# belongs to the datum that FOLLOWS it, which is one fact and therefore one
-# authority — `_datum_end` needs it to find a datum's extent and `_evaluated`
-# needs it to find where a quoted datum begins.
-_PREFIXES = "#'`~@^"
+# The reader macro prefixes that belong to the ONE datum following them: `#`,
+# `'`, `` ` ``, `~`, `~@` and `@`.  One fact and therefore one authority —
+# `_datum_end` needs it to find a datum's extent and `_evaluated` needs it to
+# find where a quoted datum begins.  `~@` is two of these characters and both are
+# in the set, so one loop reads it.
+_PREFIXES = "#'`~@"
+# `^` is the prefix that is NOT one of them, and reading it as one was a false
+# green a merged-PR audit had to reproduce.  `^` consumes TWO datums — its
+# metadata and then the target that metadata annotates — so `'^{:audit true} [fx]`
+# is a quote over the whole annotated vector, not a quote over the map with the
+# vector left standing beside it.  Counted the wrong way, `_evaluated` blanked
+# `'^{:audit true}` and left `[fx]` exposed as a live reference, so a `deftest`
+# whose only mention of the fixture was inside quoted data proved a row — while
+# the `(quote ^{:audit true} [fx])` spelling of the same datum correctly red,
+# because there the whole list is blanked and no extent is counted.  Its own
+# constant, and its own step in `_datum_end`, because "belongs to the datum that
+# follows" is exactly the sentence that is untrue of it.
+_META_PREFIX = "^"
 
 
 def _prefix_end(text: str, start: int) -> int:
     """The index of the datum the run of reader prefixes at `start` introduces.
 
     `start` itself when there is no prefix there, so this is safe to call on any
-    position a datum may begin at.  `~@` is one prefix spelled two characters,
-    and the inner step is what keeps its `@` from being read as a deref of
-    nothing.
+    position a datum may begin at.  `^` is not among them and stops the run: the
+    datum a `^` introduces begins AT the `^`, and how far it then reaches is
+    `_datum_end`'s question rather than this one's.
     """
     i, n = start, len(text)
     while i < n and text[i] in _PREFIXES:
         i += 1
-        if i < n and text[i] == "@":
-            i += 1
     return i
 
 
@@ -491,6 +513,11 @@ def _datum_end(text: str, start: int) -> int:
 
     Whitespace and stacked `#_`s are skipped first, so `#_ #_ a b` discards both
     `a` and `b` the way the reader does.
+
+    A `^` reaches over TWO datums, and the step is recursive so that the shapes
+    which stack fall out of one rule rather than three: `^:private ^:const x`
+    annotates twice, `^{:doc "d"} 'x` annotates a datum carrying its own prefix,
+    and `^:m ^:n [a b]` ends where the vector ends.
     """
     i = start
     n = len(text)
@@ -504,6 +531,9 @@ def _datum_end(text: str, start: int) -> int:
     if i >= n:
         return n
     i = _prefix_end(text, i)
+    if i < n and text[i] == _META_PREFIX:
+        # The metadata datum, and then the datum it annotates.
+        return _datum_end(text, _datum_end(text, i + 1))
     if i < n and text[i] in _OPENERS:
         return _form_end(text, i)
     if i < n and text[i] == '"':
@@ -654,6 +684,17 @@ def _evaluated(text: str) -> str:
     the three were silent and the third was red only by lexical accident (the
     `'` fell inside `_SYMBOL_HEAD`, so `'fx` came back as the unresolvable token
     `'fx`).  Accidentally loud is not the same as right.
+
+    WHICH datum is quoted is only half of it; the other half is HOW FAR the datum
+    reaches, and that is `_datum_end`'s arithmetic rather than this function's.
+    A merged-PR audit found the two prefix spellings standing a row up again
+    through `'^{:audit true} [fx]`, because `^` was filed with the prefixes that
+    introduce ONE datum: the blank ended at the metadata map's `}` and left
+    `[fx]` beside it in code.  The `(quote ^{:audit true} [fx])` spelling of the
+    same datum was red throughout — its extent is the LIST, so no `^` was
+    counted — and that difference is what made it arithmetic and not policy.
+    Fixed where extent lives, so `#_` and the reader conditionals get the
+    correction with it.
 
     AND IT IS A NARROWING, NOT A REFUSAL, which is the half that keeps it honest.
     Inside a syntax quote, `~x` and `~@x` ARE evaluated — that is what they are
@@ -1618,6 +1659,14 @@ def _cell_lanes(mode: str, host: str) -> frozenset[str]:
 # `{:compiled true}` and a quoted `re-frame.freehand.compiler.…` witness nothing
 # either, and the marker cannot disagree with the names beside it.
 #
+# And blanking quoted data is only as sound as the EXTENT of the datum blanked.
+# `'^{:audit true} [panel]` had its quote counted as reaching the metadata map
+# alone, so `[panel]` stayed in code and witnessed a compiled tier the assertion
+# never entered — while the same datum written `(quote ^{:audit true} [panel])`
+# red, because a list's extent needs no prefix arithmetic.  `_datum_end` reads `^`
+# as the two-datum prefix it is for that reason (`_META_PREFIX`), and every pass
+# that asks how far a datum reaches gets the correction.
+#
 # What stays TEXTUAL within what does evaluate, and is stated rather than hidden,
 # is the marker itself: a statement mentioning a live `{:compiled true}` map
 # literal or a spelled-out `re-frame.freehand.compiler.…` as DATA still witnesses.
@@ -2117,6 +2166,101 @@ def _build_census_fixtures(base: Path) -> None:
             (),
             (),
         ),
+        # Red: A QUOTED DATUM MAY BE ANNOTATED, and reading `^` as a one-datum
+        # prefix let the annotation carry the quote away from what it quoted.  The
+        # extent of `'^{:audit true} [fx]` is the whole annotated vector; counted
+        # as `'` over the MAP, the blank ended at the `}` and `[fx]` stood there
+        # in code, so a `deftest` naming the fixture only inside quoted data
+        # proved the row.  This assertion is true in Clojure with no `fx` binding
+        # in the image at all - which is the plainest statement of what it does
+        # not read.
+        "census_metadata_reader_quote_shaped_like_the_fixture_binding": (
+            {"CALL": _row()},
+            {"a_cljs_test.cljc": "(ns x)\n(def fx (conf/fixture :FH-CALL-001))\n"
+                                 "(deftest t\n"
+                                 "  (is (vector? '^{:audit true} [fx])))\n"},
+            (),
+            (),
+        ),
+        # Red: the syntax-quoted twin of the same annotated datum.  Both spellings
+        # go through one extent calculation, so pinning both is what says the fix
+        # is the extent rather than a patch on the `'` branch.
+        "census_metadata_syntax_quote_shaped_like_the_fixture_binding": (
+            {"CALL": _row()},
+            {"a_cljs_test.cljc": "(ns x)\n(def fx (conf/fixture :FH-CALL-001))\n"
+                                 "(deftest t\n"
+                                 "  (is (vector? `^{:audit true} [fx])))\n"},
+            (),
+            (),
+        ),
+        # Red, AND THE CONTROL THAT LOCALISED THE FAULT.  The same annotated datum
+        # in the `(quote …)` spelling was ALREADY red, because there the extent is
+        # the LIST and no `^` is counted - so the census's verdict turned on which
+        # of three equivalent spellings the author reached for, and the difference
+        # between them was the prefix arithmetic and nothing else.  Red by rule
+        # now, like its two twins above.
+        "census_metadata_quote_form_shaped_like_the_fixture_binding": (
+            {"CALL": _row()},
+            {"a_cljs_test.cljc": "(ns x)\n(def fx (conf/fixture :FH-CALL-001))\n"
+                                 "(deftest t\n"
+                                 "  (is (vector? (quote ^{:audit true} [fx]))))\n"},
+            (),
+            (),
+        ),
+        # Red: annotations STACK, and `^` reaches over each of them to the target.
+        # One `^` handled and the next left standing would be the same bug with a
+        # smaller radius, so the extent step recurses rather than special-casing
+        # one caret.
+        "census_stacked_metadata_on_a_quoted_fixture_binding": (
+            {"CALL": _row()},
+            {"a_cljs_test.cljc": "(ns x)\n(def fx (conf/fixture :FH-CALL-001))\n"
+                                 "(deftest t (is (= '^:audit ^:slow fx 1)))\n"},
+            (),
+            (),
+        ),
+        # Red: THE SAME EXTENT READ BY A DIFFERENT PASS, and a false green found by
+        # asking where else a datum's reach is counted rather than only where the
+        # audit pointed.  `#_` discards the next datum, and the next datum here is
+        # the ANNOTATED `def` - so the whole binding is discarded.  Counted the
+        # short way, only the metadata went and the `def` survived to bind a
+        # fixture the reader never sees, which is `census_discarded_proof_site`
+        # defeated by one annotation.
+        "census_metadata_on_a_discarded_proof_site": (
+            {"CALL": _row()},
+            {"a_cljs_test.cljc": "(ns x)\n"
+                                 "#_^{:audit true}\n"
+                                 "(def fx (conf/fixture :FH-CALL-001))\n"
+                                 "(deftest t (is (seq fx)))\n"},
+            (),
+            (),
+        ),
+        # Green, and the control for OVER-tightening on this axis.  An annotation
+        # is not a quote: `^{:audit true} fx` in an evaluated position IS the Var
+        # reference, metadata and all.  Read the extent as "the caret swallows the
+        # target" rather than "the caret's DATUM is the pair" and this honest row
+        # reds.
+        "census_metadata_on_an_evaluated_fixture_reference": (
+            {"CALL": _row()},
+            {"a_cljs_test.cljc": "(ns x)\n(def fx (conf/fixture :FH-CALL-001))\n"
+                                 "(deftest t (is (seq ^{:audit true} fx)))\n"},
+            (),
+            (),
+        ),
+        # Green, and the half of the extent fix that RECOVERS an edge rather than
+        # removing one.  `~` unquotes the datum after it, and when that datum is
+        # annotated the datum is the pair - so `~^{:audit true} fx` evaluates the
+        # Var inside the template.  Counted the short way the unquote reached only
+        # the metadata MAP and `fx` stayed blanked with the rest of the quote, so
+        # this honest row red at `DEAD PROOF SITE`: the miscount cost a green here
+        # and gave one away above, from one arithmetic error in one place.
+        "census_metadata_on_an_unquote_island_reads_the_fixture": (
+            {"CALL": _row()},
+            {"a_cljs_test.cljc": "(ns x)\n(def fx (conf/fixture :FH-CALL-001))\n"
+                                 "(deftest t\n"
+                                 "  (is (= `(a ~^{:audit true} fx) 1)))\n"},
+            (),
+            (),
+        ),
         # Red: the same reduction on the OTHER surface a datum reaches a fixture
         # through.  Here the quoted datum is the `(conf/fixture …)` CALL itself,
         # so the id is read straight off the assertion without a binding in
@@ -2428,6 +2572,69 @@ def _build_census_fixtures(base: Path) -> None:
                                  "(v/defview panel {:compiled true} [_] [:div])\n"
                                  "(def fx (conf/fixture :FH-CALL-001))\n"
                                  "(deftest t (is (= 'panel (first fx))))\n"},
+            (),
+            (),
+        ),
+        # Red: THE ANNOTATED-DATUM EXTENT ON THE WITNESS AXIS.  The fixture is
+        # genuinely read - `(map? fx)` is a real reference in the same statement -
+        # so nothing but the mode witness is in question, exactly as the audit
+        # isolated it.  The declaration is named ONLY inside a quoted annotated
+        # vector, and the short extent left `[panel]` standing in code, so a
+        # `compiled jvm` row was witnessed by a datum.
+        "census_metadata_reader_quote_shaped_like_the_compiled_declaration": (
+            {"CALL": _row(applicability="compiled jvm")},
+            {"a_cljs_test.cljc": "(ns x)\n"
+                                 "(v/defview panel {:compiled true} [_] [:div])\n"
+                                 "(def fx (conf/fixture :FH-CALL-001))\n"
+                                 "(deftest t\n"
+                                 "  (is (and (map? fx)\n"
+                                 "           (vector? '^{:audit true} [panel]))))\n"},
+            (),
+            (),
+        ),
+        # Red: the syntax-quoted twin on the witness axis.  Four reds is what the
+        # family costs: two spellings x two axes, because one extent calculation
+        # serves both and a pin on one axis alone would not say so.
+        "census_metadata_syntax_quote_shaped_like_the_compiled_declaration": (
+            {"CALL": _row(applicability="compiled jvm")},
+            {"a_cljs_test.cljc": "(ns x)\n"
+                                 "(v/defview panel {:compiled true} [_] [:div])\n"
+                                 "(def fx (conf/fixture :FH-CALL-001))\n"
+                                 "(deftest t\n"
+                                 "  (is (and (map? fx)\n"
+                                 "           (vector? `^{:audit true} [panel]))))\n"},
+            (),
+            (),
+        ),
+        # Red, and the already-red control for the pair above: the `(quote …)`
+        # spelling of the same annotated vector, whose extent is the list and was
+        # therefore never miscounted.  Its twins differed from it by the prefix
+        # arithmetic alone.
+        "census_metadata_quote_form_shaped_like_the_compiled_declaration": (
+            {"CALL": _row(applicability="compiled jvm")},
+            {"a_cljs_test.cljc": "(ns x)\n"
+                                 "(v/defview panel {:compiled true} [_] [:div])\n"
+                                 "(def fx (conf/fixture :FH-CALL-001))\n"
+                                 "(deftest t\n"
+                                 "  (is (and (map? fx)\n"
+                                 "           (vector? (quote ^{:audit true} "
+                                 "[panel])))))\n"},
+            (),
+            (),
+        ),
+        # Green, and the over-tightening control on the witness axis.  The same
+        # vector UNQUOTED: `[^{:audit true} panel]` evaluates its annotated
+        # element, so the assertion really does reach the declaration and the
+        # `compiled` claim really is witnessed.  One `'` apart from the first red
+        # above, and the rule has to keep them apart in both directions.
+        "census_metadata_on_an_evaluated_declaration_reference": (
+            {"CALL": _row(applicability="compiled jvm")},
+            {"a_cljs_test.cljc": "(ns x)\n"
+                                 "(v/defview panel {:compiled true} [_] [:div])\n"
+                                 "(def fx (conf/fixture :FH-CALL-001))\n"
+                                 "(deftest t\n"
+                                 "  (is (and (map? fx)\n"
+                                 "           (vector? [^{:audit true} panel]))))\n"},
             (),
             (),
         ),
@@ -2786,6 +2993,17 @@ def _run_self_tests(verbose: bool = False) -> int:
          "DEAD PROOF SITE"),
         ("census_reader_quote_shaped_like_the_fixture_binding", 1,
          "DEAD PROOF SITE"),
+        ("census_metadata_reader_quote_shaped_like_the_fixture_binding", 1,
+         "DEAD PROOF SITE"),
+        ("census_metadata_syntax_quote_shaped_like_the_fixture_binding", 1,
+         "DEAD PROOF SITE"),
+        ("census_metadata_quote_form_shaped_like_the_fixture_binding", 1,
+         "DEAD PROOF SITE"),
+        ("census_stacked_metadata_on_a_quoted_fixture_binding", 1,
+         "DEAD PROOF SITE"),
+        ("census_metadata_on_a_discarded_proof_site", 1, "DEAD PROOF SITE"),
+        ("census_metadata_on_an_evaluated_fixture_reference", 0, None),
+        ("census_metadata_on_an_unquote_island_reads_the_fixture", 0, None),
         ("census_quoted_fixture_call_is_not_a_read", 1, "DEAD PROOF SITE"),
         ("census_unquote_inside_a_syntax_quote_reads_the_fixture", 0, None),
         ("census_nested_syntax_quote_does_not_read_the_fixture", 1,
@@ -2816,6 +3034,13 @@ def _run_self_tests(verbose: bool = False) -> int:
          "UNWITNESSED MODE"),
         ("census_reader_quote_shaped_like_the_compiled_declaration", 1,
          "UNWITNESSED MODE"),
+        ("census_metadata_reader_quote_shaped_like_the_compiled_declaration", 1,
+         "UNWITNESSED MODE"),
+        ("census_metadata_syntax_quote_shaped_like_the_compiled_declaration", 1,
+         "UNWITNESSED MODE"),
+        ("census_metadata_quote_form_shaped_like_the_compiled_declaration", 1,
+         "UNWITNESSED MODE"),
+        ("census_metadata_on_an_evaluated_declaration_reference", 0, None),
         ("census_unquote_inside_a_syntax_quote_witnesses_the_mode", 0, None),
         ("census_quoted_compiled_marker_does_not_witness", 1,
          "UNWITNESSED MODE"),

--- a/spec/conformance/freehand/README.md
+++ b/spec/conformance/freehand/README.md
@@ -244,14 +244,27 @@ assertion heads and the mode marker are all read off the same text and none can
 drift from another: a quoted `(conf/fixture :FH-…)` is not a fixture read, and a
 helper returning `'(is (seq fx))` returns a list rather than asserting.
 
+And knowing *which* datum is quoted still leaves **how far it reaches**. All three
+reductions ask one function — `#_` discards a datum, a reader conditional pairs its
+arms as datums, a quote blanks one — so a miscount there is a miscount everywhere.
+`^` is the shape that miscounts if it is filed with the prefixes that introduce one
+datum, because it consumes its metadata *and* the target that metadata annotates:
+read the short way, `'^{:audit true} [fx]` blanked the quote and the map and left
+`[fx]` standing in code, so a `deftest` whose only mention of the fixture was
+inside quoted data proved a row — and the assertion is true in Clojure with no
+`fx` in the image at all. The same datum written `(quote ^{:audit true} [fx])` was
+red throughout, because a list's extent needs no prefix arithmetic, and that
+difference is what made this arithmetic rather than policy.
+
 It is a narrowing, not a refusal. Inside a syntax quote `~x` and `~@x` *are*
 evaluated, so those islands are read as code and a genuine reference stays one
-however deep in a template it is written. Two residues remain, and both are
-*missed* edges rather than invented ones, so both cost a noisy defect on an honest
-row instead of a silent green: a nested syntax quote raises the level, so the
-double unquote that would climb back out of it (`` `(a `(b ~~c)) ``) is not
-modelled; and `#'x` is a var quote — a real reference — that resolves to nothing,
-as it did before the reduction existed.
+however deep in a template it is written — including `~^{:audit true} fx`, whose
+annotated datum is the pair. Two residues remain, and both are *missed* edges
+rather than invented ones, so both cost a noisy defect on an honest row instead of
+a silent green: a nested syntax quote raises the level, so the double unquote that
+would climb back out of it (`` `(a `(b ~~c)) ``) is not modelled; and `#'x` is a
+var quote — a real reference — that resolves to nothing, as it did before the
+reduction existed.
 
 The census also reads the **reader**. A `.cljc` suite is discovered by the JVM
 runner *and* the node runner, but a `#?(:clj (deftest …))` inside it asserts in
@@ -289,7 +302,9 @@ not a fixture a test reads. Reachability is only as sound as name resolution, so
 the witness is reached by a symbol read from a token boundary and from an
 *evaluated* position: `:panel` is a datum, not the declaration it is spelled like;
 neither is `:check/findings` the alias; and neither are `` `panel `` or
-`(quote panel)`, which name the declaration without evaluating it. Both halves of
+`(quote panel)`, which name the declaration without evaluating it — nor
+`'^{:audit true} [panel]`, whose annotation used to carry the quote away from the
+vector it quoted. Both halves of
 the witness are read off the same reduced text as the names, so a quoted
 `{:compiled true}` and a quoted `re-frame.freehand.compiler.…` witness nothing
 either. What stays textual, and is claimed as nothing more, is the marker within


### PR DESCRIPTION
Discharges the `MERGED-PR AUDIT #6968` reopen on `rf2-drpa3.53`. **This bead is
EP-0036's chain head** — F6c, F6d and F6e (donor deletion) all sit behind it — and
it is **not closed here**: it has been closed on PR-open once and on merge three
times and reopened by a merged-PR audit each time. The mayor closes it on the
merged SHA.

## The bug: one arithmetic error, in the one place extent is counted

`_evaluated` (shipped in #6968) is the third pipeline stage beside `_strip` and
`_read_as`; it blanks quoted data so a quoted symbol cannot create a reachability
edge. It closed reader-quote, syntax-quote and `(quote …)`.

Knowing *which* datum is quoted still leaves **how far it reaches**, and that is
`_datum_end`'s arithmetic. `^` was filed in `_PREFIXES` with the prefixes that
introduce **one** datum. `^` consumes **two** — its metadata datum and then the
target that metadata annotates. So the extent of `'^{:audit true} [fx]` ended at
the metadata map's `}`, `_evaluated` blanked the quote plus the metadata, and
`[fx]` survived in code as a live reference.

The `(quote ^{:audit true} [fx])` spelling of the same datum was **red
throughout** — a list's extent needs no prefix arithmetic. That difference is what
makes this arithmetic rather than policy: the census's verdict turned on which of
three equivalent spellings the author reached for.

## Reproduced hermetically against the merged script, before anything changed

Not taken on the audit's word and not re-derived either: run. The audit's two
mutations, plus three more of the same class found by asking where else extent is
counted rather than only where the audit pointed. Each shape below returned
`defects=0` on merged `b29c7d2db2`, and each has a control one datum away.

| Shape | merged | after |
|---|---|---|
| fixture axis: `(is (vector? '^{:audit true} [fx]))` | **defects=0** | `DEAD PROOF SITE` |
| fixture axis: the syntax-quoted twin | **defects=0** | `DEAD PROOF SITE` |
| fixture axis: `(is (vector? (quote ^{:audit true} [fx])))` | `DEAD PROOF SITE` | `DEAD PROOF SITE` — the control that localised the fault |
| fixture axis: stacked, `(is (= '^:audit ^:slow fx 1))` | **defects=0** | `DEAD PROOF SITE` |
| witness axis: `(map? fx)` + `(vector? '^{:audit true} [panel])` beside `(v/defview panel {:compiled true} …)` | **defects=0** | `UNWITNESSED MODE` |
| witness axis: the syntax-quoted twin | **defects=0** | `UNWITNESSED MODE` |
| witness axis: the `(quote …)` spelling | `UNWITNESSED MODE` | `UNWITNESSED MODE` — already red, same reason |
| `#_^{:audit true}` over `(def fx (conf/fixture :FH-CALL-001))` | **defects=0** | `DEAD PROOF SITE` |

Both quoted-vector assertions on the fixture axis evaluate **true in Clojure with
no `fx` binding in the image at all**, which is the plainest statement of what
they do not read.

The last row is a third surface, and it is the reason the fix went where it did:
`#_` discards a datum, so `#_^{:audit true} (def fx …)` discards the annotated
`def` — counted the short way only the metadata went, the `def` survived to bind
a fixture the reader never sees, and `census_discarded_proof_site` was defeated by
one annotation.

## The fix: one bounded reader-macro correction, inside the existing fence

`^` leaves `_PREFIXES` for its own constant `_META_PREFIX`, and `_datum_end` gains
one step:

```python
    if i < n and text[i] == _META_PREFIX:
        # The metadata datum, and then the datum it annotates.
        return _datum_end(text, _datum_end(text, i + 1))
```

Recursive, so the shapes that stack fall out of one rule rather than three:
`^:private ^:const x` annotates twice, `^{:doc "d"} 'x` annotates a datum carrying
its own prefix, `^:m ^:n [a b]` ends where the vector ends. `_prefix_end` stops at
a `^` because the datum a `^` introduces begins **at** the `^`, and how far it then
reaches is `_datum_end`'s question. (`_prefix_end` also loses a redundant inner
`@` step: `@` is itself in `_PREFIXES`, so `~@` was always read by the one loop.)

One regex-free step, in the one function all three reductions already ask. No
parse, no AST, no dependency. **A general Clojure parser was not built and is not
needed here**: this is a miscounted extent inside a mechanism that already exists.

**And the fix runs in both directions.** The same miscount was *costing* an honest
edge: `~^{:audit true} fx` inside a syntax quote reached only the metadata map, so
`fx` stayed blanked with the rest of the template and an honest row red at
`DEAD PROOF SITE`. It is green now. One arithmetic error gave a green away on one
axis and took one on another.

## Nothing honest was reddened and nothing was reclassified

Both scripts run over the **same tree**: the per-row `--report` table is
**byte-identical**, md5 `bdb95d24524b6a460a687b408a7b1a48`, 102 lines / 96
applicable rows — the reference md5 recorded on the bead, unchanged. All 96 rows
still reached by an assertion in a lane serving every mode/host cell they claim;
all 4 `compiled` rows still carrying a reachable, lane-scoped witness. No row
narrowed, no row marked inapplicable.

**The fix bites on real code, and the byte-identity is therefore evidence rather
than absence.** Measured across every `.clj/.cljc/.cljs` file under
`implementation/freehand/{src,test}`, on both platforms, the reduction changes for
two files — and the **symbol set is unchanged in both**, which is exactly why no
verdict moved:

* `test/…/a11y_diagnostics_cljs_test.cljc` (158 chars, 33 runs) — reader-quoted
  annotated hiccup, `'^{:rf.ui/suppress …} [:div …]`. Every differing run is
  content main kept and this branch correctly blanks.
* `src/…/rules.cljc` — `#?(:cljs ^boolean js/goog.DEBUG :clj true)`. Main's
  `_branch` mis-**paired** the arms: it returned `^boolean` for `:cljs` (losing
  `js/goog.DEBUG`) and *nothing at all* for `:clj` (losing `true`). Correct now.
  The census graph reads only the test tree, so this was a latent reader defect
  rather than a live census defect — and no test file writes the shape today.

The mis-pairing residue fails to the **loud** side: an odd datum count shifts a
later platform key onto an odd index, so it matches nothing and the arm comes back
empty. A lost arm costs a noisy defect on an honest row; it cannot credit a lane.

## Self-tests 85 -> 96, falsified in BOTH directions per axis

Eleven new cases, each pinning a defect **kind** and not merely a count: eight red
(five `DEAD PROOF SITE`, three `UNWITNESSED MODE`) and three green controls.

Splicing **only** the extent step back out (`^` returned to `_PREFIXES`, the
`_datum_end` step removed), self-tests otherwise untouched, moves **7 of the 11**:

```
census_metadata_reader_quote_shaped_like_the_fixture_binding        expected 1, got 0
census_metadata_syntax_quote_shaped_like_the_fixture_binding        expected 1, got 0
census_stacked_metadata_on_a_quoted_fixture_binding                 expected 1, got 0
census_metadata_on_a_discarded_proof_site                           expected 1, got 0
census_metadata_on_an_unquote_island_reads_the_fixture              expected 0, got 1
census_metadata_reader_quote_shaped_like_the_compiled_declaration   expected 1, got 0
census_metadata_syntax_quote_shaped_like_the_compiled_declaration   expected 1, got 0
```

All four axes the audit names — reader-quote and syntax-quote, on fixture
reachability and on compiled witnessing — are in that list, each with the paired
control that does **not** move:

* `census_metadata_quote_form_shaped_like_the_fixture_binding` and
  `…_the_compiled_declaration` were **already red**, and that is precisely their
  job: they show their twins differed from them by the prefix arithmetic alone.
* `census_metadata_on_an_evaluated_fixture_reference`
  (`(is (seq ^{:audit true} fx))`) and
  `census_metadata_on_an_evaluated_declaration_reference`
  (`(vector? [^{:audit true} panel])`) are the **over-tightening** controls — an
  annotation is not a quote, and reading the extent as "the caret swallows the
  target" rather than "the caret's *datum* is the pair" reds both honest rows.

**None of the pre-existing 85 moved in either direction.**

## `rf2-mom1g` considered and NOT fired

The standing ruling — *if a fifth census false-green axis appears, narrow the
fixture grammar rather than harden the reader again* — was evaluated and
deliberately **not** fired, on the test the mayor recorded: *can the fix be stated
as "this existing pass mis-handles form X" (fix it), or does it require the pass to
know something only evaluation knows (fire the rule)?*

This is the first: `_datum_end` mis-handles `^`. It needs no dataflow, no binding
resolution, no control flow and no macro expansion — nothing the lightweight
reader does not already have. The correction is arithmetic in a function that
already exists, and it is *shared*, which is why one step closed three surfaces.

I did not encounter a shape that cannot be closed lexically while doing it: `#`
dispatch forms, `#_` discard and reader conditionals all compose with the two-datum
rule through the same recursion (and `#_` and the conditionals were *improved* by
it). Had they not, the report would say so rather than growing a parser. The
stated bounds are unchanged and still the honest ones: granularity is the
statement, the `{:compiled true}` marker reading is textual, `interpreted` and
`common` carry no mode witness, a nested syntax quote's double unquote is not
modelled, and `#'x` resolves to nothing.

## One finding reproduced and deliberately NOT shipped here — `rf2-jl7gz`

A **tagged literal** is the same `#tag datum` shape and is still read as consuming
the tag alone:

```
_datum_end("#js {:a fx}")        -> "#js"      (should be the whole literal)
_datum_end('#inst "2020"')       -> "#inst"
_datum_end("#?(:clj x :cljs y)") -> "#?"
_datum_end("#?@(:clj [x])")      -> "#?@"
```

Reproduced against this branch's script: `(is (= '#js [fx] 1))` reads `fx` as a
live reference in both quote spellings, and `#_#?(:clj (def fx …))` discards only
the `#?`, leaving the `def` to bind a fixture the reader never sees.

**Latent today, and measured so rather than assumed.** `#js` appears **143 times**
in `implementation/freehand/test/` (plus 2 `#inst`, 2 `#uuid`, 1 `#queue`) and
**zero** of them sit behind a quote prefix or a `#_` — the only positions where
extent causes blanking. So no row is false-green from it now, and the `--report`
table would not move either way. It is a loaded gun, not a discharged one.

Not folded in, because this bead was scoped to `^` and I was asked not to hand back
a silent scope expansion. `rf2-mom1g` does not fire on it either — it is lexically
closable by the same recursion. It wants its own review because it needs an
**exclusion list** that `^` did not: `#'` is a var quote, and both `'` and `_` are
inside `_SYMBOL_HEAD`, so the naive "symbol character after `#`" rule mis-reads
`#'x`. That list is the part worth a reviewer's eye. Filed **`rf2-jl7gz`** (P2,
`discovered-from` this bead) with the reproduction, the exclusion list, and
red/control acceptance criteria in this bead's established idiom.

## Quality gates

All foreground to completion. `rc=$?` captured immediately after each runner into
a **worktree-local** log and cross-checked against that log's own PASS/FAIL lines
— nothing piped through `tail`/`grep` for its status, nothing backgrounded, no
trailing `echo` supplying a 0.

| Gate | Result | rc |
|---|---|---|
| `check_freehand_conformance_index.py --self-test` | **96/96** (was 85), 0 FAIL | **0** |
| the same 96 with the extent step spliced out | **7 FAIL**, as intended | **1** |
| live index + census | 0 defects; **97 rows / 96 active / 15-of-15 areas / 4-of-4 `compiled` witnessed** | **0** |
| `--report`, both scripts over the same tree | **byte-identical**, md5 `bdb95d24524b6a460a687b408a7b1a48`, 102 lines / 96 applicable rows | **0** |
| Freehand JVM suite (`clojure -M:test`) | **1099 tests / 7390 assertions, 0 failures 0 errors** | **0** |
| `test-fast-pr.sh` | PASS (classifier: `implementation_jvm=false`, `cljs_node_test=false`) | **0** |
| `python -m mkdocs build --strict` | clean, built in 27.46s | **0** |
| `check_doc_slugs.py` | clean | **0** |
| `check_readme_links.py` | clean | **0** |
| `check_donor_inventory.py --self-test` | all cases passed | **0** |
| `check_donor_inventory.py --ci --report` | clean, 53 donor tests | **0** |

`test-fast-pr.sh` **soft-skipped its own mkdocs step** ("mkdocs not on PATH"), which
is one of the documented false-green vectors, so `mkdocs build --strict` was run
separately via `python -m mkdocs` and reported on its own line above.

`npm run test:cljs` / `test:browser` **NOT RUN and not applicable**: the diff is
one Python script plus one spec README. `report-changed-surfaces.sh` reports
`implementation_jvm=false` and `cljs_node_test=false`; no CLJS source, fixture or
index row changed, and the byte-identical `--report` table is the evidence no row's
suite or lane moved. The `.shadow-cljs` cache caveat does not apply — no `.edn`
changed and no CLJS gate was believed.

The unfiltered required **`Freehand conformance index`** job — the job that runs
this very change on every PR — is **green in 27s** on this PR.
