### PR TITLE
examples,spec,ci: cut donor-inventory row 409 (minimal-counter) over to Freehand (rf2-nutll)

### DIFF
--- a/.github/scripts/report-changed-surfaces.sh
+++ b/.github/scripts/report-changed-surfaces.sh
@@ -155,8 +155,17 @@ else
     # to the nightly safety net for core-only changes. Story/Xray and
     # machines-viz remain here because example builds load the Xray preload
     # and Story hosts, whose compiled closure includes machines-viz.
+    #
+    # rf2-nutll — implementation/freehand/* joined this list when
+    # examples/ui/minimal-counter cut over to Freehand. That scaffold is the
+    # subject of the `ui-scaffold-smoke` job, which is gated on this same
+    # output, and it now resolves day8/re-frame2-freehand by :local/root — so a
+    # Freehand change that breaks the standalone scaffold's compile would
+    # otherwise SKIP the only job that builds it. The widening the
+    # `implementation/freehand/*` case further down anticipated, arrived at from
+    # the consumer side.
     case "$file" in
-      examples/*|implementation/adapters/*|implementation/epoch/*|implementation/schemas/*|implementation/machines/*|implementation/routing/*|implementation/flows/*|implementation/http/*|implementation/ssr/*|implementation/ssr-ring/*|implementation/resources/*|implementation/security/*|implementation/ui/*|implementation/deps.edn|implementation/shadow-cljs.edn|implementation/package.json|implementation/package-lock.json|implementation/scripts/check-examples-compile.cjs)
+      examples/*|implementation/adapters/*|implementation/epoch/*|implementation/schemas/*|implementation/machines/*|implementation/routing/*|implementation/flows/*|implementation/http/*|implementation/ssr/*|implementation/ssr-ring/*|implementation/resources/*|implementation/security/*|implementation/ui/*|implementation/freehand/*|implementation/deps.edn|implementation/shadow-cljs.edn|implementation/package.json|implementation/package-lock.json|implementation/scripts/check-examples-compile.cjs)
         examples_compile=true
         ;;
       tools/story/src/*|tools/story/testbeds/*|tools/story/deps.edn|tools/xray/src/*|tools/xray/testbeds/*|tools/xray/deps.edn|tools/machines-viz/src/*|tools/machines-viz/deps.edn)
@@ -733,6 +742,11 @@ else
         # holds. Those builds are covered by the dedicated
         # freehand_evidence_elision output, armed narrowly on the probe's
         # primary inputs in the case above — not by these four.
+        #
+        # rf2-nutll — examples_compile is armed too, but from the FIRST case
+        # block (where the examples_compile roster lives) rather than here:
+        # examples/ui/minimal-counter is a standalone Freehand project now, so
+        # Freehand is a framework artefact a standalone example build resolves.
         implementation_jvm=true
         cljs_node_test=true
         cljs_browser=true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2280,16 +2280,21 @@ jobs:
   ui-scaffold-smoke:
     name: UI scaffold smoke (materialize + install + compile minimal-counter)
     # rf2-vxgfnd.281 — the CI teeth for examples/ui/minimal-counter, the
-    # minimal RUNNABLE re-frame.ui scaffold. Unlike cljs-examples-compile
-    # (which sweeps the monorepo :examples/* shadow builds), this scaffold is
-    # a STANDALONE project with its own deps.edn / package.json /
-    # shadow-cljs.edn. The smoke materializes ONLY the files the README's
-    # manifest documents into a temp dir, runs a real `npm install` +
-    # `npx shadow-cljs compile app`, and then an omission matrix that proves
-    # every documented file is genuinely load-bearing. RF2_UI_SCAFFOLD_COMPILE
-    # arms the install+compile tier (the structural tier runs unconditionally).
+    # minimal RUNNABLE Freehand scaffold (cut over from the donor substrate by
+    # rf2-nutll). Unlike cljs-examples-compile (which sweeps the monorepo
+    # :examples/* shadow builds), this scaffold is a STANDALONE project with its
+    # own deps.edn / package.json / shadow-cljs.edn. The smoke materializes ONLY
+    # the files the README's manifest documents into a temp dir, runs a real
+    # `npm install` + `npx shadow-cljs compile app`, and then an omission matrix
+    # that proves every documented file is genuinely load-bearing.
+    # RF2_UI_SCAFFOLD_COMPILE arms the install+compile tier (the structural tier
+    # runs unconditionally).
     # Same examples_compile surface as the sibling gate: fires for the scaffold
-    # itself, the framework core/ui it compiles against, and the build config.
+    # itself, the framework core/freehand it compiles against, and the build
+    # config. (The job id and the env-var name still read "ui" — renaming them
+    # is a required-check rename plus a `needs:` edge, so they are deliberately
+    # left alone; the lane's home under implementation/ui/scaffold-smoke moves
+    # with donor-inventory row 284, not here.)
     needs: detect_changed_surfaces
     if: needs.detect_changed_surfaces.outputs.examples_compile == 'true'
     runs-on: ubuntu-latest
@@ -2321,7 +2326,7 @@ jobs:
             ~/.m2/repository
             ~/.gitlibs
             ~/.deps.clj
-          key: ${{ runner.os }}-ui-scaffold-smoke-${{ hashFiles('examples/ui/minimal-counter/deps.edn', 'implementation/ui/deps.edn', 'implementation/core/deps.edn') }}
+          key: ${{ runner.os }}-ui-scaffold-smoke-${{ hashFiles('examples/ui/minimal-counter/deps.edn', 'implementation/freehand/deps.edn', 'implementation/core/deps.edn') }}
           restore-keys: |
             ${{ runner.os }}-ui-scaffold-smoke-
             ${{ runner.os }}-cljs-

--- a/examples/README.md
+++ b/examples/README.md
@@ -59,7 +59,7 @@ examples/
       dashboard/
     reagent_slim/
       counter/
-  ui/                          <-- standalone re-frame.ui scaffold (its own build; not on the monorepo classpath)
+  ui/                          <-- standalone Freehand scaffold (its own build; not on the monorepo classpath)
     minimal-counter/
 ```
 

--- a/examples/ui/minimal-counter/README.md
+++ b/examples/ui/minimal-counter/README.md
@@ -1,13 +1,18 @@
-# minimal-counter — the smallest runnable re-frame.ui project
+# minimal-counter — the smallest runnable Freehand project
 
-A complete, checked, standalone re-frame.ui app: a counter, its dataflow, and
-the mount that stands it up. Copy the directory, install, compile, run.
+A complete, checked, standalone Freehand app: a counter, its dataflow, and the
+mount that stands it up. Copy the directory, install, compile, run.
 
 Unlike the rest of [`examples/`](../../README.md) — which are source-only and
 run from `implementation/` with a monorepo build-id — this scaffold is a
 **standalone project**. It carries its own `deps.edn`, `package.json`, and
 `shadow-cljs.edn`, and it is deliberately *not* on the monorepo classpath.
 That is the whole point: it is the tree you would have created yourself.
+
+The prose companion is
+[Install and boot](../../../docs/core/freehand/install.md); this directory is
+the same four moves — depend, install an adapter, mount, tear down — as a tree
+that builds.
 
 ## The complete file manifest
 
@@ -29,12 +34,24 @@ resources/public/index.html
 |---|---|
 | [`deps.edn`](deps.edn) | The Clojure classpath: the two framework artefacts, ClojureScript, and the `:shadow` alias that puts shadow-cljs's JVM side on the classpath. Also `:paths ["src"]` — shadow ignores `:source-paths` in `shadow-cljs.edn` when `:deps` is used. |
 | [`package.json`](package.json) | The npm half: `react` + `react-dom` (resolved from `node_modules` at compile time) and the `shadow-cljs` CLI. Without it there is no `npx shadow-cljs` and no React to compile against. |
-| [`shadow-cljs.edn`](shadow-cljs.edn) | The `:app` build, `:dev-http`, and the one load-bearing re-frame.ui setting — the `:build-defaults` build hook. |
-| [`src/my/app.cljs`](src/my/app.cljs) | The app: events, a sub, one `defview`, and the `ui/mount`. |
-| [`resources/public/index.html`](resources/public/index.html) | The host page — supplies the `<div id="root">` that `ui/mount` targets and loads the compiled bundle. |
+| [`shadow-cljs.edn`](shadow-cljs.edn) | The `:app` build and `:dev-http`. No framework setting at all — interpreted views need no build configuration. |
+| [`src/my/app.cljs`](src/my/app.cljs) | The app: events, a sub, one `v/defview`, and the `v/mount`. |
+| [`resources/public/index.html`](resources/public/index.html) | The host page — supplies the `<div id="root">` that `v/mount` targets and loads the compiled bundle. |
 
 Everything else in a real project (tests, linters, CSS, Xray) is genuinely
 optional and deliberately absent here.
+
+## Two artefacts, and no build hook
+
+`deps.edn` names `day8/re-frame2` and `day8/re-frame2-freehand`, and that is
+the whole floor: Freehand ships its own reactive-substrate adapter, so nothing
+here depends on a wrapper library. `(rf/init! v/adapter)` at boot fills the
+reactive-substrate contract; `v/mount` puts the tree on the page.
+
+`shadow-cljs.edn` configures nothing on Freehand's behalf, deliberately. The
+**compiled** tier is what needs a build hook — its analyzer and registries run
+at build time — and this scaffold declares no `{:compiled true}` view. Opt one
+in and the hook comes with it, set once in `:build-defaults`.
 
 ## Install and run
 
@@ -52,11 +69,12 @@ is not on `PATH`.
 ## Why the coordinates are checkout-relative
 
 `deps.edn` resolves both framework artefacts with `:local/root` relative to
-this checkout, and that is permanent rather than a stopgap. `day8/re-frame2-ui`
-is donor-only: the release contract rules out a Clojars coordinate for it, now
-and for good, so a monorepo checkout is the only supported way to resolve it.
-`day8/re-frame2` does ship to Clojars with every release, but this scaffold
-takes it from the same checkout so that the two artefacts cannot drift apart.
+this checkout. `day8/re-frame2-freehand` is not published and carries no date
+at which it will be, so a monorepo checkout is the only supported way to
+resolve it — read the coord as the *shape* of the dependency, not as something
+you can paste into a fresh project. `day8/re-frame2` does ship to Clojars with
+every release, but this scaffold takes it from the same checkout so that the
+two artefacts cannot drift apart.
 
 Copying this directory *out* of the monorepo therefore means repointing both
 coords at your own checkout. Nothing else in the tree is checkout-relative.
@@ -65,14 +83,16 @@ coords at your own checkout. Nothing else in the tree is checkout-relative.
 
 [`scaffold_smoke_test.clj`](../../../implementation/ui/scaffold-smoke/test/scaffold_smoke_test.clj)
 copies exactly the manifest above into a temporary directory, runs a real
-`npm install`, and runs `npx shadow-cljs compile app` there. The manifest is
-read from *this file*, so the claim above and the tested contract are the same
-list.
+`npm install`, and runs `npx shadow-cljs compile app` there. Then the omission
+matrix: the manifest minus each file in turn, each expected to stop building.
+The manifest is read from *this file*, so the claim above and the tested
+contract are the same list.
 
-It proves the documented files alone install and compile. It does **not** drive
-a browser: DOM handler wiring (`{:on-click [:count/inc]}` actually firing) lands
-with re-frame.ui S3 — until then drive the loop from a REPL against the running
-frame, per [`re-frame.ui`'s public surface](../../../implementation/ui/src/re_frame/ui.cljc):
+What it does **not** do is drive a browser — it is a compile gate, and a
+compile cannot observe a click. Freehand's mounted behaviour is proved by its
+own artefact suites (the `*-dom-cljs-test` namespaces that mount through
+`react-dom/client`), not here. To drive this app's loop by hand, use a REPL
+against the running frame:
 
 ```clojure
 (rf/dispatch <frame> [:count/inc])

--- a/examples/ui/minimal-counter/deps.edn
+++ b/examples/ui/minimal-counter/deps.edn
@@ -1,16 +1,21 @@
-;; minimal-counter — the smallest runnable re-frame.ui project.
+;; minimal-counter — the smallest runnable Freehand project.
 ;;
-;; CHECKOUT-RELATIVE BY DESIGN, not pending a publish. day8/re-frame2-ui is
-;; donor-only: the release contract rules out a Clojars coordinate for it,
-;; now and permanently (see docs/release-process.md). Resolving it from an
-;; enclosing monorepo checkout is therefore the only supported shape, and it
-;; does not become an :mvn/version coord later. day8/re-frame2 does ship to
+;; CHECKOUT-RELATIVE BY DESIGN. day8/re-frame2-freehand is not published and
+;; carries no date at which it will be (docs/core/freehand/install.md), so
+;; resolving it from an enclosing monorepo checkout is the only supported
+;; shape today — treat the coord as the SHAPE of the dependency, not as
+;; something you can paste into a fresh project. day8/re-frame2 does ship to
 ;; Clojars with every release, but this scaffold resolves it from the same
 ;; checkout so both artefacts come from one source and cannot drift apart.
 ;;
 ;; Both artefacts are named because the app :requires namespaces from
-;; both -- re-frame.core and re-frame.ui -- and a direct :require deserves
-;; a direct dependency. (re-frame2-ui does depend on re-frame2 itself.)
+;; both -- re-frame.core and re-frame.freehand -- and a direct :require
+;; deserves a direct dependency. (re-frame2-freehand does depend on
+;; re-frame2 itself.)
+;;
+;; TWO artefacts is the whole floor: Freehand ships its own
+;; reactive-substrate adapter (v/adapter), so nothing here names a wrapper
+;; library.
 ;;
 ;; React is NOT a Clojure dependency: it arrives through npm
 ;; (package.json) and shadow-cljs resolves it from node_modules at compile
@@ -21,7 +26,7 @@
          org.clojure/clojurescript {:mvn/version "1.12.145"}
 
          day8/re-frame2            {:local/root "../../../implementation/core"}
-         day8/re-frame2-ui         {:local/root "../../../implementation/ui"}}
+         day8/re-frame2-freehand   {:local/root "../../../implementation/freehand"}}
 
  :aliases
  {;; shadow-cljs's JVM side. shadow-cljs.edn's `{:deps {:aliases [:shadow]}}`

--- a/examples/ui/minimal-counter/package.json
+++ b/examples/ui/minimal-counter/package.json
@@ -2,7 +2,7 @@
   "name": "minimal-counter",
   "version": "0.0.1",
   "private": true,
-  "description": "The smallest runnable re-frame.ui project.",
+  "description": "The smallest runnable Freehand project.",
   "devDependencies": {
     "shadow-cljs": "3.4.10"
   },

--- a/examples/ui/minimal-counter/resources/public/index.html
+++ b/examples/ui/minimal-counter/resources/public/index.html
@@ -6,7 +6,7 @@
     <title>minimal-counter</title>
   </head>
   <body>
-    <!-- ui/mount targets this node by id. -->
+    <!-- v/mount targets this node by id. -->
     <div id="root"></div>
     <!-- :asset-path "/js" + :output-dir "resources/public/js" put the
          compiled bundle here. -->

--- a/examples/ui/minimal-counter/shadow-cljs.edn
+++ b/examples/ui/minimal-counter/shadow-cljs.edn
@@ -12,18 +12,18 @@
  :dev-http {8280 "resources/public"}
 
  ;; ---------------------------------------------------------------------
- ;; The one load-bearing re-frame.ui setting (spec/004C-Roots-and-Mount.md
- ;; §2.1.1). Set it ONCE here, not once per build.
+ ;; NO Freehand build configuration, and that is the point: interpreted
+ ;; views need none at all (docs/core/freehand/install.md §Shadow build
+ ;; settings). The whole framework contribution to this file is nothing.
  ;;
- ;; :build-defaults  — the build hook harvests re-frame.ui's whole-build
- ;;                    registries (view digests, root/plan indexes, Root
- ;;                    Descriptors, custom-element declarations) from
- ;;                    cache-durable per-namespace analyzer data at build
- ;;                    time. Because the registries no longer depend on
- ;;                    macro-expansion side effects, a warm daemon start
- ;;                    REUSES Shadow's disk cache — no cache blocker needed.
+ ;; The COMPILED tier is what needs one — its analyzer and registries run
+ ;; at build time, behind a single hook set once in :build-defaults:
+ ;;
+ ;;   :build-defaults {:build-hooks [(re-frame.freehand.compiler.build-hook/hook)]}
+ ;;
+ ;; This scaffold declares no `{:compiled true}` view, so it wires no hook.
+ ;; Opt a view into the compiled tier and the hook comes with it.
  ;; ---------------------------------------------------------------------
- :build-defaults {:build-hooks [(re-frame.ui.compiler.build-hook/hook)]}
 
  :builds
  {:app

--- a/examples/ui/minimal-counter/src/my/app.cljs
+++ b/examples/ui/minimal-counter/src/my/app.cljs
@@ -1,7 +1,7 @@
 (ns my.app
-  "The smallest complete re-frame.ui app: dataflow, one view, one mount."
+  "The smallest complete Freehand app: dataflow, one view, one mount."
   (:require [re-frame.core :as rf]
-            [re-frame.ui :as ui :refer [defview sub]]))
+            [re-frame.freehand :as v :refer [sub]]))
 
 ;; ---- dataflow: plain re-frame2 --------------------------------------------
 
@@ -12,21 +12,28 @@
 ;; ---- view -----------------------------------------------------------------
 ;;
 ;; `(sub [:count])` is the value, not a ref — nothing to deref. When [:count]
-;; changes, this view re-renders.
+;; changes, this view re-renders. `{:on-click [:count/inc]}` is the intent as
+;; data: no closure, and readable in the source before anything runs.
+;;
+;; `v/defview` takes one props map; this view uses none, so the parameter is
+;; `_`. Mount it as `[counter {}]` — calling `(counter {})` is an error.
 
-(defview counter []
+(v/defview counter [_]
   [:div
    [:span "Count: " (sub [:count])]
    [:button {:on-click [:count/inc]} "+"]])
 
 ;; ---- mount ----------------------------------------------------------------
 ;;
-;; `frame-root` ensures frame :app exists and drains :initial-events once
-;; before React renders. A hot reload finds the frame live and reuses it, so
-;; your state survives edits.
+;; The mount's `:frame` ENSURES frame :app and drains :initial-events to
+;; completion before React is handed anything, so the first paint already
+;; carries the seeded count — no dispatch-sync, no empty-then-flash. The
+;; root's identity is DERIVED from the mounted view's registered id, so a hot
+;; reload finds the same root live and re-renders it in place: your state
+;; survives edits.
 
 (defn ^:export run []
-  (rf/init! ui/adapter)
-  (ui/mount [ui/frame-root {:id :app :initial-events [[:app/init]]}
-             [counter]]
-            (js/document.getElementById "root")))
+  (rf/init! v/adapter)
+  (v/mount [counter {}]
+           (js/document.getElementById "root")
+           {:frame {:id :app :initial-events [[:app/init]]}}))

--- a/implementation/scripts/_changed-surfaces.test.cjs
+++ b/implementation/scripts/_changed-surfaces.test.cjs
@@ -700,6 +700,10 @@ test('example compilation has a dedicated changed-surface output (rf2-gzavkm)', 
     'implementation/deps.edn',
     'implementation/adapters/uix/src/re_frame/adapter/uix.cljs',
     'implementation/ui/src/re_frame/ui/rules.cljc',
+    // rf2-nutll — examples/ui/minimal-counter is a standalone FREEHAND project
+    // now, resolved by :local/root, so a Freehand change can break the
+    // ui-scaffold-smoke build that examples_compile gates.
+    'implementation/freehand/src/re_frame/freehand.cljc',
     'implementation/epoch/src/re_frame/epoch.cljc',
     'implementation/schemas/src/re_frame/schemas.cljc',
     'implementation/machines/src/re_frame/machines.cljc',

--- a/implementation/ui/scaffold-smoke/test/scaffold_smoke_test.clj
+++ b/implementation/ui/scaffold-smoke/test/scaffold_smoke_test.clj
@@ -1,14 +1,15 @@
 (ns scaffold-smoke-test
-  "CI teeth for examples/ui/minimal-counter — the minimal runnable re-frame.ui
-   scaffold (rf2-vxgfnd.281).
+  "CI teeth for examples/ui/minimal-counter — the minimal runnable Freehand
+   scaffold (rf2-vxgfnd.281; cut over from the donor substrate by rf2-nutll).
 
    Two tiers:
 
      STRUCTURAL (always) — read the file manifest straight out of the
      scaffold's README, and assert it matches what is on disk: every listed
      file present, no un-listed source/config file hiding alongside them, the
-     two load-bearing shadow-cljs settings present, the host page wired, and
-     deps.edn's :local/root coords resolving. Pure file reads; no Node.
+     shadow config wiring no build hook (the interpreted tier needs none), the
+     host page wired, and deps.edn's :local/root coords resolving. Pure file
+     reads; no Node.
 
      COMPILE (env RF2_UI_SCAFFOLD_COMPILE=1) — the real proof. Materialize
      ONLY the manifest files into a temp dir, `npm install`, and
@@ -108,40 +109,49 @@
                "  unexpected (on disk, not documented): " (sort (remove allowed on-disk)) "\n"
                "  missing   (documented, not on disk):  " (sort (remove on-disk allowed)))))))
 
-(def ^:private contract-keys [:build-defaults])
-
 (defn- read-config
   "Read a shadow-cljs.edn as data. `:default` absorbs the build-tool reader tags
   (`#shadow/env`) that appear in the monorepo's own config."
   [file]
   (edn/read-string {:default (fn [_tag v] v)} (slurp file)))
 
-(deftest shadow-config-carries-the-one-load-bearing-setting
-  ;; spec/004C-Roots-and-Mount.md §2.1.1: the build hook is load-bearing on
-  ;; Shadow. The old top-level :cache-blockers tax was removed at the S6 cut-over
-  ;; (rf2-u53yy.1) — the registries are harvested from cache-durable analyzer
-  ;; data, so a warm daemon reuses the disk cache and no blocker is needed.
+(defn- build-hooks
+  "Every :build-hooks vector a shadow config wires — the top-level
+  :build-defaults and each build alike, so the claim below cannot be dodged by
+  moving a hook one level down."
+  [config]
+  (concat (get-in config [:build-defaults :build-hooks])
+          (mapcat :build-hooks (vals (:builds config)))))
+
+(deftest shadow-config-wires-no-build-hook
+  ;; docs/core/freehand/install.md §Shadow build settings: interpreted views
+  ;; need no build configuration at all. The COMPILED tier is what needs one —
+  ;; its analyzer and whole-build registries run at build time behind
+  ;; `(re-frame.freehand.compiler.build-hook/hook)` — and this scaffold declares
+  ;; no `{:compiled true}` view, so the framework's contribution to its build
+  ;; config is nothing. "The smallest runnable project" has to mean it.
   ;;
-  ;; rf2-vxgfnd.196 — DERIVED, not restated. This test used to spell the setting
-  ;; as a string literal, which made it a copy of the rule checking itself: edit
-  ;; the real configuration and this stayed green. The expected value is now the
-  ;; monorepo's own shadow-cljs.edn, read at run time, so the scaffold is pinned
-  ;; to what the framework actually configures.
-  (let [real (select-keys (read-config (io/file @root "implementation/shadow-cljs.edn"))
-                          contract-keys)]
-    ;; Shape guard first: if the framework config lost the setting, both sides
-    ;; would be {} and the comparison would pass vacuously.
-    (is (= (set contract-keys) (set (keys real)))
-        (str "implementation/shadow-cljs.edn no longer carries the build-hook "
-             "setting; found " (sort (keys real))))
-    (is (not (contains? (read-config (io/file @root "implementation/shadow-cljs.edn"))
-                        :cache-blockers))
-        "implementation/shadow-cljs.edn must NOT carry the removed :cache-blockers tax")
-    (is (= real (select-keys (read-config (scaffold-file "shadow-cljs.edn"))
-                             contract-keys))
-        (str "the scaffold's shadow-cljs.edn diverged from the framework's own "
-             "re-frame.ui configuration — a consumer copying this scaffold would "
-             "not configure re-frame.ui the way this repo actually does"))))
+  ;; Until rf2-nutll this compared the scaffold's `:build-defaults` against the
+  ;; monorepo's own, because the scaffold was a donor consumer and the donor's
+  ;; hook was load-bearing for every view. It is a Freehand consumer now, on the
+  ;; interpreted tier, so there is no longer a setting to agree about — what is
+  ;; worth pinning is the absence, and the REASON for the absence with it.
+  (let [config (read-config (scaffold-file "shadow-cljs.edn"))]
+    ;; Shape guard first: an emptied or unparseable config would read as
+    ;; "no hooks" and pass the assertion below vacuously.
+    (is (contains? (:builds config) :app)
+        "the scaffold's shadow-cljs.edn no longer declares the :app build")
+    (is (empty? (build-hooks config))
+        (str "the scaffold's shadow-cljs.edn wires a build hook: "
+             (pr-str (vec (build-hooks config)))
+             ". Interpreted Freehand needs none — either the scaffold gained a "
+             "compiled-tier view (then say so here and in the README), or the "
+             "hook is cargo."))
+    ;; The reason, read from the source rather than assumed.
+    (is (not (str/includes? (slurp (scaffold-file "src/my/app.cljs")) ":compiled"))
+        (str "the scaffold's app declares a compiled-tier view, so it DOES need "
+             "the Freehand build hook — wire it in shadow-cljs.edn and retarget "
+             "this test"))))
 
 (deftest host-page-wires-the-mount-target-and-bundle
   (let [html (slurp (scaffold-file "resources/public/index.html"))]

--- a/implementation/ui/test/re_frame/ui/shadow_config_contract_jvm_test.clj
+++ b/implementation/ui/test/re_frame/ui/shadow_config_contract_jvm_test.clj
@@ -20,15 +20,27 @@
   its own copy of it (the rf2-5e3ic failure mode: gates that answered `true` for
   a 404 and for a path outside the repo).
 
-  Three holders, compared as DATA:
+  Two holders, compared as DATA:
 
     1. this repo's own build    implementation/shadow-cljs.edn        (top level)
-    2. the consumer scaffold    examples/ui/minimal-counter/shadow-cljs.edn
-    3. the setup skill          skills/re-frame2-setup/references/shadow-cljs.md
+    2. the setup skill          skills/re-frame2-setup/references/shadow-cljs.md
 
   The setup skill carries only the settings themselves, behind the
   `rf2:shadow-ui-contract` anchor — so it is pinned to the real build config
   rather than being a copy free to drift.
+
+  THERE WAS A THIRD (rf2-nutll). `examples/ui/minimal-counter/shadow-cljs.edn`
+  held the same one setting, and this suite compared the two real configs
+  directly. That scaffold has CUT OVER to Freehand: it is not a donor consumer
+  any more, and on the interpreted tier it configures no build hook at all — the
+  compiled tier's hook is Freehand's own
+  (`re-frame.freehand.compiler.build-hook`) and belongs to its own contract, as
+  the note below already said of the published page. So the scaffold stopped
+  being a holder of THIS rule rather than drifting from it, and comparing it
+  here would assert a setting it is correct not to carry; its own gate
+  (`implementation/ui/scaffold-smoke`) pins the absence and the reason for it.
+  The scaffold's `deps.edn` is still read below, for the one comparison that
+  survives the cut-over: it remains a REAL shadow-cljs pin.
 
   THERE WAS A FOURTH (rf2-ote5u). `docs/core/how-to/install-re-frame-ui.md`
   published the same contract and a supported shadow-cljs version, and this
@@ -69,7 +81,6 @@
 ;; `slice-memo-lifetime-census-jvm-test` in this directory.
 (def ^:private root-marker-rel "AGENTS.md")
 (def ^:private impl-config-rel "implementation/shadow-cljs.edn")
-(def ^:private example-config-rel "examples/ui/minimal-counter/shadow-cljs.edn")
 (def ^:private example-deps-rel "examples/ui/minimal-counter/deps.edn")
 (def ^:private impl-package-rel "implementation/package.json")
 (def ^:private skill-rel "skills/re-frame2-setup/references/shadow-cljs.md")
@@ -195,9 +206,8 @@
     ;; The whole point of S6: the tax line must not creep back into any real
     ;; shadow-cljs.edn holder. (The skill's anchored contract block is pinned
     ;; one-setting by the comparison below.)
-    (doseq [rel [impl-config-rel example-config-rel]]
-      (is (not (contains? (read-config rel) :cache-blockers))
-          (str rel " still carries the removed :cache-blockers install tax")))
+    (is (not (contains? (read-config impl-config-rel) :cache-blockers))
+        (str impl-config-rel " still carries the removed :cache-blockers install tax"))
     ;; And the anchored contract block itself must be exactly one setting.
     (is (not (contains? (skill-contract) :cache-blockers))
         (str skill-rel " anchored contract block still carries :cache-blockers"))))
@@ -223,15 +233,6 @@
              impl-config-rel ". An author following the setup skill would not "
              "configure re-frame.ui the way this repo actually does — "
              "reconcile the skill against the real build config."))))
-
-(deftest the-two-real-configs-agree
-  (testing "this repo and the scaffold configure re-frame.ui identically"
-    ;; A consumer copying the runnable scaffold must get what this repo itself
-    ;; builds with. Asserted directly so a failure names the two configs.
-    (is (= (top-level-contract impl-config-rel)
-           (top-level-contract example-config-rel))
-        (str impl-config-rel " and " example-config-rel
-             " no longer configure re-frame.ui the same way."))))
 
 ;; ---------------------------------------------------------------------------
 ;; Version posture — a concrete pin within the supported, tested range

--- a/spec/conformance/freehand/donor-inventory.md
+++ b/spec/conformance/freehand/donor-inventory.md
@@ -406,7 +406,7 @@ disposed when the consumer moves to Freehand names.
 
 | Donor row | What it is | Disposition | Slice | Status |
 |---|---|---|---|---|
-| `examples/ui/minimal-counter/*` | the minimal runnable donor scaffold example | MOVE | F6 | pending |
+| `examples/ui/minimal-counter/*` | the minimal runnable donor scaffold example | MOVE | F6 | done |
 | `examples/real-apps/realworld_resources/ui_*` | the donor-authored views of the realworld example, including its compiled editor and counter | MOVE | F6 | pending |
 | `tools/xray/testbeds/feature_matrix/scenarios.cjs` | the xray feature-matrix scenarios that mount donor views | MOVE | F6 | pending |
 


### PR DESCRIPTION
Cuts donor-inventory **row 409** — `examples/ui/minimal-counter/*`, the smallest
runnable scaffold — over from the `re-frame.ui` donor to Freehand, and moves the
four bookkeeping files that fail if it lands alone.

The code half was already proven by measurement on rf2-3bjs8 (migrate, gate,
capture `rc`, revert). This PR re-verified that diff against current `main` and
then landed the rest of it: the three-file code change is byte-for-byte the
measured one, and `npx shadow-cljs compile app` reproduces the same numbers —
**167 files, 166 compiled, 0 warnings, rc=0**.

Also corrected: rf2-3bjs8's mapping note claimed "Freehand has NO adapter export".
It does — `v/adapter`. The scaffold installs it directly and needs no wrapper
artefact, which is why `deps.edn` still names exactly two coordinates.

## What moved

**The scaffold (`examples/ui/minimal-counter/`)**

- `deps.edn` — `day8/re-frame2-ui` → `day8/re-frame2-freehand`
  (`../../../implementation/freehand`). Still exactly **2** `:local/root` coords;
  the `thheller/shadow-cljs` pin under `:aliases :shadow` is untouched, so the
  npm↔Clojure lockstep comparison still has both its real holders.
- `shadow-cljs.edn` — the donor `:build-defaults` build-hook line is **deleted,
  not replaced**. Interpreted Freehand views need no build configuration at all
  (`docs/core/freehand/install.md` §Shadow build settings); the compiled tier's
  hook is what needs wiring, and this scaffold declares no `{:compiled true}`
  view. The comment now says that, and names the hook a compiled-tier scaffold
  would add.
- `src/my/app.cljs` — `[re-frame.freehand :as v :refer [sub]]`,
  `(rf/init! v/adapter)`, `(v/defview counter [_] …)`, and
  `(v/mount [counter {}] node {:frame {:id :app :initial-events [[:app/init]]}})`.
  The donor's `ui/frame-root` wrapper is gone: the mount's own `:frame` option
  ensures the frame and drains `:initial-events` before React sees anything.
- `README.md`, `package.json`, `index.html` — prose and the mount-target comment
  follow the substrate. The README gained a pointer to the Freehand install page
  and a short section on why there are two artefacts and no build hook.

**The four blocking files**

1. `spec/conformance/freehand/donor-inventory.md` — row 409 `pending` → `done`.
   Row identity unchanged (`examples/ui/minimal-counter/*`), so
   `ESTABLISHED_ROWS` needs no edit and the roster stays exact.
2. `implementation/ui/scaffold-smoke/test/scaffold_smoke_test.clj` —
   `shadow-config-carries-the-one-load-bearing-setting` retargeted to
   `shadow-config-wires-no-build-hook`. Same file, same tier count, no new gate.
   It now pins the **absence and its reason**: no `:build-hooks` anywhere in the
   config (top-level *or* per-build), and no `:compiled` view in the app source —
   with a shape guard (`:builds :app` present) first, so an emptied config cannot
   pass it vacuously.
3. `implementation/ui/test/re_frame/ui/shadow_config_contract_jvm_test.clj` —
   `the-two-real-configs-agree` removed along with `example-config-rel`. The
   scaffold stopped being a *holder* of the `re-frame.ui` rule rather than
   drifting from it, and asserting the setting against it would demand a line the
   scaffold is correct not to carry. The ns docstring records the departure the
   same way it records the fourth holder rf2-ote5u removed. `example-deps-rel`
   stays: `the-two-real-pins-agree` is a shadow-cljs *version* comparison and
   survives the cut-over untouched.
4. `.github/workflows/test.yml` — hot-zone; two hunks, enumerated below.

**One more, for a coverage hole the cut-over would otherwise open**

- `.github/scripts/report-changed-surfaces.sh` — `implementation/freehand/*`
  added to the `examples_compile` case. The `ui-scaffold-smoke` job is gated on
  that output, and the scaffold now resolves `day8/re-frame2-freehand` by
  `:local/root` — so without this, a Freehand change that breaks the standalone
  scaffold's compile skips the only job that builds it. `implementation/ui/*` was
  in the list for exactly this reason, and the `implementation/freehand/*` case
  further down explicitly invites the widening ("Widen each the moment that
  changes — the `implementation/ui/*` case above is the worked precedent").
- `implementation/scripts/_changed-surfaces.test.cjs` — one path added to the
  existing `directSurfaces` list so that coverage cannot be narrowed back
  silently. An existing test's data, not a new gate.

## `test.yml` hunks (hot-zone — both, in full)

| Hunk | Lines | What |
|---|---|---|
| 1 | `@@ -2282,12 +2282,17` | The `ui-scaffold-smoke` job comment: "the minimal RUNNABLE re-frame.ui scaffold" → Freehand; "the framework core/ui it compiles against" → "core/freehand". Adds the note that the job id and `RF2_UI_SCAFFOLD_COMPILE` still read "ui" **on purpose**. |
| 2 | `@@ -2323,3 +2328,3` | Cache key: `hashFiles(… 'implementation/ui/deps.edn' …)` → `'implementation/freehand/deps.edn'`. The scaffold no longer resolves the donor's deps.edn, so the old key hashed a file with no bearing on the restored `~/.m2`. |

No new job, no `needs:` edge, no `if:` change, no runner or action-pin change. The
job **id** stays `ui-scaffold-smoke` and the env var stays
`RF2_UI_SCAFFOLD_COMPILE`: renaming either is a required-status-check rename plus
an edit to the aggregate `needs:` list, which the brief said to stop and report
rather than land. Likewise `working-directory: implementation/ui/scaffold-smoke`
— relocating that lane out of the donor tree is donor-inventory **row 284**, which
stays `pending`.

## Quality gates

Every command run to completion in the foreground from the worker worktree
`C:/Users/miket/code/re-frame2-worktrees/row409-cutover`. `rc` captured
immediately; the three ledger/classifier lanes are silent-on-success by design,
so `rc` *is* their verdict.

| Gate | Command | Result | rc |
|---|---|---|---|
| Donor ledger (before) | `python scripts/check_donor_inventory.py --ci` | clean on the base | **0** |
| Donor ledger (after) | `python scripts/check_donor_inventory.py --ci` | clean with the cut-over + row flip | **0** |
| Ledger checker self-tests | `python scripts/check_donor_inventory.py --self-test` | `self-test: all cases passed.` | **0** |
| Surface classifier | `node --test implementation/scripts/_changed-surfaces.test.cjs` | `changed-surfaces tests: 236 passed.` | **0** |
| The proven compile | `npx shadow-cljs compile app` (in the scaffold) | **167 files, 166 compiled, 0 warnings** | **0** |
| Scaffold smoke — structural | `clojure -M:test` (`implementation/ui/scaffold-smoke`) | 7 tests / 17 assertions, 0 failures, 0 errors | **0** |
| Scaffold smoke — compile + omission matrix | `RF2_UI_SCAFFOLD_COMPILE=1 clojure -M:test` | 7 tests / **23** assertions, 0 failures, 0 errors | **0** |
| `implementation/ui` JVM suite | `clojure -M:test` (`implementation/ui`) | **702 tests / 17609 assertions**, 0 failures, 0 errors | **0** |

The omission matrix is the one that matters most here: it re-materializes the
manifest minus each file in turn and requires the result to stop being viable, so
every one of the five documented files is still *load-bearing* after the
substrate swap — `shadow-cljs.edn` included, now that it carries no framework
setting at all.

**And it is not vacuously green.** The retargeted test was falsified in both
directions and the perturbations reverted:

| Perturbation | Result |
|---|---|
| Add `:build-defaults {:build-hooks [(re-frame.freehand.compiler.build-hook/hook)]}` to the scaffold's config | rc=**1**, `FAIL in (shadow-config-wires-no-build-hook)` at `:144`, message naming the hook |
| Add `{:compiled true}` to the scaffold's `v/defview` | rc=**1**, `FAIL in (shadow-config-wires-no-build-hook)` at `:151`, "the scaffold's app declares a compiled-tier view, so it DOES need the Freehand build hook" |
| Both reverted | rc=**0**, 7 tests / 17 assertions |

## Counts

**Donor references under `examples/`** — `git ls-files examples/` filtered on the
ledger's own `DONOR_EVIDENCE_RE` spellings:

|  | Files | Total matches |
|---|---|---|
| Before | 17 | 51 |
| After | 12 | 33 |

All five `minimal-counter` files that carried donor spellings are clear
(`README.md` 7→1, `deps.edn` 5→0, `shadow-cljs.edn` 3→0, `src/my/app.cljs` 2→0,
`package.json` 1→0).

**The one residual, stated plainly:** `examples/ui/minimal-counter/README.md`
keeps a single donor string — the link to
`../../../implementation/ui/scaffold-smoke/test/scaffold_smoke_test.clj`. That is
a *true* path to the CI lane that gates this scaffold, and relocating that lane is
donor-inventory row 284's job, not row 409's. Removing the link would cost a
reader the pointer without disposing of anything. The census signals it does not
match (no `re-frame.ui…` libspec, no `day8/re-frame2-ui {` coordinate), so the
ledger is green with row 409 `done`.

**Ledger burn-down** (`--report`):

| | Rows | Undisposed |
|---|---|---|
| Before | 203 | **142** |
| After | 203 | **141** |

Trend: 177 → 161 → 149 → 142 → **141**. Row count unchanged, as the roster rule
requires — the count fell by a disposition, not by a deletion.

## Deliberately not in scope

- **Row 410 (`examples/real-apps/realworld_resources/ui_*`)** — untouched. It
  waits on EP-0037 R4/R6 plus two coupling sets: `implementation/ui/deps.edn`'s
  `:test` alias puts `../../examples/real-apps` on the JVM classpath with tests
  requiring the realworld views directly, and `tools/` pins the realworld view
  ids (both story and xray key on `:realworld-resources.ui-counter/counter`).
- **The four `examples/` prose references that describe *other* clusters as
  donor-based** — `examples/scripts/examples-asset-manifest.cjs` (the RealWorld
  `re-frame.ui` variant) and `examples/scripts/check-examples-assets.cjs` (the
  scaffold-smoke lane's location) are left exactly as they are. They are true
  today; renaming the words while their subjects are still donor-based would make
  the docs lie. `examples/README.md`'s tree comment **was** edited, because its
  subject is precisely what this PR migrated.
- **Renaming `examples/ui/`** — the directory keeps its name. Re-keying it means
  the ledger row identity + `ESTABLISHED_ROWS` + the smoke test's `scaffold-rel` +
  the JVM contract's `example-deps-rel` + two `test.yml` references + two
  `examples/` scripts + `examples/README.md`, which is a different change from
  this one. Filed as a follow-up.
- **No scaffold restructuring, no new gate, no scaffold "improvement".** One
  cut-over, one PR.
