### PR TITLE
docs,spec: move :path out of reg-route metadata in the 8 live worked examples (rf2-txe8o)

### DIFF
--- a/docs/core/how-to/keep-secrets-out-of-traces.md
+++ b/docs/core/how-to/keep-secrets-out-of-traces.md
@@ -205,7 +205,8 @@ So a route carrying a token in its query string (`?reset_token=…`) classifies 
 
 ```clojure
 (rf/reg-route :password-reset
-  {:path "/reset" :sensitive [[:query :reset-token]]})
+  {:sensitive [[:query :reset-token]]}
+  "/reset")
 
 (rf/reg-resource :user-profile
   {:sensitive [[:data :ssn]] :large [[:data :avatar-bytes]]})

--- a/spec/012-Routing.md
+++ b/spec/012-Routing.md
@@ -890,9 +890,9 @@ A route may declare a vector of events the runtime **fires-and-forgets** wheneve
 ```clojure
 (rf/reg-route :route/cart
   {:doc      "The cart page."
-   :path     "/cart"
    :on-match [[:analytics/viewed-cart]
-              [:cart/seed-ui-state]]})
+              [:cart/seed-ui-state]]}
+  "/cart")
 ```
 
 Its contract is fire-and-forget (EP-0037 §`:on-match` is activation work):
@@ -980,10 +980,10 @@ A prefetch never warms or attaches work in a **sibling frame** merely because th
 ```clojure
 (rf/reg-route :rf.route/not-found
   {:doc      "404 page."
-   :path     "/404"                     ;; required, but rarely matched directly — the runtime
-                                          ;; routes URL-driven misses here regardless of :path
    :on-match [[:analytics/log-404]]
-   :scroll   :top})
+   :scroll   :top}
+  "/404")                                ;; required, but rarely matched directly — the runtime
+                                         ;; routes URL-driven misses here regardless of the pattern
 ```
 
 Semantics:
@@ -1317,9 +1317,9 @@ The path syntax is the *primary* binding. Query strings are bound separately via
 
 ```clojure
 (rf/reg-route :route/search
-  {:path            "/search"
-   :query           [:map [:q :string] [:page {:optional true} :int]]
-   :query-defaults  {:page 1}})
+  {:query           [:map [:q :string] [:page {:optional true} :int]]
+   :query-defaults  {:page 1}}
+  "/search")
 
 ;; URL: /search?q=clojure&page=2
 ;; match-url yields:
@@ -1429,9 +1429,9 @@ Routes that declare **no** `:query` vocabulary at all (neither a `:query` schema
 ```clojure
 ;; safe enum allowlist for a keyword-typed query value.
 (rf/reg-route :route/sorted
-  {:path  "/items"
-   :query [:map
-           [:sort [:enum :asc :desc]]]})
+  {:query [:map
+           [:sort [:enum :asc :desc]]]}
+  "/items")
 
 ;; URL: /items?sort=desc       → :query {:sort :desc}     ;; declared enum value → interned
 ;; URL: /items?sort=hostile    → :query {:sort "hostile"} ;; outside enum → stays as string

--- a/spec/016-Resources.md
+++ b/spec/016-Resources.md
@@ -1236,8 +1236,7 @@ Invalidation can be batched: a single event may carry many tags, but it emits on
 ```clojure
 (rf/reg-route
   :route/article
-  {:path "/articles/:slug"
-   :params [:map [:slug :string]]
+  {:params [:map [:slug :string]]
    :resources
    [{:resource  :article/by-slug
      :params    (fn [route] {:slug (get-in route [:params :slug])})
@@ -1248,7 +1247,8 @@ Invalidation can be batched: a single event may carry many tags, but it emits on
      :params    (fn [route] {:slug (get-in route [:params :slug])})
      :when      (fn [route _ctx] (some? (get-in route [:params :slug])))
      :blocking? false
-     :keep-previous? true}]})
+     :keep-previous? true}]}
+  "/articles/:slug")
 ```
 
 The route entry's `:scope` is a named-resolver reference `{:from-db :realworld/session}` — the **one** scope-resolution currency ([§Named resource-scope resolvers](#named-resource-scope-resolvers-reg-resource-scope)), resolved against the route-entry app-db coeffect at use time. It is **not** an anonymous `(fn [_route ctx] …)` that reads viewer identity out of the planning `ctx`: the route-planning `ctx` is the reserved trailing context (currently the empty map, [§The `ctx` argument is reserved across resource/mutation fn surfaces](#the-ctx-argument-is-reserved-across-resourcemutation-fn-surfaces)), so reading session scope from it would hide the dependency, defeat tooling naming, and resolve nil (fail-closed). The named resolver is the recommended form everywhere viewer identity decides resource identity; the `(fn [route ctx] …)` resolver tier exists for route facts available on the `route` argument (e.g. a path-segment param), not for db-derived viewer scope.
@@ -1715,13 +1715,13 @@ The artefact adds a `:rf.resource/*` trace family with operations such as `:rf.r
 
 (rf/reg-route
   :route/article
-  {:path "/articles/:slug"
-   :params [:map [:slug :string]]
+  {:params [:map [:slug :string]]
    :resources
    [{:resource  :article/by-slug
      :params    (fn [route] {:slug (get-in route [:params :slug])})
      :scope     {:from-db :realworld/session}
-     :blocking? true}]})
+     :blocking? true}]}
+  "/articles/:slug")
 
 (rf/reg-view article-page []
   (let [slug  (:slug @(rf/subscribe [:rf.route/params]))

--- a/spec/Derivations.md
+++ b/spec/Derivations.md
@@ -605,11 +605,11 @@ The split the [§Authority](#authority--the-remote-axis) section names is visibl
 ```clojure
 ;; SOURCE FORM
 (rf/reg-route :route/article
-  {:path "/articles/:slug"
-   :params [:map [:slug :string]]
+  {:params [:map [:slug :string]]
    :resources [{:resource :article/by-slug
                 :params   (fn [route] {:slug (get-in route [:params :slug])})
-                :blocking? true}]})
+                :blocking? true}]}
+  "/articles/:slug")
 ```
 
 ```clojure


### PR DESCRIPTION
Fixes the eight **live** worked examples of `rf2-txe8o`'s eighteen. The ten in `docs/EP/**` are deliberately left; the reason is below and it is evidence-backed, not deference to "history".

## The defect, and where the bead's diagnosis is one step off

The bead attributes the throw to `implementation/routing/src/re_frame/routing/registry.cljc:455` — the guard that rejects a `:path` left inside the metadata map. **That guard is not what the corpus hits.** Every one of the eighteen sites is a **2-arg** `reg-route` call, and `reg-route`'s only arity is `[id metadata path]`, so they die with a raw `ArityException` *before* reaching line 455. Line 455 fires only for the *half-migrated* 3-arg-with-`:path`-still-in-the-map form.

That makes the corpus symptom **worse** than the bead states. Compare the two, both run below: the ArityException names an internal var and a number — no route id, no `:rf.error/*` id, no pointer to the grammar. Line 455's message is the good one, and the reader never sees it.

## The executable before/after

Run against the real registrar on the routing + resources classpath (`java -cp $(clojure -Spath …) clojure.main`), forms transcribed verbatim from the corpus sites. `PROBE_RC=0`.

```
===== BEFORE — the 2-arg shape all 18 corpus sites carry today =====
  THROW spec/012:890  :route/cart            clojure.lang.ArityException
        Wrong number of args (2) passed to: re-frame.core-routing/reg-route
  THROW spec/012:980  not-found (CANONICAL)  clojure.lang.ArityException
  THROW spec/012:1318 :route/search          clojure.lang.ArityException
  THROW spec/012:1429 :route/sorted          clojure.lang.ArityException
  THROW docs/core how-to :password-reset     clojure.lang.ArityException
  THROW spec/Derivations:605 :route/article  clojure.lang.ArityException
  THROW spec/016:1236 :route/article         clojure.lang.ArityException

----- and the registry.cljc:455 guard, for the HALF-migrated 3-arg form -----
  THROW 3-arg, :path still in the map        :rf.error/route-bad-metadata
        route :route/half declares :path inside its metadata map — per rf2-wvh95f F1
        the path pattern is the THIRD slot: (reg-route :route/half {…} "/cart").
        Move the pattern out of the metadata map into the value slot.

===== AFTER — the 3-slot spelling this PR writes =====
  PASS  spec/012:890  :route/cart            registered -> :route/cart
  PASS  spec/012:980  not-found (CANONICAL)  registered -> :rf.route/not-found
  PASS  spec/012:1318 :route/search          registered -> :route/search
  PASS  spec/012:1429 :route/sorted          registered -> :route/sorted
  PASS  docs/core how-to :password-reset     registered -> :password-reset
  PASS  spec/Derivations:605 :route/article  registered -> :route/article
  PASS  spec/016:1236 + :1698 :route/article registered -> :route/article
```

Registering is the low bar; the corrected routes also **behave as their own surrounding prose promises**:

```
  handler-meta not-found :path   -> "/404"
  match-url /search?q=clojure    -> {:route-id :route/search, :query {:page 1, :q "clojure"}}
  match-url /items?sort=desc     -> {:route-id :route/sorted, :query {:sort :desc}}
  match-url /items?sort=hostile  -> {:route-id :route/sorted, :query {:sort "hostile"}}
  match-url /nope                -> nil
  how-to :sensitive survives     -> [[:query :reset-token]]
```

The last two lines are the ones that matter. `/nope → nil` is the not-found path the canonical example exists to set up, and the how-to's whole purpose is that `:sensitive` declaration reaching the route — which it could not, because the route never registered.

## My recount against the bead's 18

**18, confirmed exactly** — same files, same route ids. (My line numbers are the first content line; the bead's are the fence line.) Re-derived independently with the reader, not grep: `:read-cond :allow`, `:features #{:cljs}`, `*default-data-reader-fn*` pass-through, `postwalk` over every subform, matching `(reg-route <id> <map> …)` where the map contains `:path`. After this PR the same scan returns **10**, and they are exactly the ten `docs/EP` rows — which is also the independent confirmation that all eight edits landed.

**But 18 is one verb of four, and that is the finding.** Reading the live arglists off the facade rather than from memory, exactly four public `reg-*` verbs have **no** 2-arg arity — `reg-flow`, `reg-mutation`, `reg-resource`, `reg-route`. Scanning the corpus for wrong-arity calls of all four:

| verb | wrong-arity instances |
|---|---|
| `reg-resource` | 21 |
| `reg-route` | 18 (this bead) |
| `reg-flow` | 8 |
| `reg-mutation` | 8 |
| **total** | **55** |

So the bead enumerated its verb correctly and completely, and that verb is **33%** of the class. Three of the other instances are in the **normative spec** — `spec/015-Data-Classification.md:156`, `spec/016-Resources.md:1361`, `spec/016-Resources.md:1698` — i.e. the same sharp end the bead identifies, in a verb it did not scan. Filed as a follow-up rather than swept here: each sibling verb needs more than a third slot (a 2-arg `reg-resource` corrected to 3-arg still throws `:rf.error/resource-missing-scope-policy`, then `:rf.error/resource-bad-spec` for a missing `:params-schema`), so repairing them is authoring example content, not relocating an argument — and it should be done uniformly across all 21 sites by someone who has measured that class.

**This has a direct consequence for one file in this PR, stated plainly:** `docs/core/how-to/keep-secrets-out-of-traces.md` has **two** broken lines in the same fenced block — the `reg-route` I fixed and a 2-arg `reg-resource` two lines below it. This PR does **not** make that block paste-able. It fixes the line the bead names, and the follow-up finishes the page.

## Every `spec/012` hunk (hot-zone; sole occupant this wave)

Four hunks, all inside fenced `clojure` blocks; no prose changed.

1. **L891 `:route/cart`** (§Per-route data loading) — `:path "/cart"` out of the map, `"/cart"` appended as the third slot.
2. **L981 `:rf.route/not-found`** (§Route-not-found — canonical) — same move. The trailing comment that hung off the `:path` line (*"required, but rarely matched directly…"*) travels with the pattern to the value slot; its last two words change from "regardless of `:path`" to "regardless of the pattern", since `:path` is no longer the spelling at that site.
3. **L1319 `:route/search`** (§Query strings and fragments) — same move.
4. **L1431 `:route/sorted`** (§keyword-interning defences) — same move. This block sat directly under prose that *already* spelled the correct form inline (`a bare (reg-route :route/x {} "/x")`, L1427).

**The spec was contradicting itself, not lagging.** `spec/012` states the 3-slot rule in four separate places — L17, L253, L270, L283 — and L270 goes as far as naming the penalty: *"A `:path` left INSIDE the metadata map is rejected the same way."* L283's table row spells `(reg-route id {…metadata…} "/path")`. The normative prose and the reserved-key table were right the whole time; only the worked examples were wrong. Nothing in that prose needed to change, and nothing did.

Other files: `spec/016-Resources.md` L1237 + L1716 (both `:route/article`, `:resources` vector preserved verbatim), `spec/Derivations.md` L605 (the `;; SOURCE FORM` block — its paired `;; ALGEBRA VIEW` block needs no change, as it projects `:source-form {:kind :reg-route :id :route/article}` and never spells the pattern), `docs/core/how-to/keep-secrets-out-of-traces.md` L206.

**No digest-pinned block was touched.** `samples_coverage_jvm_test.clj` pins `guide-dir` = `docs/core/freehand` via a non-recursive `.listFiles`; `docs/core/how-to/` is outside it. No digests to report. (Per the brief, the sample-coverage census is not cited as fence evidence — it is insensitive to block text by construction.)

## Per-tree disposition

**`spec/**` (7) — corrected.** Normative. Not arguable.

**`docs/core/**` (1) — corrected.** Live teaching surface, with the caveat above that the block is not yet whole.

**`docs/EP/**` (10) — left as-is, deliberately.** Three reasons, in increasing order of weight.

1. **The EP process's own rule permits the edit but does not require it.** EP-0009 §Durability rule 3 allows "mechanical corrections… always fine", where mechanical means "the edit cannot change a reasonable reader's understanding of the proposal, alternatives, rationale, ruling, or scope" — *"freeze meaning, not bytes"*. In all ten, `reg-route` is scaffolding for a passage about something else (resource queries, the reply envelope, path optics, derivation algebra, mutation completion, polling); none argues about route grammar. So this is permission, not obligation. Rules 1–3 make the tree a durable record; they do not make it a maintained one.

2. **The tree is uniformly period-spelled, and by a wide margin.** Counting fenced blocks in `docs/EP` containing grammar that has since been retired: `reg-event-fx` **34**, `:include-ns` 21, `:initial-db` 11, `reg-event-db` 10, `:on-create` 9, `:rf.world/inputs` 9, `:data-schema` 6, `:exclude-ns` 3 — **103 blocks across eight retired tokens**, against 9 in all of `spec/**` and 4 in all of `docs/core/**`. The `:path` instances are a ninth token in an established class. The EP tree is written in the vocabulary of its time and has never been swept; `spec/` and `docs/core/` have been.

3. **It is the same defect, not merely a similar one — and fixing only `:path` would not achieve the fix's purpose.** `reg-event-fx` and `reg-event-db` are not soft-deprecated, they are throwing stubs, verified in the same probe run:

   ```
     THROW EP-0011:1189 reg-event-fx (34 blocks)  :rf.error/reg-event-fx-removed
     THROW EP reg-event-db (10 blocks)            :rf.error/reg-event-db-removed
   ```

   EP-0011's block is the clean demonstration: it contains **both** a 2-arg `reg-route` and an `rf/reg-event-fx`, three lines apart. Correcting the `reg-route` leaves a block that still throws on paste — the paste-ability argument that justifies fixing `spec/` and `docs/core/` **cannot be delivered** in `docs/EP/` without also sweeping eight other token classes. What it would deliver instead is a corpus of half-modernised records: current in one respect, dated in eight, with no marker saying which.

   Leaving them keeps the record uniform and honest. Sweeping the EP tree to current grammar is a coherent thing to want, but it is a different, much larger decision — one for Mike, across all nine token classes at once, not a side effect of a routing bead.

An annotation was considered and rejected: ten "this spelling predates rf2-wvh95f F1" notes would be the only such markers in a tree with 113 instances needing them.

## Follow-ups filed

- **`rf2-rzuc7`** (P2, discovered-from `rf2-txe8o`) — the 37 sibling wrong-arity instances (`reg-resource` 21, `reg-flow` 8, `reg-mutation` 8), carrying the full inventory, flagging the three normative-spec `reg-resource` sites and the half-fixed how-to block from this PR. It recommends the same EP-tree ruling as this PR so the two stay consistent.

No conformance gate is proposed; that scope question was settled with evidence (609 blocks / 80 pages to catch 1 of these 18).

## Quality gates

Run from the worktree, `rc` captured immediately into a worktree-local log and cross-checked against each log's own verdict line.

All run from the worktree, foreground to completion. `rc` captured immediately into a worktree-local log and cross-checked against each log's own verdict line.

| gate | result | rc |
|---|---|---|
| `implementation/routing` `clojure -M:test` | **511 tests, 2771 assertions, 0 failures, 0 errors** | 0 |
| `implementation/freehand` `clojure -M:test` | **1164 tests, 7736 assertions, 0 failures, 0 errors** | 0 |
| `implementation/core` `clojure -M:test` | **2126 tests, 10492 assertions, 0 failures, 0 errors** | 0 |
| `python -m mkdocs build --strict` (run directly — the spine soft-skips it) | `Documentation built in 36.51 seconds`; **0 `WARNING`, 0 `ERROR`** in 139 log lines | 0 |
| `scripts/check_doc_slugs.py` | clean, 0 bytes output | 0 |
| reader recount of `reg-route` `:path`-in-metadata | 18 → **10**, all ten in `docs/EP` | 0 |
| executable before/after probe | 7 THROW → 7 PASS, plus behaviour | 0 |

All three suites match the briefed baselines exactly — routing 511/2771, freehand 1164/7736, core 2126/10492. **No count moved,** which is the expected result: this PR changes only fenced blocks in four Markdown files and adds no test.

Two notes on the false-signal masks. Every `rc` above is a genuine test outcome, not a wrapper's summary — none is one of the non-outcome exit codes (`0xC0000142`, `124` from `timeout(1)`, or a `'shadow-cljs' is not recognized` `1`). And `mkdocs --strict` is verified two ways rather than on `rc` alone: `--strict` promotes any `WARNING` to a failure, and the log independently contains zero `WARNING`/`ERROR` lines.

One thing worth flagging for anyone re-running the scan: `mkdocs build` **generates `docs/spec/`**, a gitignored mirror of `spec/`. A corpus scan run after a docs build double-counts those pages (it added 3 phantom `reg-resource` rows here). Every count in this PR is over **tracked files only** (`git ls-files docs/spec` → 0).
