### PR TITLE
tools/machines-viz: land #7071's lost commit, and retire the deps.edn note the two merges left stale (rf2-k7l2o)

### DIFF
--- a/tools/machines-viz/deps.edn
+++ b/tools/machines-viz/deps.edn
@@ -159,14 +159,16 @@
   ;; this file for why the lane is declared HERE rather than borrowed onto the
   ;; consolidated one).
   ;;
-  ;; It carries the SAME paths and the SAME test-only deps as `:test` above and
-  ;; differs in exactly one respect: no `:main-opts`. shadow-cljs resolves a
+  ;; It carries the SAME test-only deps as `:test` above and differs in exactly
+  ;; two respects. First, no `:main-opts`: shadow-cljs resolves a
   ;; `:deps {:aliases [...]}` classpath by shelling out to `clojure -A:<alias>`,
   ;; which INHERITS the alias's `:main-opts` and then hands shadow's own
   ;; arguments to cognitect's test-runner instead of to shadow. Pointing the
-  ;; build at `:test` therefore fails before it compiles anything. A
-  ;; :main-opts-free alias is the whole difference; keeping the deps in lockstep
-  ;; is what makes the two runtimes see one classpath.
+  ;; build at `:test` therefore fails before it compiles anything, so a
+  ;; :main-opts-free alias is unavoidable; keeping the deps in lockstep is what
+  ;; makes the two runtimes see one classpath. Second, the `page` path — see
+  ;; below; `:test` does not carry it because the page is `.cljs` and the JVM
+  ;; lane never loads it.
   ;; `thheller/shadow-cljs` is pinned here for the same reason
   ;; tools/mcp-base/deps.edn and tools/re-frame2-pair-mcp/deps.edn pin it: the
   ;; artefact has no npm surface, so the shadow-cljs launcher cannot inject its

--- a/tools/machines-viz/deps.edn
+++ b/tools/machines-viz/deps.edn
@@ -72,35 +72,27 @@
          ;; bundle never pulls Reagent through it.
          reagent/reagent {:mvn/version "2.0.1"}
 
-         ;; `viewer.cljs` requires `re-frame.adapter.reagent` and passes it to
-         ;; `rf/init!`, and that dep is DELIBERATELY NOT DECLARED HERE
-         ;; (rf2-3d5u3 → rf2-k7l2o). Undeclared, the viewer namespace dies at
-         ;; LOAD for a consumer — "The required namespace
-         ;; re-frame.adapter.reagent is not available" — so this is a real
-         ;; defect, but `day8/re-frame2-reagent` is the wrong repair and a hard
-         ;; dep here would be worse than the hole:
+         ;; NO ADAPTER COORDINATE BELONGS IN THIS MAP, and the reason has
+         ;; already been acted on rather than merely noted (rf2-3d5u3 →
+         ;; rf2-k7l2o, both landed). `re-frame.adapter.reagent` was required by
+         ;; `viewer.cljs` while that file sat in `src`, and undeclared it killed
+         ;; the whole jar at namespace LOAD for a consumer. Declaring
+         ;; `day8/re-frame2-reagent` would have been worse than the hole:
+         ;; `day8/reagent-slim` publishes ITS adapter at the same canonical
+         ;; `re-frame.adapter.reagent` ns (release.yml renames
+         ;; `reagent_slim.cljs` → `reagent.cljs` before clein packages, and says
+         ;; downstream apps depend on EXACTLY ONE of {day8/re-frame2-reagent,
+         ;; day8/reagent-slim}), so a slim app would have carried two
+         ;; implementations of one namespace with load order picking the
+         ;; substrate — and in-tree the slim ns is still `reagent_slim`, so the
+         ;; monorepo build cannot see the collision. It would not have reached
+         ;; the published pom anyway: `clein pom` silently skips `:local/root`
+         ;; and `release-machines-viz.yml` rewrites exactly one coordinate.
          ;;
-         ;;   - `day8/reagent-slim` publishes ITS adapter at the same canonical
-         ;;     `re-frame.adapter.reagent` ns (release.yml renames
-         ;;     `reagent_slim.cljs` → `reagent.cljs` before clein packages), and
-         ;;     release.yml states downstream apps depend on EXACTLY ONE of
-         ;;     {day8/re-frame2-reagent, day8/reagent-slim} so the adapter ns is
-         ;;     single-source per app. A hard dep here puts BOTH on a slim app's
-         ;;     classpath — one bound to `reagent.*`, one to `reagent2.*` — and
-         ;;     classpath order silently picks the substrate. In-tree the slim ns
-         ;;     is still `reagent_slim`, so the monorepo build cannot see it.
-         ;;   - It would not reach the published pom anyway.
-         ;;     `release-machines-viz.yml` rewrites exactly ONE `:local/root`
-         ;;     path (`../../implementation/core`) and `clein pom` SILENTLY SKIPS
-         ;;     `:local/root` coordinates, so a second in-repo coordinate is
-         ;;     dropped from the pom without a word. `ssr-ring` is today's only
-         ;;     leaf with two, and it needs a second rewrite call to work.
-         ;;
-         ;; The shape that resolves it: `viewer.cljs` is a PAGE entry
-         ;; (`^:export run`, mounted by `public/viewer.html`), not library
-         ;; surface — picking a substrate adapter is an application's job, and
-         ;; this jar is a library. Moving the page out of the packaged `src`
-         ;; takes the require with it. That is a packaging change; see the bead.
+         ;; The page moved to the `page` root instead — see "Two source roots"
+         ;; at the top of this file. The require left the jar with it, so there
+         ;; is nothing here to declare; the coordinate the page needs is scoped
+         ;; to `:cljs-test`, the lane that compiles it.
 
          ;; `adapters/uix.cljs` requires `uix.core` for `defui` / `$`
          ;; (rf2-3d5u3). Undeclared, that namespace dies at LOAD the same way.

--- a/tools/machines-viz/shadow-cljs.edn
+++ b/tools/machines-viz/shadow-cljs.edn
@@ -53,7 +53,10 @@
 ;; `:cljs-test`, not `:test`: shadow-cljs resolves a `:deps {:aliases [...]}`
 ;; classpath by shelling out to `clojure -A:<alias>`, which INHERITS the
 ;; alias's `:main-opts` and then hands shadow's own arguments to cognitect's
-;; test-runner. The two aliases carry the same paths; see deps.edn.
+;; test-runner. The two aliases carry the same test-only deps; `:cljs-test`
+;; additionally carries the `page` root, which holds the viewer page entry
+;; `viewer_cljs_test.cljs` requires and which the published jar does not ship
+;; (rf2-k7l2o). See deps.edn.
 {:deps {:aliases [:cljs-test]}
 
  ;; The repo installs exactly one node_modules (implementation/). Pointing at


### PR DESCRIPTION
Follow-up to **#7071** (rf2-k7l2o), for two reasons — one a lost push, one a
merge-order collision. Comments only; no code, no dependency, no build change.

## Why this PR exists at all

**#7071 was merged at a stale head.** Its branch tip was `26cb5f713c`
(`git ls-remote` and `gh api .../git/ref/heads/...` both confirmed it), but the PR
object never advanced past `1df23ea93e` — `commits: 1` — and it merged there. A ref
bounce (force to the old SHA, push the new one) did not resync it either; the state
is durably wrong on GitHub's side, not locally. So the second commit's content never
reached `main`, and this PR carries it (`e00278bbc8`, cherry-picked onto current
`main`).

This is the failure mode worth naming: **the branch was correct the whole time.**
Anyone verifying by "did my push succeed?" would have seen success. Only comparing
the PR's `head.sha` against the ref catches it.

## Commit 1 — the "same paths" claims the `page` root falsified

#7071 added `page` to `:cljs-test :extra-paths`. Two comments asserted that
`:cljs-test` and `:test` carry the **same paths**, and both are now false:

- `tools/machines-viz/deps.edn` — the `:cljs-test` alias header ("It carries the SAME
  paths … and differs in exactly one respect: no `:main-opts`").
- `tools/machines-viz/shadow-cljs.edn` — the note on why the build points at
  `:cljs-test` ("The two aliases carry the same paths; see deps.edn").

Both now say what actually differs, and why `:test` does not follow: the page is
`.cljs`, so the JVM lane never loads it.

## Commit 2 — the `:deps` note that still describes the fixed defect

**#7066 and #7071 landed within minutes of each other, and their texts collided.**
#7066 (rf2-3d5u3, the `uix.core` half) added a `:deps` note explaining why no adapter
coordinate is declared, and named the page move as *the shape that would resolve it*.
#7071 made the move. Neither PR could see the other's text, and git merged both
cleanly because they touch different regions of the file — so `main` now carries a
28-line note in the present tense:

> `viewer.cljs` requires `re-frame.adapter.reagent` … that dep is DELIBERATELY NOT
> DECLARED HERE … so this is a real defect … The shape that resolves it: … Moving the
> page out of the packaged `src` takes the require with it. That is a packaging
> change; **see the bead.**

`viewer.cljs` is not in `src` any more, the require is gone from the jar, and the bead
is not open work. A reader following that note lands on a defect that no longer
exists.

It becomes a short statement of the standing rule — **no adapter coordinate belongs in
this map** — which:

- **keeps** the collision reasoning (`day8/reagent-slim` publishes its adapter at the
  same canonical `re-frame.adapter.reagent` ns; a hard dep puts two implementations on
  one classpath with load order picking the substrate) and the pom reasoning
  (`clein pom` silently skips `:local/root`; `release-machines-viz.yml` rewrites
  exactly one coordinate) — that is what stops the next audit re-filing it;
- **drops** the detail now carried, non-duplicated, by the "Two source roots: `src`
  ships, `page` does not" block at the top of the same file;
- **points** at where the page's coordinate actually lives: the `:cljs-test` alias.

Net 20 insertions / 28 deletions on `deps.edn`.

## Quality gates

Run in this worktree on the follow-up branch (cherry-pick onto `main` at
`2581c37aef`, which already carries both #7066 and #7071), foreground to completion,
`rc` captured into worktree-local logs and cross-checked against each log's verdict
line.

| gate | result | rc |
|---|---|---|
| `tools/machines-viz` JVM — `clojure -M:test` | 632 tests / 2537 assertions, 0 failures, 0 errors | 0 |
| machines-viz CLJS lane — `npm run test:tools-machines-viz` | 249 files, 0 warnings; 821 tests / 3214 assertions, 0 failures, 0 errors | 0 |

Both figures are unchanged from #7071, which is the expected result for a
comments-only diff — and running them is not ceremony here: `deps.edn` comments sit
inside the EDN map, so a malformed edit fails classpath resolution before either lane
compiles anything.

The heavier lanes #7071 ran (consolidated `npm run test:cljs` at 11495/57478, the
`:machines-viz-viewer` page build, the simulated-consumer before/after, the bijection
and lockstep gates) are not repeated: this diff changes no path, no coordinate and no
build id. CI covers the rest.

### The consumer check, re-run against `main` with nothing borrowed

Worth recording once now that **both** halves of rf2-3d5u3 are on `main`: the
simulated consumer no longer needs `com.pitch/uix.core` loaned to it (#7066 declared
it in the artefact's own `:deps`), so its `deps.edn` can be reduced to the machines-viz
coordinate and shadow-cljs and nothing else — the honest published graph.

```
$ clojure -M -m shadow.cljs.devtools.cli compile sim-lib   # ALL 29 published namespaces
[:sim-lib] Build completed. (142 files, 141 compiled, 0 warnings, 60.26s)
rc=0
```

Checked at the artefact: `out/sim-lib/cljs-runtime` carries **29**
`day8.re_frame2_machines_viz.*` modules, **0** viewer modules, `uix.core.js` present
(resolved through the artefact's own declaration), and **no** `re-frame.adapter.reagent`
module at all.

`day8/re-frame2-machines-viz` is now loadable in whole by a consumer whose only
dependency is the published coordinate — which is what rf2-k7l2o asked for.
