### PR TITLE
fix(resources): read continuations honour the owner's projection-relative declaration (rf2-ko5lm); rule the sample gate stays in its tree (rf2-h5fkc)

### DIFF
--- a/implementation/epoch/test/re_frame/epoch_egress_resource_trace_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_egress_resource_trace_test.clj
@@ -2241,7 +2241,7 @@
 ;; by construction — the same reason rf2-1zc33 gave `:scope` the family's grain
 ;; and rf2-xx4ty gave `:value` / `:params` the owner's.
 ;;
-;; RESIDUE, filed not fixed (rf2-swpd0): a `:params`-rooted declaration on a
+;; RESIDUE, filed not fixed (rf2-dl7bz): a `:params`-rooted declaration on a
 ;; `:serialize` owner still rides raw inside the sibling `:resource/key`, whose
 ;; trace projection is coarse-only by documented decision
 ;; (`ssr/project-scoped-key` — "the trace / tool egress callers pass
@@ -2403,7 +2403,7 @@
             The sibling `:resource/key` still carries the same params raw — a
             `:serialize` owner's key rides verbatim at trace egress by
             documented decision (`ssr/project-scoped-key`). That residue is
-            filed as rf2-swpd0 and is a different carrier on every family row;
+            filed as rf2-dl7bz and is a different carrier on every family row;
             it is deliberately NOT asserted here, so this test does not have to
             change when that bead lands."
     (let [params    {:account "acct-9911" :slug plain-slug}

--- a/implementation/epoch/test/re_frame/epoch_egress_resource_trace_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_egress_resource_trace_test.clj
@@ -96,6 +96,30 @@
                   {:scope         :rf.scope/global
                    :params-schema [:map [:slug :string]]}
                   (fn [_ _] {:request {:method :get :url "/a"}}))
+                ;; rf2-ko5lm — a resource that makes NO COARSE claim and
+                ;; declares PROJECTION-RELATIVE slots instead.
+                ;; `whole-entry-disposition` of this spec is `:serialize`, so
+                ;; `row-owner-redacts?` is FALSE and the coarse read-reply arm
+                ;; (rf2-xx4ty) never fires on it — which is exactly why its
+                ;; continuation reply rode verbatim. `:email` is declared
+                ;; sensitive, `:avatar` declared large, and `:display-name`
+                ;; declared as NEITHER, so one body exercises redact, elide,
+                ;; and the untouched sibling that proves the projection is
+                ;; per-PATH rather than per-slot.
+                (rf/reg-resource :declared/profile
+                  {:scope         :rf.scope/global
+                   :sensitive     [[:data :email]]
+                   :large         [[:data :avatar]]
+                   :params-schema [:map [:slug :string]]}
+                  (fn [_ _] {:request {:method :get :url "/c"}}))
+                ;; rf2-ko5lm — the PARAMS axis of the same declaration surface,
+                ;; on its own owner so the data-axis fixture above stays a
+                ;; three-outcome body and nothing else.
+                (rf/reg-resource :declared/params-owner
+                  {:scope         :rf.scope/global
+                   :sensitive     [[:params :account]]
+                   :params-schema [:map [:account :string] [:slug :string]]}
+                  (fn [_ _] {:request {:method :get :url "/d"}}))
                 ;; a PLAIN resource under a CONCRETE (non-global) scope — the
                 ;; over-redaction control for the FREE `:scope` tag (rf2-1zc33).
                 ;; Its scoped KEY must keep scope AND params verbatim, which is
@@ -2170,3 +2194,296 @@
           (is (true? (:sensitive? (:tags reply-row))))))
       (is (= [] (secret-leak-paths projected))
           "and nothing raw survives anywhere in the record"))))
+
+;; ===========================================================================
+;; (rf2-ko5lm) the OTHER half of the read reply: the owner that makes NO COARSE
+;; CLAIM and declares PROJECTION-RELATIVE paths instead.
+;; ===========================================================================
+;;
+;; §(rf2-xx4ty) above reads the reply's owner through `row-owner-redacts?` —
+;; `whole-entry-disposition`, the COARSE root-prop `:sensitive?` / `:large?`
+;; claim. That is the right grain for tokenizing a WHOLE slot, and it is the
+;; only claim `:derived/profile` makes. But it is not the only claim a resource
+;; CAN make, and it is not the common one:
+;;
+;;   (rf/reg-resource :declared/profile
+;;     {:sensitive [[:data :email]] :large [[:data :avatar]]}
+;;     …)
+;;
+;; declares no coarse prop at all, so `whole-entry-disposition` is `:serialize`,
+;; `row-owner-redacts?` is false, and the reply arm never fires. The DECODED
+;; RESPONSE BODY carrying that declared `:email` rode `:rf.fx/args` and
+;; `:rf.event/fx` VERBATIM — while the very same bytes, landed in the durable
+;; entry one commit earlier, redact off-box because `reconcile-registry` lowered
+;; `[:data :email]` to `[:rf.runtime/resources :entries <key-id> :data :email]`
+;; and the epoch walk reads that registry. One value, two carriers, one rule
+;; applied: the rf2-irwsq shape again, this time between the DURABLE entry and
+;; the CONTINUATION echo of it.
+;;
+;; MUTATIONS DO NOT HAVE THIS HOLE, and the reason names the repair. Both
+;; mutation settle sites wrap their reply in
+;; `classification/redact-continuation-reply`, which derives the paths from the
+;; mutation spec's own projection-relative declaration and substitutes them in
+;; the SAME construction step (rf2-825mzj). Reads had no counterpart. The read
+;; reply's carrier shape is the mutation reply's carrier shape — `:value` beside
+;; `:params` beside `:scope` — so the counterpart is that same function, read at
+;; the EGRESS projector instead of at the source (the read half must not redact
+;; at source: the app's own continuation handler is entitled to the decoded
+;; body, and `:include-sensitive?` must still show it).
+;;
+;; THE GRAIN, since taking the wrong one is how this family keeps regressing.
+;; This arm is DECLARATION-conditional: it fires on the paths the owner
+;; declared, and on nothing else. Not unconditional (an owner that declares
+;; nothing rides verbatim — the plain-owner control below), and not
+;; coarse-owner-conditional (that is precisely the read that misses a
+;; `:serialize` owner's declaration). It is the grain of the declaration itself,
+;; which is what makes the durable carrier and the continuation carrier agree
+;; by construction — the same reason rf2-1zc33 gave `:scope` the family's grain
+;; and rf2-xx4ty gave `:value` / `:params` the owner's.
+;;
+;; RESIDUE, filed not fixed (rf2-swpd0): a `:params`-rooted declaration on a
+;; `:serialize` owner still rides raw inside the sibling `:resource/key`, whose
+;; trace projection is coarse-only by documented decision
+;; (`ssr/project-scoped-key` — "the trace / tool egress callers pass
+;; `:serialize` through verbatim"). This section closes the reply's copy of
+;; those params; the key's copy is a different carrier on every family row and
+;; is its own bead.
+
+(def ^:private declared-reply-params
+  "The canonical params of the declared-owner read. Deliberately PLAIN:
+  `:declared/profile` declares nothing under `:params`, and this section's
+  acceptance scan is whole-record, so a secret here would be caught in the
+  sibling `:resource/key` (see the RESIDUE note above) and prove nothing about
+  the reply slot the section owns. The params axis gets its own deterministic
+  probe below, with its own marker."
+  {:slug plain-slug})
+
+(def ^:private declared-reply-value
+  "The DECODED RESPONSE BODY of the declared-owner read. Three fields, three
+  outcomes: `:email` is declared `:sensitive` and must redact to the sentinel,
+  `:avatar` is declared `:large` and must become the size marker, and
+  `:display-name` is declared as NEITHER and must ride verbatim — which is what
+  proves the projection is per-PATH and not a whole-slot tokenization wearing a
+  declaration as its trigger."
+  {:email        (str secret "@example.com")
+   :avatar       "0123456789abcdef"
+   :display-name "Ada"})
+
+(defn- drive-declared-reply-to-read!
+  "The `drive-reply-to-read!` of §(rf2-xx4ty), against the DECLARED-slot owner
+  instead of the coarse `:sensitive?` one. Drives a REAL
+  `[:rf.resource/ensure … :reply-to …]`, replays the terminal reply through the
+  runtime's own internal reply event, then drives a SECOND ensure that finds the
+  entry fresh — so one call produces BOTH continuation paths (the async accepted
+  fan-out, `:cache-hit? false`, and the fresh-skip immediate dispatch,
+  `:cache-hit? true`).
+
+  No app-db classification is needed here: `:declared/profile`'s scope is
+  `:rf.scope/global`, so nothing about this read reaches the app-db axis and any
+  surviving copy of the secret came off a trace carrier — the axis this section
+  owns. `fx/reg-fx` (the plain fn, not the macro) for the reason
+  `drive-real-cascade!` documents."
+  []
+  (rf/configure! {:epoch-history {:trace-events-keep 80}})
+  (let [captured (atom nil)]
+    (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! captured args) nil))
+    (rf/reg-event :app/read-loaded (fn [_ _ev] {}))
+    (rf/dispatch-sync [:rf.resource/ensure
+                       {:resource :declared/profile :params declared-reply-params
+                        :owner    real-owner :reply-to read-reply-target}]
+                      {:frame :test/rt})
+    (rf/dispatch-sync (conj (:on-success @captured) {:status :ok :value declared-reply-value})
+                      {:frame :test/rt})
+    (rf/dispatch-sync [:rf.resource/ensure
+                       {:resource :declared/profile :params declared-reply-params
+                        :owner    [:app :reader 2] :reply-to read-reply-target}]
+                      {:frame :test/rt})
+    (rf/epoch-history :test/rt)))
+
+;; ---------------------------------------------------------------------------
+;; (1) THE ACCEPTANCE ARM — a REAL reply-to read, both continuation paths
+;; ---------------------------------------------------------------------------
+
+(deftest real-declared-reply-to-read-leaks-no-declared-slot-into-fx-carriers
+  (testing "rf2-ko5lm — `projected-record` over the records a REAL
+            `[:rf.resource/ensure … :reply-to …]` settles for an owner whose
+            ONLY claim is a projection-relative declaration must carry the
+            declared body slot at ZERO paths, on BOTH continuation paths.
+            Before the repair each carried it at two: `:value :email` under
+            `:rf.fx/args` and again under `:rf.event/fx`."
+    (let [records (drive-declared-reply-to-read!)]
+      (doseq [[label cache-hit?] [["async settle" false] ["fresh-skip cache hit" true]]]
+        (testing label
+          (let [raw       (record-carrying-reply records cache-hit?)
+                projected (epoch/projected-record raw)]
+
+            (testing "FIXTURE — the producer really put a decoded body on the fx
+                      carriers, and the owner really makes no coarse claim"
+              (is (some? raw) "the continuation reached an fx carrier at all")
+              (is (seq (carrier-replies raw)) "and the reply map is findable on it")
+              (is (every? #(= declared-reply-value (:value %)) (carrier-replies raw))
+                  "every carrier's reply carries the RAW decoded body")
+              (is (seq (secret-leak-paths raw))
+                  "the unprojected record leaks — the projector's input is the
+                   runtime's own output, not an invented tag map"))
+
+            (testing "ACCEPTANCE — nothing raw survives anywhere in the projected
+                      record"
+              (is (= [] (secret-leak-paths projected))
+                  "every leaking path is named here; before the repair this
+                   printed the [:trace-events n :tags :rf.fx/args 1 :value :email]
+                   shape, once per carrier"))
+
+            (testing "and the projection is PER-PATH — the declared slots move,
+                      their undeclared sibling does not"
+              (doseq [r (carrier-replies projected)]
+                (is (= :rf/redacted (:email (:value r)))
+                    "the `:sensitive`-declared slot carries the sentinel")
+                (is (elision/marker? (:avatar (:value r)))
+                    "the `:large`-declared slot carries the size marker")
+                (is (= "Ada" (:display-name (:value r)))
+                    "and the slot the owner declared NEITHER axis for rides
+                     verbatim — the whole point of a path declaration")))
+
+            (testing "the whole reply still reads as a reply"
+              (let [r (first (carrier-replies projected))]
+                (is (= :declared/profile (:resource r))
+                    "the resource id rides verbatim")
+                (is (= cache-hit? (:cache-hit? r))
+                    "and the cache-hit disposition")
+                (is (= :ok (:status r)) "and the status")
+                (is (= declared-reply-params (:params r))
+                    "and the params, which this owner declared nothing under")
+                (is (= :rf.scope/global (:scope r))
+                    "and `:rf.scope/global` is untouched — a scalar scope is a
+                     structural fact, not a payload")
+                (is (= [:rf.scope/global :declared/profile declared-reply-params]
+                       (:resource/key r))
+                    "and the whole scoped key, since a `:serialize` owner's key
+                     rides verbatim")))))))))
+
+;; ---------------------------------------------------------------------------
+;; (2) the same shape assembled — deterministic, and it names the paths
+;; ---------------------------------------------------------------------------
+
+(deftest fx-carrier-declared-reply-slots-redact-on-both-carriers
+  (testing "rf2-ko5lm — the projector, over the exact reply the runtime builds.
+            One declared slot per carrier, both redacted; and the foreign
+            `:value` on the same effect vector rides untouched, because the
+            resource family speaks only for what it planted."
+    (let [k1        (sk :rf.scope/global :declared/profile declared-reply-params)
+          reply     (read-reply k1 :rf.scope/global declared-reply-value)
+          projected (epoch/projected-record (reply-carrier-record reply))
+          replies   (carrier-replies projected)
+          [handled do-fx] (:trace-events projected)]
+      (is (= 2 (count replies))
+          "one reply per carrier — the two the bead named")
+      (is (every? #(and (= :rf/redacted (:email (:value %)))
+                        (elision/marker? (:avatar (:value %)))
+                        (= "Ada" (:display-name (:value %))))
+                  replies)
+          "each carrier redacts, elides, and rides the three slots identically")
+      (is (= [] (secret-leak-paths projected))
+          "and nothing raw survives anywhere in the record")
+      (testing "the FOREIGN :value on the same effect vector is untouched"
+        (is (= [:rf.resource/commit-generation {:value 1}]
+               (first (:rf.event/fx (:tags do-fx))))
+            "a map with a :value and no reply marker is nobody's business here")
+        (is (= :app/read-loaded (first (:rf.fx/args (:tags handled))))
+            "as is the continuation TARGET — a tool still reads which event ran")
+        (is (true? (:sensitive? (:tags handled)))
+            "but the row IS stamped :sensitive?")))))
+
+(deftest fx-carrier-declared-reply-params-redact-through-the-same-declaration
+  (testing "rf2-ko5lm — the PARAMS axis of the same declaration surface. A
+            `:params`-rooted declaration redacts the reply's `:params` slot
+            through the identical `carrier-decl-paths` re-rooting the mutation
+            reply uses, and leaves its undeclared sibling alone.
+
+            The sibling `:resource/key` still carries the same params raw — a
+            `:serialize` owner's key rides verbatim at trace egress by
+            documented decision (`ssr/project-scoped-key`). That residue is
+            filed as rf2-swpd0 and is a different carrier on every family row;
+            it is deliberately NOT asserted here, so this test does not have to
+            change when that bead lands."
+    (let [params    {:account "acct-9911" :slug plain-slug}
+          k1        (sk :rf.scope/global :declared/params-owner params)
+          reply     (read-reply k1 :rf.scope/global {:ok true})
+          projected (epoch/projected-record (reply-carrier-record reply))
+          r         (first (carrier-replies projected))]
+      (is (= :rf/redacted (:account (:params r)))
+          "the `[:params :account]` declaration reaches the reply's :params")
+      (is (= plain-slug (:slug (:params r)))
+          "and its undeclared sibling rides verbatim")
+      (is (= {:ok true} (:value r))
+          "the body is untouched — this owner declares nothing under :data"))))
+
+;; ---------------------------------------------------------------------------
+;; (3) THE TWO-SIDED CONTROL — over-redaction must fail as loudly as leaking
+;; ---------------------------------------------------------------------------
+
+(deftest fx-carrier-keeps-an-undeclared-owners-reply-byte-identical
+  (testing "rf2-ko5lm guard — an owner that makes NEITHER claim (no coarse
+            `:sensitive?`, no projection-relative declaration) must ride its
+            continuation reply BYTE-IDENTICAL through both carriers and must not
+            stamp the row sensitive. This is the side that proves the arm reads
+            the DECLARATION rather than the reply's shape: the same `:value` and
+            `:params` slots that redact for `:declared/profile` are fully
+            readable here."
+    (let [k1        (sk :rf.scope/global :plain/article {:slug plain-slug})
+          reply     (read-reply k1 :rf.scope/global declared-reply-value)
+          record    (reply-carrier-record reply)
+          projected (epoch/projected-record record)
+          [handled do-fx] (:trace-events projected)]
+      (is (= (conj read-reply-target reply) (:rf.fx/args (:tags handled)))
+          "the whole dispatched event vector rides verbatim — reply :value,
+           :params, :scope and scoped key included")
+      (is (= (:rf.event/fx (:tags (second (:trace-events record))))
+             (:rf.event/fx (:tags do-fx)))
+          "and so does the whole effect vector on the other carrier")
+      (is (not (:sensitive? (:tags handled)))
+          "an undeclared-owner reply row is NOT stamped sensitive")
+      (is (not (:sensitive? (:tags do-fx)))
+          "on either carrier"))))
+
+(deftest fx-carrier-declared-arm-leaves-the-fx-familys-own-value-verbatim
+  (testing "rf2-ko5lm guard — the other half of the over-redaction control. A
+            map carrying `:value` / `:params` WITHOUT the canonical reply marker
+            is not a reply, whatever owner its neighbours name, so a declaration
+            can never reach it. The app's own managed-HTTP args and the
+            runtime's generation counter are the two shapes that have caught
+            every name-only arm in this family."
+    (let [k1        (sk :rf.scope/global :declared/profile declared-reply-params)
+          unmarked  {:resource/key k1 :value declared-reply-value}
+          record    (record-with
+                      [(event :rf.fx/handled
+                              {:rf.frame/id :test/rt :frame :test/rt
+                               :rf.fx/id :app/custom :rf.fx/args unmarked})])
+          projected (epoch/projected-record record)
+          tags      (:tags (first (:trace-events projected)))]
+      (is (= declared-reply-value (:value (:rf.fx/args tags)))
+          "no marker, no reply, no declaration — the map rides byte-for-byte")
+      (is (not (:sensitive? tags))
+          "and the row is NOT stamped :sensitive?"))))
+
+;; ---------------------------------------------------------------------------
+;; (4) the trusted-local boundary — the redaction is the off-box DEFAULT
+;; ---------------------------------------------------------------------------
+
+(deftest trusted-local-include-sensitive-keeps-raw-declared-reply
+  (testing "rf2-ko5lm — the trusted-local `:include-sensitive?` opt-in keeps the
+            raw declared slots (the local-raw boundary — the redaction is the
+            off-box default, not a strip). Load-bearing for the same reason the
+            coarse arm's opt-in is: a `:reply-to` continuation is how a workflow
+            reads a resource, and a local tool that could not see the declared
+            field could not debug the workflow."
+    (let [k1        (sk :rf.scope/global :declared/profile declared-reply-params)
+          reply     (read-reply k1 :rf.scope/global declared-reply-value)
+          projected (epoch/projected-record (reply-carrier-record reply)
+                                            {:include-sensitive? true})]
+      (is (= [declared-reply-value declared-reply-value]
+             (mapv :value (carrier-replies projected)))
+          "every carrier's raw :value rides with :include-sensitive?")
+      (is (= (conj read-reply-target reply)
+             (:rf.fx/args (:tags (first (:trace-events projected)))))
+          "and so does the rest of the event vector it sits in"))))

--- a/implementation/resources/src/re_frame/resources/classification.cljc
+++ b/implementation/resources/src/re_frame/resources/classification.cljc
@@ -254,15 +254,30 @@
 
 (defn redact-continuation-reply
   "Redact the owner-declared `:sensitive` / `:large` param + scope subpaths of a
-  mutation continuation REPLY map, deriving the paths from the mutation `spec`'s
+  continuation REPLY map, deriving the paths from the owner `spec`'s
   projection-relative declaration (`carrier-decl-paths`). The reply carries
   `:params` + `:scope` as siblings and the decoded result under `:value`, so a
   `:params`-rooted decl `[:password]` redacts reply `[:params :password]`, a
   `:scope`-rooted decl redacts reply `[:scope …]`, and a `:data`-rooted decl
-  redacts the reply's `:value` (the mutation-result projection). Sensitive wins
+  redacts the reply's `:value` (the result projection). Sensitive wins
   over large at a shared path (the shared elision walker's ordering). A `spec`
   that declares neither axis — or a nil spec (unregistered owner) — rides the
-  reply UNCHANGED. Pure / value-independent."
+  reply UNCHANGED. Pure / value-independent.
+
+  BOTH continuation families use this, at DIFFERENT boundaries, and the
+  difference is deliberate:
+
+    - MUTATIONS call it at the SOURCE (`mutation_events`, rf2-825mzj). A
+      mutation's completion echo is redacted before it reaches any carrier;
+      a coarse `:sensitive?` root prop is not part of `reg-mutation`'s
+      declaration surface at all, so this is the whole of the mutation reply's
+      classification.
+    - READS call it at OFF-BOX EGRESS
+      (`trace_egress/redact-reply-declarations`, rf2-ko5lm), and must not call
+      it at the source: the app's own `:reply-to` handler is entitled to the
+      decoded body and the trusted-local `:include-sensitive?` opt-in must still
+      show it. There it composes with the coarse `whole-entry-disposition` arm,
+      which reads the root prop a read owner CAN declare."
   [reply spec]
   (let [sens  (carrier-decl-paths spec :sensitive :value)
         large (carrier-decl-paths spec :large :value)]

--- a/implementation/resources/src/re_frame/resources/trace_egress.cljc
+++ b/implementation/resources/src/re_frame/resources/trace_egress.cljc
@@ -529,7 +529,21 @@
   fail-closed arm of its own: a nil spec makes `project-trace-scoped-key`'s
   nil-spec branch redact, so `row-owner-redacts?` is already true and the
   caller has tokenized the whole payload before reaching this. Reference-
-  preserving when the spec declares neither axis. Pure."
+  preserving when the spec declares neither axis. Pure.
+
+  ## Two residues, filed rather than fixed
+
+    - rf2-dl7bz — a `:params`-rooted declaration also names bytes that ride
+      the SIBLING `:resource/key`, and a `:serialize` owner's key rides
+      verbatim at trace egress by documented decision
+      (`ssr/project-scoped-key`). This closes the reply's copy; the key's copy
+      is the family's universal carrier and is its own ruling.
+    - rf2-zaopo — `redact-with-paths` matches paths EXACTLY, so on an INFINITE
+      feed a `[:data :email]` decl does not reach the merged-items vector
+      `infinite-reply-value` delivers under `:value` (`[:value <i> :email]`).
+      The durable side forks index-free (`project-entry-data`); the carrier
+      walker does not, and teaching it to is a core-primitive change with four
+      callers."
   [reply]
   (let [rid  (second (:resource/key reply))
         spec (when (keyword? rid) (registry/resource-meta rid))]

--- a/implementation/resources/src/re_frame/resources/trace_egress.cljc
+++ b/implementation/resources/src/re_frame/resources/trace_egress.cljc
@@ -72,7 +72,8 @@
   opt-in lifts it at the epoch consumer (the `local-raw` boundary — the same
   switch the app-db / HTTP-body / scope-resolved redactions honour).
 
-  ## The family's keys also ride FOREIGN rows (rf2-1kiuj, rf2-425mm, rf2-xx4ty)
+  ## The family's keys also ride FOREIGN rows (rf2-1kiuj, rf2-425mm, rf2-xx4ty,
+  ## rf2-ko5lm)
 
   Everything above is routed by the epoch tool-pair on the row's OPERATION
   namespace. But an `ensure` lowers into EFFECTS, and those effects address the
@@ -87,8 +88,12 @@
   of one scope agree the way the two carriers of one key already did; and, since
   rf2-xx4ty, the `:value` + `:params` a READ COMPLETION CONTINUATION reply
   carries beside its `:resource/key`, tokenized through that key's OWNER exactly
-  as the load-more cursor is through its row's."
-  (:require [re-frame.resources.registry :as registry]
+  as the load-more cursor is through its row's; and, since rf2-ko5lm, that same
+  reply's owner-DECLARED projection-relative slots, which the coarse owner read
+  is blind to, substituted through the same `redact-continuation-reply` the
+  mutation reply uses at its source."
+  (:require [re-frame.resources.classification :as classification]
+            [re-frame.resources.registry :as registry]
             [re-frame.resources.reply :as resources-reply]
             [re-frame.resources.ssr :as ssr]))
 
@@ -475,6 +480,63 @@
   [m]
   (= resources-reply/work-kind-resource (:rf.reply/work-kind m)))
 
+(defn- redact-reply-declarations
+  "The READ-CONTINUATION analogue of the mutation's source-side
+  `classification/redact-continuation-reply` (rf2-ko5lm) — literally that
+  function, reached at the egress projector instead of at the source.
+
+  `row-owner-redacts?` above reads the COARSE root-prop claim
+  (`whole-entry-disposition`). That is the whole of a `:sensitive?` owner's
+  declaration and the right grain for tokenizing a WHOLE reply slot, but it is
+  not the only claim a resource can make. A spec that declares
+  `{:sensitive [[:data :email]]}` and no coarse prop classifies `:serialize`,
+  so the coarse arm never fires — and the decoded body carrying that declared
+  slot rode the fx carriers VERBATIM, while the very same bytes, landed in the
+  durable entry, redact off-box because `reconcile-registry` lowered the
+  declaration to the entry's absolute runtime path and the epoch walk reads
+  that registry. One value, two carriers, one rule applied: the rf2-irwsq shape
+  between the durable entry and the continuation echo of it.
+
+  The mutation half has never had this hole — both settle sites wrap their
+  reply in `redact-continuation-reply`, which derives the paths from the spec's
+  own projection-relative declaration (rf2-825mzj). The READ reply's carrier
+  shape IS the mutation reply's carrier shape — `:value` beside `:params`
+  beside `:scope` — so the counterpart is that same function over the read
+  owner's spec: a `:data`-rooted / bare decl redacts the reply's `:value`, a
+  `:params`-rooted decl its `:params`, a `:scope`-rooted decl its `:scope`.
+  Never a second classification language, and nothing new to keep in step.
+
+  ## Grain: DECLARATION-conditional
+
+  This arm fires on the paths the owner DECLARED and on nothing else — not
+  unconditionally (an owner that declares nothing rides verbatim) and not
+  coarse-owner-conditionally (that read is exactly what misses a `:serialize`
+  owner's declaration). The declaration is the thing whose two carriers must
+  agree, so its own grain is what makes them agree: the durable entry redacts
+  `[:data :email]` and so now does the reply's `:value`. It COMPOSES with the
+  coarse arm rather than replacing it — the caller applies this only when
+  `row-owner-redacts?` is false, so a coarse owner still tokenizes the whole
+  slot and the digests that arm produces are untouched.
+
+  ## Why at egress and not at the source, where the mutation does it
+
+  The coarse `:sensitive?` claim governs OFF-BOX egress, not in-process
+  delivery: the app's own `:reply-to` handler is entitled to the decoded body,
+  and the trusted-local `:include-sensitive?` opt-in must still show it. A
+  source-side redaction would take both away.
+
+  A reply naming an UNREGISTERED owner rides unchanged here and needs no
+  fail-closed arm of its own: a nil spec makes `project-trace-scoped-key`'s
+  nil-spec branch redact, so `row-owner-redacts?` is already true and the
+  caller has tokenized the whole payload before reaching this. Reference-
+  preserving when the spec declares neither axis. Pure."
+  [reply]
+  (let [rid  (second (:resource/key reply))
+        spec (when (keyword? rid) (registry/resource-meta rid))]
+    (if spec
+      (classification/redact-continuation-reply reply spec)
+      reply)))
+
 (defn- carrier-family-value?
   "Whether a value sitting in a FOREIGN carrier is a resource scoped key the
   family may speak for. Scoped-key SHAPE is necessary and not sufficient here,
@@ -679,7 +741,21 @@
   `:sensitive?` claim governs OFF-BOX egress, not in-process delivery — the
   app's own continuation handler is entitled to the decoded body, and the
   trusted-local `:include-sensitive?` opt-in must still show it. So the read
-  half belongs exactly here, at the egress projector. Pure."
+  half belongs exactly here, at the egress projector.
+
+  ## …AND the owner's DECLARED paths, when it makes no coarse claim (rf2-ko5lm)
+
+  The owner read above is `whole-entry-disposition` — the COARSE root prop. A
+  spec that declares `{:sensitive [[:data :email]]}` and no coarse prop
+  classifies `:serialize`, so that read says nothing and the reply rode
+  verbatim — while the same bytes in the durable entry redact, because the
+  declaration was lowered into the frame's elision registry and the epoch walk
+  reads it. `redact-reply-declarations` closes that half by applying the
+  mutation's own `classification/redact-continuation-reply` over the read
+  owner's spec, and the two arms compose by grain rather than overlap: coarse
+  claim ⇒ the whole `:value` / `:params` tokenize; declaration only ⇒ the
+  declared paths substitute in place and their undeclared siblings ride;
+  neither ⇒ the reply is byte-identical. Pure."
   [v frame-id named?]
   (cond
     (redacted-token? v) [v true]
@@ -694,6 +770,27 @@
           proj     (fn [x named?]
                      (let [[pv s] (project-embedded-keys x frame-id named?)]
                        (note! s pv)))
+          ;; rf2-xx4ty — a read continuation reply's `:value` / `:params`, read
+          ;; through the owner its own `:resource/key` names (ONCE per map,
+          ;; exactly as `project-tags*` reads it once per row for the cursor).
+          ;; Gated on the canonical reply MARKER (audit #7059), not on the mere
+          ;; presence of a sibling key.
+          owner-redacts? (and (map? v)
+                              (resource-reply? v)
+                              (row-owner-redacts? v frame-id))
+          ;; rf2-ko5lm — …and, when that COARSE read says nothing (a
+          ;; `:serialize` owner, which is what a spec declaring only
+          ;; projection-relative paths classifies as), the owner's DECLARED
+          ;; paths, substituted through the mutation reply's own
+          ;; `redact-continuation-reply`. Applied to the whole reply BEFORE the
+          ;; walk, so the walk descends the already-substituted map and the
+          ;; `:rf/redacted` / size-marker sentinels ride out as the scalars they
+          ;; are. Reference-preserving — and stamp-precise: a declaration that
+          ;; matched nothing in THIS reply leaves the row unstamped.
+          v        (if (and (map? v) (not owner-redacts?) (resource-reply? v))
+                     (let [v' (redact-reply-declarations v)]
+                       (if (= v' v) v (note! true v')))
+                     v)
           ;; position 1 of a `[:rf.work/resource …]` vector is family-planted by
           ;; construction, so the key there is NAMED however unregistered its
           ;; resource-id has become.
@@ -703,14 +800,6 @@
           ;; cannot drift from the row. Gated on the payload being provably the
           ;; runtime's (audit #7054): `:scope` is a word apps use too.
           payload? (and (map? v) (carrier-family-payload? v))
-          ;; rf2-xx4ty — a read continuation reply's `:value` / `:params`, read
-          ;; through the owner its own `:resource/key` names (ONCE per map,
-          ;; exactly as `project-tags*` reads it once per row for the cursor).
-          ;; Gated on the canonical reply MARKER (audit #7059), not on the mere
-          ;; presence of a sibling key.
-          owner-redacts? (and (map? v)
-                              (resource-reply? v)
-                              (row-owner-redacts? v frame-id))
           entry    (fn [k x]
                      (cond
                        (and payload? (= :scope k))
@@ -962,7 +1051,11 @@
   and let through in the clear one slot from the `:resource/key` that had just
   redacted the same bytes, and (rf2-xx4ty) the `:value` + `:params` a READ
   CONTINUATION reply carries beside its own `:resource/key`, tokenized iff that
-  key's OWNER redacts so a plain resource's reply stays readable.
+  key's OWNER redacts so a plain resource's reply stays readable — and
+  (rf2-ko5lm) that same reply's owner-DECLARED projection-relative paths, which
+  a coarse-only owner read cannot see, substituted through the mutation half's
+  own `redact-continuation-reply` so the continuation echo classifies exactly
+  as the durable entry it echoes.
 
   \"Speaks only for the data it planted\" is enforced, not merely intended:
   each of those three arms fires on PROOF that the runtime planted the value —


### PR DESCRIPTION
Two beads on different surfaces: a privacy gap in the resource-egress family, and a scope ruling. `rf2-ko5lm` is code; `rf2-h5fkc` is a decision recorded on the bead and reproduced below. Neither is closed here.

---

## 1. `rf2-ko5lm` — read continuations had no analogue of the mutation's declaration redaction

A resource whose only classification is projection-relative —

```clojure
(rf/reg-resource :account/profile
  {:sensitive [[:data :email]] :large [[:data :avatar]]} …)
```

— declares no coarse `:sensitive?`, so `whole-entry-disposition` is `:serialize`, `row-owner-redacts?` says nothing, and the rf2-xx4ty reply arm never fires. The decoded response body of that resource's `:reply-to` continuation rode `:rf.fx/args` and `:rf.event/fx` **verbatim**, while the very same bytes, landed in the durable entry one commit earlier, redact off-box — because `reconcile-registry` lowered `[:data :email]` to the entry's absolute runtime path and the epoch walk reads that registry. One value, two carriers, one rule applied: the rf2-irwsq shape, this time between the durable entry and the continuation echo of it.

**Mutations never had the hole.** Both settle sites wrap their reply in `classification/redact-continuation-reply`, which derives the paths from the spec's own projection-relative declaration (rf2-825mzj). The read reply's carrier shape **is** the mutation reply's carrier shape — `:value` beside `:params` beside `:scope` — so the counterpart is that same function, over the read owner's spec, reached at the egress projector instead of at the source. `carrier-decl-paths` already re-roots a `:data`-rooted decl onto `:value`, a `:params`-rooted decl onto `:params`, a `:scope`-rooted decl onto `:scope`. No second classification language, no new roster, ~15 lines of new logic.

Reads must **not** redact at the source, and that is why this is at egress rather than beside the mutation call: the coarse claim governs off-box egress, not in-process delivery. The app's own `:reply-to` handler is entitled to the decoded body and the trusted-local `:include-sensitive?` opt-in must still show it.

### The grain, and why this one

**Declaration-conditional** — it fires on the paths the owner declared and on nothing else.

Not unconditional, and not coarse-owner-conditional. The family's standing distinction is that a free `:scope` fails closed *unconditionally* once recognised (rf2-1zc33), while `:value` / `:params` are *owner-conditional* through `row-owner-redacts?` (rf2-xx4ty), and taking the wrong one makes the two carriers of one datum disagree for a plain owner. Here the datum is the declaration itself, and its two carriers are the **durable entry** and the **continuation echo**. Coarse-owner-conditional is precisely the read that misses a `:serialize` owner's declaration — it is the bug. Unconditional would tokenize an undeclared owner's reply, which is the over-redaction rf2-1kiuj rejected. The declaration's own grain is the only one that makes the two carriers agree, and it is the same grain the mutation half has always used.

It **composes** with the coarse arm rather than replacing it: applied only when `row-owner-redacts?` is false, so a coarse owner still tokenizes the whole slot and that arm's content-addressed digests are byte-identical. Three outcomes, one per claim shape:

| owner claims | reply `:value` / `:params` |
|---|---|
| coarse `:sensitive?` / `:large?` | whole slot tokenized (unchanged, rf2-xx4ty) |
| projection-relative declaration only | declared paths substitute in place; undeclared siblings ride |
| neither | byte-identical |

Recognition is unchanged and still a proof, never a local cue: the canonical `:rf.reply/work-kind :resource` marker gates the arm, so an app map carrying `:value` beside a genuine sensitive key is still nobody's business here. An unregistered owner needs no fail-closed arm of its own — a nil spec already makes `row-owner-redacts?` true, so the coarse arm has tokenized the whole payload before this is reached.

### Residues, filed not fixed

Widening surfaced two, both real, both a different mechanism:

- **`rf2-dl7bz`** — a `:params`-rooted declaration also names bytes riding the sibling `:resource/key`, and a `:serialize` owner's key rides verbatim at trace egress *by documented decision* (`ssr/project-scoped-key`: "the trace / tool egress callers pass `:serialize` through verbatim"). This PR closes the reply's copy; the key's copy is the family's universal carrier, its fix lives in the shared `disposition+project-key` pipeline three egress boundaries reuse, and it collides with the CEDN-1 cache-key-identity round-trip. That is a ruling, not a mechanical fix.
- **`rf2-zaopo`** — `redact-with-paths` matches paths **exactly**, so on an infinite feed a `[:data :email]` decl does not reach the merged-items vector `infinite-reply-value` delivers under `:value` (`[:value <i> :email]`). The durable side forks index-free (`project-entry-data`); the carrier walker does not, and teaching it to is a change to a core primitive with four callers.

Both are named in the source docstring and in the test section's prose. The test deliberately does **not** assert either, so neither bead's landing forces a test change here.

---

## 2. `rf2-h5fkc` — does the sample gate extend past `docs/core/freehand/**`?

### Verdict: **No.**

Recorded in full on the bead. The evidence, measured with the gate's own block splitter over tracked files:

| tree | pages | blocks | hard-unexecutable |
|---|---|---|---|
| `docs/core/freehand` (today) | 21 | 137 | 28 (20%) |
| `docs/api` | 21 | 94 | 15 (16%) |
| `docs/core` (minus freehand) | 36 | 337 | 85 (25%) |
| `docs/story` | 16 | 53 | 17 (32%) |
| `migration` | 7 | 125 | 58 (46%) |
| **extension total** | **80** | **609** | **175 (29%)** |

609 blocks is **4.4×** today's corpus, and each needs a row pinning a digest of its exact text. "hard-unexecutable" counts only blocks that cannot be transcribed at all — a non-Clojure fence, an elision marker, a bare `ns` form. Calibrated against freehand, where the roster's own reason column is the ground truth (23 of 137, 17%), the proxy reads 28 — it **over**-reads by ~20% on a tree written to be fixture-able and **under**-reads everywhere else, because it cannot see the `;; =>` illustrative fragment that has no surrounding code for a fixture to host. 175 is a floor.

**Fixture spine.** The roster works because a chapter fixture namespace exists per page group and the samples are transcribed onto the real classpath: 7 namespaces, 2,604 lines, 137 blocks — 19 lines of fixture per block. At that ratio the ~434 executable blocks outside freehand need roughly **8,200 new lines across ~27 namespaces**, on pages that were not written with a fixture beside them.

**The decisive number is yield.** The bead names one known outsider: a `reg-route` example whose `:path` sits in the metadata map, so `registry.cljc` throws `:rf.error/route-bad-metadata` and the route never registers. A reader-based scan of every fenced Clojure block in the repository finds **eighteen** instances of that defect. **Exactly one lies inside the proposed extension scope.** The other seventeen are in `spec/**` (7 — four in `spec/012-Routing.md`, including the canonical `:rf.route/not-found` registration) and `docs/EP/**` (10), trees nobody proposed rostering. So the extension buys **1 of 18** of the very defect class it is proposed to catch, for 609 rows and ~8,200 fixture lines. Full inventory filed as **`rf2-txe8o`** (P2 — seven of them are in the normative spec, which is the spec disagreeing with its own implementation).

**The second cost is structural, and the digest pin is what makes it so.** Editing any fenced block in `docs/core/freehand` reds this suite today, because the row pins the block's exact text — every guide edit is already a two-file change. Extending puts 80 more pages behind one roster `def` in one file: every doc edit anywhere becomes a two-file change and they all serialise on that file. This repo has spent beads removing exactly that shape.

**On the opt-in marker — established, not assumed.** The bead's hypothesis is right *outside* freehand and wrong *inside* it, and the boundary is not taste:

- Sweep-by-default is correct where a fixture spine exists and every block is a claim. It buys the three properties the gate's docstring names — adding a sample reds, editing a sample reds, deleting a fixture reds. Inside freehand all three hold and the 17% reason-rows are a tolerable tax.
- Outside, most blocks are prose. A sweep needs ≥175 rows whose only content is "this one does not run" — the "excuse column" the `unexecutable-reasons` docstring says the closed set exists to prevent — and the closed set of seven reasons does not stretch to what those trees contain (`docs/api` alone is dominated by `;; =>` result illustrations and bare expression fragments). An opt-in marker removes the flake mode structurally rather than managing it: prose that never claimed to run cannot red the build.
- Its honest cost: it gives up "adding a sample reds". Outside freehand that property was never available anyway — there is no fixture for an unrostered block to point at — so nothing that exists today is lost.

The two shapes are not competitors. They are correct in different regimes, and the regime boundary is "does this tree have a fixture spine".

**The honest limit, either way.** No mechanical gate of this class catches `forms.md`'s instance, where a rendered example subscribes to the wrong thing. The tightened rule proves a roster row's owner is a var some test *exercises*; an exercised fixture proves the spelling compiles and renders, never that the example teaches the right thing. That is a correctness judgement about a running example and it stays with human review, under either shape, in every tree.

If a standing check for the `reg-route` class is ever wanted, it belongs as a rule inside the **existing** `doc_api_check` / `doc_guide_check` family, which already reads every doc tree and already asks call-position questions. Not a roster extension, and not a second gate.

---

## Quality gates

All runs foreground to completion, `rc` captured immediately into a worktree-local log and cross-checked against each log's own verdict line.

| run | tests | assertions | failures | errors | rc |
|---|---|---|---|---|---|
| epoch — baseline (pre-change) | 504 | 6755 | 0 | 0 | 0 |
| **epoch — RED** (tests added, fix absent) | **510** | **6806** | **14** | **0** | **1** |
| **epoch — GREEN** (fix applied) | **510** | **6806** | **0** | **0** | **0** |
| epoch — final (after docstring edits) | 510 | 6806 | 0 | 0 | 0 |
| resources | 734 | 6820 | 0 | 0 | 0 |
| core | 2126 | 10492 | 0 | 0 | 0 |

`clojure -M:test` from `implementation/epoch`, `implementation/resources`, `implementation/core`.

### The identical-count proof (bead 1)

RED and GREEN are **510 tests / 6806 assertions** on both sides, differing only in failures: **14 → 0**. A silently-failed edit leaves the failures behind, so the identity is the proof that the fix — not the test file — moved. The baseline row shows the 6 new tests / 51 new assertions the section adds (504/6755 → 510/6806) and that the pre-existing suite was green before any of it.

Every RED failure was in the new section and named the leak directly. Two representative `actual:` lines, in argument order:

```
expected: (= [] (secret-leak-paths projected))
  actual: (not (= [] [[[:trace-events 8 :tags :rf.fx/args 1 :value :email] "topsecret-PII@example.com"]
                      [[:trace-events 9 :tags :rf.event/fx 1 1 1 :value :email] "topsecret-PII@example.com"]]))

expected: (= :rf/redacted (:email (:value r)))
  actual: (not (= :rf/redacted "topsecret-PII@example.com"))
```

The acceptance arm drives a **real** `[:rf.resource/ensure … :reply-to …]` through the runtime's own settle path and covers **both** continuation paths — the async accepted fan-out and the fresh-skip immediate dispatch — so the projector's input is the runtime's output, not an invented tag map. Note what the RED scan did *not* report: the durable entry's copy of the same body, which was already redacting through the lowered registry. That is the disagreement this PR closes, visible in the failure itself.

### The two-sided control (bead 1)

Over-redaction has to fail as loudly as leaking; three merged repairs in this family shipped a second-order defect on the way, each firing on a local cue ordinary FX data hits by coincidence. Four controls, all passing in **both** RED and GREEN — which is what proves they are not satisfied by the arm simply being off:

- **`fx-carrier-keeps-an-undeclared-owners-reply-byte-identical`** — a `:plain/article` reply carrying the identical `:value` and `:params` rides **byte-identical** through both carriers (`:rf.fx/args` compared whole against the raw event vector, `:rf.event/fx` compared whole against the raw record's), and neither row is stamped `:sensitive?`.
- **`:rf.scope/global` is untouched** — asserted directly on the projected reply of the real drive, alongside the whole scoped key `[:rf.scope/global :declared/profile {:slug "welcome"}]` riding verbatim.
- **the undeclared sibling rides** — `:display-name` sits inside the same `:value` map as the declared `:email` and comes out `"Ada"`. That is what makes this a path declaration rather than a whole-slot tokenization wearing a declaration as its trigger.
- **`fx-carrier-declared-arm-leaves-the-fx-familys-own-value-verbatim`** — a map carrying `:value` beside a genuine `:resource/key` but **without** the canonical reply marker rides byte-for-byte and does not stamp the row. Plus the runtime's own `[:rf.resource/commit-generation {:value 1}]` on the same effect vector, untouched.

`:include-sensitive?` keeps the raw declared slots on every carrier — the redaction is the off-box default, not a strip.

### Note on the core count

Core reads 2126/10492 against a stated baseline of 2125/10484. This branch touches no file under `implementation/core` (the diff is two files in `implementation/resources/src` and one in `implementation/epoch/test`), so the +1 test / +8 assertions arrived on `main` from another merge, not from here.
