### PR TITLE
scripts: teach the lane-bijection gate the test shapes it could not see (rf2-4hc9p); rf2-6tags Tags arm held on a row ruling

### DIFF
--- a/scripts/check_test_lane_bijection.py
+++ b/scripts/check_test_lane_bijection.py
@@ -37,17 +37,32 @@ that defines it:
 A new artefact, a new build, a renamed directory or a retightened regex is
 therefore picked up by construction.
 
-WHAT COUNTS AS A TEST FILE.  A file that carries at least one TOP-LEVEL
-`(deftest` -- column 0, which is where every one of the repo's deftests is
-written.  Naming is not consulted, so a test file that does not follow the
-`_test` filename convention is still in the universe.  This also makes the
-repo's one deftest GENERATOR
-(`implementation/core/test/re_frame/adapter/react_shared_suite_tests.clj`, a
-`defmacro` whose expansion emits the deftests, invoked from the namespaces that
-want the shared suite) fall out for free: it has no top-level deftest of its
-own, so it is not a test file and needs no exemption.
+WHAT COUNTS AS A TEST FILE.  A file that evaluates at least one test-defining
+form AT THE TOP LEVEL.  Naming is not consulted, so a test file that does not
+follow the `_test` filename convention is still in the universe.  Top level is
+decided by reading the enclosing forms, not by the column the form starts in:
 
-THE FOUR RULES
+  * `(deftest ...)`, bare or namespace-qualified (`cljs.test/deftest`);
+  * the same, inside a reader conditional (`#?(:cljs (deftest ...))`) and/or a
+    `do` -- both are transparent to the reader, so what they wrap IS top level.
+    Column 0 was the original test, and it could not see either shape;
+  * a call to a macro whose expansion emits deftests.  The roster of such
+    macros is DERIVED, not listed: any `(defmacro NAME ...)` in the scanned
+    tree whose body contains a `deftest` form makes a top-level `(NAME ...)`
+    call a test definition.  The macro's own file stays a non-test file, since
+    the deftest there sits inside the `defmacro`, which is not transparent.
+
+Comments and string bodies are masked before any of this, because the repo's
+test files discuss `deftest` in prose at length.
+
+CLASSIFIED BY THE DECLARED NAMESPACE.  A lane selector is applied by the
+runner to the namespace the file DECLARES, so this gate reads `(ns ...)` rather
+than deriving a name from the file path.  Deriving it was a second false green:
+editing only the declared suffix moves the file out of a lane's selector while
+a path-derived name goes on matching, so the lane silently sheds the file and
+the gate goes on reporting it covered.
+
+THE FIVE RULES
 
   B1  ORPHAN FILE.  A test file must be selected by at least one lane that can
       load it (`.clj` -> JVM lanes, `.cljs` -> CLJS lanes, `.cljc` -> either).
@@ -84,6 +99,11 @@ THE FOUR RULES
       flag.  Same declaration, same teeth, one tier earlier than the runner's
       own runtime check.
 
+  B5  UNREADABLE NAMESPACE.  A test file must declare exactly one namespace.
+      With none, or with two that disagree, there is no name to apply a
+      selector to -- and a gate that quietly fell back to a path-derived guess
+      would be back to the false green B5 exists to remove.
+
 Counts belong in a PR body where they carry a date; this file states rules.
 """
 
@@ -114,7 +134,127 @@ SHADOW_DEFAULT_NS_REGEXP = r"-test$"
 #: A `.cljc` test namespace declaring that the JVM lane is its only lane.
 JVM_ONLY_SUFFIX = "-jvm-test"
 
-TOP_LEVEL_DEFTEST = re.compile(r"^\(deftest", re.MULTILINE)
+#: The token immediately after an opening delimiter -- a form's head.
+FORM_HEAD = re.compile(r"[^\s()\[\]{}\"';`~@,^]+")
+
+#: A head that is `deftest`, bare or namespace-qualified (`cljs.test/deftest`).
+DEFTEST_HEAD = re.compile(r"(?:[^\s()\[\]{}/]+/)?deftest\Z")
+
+#: The same as an opening form, for scanning a `defmacro` body.
+DEFTEST_FORM = re.compile(r"\((?:[^\s()\[\]{}/]+/)?deftest[\s()\[\]{}]")
+
+#: A `deftest` form in column 0 -- the shape almost every test file uses, and
+#: the only one the pre-repair gate could see.  Kept as a fast path.
+TOP_LEVEL_DEFTEST = re.compile(r"^\((?:[^\s()\[\]{}/]+/)?deftest[\s()\[\]{}]",
+                               re.MULTILINE)
+
+DEFMACRO_FORM = re.compile(r"\(defmacro\s+([^\s()\[\]{}]+)")
+
+#: Forms the reader sees through: what they wrap is still top level.  A reader
+#: conditional is recorded as `#?` whatever platform keyword heads it.
+TRANSPARENT_HEADS = frozenset({"#?", "do"})
+
+#: `(ns name)`, tolerating any number of metadata prefixes (`^{:doc ...}`,
+#: `^:no-doc`).  Anchored at column 0: an `ns` form is never nested.
+NS_FORM = re.compile(r"^\(ns\s+(?:\^(?:\{[^}]*\}|[^\s()\[\]{}]+)\s+)*([^\s()\[\]{}]+)",
+                     re.MULTILINE)
+
+
+#: A character literal, a string, or a `;` comment -- the three spans whose
+#: contents are not structure.  The char-literal branch is FIRST and is the
+#: only captured one, so a `\\"` or `\\;` survives (it is code) while a string
+#: or a comment is dropped; `sub(r"\\1")` therefore needs no Python callback,
+#: which is what keeps a 40 MB scan at C speed.
+MASKABLE = re.compile(r'(\\.)|"[^"\\]*(?:\\.[^"\\]*)*"|;[^\n]*', re.DOTALL)
+DELIMITERS = re.compile(r"[()\[\]{}]")
+
+
+def mask_source(text: str) -> str:
+    """Drop `;` comments and string bodies, leaving code and its line structure.
+
+    Every recogniser below reads CODE only.  The repo's test files discuss
+    `deftest` in docstrings and comments at length -- one of them spends a
+    paragraph on how a map-form `use-fixtures` "SILENTLY SKIPS every deftest"
+    -- so an unmasked scan reads prose as structure.
+
+    A comment's own newline is outside the match and survives, and a string is
+    replaced in place, so no newline is ever ADDED: a form that began a line
+    still begins one, and a form that did not cannot come to.  Newlines INSIDE
+    a string go with it, which is the point -- a docstring that quotes an
+    `(ns ...)` form must not read as a second declaration.
+    """
+    return MASKABLE.sub(r"\1", text)
+
+
+def top_level_heads(masked: str):
+    """Yield the head of every form the reader evaluates at the top level.
+
+    One pass over the delimiters, carrying the stack of enclosing heads.  A
+    form counts as top level when every form enclosing it is transparent -- a
+    reader conditional or a `do`.  That is what makes `#?(:cljs (deftest ...))`
+    and `#?(:clj (do ... (deftest ...)))` reachable while a `deftest` inside a
+    `defmacro` (the suite generator) correctly stays out of reach.
+    """
+    stack = []
+    for match in DELIMITERS.finditer(masked):
+        i = match.start()
+        if match.group(0) in "([{":
+            if masked[max(i - 3, 0):i] == "#?@" or masked[max(i - 2, 0):i] == "#?":
+                head = "#?"
+            else:
+                m = FORM_HEAD.match(masked, i + 1)
+                head = m.group(0) if m else ""
+            if all(h in TRANSPARENT_HEADS for h in stack):
+                yield head
+            stack.append(head)
+        elif stack:
+            stack.pop()
+
+
+def deftest_emitting_macros(masked_texts) -> set:
+    """Names of macros whose expansion emits deftests, derived from the tree.
+
+    A roster of generator macros written here would be the staleness class the
+    gate exists to catch, so it is read off the `defmacro` forms themselves: a
+    macro whose body contains a `deftest` form emits tests, and a top-level
+    call to it therefore defines them.
+    """
+    names = set()
+    for masked in masked_texts:
+        for m in DEFMACRO_FORM.finditer(masked):
+            try:
+                body = masked[m.start():match_delimiter(masked, m.start())]
+            except ValueError:
+                continue
+            if DEFTEST_FORM.search(body):
+                names.add(m.group(1))
+    return names
+
+
+def defines_tests(masked: str, macro_names) -> bool:
+    # The overwhelmingly common shape, on MASKED text so it cannot be a
+    # docstring line: `(deftest` in column 0.  Recognising it without walking
+    # the delimiters is what keeps the scan's runtime where it was.
+    if TOP_LEVEL_DEFTEST.search(masked):
+        return True
+    for head in top_level_heads(masked):
+        if DEFTEST_HEAD.match(head):
+            return True
+        if head in macro_names:
+            return True
+        slash = head.rfind("/")
+        if slash != -1 and head[slash + 1:] in macro_names:
+            return True
+    return False
+
+
+def declared_namespaces(masked: str):
+    """Every distinct namespace the file declares, in order of appearance."""
+    seen = []
+    for m in NS_FORM.finditer(masked):
+        if m.group(1) not in seen:
+            seen.append(m.group(1))
+    return seen
 
 #: Build output and dependency trees.  Nothing under them defines a lane or a
 #: test the lanes select, and walking them dominates the runtime.
@@ -389,12 +529,15 @@ def jvm_lanes(repo: Path):
 
 
 # --------------------------------------------------------------------------
-# The universe: files under a lane root that define a top-level deftest
+# The universe: files under a lane root that define tests at the top level
 # --------------------------------------------------------------------------
 
 @dataclass
 class TestFile:
     path: Path
+    #: The namespace the file DECLARES -- the name a lane selector is applied
+    #: to.  None when the declaration is missing or self-contradictory, which
+    #: B5 reports and which removes the file from selector-based reasoning.
     ns: str
     ext: str
     #: True when some CLJS lane root that OWNS its tree contains this file.
@@ -402,17 +545,24 @@ class TestFile:
     #: Every ancestor directory, as strings, so "is this file under one of the
     #: lane's roots?" is a set intersection rather than a walk per (lane, root).
     ancestors: frozenset = frozenset()
+    #: Set when the `(ns ...)` declaration could not be read (B5).
+    ns_problem: str = ""
 
 
 def discover(lanes, repo: Path):
-    """Map every lane root to its test files, keyed by (path, derived ns).
+    """Every test-defining file under a lane root, keyed by path.
 
     A root is walked once and a file is read once no matter how many lanes share
     it -- every CLJS build in `implementation/shadow-cljs.edn` shares one
     `:source-paths` vector, so the naive shape re-reads the whole tree per lane.
+
+    Two passes over that one read: the first derives the roster of macros whose
+    expansion emits deftests, the second classifies each file against it.  The
+    order matters -- a file whose only test definition is a call to such a macro
+    is invisible until the roster exists.
     """
-    defines_test = {}       # absolute path -> bool
-    walked = {}             # root -> [(path, ext)] of test-defining files
+    sources = {}            # absolute path -> raw text
+    walked = {}             # root -> [(path, ext)] of candidate files
     found = {}
 
     def scan(root: Path):
@@ -427,26 +577,63 @@ def discover(lanes, repo: Path):
                     continue
                 path = Path(dirpath) / filename
                 key = str(path)
-                if key not in defines_test:
+                if key not in sources:
                     try:
-                        defines_test[key] = bool(TOP_LEVEL_DEFTEST.search(
-                            path.read_text(encoding="utf-8")))
+                        sources[key] = path.read_text(encoding="utf-8")
                     except (UnicodeDecodeError, OSError):
-                        defines_test[key] = False
-                if defines_test[key]:
-                    hits.append((path, ext))
+                        sources[key] = ""
+                hits.append((path, ext))
         walked[root] = hits
         return hits
 
     for lane in lanes:
+        for root, _owned in lane.roots:
+            scan(root)
+
+    # Pass 1 -- the generator-macro roster, read off the tree's own `defmacro`
+    # forms.  Only files that carry both tokens can contribute one.
+    macro_names = deftest_emitting_macros(
+        mask_source(text) for text in sources.values()
+        if "defmacro" in text and "deftest" in text)
+
+    # Pass 2 -- classify.  The substring pre-filter keeps masking off the ~40%
+    # of scanned files that mention neither, which is what holds the runtime.
+    classified = {}
+
+    def classify(key: str):
+        if key in classified:
+            return classified[key]
+        text = sources[key]
+        if "deftest" not in text and not any(name in text for name in macro_names):
+            classified[key] = (False, None, "")
+            return classified[key]
+        masked = mask_source(text)
+        if not defines_tests(masked, macro_names):
+            classified[key] = (False, None, "")
+            return classified[key]
+        names = declared_namespaces(masked)
+        if len(names) == 1:
+            classified[key] = (True, names[0], "")
+        elif not names:
+            classified[key] = (True, None, "declares no `(ns ...)`")
+        else:
+            classified[key] = (
+                True, None, "declares more than one namespace: " + ", ".join(names))
+        return classified[key]
+
+    for lane in lanes:
         for root, owned in lane.roots:
-            for path, ext in scan(root):
-                ns = str(path.relative_to(root).with_suffix("")).replace(os.sep, ".").replace("_", "-")
-                entry = found.get((str(path), ns))
+            for path, ext in walked[root]:
+                key = str(path)
+                is_test, ns, problem = classify(key)
+                if not is_test:
+                    continue
+                entry = found.get(key)
                 if entry is None:
                     entry = TestFile(path=path, ns=ns, ext=ext,
-                                     ancestors=frozenset(str(p) for p in path.parents))
-                    found[(str(path), ns)] = entry
+                                     ancestors=frozenset(str(p) for p in path.parents),
+                                     ns_problem=problem)
+                    found[key] = entry
                 if lane.runtime == "cljs" and owned:
                     entry.on_owned_cljs_root = True
     return list(found.values())
@@ -464,6 +651,8 @@ def select(lanes, files):
     for lane in lanes:
         lane_roots = frozenset(str(root) for root, _owned in lane.roots)
         for test_file in files:
+            if test_file.ns is None:
+                continue        # no name to select on; B5 owns it
             if not loadable_by(lane, test_file):
                 continue
             if lane_roots.isdisjoint(test_file.ancestors):
@@ -494,15 +683,29 @@ def check(lanes, files, repo: Path):
         except ValueError:
             return str(p)
 
+    ordered = sorted(files, key=lambda f: (f.ns or "", str(f.path)))
+
+    # B5 -- no readable namespace, so no selector can be applied at all.
+    for test_file in ordered:
+        if test_file.ns is None:
+            failures.append(
+                f"B5 unreadable namespace: {rel(test_file.path)} defines tests but "
+                f"{test_file.ns_problem}. A lane selector is applied to the DECLARED "
+                f"namespace, so this file's lane membership is undecidable.")
+
     # B1 -- selected by nothing at all.
-    for test_file in sorted(files, key=lambda f: f.ns):
+    for test_file in ordered:
+        if test_file.ns is None:
+            continue
         if not selected_by[id(test_file)]:
             failures.append(
                 f"B1 orphan test file: {rel(test_file.path)} defines tests as `{test_file.ns}`, "
                 f"which no lane selector reaches. It runs in no lane.")
 
     # B2 -- a `.cljc` on a CLJS-owned root that no CLJS lane selects.
-    for test_file in sorted(files, key=lambda f: f.ns):
+    for test_file in ordered:
+        if test_file.ns is None:
+            continue
         if test_file.ext != ".cljc" or not test_file.on_owned_cljs_root:
             continue
         cljs_hits = [l for l in selected_by[id(test_file)] if l.runtime == "cljs"]
@@ -606,9 +809,26 @@ GREEN_FILES = {
     "implementation/core/test/app/only_jvm_test.cljc": "(ns app.only-jvm-test)\n(deftest t (is true))\n",
     # a borrowed tree's JVM-only `.cljc` -- B1 holds, B2 does not apply
     "borrowed/test/app/borrowed_test.cljc": "(ns app.borrowed-test)\n(deftest t (is true))\n",
+    # deftests the reader sees through to: one behind a reader conditional, one
+    # behind a `do` inside one.  Both are top-level definitions and both are
+    # properly selected here, so the green baseline exercises the recogniser
+    # positively as well as the mutations below exercising it negatively.
+    "implementation/core/test/app/conditional_cljs_test.cljc":
+        "(ns app.conditional-cljs-test)\n"
+        "#?(:cljs\n   (deftest in-a-reader-conditional (is true)))\n"
+        "#?(:clj\n   (do\n     (deftest in-a-do (is true))))\n",
     # a generator: deftest only inside a defmacro, so not a test file at all
     "implementation/core/test/app/shared_suite.clj":
         "(ns app.shared-suite)\n(defmacro define! []\n  `(deftest generated (is true)))\n",
+    # ... and its caller, which IS one: the suite arrives by expansion
+    "implementation/core/test/app/generated_cljs_test.cljs":
+        "(ns app.generated-cljs-test\n"
+        "  (:require-macros [app.shared-suite :refer [define!]]))\n(define!)\n",
+    # prose is not structure.  A commented-out deftest and a docstring quoting
+    # one in column 0 -- the exact shape a raw `^\\(deftest` scan misreads.
+    "implementation/core/test/app/prose_helper.clj":
+        "(ns app.prose-helper)\n;; (deftest not-a-test (is true))\n"
+        '(def example\n  "for the docs:\n(deftest also-not-a-test (is true))\nend")\n',
 }
 
 
@@ -649,6 +869,52 @@ def run_self_test() -> int:
 
     case("B4 fires on a `--probe` lane that gained a test",
          probe_flag=' "--probe"', expect="B4 probe lane gained coverage")
+
+    # The recogniser mutations.  Each plants a test file in one of the shapes
+    # the pre-repair column-0 scan could not see, under a namespace no selector
+    # reaches.  Seeing the shape is what makes B1 fire; not seeing it was a
+    # silent pass.
+    files = dict(GREEN_FILES)
+    files["implementation/core/test/app/rc_helper.cljc"] = (
+        "(ns app.rc-helper)\n#?(:cljs\n   (deftest t (is true)))\n")
+    case("B1 sees a deftest behind a reader conditional", expect="B1 orphan", files=files)
+
+    files = dict(GREEN_FILES)
+    files["implementation/core/test/app/rc_do_helper.cljc"] = (
+        "(ns app.rc-do-helper)\n#?(:clj\n   (do\n     (deftest t (is true))))\n")
+    case("B1 sees a deftest behind a reader-conditional `do`",
+         expect="B1 orphan", files=files)
+
+    files = dict(GREEN_FILES)
+    files["implementation/core/test/app/macro_helper.cljs"] = (
+        "(ns app.macro-helper\n"
+        "  (:require-macros [app.shared-suite :refer [define!]]))\n(define!)\n")
+    case("B1 sees a macro-generated suite entry point", expect="B1 orphan", files=files)
+
+    files = dict(GREEN_FILES)
+    files["implementation/core/test/app/qualified_helper.cljc"] = (
+        "(ns app.qualified-helper)\n(clojure.test/deftest t (is true))\n")
+    case("B1 sees a namespace-qualified deftest", expect="B1 orphan", files=files)
+
+    # The declared-namespace mutation: the FILE keeps its selected path, only
+    # the `(ns ...)` moves.  A path-derived name goes on matching `cljs-test$`
+    # while the lane, which reads the declaration, has quietly dropped it.
+    files = dict(GREEN_FILES)
+    files["implementation/core/test/app/both_cljs_test.cljc"] = (
+        "(ns app.both-test)\n(deftest t (is true))\n")
+    case("B2 fires when only the DECLARED namespace leaves the selector",
+         expect="B2 partially emptied", files=files)
+
+    files = dict(GREEN_FILES)
+    files["implementation/core/test/app/nameless_cljs_test.cljc"] = "(deftest t (is true))\n"
+    case("B5 fires on a test file that declares no namespace",
+         expect="B5 unreadable namespace", files=files)
+
+    files = dict(GREEN_FILES)
+    files["implementation/core/test/app/two_ns_cljs_test.cljc"] = (
+        "(ns app.two-ns-cljs-test)\n(deftest t (is true))\n(ns app.somewhere-else)\n")
+    case("B5 fires on two disagreeing namespace declarations",
+         expect="B5 unreadable namespace", files=files)
 
     ok = True
     for name, expect, files, shadow, probe_flag in cases:

--- a/scripts/check_test_lane_bijection.py
+++ b/scripts/check_test_lane_bijection.py
@@ -143,11 +143,6 @@ DEFTEST_HEAD = re.compile(r"(?:[^\s()\[\]{}/]+/)?deftest\Z")
 #: The same as an opening form, for scanning a `defmacro` body.
 DEFTEST_FORM = re.compile(r"\((?:[^\s()\[\]{}/]+/)?deftest[\s()\[\]{}]")
 
-#: A `deftest` form in column 0 -- the shape almost every test file uses, and
-#: the only one the pre-repair gate could see.  Kept as a fast path.
-TOP_LEVEL_DEFTEST = re.compile(r"^\((?:[^\s()\[\]{}/]+/)?deftest[\s()\[\]{}]",
-                               re.MULTILINE)
-
 DEFMACRO_FORM = re.compile(r"\(defmacro\s+([^\s()\[\]{}]+)")
 
 #: Forms the reader sees through: what they wrap is still top level.  A reader
@@ -232,11 +227,9 @@ def deftest_emitting_macros(masked_texts) -> set:
 
 
 def defines_tests(masked: str, macro_names) -> bool:
-    # The overwhelmingly common shape, on MASKED text so it cannot be a
-    # docstring line: `(deftest` in column 0.  Recognising it without walking
-    # the delimiters is what keeps the scan's runtime where it was.
-    if TOP_LEVEL_DEFTEST.search(masked):
-        return True
+    """One rule and no column heuristic.  A `(deftest` in column 0 was measured
+    against the walk and saved 0.05s over the whole tree, which does not buy a
+    second way to be wrong."""
     for head in top_level_heads(masked):
         if DEFTEST_HEAD.match(head):
             return True
@@ -255,6 +248,7 @@ def declared_namespaces(masked: str):
         if m.group(1) not in seen:
             seen.append(m.group(1))
     return seen
+
 
 #: Build output and dependency trees.  Nothing under them defines a lane or a
 #: test the lanes select, and walking them dominates the runtime.
@@ -597,7 +591,8 @@ def discover(lanes, repo: Path):
         if "defmacro" in text and "deftest" in text)
 
     # Pass 2 -- classify.  The substring pre-filter keeps masking off the ~40%
-    # of scanned files that mention neither, which is what holds the runtime.
+    # of scanned files that mention neither token, which is what holds the
+    # runtime: masking is the only new work, and it is a callback-free `sub`.
     classified = {}
 
     def classify(key: str):


### PR DESCRIPTION
Two beads of one family — a gate that is sound but cannot SEE the case it exists to catch. **One lands; one is a STOP-and-tell, because arming it requires edits inside my fence.**

- **`rf2-4hc9p` (P2) — LANDS.** The lane-bijection gate now recognises the test shapes it was blind to, and classifies by the declared namespace.
- **`rf2-6tags` (P3) — HELD, ruling needed.** The Tags-column arm is designed and measured; arming it reds on **23 pre-existing catalogue rows**, and the fence on this dispatch says a row that genuinely must change is a STOP. Full evidence below.

---

## 1. `rf2-4hc9p` — detect a PARTIALLY emptied test lane

### What was wrong

`scripts/check_test_lane_bijection.py` defined a test file as a literal column-0 `(deftest`, and derived a file's namespace from its path. Both are false greens, and the merged-PR audit of #6988 found live suites in each.

**Three shipped shapes sat outside the universe entirely** — B1/B2 could not see the file at all, so a suffix or source-root drift could partially empty their lanes in silence:

| shape | live instance |
|---|---|
| deftests under a reader conditional | `implementation/freehand/test/re_frame/freehand/behavior_door_projections_cljs_test.cljc` |
| deftests under a `do` inside one | `tools/story/test/re_frame/story/meta_fixtures_test.cljc` |
| the suite emitted by a macro call | `implementation/adapters/uix/test/re_frame/adapter/uix_react_shared_cljs_test.cljs` |

**The second false green was the namespace.** A lane selector is applied by the runner to the namespace a file DECLARES; the gate matched a name derived from the file path. Editing only the declared suffix therefore moved a file out of a lane while the gate went on testing the old path-derived name.

### What the repair does

**A test file is recognised by reading its enclosing forms, not its indentation.** A reader conditional and a `do` are transparent to the reader, so what they wrap IS top level; a `deftest` inside a `defmacro` is not, so the suite GENERATOR correctly stays a non-test file while its CALLERS become test files. `deftest` is matched bare or namespace-qualified.

**The roster of suite-emitting macros is DERIVED, never listed** — any `(defmacro NAME ...)` in the scanned tree whose body contains a `deftest` makes a top-level `(NAME ...)` call a test definition. A list here would be the staleness class the gate exists to catch. One macro is found in the tree today: `define-react-shared-suite-tests!`.

**Comments and string bodies are masked first.** This is not hygiene — the pre-repair scan reads a docstring that quotes `(deftest` in column 0 as a real test file, which the new prose fixture pins as an inverted proof below.

**Classification reads `(ns ...)`.** New rule **B5**: a test file must declare exactly one namespace. None, or two that disagree, fails loud rather than falling back to a guess — a silent path-derived fallback would reinstate the very false green B5 removes.

**No hand-maintained file exemption roster; B1–B4 and lane discovery are unchanged.**

### Mutation proof — every mutation is green under the pre-repair gate

Each fixture is built once and run through BOTH gates: `HEAD`'s `check_test_lane_bijection.py` and this one. A mutation is only a proof when the old gate reports green on it.

```
mutation                                                pre-repair gate                repaired gate
------------------------------------------------------------------------------------------------------
green baseline (no prose fixture)                        3 files, GREEN               5 files, GREEN
reader-conditional deftest                               3 files, GREEN   6 files, RED: B1 orphan test file
reader-conditional `do` deftest                          3 files, GREEN   6 files, RED: B1 orphan test file
macro-generated suite entry point                        3 files, GREEN   6 files, RED: B1 orphan test file
namespace-qualified deftest                              3 files, GREEN   6 files, RED: B1 orphan test file
declared-namespace drift (path unchanged)                3 files, GREEN   5 files, RED: B2 partially emptied CLJS lane
no namespace declaration                                 4 files, GREEN   6 files, RED: B5 unreadable namespace
two disagreeing namespace declarations                   4 files, GREEN   6 files, RED: B5 unreadable namespace
+ prose fixture (inverted: old must RED)     4 files, RED: B1 orphan test file               5 files, GREEN
------------------------------------------------------------------------------------------------------
VERDICT: every mutation is non-vacuous
```

Read the `green baseline` row as well: on the SAME five-file clean tree the old gate sees **three**. It misses the reader-conditional suite and the macro-generated one — and on the prose fixture it invents a fourth that does not exist.

The `declared-namespace drift` row is the second false green exactly: the file keeps the path `both_cljs_test.cljc` (whose derived name still matches `cljs-test$`) and only its `(ns ...)` moves to `app.both-test`. The old gate is green; the repaired one reds B2.

All eight are in the committed `--self-test`, which now runs **15 cases** (was 8).

### Live effect

`1652 → 1661` test-defining files. The nine additions are the three the audit named plus six sibling `tools/story` UI suites in the same reader-conditional shape:

```
+ implementation/adapters/uix/test/re_frame/adapter/uix_react_shared_cljs_test.cljs
+ implementation/freehand/test/re_frame/freehand/behavior_door_projections_cljs_test.cljc
+ tools/story/test/re_frame/story/meta_fixtures_test.cljc
+ tools/story/test/re_frame/story/ui/backgrounds_switcher_cljs_test.cljc
+ tools/story/test/re_frame/story/ui/controls_scalar_widgets_cljs_test.cljc
+ tools/story/test/re_frame/story/ui/controls_validation_diff_cljs_test.cljc
+ tools/story/test/re_frame/story/ui/sidebar_chips_cljs_test.cljc
+ tools/story/test/re_frame/story/ui/tag_badges_cljs_test.cljc
+ tools/story/test/re_frame/story/ui/viewport_switcher_cljs_test.cljc
```

Nothing is dropped, and all nine satisfy B1/B2/B5, so the live scan stays green. Across the whole tree there are **zero** files with no `(ns ...)`, **zero** with two, and **zero** declared-vs-path divergences — B5 arms on a clean tree.

**No workflow edit.** The gate is already armed at `.github/workflows/test.yml:714,717` and `scripts/test-fast-pr.sh:545,548`; both invocations pick the repair up unchanged. `.github/workflows/**` is untouched by this PR.

### Cost

Masking 56 MB of source is the only new work, so it is callback-free: `MASKABLE.sub(r"\1")` with the char-literal branch as the sole capture group, and the string branch written as the unrolled `"[^"\\]*(?:\\.[^"\\]*)*"` rather than the naive alternation. That rewrite alone is 2.5× (1.04s → 0.42s over the corpus) and produces byte-identical output, which was checked.

A column-0 `^\(deftest` fast path was tried and then **removed** in the second commit: it saved 0.05s over the whole tree, because the delimiter walk already short-circuits on the first top-level form — and it bought a second way to be wrong, since masking removes a string outright and a `"doc"(deftest ...)` nested in a `defmacro` can therefore arrive at column 0 in the masked text having not been there in the source. One rule decides.

Same-process A/B against `origin/main`'s copy, `discover` + `check`, seven interleaved runs each on a noisy Windows host:

```
baseline  min 1.133s   median 1.256s    1652 files, 0 failures
repaired  min 1.400s   median 1.473s    1661 files, 0 failures
```

Roughly +0.27s, all of it the mask, for two closed false greens and nine files brought into the universe. Stating it plainly rather than claiming parity.

---

## 2. `rf2-6tags` — the Tags-column arm: STOP and tell

### The ruling, reproduced verbatim

> **MAYOR RULING: YES, and only the Tags arm (2026-07-26).** The rf2-wsopx worker recommended this and asked rather than filing it, per its brief. I am adopting its reasoning as filed.
>
> **WHY THIS IS WORTH BUILDING AT ALL:** the 009 ratchet pins the Channel column and the error/warning emit sites — not trace ops and NOT the Tags column. That blind spot is why spec/009 never received the EP-0037 planner rows: `:rf.route/prefetched` appeared ZERO times in the catalogue while shipping, and `:rf.error/resource-route-plan` Tags column omitted both `:plan-cause` and `:contributor` while its narrative still taught partial planning against the ratified atomicity rule. A gate whose coverage never reaches the column where drift accumulates will keep reporting green over it.
>
> **THE RULED SHAPE — Tags-column keys-set diff, and nothing else:** Spec-Schemas.md ALREADY defines one `*Tags` schema per catalogue row, and both files are ALREADY parsed by existing gates. So the arm is a keys-set comparison between the schema and the row, which the worker describes as "a parser away". It would have caught the Tags omission directly.
>
> **WHY NOT THE TRACE-OP ARM, which is the tempting other half:** there is no per-op schema roster to diff against, so the only available check is "is every emitted op documented somewhere in 2500 lines of prose?" — a scan with a bad false-positive rate. That is the expensive half for the weaker signal, and this repo has already learned that a census whose pattern cannot distinguish a correction from a defect will fight every fix. Declined.
>
> **CONSTRAINTS:** extend the EXISTING gate, do not add a new script. No new vocabulary. If the keys-set diff turns out to need a second source of truth to be meaningful, STOP and report — a gate needing a hand-maintained roster is the drift generator this repo keeps removing (see the derived evidence-producer roster that ended its class after going stale twice by hand-copying).
>
> **NON-VACUITY IS MANDATORY:** prove the arm reds against the PRE-rf2-wsopx catalogue state, where `:plan-cause` and `:contributor` were genuinely missing from the row. An arm that cannot red on the defect that motivated it has not been tested — and this repo has shipped exactly that mistake before, where an audit method could not have caught its own motivating instance.

And the ruling this dispatch added on top of it:

> **YES to the Tags-column arm, and ONLY that arm.** `spec/Spec-Schemas.md` already defines one `*Tags` schema per catalogue row (I count **125** `Tags` occurrences), and both files are already parsed by existing gates — so a keys-set diff is a parser away. **NO to a trace-op arm**: there is no per-op schema roster to diff against, so the only available check is "is every emitted op documented somewhere in 2500 lines of prose", which has a bad false-positive rate. That is the expensive half for the weaker signal.

### The arm, and the proof that it works

Direction, pairing and exclusions are all derived, with no second source of truth:

- **Pairing.** A catalogue category's name PascalCases to its schema: `:rf.error/resource-route-plan` → `ResourceRoutePlanTags`. No alias table.
- **Direction.** Schema → row. Row → schema cannot catch the motivating defect at all (the pre-fix row was a strict SUBSET of its schema, which a subset check satisfies), and the Tags cell's parenthetical prose makes it noisy besides.
- **Exclusions.** Exactly two, and both come from the catalogue's own stated rule at `spec/009-Instrumentation.md:1948`: *"The `:tags` column lists the keys that genuinely ride under `:tags` on the wire — nothing else. Two envelope-level slots are therefore deliberately absent from every row"* — `:recovery` and `:category`.

Measured against the pre-`rf2-wsopx` tree (`ded86cff64`, the parent of `344c5f7e09`) and against `origin/main`:

```
                      paired rows   findings   :rf.error/resource-route-plan
pre-fix ded86cff64         90          24      RED -> missing [':contributor', ':plan-cause']
main    5026a73078         90          23      (absent — fixed)
```

**The arm reds on exactly the defect that motivated it and goes green on the fix.** Non-vacuity is measured, not asserted.

Two variants were rejected on the same measurement. Restricting to non-`{:optional true}` schema keys gives 13 findings on BOTH trees — it is **vacuous on the motivating defect**, because `:contributor` and `:plan-cause` are both optional. Widening the containment test from the Tags cell to the whole row changes nothing (24/23); those keys appear nowhere in the pre-fix row.

### Why it cannot be armed in this PR

The same run finds **23 more rows of the same class on `main`** — 44 undocumented schema keys. By the catalogue's own rule ("nothing else"), each is a row that must change, and this dispatch's fence reads: *"`spec/009-Instrumentation.md`'s row content — read freely, edit none … if a row genuinely must change, STOP and tell me."* So: stopping, and telling.

Also worth recording against the ruling's premise: the pairing is **90 rows of 489**, not one schema per row. `spec/Spec-Schemas.md` defines **111** `*Tags` schemas; 89 pair by derivation and 22 do not (`FxHandledTags`, `MachineUnhandledNoOpTags`, `SchemaValidationTags`, `NoSuchCofxTags`, `RoutePrefetchedTags`, …). Explicit in-row `Spec-Schemas §\`XxxTags\`` citations exist on only **3** of 489 rows, so citation is not a usable pairing key either. Pairing those 22 needs either row edits or an alias table — the hand-maintained roster the ruling forbids.

<details>
<summary>The 23 rows, with the schema keys their Tags column omits</summary>

```
:rf.error/coeffect-exception        (CoeffectExceptionTags)     :reason :event :event-id :frame :exception-message
:rf.error/drain-depth-exceeded      (DrainDepthExceededTags)    :frame
:rf.error/effect-handler-bad-return (EffectHandlerBadReturnTags):event-id :event
:rf.error/flow-eval-exception       (FlowEvalExceptionTags)     :event
:rf.error/fx-handler-exception      (FxHandlerExceptionTags)    :failing-id :frame
:rf.error/handler-exception         (HandlerExceptionTags)      :reason :event :event-id :frame :exception
:rf.error/interceptor-exception     (InterceptorExceptionTags)  :reason :event :event-id :frame :exception
:rf.error/machine-action-exception  (MachineActionExceptionTags):event :handler-id :frame
:rf.error/machine-grammar-not-in-v1 (MachineGrammarNotInV1Tags) :substitute
:rf.error/malformed-schema          (MalformedSchemaTags)       :failing-id :frame
:rf.error/no-such-sub               (NoSuchSubTags)             :frame
:rf.error/override-fallthrough      (OverrideFallthroughTags)   :failing-id
:rf.error/reg-sub-bad-args          (RegSubBadArgsTags)         :frame
:rf.error/sanitised-on-projection   (SanitisedOnProjectionTags) :exception-message :returned :reason
:rf.error/sub-exception             (SubExceptionTags)          :failing-id
:rf.error/sub-input-fn-bad-return   (SubInputFnBadReturnTags)   :frame
:rf.error/sub-input-fn-exception    (SubInputFnExceptionTags)   :frame
:rf.error/system-id-collision       (SystemIdCollisionTags)     :reason
:rf.http/stale-suppressed           (StaleSuppressedTags)       :carried-token :current-token :event-id
:rf.route.nav-token/stale-suppressed(StaleSuppressedTags)       :event-id
:rf.ssr/hydration-mismatch          (HydrationMismatchTags)     :first-diff-path
:rf.warning/multiple-redirects      (MultipleRedirectsTags)     :frame
:rf.warning/multiple-status-set     (MultipleStatusSetTags)     :frame
```

Several are alias divergences rather than plain omissions — the schema declares `:event` / `:event-id` where the row documents `:rf.event/v` / `:rf.trace/event-id` — so a few of the 23 may be schema-side corrections rather than row-side ones. That adjudication is the ruling being asked for.
</details>

**Filed as `rf2-zk1xu` (P2, `blocks: rf2-6tags`)** — the 23 rows, the adjudication each needs, the pairing-coverage measurement and the rejected variants. `rf2-6tags` is released back to `open` with the measured design recorded on it, so the follow-up does not re-derive any of this: unblock `rf2-zk1xu` and the arm lands armed and green in one pass.

---

## Quality gates

Run from `C:/Users/miket/code/re-frame2-worktrees/gate-detectors`, `rc` captured immediately into a worktree-local log and cross-checked against each log's own verdict line.

| gate | command | result | rc |
|---|---|---|---|
| lane-bijection self-test | `python scripts/check_test_lane_bijection.py --self-test` | `self-test: PASS (15 cases)` — 15/15 | 0 |
| lane-bijection live scan | `python scripts/check_test_lane_bijection.py` | `PASS test-lane bijection: 1661 test-defining files, 44 lanes, every file selected and every selector reached` | 0 |
| lane-bijection verbose | `python scripts/check_test_lane_bijection.py --verbose` | 44 lanes listed, every selector reaching ≥1 | 0 |
| mutation non-vacuity harness | scratchpad, both gates over one fixture | `VERDICT: every mutation is non-vacuous` — 8/8 | 0 |
| fast PR spine | `scripts/test-fast-pr.sh` | `PASS fast PR spine` | 0 |

`scripts/test-fast-pr.sh` soft-skips its own mkdocs step and still exits 0, so its rc was cross-checked against the per-step verdict lines rather than taken alone. The spine's own copy of this gate printed `self-test: PASS (15 cases)` and `PASS test-lane bijection: 1661 test-defining files, 44 lanes`. It reported four steps NOT RUN, all for reasons independent of this diff: `mkdocs --strict` (mkdocs not on PATH — CI runs it), the JVM artefact suites and the npm/CLJS/isolation lanes (both surfaces unchanged by a `scripts/`-only diff), and the CI-only lanes per `TESTING.md`. The doc-surface gates DID run (README link/anchor, docs corpus anchor, EP status-sync, runtime-subsystem grading) and passed.

Re-run in full after the rebase onto `origin/main` and again after the fast-path removal; same results each time.

**Diff surface:** one file, `scripts/check_test_lane_bijection.py`, over two commits. No spec, no implementation, no workflow, no `.beads`. `.github/workflows/**` is untouched — the gate is already armed there and both invocations pick the repair up unchanged.
