### PR TITLE
docs(freehand): reflow the forms.md narrow-read paragraph (tail of #7080, rf2-kf299)

### DIFF
--- a/docs/core/freehand/forms.md
+++ b/docs/core/freehand/forms.md
@@ -58,8 +58,9 @@ and it reads **its own key** — never the whole draft map:
 ```
 
 **Why parametric, and not `(:email (v/sub [:editor/draft]))`.** `:editor/field` is
-the narrow read — `(rf/reg-sub :editor/field (fn [db [_ k]] (get-in db [:editor
-:draft k])))`. The two spellings look equivalent and are not. Every keystroke
+the narrow read:
+`(rf/reg-sub :editor/field (fn [db [_ k]] (get-in db [:editor :draft k])))`.
+The two spellings look equivalent and are not. Every keystroke
 writes a new `:draft` map, so a field that subscribed to the whole map is
 invalidated by a character typed in any other field; and because a controlled
 input's [synchronous door](events-and-handlers.md#controlled-inputs) drains


### PR DESCRIPTION
Tail of PR #7080 (rf2-kf299), which merged at `7db3d4b8b3` while this last commit was still in flight — the PR object's `head.sha` never advanced past the third commit, so a fourth was left behind. The three bead fixes are all on `main`; this is the leftover.

Source tidiness only, **no rendered change**: the inline `(rf/reg-sub :editor/field …)` spelling beside forms.md's canonical field block wrapped across a source line inside its backtick span. Markdown renders that identically; it just reads badly in the file.

## Quality gates

| Gate | Result | rc |
|---|---|---|
| `clojure -M:test -n re-frame.freehand.guide.samples-coverage-jvm-test` (the digest suite; the edit is prose, outside every fence, so no digest moves) | `Ran 4 tests containing 14 assertions. 0 failures, 0 errors.` | 0 |
| `python scripts/check_doc_slugs.py` | no broken links | 0 |

Rebased onto current `origin/main`, so the diff is exactly the three lines.
