### PR TITLE
test(epoch): the MCP-egress gate reaches the free :scope tag and the recomputed large sub (rf2-0t7o8, rf2-isp3i)

### DIFF
--- a/implementation/epoch/test/re_frame/epoch_mcp_egress_conformance_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_mcp_egress_conformance_test.clj
@@ -14,13 +14,20 @@
        the whole-output `:large?` sub REGISTRATION stamp (rf2-isp3i). The
        second is not app-db-rooted, so a fixture that declared only paths
        left this gate's own claim — no raw large bytes ANYWHERE — scanning
-       a record the shape never appeared in. `sensitive` likewise means BOTH
-       families: the app-db path AND the resource/mutation trace family, whose
-       owner-local SCOPED KEYS are classified by the resource OWNER's
-       `:sensitive?` declaration rather than by any app-db path (rf2-isp3i's
-       rescoping — before the widening this file contained no `reg-resource`
-       at all, so the family's projector had never been reached from the gate
-       that owns the no-raw-sensitive-egress claim).
+       a record the shape never appeared in; and the sub is RECOMPUTED, so
+       all FOUR of that shape's payload slots (current + previous, on each of
+       its two carriers) carry a real value rather than one value beside a nil.
+       `sensitive` likewise means BOTH families: the app-db path AND the
+       resource/mutation trace family, whose owner-local SCOPED KEYS are
+       classified by the resource OWNER's `:sensitive?` declaration rather than
+       by any app-db path (rf2-isp3i's rescoping — before the widening this
+       file contained no `reg-resource` at all, so the family's projector had
+       never been reached from the gate that owns the no-raw-sensitive-egress
+       claim). And the family is inhabited across OPERATIONS, not only slots
+       (rf2-0t7o8): the tag vocabulary is operation-agnostic but the DEFECTS
+       are not, so the cascade drives the operation that stamps a free `:scope`
+       tag as well as the ones that carry their scope inside a key, in both the
+       identity-bearing and the scalar scope shape.
     2. Run the ring through `projected-record` (per-record forwarder shape,
        e.g. `register-epoch-listener!` ship!) AND `projected-history` (bulk-egress
        shape, e.g. `watch-epochs` initial snapshot).
@@ -114,6 +121,26 @@
 ;; that had no sub-output slot in it at all — which is how rf2-irwsq shipped a
 ;; 25000-char payload raw at `[:trace-events <i> :tags :rf.sub/value]` past this
 ;; very gate.
+;;
+;; The sub's output rides its input, and the cascade below RECOMPUTES it, so the
+;; two payload slots of each carrier — `:value` / `:prev-value` on the
+;; structured row, `:rf.sub/value` / `:rf.sub/prev-value` on the trace tag —
+;; hold DISTINCT large values rather than one value beside a nil. All four are
+;; projected by the shared rule and all four are pinned below, and the pinning
+;; is not decorative: with a single compute the previous-value slots are nil, a
+;; nil projects to a marker over nothing, and the whole-output scans see no
+;; difference — so deleting either previous-value projection left this gate
+;; GREEN. Measured, both directions:
+;;
+;;   - pass `:value :rf.disabled/prev-value` to `elide-sub-run-row`'s shared-rule
+;;     call (the structured row's previous-value projection off) → 5 failures;
+;;   - pass `:rf.sub/value :rf.disabled/prev-value` in
+;;     `elide-large-sub-trace-values` (the trace tag's off) → 5 failures.
+;;
+;; Each names its own slot, both trip the two carriers' `:bytes` agreement, and
+;; both trip the cross-cutting "no leaf of the payload's size anywhere" scans on
+;; the per-record AND the bulk `projected-history` surface — which is the part
+;; that was silently uncovered.
 (def ^:private large-sub-id   :sub/whole-output-large)
 ;; An UNMARKED sibling sub whose value rides the same two egress slots. It is
 ;; the negative control: if the elision below ever became a blanket truncation
@@ -163,7 +190,17 @@
               so this fixture kept them out; that constraint is now lifted)
     - :upload — writes the large path (large payload closed-over in the
                 handler for the same reason)
-    - :inc — non-sensitive again
+    - :inc — non-sensitive again, AND the FIRST reading of the two subs
+             below. It takes that reading through `subscribe` (not
+             `subscribe-once`), so the cache entry outlives the cascade
+             and the read in `:read-subs` is a RECOMPUTE with a
+             previous value rather than a first run. The reading is
+             taken from the handler body, i.e. BEFORE this cascade's own
+             `:n` increment commits, which is what makes the two
+             readings see different inputs and produce two DISTINCT
+             large values (rf2-isp3i: with one compute both
+             previous-value slots are nil, and deleting either
+             previous-value projection leaves this gate green)
     - :read-subs — reads a whole-output `:large?` sub and an unmarked
                    control sub (rf2-isp3i). This is the SECOND large
                    shape, and it is not app-db-rooted: the `:large?`
@@ -175,7 +212,8 @@
                    (`:rf.sub/value` / `:rf.sub/prev-value`, projected by
                    `elide-large-sub-trace-values`). Both callers of the
                    shared `elide-whole-output-large-slots` rule are
-                   therefore inhabited by one cascade.
+                   therefore inhabited by one cascade, and all FOUR of
+                   their payload slots carry a real value
   Driven LAST so the existing index-addressed assertions (`(nth _ 1)` =
   :login, `(nth _ 2)` = :upload) keep addressing the same cascades. Five
   cascades against this suite's `:trace-events-keep 5` means every record
@@ -186,9 +224,18 @@
   (rf/reg-event :seed   (fn [{:keys [db]} _] {:db {:n 0}}))
   (rf/reg-event :login  (fn [{:keys [db]} _] {:db (assoc-in db [:auth :password] secret-password)}))
   (rf/reg-event :upload (fn [{:keys [db]} _] {:db (assoc-in db [:blob :payload] (big-string payload-size))}))
-  (rf/reg-event :inc    (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
-  (rf/reg-sub large-sub-id   {:large? true} (fn [_ _] (big-string payload-size)))
-  (rf/reg-sub control-sub-id                (fn [_ _] control-note))
+  ;; The `:large?` sub's output rides `:n`, so the two readings below produce
+  ;; values of DIFFERENT sizes — the raw current / previous pair the four
+  ;; payload slots must each carry, and the reason their two markers can be
+  ;; told apart by `:bytes`.
+  (rf/reg-sub large-sub-id   {:large? true}
+    (fn [db _] (big-string (* payload-size (inc (:n db 0))))))
+  (rf/reg-sub control-sub-id (fn [_db _] control-note))
+  (rf/reg-event :inc
+    (fn [{:keys [db]} _]
+      @(rf/subscribe [large-sub-id]   {:frame frame-id})
+      @(rf/subscribe [control-sub-id] {:frame frame-id})
+      {:db (update db :n (fnil inc 0))}))
   (rf/reg-event :read-subs
     (fn [_ _]
       (rf/subscribe-once [large-sub-id]   {:frame frame-id})
@@ -324,22 +371,50 @@
 ;;     widening the op roster, which is why the scans below run over the WHOLE
 ;;     record and the whole settled history rather than over the family rows.
 ;;
-;; All three are reachable from the cascade `drive-resource-family!` drives, and
-;; all three were MEASURED here by reverting the fix and re-running, because a
-;; widening that cannot red against a defect that actually shipped has proven
-;; nothing:
+;;   - rf2-1zc33 — and the FOURTH, which is a different axis again: a projector
+;;     that is right per SHAPE but was reached on the wrong ROWS. The free
+;;     `:scope` tag (the resolved CONCRETE scope, not the one inside a scoped
+;;     key) was treated as sibling-owned, on the premise that the
+;;     `:rf.resource/scope-resolved` projector had already classified it. The
+;;     epoch tool-pair applies that sibling under `(= :rf.resource/scope-resolved
+;;     (:operation ev))` — ONE operation — while this family projector runs on
+;;     every row, so on five OTHER row types `:scope` was classified by nobody
+;;     and a `{:from-db …}` resolver's identity map egressed raw. The cascade
+;;     could not see it twice over (rf2-0t7o8): it drove only `ensure` /
+;;     `release-owner`, none of which stamps a free `:scope`, and both its
+;;     resources were `:rf.scope/global` — a SCALAR, the value that correctly
+;;     rides verbatim — so even a row that DID carry `:scope` would have proven
+;;     nothing. Both gaps are closed by the two `invalidate-tags` the cascade now
+;;     drives.
 ;;
-;;   - revert rf2-wd9im (`trace_egress.cljc` back to the map-only default) → 5
-;;     failures, naming all five leaking paths — the three lifecycle rows'
+;; All four are reachable from the cascade `drive-resource-family!` drives, and
+;; all four were MEASURED here by reverting the fix and re-running, because a
+;; widening that cannot red against a defect that actually shipped has proven
+;; nothing. Counts are for THIS FILE, re-derived against the widened cascade —
+;; each mutation is stated precisely enough to reproduce:
+;;
+;;   - revert rf2-wd9im (`project-unknown-slot-value` back to the map-only
+;;     default: drop its `scoped-key-shape?` and `coll?` arms) → 7 failures,
+;;     naming every leaking path — the lifecycle rows'
 ;;     `[:tags :work/id 1 2 :auth-token]`, the release row's `:released` and its
-;;     `:aborted` — and printing raw `{:auth-token "…"}` beside raw
-;;     `:rf.scope/global`;
-;;   - revert rf2-5o52l (`events.cljc` + `ssr.cljc` back to key-ids) → 8
-;;     failures, the report printing the raw CEDN-1 string
-;;     `v[k::rf.scope/global k::secret/article m{k::auth-token s:"…"}]`, and the
-;;     PLAIN control reddening too (a key-id is not a scoped-key vector, so the
-;;     plain owner's `:released` member goes missing) — the fixture notices the
-;;     change in both directions, not just the leaking one.
+;;     `:aborted`, and (new) the invalidation row's `[:tags :scope 1 :username]`,
+;;     since a scope TUPLE is a vector and the map-only default lets a vector
+;;     fall through verbatim. Epoch suite under that mutation: 35 failures.
+;;   - revert rf2-5o52l (`events.cljc`'s `:released` back to
+;;     `(vec (or owned #{}))`, i.e. key-ids) → 9 failures: 8 in the acceptance
+;;     deftest, the report printing the raw CEDN-1 string
+;;     `v[k::rf.scope/global k::secret/article m{k::auth-token s:"…"}]`, and 1 in
+;;     the PLAIN control (a key-id is not a scoped-key vector, so the plain
+;;     owner's `:released` member goes missing) — the fixture notices the change
+;;     in both directions, not just the leaking one. Epoch suite: 10 failures.
+;;   - revert rf2-1zc33 (put `:scope` back into `sibling-owned-slot`) → 3
+;;     failures, naming `[:trace-events <i> :tags :scope 1 :username]` on both
+;;     the assembled record and the real settled one, plus the per-slot
+;;     `(redacted-token? (second pscope))`. Epoch suite: 490 tests / 6628
+;;     assertions, 19 failures — the SAME test and assertion counts as green,
+;;     differing only in failures, which is what proves the mutation applied
+;;     rather than the gate quietly not firing. Before this widening the same
+;;     revert left this file GREEN.
 ;;   - revert rf2-1kiuj (drop the `omit-off-box-fx-args-resource-keys` arm from
 ;;     `elide-trace-events-slot`) → see the reversion counts recorded on the
 ;;     bead; the whole-record and whole-history scans name every leaking carrier
@@ -350,7 +425,12 @@
 ;; Note what the second reversion shows about the first: `:released` is NOT in
 ;; the projector's named `scoped-keys-slot` roster, so carrying scoped keys there
 ;; only redacts because rf2-wd9im's shape-driven default recognises a key
-;; wherever it sits. The two fixes hold this slot up together.
+;; wherever it sits. The two fixes hold this slot up together. And note what the
+;; third shows about all of them: three of the four defects were reached by the
+;; whole-record `secret-leak-paths` / `cedn-tokens` scans rather than by a
+;; per-slot assertion, which is why those scans run over the WHOLE record and the
+;; whole settled history — the per-slot assertions say WHERE, the scans say
+;; WHETHER, and only the scans cover a slot nobody has looked at yet.
 
 (def ^:private sensitive-resource-id :secret/article)
 (def ^:private plain-resource-id     :plain/article)
@@ -727,36 +807,71 @@
             proj-row  (sub-run-row  proj large-sub-id)
             proj-tags (sub-run-tags proj large-sub-id)]
         ;; Fixture controls: the shape the scan above must be able to see.
-        (is (= payload-size (count (:value raw-row)))
+        ;; The last cascade RECOMPUTES the sub, so all four payload slots hold a
+        ;; real value and the current / previous pair are DISTINCT — with one
+        ;; compute the two previous-value slots are nil, and a nil projects to a
+        ;; marker over nothing, so deleting either previous-value projection
+        ;; outright would leave this gate green (rf2-isp3i).
+        (is (= (* 2 payload-size) (count (:value raw-row)))
             "fixture: the raw `:sub-runs` row carries the sub's full computed
              value — the slot `elide-sub-run-row` projects")
-        (is (= payload-size (count (:rf.sub/value raw-tags)))
+        (is (= payload-size (count (:prev-value raw-row)))
+            "fixture: and its PREVIOUS value, a DIFFERENT large value — the
+             recompute is what puts one there")
+        (is (= (:value raw-row) (:rf.sub/value raw-tags))
             "fixture: the raw `:rf.sub/run` trace tag carries the SAME value —
              the slot `elide-large-sub-trace-values` projects. The emit
              chokepoint deliberately leaves both raw so the on-box ring keeps
              the exact value (Xray diff / restore-epoch! need it)")
+        (is (= (:prev-value raw-row) (:rf.sub/prev-value raw-tags))
+            "fixture: and the same previous value, so the two carriers are
+             carrying one pair and the markers below are comparable")
         (is (true? (:large? raw-tags))
             "fixture: the emit chokepoint stamped the bare whole-output
              `:large?` flag — a REGISTRATION marker, so the app-db-rooted
              classification this fixture installs cannot reach it, and the flag
              is the entire contract egress has to honour")
-        ;; Both callers of the shared rule, at egress.
+        ;; Both callers of the shared rule, both slots of each, at egress.
         (is (elision/marker? (:value proj-row))
             "`elide-sub-run-row` substituted the marker in the structured row")
+        (is (elision/marker? (:prev-value proj-row))
+            "…and in that row's PREVIOUS-value slot")
         (is (elision/marker? (:rf.sub/value proj-tags))
             "`elide-large-sub-trace-values` substituted the marker in the trace
              tag — the slot whose omission was rf2-irwsq's leak")
-        (is (= (get-in (:value proj-row)          [:rf.size/large-elided :bytes])
-               (get-in (:rf.sub/value proj-tags)  [:rf.size/large-elided :bytes]))
-            "both markers agree on `:bytes` — the structural evidence that ONE
-             shared rule produced them, so the two projections cannot drift")
+        (is (elision/marker? (:rf.sub/prev-value proj-tags))
+            "…and in that tag's PREVIOUS-value slot, the fourth and last of the
+             pair-of-pairs the one shared rule owns")
+        (is (zero? (count-leaf-strings-at-least payload-size proj))
+            "and NEITHER value survives as raw bytes anywhere in the projected
+             record — the claim the four markers exist to keep")
+        (let [bytes-at (fn [m] (get-in m [:rf.size/large-elided :bytes]))]
+          (is (= (bytes-at (:value proj-row)) (bytes-at (:rf.sub/value proj-tags)))
+              "the two CURRENT-value markers agree on `:bytes` — the structural
+               evidence that ONE shared rule produced them, so the two
+               projections cannot drift")
+          (is (= (bytes-at (:prev-value proj-row))
+                 (bytes-at (:rf.sub/prev-value proj-tags)))
+              "and so do the two PREVIOUS-value markers")
+          (is (not= (bytes-at (:value proj-row)) (bytes-at (:prev-value proj-row)))
+              "while current and previous DIFFER — each marker is measured over
+               its own value, so a projection that substituted one constant, or
+               measured the wrong slot, cannot pass"))
         ;; Negative control: an UNMARKED sub's value rides through raw, so the
         ;; elisions above are driven by the registration stamp and not by some
         ;; blanket truncation on the way out.
-        (is (= control-note (:value (sub-run-row proj control-sub-id)))
-            "NEGATIVE CONTROL — the unmarked sub's row value survives raw")
-        (is (= control-note (:rf.sub/value (sub-run-tags proj control-sub-id)))
-            "NEGATIVE CONTROL — and so does its trace tag value")))))
+        (let [ctrl-row  (sub-run-row  proj control-sub-id)
+              ctrl-tags (sub-run-tags proj control-sub-id)]
+          (is (= control-note (:value ctrl-row))
+              "NEGATIVE CONTROL — the unmarked sub's row value survives raw")
+          (is (= control-note (:prev-value ctrl-row))
+              "NEGATIVE CONTROL — and so does its previous value, so the
+               previous-value substitution is driven by the `:large?` stamp and
+               not by the slot's position")
+          (is (= control-note (:rf.sub/value ctrl-tags))
+              "NEGATIVE CONTROL — and so does its trace tag value")
+          (is (= control-note (:rf.sub/prev-value ctrl-tags))
+              "NEGATIVE CONTROL — and its trace tag's previous value"))))))
 
 (deftest forwarder-projected-record-preserves-bookkeeping-slots
   (testing "MCP forwarder pattern: the projected record's bookkeeping

--- a/implementation/epoch/test/re_frame/epoch_mcp_egress_conformance_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_mcp_egress_conformance_test.clj
@@ -138,7 +138,14 @@
   [frame-id]
   (frame/swap-runtime-db! frame-id
     (fn [rt] (elision/apply-classification-effects rt
-               {:sensitive [[:auth :password]]
+               {:sensitive [[:auth :password]
+                            ;; rf2-0t7o8 — the SESSION IDENTITY the named scope
+                            ;; resolver reads (`install-resource-family!`).
+                            ;; Classified here so the app-db axis is never what
+                            ;; the resource-family scans catch: any surviving
+                            ;; copy of the secret came off a resource TRACE tag,
+                            ;; which is the axis those scans own.
+                            [:auth :user :username]]
                 :large     [[:blob :payload]]})))
   nil)
 
@@ -350,13 +357,27 @@
 (def ^:private plain-slug            "mcp-egress-plain-control")
 (def ^:private resource-owner        [:app :reader 1])
 
+;; rf2-0t7o8 — the SESSION axis. A `reg-resource-scope` resolver derives an
+;; identity-bearing `[tier {identity}]` scope from an app-db read, which is the
+;; scope SHAPE the free `:scope` tag leaked; `:rf.scope/global` (every other
+;; owner here) is a SCALAR and rides verbatim, so it could never have shown the
+;; defect. The identity IS this suite's secret, so a scope that egresses raw is
+;; caught by the same whole-record scans the rest of the family answers to.
+(def ^:private session-scope-id      :mcp/session)
+(def ^:private session-cause         [:logout :session])
+(def ^:private global-cause          [:logout :global])
+(def ^:private invalidation-tag      :mcp/article)
+
 (defn- install-resource-family!
   "Register the two resource owners the family scans need: one `:sensitive?`
   (its scoped key's scope + params MUST tokenize off-box) and one PLAIN (its key
   MUST ride verbatim — the two-sided over-redaction control, so redacting
-  everything fails as loudly as leaking). Plus a no-op managed-HTTP fx so
-  `ensure` writes its `:loading` entry and emits its lifecycle rows without a
-  request leaving the box.
+  everything fails as loudly as leaking). Plus the NAMED SCOPE RESOLVER whose
+  `{:from-db …}` reference gives the cascade an identity-bearing `[tier
+  {identity}]` scope (rf2-0t7o8) rather than the bare `:rf.scope/global` scalar
+  both owners carry, and a no-op managed-HTTP fx so `ensure` writes its
+  `:loading` entry and emits its lifecycle rows without a request leaving the
+  box.
 
   `fx/reg-fx`, NOT `rf/reg-fx`, and the difference is load-bearing. `rf/reg-fx`
   is a macro that stamps the calling namespace as the registration's provenance,
@@ -370,9 +391,28 @@
   cascade, off the global registrar) cheerfully reports the resource present. The
   plain fn carries no provenance, so it REPLACES the artefact's own slot and the
   reprojection keeps working. The resources artefact's own suites hit the same
-  seam and resolve it the same way."
-  []
+  seam and resolve it the same way.
+
+  rf2-0t7o8, two fixture preconditions worth stating out loud:
+
+  - the SESSION IDENTITY is seeded straight into the app-db partition, the
+    symmetric sibling of the runtime-db write `install-mcp-style-schemas!`
+    makes. A `dispatch` would settle another epoch record for a value that is
+    pure setup, and the cascade's record count is read below.
+  - `:trace-events-keep` is pinned to the shipped default. The suite-wide
+    `:init-fn` sets 5 for `drive-mixed-ring!`'s five cascades; this cascade
+    settles more than five and EVERY record is read for its `:trace-events`, so
+    inheriting that cap would silently elide the FIRST record's rows and return
+    the fx-carrier scans to reporting green over ground they no longer cover.
+    Pinning it here is what stops the cascade's LENGTH from being load-bearing."
+  [frame-id]
+  (rf/configure! {:epoch-history {:trace-events-keep 50}})
+  (frame/swap-frame-db! frame-id assoc-in [:auth :user :username] secret-password)
   (fx/reg-fx :rf.http/managed (fn [_ctx _args] nil))
+  (rf/reg-resource-scope session-scope-id
+    {:inputs {:username [:db [:auth :user :username]]}}
+    (fn [{:keys [username]} _ctx]
+      (when username [:rf.scope/session {:username username}])))
   (rf/reg-resource sensitive-resource-id
     {:scope         :rf.scope/global
      :sensitive?    true
@@ -406,11 +446,47 @@
   work-id vector — each present twice over, once for a sensitive owner and once
   for a plain one.
 
+  THEN two `invalidate-tags`, and they are the other axis (rf2-0t7o8). Every
+  operation above carries its scope INSIDE a scoped key, where the family's
+  own key projection owns it. `invalidate-tags` is the first operation here that
+  stamps the resolved CONCRETE scope as a FREE `:scope` tag, which is a slot
+  NOTHING owned: the sibling `:rf.resource/scope-resolved` projector is applied
+  by the epoch tool-pair under `(= :rf.resource/scope-resolved (:operation ev))`
+  — ONE operation — while the family projector runs on all of them, so a
+  pass-through here classified `:scope` by nobody and the resolver's identity
+  map egressed raw (rf2-1zc33, five row types). One dispatch resolves its scope
+  through the named resolver (the identity-bearing `[tier {identity}]` TUPLE,
+  the shape that leaked); the other names `:rf.scope/global` (a SCALAR, the
+  shape that must still ride verbatim). Same slot, same row type, two shapes —
+  which is what makes the pair a control rather than two assertions.
+
+  NOT driven, and deliberately, two things:
+
+  - `:rf.resource/refetch-decision`. It fires once per entry an invalidation
+    MATCHES, and an entry acquires its `:tags` at SETTLE — so reaching it means
+    an HTTP reply round-trip the `ensure` path does not need, i.e. real
+    machinery inside a conformance fixture. Its `:scope` is
+    `(first resource-key)`, the same value the `:resource/key` beside it carries
+    and the same free-tag slot `:rf.resource/invalidated` proves below, so the
+    marginal coverage is a second INSTANCE of an exercised mechanism. Same
+    judgement, and for the same reason, as the standing ruling against adding
+    `:rf.mutation/*` rows here.
+  - an `ensure` of a SESSION-SCOPED owner. That shape reds today, on a leak this
+    widening found and which is NOT this fixture's to fix (rf2-425mm): an
+    `ensure` stamps the resolved `:scope` into its `:on-success` / `:on-failure`
+    continuation arg maps, those ride `:rf.fx/args` / `:rf.event/fx`, and the
+    fx-args projector deliberately speaks only for SCOPED KEYS inside a carrier
+    — so a `[tier {identity}]` scope sitting in a free `:scope` slot there is
+    reached by nobody and the resolver's identity map egresses raw at four paths
+    of the `ensure` record. The identity-bearing scope therefore enters this
+    cascade through `invalidate-tags`, which stamps it as a free tag WITHOUT
+    lowering into fx. When rf2-425mm lands, add the `ensure` here: it is the
+    same shape one carrier further out.
+
   The rows are harvested off the trace bus rather than read out of the settled
-  epoch records because ONE record is one dequeued event: this cascade is three
-  dispatches, so its 7 family rows are spread across 3 records (the sensitive
-  `ensure`'s, the plain `ensure`'s, the `release-owner`'s). Every scan below
-  wants them together, which `record-carrying-resource-rows` assembles.
+  epoch records because ONE record is one dequeued event: this cascade is five
+  dispatches, so its family rows are spread across five records. Every scan
+  below wants them together, which `record-carrying-resource-rows` assembles.
 
   They used also to be harvested here because epoch capture DROPPED them
   outright — `capture-event!` resolved an event's frame from `[:tags :frame]`
@@ -438,8 +514,35 @@
                         {:frame frame-id})
       (rf/dispatch-sync [:rf.resource/release-owner {:owner resource-owner}]
                         {:frame frame-id})
+      ;; rf2-0t7o8 — the free `:scope` tag, in both of its shapes. Driven AFTER
+      ;; `release-owner` on purpose: an invalidation refetches every matched
+      ;; entry that still has an active owner, and a refetch storm would settle
+      ;; records this fixture neither needs nor addresses.
+      (rf/dispatch-sync [:rf.resource/invalidate-tags
+                         {:scope {:from-db session-scope-id}
+                          :tags  #{invalidation-tag}
+                          :cause session-cause}]
+                        {:frame frame-id})
+      (rf/dispatch-sync [:rf.resource/invalidate-tags
+                         {:scope :rf.scope/global
+                          :tags  #{invalidation-tag}
+                          :cause global-cause}]
+                        {:frame frame-id})
       (finally (trace-tooling/unregister-listener! k)))
     @rows))
+
+(defn- invalidated-row
+  "The tags of the `:rf.resource/invalidated` row in `rows` carrying `cause`.
+  The cascade drives one invalidation per scope SHAPE and labels each with its
+  own cause, so the cause names the row on raw and projected rows alike — a
+  cause is a vector of keywords, i.e. structural attribution, so it rides
+  verbatim through the projection."
+  [rows cause]
+  (->> rows
+       (filter #(and (= :rf.resource/invalidated (:operation %))
+                     (= cause (:cause (:tags %)))))
+       first
+       :tags))
 
 (defn- record-carrying-resource-rows
   "The frame's last REAL epoch record with the cascade's WHOLE set of family
@@ -1194,10 +1297,12 @@
             params in ANY representation — not as the raw params map, and not
             hidden inside a reversible CEDN-1 `key-id` string. The two leaks
             this gate could not see (rf2-wd9im's embedded work-id key,
-            rf2-5o52l's plaintext key-id) both land in the rows below."
+            rf2-5o52l's plaintext key-id) both land in the rows below, and so
+            does the third (rf2-1zc33's free `:scope` tag, reached by driving an
+            operation that stamps one)."
     (rf/make-frame {:id :test/mcp})
     (install-mcp-style-schemas! :test/mcp)
-    (install-resource-family!)
+    (install-resource-family! :test/mcp)
     (let [rows      (drive-resource-family! :test/mcp)
           raw-hist  (rf/epoch-history :test/mcp)
           record    (record-carrying-resource-rows :test/mcp rows)
@@ -1241,7 +1346,15 @@
                no slot-addressed lookup reaches it")
           (is (some #(contains-secret? (:tags %)) (mapcat fx-carrier-rows raw-hist))
               "carrying the secret itself — so a green scan below is the
-               projector's doing, not an absent shape")))
+               projector's doing, not an absent shape"))
+        (is (every? (comp seq :trace-events) raw-hist)
+            "FIXTURE — EVERY record the cascade settled retained its
+             `:trace-events`. The suite's `:trace-events-keep` elides the
+             oldest records' rows once a cascade outgrows the cap, and the scans
+             below would then read a record whose family + fx rows are simply
+             gone — green over ground they no longer cover. Pinned in
+             `install-resource-family!`; asserted here so the pin cannot rot
+             silently"))
 
       ;; ---- the claim this gate owns ---------------------------------------
       (testing "ACCEPTANCE — no raw sensitive bytes anywhere in the projected
@@ -1252,9 +1365,9 @@
         (is (empty? (mapcat secret-leak-paths proj-hist))
             "and from every leaf of every REAL record the cascade settled,
              projected as a forwarder ships it — the assembled record above
-             carries the family rows of all three cascades but only the LAST
-             one's fx rows, so the `ensure` record's carriers are only seen
-             here (rf2-1kiuj)")
+             carries the family rows of every cascade but only the LAST one's
+             fx rows, so the `ensure` records' carriers are only seen here
+             (rf2-1kiuj)")
         (is (empty? (cedn-tokens projected))
             "and no CEDN-1 key-id egresses under ANY tag of the WHOLE record —
              a key-id would disclose the same scope + params in the clear while
@@ -1306,6 +1419,58 @@
           (is (some? aborted) "the sensitive owner's work-id rode under :aborted")
           (is (= released aborted)))
         (is (true? (:sensitive? tags)) "the release row is stamped :sensitive?"))
+
+      ;; ---- the FREE `:scope` tag (rf2-0t7o8 / rf2-1zc33) --------------------
+      ;;
+      ;; Every slot above carries its scope INSIDE a scoped key. `:scope` is a
+      ;; tag in its own right, on a row type no other operation in this cascade
+      ;; emits, and it was owned by NOBODY: the sibling scope-resolved projector
+      ;; runs on ONE operation, the family projector runs on all of them and
+      ;; passed the slot through. It is now the SHAPE-driven default's, which is
+      ;; why the pair of shapes below is one control and not two assertions.
+      (let [raw-tags  (invalidated-row rows      session-cause)
+            proj-tags (invalidated-row proj-rows session-cause)
+            pscope    (:scope proj-tags)]
+        (testing "FIXTURE — the session invalidation resolved a real
+                  identity-bearing scope and stamped it as a FREE tag"
+          (is (= [:rf.scope/session {:username secret-password}] (:scope raw-tags))
+              "FIXTURE — the RAW row carries the resolver's identity map one
+               level OUTSIDE any scoped key. Both other owners here are
+               `:rf.scope/global`, a SCALAR — the value that correctly rides
+               verbatim — so before this operation the tuple shape did not occur
+               anywhere in the fixture and a row carrying `:scope` would have
+               proven nothing")
+          (is (= #{invalidation-tag} (set (:tags raw-tags)))))
+        (testing "the TIER survives and the IDENTITY tokenizes — the two halves
+                  of the shape rule, on one value"
+          (is (vector? pscope)
+              "the projected scope is still the 2-tuple a tool reads")
+          (is (= :rf.scope/session (first pscope))
+              "the tier keyword rides verbatim — a tool still shows
+               \"session scope\"")
+          (is (redacted-token? (second pscope))
+              "and the resolver's identity MAP tokenizes, distinct scopes
+               keeping distinct digests so per-scope joins survive")
+          (is (= #{invalidation-tag} (set (:tags proj-tags)))
+              "the invalidated tag set rides verbatim beside it — the default
+               tokenizes app payloads, not the structural attribution")))
+
+      (testing "and the SIBLING's own row is untouched by that change — it had
+                already substituted its scalar `:rf/redacted` SENTINEL, which
+                the shape-driven default rides verbatim, so dropping `:scope`
+                from the sibling-owned set cost the scope-resolved row nothing"
+        (let [tags (family-row proj-rows :rf.resource/scope-resolved nil)]
+          (is (some? tags)
+              "FIXTURE — the `{:from-db …}` reference emitted a causal
+               scope-resolved row")
+          (is (= :rf/redacted (:scope tags)))
+          (is (= :rf/redacted (:input-values tags))
+              "`:input-values` is STILL sibling-owned — it has no shape rule of
+               its own and must not be reached by the default")
+          (is (= session-scope-id (:resource-id tags))
+              "the resolver id survives for attribution")
+          (is (= [:username] (:inputs tags))
+              "and so do the declared input NAMES — only the VALUES redact")))
 
       ;; ---- the FX-ARGS carriers, per slot (rf2-1kiuj) -----------------------
       (let [ensure-rec (first proj-hist)
@@ -1387,10 +1552,12 @@
             VERBATIM off-box, in the SAME rows that tokenize the sensitive
             owner's. Without this half, the acceptance test above could be
             satisfied by redacting everything, which would destroy the
-            attribution every resource tool is built on."
+            attribution every resource tool is built on. rf2-0t7o8 adds the
+            same control on the free `:scope` tag, where the un-redacted side
+            is the `:rf.scope/global` SCALAR."
     (rf/make-frame {:id :test/mcp})
     (install-mcp-style-schemas! :test/mcp)
-    (install-resource-family!)
+    (install-resource-family! :test/mcp)
     (let [rows      (drive-resource-family! :test/mcp)
           proj-hist (mapv epoch/projected-record (rf/epoch-history :test/mcp))
           projected (epoch/projected-record
@@ -1418,6 +1585,23 @@
       (testing "the plain owner's params are the real map, not a token"
         (is (= {:slug plain-slug} (nth (:resource/key tags) 2)))
         (is (not (redacted-token? (nth (:resource/key tags) 2)))))
+
+      ;; ---- the free `:scope` tag's un-redacted side (rf2-0t7o8) ------------
+      (testing "a `:rf.scope/global` scope is a SCALAR and rides the FREE
+                `:scope` tag verbatim, on the same row type and in the same slot
+                whose identity-bearing tuple tokenizes in the acceptance test
+                above. Without this half the shape rule could be a blanket
+                strip, and every tool's scope column would read `:rf/redacted`
+                for the ordinary case"
+        (let [tags (invalidated-row proj-rows global-cause)]
+          (is (some? tags) "FIXTURE — the global invalidation row is present")
+          (is (= :rf.scope/global (:scope tags))
+              "the global scope rides verbatim")
+          (is (= #{invalidation-tag} (set (:tags tags)))
+              "and so does the invalidated tag set beside it")
+          (is (empty? (cedn-tokens tags)))
+          (is (not (:sensitive? tags))
+              "a row that redacted nothing is NOT stamped :sensitive?")))
 
       ;; ---- and the same control on the FX-ARGS carriers (rf2-1kiuj) --------
       (let [plain-rec (second proj-hist)          ; the PLAIN owner's `ensure`


### PR DESCRIPTION
Closes rf2-0t7o8. Closes rf2-isp3i.

`implementation/epoch/test/re_frame/epoch_mcp_egress_conformance_test.clj` owns
two claims — *no raw sensitive bytes anywhere in a projected record* and *no raw
large bytes anywhere*. Two independent blind spots in that one fixture, and in
both the assertion was real, the machinery was fine, and the **input** could not
reach the case.

## rf2-0t7o8 — the cascade inhabited one operation shape

`drive-resource-family!` dispatched two `ensure`s and one `release-owner`. Every
one of those carries its scope **inside a scoped key**, where the family's key
projection owns it. None of them stamps the resolved concrete scope as a **free
`:scope` tag** — the slot rf2-1zc33 found classified by nobody, because the
sibling `:rf.resource/scope-resolved` projector is applied by the epoch
tool-pair under `(= :rf.resource/scope-resolved (:operation ev))`, one
operation, while the family projector runs on all of them.

Second, independent: both fixture resources were `:rf.scope/global`. A global
scope is a **scalar** — the value that correctly rides verbatim — so the
`[tier {identity}]` tuple, the shape that actually leaked, did not occur
anywhere in the file. Even a row that *did* carry `:scope` would have proven
nothing.

The cascade now registers a `reg-resource-scope` resolver deriving
`[:rf.scope/session {:username <secret>}]` from an app-db read, and drives two
`invalidate-tags`: one resolving through `{:from-db …}`, one naming
`:rf.scope/global`. Same slot, same row type, two shapes — which is what makes
the pair a control and not two assertions. The tier keyword rides verbatim while
the identity map tokenizes; the global scalar is untouched. The
`:rf.resource/scope-resolved` row is asserted **unchanged**, so dropping
`:scope` from the sibling-owned set is shown to have cost the sibling's own row
nothing and `:input-values` is shown to still be sibling-owned.

## rf2-isp3i — the residual on the large-value acceptance

Per the merged-PR-#7021 audit note on the bead. `drive-mixed-ring!` computed
`:sub/whole-output-large` **once**, so both raw previous-value slots were nil and
the acceptance test asserted only `:value` and `:rf.sub/value` — while its own
docstring claimed both callers and both slots were inhabited. A nil previous
value projects to a marker over nothing, so deleting or breaking **either**
previous-value projection left this gate green, including the cross-cutting
"no leaf of the payload's size anywhere" scans on the per-record *and* the bulk
`projected-history` surface.

The sub's output now rides `:n`; `:inc` takes a first reading through
`subscribe` (retained past the cascade) before its own increment commits, so
`:read-subs` is a recompute. Current and previous are both large and **distinct**
in both carriers, all four projected slots are pinned as markers, the two
current markers agree on `:bytes`, the two previous markers agree on `:bytes`,
and current differs from previous — so a projection that substituted one
constant, or measured the wrong slot, cannot pass. `:digest` is deliberately not
asserted: `classification/large-marker` is called without `include-digests?`, so
the marker built at this seam carries `:path` / `:bytes` / `:type` / `:reason` /
`:hint` / `:handle` and no digest. `:bytes` is the per-value agreement the two
carriers actually publish.

## Is the operation set derived or enumerated?

**The row-classification rule is derived; the dispatch set is enumerated, and
there is nothing to derive it from.**

Derived, and already so: which rows take the family projector is
`resource-family-op?` — a namespace predicate, not a roster. The fixture's own
`resource-family-row?` mirrors it, and the assertions harvest *whatever the
producer emits* through that predicate rather than listing expected operations.
So no roster rots here, and a family row on a future operation is covered by
construction. That is also why the scans run over the **whole record** and the
whole settled history rather than over the family rows: three of the four
defects re-proved below were caught by a whole-record scan, not by a per-slot
assertion.

Enumerated, necessarily: the **dispatches**. The registrar does hold every
registered `:rf.resource/*` event handler, so the ids are enumerable — but an id
is not a cascade. Each public event takes a bespoke, semantically loaded payload
(an `ensure` needs a resource + params + owner; an `invalidate-tags` needs a
scope + tags + cause; a `clear-scope` needs a resolvable scope), and deriving
those would mean inventing producer input — the canned-stub class this repo
rejects, and a generator, which the fence forbids. What the fixture does instead
is state each *omission* and why, in `drive-resource-family!`'s docstring, so the
uncovered set is readable rather than implied:

- `:rf.resource/refetch-decision` — fires per **matched** entry, and an entry
  acquires its `:tags` at settle, so reaching it needs an HTTP reply round-trip
  the `ensure` path does not need. Its `:scope` is `(first resource-key)` — the
  same value in the same slot `:rf.resource/invalidated` already proves. A
  second instance of an exercised mechanism, which is the standing ruling
  against adding `:rf.mutation/*` rows here, for the same reason.
- an `ensure` of a **session-scoped** owner — reds today, on a leak this
  widening found. See below.

## A new leak, filed not fixed: rf2-425mm

Driving a session-scoped `:sensitive?` `ensure` reddened the acceptance test
immediately, at four paths:

```
[:trace-events 10 :tags :rf.fx/args   :on-success 1 :scope 1 :username]
[:trace-events 10 :tags :rf.fx/args   :on-failure 1 :scope 1 :username]
[:trace-events 11 :tags :rf.event/fx 2 1 :on-success 1 :scope 1 :username]
[:trace-events 11 :tags :rf.event/fx 2 1 :on-failure 1 :scope 1 :username]
```

An `ensure` lowers into `:rf.http/managed` and the continuation payload carries
the resolved `:scope` (the stale-suppression verification payload). Those ride
the fx carriers. `project-embedded-keys` deliberately speaks only for **scoped
keys** inside a carrier — tokenizing an fx payload wholesale would redact a
plain owner's request map, which rf2-1kiuj explicitly rejected — and rf2-1zc33's
shape default reaches `:scope` only on rows `resource-family-op?` selects, which
`:rf.fx/*` rows are not. Two correct decisions, and a free `:scope` slot between
them that nobody reaches. On the same record the scoped key one slot over
tokenizes correctly, so the identical identity is redacted and leaked side by
side.

Per the fence (`implementation/resources/src/**` is read-only for this bead)
this is **filed, not fixed**: **rf2-425mm**, P1, with the reproduction. The
cascade therefore takes its identity-bearing scope in through `invalidate-tags`,
which stamps the free tag without lowering into fx, and
`drive-resource-family!`'s docstring says so and says to add the `ensure` when
rf2-425mm lands.

## Two-sided control

Both directions, and both had to stay green while the reverts below went red:

- **plain owner rides verbatim** — `forwarder-projected-record-keeps-plain-resource-owner-verbatim`
  is green in every direction, including on the one slot
  (`:rf.resource/cancel-poll-timers`'s `:resource/keys`) that carries both
  owners' keys, where the plain key rides verbatim beside a tokenized sibling.
- **`:rf.scope/global` untouched** — new, on the free `:scope` tag: the global
  scalar rides verbatim, its `:tags` set rides verbatim, no CEDN-1 token appears,
  and the row is not stamped `:sensitive?`. Under the rf2-1zc33 revert this half
  stays **green** while the session half reds — the discrimination is by shape,
  not a blanket strip.
- and on the large axis, the unmarked control sub's **four** slots
  (`:value` / `:prev-value` / `:rf.sub/value` / `:rf.sub/prev-value`) all still
  ride raw, so the marker substitution follows the `:large?` registration stamp
  and not the slot's position.

## Fixture hygiene worth naming

`install-resource-family!` pins `:trace-events-keep` and a new fixture control
asserts **every** settled record kept its `:trace-events`. The suite-wide
`:init-fn` sets 5 for `drive-mixed-ring!`'s five cascades; inheriting that cap
would silently elide the oldest record's rows as the family cascade grows and
return the fx-carrier scans to green over ground they no longer cover. The
cascade's *length* is no longer load-bearing.

## Quality gates

All run to completion in the foreground from this worktree, `rc` captured
immediately into a worktree-local log and cross-checked against each log's own
`Ran …/… failures` verdict line.

| gate | result | rc |
| --- | --- | --- |
| `implementation/epoch` `clojure -M:test` | 490 tests / 6637 assertions, 0 failures 0 errors | 0 |
| `implementation/resources` `clojure -M:test` | 733 tests / 6799 assertions, 0 failures 0 errors | 0 |
| `implementation/core` `clojure -M:test` | 2115 tests / 10462 assertions, 0 failures 0 errors | 0 |
| `scripts/test-fast-pr.sh` | see below | see below |
| this ns alone, before | 22 tests / 172 assertions, 0 failures | 0 |
| this ns alone, after | 22 tests / 198 assertions, 0 failures | 0 |

Baselines re-derived rather than trusted. epoch went 490/6611 → 490/6637 (+26
assertions, same test count — the widening adds assertions to existing deftests,
it adds no deftest). resources 733/6799 matches its baseline exactly. core
measured **2115/10462**, not the 2115/10459 I was given; it is deterministic
across two runs and the diff cannot reach core's classpath (the only changed
file is `implementation/epoch/test/**`), so the 10459 baseline is stale.

### The three revert-proofs

Each mutation applied to production source, measured, then restored with
`git checkout --` (no stash). Counts are **this file**; the epoch-suite figure
is beside each.

**1. rf2-wd9im** — `project-unknown-slot-value` back to the map-only default
(drop its `scoped-key-shape?` and `coll?` arms).

→ **7 failures** in this file; epoch suite **35 failures** (490/6637). Names
every leaking path: the lifecycle rows' `[:tags :work/id 1 2 :auth-token]`, the
release row's `:released` and its `:aborted`, and — new from this widening —
the invalidation row's `[:tags :scope 1 :username]`, because a scope tuple is a
*vector* and the map-only default lets a vector fall through verbatim. The
pre-widening precedent recorded in the fixture was 5.

**2. rf2-5o52l** — `events.cljc`'s `:released` back to `(vec (or owned #{}))`,
i.e. entries named by `state/key-id`.

→ **9 failures** in this file (8 in the acceptance deftest, 1 in the plain
control); epoch suite **10 failures** (490/6637). The report prints the raw
CEDN-1 plaintext
`v[k::rf.scope/global k::secret/article m{k::auth-token s:"…"}]`. The plain
control reds too — a key-id is not a scoped-key vector, so the plain owner's
`:released` member goes missing — so the fixture notices the change in **both**
directions, not only the leaking one. Matches the pre-widening precedent (8 + the
plain control).

**3. rf2-1zc33** — `:scope` back into `sibling-owned-slot`.

→ **3 failures** in this file; epoch suite **19 failures**, at **490 tests /
6628 assertions** — the *same* test and assertion counts as that revision's
green run, differing only in failures, which is what proves the mutation applied
rather than the gate quietly not firing. The failures name
`[:trace-events <i> :tags :scope 1 :username]` on both the assembled record and
a real settled one, plus the per-slot `(redacted-token? (second pscope))`. The
plain/global control stays green.

**Before this widening the same revert left this file green** — the bead records
exactly that ("rf2-1zc33 did NOT red this fixture"). That is the whole point of
the change.

### And the two rf2-isp3i mutation proofs

Disabling each previous-value projection in turn, by passing a
`:rf.disabled/prev-value` key to the shared `elide-whole-output-large-slots`
rule:

- `elide-sub-run-row` (structured row) → **5 failures**
- `elide-large-sub-trace-values` (trace tag) → **5 failures**

Each names its own slot, both trip the two carriers' `:bytes` agreement, and
both trip the cross-cutting "no leaf of the payload's size anywhere" scans on
the per-record **and** the bulk `projected-history` surface — the part that was
silently uncovered while the previous-value slots were nil.

## Scope

One fixture gained the missing operations and shapes. No new scanner, no second
gate, no fixture framework, no generator. No production source changed; the only
file in the diff is the test.
