### PR TITLE
tools: give the consumer-reachable MCP throws the Spec 009 human-message shape (rf2-jquiy)

### DIFF
--- a/scripts/check_thrown_error_messages.py
+++ b/scripts/check_thrown_error_messages.py
@@ -334,6 +334,31 @@ _INLINE_TOKEN_MSG_RE = re.compile(r"\[:rf\.[a-z][\w.-]*/[\w.*+!?<>=-]+\]")
 # so it is equally conformant to rule 4; statically the bracket is not
 # contiguous with the keyword, so this matches the assembled form: a `[` then
 # (across quotes/whitespace) a `:rf.<ns>/…` keyword then a `]`.
+#
+# KNOWN BLIND SPOT — a conformant message the scan cannot see (rf2-jquiy).
+# Both token regexes need the `:rf.<ns>/<id>` keyword and the human text to be
+# LITERAL at the `ex-info` call. Two conformant shapes are not:
+#
+#   (a) a let-BOUND message —  (let [msg (str "… [:rf.error/x]")] (ex-info msg …))
+#       `re-frame.story/configure!` (tools/story/src/re_frame/story.cljc:877,
+#       :914) does exactly this, under a comment citing Spec 009; the scan sees
+#       only the symbol `msg` and reports `builder-bypass-message`.
+#   (b) a COMPUTED discriminator — (ex-info (str reason " [" error-kw "]") …)
+#       where `error-kw` is derived (`(keyword "rf.error" (str (name kind)
+#       "-shape"))`) or arrives as a parameter of a shared throw helper. The
+#       runtime message carries the token; the source text cannot.
+#
+# Both are FALSE POSITIVES, and nothing here distinguishes them from a real
+# bypass — deciding it needs the message form evaluated, not matched. So the
+# rule is deliberately left as-is and the false-red is accepted where it lands:
+# a site pinned to a conformant-but-invisible shape carries a comment saying
+# so, and `rf2:builder-bypass-ok` remains the opt-out of last resort. The trees
+# where this currently bites are all outside the roster, but the same shape
+# under `implementation/` would false-red identically — so do NOT "fix" a site
+# to satisfy this scan without first checking what its message renders to at
+# runtime. Widening the regexes to chase (a)/(b) would mean tracking a local
+# binding and constant-folding a `str`, which buys a handful of sites at the
+# cost of a scan that can no longer be read at a glance.
 _ASSEMBLED_TOKEN_MSG_RE = re.compile(
     r'\[["\s]*:rf\.[a-z][\w.-]*/[\w.*+!?<>=-]+["\s]*\]'
 )

--- a/tools/mcp-base/src/re_frame/mcp_base/diff_encode.cljc
+++ b/tools/mcp-base/src/re_frame/mcp_base/diff_encode.cljc
@@ -284,13 +284,28 @@
   when the batch is sequential — the first failing element's
   `:bad-index` and a value-free `:shape` (path / op / kind / arity /
   type, never the leaf value). This mirrors `assoc-in-safe`, which
-  reports path + parent TYPE instead of the parent VALUE."
+  reports path + parent TYPE instead of the parent VALUE.
+
+  ## The ex-message (Spec 009 §The thrown-error shape)
+
+  The message is the human `reason` sentence + the tripped boundary +
+  a trailing `[:rf.error/<id>]` greppability token, with `:rf.error/id`
+  the sole machine discriminator. It is relayed off-box (rf2-jquiy):
+  the encode side of this gate is reached from `diff-encode-epochs`,
+  which pair-mcp runs inside a tool handler, and `server.cljs`'s
+  `invoke-and-guard` puts `(.-message err)` — and NOT the ex-data —
+  into the `:handler-threw` envelope the agent receives. A bare
+  `(str error-id)` therefore shipped the agent the stringified
+  discriminator with every actionable slot stranded in ex-data.
+  `reason` and `where` are both static, value-free strings supplied by
+  the calling boundary, so promoting them into the message cannot leak
+  an app-db leaf (EP-0015 — see above)."
   [schema element-schema data where error-id reason summarize]
   (when validate-patches?
     (when-let [validate (resolve-malli-validate)]
       (when-not (validate schema data)
         (let [[bad-index shape] (first-bad validate element-schema data summarize)]
-          (throw (ex-info (str error-id)
+          (throw (ex-info (str reason " at " where " [" error-id "]")
                           (cond-> {:rf.error/id error-id
                                    :where       where
                                    :recovery    :no-recovery

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/eval_form.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/eval_form.cljs
@@ -125,7 +125,15 @@
   ;; Binding names must be symbols — they appear verbatim in the source
   ;; (no quoting) so body forms can refer to them by name.
   (when-not (symbol? n)
-    (throw (ex-info ":rf.error/pair-mcp-rt-let-binding-bad-shape"
+    ;; Canonical thrown-error shape per Spec 009 §The thrown-error shape: the
+    ;; human sentence + a trailing `[:rf.error/<id>]` token IS the ex-message.
+    ;; Load-bearing here (rf2-jquiy) — `server.cljs`'s `invoke-and-guard`
+    ;; relays `(.-message err)` into the `:handler-threw` envelope, so this
+    ;; text is what the agent on the other end of the MCP wire reads.
+    ;; Hand-rolled inline: `tools/` MUST NOT `:require re-frame.*`.
+    (throw (ex-info (str "rt-let binding name must be a symbol, got "
+                         (pr-str n)
+                         " [" :rf.error/pair-mcp-rt-let-binding-bad-shape "]")
                     {:rf.error/id :rf.error/pair-mcp-rt-let-binding-bad-shape
                      :where    're-frame2-pair-mcp/rt-let
                      :recovery :no-recovery

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/wire_pipeline.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/wire_pipeline.cljs
@@ -265,7 +265,18 @@
           :snapshot-map (run-snapshot-map payload opts)
           :epoch-vector (run-epoch-vector payload opts)
           :scalar-value (run-scalar-value payload opts)
-          (throw (ex-info ":rf.error/pair-mcp-unknown-wire-pipeline-kind"
+          ;; Canonical thrown-error shape per Spec 009 §The thrown-error shape:
+          ;; the human sentence + a trailing `[:rf.error/<id>]` token IS the
+          ;; ex-message. Load-bearing here (rf2-jquiy) — `server.cljs`'s
+          ;; `invoke-and-guard` relays `(.-message err)` into the
+          ;; `:handler-threw` envelope, so this text is what the agent on the
+          ;; other end of the MCP wire reads. Hand-rolled inline: `tools/`
+          ;; MUST NOT `:require re-frame.*`.
+          (throw (ex-info (str "run-wire-pipeline got an unknown :kind "
+                               (pr-str kind)
+                               " — expected one of :snapshot-map, :epoch-vector, "
+                               ":scalar-value"
+                               " [" :rf.error/pair-mcp-unknown-wire-pipeline-kind "]")
                           {:rf.error/id :rf.error/pair-mcp-unknown-wire-pipeline-kind
                            :where    're-frame2-pair-mcp/run-wire-pipeline
                            :recovery :no-recovery

--- a/tools/story/src/re_frame/story/plan.cljc
+++ b/tools/story/src/re_frame/story/plan.cljc
@@ -132,9 +132,22 @@
 (defn- fail!
   "Throw a structured plan-construction error. Mirrors the
   `:rf.error/story-*` family the registrar / extends layers use so tools
-  surface plan failures the same way registration failures surface."
+  surface plan failures the same way registration failures surface.
+
+  The ex-message is the canonical Spec 009 thrown-error shape: the human
+  `reason` sentence carrying a trailing `[:rf.error/<id>]` greppability
+  token, with `:rf.error/id` the sole machine discriminator. That is
+  load-bearing rather than cosmetic (rf2-jquiy) — story-mcp's tool
+  dispatcher relays `(ex-message e)` verbatim into the MCP result
+  (`tools/wire_pipeline.cljc` `(str \"Tool handler threw: \" …)`), so a
+  plan failure raised under `explain` / `variant-plan` is read by the
+  consumer AI on the other end of the wire. A bare `(str id)` shipped it
+  the stringified discriminator and discarded the sentence sitting right
+  there in `:reason`. Hand-rolled inline rather than routed through
+  `re-frame.error`: `tools/` is bundle-isolated and MUST NOT
+  `:require re-frame.*`."
   [id reason data]
-  (throw (ex-info (str id)
+  (throw (ex-info (str reason " [" id "]")
                   (merge {:rf.error/id id
                           :where       'rf.story/variant-plan
                           :recovery    :fix-registration

--- a/tools/story/src/re_frame/story/registrar.cljc
+++ b/tools/story/src/re_frame/story/registrar.cljc
@@ -298,14 +298,27 @@
   [kind id body]
   (when-let [explain (schemas/validate kind body)]
     (let [error-kw (keyword "rf.error" (str (name kind) "-shape"))
-          unknown  (unknown-key-reason kind explain)]
-      (throw (ex-info (str error-kw)
+          unknown  (unknown-key-reason kind explain)
+          reason   (or unknown
+                       (str "re-frame2-story: " (name kind) " body for "
+                            id " does not match " (name kind) " schema"))]
+      ;; Canonical thrown-error shape per Spec 009 §The thrown-error shape:
+      ;; the human sentence + a trailing `[:rf.error/<id>]` token IS the
+      ;; ex-message, with `:rf.error/id` the sole machine discriminator.
+      ;; NOT decorative here (rf2-jquiy): story-mcp relays `(ex-message e)`
+      ;; verbatim onto the MCP tool surface — `tools/write.cljc`
+      ;; register-variant and `tools/recorder.cljc` record-as-variant both
+      ;; wrap this call in `(str "… " (ex-message e))` — so the consumer AI
+      ;; on the other end of the wire reads THIS text. A bare `(str error-kw)`
+      ;; shipped it `:rf.error/variant-shape` and nothing else.
+      ;; The central `re-frame.error` builder is NOT used: `tools/` is
+      ;; bundle-isolated and MUST NOT `:require re-frame.*`, so the shape is
+      ;; hand-rolled inline (as `re-frame.story/configure!` already does).
+      (throw (ex-info (str reason " [" error-kw "]")
                       {:rf.error/id error-kw
                        :where    'rf.story/reg-story
                        :recovery :fix-registration
-                       :reason   (or unknown
-                                     (str "re-frame2-story: " (name kind) " body for "
-                                          id " does not match " (name kind) " schema"))
+                       :reason   reason
                        :kind     kind
                        :id       id
                        :explain  explain}))))
@@ -333,14 +346,17 @@
                                   (not (contains? registered-tag-ids base))))
                               tags)]
       (when (seq unknown)
-        (throw (ex-info ":rf.error/unknown-tag"
-                        {:rf.error/id :rf.error/unknown-tag
-                         :where    'rf.story/reg-story
-                         :recovery :fix-registration
-                         :reason   (str "re-frame2-story: unregistered tag(s) on " id
-                                        ": " (pr-str unknown))
-                         :id       id
-                         :unknown  unknown}))))))
+        ;; Canonical thrown-error shape — see `validate-shape!` above for why
+        ;; the message (not just the ex-data) is load-bearing on this path.
+        (let [reason (str "re-frame2-story: unregistered tag(s) on " id
+                          ": " (pr-str unknown))]
+          (throw (ex-info (str reason " [" :rf.error/unknown-tag "]")
+                          {:rf.error/id :rf.error/unknown-tag
+                           :where    'rf.story/reg-story
+                           :recovery :fix-registration
+                           :reason   reason
+                           :id       id
+                           :unknown  unknown})))))))
 
 ;; ---- id-shape policing ----------------------------------------------------
 
@@ -361,13 +377,19 @@
               :tag         keyword?
               keyword?)]
     (when-not (ok? id)
-      (let [error-kw (keyword "rf.error" (str (name kind) "-id-shape"))]
-        (throw (ex-info (str error-kw)
+      ;; Canonical thrown-error shape — see `validate-shape!` above for why
+      ;; the message (not just the ex-data) is load-bearing on this path.
+      ;; This is the exact site rf2-jquiy traced: a malformed `:variant-id`
+      ;; sent to story-mcp's `register-variant` reached the agent as the
+      ;; bare string "Registration failed: :rf.error/variant-id-shape".
+      (let [error-kw (keyword "rf.error" (str (name kind) "-id-shape"))
+            reason   (str "re-frame2-story: " (name kind) " id " (pr-str id)
+                          " does not match the canonical id grammar")]
+        (throw (ex-info (str reason " [" error-kw "]")
                         {:rf.error/id error-kw
                          :where    'rf.story/reg-story
                          :recovery :fix-registration
-                         :reason   (str "re-frame2-story: " (name kind) " id " (pr-str id)
-                                        " does not match the canonical id grammar")
+                         :reason   reason
                          :kind     kind
                          :id       id}))))))
 

--- a/tools/story/src/re_frame/story/registrar.cljc
+++ b/tools/story/src/re_frame/story/registrar.cljc
@@ -311,6 +311,13 @@
       ;; wrap this call in `(str "… " (ex-message e))` — so the consumer AI
       ;; on the other end of the wire reads THIS text. A bare `(str error-kw)`
       ;; shipped it `:rf.error/variant-shape` and nothing else.
+      ;; Caveat, until rf2-2z9u3 lands: a client cannot yet SEE this
+      ;; particular message. Both relays also copy `:explain` (below) into
+      ;; the tool result, and the live malli schema objects it holds are not
+      ;; JSON-encodable, so the response collapses into a protocol-level
+      ;; -32603 before the text ships. That is an ex-DATA defect; the message
+      ;; is correct here and correct the moment the relay stops shipping raw
+      ;; `:explain`. Sibling paths without `:explain` are unaffected.
       ;; The central `re-frame.error` builder is NOT used: `tools/` is
       ;; bundle-isolated and MUST NOT `:require re-frame.*`, so the shape is
       ;; hand-rolled inline (as `re-frame.story/configure!` already does).
@@ -377,11 +384,17 @@
               :tag         keyword?
               keyword?)]
     (when-not (ok? id)
-      ;; Canonical thrown-error shape — see `validate-shape!` above for why
-      ;; the message (not just the ex-data) is load-bearing on this path.
-      ;; This is the exact site rf2-jquiy traced: a malformed `:variant-id`
-      ;; sent to story-mcp's `register-variant` reached the agent as the
-      ;; bare string "Registration failed: :rf.error/variant-id-shape".
+      ;; Canonical thrown-error shape — see `validate-shape!` above.
+      ;; The reachability here is NARROWER than its siblings', and rf2-jquiy
+      ;; established that by driving the wire rather than reading the call
+      ;; graph: both story-mcp entry points (`tools/write.cljc`
+      ;; register-variant, `tools/recorder.cljc` record-as-variant) pre-check
+      ;; the id grammar on the STRING shape — `fresh-keyword-checked` against
+      ;; `story/valid-variant-id?`, single-sourced with the `schemas/…-id?`
+      ;; predicates below — before interning, and answer with their own
+      ;; conformant message. So an MCP client does not reach this throw; a
+      ;; library / REPL caller passing an already-keyword id does, and the
+      ;; shape is theirs to read.
       (let [error-kw (keyword "rf.error" (str (name kind) "-id-shape"))
             reason   (str "re-frame2-story: " (name kind) " id " (pr-str id)
                           " does not match the canonical id grammar")]


### PR DESCRIPTION
Closes rf2-jquiy.

The rf2-eo2y5 ruling put `tools/` out of scope for the Spec 009 thrown-error
shape and named the condition that would reverse it: a site whose thrown message
reaches a **consumer**. It does. This PR converts the relay-confirmed subset and
nothing else.

Each converted site now emits the human sentence it was **already computing into
`:reason`**, plus the trailing `[:rf.error/<id>]` greppability token — hand-rolled
inline, because `tools/` is bundle-isolated and MUST NOT `:require re-frame.*`.
No new `:rf.error/*` ids, no builder, no sweep. `:rf.error/id` stays the sole
machine discriminator, so every ex-data-branching test is untouched.

## Before / after — the message an MCP client receives

Driven through the **real** JSON-RPC path (`server/handle-frame!`, the same fn
`run-loop!` drives per stdin frame), reading the response off the writer. A unit
test on the throw site would not have proven the relay — and would have missed
both corrections below.

**`register-variant` with an unregistered tag** → `registrar/validate-tag-membership!`,
relayed by `write.cljc`'s `register-or-error`:

```
- Registration failed: :rf.error/unknown-tag
+ Registration failed: re-frame2-story: unregistered tag(s) on :story.button/proof-tag: [:no-such-tag] [:rf.error/unknown-tag]
```

**`explain-variant` on a variant that registers but does not compile** →
`plan/fail!`, relayed by the story-mcp tool-dispatch catch-all
(`wire_pipeline.cljc:385`):

```
- Tool handler threw: :rf.error/story-extends-unknown
+ Tool handler threw: re-frame2-story: :extends references unregistered variant :story.proof/no-such-parent [:rf.error/story-extends-unknown]
```

**`registrar/assert-id!`** — the text every relay concatenates:

```
- Registration failed: :rf.error/variant-id-shape
+ Registration failed: re-frame2-story: variant id :not-a-story-ns/nope does not match the canonical id grammar [:rf.error/variant-id-shape]
```

ex-data is unchanged on all three:
`{:rf.error/id :rf.error/variant-id-shape, :where rf.story/reg-story, :recovery :fix-registration}`

## Negative control

Revert in place, prove the revert took, re-run, restore, re-run.

| step | evidence |
|---|---|
| revert `git checkout HEAD~1 -- tools/` | working blobs `6f3a681cd8`/`6cd0872ce7` **==** `HEAD~1:registrar.cljc`/`plan.cljc`; `grep` re-finds `(ex-info (str error-kw)`, `(ex-info ":rf.error/unknown-tag"`, `(ex-info (str id)` |
| BEFORE run | rc=0, all three messages **bare keyword** (left column above) |
| restore `git checkout HEAD -- tools/` | `git status --porcelain tools/` → 0 lines; 4 occurrences of the new `(str reason " [` shape |
| AFTER run | rc=0, byte-identical to the pre-revert AFTER run |
| BEFORE vs AFTER diff | exactly **3 changed lines** — the three messages, nothing else |

The mutation was confirmed applied *before* each verdict was read, in both
directions.

## Two corrections to the bead's premises

Both surfaced only because the proof went through the real MCP path.

**1. `registrar/assert-id!` is NOT wire-reachable — the bead's headline repro
does not reproduce.** The bead states an MCP client calling `register-variant`
with a malformed id receives `Registration failed: :rf.error/variant-id-shape`.
It does not. `write.cljc:323` pre-checks the id grammar on the **string** shape
via `args/fresh-keyword-checked … story/valid-variant-id?` (single-sourced with
the registrar's own `variant-id?`) before interning, and returns its own already
conformant message:

```
:variant-id "not-a-story-ns/nope" does not match the canonical variant-id grammar :story.<path>/<name>.
```

`recorder.cljc`'s `record-as-variant` pre-checks `:new-variant-id` identically.
The static trace was right that the relay exists; it did not account for the
pre-intern guard sitting in front of it. `assert-id!` is still converted — it is
the same function family, and it *is* reachable by a library / direct-invoke
caller passing an already-keyword id — but **no MCP-reachability claim is made
for it.**

**The ruling's condition is still met**, on two other sites, proven live above:
`validate-tag-membership!` and `plan/fail!`.

**2. `registrar/validate-shape!` is reached, but the client cannot see it — a
worse bug sits in front.** Any schema-violating body makes the client receive:

```
Server fault: Cannot JSON encode object of class: class malli.core$_and_schema$reify$reify__4930
```

`validate-shape!` puts the live malli `:explain` in ex-data, `write.cljc` copies
`[:rf.error :explain]` into `:structuredContent`, cheshire hits a reified schema
object, and the throw escapes the handler into a protocol-level `-32603`. So the
most common authoring mistake an agent makes through the write surface produces
no diagnostic at all. **Pre-existing** — byte-identical in the BEFORE and AFTER
runs — and out of scope here (that is ex-**data** wire-encodability; this bead is
the thrown **message** shape). Filed as **rf2-2z9u3 (P1)**.

## Sites reachable that the bead does not name

The bead asks for these explicitly. **The four named relays are not the complete
set** — three more relay `(ex-message e)` onto the wire:

- `story-mcp/tools/recorder.cljc:128` — `"Write-back failed: "`, wrapping the
  **same** `reg-variant*` call as `write.cljc`. A fifth relay of the identical
  registrar throws; covered by the same fix.
- `story-mcp/server.cljc:290` — `"Server fault: "` into a JSON-RPC
  `-32603`. The outer net; it is what surfaces rf2-2z9u3.
- `pair-mcp/tools/probe.cljs:753` and `tools/tail_build.cljs:154` — relay
  `(.-message err)`, but of **nREPL/JS** errors, not `tools/` ex-infos.

And three more **throw sites** behind those relays:

- `registrar.cljc` `validate-tag-membership!` — **proven client-visible above**,
  and the strongest single piece of evidence for the whole bead. Converted.
- `mcp-base/diff_encode.cljc` `validate-against!` — reached from the **encode**
  side (`diff-encode-epochs`, which pair-mcp runs inside a tool handler), so
  relayed by `invoke-and-guard`. Converted.
- `plan.cljc` `fail!` covers **16** call sites, not one — every `:rf.error/story-*`
  plan failure. One line.

## Sites I confirmed NOT reachable — the subset stays honest

The bead's two non-reachability findings **both hold**; I re-derived them rather
than trusting them:

- `pair-mcp/server.cljs:321`/`:331` — thrown inside `discover-and-cache!`, i.e.
  inside `ensure-connection!`. A rejection there skips `handle-call*`'s `.then`
  (and so never reaches `invoke-and-guard`) and lands in the outer `.catch`,
  which builds its payload from **ex-data** — `(:rf.error/id data)`, `:hint`,
  `:candidates`. The message goes to stderr via `log!` only. Correct by
  construction; left alone.
- `mcp-base/cursor.cljc:123`/`:188`/`:218` — swallowed to `::malformed` by
  `decode-cursor`'s `(catch … _ ::malformed)` at `:334`. The sentinel is the
  contract. Left alone.

Also newly established as unreachable, so **not** converted:

- `story/extends.cljc:68`/`:77`/`:92` — `re-frame.story.extends` is `:require`d
  by **nothing but its own test**. The live `:extends` logic is `plan/fail!`.
- `story/golden.cljc:221`, `story/promotion.cljc:370` — exposed as
  `story/capture-golden` / `compare-golden` / `promote-run-artifact!`, none of
  which story-mcp calls.
- `story/macros.clj:94`/`:101` — macroexpansion-time, in the consumer's own
  compile, not at MCP call time.
- `diff_encode.cljc:623`/`:784` — `assoc-in-safe` and
  `validate-diff-marker-body!` are on the **decode** path (`apply-patches`,
  `decode-db-after`). The MCP servers call only `diff-encode-epochs`; decode
  happens agent-host-side.

The remaining ~28 (`template/`, `xray/`, `machines-viz/`) stay out of scope under
rf2-eo2y5.

## The two gate false positives — untouched, as instructed

`story.cljc:877` and `:914` are **already conformant** (human sentence + token,
under a comment citing Spec 009) and only look otherwise because the message is
`let`-bound. Their conformance is pinned at runtime by
`story_authoring_validation_test.clj:749` and `sensitive_trace_cljs_test.cljc:177`,
which assert the rendered message matches `[:rf.error/<id>]`. Not "fixed".

The blind spot is real, and identical inside `implementation/`: the second escape
`_ASSEMBLED_TOKEN_MSG_RE` needs a **literal** keyword, so a **computed**
discriminator is equally invisible — which is why four of my seven conversions
still report. The gate now says so in its own comment (comment only; no logic
change). Options are filed as **rf2-u3otj (P3)**.

## Quality gates

All run to completion in the foreground; `rc` captured immediately. The Python
gates are silent-on-success by design, so `rc` **is** the verdict.

| gate | rc |
|---|---|
| `scripts/check_thrown_error_messages.py` (bare — default roster `implementation/`) | **0** |
| `scripts/check_thrown_error_messages.py --self-test` (20 fixtures) | **0** |
| `scripts/check_thrown_error_messages.py --scan-dir tools` | **1** — see below |
| `scripts/check_keyword_catalogue_drift.py` | **0** |
| `scripts/check-beads-pr-boundary.sh origin/main` | **0** — "No beads-database paths in this PR diff" |
| `tools/story` JVM — 1847 tests / 6824 assertions | **0** — 0 failures, 0 errors |
| `tools/story-mcp` JVM — 292 tests / 1531 assertions | **0** — 0 failures, 0 errors |
| `tools/mcp-base` JVM — 272 tests / 924 assertions | **0** — 0 failures, 0 errors |
| `tools/re-frame2-pair-mcp` CLJS (`npm test`) — 1214 tests / 4285 assertions | **0** — 0 failures, 0 errors |

**`--scan-dir tools` findings: 38 → 35.** `tools/` is not in `DEFAULT_SCAN_DIRS`,
so this is diagnostic, not a CI gate — rc=1 is its steady state either way, since
the ruling declined the other sites. The three that cleared are exactly those
whose discriminator is a **literal** keyword in the message
(`registrar` `unknown-tag`, `pair-mcp` `eval_form`, `pair-mcp` `wire_pipeline`).
The four that remain — `registrar:317`, `registrar:388`, `plan.cljc:150`,
`diff_encode.cljc:308` — are runtime-conformant with a **computed** keyword, so
the static scan cannot see the token. Their kind changed from
`str-error-keyword-var` / `literal-keyword-string` to `builder-bypass-message`,
which is the blind spot, not a defect. Proven at runtime in the before/after
above. Plus `story.cljc:877`/`:914`, unchanged and conformant.

## Files

| file | change |
|---|---|
| `tools/story/src/re_frame/story/registrar.cljc` | `validate-shape!`, `validate-tag-membership!`, `assert-id!` |
| `tools/story/src/re_frame/story/plan.cljc` | `fail!` — one line, 16 call sites |
| `tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/eval_form.cljs` | `emit-name` |
| `tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/wire_pipeline.cljs` | `run-wire-pipeline` unknown `:kind` |
| `tools/mcp-base/src/re_frame/mcp_base/diff_encode.cljc` | `validate-against!` |
| `scripts/check_thrown_error_messages.py` | **comment only** — names the blind spot |
