### PR TITLE
fix(freehand): seed overlap, absent-vs-nil reset, and a falsifiable composing-Enter proof (rf2-drpa3.182.4)

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/form.cljc
+++ b/implementation/freehand/src/re_frame/freehand/form.cljc
@@ -144,6 +144,33 @@
   (leaf-entries [] values))
 
 ;; ---------------------------------------------------------------------------
+;; Overlap — when two leaf paths name the same data
+;; ---------------------------------------------------------------------------
+
+(defn- ancestor-or-self?
+  "Is the leaf path `a` the path `b`, or an ANCESTOR of it? A leaf path is
+  a vector, so the question is a prefix test."
+  [a b]
+  (and (<= (count a) (count b))
+       (= (vec a) (vec (take (count a) b)))))
+
+(defn- overlapping?
+  "Does the leaf path `path` OVERLAP any path in `paths` — as the same
+  leaf, as an ancestor of one, or as a descendant of one?
+
+  Set membership answers only the first, and the other two are the shape
+  change a late payload actually arrives in. `[:contact]` and `[:contact
+  :email]` are different paths naming overlapping data: an empty map or a
+  scalar at `[:contact]` is ONE leaf here (see [[leaf-entries]]), and
+  writing it erases everything beneath it — while `{:tags {:featured
+  true}}` reaches INSIDE a `[:tags]` that is a leaf on the other side and
+  overwrites it from below."
+  [paths path]
+  (boolean (some (fn [p] (or (ancestor-or-self? p path)
+                             (ancestor-or-self? path p)))
+                 paths)))
+
+;; ---------------------------------------------------------------------------
 ;; The empty form
 ;; ---------------------------------------------------------------------------
 
@@ -224,6 +251,16 @@
   - **Edited leaves survive.** A leaf in `:edited` keeps its draft AND
     keeps its baseline unmoved, so the user's work is neither displayed
     over nor silently re-based under.
+  - **And they survive a SHAPE CHANGE, in both directions.** A payload
+    leaf is skipped when it merely OVERLAPS an edited leaf, not only when
+    it is one. `{:contact {}}` is a single leaf at `[:contact]` — an
+    empty map stops the walk — so writing it would erase an edited
+    `[:contact :email]` from above; `{:tags {:featured true}}` reaches
+    INSIDE an edited `[:tags]` and would overwrite it from below. Either
+    would leave `:edited` naming data that is no longer there, and a
+    marker describing an absent leaf is its own defect. Both are held,
+    WHOLE: a partial write of a leaf is not a thing this model has, so
+    the overlapping payload leaf is declined rather than merged.
   - **Unrelated state survives.** A leaf `values` does not mention is
     untouched — including a leaf nested beside one that IS mentioned, and
     including a whole sub-tree the payload omits. Seeding a partial
@@ -241,7 +278,7 @@
   (let [edited (:edited form #{})]
     (reduce
       (fn [f [path value]]
-        (if (contains? edited path)
+        (if (overlapping? edited path)
           f
           (-> f
               (assoc-in (into [:baseline] path) value)

--- a/implementation/freehand/src/re_frame/freehand/form.cljc
+++ b/implementation/freehand/src/re_frame/freehand/form.cljc
@@ -171,6 +171,58 @@
                  paths)))
 
 ;; ---------------------------------------------------------------------------
+;; Absent is not the same as nil
+;; ---------------------------------------------------------------------------
+
+(defn- absent?
+  "Has the nested map `m` NO KEY at the leaf path `path`?
+
+  `get-in` answers `nil` for a key that is missing and for a key holding
+  `nil` alike, and `assoc-in` materialises whatever key it is handed — so
+  the pair cannot express *there is nothing here*, and [[reset]] has to
+  be able to. A baseline `nil` is a VALUE the domain accepted; an absent
+  baseline key is the domain never having had that leaf at all, and a
+  reset that conflated them would answer a draft the baseline never held."
+  [m path]
+  (let [parent (get-in m (vec (butlast path)))]
+    (not (and (associative? parent) (contains? parent (last path))))))
+
+(defn- discard
+  "The nested map `m` with the key at leaf path `path` REMOVED — `m`
+  unchanged when there is no key there. `dissoc`, never a written `nil`."
+  [m path]
+  (if (absent? m path)
+    m
+    (let [parent-path (vec (butlast path))
+          remaining   (dissoc (get-in m parent-path) (last path))]
+      (if (seq parent-path)
+        (assoc-in m parent-path remaining)
+        remaining))))
+
+(defn- restore-leaf
+  "`form` with its DRAFT leaf at `path` back to what the baseline holds
+  there: the baseline's value where it has one, and NOTHING where it has
+  none.
+
+  The second half is why this is not one `assoc-in`. A leaf the user typed
+  into that the baseline never had must come back ABSENT, and any
+  enclosing map the removal empties goes with it — up to the first
+  ancestor the baseline does have a key for. That pruning is what makes
+  [[reset]]'s two arities agree: the whole-form arity simply takes the
+  baseline, so discarding a draft-only sub-tree one leaf at a time has to
+  arrive at the same value rather than at a husk of empty maps the
+  baseline never held."
+  [form path]
+  (let [baseline (:baseline form)]
+    (if-not (absent? baseline path)
+      (assoc-in form (into [:draft] path) (get-in baseline path))
+      (loop [draft (discard (:draft form) path)
+             p     (vec (butlast path))]
+        (if (and (seq p) (= {} (get-in draft p)) (absent? baseline p))
+          (recur (discard draft p) (vec (butlast p)))
+          (assoc form :draft draft))))))
+
+;; ---------------------------------------------------------------------------
 ;; The empty form
 ;; ---------------------------------------------------------------------------
 
@@ -350,6 +402,16 @@
   the form — baseline, draft, visited, edited or errors — so a leaf the
   user typed into that the baseline never had is discarded too.
 
+  **Back to the baseline means back to ABSENT where the baseline has no
+  key.** A baseline `nil` is a value the domain accepted; a missing
+  baseline key is the domain never having had that leaf, and `get-in`
+  cannot tell the two apart while `assoc-in` materialises whichever it is
+  handed. So `(reset (edit (init {}) [:nickname] \"typed\") [:nickname])`
+  answers a draft of `{}` — not `{:nickname nil}`, which is a leaf the
+  baseline never held. Any enclosing map the removal empties goes too, up
+  to the first ancestor the baseline does have: the two arities have to
+  agree, and the whole-form arity simply takes the baseline.
+
   A pending submit is settled: the work it was for is gone."
   ([form]
    (let [paths (into #{}
@@ -367,7 +429,7 @@
          (assoc-in [:submit :pending] nil))))
   ([form path]
    (-> form
-       (assoc-in (into [:draft] path) (get-in form (into [:baseline] path)))
+       (restore-leaf path)
        (update :visited disj path)
        (update :edited disj path)
        (update :errors dissoc path)

--- a/implementation/freehand/test/re_frame/freehand/form_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/form_cljs_test.cljc
@@ -373,6 +373,100 @@
           "non-vacuous: the two generations differ, so a shared counter would
            have been visible"))))
 
+(deftest fh-ctrl-014-a-scoped-reset-restores-ABSENT-where-the-baseline-has-no-key
+  (testing "Per FH-CTRL-014: `reset` discards back to the baseline, and where
+            the baseline has NO KEY that means back to ABSENT. `get-in`
+            answers nil for a missing key and for a key holding nil alike,
+            and `assoc-in` materialises whichever it is handed — so the
+            value after the reset is nil in BOTH cases below and presence is
+            the only thing that separates them. Every case here pins the
+            whole draft and its presence; an assertion about the value alone
+            is green against the bug."
+    (let [{:keys [draft-only-baseline draft-only-path draft-only-typed
+                  draft-only-draft-after-edit draft-only-draft-after-reset
+                  draft-only-present-after-edit? draft-only-present-after-reset?
+                  draft-only-value-after-reset draft-only-reset-key-after
+                  draft-only-materialised-draft]} ctrl-014
+          edited (-> (form/init draft-only-baseline)
+                     (form/edit draft-only-path draft-only-typed))
+          r      (form/reset edited draft-only-path)]
+      (is (= draft-only-draft-after-edit (:draft edited))
+          "non-vacuous: the user really did type into a leaf the baseline never had")
+      (is (= draft-only-present-after-edit? (leaf-present? (:draft edited) draft-only-path))
+          "and the edit really did materialise the key")
+      (is (= draft-only-draft-after-reset (:draft r))
+          "the whole draft is the baseline again — the leaf is GONE, not nil")
+      (is (= draft-only-present-after-reset? (leaf-present? (:draft r) draft-only-path))
+          "there is no key there")
+      (is (= draft-only-value-after-reset (get-in (:draft r) draft-only-path))
+          "and reading it answers nil, exactly as reading a baseline nil would")
+      (is (= draft-only-reset-key-after (form/reset-key r draft-only-path))
+          "the generation advanced all the same — the caller asked")
+      (is (not= draft-only-materialised-draft draft-only-draft-after-reset)
+          "non-vacuous: the fixture's two outcomes really differ")
+      (is (= (get-in draft-only-materialised-draft draft-only-path)
+             (get-in draft-only-draft-after-reset draft-only-path))
+          "and they differ in PRESENCE ONLY — the same read answers nil on both,
+           which is why an assertion about the value cannot see this defect"))
+
+    (testing "the same law two levels down, where the removal also empties the
+              map the edit created on the way in — and the scoped arity lands
+              exactly where the whole-form arity does, which simply takes the
+              baseline"
+      (let [{:keys [draft-only-baseline draft-only-typed nested-path
+                    nested-draft-after-edit nested-draft-after-reset
+                    nested-materialised-draft nested-husk-draft]} ctrl-014
+            edited (-> (form/init draft-only-baseline)
+                       (form/edit nested-path draft-only-typed))
+            r      (form/reset edited nested-path)]
+        (is (= nested-draft-after-edit (:draft edited))
+            "non-vacuous: the edit built the sub-tree")
+        (is (= nested-draft-after-reset (:draft r)))
+        (is (false? (leaf-present? (:draft r) nested-path)) "the leaf is gone")
+        (is (= (:draft (form/reset edited)) (:draft r))
+            "and the two arities agree — a scoped reset of a draft-only leaf
+             converges on the baseline rather than on a husk")
+        (is (not= nested-materialised-draft nested-draft-after-reset)
+            "non-vacuous: a written nil really would have been a different draft")
+        (is (not= nested-husk-draft nested-draft-after-reset)
+            "and so would an empty map the baseline never held")))
+
+    (testing "…while the pruning STOPS at the first ancestor the baseline does
+              have a key for — an empty baseline map is a value too"
+      (let [{:keys [kept-parent-baseline nested-path draft-only-typed
+                    kept-parent-draft-after-reset]} ctrl-014
+            edited (-> (form/init kept-parent-baseline)
+                       (form/edit nested-path draft-only-typed))
+            r      (form/reset edited nested-path)]
+        (is (= kept-parent-draft-after-reset (:draft r)))
+        (is (= (:draft (form/reset edited)) (:draft r))
+            "the two arities agree here as well")))
+
+    (testing "and THE OTHER CASE, which is what makes the first mean anything:
+              a baseline nil is a value the domain accepted, so the reset
+              restores it and the key STAYS"
+      (let [{:keys [baseline-nil draft-only-path draft-only-typed
+                    baseline-nil-draft-after-reset baseline-nil-present-after-reset?
+                    baseline-nil-value-after-reset draft-only-value-after-reset
+                    nested-baseline-nil nested-path
+                    nested-baseline-nil-draft-after-reset]} ctrl-014
+            r (-> (form/init baseline-nil)
+                  (form/edit draft-only-path draft-only-typed)
+                  (form/reset draft-only-path))]
+        (is (= baseline-nil-draft-after-reset (:draft r)) "the whole draft")
+        (is (= baseline-nil-present-after-reset? (leaf-present? (:draft r) draft-only-path))
+            "the key is still there, holding the nil the domain accepted")
+        (is (= baseline-nil-value-after-reset draft-only-value-after-reset)
+            "non-vacuous: the two cases read IDENTICALLY through the value, so
+             presence is the whole of what this law says")
+
+        (let [nested-r (-> (form/init nested-baseline-nil)
+                           (form/edit nested-path draft-only-typed)
+                           (form/reset nested-path))]
+          (is (= nested-baseline-nil-draft-after-reset (:draft nested-r))
+              "and nested, a baseline nil is restored rather than removed")
+          (is (true? (leaf-present? (:draft nested-r) nested-path))))))))
+
 (deftest fh-ctrl-014-rebase-moves-the-baseline-under-a-live-draft
   (testing "Per FH-CTRL-014: rebase is a save landing, not a rejection.
             The baseline moves, the draft STANDS — including on the very

--- a/implementation/freehand/test/re_frame/freehand/form_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/form_cljs_test.cljc
@@ -199,6 +199,95 @@
       (is (not= errors-before errors-after)
           "non-vacuous: the seed really removed one of them"))))
 
+(defn- leaf-present?
+  "Does the nested map `m` actually HAVE a key at leaf path `path`?
+
+  `get-in` cannot answer this — it says `nil` for a missing key and for a
+  key holding `nil` alike — and the question is what makes the
+  edited-marker law below assert something. A `:edited` path that names
+  no leaf is a marker describing data that is not there."
+  [m path]
+  (let [parent (get-in m (vec (butlast path)))]
+    (boolean (and (associative? parent) (contains? parent (last path))))))
+
+(deftest fh-ctrl-013-an-edited-leaf-survives-a-payload-that-OVERLAPS-it
+  (testing "Per FH-CTRL-013: the payload's leaf and the user's leaf can name
+            the same data without being the same path, and protecting only
+            EXACT path membership is blind to both directions.
+
+            FROM ABOVE: an empty map stops the leafwise walk, so
+            `{:contact {}}` is one leaf at `[:contact]` — writing it erases
+            the edited `[:contact :email]` beneath it. FROM BELOW: the user
+            cleared `[:address]` to `nil`, which is a leaf, and a payload
+            carrying `[:address :street]` reaches inside it.
+
+            Each payload also carries a leaf the seed MUST land on, so
+            'held' cannot be green because the seed declined everything."
+    (let [{:keys [ancestor-baseline ancestor-edited-path ancestor-typed
+                  ancestor-payload ancestor-draft-after ancestor-baseline-after
+                  ancestor-edited-after ancestor-clobbered-draft]} ctrl-013
+          f      (-> (form/init ancestor-baseline)
+                     (form/edit ancestor-edited-path ancestor-typed))
+          seeded (form/seed f ancestor-payload)]
+      (is (= ancestor-draft-after (:draft seeded))
+          "the whole draft: the edited leaf AND its unedited sibling held, the
+           leaf the payload really does address seeded")
+      (is (= ancestor-baseline-after (:baseline seeded))
+          "and the whole baseline — an edited leaf is not re-based from above either")
+      (is (= ancestor-edited-after (:edited seeded)) "the mark stands")
+      (is (not= ancestor-draft-after ancestor-clobbered-draft)
+          "non-vacuous: the fixture's two outcomes really differ")
+      (is (not= (get-in ancestor-draft-after ancestor-edited-path)
+                (get-in ancestor-clobbered-draft ancestor-edited-path))
+          "at the very leaf the user was typing in")
+      (is (not (leaf-present? ancestor-clobbered-draft ancestor-edited-path))
+          "non-vacuous: under exact-path protection the mark named NOTHING —
+           the second defect, and the one a draft comparison alone misses"))
+
+    (let [{:keys [descendant-baseline descendant-edited-path descendant-cleared-value
+                  descendant-payload descendant-draft-after descendant-baseline-after
+                  descendant-edited-after descendant-clobbered-draft]} ctrl-013
+          f      (-> (form/init descendant-baseline)
+                     (form/edit descendant-edited-path descendant-cleared-value))
+          seeded (form/seed f descendant-payload)]
+      (is (= descendant-draft-after (:draft seeded))
+          "the cleared leaf stays cleared, and the unrelated leaf is seeded")
+      (is (= descendant-baseline-after (:baseline seeded))
+          "with the edited leaf's baseline unmoved")
+      (is (= descendant-edited-after (:edited seeded)) "and the mark stands")
+      (is (not= descendant-draft-after descendant-clobbered-draft)
+          "non-vacuous: a descendant write really would have rebuilt it")
+      (is (leaf-present? descendant-draft-after descendant-edited-path)
+          "the cleared leaf is PRESENT holding nil, which is what the user asked for"))
+
+    (testing "and — the law behind both — no seed leaves an `:edited` path
+              naming data that is not there. Asserted over every witness in
+              this fixture at once, because the failure is never 'the leaf I
+              looked at moved', it is 'a marker outlived its leaf'."
+      (let [{:keys [baseline email-path qty-path typed-email typed-qty payload
+                    ancestor-baseline ancestor-edited-path ancestor-typed
+                    ancestor-payload descendant-baseline descendant-edited-path
+                    descendant-cleared-value descendant-payload]} ctrl-013
+            witnesses [(form/seed (-> (form/init baseline)
+                                      (form/edit email-path typed-email)
+                                      (form/edit qty-path typed-qty))
+                                  payload)
+                       (form/seed (-> (form/init ancestor-baseline)
+                                      (form/edit ancestor-edited-path ancestor-typed))
+                                  ancestor-payload)
+                       (form/seed (-> (form/init descendant-baseline)
+                                      (form/edit descendant-edited-path
+                                                 descendant-cleared-value))
+                                  descendant-payload)]]
+        (is (= 3 (count witnesses)) "non-vacuous: three seeds are under the law")
+        (doseq [seeded witnesses]
+          (is (seq (:edited seeded)) "non-vacuous: there are marks to check")
+          (doseq [path (:edited seeded)]
+            (is (leaf-present? (:draft seeded) path)
+                (str "the edited path " (pr-str path) " still names a draft leaf"))
+            (is (leaf-present? (:baseline seeded) path)
+                (str "and " (pr-str path) " still names the baseline leaf it held"))))))))
+
 (deftest fh-ctrl-013-a-keyed-row-keeps-its-identity-across-a-re-sort
   (testing "Per FH-CTRL-013: rows are addressed by their STABLE DOMAIN ID.
             The payload returns them in the opposite order with a new row

--- a/spec/004-Views.md
+++ b/spec/004-Views.md
@@ -1259,6 +1259,18 @@ that they are **three and not one**.
   the payload omits, and MUST mark nothing visited or edited, because the server
   typing is not the user typing. A seeded leaf moves baseline and draft together
   and clears the error its old value carried.
+- **A payload leaf that OVERLAPS an edited leaf is held too, and held WHOLE.**
+  Two leaf paths overlap when one addresses data inside the other, which
+  membership of `:edited` does not answer: `{:contact {}}` is a single leaf at
+  `[:contact]` — an empty map, like a scalar, stops the walk — so writing it
+  would erase an edited `[:contact :email]` from *above*, while a payload leaf
+  `[:tags :featured]` reaches *below* an edited `[:tags]` and would overwrite it.
+  `seed` MUST therefore decline a payload leaf that is an ancestor **or** a
+  descendant of an edited leaf, entirely rather than partially — a partial write
+  of a leaf is not a thing this model has. The consequence is a second MUST that
+  holds over every seed: **no `seed` may leave an `:edited` path naming data that
+  is no longer there.** A marker describing an absent leaf is a defect on its own
+  terms, whatever the draft beside it looks like.
 - **`reset` is a REJECTION and advances the generation.** A caller refuses a
   draft by reasserting what it already had, so nothing derived from the value can
   observe the decision (§The generation fence). Advancing the leaf's revision is

--- a/spec/004-Views.md
+++ b/spec/004-Views.md
@@ -1276,6 +1276,17 @@ that they are **three and not one**.
   observe the decision (§The generation fence). Advancing the leaf's revision is
   the one signal equality is not blind to. Scoped to a leaf, it advances that
   leaf's generation and no other.
+- **Back to the baseline means back to ABSENT where the baseline has no key.** A
+  baseline `nil` is a value the domain accepted and MUST be restored as one; a
+  baseline key that is *missing* is the domain never having held that leaf, and a
+  scoped `reset` MUST remove the draft leaf rather than materialise it holding
+  `nil` — at any depth, together with any enclosing map the removal empties, up
+  to the first ancestor the baseline does have a key for. `get-in` answers `nil`
+  for both cases and `assoc-in` materialises whichever it is handed, so this is a
+  distinction an implementation has to make deliberately and a conformance row
+  has to pin through **presence** rather than through the value. The scoped arity
+  therefore converges on what the whole-form arity takes, which is the baseline
+  itself.
 - **`rebase` is an ACCEPTANCE and advances nothing.** The baseline moved under a
   live draft — a save landed, an authoritative refresh arrived — and the user's
   unsaved work is not a draft to be rejected, so a control holding a live buffer

--- a/spec/conformance/freehand/fixtures/fh-ctrl-013.edn
+++ b/spec/conformance/freehand/fixtures/fh-ctrl-013.edn
@@ -1,5 +1,5 @@
 {:fh/id  "FH-CTRL-013"
- :fh/law "A late authoritative load SEEDS LEAFWISE: every leaf the user has edited keeps its draft AND its baseline, every leaf the payload does not mention is untouched — including a sibling of one that IS mentioned and a whole sub-tree the payload omits — and a leaf reached through a keyed row is addressed by its stable domain id rather than its index, so an insert, a delete and a re-sort leave the path meaning the same leaf. A seeded leaf moves baseline and draft together and clears the error the old value carried; nothing is marked visited or edited, because the server typing is not the user typing."
+ :fh/law "A late authoritative load SEEDS LEAFWISE: every leaf the user has edited keeps its draft AND its baseline — including where the payload OVERLAPS it rather than naming it, from above as an ancestor leaf and from below as a descendant — every leaf the payload does not mention is untouched — including a sibling of one that IS mentioned and a whole sub-tree the payload omits — and a leaf reached through a keyed row is addressed by its stable domain id rather than its index, so an insert, a delete and a re-sort leave the path meaning the same leaf. A seeded leaf moves baseline and draft together and clears the error the old value carried; nothing is marked visited or edited, because the server typing is not the user typing, and no seed leaves an `:edited` path naming data that is no longer there."
 
  ;; A form with a nested contact, a keyed row collection and a scalar. The
  ;; rows are keyed by STABLE DOMAIN ID — never by index — which is what the
@@ -65,4 +65,47 @@
                             "line-9" {:qty 80 :note "moved"}
                             "line-7" {:qty 70 :note "moved"}}}
  :qty-after-resort "99"
- :other-qty-after-resort 80}
+ :other-qty-after-resort 80
+
+ ;; ---------------------------------------------------------------------------
+ ;; OVERLAP — a shape change, in both directions
+ ;; ---------------------------------------------------------------------------
+ ;;
+ ;; A payload leaf and an edited leaf can name the SAME data without being
+ ;; the SAME path, and exact-path protection is blind to both directions.
+ ;; Each witness pairs the held leaf with a leaf the payload DOES land on,
+ ;; so "held" cannot be green because the seed did nothing at all.
+
+ ;; FROM ABOVE — the payload's leaf is an ANCESTOR of the edited one. An
+ ;; empty map stops the leafwise walk, so `{:contact {}}` is ONE leaf at
+ ;; [:contact]: writing it erases the edited [:contact :email] beneath and
+ ;; leaves :edited naming a leaf that is no longer there.
+ :ancestor-baseline    {:contact {:email "base" :phone "555"} :title "Draft article"}
+ :ancestor-edited-path [:contact :email]
+ :ancestor-typed       "typed"
+ :ancestor-payload     {:contact {} :title "From the server"}
+
+ :ancestor-draft-after    {:contact {:email "typed" :phone "555"}
+                           :title   "From the server"}
+ :ancestor-baseline-after {:contact {:email "base" :phone "555"}
+                           :title   "From the server"}
+ :ancestor-edited-after   #{[:contact :email]}
+
+ ;; What exact-path protection produced: the sub-tree gone, and the mark
+ ;; left pointing at nothing.
+ :ancestor-clobbered-draft {:contact {} :title "From the server"}
+
+ ;; FROM BELOW — the payload's leaf is a DESCENDANT of the edited one. The
+ ;; user CLEARED the address, and `nil` is a leaf; the late load must not
+ ;; rebuild it one key at a time under them.
+ :descendant-baseline      {:address {:street "1 Main"} :title "Draft article"}
+ :descendant-edited-path   [:address]
+ :descendant-cleared-value nil
+ :descendant-payload       {:address {:street "9 Elm"} :title "From the server"}
+
+ :descendant-draft-after    {:address nil :title "From the server"}
+ :descendant-baseline-after {:address {:street "1 Main"} :title "From the server"}
+ :descendant-edited-after   #{[:address]}
+
+ ;; And what a descendant write produced: the cleared leaf re-populated.
+ :descendant-clobbered-draft {:address {:street "9 Elm"} :title "From the server"}}

--- a/spec/conformance/freehand/fixtures/fh-ctrl-014.edn
+++ b/spec/conformance/freehand/fixtures/fh-ctrl-014.edn
@@ -1,5 +1,5 @@
 {:fh/id  "FH-CTRL-014"
- :fh/law "RESET and REBASE are distinct transitions and neither is the other. Reset discards the draft back to the baseline, clears the leaf's visited / edited / error marks, and ADVANCES that leaf's reset revision — so a caller rejecting a draft by reasserting the value it already had is observable, which value-equality provably is not. Rebase moves the baseline under a live draft, KEEPS the draft, clears the edited mark only where the draft now agrees with the new baseline, and advances no revision, because a rebase is not a rejection. A scoped reset advances one leaf's generation and no other."
+ :fh/law "RESET and REBASE are distinct transitions and neither is the other. Reset discards the draft back to the baseline, clears the leaf's visited / edited / error marks, and ADVANCES that leaf's reset revision — so a caller rejecting a draft by reasserting the value it already had is observable, which value-equality provably is not. Rebase moves the baseline under a live draft, KEEPS the draft, clears the edited mark only where the draft now agrees with the new baseline, and advances no revision, because a rebase is not a rejection. A scoped reset advances one leaf's generation and no other, and back to the baseline means back to ABSENT where the baseline has no key at all: a baseline nil is a value the domain accepted and is restored as one, while a leaf the baseline never had is REMOVED rather than materialised holding nil, at any depth, so the scoped arity converges on the value the whole-form arity takes."
 
  :baseline {:amount "10" :notes "keep typing"}
 
@@ -50,4 +50,55 @@
  :reset-discards-draft? true
  :rebase-keeps-draft?   true
  :reset-advances-generation? true
- :rebase-advances-generation? false}
+ :rebase-advances-generation? false
+
+ ;; ---------------------------------------------------------------------------
+ ;; ABSENT IS NOT NIL — what "back to the baseline" means where the baseline
+ ;; has no key at all
+ ;; ---------------------------------------------------------------------------
+ ;;
+ ;; `get-in` answers nil for a missing key and for a key holding nil alike,
+ ;; and `assoc-in` materialises whichever it is handed. So the VALUE after a
+ ;; reset is nil in both of the cases below and PRESENCE is the only thing
+ ;; that separates them: an assertion about the value alone is green against
+ ;; the bug, which is why each case pins the whole draft and its presence.
+
+ ;; The user typed into a leaf the baseline never had. The reset removes it.
+ :draft-only-baseline           {}
+ :draft-only-path               [:nickname]
+ :draft-only-typed              "typed"
+ :draft-only-draft-after-edit   {:nickname "typed"}
+ :draft-only-draft-after-reset  {}
+ :draft-only-present-after-edit?  true
+ :draft-only-present-after-reset? false
+ :draft-only-value-after-reset    nil
+ :draft-only-reset-key-after      1
+
+ ;; What `assoc-in` produced: the key materialised, holding nil — a leaf the
+ ;; baseline never had, and one a subsequent whole-form reset would have to
+ ;; advance a generation for.
+ :draft-only-materialised-draft {:nickname nil}
+
+ ;; NESTED — the same law two levels down, where the removal also empties
+ ;; the map `edit` created on the way in. The scoped arity has to converge
+ ;; on what the whole-form arity takes, which is the baseline itself.
+ :nested-path                      [:contact :nickname]
+ :nested-draft-after-edit          {:contact {:nickname "typed"}}
+ :nested-draft-after-reset         {}
+ :nested-materialised-draft        {:contact {:nickname nil}}
+ :nested-husk-draft                {:contact {}}
+
+ ;; …and the pruning stops at the first ancestor the baseline DOES have a
+ ;; key for, empty map included.
+ :kept-parent-baseline          {:contact {}}
+ :kept-parent-draft-after-reset {:contact {}}
+
+ ;; THE OTHER CASE, and the one that makes the first mean anything: a
+ ;; baseline nil is a VALUE the domain accepted, so the reset restores it
+ ;; and the key STAYS — at the top level and nested alike.
+ :baseline-nil                     {:nickname nil}
+ :baseline-nil-draft-after-reset   {:nickname nil}
+ :baseline-nil-present-after-reset? true
+ :baseline-nil-value-after-reset    nil
+ :nested-baseline-nil                   {:contact {:nickname nil}}
+ :nested-baseline-nil-draft-after-reset {:contact {:nickname nil}}}


### PR DESCRIPTION
Three defects reopened on `rf2-drpa3.182.4` by the merged-PR audits of #7091 and
#7095. The slice itself shipped; these are the three specific findings.

## 1 — `seed` wiped an edited leaf a payload OVERLAPPED

```clojure
(-> (form/init {:contact {:email "base"}})
    (form/edit [:contact :email] "typed")
    (form/seed {:contact {}}))
```

answered draft `{:contact {}}` with `:edited` still holding `[:contact :email]`.
`leaf-entries` deliberately treats an empty map as a leaf, and `seed` protected
only EXACT membership of `:edited`, so an ancestor leaf from the payload erased
an edited descendant — and the reverse shape overwrote an edited ancestor from
below. Two defects at once: "edited leaves survive" was violated, and the edit
marker was left describing data that no longer existed.

`seed` now declines a payload leaf that OVERLAPS an edited leaf in either
direction — ancestor or descendant — whole rather than partially. Still one
leafwise `reduce` over the payload; no runtime, no atom, no new dependency.
FH-CTRL-013 gains an ancestor witness, a descendant witness (a *cleared* leaf a
late load must not rebuild), and the law behind both asserted over every seed in
the fixture: **no seed leaves an `:edited` path naming absent data.**

## 2 — a scoped `reset` materialized an absent baseline key

(in progress)

## 3 — FH-CTRL-018 under-proved its own browser-compatibility claim

(in progress)

## Quality gates

| gate | status |
|---|---|
| `clojure -M:test` in `implementation/freehand` | green after defect 1 — 1207 tests, 8065 assertions, 0 failures, exit 0 |
| `npm run test:cljs` | running |
| `npm run test:browser` | running (defect 3) |

Each defect carries a red-then-green mutation proof: the mutation is confirmed
applied (`git diff --stat` plus grepping the token back out) before any verdict
is read, and the tree is confirmed byte-identical on restore.

Defect 1's proof: reverting the predicate to `contains?` reds
`fh-ctrl-013-an-edited-leaf-survives-a-payload-that-OVERLAPS-it` with 6
failures and reds **nothing else** in the suite — which is the audit's point
about the previous coverage.
