### PR TITLE
gate,spec,story-mcp: three audit reopens — bijection reader forms, Privacy coord qualification, wire-safe ex-data (rf2-4hc9p, rf2-12g5z, rf2-ia904)

### DIFF
--- a/scripts/check_test_lane_bijection.py
+++ b/scripts/check_test_lane_bijection.py
@@ -53,7 +53,13 @@ decided by reading the enclosing forms, not by the column the form starts in:
     the deftest there sits inside the `defmacro`, which is not transparent.
 
 Comments and string bodies are masked before any of this, because the repo's
-test files discuss `deftest` in prose at length.
+test files discuss `deftest` in prose at length.  Masking is not enough on its
+own: a form can be spelled in full, in code, and still never be evaluated.  A
+reader DISCARD (`#_(deftest ...)`) and a QUOTE (`'(deftest ...)`,
+`` `(deftest ...) ``) both produce data, so neither defines a test, and reading
+either as one invents a test file and fires a false B1/B2 -- the same way the
+retired column-0 prose scan did.  Both are skipped, and everything nested
+inside them with them.
 
 CLASSIFIED BY THE DECLARED NAMESPACE.  A lane selector is applied by the
 runner to the namespace the file DECLARES, so this gate reads `(ns ...)` rather
@@ -149,6 +155,30 @@ DEFMACRO_FORM = re.compile(r"\(defmacro\s+([^\s()\[\]{}]+)")
 #: conditional is recorded as `#?` whatever platform keyword heads it.
 TRANSPARENT_HEADS = frozenset({"#?", "do"})
 
+#: The head recorded for a form the reader does not EVALUATE -- one behind a
+#: discard or a quote.  It is deliberately not a legal Clojure symbol, so it
+#: can be neither `deftest` nor a derived generator-macro name, and it is not
+#: in `TRANSPARENT_HEADS`, so the whole subtree under it is unreachable too.
+NON_EXECUTABLE_HEAD = "#_"
+
+#: A run of reader prefixes that makes the delimited form after it DATA rather
+#: than code: `#_` (discard) and `'` / `` ` `` (quote, syntax quote), in any
+#: number and any order, optionally with a reader conditional between the run
+#: and the form (`#_#?(:clj ...)`).  The match ENDS on the opening delimiter,
+#: which is the position the walk below tests.
+#:
+#: The lookbehind is the character literal `\'`, which `mask_source` leaves in
+#: place because it is code: without it, `(do \' (deftest t ...))` would read
+#: as a quoted deftest and the file would leave the universe.
+#:
+#: BOUND: a run consumes ONE following form.  `#_#_ (a) (b)` discards two, and
+#: only `(a)` is seen as data here.  There is no such run in the tree (measured
+#: 2026-07-26: two `#_`-prefixed forms in all of `.clj`/`.cljc`/`.cljs`, no
+#: multi-discard anywhere), and a run that consumes a non-delimited form
+#: (`#_ignored (deftest ...)`) is already exact, because the run only matches
+#: when a delimiter follows it.
+NON_EXECUTABLE_PREFIX = re.compile(r"(?<!\\)(?:(?:#_|['`])\s*)+(?:#\?@?)?(?=[(\[{])")
+
 #: `(ns name)`, tolerating any number of metadata prefixes (`^{:doc ...}`,
 #: `^:no-doc`).  Anchored at column 0: an `ns` form is never nested.
 NS_FORM = re.compile(r"^\(ns\s+(?:\^(?:\{[^}]*\}|[^\s()\[\]{}]+)\s+)*([^\s()\[\]{}]+)",
@@ -189,17 +219,28 @@ def top_level_heads(masked: str):
     reader conditional or a `do`.  That is what makes `#?(:cljs (deftest ...))`
     and `#?(:clj (do ... (deftest ...)))` reachable while a `deftest` inside a
     `defmacro` (the suite generator) correctly stays out of reach.
+
+    Reachable is not the same as evaluated.  A form behind a discard or a
+    quote is DATA: it is yielded by nothing, and because the head recorded for
+    it is not transparent, neither is anything nested inside it.  One
+    `NON_EXECUTABLE_PREFIX` pass supplies those positions; the stack does the
+    rest, so the rule costs a set lookup per delimiter rather than a branch
+    per shape.
     """
     stack = []
+    data_openers = {m.end() for m in NON_EXECUTABLE_PREFIX.finditer(masked)}
     for match in DELIMITERS.finditer(masked):
         i = match.start()
         if match.group(0) in "([{":
-            if masked[max(i - 3, 0):i] == "#?@" or masked[max(i - 2, 0):i] == "#?":
+            executable = i not in data_openers
+            if not executable:
+                head = NON_EXECUTABLE_HEAD
+            elif masked[max(i - 3, 0):i] == "#?@" or masked[max(i - 2, 0):i] == "#?":
                 head = "#?"
             else:
                 m = FORM_HEAD.match(masked, i + 1)
                 head = m.group(0) if m else ""
-            if all(h in TRANSPARENT_HEADS for h in stack):
+            if executable and all(h in TRANSPARENT_HEADS for h in stack):
                 yield head
             stack.append(head)
         elif stack:
@@ -824,6 +865,15 @@ GREEN_FILES = {
     "implementation/core/test/app/prose_helper.clj":
         "(ns app.prose-helper)\n;; (deftest not-a-test (is true))\n"
         '(def example\n  "for the docs:\n(deftest also-not-a-test (is true))\nend")\n',
+    # Spelled in code, in column 0, and still never evaluated: a discarded
+    # form and two quoted ones.  Both files sit under a namespace no selector
+    # reaches, so reading either as a test file fires B1 -- which makes the
+    # green case above their inverted proof, exactly as it is for the prose.
+    "implementation/core/test/app/discard_helper.clj":
+        "(ns app.discard-helper)\n#_(deftest discarded (is true))\n",
+    "implementation/core/test/app/quote_helper.clj":
+        "(ns app.quote-helper)\n'(deftest quoted (is true))\n"
+        "`(deftest syntax-quoted (is true))\n",
 }
 
 
@@ -899,6 +949,22 @@ def run_self_test() -> int:
         "(ns app.both-test)\n(deftest t (is true))\n")
     case("B2 fires when only the DECLARED namespace leaves the selector",
          expect="B2 partially emptied", files=files)
+
+    # ... and the other side of the discard/quote rule: it must not swallow a
+    # real definition.  A discard consumes the ONE form after it, and `\\'` is
+    # a character literal rather than a quote, so both deftests below are
+    # still evaluated and both files are still in the universe.
+    files = dict(GREEN_FILES)
+    files["implementation/core/test/app/after_discard_helper.cljc"] = (
+        "(ns app.after-discard-helper)\n#_ignored\n(deftest t (is true))\n")
+    case("B1 still sees a deftest after a discarded SYMBOL",
+         expect="B1 orphan", files=files)
+
+    files = dict(GREEN_FILES)
+    files["implementation/core/test/app/char_quote_helper.cljc"] = (
+        "(ns app.char-quote-helper)\n(do \\' (deftest t (is true)))\n")
+    case("B1 still sees a deftest after a `\\'` character literal",
+         expect="B1 orphan", files=files)
 
     files = dict(GREEN_FILES)
     files["implementation/core/test/app/nameless_cljs_test.cljc"] = "(deftest t (is true))\n"

--- a/tools/story-mcp/spec/001-Wire-Protocol.md
+++ b/tools/story-mcp/spec/001-Wire-Protocol.md
@@ -320,6 +320,20 @@ The run-loop is designed to survive every recoverable error:
 
 The protocol and server tests cover each of these paths.
 
+**A tool HANDLER's exception never reaches that `-32603` arm.** `invoke-tool`
+catches it and answers an `isError: true` result, which is what MCP §Error
+Handling asks for: the agent shows the failure to the LLM instead of aborting
+the conversation. That containment has to hold for an arbitrary throw, so the
+relayed `ex-data` is projected by `tools.result/wire-safe-ex-data` — total by
+SHAPE, not by a roster of known-bad slots. Any value outside the EDN value
+space, at any depth and in key position, becomes
+`{:rf.story-mcp/unencodable "<class name>"}`: bounded loss, and never an
+object address. Without the projection an un-encodable slot throws inside
+`protocol/write-frame!`, *past* the handler's own error result, and the client
+gets a protocol fault on what was a tool-domain failure (rf2-2z9u3,
+rf2-ia904). The `-32603` arm remains the outer net for a fault in dispatch
+itself.
+
 ## Cross-references
 
 - [`002-Tool-Registry.md`](002-Tool-Registry.md) — the 20 tools.

--- a/tools/story-mcp/spec/API.md
+++ b/tools/story-mcp/spec/API.md
@@ -558,6 +558,15 @@ result, on the commonest authoring mistake there is (rf2-2z9u3). Every
 handler that copies `ex-data` onto `:structuredContent` runs it through
 `tools.result/wire-safe-ex-data` for that reason.
 
+That projection is total, and total by SHAPE rather than by naming the
+slots known to misbehave — `:explain` was the first, and the next opaque
+value arrived under a different key (rf2-ia904). Any value outside the
+EDN value space, at any depth and in key position, is replaced by
+`{:rf.story-mcp/unencodable "<class name>"}`. `:explain` is still named,
+but only because `:explain-humanized` is a better answer than a marker,
+not because the relay would otherwise fail. See
+[`001-Wire-Protocol.md`](001-Wire-Protocol.md) §Run-loop survivability.
+
 ### `unregister-variant`
 
 **Input.** `{:variant-id keyword (required)}`.

--- a/tools/story-mcp/src/re_frame/story_mcp/tools/result.cljc
+++ b/tools/story-mcp/src/re_frame/story_mcp/tools/result.cljc
@@ -13,6 +13,8 @@
 
   `wire-safe-ex-data` is the one projection every handler that relays a
   caught exception's `ex-data` onto `:structuredContent` runs it through.
+  It is TOTAL: whatever a handler threw, the projection's output can be
+  JSON-encoded.
 
   No story-mcp ns deps — `cap` / `cursor` / `args` / `egress`
   / every category ns reaches here. `malli.error` is the sole library
@@ -28,56 +30,134 @@
   (binding [*print-readably* true]
     (pr-str v)))
 
+(def ^:private unencodable-key
+  "Wire key of the bounded stand-in `wire-safe-value` puts where a value
+  the encoder cannot write used to be. A member of story-mcp's own
+  `:rf.story-mcp/*` vocabulary, alongside
+  `:rf.story-mcp/unknown-arguments` — not an `:rf.error/*` id, because it
+  labels a VALUE that was withheld, not a failure that occurred."
+  :rf.story-mcp/unencodable)
+
+(defn- type-name
+  "The class/type NAME of `v`, and nothing else. Never `str`/`pr-str` of
+  the value itself: a bare `Object`'s printed form is
+  `java.lang.Object@2c6aed22`, and that identity-hash suffix is a build-
+  local address the wire has no business carrying."
+  [v]
+  #?(:clj  (.getName (class v))
+     :cljs (pr-str (type v))))
+
+(defn- wire-safe-value
+  "Project any value into the EDN value space, which is the shape the JSON
+  encoder can write.
+
+  A value survives when it IS data: nil, a boolean, a number, a string, a
+  keyword, a symbol, a character, a UUID or an instant — the closed set of
+  EDN scalars, the last two being EDN's two built-in tagged literals — or a
+  collection of values that survive. Everything else is a live object: a
+  reified Malli schema, a `Throwable`, an atom, a regex, a function, a bare
+  `Object`. Those become `{:rf.story-mcp/unencodable \"<class name>\"}`,
+  which says both that a value was there and what kind it was.
+
+  Map KEYS go through the same projection, and for the same reason the
+  values do: Cheshire will happily `str` a non-scalar key, so an opaque
+  key does not throw — it leaks `\"java.lang.Object@2c6aed22\"` as a JSON
+  member name instead, which is the worse failure of the two because
+  nothing goes red.
+
+  This is a rule about SHAPE, deliberately not a roster of slots. The
+  first fix for this defect named `:explain`, the one slot whose value was
+  known to be un-encodable; the next opaque value simply arrived under a
+  different key (rf2-ia904). A named-slot list is a roster that rots, so
+  the default handles the shape and the named slots below are left to do
+  only what naming is actually for — improving a projection, not rescuing
+  one."
+  [v]
+  (cond
+    (or (nil? v) (boolean? v) (number? v) (string? v)
+        (keyword? v) (symbol? v) (char? v) (uuid? v) (inst? v))
+    v
+
+    (map? v)        (reduce-kv (fn [m k x]
+                                 (assoc m (wire-safe-value k) (wire-safe-value x)))
+                               {} v)
+    (set? v)        (into #{} (map wire-safe-value) v)
+    (sequential? v) (mapv wire-safe-value v)
+    :else           {unencodable-key (type-name v)}))
+
 (defn wire-safe-ex-data
   "Project a caught exception's `ex-data` into something the JSON encoder
   can actually write, for the handlers that relay it onto
   `:structuredContent`.
 
-  ONE slot needs projecting. `re-frame.story.registrar/validate-shape!`
-  puts the raw Malli `explain` map in `ex-data`, and its `:schema`
-  entries are LIVE reified `malli.core/Schema` objects, not data. Cheshire
-  cannot encode them, so relaying `:explain` verbatim made
-  `protocol/write-frame!` throw — past the tool handler, into
-  `server/handle-frame!`, which answered a protocol-level `-32603`
-  \"Server fault: Cannot JSON encode object of class:
-  malli.core$_and_schema$…\". The tool's own `isError: true` contract was
-  bypassed and the actionable message (which names the offending key and
-  the nearest declared slot) never left the JVM — on the single commonest
-  authoring mistake an agent makes through the write surface, a typo'd
-  variant slot (rf2-2z9u3).
+  TOTALITY IS THE SHAPE RULE, not a list of slots. `wire-safe-value`
+  above rewrites every value that is not EDN data into a bounded marker
+  naming its class, so an `ex-data` carrying anything at all — under any
+  key, at any depth, as a key — relays. That is the whole guarantee, and
+  it is what makes `invoke-tool`'s belt-and-braces catch mean what it
+  says: a handler exception becomes an `isError: true` tool result, never
+  a protocol-level `-32603`.
 
-  So `:explain` is replaced by `:explain-humanized`, the
+  The history is worth keeping, because it is why the guarantee is stated
+  as a shape. `re-frame.story.registrar/validate-shape!` puts the raw
+  Malli `explain` map in `ex-data`, and its `:schema` entries are LIVE
+  reified `malli.core/Schema` objects. Relaying `:explain` verbatim made
+  `protocol/write-frame!` throw — past the tool handler, into
+  `server/handle-frame!`, which answered \"Server fault: Cannot JSON
+  encode object of class: malli.core$_and_schema$…\". The tool's own
+  `isError: true` contract was bypassed and the actionable message (which
+  names the offending key and the nearest declared slot) never left the
+  JVM — on the single commonest authoring mistake an agent makes through
+  the write surface, a typo'd variant slot (rf2-2z9u3). The fix named
+  `:explain`. The generic arm then failed identically for `{:opaque
+  (Object.)}`, because one named slot is not a rule (rf2-ia904).
+
+  TWO SLOTS ARE STILL NAMED, and neither is load-bearing for encodability
+  any more — the walk would render both safe on its own. They are named
+  because a good projection beats a marker:
+
+  `:explain` is replaced by `:explain-humanized`, the
   `malli.error/humanize` projection: plain maps, keywords and strings,
   keyed by the failing slot (`{:compnent [\"disallowed key\"]}`), and
   carrying the schema's own `:error/message` prose for the mutual-
-  exclusion `:fn` clauses. `:explain-humanized` is not a new word — it is
-  the slot `spec/010-Schemas.md` §humanize hook already defines for
-  exactly this value, and consumers there already read it in preference
-  to raw `:explain`. Renaming rather than adding also keeps the write
-  surface's error slot from colliding with `explain-variant`'s unrelated
-  plan-`:explain` projection.
+  exclusion `:fn` clauses. Left to the walk it would survive as a tree of
+  markers — encodable, and useless. `:explain-humanized` is not a new
+  word: it is the slot `spec/010-Schemas.md` §humanize hook already
+  defines for exactly this value, and consumers there already read it in
+  preference to raw `:explain`. Renaming rather than adding also keeps
+  the write surface's error slot from colliding with `explain-variant`'s
+  unrelated plan-`:explain` projection.
 
-  The OTHER slot needs renaming, not projecting. A thrown error's
-  machine-readable discriminator is `:rf.error/id` — the canonical
-  thrown-error shape of `spec/009-Instrumentation.md`, which is what
-  `re-frame.story.registrar` actually throws. But story-mcp's own wire
-  vocabulary for that same fact is the BARE `:rf.error` key, the one
-  `Principles.md` §Error envelopes names as the error payload's
-  discriminator and every tool-EMITTED error already sets. Relaying the
-  thrown spelling verbatim would put a SECOND word for one fact on the
-  wire, so the thrown key is renamed to the wire key here — the same
-  in-vocabulary move `:explain` → `:explain-humanized` makes just above,
-  and the reason both live in one function: this is where ex-data
-  vocabulary becomes wire vocabulary (rf2-2nbck).
+  `:rf.error/id` is renamed to `:rf.error` — a vocabulary move, never an
+  encodability one. A thrown error's machine-readable discriminator is
+  `:rf.error/id`, the canonical thrown-error shape of
+  `spec/009-Instrumentation.md`, which is what `re-frame.story.registrar`
+  actually throws. But story-mcp's own wire vocabulary for that same fact
+  is the BARE `:rf.error` key, the one `Principles.md` §Error envelopes
+  names as the error payload's discriminator and every tool-EMITTED error
+  already sets. Relaying the thrown spelling verbatim would put a SECOND
+  word for one fact on the wire (rf2-2nbck). This is where ex-data
+  vocabulary becomes wire vocabulary.
 
-  Every other `ex-data` slot rides through untouched — `:reason`,
-  `:where`, `:recovery`, `:kind`, `:id` are all plain data."
+  Every other slot rides through as itself — `:reason`, `:where`,
+  `:recovery`, `:kind`, `:id` are all plain data and the walk returns
+  them unchanged.
+
+  The projection cannot itself escape the caller's catch. `me/humanize`
+  runs on a value the registrar built, the walk recurses to whatever
+  depth `ex-data` nests, and neither is this function's to trust, so both
+  sit under a guard whose fallback is the same bounded marker."
   [d]
-  (cond-> d
-    (:explain d)      (-> (dissoc :explain)
-                          (assoc :explain-humanized (me/humanize (:explain d))))
-    (:rf.error/id d)  (-> (dissoc :rf.error/id)
-                          (assoc :rf.error (:rf.error/id d)))))
+  (try
+    (wire-safe-value
+      (cond-> d
+        (:explain d)      (-> (dissoc :explain)
+                              (assoc :explain-humanized (me/humanize (:explain d))))
+        (:rf.error/id d)  (-> (dissoc :rf.error/id)
+                              (assoc :rf.error (:rf.error/id d)))))
+    (catch #?(:clj Throwable :cljs :default) e
+      {unencodable-key (type-name e)
+       :reason         "ex-data projection failed"})))
 
 (defn text-result
   "Build a success result with a single text content item. `structured`

--- a/tools/story-mcp/test/re_frame/story_mcp/wire_encodability_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/wire_encodability_test.clj
@@ -22,6 +22,14 @@
       which relays a whole `ex-data` under `:data` and so fails for ANY
       handler whose throw carries a non-encodable slot.
 
+  The generic arm is the one that has to be TOTAL (rf2-ia904). Naming
+  `:explain` closed the reachable producer and left `{:opaque (Object.)}`
+  reaching Cheshire under any other key, so `wire-safe-ex-data` now
+  projects by SHAPE rather than by slot. Its tests plant opaque values
+  where no slot roster would look — under a non-`:explain` key, three
+  levels down, and in KEY position, which does not even throw: Cheshire
+  `str`s an opaque key and leaks its address into a JSON member name.
+
   Only the first is reachable through the shipped tool surface today: the
   other two re-register bodies the registrar itself produced (already
   valid) or catch throws the handlers already handle. Their tests seam
@@ -31,10 +39,12 @@
   (:require [cheshire.core :as cheshire]
             [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
+            [malli.error]
             [re-frame.core :as rf]
             [re-frame.story :as story]
             [re-frame.story-mcp.config :as config]
             [re-frame.story-mcp.server :as server]
+            [re-frame.story-mcp.tools.result :as result]
             [re-frame.substrate.plain-atom :as plain-atom]))
 
 ;; ---- fixture --------------------------------------------------------------
@@ -232,3 +242,120 @@
                  (get-in (structured frame) [:data :explain-humanized])))
           (is (= "rf.story/reg-story" (get-in (structured frame) [:data :where]))
               "every other ex-data slot rides through untouched"))))))
+
+;; ---- wire-pipeline: ARBITRARY ex-data, not just the named slot -------------
+;;
+;; rf2-ia904. Naming `:explain` fixed the reachable producer and left the
+;; generic promise unmet: `invoke-tool`'s catch relays a WHOLE `ex-data`, so
+;; the next opaque value simply arrived under a different key. The rule is now
+;; the value's SHAPE — anything outside the EDN value space becomes a bounded
+;; marker naming its class — so these tests plant opaque values where no slot
+;; roster would have looked: a non-`:explain` key, a nested one, and a KEY.
+
+(def ^:private address-in-line
+  "A `java.lang.Object@2c6aed22`-style identity hash. Cheshire does NOT
+  throw on an opaque map KEY — it `str`s it — so the key half of this
+  fails silently, and only an assertion on the raw bytes catches it."
+  #"@[0-9a-f]{6,}")
+
+(defn- throwing-get-variant
+  "Drive the real `get-variant` boundary with `thrown` coming out of the
+  one producer the read handler trusts, and return `[raw-line frame]`."
+  [thrown]
+  (story/reg-variant* :story.button/probe {:doc "probe"})
+  (with-redefs [story/variant->edn (fn [_] (throw thrown))]
+    (call-tool "get-variant" "{\"variant-id\":\"story.button/probe\"}")))
+
+(deftest handler-throw-with-opaque-ex-data-outside-explain-is-a-tool-error
+  (testing "an opaque value under a NON-:explain key still returns isError"
+    ;; The bead's headline repro, verbatim: before the shape rule this line
+    ;; was {"error":{"code":-32603,"message":"Server fault: Cannot JSON
+    ;; encode object of class: class java.lang.Object …"}}.
+    (let [[line frame] (throwing-get-variant
+                         (ex-info "opaque throw" {:opaque (Object.)}))]
+      (is (not (str/includes? line "Server fault"))
+          "the generic catch must contain an arbitrary ex-data, not just a malli one")
+      (is (nil? (:error frame))
+          (str "expected a JSON-RPC result envelope, got an error: " line))
+      (is (tool-error? frame))
+      (is (str/includes? (result-text frame) "opaque throw")
+          "the handler's own message still reaches the agent")
+      (is (= {:rf.story-mcp/unencodable "java.lang.Object"}
+             (get-in (structured frame) [:data :opaque]))
+          "the opaque value is a bounded marker naming its class")
+      (is (nil? (re-find address-in-line line))
+          "and the marker carries the class only — never an object address"))))
+
+(deftest handler-throw-with-nested-and-keyed-opaque-values-is-a-tool-error
+  (testing "depth and key position are covered by the same rule"
+    (let [[line frame] (throwing-get-variant
+                         (ex-info "deep throw"
+                                  {:ctx    {:layers [{:handle (Object.)} :ok]}
+                                   (Object.) :opaque-key
+                                   :reason "still readable"}))
+          data (:data (structured frame))]
+      (is (not (str/includes? line "Server fault")))
+      (is (tool-error? frame))
+      (is (= {:rf.story-mcp/unencodable "java.lang.Object"}
+             (get-in data [:ctx :layers 0 :handle]))
+          "a value nested three levels down is projected too")
+      (is (= "ok" (get-in data [:ctx :layers 1]))
+          "its encodable siblings are untouched")
+      (is (= "still readable" (:reason data))
+          "and so is every sibling slot")
+      (is (nil? (re-find address-in-line line))
+          "an opaque KEY does not throw — Cheshire strs it — so the only
+           evidence of the leak is the raw line"))))
+
+(deftest handler-throw-with-ordinary-ex-data-is-relayed-verbatim
+  ;; The control. A projection that made everything a marker would pass the
+  ;; two tests above and be useless.
+  (testing "plain data crosses unchanged"
+    (let [[_ frame] (throwing-get-variant
+                      (ex-info "plain throw" {:reason  "not found"
+                                              :where   :rf.story/get-variant
+                                              :ids     [:a/b :c/d]
+                                              :count   3
+                                              :nested  {:ok true}}))
+          data (:data (structured frame))]
+      (is (tool-error? frame))
+      (is (= {:reason "not found"
+              :where  "rf.story/get-variant"
+              :ids    ["a/b" "c/d"]
+              :count  3
+              :nested {:ok true}}
+             data)
+          "every slot is its own JSON encoding of the EDN value, marker-free"))))
+
+(deftest wire-safe-ex-data-output-always-encodes
+  ;; The fast guard under the three boundary tests. It cannot replace them —
+  ;; the defect lived between the handler and the wire, and only `run-loop!`
+  ;; covers that — but it fails in milliseconds when the rule regresses, and
+  ;; it can enumerate more shapes than it is worth driving a server for.
+  (testing "no ex-data shape survives the projection un-encodable"
+    (doseq [[label d] [["opaque"      {:opaque (Object.)}]
+                       ["nested"      {:a [{:b #{(Object.)}}]}]
+                       ["opaque key"  {(Object.) 1}]
+                       ["throwable"   {:cause (ex-info "boom" {:x 1})}]
+                       ["regex"       {:re #"x"}]
+                       ["fn"          {:f (fn [] 1)}]
+                       ["atom"        {:a (atom 1)}]
+                       ["tagged EDN"  {:u (java.util.UUID/randomUUID)
+                                       :d (java.util.Date. 0)}]
+                       ["nil"         nil]]]
+      (is (string? (cheshire/generate-string
+                     (result/wire-safe-ex-data d)))
+          (str "wire-safe-ex-data output must encode: " label)))))
+
+(deftest wire-safe-ex-data-cannot-itself-throw
+  ;; The projection runs INSIDE the caller's catch, so a throw here would be
+  ;; the same -32603 by another route.
+  (testing "a humanizer that throws degrades to a bounded marker"
+    (with-redefs [malli.error/humanize (fn [_] (throw (ex-info "humanize blew up" {})))]
+      (let [projected (result/wire-safe-ex-data {:explain {:schema :whatever}
+                                                 :reason  "x"})]
+        (is (= "clojure.lang.ExceptionInfo"
+               (:rf.story-mcp/unencodable projected))
+            "the guard names what failed")
+        (is (string? (cheshire/generate-string projected))
+            "and its fallback encodes")))))


### PR DESCRIPTION
Three audit-derived beads, one PR. Two changed code; one is a verification whose
residual was already discharged on `main`.

## Reopen class, per bead

The distinction matters because it says whether the previous close was weak.

| Bead | Class | Why |
| --- | --- | --- |
| `rf2-4hc9p` | **Fresh work.** The audit engaged with #7027's close evidence — it confirms the nine live suites entered the universe, that B1–B5 and the 15-case mutation proof stay green, and that the Tags-column arm correctly stopped at its fence — and then names a defect nobody had looked at: the walk models enclosure but not *evaluation*. | Not a re-assertion. #7027's close stands; this is a second, independent way for the recogniser to invent a test file. |
| `rf2-12g5z` | **Fresh work, and specifically a defect the CLOSE introduced.** The #7028 audit reopened against #7028's own new text, not against the original bundle-disclosure finding, which it accepts as correctly measured. | Neither class exactly: not the original defect re-asserted, and not a residual the close missed — a new false sentence that shipped *as* the close. |
| `rf2-ia904` | **Fresh work, and not a reopen at all.** Filed new on 2026-07-26 by the #7042 audit (`external: github-pr-7042-audit`), discovered from the closed `rf2-2z9u3`. | #7042's fix for the reachable Malli producer is correct and `rf2-2z9u3` stays closed. This is the *generic* promise #7042 additionally chose to make and did not keep. |

## `rf2-4hc9p` — a discarded or quoted form defines no test

**Found.** `top_level_heads` treated every delimiter under an otherwise
empty-or-transparent stack as executable. On current `main`, `mask_source` +
`defines_tests` returns `True` for both `#_(deftest disabled (is true))` and
`'(deftest data (is true))` following an `(ns …)`. Neither form is evaluated, so
neither defines a test; reading either as one invents a test file and emits a
false B1/B2 — the same failure mode as the retired column-0 prose scan, arriving
by a different route.

**Changed.** One `NON_EXECUTABLE_PREFIX` pass supplies the positions of opening
delimiters that a discard/quote run turns into data. The existing stack does the
rest: the head recorded for such a form is not in `TRANSPARENT_HEADS`, so
everything nested inside it is unreachable too — one rule, no per-shape branch.
A reader conditional between the run and the form (`#_#?(:clj …)`) is carried,
and a lookbehind excludes the `\'` character literal so `(do \' (deftest t …))`
keeps its test.

Deliberate bound, stated in the source: a run consumes ONE following form, so
`#_#_ (a) (b)` sees only `(a)` as data. Measured 2026-07-26 — two `#_`-prefixed
forms in all of `.clj`/`.cljc`/`.cljs`, and no multi-discard run anywhere in the
tree. A run over a *non*-delimited form (`#_ignored (deftest …)`) is exact, not
bounded, because the run only matches when a delimiter follows it.

B1–B5, lane discovery, the derived generator-macro roster and the
no-exemption-roster posture are untouched.

**Mutation proof — three plants, each confirmed applied by diff and by grepping
the token back out before the verdict was read.**

| Plant | Effect | Proves |
| --- | --- | --- |
| `data_openers = set()` (repair neutered) | `A green tree reports no failure` reddens with a B1 orphan for `discard_helper.clj` **and** for `quote_helper.clj` | The two new fixtures are inverted proofs, riding the green tree beside the existing prose fixture |
| lookbehind `(?<!\\)` removed | reddens **only** `B1 still sees a deftest after a \' character literal` | That guard case has teeth and is not decorative |
| run allowed to skip an intervening token | reddens **only** `B1 still sees a deftest after a discarded SYMBOL` | The one-form bound is the tested behaviour, not an accident |

## `rf2-12g5z` — verified already correct on `main`; nothing changed

**Found.** The reopen's bounded completion — qualify the new `spec/Privacy.md`
sentence, which claimed *"every production error record shipped off-box carries
one too"* — is **already discharged on `main`** by `ac1441ba99`
(*spec(privacy): qualify which production error records carry an absolute source
path*, 2026-07-26 10:19:07 +1000), which is an ancestor of `origin/main`.

**Verified rather than re-litigated**, against the implementation and against
the tests, not against the prose:

- `error_emit.cljc:216` `error-source-coord` returns nil for a sub/event id with
  no captured coords, and `nil` explicitly for `frame-destroyed` with
  `:op :capture` (`:capture nil` in the `case`). `dispatch-on-error!` at
  `error_emit.cljc:427` `cond->`s the slot in, so nil means the key is **absent**,
  not present-and-nil. Both match the landed Privacy paragraph exactly.
- The executable authority is `implementation/core/test/re_frame/on_error_cljs_test.cljc`:
  `frame-destroyed-programmatic-registration-omits-the-coord` pins the
  programmatic / never-registered shape, and the `:capture` case at ~line 735
  pins *":capture never fabricates a source-coord"*. Named rather than counted.
- The cross-reference resolves: `Spec-Schemas.md` §`:rf/source-coord-meta` does
  record the partial-shape caveat for programmatic registrations that the
  paragraph cites.
- The paragraph's *"Three shapes … and are the common ones"* is explicitly
  non-exhaustive, which is correct: a nil failing id short-circuits at
  `(when id …)` as a fourth, and *"only when the failing id resolves"* is stated
  as a necessary condition, so `:file` being `[:maybe :string]` does not make it
  false.
- Swept the rest of the corpus for the same unqualified claim. `spec/004D`'s
  #7028 subsection speaks about the bundle and about *registrations*, never about
  error records, so it needed no change either.

**Changed: nothing.** The residual is on `main`; a speculative edit here would
only make an open bead feel handled.

## `rf2-ia904` — the generic catch is wire-safe by SHAPE, not by slot

**Found.** `#7042` named `:explain`, the one slot known to carry live Malli
schema objects. One named slot is not a rule: `invoke-tool`'s catch relays a
WHOLE `ex-data`, so the next opaque value arrives under a different key and
reaches Cheshire exactly as before. Confirmed at the real JSON-RPC boundary, not
at the throw site.

**Changed.** `wire-safe-value` keeps a value when it is EDN data — nil, boolean,
number, string, keyword, symbol, char, uuid, inst, or a collection of those — and
replaces anything else with `{:rf.story-mcp/unencodable "<class name>"}`. Class
name only: `str` of a bare `Object` carries an identity-hash address. Map KEYS go
through the same projection, because an opaque key does **not** throw — Cheshire
`str`s it and leaks the address into a JSON member name, the worse of the two
failures because nothing reddens. The projection sits under its own guard, so
neither a throwing `me/humanize` nor an arbitrarily deep `ex-data` can escape the
catch it exists to serve.

`:explain` and `:rf.error/id` stay named and neither is load-bearing for
encodability any more — the walk renders both safe on its own. They are
vocabulary: `:explain-humanized` is a better answer than a marker, and
`:rf.error` is story-mcp's own wire spelling of the thrown discriminator.

No new `:rf.error/*` id. `:rf.story-mcp/unencodable` labels a value that was
withheld rather than a failure that occurred, and joins the existing tool-owned
`:rf.story-mcp/*` vocabulary. It is outside `check_keyword_catalogue_drift.py`'s
scan surface, which is `implementation/` only, so no fenced file is involved.

### The before/after JSON a client receives

Driving `server/run-loop!` with `initialize` then `tools/call get-variant`, with
`story/variant->edn` seamed to throw `(ex-info "opaque throw" {:opaque (Object.)})`.
The `id=2` line, verbatim.

**Before** (reproduced on this branch by planting `identity` in place of the walk):

```json
{"jsonrpc":"2.0","id":2,"error":{"code":-32603,"message":"Server fault: Cannot JSON encode object of class: class java.lang.Object: java.lang.Object@5d9d7f05","data":{"exception":"com.fasterxml.jackson.core.JsonGenerationException"}}}
```

**After:**

```json
{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"Tool handler threw: opaque throw"}],"isError":true,"structuredContent":{"tool":"get-variant","exception":"clojure.lang.ExceptionInfo","data":{"opaque":{"rf.story-mcp/unencodable":"java.lang.Object"}}}}}
```

And the nested + opaque-KEY case, which never threw at all — it silently shipped
the address as a JSON member name:

```json
{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"Tool handler threw: deep throw"}],"isError":true,"structuredContent":{"tool":"get-variant","exception":"clojure.lang.ExceptionInfo","data":{"ctx":{"layers":[{"handle":{"rf.story-mcp/unencodable":"java.lang.Object"}},"ok"]},"#:rf.story-mcp{:unencodable \"java.lang.Object\"}":"opaque-key","reason":"still readable"}}}}
```

**Mutation proof.** Planting `identity` in place of the walk (confirmed applied
by `git diff --stat` and by grepping `PLANTED` back out) reddens exactly the
three new boundary tests and the all-shapes direct proof — **11 failures, 7
errors, rc=1** — while every pre-existing test stays green, including the
`:explain` arm #7042 fixed and both new controls. So the new coverage is not
re-proving the old fix, and the old fix is not masking the new one.

## Quality gates

Every run's `rc` was captured immediately into a worktree-local log and
cross-checked against that log's own verdict line.

| Gate | Result | rc |
| --- | --- | --- |
| `scripts/check_test_lane_bijection.py --self-test` | `self-test: PASS (17 cases)` — was 15 | 0 |
| `scripts/check_test_lane_bijection.py` (whole tree) | `PASS test-lane bijection: 1665 test-defining files, 44 lanes` — **identical to the pre-repair count**, so no live suite left the universe | 0 |
| bijection cost, 5 runs each | pre-repair min 1.36s / median 1.43s → repaired min 1.59s / median 1.66s | — |
| `tools/story-mcp` `clojure -M:test` | **303 tests / 1590 assertions, 0 failures, 0 errors** (baseline 298/1565; +5 deftests, +25 assertions — exact) | 0 |
| `tools/mcp-base` `clojure -M:test` | **272 tests / 924 assertions, 0 failures, 0 errors** — exactly the baseline, no drift | 0 |
| `scripts/test-fast-pr.sh` | `PASS fast PR spine`; zero `FAIL`/`ERROR` lines in the log; wrapper rc and log verdict agree | 0 |

Mutation runs, reported as the failures they are meant to be: bijection
`data_openers = set()` → `self-test: FAIL`, rc=1; lookbehind removed → `FAIL`,
rc=1; run-skips-a-token → `FAIL`, rc=1; story-mcp `identity` plant → 11 failures
/ 7 errors, rc=1.

**Not run, and why.** `core 2115/10462` and `test:cljs ~11495/57478` were not
re-derived: the diff touches zero files under `implementation/`, and the spine's
own surface selection reached the same conclusion — *"implementation_jvm surface
unchanged → skipping JVM artefact suites"* and *"cljs_node_test surface unchanged
→ skipping npm/CLJS/isolation"*. `mkdocs build --strict` soft-skipped (not on
PATH on this host); `mkdocs.yml` carries no `tools/story-mcp/spec` entries, and
the one link added there is a same-directory relative file link. CI is
authoritative for both.

## Fences respected

No file touched under `implementation/epoch/**`, `implementation/resources/**`,
`.github/workflows/**`, `report-changed-surfaces.sh`, `tools/*/shadow-cljs.edn`,
`scripts/check_thrown_error_messages.py`, `check_keyword_catalogue_drift.py`,
`spec/009-Instrumentation.md`, or `spec/conformance/freehand/donor-inventory.md`.
`spec/Privacy.md` is unchanged — see `rf2-12g5z` above. No `.beads` path is in
the diff.
