### PR TITLE
ci,docs: reconcile the two test-lane rosters, plus the rf2-boyep remainder (rf2-as6bg)

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -1299,10 +1299,22 @@ else
         # must fire BOTH the `cljs` (node-test) job and the `cljs-browser`
         # job — the latter runs the `*-dom-cljs-test` export/redaction +
         # chart DOM suites under headless Chromium (where EP-0015 image-
-        # export egress is verified). No tools_jvm / mcp_conformance /
-        # template_expensive fan-out: machines-viz has no JVM suite, is not
-        # consumed by an MCP wrapper, and is not part of the deps-new
-        # template's generated app.
+        # export egress is verified). No mcp_conformance /
+        # template_expensive fan-out: machines-viz is not consumed by an MCP
+        # wrapper and is not part of the deps-new template's generated app.
+        #
+        # rf2-as6bg — this arm used to claim machines-viz "has no JVM suite".
+        # It does: a wired `:test` alias, on `scripts/test-jvm-tools.sh`'s
+        # roster. 29 of its 31 suites are `*_cljs_test.*` and ride the two
+        # CLJS gates above, but `engine_grammar_parity_test.cljc` and
+        # `mermaid_public_smoke_test.cljc` match neither `cljs-test$`
+        # (`:node-test`) nor `-dom-cljs-test$` (`:browser-test`), so they run
+        # in the JVM lane ONLY — and no CI job runs that lane. Setting
+        # tools_jvm here would NOT close it: none of the five jvm-tools-*
+        # jobs runs machines-viz, so it would fire five unrelated probes and
+        # still skip these two files. Closing it needs a
+        # `jvm-tools-machines-viz` job; test.yml is hot-zone, so that half of
+        # rf2-as6bg is sequenced separately.
         #
         # spec-md guard (mirrors story/xray above): a pure documentation
         # change under tools/machines-viz/spec/**.md cannot affect any
@@ -1322,6 +1334,32 @@ else
             cljs_browser=true
             ;;
         esac
+        ;;
+      tools/testbed-support/*)
+        # rf2-as6bg — this tree had NO arm at all, so a testbed-support-only
+        # PR classified as zero changed surfaces and ran zero gates. Not just
+        # the JVM suite the bijection gate found (rf2-4hc9p): its three CLJS
+        # suites were skipped too. `implementation/shadow-cljs.edn` says the
+        # slice "additionally rides the always-on `:node-test` gate, so the
+        # slice is covered on every PR" — that was true of the BUILD's
+        # source-paths and false of CI, because the `cljs` job is gated on
+        # cljs_node_test, which nothing here set.
+        #
+        # src+test are :source-paths of the consolidated :node-test AND
+        # :browser-test builds, exactly like machines-viz above, so the same
+        # two gates own them: `config_cljs_test.cljs` +
+        # `story_host_cljs_test.cljs` under node, and
+        # `story_host_dom_cljs_test.cljs` (matching `-dom-cljs-test$`) under
+        # headless Chromium for its real React-root handoff assertions.
+        #
+        # The `.clj` half — `open_in_editor_server_test.clj`, which no CLJS
+        # build can load — still has no CI lane. tools_jvm is deliberately
+        # NOT set: none of the five jvm-tools-* jobs runs this artefact, so it
+        # would fire five unrelated probes and still skip the file. That half
+        # needs a `jvm-tools-testbed-support` job in the hot-zone test.yml and
+        # is sequenced separately.
+        cljs_node_test=true
+        cljs_browser=true
         ;;
       tools/story-mcp/*)
         # rf2-os0c1 — MCP wrappers don't run in a browser; story-xray-browser

--- a/docs/resources/tutorial/03-auth-and-forms.md
+++ b/docs/resources/tutorial/03-auth-and-forms.md
@@ -616,6 +616,10 @@ Teardown is just setup reversed, in one event. Wire `(dispatch [:auth/logout])` 
 
 Nothing else to unhook, which is the nice part. The bearer interceptor reads app-db per request, so the header stops the instant the token is `nil`. The guard starts intercepting again for the same reason. State went away, and behaviour followed. That's the whole dividend of keeping the session *in* app-db rather than in scattered closures: there's exactly one place to clear, and everything that read it goes quiet on its own.
 
+!!! note "What about the previous user's cached server data?"
+
+    Logout clears `:auth`, but Part 2's [resource](../glossary.md#resource) caches (the feed, the profile) still hold the departed user's data until they're re-fetched or evicted. If a fresh sign-in could show a flash of the old user's content, clear those caches in the same logout event — one more named, traced step, not a scattered checklist. The how-to [Add authentication](../../core/how-to/add-auth.md) covers the cache-teardown shape in full.
+
 ### The second trigger: the server signs you out
 
 The navbar is not the only thing that ends a session. A JWT that was valid at boot expires while the reader sits on `/settings`, and the route guard cannot notice — it reads cached auth state, and that state still says *signed in*. Entry was already allowed; the next authenticated request is where the truth turns up. So catch it on the response side of the interceptor chain you registered for `bearer-auth` — same chain, other leg:
@@ -634,10 +638,6 @@ The navbar is not the only thing that ends a session. A JWT that was valid at bo
 Two details earn their keep. Mind the **two `:status` levels**: the reply envelope's `:status` is `:error`, and the HTTP code lives *inside* the failure map at `[:error :status]`, under a framework-owned `:kind` — branch on those, never on a stringified message. And carry the frame from `ctx`: the reply arrives in a transport callback, where a bare `rf/dispatch` can hit `:rf.error/no-frame-context`.
 
 There is nothing new to clear, and that is the point. `:auth/logout` already drops `:auth`, wipes the persisted JWT, and moves the reader off the page they can no longer see — so logout gained a second trigger, not a second code path. (Send them to `:conduit.auth/login` instead of `:conduit/home` if you'd rather; it's the one keyword.) Note the *shape* of this response: the expired token is discarded, not refreshed. Trading it for a fresh one and replaying the original request is semantic retry — a bigger job, and [a machine's](#when-a-machine-is-the-better-tool). [Add authentication](../../core/how-to/add-auth.md) carries the full response-hook treatment, including the chain's failure semantics.
-
-!!! note "What about the previous user's cached server data?"
-
-    Logout clears `:auth`, but Part 2's [resource](../glossary.md#resource) caches (the feed, the profile) still hold the departed user's data until they're re-fetched or evicted. If a fresh sign-in could show a flash of the old user's content, clear those caches in the same logout event — one more named, traced step, not a scattered checklist. The how-to [Add authentication](../../core/how-to/add-auth.md) covers the cache-teardown shape in full.
 
 ## When a machine is the better tool
 

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -287,6 +287,42 @@ test('machines-viz deps.edn change fires cljs + cljs-browser (rf2-z0cw6s)', () =
   assert.equal(result.cljs_browser, 'true');
 });
 
+// rf2-as6bg — tools/testbed-support had NO arm in the classifier at all, so a
+// testbed-support-only PR classified as zero changed surfaces and ran zero
+// gates: not just the `.clj` suite the bijection gate found (rf2-4hc9p), but
+// its three `.cljs` suites too. Its src+test are :source-paths of the
+// consolidated :node-test AND :browser-test builds, so those two gates own the
+// CLJS half — same shape as machines-viz above. These assertions are the teeth
+// on that arm; deleting it makes them red rather than making CI quietly empty.
+
+test('testbed-support src change runs cljs + cljs-browser (rf2-as6bg)', () => {
+  const result = classify('tools/testbed-support/src/re_frame/testbed/config.cljs');
+  assert.equal(result.cljs_node_test, 'true');
+  assert.equal(result.cljs_browser, 'true');
+});
+
+test('testbed-support CLJS test-tree change runs cljs + cljs-browser (rf2-as6bg)', () => {
+  const result = classify(
+    'tools/testbed-support/test/re_frame/testbed/story_host_dom_cljs_test.cljs',
+  );
+  assert.equal(result.cljs_node_test, 'true');
+  assert.equal(result.cljs_browser, 'true');
+});
+
+// The `.clj` half — open_in_editor_server_test.clj, which no CLJS build can
+// load — still has no CI lane. tools_jvm is deliberately NOT set: none of the
+// five jvm-tools-* jobs runs this artefact, so setting it would fire five
+// unrelated probes and still skip the file. This pins the current, honest
+// state; a `jvm-tools-testbed-support` job in the hot-zone test.yml is
+// sequenced separately, and lands with this assertion flipped.
+test('testbed-support does NOT fan out to tools_jvm (no job runs it) (rf2-as6bg)', () => {
+  const result = classify(
+    'tools/testbed-support/test/re_frame/testbed/open_in_editor_server_test.clj',
+  );
+  assert.equal(result.tools_jvm, 'false');
+  assert.equal(result.cljs_node_test, 'true');
+});
+
 // The CLJS-only
 // adapter / Xray / pair-MCP public surfaces live in the sidecar
 // (spec/api-manifest-metadata.edn) under :cljs-only and are carried into

--- a/scripts/test-jvm-tools.sh
+++ b/scripts/test-jvm-tools.sh
@@ -20,6 +20,15 @@ tools=(
   # tracked separately (rf2-as6bg).
   tools/testbed-support
   tools/mcp-conformance/wire-vocab
+  # rf2-as6bg — the other direction of the same disagreement. tools/template
+  # has a CI job (`jvm-tools-template`, gated on `template_expensive`) but was
+  # on no local roster, so a template-only change had no local JVM lane at all.
+  # Its expensive slice — `emitted_test_run_test.clj`, which compiles and runs
+  # the emitted app — is already gated behind RF2_TEMPLATE_RUN_EMITTED_TESTS=1
+  # precisely so a local run without Node stays green and quick, so the suite
+  # was built to be listed here; nobody listed it. Runs last because it is the
+  # slowest of the set even with the emitted slice skipped.
+  tools/template
 )
 
 for tool in "${tools[@]}"; do


### PR DESCRIPTION
**Follow-up to #6995, which merged at my first commit only.** #6995 was rebase-merged (`ef6eef44a8`) while I was still working the second bead, so it carried the 401 fix and nothing after it. Verified by content, not `--is-ancestor`: `origin/main` has the `expired-session` hook but does **not** have the note reorder, `tools/template` on the local roster, the `tools/testbed-support` classifier arm, or the three new classifier assertions. This PR carries the remainder.

Two commits:

1. `fecaf4196a` — **docs, `rf2-boyep` remainder.** Adding the `### The second trigger` subsection had pushed the "previous user's cached server data" note *inside* it. That note is about `:auth/logout` generally, not about the expiry trigger, so it moves back above the new heading. Cosmetic but it is the difference between the note reading as a footnote to the 401 hook and reading as what it is.
2. `0dbf28fbe4` — **`rf2-as6bg`**, in full. Nothing of it reached main.

The `rf2-boyep` findings-versus-changes writeup is in #6995 and is unchanged by this PR.

## 2. `rf2-as6bg` — the two test-lane rosters disagree in both directions

Read the rosters rather than listing them: `scripts/test-jvm-tools.sh`'s `tools=()` array, `test.yml`'s `jvm-tools-*` job family plus `all-required-passed`'s `needs:`, and — the piece the bead did not have — `.github/scripts/report-changed-surfaces.sh`, which decides whether any of those jobs runs at all. That third roster is where the real hole was: a `jvm-tools-*` job that exists but is never armed gates nothing, so job existence alone is not coverage. I ran the classifier directly against synthetic paths per artefact rather than reasoning about the `case` arms.

### Verdict per artefact

| artefact | local roster | CI | verdict | why |
| --- | --- | --- | --- | --- |
| `tools/testbed-support` | added by #6988 | **nothing** | **accidental** | no classifier arm at all — a testbed-support-only PR classified as *zero* surfaces |
| `tools/machines-viz` | present | no JVM lane | **accidental** | the classifier arm asserted, in a comment, that it "has no JVM suite". It has one. |
| `tools/template` | **missing** | `jvm-tools-template` | **accidental** | its expensive slice is already env-gated *so that local runs stay green* |
| `tools/mcp-conformance/wire-vocab` | present | `mcp-conformance-wire-vocab` | **deliberate — not a defect** | covered, by a differently-*named* job, and in the aggregator's `needs:` |

**`tools/testbed-support` — worse than the bead states.** The bead says "no CI job". The truth is no *gate*: `tools/testbed-support/**` matched no arm in `report-changed-surfaces.sh`, so a testbed-support-only PR set every surface false and ran nothing. Not just the 32-test `.clj` suite rf2-4hc9p found — its three `.cljs` suites were skipped too. `implementation/shadow-cljs.edn` states the slice "additionally rides the always-on `:node-test` gate, so the slice is covered on every PR"; that is true of the *build's* source-paths and false of CI, because the `cljs` job is `if: … cljs_node_test == 'true'` and nothing set it. Accidental beyond argument: the artefact ships a fully wired `:test` alias and the config asserts coverage that did not exist.

**`tools/machines-viz` — the omission is a documented false premise.** Its classifier arm reasoned "No `tools_jvm` … fan-out: machines-viz has no JVM suite". It has a wired `:test` alias on the local roster running **632 tests / 2537 assertions**. So this is a mistaken belief, not a decision — which is the distinction the brief asked for.

Sizing it honestly: 29 of its 31 test files are `*_cljs_test.*` and already ride the two CLJS gates, so most of those 632 double-run. The *uniquely* uncovered surface is the two files whose namespaces match neither `cljs-test$` (`:node-test`) nor `-dom-cljs-test$` (`:browser-test`) — `engine_grammar_parity_test.cljc` (10 deftests, the engine-to-viz grammar drift ratchet) and `mermaid_public_smoke_test.cljc` (2). Those run in the JVM lane only, and no CI job runs that lane. Small, but a parity ratchet is exactly the kind of gate that is worthless when it never fires.

**`tools/template` — accidental.** The tempting read is "deliberate, because it's expensive": `jvm-tools-template` is gated on its own `template_expensive` surface with `timeout-minutes: 35`. Two things refute it. Its own workflow comment says the emitted-app slice is behind `RF2_TEMPLATE_RUN_EMITTED_TESTS=1` "so local fast-loop runs (where Node may be absent) stay green" — the suite was *built* to be locally runnable and nobody listed it. And cost is not the roster's exclusion criterion anyway: the roster already carries `tools/story` (1847 tests) and `tools/xray` (1270), against template's 59.

**`tools/mcp-conformance/wire-vocab` — verified, no defect.** `mcp-conformance-wire-vocab` runs its JVM gates, gated on `mcp_conformance`, and it is in `all-required-passed`'s `needs:`. The name is not `jvm-tools-*` because it belongs to the MCP-conformance family, and the `tools/mcp-conformance/*` classifier arm says so explicitly: setting `tools_jvm` there "would needlessly fire four unrelated `jvm-tools-*` probes". Present in one roster and absent from the other, deliberately — the same shape as the `tools/story` `:clein/build`-outside-`release.yml` case the brief flagged. Nothing removed.

### What I changed — `test.yml` is untouched

Every landed change avoids a new job and a `needs:` edge, so the hot-zone workflow has no diff:

1. **`scripts/test-jvm-tools.sh`** — appended `tools/template` to the roster, last (slowest of the set). Closes the "CI job, no local lane" direction.
2. **`.github/scripts/report-changed-surfaces.sh`** — new `tools/testbed-support/*` arm firing `cljs_node_test` + `cljs_browser`. Those two jobs already carry the tree on their `:source-paths` and are already in `all-required-passed`'s `needs:`, so this arms existing jobs rather than adding one. The file is `.github/scripts/`, not `.github/workflows/*` — outside the declared hot zone.
3. **`.github/scripts/report-changed-surfaces.sh`** — corrected the false "machines-viz has no JVM suite" comment, recording what the JVM lane holds, that no job runs it, and why setting `tools_jvm` would not help.
4. **`implementation/scripts/_changed-surfaces.test.cjs`** — three assertions giving the new arm teeth (199 to 202 top-level tests; suite reports 232 passed). Falsification is on the record: before the arm, `report-changed-surfaces.sh tools/testbed-support/src/foo.cljs` printed every surface `false`; after, `cljs_node_test=true cljs_browser=true`. One assertion deliberately pins `tools_jvm == 'false'` *while no job runs the artefact*, so the JVM follow-up lands with that assertion flipped rather than silently contradicting it.

No detector was built. The durable fix the bead floats — asserting both rosters against `test.yml`'s job list — needs a workflow-job parser, and the bead itself scopes that as a follow-on.

### Reported, not landed — the JVM half

Per the brief, this is the part I stopped on. `tools/machines-viz` and `tools/testbed-support` still have no CI JVM lane, and closing it honestly needs hot-zone edits:

- two new jobs, `jvm-tools-machines-viz` and `jvm-tools-testbed-support` (each seconds: 632/2537 and 32/153, both green locally), plus two `needs:` edges on `all-required-passed`, plus classifier arms arming them;
- **or** two steps appended to an existing `jvm-tools-*` job. I rejected this even though it is the cheaper shape: no existing job is armed for these artefacts, so it would also require setting `tools_jvm=true` for both trees — which fires five unrelated `jvm-tools-*` probes, the exact cost the existing arms deliberately avoid, and hangs a `tools/machines-viz` step off a job named "JVM tools/xray".

Recommend the two jobs, sequenced.

## Quality gates

Run from `C:/Users/miket/code/re-frame2-worktrees/misc-truth`, exit codes captured into `rc=$?` immediately and cross-checked against each log's own PASS/FAIL lines.

| gate | result | exit |
| --- | --- | --- |
| `python -m mkdocs build --strict` | `Documentation built in 19.66 seconds`; no font or target failure | **0** |
| `python scripts/check_doc_slugs.py --verbose` | `scanning 600 markdown files… no broken links.` | **0** |
| `python scripts/check_test_lane_bijection.py --self-test` | `self-test: PASS (8 cases)` | **0** |
| `python scripts/check_test_lane_bijection.py` | `PASS test-lane bijection: 1651 test-defining files, 44 lanes, every file selected and every selector reached` | **0** |
| `bash scripts/test-jvm-tools.sh` | `PASS tools JVM artefacts` — 8 artefacts, 4504 tests / 19557 assertions, 0 failures 0 errors | **0** |
| `npm run test:script-policy` (from `implementation/`) | all policy suites passed; `changed-surfaces tests: 232 passed.` | **0** |
| `bash scripts/test-fast-pr.sh` | `PASS fast PR spine`; `per-ns isolation: all 17 namespace(s) pass standalone.`; JVM core + CLJS node 11442 tests / 57290 assertions, 0 failures 0 errors | **0** |

`test-jvm-tools.sh` per artefact: xray 1270/5908, machines-viz 632/2537, story 1847/6824, story-mcp 292/1531, mcp-base 272/924, testbed-support 32/153, wire-vocab 100/1069, **template 59/611 (new)**.

One more cross-check worth naming: the spine's log contains a single line matching `FAIL` — `self-test PASS: a single standalone failure is flagged as the red namespace (FAIL path)`. That is the isolation gate proving it *can* go red, not a failure. No non-zero `failures` count appears anywhere in the log.

**False-green notes.** `test-fast-pr.sh` printed `SKIP mkdocs --strict build: mkdocs not on PATH` and would still have exited 0 — the separate `python -m mkdocs build --strict` above is what actually covers the docs diff, and it is the run reported here. `npm run test:script-policy` and `_changed-surfaces.test.cjs` are silent-on-success reporters, so I confirmed my three new assertions ran by count (199 to 202 declarations, 232 reported) rather than trusting exit 0. `npm ci` was run in this worktree; nothing junctioned to the mayor tree.

**Boundary.** Every edit landed under `C:/Users/miket/code/re-frame2-worktrees/misc-truth`; the mayor checkout showed no working-tree change from this task throughout. No `git stash` was used. `.beads/issues.jsonl` untouched.
