### PR TITLE
spec/004,004B: the v/defhost head in props forwarding and in the node contract (rf2-33pts, rf2-pgrkm)

### DIFF
--- a/spec/004-Views.md
+++ b/spec/004-Views.md
@@ -1477,6 +1477,22 @@ Normatively, for both forms:
   Honouring one in a forwarded map would decide element identity from a value the
   compiler cannot see, so it is refused rather than silently honoured in one mode and
   dropped in the other.
+- **Both forms fold onto an element, and neither is legal at a `v/defhost` head.**
+  Their entire content is the attribute grammar — the refusals above, the slot
+  canonicalization [004B §Attribute names](004B-UI-Tree-and-Conversion.md#attribute-names)
+  applies to an alias of an accepted key, the `.class#id` sugar, the controlled door —
+  and a host prop is none of those. It is an exact unqualified keyword handed shallowly
+  to a foreign API ([§Three disjoint planes](#three-disjoint-planes)), so running one
+  through the element rule is wrong in both directions at once. It **admits** what the
+  host head refuses, because an alias of a slot-owning key is rewritten on the way
+  through: `:className` — the name a React library actually wants — arrives as `class`,
+  a prop the component does not read, and `"class"` walks past the exactness check that
+  would have caught it. And it **refuses** what the host head accepts, because
+  `:class-name`, a mixed-case `data-*` and `:key` name nothing on a foreign prop ABI
+  that the attribute table is entitled to judge. Forward to a host with an ordinary
+  map — `merge`, caller's remainder as the base and the props you own second — and the
+  host's own naming law then judges every key that arrives, which is the only law that
+  was ever true there.
 
 And for `v/spread-safe` alone:
 
@@ -1742,8 +1758,12 @@ Three of those slots are chosen against a way the node could lie.
 
 - **`:children` is the SSR PROJECTION and nothing else** — the declared
   fallback, or empty. It is the slot that folds to HTML, so it MUST carry only
-  what the server can honestly emit. It is retained when empty, like a fragment:
-  it is the node's discriminator.
+  what the server can honestly emit. It is retained when empty, like a fragment,
+  and for the fragment's reason: the serialiser folds a host by splicing that
+  slot, so a node without it is a map with nothing to emit and nothing to say so
+  ([004B §The SSR consumption boundary](004B-UI-Tree-and-Conversion.md#the-ssr-consumption-boundary)).
+  The variant, its discriminator and its place in the closed node set are 004B's
+  ([004B §The node schema](004B-UI-Tree-and-Conversion.md#the-node-schema--version-1)).
 - **The caller's trailing children are COUNTED, not walked.** They cross into
   the registered component's own React tree, and where that tree places them is
   React's business, so a server tree that showed them would invite an assertion

--- a/spec/004B-UI-Tree-and-Conversion.md
+++ b/spec/004B-UI-Tree-and-Conversion.md
@@ -122,8 +122,8 @@ in an emitter is indistinguishable from a bug:
 ## The node schema — version 1
 
 The tree is **plain, serialisable Clojure data** — plain maps and strings, no wrapper
-types, no metadata-carried contract (EDN print/read round-trips losslessly). Five node
-variants, a **closed set**:
+types, no metadata-carried contract (EDN print/read round-trips losslessly). The node
+variants are a **closed set**, and this table is their roster:
 
 | Variant | Shape | Required field | Optional fields |
 |---|---|---|---|
@@ -131,11 +131,23 @@ variants, a **closed set**:
 | **fragment** | map | `:children` | `:key` + reserved keys |
 | **view-boundary** | map | `:view-id` | `:props` `:children` `:key` + reserved keys |
 | **trusted-HTML** | map | `:html` | `:key` |
+| **host** | map | `:rf.ui/host` `:rf.ui/host-ssr` `:children` | `:props` `:rf.ui/host-children` `:rf.ui/host-map-props` `:key` |
 | **text** | **the host string itself** | — | — |
 
+The **host** variant is one `v/defhost` crossing. Its fields, and the reason each was
+chosen against a way the node could lie, are pinned by
+[004 §Structure and SSR](004-Views.md#structure-and-ssr) and are not restated here;
+what this contract owns is its place in the closed set, its place in the discrimination
+order, and what the projections and `N` answer for it. Its `:children` are the declared
+SSR projection — retained when empty, like a fragment's.
+
 **Discrimination is pinned, in order:** a string is a text node; a map with `:tag` is an
-element; else `:view-id` → view-boundary; else `:html` → trusted-HTML; else a map with
-`:children` → fragment. A map carrying more than one discriminating field, or none, is
+element; else `:view-id` → view-boundary; else `:html` → trusted-HTML; else
+`:rf.ui/host` → host; else a map with
+`:children` → fragment. The **primary** discriminators are the four a map may carry only
+one of — `:tag`, `:view-id`, `:html`, `:rf.ui/host`. `:children` is the fallthrough
+rather than a fifth, which is why an element, a view-boundary and a host all carry it
+without ambiguity. A map carrying two primaries, or no primary and no `:children`, is
 **malformed** — every consumer (the traversal helpers, the serialiser, the fingerprint
 fn) fails loud with the typed error `:rf.error/ui-tree-malformed`, and so does the walk
 that would otherwise build one. The **text variant is deliberately not a map**: text
@@ -328,11 +340,20 @@ representation.
 
 ### Reserved `:rf.ui/*` keys — the three roles (required gate, semantic, diagnostic)
 
-A closed v1 set of reserved-namespace keys. **Consumers MUST ignore *unknown*
-`:rf.ui/*` keys**, and **normalization removes every `:rf.ui/*` key from its output** —
-no reserved key survives into a semantic node or a fingerprint. But *absent from the
-output* is **not** *safe to strip from the input*: these keys fall into three roles,
-and only one is a droppable diagnostic.
+A closed v1 set of reserved-namespace keys that **decorate** a node. **Consumers MUST
+ignore *unknown* `:rf.ui/*` keys**, and **normalization removes every `:rf.ui/*` key
+from its output** — no reserved key survives into a semantic node or a fingerprint. But
+*absent from the output* is **not** *safe to strip from the input*: these keys fall into
+three roles, and only one is a droppable diagnostic.
+
+**The host variant's fields are outside this roster, and the word "decorate" is what
+puts them there.** `:rf.ui/host`, `:rf.ui/host-ssr`, `:rf.ui/host-children` and
+`:rf.ui/host-map-props` do not annotate a node — they *are* one, enumerated as a variant
+in §The node schema and meant by [004 §Structure and SSR](004-Views.md#structure-and-ssr).
+Neither rule above reaches them: a consumer that "ignored" `:rf.ui/host` would read a
+host as a fragment, which is the single wrong answer this namespace is able to produce,
+and `N` holds its removal step back until the splice has read them (§Semantic
+normalization `N`, steps 1–2).
 
 - **Semantic — consumers MUST honor.** Load-bearing **conversion input**: `N` and the
   serialiser READ it *during* conversion and only then drop the marker. Its absence
@@ -407,6 +428,12 @@ bumps the integer. Adding a new optional **diagnostic** `:rf.ui/*` key does **no
 conversion. Consumers seeing an unsupported version fail loud (§SSR boundary names the
 error).
 
+**One exception, recorded rather than hidden.** The **host** variant joined the roster
+after this document first pinned it, and did **not** bump the integer: it shipped under
+`:rf.ui/tree-version 1`, so bumping now would name a tree no emitter writes and fail
+every consumer against trees that are already correct. The bump rules govern a roster
+change made from here.
+
 ## Projections — how nodes are read
 
 Nodes are plain maps, so **field** reads (`(:tag node)`, `(:events node)`,
@@ -418,15 +445,27 @@ under their own keys.
 - **`(t/attrs node)`** — the merged projection:
   - element → `:attrs` merged with `:events` (collision-free by construction; event
     slots carry vectors/options-maps/opaque markers as data);
-  - view-boundary → `:props` (so attr-map selectors match views by prop values for
-    free, via the same `rf=` relation);
+  - view-boundary **and host** → `:props` (so attr-map selectors match views by prop
+    values for free, via the same `rf=` relation; on a host these are the authored
+    ordinary props, each filled callback position recorded as its opaque role marker);
   - fragment / trusted-HTML → `{}` (no attributes exist; total, not an error);
   - `nil` → `nil` (nil-punning threads through a missed `find`);
   - a string (text content) → typed error (text is not a node).
 - **`(t/text node)`** — concatenation of text descendants in document order,
-  descending through elements, fragments, and view boundaries; **trusted-HTML nodes
-  contribute nothing** (their content is unparsed markup, not text data — by design);
-  `nil` → `nil`.
+  descending through elements, fragments, view boundaries and hosts; **trusted-HTML
+  nodes contribute nothing** (their content is unparsed markup, not text data — by
+  design); `nil` → `nil`.
+
+**A host is a real arm, not a fragment that happens to have props, and the difference is
+the whole point of giving it one.** A host node carries `:children` and no `:tag`, so a
+consumer written to the roster *before* the host variant existed reaches the fragment
+arm and answers `{}` — a total, harmless-looking, wrong answer, delivered silently
+because the fragment arm is documented total rather than an error. `:rf.ui/presence` and
+`:rf.ui/boundary` are deliberately **not** in the same position: those genuinely are
+fragments carrying diagnostic metadata (§Reserved `:rf.ui/*` keys), so `{}` is their true
+answer and their metadata is an ordinary field read. What `t/text` descends into on a
+host is the **SSR projection** — the declared fallback, or nothing — never the registered
+React component's own text, which no structural consumer can see.
 
 Intent assertion, respelled to this contract:
 `(is (= [:cart/add 42] (:on-click (t/attrs (some #(when (= :button (:tag %)) %) (tree-seq map? :children tree))))))`.
@@ -442,9 +481,21 @@ and to the render fingerprint. Pinned, in order:
    The property-props marker is **semantic conversion input**, not a diagnostic: step 5
    consumes it (property-classified props are omitted from markup) and only *then* is the
    marker itself dropped. Stripping it *before* conversion is unsafe — it moves the
-   fingerprint boundary (§Reserved `:rf.ui/*` keys).
-2. **Splice** view-boundary nodes (children replace the node — HTML has no view
-   boundaries; dev `data-rf2-*` annotation is excluded by the same rule).
+   fingerprint boundary (§Reserved `:rf.ui/*` keys). A host node's `:rf.ui/host*` fields
+   are the same kind of exception for a stronger reason: they are the node's **variant**,
+   and step 2 reads `:rf.ui/host` to know it has one. Remove them first and a host is
+   indistinguishable from a fragment, so removal waits on the splice exactly as it waits
+   on the property-props read.
+2. **Splice** view-boundary **and host** nodes (children replace the node — HTML has
+   neither; dev `data-rf2-*` annotation is excluded by the same rule). A host's children
+   are its declared SSR projection, so splicing is not a normalization choice about
+   hosts — it is the *same* fold §The SSR consumption boundary performs, restated in
+   semantic space so the two cannot answer differently. The fields step 1 held back go
+   with the node: read here, then gone, and no `:rf.ui/*` key reaches a fingerprint
+   either way. `v/render-static` refuses a host outright
+   ([004 §Structure and SSR](004-Views.md#structure-and-ssr)) and `emit-ui-tree` does
+   not, so `N` cannot rule the variant out — it has to mean something here, and what it
+   means is the projection.
 3. **Splice** fragment nodes.
 4. **Drop** `:events` entirely and drop `:key` values (neither has HTML presence;
    *keyed order* survives as the child order itself).
@@ -647,7 +698,9 @@ shapes.
 - **Signature — the shipped seam.** `(re-frame.ssr/emit-ui-tree tree opts) → HTML
   string` — consumes a version-1 structural tree; applies the serialisation half of the
   conversion table (final names, boolean emission, property-only omission, escaping, void
-  handling); erases view boundaries (dev coord annotation policy stays 011-owned); writes
+  handling); erases view boundaries (dev coord annotation policy stays 011-owned) **and
+  hosts**, a host's `:children` being its declared SSR projection and therefore exactly
+  the markup it folds to — the fallback, or nothing for `:client-only`; writes
   trusted-HTML nodes verbatim. `opts` carries a single current option, `:doctype?`, which
   prefixes `<!DOCTYPE html>`; other keys are ignored (the `render-to-string` option set
   does not transfer to this seam). This is the **shipped, final contract** (final naming


### PR DESCRIPTION
Two spec gaps left by `v/defhost` shipping, both filed by workers who hit them. Spec-only — no verb, no host kind, no `:rf.error/*` id, no `spec/api-manifest.edn` touch.

## rf2-33pts — is `v/spread` legal at a `v/defhost` head?

**Found:** it is not, and it does not merely "work by accident for ordinary keywords" — it is wrong in **both directions at once**. Established by running the real path on the JVM, with a declared `(v/defhost date-picker … {:callbacks {:onChange :event} :children :none :ssr :client-only})` head and the forwarding map built inside the view body:

| remainder key | `v/spread` at the host head | plain `merge` at the host head |
|---|---|---|
| `:placeholder` | `:placeholder` | `:placeholder` |
| `:className` | **`:class`** — silently renamed | `:className` |
| `"class"` | **`:class`** — laundered past the exactness law | REFUSED (`:rf.error/view-bad-props`) |
| `:class-name` | **REFUSED** (`:rf.error/ui-tree-malformed`) | `:class-name` |

`node/spread-attrs` projects both maps through `canonical-slot-keys` → `conv/attr-key` → `rules/canonical-attr-key`, which rewrites **every** spelling projecting onto the `className` or `style` slot. At an element that is correct — those two own a slot. At a host head it defeats `descriptor/normalize-host-call`'s `inexact-host-prop-names` check, which runs *first* precisely so every later law can be enforced BY name — the same hole class the disjoint-plane guard was just closed against. And `:className` → `:class` is not a laundered spelling of one prop: it is a **different React prop**, the one a third-party component most commonly reads, renamed to one it does not. The other direction is `assert-forwardable-attrs!` applying the DOM attribute grammar, so `:class-name`, a mixed-case `data-*` and `:key` are refused — all three ordinary names on a foreign prop ABI, and `:key` is how a host crossing is keyed at a plain head.

**Changed:** one bullet under §Props forwarding's "Normatively, for both forms" — both forms fold onto an element, neither is legal at a `v/defhost` head, forward to a host with an ordinary map. `merge` is the whole mechanism, the same later-arg-wins shape, and it is strictly better here: it preserves `:className` and lets the host's own exactness law catch `"class"`.

Also corrected in §Structure and SSR: `:children` "is the node's discriminator" became false when `:rf.ui/host` landed. Left unfixed it would have contradicted 004B in the same PR.

**Not changed, deliberately:** `FH-PROPS-006` already reads "onto the element", which is exactly right under the new statement — no drift, no fixture churn.

## rf2-pgrkm — 004B's node roster has no host arm

**Found:** the owning spec's roster, discrimination order, reserved-key classification, projections and `N` all predate `v/defhost`. Verified against the shipped code and the shipped serialiser, not inferred:

- `re-frame.freehand.test/node-kind` discriminates `:tag` → `:view-id` → `:html` → `:rf.ui/host` → `:children`; `t/attrs` answers `:props` for `(:view-boundary :host)`; `t/text` descends a host's `:children`.
- `re-frame.ssr/emit-ui-tree` **erases** a host and splices `:children`: `:client-only` → `""`, a `[{:tag :div :children ["loading"]}]` fallback → `"<div>loading</div>"`, and dropping `:children` → `:rf.error/ui-tree-malformed`. That is why 004 retains the slot when empty, and it is the shipped behaviour the spec now states.

**Changed:** the **host** row in the node table; the host paragraph deferring its field meanings to 004 §Structure and SSR; `:rf.ui/host` in the pinned discrimination order plus the primary-vs-fallthrough precision (`:children` is not a fifth primary, which is what lets an element, a view-boundary and a host all carry it); a carve-out putting the four `:rf.ui/host*` fields outside the reserved-key roster; the `:rf.ui/tree-version` no-bump exception; the host arms on `t/attrs` and `t/text` with the presence/boundary contrast; `N` steps 1–2; and "**and hosts**" on the SSR seam's erase list.

**`N` was a decision, so here is the reasoning.** `v/render-static` refuses a host outright, but `emit-ui-tree` does not — so `N` cannot rule the variant out and has to mean something. It means the same thing the serialiser means: splice, because a host's children *are* its SSR projection. Ordering follows: step 1 holds the `:rf.ui/host*` fields back until step 2 has read the discriminator, exactly as it holds `:rf.ui/property-props` back until step 5 has consumed it. Read literally, today's step order strips the discriminator first and then splices the result as a fragment — the right answer by accident of ordering, which is the pattern this PR exists to remove.

## Duplication or claim, per edit

| Edit | Which went |
|---|---|
| 004 §Props forwarding, new bullet | Neither — a **new claim** on a stated gap, written to defer to §Three disjoint planes and 004B §Attribute names rather than restate either |
| 004 §Structure and SSR, `:children` | **The claim went** — "it is the node's discriminator" was false; replaced by the true reason and a pointer to 004B, not a second copy of the schema |
| 004B "Five node variants" → "this table is their roster" | **The duplication went** — a prose count of the table's own rows, which could only ever drift from it |
| 004B host row + host paragraph | **New claim**, written to avoid duplication: field meanings deferred to 004 §Structure and SSR by name |
| 004B discrimination order + primary/fallthrough | **New claim** (host in the order) plus a precision fix that the host row made necessary |
| 004B reserved-key carve-out | **The claim went** — "every `:rf.ui/*` key" and "MUST ignore unknown" were over-broad. Narrowed rather than given a fourth role, which would have changed the heading and broken the anchor `spec/004-Views.md` links to |
| 004B §Versioning no-bump exception | **New claim** — without it the bump rule reads as violated by this very PR |
| 004B §Projections host arms + "a real arm" | **New claim**; the presence/boundary contrast points at §Reserved keys rather than restating it |
| 004B `N` steps 1–2 | **New claim**, and it makes the SSR fold and `N` one rule instead of two |
| 004B SSR seam "and hosts" | **New claim**, placed where readers already look so `N` step 2 could point at it |

## Does `re-frame.ui.test` still inherit the same gap?

**Yes — unchanged by this PR, and that is correct.** `implementation/ui/**` was fenced; nothing in it moved. `re-frame.ui.test/node-kind` (`test.cljc:103-129`) still carries the four-way discriminator with no `:host` arm, and it is still safe for exactly the reason rf2-pgrkm recorded: `re-frame.ui` never emits a `:rf.ui/host` node, because the compiled tier refuses the crossing at **build** with `:rf.ui.compile/host-crossing-unsupported`. The day 004 §Compiled mode's "a compiled parent MAY cross the host when lowering supports the same laws" is cashed, a host node reaches ui.test's fragment arm and `t/attrs` answers `{}` silently — the exact rf2-c20nr failure.

What did change is the standing of that gap. Before this PR the `:host` arm existed only in one implementation, so a second consumer written to the contract would have been *correct* to omit it. Now 004B carries the variant in the closed set and in the pinned order, so omitting it is a contract violation a reviewer can name. Whoever lowers the crossing carries the arm across in the same PR. Filed as **rf2-h0azk** together with the two docstrings that still assert "the closed five-variant node set" (`ui/test.cljc`, `ssr/ui_tree.cljc`) — the ssr one is a docstring fix only, its behaviour being already right and now stated.

## Follow-ups filed (all on surfaces fenced this wave)

- **rf2-33bgx** (P2) — `docs/core/freehand/composition.md` teaches `v/spread` at a `v/defhost` head in five places, including a worked sketch against a real head. Its own next paragraph already contradicts it: "Host prop names pass exactly … there is no camelisation on this path" sits directly under a spread that rewrites `:className`. Every fenced block there is digest-pinned, so it is a two-file change.
- **rf2-n4by4** (P2) — the implementation arm. Nothing enforces the new 004 rule; the enforcement mechanism is a genuine ruling (mark the spread's result the way `carry-caller` marks a spread-safe caller map, or leave it to spec + guide), so it is written up rather than guessed. No new verb or id either way.
- **rf2-h0azk** (P3) — the two "five-variant" docstrings, and the ui.test `:host` arm obligation.
- **rf2-je886** (P3) — `spec/Conventions.md`'s `:rf.ui/*` member roster omits all four host keys and `:rf.ui/top-layer`, and restates 004B's three-role rule which 004B now carves the host fields out of. Hot-zone file, so sequenced rather than bundled here.

## Quality gates

Run foreground to completion in the worker worktree; `rc` captured immediately and cross-checked against each log's own verdict line.

| Gate | Result | rc |
|---|---|---|
| `python -m mkdocs build --strict` | built in 34.11s; no WARNING/ERROR, no anchor complaint against either edited file | 0 |
| `python scripts/check_doc_slugs.py --self-test --verbose` | all 58 self-tests passed | 0 |
| `python scripts/check_doc_slugs.py --verbose` | 604 markdown files scanned, **no broken links** | 0 |
| freehand JVM `clojure -M:test` | **1164 tests / 7736 assertions, 0 failures, 0 errors** | 0 |
| core JVM `clojure -M:test` | **2126 tests / 10492 assertions, 0 failures, 0 errors** | 0 |
| `check_ep_status_sync.py --verbose` | clean | 0 |
| `check_runtime_subsystem_grading.py --verbose` | clean | 0 |
| `check_inject_cofx_residue.py --verbose` | clean | 0 |
| `check_failure_corpus_residue.py --verbose` | clean | 0 |
| `check_retired_composition_vocab.py --verbose` | clean | 0 |
| `check_retired_image_keys.py --verbose` | clean | 0 |

Counts re-derived, not trusted: freehand matched the briefed 1164/7736; **core came out 2126/10492 against a briefed 2125/10484** — pre-existing drift on `main`, not this diff, which touches no `.clj*` file.

`spec/api-manifest.edn` is untouched — no public verb and no `:rf.error/*` id was added or changed, so the five-to-seven-file regenerate lane is not entered and `:var-count` stays 575.
