### PR TITLE
Deferred foreign-handle ownership: recipe, mounted evidence, and the DC-02 reconciliation (rf2-drpa3.182.5)

### DIFF
--- a/docs/core/freehand/js-libraries.md
+++ b/docs/core/freehand/js-libraries.md
@@ -22,6 +22,7 @@ law; this page is the **recipe** companion.
 | **Only enter/exit retention** | **`v/presence` + CSS** first | toasts, simple panel fade |
 | **React component**: values in, callbacks out (hooks only *inside* the lib) | **Qualified host leaf** | date pickers, many charts, **Framer `motion.*` / `AnimatePresence`** |
 | **Imperative DOM owner**: `new X(el)`, dispose | **Registered behavior** | Vega View, Mapbox GL, GSAP on a node |
+| **Imperative owner you must *await***: construction answers a Promise | **Registered behavior** whose `:connect` returns a **cell** | `vegaEmbed(el, spec)`, a Maps `loader.load()`, a workbook `.ready` |
 | **Your code must call React hooks** (or similar) | a **small React component** of your own, entered as a child | `useMotionValue`, custom scroll-linked motion |
 
 The fence is **hooks in your Freehand view body**, not “any JS library.” A foreign
@@ -284,6 +285,97 @@ Most animation “play when props change” work is **`:passive`** timing. Use
 **`:layout`** only when you must measure before paint and can prove no wrong-frame
 flash. Silent forever-`rAF` loops are not a hidden policy.
 
+## Pattern E — the handle arrives later (Promise-acquired hosts)
+
+A large class of libraries cannot be constructed on the spot. `vegaEmbed(el, spec)`
+answers a Promise. A Maps `loader.load()` answers a Promise. A workbook has a
+`.ready`. So at the moment `:connect` runs, the thing you are supposed to own does
+not exist yet.
+
+This needs no new machinery, and it is worth being precise about why. **re-frame
+event processing is one complete synchronous pass.** A Promise settling later does
+not pause an event, resume a handler, or await anything — it just runs a callback,
+which may dispatch a new and entirely ordinary event. There is nothing to
+schedule, so there is no scheduler.
+
+What the lifecycle needs is a *place to put the handle when it turns up*, and the
+memory law already says where: `:connect` establishes the connection's private
+memory **once**, and `:update`, a command and `:disconnect` only ever receive it.
+So when the handle is not ready, what `:connect` returns is a **mutable cell** —
+and the deferred continuation moves that one cell in place, exactly as a
+void-returning mutator does.
+
+```clojure
+(ns app.ui.chart
+  (:require [re-frame.freehand :as v]))
+
+;; The library's own async door, and its handle:
+;;   (acquire! node spec)     => Promise of a handle
+;;   (set-spec! handle spec)  mutates, answers nothing
+;;   (dispose! handle)        releases it, once
+
+(v/defbehavior async-chart
+  {:connect
+   (fn [{:keys [node config dispatch]}]
+     ;; The handle is not ready. The MEMORY is — so :connect returns a cell,
+     ;; synchronously, and the continuation closes over that local (NOT over
+     ;; (:memory ctx), which is still nil while :connect is running).
+     (let [cell (atom {:phase :pending :spec config})]
+       (.then (acquire! node config)
+              (fn [handle]
+                (if (= :closed (:phase @cell))
+                  (dispose! handle)                     ; late success: finalise, never install
+                  (do (swap! cell assoc :phase :ready :handle handle)
+                      (set-spec! handle (:spec @cell))  ; the LATEST spec, not :connect's
+                      (dispatch [:chart/ready]))))      ; an ordinary event, fenced to this connection
+              (fn [_err]
+                ;; :closed is TERMINAL — a late failure is evidence only
+                (swap! cell #(cond-> % (not= :closed (:phase %)) (assoc :phase :failed)))))
+       cell))
+
+   :update
+   (fn [{:keys [config memory]}]
+     (swap! memory assoc :spec config)                  ; desired state, always
+     (when (= :ready (:phase @memory))                  ; a host call only if there is a host
+       (set-spec! (:handle @memory) config)))
+
+   :disconnect
+   (fn [{:keys [memory]}]
+     ;; FENCE FIRST, then release: an acquisition still in flight must find a
+     ;; closed cell and finalise itself.
+     (let [{:keys [phase handle]} @memory]
+       (swap! memory assoc :phase :closed)
+       (when (= :ready phase) (dispose! handle))))})
+```
+
+Five rules, and each one is a bug you would otherwise ship:
+
+| Rule | The bug it prevents |
+|---|---|
+| `:connect` returns the cell **synchronously** | returning the Promise leaves `:disconnect` with nothing to release |
+| The continuation closes over the **local** cell | `(:memory ctx)` is still `nil` inside `:connect` |
+| `:disconnect` **fences before it releases** | an in-flight acquisition installs into a connection that is gone |
+| `:closed` is **terminal** | a late failure reopens a cell the teardown already settled |
+| Take the **two-argument** `.then` | a trailing `.catch` lets a throw from the success arm masquerade as an acquisition failure |
+
+**Commands do not queue.** While the phase is `:pending` there is no host, so a
+command refuses — visibly, naming the phase — and is not remembered. Replaying it
+when the handle finally arrives would fire an export the user asked for and gave
+up on.
+
+**The outward `dispatch` is already fenced.** A behavior context resolves its
+connection at firing time, so a continuation that outlives its node dispatches
+nothing and answers `false`. You do not need to null out your own callbacks; you
+do need to release host listeners in `:disconnect`.
+
+### Proven, not merely argued
+
+Unlike the exit-animation path above, this one is mounted. The ordering that
+matters — **unmount before the Promise resolves** — is asserted in
+`behavior_async_dom_cljs_test.cljs` against a deterministic surrogate: the late
+handle is disposed exactly once, never configured, and the library's book of
+undisposed instances reads empty. A real third-party witness is still outstanding.
+
 ## Animation checklist
 
 | Question | Prefer |
@@ -292,6 +384,7 @@ flash. Silent forever-`rAF` loops are not a hidden policy.
 | Framer components only (`motion.*`, `AnimatePresence`)? | **React elements in child positions** (+ pilot for exit) |
 | You call Framer **hooks** (`useMotionValue`, …)? | a **small React component of your own** — hooks only inside that file |
 | Drive a non-React player (GSAP on a node)? | **Behavior** |
+| Construction answers a Promise? | **Behavior** whose `:connect` returns a **cell** ([Pattern E](#pattern-e--the-handle-arrives-later-promise-acquired-hosts)) |
 | Must mid-animation state time-travel? | Put *intent* in re-frame; keep the player in the host |
 
 **Reduced motion:** read a preference (a media query or an app setting, as data)
@@ -309,6 +402,8 @@ motion bus.
 | `v/event` in a foreign element's `#js` props | a plain closure over `rf/capture-frame` — Freehand does not walk those props, so the carrier arrives non-callable |
 | A callback closing over `rf/dispatch` | close over `(rf/capture-frame)`'s `:dispatch`; the render scope is gone when the library calls |
 | Assume AnimatePresence exit works untested | mounted pilot before you depend on it |
+| Return the acquisition Promise from `:connect` | return a **cell**; `:disconnect` must have something to release |
+| Let a late handle install into a torn-down connection | `:disconnect` fences first; the continuation checks `:closed` and finalises |
 | Full motion library for one opacity fade | presence + CSS |
 
 ## Other libraries, same shapes
@@ -316,7 +411,8 @@ motion bus.
 | Library class | Pattern |
 |---|---|
 | Date picker / select (React) | a React element in a child position; callbacks close over `rf/capture-frame` |
-| Vega / Mapbox / SpreadJS | behavior (+ commands if needed) |
+| Mapbox GL, a Vega `View` you construct yourself | behavior (+ commands if needed) |
+| Vega Embed, a Maps `loader.load()`, a workbook `.ready` | behavior whose `:connect` returns a cell — [Pattern E](#pattern-e--the-handle-arrives-later-promise-acquired-hosts) |
 | Props-only React kits | qualified leaf |
 | Hook APIs *you* call | small React component as host leaf |
 | Freehand view inside a React grid cell | `v/->react` + live frame |

--- a/docs/design/freehand/product-completion-setpoint.md
+++ b/docs/design/freehand/product-completion-setpoint.md
@@ -56,17 +56,28 @@ identity, structure, SSR, and compiler claims.
 
 [D022](decisions/D022-public-react-host-door.md) owns the detailed ruling.
 
-### DC-02 — One async connection-owner recipe
+### DC-02 — Deferred foreign-handle ownership recipe
 
-Keep behavior `:connect` synchronous. It may start asynchronous acquisition and
-return a private pending/ready/failed/closed owner immediately. Publish one tested
-recipe covering latest desired config, late success and failure, cooperative
-cancellation, close-before-resolve, exact-once finalization, non-queued commands,
-and finalizer failure.
+Keep behavior `:connect` synchronous. It may start acquisition of a foreign handle
+and return a private pending/ready/failed/closed owner immediately. Publish one
+tested recipe covering latest desired config, late success and failure,
+cooperative cancellation, close-before-resolve, exact-once finalization,
+non-queued commands, and finalizer failure.
 
-Prove the recipe with Vega Embed and reuse its conformance-shaped double for Maps
-loading and a void-mutator SpreadJS-shaped adapter. Do not add a task system or
-helper until at least two more real integrations repeat irreducible machinery.
+**re-frame event processing remains one complete synchronous pass.** A later
+foreign completion may dispatch a new ordinary event; it never pauses or resumes
+the original event. There is no awaited event, no suspended handler, and nothing
+to resume — which is precisely why this recipe needs no task system, no async
+runtime, and no scheduling policy. The difficulty is that the handle arrives
+later, not that anything in re-frame is asynchronous.
+
+Prove the recipe with a deterministic Promise-acquired surrogate whose acquisition
+settles only on a controlled trigger, so the evidence is reproducible rather than
+a timing observation. A real third-party witness — Vega Embed, a Maps loader, a
+void-mutator SpreadJS-shaped adapter — is **evidence-deferred**: recorded as
+not-now rather than dropped, and it does not gate the recipe. Do not add a task
+system or helper until at least two more real integrations repeat irreducible
+machinery.
 
 ### DC-03 — Pure form transitions and causal owner release
 

--- a/implementation/freehand/test/re_frame/freehand/behavior_async_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/behavior_async_dom_cljs_test.cljs
@@ -263,7 +263,12 @@
                 ;; `:closed` is TERMINAL — a late failure is evidence only.
                 (swap! cell (fn [m] (cond-> m (not= :closed (:phase m))
                                             (assoc :phase :failed))))
-                (announce! dispatch [:chart/failed (:id config)])))
+                ;; The OBSERVED phase rides on the event, which is the one
+                ;; divergence from the guide's sample and it is deliberate:
+                ;; without it, `:closed` being terminal is a claim nothing
+                ;; here could falsify. A cell that let `:failed` overwrite
+                ;; `:closed` reds this line and nothing else would notice.
+                (announce! dispatch [:chart/failed (:phase @cell)])))
        cell))
 
    :update
@@ -547,8 +552,10 @@
               (.then (fn [_]
                        (is (= [[:acquire 1 [4]]] @ops)
                            "a failed acquisition performed no host work at all")
-                       (is (= [[:chart/failed :main]] (events))
-                           "the failure arm ran — the rejection was HANDLED")
+                       (is (= [[:chart/failed :closed]] (events))
+                           "the failure arm ran — the rejection was HANDLED — and it
+                            observed the cell STILL CLOSED, because a teardown that
+                            has already settled the connection is terminal")
                        (is (= [false] (accepted))
                            "and its dispatch was refused, because the view is gone")
                        (nothing-survived! "after the late rejection")

--- a/implementation/freehand/test/re_frame/freehand/behavior_async_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/behavior_async_dom_cljs_test.cljs
@@ -1,0 +1,609 @@
+(ns re-frame.freehand.behavior-async-dom-cljs-test
+  "EVIDENCE — does the SHIPPING `v/defbehavior` own a host that is acquired
+  through a Promise, or does it not?
+
+  Every behavior in this corpus so far owns a host it can construct
+  SYNCHRONOUSLY: `new ResizeObserver(…)`, a GSAP timeline, a DOM write. A
+  large and ordinary class of libraries cannot be constructed that way —
+  `vegaEmbed(el, spec)`, a Maps `loader.load()`, a workbook whose
+  `.ready` is a Promise — and for those the handle simply does not exist at
+  the moment `:connect` runs. That gap is where a lifecycle contract either
+  holds or quietly leaks, and nothing here had mounted it.
+
+  This file is a MEASUREMENT, not a mechanism. It adds no verb, no runtime,
+  no scheduling policy and no new law. It takes the two settled rulings the
+  substrate already carries, writes the one recipe they imply, and mounts it
+  against a DETERMINISTIC surrogate host so the answer is reproducible:
+
+    THE MEMORY LAW (rf2-wj1ao)  `:connect` ESTABLISHES the connection's
+                                private memory and nothing else ever writes
+                                it. So when the handle is not ready yet,
+                                what `:connect` returns is a MUTABLE CELL —
+                                and the deferred continuation, `:update`, a
+                                command and `:disconnect` all move that one
+                                cell in place. There is no second writer to
+                                race, which is precisely why no new
+                                mechanism is needed.
+
+    THE FENCE (FH-BEHAVIOR-006)  a behavior context's `:dispatch` resolves
+                                its connection AT FIRING TIME, so a callback
+                                the host kept past teardown is inert and
+                                SAYS SO by answering `false`. A deferred
+                                acquisition's continuation is exactly such a
+                                callback.
+
+  ## The surrogate, and why it is not Vega
+
+  A third-party chart library would make this evidence a test of that
+  library's scheduling. The surrogate below is the same SHAPE with none of
+  the nondeterminism: an async constructor answering a Promise that settles
+  ONLY when a case says so, a handle with a VOID-returning mutator
+  (`set-spec!` — the ordinary JS shape the memory law exists for), a
+  `dispose!` that must run exactly once, and a book of undisposed instances
+  that is the leak assertion. No timer, no `AbortController`, no npm
+  module: every settle in this file is an explicit call at a chosen moment.
+
+  Crucially, `set-spec!` and `dispose!` THROW when the handle is already
+  disposed. Real libraries do (a destroyed Vega view, a released workbook),
+  and it is what turns a lifecycle defect into a visible failure instead of
+  a silent no-op — a throw inside a `.then` becomes an unhandled rejection,
+  and the browser lane fails a run on ANY uncaught page error even when
+  every assertion passes.
+
+  ## The five cases, and which one is the point
+
+  1. NORMAL — acquire, install once, apply the spec, dispose once on
+     unmount, and leave nothing behind.
+  2. UNMOUNT BEFORE RESOLVE — the headline. Teardown runs while the
+     acquisition is still in flight, and the handle arrives afterwards to a
+     connection that is already gone. It must be finalised where it was
+     born and NEVER installed, and the fenced dispatch must refuse.
+  3. UPDATE WHILE PENDING — two config movements arrive before the handle
+     does. The host must be configured ONCE, with the LATEST spec: a
+     pending `:update` writes desired state, it does not queue host calls.
+  4. LATE REJECTION AFTER UNMOUNT — a failure that arrives after teardown is
+     EVIDENCE ONLY. It must not reopen the closed cell and must not raise.
+  5. A COMMAND WHILE PENDING — refused at the recipe, and never replayed
+     when the handle later arrives. Commands do not queue.
+
+  Case 2 is why the file exists. Cases 1 and 3 pass against a naive recipe;
+  case 2 is where a naive one leaks a handle, and case 4 is where it
+  crashes the lane.
+
+  This file rides the browser lane through its `-dom-cljs-test` suffix. It
+  also matches the node suites' broader regex, where there is no DOM to
+  mount and it says so rather than passing quietly."
+  (:require ["react" :as react]
+            ["react-dom/client" :as rdc]
+            [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.behaviors :as behaviors]
+            [re-frame.freehand.react :as fr]
+            [re-frame.freehand.shell :as shell]
+            [re-frame.live-frame :as live-frame]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       plain-atom/adapter
+     :ambient-frame nil
+     :async?        true}))
+
+(def ^:private frame-id :dom/behavior-async)
+
+;; ===========================================================================
+;; The surrogate host library
+;; ===========================================================================
+;;
+;; Deliberately tiny, deliberately hostile, and deliberately deterministic.
+;; It is a stand-in for `vegaEmbed` / a Maps loader / a workbook `.ready`,
+;; and every one of its behaviours is chosen because a real library has it:
+;;
+;;   - construction is ASYNC and answers a Promise of a handle;
+;;   - the handle's configuration call MUTATES and answers NOTHING;
+;;   - the handle's dispose is not idempotent — a second one is a fault;
+;;   - a call on a disposed handle THROWS;
+;;   - the library itself knows which instances are still alive, which is
+;;     what makes "no handle survived" an assertion rather than a hope.
+
+(def ^:private ops
+  "Every host-visible operation, in order. The library's own transcript —
+  the behavior never writes it, so it cannot flatter itself."
+  (atom []))
+
+(def ^:private live
+  "The library's book of instances it has handed out and not been asked to
+  release: `id -> spec`. The LEAK ASSERTION reads this and nothing else."
+  (atom {}))
+
+(def ^:private acquisitions
+  "Every outstanding acquisition, in the order `:connect` asked for it.
+  Each is `{:id :promise :resolve! :reject!}`. A case settles one BY HAND;
+  there is no timer anywhere in this file."
+  (atom []))
+
+(def ^:private next-id (atom 0))
+
+(defn- reset-host! []
+  (reset! ops []) (reset! live {}) (reset! acquisitions []) (reset! next-id 0)
+  nil)
+
+(defn- record! [op] (swap! ops conj op) nil)
+
+(defn- acquire!
+  "The library's async constructor — `vegaEmbed(el, spec)` in miniature.
+  Answers a Promise of a handle that settles only when a case settles it."
+  [node spec]
+  (let [id       (swap! next-id inc)
+        resolve* (atom nil)
+        reject*  (atom nil)
+        promise  (js/Promise. (fn [res rej] (reset! resolve* res) (reset! reject* rej)))]
+    (record! [:acquire id (:series spec)])
+    (swap! acquisitions conj
+           {:id       id
+            :promise  promise
+            :resolve! (fn []
+                        (swap! live assoc id ::unconfigured)
+                        (@resolve* {:id id :node node}))
+            :reject!  (fn [] (@reject* (js/Error. (str "acquisition " id " failed"))))})
+    promise))
+
+(defn- set-spec!
+  "Reconfigure a live instance. VOID-returning, exactly like
+  `chart.update(spec)` and `map.setOptions(…)` — the shape the memory law
+  exists for. THROWS on a released instance, exactly like a real one."
+  [handle spec]
+  (let [id (:id handle)]
+    (when-not (contains? @live id)
+      (throw (ex-info "set-spec! on a RELEASED instance" {:id id})))
+    (swap! live assoc id (:series spec))
+    (record! [:set-spec id (:series spec)])
+    nil))
+
+(defn- dispose!
+  "Release an instance. Not idempotent — a second release is a fault the
+  library reports rather than absorbs, so a double teardown cannot hide."
+  [handle]
+  (let [id (:id handle)]
+    (when-not (contains? @live id)
+      (throw (ex-info "dispose! on an ALREADY-RELEASED instance" {:id id})))
+    (swap! live dissoc id)
+    (record! [:dispose id])
+    nil))
+
+(defn- export
+  "A read the host can only answer while it is alive — the thing a command
+  is for."
+  [handle]
+  (record! [:export (:id handle)])
+  (str "png:" (:id handle)))
+
+;; ---------------------------------------------------------------------------
+;; Settling, deterministically
+;; ---------------------------------------------------------------------------
+
+(defn- settle!
+  "Settle the `n`th acquisition and answer a promise that is done once the
+  recipe's continuation has run.
+
+  Registration order is the whole mechanism: the behavior attached its
+  handler inside `:connect`, so a handler attached HERE is queued strictly
+  after it. One further tick covers the continuation's own tail. No timer,
+  no polling, and no wall-clock anywhere — which is what makes this
+  evidence reproducible rather than merely observed once."
+  [n outcome]
+  (let [{:keys [promise resolve! reject!]} (nth @acquisitions n)]
+    (if (= :ok outcome) (resolve!) (reject!))
+    (-> promise
+        (.then (fn [_] nil) (fn [_] nil))
+        (.then (fn [_] nil)))))
+
+;; ===========================================================================
+;; THE RECIPE — the one under measurement
+;; ===========================================================================
+;;
+;; Read the four moves, because they are the entire answer and there is no
+;; fifth:
+;;
+;;   1. `:connect` returns a MUTABLE CELL, synchronously. The handle is not
+;;      ready; the MEMORY is, because memory is the connection's and is
+;;      established once with it (rf2-wj1ao). Everything later moves this
+;;      one cell in place, and nothing ever writes the memory again.
+;;
+;;   2. The continuation closes over that cell — over the local, NOT over
+;;      `(:memory ctx)`, which is still `nil` while `:connect` is running.
+;;
+;;   3. `:disconnect` FENCES FIRST. It flips the phase to `:closed` before
+;;      it releases anything, so an acquisition still in flight finds a
+;;      closed cell and finalises the handle where it was born instead of
+;;      installing it into a connection that is gone.
+;;
+;;   4. `:closed` is TERMINAL. A late success and a late failure both check
+;;      it and neither may move out of it — otherwise a rejection arriving
+;;      after teardown reopens a cell the teardown already settled.
+;;
+;; Note the two-argument `.then`: the failure arm is the ACQUISITION's, and
+;; routing it through a trailing `.catch` would let a throw from the success
+;; arm masquerade as an acquisition failure.
+
+(def ^:private dispatches
+  "Every outward dispatch the recipe attempted, paired with the boolean the
+  fenced context answered. `[event accepted?]` — the `false` is the
+  evidence that a callback outliving its node is inert."
+  (atom []))
+
+(defn- announce! [dispatch event]
+  (swap! dispatches conj [event (dispatch event)])
+  nil)
+
+(defn- closed? [cell] (= :closed (:phase @cell)))
+
+(v/defbehavior async-chart
+  "A Promise-acquired imperative host, owned with the mechanism that ships."
+  {:timing  :passive
+   :connect
+   (fn [{:keys [node config dispatch]}]
+     ;; The memory is established HERE and never again. It is a cell
+     ;; because the thing it will hold does not exist yet.
+     (let [cell (atom {:phase :pending :handle nil :spec config})]
+       (.then (acquire! node config)
+              (fn [handle]
+                (if (closed? cell)
+                  ;; LATE SUCCESS — the connection is gone. Finalise the
+                  ;; handle where it was born; never install it.
+                  (do (dispose! handle)
+                      (announce! dispatch [:chart/abandoned (:id config)]))
+                  (do (swap! cell assoc :phase :ready :handle handle)
+                      ;; the LATEST desired spec, not the one :connect saw
+                      (set-spec! handle (:spec @cell))
+                      (announce! dispatch [:chart/ready (:id config)]))))
+              (fn [_err]
+                ;; `:closed` is TERMINAL — a late failure is evidence only.
+                (swap! cell (fn [m] (cond-> m (not= :closed (:phase m))
+                                            (assoc :phase :failed))))
+                (announce! dispatch [:chart/failed (:id config)])))
+       cell))
+
+   :update
+   (fn [{:keys [config memory]}]
+     ;; The return is DISCARDED, so this writes the cell in place. While
+     ;; pending it records DESIRED state only: no host call is queued,
+     ;; because a queue is a scheduling policy and there is none here.
+     (swap! memory assoc :spec config)
+     (when (= :ready (:phase @memory))
+       (set-spec! (:handle @memory) config)))
+
+   :disconnect
+   (fn [{:keys [memory]}]
+     ;; FENCE FIRST, then release. The order is the contract.
+     (let [{:keys [phase handle]} @memory]
+       (swap! memory assoc :phase :closed)
+       (when (= :ready phase) (dispose! handle))))
+
+   :commands
+   {:export (fn [{:keys [memory dispatch]}]
+              (let [{:keys [phase handle]} @memory]
+                (if (= :ready phase)
+                  (announce! dispatch [:chart/exported (export handle)])
+                  ;; Refused, and NOT remembered. A command that queued
+                  ;; would fire into a host the user has stopped looking at.
+                  (announce! dispatch [:chart/export-refused phase]))))}})
+
+;; ---------------------------------------------------------------------------
+;; Views. Module-level — a declared view cannot close over a test's locals.
+;; ---------------------------------------------------------------------------
+
+(v/defview chart-panel
+  [{:keys [series]}]
+  [:section.host
+   [v/behavior {:use    async-chart
+                :target :chart/main
+                :config {:id :main :series series}}
+    [:div.node]]])
+
+(v/defview control-panel
+  "The CONTROL: the same markup with no behavior at all, so a zero after
+  teardown is the substrate's release rather than a counter nothing wrote."
+  [_]
+  [:section.host
+   [:div.node]])
+
+;; ---------------------------------------------------------------------------
+;; Harness
+;; ---------------------------------------------------------------------------
+
+(defn- browser? []
+  (and (exists? js/document) (some? (.-createElement js/document))))
+
+(defn- skip! [why]
+  (is true (str "a real React mount needs a DOM host — " why)))
+
+(defn- act
+  "A React 19 `act` boundary as a promise, so assertions run after the
+  commit AND its flushed effects rather than racing them."
+  [thunk]
+  (try
+    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+    (js/Promise.resolve (react/act (fn [] (js/Promise.resolve (thunk)))))
+    (catch :default e
+      (js/Promise.reject e))))
+
+(defn- mount! []
+  (let [container (js/document.createElement "div")]
+    (.appendChild js/document.body container)
+    [container (rdc/createRoot container)]))
+
+(defn- teardown! [container root]
+  (.unmount root)
+  (.remove container)
+  nil)
+
+(defn- element [form]
+  (shell/provide-frame frame-id (fr/element form)))
+
+(defn- setup! []
+  (behaviors/reset-connections!)
+  (reset-host!)
+  (reset! dispatches [])
+  (live-frame/make-frame {:id frame-id})
+  (rf/reg-event :chart/ready          (fn [db _] db))
+  (rf/reg-event :chart/failed         (fn [db _] db))
+  (rf/reg-event :chart/abandoned      (fn [db _] db))
+  (rf/reg-event :chart/exported       (fn [db _] db))
+  (rf/reg-event :chart/export-refused (fn [db _] db))
+  (rf/reg-event :chart/command (fn [_ [_ cmd]] {:fx [[behaviors/command-fx-id cmd]]}))
+  nil)
+
+(defn- events [] (mapv first @dispatches))
+(defn- accepted [] (mapv second @dispatches))
+
+(defn- nothing-survived!
+  "The leak assertion, said in one place because every case ends with it.
+  Three independent books must all read empty: the library's own instance
+  ledger, the substrate's connection table, and its live target index."
+  [where]
+  (is (= {} @live)          (str where " — the library holds NO undisposed instance"))
+  (is (= 0 (behaviors/connection-count)) (str where " — the connection table is empty"))
+  (is (= #{} (behaviors/target-ids))     (str where " — no target claim survives")))
+
+;; ===========================================================================
+;; 1 — the ordinary case
+;; ===========================================================================
+
+(deftest an-acquired-host-installs-once-and-releases-once
+  (testing "The baseline every other case is measured against. `:connect`
+            asks the library to construct and returns a cell immediately;
+            when the handle arrives it is installed ONCE and configured
+            with the desired spec; unmount releases it EXACTLY once. The
+            CONTROL mount first proves the counters read zero for markup
+            that never connected, so the zero at the end is a release."
+    (if-not (browser?)
+      (skip! "the browser job owns the acquisition cases")
+      (async done
+        (setup!)
+        (let [[cc croot]       (mount!)
+              [container root] (mount!)]
+          (-> (act #(.render croot (element [control-panel {}])))
+              (.then (fn [_]
+                       (is (= [] @ops) "the CONTROL mount asks the library for nothing")
+                       (nothing-survived! "control mounted")
+                       (act #(teardown! cc croot))))
+
+              (.then (fn [_] (act #(.render root (element [chart-panel {:series [1 2]}])))))
+              (.then (fn [_]
+                       (is (= [[:acquire 1 [1 2]]] @ops)
+                           "the commit asked for ONE construction and nothing more")
+                       (is (= 1 (behaviors/connection-count)))
+                       (is (= {} @live)
+                           "and no instance exists yet — the handle is still in flight")
+                       (is (= [] (events)) "so nothing has been announced")
+                       (settle! 0 :ok)))
+
+              (.then (fn [_]
+                       (is (= [[:acquire 1 [1 2]] [:set-spec 1 [1 2]]] @ops)
+                           "the arriving handle is installed once and configured once")
+                       (is (= {1 [1 2]} @live) "one live instance")
+                       (is (= [[:chart/ready :main]] (events)))
+                       (is (= [true] (accepted))
+                           "and the LIVE connection's fenced dispatch was accepted")
+                       (act #(teardown! container root))))
+
+              (.then (fn [_]
+                       (is (= [[:acquire 1 [1 2]] [:set-spec 1 [1 2]] [:dispose 1]] @ops)
+                           "unmount released it, exactly once")
+                       (nothing-survived! "after teardown")
+                       (done)))
+              (.catch (fn [e] (is false (str "mount rejected: " e)) (done)))))))))
+
+;; ===========================================================================
+;; 2 — THE HEADLINE: unmount BEFORE the Promise resolves
+;; ===========================================================================
+
+(deftest a-handle-arriving-after-teardown-is-finalised-and-never-installed
+  (testing "The ordering an async host exists to survive: the user navigates
+            away while the chart is still loading. `:disconnect` runs with
+            the cell still `:pending`, so there is nothing to release yet —
+            and then the library hands over a real instance to a connection
+            that no longer exists.
+
+            Three things must hold, and each fails differently if they do
+            not. The handle must be DISPOSED (or the library leaks it
+            forever). It must NEVER be INSTALLED — no `set-spec!` — because
+            configuring a released node is both wrong and, against a real
+            library, a throw inside a `.then` and therefore an unhandled
+            rejection the browser lane fails the whole run on. And the
+            outward dispatch must be REFUSED, because the frame's view is
+            gone.
+
+            `:disconnect` still ran exactly once: a pending connection is a
+            connection."
+    (if-not (browser?)
+      (skip! "the browser job owns the acquisition cases")
+      (async done
+        (setup!)
+        (let [[container root] (mount!)]
+          (-> (act #(.render root (element [chart-panel {:series [7]}])))
+              (.then (fn [_]
+                       (is (= [[:acquire 1 [7]]] @ops))
+                       (is (= 1 (behaviors/connection-count)))
+                       ;; UNMOUNT while the acquisition is still in flight.
+                       (act #(teardown! container root))))
+
+              (.then (fn [_]
+                       (is (= [[:acquire 1 [7]]] @ops)
+                           "teardown of a PENDING connection releases nothing — there
+                            is nothing yet to release")
+                       (nothing-survived! "torn down while pending")
+                       ;; ... and NOW the library answers.
+                       (settle! 0 :ok)))
+
+              (.then (fn [_]
+                       (is (= [[:acquire 1 [7]] [:dispose 1]] @ops)
+                           "the late handle was FINALISED where it was born, and
+                            never configured — no :set-spec ran")
+                       (is (= {} @live)
+                           "so the library holds no undisposed instance")
+                       (is (= [[:chart/abandoned :main]] (events))
+                           "the continuation took the abandoned arm")
+                       (is (= [false] (accepted))
+                           "and its outward dispatch was REFUSED — the context is
+                            fenced to a generation that is gone")
+                       (nothing-survived! "after the late arrival")
+                       (done)))
+              (.catch (fn [e] (is false (str "mount rejected: " e)) (done)))))))))
+
+;; ===========================================================================
+;; 3 — config that moves while the acquisition is in flight
+;; ===========================================================================
+
+(deftest updates-while-pending-collapse-to-the-latest-desired-spec
+  (testing "Config moves twice before the handle arrives. A recipe that
+            queued the host calls would replay two stale configurations
+            against a chart the user never saw in those states; a recipe
+            that dropped them would install the config `:connect` happened
+            to see. Neither is right. The pending `:update` writes DESIRED
+            state into the cell, and the arriving handle is configured ONCE
+            with the latest — which is a fact about the cell, not a
+            scheduling policy."
+    (if-not (browser?)
+      (skip! "the browser job owns the acquisition cases")
+      (async done
+        (setup!)
+        (let [[container root] (mount!)
+              render (fn [series] (act #(.render root (element [chart-panel {:series series}]))))]
+          (-> (render [1])
+              (.then (fn [_] (render [1 2])))
+              (.then (fn [_] (render [1 2 3])))
+              (.then (fn [_]
+                       (is (= [[:acquire 1 [1]]] @ops)
+                           "two config movements while pending performed NO host work")
+                       (is (= 1 (count @acquisitions))
+                           "and asked for no second construction")
+                       (settle! 0 :ok)))
+
+              (.then (fn [_]
+                       (is (= [[:acquire 1 [1]] [:set-spec 1 [1 2 3]]] @ops)
+                           "the handle is configured ONCE, with the LATEST spec")
+                       ;; and an update AFTER readiness reaches the host directly
+                       (render [9])))
+              (.then (fn [_]
+                       (is (= [[:acquire 1 [1]] [:set-spec 1 [1 2 3]] [:set-spec 1 [9]]] @ops)
+                           "once ready, a movement is an ordinary host call")
+                       (act #(teardown! container root))))
+              (.then (fn [_]
+                       (is (= [:dispose 1] (last @ops)) "and it still releases once")
+                       (nothing-survived! "after teardown")
+                       (done)))
+              (.catch (fn [e] (is false (str "mount rejected: " e)) (done)))))))))
+
+;; ===========================================================================
+;; 4 — a failure that arrives after teardown
+;; ===========================================================================
+
+(deftest a-rejection-after-teardown-is-evidence-only-and-cannot-reopen-the-cell
+  (testing "The acquisition fails, but only after the view is gone. There is
+            no host to release and nothing to report to a screen nobody is
+            looking at, so the ONLY correct outcome is that nothing happens:
+            the cell stays `:closed`, the outward dispatch is refused, and
+            the rejection is HANDLED — an unhandled one is a page error, and
+            the browser lane fails a run on any page error even when every
+            assertion passes.
+
+            `:closed` being TERMINAL is what makes this true. A cell that
+            let `:failed` overwrite it would have a torn-down connection
+            re-enter a live phase, and the next thing to read the phase
+            would believe the connection was merely broken rather than
+            gone."
+    (if-not (browser?)
+      (skip! "the browser job owns the acquisition cases")
+      (async done
+        (setup!)
+        (let [[container root] (mount!)]
+          (-> (act #(.render root (element [chart-panel {:series [4]}])))
+              (.then (fn [_] (act #(teardown! container root))))
+              (.then (fn [_] (settle! 0 :fail)))
+              (.then (fn [_]
+                       (is (= [[:acquire 1 [4]]] @ops)
+                           "a failed acquisition performed no host work at all")
+                       (is (= [[:chart/failed :main]] (events))
+                           "the failure arm ran — the rejection was HANDLED")
+                       (is (= [false] (accepted))
+                           "and its dispatch was refused, because the view is gone")
+                       (nothing-survived! "after the late rejection")
+                       (done)))
+              (.catch (fn [e] (is false (str "mount rejected: " e)) (done)))))))))
+
+;; ===========================================================================
+;; 5 — a command while the host is still pending
+;; ===========================================================================
+
+(deftest a-command-issued-while-pending-is-refused-and-never-replays
+  (testing "A command is a one-shot host operation, and while the host is
+            pending there is no host. The substrate DELIVERS it — the target
+            is claimed by a live connection, which it genuinely is — and the
+            recipe refuses it, visibly, rather than remembering it. The
+            second half is the assertion that matters: when the handle
+            arrives, the refused export must NOT run. A queue here would fire
+            an export the user asked for and gave up on."
+    (if-not (browser?)
+      (skip! "the browser job owns the acquisition cases")
+      (async done
+        (setup!)
+        (let [[container root] (mount!)]
+          (-> (act #(.render root (element [chart-panel {:series [5]}])))
+              (.then (fn [_]
+                       (act #(rf/dispatch-sync [:chart/command {:target :chart/main
+                                                                :op     :export}]
+                                               {:frame frame-id}))))
+              (.then (fn [_]
+                       (is (= [[:acquire 1 [5]]] @ops)
+                           "the refused command performed NO host work")
+                       (is (= [[:chart/export-refused :pending]] (events))
+                           "and the refusal is visible, naming the phase")
+                       (is (= [:delivered] (mapv :outcome (behaviors/command-log)))
+                           "the SUBSTRATE delivered it — the refusal is the recipe's,
+                            because a live connection did claim the target")
+                       (settle! 0 :ok)))
+
+              (.then (fn [_]
+                       (is (= [[:acquire 1 [5]] [:set-spec 1 [5]]] @ops)
+                           "the arriving handle is configured — and the refused export
+                            did NOT replay")
+                       (is (= [[:chart/export-refused :pending] [:chart/ready :main]]
+                              (events)))
+                       ;; the same command, now that there IS a host
+                       (act #(rf/dispatch-sync [:chart/command {:target :chart/main
+                                                                :op     :export}]
+                                               {:frame frame-id}))))
+              (.then (fn [_]
+                       (is (= [:export 1] (last @ops))
+                           "once ready the very same command reaches the host")
+                       (is (= [:chart/exported "png:1"] (last (events))))
+                       (act #(teardown! container root))))
+              (.then (fn [_]
+                       (is (= [:dispose 1] (last @ops)))
+                       (nothing-survived! "after teardown")
+                       (done)))
+              (.catch (fn [e] (is false (str "mount rejected: " e)) (done)))))))))

--- a/implementation/freehand/test/re_frame/freehand/guide/host_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/guide/host_cljs_test.cljc
@@ -215,6 +215,60 @@
       (when open? [:div.body "…"])]]))
 
 ;; ---------------------------------------------------------------------------
+;; js-libraries.md — Pattern E, the handle that arrives later
+;; ---------------------------------------------------------------------------
+;;
+;; Stubs standing in for the library's async door, exactly as `start-fade!`
+;; above stands in for a player. This fixture pins the SPELLING the page
+;; teaches — the cell, the fence, the terminal `:closed`, the two-argument
+;; `.then`. What the recipe DOES is proved by a real mount against a
+;; deterministic surrogate in `re-frame.freehand.behavior-async-dom-cljs-test`,
+;; including the ordering that matters: unmount before the Promise resolves.
+
+(defn- acquire! [_node _spec] #?(:cljs (js/Promise.resolve {:handle :chart})
+                                 :clj  ::browser-only))
+(defn- set-spec! [_handle _spec] nil)
+(defn- dispose! [_handle] nil)
+
+;; js-libraries.md block 6 — `:connect` establishes the memory ONCE, so when
+;; the handle is not ready yet what it establishes is a mutable CELL, and the
+;; deferred continuation moves that one cell in place (rf2-wj1ao). No task
+;; system, no scheduler: re-frame's event pass stays one synchronous pass and
+;; the continuation merely dispatches an ordinary event.
+(v/defbehavior async-chart
+  {:connect
+   (fn [{:keys [node config dispatch]}]
+     ;; The handle is not ready. The MEMORY is — so :connect returns a cell,
+     ;; synchronously, and the continuation closes over that local (NOT over
+     ;; (:memory ctx), which is still nil while :connect is running).
+     (let [cell (atom {:phase :pending :spec config})]
+       (.then (acquire! node config)
+              (fn [handle]
+                (if (= :closed (:phase @cell))
+                  (dispose! handle)                     ; late success: finalise, never install
+                  (do (swap! cell assoc :phase :ready :handle handle)
+                      (set-spec! handle (:spec @cell))  ; the LATEST spec, not :connect's
+                      (dispatch [:chart/ready]))))      ; an ordinary event, fenced to this connection
+              (fn [_err]
+                ;; :closed is TERMINAL — a late failure is evidence only
+                (swap! cell #(cond-> % (not= :closed (:phase %)) (assoc :phase :failed)))))
+       cell))
+
+   :update
+   (fn [{:keys [config memory]}]
+     (swap! memory assoc :spec config)                  ; desired state, always
+     (when (= :ready (:phase @memory))                  ; a host call only if there is a host
+       (set-spec! (:handle @memory) config)))
+
+   :disconnect
+   (fn [{:keys [memory]}]
+     ;; FENCE FIRST, then release: an acquisition still in flight must find a
+     ;; closed cell and finalise itself.
+     (let [{:keys [phase handle]} @memory]
+       (swap! memory assoc :phase :closed)
+       (when (= :ready phase) (dispose! handle))))})
+
+;; ---------------------------------------------------------------------------
 ;; ssr.md
 ;; ---------------------------------------------------------------------------
 
@@ -359,6 +413,18 @@
           "the decorated element renders as itself")
       (is (some? (t/find tree #(= ::autosize (:use (:props %)))))
           "and the boundary records the behavior id in the tree"))))
+
+(deftest the-deferred-handle-recipe-is-an-ordinary-registered-behavior
+  (testing "js-libraries.md block 6 — Pattern E adds NOTHING to the door. The
+            Promise-acquired recipe is a `v/defbehavior` like any other: the
+            var holds the registered id, the definition is accepted by the
+            same closed roster, and the whole async part is a cell the
+            continuation moves. If this ever needed a new verb, it would be
+            visible right here as a spelling this suite could not write."
+    (is (= ::async-chart async-chart)
+        "the var holds the REGISTERED ID, exactly like every other behavior")
+    (is (keyword? fade-panel)
+        "and its synchronous sibling is registered the same way — one door")))
 
 (deftest client-only-renders-its-mandatory-fallback-on-the-structural-host
   (testing "host-boundaries.md block 2 and ssr.md block 1 — the structural

--- a/implementation/freehand/test/re_frame/freehand/guide/samples_coverage_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/guide/samples_coverage_jvm_test.clj
@@ -339,7 +339,8 @@
     [ 2 "b9e89841da17" :foreign-npm]
     [ 3 "e94f3380438e" :foreign-npm]
     [ 4 "2248c34107cb" :foreign-npm]
-    [ 5 "8e3bda770349" host/fade-panel]]
+    [ 5 "8e3bda770349" host/fade-panel]
+    [ 6 "b104f110d013" host/async-chart]]
    "limits-and-escapes.md"
    []
    "mental-model.md"


### PR DESCRIPTION
# Deferred foreign-handle ownership: the recipe, the evidence, and the DC-02 reconciliation

**Answer to the question this slice exists to ask: the existing mechanism SUFFICES.**
This is not a returned concrete failure. `v/defbehavior` — unchanged, unextended — expresses
the whole recipe, including the ordering that was in doubt: **unmount before the Promise
resolves**. No public API, no async runtime, no scheduling policy, no D022 dependency, and
no new contract of any kind was added.

## The operator rulings, verbatim

These are reproduced here rather than linked because a clean clone carries git history, not
tracker notes.

**Ruling 1 (Mike, 2026-07-26):**

> *"Release .182.5 as a documentation-and-evidence slice only. Use existing `v/defbehavior`
> and a deterministic Promise-acquired surrogate. Add no public API, async runtime,
> scheduling policy, or dependency on D022. If the existing mechanism is insufficient, stop
> and return the concrete failure rather than expanding Freehand."*

**Ruling 2 — follow-up (Mike, 2026-07-26):**

> *"Continue .182.5 under the released narrow scope. Reconcile the canonical setpoint in the
> same PR or an immediate documentation follow-up:*
>
> *- Rename DC-02 to "Deferred foreign-handle ownership recipe."*
>
> *- State explicitly that re-frame event processing remains one complete synchronous pass. A
> later foreign completion may dispatch a new ordinary event; it never pauses or resumes the
> original event.*
>
> *- Use the deterministic Promise-acquired surrogate for this slice. Remove the current
> requirement for a real Vega dependency; leave a real-library witness evidence-deferred.*
>
> *- Add no public API, async runtime, scheduling policy, or D022 dependency.*
>
> *- Rename .182.5 consistently when the active worker finishes.*
>
> *- If existing `v/defbehavior` cannot express the recipe, return the concrete failure
> instead of adding machinery."*

Both are honoured in full. Ruling 2's fifth bullet (renaming the bead) is explicitly not
mine; the setpoint reconciliation landed in this same PR rather than a follow-up.

## What the recipe turned out to be

Four moves, and there is no fifth. Each one is already implied by a law that shipped.

1. **`:connect` returns a mutable cell, synchronously.** The handle is not ready; the
   *memory* is. Memory is the connection's and is established once with it (rf2-wj1ao), so
   when the thing to remember does not exist yet, what `:connect` establishes is the cell
   that will hold it. Everything later moves that one cell in place. There is no second
   writer to race — which is exactly why no new mechanism is needed.
2. **The continuation closes over the local cell**, not over `(:memory ctx)`, which is still
   `nil` while `:connect` is running.
3. **`:disconnect` fences before it releases.** It flips the phase to `:closed` first, so an
   acquisition still in flight finds a closed cell and finalises the handle where it was born
   instead of installing it into a connection that is gone.
4. **`:closed` is terminal.** A late failure may not move out of it, or a rejection arriving
   after teardown reopens a cell the teardown already settled.

The outward dispatch needed nothing new either: a behavior context's `:dispatch` already
resolves its connection at firing time (FH-BEHAVIOR-006), so a continuation that outlives its
node dispatches nothing and answers `false`. That is precisely the fence a deferred foreign
callback needs, and it was already there.

And the architectural point the follow-up ruling asked to be stated explicitly, which is also
why "no async runtime" is a boundary rather than a preference: **re-frame event processing
remains one complete synchronous pass.** A settling Promise does not suspend an event, resume
a handler, or await anything. It runs a callback, which may dispatch a new and entirely
ordinary event. There is nothing to schedule, so there is no scheduler.

## What landed

| File | Change |
|---|---|
| `implementation/freehand/test/re_frame/freehand/behavior_async_dom_cljs_test.cljs` | **new** — five mounted cases against a deterministic surrogate host |
| `docs/core/freehand/js-libraries.md` | Pattern E — "the handle arrives later"; plus rows in the decision, checklist, mistakes and library tables |
| `implementation/freehand/test/re_frame/freehand/guide/host_cljs_test.cljc` | the fixture pinning Pattern E's spelling, and one deftest asserting it is an ordinary registered behavior |
| `implementation/freehand/test/re_frame/freehand/guide/samples_coverage_jvm_test.clj` | the roster row + digest for the new fenced block (the guide edit is a three-file change, as expected) |
| `docs/design/freehand/product-completion-setpoint.md` | DC-02 renamed and reconciled |

Nothing under `implementation/freehand/src/**` was touched. No spec file, no api-manifest, no
`docs/api/**`.

### The surrogate

Not Vega, not SpreadJS, no third-party dependency, and no timer. It is the same *shape* with
none of the nondeterminism: an async constructor answering a Promise that settles **only when
a case settles it by hand**, a handle whose configuration call mutates and answers nothing
(the ordinary JS shape the memory law exists for), a `dispose!` that is not idempotent, and a
book of undisposed instances that *is* the leak assertion.

Determinism comes from registration order, not from waiting: the behavior attached its
continuation inside `:connect`, so a continuation the test attaches to the same promise
afterwards is queued strictly after it. No polling, no wall clock.

`set-spec!` and `dispose!` **throw** on a released instance, because real libraries do. That
is what turns a lifecycle defect into a visible failure rather than a silent no-op — a throw
inside a `.then` is an unhandled rejection, and the browser lane fails a run on any uncaught
`pageerror` even when every assertion passes.

## Leak-test evidence

Every case ends by asserting three independent books all read empty: the library's own
instance ledger, `behaviors/connection-count`, and `behaviors/target-ids`. A control mount of
the same markup with no behavior is measured first, so a zero at the end is a release rather
than a counter nothing ever wrote.

### The headline: unmount BEFORE the Promise resolves

`a-handle-arriving-after-teardown-is-finalised-and-never-installed`

| Step | Observed |
|---|---|
| mount | `[[:acquire 1 [7]]]`, one live connection, `@live` empty — the handle is still in flight |
| **unmount, still pending** | ops unchanged — teardown of a pending connection releases nothing, because there is nothing yet to release. Connection table 0, target index empty. |
| **then the library answers** | `[[:acquire 1 [7]] [:dispose 1]]` — the late handle is **finalised where it was born** and **never configured**; no `:set-spec` ran |
| leak check | `@live` = `{}` — the library holds no undisposed instance |
| the fence | the continuation's outward dispatch answered **`false`** and took the `:chart/abandoned` arm |
| the lane | **no uncaught `pageerror`** — verified by the runner's dedicated `pageErrors` array, which flips the verdict before the green summary (rf2-mwx08) |

`:disconnect` still ran exactly once: a pending connection is a connection.

### The other four

| Case | What it pins |
|---|---|
| `an-acquired-host-installs-once-and-releases-once` | the baseline — acquire, install once, configure once, dispose once, against a no-behavior control mount |
| `updates-while-pending-collapse-to-the-latest-desired-spec` | two config movements before the handle arrives perform **no** host work and collapse to **one** `set-spec` with the **latest** spec — not a queue, and not `:connect`'s stale config |
| `a-rejection-after-teardown-is-evidence-only-and-cannot-reopen-the-cell` | the rejection is **handled** (no page error), the dispatch is refused, and the failure arm observes the cell **still `:closed`** |
| `a-command-issued-while-pending-is-refused-and-never-replays` | the substrate **delivers** it (a live connection does claim the target) and the recipe refuses it, naming the phase; when the handle later arrives the refused export **does not** replay |

## Negative controls

Each control was applied in place, run, and reverted. After the last revert the working tree
was **byte-identical to the commit** (`git status --porcelain` empty), so no control leaked
into the branch.

Baseline for every row: browser **790 tests / 5019 assertions, 0 failures, rc=0**.

| # | Control (recipe defect introduced) | Result | Caught by |
|---|---|---|---|
| NC1 | `:disconnect` no longer fences — drop the `:closed` write before releasing | **5 failures, rc=1** | the late handle is installed and `set-spec`'d; `@live` = `{1 [7]}` — **a leaked instance**; wrong arm announced; case 4 also reds |
| NC2 | `:closed` is not terminal — let `:failed` overwrite it | **1 failure, rc=1** | the failure arm observes `:failed` where `:closed` is required |
| NC3 | a pending `:update` does not record desired state | **2 failures, rc=1** | the stale `[1]` spec is installed instead of `[1 2 3]` |
| NC4 | the pending command queues and replays on ready | **2 failures, rc=1** | an unwanted `[:export 1]` and a `:chart/exported` the user gave up on |
| NC5 | `:connect` returns the **Promise** instead of the cell | **9 failures, rc=1** (assertions fall to 4991 — four cases bail into their `.catch`) | all five cases red — `:disconnect` cannot deref a promise, so there is nothing to release |

NC5 is the headline claim's own control: it is exactly the mistake the memory law predicts,
and it fails every case at once.

Two rules in the guide's Pattern E table are **design reasoning, not test-pinned**, and the
guide says so by scoping its "Proven, not merely argued" note to the unmount-before-resolve
ordering: the two-argument `.then` (a trailing `.catch` would let a throw from the success arm
masquerade as an acquisition failure) and closing over the local cell rather than
`(:memory ctx)`.

## Quality gates

Baselines re-derived on this branch's merge-base, not quoted from memory.

| Gate | Baseline (before) | After | rc |
|---|---|---|---|
| `implementation/freehand` JVM (`clojure -M:test`) | 1102 tests / 7420 assertions, 0 failures 0 errors | **1103 / 7422, 0 failures 0 errors** | **0** |
| `npm run test:cljs` | 11462 / 57397, 0 failures 0 errors | **11468 / 57404, 0 failures 0 errors** | **0** |
| `npm run test:browser` | 785 / 4965, 0 failures 0 errors | **790 / 5019, 0 failures 0 errors** | **0** |
| `scripts/test-fast-pr.sh` | — | **`PASS fast PR spine`** (incl. per-ns isolation: all 17 namespaces pass standalone) | **0** |
| `python scripts/check_doc_slugs.py --verbose` | — | **602 markdown files scanned, no broken links** | **0** |

Deltas account exactly:

- **browser +5 tests / +54 assertions** — the five new mounted cases.
- **cljs +6 tests / +7 assertions** — the same five, which skip with one assertion each in the
  node lane (they say so rather than passing quietly), plus the one new guide-fixture deftest
  (+1 test / +2 assertions).
- **freehand JVM +1 test / +2 assertions** — the guide-fixture deftest. The `.cljs` evidence
  file is invisible to the JVM lane by construction.

The spine's own PASS line names what it did **not** run: `mkdocs --strict` (mkdocs is not on
PATH here — CI's *MkDocs build* job covers it), the untouched JVM artefact suites, and the
browser/elision/perf/conformance lanes that are CI-only. The browser lane above was therefore
run directly rather than through the spine.

The `rc=$?` for every run above was captured immediately into a worktree-local log and
cross-checked against each log's own verdict line; no lane reported an empty log or a
compile-time death.

CI on this branch (run 30173649915) is green so far with **38 pass / 0 fail**, including the
two that matter most here: *CLJS (shadow-cljs :browser-test, headless Chromium)* and
*JVM freehand (clojure -M:test)* — the digest gate the guide edit had to satisfy.

## One contradiction reported rather than resolved

Per the follow-up ruling's closing instruction, this is surfaced rather than silently edited.

`docs/design/freehand/product-completion-setpoint.md` **DC-07** (line 138, "One executable
fixture spine") still reads:

> The first fixtures are the declared React host, serious form, and **Vega async owner**.

That naming is downstream of the DC-02 requirement this PR removes. It is DC-07's text and
belongs to `rf2-drpa3.182.7`'s slice, so it was left alone: reconciling it here would mean
rewriting another slice's accepted design change on my own authority. It needs a decision —
either DC-07's first fixture becomes the surrogate-backed deferred-handle owner, or DC-07
knowingly keeps a real-Vega fixture that DC-02 no longer requires.

Apart from that line, the only other occurrence of "DC-02" anywhere in the tree is inside
`.beads/issues.jsonl` — the tracker database, which is the mayor's to commit and which this
branch does not touch. Renaming the bead itself is explicitly not mine (ruling 2, fifth
bullet). So the setpoint rename is otherwise self-contained.

## Scope discipline

- **No public API.** The api-manifest, `spec/API.md` and `docs/api/**` are untouched; this
  slice never entered the serial lane `rf2-drpa3.182.3` holds.
- **No D022 dependency.** Nothing here consumes, references or waits on `v/defhost`.
- **No async runtime, no scheduling policy.** The words "queue", "retry", "cancel token" and
  "task" appear in this PR only as things the recipe explicitly does *not* do.
- **No source change.** `implementation/freehand/src/**` was read and not edited.

Closes work on `rf2-drpa3.182.5` (the mayor closes `.182` children on the merged SHA).
