### PR TITLE
fix(scripts): let the non-executable prefix cross metadata, and stop reading a prime-suffixed symbol as a quote (rf2-4hc9p) — follow-up to #7062

### DIFF
--- a/scripts/check_test_lane_bijection.py
+++ b/scripts/check_test_lane_bijection.py
@@ -163,21 +163,42 @@ NON_EXECUTABLE_HEAD = "#_"
 
 #: A run of reader prefixes that makes the delimited form after it DATA rather
 #: than code: `#_` (discard) and `'` / `` ` `` (quote, syntax quote), in any
-#: number and any order, optionally with a reader conditional between the run
-#: and the form (`#_#?(:clj ...)`).  The match ENDS on the opening delimiter,
-#: which is the position the walk below tests.
+#: number and any order, optionally with METADATA and/or a reader conditional
+#: between the run and the form (`#_^:doc (...)`, `#_#?(:clj ...)`).  The match
+#: ENDS on the opening delimiter, which is the position the walk below tests.
 #:
-#: The lookbehind is the character literal `\'`, which `mask_source` leaves in
-#: place because it is code: without it, `(do \' (deftest t ...))` would read
-#: as a quoted deftest and the file would leave the universe.
+#: TWO LOOKALIKES ARE NOT QUOTES, and both would cost a live suite:
+#:
+#:   * the character literal `\'`, which `mask_source` leaves in place because
+#:     it is code -- without the guard, `(do \' (deftest t ...))` reads as a
+#:     quoted deftest;
+#:   * the PRIME SUFFIX on a symbol -- `db'`, `tags'`, `ring'`.  A `'` closing
+#:     a symbol is part of that symbol, not a reader macro, so `(do tags'
+#:     (deftest t ...))` must keep its deftest.  Measured 2026-07-26: 352 such
+#:     runs across `.clj`/`.cljc`/`.cljs`, every one of them nested inside a
+#:     binding vector where the walk cannot see it, so the universe is the same
+#:     1694 files either way -- a latent false GREEN, not a live one.
+#:
+#: Both are handled by the same lookbehind, which rejects a quote preceded by
+#: any symbol constituent (a `\` among them) while still allowing one preceded
+#: by another prefix in the run (`''(...)`).
 #:
 #: BOUND: a run consumes ONE following form.  `#_#_ (a) (b)` discards two, and
 #: only `(a)` is seen as data here.  There is no such run in the tree (measured
 #: 2026-07-26: two `#_`-prefixed forms in all of `.clj`/`.cljc`/`.cljs`, no
 #: multi-discard anywhere), and a run that consumes a non-delimited form
 #: (`#_ignored (deftest ...)`) is already exact, because the run only matches
-#: when a delimiter follows it.
-NON_EXECUTABLE_PREFIX = re.compile(r"(?<!\\)(?:(?:#_|['`])\s*)+(?:#\?@?)?(?=[(\[{])")
+#: when a delimiter follows it -- METADATA is the one non-delimited form it may
+#: cross, because metadata is not the form the run consumes, it is part of it.
+#:
+#: BOUND: a metadata MAP is read to its first `}`, as `NS_FORM` reads one, so a
+#: nested map (`^{:a {:b 1}}`) does not match and its form stays executable --
+#: the reporting direction, and there is no such spelling in the tree.
+NON_EXECUTABLE_PREFIX = re.compile(
+    r"(?:(?:#_|(?<![\\\w*+!?<>=/.-])['`])\s*)+"
+    r"(?:\^(?:\{[^{}]*\}|[^\s()\[\]{}]+)\s*)*"
+    r"(?:#\?@?)?(?=[(\[{])"
+)
 
 #: `(ns name)`, tolerating any number of metadata prefixes (`^{:doc ...}`,
 #: `^:no-doc`).  Anchored at column 0: an `ns` form is never nested.
@@ -874,6 +895,12 @@ GREEN_FILES = {
     "implementation/core/test/app/quote_helper.clj":
         "(ns app.quote-helper)\n'(deftest quoted (is true))\n"
         "`(deftest syntax-quoted (is true))\n",
+    # ... and the same two shapes wearing a metadata reader prefix, which is
+    # part of the form the run consumes rather than a form of its own.  Neither
+    # is evaluated, so reading either as a test file fires B1 here too.
+    "implementation/core/test/app/meta_helper.clj":
+        "(ns app.meta-helper)\n'^:doc (deftest quoted-with-meta (is true))\n"
+        '#_^{:doc "dead"} (deftest discarded-with-meta (is true))\n',
 }
 
 
@@ -964,6 +991,22 @@ def run_self_test() -> int:
     files["implementation/core/test/app/char_quote_helper.cljc"] = (
         "(ns app.char-quote-helper)\n(do \\' (deftest t (is true)))\n")
     case("B1 still sees a deftest after a `\\'` character literal",
+         expect="B1 orphan", files=files)
+
+    # The other quote lookalike: a PRIME-SUFFIXED symbol.  The `'` closing
+    # `tags'` belongs to the symbol, so the deftest after it is evaluated.
+    files = dict(GREEN_FILES)
+    files["implementation/core/test/app/prime_symbol_helper.cljc"] = (
+        "(ns app.prime-symbol-helper)\n(do\n  tags'\n  (deftest t (is true)))\n")
+    case("B1 still sees a deftest after a prime-suffixed SYMBOL",
+         expect="B1 orphan", files=files)
+
+    # ... and metadata alone is not a discard: `^:doc (deftest ...)` with no
+    # quote or `#_` in front of it is evaluated, metadata and all.
+    files = dict(GREEN_FILES)
+    files["implementation/core/test/app/meta_live_helper.cljc"] = (
+        "(ns app.meta-live-helper)\n^:doc (deftest t (is true))\n")
+    case("B1 still sees a deftest carrying METADATA",
          expect="B1 orphan", files=files)
 
     files = dict(GREEN_FILES)

--- a/scripts/check_thrown_error_messages.py
+++ b/scripts/check_thrown_error_messages.py
@@ -673,8 +673,7 @@ def _crossing_is_transparent(masked: str, open_idx: int, offset: int, sym: str) 
         return True  # a vector / map / set literal binds nothing
     # A reader conditional (`#?(:clj …)` / `#?@(…)`) is a branch selector, not a
     # binder; its head is a platform keyword, so it needs saying explicitly.
-    if masked[max(0, open_idx - 2):open_idx].endswith("#?") or \
-       masked[max(0, open_idx - 3):open_idx].endswith("#?@"):
+    if masked[max(0, open_idx - 3):open_idx].endswith(("#?", "#?@")):
         return True
     m = _FORM_HEAD_RE.match(masked, open_idx)
     if not m:


### PR DESCRIPTION
Follow-up to #7062, which merged an earlier SHA of this branch while the last two commits were still being pushed. **rf2-u3otj landed in full** — verified by blob hash, not by ancestry: `origin/main:scripts/check_thrown_error_messages.py` is `5397a03f`, identical to my first commit, and both new fixtures are present (`4acc3abf`, `2574f41f`). **rf2-4hc9p did not land** — `origin/main:scripts/check_test_lane_bijection.py` is `ba4a7150`, the pre-repair blob. This PR carries the two missing commits, rebased onto `c4abe9a207`; the two blobs came through the rebase byte-identical (`9001b3a2`, `cef28a59`).

Nothing in the merged half is revisited.

## rf2-4hc9p — the non-executable prefix could not cross metadata

**FOUND (the audit's residual).** `NON_EXECUTABLE_PREFIX` required the quote/discard run to reach the opening delimiter directly, so the metadata reader prefix put a discarded or quoted form back into the executable universe. Reproduced on main: `'^:doc (deftest data (is true))` and `#_^:doc (deftest dead (is true))` both give `top_level_heads` `[ns, deftest]` and `defines_tests` **True**, while the unprefixed quoted control correctly gives False. Metadata is not the form the run consumes — it is part of it — so the run may cross it.

**FOUND (a second lookalike, while measuring the first).** The same regex read a PRIME-SUFFIXED symbol as a quote. The `'` closing `db'` / `tags'` / `ring'` is part of the symbol, but the run took it for a reader macro and marked the next delimiter as data, making the whole subtree unreachable. **352 occurrences** across `.clj`/`.cljc`/`.cljs`. This is the class the existing `\'` character-literal lookbehind already exists for, so it is that same guard finishing its job rather than a second mechanism — and it is a false GREEN (a live suite silently leaving the universe), the expensive direction. Every one of the 352 is nested inside a binding vector where the walk cannot see it, so it is latent, not live: the universe is **1694 files of 2850 tracked Clojure files either way**, under the old pattern, under metadata-only, and under the shipped pattern, with an empty symmetric difference. One lookbehind now rejects a quote preceded by any symbol constituent (the backslash among them) while still allowing `''(…)`.

**CHANGED.** One clause added to the prefix for metadata, one lookbehind moved onto the quote alternative — one walk, one model of what "not executed" means. `top_level_heads`, the stack, lane discovery, the derived generator-macro roster, B1–B5 and the no-exemption-roster posture are untouched.

**BOUNDS, re-measured and preserved.** A 15-shape matrix run against the shipped recogniser: quote / discard / syntax-quote and their metadata forms are data; live `^:doc (deftest …)` (metadata with no run in front of it), the `\'` character literal, the prime-suffixed symbol, the discarded SYMBOL, the plain reader conditional, `#_#?(:clj …)`, the one-form multi-discard bound (`#_#_ (a) (deftest …)` still defines a test), and a nested metadata map (`^{:a {:b 1}}`, read to its first `}`, so it stays executable — the reporting direction) all behave as documented. **Zero mismatches.**

## rf2-u3otj — the refusal still holds, and nothing widened

The coordinator asked for this explicitly, and it is the right thing to ask of a scope-resolution change. **The shipped scope proof only ever REMOVES a suppression; it cannot add one.** `_message_is_conformant` is untouched, so the set of forms a resolved binding may be is exactly what it was — the change adds a way for the resolution to FAIL (return `None`), never a new way for it to succeed. A lone symbol between the brackets is still not a token, and the shape it would have licensed is still reported.

Re-derived on this base, against the merged checker itself, the four computed / parameter-supplied discriminator sites all still report:

```
builder-bypass-message: tools/mcp-base/src/re_frame/mcp_base/diff_encode.cljc:308
builder-bypass-message: tools/story/src/re_frame/story/plan.cljc:150
builder-bypass-message: tools/story/src/re_frame/story/registrar.cljc:324
builder-bypass-message: tools/story/src/re_frame/story/registrar.cljc:401
```

and the whole `--scan-dir tools` findings list — 33 entries — diffs **byte-identical** against the checker as it stands on `origin/main`. The only file change this PR makes to that gate is the one-line style fold below; the detector is bit-for-bit the merged one.

The audit's own witness and all eight binder families still fire on this base: `shadow_witness.cljc` 1 finding, `binders.cljc` 8 findings, against 0 and 0 before the merged repair.

## The style commit

`cb46c59dc7` folds the reader-conditional prefix test from a backslash line-continuation into a single `endswith(("#?", "#?@"))`. Same two prefixes, same result; it is in this PR only because it was in the tail that #7062 missed.

## Mutation proofs

Every plant was confirmed applied by `git diff --stat` **and** by grepping its marker token back out of the file BEFORE any verdict was read. This is not ceremony: **plant C below did not apply on its first attempt** (a line-continuation backslash in the anchor), and the self-test came back `rc=0` — indistinguishable from "the gate missed it" had the anchor assertion not fired first.

### rf2-4hc9p (`check_test_lane_bijection.py --self-test`)

| plant | applied | verdict |
|---|---|---|
| **D** — the metadata clause removed (the pre-repair prefix) | `1 insertion(+), 1 deletion(-)`; `199: r""  # PLANT_D_METADATA_CLAUSE_OFF` | rc=1, **`A green tree reports no failure`** → `B1 orphan test file: implementation/core/test/app/meta_helper.clj` — that guard only |
| **E** — the prime-suffix lookbehind reverted to guarding only `\` | `1 insertion(+), 1 deletion(-)`; `198: … # PLANT_E_PRIME_LOOKBEHIND_OFF` | rc=1, **`B1 still sees a deftest after a prime-suffixed SYMBOL`** — that guard only |
| **F** — the metadata clause accepts any bare token, not only a `^` form | `1 insertion(+), 1 deletion(-)`; `199: … # PLANT_F_ANY_TOKEN` | rc=1, **`B1 still sees a deftest after a discarded SYMBOL`** — that guard only |

Plant D was re-run after the rebase and reddens identically; E and F were run against blob `cef28a59`, which is the blob this PR ships (the rebase changed nothing in the file).

The two new metadata fixtures ride the green tree beside the existing prose / discard / quote helpers, so they are inverted proofs: reading either as a test file fires B1 on the green case, which is exactly what plant D demonstrates. Both new controls (`prime-suffixed SYMBOL`, `carrying METADATA`) are ordinary mutation cases in the same style as the `\'` character-literal control.

### rf2-u3otj (`check_thrown_error_messages.py --self-test`) — for the record; this half is already on main

| plant | applied | verdict |
|---|---|---|
| **A** — `_scope_is_provable` returns True unconditionally (the pre-repair resolver) | `1 insertion(+), 5 deletions(-)`; `697: return True  # PLANT_A_SCOPE_PROOF_OFF` | rc=1, **`positive/bypass_let_bound_shadowed.cljc` expected 9, got 0** — that guard only |
| **B** — vector binders always transparent (the `_mentions_symbol` check off) | `1 insertion(+), 4 deletions(-)`; `686: return True  # PLANT_B_VECTOR_MENTION_OFF` | rc=1, **same fixture, expected 9, got 4** — that guard only. The four survivors (`catch`, `letfn`, `as->`, arity list) are caught by the unrecognised-head arm instead, which is the fail-closed rule doing its own job |
| **C** — reader-conditional transparency off | `1 insertion(+), 1 deletion(-)`; `676: if False:  # PLANT_C_READER_CONDITIONAL_OFF` | rc=1, **`negative/bypass_let_bound_guarded.cljc` expected 0, got 2** — that guard only (plus its `main()`-level counterpart, the same fixture directory seen through the CLI) |

**Which layer the new cases enter at.** The `rf2-u3otj` fixture cases call `scan()`, which is the right layer because the defect is in the detector; the argument-handling layer that hid the `--scan-dir` hole keeps its own separate `_run_cli_self_tests`, and plant C reddens that too. The `rf2-4hc9p` cases go through `check()` over a built temp repo, so they enter above lane discovery.

## Quality gates

All run from the worktree on base `c4abe9a207`; `rc` captured immediately into a worktree-local log and cross-checked against each log's own verdict line. **These Python gates are silent on success — `rc` IS the verdict**, so no PASS line is invented for them.

| gate | rc | what it produced |
|---|---|---|
| `check_test_lane_bijection.py --self-test` (main's checker) | **0** | `self-test: PASS (17 cases)` |
| `check_test_lane_bijection.py --self-test` (this PR) | **0** | `self-test: PASS (19 cases)` — +`prime-suffixed SYMBOL`, +`carrying METADATA` |
| `check_test_lane_bijection.py` (bare) | **0** | `PASS test-lane bijection: 1665 test-defining files, 44 lanes` |
| `check_test_lane_bijection.py --repo-root .` | **0** | identical verdict line |
| `check_thrown_error_messages.py --self-test -v` | **0** | `all 24 fixture self-tests passed` + 4 CLI cases |
| `check_thrown_error_messages.py` (bare, default roster) | **0** | 0 findings, empty log |
| `check_thrown_error_messages.py --scan-dir implementation` | **0** | 0 findings, empty log |
| `check_thrown_error_messages.py --scan-dir tools` | **1** | **33 findings**, list diffed **byte-identical** against main's own checker. The rc=1 is the pre-existing, ruled-out-of-roster `tools/` state (rf2-eo2y5), not a regression |
| `scripts/test-fast-pr.sh` | **1** | environment, not a test outcome — see below |

**Whole-tree file/lane figure for rf2-4hc9p — BEFORE 1665 test-defining files / 44 lanes, AFTER 1665 test-defining files / 44 lanes.** Both derived on this same base `c4abe9a207`, the "before" by running `git show c4abe9a207:scripts/check_test_lane_bijection.py` against the identical tree. Identical is the check that matters: a walker change that silently drops real suites looks exactly like one that fixes false ones. The independent measure over all 2850 tracked Clojure files agrees at 1694 either way.

On the lane count: **44 is correct as of this base.** PR #7063 adds a per-tool `:machines-viz-node-test` build and takes it to **45** — that is #7063's lane, not a lane appearing or vanishing here. The file count stays 1665 across both.

**`scripts/test-fast-pr.sh` rc=1 is a fresh-worktree environment condition, not a failure of this change.** Every stage passed — including both gates this branch touches (`thrown-error message gate` self-test + scan, `test-lane bijection` self-test 19/19 + the 1665/44 scan) and `JVM implementation/core` at **2122 tests / 10475 assertions, 0 failures, 0 errors** — until `CLJS node integration`, which stopped on:

```
'shadow-cljs' is not recognized as an internal or external command
```

`implementation/node_modules` does not exist in this worktree, and the standing rule is not to junction to the mayor tree. The tell is the one the outage notes describe: a real failure names a deftest and an assertion; this names neither — the shell is saying the program is absent. CI, which installs, owns that stage.

One more instance of the same class worth recording: the background wrapper that ran this spine reported **exit code 0** while the script's own captured `rc=1` sat in the log. The log's `rc=` line, written by the script itself, is the verdict; the wrapper's code is not. Both figures above were read off the log.
