### PR TITLE
fix(routing): collapse the last second URL reader, the lying plan branch, and two seam re-assemblies (rf2-teov0, rf2-cqyq2, rf2-2gna9, rf2-szp11)

### DIFF
--- a/implementation/routing/src/re_frame/routing/events.cljc
+++ b/implementation/routing/src/re_frame/routing/events.cljc
@@ -234,9 +234,20 @@
   `emit-activation-traces!` so the lifecycle pair carries `:frame` too.
   Without it those frame-known traces miss epoch capture (which buffers
   only frame-tagged events) and bypass the frame-level trace-disable gate.
+
+  rf2-cqyq2 — `branch-contributors` / `branch-error` are the route plan's
+  already-resolved `:parent` walk (`resolve-branch`, called ONCE per navigation
+  in `re-frame.routing.resolve/route-plan`), threaded in by the door. Both doors
+  build the plan immediately before calling this, so the value is in hand; this
+  hop used to re-walk the chain itself, which is how the plan came to REPORT one
+  branch (the display walk) and EXECUTE another (this one). Reading it off the
+  plan makes the reported branch and the composed branch the same value by
+  construction, and costs one walk fewer per navigation.
+
   Returns the effects map `{:rf.db/runtime :fx}`."
   [rdb {:keys [route-id params query fragment transition]} on-match-vec
-   {:keys [prev-id prev-nav-token capture-fx scroll-fx push-fx nav-allocation app-db frame]}]
+   {:keys [prev-id prev-nav-token capture-fx scroll-fx push-fx nav-allocation app-db frame
+           branch-contributors branch-error]}]
   (let [;; rf2-vcop6y: the nav-token rides the RECORDABLE `:rf.route/nav-allocation`
         ;; cofx — `:token` is published into the slice (recorded + replay-stable),
         ;; `:counter` advances the host high-water via the bump fx below.
@@ -259,12 +270,12 @@
         ;; `:error`, visible to the `:rf/route` sub + Xray. No-op when no
         ;; Resources artefact / no `:resources` route metadata.
         route-meta (registrar/lookup :route route-id)
-        ;; EP-0037 R2: resolve the effective parent-to-leaf branch (fail-loud)
-        ;; and read the SUPERSEDED nav-token's owned identity set — the plan
-        ;; diff's previous set (`[:rf.runtime/routing :resource-plan <token>]`,
-        ;; a resources-written sibling of `:resource-blocking`). Routing owns
-        ;; the `:parent` walk; the Resources plan composes + diffs.
-        {:keys [branch branch-error]} (resolve-branch route-id)
+        ;; EP-0037 R2: read the SUPERSEDED nav-token's owned identity set — the
+        ;; plan diff's previous set (`[:rf.runtime/routing :resource-plan
+        ;; <token>]`, a resources-written sibling of `:resource-blocking`).
+        ;; Routing owns the `:parent` walk (`resolve-branch`, run once in
+        ;; `route-plan` and threaded in as `branch-contributors` /
+        ;; `branch-error`); the Resources plan composes + diffs.
         prev-identities (get-in rdb [:rf.runtime/routing :resource-plan prev-nav-token])
         plan       (when-let [on-entry (late-bind/get-fn :routing/on-route-entry)]
                      (on-entry {:route-meta      route-meta
@@ -277,7 +288,9 @@
                                 :prev-nav-token  prev-nav-token
                                 :ctx             {}
                                 ;; EP-0037 R2 branch composition + plan diff.
-                                :branch          branch
+                                ;; The hook's documented key names; the values
+                                ;; are the route plan's already-resolved walk.
+                                :branch          branch-contributors
                                 :branch-error    branch-error
                                 :prev-identities prev-identities
                                 ;; Preserve the handler's causal app-db input for

--- a/implementation/routing/src/re_frame/routing/navigate.cljc
+++ b/implementation/routing/src/re_frame/routing/navigate.cljc
@@ -251,7 +251,7 @@
         (let [destination? (address/destination? request)
               url-target   (:url request)
               {:keys [route-id path-params query-params matched-fragment unmatched-url
-                      throw-reason requested-url external-url-target?]}
+                      throw-reason malformed? requested-url external-url-target?]}
               (cond
                 ;; rf2-cylse.4 (SECURITY -- open-redirect): an external-classed
                 ;; `:url` target fails closed BEFORE match-url, identical to
@@ -263,22 +263,55 @@
                  :requested-url        url-target
                  :external-url-target? true}
 
-                ;; URL-string target (escape hatch). `match-url-fail-closed`
-                ;; catches any throw -> nil match + `:throw-reason`, so a
-                ;; throwing `:url` fails closed to `:rf.route/not-found` (the
-                ;; same fail-closed path as a bare miss). An unmatched URL keeps
-                ;; the REQUESTED url on the address bar (rf2-0zr2o).
+                ;; URL-string target (escape hatch). rf2-teov0: this door lowers
+                ;; to the SAME `resolver/url-resolution` extraction every other
+                ;; URL-bearing door reaches, rather than reading the URL a second
+                ;; time. It was the last surviving second reader of "what does
+                ;; this URL mean", and `plan.cljc`'s not-found section claims the
+                ;; `:reason` vocabulary is shared "byte-for-byte" across both
+                ;; entry points — which it was not: the inline derivation never
+                ;; ran the `malformed-url?` scan, so a malformed percent-encoding
+                ;; arriving HERE (the door Spec 012 documents as taking dynamic /
+                ;; user-supplied URLs, and `egress.cljc` names as the class most
+                ;; likely to carry `?token=` / `#access_token=`) stamped a bare
+                ;; `{:url …}` and emitted no EP-0015 diagnostic, while the same
+                ;; URL through `:rf.route/handle-url-change` stamped
+                ;; `:reason :malformed-url` and warned.
+                ;;
+                ;; The extraction supplies the shared FACTS; the ratified
+                ;; programmatic policy layers on top of them, exactly as
+                ;; `url_change.cljc` layers `fragment-only?` on the seam's raw
+                ;; `:match` rather than on the normalised target:
+                ;;
+                ;;   - `(:route-id match)` — NOT the normalised `:rf.route/not-found`.
+                ;;     A schema-validation miss is a MATCH, and the programmatic
+                ;;     door's ratified behaviour on one (Spec 012 §resolve-target
+                ;;     table / §Validation-error surfacing) is to reject the
+                ;;     caller's bug through `route-url` below, NOT to route to
+                ;;     not-found the way the URL-driven door does. Taking the
+                ;;     matched id, params, and query preserves that asymmetry
+                ;;     byte-for-byte.
+                ;;   - `(:params target)` on a MISS — the seam's normalised
+                ;;     not-found params, which is where the `:reason`
+                ;;     discriminators (`:malformed-url`, `:match-error`, or none)
+                ;;     now come from instead of being re-derived here.
+                ;;   - `match-url` always carries `:route-id` when it matches, so
+                ;;     `(when-not matched? …)` is the same unmatched-URL test as
+                ;;     the old `(when-not (:route-id match) …)`. An unmatched URL
+                ;;     keeps the REQUESTED url on the address bar (rf2-0zr2o).
+                ;;   - `(:fragment target)` is nil on a malformed URL (the
+                ;;     fragment may itself be the decode-fail site) and the
+                ;;     matched fragment otherwise.
                 (some? url-target)
-                (let [{:keys [match throw-reason]}
-                      (registry/match-url-fail-closed url-target)]
+                (let [{:keys [match matched? malformed? throw-reason target]}
+                      (resolver/url-resolution url-target)]
                   {:route-id         (or (:route-id match) :rf.route/not-found)
-                   :path-params      (if throw-reason
-                                       (plan/not-found-params url-target throw-reason)
-                                       (:params match (plan/not-found-params url-target nil)))
+                   :path-params      (if matched? (:params match) (:params target))
                    :query-params     (:query match {})
-                   :matched-fragment (:fragment match)
-                   :unmatched-url    (when-not (:route-id match) url-target)
+                   :matched-fragment (:fragment target)
+                   :unmatched-url    (when-not matched? url-target)
                    :throw-reason     throw-reason
+                   :malformed?       malformed?
                    :requested-url    url-target})
 
                 ;; Route-id destination -- build a FRESH address (omitted
@@ -513,10 +546,17 @@
                   ;; `:rf.warning/malformed-url`; an unmatched URL that resolved
                   ;; to `:rf.route/not-found` with no such route registered
                   ;; surfaces `:rf.warning/no-not-found-route`.
+                  ;; rf2-teov0: `:malformed?` is the shared extraction's answer,
+                  ;; not a hardcoded `false`. Passing `false` into the SHARED
+                  ;; intent builder is what made the parity structural in form and
+                  ;; absent in fact — the two callers built the same intent list
+                  ;; from DIFFERENT inputs, so the one input that mattered never
+                  ;; reached it. Mutually exclusive with `:throw-reason` by
+                  ;; construction (a throw pre-empts the malformed scan).
                   (plan/emit-intents!
                     (plan/fallback-telemetry-intents
                       {:throw-reason  throw-reason
-                       :malformed?    false
+                       :malformed?    malformed?
                        :no-not-found? (boolean (and unmatched-url (nil? route-meta)))
                        :url           requested-url
                        :frame         frame}))

--- a/implementation/routing/src/re_frame/routing/navigate.cljc
+++ b/implementation/routing/src/re_frame/routing/navigate.cljc
@@ -593,4 +593,11 @@
                      :push-fx        push-fx
                      :nav-allocation nav-allocation
                      :frame          frame
-                     :app-db         app-db})))))))))
+                     :app-db         app-db
+                     ;; rf2-cqyq2: the plan's already-resolved fail-loud
+                     ;; `:parent` walk — the SAME value its `:branch` diagnostic
+                     ;; projects, so the trace and the resource composition
+                     ;; cannot disagree, and the commit hop walks the chain no
+                     ;; second time.
+                     :branch-contributors (:branch-contributors route-plan)
+                     :branch-error        (:branch-error route-plan)})))))))))

--- a/implementation/routing/src/re_frame/routing/registry.cljc
+++ b/implementation/routing/src/re_frame/routing/registry.cljc
@@ -1395,8 +1395,14 @@
           (route-table))))))
 
 (defn match-url-fail-closed
-  "Fail-closed wrapper over `match-url` for the URL-driven and
-  programmatic nav entry points (`url-change-fx`, `navigate`). Returns
+  "Fail-closed wrapper over `match-url`, reached by every URL-bearing
+  navigation door through the ONE URL -> ResolvedTarget extraction
+  (`re-frame.routing.resolve/url-resolution`) — the URL-driven
+  `url-change-fx`, the link door's stage-3 target, and the programmatic
+  `{:url …}` escape hatch alike. It has no direct callers among the doors
+  (rf2-teov0: the programmatic door was the last one, and calling this
+  directly is exactly how it came to re-derive the not-found shape and lose
+  the `:malformed-url` discriminator). Returns
   `{:match <match-or-nil> :throw-reason <keyword-or-nil>}`.
 
   A generic navigation-resilience guard: any unexpected throw out of

--- a/implementation/routing/src/re_frame/routing/resolve.cljc
+++ b/implementation/routing/src/re_frame/routing/resolve.cljc
@@ -45,9 +45,9 @@
   (:require [re-frame.identity :as identity]
             [re-frame.registrar :as registrar]
             [re-frame.routing.egress :as egress]
+            [re-frame.routing.events :as routing-events]
             [re-frame.routing.plan :as plan]
-            [re-frame.routing.registry :as registry]
-            [re-frame.routing.subs :as routing-subs]))
+            [re-frame.routing.registry :as registry]))
 
 ;; ---- the R0 causes --------------------------------------------------------
 
@@ -199,16 +199,33 @@
 
 ;; ---- the parent-to-leaf branch + the leaf resource plan -------------------
 
-(defn branch-of
-  "The parent-to-leaf branch for a resolved target's `route-id` — the vector
-  `[parent-most ... leaf]` derived from the routes' `:parent` chain (Spec 012
-  §Nested layouts). The plan's branch field. Shares the ONE `:parent`-chain
-  walk the `:rf.route/chain` sub reduces over (`routing-subs/chain-from-meta`),
-  so the plan branch and the public chain sub can never disagree. The full
-  parent-to-leaf branch PLAN (per-segment resource requirements) graduates in
-  EP-0037 R2; R0 exposes the branch itself."
-  [route-id]
-  (routing-subs/chain-from-meta route-id))
+;; rf2-cqyq2 — the plan's branch is the FAIL-LOUD walk, resolved ONCE.
+;;
+;; Two `:parent` walks exist deliberately. The DISPLAY walk behind the
+;; `:rf.route/chain` sub (`re-frame.routing.subs/chain-from-meta`) is defensive:
+;; it swallows cycles and INCLUDES an unregistered parent id in the chain it
+;; returns. `routing-events/resolve-branch` is the PLANNING walk: fail-loud, reporting
+;; `{:branch-error {:kind :unknown-parent | :parent-cycle …}}` rather than a
+;; silently-truncated branch — and `events.cljc` says so in as many words, that
+;; the display sub "is not a substitute here".
+;;
+;; The plan's `:branch` used to delegate to the display walk (its docstring
+;; correctly claimed it "can never disagree" with the chain sub) while
+;; `commit-navigation` independently called `resolve-branch` for the resource
+;; composition. So the plan REPORTED one branch and EXECUTED another, and they
+;; disagreed exactly on the malformed-registration cases where a diagnostic
+;; earns its keep: `:rf.route/planned` named `:route/nowhere` as a branch
+;; segment — no such route — while the very same activation aborted with
+;; `:branch-error :unknown-parent` and landed `:transition :error`. R0 exposed
+;; the branch as a reflection of the chain sub; R2 then needed a fail-loud walk
+;; and ADDED a second one rather than promoting the first.
+;;
+;; Resolving it here, once, is both the fix and a walk removed per navigation:
+;; the plan carries the ids (the R0 diagnostic `:branch`), the error, and the
+;; per-segment contributors `commit-navigation` hands the resource plan, so the
+;; commit hop reads the branch off the plan the door already built instead of
+;; re-walking it. `chain-from-meta` stays exactly as it is — it is correct for
+;; what it does; it is just not the plan branch.
 
 (defn leaf-plan-of
   "The behaviour-preserving LEAF resource plan for a resolved target's
@@ -236,14 +253,32 @@
 
   Plain data — this contract adds no public `RoutePlan` constructor or
   promise-returning router object; its diagnostic projection is
-  `plan-projection`."
+  `plan-projection`.
+
+  The parent-to-leaf `:branch` is the FAIL-LOUD walk
+  (`routing-events/resolve-branch`), resolved ONCE per navigation here:
+
+    - `:branch` — `[parent-most … leaf]` route ids, the R0 diagnostic field.
+      EMPTY when the chain does not resolve, so the plan can never name a route
+      the registry does not carry;
+    - `:branch-error` — `{:kind :unknown-parent|:parent-cycle :route-id* …}`
+      when a `:parent` names an unregistered route or the chain cycles, else
+      absent. The plan's honest failure signal;
+    - `:branch-contributors` — the walk's `[{:route-id :route-meta} …]`
+      segments, the value `commit-navigation` hands the late-bound
+      `:routing/on-route-entry` resource plan. Carried on the plan so the commit
+      hop READS the branch the door already resolved rather than walking the
+      `:parent` chain a second time."
   [{:keys [source cause target]}]
-  (let [route-id (:route-id target)]
-    {:source    source
-     :cause     cause
-     :target    target
-     :branch    (branch-of route-id)
-     :leaf-plan (leaf-plan-of route-id)}))
+  (let [route-id (:route-id target)
+        {:keys [branch branch-error]} (routing-events/resolve-branch route-id)]
+    (cond-> {:source              source
+             :cause               cause
+             :target              target
+             :branch              (mapv :route-id branch)
+             :branch-contributors (vec branch)
+             :leaf-plan           (leaf-plan-of route-id)}
+      branch-error (assoc :branch-error branch-error))))
 
 ;; ---- the diagnostic projection --------------------------------------------
 
@@ -307,11 +342,22 @@
   vector of route ids and `:leaf-plan-ids` the leaf plan's event ids, both
   registration-time identifiers rather than runtime values, so both ride whole.
 
+  rf2-cqyq2 — `:branch-error` rides only when the `:parent` chain FAILED to
+  resolve, and only as its `:kind` + offending `:route-id*`. Both are
+  registration-time identifiers, so neither is a carrier; a `:parent-cycle`'s
+  `:chain` is deliberately left off the bus because `resolve-branch` builds it
+  out of route-META maps, and route metadata on a trace tag is bulk no consumer
+  branches on. The tag is a FAILURE SIGNAL, absent on every healthy navigation —
+  which is what makes `:branch` honest: before this, `:branch` came from the
+  display `:parent` walk while the activation composed over the fail-loud one, so
+  a malformed registration produced a plausible branch naming an unregistered
+  route with no indication that planning had failed on that very chain.
+
   Callers add the `:frame` stamp (the in-flight drain's frame), which is
   load-bearing rather than cosmetic: epoch capture admits only frame-tagged
   traces and the frame-level trace-disable gate keys suppression off it (Spec 012
   §Trace events — Frame attribution)."
-  [{:keys [cause target branch leaf-plan]}]
+  [{:keys [cause target branch branch-error leaf-plan]}]
   (-> {:cause         cause
        :route-id      (:route-id target)
        :url           (:url target)
@@ -323,4 +369,6 @@
        ;; surface; the id is the diagnostic half. Total over a non-sequential
        ;; entry so a malformed `:on-match` cannot throw on the trace path.
        :leaf-plan-ids (mapv #(if (sequential? %) (first %) %) leaf-plan)}
+      (cond-> branch-error
+        (assoc :branch-error (select-keys branch-error [:kind :route-id*])))
       egress/redact-url-tag))

--- a/implementation/routing/src/re_frame/routing/url_change.cljc
+++ b/implementation/routing/src/re_frame/routing/url_change.cljc
@@ -73,9 +73,9 @@
       (seq fx) (assoc :fx fx))))
 
 (defn- url-change-fx
-  "Pure helper: given runtime-db + url + default scroll strategy (+ the
-  `frame` to carry on the no-such-handler trace + the RECORDABLE
-  `nav-allocation`), return the effects map `{:rf.db/runtime :fx}` for
+  "Pure helper: given ONE argument map — runtime-db + url + default scroll
+  strategy (+ the `frame` to carry on the no-such-handler trace + the
+  RECORDABLE `nav-allocation`), return the effects map `{:rf.db/runtime :fx}` for
   a URL-driven full slice rewrite. Performs the `match-url` lookup and
   publishes the nav-token from the recordable, replay-stable
   `nav-allocation`; the `:counter` high-water bump rides a
@@ -120,8 +120,26 @@
    map: `:bypass-leave?` is the public one-shot leave escape and
    `:rf.route/decided?` is the runtime-internal rider the link door sets on
    the `:rf.route/transitioned` event it synthesises after deciding, so the
-   same target is not decided twice."
-  [rdb url default-scroll frame nav-allocation pending-nav-allocation app-db cause opts]
+   same target is not decided twice.
+
+   rf2-szp11 — ONE argument map, keys named exactly as the destructuring
+   names them, which is the shape every other function in this seam already
+   takes (`decisions/decide`, `plan/scroll-plan`, `resolve/route-plan`,
+   `plan/fallback-telemetry-intents`, `commit-navigation`'s opts,
+   `navigate/fragment-only-nav-fx`). This was the seam's one positional
+   outlier, and it had grown to NINE positions — the last two (`cause` at
+   R0b, `opts` at R4) one slice at a time, each addition individually
+   harmless. Two of those positions were `nav-allocation`
+   (`{:token :counter}`) and `pending-nav-allocation` (`{:id :counter}`):
+   ADJACENT, SAME-SHAPED two-key maps, so transposing them at a call site
+   compiled and ran with no arity or type complaint, minted a nil id into
+   either the committed slice's nav-token or the pending-navigation value,
+   and surfaced hundreds of lines away in nav-token cofx behaviour with
+   nothing pointing back at the call site. What kept it safe was that both
+   call sites live 75 lines apart in this namespace, not the design. Named
+   keys make each call site say what it passes."
+  [{:keys [rdb url default-scroll frame nav-allocation pending-nav-allocation
+           app-db cause opts]}]
   (let [rdb (or rdb {})
         ;; EP-0037 R0b: the URL -> ResolvedTarget extraction — including the
         ;; `:rf.route/not-found` fallback normalisation and its `:reason`
@@ -215,11 +233,19 @@
                      (decisions/decide
                        {:rdb                    rdb
                         :frame                  frame
-                        :target                 {:route-id route-id
-                                                 :params   params
-                                                 :query    query
-                                                 :fragment fragment
-                                                 :url      url}
+                        ;; rf2-2gna9: the guards decide against the ResolvedTarget
+                        ;; the seam produced above — NOT a hand-rebuilt copy of it.
+                        ;; Re-assembling the five fields here is what let the two
+                        ;; branches of this one door disagree about what the target
+                        ;; is: the commit branch below publishes
+                        ;; `(:target route-plan)`, which IS `resolved-target`, so a
+                        ;; field the seam later adds would reach the guards and the
+                        ;; committed slice DIFFERENTLY — the precise class of bug
+                        ;; R0b closed between the link door and the commit hop
+                        ;; (`resolve.cljc`: "no door reinvents the ResolvedTarget
+                        ;; shape"), reappearing three lines from where the door
+                        ;; received the value.
+                        :target                 resolved-target
                         :requested-url          url
                         :cause                  cause
                         :policy                 {}
@@ -399,8 +425,15 @@
     ;; EP-0037 R0b: the forward `:rf.route/transitioned` door's plan cause
     ;; is `:link`. EP-0037 R4: the guard decisions run INSIDE
     ;; `url-change-fx`, after the transition kind is classified.
-    (url-change-fx rdb url :top frame nav-allocation pending-nav-allocation
-                   app-db :link opts)))
+    (url-change-fx {:rdb                    rdb
+                    :url                    url
+                    :default-scroll         :top
+                    :frame                  frame
+                    :nav-allocation         nav-allocation
+                    :pending-nav-allocation pending-nav-allocation
+                    :app-db                 app-db
+                    :cause                  :link
+                    :opts                   opts})))
 
 (defn url-change-cause
   "The true R0 navigation cause for one `:rf.route/handle-url-change`
@@ -474,5 +507,12 @@
     ;; EP-0037 R0b: the URL-driven `:rf.route/handle-url-change` door stands for
     ;; THREE sub-doors, so it carries the cause `url-change-cause` resolves for
     ;; THIS dispatch — `:popstate`, `:initial`, or `:ssr`.
-    (url-change-fx rdb url :restore frame nav-allocation pending-nav-allocation
-                   app-db (url-change-cause frame opts) opts)))
+    (url-change-fx {:rdb                    rdb
+                    :url                    url
+                    :default-scroll         :restore
+                    :frame                  frame
+                    :nav-allocation         nav-allocation
+                    :pending-nav-allocation pending-nav-allocation
+                    :app-db                 app-db
+                    :cause                  (url-change-cause frame opts)
+                    :opts                   opts})))

--- a/implementation/routing/src/re_frame/routing/url_change.cljc
+++ b/implementation/routing/src/re_frame/routing/url_change.cljc
@@ -378,6 +378,12 @@
            ;; so the nav-token is PUBLISHED from `:token` (recorded +
            ;; replay-stable) + the `:counter` bump rides an fx.
            :nav-allocation nav-allocation
+           ;; rf2-cqyq2: the plan's already-resolved fail-loud `:parent` walk —
+           ;; the SAME value its `:branch` diagnostic projects, so the trace and
+           ;; the resource composition cannot disagree, and the commit hop walks
+           ;; the chain no second time.
+           :branch-contributors (:branch-contributors route-plan)
+           :branch-error        (:branch-error route-plan)
            ;; rf2-dbmj6x: the carried frame stamp (validated at the handler
            ;; top, threaded into `url-change-fx`). `commit-navigation` stamps
            ;; it on the nav-token-allocated + activated/deactivated lifecycle

--- a/implementation/routing/test/re_frame/routing_plan_seam_test.clj
+++ b/implementation/routing/test/re_frame/routing_plan_seam_test.clj
@@ -19,7 +19,9 @@
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.fx :as fx]
+            [re-frame.registrar :as registrar]
             [re-frame.routing :as routing]
+            [re-frame.routing.events :as routing-events]
             [re-frame.routing.registry :as registry]
             [re-frame.routing.resolve :as resolver]
             [re-frame.routing.subs :as routing-subs]
@@ -103,16 +105,79 @@
 
 ;; ---- branch + leaf plan ---------------------------------------------------
 
-(deftest branch-of-is-the-parent-to-leaf-chain
+(defn- plan-for
+  "The route plan for a bare `route-id` — the branch / branch-error fields are
+  derived from it alone."
+  [route-id]
+  (resolver/route-plan {:cause  :navigate
+                        :source {:to route-id}
+                        :target (resolver/resolved-target {:route-id route-id})}))
+
+(deftest plan-branch-is-the-parent-to-leaf-chain
   (routing/reg-route :route/dashboard {} "/dashboard")
   (routing/reg-route :route/reports {:parent :route/dashboard} "/dashboard/reports")
   (routing/reg-route :route/report {:parent :route/reports} "/dashboard/reports/:id")
-  (testing "the plan branch is [parent-most … leaf], shared with the :rf.route/chain sub reduction"
+  (testing "the plan branch is [parent-most … leaf]"
     (is (= [:route/dashboard :route/reports :route/report]
-           (resolver/branch-of :route/report)))
+           (:branch (plan-for :route/report))))
+    (is (nil? (:branch-error (plan-for :route/report)))))
+  (testing "on a chain that RESOLVES it agrees with the :rf.route/chain display
+            sub — the display walk is still correct for what it does"
     (is (= (routing-subs/chain-from-meta :route/report)
-           (resolver/branch-of :route/report))
-        "branch-of and the chain sub can never disagree — one :parent walk")))
+           (:branch (plan-for :route/report)))))
+  (testing "the plan also carries the walk's CONTRIBUTORS (route-id + route-meta
+            per segment) — the value commit-navigation hands the resource plan,
+            resolved once per navigation rather than re-walked at the commit"
+    (is (= [:route/dashboard :route/reports :route/report]
+           (mapv :route-id (:branch-contributors (plan-for :route/report)))))
+    (is (= (registrar/lookup :route :route/reports)
+           (:route-meta (second (:branch-contributors (plan-for :route/report))))))))
+
+;; ---- the plan branch is the FAIL-LOUD walk (rf2-cqyq2) ---------------------
+;;
+;; Two `:parent` walks exist deliberately. `subs/chain-from-meta` is the DISPLAY
+;; walk: defensive, swallows cycles, and INCLUDES an unregistered parent id in
+;; the chain it returns. `events/resolve-branch` is the PLANNING walk: fail-loud,
+;; reporting `{:branch-error {:kind :unknown-parent | :parent-cycle …}}`. And
+;; `events.cljc` says so in as many words — the display sub "swallows cycles
+;; defensively and is not a substitute here".
+;;
+;; The plan's `:branch` used the display walk while `commit-navigation`
+;; independently re-walked with the fail-loud one, so the plan REPORTED one
+;; branch and EXECUTED another — and they disagreed exactly on the
+;; malformed-registration cases where a diagnostic earns its keep.
+
+(deftest plan-branch-never-names-an-unregistered-route
+  (routing/reg-route :route/leaf {:parent :route/nowhere} "/leaf")
+  (testing "the premise: the two walks answer differently for an unregistered
+            :parent, and the display walk is the one that invents a route"
+    (is (= [:route/nowhere :route/leaf] (routing-subs/chain-from-meta :route/leaf))
+        "the display walk includes an id no route table entry backs")
+    (is (= {:kind :unknown-parent :route-id* :route/nowhere}
+           (:branch-error (routing-events/resolve-branch :route/leaf)))
+        "the planning walk refuses to resolve it"))
+  (testing "the PLAN now reports the fail-loud answer — an empty branch plus the
+            error, rather than a plausible two-segment branch naming
+            :route/nowhere while the activation aborts"
+    (let [plan (plan-for :route/leaf)]
+      (is (= [] (:branch plan)))
+      (is (not-any? #{:route/nowhere} (:branch plan)))
+      (is (= {:kind :unknown-parent :route-id* :route/nowhere} (:branch-error plan)))
+      (is (empty? (:branch-contributors plan))
+          "no contributors resolved, so the resource plan aborts rather than
+           composing over a truncated branch"))))
+
+(deftest plan-branch-reports-a-parent-cycle-rather-than-truncating-at-it
+  (routing/reg-route :route/ping {:parent :route/pong} "/ping")
+  (routing/reg-route :route/pong {:parent :route/ping} "/pong")
+  (testing "the display walk terminates silently at the cycle entry — a chain
+            that looks perfectly ordinary"
+    (is (= [:route/pong :route/ping] (routing-subs/chain-from-meta :route/ping))))
+  (testing "the plan reports the cycle"
+    (let [plan (plan-for :route/ping)]
+      (is (= [] (:branch plan)))
+      (is (= :parent-cycle (:kind (:branch-error plan))))
+      (is (= :route/ping (:route-id* (:branch-error plan)))))))
 
 (deftest leaf-plan-of-is-the-behaviour-preserving-on-match-loader
   (routing/reg-route :route/article
@@ -307,6 +372,47 @@
       (is (not (re-find #"tok-99" (pr-str tags))))
       (is (= "/invite/acct-42?invite=rf/redacted#rf/redacted" (:url tags))
           "the structured PATH survives — it is what a consumer branches on"))))
+
+(deftest planned-traces-branch-agrees-with-the-activation-rf2-cqyq2
+  (routing/reg-route :route/home {} "/")
+  (routing/reg-route :route/leaf {:parent :route/nowhere} "/leaf")
+  (quiet-nav-fx!)
+  (testing "a navigation to a route whose :parent is unregistered emits a
+            :rf.route/planned whose :branch names NO unregistered route, and
+            whose :branch-error is the same fail-loud error the activation
+            aborts on. Before this the trace read
+            :branch [:route/nowhere :route/leaf] — a plausible two-segment
+            branch naming a route that does not exist — with no hint that
+            planning had failed on that very chain."
+    (let [ts   (planned (rf/dispatch-sync [:rf.route/navigate {:to :route/leaf}]))
+          tags (:tags (first ts))]
+      (is (= 1 (count ts)))
+      (is (= [] (:branch tags)))
+      (is (not-any? #{:route/nowhere} (:branch tags))
+          "a tool reading the trace is not told a route exists that does not")
+      (is (= (select-keys (:branch-error (routing-events/resolve-branch :route/leaf))
+                          [:kind :route-id*])
+             (:branch-error tags))
+          "the trace's failure signal IS the activation's")))
+  (testing "and a well-formed branch carries no :branch-error at all — the tag is
+            a failure signal, not a slot that is always present"
+    (routing/reg-route :route/shell {} "/shell")
+    (routing/reg-route :route/child {:parent :route/shell} "/shell/child")
+    (let [tags (:tags (first (planned (rf/dispatch-sync
+                                        [:rf.route/navigate {:to :route/child}]))))]
+      (is (= [:route/shell :route/child] (:branch tags)))
+      (is (not (contains? tags :branch-error)))))
+  (testing "the :branch-error tag carries only registration-time identifiers —
+            a kind and a route id, never a route-meta map (a cycle's :chain
+            rides on the plan value, not on the trace bus)"
+    (routing/reg-route :route/ping {:parent :route/pong} "/ping")
+    (routing/reg-route :route/pong {:parent :route/ping} "/pong")
+    (rf/dispatch-sync [:rf.route/handle-url-change "/"])
+    (let [tags (:tags (first (planned (rf/dispatch-sync
+                                        [:rf.route/navigate {:to :route/ping}]))))]
+      (is (= {:kind :parent-cycle :route-id* :route/ping} (:branch-error tags)))
+      (is (not (re-find #":path|:rf.route/compiled|:chain" (pr-str (:branch-error tags))))
+          "no route metadata and no meta-bearing :chain reaches the trace"))))
 
 ;; ---- the URL -> ResolvedTarget extraction (ONE definition) ----------------
 

--- a/implementation/routing/test/re_frame/routing_plan_seam_test.clj
+++ b/implementation/routing/test/re_frame/routing_plan_seam_test.clj
@@ -20,6 +20,7 @@
             [re-frame.frame :as frame]
             [re-frame.fx :as fx]
             [re-frame.routing :as routing]
+            [re-frame.routing.registry :as registry]
             [re-frame.routing.resolve :as resolver]
             [re-frame.routing.subs :as routing-subs]
             [re-frame.routing.url-change :as url-change]
@@ -408,6 +409,87 @@
       (is (empty? @pushed)
           "no :rf.nav/push-url — the exact no-op terminated before history moved")
       (is (= :rf.route/not-found (current-id))))))
+
+;; ---- both URL-bearing doors share ONE reason vocabulary (rf2-teov0) --------
+;;
+;; `plan.cljc`'s not-found section states the invariant: "The reason vocabulary
+;; is SHARED across both entry points … a malformed percent-encoding stamps
+;; `:malformed-url` … Encoding the shape once keeps the two paths' fallback
+;; params byte-for-byte identical." It did not. The programmatic `{:url …}` door
+;; resolved its own URL — `match-url-fail-closed` called directly, the not-found
+;; shape re-derived inline — so it never ran the `malformed-url?` scan and
+;; hardcoded `:malformed? false` into the SHARED telemetry call. On the same
+;; malformed URL the URL-driven door stamped `:reason :malformed-url` and warned;
+;; the programmatic door stamped `{:url …}` and said nothing. That is the one
+;; door Spec 012 documents as taking user-supplied URLs, and `egress.cljc` names
+;; the unmatched URL as the class most likely to carry `?token=` — so the
+;; EP-0015 malformed-URL diagnostic was absent exactly where malformed input
+;; arrives.
+
+(defn- door-fallback
+  "Drive ONE not-found navigation and report what the two surfaces a consumer
+  reads actually say: the slice's `:route-id` + `:params`, and the fail-closed
+  warning operations the drain emitted."
+  [dispatch]
+  (with-trace-recorder! [traces {:pred #(contains? #{:rf.warning/malformed-url
+                                                     :rf.warning/no-not-found-route}
+                                                   (:operation %))}]
+    (rf/dispatch-sync dispatch)
+    {:route-id (current-id)
+     :params   (get-in (rdb) [:rf.runtime/routing :current :params])
+     :warnings (mapv :operation @traces)}))
+
+(deftest both-url-bearing-doors-stamp-the-same-not-found-reason
+  (routing/reg-route :route/home {} "/home")
+  (routing/reg-route :route/typed {:params [:map [:id :int]]} "/typed/:id")
+  (routing/reg-route :rf.route/not-found {} "/not-found")
+  (quiet-nav-fx!)
+  (testing "a BARE miss — the discriminator that already agreed"
+    (let [url-driven   (door-fallback [:rf.route/handle-url-change "/miss-a"])
+          programmatic (door-fallback [:rf.route/navigate {:url "/miss-b"}])]
+      (is (= :rf.route/not-found (:route-id url-driven) (:route-id programmatic)))
+      (is (= {:url "/miss-a"} (:params url-driven)))
+      (is (= {:url "/miss-b"} (:params programmatic)))
+      (is (= [] (:warnings url-driven) (:warnings programmatic))
+          "a well-formed miss is not a malformed URL")))
+  (testing "a MALFORMED percent-encoding — the discriminator that did NOT agree.
+            The programmatic door yielded {:url …} and emitted no warning at
+            all, so a per-route error UI branching on :reason (Spec 012) and the
+            EP-0015 malformed-URL diagnostic both went dark on the one door that
+            takes user-supplied URLs."
+    (let [url-driven   (door-fallback [:rf.route/handle-url-change "/miss-a/%zz"])
+          programmatic (door-fallback [:rf.route/navigate {:url "/miss-b/%zz"}])]
+      (is (= :rf.route/not-found (:route-id url-driven) (:route-id programmatic)))
+      (is (= :malformed-url (:reason (:params url-driven))))
+      (is (= :malformed-url (:reason (:params programmatic)))
+          "the two doors stamp the SAME :reason for the same class of URL")
+      (is (= [:rf.warning/malformed-url] (:warnings url-driven)))
+      (is (= [:rf.warning/malformed-url] (:warnings programmatic))
+          "EP-0015's malformed-URL diagnostic fires on BOTH doors")))
+  (testing "a match-url THROW — the second discriminator that already agreed,
+            pinned so the merge onto the shared extraction cannot lose it"
+    (with-redefs [registry/match-url
+                  (fn [_] (throw (ex-info "simulated hostile-URL parse failure" {})))]
+      (let [url-driven   (door-fallback [:rf.route/handle-url-change "/throw-a"])
+            programmatic (door-fallback [:rf.route/navigate {:url "/throw-b"}])]
+        (is (= :rf.route/not-found (:route-id url-driven) (:route-id programmatic)))
+        (is (= {:url "/throw-a" :reason :match-error} (:params url-driven)))
+        (is (= {:url "/throw-b" :reason :match-error} (:params programmatic)))
+        (is (= [:rf.warning/malformed-url] (:warnings url-driven)))
+        (is (= [:rf.warning/malformed-url] (:warnings programmatic))))))
+  (testing "a VALIDATION miss is the RATIFIED asymmetry, not a defect: Spec 012's
+            resolve-target table and §Validation-error surfacing ratify
+            URL-driven-routes-to-not-found vs programmatic-caller-bug-rejects.
+            The merge preserves it exactly — the programmatic door takes the
+            MATCHED route-id, so `route-url` rejects the caller's bad params
+            rather than routing to not-found."
+    (let [url-driven (door-fallback [:rf.route/handle-url-change "/typed/not-an-int"])]
+      (is (= :rf.route/not-found (:route-id url-driven)))
+      (is (= {:url "/typed/not-an-int" :reason :validation} (:params url-driven))))
+    (rf/dispatch-sync [:rf.route/handle-url-change "/home"])
+    (rf/dispatch-sync [:rf.route/navigate {:url "/typed/also-not-an-int"}])
+    (is (= :route/home (current-id))
+        "the programmatic door REJECTS a validation miss — slice unchanged")))
 
 ;; ---- the URL-change door reports WHICH of its three sub-doors fired --------
 


### PR DESCRIPTION
Four EP-0037 gate-3 findings, all in the routing planning seam
(`navigate.cljc` / `resolve.cljc` / `plan.cljc` / `url_change.cljc` /
`events.cljc`). They ride together because routing is a coupled artefact.

Work in progress — body updated as each bead lands.

- `rf2-2gna9` (P3) — `url-change-fx`'s decide branch re-assembled the
  `ResolvedTarget` it was handed. **Landed.**
- `rf2-szp11` (P3) — `url-change-fx`'s nine positional params. **Landed.**
- `rf2-teov0` (P2) — the programmatic `{:url}` door resolves its own URL.
- `rf2-cqyq2` (P2) — the plan's `:branch` comes from the display walk.

## Quality gates

Pending.
