### PR TITLE
fix(freehand): evaluate a compiled element's :key before its trusted markup (rf2-rrosy)

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/compiler/emit_react.cljc
+++ b/implementation/freehand/src/re_frame/freehand/compiler/emit_react.cljc
@@ -463,22 +463,37 @@
                                               (safe-spread-write o tag controlled? safe-spread)))
                       (seq top) (conj `(re-frame.freehand.top-layer/install!
                                         ~o ~tag ~top))
+                      ;; The key is the LAST of the props, and it is a props
+                      ;; expression: it is authored inside the map, so the
+                      ;; interpreted walk evaluates it — with the rest of the
+                      ;; map — before it ever looks at the child position. It
+                      ;; therefore writes before the trusted markup below.
+                      ;; Nothing about the OBJECT turns on this: `"key"` and
+                      ;; `"dangerouslySetInnerHTML"` are different slots and
+                      ;; neither write reads the other. What turns on it is
+                      ;; EVALUATION ORDER, which is observable through side
+                      ;; effects and through which of the two throws first —
+                      ;; and with the markup emitted ahead of the key both
+                      ;; diverged from the authored order: a throwing key let
+                      ;; the markup expression run anyway, and a throwing
+                      ;; markup expression pre-empted a key the author wrote
+                      ;; first (rf2-rrosy, #6980 audit).
+                      (:present? key-info)
+                      (conj `(cljs.core/unchecked-set ~o "key" ~(:expr key-info)))
                       ;; Trusted markup writes LAST, and it is a write rather
                       ;; than a build-time literal for one reason: the string is
                       ;; usually an expression, and an expression authored as the
-                      ;; element's CHILD must evaluate after the props map it
-                      ;; follows in the source — the order the interpreted walk
-                      ;; produces. It goes through the shared browser writer, so
-                      ;; the string check and the `<textarea>` / void refusals
-                      ;; are the interpreted walk's, not a second set here. The
-                      ;; analyzer sets `:children []` on an html-kid element, so
-                      ;; no positional child accompanies the markup and React's
-                      ;; children-vs-innerHTML conflict cannot arise.
+                      ;; element's CHILD must evaluate after the whole props map
+                      ;; it follows in the source — the order the interpreted
+                      ;; walk produces. It goes through the shared browser
+                      ;; writer, so the string check and the `<textarea>` / void
+                      ;; refusals are the interpreted walk's, not a second set
+                      ;; here. The analyzer sets `:children []` on an html-kid
+                      ;; element, so no positional child accompanies the markup
+                      ;; and React's children-vs-innerHTML conflict cannot arise.
                       (:html node)
                       (conj `(re-frame.freehand.compiled-react/html!
-                              ~o ~tag ~(:form (:html node))))
-                      (:present? key-info)
-                      (conj `(cljs.core/unchecked-set ~o "key" ~(:expr key-info))))
+                              ~o ~tag ~(:form (:html node)))))
         ;; Bindings, in evaluation order: owned dynamic values (source order),
         ;; then the guarded caller map (after the owned expressions), then the
         ;; one verdict derived from both — then each reconciler handler site,

--- a/implementation/freehand/test/re_frame/freehand/react_lowering_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/react_lowering_jvm_test.clj
@@ -459,6 +459,53 @@
       (is (= 1 (count (filter #(= '(:m props) %) nodes)))
           "and the :multiple expression exactly once"))))
 
+(deftest an-element-evaluates-its-key-before-its-trusted-markup
+  (testing "rf2-rrosy #6980 audit — trusted markup used to be conjoined onto
+            the write list BEFORE the key, so the emitted body evaluated the
+            element's CHILD expression ahead of a props expression the author
+            wrote first. Nothing about the props OBJECT turned on it — `key`
+            and `dangerouslySetInnerHTML` are different slots — but the
+            observable order did: a throwing key still ran the markup
+            expression, and a throwing markup expression pre-empted the key.
+            Interpreted, the whole authored map is evaluated before the child
+            position is looked at, so the compiled tier owes that order.
+
+            This reads the emitted FORM. The RUN twin of the same claim, over
+            the same declaration and on both React paths, is
+            `re-frame.freehand.trusted-markup-dom-cljs-test`; the structural
+            pair is `re-frame.freehand.trusted-markup-ssr-jvm-test`."
+    (let [[e ast]  (analyzed '[:div {:key (:k props)} (v/html (:markup props))])
+          form     (emit-react/emit-react-body e '[props] ast)
+          nodes    (vec (tree-seq coll? seq form))
+          key-idx  (.indexOf nodes '(:k props))
+          html-idx (.indexOf nodes '(:markup props))]
+      (is (<= 0 key-idx) "the :key expression is present in the emitted body")
+      (is (<= 0 html-idx)
+          "the trusted-markup expression is present — the row is not vacuous")
+      (is (.contains ^String (pr-str form)
+                     "re-frame.freehand.compiled-react/html!")
+          "and it is present as the html! WRITE, not as a positional child")
+      (is (< key-idx html-idx)
+          "the :key expression is evaluated before the trusted-markup one")
+      (is (= 1 (count (filter #(= '(:k props) %) nodes)))
+          "the :key expression is evaluated exactly once")
+      (is (= 1 (count (filter #(= '(:markup props) %) nodes)))
+          "and the trusted-markup expression exactly once"))))
+
+(deftest a-wholly-literal-trusted-markup-element-is-still-hoisted
+  (testing "The repair above reorders two writes and must not cost the
+            build-time settlement beside them: an element whose props and
+            whose markup are all literal is `:static?`, so the emitter builds
+            it ONCE outside the render and shares it. The hoist shows up as a
+            binding symbol in the emitted body rather than an inline
+            `compiled-react/el` call under the render fn."
+    (let [[e ast] (analyzed '[:div.static (v/html "<em>fixed</em>")])
+          form    (pr-str (emit-react/emit-react-body e '[props] ast))]
+      (is (.contains ^String form "rf-fh-const-")
+          "the literal trusted-markup element is bound once, outside the render")
+      (is (.contains ^String form "re-frame.freehand.compiled-react/html!")
+          "and the hoisted build still writes the markup"))))
+
 (deftest a-safe-spread-caller-multiple-shapes-the-owned-nil-value
   (testing "rf2-sf9n5 gap #1 — a v/spread-safe caller may legally carry
             :multiple, and it folds UNDER the owned props. The compiled emitter

--- a/implementation/freehand/test/re_frame/freehand/trusted_markup_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/trusted_markup_dom_cljs_test.cljs
@@ -25,12 +25,21 @@
   to fail; in the browser job the same declarations mount and the claims are
   read off `document`.
 
+  The host-neutral lane carries one more thing, and it is there because the
+  DOM cannot see it: EVALUATION ORDER. A compiled element writes its key and
+  its trusted markup into different slots of one props object, so an emitter
+  that ran the child expression before the props map produced byte-identical
+  DOM — and diverged only in side-effect order and in which expression throws
+  first. Those rows run the declaration's body directly and read a log
+  (rf2-rrosy, #6980 audit).
+
   The structural counterpart, over the same declarations, is
   `re-frame.freehand.trusted-markup-ssr-jvm-test`."
   (:require ["react" :as react]
             [cljs.test :refer-macros [async deftest is testing use-fixtures]]
             [re-frame.adapter.uix :as react-substrate]
             [re-frame.freehand :as v]
+            [re-frame.freehand.descriptor :as descriptor]
             [re-frame.freehand.react :as fr]
             [re-frame.freehand.root :as root]
             [re-frame.freehand.trusted-markup-views :as views]
@@ -67,12 +76,96 @@
             beside it, so one that quietly fell back to the interpreted walk
             could not pass."
     (doseq [k [:markup-body-compiled :markup-with-props-compiled
-               :literal-markup-compiled :markup-nested-compiled]]
+               :keyed-markup-compiled :literal-markup-compiled
+               :markup-nested-compiled]]
       (let [view (get views/by-name k)]
         (is (= :compiled (:lowering (v/describe view)))
             (str k " — declared compiled"))
         (is (contains? (:capabilities (v/manifest view)) :html)
             (str k " — and its manifest names the trusted-markup capability"))))))
+
+;; ---------------------------------------------------------------------------
+;; The host-neutral lane — evaluation ORDER on the two React paths
+;; ---------------------------------------------------------------------------
+
+;; What the DOM cannot see. Every mounted row below reads the RESULT, and the
+;; result is the same whichever of the element's two expressions ran first —
+;; `key` and `dangerouslySetInnerHTML` are different slots on the props object
+;; and neither write reads the other. So a compiled emitter that evaluated the
+;; child before the props map produced identical DOM and diverged only in
+;; side-effect order and in which expression throws first (rf2-rrosy, #6980
+;; audit). These rows make that observable: the declaration's key and its
+;; markup are opaque calls, and the suite hands it thunks that record.
+;;
+;; No DOM is needed to see it, so these run in the node suites too: the
+;; declaration's body is what evaluates, and `descriptor/react-body` /
+;; `descriptor/render-body` are the two fns a React mount would have called.
+
+(defn- ran
+  "Run one census declaration's BODY on the React path its lowering names —
+  the compiled twin's emitted React realisation, or the interpreted twin's
+  render body — and answer the log of what its two expressions did.
+
+  Calling the body is what a React mount does with it; going through the
+  mount as well would add a DOM the claim does not need, and a React error
+  boundary between the throw and the assertion."
+  [view-name props]
+  (let [view (get views/by-name view-name)]
+    ((or (descriptor/react-body view) (descriptor/render-body view)) props)))
+
+(deftest an-element-evaluates-its-key-before-its-trusted-markup
+  (testing "THE ORDER ROW. `:key` is authored inside the props map, so the
+            interpreted path evaluates it — with the rest of the map — before
+            it looks at the child position holding the markup. The compiled
+            twin owes the same order, and used to invert it: the emitter
+            conjoined the `html!` write before the `unchecked-set` of the key.
+            Both paths, one declaration, and each expression exactly once."
+    (doseq [k [:keyed-markup :keyed-markup-compiled]]
+      (let [[log props] (views/recorder)]
+        (ran k props)
+        (is (= [:key :html] @log)
+            (str k " — the key ran first, and each expression ran once"))))))
+
+(deftest a-throwing-key-pre-empts-the-trusted-markup
+  (testing "The first exception prefix. A key expression that throws means
+            the markup expression never runs at all — which is what the
+            author wrote, and what the interpreted path does. With the markup
+            emitted first the compiled twin ran it anyway, so a failed render
+            had performed a side effect the source says it could not reach."
+    (doseq [k [:keyed-markup :keyed-markup-compiled]]
+      (let [[log props] (views/recorder {:k #(throw (ex-info "key boom" {}))})
+            thrown      (try (ran k props) ::no-throw
+                             (catch :default e (ex-message e)))]
+        (is (= "key boom" thrown)
+            (str k " — the authored key expression is what threw"))
+        (is (= [] @log)
+            (str k " — and the trusted-markup expression never ran"))))))
+
+(deftest a-throwing-trusted-markup-runs-after-the-key
+  (testing "The other prefix, and the one that fails the other way round: a
+            markup expression that throws throws AFTER the key has been
+            evaluated, so the key's side effect is already recorded when the
+            render fails. Compiled, the markup used to throw first and the key
+            expression never ran."
+    (doseq [k [:keyed-markup :keyed-markup-compiled]]
+      (let [[log props] (views/recorder {:m #(throw (ex-info "markup boom" {}))})
+            thrown      (try (ran k props) ::no-throw
+                             (catch :default e (ex-message e)))]
+        (is (= "markup boom" thrown)
+            (str k " — the authored markup expression is what threw"))
+        (is (= [:key] @log)
+            (str k " — and the key had already been evaluated, once"))))))
+
+(deftest the-order-rows-run-one-react-path-each
+  (testing "The non-vacuity pin for the three rows above. They are a claim
+            about the COMPILED React lowering and its interpreted twin, so a
+            compiled declaration that quietly had no React realisation —
+            `descriptor/react-body` nil, the interpreted body run twice —
+            would satisfy every one of them while proving nothing."
+    (is (some? (descriptor/react-body (views/by-name :keyed-markup-compiled)))
+        "the compiled twin carries a React realisation, and that is what ran")
+    (is (nil? (descriptor/react-body (views/by-name :keyed-markup)))
+        "and the interpreted twin carries none, so its own body ran")))
 
 ;; ---------------------------------------------------------------------------
 ;; The browser lane

--- a/implementation/freehand/test/re_frame/freehand/trusted_markup_ssr_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/trusted_markup_ssr_jvm_test.clj
@@ -88,10 +88,53 @@
             other off the analyzed AST — and they meet only at the
             canonicaliser's `:html` slot."
     (is (seq views/modes) "the pair table loaded")
-    (doseq [[interpreted compiled] views/modes]
-      (is (= (rendered interpreted {:markup markup :lang "en"})
-             (rendered compiled {:markup markup :lang "en"}))
-          (str interpreted " / " compiled " — one tree, either mode")))))
+    ;; The whole props roster the table's declarations read, so one sweep
+    ;; drives every pair: the `keyed-markup` pair takes its key and its
+    ;; markup from thunks (see `views/recorder`) and the rest ignore them.
+    (let [props {:markup markup :lang "en"
+                 :k (constantly "k1") :m (constantly markup)}]
+      (doseq [[interpreted compiled] views/modes]
+        (is (= (rendered interpreted props) (rendered compiled props))
+            (str interpreted " / " compiled " — one tree, either mode"))))))
+
+(deftest the-structural-paths-evaluate-the-key-before-the-trusted-markup
+  (testing "rf2-rrosy #6980 audit — the authored order, on the two STRUCTURAL
+            paths. `:key` is a prop, so an interpreted walk evaluates it with
+            the rest of the map BEFORE it looks at the child position; a
+            compiled twin that reversed the two would diverge in exactly the
+            ways side effects and exceptions can be observed. The defect the
+            audit found was the React emitter's, but the claim is the
+            declaration's, so it is pinned on every path the declaration has."
+    (doseq [view [:keyed-markup :keyed-markup-compiled]]
+      (let [[log props] (views/recorder)]
+        (structural view props)
+        (is (= [:key :html] @log)
+            (str view " — the key expression ran first, and each ran once"))))))
+
+(deftest a-throwing-structural-key-pre-empts-the-trusted-markup
+  (testing "The exception-prefix half of the order claim: what has already
+            happened when the render fails. A key that throws means the
+            markup expression never runs — on both structural paths."
+    (doseq [view [:keyed-markup :keyed-markup-compiled]]
+      (let [[log props] (views/recorder {:k #(throw (ex-info "key boom" {}))})]
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"key boom"
+                              (structural view props))
+            (str view " — the authored key expression is what threw"))
+        (is (= [] @log)
+            (str view " — and the trusted-markup expression never ran"))))))
+
+(deftest a-throwing-structural-markup-runs-after-the-key
+  (testing "The other prefix. A markup expression that throws throws AFTER
+            the key has been evaluated, because the key is part of the props
+            map that precedes the child — so the key's side effect is
+            already recorded when the render fails."
+    (doseq [view [:keyed-markup :keyed-markup-compiled]]
+      (let [[log props] (views/recorder {:m #(throw (ex-info "markup boom" {}))})]
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo #"markup boom"
+                              (structural view props))
+            (str view " — the authored markup expression is what threw"))
+        (is (= [:key] @log)
+            (str view " — and the key had already been evaluated, once"))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The markup — verbatim, and the control that makes "verbatim" mean something

--- a/implementation/freehand/test/re_frame/freehand/trusted_markup_views.cljc
+++ b/implementation/freehand/test/re_frame/freehand/trusted_markup_views.cljc
@@ -62,7 +62,10 @@
 (v/defview markup-with-props
   "An element carries its attributes AND its trusted markup: the content
   channel is the markup's, and the props channel is untouched by it. A
-  literal class, a runtime attribute and a key all sit beside the bypass."
+  literal class, `#id` sugar, a runtime attribute and a `data-*`
+  pass-through all sit beside the bypass. A real React `:key` is a
+  separate fixture — see `keyed-markup` below, which is about ORDER rather
+  than about arrival."
   [{:keys [markup lang]}]
   [:section.prose#post {:lang lang :data-kind "body"} (v/html markup)])
 
@@ -73,6 +76,39 @@
   {:compiled true}
   [{:keys [markup lang]}]
   [:section.prose#post {:lang lang :data-kind "body"} (v/html markup)])
+
+;; ---------------------------------------------------------------------------
+;; A real `:key` beside the markup — the ORDER fixture
+;; ---------------------------------------------------------------------------
+
+;; `#post` id sugar is a build-time literal, so `markup-with-props` can only
+;; prove that ordinary props ARRIVE. It cannot see the other cross-mode fact a
+;; props-plus-markup element carries: WHEN each expression runs. Both values
+;; here are opaque zero-argument calls, so a suite supplies thunks that record
+;; their own turn — or throw — and the authored order becomes observable
+;; (rf2-rrosy, #6980 audit: the compiled React emitter wrote the trusted markup
+;; before the key, so a throwing key still ran the markup expression and a
+;; throwing markup expression pre-empted the key).
+;;
+;; `:key` is the prop chosen because it is the LAST thing the compiled React
+;; emitter writes onto the props object, and trusted markup is the element's
+;; content — so this pair is the two ends of the emitted element meeting.
+
+(v/defview keyed-markup
+  "A real React `:key` and trusted markup on ONE element, both from opaque
+  calls. Interpreted, the authored props map — key included — is evaluated
+  whole before the child position is looked at; the compiled twin must
+  produce that same order."
+  [{:keys [k m]}]
+  [:section.order {:key (k)} (v/html (m))])
+
+(v/defview keyed-markup-compiled
+  "The compiled twin. Here the key is an `unchecked-set` write and the
+  markup a `html!` write onto the same props object, so their emitted
+  ORDER is the whole of the claim."
+  {:compiled true}
+  [{:keys [k m]}]
+  [:section.order {:key (k)} (v/html (m))])
 
 ;; ---------------------------------------------------------------------------
 ;; A literal string — the site the compiler can settle whole
@@ -121,6 +157,8 @@
    :escaped-body-compiled    escaped-body-compiled
    :markup-with-props       markup-with-props
    :markup-with-props-compiled markup-with-props-compiled
+   :keyed-markup             keyed-markup
+   :keyed-markup-compiled    keyed-markup-compiled
    :literal-markup           literal-markup
    :literal-markup-compiled  literal-markup-compiled
    :markup-nested            markup-nested
@@ -134,5 +172,21 @@
   [[:markup-body       :markup-body-compiled]
    [:escaped-body      :escaped-body-compiled]
    [:markup-with-props :markup-with-props-compiled]
+   [:keyed-markup      :keyed-markup-compiled]
    [:literal-markup    :literal-markup-compiled]
    [:markup-nested     :markup-nested-compiled]])
+
+(defn recorder
+  "Props for the `keyed-markup` pair that RECORD their turn: an atom of the
+  tags in evaluation order, and the props map whose two thunks conj onto it.
+
+  `overrides` replaces either thunk — `{:k #(throw …)}` — so the throwing
+  arms and the ordinary one are the same declaration under different
+  values, which is what makes the comparison a claim about the LOWERING."
+  ([] (recorder {}))
+  ([overrides]
+   (let [log (atom [])
+         note (fn [tag v] (swap! log conj tag) v)]
+     [log (merge {:k #(note :key "k1")
+                  :m #(note :html "<b>bold</b>")}
+                 overrides)])))


### PR DESCRIPTION
Closes rf2-rrosy — the **audit reopen of #6980**, not a re-ship of the slice.

## What this is, and what it is not

`v/html` is already complete on `main`. #6973 (53b93abb7) published the verb
**together with** all four lowerings and the `element-content-carriers` fence;
#6980 landed the acceptance corpus and the corpus alignment. `main` was never
in the publish-without-lowering state, so the atomicity constraint is not live
here and this is not the honest-diagnostic half — that split was about a
capability that did not yet exist.

The merged-PR audit of #6980 reopened this bead for **one residual defect** in
the code half, and that is what this PR repairs.

## The defect

> the new compiled React lowering evaluates the trusted-markup child before the
> element's `:key`, reversing authored/interpreted evaluation order.

Confirmed by direct production-emitter probe before touching anything. For
`[:div {:key (:k props)} (v/html (:markup props))]` `emit-react` produced:

```clojure
(let [o (js-obj)]
  (compiled-react/html! o :div (:markup props))     ; the CHILD, first
  (unchecked-set o "key" (:k props))                ; the PROP, second
  o)
```

`:key` is authored **inside the props map**, so the interpreted walk evaluates
it — with the rest of the map — before it ever looks at the child position.

Nothing about the props *object* turned on the order: `"key"` and
`"dangerouslySetInnerHTML"` are different slots and neither write reads the
other, which is exactly why every existing row stayed green and why the DOM
could not see it. What turned on it was **evaluation order**, observable two
ways — side effects, and which expression throws first. A throwing key still
ran the markup expression; a throwing markup expression pre-empted a key the
author wrote first.

## The repair

One reordering in `emit-react/emit-element*`: the `(:present? key-info)` write
now conjoins **before** the `(:html node)` write. Bounded exactly as the audit
directed — no scheduler, no emitter rewrite. Preserved, and each pinned by a
row:

- each expression emitted **once**;
- the **children-free** `dangerouslySetInnerHTML` shape (`el` still gets `nil`
  kids);
- **hoisting** for a wholly literal trusted-markup element.

`rules.cljc:362-364` needed no edit, exactly as the ruling anticipated.

## The four lowerings, and where each is now pinned for ORDER

All four already existed and are unchanged by this PR. The audit's
completeness point was that no fixture could see the *order* on any of them —
the props fixture uses `#post` id sugar, a build-time literal, so it can only
prove that ordinary props arrive. Each path now has a row.

| # | Path | Lowering | Order pinned by |
|---|---|---|---|
| 1 | interpreted React | `react/element-node` reads the sole-child position, calls `put-html!` | `trusted-markup-dom-cljs-test` — runs `descriptor/render-body` |
| 2 | **compiled React** | `emit-react/emit-element*` emits `compiled-react/html!` — **the defect** | `react-lowering-jvm-test` (emitted form) **+** `trusted-markup-dom-cljs-test` (run, via `descriptor/react-body`) |
| 3 | interpreted structural | `node/element`'s `:html` slot via `node/html-content!` | `trusted-markup-ssr-jvm-test` — `tree/render` |
| 4 | compiled structural | `emit-jvm/emit-element` fills the same `:html` slot | `trusted-markup-ssr-jvm-test` — `tree/render` on the promoted twin |

Paths 3 and 4 were **already correct**, verified by probe rather than assumed:
`emit-jvm`'s `cond->` writes `:key-val` before `:html` into a small array-map
whose values the compiler evaluates in insertion order. Probed at three widths
(bare, six-prop, `v/spread`-carrying) and the order held on all three. They are
pinned anyway, because the claim belongs to the declaration rather than to one
emitter.

**The carrier fence held and was checked before trusting any green.** `:html`
still hangs *outside* `grammar/element-props-carriers`; #6973's
`element-content-carriers` roster and
`the-react-emitter-reads-every-element-content-carrier` are untouched and green.
That fence catches a *dropped* carrier — this defect was a carrier read at the
wrong *moment*, a different axis, which is why it needed its own row.

## The fixture

`markup-with-props`'s docstring claimed "a key" sat beside the bypass. There is
none. Corrected, and a new pair added:

```clojure
(v/defview keyed-markup [{:keys [k m]}]
  [:section.order {:key (k)} (v/html (m))])
```

Both values are opaque zero-argument calls, so `views/recorder` hands the
declaration thunks that record their turn — or throw. One declaration, three
scenarios (ordinary, throwing key, throwing markup), which is what makes the
comparison a claim about the **lowering** rather than about two different
views. The pair joins `by-name` and `modes`, so the pre-existing
`the-two-structural-paths-build-the-identical-tree` sweep covers it too.

The React order rows need no DOM — the declaration's *body* is what evaluates —
so they ride the host-neutral lane and run in the node suites as well as the
browser job. `the-order-rows-run-one-react-path-each` is their non-vacuity pin:
a compiled declaration that quietly had no React realisation would satisfy all
three while proving nothing.

## Scope notes for the mayor

The brief was written against the pre-#6973 state of the bead. Two standing
instructions turned out not to apply, and I did not act on them:

- **The api-manifest serial lane was not entered.** No var is published by this
  PR — `re-frame.freehand/html` has been on `main` since 53b93abb7 — so there
  is no manifest row, no metadata tier, no `spec/API.md` roster row and no
  `docs/api` member to co-edit. `spec/api-manifest.edn` is untouched and its
  `:var-count` is unchanged at **574**. All three api-manifest steps were run
  anyway, to prove the lane really is quiet.
- **Nothing under `docs/core/freehand/` was edited**, so the digest-pinned
  fenced blocks are untouched.

Fences respected: no edit under `scripts/**`, `tools/**`,
`spec/009-Instrumentation.md`, `spec/Spec-Schemas.md`, `implementation/epoch/**`,
`implementation/resources/**`, `docs/design/freehand/**`. The one shared tree,
`implementation/freehand/src/**`, was touched in exactly one file
(`compiler/emit_react.cljc`) and one function (`emit-element*`); the live
small-defect worker's landed work (`descriptor.cljc`, `events.cljc`,
`behaviors.cljc`) does not overlap, and this branch is rebased on top of it.

## Negative control per path

Each mutation was applied to the **source**, `git diff --stat` was read to
confirm it actually landed (the leading-space failure mode), the gate was run,
the mutation reverted, and the gate re-run.

### Path 2 — compiled React (the path this PR changes)

Mutation: restore the original write order — move the key `conj` back after the
html `conj` in `emit_react.cljc`. Applied: `1 file changed, 4 insertions(+), 3
deletions(-)`.

| gate | mutated | restored |
|---|---|---|
| freehand JVM | **1 failure**, rc=1 | 0 failures, rc=0 |
| freehand CLJS (`test:freehand`) | **3 failures**, rc=1 | 0 failures, rc=0 |

Named verdicts, read in `clojure.test` argument order (expected first):

```
FAIL (an-element-evaluates-its-key-before-its-trusted-markup)   [emitted form]
  the :key expression is evaluated before the trusted-markup one
  expected: (< key-idx html-idx)
    actual: (not (< 26 19))

FAIL (an-element-evaluates-its-key-before-its-trusted-markup)   [run]
  :keyed-markup-compiled — the key ran first, and each expression ran once
  expected: (= [:key :html] (deref log))
    actual: (not (= [:key :html] [:html :key]))

FAIL (a-throwing-key-pre-empts-the-trusted-markup)
  :keyed-markup-compiled — and the trusted-markup expression never ran
  expected: (= [] (deref log))
    actual: (not (= [] [:html]))

FAIL (a-throwing-trusted-markup-runs-after-the-key)
  :keyed-markup-compiled — and the key had already been evaluated, once
  expected: (= [:key] (deref log))
    actual: (not (= [:key] []))
```

The **interpreted** rows (`:keyed-markup`) stayed green throughout the
mutation, and so did all three structural rows. That is the control that makes
them an oracle rather than a copy of the subject.

### Paths 1, 3, 4 — revert the lowering itself

These lowerings are not what this PR changes, so what is owed is that their
rows are not vacuous. Each was reverted in place and restored.

| path | mutation | mutated result | restored |
|---|---|---|---|
| 1 interpreted React | `props (cond-> props false (put-html! …))` in `react.cljs` | node lane **0 failures** — it cannot see this path; browser lane **8 failures + 3 errors**, all in `trusted-markup-dom-cljs-test` | 794/5033, 0 failures, rc=0 |
| 3 interpreted structural | `html-leaf nil` in `node.cljc` `element` | freehand JVM **17 failures** across `trusted-markup-ssr-jvm-test` (both twins) and `trusted-markup-cljs-test` | 0 failures, rc=0 |
| 4 compiled structural | `false (assoc :html …)` in `emit_jvm.cljc` | freehand JVM **17 failures**, compiled twins only — including both new structural order rows | 0 failures, rc=0 |

Path 1's row is worth naming: reverting the interpreted React lowering is
**invisible to `test:cljs`** and reds only in the browser job, because the
mount assertions `skip!` without a DOM. The order rows added here are the
first rows on that path that run in both lanes.

Hoisting control: with `constant-node?` no longer reaching the literal
trusted-markup element, `a-wholly-literal-trusted-markup-element-is-still-hoisted`
reds (`rf-fh-const-` absent). Restored green.

## Quality gates

Run from the worktree, foreground, to completion. `rc` captured immediately
into a worktree-local log and cross-checked against each log's own verdict
line. Everything below is **post-rebase** onto `3d443d44d6` unless marked.

| gate | result | rc |
|---|---|---|
| `implementation/freehand` JVM (`clojure -M:test`) | **1132 tests / 7584 assertions, 0 failures, 0 errors** | 0 |
| `npm run test:freehand` (focused CLJS node) | **1199 tests / 6583 assertions, 0 failures, 0 errors** | 0 |
| `npm run test:cljs` (pre-rebase base `c8db10dd26`) | **11490 tests / 57490 assertions, 0 failures, 0 errors** | 0 |
| `npm run test:browser` | **794 tests / 5036 assertions, 0 failures, 0 errors**, no uncaught pageerror | 0 |
| api-manifest step 1 — `gen --check` | `OK: spec/api-manifest.edn in sync (574 public vars).` | 0 |
| api-manifest step 2 — `ui-context --check` | `OK: ui-context.md in sync (98 ids, 32 authoring vars).` | 0 |
| api-manifest step 3 — `api-md-check` | `OK: spec/API.md projection in sync (254 var-rows).` | 0 |
| Splint (`--fail-on-errors`, CI surface) | 0 errors; style warnings only, all pre-existing idiom | 0 |
| clj-kondo (`--fail-level error`, CI surface) | **0 errors under `implementation/freehand`** | see note |

**Empty-diff proof for the regenerated manifest.** `spec/api-manifest.edn` was
never hand-edited and `gen --check` exits 0, so the committed file equals
generator output:

```
$ git diff --stat -- spec/api-manifest.edn spec/api-manifest-metadata.edn spec/API.md docs/api skills/
(no output)
```

The whole branch diff is five files, all under `implementation/freehand/`:

```
$ git diff origin/main...HEAD --stat
 .../src/re_frame/freehand/compiler/emit_react.cljc | 37 ++++++---
 .../re_frame/freehand/react_lowering_jvm_test.clj  | 47 +++++++++++
 .../freehand/trusted_markup_dom_cljs_test.cljs     | 95 +++++++++++++++++++++-
 .../freehand/trusted_markup_ssr_jvm_test.clj       | 51 +++++++++++-
 .../re_frame/freehand/trusted_markup_views.cljc    | 56 ++++++++++++-
 5 files changed, 269 insertions(+), 17 deletions(-)
```

**clj-kondo note.** The local run exits 3 on **10 pre-existing errors**, all of
class `Expected: throwable, received: boolean/nil/string` in
`implementation/ui/**` and `implementation/epoch/**` — trees this PR never
touches and which are fenced for this worker. They are an artefact of the local
binary (v2025.10.23) against CI's pinned v2026.04.15. Zero errors anywhere
under `implementation/freehand/`; the new lines produce only the same
`Unresolved symbol` warning class every pre-existing `v/defview` in the same
file already produces, and warnings never fail the gate.

**Baselines re-derived, not trusted**, from this worktree before any edit:
freehand JVM **1124 / 7517** (brief: 1124/7517 ✓); `test:cljs` **11486 /
57476** implied by the post-change 11490/57490 (brief: ~11486/57497);
browser **790 / 5019** implied by the post-change 794/5033 (brief: ~790/5019 ✓).
The +4 browser/CLJS tests and +8 JVM tests are exactly the rows added here.

## Non-goals — not drifted into

No sanitizer, no DOMPurify, no Trusted Types, no content-policy hook, no "safe
string" branding, no generalized evaluation-order framework. `v/html` remains a
derivative projection: this PR moves one `conj` and adds rows that watch it.
