### PR TITLE
docs(freehand): record the product-completion setpoint and D022

### DIFF
--- a/docs/EP/EP-0036-the-freehand-view-substrate-programme.md
+++ b/docs/EP/EP-0036-the-freehand-view-substrate-programme.md
@@ -117,8 +117,14 @@ not fit the common model disappear rather than opting a view out of parity.
 7. **Proof is honest.** Separate React and JVM emitters may share normalizers but
    prove parity through common conformance values and fixtures.
 
-The detailed D001–D021 rulings are indexed in
+The detailed D001–D022 rulings are indexed in
 `docs/design/freehand/decisions/README.md`.
+
+The accepted 2026-07-26 product-completion delta is recorded in
+`docs/design/freehand/product-completion-setpoint.md`. It extends these laws with
+the sole inward React host door, pure forms and first-party controls, executable
+fixture/tooling authority, and ownership/evidence witnesses. It is additional
+vertical work under this EP, not a second programme.
 
 ### Canonical contract migration
 
@@ -207,9 +213,10 @@ The following are release work, not unresolved product questions:
 - root tests cover the minimal one-root spelling, the same form in structural
   rendering, explicit multi-root identity, frame preflight, hydration, failed-root
   isolation, and total teardown;
-- direct Vega and SpreadJS-class behaviors, Radix and TanStack wrappers, and an
-  AG-Grid-style `v/->react` cell prove all three host shapes without adding neutral
-  hooks, refs, portals, or arbitrary lifecycle callbacks.
+- direct Vega and SpreadJS-class behaviors, D022-declared Radix and TanStack
+  wrappers, and an AG-Grid-style `v/->react` cell prove the behavior, inward-host,
+  and outward-bridge routes without adding neutral hooks, refs, portals, or
+  arbitrary lifecycle callbacks.
 
 ### Conformance and donor deletion gate
 
@@ -291,8 +298,11 @@ External renderer adapters remain independent and are not renamed into Freehand.
 - **State and host boundaries:** re-frame is the only reactive state system;
   semantic controllers, behaviors, and wrappers replace the donor forms that do
   not cross.
-- **D001–D021:** all are ruled;
+- **D001–D022:** all are ruled;
   `docs/design/freehand/decisions/README.md` states each ruling.
+- **Product completion:** DC-01–DC-09 and ER-01–ER-08 are accepted in
+  `docs/design/freehand/product-completion-setpoint.md`; implementation stays
+  inside this programme.
 - **Contract ownership:** existing specs are migrated; `004D` owns the compiled
   grammar; there is no new numbered Freehand family.
 - **Programme shape:** vertical F0–F6 slices replace the seven-spec waterfall.
@@ -301,9 +311,16 @@ External renderer adapters remain independent and are not renamed into Freehand.
 
 ## Open Issues
 
-There are no open product decisions required before implementation. If a slice
-discovers a genuine contradiction, it must propose one explicit amendment to the
-affected ruling or canonical contract; it must not silently preserve both answers.
+There are no open product decisions blocking the accepted implementation work. If
+a slice discovers a genuine contradiction, it must propose one explicit amendment
+to the affected ruling or canonical contract; it must not silently preserve both
+answers.
+
+One operator-level architecture choice is deliberately deferred: the commissioned
+`v/$` comparison may justify replacing compiled Hiccup, but the experiment itself
+does not make that change. `v/->element`, behavior outlets, a reusable async
+helper, and scheduling/equality vocabulary remain evidence-gated rather than open
+prerequisites.
 
 Programme graduation remains open until F6: conformance green, pilots passed,
 evidence current, consumers migrated, and the donor artifact deleted.
@@ -311,10 +328,12 @@ evidence current, consumers migrated, and the donor artifact deleted.
 ## References
 
 - Freehand design record: `docs/design/freehand/README.md`
+- Product-completion setpoint:
+  `docs/design/freehand/product-completion-setpoint.md`
 - Product spine: `docs/design/freehand/codex-design.md`
 - Argued dossier: `docs/design/freehand/fable-design.md`
 - Fitness harness: `docs/design/freehand/studio/fitness-harness.md`
-- Decision register D001–D021: `docs/design/freehand/decisions/README.md`
+- Decision register D001–D022: `docs/design/freehand/decisions/README.md`
 - [EP-0030 — donor programme](EP-0030-the-compiled-view-substrate-program.md)
 - [EP-0031 — donor programming model](EP-0031-re-frame-ui-programming-model.md)
 - [EP-0032 — donor reactivity and ownership](EP-0032-re-frame-ui-reactivity-and-ownership.md)

--- a/docs/design/freehand/README.md
+++ b/docs/design/freehand/README.md
@@ -10,18 +10,20 @@ built by absorbing the useful `re-frame.ui` machinery.
 |---|---|
 | [`codex-design.md`](codex-design.md) | product spine: the ratified target, boundaries, conformance contract, and technical dependency order |
 | [`fable-design.md`](fable-design.md) | argued dossier: worked code, corpus fitness, semantic traces, alternatives, wounds, and pre-mortems |
+| [`product-completion-setpoint.md`](product-completion-setpoint.md) | accepted 2026-07-26 problem statements, design completions, execution rulings, and evidence gates |
 | [`studio/fitness-harness.md`](studio/fitness-harness.md) | evidence and acceptance pressure from applications, re-com, and hard browser cases |
-| [`decisions/`](decisions/README.md) | D001–D021, each with its explicit ratified ruling and rationale |
+| [`decisions/`](decisions/README.md) | D001–D022, each with its explicit ratified ruling and rationale |
 | the draft guide | PROMOTED and gone from this tree. It was the operator's working draft, and it became the shipped guide at [`docs/core/freehand/`](../../core/freehand/index.md) (rf2-fby7o), refined there against what actually landed. Its history is in git; keeping a second, staler copy beside the real one would only invite readers to the wrong page. |
 
 ## Authority
 
 This directory is not a parallel specification tree. Operator rulings and
-EP-0036 control the programme. For target details not yet migrated into `spec/`,
-the product spine carries the ratified design. As each implementation slice lands,
-the owning specification becomes the canonical contract for that surface. The
-argued dossier and fitness harness explain and test the design; they do not enlarge
-the API.
+EP-0036 control the programme. The product-completion setpoint records the later
+accepted delta. For target details not yet migrated into `spec/`, the product
+spine plus that setpoint carry the ratified design. As each implementation slice
+lands, the owning specification becomes the canonical contract for that surface.
+The argued dossier and fitness harness explain and test the design; they do not
+enlarge the API.
 
 Current donor-era specs continue to describe current shipped behavior until their
 Freehand migration lands. That temporary difference between “shipped now” and

--- a/docs/design/freehand/codex-design.md
+++ b/docs/design/freehand/codex-design.md
@@ -5,12 +5,13 @@ substrate is **Freehand**; its public namespace is `re-frame.freehand`,
 conventionally aliased as `v`.
 
 This is the product spine. It incorporates the ruled
-[`decisions/D001-D021`](decisions/README.md) and defines the target until each
-surface graduates into its canonical specification. It is not a second spec tree:
-after a spec migration lands, that spec owns the contract. Required prototypes,
-pilots, and measurements are acceptance obligations, not open product design. The
-argued dossier, fitness harness, and `re-frame.ui` donor code supply evidence but
-do not independently enlarge Freehand's API.
+[`decisions/D001-D022`](decisions/README.md), as extended by the
+[product-completion setpoint](product-completion-setpoint.md), and defines the
+target until each surface graduates into its canonical specification. It is not a
+second spec tree: after a spec migration lands, that spec owns the contract.
+Required prototypes, pilots, and measurements are acceptance obligations, not
+open product design. The argued dossier, fitness harness, and `re-frame.ui` donor
+code supply evidence but do not independently enlarge Freehand's API.
 
 Notation:
 
@@ -418,12 +419,12 @@ the caret only when the caller's new reset key establishes a new baseline.
 The model and protocol are settled; the portable component claim remains gated by
 the same-value, stale-blur, browser editing, HMR, frame, JVM, multiplicity, orphan,
 and cost harnesses. Dropdown and typeahead pilots may reveal further shared
-controller infrastructure. A high-rate or opaque editor may instead use a qualified
-host-owned wrapper; that is an explicit protocol/performance escape, not generic
-local state.
+controller infrastructure. A high-rate or opaque editor may instead use a
+React-owned wrapper declared through `v/defhost`; that is an explicit
+protocol/performance escape, not generic local state.
 
 Freehand exposes no local-state, ref, effect, or hook forms. React-owned protocols
-use a qualified host leaf or UIx/Helix wrapper.
+stay inside a React component declared through the one D022 host boundary.
 
 ## 4. Common semantics
 
@@ -808,24 +809,26 @@ one-node behavior. Enter/exit retention uses `v/presence`. These intrinsics do n
 own focus policy, keyboard semantics, timers, geometry, or domain lifecycle.
 React portals remain in explicit wrappers; Freehand has no neutral portal primitive
 or target registry. Reconsider one only after multiple non-overlay integrations
-cannot fit a leaf, behavior, outward bridge, or wrapper.
+cannot fit a declared React host, behavior, outward bridge, or explicit nested
+root.
 
-### Three host shapes
+### Host ownership routes
 
 | Shape | Use |
 |---|---|
-| qualified host leaf | React component with values in and callbacks out |
+| declared `v/defhost` | React component with values/callbacks, or a React-owned wrapper using hooks, context, refs, effects, portals, or compound protocols |
 | registered behavior | one DOM node owned by an imperative library with connect/update/disconnect and optional finite commands |
-| UIx/Helix wrapper | React-owned hooks, context, refs, effects, portals, compound cloning, or callback protocols |
+| outward `v/->react` bridge | a foreign React owner needs a stable component value for a declared Freehand view |
 
 Bare React component heads are outside the Freehand tree. A host descriptor names
-the boundary, and a declared wrapper states its structural/SSR policy.
+the boundary and states its structural/SSR policy. Simple leaves and hook-owning
+wrappers are implementation shapes behind the same D022 descriptor kind.
 
 #### Outward React bridge
 
 Some React libraries demand a component value as a prop—for example a grid cell
-renderer or drag overlay. `v/->react` is the outward half of the same wrapper
-boundary, not a fourth host shape:
+renderer or drag overlay. `v/->react` is the outward half of the same ownership
+boundary:
 
 ```clojure
 {:cellRenderer (v/->react person-cell)}
@@ -973,7 +976,8 @@ bus, ref registry, service locator, or catalog of framework-owned behaviors.
 
 This is not a general `on-mount`/`on-unmount` callback. It is a finite host adapter
 protocol. Mapbox, direct Vega, canvas, observers, editors, or direct SpreadJS may
-fit it. Radix context/portals and hook-based React adapters remain wrappers.
+fit it. Radix context/portals and hook-based React adapters remain React-owned
+wrappers registered through `v/defhost`.
 
 ### Roots, structural rendering, and SSR
 
@@ -1004,9 +1008,9 @@ The versioned structural host retains declared view boundaries, public props,
 children, data intents/key maps, presence and top-layer metadata, error boundaries,
 and host behavior/component/command markers. Host internals remain opaque.
 
-A browser-only host leaf uses `client-only` with an explicit fallback. A host with
-real server support can provide an explicit JVM/SSR adapter. A React component does
-not acquire server semantics merely because it can create browser DOM.
+A D022 React host is client-only in v1 and declares either a portable fallback or
+explicit no-server content. Freehand never executes the registered React component
+on the JVM.
 
 ## 6. Compiled mode
 
@@ -1196,16 +1200,16 @@ compatibility exercise; §8 pilots determine completeness.
 
 | Library shape | Representative API | Boundary | Consequence |
 |---|---|---|---|
-| declarative leaf | `react-vega` `spec` and options | qualified React leaf | static chart remains data-oriented |
-| imperative view | Vega View API for data, resize, signals | direct Vega behavior or `react-vega` wrapper | View/listeners private; config/intents visible; disconnect tested |
-| large widget | SpreadJS Workbook from `workbookInitialized`, instance methods, nested sheets | direct Workbook behavior with explicit command target, or React wrapper | one opaque owner; finite commands/events cross a small data API |
+| declarative leaf | `react-vega` `spec` and options | declared `v/defhost` | static chart remains data-oriented |
+| imperative view | Vega View API for data, resize, signals | direct Vega behavior or React-owned wrapper declared by `v/defhost` | View/listeners private; config/intents visible; disconnect tested |
+| large widget | SpreadJS Workbook from `workbookInitialized`, instance methods, nested sheets | direct Workbook behavior with explicit command target, or React-owned wrapper declared by `v/defhost` | one opaque owner; finite commands/events cross a small data API |
 | component-as-prop | AG Grid cell renderer, drag overlay, virtual row component | `v/->react` descriptor bridge with optional top-level prop adapter | stable frame-aware React identity; foreign parameter object projected explicitly |
-| compound/context/ref | Radix `asChild`, prop cloning, forwarded refs, portals | UIx/React wrapper | do not emulate React composition in neutral Hiccup |
-| headless hook adapter | TanStack `useReactTable` over framework-neutral core | core as value logic or hook wrapper | do not recreate hooks; state in, intent out |
-| simple controlled control | date picker/select value + callback | qualified leaf with `v/event` | no bespoke adapter per leaf |
+| compound/context/ref | Radix `asChild`, prop cloning, forwarded refs, portals | React-owned wrapper declared by `v/defhost` | do not emulate React composition in neutral Hiccup |
+| headless hook adapter | TanStack `useReactTable` over framework-neutral core | core as value logic or React-owned `v/defhost` wrapper | do not recreate hooks; state in, intent out |
+| simple controlled control | date picker/select value + callback | declared `v/defhost` with `v/event` | no bespoke adapter per leaf |
 
-These cases fit the three host shapes. They do not justify neutral refs, effects,
-hooks, or arbitrary mount callbacks.
+These cases fit the ownership routes above. They do not justify neutral refs,
+effects, hooks, or arbitrary mount callbacks.
 
 ### Testing
 

--- a/docs/design/freehand/decisions/D001-product-name-and-namespace.md
+++ b/docs/design/freehand/decisions/D001-product-name-and-namespace.md
@@ -42,8 +42,9 @@ Consequences:
 - Distinctive and searchable in prose, source, traces, and package indexes.
 - Communicates that this is a designed authoring surface, not merely a generic
   `view` namespace.
-- Naturally supports small qualified edges such as `re-frame.freehand.host` and
-  `re-frame.freehand.test` without suggesting separate products.
+- Naturally supports small qualified edges such as `re-frame.freehand.test`,
+  `re-frame.freehand.form`, and `re-frame.freehand.controls` without suggesting
+  separate products.
 - Slightly longer when written unaliased; normal code pays none of that because it
   uses `v`.
 

--- a/docs/design/freehand/decisions/D008-callback-forms-and-stable-identity.md
+++ b/docs/design/freehand/decisions/D008-callback-forms-and-stable-identity.md
@@ -131,9 +131,10 @@ or a wrapper instead of asking Freehand to guess.
 Bare functions remain legal at native `:on-*` sites and as opaque values passed
 between internal views; the site's stable outer adapter owns native callback
 lifetime. They are rejected in declared foreign callback positions, where phase
-and identity are otherwise unknown, with a diagnostic that names the roster. A
-qualified host leaf's schema identifies those positions; an unknown or
-protocol-heavy foreign surface needs a wrapper.
+and identity are otherwise unknown, with a diagnostic that names the roster.
+D022's host declaration identifies those positions through its mandatory
+`:callbacks` map; a protocol-heavy foreign surface remains React-owned behind
+that same declared host boundary.
 
 Per-site ownership is the public law, not the private key representation. The
 interpreted runtime may key a site by committed normalized-node identity while the
@@ -167,7 +168,7 @@ adapters, memoized React children, and deterministic callback diagnostics.
 
 - [Codex design, §4 “Event law”](../codex-design.md#event-law) gives the role-specific
   callback table and per-event-site ownership law.
-- [Codex design, §5 “Three host shapes”](../codex-design.md#three-host-shapes) places
+- [Codex design, §5 “Host ownership routes”](../codex-design.md#host-ownership-routes) places
   React-owned callback protocols in wrappers.
 - [Fable design, §2.1 “Dream code”](../fable-design.md#21-dream-code) introduces the
   dispatcher and four-form escape roster.

--- a/docs/design/freehand/decisions/D010-compiled-dynamic-markup-crossing.md
+++ b/docs/design/freehand/decisions/D010-compiled-dynamic-markup-crossing.md
@@ -50,7 +50,7 @@ diagnostics. The compiled form therefore presents a choice:
 
 The issue is not cross-mode child mounting. A statically named descriptor such
 as `[field-help-view props]` is an explicit mounted boundary and is required to
-work in both directions. Nor is it a qualified React leaf or wrapper. The issue
+work in both directions. Nor is it a D022-declared React host. The issue
 is an arbitrary runtime value that the compiled template would have to interpret
 as more Freehand markup.
 

--- a/docs/design/freehand/decisions/D012-declared-reads-and-evidence-levels.md
+++ b/docs/design/freehand/decisions/D012-declared-reads-and-evidence-levels.md
@@ -230,6 +230,36 @@ The smallest future experiment should be an enforced empty-read declaration for 
 props-only boundary, with any `v/sub` rejected. It can test the value of static
 read contracts without first inventing placeholder interpolation.
 
+## 2026-07-26 amendment — test-render subscription overrides
+
+Mike accepted one development/testing substitution seam under
+`re-frame.freehand.test`. It preserves Story's useful ability to show an error,
+loading, empty, or other difficult view state without replaying the full event
+history. It does not introduce `:reads`, application state, or a production
+`v/*` API.
+
+The contract is deliberately narrow:
+
+1. An override key is the entire subscription query vector, compared by ordinary
+   equality. There are no prefixes, patterns, predicates, or fallback matching.
+2. A matching `v/sub` inside the explicit test/Story render bracket reads the
+   pinned value. A miss takes the ordinary subscription path.
+3. The override map never mutates app-db, registration state, or the subscription
+   cache and never satisfies a subscription assertion. A derivation test still
+   tests the real subscription.
+4. The seam and its React carriage are development/test-only and production
+   elided. Installation and cleanup are bracket-owned and exact.
+5. Story records `:sub-overrides` as a lower-fidelity rendering rung. Freehand
+   evidence uses the existing `:basis :declaration` and a test-render scope, with
+   explicit loss such as `{:reason :subscription-resolution-substituted}`; it
+   does not invent a fifth evidence basis or claim that real subscription logic
+   ran.
+
+Spec 008 owns the mounted/structural test contract when the implementation slice
+lands. The Story provider, `re-frame.freehand.test` facade, Spec 008 text, mounted
+proof, and programmer guide move together. Until then, the shipped guide remains
+honest about the currently absent Freehand seam.
+
 ## Tool contract to settle now
 
 The initial evidence schema should distinguish:

--- a/docs/design/freehand/decisions/D013-imperative-host-behaviors-and-commands.md
+++ b/docs/design/freehand/decisions/D013-imperative-host-behaviors-and-commands.md
@@ -78,8 +78,10 @@ identity.
 
 This decision does not reopen the following points shared by the two designs:
 
-- Freehand has three host shapes: qualified React leaf, registered one-node
-  behavior, and explicit UIx/Helix/React wrapper. A behavior is not a neutral
+- Freehand has two inward host routes: D022's qualified React host descriptor and
+  this decision's registered one-node behavior. A simple React leaf and a
+  hook-owning UIx/Helix/React wrapper are implementation shapes behind the same
+  D022 descriptor, not separate host kinds. A behavior is not a neutral
   hook/effect system.
 - The use site is data: a qualified behavior id plus public configuration and
   outward event intents. The implementation is registered code.
@@ -314,7 +316,7 @@ Unlocks:
 
 ## Source basis
 
-- [Codex design — Three host shapes](../codex-design.md#three-host-shapes) defines
+- [Codex design — Host ownership routes](../codex-design.md#host-ownership-routes) defines
   the minimal registered behavior and its lifecycle laws.
 - [Codex design — React-library integration](../codex-design.md#react-library-integration)
   classifies direct Vega and SpreadJS as behavior-or-wrapper integrations.

--- a/docs/design/freehand/decisions/D014-outward-react-bridge.md
+++ b/docs/design/freehand/decisions/D014-outward-react-bridge.md
@@ -19,9 +19,9 @@ belongs on the one main authoring surface.
 
 ## The problem
 
-Freehand normally points inward: a Freehand tree can mount a qualified React
-leaf or wrapper. Some React libraries reverse the direction and demand a React
-component value:
+Freehand normally points inward: a Freehand tree can mount a React component or
+React-owned wrapper through D022's one declared host kind. Some React libraries
+reverse the direction and demand a React component value:
 
 ```clojure
 {:cellRenderer (v/->react person-cell)}
@@ -352,7 +352,7 @@ Unlocks:
 
 ## Source basis
 
-- [Codex design — Three host shapes](../codex-design.md#three-host-shapes) defines
+- [Codex design — Host ownership routes](../codex-design.md#host-ownership-routes) defines
   `v/->react` as the outward half of the wrapper boundary.
 - [Codex design — React-library integration](../codex-design.md#react-library-integration)
   identifies component-as-prop and compound React protocols as separate cases.

--- a/docs/design/freehand/decisions/D015-top-layer-overlays-and-portals.md
+++ b/docs/design/freehand/decisions/D015-top-layer-overlays-and-portals.md
@@ -275,7 +275,7 @@ Unlocks:
 
 ## Source basis
 
-- [Codex design — Three host shapes](../codex-design.md#three-host-shapes) keeps
+- [Codex design — Host ownership routes](../codex-design.md#host-ownership-routes) keeps
   portals and React protocols in wrappers while permitting one-node behaviors.
 - [Codex design — Re-implementing re-com](../codex-design.md#re-implementing-re-com)
   selects native top layer plus bounded host behavior for popup/focus/measurement.

--- a/docs/design/freehand/decisions/D022-public-react-host-door.md
+++ b/docs/design/freehand/decisions/D022-public-react-host-door.md
@@ -1,0 +1,195 @@
+# D022 — Public React host door
+
+Status: **Ruled**
+
+Ruling: **`v/defhost` is Freehand's sole public inward React host declaration. It
+produces one qualified descriptor kind with explicit ordinary-prop, callback,
+children, and SSR planes. There is no runtime `v/host`, `:kind` split, or
+`v/react-el`.**
+
+Horizon: **Immediate**
+
+## Decision
+
+Freehand needs a short, honest way to use common React libraries without allowing
+hooks, refs, effects, or opaque React elements to dissolve its callback,
+structure, SSR, and compiler laws.
+
+`v/defhost` declares a React component as a stable qualified Freehand host
+descriptor. The registered React component may itself be a simple value/callback
+component or a React-owned wrapper using hooks, context, refs, effects, Suspense,
+or a compound-component protocol. Those are implementation styles behind one
+boundary, not separate public host kinds.
+
+An illustrative declaration is:
+
+```clojure
+(v/defhost date-picker
+  DatePicker
+  {:callbacks {:onChange :event}
+   :children  :optional
+   :ssr       :client-only})
+
+[date-picker
+ {:selected date
+  :onChange
+  (v/event [js-date]
+    [:booking/date-picked (from-js-date js-date)])}]
+```
+
+The canonical specification may sharpen reversible data spelling while
+preserving the planes and laws below.
+
+## Contract
+
+### Identity and invocation
+
+- A declaration produces one stable, qualified, non-callable host descriptor.
+- It is used as a Freehand vector head. React components do not become legal bare
+  heads.
+- There is one descriptor kind. “Leaf” and “wrapper” describe the registered
+  React implementation, not distinct ABIs.
+- There is no public runtime constructor. Public host identity comes from the
+  declaration and remains source-locatable and checkable.
+
+### Ordinary props
+
+- Unreserved ordinary prop names pass shallowly and exactly by default.
+- There is no automatic case conversion, deep Clojure-to-JavaScript conversion,
+  callback inference, or per-prop conversion language.
+- One optional whole-ordinary-props `:map-props` adapter may prepare non-portable
+  host values.
+- Ordinary props, declared callbacks, and children are disjoint planes.
+  Callback carriers and trailing children are withheld from `:map-props` and
+  installed afterward. The adapter cannot supply or replace declared callbacks,
+  children, keys, identity, or other reserved Freehand facts; collisions and
+  function values in ordinary-data slots are refused.
+- Props-contract evidence is optional for application-private declarations.
+  D011's stronger schema policy still applies to public library, catalogue, and
+  generated-parity surfaces. Evidence reports declaration, key closure, value
+  validation, and generator availability independently.
+
+### Callbacks
+
+- `:callbacks` is a finite map from exact prop names to the D008 roles `:event`
+  or `:handler`.
+- A callback position accepts the corresponding `v/event` or `v/handler`
+  carrier. It is not inferred from an `on*` name.
+- Freehand materializes carriers only at declared positions after the candidate
+  is selected. The resulting functions obey D008's stable identity, latest
+  committed body/frame, abandoned-render silence, retirement, and HMR laws.
+- A bare event vector at a foreign callback position is not an implicit
+  converter; it could otherwise confuse a host value with re-frame intent.
+
+### Children and React ownership
+
+- Every declaration states its children policy. Undeclared child crossing is a
+  refusal, not an opaque accident.
+- Accepted children are ordinary React children in the registered component's
+  React tree, preserving that tree's context.
+- Freehand does not promise that a Freehand-authored child can participate
+  directly in `asChild`, arbitrary `cloneElement`, or ref-injection protocols.
+  Keep such a region React-owned and register its wrapper through `v/defhost`.
+- Hooks remain outside `v/defview`. Using a hook inside the registered React
+  component is the intended route, not a hook API in Freehand.
+
+### Structure and SSR
+
+- Every host declaration states an SSR policy. In v1 a React host is client-only:
+  the declaration chooses either a portable fallback or explicit no-server
+  content according to the owning SSR contract. Freehand never executes the
+  registered React component on the JVM.
+- Structural rendering emits a stable honest marker carrying the declared host
+  identity and permitted public evidence, not the opaque React implementation.
+- Host values, React elements, functions, refs, and third-party instances are not
+  serialized.
+
+### Compiled mode
+
+- The checker and compiler recognize the declared descriptor and its finite
+  callback and children positions.
+- A compiled parent may cross the host when lowering supports the same laws.
+- Until then, the exact build refuses the crossing with a stable id, source
+  location, explanation, and recovery. It must not accept the view and fail only
+  at runtime or secretly invoke the interpreted walker.
+
+### Raw React-element escape
+
+Finished React elements remain legal opaque browser-only children where the
+owning tree contract permits them. Their callbacks are ordinary captured-frame
+closures. Freehand does not claim site retirement, structural inspection, SSR
+portability, or compiled visibility for their internals.
+
+`v/event` and `v/handler` are non-callable carriers and therefore are not legal
+raw `createElement` callbacks. Use an ordinary captured-frame closure there, with
+none of D008's declared-site identity or retirement claims.
+
+This escape is deliberately weaker than `v/defhost`; it is not a second host API.
+
+## Alternatives considered
+
+### Raw elements only
+
+This keeps the API smallest but cannot own callback positions, committed identity,
+retirement, structure, SSR policy, or compiler recognition. It leaves ordinary
+React-library use outside Freehand's strongest laws.
+
+### `v/react-el` as a staged scanner
+
+A helper that receives an already-created React element is too late to materialize
+callback carriers with D008 identity and lifecycle. If it grows enough declaration
+and commit machinery to do so, it becomes the host door under a second spelling.
+It is rejected.
+
+### Separate leaf and wrapper host kinds
+
+Hook ownership is internal to the React component. Freehand can enforce the same
+boundary contract around a simple third-party component and a hook-owning wrapper.
+Two kinds would add authoring choice without adding an enforceable law.
+
+### A neutral hook or ref tier
+
+This would introduce another authoring and lifecycle model inside Freehand,
+weaken cross-host parity, and duplicate the existing explicit React-owner route.
+It remains rejected by EP-0036.
+
+## Required proof
+
+The first vertical fixture covers:
+
+1. shallow value props;
+2. one `:event` and one `:handler` callback;
+3. ordinary child and context continuity;
+4. callback identity across commits;
+5. latest committed body and frame;
+6. silence for abandoned renders;
+7. retirement after unmount and HMR replacement;
+8. structural identity and declared loss;
+9. SSR policy and fallback;
+10. interpreted mounted behavior; and
+11. compiled crossing or source-located build refusal with recovery.
+
+Vega-Lite, Google Maps, Framer Motion, SpreadJS, and another hook/compound
+React library extend the same fixture spine according to their actual ownership
+shape. They do not each earn a new boundary.
+
+## Consequences
+
+- Programmers get one short vector-head route for ordinary React libraries and
+  hook-owning wrappers.
+- Freehand retains a small, explicit semantic seam instead of mirroring a
+  third-party TypeScript API.
+- Library authors must declare callback positions, children, and SSR behavior.
+  That ceremony buys enforceable Freehand laws.
+- Opaque React elements remain useful when those laws are unnecessary, with
+  their price stated honestly.
+
+## Dependencies
+
+This ruling preserves D002 boundary identity, D008 callback lifetime, D010
+compiled-boundary honesty, D011 props publication policy, D012 evidence honesty,
+D014's opposite-direction bridge, and EP-0036's one-state-system and no-neutral-
+hooks laws.
+
+It unlocks the declared-host vertical slice and the React-library witnesses in
+the [product-completion setpoint](../product-completion-setpoint.md).

--- a/docs/design/freehand/decisions/README.md
+++ b/docs/design/freehand/decisions/README.md
@@ -1,6 +1,6 @@
 # Freehand decision register
 
-All twenty-one Freehand product decisions are **Ruled**. The files in this
+All twenty-two Freehand product decisions are **Ruled**. The files in this
 directory explain the problem, alternatives, consequences, and rationale; their
 header states the operative ruling so an implementer does not have to infer it
 from a recommendation section.
@@ -16,12 +16,15 @@ Use these sources according to the question being answered:
 1. An explicit operator ruling controls.
 2. [EP-0036](../../../EP/EP-0036-the-freehand-view-substrate-programme.md)
    controls product topology, programme ownership, migration, and gates.
-3. A canonical specification controls a surface once its Freehand migration has
+3. The accepted
+   [product-completion setpoint](../product-completion-setpoint.md) records the
+   2026-07-26 completion rulings until their vertical slices graduate.
+4. A canonical specification controls a surface once its Freehand migration has
    landed. Until then, the existing specification describes the donor-era shipped
    contract and [`codex-design.md`](../codex-design.md) describes the ratified
    Freehand target.
-4. This register records the individual rulings and their rationale.
-5. [`fable-design.md`](../fable-design.md) and the
+5. This register records the individual rulings and their rationale.
+6. [`fable-design.md`](../fable-design.md) and the
    [fitness harness](../studio/fitness-harness.md) supply worked examples,
    evidence, failure modes, and acceptance pressure. They do not add API.
 
@@ -32,7 +35,8 @@ code; after that migration there is one owner.
 ## Settled foundations
 
 - The product is Freehand, published through `re-frame.freehand` with alias `v`
-  and no second public namespace.
+  and no second product root or alternative primary facade. Qualified edge
+  namespaces such as `.test`, `.form`, and `.controls` remain part of Freehand.
 - Freehand is one re-frame-native substrate with interpreted and compiled modes;
   the compiled mode is required.
 - The useful `re-frame.ui` machinery is absorbed as the compiled mode's
@@ -76,6 +80,7 @@ code; after that migration there is one owner.
 | [D019](D019-error-boundaries-and-production-reports.md) | resettable error boundary, once-per-generation safe intent, and private frame error egress |
 | [D020](D020-tool-evidence-retention-and-warning-policy.md) | one occurrence-keyed evidence schema and the existing Spec 009 retention axis |
 | [D021](D021-performance-budgets-and-release-evidence.md) | deterministic release gates plus mandatory published timing/byte evidence without fixed thresholds |
+| [D022](D022-public-react-host-door.md) | sole inward React door is one declared `v/defhost` descriptor kind; no runtime `v/host` or `v/react-el` |
 
 ## Implementation horizons
 
@@ -90,6 +95,9 @@ design.
   error, and tooling slices.
 - **Continuous release evidence:** D021 applies from the first runnable B1–B5
   fixture and cannot weaken a semantic or browser-correctness gate.
+- **Product-completion slices:** D022 and the accepted completion setpoint add the
+  declared React host, forms/controls, executable fixture spine, and integration
+  witnesses without reopening the original topology.
 
 Dependency constraints remain small and explicit: D003 precedes the controller
 work governed by D004/D016; D006–D009 precede the controlled-input proof; D013

--- a/docs/design/freehand/fable-design.md
+++ b/docs/design/freehand/fable-design.md
@@ -2,9 +2,9 @@
 
 **Freehand** is the product name, and the single public entry point is
 `re-frame.freehand`, with `v` as the documented source alias (D001) — all
-dream code below uses `v`. Edge namespaces (`re-frame.freehand.host`,
-`re-frame.freehand.test` — aliased `host`/`v.test` here) exist only where a
-host-only or test-only capability materially clarifies; compiler and runtime
+dream code below uses `v`. Edge namespaces (`re-frame.freehand.test`, plus the
+later accepted `.form` and `.controls`) exist only where a bounded capability
+materially clarifies; there is no public `.host` namespace. Compiler and runtime
 namespaces stay internal; `re-frame.view` is NOT published as an alias (one
 door, per the absorption ruling), and `re-frame.ui` is a donor namespace only,
 deleted at the gate.
@@ -25,6 +25,14 @@ claim is verified at source (`file:line` in this checkout; decision headers for
 rulings); estimates and knowledge-sourced claims are labelled. Provenance and
 the verification ledger are in Appendix C.
 
+**2026-07-26 completion addendum.** The later accepted
+[`product-completion-setpoint.md`](product-completion-setpoint.md) and
+[D022](decisions/D022-public-react-host-door.md) extend the original twenty-one
+decisions. Where this dossier still distinguishes a qualified leaf from a
+React-owned wrapper, or sketches a different inward React door, the later
+setpoint controls: both are implementation shapes behind one `v/defhost`
+descriptor kind.
+
 Two premises govern everything below:
 
 - **The compiled tier is assumed (operator axiom).** Some applications will have
@@ -35,7 +43,7 @@ Two premises govern everything below:
 - **One reactive state system: re-frame.** Events and subscriptions are the only
   reactive model. No ratoms, no hooks-shaped state, no component-local reactive
   cells in the neutral core. Hooks exist only inside visibly React-bound
-  wrappers.
+  components registered through `v/defhost`.
 
 ---
 

--- a/docs/design/freehand/product-completion-setpoint.md
+++ b/docs/design/freehand/product-completion-setpoint.md
@@ -1,0 +1,237 @@
+# Freehand product-completion setpoint
+
+Status: **Accepted**
+
+Ruling date: **2026-07-26**
+
+This document records Mike's accepted completion of the original Freehand design:
+DC-01 through DC-09 and execution rulings ER-01 through ER-08. It extends
+[EP-0036](../../EP/EP-0036-the-freehand-view-substrate-programme.md); it does not
+create a second programme or replace the canonical specifications.
+
+Where an earlier working draft conflicts with this setpoint, this setpoint
+controls until the owning specification lands. Once a vertical slice migrates its
+surface, the canonical specification controls that surface.
+
+## Working posture
+
+Freehand is pre-alpha. Optimize for an elegant, powerful whole and excellent
+ergonomics for programmers and the AIs working with them. Trust the programmer,
+keep the paved path short, and avoid ceremony whose only purpose is to defend
+against hypothetical misuse.
+
+This is not permission to hide semantic uncertainty. Callback lifetime, state
+ownership, SSR loss, compiler refusal, cleanup, and evidence completeness must be
+honest. It is permission to leave reversible implementation details with the
+programmer and to decline speculative frameworks.
+
+## Problem statements
+
+| ID | Problem |
+|---|---|
+| **P1** | Finished React elements are useful opaque children, but Freehand lacks a first-class inward React boundary that can own callback identity, retirement, structural evidence, SSR policy, and compiled parity. |
+| **P2** | Promise-acquired imperative resources and host-created DOM panes are possible, but their causal ownership and reclamation recipes are neither paved nor proved. |
+| **P3** | The form, controller, and controlled-input laws are stronger than the product programmers can import; current reference paths contain unsafe form semantics. |
+| **P4** | The compiler and checker can overstate eligibility when a source-visible child expression becomes opaque before first render. |
+| **P5** | Props-schema and controlled-input evidence can appear stronger or more complete than the facts available. |
+| **P6** | Documentation, checker/build facts, mounted tests, examples, and Xray are not projections of one executable fixture authority. |
+| **P7** | The ownership route through pure libraries, React components, behaviors, islands, and nested roots is scattered, so programmers learn the real costs after choosing a library. |
+| **P8** | High-rate host input and frame-wide controlled flushing have an incompletely measured operating envelope, so proposed policy additions cannot yet be distinguished from gold plating. |
+
+## Accepted design changes
+
+### DC-01 — One declared React host ABI
+
+Provide one public declaration, `v/defhost`, producing one stable qualified host
+descriptor kind. It is the inward boundary for ordinary React value/callback
+components and React-owned wrappers that may use hooks, context, refs, or compound
+protocols internally.
+
+The declaration owns shallow ordinary props, finite `:event` and `:handler`
+callback positions, an explicit children policy, a required SSR policy, one
+optional whole-ordinary-props adapter, and optional props-contract evidence.
+Callback carriers materialize only at their declared positions. Finished raw
+React elements remain legal opaque browser children with correspondingly weaker
+identity, structure, SSR, and compiler claims.
+
+[D022](decisions/D022-public-react-host-door.md) owns the detailed ruling.
+
+### DC-02 — One async connection-owner recipe
+
+Keep behavior `:connect` synchronous. It may start asynchronous acquisition and
+return a private pending/ready/failed/closed owner immediately. Publish one tested
+recipe covering latest desired config, late success and failure, cooperative
+cancellation, close-before-resolve, exact-once finalization, non-queued commands,
+and finalizer failure.
+
+Prove the recipe with Vega Embed and reuse its conformance-shaped double for Maps
+loading and a void-mutator SpreadJS-shaped adapter. Do not add a task system or
+helper until at least two more real integrations repeat irreducible machinery.
+
+### DC-03 — Pure form transitions and causal owner release
+
+Ship a small side-effect-free CLJC form module over ordinary application data. It
+registers no events or subscriptions and owns no atom, validator engine, or form
+runtime.
+
+Its starting public operation roster is:
+
+```text
+init · edit · visit · seed · reset · rebase · set-errors
+attempt-submit · reset-key
+```
+
+The model distinguishes baseline, draft, visited, edited, per-leaf reset
+revision, structured errors, submit attempt/status, stable vector leaf paths, and
+causal ownership. Seed preserves unrelated state and edited leaves; reset and
+rebase are distinct; invalid submit remains attemptable; stale async and buffered
+operations are inert; composing Enter never commits.
+
+Owner clearing is an explicit application transition that removes the form slice
+and its controller records atomically. Unmount is not a domain event, and absence
+of a mounted occurrence is not proof of orphaning.
+
+### DC-04 — A small first-party control kit grown through witnesses
+
+Keep pure transitions in `re-frame.freehand.form` and versioned control
+descriptors and protocol machinery in `re-frame.freehand.controls`. Skins,
+examples, and application compositions may be copied and adapted; correctness
+machinery is not copy-only.
+
+Start with `field`, `buffered-field`, and one causal owner-clear operation. Grow
+through serious witnesses rather than a catalogue promise: form/fields,
+typeahead with anchored menu or popover, splitter, and a fixed-size virtual
+collection/table. Each witness must show a short call site, public props/parts,
+ownership and cleanup, relevant browser laws, structural proof, parity or an
+honest limitation, and measured work at its hard edge.
+
+### DC-05 — Conservative compiled source judgment
+
+Classify admitted child-producing expressions as a known template or boundary,
+an audited scalar producer, or an opaque result. Opaque child results are
+checker/build ineligible before render and report one stable id, source,
+expression summary, and executable recoveries.
+
+Carry the judgment through admitted control/binding forms, but do not invent a
+general type system or a theoretical scalar allowlist. The checker and exact
+build analyzer expose the same facts. Existing priced slot and crossing limits
+remain honest limits.
+
+### DC-06 — Orthogonal contract evidence
+
+Report independent props facts—declaration, key closure, value validation, and
+generator availability—rather than compressing them into “schema present.”
+Application-private schemas remain optional; public library and catalogue
+surfaces retain D011's stronger policy.
+
+Report controlled-site knowledge independently as `known-open`,
+`known-closed`, `dynamic`, or `unavailable`, including its basis. A legal
+doorless site is reported rather than nagged. Incomplete evidence never becomes
+apparent proof, and sensitive values never enter diagnostics.
+
+### DC-07 — One executable fixture spine
+
+Use one small workshop application and one stable fixture identity per claim.
+Project each fixture into its guide source, checker/build facts, JVM structural
+assertions, mounted browser proof, runnable route, and Xray evidence.
+
+The first fixtures are the declared React host, serious form, and Vega async
+owner. Maps, Motion, SpreadJS, and controls join as their slices land. Publish
+`v/check` over the exact build analyzer and a small
+`re-frame.freehand.test` lifecycle facade. Do not create a browser-action DSL, a
+second test language, a second evidence store, or a documentation generator
+before repetition earns it.
+
+### DC-08 — Publish ownership routing and pave nested roots
+
+Publish one short routing guide:
+
+| Ownership shape | Route |
+|---|---|
+| Pure or framework-neutral core | ordinary value logic with re-frame as state adapter |
+| React value/callback component | declared `v/defhost` |
+| Hooks/context/refs/compound protocol | React-owned wrapper registered with `v/defhost`; keep the region React-primary |
+| Imperative node-owned SDK | registered behavior |
+| Freehand descriptor requested as a React component | `v/->react` |
+| Host-created DOM pane | explicit nested root with authored identity, frame, and reclamation |
+| Deliberately isolated region | explicit island/root with stated context and teardown costs |
+
+State the permanent limits beside the routes: hooks stay outside `v/defview`; raw
+elements are opaque; `asChild` and ref cloning stay in a React owner; nested roots
+do not inherit the outer React context, bubbling, or Suspense; one subtree has one
+exit-retention owner.
+
+Prove the behavior-plus-nested-root route with a Maps overlay witness and publish
+small comparative ceremony tallies. Do not add `v/->element`, behavior outlets,
+or a portal manager until Maps plus a second independent integration show the
+same substantial ownership steps.
+
+### DC-09 — Measure the two-clock seam before adding policy
+
+Let behaviors own high-rate host motion while semantic `started`, optional
+`preview`, and `committed` events cross into re-frame. Keep host-local geometry
+and motion out of app-db unless the application genuinely needs the live values.
+
+Measure offered and observed host events, accepted semantic events, reducer
+applications, commits, presentation opportunities, backlog, settlement tail,
+equality cost, and host update cost across realistic rates and dirty-sibling
+loads. Publish distributions and deterministic correctness under D021. Do not add
+generic throttle, debounce, coalescing, equality, or preview vocabulary until an
+attributed material bottleneck repeats in two realistic witnesses.
+
+## Accepted execution rulings
+
+1. **ER-01 — Run the `v/$` comparison now.** Compare one virtual-table fixture
+   across tuned interpreted Freehand, compiled Hiccup, and a `v/$` spike while
+   preserving descriptor, callback, ViewCell, structure, and evidence semantics.
+   Pause only discretionary compiled-Hiccup completion. The experiment cannot
+   change the architecture without a later Mike ruling.
+2. **ER-02 — Fix the React-door surface.** The name is `v/defhost`; there is one
+   host kind, no runtime `v/host`, no `:kind` split, and no `v/react-el`.
+3. **ER-03 — Land an honest host vertical slice.** Interpreted mounting,
+   committed callback lifecycle, structure, SSR, and checker/build behavior land
+   together. A compiled crossing either works or refuses at build time with
+   source and recovery.
+4. **ER-04 — Keep forms and controls in Freehand's distribution.** Use
+   `re-frame.freehand.form` and `re-frame.freehand.controls`; do not create a
+   separate artifact or registry now.
+5. **ER-05 — Fix witness order, not catalogue size.** Form/fields, then
+   typeahead/popover, splitter, and fixed-size virtual table. The architecture
+   comparison may run in parallel.
+6. **ER-06 — Fix the productivity surface.** Public paths are `v/check` and
+   `re-frame.freehand.test`, backed by the shared workshop/fixture identity.
+7. **ER-07 — Delegate reversible details.** The programmer owns private
+   structures, decomposition, diagnostic prose, source layout, and benchmark
+   mechanics. Return to Mike only for a new public concept, a contradiction, an
+   evidence-gated graduation, or the `v/$` architecture result.
+8. **ER-08 — Preserve subscription overrides as a test/tool seam.** Story's exact
+   subscription-query-to-pinned-value capability survives through
+   `re-frame.freehand.test`, not through a general production `v/*` API. It is
+   dev/test-only, matches the whole query vector by ordinary equality, does not
+   mutate app-db or satisfy subscription assertions, falls through to ordinary
+   subscription behavior on a miss, does not create a second reactive state
+   system, states its fidelity and loss, and cleans up exactly. Story's provider
+   consumes the seam; ordinary application code does not. D012 records the
+   evidence amendment and Spec 008 owns the implementation contract.
+
+## Delivery discipline
+
+Deliver the setpoint as thin vertical slices: owning spec, implementation,
+conformance, fixture, guide, and evidence together where applicable. A prose
+phase must not block runnable work. New public verbs use the existing
+API-manifest serial lane.
+
+The programmer may adjust reversible names not fixed above, initial corpus sizes,
+benchmark parameters, private workshop layout, and implementation mechanics.
+Workers and AIs must not implement from superseded examples.
+
+The only deliberately deferred product choices are:
+
+- whether the `v/$` evidence justifies replacing compiled Hiccup;
+- whether repeated compound or nested-root ceremony earns `v/->element` or a
+  behavior outlet;
+- whether repeated async integrations earn a reusable helper; and
+- whether attributed measurements earn scheduling, throttling, preview, or
+  equality vocabulary.
+
+These are evidence gates, not missing prerequisites.

--- a/spec/004-Views.md
+++ b/spec/004-Views.md
@@ -76,7 +76,7 @@ answer beside it.
    prove parity through common conformance values and fixtures.
 
 The detailed rulings behind these laws are the Freehand decision register
-(`docs/design/freehand/decisions/`, D001–D021). They are all ruled; a slice cites
+(`docs/design/freehand/decisions/`, D001–D022). They are all ruled; a slice cites
 them, it does not reopen them.
 
 ## What this Spec owns, and what it defers
@@ -2424,7 +2424,7 @@ A Freehand implementation MUST NOT provide:
   standalone artifact is removed when internal conformance, the pilots, and consumer
   migration are complete.
 
-The full rulings D001–D021 and their rationale are the Freehand decision register
+The full rulings D001–D022 and their rationale are the Freehand decision register
 (`docs/design/freehand/decisions/`); the programme topology, migration map, and
 release gates are
 [EP-0036](../docs/EP/EP-0036-the-freehand-view-substrate-programme.md).


### PR DESCRIPTION
## What changed

- records Mike's accepted DC-01–DC-09 and ER-01–ER-08 product-completion setpoint
- adds ruled D022: one inward React host declaration, `v/defhost`, with no `v/react-el` or second host kind
- places ER-08's development/test-only subscription overrides in a dated D012 amendment
- reconciles the product spine, argued dossier, related decisions, Spec 004 references, and EP-0036
- keeps the `v/$` architecture fork and the other evidence-gated concepts explicitly deferred

## Why

The adversarial reviews converged, Mike accepted the setpoint, and implementation now needs one durable authority rather than ignored working drafts. This remains work under EP-0036; it does not create a new EP or implement public API.

The corresponding implementation programme is tracked by `rf2-drpa3.182`; this documentation change is `rf2-drpa3.182.1` plus reconciliation follow-up `rf2-drpa3.182.13`. Existing Story, Xray, and guide beads are reused rather than duplicated.

## Checks

- `python scripts/check_doc_slugs.py`
- `python scripts/check_readme_links.py --ci`
- `python scripts/check_ep_status_sync.py`
- `python -m mkdocs build --strict`
- `git diff HEAD^ --check`