### PR TITLE
fix(machines-viz,resources,epoch): declare the two deps machines-viz src requires; retire the five-vs-six resource-scope counts (rf2-3d5u3, rf2-ruiga)

### DIFF
--- a/implementation/epoch/test/re_frame/epoch_egress_resource_trace_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_egress_resource_trace_test.clj
@@ -885,8 +885,8 @@
                (pr-str (frequencies (map :operation frameless))))))))
 
 ;; ===========================================================================
-;; (rf2-1zc33) the FREE `:scope` tag on the FIVE rows the sibling
-;; `:rf.resource/scope-resolved` projector never touches.
+;; (rf2-1zc33) the FREE `:scope` tag on the rows the sibling
+;; `:rf.resource/scope-resolved` projector never touches — rostered below.
 ;; ===========================================================================
 ;;
 ;; `trace-egress/sibling-owned-slot` passed `:scope` through VERBATIM, justified
@@ -896,15 +896,19 @@
 ;; `(= :rf.resource/scope-resolved (:operation ev))` — ONE operation — while the
 ;; family projector that consults `sibling-owned-slot` runs on EVERY
 ;; `:rf.resource/*` / `:rf.mutation/*` / `:rf.warning/resource-*` row
-;; (`resource-family-op?` is operation-agnostic). So on five OTHER row types the
-;; resolved concrete scope — `[:rf.scope/session {:username …}]`, tier keyword
-;; plus IDENTITY MAP — was classified by NOBODY and egressed raw:
+;; (`resource-family-op?` is operation-agnostic). So on every OTHER row type
+;; that stamps one, the resolved concrete scope — `[:rf.scope/session
+;; {:username …}]`, tier keyword plus IDENTITY MAP — was classified by NOBODY
+;; and egressed raw. ONE OPERATION PER LINE, deliberately: this roster used to
+;; pack the two `:rf.mutation/*` rows onto a shared line, and every prose count
+;; taken off it read the LINES rather than the operations (rf2-ruiga).
 ;;
 ;;   :rf.resource/invalidated                       (events.cljc:1811)
 ;;   :rf.resource/refetch-decision                  (events.cljc:1828)
 ;;   :rf.resource/removed                           (events.cljc:2069)
 ;;   :rf.warning/resource-clear-scope-unresolved    (events.cljc:2138)
-;;   :rf.mutation/started + …/optimistic-applied    (mutation_events.cljc:1390, 1403)
+;;   :rf.mutation/started                           (mutation_events.cljc:1403)
+;;   :rf.mutation/optimistic-applied                (mutation_events.cljc:1390)
 ;;
 ;; `:rf.resource/refetch-decision` is the sharpest case: it carries the SAME
 ;; scope TWICE — correctly redacted inside `:resource/key`, raw under `:scope`.
@@ -922,9 +926,10 @@
 ;;                                                 substituted; unchanged.
 
 (def ^:private session-scope
-  "A resolved CONCRETE scope as the five rows below carry it — the tier keyword
-  plus the resolver's IDENTITY MAP. The map is what EP-0025 made unconditionally
-  fail-closed on the scope-resolved row, and what leaked on these five."
+  "A resolved CONCRETE scope as the rows rostered above carry it — the tier
+  keyword plus the resolver's IDENTITY MAP. The map is what EP-0025 made
+  unconditionally fail-closed on the scope-resolved row, and what leaked on
+  every rostered row."
   [:rf.scope/session {:username secret}])
 
 (def ^:private other-session-scope
@@ -1256,8 +1261,9 @@
 
 (deftest trusted-local-include-sensitive-keeps-raw-free-scope
   (testing "rf2-1zc33 — the trusted-local `:include-sensitive?` opt-in keeps the
-            raw free `:scope` tag across all five row types (the local-raw
-            boundary — the tokenization is the off-box default, not a strip)"
+            raw free `:scope` tag on every rostered row type, one of each driven
+            below (the local-raw boundary — the tokenization is the off-box
+            default, not a strip)"
     (let [record    (record-with
                       [(event :rf.resource/invalidated
                               {:rf.frame/id :test/rt :scope session-scope})

--- a/implementation/epoch/test/re_frame/epoch_mcp_egress_conformance_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_mcp_egress_conformance_test.clj
@@ -378,8 +378,10 @@
 ;;     `:rf.resource/scope-resolved` projector had already classified it. The
 ;;     epoch tool-pair applies that sibling under `(= :rf.resource/scope-resolved
 ;;     (:operation ev))` — ONE operation — while this family projector runs on
-;;     every row, so on five OTHER row types `:scope` was classified by nobody
-;;     and a `{:from-db …}` resolver's identity map egressed raw. The cascade
+;;     every row, so on every OTHER row type that stamps a free `:scope` it was
+;;     classified by nobody and a `{:from-db …}` resolver's identity map
+;;     egressed raw (`trace-egress/sibling-owned-slot`'s docstring is the
+;;     roster of those row types). The cascade
 ;;     could not see it twice over (rf2-0t7o8): it drove only `ensure` /
 ;;     `release-owner`, none of which stamps a free `:scope`, and both its
 ;;     resources were `:rf.scope/global` — a SCALAR, the value that correctly
@@ -541,7 +543,8 @@
   by the epoch tool-pair under `(= :rf.resource/scope-resolved (:operation ev))`
   — ONE operation — while the family projector runs on all of them, so a
   pass-through here classified `:scope` by nobody and the resolver's identity
-  map egressed raw (rf2-1zc33, five row types). One dispatch resolves its scope
+  map egressed raw (rf2-1zc33; `trace-egress/sibling-owned-slot`'s docstring
+  rosters the row types it happened on). One dispatch resolves its scope
   through the named resolver (the identity-bearing `[tier {identity}]` TUPLE,
   the shape that leaked); the other names `:rf.scope/global` (a SCALAR, the
   shape that must still ride verbatim). Same slot, same row type, two shapes —

--- a/implementation/resources/src/re_frame/resources/trace_egress.cljc
+++ b/implementation/resources/src/re_frame/resources/trace_egress.cljc
@@ -208,14 +208,15 @@
   holds on exactly ONE row: the epoch tool-pair applies the sibling under
   `(= :rf.resource/scope-resolved (:operation ev))`, while THIS projector runs on
   every `:rf.resource/*` / `:rf.mutation/*` / `:rf.warning/resource-*` row
-  (`resource-family-op?` is operation-agnostic). Five other row types carry a
-  resolved CONCRETE scope under a free `:scope` tag — `:rf.resource/invalidated`
-  / `refetch-decision` / `removed`, `:rf.warning/resource-clear-scope-unresolved`
-  and `:rf.mutation/started` + `optimistic-applied` — and on those the sibling
-  never ran, so a pass-through here meant `:scope` was classified by NOBODY and
-  the resolver's IDENTITY MAP (`[:rf.scope/session {:username …}]`) egressed
-  off-box raw. `:rf.resource/refetch-decision` carried the same scope TWICE:
-  redacted inside `:resource/key`, raw under `:scope`.
+  (`resource-family-op?` is operation-agnostic). This docstring is the ROSTER of
+  the other row types that stamp a resolved CONCRETE scope under a free `:scope`
+  tag — `:rf.resource/invalidated`, `:rf.resource/refetch-decision`,
+  `:rf.resource/removed`, `:rf.warning/resource-clear-scope-unresolved`,
+  `:rf.mutation/started` and `:rf.mutation/optimistic-applied`. The sibling never
+  ran on any of them, so a pass-through here meant `:scope` was classified by
+  NOBODY and the resolver's IDENTITY MAP (`[:rf.scope/session {:username …}]`)
+  egressed off-box raw. `:rf.resource/refetch-decision` carried the same scope
+  TWICE: redacted inside `:resource/key`, raw under `:scope`.
 
   `:scope` now falls to the SHAPE-driven default below, which is right per shape
   without a row predicate: `:rf.scope/global` is a scalar and rides verbatim (no
@@ -667,9 +668,10 @@
                 ;; unconditionally fail-closed), so re-tokenizing here is a no-op
                 ;; at best and double-work at worst. `:scope` is deliberately NOT
                 ;; here (rf2-1zc33) — the sibling runs on ONE operation and this
-                ;; projector runs on the whole family, so a pass-through left
-                ;; five row types' resolved scopes classified by nobody. See the
-                ;; `sibling-owned-slot` docstring.
+                ;; projector runs on the whole family, so a pass-through left the
+                ;; resolved scope classified by nobody on every OTHER row type
+                ;; that stamps one. The `sibling-owned-slot` docstring rosters
+                ;; them.
                 (sibling-owned-slot k)
                 (assoc m k v)
 
@@ -746,18 +748,16 @@
   unregistered fail-closed), riding verbatim for a plain feed (no
   over-redaction).
 
-  The free `:scope` tag — the RESOLVED CONCRETE scope the family stamps on
-  `:rf.resource/invalidated` / `refetch-decision` / `removed`,
-  `:rf.warning/resource-clear-scope-unresolved` and `:rf.mutation/started` +
-  `optimistic-applied` — also takes the shape default (rf2-1zc33). It is NOT
-  sibling-owned: the `:rf.resource/scope-resolved` projector the epoch tool-pair
-  runs first is applied on that ONE operation, so on these five rows a
-  pass-through left the resolver's identity map classified by nobody. Under the
-  shape default `:rf.scope/global` rides verbatim, and a
-  `[:rf.scope/session {…}]` tuple keeps its TIER keyword while the identity map
-  tokenizes — so `:rf.resource/refetch-decision`, which carries one scope under
-  BOTH `:resource/key` and `:scope`, can no longer redact and leak the same
-  value side by side.
+  The free `:scope` tag — the RESOLVED CONCRETE scope the family stamps on the
+  row types `sibling-owned-slot`'s docstring rosters — also takes the shape
+  default (rf2-1zc33). It is NOT sibling-owned: the `:rf.resource/scope-resolved`
+  projector the epoch tool-pair runs first is applied on that ONE operation, so
+  on every rostered row a pass-through left the resolver's identity map
+  classified by nobody. Under the shape default `:rf.scope/global` rides
+  verbatim, and a `[:rf.scope/session {…}]` tuple keeps its TIER keyword while
+  the identity map tokenizes — so `:rf.resource/refetch-decision`, which carries
+  one scope under BOTH `:resource/key` and `:scope`, can no longer redact and
+  leak the same value side by side.
 
   Nested-map slots (`:patch-summary` / `:invalidation`) are projected
   RECURSIVELY through the same vocabulary so a row's nested scoped keys never

--- a/tools/machines-viz/deps.edn
+++ b/tools/machines-viz/deps.edn
@@ -49,14 +49,34 @@
          reagent/reagent {:mvn/version "2.0.1"}
 
          ;; `viewer.cljs` requires `re-frame.adapter.reagent` and passes it to
-         ;; `rf/init!` — the standalone viewer page must have a live substrate
-         ;; adapter before it mounts a Reagent chart. Stock `reagent/reagent`
-         ;; above is NOT that namespace; the adapter ships as its own artefact
-         ;; (rf2-3d5u3). Undeclared, the viewer namespace dies at LOAD:
-         ;; "The required namespace re-frame.adapter.reagent is not available".
-         ;; Marginal cost is this artefact's source only — core and stock
-         ;; Reagent, its whole dependency set, are already declared above.
-         day8/re-frame2-reagent {:local/root "../../implementation/adapters/reagent"}
+         ;; `rf/init!`, and that dep is DELIBERATELY NOT DECLARED HERE
+         ;; (rf2-3d5u3 → rf2-k7l2o). Undeclared, the viewer namespace dies at
+         ;; LOAD for a consumer — "The required namespace
+         ;; re-frame.adapter.reagent is not available" — so this is a real
+         ;; defect, but `day8/re-frame2-reagent` is the wrong repair and a hard
+         ;; dep here would be worse than the hole:
+         ;;
+         ;;   - `day8/reagent-slim` publishes ITS adapter at the same canonical
+         ;;     `re-frame.adapter.reagent` ns (release.yml renames
+         ;;     `reagent_slim.cljs` → `reagent.cljs` before clein packages), and
+         ;;     release.yml states downstream apps depend on EXACTLY ONE of
+         ;;     {day8/re-frame2-reagent, day8/reagent-slim} so the adapter ns is
+         ;;     single-source per app. A hard dep here puts BOTH on a slim app's
+         ;;     classpath — one bound to `reagent.*`, one to `reagent2.*` — and
+         ;;     classpath order silently picks the substrate. In-tree the slim ns
+         ;;     is still `reagent_slim`, so the monorepo build cannot see it.
+         ;;   - It would not reach the published pom anyway.
+         ;;     `release-machines-viz.yml` rewrites exactly ONE `:local/root`
+         ;;     path (`../../implementation/core`) and `clein pom` SILENTLY SKIPS
+         ;;     `:local/root` coordinates, so a second in-repo coordinate is
+         ;;     dropped from the pom without a word. `ssr-ring` is today's only
+         ;;     leaf with two, and it needs a second rewrite call to work.
+         ;;
+         ;; The shape that resolves it: `viewer.cljs` is a PAGE entry
+         ;; (`^:export run`, mounted by `public/viewer.html`), not library
+         ;; surface — picking a substrate adapter is an application's job, and
+         ;; this jar is a library. Moving the page out of the packaged `src`
+         ;; takes the require with it. That is a packaging change; see the bead.
 
          ;; `adapters/uix.cljs` requires `uix.core` for `defui` / `$`
          ;; (rf2-3d5u3). Undeclared, that namespace dies at LOAD the same way.

--- a/tools/machines-viz/deps.edn
+++ b/tools/machines-viz/deps.edn
@@ -46,7 +46,44 @@
          ;; requires reagent.* must declare it. This is dev-only: the whole
          ;; machines-viz jar is bundle-isolated, so a consumer's production
          ;; bundle never pulls Reagent through it.
-         reagent/reagent {:mvn/version "2.0.1"}}
+         reagent/reagent {:mvn/version "2.0.1"}
+
+         ;; `viewer.cljs` requires `re-frame.adapter.reagent` and passes it to
+         ;; `rf/init!` — the standalone viewer page must have a live substrate
+         ;; adapter before it mounts a Reagent chart. Stock `reagent/reagent`
+         ;; above is NOT that namespace; the adapter ships as its own artefact
+         ;; (rf2-3d5u3). Undeclared, the viewer namespace dies at LOAD:
+         ;; "The required namespace re-frame.adapter.reagent is not available".
+         ;; Marginal cost is this artefact's source only — core and stock
+         ;; Reagent, its whole dependency set, are already declared above.
+         day8/re-frame2-reagent {:local/root "../../implementation/adapters/reagent"}
+
+         ;; `adapters/uix.cljs` requires `uix.core` for `defui` / `$`
+         ;; (rf2-3d5u3). Undeclared, that namespace dies at LOAD the same way.
+         ;;
+         ;; This is a HARD dep rather than a `:provided` / optional posture,
+         ;; and the reasoning is the rf2-nucj0 one (see implementation/http/
+         ;; deps.edn): no artefact in this repo uses `:provided`, `provided`
+         ;; says a CONTAINER supplies the dependency, and a CLJS app has none —
+         ;; it would just be asking every UIx host to redeclare a dep the
+         ;; artefact's own source requires. `implementation/adapters/uix`
+         ;; declares `com.pitch/uix.core` the same way for the same reason.
+         ;;
+         ;; What a Reagent-only consumer pays, measured against a resolved
+         ;; classpath: 6 jars / 526.5 KiB, of which jsoup (436 KiB, via
+         ;; hickory via preo) is UIx's dev-time prop tooling. NONE of it
+         ;; reaches a bundle — machines-viz is dev-only and bundle-isolated,
+         ;; and CLJS only compiles namespaces something requires, so a
+         ;; Reagent-only host never even compiles `adapters/uix.cljs`.
+         ;;
+         ;; The way to make that cost zero is to NARROW what src requires, not
+         ;; to weaken the scope: `adapters/react-chart` is already substrate-
+         ;; agnostic and its `chart-element` returns a plain React element a
+         ;; UIx host can mount with `$` directly, so the 40-line `defui` shell
+         ;; is ergonomics rather than capability. Retiring it is an API change
+         ;; (spec/API.md §MachineChart), so it is not this dep declaration's
+         ;; call to make.
+         com.pitch/uix.core {:mvn/version "1.4.4"}}
 
  :aliases
  {:test {:extra-paths ["test"]


### PR DESCRIPTION
Two beads, different surfaces. One real fix, one measured refusal, and a docs cluster closed whole.

## rf2-3d5u3 — `tools/machines-viz` under-declares two deps its own `src` requires

### Simulated consumer: the failure, before and after

A throwaway project whose **only** dependency is the published coordinate
(`day8/re-frame2-machines-viz` via `:local/root`, i.e. exactly the graph the release
workflow rewrites to `:mvn/version`), plus shadow-cljs and one entry namespace per
target ns. No repo `:source-paths`, no `implementation/shadow-cljs.edn`
`:dependencies`, no borrowed classpath.

**BEFORE — both halves fail**

```
$ clojure -M -m shadow.cljs.devtools.cli compile sim-uix
[:sim-uix] Compiling ...
The required namespace "uix.core" is not available, it was required by
  "day8/re_frame2_machines_viz/adapters/uix.cljs".
rc=1

$ clojure -M -m shadow.cljs.devtools.cli compile sim-viewer
[:sim-viewer] Compiling ...
The required namespace "re-frame.adapter.reagent" is not available, it was required by
  "day8/re_frame2_machines_viz/viewer.cljs".
rc=1
```

Both fail at **namespace load**, not at first use — same shape as rf2-nucj0's
`FileNotFoundException`, because the `:require` forms are unconditional.

**AFTER — uix fixed, viewer knowingly held**

```
$ clojure -M -m shadow.cljs.devtools.cli compile sim-uix
[:sim-uix] Build completed. (110 files, 109 compiled, 0 warnings, 13.15s)
rc=0

$ clojure -M -m shadow.cljs.devtools.cli compile sim-viewer
The required namespace "re-frame.adapter.reagent" is not available, it was required by
  "day8/re_frame2_machines_viz/viewer.cljs".
rc=1     ← unchanged, deliberately; see the refusal below (rf2-k7l2o)
```

Verdict confirmed against the artefact rather than the exit code: `out/uix.js` carries
`machines_viz.adapters.uix` **and** `uix.core`, so the build genuinely analysed and
emitted the namespace that previously could not resolve.

### Found vs changed

**Found.** Both failures are real published-artefact defects, exactly as the bead
describes. Three things the bead did not say:

- The two halves have **very different costs**, measured by diffing two resolved
  classpaths:
  - `com.pitch/uix.core` adds **6 jars / 526.5 KiB** — jsoup 436 KiB, uix.core 48 KiB,
    hickory 32 KiB, cljs-bean 15 KiB, quoin 3.7 KiB, preo 2.4 KiB. 83% of that is an
    HTML-parsing tree (jsoup ← hickory ← preo, UIx's dev-time prop tooling) nothing in
    this artefact touches.
  - `day8/re-frame2-reagent` adds **zero new jars** — its whole dependency set is
    already declared here. Which made it look like the free half. It is not.
- **The reagent half is a ruling, not a repair** — two independent measured reasons,
  below.
- **No sibling artefact has the same shape.** Swept every tracked `.cljs`/`.cljc` that
  `:require`s `uix.core`: only `implementation/adapters/uix` (declares it), the
  examples and template (declare it), and this file. The `uix.core` hits in
  `implementation/core/src/re_frame/substrate/spine.cljs` are **prose in comments**,
  not requires.

**Changed.** `com.pitch/uix.core` declared in `:deps`. The reagent coordinate is
**not** added; a comment records why, so the next audit does not re-file it.

### `uix.core` → real dep, not `:provided`

The optional-adapter concern is real: a Reagent-only consumer pays 526.5 KiB for a
namespace they will never require (CLJS compiles only what something requires, so they
never even compile `adapters/uix.cljs`). It is still the wrong lever, for rf2-nucj0's
reason recorded one artefact over in `implementation/http/deps.edn`: `provided` says a
**container** supplies the dependency, and a CLJS app has none — it would just ask
every UIx host to redeclare a dep this artefact's own source requires. No artefact in
this repo uses `:provided`; `implementation/adapters/uix` declares `com.pitch/uix.core`
outright for the same reason. And none of the 526.5 KiB reaches a bundle: machines-viz
is dev-only and bundle-isolated by contract, which is the artefact's own stated
rationale for the hard `reagent/reagent` dep it already carries. The coordinate is
already `:mvn/version`, so `clein pom` emits it and the published pom is fixed too.

The lever that would make the cost **zero** is the bead's other option — narrow what
`src` requires — and it is recorded in the comment rather than taken here:
`adapters/react-chart` is already substrate-agnostic and its `chart-element` returns a
plain React element a UIx host can mount with `$` directly, so the 40-line `defui`
shell is ergonomics rather than capability. Retiring it is an API change
(`spec/API.md` §MachineChart), not a dep declaration's call.

### `re-frame.adapter.reagent` → refused, and why the obvious repair is worse than the hole

Filed as **rf2-k7l2o** (P2, discovered-from rf2-3d5u3) with the full evidence.

1. **Adapter-ns collision for slim apps.** `day8/reagent-slim` publishes *its* adapter
   at the same canonical `re-frame.adapter.reagent` ns — `release.yml`'s "Rename
   adapter ns at publication (reagent-slim only)" step `mv`s `reagent_slim.cljs` →
   `reagent.cljs` and rewrites the `(ns …)` form before clein packages. `release.yml`
   states outright that downstream apps depend on **exactly one** of
   `{day8/re-frame2-reagent, day8/reagent-slim}` so the adapter ns is single-source per
   app. A hard dep here puts **both** on a slim app's classpath — one bound to
   `reagent.*`, one to `reagent2.*` — and classpath order silently decides which the
   app's own `(:require [re-frame.adapter.reagent])` resolves to. **In-tree the slim ns
   is still `reagent_slim`, so the monorepo build can never surface this** — the same
   masking mechanism this bead is about, one layer over.
   (Stock `reagent/reagent`, already a dep here, does *not* collide: slim ships its
   Reagent as `reagent2.*`.)

2. **It would not reach the published pom anyway.** `clein pom` **silently skips**
   `:local/root` coordinates (rf2-do3m2 / #6340) — which is why every leaf rewrites
   `:local/root` → `:mvn/version` first. `release-machines-viz.yml` calls
   `rewrite-local-root-coord.sh` **once**, for `../../implementation/core`. A second
   in-repo coordinate is never rewritten and is dropped from the pom without a word.
   `ssr-ring` is today's only leaf with two, and it needs a second call
   (`matrix.extra-local-root`, `release.yml:738-739`) to work. So the hard dep buys
   **nothing published** while introducing (1) for source consumers.
   `.github/workflows/**` is fenced to a live lane worker, so the second call was not
   attempted.

**The shape that resolves it**, recorded on the bead: `viewer.cljs` is a **page** entry
(`^:export run`, mounted by `public/viewer.html`), not library surface. Choosing a
substrate adapter is an *application's* job and this jar is a library — core is
deliberately adapter-free for exactly this reason. Moving the page out of the packaged
`:src-dirs` takes the require with it and needs no dep at all. That is a packaging +
`spec/API.md` §Read-only viewer change, hence a ruling.

Net effect on the published artefact: strictly better, never worse. The pom gains
`com.pitch/uix.core`; the reagent gap is unchanged and now named, evidenced and owned.

## rf2-ruiga — the six-versus-five count cluster

### Found vs changed

**Found.** Nine active sites, **all re-derived from current `main`** (`d1e2db74ee`) —
and the bead's line numbers were stale for **two** files, not the one it warned about:

| bead said | actually at | file |
|---|---|---|
| `:205` / `:521` / `:604` | **`:211` / `:671` / `:754`** | `trace_egress.cljc` |
| `:886` / `:897` / `:923` / `:1257` | **`:888` / `:899` / `:925`+`:927` / `:1259`** | `epoch_egress_resource_trace_test.clj` |
| `:381` / `:537`→`:544` | `:381` / `:544` (as the note said) | `epoch_mcp_egress_conformance_test.clj` |

`:925` and `:927` are two counts in one docstring, so the four "sites" in the resource
trace test are five wrong counts. Nine in total.

**The roster of six is correct and complete** — verified, not assumed. Enumerated every
`trace/emit!` in `implementation/resources/src` whose tag map carries a bare `:scope`
key, then read each candidate: exactly six, plus `:rf.resource/scope-resolved` which
the sibling projector owns. Thirteen further greps matched and were all false positives
— `:descriptor-scope`, `:sub-scope`, `:mutation-scope`, or a `:scope` in the `:fx`
vector *below* the emit. One genuine nuance surfaced: `:rf.resource/removed` has **two**
emit sites and only `events.cljc:2068` stamps `:scope`.

**A root cause, not just nine symptoms.** The roster comment listed six operations on
**five lines** — `:rf.mutation/started + …/optimistic-applied` shared one. Every wrong
count in the cluster is a count of that roster's *lines*, and the two ops were even
listed in prose order against file-order line refs. It is now one operation per line,
each with its own ref, and a one-clause note saying why.

**Changed.** All nine. **No count was swapped for a larger count.**

### Per site: members, or authority

| site | what it now names |
|---|---|
| `trace_egress.cljc:211` (`sibling-owned-slot` docstring) | **Members.** Promoted to *the* roster — all six named, no numeral. Every other site points here. |
| `trace_egress.cljc:671` (cond comment) | **Authority** — "every OTHER row type that stamps one. The `sibling-owned-slot` docstring rosters them." |
| `trace_egress.cljc:754` (`project-tags-egress` docstring) | **Authority** — "the row types `sibling-owned-slot`'s docstring rosters"; the duplicated inline list is gone. |
| `epoch_egress_resource_trace_test.clj:888` (§ header) | **Authority** — "rostered below". |
| `:899` (§ prose) | **Authority** — "every OTHER row type that stamps one", followed by the roster. |
| `:906`–`:911` (the roster itself) | **Members**, one operation per line. |
| `:925` / `:927` (`session-scope` docstring) | **Authority** ×2 — "the rows rostered above", "every rostered row". |
| `:1259` (`testing` string) | **Authority** — "every rostered row type, one of each driven below". |
| `epoch_mcp_egress_conformance_test.clj:381` | **Authority** — "`trace-egress/sibling-owned-slot`'s docstring is the roster of those row types". |
| `:544` | **Authority** — same, as a parenthetical. |

### The two counts deliberately left alone

Both are dispatch counts, both sit in a docstring **directly above the forms they
count**, and both were re-measured true:

- `:218`, `drive-mixed-ring!` — "Five cascades against this suite's
  `:trace-events-keep 5`". Body dispatches `:seed :login :upload :inc :read-subs` = 5.
  **Different subject** from this cluster (cascades, not resource row types), and true.
- `:577`–`:578`, `drive-resource-family!` — "this cascade is five dispatches, so its
  family rows are spread across five records". Body dispatches two `ensure`, one
  `release-owner`, two `invalidate-tags` = 5. This is the count rf2-uozi8 measured true
  and left; independently re-measured here, same verdict.

A count adjacent to its subject cannot drift silently. Both stay.
`record-carrying-resource-rows`'s parenthetical at `:639` already reads "spread across
as many records as it dispatches" — rf2-uozi8's rewrite, on main, untouched.

### Subject check

Every rewritten sentence was checked for what it *claims*, not just its arithmetic. All
nine had the right subject under the wrong count — "row types carrying a resolved
concrete scope under a free `:scope` tag" is correct at every site. No mis-attributed
subject of the kind rf2-uozi8 found in its own cluster.

### Fence

`trace_egress.cljc` is **comment- and docstring-only** — three hunks, zero code forms
touched, cleanly separable from the live P1 privacy work on that file. `spec/009` not
touched (PR #7050 correctly kept the bad count out of it). Nothing under
`scripts/check_*`, `.github/workflows/**`, `tools/*/shadow-cljs.edn`.

## Quality gates

All foreground to completion. `rc=$?` captured immediately into a worktree-local log
and cross-checked against each log's own verdict line. No exit code that is not a test
outcome; no backgrounded gate.

| gate | tests / assertions | fail / error | rc |
|---|---|---|---|
| `implementation/epoch` | 501 / 6711 | 0 / 0 | 0 |
| `implementation/resources` | 733 / 6799 | 0 / 0 | 0 |
| `implementation/core` | 2122 / 10475 | 0 / 0 | 0 |
| `tools/machines-viz` | 632 / 2537 | 0 / 0 | 0 |
| simulated consumer `sim-uix` | compile | 0 warnings | 0 |
| simulated consumer `sim-viewer` | compile | known hole (rf2-k7l2o) | 1 |

Epoch, resources and core hit the quoted baselines exactly (501/6711, 733/6799,
2122/10475).

**`tools/machines-viz` is 632/2537, not the quoted 821/3214** — and that is not a
regression. A/B measured: `clojure -M:test` on this branch gives 632/2537, and with
`HEAD~1`'s pristine `deps.edn` checked back in it gives **632/2537 as well**, both
rc=0. The change is count-neutral; the quoted baseline is a different lane (the JVM
`:test` alias is all that exists on `main` — the per-tool CLJS lane that would add the
rest is PR #7063, unmerged).
