### PR TITLE
ssr,core: stop naming day8/re-frame2-ui as the canonical boot and as the consumer in two shipped error strings (rf2-jzrg1)

### DIFF
--- a/implementation/core/src/re_frame/substrate/observation.cljc
+++ b/implementation/core/src/re_frame/substrate/observation.cljc
@@ -553,10 +553,11 @@
   axis) when `expected` ≠ [[port-abi-version]]. Returns nil on a match."
   [expected]
   (when (not= expected port-abi-version)
-    (let [reason (str "re-frame2-ui was compiled against observation-port ABI "
-                      "version " (pr-str expected) " but this core exports "
-                      port-abi-version "; core and re-frame2-ui release on a "
-                      "lockstep train — align the two artifact versions.")]
+    (let [reason (str "an observation-port consumer was compiled against "
+                      "observation-port ABI version " (pr-str expected)
+                      " but this core exports " port-abi-version
+                      "; core and its port consumers release on a lockstep "
+                      "train — align the two artifact versions.")]
       (error-emit/emit-error-both!
         :rf.error/observation-port-version-mismatch
         nil nil nil nil 0 (interop/now-ms)
@@ -1356,8 +1357,9 @@
                                  "production observability. The escape is "
                                  "contained (siblings still notified) and rides "
                                  "as this record's :exception cause — the "
-                                 "underlying on-change consumer bug is a "
-                                 "re-frame.ui defect to fix.")
+                                 "underlying bug is a defect in the "
+                                 "observation-port consumer that registered the "
+                                 "callback.")
          :recovery          :no-recovery}))))
 
 (defn ^:no-doc drain-pending-disposals!

--- a/implementation/ssr/src/re_frame/ssr/boot.cljc
+++ b/implementation/ssr/src/re_frame/ssr/boot.cljc
@@ -188,19 +188,26 @@
                  **The render-tree hash is HICCUP-TIER-ONLY** (Spec 011
                  §Hydration-mismatch detection, the two-tier split). It applies
                  to substrates whose view is a pure fn returning a hashable
-                 render-tree — Reagent / UIx, where `((rf/view :app/root))`
-                 yields hiccup. The COMPILED-UI substrate (`re-frame.ui`) has NO
-                 hashable client render-tree — its views compile to React
-                 elements, not the structural tree the server hashes — so it does
-                 NOT pass `:render-tree-fn`. **The canonical compiled-ui boot is
-                 `ssr/hydrate!` WITHOUT `:render-tree-fn`, then `ui/hydrate-root`**:
-                 the compiled root VERIFIES by React-native ADOPTION (React diffs
-                 its first `:server`-phase render against the server DOM during
-                 hydration and reports divergence through `onRecoverableError`,
-                 surfaced as `:rf.ssr/hydration-mismatch` — see
-                 `re-frame.ui.runtime/emit-hydration-mismatch!`). The
-                 `:ssr {:on-mismatch :hard-error}` escalation is likewise
-                 hiccup-tier-only.
+                 render-tree — **Reagent and UIx, the published view adapters**,
+                 where `((rf/view :app/root))` yields hiccup. That is the boot a
+                 consumer of `day8/re-frame2-ssr` takes: `ssr/hydrate!` WITH
+                 `:render-tree-fn`, then the adapter's own render.
+
+                 A COMPILED-VIEW substrate has NO hashable client render-tree —
+                 its views compile to React elements, not the structural tree the
+                 server hashes — so it does NOT pass `:render-tree-fn`: it calls
+                 `ssr/hydrate!` without one and then hydrates its own root
+                 (`v/hydrate-root` on Freehand), VERIFYING by React-native
+                 ADOPTION instead — React diffs its first `:server`-phase render
+                 against the server DOM during hydration and reports divergence
+                 through `onRecoverableError`, surfaced as
+                 `:rf.ssr/hydration-mismatch`. Freehand is in-tree /
+                 pre-publication. The `re-frame.ui` compiled substrate (whose
+                 counterpart emitter is `re-frame.ui.runtime/emit-hydration-mismatch!`)
+                 is DONOR-ONLY code being absorbed into Freehand — `day8/re-frame2-ui`
+                 is not a Maven coordinate and never will be, so do not reach for
+                 `ui/hydrate-root` as a boot. The `:ssr {:on-mismatch :hard-error}`
+                 escalation is likewise hiccup-tier-only.
 
   Opts:
 


### PR DESCRIPTION
Follow-up to #6989, which merged a branch state **older than my tip**: it landed rf2-p6wwy and rf2-ynd90 (as `2182eab657` / `12abbdced3`) but not the third commit, which I pushed after the merge. Verified on `origin/main` — both old error strings and the "canonical compiled-ui boot" docstring are still there. This PR is that commit, rebased onto current `main`; nothing else.

Closes rf2-jzrg1. (rf2-p6wwy and rf2-ynd90 landed in #6989.)

## The problem

Three sites inside the **published** artefacts pointed a consumer at `day8/re-frame2-ui`, a coordinate that will never exist. `docs/release-process.md` policy 3 is normative on that — Mike ruled 2026-07-22 that the artefact is not to be published — and `implementation/ui/deps.edn` carries no `:clein/build`, with a comment saying the omission is deliberate. I confirmed the thirteen coordinates a `v*` tag does publish three independent ways, all agreeing: `release.yml`'s `deploy-core` + `deploy-leaf` matrix + `deploy-ssr-ring` stage and its release-notes body; `node implementation/scripts/lib/publishable-runtimes.cjs implementation`; and `verify-version-lockstep.sh:112`'s `ARTEFACTS` array. `day8/re-frame2-ui` is in none of them.

## What I found vs what I changed

**A. `hydrate!`'s public docstring** — `implementation/ssr/src/re_frame/ssr/boot.cljc:195`, as filed:

> **The canonical compiled-ui boot is `ssr/hydrate!` WITHOUT `:render-tree-fn`, then `ui/hydrate-root`**

A consumer of the published `day8/re-frame2-ssr`, reading its hydration entry point, is told the canonical path runs through a root fn they cannot obtain. This is precisely the line the two precedents from 2026-07-25 draw: the three `docs/api/re-frame.ui*.md` pages were **kept** with an admonition, and Spec 004D **reclassified** the retired frame family as donor-only rather than deleting it — because a donor mention in a clearly-labelled donor context is correct. A donor spelling presented as *the canonical thing to use* is the defect.

**Changed.** The hiccup tier is now stated as the boot a consumer of the published artefacts actually takes — Reagent and UIx, `ssr/hydrate!` **with** `:render-tree-fn`. The compiled-view tier is described generically in its own paragraph: no `:render-tree-fn`, then the substrate hydrates its own root (`v/hydrate-root` on Freehand), verifying by React-native adoption. `re-frame.ui` survives as an explicitly **donor-only** reference with the coordinate fact attached, and the docstring now says plainly not to reach for `ui/hydrate-root` as a boot. The verification mechanism is unchanged in substance — React diffing its first `:server`-phase render against the server DOM and reporting divergence through `onRecoverableError`, surfaced as `:rf.ssr/hydration-mismatch`; only the "canonical" framing and the unqualified `ui/*` naming moved.

**B. Two user-visible runtime `:reason` strings** in `implementation/core/src/re_frame/substrate/observation.cljc`, as filed:

- `:556-559` — the ABI-skew guard: *"re-frame2-ui was compiled against observation-port ABI version … core and re-frame2-ui release on a lockstep train"*. Reaches a user as `ex-message` on a thrown boot error **and** as the `:reason` on an always-on error record, so an off-box shipper carries it too.
- `:1360` — `:rf.error/observation-on-change-failed`: *"the underlying on-change consumer bug is a **re-frame.ui** defect to fix"*, same two-channel visibility.

**One extra finding worth recording:** both strings are wrong on their own terms, independent of publication. `port-abi-version` has **two** consumers today, not one — `implementation/freehand/src/re_frame/freehand/cell.cljc:101` and `implementation/ui/src/re_frame/ui/reactive.cljc:231` both declare the v2 ABI, and the surviving one is Freehand. So naming a single artefact in the diagnostic misdirected a Freehand consumer as well as citing a coordinate that does not publish. The generic framing the bead asks for is also the more accurate one.

**Changed.** Both now read "an observation-port consumer" / "the observation-port consumer that registered the callback", naming the **port versions** and the lockstep train rather than any artefact — exactly acceptance criterion 2.

**Error-string safety.** Grepped both literals across the whole tree before editing: no test, fixture, or conformance corpus asserts on either. `ex-data` is untouched — `:rf.error/id`, `:where`, `:expected`, `:actual`, `:recovery` are byte-identical, so no machine discriminator moved and nothing that branches on one is affected. No behaviour change beyond message text.

## Named, not actioned — out of this bead's stated scope

The bead was deliberately scoped small: the same sweep found ~108 `re-frame.ui` references across 20 files in the thirteen published trees, and everything not listed above is legitimate provenance for copied version-pinned tables. Three items I hit while verifying, which are **not** the `rf2-snjn5` "flips at the tag" class and so need their own bead:

1. **`re-frame.ui`'s "pre-publication" framing implies eventual publication.** `spec/Conventions.md`'s `day8/re-frame2-ui` row and `spec/006-ReactiveSubstrate.md`'s adapter-inventory row both say "**Not yet published** … the coordinate is not yet consumable", and the 006 row adds "publication is owned by rf2-vxgfnd.99.2". Per the 2026-07-22 ruling it will *never* publish, so "not yet" plus a named publication owner is wrong in the opposite direction from the sites `rf2-snjn5` tracks — the tag does not fix it. The `docs/api/re-frame.ui*.md` admonition ("is not a Maven coordinate and never will be") is the shape the fix should take. Two hot-zone spec files.
2. **`spec/009-Instrumentation.md`'s error-catalogue row** for `:rf.error/observation-on-change-failed` paraphrases the `:reason` I generalised here — it still says "a `day8/re-frame2-ui` ViewCell mark-dirty defect" and closes "The underlying `on-change` consumer bug is a re-frame.ui defect to fix". Spec prose rather than runtime output, hot-zone file, and now one generalisation behind the code.
3. **`port-abi-version`'s own docstring** (`observation.cljc:535`) still reads "`day8/re-frame2-ui` records the version it compiled against", and Spec 006 §The internal observation port describes the port's consumer set as a single artefact. Two consumers declare the ABI, per the finding above.
4. **`core/late_bind/directory.cljc:737`**'s hook `:description` says "`ui/hydrate-root` is the DOM-adoption call, so the two-call boot model stays the public contract". Closer to the defect I fixed than the other residue, but it is directory data read by a drift test rather than a public docstring or runtime output, and it names `re-frame.freehand.root/hydrate-root` alongside the donor in the same sentence — so it reads as donor-plus-successor context, not as *the canonical thing to use*. Left as-is; recorded here so the sweep does not have to be re-derived.

**To confirm the residue count I re-swept it myself** rather than taking the bead's word: grepping string literals (not comments) for `re-frame.ui` / `re-frame2-ui` across all eleven published source trees returns only late-bind directory `:description` fields plus the `port-abi-version` docstring. The bead's "only two user-visible runtime strings" is correct, and both are fixed here.

## Deliberately NOT changed — the rf2-snjn5 boundary

Every "the artefacts are not published yet" claim in the corpus is **true today** and flips only when the operator cuts the tag. Untouched on purpose, including `skills/re-frame2-setup/references/deps-versions.md`. The one place I state a publication fact — "`day8/re-frame2-ui` is not a Maven coordinate and never will be" — is true both before and after the tag, which is what makes it safe to write now.

## Quality gates

Run from the worktree root `C:/Users/miket/code/re-frame2-worktrees/install-truth`, each `rc` captured immediately into a worktree-local log and cross-checked against the log's own PASS/FAIL and `0 failures, 0 errors` lines rather than trusting the exit code alone. Every gate was also run **before** the first edit, so a green below is a green diff and not merely a green tree.

| Gate | rc | Evidence in log |
|---|---|---|
| `implementation/core` `clojure -M:test` | `0` | `Ran 2115 tests containing 10456 assertions. 0 failures, 0 errors.` — the suite covering both rewritten error strings |
| `implementation/ssr` `clojure -M:test` | `0` | `Ran 528 tests containing 2539 assertions. 0 failures, 0 errors.` — the artefact carrying the docstring edit |
| `python scripts/check_thrown_error_messages.py` | `0` | the gate that actually covers the two `:reason` rewrites — both messages remain human sentences derived through `error/thrown-ex-info` |
| `python scripts/check_donor_inventory.py` | `0` | its census matches `[re-frame.ui…` libspecs and `day8/re-frame2-ui {` in dependency position; this diff strictly *reduces* donor mentions and adds neither shape |
| `python scripts/check_keyword_catalogue_drift.py` | `0` | |
| `python -m mkdocs build --strict` | `0` | run **separately** — `test-fast-pr.sh` soft-skips its own mkdocs step and still exits 0, so it does not cover a docs diff. No Google Fonts 503 on this run. |
| `python scripts/check_doc_slugs.py` | `0` | |
| `python scripts/check_retired_spellings.py` | `0` | |
| `python scripts/check_readme_inventories.py` | `0` | |
| `python scripts/check_readme_links.py` | `0` | |
| `clojure -M -m re-frame.api-manifest.gen --check` | `0` | `hydrate!`'s manifest row is unchanged; `spec/api-manifest.edn` carries no docstrings, so a docstring rewrite cannot move it |
| `clojure -M -m re-frame.api-manifest.ui-context --check` | `0` | |
| `clojure -M -m re-frame.api-manifest.api-md-check` | `0` | |
| `clojure -M -m re-frame.api-manifest.doc-api-check` | `0` | |
| `clojure -M -m re-frame.api-manifest.skills-check` | `0` | |
| `clojure -M -m re-frame.api-manifest.doc-guide-check` | `0` | |
| `sh scripts/test-fast-pr.sh` | **`1` — RED, isolated to one untouched deftest** | see below |

The doc / skill / manifest gates above were run against the full three-bead tree (all seven files) before #6989 merged, so they cover the two files here as well as the five that already landed.

### The `test-fast-pr.sh` failure — load-induced, not this diff

I hit two of the documented false-green vectors on this run and want both on the record.

**1. The spine soft-skipped its own mkdocs step.** Verbatim from the log: `SKIP mkdocs --strict build: mkdocs not on PATH (CI will run this; local soft-skip OK)`. This is why `python -m mkdocs build --strict` is run separately above — the spine does not cover a docs diff.

**2. The backgrounding harness reported "exit code 0" for a run whose log says `FAIL CLJS node integration`.** I did not take the wrapper's word for it; the log's own tally is authoritative:

```
Ran 11438 tests containing 57241 assertions.
4 failures, 0 errors.
FAIL CLJS node integration
```

**All four failures are the same deftest** — `real-shadow-node-green-run-is-quiet` in `implementation/test-quiet/test/re_frame/test_quiet_shadow_node_cljs_test.cljs`, at `:413`, `:415`, `:433`, `:436`. The first one is the cause and the other three cascade from it:

```
spawning the real runner must not error;
got: #object[Error Error: spawnSync C:\Program Files\nodejs\node.exe ETIMEDOUT]
```

**Why this cannot be my diff.** The assertion that failed is `(is (nil? err))` where `err` is `spawnSync`'s **process-spawn** error — a wall-clock timeout, not an assertion about any behaviour. The test re-spawns the *entire* compiled `out/node-test.js` bundle as a child process (`--test=re-frame.test-quiet-green-fixture-cljs-test`) against `spawn-timeout-ms` = **60000**, while the parent's own 11438-test run is still finishing, on Windows. The remaining three assertions then fail because `res` came back empty. My diff changes one docstring in `re-frame.ssr.boot` and two message strings in `re-frame.substrate.observation` — neither is on `test-quiet`'s spawn path, and neither can slow a process spawn or alter the green fixture's output. `implementation/core`'s own 2115-test JVM suite passed inside the same spine run (`0 failures, 0 errors.`), as did the standalone `implementation/ssr` run.

**Corroboration:** CI is green on the counterpart Linux runners — `JVM core (clojure -M:test)` **pass**, and 58 pass / 0 fail across the run at time of writing, with `CLJS (shadow-cljs :node-test)` still in flight. Note also that this test file was last touched **today** by `db32e1eaba` (rf2-qqzmf, "fail a zero-test run on every whole-suite lane"), which is in my base — so if the flake proves reproducible on quiet hardware it belongs to that change, not to this PR. Flagging rather than papering over it: if CI's `:node-test` job comes back red on the *same* deftest, that is a real regression in rf2-qqzmf's surface and wants its own bead; if it comes back green, the local failure was load.
