### PR TITLE
fix(test): route ui-scaffold-smoke through the quiet runner's test-count floor (rf2-qqzmf)

### DIFF
--- a/implementation/ui/scaffold-smoke/deps.edn
+++ b/implementation/ui/scaffold-smoke/deps.edn
@@ -1,9 +1,10 @@
 ;; scaffold-smoke — the CI teeth for examples/ui/minimal-counter.
 ;;
 ;; A focused JVM smoke, deliberately its OWN tiny project so it does not
-;; ride (or slow) the implementation/ui suite. It has no framework deps of
-;; its own: it materializes the scaffold's documented files into a temp
-;; directory and shells out to `npm install` + `npx shadow-cljs compile app`.
+;; ride (or slow) the implementation/ui suite. It carries no SHIPPING framework
+;; dep — it materializes the scaffold's documented files into a temp directory
+;; and shells out to `npm install` + `npx shadow-cljs compile app` — and its
+;; one test-only dep is the shared quiet runner (see the `:test` alias).
 ;;
 ;;   clojure -M:test        — structural checks only (fast, no Node needed)
 ;;   RF2_UI_SCAFFOLD_COMPILE=1 clojure -M:test
@@ -13,7 +14,18 @@
 {:deps {org.clojure/clojure {:mvn/version "1.12.0"}}
 
  :aliases
+ ;; This lane is a SUITE — it claims coverage of the scaffold, so it must prove
+ ;; it RAN. Routed through `re-frame.test-quiet.runner` like every sibling
+ ;; artefact's `:test` alias, which is what applies the test-count floor
+ ;; (rf2-qqzmf): calling `cognitect.test-runner` directly left a discovery set
+ ;; that collapsed to nothing — a renamed test file, a lost `:extra-paths`, a
+ ;; `-r` selector matching no namespace — reporting `Ran 0 tests … / 0 failures,
+ ;; 0 errors.` and exiting 0, in a REQUIRED CI check. The runner supplies
+ ;; cognitect transitively and forwards args verbatim, so `clojure -M:test`
+ ;; keeps behaving identically in CI and on a laptop. This is emphatically NOT a
+ ;; `--probe` lane: `test/` holds JVM-runnable tests, and zero of them running
+ ;; is a configuration error, not the correct outcome.
  {:test {:extra-paths ["test"]
-         :extra-deps  {io.github.cognitect-labs/test-runner
-                       {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
-         :main-opts   ["-m" "cognitect.test-runner"]}}}
+         ;; Silent-on-success reporter + the test-count floor.
+         :extra-deps  {day8/re-frame2-test-quiet {:local/root "../../test-quiet"}}
+         :main-opts   ["-m" "re-frame.test-quiet.runner"]}}}


### PR DESCRIPTION
Closes the residual of `rf2-qqzmf`. Most of that bead shipped in #6975 / #6982; the merged-PR audit found one whole-suite lane the floor never reached.

## The residual

`implementation/ui/scaffold-smoke`'s `:test` alias called `cognitect.test-runner` **directly**, bypassing `re-frame.test-quiet.runner` — the wrapper that carries the test-count floor. Every sibling artefact under `implementation/` already routes through it; this one was the last that did not. It is also a **required** CI check (`ui-scaffold-smoke` in `.github/workflows/test.yml`, gated on the `examples_compile` surface), so the false green was live on a gate, not a dormant lane.

On `origin/main`, from `implementation/ui/scaffold-smoke`:

```
$ clojure -M:test -r '^zzz-nonexistent-namespace$'
Ran 0 tests containing 0 assertions.
0 failures, 0 errors.
rc=0
```

## The change

Five lines of `deps.edn`: the `io.github.cognitect-labs/test-runner` extra-dep becomes `day8/re-frame2-test-quiet {:local/root "../../test-quiet"}` (which supplies cognitect transitively, exactly as the sibling aliases rely on), and `:main-opts` becomes `["-m" "re-frame.test-quiet.runner"]`. Plus a comment saying which kind of lane this is and why, and a one-clause correction to the file header, which claimed the project has no deps of its own.

Nothing about how the lane is invoked changes — the runner forwards args verbatim and `clojure -M:test` behaves identically in CI and on a laptop, so `.github/workflows/test.yml` is untouched. No new mechanism: the floor, its `RF2_MIN_TESTS` default of 1, the malformed-value exit 2, and the `--probe` declaration all already exist and are proven. This lane is now pointed at machinery that works.

## Suite or probe? — a SUITE

`test/scaffold_smoke_test.clj` defines **7 JVM-runnable `deftest`s** (5 structural, 2 `^:compile`), and an ordinary run executes all 7 for 17 assertions. The lane therefore claims **coverage of the scaffold**, so it must prove it ran: zero tests is a configuration error, not the correct outcome, and it takes the floor.

It is emphatically not the `--probe` case. The two probes (`implementation/adapters/reagent`, `implementation/adapters/uix`) are CLJS-only artefacts whose `test/` trees hold nothing a JVM can run, so zero is their *right* answer and they declare that in their own `deps.edn`. `scaffold-smoke` is a `.clj` suite that runs today; declaring it a probe would have made it red, which is the declaration working as designed.

## Quality gates

Run from `C:/Users/miket/code/re-frame2-worktrees/scaffold-floor` on Windows. `rc` captured with `rc=$?` immediately after each command and cross-checked against the log's own summary lines.

### The both-ways proof (the point of the bead)

All four from `implementation/ui/scaffold-smoke`. A floor that cannot go red is the same defect wearing a different hat, so the red path is pinned first.

| # | Command | Before (main) | After (this PR) |
|---|---|---|---|
| 1 | `clojure -M:test -r '^zzz-nonexistent-namespace$'` | `Ran 0 tests containing 0 assertions.` · **rc=0** | `Ran 0 tests …` + `[test-quiet] ERROR: this run executed 0 test(s), below the floor of 1 (RF2_MIN_TESTS).` · **rc=1** |
| 2 | `clojure -M:test` | `Ran 7 tests containing 17 assertions. / 0 failures, 0 errors.` · **rc=0** | `Ran 7 tests containing 17 assertions. / 0 failures, 0 errors.` · **rc=0** |
| 3 | `RF2_MIN_TESTS=8 clojure -M:test` | (floor not wired) | `[test-quiet] ERROR: this run executed 7 test(s), below the floor of 8` · **rc=1** |
| 4 | `RF2_MIN_TESTS=1O clojure -M:test` | (floor not wired) | `ERROR: RF2_MIN_TESTS="1O" is not a non-negative integer.` · **rc=2** |

Row 2 also shows the quiet contract arriving with the runner: the ordinary green run no longer prints cognitect's `Running tests in #{"test"}` discovery banner, just the two summary lines. Rows 3 and 4 confirm the floor's env plumbing and its configuration-error exit code are live *at this lane*, not merely present in the runner.

### Repo gates

| Gate | Result | rc |
|---|---|---|
| `sh scripts/test-jvm-implementation.sh` | `PASS implementation JVM artefacts` — 22 artefacts, **8910 tests / 90519 assertions**, `0 failures, 0 errors.` on every one | **0** |
| spine self-test (`sh scripts/_test_fixtures/test_fast_pr_docs_gate/run-self-test.sh`) | **22/22 self-test cases passed** (A–V) | **0** |
| `npm run test:script-policy` (from `implementation/`) | full 27-script chain, **291 PASS** lines, no failures | **0** |
| `python scripts/check_test_lane_bijection.py` | `PASS test-lane bijection: 1645 test-defining files, 43 lanes, every file selected and every selector reached` | **0** |
| `python scripts/check_test_lane_bijection.py --self-test` | `self-test: PASS (8 cases)` — including `B4 fires on a --probe lane that gained a test` | **0** |
| `python scripts/check_donor_inventory.py` | silent (the touched file is inventoried by the `implementation/ui/scaffold-smoke/*` glob) | **0** |
| `sh scripts/check-beads-pr-boundary.sh origin/main` | `No beads-database paths in this PR diff.` (base ref passed explicitly — the script exits 0 when it cannot find one) | **0** |

Within the JVM sweep, `implementation/adapters/reagent` and `implementation/adapters/uix` both report `Ran 0 tests containing 0 assertions.` and stay green: the two declared `--probe` lanes behaving exactly as designed, which is the contrast that makes this lane's `Ran 7` the right kind of claim.

`grep`ping the script-policy log for `FAIL` legitimately hits negative self-tests named `ok … → FAILED` and `PASS … FAILS CLOSED …`; the chain's own rc is 0 and no assertion failed. The `_playground-sci-inputs` fixture failure seen on this host in earlier runs did not reproduce.

### CI surface armed

`sh .github/scripts/report-changed-surfaces.sh implementation/ui/scaffold-smoke/deps.edn` → `examples_compile=true` (with `implementation_jvm`, `cljs_node_test`, `ui_gates`, `cljs_browser`, `cljs_prod`, `bundle_isolation`, `ui_smoke`). So the `ui-scaffold-smoke` job runs on this very PR, with `RF2_UI_SCAFFOLD_COMPILE=1`, and CI itself re-proves the green path through the new runner including the install+compile tier and the omission matrix.

## Notes for the reviewer

- **Limited lifetime, deliberately.** `implementation/ui/` is donor code that `rf2-drpa3.57` deletes wholesale at the F6e gate, so this fix is temporary by construction. That is precisely why it stays a `deps.edn` change and invests nothing in the donor.
- **`scaffold-smoke` is in neither JVM artefact roster** (`scripts/test-jvm-implementation.sh`, `scripts/test-jvm-tools.sh`), so `scripts/check_test_lane_bijection.py` — which reads its JVM lanes from those rosters — does not see this lane, and its static B4 half still would not catch a regex typo here. Adding it to the roster would put a standalone project that shells out to `npm install` into the local sweep, for a lane that has no `-r`/`-n` selector to typo and is scheduled for deletion. Left alone on purpose; recording it so the gap is a known one rather than an oversight.
- **`migration/from-re-frame-v1/codemod` still calls cognitect directly**, and that stays: its `deps.edn` documents the reason (`so the artefact stays self-contained and the test JVM never pulls the implementation tree`). It is outside `implementation/`, and re-litigating it is not this bead's bounded repair. It is now the only such alias in the tree.
- **No hardcoded exemption list** was added to any script, and no per-namespace registry or per-lane calibrated number: nothing here needs an update when a test is added to the scaffold smoke.
