### PR TITLE
story: settle the presence bridge at Freehand's own commit boundary (rf2-gzmg0)

### DIFF
--- a/tools/story/spec/017-Testing-Story.md
+++ b/tools/story/spec/017-Testing-Story.md
@@ -1109,12 +1109,26 @@ bridge once at boot:
 holds the Freehand dependency on the *app's* side of the seam — Story's
 jar ships the file but never requires it, so the dependency direction is
 unchanged. It composes two verbs the substrate already published — the
-logical advance above, and core's adapter-dispatched synchronous commit
-(`re-frame.substrate.adapter/flush-render!`, Spec 006) so the removals the
-advance fires are committed before the step returns. It installs at load
-time; there is nothing else to call.
+logical advance above, and **Freehand's own** synchronous commit, the Spec 006
+`flush-render!` contract slot read off the published `v/adapter` value — so
+the removals the advance fires are committed before the step returns. It
+installs at load time; there is nothing else to call.
 (`re-frame.story.play.presence/install-presence-flush!` stays public for a
 host registering a different advance.)
+
+**Freehand's boundary, not the process adapter's.** The commit that has to
+happen is a commit of a Freehand root, so the bridge does not route through
+`re-frame.substrate.adapter/flush-render!`, which dispatches on whatever
+substrate adapter the process installed. Story's own shell is a Reagent
+application and every shipped testbed seats `re-frame.adapter.reagent/adapter`,
+whose slot is `(fn [f] (f) (reagent.core/flush))`: it runs the thunk bare and
+drains Reagent's own queues. A presence removal makes no Reagent component
+dirty — it calls a plain React `useState` setter inside the Freehand root — so
+that drain never reaches `react-dom/flushSync` and never closes Freehand's
+ViewCell window. Dispatched, the verb would return with the clock reporting
+zero pending and the retained child still painted. Read off `v/adapter`, the
+boundary is correct under every seating and byte-identical under Freehand's
+own.
 
 `[:flush-presence]` requires NO capability token and does not lift
 `:required-runner` to `:dom` — the presence clock is a process-global

--- a/tools/story/src/re_frame/story/play/presence_host.cljc
+++ b/tools/story/src/re_frame/story/play/presence_host.cljc
@@ -47,14 +47,14 @@
     quiescence, a number → advance by that many logical ms). The advance is
     the framework's; only the wrapper around it is this bridge's.
 
-  - **`re-frame.substrate.adapter/flush-render!`** — core's adapter-dispatched
-    SYNCHRONOUS commit (Spec 006 §`flush-render!`). The removals an advance
-    fires are React state updates, so a bare advance would leave the DOM one
-    commit behind; running the advance INSIDE the substrate's synchronous
-    commit boundary returns with the DOM settled. Freehand's override of that
-    slot also closes the pending ViewCell window inside the same boundary and
-    converges, and runs the shared `guard-open-drain!` first — so a flush
-    forced from inside an open drain fails loud
+  - **`(:flush-render! v/adapter)`** — FREEHAND's synchronous commit, the
+    Spec 006 `flush-render!` contract slot read off the published adapter
+    VALUE. The removals an advance fires are React state updates, so a bare
+    advance would leave the DOM one commit behind; running the advance INSIDE
+    that commit boundary returns with the DOM settled. Freehand's
+    implementation also closes the pending ViewCell window inside the same
+    boundary and converges, and runs the shared `guard-open-drain!` first —
+    so a flush forced from inside an open drain fails loud
     (`:rf.error/flush-in-open-epoch`) exactly as the donor's did.
 
   Composing them is why crossing to Freehand needed no new published verb.
@@ -64,6 +64,52 @@
   supported both — `presence/advance!` attaches a `:pending` thenable only
   when the host verb returns one, and `settle!` calls back synchronously when
   it does not — so the runner needs no arm for this and gains no latency.
+
+  ## Why FREEHAND's boundary and not the PROCESS adapter's (rf2-gzmg0)
+
+  The commit that has to happen is a commit of a FREEHAND root, so the
+  boundary that closes it is Freehand's — not whichever substrate adapter the
+  process happens to have installed.
+
+  This bridge first reached for `re-frame.substrate.adapter/flush-render!`,
+  core's adapter-DISPATCHED spelling of the same slot, on the reasonable-
+  sounding ground that a Freehand app installs `v/adapter` and the dispatch
+  therefore lands on Freehand's implementation anyway. It does not, in the
+  topology that matters. Every shipped Story testbed seats
+  `re-frame.adapter.reagent/adapter` — Story's own shell is a Reagent
+  application — and a Freehand variant mounts inside that process. Reagent's
+  slot is `(fn [f] (f) (reagent.core/flush))`: it runs the thunk bare and then
+  drains Reagent's own before-flush / ratom / component / after-render queues.
+  A presence removal makes no Reagent component dirty (it calls a plain React
+  `useState` setter inside the Freehand root), so that drain never enters
+  `react-dom/flushSync`, and it never closes Freehand's ViewCell window
+  either. The verb would return, the clock would report zero pending, and the
+  retained child would still be painted — a green clock over a stale DOM,
+  which is the ONE failure this rung exists to exclude.
+
+  Reading the slot off `v/adapter` removes the process adapter from the
+  question entirely. Under `v/adapter` it is byte-identical to what the
+  dispatch found before; under any other seating it is the boundary that is
+  actually correct. `re-frame.freehand.substrate/flush-render!` — the fn this
+  resolves to — is adapter-state-free by construction: it stands on
+  `react-dom/flushSync`, the module-global ViewCell registry and core's
+  router-state drain guard, none of which consult the installed adapter.
+
+  It also retires the bridge's old headless special case. `flush-render!` is
+  an OPTIONAL contract fn and the plain-atom adapter a headless Story run
+  installs ships none, so the dispatched call used to run nothing and the
+  bridge re-ran the advance outside the boundary to compensate. Freehand's
+  slot always exists, so the advance now runs exactly once, on every host,
+  through one path.
+
+  KNOWN, WIDER, AND NOT THIS BRIDGE'S (rf2-gzmg0): a Freehand view's
+  SUBSCRIPTION reads are inert on the ratom substrates. Core's observation
+  port activates a derived value by adding a watch and dereferencing it, and a
+  stock Reagent `Reaction` deref'd outside `*ratom-context*` never captures
+  its sources — so it never notifies, and the ViewCell it feeds is never
+  marked dirty. That is upstream of this file and of Story, it is why the
+  mounted proof drives its presence children through props rather than a
+  subscription under the Reagent seating, and it is tracked separately.
 
   ## What it deliberately does NOT do
 
@@ -80,14 +126,25 @@
   With this bridge absent, `[:flush-presence]` REFUSES (`:cannot-run`) rather
   than skipping silently — see `re-frame.story.play.presence`."
   (:require [re-frame.story.play.presence :as presence]
-            ;; Core's adapter-dispatched synchronous commit. Core is already a
-            ;; hard Story dependency, so this adds no coordinate — it is named
-            ;; here rather than reached through `re-frame.core` because the
-            ;; substrate-contract verbs live on this namespace.
-            [re-frame.substrate.adapter :as substrate]
-            ;; The substrate's presence clock. This is the ONE require that
-            ;; makes this file the app-side half of the seam.
-            [re-frame.freehand.presence-runtime :as fh-presence]))
+            ;; The substrate's presence clock. Host-neutral, so it is required
+            ;; unconditionally — the JVM arm below never calls into it, but the
+            ;; namespace loads on both hosts.
+            [re-frame.freehand.presence-runtime :as fh-presence]
+            ;; The Freehand DOOR, for `v/adapter` alone. CLJS-only because the
+            ;; adapter value is: it stands on the core React spine, and a JVM
+            ;; structural render has no React root to commit.
+            #?@(:cljs [[re-frame.freehand :as v]])))
+
+#?(:cljs
+   (def ^:private freehand-commit!
+     "Freehand's own synchronous commit boundary — the Spec 006
+     `flush-render!` contract slot, read off the PUBLISHED adapter value.
+
+     Deliberately not `re-frame.substrate.adapter/flush-render!`, which
+     dispatches to whatever adapter the process installed: the commit that has
+     to happen here is a commit of a Freehand root. See the ns docstring
+     §Why FREEHAND's boundary and not the PROCESS adapter's."
+     (:flush-render! v/adapter)))
 
 #?(:cljs
    (defn- advance-clock!
@@ -100,21 +157,13 @@
 
 #?(:cljs
    (defn- advance-and-commit!
-     "Advance the presence clock and return with the DOM SETTLED.
-
-     `flush-render!` is an OPTIONAL contract fn: core's dispatcher runs the
-     thunk only when the installed adapter ships the slot, and returns nil
-     otherwise. A headless Story run installs `plain-atom`, which ships none —
-     there is no React commit to settle there, but the clock is still real and
-     its removal callbacks must still fire. So the advance is re-run outside
-     the boundary exactly when the boundary never ran it, and never twice."
+     "Advance the presence clock and return with the Freehand DOM SETTLED,
+     whatever adapter the process installed. One advance, one boundary, one
+     path on every host — Freehand always ships the slot, so there is no
+     'the boundary ran nothing' case to compensate for."
      [ms]
-     (let [advanced? (volatile! false)]
-       (substrate/flush-render! (fn []
-                                  (vreset! advanced? true)
-                                  (advance-clock! ms)))
-       (when-not @advanced? (advance-clock! ms))
-       nil)))
+     (freehand-commit! #(advance-clock! ms))
+     nil))
 
 (defn install!
   "Register the Freehand presence advance under the `:flush-presence!`

--- a/tools/story/test/re_frame/story/play/presence_freehand_dom_cljs_test.cljs
+++ b/tools/story/test/re_frame/story/play/presence_freehand_dom_cljs_test.cljs
@@ -17,16 +17,77 @@
 
   That gap is exactly where the donor→Freehand crossing could have gone
   wrong. The donor's verb settled at an awaited React `act`; the Freehand
-  bridge settles at the substrate's SYNCHRONOUS commit
-  (`re-frame.substrate.adapter/flush-render!` → Freehand's `flushSync`
-  override). A crossing that advanced the clock but committed nothing would
-  pass every headless assertion in the rung and leave a dismissed toast on
-  screen forever. So this file asserts against `document`.
+  bridge settles at a SYNCHRONOUS React commit. A crossing that advanced the
+  clock but committed nothing would pass every headless assertion in the rung
+  and leave a dismissed toast on screen forever. So this file asserts against
+  `document`.
+
+  ## Both seatings, because Story ships the OTHER one
+
+  The behavioural pair runs under two seated substrate adapters, and the
+  second is the one that matters:
+
+  - `v/adapter` — a pure Freehand process.
+  - `re-frame.adapter.reagent/adapter` — **the shipped Story topology.** Every
+    Story testbed (`tools/story/testbeds/*/core.cljs`) seats Reagent, because
+    Story's own shell is a Reagent application; a Freehand variant then mounts
+    inside that process. Spec 006 calls the mixed shape legitimate, and it is
+    the only shape a Story user actually gets.
+
+  A proof that only ever seated `v/adapter` proved the law under a topology
+  nobody ships (merged-PR audit #7037). The bridge originally settled through
+  `re-frame.substrate.adapter/flush-render!`, which DISPATCHES on the seated
+  adapter; under Reagent that lands on `(fn [f] (f) (reagent.core/flush))`,
+  which drains Reagent's own queues and never enters `react-dom/flushSync`
+  when no Reagent component is dirty — and a presence removal makes none
+  dirty, because it removes a retained key by calling a plain React `useState`
+  setter inside the Freehand root. The bridge now reads Freehand's own
+  `flush-render!` off `v/adapter`, so the boundary no longer depends on what
+  the process seated; these arms are what forced that and what hold it.
+
+  ## Why the Reagent arms drive presence through PROPS
+
+  A Freehand view's SUBSCRIPTION reads are inert on the ratom substrates, and
+  that is a separate defect upstream of Story. Core's observation port
+  activates a derived value by adding a watch and dereferencing it
+  (`re-frame.substrate.observation/build-node-handle!`), but a stock Reagent
+  `Reaction` deref'd outside `*ratom-context*` takes the non-reactive branch
+  of its own `-deref` and never captures its sources — so it never notifies,
+  and the ViewCell it feeds is never marked dirty. Measured here: under
+  Reagent, a `(v/sub …)`-driven boundary renders once and never again, so no
+  retained child can be produced at all.
+
+  So the Reagent arms build the retained child the way `v/mount` documents
+  as idempotent-per-root: re-mounting the same root-id into the same container
+  RE-RENDERS it. Presence keys arrive as props, a re-mount drops one, and the
+  boundary retains it. Nothing about the `[:flush-presence]` step changes —
+  it still travels `re/run!` → the run loop → `presence/advance!` → the
+  shipped bridge — and `the-props-driven-fixture-behaves-the-same-on-a-
+  freehand-process` runs the identical fixture under `v/adapter`, so the ONLY
+  variable between the two green arms is the seated adapter.
+
+  ## What each arm reads, and why there are two reads
+
+  `gone-at-verb-return` is the tight one. It snapshots `document` at the
+  instant the SHIPPED host verb returns, through a passthrough wrapper around
+  the verb the bridge itself registered — so it measures the bridge's own
+  stated law (*advance the presence clock and return with the DOM settled*)
+  at exactly the boundary that law names. Nothing about the dispatch is
+  hand-written: the wrapper delegates to the registered bridge and hands its
+  return value straight back.
+
+  The read in the run callback is the looser one, and it is here because it
+  is what a Story AUTHOR observes. Both caught the unfixed bridge — the child
+  was still painted at the callback too — but only the tight read is
+  GUARANTEED to: the run loop yields a `setTimeout` 0 after a
+  `:flush-presence` step (`runner/async-yield-step-types`), and React's own
+  scheduler task is a macrotask that can win that race on a different engine
+  or a different day. Keep both, and treat the tight one as the evidence.
 
   ## The red/green pair
 
-  Both tests run the SAME script shape against the SAME retained child and
-  differ in ONE step:
+  Both behavioural tests run the SAME script shape against the SAME retained
+  child and differ in ONE step:
 
     with    `[[:flush-presence]]`  → the retained child LEAVES the DOM
     without `[[:dispatch …]]`      → the retained child is STILL THERE
@@ -42,6 +103,10 @@
   and says so rather than passing quietly."
   (:require ["react" :as react]
             [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            ;; The adapter EVERY shipped Story testbed seats. Already a Story
+            ;; dependency (`day8/re-frame2-reagent`, main `:deps`) because the
+            ;; Story shell is itself a Reagent application.
+            [re-frame.adapter.reagent :as reagent-adapter]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.freehand :as v]
@@ -50,6 +115,7 @@
             [re-frame.router :as router]
             [re-frame.story :as story]
             [re-frame.story.late-bind :as late-bind]
+            [re-frame.story.play.presence :as story-presence]
             ;; The OPTIONAL bridge under test — required, not hand-rolled, so
             ;; this suite is an acceptance test of the ONE canonical
             ;; integration path (rf2-36biz).
@@ -65,6 +131,15 @@
   LOGICAL clock's, which is the determinism the rung exists for."
   60000)
 
+(def ^:private freehand-commit!
+  "Freehand's OWN synchronous commit boundary, read off the PUBLISHED adapter
+  value rather than off whatever adapter the process installed — the same slot
+  the bridge reaches for, and for the same reason.
+
+  HARNESS ONLY. Reaching for it here settles the SETUP; the thing under test
+  is the `[:flush-presence]` step, and that always travels `re/run!`."
+  (:flush-render! v/adapter))
+
 ;; ---------------------------------------------------------------------------
 ;; The views. Module-level: a declared view cannot close over a test's locals.
 ;; ---------------------------------------------------------------------------
@@ -78,12 +153,24 @@
      label]))
 
 (v/defview toaster
+  "Presence children from a SUBSCRIPTION — the shape a Freehand application
+  writes, and the shape the `v/adapter` arms drive."
   [_]
   (let [ids (v/sub [:toasts])]
     [:div#story-presence-stack
      (v/presence {:timeout-ms retention-ms}
        (for [k ids]
          [toast {:key k :label k}]))]))
+
+(v/defview prop-toaster
+  "Presence children from PROPS — the same boundary, re-rendered by a
+  re-mount rather than by a moving subscription. See the ns docstring
+  §Why the Reagent arms drive presence through PROPS."
+  [{:keys [ids]}]
+  [:div#story-presence-stack
+   (v/presence {:timeout-ms retention-ms}
+     (for [k ids]
+       [toast {:key k :label k}]))])
 
 ;; ---------------------------------------------------------------------------
 ;; Harness
@@ -93,11 +180,10 @@
   (and (exists? js/document) (some? (.-createElement js/document))))
 
 (defn- act
-  "A React 19 `act` boundary as a Promise — used ONLY to drive the MOUNT, the
+  "A React 19 `act` boundary as a Promise — used ONLY to drive the MOUNTS, the
   way every Freehand DOM suite does. The presence advance under test is
-  deliberately NOT act-driven: it settles through the substrate's own
-  synchronous commit, and wrapping it here would prove the harness rather
-  than the bridge.
+  deliberately NOT act-driven: it settles through Freehand's own synchronous
+  commit, and wrapping it here would prove the harness rather than the bridge.
 
   The act-environment flag is RESTORED once React settles. Leaving it armed
   would make every subsequent update outside an act boundary — which is every
@@ -116,7 +202,11 @@
         (restore!)
         (js/Promise.reject e)))))
 
-(defn- setup! []
+(defn- setup!
+  "Everything that is true of NEITHER seating. Which adapter is installed is
+  the variable this file exists to vary, so seating is each test's own first
+  act — see `seat!`."
+  []
   (story/clear-all!)
   (registrar/clear-all!)
   (reset! frame/frames {})
@@ -125,13 +215,21 @@
   ;; The BRIDGE deliberately leaves the wall clock armed — see `presence-host`
   ;; — so a suite that wants determinism disables it here, not there.
   (presence-rt/set-wall-clock! false)
-  ;; Seat FREEHAND's own adapter, explicitly. A `rf/init!` guarded only by a
-  ;; catch would silently keep whatever a sibling namespace left installed,
-  ;; and a Freehand root mounted over someone else's substrate is a different
-  ;; experiment from the one this file claims to run.
+  ;; An `rf/init!` guarded only by a catch would silently keep whatever a
+  ;; sibling namespace left installed, and a Freehand root mounted over
+  ;; someone else's substrate is a different experiment from the one a given
+  ;; test claims to run. So: destroy first, always, and seat explicitly.
   (try (rf/destroy-adapter!) (catch :default _ nil))
-  (rf/init! v/adapter)
   (reset! re/run-state {})
+  nil)
+
+(defn- seat!
+  "Install `adapter-value` as THE process adapter and build the variant frame
+  over it. Returns the adapter's canonical `:kind`, which every test pins — an
+  arm that silently ran on the other substrate would prove the opposite of
+  what it claims."
+  [adapter-value]
+  (rf/init! adapter-value)
   (story/install-canonical-vocabulary!)
   (frame/ensure-default-frame!)
   (rf/make-frame {:id variant-frame :doc "Freehand presence rung test frame"})
@@ -143,7 +241,7 @@
   ;; `teardown!` drops it so this suite cannot leak a presence host into the
   ;; consolidated bundle, and `install!` is public for exactly this case.
   (presence-host/install!)
-  nil)
+  (substrate/current-adapter))
 
 (defn- teardown! []
   (try (rf/destroy-adapter!) (catch :default _ nil))
@@ -168,19 +266,51 @@
   (some-> (toast-el container label) (.getAttribute "data-phase")))
 
 (defn- dispatch-and-settle!
-  "Dispatch into the variant frame and return with the Freehand DOM SETTLED —
+  "Dispatch into the variant frame and return with the Freehand DOM settled —
   the substrate's own synchronous commit, which is what a Story `:dispatch`
   step reaches through the settled-boundary ladder."
   [event]
   (substrate/flush-render! (fn [] (router/dispatch-sync! event {:frame variant-frame}))))
 
+(defn- watch-verb-return!
+  "Wrap the INSTALLED `:flush-presence!` verb — the shipped bridge, already
+  registered by `presence-host/install!` — in a passthrough that calls
+  `observe!` the instant the verb returns, and hands the verb's own return
+  value straight back.
+
+  An OBSERVER, not a second door: the step still travels `re/run!` →
+  `run-loop!` → `presence/advance!` → this wrapper → the shipped bridge. It
+  exists because the bridge's law is stated about its RETURN, and the run
+  callback is a macrotask later — far enough away that React's own scheduler
+  can settle the DOM on the bridge's behalf and hide a bridge that settled
+  nothing."
+  [observe!]
+  (let [shipped (story-presence/presence-flush-fn)]
+    (assert (some? shipped) "the shipped bridge must be installed before wrapping it")
+    (story-presence/install-presence-flush!
+      (fn [ms]
+        (let [ret (shipped ms)]
+          (observe!)
+          ret)))))
+
 (defn- skip! [why]
   (is true (str "a real Freehand mount needs a DOM host — " why)))
 
-(defn- retained-child-on-screen!
-  "Mount the boundary, dismiss `b`, and hand `k` the container with `b`
-  RETAINED: still in the DOM, reading `:unmounting`, its removal pending on
-  the logical clock. Every test below starts from exactly this state."
+(defn- retained!
+  "The state every behavioural arm starts from: `b` still in the DOM, reading
+  `:unmounting`, its removal pending on the logical clock."
+  [container k mounted]
+  (is (some? (toast-el container "b"))
+      "b is RETAINED in the DOM while exiting, not removed")
+  (is (= "unmounting" (phase-of container "b"))
+      "and its own (v/presence-phase) read reaches :unmounting")
+  (is (= 1 (presence-rt/pending-count))
+      "exactly one exit is retained on the logical clock")
+  (k container mounted))
+
+(defn- retain-via-subscription!
+  "Mount the subscription-driven boundary, dispatch the dismissal, and hand
+  `k` the retained state."
   [k]
   (let [container (host-node!)]
     (-> (act #(v/mount [toaster {}] container {:frame variant-frame}))
@@ -188,54 +318,98 @@
                  (dispatch-and-settle! [:toasts/seed])
                  (is (some? (toast-el container "b")) "b mounted")
                  (dispatch-and-settle! [:toasts/dismiss])
-                 (is (some? (toast-el container "b"))
-                     "b is RETAINED in the DOM while exiting, not removed")
-                 (is (= "unmounting" (phase-of container "b"))
-                     "and its own (v/presence-phase) read reaches :unmounting")
-                 (is (= 1 (presence-rt/pending-count))
-                     "exactly one exit is retained on the logical clock")
-                 (k container mounted))))))
+                 (retained! container k mounted))))))
+
+(defn- retain-via-props!
+  "Mount the props-driven boundary with both keys, RE-MOUNT it with one — the
+  idempotent-per-root re-render `v/mount` documents — and hand `k` the
+  retained state."
+  [k]
+  (let [container (host-node!)]
+    (-> (act #(v/mount [prop-toaster {:ids ["a" "b"]}] container {:frame variant-frame}))
+        (.then (fn [_]
+                 (is (some? (toast-el container "b")) "b mounted")
+                 (act #(v/mount [prop-toaster {:ids ["a"]}] container {:frame variant-frame}))))
+        (.then (fn [mounted]
+                 (retained! container k mounted))))))
 
 (defn- cleanup! [container mounted]
   (try (v/unmount! mounted) (catch :default _ nil))
   (.remove container)
   nil)
 
+;; ---------------------------------------------------------------------------
+;; The two arms, written once and driven under both seatings
+;; ---------------------------------------------------------------------------
+
+(defn- flush-presence-arm!
+  "GREEN: the runner's step takes the retained child off the screen, and had
+  already done so by the time the shipped verb returned."
+  [retain! done]
+  (retain!
+    (fn [container mounted]
+      (let [gone-at-verb-return (atom ::verb-never-reached)]
+        (watch-verb-return! #(reset! gone-at-verb-return (nil? (toast-el container "b"))))
+        (re/run! variant-frame "flushing"
+                 {:name   "flushing"
+                  :script [[:flush-presence]]}
+                 (fn [state]
+                   (is (= :pass (:status state))
+                       "the run passed — the step was reached and did not refuse")
+                   (is (true? @gone-at-verb-return)
+                       "the SHIPPED bridge RETURNED with the Freehand DOM settled:
+                        the retained child was already off the page at the instant
+                        the host verb handed control back, not a scheduler tick
+                        later")
+                   (is (nil? (toast-el container "b"))
+                       "the retained child LEFT THE DOM: the advance fired the
+                        exit AND the commit boundary committed the unmount")
+                   (is (some? (toast-el container "a"))
+                       "and the present sibling is untouched by b's removal")
+                   (is (zero? (presence-rt/pending-count))
+                       "the exit fired exactly once, leaving nothing pending")
+                   (cleanup! container mounted)
+                   (done)))))))
+
+(defn- no-step-control-arm!
+  "RED CONTROL: the same script without the step leaves the child exactly
+  where it was."
+  [retain! done]
+  (retain!
+    (fn [container mounted]
+      (re/run! variant-frame "not-flushing"
+               {:name   "not-flushing"
+                :script [[:dispatch [:toasts/noop]]]}
+               (fn [state]
+                 (is (= :pass (:status state))
+                     "the run itself is fine — it simply never flushed presence")
+                 (is (some? (toast-el container "b"))
+                     "the retained child is STILL on screen: no step advanced
+                      the presence clock, and no other rung can")
+                 (is (= "unmounting" (phase-of container "b"))
+                     "still reading :unmounting, still awaiting its timeout")
+                 (is (= 1 (presence-rt/pending-count))
+                     "its exit is still pending")
+                 (cleanup! container mounted)
+                 (done))))))
+
 ;; ===========================================================================
-;; GREEN — the runner's step takes the retained child off the screen
+;; Seating 1 — a pure Freehand process
 ;; ===========================================================================
 
 (deftest a-flush-presence-step-removes-the-retained-child-from-the-dom
   (testing "rf2-gzmg0 — the SHIPPED bridge, driven by the SHIPPED run loop:
             a `[:flush-presence]` script step advances the framework clock,
-            fires the retained exit, and the substrate commits the removal
-            before the run reports. Read back off `document`, because a
-            crossing that advanced the clock and committed nothing would pass
-            every counter-based arm of this rung."
+            fires the retained exit, and the DOM is committed before the verb
+            returns. Read back off `document`, because a crossing that
+            advanced the clock and committed nothing would pass every
+            counter-based arm of this rung."
     (if-not (browser?)
       (skip! "the browser job runs the removal assertion")
       (async done
-        (retained-child-on-screen!
-          (fn [container mounted]
-            (re/run! variant-frame "flushing"
-                     {:name   "flushing"
-                      :script [[:flush-presence]]}
-                     (fn [state]
-                       (is (= :pass (:status state))
-                           "the run passed — the step was reached and did not refuse")
-                       (is (nil? (toast-el container "b"))
-                           "the retained child LEFT THE DOM: the advance fired the
-                            exit AND the substrate committed the unmount")
-                       (is (some? (toast-el container "a"))
-                           "and the present sibling is untouched by b's removal")
-                       (is (zero? (presence-rt/pending-count))
-                           "the exit fired exactly once, leaving nothing pending")
-                       (cleanup! container mounted)
-                       (done)))))))))
-
-;; ===========================================================================
-;; RED — the same script without the step leaves it exactly where it was
-;; ===========================================================================
+        (is (= :rf.adapter/freehand (seat! v/adapter))
+            "this arm runs on a pure Freehand process")
+        (flush-presence-arm! retain-via-subscription! done)))))
 
 (deftest without-the-step-the-retained-child-stays-on-screen
   (testing "The NEGATIVE CONTROL for the test above, differing in ONE step.
@@ -248,33 +422,76 @@
     (if-not (browser?)
       (skip! "the browser job runs the retention assertion")
       (async done
-        (retained-child-on-screen!
-          (fn [container mounted]
-            (re/run! variant-frame "not-flushing"
-                     {:name   "not-flushing"
-                      :script [[:dispatch [:toasts/noop]]]}
-                     (fn [state]
-                       (is (= :pass (:status state))
-                           "the run itself is fine — it simply never flushed presence")
-                       (is (some? (toast-el container "b"))
-                           "the retained child is STILL on screen: no step advanced
-                            the presence clock, and no other rung can")
-                       (is (= "unmounting" (phase-of container "b"))
-                           "still reading :unmounting, still awaiting its timeout")
-                       (is (= 1 (presence-rt/pending-count))
-                           "its exit is still pending")
-                       (cleanup! container mounted)
-                       (done)))))))))
+        (is (= :rf.adapter/freehand (seat! v/adapter))
+            "this arm runs on a pure Freehand process")
+        (no-step-control-arm! retain-via-subscription! done)))))
+
+(deftest the-props-driven-fixture-behaves-the-same-on-a-freehand-process
+  (testing "The PARITY control for the Reagent seating below: the identical
+            props-driven fixture, under `v/adapter`. It is what makes the
+            seated adapter the only variable between the two green arms — a
+            Reagent red could otherwise be blamed on the re-mount fixture
+            rather than on the boundary the bridge settles at."
+    (if-not (browser?)
+      (skip! "the browser job runs the removal assertion")
+      (async done
+        (is (= :rf.adapter/freehand (seat! v/adapter))
+            "this arm runs on a pure Freehand process")
+        (flush-presence-arm! retain-via-props! done)))))
+
+;; ===========================================================================
+;; Seating 2 — THE SHIPPED STORY TOPOLOGY (rf2-gzmg0, merged-PR audit #7037)
+;; ===========================================================================
+
+(deftest a-flush-presence-step-removes-the-child-under-the-shipped-story-adapter
+  (testing "The SAME proof under the adapter Story actually ships. Every Story
+            testbed seats `re-frame.adapter.reagent/adapter`; a Freehand
+            variant then mounts inside that Reagent process. Reagent's
+            `:flush-render!` is `(fn [f] (f) (reagent.core/flush))`, which
+            drains Reagent's own queues and — with no Reagent component dirty,
+            which a presence removal never makes one — never enters
+            `react-dom/flushSync`. A bridge that settled through the PROCESS
+            adapter therefore returns with the retained child still painted
+            and the clock already reporting zero pending: green clock over
+            stale DOM, the one failure this rung exists to exclude. This arm
+            is what fails when the bridge reaches for the dispatched
+            `flush-render!` instead of Freehand's own."
+    (if-not (browser?)
+      (skip! "the browser job runs the removal assertion")
+      (async done
+        (is (= :rf.adapter/reagent (seat! reagent-adapter/adapter))
+            "this arm runs on the SHIPPED Story topology — Reagent seated,
+             Freehand root mounted inside it")
+        (flush-presence-arm! retain-via-props! done)))))
+
+(deftest without-the-step-the-child-stays-under-the-shipped-story-adapter
+  (testing "The negative control for the Reagent seating, so its green cannot
+            be an artefact of the mixed-adapter mount."
+    (if-not (browser?)
+      (skip! "the browser job runs the retention assertion")
+      (async done
+        (is (= :rf.adapter/reagent (seat! reagent-adapter/adapter))
+            "this arm runs on the SHIPPED Story topology")
+        (no-step-control-arm! retain-via-props! done)))))
 
 ;; ===========================================================================
 ;; Non-vacuity
 ;; ===========================================================================
 
-(deftest the-bridge-is-installed-by-requiring-it
-  (testing "Non-vacuity, and the claim the whole rung rests on: merely
-            REQUIRING `re-frame.story.play.presence-host` installs the
-            `:flush-presence!` hook. A suite whose bridge never loaded would
-            report `:cannot-run` above rather than a removal, so pin the
-            install here where the failure names itself."
+(deftest the-bridge-arms-the-seam
+  (testing "Non-vacuity, and the claim the whole rung rests on: the bridge
+            arms the `:flush-presence!` seam, and a `[:flush-presence]` step
+            reaches THAT fn. A suite whose bridge never loaded would report
+            `:cannot-run` above rather than a removal, so pin the install
+            here where the failure names itself.
+
+            `install!` is the same call the namespace makes at LOAD time (a
+            bare `:require` is the whole integration); it is called
+            explicitly because `teardown!` drops the hook between tests so
+            this suite cannot leak a presence host into the consolidated
+            bundle."
+    (presence-host/install!)
+    (is (some? (story-presence/presence-flush-fn))
+        "the bridge armed the seam the run loop reads")
     (is (some? (late-bind/get-fn :flush-presence!))
-        "the load-time install armed the hook")))
+        "under the documented hook key")))


### PR DESCRIPTION
# The presence bridge settles at Freehand's own commit boundary (rf2-gzmg0)

## The ruling this executes, verbatim

> *"But xray and story should not be using the donor, they should be across onto freehand"*
> *"We intend to remove the donor (re-frame.ui)"*

`rf2-drpa3.57` (F6e) deletes `implementation/ui/` wholesale, so a tool still reading it depends on an artefact scheduled for deletion. The crossing itself landed in #7037. This closes the **one residual** the merged-PR audit of that PR reopened the bead for.

---

## The residual, and what was wrong

The crossing's mounted proof seated `(rf/init! v/adapter)` explicitly. **Every shipped Story testbed seats `re-frame.adapter.reagent/adapter`** — `tools/story/testbeds/counter_with_stories/core.cljs:75`, `.../story_static.cljs:39`, `tools/story/testbeds/login_form/core.cljs:82` — because Story's own shell is a Reagent application, and a Freehand variant mounts inside that process.

The bridge advanced the clock inside `re-frame.substrate.adapter/flush-render!`, core's adapter-**dispatched** commit. Under Reagent that resolves to `(fn [f] (f) (reagent.core/flush))` (`implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs:38`): it runs the thunk bare, then drains Reagent's before-flush / ratom / component / after-render queues. A presence removal makes **no** Reagent component dirty — `PresenceComponent`'s `remove-key!` calls a plain React `useState` setter inside the Freehand root (`implementation/freehand/src/re_frame/freehand/presence_runtime.cljc`, the `force!` in the commit effect) — so the drain never enters `react-dom/flushSync`, and it never closes Freehand's ViewCell window either.

So the verb returned, `pending-count` was already zero, and the retained child was still on the page. Green clock over stale DOM: the exact failure the rung exists to exclude, under the only topology a Story user gets.

## Which outcome, and why

The audit named two legitimate outcomes: fix the boundary, or fail loud and document a real adapter restriction. **Fixed the boundary**, and the measurement is what decided it — a documented restriction would only have been honest if a mixed Story+Freehand process genuinely could not settle, and it can. The commit that has to happen is a commit of a **Freehand** root, so the boundary that closes it is Freehand's.

```clojure
(def ^:private freehand-commit! (:flush-render! v/adapter))

(defn- advance-and-commit! [ms]
  (freehand-commit! #(advance-clock! ms))
  nil)
```

`v/adapter` is public and `:flush-render!` is the Spec 006 contract slot name, so no new verb and no manifest movement. The fn it resolves to (`re-frame.freehand.substrate/flush-render!`) is adapter-state-free by construction: it stands on `react-dom/flushSync`, the module-global ViewCell registry and core's router-state drain guard, none of which consult the installed adapter. Under `v/adapter` it is byte-identical to what the dispatch found before.

It also **retires** the bridge's headless special case rather than adding to it. `flush-render!` is an optional contract fn and plain-atom ships none, so the dispatched call used to run nothing and the bridge re-ran the advance outside the boundary to compensate, guarded by a `volatile!`. Freehand always ships the slot: one advance, one boundary, one path on every host.

Nothing under `implementation/**` changed.

---

## Red, fix, green

Proof standard: a test that is merely ADDED is not a test that CATCHES. So the new arm was driven **against the unfixed bridge first**, from the `worker/story-bridge-gzmg0` worktree, `implementation/shadow-cljs.edn` temporarily narrowed to this one namespace for the iteration loop (restored before commit — the diff touches no build config).

### RED — bridge unfixed, `git checkout HEAD -- .../presence_host.cljc` verified (`grep` for `substrate/flush-render!` back in the source)

```
Testing re-frame.story.play.presence-freehand-dom-cljs-test

FAIL in (a-flush-presence-step-removes-the-child-under-the-shipped-story-adapter)
  the SHIPPED bridge RETURNED with the Freehand DOM settled: …
  expected: (true? (deref gone-at-verb-return))
    actual: (not (true? false))

FAIL in (a-flush-presence-step-removes-the-child-under-the-shipped-story-adapter)
  the retained child LEFT THE DOM: …
  expected: (nil? (toast-el container "b"))
    actual: (not (nil? #object[HTMLDivElement [object HTMLDivElement]]))

Ran 6 tests containing 50 assertions.
2 failures, 0 errors.        EXIT=1
```

Two failures, **both in the Reagent arm and nowhere else**. The two `v/adapter` subscription arms, the `v/adapter` props parity arm, the Reagent no-step control and the non-vacuity test all stayed green — so the red is attributable to the seated adapter and not to the fixture.

### GREEN — same tests, fix applied

```
Browser tests: Ran 6 tests containing 50 assertions. 0 failures, 0 errors.        EXIT=0
```

### The mutation actually applied

`git apply` / `git checkout` were confirmed each way with `git diff --stat` **and** by grepping the mutated token back out of the source before reading a verdict.

## What the new arms read, and why there are two reads

`gone-at-verb-return` is the tight one. It snapshots `document` at the instant the shipped host verb returns, through a **passthrough wrapper** around the verb the bridge itself registered — so it measures the bridge's own stated law (*advance the presence clock and return with the DOM settled*) at exactly the boundary that law names. The dispatch is not hand-written: the step still travels `re/run!` → `run-loop!` → `presence/advance!` → the wrapper → the shipped bridge, and the wrapper hands the verb's return value straight back.

The read in the run callback is the audit's literal observable and it caught the defect too. It is kept as the looser of the two rather than relied on: the run loop yields a `setTimeout` 0 after a `:flush-presence` step (`runner/async-yield-step-types`), and React's scheduler task is a macrotask that could win that race on another engine.

## Preserved, not replaced

The `v/adapter` proof (both arms, subscription-driven) and the headless `(browser?)` fallback are untouched — every arm still self-gates and says so under `:node-test` rather than passing quietly. A third `v/adapter` arm was **added** as the parity control (see below).

---

## A separate, wider defect this measurement surfaced

**A Freehand view's SUBSCRIPTION reads are inert on the ratom substrates.**

Core's observation port activates a derived value by adding a watch and dereferencing it — `build-node-handle!` in `implementation/core/src/re_frame/substrate/observation.cljc:1959`, whose comment reads *"a watched reaction is live on the reactive hosts, so the observe below reads through the activated node"*. That does not hold for stock Reagent. `add-watch` on a `Reaction` is `add-w`, which only assoc's into `watches`; and `Reaction`'s `-deref` outside `*ratom-context*` with no `:auto-run` takes its non-reactive branch and recomputes `(f)` **without** `deref-capture`, so `watching` stays nil and `_handle-change` is never called. The reaction never notifies, and the ViewCell it feeds is never marked dirty. `make-derived-value` for the ratom family is a plain `(make-reaction …)` with no `:auto-run` (`implementation/core/src/re_frame/substrate/spine.cljs`).

Measured directly, under Reagent with a `(v/sub …)`-driven boundary:

```
DIAG toaster render ids: nil
DIAG after bare dispatch-sync html: <div id="story-presence-stack"></div> cell-pending: 0
DIAG after substrate/flush-render! html: <div id="story-presence-stack"></div> cell-pending: 0
DIAG after freehand-commit!       html: <div id="story-presence-stack"></div>
DIAG after microtask              html: <div id="story-presence-stack"></div>
DIAG after macrotask              html: <div id="story-presence-stack"></div>
```

One render, ever. The same fixture under `v/adapter` renders three times. This matters beyond this bead: Spec 006's stated rationale for Freehand owning an adapter is that plain-atom's derived value is not `IWatchable` while the spine's is — but being `IWatchable` turns out to be necessary and not sufficient, and Reagent's `Reaction` satisfies the letter of that test while never notifying.

It is upstream of Story and outside this bead's surface (core's observation port / the ratom spine), so it is **filed, not fixed here**. It is also why the Reagent arms build their retained child through **props** — re-mounting the same root-id into the same container, the idempotent-per-root re-render `v/mount` documents — rather than through a subscription. `the-props-driven-fixture-behaves-the-same-on-a-freehand-process` runs that identical fixture under `v/adapter`, so the seated adapter is the only variable between the two green arms.

---

## Files

| file | what |
|---|---|
| `tools/story/src/re_frame/story/play/presence_host.cljc` | the fix; `substrate/flush-render!` → `(:flush-render! v/adapter)`; the `volatile!` headless compensation retired; docstring §*Why FREEHAND's boundary and not the PROCESS adapter's* |
| `tools/story/test/re_frame/story/play/presence_freehand_dom_cljs_test.cljs` | 3 new arms (Reagent step, Reagent control, `v/adapter` props parity), the verb-return probe, adapter-kind pins on every arm |
| `tools/story/spec/017-Testing-Story.md` | §Presence-bearing variants: the bridge's boundary respelled, with the new §*Freehand's boundary, not the process adapter's* |

Not touched, per the brief's fences: `tools/xray/**`, `examples/**`, `spec/conformance/freehand/donor-inventory.md`, and the ER-08 sub-override / mounted-test-facade work that stays with `rf2-drpa3.182.7`.

## Quality gates

See the section below; anything still running at the time of opening is stated as reliance-on-CI.
