### PR TITLE
fix(resources): classify the resolved :scope riding the fx-args carriers (rf2-425mm)

### DIFF
--- a/implementation/epoch/test/re_frame/epoch_egress_resource_trace_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_egress_resource_trace_test.clj
@@ -33,7 +33,9 @@
   suite which runs without resources)."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.elision :as elision]
             [re-frame.epoch :as epoch]
+            [re-frame.frame :as frame]
             ;; rf2-hbmeb §(8) — `fx/reg-fx`, the plain fn, NOT the `rf/reg-fx`
             ;; macro: see `drive-real-cascade!` for why the difference decides
             ;; whether the frame's default image can still be reprojected.
@@ -1276,4 +1278,319 @@
               session-scope session-scope]
              scopes)
           "every row's raw :scope rides with :include-sensitive?"))))
+
+;; ===========================================================================
+;; (rf2-425mm) the SAME free `:scope`, ONE CARRIER FURTHER OUT — inside the
+;; transport continuation payload copied onto `:rf.fx/args` / `:rf.event/fx`.
+;; ===========================================================================
+;;
+;; §(rf2-1zc33) above settled the free `:scope` tag on the rows the resource
+;; family OWNS. This is not its residual — a one-line change to
+;; `sibling-owned-slot` could not have reached here, because the epoch tool-pair
+;; routes that projector by OPERATION NAMESPACE (`resource-family-op?`) and the
+;; rows below are `rf.fx`. It is the completeness remainder of rf2-1kiuj, the
+;; OTHER projector: `project-fx-args-egress` → `project-embedded-keys`, reached
+;; by SLOT on every row.
+;;
+;; An `ensure` lowers into `[:rf.http/managed <args>]`, and
+;; `transport.http/build-managed-args` puts the runtime's stale-suppression
+;; verification payload into the args' `:on-success` / `:on-failure`:
+;;
+;;   {:work/id      [:rf.work/resource <scoped-key> <gen>]
+;;    :resource/key <scoped-key>
+;;    :scope        <resolved scope>          ← the leak
+;;    :generation   <n>
+;;    :rf.frame/id  <frame>}
+;;
+;; `re-frame.fx/handle-one-fx` stamps those args under `:rf.fx/args` and `do-fx`
+;; stamps the whole effect vector under `:rf.event/fx`, so the payload egresses
+;; twice. `project-embedded-keys` walks both carriers, and — deliberately, and
+;; rightly (rf2-1kiuj) — DESCENDS a map rather than tokenizing it, because an
+;; fx-args payload belongs to the fx family and tokenizing it wholesale would
+;; redact a plain owner's request map. It recognised the `:resource/key` and the
+;; key embedded in the `:work/id` and redacted both. The `:scope` beside them is
+;; a `[tier {identity}]` TUPLE, not a scoped key, so the walk descended it, found
+;; an ordinary map, and let the resolver's IDENTITY MAP through in the clear —
+;; one slot from the `:resource/key` that had just redacted the identical bytes,
+;; and one carrier from the `:effects[*].args` twin that read `:rf/redacted`.
+;;
+;; No existing fixture could see it: every resource in every epoch-egress fixture
+;; scoped `:rf.scope/global`, a SCALAR with nothing in it to leak. Only a
+;; `{:from-db …}` resolver puts an identity map on the carrier, and the MCP-egress
+;; conformance cascade reaches its identity-bearing scope through
+;; `invalidate-tags`, which stamps a free `:scope` on a FAMILY row and never
+;; lowers into fx.
+;;
+;; The repair gives a `:scope`-keyed value inside the carrier the SAME family rule
+;; §(rf2-1zc33) gave it on the family's own rows (`project-unknown-slot-value`),
+;; so the two carriers agree by construction. Per shape, unchanged from there:
+;; a `:rf.scope/global` scalar rides verbatim, a `[tier {identity}]` tuple keeps
+;; its tier and tokenizes its identity map.
+
+(def ^:private profile-params {:slug "me"})
+
+(defn- secret-leak-paths
+  "Every path in `x` whose leaf string carries the secret, each with the
+  offending value. The path-reporting counterpart of `contains-secret?`: a
+  failure NAMES the slot that leaked instead of printing `(not (not true))`,
+  which is the whole diagnostic value when the leak is four levels down inside
+  an fx carrier."
+  [x]
+  (let [found (atom [])
+        walk  (fn walk [path v]
+                (cond
+                  (string? v) (when (.contains ^String v "topsecret")
+                                (swap! found conj [path v]))
+                  (map? v)    (doseq [[k vv] v]
+                                (walk (conj path k) k)
+                                (walk (conj path k) vv))
+                  (coll? v)   (doseq [[i vv] (map-indexed vector v)]
+                                (walk (conj path i) vv))))]
+    (walk [] x)
+    @found))
+
+(defn- carrier-scopes
+  "Every value sitting under a `:scope` key anywhere inside the `:rf.fx/args` /
+  `:rf.event/fx` carriers of `record`'s trace rows — i.e. the exact slot the
+  four leaking paths name, found by walking rather than by index so the
+  assertion does not encode the cascade's fx ORDER."
+  [record]
+  (let [found (atom [])
+        walk  (fn walk [v]
+                (cond
+                  (map? v)  (doseq [[k vv] v]
+                              (when (= :scope k) (swap! found conj vv))
+                              (walk vv))
+                  (coll? v) (run! walk v)))]
+    (doseq [tags (map :tags (:trace-events record))
+            slot [:rf.fx/args :rf.event/fx]
+            :when (contains? tags slot)]
+      (walk (get tags slot)))
+    @found))
+
+(defn- continuation-payload
+  "The `:on-success` verification payload of the `:rf.http/managed` args as they
+  egress under `:rf.fx/args` — `{:work/id … :resource/key … :scope … :generation
+  … :rf.frame/id …}`, the map the four leaking paths run through."
+  [record]
+  (->> (:trace-events record)
+       (map :tags)
+       (keep :rf.fx/args)
+       (filter #(and (map? %) (contains? % :on-success)))
+       first
+       :on-success
+       second))
+
+(defn- tokenized-scope?
+  "Whether `s` is a resolved `[tier {identity}]` scope that egressed correctly —
+  the tier keyword verbatim (attribution survives) over a tokenized identity."
+  [s]
+  (and (vector? s) (= 2 (count s))
+       (= :rf.scope/session (first s))
+       (redacted-component? (second s))))
+
+(defn- drive-session-scoped-ensure!
+  "Drive ONE real `[:rf.resource/ensure …]` of the `:sensitive?`
+  `{:from-db :rt/session}` resource and return the epoch records it settled.
+
+  The session identity is written straight into the frame's app-db partition
+  (not dispatched) so it settles no record of its own, and CLASSIFIED
+  `:sensitive` there so the app-db axis can never be what the scans below
+  catch — any surviving copy of the secret came off a trace carrier, which is
+  the axis this section owns. `fx/reg-fx` (the plain fn, not the `rf/reg-fx`
+  macro) overrides managed HTTP with a no-op for the reason `drive-real-cascade!`
+  documents."
+  [resource-id]
+  (rf/configure! {:epoch-history {:trace-events-keep 50}})
+  (fx/reg-fx :rf.http/managed (fn [_ctx _args] nil))
+  (frame/swap-runtime-db! :test/rt
+    (fn [rt] (elision/apply-classification-effects
+               rt {:sensitive [[:auth :user :username]]})))
+  (frame/swap-frame-db! :test/rt assoc-in [:auth :user :username] secret)
+  (rf/dispatch-sync [:rf.resource/ensure
+                     {:resource resource-id
+                      :params   profile-params
+                      :owner    real-owner}]
+                    {:frame :test/rt})
+  (rf/epoch-history :test/rt))
+
+;; ---------------------------------------------------------------------------
+;; (1) THE ACCEPTANCE ARM — a REAL ensure, the whole projected record
+;; ---------------------------------------------------------------------------
+
+(deftest real-session-scoped-ensure-leaks-no-identity-into-fx-carriers
+  (testing "rf2-425mm — `projected-record` over the record a REAL
+            `[:rf.resource/ensure …]` settles for a `:sensitive?` resource with
+            a `{:from-db …}` scope must carry the resolved identity at ZERO
+            paths. Before the repair it carried it at four: the `:scope` inside
+            the `:on-success` and `:on-failure` continuation payloads, once under
+            `:rf.fx/args` and again under `:rf.event/fx`."
+    (let [records   (drive-session-scoped-ensure! :derived/profile)
+          raw       (last records)
+          projected (epoch/projected-record raw)]
+
+      (testing "FIXTURE — the producer really put an identity-bearing scope on
+                the fx carriers, so the assertions below are not passing over an
+                empty set"
+        (is (seq (carrier-scopes raw))
+            "the ensure's fx carriers carry a `:scope` at all")
+        (is (every? #(= session-scope %) (carrier-scopes raw))
+            "and every one of them is the RAW resolved [tier {identity}] tuple
+             the resolver derived from app-db")
+        (is (seq (secret-leak-paths raw))
+            "the unprojected record leaks — the projector's input is the
+             runtime's own output, not an invented tag map"))
+
+      (testing "ACCEPTANCE — nothing raw survives anywhere in the projected
+                record"
+        (is (= [] (secret-leak-paths projected))
+            "every leaking path is named here; before the repair this printed
+             the four [:trace-events n :tags :rf.fx/args :on-success 1 :scope 1
+             :username] shapes"))
+
+      (testing "and each carrier's scope is PROJECTED, not merely absent"
+        (is (= (count (carrier-scopes raw)) (count (carrier-scopes projected)))
+            "projection neither drops nor invents a carrier scope")
+        (is (every? tokenized-scope? (carrier-scopes projected))
+            "each keeps its TIER keyword and tokenizes its identity map"))
+
+      (testing "the sibling `:resource/key` in the SAME payload agrees — the two
+                carriers of one scope can no longer redact and leak it side by
+                side"
+        (let [cont (continuation-payload projected)]
+          (is (some? cont) "the continuation payload is on the carrier")
+          (is (= :derived/profile (second (:resource/key cont)))
+              "the resource-id survives for attribution")
+          (is (redacted-component? (first (:resource/key cont)))
+              "carrier 1 — the key's scope component is tokenized")
+          (is (tokenized-scope? (:scope cont))
+              "carrier 2 — the free :scope beside it is tokenized too")
+          (is (= (:generation (continuation-payload raw)) (:generation cont))
+              "the generation rides verbatim")
+          (is (= :test/rt (:rf.frame/id cont)) "the frame stamp rides verbatim"))))))
+
+;; ---------------------------------------------------------------------------
+;; (2) the same shape assembled — deterministic, and it names the four paths
+;; ---------------------------------------------------------------------------
+
+(defn- managed-args
+  "The `:rf.http/managed` args `transport.http/build-managed-args` produces for
+  one ensure: the app `:request` map plus the runtime-owned `:request-id` and
+  the `:on-success` / `:on-failure` verification payloads."
+  [scoped-key scope]
+  (let [work-id [:rf.work/resource scoped-key 1]
+        payload {:work/id      work-id
+                 :resource/key scoped-key
+                 :scope        scope
+                 :generation   1
+                 :rf.frame/id  :test/rt}]
+    {:request    {:method :get :url "/z"}
+     :request-id [:rf.req :test/rt work-id]
+     :on-success [:rf.resource.internal/succeeded payload]
+     :on-failure [:rf.resource.internal/failed payload]}))
+
+(defn- fx-carrier-record
+  "A record carrying the ensure's TWO fx carriers of one payload — the
+  `:rf.fx/handled` row's `:rf.fx/args` and the `:rf.fx/do-fx` row's
+  `:rf.event/fx` (the whole effect vector, the managed fx third)."
+  [args]
+  (record-with
+    [(event :rf.fx/handled
+            {:rf.frame/id :test/rt :frame :test/rt
+             :rf.fx/id :rf.http/managed :rf.fx/args args})
+     (event :rf.fx/do-fx
+            {:rf.frame/id :test/rt :frame :test/rt
+             :rf.event/fx [[:rf.resource/commit-generation {:value 1}]
+                           [:rf.resource/record-work-handle {:frame-id :test/rt}]
+                           [:rf.http/managed args]]})]))
+
+(deftest fx-carrier-scope-tokenizes-on-both-carriers
+  (testing "rf2-425mm — the projector, over the exact payload the transport
+            builds. Four `:scope` occurrences across the two carriers, every one
+            of them tokenized; and the fx family's OWN slots on the same rows
+            ride untouched, because the resource family speaks only for what it
+            planted there."
+    (let [k1        (sk session-scope :derived/profile profile-params)
+          args      (managed-args k1 session-scope)
+          projected (epoch/projected-record (fx-carrier-record args))
+          scopes    (carrier-scopes projected)]
+      (is (= 4 (count scopes))
+          "two payloads per carrier, two carriers — the four paths the bead named")
+      (is (every? tokenized-scope? scopes)
+          "each keeps its tier keyword and tokenizes its identity map")
+      (is (= [] (secret-leak-paths projected))
+          "and nothing raw survives anywhere in the record")
+      (testing "the fx family's own args ride UNTOUCHED"
+        (let [tags (:tags (first (:trace-events projected)))]
+          (is (= {:method :get :url "/z"} (:request (:rf.fx/args tags)))
+              "the app's request map is not redacted")
+          (is (= :rf.http/managed (:rf.fx/id tags))
+              "the fx id rides verbatim")
+          (is (true? (:sensitive? tags))
+              "but the row IS stamped :sensitive?"))))))
+
+;; ---------------------------------------------------------------------------
+;; (3) THE TWO-SIDED CONTROL — over-redaction must fail as loudly as leaking
+;; ---------------------------------------------------------------------------
+
+(deftest fx-carrier-keeps-plain-request-map-and-global-scope-verbatim
+  (testing "rf2-425mm guard — a PLAIN owner's `:rf.http/managed` args, whose
+            scope is the `:rf.scope/global` SCALAR, must ride BYTE-IDENTICAL
+            through both carriers and must not stamp the row sensitive. This is
+            the side that proves the repair did not turn `project-embedded-keys`
+            into the wholesale map tokenizer rf2-1kiuj rejected: the app's own
+            request map, its params and its scope all survive."
+    (let [k1        (sk :rf.scope/global :plain/article {:slug plain-slug})
+          args      (managed-args k1 :rf.scope/global)
+          record    (fx-carrier-record args)
+          projected (epoch/projected-record record)
+          [handled do-fx] (:trace-events projected)]
+      (is (= args (:rf.fx/args (:tags handled)))
+          "the whole args map rides verbatim — request, request-id and both
+           continuation payloads, scoped keys and scope included")
+      (is (= (:rf.event/fx (:tags (second (:trace-events record))))
+             (:rf.event/fx (:tags do-fx)))
+          "and so does the whole effect vector on the other carrier")
+      (is (= [:rf.scope/global :rf.scope/global :rf.scope/global :rf.scope/global]
+             (carrier-scopes projected))
+          "a global scope is a scalar — no over-redaction on any carrier")
+      (is (not (:sensitive? (:tags handled)))
+          "a plain-owner fx row is NOT stamped sensitive")
+      (is (not (:sensitive? (:tags do-fx)))
+          "on either carrier"))))
+
+(deftest fx-carrier-scope-tokens-stay-distinct-per-scope
+  (testing "rf2-425mm — distinct scopes must keep DISTINCT digests on the fx
+            carriers too, so an Xray effect graph can still group and join a
+            record's requests by session after the identity map tokenizes"
+    (let [proj  (fn [scope]
+                  (let [k (sk scope :derived/profile profile-params)]
+                    (-> (fx-carrier-record (managed-args k scope))
+                        epoch/projected-record
+                        carrier-scopes
+                        first)))
+          s1    (proj session-scope)
+          s2    (proj other-session-scope)]
+      (is (tokenized-scope? s1))
+      (is (tokenized-scope? s2))
+      (is (not= (second s1) (second s2))
+          "two distinct sessions keep two distinct digests"))))
+
+;; ---------------------------------------------------------------------------
+;; (4) the trusted-local boundary — the redaction is the off-box DEFAULT
+;; ---------------------------------------------------------------------------
+
+(deftest trusted-local-include-sensitive-keeps-raw-fx-carrier-scope
+  (testing "rf2-425mm — the trusted-local `:include-sensitive?` opt-in keeps the
+            raw carrier scope (the local-raw boundary — the tokenization is the
+            off-box default, not a strip)"
+    (let [k1        (sk session-scope :derived/profile profile-params)
+          args      (managed-args k1 session-scope)
+          projected (epoch/projected-record (fx-carrier-record args)
+                                            {:include-sensitive? true})]
+      (is (= [session-scope session-scope session-scope session-scope]
+             (carrier-scopes projected))
+          "every carrier's raw :scope rides with :include-sensitive?")
+      (is (= args (:rf.fx/args (:tags (first (:trace-events projected)))))
+          "and so does the rest of the payload it sits in"))))
 

--- a/implementation/resources/src/re_frame/resources/trace_egress.cljc
+++ b/implementation/resources/src/re_frame/resources/trace_egress.cljc
@@ -72,7 +72,7 @@
   opt-in lifts it at the epoch consumer (the `local-raw` boundary — the same
   switch the app-db / HTTP-body / scope-resolved redactions honour).
 
-  ## The family's keys also ride FOREIGN rows (rf2-1kiuj)
+  ## The family's keys also ride FOREIGN rows (rf2-1kiuj, rf2-425mm)
 
   Everything above is routed by the epoch tool-pair on the row's OPERATION
   namespace. But an `ensure` lowers into EFFECTS, and those effects address the
@@ -81,7 +81,10 @@
   does not own — where the namespace routing never looks. `project-fx-args-egress`
   (bottom of this ns) closes that: the SAME `project-trace-scoped-key` owner
   classification, reached by SLOT instead of by op, and touching nothing on the
-  row but the keys."
+  row but the keys — and, since rf2-425mm, the resolved `:scope` the runtime
+  writes into that same continuation payload, projected by the SAME rule the
+  family's own rows give it (`project-unknown-slot-value`), so the two carriers
+  of one scope agree the way the two carriers of one key already did."
   (:require [re-frame.resources.registry :as registry]
             [re-frame.resources.ssr :as ssr]))
 
@@ -383,15 +386,16 @@
   #{:rf.fx/args :rf.event/fx})
 
 (defn- project-embedded-keys
-  "Project every resource SCOPED KEY embedded anywhere in `v`, leaving every
-  non-key value UNTOUCHED. Returns `[projected sensitive?]`.
+  "Project every resource SCOPED KEY — and every resolved `:scope` — embedded
+  anywhere in `v`, leaving every other value UNTOUCHED. Returns
+  `[projected sensitive?]`.
 
   The FOREIGN-CARRIER counterpart of `project-unknown-slot-value`, and it differs
   from it in exactly one arm, deliberately: a MAP is DESCENDED INTO rather than
   tokenized. The fail-closed map arm is right for an unnamed slot on a row the
   resource family OWNS (the value there is presumed owner payload — rf2-7qbxbm);
   it is wrong here, because an fx-args payload is the FX family's, and the only
-  thing in it the resource family may speak for is its own keys. Tokenizing the
+  thing in it the resource family may speak for is its own data. Tokenizing the
   whole payload would redact a PLAIN owner's request map as readily as a sensitive
   one's — over-redaction, which for the resource tools is as much a defect as the
   leak.
@@ -402,7 +406,41 @@
   carriers of one key cannot drift; any other collection is walked through,
   preserving its KIND (scoped-key identity is kind-sensitive — rf2-wgutc2) and
   walking a map's KEYS as well as its values (a key can be map-keyed by scoped
-  key); every other scalar rides verbatim. Pure."
+  key); every other scalar rides verbatim.
+
+  ## …AND the resolved `:scope` beside them (rf2-425mm)
+
+  A scoped key is not the only family datum the family PUTS in a foreign carrier.
+  The continuation payload every `ensure` / `refetch` / `load-more` / mutation
+  `execute` builds for its transport
+  (`transport.http/build-managed-args`) is the runtime's stale-suppression
+  verification identity — `{:work/id … :resource/key <scoped-key> :scope <resolved
+  scope> :generation … :rf.frame/id …}` — and it rides `:on-success` /
+  `:on-failure` INSIDE the fx args. The `:resource/key` there projects (it is
+  scoped-key-shaped) and so does the key embedded in the `:work/id`; the free
+  `:scope` beside them is a `[tier {identity}]` TUPLE, not a scoped key, so the
+  walk descended it, found a plain map of app values, and let the resolver's
+  IDENTITY MAP through in the clear — one slot from the `:resource/key` that had
+  just redacted the very same bytes. The rf2-irwsq shape again, now inside a
+  single map.
+
+  A value under a `:scope` key is therefore projected by the FAMILY rule
+  (`project-unknown-slot-value`) rather than by the carrier walk, which is what
+  makes the two carriers of one scope agree by construction: `:rf.scope/global`
+  is a SCALAR and rides verbatim, a `[tier {identity}]` tuple keeps its TIER
+  keyword (a tool still reads \"session scope\") while the identity map
+  tokenizes to a content-addressed `{:rf/redacted <digest>}` — distinct scopes
+  keeping distinct digests, so per-scope joins survive — and an unresolved
+  `{:from-db …}` reference tokenizes whole. Exactly what rf2-1zc33 settled for
+  the same slot on the family's OWN rows; this is that ruling reaching the
+  carrier the family projector never runs on.
+
+  `:scope` is the ONE key named here and this is not the beginning of a roster:
+  the arm exists because the resource runtime writes that key into a foreign
+  payload itself, so the family owns the value by construction rather than by a
+  guess about shape (a resolved scope is arbitrary EDN — there is no shape to
+  read). Everything else in the carrier is still the fx family's and still rides
+  through untouched. Pure."
   [v frame-id]
   (cond
     (redacted-token? v)   [v true]
@@ -410,12 +448,20 @@
 
     (coll? v)
     (let [sens?* (volatile! false)
+          note!  (fn [s pv] (when s (vreset! sens?* true)) pv)
           proj   (fn [x]
                    (let [[pv s] (project-embedded-keys x frame-id)]
-                     (when s (vreset! sens?* true))
-                     pv))]
+                     (note! s pv)))
+          ;; the family's own resolved scope, planted in a foreign payload by
+          ;; the runtime — projected by the FAMILY rule so the carrier cannot
+          ;; drift from the row (rf2-425mm). Every other entry takes the walk.
+          entry  (fn [k x]
+                   (if (= :scope k)
+                     (let [[pv s] (project-unknown-slot-value x frame-id)]
+                       (note! s pv))
+                     (proj x)))]
       [(cond
-         (map? v)    (reduce-kv (fn [m k x] (assoc m (proj k) (proj x))) {} v)
+         (map? v)    (reduce-kv (fn [m k x] (assoc m (proj k) (entry k x))) {} v)
          (set? v)    (into #{} (map proj) v)
          (vector? v) (mapv proj v)
          (seq? v)    (apply list (map proj v))
@@ -641,8 +687,12 @@
   Given a row's `tags` + the `frame-id`, walks `:rf.fx/args` / `:rf.event/fx` by
   SHAPE (`project-embedded-keys`) and stamps `:sensitive? true` when a key
   redacted. Everything else on the row rides UNTOUCHED, whatever its shape: the
-  row belongs to the fx family, and the resource family speaks only for the keys
-  inside it. A tags map carrying NEITHER slot rides through reference-preserved —
+  row belongs to the fx family, and the resource family speaks only for the data
+  it planted there — its scoped keys, and (rf2-425mm) the resolved `:scope` the
+  transport continuation payload carries beside them, which is a
+  `[tier {identity}]` TUPLE rather than a scoped key and so was descended into
+  and let through in the clear one slot from the `:resource/key` that had just
+  redacted the same bytes. A tags map carrying NEITHER slot rides through reference-preserved —
   which is what lets the epoch consumer apply this to every row and keep no row
   predicate of its own, so a family key riding a carrier on some future op is
   covered without anyone widening a roster.


### PR DESCRIPTION
Closes rf2-425mm.

A `:sensitive?` resource whose `:scope` is a `{:from-db <resolver-id>}` named-resolver
reference egressed the resolver's **resolved identity map in the clear** at four paths of
the record a single real `[:rf.resource/ensure …]` settles.

## The leak

An `ensure` lowers into `[:rf.http/managed <args>]`, and
`transport.http/build-managed-args` puts the runtime's stale-suppression verification
payload into the args' `:on-success` / `:on-failure`:

```clojure
{:work/id      [:rf.work/resource <scoped-key> <gen>]
 :resource/key <scoped-key>
 :scope        <resolved scope>          ; ← the leak
 :generation   <n>
 :rf.frame/id  <frame>}
```

`re-frame.fx/handle-one-fx` stamps those args under `:rf.fx/args` and `do-fx` stamps the
whole effect vector under `:rf.event/fx`, so the payload egresses twice.
`project-fx-args-egress` → `project-embedded-keys` walks both carriers and **descends** a
map rather than tokenizing it — deliberately, and rightly (rf2-1kiuj): an fx-args payload
belongs to the fx family, and tokenizing it wholesale would redact a *plain* owner's
request map. So it recognised the `:resource/key` and the key embedded in the `:work/id`
and redacted both, and let the `:scope` sitting one slot away through untouched: a
`[tier {identity}]` tuple is not scoped-key-shaped, so the walk descended it, found an
ordinary map of app values, and passed it verbatim. The rf2-irwsq shape again — one value
redacted and leaked side by side, this time inside a single map.

## Residual of rf2-1zc33, or a distinct mechanism?

**Distinct mechanism, and rf2-1zc33's repair could not have reached it.** Same *value*
(the free `:scope` slot carrying a resolved identity), different *carrier*, different
*function*, different *routing*:

- rf2-1zc33 changed `sibling-owned-slot`, consumed by `project-tags*` — the projector the
  epoch tool-pair routes **by operation namespace** (`resource-family-op?`). The rows here
  are `rf.fx`, so that projector never runs on them, whatever `sibling-owned-slot` says.
- The leak lives in `project-embedded-keys`, the **slot**-reached carrier walk rf2-1kiuj
  added. It is that bead's bounded completeness remainder: rf2-1kiuj taught the carriers
  about scoped keys and about nothing else, and the runtime plants a second family datum
  in the same payload.

What rf2-1zc33 *did* supply is the rule. A `:scope`-keyed value inside the carrier now
takes the **same** family rule (`project-unknown-slot-value`) that ruling gave the same
slot on the family's own rows, so the two carriers of one scope agree by construction the
way the two carriers of one key already did. Per shape, unchanged from there:
`:rf.scope/global` is a scalar and rides verbatim; a `[tier {identity}]` tuple keeps its
tier keyword and tokenizes its identity map; an unresolved `{:from-db …}` reference
tokenizes whole.

### Two corrections to the bead's own notes

1. The bead offered two candidate repairs: a `:scope`-aware arm in the carrier walk, **or**
   "reaching the scope through the ROW's already-resolved owner classification the way the
   `cursor-slot` rule does". The second must **not** be taken. `cursor-slot` is
   owner-*conditional* (tokenize iff the row's owner redacts), but rf2-1zc33 made the free
   `:scope` tokenize **unconditionally** on the family's own rows — that is the explicit
   ruling of `off-box-plain-owner-free-scope-map-fails-closed-key-rides-verbatim`. Routing
   the carrier scope through owner classification would make the two carriers *disagree*
   for a plain owner (tokenized on the family row, verbatim on the fx row), reintroducing
   the rf2-irwsq shape in mirror image. The whole point of the repair is that they agree.
2. The dispatch brief asked that "a plain owner's scope must still ride verbatim". Read as
   the bead's own acceptance criterion states it — *a plain owner **request map** and
   `:rf.scope/global`* — that holds and is tested. Read as "a plain owner's
   identity-bearing session scope", it would be wrong: that map tokenizes, exactly as it
   already does on the family's rows. Consistency with the family row is the invariant;
   over-redaction is measured against the request map and the global scalar, both of which
   ride byte-identical.

Also worth stating, because it decided the shape of the arm: the arm keys on `:scope`
alone, **not** on the presence of a sibling `:resource/key`. A mutation `execute`'s
continuation payload (`{:instance-id … :mutation-id … :work/id … :scope <cscope>
:generation …}`, `mutation_events.cljc`) carries a free `:scope` with no scoped key beside
it, and rides the same two carriers. Gating on the sibling key would have covered the read
path and left the mutation path leaking. `:scope` is the one key named and this is not the
start of a roster — the arm exists because the resource runtime writes that key into a
foreign payload itself, so the family owns the value by construction rather than by a
guess about shape (a resolved scope is arbitrary EDN; there is no shape to read).

## The negative control

`implementation/epoch/test/re_frame/epoch_egress_resource_trace_test.clj` §(rf2-425mm),
five deftests / 54 assertions. The acceptance arm drives a **real**
`[:rf.resource/ensure …]` of the `:sensitive?` `{:from-db :rt/session}` resource with the
session identity seeded — and classified `:sensitive` — in the frame's app-db, so the
app-db axis can never be what the scan catches, then asserts `secret-leak-paths` over the
whole `epoch/projected-record` is `[]`.

Reverting the repair in place (`(entry k x)` → `(proj x)` in the map arm, one token) makes
the acceptance arm name the four leaking paths, and it names **the bead's four, byte for
byte, at the bead's own indices**:

```
[:trace-events 10 :tags :rf.fx/args   :on-success 1 :scope 1 :username]
[:trace-events 10 :tags :rf.fx/args   :on-failure 1 :scope 1 :username]
[:trace-events 11 :tags :rf.event/fx 2 1 :on-success 1 :scope 1 :username]
[:trace-events 11 :tags :rf.event/fx 2 1 :on-failure 1 :scope 1 :username]
```

**RED and GREEN have identical test and assertion counts — 495 / 6665 — differing only in
failures.** That identity is the proof the mutation applied rather than the gate quietly
not firing, and the mutation was confirmed present in the file before either verdict was
read.

**The two-sided control is green in BOTH directions.** Two deftests never move:

- `fx-carrier-keeps-plain-request-map-and-global-scope-verbatim` — a plain owner's whole
  `:rf.http/managed` args map (request, `:request-id`, both continuation payloads, scoped
  keys and `:rf.scope/global` scope) rides **byte-identical** through both carriers, and
  neither row is stamped `:sensitive?`. This is what proves the repair did not turn
  `project-embedded-keys` into the wholesale map tokenizer rf2-1kiuj rejected.
- `trusted-local-include-sensitive-keeps-raw-fx-carrier-scope` — the `local-raw` boundary:
  the tokenization is the off-box default, not a strip.

Attribution is preserved and measured: the tier keyword rides while the identity
tokenizes; `fx-carrier-scope-tokens-stay-distinct-per-scope` shows two distinct sessions
keep two distinct digests, so per-scope joins survive; and the acceptance arm checks the
`:generation` and `:rf.frame/id` beside the redacted scope ride verbatim.

## Can the MCP-egress conformance fixture see these rows?

**No, and deliberately — the fixture says so itself.** `drive-resource-family!`'s docstring
already documents that it does not drive an `ensure` of a session-scoped owner, names
rf2-425mm as the reason, and ends "When rf2-425mm lands, add the `ensure` here: it is the
same shape one carrier further out." Its identity-bearing scope enters only through
`invalidate-tags`, which stamps a free `:scope` on a **family** row and never lowers into
fx; every resource it registers is `:rf.scope/global`, a scalar with nothing in it to leak.
So these four paths are invisible to that gate today. Widening it is not this bead's (the
file is a live sibling's, rf2-0t7o8) — but the follow-on is now unblocked and the fixture
carries its own instruction.

## Quality gates

Run from this worktree, `rc` captured immediately and cross-checked against each log's own
verdict line.

| Gate | Result | rc |
| --- | --- | --- |
| `implementation/epoch` — `clojure -M:test` (**green, with fix**) | 495 tests / 6665 assertions, 0 failures, 0 errors | 0 |
| `implementation/epoch` — `clojure -M:test` (**red, fix reverted in place**) | 495 tests / 6665 assertions, **7 failures**, 0 errors | 1 |
| `implementation/resources` — `clojure -M:test` | 733 tests / 6799 assertions, 0 failures, 0 errors | 0 |
| `implementation/core` — `clojure -M:test` | 2115 tests / 10462 assertions, 0 failures, 0 errors | 0 |
| `scripts/test-fast-pr.sh` | `PASS fast PR spine` — static/drift checks, JVM core+epoch+resources, JS harness helpers, CLJS node integration, per-ns isolation | 0 |

The spine's own JVM tier independently reproduced the three suites above (core 2115/10462,
epoch 495/6665, resources 733/6799), and its `PASS` line and its `rc` agree — cross-checked
against each other rather than trusting the wrapper. It soft-skipped `mkdocs --strict`
(mkdocs not on PATH) and, by design, the untouched artefact suites and the CI-only browser
/ bundle-isolation / perf / Xray-matrix / mcp-conformance lanes.

Baselines re-derived rather than trusted: epoch 490 / 6611 → 495 / 6665 is exactly the five
new deftests and 54 new assertions; resources 733 / 6799 and core 2115 / 10462 land on the
recorded figures unchanged.

The change is `.cljc` with no platform-conditional code (`reduce-kv`, keyword `=`), so the
CLJS lane exercises the identical branch; the node tier runs in the spine above and CI owns
the browser lanes.
