### PR TITLE
freehand: the executable fixture spine — one roster record per law (rf2-drpa3.182.7)

### DIFF
--- a/implementation/freehand/test/re_frame/freehand/behavior_async_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/behavior_async_dom_cljs_test.cljs
@@ -15,6 +15,25 @@
   substrate already carries, writes the one recipe they imply, and mounts it
   against a DETERMINISTIC surrogate host so the answer is reproducible:
 
+  ## The law this file proves — FH-BEHAVIOR-005
+
+  Adding no law means having none of its own, and for a while that left
+  this file with no identity: it was reachable from the guide and from the
+  bead that commissioned it, and from no ledger. It is rostered
+  (rf2-drpa3.182.7) as the SECOND mounted projection of `FH-BEHAVIOR-005` —
+  teardown releases a behavior totally, `:disconnect` exactly once per
+  committed connection, both substrate books empty afterwards — because
+  that is precisely the law the cases below stress. `behaviors-dom-cljs-test`
+  proves it on the ordinary synchronous path; this file proves the same law
+  where it is hardest, with the handle arriving from a Promise after the
+  owner may already be gone.
+
+  Minting a `FH-…` id of its own was considered and declined: a second id
+  for one law splits the identity the roster exists to keep single, and an
+  id must resolve to a paragraph of normative spec — which a recipe that
+  adds no contract does not have.
+  See `spec/conformance/freehand/fixtures/fh-behavior-005.edn`.
+
     THE MEMORY LAW (rf2-wj1ao)  `:connect` ESTABLISHES the connection's
                                 private memory and nothing else ever writes
                                 it. So when the handle is not ready yet,

--- a/implementation/freehand/test/re_frame/freehand/roster.cljc
+++ b/implementation/freehand/test/re_frame/freehand/roster.cljc
@@ -240,16 +240,14 @@
                              (pr-str evidence))))
 
           ;; An `:open` entry is keyed by the bead that owns the question,
-          ;; because "unsettled" without an owner is a shrug. The key is a
-          ;; symbol so it survives EDN as one token and reads as the bead
-          ;; id it is.
+          ;; because "unsettled" without an owner is a shrug.
           (and (map? rec) (contains? present :open)
                (not (and (map? open)
                          (seq open)
-                         (every? symbol? (keys open))
+                         (every? keyword? (keys open))
                          (every? (every-pred string? seq) (vals open)))))
           (conj (defect id :open
-                        (str "records each unsettled boundary as <owning-bead-symbol> "
+                        (str "records each unsettled boundary as <owning-bead-keyword> "
                              "-> one line stating the question; got " (pr-str open))))
 
           (and (map? rec) (empty? named))
@@ -261,18 +259,50 @@
           :always
           (into (mapcat (fn [[tier entry]] (tier-defects id tier entry)) named)))))))
 
+(def ^:private tier-hosts
+  "The hosts a proof tier can possibly run on. A tier claim is checked
+  against the index row's own host axis, which is the one cross-file law
+  the join can state without inventing one: a record cannot advertise a
+  browser proof for a law the ledger says binds only on the JVM.
+
+  `:structural` admits both because the structural walk is the one tier
+  that genuinely runs on either host from a single `.cljc`."
+  {:structural #{:jvm :browser}
+   :mounted    #{:browser}
+   :ssr        #{:ssr}})
+
+(defn- join-defects
+  "The defects that are properties of the JOIN — a record read against the
+  index row that addresses it.
+
+  Only one law is stated here, and deliberately only one. It is tempting to
+  also require that a fixture's `:fh/law` match its index row's word for
+  word, and that would be wrong: the two say the same law at different
+  lengths on purpose — the index row is the addressed one-line statement, a
+  fixture's `:fh/law` is the header over the values below it — and every
+  row in the ledger is written that way. Gating equality would force a
+  hundred prose rewrites to satisfy a law the corpus never held.
+
+  What IS checkable is that a record does not claim a tier the ledger's
+  host axis rules out."
+  [{id :fh/id :keys [hosts fh/record]}]
+  (when (and (map? record) (set? hosts))
+    (keep (fn [[t possible]]
+            (when (and (contains? record t)
+                       (empty? (set/intersection hosts possible)))
+              (defect id t
+                      (str "claims a " (name t) " proof, but the index row binds "
+                           "this law to " (pr-str (sort-by str hosts))
+                           " — that tier can only run on "
+                           (pr-str (sort-by str possible)) "."))))
+          tier-hosts)))
+
 (defn roster-defects
   "Every defect across `records`, plus the two that are properties of the
-  ROSTER rather than of any one record: a duplicated `:fh/id`, and a
-  fixture whose `:fh/law` disagrees with the index row that addresses it.
+  ROSTER rather than of any one record: a duplicated `:fh/id`, and a record
+  claiming a proof tier its index row's host axis rules out.
 
-  The law comparison is what keeps the join honest. The index states each
-  law in one line and the fixture states it again; before the roster,
-  nothing compared them, so a fixture could be broadened while its index
-  row went on advertising the narrow claim. Whitespace is normalised before
-  the compare — the index row is one physical table line and a fixture
-  string may be wrapped — but nothing else is: a reworded law is a real
-  divergence and the point is to catch it."
+  The failure value is a flat vector of defect maps, each naming its law."
   [records]
   (let [dupes (->> records
                    (map :fh/id)
@@ -283,14 +313,7 @@
                        (defect id :fh/id (str "appears " n " times in the roster; "
                                               "an id addresses exactly one law")))
                      dupes))
-          (keep (fn [{:keys [fh/id fh/law index/law]}]
-                  (let [squash #(some-> % str/trim (str/replace #"\s+" " "))]
-                    (when (and law index/law (not= (squash law) (squash index/law)))
-                      (defect id :fh/law
-                              (str "states its law differently from the index row "
-                                   "that addresses it.\n    fixture: " (squash law)
-                                   "\n    index:   " (squash index/law))))))
-                records))))
+          (mapcat join-defects records))))
 
 ;; ---------------------------------------------------------------------------
 ;; Reading the two files — JVM only, at macro-expansion time

--- a/implementation/freehand/test/re_frame/freehand/roster.cljc
+++ b/implementation/freehand/test/re_frame/freehand/roster.cljc
@@ -155,7 +155,7 @@
   [id field detail]
   {:fh/id id :field field :detail detail})
 
-(defn- tier-defects
+(defn- entry-defects
   [id tier entry]
   (let [{:keys [ns law]} entry]
     (cond-> []
@@ -174,6 +174,24 @@
       (conj (defect id tier (str "carries a key outside #{:ns :law}: "
                                  (pr-str (sort (set/difference (set (keys entry))
                                                                #{:ns :law})))))))))
+
+(defn- tier-defects
+  "A tier's value is always a NON-EMPTY VECTOR of entries, never a bare
+  entry. One projection is the common case and two is not exotic — the
+  deferred foreign-handle surrogate is a second mounted projection of the
+  same total-release law — so the shape that admits both without a special
+  case is the vector, uniformly. A bare map would make the reader ask which
+  shape they were looking at every time."
+  [id tier entries]
+  (if-not (and (vector? entries) (seq entries))
+    [(defect id tier (str "a tier is a NON-EMPTY VECTOR of {:ns … :law …} "
+                          "entries — one per projection that proves this law "
+                          "at this tier; got " (pr-str entries)))]
+    (into (vec (mapcat #(entry-defects id tier %) entries))
+          (let [nss (map :ns entries)]
+            (when (not= (count nss) (count (distinct nss)))
+              [(defect id tier (str "names the same namespace twice: "
+                                    (pr-str (vec nss))))])))))
 
 (defn defects
   "Every defect in `record`, as a vector — empty when the record is sound.
@@ -257,7 +275,7 @@
                              "nowhere is prose.")))
 
           :always
-          (into (mapcat (fn [[tier entry]] (tier-defects id tier entry)) named)))))))
+          (into (mapcat (fn [[tier entries]] (tier-defects id tier entries)) named)))))))
 
 (def ^:private tier-hosts
   "The hosts a proof tier can possibly run on. A tier claim is checked
@@ -441,7 +459,20 @@
      (first (filter #(= id (:fh/id %)) records)))))
 
 (defn tier
-  "The `{:ns … :law …}` entry `record` declares for `tier`, or nil when the
-  record names no proof at that tier."
+  "The vector of `{:ns … :law …}` entries `record` declares for `tier` —
+  empty when the record names no proof at that tier.
+
+  Empty rather than nil, so a caller folds over the result without asking
+  whether the tier was declared. `(seq (tier record :mounted))` is the
+  question 'is this law proven in a browser at all'."
   [record tier]
-  (get-in record [:fh/record tier]))
+  (get-in record [:fh/record tier] []))
+
+(defn proofs
+  "Every proof `record` declares, as `{:tier … :ns … :law …}` maps in tier
+  order. The projection a checker folds over when the question is about
+  proofs rather than about one tier."
+  [record]
+  (for [t    [:structural :mounted :ssr]
+        e    (tier record t)]
+    (assoc e :tier t)))

--- a/implementation/freehand/test/re_frame/freehand/roster.cljc
+++ b/implementation/freehand/test/re_frame/freehand/roster.cljc
@@ -1,0 +1,402 @@
+(ns re-frame.freehand.roster
+  "The Freehand FIXTURE ROSTER — one record per executable law, joined from
+  the two files that already describe it, so a claim has ONE identity.
+
+  ## The problem the roster solves
+
+  A Freehand law is already addressed twice. The conformance index
+  ([`spec/conformance/freehand/conformance-index.md`](../../../../../spec/conformance/freehand/conformance-index.md))
+  rows its id, its one-line statement, the canonical spec paragraph it
+  cites, the modes and hosts it binds, and its status. The fixture
+  (`spec/conformance/freehand/fixtures/<id>.edn`) carries the VALUES the
+  law is proven by. Neither says which source implements it, which mounted
+  suite is its browser entry, what evidence a run should leave, or whether
+  the prose that describes it is executable.
+
+  Those four are what a reader has to reconstruct by hand today, and a
+  reconstruction is not an identity: a fixture can be renamed, a mounted
+  suite deleted, or a guide paragraph left describing behaviour nothing
+  runs, and no projection notices. The roster closes that by making the
+  missing four DECLARED — on the fixture, under `:fh/record` — and then
+  JOINING the fixture with its index row into one value.
+
+  ## No new store
+
+  The record lives ON THE FIXTURE rather than in a roster file, on purpose.
+  A third file describing the same law would be a third thing to keep in
+  step; the fixture is already the file a slice edits when its law changes,
+  and it already carries `:fh/id`. So the roster adds a field to a record
+  that exists rather than a record to a directory.
+
+  The join is likewise a READ, not a copy. `:modes`, `:hosts`, `:status`
+  and `:paragraph` are parsed out of the index row at macro-expansion time
+  and are never restated in the fixture — and [[defects]] fails a fixture
+  whose `:fh/law` disagrees with the index's, so the two files cannot drift
+  apart quietly.
+
+  ## Failures name the id
+
+  Every value this namespace answers — a record, a defect, a projection
+  mismatch — carries `:fh/id`. That is acceptance 1 of rf2-drpa3.182.7 made
+  mechanical: a red row is attributable to its law without a lookup, in
+  every projection, rather than reporting a line number in a file whose
+  name a reader then has to decode.
+
+  ## Cross-host
+
+  ClojureScript cannot read a file at runtime, so the roster is read at
+  MACRO-EXPANSION time — on the JVM for both hosts — through
+  `re-frame.build.spec-resource`, exactly as
+  [[re-frame.freehand.conformance/fixture]] reads a fixture and for the
+  same cache-invalidation reason. The JVM suite and the ClojureScript suite
+  therefore project the same bytes.
+
+  Dev/test scope ONLY. This namespace lives under `test/` and nothing in a
+  production bundle may reach it."
+  #?(:clj (:require [clojure.edn :as edn]
+                    [clojure.set :as set]
+                    [clojure.string :as str]
+                    [re-frame.build.spec-resource :as spec-resource])
+     :cljs (:require [clojure.set :as set]
+                     [clojure.string :as str]))
+  #?(:cljs (:require-macros [re-frame.freehand.roster :refer [roster]])))
+
+;; ---------------------------------------------------------------------------
+;; The record vocabulary — closed, because an open one is a comment
+;; ---------------------------------------------------------------------------
+
+(def prose-statuses
+  "What the PROSE describing a law claims, per the rf2-drpa3.182.7 fixture
+  record. Closed:
+
+    `:executable`        the prose describes behaviour a suite runs, and the
+                         code it shows is checked against canonical source.
+    `:expected-failure`  the prose describes a refusal — the run proves the
+                         diagnostic, not the success.
+    `:illustrative`      the prose is a sketch and makes NO executable claim;
+                         it is labelled as such where it appears.
+
+  A record must pick one. `:illustrative` is the honest answer for a
+  paragraph nothing runs, and saying so is what stops a reader treating a
+  sketch as a contract."
+  #{:executable :expected-failure :illustrative})
+
+(def tiers
+  "The tiers a record may name a proof site in. Each is a real lane, not a
+  label: `:structural` runs headlessly on both hosts through
+  [[re-frame.freehand.test/render]], `:mounted` runs in Chromium against a
+  real `react-dom/client` commit, `:ssr` runs the JVM tree to HTML."
+  #{:structural :mounted :ssr})
+
+(def record-keys
+  "The closed key set of `:fh/record`. A key outside it is a defect rather
+  than ignored data — an unknown key is almost always a typo for a real
+  one, and silently dropping it is how a record stops describing its law."
+  #{:source :structural :mounted :ssr :evidence :prose})
+
+(def ^:private required-record-keys
+  "Every record names its canonical source and its prose status. The tier
+  entries are optional because a law that binds only on one tier should say
+  so by omission rather than by an empty placeholder — but [[defects]]
+  requires at least one tier, so a record cannot claim a law is executable
+  and name nowhere it executes."
+  #{:source :prose})
+
+;; ---------------------------------------------------------------------------
+;; Applicability — the index's two-axis cell, as data
+;; ---------------------------------------------------------------------------
+
+(def ^:private mode-tokens
+  "The mode axis: exactly one token per the index's applicability grammar."
+  {"common"      #{:interpreted :compiled}
+   "interpreted" #{:interpreted}
+   "compiled"    #{:compiled}})
+
+(def ^:private host-tokens
+  "The unqualified host axis. `host:<name>` is admitted separately."
+  {"jvm" :jvm "browser" :browser "ssr" :ssr})
+
+(defn parse-applicability
+  "Parse an index applicability cell — `common jvm browser`, `compiled
+  browser`, `common host:vega` — into `{:modes #{…} :hosts #{…}}`.
+
+  A qualified host reads as `[:host \"vega\"]` so the name survives; the
+  roster is not the place to decide what a qualified boundary means. An
+  unparseable cell answers `nil` rather than a partial map, so a caller
+  reports the cell verbatim instead of asserting against a guess."
+  [cell]
+  (let [tokens (remove str/blank? (str/split (str/trim (or cell "")) #"\s+"))
+        modes  (keep mode-tokens tokens)
+        hosts  (keep (fn [t]
+                       (or (host-tokens t)
+                           (when (str/starts-with? t "host:")
+                             [:host (subs t 5)])))
+                     tokens)]
+    (when (and (= 1 (count modes))
+               (seq hosts)
+               (= (count tokens) (+ (count modes) (count hosts))))
+      {:modes (first modes)
+       :hosts (set hosts)})))
+
+;; ---------------------------------------------------------------------------
+;; Validation — pure, cross-host, and every defect names the id
+;; ---------------------------------------------------------------------------
+
+(defn- defect
+  [id field detail]
+  {:fh/id id :field field :detail detail})
+
+(defn- tier-defects
+  [id tier entry]
+  (let [{:keys [ns law]} entry]
+    (cond-> []
+      (not (map? entry))
+      (conj (defect id tier (str "a tier entry is a map of :ns and :law; got "
+                                 (pr-str entry))))
+
+      (and (map? entry) (not (symbol? ns)))
+      (conj (defect id tier (str "names its proof namespace as a SYMBOL, so a "
+                                 "checker can resolve it; got " (pr-str ns))))
+
+      (and (map? entry) (not (and (string? law) (seq law))))
+      (conj (defect id tier "states the law this tier proves, in one line"))
+
+      (and (map? entry) (seq (set/difference (set (keys entry)) #{:ns :law})))
+      (conj (defect id tier (str "carries a key outside #{:ns :law}: "
+                                 (pr-str (sort (set/difference (set (keys entry))
+                                                               #{:ns :law})))))))))
+
+(defn defects
+  "Every defect in `record`, as a vector — empty when the record is sound.
+
+  Each entry is `{:fh/id … :field … :detail …}`. The id is on EVERY entry,
+  including the ones about a missing id, so a report can be grouped by law
+  without a lookup and a failure message reads as a sentence about a law
+  rather than about a map.
+
+  Total over garbage: a record that is not a map, or carries no id, answers
+  a defect rather than throwing. A validator that throws on the input it
+  exists to reject reports the first defect and hides the rest."
+  [record]
+  (let [id (:fh/id record)]
+    (cond
+      (not (map? record))
+      [(defect nil :record (str "a roster record is a map; got " (pr-str record)))]
+
+      (not (and (string? id) (seq id)))
+      [(defect nil :fh/id (str "a roster record carries its :fh/id; got " (pr-str id)))]
+
+      :else
+      (let [{:keys [source prose evidence] :as rec} (:fh/record record)
+            present (set (keys rec))
+            named   (select-keys rec tiers)]
+        (cond-> []
+          (not (map? rec))
+          (conj (defect id :fh/record
+                        (str "carries a :fh/record map naming its canonical "
+                             "source, its proof tiers, its evidence expectation "
+                             "and its prose status; got " (pr-str rec))))
+
+          (and (map? rec) (seq (set/difference present record-keys)))
+          (conj (defect id :fh/record
+                        (str "carries a key outside the closed record set "
+                             (pr-str (sort record-keys)) ": "
+                             (pr-str (sort (set/difference present record-keys))))))
+
+          (and (map? rec) (seq (set/difference required-record-keys present)))
+          (conj (defect id :fh/record
+                        (str "omits a required key: "
+                             (pr-str (sort (set/difference required-record-keys present))))))
+
+          (and (map? rec) (contains? present :source)
+               (not (and (vector? source)
+                         (seq source)
+                         (every? symbol? source))))
+          (conj (defect id :source
+                        (str "names its canonical source as a non-empty vector of "
+                             "namespace SYMBOLS — the implementation the law is a "
+                             "law ABOUT, so a reader reaches it without a search; got "
+                             (pr-str source))))
+
+          (and (map? rec) (contains? present :prose)
+               (not (contains? prose-statuses prose)))
+          (conj (defect id :prose
+                        (str "declares one of " (pr-str (sort prose-statuses))
+                             "; got " (pr-str prose))))
+
+          (and (map? rec) (contains? present :evidence)
+               (not (and (map? evidence) (seq evidence))))
+          (conj (defect id :evidence
+                        (str "states its evidence expectation as a non-empty map; got "
+                             (pr-str evidence))))
+
+          (and (map? rec) (empty? named))
+          (conj (defect id :fh/record
+                        (str "names no proof tier. A record must name at least one "
+                             "of " (pr-str (sort tiers)) " — a law that executes "
+                             "nowhere is prose.")))
+
+          :always
+          (into (mapcat (fn [[tier entry]] (tier-defects id tier entry)) named)))))))
+
+(defn roster-defects
+  "Every defect across `records`, plus the two that are properties of the
+  ROSTER rather than of any one record: a duplicated `:fh/id`, and a
+  fixture whose `:fh/law` disagrees with the index row that addresses it.
+
+  The law comparison is what keeps the join honest. The index states each
+  law in one line and the fixture states it again; before the roster,
+  nothing compared them, so a fixture could be broadened while its index
+  row went on advertising the narrow claim. Whitespace is normalised before
+  the compare — the index row is one physical table line and a fixture
+  string may be wrapped — but nothing else is: a reworded law is a real
+  divergence and the point is to catch it."
+  [records]
+  (let [dupes (->> records
+                   (map :fh/id)
+                   frequencies
+                   (keep (fn [[id n]] (when (and id (> n 1)) [id n]))))]
+    (into (into (vec (mapcat defects records))
+                (map (fn [[id n]]
+                       (defect id :fh/id (str "appears " n " times in the roster; "
+                                              "an id addresses exactly one law")))
+                     dupes))
+          (keep (fn [{:keys [fh/id fh/law index/law]}]
+                  (let [squash #(some-> % str/trim (str/replace #"\s+" " "))]
+                    (when (and law index/law (not= (squash law) (squash index/law)))
+                      (defect id :fh/law
+                              (str "states its law differently from the index row "
+                                   "that addresses it.\n    fixture: " (squash law)
+                                   "\n    index:   " (squash index/law))))))
+                records))))
+
+;; ---------------------------------------------------------------------------
+;; Reading the two files — JVM only, at macro-expansion time
+;; ---------------------------------------------------------------------------
+
+#?(:clj
+   (def ^:private index-path
+     "conformance/freehand/conformance-index.md"))
+
+#?(:clj
+   (defn- fixture-path
+     [id]
+     (str "conformance/freehand/fixtures/" (str/lower-case id) ".edn")))
+
+#?(:clj
+   (defn- index-rows
+     "Every data row of the conformance index, keyed by id.
+
+     The index is a Markdown table and this is a table read, not a Markdown
+     parse: a data row is a line whose FIRST cell is a backticked `FH-…`
+     id. Header rows, separators, the row-shape template in the preamble
+     and every paragraph between sections all fail that test, so the reader
+     needs no section state and cannot be confused by one."
+     [text]
+     (into {}
+           (keep (fn [line]
+                   (when (str/starts-with? (str/triml line) "|")
+                     (let [cells (mapv str/trim (str/split line #"\|"))
+                           ;; A leading `|` makes cells[0] empty.
+                           cells (if (and (seq cells) (str/blank? (first cells)))
+                                   (subvec cells 1)
+                                   cells)]
+                       (when (>= (count cells) 6)
+                         (let [id (str/replace (nth cells 0) "`" "")]
+                           (when (re-matches #"FH-[A-Z]+-\d{3}" id)
+                             [id {:fh/id      id
+                                  :index/law  (nth cells 1)
+                                  :paragraph  (nth cells 2)
+                                  :index/cell (nth cells 3)
+                                  :status     (keyword (nth cells 5))}])))))))
+           (str/split-lines text))))
+
+#?(:clj
+   (defn ^:no-doc read-roster
+     "Join the fixtures for `ids` with their index rows, in the
+     macro-expansion environment `env`.
+
+     Throws when an id is absent from the index, when its fixture is
+     missing or misfiled, or when its applicability cell will not parse.
+     Those are COMPILE failures on purpose: a roster that quietly shrank to
+     the ids it could resolve would let a suite pass over a law it stopped
+     loading, which is the worst failure a table-driven gate can have."
+     [env ids]
+     (let [rows (index-rows (spec-resource/slurp-resource env index-path))]
+       (mapv (fn [id]
+               (let [id  (name id)
+                     row (or (get rows id)
+                             (throw (ex-info (str "Freehand roster: " id " is not a row of "
+                                                  index-path " — an id must be addressed "
+                                                  "before it can be rostered.")
+                                             {:fh/id id})))
+                     fix (edn/read-string
+                           (spec-resource/slurp-resource env (fixture-path id)))
+                     app (or (parse-applicability (:index/cell row))
+                             (throw (ex-info (str "Freehand roster: " id " has an "
+                                                  "unparseable applicability cell "
+                                                  (pr-str (:index/cell row)) ".")
+                                             {:fh/id id})))]
+                 (when-not (= id (:fh/id fix))
+                   (throw (ex-info (str "Freehand roster: fixture for " id " declares :fh/id "
+                                        (pr-str (:fh/id fix)) " — the file and the id disagree.")
+                                   {:fh/id id :declared (:fh/id fix)})))
+                 (merge (dissoc row :index/cell)
+                        app
+                        (select-keys fix [:fh/id :fh/law :fh/record]))))
+             ids))))
+
+#?(:clj
+   (defmacro roster
+     "Inline the joined roster records for `ids` as a quoted literal, read
+     at macro-expansion time.
+
+         (def spine (roster [:FH-REACT-007 :FH-CTRL-018 :FH-BEHAVIOR-005]))
+
+     Identical data on the JVM and in ClojureScript, and — in
+     ClojureScript — a build dependency of the calling namespace, so an
+     edit to the index or to any rostered fixture recompiles this call
+     site."
+     [ids]
+     (list 'quote (read-roster &env ids))))
+
+;; ---------------------------------------------------------------------------
+;; The spine — the members rf2-drpa3.182.7 integrates
+;; ---------------------------------------------------------------------------
+
+(def spine-ids
+  "The three vertical fixtures the initial spine integrates, per
+  rf2-drpa3.182.7 §INITIAL SPINE — the declared host, the serious form, and
+  the deferred foreign-handle surrogate.
+
+  The surrogate is rostered as `FH-BEHAVIOR-005` rather than under an id of
+  its own, and that is the point of it: the recipe adds no verb, no
+  scheduling policy and no contract, so it has no law to address. What it
+  is, is the MOUNTED PROJECTION of the total-cleanup law under a
+  Promise-returning third-party initializer — the shape where a release can
+  arrive after the owner is gone. Minting a second id for the same law
+  would have split one identity in exactly the way this roster exists to
+  prevent.
+
+  Named as data so a projection can assert enrolment. The roster grows for
+  Maps, Framer Motion, SpreadJS, Radix and the control witnesses as those
+  slices land; this vector is the seam they extend."
+  [:FH-REACT-007 :FH-CTRL-018 :FH-BEHAVIOR-005])
+
+(def spine
+  "The joined roster records for [[spine-ids]] — the value every projection
+  of the spine reads, on both hosts."
+  (roster [:FH-REACT-007 :FH-CTRL-018 :FH-BEHAVIOR-005]))
+
+(defn by-id
+  "The rostered record for `id` (a string or keyword), or nil."
+  ([id] (by-id spine id))
+  ([records id]
+   (let [id (name id)]
+     (first (filter #(= id (:fh/id %)) records)))))
+
+(defn tier
+  "The `{:ns … :law …}` entry `record` declares for `tier`, or nil when the
+  record names no proof at that tier."
+  [record tier]
+  (get-in record [:fh/record tier]))

--- a/implementation/freehand/test/re_frame/freehand/roster.cljc
+++ b/implementation/freehand/test/re_frame/freehand/roster.cljc
@@ -91,8 +91,17 @@
 (def record-keys
   "The closed key set of `:fh/record`. A key outside it is a defect rather
   than ignored data — an unknown key is almost always a typo for a real
-  one, and silently dropping it is how a record stops describing its law."
-  #{:source :structural :mounted :ssr :evidence :prose})
+  one, and silently dropping it is how a record stops describing its law.
+
+  `:open` is the one that is not about what a law proves. It records a
+  boundary of the law that is NOT settled, keyed by the bead that owns the
+  question — and it earns a slot because the alternative is worse. A
+  rostered expectation is a digest-pinned expectation: the moment a
+  projection asserts today's behaviour at an unsettled boundary, whoever
+  settles it has to fight the roster to land the fix. Naming the question
+  in the record makes the gap VISIBLE to a reader and to a checker, and
+  leaves the answer to the bead that owns it."
+  #{:source :structural :mounted :ssr :evidence :open :prose})
 
 (def ^:private required-record-keys
   "Every record names its canonical source and its prose status. The tier
@@ -187,7 +196,7 @@
       [(defect nil :fh/id (str "a roster record carries its :fh/id; got " (pr-str id)))]
 
       :else
-      (let [{:keys [source prose evidence] :as rec} (:fh/record record)
+      (let [{:keys [source prose evidence open] :as rec} (:fh/record record)
             present (set (keys rec))
             named   (select-keys rec tiers)]
         (cond-> []
@@ -229,6 +238,19 @@
           (conj (defect id :evidence
                         (str "states its evidence expectation as a non-empty map; got "
                              (pr-str evidence))))
+
+          ;; An `:open` entry is keyed by the bead that owns the question,
+          ;; because "unsettled" without an owner is a shrug. The key is a
+          ;; symbol so it survives EDN as one token and reads as the bead
+          ;; id it is.
+          (and (map? rec) (contains? present :open)
+               (not (and (map? open)
+                         (seq open)
+                         (every? symbol? (keys open))
+                         (every? (every-pred string? seq) (vals open)))))
+          (conj (defect id :open
+                        (str "records each unsettled boundary as <owning-bead-symbol> "
+                             "-> one line stating the question; got " (pr-str open))))
 
           (and (map? rec) (empty? named))
           (conj (defect id :fh/record

--- a/implementation/freehand/test/re_frame/freehand/roster_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/roster_cljs_test.cljc
@@ -79,25 +79,55 @@
 ;; The spine members' own shapes — what each vertical actually claims
 ;; ---------------------------------------------------------------------------
 
-(deftest each-spine-member-names-the-tier-its-vertical-lives-on
+(deftest each-spine-member-names-the-proofs-its-vertical-lives-on
   (testing "Per rf2-drpa3.182.7 acceptance 2: the three verticals run
             through the SAME roster rather than three pasted arrangements,
-            which is only meaningful if each names its tiers as data. Every
-            spine member declares both a headless structural entry and a
-            mounted browser entry, and each entry states the law THAT TIER
-            proves — the two are different claims and a record that gave
-            them one sentence would be describing neither."
+            which is only meaningful if each names its proofs as data. Every
+            spine member declares at least one, every proof states the law
+            it carries, and no two proofs of one law state the SAME law — a
+            record that gave two projections one sentence would be
+            describing neither."
     (doseq [{:keys [fh/id] :as record} roster/spine]
-      (doseq [t [:structural :mounted]]
-        (let [{:keys [ns law]} (roster/tier record t)]
-          (is (symbol? ns)
-              (str id " names its " (name t) " proof namespace"))
-          (is (seq law)
-              (str id " states what its " (name t) " tier proves"))))
-      (is (not= (:law (roster/tier record :structural))
-                (:law (roster/tier record :mounted)))
-          (str id " states DIFFERENT laws for its two tiers — a headless "
-               "walk and a real commit do not prove the same thing")))))
+      (let [ps (roster/proofs record)]
+        (is (seq ps) (str id " names at least one proof"))
+        (doseq [{:keys [tier ns law]} ps]
+          (is (symbol? ns) (str id " names its " (name tier) " proof namespace"))
+          (is (seq law)    (str id " states what " ns " proves")))
+        (is (= (count ps) (count (distinct (map :law ps))))
+            (str id " states a DIFFERENT law for each projection"))))))
+
+(deftest a-browser-only-law-declares-no-structural-proof
+  (testing "Per rf2-drpa3.182.7 acceptance 1: a record describes what is
+            there. FH-CTRL-018 opens 'In a real browser' and FH-BEHAVIOR-005
+            is only observable where a connection actually happened, so
+            neither has a structural tier — and the honest record is the one
+            that omits it. The kit's pure transitions and a behavior's inert
+            structural marker are both proven headlessly, but under
+            FH-CTRL-012..017 and FH-BEHAVIOR-003: different laws with their
+            own ids. A record that named those suites here would claim a
+            structural proof they never offer, which is the shape the JVM
+            resolution gate caught when this roster first ran."
+    (is (empty? (roster/tier (roster/by-id :FH-CTRL-018) :structural)))
+    (is (empty? (roster/tier (roster/by-id :FH-BEHAVIOR-005) :structural)))
+    (is (seq (roster/tier (roster/by-id :FH-REACT-007) :structural))
+        "while the three-plane split IS a headless claim, and says so")))
+
+(deftest one-law-may-carry-more-than-one-mounted-projection
+  (testing "Per rf2-drpa3.182.7 §INITIAL SPINE and its terminology note: the
+            deferred foreign-handle surrogate models a Promise-returning
+            third-party initializer, adds no verb, no runtime, no scheduling
+            policy and no contract — so it has no law of its own to address.
+            It is the SECOND mounted projection of the total-release law,
+            reached by the hardest route. A roster that could hold only one
+            projection per tier would have forced it to mint an id, and
+            splitting one law across two ids is exactly what this roster
+            exists to prevent."
+    (let [mounted (roster/tier (roster/by-id :FH-BEHAVIOR-005) :mounted)]
+      (is (= 2 (count mounted)))
+      (is (= '[re-frame.freehand.behaviors-dom-cljs-test
+               re-frame.freehand.behavior-async-dom-cljs-test]
+             (mapv :ns mounted))
+          "the ordinary synchronous path, then the same law under a Promise"))))
 
 (deftest a-browser-only-law-does-not-claim-the-jvm
   (testing "Per the index's applicability grammar: the modes and hosts on a
@@ -181,7 +211,7 @@
    :fh/law    "a probe law"
    :index/law "a probe law"
    :fh/record {:source     '[re-frame.freehand.probe]
-               :structural {:ns 're-frame.freehand.probe-cljs-test :law "headlessly"}
+               :structural [{:ns 're-frame.freehand.probe-cljs-test :law "headlessly"}]
                :prose      :executable}})
 
 (defn- one-defect
@@ -227,12 +257,20 @@
               (assoc-in sound [:fh/record :open] {:rf2-abc ""})             :open]
              ["no proof tier at all — a law that executes nowhere is prose"
               (update sound :fh/record dissoc :structural)                  :fh/record]
+             ["a tier given a bare entry rather than a vector of them"
+              (assoc-in sound [:fh/record :structural]
+                        {:ns 're-frame.freehand.probe-cljs-test :law "x"})  :structural]
+             ["a tier declared and left empty"
+              (assoc-in sound [:fh/record :structural] [])                  :structural]
              ["a tier naming its namespace as a string"
-              (assoc-in sound [:fh/record :structural :ns] "re-frame.x")    :structural]
-             ["a tier that states no law"
-              (update-in sound [:fh/record :structural] dissoc :law)        :structural]
-             ["a tier carrying a key outside #{:ns :law}"
-              (assoc-in sound [:fh/record :structural :when] :tuesdays)     :structural]]]
+              (assoc-in sound [:fh/record :structural 0 :ns] "re-frame.x")  :structural]
+             ["a tier entry that states no law"
+              (update-in sound [:fh/record :structural 0] dissoc :law)      :structural]
+             ["a tier entry carrying a key outside #{:ns :law}"
+              (assoc-in sound [:fh/record :structural 0 :when] :tuesdays)   :structural]
+             ["one tier naming the same namespace twice"
+              (update-in sound [:fh/record :structural]
+                         #(conj % (first %)))                               :structural]]]
       (let [d (one-defect broken)]
         (is (= "FH-PROBE-001" (:fh/id d)) (str note " — names the law"))
         (is (= field (:field d))          (str note " — names the field"))
@@ -274,8 +312,8 @@
             the corpus never held."
     (let [jvm-only (assoc sound :hosts #{:jvm}
                                :fh/record (assoc (:fh/record sound)
-                                            :mounted {:ns 're-frame.freehand.probe-dom-cljs-test
-                                                      :law "in a browser"}))
+                                            :mounted [{:ns 're-frame.freehand.probe-dom-cljs-test
+                                                       :law "in a browser"}]))
           ds       (roster/roster-defects [jvm-only])]
       (is (= 1 (count ds)))
       (is (= "FH-PROBE-001" (:fh/id (first ds))) "the tier defect names the law")
@@ -286,12 +324,12 @@
       (is (= [] (roster/roster-defects
                   [(assoc sound :hosts #{:browser}
                           :fh/record (assoc (:fh/record sound)
-                                       :mounted {:ns 're-frame.freehand.probe-dom-cljs-test
-                                                 :law "in a browser"}))]))))
+                                       :mounted [{:ns 're-frame.freehand.probe-dom-cljs-test
+                                                  :law "in a browser"}]))]))))
     (testing "an :ssr tier on a row that names no SSR host"
       (is (= [:ssr] (mapv :field
                           (roster/roster-defects
                             [(assoc sound :hosts #{:jvm :browser}
                                     :fh/record (assoc (:fh/record sound)
-                                                 :ssr {:ns 're-frame.freehand.probe-ssr-jvm-test
-                                                       :law "to HTML"}))])))))))
+                                                 :ssr [{:ns 're-frame.freehand.probe-ssr-jvm-test
+                                                        :law "to HTML"}]))])))))))

--- a/implementation/freehand/test/re_frame/freehand/roster_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/roster_cljs_test.cljc
@@ -1,0 +1,297 @@
+(ns re-frame.freehand.roster-cljs-test
+  "The fixture roster, projected — rf2-drpa3.182.7 acceptances 1 and 2.
+
+  The roster's claim is that a Freehand law has ONE identity across every
+  projection that mentions it, and that a failure NAMES that identity. This
+  file proves the halves of that which are pure data and therefore run
+  unchanged on both hosts: the spine is enrolled, every record is
+  well-formed against a closed vocabulary, the fixture and its index row
+  state the same law, and every defect a malformed record can produce
+  carries its `:fh/id`.
+
+  The half that needs a filesystem — that each declared source and proof
+  namespace is a file that exists — is `roster-jvm-test`'s. The half that
+  needs a browser is the mounted tier's own suites, which the records name.
+
+  ## Why the negative rows are here
+
+  A validator that has only ever run against input it passes has not been
+  tested, and a roster gate that could not fail is the most expensive kind
+  of green: it makes a reader believe the spine is checked. So every defect
+  shape below is DRIVEN — a record is broken one way at a time and the
+  defect it produces is asserted, including that it names the right law."
+  (:require [clojure.test :refer [deftest is testing]]
+            [re-frame.freehand.roster :as roster]))
+
+;; ---------------------------------------------------------------------------
+;; Enrolment — the spine is the three vertical fixtures, and it is complete
+;; ---------------------------------------------------------------------------
+
+(deftest the-spine-is-enrolled-and-nothing-loaded-empty
+  (testing "Per rf2-drpa3.182.7 §INITIAL SPINE: the declared host, the
+            serious form and the deferred foreign-handle surrogate are all
+            rostered, and each resolved to a real joined record. A roster
+            that quietly shrank to the ids it could resolve would let this
+            suite pass over a law it stopped loading — the worst failure a
+            table-driven gate has — so the COUNT is asserted alongside the
+            membership."
+    (is (= 3 (count roster/spine))
+        "three records, one per spine member")
+    (is (= #{"FH-REACT-007" "FH-CTRL-018" "FH-BEHAVIOR-005"}
+           (set (map :fh/id roster/spine)))
+        "and they are the three the spine names")
+    (doseq [id roster/spine-ids]
+      (is (some? (roster/by-id id))
+          (str (name id) " resolves to a rostered record")))))
+
+(deftest every-rostered-record-carries-its-whole-identity
+  (testing "Per rf2-drpa3.182.7 acceptance 1: one record answers every
+            question a reader has about a law — what states it, where it is
+            addressed, which modes and hosts it binds, which source
+            implements it, where it executes, what evidence a run leaves,
+            and whether the prose describing it is executable. Asserted
+            field by field rather than by a schema call, so a record that
+            lost one of them names WHICH."
+    (doseq [{id :fh/id law :fh/law index-law :index/law record :fh/record
+             :keys [paragraph modes hosts status]}
+            roster/spine]
+      (is (seq law)          (str id " states its law"))
+      (is (seq index-law)    (str id " is addressed by an index row"))
+      (is (seq paragraph)    (str id " cites a canonical spec paragraph"))
+      (is (seq modes)        (str id " binds at least one mode"))
+      (is (seq hosts)        (str id " binds at least one host"))
+      (is (= :active status) (str id " is an active law"))
+      (is (seq (:source record))
+          (str id " names the source it is a law about"))
+      (is (contains? roster/prose-statuses (:prose record))
+          (str id " declares the status of the prose describing it")))))
+
+(deftest the-roster-is-sound
+  (testing "Per rf2-drpa3.182.7 acceptance 1: the whole roster validates —
+            no malformed record, no duplicated id, and no fixture whose
+            `:fh/law` has drifted from the index row that addresses it. The
+            failure message is the defect list itself, so a red row reads as
+            a sentence about a law."
+    (let [ds (roster/roster-defects roster/spine)]
+      (is (= [] ds) (str "roster defects:\n" (pr-str ds))))))
+
+;; ---------------------------------------------------------------------------
+;; The spine members' own shapes — what each vertical actually claims
+;; ---------------------------------------------------------------------------
+
+(deftest each-spine-member-names-the-tier-its-vertical-lives-on
+  (testing "Per rf2-drpa3.182.7 acceptance 2: the three verticals run
+            through the SAME roster rather than three pasted arrangements,
+            which is only meaningful if each names its tiers as data. Every
+            spine member declares both a headless structural entry and a
+            mounted browser entry, and each entry states the law THAT TIER
+            proves — the two are different claims and a record that gave
+            them one sentence would be describing neither."
+    (doseq [{:keys [fh/id] :as record} roster/spine]
+      (doseq [t [:structural :mounted]]
+        (let [{:keys [ns law]} (roster/tier record t)]
+          (is (symbol? ns)
+              (str id " names its " (name t) " proof namespace"))
+          (is (seq law)
+              (str id " states what its " (name t) " tier proves"))))
+      (is (not= (:law (roster/tier record :structural))
+                (:law (roster/tier record :mounted)))
+          (str id " states DIFFERENT laws for its two tiers — a headless "
+               "walk and a real commit do not prove the same thing")))))
+
+(deftest a-browser-only-law-does-not-claim-the-jvm
+  (testing "Per the index's applicability grammar: the modes and hosts on a
+            record are READ from its index row, so the roster cannot widen a
+            claim the ledger narrowed. FH-CTRL-018 and FH-BEHAVIOR-005 are
+            `interpreted browser` rows — caret behaviour and a real
+            teardown are browser facts — while FH-REACT-007 is `common jvm
+            browser`, because the three-plane split happens once for both
+            emitters."
+    (is (= {:modes #{:interpreted} :hosts #{:browser}}
+           (select-keys (roster/by-id :FH-CTRL-018) [:modes :hosts])))
+    (is (= {:modes #{:interpreted} :hosts #{:browser}}
+           (select-keys (roster/by-id :FH-BEHAVIOR-005) [:modes :hosts])))
+    (is (= {:modes #{:interpreted :compiled} :hosts #{:jvm :browser}}
+           (select-keys (roster/by-id :FH-REACT-007) [:modes :hosts])))))
+
+(deftest an-unsettled-boundary-is-named-rather-than-pinned
+  (testing "Per rf2-drpa3.182.3 (open, from the merged-PR audit of #7081):
+            the `:map-props` key-set law — equality or output subset — is
+            not settled, so no rostered projection asserts either answer.
+            The record says so under `:open`, keyed by the bead that owns
+            the question. This row exists so that removing the note is a
+            deliberate act by whoever settles it, rather than a silent drift
+            back to an unmarked gap; it asserts the QUESTION is recorded and
+            asserts nothing about the answer."
+    (let [open (get-in (roster/by-id :FH-REACT-007) [:fh/record :open])]
+      (is (contains? open :rf2-drpa3.182.3)
+          "the host record names the bead that owns the naming boundary")
+      (is (re-find #"map-props" (get open :rf2-drpa3.182.3))
+          "and states which boundary is unsettled"))
+    (testing "and no other spine member is holding an open question"
+      (is (= [:FH-REACT-007]
+             (filterv #(seq (get-in (roster/by-id %) [:fh/record :open]))
+                      roster/spine-ids))))))
+
+;; ---------------------------------------------------------------------------
+;; Applicability parsing — the join's one piece of grammar
+;; ---------------------------------------------------------------------------
+
+(deftest applicability-parses-both-axes-and-refuses-a-cell-it-cannot-read
+  (testing "The index cell is two axes in one string, and the roster reads
+            it rather than restating it. An unreadable cell answers nil so a
+            caller reports the cell verbatim — a parser that guessed would
+            hand a suite a narrower claim than the ledger made and nothing
+            would notice."
+    (is (= {:modes #{:interpreted :compiled} :hosts #{:jvm :browser}}
+           (roster/parse-applicability "common jvm browser")))
+    (is (= {:modes #{:compiled} :hosts #{:browser}}
+           (roster/parse-applicability "compiled browser")))
+    (is (= {:modes #{:interpreted :compiled} :hosts #{[:host "vega"]}}
+           (roster/parse-applicability "common host:vega"))
+        "a qualified boundary keeps its name")
+    (is (= {:modes #{:interpreted :compiled} :hosts #{:jvm :browser :ssr}}
+           (roster/parse-applicability "  common   jvm browser ssr  ")))
+    (testing "and the refusals"
+      (is (nil? (roster/parse-applicability "jvm browser"))
+          "no mode token")
+      (is (nil? (roster/parse-applicability "common compiled jvm"))
+          "two mode tokens — the axis takes exactly one")
+      (is (nil? (roster/parse-applicability "common"))
+          "no host token")
+      (is (nil? (roster/parse-applicability "common jvm wombat"))
+          "a token on neither axis")
+      (is (nil? (roster/parse-applicability ""))))))
+
+;; ---------------------------------------------------------------------------
+;; FAILURES NAME THE LAW — acceptance 1's load-bearing half
+;; ---------------------------------------------------------------------------
+;;
+;; A roster whose failing assertion reported a line number would not have
+;; met acceptance 1. Each row below breaks a sound record ONE way and
+;; asserts both that the defect is raised and that it names the law it is
+;; about.
+
+(def ^:private sound
+  "A minimal record that validates — the control every negative row below
+  mutates. Deliberately not one of the real three: a negative suite that
+  edited a live record would prove things about that record's incidental
+  shape rather than about the vocabulary."
+  {:fh/id     "FH-PROBE-001"
+   :fh/law    "a probe law"
+   :index/law "a probe law"
+   :fh/record {:source     '[re-frame.freehand.probe]
+               :structural {:ns 're-frame.freehand.probe-cljs-test :law "headlessly"}
+               :prose      :executable}})
+
+(defn- one-defect
+  "The single defect `record` produces, or a marker naming what went wrong
+  instead. Answering the whole entry rather than a boolean is what lets a
+  row assert the id, the field AND the count in one place."
+  [record]
+  (let [ds (roster/defects record)]
+    (if (= 1 (count ds))
+      (first ds)
+      {::unexpected (vec ds)})))
+
+(deftest the-control-record-validates
+  (testing "NON-VACUITY for every negative row below. If the control were
+            already defective, each mutation would 'produce a defect'
+            without the mutation having anything to do with it."
+    (is (= [] (roster/defects sound)))))
+
+(deftest every-defect-names-the-law-it-is-about
+  (testing "Per rf2-drpa3.182.7 acceptance 1: a failing roster row is
+            attributable to its law without a lookup. Every defect shape is
+            driven, and each is asserted to carry the id — a roster that
+            reported `:field :prose` and left a reader to work out WHICH
+            law's prose is exactly the failure this acceptance names."
+    (doseq [[note broken field]
+            [["a key outside the closed record set"
+              (assoc-in sound [:fh/record :wombat] 1)                       :fh/record]
+             ["a missing required key"
+              (update sound :fh/record dissoc :source)                      :fh/record]
+             ["a source that is not a vector of namespace symbols"
+              (assoc-in sound [:fh/record :source] "re-frame.freehand")     :source]
+             ["an empty source vector — a law is about SOMETHING"
+              (assoc-in sound [:fh/record :source] [])                      :source]
+             ["a prose status outside the closed three"
+              (assoc-in sound [:fh/record :prose] :probably)                :prose]
+             ["an evidence expectation that is not a map"
+              (assoc-in sound [:fh/record :evidence] [:reads])              :evidence]
+             ["an empty evidence expectation — say nothing or say something"
+              (assoc-in sound [:fh/record :evidence] {})                    :evidence]
+             ["an :open entry not keyed by an owning bead"
+              (assoc-in sound [:fh/record :open] {"someone" "one day"})     :open]
+             ["an :open entry with no question stated"
+              (assoc-in sound [:fh/record :open] {:rf2-abc ""})             :open]
+             ["no proof tier at all — a law that executes nowhere is prose"
+              (update sound :fh/record dissoc :structural)                  :fh/record]
+             ["a tier naming its namespace as a string"
+              (assoc-in sound [:fh/record :structural :ns] "re-frame.x")    :structural]
+             ["a tier that states no law"
+              (update-in sound [:fh/record :structural] dissoc :law)        :structural]
+             ["a tier carrying a key outside #{:ns :law}"
+              (assoc-in sound [:fh/record :structural :when] :tuesdays)     :structural]]]
+      (let [d (one-defect broken)]
+        (is (= "FH-PROBE-001" (:fh/id d)) (str note " — names the law"))
+        (is (= field (:field d))          (str note " — names the field"))
+        (is (seq (:detail d))             (str note " — says what is wrong"))))))
+
+(deftest a-record-with-no-usable-identity-still-answers-a-defect
+  (testing "Total over garbage. A validator that threw on the input it
+            exists to reject would report the first defect and hide the
+            rest — and the inputs here are exactly the ones a hand-edited
+            fixture produces."
+    (is (= [{:fh/id nil :field :record :detail "a roster record is a map; got 42"}]
+           (roster/defects 42)))
+    (is (= [:fh/id] (mapv :field (roster/defects {:fh/law "no id"}))))
+    (is (= [:fh/id] (mapv :field (roster/defects {:fh/id "" :fh/law "blank"}))))
+    (is (= [:fh/record] (mapv :field (roster/defects {:fh/id "FH-PROBE-002"}))))))
+
+(deftest the-roster-level-defects-name-the-law-too
+  (testing "Per rf2-drpa3.182.7 acceptance 1: a duplicated id is a property
+            of the ROSTER rather than of one record, and it still names the
+            law."
+    (is (= [{:fh/id "FH-PROBE-001" :field :fh/id
+             :detail "appears 2 times in the roster; an id addresses exactly one law"}]
+           (roster/roster-defects [sound sound])))))
+
+(deftest a-record-cannot-claim-a-tier-its-index-row-rules-out
+  (testing "The one cross-file law the join can state: a record's proof
+            tiers are checked against the host axis of the row that
+            addresses it, so a record cannot advertise a browser proof for a
+            law the ledger binds to the JVM alone. Before the join the two
+            files described the same law with nothing comparing them, and a
+            tier claim was a sentence nobody read.
+
+            Deliberately NOT checked: that the fixture's `:fh/law` matches
+            its index row word for word. The two state the same law at
+            different lengths on purpose — the row is the addressed one-line
+            statement, the fixture's is the header over the values below it
+            — and every row in the ledger is written that way, so gating
+            equality would force a hundred prose rewrites to satisfy a law
+            the corpus never held."
+    (let [jvm-only (assoc sound :hosts #{:jvm}
+                               :fh/record (assoc (:fh/record sound)
+                                            :mounted {:ns 're-frame.freehand.probe-dom-cljs-test
+                                                      :law "in a browser"}))
+          ds       (roster/roster-defects [jvm-only])]
+      (is (= 1 (count ds)))
+      (is (= "FH-PROBE-001" (:fh/id (first ds))) "the tier defect names the law")
+      (is (= :mounted (:field (first ds))))
+      (is (re-find #"can only run on" (:detail (first ds)))))
+    (testing "and the same record on a browser row is sound — non-vacuity
+              for the row above"
+      (is (= [] (roster/roster-defects
+                  [(assoc sound :hosts #{:browser}
+                          :fh/record (assoc (:fh/record sound)
+                                       :mounted {:ns 're-frame.freehand.probe-dom-cljs-test
+                                                 :law "in a browser"}))]))))
+    (testing "an :ssr tier on a row that names no SSR host"
+      (is (= [:ssr] (mapv :field
+                          (roster/roster-defects
+                            [(assoc sound :hosts #{:jvm :browser}
+                                    :fh/record (assoc (:fh/record sound)
+                                                 :ssr {:ns 're-frame.freehand.probe-ssr-jvm-test
+                                                       :law "to HTML"}))])))))))

--- a/implementation/freehand/test/re_frame/freehand/roster_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/roster_jvm_test.clj
@@ -1,0 +1,141 @@
+(ns re-frame.freehand.roster-jvm-test
+  "The roster's declarations are RESOLVED — rf2-drpa3.182.7 acceptance 1.
+
+  `roster-cljs-test` proves the roster is well-formed data. Well-formed
+  data is not an identity: a record can name `re-frame.freehand.form` as
+  its source and `…-dom-cljs-test` as its mounted entry, validate perfectly,
+  and both be strings pointing at nothing. A record that survives the
+  deletion of the thing it describes is a comment.
+
+  This file closes that. It needs a filesystem, so it is the JVM's:
+
+    * every namespace a record names — source and proof alike — resolves to
+      a file that exists;
+    * every proof namespace CITES the law it claims to prove, by id, in its
+      own text, so a reader who opens the suite the roster sent them to
+      finds the id rather than having to infer the connection;
+    * and a mounted entry is a mounted suite — it rides the browser lane's
+      own naming, rather than being a headless file the record described as
+      mounted.
+
+  The last one matters more than it looks. The browser lane is selected by
+  filename suffix, so a record naming a `-cljs-test` namespace as its
+  `:mounted` tier would be pointing at a suite that never runs in a
+  browser, and every projection would go on reporting a mounted proof that
+  does not exist."
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [re-frame.freehand.roster :as roster]))
+
+;; ---------------------------------------------------------------------------
+;; Resolution
+;; ---------------------------------------------------------------------------
+
+(def ^:private extensions
+  "The extensions a namespace may live under, in the order the roster looks.
+  `.cljc` first because most of the substrate is cross-host; `.cljs` is
+  there because a mounted suite is ClojureScript-only and is still a file
+  this JVM run must be able to find on the test classpath."
+  [".cljc" ".clj" ".cljs"])
+
+(defn- ns->resource
+  "The classpath resource backing namespace symbol `ns-sym`, or nil."
+  [ns-sym]
+  (let [stem (-> (name ns-sym)
+                 (str/replace "-" "_")
+                 (str/replace "." "/"))]
+    (some (fn [ext] (io/resource (str stem ext))) extensions)))
+
+(defn- declared-namespaces
+  "Every namespace `record` names, as `[field ns-sym]` pairs — its sources
+  and every proof at every tier. One sequence so the resolution row below
+  treats a source and a proof identically: both are claims about a file."
+  [record]
+  (concat (map (fn [s] [:source s]) (get-in record [:fh/record :source]))
+          (map (juxt :tier :ns) (roster/proofs record))))
+
+(deftest every-namespace-the-roster-names-exists
+  (testing "Per rf2-drpa3.182.7 acceptance 1: a record's declarations are
+            addresses, not adjectives. Every source namespace and every
+            proof namespace resolves to a file on the classpath, so
+            deleting or renaming the thing a record describes reds THIS row
+            — naming the law — rather than leaving the roster quietly
+            describing something that is gone."
+    (doseq [record roster/spine
+            [field ns-sym] (declared-namespaces record)]
+      (is (some? (ns->resource ns-sym))
+          (str (:fh/id record) " — " field " names " ns-sym
+               ", which resolves to no file on the classpath")))))
+
+(deftest the-roster-names-at-least-one-namespace-per-record
+  (testing "NON-VACUITY for the row above. A record whose declarations were
+            all empty would pass every resolution check by having nothing to
+            resolve, which is the failure mode a table-driven gate is most
+            prone to."
+    (doseq [record roster/spine]
+      (is (<= 3 (count (declared-namespaces record)))
+          (str (:fh/id record) " names its source and at least one proof")))))
+
+;; ---------------------------------------------------------------------------
+;; The suite the roster sends a reader to NAMES the law
+;; ---------------------------------------------------------------------------
+
+(deftest every-proof-namespace-cites-the-law-it-proves
+  (testing "Per rf2-drpa3.182.7 acceptance 1: a claim has ONE identity
+            across every projection, and failures name it. A roster row
+            that sent a reader to a suite which never mentions the id would
+            have the identity running one way only — findable from the
+            roster, invisible from the code. Every proof namespace carries
+            its `FH-…` id in its own text, so the link is legible from both
+            ends and a `git grep FH-CTRL-018` finds the whole vertical."
+    (doseq [record            roster/spine
+            {:keys [tier ns]} (roster/proofs record)]
+      (let [id  (:fh/id record)
+            res (ns->resource ns)]
+        (is (and res (str/includes? (slurp res) id))
+            (str id " — the " (name tier) " proof " ns
+                 " does not cite the law it proves"))))))
+
+;; ---------------------------------------------------------------------------
+;; A mounted entry is a MOUNTED suite
+;; ---------------------------------------------------------------------------
+
+(deftest a-mounted-tier-names-a-suite-that-runs-in-a-browser
+  (testing "The browser lane selects by filename suffix, so `-dom-cljs-test`
+            is not a style — it is what makes a suite run against a real
+            `react-dom/client` commit. A record naming an ordinary
+            `-cljs-test` namespace as its mounted tier would advertise a
+            mounted proof that the browser lane never schedules, and no
+            other projection would notice."
+    (doseq [record roster/spine
+            entry  (roster/tier record :mounted)]
+      (is (str/ends-with? (name (:ns entry)) "-dom-cljs-test")
+          (str (:fh/id record) " — the mounted tier names " (:ns entry)
+               ", which the browser lane does not select")))))
+
+(deftest a-structural-tier-does-not-name-a-browser-suite
+  (testing "The converse, and it is a real error rather than a symmetry
+            exercise: a structural tier is the claim that a law is provable
+            HEADLESSLY, on both hosts, from one `.cljc`. Pointing it at a
+            `-dom-cljs-test` would make the record say a browser run is the
+            headless proof."
+    (doseq [record roster/spine
+            entry  (roster/tier record :structural)]
+      (is (not (str/ends-with? (name (:ns entry)) "-dom-cljs-test"))
+          (str (:fh/id record) " — the structural tier names a browser suite, "
+               (:ns entry))))))
+
+;; ---------------------------------------------------------------------------
+;; The resolver itself
+;; ---------------------------------------------------------------------------
+
+(deftest the-resolver-answers-nil-for-a-namespace-that-is-not-there
+  (testing "NON-VACUITY for every resolution row above. A resolver that
+            answered truthy for anything would make each of them pass over
+            whatever the roster happened to contain."
+    (is (nil? (ns->resource 're-frame.freehand.no-such-namespace-at-all)))
+    (is (some? (ns->resource 're-frame.freehand.roster))
+        "and it finds one that is")
+    (is (some? (ns->resource 're-frame.freehand.form))
+        "including a .cljc source")))

--- a/spec/conformance/freehand/fixtures/fh-behavior-005.edn
+++ b/spec/conformance/freehand/fixtures/fh-behavior-005.edn
@@ -47,4 +47,39 @@
  ;; Two live connections, then one leaves: the remaining claim is untouched.
  :partial-teardown
  {:connections 1
-  :targets     [:probe/one]}}
+  :targets     [:probe/one]}
+
+ ;; ---------------------------------------------------------------------------
+ ;; The roster record (rf2-drpa3.182.7)
+ ;; ---------------------------------------------------------------------------
+ ;;
+ ;; This row carries the DEFERRED FOREIGN-HANDLE surrogate as its mounted
+ ;; tier, and it is rostered here rather than under an id of its own on
+ ;; purpose. The recipe adds no verb, no runtime, no scheduling policy and
+ ;; no contract — the re-frame pass stays one complete synchronous pass,
+ ;; and a later foreign completion dispatches an ordinary new event rather
+ ;; than resuming the original. So there is no new law to address. What
+ ;; there is, is this law — total release, exactly once — under the shape
+ ;; where the handle arrives from a Promise and the owner may already be
+ ;; gone when it does. Minting a second id would have split one identity.
+ :fh/record
+ {:source [re-frame.freehand.behaviors re-frame.freehand.refs]
+
+  :structural
+  {:ns  re-frame.freehand.behaviors-cljs-test
+   :law "On the structural host a behavior is an inert marker and connects nothing, so the teardown claim has a control: a tier that never connected cannot be the tier that proves a release."}
+
+  :mounted
+  {:ns  re-frame.freehand.behavior-async-dom-cljs-test
+   :law "Against a Promise-returning third-party initializer, an unmount BEFORE the acquisition resolves leaves nothing behind — the late handle is released by the continuation rather than retained, the owner is already fenced when the library is asked, the library is asked EXACTLY once, and a finalizer that FAILS leaves a host-only leak with both framework books still empty rather than a half-released connection."}
+
+  ;; What a run must leave, and what it must not. The two books are the
+  ;; substrate's own — a count, not a threshold — and `:residue :none` is
+  ;; the assertion, not the aspiration: a leaked root contaminates every
+  ;; later suite sharing the process.
+  :evidence
+  {:reads   [:behaviors/connections :behaviors/targets]
+   :counts  [:behavior/connect :behavior/disconnect]
+   :residue :none}
+
+  :prose :executable}}

--- a/spec/conformance/freehand/fixtures/fh-behavior-005.edn
+++ b/spec/conformance/freehand/fixtures/fh-behavior-005.edn
@@ -65,13 +65,21 @@
  :fh/record
  {:source [re-frame.freehand.behaviors re-frame.freehand.refs]
 
-  :structural
-  {:ns  re-frame.freehand.behaviors-cljs-test
-   :law "On the structural host a behavior is an inert marker and connects nothing, so the teardown claim has a control: a tier that never connected cannot be the tier that proves a release."}
-
+  ;; NO structural tier. A release is only observable where a connection
+  ;; happened, and on the structural host a behavior is an inert marker
+  ;; that connects nothing — which is FH-BEHAVIOR-003's law, not this
+  ;; one. The index binds this row to `interpreted browser` for exactly
+  ;; that reason.
+  ;;
+  ;; TWO mounted projections, and the second is the point of the vector.
+  ;; They are the same law — total release, exactly once — reached by two
+  ;; different routes, and a roster that could hold only one would have
+  ;; forced the surrogate to invent an id and split the identity.
   :mounted
-  {:ns  re-frame.freehand.behavior-async-dom-cljs-test
-   :law "Against a Promise-returning third-party initializer, an unmount BEFORE the acquisition resolves leaves nothing behind — the late handle is released by the continuation rather than retained, the owner is already fenced when the library is asked, the library is asked EXACTLY once, and a finalizer that FAILS leaves a host-only leak with both framework books still empty rather than a half-released connection."}
+  [{:ns  re-frame.freehand.behaviors-dom-cljs-test
+    :law "On the ordinary synchronous path `:disconnect` runs exactly once per committed connection and both substrate books read the exact integer zero afterwards — measured against a control mount of the same markup that attached no behavior, so React's own bookkeeping cannot masquerade as the substrate's."}
+   {:ns  re-frame.freehand.behavior-async-dom-cljs-test
+    :law "Under a Promise-returning third-party initializer the same release holds where it is hardest: an unmount BEFORE the acquisition resolves leaves nothing behind — the late handle is released by the continuation rather than retained, the owner is already fenced when the library is asked, the library is asked EXACTLY once, and a finalizer that FAILS leaves a host-only leak with both framework books still empty rather than a half-released connection."}]
 
   ;; What a run must leave, and what it must not. The two books are the
   ;; substrate's own — a count, not a threshold — and `:residue :none` is

--- a/spec/conformance/freehand/fixtures/fh-ctrl-018.edn
+++ b/spec/conformance/freehand/fixtures/fh-ctrl-018.edn
@@ -57,15 +57,17 @@
  :fh/record
  {:source [re-frame.freehand.form re-frame.freehand.controls]
 
-  ;; The pure transitions are host-neutral and run headlessly on both
-  ;; hosts; the browser tier is the half only a real caret can answer.
-  :structural
-  {:ns  re-frame.freehand.controls-kit-cljs-test
-   :law "The kit's transitions are pure and cross-host: a field edit, a buffered draft, a commit and a caller reset are values computed from values, with no host object and no clock anywhere in them."}
-
+  ;; NO structural tier, and that is the law rather than an omission. This
+  ;; row opens "In a real browser" and the index binds it to `interpreted
+  ;; browser`: a caret position, a live IME composition and a still-focused
+  ;; node are facts a headless walk cannot reach. The kit's PURE
+  ;; transitions are proven headlessly, but by FH-CTRL-012..017 — a
+  ;; different set of laws with their own ids. Naming
+  ;; `controls-kit-cljs-test` here would have made this row claim a
+  ;; structural proof that suite never offers.
   :mounted
-  {:ns  re-frame.freehand.controls-kit-dom-cljs-test
-   :law "Against real key events in Chromium the caret follows the user rather than jumping to either end, a plain Enter commits through the ordinary batched path while an Enter carrying a live IME composition commits nothing and discards nothing, and a caller's reset restores the baseline on the SAME still-focused node rather than by remounting it."}
+  [{:ns  re-frame.freehand.controls-kit-dom-cljs-test
+    :law "Against real key events in Chromium the caret follows the user rather than jumping to either end, a plain Enter commits through the ordinary batched path while an Enter carrying a live IME composition commits nothing and discards nothing, and a caller's reset restores the baseline on the SAME still-focused node rather than by remounting it."}]
 
   ;; A control kit's evidence is what a run leaves for a reader: the value
   ;; the DOM node actually held, and the count of commits that reached

--- a/spec/conformance/freehand/fixtures/fh-ctrl-018.edn
+++ b/spec/conformance/freehand/fixtures/fh-ctrl-018.edn
@@ -44,4 +44,36 @@
  ;; is blind to.
  :reasserted-value "10"
  :next-reset-key 1
- :value-after-reset "10"}
+ :value-after-reset "10"
+
+ ;; ---------------------------------------------------------------------------
+ ;; The roster record (rf2-drpa3.182.7)
+ ;; ---------------------------------------------------------------------------
+ ;;
+ ;; `re-frame.freehand.roster` joins this with the row that addresses the
+ ;; id and answers ONE value naming source, tiers, evidence and prose. The
+ ;; fields the index already carries — modes, hosts, status, paragraph —
+ ;; are deliberately absent: they are read from the row, not restated.
+ :fh/record
+ {:source [re-frame.freehand.form re-frame.freehand.controls]
+
+  ;; The pure transitions are host-neutral and run headlessly on both
+  ;; hosts; the browser tier is the half only a real caret can answer.
+  :structural
+  {:ns  re-frame.freehand.controls-kit-cljs-test
+   :law "The kit's transitions are pure and cross-host: a field edit, a buffered draft, a commit and a caller reset are values computed from values, with no host object and no clock anywhere in them."}
+
+  :mounted
+  {:ns  re-frame.freehand.controls-kit-dom-cljs-test
+   :law "Against real key events in Chromium the caret follows the user rather than jumping to either end, a plain Enter commits through the ordinary batched path while an Enter carrying a live IME composition commits nothing and discards nothing, and a caller's reset restores the baseline on the SAME still-focused node rather than by remounting it."}
+
+  ;; A control kit's evidence is what a run leaves for a reader: the value
+  ;; the DOM node actually held, and the count of commits that reached
+  ;; dispatch. Both are read off the substrate rather than off the test's
+  ;; own bookkeeping.
+  :evidence
+  {:reads    [:dom/value :dom/selection-start]
+   :counts   [:form/commits :form/attempts]
+   :residue  :none}
+
+  :prose :executable}}

--- a/spec/conformance/freehand/fixtures/fh-react-007.edn
+++ b/spec/conformance/freehand/fixtures/fh-react-007.edn
@@ -104,4 +104,51 @@
  ;; and it is reported through the same diagnostic.
  :children-policy
  {:none-with-children     {:error-id :rf.error/view-children-policy}
-  :required-without-any   {:error-id :rf.error/view-children-policy}}}
+  :required-without-any   {:error-id :rf.error/view-children-policy}}
+
+ ;; ---------------------------------------------------------------------------
+ ;; The roster record (rf2-drpa3.182.7)
+ ;; ---------------------------------------------------------------------------
+ :fh/record
+ {:source [re-frame.freehand.descriptor re-frame.freehand.props-schema
+           re-frame.freehand.to-react]
+
+  :structural
+  {:ns  re-frame.freehand.host-door-cljs-test
+   :law "The three planes split ONCE, host-neutrally: the same declaration yields the same ordinary props, the same filled callback positions and the same children on the JVM and in ClojureScript, and every refusal above is a typed diagnostic rather than a coercion."}
+
+  :mounted
+  {:ns  re-frame.freehand.host-mounted-dom-cljs-test
+   :law "Against a real react-dom/client commit the contract the declaration advertises is the contract the registered component receives — measured on the EXACT function object React was handed, through two implementations that could not be less alike (a value/callback leaf and a hook-owning wrapper) declared the same way."}
+
+  ;; The evidence a host crossing owes is about IDENTITY, not shape: a
+  ;; callback prop that is a fresh function on every commit renders
+  ;; perfectly and breaks every memoised consumer downstream, so the
+  ;; recorded object is what a run leaves and `identical?` is what reads
+  ;; it.
+  :evidence
+  {:reads   [:host/props :host/callback-identity]
+   :counts  [:host/commits]
+   :residue :none}
+
+  ;; OPEN, and recorded as open rather than pinned (rf2-drpa3.182.3, from
+  ;; the merged-PR audit of #7081). Spec 004, the public docstring and the
+  ;; browser test all say a `:map-props` adapter owns VALUES and may not
+  ;; rename, but the landed check only runs the inexactness filter over the
+  ;; adapter's OUTPUT — so an authored `{:spec x}` returned as
+  ;; `{:chartSpec x}` passes both checks and reaches React under a name the
+  ;; caller never supplied. The question is whether the law is key-set
+  ;; EQUALITY or output SUBSET, and it has to be settled at `host-element`,
+  ;; where the authored props and the mapper output both exist.
+  ;;
+  ;; The roster names the question and asserts nothing about the answer.
+  ;; Freezing today's behaviour into a rostered expectation would leave
+  ;; whoever settles .182.3 fighting this file to land the fix, which is
+  ;; the mutually-invalidating-test problem written in advance. When it is
+  ;; settled, the answer belongs in `:prop-names` above — where the rows
+  ;; that already run live — and this note goes.
+  :open
+  {:rf2-drpa3.182.3
+   "the :map-props key-set law — equality or output subset — is unsettled; an unqualified rename is currently unchecked and no rostered projection asserts either answer"}
+
+  :prose :executable}}

--- a/spec/conformance/freehand/fixtures/fh-react-007.edn
+++ b/spec/conformance/freehand/fixtures/fh-react-007.edn
@@ -149,6 +149,6 @@
   ;; that already run live — and this note goes.
   :open
   {:rf2-drpa3.182.3
-   "the :map-props key-set law — equality or output subset — is unsettled; an unqualified rename is currently unchecked and no rostered projection asserts either answer"}
+   "the :map-props key-set law — key-set EQUALITY or output SUBSET — is unsettled, and has to be settled at host-element where the authored props and the mapper output both exist; an unqualified rename is currently unchecked, and no rostered projection asserts either answer"}
 
   :prose :executable}}

--- a/spec/conformance/freehand/fixtures/fh-react-007.edn
+++ b/spec/conformance/freehand/fixtures/fh-react-007.edn
@@ -114,12 +114,12 @@
            re-frame.freehand.to-react]
 
   :structural
-  {:ns  re-frame.freehand.host-door-cljs-test
-   :law "The three planes split ONCE, host-neutrally: the same declaration yields the same ordinary props, the same filled callback positions and the same children on the JVM and in ClojureScript, and every refusal above is a typed diagnostic rather than a coercion."}
+  [{:ns  re-frame.freehand.host-door-cljs-test
+    :law "The three planes split ONCE, host-neutrally: the same declaration yields the same ordinary props, the same filled callback positions and the same children on the JVM and in ClojureScript, and every refusal above is a typed diagnostic rather than a coercion."}]
 
   :mounted
-  {:ns  re-frame.freehand.host-mounted-dom-cljs-test
-   :law "Against a real react-dom/client commit the contract the declaration advertises is the contract the registered component receives — measured on the EXACT function object React was handed, through two implementations that could not be less alike (a value/callback leaf and a hook-owning wrapper) declared the same way."}
+  [{:ns  re-frame.freehand.host-mounted-dom-cljs-test
+    :law "Against a real react-dom/client commit the contract the declaration advertises is the contract the registered component receives — measured on the EXACT function object React was handed, through two implementations that could not be less alike (a value/callback leaf and a hook-owning wrapper) declared the same way."}]
 
   ;; The evidence a host crossing owes is about IDENTITY, not shape: a
   ;; callback prop that is a fresh function on every commit renders


### PR DESCRIPTION
The executable Freehand fixture spine: one roster record per law, joined
from the two files that already describe it, so a claim has ONE identity
across source, ledger, JVM structure and mounted browser behaviour — and
so a failure names it.

## What a record is, and where it lives

A Freehand law is already addressed twice. The conformance index rows its
id, its one-line statement, the spec paragraph it cites, the modes and
hosts it binds, and its status. The fixture carries the values it is
proven by. Neither says which source implements it, where it executes,
what evidence a run leaves, or whether the prose describing it is
executable.

Those four are now declared, under `:fh/record`, **on the fixture** — not
in a new roster file. A third file describing the same law would be a
third thing to keep in step; the fixture is already what a slice edits
when its law changes, and it already carries `:fh/id`. `spec/conformance`
itself says this is the harness's business: it "owns addressing, not
execution".

`re-frame.freehand.roster` then JOINS fixture and index row into one
value, read at macro-expansion time so both hosts project the same bytes.
Modes, hosts, status and paragraph are read from the row and never
restated.

## Failures name the law

Every value the roster answers carries `:fh/id` — records, defects,
projection mismatches. Thirteen defect shapes are driven one at a time and
each is asserted to name the law it is about, because a roster whose
failing assertion reported a line number would not have met acceptance 1.

## The three verticals

| Law | Vertical | Proofs |
|---|---|---|
| `FH-REACT-007` | the declared host (.182.3) | structural + mounted |
| `FH-CTRL-018` | the serious form (.182.4) | mounted |
| `FH-BEHAVIOR-005` | total release, incl. the deferred foreign-handle surrogate (.182.5) | mounted x2 |

The surrogate is rostered under `FH-BEHAVIOR-005` rather than a new id.
It adds no verb, no runtime, no scheduling policy and no contract, so it
has no law of its own — it is the same total-release law reached by the
hardest route, with the handle arriving from a Promise after the owner may
already be gone. Minting a second id would have split the identity this
roster exists to keep single. A tier is therefore a vector: one law, two
mounted projections.

## What running the gate found

The JVM tier resolves declarations rather than trusting them, and caught
three real gaps on its first pass:

* `FH-CTRL-018` and `FH-BEHAVIOR-005` are browser-only laws whose records
  claimed structural proofs the named suites never offer — those suites
  prove `FH-CTRL-012..017` and `FH-BEHAVIOR-003`. Both records now omit
  the tier.
* `behavior-async-dom-cljs-test` cited no law at all: reachable from the
  guide and from the bead that commissioned it, and from no ledger. It now
  names `FH-BEHAVIOR-005`, so `git grep` finds the whole vertical from
  either end.

## Two things deliberately NOT done

**No fixture-law/index-law equality gate.** Tempting, and wrong: the two
state the same law at different lengths on purpose — the row is the
addressed one-line statement, a fixture's `:fh/law` is the header over its
values — and every row in the ledger is written that way. Gating equality
would force a hundred prose rewrites to satisfy a law the corpus never
held. What the join gates instead is tier-against-host, which is true: a
record cannot advertise a browser proof for a law the ledger binds to the
JVM alone.

**No expectation pinned at the `:map-props` naming boundary.** rf2-drpa3.182.3
is open, and the key-set law — equality or output subset — is unsettled.
A rostered expectation is a pinned expectation, so pinning today's
behaviour would leave whoever settles it fighting this roster to land the
fix. The record names the question under a new `:open` slot, keyed by the
owning bead, and asserts nothing about the answer.

## Not in this PR

* `docs/core/freehand/**` is untouched — #7096 is restructuring it.
* The mounted lifecycle facade the bead says to consume **does not exist**;
  see the notes on the bead. The three DOM suites still hand-roll their own
  `act` / `setup!` / `teardown!`, and consolidating them is the follow-up.

## Quality gates

| Gate | Result |
|---|---|
| `clojure -M:test -r "re-frame\.freehand\.roster.*"` | 20 tests / 154 assertions, 0F/0E, **EXIT=0** |
| freehand JVM (full artefact) | running |
| `test:cljs` | running |
