### PR TITLE
core: record the per-dispatch frame-registry resolution cost (rf2-l260n); routing door-parity is a contract decision (rf2-0iuh3)

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -806,6 +806,39 @@
       (apply f args))))
 
 ;; ---- lookup ---------------------------------------------------------------
+;;
+;; WHAT ONE DISPATCH COSTS THIS REGISTRY, RECORDED (rf2-l260n). A single
+;; `dispatch-sync` of a one-line `:db`-writing handler re-resolves the registry
+;; 124 times:
+;;
+;;     frame                                    124
+;;     frame-record-visible-to-current-actor?   125
+;;     frame-incarnation-token                  115
+;;     frame-incarnation-closing?               105
+;;
+;; Method: counting wrappers installed over those four vars for the duration of
+;; ONE dispatch, plain-atom substrate, JVM, default debug gate. Structural
+;; counts, not timings — identical on every run. (The visibility predicate runs
+;; once more than `frame` because one call arrives from a registry enumeration —
+;; `frame-meta` / `frame-ids` — rather than through `frame`.)
+;;
+;; The total points at the wrong file, so the ATTRIBUTION is the part worth
+;; keeping. 115 of the 124 arrive through `frame-incarnation-token` from
+;; `frame-incarnation-live?`, and 105 of those from `event-continuation-live?` —
+;; the liveness fence, consulted from TWENTY distinct sites in one pipeline run.
+;; The heaviest are `router/call-while-exact-owner` (22), `process-event!`'s
+;; inner continuation (21) and `prepare-handler-ctx` (9). The four router seams
+;; that already hold a frame record — `run-one-pass!`, `prepare-handler-ctx`,
+;; `commit-and-flow!`, `emit-pipeline-trailers!` — account for 20 between them.
+;;
+;; So the tempting remedy, record-taking arities at the seams that already hold
+;; the record, reaches about a sixth of the resolutions; collapsing the rest
+;; means threading an incarnation token through a chain whose widest hop
+;; (`emit-pipeline-trailers!`) already takes eight positional arguments. That
+;; trades clarity for microseconds and is DELIBERATELY NOT TAKEN — the fence
+;; density is the design: every hop that could outlive its incarnation asks. The
+;; one unconditionally free win here, dropping the literal-path `get-in` from
+;; these predicates, is already applied (rf2-sj5s7).
 
 (defn- frame-record-visible-to-current-actor?
   "True when raw registry record `f` is a live frame visible to this actor.


### PR DESCRIPTION
Two beads. One lands a change; the other stops at a contract decision, as its own filing asked.

## rf2-l260n — the number is the deliverable

**Found: a record bead. Changed: one comment block in `implementation/core/src/re_frame/frame.cljc` (+33 lines, comment only, no code touched).**

**Which it is.** A record, not an optimisation. The title says *record*; the body says "this bead exists to RECORD the number so a future reader ... does not rediscover it. Do rf2-sj5s7. Do not refactor the router drain signature chasing this." And rf2-sj5s7 is already closed (PR #6986, merge `facb868db3`) — so the actionable half was taken last week. What was left was to write the finding down where a reader lands.

### Profile, with the method stated

Counting wrappers installed over `frame`, `frame-record-visible-to-current-actor?`, `frame-incarnation-token` and `frame-incarnation-closing?` for the duration of ONE `dispatch-sync`; plain-atom substrate, JVM, core `:test` classpath, default debug gate. These are **structural counts, not timings** — identical on every run, so the concurrent load on this box cannot reach them. **No wall clock is quoted anywhere in this PR.**

Re-derived, `[:inc]` (a one-line `:db` write):

| | measured here | bead claimed |
|---|---|---|
| `frame` | **124** | 124 |
| `frame-record-visible-to-current-actor?` | **125** | 124 |
| `frame-incarnation-token` | **115** | 115 |
| `frame-incarnation-closing?` | **105** | 105 |

Three of four reproduce exactly. The visibility predicate is 125 rather than 124 because one call arrives from a registry enumeration (`frame-meta` / `frame-ids` — the only other two callers) instead of through `frame`. `[:noop]` measures 118 / 119 / 109 / 99.

### Caller attribution, which is what actually decided the outcome

The count names `frame` and `frame-incarnation-token`. Attribution names neither as the fix site.

```
frame  (124)
  115  <- frame-incarnation-live?            93%
    5  <- frame-slot
    4  <- dispatch-sync! / process-event! / commit-frame-transition! / frame-observability

frame-incarnation-live?  (115)
  105  <- event-continuation-live?
    9  <- dispatch-sync!'s target-live?
    1  <- drain-block!

event-continuation-live?  (105) — TWENTY distinct call sites in ONE pipeline run
   22  router/call-while-exact-owner          21  router/process-event! inner continuation
    9  router/prepare-handler-ctx              6  frame/event-owner-live?
    5  router/run-chain                        5  router/commit-frame-effects!
    4  router/run-one-pass!                    4  router/emit-pipeline-trailers!
    4  frame/call-exact-frame-callback         4  router/run-candidate-validation!
    3  router/commit-and-flow!                 3  router/run-handler-pipeline!
    2  flows/owner-live?                       2  events/wrap-event-handler
    2  frame/commit-frame-record-transition!   2  flows.registry/capture-flow-pass-state
    1  flows.registry/abandoned-output-paths-snapshot
    1  flows.registry/frame-last-inputs-snapshot
    1  router/run-handler-pipeline! inner fn
```

**This revises the bead's own clarity verdict — toward doing less.** The bead reasoned that "the router already holds `frame-record` at most of these call sites (`run-one-pass!`, `prepare-handler-ctx`, `commit-and-flow!`, `emit-pipeline-trailers!`)", so record-taking arities there would be free and clarity-positive. Attribution says those four account for **20 of the 105**; the fan-out is twenty sites, not four, and the two heaviest — `call-while-exact-owner` (22) and `process-event!`'s inner continuation (21) — are not among them. Record-taking arities would therefore reach about a sixth of the resolutions. Collapsing the rest means threading an incarnation token through a chain whose widest hop, `emit-pipeline-trailers!`, already takes eight positional arguments (verified: `[event-id event emit-event frame outcome start-ms handler-elapsed-ms final-ctx]`).

**So no optimisation is taken.** The comment records the counts, the method, the attribution chain, and the reason not to act — the fence density is the design: every hop that could outlive its incarnation asks.

## rf2-0iuh3 — STOPPING: this is a contract decision

The bead asked for a ruling and it was right to. **I did not pick a side, and nothing was changed on this surface.**

### Which door is right — established, from the emitting sites and the spec

**The link (URL) door is right; the programmatic door is wrong.** Four independent lines, all reproduced on current `main` (`f615199b21`):

1. **Reproduced through two genuinely different seams** — no same-seam false green. The programmatic side is `[:rf.route/navigate {:to :route/probe :params {:id "7" :extra "x"}}]` (named-address resolver). The click side is `(:payload (link/link-model props :rf/default))` — exactly what the real click handler dispatches — which resolves through the URL. Route `/probe/:id`:
   - programmatic commits `:params {:id "7" :extra "x"}`
   - link click commits `:params {:id "7"}`
2. **The programmatic door commits a slice its own pushed URL cannot restore.** Same probe: `BEFORE-RELOAD {:id "7" :extra "x"}`; feed its own `route-url` output (`/probe/7`) back through `:rf.route/handle-url-change`; `AFTER-RELOAD {:id "7"}`. Reload, Back/Forward, deep link and SSR all land on `{:id "7"}`. The `:extra` survives exactly until the first URL round-trip.
3. **`resolve/resolved-target`'s own docstring states the rule it is breaking** — three times over, for nil query values, for `:fragment ""`, and for `:query-defaults`: *"a resolved target must describe a place its own canonical URL can spell, so every spelling of one destination lowers to one target."* `:extra` is that same failure in the `:params` slot, which is the one slot the seam reflects verbatim rather than resolving.
4. **Spec 012** §The one planning pipeline: "Doors differ in cause and history / scroll policy, **not in target**." §The raw-URL escape: a matching raw URL "produces the same resolved target ... it would from `:to`."

### Why the remedy is still a ruling, and not a worker's pick

The bead's (a) *fail loud at the address gate* and (b) *drop at the ResolvedTarget seam* are not interchangeable, and one of them carries a hard blocker I can prove:

**(b) as worded would break the canonical not-found contract.** `resolve/url-resolution` builds the reserved `:rf.route/not-found` target through the *same* `resolved-target` seam, carrying spec-mandated `:params {:url … :reason …}` (Spec 012 §Route-not-found rule 1; §URL changes are events rules 4–5). Measured: `(resolver/target-of-url "/no/such/thing")` → `{:route-id :rf.route/not-found, :params {:url "/no/such/thing"}, …}`. No pattern captures those keys — and `:rf.route/not-found` need not be registered at all (`(registrar/lookup :route :rf.route/not-found)` → `nil` in that run), so there is no pattern to consult. A blanket "drop params the pattern does not capture" at that seam erases the not-found `:url` / `:reason` vocabulary. (b) is viable only with an explicit fallback carve-out — a second rule at a second place, which is what the bead wanted to avoid.

**(a) has the stronger house-style precedent, and a visible blast radius.** Spec 012 validity rule 2 already says of address keys riding beside `:url`: *"letting address keys ride beside it and be silently ignored is **the exact failure class this grammar exists to kill**."* And `route-url` is already loud about the address KEY class (`:rf.error/route-url-validation`, `:reason :bad-address-keys`) while silently ignoring uncaptured param NAMES — internally inconsistent today. Against that: the same address flows through `route-link`'s href projection, so a fail-loud gate turns a typo'd param into a **render-time throw**; and `address.cljc` is today pure set logic with no registry dependency, which a capture-name check would end.

**Implementation note for whoever takes the ruling.** The capture set is cheap and already precomputed: `(:names (:rf.route/compiled route-meta))` includes optional-group inner names (verified — `/probe/:id{/:page}?` → `:names ["id" "page"]`), so it is `(set (map keyword names))` with no pattern re-walk.

**One incidental fact, reported not acted on.** `link/url-requested-payload` puts `:to` / `:params` / `:query` onto the `[:rf.route/url-requested {…}]` vector, and `decisions/url-requested-handler` destructures only `{:keys [url replace? bypass-leave?]}`. The link door does not *drop* `:extra` at a seam — it never consults the address at all.

Nothing settled on this surface was re-litigated: the `:validation` asymmetry is untouched, and the `readiness.cljc` / `resources` and `href-attrs` / `link-model` duplications are untouched.

## Separate finding — NOT in this PR, wants its own bead (P1 candidate)

While re-deriving rf2-l260n's debug-off arm I hit a reproducible core defect on a **documented production configuration**. `implementation/SECURITY.md` lists `-Dre-frame.debug=false` as the gate that "SSR / long-running JVMs set". Under it, on current `main`, a plain event never runs:

```clojure
(rf/reg-event :inc (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
(rf/dispatch-sync [:inc])
```

- `handler-runs = 0`; app-db stays `{}`. Identical code with the gate at its default: `handler-runs = 2`, app-db `{:n 2}`.
- The always-on error channel reports `:rf.error/no-such-handler` for `[:inc]` — so it is loud, not silent.
- **Yet the router's own resolver finds the handler.** At that same moment `(#'re-frame.router/resolve-handler :inc)` → non-nil, `(registrar/lookup :event :inc)` → `{:handler-fn … :interceptors …}`, and the frame is live (`frame-ids` → `#{:rf/default}`). `resolve-handler` is literally `(registrar/lookup :event event-id)`.
- `clojure -J-Dre-frame.debug=false -M:test -n re-frame.drain-test` → **34 failures / 40 assertions**.

This is also why rf2-l260n's and rf2-sj5s7's "debug off" call counts (95 / 88 / 82) do not reproduce today — I measure 34 / 27 / 21, the counts of a pipeline that aborts before the handler. Not diagnosed further: out of scope for these two beads, and it wants its own owner.

## Quality gates

All re-derived on this branch. Each `rc` captured immediately into a worktree-local log (`ai/gates/*.log`, gitignored) and cross-checked against that log's own verdict line — not inferred from the shell.

| gate | result | rc |
|---|---|---|
| `implementation/core` `clojure -M:test` | 2115 tests / 10462 assertions, 0 failures, 0 errors | **0** |
| `implementation/routing` `clojure -M:test` | 511 tests / 2771 assertions, 0 failures, 0 errors | **0** |
| `scripts/test-fast-pr.sh` | log reads `PASS fast PR spine` | **0** |
| ├ JVM `implementation/core` (inside the spine) | 2115 / 10462, 0 failures, 0 errors | — |
| └ `npm run test:cljs` (inside the spine) | 11491 tests / 57471 assertions, 0 failures, 0 errors | — |

Against the baselines I was handed: routing **511 / 2771 matches exactly**. Core is 2115 / **10462** against a handed 10459, and `test:cljs` 11491 / 57471 against a handed ~11489 / 57479 — both are main moving, not this diff, and that is provable rather than asserted: **every added line in this PR is a `;;` comment.** `git diff origin/main...HEAD | grep '^+' | grep -v '^+;;'` is empty; 33 insertions, 0 deletions, one file. A comment cannot add or remove an assertion.

**On "prove by mutation": no test is added by this PR, so there is no gate of mine to plant against.** The two claims that needed proving were proven by direct measurement instead, each with a built-in discriminator that would have exposed a dead probe:

- the call counts move between events (`[:noop]` 118 / 119 / 109 / 99 vs `[:inc]` 124 / 125 / 115 / 105), so the counters are tracking the dispatch rather than reporting a constant;
- the door-parity probe drives its two sides through **different** seams and pins the canonical value as a literal, and the reload arm flips `{:id "7" :extra "x"}` → `{:id "7"}` within one test — a same-seam probe could not produce that flip.

The `-Dre-frame.debug=false` finding has the same shape: `handler-runs` reads 2 with the gate at default and 0 with it set, in otherwise identical code.
