### PR TITLE
test(routing): make R6's rf/route-link intent arm detect a doubled and a reordered dispatch (rf2-kqxe6.22)

### DIFF
--- a/implementation/resources/test/re_frame/ep0037_r6_integrated_proof_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/ep0037_r6_integrated_proof_cljs_test.cljc
@@ -387,13 +387,23 @@
 (def ^:private listener-seq (atom 0))
 
 (defn- capture-traces
-  "Run `f` with a trace listener installed; return the collected trace events."
-  [f]
-  (let [seen (atom [])
-        id   (keyword "ep0037-r6" (str "listener-" (swap! listener-seq inc)))]
-    (rf/register-listener! :trace id (fn [ev] (swap! seen conj ev)))
-    (try (f) (finally (rf/unregister-listener! :trace id)))
-    @seen))
+  "Run `f` with a trace listener installed; return the collected trace events.
+
+  The 2-arity also hands each event to `on-event` AS IT ARRIVES (trace delivery
+  is synchronous — Spec 009 §Emitting trace events). A vector read once `f` has
+  returned can be counted, but it cannot be interleaved with milestones `f`'s own
+  code reaches, and interleaving is the whole of an ORDERING claim: it is what
+  distinguishes a dispatch that FOLLOWED a caller's handler from one that
+  preceded it (rf2-kqxe6.22)."
+  ([f] (capture-traces f nil))
+  ([f on-event]
+   (let [seen (atom [])
+         id   (keyword "ep0037-r6" (str "listener-" (swap! listener-seq inc)))]
+     (rf/register-listener! :trace id (fn [ev]
+                                        (swap! seen conj ev)
+                                        (when on-event (on-event ev))))
+     (try (f) (finally (rf/unregister-listener! :trace id)))
+     @seen)))
 
 (defn- event-ids [traces]
   (into #{} (comp (filter #(= :rf.event/run-start (:operation %)))
@@ -717,28 +727,51 @@
                compiled `v/route-link` and the Freehand descriptor have real-DOM
                intent tests; `rf/route-link`'s own composed handler had none. The
                handler must run the caller's `:on-mouse-enter` FIRST and then
-               enqueue exactly the prefetch payload, stamped `:source :router`,
+               enqueue EXACTLY ONE prefetch payload, stamped `:source :router`,
                to the frame that RENDERED the link — not an ambient frame
-               resolved at event time."
+               resolved at event time.
+
+               Read as an ORDERED MILESTONE SEQUENCE, because neither law is
+               visible to an after-the-fact read (rf2-kqxe6.22). `(some? (first
+               (filter …)))` over the captured traces is exactly as true for one
+               dispatch as for five, so cardinality goes unasserted; and a
+               caller-ran counter inspected once the composed handler has already
+               RETURNED is exactly as true whether the dispatch preceded the
+               caller or followed it, so ordering goes unasserted. A mutation that
+               dispatched twice, and before the caller, kept the whole CLJS lane
+               byte-identically green. So the caller pushes `:caller` and the
+               trace listener pushes `:dispatch` into ONE atom as each happens,
+               and the law IS the sequence."
        (let [app        (boot-app!)
              other      (seal-frame! {:frame-id :conduit/other})
              slug       "composed"
-             caller-ran (atom 0)
-             props      (article-link-props slug (fn [_e] (swap! caller-ran inc)))
+             ;; The expected payload, written out rather than read back through
+             ;; `prefetch-payload`: an expectation that arrives through the seam
+             ;; under test agrees with it by construction.
+             expected   [:rf.route/prefetch {:to :conduit/article :params {:slug slug}}]
+             milestones (atom [])
+             props      (article-link-props slug (fn [_e] (swap! milestones conj :caller)))
              attrs      (second (rf/with-frame app
                                   (routing/route-link-render props "Read it")))]
          (is (fn? (:on-mouse-enter attrs)))
          ;; render scope has unwound by the time a real pointer arrives, and a
          ;; DIFFERENT frame is ambient — exactly the rf2-o3nam4 hazard.
          (let [traces (capture-traces
-                        #(rf/with-frame other ((:on-mouse-enter attrs) #js {})))
-               row    (first (filter #(= :rf.event/dispatched (:operation %)) traces))]
-           (is (= 1 @caller-ran)
-               "the caller's own intent handler ran — composed, not replaced")
-           (is (some? row) "the handler enqueued exactly one dispatch")
-           (is (= [:rf.route/prefetch {:to :conduit/article :params {:slug slug}}]
-                  (-> row :tags :rf.event/v))
-               "…and it is the address-only prefetch payload")
+                        #(rf/with-frame other ((:on-mouse-enter attrs) #js {}))
+                        (fn [ev]
+                          (when (and (= :rf.event/dispatched (:operation ev))
+                                     (= expected (-> ev :tags :rf.event/v)))
+                            (swap! milestones conj :dispatch))))
+               rows   (filterv #(= :rf.event/dispatched (:operation %)) traces)
+               row    (first rows)]
+           (is (= [:caller :dispatch] @milestones)
+               "the caller's own intent handler ran FIRST and exactly ONE
+                prefetch dispatch followed it — composed, not replaced; once,
+                not twice; after, not before")
+           (is (= 1 (count rows))
+               "…and the composed handler enqueued nothing else besides it")
+           (is (= expected (-> row :tags :rf.event/v))
+               "…the dispatch is the address-only prefetch payload")
            (is (= app (-> row :tags :frame))
                "…targeting the RENDER-time frame, not the ambient one")
            ;; the trace projection lifts `:source` out of `:tags` onto the


### PR DESCRIPTION
Fixes the false green EP-0037's correctness gate found: R6's `rf/route-link`
intent arm asserted two properties and detected neither.

`the-real-anchor-intent-handler-composes-and-dispatches` (in
`implementation/resources/test/re_frame/ep0037_r6_integrated_proof_cljs_test.cljc`)
is the only coverage anywhere for `rf/route-link`'s composed `:prefetch :intent`
handler — conformance row 7's "both link surfaces" clause. The gate mutated
`compose-intent-handler` to dispatch **twice** and **before** the caller, and the
whole CLJS lane stayed green, byte-identical to baseline. Not one assertion in
the repository reddened.

## Why it false-greened

Two assertions did no work:

```clojure
row (first (filter #(= :rf.event/dispatched (:operation %)) traces))
(is (some? row) "the handler enqueued exactly one dispatch")
```

`(some? (first (filter …)))` is exactly as true for one matching row as for
five, so **cardinality** went unasserted. And `caller-ran` was inspected only
once the composed handler had **returned**, by which time a dispatch that
preceded the caller is indistinguishable from one that followed it — so
**ordering** went unasserted too.

## The repair

Both laws are now read as ONE **ordered milestone sequence**, which is the only
shape that can see either. The caller's `:on-mouse-enter` pushes `:caller`; a
trace listener pushes `:dispatch` as the matching `:rf.event/dispatched` arrives
(trace delivery is synchronous — Spec 009 §Emitting trace events). Then:

```clojure
(is (= [:caller :dispatch] @milestones))   ; composed not replaced; once not
                                           ; twice; after not before
(is (= 1 (count rows)))                    ; …and nothing else was enqueued
```

The remaining assertions (address-only payload, render-time frame, `:source
:router`) are unchanged.

Two details that keep the arm honest:

- The caller's intent still travels **the seam a real caller uses** —
  `route-link-render`'s own composed handler, taken off the rendered attrs —
  rather than a hand-written dispatch. A parity or ordering claim whose two
  sides go through the same hand-rolled door tests nothing.
- The **expected payload is written out** rather than read back through
  `link/prefetch-payload`. An expectation that arrives through the seam under
  test agrees with it by construction.

`capture-traces` grows a 2-arity that hands each event to a callback as it
arrives. A vector read after `f` returns can be counted but not interleaved, and
interleaving is the whole of an ordering claim. The 1-arity is unchanged and
every other call site is untouched.

One file changed. `compose-intent-handler` itself is untouched on this branch —
the shipped implementation was already correct; only the proof was blind.

## Quality gates

Every runner was foregrounded to completion; `rc` was captured with `rc=$?`
immediately after the runner and cross-checked against the log's own
`Ran …` / `PASS` lines.

| Gate | Result | Captured rc |
|---|---|---|
| `implementation/resources` `clojure -M:test` | Ran 722 tests containing 6729 assertions. 0 failures, 0 errors. | 0 |
| `npm run test:cljs` | Ran 11453 tests containing 57342 assertions. 0 failures, 0 errors. | 0 |
| `scripts/test-fast-pr.sh` | `PASS fast PR spine` — tiers `docs=false jvm=true node=true`; JVM `implementation/core` 2115/10456 and `implementation/resources` 722/6729, node tier 11453/57342, all `0 failures, 0 errors` | 0 |

The spine's `NOT RUN` line names what it skipped: the documentation gates
(documentation surface unchanged), the JVM artefact suites the diff did not
touch, and the CI-only lanes (browser, prod-elision / bundle-isolation / perf,
adapter probes and smokes, Xray feature matrix, mcp-conformance, tool JVM
suites).

### Non-vacuity — both mutations red the arm

Proven the way the gate proved the defect: by mutating
`implementation/routing/src/re_frame/routing/link.cljc` in place, running the
**full** CLJS lane, and restoring. `link.cljc` is byte-identical to `HEAD` on
this branch (`git diff` empty) and appears in no commit.

**Baseline (repaired arm, unmutated implementation)** — `Ran 11453 tests
containing 57342 assertions. 0 failures, 0 errors.` rc=0.

**Mutation 1 — doubled dispatch.** `compose-intent-handler` dispatches the
prefetch payload twice, caller still first:

```clojure
(fn [e]
  (when caller-handler (caller-handler e))
  (router/dispatch! payload {:source :router :frame render-frame})
  (router/dispatch! payload {:source :router :frame render-frame}))
```

`Ran 11453 tests containing 57342 assertions. 2 failures, 0 errors.` rc=1 —
both failures in `the-real-anchor-intent-handler-composes-and-dispatches` and
nowhere else:

```
actual: (not (= [:caller :dispatch] [:caller :dispatch :dispatch]))
actual: (not (= 1 2))
```

**Mutation 2 — reordered dispatch.** `compose-intent-handler` dispatches before
the caller instead of after:

```clojure
(fn [e]
  (router/dispatch! payload {:source :router :frame render-frame})
  (when caller-handler (caller-handler e)))
```

`Ran 11453 tests containing 57342 assertions. 1 failures, 0 errors.` rc=1 —
again the same arm, alone:

```
actual: (not (= [:caller :dispatch] [:dispatch :caller]))
```

Under both mutations the pre-repair arm was green; the repaired arm is the sole
detector in the lane, which is the whole point of the bead.

Closes rf2-kqxe6.22.
