### PR TITLE
fix(machines-viz): refuse a share :host that already carries a URL fragment (rf2-xld5m)

### DIFF
--- a/tools/machines-viz/README.md
+++ b/tools/machines-viz/README.md
@@ -128,6 +128,17 @@ The page decodes the `#machine=` fragment entirely client-side, so the
 fragment never reaches your server and the host needs no application
 logic. Per [DESIGN-RATIONALE Lock #7](./spec/DESIGN-RATIONALE.md).
 
+Pass the page's URL **without a fragment of its own** — a query string is
+fine. The machine payload *is* the fragment, and a URL has only one, so
+`{:host ".../viewer.html#docs"}` would produce
+`.../viewer.html#docs#machine=…`: a link that looks right and that the
+viewer cannot read, because it stops at the first `#`. The encoder refuses
+that rather than shipping it (`:reason :host-carries-fragment`, rf2-xld5m).
+It does not otherwise parse the URL — a host that is not a URL comes back
+to you as `"banana#machine=…"`, visibly wrong before you share it, so
+`file:///…/viewer.html` and a relative `/viewer.html` both keep working.
+See [spec/API.md §What `:host` is checked for](./spec/API.md).
+
 ## How to test
 
 ```bash

--- a/tools/machines-viz/spec/API.md
+++ b/tools/machines-viz/spec/API.md
@@ -1643,7 +1643,10 @@ and need no server logic. Then pass its URL to the encoder:
 ```
 
 `:host` is required. Omitting it throws rather than guessing
-(`:reason :no-host`).
+(`:reason :no-host`), and it must carry no URL fragment of its own — the
+machine payload is the fragment (`:reason :host-carries-fragment`, see
+[§What `:host` is checked for](#what-host-is-checked-for-and-what-it-is-not-rf2-xld5m)).
+A query string is fine.
 
 ### The viewer is a page, not library surface
 
@@ -1686,12 +1689,48 @@ Source: lifted from
 
 (share/encode-share-url chart-state {})
 ;; => throws :rf.machines-viz.share/encode-failed, :reason :no-host
+
+(share/encode-share-url chart-state {:host "https://acme.example.com/viewer.html#docs"})
+;; => throws :rf.machines-viz.share/encode-failed, :reason :host-carries-fragment
 ```
 
-`:host` is **required** — the absolute URL of the viewer page the caller
-hosts (see [§Hosting](#hosting)). There is no default and no arity that
-omits it: the library cannot know where your viewer is served from, and
-the value it used to guess returned 404 (rf2-8m344).
+`:host` is **required** — the URL of the viewer page the caller hosts
+(see [§Hosting](#hosting)). There is no default and no arity that omits
+it: the library cannot know where your viewer is served from, and the
+value it used to guess returned 404 (rf2-8m344).
+
+#### What `:host` is checked for, and what it is not (rf2-xld5m)
+
+The machine payload **is** the URL fragment, so the encoder appends
+`#machine=<payload>` to the string you pass and checks exactly one thing:
+that the string carries no `#` of its own. A `:host` that already has a
+fragment is refused with `:host-carries-fragment`.
+
+It does **not** parse the URL, police the scheme, or require
+absoluteness, and that is a decision rather than an omission. A host that
+is not a URL fails *loudly*: `{:host "banana"}` returns
+`"banana#machine=…"`, which begins with the word you typed and is not a
+link in any browser. A scheme allowlist would also refuse working input
+to catch input nobody can miss — `file:///…/viewer.html` is exactly what
+the build recipe in [§Hosting](#hosting) leaves on disk, and a relative
+`"/viewer.html"` is a legitimate same-origin base for an in-app link.
+
+An existing fragment is the one defect the caller **cannot** see.
+`"https://acme.example.com/viewer.html#docs"` would produce
+
+```
+https://acme.example.com/viewer.html#docs#machine=<400 characters of base64>
+```
+
+— right origin, right path, `#machine=` present — and the viewer cannot
+read it, because a URL has one fragment and the decoder stops at the
+first `#` (it surfaces `:malformed-fragment`). Nobody counts `#`s in 400
+characters of base64, so the sender would ship a dead link and the
+failure would land on the recipient: the outcome rf2-8m344 removed the
+hosted default to stop. The encoder therefore **refuses** rather than
+silently stripping the caller's fragment, which would be a quieter wrong
+answer. A **query string is untouched** — it precedes the fragment, so
+`…/viewer.html?theme=dark` composes correctly.
 
 `chart-state` is a map with the schema in
 [§Share-URL payload schema](#share-url-payload-schema) below. The
@@ -1732,6 +1771,7 @@ Failure modes:
 | `:reason` | Meaning |
 |---|---|
 | `:no-host` | No non-blank `:host` was supplied. There is no default viewer host — see [§Hosting](#hosting). |
+| `:host-carries-fragment` | `:host` already contains a `#`. The machine payload rides in the fragment and a URL has only one, so a second `#` yields a link the viewer cannot read (rf2-xld5m). `ex-data` carries `:fragment-index` — the offset of the offending `#`, not the host itself, which may carry a query token. |
 | `:invalid-chart-state` | The allowlisted chart state fails the same `valid-chart-state?` predicate the decoder applies (a missing/malformed `:machine-id` or `:definition`, a non-keyword `:frame-id`, or a `:snapshot` `:state` that is none of the three configuration arms). Rejected at encode rather than emitted as an undecodable URL. |
 
 ### Decoder
@@ -1993,11 +2033,12 @@ private chart-state internals are never named in the user-facing message.
 (or a hiccup-equivalent reference). The export functions derive the
 payload from the element's bound props + the live snapshot.
 
-`opts` is required and must carry `:host`, which is passed to
-`encode-share-url` (see [§Hosting](#hosting)); it may also carry an
-optional `:frame-id` for payload provenance. Neither fn has an
-`opts`-free arity — a share-URL that does not name a viewer someone
-actually serves is a dead link (rf2-8m344).
+`opts` is required and must carry `:host`, which is passed straight to
+`encode-share-url` (see [§Hosting](#hosting)) and is subject to its rules
+— including the fragment refusal (`:host-carries-fragment`, rf2-xld5m).
+`opts` may also carry an optional `:frame-id` for payload provenance.
+Neither fn has an `opts`-free arity — a share-URL that does not name a
+viewer someone actually serves is a dead link (rf2-8m344).
 
 ### Mermaid `stateDiagram-v2`
 

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/export.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/export.cljs
@@ -619,10 +619,12 @@
   topology + active-state configuration off the DOM seam, projects them
   into a `ChartState`, and delegates to `share/encode-share-url`.
 
-  `opts` REQUIRES `:host` — the absolute URL of the viewer page you host,
-  passed straight to `share/encode-share-url`. There is no default host
-  (rf2-8m344), so there is no `opts`-free arity: a share-URL that does not
-  name a real viewer is a dead link. `opts` may also carry `:frame-id`
+  `opts` REQUIRES `:host` — the URL of the viewer page you host, passed
+  straight to `share/encode-share-url` and subject to its rules: there is
+  no default host (rf2-8m344), so there is no `opts`-free arity (a
+  share-URL that does not name a real viewer is a dead link), and the host
+  must carry no URL fragment of its own, since the machine payload IS the
+  fragment (`:reason :host-carries-fragment`, rf2-xld5m). `opts` may also carry `:frame-id`
   (the chart element doesn't know its frame; a host that does can supply a
   frame-target id for payload provenance). `:frame-id` is OPTIONAL
   (v2 / EP-0023) — omit it to share a topology that does not name a live

--- a/tools/machines-viz/src/day8/re_frame2_machines_viz/share.cljs
+++ b/tools/machines-viz/src/day8/re_frame2_machines_viz/share.cljs
@@ -505,11 +505,32 @@
   ;; => \"https://acme.example.com/viewer.html#machine=...\"
   ```
 
-  `:host` is REQUIRED — the absolute URL of the viewer page YOU host (see
+  `:host` is REQUIRED — the URL of the viewer page YOU host (see
   `tools/machines-viz/README.md` §Building and hosting the viewer page).
   There is no default and no Day8-hosted instance; the arity that used to
   supply one emitted a URL that 404s (rf2-8m344). Calling without a
   non-blank `:host` throws `:reason :no-host` rather than guessing.
+
+  ## What `:host` is checked for, and what it is not (rf2-xld5m)
+
+  The machine payload IS the URL fragment, so the encoder appends
+  `#machine=<payload>` to the string you pass and checks exactly one
+  thing: that the string carries no `#` of its own. A `:host` that
+  already has a fragment is REFUSED (`:reason :host-carries-fragment`) —
+  see the `when-let` below for why that one case is worth a refusal.
+
+  It does NOT parse the URL, police the scheme, or require
+  absoluteness, and that is deliberate rather than unfinished. A host
+  that is not a URL fails LOUDLY at first use: `{:host \"banana\"}`
+  returns `\"banana#machine=…\"`, which begins with the word you typed
+  and is not a link in anyone's browser. A scheme allowlist would also
+  refuse working input to catch input nobody can miss —
+  `file:///…/viewer.html` is exactly what the README's build recipe
+  leaves on disk, and a relative `\"/viewer.html\"` is a legitimate
+  same-origin base for an in-app link. A fragment is the one defect the
+  caller CANNOT see: `\"https://acme.example.com/viewer.html#docs\"`
+  yields a URL that looks perfectly right and fails only on the
+  recipient's machine.
 
   `chart-state` is a `ChartState` map (per `API.md` §Share-URL payload
   schema):
@@ -538,10 +559,11 @@
 
   Throws `:rf.machines-viz.share/encode-failed` (an ex-info) with:
 
-  | `:reason`              | Meaning |
+  | `:reason`                 | Meaning |
   |---|---|
-  | `:no-host`             | No non-blank `:host` was supplied. |
-  | `:invalid-chart-state` | The chart state does not validate — including a `:snapshot` `:state` that is none of the three allowed configuration arms (a malformed `:state` would yield an undecodable URL, so it is rejected at encode). |"
+  | `:no-host`                | No non-blank `:host` was supplied. |
+  | `:host-carries-fragment`  | `:host` already contains a `#`. The machine payload rides in the fragment, and a URL has only one — see below. |
+  | `:invalid-chart-state`    | The chart state does not validate — including a `:snapshot` `:state` that is none of the three allowed configuration arms (a malformed `:state` would yield an undecodable URL, so it is rejected at encode). |"
   [chart-state {:keys [host]}]
   (let [host (when (string? host) (str/trim host))]
     (when (str/blank? host)
@@ -560,6 +582,44 @@
                          :recovery    :supply-the-url-of-a-viewer-page-you-host
                          :reason      :no-host
                          :message     msg}))))
+    ;; rf2-xld5m — a `:host` that already carries a fragment is the ONE
+    ;; malformed host worth refusing, because it is the only one the caller
+    ;; cannot see. A URL has exactly one fragment and the machine payload IS
+    ;; that fragment, so appending a second `#` yields
+    ;;
+    ;;   https://acme.example.com/viewer.html#docs#machine=<400 chars>
+    ;;
+    ;; which reads as correct (right origin, right path, `#machine=` present)
+    ;; and is unreadable: `extract-fragment` splits on the FIRST `#`, so the
+    ;; viewer sees `docs#machine=…`, finds no `machine=` prefix, and refuses
+    ;; the link with `:malformed-fragment`. Nobody eyeballs 400 characters of
+    ;; base64 to count `#`s, so the sender ships a dead link and the failure
+    ;; lands on the recipient — the same outcome rf2-8m344 removed the hosted
+    ;; default to stop.
+    ;;
+    ;; We REFUSE rather than strip the caller's fragment: the fragment they
+    ;; passed meant something to them, and silently discarding it is just a
+    ;; quieter wrong answer. A query string is untouched — it precedes the
+    ;; fragment, so `…/viewer.html?theme=dark` composes correctly.
+    (when-let [hash-idx (str/index-of host "#")]
+      (let [msg (str "cannot encode a share-URL: :host already carries a URL "
+                     "fragment (a '#' at index " hash-idx "). The machine "
+                     "payload IS the fragment, and a URL has only one — a "
+                     "second '#' produces a link the viewer cannot read, "
+                     "because it stops at the first. Pass the viewer page URL "
+                     "with no fragment; a query string is fine "
+                     "(\"https://your.example.com/viewer.html?theme=dark\").")]
+        (throw (ex-info (error/human-message :rf.machines-viz.share/encode-failed msg)
+                        {:rf.error/id :rf.machines-viz.share/encode-failed
+                         :where       'machines-viz.share/encode-share-url
+                         :recovery    :pass-a-viewer-page-url-with-no-fragment
+                         :reason      :host-carries-fragment
+                         :message     msg
+                         ;; The OFFSET, not the host itself: a viewer URL can
+                         ;; carry a query string with a token in it, and this
+                         ;; namespace keeps raw caller values out of ex-data
+                         ;; (rf2-8nzxib).
+                         :fragment-index hash-idx}))))
     (let [allowlisted (allowlist-chart-state chart-state)]
       (when-not (valid-chart-state? allowlisted)
         ;; rf2-vvixub — the ex-message is the human sentence + the

--- a/tools/machines-viz/test/day8/re_frame2_machines_viz/share_cljs_test.cljs
+++ b/tools/machines-viz/test/day8/re_frame2_machines_viz/share_cljs_test.cljs
@@ -17,7 +17,11 @@
   - Versioned envelope: `:rf.machines-viz.share/v` rides outermost;
     a newer version is rejected with `:unknown-version`.
   - Every documented `decode-failed` `:reason`.
-  - Host override + `chart-state->props` projection."
+  - Host override + `chart-state->props` projection.
+  - The `:host` fragment rule (rf2-xld5m): a fragment-bearing host is
+    refused, and — the negative control — every fragment-free host still
+    encodes byte-identically, including the relative / `file://` forms
+    the encoder deliberately does not police."
   (:require [cljs.test :refer-macros [deftest is testing]]
             [clojure.string :as str]
             [clojure.walk]
@@ -52,6 +56,18 @@
                 (str/replace "/" "_")
                 (str/replace "=" ""))]
     (str test-host "#machine=" b64)))
+
+(defn- frozen-now
+  "Run `f` with `js/Date.now` pinned to a constant so the envelope's
+  non-reproducible `:created` stamp doesn't perturb byte-identity
+  assertions. (`:created` is the ONE allowed non-reproducible bit per
+  Principles §Reproducible from the registry alone.)"
+  [f]
+  (let [orig (.-now js/Date)]
+    (try
+      (set! (.-now js/Date) (fn [] 1736000000000))
+      (f)
+      (finally (set! (.-now js/Date) orig)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Fixtures
@@ -222,19 +238,112 @@
                            (catch :default _ nil)))))))
 
 ;; ---------------------------------------------------------------------------
-;; Canonicalisation / reproducibility
+;; rf2-xld5m — the `:host` fragment rule, and the deliberate LIMIT of it.
+;;
+;; Measured before anything was written. Every non-URL `:host` the encoder
+;; accepts produces a string that BEGINS with what the caller typed —
+;; `{:host "banana"}` → `"banana#machine=…"` — so a wrong host is visible at a
+;; glance and dead at first paste. One malformed host is different: a `:host`
+;; that already carries a fragment yields
+;; `…/viewer.html#docs#machine=<400 chars>`, which reads as correct and is
+;; unreadable, because `extract-fragment` stops at the FIRST `#`. The sender
+;; sees success; the recipient gets `:malformed-fragment`.
+;;
+;; So the refusal is exactly one check wide, and the two tests below pin BOTH
+;; sides of it: fragment-bearing hosts are refused, and every other host —
+;; absolute, relative, ported, queried, `file://` — still passes through
+;; VERBATIM with a byte-identical payload.
 
-(defn- frozen-now
-  "Run `f` with `js/Date.now` pinned to a constant so the envelope's
-  non-reproducible `:created` stamp doesn't perturb byte-identity
-  assertions. (`:created` is the ONE allowed non-reproducible bit per
-  Principles §Reproducible from the registry alone.)"
-  [f]
-  (let [orig (.-now js/Date)]
-    (try
-      (set! (.-now js/Date) (fn [] 1736000000000))
-      (f)
-      (finally (set! (.-now js/Date) orig)))))
+(def ^:private fragment-bearing-hosts
+  "Hosts whose `#` makes the machine payload unreachable. Each one encoded
+  successfully before rf2-xld5m and produced a link the viewer refused."
+  {:trailing-fragment   "https://acme.example.com/viewer.html#docs"
+   :bare-hash           "https://acme.example.com/viewer.html#"
+   :already-a-share-url "https://acme.example.com/viewer.html#machine=AAAA"
+   :fragment-with-query "https://acme.example.com/viewer.html?theme=dark#docs"
+   :bare-fragment       "#machine=x"})
+
+(deftest host-carrying-a-fragment-is-refused
+  (testing "rf2-xld5m — a :host that already has a URL fragment is refused at
+            encode: the payload IS the fragment, and the viewer stops at the
+            first '#'"
+    (doseq [[label host] fragment-bearing-hosts]
+      (let [r (try {:url (share/encode-share-url chart-state {:host host})}
+                   (catch :default e {:data (ex-data e)}))
+            d (:data r)]
+        (is (nil? (:url r))
+            (str label ": no URL is produced for a fragment-bearing host"))
+        (is (= :host-carries-fragment (:reason d))
+            (str label ": refused with the :host-carries-fragment reason"))
+        (is (= :rf.machines-viz.share/encode-failed (:rf.error/id d)))
+        (is (= :pass-a-viewer-page-url-with-no-fragment (:recovery d)))
+        ;; The diagnostic NAMES what was wrong — the fragment, and where.
+        (is (str/includes? (:message d) "fragment")
+            (str label ": the message names the fragment"))
+        (is (= (str/index-of host "#") (:fragment-index d))
+            (str label ": ex-data locates the offending '#'"))
+        ;; …without echoing the caller's URL (which can carry a query token).
+        (is (not (str/includes? (pr-str d) host))
+            (str label ": the raw host is not echoed into ex-data"))))))
+
+(def ^:private fragment-free-hosts
+  "The NEGATIVE CONTROL roster. Every legitimate viewer base a caller might
+  host the page at — plus the relative and non-http forms the encoder
+  deliberately does NOT police (a `file://` URL is literally what the README's
+  build recipe leaves on disk, and `/viewer.html` is a legitimate same-origin
+  base). None of them carries a fragment, so none of them may be refused."
+  ["https://acme.example.com/viewer.html"
+   "https://acme.example.com"
+   "https://acme.example.com/deep/path/to/viewer.html"
+   "https://acme.example.com/viewer.html?theme=dark"
+   "https://acme.example.com/viewer.html?a=1&b=2"
+   "https://acme.example.com:8443/viewer.html"
+   "https://acme.example.com/a%20path/viewer.html"
+   "http://localhost:8080/viewer.html"
+   "file:///C:/out/machines-viz-viewer/viewer.html"
+   "//acme.example.com/viewer.html"
+   "/viewer.html"
+   "viewer.html"
+   "  https://acme.example.com/viewer.html  "])   ;; trimmed, as before
+
+(deftest fragment-free-hosts-are-untouched
+  (testing "rf2-xld5m NEGATIVE CONTROL — every host without a '#' still
+            encodes EXACTLY as before: the host is passed through verbatim
+            (only trimmed), the payload is byte-identical, and the URL decodes"
+    (frozen-now
+      (fn []
+        ;; The fragment does not depend on the host, so with `:created` frozen
+        ;; it must be identical for every base — which is what "unchanged"
+        ;; means here: no normalising, no rewriting, no re-encoding.
+        (let [canonical-fragment (subs (encode chart-state) (count test-host))]
+          (is (str/starts-with? canonical-fragment "#machine="))
+          (doseq [host fragment-free-hosts]
+            (let [url (share/encode-share-url chart-state {:host host})]
+              (is (= (str (str/trim host) canonical-fragment) url)
+                  (str host ": host passed through verbatim + identical payload"))
+              (let [{:keys [ok error]} (share/decode-share-url-safe url)]
+                (is (nil? error) (str host ": decodes without error"))
+                (is (= :auth/login-flow
+                       (get-in ok [:rf.machines-viz.share/chart :machine-id]))
+                    (str host ": the ChartState round-trips"))))))))))
+
+(deftest non-url-host-is-accepted-and-fails-visibly
+  (testing "rf2-xld5m — a host that is not a URL is NOT refused, and that is
+            the ruling rather than an omission: the failure is LOUD. The
+            returned string begins with the word the caller typed, so the
+            defect is on screen before anyone shares it. A scheme allowlist
+            would refuse the working forms above to catch this."
+    (doseq [host ["banana" "not a url" "javascript:alert(1)"]]
+      (let [url (share/encode-share-url chart-state {:host host})]
+        (is (str/starts-with? url (str host "#machine="))
+            (str host ": the caller's own string is what they get back"))
+        ;; The PAYLOAD is well-formed — only the base is nonsense, which is
+        ;; precisely why this class needs no guard: nothing is hidden.
+        (is (some? (:ok (share/decode-share-url-safe url)))
+            (str host ": the machine payload itself is intact"))))))
+
+;; ---------------------------------------------------------------------------
+;; Canonicalisation / reproducibility
 
 (deftest reproducible-encoding
   (testing "differently-ordered but equal ChartStates encode identically"


### PR DESCRIPTION
Closes rf2-xld5m.

## What a non-URL actually does today (measured, not reasoned)

Before writing any validation I probed `encode-share-url` through the real CLJS lane with 17 hosts. Two distinct classes came back:

**Loud** — the string returned begins with what the caller typed, and the payload is fine:

| `:host` | returned | decodes? |
|---|---|---|
| `banana` | `banana#machine=…` | OK |
| `/viewer.html` | `/viewer.html#machine=…` | OK |
| `viewer.html` | `viewer.html#machine=…` | OK |
| `//acme.example.com/viewer.html` | `//acme.example.com/viewer.html#machine=…` | OK |
| `javascript:alert(1)` | `javascript:alert(1)#machine=…` | OK |

Nothing is hidden here. `banana#machine=…` is not a link in any browser, the defect is the caller's own word sitting at the front of the string, and it dies at first paste. Per the house rule this is not a guard's business — and a scheme allowlist would refuse forms that legitimately work: `file:///…/viewer.html` is exactly what the README's build recipe leaves on disk, and `/viewer.html` is a legitimate same-origin base for an in-app link.

**Silent** — the string looks correct and the recipient gets a dead link:

| `:host` | returned | decodes? |
|---|---|---|
| `https://acme.example.com/viewer.html#foo` | `…/viewer.html#foo#machine=…` | **`:malformed-fragment` — "URL carries no #machine= share fragment"** |
| `https://acme.example.com/viewer.html#` | `…/viewer.html##machine=…` | **`:malformed-fragment`** |
| `https://acme.example.com/viewer.html#machine=AAAA` | `…#machine=AAAA#machine=…` | **`:malformed-fragment` — "not valid base64url"** |

Right origin, right path, `#machine=` present, 400 characters of base64 nobody counts `#`s in. `extract-fragment` splits on the FIRST `#`, so the viewer never sees the payload. The sender sees success; the failure lands on the recipient — the same dead-link-that-looks-right outcome rf2-8m344 removed the hosted default to stop.

## Outcome: both, split along that line

- **A refusal for the fragment case only.** `:reason :host-carries-fragment`, with a diagnostic that names the fragment and its index. It reports the OFFSET rather than echoing the host, because a viewer URL can carry a query token and this namespace keeps raw caller values out of `ex-data` (rf2-8nzxib). It refuses rather than strips: the caller's fragment meant something to them, and discarding it silently is just a quieter wrong answer.
- **A contract correction for everything else.** The docstring said "the absolute URL" and the encoder never enforced absoluteness. It now says what IS checked (one `#`), what is not (parsing, scheme, absoluteness), and why the asymmetry is right. Same correction in `spec/API.md` and `README.md`.

A query string is untouched — it precedes the fragment, so `…/viewer.html?theme=dark` composes correctly.

## Witnesses

- **Positive** — `host-carrying-a-fragment-is-refused`: 5 fragment-bearing hosts (trailing fragment, bare `#`, an already-built share URL, fragment-after-query, bare fragment) each refused with `:host-carries-fragment`, the right `:rf.error/id` / `:recovery`, a message naming the fragment, `:fragment-index` locating the `#`, and no raw host in `ex-data`.
- **Negative control** — `fragment-free-hosts-are-untouched`: 13 hosts (plain https, no-path, deep path, query, multi-query, explicit port, percent-encoded path, http+localhost, `file://`, protocol-relative, root-relative, bare relative, untrimmed) must each produce `(str (trim host) canonical-fragment)` with `:created` frozen — i.e. the host passes through verbatim and the payload is **byte-identical** to the canonical encode. No normalising, no rewriting. Each also decodes back to the ChartState.
- **The ruling, pinned** — `non-url-host-is-accepted-and-fails-visibly`: `banana` / `not a url` / `javascript:alert(1)` are still ACCEPTED, and the test says why, so a future guard-adder has to confront the decision rather than quietly widen the check.

## Scope

This is input validation at the encoder boundary only. It adds no hosting or deployment machinery and it does not touch the sibling defect rf2-8m344 (the default viewer URL 404s and no workflow ships the page bundle) — **the viewer is still not deployed anywhere by this repository, and nothing here implies the share path works end to end.**

`tools/xray/spec/*` is unchanged because Xray's spec does not document the machines-viz share `:host` contract (`grep` for `encode-share-url` / `:host` across `tools/xray` finds only an unrelated `:host-transient` and an Xray-local `:rf.xray/share-url` sub).

## Quality gates

Running:

- `tools/machines-viz` JVM lane — `clojure -M:test`
- `tools/machines-viz` CLJS lane — `npm run test:tools-machines-viz`
- mutation check that the new refusal is load-bearing

Results reported below as they land.
