### PR TITLE
routing: collapse rf/route-link's inlined click law and dispatch payload onto their owners (rf2-e9974)

### DIFF
--- a/implementation/routing/src/re_frame/routing/link.cljc
+++ b/implementation/routing/src/re_frame/routing/link.cljc
@@ -70,11 +70,13 @@
   "Synthesise the `<a>` href from the link control keys (`:to` /
   `:params` / `:query` / `:fragment`), strip those control keys (plus
   `:on-click`, which the CLJS path replaces and the SSR path drops) off
-  `props`, and return `[path-url base-attrs]`. The base attrs carry the
+  `props`, and return `[path-url base-attrs address]`. The base attrs carry the
   synthesised `:href` plus every passthrough HTML attr; both the CLJS
   and SSR render fns build on it so the control-key list lives in ONE
   place and cannot drift between the two halves of the Spec 011 render
-  contract.
+  contract. `address` is the extracted address the href was built FROM, handed
+  back so the CLJS render's click payload names the destination through the
+  same single extraction rather than reading `props` a second time.
 
   `route-url` builds the path-form URL
   (`/active`); `encode` maps it to the rendered `:href` — one of the four
@@ -101,10 +103,12 @@
   ;; rejects an unsupported mode on the client AND in the SSR shell rather than
   ;; stripping it silently on the way to the `<a>`.
   (validate-prefetch! props)
-  (let [{:keys [to params query fragment]} (address/extract-address props)
+  (let [{:keys [to params query fragment] :as addr} (address/extract-address props)
         path-url (registry/route-url {:to to :params (or params {}) :query (or query {}) :fragment fragment})]
-    [path-url (-> (apply dissoc props (concat address/address-keys address/link-behavior-keys))
-                  (assoc :href (encode path-url)))]))
+    [path-url
+     (-> (apply dissoc props (concat address/address-keys address/link-behavior-keys))
+         (assoc :href (encode path-url)))
+     addr]))
 
 (defn prefetch-payload
   "The `[:rf.route/prefetch {address}]` dispatch vector for a link whose props
@@ -127,6 +131,25 @@
        (cond-> {:to to}
          (seq params) (assoc :params params)
          (seq query)  (assoc :query query))])))
+
+(defn- url-requested-payload
+  "The `[:rf.route/url-requested {…}]` dispatch vector a link click carries —
+  the ONE definition, run by `rf/route-link` (`route-link-render`) and by the
+  `link-model` seam the compiled `ui/route-link` consumes, so the navigation
+  identity the two surfaces dispatch cannot drift.
+
+  `address` is the EXTRACTED address (`address/extract-address`), never a
+  bespoke destructuring of the caller's props, so the payload names the same
+  destination the rendered `:href` was built from; `path-url` is the PATH-FORM
+  url `route-url` built from it (the cascade is path-form throughout, so a
+  strategy's `:encode` touches only the `:href`). Empty `:params` / `:query`
+  and an absent `:fragment` are omitted, not carried as empty values."
+  [{:keys [to params query fragment]} path-url]
+  [:rf.route/url-requested
+   (cond-> {:url path-url :to to}
+     (seq params) (assoc :params params)
+     (seq query)  (assoc :query query)
+     fragment     (assoc :fragment fragment))])
 
 #?(:cljs
    (defn- compose-intent-handler
@@ -205,6 +228,38 @@
                (not (nil? download)))))))
 
 #?(:cljs
+   (defn activate-link!
+     "THE router-attributed click decision for a route-link anchor, in ONE
+     place: `rf/route-link`'s own `:on-click` (`route-link-render`, below) and
+     the compiled `ui/route-link` both run this body, so neither surface states
+     the click law for itself. Also PUBLISHED as the `:routing/activate-link!`
+     late-bound seam, which is how the optional re-frame.ui artefact reaches it
+     without statically requiring routing.
+
+     `e` is the native click event; `on-click` is the caller-supplied
+     `:on-click` (or nil); `render-frame` is the render-time-captured frame id;
+     `payload` and `native?` come from `url-requested-payload` /
+     `native-anchor?` (`link-model` bundles both for the ui side).
+
+     Runs the caller `:on-click` first; then, unless the anchor is native (new
+     tab / download), the caller already prevented the default, or the click is
+     not a plain primary-button click (a modifier-key or auxiliary-button click
+     keeps the browser's open-in-new-tab affordance), calls `.preventDefault`
+     and dispatches `payload` to the captured render frame with `:source
+     :router` (so the L2 epoch timeline tags the cascade as a routing-substrate
+     dispatch, per rf2-t1lxr / rf2-1ve9h). `:frame render-frame` is an explicit
+     dispatch opt — the router targets the rendering frame verbatim even though
+     the render scope has unwound by click time (rf2-o3nam4), so the dispatch
+     always lands on the CURRENTLY-committed frame (retarget-safe)."
+     [e on-click render-frame payload native?]
+     (when on-click (on-click e))
+     (when (and (not native?)
+                (not (.-defaultPrevented e))
+                (plain-left-click? e))
+       (.preventDefault e)
+       (router/dispatch! payload {:source :router :frame render-frame}))))
+
+#?(:cljs
    (defn route-link-render
      "Render fn for the `:route/link` registered view. Exposed (without
      the registry wrap) so tests can call it directly without going
@@ -224,26 +279,21 @@
      props map is passed through to the underlying `<a>` element (e.g.
      `:class`, `:title`, `:id`, `:aria-label`).
 
-     If the caller supplies an `:on-click` fn, it is invoked first; when
-     it calls `.preventDefault` (or otherwise the event's
-     `defaultPrevented` is true after it returns) the framework's
-     plain-left-click interception is skipped — the caller has taken
-     responsibility for the navigation. Otherwise the standard rules
-     apply: plain left-click → `preventDefault` + dispatch
-     `:rf.route/url-requested`; modifier-key or middle-click → no interception.
-
-     Anchors carrying native-handling attributes
-     (`:target` other than `_self`, or `:download`) are NOT intercepted on
-     a plain left-click either — they look like a normal anchor in the DOM
-     and the user expects native new-tab / download behaviour
-     (see `native-anchor?`).
+     The click is handed to `activate-link!` and the payload to
+     `url-requested-payload`, the two definitions the compiled `ui/route-link`
+     also runs — so this render fn states no part of the click law or the
+     dispatch shape for itself, and the two link surfaces Spec 012 declares
+     behaviourally identical are identical by construction rather than by
+     inspection. Read `activate-link!` for the law (caller `:on-click` first,
+     defer on `defaultPrevented` / a native anchor / a modifier or
+     auxiliary-button click, else `preventDefault` + dispatch).
 
      Performance (rf2-r1in4): this is render-path code — every
      `[rf/route-link ...]` re-render walks `route-url` for the href.
      Large nav menus re-rendering frequently amortise the cost over many
      calls; see `route-url`'s perf note for the precompute follow-on
      should it become a bottleneck."
-     [{:keys [to params query fragment on-click] :as props} & children]
+     [{:keys [on-click] :as props} & children]
      (let [;; rf2-o3nam4: CAPTURE the render-time frame ONCE, here at render —
            ;; NOT at click time. `:route/link` is registered via `reg-view*`
            ;; with this prebuilt fn, so it does NOT receive the `reg-view`
@@ -269,13 +319,21 @@
            ;; the click dispatch — the cascade is path-form throughout, so the
            ;; encode touches ONLY the href. One of the four consult points.
            encode (:encode (strategy/url-strategy-for-frame-id render-frame))
-           [url base-attrs] (href-attrs props encode)
+           [url base-attrs address] (href-attrs props encode)
+           ;; The click payload comes from the ONE synthesiser
+           ;; (`url-requested-payload`) over the address `href-attrs` already
+           ;; extracted — the href and the payload therefore name the same
+           ;; destination by construction, not by two readings of `props`.
+           payload (url-requested-payload address url)
            ;; Anchors carrying native-handling attributes
            ;; (`target="_blank"`, `download`) must let the browser handle
            ;; the click — SPA interception would defeat new-tab / download.
-           ;; Computed once at render against the resolved attrs (post
-           ;; control-key strip) so the string/keyword attr forms are seen.
-           native? (native-anchor? base-attrs)
+           ;; Computed once at render, off the RAW props — the same side
+           ;; `link-model` reads, so the two link surfaces cannot disagree.
+           ;; (`:target` / `:download` are neither address nor behaviour keys,
+           ;; so the strip does not touch them; reading pre-strip makes that
+           ;; independence explicit rather than incidental.)
+           native? (native-anchor? props)
            ;; EP-0037 R3: `:prefetch :intent` warms the destination's resources
            ;; on credible user intent (hover / focus / touch). The handlers
            ;; compose with caller-supplied ones of the same name and dispatch to
@@ -287,34 +345,9 @@
            intent-attrs (prefetch-intent-attrs props render-frame)
            attrs (merge
                    (assoc base-attrs
-                        :on-click
-                        (fn [e]
-                          (when on-click (on-click e))
-                          (when (and (not native?)
-                                     (not (.-defaultPrevented e))
-                                     (plain-left-click? e))
-                            (.preventDefault e)
-                            ;; Per rf2-t1lxr: route-link click → :router
-                            ;; origin so the L2 epoch timeline tags the
-                            ;; resulting :rf.route/url-requested cascade as a
-                            ;; routing-substrate dispatch (not :ui). Per
-                            ;; rf2-1ve9h the single closed-enum
-                            ;; functional-origin axis is `:source` —
-                            ;; routing-internal dispatches stamp
-                            ;; `:source :router`. rf2-o3nam4: carry the
-                            ;; captured render-time frame so the dispatch
-                            ;; targets the rendering frame even though the
-                            ;; render scope has unwound by click time. `:frame`
-                            ;; is an explicit dispatch opt, so the router uses
-                            ;; it verbatim (its resolution order #1) — no
-                            ;; ambient read.
-                            (router/dispatch!
-                              [:rf.route/url-requested
-                               (cond-> {:url url :to to}
-                                 (seq params)   (assoc :params params)
-                                 (seq query)    (assoc :query  query)
-                                 fragment       (assoc :fragment fragment))]
-                              {:source :router :frame render-frame}))))
+                          :on-click
+                          (fn [e]
+                            (activate-link! e on-click render-frame payload native?)))
                    ;; compose the prefetch intent handlers OVER the base attrs
                    ;; (they wrap any caller-supplied intent handler); nil when
                    ;; the link did not opt into `:prefetch :intent`.
@@ -336,7 +369,7 @@
   `/active` and the hydrated anchor carries `#/active`, both pointing at
   the same route."
   [props & children]
-  (let [[_url attrs] (href-attrs props identity)]
+  (let [[_url attrs _address] (href-attrs props identity)]
     (into [:a attrs] children)))
 
 ;; ---------------------------------------------------------------------------
@@ -359,6 +392,9 @@
 ;;                      caller `:on-click`, defer on defaultPrevented / native? /
 ;;                      modifier / auxiliary-button, else preventDefault + dispatch
 ;;                      to the captured render frame with `:source :router`).
+;;                      DEFINED ABOVE, beside the click predicates it reads,
+;;                      because `rf/route-link`'s own `:on-click` calls it too —
+;;                      it is the shared click law first and a ui seam second.
 ;;
 ;; The ui side captures its render frame (its compiled `(ui/frame)` bundle's
 ;; `:frame` id) and threads it through both hooks; it owns nothing but the
@@ -377,10 +413,12 @@
      :native? <true when the anchor carries native-handling attrs the
               framework must not intercept even on a plain left click>}
 
-  Owns route-url synthesis + strategy encode + payload synthesis + native-attr
-  detection, so the ui artefact reaches route-link semantics through this one
-  seam without exposing routing internals (strategy encode, frame capture,
-  source stamping) as separate hooks. The JVM branch encodes path-form (SSR has
+  Bundles route-url synthesis, strategy encode, the shared
+  `url-requested-payload`, and native-attr detection, so the ui artefact reaches
+  route-link semantics through this one seam without exposing routing internals
+  (strategy encode, frame capture, source stamping) as separate hooks — and
+  reaches the SAME payload synthesiser `rf/route-link` uses, not a copy of it.
+  The JVM branch encodes path-form (SSR has
   no address bar); on hydration the CLJS render re-encodes through the frame
   strategy. Per Spec 012 §Linking from views and the rf2-5yovjt ruling."
   [target render-frame]
@@ -388,7 +426,8 @@
   ;; (`address/extract-address`) — the same closed key class `rf/route-link`,
   ;; `route-url`, and `:rf.route/navigate` resolve through. `native-anchor?`
   ;; still reads the FULL `target` (the `:target` / `:download` DOM attrs live
-  ;; outside the address class).
+  ;; outside the address class) — the same side `route-link-render` reads, so
+  ;; the two surfaces classify a native anchor identically by construction.
   ;;
   ;; EP-0037 R3: `link-model` is the one link calculation the compiled
   ;; `ui/route-link` runs on BOTH hosts, so the `:prefetch` value is validated
@@ -396,46 +435,13 @@
   ;; installs no intent handlers), which left the server render accepting an
   ;; unsupported mode the client rejected.
   (validate-prefetch! target)
-  (let [{:keys [to params query fragment]} (address/extract-address target)
+  (let [{:keys [to params query fragment] :as addr} (address/extract-address target)
         path-url (registry/route-url {:to to :params (or params {}) :query (or query {}) :fragment fragment})
         encode   #?(:cljs (:encode (strategy/url-strategy-for-frame-id render-frame))
                     :clj  identity)]
     {:href    (encode path-url)
-     :payload [:rf.route/url-requested
-               (cond-> {:url path-url :to to}
-                 (seq params) (assoc :params params)
-                 (seq query)  (assoc :query  query)
-                 fragment     (assoc :fragment fragment))]
+     :payload (url-requested-payload addr path-url)
      :native? (native-anchor? target)}))
-
-#?(:cljs
-   (defn activate-link!
-     "The `:routing/activate-link!` seam (CLJS only). THE router-attributed
-     click decision for a compiled `ui/route-link` anchor — the SAME click law
-     `route-link-render` applies to `rf/route-link`, kept inside routing so the
-     ui artefact reimplements none of it.
-
-     `e` is the native click event; `on-click` is the caller-supplied `:on-click`
-     (or nil); `render-frame` is the ui view's captured render-frame id; `payload`
-     and `native?` come from `link-model`.
-
-     Runs the caller `:on-click` first; then, unless the anchor is native (new
-     tab / download), the caller already prevented the default, or the click is
-     not a plain primary-button click (a modifier-key or auxiliary-button click
-     keeps the browser's open-in-new-tab affordance), calls `.preventDefault` and
-     dispatches `payload` to the captured render frame with `:source :router` (so
-     the L2 epoch timeline tags the cascade as a routing-substrate dispatch, per
-     rf2-t1lxr / rf2-1ve9h). `:frame render-frame` is an explicit dispatch opt —
-     the router targets the rendering frame verbatim even though the render scope
-     has unwound by click time (rf2-o3nam4), so the dispatch always lands on the
-     CURRENTLY-committed frame (retarget-safe)."
-     [e on-click render-frame payload native?]
-     (when on-click (on-click e))
-     (when (and (not native?)
-                (not (.-defaultPrevented e))
-                (plain-left-click? e))
-       (.preventDefault e)
-       (router/dispatch! payload {:source :router :frame render-frame}))))
 
 #?(:cljs
    (defn prefetch-on-intent!

--- a/implementation/routing/test/re_frame/route_link_cljs_test.cljs
+++ b/implementation/routing/test/re_frame/route_link_cljs_test.cljs
@@ -138,8 +138,8 @@
         (is (= "/cart" (:url payload)))
         (is (= :route/cart (:to payload)))))))
 
-(deftest plain-left-click-passes-params-and-query
-  (testing "the dispatched payload carries :params and :query when present"
+(deftest plain-left-click-passes-params-query-and-fragment
+  (testing "the dispatched payload carries :params, :query and :fragment when present"
     (rf/reg-route :route/article {:params [:map [:id :string]]
                                   :query  [:map [:tab [:enum :summary :details]]]} "/articles/:id")
     ;; :tab is declared as a BOUNDED [:enum …] keyword slot in the route's
@@ -147,15 +147,21 @@
     ;; rf2-qot6ii); pass a conformant value through the link click so
     ;; rf2-ug2m1's route-url validation doesn't reject the caller's payload.
     (let [{:keys [dispatched]}
-          (click! {:to     :route/article
-                   :params {:id "intro"}
-                   :query  {:tab :summary}}
+          (click! {:to       :route/article
+                   :params   {:id "intro"}
+                   :query    {:tab :summary}
+                   :fragment "notes"}
                   (mk-event {}))
           payload (second dispatched)]
       (is (= {:id "intro"} (:params payload))
           ":params lands in the dispatched payload")
       (is (= {:tab :summary} (:query payload))
-          ":query lands in the dispatched payload"))))
+          ":query lands in the dispatched payload")
+      ;; rf2-e9974: the click payload now comes from the SHARED
+      ;; `url-requested-payload` rather than an inlined `cond->`, and
+      ;; `:fragment` was the one slot no assertion covered on either surface.
+      (is (= "notes" (:fragment payload))
+          ":fragment lands in the dispatched payload"))))
 
 ;; ---- modifier-key clicks defer to browser ------------------------------
 

--- a/implementation/routing/test/re_frame/route_link_seam_cljs_test.cljs
+++ b/implementation/routing/test/re_frame/route_link_seam_cljs_test.cljs
@@ -82,6 +82,16 @@
       (is (= "/articles/intro?tab=summary" href))
       (is (= {:url "/articles/intro?tab=summary" :to :route/article
               :params {:id "intro"} :query {:tab :summary}}
+             (second payload)))))
+  ;; rf2-e9974: `:fragment` is the one payload slot neither link surface had an
+  ;; assertion for, and it is now synthesised by the SHARED
+  ;; `url-requested-payload` that `rf/route-link` also runs — so the slot is
+  ;; pinned here and at the `rf/route-link` click (see
+  ;; `plain-left-click-passes-params-query-and-fragment`).
+  (testing "a fragment rides the payload as well as the href"
+    (let [{:keys [href payload]} (link/link-model {:to :route/cart :fragment "totals"} nil)]
+      (is (= "/cart#totals" href))
+      (is (= {:url "/cart#totals" :to :route/cart :fragment "totals"}
              (second payload))))))
 
 (deftest link-model-detects-native-anchors


### PR DESCRIPTION
Follow-up to #7009, which merged while this bead was still in progress and so
took a branch state older than my tip. Three of the four EP-0037 gate-3 cohesion
findings landed there; **`rf2-e9974` did not**, and this PR carries it.

Verified by blob hash rather than ancestry (`--is-ancestor` and `git cherry`
both mislead after a rebase-merge):

| file | `HEAD` vs `origin/main` |
|---|---|
| `routing/strategy.cljc` | identical — landed |
| `resources/revalidate_listeners.cljc` | identical — landed |
| `routing/readiness.cljc` | identical — landed |
| `resources/route.cljc` | identical — landed |
| `routing/plan.cljc` | identical — landed |
| `routing/events.cljc` | identical — landed |
| `routing/link.cljc` | **differs — this PR** |
| `routing/test/…/route_link_cljs_test.cljs` | **differs — this PR** |
| `routing/test/…/route_link_seam_cljs_test.cljs` | **differs — this PR** |

### rf2-cqyq2 overlap check (the dangerous one)

`commit-navigation` lives in `events.cljc`, which `rf2-saf54` edited. The
`rf2-cqyq2` fix is intact on `main` and after this rebase:

- `branch-contributors` appears **4×** in `events.cljc`.
- `(resolve-branch …)` appears **0×** inside `commit-navigation`. The only call
  sites are `prefetch.cljc:176` and `resolve.cljc:274`, both spelled
  `routing-events/resolve-branch` — the legitimate separate callers, untouched.
- `rf2-saf54`'s diff against `main` was a **pure deletion** of
  `identical-route-target?` and its comment block, plus the `Owns:` bullet.
  Nothing else in `events.cljc` moved, so the second `:parent` walk was never
  in a position to come back.

## rf2-e9974 — what this PR changes

`link.cljc` held two copies of one decision. `activate-link!` documented itself
as "THE router-attributed click decision … the SAME click law
`route-link-render` applies to `rf/route-link`" — but `route-link-render` did
not call it; it inlined the identical body. The `[:rf.route/url-requested {…}]`
payload `cond->` likewise appeared twice, byte-identical, in
`route-link-render` and `link-model`.

- A private `url-requested-payload` is now the one payload synthesiser, run by
  both surfaces. It takes the **extracted** address, so no surface destructures
  the caller's props for a destination.
- `href-attrs` returns that address as a third value, so `route-link-render`'s
  href and payload come from **one** extraction rather than two readings of
  `props` — finding detail 1.
- `route-link-render`'s `:on-click` is now
  `(activate-link! e on-click render-frame payload native?)`. The inlined click
  body is gone, and so is the second statement of the law in its docstring,
  which now points at `activate-link!`.
- `native?` is read off the **raw props** on both sides, matching `link-model`
  — finding detail 2. `:target` / `:download` are neither address nor behaviour
  keys, so the strip never touched them; reading pre-strip on both sides makes
  that independence explicit instead of incidental.
- `activate-link!` **moved up** beside the click predicates it reads. A var
  referenced from `route-link-render`'s closure has to exist by then — and it is
  now the shared click law first, a ui late-bind seam second. Its docstring and
  the seam block comment say so.
- `href-attrs` stays: `route-link-render` needs the stripped passthrough attrs,
  which `link-model` does not return.

### Two assertions added, because proving the collapse exposed a real gap

Forcing `native?` false at the new call site reds 12 assertions across
`target-parent-and-top-defer-rf2-fwz29i`,
`download-defers-to-browser-rf2-fwz29i` and
`target-blank-defers-to-browser-rf2-fwz29i` — the click law is well covered.

But suppressing the payload's `:fragment` slot reddened **nothing**, on either
host. `:fragment` was asserted in the rendered href and never in the dispatched
payload, on either surface — exactly the drift the finding predicted for two
byte-identical copies with nothing pinning the shape. The `rf/route-link` click
test and the `link-model` seam test now each pin it, and with them in place the
same suppression reds one assertion per surface. That is the +3 assertions in
the CLJS count below.

## Per-bead: found versus changed

**rf2-e9974 (P3) — as filed, no growth.** Found exactly what the bead
described. Changed as its remedy specified. One thing the bead did not name and
I did **not** fix: `route-url` + strategy-encode are *also* duplicated between
`href-attrs` and `link-model`. Collapsing that would mean one of them calling
the other, and `link-model` must not strip/emit DOM attrs while `href-attrs`
must — so it is a real finding but a different one, and out of scope here.
Worth a bead if the mayor wants it.

**rf2-wzqtu (P3) — landed in #7009. The claim was worded differently than the
bead paraphrases, and there were TWO of them.** The routing sentence is
`readiness.cljc`: "This namespace is **the ONE pure implementation** the
navigation-commit assembler uses to seed the stored slice; the Resources
artefact's reply-driven reconciliation … **project through the same table**."
The mirror claim is on the resources side and is why a grep for the bead's
phrasing finds nothing in routing — `resources/route.cljc` carries a block
comment literally headed `---- the ONE readiness projector ----`, asserting
"There is exactly **ONE** implementation of that table, and **EVERY** path …
projects through it: **the activation commit** …". Both were false in the same
way. Neither was already corrected.

Fixed as the finding directed — **the claim went, not the duplication.** Each
side now says it holds one half (commit-time / reply-driven), names its sibling
by fully-qualified var, gives the vocabulary mapping between the two tables,
states why packaging forbids sharing one function, and says outright that
changing the precedence means changing both sites. No shared function, no
late-bind hook.

*Not done, and deliberately:* the finding's third item — one shared conformance
assertion driving both projectors over the same input classes — needs a test
that requires **both** namespaces, which only `implementation/resources/test/`
can do (routing is a test-only dep there). That tree was fenced this wave, so it
is left as follow-up.

**rf2-saf54 (P4) — landed in #7009. The bead's premise holds in full; I checked
rather than assumed.** `plan.cljc`'s `:require` of `re-frame.routing.events` is
**gone**, not merely the alias: on `main` its require vector is now exactly
`egress` / `scroll` / `trace`. The alias at line 81 was genuinely the file's only
use of that namespace, so the payoff is the one the bead claimed — one namespace
edge removed as well as one indirection. `commit-navigation` taking contributors
as opts did not change this, because `plan` never called `commit-navigation`;
it only aliased the predicate. No cycle appeared (`events` does not require
`plan`). Net −10 lines.

**rf2-yvn0g (P4) — landed in #7009. Three of the four items were real; the
fourth was already fixed.** The three `install-url-listener!` docstrings existed
as filed and now name live functions. The fourth item — `match-url-fail-closed`
naming `url-change-fx` as a direct caller — had **already** been corrected on
`main` by rf2-teov0, which rewrote it to record that the door has no direct
callers at all. I swept the rest of the tracked tree: every other mention of the
retired exports is a retirement note that correctly says they are gone.

While fixing `strategy.cljc` I also corrected a second inaccuracy in the same
sentence that the bead did not mention: the initial sync does **not** run
through the `on-change` thunk that fn is handed. `install-listener-for-owner!`
calls its dispatch closure directly with cause `:initial`.

## Quality gates

All run to completion in the foreground, `rc` captured immediately after each
runner and cross-checked against the log's own `Ran …` line.

| gate | result | exit code |
|---|---|---|
| `implementation/routing` `clojure -M:test` | 505 tests / 2743 assertions, 0 failures | 0 |
| `implementation/core` `clojure -M:test` | 2115 tests / 10456 assertions, 0 failures | 0 |
| `implementation/resources` `clojure -M:test` | 722 tests / 6729 assertions, 0 failures | 0 |
| `npm run test:cljs` | 11453 tests / 57345 assertions, 0 failures | 0 |
| `scripts/test-fast-pr.sh` | `PASS fast PR spine` — 17/17 namespaces pass standalone in the per-ns isolation lane | 0 |

Baselines re-derived on this rebase base (`main` has moved several times
today; the figures in my brief were stale):

| suite | baseline | after |
|---|---|---|
| routing | 505 tests / 2743 assertions | 505 / 2743 — unchanged |
| core | 2115 / 10456 | 2115 / 10456 — unchanged |
| resources | 722 / 6729 | 722 / 6729 — unchanged |
| CLJS | 11453 / 57342 | 11453 / **57345** (+3 — the two new assertions, one of which asserts twice) |

Cross-checks, since a wrapper-reported exit code has disagreed with a captured
`rc` on this box before: for fast-pr the harness exit code (0), the `rc=$?`
captured immediately after the runner (`FAST-PR rc=0`), and the log's own
terminal line (`PASS fast PR spine`) all agree. fast-pr independently
reproduced two of the standalone figures from inside its own spine — JVM core
2115 / 10456 and JVM routing 505 / 2743 — and its CLJS lane reported 11453 /
57345, identical to the standalone `npm run test:cljs`. No CLJS lane reddened
with an empty log, so nothing died at macroexpansion, and no
`spawnSync … ETIMEDOUT` appeared in `re-frame.test-quiet-shadow-node-cljs-test`.

`implementation/resources` is listed by fast-pr as NOT RUN by the spine, because
this PR's diff does not touch that artefact — `rf2-e9974` is routing-only. I ran
it standalone anyway (722 / 6729, rc=0), since `rf2-wzqtu` had touched
`resources/route.cljc` earlier in the wave.

### Negative controls

| bead | control | red | restored |
|---|---|---|---|
| rf2-e9974 | force `native?` false at the `activate-link!` call site | 12 assertions, 3 deftests, rc=1 | green |
| rf2-e9974 | suppress the payload's `:fragment` slot | 2 assertions (1 per surface), rc=1 — **reddened nothing before the two assertions above were added** | green |
| rf2-saf54 | invert the moved predicate's fragment comparison | 59 assertions, 12 deftests, rc=1 | 505/2743 green |
| rf2-wzqtu, rf2-yvn0g | comment/docstring-only — no assertions to red; proof is the suites at unchanged counts | — | — |

## Spec

No `spec/012-Routing.md` change is needed for any of the four. `spec/012`
already describes the click law as a seam "not one an application should have to
re-derive per link", which is what `rf2-e9974` makes true internally, and it
already describes route readiness as a resource projection without asserting a
single implementation site.
