### PR TITLE
fix(gates): three silent gates made honest — a skip is not a pass (rf2-udro3, rf2-72gaq, rf2-0dbvy)

### DIFF
--- a/implementation/scripts/check-elision.cjs
+++ b/implementation/scripts/check-elision.cjs
@@ -12,11 +12,17 @@
  *      sentinel survives, dead-code elimination has failed somewhere
  *      and the elision contract is broken.
  *
- *   2. The :elision-probe-control bundle (goog.DEBUG=true), if present,
- *      DOES contain those sentinels. This confirms the grep
- *      methodology has signal — without the control, a refactor that
- *      moved the strings somewhere else would silently turn the
- *      negative assertion into a vacuous pass.
+ *   2. The :elision-probe-control bundle (goog.DEBUG=true) DOES contain
+ *      those sentinels. This confirms the grep methodology has signal —
+ *      without the control, a refactor that moved the strings somewhere
+ *      else would silently turn the negative assertion into a vacuous
+ *      pass. The control is therefore REQUIRED, not optional: a missing
+ *      control bundle is a FAILURE (rf2-udro3). `npm run test:elision`
+ *      — the only wired entry point — builds both bundles in one
+ *      command, so its absence means the build did not run, not that a
+ *      lane cannot produce one. A local production-arm-only run says so
+ *      explicitly with `--no-control`, and the PASS line then names how
+ *      many absence assertions went unproven.
  *
  * Strategy: grep, not parse. The closure compiler may rename symbols
  * but does not rewrite string literals.  String literals from a
@@ -868,19 +874,34 @@ function main() {
     ep23 = { ok: surviving.ok && absent.ok, surviving, absent };
   }
 
-  // Control bundle: dev-only sentinels MUST be present (if compiled).
-  let control = { ok: true, skipped: true };
+  // Control bundle: dev-only sentinels MUST be present. The control IS the
+  // methodology (rf2-udro3) — the production arm is a pure absence assertion,
+  // and a sentinel that was renamed, moved out of its gated branch, or whose
+  // rooting probe was deleted is absent for the WRONG reason and passes. So a
+  // missing control bundle is a VIOLATED precondition, not an honest skip: the
+  // one wired entry point (`npm run test:elision`) builds both in a single
+  // command. Fail closed, matching the sibling present-but-empty floor above.
+  // `--no-control` is the explicit opt-out for a local production-arm-only run,
+  // and it still says out loud how many assertions it left unproven.
+  const allowMissingControl = process.argv.slice(2).includes('--no-control');
+  let control;
   if (fs.existsSync(controlDir)) {
     control = checkBundle('control    (goog.DEBUG=true) ', controlDir, true);
+  } else if (allowMissingControl) {
+    control = { ok: true, skipped: true, checked: 0, passed: 0 };
+    console.error(
+      `[elision] --no-control: methodology check SKIPPED — the ` +
+      `${DEV_ONLY_SENTINELS.length} production sentinel ABSENCES below are ` +
+      `UNPROVEN (an absent sentinel may be absent for the wrong reason).`
+    );
   } else {
-    report.detail('[elision] control bundle not built — skipping methodology check.');
-    report.detail('          Run "npx shadow-cljs release elision-probe-control"');
-    report.detail('          to enable the methodology assertion.');
+    control = { ok: false, skipped: true, missingControl: true, checked: 0, passed: 0 };
   }
 
   if (prod.ok && ep23.ok && control.ok) {
     const controlSummary = control.skipped
-      ? 'control skipped'
+      ? `control SKIPPED (--no-control) — 0/${DEV_ONLY_SENTINELS.length} ` +
+        'methodology assertions run, production absences UNPROVEN'
       : `control ${control.passed}/${control.checked} present (${control.bytes} chars)`;
     report.pass(
       'elision',
@@ -910,7 +931,15 @@ function main() {
       console.error('    probe does not root make-frame/assemble. If present, an');
       console.error('    assembly fn became reachable from an always-run path.');
     }
-    if (!control.ok) {
+    if (control.missingControl) {
+      console.error('Control bundle not built — the methodology check did NOT run,');
+      console.error(`so all ${DEV_ONLY_SENTINELS.length} production sentinel ABSENCES above are`);
+      console.error('UNPROVEN: a renamed / relocated / no-longer-rooted sentinel is');
+      console.error('absent for the wrong reason and passes.  A skip is not a pass.');
+      console.error(`  Build it:  npx shadow-cljs release elision-probe-control`);
+      console.error('  or simply: npm run test:elision   (builds both bundles)');
+      console.error('To run the production arm ALONE, pass --no-control explicitly.');
+    } else if (!control.ok) {
       console.error('Control bundle missing dev-only sentinels — the grep test');
       console.error('would be vacuous.  A sentinel string was likely renamed,');
       console.error('moved out of a gated branch, or removed.  Update');

--- a/implementation/scripts/check-examples-assets.test.cjs
+++ b/implementation/scripts/check-examples-assets.test.cjs
@@ -248,13 +248,83 @@ it('isStandaloneExampleProject is true iff the dir carries its own shadow-cljs.e
   );
 });
 
-it('LIVE: the standalone minimal-counter scaffold host page is NOT enumerated (rf2-vxgfnd.281)', () => {
-  const rel = realIndexes.map((p) => path.relative(EXAMPLES_ROOT, p).split(path.sep).join('/'));
+// Discover the standalone project roots on disk, and the host pages each one
+// actually serves. This is the PRECONDITION half of the prune assertion
+// (rf2-72gaq): the old LIVE test was a bare negative naming one path
+// (`ui/minimal-counter/`), so the day that scaffold is deleted — or merely
+// relocated, its ledger row being MOVE — it would assert 0 of 0 and stay green,
+// indistinguishable from a real pass by exit code. Discovering the subjects
+// instead of naming one keeps the assertion alive across the relocation, and
+// makes the day the LAST standalone project leaves examples/ a loud failure
+// rather than a quiet one. The walk deliberately does NOT prune standalone
+// roots (that is the behaviour under test) — it stops AT one, since the whole
+// subtree belongs to that project.
+function findStandaloneProjects(root) {
+  const fs = require('fs');
+  const found = [];
+  const hostPagesUnder = (dir) => {
+    const out = [];
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === 'node_modules') continue;
+        out.push(...hostPagesUnder(full));
+      } else if (entry.isFile() && isExampleHostPage(entry.name)) {
+        out.push(full);
+      }
+    }
+    return out;
+  };
+  const walk = (dir) => {
+    if (dir !== root && isStandaloneExampleProject(dir)) {
+      found.push({ root: dir, hostPages: hostPagesUnder(dir) });
+      return;
+    }
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      if (entry.name === 'node_modules' || entry.name === '_shared') continue;
+      walk(path.join(dir, entry.name));
+    }
+  };
+  walk(root);
+  return found;
+}
+
+const standaloneProjects = findStandaloneProjects(EXAMPLES_ROOT);
+
+it('LIVE: every standalone example project is pruned from the gallery host-page walk (rf2-vxgfnd.281)', () => {
   assert.ok(
-    !rel.some((p) => p.startsWith('ui/minimal-counter/')),
-    `the standalone re-frame.ui scaffold must be pruned from the gallery asset ` +
-      `walk (its host-page contract is owned by implementation/ui/scaffold-smoke), ` +
-      `got: ${rel.filter((p) => p.startsWith('ui/')).join(', ')}`,
+    standaloneProjects.length >= 1,
+    'no standalone example project (a dir bearing its own shadow-cljs.edn) exists ' +
+      'under examples/, so this negative assertion has no subject and would pass ' +
+      'vacuously — 0 of 0. Either a standalone scaffold is staged and the walk lost ' +
+      'sight of it, or the last one is gone and the prune rule should be retired ' +
+      'together with its final subject.',
+  );
+  const rel = realIndexes.map((p) => path.relative(EXAMPLES_ROOT, p).split(path.sep).join('/'));
+  let prunedPages = 0;
+  for (const project of standaloneProjects) {
+    const projectRel = path.relative(EXAMPLES_ROOT, project.root).split(path.sep).join('/');
+    assert.ok(
+      project.hostPages.length >= 1,
+      `the standalone project '${projectRel}' serves NO host page, so pruning it ` +
+        `proves nothing — the walk had no candidate to drop. A standalone scaffold ` +
+        `without a host page cannot witness this rule.`,
+    );
+    for (const page of project.hostPages) {
+      const pageRel = path.relative(EXAMPLES_ROOT, page).split(path.sep).join('/');
+      assert.ok(
+        !rel.includes(pageRel),
+        `the standalone project '${projectRel}' must be pruned from the gallery ` +
+          `asset walk (its host-page contract is owned by its own scaffold smoke), ` +
+          `but '${pageRel}' was enumerated`,
+      );
+      prunedPages++;
+    }
+  }
+  console.log(
+    `        (checked ${standaloneProjects.length} standalone project(s), ` +
+      `${prunedPages} candidate host page(s) proven pruned)`,
   );
 });
 

--- a/scripts/check_skill_implementor_partition_drift.py
+++ b/scripts/check_skill_implementor_partition_drift.py
@@ -107,6 +107,16 @@ user-facing implementor docs and asserts:
      `[REACT-ADAPTERS]` token below is a lifecycle-PARTITION marker, not a
      status label.)
 
+     Rule 7's arms are individually skippable — each reads a source file, and a
+     missing file used to leave its arm silently unevaluated behind a SETUP
+     error whose own text invited the edit that retires it ("update the *_FILE
+     constants"). A skipped assertion is not a passing one, so the arms are
+     declared in `LIFECYCLE_ARM_SOURCES` and the guard FAILS when any declared
+     arm did not run. Deleting a `*_FILE` constant therefore no longer buys
+     silence — it trades one loud failure for another. Retiring an arm is a
+     deliberate, self-documenting act: delete its row from
+     `LIFECYCLE_ARM_SOURCES` and record that the contract it held is unguarded.
+
 Exit code:
     0  no drift detected
     1  drift detected (printed line-by-line; GitHub-Actions ::error:: under CI)
@@ -408,6 +418,40 @@ SPEC_002_FILE = REPO_ROOT / "spec" / "002-Frames.md"
 FRAME_ROOT_ANCHOR = "#frame-root--the-ensure-component-cljs-reference"
 FRAME_PROVIDER_ANCHOR = "#frame-provider--the-scope-only-component-cljs-reference"
 
+# --- Rule 7 arm coverage (rf2-0dbvy) ----------------------------------------
+# Every Rule-7 assertion arm, and the source texts it needs in order to RUN.
+# An arm whose sources are all present is evaluated; an arm missing any source
+# is SKIPPED — and a skip is not a pass, so `lifecycle_realization_problems`
+# fails on any declared arm that did not run.
+#
+# This map is the requirement declaration, held SEPARATELY from the `*_FILE`
+# constants it depends on. That separation is the whole point: the old SETUP
+# error told the reader to "update the *_FILE constants", and deleting the two
+# `ui/` constants cleared the error AND retired the L5 causal assertion in one
+# stroke, with nothing left to notice (found by the F6e deletion probe).
+# Deleting a constant now trades the SETUP failure for an ARM-NOT-RUN failure.
+# Retiring an arm is a deliberate second edit — delete its row here, and record
+# that the contract it held is henceforth unguarded.
+LIFECYCLE_ARM_SOURCES: dict[str, tuple[str, ...]] = {
+    "L1-compiled-realization": ("phase2",),
+    "L2-react-adapters": ("phase2",),
+    "L4-spec002-links-present": ("phase2",),
+    "L4-spec002-links-resolve": ("phase2", "spec002"),
+    "L5-client-preflight-causality": ("client",),
+    "L5-frames-executor": ("frames",),
+    "L6-inventory-row": ("conventions",),
+}
+
+
+def lifecycle_arms_run(texts: dict[str, str | None]) -> set[str]:
+    """The declared arms whose every source text is present — i.e. the arms
+    that actually get evaluated for this input."""
+    return {
+        arm
+        for arm, sources in LIFECYCLE_ARM_SOURCES.items()
+        if all(texts.get(src) is not None for src in sources)
+    }
+
 # The compiled client's frame-lifecycle CALL forms. Keyed on the leading paren so
 # docstring / backtick mentions (`(run-preflight! …)`, `` `.render` ``,
 # `` `createRoot` ``) never register as calls.
@@ -593,33 +637,20 @@ def _top_level_form_regions(text: str) -> list[tuple[str, str]]:
     return regions
 
 
-def _preflight_causal_problems(client_text: str) -> list[str]:
-    """CAUSAL source assertions over the compiled client's render paths, scoped
-    PER top-level function body (rf2-8cncz — the old whole-file substring pool let
-    a preflight in one function credit another's render, and a reader-discarded /
-    dead-conditional preflight still counted as live).
-
-    A — render causality (per function): within EACH function body, every host
-        render is preceded by its OWN LIVE frame preflight. Dead forms (`#_…`,
-        `(when false …)`) are neutralized first, then a per-function credit walk
-        arms one credit per preflight; each render spends a credit (and consumes
-        any surplus). Fires if any function has a render its own body does not
-        preflight — a removed / reordered / reader-discarded / dead-conditional
-        preflight on the existing-root, fresh-mount, or `render!*` path, OR a
-        preflight migrated into `create-root*` (which cannot credit `render!*`).
-    B — one-shot allocation ordering: the fresh one-shot mount preflights BEFORE
-        it creates the React root — a contiguous `pre → create → render` triple
-        WITHIN one function body (`mount*`). The split `create-root*` allocation is
-        a render-less lone `create`, so it never forms this triple and is never
-        falsely claimed to preflight before `create-root*`. Fires if the fresh
-        mount's preflight moves after its `createRoot` (or disappears)."""
-    problems: list[str] = []
+def preflight_scan(client_text: str) -> dict[str, object]:
+    """The per-function credit walk over the compiled client, returned as a
+    POPULATION rather than a verdict: `forms` top-level forms partitioned,
+    `renders` host renders found, `caused` of them preceded by their own live
+    preflight, the `uncredited` function names, and whether the one-shot
+    `pre → create → render` triple is present. Reported by `--verbose` so a
+    scan that covered nothing is visible rather than merely exit-0."""
     total_renders = 0
     total_caused = 0
     one_shot = False
     uncredited: list[str] = []
+    regions = _top_level_form_regions(client_text)
 
-    for name, body in _top_level_form_regions(client_text):
+    for name, body in regions:
         seq = _client_call_order(_neutralize_dead_forms(body))
         armed = 0
         caused = 0
@@ -641,6 +672,42 @@ def _preflight_causal_problems(client_text: str) -> list[str]:
             for i in range(len(seq) - 2)
         ):
             one_shot = True
+
+    return {
+        "forms": len(regions),
+        "renders": total_renders,
+        "caused": total_caused,
+        "uncredited": uncredited,
+        "one_shot": one_shot,
+    }
+
+
+def _preflight_causal_problems(client_text: str) -> list[str]:
+    """CAUSAL source assertions over the compiled client's render paths, scoped
+    PER top-level function body (rf2-8cncz — the old whole-file substring pool let
+    a preflight in one function credit another's render, and a reader-discarded /
+    dead-conditional preflight still counted as live).
+
+    A — render causality (per function): within EACH function body, every host
+        render is preceded by its OWN LIVE frame preflight. Dead forms (`#_…`,
+        `(when false …)`) are neutralized first, then a per-function credit walk
+        arms one credit per preflight; each render spends a credit (and consumes
+        any surplus). Fires if any function has a render its own body does not
+        preflight — a removed / reordered / reader-discarded / dead-conditional
+        preflight on the existing-root, fresh-mount, or `render!*` path, OR a
+        preflight migrated into `create-root*` (which cannot credit `render!*`).
+    B — one-shot allocation ordering: the fresh one-shot mount preflights BEFORE
+        it creates the React root — a contiguous `pre → create → render` triple
+        WITHIN one function body (`mount*`). The split `create-root*` allocation is
+        a render-less lone `create`, so it never forms this triple and is never
+        falsely claimed to preflight before `create-root*`. Fires if the fresh
+        mount's preflight moves after its `createRoot` (or disappears)."""
+    problems: list[str] = []
+    scan = preflight_scan(client_text)
+    total_renders = scan["renders"]
+    total_caused = scan["caused"]
+    uncredited = scan["uncredited"]
+    one_shot = scan["one_shot"]
 
     if total_renders == 0:
         problems.append(
@@ -715,15 +782,22 @@ def _core_artifact_inventory_row(conventions_text: str) -> str | None:
 
 def lifecycle_realization_problems(
     *,
-    phase2: str | None,
-    client: str | None,
-    frames: str | None,
-    conventions: str | None,
-    spec002: str | None,
+    phase2: str | None = None,
+    client: str | None = None,
+    frames: str | None = None,
+    conventions: str | None = None,
+    spec002: str | None = None,
 ) -> list[str]:
     """Positive-presence assertions for the two frame-root lifecycles. Each arg
-    is the file's text (or None to skip — the caller reports a missing required
-    file as a SETUP error). Returns drift labels (empty when all present)."""
+    is the file's text, or None when that source could not be read — in which
+    case the arms depending on it do not run, and the ARM-NOT-RUN floor at the
+    end reports exactly which assertions were skipped. Returns drift labels
+    (empty only when every declared arm ran clean).
+
+    Every parameter defaults to None on purpose: deleting a `*_FILE` constant
+    (and its entry in `find_lifecycle_drift`'s `required` map) must not crash
+    with a TypeError, nor silently retire the arm — it must land on the
+    coverage floor with a message naming the assertion that stopped running."""
     problems: list[str] = []
 
     if phase2 is not None:
@@ -819,13 +893,48 @@ def lifecycle_realization_problems(
                         "elsewhere do not count)."
                     )
 
+    # --- ARM-NOT-RUN floor (rf2-0dbvy). Every arm above is conditional on a
+    # source text; a missing source means the assertion was never evaluated,
+    # and an unevaluated assertion guards nothing. Report it as a failure here
+    # rather than letting the caller's SETUP line be the only trace — because
+    # that SETUP line is exactly what a well-meaning edit deletes.
+    missing_arms = sorted(
+        set(LIFECYCLE_ARM_SOURCES)
+        - lifecycle_arms_run(
+            {
+                "phase2": phase2,
+                "client": client,
+                "frames": frames,
+                "conventions": conventions,
+                "spec002": spec002,
+            }
+        )
+    )
+    if missing_arms:
+        total = len(LIFECYCLE_ARM_SOURCES)
+        problems.append(
+            "LIFECYCLE-ARM-NOT-RUN: the frame-root lifecycle guard evaluated "
+            f"{total - len(missing_arms)} of {total} declared assertion arms; it "
+            f"did NOT evaluate {', '.join(missing_arms)}. A skipped assertion is "
+            "not a passing one — with the arm silent, the contract it holds is "
+            "unguarded and nothing else reports that. Either RE-POINT the arm's "
+            "source constant at the file that now owns the contract, so the "
+            "assertion keeps running; or RETIRE the arm deliberately by deleting "
+            "its row from LIFECYCLE_ARM_SOURCES and recording the contract as "
+            "unguarded."
+        )
+
     return problems
 
 
-def find_lifecycle_drift() -> list[str]:
+def find_lifecycle_drift() -> tuple[list[str], str]:
     """Read the Rule-7 source-of-truth files and run the presence assertions,
     reporting a missing REQUIRED file as a SETUP error (the spec + ui
-    sources are all repo-tracked, so a miss means the guard's paths drifted)."""
+    sources are all repo-tracked, so a miss means the guard's paths drifted).
+
+    Returns (problems, coverage summary). The summary states how many declared
+    arms actually ran and the L5 scan's population, so a `--verbose` run cannot
+    claim an assertion "held" that never executed."""
     problems: list[str] = []
     texts: dict[str, str | None] = {}
     required = {
@@ -840,13 +949,35 @@ def find_lifecycle_drift() -> list[str]:
             texts[key] = _slurp(path)
         else:
             texts[key] = None
+            arms = sorted(
+                arm for arm, srcs in LIFECYCLE_ARM_SOURCES.items() if key in srcs
+            )
             problems.append(
                 "SETUP: expected Rule-7 source file missing: "
-                f"{path.relative_to(REPO_ROOT)} — the lifecycle guard's path list "
-                "drifted; update the *_FILE constants."
+                f"{path.relative_to(REPO_ROOT)} — {', '.join(arms)} cannot run "
+                "against it. Two honest fixes, and only two: RE-POINT this "
+                "*_FILE constant at the source that now owns the contract, so "
+                "the assertion keeps running; or RETIRE the arm DELIBERATELY, "
+                "which means ALSO deleting its row from LIFECYCLE_ARM_SOURCES "
+                "and recording that the contract it held is now unguarded. "
+                "Deleting the constant alone does NOT quiet this guard — the "
+                "ARM-NOT-RUN floor then reports the assertion as never evaluated."
             )
     problems.extend(lifecycle_realization_problems(**texts))
-    return problems
+
+    arms_run = lifecycle_arms_run(texts)
+    summary = f"{len(arms_run)} of {len(LIFECYCLE_ARM_SOURCES)} assertion arms evaluated"
+    client_text = texts.get("client")
+    if client_text is None:
+        summary += "; L5 causal scan DID NOT RUN (0 renders checked)"
+    else:
+        scan = preflight_scan(client_text)
+        summary += (
+            f"; L5 causal scan: {scan['forms']} top-level forms, "
+            f"{scan['renders']} host renders, {scan['caused']} preflight-caused, "
+            f"one-shot pre→create→render triple {'present' if scan['one_shot'] else 'ABSENT'}"
+        )
+    return problems, summary
 
 
 def run(*, verbose: bool, ci: bool) -> int:
@@ -862,7 +993,8 @@ def run(*, verbose: bool, ci: bool) -> int:
     beadid_problems, beadid_lines = find_beadid_drift(beadid_files)
     problems.extend(beadid_problems)
 
-    problems.extend(find_lifecycle_drift())
+    lifecycle_problems, lifecycle_coverage = find_lifecycle_drift()
+    problems.extend(lifecycle_problems)
 
     if verbose:
         print(
@@ -873,11 +1005,9 @@ def run(*, verbose: bool, ci: bool) -> int:
             f"implementor no-bead-ids guard: scanned {len(beadid_files)} "
             f"user-facing leaves ({beadid_lines} lines)."
         )
-        print(
-            "implementor frame-root lifecycle guard: two realizations present + "
-            "distinct, Spec-002 links resolvable, compiled preflight-before-render "
-            "source assertion held."
-        )
+        # State the POPULATION, not a claim: an arm that did not run says so
+        # here rather than hiding behind "assertion held" (rf2-0dbvy).
+        print(f"implementor frame-root lifecycle guard: {lifecycle_coverage}.")
 
     if not problems:
         if verbose:
@@ -1301,6 +1431,54 @@ def _self_test() -> int:
             "| `day8/re-frame2-uix` | UIx adapter — frame-root / frame-provider. |\n")},
         dirty=True, label="I3 core artifact inventory row removed",
     )
+
+    # --- Rule 7 ARM-NOT-RUN floor (rf2-0dbvy) — the F6e trap. A missing source
+    # used to make its arm SKIP silently: `find_lifecycle_drift` reported the
+    # file and passed None on, and `lifecycle_realization_problems` simply did
+    # not evaluate that arm. Clearing the SETUP error by deleting the *_FILE
+    # constant then retired the assertion outright with nothing left to notice.
+    # Every one of these was GREEN before the floor and must now be RED, and the
+    # message must NAME the arm that stopped running.
+    def expect_arm_not_run(overrides: dict, *, arm: str, label: str) -> None:
+        nonlocal failures
+        got = lifecycle_realization_problems(**{**base, **overrides})
+        floor = [p for p in got if p.startswith("LIFECYCLE-ARM-NOT-RUN")]
+        if not floor:
+            print(f"SELF-TEST FAIL ({label}): expected an ARM-NOT-RUN floor, got none.")
+            failures += 1
+        elif arm not in floor[0]:
+            print(f"SELF-TEST FAIL ({label}): floor does not name `{arm}`: {floor[0]!r}")
+            failures += 1
+
+    expect_arm_not_run(
+        {"client": None}, arm="L5-client-preflight-causality",
+        label="L1 client source gone — the causal preflight assertion stops running",
+    )
+    expect_arm_not_run(
+        {"frames": None}, arm="L5-frames-executor",
+        label="L2 frames source gone — the executor presence assertion stops running",
+    )
+    expect_arm_not_run(
+        {"conventions": None}, arm="L6-inventory-row",
+        label="L3 conventions gone — the inventory-row assertion stops running",
+    )
+    expect_arm_not_run(
+        {"spec002": None}, arm="L4-spec002-links-resolve",
+        label="L4 spec002 gone — anchors still checked PRESENT but never RESOLVED",
+    )
+    expect_arm_not_run(
+        {"phase2": None}, arm="L1-compiled-realization",
+        label="L5 phase2 gone — the guide realization arms stop running",
+    )
+    # Every source present ⇒ every declared arm runs, and no floor fires.
+    ran = lifecycle_arms_run(dict(base))
+    if ran != set(LIFECYCLE_ARM_SOURCES):
+        print(
+            f"SELF-TEST FAIL (L6 full coverage): expected all "
+            f"{len(LIFECYCLE_ARM_SOURCES)} arms to run, missing "
+            f"{sorted(set(LIFECYCLE_ARM_SOURCES) - ran)}."
+        )
+        failures += 1
 
     if failures:
         print(f"self-test: {failures} failure(s).")

--- a/scripts/check_skill_implementor_partition_drift.py
+++ b/scripts/check_skill_implementor_partition_drift.py
@@ -452,6 +452,7 @@ def lifecycle_arms_run(texts: dict[str, str | None]) -> set[str]:
         if all(texts.get(src) is not None for src in sources)
     }
 
+
 # The compiled client's frame-lifecycle CALL forms. Keyed on the leading paren so
 # docstring / backtick mentions (`(run-preflight! …)`, `` `.render` ``,
 # `` `createRoot` ``) never register as calls.


### PR DESCRIPTION
Three gates that had stopped checking without saying so. One family, one rule:
**a skip is not a pass.** A gate that can fail to RUN must exit non-zero when it
does not run — or, at minimum, say loudly what it did not check.

No new gate, no framework. Three existing gates made honest.

---

## `rf2-0dbvy` (P2) — the skill gate's `LIFECYCLE-SOURCE-ORDER` arm never failed, it was skipped

**Found.** `scripts/check_skill_implementor_partition_drift.py` Rule 7 holds a
per-function causal assertion over the compiled client's three production render
paths — every host render preceded by its OWN live `(run-preflight! …)` in the
same function body, dead forms neutralized first, plus the one-shot
`pre → create → render` triple. It exists because two real classes of bypass were
found. With `implementation/ui/` absent, `find_lifecycle_drift` reported the two
missing files and passed `None` on, and `lifecycle_realization_problems` simply
did not evaluate the arm. The only remaining trace was a SETUP line whose own
text told the reader how to delete it — *"the lifecycle guard's path list
drifted; update the `*_FILE` constants"*. An error message that tells you how to
make the check stop running is worse than no message.

Worse, `--verbose` printed *"compiled preflight-before-render source assertion
held"* unconditionally — a claim the run had not earned.

**Changed.** The arms and the sources each one needs are declared in
`LIFECYCLE_ARM_SOURCES`, held **separately** from the `*_FILE` constants, and the
guard fails on any declared arm that did not run. Deleting a constant now trades
one loud failure for another; retiring an arm is a deliberate second edit that
deletes its row from that map and records the contract as unguarded. The SETUP
text says exactly that, and names the arms the missing file silences. Every
keyword parameter defaults to `None` so the deletion lands on the coverage floor
rather than a `TypeError`. `--verbose` now states the population it covered.

**Checked population.**

| | before | after |
|---|---|---|
| sources present (today's `main`) | 7 arms ran, count not reported; verbose *claimed* the assertion held | **7 of 7 arms evaluated**; L5 causal scan: **61 top-level forms, 3 host renders, 3 preflight-caused**, one-shot triple present |
| the two `ui/` sources absent | 5 of 7 arms ran, `rc=1` from 2 SETUP lines only; verbose still claimed the assertion held | `rc=1` with **`LIFECYCLE-ARM-NOT-RUN`** naming both arms; verbose: *"5 of 7 assertion arms evaluated; L5 causal scan DID NOT RUN (0 renders checked)"* |
| after the invited edit (guard no longer names those sources) | **0 problems — total silence, `rc=0`** | **1 problem: `LIFECYCLE-ARM-NOT-RUN`** |

**Absent or violated: VIOLATED.** `client.cljs` and `frames.cljc` are
repo-tracked and there is no lane that runs this guard without expecting them, so
their absence is real drift, not an honest precondition gap. F6e
(`rf2-drpa3.57`) will legitimately vacate them — and that is the point: the two
honest answers there are *re-point at the source that now owns the contract* or
*retire the arm deliberately and record the contract as unguarded*. Both are now
named in the message; neither is reachable by accident.

## `rf2-udro3` (P3) — `check-elision.cjs` skipped its whole methodology check

**Found.** The production arm is a pure absence assertion over 60 dev-only
sentinels. A sentinel that was renamed, moved out of its gated branch, or whose
rooting probe was deleted is absent for the **wrong reason** and passes. The
`goog.DEBUG=true` control bundle is the entire methodology, and it was
conditional: no control dir meant a `report.detail()` line, `ok` stayed true, and
the run exited 0 with `control skipped` in the PASS text.

**Changed.** A missing control bundle is now a failure, matching the
present-but-empty non-vacuity floor already in the same file (`check-elision.cjs`
line ~804). `--no-control` is the explicit opt-out for a local
production-arm-only run, and it names the unproven count on stderr *and* in the
PASS line instead of saying "skipped".

The younger sibling gate `check-freehand-evidence-elision.cjs` already reads its
control bundle unconditionally and exits 1 when either bundle is missing or
empty. This change brings the older gate into line with it rather than
introducing a new convention.

**Checked population.** `DEV_ONLY_SENTINELS` measured at **60 entries, 8 of them
`re-frame.ui` bodies → 52 meaningful**; `PROD_SURVIVING` 1; `PROD_ABSENT_WHEN_UNUSED` 2.

| | before | after |
|---|---|---|
| control built (CI, and `npm run test:elision`) | production 60/60 absent + control 60/60 present, `rc=0` | unchanged — verified on real `:advanced` bundles, `rc=0` |
| control absent | production 60/60 absent, **control 0/60**, `rc=0`, PASS says "control skipped" | **`rc=1`**, naming all 60 absences as unproven |
| control absent, `--no-control` | n/a | `rc=0`, PASS says `control SKIPPED (--no-control) — 0/60 methodology assertions run, production absences UNPROVEN` |

**Absent or violated: VIOLATED.** The only wired entry point,
`npm run test:elision`, builds both bundles in one command, so a missing control
means the build did not run — not that a lane cannot produce one. Deliberately
*not* a hard red for the developer who genuinely wants the production arm alone:
that case gets a flag, and the flag still reports what went unproven.

## `rf2-72gaq` (P3) — a `check-examples-assets` negative assertion went vacuous

**Found.** The LIVE test named one path, `ui/minimal-counter/`, and asserted only
its absence from the gallery host-page walk. Delete or relocate that scaffold and
it asserts 0 of 0 and stays green, indistinguishable from a real pass by exit
code. Its synthetic sibling covers the `isStandaloneExampleProject` predicate
against a fabricated path and never touches disk, so nothing else watches the
prune rule.

**Changed.** Discover the subjects instead of naming one: walk `examples/` for
project roots bearing their own `shadow-cljs.edn`, floor the set at one, require
each to serve at least one host page (a standalone project with no host page
gives the walk no candidate to drop), then assert every one of those pages is
absent from the enumeration.

**Checked population.**

| | before | after |
|---|---|---|
| today's tree | 1 hardcoded path prefix, 0 preconditions asserted | **1 standalone project discovered, 1 candidate host page proven pruned** (printed by the test) |
| scaffold gone | **0 subjects, still green** | `rc=1`: *"no standalone example project … exists under `examples/`, so this negative assertion has no subject and would pass vacuously"* |
| scaffold present but serving no host page | green | `rc=1`: *"serves NO host page, so pruning it proves nothing"* |
| prune disabled in the scanner (the real regression) | red | red — original teeth intact |

**Absent or violated: VIOLATED — and repaired, not retired.** The disposition
was checked before touching it: the ledger row
(`spec/conformance/freehand/donor-inventory.md`) is `examples/ui/minimal-counter/*`
→ **MOVE**, i.e. absorbed under Freehand ownership by relocation. The rule
therefore outlives its current witness, and the generalization means the
assertion survives the move **with no edit at all** — which is a better outcome
than repairing a hardcoded path that would have to be repaired again. Retiring
would have been right only for a `DELETE` row.

One knock-on worth flagging for the ledger's owner: `donor-inventory.md`'s
"deliberately NOT rowed" note says this test *"couples to
`examples/ui/minimal-counter/`"*. It no longer does — the coupling is now to the
marker, not the path. The note's conclusion (not rowed) is unchanged, only its
stated reason is now stronger. That file is fenced in this PR, so it is untouched
here; `python scripts/check_donor_inventory.py` is `rc=0` either way.

---

## How each fix was proven

Each was proven by mutation, with the mutation confirmed applied before any
verdict was read, and each probe matched to **what that gate actually reads**.
All three read the filesystem (`fs.existsSync` / `fs.readdirSync` /
`Path.is_file`) rather than git, so all three were broken on the filesystem.
Restores are `sha256`-verified byte-identical moves; no `git checkout --` was
used anywhere. Two probe defects were caught and fixed before their verdicts were
trusted:

* a first run reported `rc=1` for every scenario — MODULE_NOT_FOUND from a
  repo-relative path resolved against the child's `cwd`, an exit code that is not
  a gate verdict;
* a first "scaffold deleted" mutation parked the tree at
  `examples/ui/_probe-aside-minimal-counter`, which still carried
  `shadow-cljs.edn` — so the "deleted" project was still discoverable and the
  probe false-GREENed. The aside now leaves `examples/` entirely.

`implementation/ui/**` is fenced, so the Rule-7 teeth check (remove one live
`run-preflight!`, confirm `LIFECYCLE-SOURCE-ORDER` fires) runs **in memory**
against a mutated copy of the client text: `3/3 caused → 2/3 caused`, 1 problem
raised. The two `ui/` sources were moved aside only for the end-to-end exit-code
probe, and restored byte-identical.

## Quality gates

Run from `C:/Users/miket/code/re-frame2-worktrees/silent-gates`. Exit codes
captured immediately and cross-checked against each log's own verdict line.

| gate | rc | verdict line |
|---|---|---|
| `python scripts/check_skill_implementor_partition_drift.py --self-test` | 0 | `self-test: all cases passed.` (6 new ARM-NOT-RUN cases added) |
| `python scripts/check_skill_implementor_partition_drift.py --verbose --ci` | 0 | `7 of 7 assertion arms evaluated; L5 causal scan: 61 top-level forms, 3 host renders, 3 preflight-caused, one-shot pre→create→render triple present.` |
| `npm run test:elision` (real `shadow-cljs release` ×2) | 0 | `PASS elision: production 60/60 absent (1109124 chars); EP-0023 1/1 + 2/2; control 60/60 present (1282639 chars)` |
| `node scripts/check-examples-assets.test.cjs` | 0 | 149 PASS, 0 FAIL — same count as baseline; new line `(checked 1 standalone project(s), 1 candidate host page(s) proven pruned)` |
| `npm run test:script-policy` (27 suites, incl. the changed one) | 0 | `serve-and-run-cli tests: 5 passed.` — zero `FAIL` lines; the 15 `→ FAILED` strings in the log are expected negative fixtures |
| `python scripts/check_donor_inventory.py` | 0 | silent-on-success |
| `sh scripts/test-fast-pr.sh` | 0 | `PASS fast PR spine` — plan `docs=false jvm=false node=true`; node/CLJS tier incl. `test:cljs` + per-ns isolation (17 namespaces) |
| `python -m py_compile` / `node --check` on all three files | 0 | |

Beads are left open — the mayor closes on the merged SHA.
