### PR TITLE
fix(resources): a :reply-to read continuation's :value + :params egress raw on the fx carriers (rf2-xx4ty)

### DIFF
--- a/implementation/epoch/test/re_frame/epoch_egress_resource_trace_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_egress_resource_trace_test.clj
@@ -1594,3 +1594,383 @@
       (is (= args (:rf.fx/args (:tags (first (:trace-events projected)))))
           "and so does the rest of the payload it sits in"))))
 
+;; ===========================================================================
+;; (rf2-xx4ty) the SAME two carriers, a DIFFERENT map: the READ COMPLETION
+;; CONTINUATION reply, whose `:value` is the DECODED RESPONSE BODY.
+;; ===========================================================================
+;;
+;; §(rf2-425mm) above closed the resolved `:scope` inside the TRANSPORT
+;; continuation payload. This is a different map on the same carriers, and it
+;; is the most sensitive datum the family puts there.
+;;
+;; An `ensure` / `refetch` MAY carry a call-site `:reply-to` (EP-0016 D1 →
+;; reads, rf2-p1yri7; Spec 016 §Read completion continuations). When the read
+;; settles — or is served immediately by a fresh-skip cache hit —
+;; `events/read-continuation-reply` augments the canonical reply with the
+;; top-level read facts and `re-frame.reply/complete` APPENDS the whole map as
+;; the final argument of the target event vector, which the runtime dispatches
+;; through `[:dispatch <ev>]`. So this rides `:rf.fx/args` and `:rf.event/fx`:
+;;
+;;   {:status       :ok
+;;    :value        <DECODED RESPONSE BODY>      ← the leak
+;;    :params       <canonical params>           ← the leak
+;;    :scope        <resolved scope>             ← closed by rf2-425mm
+;;    :resource/key <scoped-key>                 ← closed by rf2-1kiuj
+;;    :resource     <resource-id>
+;;    :cache-hit?   <bool>
+;;    :rf.reply/work-id …, :correlation {…}, …}
+;;
+;; `project-embedded-keys` recognised the `:resource/key`, the key embedded in
+;; the `:rf.reply/work-id`, the `:correlation`'s `:rf.reply/resource-key`, and
+;; (rf2-425mm) the free `:scope`. `:value` and `:params` are ordinary maps, so
+;; the walk descended them and let the owner's decoded body through in the
+;; clear — one slot from the `:resource/key` that had just redacted the very
+;; same params.
+;;
+;; WHY THIS ONE IS OWNER-CONDITIONAL AND `:scope` IS NOT. The `:scope` arm
+;; §(rf2-425mm) added fires unconditionally, because the family's own rows
+;; classify a free `:scope` unconditionally (rf2-1zc33) and the two carriers of
+;; one scope must agree. `:value` and `:params` are the opposite case twice
+;; over. They belong to a NAMED owner whose `:resource/key` sits one slot away,
+;; and the family's own rows tokenize that owner's params IFF
+;; `whole-entry-disposition` is non-`:serialize` — so an unconditional arm would
+;; redact a PLAIN resource's reply, the over-redaction rf2-1kiuj rejected. And
+;; `:params` / `:value` are words the FX FAMILY uses for its own data: an app's
+;; managed-HTTP args carry `{:request {… :params {…}}}` and
+;; `[:rf.resource/commit-generation {:value 1}]` rides the same effect vector,
+;; neither of which the resource family may touch. The sibling `:resource/key`
+;; is what makes the two names safe to read — it says the map is a resource
+;; reply and names whose. `row-owner-redacts?` (the load-more cursor's read,
+;; rf2-3tysyj) already answers exactly that question, one carrier out.
+;;
+;; READS AND MUTATIONS DIFFER HERE, and the difference is the reason this arm
+;; keys on the sibling where rf2-425mm's could not. The mutation `:reply-to`
+;; (`mutation_events/continuation-reply`) carries `:params` / `:value` with NO
+;; `:resource/key` beside them, so this arm does not fire on it. It does not
+;; need to: both mutation settle sites wrap their reply in
+;; `classification/redact-continuation-reply`, which applies the mutation's own
+;; projection-relative `:sensitive` / `:large` declarations at the SOURCE,
+;; before the reply reaches any carrier (rf2-825mzj). The read reply has no
+;; such source-side redaction and must not: the coarse `:sensitive?` claim
+;; governs OFF-BOX egress, not in-process delivery — the app's own continuation
+;; handler is entitled to the decoded body, and `:include-sensitive?` must still
+;; show it. Hence the egress projector, and hence the owner gate.
+
+(def ^:private reply-params
+  "The canonical params of the read whose continuation leaks — SECRET-bearing,
+  because `:params` is one of the two slots this section owns. Safe to carry
+  the secret: `:derived/profile`'s request fn does not echo its params into the
+  request map (the app's own request is the FX family's data and rides
+  untouched by design — rf2-1kiuj)."
+  {:slug secret})
+
+(def ^:private reply-value
+  "The DECODED RESPONSE BODY the read delivers under `:value`. The most
+  sensitive datum this family puts on a foreign carrier: not a key, not a
+  scope, not an identity map — payload."
+  {:email (str secret "@example.com")})
+
+(def ^:private read-reply-target
+  "The call-site `:reply-to` — an ordinary app event vector. `reply/complete`
+  APPENDS the reply map after it, so the dispatched vector is
+  `[:app/read-loaded <reply>]` and the reply sits at index 1 of `:rf.fx/args`."
+  [:app/read-loaded])
+
+(defn- carrier-replies
+  "Every READ CONTINUATION REPLY map riding a `:rf.fx/args` / `:rf.event/fx`
+  carrier of `record`'s trace rows. Found by walking for the reply's OWN marker
+  (`:rf.reply/work-kind :resource`) rather than by index, so no assertion here
+  encodes the cascade's fx order or the reply's position in the event vector."
+  [record]
+  (let [found (atom [])
+        walk  (fn walk [v]
+                (cond
+                  (map? v)  (do (when (= :resource (:rf.reply/work-kind v))
+                                  (swap! found conj v))
+                                (run! walk (vals v)))
+                  (coll? v) (run! walk v)))]
+    (doseq [tags (map :tags (:trace-events record))
+            slot [:rf.fx/args :rf.event/fx]
+            :when (contains? tags slot)]
+      (walk (get tags slot)))
+    @found))
+
+(defn- record-carrying-reply
+  "The settled record whose fx carriers carry a read-continuation reply with
+  the given `:cache-hit?` disposition — the ASYNC SETTLE (`false`, the accepted
+  terminal reply fanning out to the recorded target) or the FRESH-SKIP
+  immediate dispatch (`true`). Selected by the reply's own fact rather than by
+  record index, because the two settle through different branches of
+  `events.cljc` and only the reply says which is which."
+  [records cache-hit?]
+  (first (filter (fn [r] (some #(= cache-hit? (:cache-hit? %)) (carrier-replies r)))
+                 records)))
+
+(defn- drive-reply-to-read!
+  "Drive a REAL `[:rf.resource/ensure …]` carrying a call-site `:reply-to`
+  against the `:sensitive?` `{:from-db :rt/session}` resource, settle its reply,
+  and then drive a SECOND ensure that finds the entry fresh — so one call
+  produces BOTH continuation paths: the async accepted-reply fan-out
+  (`:cache-hit? false`) and the fresh-skip immediate dispatch
+  (`:cache-hit? true`). Returns the epoch records.
+
+  The managed-HTTP fx is a CAPTURING stub (`fx/reg-fx`, the plain fn — see
+  `drive-real-cascade!` for why the macro would break default-image
+  reprojection) and the reply is replayed through the real internal reply
+  event, so the settle path and its `[:dispatch …]` continuation fx are the
+  runtime's own. The session identity is written straight into the frame's
+  app-db partition and CLASSIFIED `:sensitive` there, so the app-db axis can
+  never be what the scans below catch."
+  [resource-id]
+  (rf/configure! {:epoch-history {:trace-events-keep 80}})
+  (let [captured (atom nil)]
+    (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! captured args) nil))
+    (rf/reg-event :app/read-loaded (fn [_ _ev] {}))
+    (frame/swap-runtime-db! :test/rt
+      (fn [rt] (elision/apply-classification-effects
+                 rt {:sensitive [[:auth :user :username]]})))
+    (frame/swap-frame-db! :test/rt assoc-in [:auth :user :username] secret)
+    (rf/dispatch-sync [:rf.resource/ensure
+                       {:resource resource-id :params reply-params
+                        :owner    real-owner  :reply-to read-reply-target}]
+                      {:frame :test/rt})
+    (rf/dispatch-sync (conj (:on-success @captured) {:status :ok :value reply-value})
+                      {:frame :test/rt})
+    (rf/dispatch-sync [:rf.resource/ensure
+                       {:resource resource-id :params reply-params
+                        :owner    [:app :reader 2] :reply-to read-reply-target}]
+                      {:frame :test/rt})
+    (rf/epoch-history :test/rt)))
+
+;; ---------------------------------------------------------------------------
+;; (1) THE ACCEPTANCE ARM — a REAL reply-to read, both continuation paths
+;; ---------------------------------------------------------------------------
+
+(deftest real-reply-to-read-leaks-no-decoded-body-into-fx-carriers
+  (testing "rf2-xx4ty — `projected-record` over the records a REAL
+            `[:rf.resource/ensure … :reply-to …]` settles for a `:sensitive?`
+            resource must carry the decoded response body and the canonical
+            params at ZERO paths, on BOTH continuation paths. Before the repair
+            each carried them at four: `:value` and `:params` under
+            `:rf.fx/args`, and again under `:rf.event/fx`."
+    (let [records (drive-reply-to-read! :derived/profile)]
+      (doseq [[label cache-hit?] [["async settle" false] ["fresh-skip cache hit" true]]]
+        (testing label
+          (let [raw       (record-carrying-reply records cache-hit?)
+                projected (epoch/projected-record raw)]
+
+            (testing "FIXTURE — the producer really put a decoded body on the fx
+                      carriers, so the assertions below are not passing over an
+                      empty set"
+              (is (some? raw) "the continuation reached an fx carrier at all")
+              (is (seq (carrier-replies raw)) "and the reply map is findable on it")
+              (is (every? #(and (= reply-value (:value %))
+                                (= reply-params (:params %)))
+                          (carrier-replies raw))
+                  "every carrier's reply carries the RAW decoded body + params")
+              (is (seq (secret-leak-paths raw))
+                  "the unprojected record leaks — the projector's input is the
+                   runtime's own output, not an invented tag map"))
+
+            (testing "ACCEPTANCE — nothing raw survives anywhere in the projected
+                      record"
+              (is (= [] (secret-leak-paths projected))
+                  "every leaking path is named here; before the repair this
+                   printed the [:trace-events n :tags :rf.fx/args 1 :value :email]
+                   and :params :slug shapes, once per carrier"))
+
+            (testing "and each reply's payload is TOKENIZED, not merely absent"
+              (is (= (count (carrier-replies raw)) (count (carrier-replies projected)))
+                  "projection neither drops nor invents a carrier reply")
+              (is (every? #(and (redacted-component? (:value %))
+                                (redacted-component? (:params %)))
+                          (carrier-replies projected))
+                  "both slots are opaque content-addressed tokens"))
+
+            (testing "the whole reply still reads as a reply — attribution and
+                      the sibling slots the earlier repairs own"
+              (let [r (first (carrier-replies projected))]
+                (is (= :derived/profile (:resource r))
+                    "the resource id rides verbatim")
+                (is (= cache-hit? (:cache-hit? r))
+                    "and the cache-hit disposition, so a tool still reads how it settled")
+                (is (= :ok (:status r)) "and the status")
+                (is (redacted-component? (first (:resource/key r)))
+                    "rf2-1kiuj — the sibling key's scope component is still tokenized")
+                (is (= :derived/profile (second (:resource/key r)))
+                    "with its resource-id intact for attribution")
+                (is (tokenized-scope? (:scope r))
+                    "rf2-425mm — and the free :scope beside it")))))))))
+
+;; ---------------------------------------------------------------------------
+;; (2) the same shape assembled — deterministic, and it names the four paths
+;; ---------------------------------------------------------------------------
+
+(defn- read-reply
+  "The continuation reply map `events/read-continuation-reply` builds — the
+  canonical reply (`resources.reply/success-reply`) plus the top-level read
+  facts it layers on."
+  [scoped-key scope value]
+  (let [[_ resource-id params] scoped-key]
+    {:status               :ok
+     :value                value
+     :rf.reply/work-id     [:rf.work/resource scoped-key 1]
+     :rf.reply/work-kind   :resource
+     :rf.reply/work-status :completed
+     :rf.frame/id          :test/rt
+     :completed-at         0
+     :correlation          {:scope scope :generation 1
+                            :rf.reply/resource-key scoped-key}
+     :resource             resource-id
+     :params               params
+     :scope                scope
+     :resource/key         scoped-key
+     :cache-hit?           false}))
+
+(defn- reply-carrier-record
+  "A record carrying the continuation's TWO fx carriers of one reply — the
+  `:rf.fx/handled` row's `:rf.fx/args` (the dispatched event vector) and the
+  `:rf.fx/do-fx` row's `:rf.event/fx` (the whole effect vector).
+
+  The effect vector deliberately also carries
+  `[:rf.resource/commit-generation {:value 1}]` — a FOREIGN map with a `:value`
+  and no `:resource/key`. It is the control that a name-only arm would fail:
+  the runtime's generation counter must ride verbatim while the reply's
+  `:value` two slots away tokenizes."
+  [reply]
+  (let [ev (conj read-reply-target reply)]
+    (record-with
+      [(event :rf.fx/handled
+              {:rf.frame/id :test/rt :frame :test/rt
+               :rf.fx/id :dispatch :rf.fx/args ev})
+       (event :rf.fx/do-fx
+              {:rf.frame/id :test/rt :frame :test/rt
+               :rf.event/fx [[:rf.resource/commit-generation {:value 1}]
+                             [:dispatch ev]]})])))
+
+(deftest fx-carrier-reply-payload-tokenizes-on-both-carriers
+  (testing "rf2-xx4ty — the projector, over the exact reply the runtime builds.
+            Two payload slots across two carriers, every one of them tokenized;
+            and the foreign `:value` on the same effect vector rides untouched,
+            because the resource family speaks only for what it planted."
+    (let [k1        (sk session-scope :derived/profile reply-params)
+          reply     (read-reply k1 session-scope reply-value)
+          projected (epoch/projected-record (reply-carrier-record reply))
+          replies   (carrier-replies projected)
+          [handled do-fx] (:trace-events projected)]
+      (is (= 2 (count replies))
+          "one reply per carrier — the two the bead named, four paths in all")
+      (is (every? #(and (redacted-component? (:value %))
+                        (redacted-component? (:params %)))
+                  replies)
+          "each carrier tokenizes both payload slots")
+      (is (= [] (secret-leak-paths projected))
+          "and nothing raw survives anywhere in the record")
+      (testing "the FOREIGN :value on the same effect vector is untouched"
+        (is (= [:rf.resource/commit-generation {:value 1}]
+               (first (:rf.event/fx (:tags do-fx))))
+            "a map with a :value and no :resource/key is nobody's business here")
+        (is (= :dispatch (:rf.fx/id (:tags handled)))
+            "and the fx id rides verbatim")
+        (is (= :app/read-loaded (first (:rf.fx/args (:tags handled))))
+            "as does the continuation TARGET — a tool still reads which event ran")
+        (is (true? (:sensitive? (:tags handled)))
+            "but the row IS stamped :sensitive?")))))
+
+;; ---------------------------------------------------------------------------
+;; (3) THE TWO-SIDED CONTROL — over-redaction must fail as loudly as leaking
+;; ---------------------------------------------------------------------------
+
+(deftest fx-carrier-keeps-plain-owners-reply-payload-verbatim
+  (testing "rf2-xx4ty guard — a PLAIN owner's read continuation reply must ride
+            BYTE-IDENTICAL through both carriers and must not stamp the row
+            sensitive. This is the side that proves the arm reads the ROW'S
+            OWNER rather than the two slot names: the same `:value` and
+            `:params` that tokenize for `:derived/profile` are fully readable
+            here, which is what keeps a plain resource debuggable off-box."
+    (let [k1        (sk :rf.scope/global :plain/article {:slug plain-slug})
+          reply     (read-reply k1 :rf.scope/global {:title "hello"})
+          record    (reply-carrier-record reply)
+          projected (epoch/projected-record record)
+          [handled do-fx] (:trace-events projected)]
+      (is (= (conj read-reply-target reply) (:rf.fx/args (:tags handled)))
+          "the whole dispatched event vector rides verbatim — reply :value,
+           :params, :scope and scoped key included")
+      (is (= (:rf.event/fx (:tags (second (:trace-events record))))
+             (:rf.event/fx (:tags do-fx)))
+          "and so does the whole effect vector on the other carrier")
+      (is (not (:sensitive? (:tags handled)))
+          "a plain-owner reply row is NOT stamped sensitive")
+      (is (not (:sensitive? (:tags do-fx)))
+          "on either carrier"))))
+
+(deftest fx-carrier-leaves-the-fx-familys-own-params-verbatim
+  (testing "rf2-xx4ty guard — the OTHER half of the over-redaction control, and
+            the sharper one: on a record carrying BOTH a `:sensitive?` owner's
+            reply AND the app's own managed-HTTP args, the reply's `:params`
+            tokenizes while the app's `:request` `:params` — a map under the
+            identical key, with no `:resource/key` beside it — rides verbatim.
+            An arm keyed on the slot NAME could not tell these apart."
+    (let [k1     (sk session-scope :derived/profile reply-params)
+          reply  (read-reply k1 session-scope reply-value)
+          req    {:method :get :url "/z" :params {:slug plain-slug}}
+          record (record-with
+                   [(event :rf.fx/handled
+                           {:rf.frame/id :test/rt :frame :test/rt
+                            :rf.fx/id :dispatch
+                            :rf.fx/args (conj read-reply-target reply)})
+                    (event :rf.fx/handled
+                           {:rf.frame/id :test/rt :frame :test/rt
+                            :rf.fx/id :rf.http/managed
+                            :rf.fx/args {:request req}})])
+          projected (epoch/projected-record record)
+          [reply-row req-row] (:trace-events projected)]
+      (is (redacted-component? (:params (first (carrier-replies projected))))
+          "the reply's :params — a named owner's, read through that owner")
+      (is (= {:request req} (:rf.fx/args (:tags req-row)))
+          "the app's request :params — the FX family's, untouched")
+      (is (true? (:sensitive? (:tags reply-row)))
+          "only the reply row is stamped sensitive")
+      (is (not (:sensitive? (:tags req-row)))
+          "the request row is not"))))
+
+(deftest fx-carrier-reply-tokens-stay-distinct-per-value
+  (testing "rf2-xx4ty — distinct bodies must keep DISTINCT digests, so an Xray
+            effect graph can still tell two reads' completions apart after the
+            payload tokenizes"
+    (let [proj  (fn [params value]
+                  (let [k (sk session-scope :derived/profile params)]
+                    (-> (reply-carrier-record (read-reply k session-scope value))
+                        epoch/projected-record
+                        carrier-replies
+                        first)))
+          r1    (proj reply-params reply-value)
+          r2    (proj {:slug (str secret "-2")} {:email "other@example.com"})]
+      (is (not= (:value r1) (:value r2))
+          "two distinct bodies keep two distinct digests")
+      (is (not= (:params r1) (:params r2))
+          "and so do two distinct params maps"))))
+
+;; ---------------------------------------------------------------------------
+;; (4) the trusted-local boundary — the redaction is the off-box DEFAULT
+;; ---------------------------------------------------------------------------
+
+(deftest trusted-local-include-sensitive-keeps-raw-fx-carrier-reply
+  (testing "rf2-xx4ty — the trusted-local `:include-sensitive?` opt-in keeps the
+            raw reply payload (the local-raw boundary — the tokenization is the
+            off-box default, not a strip). This is load-bearing beyond the
+            pattern: a `:reply-to` continuation is how a workflow reads a
+            resource, so a local tool that could not see `:value` could not
+            debug the workflow at all."
+    (let [k1        (sk session-scope :derived/profile reply-params)
+          reply     (read-reply k1 session-scope reply-value)
+          projected (epoch/projected-record (reply-carrier-record reply)
+                                            {:include-sensitive? true})]
+      (is (= [reply-value reply-value] (mapv :value (carrier-replies projected)))
+          "every carrier's raw :value rides with :include-sensitive?")
+      (is (= [reply-params reply-params] (mapv :params (carrier-replies projected)))
+          "and its :params")
+      (is (= (conj read-reply-target reply)
+             (:rf.fx/args (:tags (first (:trace-events projected)))))
+          "and so does the rest of the event vector it sits in"))))
+

--- a/implementation/resources/src/re_frame/resources/trace_egress.cljc
+++ b/implementation/resources/src/re_frame/resources/trace_egress.cljc
@@ -72,7 +72,7 @@
   opt-in lifts it at the epoch consumer (the `local-raw` boundary — the same
   switch the app-db / HTTP-body / scope-resolved redactions honour).
 
-  ## The family's keys also ride FOREIGN rows (rf2-1kiuj, rf2-425mm)
+  ## The family's keys also ride FOREIGN rows (rf2-1kiuj, rf2-425mm, rf2-xx4ty)
 
   Everything above is routed by the epoch tool-pair on the row's OPERATION
   namespace. But an `ensure` lowers into EFFECTS, and those effects address the
@@ -84,7 +84,10 @@
   row but the keys — and, since rf2-425mm, the resolved `:scope` the runtime
   writes into that same continuation payload, projected by the SAME rule the
   family's own rows give it (`project-unknown-slot-value`), so the two carriers
-  of one scope agree the way the two carriers of one key already did."
+  of one scope agree the way the two carriers of one key already did; and, since
+  rf2-xx4ty, the `:value` + `:params` a READ COMPLETION CONTINUATION reply
+  carries beside its `:resource/key`, tokenized through that key's OWNER exactly
+  as the load-more cursor is through its row's."
   (:require [re-frame.resources.registry :as registry]
             [re-frame.resources.ssr :as ssr]))
 
@@ -245,11 +248,40 @@
   rides verbatim (no over-redaction)."
   #{:page-param :next-page-param})
 
+(def ^:private reply-payload-slot
+  "Slots of a READ COMPLETION CONTINUATION reply map that carry the resource
+  owner's own data as FREE entries beside its `:resource/key` (rf2-xx4ty):
+  `:value` — the DECODED RESPONSE BODY — and `:params` — the canonical params.
+
+  `re-frame.resources.events/read-continuation-reply` builds that map for an
+  `ensure` / `refetch` carrying a call-site `:reply-to` (EP-0016 D1, Spec 016
+  §Read completion continuations) and `re-frame.reply/complete` APPENDS it as
+  the final argument of the target event vector, which the runtime dispatches
+  through `[:dispatch <ev>]` — so it rides `:rf.fx/args` and `:rf.event/fx`,
+  the same two foreign carriers rf2-1kiuj and rf2-425mm addressed. Neither
+  reached these two: `:value` and `:params` are ordinary maps, not scoped keys,
+  so the carrier walk descended them and let the owner's data through in the
+  clear one slot from the `:resource/key` that had just redacted the very same
+  params.
+
+  OWNER-CONDITIONAL, and that is the whole design (see `project-embedded-keys`
+  §rf2-xx4ty): these two are read through the ROW's owner exactly as
+  `cursor-slot` is, never unconditionally. `:params` and `:value` are ordinary
+  English words the FX family uses for its own data — an app's managed-HTTP
+  args carry `{:request {… :params {…}}}`, and
+  `[:rf.resource/commit-generation {:value 1}]` rides the same effect vector —
+  so a name-only arm would redact a plain owner's request map and the runtime's
+  own generation counter. The sibling `:resource/key` is what makes the name
+  safe to read: it says the map is a RESOURCE reply and names whose."
+  #{:params :value})
+
 (defn- row-owner-redacts?
   "Whether the resource OWNER named by this trace row's `:resource/key`
   classifies non-`:serialize` (sensitive / large, or UNREGISTERED →
   fail-closed) — i.e. whether the row's
-  owner-local identity-bearing FREE tags (the load-more cursor) must tokenize.
+  owner-local identity-bearing FREE tags (the load-more cursor; and, inside an
+  fx carrier, a read continuation reply's `reply-payload-slot` entries) must
+  tokenize.
   Reuses the SAME owner classification the scoped-key projection uses
   (`disposition+project-key`), with the trace-egress fail-closed default for an
   unregistered / unreadable owner (`project-trace-scoped-key`'s nil-spec arm).
@@ -440,7 +472,64 @@
   payload itself, so the family owns the value by construction rather than by a
   guess about shape (a resolved scope is arbitrary EDN — there is no shape to
   read). Everything else in the carrier is still the fx family's and still rides
-  through untouched. Pure."
+  through untouched.
+
+  ## …AND a read continuation reply's `:value` + `:params` (rf2-xx4ty)
+
+  The transport payload is not the only map the family plants in a foreign
+  carrier. An `ensure` / `refetch` MAY carry a call-site `:reply-to`; when the
+  read settles, `events/read-continuation-reply` augments the canonical reply
+  with the top-level read facts and `re-frame.reply/complete` appends the whole
+  map as the target event's final argument, dispatched via `[:dispatch <ev>]`.
+  So `{:status :ok :value <DECODED RESPONSE BODY> :params <canonical params>
+  :scope … :resource/key <scoped-key> :cache-hit? …}` rides the same two
+  carriers. The `:resource/key` projected (scoped-key-shaped) and the `:scope`
+  took the arm above, but `:value` and `:params` are ordinary maps: the walk
+  descended them and the owner's decoded body egressed in the clear one slot
+  from the key that had just redacted its params.
+
+  ### Why this one is OWNER-CONDITIONAL where `:scope` is unconditional
+
+  Not a style choice — the two would DISAGREE for a plain owner if it were, and
+  each way round is wrong for the other datum.
+
+  `:scope` is unconditional because the family's own rows classify a free
+  `:scope` unconditionally (rf2-1zc33) and the two carriers of one scope must
+  agree; and because it is safe to be — `:scope` inside an fx carrier is a word
+  only the resource runtime writes.
+
+  `:value` and `:params` are neither. They belong to a NAMED owner whose
+  `:resource/key` sits one slot over, and the family's own rows tokenize that
+  owner's params IFF `whole-entry-disposition` is non-`:serialize`, so
+  unconditional tokenization would redact a PLAIN resource's reply — the
+  over-redaction rf2-1kiuj rejected, and the reason this walk descends maps at
+  all. Worse, `:params` and `:value` are words the FX family uses for its own
+  data: an app's managed-HTTP args carry `{:request {… :params {…}}}`, and
+  `[:rf.resource/commit-generation {:value 1}]` rides the same effect vector, so
+  a name-only arm would tokenize a plain app's request params and the runtime's
+  generation counter. The grain is therefore `cursor-slot`'s, one carrier out —
+  `row-owner-redacts?` on the map's OWN `:resource/key`, the same read that
+  governs the load-more cursor (rf2-3tysyj) and the same
+  `whole-entry-disposition` that governs the key beside it.
+
+  ### Reads and mutations differ here, and the difference is already handled
+
+  The mutation `:reply-to` (`mutation_events/continuation-reply`) is the sibling
+  shape and carries `:params` / `:value` with NO `:resource/key` beside them
+  (its owner is named by `:mutation` / `:instance`), so this arm does not fire
+  on it — deliberately. The mutation half is closed one layer EARLIER, at the
+  source: both settle sites wrap the reply in
+  `classification/redact-continuation-reply`, which redacts the mutation's own
+  projection-relative `:sensitive` / `:large` declarations before the reply ever
+  reaches a carrier (rf2-825mzj). A coarse `:sensitive?` ROOT prop is not part
+  of `reg-mutation`'s declaration surface and is inert at every mutation egress
+  boundary, not merely this one.
+
+  The read reply has no such source-side redaction, and MUST NOT: the coarse
+  `:sensitive?` claim governs OFF-BOX egress, not in-process delivery — the
+  app's own continuation handler is entitled to the decoded body, and the
+  trusted-local `:include-sensitive?` opt-in must still show it. So the read
+  half belongs exactly here, at the egress projector. Pure."
   [v frame-id]
   (cond
     (redacted-token? v)   [v true]
@@ -452,14 +541,29 @@
           proj   (fn [x]
                    (let [[pv s] (project-embedded-keys x frame-id)]
                      (note! s pv)))
+          ;; rf2-xx4ty — a read continuation reply names its resource OWNER in
+          ;; the `:resource/key` one slot over. Read ONCE per map, exactly as
+          ;; `project-tags*` reads it once per row for the cursor; nil (no
+          ;; usable key) means this map is not a reply and its `:params` /
+          ;; `:value` are somebody else's.
+          owner-redacts? (and (map? v) (row-owner-redacts? v frame-id))
           ;; the family's own resolved scope, planted in a foreign payload by
           ;; the runtime — projected by the FAMILY rule so the carrier cannot
           ;; drift from the row (rf2-425mm). Every other entry takes the walk.
           entry  (fn [k x]
-                   (if (= :scope k)
+                   (cond
+                     (= :scope k)
                      (let [[pv s] (project-unknown-slot-value x frame-id)]
                        (note! s pv))
-                     (proj x)))]
+
+                     ;; the owner's own reply data (rf2-xx4ty) — tokenized
+                     ;; content-addressed iff THIS map's owner redacts, so a
+                     ;; plain resource's reply stays fully readable. Idempotent
+                     ;; (an opaque token stays sensitive and is not re-digested).
+                     (and owner-redacts? (reply-payload-slot k) (some? x))
+                     (note! true (if (redacted-token? x) x (ssr/redact-value x)))
+
+                     :else (proj x)))]
       [(cond
          (map? v)    (reduce-kv (fn [m k x] (assoc m (proj k) (entry k x))) {} v)
          (set? v)    (into #{} (map proj) v)
@@ -692,7 +796,10 @@
   transport continuation payload carries beside them, which is a
   `[tier {identity}]` TUPLE rather than a scoped key and so was descended into
   and let through in the clear one slot from the `:resource/key` that had just
-  redacted the same bytes. A tags map carrying NEITHER slot rides through reference-preserved —
+  redacted the same bytes, and (rf2-xx4ty) the `:value` + `:params` a READ
+  CONTINUATION reply carries beside its own `:resource/key`, tokenized iff that
+  key's OWNER redacts so a plain resource's reply stays readable.
+  A tags map carrying NEITHER slot rides through reference-preserved —
   which is what lets the epoch consumer apply this to every row and keep no row
   predicate of its own, so a family key riding a carrier on some future op is
   covered without anyone widening a roster.


### PR DESCRIPTION
Closes rf2-xx4ty (P1, privacy).

A `:sensitive?` resource's **decoded response body** egressed off-box in the clear. The fifth leak in this family this week, and the first whose datum is payload rather than a key, a scope or an identity map.

## The leak

EP-0016 D1 read continuations: an `ensure` / `refetch` may carry a call-site `:reply-to`. When the read settles — or is served immediately by a fresh-skip cache hit — `events/read-continuation-reply` augments the canonical reply with the top-level read facts and `re-frame.reply/complete` **appends the whole map** as the final argument of the target event vector, which the runtime dispatches through `[:dispatch <ev>]`. So it rides `:rf.fx/args` (the dispatch fx) and `:rf.event/fx` (the whole effect vector) — the same two foreign carriers rf2-1kiuj and rf2-425mm addressed.

`project-embedded-keys` recognised the `:resource/key`, the key embedded in the `:rf.reply/work-id`, the `:correlation`'s `:rf.reply/resource-key`, and (rf2-425mm) the free `:scope`. `:value` and `:params` are ordinary maps, so the walk descended them and let the owner's data through.

Reproduced against merged `main` by driving the public path (a real ensure, a real reply settle, `epoch/projected-record`) — four paths per continuation, on the record the async settle produces and again on the fresh-skip cache hit:

```
[:trace-events 7 :tags :rf.fx/args   1     :value  :email]
[:trace-events 7 :tags :rf.fx/args   1     :params :slug]
[:trace-events 8 :tags :rf.event/fx  1 1 1 :value  :email]
[:trace-events 8 :tags :rf.event/fx  1 1 1 :params :slug]
```

## Why the owner-conditional grain is right here and wrong for `:scope`

rf2-425mm's `:scope` arm fires **unconditionally**. Two reasons, and neither transfers.

It *must* be unconditional because the family's own rows classify a free `:scope` unconditionally (rf2-1zc33), and the two carriers of one scope have to agree. And it is *safe* to be, because `:scope` inside an fx carrier is a word only the resource runtime writes.

`:value` and `:params` are the opposite case twice over.

**They belong to a named owner.** The reply carries that owner's `:resource/key` one slot away, and the family's own rows tokenize an owner's params **iff** `whole-entry-disposition` is non-`:serialize`. An unconditional arm would redact a *plain* resource's reply — the over-redaction rf2-1kiuj rejected, and the whole reason this walk descends maps instead of tokenizing them.

**And the names are not ours.** `:params` and `:value` are ordinary English the fx family uses for its own data. An app's managed-HTTP args carry `{:request {… :params {…}}}`; `[:rf.resource/commit-generation {:value 1}]` rides the same effect vector as the reply it accompanies. A name-only arm would tokenize a plain app's request params and the runtime's own generation counter. The sibling `:resource/key` is what makes the two names safe to read — it says the map is a resource reply and names whose.

So: `cursor-slot`'s grain, one carrier out. `row-owner-redacts?` already answers exactly that question and is reused unchanged.

Both halves are tested, and the second is the sharper one: `fx-carrier-leaves-the-fx-familys-own-params-verbatim` puts a `:sensitive?` owner's reply and the app's `{:request {… :params …}}` on **one record** and asserts the first tokenizes while the second rides verbatim — a discrimination a name-keyed arm cannot make.

## Do reads and mutations differ in what sits beside the datum?

**Yes** — the same asymmetry that stopped rf2-425mm keying on a sibling. A read reply carries `:resource/key` beside `:value` / `:params`; a mutation reply (`mutation_events/continuation-reply`) carries `:mutation` / `:instance` / `:affected-keys` and **no `:resource/key`**, so this arm does not fire on it.

Unlike rf2-425mm's case, that costs nothing, and I measured it rather than assuming. Driving a mutation `:reply-to` end-to-end, three declarations:

| mutation spec | continuation reply on the carriers |
|---|---|
| `{:sensitive [[:params :token] [:data :receipt]]}` | **clean** |
| `{:sensitive? true}` (coarse root prop) | leaks |
| `{}` (no declaration) | leaks — *byte-identical to the row above* |

The mutation half is closed **one layer earlier, at the source**: both settle sites wrap their reply in `classification/redact-continuation-reply`, which applies the mutation's own projection-relative `:sensitive` / `:large` declarations before the reply reaches any carrier (rf2-825mzj). And rows 2 and 3 being identical is the point — a coarse `:sensitive?` root prop is not part of `reg-mutation`'s declaration surface and is inert at *every* mutation egress boundary, not merely this one. Nothing is left leaking that a mutation author could have declared.

The read reply has no source-side redaction and **must not**: the coarse `:sensitive?` claim governs off-box egress, not in-process delivery. The app's own continuation handler is entitled to the decoded body, and `:include-sensitive?` must still show it. Hence the egress projector, and hence the owner gate.

## Two-sided control

- **Plain owner** — a `:plain/article` reply rides **byte-identical** through both carriers, and neither row is stamped `:sensitive?`. Same `:value`, same `:params`, fully readable.
- **Foreign slots** — the app's `:request` `:params` and `[:rf.resource/commit-generation {:value 1}]` ride verbatim on a record whose reply tokenizes.
- **Trusted-local** — `:include-sensitive? true` keeps the raw `:value` and `:params`, and the rest of the event vector they sit in. Load-bearing beyond the pattern here: a `:reply-to` continuation is how a workflow reads a resource, so a local tool that could not see `:value` could not debug the workflow at all.
- **Distinct digests** — two distinct bodies (and two distinct params maps) keep distinct digests, so an Xray effect graph can still tell two completions apart.

## Can the conformance fixture see these rows?

**No, and it is not among the blind spots `drive-resource-family!` documents.** It names two omissions — `:rf.resource/refetch-decision`, and a session-scoped `ensure` (deferred to rf2-425mm, now landed; widening it is rf2-0t7o8, not this bead). A `:reply-to` continuation is neither, and it is structurally out of reach on two counts:

1. the fixture drives no `:reply-to` on any dispatch, and never replays an HTTP reply — it says so explicitly, ruling out `refetch-decision` because "reaching it means an HTTP reply round-trip the `ensure` path does not need". These rows only exist on a settled reply or on a fresh-skip cache hit *with* a call-site `:reply-to`;
2. its rows are harvested through `resource-family-row?`, which filters on operation namespace `rf.resource` / `rf.mutation`. The leaking rows are `rf.fx`.

The coverage therefore lives where the two prior fx-carrier fixes' does — `epoch_egress_resource_trace_test`, §(rf2-xx4ty).

## Two findings for follow-up beads (measured, not fixed here)

Both are separate classification rulings, not this arm's to make.

1. **A read FAILURE continuation's `:error` envelope egresses raw on the same carriers.** Driving the failure path: `:params` and `:scope` now tokenize, and `:error :body :detail` leaks — the decoded failure body, which `error-envelope-slot`'s own docstring notes "routinely echoes the SUBMITTED FORM FIELDS and validation text quoting user values". It cannot simply take this arm: on the family's own rows `:error` is **unconditional**, so an owner-conditional arm would make the two carriers disagree — but `:error` is also a word the fx family uses, so an unconditional one risks the over-redaction this PR's control exists to catch. That is a genuine ruling, and a bead.
2. **A resource's projection-relative `:sensitive` declaration has no read-continuation analogue.** A resource with `{:sensitive [[:data :email]]}` and no coarse `:sensitive?` is `:serialize`, so its reply rides verbatim — consistent with every other boundary in this family (its scoped key rides verbatim too), but it means reads have no counterpart to the mutations' `redact-continuation-reply`. Source-side, and a different surface.

## Quality gates

Run from the worktree, foreground to completion. `rc` captured immediately into a worktree-local log and cross-checked against each log's own verdict line.

| gate | command | tests / assertions | failures | rc |
|---|---|---|---|---|
| epoch (incl. the MCP-egress conformance fixture) | `cd implementation/epoch && clojure -M:test` | 501 / 6711 | 0 | 0 |
| resources | `cd implementation/resources && clojure -M:test` | 733 / 6799 | 0 | 0 |
| core | `cd implementation/core && clojure -M:test` | 2115 / 10462 | 0 | 0 |
| ssr-ring | `cd implementation/ssr-ring && clojure -M:test` | 199 / 978 | 0 | 0 |

Baselines re-derived, not trusted: resources and core land exactly on 733/6799 and 2115/10462. Epoch moves 6665 → 6711 and 495 → 501, which is this PR's six new deftests and nothing else.

`scripts/test-fast-pr.sh` was **not** run as a unit. The classifier arms `cljs_node_test=true` for this diff, so the spine would install npm and cold-compile the shadow-cljs `:node-test` bundle in a fresh worktree; its JVM tier is exactly `core` + each touched artefact (`resources`, `epoch`), which the four runs above cover and exceed. No Markdown changed, so the mkdocs soft-skip is not load-bearing here. The change is eight lines of portable Clojure in a `.cljc` already loaded on both platforms — no reader conditionals, no host interop — so the CLJS lane is CI's, as are the browser lanes.

### Negative control — reverted in place, red, restored, green

The arm alone was reverted (the `reply-payload-slot` branch of `project-embedded-keys`'s `entry` fn dropped back to `(if (= :scope k) … (proj x))`), leaving the tests and every other fix in the family intact. Restoring it returned the file byte-identical to the commit (`git diff --exit-code` → 0).

| | tests | assertions | failures | rc |
|---|---|---|---|---|
| GREEN | 501 | 6711 | 0 | 0 |
| RED (arm reverted) | 501 | 6711 | **7** | 1 |
| GREEN (restored) | 501 | 6711 | 0 | 0 |

Identical test **and** assertion counts, differing only in failure count — which is what proves the mutation applied rather than the gate quietly not firing; a silently-failed edit leaves the failure count behind.

The seven name the leak directly, and their distribution is the interesting part:

- `real-reply-to-read-leaks-no-decoded-body-into-fx-carriers` — the whole-record `secret-leak-paths` scan and the per-slot tokenization assertion, **each failing twice**, once for the async settle and once for the fresh-skip cache hit. Both continuation paths leaked, and both are covered;
- `fx-carrier-reply-payload-tokenizes-on-both-carriers` — the per-carrier assertion and the whole-record scan on the deterministic assembly;
- `fx-carrier-leaves-the-fx-familys-own-params-verbatim` — the reply's `:params`, on the record that also carries the app's.

And note what stayed **green in both directions**: the plain-owner byte-identity control, the trusted-local `:include-sensitive?` control, and the foreign-slot assertions (`{:request …}`, `[:rf.resource/commit-generation {:value 1}]`). That is what proves the fix discriminates by owner rather than blanket-stripping the carriers — an over-redacting version of this change would have gone red on exactly those.
