### PR TITLE
docs,ci: correct the auth tutorial's 401 claim and reconcile the two test-lane rosters (rf2-boyep, rf2-as6bg)

### DIFF
--- a/docs/resources/tutorial/03-auth-and-forms.md
+++ b/docs/resources/tutorial/03-auth-and-forms.md
@@ -562,7 +562,7 @@ The return trip is an ordinary fresh navigation: the guard runs again and — no
 
 ??? info "Coming from Axios?"
 
-    Your redirect-on-401 *response* interceptor is gone entirely, not relocated. The gate now sits on the route declaration, one layer above any request: it stops the navigation *before* a request exists, because it already knows there is no user.
+    Your redirect-on-401 *response* interceptor was doing two jobs, and only one of them moves here. The **gating** job — bounce a visitor who trips a 401 on a page they should never have opened — is gone entirely, not relocated: the gate now sits on the route declaration, one layer above any request, and stops the navigation *before* a request exists because it already knows there is no user. The **session-expiry** job stays exactly where it was, on the response side. `:can-enter` can only be as fresh as the auth state it reads, so it cannot notice a token that dies *after* entry was allowed; the next authenticated request is where that arrives. [Sign out](#sign-out) carries the `:after` hook.
 
 Watch it fire. Signed out, click *Settings*. In Xray the navigation row is followed by the `:rf.route/entry-denied` dispatch and then your redirect to the login route — and no `[:settings/load]` row anywhere, because the route never committed. Sign in, and the ledger shows the bounce back to `/settings`: the stash paying off.
 
@@ -615,6 +615,25 @@ Teardown is just setup reversed, in one event. Wire `(dispatch [:auth/logout])` 
 ```
 
 Nothing else to unhook, which is the nice part. The bearer interceptor reads app-db per request, so the header stops the instant the token is `nil`. The guard starts intercepting again for the same reason. State went away, and behaviour followed. That's the whole dividend of keeping the session *in* app-db rather than in scattered closures: there's exactly one place to clear, and everything that read it goes quiet on its own.
+
+### The second trigger: the server signs you out
+
+The navbar is not the only thing that ends a session. A JWT that was valid at boot expires while the reader sits on `/settings`, and the route guard cannot notice — it reads cached auth state, and that state still says *signed in*. Entry was already allowed; the next authenticated request is where the truth turns up. So catch it on the response side of the interceptor chain you registered for `bearer-auth` — same chain, other leg:
+
+```clojure
+(rf/with-frame :rf/default
+  (rf/reg-http-interceptor :conduit/expired-session
+    {:after (fn [ctx response]
+              (when (and (= :error (:status response))
+                         (= :rf.http/http-4xx (get-in response [:error :kind]))
+                         (= 401 (get-in response [:error :status])))
+                (rf/dispatch [:auth/logout] {:frame (:frame ctx)}))
+              response)}))                     ;; :after MUST return the response
+```
+
+Two details earn their keep. Mind the **two `:status` levels**: the reply envelope's `:status` is `:error`, and the HTTP code lives *inside* the failure map at `[:error :status]`, under a framework-owned `:kind` — branch on those, never on a stringified message. And carry the frame from `ctx`: the reply arrives in a transport callback, where a bare `rf/dispatch` can hit `:rf.error/no-frame-context`.
+
+There is nothing new to clear, and that is the point. `:auth/logout` already drops `:auth`, wipes the persisted JWT, and moves the reader off the page they can no longer see — so logout gained a second trigger, not a second code path. (Send them to `:conduit.auth/login` instead of `:conduit/home` if you'd rather; it's the one keyword.) Note the *shape* of this response: the expired token is discarded, not refreshed. Trading it for a fresh one and replaying the original request is semantic retry — a bigger job, and [a machine's](#when-a-machine-is-the-better-tool). [Add authentication](../../core/how-to/add-auth.md) carries the full response-hook treatment, including the chain's failure semantics.
 
 !!! note "What about the previous user's cached server data?"
 


### PR DESCRIPTION
Two beads on disjoint surfaces: a false docs claim and a CI/local test-lane roster disagreement.

## 1. `rf2-boyep` — the resources auth tutorial falsely retired response-side 401 handling

**What I found.** The claim is *half* false, and the half that is false is the one that matters.

`docs/resources/tutorial/03-auth-and-forms.md` said, in a "Coming from Axios?" callout:

> Your redirect-on-401 *response* interceptor is gone entirely, not relocated.

An Axios redirect-on-401 interceptor does two jobs:

| job | verdict |
| --- | --- |
| **gating** — bounce a visitor who trips a 401 on a page they should never have opened | genuinely retired. `:can-enter` stops the navigation before a request exists. |
| **session-expiry** — a token that was valid at entry dies mid-session; clear the cached and persisted credential | **not** retired, and cannot be. |

`:can-enter` is only as fresh as the auth state it reads, so it cannot notice a token that dies *after* entry was allowed. Verified against source, not inferred:

- `docs/core/how-to/add-auth.md` teaches exactly this hook (`:my-app/expired-session`) and its step 3 says the 401 response hook "is what turns that into a clean logout, and it is why the optimistic restore below is safe rather than sloppy."
- `spec/014-HTTPRequests.md` §Middleware names "flag a 401 for auth refresh (response side)" as one of the motivating high-frequency response-side cases (§ lines 768, 814).
- `spec/Pattern-Boot.md` is explicit that `:refreshing` "is the answer to 'the token expired mid-session'", and that init's 401 is the *different* case.
- Nothing in `implementation/` handles 401 automatically — the only repo-wide hit outside tests is an SSR error-projector comment about *custom* projectors injecting 401/403.

The tutorial taught no response-side 401 hook anywhere. Its only 401-adjacent handler is `:auth/session-expired`, wired to the boot restore's `:on-failure` — cold boot only. So a reader following the tutorial ships an app where an expired token leaves `[:auth :user]`/`[:auth :token]` populated, the persisted JWT on disk, and protected routes apparently allowed, while every request 401s.

**What I changed.** One file, two edits.

1. Split the Axios callout into the two jobs, saying which moves and which stays, and why the guard structurally cannot cover the second. Points at the Sign out section.
2. Added `### The second trigger: the server signs you out` to the Sign out section — the `:after` hook, reusing the `:auth/logout` the section defines two paragraphs above, which already drops `:auth` and wipes the persisted JWT. Notes the two `:status` levels and the frame-carried dispatch (the reply runs in a transport callback).

**Deliberately not changed**, per the settled decisions around this file:

- The synchronous-restore recipe in `docs/core/how-to/add-auth.md` — untouched; that file has no diff.
- The Conduit tutorial's *async* restore, which is intentional (it holds only a bearer token and must exchange it) — untouched, including both restore outcomes and the cold-boot deferral in `:rf.route/entry-denied` / `:auth/settle-deferred-entry`.
- `:can-enter` stays a closed boolean. No tri-state guard proposed; the denial handler keeps owning "not known yet".
- No `{:sensitive …}` ceremony on the new registration — bare, correct.
- No retry machinery. The hook *discards* the expired token; refreshing and replaying is semantic retry, and the text says so and points at the existing machine section.

No executable example code changed, so no auth regression test was needed (the acceptance criterion gates that on executable changes).

## 2. `rf2-as6bg` — the two test-lane rosters

PLACEHOLDER — filled in below on the second commit.

## Quality gates

PLACEHOLDER
