### PR TITLE
fix(gates): two false reds — the thrown-error scan and the G-8 perf baseline (rf2-u3otj, rf2-yumaq)

### DIFF
--- a/implementation/scripts/_g8-latency-evidence.test.cjs
+++ b/implementation/scripts/_g8-latency-evidence.test.cjs
@@ -37,6 +37,7 @@ const {
   PERCENTILE_CONVENTION,
   RATIO_BUDGET,
   NOISE_POLICY,
+  ZERO_BASELINE_REASON,
   CHANNELS,
   latencyPercentile,
   validateLatencySamples,
@@ -165,6 +166,39 @@ test('engineLatencyEvidence flips within-10% to false when compiled p95 crosses 
   assert.equal(e['within-10pct'], false);
 });
 
+// ----- rf2-yumaq: a baseline that is TOO FAST must not redden the gate -------
+
+test('engineLatencyEvidence SKIPS the comparison when the baseline p95 is 0 (too fast to compare)', () => {
+  const e = engineLatencyEvidence('chromium', fill25(1.0), fill25(0));
+  assert.equal(e.comparison, 'skipped');
+  assert.equal(e['p95-ratio'], null);
+  assert.equal(e['within-10pct'], null); // NOT true — a skip is never a verdict
+  assert.equal(e['comparison-reason'], ZERO_BASELINE_REASON);
+  assert.match(e['comparison-reason'], /too fast to compare/);
+  // Both distributions are still recorded — the skip hides nothing.
+  assert.equal(e.compiled['p95-ms'], 1.0);
+  assert.equal(e.handwritten['p95-ms'], 0);
+  assert.deepEqual(e.handwritten['raw-ms'], fill25(0));
+});
+
+test('engineLatencyEvidence marks a real comparison as compared, with no skip reason', () => {
+  const e = engineLatencyEvidence('webkit', fill25(1.0), fill25(1.0));
+  assert.equal(e.comparison, 'compared');
+  assert.equal(e['comparison-reason'], null);
+});
+
+test('a zero COMPILED p95 still compares — only the denominator can be missing', () => {
+  const e = engineLatencyEvidence('chromium', fill25(0), fill25(1.0));
+  assert.equal(e.comparison, 'compared');
+  assert.equal(e['p95-ratio'], 0);
+  assert.equal(e['within-10pct'], true);
+});
+
+test('withinBudget / p95Ratio stay STRICT on a zero denominator (the runner tooth still bites)', () => {
+  assert.throws(() => withinBudget(1.0, 0), /positive finite/);
+  assert.throws(() => p95Ratio(1.0, 0), /positive finite/);
+});
+
 test('engineLatencyEvidence validates BOTH raw arrays (a malformed one fails loudly)', () => {
   assert.throws(() => engineLatencyEvidence('chromium', fill25(1).slice(0, 10), fill25(1)), /exactly 25/);
   assert.throws(() => engineLatencyEvidence('chromium', fill25(1), fill25(1).slice(0, 10)), /exactly 25/);
@@ -253,6 +287,27 @@ test('buildPerformanceSummary reports an over-budget commit channel as observed-
   });
   const md = buildPerformanceSummary([over]);
   assert.match(md, /\| chromium \| commit \| 2\.000 \| 1\.000 \| 2\.000 \| observed over \|/);
+});
+
+test('buildPerformanceSummary renders a skipped channel as n/a + not-compared, never a ✓ (rf2-yumaq)', () => {
+  const tooFast = engineLatencyChannels('chromium', {
+    ...fixtureLatency(),
+    'handwritten-commit-raw-ms': fill25(0), // baseline below the timer resolution
+  });
+  const md = buildPerformanceSummary([tooFast]);
+  assert.match(md, /\| chromium \| commit \| 1\.200 \| 0\.000 \| n\/a \| not compared \|/);
+  // The reason is STATED in the packet, not left as a bare blank cell.
+  assert.equal(md.includes(ZERO_BASELINE_REASON), true);
+  // The other channel is unaffected and still carries its real numbers.
+  assert.match(md, /\| chromium \| settlement \| 5\.000 \| 4\.000 \| 1\.250 \| observed over \|/);
+  // A skip must never be dressed up as a pass.
+  assert.equal(/\| chromium \| commit \|[^\n]*✓/.test(md), false);
+});
+
+test('buildPerformanceSummary omits the skip footnote when every channel compared', () => {
+  const md = buildPerformanceSummary(twoEngineEvidence());
+  assert.equal(md.includes(ZERO_BASELINE_REASON), false);
+  assert.equal(md.includes('not compared'), false);
 });
 
 test('buildPerformanceSummary rejects an empty per-engine set', () => {

--- a/implementation/scripts/lib/g8-latency-evidence.cjs
+++ b/implementation/scripts/lib/g8-latency-evidence.cjs
@@ -43,6 +43,19 @@ const PERCENTILE_CONVENTION =
 // EVIDENCE-ONLY — `within-10pct` is reported, never gated.
 const RATIO_BUDGET = 1.1;
 
+// Why a comparison is sometimes not made at all (rf2-yumaq). A baseline p95 of
+// exactly 0 is NOT a broken measurement — `validateLatencySamples` has already
+// proved every sample finite and non-negative. It means the hand-written React
+// control settled faster than the host clock can resolve, so the ratio has no
+// denominator. The evidence records that as a SKIPPED comparison with this
+// reason stated, because a perf gate must never redden because the thing it
+// measures was too fast. The compiled and hand-written p95s are still recorded,
+// so nothing is hidden and nothing is claimed: `within-10pct` becomes `null`
+// (not-compared), never `true`.
+const ZERO_BASELINE_REASON =
+  'hand-written baseline p95 is 0 ms — at or below the host timer resolution, so the ' +
+  'ratio has no denominator (too fast to compare); both p95s are still recorded';
+
 // The noise policy recorded in the artifact so the stated relative budget is
 // reproducible and meaningful. rf2-dpwel resolved the two measurement effects
 // the rf2-5qz8z audit surfaced: the endpoint is now the arm's own Profiler
@@ -151,9 +164,17 @@ function p95Ratio(compiledP95, baselineP95) {
 // The comparative-latency evidence object for ONE channel, built from the two
 // raw sample arrays measured in the SAME warmed run. Pure — the runner folds
 // this into the artifact's `performance` section (per engine, per channel).
+// A zero baseline p95 does not throw here: the samples are already validated,
+// so it is a resolution floor, not corruption — the comparison is reported as
+// `skipped` with `ZERO_BASELINE_REASON`, and both `p95-ratio` and
+// `within-10pct` are `null`. `withinBudget`/`p95Ratio` stay strict: they are
+// the pure math, and a zero denominator remains meaningless to them.
 function engineLatencyEvidence(engine, compiledRaw, handwrittenRaw) {
   const compiled = summarizeLatency(compiledRaw, `[${engine}] compiled latency`);
   const handwritten = summarizeLatency(handwrittenRaw, `[${engine}] hand-written latency`);
+  const compiledP95 = compiled['p95-ms'];
+  const baselineP95 = handwritten['p95-ms'];
+  const comparable = baselineP95 > 0;
   return {
     engine,
     'samples-recorded': RECORDED_SAMPLES,
@@ -161,8 +182,10 @@ function engineLatencyEvidence(engine, compiledRaw, handwrittenRaw) {
     'ratio-budget': RATIO_BUDGET,
     compiled,
     handwritten,
-    'p95-ratio': p95Ratio(compiled['p95-ms'], handwritten['p95-ms']),
-    'within-10pct': withinBudget(compiled['p95-ms'], handwritten['p95-ms']),
+    comparison: comparable ? 'compared' : 'skipped',
+    'comparison-reason': comparable ? null : ZERO_BASELINE_REASON,
+    'p95-ratio': comparable ? p95Ratio(compiledP95, baselineP95) : null,
+    'within-10pct': comparable ? withinBudget(compiledP95, baselineP95) : null,
   };
 }
 
@@ -215,16 +238,30 @@ function buildPerformanceSummary(perEngine) {
     '| engine | channel | compiled p95 ms | hand-written p95 ms | p95 ratio | within 10% (evidence) |',
     '|---|---|---:|---:|---:|:---:|',
   ];
+  let anySkipped = false;
   for (const e of perEngine) {
     for (const ch of CHANNELS) {
       const ev = e[ch];
+      // A skipped comparison renders as `n/a` / `not compared` — never as a ✓.
+      // Silently showing a tick for an uncomparable channel would turn the old
+      // false red into a false green, which is the more expensive defect.
+      const skipped = ev.comparison === 'skipped';
+      if (skipped) anySkipped = true;
+      const ratioCell = skipped ? 'n/a' : fmt(ev['p95-ratio']);
+      const verdictCell = skipped
+        ? 'not compared'
+        : (ev['within-10pct'] ? '✓' : 'observed over');
       lines.push(
         `| ${e.engine} | ${ch} | ${fmt(ev.compiled['p95-ms'])} | ${fmt(ev.handwritten['p95-ms'])} | ` +
-          `${fmt(ev['p95-ratio'])} | ${ev['within-10pct'] ? '✓' : 'observed over'} |`,
+          `${ratioCell} | ${verdictCell} |`,
       );
     }
   }
   lines.push('');
+  if (anySkipped) {
+    lines.push(`\`n/a\` / \`not compared\`: ${ZERO_BASELINE_REASON}.`);
+    lines.push('');
+  }
   lines.push('<details><summary>Raw latency samples (ms)</summary>');
   lines.push('');
   for (const e of perEngine) {
@@ -250,6 +287,7 @@ module.exports = {
   PERCENTILE_CONVENTION,
   RATIO_BUDGET,
   NOISE_POLICY,
+  ZERO_BASELINE_REASON,
   CHANNELS,
   latencyPercentile,
   validateLatencySamples,

--- a/implementation/scripts/run-ui-g8.cjs
+++ b/implementation/scripts/run-ui-g8.cjs
@@ -227,9 +227,16 @@ function runMutationTeeth() {
 // it false, and a vacuous (zero) baseline is rejected as a broken measurement.
 // These teeth run over SYNTHETIC arrays — they prove the comparison is
 // non-vacuous WITHOUT ever gating the real measured latency.
+//
+// rf2-yumaq added the fourth tooth. A baseline that rounds to 0 ms USED to kill
+// the whole gate ("baseline p95 must be a positive finite number: 0") — a red
+// indistinguishable from a real browser failure, produced because the reference
+// was too FAST. It now reports a skipped comparison; the tooth pins that the
+// skip is stated and, crucially, that it does NOT report `within-10pct` true.
 function runBudgetTeeth() {
   const tight = Array(RECORDED_SAMPLES).fill(1.0);
   const overBudget = Array(RECORDED_SAMPLES).fill(2.0); // 2x the baseline p95
+  const zero = Array(RECORDED_SAMPLES).fill(0); // baseline below timer resolution
   const teeth = [];
   const ok = engineLatencyEvidence('synthetic', tight, tight);
   if (ok['within-10pct'] !== true) {
@@ -241,9 +248,20 @@ function runBudgetTeeth() {
     fail('budget tooth did not bite: a 2x compiled p95 was still reported within 10%');
   }
   teeth.push('over-budget compiled p95 (2x baseline) flagged outside 10%');
-  teeth.push(expectRejected('a zero baseline p95 is rejected as a broken measurement', () => {
+  teeth.push(expectRejected('a zero baseline p95 is rejected by the raw budget math', () => {
     withinBudget(1.0, 0);
   }));
+  const tooFast = engineLatencyEvidence('synthetic', tight, zero);
+  if (tooFast.comparison !== 'skipped') {
+    fail('too-fast tooth: a zero baseline p95 did not report a SKIPPED comparison');
+  }
+  if (tooFast['within-10pct'] !== null || tooFast['p95-ratio'] !== null) {
+    fail('too-fast tooth: a skipped comparison must report null ratio and null within-10pct, never a verdict');
+  }
+  if (!tooFast['comparison-reason']) {
+    fail('too-fast tooth: a skipped comparison must state its reason');
+  }
+  teeth.push(`zero baseline p95 skipped with a stated reason (${tooFast['comparison-reason']})`);
   return teeth;
 }
 
@@ -374,10 +392,14 @@ async function main() {
         const label = ch === 'commit'
           ? 'commit (true event-to-commit)'
           : 'settlement (former metric)';
+        // A skipped comparison has a null ratio — say so, with the reason.
+        const verdict = ev.comparison === 'skipped'
+          ? `ratio n/a — ${ev['comparison-reason']}`
+          : `ratio ${ev['p95-ratio'].toFixed(3)}, within-10% ${ev['within-10pct']}`;
         console.log(
           `  [${e.engine}] ${label} p95: compiled ${ev.compiled['p95-ms'].toFixed(3)}ms ` +
             `vs hand-written ${ev.handwritten['p95-ms'].toFixed(3)}ms ` +
-            `(ratio ${ev['p95-ratio'].toFixed(3)}, within-10% ${ev['within-10pct']}) — evidence only`,
+            `(${verdict}) — evidence only`,
         );
       }
     }

--- a/scripts/_test_fixtures/check_thrown_error_messages/negative/bypass_let_bound_token.cljc
+++ b/scripts/_test_fixtures/check_thrown_error_messages/negative/bypass_let_bound_token.cljc
@@ -1,0 +1,53 @@
+(ns fixture.bypass-let-bound-token)
+
+;; NEGATIVE (rf2-u3otj) — a CONFORMANT message that is `let`-bound before it is
+;; thrown. The runtime message is a human sentence plus the trailing
+;; `[:rf.error/…]` token, exactly as Spec 009 §The thrown-error shape requires;
+;; only the `ex-info` call site spells it as the symbol `msg`. This is the shape
+;; `re-frame.story/configure!` writes, and the gate must NOT report it.
+
+(defn configure!
+  [unknown known-keys]
+  (let [msg (str "configure! got unknown key(s): "
+                 (pr-str (vec unknown))
+                 " — known keys are " (pr-str known-keys) ". "
+                 "Fix the call site. [:rf.error/unknown-story-config-key]")]
+    (throw (ex-info msg
+                    {:rf.error/id :rf.error/unknown-story-config-key
+                     :where       'rf.story/configure!
+                     :recovery    :fix-call-site
+                     :reason      msg
+                     :unknown     (vec unknown)}))))
+
+;; The same one hop away through the ASSEMBLED token form — the bracket pair is
+;; split across the `(str …)` pieces with a LITERAL keyword between them.
+(defn assembled
+  [reason]
+  (let [msg (str reason " [" :rf.error/assembled-let-bound "]")]
+    (throw (ex-info msg {:rf.error/id :rf.error/assembled-let-bound
+                         :where       'rf/assembled}))))
+
+;; A `human-message` derivation bound before the throw is equally conformant.
+(defn via-builder
+  [data]
+  (let [msg (human-message :rf.error/via-builder data)]
+    (throw (ex-info msg {:rf.error/id :rf.error/via-builder
+                         :where       'rf/via-builder}))))
+
+;; INNERMOST binding wins, the way Clojure resolves it: the outer `msg` has no
+;; token, the inner one does, and the inner one is what is thrown.
+(defn shadowed
+  [reason]
+  (let [msg (str "outer sentence with no token at all")]
+    (let [msg (str reason " [:rf.error/shadowed-inner]")]
+      (throw (ex-info msg {:rf.error/id :rf.error/shadowed-inner
+                           :where       'rf/shadowed
+                           :outer       msg})))))
+
+;; LAST binding of the symbol in one vector wins, likewise.
+(defn rebound
+  [reason]
+  (let [msg (str "no token here")
+        msg (str reason " [:rf.error/rebound-last]")]
+    (throw (ex-info msg {:rf.error/id :rf.error/rebound-last
+                         :where       'rf/rebound}))))

--- a/scripts/_test_fixtures/check_thrown_error_messages/positive/bypass_let_bound_no_token.cljc
+++ b/scripts/_test_fixtures/check_thrown_error_messages/positive/bypass_let_bound_no_token.cljc
@@ -1,0 +1,58 @@
+(ns fixture.bypass-let-bound-no-token)
+
+;; POSITIVE (rf2-u3otj) — the let-binding resolution must not become a way to
+;; PASS. Every throw below is a genuine builder bypass and must still be
+;; reported. Six findings expected.
+
+;; 1. A `let`-bound message with NO token at all. Resolution finds the bound
+;;    form and re-tests it — the bound form fails the rule on its own text, so
+;;    the site fires exactly as it did before.
+(defn bound-but-bare
+  [what]
+  (let [msg (str "something went wrong with " what)]
+    (throw (ex-info msg {:rf.error/id :rf.error/bound-but-bare
+                         :where       'rf/bound-but-bare}))))
+
+;; 2. A bare symbol that is a FUNCTION PARAMETER, not a local binding. Nothing
+;;    encloses it in a `let`, so nothing resolves and the site fires.
+(defn param-message
+  [msg]
+  (throw (ex-info msg {:rf.error/id :rf.error/param-message
+                       :where       'rf/param-message})))
+
+;; 3. The COMPUTED discriminator, deliberately NOT resolved: the runtime
+;;    message carries the token, the source text cannot, and accepting a lone
+;;    symbol between the brackets would let any symbol through.
+(defn computed-discriminator
+  [id reason]
+  (throw (ex-info (str reason " [" id "]")
+                  {:rf.error/id id
+                   :where       'rf/computed-discriminator
+                   :reason      reason})))
+
+;; 4. A SIBLING `let` binds a perfectly conformant `msg`, but it does not
+;;    enclose the throw below it. Resolution must not reach across scopes.
+(defn sibling-scope
+  [reason]
+  (let [msg (str reason " [:rf.error/sibling-conformant]")]
+    (prn msg))
+  (throw (ex-info msg {:rf.error/id :rf.error/sibling-scope
+                       :where       'rf/sibling-scope})))
+
+;; 5. Shadowing in the other direction: the OUTER binding carries a token, the
+;;    inner one does not, and the inner one is what is thrown.
+(defn shadowed-away
+  [reason]
+  (let [msg (str reason " [:rf.error/outer-had-a-token]")]
+    (prn msg)
+    (let [msg (str "the inner sentence dropped the token")]
+      (throw (ex-info msg {:rf.error/id :rf.error/shadowed-away
+                           :where       'rf/shadowed-away})))))
+
+;; 6. A DESTRUCTURED binding is not a binding NAME the resolver accepts, so
+;;    nothing resolves and the site fires.
+(defn destructured
+  [ctx]
+  (let [{:keys [msg]} ctx]
+    (throw (ex-info msg {:rf.error/id :rf.error/destructured
+                         :where       'rf/destructured}))))

--- a/scripts/check_thrown_error_messages.py
+++ b/scripts/check_thrown_error_messages.py
@@ -85,7 +85,10 @@ A CONFORMANT message (does not fire) is one of:
     literal `"… [:rf.<ns>/…]"` OR the token ASSEMBLED across a `(str …)`
     concatenation `(str "… [" :rf.<ns>/<id> "]")` — the SANCTIONED
     bundle-isolated reagent-slim shape (it cannot `:require re-frame.error`,
-    so it hand-rolls the human sentence + token inline).
+    so it hand-rolls the human sentence + token inline); or
+  - a bare LOCAL SYMBOL whose binding in the innermost enclosing `let` is
+    itself conformant by the two rules above (rf2-u3otj) — the token lives on
+    the bound form, one hop from the `ex-info`.
 
 A DELIBERATE exemption — a message pinned to bare prose downstream (the
 conformance-DSL `:throw` / `:count` ops re-emit it as `:exception-message`,
@@ -335,33 +338,35 @@ _INLINE_TOKEN_MSG_RE = re.compile(r"\[:rf\.[a-z][\w.-]*/[\w.*+!?<>=-]+\]")
 # contiguous with the keyword, so this matches the assembled form: a `[` then
 # (across quotes/whitespace) a `:rf.<ns>/…` keyword then a `]`.
 #
-# KNOWN BLIND SPOT — a conformant message the scan cannot see (rf2-jquiy).
 # Both token regexes need the `:rf.<ns>/<id>` keyword and the human text to be
-# LITERAL at the `ex-info` call. Two conformant shapes are not:
+# LITERAL in the form they are handed. Two conformant shapes are not (rf2-jquiy
+# documented them; rf2-u3otj resolves the first):
 #
 #   (a) a let-BOUND message —  (let [msg (str "… [:rf.error/x]")] (ex-info msg …))
 #       `re-frame.story/configure!` (tools/story/src/re_frame/story.cljc:877,
-#       :914) does exactly this, under a comment citing Spec 009; the scan sees
-#       only the symbol `msg` and reports `builder-bypass-message`.
+#       :914) does exactly this, under a comment citing Spec 009. RESOLVED —
+#       `_resolve_let_binding` below hands the BOUND form to these same
+#       regexes, so the token is found one hop from the call.
 #   (b) a COMPUTED discriminator — (ex-info (str reason " [" error-kw "]") …)
 #       where `error-kw` is derived (`(keyword "rf.error" (str (name kind)
 #       "-shape"))`) or arrives as a parameter of a shared throw helper. The
-#       runtime message carries the token; the source text cannot.
-#
-# Both are FALSE POSITIVES, and nothing here distinguishes them from a real
-# bypass — deciding it needs the message form evaluated, not matched. So the
-# rule is deliberately left as-is and the false-red is accepted where it lands:
-# a site pinned to a conformant-but-invisible shape carries a comment saying
-# so, and `rf2:builder-bypass-ok` remains the opt-out of last resort. The trees
-# where this currently bites are all outside the roster, but the same shape
-# under `implementation/` would false-red identically — so do NOT "fix" a site
-# to satisfy this scan without first checking what its message renders to at
-# runtime. Widening the regexes to chase (a)/(b) would mean tracking a local
-# binding and constant-folding a `str`, which buys a handful of sites at the
-# cost of a scan that can no longer be read at a glance.
+#       runtime message carries the token; the source text cannot. NOT
+#       resolved, deliberately — see `_resolve_let_binding`'s note.
 _ASSEMBLED_TOKEN_MSG_RE = re.compile(
     r'\[["\s]*:rf\.[a-z][\w.-]*/[\w.*+!?<>=-]+["\s]*\]'
 )
+
+
+def _message_is_conformant(form: str) -> bool:
+    """Does this message FORM satisfy the thrown-error shape on its own text —
+    a central `human-message` derivation, or a message already embedding the
+    `[:rf.<ns>/…]` greppability token (contiguous, or assembled across a
+    `(str …)`)?"""
+    return bool(
+        _HUMAN_MESSAGE_MSG_RE.match(form)
+        or _INLINE_TOKEN_MSG_RE.search(form)
+        or _ASSEMBLED_TOKEN_MSG_RE.search(form)
+    )
 
 
 def _split_first_arg(body: str) -> tuple[str, str]:
@@ -465,6 +470,123 @@ def _extract_ex_info_form(text: str, open_paren_idx: int) -> str | None:
 
 _EX_INFO_OPEN_RE = re.compile(r"\(\s*ex-info\b")
 
+# --------------------------------------------------------------------------
+# Local-binding resolution (rf2-u3otj) — the message one hop from the call
+# --------------------------------------------------------------------------
+#
+# A conformant message is sometimes bound before it is thrown:
+#
+#   (let [msg (str "configure! got unknown key(s): " … " [:rf.error/x]")]
+#     (throw (ex-info msg {:rf.error/id :rf.error/x …})))
+#
+# The runtime message DOES carry the token, but the first `ex-info` argument is
+# the bare symbol `msg`, so both token regexes saw nothing and the site was
+# reported as a builder bypass. That false red is not free: it costs a round
+# trip under the standing rule that a failing gate on a touched surface is
+# never a flake, and the tempting "fix" is to DE-conformise working code to
+# satisfy a blind scan. The trees where it currently bites sit outside
+# `DEFAULT_SCAN_DIRS`, but the same shape under `implementation/` reds CI.
+#
+# So: when the message is a bare local symbol, resolve it through the innermost
+# enclosing `let` and re-test the BOUND FORM with `_message_is_conformant` —
+# the same predicates, no new ones. This is pure precision. A let-bound message
+# WITHOUT a token still fires, because the bound form must clear the rule on
+# its own text.
+#
+# DELIBERATELY NOT RESOLVED — the computed discriminator:
+#
+#   (ex-info (str reason " [" error-kw "]") {:rf.error/id error-kw …})
+#
+# where `error-kw` is derived, or arrives as a parameter of a shared throw
+# helper (`story.plan/fail!`, `mcp-base.diff_encode/validate-against!`). The
+# runtime message carries the token; the source cannot, and no static rule
+# separates it from a genuine bypass. Treating a lone symbol between the
+# brackets as a token would let ANY symbol pass — turning this false RED into a
+# false GREEN, the more expensive defect. Those sites stay reported, and
+# `rf2:builder-bypass-ok` exists for exactly that: a deliberate, documented
+# exemption whose conformance a human has checked at runtime.
+#
+# `let` only. `loop` rebinds through `recur`, and `if-let`'s else branch does
+# not see the binding — resolving either could green a site the reader cannot
+# verify, which is the direction this gate must never move.
+_LET_OPEN_RE = re.compile(r"\(\s*let\b")
+
+# A bare local symbol as the WHOLE message argument: no parens, no quotes, no
+# `/` (a namespaced var is not a local binding), not a keyword, not a number.
+_BARE_LOCAL_SYM_RE = re.compile(r"^[a-zA-Z*+!?<>=_-][\w*+!?<>=.-]*$")
+
+
+def _balanced_extent(text: str, open_idx: int) -> int | None:
+    """The index just past the delimiter matching the opener at `open_idx`, or
+    None if the form is unterminated. String-aware (the caller passes
+    comment-masked text, so a `(` inside a sentence cannot open a form)."""
+    n = len(text)
+    i = open_idx
+    depth = 0
+    in_string = False
+    while i < n:
+        c = text[i]
+        if in_string:
+            if c == "\\" and i + 1 < n:
+                i += 2
+                continue
+            if c == '"':
+                in_string = False
+            i += 1
+            continue
+        if c == '"':
+            in_string = True
+        elif c in "([{":
+            depth += 1
+        elif c in ")]}":
+            depth -= 1
+            if depth == 0:
+                return i + 1
+        i += 1
+    return None
+
+
+def _split_forms(body: str) -> list[str]:
+    """Every top-level form in `body`, in order — `_split_first_arg` applied
+    until the body is consumed."""
+    forms: list[str] = []
+    rest = body.strip()
+    while rest:
+        first, rest = _split_first_arg(rest)
+        if not first:
+            break
+        forms.append(first)
+    return forms
+
+
+def _resolve_let_binding(masked: str, offset: int, sym: str) -> str | None:
+    """The form `sym` is bound to by the innermost `let` whose form ENCLOSES
+    `offset`, or None if no enclosing `let` binds it.
+
+    Shadowing resolves the way Clojure resolves it: among enclosing `let`s the
+    innermost wins (they nest, so the latest start offset is the innermost),
+    and within one binding vector the LAST binding of the symbol wins. A
+    symbol bound only inside a destructuring form resolves nothing — the
+    binding NAME must be exactly `sym`."""
+    bound: str | None = None
+    for m in _LET_OPEN_RE.finditer(masked, 0, offset):
+        end = _balanced_extent(masked, m.start())
+        if end is None or end <= offset:
+            continue  # a sibling `let`, not an enclosing one
+        vec_start = masked.find("[", m.end())
+        # The binding vector must follow `let` immediately — only whitespace
+        # between, or this is not the vector we think it is.
+        if vec_start == -1 or masked[m.end():vec_start].strip():
+            continue
+        vec_end = _balanced_extent(masked, vec_start)
+        if vec_end is None:
+            continue
+        forms = _split_forms(masked[vec_start + 1:vec_end - 1])
+        for name, value in zip(forms[0::2], forms[1::2]):
+            if name == sym:
+                bound = value
+    return bound
+
 # The inline opt-out marker for a DELIBERATE, sanctioned builder-bypass — a
 # message that intentionally stays bare human prose WITHOUT the `[:rf.<ns>/…]`
 # token. A handful of sites need this: the conformance-DSL `:throw` / `:count`
@@ -502,12 +624,15 @@ def _scan_builder_bypass(path: Path, masked: str, raw_lines: list[str]) -> list[
         # Conformant messages do not fire: a central `human-message` derivation,
         # or a message already embedding the `[:rf.<ns>/…]` greppability token
         # (the reagent-slim inline shape).
-        if _HUMAN_MESSAGE_MSG_RE.match(first_arg):
+        if _message_is_conformant(first_arg):
             continue
-        if _INLINE_TOKEN_MSG_RE.search(first_arg):
-            continue
-        if _ASSEMBLED_TOKEN_MSG_RE.search(first_arg):
-            continue
+        # …or a bare local symbol whose `let` binding is conformant — the token
+        # lives one hop away (rf2-u3otj). Same predicates on the bound form, so
+        # a let-bound message WITHOUT a token still fires.
+        if _BARE_LOCAL_SYM_RE.match(first_arg):
+            bound = _resolve_let_binding(masked, m.start(), first_arg)
+            if bound is not None and _message_is_conformant(bound):
+                continue
         line_no = _line_of_offset(masked, m.start())
         # A deliberate, documented exemption opts out via the marker comment on
         # the `ex-info` line or within the small comment block directly above it
@@ -846,6 +971,12 @@ def _run_self_tests(verbose: bool = False) -> int:
         # --- positives for the WIDENED builder-bypass rule (rf2-krrv87) ---
         ("positive/bypass_str_concat_no_token.cljc",     1),
         ("positive/bypass_plain_string_no_token.cljc",   1),
+        # --- positives for the let-binding resolution (rf2-u3otj): resolving a
+        #     local must not become a way to PASS. A bound form with no token,
+        #     an unresolvable parameter, the computed discriminator, a sibling
+        #     (non-enclosing) scope, an inner binding that shadows a
+        #     token-bearing outer one, and a destructured name all still fire.
+        ("positive/bypass_let_bound_no_token.cljc",      6),
         # --- negatives: every conformant counterpart must stay GREEN ---
         ("negative/human_message_builder.cljc",      0),
         ("negative/throw_error_bang.cljc",           0),
@@ -860,6 +991,9 @@ def _run_self_tests(verbose: bool = False) -> int:
         ("negative/bypass_human_message_with_id.cljc",   0),
         ("negative/bypass_marker_exempt.cljc",           0),
         ("negative/bypass_no_error_id.cljc",             0),
+        # --- negative for the let-binding resolution (rf2-u3otj): a conformant
+        #     message bound one hop from the `ex-info` must stay GREEN.
+        ("negative/bypass_let_bound_token.cljc",         0),
     ]
 
     failures = 0


### PR DESCRIPTION
Two gates that red when nothing is wrong. This repo documents twelve ways a signal lies and eleven of them are greens that should have been red; these are the other direction. Each fix is held to the rule that it must not move a defect from the cheap column to the expensive one, so both carry an explicit anti-false-green tooth.

No workflow edit was needed. `.github/workflows/**` is untouched.

---

## rf2-u3otj — the thrown-error gate false-reds CONFORMANT messages

### Found versus changed

Verified before editing. `scripts/check_thrown_error_messages.py` reported 35 findings under `tools/`, six of them `builder-bypass-message`. All six were read at source:

| site | shape | verdict |
|---|---|---|
| `story.cljc:877`, `:914` | `let`-bound `msg`, bound form carries a **literal** `[:rf.error/…]` | conformant — **false red** |
| `registrar.cljc:324`, `:401`, `plan.cljc:150`, `diff_encode.cljc:308` | `(str reason " [" <sym> "]")`, discriminator computed or a parameter | runtime-conformant, **statically undecidable** |

Changed: the checker only. **No conformant Clojure was touched** — that pressure is what the bead exists to resist.

The fix: when the `ex-info` message is a bare local symbol, resolve it through the innermost enclosing `let` and re-test the **bound form** with `_message_is_conformant` — the same three predicates, no new ones. Pure precision; a bound form without a token still fires.

The four computed-discriminator sites are **deliberately not resolved**. Accepting a lone symbol between the brackets would let *any* symbol pass, converting this false red into a false green. `rf2:builder-bypass-ok` already exists for a site whose conformance a human has verified at runtime. `let` only: `loop` rebinds through `recur` and `if-let`'s else branch does not see the binding.

### Mutation proof — planted condition, both directions

A probe file was planted on the **default scan surface** (`implementation/`), which is the surface that reds CI.

**C2 — the defect, on the real scan surface.** Planted a conformant `let`-bound message (human sentence + trailing token, bound to `msg`). Mutation confirmed applied: `grep -c "rf.error/probe-conformant"` → `2`.

| checker | result |
|---|---|
| **pre-fix** (`origin/main`, extracted via `git show`) | `1 bare-keyword thrown-error message(s) found` → `builder-bypass-message: implementation/_rf2_mutation_probe/probe.cljc:10`, **rc=1** |
| **fixed** | `scanning 409 framework source file(s)` → `no bare-keyword thrown-error messages`, **rc=0** |

That is the bead's "turns from theory into a red build", reproduced and cleared.

**C1 — the anti-false-green direction.** Replaced the probe with a *genuine* bypass that goes through the new resolution path: a `let`-bound message whose bound form has **no** token, plus a computed discriminator. Mutation confirmed applied: `grep -c "probe-real-bypass\|probe-computed"` → `2`.

Fixed checker: `2 bare-keyword thrown-error message(s) found` at `probe.cljc:8` and `:14`, **rc=1**. The resolution did not blind the gate.

**Restored.** Probe removed; `git status` shows no residue. Bare gate: `scanning 408 framework source file(s)` … `no bare-keyword thrown-error messages`, **rc=0**.

### Corpus effect — exactly two lines, nothing else

`--scan-dir tools`: **35 → 33**. Diffing the sorted finding lists before and after yields exactly two deletions:

```
<   builder-bypass-message: tools/story/src/re_frame/story.cljc:877
<   builder-bypass-message: tools/story/src/re_frame/story.cljc:914
```

`literal-keyword-string` count unchanged at 29. The four computed-discriminator findings correctly remain.

Self-test fixtures: one negative (five conformant `let`-bound shapes incl. shadowing and rebinding → 0 findings) and one positive (six genuine bypasses → 6 findings, incl. sibling scope, destructuring, and a shadowed-away token).

---

## rf2-yumaq — the G-8 perf gate dies when the baseline is TOO FAST

### F6e mootness determination: NOT MOOT — the defect outlives the donor

Established before any edit, from `spec/conformance/freehand/donor-inventory.md` on `origin/main` (read-only; the file is untouched by this PR):

| row | disposition | slice | status |
|---|---|---|---|
| `implementation/scripts/lib/g8-latency-evidence.cjs` — the input-latency evidence library | **MOVE** | F6 | pending |
| `implementation/ui/g8/*` — the input-latency evidence fixture | **MOVE** | F6 | pending |

The inventory's own legend: **MOVE** = "the code, test, or obligation is absorbed under Freehand ownership". The closed set also contains `DELETE` ("the row does not cross at all"), and these rows are not it. The defective math therefore **crosses into Freehand** when `rf2-drpa3.57` deletes `implementation/ui/`; fixing it now means F6e carries the fix across rather than the bug.

Reinforcing: the file lives under `implementation/scripts/`, **not** `implementation/ui/` — outside the tree F6e removes. `implementation/ui/**` was read only, never edited.

### Found versus changed

The guard is in `withinBudget` / `p95Ratio`, both of which refuse a non-positive denominator. `validateLatencySamples` explicitly accepts `0` as a valid sample (there is a test asserting "zero ms is valid"), so an all-zero baseline passes validation, produces `p95 = 0`, and then kills the gate — the failure is in the *interpretation*, not the measurement.

Fix shape chosen: **"too fast to compare" — skip the ratio with a stated reason.** Not the timer-resolution floor, which would require inventing an engine-dependent constant and would fabricate a denominator the run never measured.

`engineLatencyEvidence` now reports `comparison: 'skipped'` with `ZERO_BASELINE_REASON`, and `p95-ratio` / `within-10pct` both `null`. `withinBudget` and `p95Ratio` stay strict — they are the pure math, a zero denominator remains meaningless to them, and the existing budget tooth that asserts they reject it still bites unchanged.

### It does not become a false green

- `within-10pct` is `null`, **never `true`** — a skip is not a verdict.
- Both p95s and both raw distributions stay in the artifact. Nothing is hidden; a reader sees compiled `1.200`, hand-written `0.000`, ratio `n/a`.
- The step summary renders `n/a` / `not compared` plus the stated reason, never a `✓`, and the footnote appears only when a channel actually skipped.
- The hard gate — the deterministic correctness matrix — is untouched. `within-10pct` was already evidence-only and never gated.

### Mutation proof — planted condition, both directions

**A — the defect reproduces and the fix clears it.** Planted the exact condition: 25 hand-written baseline samples all `0`.

- Pre-fix library, extracted verbatim from `origin/main`: threw `G-8 latency-evidence FAIL: baseline p95 must be a positive finite number: 0` — the bead's message, reproduced.
- Fixed library, same input: `comparison=skipped ratio=null within-10pct=null` with the reason stated.
- The runner's **real** `runBudgetTeeth()` (executed with `playwright` stubbed at `Module._load`; the teeth run over synthetic arrays before any browser) returns **4 teeth**, up from 3.

**B1 — the false-green mutation.** Changed the skip branch to report `within-10pct: true`. Applied confirmed: `git diff --stat` → `1 insertion(+), 1 deletion(-)`; `grep -n "MUTANT-B1"` → line 188.

| gate | result |
|---|---|
| `_g8-latency-evidence.test.cjs` | `FAIL engineLatencyEvidence SKIPS the comparison when the baseline p95 is 0`, `1 failed`, **rc=1** |
| `runBudgetTeeth()` | `BIT: too-fast tooth: a skipped comparison must report null ratio and null within-10pct, never a verdict`, **rc=1** |

**B2 — the regression mutation.** Forced `comparable = true`, i.e. the pre-fix shape. Applied confirmed: `git diff --stat` → `1 insertion(+), 1 deletion(-)`; `grep -n "MUTANT-B2"` → line 177.

| gate | result |
|---|---|
| unit tests | 2 failed (the skip test **and** the summary-rendering test), **rc=1** |
| `runBudgetTeeth()` | `BIT: baseline p95 must be a positive finite number: 0` — the original defect, caught by the tooth, **rc=1** |

**Restored after each.** `git diff --stat` clean against `HEAD`, no `MUTANT-` token anywhere in the file, unit tests `29 passed` **rc=0**, `runBudgetTeeth OK — 4 teeth` **rc=0**.

---

## Quality gates

| gate | command | rc |
|---|---|---|
| thrown-error gate, default scan dirs | `python scripts/check_thrown_error_messages.py --verbose` | **0** (408 files, no findings) |
| thrown-error gate, self-test | `python scripts/check_thrown_error_messages.py --self-test --verbose` | **0** (all 22 passed, up from 20) |
| thrown-error gate, explicit scan dir | `python scripts/check_thrown_error_messages.py --scan-dir tools` | **1** (33 findings — expected; `tools/` is outside `DEFAULT_SCAN_DIRS` and is not a CI gate) |
| G-8 latency-evidence unit tests | `node implementation/scripts/_g8-latency-evidence.test.cjs` | **0** (29 passed, up from 23) |
| G-8 runner budget teeth | `runBudgetTeeth()`, playwright stubbed | **0** (4 teeth) |
| python syntax | `python -m py_compile scripts/check_thrown_error_messages.py` | **0** |

The Python gates are silent-on-success by design — `rc` is the verdict; they print no PASS line. Every rc above was captured with `rc=$?` immediately after the command into a worktree-local log and cross-checked against that log's own verdict line.

**Not run locally:** the G-8 real-browser gate itself (needs `playwright` + a shadow-cljs `:ui-g8` compile). Its measurement-guard path is what changed, and that path is exercised by `runBudgetTeeth()`, which the runner calls *before* any browser launches — run here directly, in both mutant and restored states. CI owns the browser arms.

**No other consumer** of the evidence shape exists: a repo-wide grep for `within-10pct` / `p95-ratio` outside the three G-8 files returns nothing, so the two new keys and the two nullable ones break no downstream reader.

## Files

| file | bead |
|---|---|
| `scripts/check_thrown_error_messages.py` | rf2-u3otj |
| `scripts/_test_fixtures/check_thrown_error_messages/negative/bypass_let_bound_token.cljc` (new) | rf2-u3otj |
| `scripts/_test_fixtures/check_thrown_error_messages/positive/bypass_let_bound_no_token.cljc` (new) | rf2-u3otj |
| `implementation/scripts/lib/g8-latency-evidence.cjs` | rf2-yumaq |
| `implementation/scripts/run-ui-g8.cjs` | rf2-yumaq |
| `implementation/scripts/_g8-latency-evidence.test.cjs` | rf2-yumaq |

Neither bead is closed — the mayor closes on the merged SHA.
