### PR TITLE
skills(re-frame2-ui): split the handler-options example so it stops teaching a refused pair (rf2-uvcm3 follow-up)

### DIFF
--- a/skills/re-frame2-ui/SKILL.md
+++ b/skills/re-frame2-ui/SKILL.md
@@ -249,9 +249,15 @@ positions of literal vectors only**. Richer payloads (form data, files,
 | bare `#(…)` | legal shorthand **only** on known native event props (`:on-*` on DOM/custom elements) — never refs, never foreign/view props |
 | `(ui/raw-fn f)` | identity-as-protocol callbacks; **the callback-ref form** |
 
-- **Handler-map options** for DOM listeners are explicit, never implied:
-  `{:event [:ev …] :prevent-default true :stop-propagation true :capture
-  true :passive true :once true}` (closed set).
+- **Handler-map options** for DOM listeners are explicit, never implied — a
+  closed set of six keys, of which **no one legal map carries all six**:
+  `:passive` and `:prevent-default` are mutually exclusive (a passive listener
+  promises the browser it will never call `preventDefault`), so a map carrying
+  both is refused as `:rf.ui.compile/contradictory-handler-options`. The two
+  sides of the lane carry the set between them — blocking
+  `{:event [:ev …] :prevent-default true :stop-propagation true :capture true
+  :once true}`, passive `{:event [:ev …] :passive true :stop-propagation true
+  :capture true :once true}`.
 - **Loops:** a vector capturing the loop binding is a compile error —
   extract a keyed child view and pass the captured value as a prop. A bare
   fn in a loop works but dev-warns (per-row closures defeat the data idiom).


### PR DESCRIPTION
Recovery of one commit stranded by a merge race on **#7010** (`rf2-uvcm3`, merged
as `f40681892c` / `67f0f205ed` / `7213bd9991`). That PR was merged at my branch's
third commit; this fourth one had been pushed but was not in the merged state.
Verified by content, not ancestry — `origin/main:skills/re-frame2-ui/SKILL.md` is
byte-identical to the pre-branch base, so nobody else edited it in between and the
cherry-pick applies cleanly onto current `main`.

## What it fixes

The #6963 audit note on `rf2-uvcm3` said a repo-wide sweep for the exact
`:passive` + `:prevent-default` combination "found no other positive documentation
example" beside `spec/004D`. Re-running that sweep over every tracked map literal
(`git ls-files` → `{[^{}]*}` scan of `.md/.edn/.clj/.cljc/.cljs`, 13 hits) found one
it missed:

`skills/re-frame2-ui/SKILL.md` presented the handler-options roster as **one** map
carrying all six keys, `:prevent-default true` and `:passive true` among them. That
pair is a contradiction — a passive listener promises the browser it will never call
`preventDefault` — and `re-frame.ui`'s own analyzer refuses it
(`implementation/ui/src/re_frame/ui/compiler/analyze.cljc:1451`,
`:rf.ui.compile/contradictory-handler-options`, "the combination is a contradiction
(in any stage)"). Written as vocabulary; reads as executable map syntax.

Corrected the same way #7010 corrected `spec/004D`: two legal maps, one per side of
the native-attachment lane, carrying all six roster keys between them, with the
exclusion stated beside them rather than discovered at compile time.

This is the **authored** skill file, not the generated `references/ui-context.md`
leaf (`implementation/scripts/api-manifest` owns that one and names SKILL.md as the
file "carrying the teaching prose"). No regeneration, no digest disturbed.

## Quality gates

| Gate | Result | rc |
|---|---|---|
| `scripts/check_skill_re_frame2_drift.py` | clean | 0 |
| `scripts/check_skill_mcp_drift.py --verbose --ci` | clean | 0 |
| `scripts/check_doc_slugs.py` | clean | 0 |
| `scripts/test-fast-pr.sh` (on the superset branch, same SKILL.md blob) | `PASS fast PR spine` — includes the skill/MCP drift, migration cite-integrity, implementor-order and eval-docs gates | 0 |
| `npm run test:cljs` (same blob) | 11453 tests / 57342 assertions, 0 failures, 0 errors | 0 |
| `implementation/freehand` `clojure -M:test` (same blob) | 1102 tests / 7420 assertions, 0 failures, 0 errors | 0 |

Markdown prose in one bullet; no rendering path, so `npm run test:browser` is not
applicable.

## Census row count

Unchanged and unreachable from this diff: 98 rows in the index, 97 applicable,
`--report` byte-identical. The file is not part of the Freehand conformance ledger.

## Related

`rf2-av5ml` (P4, bug) is filed for the other half of this asymmetry:
`re-frame.ui`'s runtime (`ui/events.cljs:610`) still *accepts* the pair its own
analyzer refuses — the exact tier drift `rf2-uvcm3` removed on the Freehand side.
