### PR TITLE
routing: name the structural href duplication, publish the prefetch intent class (rf2-arenp, rf2-7g4qn)

### DIFF
--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -520,6 +520,10 @@
     :producer-ns 're-frame.routing
     :design-bead "rf2-kqxe6.7"
     :description "CLJS-only prefetch intent-dispatch op `(fn [event caller-handler render-frame payload])` consumed by every non-Reagent route-link view (the compiled `re-frame.ui/route-link` defview, the Freehand `v/route-link` descriptor): warms the destination on credible user intent — run the caller-supplied intent handler first (compose, not replace), then `router/dispatch!` the `:rf.route/prefetch` payload to the captured render frame with `:source :router` (a nil payload dispatches nothing — passive by construction). The hover/focus/touch sibling of `:routing/activate-link!`; keeps the intent-dispatch law inside routing so a view artefact reimplements none of it. Unbound on the JVM (SSR emits no intent handlers) and when routing is absent. Per Spec 012 §Route-plan prefetch."}
+   {:key         :routing/prefetch-intent-keys
+    :producer-ns 're-frame.routing
+    :design-bead "rf2-7g4qn"
+    :description "The CLOSED class of DOM positions a `:prefetch :intent` route-link warms from — pointer hover, focus, touch-start (Spec 012 §Route-plan prefetch) — published on BOTH hosts as a thunk `(fn []) -> [<keyword> ...]` over `re-frame.routing.link/prefetch-intent-keys`. DATA rather than an op: the class is routing's law, and a view artefact that wrote its own copy would drift silently — a `v/route-link` lacking a trigger `rf/route-link` installs, with nothing failing to say so. Consumed by every non-Reagent route-link view (the Freehand `v/route-link` descriptor) both to normalise the caller's value at each owned position and to strip those positions off the passthrough attrs, which is why it is needed on the JVM too (the SSR shell installs no handler but must still not emit a routing control key as an HTML attribute). The class sibling of `:routing/prefetch-payload` / `:routing/prefetch-on-intent!`. Unbound when routing is absent → the consuming view has already failed loud at `:routing/prefetch-payload`."}
    {:key         :routing/preflight-frame-config!
     :producer-ns 're-frame.routing
     :design-bead "rf2-ktmto9"

--- a/implementation/freehand/src/re_frame/freehand/route_link_seam.cljc
+++ b/implementation/freehand/src/re_frame/freehand/route_link_seam.cljc
@@ -1,6 +1,6 @@
 (ns re-frame.freehand.route-link-seam
-  "The anchor `v/route-link` renders, and the two late-bound hooks it
-  reads to get it. (The `-seam` suffix avoids a ClojureScript ns/var
+  "The anchor `v/route-link` renders, and the late-bound hooks it reads
+  to get it. (The `-seam` suffix avoids a ClojureScript ns/var
   clash with the `re-frame.freehand/route-link` view var.)
 
   `route-link` is ORDINARY framework view code — a `v/defview` like any
@@ -11,9 +11,9 @@
   it, and hand the click back to routing.
 
   All routing knowledge stays in the OPTIONAL `re-frame.routing`
-  artefact, behind four substrate-neutral late-bound hooks routing
-  publishes and this namespace consumes — two for the click, two for the
-  `:prefetch :intent` warm-up, and each pair split the same way:
+  artefact, behind the substrate-neutral late-bound hooks routing
+  publishes and this namespace consumes — the click pair, and the
+  `:prefetch :intent` warm-up trio:
 
     `:routing/link-model`        — PURE, both hosts; the whole link
                                    calculation (strategy-encoded href,
@@ -23,13 +23,15 @@
     `:routing/prefetch-payload`  — PURE, both hosts; the
                                    `[:rf.route/prefetch {address}]` vector
                                    for a link that asked for it, or nil.
+    `:routing/prefetch-intent-keys` — DATA, both hosts; the closed class of
+                                   DOM positions an opted-in link warms from.
     `:routing/prefetch-on-intent!` — ClojureScript only; the intent
                                    dispatch that warms the destination.
 
   Consuming them through `re-frame.late-bind` (core) keeps the packaging
   graph `freehand -> core late-bind <- routing`: neither optional
   artefact statically requires the other (Conventions §Packaging). When
-  routing is absent both hooks are unbound and rendering a `v/route-link`
+  routing is absent the hooks are unbound and rendering a `v/route-link`
   fails loud with `:rf.error/routing-artefact-missing`, naming the
   artefact, its Maven coordinate, and the link site — a plain `[:a]`
   remains available for intentional browser-native navigation.
@@ -46,9 +48,9 @@
   something to invoke. [[veto]] and [[intent-callback]] are the
   translation at that boundary: they are where the accepted grammar is
   named, narrowed and enforced, before anything is handed across. The
-  click position is always owned; the three [[intent-keys]] are owned
-  only by a link that asked for `:prefetch :intent`, and stay ordinary
-  open event positions on every other link."
+  click position is always owned; the [[intent-keys]] are owned only by
+  a link that asked for `:prefetch :intent`, and stay ordinary open
+  event positions on every other link."
   (:require [re-frame.error :as error]
             [re-frame.frame :as frame]
             [re-frame.freehand.events :as events]
@@ -89,9 +91,8 @@
   render — nil when the link did not ask for a prefetch.
 
   PURE, and asked on BOTH hosts, because a nil answer is what makes the
-  three [[intent-keys]] ordinary open event positions again: the JVM
-  render attaches no handler but still has to know whether it owns those
-  keys, or the server shell would emit an attribute the browser render
+  [[intent-keys]] ordinary open event positions again: the JVM render
+  attaches no handler but still has to know whether it owns those keys, or the server shell would emit an attribute the browser render
   strips. The descriptor never reads `:prefetch` itself — which values
   opt a link in, and which address they warm, is routing's law and stays
   behind the hook."
@@ -141,7 +142,7 @@
        (f e veto render-frame payload native?))))
 
 ;; ---------------------------------------------------------------------------
-;; The callback positions the framework OWNS — `:on-click`, and the three
+;; The callback positions the framework OWNS — `:on-click`, and the
 ;; intent positions a `:prefetch :intent` link binds
 ;; ---------------------------------------------------------------------------
 
@@ -160,21 +161,37 @@
   analytics ping). That is exactly `v/handler`'s declared role, and a bare
   function is its unceremonious spelling.
 
-  The same roster governs the three [[intent-keys]] on a link that asked
+  The same roster governs the [[intent-keys]] on a link that asked
   for `:prefetch :intent`, for the same mechanical reason: the framework
   runs the caller's handler itself, so it has to be something callable."
   [:bare-fn :v-handler :nil])
 
-(def intent-keys
-  "The three DOM positions a `:prefetch :intent` link binds — pointer
-  hover, focus and touch-start, the credible-intent triggers Spec 012
+(defn intent-keys
+  "Resolve the `:routing/prefetch-intent-keys` hook — the DOM positions a
+  `:prefetch :intent` link binds, the credible-intent triggers Spec 012
   names. FRAMEWORK-OWNED on such a link and on no other: the anchor
   installs its own handler at each, running the caller's FIRST, so the
   prefetch composes with the author's hover work rather than replacing it.
 
-  A link that did not opt in leaves all three exactly as it found them —
-  ordinary open Freehand event positions like every other `:on-*`."
-  [:on-mouse-enter :on-focus :on-touch-start])
+  A link that did not opt in leaves every one of them exactly as it found
+  it — ordinary open Freehand event positions like every other `:on-*`.
+
+  Asked of routing rather than written out here (rf2-7g4qn): WHICH
+  positions count as credible intent is routing's law, the same law
+  [[prefetch-payload]] already keeps behind the hook, and a descriptor
+  holding its own copy of the class would drift from it silently — a
+  `v/route-link` short a trigger `rf/route-link` installs, with nothing
+  failing to say so. Asked on BOTH hosts, because the JVM render strips
+  these positions too: a routing control key must not reach the server
+  shell as an HTML attribute.
+
+  Reached only when [[prefetch-payload]] has already answered non-nil, so
+  routing is proven present; the `require-fn!` is the honest spelling of
+  that, not a second gate."
+  []
+  ((late-bind/require-fn! :routing/prefetch-intent-keys
+                          'v/route-link
+                          routing-artefact)))
 
 (defn- value-description
   "A short HOST-NEUTRAL description of an offending callback value, for
@@ -245,7 +262,7 @@
 (defn intent-callback
   "Normalize a caller's value at one of the [[intent-keys]] into the
   callback routing's prefetch runs first — a plain one-argument fn, or nil
-  — or reject it. [[veto]]'s sibling for the three prefetch positions:
+  — or reject it. [[veto]]'s sibling for the prefetch positions:
   same roster, same error, same both-hosts render-time check, and a
   different reason.
 
@@ -303,7 +320,7 @@
   `:href` win. On ClojureScript the anchor carries the activation closure;
   on the JVM it does not — an SSR shell has no click to intercept.
 
-  A link that asked for `:prefetch :intent` additionally owns the three
+  A link that asked for `:prefetch :intent` additionally owns the
   [[intent-keys]]: each caller value is normalized by [[intent-callback]]
   (both hosts, same reason as the veto), stripped from the attrs, and on
   ClojureScript replaced by a handler that runs it FIRST and then warms
@@ -325,9 +342,13 @@
         target       (dissoc props :on-click :children)
         {:keys [href payload native?]} (link-model target render-frame)
         prefetch     (prefetch-payload target)
+        ;; Routing owns WHICH positions are credible intent; resolve the class
+        ;; once per opted-in render and use it for both the normalization and
+        ;; the strip, so the anchor cannot own a position it fails to strip.
+        ikeys        (when prefetch (intent-keys))
         intent-fns   (when prefetch
-                       (into {} (map (fn [k] [k (intent-callback k (get props k))])) intent-keys))
-        owned        (cond-> control-keys prefetch (concat intent-keys))
+                       (into {} (map (fn [k] [k (intent-callback k (get props k))])) ikeys))
+        owned        (cond-> control-keys prefetch (concat ikeys))
         attrs        (assoc (apply dissoc props owned) :href href)
         attrs #?(:cljs (into (assoc attrs
                                     :on-click

--- a/implementation/routing/src/re_frame/routing.cljc
+++ b/implementation/routing/src/re_frame/routing.cljc
@@ -513,3 +513,10 @@
 ;; no DOM intent to intercept). Per Spec 012 §Route-plan prefetch.
 (late-bind/set-fn! :routing/prefetch-payload link/prefetch-payload)
 #?(:cljs (late-bind/set-fn! :routing/prefetch-on-intent! link/prefetch-on-intent!))
+;; The closed intent-position class itself (rf2-7g4qn) — DATA, not an op, so the
+;; hook is a thunk over `link/prefetch-intent-keys`. Published on BOTH hosts
+;; because a descriptor strips the positions it owns on the JVM too (the SSR
+;; shell must not emit a routing control key as an attribute), and a descriptor
+;; that wrote its own copy of the class would silently drift from the one
+;; `rf/route-link` installs.
+(late-bind/set-fn! :routing/prefetch-intent-keys (constantly link/prefetch-intent-keys))

--- a/implementation/routing/src/re_frame/routing/link.cljc
+++ b/implementation/routing/src/re_frame/routing/link.cljc
@@ -22,6 +22,24 @@
   delay knob — a passive render dispatches nothing (Governing Law 1)."
   :intent)
 
+(def prefetch-intent-keys
+  "The CLOSED class of DOM positions a `:prefetch :intent` link warms from —
+  pointer hover, focus, touch-start, the credible-intent triggers Spec 012
+  §Route-plan prefetch names. Held here, beside `prefetch-intent-value`, for the
+  same reason `address/link-behavior-keys` is held in `address`: it is a closed
+  key class of routing's law, and a link surface that writes its own copy can
+  drift from it silently — a `v/route-link` would lack a trigger `rf/route-link`
+  installs, with nothing failing to say so.
+
+  Routing's own `prefetch-intent-attrs` maps over it; the compiled
+  `ui/route-link` and Freehand `v/route-link` descriptors reach it as the
+  `:routing/prefetch-intent-keys` late-bound seam, the same way they already
+  reach `prefetch-payload` — so no view substrate states the class for itself.
+
+  Order is the order the anchor's attrs are built in and carries no meaning:
+  the positions are independent, and each warms the same destination."
+  [:on-mouse-enter :on-focus :on-touch-start])
+
 (defn validate-prefetch!
   "Validate the `:prefetch` link-behaviour value, the ONE definition every link
   surface reaches (Spec 012 §`:prefetch :intent` — the opt-in warm-mode
@@ -102,6 +120,20 @@
   ;; calculation both halves of the render contract run, so `rf/route-link`
   ;; rejects an unsupported mode on the client AND in the SSR shell rather than
   ;; stripping it silently on the way to the `<a>`.
+  ;;
+  ;; DELIBERATE DUPLICATION — the `route-url` + `encode` pair below is also
+  ;; derived by `link-model` (bottom of this file), and that is STRUCTURAL
+  ;; rather than incidental (rf2-arenp). Neither can call the other: this fn
+  ;; must ALSO strip the control keys and hand back route-link's open
+  ;; DOM-attribute passthrough map (Spec 012 §The extraction law), which
+  ;; `link-model` must NOT do — the consuming view artefact owns its own markup
+  ;; — and this fn takes `encode` as an ARGUMENT (CLJS render passes the frame
+  ;; strategy's `:encode`, SSR passes `identity`) where `link-model` resolves it
+  ;; behind a reader conditional. A shared helper would need a home both already
+  ;; require, and there is none; a namespace invented to hold this calculation
+  ;; would cost more than it saves. Do not spend an afternoon unifying them —
+  ;; but if a shared home appears for another reason, collapse both onto it.
+  ;; (The same wall rf2-wzqtu hit for the readiness projectors.)
   (validate-prefetch! props)
   (let [{:keys [to params query fragment] :as addr} (address/extract-address props)
         path-url (registry/route-url {:to to :params (or params {}) :query (or query {}) :fragment fragment})]
@@ -156,8 +188,8 @@
      "Build one intent-event handler that runs a caller-supplied handler of the
      same name FIRST (compose, not replace) and then dispatches `payload` to the
      `render-frame` with `:source :router` (rf2 routing-substrate attribution).
-     Reused for `:on-mouse-enter` / `:on-focus` / `:on-touch-start` so the three
-     prefetch triggers share one composition + dispatch law."
+     Reused at every `prefetch-intent-keys` position so the credible-intent
+     triggers share one composition + dispatch law."
      [caller-handler render-frame payload]
      (fn [e]
        (when caller-handler (caller-handler e))
@@ -166,18 +198,22 @@
 #?(:cljs
    (defn- prefetch-intent-attrs
      "The `:prefetch :intent` DOM handlers for `rf/route-link`, or nil when the
-     link does not opt in. Warms the destination on credible user intent —
-     pointer hover (`:on-mouse-enter`), focus (`:on-focus`), touch
-     (`:on-touch-start`) — NEVER on render / viewport (Governing Law 1). Each
-     composes with a caller-supplied handler of the same name (read from
-     `props`) and dispatches `[:rf.route/prefetch …]` to the render-time-captured
-     `render-frame`, exactly as the delayed click handler targets its frame. Per
-     Spec 012 §Route-plan prefetch."
+     link does not opt in. Warms the destination on credible user intent — at
+     every `prefetch-intent-keys` position, and NEVER on render / viewport
+     (Governing Law 1). Each handler composes with a caller-supplied handler of
+     the same name (read from `props`) and dispatches `[:rf.route/prefetch …]` to
+     the render-time-captured `render-frame`, exactly as the delayed click
+     handler targets its frame. Per Spec 012 §Route-plan prefetch."
      [props render-frame]
      (when-let [payload (prefetch-payload props)]
-       {:on-mouse-enter (compose-intent-handler (:on-mouse-enter props) render-frame payload)
-        :on-focus       (compose-intent-handler (:on-focus props)       render-frame payload)
-        :on-touch-start (compose-intent-handler (:on-touch-start props) render-frame payload)})))
+       ;; Map over the published class rather than writing the positions out a
+       ;; second time (rf2-7g4qn): `prefetch-intent-keys` is the ONE enumeration
+       ;; this anchor and the `:routing/prefetch-intent-keys` seam both read, so
+       ;; a position added there cannot reach one link surface and miss another.
+       (into {}
+             (map (fn [k]
+                    [k (compose-intent-handler (get props k) render-frame payload)]))
+             prefetch-intent-keys))))
 
 #?(:cljs
    (defn- plain-left-click?
@@ -434,6 +470,21 @@
   ;; here too. Its `prefetch-payload` call is CLJS-only (the JVM/SSR shell
   ;; installs no intent handlers), which left the server render accepting an
   ;; unsupported mode the client rejected.
+  ;;
+  ;; DELIBERATE DUPLICATION — the `route-url` + `encode` pair below is also
+  ;; derived by `href-attrs` (top of this file, the `rf/route-link` internal),
+  ;; and that is STRUCTURAL rather than incidental (rf2-arenp). Neither can call
+  ;; the other: `href-attrs` must ALSO strip the control keys and return
+  ;; route-link's open DOM-attribute passthrough map (Spec 012 §The extraction
+  ;; law), which this seam must NOT do — the consuming view artefact owns its
+  ;; own markup and passthrough attrs — and `href-attrs` takes `encode` as an
+  ;; ARGUMENT where this fn resolves it behind the reader conditional below.
+  ;; Calling `href-attrs` from here would also invert the seam: it is the
+  ;; `rf/route-link` internal, this is the ui-facing surface. A shared helper
+  ;; would need a home both already require, and there is none. Do not spend an
+  ;; afternoon unifying them — but if a shared home appears for another reason,
+  ;; collapse both onto it. (The same wall rf2-wzqtu hit for the readiness
+  ;; projectors.)
   (validate-prefetch! target)
   (let [{:keys [to params query fragment] :as addr} (address/extract-address target)
         path-url (registry/route-url {:to to :params (or params {}) :query (or query {}) :fragment fragment})


### PR DESCRIPTION
Two ruled P4 beads on the routing link surface, one PR. Both rulings are reproduced verbatim below rather than linked — a clean clone gets git history, not tracker notes.

---

## rf2-arenp — ACCEPT the duplication, with comments

### Ruling (verbatim, from the bead)

> MAYOR RULING: ACCEPT THE DUPLICATION, WITH A COMMENT THAT SAYS WHY (2026-07-26). The filer asked for a ruling rather than a fix and framed it correctly — neither surface can call the other, so accepting it is a legitimate outcome.
>
> THE SITUATION: href-attrs and link-model each re-derive route-url plus the strategy encode. It is the last duplicated calculation between the two link surfaces, after rf2-e9974 collapsed the click law and the payload synthesiser onto single owners.
>
> WHY ACCEPT RATHER THAN UNIFY: neither can call the other. A shared helper would have to live somewhere both already require, and the filer did not find such a home — which is the same structural wall rf2-wzqtu hit, where packaging made a single readiness projector impossible. This artefact has converged on collapse-to-one-owner SIX times and been right each time; this is the second case where the honest answer is the opposite, and recognising that is harder than applying the pattern.
>
> WHAT TO DO, and it is small: write the comment at BOTH sites, each naming the other and stating that the duplication is structural rather than incidental — so the next reader does not spend an afternoon trying to unify them, and a future refactor that DOES create a shared home knows to collapse them. That is the rf2-wzqtu lesson applied forward: when you cannot have one implementation, stop implying you do.
>
> DO NOT introduce a third namespace to hold a two-line helper. Do not add a gate. If a shared home appears later for another reason, collapse them then.
>
> THIS RIDES WITH the next link-surface dispatch rather than alone — it is two comments. Reduced from a fix to a note by ruling, not deferred.

### Found vs changed

**Found.** `route-url` appears 9 times in `implementation/routing/src/re_frame/routing/link.cljc`; 7 of those are prose. The two call sites are exactly the pair the bead names:

- `href-attrs`, the `rf/route-link` internal — `(registry/route-url {:to to :params (or params {}) :query (or query {}) :fragment fragment})`, then `(assoc :href (encode path-url))`, with `encode` taken as an **argument** (the CLJS render passes the frame strategy's `:encode`, `route-link-render-ssr` passes `identity`).
- `link-model`, the `:routing/link-model` seam the compiled `ui/route-link` and Freehand `v/route-link` consume — the byte-identical `route-url` call with the same `(or … {})` defaulting, then `{:href (encode path-url) …}`, with `encode` resolved **behind a reader conditional** (`:cljs` strategy lookup / `:clj` identity).

The bead's stated reason neither can call the other holds on inspection: `href-attrs` must also strip the address + behaviour keys and hand back route-link's open DOM-attribute passthrough map (Spec 012 §The extraction law), which `link-model` must not do — the consuming view artefact owns its own markup. No namespace both surfaces already require can hold the shared calculation.

**Changed.** Comments only, at both sites, each naming the other by name (not "the two places") and stating the duplication is structural rather than incidental, with the `encode`-as-argument-vs-reader-conditional difference any future collapse has to preserve, and a forward instruction to collapse if a shared home ever appears. Both cite rf2-arenp and the rf2-wzqtu precedent. No third namespace, no helper, no gate — as ruled.

---

## rf2-7g4qn — routing owns the prefetch intent class

### Ruling (verbatim, from the bead)

> RESCOPED (mayor, 2026-07-26), same reason as rf2-y29wg: the cluster reviewer found the third enumeration site is ui.cljc:840-848 — donor code that rf2-drpa3.57 deletes.
>
> DROP the ui arm. Keep the routing and freehand enumeration sites, which is where a real duplication exists. If that leaves only two sites, say so and fix them; two enumerations of one triple is still a drift risk worth removing, and it stops being P4 minutiae once the donor arm is gone from the count.

The bead's original remedy, which the rescope narrowed but did not replace:

> REMEDY. Routing already exports address/link-behavior-keys as a shared closed-key-class constant for exactly this reason. Publish the intent triple the same way (a vector in routing, reachable by both view substrates the way they already reach prefetch-payload) and have all three sites map over it. Freehand shape is the model. Tests loop the published constant rather than a literal.

### Found vs changed

**Found — it does leave two implementation sites, and they are the two the ruling names:**

- `implementation/routing/src/re_frame/routing/link.cljc`, `prefetch-intent-attrs` — a literal three-key map, one `compose-intent-handler` call per key.
- `implementation/freehand/src/re_frame/freehand/route_link_seam.cljc`, `intent-keys` — a `def`'d vector, mapped over. The one that got it right, and the shape the bead named as the model.
- `implementation/ui/src/re_frame/ui.cljc` — the donor arm. **Not touched**, per the rescope (rf2-drpa3.57 deletes `implementation/ui/**`).

Two further enumerations exist and are deliberately left alone, because each is an *authority* rather than a copy:

- `spec/012-Routing.md` names the positions in prose in the §Route-plan prefetch and Freehand-grammar sections. That document is the law the constant is derived from.
- `spec/conformance/freehand/fixtures/fh-routelink-008.edn` carries `:intent-keys` as fixture data, which the Freehand tests loop. A conformance fixture stating the class independently of the implementation is the point of a conformance fixture, not drift.

**The spec half is already done** — Spec 012 already states the class as the closed credible-intent trigger set and already declares the link surfaces behaviourally identical. Nothing normative was missing; the gap was purely that two implementations each wrote the class out.

**Changed.**

- Routing now owns the constant: `re-frame.routing.link/prefetch-intent-keys`, held beside `prefetch-intent-value` for the same reason `address/link-behavior-keys` is held in `address` — it is a closed key class of routing's law.
- `prefetch-intent-attrs` maps over it instead of writing the positions out again.
- Published on **both hosts** as `:routing/prefetch-intent-keys`, reached the way Freehand already reaches `prefetch-payload`. It is data rather than an op, so the hook is a thunk over the constant. Directory entry added in `re-frame.late-bind.directory` (the drift test pins publication ↔ directory in both directions).
- Freehand's `intent-keys` becomes the hook wrapper; the descriptor no longer states the class. It is asked on both hosts because the JVM render strips the owned positions too — a routing control key must not reach the server shell as an HTML attribute — and is only reached after `prefetch-payload` has already answered non-nil, so routing is proven present.
- Count words removed from the surrounding docstrings ("the three intent-keys" → "the intent-keys"), so the prose cannot go stale the moment the class changes.

**Deliberately not changed: the test literals.** The bead's original remedy line "tests loop the published constant rather than a literal" is not applied. `implementation/routing/test/re_frame/route_link_cljs_test.cljs` loops `[:on-mouse-enter :on-focus :on-touch-start]` literally, and that is the stronger test: a test that derives its expectations from the constant under test stops being able to catch a wrong constant. The Freehand tests already loop the conformance fixture, which is the same independence expressed through spec data. Flagging rather than silently diverging.

---

## Quality gates

Run from the worker worktree `C:/Users/miket/code/re-frame2-worktrees/routing-tail`, foreground to completion. Exit codes captured immediately with `rc=$?` into a worktree-local log and cross-checked against each run's own verdict line — the table below is the run against the final tree (`21e3c629c4`), not an earlier one.

| Gate | rc | Verdict line |
| --- | --- | --- |
| `npm ci` (`implementation/`) | `0` | — |
| `sh scripts/test-fast-pr.sh` | `0` | `PASS fast PR spine` |

Suite counts inside that spine, each re-derived rather than trusted:

| Suite | Result | Against the stated baseline |
| --- | --- | --- |
| JVM `implementation/core` | Ran 2115 tests containing 10462 assertions. 0 failures, 0 errors. | baseline 2115/10459 — same test count, +3 assertions, which arrived with the 12 `origin/main` commits this branch was rebased onto, not with this diff |
| JVM `implementation/routing` | Ran 511 tests containing 2771 assertions. 0 failures, 0 errors. | baseline 511/2771 — exact match |
| JVM `implementation/freehand` | Ran 1132 tests containing 7584 assertions. 0 failures, 0 errors. | no baseline stated |
| CLJS `:node-test` + JS harness + per-ns isolation | Ran 11491 tests containing 57471 assertions. 0 failures, 0 errors. 17/17 namespaces pass standalone. | no baseline stated |

`implementation/resources` is not in this diff's surface, so the spine did not select it and the 733/6799 baseline was not exercised.

The spine's own PASS line names what it did **not** run: the documentation gates (surface unchanged), the JVM artefact suites the diff did not touch, and the CI-only lanes (browser, prod-elision / bundle-isolation / perf, adapter probes and smokes, Xray feature matrix, mcp-conformance, tool JVM suites).

Landing verified by blob hash — worktree, index and the pushed remote ref agree on all four files:

```
cf0450ffb226aa89b15af3a4c702ab0e3b840696  implementation/core/src/re_frame/late_bind/directory.cljc
55065f5f4e6b4d3b43879827deb9ee73fa7fda06  implementation/freehand/src/re_frame/freehand/route_link_seam.cljc
eab8827eb72a81bfc126fc9e15b2d542b7b87cd6  implementation/routing/src/re_frame/routing.cljc
08184f23c39081153c5ee368a5d4e01992df246d  implementation/routing/src/re_frame/routing/link.cljc
```
