### PR TITLE
perf(core): apply frame.cljc's own documented no-literal-path-get-in rule to the sites that missed it (rf2-sj5s7)

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -817,8 +817,8 @@
   may expose a half-constructed id by filtering raw `@frames` independently."
   [id f]
   (and (not (-> f :lifecycle :destroyed?))
-       (or (not= :provisional (get-in f [:construction :state]))
-           (let [owner (get-in f [:construction :owner])]
+       (or (not= :provisional (-> f :construction :state))
+           (let [owner (-> f :construction :owner)]
              (and (identical? owner *frame-transaction-owner*)
                   (owner-holds-frame-id? owner id))))))
 
@@ -904,7 +904,7 @@
   [id]
   (if-let [f (get @frames id)]
     (or (true? (-> f :lifecycle :destroyed?))
-        (let [token (get-in @destroying-frames [id :token])]
+        (let [token (:token (get @destroying-frames id))]
           (and (some? token)
                (identical? token (:drain-lock f)))))
     ;; Absent from the atom — destroy-frame!'s step 10 ran, OR the id
@@ -969,7 +969,7 @@
 
   Keyed by the bare frame-id; the incarnation is disambiguated by the token value."
   [id token]
-  (let [closing-token (get-in @destroying-frames [id :token])]
+  (let [closing-token (:token (get @destroying-frames id))]
     (and (some? closing-token) (identical? token closing-token))))
 
 (defn frame-address
@@ -2784,7 +2784,7 @@
         ;; this exact-token check fails construction before any side effect. A
         ;; stale marker from an already-dissoc'd incarnation does not match.
         (let [raw           (get @frames id)
-              closing-token (get-in @destroying-frames [id :token])]
+              closing-token (:token (get @destroying-frames id))]
           (when (and raw
                      (some? closing-token)
                      (identical? closing-token (:drain-lock raw)))
@@ -2885,10 +2885,10 @@
 
           ;; A provisional row without its matching reservation is internal
           ;; corruption, not a refreshable live frame. Fail closed.
-          (= :provisional (get-in existing [:construction :state]))
+          (= :provisional (-> existing :construction :state))
           (throw-frame-construction-in-progress!
             id :orphaned-provisional
-            (get-in existing [:construction :owner :kind]))
+            (-> existing :construction :owner :kind))
 
           ;; ---- must-create met a LIVE final frame → COLLISION ----------------
           ;; Exclusive mode never adopts or surgically refreshes; a present id is
@@ -3407,7 +3407,7 @@
     ;; EP-0001: machine snapshots are durable runtime-db state.
     (let [container  (runtime-db-container id)
           rt         (when container (adapter/read-container container))
-          machines   (get-in rt [:rf.runtime/machines :snapshots])
+          machines   (-> rt :rf.runtime/machines :snapshots)
           abort-http (late-bind/get-fn :http/abort-on-actor-destroy)]
       (doseq [[machine-id snapshot] machines]
         (when abort-http
@@ -3481,7 +3481,7 @@
                   id
                   (fn []
                     (when-let [current (frame id)]
-                      (let [marker-token (get-in @destroying-frames [id :token])]
+                      (let [marker-token (:token (get @destroying-frames id))]
                         (cond
                           (not (identical? candidate-token (:drain-lock current)))
                           ::retry-destroy-claim
@@ -3539,7 +3539,7 @@
   [id expected-token]
   (swap! destroying-frames
          (fn [claims]
-           (if (identical? expected-token (get-in claims [id :token]))
+           (if (identical? expected-token (:token (get claims id)))
              (dissoc claims id)
              claims))))
 

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -1700,7 +1700,7 @@
             ;; and accidentally read same-id B.
             pending-db  (if has-db?
                           (:db effects)
-                          (when run-on-db (get-in ctx [:coeffects :db])))
+                          (when run-on-db (-> ctx :coeffects :db)))
             ;; The pending runtime-db partition the flows read their qualified
             ;; inputs against: the handler's `:rf.db/runtime` effect when one
             ;; landed, else the current (unchanged) runtime-db. Only resolved
@@ -1710,7 +1710,7 @@
             pending-runtime-db (when run-on-db
                                  (if has-runtime-effect?
                                    (:rf.db/runtime effects)
-                                   (get-in ctx [:coeffects :rf.db/runtime])))
+                                   (-> ctx :coeffects :rf.db/runtime)))
             ;; Stamp `:rf.event/v` + `:rf.trace/event-id`
             ;; on the t1 / t2 trace events so they carry the same
             ;; per-event attribution every other `:op-type :rf.event`
@@ -2685,7 +2685,7 @@
             ;; (`marks/project-cofx-token-tags`) redacts per-cofx-id declared
             ;; `:sensitive` / `:large` slots before any off-box egress.
             run-cofx  (when interop/debug-enabled?
-                        (get-in initial-ctx [:coeffects :rf.cofx]))
+                        (-> initial-ctx :coeffects :rf.cofx))
             ;; rf2-yigokd — the envelope's OWN per-call + lexical
             ;; `:fx-overrides` / per-call `:interceptor-overrides` (NOT the
             ;; frame-merged `fx-overrides` local above — the per-frame tier is
@@ -3544,7 +3544,7 @@
     (fn []
       (let [drain-lock  (:drain-lock frame-record)
             router      (:router frame-record)
-            drain-depth (get-in frame-record [:config :drain-depth] drain-depth-default)]
+            drain-depth (get (:config frame-record) :drain-depth drain-depth-default)]
         (when (compare-and-set! drain-lock false true)
           ;; Exact-target revalidation belongs INSIDE the acquired serialization
           ;; boundary.  A scheduled callback for obsolete incarnation A must never
@@ -3592,7 +3592,7 @@
     (fn []
       (let [drain-lock  (:drain-lock frame-record)
             router      (:router frame-record)
-            drain-depth (get-in frame-record [:config :drain-depth] drain-depth-default)]
+            drain-depth (get (:config frame-record) :drain-depth drain-depth-default)]
         ;; Spin-CAS until we acquire. On JVM the active drainer holds
         ;; the lock for the duration of one drain pass — bounded by
         ;; drain-depth events at most — so the wait is bounded. CLJS
@@ -3639,7 +3639,7 @@
   [frame-id frame-record under-lock-fn]
   (let [drain-lock  (:drain-lock frame-record)
         router      (:router frame-record)
-        drain-depth (get-in frame-record [:config :drain-depth] drain-depth-default)]
+        drain-depth (get (:config frame-record) :drain-depth drain-depth-default)]
     ;; The outer cold section owns THIS record's lock.  Same-id replacement
     ;; invalidates the target; it does not retarget the synchronous dispatch.
     (when (frame/frame-incarnation-live? frame-id drain-lock)
@@ -4311,8 +4311,8 @@
         (when (and (identical? expected-token (:drain-lock frame-record))
                    (frame/frame-incarnation-closing? frame-id expected-token))
           (let [real-router     (:router frame-record)
-                drain-depth    (get-in frame-record [:config :drain-depth]
-                                       drain-depth-default)
+                drain-depth    (get (:config frame-record) :drain-depth
+                                    drain-depth-default)
                 envelope       (build-envelope event {:frame frame-id})
                 teardown-router (atom {:queue            (conj interop/empty-queue
                                                                envelope)

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -1316,7 +1316,7 @@
             (doseq [input-q input-signals]
               (release-input-ref! frame-id input-q :on-dispose))
             (swap! cache (fn [m]
-                           (if (identical? reaction (get-in m [k :reaction]))
+                           (if (identical? reaction (:reaction (get m k)))
                              (dissoc m k)
                              m)))))
         (let [installed (swap! cache (fn [m]
@@ -1342,10 +1342,10 @@
                     (swap-vals! cache
                                 (fn [m]
                                   (if (identical? winner-reaction
-                                                  (get-in m [k :reaction]))
+                                                  (:reaction (get m k)))
                                     (update-in m [k :ref-count] (fnil inc 0))
                                     m)))]
-                (if (identical? winner-reaction (get-in post [k :reaction]))
+                (if (identical? winner-reaction (:reaction (get post k)))
                   winner-reaction
                   ;; rf2-7w1im: the collision-retry rebuild stays fenced to the
                   ;; SAME captured incarnation.
@@ -1654,10 +1654,10 @@
                    (swap-vals! cache
                                (fn [m]
                                  (if (identical? reaction
-                                                 (get-in m [k :reaction]))
+                                                 (:reaction (get m k)))
                                    (update-in m [k :ref-count] (fnil inc 0))
                                    m)))]
-               (if (identical? reaction (get-in new [k :reaction]))
+               (if (identical? reaction (:reaction (get new k)))
                  reaction
                  ;; rf2-7w1im: the hit's concurrent-eviction rebuild carries the
                  ;; captured token so the rebuild is fenced to the SAME
@@ -2302,10 +2302,10 @@
                   (swap-vals! cache
                               (fn [m]
                                 (if (identical? reaction
-                                                (get-in m [k :reaction]))
+                                                (:reaction (get m k)))
                                   (update-in m [k :ref-count] (fnil inc 0))
                                   m)))]
-              (if (identical? reaction (get-in new [k :reaction]))
+              (if (identical? reaction (:reaction (get new k)))
                 {:reaction reaction}
                 (build-and-classify! frame-id query-v k)))
             (build-and-classify! frame-id query-v k)))


### PR DESCRIPTION
## What

Replace literal-path `get-in` with direct keyword access at the sites `rf2-sj5s7`
names in `frame.cljc`, `router.cljc` and `subs.cljc`, plus the same-shape siblings
found by sweeping those three files.

This is not a new optimisation policy. **`frame.cljc`'s own `frame` docstring already
prescribes exactly this fix** (lines 835-838):

> 2-level lookup written as keyword-invoke (`(-> f :lifecycle :destroyed?)`)
> rather than `(get-in f [:lifecycle :destroyed?])` — `get-in` allocates
> a path vector per call, and `frame` runs on every dispatch
> / subscribe through `current-frame` resolution.

`registrar.cljc` (lines 808-810) states the same rule for `lookup` and applies it
throughout — that file has zero `get-in` in code. The rule was applied to `frame`
and to `lookup`, and never to `frame`'s siblings sixty lines away. This PR applies
the file's own documented rule to the call sites that missed it.

## Why it is worth doing

From `rf2-ods8n` lens A (perf + back-compat audit), the one perf finding the audit
recommended taking unconditionally, because it is clarity-positive rather than a
trade-off:

- `jdk.ObjectAllocationSample` attributes **2.784 GB of 24.63 GB sampled weight
  (11.3%)** to `frame-incarnation-closing?` alone — three times the next re-frame
  site, and the largest single allocation source in the framework.
- The top two allocated classes overall are `PersistentVector$ChunkedSeq` (2.759 GB)
  and `ArrayChunk` (1.898 GB), 19% of all allocation combined. Both are the seq
  `get-in` builds over its literal path vector on every call.
- `frame-incarnation-closing?` runs 105 times per single `dispatch-sync` of a
  one-line `:db-write` handler.

## Scope

Representation-of-access only. No behaviour change, no caching layer, no memoised
resolver, no token threading, and no performance gate (`rf2-8o66x` records that
separately). `rf2-l260n` — the per-dispatch call-count hot spot the same audit filed
as record-only, because collapsing it means threading a token through a chain where
one function already takes eight positional args — is deliberately untouched.

Two sites in the swept files were **left alone on purpose**:

- `frame.cljc:836` — the docstring stating the rule.
- `subs.cljc:243` — a `reg-sub` docstring example. `(get-in db [:user :name])` over
  app-db is the idiomatic app-code form and is not a framework hot path.

### Substitutions used

| Original | Replacement |
| --- | --- |
| `(get-in @destroying-frames [id :token])` | `(:token (get @destroying-frames id))` |
| `(get-in m [k :reaction])` | `(:reaction (get m k))` |
| `(get-in f [:construction :state])` | `(-> f :construction :state)` |
| `(get-in ctx [:coeffects :db])` | `(-> ctx :coeffects :db)` |
| `(get-in frame-record [:config :drain-depth] default)` | `(get (:config frame-record) :drain-depth default)` |

All five are semantically identical. `get-in` resolves each step through `get`, and
keyword-invoke resolves through the same `RT.get`, including the nil-propagating and
non-`ILookup` cases. The three-arity `get` preserves the not-found default exactly:
`get-in` returns the default when the *final* lookup misses, and so does
`(get (:config r) :drain-depth default)` — a missing `:config` yields
`(get nil :drain-depth default)`.

Rather than assert that, I checked it: **61 cases across all five shapes agreed on
both value and identity** — absent outer key, absent inner key, nil map, empty map,
nil / `false` / zero leaf values, a non-associative inner value (`"a string"`, `42`,
a vector), `sorted-map`, `java.util.HashMap` at both levels, a `defrecord`,
non-keyword keys (string, vector), and every branch of the three-arity default
including the case where the default must NOT fire because the stored value is
`false` or `nil`.

One site is outside the literal-two-element shape: `frame.cljc:2891`
`(get-in existing [:construction :owner :kind])`, converted to `->`. It sits two
lines from `:2888`, which is in scope; converting one and leaving the other would
reproduce the exact inconsistency this bead is about, and `->` is the form the
docstring prescribes.

## Measurement

### Method — state it plainly

**These are JVM / plain-atom-adapter figures. They are NOT browser wall-clock, and
nothing here measures a bundle or a release build.** Temurin 21.0.10+7, Clojure
1.12.0, `implementation/core` `src` + the `:test` classpath, loaded from source.

- **A fresh JVM per configuration.** `before` is `HEAD~1`'s content of the three
  files; `after` is `HEAD`'s. Everything else — classpath, JDK, flags, machine — is
  identical, and the runs were interleaved `before, after, before, after…`.
- **Warm-up then `(System/gc)` immediately before each timed window.** 2M warm-up
  calls for the primitive, 50k warm-up dispatches for the end-to-end loop; three
  timed repetitions inside each JVM, best-of taken; three JVM pairs in total.
- **Allocation** from `com.sun.management.ThreadMXBean/getThreadAllocatedBytes` on the
  dispatching thread, not from a sampler. This is the figure I would defend.
- `debug-enabled?` was `true` — the heavier of the two paths the bead quotes
  (105 `frame-incarnation-closing?` calls per dispatch rather than 82).

### The access primitive — deterministic, identical in all six JVMs

|  | ns/call | **bytes/call** |
| --- | --- | --- |
| `(get-in m [k :token])` | 26.8 – 43.8 | **128.0** |
| `(:token (get m k))` | 10.4 – 21.7 | **0.0** |

The byte figures were *exactly* 128.0 and 0.0 in every one of the six JVMs — that is
the path vector plus its `ChunkedSeq`/`ArrayChunk` walk, and its removal. The timing
ratio came out 1.79x – 2.92x against the bead's 3.2x; I attribute the gap and the wide
ns spread to concurrent load on this box (other build workers), not to a difference in
the change.

### End-to-end `dispatch-sync`, 200k events

| | before | after | delta |
| --- | --- | --- | --- |
| **bytes/event** (median of 3) | 78,569 | 61,193 | **−17,376 (−22.1%)** |
| bytes/event (within-config spread) | 0.35% | 1.8% | — |
| us/event (median of 3) | 45.81 | 39.03 | −14.8% |
| us/event (min of 3) | 45.52 | 36.48 | −19.9% |
| us/event (max of 3) | 48.04 | 44.73 | — |

**The allocation number is the trustworthy one** and it is the bead's actual claim:
the within-configuration spread is 0.35% / 1.8%, while the before/after gap is 28% of
the after value — orders outside the noise band.

**The wall-clock number deserves a caveat rather than a headline.** The after band
(36.5 – 44.7 us) and the before band (45.5 – 48.0 us) do not overlap across three
pairs, so the direction is real, but n=3 on a machine running concurrent
shadow-cljs/Chromium work is not a basis for quoting a precise percentage. Read it as
"roughly 15% on this box, on this workload", not as a specification.

Consistent with the audit and with `rf2-8o66x`: **no performance gate is added here.**

## Quality gates

Run in this worktree, `rc` captured into a worktree-local log immediately after each
command and cross-checked against the log's own PASS/FAIL lines (per the known
false-green vectors: pipe status, trailing `echo`, `test-fast-pr.sh`'s soft mkdocs
skip, silently-skipped lane-suffix-less `.cljc` test namespaces, and the backgrounding
harness disagreeing with a captured `rc`).

| Gate | Result | `rc` |
| --- | --- | --- |
| `implementation/core` `clojure -M:test` | **2115 tests / 10456 assertions, 0 failures, 0 errors** — matches the stated baseline exactly | 0 |
| `npm run test:cljs` | **11438 tests / 57234 assertions, 0 failures, 0 errors** | 0 |
| `npm run test:cljs` on **pre-patch sources**, same worktree, same `node_modules` | **11438 tests / 57234 assertions, 0 failures, 0 errors** — identical | 0 |
| `scripts/test-fast-pr.sh` | log's own verdict line reads **`PASS fast PR spine`**; its embedded core JVM run also reported 2115 / 10456, 0 failures | 0 |
| Substitution equivalence probe (61 cases, all five shapes) | **PASS** | 0 |

For `test-fast-pr.sh` the captured `rc`, the backgrounding harness's reported exit
code, and the log's own `PASS fast PR spine` line all agree. The only `FAIL` strings in
that log are two self-test *descriptions* exercising the gate's own failure path, not
failures. The script honestly names what it did **not** run:

- `mkdocs --strict build` — soft-skipped, mkdocs not on PATH. CI skipped MkDocs too,
  because this diff has no docs surface, so the current Google-Fonts 503 never applied.
- 17 of 18 implementation JVM artefact suites (only `core` ran locally).
- Browser lanes, prod-elision / bundle-isolation / perf gates, adapter probes and
  smokes, Xray feature matrix, mcp-conformance, tool JVM suites.

**Every one of those was covered by CI on this PR: 60 checks passed, 13
surface-gated skips, zero failures** — including all the JVM artefact suites, both
`:advanced` + `goog.DEBUG=false` prod-elision lanes, bundle isolation, and the ui G-1 /
G-8 / G-13 / G-18 gates. The prod-elision and `:advanced` lanes matter here: they are
what would catch a keyword-invoke behaving differently from `get` under advanced
compilation.

The brief's `test:cljs` baseline of ~11423 / 57166 is stale — `main` moved. Rather
than assume that, I re-derived it: I reverted the three files to their `HEAD~1`
content in this same worktree and re-ran, giving **11438 / 57234, byte-identical to
the patched run**. The diff also touches no test file
(`git diff --stat HEAD~1 HEAD -- '*test*'` is empty), so the suite composition cannot
have moved. This is behaviour-preserving, so an unchanged suite at an unchanged count
*is* the deliverable.

Closes rf2-sj5s7.
