### PR TITLE
fix(freehand): close the host prop-name collision and prove the crossing mounted (rf2-drpa3.182.3)

### DIFF
--- a/docs/api/re-frame.freehand.md
+++ b/docs/api/re-frame.freehand.md
@@ -1244,10 +1244,19 @@ an open flag is writable and not buffered, so it takes the key and no generation
   retirement after unmount and HMR. Children are ordinary React children in the
   registered component's tree, under the declared policy.
 
+  A prop **name** is exact as well: an unqualified keyword, spelled as the
+  library spells the prop. A qualified keyword would cross with its namespace
+  silently dropped, and a string would give one React prop a second spelling —
+  and since every law here is enforced by the name, a second spelling is how
+  `"children"`, `:x/key` or an undeclarable `"onSelect"` would reach React under
+  a reserved name while passing the check that looked for the keyword.
+
   `:map-props` is one optional whole-ordinary-props adapter, run in the browser
   only, for preparing non-portable host values. Callback carriers, children and
   the key are withheld from it and installed afterwards, so it can neither supply
-  nor replace a reserved fact; a returned map that names one is refused.
+  nor replace a reserved fact; a returned map that names one is refused. It
+  answers under the same naming law: the adapter owns the ordinary plane's
+  values, and the names stay the caller's.
 
   A structural render emits an honest marker — the declared host id, the declared
   SSR policy, a **count** of the children that crossed into React's tree, and the

--- a/implementation/freehand/src/re_frame/freehand.cljc
+++ b/implementation/freehand/src/re_frame/freehand.cljc
@@ -2160,6 +2160,15 @@
      only at a position the declaration named, because that is what makes
      the site finite, checkable and able to carry the committed identity.
 
+     **A prop NAME is exact too** — an unqualified keyword, spelled as the
+     library spells the prop, which is the same law `:callbacks` states
+     above. A qualified keyword would cross with its namespace silently
+     dropped and a string would give one React prop a second spelling; and
+     because every law here is enforced BY the name, a second spelling is
+     how `\"children\"`, `:x/key` or an undeclarable `\"onSelect\"` would
+     reach React under a reserved name while passing the check that looked
+     for the keyword.
+
      **`:callbacks` names the finite positions**, and each takes the
      matching `v/event` / `v/handler` carrier. It is never inferred from an
      `on*` name, and a bare event vector there is refused rather than
@@ -2183,9 +2192,12 @@
      non-portable host values. Callback carriers and trailing children are
      withheld from it and installed afterwards, so it cannot supply or
      replace a declared callback, the children, the key or any other
-     reserved fact; a returned map that names one is refused. The
-     structural tree records the AUTHORED props, not the adapter's output —
-     an adapter exists to make values a tree could not print.
+     reserved fact; a returned map that names one is refused. It answers
+     under the caller's own naming law, which is what makes that refusal
+     total: the adapter owns the ordinary plane's VALUES, and the names
+     stay the caller's. The structural tree records the AUTHORED props, not
+     the adapter's output — an adapter exists to make values a tree could
+     not print.
 
      ## Structure and SSR
 

--- a/implementation/freehand/src/re_frame/freehand/descriptor.cljc
+++ b/implementation/freehand/src/re_frame/freehand/descriptor.cljc
@@ -640,6 +640,42 @@
     {:recovery recovery
      :extra    (assoc extra :view-id host-id)}))
 
+(defn host-prop-name
+  "The ONE name `k` crosses under — the name the registered React component
+  reads off its props object.
+
+  There is a single projection because there is a single boundary: the
+  React emitter writes this name, and [[inexact-host-prop-names]] refuses
+  every key this projection could not carry faithfully. Together they are
+  what makes `name` sufficient here."
+  [k]
+  (name k))
+
+(defn inexact-host-prop-names
+  "The keys of `m` that have NO exact crossing name — every key that is not
+  an unqualified keyword — sorted, for a diagnostic.
+
+  The declaration already spells `:callbacks` positions as unqualified
+  keywords, \"EXACT foreign prop names, spelled as the library spells
+  them\". This is that same law on the other side of the call, and it is
+  what makes [[host-prop-name]] total: a qualified keyword would cross with
+  its namespace silently dropped, and a string would give one React prop a
+  SECOND spelling.
+
+  A second spelling is not a cosmetic matter. Every law this boundary
+  enforces — `:children` is the trailing-forms slot, `:key` is the ABI's,
+  a declared callback position takes a carrier and nothing else, a
+  `:map-props` adapter may not supply a reserved fact — is enforced by
+  NAME. So `\"children\"`, `:x/key` and a `\"onSelect\"` no declaration can
+  see would each arrive at React under the reserved name while passing
+  every check that looked for the keyword. Refusing the spelling closes all
+  of them at once, and closes them where the name is authored rather than
+  at each check in turn."
+  [m]
+  (vec (sort-by pr-str
+                (remove #(and (keyword? %) (nil? (namespace %)))
+                        (keys m)))))
+
 (defn- host-callback-value
   "Validate one declared callback position's supplied `value` against its
   declared `role`, and answer it. `nil` is a legal empty position — a
@@ -698,6 +734,9 @@
     inside it is rejected — the same two laws [[normalize-call]] enforces
     for an internal boundary, because they are the boundary CALL ABI and
     not a per-kind rule;
+  - **every prop name is EXACT** — an unqualified keyword, checked FIRST so
+    that every law below can be enforced by name (see
+    [[inexact-host-prop-names]]);
   - **`:key` is stripped** and returned separately, with `:keyed?`
     reporting presence;
   - **declared positions leave the ordinary plane.** A key the declaration
@@ -725,6 +764,23 @@
              "needs no props.")
         :supply-one-props-map
         {:props (error/diag-value-summary props)}))
+    ;; FIRST, because every check after it reads a NAME. A key with two
+    ;; spellings would reach React under the reserved name while passing the
+    ;; check that looked for the keyword.
+    (let [inexact (inexact-host-prop-names props)]
+      (when (seq inexact)
+        (bad-host-props-error!
+          host-id
+          (str "a host prop name is EXACT — an unqualified keyword, spelled as the "
+               "library spells the prop. " (pr-str inexact)
+               (if (= 1 (count inexact)) " is not one." " are not.")
+               " Every key here crosses as its bare name, so a qualified keyword "
+               "would arrive with its namespace silently dropped and a string "
+               "would give one React prop a second spelling — and a second "
+               "spelling is a way past the checks this call makes BY name: "
+               ":children, :key and each declared callback position.")
+          :spell-host-props-as-unqualified-keywords
+          {:props inexact})))
     (when (contains? props :children)
       (bad-host-props-error!
         host-id

--- a/implementation/freehand/src/re_frame/freehand/react.cljs
+++ b/implementation/freehand/src/re_frame/freehand/react.cljs
@@ -940,14 +940,22 @@
   props. `:selected` reaches React as `selected`, and a name the library
   spells `onChange` is written `:onChange`. D022: \"There is no automatic
   case conversion, deep Clojure-to-JavaScript conversion, callback
-  inference, or per-prop conversion language.\""
+  inference, or per-prop conversion language.\"
+
+  Both planes are named by `descriptor/host-prop-name`, the SINGLE crossing
+  projection, and the two planes cannot collide on one name: the ordinary
+  plane has had the declared positions removed from it, and every key in
+  either plane is an unqualified keyword — the exactness
+  `descriptor/inexact-host-prop-names` enforces on the caller's map and on
+  a `:map-props` adapter's answer alike. So this writer never has to ask
+  what a name might already mean."
   [cand ordinary callbacks]
   (let [o (js-obj)]
-    (reduce-kv (fn [_ k v] (gobj/set o (if (keyword? k) (name k) (str k)) v) nil)
+    (reduce-kv (fn [_ k v] (gobj/set o (descriptor/host-prop-name k) v) nil)
                nil ordinary)
     (reduce-kv
       (fn [_ k carrier]
-        (gobj/set o (name k)
+        (gobj/set o (descriptor/host-prop-name k)
                   (if (some? cand)
                     ;; The site key is this walk's ordinal, exactly as an
                     ;; element handler's is — so the position keeps ONE proxy
@@ -989,6 +997,20 @@
              (type-name ordinary) ". It prepares the ordinary-props MAP and must "
              "answer one — it is not a place to build the element.")
         {:host host-id}))
+    ;; The adapter's answer is held to the caller's own naming law, and
+    ;; BEFORE the reserved check below — which is what makes that check
+    ;; total. Asked the other way round, an adapter returning `"key"` or
+    ;; `"onSelect"` would pass a filter looking for the keyword and then
+    ;; reach React under the reserved name anyway.
+    (let [inexact (descriptor/inexact-host-prop-names ordinary)]
+      (when (seq inexact)
+        (malformed!
+          (str "The :map-props adapter on " host-id " returned " (pr-str inexact)
+               ". A host prop name is EXACT — an unqualified keyword, spelled as "
+               "the library spells the prop — because the name is what every "
+               "reserved-fact check reads. The adapter prepares VALUES the "
+               "authored map could not hold; the names stay the caller's.")
+          {:host host-id :props inexact})))
     (let [reserved (vec (sort (filter (fn [k] (or (contains? (:callbacks entry) k)
                                                   (= :key k)
                                                   (= :children k)))

--- a/implementation/freehand/test/re_frame/freehand/host_door_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/host_door_cljs_test.cljc
@@ -256,7 +256,8 @@
   (testing "Pin the table before trusting a row of it."
     (is (= "FH-REACT-007" (:fh/id react-007)))
     (is (<= 5 (count (:accepts react-007))))
-    (is (<= 7 (count (:rejects react-007))))))
+    (is (<= 12 (count (:rejects react-007))))
+    (is (seq (get-in react-007 [:prop-names :rejects])))))
 
 (deftest fh-react-007-the-declaration-matches-the-fixture
   (testing "Per FH-REACT-007: the host under test declares the positions
@@ -296,6 +297,59 @@
               #(descriptor/normalize-host-call planes-host [{:onSelect [:chart/selected]}]))]
       (is (str/includes? m "not a bare event vector"))
       (is (str/includes? m "v/event")))))
+
+(deftest fh-react-007-a-prop-name-is-exact
+  (testing "Per FH-REACT-007 §prop-names: a host prop name is an unqualified
+            keyword, because the crossing names the prop by `name` and every
+            law at this boundary — `:children`, `:key`, each declared
+            position, and what a `:map-props` adapter may not supply — is
+            enforced BY that name. A key with a second spelling reaches React
+            under the reserved name while passing the check that looked for
+            the keyword, so exactness is what makes those checks total rather
+            than a style rule about how to spell a map."
+    (let [{:keys [accepts rejects]} (:prop-names react-007)]
+      (is (= [] (descriptor/inexact-host-prop-names (zipmap accepts (repeat 1))))
+          "an unqualified keyword has an exact crossing name")
+      (is (= (vec (sort-by pr-str rejects))
+             (descriptor/inexact-host-prop-names (zipmap rejects (repeat 1))))
+          "and nothing else does — every rejected spelling is reported, not just the first")
+      (is (= "onSelect" (descriptor/host-prop-name :onSelect))
+          "the crossing projection is the bare name")
+      (is (= (count accepts) (count (into #{} (map descriptor/host-prop-name) accepts)))
+          "and it is injective over the names it accepts — which is the whole claim"))))
+
+(deftest fh-react-007-a-second-spelling-is-refused-at-the-call
+  (testing "Per FH-REACT-007: each of these shipped as a real bypass. The
+            planes were split by comparing Clojure keys while the crossing
+            collapsed them by name, so `\"children\"` walked past both the
+            `:children` rejection and the `:none` policy, `\"onSelect\"` was
+            treated as ordinary DATA and handed to React as the callback
+            prop with none of D008's identity, and `\"key\"` keyed the inner
+            element while the outer phase boundary stayed unkeyed."
+    (doseq [[props case] [[{"children" ["nope"]} "\"children\""]
+                          [{"key" "k"}           "\"key\""]
+                          [{:x/key "k"}          ":x/key"]
+                          [{"onSelect" [:chart/selected]} "\"onSelect\""]
+                          [{:x/spec "bar"}       ":x/spec"]]]
+      (is (= :rf.error/view-bad-props
+             (conf/caught-id #(descriptor/normalize-host-call planes-host [props])))
+          case))))
+
+(deftest fh-react-007-the-inexact-refusal-names-every-offender-and-the-recovery
+  (testing "Per FH-REACT-007 §prop-names: the refusal reports EVERY badly
+            spelled key rather than the first one found, because a call that
+            got the spelling wrong once usually got it wrong twice, and it
+            names the recovery."
+    (let [call #(descriptor/normalize-host-call
+                  planes-host [{"spec" "bar" :x/rows 3 :variant :compact}])
+          m    (conf/caught-message call)]
+      (is (str/includes? m "\"spec\"") "the string key is named")
+      (is (str/includes? m ":x/rows") "and so is the qualified one")
+      (is (not (str/includes? m ":variant")) "the well-spelled key is not accused")
+      (is (str/includes? m "unqualified keyword") "the law is stated")
+      (is (= (get-in react-007 [:prop-names :recovery])
+             (:recovery (conf/caught-data call)))
+          "and the recovery is the fixture's"))))
 
 (deftest fh-react-007-the-children-policy-is-the-common-law
   (testing "Per FH-REACT-007: a host's children policy is the same closed

--- a/implementation/freehand/test/re_frame/freehand/host_mounted_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/host_mounted_dom_cljs_test.cljs
@@ -1,0 +1,513 @@
+(ns re-frame.freehand.host-mounted-dom-cljs-test
+  "D022 acceptance 1 and 4 — the `v/defhost` crossing MOUNTED, against a
+  real `react-dom/client` commit.
+
+  The headless suite (`host-door-cljs-test`) proves the declaration, the
+  three disjoint planes and the structural projection, host-neutrally. None
+  of that runs React. What is left, and what this file owes, is the half
+  that only a real mount can answer: that the contract the declaration
+  advertises is the contract the registered React component actually
+  receives, and that the callback positions carry D008's identity laws
+  rather than a plain function that happens to work once.
+
+  ## The two witnesses
+
+  D022 acceptance 4 asks for a value/callback component and a hook-owning
+  wrapper through the SAME declaration kind, because \"leaf\" and
+  \"wrapper\" describe the registered implementation and were explicitly
+  rejected as a `:kind` split on the declaration.
+
+  * [[vega-chart]] is the React-Vega shape: a value spec in, a selection
+    out, a `:map-props` adapter turning the authored Clojure spec into the
+    JS object the library would want. Nothing else is declared.
+  * [[hook-panel]] is the wrapper shape: it owns `useState`, `useRef`,
+    `useEffect` and a React context Provider, and it renders the caller's
+    children inside its own tree.
+
+  Two implementations that could not be less alike, and the declarations
+  differ only in their options. That is the claim.
+
+  ## Why the assertions are shaped the way they are
+
+  Every callback claim is measured on the EXACT function object React was
+  handed — [[hook-panel]] records it from its own props on every commit —
+  rather than on a value this file constructed. A test that builds its own
+  proxy proves the site machinery works; only the recorded one proves the
+  host path went through it.
+
+  Identity is asserted with `identical?` over the recorded list rather than
+  through a set, because a JS function's CLJS hash is not the thing under
+  test.
+
+  This file rides the browser lane through its `-dom-cljs-test` suffix, and
+  also matches the node suites' broader regex — where the mounted rows have
+  no DOM and say so rather than passing quietly. The two rows that need
+  only the emitter, not a commit, run in both."
+  (:require ["react" :as react]
+            [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.conformance :as conf]
+            [re-frame.freehand.react :as fr]
+            [re-frame.freehand.root :as root]
+            [re-frame.live-frame :as live-frame]
+            [re-frame.adapter.uix :as react-substrate]
+            [re-frame.test-support :as test-support]))
+
+(def react-007 (conf/fixture :FH-REACT-007))
+
+;; ===========================================================================
+;; The ledger — what the REGISTERED COMPONENT saw, in its own words
+;; ===========================================================================
+;;
+;; Written from inside the React components, so every claim below is about
+;; what really crossed rather than about what this file passed in.
+
+(def ^:private ledger (atom nil))
+
+(defn- reset-ledger! []
+  (reset! ledger {:commits      0
+                  :callback-ids []
+                  :rows-shape   nil
+                  :notes        []
+                  :live-panels  0})
+  nil)
+
+(defn- one-identity?
+  "Are all of `fs` the same object? `identical?` rather than a set, because
+  a JS function's CLJS hash is not what this is asking about."
+  [fs]
+  (and (seq fs) (every? #(identical? (first fs) %) fs)))
+
+;; ===========================================================================
+;; Witness 1 — a hook-owning wrapper (D022 acceptance 4)
+;; ===========================================================================
+
+(defonce ^:private theme-context
+  ;; Default "default", so a consumer reached from a DIFFERENT React tree
+  ;; reads the default and "outer" read back is proof of ONE shared tree.
+  (react/createContext "default"))
+
+(def ^:private theme-probe
+  "A raw React consumer, handed to the host as an ordinary child value."
+  (fn [_props]
+    (react/createElement "span" #js {:className "theme-probe"}
+                         (react/useContext theme-context))))
+
+(def hook-panel
+  "A React component that owns hooks — `useState`, `useRef`, `useEffect`
+  and a context Provider — and renders the caller's children inside its own
+  tree. The wrapper shape, and deliberately NOT a second declaration kind:
+  D022 rejected a leaf/wrapper `:kind` split by name, because which of the
+  two a component is is a fact about its implementation and not about its
+  boundary."
+  (fn [^js props]
+    (let [label     (.-label props)
+          rows      (.-rows props)
+          on-select (.-onSelect props)
+          on-note   (.-onNote props)
+          [opened set-opened] (react/useState 0)
+          first-seen (react/useRef nil)]
+      (when (nil? (.-current first-seen))
+        (set! (.-current first-seen) on-select))
+      ;; No dependency array: this runs after EVERY commit, which is what
+      ;; makes `:commits` a count of committed renders rather than of render
+      ;; passes. An abandoned pass never reaches here, and that is the point.
+      (react/useEffect
+        (fn []
+          (swap! ledger (fn [l]
+                          (-> l
+                              (update :commits inc)
+                              (update :callback-ids conj on-select)
+                              (assoc :rows-shape (cond
+                                                   (vector? rows) :cljs-vector
+                                                   (array? rows)  :js-array
+                                                   :else          :other)))))
+          js/undefined))
+      (react/useEffect
+        (fn []
+          (swap! ledger update :live-panels inc)
+          (fn [] (swap! ledger update :live-panels dec)))
+        #js [])
+      (react/createElement
+        "div" #js {:className   "hook-panel"
+                   :data-label  label
+                   :data-opened (str opened)}
+        (react/createElement "button"
+                             #js {:className "select"
+                                  :onClick   (fn [] (when on-select (on-select "mark")))}
+                             "select")
+        (react/createElement "button"
+                             #js {:className "note"
+                                  :onClick   (fn [] (when on-note (on-note "noted")))}
+                             "note")
+        (react/createElement "button"
+                             #js {:className "open"
+                                  :onClick   (fn [] (set-opened inc))}
+                             "open")
+        ;; The caller's children, inside the component's OWN tree and under
+        ;; its OWN context. One shared React tree is what makes this legal.
+        (react/createElement (.-Provider theme-context) #js {:value "outer"}
+                             (.-children props))))))
+
+;; ===========================================================================
+;; Witness 2 — a React-Vega-class value/callback component (acceptance 4)
+;; ===========================================================================
+
+(def vega-chart
+  "The React-Vega shape: a spec in, a selection out. It reads a real JS
+  object off `props.spec`, which is what a charting library wants and what
+  the authored Clojure map is NOT — so the declaration carries the one
+  `:map-props` adapter, and the crossing itself stays free of any per-prop
+  conversion language."
+  (fn [^js props]
+    (let [spec      (.-spec props)
+          on-select (.-onSelect props)]
+      (react/createElement
+        "div" #js {:className "vega-chart" :data-mark (.-mark spec)}
+        (.map (.-values spec)
+              (fn [value _i]
+                (react/createElement
+                  "button"
+                  #js {:key        (str value)
+                       :className  "vega-mark"
+                       :data-value (str value)
+                       :onClick    (fn [] (when on-select (on-select value)))}
+                  (str value))))))))
+
+;; ===========================================================================
+;; The declarations — one kind, two very different implementations
+;; ===========================================================================
+
+(v/defhost panel-host
+  "The hook-owning wrapper, declared."
+  hook-panel
+  {:callbacks {:onSelect :event :onNote :handler}
+   :children  :required
+   :ssr       :client-only})
+
+(v/defhost vega-host
+  "The value/callback chart, declared. Same verb, same descriptor kind."
+  vega-chart
+  {:callbacks {:onSelect :event}
+   :children  :none
+   :ssr       :client-only
+   :map-props (fn [p] {:spec (clj->js (:spec p))})})
+
+(v/defhost renaming-host
+  "A host whose adapter tries to rename its way past the reserved-fact
+  check — the browser half of the naming law FH-REACT-007 §prop-names
+  states. The adapter owns VALUES; the names stay the caller's."
+  vega-chart
+  {:callbacks {:onSelect :event}
+   :children  :none
+   :ssr       :client-only
+   :map-props (fn [_p] {"key" "smuggled" "onSelect" "smuggled" :x/spec 1})})
+
+;; ===========================================================================
+;; The application under mount
+;; ===========================================================================
+
+(rf/reg-sub :d022/label      (fn [db _] (:label db)))
+(rf/reg-sub :d022/prefix     (fn [db _] (:prefix db)))
+(rf/reg-sub :d022/selections (fn [db _] (:selections db)))
+
+(rf/reg-event :d022/selected
+  (fn [{:keys [db]} [_ v]] {:db (update db :selections conj v)}))
+(rf/reg-event :d022/label-changed
+  (fn [{:keys [db]} [_ l]] {:db (assoc db :label l)}))
+(rf/reg-event :d022/prefix-changed
+  (fn [{:keys [db]} [_ p]] {:db (assoc db :prefix p)}))
+
+(v/defview panel-page
+  "The use site, and the whole integration. `prefix` is read INSIDE the
+  render, so the `v/event` body is re-authored on every commit while the
+  site — and therefore the function React holds — stays put. That gap is
+  where `latest committed body` lives."
+  [_]
+  (let [label  (v/sub [:d022/label])
+        prefix (v/sub [:d022/prefix])]
+    [:section.panel-page
+     [panel-host {:label    label
+                  ;; An ordinary prop is DATA and crosses SHALLOWLY: this
+                  ;; arrives as the Clojure vector it is, not as a JS array.
+                  :rows     [1 2 3]
+                  :onSelect (v/event [mark] [:d022/selected (str prefix "-" mark)])
+                  :onNote   (v/handler [n] (swap! ledger update :notes conj n))}
+      [:em.kid "freehand child"]
+      (react/createElement theme-probe nil)]]))
+
+(v/defview vega-page
+  [_]
+  (let [prefix (v/sub [:d022/prefix])]
+    [:figure.vega-page
+     [vega-host {:spec     {:mark "bar" :values [10 20]}
+                 :onSelect (v/event [value] [:d022/selected (str prefix "-" value)])}]]))
+
+;; ===========================================================================
+;; Harness
+;; ===========================================================================
+
+(def ^:private fid :dom/host-mounted)
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       react-substrate/adapter
+     :ambient-frame nil
+     :async?        true
+     :init-fn       (fn []
+                      (reset-ledger!)
+                      (root/reset-registry!)
+                      (fr/reset-boundaries!))}))
+
+(defn- browser? []
+  (and (exists? js/document) (some? (.-createElement js/document))))
+
+(defn- skip! [why]
+  (is true (str "a real React mount needs a DOM host — " why)))
+
+(defn- act
+  "A React 19 `act` boundary as a promise, so assertions run after the
+  commit AND its flushed effects rather than racing them."
+  [thunk]
+  (try
+    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+    (js/Promise.resolve (react/act (fn [] (js/Promise.resolve (thunk)))))
+    (catch :default e
+      (js/Promise.reject e))))
+
+(defn- host-node! []
+  (let [container (js/document.createElement "div")]
+    (.appendChild js/document.body container)
+    container))
+
+(defn- setup! [db]
+  (live-frame/make-frame {:id fid})
+  (frame/replace-app-db! fid db)
+  nil)
+
+(defn- send! [ev] (rf/dispatch-sync ev {:frame fid}))
+(defn- read* [query] (rf/subscribe-once query {:frame fid}))
+(defn- mount! [container form] (v/mount form container {:frame fid}))
+(defn- q [container selector] (.querySelector container selector))
+
+(defn- teardown! [container mounted]
+  (v/unmount! mounted)
+  (.remove container)
+  nil)
+
+(def ^:private seed {:label "alpha" :prefix "p1" :selections []})
+
+;; ===========================================================================
+;; D022 acceptance 1 — one mounted fixture, the whole declared contract
+;; ===========================================================================
+
+(deftest d022-a-mounted-host-carries-the-whole-declared-contract
+  (testing "D022 acceptance 1. One crossing, mounted, and every law the
+            declaration advertises measured on it: value props shallow and
+            exact, an `:event` position and a `:handler` position doing
+            their two different jobs, the caller's children inside the
+            registered component's own tree and under its own context,
+            ONE callback identity across every commit, the LATEST committed
+            body behind that unchanged identity, and total retirement after
+            unmount.
+
+            The identity and the body claims are the pair that matters, and
+            they pull in opposite directions: React must see a prop that
+            never changes, and the adopter must get the behaviour they most
+            recently wrote. A host position that handed over the authored
+            closure would pass the second and fail the first; one that
+            memoised the closure would pass the first and fail the second."
+    (if-not (browser?)
+      (skip! "the browser job runs the mounted host crossing")
+      (async done
+        (setup! seed)
+        (let [container (host-node!)]
+          (-> (act #(mount! container [panel-page {}]))
+              (.then
+                (fn [mounted]
+                  (let [panel (q container ".hook-panel")]
+                    (is (some? panel) "the registered component really rendered")
+                    (is (= "alpha" (.getAttribute panel "data-label"))
+                        "a value prop crossed under its exact name")
+                    (is (= :cljs-vector (:rows-shape @ledger))
+                        "and crossed SHALLOWLY — no deep Clojure-to-JavaScript walk")
+                    (is (= "freehand child" (.-textContent (q container ".hook-panel em.kid")))
+                        "the caller's children are inside the component's own tree")
+                    (is (= "outer" (.-textContent (q container ".hook-panel .theme-probe")))
+                        "and read the component's OWN React context — one shared
+                         tree, not a portal or a nested root")
+                    (is (= 1 (:live-panels @ledger))
+                        "the wrapper's own mount effect ran exactly once"))
+                  (act (fn [] (.click (q container "button.select")) mounted))))
+              (.then
+                (fn [mounted]
+                  (is (= ["p1-mark"] (read* [:d022/selections]))
+                      "the :event position dispatched its event vector")
+                  (act (fn [] (.click (q container "button.note")) mounted))))
+              (.then
+                (fn [mounted]
+                  (is (= ["noted"] (:notes @ledger))
+                      "the :handler position ran imperative work")
+                  (is (= ["p1-mark"] (read* [:d022/selections]))
+                      "and dispatched nothing of its own — the two roles are
+                       different contracts, not two spellings of one")
+                  ;; A commit that moves BOTH the rendered value and the
+                  ;; callback's body, so the next two assertions cannot both
+                  ;; be read off a tree that never re-rendered.
+                  (act (fn []
+                         (send! [:d022/prefix-changed "p2"])
+                         (send! [:d022/label-changed "beta"])
+                         mounted))))
+              (.then
+                (fn [mounted]
+                  (is (= "beta" (.getAttribute (q container ".hook-panel") "data-label"))
+                      "the re-render really committed")
+                  (is (< 1 (:commits @ledger))
+                      "and there was more than one commit to compare across")
+                  (is (one-identity? (:callback-ids @ledger))
+                      "React was handed the SAME function object every time —
+                       a declared position is one site, and a site owns its
+                       identity")
+                  (act (fn [] (.click (q container "button.select")) mounted))))
+              (.then
+                (fn [mounted]
+                  (is (= ["p1-mark" "p2-mark"] (read* [:d022/selections]))
+                      "and that unchanged object ran the LATEST committed body")
+                  (act #(teardown! container mounted))))
+              (.then
+                (fn [_]
+                  (let [held (first (:callback-ids @ledger))]
+                    (is (fn? held) "the component really recorded what it was handed")
+                    (held "after-unmount")
+                    (is (= ["p1-mark" "p2-mark"] (read* [:d022/selections]))
+                        "a proxy a foreign component still holds is INERT after
+                         unmount — it dispatches nothing rather than firing into
+                         whatever owns the frame now"))
+                  (is (= 0 (:live-panels @ledger))
+                      "and the registered component's own cleanup ran")
+                  (done)))
+              (.catch (fn [e]
+                        (is false (str "mount rejected: " e))
+                        (done)))))))))
+
+(deftest d022-a-hosts-callback-does-not-fire-into-its-successor
+  (testing "D022 acceptance 1, the retirement half that unmount alone cannot
+            show: a proxy held across a REMOUNT of the same view — the shape
+            a hot reload takes, and the shape a foreign library takes when it
+            caches the callback it was given.
+
+            The successor occupies the same view id and the same site key, so
+            a scheme that keyed identity on either would let the stale
+            reference fire into the new occurrence. It must stay inert while
+            the successor's own callback works."
+    (if-not (browser?)
+      (skip! "the browser job runs the remount")
+      (async done
+        (setup! seed)
+        (let [container (host-node!)]
+          (-> (act #(mount! container [panel-page {}]))
+              (.then (fn [mounted] (act #(teardown! container mounted))))
+              (.then
+                (fn [_]
+                  (let [stale     (first (:callback-ids @ledger))
+                        container (host-node!)]
+                    (-> (act #(mount! container [panel-page {}]))
+                        (.then
+                          (fn [mounted]
+                            (stale "from-the-dead")
+                            (is (= [] (read* [:d022/selections]))
+                                "the stale proxy fired into nothing")
+                            (is (= 1 (count (filter #(= :re-frame.freehand.host-mounted-dom-cljs-test/panel-page %)
+                                                    (keys (fr/boundary-cache)))))
+                                "and the successor reused the ONE cached boundary
+                                 for this view id, which is the reload invariant
+                                 that makes the stale reference plausible")
+                            (act (fn [] (.click (q container "button.select")) mounted))))
+                        (.then
+                          (fn [mounted]
+                            (is (= ["p1-mark"] (read* [:d022/selections]))
+                                "while the successor's own callback is live")
+                            (act #(teardown! container mounted))))
+                        (.then (fn [_] (done)))
+                        (.catch (fn [e]
+                                  (is false (str "remount rejected: " e))
+                                  (done)))))))
+              (.catch (fn [e]
+                        (is false (str "mount rejected: " e))
+                        (done)))))))))
+
+;; ===========================================================================
+;; D022 acceptance 4 — the value/callback witness, through the same verb
+;; ===========================================================================
+
+(deftest d022-a-value-callback-chart-crosses-through-the-same-declaration
+  (testing "D022 acceptance 4: a React-Vega-class component — a value spec
+            in, a selection out — reaching the page through the same verb
+            and the same descriptor kind as the hook-owning wrapper above,
+            from a call site that is one map.
+
+            The `:map-props` adapter is the whole of the conversion story:
+            it prepares the ONE value the authored Clojure map could not
+            hold, and the crossing itself gains no per-prop conversion
+            language for it."
+    (if-not (browser?)
+      (skip! "the browser job runs the chart mount")
+      (async done
+        (setup! seed)
+        (let [container (host-node!)]
+          (-> (act #(mount! container [vega-page {}]))
+              (.then
+                (fn [mounted]
+                  (is (= "bar" (.getAttribute (q container ".vega-chart") "data-mark"))
+                      "the adapter's JS object reached the library as one")
+                  (is (= 2 (.-length (.querySelectorAll container ".vega-mark")))
+                      "and the chart rendered from it")
+                  (act (fn [] (.click (q container "button.vega-mark")) mounted))))
+              (.then
+                (fn [mounted]
+                  (is (= ["p1-10"] (read* [:d022/selections]))
+                      "a value the LIBRARY chose came back as an ordinary
+                       re-frame event")
+                  (act #(teardown! container mounted))))
+              (.then (fn [_] (done)))
+              (.catch (fn [e]
+                        (is false (str "mount rejected: " e))
+                        (done)))))))))
+
+;; ===========================================================================
+;; The naming law, browser half — a `:map-props` adapter may not rename
+;; ===========================================================================
+
+(deftest d022-a-map-props-adapter-answers-under-the-callers-naming-law
+  (testing "Per FH-REACT-007 §prop-names §map-props-adapter: the adapter
+            owns the ordinary plane's VALUES, and the names stay the
+            caller's.
+
+            This is the second half of the defect the reopen named. The
+            reserved-fact check filtered the adapter's answer for the
+            KEYWORDS `:key`, `:children` and each declared position, while
+            the crossing named every key by `name` — so an adapter
+            returning `\"key\"` or `\"onSelect\"` passed the filter and
+            reached React under the reserved name anyway. Holding the
+            answer to the caller's own exactness law FIRST is what makes
+            that filter total.
+
+            No commit needed: the refusal is the emitter's, so this row
+            runs in the node lane too."
+    (let [d (conf/caught-data #(fr/element [renaming-host {:spec {:mark "bar" :values [1]}}]))]
+      (is (= (get-in react-007 [:prop-names :map-props-adapter :error-id])
+             (:rf.error/id d))
+          "the adapter's answer is refused")
+      (doseq [k (get-in react-007 [:prop-names :map-props-adapter :rejects])]
+        (is (some #(= k %) (:props d))
+            (str "and " (pr-str k) " is named in the refusal"))))))
+
+(deftest d022-a-well-named-adapter-still-crosses
+  (testing "The positive control for the row above: the SAME machinery, an
+            adapter that spells its answer exactly, and the crossing
+            happens. Without this, the refusal above could be a host that
+            never crosses at all."
+    (is (some? (fr/element [vega-host {:spec {:mark "bar" :values [1]}}]))
+        "an exactly-named adapter answer produces a real React element")))

--- a/spec/004-Views.md
+++ b/spec/004-Views.md
@@ -1667,6 +1667,16 @@ reaches a host only at a position the declaration named, because that is what
 makes the site finite, checkable, and able to carry the committed identity
 below.
 
+**A prop NAME is exact too: an unqualified keyword, and nothing else.** The
+crossing names each prop by its bare name, so a qualified keyword would arrive
+with its namespace silently dropped, and a string would give one React prop a
+second spelling. A second spelling is not cosmetic — every law at this boundary
+is enforced BY the name, so `"children"`, `:x/key` and a `"onSelect"` no
+declaration can see would each reach React under the reserved name while
+passing the check that looked for the keyword. Exactness is what makes those
+checks total, and it is the same law `:callbacks` already states on the
+declaration side.
+
 **`:callbacks` is a finite map from EXACT prop names to the roles `:event` or
 `:handler`.** A position accepts the corresponding carrier and is never inferred
 from an `on*` name. A bare event vector at a foreign callback position is NOT an
@@ -1698,7 +1708,9 @@ non-portable host values. It runs in the browser only, and on the ordinary plane
 only: callback carriers and trailing children are WITHHELD from it and installed
 afterwards. The adapter MUST NOT supply or replace declared callbacks, children,
 the key, or any other reserved Freehand fact, and a returned map naming one is
-refused.
+refused. It answers under the caller's own naming law — the adapter owns the
+ordinary plane's VALUES, and the names stay the caller's — which is what makes
+that refusal total rather than a filter a second spelling walks past.
 
 Props-contract evidence under `:props` is OPTIONAL for application-private
 declarations; the stronger publication policy of

--- a/spec/conformance/freehand/fixtures/fh-react-007.edn
+++ b/spec/conformance/freehand/fixtures/fh-react-007.edn
@@ -60,7 +60,45 @@
    :error-id :rf.error/view-bad-props}
   {:case     "a non-map props slot"
    :props    :fixture/not-a-map
+   :error-id :rf.error/view-bad-props}
+
+  ;; Every row from here down is ONE defect: a prop key with a SECOND
+  ;; spelling. The planes above are split by comparing Clojure keys, and the
+  ;; crossing names the prop by `name`, so `:children`, "children" and
+  ;; :x/children were one React prop name reached by three keys of which only
+  ;; the first was ever checked. Each row is a real bypass that shipped.
+  {:case     "\"children\" — the reserved slot under a second spelling, which reached React as props.children past the :children rejection AND the :none policy"
+   :props    {"children" ["nope"]}
+   :error-id :rf.error/view-bad-props}
+  {:case     "\"key\" — became an inner React key while the outer phase boundary stayed unkeyed, because :keyed? tracks the keyword"
+   :props    {"key" "k"}
+   :error-id :rf.error/view-bad-props}
+  {:case     ":x/key — a qualified keyword drops its namespace at the crossing and lands on the same reserved name"
+   :props    {:x/key "k"}
+   :error-id :rf.error/view-bad-props}
+  {:case     "\"onSelect\" — a declared position under a second spelling, which passed the ordinary-plane DATA check and arrived as the callback prop with none of D008's identity"
+   :props    {"onSelect" [:chart/selected]}
+   :error-id :rf.error/view-bad-props}
+  {:case     ":x/spec — no collision, and still refused: the namespace would be dropped silently, and exactness is what makes every check above total"
+   :props    {:x/spec "bar"}
    :error-id :rf.error/view-bad-props}]
+
+ ;; The naming law the rows above rest on. Stated positively so a regression
+ ;; that removes the check reds this row rather than passing through an
+ ;; absence list.
+ :prop-names
+ {:law      "a host prop name is EXACT: an unqualified keyword, which is the same spelling the declaration requires of every :callbacks position"
+  ;; Exactness only. `:key` is exact and legal HERE — that it is then
+  ;; stripped as the ABI's own slot is a different law, two rows above.
+  :accepts  [:spec :onWhatever :data-testid :aria-label :key]
+  :rejects  ["spec" :x/spec "children" "key" 3]
+  :recovery :spell-host-props-as-unqualified-keywords
+  :error-id :rf.error/view-bad-props
+  ;; A `:map-props` adapter answers the ordinary plane, so it answers under
+  ;; the same law — and is checked BEFORE the reserved filter, which is what
+  ;; makes that filter total. Browser-side: the adapter never runs on the JVM.
+  :map-props-adapter {:rejects  ["key" "onSelect" :x/spec]
+                      :error-id :rf.error/ui-tree-malformed}}
 
  ;; The children policy is the same closed roster an internal boundary uses,
  ;; and it is reported through the same diagnostic.


### PR DESCRIPTION
Reopen work on `rf2-drpa3.182.3` (D022 vertical slice). PR #7025 landed the
door; this PR answers the merged-PR audit that reopened it.

## What the reopen actually named versus what already shipped

**`v/defhost` already ships, and this PR adds no public verb.** The
declaration, the nominal `HostDescriptor`, `normalize-host-call`, structural
and SSR lowering, React lowering, the compiled build refusal
(`:rf.ui.compile/host-crossing-unsupported`), the FH-REACT-006/007/008 rows
and the whole api-manifest lane all landed in #7025. `spec/api-manifest.edn`
already rows `defhost` `:runtime-verified? true`, and there is no
`re-frame.freehand.host` namespace — the only published siblings are `.test`
and `.tool`. Nothing here changes that.

The audit named three things on top of that door. Two were mine to fix, one
was not.

**1. A real correctness defect — the prop-name collision.** The disjoint-plane
guard compared raw Clojure keys, while the crossing named keyword keys by
`name` and every other key by `str` into one JS object. So `:key`, `"key"`
and `:x/key` were one React prop name, as were `:children`/`"children"` and a
declared `:onSelect`/`"onSelect"`. Every law at this boundary is enforced BY
the name, so each second spelling walked past the check written to stop it
and arrived at React under the reserved name anyway:

* `[host {"children" c}]` bypassed the `:children` rejection **and** the
  `:none` children policy, reaching React as `props.children`;
* `{"onSelect" [:evt]}` bypassed the declared carrier check as ordinary
  data, arriving as the callback prop with none of D008's identity;
* `"key"` became an inner React key while the outer phase boundary stayed
  unkeyed, because `:keyed?` tracks the keyword;
* `:map-props` could return any of those past a keyword-only reserved filter.

Fixed at the naming boundary rather than at each check in turn, which is what
the audit asked for. **A host prop name is EXACT — an unqualified keyword**,
which is already the law the declaration states for `:callbacks` positions
("EXACT foreign prop names, spelled as the library spells them"). That makes
`descriptor/host-prop-name` total, and every law enforced by name total with
it. Constraining the key domain removes the collision class rather than
patching each collision, so no new per-check machinery appears.

**2. Acceptance 1 — the mounted fixture.** The only browser host row that
shipped called `fr/element` on `[chart-host {:spec "bar"}]` and asserted an
element existed. It mounted nothing. There is now one mounted fixture against
a real `react-dom/client` commit proving value props (shallow and exact), an
`:event` position and a `:handler` position doing their two different jobs,
children inside the registered component's own tree and under its own React
context, ONE callback identity across every commit, the LATEST committed body
behind that unchanged identity, inertness after unmount, and no firing into a
successor across a remount. Every callback claim is measured on the exact
function object React was handed — the component records it from its own
props — rather than on a value the test built.

**3. Acceptance 4 — the two witnesses.** `vega-chart` is the React-Vega-shaped
value/callback component (the audit's `(fn [_props] nil)` stand-in is
replaced by a component that really renders and really calls back), fed by
the one `:map-props` adapter. `hook-panel` owns `useState`, `useRef`,
`useEffect` and a context Provider. Same verb, same descriptor kind — which
is the claim D022 makes in rejecting a leaf/wrapper `:kind` split. The
`.cljc` `chart-host` in the pilot is left as the cross-host declaration
stand-in it has to be: there is no React on the JVM.

**Not mine, and deliberately untouched.** The audit assigns item 5's guide
convergence to `rf2-drpa3.182.13` (merged) and the fenced Spec 009 catalogue
wording to `rf2-drpa3.182.14`. `docs/core/freehand/**` is not touched by this
PR — including the `js-libraries.md:15` DC-08 conflict, which a live worker
owns. This slice needed no restatement of the DC-08 routing table.

## Not the api-manifest serial lane

No public verb is added, removed, renamed or re-tiered, and the manifest rows
carry structural facts only — no prose. Verified rather than assumed: `gen
--check` reports **in sync (574 public vars)** at rc=0, with an **empty `git
diff` on `spec/api-manifest.edn` and `spec/api-manifest-metadata.edn`**.

## Quality gates

All run in the worker worktree, `rc` captured immediately and cross-checked
against each log's own verdict line.

| Gate | Result | rc |
|---|---|---|
| freehand JVM (`clojure -M:test`) | 1135 tests / 7604 assertions, 0F 0E | 0 |
| core JVM (`clojure -M:test`) | 2125 / 10484, 0F 0E | 0 |
| `npm run test:cljs` (node) | 11506 / 57547, 0F 0E | 0 |
| `node-test-freehand` (node) | 1210 / 6617, 0F 0E | 0 |
| `npm run test:browser` | 805 / 5105, 0F 0E | 0 |
| `python -m mkdocs build --strict` (run directly) | built in 23.3s | 0 |
| `api-manifest.gen --check` | in sync, 574 vars, **empty diff** | 0 |
| `api-manifest.api-md-check` | in sync, 254 var-rows | 0 |
| `api-manifest.doc-api-check` | in sync, 323 refs + 240 vars | 0 |
| `api-manifest.doc-guide-check` | in sync, 733 refs | 0 |
| `api-manifest.skills-check` | in sync, 560 refs | 0 |
| `api-manifest.ui-context --check` | in sync, 98 ids / 32 vars | 0 |
| `scripts/test-fast-pr.sh` | `PASS fast PR spine` | 0 |

The spine soft-skips mkdocs ("mkdocs not on PATH"), so `python -m mkdocs
build --strict` was run directly instead of relied on through it.

The browser lane moved 800→805 tests and 5078→5105 assertions: **+5 tests and
+27 assertions, which is exactly this PR's browser-mode count**, so no
mounted row silently took the `skip!` path.

**Determinism.** The mounted assertions are new and settle-dependent, so the
compiled bundle was replayed **10 further times** beyond the gate run. All 11
runs: `805 tests / 5105 assertions, 0 failures, 0 errors, rc=0` — byte
identical.

**Negative controls.** Both halves of the fix were reverted in turn and the
suites go loudly red:

* caller half (exactness removed from `normalize-host-call`) —
  `host-door-cljs-test` gives **11 failures / 4 errors** across its 23 tests,
  against 0F/0E with the fix;
* `:map-props` half (the check removed from `host-element`) — the freehand
  node lane gives **4 failures**, against 0F/0E with it.

Each mutation was confirmed applied by `git diff --stat` **and** by grepping
the token back out before the verdict was read. Each file was restored from a
**backup copy** rather than `git checkout --`, and both restorations were
verified **blob-identical to HEAD** via `git hash-object`.

## Fenced surfaces

`docs/core/freehand/**`, `scripts/git-hooks/**` and
`spec/conformance/freehand/donor-inventory.md` are untouched.
`rules.cljc` / `conversion.cljc` are untouched. `react.cljs` **is** edited —
unavoidably, since the defect lives in its `host-props` / `host-element`
pair, which is D022's own code from #7025. The just-merged interpreter
optimisation (`bcfc568c69`) touches that file only at old lines 187–836; the
host block begins at line 930 and none of its six changes is altered,
reverted or moved.
