### PR TITLE
fix(resources): make the off-box trace-egress fail-closed default read SHAPE, not slot name (rf2-wd9im)

### DIFF
--- a/implementation/epoch/test/re_frame/epoch_egress_resource_trace_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_egress_resource_trace_test.clj
@@ -35,6 +35,7 @@
             [re-frame.core :as rf]
             [re-frame.epoch :as epoch]
             [re-frame.resources.state :as state]
+            [re-frame.resources.work-ledger :as work-ledger]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
             ;; load-bearing: publishes the :resources/* late-bind hooks,
@@ -504,3 +505,186 @@
           tags      (:tags (first (:trace-events projected)))]
       (is (= http-error-envelope (:error tags))
           "the raw envelope rides with :include-sensitive?"))))
+
+;; ---------------------------------------------------------------------------
+;; (rf2-wd9im) the SHAPE-driven fail-closed default — a scoped key sitting in a
+;; slot the projector's vocabulary does not NAME.
+;; ---------------------------------------------------------------------------
+;;
+;; rf2-7qbxbm flipped the `:else` to fail CLOSED, but only over ONE value shape:
+;; a MAP. A SEQUENTIAL value under an unnamed slot still fell through verbatim,
+;; so `:rf.resource/route-plan`'s `:blocking` / `:identities` — EP-0037 R1/R2
+;; VECTORS OF SCOPED KEYS on a row that predates the projector — egressed a
+;; `:sensitive?` owner's resolved scope and canonical params RAW, while the
+;; IDENTICAL keys under `:matched` tokenized. The repair reads SHAPE rather than
+;; slot name, which also covers `:optimistic-keys` / `:forced-keys` /
+;; `:revisions` and the scoped key EMBEDDED in every resource work-id.
+
+(defn- route-plan-tags
+  "A `:rf.resource/route-plan` row's tags in the shape `route.cljc` emits them
+  (EP-0037 R1/R2): `:blocking` + `:identities` are VECTORS OF SCOPED KEYS,
+  `:branch` is a vector of route ids that MUST ride verbatim, and `:removed` is
+  an INT COUNT (the same slot NAME the mutation-settlement rows use for a key
+  vector — the row and the projector were written against different mental
+  models of `:removed`, and both must be handled)."
+  [blocking identities]
+  {:rf.frame/id :test/rt
+   :route-id    :r/article
+   :nav-token   7
+   :branch      [:r/root :r/article]
+   :ensured     2
+   :kept        1
+   :removed     1
+   :blocking    blocking
+   :identities  identities})
+
+(deftest off-box-redacts-route-plan-blocking-and-identities
+  (testing "rf2-wd9im — a :rf.resource/route-plan row's :blocking / :identities
+            plan-membership slots are VECTORS OF SCOPED KEYS under no NAMED slot;
+            a :sensitive? owner's scope + params must tokenize PER KEY, not
+            egress raw"
+    (let [k1        (sk :rf.scope/global :secret/article {:auth-token secret})
+          k2        (sk :rf.scope/global :secret/article
+                        {:auth-token (str secret "-2")})
+          record    (record-with
+                      [(event :rf.resource/route-plan (route-plan-tags [k1] [k1 k2]))])
+          projected (epoch/projected-record record)
+          tags      (:tags (first (:trace-events projected)))
+          [bscope brid bparams] (first (:blocking tags))]
+      (testing ":blocking tokenizes per key"
+        (is (= :secret/article brid) "the resource-id (position 1) survives")
+        (is (redacted-component? bscope) "the scope is tokenized")
+        (is (redacted-component? bparams) "the canonical params are tokenized"))
+      (testing ":identities tokenizes per key, preserving per-key DISTINCTNESS
+                so a tool's per-key joins survive"
+        (is (= 2 (count (:identities tags))))
+        (is (every? #(= :secret/article (second %)) (:identities tags)))
+        (is (every? #(redacted-component? (nth % 2)) (:identities tags)))
+        (is (apply not= (map #(nth % 2) (:identities tags)))
+            "two distinct keys keep two distinct digests"))
+      (is (true? (:sensitive? tags)) "the row is stamped :sensitive?")
+      (testing "the plan's structural attribution rides verbatim"
+        (is (= :r/article (:route-id tags)))
+        (is (= 7 (:nav-token tags)))
+        (is (= [:r/root :r/article] (:branch tags))
+            "a vector of ROUTE IDS is scalar-only and must NOT be tokenized")
+        (is (= 2 (:ensured tags)))
+        (is (= 1 (:kept tags)))
+        (is (= 1 (:removed tags))
+            "this row's :removed is an INT COUNT, not a key vector — it rides"))
+      (testing "NO raw secret survives anywhere in the projected record"
+        (is (not (contains-secret? projected)))))))
+
+(deftest unnamed-slot-projects-identically-to-named-slot
+  (testing "rf2-wd9im anti-drift — the SAME scoped keys under a NAMED slot
+            (:matched) and under UNNAMED slots (:blocking / :identities) must
+            project IDENTICALLY. This is the property that makes the shape-driven
+            default a replacement for growing the slot roster rather than a
+            second, weaker projection that can drift from it."
+    (let [k1        (sk :rf.scope/global :secret/article {:auth-token secret})
+          k2        (sk [:rf.scope/session {:username secret}]
+                        :derived/profile {:slug "me"})
+          ks        [k1 k2]
+          record    (record-with
+                      [(event :rf.resource/route-plan
+                              {:rf.frame/id :test/rt
+                               :matched     ks     ; NAMED  → roster arm
+                               :blocking    ks     ; UNNAMED → shape arm
+                               :identities  ks})]) ; UNNAMED → shape arm
+          projected (epoch/projected-record record)
+          tags      (:tags (first (:trace-events projected)))]
+      (is (= (:matched tags) (:blocking tags))
+          ":blocking projects exactly as the NAMED :matched does")
+      (is (= (:matched tags) (:identities tags))
+          ":identities projects exactly as the NAMED :matched does")
+      (is (every? redacted-component? (map first (:blocking tags)))
+          "both keys' scopes tokenized (the derived scope included)")
+      (is (not (contains-secret? projected))))))
+
+(deftest off-box-keeps-plain-owner-plan-membership-verbatim
+  (testing "rf2-wd9im guard — a PLAIN owner's :blocking / :identities ride
+            VERBATIM. The shape-driven default projects through the OWNER
+            classification, exactly as the named slots do, so closing the leak
+            costs no over-redaction on the ordinary route plan."
+    (let [k1        (sk :rf.scope/global :plain/article {:slug "welcome"})
+          record    (record-with
+                      [(event :rf.resource/route-plan (route-plan-tags [k1] [k1]))])
+          projected (epoch/projected-record record)
+          tags      (:tags (first (:trace-events projected)))]
+      (is (= [k1] (:blocking tags)) "a plain owner's :blocking rides verbatim")
+      (is (= [k1] (:identities tags)) "a plain owner's :identities rides verbatim")
+      (is (not (:sensitive? tags)) "a plain row is NOT stamped sensitive"))))
+
+(deftest off-box-redacts-scoped-key-embedded-in-resource-work-id
+  (testing "rf2-wd9im — a RESOURCE work-id is
+            `[:rf.work/resource <scoped-key> <generation>]`, so the scoped key
+            (and with it a sensitive owner's scope + params) is EMBEDDED one
+            level down in the :work/id tag on the majority of rows in the family
+            — :work-started / :fetch-started / :deduped / :succeeded / … . No
+            slot roster names :work/id, and the value is a vector, so it rode the
+            verbatim :else. The shape-driven default reaches it by DEPTH."
+    (let [scoped-key (sk :rf.scope/global :secret/article {:auth-token secret})
+          work-id    (work-ledger/resource-work-id scoped-key 3)
+          record     (record-with
+                       [(event :rf.resource/work-started
+                               {:rf.frame/id :test/rt :resource/key scoped-key
+                                :generation 3 :work/id work-id
+                                :status :running :cause :ensure})])
+          projected  (epoch/projected-record record)
+          tags       (:tags (first (:trace-events projected)))
+          [marker embedded generation] (:work/id tags)]
+      (is (= :rf.work/resource marker) "the work-kind marker rides verbatim")
+      (is (= 3 generation) "the generation rides verbatim")
+      (is (= :secret/article (second embedded))
+          "the embedded key's resource-id survives (attribution)")
+      (is (redacted-component? (first embedded))
+          "the embedded key's scope is tokenized")
+      (is (redacted-component? (nth embedded 2))
+          "the embedded key's params are tokenized")
+      (is (= (:resource/key tags) embedded)
+          "the embedded key projects exactly as the row's own :resource/key")
+      (is (true? (:sensitive? tags)) "the row is stamped :sensitive?")
+      (testing "NO raw secret survives anywhere in the projected record"
+        (is (not (contains-secret? projected)))))))
+
+(deftest off-box-keeps-scalar-only-work-id-and-set-tags-verbatim
+  (testing "rf2-wd9im guard — the shape default must not over-redact the
+            scalar-only collections the family relies on: a MUTATION work-id
+            `[:rf.work/mutation <id> <instance>]` carries no scoped key, and
+            `:tags` rides as a SET whose egress KIND tools read (scoped-key
+            identity is kind-sensitive, rf2-wgutc2, so the walk must not collapse
+            a set / seq to a vector)"
+    (let [record    (record-with
+                      [(event :rf.mutation/succeeded
+                              {:rf.frame/id :test/rt :mutation :m/del :instance 1
+                               :work/id [:rf.work/mutation :m/del 1]
+                               :tags    #{:tag/articles :tag/feed}
+                               :left-stale 2})])
+          projected (epoch/projected-record record)
+          tags      (:tags (first (:trace-events projected)))]
+      (is (= [:rf.work/mutation :m/del 1] (:work/id tags))
+          "a mutation work-id is scalar-only and rides verbatim")
+      (is (= #{:tag/articles :tag/feed} (:tags tags))
+          "a SET-valued tag rides verbatim AND stays a set")
+      (is (set? (:tags tags)) "the collection KIND is preserved")
+      (is (= 2 (:left-stale tags)))
+      (is (not (:sensitive? tags))
+          "a row with no key-bearing slot is NOT stamped sensitive"))))
+
+(deftest trusted-local-include-sensitive-keeps-raw-plan-membership
+  (testing "rf2-wd9im — the trusted-local :include-sensitive? opt-in keeps the
+            raw plan membership + the raw embedded work-id key (the local-raw
+            boundary — the shape-driven redaction is the off-box DEFAULT, not an
+            unconditional strip)"
+    (let [k1        (sk :rf.scope/global :secret/article {:auth-token secret})
+          work-id   (work-ledger/resource-work-id k1 3)
+          record    (record-with
+                      [(event :rf.resource/route-plan (route-plan-tags [k1] [k1]))
+                       (event :rf.resource/work-started
+                              {:rf.frame/id :test/rt :work/id work-id})])
+          projected (epoch/projected-record record {:include-sensitive? true})
+          [plan work] (:trace-events projected)]
+      (is (= [k1] (:blocking (:tags plan))) "raw :blocking rides")
+      (is (= [k1] (:identities (:tags plan))) "raw :identities rides")
+      (is (= work-id (:work/id (:tags work))) "raw embedded work-id key rides"))))
+

--- a/implementation/resources/src/re_frame/resources/trace_egress.cljc
+++ b/implementation/resources/src/re_frame/resources/trace_egress.cljc
@@ -59,7 +59,14 @@
   fails closed independently of any frame. Structural attribution survives every
   case: the resource-id (position 1 of the projected key) and recognized
   structural scalar tags ride verbatim, so a tool can still attribute the row.
-  Unknown map-valued tags fail closed rather than bypassing projection.
+
+  A tag the slot vocabulary does not NAME is projected by SHAPE rather than
+  passed through verbatim (rf2-wd9im): a scoped key anywhere inside it — a member
+  of an unnamed key vector, or the key EMBEDDED at position 1 of a resource
+  work-id — projects through the same owner classification a NAMED slot's keys
+  do, a map payload tokenizes, and a scalar rides verbatim. So no map-shaped
+  value under an unrecognised tag egresses raw at any depth, and a slot nobody
+  has enumerated yet cannot leak the way `:blocking` / `:identities` did.
 
   The redaction is the off-box DEFAULT; the trusted-local `:include-sensitive?`
   opt-in lifts it at the epoch consumer (the `local-raw` boundary — the same
@@ -116,14 +123,28 @@
   #{:resource/key})
 
 (def ^:private scoped-keys-slot
-  "Tag slots that carry a VECTOR of scoped-key vectors across the resource +
+  "Tag slots NAMED as carrying a VECTOR of scoped-key vectors across the
+  resource +
   mutation trace family — `events.cljc` (`:matched` / `:keys` / `:exempt`),
   the `:rf.mutation/succeeded` settlement + its nested `:patch-summary`
   (`:removed` / `:committed` / `:patched` / `:populated` / `:invalidated`), the
   `:rf.mutation/optimistic-rolled-back` row (`:restored` / `:conflicted` /
   `:refetched`), the reconcile summaries (`:restored-keys` / `:conflicted-keys`
   / `:refetched-keys` / `:reconciliation-refetches`), and the
-  `:rf.resource/cancel-timers` fx evidence (`:resource/keys`)."
+  `:rf.resource/cancel-timers` fx evidence (`:resource/keys`).
+
+  This roster is a FIDELITY aid, not the line of defence (rf2-wd9im). It was
+  enumerated from the events / mutation / reconcile rows, so it is a list of the
+  slots someone happened to look at — and it rotted: `:blocking` / `:identities`
+  (EP-0037 `:rf.resource/route-plan`), `:optimistic-keys`, `:forced-keys`,
+  `:revisions`, and the scoped-key EMBEDDED in every `:work/id` /
+  `:superseded` / `:aborted` work-id all carry scoped keys and none of them is
+  named here. Naming a slot buys nothing a shape read cannot: the SHAPE-DRIVEN
+  fail-closed default (`project-unknown-slot-value`) recognises a scoped key
+  wherever it sits and projects it through the SAME
+  `project-trace-scoped-key`, so an unnamed slot's keys project IDENTICALLY to a
+  named one's. Do not grow this set for a newly-noticed slot; the default
+  already covers it."
   #{:resource/keys :matched :removed :keys :exempt :committed
     :patched :populated :invalidated
     :restored :conflicted :refetched
@@ -217,6 +238,94 @@
   vocabulary so a row's nested scoped keys never leak."
   #{:patch-summary :invalidation})
 
+(defn- scoped-key-shape?
+  "Whether `v` has the SHAPE of a scoped resource key
+  `[scope resource-id canonical-params]`: a 3-vector whose position 1 is the
+  resource-id KEYWORD and whose position 2 is the canonical params MAP. Read
+  ONLY by the shape-driven fail-closed default below, to recognise a scoped key
+  sitting in a slot the vocabulary does not name (rf2-wd9im).
+
+  The params `map?` test is what discriminates a real key from the family's
+  OTHER 3-element vectors, and it is the whole reason a shape read is safe here:
+  `:owner [:app :l 1]` (a view path) and `:cause [:mutation :m/save 7]` both
+  have a keyword at position 1 and a SCALAR at position 2, and both MUST ride
+  verbatim — tokenizing them would destroy attribution for no security gain.
+  A `:params-schema` may admit non-map params (a vector / an explicit nil), and
+  such a key is deliberately NOT recognised here; it falls to the recursive walk
+  instead, which still tokenizes every map the key contains (a `{:from-db …}`
+  resolved scope's value map included). The walk is the guarantee, this
+  predicate is the fidelity arm."
+  [v]
+  (and (vector? v) (= 3 (count v)) (keyword? (nth v 1)) (map? (nth v 2))))
+
+(defn- project-unknown-slot-value
+  "SHAPE-DRIVEN fail-closed projection of ONE tag value under a slot the
+  vocabulary above does not name. Returns `[projected sensitive?]`.
+
+  ## Why shape and not another slot name (rf2-wd9im)
+
+  The projector was keyed ENTIRELY on slot NAME, and the fail-closed default
+  rf2-7qbxbm added closed over ONE value shape — a MAP. A sequential value under
+  an unnamed slot fell through the verbatim `:else`, so
+  `:rf.resource/route-plan`'s `:blocking` / `:identities` (vectors of scoped
+  keys) egressed a `:sensitive?` owner's scope + params RAW, where the identical
+  keys under `:matched` tokenized. Adding those two names would have left the
+  same hole for `:optimistic-keys`, `:forced-keys`, `:revisions`, and — on the
+  MAJORITY of rows in the family — the scoped key EMBEDDED at position 1 of
+  every resource `:work/id` / `:superseded` / `:aborted` work-id
+  (`[:rf.work/resource <scoped-key> <generation>]`), none of which any roster
+  named. A name roster cannot cover a slot nobody has looked at yet; a shape
+  read covers all of them, including the ones added next year.
+
+  ## The rule
+
+    - an already-projected `{:rf/redacted …}` token rides as-is + stays
+      sensitive (idempotent — never re-digested);
+    - a SCOPED-KEY-SHAPED vector projects through `project-trace-scoped-key` —
+      the SAME owner classification the NAMED slots use, so an unnamed slot's
+      keys and a named slot's keys cannot drift, per-key distinctness (and
+      therefore a tool's per-key joins) survives, and a PLAIN owner's key still
+      rides verbatim (no over-redaction);
+    - a MAP is tokenized — the unambiguous app-payload shape (rf2-7qbxbm);
+    - any OTHER collection is walked MEMBER-WISE by this same rule, preserving
+      the collection's KIND. Depth is what reaches a work-id's embedded key and
+      a `{:from-db …}` scope's value map; kind preservation is load-bearing
+      because scoped-key identity is kind-SENSITIVE (rf2-wgutc2 — a list-params
+      key and a vector-params key are DISTINCT), so collapsing a list to a
+      vector at egress would make two distinct keys look like one, and `:tags`
+      rides as a SET whose egress shape tools read;
+    - a SCALAR rides verbatim — keywords / numbers / booleans / short id strings
+      are structural facts, not app payloads. Vectors of them (`:branch`'s route
+      ids, `:invalidated-tags`, `:owner`, a mutation `:work/id`) therefore still
+      ride verbatim member-by-member, which is the discrimination the bare
+      \"redact any vector-of-vectors\" guard could not make.
+
+  The invariant this buys, statable and testable: NO map-shaped value under an
+  unrecognised resource-family trace tag egresses off-box raw, at ANY depth.
+  Pure."
+  [v frame-id]
+  (cond
+    (redacted-token? v)   [v true]
+    (scoped-key-shape? v) (project-trace-scoped-key v frame-id)
+    (map? v)              [(ssr/redact-value v) true]
+
+    (coll? v)
+    (let [sens?* (volatile! false)
+          proj   (fn [x]
+                   (let [[pv s] (project-unknown-slot-value x frame-id)]
+                     (when s (vreset! sens?* true))
+                     pv))]
+      [(cond
+         (set? v)    (into #{} (map proj) v)
+         (vector? v) (mapv proj v)
+         ;; a list / lazy seq must stay a seq — `mapv` would print it as a
+         ;; vector and erase the kind distinction described above.
+         (seq? v)    (apply list (map proj v))
+         :else       (mapv proj v))
+       @sens?*])
+
+    :else [v false]))
+
 (declare project-tags*)
 
 (defn- project-disposition-row
@@ -297,44 +406,49 @@
                   (do (note! true) (assoc m k v))
                   (do (note! true) (assoc m k (ssr/redact-value v))))
 
-                ;; FAIL-CLOSED default (rf2-7qbxbm): an UNKNOWN slot whose value
-                ;; is a MAP — the unambiguous payload shape (an HTTP envelope, an
-                ;; arbitrary app result/error map the scoped-key / cursor /
-                ;; envelope vocabulary above did not recognise) — is tokenized
-                ;; rather than passed through verbatim. This flips the former
-                ;; verbatim `:else` (which fell OPEN on any unrecognised slot) to
-                ;; fail CLOSED on map payloads, so a FUTURE map-bearing slot
-                ;; added to a resource/mutation row without a projector clause
-                ;; cannot leak the same way `:error` did. An already-projected
-                ;; (`{:rf/redacted …}`) map is itself a map, so it is guarded
-                ;; FIRST and rides as-is (idempotent — never re-digested).
-                ;;
-                ;; SCALARS, scalar-collections, and SIBLING-OWNED slots ride
-                ;; verbatim through the final `:else`: structural facts
-                ;; (keywords / numbers / booleans / short id strings —
-                ;; `:rf.frame/id`, `:cause`, `:decision`, `:generation`,
-                ;; `:work/id`, `:delay-ms`, `:status-before` / `:status-after`,
-                ;; counts) and app-defined TAG-keyword vectors
-                ;; (`:invalidated-tags`) are not app-data payloads, and
-                ;; tokenizing them would destroy attribution / a tool's joins
-                ;; with no security gain; the scope-resolved sibling projector's
-                ;; `:input-values` / `:scope` slots (`sibling-owned-slot`) were
-                ;; ALREADY classified upstream (EP-0025 made resolved-scope egress
-                ;; unconditionally fail-closed), so re-tokenizing them here is a
-                ;; no-op at best and double-work at worst. The genuine app-data
-                ;; leak vectors are the scoped keys (above), the cursor (above),
-                ;; and the MAP-shaped HTTP envelope (above) — the conservative
-                ;; fail-closed scope the audit ruled.
+                ;; An already-projected token rides as-is and still marks the row
+                ;; sensitive — guarded BEFORE `sibling-owned-slot` so a
+                ;; pre-redacted `:scope` / `:input-values` does not lose the
+                ;; row's `:sensitive?` stamp.
                 (redacted-token? v)
                 (do (note! true) (assoc m k v))
 
+                ;; SIBLING-OWNED slots ride verbatim: the scope-resolved sibling
+                ;; projector already classified `:input-values` / `:scope`
+                ;; upstream on the row it owns (EP-0025 made resolved-scope
+                ;; egress unconditionally fail-closed), so re-tokenizing here is
+                ;; a no-op at best and double-work at worst.
                 (sibling-owned-slot k)
                 (assoc m k v)
 
-                (map? v)
-                (do (note! true) (assoc m k (ssr/redact-value v)))
-
-                :else (assoc m k v)))
+                ;; FAIL-CLOSED default — SHAPE-DRIVEN (rf2-7qbxbm gave it the
+                ;; map arm; rf2-wd9im made it read shape rather than only
+                ;; `map?`). Every slot the vocabulary above does not NAME is
+                ;; projected by `project-unknown-slot-value`: a scoped key
+                ;; anywhere inside it projects through the owner exactly as a
+                ;; NAMED slot's keys do, a map payload tokenizes, a scalar rides
+                ;; verbatim, and any other collection is walked member-wise.
+                ;;
+                ;; This is what closes the CLASS rather than an instance. The
+                ;; former arm covered ONE shape, so a sequential value fell
+                ;; through the verbatim `:else` and
+                ;; `:rf.resource/route-plan`'s `:blocking` / `:identities`
+                ;; egressed a sensitive owner's scope + params RAW — as did
+                ;; `:optimistic-keys` / `:forced-keys` / `:revisions` and the
+                ;; scoped key EMBEDDED in every resource `:work/id` /
+                ;; `:superseded` / `:aborted` work-id.
+                ;;
+                ;; NOTE for the reader who reaches here from a row's emit site:
+                ;; a slot NAME in `scoped-keys-slot` does not mean the row's
+                ;; value is a key vector. `:rf.resource/route-plan` carries
+                ;; `:removed` as an INT COUNT while the mutation-settlement rows
+                ;; carry it as a key vector — the two were written against
+                ;; different mental models of `:removed`. Both are handled: the
+                ;; named arm above requires `sequential?`, so the int count
+                ;; falls to this default and rides verbatim as the scalar it is.
+                :else
+                (let [[pv s] (project-unknown-slot-value v frame-id)]
+                  (note! s) (assoc m k pv))))
             {}
             tags)]
       [tags' @sens?*])))
@@ -358,8 +472,16 @@
   rides verbatim; an UNREGISTERED owner FAILS CLOSED (redacted — the
   trace-egress default). The resource-id (position 1 of every projected key) and
   recognized structural scalar tags (`:rf.frame/id`, `:cause`, `:decision`,
-  `:generation`, `:owner`, `:work/id`, `:delay-ms`, counts, …) ride verbatim;
-  unknown map-valued tags fail closed. When ANY projected slot redacted a
+  `:generation`, `:owner`, `:delay-ms`, counts, …) ride verbatim. A tag the
+  vocabulary does not NAME is projected by SHAPE (rf2-wd9im,
+  `project-unknown-slot-value`): a scoped key anywhere inside it projects through
+  the same owner classification, a map payload tokenizes, a scalar rides
+  verbatim. That is what covers `:rf.resource/route-plan`'s `:blocking` /
+  `:identities`, the optimistic rows' `:optimistic-keys` / `:forced-keys` /
+  `:revisions`, and the scoped key EMBEDDED at position 1 of every resource
+  `:work/id` / `:superseded` / `:aborted` work-id
+  (`[:rf.work/resource <scoped-key> <generation>]`) — none of which the slot
+  roster names. When ANY projected slot redacted a
   sensitive / unregistered key, the row is stamped `:sensitive? true`.
 
   The load-more PAGINATION CURSOR — `:page-param` (on `:rf.resource/load-more`)


### PR DESCRIPTION
Closes rf2-wd9im.

## The defect

`:rf.resource/route-plan` carries two EP-0037 R1/R2 slots that are **vectors of
scoped resource keys** — `:blocking` and `:identities` — and a scoped key is
`[scope resource-id canonical-params]`, so both slots carry the resolved **scope**
and the **canonical params** of every requirement in the plan.

The resources off-box egress projector runs on the row (`resource-family-op?` is
operation-agnostic), but the fail-closed default rf2-7qbxbm added was closed over
**one value shape**: a map. A *sequential* value under an unnamed slot fell
through the verbatim `:else`. So a `:sensitive?` owner's scope and params
egressed **raw**, where the identical keys under `:matched` tokenized.

The negative control shows the leak literally:

```
FAIL in (off-box-redacts-route-plan-blocking-and-identities)
the canonical params are tokenized
expected: (redacted-component? bparams)
  actual: (not (redacted-component? {:auth-token "topsecret-PII"}))
```

## The fix shape, and why not a roster entry

The bead recommended adding `:blocking` / `:identities` to `scoped-keys-slot` and
treating the class fix as a separate decision. **I did the class fix instead, and
added neither name.** The reason is the survey below: the roster is not two names
short, it is *a dozen* names short, and it was already the wrong kind of artefact.
`scoped-keys-slot`'s own docstring says it was enumerated from "the events /
mutation / reconcile rows" — it is a list of the slots someone happened to look
at, and it rots by construction, because the projector was keyed on slot **name**
while the leak vector is a value **shape**.

So the fail-closed default now reads shape (`project-unknown-slot-value`). For
every slot the vocabulary does not name:

| shape | treatment |
|---|---|
| `{:rf/redacted …}` token | rides as-is, stays sensitive (idempotent) |
| scoped-key-shaped vector | `project-trace-scoped-key` — the **same** owner classification the named slots use |
| map | tokenized (rf2-7qbxbm's arm, unchanged) |
| any other collection | walked **member-wise** by this same rule, **kind preserved** |
| scalar | verbatim |

Two properties make this a replacement for growing the roster rather than a
second, weaker projection beside it:

- **It cannot drift from the named arm.** Both go through
  `project-trace-scoped-key`, so an unnamed slot's keys project *identically* to a
  named slot's. `unnamed-slot-projects-identically-to-named-slot` asserts exactly
  that — `(= (:matched tags) (:blocking tags))` over the same keys — which is the
  structural-non-drift property rf2-irwsq's shared rule bought by a different
  route. Adding `:blocking` to the roster would have been *unobservable*; that is
  the proof the roster entry buys nothing.
- **It costs no over-redaction.** Because it projects through the owner rather
  than tokenizing coarsely, a plain owner's `:blocking` still rides verbatim
  (`off-box-keeps-plain-owner-plan-membership-verbatim`).

The discrimination the bead was right to worry about is the params `map?` test in
`scoped-key-shape?`. A bare "3-vector" or "vector whose members are vectors" test
is not sufficient: `:owner [:app :l 1]` and `:cause [:mutation :m/save 7]` are
3-vectors with a keyword at position 1, and both must ride verbatim. Requiring a
**map at position 2** separates a real key from both, and the recursive walk is
the backstop when the predicate declines — it still tokenizes every map the value
contains at any depth, including a `{:from-db …}` resolved scope's value map. The
statable invariant: **no map-shaped value under an unrecognised resource-family
trace tag egresses off-box raw, at any depth.**

Kind preservation in the walk is not gold-plating. Scoped-key identity is
kind-*sensitive* (rf2-wgutc2 — a list-params key and a vector-params key are
distinct entries), so collapsing a list to a vector at egress would make two
distinct keys look like one; and `:tags` rides as a **set** on
`:rf.resource/invalidated` / `refetch-decision` today, so a `mapv` walk would have
changed a live tag's egress shape. Pinned by
`off-box-keeps-scalar-only-work-id-and-set-tags-verbatim`.

I also recorded the bead's `:removed` observation where the fix lives: this row
carries `:removed` as an **int count** while the mutation-settlement rows carry it
as a key vector. Both work — the named arm requires `sequential?`, so the count
falls to the default and rides as the scalar it is — but the two were written
against different mental models of the same slot name, which is worth a reader's
note.

## Can any other slot carry a sequential value?

**Yes — this was not two instances, it was a class with at least a dozen live
members, and several were leaking scope + params raw before this PR.** I surveyed
every `trace/emit!` site in the family (77 across `events`, `mutation_events`,
`registry`, `reply_handlers`, `route`, `scope_registry`, `ssr`, `subs`, `timers`).
Uncovered by any roster, sequential, and now closed by the shape default:

- **`:work/id` — the big one.** A resource work-id is
  `[:rf.work/resource <scoped-key> <generation>]` (`work_ledger/resource-work-id`),
  so **the scoped key is embedded one level down**, and `:work/id` rides on the
  *majority* of rows in the family — `work-started`, `fetch-started`, `deduped`,
  `succeeded`, `failed`, `load-more`, `owner-attached`, the mutation settlements.
  Every one of them egressed a sensitive owner's scope + params raw. The existing
  tests missed it because their fixtures use a synthetic **2-element**
  `[:rf.work/resource 2]`, never the real 3-element shape — fixture blindness of
  exactly the kind that shipped rf2-irwsq. Pinned now by
  `off-box-redacts-scoped-key-embedded-in-resource-work-id`, which builds the
  work-id with the real constructor so it cannot drift.
- **`:superseded`** (`work-started`) and **`:aborted`** (`owner-released`,
  `removed`, `mutation/cancelled`) — the same work-ids, so the same embedded key.
- **`:optimistic-keys`** (`optimistic-applied`, `optimistic-reconciled`) and
  **`:forced-keys`** (`:rf.warning/optimistic-force-clobber`) — plain vectors of
  scoped keys, no roster entry.
- **`:tag-matched-keys`** (`optimistic-applied`) — vector of scoped keys.
- **`:revisions`** (`optimistic-applied`) and **`:redundant-children`**
  (`route-plan`, the third leaking slot **on the bead's own row**) — vectors of
  *maps* each embedding a key (`:resource/key` / `:scoped-key`). These now fail
  closed as coarse per-map digests rather than riding raw. Safe, but attribution
  is lost where `disposition-rows-slot` would have preserved it; I left that as a
  fidelity question rather than growing a second roster (noted below).
- **`:targets` / `:target`** (`:rf.resource/replied`, `:rf.mutation/replied`) —
  `:reply-to` event vectors, which can carry an app payload map.

Genuine scalar-only sequential slots that must and do still ride verbatim:
`:branch` (route ids), `:invalidated-tags`, `:tags`, `:owner`, `:cause`,
`:released`-adjacent counts, and a *mutation* work-id
`[:rf.work/mutation <id> <instance>]`.

## Two findings I did NOT fix — they need rulings, not code from me

Both are off my bead's class (neither is a shape hole), and both change egress on
rows beyond this one, so I filed them as beads rather than deciding them here:
**rf2-5o52l** (P1) and **rf2-1zc33** (P1), each `discovered-from:rf2-wd9im` with
the file/line evidence and the specific decision needed.

1. **`:scope` rides raw on every row except the one it was cleared for.**
   `sibling-owned-slot` passes `:scope` / `:input-values` through verbatim on the
   premise that "they were already classified upstream". That premise holds *only*
   on `:rf.resource/scope-resolved` — `omit-off-box-resource-scope-values` matches
   that operation alone. On `:rf.resource/invalidated`, `:rf.resource/removed`,
   `:rf.resource/refetch-decision`, `:rf.mutation/started` and
   `:rf.mutation/optimistic-applied`, `:scope` is a **raw canonical concrete
   scope**, so a `[:rf.scope/session {:username "…"}]` tier egresses its identity
   map in plaintext. The shape default would handle it correctly if `:scope` were
   dropped from `sibling-owned-slot` (tier keyword survives, identity map
   tokenizes), but that overrides a recorded EP-0025 decision and changes egress
   on five row types — a ruling, not a drive-by.
2. **`:released` egresses plaintext CEDN key-ids, and no shape rule can see it.**
   `:rf.resource/owner-released`'s `:released` is a vector of `state/key-id`
   values, and a key-id is `identity/canonical-bytes` — a **reversible plaintext
   encoding**, not a digest (`encode-string` emits `s:"topsecret-PII"`). So the
   released entries' scope and params egress verbatim inside *strings*. My walk
   correctly treats strings as scalars, so this is a genuinely different class (an
   encoded scalar carrying the payload) and needs its own fix — probably projecting
   key-ids to the projected scoped key, or tokenizing them.

## The sibling conformance gate cannot see this shape either — and it is blind to more than expected

`epoch_mcp_egress_conformance_test.clj` owns the "no raw sensitive egress
anywhere" claim, and it is blind to this defect **class**, not merely to this
slot. Its fixture is entirely app-db-**path** driven
(`{:sensitive [[:auth :password]]}` plus events that write that path); it contains
**zero** occurrences of `reg-resource`, `:rf.resource/`, `:rf.mutation/` or
`resources`, and it does not require the resources artefact at all. So its record
carries no resource-family trace rows, `project-resource-trace-egress` is never
reachable in that gate (the late-bind hook is nil there), and its whole-output
scans have never had a scoped key to find. That is a stronger blindness than
rf2-irwsq's, where the `:large` axis at least existed and was merely declared with
the wrong shape. rf2-isp3i owns widening it — I have not touched it.

Worth noting the converse, because it is the encouraging half: the
`contains-secret?` whole-record scan in *this* file **did** red on the unfixed
code once the fixture carried the shape. The scan was never the weak part; the
fixture was.

## Quality gates

Foreground, to completion, in this worktree. `rc` captured immediately into
worktree-local logs and cross-checked against each log's own summary line.

| gate | result | rc |
|---|---|---|
| `implementation/epoch` `clojure -M:test` | Ran 476 tests, 6469 assertions, **0 failures, 0 errors** | **0** |
| `implementation/resources` `clojure -M:test` | Ran 722 tests, 6729 assertions, **0 failures, 0 errors** | **0** |
| `npm run test:cljs` | Ran 11453 tests, 57342 assertions, **0 failures, 0 errors** | **0** |
| `scripts/test-fast-pr.sh` | `PASS fast PR spine` — 306 gate PASS lines, per-ns isolation 17/17 standalone, 0 failures | **0** |

`rc` cross-check: the wrapper's reported exit code, the `rc=$?` I captured into
each worktree-local log, and each log's own summary line agree in all four cases —
`PASS fast PR spine` against `FASTPR_CAPTURED_RC=0`, and `0 failures, 0 errors`
against `rc=0` for the three suites. The spine's three soft-skips are the standing
ones (mkdocs not on PATH; untouched JVM artefacts; CI-only browser/bundle/perf
lanes), not silent failures.

Counts, before → after: epoch **470 tests / 6431 assertions → 476 / 6469**
(+6 deftests, +38 assertions). resources unchanged at 722 / 6729 (the projector
has no resources-side test; its tests live in the epoch suite, which is where the
existing rf2-8x0gfa / rf2-3tysyj / rf2-7qbxbm coverage for it sits).

**Negative control — the deliverable, since this is a privacy fix.** The new tests
drive the public path (`epoch/projected-record`), not the projector directly.

1. fixed → `rc=0`, 476/6469, **0 failures**;
2. `trace_egress.cljc` reverted in place to `origin/main` (file-scoped
   `git show origin/main:… >`; **no stash**) → `rc=1`, **13 failures** across
   `off-box-redacts-route-plan-blocking-and-identities` (5),
   `unnamed-slot-projects-identically-to-named-slot` (4) and
   `off-box-redacts-scoped-key-embedded-in-resource-work-id` (4), reporting the
   raw `{:auth-token "topsecret-PII"}` and raw `:rf.scope/global` quoted above;
3. restored (`git checkout HEAD -- <file>`) → `rc=0`, 476/6469, **0 failures**.

The two guard tests (plain owner rides verbatim; scalar-only work-id and set-valued
`:tags` ride verbatim) stay green in *both* directions, which is what shows the
13 failures are the leak and not the fix over-reaching.
