### PR TITLE
fix(trace,epoch): stamp the canonical [:tags :frame] at the producer so epoch capture stops dropping the resource/mutation family (rf2-hbmeb)

### DIFF
--- a/implementation/core/src/re_frame/trace.cljc
+++ b/implementation/core/src/re_frame/trace.cljc
@@ -402,41 +402,39 @@
   (swap! trace-disabled-frames disj frame-id)
   nil)
 
+(defn- ambient-frame-id
+  "The frame the runtime is currently running in, read through the
+  late-bound `:frame/current-frame-id` hook (published by
+  `re-frame.frame` at ns-load; `re-frame.trace` cannot require `frame`
+  — `frame` requires `trace`). nil outside any frame-bound scope
+  (registry-time, boot-time, a bare REPL emit).
+
+  ONE resolution point. Both the pre-build frame-policy gate
+  (`tagged-frame-trace-disabled?`) and the envelope's own `:frame`
+  stamp (`stamp-frame`) read the ambient frame here, so the gate and
+  the envelope can never disagree about which frame an emit belongs to."
+  []
+  (when-let [current-frame (late-bind/get-fn-cached :frame/current-frame-id)]
+    (current-frame)))
+
 (defn- tagged-frame-trace-disabled?
   "True when the frame this (not-yet-built) trace envelope targets is
-  registered trace-disabled. Mirrors
-  `re-frame.trace.tooling/push-to-ring!`'s frame-resolution chain so the
-  suppression gate agrees with the ring on which frame an event belongs
-  to — `tags` here is exactly what becomes the envelope's `:tags`, so
-  `push-to-ring!`'s first two steps (`[:tags :frame]` and a top-level
-  `:frame` on the built envelope) collapse into the single `(:frame
-  tags)` read; its third step, the late-bound `:frame/current-frame-id`
-  hook, is mirrored as-is:
+  registered trace-disabled. Resolves the frame exactly as
+  `build-event`'s `stamp-frame` will a moment later — the explicit
+  `:frame` tag when the emit site supplied one, else `ambient-frame-id`
+  — so the suppression gate and the envelope it gates can never
+  disagree about which frame an emit belongs to.
 
-    1. `:frame` under `tags` (the router / call sites stamp it on most
-       in-run emits).
-    2. The late-bound `:frame/current-frame-id` hook (published by
-       `re-frame.frame` at ns-load) — covers emits inside an in-flight
-       cascade whose call site doesn't stamp a `:frame` tag but whose
-       dynamic `*current-frame*` is bound (e.g. a sub recompute / view
-       render reached through the ambient scope rather than an explicit
-       `:frame` opt).
-
-  Without step 2 an un-tagged emit under a disabled tool frame ESCAPED
-  suppression (rf2-yl4c0s) — the inspector's own reactivity could leak
-  into the ring it inspects via any resolution path push-to-ring! honours
-  but this gate didn't. The empty-set common case (no tool frame
-  mounted) short-circuits before ANY frame resolution — including the
-  late-bind hook lookup — so the hot emit path pays a single nil-check
-  when no inspector is running."
+  The ambient tier is load-bearing (rf2-yl4c0s): without it an
+  un-tagged emit under a disabled tool frame ESCAPED suppression, and
+  the inspector's own reactivity leaked into the ring it inspects. The
+  empty-set common case (no tool frame mounted) short-circuits before
+  ANY frame resolution — including the late-bind hook lookup — so the
+  hot emit path pays a single nil-check when no inspector is running."
   [tags]
   (let [disabled @trace-disabled-frames]
     (and (seq disabled)
-         (let [frame-id (or (:frame tags)
-                             (when-let [current-frame
-                                        (late-bind/get-fn-cached :frame/current-frame-id)]
-                               (current-frame)))]
-           (contains? disabled frame-id)))))
+         (contains? disabled (or (:frame tags) (ambient-frame-id))))))
 
 ;; ---- canonical frame reader (rf2-7737vq Stage A) --------------------------
 ;;
@@ -550,6 +548,48 @@
     (assoc base-tags :rf.trace/dispatch-id dispatch-id)
     base-tags))
 
+(defn- stamp-frame
+  "Merge the emit's frame into `base-tags` under the canonical raw
+  trace-event key `:frame`, so EVERY event emitted inside a
+  frame-bound run carries frame identity at the one path Spec 009
+  §Frame identity on the raw event designates — the path
+  `trace-event-frame` reads.
+
+  Spec 009 says a raw trace event carries frame identity ONLY under
+  `[:tags :frame]`, and that every emit site that knows the frame
+  includes it there. Emit sites that pass an explicit `:frame` tag
+  (the router, cofx, error and frame-lifecycle sites) still win —
+  a `:rf.frame/created` for a dynamically constructed frame B is
+  tagged `{:frame B}` while the ambient frame is still A, and that
+  explicit tag is authoritative. The stamp only supplies the tag for
+  emit sites that DIDN'T, which the runtime otherwise leaves with no
+  frame identity at all.
+
+  rf2-hbmeb is what that costs. The whole `:rf.resource/*` /
+  `:rf.mutation/*` family stamps its frame as the family EVIDENCE key
+  `:rf.frame/id` (the qualified carried-frame spelling of Spec 016 /
+  EP-0002, alongside `:resource/key` and `:generation`) and never
+  stamped the routing tag, so `trace-event-frame` returned nil for
+  every row in the family. `re-frame.epoch.capture/capture-event!`
+  buffers only frame-resolvable events, so a real `ensure` /
+  `release-owner` cascade put 7 family rows on the bus and 0 into the
+  3 epoch records it settled — the resource lifecycle was absent from
+  every epoch record a tool could read, and the epoch-side resource
+  egress projector had never run over a real record.
+
+  Stamping HERE rather than at ~100 family emit sites is the point:
+  the fact is supplied once, in the producer every reader already
+  goes through, so no future emit site can forget it. It also lets the
+  duplicated ambient-frame fallback chains downstream
+  (`trace.tooling/push-to-ring!`, `epoch.capture/capture-event!`)
+  collapse onto the single canonical `[:tags :frame]` read."
+  [base-tags]
+  (if (contains? base-tags :frame)
+    base-tags
+    (if-let [frame-id (ambient-frame-id)]
+      (assoc base-tags :frame frame-id)
+      base-tags)))
+
 (def ^:private uncorrelated-op-types
   "Op-type classes whose emits are STRUCTURAL — not part of any cascade's
   causal event chain — so they must never inherit the in-scope cascade's
@@ -612,9 +652,16 @@
         ;; seam's orphan-drop arm keeps a cross-frame `:rf.frame/created` /
         ;; `:rf.frame/re-registered` marker out of a SIBLING frame's harvested
         ;; record (rf2-7eel71). See `uncorrelated-op-types`.
-        tags+       (if (contains? uncorrelated-op-types op-type)
-                      base-tags
-                      (stamp-dispatch-id base-tags dispatch-id))]
+        ;; `stamp-frame` supplies the canonical `[:tags :frame]` routing
+        ;; tag for emit sites that didn't (rf2-hbmeb); it runs for EVERY
+        ;; op-type, including the uncorrelated structural ones — those are
+        ;; exempt from inheriting the cascade's DISPATCH-ID, not from
+        ;; carrying their own frame (they already tag it explicitly, so the
+        ;; stamp is a no-op there).
+        tags+       (stamp-frame
+                      (if (contains? uncorrelated-op-types op-type)
+                        base-tags
+                        (stamp-dispatch-id base-tags dispatch-id)))]
     (cond-> {:operation operation
              :op-type   op-type
              :id        (next-event-id)

--- a/implementation/core/src/re_frame/trace.cljc
+++ b/implementation/core/src/re_frame/trace.cljc
@@ -409,21 +409,36 @@
   — `frame` requires `trace`). nil outside any frame-bound scope
   (registry-time, boot-time, a bare REPL emit).
 
-  ONE resolution point. Both the pre-build frame-policy gate
-  (`tagged-frame-trace-disabled?`) and the envelope's own `:frame`
-  stamp (`stamp-frame`) read the ambient frame here, so the gate and
-  the envelope can never disagree about which frame an emit belongs to."
+  ONE reader, TWO callers with deliberately different reach — the
+  asymmetry is documented rather than papered over:
+
+    - `tagged-frame-trace-disabled?` (the pre-build frame-policy gate)
+      consults it for EVERY emit, correlated or not. That breadth is
+      rf2-yl4c0s: an un-tagged emit under a disabled inspector frame
+      escaped suppression, and the inspector's own reactivity leaked
+      into the ring it inspects. Suppression is about where an emit
+      came FROM, which is a question the ambient scope answers even
+      outside a run.
+    - `stamp-frame` (the envelope's own tag) consults it only for
+      emits INSIDE a run. Identity is about which frame's ring, epoch
+      and history an event belongs TO, and Spec 009 says an emit
+      outside any frame-qualified run belongs to none.
+
+  Sharing the reader is what keeps the two from drifting on HOW the
+  ambient frame is resolved; they differ only on WHEN it applies."
   []
   (when-let [current-frame (late-bind/get-fn-cached :frame/current-frame-id)]
     (current-frame)))
 
 (defn- tagged-frame-trace-disabled?
-  "True when the frame this (not-yet-built) trace envelope targets is
-  registered trace-disabled. Resolves the frame exactly as
-  `build-event`'s `stamp-frame` will a moment later — the explicit
-  `:frame` tag when the emit site supplied one, else `ambient-frame-id`
-  — so the suppression gate and the envelope it gates can never
-  disagree about which frame an emit belongs to.
+  "True when the frame this (not-yet-built) trace envelope came FROM is
+  registered trace-disabled: the explicit `:frame` tag when the emit
+  site supplied one, else `ambient-frame-id`.
+
+  Note the deliberate breadth relative to `build-event`'s `stamp-frame`,
+  which shares this ns's one `ambient-frame-id` reader but applies it
+  only to emits inside a run — see that fn and `ambient-frame-id` for
+  why suppression and identity answer different questions.
 
   The ambient tier is load-bearing (rf2-yl4c0s): without it an
   un-tagged emit under a disabled tool frame ESCAPED suppression, and
@@ -549,46 +564,64 @@
     base-tags))
 
 (defn- stamp-frame
-  "Merge the emit's frame into `base-tags` under the canonical raw
-  trace-event key `:frame`, so EVERY event emitted inside a
-  frame-bound run carries frame identity at the one path Spec 009
-  §Frame identity on the raw event designates — the path
-  `trace-event-frame` reads.
+  "Merge the emit's frame into `tags` under the canonical raw
+  trace-event key `:frame`, so every event emitted INSIDE A RUN carries
+  frame identity at the one path Spec 009 §Frame identity on the raw
+  event designates — the path `trace-event-frame` reads.
 
-  Spec 009 says a raw trace event carries frame identity ONLY under
-  `[:tags :frame]`, and that every emit site that knows the frame
-  includes it there. Emit sites that pass an explicit `:frame` tag
-  (the router, cofx, error and frame-lifecycle sites) still win —
-  a `:rf.frame/created` for a dynamically constructed frame B is
-  tagged `{:frame B}` while the ambient frame is still A, and that
-  explicit tag is authoritative. The stamp only supplies the tag for
-  emit sites that DIDN'T, which the runtime otherwise leaves with no
-  frame identity at all.
+  TWO conditions, and Spec 009 states both. The stamp is skipped unless
+  each holds.
 
-  rf2-hbmeb is what that costs. The whole `:rf.resource/*` /
-  `:rf.mutation/*` family stamps its frame as the family EVIDENCE key
-  `:rf.frame/id` (the qualified carried-frame spelling of Spec 016 /
-  EP-0002, alongside `:resource/key` and `:generation`) and never
-  stamped the routing tag, so `trace-event-frame` returned nil for
-  every row in the family. `re-frame.epoch.capture/capture-event!`
-  buffers only frame-resolvable events, so a real `ensure` /
-  `release-owner` cascade put 7 family rows on the bus and 0 into the
-  3 epoch records it settled — the resource lifecycle was absent from
-  every epoch record a tool could read, and the epoch-side resource
-  egress projector had never run over a real record.
+  1. THE EMIT SITE DIDN'T ALREADY SUPPLY ONE. `:frame` under `tags` is
+     authoritative wherever the site stamps it: a `:rf.frame/created`
+     for a dynamically constructed frame B is tagged `{:frame B}` while
+     the ambient frame is still A (rf2-7eel71), and the `:rf.ui`
+     cross-frame carried-op warning deliberately names its two frames
+     `:origin-frame` / `:ambient-frame` and carries no bare `:frame` at
+     all. This fn only supplies the tag; it never overrides one.
+
+  2. THE EMIT IS CORRELATED TO A RUN — its tags carry a
+     `:rf.trace/dispatch-id`. Spec 009 is explicit that
+     `trace-event-frame` returns \"nil for an event emitted outside any
+     frame-qualified run (registry-time / boot-time)\", and the
+     dispatch-id is the runtime's own signal for which of those an emit
+     is. A `reg-machine` cofx lint warning, a direct 4-arity
+     `validate-fx!` call, an Xray preload's synthetic boot emit: all
+     fire with no run in scope and MUST stay frameless — they belong to
+     no frame's ring, no frame's epoch, and no frame's history. An
+     earlier revision of this fix omitted this condition and stamped
+     the ambient frame on them, which reddened four suites (machines
+     x3, schemas x1, ui x1, the Xray frameless-secondary-ring CLJS
+     arms) — every one of them asserting exactly this clause.
+
+  rf2-hbmeb is what the missing stamp cost inside a run. The whole
+  `:rf.resource/*` / `:rf.mutation/*` family stamps its frame as the
+  family EVIDENCE key `:rf.frame/id` (the qualified carried-frame
+  spelling of Spec 016 / EP-0002, alongside `:resource/key` and
+  `:generation`) and never stamped the routing tag, so
+  `trace-event-frame` returned nil for every row in the family.
+  `re-frame.epoch.capture/capture-event!` buffers only
+  frame-resolvable events, so a real `ensure` / `release-owner`
+  cascade put 7 family rows on the bus and 0 into the 3 epoch records
+  it settled — the resource lifecycle was absent from every epoch
+  record a tool could read, and the epoch-side resource egress
+  projector had never run over a real record. Every one of those 7
+  rows carries a dispatch-id, so condition 2 admits them.
 
   Stamping HERE rather than at ~100 family emit sites is the point:
-  the fact is supplied once, in the producer every reader already
-  goes through, so no future emit site can forget it. It also lets the
-  duplicated ambient-frame fallback chains downstream
-  (`trace.tooling/push-to-ring!`, `epoch.capture/capture-event!`)
-  collapse onto the single canonical `[:tags :frame]` read."
-  [base-tags]
-  (if (contains? base-tags :frame)
-    base-tags
+  the fact is supplied once, in the producer every reader already goes
+  through, so no future emit site inside a run can forget it. It also
+  lets `trace.tooling/push-to-ring!`'s duplicated ambient-frame
+  fallback collapse onto the single canonical `[:tags :frame]` read —
+  behaviour-preserving under condition 2, because that fn discards any
+  event with no dispatch-id before it ever consults a frame."
+  [tags]
+  (if (or (contains? tags :frame)
+          (nil? (:rf.trace/dispatch-id tags)))
+    tags
     (if-let [frame-id (ambient-frame-id)]
-      (assoc base-tags :frame frame-id)
-      base-tags)))
+      (assoc tags :frame frame-id)
+      tags)))
 
 (def ^:private uncorrelated-op-types
   "Op-type classes whose emits are STRUCTURAL — not part of any cascade's
@@ -652,12 +685,14 @@
         ;; seam's orphan-drop arm keeps a cross-frame `:rf.frame/created` /
         ;; `:rf.frame/re-registered` marker out of a SIBLING frame's harvested
         ;; record (rf2-7eel71). See `uncorrelated-op-types`.
-        ;; `stamp-frame` supplies the canonical `[:tags :frame]` routing
-        ;; tag for emit sites that didn't (rf2-hbmeb); it runs for EVERY
-        ;; op-type, including the uncorrelated structural ones — those are
-        ;; exempt from inheriting the cascade's DISPATCH-ID, not from
-        ;; carrying their own frame (they already tag it explicitly, so the
-        ;; stamp is a no-op there).
+        ;; ORDER IS LOAD-BEARING: `stamp-frame` reads the dispatch-id off
+        ;; the tags `stamp-dispatch-id` just produced, because "is this
+        ;; emit inside a run?" is exactly the condition on which it
+        ;; supplies the canonical `[:tags :frame]` routing tag (rf2-hbmeb).
+        ;; A structural `:rf.frame` emit is therefore never ambient-stamped
+        ;; — it is exempt from the dispatch-id, so it reads as uncorrelated
+        ;; here — which is right: those sites tag their own frame
+        ;; explicitly, and it is deliberately NOT the ambient one.
         tags+       (stamp-frame
                       (if (contains? uncorrelated-op-types op-type)
                         base-tags

--- a/implementation/core/src/re_frame/trace/projection.cljc
+++ b/implementation/core/src/re_frame/trace/projection.cljc
@@ -163,7 +163,7 @@
   [events]
   (reduce (fn [acc ev]
             (if-let [id (dispatch-id ev)]
-              (if-let [frame (or (get-in ev [:tags :frame]) (:frame ev))]
+              (if-let [frame (get-in ev [:tags :frame])]
                 (update acc id (fnil conj #{}) frame)
                 acc)
               acc))
@@ -177,7 +177,6 @@
   default-frame traces so errors/warnings still ride with their run."
   [frame-index ev]
   (or (get-in ev [:tags :frame])
-      (:frame ev)
       (when-let [id (dispatch-id ev)]
         (let [frames (get frame-index id)]
           (when (= 1 (count frames))

--- a/implementation/core/src/re_frame/trace/tooling.cljc
+++ b/implementation/core/src/re_frame/trace/tooling.cljc
@@ -229,24 +229,27 @@
   `:rf.trace/dispatch-id` in scope) bypass the ring entirely per the
   B3 ruling — they stream live to listeners only and are never retained.
 
-  Routing chain for the destination frame-id:
-    1. `:frame` under `:tags` (the router stamps it on most in-run
-       emits).
-    2. Top-level `:frame` on the envelope.
-    3. The late-bound `:frame/current-frame-id` hook (published by
-       `re-frame.frame` at ns-load) — covers sub recompute / view
-       render emits where the call site doesn't stamp `:frame` but the
-       in-flight run's `frame/*current-frame*` is bound.
+  The destination frame-id is the event's own `[:tags :frame]` — the
+  single canonical raw-event frame path (Spec 009 §Frame identity on
+  the raw event; `re-frame.trace/trace-event-frame` is the accessor
+  consumers outside the trace subsystem read it through, and this ns
+  cannot require it — `re-frame.trace` requires THIS ns).
+
+  This used to be a three-tier chain — the tag, then a top-level
+  `:frame` on the envelope, then the late-bound
+  `:frame/current-frame-id` hook — because emit sites that didn't stamp
+  the tag left the ring nothing else to route on. `build-event` now
+  supplies the tag from the ambient frame for every such site
+  (`re-frame.trace/stamp-frame`, rf2-hbmeb), so the fallbacks were the
+  SAME resolution done a second time; keeping them would let the ring
+  and the event's own tag disagree about which frame a row belongs to.
+  There is no top-level `:frame` on a raw trace event at all.
 
   No-op in production (production never reaches the emit site)."
   [ev]
   (when interop/debug-enabled?
     (let [dispatch-id (get-in ev [:tags :rf.trace/dispatch-id])
-          frame-id    (or (get-in ev [:tags :frame])
-                          (:frame ev)
-                          (when-let [current-frame
-                                     (late-bind/get-fn-cached :frame/current-frame-id)]
-                            (current-frame)))]
+          frame-id    (get-in ev [:tags :frame])]
       ;; Frameless emits (no in-flight run) skip the ring. The B3
       ;; ruling is that frameless events stream live to listeners only
       ;; and are never retained. A `:dispatch-id` without a resolvable

--- a/implementation/epoch/src/re_frame/epoch/capture.cljc
+++ b/implementation/epoch/src/re_frame/epoch/capture.cljc
@@ -190,8 +190,18 @@
   (when interop/debug-enabled?
     (let [op       (:operation event)
           tags     (:tags event)
-          frame-id (or (:frame tags)
-                       (:frame event))]
+          ;; The canonical raw trace-event frame path, and the ONLY one
+          ;; (Spec 009 §Frame identity on the raw event — there is no
+          ;; top-level `:frame` on a raw event, and the dual
+          ;; `(or (:frame tags) (:frame event))` read this replaces is
+          ;; named there as the thing not to write). `build-event`
+          ;; supplies the tag from the ambient frame for emit sites that
+          ;; don't stamp it themselves (rf2-hbmeb), so this single read
+          ;; now resolves every frame-bound emit — including the whole
+          ;; `:rf.resource/*` / `:rf.mutation/*` family, which spells its
+          ;; frame as the EVIDENCE key `:rf.frame/id` and so was
+          ;; frame-less here, and dropped, on every real cascade.
+          frame-id (:frame tags)]
       ;; Any path below that can mutate epoch state first claims the id-keyed
       ;; stores for the exact live frame incarnation. This serialises a fresh
       ;; same-id B publication against stale A's final destroy hook.

--- a/implementation/epoch/test/re_frame/epoch_egress_resource_trace_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_egress_resource_trace_test.clj
@@ -34,17 +34,30 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.epoch :as epoch]
+            ;; rf2-hbmeb §(8) — `fx/reg-fx`, the plain fn, NOT the `rf/reg-fx`
+            ;; macro: see `drive-real-cascade!` for why the difference decides
+            ;; whether the frame's default image can still be reprojected.
+            [re-frame.fx :as fx]
             [re-frame.resources.state :as state]
             [re-frame.resources.work-ledger :as work-ledger]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
+            [re-frame.trace.tooling :as trace-tooling]
             ;; load-bearing: publishes the :resources/* late-bind hooks,
             ;; including :resources/project-resource-trace-egress.
             [re-frame.resources]
+            ;; rf2-hbmeb §(8) — the real cascade's `ensure` lowers into the
+            ;; managed-HTTP transport, which fails closed with
+            ;; `:rf.error/http-artefact-missing` unless this ns has published
+            ;; its late-bind feature probe. Test-only; production epoch stays
+            ;; http-free.
+            [re-frame.http.managed]
             [re-frame.schemas]))
 
 (def ^:private secret "topsecret-PII")
 (def ^:private big-params {:blob (apply str (repeat 5000 "x"))})
+(def ^:private plain-slug "welcome")
+(def ^:private real-owner [:app :reader 1])
 
 (use-fixtures :each
   (test-support/make-reset-runtime-fixture
@@ -687,4 +700,177 @@
       (is (= [k1] (:blocking (:tags plan))) "raw :blocking rides")
       (is (= [k1] (:identities (:tags plan))) "raw :identities rides")
       (is (= work-id (:work/id (:tags work))) "raw embedded work-id key rides"))))
+
+;; ===========================================================================
+;; (8) THE WIRING IS REACHED — driven from a REAL cascade (rf2-hbmeb)
+;; ===========================================================================
+;;
+;; Every arm above builds its record with `record-with`. That proves the
+;; PROJECTOR and it proves the epoch tool-pair's routing, but it cannot prove
+;; the projector is ever REACHED from a producer — and for the whole life of
+;; this suite it was not. `epoch.capture/capture-event!` buffers only
+;; frame-resolvable events; the `:rf.resource/*` / `:rf.mutation/*` family
+;; stamps its frame as the EVIDENCE key `:rf.frame/id` (Spec 016 / EP-0002,
+;; beside `:resource/key` and `:generation`) and never stamped the canonical
+;; `[:tags :frame]` routing tag Spec 009 §Frame identity on the raw event
+;; designates. So a real `ensure` / `release-owner` cascade put 7 family rows
+;; on the bus and 0 into the 3 epoch records it settled, and every
+;; `record-with` arm above ran green over input the runtime never produced.
+;;
+;; That is the defect these two deftests exist to make impossible to
+;; reintroduce, and they are deliberately different in kind:
+;;
+;;   - `real-cascade-lands-family-rows-...` is the SPECIFIC control. It reds if
+;;     the family stops reaching the record for any reason, and it is the arm
+;;     that satisfies rf2-hbmeb's acceptance criterion — a real record, a real
+;;     `projected-record`, a `:sensitive?` owner redacted beside a plain one
+;;     verbatim.
+;;   - `real-cascade-emits-no-frameless-correlated-row` is the GENERAL one, and
+;;     it is the assertion whose absence was the actual defect. It fixes no
+;;     vocabulary and names no family: it says every row a cascade emits INTO a
+;;     run carries the one frame path every reader resolves on. A future family
+;;     that spells its frame some third way reds here on the day it lands,
+;;     rather than being discovered a release later by someone measuring the
+;;     bus against the record by hand.
+
+(defn- family-row?
+  "Whether `ev` is a resource/mutation-family trace row — the same namespace
+  test the epoch tool-pair's `resource-family-op?` makes when routing a row to
+  the family projector."
+  [ev]
+  (boolean (some-> (:operation ev) namespace #{"rf.resource" "rf.mutation"})))
+
+(defn- drive-real-cascade!
+  "Drive a REAL resource cascade against `:test/rt` and return every trace row
+  it put on the bus, in emit order.
+
+  Two `ensure`s under one shared owner — the `:sensitive?` resource carrying
+  the secret in its params, the PLAIN one beside it as the over-redaction
+  control — then a `release-owner`. `fx/reg-fx` (the plain fn, NOT the
+  `rf/reg-fx` macro) overrides managed-HTTP with a no-op so `ensure` writes its
+  `:loading` entry and emits its lifecycle rows without a request leaving the
+  box; the macro would stamp this ns as a second provenance under one fx id and
+  the frame's next default-image reprojection would die on
+  `:rf.error/image-duplicate-id`."
+  []
+  (fx/reg-fx :rf.http/managed (fn [_ctx _args] nil))
+  (let [rows (atom [])
+        k    ::real-cascade-recorder]
+    (trace-tooling/register-listener! k (fn [ev] (swap! rows conj ev)))
+    (try
+      (rf/dispatch-sync [:rf.resource/ensure
+                         {:resource :secret/article
+                          :params   {:auth-token secret}
+                          :owner    real-owner}]
+                        {:frame :test/rt})
+      (rf/dispatch-sync [:rf.resource/ensure
+                         {:resource :plain/article
+                          :params   {:slug plain-slug}
+                          :owner    real-owner}]
+                        {:frame :test/rt})
+      (rf/dispatch-sync [:rf.resource/release-owner {:owner real-owner}]
+                        {:frame :test/rt})
+      (finally (trace-tooling/unregister-listener! k)))
+    @rows))
+
+(defn- settled-family-rows
+  "Every resource/mutation row across the `:trace-events` of every epoch record
+  the frame has settled — what an Xray / MCP consumer reading `watch-epochs`
+  actually sees."
+  [frame-id]
+  (filterv family-row? (mapcat :trace-events (rf/epoch-history frame-id))))
+
+(deftest real-cascade-lands-family-rows-in-the-settled-epoch-record
+  (testing "rf2-hbmeb — the rows a REAL `ensure` / `release-owner` cascade emits
+            reach the settling epoch record's `:trace-events`, and
+            `projected-record` over THAT record (not a hand-built one) redacts a
+            `:sensitive?` owner's scope + params while a plain owner's ride
+            verbatim. Before the capture-seam fix the bus carried 7 family rows
+            and the 3 settled records carried 0, so every `record-with` arm in
+            this file proved a projector nothing reached."
+    (let [bus-rows    (drive-real-cascade!)
+          bus-family  (filterv family-row? bus-rows)
+          rec-family  (settled-family-rows :test/rt)]
+
+      (testing "FIXTURE — the cascade really emitted family rows carrying the
+                real secret, so the assertions below are not passing over an
+                empty set"
+        (is (seq bus-family) "the cascade put family rows on the bus")
+        (is (contains-secret? bus-family)
+            "and they carry the raw secret — the projector's input is the
+             producer's own output, not an invented tag map"))
+
+      (testing "ACCEPTANCE — nothing the cascade emitted into a run is dropped
+                on the way to the record"
+        (is (= (count bus-family) (count rec-family))
+            "every family row on the bus reached a settled record's
+             :trace-events — this is the count that read 7 vs 0")
+        (is (= (frequencies (map :operation bus-family))
+               (frequencies (map :operation rec-family)))
+            "and row-for-row by operation, so a partial arrival cannot pass"))
+
+      (testing "the epoch-side family projector runs over a REAL record"
+        ;; Every record the cascade settled, projected — the epoch stream an
+        ;; off-box consumer reads through `watch-epochs`. Across records
+        ;; because one dequeued event is one record: the sensitive `ensure`,
+        ;; the plain `ensure` and the `release-owner` each settle their own,
+        ;; and the two-sided control needs both owners.
+        (let [proj-rows (->> (rf/epoch-history :test/rt)
+                             (map epoch/projected-record)
+                             (mapcat :trace-events)
+                             (filterv family-row?))
+              sens      (->> proj-rows
+                             (filter #(= :secret/article
+                                         (second (:resource/key (:tags %)))))
+                             first
+                             :tags)
+              plain     (->> proj-rows
+                             (filter #(= :plain/article
+                                         (second (:resource/key (:tags %)))))
+                             first
+                             :tags)]
+          (is (= (count rec-family) (count proj-rows))
+              "the settled records carry family rows of their own, and
+               projection neither drops nor invents one")
+          (testing "the :sensitive? owner's scoped key tokenizes"
+            (is (some? sens) "a sensitive-owner row is present in the record")
+            (is (= :secret/article (second (:resource/key sens)))
+                "its resource-id survives for attribution")
+            (is (redacted-component? (first (:resource/key sens)))
+                "its resolved scope is tokenized")
+            (is (redacted-component? (nth (:resource/key sens) 2))
+                "its canonical params are tokenized")
+            (is (true? (:sensitive? sens)) "the row is stamped :sensitive?"))
+          (testing "and the PLAIN owner's rides VERBATIM in the same record —
+                    over-redaction fails as loudly as leaking"
+            (is (some? plain) "a plain-owner row is present in the record")
+            (is (= [:rf.scope/global :plain/article {:slug plain-slug}]
+                   (:resource/key plain))
+                "scope and params intact")
+            (is (not (:sensitive? plain)) "a plain row is NOT stamped sensitive"))
+          (testing "no raw secret egresses from the projected REAL record's
+                    family rows"
+            (is (not (contains-secret? proj-rows)))))))))
+
+(deftest real-cascade-emits-no-frameless-correlated-row
+  (testing "rf2-hbmeb, the general form — EVERY trace row emitted inside a run
+            (one carrying a `:rf.trace/dispatch-id`) carries frame identity at
+            `[:tags :frame]`, the single canonical raw-event frame path of Spec
+            009 §Frame identity on the raw event.
+
+            This is the assertion whose absence WAS the defect. Three
+            independent consumers resolve a row's frame — the per-frame trace
+            ring, the frame trace-disable policy gate, and epoch capture — and
+            a row that reaches none of them consistently is silently absent
+            from whichever one lacks a fallback. It named no family on purpose:
+            the resource family is simply the one that was wrong, and the next
+            one to spell its frame a third way reds here."
+    (let [rows        (drive-real-cascade!)
+          correlated  (filterv #(some? (:rf.trace/dispatch-id (:tags %))) rows)
+          frameless   (remove #(some? (:frame (:tags %))) correlated)]
+      (is (seq correlated)
+          "FIXTURE — the cascade emitted correlated rows to check")
+      (is (empty? frameless)
+          (str "every correlated row must carry [:tags :frame]; frameless ops: "
+               (pr-str (frequencies (map :operation frameless))))))))
 

--- a/implementation/epoch/test/re_frame/epoch_mcp_egress_conformance_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_mcp_egress_conformance_test.clj
@@ -389,17 +389,19 @@
   for a plain one.
 
   The rows are harvested off the trace bus rather than read out of the settled
-  epoch record because epoch CAPTURE DROPS THEM: `epoch.capture/capture-event!`
-  derives an event's frame as `(or (:frame tags) (:frame event))`, and the whole
-  family stamps `:rf.frame/id` — so `frame-id` is nil for every row and nothing
-  is buffered. Measured, not inferred: this cascade puts 7 family rows on the bus
-  and 0 into the 3 epoch records it settles. That is a real bug (fidelity: the
-  resource lifecycle is absent from every epoch a tool reads; coverage: the
-  epoch-side projector has never run over a real record) and it is filed as
-  rf2-hbmeb, NOT fixed here — the repair is a production capture-seam change,
-  outside this bead's one-fixture-gains-one-family fence. Until it lands, a real
-  record carrying real family rows is assembled by splicing
-  (`record-carrying-resource-rows`)."
+  epoch records because ONE record is one dequeued event: this cascade is three
+  dispatches, so its 7 family rows are spread across 3 records (the sensitive
+  `ensure`'s, the plain `ensure`'s, the `release-owner`'s). Every scan below
+  wants them together, which `record-carrying-resource-rows` assembles.
+
+  They used also to be harvested here because epoch capture DROPPED them
+  outright — `capture-event!` resolved an event's frame from `[:tags :frame]`
+  and the whole family stamped only its `:rf.frame/id` EVIDENCE key, so the
+  cascade put 7 rows on the bus and 0 into the 3 records it settled. Fixed in
+  rf2-hbmeb: `build-event` now supplies the canonical `[:tags :frame]` routing
+  tag for emit sites that don't stamp one, and the rows land. The proof that
+  they do — bus counted against record, over a real cascade — lives in
+  `epoch_egress_resource_trace_test`'s §(8)."
   [frame-id]
   (let [rows (atom [])
         k    ::resource-family-recorder]
@@ -422,10 +424,17 @@
     @rows))
 
 (defn- record-carrying-resource-rows
-  "The frame's last REAL epoch record with `rows` appended to its
-  `:trace-events` — the record a forwarder would ship if epoch capture retained
-  the family (rf2-hbmeb). Everything else about the record is the producer's:
-  its own trace rows, `:sub-runs`, `:effects`, bookkeeping slots and frame."
+  "The frame's last REAL epoch record with the cascade's WHOLE set of family
+  rows appended to its `:trace-events` — one record carrying every row the
+  scans below want to see at once, which no single real record does (one record
+  is one dequeued event, and this cascade is three). Everything else about the
+  record is the producer's: its own trace rows, `:sub-runs`, `:effects`,
+  bookkeeping slots and frame.
+
+  Since rf2-hbmeb the record already carries its OWN family rows, so the last
+  record's `:rf.resource/owner-released` appears twice here. Harmless: every
+  scan below is either a whole-set leak scan or a `first`-match lookup by
+  `[operation resource-id]`, and both read the same row either way."
   [frame-id rows]
   (update (last (rf/epoch-history frame-id)) :trace-events (fnil into []) rows))
 


### PR DESCRIPTION
Fixes **rf2-hbmeb** (P1, bug).

> **Read this first if you saw the earlier red.** Two things are true at once, and
> they are easy to conflate. **`:frame` and `:rf.frame/id` do mean different
> things** — and this PR never converged them. It renames nothing, and touches
> **zero** of the 195 `:rf.frame/id` sites in the tree. The four suites that
> reddened were reddened by a different, narrower defect of mine — an
> over-broad stamp — diagnosed and fixed in `06573b4c`. All four are green.
> §*The red, and what it actually was* has the evidence.

## The two spellings, and why nothing was converged

They are different keys for different jobs, and the fix depends on that being
true rather than papering over it:

| | `[:tags :frame]` | `:rf.frame/id` |
|---|---|---|
| layer | the **raw trace-event wire shape** | the **event-context / carried-frame stamp** |
| owner | Spec 009 §*Frame identity on the raw event* | Spec 002 §*One carrier, one name*; EP-0002 R3 |
| means | which frame's ring / epoch / history this **trace row** belongs to | the frame stamp a **handler context, reply envelope or ledger row** carries |
| read by | `trace-event-frame` (the one canonical accessor) | handler destructuring, reply verification, work-ledger identity |
| on a raw trace event | the **only** frame path — "there is no public top-level `:frame`" | present only where a family **also copies it in as evidence** |

The resource family stamps `:rf.frame/id` into its trace tags for a real reason
— it is the same qualified stamp its reply envelopes and ledger rows carry, so a
tool can join a trace row to a work record. That is evidence, and it stays. What
the family never stamped is the *routing* tag. Both facts can be true; the row
needs both keys, and now has both.

So: **no rename, no shim, no reader taught a second spelling.** Every reader in
the tree still reads exactly one key for exactly one purpose.

## What was broken

`re-frame.epoch.capture/capture-event!` buffers only events whose frame it can
resolve, and resolved it as `(or (:frame tags) (:frame event))` — both nil for
every row in the `:rf.resource/*` / `:rf.mutation/*` family, because the family
stamps only its `:rf.frame/id` evidence key. Every branch that buffers is inside
`(when (and frame-id …) …)`, so nothing was buffered.

The consequence that made this P1 is second-order: the epoch-side resource-egress
projector had **never run over a real record**. Every arm in
`epoch_egress_resource_trace_test.clj` hand-builds its input with `record-with`,
so the suite proved the projector while proving nothing about whether the wiring
is reached — and it was not.

## Measured, not inferred

A real cascade on `:test/mcp` — `[:rf.resource/ensure {:resource :secret/article …}]`,
the same for a plain resource under the same owner, then `[:rf.resource/release-owner …]`.

| | before | after |
|---|---:|---:|
| family rows on the trace bus | 7 | 7 |
| …carrying `[:tags :frame]` | **0** | **7** |
| …carrying `:rf.frame/id` | 7 | 7 |
| …carrying a top-level `:frame` | 0 | 0 |
| epoch records settled | 3 | 3 |
| their `:trace-events` counts | `[9 9 8]` = 26 | `[12 12 9]` = 33 |
| **family rows reaching those records** | **0** | **7** |
| per-frame raw trace ring | 33 events | 33 events |
| …family rows in it | 7 | 7 |
| ring rows lacking `[:tags :frame]` | 7 | **0** |

Two corrections to the filed bead, both from measurement:

- **The bead says the rows "still ride the raw trace ring". True, and the reason
  is the whole diagnosis.** `trace.tooling/push-to-ring!` had a **third** fallback
  tier — the late-bound `:frame/current-frame-id` hook — that `capture-event!`
  did not. Two of the three frame resolvers in the tree (the ring, and the frame
  trace-disable policy gate) fell back to the ambient frame; epoch capture was
  the one that did not. That is the drift, and it decided the shape of the fix.
- **The mismatch is exactly "every row of the family", and nothing wider.** In
  the same cascade all 26 non-family rows carried `[:tags :frame]`; the 7
  frameless rows were the family's, all 7.

## The fix, at one seam

`re-frame.trace/build-event` supplies the canonical `[:tags :frame]` tag from the
ambient frame, under **two** conditions — both from Spec 009, and the second is
the one the first revision got wrong:

1. the emit site didn't already supply a `:frame` (explicit tags always win —
   `:rf.frame/created`'s cross-frame `{:frame B}`, rf2-7eel71); **and**
2. the emit is **inside a run** — its tags carry a `:rf.trace/dispatch-id`.
   Spec 009: `trace-event-frame` returns "nil for an event emitted outside any
   frame-qualified run (registry-time / boot-time)".

~100 family emit sites are left exactly as they are. That is the point: the fact
is supplied **once**, in the producer every reader already goes through, so no
future emit site inside a run can forget it — which is how this bug happened.

With it supplied once, duplicated resolution collapses rather than being left:

- `trace.tooling/push-to-ring!` — three-tier chain → the single canonical read.
  Provably behaviour-preserving under condition 2: it discards any event without
  a dispatch-id *before* it consults a frame at all.
- `epoch.capture/capture-event!` — the dual `(or (:frame tags) (:frame event))`
  → the single canonical read. Spec 009 names that exact dual read as the thing
  not to write.
- `trace.projection` — `frame-index` / `bundle-frame` lose their top-level
  `:frame` tier (there is no top-level `:frame` on a raw trace event).
- `trace/tagged-frame-trace-disabled?` and `stamp-frame` share one
  `ambient-frame-id`, with the **asymmetry documented rather than papered over**:
  suppression asks where an emit came *from* (rf2-yl4c0s — answerable outside a
  run), identity asks which frame it belongs *to*. Same reader, different reach.

## The red, and what it actually was

The first revision applied condition 1 but not condition 2, so it stamped the
ambient frame onto emits fired **outside any run**. Four suites assert exactly
that clause, and all four reddened:

| suite | test | why |
|---|---|---|
| machines ×3 | `machine_cofx_lint_test` | `reg-machine` lint warnings, exact-tags equality — registry-time |
| schemas ×1 | `fx-args-validation-direct-call-shape` | assertion is literally *"direct 4-arity call emits no `:frame` (runtime callers supply it)"* |
| ui ×1 | `carried-subscribe-warning-conforms-to-emitted-envelope` | the cross-frame carried-op warning names `:origin-frame` / `:ambient-frame` and carries no bare `:frame` — the stamp injected the very ambient frame the warning exists to complain about |
| CLJS ×9 | Xray preload arms | expect frameless synthetic emits in the **frameless** secondary ring; got 0, because they were no longer frameless |

**On reading that output**, since the direction is load-bearing and easy to
invert. The ui assertion is:

```clojure
(is (= #{:origin-frame :ambient-frame :rf.sub/query-v :reason}   ; ← the literal: EXPECTED
       (set (keys tags))))                                        ; ← produced
```

`clojure.test` prints `actual: (not (= <first> <second>))` in argument order, so
in `(not (= #{4 keys} #{5 keys incl :frame}))` the **4-key set is the test's
expectation and the 5-key set is what my code produced**. The change was *adding*
`:frame` where those tests require it absent — not removing it. Same shape in
machines: the literal 4-key map is the expectation; the map carrying
`:frame :rf/default` is the produced value.

And that `:rf/default` is not a frame-resolution floor surfacing. It is the
**test fixture's own ambient frame**: `make-reset-runtime-fixture` ensures a
`:rf/default` frame and binds it as `*current-frame*`, and the over-broad stamp
read it at registry time where it had no business. Under condition 2 the emit is
uncorrelated, so nothing is read and nothing is stamped.

**`JVM ui` was a genuine signal, not F6e donor noise** — it caught a real defect
in my change, and `implementation/ui/**` was not edited.

## Enumeration of both spellings

Full inventory in `src` (tests excluded), which is the deliverable the review
asked for. **Rows changed by this PR: 4, all in the `[:tags :frame]` column.**

### `:rf.frame/id` — 195 sites, **0 changed**

Every site below is untouched. Three distinct meanings, none of them a raw-trace
routing tag:

- **event-context stamp** (handlers destructure `{frame-id :rf.frame/id}`) —
  `core/events`, `core/frame`, `core/fx`, `core/live_frame`, `core/router`,
  `core/spec`, `routing/*` (16 across 8 files), `ssr/hydrate` (3).
- **reply-envelope / ledger identity** — `core/reply` (7), `http/reply` (6),
  `http/transport` (2), `machines/reply` (12),
  `machines/lifecycle_fx/registration` (2), `resources/reply` (8),
  `resources/reply_handlers` (6), `resources/work_ledger` (4),
  `resources/transport*` (7), `xray/reply_envelope` (9),
  `xray/image_view_*` (3), `story/assertions` (3).
- **resource/mutation trace evidence key** — `resources/events` (73),
  `resources/mutation_events` (21), `resources/ssr` (7), `resources/timers` (1),
  `resources/registry` (1), `resources/trace_egress` (2),
  `epoch/tool_pair` (2), `core/trace` (1 docstring).

`epoch/tool_pair`'s `omit-off-box-resource-trace-keys` reads
`(or (:rf.frame/id (:tags ev)) frame-id)` — correct and unchanged: it is reading
the family's **evidence** key, which is what it wants.

### `[:tags :frame]` — the raw-trace routing tag

| site | role | changed? |
|---|---|---|
| `trace/build-event` | **producer** | **yes** — supplies it under the 2 conditions |
| `trace/trace-event-frame` + `frame-of` | the canonical accessor | no |
| `trace/tagged-frame-trace-disabled?` | suppression gate | refactored onto shared `ambient-frame-id`; reach unchanged |
| `trace.tooling/push-to-ring!` | per-frame ring routing | **yes** — 3 tiers → 1 |
| `epoch.capture/capture-event!` | epoch buffering | **yes** — dual read → 1 |
| `trace.projection` `frame-index` / `bundle-frame` | bundle grouping | **yes** — drops the top-level tier |
| `classification/project-trace-event` (×2) | per-frame elision policy | no |
| `epoch.cljc` silence-current | listener silencing | no |
| `ssr/error_listener` | server-frame filter | no |
| `story/config`, `error`, `play`, `recorder`, `runtime`, `ui/trace_buffer` | per-variant routing + redaction | no |
| `xray/epoch/projection` (×2), `xray/reply_envelope` | panel routing | no |
| `re-frame2-pair-mcp/subscribe` | MCP subscription filter | no |

Nothing in this column reads `:rf.frame/id`, and nothing in the previous column
reads `[:tags :frame]`. The two vocabularies stay disjoint.

## Newly-reaching rows: does anything new egress?

**No.** Measured, because the fix delivers 7 more rows to the egress projector
and rf2-1kiuj is open in the same artefact. Raw-secret leaf paths across every
projected record of the same real cascade:

| | before | after |
|---|---:|---:|
| projected `:trace-events` rows | 26 | 33 |
| family rows among them | 0 | 7 |
| **raw-secret paths, total** | **18** | **18** |
| …in family rows | 0 | 0 |
| leaking ops | `:rf.fx/handled` ×4, `:rf.fx/do-fx` ×2 | identical |

The 7 rows that newly reach the record egress **nothing** raw — they route
through `resources.trace-egress/project-resource-trace-egress`, which handles
them correctly, for the first time over producer output.

**rf2-1kiuj is unchanged: 18 paths before, 18 after, same rows, same ops.** Its
leak is on `:rf.fx/*` rows that already carried `[:tags :frame]` and already
reached the records; `resource-family-op?` routing skips them so the family
projector never runs. Nothing here makes it worse or better. (My count differs
from the bead's 14 because I count map-key occurrences too and my fixture carries
a plain resource alongside the sensitive one; same ops, same rows.)

## The assertion that would have caught it

Two new arms in `epoch_egress_resource_trace_test.clj` §(8):

- **`real-cascade-lands-family-rows-in-the-settled-epoch-record`** — the specific
  control and the bead's acceptance criterion. Bus rows counted against rows
  reaching the settled records (and compared by `:operation` frequency, so a
  partial arrival cannot pass); then `projected-record` over those **real**
  records, redacting the `:sensitive?` owner while the plain owner rides verbatim.
- **`real-cascade-emits-no-frameless-correlated-row`** — the general one, and its
  absence *was* the defect. It names no family: every row emitted **into a run**
  must carry `[:tags :frame]`. Note it already encoded the correlated-only rule
  the fix now enforces — the assertion was right before the implementation was.

### Negative control

Reverting the four source files to their pre-fix state and re-running reds
**10 assertions**:

```
FAIL real-cascade-lands-family-rows-in-the-settled-epoch-record
expected: (= (count bus-family) (count rec-family))
  actual: (not (= 7 0))
expected: (= (frequencies (map :operation bus-family)) (frequencies (map :operation rec-family)))
  actual: (not (= #:rf.resource{:work-started 2, :fetch-started 2, :owner-attached 2, :owner-released 1} {}))
…the five sensitive-owner projections and the plain-owner control, all nil…

FAIL real-cascade-emits-no-frameless-correlated-row
expected: (empty? frameless)
  actual: (not (empty? (…all 7 rows, each printing :tags {:rf.frame/id :test/rt …}…)))
```

Restored: `24 tests / 127 assertions, 0 failures, rc=0`.

## Not touched

- **`spec/009-Instrumentation.md` — no edit needed, none made.** The fix makes
  009's existing sentences true by construction rather than contradicting either
  of them. A prose refinement (the *producer* supplies the tag, rather than each
  emit site) would help whoever owns 009 rows next, but is not required here.
- **rf2-1kiuj** — measured above, deliberately left alone.
- **rf2-1zc33** — untouched, still held for its ruling.
- **`implementation/ui/**`** — not edited, per the F6e rescoping ruling.
- `epoch_mcp_egress_conformance_test.clj` gets docstring corrections only (its
  `drive-resource-family!` note asserted the capture gap as current fact, now
  false on main). No assertion changed; restructuring it belongs to rf2-1kiuj.

## Quality gates

Baselines re-derived in this worktree at `origin/main` (5026a73078) before any
edit — epoch / resources / core match the dispatch brief's figures.

| gate | baseline | after | exit code |
|---|---|---|---:|
| `implementation/epoch` `clojure -M:test` | 478 / 6503, 0F 0E | **480 / 6519, 0F 0E** | `rc=0` |
| `implementation/resources` `clojure -M:test` | 731 / 6781, 0F 0E | **731 / 6781, 0F 0E** | `rc=0` |
| `implementation/core` `clojure -M:test` | 2115 / 10456, 0F 0E | **2115 / 10456, 0F 0E** | `rc=0` |
| `implementation/machines` `clojure -M:test` | — | **1195 / 4164, 0F 0E** | `rc=0` |
| `implementation/schemas` `clojure -M:test` | — | **363 / 19188, 0F 0E** | `rc=0` |
| `implementation/ui` `clojure -M:test` | — | **702 / 17608, 0F 0E** | `rc=0` |
| `scripts/test-jvm-tools.sh` | — | all suites, 0F 0E | `rc=0` |
| `npm run test:cljs` | ~11462 / 57397 | **11462 / 57398, 0F 0E** | `rc=0` |
| `scripts/test-fast-pr.sh` | — | **`PASS fast PR spine`**, per-ns isolation 17/17 | `rc=0` |
| negative control (4 src files reverted) | — | 24 / 127, **10 failures** | `rc=1` |

**CI on the tip: 62 pass, 13 skipping, 0 fail.** The four suites that reddened
the first revision — `JVM machines`, `JVM schemas`, `JVM ui`,
`CLJS (:node-test)` — all pass.

The epoch delta is exactly the two new deftests (+2 tests, +16 assertions);
machines / schemas / ui / resources / core are unchanged from their own
baselines. Every `rc` is `$?` captured immediately into a worktree-local log and
cross-checked against that log's own `Ran … / N failures` verdict line.
