### PR TITLE
fix(resources): stop trace tags naming entries by CEDN key-id (rf2-5o52l)

### DIFF
--- a/implementation/resources/src/re_frame/resources/events.cljc
+++ b/implementation/resources/src/re_frame/resources/events.cljc
@@ -1913,9 +1913,28 @@
                       (let [e (get-in rdb2 (state/entry-path-by-id k-id))]
                         (when (and e (empty? (:active-owners e)))
                           (:resource/key e)))))
+              (or owned #{}))
+        ;; rf2-5o52l — the trace's `:released` names the released entries by
+        ;; their SCOPED KEY, never by their `key-id`. A `key-id` is
+        ;; `identity/canonical-bytes`, a REVERSIBLE PLAINTEXT CEDN-1 encoding
+        ;; (`encode-string` emits `s:"…"`), so emitting one would carry a
+        ;; `:sensitive?` owner's resolved scope + canonical params OFF-BOX in the
+        ;; clear — inside a STRING the off-box trace-egress projector correctly
+        ;; reads as an opaque scalar, and correctly must (tokenizing strings
+        ;; wholesale would destroy `:rf.frame/id` / `:cause` attribution across
+        ;; the family). No shape rule can see a payload hidden inside an encoded
+        ;; scalar; the emit site is the only layer that can carry the right
+        ;; value. As scoped keys these ride the SAME owner classification
+        ;; `:matched` / `:blocking` / the `:aborted` work-ids' embedded keys do,
+        ;; so a sensitive owner's scope + params tokenize and a plain owner's
+        ;; ride verbatim — better attribution than a key-id, not worse.
+        released
+        (into []
+              (keep (fn [k-id]
+                      (:resource/key (get-in runtime-db (state/entry-path-by-id k-id)))))
               (or owned #{}))]
     (trace/emit! :rf.event :rf.resource/owner-released
-                 {:rf.frame/id frame-id :owner owner :released (vec (or owned #{}))
+                 {:rf.frame/id frame-id :owner owner :released released
                   :aborted (mapv first aborts)})
     {:rf.db/runtime rdb2
      ;; rf2-sxyrzk — abort by the frame-QUALIFIED request-id (the registered

--- a/implementation/resources/src/re_frame/resources/ssr.cljc
+++ b/implementation/resources/src/re_frame/resources/ssr.cljc
@@ -978,16 +978,26 @@
              ;; (`:fetching`+data → `:loaded`, `:loading`+no-data → `:idle`)
              ;; lets the refetch planner classify it correctly rather than
              ;; leaving it dangling in a non-terminal status forever.
+             ;; rf2-5o52l — `:entries` stays keyed on the byte `key-id` (`k`),
+             ;; but the `:orphaned` / `:skews` accumulators name each entry by
+             ;; its SCOPED KEY, because they feed TRACE TAGS. A `key-id` is a
+             ;; reversible plaintext CEDN-1 encoding, so a key-id in a trace tag
+             ;; egresses the entry's scope + params in the clear inside a string
+             ;; the off-box projector reads as an opaque scalar; a scoped key
+             ;; projects through the resource owner classification instead. Same
+             ;; move the refetch-plan below already makes (`(:resource/key
+             ;; entry)`), and the reason `:entries` and these two diverge.
              reconciled (reduce-kv
                           (fn [acc k entry]
                             (let [[entry' dropped] (reconcile-entry-owners
                                                      entry hydration-route-owner-policy)
                                   entry''          (settle-entry-to-last-stable entry')
-                                  skew             (clock-skew-ms entry clock-ms)]
+                                  skew             (clock-skew-ms entry clock-ms)
+                                  sk               (:resource/key entry)]
                               (-> acc
                                   (assoc-in [:entries k] entry'')
-                                  (update :orphaned into (map (fn [o] [k o])) dropped)
-                                  (cond-> skew (update :skews assoc k skew)))))
+                                  (update :orphaned into (map (fn [o] [sk o])) dropped)
+                                  (cond-> skew (update :skews assoc sk skew)))))
                           {:entries {} :orphaned [] :skews {}}
                           entries)
              entries'  (:entries reconciled)
@@ -1000,10 +1010,10 @@
                        :installed      (count entries')
                        :orphaned-owners (vec (:orphaned reconciled))
                        :clock-skews    (:skews reconciled)})
-         (doseq [[k skew] (:skews reconciled)]
+         (doseq [[sk skew] (:skews reconciled)]
            (trace/emit! :warning :rf.resource/hydrate-clock-skew
                         {:rf.frame/id  frame-id
-                         :resource/key k
+                         :resource/key sk
                          :skew-ms      skew
                          :reason       (str "hydrated entry's absolute :stale-at is "
                                             skew "ms ahead of the live client clock "
@@ -1430,15 +1440,23 @@
              ;; projection never carried an in-flight entry, but the
              ;; unprojected snapshot can).
              route-owner-policy (restore-route-owner-policy live-nav-token)
+             ;; rf2-5o52l — as in `hydrate-runtime-db`: `:entries` stays keyed on
+             ;; the byte `key-id` (`k`), while `:orphaned` / `:skews` name each
+             ;; entry by its SCOPED KEY because they feed TRACE TAGS, and a
+             ;; key-id is a reversible plaintext CEDN-1 encoding the off-box
+             ;; projector can only read as an opaque scalar. Restore reconciles a
+             ;; LIVE (never wire-projected) snapshot, so its key-ids carry the
+             ;; raw scope + params.
              reconciled (reduce-kv
                           (fn [acc k entry]
                             (let [[entry' dropped] (reconcile-entry-owners entry route-owner-policy)
                                   entry''          (settle-entry-to-last-stable entry')
-                                  skew             (clock-skew-ms entry clock-ms)]
+                                  skew             (clock-skew-ms entry clock-ms)
+                                  sk               (:resource/key entry)]
                               (-> acc
                                   (assoc-in [:entries k] entry'')
-                                  (update :orphaned into (map (fn [o] [k o])) dropped)
-                                  (cond-> skew (update :skews assoc k skew)))))
+                                  (update :orphaned into (map (fn [o] [sk o])) dropped)
+                                  (cond-> skew (update :skews assoc sk skew)))))
                           {:entries {} :orphaned [] :skews {}}
                           entries)
              entries'  (:entries reconciled)
@@ -1503,22 +1521,22 @@
                         ;; "orphaned owners are dropped with a trace row"). SSR
                         ;; orphans ride the summary above (they belong to a
                         ;; settled server render, not a stale navigation).
-                        (for [[k owner] (:orphaned reconciled)
+                        (for [[sk owner] (:orphaned reconciled)
                               :when (route-owner? owner)]
                           {:level :rf.epoch
                            :op    :rf.resource/owner-released
                            :tags  {:rf.frame/id    frame-id
-                                   :resource/key   k
+                                   :resource/key   sk
                                    :owner          owner
                                    :nav-token      (nth owner 2 nil)
                                    :live-nav-token live-nav-token
                                    :reason         :stale-nav-orphan
                                    :recovery       :restore-reconcile}})
-                        (for [[k skew] (:skews reconciled)]
+                        (for [[sk skew] (:skews reconciled)]
                           {:level :warning
                            :op    :rf.resource/restore-clock-skew
                            :tags  {:rf.frame/id  frame-id
-                                   :resource/key k
+                                   :resource/key sk
                                    :skew-ms      skew
                                    :reason       (str "restored entry's absolute :stale-at is "
                                                       skew "ms ahead of the live clock — clock "

--- a/implementation/resources/test/re_frame/resources_trace_keyid_egress_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_trace_keyid_egress_cljs_test.cljc
@@ -1,0 +1,427 @@
+(ns re-frame.resources-trace-keyid-egress-cljs-test
+  "A `key-id` MUST NEVER reach a resource-family trace tag (rf2-5o52l).
+
+  ## The leak this suite pins
+
+  A `state/key-id` is `re-frame.identity/canonical-bytes` of the scoped key —
+  CEDN-1, a **reversible plaintext encoding, not a digest**. `encode-string`
+  emits `(str \"s:\" (pr-str s))`, so the key-id for
+  `[:rf.scope/global :secret/article {:auth-token \"topsecret-PII\"}]` is
+  literally
+
+    v[k::rf.scope/global k::secret/article m{k::auth-token s:\"topsecret-PII\"}]
+
+  `:rf.resource/owner-released` emitted `:released` as the raw owner-index
+  members, which ARE key-ids, so a `:sensitive?` owner's resolved scope and
+  canonical params egressed off-box **in the clear** — inside a string that
+  looks opaque. `deftest key-id-is-reversible-plaintext-not-a-digest` below is
+  the standing statement of that fact; it is the whole reason the emit sites
+  must carry scoped keys.
+
+  ## Why no projector rule could have caught it
+
+  rf2-wd9im made the off-box trace-egress default (`re-frame.resources.trace-
+  egress/project-unknown-slot-value`) read value SHAPE rather than slot name,
+  which closes every scoped key and every map payload at any depth — including
+  the key EMBEDDED at position 1 of a `:rf.work/resource` work-id. To that walk
+  a key-id is a STRING, correctly a scalar: tokenizing strings wholesale would
+  destroy `:rf.frame/id` / `:cause` / short-id attribution across the whole
+  family. The payload was hidden INSIDE an encoded scalar — a class a shape read
+  cannot and should not try to detect, and one no slot-name roster reaches
+  either. The only layer that can fix it is the EMIT SITE, by carrying the value
+  the projector is built to classify.
+
+  `off-box-released-and-aborted-keys-agree-digest-for-digest` shows the leak's
+  signature directly: BEFORE the fix, one `:rf.resource/owner-released` row
+  carried the SAME resource identity twice — tokenized under `:aborted` (the
+  work-id's embedded scoped key, covered by the shape walk) and verbatim under
+  `:released` (the key-id string) — so the row was even stamped
+  `:sensitive? true` while the secret rode raw beside the stamp.
+
+  ## The sibling emit sites
+
+  `ssr.cljc` reconciles `:entries` with `reduce-kv`, so its fold key is a
+  key-id too, and it fed FIVE more trace tags of the same class: the hydrate
+  `:rf.resource/hydrated` `:orphaned-owners` + `:rf.resource/hydrate-clock-skew`
+  `:resource/key`, and the restore `:rf.resource/restored` `:orphaned-owners` +
+  `:rf.resource/owner-released` `:resource/key` + `:rf.resource/restore-clock-
+  skew` `:resource/key`. The two `:resource/key` rows are the sharper case: that
+  slot is NAMED in the projector's single-scoped-key vocabulary, so a key-id
+  there defeated an arm written specifically to redact it. Spec 009's
+  `:rf.resource/*-clock-skew` rows already document `:resource/key`, which in
+  this family means the scoped-key vector, so those two were spec drift as well.
+
+  ## No over-redaction
+
+  Every off-box assertion here is paired with a PLAIN (non-`:sensitive?`) owner
+  in the same row: `off-box-plain-owners-released-key-rides-verbatim` and
+  `plain-owners-key-is-never-tokenized` pin that a plain owner's scope + params
+  still ride verbatim, so redacting-everything would fail this suite as loudly
+  as leaking does.
+
+  Dual-target (`.cljc` + `_cljs_test`): the JVM runner picks it up via the
+  `.*-test$` ns regex, Shadow's `:node-test` build via the `cljs-test$` regex.
+  The browser / MCP off-box channel is where this matters most, so the guarantee
+  is asserted on BOTH hosts."
+  (:require
+   #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
+      :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
+   [clojure.string :as str]
+   [re-frame.core :as rf]
+   [re-frame.fx :as fx]
+   [re-frame.identity :as identity]
+   ;; load-bearing side-effecting require: registers the :rf.resource/* events
+   ;; + subs this suite dispatches.
+   [re-frame.resources]
+   [re-frame.resources.ssr :as r-ssr]
+   [re-frame.resources.state :as state]
+   [re-frame.resources.test-support]
+   [re-frame.resources.trace-egress :as trace-egress]
+   [re-frame.http.managed]
+   [re-frame.schemas]
+   [re-frame.interop :as interop]
+   [re-frame.test-support :as core-test-support]
+   [re-frame.trace.tooling :as trace-tooling]
+   #?(:clj  [re-frame.substrate.plain-atom :as substrate]
+      :cljs [re-frame.adapter.reagent :as substrate])))
+
+(def ^:private secret "topsecret-PII")
+
+;; ---- fixture --------------------------------------------------------------
+
+(defn- init!
+  "One `:sensitive?` owner (scope + params tokenize off-box) and one PLAIN
+  owner (must ride verbatim — the over-redaction control), plus a no-op
+  managed-HTTP fx so `ensure` writes its `:loading` entry without fetching."
+  []
+  (rf/make-frame {:id :rf/default :url-bound? true
+                  :doc "key-id trace-egress suite default app frame."})
+  (fx/reg-fx :rf.http/managed (fn [_ctx _args] nil))
+  (rf/reg-resource :secret/article
+    {:scope         :rf.scope/global
+     :sensitive?    true
+     :params-schema [:map [:auth-token :string]]}
+    (fn [_p _ctx] {:request {:method :get :url "/secret"}}))
+  (rf/reg-resource :plain/article
+    {:scope         :rf.scope/global
+     :params-schema [:map [:slug :string]]}
+    (fn [_p _ctx] {:request {:method :get :url "/public"}})))
+
+(use-fixtures :each
+  (core-test-support/make-reset-runtime-fixture
+    {:adapter substrate/adapter
+     :init-fn init!}))
+
+;; ---- helpers --------------------------------------------------------------
+
+(def ^:private secret-key
+  (state/scoped-resource-key :rf.scope/global :secret/article {:auth-token secret}))
+
+(def ^:private plain-key
+  (state/scoped-resource-key :rf.scope/global :plain/article {:slug "public-post"}))
+
+(defn- runtime-db [] (:rf.db/runtime (rf/frame-state-value :rf/default)))
+
+(defn- redacted-token? [c] (and (map? c) (contains? c :rf/redacted)))
+
+(defn- leaks-secret?
+  "Whether the raw secret survives ANYWHERE in `v` — the plaintext test a
+  reversible key-id fails and an opaque token passes."
+  [v]
+  (str/includes? (pr-str v) secret))
+
+(defn- leaks-cedn-token?
+  "Whether a CEDN-1 encoded token survives anywhere in `v`. Broader than
+  `leaks-secret?`: it catches ANY key-id, not only one carrying this suite's
+  secret, so a future emit site that reintroduces the class fails here even
+  with innocuous params."
+  [v]
+  (boolean (re-find #"v\[k:" (pr-str v))))
+
+(defn- capture-op!
+  "Run `body-fn` with a trace listener installed; return every trace event
+  whose `:operation` is `op`, in capture order."
+  [op body-fn]
+  (let [seen (atom [])
+        k    ::keyid-egress-recorder]
+    (trace-tooling/register-listener!
+      k (fn [ev] (when (= op (:operation ev)) (swap! seen conj ev))))
+    (try (body-fn)
+         (finally (trace-tooling/unregister-listener! k)))
+    @seen))
+
+(defn- project
+  "Project `tags` for OFF-BOX egress exactly as the epoch tool-pair does —
+  through the late-bound `:resources/project-resource-trace-egress` hook's
+  body, against the row's own `:rf.frame/id`."
+  [tags]
+  (trace-egress/project-resource-trace-egress tags (:rf.frame/id tags)))
+
+(defn- release-owner-row
+  "Drive the PUBLIC path: `ensure` the sensitive resource AND the plain
+  resource under one shared owner, then release that owner. Returns the single
+  `:rf.resource/owner-released` row's tags."
+  []
+  (let [owner [:app :reader 1]
+        rows  (capture-op!
+                :rf.resource/owner-released
+                (fn []
+                  (rf/dispatch-sync [:rf.resource/ensure
+                                     {:resource :secret/article
+                                      :params   {:auth-token secret}
+                                      :owner    owner}])
+                  (rf/dispatch-sync [:rf.resource/ensure
+                                     {:resource :plain/article
+                                      :params   {:slug "public-post"}
+                                      :owner    owner}])
+                  (rf/dispatch-sync [:rf.resource/release-owner {:owner owner}])))]
+    (is (= 1 (count rows)) "exactly one owner-released row for the released owner")
+    (:tags (first rows))))
+
+(defn- released-member
+  "The `:released` member naming `resource-id`, from a projected row."
+  [tags resource-id]
+  (first (filter #(and (vector? %) (= resource-id (second %))) (:released tags))))
+
+;; ===========================================================================
+;; 1. THE PREMISE. A key-id is a reversible plaintext encoding, not a digest.
+;;    This is the standing fact the emit-site rule rests on; it holds
+;;    independently of any fix and must keep holding, because the day a key-id
+;;    becomes a digest is the day this whole suite's reasoning changes.
+;; ===========================================================================
+
+(deftest key-id-is-reversible-plaintext-not-a-digest
+  (testing "rf2-5o52l — `state/key-id` is `identity/canonical-bytes`, CEDN-1: a
+            REVERSIBLE PLAINTEXT encoding. The key-id for a scoped key whose
+            params carry a secret CONTAINS that secret verbatim, wrapped in the
+            `s:\"…\"` string token `encode-string` emits. This is why a key-id
+            may never be copied into a trace tag: nothing downstream can undo
+            it, and the off-box projector correctly sees only a string"
+    (let [k-id (state/key-id secret-key)]
+      (is (string? k-id) "a key-id is a plain string — a scalar to any shape walk")
+      (is (= k-id (identity/canonical-bytes secret-key))
+          "key-id IS canonical-bytes — no hashing step exists")
+      (is (str/includes? k-id secret)
+          "the raw secret survives verbatim inside the key-id")
+      (is (str/includes? k-id (str "s:" (pr-str secret)))
+          "specifically as the CEDN-1 `s:\"…\"` string token")
+      (is (str/includes? k-id "k::secret/article")
+          "and the resource-id as a `k:` keyword token")
+      (testing "a digest would not do this — the identity is recoverable, so a
+                key-id is disclosure-equivalent to the scoped key itself"
+        (is (str/includes? k-id (pr-str :rf.scope/global))
+            "the resolved scope is recoverable too")))))
+
+;; ===========================================================================
+;; 2. THE EMIT SITE. `:released` names scoped keys, so the family's owner
+;;    classification can reach them.
+;; ===========================================================================
+
+(deftest owner-released-names-released-entries-by-scoped-key
+  (testing "rf2-5o52l — the ON-BOX `:rf.resource/owner-released` row names each
+            released entry by its SCOPED KEY, never by its `key-id`. The
+            owner-index members ARE key-ids, so the handler resolves each to its
+            entry's `:resource/key` — the same move the sibling `now-owner-free`
+            poll-cancel computation two lines above already makes"
+    (let [tags (release-owner-row)]
+      (is (= #{secret-key plain-key} (set (:released tags)))
+          "both released entries are named by their canonical scoped-key vectors")
+      (is (every? #(and (vector? %) (= 3 (count %)) (keyword? (second %)))
+                  (:released tags))
+          "every member is scoped-key SHAPED, so the shape-driven projector
+           default recognises it wherever the slot vocabulary does not")
+      (is (not-any? string? (:released tags))
+          "no member is a CEDN-1 byte string"))))
+
+;; ===========================================================================
+;; 3. THE OFF-BOX GUARANTEE. This is the assertion that reds on the unfixed
+;;    emit site: the secret arrives in the clear when `:released` carries
+;;    key-ids, and is absent once it carries scoped keys.
+;; ===========================================================================
+
+(deftest off-box-owner-released-never-egresses-the-sensitive-owners-params
+  (testing "rf2-5o52l — off-box, a `:sensitive?` owner's released key has its
+            resolved scope + canonical params tokenized to opaque content-
+            addressed `{:rf/redacted <digest>}`; the resource-id survives for
+            attribution, and NO plaintext — neither the raw secret nor any
+            CEDN-1 token — reaches the off-box channel"
+    (let [projected (project (release-owner-row))
+          [pscope rid pparams] (released-member projected :secret/article)]
+      (is (= :secret/article rid) "the resource-id (position 1) survives")
+      (is (redacted-token? pparams) "the sensitive params are tokenized")
+      (is (redacted-token? pscope) "the resolved scope is tokenized")
+      (is (true? (:sensitive? projected)) "the row is stamped :sensitive?")
+      (testing "ACCEPTANCE — no plaintext survives anywhere in the projected row"
+        (is (not (leaks-secret? projected))
+            "the raw secret does not egress")
+        (is (not (leaks-cedn-token? projected))
+            "no CEDN-1 key-id egresses under ANY tag of the row")))))
+
+(deftest off-box-plain-owners-released-key-rides-verbatim
+  (testing "rf2-5o52l — the over-redaction control. A PLAIN (non-`:sensitive?`,
+            non-`:large?`, registered) owner's released key rides VERBATIM in
+            the SAME row that tokenizes the sensitive one, so the fix cannot be
+            satisfied by redacting everything"
+    (let [projected (project (release-owner-row))]
+      (is (= plain-key (released-member projected :plain/article))
+          "the plain owner's scope + params are unchanged off-box")
+      (is (= {:slug "public-post"} (nth (released-member projected :plain/article) 2))
+          "its params ride as the real map, not a token"))))
+
+(deftest plain-owners-key-is-never-tokenized
+  (testing "rf2-5o52l — the property form of the control, TRUE of the unfixed
+            emit site too (a key-id string is not a redaction token either), so
+            it holds in both directions and isolates over-redaction as a
+            distinct failure from the leak"
+    (let [projected (project (release-owner-row))]
+      (is (not (leaks-cedn-token? (released-member projected :plain/article)))
+          "no CEDN-1 token")
+      (is (not-any? redacted-token?
+                    (filter coll? (flatten [(released-member projected :plain/article)])))
+          "and nothing about the plain owner's key was redacted"))))
+
+(deftest off-box-released-and-aborted-keys-agree-digest-for-digest
+  (testing "rf2-5o52l — the leak's signature, and the fidelity the fix buys.
+            One `:rf.resource/owner-released` row carries the same resource
+            identity TWICE: under `:aborted`, embedded at position 1 of the
+            `[:rf.work/resource <scoped-key> <generation>]` work-id (which the
+            rf2-wd9im shape walk redacts), and under `:released`. With `:released`
+            carrying key-ids the two disagreed — one tokenized, one raw, on a row
+            stamped `:sensitive? true`. Now both project through the SAME
+            classification to the SAME digests, so a tool's per-key joins across
+            the row survive redaction"
+    (let [projected      (project (release-owner-row))
+          released-key   (released-member projected :secret/article)
+          aborted-key    (->> (:aborted projected)
+                              (filter #(and (vector? %)
+                                            (= :secret/article (second (nth % 1 nil)))))
+                              first
+                              (#(nth % 1 nil)))]
+      (is (some? aborted-key) "the sensitive owner's work-id rode under :aborted")
+      (is (= released-key aborted-key)
+          "the :released key and the :aborted work-id's embedded key project
+           IDENTICALLY — same digests for the same identity")
+      (is (redacted-token? (nth aborted-key 2))
+          "and both are genuinely tokenized (not merely equal-because-raw)"))))
+
+;; ===========================================================================
+;; 4. THE CLASS. No resource-family trace tag anywhere on the row carries a
+;;    CEDN-1 key-id, whatever the slot is called.
+;; ===========================================================================
+
+(deftest no-owner-released-tag-carries-a-cedn-key-id
+  (testing "rf2-5o52l — the statable invariant, over the WHOLE tag map rather
+            than one slot: no value under ANY tag of an off-box
+            `:rf.resource/owner-released` row is a CEDN-1 byte string. A key-id
+            is opaque to the projector by construction, so the only durable
+            guarantee is that none is ever emitted"
+    (let [tags      (release-owner-row)
+          projected (project tags)]
+      (is (not (leaks-cedn-token? tags))
+          "not even ON-BOX — the emit site simply never mints one into a tag")
+      (is (not (leaks-cedn-token? projected))
+          "and therefore none off-box")
+      (is (not (leaks-secret? projected))
+          "no plaintext secret under any tag"))))
+
+;; ===========================================================================
+;; 5. THE SIBLING EMIT SITES (ssr.cljc). Its `reduce-kv` over `:entries` folds
+;;    on the key-id too, and it fed five more trace tags of this same class.
+;; ===========================================================================
+
+(defn- skewed-runtime-db
+  "A runtime-db holding ONE `:sensitive?` entry whose absolute `:stale-at` is
+  implausibly far ahead of the live clock (`clock-skew-ms` fires when
+  `:loaded-at` itself is in the future — the server clock ran ahead), owned by
+  `owner`. The vehicle for both the clock-skew row and the orphaned-owner row:
+  `reconcile-entry-owners` drops an `[:ssr …]` owner always and, on restore with
+  no live nav-token, every `[:route …]` owner."
+  [owner]
+  (let [now (interop/epoch-now-ms)]
+    (-> (runtime-db)
+        (assoc-in (state/entry-path secret-key)
+                  {:resource/key   secret-key
+                   :status         :loaded
+                   :data           {:body "server-rendered"}
+                   :active-owners  #{owner}
+                   :current-work   nil
+                   :generation     1
+                   :loaded-at      (+ now 100000)
+                   :stale-at       (+ now 200000)
+                   :stale-after-ms 100000}))))
+
+(deftest hydrate-rows-name-entries-by-scoped-key-not-key-id
+  (testing "rf2-5o52l — the `:rf/hydrate` reconcile's `:rf.resource/hydrate-
+            clock-skew` `:resource/key` and `:rf.resource/hydrated`
+            `:orphaned-owners` name the entry by its SCOPED KEY. `:resource/key`
+            is the sharper case: it is NAMED in the projector's single-scoped-key
+            vocabulary, so a key-id there defeated an arm written specifically to
+            redact it — and Spec 009 already documents this row's
+            `:resource/key`, so it was spec drift too"
+    (let [ssr-owner [:ssr "req-1" "nav-1"]
+          rows      (capture-op!
+                      :rf.resource/hydrate-clock-skew
+                      (fn [] (r-ssr/hydrate-runtime-db (skewed-runtime-db ssr-owner)
+                                                       :rf/default)))
+          tags      (:tags (first rows))]
+      (is (= 1 (count rows)) "one skew row for the one skewed entry")
+      (is (= secret-key (:resource/key tags))
+          "named by the scoped-key vector, not the CEDN-1 byte string")
+      (let [[pscope rid pparams] (:resource/key (project tags))]
+        (is (= :secret/article rid) "resource-id survives off-box")
+        (is (redacted-token? pscope) "scope tokenized off-box")
+        (is (redacted-token? pparams) "params tokenized off-box"))
+      (is (not (leaks-secret? (project tags))) "no plaintext off-box")
+      (is (not (leaks-cedn-token? (project tags))) "no CEDN-1 token off-box"))
+    (testing "and the summary row's :orphaned-owners pairs, which carry the
+              dropped SSR owner alongside its entry"
+      (let [ssr-owner [:ssr "req-1" "nav-1"]
+            rows      (capture-op!
+                        :rf.resource/hydrated
+                        (fn [] (r-ssr/hydrate-runtime-db (skewed-runtime-db ssr-owner)
+                                                         :rf/default)))
+            tags      (:tags (first rows))]
+        (is (= [[secret-key ssr-owner]] (:orphaned-owners tags))
+            "the orphaned SSR owner is paired with its entry's scoped key")
+        (is (not (leaks-secret? (project tags))) "no plaintext off-box")
+        (is (not (leaks-cedn-token? (project tags))) "no CEDN-1 token off-box")))))
+
+(deftest restore-rows-name-entries-by-scoped-key-not-key-id
+  (testing "rf2-5o52l — the restore-reconcile twin. Restore reconciles a LIVE
+            (never wire-projected) snapshot, so its key-ids carry the RAW scope +
+            params: `:rf.resource/restore-clock-skew` / `:rf.resource/owner-
+            released` `:resource/key` and `:rf.resource/restored`
+            `:orphaned-owners` all name the entry by its scoped key instead. With
+            no live nav-token every `[:route …]` owner orphans (rf2-64bdnk), which
+            is what produces the per-owner released row"
+    (let [route-owner [:route :r/reader "tok-stale"]
+          rdb         (skewed-runtime-db route-owner)]
+      (testing "the :warning clock-skew row"
+        (let [tags (:tags (first (capture-op!
+                                   :rf.resource/restore-clock-skew
+                                   #(r-ssr/reconcile-on-restore rdb :rf/default))))]
+          (is (= secret-key (:resource/key tags)) "scoped key, not key-id")
+          (is (redacted-token? (nth (:resource/key (project tags)) 2))
+              "params tokenized off-box")
+          (is (not (leaks-secret? (project tags))) "no plaintext off-box")))
+      (testing "the per-owner :rf.resource/owner-released row for the stale-nav
+                route orphan"
+        (let [tags (:tags (first (capture-op!
+                                   :rf.resource/owner-released
+                                   #(r-ssr/reconcile-on-restore rdb :rf/default))))]
+          (is (= secret-key (:resource/key tags)) "scoped key, not key-id")
+          (is (= route-owner (:owner tags)) "names the orphaned route owner")
+          (is (redacted-token? (nth (:resource/key (project tags)) 2))
+              "params tokenized off-box")
+          (is (not (leaks-secret? (project tags))) "no plaintext off-box")
+          (is (not (leaks-cedn-token? (project tags))) "no CEDN-1 token off-box")))
+      (testing "the :rf.resource/restored summary's :orphaned-owners"
+        (let [tags (:tags (first (capture-op!
+                                   :rf.resource/restored
+                                   #(r-ssr/reconcile-on-restore rdb :rf/default))))]
+          (is (= [[secret-key route-owner]] (:orphaned-owners tags))
+              "the orphaned route owner is paired with its entry's scoped key")
+          (is (not (leaks-secret? (project tags))) "no plaintext off-box")
+          (is (not (leaks-cedn-token? (project tags)))
+              "no CEDN-1 token off-box — including under :clock-skews, whose
+               MAP shape the projector tokenizes wholesale"))))))


### PR DESCRIPTION
## The defect

`:rf.resource/owner-released` emitted `:released` as the raw owner-index members
(`(vec (or owned #{}))`, `events.cljc:1918`). Those members are `state/key-id`
values, and a `key-id` is `identity/canonical-bytes` — **CEDN-1, a reversible
plaintext encoding, not a digest.** So a `:sensitive?` owner's resolved scope and
canonical params egressed off-box **in the clear**, inside a string that looks
opaque.

## Verification of the reversible-plaintext premise

Checked before writing anything, by producing a key-id from a scoped key
carrying a recognisable secret and reading it back:

```
scoped-key : [:rf.scope/global :secret/article {:auth-token "topsecret-PII"}]
key-id     : "v[k::rf.scope/global k::secret/article m{k::auth-token s:\"topsecret-PII\"}]"
key-id contains the raw secret?     true
key-id contains the CEDN s: token?  true
key-id = canonical-bytes?           true
```

Confirmed: no hashing step exists. `key-id` **is** `canonical-bytes`,
`encode-string` emits `(str "s:" (pr-str s))`, and the resolved scope and the
resource-id come back as `k:` keyword tokens. A key-id is
disclosure-equivalent to the scoped key itself. This is now pinned as a standing
fact by `deftest key-id-is-reversible-plaintext-not-a-digest`.

## Why no projector rule could have caught it

The leak's signature is visible on a single unfixed row, which carries the same
resource identity **twice**:

```clojure
;; PROJECTED off-box, BEFORE the fix
{:owner    [:app :reader 1]
 :released ["v[k::rf.scope/global k::secret/article m{k::auth-token s:\"topsecret-PII\"}]"
            "v[k::rf.scope/global k::plain/article m{k::slug s:\"public-post\"}]"]
 :aborted  [[:rf.work/resource [#:rf{:redacted "bfdae59b"} :secret/article
                                #:rf{:redacted "01d4822d"}] 1] …]
 :sensitive? true}
```

`:aborted` carries the identity embedded at position 1 of a
`[:rf.work/resource <scoped-key> <generation>]` work-id, which rf2-wd9im's
shape-driven default correctly tokenizes. `:released` carries the identical
identity as a key-id string and rides raw — so the row was even stamped
`:sensitive? true` while the secret sat beside the stamp.

Extending the shape rule is the wrong layer, as the bead says. To that walk a
key-id is a string, and correctly a scalar: tokenizing strings wholesale would
destroy `:rf.frame/id` / `:cause` / short-id attribution across the whole
family. The payload was hidden *inside* an encoded scalar — a class no shape
read and no slot-name roster can reach. Only the emit site can carry the value
the projector is built to classify.

## The fix — six emit sites, one move

Carry the entry's `:resource/key` vector, exactly as the sibling
`now-owner-free` poll-cancel computation two lines above already does (premise
verified: it resolves each owned key-id through `state/entry-path-by-id` and
takes `(:resource/key e)`).

| # | Row | Tag | File |
|---|---|---|---|
| 1 | `:rf.resource/owner-released` | `:released` | `events.cljc` |
| 2 | `:rf.resource/hydrated` | `:orphaned-owners` | `ssr.cljc` hydrate |
| 3 | `:rf.resource/hydrate-clock-skew` | `:resource/key` | `ssr.cljc` hydrate |
| 4 | `:rf.resource/restored` | `:orphaned-owners` | `ssr.cljc` restore |
| 5 | `:rf.resource/owner-released` | `:resource/key` | `ssr.cljc` restore |
| 6 | `:rf.resource/restore-clock-skew` | `:resource/key` | `ssr.cljc` restore |

Sites 2–6 are the bead's mandated "grep the family for any other tag whose value
is a key-id" — **all five were leaking plaintext**, each confirmed by the
negative control below, not by inspection. `ssr.cljc` reconciles `:entries` with
`reduce-kv`, so its fold key is a key-id too; its `:orphaned` / `:skews`
accumulators feed trace tags, so they now name entries by scoped key while
`:entries` stays keyed on the byte key-id. That divergence is the whole point of
the change there, and it is commented as such.

Sites 3, 5 and 6 are the sharper case: `:resource/key` is **named** in the
projector's single-scoped-key vocabulary, so a key-id there defeated an arm
written specifically to redact it.

**No spec change needed, and one drift closed.** Spec 009 already documents both
clock-skew rows as carrying `:resource/key`, which in this family means the
scoped-key vector — so sites 3 and 6 were spec drift as well, and the code now
matches the spec. (`spec/009-Instrumentation.md` is `rf2-p3u59`'s; untouched
here. No spec text pins `:released`'s shape, so nothing there needed updating
either.)

As scoped keys, all six now ride the same owner classification `:matched` /
`:blocking` do: a sensitive owner's scope + params tokenize, a plain owner's
ride verbatim, and the resource-id survives. `:released` and `:aborted` now
agree digest-for-digest on one row, so a tool's per-key joins survive redaction
— **better** attribution than the key-id gave, not worse.

## Negative control — proved both ways

Reverted the two source files in place (patch file, no `git stash`), re-ran, then
restored and re-ran.

| | tests | assertions | failures | rc |
|---|---|---|---|---|
| fixed | 9 | 52 | **0** | 0 |
| **source reverted** | 9 | 52 | **33** | 1 |
| fix restored | 9 | 52 | **0** | 0 |

The reverted run reports the raw secret in its own failure output, e.g.

```
expected: (= #{plain-key secret-key} (set (:released tags)))
  actual: (not (= … #{"v[k::rf.scope/global k::secret/article m{k::auth-token s:\"topsecret-PII\"}]" …}))
```

7 of the 9 deftests red on revert. **Two stayed green in both directions**, which
is what distinguishes a real leak from a fix that over-redacts:

- `key-id-is-reversible-plaintext-not-a-digest` — the premise. Independent of the
  fix, and must keep holding: the day a key-id becomes a digest, this suite's
  reasoning changes.
- `plain-owners-key-is-never-tokenized` — the over-redaction control in property
  form (a key-id string is not a redaction token either, so it is true of the
  unfixed code too). Its fixed-only twin,
  `off-box-plain-owners-released-key-rides-verbatim`, asserts the plain owner's
  key is the exact verbatim scoped key in the same row that tokenizes the
  sensitive one — so redacting everything would fail this suite as loudly as
  leaking does.

Also asserted: `no-owner-released-tag-carries-a-cedn-key-id`, a whole-row
invariant (`#"v\[k:"` under **any** tag, on-box and off-box) rather than a
per-slot check, so a future emit site that reintroduces the class fails here even
with innocuous params.

## The conformance fixture stays out of scope (`rf2-isp3i`)

Confirmed on this checkout: `epoch_mcp_egress_conformance_test.clj` contains
**zero** occurrences of `reg-resource`, `:rf.resource/`, `:rf.mutation/` or
`resources`, and never requires that artefact — so the resource projector is
unreachable from it and **this defect was invisible to that gate too**. Recorded
here so `rf2-isp3i`'s rescoping stays accurate; the fixture is not widened in
this PR.

Neither sibling leak was touched: `rf2-1zc33` (`:scope` passing verbatim on five
row types, held for an operator ruling) and `rf2-isp3i`.

`implementation/epoch/**` and `resources/trace_egress.cljc` were read on current
`main` and left unmodified — the fix is at the emit site, so no projector, no
redaction framework, no string parsing, and no new slot vocabulary was added.

## Quality gates

Foreground, to completion. `rc` captured immediately into a worktree-local log
and cross-checked against each log's own verdict line.

| gate | result | rc |
|---|---|---|
| `implementation/resources` `clojure -M:test` | 731 tests / 6781 assertions, **0 failures, 0 errors** | **0** |
| `implementation/epoch` `clojure -M:test` | 476 tests / 6469 assertions, **0 failures, 0 errors** | **0** |
| `npm run test:cljs` | 11462 tests / 57397 assertions, **0 failures, 0 errors** | **0** |
| `scripts/test-fast-pr.sh` | `PASS fast PR spine`; per-ns isolation all 17 namespaces pass standalone | **0** |

New suite, dual-target (JVM + Shadow `:node-test`): 9 deftests / 52 assertions.
