### PR TITLE
test(epoch),chore(api-manifest): make two blind gates see their whole surface (rf2-isp3i, rf2-ivuun)

### DIFF
--- a/docs/api/re-frame.resources.md
+++ b/docs/api/re-frame.resources.md
@@ -309,24 +309,34 @@ A resource (or payload, or route) references a named resolver as `{:from-db <sco
 
 Active-stale revalidation is expressed as **resource events** (see [`[:rf.resource/window-focused]` / `[:rf.resource/network-reconnected]`](#rfresourcewindow-focused--rfresourcenetwork-reconnected)) — never subscription-driven fetching. On window focus, tab-return, or network reconnect, the runtime rescans the frame's active-owner **stale** entries and refetches them by policy. A stale entry with no active owner is left alone: revalidation creates no liveness. The host-listener install/remove fns below wire and tear down the `window` listeners that dispatch those events.
 
-### `install-revalidation-listeners!` / `remove-revalidation-listeners!`
+### `install-revalidation-listeners!`
 
 - **Kind**: function (post-v1 lib)
 - **Signature**:
   ```clojure
   (install-revalidation-listeners! frame-id)   ;; → nil
-  (remove-revalidation-listeners!  frame-id)   ;; → nil
   ```
-- **Description**: `install-revalidation-listeners!` wires three host listeners for `frame-id`, each dispatched at `frame-id`:
+- **Description**: Wires three host listeners for `frame-id`, each dispatched at `frame-id`:
   - `focus` (on `window`) and `visibilitychange`-to-visible (on `document`, its only valid event target) → `[:rf.resource/window-focused]`.
   - `online` (on `window`) → `[:rf.resource/network-reconnected]`.
 
-  Installation is idempotent: re-installing replaces, never stacks, so it is hot-reload safe. It is CLJS-only; the JVM/SSR arm is a no-op. Listeners are recorded in a host side table and cancelled on frame destroy via the single `:resources/on-frame-destroyed!` hook. `remove-revalidation-listeners!` tears them down — useful for test isolation, and for single-page hosts that rotate which frame owns revalidation. It is a no-op when none is installed.
+  Installation is idempotent: re-installing replaces, never stacks, so it is hot-reload safe. It is CLJS-only; the JVM/SSR arm is a no-op. Listeners are recorded in a host side table and cancelled on frame destroy via the single `:resources/on-frame-destroyed!` hook.
 
 ```clojure
 ;; at boot, after the frame is live: wire focus / visibility / online revalidation
 (rf/install-revalidation-listeners! :rf/default)
+```
 
+### `remove-revalidation-listeners!`
+
+- **Kind**: function (post-v1 lib)
+- **Signature**:
+  ```clojure
+  (remove-revalidation-listeners! frame-id)   ;; → nil
+  ```
+- **Description**: Tears down the listeners [`install-revalidation-listeners!`](#install-revalidation-listeners) wired for `frame-id` — useful for test isolation, and for single-page hosts that rotate which frame owns revalidation. A no-op when none is installed. Frame destroy already tears them down via the `:resources/on-frame-destroyed!` hook, so this is for the cases where the frame outlives its revalidation ownership.
+
+```clojure
 ;; tear them down (test isolation, or when another frame takes over revalidation)
 (rf/remove-revalidation-listeners! :rf/default)
 ```

--- a/implementation/epoch/test/re_frame/epoch_mcp_egress_conformance_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_mcp_egress_conformance_test.clj
@@ -9,7 +9,12 @@
   Here we exercise the full off-box-forwarder pattern an MCP server runs:
 
     1. Build a realistic mixed ring (sensitive + large + bookkeeping-only
-       records, halted-destroy records, the empty case).
+       records, halted-destroy records, the empty case). `large` means BOTH
+       shapes a large value can arrive in: the app-db PATH declaration and
+       the whole-output `:large?` sub REGISTRATION stamp (rf2-isp3i). The
+       second is not app-db-rooted, so a fixture that declared only paths
+       left this gate's own claim — no raw large bytes ANYWHERE — scanning
+       a record the shape never appeared in.
     2. Run the ring through `projected-record` (per-record forwarder shape,
        e.g. `register-epoch-listener!` ship!) AND `projected-history` (bulk-egress
        shape, e.g. `watch-epochs` initial snapshot).
@@ -77,6 +82,21 @@
 (def ^:private secret-password "topsecret-do-not-leak")
 (def ^:private payload-size    25000)
 
+;; rf2-isp3i — the whole-output `:large?` SUB shape. A `:large?` stamp on a
+;; `reg-sub` is a REGISTRATION marker, not an app-db path declaration, so the
+;; app-db-rooted classification this fixture installs below structurally cannot
+;; reach it. Before this widening the fixture inhabited only the path shape, and
+;; the "no raw large bytes anywhere" scans below therefore ran over a record
+;; that had no sub-output slot in it at all — which is how rf2-irwsq shipped a
+;; 25000-char payload raw at `[:trace-events <i> :tags :rf.sub/value]` past this
+;; very gate.
+(def ^:private large-sub-id   :sub/whole-output-large)
+;; An UNMARKED sibling sub whose value rides the same two egress slots. It is
+;; the negative control: if the elision below ever became a blanket truncation
+;; (or the fixture stopped reading subs), this value would stop arriving raw.
+(def ^:private control-sub-id :sub/unmarked-control)
+(def ^:private control-note   "mcp-egress-unmarked-control")
+
 (defn- install-mcp-style-schemas!
   "A realistic mixed classification set: one sensitive path
   (`[:auth :password]`) and one large path (`[:blob :payload]`) against
@@ -113,6 +133,22 @@
     - :upload — writes the large path (large payload closed-over in the
                 handler for the same reason)
     - :inc — non-sensitive again
+    - :read-subs — reads a whole-output `:large?` sub and an unmarked
+                   control sub (rf2-isp3i). This is the SECOND large
+                   shape, and it is not app-db-rooted: the `:large?`
+                   stamp rides the sub's REGISTRATION, and the computed
+                   value reaches egress through two slots of the record
+                   the app-db walker never visits — the structured
+                   `:sub-runs` row (`:value` / `:prev-value`, projected by
+                   `elide-sub-run-row`) and the `:rf.sub/run` trace tag
+                   (`:rf.sub/value` / `:rf.sub/prev-value`, projected by
+                   `elide-large-sub-trace-values`). Both callers of the
+                   shared `elide-whole-output-large-slots` rule are
+                   therefore inhabited by one cascade.
+  Driven LAST so the existing index-addressed assertions (`(nth _ 1)` =
+  :login, `(nth _ 2)` = :upload) keep addressing the same cascades. Five
+  cascades against this suite's `:trace-events-keep 5` means every record
+  retains its `:trace-events`, so the tag slot is present on all of them.
   Returns the resulting `(epoch-history frame-id)` for direct comparison
   with `(projected-history frame-id)`."
   [frame-id]
@@ -120,11 +156,37 @@
   (rf/reg-event :login  (fn [{:keys [db]} _] {:db (assoc-in db [:auth :password] secret-password)}))
   (rf/reg-event :upload (fn [{:keys [db]} _] {:db (assoc-in db [:blob :payload] (big-string payload-size))}))
   (rf/reg-event :inc    (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
-  (rf/dispatch-sync [:seed]   {:frame frame-id})
-  (rf/dispatch-sync [:login]  {:frame frame-id})
-  (rf/dispatch-sync [:upload] {:frame frame-id})
-  (rf/dispatch-sync [:inc]    {:frame frame-id})
+  (rf/reg-sub large-sub-id   {:large? true} (fn [_ _] (big-string payload-size)))
+  (rf/reg-sub control-sub-id                (fn [_ _] control-note))
+  (rf/reg-event :read-subs
+    (fn [_ _]
+      (rf/subscribe-once [large-sub-id]   {:frame frame-id})
+      (rf/subscribe-once [control-sub-id] {:frame frame-id})
+      {}))
+  (rf/dispatch-sync [:seed]      {:frame frame-id})
+  (rf/dispatch-sync [:login]     {:frame frame-id})
+  (rf/dispatch-sync [:upload]    {:frame frame-id})
+  (rf/dispatch-sync [:inc]       {:frame frame-id})
+  (rf/dispatch-sync [:read-subs] {:frame frame-id})
   (rf/epoch-history frame-id))
+
+(defn- sub-run-row
+  "The structured `:sub-runs` row for `sub-id` in `record` — the slot
+  `elide-sub-run-row` projects."
+  [record sub-id]
+  (->> (:sub-runs record) (filter #(= sub-id (:sub-id %))) first))
+
+(defn- sub-run-tags
+  "The `:rf.sub/run` trace-event tags for `sub-id` in `record` — the slot
+  `elide-large-sub-trace-values` projects. A DIFFERENT slot from the row
+  above carrying the SAME computed value; eliding only one is the leak
+  rf2-irwsq shipped."
+  [record sub-id]
+  (->> (:trace-events record)
+       (filter #(and (= :rf.sub/run (:operation %))
+                     (= sub-id (get-in % [:tags :rf.sub/id]))))
+       first
+       :tags))
 
 (defn- contains-secret?
   "Walk an arbitrary EDN value looking for the exact secret string. Used
@@ -184,7 +246,17 @@
             string — the wire-elision walker substitutes a
             :rf.size/large-elided marker (a map containing :path, :bytes,
             :digest), not the raw bytes. An MCP forwarder downstream of
-            the token-cap walker depends on this."
+            the token-cap walker depends on this.
+
+            rf2-isp3i — the scan below is cross-cutting, but it can only
+            catch what the fixture puts in front of it, and the fixture
+            used to inhabit ONE large shape: the app-db PATH `:upload`
+            writes. The fixture controls in the second `let` pin the
+            SECOND shape — a whole-output `:large?` sub, whose value is
+            not app-db-rooted at all — in both of the slots it egresses
+            through. Without them a future retention change (or a
+            registration that silently stopped stamping) would return
+            this gate to reporting green over ground it never covered."
     (rf/make-frame {:id :test/mcp})
     (install-mcp-style-schemas! :test/mcp)
     (let [shipped (atom [])]
@@ -200,7 +272,45 @@
         (is (zero? projected-leaf-count)
             "the projected output contains zero leaf strings of the
              large payload's size — the large path landed as a marker,
-             not as raw bytes")))))
+             not as raw bytes"))
+      ;; rf2-isp3i — the whole-output `:large?` SUB shape, in both slots.
+      (let [raw       (last (rf/epoch-history :test/mcp))
+            raw-row   (sub-run-row  raw large-sub-id)
+            raw-tags  (sub-run-tags raw large-sub-id)
+            proj      (last @shipped)
+            proj-row  (sub-run-row  proj large-sub-id)
+            proj-tags (sub-run-tags proj large-sub-id)]
+        ;; Fixture controls: the shape the scan above must be able to see.
+        (is (= payload-size (count (:value raw-row)))
+            "fixture: the raw `:sub-runs` row carries the sub's full computed
+             value — the slot `elide-sub-run-row` projects")
+        (is (= payload-size (count (:rf.sub/value raw-tags)))
+            "fixture: the raw `:rf.sub/run` trace tag carries the SAME value —
+             the slot `elide-large-sub-trace-values` projects. The emit
+             chokepoint deliberately leaves both raw so the on-box ring keeps
+             the exact value (Xray diff / restore-epoch! need it)")
+        (is (true? (:large? raw-tags))
+            "fixture: the emit chokepoint stamped the bare whole-output
+             `:large?` flag — a REGISTRATION marker, so the app-db-rooted
+             classification this fixture installs cannot reach it, and the flag
+             is the entire contract egress has to honour")
+        ;; Both callers of the shared rule, at egress.
+        (is (elision/marker? (:value proj-row))
+            "`elide-sub-run-row` substituted the marker in the structured row")
+        (is (elision/marker? (:rf.sub/value proj-tags))
+            "`elide-large-sub-trace-values` substituted the marker in the trace
+             tag — the slot whose omission was rf2-irwsq's leak")
+        (is (= (get-in (:value proj-row)          [:rf.size/large-elided :bytes])
+               (get-in (:rf.sub/value proj-tags)  [:rf.size/large-elided :bytes]))
+            "both markers agree on `:bytes` — the structural evidence that ONE
+             shared rule produced them, so the two projections cannot drift")
+        ;; Negative control: an UNMARKED sub's value rides through raw, so the
+        ;; elisions above are driven by the registration stamp and not by some
+        ;; blanket truncation on the way out.
+        (is (= control-note (:value (sub-run-row proj control-sub-id)))
+            "NEGATIVE CONTROL — the unmarked sub's row value survives raw")
+        (is (= control-note (:rf.sub/value (sub-run-tags proj control-sub-id)))
+            "NEGATIVE CONTROL — and so does its trace tag value")))))
 
 (deftest forwarder-projected-record-preserves-bookkeeping-slots
   (testing "MCP forwarder pattern: the projected record's bookkeeping

--- a/implementation/scripts/api-manifest/src/re_frame/api_manifest/gen.clj
+++ b/implementation/scripts/api-manifest/src/re_frame/api_manifest/gen.clj
@@ -144,10 +144,21 @@
     ;; namespace by construction rather than by carve-out (the private helpers
     ;; beneath them are `defn-` / `def ^:private`).
     re-frame.freehand.tool
-    ;; Optional feature artefacts (public home namespaces).
+    ;; Optional feature artefacts (public home namespaces). All nine published
+    ;; feature coordinates are here. `re-frame.resources` was ABSENT until
+    ;; rf2-ivuun — eight of nine — even though `day8/re-frame2-resources` was
+    ;; already on this generator's classpath (see deps.edn), so the manifest
+    ;; carried ZERO resources rows while every other artefact carried 8-36. The
+    ;; consequence was not merely an undercount: `doc_api_check` derives its
+    ;; namespace roster FROM these rows, so `docs/api/re-frame.resources.md`
+    ;; received no coverage check at all, and anyone using the manifest as the
+    ;; "does this var exist" authority got false negatives across the whole
+    ;; resources surface. Adding a roster entry here is the whole fix; nothing
+    ;; about resources was ever unintrospectable.
     re-frame.schemas
     re-frame.machines
     re-frame.routing
+    re-frame.resources
     re-frame.flows
     re-frame.http
     re-frame.ssr

--- a/spec/api-manifest-metadata.edn
+++ b/spec/api-manifest-metadata.edn
@@ -1892,6 +1892,76 @@
   ["re-frame.routing" "route-slice-algebra-view"] {:tier :tooling :owner "012" :status "v1"}
 
   ;; =========================================================================
+  ;; re-frame.resources — optional artefact (day8/re-frame2-resources), §016.
+  ;;
+  ;; rf2-ivuun. These rows are NEW because the namespace was absent from the
+  ;; generator's `jvm-namespaces` roster — eight of the nine feature artefacts
+  ;; were listed and resources was not, so the manifest carried ZERO resources
+  ;; rows and `doc_api_check` gave `docs/api/re-frame.resources.md` no coverage
+  ;; at all. The vars themselves are not new and nothing about them was ever
+  ;; unintrospectable: `day8/re-frame2-resources` was already on the
+  ;; generator's classpath. Note the `route-ids` / `route-meta` comment in the
+  ;; routing block ABOVE, which cites `resource-ids`/`resource-meta` as the
+  ;; sibling enumerate pair — written against rows that did not exist. That is
+  ;; the trap this omission set: the manifest reads as an existence authority.
+  ;;
+  ;; TIERING RULE APPLIED HERE, stated so the next reader is not guessing.
+  ;;   (a) Where a `re-frame.core` facade row already exists, the home-ns row
+  ;;       carries the SAME classification. Precedent: `epoch-history` /
+  ;;       `projected-record` / `restore-epoch!` are `:tooling` on BOTH
+  ;;       `re-frame.core` and `re-frame.epoch`. One capability, one tier — the
+  ;;       manifest must not classify the same var `:advanced` through the
+  ;;       facade door and something else through its home door. All fifteen
+  ;;       are `:advanced :owner "016" :status "v1 (optional capability)"` on
+  ;;       the facade, so they are that here.
+  ;;   (b) The registry-enumerate accessors with NO facade export are
+  ;;       `:tooling`, per the explicit `route-ids` / `route-meta` precedent
+  ;;       (and the sibling `machines` / `machine-meta`, `flows-snapshot` /
+  ;;       `flow-meta-at`).
+  ;;   (c) The two algebra views are `:tooling` with no facade export —
+  ;;       `#?(:clj ...)`-gated JVM aliases of the bundle-isolated
+  ;;       `re-frame.resources.tooling` sibling, so a CLJS app that loads
+  ;;       resources but attaches no tool DCEs the bodies. Exact mirror of
+  ;;       `flow-algebra-view` / `route-algebra-view` / `machine-algebra-view`
+  ;;       (EP-0014 issue-1 disposition).
+  ;; =========================================================================
+  ;; (a) Facade-mirrored — resources.
+  ["re-frame.resources" "reg-resource"]         {:tier :advanced :owner "016" :status "v1 (optional capability)"}
+  ["re-frame.resources" "clear-resource"]       {:tier :advanced :owner "016" :status "v1 (optional capability)"}
+  ["re-frame.resources" "resource-meta"]        {:tier :advanced :owner "016" :status "v1 (optional capability)"}
+  ["re-frame.resources" "resources"]            {:tier :advanced :owner "016" :status "v1 (optional capability)"}
+  ["re-frame.resources" "resource-state"]       {:tier :advanced :owner "016" :status "v1 (optional capability)"}
+  ;; (a) Facade-mirrored — mutations (Spec 016 §Mutations).
+  ["re-frame.resources" "reg-mutation"]         {:tier :advanced :owner "016" :status "v1 (optional capability)"}
+  ["re-frame.resources" "clear-mutation"]       {:tier :advanced :owner "016" :status "v1 (optional capability)"}
+  ["re-frame.resources" "mutation-meta"]        {:tier :advanced :owner "016" :status "v1 (optional capability)"}
+  ["re-frame.resources" "mutations"]            {:tier :advanced :owner "016" :status "v1 (optional capability)"}
+  ["re-frame.resources" "mutation-state"]       {:tier :advanced :owner "016" :status "v1 (optional capability)"}
+  ;; (a) Facade-mirrored — named resource-scope resolvers (Spec 016 §Named
+  ;; resource-scope resolvers). `resolve-resource-scope` is PURE over the
+  ;; resolver registry (the logout coeffect-db idiom): not an effect and with
+  ;; no observability side effect, so it emits no
+  ;; `:rf.resource/scope-resolved` trace.
+  ["re-frame.resources" "reg-resource-scope"]   {:tier :advanced :owner "016" :status "v1 (optional capability)"}
+  ["re-frame.resources" "clear-resource-scope"] {:tier :advanced :owner "016" :status "v1 (optional capability)"}
+  ["re-frame.resources" "resolve-resource-scope"] {:tier :advanced :owner "016" :status "v1 (optional capability)"}
+  ;; (a) Facade-mirrored — focus / reconnect revalidation host listeners (Spec
+  ;; 016 §Stale and GC scheduling). CLJS-only host listeners; the JVM arm is a
+  ;; no-op, so the var exists on both hosts and `ns-publics` sees it here.
+  ["re-frame.resources" "install-revalidation-listeners!"] {:tier :advanced :owner "016" :status "v1 (optional capability)"}
+  ["re-frame.resources" "remove-revalidation-listeners!"]  {:tier :advanced :owner "016" :status "v1 (optional capability)"}
+  ;; (b) Registry-enumerate accessors, owned-ns surface only.
+  ["re-frame.resources" "resource-ids"]         {:tier :tooling :owner "016" :status "v1 (optional capability)"}
+  ["re-frame.resources" "mutation-ids"]         {:tier :tooling :owner "016" :status "v1 (optional capability)"}
+  ["re-frame.resources" "scope-resolver-ids"]   {:tier :tooling :owner "016" :status "v1 (optional capability)"}
+  ["re-frame.resources" "scope-resolver-meta"]  {:tier :tooling :owner "016" :status "v1 (optional capability)"}
+  ;; (c) Algebra views — a resource is the canonical PROCESS member of the
+  ;; algebra (Derivations §Process). Static registry view + live per-frame
+  ;; cache-entry view.
+  ["re-frame.resources" "resource-algebra-view"]       {:tier :tooling :owner "016" :status "v1 (optional capability)"}
+  ["re-frame.resources" "resource-cache-algebra-view"] {:tier :tooling :owner "016" :status "v1 (optional capability)"}
+
+  ;; =========================================================================
   ;; re-frame.flows — optional artefact (day8/re-frame2-flows), §013.
   ;; =========================================================================
   ["re-frame.flows" "reg-flow"]              {:tier :implementation :owner "013" :status "v1"}

--- a/spec/api-manifest.edn
+++ b/spec/api-manifest.edn
@@ -6,7 +6,7 @@
  {:doc
  "GENERATED public-API manifest — do NOT hand-edit the :vars list. Regenerate with: clojure -M -m re-frame.api-manifest.gen (run from implementation/scripts/api-manifest/). The tier/owner/status axes are curated in spec/api-manifest-metadata.edn; existence + kind + facade? are derived from live public vars. See that generator ns for the design.",
  :keystone "rf2-3nbl5.2",
- :var-count 552,
+ :var-count 573,
  :tier-vocab
  [:front-porch
   :advanced
@@ -278,6 +278,27 @@
   {:namespace "re-frame.mcp-base.sensitive", :var "sensitive-stamp?", :tier :tooling, :kind :fn, :owner "Tool-Pair", :status "post-v1 lib", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.mcp-base.sensitive", :var "strip-sensitive", :tier :tooling, :kind :fn, :owner "Tool-Pair", :status "post-v1 lib", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.performance", :var "enabled?", :tier :tooling, :kind :var, :owner "009", :status "v1", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.resources", :var "clear-mutation", :tier :advanced, :kind :fn, :owner "016", :status "v1 (optional capability)", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.resources", :var "clear-resource", :tier :advanced, :kind :fn, :owner "016", :status "v1 (optional capability)", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.resources", :var "clear-resource-scope", :tier :advanced, :kind :fn, :owner "016", :status "v1 (optional capability)", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.resources", :var "install-revalidation-listeners!", :tier :advanced, :kind :fn, :owner "016", :status "v1 (optional capability)", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.resources", :var "mutation-ids", :tier :tooling, :kind :fn, :owner "016", :status "v1 (optional capability)", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.resources", :var "mutation-meta", :tier :advanced, :kind :fn, :owner "016", :status "v1 (optional capability)", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.resources", :var "mutation-state", :tier :advanced, :kind :fn, :owner "016", :status "v1 (optional capability)", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.resources", :var "mutations", :tier :advanced, :kind :fn, :owner "016", :status "v1 (optional capability)", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.resources", :var "reg-mutation", :tier :advanced, :kind :fn, :owner "016", :status "v1 (optional capability)", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.resources", :var "reg-resource", :tier :advanced, :kind :fn, :owner "016", :status "v1 (optional capability)", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.resources", :var "reg-resource-scope", :tier :advanced, :kind :fn, :owner "016", :status "v1 (optional capability)", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.resources", :var "remove-revalidation-listeners!", :tier :advanced, :kind :fn, :owner "016", :status "v1 (optional capability)", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.resources", :var "resolve-resource-scope", :tier :advanced, :kind :fn, :owner "016", :status "v1 (optional capability)", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.resources", :var "resource-algebra-view", :tier :tooling, :kind :fn, :owner "016", :status "v1 (optional capability)", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.resources", :var "resource-cache-algebra-view", :tier :tooling, :kind :fn, :owner "016", :status "v1 (optional capability)", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.resources", :var "resource-ids", :tier :tooling, :kind :fn, :owner "016", :status "v1 (optional capability)", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.resources", :var "resource-meta", :tier :advanced, :kind :fn, :owner "016", :status "v1 (optional capability)", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.resources", :var "resource-state", :tier :advanced, :kind :fn, :owner "016", :status "v1 (optional capability)", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.resources", :var "resources", :tier :advanced, :kind :fn, :owner "016", :status "v1 (optional capability)", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.resources", :var "scope-resolver-ids", :tier :tooling, :kind :fn, :owner "016", :status "v1 (optional capability)", :facade? false, :runtime-verified? true}
+  {:namespace "re-frame.resources", :var "scope-resolver-meta", :tier :tooling, :kind :fn, :owner "016", :status "v1 (optional capability)", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.routing", :var "clear-route", :tier :tooling, :kind :fn, :owner "012", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.routing", :var "counter-snapshot", :tier :implementation, :kind :fn, :owner "012", :status "v1", :facade? false, :runtime-verified? true}
   {:namespace "re-frame.routing", :var "current-url", :tier :advanced, :kind :fn, :owner "012", :status "v1", :facade? false, :runtime-verified? true}


### PR DESCRIPTION
Two beads, one class: **a gate or roster that cannot see a whole surface, so it reports green over ground it never covered.** In both cases the machinery was sound and the *input* was wrong.

- `rf2-isp3i` — a fixture that inhabited one of two large-value shapes.
- `rf2-ivuun` — a generator roster missing one of nine feature artefacts.

---

## rf2-isp3i — the fixture blindness that let a leak ship

### What I found

`implementation/epoch/test/re_frame/epoch_mcp_egress_conformance_test.clj` owns the claim *"no raw large bytes anywhere in the projected output"*. Its fixture declared `:large` as an app-db **PATH** (`[:blob :payload]`). The whole-output `:large?` sub shape is not app-db-rooted at all — the stamp rides the sub's **registration**, not a path declaration — so the app-db classification the fixture installs structurally could not reach it, and the cross-cutting leaf scan ran over a record the shape never appeared in.

That is why `rf2-irwsq` shipped: a 25,000-character payload egressed raw at `[:trace-events <i> :tags :rf.sub/value]` while the gate whose entire job is catching that reported green.

### What I changed

`drive-mixed-ring!` gains a fifth `:read-subs` cascade that reads a whole-output `:large?` sub plus an unmarked control sub. One cascade inhabits **both** callers of the shared `elide-whole-output-large-slots` rule:

| slot | caller |
|---|---|
| `:sub-runs` row `:value` / `:prev-value` | `elide-sub-run-row` |
| `:rf.sub/run` tag `:rf.sub/value` / `:rf.sub/prev-value` | `elide-large-sub-trace-values` |

Driven **last**, so the existing index-addressed assertions (`(nth _ 1)` = `:login`, `(nth _ 2)` = `:upload`) keep addressing the same cascades. Five cascades against this suite's `:trace-events-keep 5` means every record retains its `:trace-events`, so the tag slot is present on all of them.

Scope is exactly *one fixture gains one more inhabited shape*: no new scanner, no gate rebuild, no fixture framework, **no production source change**.

### Non-vacuity — measured, not asserted

The instance is already fixed on both lanes, so the whole value of this bead is the fixture reaching the class. I reverted to the pre-`rf2-irwsq` behaviour (commented the `elide-large-sub-trace-values` call out of `elide-trace-events-slot`) and measured three ways. The revert was undone before committing — the diff touches no file under `implementation/epoch/src/`.

| fixture | source | assertions | failures | rc |
|---|---|---|---|---|
| ORIGINAL (app-db path only) | pre-`rf2-irwsq` — **leak present** | 90 | **0** | **0** |
| WIDENED | pre-`rf2-irwsq` — **leak present** | 106 | **4** | **1** |
| WIDENED | current — leak fixed | 106 | 0 | 0 |

**The first row is the defect reproduced.** The gate reported green over the exact leak it exists to catch. The four failures the widening produces are not incidental — they include the cross-cutting `(zero? projected-leaf-count)` scan and the bulk-egress `projected-history` arm, so the class is now reachable from the gate that owns the claim rather than only from the sibling that happened to find it.

The fixture also gains per-slot fixture controls naming both slots, and an unmarked-sub negative control. A future retention change, or a registration that silently stopped stamping, now reds the gate instead of returning it to scanning ground it never covered.

---

## rf2-ivuun — an artefact invisible to every manifest-driven gate

### What I found

`re-frame.resources` was absent from `gen.clj`'s `jvm-namespaces` — eight of the nine optional feature artefacts were listed and resources was not — so `spec/api-manifest.edn` carried **zero** resources rows while every other published artefact carried 8-36.

Nothing about resources was ever unintrospectable: **`day8/re-frame2-resources` was already on the generator's own classpath** (`implementation/scripts/api-manifest/deps.edn`). The omission was a roster entry, and adding it is the whole fix.

The consequence was not merely an undercount. `doc_api_check` derives its namespace roster *from* the manifest's rows, so `docs/api/re-frame.resources.md` received no page-or-member coverage check at all, and the same blind spot ran through `skills_check` / `api_md_check`.

The sharpest evidence that the manifest reads as an existence authority is already in the repo: the routing block's own sidecar comment for `route-ids` / `route-meta` cites **`resource-ids`/`resource-meta` as the sibling enumerate pair** — written against rows that did not exist.

### What I changed

One roster entry, plus curated sidecar rows for all 21 newly-visible publics. Each classifies and justifies itself at diff time, under a tiering rule stated in the sidecar so the next reader is not guessing:

| group | count | tier | precedent |
|---|---|---|---|
| Already carry a `re-frame.core` facade row | 15 | `:advanced` / "016" / "v1 (optional capability)" — the **same** classification the facade row carries | `epoch-history` / `projected-record` / `restore-epoch!` are `:tooling` on **both** `re-frame.core` and `re-frame.epoch`. One capability, one tier — the manifest must not classify a var `:advanced` through the facade door and something else through its home door. |
| Registry-enumerate accessors, no facade export | 4 | `:tooling` | `route-ids` / `route-meta`; sibling `machines` / `machine-meta`, `flows-snapshot` / `flow-meta-at`. |
| Algebra views, no facade export | 2 | `:tooling` | `#?(:clj ...)`-gated JVM aliases of the bundle-isolated `re-frame.resources.tooling` sibling — exact mirror of `flow-algebra-view` / `route-algebra-view` / `machine-algebra-view` (EP-0014 issue-1 disposition). |

`spec/api-manifest.edn` is **regenerated, never hand-edited**. `:var-count` 552 → 573 (+21, exactly the resources surface). Verified by diff that nothing else moved:

```
$ git diff -U0 spec/api-manifest.edn | grep '^[+-]' | grep -v '^[+-][+-][+-]' | grep -v 're-frame.resources'
- :var-count 552,
+ :var-count 573,
```

22 insertions / 1 deletion — 21 rows plus the count line. Acceptance criterion 4 met.

### The docs gap this surfaced — fixed, not filed

With the page under coverage for the first time, `doc_api_check` found **exactly one** real gap:

```
MEMBER: re-frame.resources/remove-revalidation-listeners! has no member heading
        on docs/api/re-frame.resources.md
```

The two fns shared a combined `### install-revalidation-listeners! / remove-revalidation-listeners!` heading, and the extractor takes the first back-ticked identifier. Split into two entries so each public var has its own lookup anchor — the right API-reference outcome independent of the checker, and no content was lost (the teardown prose was already there). No anchor in the corpus pointed at the combined heading, so nothing broke.

**Fixed: 1. Filed: 0.** The bead warned this could be an unbounded docs job; it was one heading. The other 20 vars were already documented, or are `:tooling` — not an eligible tier for the coverage check.

### Proof the coverage is real, not nominal

Acceptance criterion 3 asked for a deliberate break. De-identifying the `### resource-state` heading:

```
DRIFT: docs/api is missing required namespace pages or member entries.
  MEMBER: re-frame.resources/resource-state has no member heading on docs/api/re-frame.resources.md
rc=1
```

Before this bead that page could not be flagged at all. Restored, and the check now reports **239** eligible manifest vars covered, up from 224 — the 15 newly-eligible `:advanced` resources rows.

---

## Quality gates

All run to completion in the worker worktree, `rc` captured immediately into a worktree-local log and cross-checked against the log's own PASS/FAIL lines.

| gate | result | rc |
|---|---|---|
| `implementation/epoch` `clojure -M:test` | 470 tests / 6431 assertions, 0 failures, 0 errors | 0 |
| `npm run test:cljs` (`.shadow-cljs` cleared first) | 11442 tests / 57290 assertions, 0 failures, 0 errors | 0 |
| api-manifest step 1 — `gen --check` | `OK: spec/api-manifest.edn in sync (573 public vars)` | 0 |
| api-manifest step 2 — `ui-context --check` | `OK: ui-context.md in sync (98 ids, 32 authoring vars)` | 0 |
| api-manifest step 3 — `api-md-check` | `OK: spec/API.md projection in sync (248 var-rows)` | 0 |
| `story-spec-check` | `OK` (68 refs) | 0 |
| `xray-spec-check` | `OK` (26 refs) | 0 |
| `skills-check` | `OK` (560 refs) | 0 |
| `doc-guide-check` | `OK` (732 refs) | 0 |
| `doc-api-check` | `OK` (323 refs) + `OK: docs/api page+member coverage in sync (239 eligible vars)` | 0 |
| api-manifest reconciler tests `clojure -M:test` | 151 tests / 369 assertions, 0 failures | 0 |
| `python -m mkdocs build --strict` (run **separately**) | `Documentation built in 23.32 seconds`; remaining output is pre-existing `INFO` only, no Google Fonts 503 this run | 0 |
| `scripts/test-fast-pr.sh` | full spine green — JVM core 2115/10456, JVM epoch 470/6431, CLJS 11442/57290; zero `FAIL`/`ERROR in` lines, every failure/error count zero | 0 |

Notes on the false-green classes this brief flagged:

- **mkdocs was run separately** on purpose, and the run confirms why. `test-fast-pr.sh` printed `SKIP mkdocs --strict build: mkdocs not on PATH (CI will run this; local soft-skip OK)` and still exited 0 — the documented soft-skip, reproduced. The separate `python -m mkdocs build --strict` (rc=0) is the real signal. (`mkdocs` is not on PATH as a bare executable here; `python -m mkdocs` is.)
- `test-fast-pr.sh`'s rc=0 was **cross-checked against its own log** rather than trusted: 0 `FAIL`/`ERROR in` lines, and no `N failures, M errors` line with a non-zero count. Its only other skip is a Windows-specific JS SIGINT-delivery skip, unrelated to either bead.
- **`.shadow-cljs` was cleared** before believing the CLJS result, since bead 1 is a fixture-only change and an `.edn` / test-only edit may not invalidate the cache.
- The `rc` in every row is the **captured** `rc=$?`, written to the log immediately, then cross-checked against that log's own `Ran … / N failures` line — not a wrapper's report and not a trailing `echo`.
- Bead 1's file is `.clj`, so it runs on the cognitect lane only. Its dual-lane `.cljc` sibling `epoch_egress_redaction_cljs_test.cljc` (ns ends `-cljs-test`, so it matches both shadow's `:ns-regexp` and cognitect's `.*-test$`) is untouched here.
