### PR TITLE
docs,routing: correct two audit-reopened claims the fixes themselves introduced (rf2-yn5nj, rf2-7g4qn)

### DIFF
--- a/docs/core/freehand/events-and-handlers.md
+++ b/docs/core/freehand/events-and-handlers.md
@@ -362,10 +362,12 @@ What you see when it fails depends on who is calling. Reach the carrier from
 ClojureScript and you get a Freehand error naming the form you wrote, this position,
 and the closure below. Reach it the way a JavaScript library actually does —
 `props.onPing(…)`, a native call on a value that is not a native function — and you
-get the host's own `cb.call is not a function`, because a call JavaScript never
-dispatches is a call nothing can intercept. The carrier is a marker object, not a
-function, and making it one would quietly turn it into a function for everything else
-that asks. Either way it cannot work, which is the part worth knowing.
+get the host's own `TypeError`, worded by the engine after whatever expression it
+tripped on (`props.onPing is not a function`) and naming nothing you wrote, because
+a call JavaScript never routes through the carrier is a call nothing can intercept.
+The carrier is a marker object, not a function, and making it one would quietly turn
+it into a function for everything else that asks. Either way it cannot work, which is
+the part worth knowing.
 
 So a callback there is an ordinary closure, and it closes over
 `(rf/capture-frame)`'s `:dispatch` rather than calling `rf/dispatch`: the render

--- a/implementation/routing/src/re_frame/routing/link.cljc
+++ b/implementation/routing/src/re_frame/routing/link.cljc
@@ -33,8 +33,12 @@
 
   Routing's own `prefetch-intent-attrs` maps over it; the Freehand
   `v/route-link` descriptor reaches it as the `:routing/prefetch-intent-keys`
-  late-bound seam, the same way it already reaches `prefetch-payload` — so no
-  view substrate states the class for itself.
+  late-bound seam, the same way it already reaches `prefetch-payload` — so the
+  durable view substrate no longer states the class for itself. ONE exception
+  remains, and it is explicitly temporary: the donor `re-frame.ui/route-link`
+  still writes the three positions out literally, and that copy goes when the
+  donor arm does (rf2-drpa3.57). Until then a position added here reaches
+  `rf/route-link` and `v/route-link` and misses `ui/route-link`.
 
   Order carries no meaning — the positions are independent, and each warms the
   same destination — but it is stable, so the attrs a render emits are too."
@@ -209,7 +213,7 @@
        ;; Map over the published class rather than writing the positions out a
        ;; second time (rf2-7g4qn): `prefetch-intent-keys` is the ONE enumeration
        ;; this anchor and the `:routing/prefetch-intent-keys` seam both read, so
-       ;; a position added there cannot reach one link surface and miss another.
+       ;; a position added there reaches both of them together.
        (into {}
              (map (fn [k]
                     [k (compose-intent-handler (get props k) render-frame payload)]))


### PR DESCRIPTION
Two audit reopens, both **class (C)** — the close itself introduced the defect.
Each audit engages with the close evidence, accepts the substantive repair, and
then objects to something that fix's own new text says. Documentation only on
both arms: no runtime change, no new gate, no new vocabulary.

## rf2-yn5nj — reopen class (C)

`MERGED-PR AUDIT #7051` accepts the host-reach repair in full — the carrier
stays an object marker, a ClojureScript call reaches the typed
`:rf.error/view-bad-event`, and the `js/Function`-authored native caller
reaches a host `TypeError` carrying no `:rf.error/id` — and then objects to a
sentence that same fix added.

**Found.** Commit `2a6a0fcb44`, the #7051 fix, rewrote the guide's failure
paragraph and in doing so moved the phrase `cb.call is not a function` out of
the framing where it was true and into the one where it cannot be. The old
sentence attached it to the **ClojureScript** direct call, which is right:
before the carrier carried `IFn`, CLJS compiled `(carrier x)` down to
`carrier.call(null, x)`, so `cb.call is not a function` was exactly what a
ClojureScript author saw. The new paragraph attached it to the **native**
`props.onPing(…)` call, which never touches the object's `.call` member at all
— V8 produces an expression-shaped `props.onPing is not a function`. The
paragraph written to document the boundary was the last place still promising
the wording the boundary rules out.

**Changed.** One prose paragraph in
`docs/core/freehand/events-and-handlers.md`. The native branch now names the
host's own `TypeError`, says the wording is the engine's and follows whatever
call expression it tripped on, and offers V8's real shape as an illustration
rather than a guarantee. The ClojureScript branch, the marker-not-a-function
rationale and the captured-frame recovery are untouched.

**Deliberately not changed.** The same phrase in
`implementation/freehand/test/re_frame/freehand/events_cljs_test.cljc:656` and
`pilot_react_interop_dom_cljs_test.cljs:629,648` is historically accurate:
every occurrence explicitly describes the pre-IFn ClojureScript path, which is
where `cb.call` is the correct spelling. `spec/009-Instrumentation.md` already
says "the host's own `TypeError`" for the native case, and is fenced for this
dispatch in any event.

### Mutation proof

The bar is that the diagnostic **appears on the failing path**, not that a
string changed. Two defects were planted in
`implementation/freehand/src/re_frame/freehand/events.cljc`, each confirmed
applied by `git diff --stat` **and** by grepping the planted token back out
*before* any verdict was read, and each reverted with `git checkout --`
followed by re-grepping the token to absence and the original text to presence.

| run | plant applied? | freehand JVM verdict |
| --- | --- | --- |
| baseline | — | 1132 tests / 7584 assertions, **0 failures 0 errors**, rc=0 |
| **P1** — drop the `call-protocol` splice from `def-callback-type` | `1 file changed, 2 insertions(+), 2 deletions(-)`; `PLANTED-STRIP-PROTOCOL` present (1), `call-protocol (some?` absent (0) | **34 failures**, rc=1 |
| **P2** — keep the protocol, blunt `carrier-called-directly!`'s message to `"PLANTED-BLUNT: something went wrong."` | `1 file changed, 1 insertion(+), 9 deletions(-)`; `PLANTED-BLUNT` present (1) | **12 failures**, rc=1 |

**P1 — the diagnostic is reached, not incidental.** Every id assertion
collapsed with `actual: (not (= :rf.error/view-bad-event
:re-frame.freehand.conformance/no-id))` — the carrier stopped being reachable
through the host call protocol and the typed error vanished. The failures span
`an-invoked-carrier-is-didactic-on-both-hosts` (lines 690/694/696/698/701/703/705
× 4 roles), `no-call-arity-escapes-the-carrier-diagnostic` (720) and
`a-carrier-is-ifn-and-nothing-classifies-on-that` (735).

**P2 — the message content is separately load-bearing.** Exactly 12 failures,
all in `an-invoked-carrier-is-didactic-on-both-hosts` at lines **694, 696 and
698** × 4 roles — the three assertions that the message names the roster form,
the `createElement` position class and the `capture-frame` recovery. The id
assertion at 690 and the ex-data assertions at 701/703/705 stayed **green**:

```
FAIL in (an-invoked-carrier-is-didactic-on-both-hosts) (events_cljs_test.cljc:694)
:render-fn — the message names the roster form that was invoked
expected: (str/includes? message (str "v/" (name role)))
  actual: (not (str/includes? "PLANTED-BLUNT: something went wrong. [:rf.error/view-bad-event]" "v/render-fn"))
```

A diagnostic that still raises the right id while naming none of the three
things it exists to name is caught. Both plants produced real test outcomes —
each names a deftest, a line and an assertion — not an exit code standing in
for one.

### Digest-pinned fences

`docs/core/freehand/**` fenced blocks are hashed by
`samples_coverage_jvm_test.clj`. The edited paragraph is prose, proved rather
than assumed: the last fence before it closes at line 323 and the next opens
after line 380, so the edit sits between fences. Sample coverage is unchanged
at **113 of 136 fenced blocks** and the digest test is green.

## rf2-7g4qn — reopen class (C)

`MERGED-PR AUDIT #7048` accepts the two consumer-roster edits and objects to
the docstring those same PRs edited.

**Found — not "already correct".** On `main` at `d1c49b1164`,
`re-frame.routing.link/prefetch-intent-keys` still concluded "so no view
substrate states the class for itself" while
`implementation/ui/src/re_frame/ui.cljc:840-848` still assocs
`:on-mouse-enter`, `:on-focus` and `:on-touch-start` literally. The donor
deletion (rf2-drpa3.57) has **not** landed, so the #7043 note's hope that it
would remove the exception before this bead closed did not come true, and
narrowing the consumer list to Freehand in #7048 did not make the conclusion
true either. `prefetch-intent-attrs`' inline note carried the same overclaim in
miniature — "a position added there cannot reach one link surface and miss
another" — which is likewise false while the donor holds its own copy.

**Changed.** Two comment blocks in
`implementation/routing/src/re_frame/routing/link.cljc`. The docstring now says
the durable view substrate no longer states the class, names the donor as the
one remaining and explicitly temporary exception, and says plainly what that
costs until rf2-drpa3.57 lands: a position added here reaches `rf/route-link`
and `v/route-link` and misses `ui/route-link`. The inline note is narrowed to
its two actual readers.

**Deliberately not changed.** The donor arm itself, which is out of scope by
the mayor rescope and rf2-drpa3.57's to delete; the tests, which keep
independent literals because a test deriving its expectation from the constant
under test cannot catch a wrong constant; and `spec/012` plus the
`fh-routelink-008` conformance fixture, which state the class independently on
purpose.

## Quality gates

Every baseline re-derived in this worktree rather than trusted. `rc` captured
immediately into a worktree-local log and cross-checked against each log's own
verdict line, so no wrapper's exit code stands in for a test outcome.

| gate | result | rc |
| --- | --- | --- |
| `implementation/routing` — `clojure -M:test` | 511 tests / 2771 assertions, 0 failures 0 errors | 0 |
| `implementation/freehand` — `clojure -M:test` (carries `samples_coverage_jvm_test`) | 1132 tests / 7584 assertions, 0 failures 0 errors | 0 |
| `implementation/core` — `clojure -M:test` | 2122 tests / 10475 assertions, 0 failures 0 errors | 0 |
| `npm run test:cljs` | 11495 tests / 57478 assertions, 0 failures 0 errors | 0 |
| `npm run test:browser` | 798 tests / 5057 assertions, 0 failures 0 errors | 0 |
| `python -m mkdocs build --strict` | built in 39.75s | 0 |

All five suite counts match the expected baselines exactly. Freehand guide
sample coverage: **113 of 136 fenced blocks**, unchanged.

One non-verdict exit was seen and discarded rather than reported as a failure:
the first `implementation/core` run returned `rc=124`, which is `timeout(1)`
killing a cold `.cpcache` compile at 590s, not a test result — no deftest and
no assertion in the log. Re-run without the wrapper timeout it is green above.
