### PR TITLE
gates,pkg: row the G-8 evidence runner in the donor ledger, and scope Cheshire off browser-only http consumers (rf2-vfv8r, rf2-nucj0)

### DIFF
--- a/implementation/http/deps.edn
+++ b/implementation/http/deps.edn
@@ -23,6 +23,25 @@
 {:paths ["src"]
  :deps  {day8/re-frame2 {:local/root "../core"}
          ;; The JVM codec uses Cheshire; CLJS uses the host `JSON` object.
+         ;;
+         ;; This stays at COMPILE scope, and `:provided` is the wrong shape for
+         ;; it (rf2-nucj0). `provided` says a container supplies the dependency;
+         ;; a JVM re-frame2 app has no container, so the artefact would be
+         ;; asking every JVM consumer to redeclare its own codec. And the cost
+         ;; of getting that wrong is not a lazy failure at first decode: the
+         ;; `cheshire.core` require in `re-frame.http.json` is unconditional
+         ;; inside `#?(:clj …)`, so it fires when the namespace LOADS. Drop
+         ;; Cheshire from a JVM classpath and requiring this artefact's own
+         ;; `:main` — `re-frame.http.managed` — dies at boot with
+         ;; "Could not locate cheshire/core". Spec 014 ships the JVM transport
+         ;; (`java.net.http.HttpClient`) and names Cheshire as the JVM `:json`
+         ;; codec, so that path is specified, not incidental.
+         ;;
+         ;; What a browser-only consumer actually pays is smaller than it looks:
+         ;; `jackson-core` is already on any `day8/re-frame2` classpath via
+         ;; ClojureScript -> transit-java. Cheshire's marginal cost is itself
+         ;; plus jackson-dataformat-smile, -cbor, and tigris, and a jackson-core
+         ;; version bump. Nothing reaches the bundle.
          cheshire/cheshire {:mvn/version "5.13.0"}}
 
  :aliases

--- a/scripts/check_donor_inventory.py
+++ b/scripts/check_donor_inventory.py
@@ -196,7 +196,16 @@ DONOR_EVIDENCE_RE = re.compile(
     r"|re-frame2-ui"     # the artifact coordinate
     r"|re_frame2_ui"     # the munged coordinate
     r"|implementation/ui"  # the donor tree
-    r"|node-test-ui"     # the donor build ids and npm entry points
+    # The donor build ids and npm entry points. A runner can couple to the donor
+    # entirely through its BUILD ID and never spell `re-frame.ui` at all — that is
+    # how `implementation/scripts/run-ui-g8.cjs` came to carry no recognised donor
+    # material while its `:ui-g13` sibling passed on an incidental prose mention
+    # (rf2-vfv8r). The donor-owned ids are enumerated in `implementation/deps.edn`
+    # and `implementation/shadow-cljs.edn`; keep this alternation in step with them.
+    r"|node-test-ui"
+    r"|ui-bench"
+    r"|ui-g8"
+    r"|ui-g13"
     r"|check-ui-"
     r"|run-ui-"
     r"|test:ui"
@@ -1139,10 +1148,13 @@ ESTABLISHED_ROWS = (
     "implementation/scripts/check-ui-warm-watch.cjs",
     "implementation/scripts/check-ui-mounted-prod-elision.cjs",
     "implementation/scripts/run-ui-bench.cjs",
+    "implementation/scripts/run-ui-g8.cjs",
     "implementation/scripts/run-ui-g13.cjs",
     "implementation/scripts/lib/g13-timing-evidence.cjs",
     "implementation/scripts/lib/g8-latency-evidence.cjs",
     "implementation/scripts/bundle-isolation-positive-control/*",
+    "implementation/scripts/_g8-latency-evidence.test.cjs",
+    "implementation/scripts/_g13-timing-evidence.test.cjs",
     "implementation/scripts/_release-ui-required-gate.test.cjs",
     "implementation/scripts/_ui-deps-edn-boundary.test.cjs",
     ".github/scripts/verify-version-lockstep.sh",

--- a/spec/conformance/freehand/donor-inventory.md
+++ b/spec/conformance/freehand/donor-inventory.md
@@ -96,6 +96,20 @@ donor in order to retire it. Nothing else is excluded. Incidental prose
 elsewhere is simply not a signal, because neither detector fires on it, and the
 gate deliberately does not police it.
 
+Both signals are **spellings of the donor's name**, so the derived set is a
+floor and not the whole open roster. A file can depend on the donor without
+naming it: a `.cjs` runner that compiles a donor build id, an npm entry point,
+a script that reads a donor output directory. Neither detector fires on any of
+those, and no `.cjs` file can ever raise the require signal at all — that
+detector only reads `.clj`, `.cljs`, `.cljc`, and `.edn`. Those rows are placed
+by hand, and the gate holds them only once they exist: it can prove a row has
+not gone stale, and it can prove a row has not been deleted, but it cannot tell
+you that a row was never written. `implementation/scripts/run-ui-g8.cjs` was
+exactly that hole — its whole coupling to the donor is the `:ui-g8` build id,
+so it went unrowed while its `:ui-g13` sibling was rowed (rf2-vfv8r). When you
+add a donor build id, an npm entry point, or a runner, the row is yours to
+write.
+
 ## How coverage is enforced
 
 ```
@@ -307,10 +321,13 @@ release train have no Freehand successor and are DELETEd outright.
 | `implementation/scripts/check-ui-warm-watch.cjs` | the warm-watch recompile probe runner | MOVE | F6 | pending |
 | `implementation/scripts/check-ui-mounted-prod-elision.cjs` | proof that mounted-view debug machinery elides in production | MOVE | F6 | pending |
 | `implementation/scripts/run-ui-bench.cjs` | the parity-bench runner | MOVE | F6 | pending |
+| `implementation/scripts/run-ui-g8.cjs` | the controlled-input evidence runner: compiles the `:ui-g8` build and drives the donor's input-latency fixture in Chromium and WebKit | MOVE | F6 | pending |
 | `implementation/scripts/run-ui-g13.cjs` | the mass-mount evidence runner | MOVE | F6 | pending |
 | `implementation/scripts/lib/g13-timing-evidence.cjs` | the mass-mount timing-evidence library | MOVE | F6 | pending |
 | `implementation/scripts/lib/g8-latency-evidence.cjs` | the input-latency evidence library | MOVE | F6 | pending |
 | `implementation/scripts/bundle-isolation-positive-control/*` | the positive control proving the donor client sentinel is emitted | MOVE | F6 | pending |
+| `implementation/scripts/_g8-latency-evidence.test.cjs` | the unit tests for the input-latency evidence library | MOVE | F6 | pending |
+| `implementation/scripts/_g13-timing-evidence.test.cjs` | the unit tests for the mass-mount timing-evidence library | MOVE | F6 | pending |
 | `implementation/scripts/_release-ui-required-gate.test.cjs` | the guard asserting the donor is a required artifact of the release train; the donor is never published, so nothing succeeds it | DELETE | F6 | done |
 | `implementation/scripts/_ui-deps-edn-boundary.test.cjs` | the guard scoping optional artifacts out of the donor's production dependencies | REPLACE | F6 | pending |
 | `.github/scripts/verify-version-lockstep.sh` | the release inventory's assertion that the donor artifact is publishable; the surrounding inventory serves other artifacts and stays | DELETE | F6 | done |


### PR DESCRIPTION
Two beads, one PR. Both are audit-shaped: one is a gate that could not see a file, one is a dependency scope.

## rf2-vfv8r — the donor ledger could not see `run-ui-g8.cjs`

**Found.** `implementation/scripts/run-ui-g8.cjs` had no row in `spec/conformance/freehand/donor-inventory.md`; its sibling `run-ui-g13.cjs` did (MOVE, F6). A file with no row can never be undisposed, and F6d's acceptance measure is the undisposed count, which F6e then deletes `implementation/ui/` on.

**Is the ledger population derived or hand-maintained?** **Hybrid, and the half that failed here is hand-maintained.** Measured at `e67201b225`:

| | rows |
|---|---|
| donor-tree path rows — DERIVED-ENFORCED, closed partition | 106 |
| contract label rows — hand-authored by design, no path | 14 |
| outside-tree path rows | 86 |
| …of which a census signal currently backs | **20** |
| …of which nothing mechanical would have discovered | **66** |
| census live-consumer files (the entire derived floor) | **30** of 4559 tracked |

Inside `implementation/ui/` the ledger is genuinely derived: `check_partition` fails if any tracked donor file is unclaimed. Outside it, the derived arm is a census over exactly two signals — a `re-frame.ui…` libspec and a `day8/re-frame2-ui {` coordinate — and **both are spellings of the donor's name**.

Direct evidence, not inference. Running `live_consumers()` over the real tree returns 30 files, and **none of these eight is among them**:

```
census[implementation/scripts/run-ui-g8.cjs]              = None
census[implementation/scripts/run-ui-g13.cjs]             = None
census[implementation/scripts/lib/g8-latency-evidence.cjs]  = None
census[implementation/scripts/lib/g13-timing-evidence.cjs]  = None
census[implementation/scripts/_g8-latency-evidence.test.cjs]  = None
census[implementation/scripts/_g13-timing-evidence.test.cjs]  = None
census[implementation/scripts/run-ui-bench.cjs]           = None
census[implementation/scripts/check-ui-adapter-isolation.cjs] = None
```

Six of those eight have rows. Those six rows were written **by hand**. The census would not have found any of them, so `run-ui-g8.cjs` did not escape a derivation — there was no derivation to escape. Two structural reasons: the require detector only reads `.clj/.cljs/.cljc/.edn`, so a `.cjs` file can never raise it; and `run-ui-g8.cjs` couples to the donor only through the `:ui-g8` build id, which is not a name-spelling at all. Its `:ui-g13` sibling matches the *currency* regex purely by an incidental prose mention of `implementation/ui/deps.edn` in a comment.

The gate is not weak — it is precisely bounded. It proves a row is not stale and proves a row was not deleted. It cannot prove a row was never written.

**Changed.** Three rows, each with the disposition its already-rowed sibling carries, plus the roster identity the gate demands in the same change.

| Row | Disposition | Evidence for that disposition |
|---|---|---|
| `implementation/scripts/run-ui-g8.cjs` | **MOVE** F6 | It runs `shadow('compile','ui-g8')` over `implementation/ui/g8/*` (rowed **MOVE** F6, "the input-latency evidence fixture") and requires `lib/g8-latency-evidence.cjs` (rowed **MOVE** F6). Both ends of what it drives cross under Freehand ownership; a moved fixture with no driver is not a disposition. Structurally identical to the rowed `run-ui-g13.cjs` → `implementation/ui/g13/*` + `lib/g13-timing-evidence.cjs` triple, which is MOVE throughout. Not REPLACE: nothing states Freehand measures controlled-input latency differently on purpose — the realization is the thing being carried. Not DELETE: `:ui-g8` is a live build id in `implementation/shadow-cljs.edn`. |
| `implementation/scripts/_g8-latency-evidence.test.cjs` | **MOVE** F6 | Unit tests of `lib/g8-latency-evidence.cjs`, which is MOVE. The ledger's own rule — "a suite proves a contract, and the contract has one owner" — puts the suite where the contract goes. The section already rows `_*.test.cjs` files individually (`_release-ui-required-gate.test.cjs`, `_ui-deps-edn-boundary.test.cjs`), so this is the section's established granularity, not a new one. |
| `implementation/scripts/_g13-timing-evidence.test.cjs` | **MOVE** F6 | Same argument against `lib/g13-timing-evidence.cjs` (MOVE). |

`DONOR_EVIDENCE_RE` gains `ui-g8`, `ui-g13`, `ui-bench` alongside the `node-test-ui` it already carried. This is not a widening of intent — the alternation's own comment already reads "the donor build ids and npm entry points", and those three ids are enumerated in `implementation/shadow-cljs.edn`. It was required: see mutation B below. Widening this regex can only *remove* failures (it is the "does this row still point at donor material" test), never add them.

The ledger gains a paragraph stating the bound, so the next reader does not infer that the derived floor is total.

**Deliberately not changed.** `implementation/scripts/_changed-surfaces.test.cjs` is unrowed and carries the same class of coupling (it asserts the changed-surface router classifies `run-ui-g13.cjs` and `check-ui-adapter-isolation.cjs`). Its subject, `.github/scripts/report-changed-surfaces.sh`, is rowed REPLACE F6 — but that file is fenced to a live lane worker, and the row's disposition is that worker's to settle. Filed rather than taken.

**Fence note, stated plainly.** The brief fenced `scripts/check_*` for "a live checker worker with an open PR". This bead **cannot** be fixed without editing `scripts/check_donor_inventory.py`: `ESTABLISHED_ROWS` lives inside it and the gate hard-fails `DONOR-LEDGER-ROW-UNROSTERED` on a row added without its roster identity (mutation A below is that failure). I checked before editing — the live PR is **#7057**, and its files are `scripts/check_keyword_catalogue_drift.py`, `spec/009-Instrumentation.md`, `implementation/core/test/re_frame/error_catalogue_channel_conformance_test.clj`. It does not touch `check_donor_inventory.py`, so there is no conflict. Flagging it because the fence was by glob, not by file.

### Mutation proof

Every mutation was confirmed present in the file before its verdict was read.

| # | State | rc | Verdict |
|---|---|---|---|
| baseline | `e67201b225` untouched | **0** | 203 rows, 129 pending, 74 disposed |
| A | ledger row added, roster entry withheld | **1** | `DONOR-LEDGER-ROW-UNROSTERED` at :310 **and** `DONOR-LEDGER-DRIFTED` at :310 — two independent blind spots, both named |
| B | roster entry added, regex withheld | **1** | `ROW-UNROSTERED` cleared for all three rows; `DONOR-LEDGER-DRIFTED` for `run-ui-g8.cjs` alone survives — isolating the currency-signal gap |
| final | row + roster + regex | **0** | 206 rows, 132 pending, **74 disposed unchanged** |
| negative control | the new `run-ui-g8.cjs` row deleted again, roster kept | **1** | `DONOR-LEDGER-ROW-REMOVED` — the row is now protected; the count can no longer fall by deletion |

The ledger was restored from backup after the negative control and verified by blob hash (`bfa6883f26fbc6f915e9424d6cc1afa0bb416618`).

The count moves `129 → 132` pending and `203 → 206` rows. The disposed count stays at 74: three rows were added, none disposed, and no existing row was touched.

## rf2-nucj0 — Cheshire on `day8/re-frame2-http`

**Verdict: investigated, not taken.** `:provided` is the wrong shape, and the bead's premise is partly wrong too. No dependency was changed; the resolved tree is byte-identical before and after.

**Who calls Cheshire, and on which host.** Exactly one namespace: `implementation/http/src/re_frame/http/json.cljc`, inside `#?(:clj …)` on lines 38, 55 and 101. CLJS uses the host `JSON` object. Nothing else in the artefact touches it — `git grep cheshire -- implementation/http/src` returns those three lines and nothing more.

But that JVM branch is **not** an SSR-only nicety, and it is not implicit:

- **Spec 014 §26 (normative):** "The **CLJS reference implementation ships `:rf.http/managed`**, backed by Fetch on the browser **and `java.net.http.HttpClient` on the JVM**." The artefact ships `transport_jvm.cljc`, a full JDK `HttpClient` adapter.
- **Spec 014 line 168:** "`:json` runs `pr-str → JSON.stringify` (CLJS) / **Cheshire (JVM)**." Cheshire is the spec's named JVM codec.
- **Run, not inferred.** The artefact's own clein `:main` is `re-frame.http.managed`. Requiring it on the JVM:

  ```
  $ clojure -M -e "(require 're-frame.http.managed) ..."
  cheshire.core loaded? true
  json-stringify: {"a":1}
  ```

  The chain is `managed → handlers → transport/decode → json → cheshire.core`.

**Why `:provided` would break a consumer.** The `cheshire.core` require is **unconditional inside the reader conditional**, so it resolves when the namespace **loads**, not at first decode. `provided` deps are not transitive, so a JVM consumer who does not redeclare Cheshire gets a classpath without it. Simulated exactly — http's `src` on `:paths`, `day8/re-frame2` as the only dep, zero cheshire entries on `clojure -Spath`:

```
$ clojure -M -e "(require 're-frame.http.managed) (println \"LOADED OK\")"
Execution error (FileNotFoundException) at re-frame.http.json/eval2598$loading (json.cljc:1).
Could not locate cheshire/core__init.class, cheshire/core.clj or cheshire/core.cljc on classpath.
```

Not a degraded codec — a **boot failure for every JVM consumer**, before any request is issued. And `provided` means "a container supplies this at runtime". A JVM re-frame2 app has no container; the scope would just be asking consumers to redeclare an artefact's own specified codec, with a load-time crash as the penalty for not reading the release notes. Per the brief: **a shipped JVM path depends on it, so stop.**

**The premise correction — it is not "the Jackson tree".** `jackson-core` is already on every `day8/re-frame2` classpath via `org.clojure/clojurescript → com.cognitect/transit-java`. The http artefact does not put Jackson there. Measured from `clojure -Stree` / `-Spath`:

| | browser-only consumer today | without Cheshire (the `provided` counterfactual) |
|---|---|---|
| `cheshire` | 24 KiB | — |
| `jackson-core` | 567 KiB (2.17.0) | 275 KiB (2.8.7, via ClojureScript) |
| `jackson-dataformat-smile` | 94 KiB | — |
| `jackson-dataformat-cbor` | 68 KiB | — |
| `tigris` | 10 KiB | — |
| **total** | **763 KiB** | **275 KiB** |

Marginal cost of Cheshire: **~488 KiB across four extra jars plus a `jackson-core` version bump**, none of it reaching the bundle. Real, but a good deal smaller than "Cheshire plus the Jackson tree", and the correct price for a specified JVM transport.

**The clein mechanism is real; only its applicability fails.** Verified at the pinned sha `2b83503246e8291fc023d688574640a9b23d8c50`, in `src/noahtheduke/clein/pom_data.cljc`: `get-provided-deps` reads `(-> basis :aliases :provided :extra-deps)` (line 20) and emits `[(xml/qname pom-ns "scope") "provided"]` (line 17). The bead's toolchain claim is accurate. Nothing here was inferred from a local install — per the sibling finding that `clein install` writes no POM, the only artefacts consulted were the clein source at the pinned sha and live `clojure -Stree` / `-Spath` resolution.

**Same answer for core, for the same reason.** `implementation/core/deps.edn`'s `org.clojure/clojure` and `org.clojure/clojurescript` stay at compile scope. `provided` on those would change 13 published poms for no user-visible gain, and Maven nearest-wins already means a consumer's own pin takes precedence — the bead itself calls this cosmetic. Not touched.

**Changed.** A comment in `implementation/http/deps.edn` recording the finding, so the next dependency audit does not re-file this. Nothing else.

**Note on the mutation standard.** The brief asked for a browser-only consumer's tree before and after, and a JVM consumer still resolving. Since the verdict is "do not change the dependency", before and after are identical by construction (`diff` of the two `-Stree` runs is empty). The informative experiment is the counterfactual instead: the tree *with* Cheshire (quantified above, and the JVM load succeeding) against the tree *without* it (the JVM load failing at namespace load). That is the evidence that decides the bead.

## Quality gates

Every rc captured immediately into a worktree-local log and cross-checked against that log's own verdict line. Python gates here are silent-on-success, so rc **is** the verdict. No gate was backgrounded or piped through a pager; each ran in the foreground to completion.

| Gate | rc | Verdict line |
|---|---|---|
| `python scripts/check_donor_inventory.py` | **0** | silent |
| `python scripts/check_donor_inventory.py --self-test --verbose` | **0** | `self-test: all cases passed.` |
| `python scripts/check_donor_inventory.py --ci --report` | **0** | `206 rows, 132 not yet disposed, 74 disposed` |
| `python scripts/check_freehand_conformance_index.py --self-test --verbose` | **0** | silent |
| `python scripts/check_freehand_conformance_index.py --verbose` | **0** | silent |
| `sh .github/scripts/verify-version-lockstep.sh` | **0** | `all 17 artefacts (13 implementation/ + 4 tools/) pinned to repo-root VERSION 0.0.1.alpha` |
| `clojure -M:test` in `implementation/http` | **0** | `Ran 493 tests containing 3787 assertions. 0 failures, 0 errors.` |
| `check_doc_slugs.py` | **0** | silent |
| `check_readme_links.py` | **0** | silent |
| `check_readme_inventories.py` | **0** | silent |
| `check_retired_spellings.py` | **0** | silent |
| `check_retired_composition_vocab.py` | **0** | silent |
| `check_retired_image_keys.py` | **0** | silent |
| `check_inject_cofx_residue.py` | **0** | silent |

The first four rows are exactly the invocations `.github/workflows/freehand-conformance.yml` runs, in its order. `implementation/http/*` routes to the JVM-artefacts lane per `.github/scripts/report-changed-surfaces.sh:520`, which is the `clojure -M:test` row. `mkdocs` was not run and is not implicated: `docs_dir` is `docs`, and `spec/conformance/freehand/donor-inventory.md` appears nowhere in `mkdocs.yml`'s nav.

No test-shaped failure and no exit code that was not a test outcome: the one suite that ran named its deftest count and its assertion count, and every other gate is a silent-on-success python or shell gate that exited 0.

## Follow-up filed

**rf2-xnb1d** (P3) — `implementation/scripts/_changed-surfaces.test.cjs` is unrowed while the router it tests is rowed. Same defect class; deliberately left because its subject is fenced to a live lane worker and the disposition should follow that worker's ruling on the router row.
