### PR TITLE
fix(resources,core): read continuations honour an index-free declaration on an infinite feed (rf2-zaopo)

### DIFF
--- a/implementation/core/src/re_frame/classification.cljc
+++ b/implementation/core/src/re_frame/classification.cljc
@@ -218,16 +218,50 @@
     (and (> (count b) na)
          (= a (subvec b 0 na)))))
 
-(defn- large-shadows-sensitive?
-  "True when the large-marked path `p` has ANY sensitive path strictly below it
-  in `sensitive-set` — a `:large`-marked subtree containing a `:sensitive`
-  descendant. Per Spec 015 §No-propagation (L338, a normative MUST) such a
-  subtree REDACTS (descend + redact the descendant) rather than emitting a
-  size-preview marker that would leak `:bytes` / `:type` (and, off-box with
-  digests on, a SHA-256 digest computed over a subtree that contains the
-  secret — a brute-force oracle)."
-  [p sensitive-set]
-  (boolean (some #(strict-prefix? p %) sensitive-set)))
+(defn- large-shadow-set
+  "The subset of `large-set` whose paths have a `:sensitive` path strictly BELOW
+  them — a `:large`-marked subtree containing a `:sensitive` descendant. Per
+  Spec 015 §No-propagation (L338, a normative MUST) such a subtree REDACTS
+  (descend + redact the descendant) rather than emitting a size-preview marker
+  that would leak `:bytes` / `:type` (and, off-box with digests on, a SHA-256
+  digest computed over a subtree that contains the secret — a brute-force
+  oracle). Computed once per walk; empty in the common no-nesting case. The
+  peer of `re-frame.elision/large-keys-shadowing-sensitive`, over path SETS
+  rather than declaration tables."
+  [sensitive-set large-set]
+  (into #{} (filter (fn [lp] (some #(strict-prefix? lp %) sensitive-set))) large-set))
+
+;; ---- the declaration-coordinate candidate set -----------------------------
+;;
+;; The walker threads `[path candidates]`: the CONCRETE runtime path (which
+;; drives the `:large` marker's `:path` / `:handle`) beside a SET of candidate
+;; DECLARATION coordinates — the positions in declaration space the walker
+;; could currently be standing at. In the default mode the two never diverge
+;; and the set is the singleton `#{path}`; `:index-free?` is what makes them
+;; differ. Both are pruned against the prefix set of every declared path, so a
+;; candidate that can never reach a declaration is dropped and the set stays
+;; bounded by the declaration cardinality. The same device
+;; `re-frame.elision`'s schema-first walker uses, at the grain this walker
+;; needs.
+
+(defn- path-prefixes
+  "Every non-empty prefix of `path`, the full path included."
+  [path]
+  (map #(subvec path 0 %) (range 1 (inc (count path)))))
+
+(defn- decl-prefix-set
+  "The set of every prefix of every declared path. A candidate declaration
+  coordinate stays alive only while it is a member: anything outside can never
+  reach a declaration, so dropping it is matching-safe."
+  [sensitive-set large-set]
+  (into #{} (mapcat path-prefixes) (concat sensitive-set large-set)))
+
+(defn- fork-segment
+  "Advance every candidate by one declaration segment `seg`, keeping only those
+  still a prefix of some declared path. A map key is always a real segment; a
+  positional index is one too UNLESS the caller opted into `:index-free?`."
+  [candidates seg prefixes]
+  (into #{} (comp (map #(conj % seg)) (filter #(contains? prefixes %))) candidates))
 
 (defn- walk-with-paths
   "Walk `v` and substitute sentinels at the declared paths. Paths in
@@ -236,38 +270,73 @@
   descendant descends-and-redacts rather than emitting a size marker
   (nested-axis suppression — rf2-izlr7f).
 
+  `index-free?` selects how a POSITIONAL container is read (rf2-zaopo). Default
+  false — every index is a declaration segment, so matching is the exact path
+  membership test this walker has always applied. True — an index is a
+  COLLECTION COORDINATE that consumes no declared segment, so the index-free
+  declaration `[:value :email]` matches the runtime `[:value <i> :email]` in
+  every element. A declaration that pins a literal index still matches either
+  way (the indexed interpretation is retained whenever some declaration
+  reaches it), so the mode only ever ADDS the per-element reading.
+
   No-op early-exit: when both path sets are empty, returns `v` unchanged.
   Shares the map/vec/set/seq recursion skeleton with the schema-first elision
   walker via `re-frame.elision/walk-tree` (rf2-cywzkh)."
-  [v sensitive-paths large-paths]
+  [v sensitive-paths large-paths index-free?]
   (if (and (empty? sensitive-paths) (empty? large-paths))
     v
     (let [sensitive-set (set (map vec sensitive-paths))
-          large-set     (set (map vec large-paths))]
+          large-set     (set (map vec large-paths))
+          prefixes      (decl-prefix-set sensitive-set large-set)
+          shadow-set    (large-shadow-set sensitive-set large-set)
+          matches?      (fn [tbl candidates] (boolean (some #(contains? tbl %) candidates)))]
       (elision/walk-tree
-        v []
-        {:decide  (fn [path v]
+        v [[] #{[]}]
+        {:decide  (fn [[path candidates] v]
                     (cond
-                      (contains? sensitive-set path) privacy/redacted-sentinel
+                      (matches? sensitive-set candidates) privacy/redacted-sentinel
                       ;; NESTED-AXIS SUPPRESSION (rf2-izlr7f): a large-marked
                       ;; node that shadows a sensitive descendant descends so
                       ;; the descendant redacts in place — no size marker.
-                      (and (contains? large-set path)
-                           (large-shadows-sensitive? path sensitive-set))
+                      (and (matches? large-set candidates)
+                           (seq shadow-set)
+                           (matches? shadow-set candidates))
                       elision/walk-recur
 
-                      (contains? large-set path)     (large-marker v path)
-                      :else                          elision/walk-recur))
-         :map-key (fn [path k] (conj path k))
-         :index   (fn [path i] (conj path i))
-         :leaf    (fn [_path v] v)}))))
+                      (matches? large-set candidates)     (large-marker v path)
+                      :else                               elision/walk-recur))
+         :map-key (fn [[path candidates] k]
+                    [(conj path k) (fork-segment candidates k prefixes)])
+         :index   (fn [[path candidates] i]
+                    [(conj path i)
+                     ;; An index-free candidate rides the descent UNCHANGED —
+                     ;; the element position consumed no declared segment.
+                     ;; Riding an index can never float a declaration past a
+                     ;; NAMED slot, so no position guard is needed here (the
+                     ;; argument `re-frame.elision/fork-index-paths` makes).
+                     (cond-> (fork-segment candidates i prefixes)
+                       index-free? (into candidates))])
+         :leaf    (fn [_state v] v)}))))
 
 (defn redact-with-paths
   "Public projection helper. Walks `v` and substitutes sentinels at the declared
   paths. Empty `[[]]` path substitutes the whole value (sensitive wins over large
-  at the root). Per Spec 015 §What gets a sentinel."
-  [v sensitive-paths large-paths]
-  (walk-with-paths v sensitive-paths large-paths))
+  at the root). Per Spec 015 §What gets a sentinel.
+
+  `opts` may carry `:index-free? true` (rf2-zaopo) for a caller whose declared
+  paths are INDEX-FREE — written against the shape rather than against a
+  concrete runtime position, so a positional container contributes no segment
+  and the declaration names EVERY element. That is the kind a
+  projection-relative resource / mutation declaration is, which is why
+  `re-frame.resources.classification/redact-continuation-reply` opts in: its
+  `[:data :email]` must reach an infinite feed's merged item list the same way
+  the durable side's `elide-wire-value` already reaches the page vector. Every
+  other caller declares CONCRETE paths and is left on the exact match — the
+  mode is opt-in precisely so it cannot widen a boundary that did not ask."
+  ([v sensitive-paths large-paths]
+   (redact-with-paths v sensitive-paths large-paths nil))
+  ([v sensitive-paths large-paths opts]
+   (walk-with-paths v sensitive-paths large-paths (true? (:index-free? opts)))))
 
 (defn- classification-paths
   "Destructure a canonical classification map into its `[sensitive-paths

--- a/implementation/epoch/test/re_frame/epoch_egress_resource_trace_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_egress_resource_trace_test.clj
@@ -120,6 +120,33 @@
                    :sensitive     [[:params :account]]
                    :params-schema [:map [:account :string] [:slug :string]]}
                   (fn [_ _] {:request {:method :get :url "/d"}}))
+                ;; rf2-zaopo — the same declaration surface on an INFINITE
+                ;; FEED. `:reply-to` delivers the MERGED / flattened item list
+                ;; under `:value` (`infinite-reply-value`), so the declared
+                ;; `[:data :email]` names a field of EACH ITEM and the runtime
+                ;; path is `[:value <i> :email]`. Same three outcomes per item
+                ;; as `:declared/profile` — redact, elide, ride — so one feed
+                ;; proves the index-free match is per-PATH and not a
+                ;; whole-slot tokenization.
+                (rf/reg-resource :declared/feed
+                  {:scope           :rf.scope/global
+                   :infinite        true
+                   :next-page-param (fn [_last _all] nil)
+                   :page->items     :items
+                   :sensitive       [[:data :email]]
+                   :large           [[:data :avatar]]
+                   :params-schema   [:map [:filter :keyword]]}
+                  (fn [_ _] {:request {:method :get :url "/e"}}))
+                ;; rf2-zaopo — the feed-shaped over-redaction control: an
+                ;; infinite feed that declares NEITHER axis. Its merged items
+                ;; carry the identical field names and must ride byte-identical.
+                (rf/reg-resource :plain/feed
+                  {:scope           :rf.scope/global
+                   :infinite        true
+                   :next-page-param (fn [_last _all] nil)
+                   :page->items     :items
+                   :params-schema   [:map [:filter :keyword]]}
+                  (fn [_ _] {:request {:method :get :url "/f"}}))
                 ;; a PLAIN resource under a CONCRETE (non-global) scope — the
                 ;; over-redaction control for the FREE `:scope` tag (rf2-1zc33).
                 ;; Its scoped KEY must keep scope AND params verbatim, which is
@@ -2487,3 +2514,239 @@
       (is (= (conj read-reply-target reply)
              (:rf.fx/args (:tags (first (:trace-events projected)))))
           "and so does the rest of the event vector it sits in"))))
+
+;; ===========================================================================
+;; (rf2-zaopo) the same declaration surface on an INFINITE FEED: the merged
+;; ITEM list under `:value`, which an EXACT path match cannot reach.
+;; ===========================================================================
+;;
+;; §(rf2-ko5lm) above closed the read reply for a SCALAR resource: the owner's
+;; `[:data :email]` declaration re-roots onto the reply's `:value`, giving
+;; `[:value :email]`, and `classification/redact-with-paths` matches that path
+;; exactly. For an INFINITE FEED the same declaration reached nothing.
+;;
+;; `events/infinite-reply-value` delivers the MERGED / flattened ITEM list as
+;; `:value` (rf2-c64uiz — both the fresh-skip cache hit and the async page-0
+;; settle deliver that one shape), so the runtime path is `[:value <i> :email]`
+;; while the declaration is `[:value :email]`. No fork, no match, and the
+;; declared field rode the fx carriers verbatim.
+;;
+;; THE DURABLE SIDE ALREADY FORKS, which is what made this a disagreement
+;; rather than a uniform limitation. `classification/project-entry-data` walks
+;; the feed's page vector through `elide-wire-value`, whose `fork-index-paths`
+;; matches an index-free declaration against the indexed runtime path on EVERY
+;; page (`ssr-infinite-feed-redacts-sensitive-page-field-per-page` in the
+;; resources suite pins it). So a feed's declared field redacted in the durable
+;; entry and rode raw in the continuation echo of it — the rf2-irwsq shape
+;; between two carriers of one value, one more time.
+;;
+;; THE SPELLING, settled here rather than invented. A feed has no "each item"
+;; wildcard syntax, and it needs none: the index-free declaration IS that
+;; spelling, because it is already what the DURABLE side means by
+;; `[:data :email]` on a page vector. The repair adds no vocabulary — it makes
+;; the carrier honour the one the durable side established
+;; (`redact-with-paths`'s `:index-free?` opt, which `redact-continuation-reply`
+;; passes because a projection-relative declaration re-rooted onto a carrier is
+;; exactly the index-free kind).
+;;
+;; GRAIN. A positional index is unambiguously a collection coordinate, never a
+;; named slot, so riding one can never float a declaration past a named slot
+;; (`fork-index-paths`' own argument). The fork therefore widens matching by
+;; exactly "each element of a declared positional container" and nothing else —
+;; which the two controls below are here to prove.
+
+(def ^:private declared-feed-params
+  "The canonical params of the declared-feed read. Deliberately PLAIN: this
+  section owns the `:data` axis, and the params axis has its own probe in
+  §(rf2-ko5lm)."
+  {:filter :recent})
+
+(defn- feed-item
+  "One item of the declared feed. Three fields, three outcomes — the same
+  redact / elide / ride triple `declared-reply-value` carries for a scalar
+  resource, so the feed proves the index-free match is per-PATH rather than a
+  whole-slot tokenization that a declaration merely triggers."
+  [tag]
+  {:email        (str secret "-" tag "@example.com")
+   :avatar       (str "0123456789abcdef" tag)
+   :display-name (str "Ada-" tag)})
+
+(def ^:private declared-feed-page
+  "One ENVELOPED terminal page (`:page-info :next` nil ⇒ no further pages) of
+  TWO items. Enveloped rather than a bare item vector on purpose: the merged
+  `:value` is then unambiguously distinct from both the page and the durable
+  page vector, so an assertion on it cannot pass by accident."
+  {:items     [(feed-item "a") (feed-item "b")]
+   :page-info {:next nil}})
+
+(def ^:private declared-feed-items
+  "The MERGED item list `infinite-reply-value` delivers under the reply's
+  `:value` — the flattened page, which is what the declaration must reach."
+  (:items declared-feed-page))
+
+(defn- drive-feed-reply-to-read!
+  "The `drive-declared-reply-to-read!` of §(rf2-ko5lm), against an INFINITE
+  FEED. An infinite ensure addresses the internal PAGE reply handler, so the
+  captured `:on-success` settles a page; the second ensure then finds the feed
+  fresh and dispatches the cache-hit continuation immediately. One call
+  produces BOTH continuation paths, and rf2-c64uiz pins that both deliver the
+  SAME merged-items `:value`. `resource-id` selects the declared feed or its
+  undeclared control, over the IDENTICAL page — so the declaration is the only
+  difference between the two runs."
+  [resource-id]
+  (rf/configure! {:epoch-history {:trace-events-keep 80}})
+  (let [captured (atom nil)]
+    (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! captured args) nil))
+    (rf/reg-event :app/read-loaded (fn [_ _ev] {}))
+    (rf/dispatch-sync [:rf.resource/ensure
+                       {:resource resource-id :params declared-feed-params
+                        :owner    real-owner :reply-to read-reply-target}]
+                      {:frame :test/rt})
+    (rf/dispatch-sync (conj (:on-success @captured) {:status :ok :value declared-feed-page})
+                      {:frame :test/rt})
+    (rf/dispatch-sync [:rf.resource/ensure
+                       {:resource resource-id :params declared-feed-params
+                        :owner    [:app :reader 2] :reply-to read-reply-target}]
+                      {:frame :test/rt})
+    (rf/epoch-history :test/rt)))
+
+;; ---------------------------------------------------------------------------
+;; (1) THE ACCEPTANCE ARM — a REAL reply-to feed read, both continuation paths
+;; ---------------------------------------------------------------------------
+
+(deftest real-declared-feed-reply-to-read-leaks-no-declared-item-slot
+  (testing "rf2-zaopo — `projected-record` over the records a REAL
+            `[:rf.resource/ensure … :reply-to …]` settles for an INFINITE FEED
+            whose only claim is a projection-relative `[:data …]` declaration
+            must carry the declared item field at ZERO paths, on BOTH
+            continuation paths. Before the repair each carried it once per ITEM
+            per carrier — four paths for this two-item feed."
+    (let [records (drive-feed-reply-to-read! :declared/feed)]
+      (doseq [[label cache-hit?] [["async page-0 settle" false]
+                                  ["fresh-skip cache hit" true]]]
+        (testing label
+          (let [raw       (record-carrying-reply records cache-hit?)
+                projected (epoch/projected-record raw)]
+
+            (testing "FIXTURE — the producer really put the MERGED ITEM LIST on
+                      the fx carriers, so the assertions below are not passing
+                      over a shape that never occurred"
+              (is (some? raw) "the continuation reached an fx carrier at all")
+              (is (seq (carrier-replies raw)) "and the reply map is findable on it")
+              (is (every? #(= declared-feed-items (:value %)) (carrier-replies raw))
+                  "every carrier's reply carries the RAW merged item list — not
+                   the enveloped page, not the durable page vector")
+              (is (seq (secret-leak-paths raw))
+                  "the unprojected record leaks — the projector's input is the
+                   runtime's own output, not an invented tag map"))
+
+            (testing "ACCEPTANCE — nothing raw survives anywhere in the projected
+                      record"
+              (is (= [] (secret-leak-paths projected))
+                  "every leaking path is named here; before the repair this
+                   printed the [:trace-events n :tags :rf.fx/args 1 :value i
+                   :email] shape, once per item per carrier"))
+
+            (testing "and the index-free match is PER-PATH and PER-ITEM — the
+                      declared slots move in EVERY item, their undeclared
+                      sibling moves in none"
+              (doseq [r (carrier-replies projected)]
+                (is (= 2 (count (:value r)))
+                    "the merged list keeps its length — projection neither drops
+                     nor invents an item")
+                (doseq [item (:value r)]
+                  (is (= :rf/redacted (:email item))
+                      "the `:sensitive`-declared field carries the sentinel in
+                       this item")
+                  (is (elision/marker? (:avatar item))
+                      "the `:large`-declared field carries the size marker"))
+                (is (= ["Ada-a" "Ada-b"] (mapv :display-name (:value r)))
+                    "and the field the owner declared NEITHER axis for rides
+                     verbatim in every item — the whole point of a path
+                     declaration")))
+
+            (testing "the whole reply still reads as a reply"
+              (let [r (first (carrier-replies projected))]
+                (is (= :declared/feed (:resource r)) "the resource id rides verbatim")
+                (is (= cache-hit? (:cache-hit? r)) "and the cache-hit disposition")
+                (is (= :ok (:status r)) "and the status")
+                (is (= declared-feed-params (:params r))
+                    "and the params, which this feed declared nothing under")
+                (is (= :rf.scope/global (:scope r))
+                    "and `:rf.scope/global` is untouched")))))))))
+
+;; ---------------------------------------------------------------------------
+;; (2) THE TWO-SIDED CONTROL — over-redaction must fail as loudly as leaking
+;; ---------------------------------------------------------------------------
+
+(defn- reply-carrier-rows
+  "Every trace row of `record` whose fx carrier slots carry a read-continuation
+  reply — the rows the reply arm speaks for, and the only ones a declaration
+  control can hold byte-identical. The rest of a real feed cascade carries the
+  INTERNAL `:rf.resource.internal/page-succeeded` event, whose own registration
+  classification redacts its args on every read declared or not, so a
+  whole-record comparison would be measuring that instead."
+  [record]
+  (filterv (fn [ev] (seq (carrier-replies {:trace-events [ev]})))
+           (:trace-events record)))
+
+(deftest fx-carrier-keeps-an-undeclared-feeds-merged-items-byte-identical
+  (testing "rf2-zaopo guard — an INFINITE FEED that declares NEITHER axis must
+            ride its merged item list BYTE-IDENTICAL through both carriers and
+            must not stamp those rows sensitive. This is the side that proves
+            the index-free fork reads the DECLARATION rather than the reply's
+            shape: the identically-named `:email` / `:avatar` fields that
+            redact for `:declared/feed` are fully readable here."
+    (let [raw       (record-carrying-reply (drive-feed-reply-to-read! :plain/feed) false)
+          projected (epoch/projected-record raw)]
+      (is (some? raw) "FIXTURE — the plain feed's continuation reached a carrier")
+      (is (= 2 (count (reply-carrier-rows raw)))
+          "FIXTURE — both carriers are present, as they are for the declared feed")
+      (is (= (mapv :tags (reply-carrier-rows raw))
+             (mapv :tags (reply-carrier-rows projected)))
+          "every carrier tag rides byte-identical — merged items, params, scope
+           and scoped key included")
+      (is (every? #(= declared-feed-items (:value %)) (carrier-replies projected))
+          "and the merged item list itself is readable field for field")
+      (is (not-any? #(:sensitive? (:tags %)) (reply-carrier-rows projected))
+          "an undeclared feed's continuation rows are NOT stamped sensitive"))))
+
+(deftest fx-carrier-index-free-fork-does-not-reach-an-undeclared-nested-slot
+  (testing "rf2-zaopo guard — the other half. Riding a positional index must
+            not let a declaration FLOAT: `[:data :email]` names a field of each
+            ITEM, so an `:email` sitting one named slot DEEPER (inside an
+            item's own undeclared sub-map) is a different position and must
+            survive. Without this side, `[:value :email]` matching
+            `[:value 0 :meta :email]` would read as a pass."
+    (let [k1        (sk :rf.scope/global :declared/feed declared-feed-params)
+          items     [{:email        (str secret "-top@example.com")
+                      :display-name "Ada"
+                      :meta         {:email (str secret "-nested@example.com")}}]
+          reply     (read-reply k1 :rf.scope/global items)
+          projected (epoch/projected-record (reply-carrier-record reply))
+          item      (first (:value (first (carrier-replies projected))))]
+      (is (= :rf/redacted (:email item))
+          "the declared field, one index down, redacts")
+      (is (= (str secret "-nested@example.com") (get-in item [:meta :email]))
+          "the same-named field one NAMED slot deeper is a different position
+           and rides verbatim")
+      (is (= "Ada" (:display-name item))
+          "and the undeclared sibling is untouched"))))
+
+;; ---------------------------------------------------------------------------
+;; (3) the trusted-local boundary — the redaction is the off-box DEFAULT
+;; ---------------------------------------------------------------------------
+
+(deftest trusted-local-include-sensitive-keeps-raw-declared-feed-items
+  (testing "rf2-zaopo — the trusted-local `:include-sensitive?` opt-in keeps the
+            raw declared item fields, exactly as it does for the scalar reply.
+            A feed's `:reply-to` continuation is how a workflow reads a page,
+            and a local tool that could not see the declared field could not
+            debug the workflow."
+    (let [k1        (sk :rf.scope/global :declared/feed declared-feed-params)
+          reply     (read-reply k1 :rf.scope/global declared-feed-items)
+          projected (epoch/projected-record (reply-carrier-record reply)
+                                            {:include-sensitive? true})]
+      (is (= [declared-feed-items declared-feed-items]
+             (mapv :value (carrier-replies projected)))
+          "every carrier's raw merged item list rides with :include-sensitive?"))))

--- a/implementation/resources/src/re_frame/resources/classification.cljc
+++ b/implementation/resources/src/re_frame/resources/classification.cljc
@@ -277,12 +277,27 @@
       it at the source: the app's own `:reply-to` handler is entitled to the
       decoded body and the trusted-local `:include-sensitive?` opt-in must still
       show it. There it composes with the coarse `whole-entry-disposition` arm,
-      which reads the root prop a read owner CAN declare."
+      which reads the root prop a read owner CAN declare.
+
+  INDEX-FREE, and that is what makes an INFINITE FEED work (rf2-zaopo). A
+  projection-relative declaration is written against the projection's SHAPE,
+  not against a concrete runtime position, so a positional container consumes
+  no declared segment and `[:data :email]` names EVERY element. The DURABLE
+  side has always read it that way — `project-entry-data` walks a feed's page
+  vector through `elide-wire-value`, whose index-free fork matches the
+  declaration on every page. The reply carries the MERGED ITEM LIST under
+  `:value` (`events/infinite-reply-value`), so without the same reading the
+  re-rooted `[:value :email]` reached nothing at `[:value <i> :email]` and a
+  feed's declared field redacted in the durable entry while riding raw in the
+  continuation echo of it. Hence `{:index-free? true}`: no new declaration
+  vocabulary — a feed needs no \"each item\" wildcard because the index-free
+  declaration already IS that spelling — just the carrier honouring the reading
+  the durable side established."
   [reply spec]
   (let [sens  (carrier-decl-paths spec :sensitive :value)
         large (carrier-decl-paths spec :large :value)]
     (if (or (seq sens) (seq large))
-      (classification/redact-with-paths reply sens large)
+      (classification/redact-with-paths reply sens large {:index-free? true})
       reply)))
 
 (defn project-execute-event-args

--- a/implementation/resources/src/re_frame/resources/trace_egress.cljc
+++ b/implementation/resources/src/re_frame/resources/trace_egress.cljc
@@ -531,19 +531,24 @@
   caller has tokenized the whole payload before reaching this. Reference-
   preserving when the spec declares neither axis. Pure.
 
-  ## Two residues, filed rather than fixed
+  ## Feeds read index-free (rf2-zaopo, closed)
+
+  `redact-with-paths` matched paths EXACTLY, so on an INFINITE feed a
+  `[:data :email]` decl reached nothing in the merged-items vector
+  `infinite-reply-value` delivers under `:value` (`[:value <i> :email]`) while
+  the durable side matched it on every page (`project-entry-data`).
+  `redact-continuation-reply` now opts into the walker's `:index-free?` mode,
+  which is the reading a projection-relative declaration always had on the
+  durable side. Opt-IN, so the walker's other callers — which declare concrete
+  paths — keep the exact match.
+
+  ## One residue, filed rather than fixed
 
     - rf2-dl7bz — a `:params`-rooted declaration also names bytes that ride
       the SIBLING `:resource/key`, and a `:serialize` owner's key rides
       verbatim at trace egress by documented decision
       (`ssr/project-scoped-key`). This closes the reply's copy; the key's copy
-      is the family's universal carrier and is its own ruling.
-    - rf2-zaopo — `redact-with-paths` matches paths EXACTLY, so on an INFINITE
-      feed a `[:data :email]` decl does not reach the merged-items vector
-      `infinite-reply-value` delivers under `:value` (`[:value <i> :email]`).
-      The durable side forks index-free (`project-entry-data`); the carrier
-      walker does not, and teaching it to is a core-primitive change with four
-      callers."
+      is the family's universal carrier and is its own ruling."
   [reply]
   (let [rid  (second (:resource/key reply))
         spec (when (keyword? rid) (registry/resource-meta rid))]


### PR DESCRIPTION
Closes rf2-zaopo.

## What leaked

`rf2-ko5lm` gave read continuations the mutation's declaration redaction:
`trace_egress/redact-reply-declarations` re-roots a read owner's `:data`-rooted
declaration onto the reply's `:value` and hands it to
`classification/redact-with-paths`, whose decider was an EXACT path membership
test.

For a scalar resource that is right — `[[:data :email]]` becomes `[:value :email]`
and matches. For an **infinite feed** it matched nothing.
`events/infinite-reply-value` delivers the MERGED / flattened item list as
`:value` (rf2-c64uiz — both the fresh-skip cache hit and the async page-0 settle
deliver that one shape), so the runtime path is `[:value <i> :email]` while the
declaration is `[:value :email]`. The declared field rode `:rf.fx/args` and
`:rf.event/fx` verbatim: off-box, epoch, MCP.

The durable side already forks, which is what made this a disagreement rather
than a uniform limitation: `classification/project-entry-data` walks a feed's
page vector through `elide-wire-value`, whose `fork-index-paths` matches an
index-free declaration against the indexed runtime path on every page. So a
feed's declared field redacted in the durable entry and rode raw in the
continuation echo of it — the rf2-irwsq two-carriers-one-rule shape again.

## The repair, and how it is scoped

`walk-with-paths` now threads `[path candidates]` — the concrete runtime path
beside a SET of candidate declaration coordinates, pruned against the prefix set
of every declared path. That is the device `re-frame.elision`'s schema-first
walker already uses, at the grain this walker needs (index fork only; no
`:map-of` key skip, so matching stays strictly more precise than the durable
side's).

`redact-with-paths` gains an **opt-in** 4th argument, `{:index-free? true}`.
With it absent — the default arity, and every existing call site — the candidate
set is the singleton `#{path}` and matching is byte-for-byte the exact test the
walker has always applied.

Exactly one caller opts in: `resources.classification/redact-continuation-reply`.
A projection-relative declaration is written against the projection's SHAPE, so
a positional container consumes no declared segment. The other callers
(`redact-event-vec`, `project-execute-event-args`, `http.privacy-body`,
`machines.ssr`, `redact-by-classification`) declare concrete paths and are left
on the exact match — the mode is opt-in precisely so it cannot widen a boundary
that did not ask for it.

No new declaration vocabulary. The bead asked whether a feed needs a spelling
meaning "each item"; it does not, because the index-free declaration already IS
that spelling — it is what the durable side has always meant by `[:data :email]`
on a page vector. The carrier now honours the reading the durable side
established.

## Proof

`epoch_egress_resource_trace_test.clj` §(rf2-zaopo) — a REAL
`[:rf.resource/ensure … :reply-to …]` against a registered infinite feed
(`:declared/feed`, enveloped pages + `:page->items`), driven through BOTH
continuation paths (async page-0 settle and fresh-skip cache hit).

RED and GREEN have identical test and assertion counts and differ only in
failures:

| | tests | assertions | failures | errors |
|---|---|---|---|---|
| RED (before the repair) | 58 | 395 | 19 | 0 |
| GREEN | 58 | 395 | 0 | 0 |

Both sides of the control are asserted, because over-redaction is as wrong as
under-redaction:

- `fx-carrier-keeps-an-undeclared-feeds-merged-items-byte-identical` — the same
  page through `:plain/feed`, which declares NEITHER axis: every reply-carrier
  row's tags are byte-identical raw vs projected, the merged items are readable
  field for field, and no carrier row is stamped `:sensitive?`. It passes before
  AND after, which is what makes it a control.
- the undeclared sibling `:display-name` survives inside EVERY item, while
  `:email` redacts and `:large`-declared `:avatar` becomes the size marker — the
  three-outcome triple per item.
- `fx-carrier-index-free-fork-does-not-reach-an-undeclared-nested-slot` — riding
  an index must not let a declaration FLOAT: an `:email` one NAMED slot deeper
  (`[:value 0 :meta :email]`) is a different position and rides verbatim.
- `trusted-local-include-sensitive-keeps-raw-declared-feed-items` — the
  redaction is the off-box default, not a strip.

## Out of scope

- **rf2-dl7bz** (a `:params`-rooted declaration riding raw inside the sibling
  `:resource/key`) is untouched — a separate ruling, and its residue note in
  `redact-reply-declarations` is preserved.
- **rf2-rnsv2** (the read-FAILURE continuation egressing a decoded error body)
  is not covered by this change: it reaches a different reply shape that
  `redact-continuation-reply` is not applied to.
- `epoch_egress_resource_trace_test.clj` §(rf2-ko5lm)'s prose residue note for
  rf2-dl7bz is left as prose, deliberately unasserted.

## Quality gates

All foreground, to completion. Each captured to a worktree-local log and the
captured rc cross-checked against the log's own `Ran …/failures` line.

**The bead's proof standard — identical test and assertion counts, failures the
only difference:**

| `implementation/epoch` §(rf2-zaopo) | tests | assertions | failures | errors |
|---|---|---|---|---|
| RED (before the repair) | 58 | 395 | **19** | 0 |
| GREEN | 58 | 395 | **0** | 0 |

**Regression evidence for the five callers this change deliberately did NOT
widen** (`redact-event-vec`, `project-execute-event-args`,
`http.privacy-body/classify-decoded`, `machines.ssr/project-snapshot-data`,
`redact-by-classification`):

| gate | tests | assertions | failures | errors | exit |
|---|---|---|---|---|---|
| `implementation/core` `clojure -M:test` | 2126 | 10492 | 0 | 0 | **0** |
| `implementation/resources` `clojure -M:test` | 734 | 6820 | 0 | 0 | **0** |
| `implementation/epoch` `clojure -M:test` | 514 | 6859 | 0 | 0 | **0** |
| `implementation/http` `clojure -M:test` | 493 | 3787 | 0 | 0 | **0** |
| `implementation/machines` `clojure -M:test` | 1195 | 4164 | 0 | 0 | **0** |
| `implementation` `npm run test:cljs` | 11549 | 57808 | 0 | 0 | **0** |

**Node tier / static gates:**

| gate | result | exit |
|---|---|---|
| `npm run test:script-policy` (`_changed-surfaces.test.cjs`) | 270 passed | **0** |
| `npm run test:script-helpers` | all passed | **0** |
| `check-per-ns-isolation.cjs --self-test` | passed | **0** |
| `check-per-ns-isolation.cjs` | all 17 namespaces pass standalone | **0** |
| `scripts/test-fast-pr.sh` | see below | — |

**One environmental flake, named rather than papered over.** The spine's first run
failed at `implementation JS harness helpers` with 36 `Command failed: bash -lc …`
errors, every one carrying
`dofork: child -1 … exit code 0xC0000142, errno 11 / Resource temporarily
unavailable` — the MSYS2 fork failure under host contention, not an assertion
failure. This diff touches no `.cjs`, no `scripts/`, no `.github/`, so
`_changed-surfaces.test.cjs` cannot be affected by it; re-run alone it passes
270/270, exit 0. The spine was re-run from scratch for a clean aggregate verdict.

**Not run by this spine** (its own PASS line enumerates them): browser lanes,
prod-elision / bundle-isolation / perf gates, adapter probes + smokes, Xray
feature matrix, mcp-conformance, tool JVM suites. CI owns those.

**Authoritative verdict: CI, on this PR's head — 65 checks pass, 11 skipped**
(all 11 skipped by surface classification: adapter/browser smokes, MkDocs,
Pages deploy, Freehand control-build probes, skills structural tests).
That supersedes the local spine, whose re-run was abandoned when the branch
was switched under it to split out a follow-up commit — recorded here rather
than quietly dropped. Every tier the spine covers is represented above by the
artefact suite or node step it runs, each executed foreground with its own
exit code.

