### PR TITLE
routing: collapse four EP-0037 gate-3 cohesion findings onto their owners (rf2-e9974, rf2-wzqtu, rf2-saf54, rf2-yvn0g)

### DIFF
--- a/implementation/resources/src/re_frame/resources/revalidate_listeners.cljc
+++ b/implementation/resources/src/re_frame/resources/revalidate_listeners.cljc
@@ -52,7 +52,7 @@
 
   Idempotent: re-installing for a frame replaces (does not stack) its
   listeners — hot-reload safe (the same teardown-then-reinstall shape
-  `re-frame.routing.history/install-url-listener!` uses)."
+  `re-frame.routing.history/reconcile-url-listener!` uses)."
   (:require [re-frame.late-bind :as late-bind]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -162,7 +162,7 @@
 
   Idempotent: re-installing for a frame REPLACES its prior listeners (does not
   stack) — hot-reload safe (the same teardown-then-reinstall shape
-  `re-frame.routing.history/install-url-listener!` uses).
+  `re-frame.routing.history/reconcile-url-listener!` uses).
   CLJS-only; the JVM arm is a no-op (no DOM under SSR / JVM tests), so this is
   `:require`-able from `.cljc` boot code without a reader conditional at the
   call site. Returns nil."

--- a/implementation/resources/src/re_frame/resources/route.cljc
+++ b/implementation/resources/src/re_frame/resources/route.cljc
@@ -183,25 +183,32 @@
     (update-in runtime-db (plan-slots-map-path) dissoc nav-token)
     runtime-db))
 
-;; ---- the ONE readiness projector -----------------------------------------
+;; ---- the reply-driven readiness projector ---------------------------------
 ;; ---- (Spec 012 §Route readiness is a resource projection /
 ;; ----  Spec 016 §Route integration / §SSR wait point) ----------------------
 ;;
 ;; Route readiness (`:rf.route/transition` / `:rf.route/error`) is a PURE
 ;; projection over the active plan's BLOCKING resource requirements, read in
-;; Spec 016 resource vocabulary. There is exactly ONE implementation of that
-;; table, and EVERY path that can change a blocking requirement's facts
-;; projects through it: the activation commit (via the plan's blocking set,
-;; which routing seeds the slice from — `re-frame.routing.readiness`), a
-;; retained-owner adoption / handoff, an `ensure` fresh-skip, every resource
+;; Spec 016 resource vocabulary. `reconcile-readiness` is the ONE implementation
+;; of that table on the REPLY-DRIVEN side, and every path that can change a
+;; blocking requirement's facts AFTER the activation commit projects through it:
+;; a retained-owner adoption / handoff, an `ensure` fresh-skip, every resource
 ;; settle, SSR hydration, and epoch restore. No caller decides for itself what
 ;; a settle "meant": they write the entry, then hand the runtime-db to
 ;; `reconcile-readiness`, which RE-READS the facts. That is what keeps a second
-;; readiness state machine from existing.
+;; readiness state machine from existing on this side.
 ;;
-;; Routing owns no part of this: it provides the `:routing/on-route-entry` plan
-;; hook, seeds the slice at commit, and (EP-0037 R1) consults no settle event
-;; and no blocking predicate.
+;; The ACTIVATION COMMIT is the one path that does NOT come through here.
+;; Routing seeds the slice from the plan's blocking set with its own statement
+;; of the same table (`re-frame.routing.readiness/project-at-commit`), because
+;; packaging forbids sharing one function: `deps.edn` holds routing as a
+;; TEST-ONLY dep of this artefact and the routing integration is late-bound, so
+;; this namespace cannot `:require` it. The two agree — error beats loading
+;; beats idle in both — and changing the precedence means changing both sites.
+;;
+;; Routing owns no part of the reply-driven half: it provides the
+;; `:routing/on-route-entry` plan hook, seeds the slice at commit, and
+;; (EP-0037 R1) consults no settle event and no blocking predicate.
 ;;
 ;; The nav-token's blocking slot is the OUTSTANDING requirement set for that
 ;; activation — the requirements that still have to resolve. A requirement that
@@ -328,10 +335,16 @@
 
 (defn reconcile-readiness
   "Re-project the CURRENT route's readiness from the live Spec 016 resource
-  facts, and prune the requirements that are done. THE projector — every
-  caller that has just written a resource entry (a settle, an adoption, a
+  facts, and prune the requirements that are done. THE reply-driven projector —
+  every caller that has just written a resource entry (a settle, an adoption, a
   fresh-skip, hydration, restore) hands it the updated runtime-db instead of
   deciding for itself what the change meant. Returns the updated runtime-db.
+
+  Its commit-time sibling is `re-frame.routing.readiness/project-at-commit`,
+  which seeds the slice from the plan's blocking set in ROUTING vocabulary
+  (plan-error / blocking / usable-data). Packaging requires two sites rather
+  than one shared fn — see the block comment above — so the table below and
+  that namespace's table must be edited together.
 
   The projection (Spec 012 §Route readiness is a resource projection):
 

--- a/implementation/routing/src/re_frame/routing/events.cljc
+++ b/implementation/routing/src/re_frame/routing/events.cljc
@@ -5,8 +5,6 @@
     - `emit-activation-traces!` — the `:rf.route/activated` /
       `:rf.route/deactivated` lifecycle pair (Spec 012 §Trace events,
       rf2-dn26r);
-    - `identical-route-target?` — Spec 012 §Per-route data loading rule
-      3 short-circuit predicate;
     - `merge-route-slice` — the slice-publish merge over
       `[:rf.runtime/routing :current]` (encodes the slice-shape
       contract once for both the programmatic-nav and URL-driven paths,
@@ -89,30 +87,6 @@
     (trace/emit! :rf.event :rf.route/activated
                  (cond-> {:route-id next-id}
                    frame (assoc :frame frame)))))
-
-;; Per Spec 012 §Per-route data loading rule 3: same-route-id
-;; navigations with IDENTICAL params/query (and identical fragment) do
-;; not re-fire `:on-match` — the runtime compares the prospective slice
-;; against the current one and skips the dispatch when nothing relevant
-;; changed. Re-firing the loaders would re-fetch unchanged data on every
-;; redundant navigation (clicking the already-active nav link, a
-;; duplicate `[:rf.route/navigate {:to :route/cart}]`, popstate to the current
-;; URL), which is the data-refetch thrash the rule forbids. The
-;; fragment-only case (id/params/query equal, fragment changed) is the
-;; sibling short-circuit (rf2-8oxj6); this predicate is the stricter
-;; "nothing at all changed" case.
-(defn identical-route-target?
-  "True when the prospective navigation target (`id`/`params`/`query`/
-  `fragment`) is identical to the current route slice — a complete
-  no-op re-navigation. `prev` is the current slice (or nil before first
-  nav)."
-  [prev id params query fragment]
-  (boolean
-    (and prev
-         (= (:route-id prev) id)
-         (= (:params prev)   params)
-         (= (:query prev)    query)
-         (= (:fragment prev) fragment))))
 
 ;; Per Spec 012 §The route slice and Spec-Schemas §`:rf/runtime-db` the
 ;; published slice carries exactly `{:route-id :params :query :fragment

--- a/implementation/routing/src/re_frame/routing/plan.cljc
+++ b/implementation/routing/src/re_frame/routing/plan.cljc
@@ -27,7 +27,6 @@
 
   Internal namespace; the public facade is `re-frame.routing`."
   (:require [re-frame.routing.egress :as egress]
-            [re-frame.routing.events :as routing-events]
             [re-frame.routing.scroll :as scroll]
             [re-frame.trace :as trace]))
 
@@ -71,14 +70,31 @@
 
 ;; ---- classification ------------------------------------------------------
 
-;; `identical-route-target?` is the complete-no-op predicate (Spec 012
-;; §Per-route data loading rule 3) — re-exported here so the planner
-;; surface carries the full classification vocabulary both entry points
-;; key on. The implementation lives in `re-frame.routing.events` (it is
-;; also consumed by `commit-navigation`'s neighbours); the alias avoids a
-;; second definition while letting planner callers + planner tests reach
-;; it through the cohesive plan seam.
-(def identical-route-target? routing-events/identical-route-target?)
+;; Per Spec 012 §Per-route data loading rule 3: same-route-id
+;; navigations with IDENTICAL params/query (and identical fragment) do
+;; not re-fire `:on-match` — the runtime compares the prospective slice
+;; against the current one and skips the dispatch when nothing relevant
+;; changed. Re-firing the loaders would re-fetch unchanged data on every
+;; redundant navigation (clicking the already-active nav link, a
+;; duplicate `[:rf.route/navigate {:to :route/cart}]`, popstate to the current
+;; URL), which is the data-refetch thrash the rule forbids. The
+;; fragment-only case (id/params/query equal, fragment changed) is the
+;; sibling short-circuit (rf2-8oxj6); this predicate is the stricter
+;; "nothing at all changed" case.
+
+(defn identical-route-target?
+  "True when the prospective navigation target (`id`/`params`/`query`/
+  `fragment`) is identical to the current route slice — a complete
+  no-op re-navigation. `prev` is the current slice (or nil before first
+  nav). Mutually exclusive with `fragment-only?` below, its sibling in
+  the stage-3 no-op / fragment-only / full discrimination."
+  [prev id params query fragment]
+  (boolean
+    (and prev
+         (= (:route-id prev) id)
+         (= (:params prev)   params)
+         (= (:query prev)    query)
+         (= (:fragment prev) fragment))))
 
 (defn fragment-only?
   "Spec 012 §Fragments rules 3-4: true when the prospective target shares

--- a/implementation/routing/src/re_frame/routing/readiness.cljc
+++ b/implementation/routing/src/re_frame/routing/readiness.cljc
@@ -5,10 +5,8 @@
   Route readiness (`:rf.route/transition` / `:rf.route/error`) is a PURE
   projection over the active route plan's blocking resource requirements. It
   is NEVER driven by `:on-match` (which is fire-and-forget). This namespace is
-  the ONE pure implementation the navigation-commit assembler uses to seed the
-  stored slice; the Resources artefact's reply-driven reconciliation (Spec 016
-  §Route integration) and any hydration / epoch-restore reconciliation project
-  through the same table:
+  the COMMIT-TIME half of that projection — the one the navigation-commit
+  assembler uses to seed the stored slice from the freshly built plan:
 
   | Effective-plan state                       | :transition | :error          |
   |--------------------------------------------|-------------|-----------------|
@@ -17,6 +15,20 @@
   | a blocking first load failed               | :error      | first failure   |
   | all blocking have usable data, or none     | :idle       | nil             |
   | Resources artefact absent                  | :idle       | nil             |
+
+  THE TABLE HAS TWO IMPLEMENTATIONS, and changing the precedence means changing
+  both. The reply-driven half is `re-frame.resources.route/reconcile-readiness`
+  (Spec 016 §Route integration): it re-reads the live resource facts on every
+  settle, retained-owner adoption, `ensure` fresh-skip, SSR hydration and epoch
+  restore, and states the same precedence in Spec 016 resource vocabulary
+  (`:failed` / `:pending` / an empty outstanding set, where the rows above read
+  plan-error / blocking / usable-data). Packaging requires the split rather than
+  one shared function: `implementation/resources/deps.edn` holds routing as a
+  TEST-ONLY dep and the routing integration is late-bound, so resources cannot
+  `:require` this namespace, and publishing a `:routing/project-readiness`
+  late-bind hook for a three-line `cond` would cost more than the duplication
+  removes. The two agree today — error beats loading beats idle in both — and
+  nothing but this note keeps them agreeing.
 
   R1 applies this over R0's behaviour-preserving leaf-only plan; R2 swaps the
   plan input for the parent-to-leaf branch plan without changing the table.")
@@ -31,8 +43,10 @@
   commit the blocking requirements have only just been ensured, so a non-empty
   blocking set is a pending first load → `:loading`; a planning failure →
   `:error` (carrying the planning error); otherwise → `:idle`. The Resources
-  reply handlers reconcile `:loading` → `:idle` / `:error` through the same
-  table as each blocking requirement settles. Returns
+  reply handlers then reconcile `:loading` → `:idle` / `:error` as each blocking
+  requirement settles, through their OWN statement of the same table
+  (`re-frame.resources.route/reconcile-readiness` — see the ns docstring for why
+  there are two). Returns
   `{:transition :idle|:loading|:error :error <err-or-nil>}`."
   [plan]
   (let [plan-error (:plan-error plan)

--- a/implementation/routing/src/re_frame/routing/strategy.cljc
+++ b/implementation/routing/src/re_frame/routing/strategy.cljc
@@ -105,8 +105,10 @@
      "History strategy `:install-listener!` — install a `window`
      `popstate` listener that calls `on-change` with the decoded (path-form)
      current URL. Returns a 0-arg teardown thunk. Does NOT do the initial
-     sync — the caller (`install-url-listener!`) drives that once at install
-     via `on-change` so it happens for every strategy uniformly."
+     sync — the caller (`re-frame.routing.history/install-listener-for-owner!`,
+     reached through the `reconcile-url-listener!` frame-lifecycle op) drives
+     that once at install, under cause `:initial` rather than through this
+     `on-change`, so it happens for every strategy uniformly."
      [on-change]
      (let [handler (fn [_event] (on-change (history-decode)))]
        (.addEventListener js/window "popstate" handler)


### PR DESCRIPTION
Four EP-0037 gate-3 quality findings in the routing artefact, each a net deletion or a
docstring correction. In flight — body updated as beads land.

- rf2-yvn0g (P4) — listener docstrings named the retired `install-url-listener!`.
- rf2-wzqtu (P3) — `readiness.cljc` claimed to be the ONE projector.
- rf2-saf54 (P4) — move `identical-route-target?` into `plan.cljc`.
- rf2-e9974 (P3) — `rf/route-link` inlined the click law `activate-link!` owns.

## Quality gates

Pending.
