### PR TITLE
tools/machines-viz: ship the viewer as a page, not as library surface (rf2-k7l2o)

### DIFF
--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -336,6 +336,20 @@
                 ;; via thin shims under tools/xray/src/day8/re_frame2_xray/chart/).
                 "../tools/machines-viz/src"
                 "../tools/machines-viz/test"
+                ;; tools/machines-viz/page (rf2-k7l2o). The artefact's one
+                ;; APPLICATION — `viewer.cljs`, the `^:export run` entry
+                ;; public/viewer.html loads — lives on its own root, OFF the
+                ;; jar's `:paths`/`:src-dirs`, because it is the only namespace
+                ;; in the tree that picks a substrate (`rf/init!` with the
+                ;; Reagent adapter). Shipping it as library surface would have
+                ;; forced a published `re-frame.adapter.reagent` dependency on
+                ;; every consumer, colliding with day8/reagent-slim (which
+                ;; publishes ITS adapter at that same canonical ns) on a slim
+                ;; app's classpath. Listed here for the two builds that DO need
+                ;; it: `:machines-viz-viewer` below, and `:node-test`, whose
+                ;; `cljs-test$` selector reaches the page's own unit suite
+                ;; (`viewer-cljs-test`, in the `test` root above).
+                "../tools/machines-viz/page"
                 ;; tools/xray/testbeds (rf2-p8f2s — examples-split step 1).
                 ;; Tool-owned testbeds colocate their testbed app source
                 ;; (where an app is needed) with the spec that drives it.
@@ -2519,6 +2533,11 @@
   ;; Bundle-isolation holds: machines-viz is a tool jar, so emitting a tool
   ;; bundle from this consumer build introduces no production-bundle leak
   ;; (nothing under implementation/ :requires the viewer ns).
+  ;;
+  ;; rf2-k7l2o — the entry ns resolves off `../tools/machines-viz/page`, not
+  ;; `.../src`. This build IS the page's delivery vehicle: `viewer.js` beside
+  ;; `public/viewer.html` is how the page ships, and the published jar
+  ;; deliberately does not carry it.
   :machines-viz-viewer
   {:target     :browser
    :output-dir "out/machines-viz-viewer"

--- a/tools/machines-viz/README.md
+++ b/tools/machines-viz/README.md
@@ -61,18 +61,35 @@ tools/machines-viz/
 ├── deps.edn                                  ; declares day8/re-frame2-machines-viz
 ├── public/viewer.html                        ; static read-only viewer host
 ├── spec/                                     ; normative contract (see below)
-└── src/day8/re_frame2_machines_viz/
-    ├── chart.cljs                            ; the MachineChart component
-    ├── chart/                                ; layout, nodes, edges, overlays, projection
-    ├── adapters/                             ; react-chart + UIx shells
-    ├── viewer.cljs                           ; read-only viewer entry
-    ├── share.cljs                            ; share-URL encode / decode
-    ├── export.cljs                           ; PNG / SVG / Mermaid / share-URL exporters
-    ├── mermaid.cljc                          ; stateDiagram-v2 emitter (pure)
-    ├── scxml.cljc                            ; SCXML import / export
-    ├── ai_generate.cljc                      ; AI-generate seam
-    └── theme/ · visual_constants.cljc        ; design tokens
+├── src/day8/re_frame2_machines_viz/          ; LIBRARY SURFACE — this ships
+│   ├── chart.cljs                            ; the MachineChart component
+│   ├── chart/                                ; layout, nodes, edges, overlays, projection
+│   ├── adapters/                             ; react-chart + UIx shells
+│   ├── share.cljs                            ; share-URL encode / decode
+│   ├── export.cljs                           ; PNG / SVG / Mermaid / share-URL exporters
+│   ├── mermaid.cljc                          ; stateDiagram-v2 emitter (pure)
+│   ├── scxml.cljc                            ; SCXML import / export
+│   ├── ai_generate.cljc                      ; AI-generate seam
+│   └── theme/ · visual_constants.cljc        ; design tokens
+└── page/day8/re_frame2_machines_viz/         ; THE APPLICATION — this does not
+    └── viewer.cljs                           ; read-only viewer entry (^:export run)
 ```
+
+**Why `page/` is a second source root (rf2-k7l2o).** `src` is library
+surface a host requires; `page` holds the one application in this tree.
+`viewer.cljs` is the `^:export run` entry `public/viewer.html` loads, and
+it ships as the compiled `viewer.js` beside that HTML — the jar was never
+its delivery vehicle. Only `src` is on `:paths` and on `:clein/build
+:src-dirs`, so only `src` reaches a consumer.
+
+The split earns its keep rather than merely tidying: the page is the only
+namespace here that picks a **substrate** (`rf/init!` with the Reagent
+adapter), and picking one is an application's job. Had it stayed in `src`,
+the jar would have had to declare `day8/re-frame2-reagent` to be loadable
+at all — and `day8/reagent-slim` publishes *its* adapter at the same
+canonical `re-frame.adapter.reagent` namespace, so a slim app taking
+machines-viz would have ended up with two implementations of that
+namespace on one classpath, load order picking the substrate.
 
 ## How to test
 

--- a/tools/machines-viz/deps.edn
+++ b/tools/machines-viz/deps.edn
@@ -17,10 +17,32 @@
 ;; :mvn/version pinned to the same VERSION file the core artefact
 ;; reads so machines-viz's published version equals the framework's
 ;; published version at every release.
+;;
+;; ## Two source roots: `src` ships, `page` does not (rf2-k7l2o)
+;;
+;; `src` is library surface — the MachineChart component, the grammar /
+;; layout / projection pipeline, the exporters, the share codec. `page`
+;; carries the ONE application in this tree: `viewer.cljs`, the
+;; `^:export run` entry `public/viewer.html` loads, which is compiled to
+;; a static `viewer.js` and shipped beside that HTML rather than in the
+;; jar. Only `:paths`/`:src-dirs` — i.e. only `src` — reaches a
+;; consumer.
+;;
+;; The split is load-bearing, not tidiness. The page is the only
+;; namespace here that picks a SUBSTRATE (`rf/init!` with the Reagent
+;; adapter), and picking one is an application's job: `day8/reagent-slim`
+;; publishes its adapter at the same canonical `re-frame.adapter.reagent`
+;; namespace (release.yml renames `reagent_slim.cljs` → `reagent.cljs` at
+;; publication, and states downstream apps depend on EXACTLY ONE of
+;; {day8/re-frame2-reagent, day8/reagent-slim}). Had the page stayed in
+;; `src`, this jar would have had to declare an adapter to be loadable at
+;; all, putting two `re-frame.adapter.reagent` implementations on a slim
+;; app's classpath with load order deciding the winner.
 {:paths ["src"]
  :deps  {;; Core supplies re-frame.error, trace/interop helpers, and the
-         ;; viewer's re-frame initialisation. Hosts obtain definitions and
-         ;; snapshots themselves and pass them to MachineChart.
+         ;; viewer page's re-frame initialisation. Hosts obtain
+         ;; definitions and snapshots themselves and pass them to
+         ;; MachineChart.
          day8/re-frame2 {:local/root "../../implementation/core"}
 
          ;; Share-URL encoding is EDN data → transit-write →
@@ -36,10 +58,12 @@
          ;; runtime).
          com.cognitect/transit-cljs {:mvn/version "0.8.280"}
 
-         ;; The MachineChart component and viewer require stock Reagent
-         ;; directly (`reagent.core` for component-local Ratom state,
-         ;; `reagent.dom.client` in the standalone viewer), so machines-viz
-         ;; declares the stock `reagent/reagent` dep itself. It previously
+         ;; The MachineChart component requires stock Reagent directly
+         ;; (`reagent.core` for component-local Ratom state — chart.cljs,
+         ;; the node/edge/overlay components and the React shim), so
+         ;; machines-viz declares the stock `reagent/reagent` dep itself.
+         ;; `reagent.dom.client` is the viewer PAGE's, and left the jar
+         ;; with it (rf2-k7l2o); `reagent.core` did not. It previously
          ;; inherited Reagent transitively from core, but core is now
          ;; Reagent-free (re-frame.views late-binds via the
          ;; `:adapter/current-component` hook), so every artefact that
@@ -92,8 +116,14 @@
   ;; own jar and the classpath must carry it. Version tracks
   ;; implementation/package.json's `shadow-cljs` entry, like every other pin of
   ;; it in the tree.
+  ;;
+  ;; `page` joins `test` on this alias (rf2-k7l2o): `viewer_cljs_test.cljs`
+  ;; :requires the page entry, and the page root is off `:paths` precisely so
+  ;; it never ships. A test lane is not a consumer, so putting it on the TEST
+  ;; classpath is exactly the right scope — the page keeps its coverage and
+  ;; the jar keeps its independence from any substrate adapter.
   :cljs-test
-  {:extra-paths ["test"]
+  {:extra-paths ["test" "page"]
    :extra-deps  {day8/re-frame2-test-quiet
                  {:local/root "../../implementation/test-quiet"}
                  day8/re-frame2-machines
@@ -114,8 +144,14 @@
                  ;; taken in a CI-arming PR.
                  com.pitch/uix.core   {:mvn/version "1.4.4"}
                  com.pitch/uix.dom    {:mvn/version "1.4.4"}
-                 ;; Same finding, second instance: `src/.../viewer.cljs`
-                 ;; :requires `re-frame.adapter.reagent`.
+                 ;; The viewer PAGE (`page/.../viewer.cljs`) :requires
+                 ;; `re-frame.adapter.reagent`. That require is why the page is
+                 ;; not in `src` (rf2-k7l2o — see the source-roots note at the
+                 ;; top of this file): as library surface it would have forced
+                 ;; a published adapter dep and collided with day8/reagent-slim
+                 ;; on a slim app's classpath. As a page it is an application
+                 ;; choosing its own substrate, and the coordinate it needs is
+                 ;; scoped to the lane that compiles it — here.
                  day8/re-frame2-reagent
                  {:local/root "../../implementation/adapters/reagent"}}}
 
@@ -141,6 +177,11 @@
   ;; surface (`spec/API.md` §MachineChart), which is the same
   ;; convention tools/story/deps.edn follows with `:main re-frame.story`
   ;; — for a library jar this only populates the manifest's Main-Class.
+  ;;
+  ;; `:src-dirs ["src"]` — `page` is deliberately absent (rf2-k7l2o). It
+  ;; is the line that keeps the viewer page out of the jar, so a consumer
+  ;; is never asked to resolve `re-frame.adapter.reagent`. Adding `page`
+  ;; here would republish the defect.
   :clein/build
   {:lib      day8/re-frame2-machines-viz
    :main     day8.re-frame2-machines-viz.chart

--- a/tools/machines-viz/page/day8/re_frame2_machines_viz/viewer.cljs
+++ b/tools/machines-viz/page/day8/re_frame2_machines_viz/viewer.cljs
@@ -41,7 +41,31 @@
   chart is a Reagent component); it registers no frame, dispatches no
   events, and reads no `[:rf.runtime/machines :snapshots]` runtime-db slot.
 
-  Per [`API.md`](../../spec/API.md) §Read-only viewer + §Share-URL
+  ## Why this file lives under `page/` and not `src/` (rf2-k7l2o)
+
+  It is the artefact's only APPLICATION. Everything under `src/` is
+  library surface a host requires; this namespace is an entry point a
+  browser loads, and it is the only one in the tree that picks a
+  substrate — `(rf/init! reagent-adapter/adapter)` on the line below.
+  Picking a substrate is an application's job. `implementation/core` is
+  deliberately adapter-free for exactly that reason, and a library jar
+  that named `re-frame.adapter.reagent` in its dependency graph would
+  force the choice on every consumer: `day8/reagent-slim` publishes ITS
+  adapter at the same canonical namespace (`release.yml` renames
+  `reagent_slim.cljs` → `reagent.cljs` at publication), so a slim app
+  taking machines-viz would get two `re-frame.adapter.reagent`
+  implementations on one classpath — one bound to `reagent.*`, one to
+  `reagent2.*` — with classpath order deciding which its own
+  `(:require [re-frame.adapter.reagent])` resolved to.
+
+  `page/` is a source root the jar does not carry (`:clein/build
+  :src-dirs [\"src\"]`), so the require never reaches a consumer's
+  classpath and no dependency is needed to satisfy it. The page is
+  shipped as the compiled `viewer.js` beside `public/viewer.html`, which
+  is how a static page ships anyway — the jar was never its delivery
+  vehicle.
+
+  Per [`API.md`](../../../spec/API.md) §Read-only viewer + §Share-URL
   encoding."
   (:require [reagent.core :as r]
             [reagent.dom.client :as rdc]

--- a/tools/machines-viz/spec/000-Vision.md
+++ b/tools/machines-viz/spec/000-Vision.md
@@ -693,7 +693,8 @@ implementation-state list.
 - `MachineChart` component (per [`API.md`](./API.md) §MachineChart) —
   **shipped** (`src/.../chart.cljs`; xyflow + elkjs).
 - Read-only viewer page (per [`API.md`](./API.md) §Read-only viewer) —
-  **shipped** (`public/viewer.html` + `src/.../viewer.cljs`, rf2-8d7w1).
+  **shipped** (`public/viewer.html` + `page/.../viewer.cljs`, rf2-8d7w1;
+  the page root is not packaged in the jar, rf2-k7l2o).
 - Share-URL encoding (per [`API.md`](./API.md) §Share-URL encoding) —
   **shipped** (`src/.../share.cljs`, rf2-8d7w1).
 - PNG + SVG exporters — **shipped** (`src/.../export.cljs`, rf2-8d7w1;

--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -1617,6 +1617,30 @@ https://acme.example.com/path/to/viewer.html#machine=<base64url-transit>
   the viewer goes to my docs site" would have to fork the page;
   the canonical viewer is read-only end-to-end.
 
+### The viewer is a page, not library surface
+
+The viewer ships as a **page** — `public/viewer.html` plus the compiled
+`viewer.js` beside it. Its source lives on a source root of its own
+(`page/day8/re_frame2_machines_viz/viewer.cljs`) which the published
+`day8/re-frame2-machines-viz` jar does **not** carry, and
+`day8.re-frame2-machines-viz.viewer` is correspondingly **not** a
+namespace a consumer can `:require`. Self-hosting means serving the two
+static files, exactly as [DESIGN-RATIONALE Lock #7](./DESIGN-RATIONALE.md)
+describes; it never meant requiring the entry namespace.
+
+The reason is a contract, not a packaging preference. The viewer is the
+only namespace in this artefact that chooses a **substrate** — it calls
+`rf/init!` with the Reagent adapter — and choosing one is an
+application's job, which is why `implementation/core` is adapter-free.
+A library jar carrying that require would have to declare
+`day8/re-frame2-reagent`, and `day8/reagent-slim` publishes its own
+adapter at the same canonical `re-frame.adapter.reagent` namespace; a
+slim application adding machines-viz would then hold two implementations
+of one namespace, with classpath order deciding which its own
+`(:require [re-frame.adapter.reagent])` resolved to. Keeping the page
+off `:src-dirs` removes the require from the jar and the choice from the
+consumer (rf2-k7l2o).
+
 Source: lifted from
 [Xray 003 §Share affordance](../../xray/spec/003-Machine-Inspector.md#share-affordance).
 


### PR DESCRIPTION
> **MERGED AT A STALE HEAD — follow-up in #7074.** This PR's branch tip was
> `26cb5f713c` (confirmed by `git ls-remote` and `gh api .../git/ref/heads/...`), but
> the PR object never advanced past `1df23ea93e` and merged there. A ref bounce did
> not resync it. The second commit's content — the comment corrections described under
> "What changed" — therefore did **not** reach `main`; **#7074** carries it,
> cherry-picked. Everything else below landed.

`day8/re-frame2-machines-viz` could not be loaded by a consumer whose only
dependency was the published coordinate. `src/.../viewer.cljs` requires
`re-frame.adapter.reagent`; the artefact never declared it; the require is
unconditional, so the failure lands at namespace **load**.

Both obvious repairs are wrong, which is why rf2-3d5u3 shipped the `uix.core` half
and split this one out. This PR takes the third shape the bead names — and the first
thing it does is test that shape's own claim rather than assume it.

## Is `viewer.cljs` genuinely a page entry and nothing else? — yes

The whole plan rests on this, so it was checked before anything moved. Sweeping every
tracked file for the namespace (`git ls-files | xargs grep`, not `git grep <ref> -- dir/`,
which false-empties on this setup) finds exactly three referents and no fourth:

| referent | kind |
|---|---|
| `implementation/shadow-cljs.edn` `:machines-viz-viewer` `:modules {:viewer {:entries [...]}}` | a **page bundle entry** |
| `public/viewer.html` → `window.day8.re_frame2_machines_viz.viewer.run()` | the **static page** that loads it |
| `test/.../viewer_cljs_test.cljs` | its **own unit suite** |

No namespace inside the artefact requires it. No sibling tool does — `tools/xray` and
`tools/story` never mention it. And it is absent from the public surface in the sense
that matters: `spec/API.md` §Read-only viewer documents a **URL and a page's
behaviour**, never a namespace to `:require`; the only `:require` API.md hands a
consumer for this feature is `share/encode-share-url`, whose output is that URL.

Two further facts sharpen "page, not library", both re-derived from the `src` tree:

- It is the **only** namespace in the artefact that picks a substrate —
  `(rf/init! reagent-adapter/adapter)`.
- It is the **only** namespace in the artefact that requires `reagent.dom.client`,
  `re-frame.core`, or `re-frame.adapter.reagent`. Every other file uses
  `re-frame.error`, `re-frame.interop`, `re-frame.trace` and `reagent.core` only.

So the file is an application living in a library's source root, and it was the
application's dependency — not the library's — that made the library unloadable.

## What changed

`viewer.cljs` moves to a `page/` source root that is on the dev and test classpaths
and **off** `:paths` and `:clein/build :src-dirs`. The require leaves the jar with the
file. No dependency is added, and **no workflow edit is needed** — the alternative
route (a second `rewrite-local-root-coord.sh` call in `release-machines-viz.yml`) is
not taken and not required.

The page still ships. It always shipped as compiled `viewer.js` beside
`public/viewer.html`; the jar was never its delivery vehicle.

### Why the two obvious repairs stay refused

1. **Adapter-namespace collision.** `day8/reagent-slim` publishes *its* adapter at the
   same canonical `re-frame.adapter.reagent` name — `release.yml:561` renames
   `reagent_slim.cljs` → `reagent.cljs` before clein packages, and `release.yml:544`
   states downstream apps depend on **exactly one** of
   `{day8/re-frame2-reagent, day8/reagent-slim}`. A hard dep here puts both on a slim
   app's classpath, one bound to `reagent.*` and one to `reagent2.*`, with load order
   deciding the substrate. In-tree the slim namespace is still `reagent_slim`, so the
   monorepo build cannot see the collision.
2. **It would not reach the pom.** `clein pom` silently skips `:local/root`, and
   `release-machines-viz.yml` rewrites exactly one coordinate.

Neither was re-verified by inspecting a local `clein install` — a sibling established
that `clein/install` never calls `write-pom`, so an installed directory holds only the
jar and `_remote.repositories`. The published pom is a different artefact, and
dependency scope cannot be read off a local install.

## Simulated consumer: before and after, checked against the artefact

A throwaway project whose only dependency is the machines-viz coordinate via
`:local/root` — the same file set the jar carries (`:src-dirs ["src"]` == `:paths
["src"]`) and the same dependency set the rewritten pom carries. No repo
`:source-paths`, no `implementation/shadow-cljs.edn` `:dependencies`, no borrowed
classpath. `com.pitch/uix.core` is declared **in the sim**, because it is the
coordinate open PR #7066 adds to `:deps` (the uix half of rf2-3d5u3, not yet on main);
declaring it there isolates this bead's half from that pending one.

**BEFORE** — base `d1c49b1164`:

```
$ clojure -M -m shadow.cljs.devtools.cli compile sim-viewer     # requires the viewer ns
[:sim-viewer] Compiling ...
The required namespace "re-frame.adapter.reagent" is not available, it was required by
  "day8/re_frame2_machines_viz/viewer.cljs".
rc=1

$ clojure -M -m shadow.cljs.devtools.cli compile sim-all        # requires ALL 30 src namespaces
[:sim-all] Compiling ...
The required namespace "re-frame.adapter.reagent" is not available, it was required by
  "day8/re_frame2_machines_viz/viewer.cljs".
rc=1
```

The jar is unloadable **in whole**: an entry requiring the artefact's full published
surface dies on the page's dependency.

**AFTER**:

```
$ clojure -M -m shadow.cljs.devtools.cli compile sim-viewer
[:sim-viewer] Compiling ...
The required namespace "day8.re-frame2-machines-viz.viewer" is not available, it was
  required by "sim/viewer.cljs".
rc=1     ← the intended outcome: the page is not library surface, and now says so

$ clojure -M -m shadow.cljs.devtools.cli compile sim-lib        # ALL 29 remaining src namespaces
[:sim-lib] Compiling ...
[:sim-lib] Build completed. (142 files, 141 compiled, 0 warnings, 27.25s)
rc=0
```

The failure did not disappear; it **moved**, from "this jar demands an adapter it never
declared" to "the page is not in the jar" — which is the contract, not a defect.

**Verified against the artefact, not the exit code.** `out/sim-lib/cljs-runtime` holds
**29** `day8.re_frame2_machines_viz.*` modules — every namespace the published `src`
tree carries — and **zero** viewer modules. The emitted framework/substrate modules
are exactly the library's footprint and nothing more:

```
re_frame.error.js  re_frame.interop.js  re_frame.late_bind.js
re_frame.trace.js  re_frame.trace.projection.js  re_frame.trace.tooling.js
reagent.core.js + reagent.impl.* + reagent.ratom.js + reagent.debug.js
```

No `re_frame.adapter.reagent`, no `re_frame.core`, no `reagent.dom.client`. Those
three left with the page.

**The page still builds and still exports its entry:**

```
$ npx shadow-cljs compile :machines-viz-viewer
[:machines-viz-viewer] Build completed. (184 files, 183 compiled, 0 warnings, 44.45s)
rc=0
```

`out/machines-viz-viewer/viewer.js` is emitted, and
`cljs-runtime/day8.re_frame2_machines_viz.viewer.js` carries
`day8.re_frame2_machines_viz.viewer.run` — the symbol `public/viewer.html` calls.

## Does the `:src-dirs` change alter what the artefact carries?

Yes, by exactly one file and three requirements, all of them the page's:

| | before | after |
|---|---|---|
| namespaces in the jar | 30 | **29** (`…viz.viewer` removed) |
| `re-frame.adapter.reagent` required | yes, undeclared → **unloadable** | **not required** |
| `re-frame.core` required | yes | **not required** |
| `reagent.dom.client` required | yes | **not required** |
| declared `:deps` | unchanged | **unchanged** |

Nothing the jar should carry is lost. `day8.re-frame2-machines-viz.viewer` was never a
consumer-facing `:require` surface, and it was never reachable from one — the sweep
above is the evidence. `reagent/reagent` and `day8/re-frame2` both remain genuine deps
(`reagent.core` for component-local Ratom state across chart/nodes/edges/overlays;
core for `re-frame.error`/`interop`/`trace`), so the dependency list is untouched.

`day8/re-frame2-reagent` stays on the `:cljs-test` alias, where it now belongs
explicitly rather than as an under-declaration: it is the coordinate the **page**
needs, scoped to the lane that compiles the page.

Adding `page` to `:cljs-test :extra-paths` falsified two comments that asserted
`:cljs-test` and `:test` carry the *same paths* — `deps.edn`'s alias header and
`tools/machines-viz/shadow-cljs.edn`'s note on why the build points at `:cljs-test`.
Both now state what actually differs, and why `:test` does not follow: the page is
`.cljs` and the JVM lane never loads it. (Second commit.)

## CI classification needs no change

The classifier's `tools/machines-viz/*` arm ends in a catch-all, so the new root is
already covered — checked rather than assumed:

```
$ .github/scripts/report-changed-surfaces.sh tools/machines-viz/page/.../viewer.cljs
cljs_node_test=true  cljs_browser=true  tools_jvm_machines_viz=true  tools_cljs_machines_viz=true
```

The narrower `examples_compile` arm lists `tools/machines-viz/src/*` and deliberately
does not gain `page/*`: that arm exists because example builds load the Xray preload
and Story hosts whose closure includes the machines-viz **chart**, and no example build
requires the viewer page.

## Quality gates

Every command run in this worktree, foreground to completion, `rc` captured
immediately into a worktree-local log and cross-checked against the log's own verdict
line.

| gate | result | rc |
|---|---|---|
| `tools/machines-viz` JVM — `clojure -M:test` | **632 tests / 2537 assertions**, 0 failures, 0 errors | 0 |
| machines-viz own CLJS lane — `npm run test:tools-machines-viz` | 249 files, 248 compiled, 0 warnings; **821 tests / 3214 assertions**, 0 failures, 0 errors | 0 |
| consolidated CLJS — `npm run test:cljs` | **11495 tests / 57478 assertions**, 0 failures, 0 errors | 0 |
| page build — `npx shadow-cljs compile :machines-viz-viewer` | 184 files, 183 compiled, 0 warnings | 0 |
| `scripts/check_test_lane_bijection.py` | PASS — 1665 test-defining files, 45 lanes, every file selected, every selector reached | 0 |
| `.github/scripts/verify-version-lockstep.sh` | PASS — all 17 artefacts at VERSION 0.0.1.alpha | 0 |
| `scripts/check-no-hardcoded-paths.sh` | Portability gate OK | 0 |
| `scripts/test-fast-pr.sh` | `PASS fast PR spine` (mkdocs soft-skipped locally — not on PATH; CI's MkDocs job passed) | 0 |
| **CI on this PR** | **36 SUCCESS / 40 skipped / 0 failures** — "All required checks passed" | — |

CI covers what the spine does not, and all of it is green here: `:browser-test`
(headless Chromium), the two prod-elision browser lanes, examples-compile, the three
bundle-isolation gates, the reagent-slim client-runtime smoke, the public-API manifest
drift check, MkDocs, `JVM tools/machines-viz`, and `CLJS tools/machines-viz`.

**Baseline, re-derived rather than taken on trust.** Both figures in circulation are
real and they are **different lanes**, not a stale reading of one:

- **632 / 2537** is `tools/machines-viz` on the **JVM** (`clojure -M:test`) — the
  number `.github/scripts/report-changed-surfaces.sh:1447` records.
- **821 / 3214** is the artefact's **own CLJS lane** (`:machines-viz-node-test`). That
  lane is on `main` — `tools/machines-viz/shadow-cljs.edn` landed at `efb0ae3c1a`
  ("ci: give tools/machines-viz its own CLJS test lane", rf2-odlm3), which is an
  ancestor of `origin/main`. It is not an unmerged figure.

Both are unchanged by this PR, which is the point: relocating the page moved no test
and lost no coverage. Confirmed at the artefact again rather than by the count staying
put — the artefact's own lane output
(`.shadow-cljs/builds/machines-viz-node-test/dev/out/cljs-runtime/`) carries both
`day8.re_frame2_machines_viz.viewer_cljs_test.js` and, resolved off the new `page`
root, `day8.re_frame2_machines_viz.viewer.js`; all six of the suite's `deftest` vars
are present in the compiled file. That is what the `page` entry on
`:cljs-test :extra-paths` buys.

Browser lanes, examples-compile, bundle-isolation and the perf/prod gates are left to
CI: the diff moves one file and adds comments, touches no DOM code, and the two shadow
builds compiled above already prove the edited `shadow-cljs.edn` parses and resolves.

## Sequencing

Open PR **#7066** (rf2-3d5u3, the `uix.core` half) also edits
`tools/machines-viz/deps.edn`. The two diffs touch disjoint regions — #7066 adds a
coordinate to `:deps`, this PR edits the header comment, the `:cljs-test` alias and the
`:clein/build` comment — but they are the same file, so whichever lands second should
be rebased rather than auto-merged.
