### PR TITLE
story: cross the presence bridge onto Freehand (rf2-gzmg0)

### DIFF
--- a/spec/conformance/freehand/donor-inventory.md
+++ b/spec/conformance/freehand/donor-inventory.md
@@ -381,13 +381,13 @@ disposed when the consumer moves to Freehand names.
 | Donor row | What it is | Disposition | Slice | Status |
 |---|---|---|---|---|
 | `tools/story/deps.edn` | the donor artifact coordinate on the story classpath | REPLACE | F6 | pending |
-| `tools/story/src/re_frame/story/late_bind.cljc` | the late-bound seam story publishes for donor views | MOVE | F6 | pending |
-| `tools/story/src/re_frame/story/sub_overrides.cljc` | the author surface behind the donor subscription-override carriage | MOVE | F6 | pending |
-| `tools/story/src/re_frame/story/play/*` | presence, presence host, runner, and runner events reaching into the donor presence runtime | MOVE | F6 | pending |
-| `tools/story/test/re_frame/story/play/presence_*` | story's play-presence tests, mounted over the donor presence runtime | MOVE | F6 | pending |
+| `tools/story/src/re_frame/story/late_bind.cljc` | the late-bound seam story publishes for donor views | MOVE | F6 | done |
+| `tools/story/src/re_frame/story/sub_overrides.cljc` | the author surface behind the donor subscription-override carriage | MOVE | F6 | done |
+| `tools/story/src/re_frame/story/play/*` | presence, presence host, runner, and runner events reaching into the donor presence runtime | MOVE | F6 | done |
+| `tools/story/test/re_frame/story/play/presence_*` | story's play-presence tests, mounted over the donor presence runtime | MOVE | F6 | done |
 | `tools/story/test/re_frame/story/view_tool*` | story's view-tool tests over donor projections | MOVE | F6 | pending |
 | `tools/story/test/re_frame/story/realworld_ui_consumer_cljs_test.cljs` | story's end-to-end consumer test over a donor example | MOVE | F6 | pending |
-| `tools/story/spec/017-Testing-Story.md` | story's testing contract where it names the donor | REPLACE | F6 | pending |
+| `tools/story/spec/017-Testing-Story.md` | story's testing contract where it names the donor | REPLACE | F6 | done |
 | `tools/xray/deps.edn` | the donor artifact coordinate on the xray classpath | REPLACE | F6 | done |
 | `tools/xray/src/day8/re_frame2_xray/viewcell_evidence.cljs` | xray's reader over the reactor evidence plane | MOVE | F6 | done |
 | `tools/xray/src/day8/re_frame2_xray/panels/reactive_panel_*` | the xray panel projecting donor view records | MOVE | F6 | done |

--- a/tools/story/deps.edn
+++ b/tools/story/deps.edn
@@ -90,6 +90,24 @@
                        ;; the JVM `clojure -M:test` gate the same classpath.
                        ;; ui depends only on core (already present) — no cycle.
                        day8/re-frame2-ui         {:local/root "../../implementation/ui"}
+                       ;; The presence rung's host bridge
+                       ;; (`re-frame.story.play.presence-host`) requires the
+                       ;; Freehand presence runtime, and the view-tool /
+                       ;; sub-override consumers read Freehand projections.
+                       ;; TEST-ONLY for the same reason the donor entry above
+                       ;; is: `day8/re-frame2-freehand` carries no `:clein`
+                       ;; deploy aliases (publication is F6 territory), so
+                       ;; Story's published jar must not depend on it — which
+                       ;; is precisely why the rung takes the advance through
+                       ;; a late-bind hook instead of a `:require` from
+                       ;; Story's own namespaces. The top-level `:node-test`
+                       ;; build already carries `freehand/src` on its
+                       ;; source-paths, so `npm run test:cljs` resolves the
+                       ;; same reads without this entry; this gives the JVM
+                       ;; `clojure -M:test` gate the same classpath. Freehand
+                       ;; depends only on core (already present) and NEVER on
+                       ;; the donor — no cycle, no donor namespace pulled in.
+                       day8/re-frame2-freehand   {:local/root "../../implementation/freehand"}
                        ;; Two test-only consumers need the live epoch surface
                        ;; on the JVM classpath:
                        ;;   • the invariant-sentinel fixture

--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -1002,8 +1002,8 @@ on caller.
   REFUSES a program containing a bare `[:wait ms]` with `:cannot-run`
   rather than running it flakily. `[:wait-until pred]` is the
   deterministic alternative and SHOULD be preferred.
-- **`[:flush-presence]` / `[:flush-presence ms]`** advances the
-  compiled-view PRESENCE clock (Spec 004 §Presence) — the fake-clock twin
+- **`[:flush-presence]` / `[:flush-presence ms]`** advances the framework's
+  PRESENCE clock (Spec 004 §Presence) — the fake-clock twin
   of `[:wait ms]`, and the reason a presence-bearing variant needs no
   determinism opt-out. See §Presence-bearing variants below.
 - **`[:assert assertion-vector]`** evaluates a `:rf.assert/*` assertion
@@ -1053,7 +1053,7 @@ errors do.
 
 #### Presence-bearing variants
 
-A variant whose view renders a `(ui/presence {:timeout-ms n} …)` boundary
+A variant whose view renders a `(v/presence {:timeout-ms n} …)` boundary
 (Spec 004 §Presence) RETAINS a removed keyed child in the `:unmounting`
 phase until the `:timeout-ms` safety bound fires. That retention is a
 CLOCK, not a queue, so no rung of the settled-boundary ladder can settle
@@ -1064,9 +1064,9 @@ The only wall-clock answer would be `[:wait ms]` — which the determinism
 gate REFUSES (§The bare-`[:wait ms]` opt-out).
 
 `[:flush-presence]` is the deterministic answer. It advances the presence
-FAKE CLOCK through the framework's own verb
-(`re-frame.ui.test/flush-presence!`), firing due exits with no wall-clock
-sleep:
+FAKE CLOCK through the framework's own advance
+(`re-frame.freehand.presence-runtime/advance-clock!`), firing due exits with
+no wall-clock sleep:
 
 - `[:flush-presence]` advances to quiescence — every pending exit fires,
   so every retained child reaches its terminal removal;
@@ -1074,9 +1074,9 @@ sleep:
   exits that come due fire, so a script can observe a child still RETAINED
   in `:unmounting` and only THEN drive its removal.
 
-Phases are asserted the ordinary way. `(ui/presence-phase)` is a
+Phases are asserted the ordinary way. `(v/presence-phase)` is a
 render-time read, so a presence-aware view renders its phase (typically as
-an attribute — `{:data-phase (name (ui/presence-phase))}`) and the script
+an attribute — `{:data-phase (name (v/presence-phase))}`) and the script
 asserts on what was rendered:
 
 ```clojure
@@ -1092,11 +1092,11 @@ asserts on what was rendered:
 Story does NOT model presence, own a clock, or reimplement the three-phase
 machine — `re-frame.story.play.presence` is a thin seam that CALLS the
 framework verb. Because Story's shipped jar must not depend on the
-never-published `day8/re-frame2-ui`, the verb arrives through the
+pre-publication `day8/re-frame2-freehand`, the verb arrives through the
 `:flush-presence!` late-bind hook rather than a `:require`.
 
 **Installing the presence host is one `:require`.** An app that mounts the
-Story shell and renders `re-frame.ui` compiled views requires the optional
+Story shell and renders Freehand views requires the optional
 bridge once at boot:
 
 ```clojure
@@ -1106,9 +1106,13 @@ bridge once at boot:
 ```
 
 `re-frame.story.play.presence-host` is the ONE canonical integration path. It
-holds the `re-frame.ui` dependency on the *app's* side of the seam — Story's
+holds the Freehand dependency on the *app's* side of the seam — Story's
 jar ships the file but never requires it, so the dependency direction is
-unchanged. It installs at load time; there is nothing else to call.
+unchanged. It composes two verbs the substrate already published — the
+logical advance above, and core's adapter-dispatched synchronous commit
+(`re-frame.substrate.adapter/flush-render!`, Spec 006) so the removals the
+advance fires are committed before the step returns. It installs at load
+time; there is nothing else to call.
 (`re-frame.story.play.presence/install-presence-flush!` stays public for a
 host registering a different advance.)
 
@@ -1121,28 +1125,29 @@ consequence through app-db alone.
 (`:cannot-run`)** — it never skips silently. The step was requested and did
 not happen, so the run reports the distinct third status rather than a clean
 verdict over a clock that never moved. A missing hook does NOT prove a missing
-presence runtime: an app can load `re-frame.ui`, render a real
-`(ui/presence …)` boundary, and merely omit the bridge require. Nor may the
+presence runtime: an app can load Freehand, render a real
+`(v/presence …)` boundary, and merely omit the bridge require. Nor may the
 refusal be delegated to the assertion that follows — the grammar requires no
 following assertion at all, and an `:assert-db` one needs only the headless
 floor, so it would happily prove a state the un-advanced clock produced. (The
-framework's own JVM arm of `flush-presence!` remains a no-op, and correctly
-so: there the structural host provably has no lifecycle to advance. An absent
-hook establishes no such thing.)
+bridge's own JVM arm remains a no-op, and correctly so: there the structural
+host provably has no lifecycle to advance. An absent hook establishes no such
+thing.)
 
-**A Promise-backed host is AWAITED before the next step.** On CLJS the
-canonical verb (`re-frame.ui.test/flush-presence!`) returns a Promise, so
-reaching the host is not the same as the flush having succeeded. The runner
-therefore settles the returned thenable before it records the step: a
-fulfilled flush records the ordinary no-assertion step, and a REJECTED one
-(a React `act` failure, `:rf.error/flush-convergence-exceeded`) becomes the
-same step-exception a synchronously throwing host produces, failing the run.
-A rejection is never left unobserved, and can never arrive too late to change
-the verdict — the run cannot report `:pass` over a flush that failed. The
-interactive step-debugger records the settled result too, so it and the
-auto-run loop always agree. Synchronous hosts — the JVM verb, a custom
-synchronous advance — keep their existing behaviour exactly: nothing is
-deferred that was not already asynchronous.
+**A Promise-backed host is AWAITED before the next step.** The shipped
+Freehand bridge is SYNCHRONOUS — its advance runs inside the substrate's
+`flushSync` commit, so the DOM has settled by the time the call returns — but
+the hook's contract admits a Promise-backed host, and reaching such a host is
+not the same as the flush having succeeded. The runner therefore settles a
+returned thenable before it records the step: a fulfilled flush records the
+ordinary no-assertion step, and a REJECTED one becomes the same step-exception
+a synchronously throwing host produces, failing the run. A rejection is never
+left unobserved, and can never arrive too late to change the verdict — the run
+cannot report `:pass` over a flush that failed. The interactive step-debugger
+records the settled result too, so it and the auto-run loop always agree.
+Synchronous hosts — the shipped bridge, the JVM arm, a custom synchronous
+advance — call back before `settle!` returns: nothing is deferred that was not
+already asynchronous.
 
 **Source metadata is preserved for narrative projection.** The runner
 keeps the script step on every step-result and trace record, and the
@@ -3320,7 +3325,7 @@ offending `:wait-steps`. (A virtual clock that would make `[:wait ms]`
 deterministic remains a non-goal, §P1 non-goals.)
 
 `[:flush-presence]` is NOT a wall-clock step and is never refused: it
-advances the compiled-view presence FAKE clock (§Presence-bearing
+advances the framework's presence FAKE clock (§Presence-bearing
 variants), so a variant that would otherwise reach for `[:wait ms]` to
 outlast a `:timeout-ms` retention keeps its deterministic verdict. This is
 not the general virtual clock the non-goal rules out — it advances exactly

--- a/tools/story/src/re_frame/story/late_bind.cljc
+++ b/tools/story/src/re_frame/story/late_bind.cljc
@@ -106,25 +106,27 @@
                                      JVM (no DOM / substrate), so
                                      `render-variant` returns `:cannot-run`.
 
-  - `:flush-presence!`             — a `re-frame.ui`-hosted shell →
+  - `:flush-presence!`             — a Freehand-hosted shell →
                                      `re-frame.story.play.presence` (consumed
                                      by the `[:flush-presence]` script step).
-                                     Advances the compiled-view PRESENCE fake
-                                     clock so a variant rendering a
-                                     `(ui/presence …)` boundary settles its
-                                     retained (`:unmounting`) children
+                                     Advances the PRESENCE fake clock so a
+                                     variant rendering a `(v/presence …)`
+                                     boundary settles its retained
+                                     (`:unmounting`) children
                                      deterministically, with no wall-clock
                                      sleep. Signature: `(f ms-or-nil) → any`
                                      — nil means 'to quiescence', mirroring
-                                     the two arities of the framework verb
-                                     `re-frame.ui.test/flush-presence!`.
+                                     the two arities of the framework advance
+                                     `re-frame.freehand.presence-runtime/
+                                     advance-clock!`.
                                      Story's shipped jar must not depend on
-                                     the never-published `day8/re-frame2-ui`,
-                                     so the verb arrives through this hook
-                                     rather than a `:require`. Installed by
-                                     ONE `:require` of the optional bridge
+                                     the pre-publication
+                                     `day8/re-frame2-freehand`, so the verb
+                                     arrives through this hook rather than a
+                                     `:require`. Installed by ONE `:require`
+                                     of the optional bridge
                                      `re-frame.story.play.presence-host`,
-                                     which holds the `re-frame.ui` dependency
+                                     which holds the Freehand dependency
                                      on the app's side of the seam. Unlike
                                      every other hook here, an ABSENT
                                      `:flush-presence!` is NOT a no-op: a

--- a/tools/story/src/re_frame/story/play/presence.cljc
+++ b/tools/story/src/re_frame/story/play/presence.cljc
@@ -4,7 +4,7 @@
 
   ## Why a rung exists
 
-  A variant whose view renders a `(ui/presence {:timeout-ms n} …)` boundary
+  A variant whose view renders a `(v/presence {:timeout-ms n} …)` boundary
   RETAINS a removed keyed child in `:unmounting` until the `:timeout-ms`
   safety bound fires. Playback then has a settlement problem the
   `settled-boundary` ladder cannot solve: the retention is a CLOCK, not a
@@ -14,10 +14,10 @@
   The only wall-clock answer is `[:wait ms]`, which the determinism gate
   REFUSES (`re-frame.story.determinism` §The bare-`[:wait ms]` opt-out).
 
-  `re-frame.ui.test/flush-presence!` is the framework's own answer: it
-  advances the presence FAKE CLOCK, firing due exits with no wall-clock
-  sleep. `(flush-presence!)` advances to quiescence (every pending exit
-  fires); `(flush-presence! ms)` advances the logical clock by `ms`, firing
+  The framework's own answer is its presence FAKE CLOCK
+  (`re-frame.freehand.presence-runtime/advance-clock!`), which fires due exits
+  with no wall-clock sleep. A bare advance goes to quiescence (every pending
+  exit fires); an advance of `ms` moves the logical clock by that much, firing
   only the exits that come due — so a script can observe the retained
   `:unmounting` phase and THEN its terminal removal, deterministically.
 
@@ -27,14 +27,15 @@
 
   ## The host hook
 
-  Story's shipped jar must not depend on `re-frame.ui` (`day8/re-frame2-ui`
-  is pre-publication — the same isolation `re-frame.story.view-tool` keeps),
-  so the verb arrives through the `re-frame.story.late-bind` registry under
-  `:flush-presence!`. The canonical installation is ONE `:require` of the
-  optional bridge `re-frame.story.play.presence-host`, which holds the
-  `re-frame.ui` dependency on the app's side of the seam and installs the
-  verb at its load time. `install-presence-flush!` below stays public for a
-  host that wants to register a different advance.
+  Story's shipped jar must not depend on the view substrate
+  (`day8/re-frame2-freehand` is pre-publication — the same isolation
+  `re-frame.story.view-tool` keeps), so the verb arrives through the
+  `re-frame.story.late-bind` registry under `:flush-presence!`. The canonical
+  installation is ONE `:require` of the optional bridge
+  `re-frame.story.play.presence-host`, which holds the Freehand dependency on
+  the app's side of the seam and installs the verb at its load time.
+  `install-presence-flush!` below stays public for a host that wants to
+  register a different advance.
 
   ## No host installed → `:cannot-run`, never a silent skip
 
@@ -44,9 +45,9 @@
   the framework's JVM arm of `flush-presence!` — conflated two different
   facts. The JVM arm is a no-op because the structural host provably has no
   lifecycle to advance; an ABSENT HOOK proves nothing of the kind, because an
-  app can load `re-frame.ui`, render a real `(ui/presence …)` boundary, and
-  simply omit the bridge call. Its playback would then advance nothing while
-  Story reported a clean verdict.
+  app can load Freehand, render a real `(v/presence …)` boundary, and simply
+  omit the bridge call. Its playback would then advance nothing while Story
+  reported a clean verdict.
 
   Nor does the following assertion carry the refusal: the grammar requires no
   following assertion at all, and an `:assert-db` one needs only the headless
@@ -59,17 +60,17 @@
   (:require [re-frame.story.late-bind :as late-bind]))
 
 (def presence-flush-hook-key
-  "The `re-frame.story.late-bind` hook key a `re-frame.ui`-hosted shell
-  registers its presence-clock advance under. The fn signature is
-  `(f ms-or-nil) → any` — `nil` means advance to quiescence, a number means
-  advance the logical clock by that many milliseconds. Both map 1:1 onto the
-  two arities of `re-frame.ui.test/flush-presence!`."
+  "The `re-frame.story.late-bind` hook key a Freehand-hosted shell registers
+  its presence-clock advance under. The fn signature is `(f ms-or-nil) → any`
+  — `nil` means advance to quiescence, a number means advance the logical
+  clock by that many milliseconds. Both map 1:1 onto the two arities of
+  `re-frame.freehand.presence-runtime/advance-clock!`."
   :flush-presence!)
 
 (defn install-presence-flush!
   "Register the host's presence-clock advance under the `:flush-presence!`
   late-bind hook. `flush-fn` takes ONE argument — the ms to advance by, or
-  `nil` for 'to quiescence' — mirroring `flush-presence!`'s two arities.
+  `nil` for 'to quiescence' — mirroring the clock advance's two arities.
   Idempotent (re-registration replaces, per Spec 001 hot-reload semantics)."
   [flush-fn]
   (late-bind/set-fn! presence-flush-hook-key flush-fn)
@@ -77,16 +78,17 @@
 
 (defn presence-flush-fn
   "The installed presence-advance fn, or nil when no host registered one
-  (the bare JVM / a Story app with no compiled-view presence boundaries)."
+  (the bare JVM / a Story app with no presence boundaries)."
   []
   (late-bind/get-fn presence-flush-hook-key))
 
 (defn- thenable
-  "`x` as a thenable, or nil. CLJS-only: the canonical host verb
-  (`re-frame.ui.test/flush-presence!`) is Promise-backed there, while the JVM
-  arm is a synchronous no-op and a custom host may be synchronous on either.
-  Duck-typed on `.then` rather than `instance? js/Promise` so any thenable a
-  host hands back is observed."
+  "`x` as a thenable, or nil. CLJS-only, and CONDITIONAL: the shipped Freehand
+  bridge is SYNCHRONOUS (its advance runs inside the substrate's `flushSync`
+  commit, so the DOM is settled by the time it returns) and hands back nil,
+  while a custom host — or one built on an awaited React `act`, as the donor's
+  was — may hand back a Promise. Duck-typed on `.then` rather than
+  `instance? js/Promise` so any thenable a host hands back is observed."
   [x]
   #?(:clj  (do x nil)
      :cljs (when (and (some? x) (fn? (unchecked-get x "then"))) x)))
@@ -103,11 +105,12 @@
     {:status :error    :ms … :error s} — the host verb threw
 
   An `:advanced` result additionally carries `:pending <thenable>` when the
-  host verb returned one and has therefore NOT finished (rf2-iz0t8). The
-  canonical CLJS host does exactly that — `flush-presence!` is Promise-backed
-  — so returning `:advanced` bare would report that the advance succeeded
-  while its outcome was still unknown. `settle!` is how a caller waits for the
-  answer; `:advanced` on its own means only 'the verb was reached'.
+  host verb returned one and has therefore NOT finished (rf2-iz0t8). A
+  Promise-backed host does exactly that, and returning `:advanced` bare would
+  report that the advance succeeded while its outcome was still unknown.
+  `settle!` is how a caller waits for the answer; `:advanced` on its own means
+  only 'the verb was reached'. The shipped Freehand bridge is synchronous and
+  carries no `:pending` — `settle!` then calls back before it returns.
 
   Never throws, and never judges: this is pure data → data reporting of what
   happened. The executor (`runner-events/exec-flush-presence!`) projects the

--- a/tools/story/src/re_frame/story/play/presence_host.cljc
+++ b/tools/story/src/re_frame/story/play/presence_host.cljc
@@ -7,26 +7,27 @@
 
   `re-frame.story.play.presence` is the SEAM: it holds the `:flush-presence!`
   late-bind hook and calls whatever the host registered there. It deliberately
-  does NOT `:require` `re-frame.ui` — Story's published jar must not depend on
-  the never-published `day8/re-frame2-ui` (the same isolation the view-tool
+  does NOT `:require` the view substrate — Story's published jar must not
+  depend on `day8/re-frame2-freehand` (the same isolation the view-tool
   consumer keeps). But a seam nothing installs is a seam nothing reaches: the
   hook shipped with no production installer at all, so a presence-bearing
   script could never advance the real clock.
 
-  This namespace is the missing half — the small bridge that DOES require
-  `re-frame.ui.test` and wires its verb into the hook. It is opt-in and never
-  loaded by Story itself, so the dependency direction is unchanged: Story's
-  jar carries this file but never requires it, and the require only resolves
-  in an app that already has `re-frame.ui` on its classpath. Exactly the shape
-  of `re-frame.story.generate.test-check` (an optional adapter whose dependency
-  lives on the `:test` alias only), differing only in that CLJS cannot
-  `requiring-resolve`, so an app without `re-frame.ui` gets a compile-time
-  \"namespace not found\" naming the missing dep rather than a runtime throw.
+  This namespace is the missing half — the small bridge that DOES require the
+  substrate's presence runtime and wires an advance into the hook. It is
+  opt-in and never loaded by Story itself, so the dependency direction is
+  unchanged: Story's jar carries this file but never requires it, and the
+  require only resolves in an app that already has Freehand on its classpath.
+  Exactly the shape of `re-frame.story.generate.test-check` (an optional
+  adapter whose dependency lives on the `:test` alias only), differing only in
+  that CLJS cannot `requiring-resolve`, so an app without Freehand gets a
+  compile-time \"namespace not found\" naming the missing dep rather than a
+  runtime throw.
 
   ## Integration — one `:require`
 
-  An app that mounts the Story shell AND renders `re-frame.ui` compiled views
-  requires this namespace once at boot:
+  An app that mounts the Story shell AND renders Freehand views requires this
+  namespace once at boot:
 
       (ns my-app.story
         (:require [re-frame.story]
@@ -36,31 +37,96 @@
   public and idempotent for the one case that needs it — a test fixture that
   wiped the hook registry (`late-bind/clear!`) and wants it back.
 
+  ## The two verbs it composes, and why neither is a new one
+
+  Freehand publishes the MECHANISM this bridge needs, in two pieces that were
+  already there:
+
+  - **`re-frame.freehand.presence-runtime/advance-clock!`** — the logical
+    clock advance, in the same two arities the script step has (`nil` → to
+    quiescence, a number → advance by that many logical ms). This is the
+    EXACT counterpart of the advance the donor's `re-frame.ui.test/
+    flush-presence!` wrapped; the wrapper is what this bridge supplies, and
+    the advance itself never moved.
+
+  - **`re-frame.substrate.adapter/flush-render!`** — core's adapter-dispatched
+    SYNCHRONOUS commit (Spec 006 §`flush-render!`). The removals an advance
+    fires are React state updates, so a bare advance would leave the DOM one
+    commit behind; running the advance INSIDE the substrate's synchronous
+    commit boundary returns with the DOM settled. Freehand's override of that
+    slot also closes the pending ViewCell window inside the same boundary and
+    converges, and runs the shared `guard-open-drain!` first — so a flush
+    forced from inside an open drain fails loud
+    (`:rf.error/flush-in-open-epoch`) exactly as the donor's did.
+
+  Composing them is why crossing to Freehand needed no new published verb.
+  It also makes the advance SYNCHRONOUS, where the donor's was Promise-backed
+  (its settle point was an awaited React `act`): `flushSync` has committed by
+  the time it returns, so there is nothing left to await. The seam has always
+  supported both — `presence/advance!` attaches a `:pending` thenable only
+  when the host verb returns one, and `settle!` calls back synchronously when
+  it does not — so the runner needs no arm for this and gains no latency.
+
   ## What it deliberately does NOT do
 
   It installs the flush verb and nothing else. In particular it leaves the
   presence WALL CLOCK armed (`presence-runtime/set-wall-clock!` stays true):
   disabling it process-wide would freeze every retained child in a variant a
   human is merely clicking through in the canvas, which no `[:flush-presence]`
-  step is there to release. Playback stays deterministic regardless — the
-  clock's `fire-timer!` is id-keyed and exactly-once, so a logical advance
-  fires a due exit early and the real `setTimeout` that lands later is a no-op.
+  step is there to release. This is why the bridge reaches for `advance-clock!`
+  and NOT for the runtime's own `flush-presence!`, which disarms the wall clock
+  as its first act. Playback stays deterministic regardless — the clock's
+  `fire-timer!` is id-keyed and exactly-once, so a logical advance fires a due
+  exit early and the real `setTimeout` that lands later is a no-op.
 
   With this bridge absent, `[:flush-presence]` REFUSES (`:cannot-run`) rather
   than skipping silently — see `re-frame.story.play.presence`."
   (:require [re-frame.story.play.presence :as presence]
-            [re-frame.ui.test             :as ui-test]))
+            ;; Core's adapter-dispatched synchronous commit. Core is already a
+            ;; hard Story dependency, so this adds no coordinate — it is named
+            ;; here rather than reached through `re-frame.core` because the
+            ;; substrate-contract verbs live on this namespace.
+            [re-frame.substrate.adapter :as substrate]
+            ;; The substrate's presence clock. This is the ONE require that
+            ;; makes this file the app-side half of the seam.
+            [re-frame.freehand.presence-runtime :as fh-presence]))
+
+#?(:cljs
+   (defn- advance-clock!
+     "The raw logical advance, arity-selected on `some?` so `0` — a legal
+     advance — is not mistaken for 'to quiescence'."
+     [ms]
+     (if (some? ms)
+       (fh-presence/advance-clock! ms)
+       (fh-presence/advance-clock!))))
+
+#?(:cljs
+   (defn- advance-and-commit!
+     "Advance the presence clock and return with the DOM SETTLED.
+
+     `flush-render!` is an OPTIONAL contract fn: core's dispatcher runs the
+     thunk only when the installed adapter ships the slot, and returns nil
+     otherwise. A headless Story run installs `plain-atom`, which ships none —
+     there is no React commit to settle there, but the clock is still real and
+     its removal callbacks must still fire. So the advance is re-run outside
+     the boundary exactly when the boundary never ran it, and never twice."
+     [ms]
+     (let [advanced? (volatile! false)]
+       (substrate/flush-render! (fn []
+                                  (vreset! advanced? true)
+                                  (advance-clock! ms)))
+       (when-not @advanced? (advance-clock! ms))
+       nil)))
 
 (defn install!
-  "Register `re-frame.ui.test/flush-presence!` under the `:flush-presence!`
+  "Register the Freehand presence advance under the `:flush-presence!`
   late-bind hook, so a `[:flush-presence]` / `[:flush-presence ms]` script
   step advances the real presence clock.
 
   Story adds no clock, no phase model and no scheduler of its own — the two
-  script arities map 1:1 onto the framework verb's two arities: `nil` ms means
-  advance to quiescence, a number advances the logical clock by that many
-  milliseconds. `0` is a legal advance, so the arity is chosen on `some?`, not
-  on truthiness.
+  script arities map 1:1 onto the framework runtime's two advance arities:
+  `nil` ms means advance to quiescence, a number advances the logical clock by
+  that many milliseconds.
 
   Runs at this namespace's LOAD time (a bare `:require` is the whole
   integration). Idempotent — re-registration replaces the slot, per Spec 001
@@ -68,16 +134,13 @@
   []
   (presence/install-presence-flush!
     (fn [ms]
-      ;; `ui.test/flush-presence!` is the CLJS mounted host only (the ratified
-      ;; ui.test minimization deleted the JVM no-op). The JVM structural render
+      ;; The presence clock is a CLJS-only surface: the JVM structural render
       ;; has no presence lifecycle — no retention timers to advance — so a JVM
       ;; `[:flush-presence]` step is a no-op returning nil, exactly the old JVM
-      ;; `flush-presence!` behaviour. Reader-conditional so the JVM arm never
-      ;; references the now-CLJS-only var.
-      #?(:clj nil
-         :cljs (if (some? ms)
-                 (ui-test/flush-presence! ms)
-                 (ui-test/flush-presence!)))))
+      ;; behaviour. Reader-conditional so the JVM arm never references the
+      ;; CLJS-only vars.
+      #?(:clj  nil
+         :cljs (advance-and-commit! ms))))
   nil)
 
 ;; Load-time install, mirroring how `re-frame.story.canonical` registers its

--- a/tools/story/src/re_frame/story/play/presence_host.cljc
+++ b/tools/story/src/re_frame/story/play/presence_host.cljc
@@ -44,10 +44,8 @@
 
   - **`re-frame.freehand.presence-runtime/advance-clock!`** — the logical
     clock advance, in the same two arities the script step has (`nil` → to
-    quiescence, a number → advance by that many logical ms). This is the
-    EXACT counterpart of the advance the donor's `re-frame.ui.test/
-    flush-presence!` wrapped; the wrapper is what this bridge supplies, and
-    the advance itself never moved.
+    quiescence, a number → advance by that many logical ms). The advance is
+    the framework's; only the wrapper around it is this bridge's.
 
   - **`re-frame.substrate.adapter/flush-render!`** — core's adapter-dispatched
     SYNCHRONOUS commit (Spec 006 §`flush-render!`). The removals an advance

--- a/tools/story/src/re_frame/story/play/runner.cljc
+++ b/tools/story/src/re_frame/story/play/runner.cljc
@@ -55,19 +55,19 @@
   with `:cannot-run` (the capability registry requires `:dom`), and they
   run under a `:dom` / `:browser` runner.
 
-  `[:flush-presence]` / `[:flush-presence ms]` advances the compiled-view
+  `[:flush-presence]` / `[:flush-presence ms]` advances the framework's
   PRESENCE clock (Spec 004 §Presence) so a variant whose view renders a
-  `(ui/presence {:timeout-ms n} …)` boundary settles its retained
+  `(v/presence {:timeout-ms n} …)` boundary settles its retained
   (`:unmounting`) children DETERMINISTICALLY — the fake-clock twin of
   `[:wait ms]`, and the reason a presence-bearing variant does not need the
   determinism opt-out. It routes through
   `re-frame.story.play.presence` to the framework's own
-  `re-frame.ui.test/flush-presence!`; with no presence host installed the
-  step REFUSES (`:cannot-run`) rather than skipping — an absent hook does not
-  prove an absent presence runtime, so a silent no-op there would let a
-  presence-bearing play report a clean verdict over a clock that never moved
-  (rf2-36biz). On CLJS the verb is Promise-backed, and the run loop awaits it
-  before the next step, so a rejected flush fails the step instead of being
+  `re-frame.freehand.presence-runtime/advance-clock!`; with no presence host
+  installed the step REFUSES (`:cannot-run`) rather than skipping — an absent
+  hook does not prove an absent presence runtime, so a silent no-op there
+  would let a presence-bearing play report a clean verdict over a clock that
+  never moved (rf2-36biz). A host verb MAY be Promise-backed, and the run loop
+  awaits it before the next step, so a rejected flush fails the step instead of being
   lost (rf2-iz0t8).
 
   | Step                               | Semantics                                                     |
@@ -140,14 +140,16 @@
   explicitly) and `:flush-presence`. The driver yields one tick AFTER
   these steps so the queued effects drain before the next step runs.
 
-  `:flush-presence` is here because the framework verb it calls
-  (`re-frame.ui.test/flush-presence!`) is Promise-backed on CLJS: the
-  clock advance and its removal callbacks run SYNCHRONOUSLY inside the
-  awaited `act`, but the React commits that unmount the retained subtree
-  settle on the microtask queue. A `setTimeout` 0 yield runs after the
-  microtask queue has drained to empty, so the next step observes the
-  committed removal rather than racing it. On the JVM the verb is a
-  synchronous no-op and the run loop recurs in tail position regardless.
+  `:flush-presence` is here because the host verb's settle point is not
+  guaranteed to be the call's return. The shipped Freehand bridge advances
+  the clock inside the substrate's `flushSync` commit, so its removals ARE
+  committed synchronously; a Promise-backed host (the donor's awaited React
+  `act`, or any custom one) instead lands its commits on the microtask queue.
+  A `setTimeout` 0 yield runs after the microtask queue has drained to empty,
+  so the next step observes the committed removal rather than racing it under
+  EITHER shape — the yield costs a tick and removes a class of flake. On the
+  JVM the verb is a synchronous no-op and the run loop recurs in tail position
+  regardless.
 
   `:dispatch` is not in this set: a `[:dispatch …]` step settles through
   `settled-boundary` (spec/017) — in headless the `dispatch-sync!`
@@ -218,8 +220,8 @@
                            (number? (nth step 1))
                            (not (neg? (nth step 1)))))
     ;; `[:flush-presence]` (to quiescence) / `[:flush-presence ms]` (advance
-    ;; the logical clock by ms) — the two arities of the framework verb
-    ;; `re-frame.ui.test/flush-presence!`, no more.
+    ;; the logical clock by ms) — the two arities of the framework advance
+    ;; `re-frame.freehand.presence-runtime/advance-clock!`, no more.
     :flush-presence (boolean
                       (or (= 1 (count step))
                           (and (= 2 (count step))
@@ -816,8 +818,8 @@
   `[:flush-presence ms]` step, or nil — for the bare `[:flush-presence]`
   (advance to quiescence) AND for any non-`:flush-presence` step. The two
   cases are distinguished by the step TAG, never by this nil: nil here
-  means exactly what nil means to `re-frame.ui.test/flush-presence!` — the
-  no-arg arity."
+  means exactly what nil means to
+  `re-frame.freehand.presence-runtime/advance-clock!` — the no-arg arity."
   [step]
   (when (= :flush-presence (step-type step))
     (nth step 1 nil)))

--- a/tools/story/src/re_frame/story/play/runner_events.cljc
+++ b/tools/story/src/re_frame/story/play/runner_events.cljc
@@ -13,9 +13,9 @@
   - `:wait` ms → JS `setTimeout` (CLJS) or `Thread/sleep` (JVM).
   - `:flush-presence` → the presence-clock advance
     (`re-frame.story.play.presence/advance!` → the host's
-    `re-frame.ui.test/flush-presence!`); `:cannot-run` with no presence
-    host installed (rf2-36biz — an advance that did not happen never
-    reports a clean verdict).
+    `re-frame.freehand.presence-runtime/advance-clock!`); `:cannot-run`
+    with no presence host installed (rf2-36biz — an advance that did not
+    happen never reports a clean verdict).
   - `:assert-db` path value → read from `rf/app-db-value` and compare.
   - `:assert-db` path :pred fn-or-sym → invoke the predicate. A FN
     handed in directly is called as-is (advanced-CLJS-safe); a SYMBOL
@@ -1077,7 +1077,7 @@
                 :message     (str "cannot run " (pr-str step)
                                   " — no presence host is installed, so the "
                                   "presence clock did not advance. An app "
-                                  "that renders re-frame.ui compiled views "
+                                  "that renders Freehand views "
                                   "installs the verb by requiring "
                                   "re-frame.story.play.presence-host (or by "
                                   "calling re-frame.story.play.presence/"
@@ -1086,10 +1086,10 @@
 
 (defn- exec-flush-presence!
   "Execute a `[:flush-presence]` / `[:flush-presence ms]` step — advance the
-  compiled-view PRESENCE clock through the installed host verb
+  framework's PRESENCE clock through the installed host verb
   (`re-frame.story.play.presence/advance!` → the framework's
-  `re-frame.ui.test/flush-presence!`), so a variant rendering a
-  `(ui/presence {:timeout-ms n} …)` boundary settles its retained
+  `re-frame.freehand.presence-runtime/advance-clock!`), so a variant rendering
+  a `(v/presence {:timeout-ms n} …)` boundary settles its retained
   (`:unmounting`) children WITHOUT a wall-clock sleep.
 
   Bare `[:flush-presence]` advances to quiescence (every pending exit
@@ -1101,7 +1101,7 @@
   REQUESTED, and with no host installed it did not happen — so the run reports
   the distinct THIRD status rather than a clean verdict over a clock that
   never moved. \"No hook installed\" does not prove \"no presence runtime
-  exists\": an app can load `re-frame.ui` and simply omit the bridge call.
+  exists\": an app can load Freehand and simply omit the bridge call.
   Nor can a following assertion be relied on to carry the refusal — the
   grammar requires no following assertion, and an `:assert-db` one needs only
   the headless floor. The refusal NAMES its install path so it is actionable.

--- a/tools/story/src/re_frame/story/sub_overrides.cljc
+++ b/tools/story/src/re_frame/story/sub_overrides.cljc
@@ -242,8 +242,12 @@
      static-export release) `ovr-ctx/override-context` is nil — the whole
      sub-override seam is compiled out, including the `subscribe` consult
      — so this fn returns `child` unchanged instead of mounting a
-     Provider on a nil context. Mirrors
-     `re-frame.ui.sub-overrides/provider-element`'s gate."
+     Provider on a nil context. The gate is not this namespace's
+     invention: `re-frame.adapter.sub-override-context` initialises the
+     context var to nil in production WITHOUT calling
+     `React.createContext`, so every mount site owes the same
+     `interop/debug-enabled?` test to avoid mounting a Provider on
+     nothing."
      [overrides child]
      (if interop/debug-enabled?
        [:r> (.-Provider ovr-ctx/override-context) #js {:value overrides} child]

--- a/tools/story/test/re_frame/story/play/presence_cljs_test.cljc
+++ b/tools/story/test/re_frame/story/play/presence_cljs_test.cljc
@@ -1,10 +1,10 @@
 (ns re-frame.story.play.presence-cljs-test
   "S4-H (rf2-qwzmt) — Story's presence rung: the `[:flush-presence]` script
-  step consumes the framework's own `re-frame.ui.test/flush-presence!` so a
+  step consumes the framework's own presence clock so a
   presence-bearing variant settles DETERMINISTICALLY during playback.
 
   The problem the rung solves: a variant whose view renders a
-  `(ui/presence {:timeout-ms n} …)` boundary RETAINS a removed keyed child
+  `(v/presence {:timeout-ms n} …)` boundary RETAINS a removed keyed child
   in `:unmounting` until the timeout fires. That retention is a CLOCK, not a
   queue, so no rung of the `settled-boundary` ladder settles it — playback
   races the timeout, and the only wall-clock answer (`[:wait ms]`) is the
@@ -22,17 +22,18 @@
     script WITH it passes. This is the red-before/green-after, proven
     host-agnostically through the real `run!` playback loop.
   - The REAL framework verb — the same script driven against the ACTUAL
-    `re-frame.ui.test/flush-presence!` and the ACTUAL presence exit
-    scheduler. That arm is ASYNC (the verb is Promise-backed on CLJS) and
-    lives in the pure-`.cljs` companion
+    `re-frame.freehand.presence-runtime/advance-clock!` and the ACTUAL
+    presence exit scheduler. That arm lives in the pure-`.cljs` companion
     `presence_real_clock_cljs_test.cljs`, which reuses this ns's harness.
-    The JVM arm of `flush-presence!` is a documented no-op (there is no
-    lifecycle to advance on the structural host), so the real-clock arm is
-    CLJS-only — exactly the host split the framework verb declares.
+    The JVM arm of the bridge is a documented no-op (the structural host
+    has no lifecycle to advance, and the clock is a CLJS-only surface), so
+    the real-clock arm is CLJS-only — exactly the host split the framework
+    runtime declares.
 
   Mounted three-phase behaviour (`:mounting` → `:present` → `:unmounting`
   against real DOM) belongs to the framework and is pinned there
-  (`re-frame.ui.presence-dom-cljs-test`); Story does not re-prove it. What
+  (`re-frame.freehand.presence-dom-cljs-test`); Story does not re-prove
+  it. What
   Story owns — and what these tests pin — is that its PLAYBACK LOOP can
   reach the verb at the right point.
 
@@ -52,7 +53,7 @@
             [re-frame.story.play.presence         :as story-presence]
             ;; The OPTIONAL bridge under test (rf2-36biz) — the one canonical
             ;; installation path. Requiring it is what an app does; it holds
-            ;; the `re-frame.ui` dependency on the app's side of the seam, so
+            ;; the Freehand dependency on the app's side of the seam, so
             ;; Story's own namespaces never require it (and its jar stays
             ;; free of the pre-publication artefact).
             [re-frame.story.play.presence-host    :as presence-host]
@@ -62,11 +63,12 @@
             ;; The framework's presence exit scheduler — reached ONLY to reset
             ;; it between tests (the CLOCK is a CLJS-only surface: the JVM
             ;; structural host has no lifecycle, so the call is reader-gated).
-            ;; `day8/re-frame2-ui` is pinned on the `:test` alias only — Story's
+            ;; `day8/re-frame2-freehand` is pinned on the `:test` alias only —
+            ;; Story's
             ;; shipped jar must not depend on the pre-publication artefact,
             ;; which is precisely why the rung takes the verb through a
             ;; late-bind hook instead of a `:require`.
-            [re-frame.ui.presence-runtime         :as presence-rt]))
+            [re-frame.freehand.presence-runtime   :as presence-rt]))
 
 ;; ===========================================================================
 ;; PURE: the step grammar (both hosts, no runtime)
@@ -292,7 +294,7 @@
   (testing "rf2-36biz — with NO presence host installed the advance did not
             happen, so the step REFUSES (`:cannot-run`) rather than skipping
             silently. `no hook installed` does not prove `no presence runtime
-            exists`: an app can load re-frame.ui and simply omit the bridge
+            exists`: an app can load Freehand and simply omit the bridge
             call, and its presence-bearing playback would then report a clean
             verdict over a clock that never moved"
     (let [res (exec-step! presence-frame 0 [:flush-presence])]

--- a/tools/story/test/re_frame/story/play/presence_freehand_dom_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/play/presence_freehand_dom_cljs_test.cljs
@@ -97,13 +97,24 @@
   way every Freehand DOM suite does. The presence advance under test is
   deliberately NOT act-driven: it settles through the substrate's own
   synchronous commit, and wrapping it here would prove the harness rather
-  than the bridge."
+  than the bridge.
+
+  The act-environment flag is RESTORED once React settles. Leaving it armed
+  would make every subsequent update outside an act boundary — which is every
+  update this file cares about — emit React's `not wrapped in act(...)`
+  warning, so the lane's console would fill with noise about the exact thing
+  the design says not to do here."
   [thunk]
-  (try
-    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
-    (js/Promise.resolve (react/act (fn [] (js/Promise.resolve (thunk)))))
-    (catch :default e
-      (js/Promise.reject e))))
+  (let [prior (.-IS_REACT_ACT_ENVIRONMENT js/globalThis)
+        restore! (fn [] (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) prior))]
+    (try
+      (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+      (-> (js/Promise.resolve (react/act (fn [] (js/Promise.resolve (thunk)))))
+          (.then (fn [v] (restore!) v)
+                 (fn [e] (restore!) (throw e))))
+      (catch :default e
+        (restore!)
+        (js/Promise.reject e)))))
 
 (defn- setup! []
   (story/clear-all!)

--- a/tools/story/test/re_frame/story/play/presence_freehand_dom_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/play/presence_freehand_dom_cljs_test.cljs
@@ -1,0 +1,269 @@
+(ns re-frame.story.play.presence-freehand-dom-cljs-test
+  "The BEHAVIOURAL proof of Story's presence rung on Freehand (rf2-gzmg0):
+  a real `(v/presence …)` boundary, mounted with `v/mount` into a real
+  `document`, holding a real retained child — and a Story `[:flush-presence]`
+  script step that takes it off the screen.
+
+  ## Why this file exists rather than another headless arm
+
+  Story's seams exist to make a RUNNER deterministic, so the claim worth
+  proving is not 'the bridge calls a function'. Every other arm of the rung
+  reads a counter: `presence-cljs-test` proves the grammar and the hook
+  against a stub, and `presence-real-clock-cljs-test` proves the shipped
+  bridge reaches the framework's real exit scheduler by watching
+  `pending-count` fall. Both would stay green if the retained DOM never
+  moved — the removal callback fires either way, and only React decides
+  whether the subtree actually leaves the page.
+
+  That gap is exactly where the donor→Freehand crossing could have gone
+  wrong. The donor's verb settled at an awaited React `act`; the Freehand
+  bridge settles at the substrate's SYNCHRONOUS commit
+  (`re-frame.substrate.adapter/flush-render!` → Freehand's `flushSync`
+  override). A crossing that advanced the clock but committed nothing would
+  pass every headless assertion in the rung and leave a dismissed toast on
+  screen forever. So this file asserts against `document`.
+
+  ## The red/green pair
+
+  Both tests run the SAME script shape against the SAME retained child and
+  differ in ONE step:
+
+    with    `[[:flush-presence]]`  → the retained child LEAVES the DOM
+    without `[[:dispatch …]]`      → the retained child is STILL THERE
+
+  so neither verdict can be an artefact of the harness. The retention is a
+  CLOCK, not a queue, which is the whole reason the rung exists: no amount
+  of dispatching, draining or yielding removes that child.
+
+  Naming convention (rf2-2hrj8): the `-dom-cljs-test$` suffix opts this file
+  into the `:browser-test` build (Playwright + Chromium, real
+  `react-dom/client`). `:node-test` also loads it — its `cljs-test$` regex
+  matches the suffix — where the mounting branch self-gates on `(browser?)`
+  and says so rather than passing quietly."
+  (:require ["react" :as react]
+            [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.presence-runtime :as presence-rt]
+            [re-frame.registrar :as registrar]
+            [re-frame.router :as router]
+            [re-frame.story :as story]
+            [re-frame.story.late-bind :as late-bind]
+            ;; The OPTIONAL bridge under test — required, not hand-rolled, so
+            ;; this suite is an acceptance test of the ONE canonical
+            ;; integration path (rf2-36biz).
+            [re-frame.story.play.presence-host :as presence-host]
+            [re-frame.story.play.runner-events :as re]
+            [re-frame.substrate.adapter :as substrate]))
+
+(def ^:private variant-frame :story.presence-freehand/frame)
+
+(def ^:private retention-ms
+  "The boundary's terminal retention bound. Large enough that no wall-clock
+  timer can plausibly fire during the test — every removal here is the
+  LOGICAL clock's, which is the determinism the rung exists for."
+  60000)
+
+;; ---------------------------------------------------------------------------
+;; The views. Module-level: a declared view cannot close over a test's locals.
+;; ---------------------------------------------------------------------------
+
+(v/defview toast
+  [{:keys [label]}]
+  (let [phase (v/presence-phase)]
+    [:div.rf-toast {:data-label  label
+                    :data-phase  (name phase)
+                    :aria-hidden (when (= :unmounting phase) true)}
+     label]))
+
+(v/defview toaster
+  [_]
+  (let [ids (v/sub [:toasts])]
+    [:div#story-presence-stack
+     (v/presence {:timeout-ms retention-ms}
+       (for [k ids]
+         [toast {:key k :label k}]))]))
+
+;; ---------------------------------------------------------------------------
+;; Harness
+;; ---------------------------------------------------------------------------
+
+(defn- browser? []
+  (and (exists? js/document) (some? (.-createElement js/document))))
+
+(defn- act
+  "A React 19 `act` boundary as a Promise — used ONLY to drive the MOUNT, the
+  way every Freehand DOM suite does. The presence advance under test is
+  deliberately NOT act-driven: it settles through the substrate's own
+  synchronous commit, and wrapping it here would prove the harness rather
+  than the bridge."
+  [thunk]
+  (try
+    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+    (js/Promise.resolve (react/act (fn [] (js/Promise.resolve (thunk)))))
+    (catch :default e
+      (js/Promise.reject e))))
+
+(defn- setup! []
+  (story/clear-all!)
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (presence-rt/reset-clock!)
+  ;; Test-only determinism: the logical advance is the SOLE removal driver.
+  ;; The BRIDGE deliberately leaves the wall clock armed — see `presence-host`
+  ;; — so a suite that wants determinism disables it here, not there.
+  (presence-rt/set-wall-clock! false)
+  ;; Seat FREEHAND's own adapter, explicitly. A `rf/init!` guarded only by a
+  ;; catch would silently keep whatever a sibling namespace left installed,
+  ;; and a Freehand root mounted over someone else's substrate is a different
+  ;; experiment from the one this file claims to run.
+  (try (rf/destroy-adapter!) (catch :default _ nil))
+  (rf/init! v/adapter)
+  (reset! re/run-state {})
+  (story/install-canonical-vocabulary!)
+  (frame/ensure-default-frame!)
+  (rf/make-frame {:id variant-frame :doc "Freehand presence rung test frame"})
+  (rf/reg-sub :toasts (fn [db _] (:toasts db)))
+  (rf/reg-event :toasts/seed    (fn [{:keys [db]} _] {:db (assoc db :toasts ["a" "b"])}))
+  (rf/reg-event :toasts/dismiss (fn [{:keys [db]} _] {:db (assoc db :toasts ["a"])}))
+  (rf/reg-event :toasts/noop    (fn [{:keys [db]} _] {:db db}))
+  ;; Re-arm the bridge. Requiring it installed the hook once, at ns load;
+  ;; `teardown!` drops it so this suite cannot leak a presence host into the
+  ;; consolidated bundle, and `install!` is public for exactly this case.
+  (presence-host/install!)
+  nil)
+
+(defn- teardown! []
+  (try (rf/destroy-adapter!) (catch :default _ nil))
+  (presence-rt/reset-clock!)
+  (presence-rt/set-wall-clock! true)
+  ;; The late-bind hook registry is process-global; a leaked host would arm
+  ;; every LATER test's `[:flush-presence]` step.
+  (swap! late-bind/hooks dissoc :flush-presence!)
+  nil)
+
+(use-fixtures :each {:before setup! :after teardown!})
+
+(defn- host-node! []
+  (let [node (js/document.createElement "div")]
+    (.appendChild js/document.body node)
+    node))
+
+(defn- toast-el [container label]
+  (.querySelector container (str ".rf-toast[data-label='" label "']")))
+
+(defn- phase-of [container label]
+  (some-> (toast-el container label) (.getAttribute "data-phase")))
+
+(defn- dispatch-and-settle!
+  "Dispatch into the variant frame and return with the Freehand DOM SETTLED —
+  the substrate's own synchronous commit, which is what a Story `:dispatch`
+  step reaches through the settled-boundary ladder."
+  [event]
+  (substrate/flush-render! (fn [] (router/dispatch-sync! event {:frame variant-frame}))))
+
+(defn- skip! [why]
+  (is true (str "a real Freehand mount needs a DOM host — " why)))
+
+(defn- retained-child-on-screen!
+  "Mount the boundary, dismiss `b`, and hand `k` the container with `b`
+  RETAINED: still in the DOM, reading `:unmounting`, its removal pending on
+  the logical clock. Every test below starts from exactly this state."
+  [k]
+  (let [container (host-node!)]
+    (-> (act #(v/mount [toaster {}] container {:frame variant-frame}))
+        (.then (fn [mounted]
+                 (dispatch-and-settle! [:toasts/seed])
+                 (is (some? (toast-el container "b")) "b mounted")
+                 (dispatch-and-settle! [:toasts/dismiss])
+                 (is (some? (toast-el container "b"))
+                     "b is RETAINED in the DOM while exiting, not removed")
+                 (is (= "unmounting" (phase-of container "b"))
+                     "and its own (v/presence-phase) read reaches :unmounting")
+                 (is (= 1 (presence-rt/pending-count))
+                     "exactly one exit is retained on the logical clock")
+                 (k container mounted))))))
+
+(defn- cleanup! [container mounted]
+  (try (v/unmount! mounted) (catch :default _ nil))
+  (.remove container)
+  nil)
+
+;; ===========================================================================
+;; GREEN — the runner's step takes the retained child off the screen
+;; ===========================================================================
+
+(deftest a-flush-presence-step-removes-the-retained-child-from-the-dom
+  (testing "rf2-gzmg0 — the SHIPPED bridge, driven by the SHIPPED run loop:
+            a `[:flush-presence]` script step advances the framework clock,
+            fires the retained exit, and the substrate commits the removal
+            before the run reports. Read back off `document`, because a
+            crossing that advanced the clock and committed nothing would pass
+            every counter-based arm of this rung."
+    (if-not (browser?)
+      (skip! "the browser job runs the removal assertion")
+      (async done
+        (retained-child-on-screen!
+          (fn [container mounted]
+            (re/run! variant-frame "flushing"
+                     {:name   "flushing"
+                      :script [[:flush-presence]]}
+                     (fn [state]
+                       (is (= :pass (:status state))
+                           "the run passed — the step was reached and did not refuse")
+                       (is (nil? (toast-el container "b"))
+                           "the retained child LEFT THE DOM: the advance fired the
+                            exit AND the substrate committed the unmount")
+                       (is (some? (toast-el container "a"))
+                           "and the present sibling is untouched by b's removal")
+                       (is (zero? (presence-rt/pending-count))
+                           "the exit fired exactly once, leaving nothing pending")
+                       (cleanup! container mounted)
+                       (done)))))))))
+
+;; ===========================================================================
+;; RED — the same script without the step leaves it exactly where it was
+;; ===========================================================================
+
+(deftest without-the-step-the-retained-child-stays-on-screen
+  (testing "The NEGATIVE CONTROL for the test above, differing in ONE step.
+            Retention is a CLOCK, not a queue: a script that dispatches and
+            settles through every rung of the settled-boundary ladder still
+            leaves the retained child on screen, because nothing advanced the
+            logical clock. Without this, 'the child is gone' could be an
+            artefact of the mount, the teardown or the harness rather than of
+            the `[:flush-presence]` step."
+    (if-not (browser?)
+      (skip! "the browser job runs the retention assertion")
+      (async done
+        (retained-child-on-screen!
+          (fn [container mounted]
+            (re/run! variant-frame "not-flushing"
+                     {:name   "not-flushing"
+                      :script [[:dispatch [:toasts/noop]]]}
+                     (fn [state]
+                       (is (= :pass (:status state))
+                           "the run itself is fine — it simply never flushed presence")
+                       (is (some? (toast-el container "b"))
+                           "the retained child is STILL on screen: no step advanced
+                            the presence clock, and no other rung can")
+                       (is (= "unmounting" (phase-of container "b"))
+                           "still reading :unmounting, still awaiting its timeout")
+                       (is (= 1 (presence-rt/pending-count))
+                           "its exit is still pending")
+                       (cleanup! container mounted)
+                       (done)))))))))
+
+;; ===========================================================================
+;; Non-vacuity
+;; ===========================================================================
+
+(deftest the-bridge-is-installed-by-requiring-it
+  (testing "Non-vacuity, and the claim the whole rung rests on: merely
+            REQUIRING `re-frame.story.play.presence-host` installs the
+            `:flush-presence!` hook. A suite whose bridge never loaded would
+            report `:cannot-run` above rather than a removal, so pin the
+            install here where the failure names itself."
+    (is (some? (late-bind/get-fn :flush-presence!))
+        "the load-time install armed the hook")))

--- a/tools/story/test/re_frame/story/play/presence_real_clock_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/play/presence_real_clock_cljs_test.cljs
@@ -2,24 +2,27 @@
   "S4-H (rf2-qwzmt) — the Story presence rung driven against the REAL
   framework verb and the REAL presence clock.
 
-  `re-frame.ui.test/flush-presence!` advances
-  `re-frame.ui.presence-runtime`'s exit scheduler — the SAME registry a
-  mounted `(ui/presence {:timeout-ms n} …)` boundary arms its retention
-  timers in. Scheduling a real exit and driving it through Story's
-  `[:flush-presence]` step proves the rung reaches the framework verb FOR
-  REAL, no stub, with no DOM required: mounted three-phase behaviour
-  (`:mounting` → `:present` → `:unmounting`) is the framework's own test
-  (`re-frame.ui.presence-dom-cljs-test`) and Story does not re-prove it.
+  The shipped bridge advances `re-frame.freehand.presence-runtime`'s exit
+  scheduler — the SAME registry a mounted `(v/presence {:timeout-ms n} …)`
+  boundary arms its retention timers in. Scheduling a real exit and driving
+  it through Story's `[:flush-presence]` step proves the rung reaches the
+  framework verb FOR REAL, no stub, with no DOM required. The mounted proof
+  that a real RETAINED CHILD leaves the DOM under this rung is the browser
+  companion `presence-freehand-dom-cljs-test`; the framework's own
+  three-phase behaviour (`:mounting` → `:present` → `:unmounting`) is pinned
+  at `re-frame.freehand.presence-dom-cljs-test` and Story does not re-prove
+  it.
 
   Pure `.cljs`, not `.cljc`, for two reasons that point the same way:
 
-  - the verb is PROMISE-backed on CLJS, so these tests are `async`, and
-    cljs.test then requires MAP fixtures — which a `.cljc` may not use
+  - the rung must be exercised against a PROMISE-backed host as well as the
+    shipped synchronous one, so these tests are `async`, and cljs.test then
+    requires MAP fixtures — which a `.cljc` may not use
     (`re-frame.story.meta-fixtures-test`: the map form silently skips every
     deftest on the JVM half);
-  - the presence CLOCK is a CLJS-only surface. The JVM arm of
-    `flush-presence!` is a documented no-op — the structural host has no
-    lifecycle to advance — so there is nothing here for the JVM to run.
+  - the presence CLOCK is a CLJS-only surface. The JVM arm of the bridge is
+    a documented no-op — the structural host has no lifecycle to advance —
+    so there is nothing here for the JVM to run.
 
   The host-agnostic half of the rung (the grammar, the capability +
   determinism classification, the hook, and the red/green playback proof
@@ -30,9 +33,10 @@
   removal driver — the determinism the whole rung exists for.
 
   This namespace establishes EVERYTHING it consumes and is run standalone as
-  well as in the consolidated bundle (rf2-i36h6). In particular it awaits each
-  Promise-backed advance through the run loop's own settle seam rather than
-  assuming a macrotask yield outran React `act`; see `flush-presence-step!`.
+  well as in the consolidated bundle (rf2-i36h6). In particular it takes every
+  advance through the run loop's own settle seam rather than assuming a
+  macrotask yield outran the host's own settlement; see
+  `flush-presence-step!`.
 
   The final block (rf2-iz0t8) covers the PROMISE-BACKED-ness itself rather
   than the clock: resolved and rejected thenable controls driven through the
@@ -50,7 +54,7 @@
             ;; does; `install!` re-arms it after the shared fixture's teardown.
             [re-frame.story.play.presence-host :as presence-host]
             [re-frame.story.play.runner-events :as re]
-            [re-frame.ui.presence-runtime      :as presence-rt]
+            [re-frame.freehand.presence-runtime :as presence-rt]
             ;; The shared harness (fresh registrar + runtime + variant frame,
             ;; and the same private step executor) — one harness across both
             ;; halves of the rung's coverage.
@@ -94,21 +98,23 @@
 
 (defn- flush-presence-step!
   "Drive ONE `[:flush-presence …]` step to completion and hand `k` its SETTLED
-  step-result. These are the two moves `runner-events/run-loop!` makes for a
-  Promise-backed presence host, in this order:
+  step-result. These are the two moves `runner-events/run-loop!` makes, in
+  this order:
 
-    1. AWAIT the advance's thenable (`settle-step-result!`). On CLJS the
-       framework verb runs its advance inside React `act` and its Promise
-       settles on act's OWN task — so 'the advance is over' is a fact ONLY
-       that thenable can report.
-    2. THEN yield one macrotask, so the React commits the advance queued have
+    1. SETTLE the advance (`settle-step-result!`). For the shipped Freehand
+       bridge that is SYNCHRONOUS — the advance runs inside the substrate's
+       `flushSync` commit — so the callback fires before the call returns.
+       For a Promise-backed host it AWAITS the thenable, because 'the advance
+       is over' is then a fact ONLY that thenable can report.
+    2. THEN yield one macrotask, so any commits the advance queued have
        landed before the next step reads them.
 
   A test driving `exec-step!` DIRECTLY owes BOTH. This namespace used to owe
-  only the yield, on the premise that a `setTimeout` 0 lands after the act has
-  settled. It does not: a macrotask is not ordered against act's own task, and
-  whenever the yield lost that race the NEXT step threw
-  `:rf.error/ui-test-overlapping-act` and advanced NOTHING.
+  only the yield, on the premise that a `setTimeout` 0 lands after a
+  Promise-backed host has settled. It does not: a macrotask is not ordered
+  against a host's own microtask chain, and whenever the yield lost that race
+  the NEXT step re-entered a host operation still in flight and advanced
+  NOTHING.
 
   That made this namespace's pass ORDER-DEPENDENT (rf2-i36h6): green under
   `npm run test:cljs`, where a namespace ahead of it had already exercised the
@@ -128,7 +134,7 @@
   never-fired exit leaves `:toast` nil exactly like a not-yet-due one). The
   STEP-RESULT is what tells those worlds apart, so every advance is checked
   through it: a reached, settled advance carries no `:exception` and no
-  `:cannot-run?`. Without this the overlapping-act failure above would have
+  `:cannot-run?`. Without this the in-flight-host failure above would have
   surfaced only as a downstream retention assertion two ticks later, which is
   precisely why it read as somebody else's bug."
   [result]
@@ -216,14 +222,15 @@
 ;; Promise-backed host settlement (rf2-iz0t8)
 ;; ===========================================================================
 ;;
-;; The canonical CLJS host returns `re-frame.ui.test/flush-presence!`'s
-;; Promise. `presence/advance!` used to call it inside a synchronous `try` and
-;; immediately return `{:status :advanced}` — so the executor recorded a clean
-;; step, the run loop merely yielded a `setTimeout` 0, and a LATER rejection
-;; (a React `act` failure, `:rf.error/flush-convergence-exceeded`) landed
-;; outside the `try`, became an unhandled rejection, and could no longer
-;; change the already-recorded result. A presence-bearing play reported
-;; `:pass` over a flush that had actually failed.
+;; The shipped Freehand bridge is SYNCHRONOUS, but the hook's contract is not
+;; — a host MAY return a Promise, and the donor's did. `presence/advance!`
+;; used to call the verb inside a synchronous `try` and immediately return
+;; `{:status :advanced}` — so the executor recorded a clean step, the run loop
+;; merely yielded a `setTimeout` 0, and a LATER rejection landed outside the
+;; `try`, became an unhandled rejection, and could no longer change the
+;; already-recorded result. A presence-bearing play reported `:pass` over a
+;; flush that had actually failed. These controls are now the ONLY coverage of
+;; that arm — no shipped host exercises it — which is exactly why they stay.
 ;;
 ;; The two hosts below differ in exactly ONE thing — whether their Promise
 ;; resolves or rejects — so neither verdict can be an artefact of anything

--- a/tools/story/test/re_frame/story/realworld_ui_consumer_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/realworld_ui_consumer_cljs_test.cljs
@@ -24,10 +24,12 @@
     2. The ui deck's variant drives the app's REAL counter events through the
        Story play runner and its `:assert-db` on the app's real app-db key
        passes — the app hosted + played GREEN through the shell.
-    3. `[:flush-presence]` reaches the REAL `re-frame.ui.test/flush-presence!`
-       through the shipped `presence-host` bridge and advances a real retained
-       exit (green); with the bridge uninstalled it fails CLOSED
-       (`:cannot-run`) — the late-bound presence seam, end-to-end.
+    3. `[:flush-presence]` reaches the REAL framework presence clock through
+       the shipped `presence-host` bridge and advances a real retained exit
+       (green); with the bridge uninstalled it fails CLOSED (`:cannot-run`) —
+       the late-bound presence seam, end-to-end. That arm follows the BRIDGE,
+       so it crossed to Freehand's scheduler with it (rf2-gzmg0); the app
+       under test in arms 1–2 is still the donor one.
 
   COVERAGE SHAPE — a CLJS unit test on the node runtime, wired into the
   EXISTING `npm run test:cljs` suite (NOT Playwright). Pure `.cljs` (not
@@ -50,14 +52,19 @@
             [re-frame.story.play.presence :as story-presence]
             ;; The shipped OPTIONAL bridge — the one canonical presence-install
             ;; path (rf2-36biz). Requiring it installs the verb at load; each
-            ;; presence test re-arms/clears it explicitly. Holds the re-frame.ui
+            ;; presence test re-arms/clears it explicitly. Holds the substrate
             ;; dependency on the app side of the seam.
             [re-frame.story.play.presence-host :as presence-host]
             [re-frame.story.play.runner-events :as re]
             ;; re-frame.ui — the outward interop bridge that exports a compiled
             ;; view as a foreign React component (the substrate render seam).
+            ;; The APP under test here is still the donor one; only the
+            ;; presence CLOCK below crossed, because the bridge crossed.
             [re-frame.ui :as ui]
-            [re-frame.ui.presence-runtime :as presence-rt]
+            ;; The clock the SHIPPED bridge advances (rf2-gzmg0). The presence
+            ;; block below is an acceptance test of the bridge, not of the
+            ;; donor app, so it follows the bridge onto Freehand's scheduler.
+            [re-frame.freehand.presence-runtime :as presence-rt]
             ;; THE REAL APP (P-1). Requiring it registers the compiled `counter`
             ;; view + the `:ui-counter/*` events + `:ui-counter/count` sub.
             [realworld-resources.ui-counter :as ui-counter]))
@@ -229,7 +236,7 @@
     ;; The logical advance is the SOLE removal driver here.
     (presence-rt/set-wall-clock! false)
     ;; A REAL retained exit on the framework's OWN scheduler — the same registry
-    ;; a mounted (ui/presence …) boundary arms; its removal callback is the
+    ;; a mounted (v/presence …) boundary arms; its removal callback is the
     ;; app-visible consequence.
     (presence-rt/schedule-exit!
      300 #(router/dispatch-sync! [:realworld-ui/presence-removed]
@@ -244,8 +251,8 @@
                        [:assert-db [:toast] :removed]]}
              (fn [state]
                (is (= :pass (:status state))
-                   "the [:flush-presence] rung reached the REAL
-                    re-frame.ui.test/flush-presence! clock and settled")
+                   "the [:flush-presence] rung reached the REAL framework
+                    presence clock and settled")
                (is (zero? (presence-rt/pending-count))
                    "advancing to quiescence fired the retained exit")
                (is (= :removed (:toast (rf/app-db-value presence-frame))))
@@ -254,7 +261,7 @@
 (deftest without-the-bridge-the-flush-presence-step-fails-closed
   (async done
     ;; The fixture left the process-global hook cleared — model an app that
-    ;; loads re-frame.ui + renders a real (ui/presence …) boundary but OMITS
+    ;; loads the substrate + renders a real (v/presence …) boundary but OMITS
     ;; the bridge require.
     (is (nil? (story-presence/presence-flush-fn))
         "no presence host installed — the bridge require is absent")


### PR DESCRIPTION
# Story's presence bridge crosses onto Freehand (rf2-gzmg0)

## The ruling this executes, verbatim

> *"But xray and story should not be using the donor, they should be across onto freehand"*
> *"We intend to remove the donor (re-frame.ui)"*

`rf2-drpa3.57` (F6e) deletes `implementation/ui/` wholesale, so a tool still reading it depends on an artefact scheduled for deletion. This closes **gap 1** of the two the bead records, and reports honestly on **gap 2**.

---

## Did each gap close with existing verbs, or require a new one?

### Gap 1 — the presence-flush hook — **closed with EXISTING verbs. No new public verb. Nothing under `implementation/freehand/src/**` changed.**

The bead framed the gap as "Freehand has the MECHANISM but not the verb". It has **two** mechanisms, and composing them is the whole crossing:

| what the donor's `ui.test/flush-presence!` did | what the Freehand bridge does |
|---|---|
| `presence/advance-clock!` / `advance-clock! ms` | `re-frame.freehand.presence-runtime/advance-clock!` — same two arities, same semantics |
| `guard-open-drain!`, then an awaited React `act`, then a convergence loop | `re-frame.substrate.adapter/flush-render!` — core's adapter-dispatched **synchronous** commit, whose Freehand override runs *the same* `guard-open-drain!`, closes the pending ViewCell window inside React's commit boundary, and converges under the same budget |

So the bridge is `(flush-render! #(advance-clock! ms))`. Both verbs already existed; `flush-render!` is the production-grade contract surface Spec 006 defines and the Tool-Pair MCP already drives in a `dispatch → flush-render! → observe-settled-DOM` loop.

Two details that are load-bearing rather than incidental:

- **`advance-clock!`, not the runtime's own `flush-presence!`.** The latter calls `(set-wall-clock! false)` as its first act. The bridge has always deliberately left the wall clock **armed** — a variant a human is merely clicking through in the canvas has no `[:flush-presence]` step to release its retained children — so reaching for the runtime's `flush-presence!` would have silently changed shipped behaviour. `advance-clock!` is the exact layer the donor's verb wrapped.
- **`flush-render!` is an OPTIONAL contract fn.** Core's dispatcher runs the thunk only when the installed adapter ships the slot and returns nil otherwise, so a headless run under `plain-atom` would have advanced *nothing*. The bridge re-runs the advance exactly when the boundary never ran it, and never twice.

**On the `v/defbehavior` precedent:** it does not apply here and I did not try to force it. That recipe is about a *view-side* deferred foreign handle — `:connect` returns a mutable cell synchronously, the continuation closes over that local, `:disconnect` fences before releasing, `:closed` is terminal. A presence flush is a *test/runner-side* settle point with no view lifetime to hang off. The equivalent move — "serve the need from what is already published rather than minting a verb" — is what I did, via a different pair of existing verbs.

### Gap 2 — the sub-overrides provider — **NOT closed. It needs Freehand source, which is fenced. STOPPING per the brief.**

Verified against current `main` rather than taken from the bead:

- The React **context** is not the donor's and is not going anywhere: `re-frame.adapter.sub-override-context` lives in **core** (`implementation/core/src/re_frame/adapter/sub_override_context.cljs`), CLJS-only, gated on `interop/debug-enabled?`.
- `re-frame.ui.sub-overrides` is two `^:no-doc` fns over that core context, consumed only by `re-frame.ui.viewcell` and donor tests. There is no public donor surface to reproduce.
- The real gap is in the **read path**. Freehand's `v/sub` goes `cell/observe!` → `cell/record-read!` → `(obs/resolve-target {:query-v query*})` — **with no `:override` key**. Core's observation port already supports `:override` and lowers a hit to a callback-free static `:story-override` handle; the *consumer* is what supplies it, and the donor's consumer is `re-frame.ui.reactive`. Freehand has no counterpart.

Closing that means editing `implementation/freehand/src/re_frame/freehand/cell.cljc` (fenced) and deciding whether the override consult is a published concept — an api-manifest question, and that lane is held. **I did not enter it.** What this PR does instead is remove the *stale pointer*: `re-frame.story.sub-overrides`' docstring cited `re-frame.ui.sub-overrides/provider-element`'s gate; it now cites the durable core carriage that actually owns the gate, so nothing in Story points at a namespace scheduled for deletion.

---

## Donor-shaped facts deliberately let go

1. **The Promise.** The Freehand advance is **synchronous** — `flushSync` has committed by the time it returns. The seam already supported both shapes (`presence/advance!` attaches `:pending` only when the host verb hands back a thenable; `settle!` calls back before returning when it does not), so the runner needed no arm and gains no latency. The docstrings that asserted "on CLJS the verb is Promise-backed and the run loop awaits it" were host-specific history and are respelled as conditional.
2. **React `act`.** Not used for the advance. `flushSync` is the production-grade commit path, and arming `IS_REACT_ACT_ENVIRONMENT` inside a live Story canvas would be wrong. `act` survives in the new DOM test **only** to drive the mount, and the flag is now saved and restored.
3. **The donor's overlapping-act guard** (`:rf.error/ui-test-overlapping-act`) and its 100-line act-serialisation apparatus. Meaningless for a synchronous verb; that machinery existed to let `with-root` and `flush!` compose, which is a mounted-host facade, not this bridge.
4. **A rejected Promise as the failure channel.** Freehand's `flush-render!` throws `:rf.error/flush-convergence-exceeded` / `:rf.error/flush-in-open-epoch` **synchronously**; `presence/advance!` catches and reports `{:status :error}`, the same vocabulary a rejection produced. The Promise-rejection arm of the seam is now exercised **only** by the stub controls in `presence-real-clock-cljs-test` — which is exactly why they stay, and the comment there says so.
5. **The mounted-host test facade itself** (`with-root` / `flush!` / `flush-presence!` on a `re-frame.freehand.test` tier). Still owed — see *Still owed* below. Story does not re-implement it, and this bridge does not stand in for it.

---

## Quality gates

All run locally in the worker worktree, foreground to completion, `rc` captured immediately.

| gate | command | counts | rc |
|---|---|---|---|
| CLJS node (consolidated) | `shadow-cljs compile node-test && node out/node-test.js` | **11494 tests / 57474 assertions, 0 failures, 0 errors** | **0** |
| Browser lane (Playwright + Chromium) | `npm run test:browser` | **797 tests / 5053 assertions, 0 failures, 0 errors** — and **0** React `not wrapped in act(...)` warnings | **0** |
| JVM tools (full roster) | `scripts/test-jvm-tools.sh` | xray 1270/5908 · machines-viz 632/2537 · **story 1847/6824** · story-mcp 292/1531 · mcp-base 272/924 · testbed-support 32/153 · wire-vocab 100/1069 · template 59/611 — **0 failures across all 8** | **0** |
| MCP conformance | `npm run test:mcp-conformance` | 6/6 gates green | **0** |
| Donor inventory | `python scripts/check_donor_inventory.py --ci --report` | 203 rows, **134 → 129** undisposed | **0** |
| Donor inventory self-test | `python scripts/check_donor_inventory.py --self-test` | all cases passed | **0** |

**CI on `6a1ad6129b` (pre-rebase): 32 non-skipped checks, all `SUCCESS`, 0 failures** — including `JVM tools/story`, `CLJS (shadow-cljs :node-test)`, `Freehand conformance index` (the donor-inventory gate), `MkDocs build`, `Public-API manifest drift-check` (no manifest movement — no new public verb), `Story/Xray browser gates (PR-smoke)`, and the four MCP-conformance jobs.

Two CI reds on the earlier commits, both resolved and both real rather than flakes:
- `JVM tools/story` on `be775be8be` — the src crossing landed before the `deps.edn` pin, so `re-frame.freehand.presence-runtime` was not on the JVM `:test` classpath. Fixed by the following commit.
- `Freehand conformance index` — `check_donor_inventory.py --ci` fails a row still marked `pending` when nothing it matches carries donor material, which removing `re-frame.ui` from `tools/story` causes by construction. Fixed by disposing the five rows below. Only rows this diff disposed were touched.

### Rebased onto `main` after PR #7038 (rf2-7gth0) landed

#7038 flipped **seven `tools/xray/` rows** in `spec/conformance/freehand/donor-inventory.md`; this branch flips **five `tools/story/` rows** in the same table, on adjacent lines — hence `CONFLICTING`. Both sets are real dispositions, so the resolution **takes both**, and neither `--ours` nor `--theirs` was used.

Method, chosen so an Xray row cannot be lost by hand: take `origin/main`'s copy of the file wholesale (carrying all seven Xray dispositions), then re-apply the five Story flips onto it as exact, asserted, single-occurrence string substitutions. Verified structurally rather than by eye:

- `git diff origin/main...HEAD` on that file is **exactly 5 changed rows, all `tools/story/`**;
- `tools/xray` rows: **7 `done`, 0 `pending`**;
- the three rows deliberately left pending — `deps.edn`, `view_tool*`, `realworld_ui_consumer` — each re-checked as still `pending`;
- 0 conflict markers.

**The count is 129, not the 135 predicted.** The arithmetic, measured rather than assumed: the pre-collision baseline was **141** undisposed; #7038 disposed **7** (not 1), taking `main` to **134**; these 5 take it to **129**. 141 − 7 − 5 = 129, and `done` moves 62 → 74 with the 203-row total unchanged. Nothing was lost in the resolution — the earlier "140 after Xray landed" figure was one row rather than seven.

Every gate was **re-run on the rebased tree**, because `main` had also moved `implementation/freehand/{behaviors,descriptor,events,compiler/emit_react}.cljc` and `tools/story/{plan,registrar}.cljc` underneath this branch — a pre-rebase green is not evidence about a post-rebase tree. The counts in the table above are the post-rebase ones, and the negative control was re-run post-rebase too. The rebase preserved every source blob byte-for-byte (hashes re-checked against the pre-rebase commits); only the ledger line differs.

## Story spec disposition

`tools/story/spec/017-Testing-Story.md` **is updated in this PR** — §Presence-bearing variants now names the framework advance the rung reaches, the core commit the bridge composes with, `(v/presence …)` / `(v/presence-phase)` in its examples, and states that the shipped host is synchronous while the hook's contract still admits a Promise-backed one.

## Donor-inventory rows disposed (`pending` → `done`)

- `tools/story/src/re_frame/story/late_bind.cljc`
- `tools/story/src/re_frame/story/sub_overrides.cljc`
- `tools/story/src/re_frame/story/play/*`
- `tools/story/test/re_frame/story/play/presence_*`
- `tools/story/spec/017-Testing-Story.md`

Left `pending`, deliberately, because this diff does not dispose them:

- `tools/story/deps.edn` — the donor coordinate is still required by `view_tool*` and `realworld_ui_consumer`. This PR **adds** `day8/re-frame2-freehand` alongside it (the node build already carried `freehand/src`; this gives the JVM `clojure -M:test` gate the same classpath).
- `tools/story/test/re_frame/story/view_tool*` — reads `re-frame.ui.tool` / `.tool.evidence` / `.reactive` / `ui.test/render`. Freehand counterparts exist (`re-frame.freehand.tool`, `.evidence`), so this is a mechanical crossing, but it is a distinct piece of work with its own contract respell (integer `:rf.ui.tool/version 3` → `:schema :re-frame.freehand.evidence/v1`, the shape PR #6978 did for pair-mcp).
- `tools/story/test/re_frame/story/realworld_ui_consumer_cljs_test.cljs` — blocked on `examples/real-apps/realworld_resources/ui_*.cljs`, which are donor apps.

---

## Still owed, and flagged rather than smuggled in

1. **Gap 2's substantive half** — a Freehand sub-override consult in `cell/record-read!`, threading `:override` into `obs/resolve-target`. Fenced; needs the api-manifest lane.
2. **The Freehand mounted test tier** — `re-frame.freehand.test` publishes `render` / `with-render` / `find` / `find-all` / `attrs` / `text`: a JVM-and-CLJS **structural** facade with no `with-root` / `flush!` / `flush-presence!`. The `spec/008-Testing.md` ledger row for "structural and mounted testing, the host and mode matrix" is still `MOVE | F1 | pending`, and `spec/Ownership.md:46` still points that contract at `day8/re-frame2-ui`. This PR does not need it — the bridge composes published verbs instead — but the row is real and outlives F6e.
3. **CI does not run the browser lane for this diff.** `.github/scripts/report-changed-surfaces.sh` reports `cljs_browser=false` for it: `is_story_xray_node_test_path` fires `cljs_node_test` for `tools/story/test/**.cljs`, but no rule fires `cljs_browser`, so a `*_dom_cljs_test.cljs` under `tools/story/test/` is gated only by `:node-test`, where it self-skips. The pre-existing `sub_overrides_render_dom_cljs_test.cljs` has the same gap. I ran the browser lane locally with the negative control above rather than widen a hot-zone CI script outside my brief.
