### PR TITLE
fix(resources,epoch): prove the foreign FX carrier speaks only for what the resource runtime planted (rf2-1kiuj, rf2-5o52l, rf2-0t7o8)

### DIFF
--- a/implementation/epoch/test/re_frame/epoch_egress_resource_trace_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_egress_resource_trace_test.clj
@@ -1974,3 +1974,193 @@
              (:rf.fx/args (:tags (first (:trace-events projected)))))
           "and so does the rest of the event vector it sits in"))))
 
+
+;; ---------------------------------------------------------------------------
+;; (5) THE CARRIER'S OTHER EDGE — over-classification (rf2-1kiuj, reopened)
+;; ---------------------------------------------------------------------------
+;;
+;; Sections (1)-(4) and their rf2-425mm / rf2-xx4ty siblings above all push in
+;; ONE direction: does the family's datum still egress raw? Three merged repairs
+;; answered yes and each shipped the same second-order defect on the way — the
+;; carrier arm fired on a LOCAL CUE that ordinary FX data hits by coincidence,
+;; and destroyed app-owned data off-box while stamping the row `:sensitive?`.
+;;
+;;   - rf2-1kiuj — `scoped-key-shape?` alone: ANY `[<x> <keyword> <map>]`
+;;     3-vector took the fail-closed unregistered-owner arm.
+;;     `[:opaque :app/not-a-resource {:account-id 42}]` came back
+;;     `[{:rf/redacted …} :app/not-a-resource {:rf/redacted …}]`.
+;;   - rf2-425mm — the `:scope` KEY alone, at arbitrary depth. An app's own
+;;     `{:request {… :scope {:tenant "alice"} …}}` had that map tokenized.
+;;   - rf2-xx4ty — a map-local `:resource/key` alone as the "this is a read
+;;     reply" test. Foreign `:value` / `:params` sitting beside a genuine
+;;     sensitive key were tokenized with it.
+;;
+;; The repair is one idea applied three times: each arm now fires on PROOF that
+;; the resource RUNTIME planted the value — its reserved keyword namespace, its
+;; `[:rf.work/resource …]` work-id head, the canonical `:rf.reply/work-kind
+;; :resource` marker, or the resource registry answering "is this one of mine?".
+;; Recognition changed; the GRAIN did not — the free `:scope` still fails closed
+;; unconditionally once recognised, and `:value` / `:params` are still
+;; owner-conditional, so the two carriers of one datum still agree for a plain
+;; owner. Each deftest below therefore carries both halves: the foreign value
+;; rides verbatim AND the runtime's own still redacts, on the same shape.
+
+(deftest fx-carrier-leaves-foreign-lookalike-vectors-verbatim
+  (testing "rf2-1kiuj — scoped-key SHAPE is necessary and not sufficient inside
+            a FOREIGN carrier. A 3-vector whose position 1 names no registered
+            resource is application data and rides byte-for-byte; the row is not
+            stamped. The two proofs that DO make a 3-vector the family's are
+            asserted beside it, so this cannot be satisfied by disabling the arm."
+    (let [foreign   [:opaque :app/not-a-resource {:account-id 42}]
+          app-event [:app/save :user {:name "alice"}]
+          sensitive (sk :rf.scope/global :secret/article {:auth-token secret})
+          gone      [:rf.scope/global :cleared/article {:auth-token secret}]
+          record    (record-with
+                      [(event :rf.fx/handled
+                              {:rf.frame/id :test/rt :frame :test/rt
+                               :rf.fx/id :app/custom
+                               :rf.fx/args {:rows [foreign] :dispatch app-event}})
+                       ;; the REGISTRY proof: a registered owner's key in a slot
+                       ;; the family never named still projects.
+                       (event :rf.fx/handled
+                              {:rf.frame/id :test/rt :frame :test/rt
+                               :rf.fx/id :app/audit
+                               :rf.fx/args {:app/anything [sensitive]}})
+                       ;; the NAMED proof: an UNREGISTERED key the runtime itself
+                       ;; named still FAILS CLOSED (a `clear-resource` / hot
+                       ;; reload leaves genuine keys in captured records).
+                       (event :rf.fx/handled
+                              {:rf.frame/id :test/rt :frame :test/rt
+                               :rf.fx/id :rf.resource/cancel-timers
+                               :rf.fx/args {:frame-id :test/rt
+                                            :resource/keys [gone]}})])
+          projected (epoch/projected-record record)
+          [custom audit cancel] (:trace-events projected)]
+      (testing "the foreign lookalikes ride verbatim"
+        (is (= foreign (first (:rows (:rf.fx/args (:tags custom)))))
+            "an app 3-vector with an unregistered keyword at position 1")
+        (is (= app-event (:dispatch (:rf.fx/args (:tags custom))))
+            "and an ordinary 3-element event vector, which has the same shape")
+        (is (not (:sensitive? (:tags custom)))
+            "so the row is NOT stamped :sensitive? — a tool reading this row
+             would otherwise believe it had seen a resource"))
+      (testing "the REGISTRY proof: a registered owner's key projects from a
+                slot no family name reaches"
+        (let [[pscope rid pparams] (first (:app/anything (:rf.fx/args (:tags audit))))]
+          (is (= :secret/article rid) "the resource-id survives for attribution")
+          (is (redacted-component? pscope))
+          (is (redacted-component? pparams))
+          (is (true? (:sensitive? (:tags audit))))))
+      (testing "the NAMED proof: an unregistered key under a `resource`-namespaced
+                key still fails closed"
+        (let [[pscope rid pparams] (first (:resource/keys (:rf.fx/args (:tags cancel))))]
+          (is (= :cleared/article rid))
+          (is (redacted-component? pscope) "scope redacted though the owner is gone")
+          (is (redacted-component? pparams))
+          (is (true? (:sensitive? (:tags cancel))))))
+      (is (= [] (secret-leak-paths projected))
+          "and no raw secret survives anywhere in the record"))))
+
+(deftest fx-carrier-leaves-app-owned-scope-maps-verbatim
+  (testing "rf2-425mm — a `:scope` ENTRY is the family's only inside a payload
+            the runtime BUILT. An app's own `:scope` — an ordinary English word
+            the FX family uses for its own data — rides verbatim; the runtime's
+            read continuation payload and its MUTATION execute payload (which
+            carries a free `:scope` with NO `:resource/key` beside it, the case
+            rf2-425mm ruled must not be gated on a sibling key) both still fail
+            closed."
+    (let [app-scope {:tenant "alice"}
+          key1      (sk session-scope :derived/profile {:slug "me"})
+          read-args {:on-success [:rf.resource.internal/succeeded
+                                  {:work/id      [:rf.work/resource key1 1]
+                                   :resource/key key1
+                                   :scope        session-scope
+                                   :generation   1}]}
+          mut-args  {:on-success [:rf.mutation.internal/succeeded
+                                  {:instance-id :m/save-1
+                                   :mutation-id :m/save
+                                   :work/id     [:rf.work/resource
+                                                 [:rf.mutation :m/save-1] 3]
+                                   :scope       session-scope
+                                   :generation  3}]}
+          app-row*  (event :rf.fx/handled
+                           {:rf.frame/id :test/rt :frame :test/rt
+                            :rf.fx/id :rf.http/managed
+                            :rf.fx/args {:request {:method :post
+                                                   :scope  app-scope
+                                                   :body   {:x 1}}}})
+          read-row* (event :rf.fx/handled
+                           {:rf.frame/id :test/rt :frame :test/rt
+                            :rf.fx/id :rf.http/managed :rf.fx/args read-args})
+          mut-row*  (event :rf.fx/handled
+                           {:rf.frame/id :test/rt :frame :test/rt
+                            :rf.fx/id :rf.http/managed :rf.fx/args mut-args})
+          project1  (fn [row] (epoch/projected-record (record-with [row])))]
+      (testing "the app's own request map is untouched"
+        (let [tags (:tags (first (:trace-events (project1 app-row*))))]
+          (is (= {:method :post :scope app-scope :body {:x 1}} (:request (:rf.fx/args tags)))
+              "byte-for-byte, :scope map included")
+          (is (not (:sensitive? tags))
+              "and the row is NOT stamped :sensitive?")))
+      (testing "the READ continuation payload's :scope still fails closed"
+        (is (= [session-scope] (carrier-scopes (record-with [read-row*])))
+            "FIXTURE — the raw payload carries the resolver's identity map")
+        (let [projected (project1 read-row*)]
+          (is (every? tokenized-scope? (carrier-scopes projected))
+              "tier keyword verbatim, identity map tokenized")
+          (is (true? (:sensitive? (:tags (first (:trace-events projected))))))))
+      (testing "and so does the MUTATION execute payload's, which has no
+                :resource/key to gate on — the work-id is what proves it"
+        (is (= [session-scope] (carrier-scopes (record-with [mut-row*])))
+            "FIXTURE — the raw mutation payload carries it too")
+        (let [projected (project1 mut-row*)]
+          (is (every? tokenized-scope? (carrier-scopes projected))
+              "gating on a sibling key here would have fixed reads and left
+               mutations leaking")
+          (is (true? (:sensitive? (:tags (first (:trace-events projected))))))))
+      (is (= [] (mapcat secret-leak-paths
+                        (map project1 [app-row* read-row* mut-row*])))
+          "no raw identity survives anywhere in any of the three records"))))
+
+(deftest fx-carrier-reply-payload-needs-the-canonical-reply-marker
+  (testing "rf2-xx4ty — `:value` / `:params` are the family's only inside a
+            CANONICAL read reply (`:rf.reply/work-kind :resource`, the marker
+            every reply the read-continuation substrate builds carries). A
+            sibling `:resource/key` says WHOSE the data would be, not that these
+            two ordinary words are the family's at all — so an app map carrying
+            a genuine sensitive key beside its own `:value` / `:params` keeps
+            them, while the key one slot over still tokenizes."
+    (let [key1      (sk session-scope :derived/profile reply-params)
+          unmarked  {:resource/key key1
+                     :value        {:public true}
+                     :params       {:format :csv}}
+          marked    (read-reply key1 session-scope reply-value)
+          record    (record-with
+                      [(event :rf.fx/handled
+                              {:rf.frame/id :test/rt :frame :test/rt
+                               :rf.fx/id :app/custom :rf.fx/args unmarked})
+                       (event :rf.fx/handled
+                              {:rf.frame/id :test/rt :frame :test/rt
+                               :rf.fx/id :dispatch
+                               :rf.fx/args (conj read-reply-target marked)})])
+          projected (epoch/projected-record record)
+          [custom reply-row] (:trace-events projected)
+          proj-un   (:rf.fx/args (:tags custom))]
+      (testing "the UNMARKED map: the key tokenizes, its foreign neighbours do not"
+        (is (= {:public true} (:value proj-un))
+            "the app's :value rides verbatim")
+        (is (= {:format :csv} (:params proj-un))
+            "and so do the app's :params")
+        (is (redacted-component? (first (:resource/key proj-un)))
+            "while the genuine sensitive key beside them still tokenizes")
+        (is (= :derived/profile (second (:resource/key proj-un)))
+            "with its resource-id intact")
+        (is (true? (:sensitive? (:tags custom)))
+            "the row IS stamped — a key redacted on it"))
+      (testing "the MARKED reply still tokenizes both slots"
+        (let [r (first (carrier-replies projected))]
+          (is (redacted-component? (:value r)))
+          (is (redacted-component? (:params r)))
+          (is (true? (:sensitive? (:tags reply-row))))))
+      (is (= [] (secret-leak-paths projected))
+          "and nothing raw survives anywhere in the record"))))

--- a/implementation/resources/src/re_frame/resources/ssr.cljc
+++ b/implementation/resources/src/re_frame/resources/ssr.cljc
@@ -987,6 +987,19 @@
              ;; projects through the resource owner classification instead. Same
              ;; move the refetch-plan below already makes (`(:resource/key
              ;; entry)`), and the reason `:entries` and these two diverge.
+             ;;
+             ;; Both accumulators are SEQUENCES, and that is load-bearing rather
+             ;; than incidental (rf2-5o52l audit of #7018). Resource identity is
+             ;; the CEDN `key-id`, which is collection-KIND sensitive
+             ;; (rf2-wgutc2): params `{:xs [1 2 3]}` and `{:xs '(1 2 3)}` are two
+             ;; distinct entries with two distinct key-ids, and yet their scoped
+             ;; keys are `=` to Clojure. A scoped-key-KEYED accumulator therefore
+             ;; silently collapses them and one live entry's diagnostic
+             ;; disappears — `:skews` was such a map and did exactly that. A
+             ;; sequence has no key to collide on: `reduce-kv` visits each
+             ;; key-id once, so one entry in is one member out, and the scoped
+             ;; key rides in the VALUE where it is emitted rather than in a
+             ;; position where it decides identity.
              reconciled (reduce-kv
                           (fn [acc k entry]
                             (let [[entry' dropped] (reconcile-entry-owners
@@ -997,8 +1010,8 @@
                               (-> acc
                                   (assoc-in [:entries k] entry'')
                                   (update :orphaned into (map (fn [o] [sk o])) dropped)
-                                  (cond-> skew (update :skews assoc sk skew)))))
-                          {:entries {} :orphaned [] :skews {}}
+                                  (cond-> skew (update :skews conj [sk skew])))))
+                          {:entries {} :orphaned [] :skews []}
                           entries)
              entries'  (:entries reconciled)
              ;; recompute the reverse indexes from the reconciled entries
@@ -1009,7 +1022,13 @@
                       {:rf.frame/id    frame-id
                        :installed      (count entries')
                        :orphaned-owners (vec (:orphaned reconciled))
-                       :clock-skews    (:skews reconciled)})
+                       ;; a VECTOR of `[<scoped-key> <skew-ms>]` pairs, the same
+                       ;; shape `:orphaned-owners` beside it carries — see the
+                       ;; accumulator note above for why it cannot be a map
+                       ;; keyed by the scoped key. The off-box shape default
+                       ;; walks it per member, so each key projects through its
+                       ;; own owner and per-key joins survive.
+                       :clock-skews    (vec (:skews reconciled))})
          (doseq [[sk skew] (:skews reconciled)]
            (trace/emit! :warning :rf.resource/hydrate-clock-skew
                         {:rf.frame/id  frame-id
@@ -1446,7 +1465,8 @@
              ;; key-id is a reversible plaintext CEDN-1 encoding the off-box
              ;; projector can only read as an opaque scalar. Restore reconciles a
              ;; LIVE (never wire-projected) snapshot, so its key-ids carry the
-             ;; raw scope + params.
+             ;; raw scope + params. Both accumulators are SEQUENCES for the
+             ;; kind-collision reason the hydrate twin states in full.
              reconciled (reduce-kv
                           (fn [acc k entry]
                             (let [[entry' dropped] (reconcile-entry-owners entry route-owner-policy)
@@ -1456,8 +1476,8 @@
                               (-> acc
                                   (assoc-in [:entries k] entry'')
                                   (update :orphaned into (map (fn [o] [sk o])) dropped)
-                                  (cond-> skew (update :skews assoc sk skew)))))
-                          {:entries {} :orphaned [] :skews {}}
+                                  (cond-> skew (update :skews conj [sk skew])))))
+                          {:entries {} :orphaned [] :skews []}
                           entries)
              entries'  (:entries reconciled)
              subtree'  (state/recompute-indexes
@@ -1514,7 +1534,10 @@
                                  ;; EP-0019 Q3 — the optimistic keys a dangled
                                  ;; optimistic write rolled back INSIDE this pass.
                                  :rolled-back-mutation-keys (vec rolled-mutation-keys)
-                                 :clock-skews       (:skews reconciled)}}]
+                                 ;; a VECTOR of `[<scoped-key> <skew-ms>]` pairs
+                                 ;; — the hydrate twin's shape, and for the same
+                                 ;; kind-collision reason.
+                                 :clock-skews       (vec (:skews reconciled))}}]
                        cat
                        [;; per-owner row for every STALE-NAV route owner released
                         ;; as an orphan (Spec 016 §Restore and replay part 4:

--- a/implementation/resources/src/re_frame/resources/trace_egress.cljc
+++ b/implementation/resources/src/re_frame/resources/trace_egress.cljc
@@ -89,6 +89,7 @@
   carries beside its `:resource/key`, tokenized through that key's OWNER exactly
   as the load-more cursor is through its row's."
   (:require [re-frame.resources.registry :as registry]
+            [re-frame.resources.reply :as resources-reply]
             [re-frame.resources.ssr :as ssr]))
 
 #?(:clj (set! *warn-on-reflection* true))
@@ -397,6 +398,115 @@
 
     :else [v false]))
 
+(def ^:private work-id-marker
+  "The reserved head keyword of a resource WORK-ID vector —
+  `[:rf.work/resource <scoped-key-or-mutation-id> <generation>]`
+  (`work_ledger/resource-work-id`; a mutation attempt reuses the head and
+  carries `[:rf.mutation <instance-id>]` at position 1). The runtime writes it
+  into every carrier payload it plants, so it is the family's own signature on
+  a foreign row — read as such by `carrier-family-value?` below, and by
+  `tooling`/`derivation.egress`'s work-id readers for the same reason."
+  :rf.work/resource)
+
+(defn- family-work-id?
+  "Whether `v` is a resource work-id vector — a vector headed by
+  `work-id-marker`. Position 1 of such a vector is family-planted BY
+  CONSTRUCTION, whatever its shape."
+  [v]
+  (and (vector? v) (= work-id-marker (first v))))
+
+(defn- family-named-key?
+  "Whether map key `k` is a name the resource runtime RESERVED for one of its
+  scoped keys: anything in the family's own `resource` keyword namespace
+  (`:resource/key`, `:resource/keys`, …) — a NAMESPACE read, per Conventions
+  §Reserved namespaces, so a name added next year is covered — plus
+  `:rf.reply/resource-key`, the spelling the shared REPLY ENVELOPE uses inside
+  a completion's `:correlation` facts (`resources.reply`), which lives in the
+  reply namespace rather than the family's.
+
+  This is a FIDELITY arm, not the line of defence, and the distinction is worth
+  keeping straight (the same one `scoped-keys-slot` makes above). A key here is
+  projected whatever the registry says, which is what keeps the fail-closed
+  unregistered-owner arm reachable inside a carrier. Every key of a REGISTERED
+  owner is already covered by `carrier-family-value?`'s registry proof without
+  appearing here, so a spelling nobody has added costs nothing except
+  fail-closed-ness for an owner that no longer exists."
+  [k]
+  (and (keyword? k)
+       (or (= "resource" (namespace k))
+           (= :rf.reply/resource-key k))))
+
+(defn- carrier-family-payload?
+  "Whether MAP `m` inside a FOREIGN carrier is a payload the resource RUNTIME
+  planted — proved by the family's own reserved vocabulary appearing among its
+  immediate entries: a `resource`-namespaced key, or a value that is a
+  `[:rf.work/resource …]` work-id.
+
+  This is what the free `:scope` arm reads (rf2-1kiuj audit #7054). All THREE
+  payloads the runtime plants a `:scope` in satisfy it, by three different
+  markers, and no two of them share one:
+
+    - the READ continuation (`transport.http/build-managed-args`) —
+      `{:work/id <work-id> :resource/key <key> :scope <scope> …}`;
+    - the MUTATION execute reply-payload — `{:instance-id … :work/id <work-id>
+      :scope <scope> …}`, with NO resource key at all, which is exactly why the
+      work-id is a marker and the key alone is not (rf2-425mm settled that
+      mutations must not be left leaking);
+    - a completion reply's `:correlation` facts (`resources.reply`) —
+      `{:scope <scope> :generation … :rf.reply/resource-key <key>}`, whose only
+      marker is that reserved reply spelling.
+
+  An app's own `{:request {… :scope {:tenant \"…\"} …}}` carries none of them,
+  so its `:scope` — an ordinary English word the FX family uses for its own
+  data — is nobody's business here and rides verbatim."
+  [m]
+  (boolean (some (fn [[k v]] (or (family-named-key? k) (family-work-id? v))) m)))
+
+(defn- resource-reply?
+  "Whether MAP `m` is a canonical resource READ-COMPLETION reply, by its own
+  marker (`resources.reply/work-kind-resource`, stamped on every reply the
+  read continuation substrate builds — `:rf.reply/work-kind :resource`). The
+  gate on the `reply-payload-slot` arm (rf2-1kiuj audit #7059): a map that
+  merely happens to carry a `:resource/key` beside a `:value` / `:params` is
+  NOT a reply, and the family does not speak for those two words anywhere
+  else. A mutation reply stamps `:mutation` and is deliberately not matched —
+  its payload is redacted at source (`classification/redact-continuation-reply`)."
+  [m]
+  (= resources-reply/work-kind-resource (:rf.reply/work-kind m)))
+
+(defn- carrier-family-value?
+  "Whether a value sitting in a FOREIGN carrier is a resource scoped key the
+  family may speak for. Scoped-key SHAPE is necessary and not sufficient here,
+  and that asymmetry is the whole of rf2-1kiuj's audit #7031.
+
+  On a row the family OWNS, the operation namespace already proves the family
+  emitted every tag on it, so shape alone is safe and
+  `project-unknown-slot-value` reads nothing more (rf2-wd9im). A carrier row is
+  the FX family's, and `[<anything> <keyword> <map>]` is a shape ordinary
+  application data hits constantly — an event vector `[:app/save :user {…}]`
+  has it. Projecting one destroys app data off-box and stamps the row
+  `:sensitive?`, which for the resource tools is as much a defect as the leak.
+
+  So the family must PROVE the key is its own, and there are exactly two
+  proofs, neither of them a roster:
+
+    - `named?` — the value was reached through the family's own reserved
+      vocabulary (a `resource`-namespaced map key, or position 1 of a
+      `[:rf.work/resource …]` work-id). The runtime named the position itself,
+      so whatever sits there is the family's WHATEVER the registry says — which
+      is what keeps the fail-closed arm reachable for a genuine key whose owner
+      was cleared or hot-reloaded away (`project-trace-scoped-key`'s nil-spec
+      arm);
+    - the RESOURCE REGISTRY knows the id. The family's own authority answering
+      \"is this one of mine?\" — positive proof independent of position, so a
+      registered owner's key still projects from a carrier slot nobody has
+      looked at yet.
+
+  A shape match with neither proof is somebody else's data and rides verbatim."
+  [v named?]
+  (and (scoped-key-shape? v)
+       (or named? (some? (registry/resource-meta (nth v 1))))))
+
 (def ^:private fx-carrier-slot
   "Trace tag slots owned by the FX family that the resource family's scoped keys
   RIDE IN (rf2-1kiuj).
@@ -433,12 +543,38 @@
   leak.
 
   So: an already-projected token rides as-is (idempotent, never re-digested); a
-  scoped-key-shaped vector projects through `project-trace-scoped-key` — the SAME
-  owner classification the family rows' own `:resource/key` takes, so the two
-  carriers of one key cannot drift; any other collection is walked through,
-  preserving its KIND (scoped-key identity is kind-sensitive — rf2-wgutc2) and
-  walking a map's KEYS as well as its values (a key can be map-keyed by scoped
-  key); every other scalar rides verbatim.
+  scoped key the family can PROVE is its own (`carrier-family-value?`) projects
+  through `project-trace-scoped-key` — the SAME owner classification the family
+  rows' own `:resource/key` takes, so the two carriers of one key cannot drift;
+  any other collection is walked through, preserving its KIND (scoped-key
+  identity is kind-sensitive — rf2-wgutc2) and walking a map's KEYS as well as
+  its values (a key can be map-keyed by scoped key); every other scalar rides
+  verbatim.
+
+  ## `named?`, and why the carrier needs a proof the family's own rows do not
+
+  The `named?` argument is that proof, threaded down the walk: it is true when
+  the value sits somewhere the family's RESERVED vocabulary put it — under a
+  `resource`-namespaced map key, or at position 1 of a `[:rf.work/resource …]`
+  work-id. It resets at every map entry (each key answers for its own value)
+  and is inherited through sequential collections, which is what carries it
+  from `:resource/keys` to the keys inside.
+
+  Every arm below reads a proof of that kind rather than a local cue, because a
+  local cue is something ordinary FX data hits by coincidence, and three merged
+  repairs each shipped one:
+
+    - a scoped-key SHAPE is not proof a 3-vector is a scoped key
+      (`carrier-family-value?`);
+    - a `:scope` KEY is not proof the map is a runtime continuation payload
+      (`carrier-family-payload?`);
+    - a sibling `:resource/key` is not proof the map is a read reply
+      (`resource-reply?`).
+
+  Each proof is the family's own reserved vocabulary — a reserved keyword
+  namespace, a reserved work-id head, a canonical reply marker, or the resource
+  registry itself. None of them is a slot roster, and none of them has to be
+  kept in step with an emit site.
 
   ## …AND the resolved `:scope` beside them (rf2-425mm)
 
@@ -456,23 +592,27 @@
   just redacted the very same bytes. The rf2-irwsq shape again, now inside a
   single map.
 
-  A value under a `:scope` key is therefore projected by the FAMILY rule
-  (`project-unknown-slot-value`) rather than by the carrier walk, which is what
-  makes the two carriers of one scope agree by construction: `:rf.scope/global`
-  is a SCALAR and rides verbatim, a `[tier {identity}]` tuple keeps its TIER
-  keyword (a tool still reads \"session scope\") while the identity map
-  tokenizes to a content-addressed `{:rf/redacted <digest>}` — distinct scopes
-  keeping distinct digests, so per-scope joins survive — and an unresolved
-  `{:from-db …}` reference tokenizes whole. Exactly what rf2-1zc33 settled for
-  the same slot on the family's OWN rows; this is that ruling reaching the
-  carrier the family projector never runs on.
+  A `:scope` entry OF A RUNTIME CONTINUATION PAYLOAD (`carrier-family-payload?`)
+  is therefore projected by the FAMILY rule (`project-unknown-slot-value`)
+  rather than by the carrier walk, which is what makes the two carriers of one
+  scope agree by construction: `:rf.scope/global` is a SCALAR and rides
+  verbatim, a `[tier {identity}]` tuple keeps its TIER keyword (a tool still
+  reads \"session scope\") while the identity map tokenizes to a
+  content-addressed `{:rf/redacted <digest>}` — distinct scopes keeping distinct
+  digests, so per-scope joins survive — and an unresolved `{:from-db …}`
+  reference tokenizes whole. Exactly what rf2-1zc33 settled for the same slot on
+  the family's OWN rows; this is that ruling reaching the carrier the family
+  projector never runs on.
 
-  `:scope` is the ONE key named here and this is not the beginning of a roster:
-  the arm exists because the resource runtime writes that key into a foreign
-  payload itself, so the family owns the value by construction rather than by a
-  guess about shape (a resolved scope is arbitrary EDN — there is no shape to
-  read). Everything else in the carrier is still the fx family's and still rides
-  through untouched.
+  The PAYLOAD gate is load-bearing and the arm shipped without it. A resolved
+  scope is arbitrary EDN, so there is no shape to read and the arm has to key on
+  the NAME — but `:scope` is an ordinary English word, and an app's own
+  `{:request {:method :post :scope {:tenant \"…\"} …}}` rides these same
+  carriers. Keying on the name ALONE destroyed that map off-box and stamped the
+  row `:sensitive?`. What the family actually owns is the payload the runtime
+  BUILT, and that payload wears the family's reserved vocabulary — a
+  `resource`-namespaced key, or a `[:rf.work/resource …]` work-id. Everything
+  else in the carrier is still the fx family's and still rides through untouched.
 
   ## …AND a read continuation reply's `:value` + `:params` (rf2-xx4ty)
 
@@ -495,12 +635,13 @@
 
   `:scope` is unconditional because the family's own rows classify a free
   `:scope` unconditionally (rf2-1zc33) and the two carriers of one scope must
-  agree; and because it is safe to be — `:scope` inside an fx carrier is a word
-  only the resource runtime writes.
+  agree. Note the grain distinction is about the CLASSIFICATION and not about
+  the recognition: both arms now require the same kind of proof that the family
+  planted the datum, and only then do they differ in how they treat it.
 
-  `:value` and `:params` are neither. They belong to a NAMED owner whose
-  `:resource/key` sits one slot over, and the family's own rows tokenize that
-  owner's params IFF `whole-entry-disposition` is non-`:serialize`, so
+  `:value` and `:params` are owner-conditional. They belong to a NAMED owner
+  whose `:resource/key` sits one slot over, and the family's own rows tokenize
+  that owner's params IFF `whole-entry-disposition` is non-`:serialize`, so
   unconditional tokenization would redact a PLAIN resource's reply — the
   over-redaction rf2-1kiuj rejected, and the reason this walk descends maps at
   all. Worse, `:params` and `:value` are words the FX family uses for its own
@@ -512,12 +653,20 @@
   governs the load-more cursor (rf2-3tysyj) and the same
   `whole-entry-disposition` that governs the key beside it.
 
+  And the owner read is a CLASSIFICATION, not a recognition: a sibling
+  `:resource/key` says whose data it would be, not that these two words are the
+  family's at all. A map carrying a genuine sensitive key beside an app's own
+  `:value` / `:params` satisfied the owner read and had them destroyed
+  (audit #7059). The recognition is the reply's own canonical marker
+  (`resource-reply?` — `:rf.reply/work-kind :resource`, which every reply the
+  read-continuation substrate builds carries and nothing else does).
+
   ### Reads and mutations differ here, and the difference is already handled
 
   The mutation `:reply-to` (`mutation_events/continuation-reply`) is the sibling
-  shape and carries `:params` / `:value` with NO `:resource/key` beside them
-  (its owner is named by `:mutation` / `:instance`), so this arm does not fire
-  on it — deliberately. The mutation half is closed one layer EARLIER, at the
+  shape: it stamps `:rf.reply/work-kind :mutation`, so `resource-reply?` is
+  false and this arm does not fire on it — deliberately. The mutation half is
+  closed one layer EARLIER, at the
   source: both settle sites wrap the reply in
   `classification/redact-continuation-reply`, which redacts the mutation's own
   projection-relative `:sensitive` / `:large` declarations before the reply ever
@@ -530,46 +679,61 @@
   app's own continuation handler is entitled to the decoded body, and the
   trusted-local `:include-sensitive?` opt-in must still show it. So the read
   half belongs exactly here, at the egress projector. Pure."
-  [v frame-id]
+  [v frame-id named?]
   (cond
-    (redacted-token? v)   [v true]
-    (scoped-key-shape? v) (project-trace-scoped-key v frame-id)
+    (redacted-token? v) [v true]
+
+    ;; a scoped key the family can PROVE is its own — see `carrier-family-value?`
+    (carrier-family-value? v named?)
+    (project-trace-scoped-key v frame-id)
 
     (coll? v)
-    (let [sens?* (volatile! false)
-          note!  (fn [s pv] (when s (vreset! sens?* true)) pv)
-          proj   (fn [x]
-                   (let [[pv s] (project-embedded-keys x frame-id)]
-                     (note! s pv)))
-          ;; rf2-xx4ty — a read continuation reply names its resource OWNER in
-          ;; the `:resource/key` one slot over. Read ONCE per map, exactly as
-          ;; `project-tags*` reads it once per row for the cursor; nil (no
-          ;; usable key) means this map is not a reply and its `:params` /
-          ;; `:value` are somebody else's.
-          owner-redacts? (and (map? v) (row-owner-redacts? v frame-id))
-          ;; the family's own resolved scope, planted in a foreign payload by
-          ;; the runtime — projected by the FAMILY rule so the carrier cannot
-          ;; drift from the row (rf2-425mm). Every other entry takes the walk.
-          entry  (fn [k x]
-                   (cond
-                     (= :scope k)
-                     (let [[pv s] (project-unknown-slot-value x frame-id)]
-                       (note! s pv))
+    (let [sens?*   (volatile! false)
+          note!    (fn [s pv] (when s (vreset! sens?* true)) pv)
+          proj     (fn [x named?]
+                     (let [[pv s] (project-embedded-keys x frame-id named?)]
+                       (note! s pv)))
+          ;; position 1 of a `[:rf.work/resource …]` vector is family-planted by
+          ;; construction, so the key there is NAMED however unregistered its
+          ;; resource-id has become.
+          work-id? (family-work-id? v)
+          ;; rf2-425mm — the family's own resolved scope, planted in a foreign
+          ;; payload by the runtime, projected by the FAMILY rule so the carrier
+          ;; cannot drift from the row. Gated on the payload being provably the
+          ;; runtime's (audit #7054): `:scope` is a word apps use too.
+          payload? (and (map? v) (carrier-family-payload? v))
+          ;; rf2-xx4ty — a read continuation reply's `:value` / `:params`, read
+          ;; through the owner its own `:resource/key` names (ONCE per map,
+          ;; exactly as `project-tags*` reads it once per row for the cursor).
+          ;; Gated on the canonical reply MARKER (audit #7059), not on the mere
+          ;; presence of a sibling key.
+          owner-redacts? (and (map? v)
+                              (resource-reply? v)
+                              (row-owner-redacts? v frame-id))
+          entry    (fn [k x]
+                     (cond
+                       (and payload? (= :scope k))
+                       (let [[pv s] (project-unknown-slot-value x frame-id)]
+                         (note! s pv))
 
-                     ;; the owner's own reply data (rf2-xx4ty) — tokenized
-                     ;; content-addressed iff THIS map's owner redacts, so a
-                     ;; plain resource's reply stays fully readable. Idempotent
-                     ;; (an opaque token stays sensitive and is not re-digested).
-                     (and owner-redacts? (reply-payload-slot k) (some? x))
-                     (note! true (if (redacted-token? x) x (ssr/redact-value x)))
+                       ;; the owner's own reply data — tokenized
+                       ;; content-addressed iff THIS reply's owner redacts, so a
+                       ;; plain resource's reply stays fully readable. Idempotent
+                       ;; (an opaque token stays sensitive and is not re-digested).
+                       (and owner-redacts? (reply-payload-slot k) (some? x))
+                       (note! true (if (redacted-token? x) x (ssr/redact-value x)))
 
-                     :else (proj x)))]
+                       ;; every other entry takes the walk, NAMED iff the family
+                       ;; reserved the key it sits under.
+                       :else (proj x (family-named-key? k))))]
       [(cond
-         (map? v)    (reduce-kv (fn [m k x] (assoc m (proj k) (entry k x))) {} v)
-         (set? v)    (into #{} (map proj) v)
-         (vector? v) (mapv proj v)
-         (seq? v)    (apply list (map proj v))
-         :else       (mapv proj v))
+         (map? v)    (reduce-kv (fn [m k x] (assoc m (proj k named?) (entry k x))) {} v)
+         (set? v)    (into #{} (map #(proj % named?)) v)
+         (vector? v) (if work-id?
+                       (into [] (map-indexed (fn [i x] (proj x (or named? (= 1 i))))) v)
+                       (mapv #(proj % named?) v))
+         (seq? v)    (apply list (map #(proj % named?) v))
+         :else       (mapv #(proj % named?) v))
        @sens?*])
 
     :else [v false]))
@@ -788,17 +952,24 @@
   rf2-irwsq shape: the structured `:effects[*].args` slot read `:rf/redacted`
   while the `:rf.fx/args` TAG three rows above it carried the secret in the clear.
 
-  Given a row's `tags` + the `frame-id`, walks `:rf.fx/args` / `:rf.event/fx` by
-  SHAPE (`project-embedded-keys`) and stamps `:sensitive? true` when a key
-  redacted. Everything else on the row rides UNTOUCHED, whatever its shape: the
-  row belongs to the fx family, and the resource family speaks only for the data
-  it planted there — its scoped keys, and (rf2-425mm) the resolved `:scope` the
+  Given a row's `tags` + the `frame-id`, walks `:rf.fx/args` / `:rf.event/fx`
+  (`project-embedded-keys`) and stamps `:sensitive? true` when a key redacted.
+  Everything else on the row rides UNTOUCHED, whatever its shape: the row
+  belongs to the fx family, and the resource family speaks only for the data it
+  planted there — its scoped keys, and (rf2-425mm) the resolved `:scope` the
   transport continuation payload carries beside them, which is a
   `[tier {identity}]` TUPLE rather than a scoped key and so was descended into
   and let through in the clear one slot from the `:resource/key` that had just
   redacted the same bytes, and (rf2-xx4ty) the `:value` + `:params` a READ
   CONTINUATION reply carries beside its own `:resource/key`, tokenized iff that
   key's OWNER redacts so a plain resource's reply stays readable.
+
+  \"Speaks only for the data it planted\" is enforced, not merely intended:
+  each of those three arms fires on PROOF that the runtime planted the value —
+  the family's reserved keyword namespace, its work-id head, the canonical
+  reply marker, or the resource registry — never on a local cue that ordinary
+  application data hits by coincidence. See `project-embedded-keys` §`named?`.
+
   A tags map carrying NEITHER slot rides through reference-preserved —
   which is what lets the epoch consumer apply this to every row and keep no row
   predicate of its own, so a family key riding a carrier on some future op is
@@ -814,7 +985,9 @@
           tags'  (reduce (fn [m slot]
                            (if-not (contains? m slot)
                              m
-                             (let [[pv s] (project-embedded-keys (get m slot) frame-id)]
+                             ;; `named? false` — the slot root is the FX
+                             ;; family's own value; nothing above it named it.
+                             (let [[pv s] (project-embedded-keys (get m slot) frame-id false)]
                                (when s (vreset! sens?* true))
                                (assoc m slot pv))))
                          tags

--- a/implementation/resources/test/re_frame/resources_trace_keyid_egress_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_trace_keyid_egress_cljs_test.cljc
@@ -105,7 +105,15 @@
   (rf/reg-resource :plain/article
     {:scope         :rf.scope/global
      :params-schema [:map [:slug :string]]}
-    (fn [_p _ctx] {:request {:method :get :url "/public"}})))
+    (fn [_p _ctx] {:request {:method :get :url "/public"}}))
+  ;; a `:sensitive?` owner whose params admit a SEQUENTIAL value, so §6 can
+  ;; build two entries whose scoped keys are Clojure-`=` and whose CEDN
+  ;; key-ids are not (rf2-wgutc2 — collection kind decides resource identity).
+  (rf/reg-resource :secret/seq
+    {:scope         :rf.scope/global
+     :sensitive?    true
+     :params-schema [:map [:xs [:sequential :string]]]}
+    (fn [_p _ctx] {:request {:method :get :url "/seq"}})))
 
 (use-fixtures :each
   (core-test-support/make-reset-runtime-fixture
@@ -423,5 +431,104 @@
               "the orphaned route owner is paired with its entry's scoped key")
           (is (not (leaks-secret? (project tags))) "no plaintext off-box")
           (is (not (leaks-cedn-token? (project tags)))
-              "no CEDN-1 token off-box — including under :clock-skews, whose
-               MAP shape the projector tokenizes wholesale"))))))
+              "no CEDN-1 token off-box — :clock-skews included"))))))
+
+;; ===========================================================================
+;; 6. THE ACCUMULATOR'S OWN IDENTITY. Naming entries by scoped key was right;
+;;    naming them by scoped key IN A MAP KEY POSITION was not.
+;; ===========================================================================
+;;
+;; Resource identity is the CEDN `key-id`, and it is collection-KIND sensitive
+;; (rf2-wgutc2): params `{:xs ["…"]}` and `{:xs '("…")}` are two DISTINCT
+;; entries under two distinct key-ids. Their scoped keys, however, are `=` to
+;; Clojure, which considers a list and a vector sequentially equal. So the
+;; moment the reconcile's `:skews` accumulator became a scoped-key-KEYED map,
+;; two live entries collapsed into one and one entry's clock-skew diagnostic
+;; vanished — silently, on both the hydrate and the restore path (the audit of
+;; PR #7018 measured exactly one row and one summary member where two entries
+;; went in).
+;;
+;; `:orphaned` never had the defect: it was a SEQUENCE from the start, and a
+;; sequence has no key to collide on. `:skews` is one now, for the same reason,
+;; and the pair below is the proof — it fails if either accumulator ever
+;; acquires a key again.
+
+(def ^:private seq-resource-id :secret/seq)
+
+(defn- seq-key
+  "A scoped key for `:secret/seq` whose secret-bearing params carry `xs` — the
+  collection whose KIND decides identity."
+  [xs]
+  (state/scoped-resource-key :rf.scope/global seq-resource-id {:xs xs}))
+
+(defn- kind-colliding-runtime-db
+  "A runtime-db holding TWO skewed `:sensitive?` entries whose scoped keys are
+  Clojure-`=` and whose key-ids are not: one with VECTOR params, one with LIST
+  params. Both owned by an `[:ssr …]` owner, so both also orphan."
+  []
+  (let [now (interop/epoch-now-ms)
+        ent (fn [sk] {:resource/key   sk
+                      :status         :loaded
+                      :data           {:body "server-rendered"}
+                      :active-owners  #{[:ssr "req-1" "nav-1"]}
+                      :current-work   nil
+                      :generation     1
+                      :loaded-at      (+ now 100000)
+                      :stale-at       (+ now 200000)
+                      :stale-after-ms 100000})]
+    (-> (runtime-db)
+        (assoc-in (state/entry-path (seq-key [secret])) (ent (seq-key [secret])))
+        (assoc-in (state/entry-path (seq-key (list secret)))
+                  (ent (seq-key (list secret)))))))
+
+(deftest reconcile-skew-accumulators-keep-kind-distinct-entries-distinct
+  (testing "rf2-5o52l — the hydrate and restore reconciles must report ONE
+            diagnostic per live ENTRY, and entry identity is the CEDN key-id,
+            not Clojure equality of the scoped key"
+    (let [vk  (seq-key [secret])
+          lk  (seq-key (list secret))
+          rdb (kind-colliding-runtime-db)]
+      (testing "FIXTURE — the collision this pins is real and is not Clojure's
+                idea of equality"
+        (is (= vk lk)
+            "the two scoped keys are `=` — a map keyed on them holds ONE entry")
+        (is (not= (state/key-id vk) (state/key-id lk))
+            "while their CEDN key-ids differ — they are two distinct resources")
+        (is (= 2 (count (:entries (get rdb state/resources-key))))
+            "and the runtime-db really holds both"))
+
+      (doseq [[label reconcile! skew-op summary-op]
+              [["hydrate" #(r-ssr/hydrate-runtime-db % :rf/default)
+                :rf.resource/hydrate-clock-skew :rf.resource/hydrated]
+               ["restore" #(r-ssr/reconcile-on-restore % :rf/default)
+                :rf.resource/restore-clock-skew :rf.resource/restored]]]
+        (testing label
+          (is (= 2 (count (capture-op! skew-op #(reconcile! rdb))))
+              "one per-entry clock-skew row per DISTINCT entry — a
+               scoped-key-keyed accumulator emits one")
+          (let [tags  (:tags (first (capture-op! summary-op #(reconcile! rdb))))
+                skews (:clock-skews tags)]
+            (is (= 2 (count skews))
+                "and two summary members, paired `[<scoped-key> <skew-ms>]`
+                 exactly as :orphaned-owners pairs beside them")
+            (is (= 2 (count (:orphaned-owners tags)))
+                "the sibling accumulator, which never had the defect, still
+                 reports both — so this is not a change in what reconciles")
+            (let [xs (map #(:xs (nth (first %) 2)) skews)]
+              (is (= [1 1] [(count (filter vector? xs)) (count (filter seq? xs))])
+                  "one member carries the VECTOR params and the other the LIST
+                   params, so the surviving entry is not simply reported twice.
+                   Compared by KIND and not by `=`, because `=` is precisely
+                   what cannot tell these two apart — a `#{}` literal of the two
+                   throws Duplicate key"))
+            (testing "and both still egress correctly"
+              (let [proj (:clock-skews (project tags))]
+                (is (every? #(redacted-token? (nth (first %) 2)) proj)
+                    "each member's params tokenize through its own owner")
+                (is (every? #(= seq-resource-id (second (first %))) proj)
+                    "each keeps its resource-id for attribution")
+                (is (= 2 (count (set (map #(nth (first %) 2) proj))))
+                    "and the two digests DIFFER — distinct identities stay
+                     distinct off-box, which a collapsed accumulator cannot show")
+                (is (not (leaks-secret? proj)) "no plaintext off-box")
+                (is (not (leaks-cedn-token? proj)) "no CEDN-1 token off-box")))))))))


### PR DESCRIPTION
Two of three reopened beads on the epoch/resources egress surface. The third —
**rf2-0t7o8**, the MCP conformance fixture's session-scoped `ensure` — was one
commit behind this merge and follows in its own PR; its revert-proofs are
there.

Both reopens here are the same class, and it is worth naming up front:
**the close introduced it**. Neither is a leak that survived a weak close and
neither is a pre-existing residual the close missed. In both cases the original
repair was complete and correct in direction, and the defect is collateral of
the repair itself — which is why reverting either fix reds, and why the new
coverage is on the *other* edge of the arm each fix added.

## rf2-1kiuj (P1) — the foreign FX carrier over-classifies

**Reopen class: the close introduced it — three times, once per sibling fix.**

*Found.* All three audit residuals reproduce verbatim on merged `main`:

```clojure
(project-fx-args-egress {:rf.fx/args [:opaque :app/not-a-resource {:account-id 42}]} :f)
;; => [{:rf/redacted "509eacb6"} :app/not-a-resource {:rf/redacted "78a0513e"}]

(project-fx-args-egress {:rf.fx/args {:request {:method :post :scope {:tenant "alice"}
                                                :body {:x 1}}}} :f)
;; => :scope {:rf/redacted "8667c723"}, row stamped :sensitive?

(project-fx-args-egress {:rf.fx/args {:resource/key <a real sensitive key>
                                      :value {:public true} :params {:format :csv}}} :f)
;; => key tokenized (correct) AND :value/:params tokenized (not)
```

The common shape: on a row the family does **not** own, each arm recognised its
own datum by a LOCAL CUE that ordinary FX data hits by coincidence. The
original 14-path leak is closed and stays closed; this is the other edge.

*Changed.* One idea, applied three times. Each arm now fires on PROOF that the
resource RUNTIME planted the value, threaded down the walk as `named?`:

- a scoped key is the family's when the **registry** knows its resource-id, or
  when the family's own reserved vocabulary named the position — a
  `resource`-namespaced map key, `:rf.reply/resource-key`, or position 1 of a
  `[:rf.work/resource …]` work-id. The registry is the line of defence; the
  name set is the fidelity arm that keeps the fail-closed **unregistered**-owner
  projection reachable inside a carrier (a cleared / hot-reloaded owner), the
  same distinction `scoped-keys-slot` already draws on the family rows;
- a free `:scope` is the family's inside a payload the runtime **built**. All
  three such payloads are covered and no two share a marker: the read
  continuation (`:resource/key` + work-id), the mutation `execute`
  reply-payload (work-id only — **no** `:resource/key`, which is exactly why
  gating on a sibling key would have fixed reads and left mutations leaking,
  per rf2-425mm), and a completion reply's `:correlation` facts
  (`:rf.reply/resource-key` only);
- a reply's `:value` / `:params` are the family's only inside a **canonical**
  reply, by its own `:rf.reply/work-kind :resource` marker.

**The grain is untouched, and deliberately so.** The free `:scope` still fails
closed UNCONDITIONALLY once recognised — matching what rf2-1zc33 gave the same
slot on the family's own rows — while `:value` / `:params` stay
OWNER-CONDITIONAL through `row-owner-redacts?`. Only *recognition* changed, so
the two carriers of one datum still agree for a plain owner and the rf2-irwsq
mirror-image does not open. The docstring now states that distinction where it
was previously implicit: the owner read is a CLASSIFICATION (whose data would
this be), never a RECOGNITION (is it ours at all).

No new slot vocabulary, no second projector, no redaction framework.

*One would-be regression, caught by the existing suite and reported rather than
buried.* The first cut of the tightening used a `resource`-namespace test alone
for the named positions. That missed `:rf.reply/resource-key`, the spelling the
shared reply envelope uses inside `:correlation`, and the existing rf2-xx4ty
producer-driven tests went red on 4 assertions naming
`[… :rf.fx/args 1 :correlation :scope 1 :username]`. Fixed before the first
commit; recorded because it is the exact failure mode this bead family keeps
producing, and this time the gate caught it. **No new pre-existing leak was
found**, so nothing is filed.

*Coverage.* Three new deftests in `epoch_egress_resource_trace_test` §(5), each
carrying BOTH halves on the same shape — the foreign value rides verbatim AND
the runtime's own still redacts — so neither over-redaction nor a disabled arm
can pass. Reverting the repair reds all three: **7 failures at 504 tests / 6755
assertions**, the same counts as green.

## rf2-5o52l (P1) — the SSR reconcile skew accumulators

**Reopen class: the close introduced it.**

*Found.* Carrying `(:resource/key entry)` instead of the reversible CEDN key-id
was the right privacy move and that leak stays closed. But it put the scoped key
in a MAP KEY position. Resource identity is the CEDN `key-id` and it is
collection-KIND sensitive (rf2-wgutc2): params `{:xs [1 2 3]}` and
`{:xs '(1 2 3)}` are two distinct entries with two distinct key-ids, and yet
their scoped keys are `=` to Clojure. Reproduced on the merged code — two such
entries in, **one** `:rf.resource/hydrate-clock-skew` row and **one**
`:clock-skews` member out; same on restore.

Scope confirmed rather than assumed: `:orphaned` was a SEQUENCE from the start
and reported **both** entries in the same run, so the defect is the
accumulator's key and not the reconcile, and `:orphaned-owners` needed nothing.

*Changed.* `:skews` is a sequence now, for that reason: `reduce-kv` visits each
key-id once, so one entry in is one member out, and the scoped key rides in the
VALUE where it is emitted rather than in a position where it decides identity.
`:clock-skews` consequently egresses as a vector of `[<scoped-key> <skew-ms>]`
pairs — the shape `:orphaned-owners` beside it already had — which the off-box
shape default walks per member, so **each key now projects through its own
owner and per-key joins survive** where the map tokenized wholesale. No string
parsing, no projector vocabulary, no framework. `:clock-skews` appears nowhere
in `spec/`, `docs/` or `tools/`, so no spec edit is required and
`spec/009-Instrumentation.md` is untouched.

*Coverage.* One dual-target deftest driving both paths over both
kind-colliding entries: two skew rows, two summary members, the two members
carrying the two DISTINCT params collections (compared by KIND — `=` is
precisely what cannot tell them apart; a `#{}` literal of the two throws
`Duplicate key`), two DIFFERENT digests off-box, and no CEDN token.

## Fence

`spec/009-Instrumentation.md`, `spec/Spec-Schemas.md`, `scripts/check_*`,
`.github/workflows/**` and `tools/*/shadow-cljs.edn` are untouched. In
`trace_egress.cljc` only code and the docstrings of the functions this diff
changes were edited — the six-versus-five `:scope`-roster comment cluster
(`sibling-owned-slot`'s docstring, the `project-tags*` sibling comment, and the
free-`:scope` paragraph of `project-resource-trace-egress`) is byte-identical to
the base, which is what let rf2-ruiga's retirement of those counts land cleanly
on top in `bcf7d291ac`.

## Quality gates

All foreground to completion, `rc` captured immediately into a worktree-local
log and cross-checked against each log's own verdict line.

| gate | result | rc |
|---|---|---|
| `implementation/epoch` `clojure -M:test` | 504 tests / 6741 assertions, 0 failures | 0 |
| `implementation/resources` `clojure -M:test` | 734 tests / 6820 assertions, 0 failures | 0 |
| `implementation/core` `clojure -M:test` | 2122 tests / 10475 assertions, 0 failures | 0 |

Baselines re-derived rather than trusted, and each delta accounted for: epoch
**501 / 6711 → 504 / 6741** is exactly this PR's 3 deftests and 30 assertions;
resources **733 / 6799 → 734 / 6820** is exactly its 1 deftest and 21
assertions; core **2122 / 10475** matches the briefed baseline unchanged, which
is what a diff that cannot reach core's classpath should do.

*(Body written after the merge — the PR was merged while its third commit was
in flight, so the placeholder it carried at merge time is replaced here with
the report the work produced.)*
