### PR TITLE
fix(freehand): a :map-props adapter answers the caller's OWN keys (rf2-drpa3.182.3)

### DIFF
--- a/docs/api/re-frame.freehand.md
+++ b/docs/api/re-frame.freehand.md
@@ -1334,10 +1334,15 @@ an open flag is writable and not buffered, so it takes the key and no generation
 
   `:map-props` is one optional whole-ordinary-props adapter, run in the browser
   only, for preparing non-portable host values. Callback carriers, children and
-  the key are withheld from it and installed afterwards, so it can neither supply
-  nor replace a reserved fact; a returned map that names one is refused. It
-  answers under the same naming law: the adapter owns the ordinary plane's
-  values, and the names stay the caller's.
+  the key are withheld from it and installed afterwards, and its answer carries
+  **exactly the keys the call authored**. The adapter owns the ordinary plane's
+  values — that is what it is for — and the names stay the caller's, so key-set
+  equality is the one law the answer owes: a name it invents would reach React
+  under a name nobody authored and would put the reserved facts back within
+  reach of a plane they were withheld from, and a name it drops would leave the
+  structural tree, which records the authored props, reporting a prop React
+  never received. A host whose props want renaming renames them inside the
+  registered React component.
 
   A structural render emits an honest marker — the declared host id, the declared
   SSR policy, a **count** of the children that crossed into React's tree, and the

--- a/implementation/freehand/src/re_frame/freehand.cljc
+++ b/implementation/freehand/src/re_frame/freehand.cljc
@@ -2313,14 +2313,20 @@
 
      Runs on the WHOLE ordinary-props map, in the browser only, to prepare
      non-portable host values. Callback carriers and trailing children are
-     withheld from it and installed afterwards, so it cannot supply or
-     replace a declared callback, the children, the key or any other
-     reserved fact; a returned map that names one is refused. It answers
-     under the caller's own naming law, which is what makes that refusal
-     total: the adapter owns the ordinary plane's VALUES, and the names
-     stay the caller's. The structural tree records the AUTHORED props, not
-     the adapter's output — an adapter exists to make values a tree could
-     not print.
+     withheld from it and installed afterwards.
+
+     **Its answer carries EXACTLY the keys the call authored.** The adapter
+     owns the ordinary plane's VALUES — that is the whole of what it is
+     for — and the names stay the caller's, so key-set equality is the one
+     law the answer owes. A name it invents is a rename no call site can
+     see: it would reach React under a name nobody authored, and it would
+     put the key, the children and every declared callback position back
+     within reach of a plane they were withheld from. A name it drops would
+     leave the structural tree — which records the AUTHORED props, because
+     an adapter exists to make values a tree could not print — reporting a
+     prop React never received. Prepare the value under the caller's key; a
+     host whose props want renaming renames them in the registered React
+     component, where it is ordinary React code.
 
      ## Structure and SSR
 

--- a/implementation/freehand/src/re_frame/freehand/descriptor.cljc
+++ b/implementation/freehand/src/re_frame/freehand/descriptor.cljc
@@ -663,11 +663,10 @@
   SECOND spelling.
 
   A second spelling is not a cosmetic matter. Every law this boundary
-  enforces — `:children` is the trailing-forms slot, `:key` is the ABI's,
-  a declared callback position takes a carrier and nothing else, a
-  `:map-props` adapter may not supply a reserved fact — is enforced by
-  NAME. So `\"children\"`, `:x/key` and a `\"onSelect\"` no declaration can
-  see would each arrive at React under the reserved name while passing
+  enforces — `:children` is the trailing-forms slot, `:key` is the ABI's, a
+  declared callback position takes a carrier and nothing else — is enforced
+  by NAME. So `\"children\"`, `:x/key` and a `\"onSelect\"` no declaration
+  can see would each arrive at React under the reserved name while passing
   every check that looked for the keyword. Refusing the spelling closes all
   of them at once, and closes them where the name is authored rather than
   at each check in turn."
@@ -675,6 +674,32 @@
   (vec (sort-by pr-str
                 (remove #(and (keyword? %) (nil? (namespace %)))
                         (keys m)))))
+
+(defn host-prop-name-drift
+  "How a `:map-props` adapter's `answered` map differs from the `authored`
+  ordinary plane BY NAME — `{:created […] :dropped […]}`, each sorted for a
+  diagnostic. Both are empty exactly when the two key sets are EQUAL, which
+  is the law: the adapter owns the ordinary plane's VALUES, so the names
+  stay the caller's.
+
+  Equality rather than a subset, and it is the *whole* law the answer owes.
+  Every fact the adapter is denied is denied BY NAME — `:key` and the
+  declared callback positions were removed from this plane before it was
+  handed over, `:children` was refused at the call, and an inexact spelling
+  was refused there too ([[inexact-host-prop-names]]). An answer that
+  carries the caller's own keys therefore cannot name a reserved fact and
+  cannot name an unspellable one: there is nothing left to filter. A
+  created name would put all of that back within reach, and a dropped one
+  would leave the structural projection — which records the AUTHORED props,
+  because the adapter exists to build values a portable tree cannot print —
+  reporting a prop React never received.
+
+  So one law, checked once, is the same shape [[host-prop-name]] has: the
+  crossing name is settled where it is authored rather than re-litigated at
+  each check that reads it."
+  [authored answered]
+  {:created (vec (sort-by pr-str (remove #(contains? authored %) (keys answered))))
+   :dropped (vec (sort-by pr-str (remove #(contains? answered %) (keys authored))))})
 
 (defn- host-callback-value
   "Validate one declared callback position's supplied `value` against its

--- a/implementation/freehand/src/re_frame/freehand/react.cljs
+++ b/implementation/freehand/src/re_frame/freehand/react.cljs
@@ -946,8 +946,9 @@
   projection, and the two planes cannot collide on one name: the ordinary
   plane has had the declared positions removed from it, and every key in
   either plane is an unqualified keyword — the exactness
-  `descriptor/inexact-host-prop-names` enforces on the caller's map and on
-  a `:map-props` adapter's answer alike. So this writer never has to ask
+  `descriptor/inexact-host-prop-names` enforces on the caller's map, which
+  a `:map-props` adapter's answer inherits by carrying the caller's own
+  keys (`descriptor/host-prop-name-drift`). So this writer never has to ask
   what a name might already mean."
   [cand ordinary callbacks]
   (let [o (js-obj)]
@@ -979,8 +980,8 @@
   component's own tree (so the tree's context reaches them)."
   [cand head {:keys [props callbacks] kid-forms :children}]
   (let [entry     (descriptor/host-entry head)
-          host-id   (:host-id entry)
-          component (:component entry)
+        host-id   (:host-id entry)
+        component (:component entry)
         mapper    (:map-props entry)
         ordinary  (if mapper (mapper props) props)]
     (when (nil? component)
@@ -997,32 +998,34 @@
              (type-name ordinary) ". It prepares the ordinary-props MAP and must "
              "answer one — it is not a place to build the element.")
         {:host host-id}))
-    ;; The adapter's answer is held to the caller's own naming law, and
-    ;; BEFORE the reserved check below — which is what makes that check
-    ;; total. Asked the other way round, an adapter returning `"key"` or
-    ;; `"onSelect"` would pass a filter looking for the keyword and then
-    ;; reach React under the reserved name anyway.
-    (let [inexact (descriptor/inexact-host-prop-names ordinary)]
-      (when (seq inexact)
-        (malformed!
-          (str "The :map-props adapter on " host-id " returned " (pr-str inexact)
-               ". A host prop name is EXACT — an unqualified keyword, spelled as "
-               "the library spells the prop — because the name is what every "
-               "reserved-fact check reads. The adapter prepares VALUES the "
-               "authored map could not hold; the names stay the caller's.")
-          {:host host-id :props inexact})))
-    (let [reserved (vec (sort (filter (fn [k] (or (contains? (:callbacks entry) k)
-                                                  (= :key k)
-                                                  (= :children k)))
-                                      (keys ordinary))))]
-      (when (seq reserved)
-        (malformed!
-          (str "The :map-props adapter on " host-id " returned " (pr-str reserved)
-               ". The adapter owns the ORDINARY plane only: declared callbacks, "
-               "children, the key and every other reserved Freehand fact are "
-               "withheld from it and installed afterwards, so it can neither "
-               "supply nor replace one.")
-          {:host host-id :reserved reserved})))
+    ;; The adapter's KEY SET is the caller's — the one law the answer owes,
+    ;; enforced here because this is the only place both maps exist. It is
+    ;; the whole law: `props` has already had `:key` and the declared
+    ;; positions removed, `:children` and every inexact spelling refused at
+    ;; the call, so an answer carrying the caller's own keys cannot name a
+    ;; reserved fact or an unspellable one, and there is no filter left to
+    ;; make total.
+    (when mapper
+      (let [{:keys [created dropped]} (descriptor/host-prop-name-drift props ordinary)]
+        (when (or (seq created) (seq dropped))
+          (malformed!
+            (str "The :map-props adapter on " host-id " answered a different KEY SET "
+                 "than the call authored"
+                 (when (seq created) (str " — created " (pr-str created)))
+                 (when (seq dropped)
+                   (str (if (seq created) ", dropped " " — dropped ") (pr-str dropped)))
+                 ". The adapter prepares the ordinary plane's VALUES, which is why "
+                 "it exists at all: it builds what the authored map could not hold. "
+                 "The names stay the caller's, so it answers the caller's OWN keys. "
+                 "A name it invents is a rename no call site can see — it reaches "
+                 "React under a name nobody authored, and it puts :key, :children "
+                 "and every declared callback position back within reach of a plane "
+                 "they were withheld from. A name it drops leaves the structural "
+                 "tree, which records the AUTHORED props, reporting a prop React "
+                 "never received. Prepare the value under the caller's key; a host "
+                 "whose props want renaming renames them inside the registered "
+                 "React component, where it is ordinary React code.")
+            {:host host-id :created created :dropped dropped}))))
     (apply react/createElement
            component
            (host-props cand ordinary callbacks)

--- a/implementation/freehand/test/re_frame/freehand/host_mounted_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/host_mounted_dom_cljs_test.cljs
@@ -195,15 +195,42 @@
    :ssr       :client-only
    :map-props (fn [p] {:spec (clj->js (:spec p))})})
 
+;; The three ways an adapter can answer a key set that is not the caller's.
+;; Same component, same declaration, one adapter each — so the only variable
+;; between these and `vega-host` above is the answer's KEY SET.
+
 (v/defhost renaming-host
-  "A host whose adapter tries to rename its way past the reserved-fact
-  check — the browser half of the naming law FH-REACT-007 §prop-names
-  states. The adapter owns VALUES; the names stay the caller's."
+  "The MINIMAL violation, and the one the merged-PR audit of #7081 named: an
+  ordinary unqualified RENAME. `:chartSpec` is exact, unreserved, and a name
+  the call never supplied, so no per-key filter over the answer can see it —
+  only the authored key set can. The adapter owns VALUES; the names stay the
+  caller's."
+  vega-chart
+  {:callbacks {:onSelect :event}
+   :children  :none
+   :ssr       :client-only
+   :map-props (fn [p] {:chartSpec (:spec p)})})
+
+(v/defhost smuggling-host
+  "A reserved fact under a second spelling. It is refused as the CREATED name
+  it is — the key-set law needs no separate reserved-name filter to be total,
+  because the plane the adapter was handed had those facts removed already."
   vega-chart
   {:callbacks {:onSelect :event}
    :children  :none
    :ssr       :client-only
    :map-props (fn [_p] {"key" "smuggled" "onSelect" "smuggled" :x/spec 1})})
+
+(v/defhost dropping-host
+  "The mirror half: an authored key the answer LOSES. The structural tree
+  records the AUTHORED props, so a dropped key leaves it reporting a prop
+  React never received — which is why the law is equality in both directions
+  rather than a subset."
+  vega-chart
+  {:callbacks {:onSelect :event}
+   :children  :none
+   :ssr       :client-only
+   :map-props (fn [p] {:spec (:spec p)})})
 
 ;; ===========================================================================
 ;; The application under mount
@@ -477,37 +504,77 @@
                         (done)))))))))
 
 ;; ===========================================================================
-;; The naming law, browser half — a `:map-props` adapter may not rename
+;; The key-set law, browser half — a `:map-props` adapter answers the
+;; caller's OWN keys
 ;; ===========================================================================
 
-(deftest d022-a-map-props-adapter-answers-under-the-callers-naming-law
+(def ^:private drift-cases
+  "Each rostered reject row's declaration and call site, keyed by the
+  `[authored answers]` key vectors FH-REACT-007 states for it. Keying on the
+  roster's own statement rather than on position means a row added to the
+  fixture with no declaration here reds, and a declaration whose adapter
+  stops matching its row reds too — neither file can drift alone."
+  {[[:spec] [:chartSpec]]
+   [renaming-host  {:spec {:mark "bar" :values [1]}}]
+
+   [[:spec] ["key" "onSelect" :x/spec]]
+   [smuggling-host {:spec {:mark "bar" :values [1]}}]
+
+   [[:spec :rows] [:spec]]
+   [dropping-host  {:spec {:mark "bar" :values [1]} :rows 3}]})
+
+(deftest d022-a-map-props-adapter-answers-the-callers-own-keys
   (testing "Per FH-REACT-007 §prop-names §map-props-adapter: the adapter
-            owns the ordinary plane's VALUES, and the names stay the
-            caller's.
+            owns the ordinary plane's VALUES, the names stay the caller's,
+            and the law that makes those words true is key-set EQUALITY,
+            enforced at the crossing where the authored plane and the
+            answer both exist.
 
-            This is the second half of the defect the reopen named. The
-            reserved-fact check filtered the adapter's answer for the
-            KEYWORDS `:key`, `:children` and each declared position, while
-            the crossing named every key by `name` — so an adapter
-            returning `\"key\"` or `\"onSelect\"` passed the filter and
-            reached React under the reserved name anyway. Holding the
-            answer to the caller's own exactness law FIRST is what makes
-            that filter total.
+            The merged-PR audit of #7081 found nothing enforcing it. The
+            landed checks filtered the ANSWER for inexact names and then
+            for reserved ones, which catches `\"key\"` and `:x/spec` and
+            cannot catch the ordinary case: `:chartSpec` is exact,
+            unreserved, and a name the call never supplied. The first row
+            below is that case, and it is the row this suite was missing.
 
-            No commit needed: the refusal is the emitter's, so this row
-            runs in the node lane too."
-    (let [d (conf/caught-data #(fr/element [renaming-host {:spec {:mark "bar" :values [1]}}]))]
-      (is (= (get-in react-007 [:prop-names :map-props-adapter :error-id])
-             (:rf.error/id d))
-          "the adapter's answer is refused")
-      (doseq [k (get-in react-007 [:prop-names :map-props-adapter :rejects])]
-        (is (some #(= k %) (:props d))
-            (str "and " (pr-str k) " is named in the refusal"))))))
+            Equality subsumes both filters rather than joining them, which
+            the second row is here to show: `\"key\"` and `\"onSelect\"` are
+            refused as CREATED names, because the plane handed to the
+            adapter had `:key` and the declared positions removed before it
+            arrived. The third row is the mirror direction — the structural
+            tree records the AUTHORED props, so an answer that drops a key
+            leaves it reporting a prop React never received.
 
-(deftest d022-a-well-named-adapter-still-crosses
-  (testing "The positive control for the row above: the SAME machinery, an
-            adapter that spells its answer exactly, and the crossing
-            happens. Without this, the refusal above could be a host that
-            never crosses at all."
+            No commit needed: the refusal is the emitter's, so these rows
+            run in the node lane too."
+    (let [{:keys [error-id rejects]} (get-in react-007 [:prop-names :map-props-adapter])]
+      (is (<= 3 (count rejects)) "the roster states the rows")
+      (doseq [{:keys [case authored answers created dropped]} rejects]
+        (if-let [[host props] (get drift-cases [authored answers])]
+          (let [d (conf/caught-data #(fr/element [host props]))]
+            (is (= error-id (:rf.error/id d))
+                (str "refused: " case))
+            (is (= created (:created d))
+                (str "and names exactly what was created, per the roster: " case))
+            (is (= dropped (:dropped d))
+                (str "and exactly what was dropped, per the roster: " case)))
+          (is false (str "no declaration here answers the rostered row: " case)))))))
+
+(deftest d022-a-key-set-preserving-adapter-still-crosses
+  (testing "The negative control for the rows above, and the half only it
+            can catch: over-refusing is as wrong as under-refusing. The
+            SAME machinery, an adapter that owns values and preserves the
+            caller's keys, and the crossing happens — `vega-host` prepares
+            `:spec` into a JS object under `:spec`, which is the whole
+            legitimate use of the option.
+
+            The mounted row above carries this further, to a real commit and
+            a click; this row is the emitter-only floor, so a regression
+            that refused every adapter would red in the node lane too."
+    (let [{:keys [accepts]} (get-in react-007 [:prop-names :map-props-adapter])]
+      (is (seq accepts) "the roster states the accepting row")
+      (doseq [{:keys [case authored answers]} accepts]
+        (is (= (set authored) (set answers))
+            (str "an accepted row is one whose key sets are EQUAL: " case))))
     (is (some? (fr/element [vega-host {:spec {:mark "bar" :values [1]}}]))
-        "an exactly-named adapter answer produces a real React element")))
+        "a key-set-preserving adapter answer produces a real React element")))

--- a/implementation/freehand/test/re_frame/freehand/roster_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/roster_cljs_test.cljc
@@ -144,24 +144,26 @@
     (is (= {:modes #{:interpreted :compiled} :hosts #{:jvm :browser}}
            (select-keys (roster/by-id :FH-REACT-007) [:modes :hosts])))))
 
-(deftest an-unsettled-boundary-is-named-rather-than-pinned
-  (testing "Per rf2-drpa3.182.3 (open, from the merged-PR audit of #7081):
-            the `:map-props` key-set law — equality or output subset — is
-            not settled, so no rostered projection asserts either answer.
-            The record says so under `:open`, keyed by the bead that owns
-            the question. This row exists so that removing the note is a
-            deliberate act by whoever settles it, rather than a silent drift
-            back to an unmarked gap; it asserts the QUESTION is recorded and
-            asserts nothing about the answer."
-    (let [open (get-in (roster/by-id :FH-REACT-007) [:fh/record :open])]
-      (is (contains? open :rf2-drpa3.182.3)
-          "the host record names the bead that owns the naming boundary")
-      (is (re-find #"map-props" (get open :rf2-drpa3.182.3))
-          "and states which boundary is unsettled"))
-    (testing "and no other spine member is holding an open question"
-      (is (= [:FH-REACT-007]
-             (filterv #(seq (get-in (roster/by-id %) [:fh/record :open]))
-                      roster/spine-ids))))))
+(deftest the-spine-holds-no-open-boundary
+  (testing "`:open` is the record key for a boundary of a law that is NOT
+            settled, and the spine currently holds none. FH-REACT-007 held
+            the last one — the `:map-props` key-set law, equality or output
+            subset, recorded as a question rather than pinned to the
+            behaviour that shipped so that settling it would not mean
+            fighting the roster. rf2-drpa3.182.3 settled it as key-set
+            EQUALITY, enforced at the crossing where the authored plane and
+            the adapter's answer both exist, and the answer moved into
+            `:prop-names` §`:map-props-adapter` where the rows that run
+            live.
+
+            This row is the ratchet, in the direction that matters now: a
+            NEW open note is a deliberate act with a bead behind it, and
+            reads as a change to this list rather than as prose nobody
+            diffs. It says nothing about which answers the settled rows
+            reached — those rows assert themselves."
+    (is (= [] (filterv #(seq (get-in (roster/by-id %) [:fh/record :open]))
+                       roster/spine-ids))
+        "no spine member is holding an open question")))
 
 ;; ---------------------------------------------------------------------------
 ;; Applicability parsing — the join's one piece of grammar

--- a/spec/004-Views.md
+++ b/spec/004-Views.md
@@ -1904,11 +1904,21 @@ component is the intended route, not a hook API in Freehand.
 A declaration MAY carry one whole-ordinary-props `:map-props` adapter to prepare
 non-portable host values. It runs in the browser only, and on the ordinary plane
 only: callback carriers and trailing children are WITHHELD from it and installed
-afterwards. The adapter MUST NOT supply or replace declared callbacks, children,
-the key, or any other reserved Freehand fact, and a returned map naming one is
-refused. It answers under the caller's own naming law — the adapter owns the
-ordinary plane's VALUES, and the names stay the caller's — which is what makes
-that refusal total rather than a filter a second spelling walks past.
+afterwards.
+
+**The adapter's answer carries EXACTLY the keys the call authored.** It owns the
+ordinary plane's VALUES — that is why it exists, to build what the authored map
+could not hold — and the names stay the caller's, so key-set equality is the
+whole law the answer owes and it is enforced where the authored plane and the
+answer both exist. Equality rather than a subset, in both directions. A created
+name is a rename no call site can see: it would reach React under a name nobody
+authored, and it would put `:key`, `:children` and every declared callback
+position back within reach of a plane they were withheld from — which is how the
+adapter MUST NOT supply or replace a reserved Freehand fact, without a
+reserved-name filter for a second spelling to walk past. A dropped name would
+leave the structural projection, which records the AUTHORED props, reporting a
+prop React never received. A host whose props want renaming renames them inside
+the registered React component.
 
 Props-contract evidence under `:props` is OPTIONAL for application-private
 declarations; the stronger publication policy of

--- a/spec/conformance/freehand/fixtures/fh-react-007.edn
+++ b/spec/conformance/freehand/fixtures/fh-react-007.edn
@@ -94,11 +94,43 @@
   :rejects  ["spec" :x/spec "children" "key" 3]
   :recovery :spell-host-props-as-unqualified-keywords
   :error-id :rf.error/view-bad-props
-  ;; A `:map-props` adapter answers the ordinary plane, so it answers under
-  ;; the same law — and is checked BEFORE the reserved filter, which is what
-  ;; makes that filter total. Browser-side: the adapter never runs on the JVM.
-  :map-props-adapter {:rejects  ["key" "onSelect" :x/spec]
-                      :error-id :rf.error/ui-tree-malformed}}
+  ;; A `:map-props` adapter answers the ordinary plane, and the law its answer
+  ;; owes is key-set EQUALITY: it owns the plane's VALUES, so it carries
+  ;; exactly the keys the call authored. Settled at rf2-drpa3.182.3, from the
+  ;; merged-PR audit of #7081 — the four normative claims all said "the names
+  ;; stay the caller's" while the landed code only filtered the answer for
+  ;; inexact and reserved NAMES, so an ordinary unqualified rename passed.
+  ;;
+  ;; Equality subsumes both of those filters rather than joining them. The
+  ;; plane handed to the adapter has already had `:key` and the declared
+  ;; positions removed, and `:children` and every inexact spelling refused at
+  ;; the call (the rows above), so an answer carrying the caller's own keys
+  ;; cannot name a reserved fact or an unspellable one. Dropping is refused
+  ;; with creating: the structural projection records the AUTHORED props, so a
+  ;; dropped key makes it report a prop React never received.
+  ;;
+  ;; Browser-side only: the adapter never runs on the JVM.
+  :map-props-adapter
+  {:law      "the adapter's answer carries EXACTLY the keys the call authored — it owns the ordinary plane's VALUES and the names stay the caller's, so the key sets are EQUAL in both directions"
+   :error-id :rf.error/ui-tree-malformed
+   :accepts  [{:case     "the ordinary adapter: the same keys, prepared values"
+               :authored [:spec]
+               :answers  [:spec]}]
+   :rejects  [{:case     "an ordinary unqualified RENAME — the plainest violation, and the one no per-key filter can see: :chartSpec is exact, unreserved, and a name the call never supplied"
+               :authored [:spec]
+               :answers  [:chartSpec]
+               :created  [:chartSpec]
+               :dropped  [:spec]}
+              {:case     "a reserved fact under a second spelling — refused as the created name it is, with no separate filter to make total"
+               :authored [:spec]
+               :answers  ["key" "onSelect" :x/spec]
+               :created  ["key" "onSelect" :x/spec]
+               :dropped  [:spec]}
+              {:case     "an authored key DROPPED — the mirror half: the structural tree records the authored props, so it would report a prop React never received"
+               :authored [:spec :rows]
+               :answers  [:spec]
+               :created  []
+               :dropped  [:rows]}]}}
 
  ;; The children policy is the same closed roster an internal boundary uses,
  ;; and it is reported through the same diagnostic.
@@ -131,24 +163,12 @@
    :counts  [:host/commits]
    :residue :none}
 
-  ;; OPEN, and recorded as open rather than pinned (rf2-drpa3.182.3, from
-  ;; the merged-PR audit of #7081). Spec 004, the public docstring and the
-  ;; browser test all say a `:map-props` adapter owns VALUES and may not
-  ;; rename, but the landed check only runs the inexactness filter over the
-  ;; adapter's OUTPUT — so an authored `{:spec x}` returned as
-  ;; `{:chartSpec x}` passes both checks and reaches React under a name the
-  ;; caller never supplied. The question is whether the law is key-set
-  ;; EQUALITY or output SUBSET, and it has to be settled at `host-element`,
-  ;; where the authored props and the mapper output both exist.
-  ;;
-  ;; The roster names the question and asserts nothing about the answer.
-  ;; Freezing today's behaviour into a rostered expectation would leave
-  ;; whoever settles .182.3 fighting this file to land the fix, which is
-  ;; the mutually-invalidating-test problem written in advance. When it is
-  ;; settled, the answer belongs in `:prop-names` above — where the rows
-  ;; that already run live — and this note goes.
-  :open
-  {:rf2-drpa3.182.3
-   "the :map-props key-set law — key-set EQUALITY or output SUBSET — is unsettled, and has to be settled at host-element where the authored props and the mapper output both exist; an unqualified rename is currently unchecked, and no rostered projection asserts either answer"}
+  ;; The `:map-props` key-set boundary was recorded OPEN here (rf2-drpa3.182.3,
+  ;; from the merged-PR audit of #7081) rather than pinned to the behaviour
+  ;; that shipped, precisely so settling it would not mean fighting this file.
+  ;; It is settled: the law is key-set EQUALITY, it is enforced once at
+  ;; `host-element` where the authored plane and the answer both exist, and the
+  ;; answer now lives in `:prop-names` §`:map-props-adapter` above — where the
+  ;; rows that run live. The note is therefore gone rather than amended.
 
   :prose :executable}}


### PR DESCRIPTION
Closes the residual the merged-PR audit of #7081 found at D022's naming boundary.

## The defect

Four normative claim sites — `spec/004-Views.md` §The one ordinary-props adapter, the public `v/defhost` docstring §`:map-props`, `docs/api/re-frame.freehand.md`, and the browser witness in `host_mounted_dom_cljs_test.cljs` — all stated that a `:map-props` adapter owns **values**, that the names stay the caller's, and that it may not rename. Nothing enforced it.

The landed code ran `inexact-host-prop-names` over the adapter's **output** (rejecting strings and qualified keywords) and then filtered the output for reserved keyword names. An authored `{:spec x}` answered as `{:chartSpec x}` passes both: `:chartSpec` is an exact unqualified keyword and it is not reserved. It reached React under a name the caller never supplied. The existing negative witness only returned string/qualified reserved spellings and the positive control preserved `:spec`, so the ordinary unqualified rename was completely untested.

## The law: key-set EQUALITY

The adapter's answer carries **exactly** the keys the call authored — equality, in both directions — enforced once in `host-element`, the only place the authored ordinary plane and the mapper's answer both exist.

Three things decided it, all from the code rather than from taste:

1. **The structural projection records the AUTHORED props.** `node.cljc/host-node` writes `:props` from the authored ordinary plane and reports the adapter's presence as `:rf.ui/host-map-props true` — deliberately, because recording the adapter's output would be exactly the host-value serialisation D022 forbids. That recording is only honest if the adapter changes values and not names. Under a subset law the tool would show `{:spec …}` while React received `chartSpec`, and the one marker hinting at any of it says nothing about which keys crossed. Equality is precisely the invariant that makes authored-props recording truthful about the crossing's shape — and it is what makes dropping wrong too, in the mirror direction: a dropped key leaves the projection reporting a prop React never received. That is why the law is equality and not "may drop but not create".

2. **Equality subsumes both existing filters rather than joining them.** `normalize-host-call` hands the adapter a plane that has already had `:key` and every declared callback position `dissoc`'d, with `:children` and every inexact spelling refused at the call. So an answer carrying the caller's own keys **cannot** name a reserved fact and cannot name an unspellable one — both prior checks were provably unreachable under the new law, and both are gone. This is the same shape as this bead's earlier fix, which closed a sibling defect at the naming boundary by making `host-prop-name` total rather than adding machinery per check: one law, enforced once, where both sides are visible. Keeping two per-check filters *plus* a total law would be the shape that fix rejected.

3. **The subset law's ergonomic case already has a better answer.** An adapter that wants to expand or rename authored props into library props is a per-prop conversion language expressed as a function — the thing D022 rejects by name. The escape hatch is the registered React component, which is React-owned and may do whatever it likes, and D022 already says the short wrapper is clearer and more powerful than any configuration for it.

Because the law makes the four claims true as written, none of them needed narrowing. They needed *stating*: each replaces "it answers under the caller's own naming law … which is what makes that refusal total" — an architecture of ordered filters that no longer exists — with the law itself and both of its reasons.

The refusal names `:created` and `:dropped` separately, which turns out to give a better message than the filter it replaced: an adapter that wrote `{"spec" …}` is told it created `"spec"` and dropped `:spec`, the wrong spelling and the right one side by side.

Scoped to the inward `v/defhost` adapter. `v/->react`'s `:map-props` (D014, the outward half) maps a foreign props **object** to a props map, where key-set equality has no meaning; it is untouched.

## Witnesses

- **The minimal unqualified rename** (the case the audit named): `renaming-host` answers `{:chartSpec x}` for an authored `{:spec x}` and is refused, naming `:created [:chartSpec]` / `:dropped [:spec]`.
- `smuggling-host` keeps the reserved-second-spelling case (`{"key" … "onSelect" … :x/spec 1}`), now refused as the created names it is — evidence the equality law is total without a reserved filter behind it.
- `dropping-host` covers the mirror direction: `:created []` / `:dropped [:rows]`.
- **Negative control:** `vega-host` — a legitimate adapter that owns values and preserves names (`{:spec (clj->js (:spec p))}`) — still produces a real React element, and the mounted row above it still commits through `react-dom/client`, renders the chart from the adapter's JS object and round-trips a library-chosen value back as a re-frame event. Over-refusing is as wrong as under-refusing and only this side catches it.

The three reject rows are keyed off FH-REACT-007's own `[authored answers]` statement rather than off position, so neither the fixture nor the suite can drift alone.

## Coordination

**#7098's fixture roster does not pin the old behaviour, and this change is what it asked for.** `FH-REACT-007`'s `:fh/record` carried an `:open` note keyed to this bead, recorded deliberately rather than pinned: *"Freezing today's behaviour into a rostered expectation would leave whoever settles .182.3 fighting this file to land the fix… When it is settled, the answer belongs in `:prop-names` above — where the rows that already run live — and this note goes."* That is exactly what happened: the answer is now in `:prop-names` §`:map-props-adapter` and the note is gone. `roster_cljs_test.cljc`'s row inverts from "the question is recorded" into a ratchet on any **new** open note, so the spine still can't acquire an unmarked gap.

`docs/core/freehand/host-boundaries.md` (out of scope, live restructure PR) needs nothing: its inward `:map-props` row says only "one adapter over the whole ordinary plane, browser-only" and makes no naming claim. `spec/API.md`'s `defhost` row is likewise still true as written ("callbacks, children and the key withheld … so it can neither supply nor replace a reserved fact") and is untouched, keeping this out of the API-manifest serial lane — no public verb, no manifest row, no new error id (`:rf.error/ui-tree-malformed` reused via the existing `malformed!`).

`spec/004-Views.md` is hot-zone: the edit is one section, §The one ordinary-props adapter. Nothing under `form/*` or `controls/*` is touched.

## Quality gates

ALL GREEN, foreground to completion, run twice — once on the authored tip and once on **merged main**, because the merge rebased this branch on top of rf2-n4by4's `normalize-host-call` changes. Full table, plus the mutation that proves the three new reject rows are load-bearing, in the [gates comment](#issuecomment-5083247769).

| Gate | Authored tip | Merged main | rc |
|---|---|---|---|
| `clojure -M:test` (freehand JVM) | 1206 / 8040, 0F 0E | 1210 / 8069, 0F 0E | 0 |
| `npm run test:cljs` | 11571 / 57951, 0F 0E | — | 0 |
| `npm run test:freehand` (node lane) | 1271 / 6997, 0F 0E | 1275 / 7026, 0F 0E | 0 |
| `npm run test:browser` | 813 / 5175, 0F 0E | 813 / 5175, 0F 0E | 0 |
| `mkdocs build --strict` + `check_doc_slugs.py` | clean | — | 0 |
| api-manifest `gen` / `ui-context` / `api-md` / `doc-api` / `doc-guide` / `skills` | all in sync | — | 0 |
| `check-no-hardcoded-paths.sh`, `check-beads-pr-boundary.sh` | OK | — | 0 |

**Mutation:** neutralising `host-prop-name-drift` to answer `{:created [] :dropped []}` reds exactly 9 assertions — three rows × three assertions in `d022-a-map-props-adapter-answers-the-callers-own-keys` — and nothing else in the suite. That the reserved-second-spelling row reds too is the direct evidence the two deleted filters were genuinely subsumed rather than replaced. Mutation confirmed applied by `git diff --stat` and by grepping the token back out; `descriptor.cljc` restored from a backup copy and verified blob-identical by `git hash-object`.

- `clojure -M:test` in `implementation/freehand` (JVM)
- `npm run test:cljs`
- `npm run test:browser` (the browser witness is one of the four claim sites)
- `python -m mkdocs build --strict` and `python scripts/check_doc_slugs.py`

