### PR TITLE
fix(story-mcp): relay the error id the registrar actually throws (rf2-2nbck); rf2-qe9xk moot

### DIFF
--- a/tools/story-mcp/src/re_frame/story_mcp/tools/recorder.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/recorder.cljc
@@ -127,14 +127,16 @@
     (catch #?(:clj Throwable :cljs :default) e
       ;; Same relay as `write/register-or-error`, same projection: the
       ;; registrar's raw Malli `:explain` carries live schema objects the
-      ;; JSON encoder cannot write (rf2-2z9u3).
+      ;; JSON encoder cannot write (rf2-2z9u3), and the thrown
+      ;; `:rf.error/id` is renamed to the wire's bare `:rf.error`
+      ;; (rf2-2nbck — this harvested `:rf.error`, a key no throw sets).
       (result/error-result (str "Write-back failed: " (ex-message e))
                       (merge base
                              {:written-back?  false
                               :new-variant-id target-vid}
                              (result/wire-safe-ex-data
                                (select-keys (ex-data e)
-                                            [:rf.error :explain])))))))
+                                            [:rf.error/id :explain])))))))
 
 (defn tool-record-as-variant
   "Dev (or Write when `:write-back` is true): bridge the recorder's

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/result.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/result.cljc
@@ -57,14 +57,27 @@
   surface's error slot from colliding with `explain-variant`'s unrelated
   plan-`:explain` projection.
 
+  The OTHER slot needs renaming, not projecting. A thrown error's
+  machine-readable discriminator is `:rf.error/id` — the canonical
+  thrown-error shape of `spec/009-Instrumentation.md`, which is what
+  `re-frame.story.registrar` actually throws. But story-mcp's own wire
+  vocabulary for that same fact is the BARE `:rf.error` key, the one
+  `Principles.md` §Error envelopes names as the error payload's
+  discriminator and every tool-EMITTED error already sets. Relaying the
+  thrown spelling verbatim would put a SECOND word for one fact on the
+  wire, so the thrown key is renamed to the wire key here — the same
+  in-vocabulary move `:explain` → `:explain-humanized` makes just above,
+  and the reason both live in one function: this is where ex-data
+  vocabulary becomes wire vocabulary (rf2-2nbck).
+
   Every other `ex-data` slot rides through untouched — `:reason`,
   `:where`, `:recovery`, `:kind`, `:id` are all plain data."
   [d]
-  (if-let [explain (:explain d)]
-    (-> d
-        (dissoc :explain)
-        (assoc :explain-humanized (me/humanize explain)))
-    d))
+  (cond-> d
+    (:explain d)      (-> (dissoc :explain)
+                          (assoc :explain-humanized (me/humanize (:explain d))))
+    (:rf.error/id d)  (-> (dissoc :rf.error/id)
+                          (assoc :rf.error (:rf.error/id d)))))
 
 (defn text-result
   "Build a success result with a single text content item. `structured`

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/write.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/write.cljc
@@ -274,10 +274,13 @@
       ;; humanized projection. Without it a schema-violating body took
       ;; the encoder down and the client got a `-32603` server fault
       ;; naming a malli class instead of this error result (rf2-2z9u3).
+      ;; It also renames the thrown `:rf.error/id` to the wire's bare
+      ;; `:rf.error`; harvesting `:rf.error` here instead was reading a
+      ;; key no throw sets, so the id slot never populated (rf2-2nbck).
       (result/error-result (str "Registration failed: " (ex-message e))
                       (merge {:variant-id vk}
                              (result/wire-safe-ex-data
-                               (select-keys (ex-data e) [:rf.error :explain])))))))
+                               (select-keys (ex-data e) [:rf.error/id :explain])))))))
 
 (defn tool-register-variant
   "Write: programmatically register a variant. Gated behind

--- a/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
@@ -4672,9 +4672,17 @@
     (drive-events-during-recording [[:counter/inc]])
     (with-redefs [story/reg-variant*
                   (fn [_id _body]
+                    ;; The CANONICAL thrown-error shape, which is what
+                    ;; `registrar/validate-shape!` really throws:
+                    ;; `:rf.error/id`, not a bare `:rf.error`. This mock
+                    ;; used to fabricate the bare key — the same key the
+                    ;; relay harvested — so it proved the relay against a
+                    ;; shape no producer emits and the dead arm looked
+                    ;; alive (rf2-2nbck). The wire slot below is still
+                    ;; `:rf.error`: that rename is the relay's job.
                     (throw (ex-info "Registration failed: boom"
-                                    {:rf.error :rf.error/variant-shape
-                                     :explain  {:why :forced-test-failure}})))]
+                                    {:rf.error/id :rf.error/variant-shape
+                                     :explain     {:why :forced-test-failure}})))]
       (let [r (invoke "record-as-variant"
                       {:variant-id     "story.button/primary"
                        :new-variant-id "story.button/recorded"  ; valid grammar

--- a/tools/story-mcp/test/re_frame/story_mcp/wire_encodability_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/wire_encodability_test.clj
@@ -127,6 +127,10 @@
         (is (nil? (:explain (structured frame)))
             "the raw, un-encodable :explain slot must not be relayed"))
 
+      (testing "the machine-readable error id crosses the wire (rf2-2nbck)"
+        (is (= "rf.error/variant-shape" (:rf.error (structured frame)))
+            "the registrar's :rf.error/id populates the wire's :rf.error slot"))
+
       (testing "the variant is not registered"
         (is (nil? (story/variant->edn :story.button/x)))))))
 
@@ -169,7 +173,12 @@
       (is (str/includes? (result-text frame) "unregistered tag(s)"))
       (is (str/includes? (result-text frame) "[:rf.error/unknown-tag]"))
       (is (nil? (:explain-humanized (structured frame)))
-          "no :explain in the ex-data ⇒ no :explain-humanized on the wire"))))
+          "no :explain in the ex-data ⇒ no :explain-humanized on the wire")
+      ;; rf2-2nbck: the discriminator must ALSO ride the structured slot,
+      ;; not only the message. A keyword value JSON-encodes to a plain
+      ;; string, so this is the wire spelling, not the EDN one.
+      (is (= "rf.error/unknown-tag" (:rf.error (structured frame)))
+          "the registrar's :rf.error/id populates the wire's :rf.error slot"))))
 
 ;; ---- record-as-variant: the sibling relay ---------------------------------
 
@@ -194,7 +203,10 @@
         (is (= {:script ["invalid type" "invalid type"]}
                (:explain-humanized (structured frame))))
         (is (false? (:written-back? (structured frame)))
-            "the recorder payload still rides alongside the projection")))))
+            "the recorder payload still rides alongside the projection")
+        ;; rf2-2nbck: the sibling relay carries the same slot.
+        (is (= "rf.error/variant-shape" (:rf.error (structured frame)))
+            "the registrar's :rf.error/id populates the wire's :rf.error slot")))))
 
 ;; ---- wire-pipeline: the generic arm ---------------------------------------
 


### PR DESCRIPTION
Two beads. One was a real defect with a real repro; the other is moot and closes with no code change.

- **`rf2-2nbck`** (P3, bug) — fixed. The structured error-id slot is now populated at the MCP boundary.
- **`rf2-qe9xk`** (P3) — **moot, no change**. Determination and the quoted ledger line are below.

---

## rf2-2nbck — the arm that had never fired

### Found vs changed

**Found (verified, not assumed):**

- **The producers are consistent.** All three registrar throw sites use `:rf.error/id`, never a bare `:rf.error` — `registrar.cljc:324` (`validate-shape!`), `:360` (`validate-tag-membership!`), `:401` (`assert-id!`). So this is *not* the producer-inconsistency shape a sibling bead had; the fix genuinely belongs at the consumer, as the bead argued.
- **No `ex-info` anywhere in `tools/story/src`, `tools/story-mcp/src` or `tools/mcp-base/src` sets a bare `:rf.error`.** The bare-`:rf.error` sites in the tree are all *emitted* error/result maps (`args.cljc`, `docs.cljc`, `wire_pipeline.cljc`, `result.cljc`, `write.cljc`, `decorators.cljc`), never `ex-data`. The `[:rf.error :explain]` `select-keys` arm was therefore provably dead.
- **Bare `:rf.error` is the correct, spec'd wire word.** `tools/story-mcp/spec/Principles.md` §"Error envelopes skip dedup": *"Tool-execution errors (`{:isError true ...}`) carry small bespoke structuredContent payloads — `:rf.error` plus `:tool` / `:exception` / `:data`."* The spec already described the intended state; only the code was wrong. **No spec change is owed.**
- **The bead named two sites; the pattern is at three.** The third is `wire_pipeline.cljc:398`, `invoke-tool`'s generic catch, which relays the *whole* `ex-data` under `:data`. It does not *drop* the id (so it is not the same defect), but it shipped it under the thrown spelling `:rf.error/id` — a **second word for one fact** on the wire, exactly what the bead said to avoid.
- **Why the dead arm looked alive** — the load-bearing finding. `tools_test.clj:4676` `record-as-variant-write-back-failure-surfaces-explain` redefined `story/reg-variant*` to throw a **fabricated** `ex-data` carrying the bare `:rf.error` — the very key the relay read. It asserted the relay against a shape no producer emits, so a green test stood guard over a slot that was never populated in production.

**Changed (4 files):**

| File | Change |
|---|---|
| `tools/story-mcp/src/re_frame/story_mcp/tools/result.cljc` | `wire-safe-ex-data` renames `:rf.error/id` → `:rf.error`. |
| `tools/story-mcp/src/re_frame/story_mcp/tools/write.cljc` | `select-keys` harvests `:rf.error/id`, the key actually thrown. |
| `tools/story-mcp/src/re_frame/story_mcp/tools/recorder.cljc` | Same, on the sibling relay. |
| `tools/story-mcp/test/re_frame/story_mcp/tools_test.clj` | Mock now throws the canonical `:rf.error/id`. |

The rename lives in `wire-safe-ex-data` rather than at each call site because that function is already documented as *"the one projection every handler that relays a caught exception's `ex-data` onto `:structuredContent` runs it through"*, and it already performs exactly one such in-vocabulary rename (`:explain` → `:explain-humanized`). Putting it there fixes all **three** relays and leaves one word on the wire. **No new `:rf.error/*` id was minted** — the values are existing catalogued ids.

### Before / after: the structured slot at the MCP boundary

Driven through the real JSON-RPC path (`server/run-loop!`, raw encoded response read back), not a unit test on the throw site:

**BEFORE**
```
register-variant {"variant-id":"story.button/tagfail","body":"{:tags #{:nope}}"}
  structuredContent: {"variant-id":"story.button/tagfail"}

register-variant {"variant-id":"story.button/x","body":{"compnent":"some/view"}}
  structuredContent: {"variant-id":"story.button/x","explain-humanized":{"compnent":["disallowed key"]}}
```

**AFTER**
```
register-variant {"variant-id":"story.button/tagfail","body":"{:tags #{:nope}}"}
  structuredContent: {"variant-id":"story.button/tagfail","rf.error":"rf.error/unknown-tag"}

register-variant {"variant-id":"story.button/x","body":{"compnent":"some/view"}}
  structuredContent: {"variant-id":"story.button/x","explain-humanized":{"compnent":["disallowed key"]},"rf.error":"rf.error/variant-shape"}
```

The `BEFORE` reproduces the bead's recorded evidence exactly.

### Proven by mutation

Three assertions were added to `wire_encodability_test.clj` **before** the fix and **failed** at the boundary — the mutation was confirmed applied first (`git diff --stat` = 14 insertions, plus grepping the token back out), so a silently-unapplied edit could not masquerade as a passing gate:

```
FAIL in (register-variant-schema-violation-is-a-tool-error-not-a-server-fault) (wire_encodability_test.clj:131)
  actual: (not (= "rf.error/variant-shape" nil))
FAIL in (register-variant-non-explain-failure-is-unchanged) (wire_encodability_test.clj:180)
  actual: (not (= "rf.error/unknown-tag" nil))
FAIL in (record-as-variant-write-back-schema-violation-is-a-tool-error) (wire_encodability_test.clj:208)
  actual: (not (= "rf.error/variant-shape" nil))
Ran 298 tests containing 1565 assertions.
3 failures, 0 errors.   rc=1
```

Reading argument order literal-first: expected `"rf.error/variant-shape"`, actual `nil` — the slot was empty on all three paths.

---

## rf2-qe9xk — MOVE-versus-DELETE determination: **moot, no change**

The bead asks for a fix in `implementation/ui/src/re_frame/ui/tool.cljc`. The ledger's disposition for that exact file is neither MOVE nor DELETE — it is the third disposition, **REPLACE**, and it is already `done`:

> `| `implementation/ui/src/re_frame/ui/tool.cljc` | the dev-only read-only projections a debugging consumer reads — REPLACED by `re-frame.freehand.evidence` … and later by the `re-frame.freehand.tool` reader, which is built from Freehand's own compiler manifest and its own commit records; **the donor projections are a shape reference, not code to port**. … The donor file stays as the re-frame.ui substrate's own | REPLACE | F4 | done |`

And the legend's definition of that disposition:

> `| **REPLACE** | the job is real but Freehand does it differently on purpose; **the donor realization is not carried across** |`

Applying the `rf2-yumaq` test: MOVE would mean the code is *absorbed under Freehand ownership*, and the defect would cross. **REPLACE means the donor realization explicitly does not cross.** So the defective `project-event-site` has no Freehand future — it dies with the donor at F6e.

Three further checks, because the bead's own P3 justification was live-consumer reachability:

1. **Freehand's replacement is already correct.** `re-frame.freehand.tool/event-site` (`tool.cljc:324`) already reads `:handler (if (and (some? event) (literal-form? handler)) handler :opaque)` — the honesty split `rf2-z0blg` landed. There is nothing to mirror; the destination already has it.
2. **The bead's headline exposure is stale.** It states the MCP `read-view-event-sites` tool "reads exactly this function". It no longer does: `tools/re-frame2-pair-mcp/.../view_tool.cljs` and `descriptors_data.cljs:1338` both read **`re-frame.freehand.tool`**. `spec/Conventions.md:107` records the migration — *"Pair migrated to Freehand's own reader door"*. That consumer row (`view_tool.cljs`, MOVE / F6) is already `done`. **An agent pointed at a live app today receives Freehand's honest answer, not the donor's.** The reason this was filed P3 rather than left as a note no longer holds.
3. **The remaining donor readers are not product surface.** Xray's `mounted_views.cljs` reads `re-frame.freehand.tool`. The only live reader of the donor's `view-event-sites` is `tools/story/test/re_frame/story/view_tool.cljc` — a **test-tree** consumer, whose own ledger row is `MOVE / F6`, and whose move lands on Freehand's already-correct reader.

So the defect is confined to a vestigial donor file, is not reachable from the MCP inspector, and its replacement is already honest. Per the mayor's recorded decision procedure step 1, this closes as moot with no code change owed. **Nothing under `implementation/ui/` or the ledger was edited** — both were read only.

---

## Quality gates

All run to completion in the foreground; `rc` captured immediately into a worktree-local log and cross-checked against each log's own verdict line.

| Gate | Result | rc |
|---|---|---|
| `tools/story-mcp` `clojure -M:test` (baseline, pre-change) | 298 tests / **1562** assertions, 0 failures, 0 errors | **0** |
| `tools/story-mcp` `clojure -M:test` (assertions added, pre-fix) | 298 tests / 1565 assertions, **3 failures**, 0 errors — *the intended repro* | **1** |
| `tools/story-mcp` `clojure -M:test` (final) | 298 tests / **1565** assertions, 0 failures, 0 errors | **0** |
| `tools/mcp-base` `clojure -M:test` | 272 tests / **924** assertions, 0 failures, 0 errors | **0** |
| `tools/story` `clojure -M:test` | 1847 tests / **6824** assertions, 0 failures, 0 errors | **0** |
| `tools/story-mcp` `clojure -M:gen --check` | `OK: tool-descriptors.edn in sync (20 tools).` | **0** |
| `scripts/check_keyword_catalogue_drift.py` | clean | **0** |
| `scripts/check_thrown_error_messages.py` | clean | **0** |

Assertion counts re-derived, not trusted: story-mcp 1562 → 1565 is exactly the three added boundary assertions; mcp-base 924 and story 6824 match the expected baselines unchanged.

The two fenced checkers (`check_keyword_catalogue_drift.py`, `check_thrown_error_messages.py`) were **run, not edited**. No new `:rf.error/*` id was introduced, so Check A needs no new `spec/009` row.

### Fence compliance

Read-only throughout, edited none: `spec/009-Instrumentation.md`, both checker scripts, `spec/Conventions.md`, `spec/006`, `implementation/epoch/**`, `implementation/resources/**`, `implementation/routing/**`, `implementation/freehand/**`, `docs/core/freehand/**`, `spec/conformance/freehand/donor-inventory.md`, `implementation/ui/**`. The diff is five files, all under `tools/story-mcp/`.
