### PR TITLE
minimal-counter reload hook, ER-01 acceptance ledger, throwing-finalizer arm (rf2-omygl, rf2-drpa3.182.2, rf2-drpa3.182.5)

### DIFF
--- a/docs/core/freehand/js-libraries.md
+++ b/docs/core/freehand/js-libraries.md
@@ -368,13 +368,39 @@ connection at firing time, so a continuation that outlives its node dispatches
 nothing and answers `false`. You do not need to null out your own callbacks; you
 do need to release host listeners in `:disconnect`.
 
+**A finalizer that fails is the host's problem, and the recipe survives it by
+ordering rather than by catching.** `:disconnect` writes `:closed` before it
+touches the host, and the substrate removes the connection record before
+`:disconnect` runs at all — so a `dispose!` that throws still leaves the owner
+terminal, the connection table and target index empty, and nothing holding a
+reference to retry from. What it leaves behind is the host's own instance, which
+no recipe can release: the library was asked exactly once and refused. Report
+that honestly rather than papering over it.
+
+Where the failure surfaces depends on which finalizer site threw, and one of the
+two is quiet:
+
+| The `dispose!` that throws | What you see |
+|---|---|
+| in `:disconnect`, at unmount | the throw comes straight back out of the unmount call — loud, and React neither swallows nor reroutes it |
+| in the late-success continuation | an **unhandled promise rejection** — and everything after it in that arm is skipped, so a `dispatch` placed below a late `dispose!` never runs |
+
+The second is the one to design around. If you need to know that a late handle
+was abandoned, dispatch **before** you finalise it, or wrap the finalise in your
+own `try`/`catch` — the announcement is not guaranteed to survive a host that
+refuses to be released.
+
 ### Proven, not merely argued
 
 Unlike the exit-animation path above, this one is mounted. The ordering that
 matters — **unmount before the Promise resolves** — is asserted in
 `behavior_async_dom_cljs_test.cljs` against a deterministic surrogate: the late
 handle is disposed exactly once, never configured, and the library's book of
-undisposed instances reads empty. A real third-party witness is still outstanding.
+undisposed instances reads empty. **Finalizer failure** is asserted there too, on
+both sites and on the *first* release rather than a second one: exactly one
+release attempted, the owner already `:closed` when it was attempted, both
+framework books empty afterwards, and the host's surviving instance asserted as a
+leak instead of wished away. A real third-party witness is still outstanding.
 
 ## Animation checklist
 

--- a/docs/design/freehand/studio/er-01-architecture-comparison.md
+++ b/docs/design/freehand/studio/er-01-architecture-comparison.md
@@ -34,7 +34,9 @@ Two findings carry that, and either one alone would be enough:
 
 The honest limit on this result is stated in [What would change the
 answer](#what-would-change-the-answer). It is not a small limit, and it is
-narrower than the question.
+narrower than the question — [ER-01's acceptance, arm by
+arm](#er-01s-acceptance-arm-by-arm) prices exactly how much narrower, and what
+closing the gap would cost.
 
 ## What was measured, and why that metric
 
@@ -292,6 +294,75 @@ None of these is a reason to hold the recommendation. ER-01's deferred choice is
 evidence gathered it does not: the performance case is empty at matched
 semantics, and the ergonomic case is paid for in the evidence plane the setpoint
 requires preserved.
+
+## ER-01's acceptance, arm by arm
+
+A recommendation that outran its own acceptance criteria would be the same
+defect this report keeps warning about, so here is the reconciliation in the
+form a reader can check. ER-01's five acceptance items, against what was
+actually run:
+
+| # | ER-01 asks for | Status |
+|---|---|---|
+| 1 | one fixture and workload identical across all arms | **met** — one virtual table, 40×8 and 200×8, four arms, interleaved |
+| 2 | structural/DOM output **and callback behavior** deterministic-equal before timing | **partly** — structural equality gated every run on both hosts; **no DOM assertion and no callback fixture** |
+| 3 | evidence separating interpreter/lowering, **React/host work**, allocations, **commits**, **bundle reachability**, and **p50/p95/p99** | **partly** — see the four rows below |
+| 4 | implementation complexity, error quality, AI editability, migration cost | **met** — [What it would cost to change](#what-it-would-cost-to-change-if-the-answer-were-different) |
+| 5 | an explicit keep/change recommendation, no architecture mutation | **met** — keep `v/$` a non-goal; the scaffolding was reverted before merge |
+
+Item 3 splits four ways, and two of its four are answerable off the evidence
+already here:
+
+- **Interpreter/lowering work and allocations — met.** That is the whole of
+  [Allocation](#allocation), and it is the axis the arms differ on.
+- **`p50/p95/p99` — met for allocation, and refused for wall clock.** The
+  allocation distribution is *degenerate*: across 40–60 samples the minimum,
+  median and maximum reading were the same number in every arm of every run bar
+  one, where a single arm moved by 0.01%. When min equals max, p95 and p99 are
+  p50 — quoting them as three columns would suggest a spread that is not there,
+  and the one exception is two orders of magnitude below the 1.1% effect. Wall
+  clock is the opposite case and is reported as a direction precisely because
+  its p50 already moved more than the effect; its p95 and p99 would be worse,
+  not better, and are not quoted for the same reason.
+- **Bundle reachability — settled, but by set membership rather than by
+  measurement.** Every symbol in the `$` expansion (`node/element`,
+  `node/children`) is already reachable from every compiled view, so the `$` arm
+  adds zero reachable runtime. Bundle *size* was not measured, and
+  [What it would cost](#what-it-would-cost-to-change-if-the-answer-were-different)
+  says why: the only saving available is deleting the compiler, which is a
+  consequence of the decision rather than evidence for it.
+- **React/host work and commits — not measured.** No `$` counterpart to
+  `emit-react` was built. This is the same gap item 2's DOM arm names, and
+  [What would change the answer](#what-would-change-the-answer) §1 is its honest
+  statement.
+
+**Why the unmet arms cannot move the recommendation.** They all bear on the
+*performance* half, and the performance half is not what decides this. The
+recommendation rests on two independent findings and says either alone would be
+enough; the second is structural rather than numeric. The compiled analyzer
+**refuses** a `$` body, so `{:compiled true}` and `$` cannot appear on one
+declaration — the two front ends are disjoint, not two settings of a dial. A
+React-host number, however large, would be a number about an arm that forfeits
+the manifest, the elided ViewCell, `v/check` and the build-time refusal that
+ER-01's own preservation clause requires kept. No measurement crosses a
+build-time refusal.
+
+**What that leaves is an acceptance question, not a recommendation question**,
+and it is the operator's:
+
+- **Narrow ER-01's acceptance to the structural verdict.** Its numeric arms were
+  specified before it was known that the analyzer refuses `$`; they cannot
+  change the answer, and the report says so above with the reasoning exposed.
+  This is the recommended close.
+- **Or reopen and complete them.** The bill: a `$` counterpart to `emit-react`;
+  a keyed callback fixture asserting DOM equality and handler behaviour across
+  arms; commit counting through a profiler build; and a pinned release worker
+  for percentiles that mean something (D021). That is a second spike of about
+  the size of the first, and its ceiling is a number that still loses to a
+  refusal.
+
+Recording the choice matters more than which way it goes: an acceptance left
+half-open reads later as a result that was quietly dropped.
 
 ## Provenance
 

--- a/examples/ui/minimal-counter/README.md
+++ b/examples/ui/minimal-counter/README.md
@@ -66,6 +66,11 @@ npx shadow-cljs watch app    # dev loop + http://localhost:8280
 `npx` matters: shadow-cljs is a local devDependency, so a bare `shadow-cljs`
 is not on `PATH`.
 
+`watch` is a real dev loop. `my.app/run` carries `^:dev/after-load`, so every
+reload re-enters the mount: the edited view re-renders in place and the counter
+keeps the value it was showing, because an equal frame plan does not re-seed
+`:initial-events`. One metadata key, no reload framework.
+
 ## Why the coordinates are checkout-relative
 
 `deps.edn` resolves both framework artefacts with `:local/root` relative to

--- a/examples/ui/minimal-counter/shadow-cljs.edn
+++ b/examples/ui/minimal-counter/shadow-cljs.edn
@@ -33,10 +33,17 @@
    ;; `:init-fn` runs ONCE, on initial load: shadow appends the call to the
    ;; module's own output (shadow.build.targets.browser/merge-init-fn), and a
    ;; hot reload re-evaluates the changed namespace files, not the module
-   ;; wrapper. This scaffold wires no `:devtools :after-load` and marks
-   ;; nothing `^:dev/after-load`, so `watch` prints shadow's own
-   ;; "reloading code but no :after-load hooks are configured!" and an edited
-   ;; view is picked up on the next page load. That is the smallest thing
-   ;; that runs, not a limit of the mount — `v/mount` is idempotent per root,
-   ;; so re-entering it is the supported reload path when you want one.
+   ;; wrapper. So the dev loop is not the `:init-fn` — it is the
+   ;; `^:dev/after-load` on `my.app/run`, which is the one metadata key this
+   ;; scaffold spends on reloading. `watch` re-enters the mount after every
+   ;; reload, the root re-renders with the edited view, and the frame keeps
+   ;; its state because an equal frame plan does not re-seed
+   ;; `:initial-events`.
+   ;;
+   ;; Note that a bare Freehand app is never hook-less: `re-frame.freehand.rules`
+   ;; declares `^:dev/before-load notify-reload!` and `^:dev/after-load
+   ;; commit-reload!`, so shadow's "no :after-load hooks are configured!"
+   ;; notice never appears here whether or not `run` is marked. What the key
+   ;; adds is not a hook where there were none — it is the one hook that
+   ;; re-renders your view.
    :modules    {:main {:init-fn my.app/run}}}}}

--- a/examples/ui/minimal-counter/src/my/app.cljs
+++ b/examples/ui/minimal-counter/src/my/app.cljs
@@ -33,16 +33,15 @@
 ;; allocating a second one (docs/core/freehand/install.md §Two roots on one
 ;; page).
 ;;
-;; Nothing in this scaffold re-enters it. `run` is the module's `:init-fn`,
-;; which shadow calls once on initial load, and no after-load hook is wired
-;; here — so under `watch` an edited view shows up on the next page load.
-;; That is a choice about how small this directory should be, not a limit:
-;; `rf/init!` is a no-op once an adapter is installed, and re-mounting the
-;; same root under the same frame plan re-renders in place without reseeding
-;; `:initial-events`, so marking `run` with `^:dev/after-load` is the whole
-;; of what a state-preserving reload loop takes.
+;; `run` RE-ENTERS it on every hot reload, and `^:dev/after-load` is the
+;; whole of how. Shadow calls `run` once as the module's `:init-fn` and then
+;; again after each reload, and both calls are safe: `rf/init!` is a no-op
+;; once an adapter is installed, and re-mounting the same root under the
+;; same frame plan re-renders in place WITHOUT reseeding `:initial-events`
+;; — `:initial-events` are a seed, not a replay. So an edited view appears
+;; without a page load and the count it was showing is still on the screen.
 
-(defn ^:export run []
+(defn ^:export ^:dev/after-load run []
   (rf/init! v/adapter)
   (v/mount [counter {}]
            (js/document.getElementById "root")

--- a/implementation/freehand/test/re_frame/freehand/behavior_async_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/behavior_async_dom_cljs_test.cljs
@@ -39,9 +39,10 @@
   the nondeterminism: an async constructor answering a Promise that settles
   ONLY when a case says so, a handle with a VOID-returning mutator
   (`set-spec!` — the ordinary JS shape the memory law exists for), a
-  `dispose!` that must run exactly once, and a book of undisposed instances
-  that is the leak assertion. No timer, no `AbortController`, no npm
-  module: every settle in this file is an explicit call at a chosen moment.
+  `dispose!` that must run exactly once and that can be told to FAIL, and a
+  book of undisposed instances that is the leak assertion. No
+  `AbortController` and no npm module: every settle in this file is an
+  explicit call at a chosen moment.
 
   Crucially, `set-spec!` and `dispose!` THROW when the handle is already
   disposed. Real libraries do (a destroyed Vega view, a released workbook),
@@ -50,7 +51,7 @@
   and the browser lane fails a run on ANY uncaught page error even when
   every assertion passes.
 
-  ## The five cases, and which one is the point
+  ## The seven cases, and which one is the point
 
   1. NORMAL — acquire, install once, apply the spec, dispose once on
      unmount, and leave nothing behind.
@@ -65,14 +66,62 @@
      EVIDENCE ONLY. It must not reopen the closed cell and must not raise.
   5. A COMMAND WHILE PENDING — refused at the recipe, and never replayed
      when the handle later arrives. Commands do not queue.
+  6. THE FINALIZER ITSELF FAILS — the FIRST release throws inside the
+     library, at unmount, on a host that was live. DC-02 names finalizer
+     failure and the recipe says it cannot reopen the owner; a non-idempotent
+     `dispose!` only ever catches a SECOND release, which is a different
+     claim. This case makes the first one fail.
+  7. THE SAME FAILURE, ON THE LATE-SUCCESS PATH — a handle arriving after
+     teardown, whose finalization throws. Its outcome DIFFERS from case 6
+     and the difference is the finding: the two finalizer sites answer to
+     different error channels, and only one of them still notifies.
 
   Case 2 is why the file exists. Cases 1 and 3 pass against a naive recipe;
-  case 2 is where a naive one leaks a handle, and case 4 is where it
-  crashes the lane.
+  case 2 is where a naive one leaks a handle, case 4 is where it crashes
+  the lane, and cases 6 and 7 are where the HOST fails and the question is
+  what the owner is left holding.
+
+  ## What cases 6 and 7 report, and what they cannot
+
+  A finalizer failure is the host's, not the recipe's, so the honest
+  deliverable is a boundary rather than a clean bill:
+
+    THE OWNER'S SIDE IS CLEAN, always. `:disconnect` fences to `:closed`
+    BEFORE it calls the finalizer, and `behaviors/disconnect!` claims and
+    REMOVES the connection record before it runs `:disconnect` at all — so
+    a throwing finalizer leaves the connection table and the target index
+    empty, the phase terminal, and the owner unreachable. There is no
+    retry, because nothing holds a reference with which to retry.
+
+    THE HOST'S SIDE IS NOT, and cannot be. The library was asked exactly
+    once, refused, and still holds the instance. No recipe can release a
+    handle its owner will not release. These cases ASSERT that leak rather
+    than pretend it away — a passing run here means the framework did
+    everything available to it, not that nothing was lost.
+
+  The two cases differ in WHERE the failure surfaces, and that is measured
+  rather than assumed — each installs both doors and asserts which one
+  reads:
+
+    case 6, at unmount    the throw comes straight back out of the unmount
+                          call. React neither swallows it nor routes it: the
+                          root's own uncaught-error handler never fires.
+    case 7, on the late   the throw is inside a `.then`, so it escapes as an
+    path                  UNHANDLED REJECTION — and the announcement that
+                          followed the `dispose!` never runs.
+
+  Case 7 is the one that costs an author something, because a silent
+  missing notification is harder to notice than a loud unmount.
 
   This file rides the browser lane through its `-dom-cljs-test` suffix. It
   also matches the node suites' broader regex, where there is no DOM to
-  mount and it says so rather than passing quietly."
+  mount and it says so rather than passing quietly.
+
+  Task boundaries (`setTimeout 0`) appear in case 7 and nowhere else, and
+  they are not a timing observation: the browser posts its
+  unhandled-rejection notification as its own task, so hopping to that task
+  is the only way to read the door at all. Every settle in this file is
+  still an explicit call."
   (:require ["react" :as react]
             ["react-dom/client" :as rdc]
             [cljs.test :refer-macros [async deftest is testing use-fixtures]]
@@ -105,6 +154,11 @@
 ;;   - the handle's configuration call MUTATES and answers NOTHING;
 ;;   - the handle's dispose is not idempotent — a second one is a fault;
 ;;   - a call on a disposed handle THROWS;
+;;   - RELEASE ITSELF CAN FAIL, on the first attempt, leaving the instance
+;;     alive — a GL context already lost, a workbook released underneath
+;;     you, a view whose teardown hit the network. This is the arm cases 6
+;;     and 7 exist for, and it is not the same thing as the non-idempotent
+;;     second release above;
 ;;   - the library itself knows which instances are still alive, which is
 ;;     what makes "no handle survived" an assertion rather than a hope.
 
@@ -126,8 +180,31 @@
 
 (def ^:private next-id (atom 0))
 
+(def ^:private brittle
+  "Instance ids whose release FAILS. `dispose!` counts the attempt and then
+  throws, and the instance stays in `live` — because it does. A case arms
+  this after the handle exists, so the failure lands on the FIRST release
+  and not on a second one."
+  (atom #{}))
+
+(def ^:private dispose-attempts
+  "id -> how many times the library was ASKED to release it, successful or
+  not. `ops` records only what SUCCEEDED, so this is the separate book that
+  lets `exactly one attempt, and it failed` say something — a retry would
+  read 2 here while `ops` stayed empty."
+  (atom {}))
+
+(def ^:private escapes
+  "Where a finalizer failure surfaced, in order. `[door value]`. Cases 6 and
+  7 install the doors themselves — React's root-level error callback and
+  the page's `unhandledrejection` — because the browser lane fails a run on
+  any uncaught page error, so an UNOBSERVED throw would red the suite
+  instead of being measured by it."
+  (atom []))
+
 (defn- reset-host! []
   (reset! ops []) (reset! live {}) (reset! acquisitions []) (reset! next-id 0)
+  (reset! brittle #{}) (reset! dispose-attempts {}) (reset! escapes [])
   nil)
 
 (defn- record! [op] (swap! ops conj op) nil)
@@ -164,11 +241,19 @@
 
 (defn- dispose!
   "Release an instance. Not idempotent — a second release is a fault the
-  library reports rather than absorbs, so a double teardown cannot hide."
+  library reports rather than absorbs, so a double teardown cannot hide.
+
+  A release can also simply FAIL (`brittle`), which is a different fault
+  and the one DC-02 names. The attempt is counted BEFORE the throw and the
+  instance is left in `live`: the caller asked, the library refused, and
+  the handle is still out there."
   [handle]
   (let [id (:id handle)]
     (when-not (contains? @live id)
       (throw (ex-info "dispose! on an ALREADY-RELEASED instance" {:id id})))
+    (swap! dispose-attempts update id (fnil inc 0))
+    (when (contains? @brittle id)
+      (throw (ex-info "dispose! FAILED inside the library" {:id id})))
     (swap! live dissoc id)
     (record! [:dispose id])
     nil))
@@ -234,6 +319,17 @@
   evidence that a callback outliving its node is inert."
   (atom []))
 
+(def ^:private cells
+  "Every owner cell `:connect` established, in order.
+
+  The SECOND deliberate divergence from the guide's sample, and it earns its
+  place the same way the first one does: cases 6 and 7 claim the owner was
+  fenced `:closed` BEFORE the finalizer was called, and an owner nothing can
+  read is a claim nothing can falsify. Publishing the cell changes no
+  behaviour — the recipe still writes only its own memory, and the test only
+  ever READS what it publishes."
+  (atom []))
+
 (defn- announce! [dispatch event]
   (swap! dispatches conj [event (dispatch event)])
   nil)
@@ -248,6 +344,7 @@
      ;; The memory is established HERE and never again. It is a cell
      ;; because the thing it will hold does not exist yet.
      (let [cell (atom {:phase :pending :handle nil :spec config})]
+       (swap! cells conj cell)                 ; published for READING only
        (.then (acquire! node config)
               (fn [handle]
                 (if (closed? cell)
@@ -335,10 +432,55 @@
     (catch :default e
       (js/Promise.reject e))))
 
-(defn- mount! []
-  (let [container (js/document.createElement "div")]
-    (.appendChild js/document.body container)
-    [container (rdc/createRoot container)]))
+(defn- mount!
+  "A React root. With `watch-errors?` the root carries its OWN error
+  callbacks, so a throw React would otherwise hand to `reportError` — which
+  the browser lane counts as an uncaught page error and fails the run on —
+  arrives in `escapes` where a case can assert on it instead."
+  ([] (mount! false))
+  ([watch-errors?]
+   (let [container (js/document.createElement "div")
+         opts      (when watch-errors?
+                     #js {:onUncaughtError (fn [e _info]
+                                             (swap! escapes conj [:react/uncaught (ex-message e)]))
+                          :onCaughtError   (fn [e _info]
+                                             (swap! escapes conj [:react/caught (ex-message e)]))})]
+     (.appendChild js/document.body container)
+     [container (rdc/createRoot container opts)])))
+
+(defn- watch-rejections!
+  "Open the page's `unhandledrejection` door for one case and answer the
+  closer. `preventDefault` is the point: without it the rejection is
+  reported to the page and the lane fails the run on it, so the door both
+  MEASURES the escape and keeps it from masquerading as a regression."
+  []
+  (let [handler (fn [e]
+                  (.preventDefault e)
+                  (swap! escapes conj [:promise/unhandled (ex-message (.-reason e))])
+                  nil)]
+    (.addEventListener js/window "unhandledrejection" handler)
+    (fn [] (.removeEventListener js/window "unhandledrejection" handler))))
+
+(defn- task-boundary
+  "A promise that settles at the next TASK, not the next microtask.
+  `unhandledrejection` is dispatched there and nowhere earlier, so this is
+  the only way to read that door. A boundary, never a duration."
+  []
+  (js/Promise. (fn [resolve] (js/setTimeout resolve 0))))
+
+(defn- await-escape
+  "Hop task boundaries until the rejection door reads, up to `n` of them.
+
+  One hop is not enough and the reason is worth writing down: the browser
+  posts its unhandled-rejection notification as its OWN task, queued after
+  the microtask checkpoint that observed the rejection — so a `setTimeout`
+  scheduled from inside the promise chain can be dispatched first and see
+  nothing. This waits for an EVENT, never for a duration; the bound exists
+  so a broken run fails instead of hanging."
+  [n]
+  (if (or (seq @escapes) (zero? n))
+    (js/Promise.resolve nil)
+    (.then (task-boundary) (fn [_] (await-escape (dec n))))))
 
 (defn- teardown! [container root]
   (.unmount root)
@@ -352,6 +494,7 @@
   (behaviors/reset-connections!)
   (reset-host!)
   (reset! dispatches [])
+  (reset! cells [])
   (live-frame/make-frame {:id frame-id})
   (rf/reg-event :chart/ready          (fn [db _] db))
   (rf/reg-event :chart/failed         (fn [db _] db))
@@ -364,14 +507,28 @@
 (defn- events [] (mapv first @dispatches))
 (defn- accepted [] (mapv second @dispatches))
 
+(defn- owner-released!
+  "The FRAMEWORK's two books, which must read empty whatever the host did.
+  Split out from [[nothing-survived!]] because cases 6 and 7 need exactly
+  this half: a finalizer that throws still leaves the connection table and
+  the target index clean, and saying so requires an assertion that does not
+  also demand the library let go."
+  [where]
+  (is (= 0 (behaviors/connection-count)) (str where " — the connection table is empty"))
+  (is (= #{} (behaviors/target-ids))     (str where " — no target claim survives")))
+
 (defn- nothing-survived!
   "The leak assertion, said in one place because every case ends with it.
   Three independent books must all read empty: the library's own instance
   ledger, the substrate's connection table, and its live target index."
   [where]
   (is (= {} @live)          (str where " — the library holds NO undisposed instance"))
-  (is (= 0 (behaviors/connection-count)) (str where " — the connection table is empty"))
-  (is (= #{} (behaviors/target-ids))     (str where " — no target claim survives")))
+  (owner-released! where))
+
+(defn- owner-phase
+  "The phase of the one owner cell this case's `:connect` established."
+  []
+  (:phase @(first @cells)))
 
 ;; ===========================================================================
 ;; 1 — the ordinary case
@@ -614,3 +771,143 @@
                        (nothing-survived! "after teardown")
                        (done)))
               (.catch (fn [e] (is false (str "mount rejected: " e)) (done)))))))))
+
+;; ===========================================================================
+;; 6 — THE FINALIZER FAILS, on the first release
+;; ===========================================================================
+
+(deftest a-throwing-finalizer-closes-the-owner-and-leaks-only-the-host
+  (testing "DC-02 requires finalizer failure, and the recipe says a failed
+            finalizer cannot reopen the owner. A `dispose!` that refuses a
+            SECOND release does not test that: the second release is a
+            double-teardown defect and it never happens on a correct path.
+            Here the FIRST release fails, on a host that was live, at
+            unmount.
+
+            The owner's side must be perfect, and it is perfect by
+            ORDERING rather than by handling. `:disconnect` writes
+            `:closed` before it touches the host, and
+            `behaviors/disconnect!` claims and REMOVES the connection
+            record before it runs `:disconnect` at all — so by the time the
+            library refuses, there is no record to retry from and no
+            reachable owner to reopen. Nothing catches the throw and
+            nothing needs to.
+
+            The host's side is a leak, and the case ASSERTS the leak
+            instead of pretending it away. The library was asked exactly
+            once, said no, and still holds the instance. That is the
+            boundary the recipe can honestly claim: everything the owner
+            controls is released; a handle the library will not release is
+            not one of those things."
+    (if-not (browser?)
+      (skip! "the browser job owns the acquisition cases")
+      (async done
+        (setup!)
+        ;; BOTH doors open, so "which one read" is a measurement.
+        (let [close-door       (watch-rejections!)
+              [container root] (mount! :watch-errors)]
+          (-> (act #(.render root (element [chart-panel {:series [6]}])))
+              (.then (fn [_] (settle! 0 :ok)))
+              (.then (fn [_]
+                       (is (= [[:acquire 1 [6]] [:set-spec 1 [6]]] @ops)
+                           "the host is live and configured before anything is armed")
+                       (is (= {1 [6]} @live))
+                       (is (= :ready (owner-phase)))
+                       ;; ARM the failure only now, so it lands on the FIRST release.
+                       (reset! brittle #{1})
+                       (-> (act #(teardown! container root))
+                           (.catch (fn [e]
+                                     (swap! escapes conj [:act/rejected (ex-message e)])
+                                     nil)))))
+
+              (.then (fn [_]
+                       (is (= :closed (owner-phase))
+                           "the owner was FENCED before the finalizer was called —
+                            `:disconnect` writes :closed first and releases second, so
+                            a throw cannot leave it in a live phase")
+                       (is (= {1 1} @dispose-attempts)
+                           "the library was asked to release EXACTLY once: no retry")
+                       (is (= [[:acquire 1 [6]] [:set-spec 1 [6]]] @ops)
+                           "and no :dispose is recorded, because none succeeded")
+                       (is (= {1 [6]} @live)
+                           "HOST-ONLY LEAK, reported rather than pretended away — the
+                            library still holds the instance it refused to release")
+                       (owner-released! "after a throwing finalizer")
+                       (is (= [:act/rejected] (mapv first @escapes))
+                           "and the failure is LOUD, out of the UNMOUNT CALL itself —
+                            exactly one door reads, so the root's own uncaught-error
+                            handler never saw it: React let the throw back out rather
+                            than routing or swallowing it")
+                       (is (= [[:chart/ready :main]] (events))
+                           "and the teardown announced nothing of its own — the only
+                            event is the one the successful install sent")
+                       (close-door)
+                       (done)))
+              (.catch (fn [e]
+                        (close-door)
+                        (is false (str "case rejected: " e))
+                        (done)))))))))
+
+;; ===========================================================================
+;; 7 — the same failure, on the LATE-SUCCESS finalizer
+;; ===========================================================================
+
+(deftest a-throwing-finalizer-on-the-late-path-escapes-as-a-rejection
+  (testing "Case 2's ordering — teardown first, handle second — with case 6's
+            failure. The recipe finalises the late handle where it was born,
+            and here that finalisation throws.
+
+            The outcome DIFFERS from case 6, and the difference is the
+            finding rather than a detail. The late finaliser runs inside a
+            `.then`, so its throw rejects a promise nothing is awaiting: it
+            escapes as an UNHANDLED REJECTION rather than through React,
+            and the `[:chart/abandoned …]` line that follows it never runs.
+            An author reading Pattern E should know that the notification
+            after a late `dispose!` is not guaranteed — a host that refuses
+            to be released takes the announcement with it.
+
+            The owner's side is unchanged and still perfect: `:closed`
+            before the handle ever arrived, connection table and target
+            index already empty, exactly one release attempted."
+    (if-not (browser?)
+      (skip! "the browser job owns the acquisition cases")
+      (async done
+        (setup!)
+        ;; BOTH doors open, so "which one read" is a measurement.
+        (let [close-door       (watch-rejections!)
+              [container root] (mount! :watch-errors)]
+          (-> (act #(.render root (element [chart-panel {:series [7]}])))
+              (.then (fn [_] (act #(teardown! container root))))
+              (.then (fn [_]
+                       (is (= :closed (owner-phase))
+                           "torn down while pending — the owner is already terminal")
+                       (is (= {} @dispose-attempts)
+                           "and nothing was released, because there was nothing yet")
+                       ;; ARM, then let the library answer.
+                       (reset! brittle #{1})
+                       (settle! 0 :ok)))
+              (.then (fn [_] (await-escape 20)))
+
+              (.then (fn [_]
+                       (is (= {1 1} @dispose-attempts)
+                           "the late handle was finalised EXACTLY once")
+                       (is (= [[:acquire 1 [7]]] @ops)
+                           "and never configured, and never successfully released")
+                       (is (= {1 ::unconfigured} @live)
+                           "HOST-ONLY LEAK: the library handed over an instance and then
+                            refused to take it back")
+                       (is (= :closed (owner-phase))
+                           "a failed finalizer cannot reopen the owner")
+                       (owner-released! "after a throwing late finalizer")
+                       (is (= [:promise/unhandled] (mapv first @escapes))
+                           "and THIS is where it differs from case 6 — a throw inside the
+                            continuation is an unhandled rejection, not a React error")
+                       (is (= [] (events))
+                           "so the :chart/abandoned announcement AFTER the dispose never
+                            ran: a refusing host takes the notification with it")
+                       (close-door)
+                       (done)))
+              (.catch (fn [e]
+                        (close-door)
+                        (is false (str "case rejected: " e))
+                        (done)))))))))


### PR DESCRIPTION
Three beads: one fresh operator ruling, two audit reopens of work that merged today.

---

## 1 — `rf2-omygl`: wire the minimal-counter reload hook

### The ruling, verbatim

> **"The capability is one metadata key away."** — Mike, 2026-07-26

### Found versus changed

**Found.** Everything the filing worker established holds, verified rather than
trusted, because the whole ruling rests on the cost:

- `rf/init!` is idempotent. `implementation/core/src/re_frame/core.cljc:2799`
  guards the install with `(when-not (adapter/current-adapter) …)`, so a second
  call is a no-op and not the `:rf.error/adapter-already-installed` throw that
  `install-adapter!` raises directly.
- Re-entering `v/mount` under an equal frame fingerprint re-renders in place.
  `root.cljs` `preflight!`: *"An equal fingerprint is the ratified idempotent
  no-op — the frame is NOT re-seeded, because `:initial-events` are a seed, not
  a replay."*
- So the cost is one metadata key. **Confirmed: the change is one metadata key
  plus prose.** No new file, no reload framework, and the scaffold's five-file
  manifest is untouched.

**One premise in the bead is wrong, and it is the one about the warning.** The
bead says shadow's dev client *"literally prints"* `reloading code but no
:after-load hooks are configured!` on this exact config. **It never did.**
`re-frame.freehand.rules` declares `^:dev/before-load notify-reload!` and
`^:dev/after-load commit-reload!`, so a bare Freehand app is never hook-less and
shadow has no reason to print the notice. It was absent from the console in
every run below, before and after. That sentence in `shadow-cljs.edn` was a
false claim of the opposite kind, and the fix retires it as such rather than
claiming it "no longer" prints.

**Changed.** `^:dev/after-load` on `my.app/run`, and the prose in
`shadow-cljs.edn`, the `app.cljs` mount comment, and one paragraph of the
README made true in the other direction.

### The live-reload proof

Driven against a real `npx shadow-cljs watch app` in this worktree (Playwright,
headless Chromium): load the page, click `+` three times, wait for the DOM to
read 3, then **edit `src/my/app.cljs` under the running build** (`"Count: "` →
`"Tally: "`), wait for shadow to push the reload, and read the DOM and the
console again. Identical runs, one metadata key apart:

| | before the edit | after the reload | verdict |
|---|---|---|---|
| **without** `^:dev/after-load` | `Count: 3` | `Count: 3` | state kept, **view STALE** — the edit is invisible until a page load |
| **with** `^:dev/after-load` | `Count: 3` | `Tally: 3` | **view UPDATED and the count survived** |

Shadow's after-load call list, from the page console, is the other half of the
same fact:

```
without                                       with
call re-frame.freehand.rules/notify-reload!   call re-frame.freehand.rules/notify-reload!
load JS my/app.cljs                           load JS my/app.cljs
call re-frame.freehand.rules/commit-reload!   call re-frame.freehand.rules/commit-reload!
                                              call my.app/run          <-- the whole change
```

**On the warning:** the honest result is that it cannot be "shown gone", because
it was never there. `noAfterLoadWarning` matched **zero** console lines in every
run — before the change, after the change, and in the final run at the committed
tree. The two framework hooks above are why, and the new comment in
`shadow-cljs.edn` says so, so nobody re-derives the false sentence.

The re-entry could plausibly have reset the counter to `0` — an `init!` that
threw, or a frame that re-seeded. It did neither: that is what `Tally: 3` proves,
and it is why the hook is a *state-preserving* reload rather than a reload.

---

## 2 — `rf2-drpa3.182.2`: ER-01's acceptance, reconciled

### Reopen class: **(B) new residual**

The close was accepted, and the audit found something else. Explicitly: *"the
report and recoverable spike satisfy the identical fixture, structural equality,
allocation, complexity, error-quality, AI-editability, migration-price, and
explicit-recommendation arms"* — and then names unmet sub-arms of acceptance
items 2 and 3. Not **(A)**: there is no gate here to be armed-but-not-catching.
Not **(C)**: I pinned the text with history rather than inferring. The only
sentences the fix (`a0be49a31d`) added were the three narrowings its own message
names, and the acceptance language the audit measures against
(*"cooperative … structural … p50/p95/p99"*) is the bead's original, untouched.

### Found versus changed

**Found.** Two of the flagged arms turn out to be **under-claimed rather than
missing**, answerable off evidence already recorded:

- **p50/p95/p99.** The allocation distribution is *degenerate* — the report
  already records min = median = max across 40–60 samples in every arm of every
  run bar one, which moved 0.01%. When min equals max, p95 and p99 **are** p50.
  Printing three columns would imply a spread that is not there.
- **Bundle reachability.** Settled by set membership, not measurement: every
  symbol in the `$` expansion already ships and is already reachable from every
  compiled view, so the arm adds zero reachable runtime. Bundle *size* stays
  unmeasured and the report already says why.

Three arms are genuinely unmeasured: a DOM assertion, a callback fixture, and
any React/host or commit number.

**Changed.** A new `## ER-01's acceptance, arm by arm` section: the five items
with their status, item 3 split four ways, and the reason none of the unmeasured
arms can move the answer — they all bear on the *performance* half, and the half
that decides is **structural**. The compiled analyzer **refuses** a `$` body, so
the two front ends are disjoint rather than two settings of a dial, and no
measurement crosses a build-time refusal.

### ⚠️ Operator gate — the audit's other branch is yours, not mine

The audit offers *"complete the bounded missing arms **or** record an explicit
operator reruling that narrows ER-01 acceptance"*. I have not asserted a
reruling. The section states both closes with their bills and recommends the
narrowing; **the ruling itself is still open.**

- **Narrow ER-01 to the structural verdict** (recommended). Its numeric arms
  were specified before it was known that the analyzer refuses `$`.
- **Or reopen and complete them.** A `$` counterpart to `emit-react`, a keyed
  callback fixture asserting DOM and handler equality, commit counting through a
  profiler build, and a pinned release worker for defensible percentiles — a
  second spike of about the size of the first, whose ceiling is a number that
  still loses to a refusal.

No `v/$` published, no standing harness, no architecture mutation.

---

## 3 — `rf2-drpa3.182.5`: make the *first* release fail

### Reopen class: **(A) weak close**

The audit's own words are the tell: *"making dispose non-idempotent only catches
a SECOND release and is not a throwing-finalizer arm."* The close **armed** a
guard — a `dispose!` that refuses a repeat — where DC-02 asks for a finalizer
that **fails**. A second release is a double-teardown defect that never happens
on a correct path, so the guard could not catch the named case. Not **(C)**: I
checked, and `2511e91993` did not introduce the requirement it fell short of —
*"cooperative cancellation, … exact-once finalization, … and finalizer failure"*
is pre-existing DC-02 text that the reconciliation only reflowed.

### Found versus changed

**Found.** Of the three arms the audit lists, two were already covered and one
was not:

- *Cooperative cancellation* — case 2 (unmount before resolve) is it, and
  `AbortController`-as-proof is an explicit NON-GOAL.
- *Exact-once finalization* — cases 1/2/3/5 each assert exactly one `dispose`.
- *Finalizer failure* — **absent**. Every mounted case let the first dispose
  succeed.

**Changed.** Two mounted cases, deterministic, on both finalizer sites:

- **Case 6 — at unmount, on a live host.** The owner is `:closed` when the
  library is asked, the library is asked **exactly once**, both framework books
  read empty afterwards, and the instance the library refused to release is
  asserted as a surviving **host-only leak** rather than wished away.
- **Case 7 — on the late-success path, after teardown.** Same owner-side
  result, **different escape**: the throw is inside a `.then`, so it is an
  unhandled rejection — and the `:chart/abandoned` announcement below it never
  runs. That is the finding an author has to design around, and Pattern E now
  says so.

Both doors (the root's own error callbacks, and the page's `unhandledrejection`)
are open in both cases, so *which one reads* is a measurement and not an
assumption — and opening them is also what keeps a measured throw from reding
the lane as an uncaught page error. Both new assertions were observed to fail
before they passed: the first focused run read `[:act/rejected]` where I had
guessed `[:react/uncaught]`, and `[]` where I expected `[:promise/unhandled]`
(one `setTimeout 0` is not enough — the browser posts its unhandled-rejection
notification as its own task, queued after a boundary scheduled from inside the
promise chain).

The recipe gains exactly one line, publishing its owner cell for **reading**:
cases 6 and 7 claim the owner was fenced before the finalizer ran, and an owner
nothing can read is a claim nothing can falsify.

### The standing constraint holds

**No public API, no async runtime, no scheduling policy, no D022, no source
change.** `re-frame` event processing remains one complete synchronous pass; the
only new asynchrony is the browser's own task boundary, used to *read* a door
rather than to schedule anything. Nothing here needed machinery, so there is no
concrete failure to return.

---

## Quality gates

Every run foreground to completion, `rc` captured immediately into a
worktree-local log and cross-checked against that log's own verdict line.

| Gate | Command | Result | `rc` |
|---|---|---|---|
| Freehand JVM | `implementation/freehand: clojure -M:test` | **1132 tests / 7584 assertions, 0 failures, 0 errors** | `0` |
| Guide sample coverage | (inside the above) | **113 of 136 fenced blocks — unchanged**, which is the check that the Pattern E prose landed *outside* the digest-pinned fences | `0` |
| Scaffold smoke, real compile | `implementation/ui/scaffold-smoke: RF2_UI_SCAFFOLD_COMPILE=1 clojure -M:test` | **7 / 23, 0 failures, 0 errors** — real `npm install` + `npx shadow-cljs compile app` in a temp dir, plus the omission matrix | `0` |
| Node CLJS | `implementation: npm run test:cljs` | **11498 / 57501, 0 failures, 0 errors** | `0` |
| Node CLJS at base | same, with the test file at `2581c37aef` | **11496 / 57499** → delta **+2 / +2**, exactly the two new cases' node-lane skips | `0` |
| Browser | `implementation: npm run test:browser` | **800 / 5078, 0 failures, 0 errors** | `0` |
| Core JVM | `implementation/core: clojure -M:test` | **2125 / 10484, 0 failures, 0 errors** | `0` |
| Live HMR proof | Playwright against `npx shadow-cljs watch app` | table above; final run taken at the committed tree | `0` |

**Delta attribution.** Browser is `798 / 5057 → 800 / 5078` = **+2 tests /
+21 assertions**, exactly cases 6 and 7. Node is `+2 / +2`, the same two cases
taking their `(browser?)` skip — re-derived at the base commit rather than
assumed, because the briefed node baseline (`11495 / 57478`) sits one test below
this branch's actual base. Freehand JVM and the sample-coverage count are
unchanged to the number. Core moved `2122 / 10475 → 2125 / 10484` with nothing
in this PR touching it; that is `main` drift between the briefed baselines and
this branch's base (`2581c37aef`), the same drift the node figure shows.

Every mutation in this PR was confirmed applied before its verdict was read:
`git diff --stat` plus a grep of the token back out of the file.
