### PR TITLE
fix(machines-viz,freehand): the viewer has no host, so stop defaulting share-URLs to one; row the realworld-resources-ui build-id family (rf2-8m344, rf2-vuylw)

### DIFF
--- a/.github/workflows/release-machines-viz.yml
+++ b/.github/workflows/release-machines-viz.yml
@@ -33,6 +33,24 @@
 # release does not republish Machines-Viz, and this tag does not touch
 # `implementation/`.
 #
+# # What this workflow does NOT do: it does not deploy the viewer page
+#
+# This workflow publishes the JAR. It does not build
+# `tools/machines-viz/page/.../viewer.cljs`, does not stage
+# `tools/machines-viz/public/viewer.html` anywhere, and does not deploy
+# either — and no other workflow in this repository does. There is no
+# hosted viewer instance, by design (DESIGN-RATIONALE Lock #7): the page
+# is a static asset the CONSUMER hosts, built with `shadow-cljs release
+# machines-viz-viewer` from `implementation/` and served beside
+# `viewer.html`. See tools/machines-viz/README.md §Building and hosting
+# the viewer page.
+#
+# This is stated here because the inference is easy to make and was made:
+# `share/encode-share-url` used to default its `:host` to
+# `https://day8.github.io/re-frame2-machines-viz/viewer.html`, which 404s
+# and names a repository that does not exist. Publishing the jar deploys
+# nothing (rf2-8m344).
+#
 # # Lockstep versioning
 #
 # Per spec/Conventions.md §Packaging conventions (rf2-w05l) every

--- a/scripts/check_donor_inventory.py
+++ b/scripts/check_donor_inventory.py
@@ -196,12 +196,25 @@ DONOR_EVIDENCE_RE = re.compile(
     r"|re-frame2-ui"     # the artifact coordinate
     r"|re_frame2_ui"     # the munged coordinate
     r"|implementation/ui"  # the donor tree
-    # The donor build ids and npm entry points. A runner can couple to the donor
-    # entirely through its BUILD ID and never spell `re-frame.ui` at all — that is
-    # how `implementation/scripts/run-ui-g8.cjs` came to carry no recognised donor
-    # material while its `:ui-g13` sibling passed on an incidental prose mention
-    # (rf2-vfv8r). The donor-owned ids are enumerated in `implementation/deps.edn`
-    # and `implementation/shadow-cljs.edn`; keep this alternation in step with them.
+    # DONOR-COUPLED BUILD IDS and npm entry points. A runner can couple to the
+    # donor entirely through its BUILD ID and never spell `re-frame.ui` at all —
+    # that is how `implementation/scripts/run-ui-g8.cjs` came to carry no
+    # recognised donor material while its `:ui-g13` sibling passed on an
+    # incidental prose mention (rf2-vfv8r).
+    #
+    # The test an id has to pass to belong here is COUPLING, not ownership: the
+    # build cannot compile once `implementation/ui/` is gone. Every id below
+    # meets it, and `examples/realworld-resources-ui` meets it from outside the
+    # donor's own trees (rf2-vuylw) — the build's sources are
+    # `examples/real-apps/realworld_resources/ui_*`, which `:require`
+    # `re-frame.ui`, so the id names the donor as surely as `ui-g8` does. An
+    # `examples/` build id is therefore admissible; an id that merely reads
+    # `…-ui` is not. Note the `-ui` suffix carries the whole distinction here:
+    # the sibling `examples/realworld-resources` is the Reagent arm and is NOT
+    # donor-coupled, so the alternative must be the full `realworld-resources-ui`.
+    #
+    # The ids live in `implementation/deps.edn` and
+    # `implementation/shadow-cljs.edn`; keep this alternation in step with them.
     r"|node-test-ui"
     r"|ui-bench"
     r"|ui-g8"
@@ -209,6 +222,7 @@ DONOR_EVIDENCE_RE = re.compile(
     r"|check-ui-"
     r"|run-ui-"
     r"|test:ui"
+    r"|realworld-resources-ui"
 )
 
 
@@ -1163,6 +1177,8 @@ ESTABLISHED_ROWS = (
     "implementation/adapters/scripts/run-adapter-smokes.cjs",
     "implementation/scripts/_adapter-smoke-filter.test.cjs",
     "implementation/scripts/_reagent-slim-smoke-policy.test.cjs",
+    "examples/scripts/examples-asset-manifest.cjs",
+    "implementation/scripts/_examples-staging.test.cjs",
     "scripts/check_ui_root_lifecycle_drift.py",
     "scripts/check_skill_implementor_partition_drift.py",
     "scripts/test-fast-pr.sh",

--- a/spec/conformance/freehand/donor-inventory.md
+++ b/spec/conformance/freehand/donor-inventory.md
@@ -152,6 +152,37 @@ REPLACE, because `day8/re-frame2-freehand` occupies the same test-only
 `:local/root` position in `tools/story/deps.edn` and carries no `:clein/build`
 either.
 
+The fourth pass took the family sideways, into the EXAMPLE build ids
+(rf2-vuylw). `examples/scripts/examples-asset-manifest.cjs` declares a bespoke
+staging entry for build `examples/realworld-resources-ui`, and
+`implementation/scripts/_examples-staging.test.cjs` hard-codes that same id in
+a five-build non-vacuity list. Neither was rowed, for the `run-ui-g8.cjs`
+reason: the coupling is a build id and both files are `.cjs`, so neither census
+signal can reach them. Neither breaks when `implementation/ui/` is deleted —
+the build simply stops compiling, because its sources are
+`examples/real-apps/realworld_resources/ui_*`.
+
+Rowing the second of them needed a decision rather than a paste, and the
+decision is worth stating because the next build id will need it too.
+`DONOR_EVIDENCE_RE` — the "has this row's subject still got donor material in
+it?" test — enumerated build ids owned by the donor's OWN artifact (`ui-g8`,
+`ui-bench`, `node-test-ui`). `examples/realworld-resources-ui` is an example's
+id, not the donor's, so on an ownership reading it did not belong and a pending
+row for the staging test would have tripped the stale-row check. **The test is
+coupling, not ownership**: the id names a build that cannot compile once the
+donor is gone, which is exactly what every other id in that alternation
+already means in substance. It is in the alternation now. Note that
+`realworld-resources-ui` must be spelled in full — the sibling
+`examples/realworld-resources` is the Reagent arm and is not donor-coupled.
+
+The manifest is a second lesson in the same paragraph. It passes the evidence
+test today, but only through the words `re-frame.ui` inside one entry's prose
+`reason` string — the identical incidental-mention accident that let
+`run-ui-g13.cjs` pass while `run-ui-g8.cjs` failed. Reword that sentence and
+the row goes stale-red for a reason that has nothing to do with the donor.
+Adding the build id fixes both files at once, which is why one alternative
+covers a two-file finding.
+
 Two files that sweep listed are deliberately NOT rowed.
 `examples/scripts/check-examples-assets.cjs` names `implementation/ui/scaffold-smoke`
 only in a comment explaining WHY it prunes standalone scaffolds; the prune
@@ -388,6 +419,8 @@ release train have no Freehand successor and are DELETEd outright.
 | `implementation/adapters/scripts/run-adapter-smokes.cjs` | the Playwright half: it drives the donor substrate spec and reconciles the manifest against the spec files actually on disk, so a declared-but-absent donor spec reds the run rather than being silently skipped | REPLACE | F6 | pending |
 | `implementation/scripts/_adapter-smoke-filter.test.cjs` | the manifest's own unit tests. Its donor arms pin the exact three-build set including `ui/testbed`, that every declared `specPath` exists on disk, and that both `ui/testbed` and `ui-testbed` filter shapes select the substrate smoke while `adapters/` deliberately excludes it. Takes its subject's disposition | REPLACE | F6 | pending |
 | `implementation/scripts/_reagent-slim-smoke-policy.test.cjs` | the slim-adapter smoke policy. Its donor arm is a second `deepStrictEqual` over the same three-build set — including `ui/testbed` — pinning that no slim entry can hide behind manifest growth. Takes the manifest's disposition, as its subject | REPLACE | F6 | pending |
+| `examples/scripts/examples-asset-manifest.cjs` | the shared per-example asset manifest. Its donor arm is the bespoke fifth `EXAMPLE_ASSET_MANIFEST` entry — build id `examples/realworld-resources-ui`, staging `default-avatar.svg` for the RealWorld example's donor arm out of the same colocated source folder the Reagent arm uses. Shared build wiring, so the section rule applies exactly as it does for `adapter-smoke-filter.cjs`: the manifest still has to exist and it serves the other four builds either way, but the donor entry is re-declared against Freehand rather than carried across. Neither census signal can reach it — the coupling is a BUILD ID, and the require detector reads only `.clj`, `.cljs`, `.cljc` and `.edn` | REPLACE | F6 | pending |
+| `implementation/scripts/_examples-staging.test.cjs` | the staging helpers' own unit tests. Its donor arm is the non-vacuity assertion in `the LIVE staging PER_EXAMPLE_ASSETS IS the real manifest projection`, which hard-codes `examples/realworld-resources-ui` in a five-build list and asserts each declares staged assets — so dropping the manifest entry reds this test rather than silently narrowing it. Takes its subject's disposition, the way every other `_*.test.cjs` row here does. This is the file that forced the `DONOR_EVIDENCE_RE` decision (rf2-vuylw): it named NO donor material in any spelling the gate recognised, so rowing it as `pending` would have tripped the stale-row check until `realworld-resources-ui` joined the build-id alternation | REPLACE | F6 | pending |
 | `scripts/check_ui_root_lifecycle_drift.py` | the Root-settlement drift gate: 32 literal anchors across runtime, spec, and docs. ELEVEN of them are donor source paths — four in `ui/client.cljs`, four in `ui/frames.cljc`, two in `ui/reactive.cljc`, one in the donor's `adapter_public_root_disposal` browser fixture — and `load_texts` raises on the FIRST missing file, so the whole gate exits before a single anchor is compared. The sharpest break in this family and the loudest: measured `rc 0 → 2`, `required lifecycle surface missing: implementation/ui/src/re_frame/ui/client.cljs`. The other twenty anchors (004C, 006, 009) are donor-independent and stay, which is why the gate is re-declared against `re-frame.freehand.root` rather than retired | REPLACE | F6 | pending |
 | `scripts/check_skill_implementor_partition_drift.py` | the implementor-skill control-surface guard. Rules 1–6 are donor-free; Rule 7's L5 arm is a CAUSAL source assertion over `ui/client.cljs` (each host render preceded by its OWN live `run-preflight!`, plus the one-shot `pre → create → render` triple) and a three-token presence assertion over `ui/frames.cljc`. Measured `rc 0 → 1`, but the failure is two SETUP lines, not a contract failure: `find_lifecycle_drift` reports each missing file and passes `None` on, so the causal assertion is never evaluated. That is the trap this row exists to name — deleting the two `*_FILE` constants to clear the SETUP error retires the preflight-before-render assertion outright, and nothing is left to notice | REPLACE | F6 | pending |
 | `scripts/test-fast-pr.sh` | the fast pre-checkin spine, which runs the Root-lifecycle drift gate twice (`--self-test`, then `--ci`). `run()` returns 1 on ANY non-zero rc and the spine is `set -euo pipefail`, so the gate's `rc=2` aborts it | REPLACE | F6 | pending |

--- a/tools/README.md
+++ b/tools/README.md
@@ -126,7 +126,9 @@ wired into the build, and consumers can use it today.
   elkjs in-page renderer: nested compound states, parallel regions,
   `:spawn-all` join + cancellation-cascade overlays, `:after` countdown
   rings, a UIx adapter) plus a read-only share-URL **viewer page**
-  (`public/viewer.html` + `viewer.cljs`). Also ships the pure-data
+  (`public/viewer.html` + `viewer.cljs`, built by the
+  `machines-viz-viewer` Shadow build and hosted by the consumer — nothing
+  in this repository deploys it, rf2-8m344). Also ships the pure-data
   Mermaid `stateDiagram-v2` emitter (relocated out of the runtime
   `machines` artefact per rf2-sqhqu so the engine stays pure), SCXML
   import/export round-trip, an AI-generate-a-machine seam, and PNG / SVG

--- a/tools/machines-viz/README.md
+++ b/tools/machines-viz/README.md
@@ -35,7 +35,8 @@ Surfaces that ship today:
 - **Read-only viewer page** — `public/viewer.html` + `viewer.cljs` decode
   a `#machine=` URL fragment client-side and mount the chart with
   `:read-only? true`. Malformed / newer-version payloads render a banner,
-  not a crash.
+  not a crash. You host it — see
+  [§Building and hosting the viewer page](#building-and-hosting-the-viewer-page).
 - **Share-URL encode / decode** — `ChartState → validate + canonicalise
   → versioned envelope → transit-write (json) → base64url → #machine=`.
   Runtime `:data`, source-coords, and definition metadata are dropped
@@ -90,6 +91,42 @@ at all — and `day8/reagent-slim` publishes *its* adapter at the same
 canonical `re-frame.adapter.reagent` namespace, so a slim app taking
 machines-viz would have ended up with two implementations of that
 namespace on one classpath, load order picking the substrate.
+
+## Building and hosting the viewer page
+
+**Nobody deploys this page for you.** Publishing
+`day8/re-frame2-machines-viz` to Clojars ships the library jar and
+nothing else; `release-machines-viz.yml` does not build or deploy the
+page, and no other workflow does either. There is no hosted instance.
+
+Until 2026-07-26 this repository claimed otherwise: `share/default-host`
+and the docs named
+`https://day8.github.io/re-frame2-machines-viz/viewer.html` as a
+"canonical hosted instance". It returns **404** and always did — there is
+no `day8/re-frame2-machines-viz` repository, because machines-viz ships
+out of the re-frame2 monorepo. Every default share-URL was a dead link
+that looked correct to whoever copied it. The default is gone and `:host`
+is now required (rf2-8m344).
+
+Hosting the page yourself is two files and no server:
+
+```bash
+cd implementation
+npx shadow-cljs release machines-viz-viewer      # → out/machines-viz-viewer/viewer.js
+cp ../tools/machines-viz/public/viewer.html out/machines-viz-viewer/
+```
+
+Serve that directory from anywhere that serves static files — your docs
+site, an S3 bucket, a GitHub Pages branch of your own. Then point
+share-URLs at it:
+
+```clojure
+(share/encode-share-url chart-state {:host "https://acme.example.com/viewer.html"})
+```
+
+The page decodes the `#machine=` fragment entirely client-side, so the
+fragment never reaches your server and the host needs no application
+logic. Per [DESIGN-RATIONALE Lock #7](./spec/DESIGN-RATIONALE.md).
 
 ## How to test
 

--- a/tools/machines-viz/public/viewer.html
+++ b/tools/machines-viz/public/viewer.html
@@ -15,10 +15,13 @@
     requests). Per spec/API.md §Read-only viewer + DESIGN-RATIONALE
     Lock #6 / Lock #7.
 
-    Canonical hosted instance:
-      https://day8.github.io/re-frame2-machines-viz/viewer.html
-    is a convenience, not a contract — consumers may self-host this file
-    alongside their own `viewer.js` bundle and point share-URLs at it.
+    There is NO hosted instance (rf2-8m344). You host this page: build
+    the bundle with `shadow-cljs release machines-viz-viewer` from
+    `implementation/`, put the emitted `viewer.js` beside this file, and
+    serve the pair as static assets. `share/encode-share-url` has no
+    default host for the same reason — it takes `{:host …}` naming YOUR
+    copy of this page. See tools/machines-viz/README.md §Building and
+    hosting the viewer page.
   -->
   <style>
     html, body { margin: 0; height: 100%; background: #1a1d23; }

--- a/tools/machines-viz/spec/000-Vision.md
+++ b/tools/machines-viz/spec/000-Vision.md
@@ -103,7 +103,8 @@ exports:
 2. **The read-only viewer page.** A statically hostable HTML page plus
    compiled viewer bundle (`public/viewer.html` + `viewer.js`) that
    decodes a `#machine=<base64url-transit>` URL fragment and renders the
-   chart with callbacks disabled and no runtime connection.
+   chart with callbacks disabled and no runtime connection. The consumer
+   hosts it; there is no Day8-hosted instance (Lock #7, rf2-8m344).
 3. **The share-URL encoding rules.** EDN-shaped data → transit-write →
    base64url, with a `:rf.machines-viz.share/v1` envelope keying the
    encoding version. Roundtrips: `(encode-share-url chart-state)`
@@ -694,7 +695,10 @@ implementation-state list.
   **shipped** (`src/.../chart.cljs`; xyflow + elkjs).
 - Read-only viewer page (per [`API.md`](./API.md) §Read-only viewer) —
   **shipped** (`public/viewer.html` + `page/.../viewer.cljs`, rf2-8d7w1;
-  the page root is not packaged in the jar, rf2-k7l2o).
+  the page root is not packaged in the jar, rf2-k7l2o). "Shipped" here
+  means *written, tested, and buildable* — `shadow-cljs release
+  machines-viz-viewer` emits the bundle. It does not mean *deployed*: no
+  workflow serves the page and there is no hosted instance (rf2-8m344).
 - Share-URL encoding (per [`API.md`](./API.md) §Share-URL encoding) —
   **shipped** (`src/.../share.cljs`, rf2-8d7w1).
 - PNG + SVG exporters — **shipped** (`src/.../export.cljs`, rf2-8d7w1;

--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -1553,20 +1553,18 @@ separation this section codifies).
 
 ## Read-only viewer
 
-A static page at the canonical hosted URL (or self-hosted by the
-consumer) that renders a chart decoded from a URL fragment.
+A static page, **hosted by the consumer**, that renders a chart decoded
+from a URL fragment.
 
 ### URL shape
 
 ```
-https://day8.github.io/re-frame2-machines-viz/viewer.html#machine=<base64url-transit>
-```
-
-Or, when self-hosted:
-
-```
 https://acme.example.com/path/to/viewer.html#machine=<base64url-transit>
 ```
+
+The origin and path are whatever the consumer serves the page from.
+There is **no hosted instance**, and `encode-share-url` has **no default
+host** — see [§Hosting](#hosting) below.
 
 ### Behaviour
 
@@ -1594,9 +1592,9 @@ https://acme.example.com/path/to/viewer.html#machine=<base64url-transit>
   chart renders the machine at rest. Per
   [DESIGN-RATIONALE Lock #5](./DESIGN-RATIONALE.md).
 - The page is statically hostable. Per
-  [DESIGN-RATIONALE Lock #7](./DESIGN-RATIONALE.md), the
-  canonical hosted instance at `day8.github.io` is a convenience,
-  not a contract; consumers can self-host.
+  [DESIGN-RATIONALE Lock #7](./DESIGN-RATIONALE.md) there is no
+  Day8-operated infrastructure behind it, and no Day8-hosted instance
+  either — see [§Hosting](#hosting).
 
 ### What the viewer never does
 
@@ -1617,10 +1615,42 @@ https://acme.example.com/path/to/viewer.html#machine=<base64url-transit>
   the viewer goes to my docs site" would have to fork the page;
   the canonical viewer is read-only end-to-end.
 
+### Hosting
+
+**Nobody deploys this page for you, and that is the design** (Lock #7,
+rf2-8m344). Publishing `day8/re-frame2-machines-viz` to Clojars ships the
+LIBRARY; it does not deploy anything, and no workflow in this repository
+does either. Until 2026-07-26 this section named a "canonical hosted
+instance" at `https://day8.github.io/re-frame2-machines-viz/viewer.html`
+and `encode-share-url` defaulted to it. That URL returned **404** and
+always had: there is no `day8/re-frame2-machines-viz` repository —
+machines-viz ships out of the re-frame2 monorepo — so every default
+share-URL was a dead link that looked correct to the person who copied it.
+
+Hosting the page is three steps and no infrastructure:
+
+```bash
+cd implementation
+npx shadow-cljs release machines-viz-viewer      # → out/machines-viz-viewer/viewer.js
+cp ../tools/machines-viz/public/viewer.html out/machines-viz-viewer/
+```
+
+Serve that directory — the two files are self-contained, decode client-side,
+and need no server logic. Then pass its URL to the encoder:
+
+```clojure
+(share/encode-share-url chart-state {:host "https://acme.example.com/viewer.html"})
+```
+
+`:host` is required. Omitting it throws rather than guessing
+(`:reason :no-host`).
+
 ### The viewer is a page, not library surface
 
 The viewer ships as a **page** — `public/viewer.html` plus the compiled
-`viewer.js` beside it. Its source lives on a source root of its own
+`viewer.js` beside it. "Ships" here means *is built and served by you*,
+not *is deployed by us*: see [§Hosting](#hosting) above. Its source lives
+on a source root of its own
 (`page/day8/re_frame2_machines_viz/viewer.cljs`) which the published
 `day8/re-frame2-machines-viz` jar does **not** carry, and
 `day8.re-frame2-machines-viz.viewer` is correspondingly **not** a
@@ -1651,12 +1681,17 @@ Source: lifted from
 ```clojure
 (:require [day8.re-frame2-machines-viz.share :as share])
 
-(share/encode-share-url chart-state)
-;; => "https://day8.github.io/re-frame2-machines-viz/viewer.html#machine=..."
-
 (share/encode-share-url chart-state {:host "https://acme.example.com/viewer.html"})
 ;; => "https://acme.example.com/viewer.html#machine=..."
+
+(share/encode-share-url chart-state {})
+;; => throws :rf.machines-viz.share/encode-failed, :reason :no-host
 ```
+
+`:host` is **required** — the absolute URL of the viewer page the caller
+hosts (see [§Hosting](#hosting)). There is no default and no arity that
+omits it: the library cannot know where your viewer is served from, and
+the value it used to guess returned 404 (rf2-8m344).
 
 `chart-state` is a map with the schema in
 [§Share-URL payload schema](#share-url-payload-schema) below. The
@@ -1691,6 +1726,13 @@ encoder:
 4. Wraps in the versioned envelope.
 5. Transit-writes the EDN-shaped value and base64url-encodes the Transit JSON.
 6. Wraps the fragment into the `:host` URL.
+
+Failure modes:
+
+| `:reason` | Meaning |
+|---|---|
+| `:no-host` | No non-blank `:host` was supplied. There is no default viewer host — see [§Hosting](#hosting). |
+| `:invalid-chart-state` | The allowlisted chart state fails the same `valid-chart-state?` predicate the decoder applies (a missing/malformed `:machine-id` or `:definition`, a non-keyword `:frame-id`, or a `:snapshot` `:state` that is none of the three configuration arms). Rejected at encode rather than emitted as an undecodable URL. |
 
 ### Decoder
 
@@ -1940,16 +1982,22 @@ private chart-state internals are never named in the user-facing message.
 ### Share URL
 
 ```clojure
-(export/share-url chart-element)
+(export/share-url chart-element {:host "https://acme.example.com/viewer.html"})
 ;; => URL string
 
-(export/copy-share-url-to-clipboard! chart-element)
+(export/copy-share-url-to-clipboard! chart-element {:host "https://acme.example.com/viewer.html"})
 ;; => Promise; clipboard contains the URL as text/plain
 ```
 
 `chart-element` is the in-DOM element rendered by `MachineChart`
 (or a hiccup-equivalent reference). The export functions derive the
 payload from the element's bound props + the live snapshot.
+
+`opts` is required and must carry `:host`, which is passed to
+`encode-share-url` (see [§Hosting](#hosting)); it may also carry an
+optional `:frame-id` for payload provenance. Neither fn has an
+`opts`-free arity — a share-URL that does not name a viewer someone
+actually serves is a dead link (rf2-8m344).
 
 ### Mermaid `stateDiagram-v2`
 

--- a/tools/machines-viz/spec/DESIGN-RATIONALE.md
+++ b/tools/machines-viz/spec/DESIGN-RATIONALE.md
@@ -485,24 +485,41 @@ How does the read-only viewer page get to a user?
 
 ### Pick
 
-**Statically hostable; the canonical hosted instance lives at
-`day8.github.io/re-frame2-machines-viz/` (or equivalent docs URL)
-but is **not load-bearing** — every consumer can self-host.**
+**Statically hostable; the consumer hosts the page.** There is no
+Day8-hosted instance.
 
 ### Why
 
 - **No Day8-side service to operate.** The page is a static
-  asset; if `day8.github.io` goes down, every self-hoster keeps
-  working.
-- **Privacy holds maximally.** Even the canonical hosted page
-  decodes client-side; the URL fragment is never transmitted.
+  asset; there is nothing for Day8 to keep up, and no consumer
+  depends on Day8 keeping anything up.
+- **Privacy holds maximally.** The page decodes client-side; the
+  URL fragment is never transmitted.
 - **Embed in docs without iframe gymnastics.** The viewer page
   can be loaded by a `<script>` tag in the consumer's own docs
   site; the consumer chooses where it lives.
-- **The canonical instance is a convenience, not a contract.**
-  Users sharing a URL with the canonical viewer get one-click
-  rendering; users who don't trust day8.github.io can self-host
-  the page and point share-URLs at their own instance.
+
+### Amendment, 2026-07-26 (rf2-8m344)
+
+As originally written this Pick added "the canonical hosted instance
+lives at `day8.github.io/re-frame2-machines-viz/` (or equivalent docs
+URL) but is not load-bearing", and `share/default-host` made that URL
+the encoder's default.
+
+**It was load-bearing, and it was never real.** The URL returns 404 and
+always did — there is no `day8/re-frame2-machines-viz` repository
+(machines-viz ships out of the re-frame2 monorepo), and no workflow here
+builds or deploys the page. "Not load-bearing" described the hosting
+posture correctly and then a default argument quietly contradicted it:
+the zero-`:host` call was the ergonomic path, so the common case emitted
+a link that 404s for the recipient and looks fine to the sender.
+
+The third option in the list above is now the whole Pick, with nothing
+bolted on: **the consumer hosts the page, and `encode-share-url` requires
+`:host`**. A hosted convenience instance may be added later — it needs a
+real host, a workflow that stages `viewer.html` beside a freshly compiled
+`viewer.js`, and a smoke check that loads the page. Until all three
+exist, naming one is a promise the repository does not keep.
 
 ---
 

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/export.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/export.cljs
@@ -619,28 +619,29 @@
   topology + active-state configuration off the DOM seam, projects them
   into a `ChartState`, and delegates to `share/encode-share-url`.
 
-  `opts` is passed to `share/encode-share-url` (`{:host ...}`), and may
-  also carry `:frame-id` (the chart element doesn't know its frame; a
-  host that does can supply a frame-target id for payload provenance).
-  `:frame-id` is OPTIONAL (v2 / EP-0023) — omit it to share a topology
-  that does not name a live frame. Returns the URL string."
-  ([chart-element] (share-url chart-element nil))
-  ([chart-element opts]
-   (let [chart-state (element->chart-state chart-element opts)]
-     (share/encode-share-url chart-state (select-keys opts [:host])))))
+  `opts` REQUIRES `:host` — the absolute URL of the viewer page you host,
+  passed straight to `share/encode-share-url`. There is no default host
+  (rf2-8m344), so there is no `opts`-free arity: a share-URL that does not
+  name a real viewer is a dead link. `opts` may also carry `:frame-id`
+  (the chart element doesn't know its frame; a host that does can supply a
+  frame-target id for payload provenance). `:frame-id` is OPTIONAL
+  (v2 / EP-0023) — omit it to share a topology that does not name a live
+  frame. Returns the URL string."
+  [chart-element opts]
+  (let [chart-state (element->chart-state chart-element opts)]
+    (share/encode-share-url chart-state (select-keys opts [:host]))))
 
 (defn copy-share-url-to-clipboard!
   "Write the chart's share-URL to the clipboard as `text/plain`.
-  Returns a Promise."
-  ([chart-element] (copy-share-url-to-clipboard! chart-element nil))
-  ([chart-element opts]
-   (let [url (share-url chart-element opts)]
-     (if (and js/navigator (.-clipboard js/navigator))
-       (.writeText (.-clipboard js/navigator) url)
-       (js/Promise.reject
-         (error/thrown-ex-info
-           :rf.machines-viz.export/no-clipboard
-           'machines-viz.export/copy-share-url-to-clipboard!
-           (str "the browser clipboard API is unavailable; copy requires a "
-                "secure (https) context with navigator.clipboard support.")
-           {:recovery :use-a-secure-context-with-clipboard-support}))))))
+  `opts` requires `:host`, exactly as `share-url` does. Returns a Promise."
+  [chart-element opts]
+  (let [url (share-url chart-element opts)]
+    (if (and js/navigator (.-clipboard js/navigator))
+      (.writeText (.-clipboard js/navigator) url)
+      (js/Promise.reject
+        (error/thrown-ex-info
+          :rf.machines-viz.export/no-clipboard
+          'machines-viz.export/copy-share-url-to-clipboard!
+          (str "the browser clipboard API is unavailable; copy requires a "
+               "secure (https) context with navigator.clipboard support.")
+          {:recovery :use-a-secure-context-with-clipboard-support})))))

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/share.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/share.cljs
@@ -71,11 +71,20 @@
   mis-decoding."
   "2")
 
-(def default-host
-  "The canonical hosted viewer instance. Per Lock #7 this is a
-  convenience, not a contract — every consumer may self-host and pass
-  `{:host ...}` to `encode-share-url`."
-  "https://day8.github.io/re-frame2-machines-viz/viewer.html")
+;; THERE IS NO DEFAULT HOST, and that is the contract rather than an
+;; omission (rf2-8m344). This var used to read
+;; `"https://day8.github.io/re-frame2-machines-viz/viewer.html"`, so
+;; `(encode-share-url chart-state)` handed back a link that 404s: no
+;; `day8/re-frame2-machines-viz` repository exists — machines-viz ships out
+;; of the re-frame2 monorepo — and no workflow deploys the page anywhere.
+;; A default that names a host nobody serves is worse than no default,
+;; because the resulting URL looks correct and fails only for the person
+;; you sent it to.
+;;
+;; Per DESIGN-RATIONALE Lock #7 the viewer is STATICALLY HOSTABLE and the
+;; consumer hosts it. `:host` is therefore the one thing this library
+;; cannot know and the caller always can, so it is required — see
+;; `encode-share-url`.
 
 (def fragment-key
   "The URL-fragment key the viewer reads off `location.hash`."
@@ -492,12 +501,15 @@
   "Encode a `chart-state` map into a share-URL string.
 
   ```clojure
-  (encode-share-url chart-state)
-  ;; => \"https://day8.github.io/re-frame2-machines-viz/viewer.html#machine=...\"
-
   (encode-share-url chart-state {:host \"https://acme.example.com/viewer.html\"})
   ;; => \"https://acme.example.com/viewer.html#machine=...\"
   ```
+
+  `:host` is REQUIRED — the absolute URL of the viewer page YOU host (see
+  `tools/machines-viz/README.md` §Building and hosting the viewer page).
+  There is no default and no Day8-hosted instance; the arity that used to
+  supply one emitted a URL that 404s (rf2-8m344). Calling without a
+  non-blank `:host` throws `:reason :no-host` rather than guessing.
 
   `chart-state` is a `ChartState` map (per `API.md` §Share-URL payload
   schema):
@@ -524,40 +536,57 @@
   versioned envelope, (5) transit-writes (json) → base64url-encodes,
   (6) wraps the fragment into `:host`.
 
-  Throws `:rf.machines-viz.share/encode-failed` (an ex-info with
-  `:reason :invalid-chart-state`) when the chart state does not validate
-  — including a `:snapshot` `:state` that is none of the three allowed
-  configuration arms (a malformed `:state` would yield an undecodable
-  URL, so it is rejected at encode)."
-  ([chart-state] (encode-share-url chart-state nil))
-  ([chart-state {:keys [host] :or {host default-host}}]
-   (let [allowlisted (allowlist-chart-state chart-state)]
-     (when-not (valid-chart-state? allowlisted)
-       ;; rf2-vvixub — the ex-message is the human sentence + the
-       ;; [:rf.machines-viz.share/encode-failed] token; the fine `:reason`
-       ;; keyword stays the documented tool-classification slot (API.md).
-       (let [msg (str "cannot encode a share-URL: the chart state does not "
-                      "validate against the share schema (a :machine-id or "
-                      ":definition is missing/malformed, :frame-id (optional) "
-                      "is non-keyword, or :snapshot :state is malformed). Pass "
-                      "a valid ChartState.")]
-         (throw (ex-info (error/human-message :rf.machines-viz.share/encode-failed msg)
-                         {:rf.error/id :rf.machines-viz.share/encode-failed
-                          :where       'machines-viz.share/encode-share-url
-                          :recovery    :supply-a-valid-chart-state
-                          :reason      :invalid-chart-state
-                          :message     msg
-                          ;; rf2-8nzxib — value-FREE summary, NOT the raw
-                          ;; chart-state (which can carry runtime :data).
-                          :chart-state-summary (value-free-summary chart-state)}))))
-     (let [envelope    (canonicalise
-                         {:rf.machines-viz.share/v       current-version
-                          :rf.machines-viz.share/chart   allowlisted
-                          :rf.machines-viz.share/created (js/Date.now)})
-           writer      (transit/writer :json)
-           transit-str (transit/write writer envelope)
-           fragment    (bytes->base64url transit-str)]
-       (str host "#" fragment-key "=" fragment)))))
+  Throws `:rf.machines-viz.share/encode-failed` (an ex-info) with:
+
+  | `:reason`              | Meaning |
+  |---|---|
+  | `:no-host`             | No non-blank `:host` was supplied. |
+  | `:invalid-chart-state` | The chart state does not validate — including a `:snapshot` `:state` that is none of the three allowed configuration arms (a malformed `:state` would yield an undecodable URL, so it is rejected at encode). |"
+  [chart-state {:keys [host]}]
+  (let [host (when (string? host) (str/trim host))]
+    (when (str/blank? host)
+      ;; rf2-8m344 — fail loud rather than fabricate. The library cannot
+      ;; know where the caller's viewer page is served from, and the
+      ;; hosted instance this used to default to never existed.
+      (let [msg (str "cannot encode a share-URL: no :host was supplied, and "
+                     "there is no default viewer host. A share-URL must name "
+                     "the viewer page you host. Build it with `shadow-cljs "
+                     "release machines-viz-viewer`, serve viewer.html + "
+                     "viewer.js as static files, and pass "
+                     "{:host \"https://your.example.com/viewer.html\"}.")]
+        (throw (ex-info (error/human-message :rf.machines-viz.share/encode-failed msg)
+                        {:rf.error/id :rf.machines-viz.share/encode-failed
+                         :where       'machines-viz.share/encode-share-url
+                         :recovery    :supply-the-url-of-a-viewer-page-you-host
+                         :reason      :no-host
+                         :message     msg}))))
+    (let [allowlisted (allowlist-chart-state chart-state)]
+      (when-not (valid-chart-state? allowlisted)
+        ;; rf2-vvixub — the ex-message is the human sentence + the
+        ;; [:rf.machines-viz.share/encode-failed] token; the fine `:reason`
+        ;; keyword stays the documented tool-classification slot (API.md).
+        (let [msg (str "cannot encode a share-URL: the chart state does not "
+                       "validate against the share schema (a :machine-id or "
+                       ":definition is missing/malformed, :frame-id (optional) "
+                       "is non-keyword, or :snapshot :state is malformed). Pass "
+                       "a valid ChartState.")]
+          (throw (ex-info (error/human-message :rf.machines-viz.share/encode-failed msg)
+                          {:rf.error/id :rf.machines-viz.share/encode-failed
+                           :where       'machines-viz.share/encode-share-url
+                           :recovery    :supply-a-valid-chart-state
+                           :reason      :invalid-chart-state
+                           :message     msg
+                           ;; rf2-8nzxib — value-FREE summary, NOT the raw
+                           ;; chart-state (which can carry runtime :data).
+                           :chart-state-summary (value-free-summary chart-state)}))))
+      (let [envelope    (canonicalise
+                          {:rf.machines-viz.share/v       current-version
+                           :rf.machines-viz.share/chart   allowlisted
+                           :rf.machines-viz.share/created (js/Date.now)})
+            writer      (transit/writer :json)
+            transit-str (transit/write writer envelope)
+            fragment    (bytes->base64url transit-str)]
+        (str host "#" fragment-key "=" fragment)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Decoder

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/export_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/export_cljs_test.cljs
@@ -17,6 +17,10 @@
             [day8.re-frame2-machines-viz.export :as export]
             [day8.re-frame2-machines-viz.share :as share]))
 
+;; `share-url` has no default host (rf2-8m344) — every caller names the
+;; viewer page it hosts, tests included.
+(def ^:private test-host "https://x/viewer.html")
+
 (def definition
   {:initial :idle
    :states  {:idle    {:on {:start :loading}}
@@ -45,7 +49,7 @@
 (deftest share-url-from-seam
   (testing "share-url derives an encodable ChartState off the DOM seam"
     (let [el  (stub-element seam)
-          url (export/share-url el)
+          url (export/share-url el {:host test-host})
           env (share/decode-share-url url)
           cs  (:rf.machines-viz.share/chart env)]
       (is (str/includes? url "#machine="))
@@ -72,7 +76,7 @@
     (let [el  (stub-element (assoc seam
                                    :definition compound-definition
                                    :current-state [:authenticated :cart :browsing]))
-          cs  (:rf.machines-viz.share/chart (share/decode-share-url (export/share-url el)))]
+          cs  (:rf.machines-viz.share/chart (share/decode-share-url (export/share-url el {:host test-host})))]
       (is (= {:state [:authenticated :cart :browsing]} (:snapshot cs))))))
 
 (deftest share-url-parallel-current-state-rides-through
@@ -81,7 +85,7 @@
                                    :definition parallel-definition
                                    :region-count 2
                                    :current-state {:data :dirty :form :busy}))
-          cs  (:rf.machines-viz.share/chart (share/decode-share-url (export/share-url el)))]
+          cs  (:rf.machines-viz.share/chart (share/decode-share-url (export/share-url el {:host test-host})))]
       (is (= {:state {:data :dirty :form :busy}} (:snapshot cs))))))
 
 (deftest share-url-honours-host-and-frame
@@ -96,7 +100,7 @@
   (testing "no :current-state on the seam → no snapshot in the payload"
     (let [el  (stub-element (dissoc seam :current-state))
           cs  (:rf.machines-viz.share/chart
-                (share/decode-share-url (export/share-url el)))]
+                (share/decode-share-url (export/share-url el {:host test-host})))]
       (is (not (contains? cs :snapshot))))))
 
 (deftest mermaid-from-seam
@@ -113,7 +117,7 @@
 
 (deftest no-seam-throws
   (testing "an element that is not a rendered MachineChart throws :no-chart-state"
-    (let [d (try (export/share-url #js {})
+    (let [d (try (export/share-url #js {} {:host test-host})
                  (catch :default e (ex-data e)))]
       ;; rf2-vvixub / rf2-s6rzia — branch on the canonical :rf.error/id, and
       ;; the :reason names the PUBLIC concept (a rendered MachineChart

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/export_dom_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/export_dom_cljs_test.cljs
@@ -60,6 +60,10 @@
             [day8.re-frame2-machines-viz.export :as export]
             [day8.re-frame2-machines-viz.share :as share]))
 
+;; `share-url` has no default host (rf2-8m344) — every caller names the
+;; viewer page it hosts, tests included.
+(def ^:private test-host "https://x/viewer.html")
+
 ;; ---- sample machine -----------------------------------------------------
 
 (def ^:private idle-loading-done
@@ -396,7 +400,7 @@
         (fn [node]
           (let [root (chart-root-of node "rf-mv-chart")]
             ;; share-url from the live chart root round-trips.
-            (let [url (export/share-url root)
+            (let [url (export/share-url root {:host test-host})
                   cs  (:rf.machines-viz.share/chart (share/decode-share-url url))]
               (is (str/includes? url "#machine=") "share-url is a machine fragment")
               (is (= :test/flow (:machine-id cs)) "share-url carries the machine-id")
@@ -405,7 +409,7 @@
               (is (= {:state :loading} (:snapshot cs))
                   "share-url carries the active-state name (no :data)"))
             ;; share-url from the WRAPPER resolves the same root.
-            (is (str/includes? (export/share-url node) "#machine=")
+            (is (str/includes? (export/share-url node {:host test-host}) "#machine=")
                 "share-url resolves from a wrapper via the seam too")
             ;; Mermaid lane still emits a fenced stateDiagram from the seam.
             (let [md (export/chart-as-mermaid root)]

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/share_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/share_cljs_test.cljs
@@ -26,6 +26,19 @@
             [day8.re-frame2-machines-viz.share :as share]))
 
 ;; ---------------------------------------------------------------------------
+;; The viewer host these tests encode against. `encode-share-url` has NO
+;; default host (rf2-8m344) — the one it used to carry named a repository
+;; that does not exist — so every producer of a share-URL names its own
+;; viewer, tests included.
+
+(def ^:private test-host "https://x/viewer.html")
+
+(defn- encode
+  "`share/encode-share-url` against `test-host`."
+  [chart-state]
+  (share/encode-share-url chart-state {:host test-host}))
+
+;; ---------------------------------------------------------------------------
 ;; Test helper — craft a raw share-URL fragment from an arbitrary
 ;; envelope (so we can build a future-version / missing-envelope payload
 ;; the public encoder would never emit). Mirrors the encoder's
@@ -38,7 +51,7 @@
                 (str/replace "+" "-")
                 (str/replace "/" "_")
                 (str/replace "=" ""))]
-    (str "https://x/viewer.html#machine=" b64)))
+    (str test-host "#machine=" b64)))
 
 ;; ---------------------------------------------------------------------------
 ;; Fixtures
@@ -79,7 +92,7 @@
 
 (deftest round-trip-preserves-chart-state
   (testing "encode → decode recovers the ChartState exactly"
-    (let [url (share/encode-share-url chart-state)
+    (let [url (encode chart-state)
           env (share/decode-share-url url)
           back (:rf.machines-viz.share/chart env)]
       (is (= :auth/login-flow (:machine-id back)))
@@ -92,7 +105,7 @@
 (deftest round-trip-parallel
   (testing "parallel definitions round-trip"
     (let [back (:rf.machines-viz.share/chart
-                 (share/decode-share-url (share/encode-share-url parallel-state)))]
+                 (share/decode-share-url (encode parallel-state)))]
       (is (= (:definition parallel-state) (:definition back)))
       (is (= :editor/flow (:machine-id back))))))
 
@@ -100,7 +113,7 @@
   (testing "a ChartState with no :snapshot round-trips without one"
     (let [cs   (dissoc chart-state :snapshot)
           back (:rf.machines-viz.share/chart
-                 (share/decode-share-url (share/encode-share-url cs)))]
+                 (share/decode-share-url (encode cs)))]
       (is (not (contains? back :snapshot)))
       (is (= idle-loading-success (:definition back))))))
 
@@ -114,7 +127,7 @@
   (testing "a FLAT keyword :state round-trips"
     (let [cs   (assoc chart-state :snapshot {:state :loading})
           back (:rf.machines-viz.share/chart
-                 (share/decode-share-url (share/encode-share-url cs)))]
+                 (share/decode-share-url (encode cs)))]
       (is (= {:state :loading} (:snapshot back)))
       (is (keyword? (get-in back [:snapshot :state]))))))
 
@@ -125,7 +138,7 @@
                 :definition compound-definition
                 :snapshot   {:state [:authenticated :cart :browsing]}}
           back (:rf.machines-viz.share/chart
-                 (share/decode-share-url (share/encode-share-url cs)))]
+                 (share/decode-share-url (encode cs)))]
       (is (= {:state [:authenticated :cart :browsing]} (:snapshot back)))
       (is (vector? (get-in back [:snapshot :state]))))))
 
@@ -133,14 +146,14 @@
   (testing "a PARALLEL region-map :state round-trips (was rejected pre-9l8h8)"
     (let [cs   (assoc parallel-state :snapshot {:state {:data :dirty :form :busy}})
           back (:rf.machines-viz.share/chart
-                 (share/decode-share-url (share/encode-share-url cs)))]
+                 (share/decode-share-url (encode cs)))]
       (is (= {:state {:data :dirty :form :busy}} (:snapshot back)))
       (is (map? (get-in back [:snapshot :state])))))
   (testing "a PARALLEL region-map whose region value is itself a compound path"
     (let [cs   (assoc parallel-state
                       :snapshot {:state {:data :dirty :form [:edit :touched]}})
           back (:rf.machines-viz.share/chart
-                 (share/decode-share-url (share/encode-share-url cs)))]
+                 (share/decode-share-url (encode cs)))]
       (is (= {:state {:data :dirty :form [:edit :touched]}} (:snapshot back))))))
 
 (deftest malformed-state-rejected-at-encode
@@ -153,7 +166,7 @@
                        {:data "loading"}               ;; non-keyword/path region value
                        {"data" :loading}]]             ;; non-keyword region name
       (let [cs (assoc chart-state :snapshot {:state bad-state})
-            d  (try (share/encode-share-url cs)
+            d  (try (encode cs)
                     (catch :default e (ex-data e)))]
         (is (= :invalid-chart-state (:reason d))
             (str "encode must reject malformed :state " (pr-str bad-state)))
@@ -168,7 +181,7 @@
       (let [cs  (assoc chart-state
                        :definition compound-definition
                        :snapshot {:state state})
-            url (share/encode-share-url cs)
+            url (encode cs)
             ;; decode-share-url-safe never throws — an undecodable URL
             ;; (the pre-9l8h8 bug) would surface as {:error ...}.
             r   (share/decode-share-url-safe url)]
@@ -178,9 +191,9 @@
 
 (deftest url-shape
   (testing "encoded URL carries the #machine= fragment + uses base64url alphabet"
-    (let [url (share/encode-share-url chart-state)
+    (let [url (encode chart-state)
           frag (subs url (inc (str/index-of url "#")))]
-      (is (str/starts-with? url share/default-host))
+      (is (str/starts-with? url test-host))
       (is (str/starts-with? frag "machine="))
       (let [payload (subs frag (count "machine="))]
         ;; base64url: no +, /, or = padding
@@ -188,10 +201,25 @@
         (is (not (str/includes? payload "/")))
         (is (not (str/includes? payload "=")))))))
 
-(deftest host-override
-  (testing "{:host ...} swaps the viewer base"
+(deftest host-selects-the-viewer-base
+  (testing "{:host ...} names the viewer the URL points at"
     (let [url (share/encode-share-url chart-state {:host "https://acme.example.com/v.html"})]
       (is (str/starts-with? url "https://acme.example.com/v.html#machine=")))))
+
+(deftest no-host-is-refused
+  (testing "rf2-8m344 — there is no default host, and a missing one is refused
+            rather than filled in with a URL that 404s"
+    (doseq [opts [nil {} {:host nil} {:host ""} {:host "   "}]]
+      (let [d (try (share/encode-share-url chart-state opts)
+                   (catch :default e (ex-data e)))]
+        (is (= :rf.machines-viz.share/encode-failed (:rf.error/id d))
+            (str "refused for opts " (pr-str opts)))
+        (is (= :no-host (:reason d))
+            (str "reason is :no-host for opts " (pr-str opts)))
+        (is (string? (:message d)) "carries a human message"))))
+  (testing "a blank host never yields a URL"
+    (is (not (string? (try (share/encode-share-url chart-state {:host "  "})
+                           (catch :default _ nil)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Canonicalisation / reproducibility
@@ -220,7 +248,7 @@
       (is (= a b) "fixtures are value-equal")
       (frozen-now
         (fn []
-          (is (= (share/encode-share-url a) (share/encode-share-url b))
+          (is (= (encode a) (encode b))
               "and therefore encode byte-for-byte identically (created frozen)"))))))
 
 (deftest reproducible-with-sets
@@ -233,9 +261,9 @@
                           :states {:s1 {:tags #{:c :a :b}}}}}]
       (frozen-now
         (fn []
-          (is (= (share/encode-share-url a) (share/encode-share-url b)))))
+          (is (= (encode a) (encode b)))))
       (let [back (:rf.machines-viz.share/chart
-                   (share/decode-share-url (share/encode-share-url a)))]
+                   (share/decode-share-url (encode a)))]
         (is (= #{:a :b :c} (get-in back [:definition :states :s1 :tags])))))))
 
 ;; ---------------------------------------------------------------------------
@@ -247,19 +275,19 @@
                                               :data  {:token "secret-abc"
                                                       :form  {:password "hunter2"}}})
           back  (:rf.machines-viz.share/chart
-                  (share/decode-share-url (share/encode-share-url leaky)))]
+                  (share/decode-share-url (encode leaky)))]
       (is (= {:state :loading} (:snapshot back)))
       (is (not (contains? (:snapshot back) :data)))
-      (is (not (str/includes? (share/encode-share-url leaky) "hunter2"))
+      (is (not (str/includes? (encode leaky) "hunter2"))
           "the secret never reaches the encoded bytes"))))
 
 (deftest source-coords-are-dropped
   (testing ":source-coords passed by the caller never reach the payload"
     (let [leaky (assoc chart-state :source-coords {:file "/Users/mike/secret/x.cljs"})
           back  (:rf.machines-viz.share/chart
-                  (share/decode-share-url (share/encode-share-url leaky)))]
+                  (share/decode-share-url (encode leaky)))]
       (is (not (contains? back :source-coords)))
-      (is (not (str/includes? (share/encode-share-url leaky) "secret"))))))
+      (is (not (str/includes? (encode leaky) "secret"))))))
 
 (deftest definition-metadata-is-stripped
   (testing "macro-captured source-coord meta on the definition does not propagate"
@@ -267,7 +295,7 @@
                                     {:rf/source-coord {:file "/Users/mike/proj/m.cljs"
                                                        :line 42}})
           cs   (assoc chart-state :definition defn-with-meta)
-          url  (share/encode-share-url cs)
+          url  (encode cs)
           back (:rf.machines-viz.share/chart (share/decode-share-url url))]
       (is (nil? (meta (:definition back))) "no meta survives")
       (is (not (str/includes? url "proj")) "the file path never reaches the bytes"))))
@@ -311,7 +339,7 @@
   (testing "rf2-m285a — nested :source-coords / :source-code on :states /
             :guards / :actions are stripped before Transit (no local path leak)"
     (let [cs   (assoc chart-state :definition macro-stamped-like-definition)
-          url  (share/encode-share-url cs)
+          url  (encode cs)
           back (:rf.machines-viz.share/chart (share/decode-share-url url))
           dfn  (:definition back)]
       ;; The encoded BYTES carry no local-filesystem path / source snippet.
@@ -337,7 +365,7 @@
             action encode successfully (instead of crashing Transit) — the
             executable body is dropped / labelled, not serialised"
     (let [cs  (assoc chart-state :definition macro-stamped-like-definition)
-          url (share/encode-share-url cs)
+          url (encode cs)
           dfn (:definition
                 (:rf.machines-viz.share/chart (share/decode-share-url url)))]
       (is (string? url) "encoding succeeds")
@@ -377,7 +405,7 @@
   (testing "rf2-skhlw2.1 — a share URL PRESERVES safe :rf.cofx/requires
             metadata while still dropping the executable :fn"
     (let [cs   (assoc chart-state :definition cofx-requires-definition)
-          url  (share/encode-share-url cs)
+          url  (encode cs)
           dfn  (:definition
                  (:rf.machines-viz.share/chart (share/decode-share-url url)))]
       ;; the requires vectors survive intact (safe topology metadata)
@@ -410,7 +438,7 @@
             preserved through share encode/decode (not dropped as if it were
             an executable function slot)"
     (let [cs   (assoc chart-state :definition fn-id-definition)
-          url  (share/encode-share-url cs)
+          url  (encode cs)
           dfn  (:definition
                  (:rf.machines-viz.share/chart (share/decode-share-url url)))]
       (is (string? url) "encoding succeeds")
@@ -432,7 +460,7 @@
                 :regions {:fn {:initial :one :states {:one {:on {:go :two}} :two {}}}
                           :b  {:initial :p   :states {:p {} :q {}}}}}
           cs   (assoc chart-state :definition defn)
-          url  (share/encode-share-url cs)
+          url  (encode cs)
           dfn  (:definition
                  (:rf.machines-viz.share/chart (share/decode-share-url url)))]
       (is (string? url) "encoding succeeds")
@@ -451,7 +479,7 @@
                 :states  {:fn {:on {:go {:target :done :guard :ready?}}}
                           :done {:final? true}}}
           cs   (assoc chart-state :definition defn)
-          url  (share/encode-share-url cs)
+          url  (encode cs)
           dfn  (:definition
                  (:rf.machines-viz.share/chart (share/decode-share-url url)))]
       (is (string? url) "encoding succeeds (the live fn did not crash Transit)")
@@ -480,7 +508,7 @@
 (deftest frame-id-is-optional
   (testing "a ChartState with no :frame-id encodes + round-trips (v2 / EP-0023)"
     (let [cs   (dissoc chart-state :frame-id)
-          url  (share/encode-share-url cs)
+          url  (encode cs)
           back (:rf.machines-viz.share/chart (share/decode-share-url url))]
       (is (not (contains? back :frame-id))
           "no fabricated :frame-id rides the payload when none was supplied")
@@ -490,7 +518,7 @@
 
 (deftest frame-id-when-present-must-be-keyword
   (testing "a non-keyword :frame-id is rejected at encode with :invalid-chart-state"
-    (let [d (try (share/encode-share-url (assoc chart-state :frame-id "not-a-keyword"))
+    (let [d (try (encode (assoc chart-state :frame-id "not-a-keyword"))
                  (catch :default e (ex-data e)))]
       (is (= :invalid-chart-state (:reason d))))))
 
@@ -640,7 +668,7 @@
             (encode/decode stay symmetric — the encoder never emits a payload
             the decoder would reject)"
     (doseq [[label definition] malformed-definitions]
-      (let [d (try (share/encode-share-url {:machine-id :demo :definition definition})
+      (let [d (try (encode {:machine-id :demo :definition definition})
                    (catch :default e (ex-data e)))]
         (is (= :invalid-chart-state (:reason d))
             (str "malformed definition " label " must be rejected at encode"))
@@ -654,7 +682,7 @@
     (doseq [[label definition] valid-definitions]
       (let [cs   {:machine-id :demo :definition definition}
             back (:rf.machines-viz.share/chart
-                   (share/decode-share-url (share/encode-share-url cs)))]
+                   (share/decode-share-url (encode cs)))]
         (is (= definition (:definition back))
             (str label " definition round-trips UNCHANGED (authored form preserved)"))))))
 
@@ -708,7 +736,7 @@
   (testing "rf2-j538f7.18 — the encoder rejects the same recursively-malformed
             definitions (encode/decode stay symmetric)"
     (doseq [[label definition] recursively-malformed-definitions]
-      (let [d (try (share/encode-share-url {:machine-id :demo :definition definition})
+      (let [d (try (encode {:machine-id :demo :definition definition})
                    (catch :default e (ex-data e)))]
         (is (= :invalid-chart-state (:reason d))
             (str "recursively-malformed " label " must be rejected at encode"))
@@ -803,7 +831,7 @@
 
 (deftest valid-chart-state-with-exact-keys-still-decodes
   (testing "guard against over-tightening — a legitimate ChartState (no extra keys) still round-trips"
-    (let [url  (share/encode-share-url chart-state)
+    (let [url  (encode chart-state)
           back (:rf.machines-viz.share/chart (share/decode-share-url url))]
       (is (= :auth/login-flow (:machine-id back)))
       (is (= {:state :loading} (:snapshot back)))
@@ -834,8 +862,8 @@
     ;; through the encoder is blocked by the encoder's own validation.
     ;; So assert the encoder rejects an invalid ChartState up front.
     (is (thrown? :default
-          (share/encode-share-url {:machine-id :x :frame-id :y :definition {}})))
-    (let [d (try (share/encode-share-url {:machine-id "not-a-kw"
+          (encode {:machine-id :x :frame-id :y :definition {}})))
+    (let [d (try (encode {:machine-id "not-a-kw"
                                           :frame-id :y
                                           :definition idle-loading-success})
                  (catch :default e (ex-data e)))]
@@ -847,7 +875,7 @@
       (is (= :malformed-fragment (get-in r [:error :reason])))
       (is (nil? (:ok r))))
     (testing "and {:ok envelope} on success"
-      (let [r (share/decode-share-url-safe (share/encode-share-url chart-state))]
+      (let [r (share/decode-share-url-safe (encode chart-state))]
         (is (some? (:ok r)))
         (is (nil? (:error r)))))))
 
@@ -856,7 +884,7 @@
 
 (deftest chart-state->props-projection
   (testing "envelope → MachineChart props (read-only, current-state from snapshot)"
-    (let [env   (share/decode-share-url (share/encode-share-url chart-state))
+    (let [env   (share/decode-share-url (encode chart-state))
           props (share/chart-state->props env)]
       (is (= :auth/login-flow (:machine-id props)))
       (is (= idle-loading-success (:definition props)))
@@ -864,7 +892,7 @@
       (is (true? (:read-only? props)))
       (is (not (contains? props :frame-id)) "frame-id is provenance, not a prop")))
   (testing "no snapshot → no :current-state"
-    (let [env   (share/decode-share-url (share/encode-share-url (dissoc chart-state :snapshot)))
+    (let [env   (share/decode-share-url (encode (dissoc chart-state :snapshot)))
           props (share/chart-state->props env)]
       (is (not (contains? props :current-state)))
       (is (true? (:read-only? props)))))
@@ -872,11 +900,11 @@
     (let [cs    {:machine-id :shop/store :frame-id :app/main
                  :definition compound-definition
                  :snapshot   {:state [:authenticated :cart :browsing]}}
-          props (share/chart-state->props (share/decode-share-url (share/encode-share-url cs)))]
+          props (share/chart-state->props (share/decode-share-url (encode cs)))]
       (is (= [:authenticated :cart :browsing] (:current-state props)))))
   (testing "parallel region-map snapshot projects :current-state verbatim"
     (let [cs    (assoc parallel-state :snapshot {:state {:data :dirty :form :busy}})
-          props (share/chart-state->props (share/decode-share-url (share/encode-share-url cs)))]
+          props (share/chart-state->props (share/decode-share-url (encode cs)))]
       (is (= {:data :dirty :form :busy} (:current-state props))))))
 
 ;; ---------------------------------------------------------------------------
@@ -908,7 +936,7 @@
                   :definition idle-loading-success
                   :snapshot   {:state "not-an-arm"        ;; rejected
                                :data  {:password secret}}}
-          d      (try (share/encode-share-url leaky)
+          d      (try (encode leaky)
                       (catch :default e (ex-data e)))]
       (is (= :invalid-chart-state (:reason d)) "reason/category preserved")
       (is (not (contains? d :chart-state)) "no raw chart-state slot")

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/viewer_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/viewer_cljs_test.cljs
@@ -33,7 +33,7 @@
 
 (deftest decode-location-ok
   (testing "a valid share-URL decodes to :ok with MachineChart props"
-    (let [url (share/encode-share-url chart-state)
+    (let [url (share/encode-share-url chart-state {:host "https://x/viewer.html"})
           vm  (viewer/decode-location url)]
       (is (= :ok (:status vm)))
       (is (= :auth/login-flow (get-in vm [:props :machine-id])))


### PR DESCRIPTION
Two beads, both fallout from the rf2-k7l2o packaging fix that landed hours ago.

- **`rf2-8m344`** (P2, bug) — the machines-viz default viewer URL is 404, and no workflow ships the page bundle.
- **`rf2-vuylw`** (P2, bug) — the `examples/realworld-resources-ui` build-id family is unrowed in the Freehand donor ledger.

The rf2-k7l2o `page`/`src` split is **untouched and re-proved**: `page` stays off `:paths` and off `:clein/build :src-dirs`, and a control build confirms a consumer still cannot reach the viewer namespace.

---

## rf2-8m344 — the verdict is "there is no host", not "build a deploy pipeline"

### What is actually broken

`share/default-host` was `https://day8.github.io/re-frame2-machines-viz/viewer.html`, so `(encode-share-url chart-state)` handed back that URL by default. Measured, not inferred:

| probe | result |
|---|---|
| `https://day8.github.io/re-frame2-machines-viz/viewer.html` | **404** |
| `https://github.com/day8/re-frame2-machines-viz` | **404** — the repository does not exist |
| `https://day8.github.io/re-frame2/` | 200 — the repo's real Pages site |

The default did not name a host that is temporarily down. It named a **repository that has never existed and is not planned**: machines-viz ships out of the re-frame2 monorepo. Every zero-`:host` share-URL was a dead link that looks correct to the person who copies it and fails only for the person they send it to.

### Why not ship the bundle

Acceptance criterion 2 (a workflow that builds `:machines-viz-viewer`, stages HTML+JS, deploys, and smoke-checks) is buildable — `docs.yml` already carries JDK 21, Node, Clojure CLI, a shadow-cljs `:advanced` build and a Playwright smoke for the playground, so the toolchain is there. It is still the wrong call right now:

- **The feature has no producer.** Xray's share affordance is not wired — `machine_inspector_view_cljs_test.cljs` asserts `:rf.xray/share-url` is *unregistered*. Nothing in this repository emits a share-URL outside tests.
- **The artefact has no consumer.** Nothing is on Clojars; `release-machines-viz.yml`'s first publish is still a manual step.
- Deploying a page nobody can currently produce a link to, and coupling the docs deploy to an `implementation/` `npm ci` plus a cold Reagent `:advanced` compile, is a delivery pipeline bought ahead of a delivery need.

So this takes **acceptance criterion 4**: remove the default, stop implying the page is deployed, keep self-hosting explicit — and make the self-host path real rather than tribal.

### What changed

**`:host` is required.** No default, and no `opts`-free arity on `share/encode-share-url`, `export/share-url`, or `export/copy-share-url-to-clipboard!`. A missing or blank host throws `:rf.machines-viz.share/encode-failed` with `:reason :no-host` and a message carrying the three-step recipe. An arity that cannot succeed is API noise; a library that guesses your origin is worse.

**The page keeps its delivery vehicle and gains a documented one.** `shadow-cljs release machines-viz-viewer` already existed; the README, the spec, and `viewer.html`'s own comment now say who runs it (you), what to put beside the output, and that nothing here deploys it.

**Lock #7 gets a dated amendment** rather than a silent rewrite. Its Pick hedged the hosted instance as "not load-bearing" — but a default argument made it exactly load-bearing, since the zero-`:host` call was the ergonomic path. The third option in its own list (consumer hosts the page) is now the whole Pick.

### Every `.github/workflows/**` hunk — 1 hunk, 1 file, comment-only

| file | hunk | lines | change |
|---|---|---|---|
| `.github/workflows/release-machines-viz.yml` | `@@ -33,6 +33,24 @@` | +18 / -0 | One new **comment** section, `# # What this workflow does NOT do: it does not deploy the viewer page`, inserted between the existing `# # Why a separate workflow…` and `# # Lockstep versioning` sections. It states that this workflow publishes the jar only, that no workflow deploys the page, and why the opposite inference was easy to make. |

**No YAML key, job, step, trigger, permission, or action pin is touched** — `git diff` on this file is entirely `#`-prefixed lines. In particular **no second `rewrite-local-root-coord.sh` call was added**: `clein pom` silently skipping `:local/root` is untouched, the single existing rewrite of `../../implementation/core` still covers machines-viz's only in-repo coordinate, and nothing here changes the dependency graph. Nothing to sequence.

### Simulated consumer — the artefact checked, not the exit code

A throwaway project (`_gates/sim-consumer/`, gitignored) whose **only** dependency is `day8/re-frame2-machines-viz` via `:local/root`, so the resolved classpath is exactly the artefact's `:paths ["src"]` + its declared `:deps` — the published surface, with **no adapter coordinate declared**.

`:sim-lib` compiled `rc=0` (125 files) and ran `rc=0`:

```
RESOLVED share/encode-share-url true      RESOLVED chart/MachineChart        true
RESOLVED share/decode-share-url true      RESOLVED react-chart/chart-element true
RESOLVED mermaid/emit           true      RESOLVED uix/MachineChart          true
RESOLVED scxml/spec->scxml      true      RESOLVED export/share-url          true
NO_HOST_REASON   :no-host
NO_HOST_ERROR_ID :rf.machines-viz.share/encode-failed
SHARE_URL_STARTS_WITH_HOST true
ROUNDTRIP_MACHINE_ID       :auth/login-flow
```

> A first run of this exited `rc=1` on `Cannot find module '@xyflow/react'` — Node resolving upward from a throwaway project directory, not a consumer-surface defect. Re-emitted into `implementation/out/` (the trick the artefact's own `:machines-viz-node-test` lane uses) and it is green. Recorded because the exit code was not a test outcome.

`:sim-page-control` — the same consumer trying `(:require [day8.re-frame2-machines-viz.viewer])` — **must fail, and does**: `rc=1`, *"The required namespace `day8.re-frame2-machines-viz.viewer` is not available"*. rf2-k7l2o holds.

### The built artefact, loaded as a recipient loads it

`shadow-cljs release machines-viz-viewer` → `rc=0`, 183 files, 118 compiled, 0 warnings, `viewer.js` 2,358,077 bytes. Then the README recipe verbatim (`cp` the checked-in `viewer.html` beside it), served over HTTP, driven in headless Chromium with the **real share-URL the simulated consumer printed** — `rc=0`:

```
STAGED_FILES ["manifest.edn","viewer.html","viewer.js"]
PASS viewer.html finds day8.re_frame2_machines_viz.viewer.run in the release bundle :: typeof=function
PASS a bare visit renders the empty state
PASS a share-URL renders the read-only banner
PASS no error banner            PASS no empty banner
PASS xyflow rendered the chart nodes :: nodes=10
PASS chart renders state "login-flow" / "idle" / "loading" / "success" / "failed"
PASS "show idle" toggle present PASS no page errors
VERDICT: viewer smoke PASSED (all checks)
```

Grepping the bundle for the literal `day8.re_frame2_machines_viz.viewer.run` finds **0** occurrences — `:advanced` splits `goog.exportSymbol`'s string. That is why this is a *browser* check: `typeof window.day8.re_frame2_machines_viz.viewer.run === 'function'` is the assertion that means something, and a grep would have reported a false negative.

Two harness bugs were hit and fixed rather than explained away: `page.goto` to a hash-only difference is a same-document navigation, so the `^:export` entry never re-ran; and the first text assertions raced elkjs's async layout (nodes present, labels not yet). Neither was a product defect — the 4-second manual dump showed the full chart both times.

---

## rf2-vuylw — `DONOR_EVIDENCE_RE` recommendation: test **coupling**, not **ownership**

### The finding, verified

| file | donor arm | rowed before? | donor evidence before? |
|---|---|---|---|
| `examples/scripts/examples-asset-manifest.cjs` | 5th `EXAMPLE_ASSET_MANIFEST` entry, build `examples/realworld-resources-ui`, staging `default-avatar.svg` | no | **yes** — but only `re-frame.ui` inside one entry's prose `reason` string |
| `implementation/scripts/_examples-staging.test.cjs` | hard-codes that id in a five-build non-vacuity list (line 542) | no | **none** |

Both are `.cjs`, so `CENSUS_REQUIRE_RE` can never fire (it reads only `.clj/.cljs/.cljc/.edn`), and neither carries the coordinate. Measured directly against the gate's own compiled regexes.

### The recommendation

**Add `realworld-resources-ui` to the alternation, and restate what the alternation is for.**

The list enumerated ids *owned by the donor's own artefact* (`ui-g8`, `ui-bench`, `node-test-ui`, `check-ui-`, `run-ui-`, `test:ui`). On that reading an example's build id does not belong, and a pending row for the staging test is a stale row. But the regex's job — per its own docstring — is *"does this row's target still have ANY donor material in it?"*, and the honest test for a build id is **coupling**: does the build stop compiling when `implementation/ui/` goes? `examples/realworld-resources-ui` does. Its sources are `examples/real-apps/realworld_resources/ui_*`, and `ui_core.cljs` is authored entirely on `re-frame.ui`. That is exactly what `ui-g8` means in substance; the alternation now says so and admits ids from outside the donor's trees.

Spelled in full, deliberately: the sibling `examples/realworld-resources` is the Reagent arm and is **not** donor-coupled, so a shorter alternative would over-match.

### Evidence it is load-bearing

Removed the one alternative line, re-ran the gate, restored the file byte-identically (sha256 `f07c316a…` before and after — no `git checkout`, per the hazard that has bitten workers here):

```
rc WITHOUT the alternative: 1
DONOR-LEDGER-DRIFTED: …donor-inventory.md:423 claims
  `implementation/scripts/_examples-staging.test.cjs` is still pending,
  but no file it matches carries any donor material.
```

Exactly one row trips — which also **confirms the manifest row passes today only on that incidental prose mention**. That is the `run-ui-g13.cjs`-passed-by-accident shape from rf2-vfv8r, one directory over: reword the `reason` sentence and the row goes stale-red for a reason unrelated to the donor. One alternative durably fixes both files, which is why a two-file finding needs one regex change.

### Dispositions — evidenced against an already-rowed sibling

Both **REPLACE / F6**, on the `implementation/adapters/scripts/adapter-smoke-filter.cjs` precedent (same section, same shape: shared build wiring coupled by a build id the census cannot see).

- **Manifest → REPLACE.** Not DELETE: the manifest serves four other builds and must survive. Not MOVE: the donor realization is **not** carried across — Freehand's RealWorld arm re-declares its own entry against its own build. Identical wording to the sibling row, which reasons "the manifest still has to exist and it serves the adapters either way, but the substrate entry is re-declared against Freehand rather than carried across".
- **Staging test → REPLACE.** Takes its subject's disposition, as `_adapter-smoke-filter.test.cjs` and `_reagent-slim-smoke-policy.test.cjs` both do in the same section.

Neither breaks when the donor tree is deleted — the build simply stops compiling — which is why the ledger, not a red gate, is what has to remember them. The ledger's "assume the hole travels in families" narrative gains a fourth-pass paragraph recording this and the coupling-vs-ownership rule, so the next build id does not re-litigate it.

---

## Quality gates

Re-derived, not trusted. Every `rc` captured immediately into a worktree-local log and cross-checked against that log's own verdict line.

| gate | command | count | verdict line | rc |
|---|---|---|---|---|
| machines-viz JVM | `clojure -M:test` in `tools/machines-viz` | **632 tests / 2537 assertions** | `0 failures, 0 errors.` | **0** |
| machines-viz CLJS | `npm run test:tools-machines-viz` | **822 tests / 3230 assertions** | `0 failures, 0 errors.` | **0** |
| donor inventory | `python scripts/check_donor_inventory.py` | 224 rows / 150 pending / 74 done | silent-on-success | **0** |
| donor inventory (self-test) | `… --self-test` | — | `self-test: all cases passed.` | **0** |
| donor inventory (mutation control) | alternative removed | 1 defect | `DONOR-LEDGER-DRIFTED: …:423` | **1** (expected) |
| thrown-error messages | `python scripts/check_thrown_error_messages.py` | — | silent-on-success | **0** |
| thrown-error messages (self-test) | `… --self-test` | — | — | **0** |
| doc links + anchors | `python scripts/check_doc_slugs.py` | — | silent-on-success | **0** |
| README inventories / links | `check_readme_inventories.py`, `check_readme_links.py` | — | silent-on-success | **0**, **0** |
| freehand conformance index | `python scripts/check_freehand_conformance_index.py` | — | silent-on-success | **0** |
| keyword catalogue drift | `python scripts/check_keyword_catalogue_drift.py` | — | silent-on-success | **0** |
| clj-kondo (changed files) | `clj-kondo --lint …` | 6 files | `errors: 0, warnings: 0` | **0** |
| Splint | `clojure -M:splint --fail-on-errors ../tools/machines-viz` | 61 files | `97 style warnings` (all pre-existing, informational) | **0** |
| viewer release build | `npx shadow-cljs release machines-viz-viewer` | 183 files, 118 compiled | `0 warnings` | **0** |
| viewer browser smoke | `node _gates/smoke-viewer.cjs <share-url>` | 13 checks | `VERDICT: viewer smoke PASSED (all checks)` | **0** |
| simulated consumer (lib) | `compile sim-lib` + run | 125 files | all 8 entry points resolved | **0**, **0** |
| simulated consumer (page control) | `compile sim-page-control` | — | `namespace "…viewer" is not available` | **1** (expected) |

Baselines held exactly: JVM `632/2537` unchanged (the JVM lane does not carry the CLJS-only share suites); CLJS `821/3214 → 822/3230`, the delta being the one new `no-host-is-refused` deftest and its 16 assertions.

The CLJS test churn is wide but mechanical: 41 `share/encode-share-url` call sites moved to a test-local `encode` helper that supplies a host, and the export/DOM/viewer suites name a `test-host`. That churn *is* the change — every producer of a share-URL now names its viewer.

The one clj-kondo `info` in `share.cljs` (`Single argument to str already is a string`) is pre-existing: the same finding reports at line 642 on `HEAD~1` and line 671 after, in the decoder, untouched by this PR.

`mkdocs build --strict` is not installed locally; `check_doc_slugs.py` is the link/anchor validator `docs.yml` runs and it is green. The only staged-into-docs file this PR touches is `spec/conformance/freehand/donor-inventory.md`, which gains prose and two table rows and no links.

### Not run, and why

`test:script-policy` and the changed-surfaces router are untouched — no file under `implementation/scripts/`, `examples/scripts/`, or `implementation/adapters/scripts/` is modified by this PR; `_examples-staging.test.cjs` and `examples-asset-manifest.cjs` are *rowed*, not edited. The public-API manifest is unaffected: `spec/api-manifest.edn` does not cover `tools/machines-viz`, whose only appearance in the metadata sidecar is two prose comments in an exclusion set.
