### PR TITLE
docs(epoch): reconcile the MCP egress authority comments with the driver and the digestless whole-output marker (rf2-uozi8)

### DIFF
--- a/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
+++ b/implementation/epoch/src/re_frame/epoch/tool_pair.cljc
@@ -1586,9 +1586,13 @@
   `:sensitive?` overload, so there is no sensitive analogue of this rule: the
   axis here is TOKEN BUDGET (a bulky derived value burning an off-box
   consumer's context window), not privacy. Because the per-path sensitive
-  substitution already happened at emit, the marker's `:bytes` / `:digest` are
-  computed over a value whose secrets are already `:rf/redacted` — no size or
-  digest oracle over live secret bytes."
+  substitution already happened at emit, the marker's `:bytes` is measured over
+  a value whose secrets are already `:rf/redacted` — no size oracle over live
+  secret bytes. And no digest oracle either, at this seam by construction: the
+  marker is built through `classification/large-marker`, which reaches
+  `elision/->marker` WITHOUT `include-digests?`, so a whole-output marker
+  carries no `:digest` under ANY egress profile — including
+  `:rf.egress/off-box-tool`, where a PATH-declared marker does get one."
   [m {:keys [include-large?]} value-key prev-value-key]
   (let [mark (fn [k] (fn [v] (if (elision/marker? v) v (classification/large-marker v [k]))))]
     (cond

--- a/implementation/epoch/test/re_frame/epoch_mcp_egress_conformance_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_mcp_egress_conformance_test.clj
@@ -480,11 +480,18 @@
     makes. A `dispatch` would settle another epoch record for a value that is
     pure setup, and the cascade's record count is read below.
   - `:trace-events-keep` is pinned to the shipped default. The suite-wide
-    `:init-fn` sets 5 for `drive-mixed-ring!`'s five cascades; this cascade
-    settles more than five and EVERY record is read for its `:trace-events`, so
-    inheriting that cap would silently elide the FIRST record's rows and return
-    the fx-carrier scans to reporting green over ground they no longer cover.
-    Pinning it here is what stops the cascade's LENGTH from being load-bearing."
+    `:init-fn` sets a cap sized for `drive-mixed-ring!`, and
+    `epoch.state/elide-just-crossed-trace-events` dissocs the `:trace-events` of
+    every record that slides out of that window. `drive-resource-family!` below
+    settles one record per `dispatch-sync` it makes and EVERY one of them is read
+    for its rows, so under the inherited cap this fixture's coverage would hang
+    on one driver never outgrowing a number tuned for a different driver — and
+    outgrowing it is SILENT: the oldest record's rows are simply gone, and the
+    fx-carrier scans return to reporting green over ground they no longer cover.
+    Pinning it here is what stops the cascade's LENGTH from being load-bearing;
+    the `every? (comp seq :trace-events)` fixture control in
+    `forwarder-projected-record-leaks-no-raw-resource-family-bytes` is what
+    catches the pin itself rotting."
   [frame-id]
   (rf/configure! {:epoch-history {:trace-events-keep 50}})
   (frame/swap-frame-db! frame-id assoc-in [:auth :user :username] secret-password)
@@ -571,7 +578,8 @@
   They used also to be harvested here because epoch capture DROPPED them
   outright — `capture-event!` resolved an event's frame from `[:tags :frame]`
   and the whole family stamped only its `:rf.frame/id` EVIDENCE key, so the
-  cascade put 7 rows on the bus and 0 into the 3 records it settled. Fixed in
+  cascade — three dispatches at the time, before rf2-0t7o8 widened it — put
+  7 rows on the bus and 0 into the 3 records it settled. Fixed in
   rf2-hbmeb: `build-event` now supplies the canonical `[:tags :frame]` routing
   tag for emit sites that don't stamp one, and the rows land. The proof that
   they do — bus counted against record, over a real cascade — lives in
@@ -628,13 +636,16 @@
   "The frame's last REAL epoch record with the cascade's WHOLE set of family
   rows appended to its `:trace-events` — one record carrying every row the
   scans below want to see at once, which no single real record does (one record
-  is one dequeued event, and this cascade is three). Everything else about the
-  record is the producer's: its own trace rows, `:sub-runs`, `:effects`,
-  bookkeeping slots and frame.
+  is one dequeued event, so `drive-resource-family!`'s rows are spread across as
+  many records as it dispatches). Everything else about the record is the
+  producer's: its own trace rows, `:sub-runs`, `:effects`, bookkeeping slots and
+  frame.
 
-  Since rf2-hbmeb the record already carries its OWN family rows, so the last
-  record's `:rf.resource/owner-released` appears twice here. Harmless: every
-  scan below is either a whole-set leak scan or a `first`-match lookup by
+  Since rf2-hbmeb the record already carries its OWN family rows, so the rows of
+  the driver's LAST dispatch appear twice here — that dispatch is the global
+  `invalidate-tags`, so today it is the global `:rf.resource/invalidated` row
+  that doubles. Harmless whichever dispatch ends up last: every scan below is
+  either a whole-set leak scan or a `first`-match lookup by
   `[operation resource-id]`, and both read the same row either way."
   [frame-id rows]
   (update (last (rf/epoch-history frame-id)) :trace-events (fnil into []) rows))
@@ -770,9 +781,16 @@
   (testing "MCP `register-epoch-listener!` forwarder pattern: the projected
             record MUST NOT egress the full large payload as a leaf
             string — the wire-elision walker substitutes a
-            :rf.size/large-elided marker (a map containing :path, :bytes,
-            :digest), not the raw bytes. An MCP forwarder downstream of
-            the token-cap walker depends on this.
+            :rf.size/large-elided marker (the body `elision/->marker` builds:
+            the slot's :path, its measured :bytes, its :type, the declaration's
+            :reason / :hint, and an addressing :handle), not the raw bytes.
+            No :digest: a forwarder projects at the default
+            :rf.egress/off-box-observability boundary, and the whole-output
+            `:large?` markers pinned below carry none at ANY boundary — that
+            seam builds through `classification/large-marker`, which calls
+            `->marker` WITHOUT `include-digests?`. So :bytes is the field these
+            assertions read. An MCP forwarder downstream of the token-cap walker
+            depends on this.
 
             rf2-isp3i — the scan below is cross-cutting, but it can only
             catch what the fixture puts in front of it, and the fixture


### PR DESCRIPTION
Four active authority comments in the epoch MCP-egress surface described a fixture
and a projector that had moved out from under them. Behaviour is correct and
untouched — this PR is prose only, in two files: one test docstring block and one
production docstring.

The governing rule for the repair: **do not restate a count — name the members, or
name the authority that enumerates them.** Every one of these went stale because it
froze a number beside code that later grew. So `record-carrying-resource-rows` now
points at the driver rather than counting its dispatches, and the retention
justification now points at the elision function and the assertion that guards it.

## Per-site: found vs changed

### 1. `epoch_mcp_egress_conformance_test.clj` — `record-carrying-resource-rows` — CHANGED

**Found.** Two false claims in one docstring.

> …which no single real record does (one record is one dequeued event, and **this
> cascade is three**).

and

> …so **the last record's `:rf.resource/owner-released`** appears twice here.

**Measured** (probe replicating the deftest's exact setup — `make-frame` →
`install-mcp-style-schemas!` → `install-resource-family!` → `drive-resource-family!`):

```
=== SETTLED RECORDS: 5
   epoch-id 1  :rf.resource/ensure          own-family-rows [work-started fetch-started owner-attached]
   epoch-id 2  :rf.resource/ensure          own-family-rows [work-started fetch-started owner-attached]
   epoch-id 3  :rf.resource/release-owner   own-family-rows [owner-released]
   epoch-id 4  :rf.resource/invalidate-tags own-family-rows [scope-resolved invalidated]
   epoch-id 5  :rf.resource/invalidate-tags own-family-rows [invalidated]
=== LAST record own family rows: [:rf.resource/invalidated]
=== duplicated ops in assembled record: {:invalidated 3, :work-started 2, :fetch-started 2, :owner-attached 2}
```

So both halves were wrong: five records, not three, and the row that doubles is the
**global `:rf.resource/invalidated`** — `owner-released` is record 3's, not the
last's. (`:invalidated` shows 3 because the bus harvest contributes both
invalidations on top of the last record's own copy.)

**Changed.** The count is gone. The parenthetical now says the rows "are spread
across as many records as it dispatches" — true for any driver length. The
duplication sentence names *the driver's LAST dispatch*, then says which row that
is today and why, and the harmlessness argument is explicitly stated to hold
whichever dispatch ends up last.

### 2. `epoch_mcp_egress_conformance_test.clj` — the `:trace-events-keep` justification — CHANGED

**Found.**

> The suite-wide `:init-fn` sets 5 for `drive-mixed-ring!`'s five cascades; **this
> cascade settles more than five** and EVERY record is read for its
> `:trace-events`, so inheriting that cap would silently elide the FIRST record's
> rows…

**Measured** — the same cascade driven under three caps:

```
--- PINNED, as install-resource-family! sets it (trace-events-keep 50)
    records: 5  retained trace-events per record: [12 12 9 6 5]   every record retained? true
--- INHERITED suite cap (trace-events-keep 5)
    records: 5  retained trace-events per record: [12 12 9 6 5]   every record retained? true
--- one BELOW the record count (trace-events-keep 4)
    records: 5  retained trace-events per record: [:ELIDED 12 9 6 5]   every record retained? false
```

The claimed sixth record does not exist, so **the inherited cap would elide
nothing today** — the fixture would be green without the pin. The *mechanism* the
comment describes is entirely real, though: at one below the record count the first
record's rows vanish silently, exactly as written. The cascade sits **on** the
boundary, not past it.

**Changed.** The justification is now future-proofing, not a current repair, and it
carries no number at all. It names `epoch.state/elide-just-crossed-trace-events` as
the thing that does the dropping, says the driver settles one record per
`dispatch-sync`, frames the hazard as "coverage hanging on one driver never
outgrowing a number tuned for a different driver", and ends by naming the
`every? (comp seq :trace-events)` fixture control in
`forwarder-projected-record-leaks-no-raw-resource-family-bytes` as what catches the
pin itself rotting. The pin value is unchanged.

### 3. `epoch_mcp_egress_conformance_test.clj` — `forwarder-projected-record-bounds-large-leaf-bytes` docstring — CHANGED

**Found.** "a :rf.size/large-elided marker (a map containing :path, :bytes,
**:digest**)". False for this test at every boundary — see the call-site evidence
below. The assertions underneath it already read `:bytes` and only `:bytes`; the
docstring was the only thing claiming a digest.

**Changed.** The field list now names what `elision/->marker` actually builds
(`:path` / `:bytes` / `:type` / `:reason` / `:hint` / `:handle`) and states plainly
that there is no `:digest`, with both reasons: the forwarder projects at the default
`:rf.egress/off-box-observability` boundary, and the whole-output seam carries none
at *any* boundary. It closes by saying `:bytes` is therefore the field the
assertions read — so the docstring and the code below it now agree by construction.

### 4. `tool_pair.cljc` — `elide-whole-output-large-slots` (PRODUCTION) — CHANGED

**Found.** Line 1589:

> the marker's `:bytes` / **`:digest`** are computed over a value whose secrets are
> already `:rf/redacted` — no size or digest oracle over live secret bytes.

The safety conclusion was right; the premise naming a `:digest` was not.

**Changed.** `:bytes` keeps its size-oracle argument. The digest half is replaced by
the stronger and true statement: there is no digest oracle *by construction at this
seam*, because the marker is built through `classification/large-marker`, which
reaches `->marker` without `include-digests?` — so a whole-output marker carries no
`:digest` under any egress profile, including `:rf.egress/off-box-tool` where a
path-declared marker does get one. That last clause is the part a reader most needs,
because the asymmetry is genuinely surprising.

### Adjacent, same paragraph as site 1 — CHANGED (one clause)

The historical note in `drive-resource-family!` read "so **the cascade** put 7 rows
on the bus and 0 into the 3 records it settled". Those numbers are accurate *history*
— `git show 88a0aabd81` confirms the fixture had three `dispatch-sync` calls when
rf2-hbmeb landed — but "the cascade" with no time qualifier reads as the present one
and contradicts the corrected text two paragraphs above it. Now reads "the cascade —
three dispatches at the time, before rf2-0t7o8 widened it — put 7 rows…".

### Verified already correct, left alone

`drive-resource-family!` at :574–575 — "ONE record is one dequeued event: this
cascade is five dispatches, so its family rows are spread across five records."
Measured true (5 dispatches → 5 records). It is a count, but it sits *at* the
authority, immediately above the five `dispatch-sync` forms it describes. Left as-is.

## Call-site evidence for the `:digest` pair

The lead was correct. `elide-whole-output-large-slots` (`tool_pair.cljc:1592-1593`)
destructures **only** `:include-large?` from its opts and builds the marker with the
2-arity call:

```clojure
[m {:keys [include-large?]} value-key prev-value-key]
(let [mark (fn [k] (fn [v] (if (elision/marker? v) v (classification/large-marker v [k]))))]
```

`classification/large-marker` (`classification.cljc:210-211`) is
`(elision/->marker v path {:reason :classification})` — no `include-digests?`. And
`elision/->marker` (`elision.cljc:589-602`) adds the digest only under
`(cond-> body include-digests? (assoc :digest (sha256-hex v)))`. There is no route by
which `include-digests?` reaches this seam.

Direct construction:

```
MARKER: #:rf.size{:large-elided {:path [:value], :bytes 42, :type :string,
                                 :reason :classification, :hint nil,
                                 :handle [:rf.elision/at [:value]]}}
HAS-DIGEST: false
```

And end-to-end through `projected-record` over the fixture's own ring, per profile:

```
--- default (off-box-observability)
    WHOLE-OUTPUT :sub-runs :value       digest? false
    WHOLE-OUTPUT :sub-runs :prev-value  digest? false
    WHOLE-OUTPUT trace :rf.sub/value    digest? false
    PATH-DECLARED [:db-after :blob :payload]  digest? false
--- explicit :rf.egress/off-box-tool
    WHOLE-OUTPUT :sub-runs :value       digest? false
    WHOLE-OUTPUT :sub-runs :prev-value  digest? false
    WHOLE-OUTPUT trace :rf.sub/value    digest? false
    PATH-DECLARED [:db-after :blob :payload]  digest? true   ← the asymmetry
```

The path-declared marker gets its digest under the tool profile because it is built
by the wire walker's `marker-opts`, which threads `:include-digests?` off the walk
ctx. The whole-output marker never touches that path. Both docstrings now say so.

## The `trace_egress.cljc` sibling defect: LEFT, deliberately

`trace_egress.cljc:204` does say "Five other row types carry a resolved CONCRETE
scope under a free `:scope` tag" and then enumerates six (`invalidated`,
`refetch-decision`, `removed`, `resource-clear-scope-unresolved`,
`:rf.mutation/started`, `optimistic-applied`). Real defect, confirmed by counting the
roster in place.

I did not take it, because it is not an orphan — **`rf2-ruiga` (P4, open) owns
exactly this cluster**, and its scope is wider than the two `trace_egress.cljc`
lines:

- `trace_egress.cljc:205, :521, :604`
- `epoch_egress_resource_trace_test.clj:886, :897, :923, :1257`
- and, per its own notes, **`epoch_mcp_egress_conformance_test.clj:381` and `:537`** —
  two lines in the very file this PR edits.

rf2-uozi8's description also excludes it by name ("The separate six-operations-as-five
count cluster is already owned by rf2-ruiga and is excluded here") and its acceptance
criteria repeat it ("rf2-ruiga retains ownership of the separate six-as-five roster
wording"). Taking the `trace_egress.cljc` half here would split one bead across two
PRs and leave rf2-ruiga owning two lines inside a file I had already rewritten around
— a merge conflict by construction. Those two lines (now :381 and :544 after my edit
shifted them) are untouched and still say "five"; rf2-ruiga should take the cluster
whole.

## Quality gates

Run from the worktree, foreground to completion, `rc=$?` captured immediately into a
worktree-local log and cross-checked against each log's own verdict line.

| Gate | Result | Verdict line | rc |
|---|---|---|---|
| `implementation/epoch` — `clojure -M:test` | **495 tests / 6665 assertions, 0 failures, 0 errors** | `0 failures, 0 errors.` | **0** |
| `epoch-mcp-egress-conformance-test`, targeted | **22 tests / 198 assertions, 0 failures, 0 errors** | `{:test 22, :pass 198, :fail 0, :error 0}` | **0** |

**Baseline re-derived, not trusted.** The brief carried epoch at 490/6637; current
`main` is **495/6665**. The delta is main's, not mine — this branch differs from
`origin/main` by docstrings only, so it cannot move an assertion count. The targeted
run is the load proof: both edited namespaces compile and the file's own suite is
green, which is the only way a docstring edit can break anything.

No `implementation/core` or `implementation/resources` run: nothing in either
artefact is touched, and `tool_pair.cljc` is epoch-internal.
