### PR TITLE
scripts: declare the thrown-error gate's scan scope as a reachability rule (rf2-eo2y5), and separate rf2-odlm3's honest subset

### DIFF
--- a/scripts/check_thrown_error_messages.py
+++ b/scripts/check_thrown_error_messages.py
@@ -99,10 +99,14 @@ specific bare-keyword kind.
 
 SCAN SURFACE
 
-Framework source under `implementation/` — `.clj` / `.cljc` / `.cljs`. That
-roster is a RULING, not a default; see `DEFAULT_SCAN_DIRS` below for the
-enumerated exclusions and the stated ground for each. The default also
-excludes `test/` trees (a test that asserts the old shape is gone, or
+Framework source under `implementation/` — `.clj` / `.cljc` / `.cljs`. The
+scope is a REACHABILITY RULE, not a directory list: the shape governs a
+message that is read off-box (a consumer app catching the ex-info, an MCP
+client shown the text), and not one whose only reader is the developer who
+ran the tool. `DEFAULT_SCAN_DIRS` below carries the decidable part of that
+rule plus the stated ground for every excluded tree — including the
+`tools/` paths the rule DOES reach, which a text scan cannot identify. The
+default also excludes `test/` trees (a test that asserts the old shape is gone, or
 constructs a `(ex-info ":rf.error/…")` to exercise a predicate, legitimately
 names it). The one framework artefact that CANNOT `:require` `re-frame.error`
 (the bundle-isolated `reagent-slim` adapter) hand-rolls a human sentence
@@ -128,44 +132,61 @@ from typing import Iterable, NamedTuple
 # Scan surface
 # --------------------------------------------------------------------------
 
-# The roster is `implementation/` ALONE, and that is a DECISION (rf2-eo2y5),
-# not the shape a default happens to have. It used to be a bare
-# `DEFAULT_SCAN_DIR = "implementation"` with no note, which reads as unexamined
-# — and an unexamined scope is how a gate silently covers less than its reader
-# assumes, then gets "helpfully" widened by the next reader who cannot tell a
-# decision from an omission. Enumerate the candidate trees with:
+# THE SCOPE IS A REACHABILITY RULE, AND THE ROSTER BELOW IS ITS DECIDABLE PART.
+#
+#   THE RULE (rf2-eo2y5, amended 2026-07-26): the Spec 009 thrown-error shape
+#   governs framework source, PLUS any `tools/` path whose thrown message is
+#   RELAYED OFF-BOX. A message is in scope when someone other than the
+#   developer at the keyboard reads it — a consumer application catching the
+#   ex-info, or an MCP client (a consumer AI) shown the text. It is out of
+#   scope when the only reader is a developer running an inspection tool, who
+#   has the stack trace, the source, and the ex-data in front of them.
+#
+# The rule is stated here rather than mechanised because THIS GATE CANNOT
+# DECIDE IT. Whether a throw's message is relayed off-box is an interprocedural
+# fact spanning artefacts: `(ex-message e)` is read in a `catch` in one tree
+# and the throw it re-narrates lives in another, reached through a call chain
+# a text scan cannot follow. A roster is the part that IS decidable, so the
+# roster carries the trees where the rule is unconditionally true and this
+# comment carries the rest. A comment that names the rule beats a roster that
+# silently means something narrower.
+#
+# It used to be a bare `DEFAULT_SCAN_DIR = "implementation"` with no note,
+# which reads as unexamined — and an unexamined scope is how a gate silently
+# covers less than its reader assumes, then gets "helpfully" widened by the
+# next reader who cannot tell a decision from an omission. Enumerate the
+# candidate trees with:
 #
 #   git ls-files | grep -E '\.clj[cs]?$' | sed -E 's#/.*##' | sort -u
 #
-# WHY ONE TREE, when the sibling ratchet rosters them all. The two gates share
-# a template but not a subject. `check_retired_spellings.py` rosters every
-# Clojure tree because a retired SPELLING is drift wherever it appears — most
-# of all in the trees a reader copies from (rf2-kqxe6.25). A thrown-error
-# SHAPE is a contract only where something downstream reads it, and Spec 009
-# §The thrown-error shape governs the FRAMEWORK'S PUBLIC ERROR SURFACE: the
-# errors a consumer application catches, whose shape is a contract precisely
-# because consumer code and consumer AI branch on it. That surface is
-# `implementation/`.
+# WHY THE ROSTER IS ONE TREE, when the sibling ratchet rosters them all. The
+# two gates share a template but not a subject. `check_retired_spellings.py`
+# rosters every Clojure tree because a retired SPELLING is drift wherever it
+# appears — most of all in the trees a reader copies from (rf2-kqxe6.25). A
+# thrown-error SHAPE is a contract only where something downstream reads it.
+# `implementation/` is where that is true of every file.
 #
 # The excluded trees, and the ground for each:
 #
-#   * `tools/` — dev tooling. Ruled OUT OF SCOPE by rf2-eo2y5: a tool's
-#     ex-info is read by a developer running an inspection tool, and
-#     `tools/` ships on its own tag prefixes (`story-v…`, `xray-v…`,
-#     `machines-viz-v…`, `template-v…`), not on the framework's `v…` tag.
-#     THIS EXCLUSION IS NOT A CLAIM THE TREE IS CLEAN. Point `--scan-dir
-#     tools` at it and the gate reports findings; the ruling declined to
-#     convert them rather than finding nothing to convert. One QUALIFICATION
-#     is known and tracked: a `tools/` throw whose `ex-message` is relayed
-#     onto the MCP tool surface IS read by a consumer, so the shape does
-#     govern that subset — rf2-jquiy holds the traced cases. Widening this
-#     roster is not how that gets fixed; those sites get converted, and the
-#     roster stays as ruled.
+#   * `tools/` — dev tooling: the reader of a tool's ex-info is the developer
+#     who ran the tool. `tools/` also ships on its own tag prefixes
+#     (`story-v…`, `xray-v…`, `machines-viz-v…`, `template-v…`), not on the
+#     framework's `v…` tag. Ruled out of scope by rf2-eo2y5, and the 38-site
+#     conversion sweep that widening would demand is refused.
+#     THIS EXCLUSION IS NOT A CLAIM THE TREE IS CLEAN, and it is NOT
+#     unconditional. Point `--scan-dir tools` at it and the gate reports
+#     findings; the ruling declined to convert them rather than finding
+#     nothing to convert. AND THE RULE ABOVE REACHES INTO IT: `tools/story-mcp`
+#     relays `(ex-message e)` straight into an MCP tool result, so the
+#     `tools/story` throws behind that relay are read by a consumer AI and
+#     ARE governed. rf2-jquiy owns the traced sites. Converting them is the
+#     fix; widening this roster is not — it would drag in the sites the
+#     ruling refused along with the ones it claimed.
 #   * `examples/`, `skills/`, `testbeds/`, `migration/`, `docs/tools/` —
 #     consumer-SHAPED code: sample apps, teaching material, the docs
 #     playground. An error thrown by an example app is the example's own,
-#     not the framework's public error surface, and no downstream contract
-#     branches on it.
+#     not the framework's public error surface, and nothing downstream
+#     re-narrates it.
 #   * `scripts/` — `scripts/_test_fixtures/check_thrown_error_messages/`
 #     holds this gate's own POSITIVE self-test fixtures. They plant the bad
 #     shapes on purpose; a live scan over them would be red by construction,

--- a/scripts/check_thrown_error_messages.py
+++ b/scripts/check_thrown_error_messages.py
@@ -99,14 +99,14 @@ specific bare-keyword kind.
 
 SCAN SURFACE
 
-Framework source under `implementation/` — `.clj` / `.cljc` / `.cljs`. The
-default excludes `test/` trees (a test that asserts the old shape is gone, or
+Framework source under `implementation/` — `.clj` / `.cljc` / `.cljs`. That
+roster is a RULING, not a default; see `DEFAULT_SCAN_DIRS` below for the
+enumerated exclusions and the stated ground for each. The default also
+excludes `test/` trees (a test that asserts the old shape is gone, or
 constructs a `(ex-info ":rf.error/…")` to exercise a predicate, legitimately
-names it). `tools/` is bundle-isolated dev tooling and `examples/` is
-consumer-shaped, so neither is framework source for this gate. The one
-framework artefact that CANNOT `:require` `re-frame.error` (the
-bundle-isolated `reagent-slim` adapter) hand-rolls a human sentence inline —
-so it too must clear the gate, and it is under `implementation/`.
+names it). The one framework artefact that CANNOT `:require` `re-frame.error`
+(the bundle-isolated `reagent-slim` adapter) hand-rolls a human sentence
+inline — so it too must clear the gate, and it is under `implementation/`.
 
 Exit code:
     0  no bare-keyword thrown-error message in framework source
@@ -128,7 +128,58 @@ from typing import Iterable, NamedTuple
 # Scan surface
 # --------------------------------------------------------------------------
 
-DEFAULT_SCAN_DIR = "implementation"
+# The roster is `implementation/` ALONE, and that is a DECISION (rf2-eo2y5),
+# not the shape a default happens to have. It used to be a bare
+# `DEFAULT_SCAN_DIR = "implementation"` with no note, which reads as unexamined
+# — and an unexamined scope is how a gate silently covers less than its reader
+# assumes, then gets "helpfully" widened by the next reader who cannot tell a
+# decision from an omission. Enumerate the candidate trees with:
+#
+#   git ls-files | grep -E '\.clj[cs]?$' | sed -E 's#/.*##' | sort -u
+#
+# WHY ONE TREE, when the sibling ratchet rosters them all. The two gates share
+# a template but not a subject. `check_retired_spellings.py` rosters every
+# Clojure tree because a retired SPELLING is drift wherever it appears — most
+# of all in the trees a reader copies from (rf2-kqxe6.25). A thrown-error
+# SHAPE is a contract only where something downstream reads it, and Spec 009
+# §The thrown-error shape governs the FRAMEWORK'S PUBLIC ERROR SURFACE: the
+# errors a consumer application catches, whose shape is a contract precisely
+# because consumer code and consumer AI branch on it. That surface is
+# `implementation/`.
+#
+# The excluded trees, and the ground for each:
+#
+#   * `tools/` — dev tooling. Ruled OUT OF SCOPE by rf2-eo2y5: a tool's
+#     ex-info is read by a developer running an inspection tool, and
+#     `tools/` ships on its own tag prefixes (`story-v…`, `xray-v…`,
+#     `machines-viz-v…`, `template-v…`), not on the framework's `v…` tag.
+#     THIS EXCLUSION IS NOT A CLAIM THE TREE IS CLEAN. Point `--scan-dir
+#     tools` at it and the gate reports findings; the ruling declined to
+#     convert them rather than finding nothing to convert. One QUALIFICATION
+#     is known and tracked: a `tools/` throw whose `ex-message` is relayed
+#     onto the MCP tool surface IS read by a consumer, so the shape does
+#     govern that subset — rf2-jquiy holds the traced cases. Widening this
+#     roster is not how that gets fixed; those sites get converted, and the
+#     roster stays as ruled.
+#   * `examples/`, `skills/`, `testbeds/`, `migration/`, `docs/tools/` —
+#     consumer-SHAPED code: sample apps, teaching material, the docs
+#     playground. An error thrown by an example app is the example's own,
+#     not the framework's public error surface, and no downstream contract
+#     branches on it.
+#   * `scripts/` — `scripts/_test_fixtures/check_thrown_error_messages/`
+#     holds this gate's own POSITIVE self-test fixtures. They plant the bad
+#     shapes on purpose; a live scan over them would be red by construction,
+#     forever. (Same ground the sibling states for the same directory.)
+#   * `docs/` — mkdocs stages `spec/` and `migration/` into `docs/` at build
+#     time (see `.gitignore`), so a checkout that has run `mkdocs build`
+#     carries GENERATED copies. Scanning `docs/` would report a finding
+#     twice, or report a stale one from a copy predating its fix.
+#   * `.clj-kondo/` — lint hook code (`.clj-kondo/hooks/**`) that runs inside
+#     the linter, never in a framework or consumer runtime.
+#
+# `spec/` carries no Clojure source at all (prose + EDN fixtures) and this
+# gate's suffix filter is source-only, so it is not a candidate.
+DEFAULT_SCAN_DIRS = ("implementation",)
 
 _SOURCE_SUFFIXES = (".clj", ".cljc", ".cljs")
 
@@ -639,10 +690,13 @@ def main(argv: list[str]) -> int:
     )
     parser.add_argument(
         "--scan-dir",
+        action="append",
         default=None,
+        dest="scan_dirs",
         help=(
-            "Directory (relative to repo-root) to scan. Defaults to "
-            f"'{DEFAULT_SCAN_DIR}'."
+            "Directory (relative to repo-root) to scan. Repeatable. Defaults "
+            "to the rostered framework-source tree(s): "
+            f"{', '.join(DEFAULT_SCAN_DIRS)}."
         ),
     )
     parser.add_argument(
@@ -681,20 +735,36 @@ def main(argv: list[str]) -> int:
         )
         return 2
 
-    scan_root = repo_root / (args.scan_dir or DEFAULT_SCAN_DIR)
-    if not scan_root.exists():
-        sys.stderr.write(f"error: scan dir {scan_root} does not exist.\n")
+    scan_roots = [repo_root / d for d in (args.scan_dirs or DEFAULT_SCAN_DIRS)]
+
+    # A rostered tree that has been renamed or deleted is NOT skipped. Skipping
+    # is how a declared scope quietly narrows again — the gate would report
+    # success for a tree it never opened, which is the defect class this
+    # roster exists to close. Same posture as the sibling ratchet and the
+    # test-lane bijection gate's phantom-path rule.
+    missing = [r for r in scan_roots if not r.exists()]
+    if missing:
+        for root in missing:
+            sys.stderr.write(f"error: scan dir {root} does not exist.\n")
         return 2
 
     if args.verbose:
-        n = sum(1 for _ in _iter_source_files(scan_root, args.include_tests))
-        rel = str(scan_root.relative_to(repo_root)).replace("\\", "/")
+        n = sum(
+            1
+            for root in scan_roots
+            for _ in _iter_source_files(root, args.include_tests)
+        )
+        rels = ", ".join(
+            str(r.relative_to(repo_root)).replace("\\", "/") for r in scan_roots
+        )
         sys.stderr.write(
-            f"scanning {n} framework source file(s) under {rel} "
+            f"scanning {n} framework source file(s) under {rels} "
             f"(tests {'included' if args.include_tests else 'excluded'})...\n"
         )
 
-    findings = scan(scan_root, include_tests=args.include_tests)
+    findings: list[Finding] = []
+    for root in scan_roots:
+        findings.extend(scan(root, include_tests=args.include_tests))
     if findings:
         _report(findings, repo_root)
         return 1


### PR DESCRIPTION
Two ruled beads, one PR. `rf2-eo2y5` gets a code change; `rf2-odlm3` gets the ordered analysis its ruling asked for and no rename. Both rulings are reproduced verbatim below, because a clean clone carries git history and not tracker notes.

---

## rf2-eo2y5 — the ruling, verbatim

> **`tools/` is OUT OF SCOPE for the Spec 009 thrown-error shape.** The shape governs the **framework's public error surface** — the errors a consumer application catches, where shape is a contract because consumer code and consumer AI read it. `tools/` is dev tooling: not among the thirteen coordinates a `v*` tag publishes, and its errors are seen by a developer running an inspection tool, never caught by a consumer app. Converting 38 sites to satisfy a contract that does not govern them is ceremony.
>
> **The actionable half is that the current scope is ACCIDENTAL.** The gate covers `implementation/` because that is its default, not because anyone decided so — which is exactly the shape that let 38 findings sit unseen, and that would let the next reader "helpfully" widen it. Declare the roster at the declaration site with a stated reason per exclusion. One comment, one roster, no conversions.
>
> **What would change this ruling:** if any of those 38 sites throws an error that reaches a CONSUMER — via the MCP tool surface, a published skill, or an error a consumer app can catch — then the shape governs it and that subset is real work. Worth one check before closing.

### The amendment, verbatim (2026-07-26)

> **AMENDED 2026-07-26 on evidence from the ruling's own falsifier.** `tools/` remains out of scope **by default**, and the 38-site sweep is still refused. But the subset whose thrown messages are **relayed to a consumer through the MCP surface** IS governed by the Spec 009 thrown-error shape, because those messages are read by consumer code and consumer AI exactly as a framework error would be. The scope roster must therefore be **stated as a reachability rule, not a directory list** — "framework source, plus any `tools/` path whose throw is relayed off-box" — and the exclusion comment must say *why* the rest are excluded, which is that a developer running an inspection tool is the only reader.

---

## rf2-odlm3 — the ruling, verbatim

> MAYOR RULING (2026-07-25): REAL, but do NOT dispatch this as a rename sweep. The filer already identified why, and I am making it binding.
>
> THE FINDING: 52 .cljc suites under tools/** that no CLJS lane selects (story 27 of 43, xray 38 of 7, machines-viz 18 of 2), and roughly 20 of them carry #?(:cljs ...) arms in their bodies — so they were AUTHORED to run on both runtimes and run on one. One, run_owner_cljc_test.cljc, documents 'Runs on BOTH runtimes' while its namespace ends -cljc-test. That is the nine-file rf2-ezbzvm class at roughly 5.8x scale.
>
> WHY THE GATE IS HONESTLY GREEN and not at fault: B2's dual-runtime symmetry rule stops at the ownership line, because ../-escaping build roots are borrowed trees. The gate is not missing this; it is correctly declining to claim jurisdiction it does not have.
>
> WHY A RENAME SWEEP IS THE WRONG SHAPE, in the filer's words and I agree: 'Fixing them = adding 52 suites to the shared node-test bundle, i.e. the contamination job rf2-ezbzvm hit with nine — not a rename sweep to hide in a gate PR.' Nine files caused real contamination. Fifty-two into one bundle is that failure amplified, and it would land as a diff that looks mechanical while changing what compiles together.
>
> THE RULING, in order:
>   1. SEPARATE THE HONEST SUBSET FIRST. The ~20 suites with actual #?(:cljs ...) arms are the real defect — code written for a runtime it never reaches. The other ~32 may be legitimately JVM-only, in which case the fix is a -jvm-test suffix declaring that, which costs nothing and adds no suite to any bundle. Nobody should touch the 52 as one set.
>   2. THE DESIGN COMES BEFORE ANY RENAME. Per-tool CLJS lanes, not 52 additions to the shared node-test bundle. A dispatch that starts renaming before that design exists will reproduce rf2-ezbzvm; the brief must say so.
>   3. THIS IS POST-ALPHA. tools/** is dev tooling and is NOT in the thirteen published coordinates, so no consumer of the alpha is affected. It does not gate the tag and must not be treated as if it does.
>   4. Keep at P2. It is a genuine multi-suite false-green class, but on unpublished surface with a fix that is dangerous if rushed.
>
> WHAT WOULD CHANGE MY RULING: if any of those ~20 suites covers behaviour that a PUBLISHED artefact depends on, its CLJS arm not running is a live gap on shipping code and that subset becomes urgent. Worth checking before the general work.
>
> CREDIT WHERE IT IS DUE: the filer measured the population, distinguished the honest subset from the total, identified the contamination hazard, and declined to sweep — rather than filing '52 files need renaming', which is what a less careful report would have said and which I would have dispatched.

---

## Found versus changed

### rf2-eo2y5

| | |
|---|---|
| **Found** | `scripts/check_thrown_error_messages.py:131` carried a bare `DEFAULT_SCAN_DIR = "implementation"` with no note, as the bead said. But the bead's "carries no such note" is true only of the declaration site — the module docstring's `SCAN SURFACE` section *did* already state a ground for two trees ("`tools/` is bundle-isolated dev tooling and `examples/` is consumer-shaped"). That prose was incomplete (silent on `skills/`, `testbeds/`, `migration/`, `docs/tools/`, `scripts/`, `docs/`, `.clj-kondo/`), it sat nowhere near the constant a reader would edit, and — per the check below — its stated ground for `tools/` was not universally true. |
| **Changed** | `DEFAULT_SCAN_DIR` → a `DEFAULT_SCAN_DIRS` roster whose comment states the scope as a **reachability rule** and gives the ground for every excluded tree. `--scan-dir` became repeatable and a rostered tree that has been renamed or deleted now fails closed at rc=2 instead of being skipped — matching the sibling `check_retired_spellings.py` and the bijection gate's phantom-path posture. The docstring's `SCAN SURFACE` now names the rule and points at the roster instead of carrying its own partial copy. **No throw sites converted.** |
| **Verified already correct, unchanged** | Both invocation sites. `scripts/test-fast-pr.sh:487-500` and `.github/workflows/test.yml:505-523` invoke the gate bare and make no scope claim beyond "framework source" / "`implementation/` framework source is clean", both still accurate. One roster, one comment, and the two invocations cannot widen apart. |

### rf2-odlm3

| | |
|---|---|
| **Found** | The gate side needs **nothing**. `scripts/check_test_lane_bijection.py:79-88` already declares the ownership boundary *with* its reason and already names this bead: *"a `:source-paths` entry that stays inside the shadow-cljs project is a tree the CLJS build owns, while a `../`-escaping entry is a foreign tree borrowed onto the classpath… Borrowed trees are held by B1 only. (Today that line falls between `implementation/**` and `tools/**`… and are tracked separately -- see rf2-odlm3.)"* It even closes with *"Counts belong in a PR body where they carry a date; this file states rules."* This is exactly the shape rf2-eo2y5 asked me to build for the other gate, already built. |
| **Changed** | Nothing. No rename, no lane addition, no gate edit. |

---

## The "what would change this ruling" check on the 38 `tools/` sites

**Answer: yes — a subset is consumer-reachable, and it is `rf2-jquiy`, not this PR.**

The confirmed chain, traced end to end rather than inferred:

```
tools/story-mcp/src/re_frame/story_mcp/tools/write.cljc:261-274
  (defn- register-or-error [vk body-v]
    (try (story/reg-variant* vk (assoc body-v :origin config/origin)) …
      (catch Throwable e
        (result/error-result (str "Registration failed: " (ex-message e)) …))))
    │
    └─> re-frame.story.registrar/reg-variant*  (registrar.cljc:451)
          calls assert-id! (:471) and validate-shape! (:477)
            │
            ├─> registrar.cljc:365  (throw (ex-info (str error-kw) {:rf.error/id error-kw …}))
            └─> registrar.cljc:302  (throw (ex-info (str error-kw) {:rf.error/id error-kw …}))
```

`error-kw` is built as `(keyword "rf.error" (str (name kind) "-id-shape"))`, so `ex-message` is exactly the stringified discriminator. An MCP client — an AI agent, i.e. the *consumer AI* whose reading is the stated reason the shape is a contract at all — calling `register-variant` with a malformed body receives, verbatim:

```
Registration failed: :rf.error/variant-id-shape
```

Three further relays on the same surface, same shape, not audited per-site: `story-mcp/tools/wire_pipeline.cljc:385` (`"Tool handler threw: " (ex-message e)` — a catch-all over every Story handler), `story-mcp/tools/lifecycle.cljc:40` (`:reason (ex-message e)`), and `re-frame2-pair-mcp/server.cljs:535-539` (`invoke-and-guard`'s `.catch` → `:message (.-message err)`, reaching `tools/eval_form.cljs:128` and `tools/wire_pipeline.cljs:268`).

**What is *not* reachable, checked so the subset stays honest.** `pair-mcp/server.cljs:321` and `:331` look reachable and are not: `handle-call*`'s `.catch` at `:563` builds its payload from **ex-data** (`:rf.error/id`, `:hint`, `:candidates`) and never relays the message, which only reaches stderr via `log!`. That is the shape the other relays should copy. And `mcp-base/cursor.cljc:123/188/218` are swallowed — their own docstrings say *"Caught by the surrounding try in `decode-cursor` → `::malformed`"*, confirmed at `cursor.cljc:334`.

**Two of the 38 are gate false positives, not defects.** `tools/story/src/re_frame/story.cljc:877` and `:914` already build a conformant message — human sentence plus trailing `[:rf.error/<id>]` token, under a comment citing Spec 009 and the bundle-isolation constraint — but bind it to a local `msg` before throwing. The gate inspects the *text* of `ex-info`'s first argument, so `msg` is neither a `human-message` call nor a token-bearing literal and it reports `builder-bypass-message`. A future conformant let-bound message under `implementation/` would false-red the same way.

### A factual correction to a premise both rulings share

Both rulings state that `tools/` is not published. It is: `.github/workflows/` carries `release-story.yml`, `release-xray.yml`, `release-machines-viz.yml` and `template-release.yml`, publishing `day8/re-frame2-story`, `day8/re-frame2-xray` and `day8/re-frame2-machines-viz` to Clojars and `day8/re-frame2-template` as a git coord. `tools/mcp-base` and `tools/story-mcp` also declare `:clein/build` Clojars deploys. The rulings are *literally* correct — none of these ships on the framework's `v*` tag, each has its own disjoint tag prefix — but "not published" is not the same claim as "not on the `v*` tag", and the ruling text leans on the stronger one. This does not by itself overturn either ruling; it is the mayor's call.

---

## rf2-odlm3: the honest subset, separated (ruling step 1)

Measured on this branch, not copied from the bead. Reproduce with:

```
python - <<'PY'   # ns-based, matching the cljs-test$ selector the runner applies
import re,subprocess
files=[f for f in subprocess.run(["git","ls-files"],capture_output=True,text=True).stdout.split()
       if f.endswith(".cljc") and re.match(r"tools/(story|xray|machines-viz)/test/",f)]
PY
```

| tree | `.cljc` suites | CLJS-selected | **unselected** | of those, carry a `:cljs` reader-conditional branch |
|---|---:|---:|---:|---:|
| `tools/story` | 74 | 27 | **47** | **23** |
| `tools/xray` | 46 | 38 | **8** | **1** |
| `tools/machines-viz` | 20 | 18 | **2** | **1** |
| total | 140 | 83 | **57** | **25** |

**The population has grown since the bead was filed** — 57 unselected, not 52; honest subset 25, not ~20. Story accounts for the whole drift (43 → 47) and for 23 of the 25. The class is not static, which strengthens step 2 rather than weakening it: the design has to land before the population outruns the triage.

The 25 (this is the separated subset; classification is per-file work the ruling deliberately does not pre-empt):

```
machines-viz/…/engine_grammar_parity_test.cljc
story/…/artifact_test.cljc          story/…/author_expectations_test.cljc
story/…/backgrounds_test.cljc       story/…/canvas_plan_resolution_test.cljc
story/…/compose_test.cljc           story/…/determinism_test.cljc
story/…/diff_test.cljc              story/…/egress_test.cljc
story/…/generate_test.cljc          story/…/golden_test.cljc
story/…/invariants_test.cljc        story/…/meta_fixtures_test.cljc
story/…/plan_network_test.cljc      story/…/plan_test.cljc
story/…/play/settled_boundary_test.cljc
story/…/play/step_runner_test.cljc  story/…/promotion_test.cljc
story/…/render_test.cljc            story/…/run_owner_cljc_test.cljc
story/…/ui/explain_panel_test.cljc  story/…/ui/markdown_test.cljc
story/…/viewport_test.cljc          story/…/xray_preset_test.cljc
xray/…/static/machines/helpers_test.cljc
```

The remaining 32 are the `-jvm-test` candidates. They are *candidates*, not a verdict — deciding one needs the file, and the ruling says nobody should touch the 57 as one set.

**They do run, on the JVM — the gap is the CLJS arm only.** `python scripts/check_test_lane_bijection.py --verbose` reports `jvm  tools/story  /.*\-test$/ -> 104 test file(s)`, and sibling lanes for xray and machines-viz. B1 holds every one of the 57; B2 correctly declines jurisdiction. Nothing here runs nowhere.

**Ruling step 2 — the design, in outline, for the mayor to rule on before any rename.** A per-tool CLJS lane means a `:<tool>-node-test` shadow build defined in `tools/<tool>/shadow-cljs.edn` with its own `:source-paths` and `:ns-regexp`, so arming a suite adds it to *that tool's* bundle and not to the shared `implementation/:node-test` one. That is what makes the triage incremental: a Story fixture that fails to restore global state can only contaminate Story's own bundle, which is the containment nine files did not have in rf2-ezbzvm. It also moves the ownership line — each tool's test root becomes a root its own CLJS build *owns*, at which point B2's existing predicate reaches it with no gate change at all and holds the result permanently. That last property is why the design must come first: done in this order, the gate ratchets the outcome for free; done as a rename sweep into the shared bundle, the gate still cannot see it.

**Ruling step 2's falsifier, measured (see the mutation proof below).** Five of the 25 were armed and run: all green, +132 tests / +455 assertions. That is not licence to arm 25 — five is not fifty-seven, and the two rf2-ezbzvm casualties were fixture-isolation failures that appear only in specific combinations — but it does say the honest-subset path is viable and that the per-file cost is low. It also settles `run_owner_cljc_test.cljc`, the file that documents *"Runs on BOTH runtimes"*: it passes on CLJS today, so its rename is a pure win with no triage attached.

---

## Mutation proof

A gate that cannot be made red is not a deliverable. Each mutation was applied, measured, restored, and re-measured.

| # | mutation | expected | measured |
|---|---|---|---|
| **M1** | plant `(throw (ex-info ":rf.error/mutation-probe" {:rf.error/id …}))` in a new file under the rostered tree | gate reds | **rc=1**, 409 files scanned, **1 finding**, `literal-keyword-string` on the planted line |
| | restore (delete the file) | gate greens | **rc=0**, 408 files, "no bare-keyword thrown-error messages" |
| **M2** | `DEFAULT_SCAN_DIRS = ("tools",)`, gate invoked **bare** | the roster constant — not a hardcoded path — drives the scan | **rc=1**, 468 files scanned under `tools`, **38 findings** |
| | restore | | **rc=0**, 408 files under `implementation` |
| **M3** | `DEFAULT_SCAN_DIRS = ("implementation-renamed",)` | the new fail-closed path: a rostered tree that vanished must not be silently skipped | **rc=2**, `error: scan dir …\implementation-renamed does not exist.` |
| | restore | | **rc=0** |
| **M4** | arm five of the 25 honest-subset suites (rename ns + file to `_cljs_test.cljc`), run `npm run test:cljs` | the ruling's risk claim, tested | **rc=0** — `Ran 11618 tests containing 57931 assertions. 0 failures, 0 errors.` vs a baseline of 11486 / 57476 |
| | restore (`git checkout -- tools/ && git clean -fd tools/`) | | five files removed, tree clean |

M2 is the one that matters for this bead: it proves the roster is load-bearing rather than decorative — edit the constant and the scan surface moves, with the bare invocation unchanged. M3 proves the behaviour the change adds.

**One negative result worth recording, because it nearly became a false conclusion.** A first attempt at M4 mutated `tools/story/deps.edn`'s `:test` alias with a leading space in the match string; the replacement silently did not apply and the bijection gate stayed green. A mutation that does not apply is indistinguishable from a gate that does not fire. Every mutation above was re-run with the diff confirmed before the verdict was read.

---

## Quality gates

Run from `C:/Users/miket/code/re-frame2-worktrees/gate-scope`. The python gates here are silent-on-success by design — `rc` is the verdict, and no PASS line is printed or invented.

| gate | rc |
|---|---|
| `python scripts/check_thrown_error_messages.py --self-test --verbose` (20 fixture cases) | **0** |
| `python scripts/check_thrown_error_messages.py --verbose` (408 files, `implementation`) | **0** |
| `python scripts/check_test_lane_bijection.py --self-test` (15 cases) | **0** |
| `python scripts/check_test_lane_bijection.py` (1663 files, 44 lanes) | **0** |
| `sh scripts/test-fast-pr.sh` — every python gate, `JVM implementation/core` (2115 tests / 10456 assertions, 0 failures), JS harness helpers, dev-testbed | **1**, see below |
| `cd implementation && npm ci` | **0** |
| `cd implementation && npm run test:cljs` — 11486 tests / 57476 assertions, 0 failures, 0 errors | **0** |
| `sh scripts/check-beads-pr-boundary.sh origin/main` | **0** — "No beads-database paths in this PR diff." |

**The spine's rc=1 is the CLJS lane and it is now green.** The spine classified the diff as `conservative fallback (unknown surface)` — `scripts/*.py` matches no surface rule — and therefore armed the node tier, which failed with `'shadow-cljs' is not recognized` because a fresh worktree has no `node_modules`. Installed and re-ran it standalone: rc=0, 0 failures. Every other spine section passed on the first run.

---

## Files

`scripts/check_thrown_error_messages.py` — the only file changed. No workflow edits, no hot-zone files, no fenced paths (`implementation/epoch/**`, `implementation/resources/**`, `implementation/freehand/**`, `docs/design/freehand/**`, `spec/009-Instrumentation.md`, `spec/Spec-Schemas.md`) read-only throughout.
