### PR TITLE
fix(story-mcp): a schema-violating variant body returns a tool error, not a -32603 server fault (rf2-2z9u3)

### DIFF
--- a/tools/story-mcp/spec/API.md
+++ b/tools/story-mcp/spec/API.md
@@ -542,6 +542,22 @@ body shape (e.g. `:tags #{:dev}`) can't round-trip through JSON.
   hardening above (`"must be a map or a valid EDN string"`).
 - `isError: true` when the parent story is not registered.
 
+A schema-violation error carries the registrar's diagnostic on both
+slots: the `:content` text is `"Registration failed: "` plus the
+registrar's own message, which names the offending key and the nearest
+declared slot; `:structuredContent` carries `:explain-humanized`, the
+`malli.error/humanize` projection of the failure keyed by the failing
+slot (`{:compnent ["disallowed key"]}`), per
+[`spec/010-Schemas.md`](../../../spec/010-Schemas.md) §humanize hook.
+
+The raw Malli `:explain` map is **never** relayed. Its `:schema` entries
+are live reified `malli.core/Schema` objects, and shipping them made the
+JSON encoder throw *past* the tool handler — the client got a
+protocol-level `-32603` naming a Malli class instead of this error
+result, on the commonest authoring mistake there is (rf2-2z9u3). Every
+handler that copies `ex-data` onto `:structuredContent` runs it through
+`tools.result/wire-safe-ex-data` for that reason.
+
 ### `unregister-variant`
 
 **Input.** `{:variant-id keyword (required)}`.
@@ -594,7 +610,9 @@ the `?` per Clojure idiom.
 - `isError: true` when `:write-back` is true but the gate is closed
   (`{:gated true}` in `structuredContent`).
 - `isError: true` when the write-back `reg-variant*` call fails (shape
-  validation, unresolved `:extends`, etc.).
+  validation, unresolved `:extends`, etc.). Same projection as
+  `register-variant`: a shape failure ships `:explain-humanized`
+  alongside the recorder payload, never the raw `:explain`.
 
 Filter layers (op-type `:event/dispatched`, frame scope, internal-ns
 skip) are inherited from the recorder; this tool does not expose a

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/recorder.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/recorder.cljc
@@ -125,12 +125,16 @@
           payload   (assoc base :written-back? true :new-variant-id id)]
       (result/edn-result payload))
     (catch #?(:clj Throwable :cljs :default) e
+      ;; Same relay as `write/register-or-error`, same projection: the
+      ;; registrar's raw Malli `:explain` carries live schema objects the
+      ;; JSON encoder cannot write (rf2-2z9u3).
       (result/error-result (str "Write-back failed: " (ex-message e))
                       (merge base
                              {:written-back?  false
                               :new-variant-id target-vid}
-                             (select-keys (ex-data e)
-                                          [:rf.error :explain]))))))
+                             (result/wire-safe-ex-data
+                               (select-keys (ex-data e)
+                                            [:rf.error :explain])))))))
 
 (defn tool-record-as-variant
   "Dev (or Write when `:write-back` is true): bridge the recorder's

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/result.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/result.cljc
@@ -11,8 +11,14 @@
   `pr-edn` is the canonical EDN-stable stringifier for embedding Story
   data inside an MCP text content item.
 
-  No external story-mcp deps — `cap` / `cursor` / `args` / `egress`
-  / every category ns reaches here.")
+  `wire-safe-ex-data` is the one projection every handler that relays a
+  caught exception's `ex-data` onto `:structuredContent` runs it through.
+
+  No story-mcp ns deps — `cap` / `cursor` / `args` / `egress`
+  / every category ns reaches here. `malli.error` is the sole library
+  require, reached transitively through `re-frame.story` (whose registrar
+  hard-requires `malli.core`), exactly as `re-frame.error` is."
+  (:require [malli.error :as me]))
 
 (defn pr-edn
   "Serialise a value to a stable, EDN-round-trippable string. Used to
@@ -21,6 +27,44 @@
   [v]
   (binding [*print-readably* true]
     (pr-str v)))
+
+(defn wire-safe-ex-data
+  "Project a caught exception's `ex-data` into something the JSON encoder
+  can actually write, for the handlers that relay it onto
+  `:structuredContent`.
+
+  ONE slot needs projecting. `re-frame.story.registrar/validate-shape!`
+  puts the raw Malli `explain` map in `ex-data`, and its `:schema`
+  entries are LIVE reified `malli.core/Schema` objects, not data. Cheshire
+  cannot encode them, so relaying `:explain` verbatim made
+  `protocol/write-frame!` throw — past the tool handler, into
+  `server/handle-frame!`, which answered a protocol-level `-32603`
+  \"Server fault: Cannot JSON encode object of class:
+  malli.core$_and_schema$…\". The tool's own `isError: true` contract was
+  bypassed and the actionable message (which names the offending key and
+  the nearest declared slot) never left the JVM — on the single commonest
+  authoring mistake an agent makes through the write surface, a typo'd
+  variant slot (rf2-2z9u3).
+
+  So `:explain` is replaced by `:explain-humanized`, the
+  `malli.error/humanize` projection: plain maps, keywords and strings,
+  keyed by the failing slot (`{:compnent [\"disallowed key\"]}`), and
+  carrying the schema's own `:error/message` prose for the mutual-
+  exclusion `:fn` clauses. `:explain-humanized` is not a new word — it is
+  the slot `spec/010-Schemas.md` §humanize hook already defines for
+  exactly this value, and consumers there already read it in preference
+  to raw `:explain`. Renaming rather than adding also keeps the write
+  surface's error slot from colliding with `explain-variant`'s unrelated
+  plan-`:explain` projection.
+
+  Every other `ex-data` slot rides through untouched — `:reason`,
+  `:where`, `:recovery`, `:kind`, `:id` are all plain data."
+  [d]
+  (if-let [explain (:explain d)]
+    (-> d
+        (dissoc :explain)
+        (assoc :explain-humanized (me/humanize explain)))
+    d))
 
 (defn text-result
   "Build a success result with a single text content item. `structured`

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/wire_pipeline.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/wire_pipeline.cljc
@@ -382,10 +382,20 @@
               result    (try
                           ((:handler t) args)
                           (catch Throwable e
+                            ;; The `ex-data` relay runs through
+                            ;; `wire-safe-ex-data` for the same reason the
+                            ;; two write handlers do: a thrown Malli
+                            ;; `:explain` carries live schema objects, and
+                            ;; an un-encodable `:data` slot here would
+                            ;; escape this catch as a `-32603` server fault
+                            ;; — the belt-and-braces catch failing exactly
+                            ;; when it is needed (rf2-2z9u3). This is the
+                            ;; GENERIC arm: it guards every handler, not
+                            ;; just the two write surfaces.
                             (result/error-result (str "Tool handler threw: " (ex-message e))
                                             {:tool      tool-name
                                              :exception (.getName (class e))
-                                             :data      (ex-data e)})))
+                                             :data      (result/wire-safe-ex-data (ex-data e))})))
               ;; Skip dedup on error envelopes (small bespoke payload; the
               ;; flat `:rf.error` shape is more useful unwrapped than under
               ;; a cache-of-one marker).

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/write.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/write.cljc
@@ -269,9 +269,15 @@
     (let [id (story/reg-variant* vk (assoc body-v :origin config/origin))]
       (result/edn-result {:variant-id id :registered? true}))
     (catch Throwable e
+      ;; `wire-safe-ex-data` swaps the registrar's raw Malli `:explain`
+      ;; (live reified schema objects — not JSON-encodable) for the
+      ;; humanized projection. Without it a schema-violating body took
+      ;; the encoder down and the client got a `-32603` server fault
+      ;; naming a malli class instead of this error result (rf2-2z9u3).
       (result/error-result (str "Registration failed: " (ex-message e))
                       (merge {:variant-id vk}
-                             (select-keys (ex-data e) [:rf.error :explain]))))))
+                             (result/wire-safe-ex-data
+                               (select-keys (ex-data e) [:rf.error :explain])))))))
 
 (defn tool-register-variant
   "Write: programmatically register a variant. Gated behind

--- a/tools/story-mcp/test/re_frame/story_mcp/wire_encodability_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/wire_encodability_test.clj
@@ -1,0 +1,222 @@
+(ns re-frame.story-mcp.wire-encodability-test
+  "Every relayed `ex-data` must survive the JSON encoder (rf2-2z9u3).
+
+  These tests drive the REAL JSON-RPC boundary — `server/run-loop!` over
+  in-memory reader/writer, real frames in, raw JSON lines out — and read
+  the encoded response, not the handler's return value. That distinction
+  is the whole point of the bead: the defect lived BETWEEN the handler
+  and the wire. `register-variant` built a perfectly good
+  `isError: true` result, then `protocol/write-frame!` hit the live
+  `malli.core/Schema` objects riding the registrar's `:explain` slot,
+  threw `Cannot JSON encode object of class:
+  malli.core$_and_schema$reify$…`, and `server/handle-frame!` turned that
+  into a protocol-level `-32603`. A unit test on the handler would have
+  passed the whole time.
+
+  Three relay sites carry the same `ex-data`-onto-`:structuredContent`
+  pattern and are covered here:
+
+    - `tools/write.cljc`         `register-or-error`   — the headline repro.
+    - `tools/recorder.cljc`      `write-back!`         — the sibling.
+    - `tools/wire-pipeline.cljc` `invoke-tool`'s catch — the GENERIC arm,
+      which relays a whole `ex-data` under `:data` and so fails for ANY
+      handler whose throw carries a non-encodable slot.
+
+  Only the first is reachable through the shipped tool surface today: the
+  other two re-register bodies the registrar itself produced (already
+  valid) or catch throws the handlers already handle. Their tests seam
+  the one producer each path trusts — `story/recording->script-body`,
+  `story/variant->edn` — so the throw, the relay, the encoder and
+  `handle-frame!` are all the real thing while the trigger is forced."
+  (:require [cheshire.core :as cheshire]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.story :as story]
+            [re-frame.story-mcp.config :as config]
+            [re-frame.story-mcp.server :as server]
+            [re-frame.substrate.plain-atom :as plain-atom]))
+
+;; ---- fixture --------------------------------------------------------------
+
+(defn- reset-story-and-config [t]
+  (try (rf/init! plain-atom/adapter)
+       (catch clojure.lang.ExceptionInfo _ nil))
+  (story/clear-all!)
+  (story/install-canonical-vocabulary!)
+  ;; Every test here exercises the write surface; the gate is default-off.
+  (config/set-allow-writes! true)
+  ;; Mirrors `tools-test`: keep the epoch ring out of the wire payload so a
+  ;; tools-root aggregate run doesn't balloon a result past the token cap.
+  (rf/configure! {:epoch-history {:depth 0}})
+  (t)
+  (config/set-allow-writes! false))
+
+(use-fixtures :each reset-story-and-config)
+
+;; ---- the real boundary ----------------------------------------------------
+
+(def ^:private init-frame
+  "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{}}")
+
+(defn- call-frame
+  [id tool args-json]
+  (str "{\"jsonrpc\":\"2.0\",\"id\":" id ",\"method\":\"tools/call\","
+       "\"params\":{\"name\":\"" tool "\",\"arguments\":" args-json "}}"))
+
+(defn- drive-raw
+  "Feed `frames` through the real `run-loop!` and return the raw response
+  LINES, initialize's reply dropped. Raw strings on purpose — a decoded
+  value cannot tell you whether the encoder ever ran."
+  [& frames]
+  (let [in  (java.io.BufferedReader.
+              (java.io.StringReader. (str (str/join "\n" frames) "\n")))
+        out (java.io.StringWriter.)]
+    ;; `server/log!` writes the handler-threw line to stderr; keep the
+    ;; suite quiet without hiding it from a failing assertion.
+    (binding [*err* (java.io.StringWriter.)]
+      (server/run-loop! in out))
+    (rest (remove str/blank? (str/split-lines (str out))))))
+
+(defn- call-tool
+  "Drive one `tools/call` and return `[raw-line decoded-frame]`."
+  [tool args-json]
+  (let [line (first (drive-raw init-frame (call-frame 2 tool args-json)))]
+    [line (cheshire/parse-string line true)]))
+
+(defn- tool-error?
+  "True when `frame` is a JSON-RPC SUCCESS envelope carrying an MCP
+  tool-execution error — the shape MCP §Error Handling asks for, and the
+  shape a `-32603` protocol fault is not."
+  [frame]
+  (and (nil? (:error frame))
+       (true? (get-in frame [:result :isError]))))
+
+(defn- result-text [frame]
+  (get-in frame [:result :content 0 :text]))
+
+(defn- structured [frame]
+  (get-in frame [:result :structuredContent]))
+
+;; ---- register-variant: the headline repro ---------------------------------
+
+(deftest register-variant-schema-violation-is-a-tool-error-not-a-server-fault
+  (testing "a typo'd variant slot returns isError, not a -32603 server fault"
+    (let [[line frame] (call-tool "register-variant"
+                                  (str "{\"variant-id\":\"story.button/x\","
+                                       "\"body\":{\"compnent\":\"some/view\"}}"))]
+      (is (not (str/includes? line "Server fault"))
+          "the encoder must not take the response down")
+      (is (nil? (:error frame))
+          (str "expected a JSON-RPC result envelope, got an error: " line))
+      (is (tool-error? frame)
+          "a schema violation is a tool error, not a protocol error")
+
+      (testing "the relayed message is the registrar's, and it is actionable"
+        (is (str/includes? (result-text frame) ":compnent")
+            "the message names the offending slot")
+        (is (str/includes? (result-text frame) "did you mean :component?")
+            "the message names the nearest declared slot")
+        (is (str/includes? (result-text frame) "[:rf.error/variant-shape]")
+            "the canonical thrown-error token rides the message"))
+
+      (testing "the explain slot crosses the wire as DATA"
+        (is (= {:compnent ["disallowed key"]}
+               (:explain-humanized (structured frame)))
+            "the humanized projection replaces the live malli schema objects")
+        (is (nil? (:explain (structured frame)))
+            "the raw, un-encodable :explain slot must not be relayed"))
+
+      (testing "the variant is not registered"
+        (is (nil? (story/variant->edn :story.button/x)))))))
+
+(deftest register-variant-mutual-exclusion-violation-crosses-the-wire
+  (testing "an `:and`-clause failure (not just an extra key) also encodes"
+    ;; The class in the original fault was the `:and` schema's reify, so
+    ;; the mutual-exclusion arm is the one that produced it.
+    (let [[line frame] (call-tool "register-variant"
+                                  (str "{\"variant-id\":\"story.button/xor\","
+                                       "\"body\":\"{:script [] :plays []}\"}"))]
+      (is (not (str/includes? line "Server fault")))
+      (is (tool-error? frame))
+      (is (some? (:explain-humanized (structured frame)))
+          "the humanized projection carries the schema's own :error/message prose"))))
+
+(deftest register-variant-valid-body-still-registers
+  ;; The two-sided control. A fix to the error path that quietly broke the
+  ;; happy path would otherwise look identical.
+  (testing "a valid body is unaffected by the ex-data projection"
+    (let [[_ frame] (call-tool "register-variant"
+                               (str "{\"variant-id\":\"story.button/ok\","
+                                    "\"body\":{\"doc\":\"a fine variant\"}}"))]
+      (is (nil? (:error frame)))
+      (is (nil? (get-in frame [:result :isError]))
+          "the success envelope carries no isError flag")
+      (is (= {:variant-id "story.button/ok" :registered? true}
+             (structured frame)))
+      (is (some? (story/variant->edn :story.button/ok))
+          "the variant really is registered"))))
+
+(deftest register-variant-non-explain-failure-is-unchanged
+  ;; The sibling failure path carries no `:explain`, so the projection must
+  ;; be a no-op on it. This is also the path rf2-jquiy fixed — its message
+  ;; improvement was invisible to a client until this bead landed.
+  (testing "an unregistered-tag rejection relays its message untouched"
+    (let [[_ frame] (call-tool "register-variant"
+                               (str "{\"variant-id\":\"story.button/tagfail\","
+                                    "\"body\":\"{:tags #{:nope}}\"}"))]
+      (is (tool-error? frame))
+      (is (str/includes? (result-text frame) "unregistered tag(s)"))
+      (is (str/includes? (result-text frame) "[:rf.error/unknown-tag]"))
+      (is (nil? (:explain-humanized (structured frame)))
+          "no :explain in the ex-data ⇒ no :explain-humanized on the wire"))))
+
+;; ---- record-as-variant: the sibling relay ---------------------------------
+
+(deftest record-as-variant-write-back-schema-violation-is-a-tool-error
+  (testing "the write-back relay projects :explain the same way"
+    (story/reg-variant* :story.button/src {:doc "source" :args {}})
+    ;; `write-back!` re-registers the SOURCE body with the recorder's own
+    ;; play body swapped in, and both halves are registrar-produced — so
+    ;; the schema violation has to come from the one producer the path
+    ;; trusts. Seam it; everything downstream is real.
+    (with-redefs [story/recording->script-body (fn [_ _] "not-a-play-spec")]
+      (let [[line frame] (call-tool "record-as-variant"
+                                    (str "{\"variant-id\":\"story.button/src\","
+                                         "\"write-back\":true,"
+                                         "\"new-variant-id\":\"story.button/rec\"}"))]
+        (is (not (str/includes? line "Server fault"))
+            "the write-back relay must not take the encoder down")
+        (is (tool-error? frame))
+        (is (str/includes? (result-text frame) "Write-back failed"))
+        ;; Two messages: `PlaySpec` is an `:or`, and a string satisfies
+        ;; neither branch.
+        (is (= {:script ["invalid type" "invalid type"]}
+               (:explain-humanized (structured frame))))
+        (is (false? (:written-back? (structured frame)))
+            "the recorder payload still rides alongside the projection")))))
+
+;; ---- wire-pipeline: the generic arm ---------------------------------------
+
+(deftest handler-throw-carrying-explain-is-a-tool-error
+  (testing "invoke-tool's belt-and-braces catch survives a malli-bearing throw"
+    (story/reg-variant* :story.button/probe {:doc "probe"})
+    ;; The generic catch relays the WHOLE ex-data under `:data`, so it
+    ;; fails for any handler throw carrying a non-encodable slot — not
+    ;; just the two write surfaces. Force one: a read handler that throws
+    ;; the registrar's own shape-violation exception.
+    (let [thrown (try (story/reg-variant* :story.button/bad {:compnent :x})
+                      (catch clojure.lang.ExceptionInfo e e))]
+      (is (some? (:explain (ex-data thrown)))
+          "precondition: the registrar throw really does carry a live :explain")
+      (with-redefs [story/variant->edn (fn [_] (throw thrown))]
+        (let [[line frame] (call-tool "get-variant"
+                                      "{\"variant-id\":\"story.button/probe\"}")]
+          (is (not (str/includes? line "Server fault"))
+              "the generic catch must not itself become a server fault")
+          (is (tool-error? frame))
+          (is (str/includes? (result-text frame) "Tool handler threw"))
+          (is (= {:compnent ["disallowed key"]}
+                 (get-in (structured frame) [:data :explain-humanized])))
+          (is (= "rf.story/reg-story" (get-in (structured frame) [:data :where]))
+              "every other ex-data slot rides through untouched"))))))


### PR DESCRIPTION
Fixes `rf2-2z9u3`.

A schema-violating variant body returned a protocol-level `-32603` instead of the
tool's own `isError` result. `registrar/validate-shape!` puts the raw Malli
`explain` map in `ex-data`; its `:schema` entries are **live reified
`malli.core/Schema` objects**, not data. Both write handlers copied that slot into
`:structuredContent`, cheshire threw on it, and the throw escaped *past* the tool
handler into `server/handle-frame!`, which answered `-32603`.

So the single commonest authoring mistake an agent makes through the write surface
— a typo'd variant slot — produced **no diagnostic at all**. It also masked
`rf2-jquiy` (#7036): that bead made `validate-shape!`'s message conformant and
actionable, and no client could see it, because the response never got built.

## What changed

`tools.result/wire-safe-ex-data` replaces `:explain` with `:explain-humanized`, the
`malli.error/humanize` projection. Not a new word — `spec/010-Schemas.md` §humanize
hook already defines that slot for exactly this value, and consumers there already
prefer it to raw `:explain`. Renaming rather than adding also stops the write
surface's error slot colliding with `explain-variant`'s unrelated plan-`:explain`.
Every other `ex-data` slot (`:reason`, `:where`, `:recovery`, `:kind`, `:id`) rides
through untouched.

## Does the pattern appear beyond the two named sites? Yes — three, not two.

| Site | Shape | Reachable through the shipped tool surface today? |
|---|---|---|
| `tools/write.cljc` `register-or-error` | `(select-keys (ex-data e) [:rf.error :explain])` | **Yes** — the headline repro. |
| `tools/recorder.cljc:132` `write-back!` | identical `select-keys` | **No** — latent. |
| `tools/wire_pipeline.cljc:388` `invoke-tool` catch | `:data (ex-data e)` — the **whole** `ex-data` | **No** — latent, but it is the GENERIC arm. |

All three now route through `wire-safe-ex-data`.

The third is the one worth flagging: the belt-and-braces catch relays an entire
`ex-data` under `:data`, so it fails for **any** handler throw carrying a
non-encodable slot, not just the two write surfaces — the catch that exists to stop
a handler throw becoming a protocol fault, becoming a protocol fault.

Reachability was checked, not assumed. `record-as-variant`'s write-back re-registers
a body both halves of which the registrar itself produced (the stored source body is
post-validation; the play body comes from `story/recording->script-body`), so no
caller-reachable input makes `validate-shape!` fire there. Same for the generic
catch: every handler that can currently throw a Malli `:explain` already catches it.
Their tests therefore seam the one producer each path trusts, so the throw, the
relay, the encoder and `handle-frame!` are all real while the trigger is forced.

Not changed, filed separately: the `select-keys` harvests `:rf.error`, but the
registrar throws `:rf.error/id`. That arm has never fired, so the structured payload
carries no machine error id on these paths (the canonical `[:rf.error/…]` token does
ride the message). Out of scope here.

## Before / after — the JSON a client receives

Driven through `server/run-loop!` over in-memory streams: real `initialize`, real
`tools/call` frame, raw response line as written by `protocol/write-frame!`.

Request (identical in both):

```json
{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"register-variant",
 "arguments":{"variant-id":"story.button/x","body":{"compnent":"some/view"}}}}
```

**Before** — a transport fault naming a Malli class:

```json
{"jsonrpc":"2.0","id":2,"error":{"code":-32603,"message":"Server fault: Cannot JSON
 encode object of class: class malli.core$_and_schema$reify$reify__4930:
 malli.core$_and_schema$reify$reify__4930@804ea79","data":{"exception":
 "com.fasterxml.jackson.core.JsonGenerationException"}}}
```

**After** — the tool error, with `rf2-jquiy`'s message finally visible:

```json
{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"Registration
 failed: re-frame2-story: unknown variant slot(s) :compnent (did you mean
 :component?) — the variant authoring body is closed (rf2-mantt). Allowed keys:
 [:args :args->events :argtypes :assertions :background :checks :component :compose
 :db-seed :decorators :dispatch-console? :doc :events :extends :frame-binding
 :fx-overrides :images :interceptor-overrides :large :loaders :loaders-complete-when
 :loaders-teardown :mcp-bound :modes :network :origin :platforms :play-script :plays
 :run-artifact :script :sensitive :setup :source :sub-overrides :substrates :tags
 :viewport :xray :xray-panel]. Remove the slot, or fix the typo.
 [:rf.error/variant-shape]"}],"isError":true,"structuredContent":{"variant-id":
 "story.button/x","explain-humanized":{"compnent":["disallowed key"]}}}}
```

## Two-sided control

The same driver, same session, unchanged by the fix:

- **Valid body still registers.**
  `{"variant-id":"story.button/ok","body":{"doc":"a fine variant"}}` →
  `{"result":{"content":[{"type":"text","text":"{:variant-id :story.button/ok, :registered? true}"}],"structuredContent":{"variant-id":"story.button/ok","registered?":true}}}`
  — no `isError`, and `story/variant->edn` confirms the variant is really there.
- **Non-`:explain` failure path untouched.** The unregistered-tag rejection (no
  `:explain` in its `ex-data`) returns byte-identical before and after:
  `"Registration failed: re-frame2-story: unregistered tag(s) on :story.button/tagfail: [:nope] [:rf.error/unknown-tag]"`,
  `structuredContent {"variant-id":"story.button/tagfail"}`, no `:explain-humanized`.

## Negative control

`wire-safe-ex-data`'s body replaced in place with a pass-through (`[d] d`).
**Mutation confirmed applied** before reading any verdict — `git diff --stat` showed
`1 file changed, 2 insertions(+), 5 deletions(-)` and the hunk itself.

- Suite: `298 tests / 1562 assertions`, **15 failures, 5 errors**, `rc=1`.
- Boundary probe: back to
  `{"error":{"code":-32603,"message":"Server fault: Cannot JSON encode object of class: class malli.core$_and_schema$reify$reify__4930…"}}`.
- The two control tests (`register-variant-valid-body-still-registers`,
  `register-variant-non-explain-failure-is-unchanged`) stayed **green under the
  mutation** — they are controls, not part of the gate.

Restored via `git checkout --`; the restored blob is byte-identical to the committed
one (`9ddcb8eb530fb3924492d887ef2c3788c0c4cb1a`, the pre-image in the mutation diff
header), and the suite is back to `0 failures / rc=0`.

## Quality gates

Each `rc` captured immediately into a worktree-local log and cross-checked against
that log's own verdict line. The Python gates are silent-on-success by design — `rc`
*is* the verdict.

| Gate | Result | rc |
|---|---|---|
| `tools/story-mcp` `clojure -M:test` | 298 tests / 1562 assertions, 0 failures, 0 errors | 0 |
| `tools/mcp-base` `clojure -M:test` | 272 tests / 924 assertions, 0 failures, 0 errors | 0 |
| `tools/story` `clojure -M:test` | 1847 tests / 6824 assertions, 0 failures, 0 errors | 0 |
| `tools/mcp-conformance/wire-vocab` `clojure -M:test` | 100 tests / 1069 assertions, 0 failures, 0 errors | 0 |
| `tools/mcp-conformance` `npm run test:story` | `STORY-MCP MCP-CLIENT CONFORMANCE GREEN` (20/20 tools SDK-called) | 0 |
| `tools/mcp-conformance` `npm run test:flag-gates` | `MCP CLI FLAG-VOCABULARY CONFORMANCE GREEN` | 0 |
| `tools/story-mcp` `clojure -M:gen --check` | `OK: tool-descriptors.edn in sync (20 tools)` | 0 |
| `scripts/check_keyword_catalogue_drift.py` | silent | 0 |
| `scripts/check_thrown_error_messages.py` | silent | 0 |
| `scripts/check_test_lane_bijection.py` | silent | 0 |
| `scripts/check_readme_links.py` | silent | 0 |
| `scripts/check_doc_slugs.py` | silent | 0 |
| `scripts/check_retired_spellings.py` | silent | 0 |

Story-mcp goes 292 → 298 tests (+6 in `wire_encodability_test.clj`); mcp-base and
story counts are unchanged from baseline, re-derived on this branch rather than
trusted.

**No new `:rf.error/*` id** — `:explain-humanized` is not an error id and
`check_keyword_catalogue_drift.py` Check A is unaffected. No new error-formatting
framework, no MCP middleware layer: one function, three call sites, one test
namespace.
