### PR TITLE
docs,ci: make four documented claims true (rf2-taceb, rf2-fy3k8, rf2-inbws, rf2-kx06s)

### DIFF
--- a/.github/workflows/freehand-conformance.yml
+++ b/.github/workflows/freehand-conformance.yml
@@ -73,6 +73,11 @@ on:
       - 'scripts/check_freehand_conformance_index.py'
       - 'scripts/check_donor_inventory.py'
       - 'scripts/check_doc_slugs.py'   # supplies the shared slug index
+      # The census DERIVES its two CLJS lane selectors rather than listing
+      # them (rf2-k41ph), so the file that defines the lanes and the reader
+      # that parses it are inputs to this job exactly as the checkers are.
+      - 'implementation/shadow-cljs.edn'
+      - 'scripts/check_test_lane_bijection.py'
       - 'requirements.txt'
       - '.github/workflows/freehand-conformance.yml'
   # PR trigger is intentionally UNFILTERED (see REQUIRED-CHECK SHAPE above).

--- a/docs/core/freehand/compilation.md
+++ b/docs/core/freehand/compilation.md
@@ -76,7 +76,8 @@ not a quota or a badge.
 ```
 
 Call sites stay `[todo-row props]`. Structural tests do not change. The public var
-remains a **descriptor** (not `IFn`) — you never `(todo-row {})`.
+remains a **descriptor** — mounted, never invoked. `(todo-row {})` does not
+render; it raises `:rf.error/view-called-directly`, naming the three recoveries.
 
 The grammar version is artifact-wide (`:re-frame.freehand/v1`), carried on findings
 and manifests. It is **not** a per-view compatibility profile between products, and
@@ -370,7 +371,8 @@ Mechanically:
 - Compiled parent → **statically named** interpreted child: fine (emitted boundary).
 - Compiled parent → runtime-chosen head: put the dynamic choice **inside** an
   interpreted child, or stay interpreted.
-- Direct call `(view props)`: always wrong (descriptor is not `IFn`).
+- Direct call `(view props)`: always wrong — the descriptor answers it with
+  `:rf.error/view-called-directly` rather than rendering.
 
 ### Evidence: static vs realized
 

--- a/docs/core/freehand/limits-and-escapes.md
+++ b/docs/core/freehand/limits-and-escapes.md
@@ -15,7 +15,7 @@ This page is a map of walls and recoveries.
 | You cannot | Why | Do this instead |
 |---|---|---|
 | Vector-call a bare `defn` | boundaries are declared descriptors | `v/defview` + `[view props]`, or call the helper with parens |
-| Direct-call a `v/defview` | public vars are not `IFn` | `[view props]` |
+| Direct-call a `v/defview` | a declared boundary is mounted, never invoked; the call raises `:rf.error/view-called-directly` | `[view props]` |
 | Use `v/sub` outside a declared render | render-only observation | `rf/subscribe-once` |
 | Call `v/sub` off the render thread | capture is same-thread only | realize on the render thread or extract a child view |
 | Put multi-intent vectors in handlers | one event per user action | one semantic event + effects |

--- a/examples/ui/minimal-counter/shadow-cljs.edn
+++ b/examples/ui/minimal-counter/shadow-cljs.edn
@@ -30,6 +30,13 @@
   {:target     :browser
    :output-dir "resources/public/js"
    :asset-path "/js"
-   ;; shadow's :browser target re-runs :init-fn after each hot reload —
-   ;; no separate ^:dev/after-load hook is needed.
+   ;; `:init-fn` runs ONCE, on initial load: shadow appends the call to the
+   ;; module's own output (shadow.build.targets.browser/merge-init-fn), and a
+   ;; hot reload re-evaluates the changed namespace files, not the module
+   ;; wrapper. This scaffold wires no `:devtools :after-load` and marks
+   ;; nothing `^:dev/after-load`, so `watch` prints shadow's own
+   ;; "reloading code but no :after-load hooks are configured!" and an edited
+   ;; view is picked up on the next page load. That is the smallest thing
+   ;; that runs, not a limit of the mount — `v/mount` is idempotent per root,
+   ;; so re-entering it is the supported reload path when you want one.
    :modules    {:main {:init-fn my.app/run}}}}}

--- a/examples/ui/minimal-counter/src/my/app.cljs
+++ b/examples/ui/minimal-counter/src/my/app.cljs
@@ -28,9 +28,19 @@
 ;; The mount's `:frame` ENSURES frame :app and drains :initial-events to
 ;; completion before React is handed anything, so the first paint already
 ;; carries the seeded count — no dispatch-sync, no empty-then-flash. The
-;; root's identity is DERIVED from the mounted view's registered id, so a hot
-;; reload finds the same root live and re-renders it in place: your state
-;; survives edits.
+;; root's identity is DERIVED from the mounted view's registered id, so
+;; re-entering `v/mount` re-renders the root that is already live rather than
+;; allocating a second one (docs/core/freehand/install.md §Two roots on one
+;; page).
+;;
+;; Nothing in this scaffold re-enters it. `run` is the module's `:init-fn`,
+;; which shadow calls once on initial load, and no after-load hook is wired
+;; here — so under `watch` an edited view shows up on the next page load.
+;; That is a choice about how small this directory should be, not a limit:
+;; `rf/init!` is a no-op once an adapter is installed, and re-mounting the
+;; same root under the same frame plan re-renders in place without reseeding
+;; `:initial-events`, so marking `run` with `^:dev/after-load` is the whole
+;; of what a state-preserving reload loop takes.
 
 (defn ^:export run []
   (rf/init! v/adapter)

--- a/implementation/core/test/re_frame/prod_elision_runner.cljs
+++ b/implementation/core/test/re_frame/prod_elision_runner.cljs
@@ -1,67 +1,53 @@
 (ns re-frame.prod-elision-runner
-  "Custom browser-test runner for the production-mode elision smoke
-  builds (rf2-2zdu trace listener elision; rf2-uwg5 source-coord
-  DOM annotation elision; rf2-00li UIx wrap-view elision;
-  rf2-hqbeh `:on-error` always-on survival).
+  "Custom browser-test runner for the production-mode elision smoke builds
+  (`:browser-test-prod-elision`).
 
-  Mirrors `re-frame.schemas-boundary-prod-runner` (Spec 010 prod-mode
-  smoke runner): the default shadow-cljs `:browser-test` runner-ns
+  ## The one job
+
+  Mirrors `re-frame.schemas-boundary-prod-runner` (Spec 010 prod-mode smoke
+  runner): the default shadow-cljs `:browser-test` runner-ns
   `shadow.test.browser` uses `cljs-test-display.core/init!`, which does
   `(set! root-node-id …)` on a `(goog-define root-node-id …)`. Under
-  `:advanced` Closure rejects re-assignment of a `@define`.
+  `:advanced` Closure rejects re-assignment of a `@define`, so the build
+  fails before a single test runs.
 
   This runner bypasses cljs-test-display and runs `cljs.test/run-tests`
   directly. The default cljs.test reporter writes the
   `Ran N tests containing M assertions.` summary to the browser console
   (via `*print-fn*` → `console.log`), which is what the Playwright
-  orchestrator (scripts/run-browser-tests.cjs) watches for."
-  (:require [cljs.test :as test]
-            [shadow.test :as st]
-            [shadow.test.env :as env]
-            ;; Pull each prod-mode smoke namespace into the test
-            ;; environment so shadow.test/run-all-tests discovers it.
-            [re-frame.trace-listener-elision-prod-test]
-            [re-frame.source-coord-dom-elision-prod-test]
-            [re-frame.adapter.uix-source-coord-dom-elision-prod-test]
-            [re-frame.on-error-elision-prod-test]
-            ;; Per rf2-9pxj70 — the three EP-0008-promoted always-on
-            ;; teardown / write-race rows
-            ;; (`:rf.error/frame-teardown-failed`,
-            ;; `:rf.error/write-after-destroy`,
-            ;; `:rf.error/on-destroy-handler-exception`) were exercised
-            ;; only by the DEV `:node-test` runner; this pins their
-            ;; production-survival under `:advanced` + `goog.DEBUG=false`,
-            ;; matching the older always-on rows in
-            ;; `on-error-elision-prod-test`.
-            [re-frame.teardown-always-on-elision-prod-test]
-            [re-frame.event-emit-elision-prod-test]
-            ;; Per rf2-gmrks — `:rf.error/flow-eval-exception` rides
-            ;; the always-on error-emit substrate (Spec 013 §Failure
-            ;; semantics rule 4 + Resolved decisions, rf2-0q0du).
-            ;; This prod-elision test pins the production-survival
-            ;; contract under `:advanced` + `goog.DEBUG=false`.
-            [re-frame.flow-eval-exception-elision-prod-test]
-            ;; Per rf2-xxd6z — runtime prod-elision pins for the
-            ;; routing / http / flows trace-emit surfaces. Companion
-            ;; behavioural check to the string-grep sentinel sweep in
-            ;; `scripts/check-elision.cjs`; pins that no `:rf.route/*`
-            ;; / `:rf.http/*` / `:rf.flow/*` events are delivered to a
-            ;; registered trace listener under `:advanced` +
-            ;; `goog.DEBUG=false`.
-            [re-frame.routing-trace-emit-elision-prod-test]
-            [re-frame.http-trace-emit-elision-prod-test]
-            [re-frame.flows-trace-emit-elision-prod-test]
-            ;; Per rf2-l7hlm — `:advanced` prod-elision pins replicated
-            ;; for the trace-bus (ring buffer), epoch (Tool-Pair
-            ;; §Time-travel surface), and frame-provider / render-key
-            ;; (Spec 004 §Render-tree primitives) machinery. Sibling
-            ;; to the existing rf2-2zdu (trace listener),
-            ;; rf2-hqbeh (`:on-error`) and rf2-uwg5 (source-coord DOM)
-            ;; pins; together they cover every dev-only sub-surface
-            ;; under `:advanced` + `goog.DEBUG=false`.
-            [re-frame.trace-bus-elision-prod-test]
-            [re-frame.epoch-elision-prod-test]
-            [re-frame.frame-provider-render-key-elision-prod-test]))
+  orchestrator (scripts/run-browser-tests.cjs) watches for.
+
+  ## What discovers the tests, and what does not
+
+  `:ns-regexp` does, and this namespace has no say in it. The
+  `:browser-test` target resolves the roster on every compile cycle
+  (`shadow.build.targets.browser-test/test-resolve`) and injects EVERY
+  match as a module entry:
+
+      (assoc-in [::modules/config :test :entries]
+        (-> '[shadow.test.env] (into test-namespaces) (conj runner-ns)))
+
+  where `test-namespaces` comes from `shadow.build.test-util/find-test-
+  namespaces` — the build's `:namespaces` when it declares any, and every
+  classpath namespace matching `:ns-regexp` otherwise. This build declares
+  no `:namespaces`, so `-elision-prod-test$` is the whole roster and a
+  file is in the lane the moment it is named to match.
+
+  So this runner deliberately requires NO test namespace. It used to
+  require thirteen, under a comment saying the list was what put them in
+  the test environment. It was not: the same run that loaded those
+  thirteen ran 116 tests, and the thirteen carry 64 `deftest`s between
+  them — the other 52 arrived by `:ns-regexp`, exactly as every one of the
+  thirteen already had. A list that cannot omit anything cannot be read
+  as authoritative either, and a maintainer who believed it would
+  conclude that the files missing from it did not run.
+
+  If a lane ever needs an authoritative roster, the place to put it is the
+  build's `:namespaces` key, which `find-test-namespaces` honours AHEAD of
+  `:ns-regexp` — there a missing entry is a real, detectable omission
+  instead of a comment."
+  (:require [shadow.test :as st]
+            [shadow.test.env :as env]))
 
 (defn ^:export init []
   (-> (env/get-test-data)

--- a/implementation/schemas/test/re_frame/schemas_boundary_prod_runner.cljs
+++ b/implementation/schemas/test/re_frame/schemas_boundary_prod_runner.cljs
@@ -13,13 +13,17 @@
   `Ran N tests containing M assertions.` summary to the browser console
   (via `*print-fn*` → `console.log`), which is exactly what the
   Playwright runner (scripts/run-browser-tests.cjs) watches for. No DOM
-  reporter is needed because the orchestrator polls the console stream."
-  (:require [cljs.test :as test]
-            [shadow.test :as st]
-            [shadow.test.env :as env]
-            ;; Pull the prod-mode boundary smoke into the test
-            ;; environment so shadow.test/run-all-tests discovers it.
-            [re-frame.schemas-boundary-prod-test]))
+  reporter is needed because the orchestrator polls the console stream.
+
+  It requires no test namespace, for the reason
+  `re-frame.prod-elision-runner` sets out at length: the `:browser-test`
+  target injects every `:ns-regexp` match as a module entry on each compile
+  cycle, so `-boundary-prod-test$` is what puts the smoke in this lane. The
+  single require this namespace used to carry was accurate, which is the
+  trap — it read as the mechanism while being a coincidence of there being
+  exactly one match."
+  (:require [shadow.test :as st]
+            [shadow.test.env :as env]))
 
 (defn ^:export init []
   (-> (env/get-test-data)


### PR DESCRIPTION
Four documented claims the code does not keep. Text, one path filter, and two
runner docstrings — no new feature, no new gate, no doc-example conformance
framework (`rf2-kem4o` stays deferred; this cluster found no second violating
example).

Closes nothing on its own — the mayor closes on the merged SHA.

---

## rf2-taceb — the descriptor **is** `IFn`

**Found.** Three sites, not two: `docs/core/freehand/compilation.md:79` and
`:373`, and `docs/core/freehand/limits-and-escapes.md:18`. All three said the
descriptor is "not `IFn`", i.e. that the call is structurally impossible.

`rf2-llxsw` made that false, and the code says so in its own words.
`implementation/freehand/src/re_frame/freehand/descriptor.cljc`,
`def-descriptor-type`:

> the type implements `IFn` and throws. `(ifn? a-view)` is therefore TRUE, and
> nothing depends on it being false

The type implements the call protocol *solely* so `direct-call!` can raise
`:rf.error/view-called-directly` and name three recoveries — and `rf2-yn5nj`
just made that diagnostic the teaching surface. "Not `IFn`" taught the reader
that the mechanism could not be reached.

**Changed.** All three now say the descriptor is mounted, never invoked, and
that a direct call raises `:rf.error/view-called-directly`. That is the
wording `mental-model.md:55`, `build-a-view.md:61`, `debugging.md:16` and
`docs/api/re-frame.freehand.md:501` already carry — these three were the
stragglers, and the sweep found no others (`grep -rn 'IFn\|ifn?' docs/`).

**Digest trap: not triggered.** Line 79 is prose after a closing fence, 373 is
a bullet, and 18 is a table row — none is inside a fenced block. Proved rather
than assumed: `samples_coverage_jvm_test.clj` still reports **113 of 136 fenced
blocks** and the freehand JVM suite is on its baseline (below).

## rf2-fy3k8 — a runner that documented a mechanism it did not have

**Found.** Both prod-mode runners carried a `:require` list under the comment
*"Pull each prod-mode smoke namespace into the test environment so
`shadow.test/run-all-tests` discovers it."* Not the mechanism.
`shadow.build.targets.browser-test/test-resolve` (shadow-cljs 3.4.10)
injects every match as a module entry on **each compile cycle**:

```clojure
(assoc-in [::modules/config :test :entries]
  (-> '[shadow.test.env] (into test-namespaces) (conj (::tu/runner-ns state))))
```

with `test-namespaces` from `shadow.build.test-util/find-test-namespaces`,
whose first line is `(if (seq namespaces) namespaces …)` — the build's
`:namespaces` key wins, `:ns-regexp` is the fallback, and neither build
declares `:namespaces`.

**The proof is executable, and it is a count.** The thirteen namespaces
`prod_elision_runner` required carry **64** `deftest`s between them (3, 4, 2,
16, 6, 4, 1, 4, 3, 6, 5, 6, 4). The lane
runs **116** — every `deftest` across all 34 files matching
`-elision-prod-test$`. So 52 tests were already arriving by a mechanism the
docstring credited to the require list, and seven whole files were missing
from that list, which is what a list nobody can detect an omission in looks
like after a year.

Deleting both lists changes nothing, which is the whole point:

| | tests | assertions | failures | rc |
|---|---|---|---|---|
| before (14 requires) | 116 | 519 | 0 | 0 |
| after (0 requires) | 116 | 519 | 0 | 0 |

**Changed.** Remedy (a) from the bead: both lists deleted, both docstrings now
name `:ns-regexp` as the owner and name `:namespaces` as where an
authoritative roster would go if a lane ever wants one. The unused
`[cljs.test :as test]` alias goes too — `shadow.test`'s own `ns` form requires
`cljs.test`, so nothing here needed to.

The schemas-boundary runner's single require was **accurate**, which is the
sharper trap: it read as the mechanism while being a coincidence of there
being exactly one matching file. Its lane runs 7 tests with zero requires —
the same 7 `deftest`s the one matching file holds.

## rf2-inbws — minimal-counter's reload claim

**I narrowed the claim. I did not wire a hook, and the capability is real but
unwired.**

**Found — and one of the two named sites was wrong.** The claim lives in
`examples/ui/minimal-counter/shadow-cljs.edn:33` and in the mount comment in
`src/my/app.cljs`. **The README carries no HMR claim at all** — `grep -i
'reload\|hmr\|survive\|state\|watch\|edit'` over it returns one line, the
`npx shadow-cljs watch app` command. It was not a site.

The false sentence was *"shadow's `:browser` target re-runs `:init-fn` after
each hot reload — no separate `^:dev/after-load` hook is needed."* Shadow does
not: `merge-init-fn` (`shadow/build/targets/browser.clj:203`) appends the init
call to the **module's** output, which a reload does not re-evaluate, and the
dev client prints *"reloading code but no :after-load hooks are configured!"*
(`shadow/cljs/devtools/client/browser.cljs:92`) on exactly this configuration.

`app.cljs` then promised *"a hot reload finds the same root live and re-renders
it in place: your state survives edits."* The mount contract behind that is
real — `preflight!` in `implementation/freehand/src/re_frame/freehand/root.cljs`:
*"An equal fingerprint is the ratified idempotent no-op — the frame is NOT
re-seeded, because `:initial-events` are a seed, not a replay."* But nothing in
the scaffold re-enters `mount`, so the sentence promised an outcome the file
could not deliver.

**Changed.** Both comments now say what the scaffold does: an edited view is
picked up on the next page load; the mount's per-root idempotency is why a
reload loop is cheap *when you want one*; and `^:dev/after-load` on `run` is
named as what it would take. Comment-only — `shadow-cljs.edn`'s data is
byte-identical, so the scaffold-smoke and `ui` shadow-config contract
assertions read the same values, and `app.cljs` still contains no `:compiled`.

**Considered and left alone.** `docs/core/freehand/install.md:133` says
*"Re-mounting the same root-id into the same container re-renders the live root
rather than allocating a second one. That is the hot-reload path…"* — which is
the `v/mount` contract stated conditionally on re-mounting, and it is verbatim
the `mount` docstring in `freehand.cljc:861`. It does not claim shadow re-enters
mount for you, so it is not a site. Correcting it would also mean editing a page
with fenced blocks for no defect.

**The capability, and why it is not here.** The bead's DESIGN proposes the
`^:dev/after-load` wiring, and I verified it would work rather than assuming
either way: `rf/init!` is idempotent (`core.cljc` guards the install with
`(when-not (adapter/current-adapter) …)` — it is `install-adapter!`, called
directly, that raises `:rf.error/adapter-already-installed`), and a re-mount
under an equal frame fingerprint re-renders in place without replaying
`:initial-events`. So it is one metadata key on one `defn`. It is still a
product decision about what "the smallest runnable Freehand project" should
teach, not a documentation correction, and this dispatch fenced it explicitly.
Filed as **`rf2-omygl`** with the verified mechanics, so the question survives
this PR instead of being closed by it.

## rf2-kx06s — the census's push-path filter

**Found.** Exactly as filed. `scripts/check_freehand_conformance_index.py`
imports its EDN reader from `check_test_lane_bijection` and reads
`SHADOW_CLJS_REL = Path("implementation/shadow-cljs.edn")`; neither path was in
`freehand-conformance.yml`'s `push` filter.

**Changed.** Two paths added, with a comment saying why they are inputs. No
guarantee is recovered — the `pull_request` trigger is deliberately unfiltered
(REQUIRED-CHECK SHAPE), so every PR already runs the census. The list is now
honest about what the job reads. YAML re-parsed and the resulting `paths`
vector checked.

---

## Quality gates

Run in this worktree, `rc` captured immediately into a worktree-local log and
cross-checked against each log's own verdict line.

| Gate | Verdict | rc |
|---|---|---|
| `npm run test:browser-prod-elision` — **before** the runner edit | Ran 116 tests containing 519 assertions. 0 failures, 0 errors. + `ui mounted production elision: PASS` | **0** |
| `npm run test:browser-prod-elision` — **after** | Ran 116 tests containing 519 assertions. 0 failures, 0 errors. + `ui mounted production elision: PASS` | **0** |
| `npm run test:browser-schemas-boundary-prod` — after | Ran 7 tests containing 9 assertions. 0 failures, 0 errors. | **0** |
| `clojure -M:test` in `implementation/freehand` | Ran 1132 tests containing 7584 assertions. 0 failures, 0 errors. — on baseline; sample coverage still 113 of 136 fenced blocks | **0** |
| `python -m mkdocs build --strict` (run **directly** — `test-fast-pr.sh` soft-skips its mkdocs step) | Documentation built in 33.48 seconds | **0** |
| `python scripts/check_doc_slugs.py` (the real link gate) | clean | **0** |
| `python scripts/check_freehand_conformance_index.py` | clean | **0** |
| `python scripts/check_donor_inventory.py --ci` | clean | **0** |
| **CI, this PR, full matrix** | **63 pass / 12 skipping / 0 fail** | — |

The four CI jobs that exercise these changes directly all pass: `CLJS
(:browser-test-prod-elision)` 2m14s, `CLJS (:browser-test-schemas-boundary-prod)`
1m11s, `UI scaffold smoke (materialize + install + compile minimal-counter)`
1m17s, and `Freehand conformance index` 30s. `JVM core`, `CLJS (:node-test)`,
`MkDocs build` and `Docs required` also pass.

**`scripts/test-fast-pr.sh` — `PASS fast PR spine`, rc=0**, 0 `FAIL` lines,
with `docs=true jvm=true node=true` all armed:

| Stage | |
|---|---|
| JVM `implementation/core` | Ran 2115 tests containing 10459 assertions. 0 failures, 0 errors. |
| JVM `implementation/schemas` | Ran 363 tests containing 19188 assertions. 0 failures, 0 errors. |
| CLJS node integration (`npm run test:cljs`) | Ran 11493 tests containing 57541 assertions. 0 failures, 0 errors. — on the ~11490/57490 baseline |
| per-ns test isolation | all 17 namespaces pass standalone |

Reported honestly rather than as a tick: the spine's **first** run exited
**rc=1**, and the failure was the machine, not the diff —

```
OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(...) failed;
error='The paging file is too small for this operation to complete'
# There is insufficient memory for the Java Runtime Environment to continue.
FAIL JVM implementation/core
```

— with three JVMs resident at once (two `shadow-cljs release` builds for the
before/after prod-elision proof, plus the freehand suite). Two things worth
recording. The wrapper's own exit status was **0** while the log's verdict line
said `rc=1`, so the cross-check is what caught it. And the spine's closing
summary confirms the soft-skip: `NOT RUN by this spine … mkdocs --strict build
(mkdocs not on PATH)` — which is why `python -m mkdocs build --strict` was run
directly above. The re-run on a quiet box is the green in the table.

`mkdocs --strict` logs three pre-existing broken-anchor INFO lines
(`spec/Security.md`, `spec/Spec-Schemas.md`, `spec/Tool-Pair.md` → an
`API.md#elide-wire-value-…` anchor). None is in a file this PR touches, and
`check_doc_slugs.py` — which is the gate that actually fails on a broken link —
is clean.
