### PR TITLE
spec,scripts: correct the 004D handler-map example, name fh-diag-003's rosters, derive the census CLJS lane selectors (rf2-uvcm3, rf2-h6wtl, rf2-k41ph)

### DIFF
--- a/scripts/check_freehand_conformance_index.py
+++ b/scripts/check_freehand_conformance_index.py
@@ -166,6 +166,7 @@ already pinned in requirements.txt).
 from __future__ import annotations
 
 import argparse
+import functools
 import re
 import sys
 import tempfile
@@ -177,9 +178,29 @@ from typing import NamedTuple
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from check_doc_slugs import _slug_index  # noqa: E402
 
+# One reader for shadow-cljs build configuration, borrowed from the gate whose
+# whole thesis is that a lane roster is READ and never listed
+# (check_test_lane_bijection.py, "THE LANES ARE READ, NEVER LISTED").  This
+# census consults exactly two of those builds — the ones that schedule its CLJS
+# lanes — and a second EDN reader written here to do it would be the drift class
+# both gates exist to close.
+from check_test_lane_bijection import (  # noqa: E402
+    SHADOW_DEFAULT_NS_REGEXP,
+    match_delimiter,
+    read_map_entries,
+    strip_edn_comments,
+    unescape_edn_string,
+)
+
 INDEX_REL = Path("spec/conformance/freehand/conformance-index.md")
 FIXTURES_REL = Path("spec/conformance/freehand/fixtures")
 TESTS_REL = Path("implementation/freehand/test")
+SHADOW_CLJS_REL = Path("implementation/shadow-cljs.edn")
+
+# This script's own checkout.  The build configuration is a fact about the repo
+# that DEFINES the lanes, not about whatever tree a `--repo-root` names, and the
+# census self-test runs against synthetic trees that carry no build at all.
+_SCRIPT_REPO = Path(__file__).resolve().parent.parent
 
 # The area roster, in index order.  Closed at any given moment — an id or a
 # section naming an area that is not here fails — but the programme EP
@@ -1105,19 +1126,29 @@ def _reached(path: Path, graph: _Graph) -> dict[str, bool]:
                 out[row_id] = out.get(row_id, False) or witness
     return out
 
-# Which lane runs a test file, derived from the three discovery rules in force —
-# not asserted here, mirrored from where they are actually configured:
+# Which lane runs a test file (`_lanes_for`).  Three discovery rules, and where
+# each one comes from:
 #
-#   jvm      `clojure -M:test` in implementation/freehand.  cognitect-test-runner
-#            discovers namespaces ending `-test` over the `:clj` platform, which
-#            is `.clj` + `.cljc`.
-#   node     `npm run test:freehand` — the :node-test-freehand build's ns-regexp
-#            `^re-frame\.freehand\..+-cljs-test$`, which matches `-cljs-test` AND
-#            `-dom-cljs-test`, over `.cljs` + `.cljc`.
-#   browser  `npm run test:browser` — the :browser-test build's ns-regexp
-#            `-dom-cljs-test$`, `.cljs` only.  The mounted tier: real DOM, real
-#            listeners.
+#   jvm      `clojure -M:test` in implementation/freehand.  The runner discovers
+#            namespaces ending `-test` over the `:clj` platform, which is `.clj`
+#            + `.cljc`.  Stated here, because the rule lives in that artefact's
+#            deps.edn `:test` alias rather than in any file this census reads.
+#   node     `npm run test:freehand` — the :node-test-freehand build.
+#   browser  `npm run test:browser` — the :browser-test build.  The mounted tier:
+#            real DOM, real listeners.
 LANES: tuple[str, ...] = ("jvm", "node", "browser")
+
+# rf2-k41ph — the two CLJS lanes name their BUILD and nothing else.  Each build's
+# `:ns-regexp` is read from the config at `_cljs_lane_selectors`, never restated
+# here: a copy of a selector is a second authority with nothing holding it in
+# step with the first, so an edit to either side silently desynchronises this
+# census's lane model from the selection the build actually performs — and a
+# census whose lane model is wrong keeps certifying rows against lanes they have
+# left.  Deriving it makes that divergence unrepresentable.
+_CLJS_LANE_BUILDS: dict[str, str] = {
+    "node": ":node-test-freehand",
+    "browser": ":browser-test",
+}
 
 _QUALIFIED_HOST_LANES = frozenset({"browser"})
 
@@ -1494,19 +1525,89 @@ _CITATION_EXCLUDED = (
 _CITATION_SUFFIXES = (".md",)
 
 
-def _lanes_for(path: Path) -> frozenset[str]:
-    """The lanes that run the test file at `path` (see LANES)."""
-    name = path.name
-    if name.endswith("_test.clj"):
-        return frozenset({"jvm"})
-    if name.endswith("_test.cljc"):
-        return frozenset({"jvm", "node"} if name.endswith("_cljs_test.cljc")
-                         else {"jvm"})
-    if name.endswith("_dom_cljs_test.cljs"):
-        return frozenset({"node", "browser"})
-    if name.endswith("_cljs_test.cljs"):
-        return frozenset({"node"})
-    return frozenset()
+def _namespace_of(path: Path, test_root: Path) -> str:
+    """The namespace a test file under `test_root` declares.
+
+    Munged from the path rather than read from the `(ns …)` form, because that is
+    what the runners do: a namespace whose name disagreed with its path could not
+    be loaded from it at all.
+    """
+    return ".".join(
+        path.relative_to(test_root).with_suffix("").parts
+    ).replace("_", "-")
+
+
+@functools.lru_cache(maxsize=None)
+def _cljs_lane_selectors() -> tuple[tuple[str, re.Pattern[str]], ...]:
+    """`(lane, selector)` for each CLJS lane, READ from the build that schedules
+    it — see `_CLJS_LANE_BUILDS` for which build owns which lane, and why the
+    selector is not written down here (rf2-k41ph).
+
+    Two things make the derivation load-bearing rather than decorative.  Selection
+    is shadow-cljs's `re-find`, so `search` and not `match`; and each derived
+    selector is held to PARTITIONING this repo's Freehand test tree — selecting at
+    least one namespace and rejecting at least one.  A derivation is the one
+    mechanism a restatement cannot drift from, and also the one that can fail
+    SILENTLY: a pattern that matches nothing quietly empties a lane, and a pattern
+    that matches everything quietly serves every cell of every row.  Both look
+    exactly like a green census.  The floor is what makes them look like a red one.
+    """
+    config = _SCRIPT_REPO / SHADOW_CLJS_REL
+    text = strip_edn_comments(config.read_text(encoding="utf-8"))
+    at = re.search(r":builds\s*\{", text)
+    if not at:
+        raise SystemExit(
+            f"error: {SHADOW_CLJS_REL.as_posix()} declares no :builds map, so no "
+            "CLJS lane selector can be derived (rf2-k41ph)."
+        )
+    builds = dict(read_map_entries(
+        text[at.end():match_delimiter(text, at.end() - 1) - 1]
+    ))
+    test_root = _SCRIPT_REPO / TESTS_REL
+    namespaces = [_namespace_of(p, test_root)
+                  for p in sorted(test_root.rglob("*"))
+                  if p.suffix in _CLJ_SUFFIXES]
+    selectors: list[tuple[str, re.Pattern[str]]] = []
+    for lane, build in _CLJS_LANE_BUILDS.items():
+        if build not in builds:
+            raise SystemExit(
+                f"error: {SHADOW_CLJS_REL.as_posix()} declares no {build} build, "
+                f"so the {lane} lane's selector cannot be derived.  A renamed "
+                "build is a lane this census can no longer model (rf2-k41ph)."
+            )
+        found = re.search(r':ns-regexp\s+"((?:[^"\\]|\\.)*)"', builds[build])
+        # shadow-cljs's own default when a test build omits the key — modelling it
+        # is what keeps a legal config from reading as a broken derivation.
+        selector = re.compile(unescape_edn_string(found.group(1)) if found
+                              else SHADOW_DEFAULT_NS_REGEXP)
+        selected = [ns for ns in namespaces if selector.search(ns)]
+        if not selected or len(selected) == len(namespaces):
+            raise SystemExit(
+                f"error: {build}'s :ns-regexp {selector.pattern!r} selects "
+                f"{'every one of' if selected else 'none'} of the "
+                f"{len(namespaces)} namespace(s) under {TESTS_REL.as_posix()}/, "
+                f"so the {lane} lane's derived membership is vacuous — it would "
+                "empty the lane, or serve every cell of every row, without "
+                "reddening a thing (rf2-k41ph)."
+            )
+        selectors.append((lane, selector))
+    return tuple(selectors)
+
+
+def _lanes_for(path: Path, test_root: Path) -> frozenset[str]:
+    """The lanes that run the test file at `path` (see LANES).
+
+    The platform a lane runs on gates it before its selector does: a `.clj` file
+    is nothing to a CLJS build however its namespace is spelled.
+    """
+    lanes = set()
+    if path.suffix in (".clj", ".cljc") and path.stem.endswith("_test"):
+        lanes.add("jvm")
+    if path.suffix in (".cljs", ".cljc"):
+        ns = _namespace_of(path, test_root)
+        lanes |= {lane for lane, selector in _cljs_lane_selectors()
+                  if selector.search(ns)}
+    return frozenset(lanes)
 
 
 class _Proof(NamedTuple):
@@ -1544,7 +1645,7 @@ def _scan_proof_sites(
     graphs = {platform: _read_tree(repo_root, platform)
               for platform in _PLATFORM_LANES}
     for path in sorted(test_root.rglob("*")):
-        file_lanes = _lanes_for(path)
+        file_lanes = _lanes_for(path, test_root)
         if path.suffix not in _CLJ_SUFFIXES or not file_lanes:
             continue
         reached: dict[str, tuple[set[str], set[str]]] = {}

--- a/spec/004D-Freehand-Compiled-Grammar.md
+++ b/spec/004D-Freehand-Compiled-Grammar.md
@@ -787,9 +787,18 @@ same-spelled user macro is rejected, and a hostile local named `some?` / `when`
 cannot capture the compiler-generated nil test or branch).
 
 **DOM prop spelling is pinned:** hyphenated lowercase words mirroring React's camelCase
-— `:on-click`, `:on-key-down`, `:on-input` (never `:on-keydown`). Handler-map options:
-`{:event […] :prevent-default true :stop-propagation true :capture true :passive true
-:once true}` — the DOM listener vocabulary is explicit, not implied.
+— `:on-click`, `:on-key-down`, `:on-input` (never `:on-keydown`). The handler-map option
+roster is closed at six keys, and **no one legal map carries all six**: `:passive` and
+`:prevent-default` are mutually exclusive, because a passive listener promises the
+browser it will never call `preventDefault`, so a map carrying both is refused —
+`:rf.ui.compile/contradictory-handler-options` at compile time, and the same verdict
+from the canonical options plan the interpreted and structural tiers ask. The two sides
+of the native-attachment lane carry the roster between them: on the blocking side
+`{:event […] :prevent-default true :stop-propagation true :capture true :once true}`, and
+on the passive side
+`{:event […] :passive true :stop-propagation true :capture true :once true}`. The DOM
+listener vocabulary is explicit, not implied (`FH-EVENT-002` governs both the closed
+roster and the exclusion).
 
 **Prop conversion is compile-time, contextual, and total:** DOM attribute casing,
 `:style` maps (keyword values stringify), `:class` string/vector/map-of-flags; component

--- a/spec/conformance/freehand/fixtures/fh-diag-003.edn
+++ b/spec/conformance/freehand/fixtures/fh-diag-003.edn
@@ -2,10 +2,13 @@
 ;; roster, and a finding is governed as a FINDING rather than as a site.
 ;;
 ;; `:diagnostics` is the one manifest roster whose entries are not lexical
-;; sites. The other six name a form the compiler READ — a `sub`, an event
-;; handler, a slot, a `(frame)` read, a `v/html`, a view crossing — and so own
-;; the `{:file :line :column}` source coordinate FH-STRUCT-010 makes total over
-;; them. A finding is MINTED from a node instead: it names the node's `:tag` and
+;; sites. The others are NAMED here rather than counted, because a tally goes
+;; wrong the moment a roster arrives or leaves and a name cannot:
+;; `:subscriptions` (a `sub`), `:events` (an event handler), `:slots` (a slot),
+;; `:html-sites` (a `v/html`) and `:crossings` (a view crossing) each name a form
+;; the compiler READ, and so own the `{:file :line :column}` source coordinate
+;; FH-STRUCT-010 makes total over them. `:frame-ops` was a sixth roster until
+;; rf2-h1ae3. A finding is MINTED from a node instead: it names the node's `:tag` and
 ;; the deterministic `:path` that reaches it, plus the compiler-minted stable
 ;; `:sid` its printed warning quotes. Those three are what locate it, and this
 ;; fixture governs that shape rather than bending a finding into the site law —


### PR DESCRIPTION
Three beads on the Freehand conformance surface. They cluster because they share
the census/fixture machinery and one `--report` baseline; doing them separately
would re-baseline it three times.

- **`rf2-uvcm3`** (P2, bug) — the canonical `spec/004D` handler-map example taught
  a combination the shipped classifier refuses.
- **`rf2-h6wtl`** (P4) — `fh-diag-003`'s header comment counted six manifest
  rosters and named a `(frame)` read.
- **`rf2-k41ph`** (P2) — the census restated the `:node-test-freehand`
  `:ns-regexp` instead of deriving from it.

## Found versus changed

### `rf2-uvcm3` — the 004D example

**Found.** The bead's title and original description name two conformance fixture
rows. Both were already corrected on `main` by the PR #6931/#6963 wave, so neither
needed touching: `fh-struct-003.edn:103`'s `[:div {:on-click "go"}]` row now reads
`:rf.error/view-bad-event` (it read `:rf.error/ui-tree-malformed`), and
`fh-struct-002.edn`'s options-map row is roster-clean at
`{:event [:cart/checkout] :once :fh/fn}` with its note saying so. `fh-event-002.edn`
already carries the split `:options-every-blocking-option` /
`:options-every-passive-option` pair and the rejected
`:options-passive-prevent-default` row.

What remained is the #6963 reopen scope: `spec/004D-Freehand-Compiled-Grammar.md`
presented **one** options-map literal carrying all six roster keys,
`:prevent-default true` and `:passive true` among them — a pair both
`compiler/analyze.cljc` and the canonical `events/options-plan` now refuse.

**Changed.** That paragraph, and one more the audit's sweep missed. It is now two
legal maps, one per side of the native-attachment lane, carrying all six roster
keys between them, with the mutual exclusion stated beside them and `FH-EVENT-002`
cited. The paragraph is the only prose this bead needed in `spec/`, and nobody
holds 004D this wave.

**Out-of-bead find, corrected in the same commit series.** The #6963 note says a
repo-wide sweep for the exact combination "found no other positive documentation
example". Re-running it over every tracked map literal (`git ls-files` →
`{[^{}]*}` scan of `.md/.edn/.clj/.cljc/.cljs`, 13 hits) found one more:
`skills/re-frame2-ui/SKILL.md:253` presented the same all-six-keys map, and
`re-frame.ui`'s own analyzer refuses it. Corrected the same way. That is the
authored skill file, **not** the generated `references/ui-context.md` leaf, so no
regeneration is involved and no digest is disturbed. The other 11 hits are all
refusal sites or vocabulary sets and are correct as they stand — including
`docs/core/freehand/events-and-handlers.md`, whose fenced example is already legal
(`{:event [:signup/requested] :prevent-default true}`) and whose roster mention is
a prose list, not a map literal. **No file under `docs/core/freehand/**` is
touched.**

Filed, not fixed: **`rf2-av5ml`** (P4) — `re-frame.ui`'s runtime
(`ui/events.cljs:610`) accepts the pair its own analyzer refuses, the exact
asymmetry `rf2-uvcm3` removed on the Freehand side. `implementation/ui/` source was
outside this dispatch.

### `rf2-h6wtl` — the fh-diag-003 comment

**Found.** Exactly as the bead describes: "The other six name a form the compiler
READ — a `sub`, an event handler, a slot, a `(frame)` read, a `v/html`, a view
crossing". `:frame-ops` was retired by rf2-h1ae3, so the lexical-site rosters are
five, and `re-frame.freehand/frame` is interned on neither host.

**Changed.** Not the tally — the *shape*. A count is a claim nothing verifies, and
correcting `six` to `five` leaves the next roster arrival free to falsify it again.
The rosters are now **named**: `:subscriptions`, `:events`, `:slots`,
`:html-sites`, `:crossings`, each beside the form it reads, with the sixth's
departure recorded in the sibling fixture's own words (`fh-struct-010.edn:60`).

### `rf2-k41ph` — the lane derivation

**Found.** `_lanes_for` restated the `:node-test-freehand` `:ns-regexp` as a chain
of filename suffixes — two authorities for one selector with nothing holding them
in step. Also found, same defect one line down: `:browser-test`'s `-dom-cljs-test$`
was restated the same way, *plus* a `.cljs`-only clause that is not in the build
config at all.

Confirmed the bead's own `MAYOR CORRECTION` before starting: the rf2-lgozq sweep
**adds** a lane suffix, so no suite ever left the node lane — all 66 `.cljc`
freehand suites on `main` already end `_cljs_test.cljc`. The residual is the
derivation, exactly as the bead states, and this PR closes on that.

**Changed.** Both CLJS selectors are now **read** from
`implementation/shadow-cljs.edn`; the only thing written down is which build owns
which lane. Selection applies shadow-cljs's `re-find` semantics to the namespace
munged from the path, which is what the runners select on. The JVM lane stays a
stated rule — its discovery lives in the artefact's `deps.edn` `:test` alias, not
in any file this census reads — and the comment now says so instead of implying all
three are mirrored.

A derivation cannot drift, but it *can* fail silently: a pattern matching nothing
quietly empties a lane, one matching everything quietly serves every cell of every
row, and both look exactly like a green census. So each derived selector is held to
**partitioning** the Freehand test tree — at least one namespace selected, at least
one rejected — and a missing `:builds` map or a renamed build is a hard error naming
the lane it orphaned.

The EDN reader is borrowed from `check_test_lane_bijection.py`, the gate whose own
thesis is that a lane roster is read and never listed. A second reader here would
be the drift class both gates exist to close. (`from check_doc_slugs import …` was
the existing precedent for a sibling import in this file.)

`implementation/shadow-cljs.edn` is **not** in this diff — verified by blob hash
against `HEAD` after the negative controls below.

## Census row count

| | rows in index | applicable (`active`) | `--report` |
|---|---|---|---|
| before (`origin/main`) | 98 (97 active, 1 retired) | 97 | 103 lines |
| after | 98 (97 active, 1 retired) | 97 | **byte-identical** |

No row moves, and none was expected to: the derivation reproduces the previous
restatement exactly on today's tree, which is the point — it is the same answer
from an authority that cannot go stale. Re-derived rather than assumed from the
"~98" in the brief.

## Quality gates

All run in this worktree, foreground to completion, `rc` captured immediately into
a worktree-local log and cross-checked against each log's own PASS/FAIL line.

| Gate | Result | rc |
|---|---|---|
| `implementation/freehand` `clojure -M:test` | 1102 tests / 7420 assertions, 0 failures, 0 errors | 0 |
| `npm run test:cljs` | 11453 tests / 57342 assertions, 0 failures, 0 errors | 0 |
| census `--self-test --verbose` | all 96 self-tests passed | 0 |
| census live scan `--verbose` | index OK 98 rows / 15 areas; census OK 97 applicable, 4 `compiled` rows witnessed | 0 |
| census `--report` | 103 lines, byte-identical to the `origin/main` baseline | 0 |
| `scripts/check_test_lane_bijection.py` | 1651 test-defining files, 44 lanes, every file selected and every selector reached | 0 |
| `scripts/test-fast-pr.sh` | `PASS fast PR spine` — includes the skill/MCP drift, migration cite-integrity, implementor-order, eval-docs, README-inventory, retired-spelling, thrown-error, doc-anchor and lane-bijection gates, JVM core, the JS harness suites and per-ns isolation (17/17) | 0 |

`npm run test:browser` **not run, and not applicable**: the diff is spec prose, an
EDN header comment, an authored skill bullet and a Python gate. No rendering path,
no `.cljs`/`.cljc` source, no fixture *data* is touched.

`test-fast-pr.sh` soft-skipped `mkdocs --strict` (not on PATH on this machine); CI
runs it. It also reported the freehand JVM artefact under "suites the diff did not
touch" — correct, and it is the first row of this table, run separately.

## Negative controls

Every one is revert-in-place: red shown, restored, green shown.

### `rf2-uvcm3` — the shipped contract is pinned by a live assertion

Flipped `fh-event-002.edn`'s `:options-passive-prevent-default` row from
`:rf.error/view-bad-event` to `:rf.error/ui-tree-malformed`.

- red: `re-frame.freehand.events-cljs-test` — 34 tests / 225 assertions,
  **1 failure**, rc=1, on
  `(= error-id (conf/caught-id … (events/event-plan (get plan-forms form))))`,
  `actual: (not (= :rf.error/ui-tree-malformed :rf.error/view-bad-event))`.
- restored → green.

So the contract my 004D prose now describes is the one a live assertion holds the
code to, and a fixture-only `.edn` edit does invalidate the build cache.

### `rf2-h6wtl` — both halves of the bead's `SCOPE` claim

The bead says no assertion reads the comment. Verified in both directions:

- the comment change itself is green across the full 1102-test freehand JVM suite —
  nothing reads it, as claimed;
- the fixture *data* in the same file is load-bearing, so the file is genuinely
  wired: `:path [0]` → `[9]` reds
  `re-frame.freehand.manifest-diagnostics-cljs-test` — 4 tests / 21 assertions,
  **1 failure**, rc=1.
- restored → both suites green together: 38 tests / 246 assertions, 0 failures,
  rc=0.

### `rf2-k41ph` — four controls, all on `implementation/shadow-cljs.edn`, all reverted

| Mutation | Result | rc |
|---|---|---|
| `:node-test-freehand`'s `:ns-regexp` → `-jvm-test$` | census red, **68 `UNEXECUTED CELL`** defects | 1 |
| …**same mutation against the pre-fix script** (`git show HEAD:scripts/check_freehand_conformance_index.py`) | **green** — "census OK: 97 APPLICABLE row(s)" | **0** |
| `:ns-regexp` → `-nope-nothing-matches$` (matches nothing) | vacuity floor: "selects none of the 235 namespace(s)" | 1 |
| `:ns-regexp` → `.` (matches everything) | vacuity floor: "selects every one of the 235 namespace(s)" | 1 |
| build key renamed to `:node-test-freehand-renamed` | "declares no `:node-test-freehand` build" | 1 |

Row two is the bead's defect reproduced: before this change the census exited **0**
while the build config said its node lane runs nothing at all. After it, the same
edit reds with 68 named defects. `implementation/shadow-cljs.edn` was then restored
and confirmed identical to `HEAD` by blob hash, and is absent from the diff.

The vacuity floor is proven by mutation rather than by a self-test fixture, and
deliberately so: the derivation reads the config from *this script's own checkout*
(a build is a fact about the repo that defines the lanes, and the census self-test
runs against synthetic trees carrying no build), so a mini-repo fixture could not
reach it. The floor runs on every census invocation, and that workflow's
`pull_request` trigger is unfiltered, so it is armed on every PR.

## Follow-ups filed

- **`rf2-av5ml`** (P4, bug) — `re-frame.ui`'s runtime accepts the
  `:passive`/`:prevent-default` pair its own analyzer refuses; the Freehand fix is
  the template.
- **`rf2-kx06s`** (P4) — `.github/workflows/freehand-conformance.yml`'s `push:`
  paths filter does not list the two files the census now derives from. No
  guarantee is lost (that workflow's `pull_request` trigger is deliberately
  unfiltered), but the list should be honest. Two lines, deferred because
  `.github/workflows/**` was fenced to a live CI worker this wave.
