### PR TITLE
freehand: measure the roster's cache edge and prove the identity claim (rf2-drpa3.182.7)

### DIFF
--- a/implementation/freehand/test/re_frame/freehand/roster.cljc
+++ b/implementation/freehand/test/re_frame/freehand/roster.cljc
@@ -113,6 +113,26 @@
   sketch as a contract."
   #{:executable :expected-failure :illustrative})
 
+(def residue-statuses
+  "What a record claims about what a mounted run LEAVES BEHIND — rf2-drpa3.182.7
+  acceptance 3. Closed:
+
+    `:none`        the mounted suites assert the absence: after teardown the
+                   substrate's own books read empty, as an exact zero rather
+                   than a threshold.
+    `:unasserted`  the suites tear their roots down but assert nothing about
+                   residue. An honest gap, and countable.
+
+  There is no third value, and in particular no way to say 'probably
+  clean'. The distinction matters more than it looks: a leaked React root
+  contaminates every later suite sharing the process, and this corpus has
+  seen one leak produce failures across dozens of unrelated suites. A
+  record that claimed `:none` because its teardown *looked* thorough would
+  be the most expensive kind of green — so `:none` is a claim a checker
+  can refuse, and `:unasserted` is what a suite says until it earns the
+  other one."
+  #{:none :unasserted})
+
 (def tiers
   "The tiers a record may name a proof site in. Each is a real lane, not a
   label: `:structural` runs headlessly on both hosts through
@@ -288,6 +308,16 @@
           (conj (defect id :evidence
                         (str "states its evidence expectation as a non-empty map; got "
                              (pr-str evidence))))
+
+          ;; Guarded on a NON-EMPTY evidence map: an empty one is already
+          ;; reported just above, and a shape error that produced two
+          ;; defects would say the same thing twice.
+          (and (map? rec) (map? evidence) (seq evidence)
+               (not (contains? residue-statuses (:residue evidence))))
+          (conj (defect id :evidence
+                        (str "declares what a mounted run leaves behind as one of "
+                             (pr-str (sort residue-statuses)) "; got "
+                             (pr-str (:residue evidence)))))
 
           ;; An `:open` entry is keyed by the bead that owns the question,
           ;; because "unsettled" without an owner is a shrug.

--- a/implementation/freehand/test/re_frame/freehand/roster.cljc
+++ b/implementation/freehand/test/re_frame/freehand/roster.cljc
@@ -51,6 +51,38 @@
   same cache-invalidation reason. The JVM suite and the ClojureScript suite
   therefore project the same bytes.
 
+  ### The cache edge, MEASURED rather than inherited
+
+  A macro that inlines a data file can DECOUPLE from it. If the compiling
+  namespace carries no build-dependency edge back to the file the macro
+  read, editing the data does not invalidate the cache, the compiled suite
+  goes on asserting the PREVIOUS content, and it reports green — the worst
+  failure available to a table-driven gate, because it is indistinguishable
+  from success. This corpus has paid for that lesson more than once, which
+  is why `spec-resource` exists and why nothing here calls `slurp`.
+
+  `conformance-index.md` is a NEW read through that reader — every earlier
+  consumer read `.edn` fixtures — so the edge was measured rather than
+  assumed, the only way that counts: mutate the file, clear NOTHING, and
+  require red.
+
+      1. warm cache, unmodified          1271 tests, 0 failures   (1 compiled)
+      2. FH-CTRL-018's applicability
+         cell edited in the index,
+         `.shadow-cljs` left alone       1 failure                (2 compiled)
+      3. reverted, cache still warm      1271 tests, 0 failures   (2 compiled)
+
+  Step 2 red on `a-browser-only-law-does-not-claim-the-jvm`, reading
+  `{:modes #{:compiled :interpreted} :hosts #{:browser :jvm}}` where the
+  suite expected `{:modes #{:interpreted} :hosts #{:browser}}` — the
+  mutation itself, arriving through the cache. The edge holds in both
+  directions.
+
+  If a future change makes step 2 pass, the roster has decoupled from the
+  index. The fix is to restore the dependency edge; it is NOT to clear the
+  cache, because clearing the cache is the broken state's own behaviour and
+  hides exactly the defect being looked for.
+
   Dev/test scope ONLY. This namespace lives under `test/` and nothing in a
   production bundle may reach it."
   #?(:clj (:require [clojure.edn :as edn]

--- a/implementation/freehand/test/re_frame/freehand/roster_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/roster_cljs_test.cljc
@@ -123,11 +123,17 @@
             splitting one law across two ids is exactly what this roster
             exists to prevent."
     (let [mounted (roster/tier (roster/by-id :FH-BEHAVIOR-005) :mounted)]
-      (is (= 2 (count mounted)))
+      ;; Both messages NAME the law, and that is not decoration here: a
+      ;; deliberate break of this record reported a bare vector inequality
+      ;; and left a reader to decode which law it was about, which is
+      ;; precisely the failure acceptance 1 forbids. Found by breaking it.
+      (is (= 2 (count mounted))
+          "FH-BEHAVIOR-005 carries two mounted projections")
       (is (= '[re-frame.freehand.behaviors-dom-cljs-test
                re-frame.freehand.behavior-async-dom-cljs-test]
              (mapv :ns mounted))
-          "the ordinary synchronous path, then the same law under a Promise"))))
+          (str "FH-BEHAVIOR-005 — the ordinary synchronous path, then the "
+               "same law under a Promise")))))
 
 (deftest a-browser-only-law-does-not-claim-the-jvm
   (testing "Per the index's applicability grammar: the modes and hosts on a

--- a/implementation/freehand/test/re_frame/freehand/roster_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/roster_cljs_test.cljc
@@ -270,6 +270,11 @@
               (assoc-in sound [:fh/record :evidence] [:reads])              :evidence]
              ["an empty evidence expectation — say nothing or say something"
               (assoc-in sound [:fh/record :evidence] {})                    :evidence]
+             ["an evidence map that does not say what a run leaves behind"
+              (assoc-in sound [:fh/record :evidence] {:reads [:dom/value]}) :evidence]
+             ["a residue claim outside the closed two"
+              (assoc-in sound [:fh/record :evidence]
+                        {:reads [:dom/value] :residue :probably-fine})     :evidence]
              ["an :open entry not keyed by an owning bead"
               (assoc-in sound [:fh/record :open] {"someone" "one day"})     :open]
              ["an :open entry with no question stated"

--- a/implementation/freehand/test/re_frame/freehand/roster_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/roster_cljs_test.cljc
@@ -163,7 +163,18 @@
             reached — those rows assert themselves."
     (is (= [] (filterv #(seq (get-in (roster/by-id %) [:fh/record :open]))
                        roster/spine-ids))
-        "no spine member is holding an open question")))
+        "no spine member is holding an open question")
+    (testing "and whatever a FUTURE note says, its shape holds: keyed by the
+              bead that owns the question, stated in words. Vacuous today by
+              design — the row above is what keeps it that way — and it is
+              the half that survives the list going empty, so a note added
+              later cannot be an unattributable shrug."
+      (doseq [id   roster/spine-ids
+              :let [open (get-in (roster/by-id id) [:fh/record :open])]]
+        (is (every? keyword? (keys open))
+            (str id " keys each open question by the bead that owns it"))
+        (is (every? (every-pred string? seq) (vals open))
+            (str id " states each open question in words"))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Applicability parsing — the join's one piece of grammar

--- a/implementation/freehand/test/re_frame/freehand/roster_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/roster_jvm_test.clj
@@ -127,6 +127,75 @@
                (:ns entry))))))
 
 ;; ---------------------------------------------------------------------------
+;; `:residue :none` is a claim a checker can refuse — acceptance 3
+;; ---------------------------------------------------------------------------
+
+(def ^:private emptiness-assertion
+  "The shapes a residue assertion takes in this corpus. A leak assertion is
+  always an ABSENCE read after teardown — an exact zero or an empty
+  collection off the substrate's own book — so these are what one looks
+  like, not an arbitrary keyword list.
+
+  `nothing-survived` is included because the async surrogate factors its
+  absence check into a named helper and calls it from every case; a rule
+  that only recognised the inline spellings would refuse the most thorough
+  suite in the set."
+  [#"\(zero\?" #"\(empty\?" #"nothing-survived" #"\(= \[\] " #"\(= 0 \(count"])
+
+(deftest a-residue-none-claim-is-backed-by-an-emptiness-assertion
+  (testing "Per rf2-drpa3.182.7 acceptance 3: mounted cleanup is EXACT, and
+            `:residue :none` is the record saying so. An unenforced `:none`
+            would be the most expensive kind of green — a leaked React root
+            contaminates every later suite sharing the process, and this
+            corpus has seen one leak produce failures across dozens of
+            unrelated suites — so the claim is checked rather than read.
+
+            Every mounted projection of a `:residue :none` record must read
+            an absence after teardown. A record whose suites only unmount
+            and remove, without asserting what survived, says
+            `:unasserted` — which is honest, countable, and what two of the
+            three spine members currently say."
+    (doseq [record roster/spine
+            :when  (= :none (get-in record [:fh/record :evidence :residue]))
+            entry  (roster/tier record :mounted)]
+      (let [res  (ns->resource (:ns entry))
+            text (some-> res slurp)]
+        (is (and text (some #(re-find % text) emptiness-assertion))
+            (str (:fh/id record) " claims :residue :none, but its mounted proof "
+                 (:ns entry) " makes no emptiness assertion — either it asserts "
+                 "what survived, or the record says :unasserted"))))))
+
+(deftest the-residue-rule-would-refuse-a-suite-that-asserts-nothing
+  (testing "NON-VACUITY for the row above, which is otherwise a rule that
+            has only ever seen input it passes. A teardown that unmounts and
+            removes and reads nothing is exactly the suite the rule exists
+            to refuse, so it is run against that text directly."
+    (let [teardown-only "(defn- teardown! [c r] (.unmount r) (.remove c) nil)"
+          with-absence  (str teardown-only "\n(is (zero? (connection-count)))")]
+      (is (not-any? #(re-find % teardown-only) emptiness-assertion)
+          "an unmount-and-remove teardown is not a residue assertion")
+      (is (some #(re-find % with-absence) emptiness-assertion)
+          "and reading a book empty afterwards is"))))
+
+(deftest the-spine-records-what-it-has-not-yet-earned
+  (testing "Per rf2-drpa3.182.7 acceptance 3: the roster's value here is
+            that the gap is COUNTABLE rather than hidden. FH-BEHAVIOR-005
+            earns `:residue :none` — both its projections read the
+            substrate's books empty after teardown, as exact zeros. The
+            other two tear down and assert nothing, and say so.
+
+            This row is a statement of the CURRENT state, and it is meant to
+            be edited when the mounted-lifecycle facade lands and the other
+            two earn `:none`. It is here so that happens deliberately."
+    (is (= {:FH-REACT-007    :unasserted
+            :FH-CTRL-018     :unasserted
+            :FH-BEHAVIOR-005 :none}
+           (into {} (map (fn [id]
+                           [id (get-in (roster/by-id id)
+                                       [:fh/record :evidence :residue])])
+                         roster/spine-ids))))))
+
+;; ---------------------------------------------------------------------------
 ;; The resolver itself
 ;; ---------------------------------------------------------------------------
 

--- a/spec/conformance/freehand/fixtures/fh-ctrl-018.edn
+++ b/spec/conformance/freehand/fixtures/fh-ctrl-018.edn
@@ -73,9 +73,17 @@
   ;; the DOM node actually held, and the count of commits that reached
   ;; dispatch. Both are read off the substrate rather than off the test's
   ;; own bookkeeping.
+  ;; `:residue :unasserted`, and it is the truthful answer rather than a
+  ;; placeholder. The suite tears its root down — `.unmount` then
+  ;; `.remove` — but asserts NOTHING about what survived: no book is read
+  ;; empty afterwards, and a root that failed to unmount would go
+  ;; unnoticed here and contaminate every later suite in the same process.
+  ;; Earning `:residue :none` is rf2-drpa3.182.7 acceptance 3's remaining
+  ;; work, and it wants the shared mounted-lifecycle facade rather than a
+  ;; fourth hand-rolled teardown.
   :evidence
   {:reads    [:dom/value :dom/selection-start]
    :counts   [:form/commits :form/attempts]
-   :residue  :none}
+   :residue  :unasserted}
 
   :prose :executable}}

--- a/spec/conformance/freehand/fixtures/fh-react-007.edn
+++ b/spec/conformance/freehand/fixtures/fh-react-007.edn
@@ -158,10 +158,15 @@
   ;; perfectly and breaks every memoised consumer downstream, so the
   ;; recorded object is what a run leaves and `identical?` is what reads
   ;; it.
+  ;; `:residue :unasserted`. The mounted suite resets the host registry and
+  ;; the boundary table in its per-test `:init-fn`, which cleans up BEFORE
+  ;; each test rather than asserting anything AFTER one — so a crossing that
+  ;; retained a boundary would be masked by the next test's reset instead of
+  ;; reported. Earning `:residue :none` is acceptance 3's remaining work.
   :evidence
   {:reads   [:host/props :host/callback-identity]
    :counts  [:host/commits]
-   :residue :none}
+   :residue :unasserted}
 
   ;; The `:map-props` key-set boundary was recorded OPEN here (rf2-drpa3.182.3,
   ;; from the merged-PR audit of #7081) rather than pinned to the behaviour


### PR DESCRIPTION
Follow-up to #7098 (merged as `24a9b47519`). Two proofs the merged spine
asserted but had not demonstrated, plus one cross-worker collision removed.

## 1. The cache edge, measured

`conformance-index.md` is the first NON-fixture read through
`re-frame.build.spec-resource` — every earlier consumer read `.edn`
fixtures. A macro that inlines a data file can DECOUPLE from it: with no
build-dependency edge from the compiling namespace back to the file, editing
the data does not invalidate the cache, the compiled suite goes on asserting
the PREVIOUS content, and it reports green. That is indistinguishable from
success, and this corpus has paid for it more than once.

So it was measured the only way that counts — mutate the file, clear
NOTHING, require red:

| Step | `.shadow-cljs` | Result | Compiled |
|---|---|---|---|
| warm cache, unmodified | untouched | 1271 tests, **0 failures** | 1 |
| FH-CTRL-018's applicability cell edited in the index | untouched | **1 failure** | 2 |
| reverted | untouched | 1271 tests, **0 failures** | 2 |

Step 2 red on `a-browser-only-law-does-not-claim-the-jvm`, reading
`{:modes #{:compiled :interpreted} :hosts #{:browser :jvm}}` where the suite
expected `{:modes #{:interpreted} :hosts #{:browser}}` — the mutation itself,
arriving through the cache. The edge holds in both directions.

The loader's docstring records the result and states the standing rule: if a
future step 2 ever passes, the roster has decoupled, and the fix is to
restore the dependency edge — **never** to clear the cache, because clearing
it is the broken state's own behaviour and hides the very defect being
looked for.

## 2. Acceptance 1 — one identity, and failures name it

Break FH-BEHAVIOR-005 one notch (mounted tier pointed at a namespace that
does not exist; prose status set to a word outside the closed three), clear
nothing, and every projection reports the same law:

```
FH-BEHAVIOR-005 declares the status of the prose describing it
FH-BEHAVIOR-005 — the ordinary synchronous path, then the same law under a Promise
FH-BEHAVIOR-005 — :mounted names re-frame.freehand.behavior-async-gone-dom-cljs-test,
                  which resolves to no file on the classpath
FH-BEHAVIOR-005 — the mounted proof ...-gone-dom-cljs-test does not cite the law it proves
[{:fh/id "FH-BEHAVIOR-005", :field :prose, :detail "declares one of
  (:executable :expected-failure :illustrative); got :aspirational"}]
```

5 deftests across both tiers (cross-host `.cljc` + JVM `.clj`); 3 of them
also red in the CLJS node lane. No failure reports only a line number.

**The proof found a real defect in the gate itself.** One assertion failed
with a bare vector inequality and left a reader to decode which law it was
about — acceptance 1's forbidden shape, inside the gate that exists to
forbid it. Both assertions in that row now name the law. This is the
argument for breaking things on purpose: the gate was green and wrong.

## 3. The open-boundary row no longer blocks its own owner

FH-REACT-007 records the unsettled `:map-props` key-set question under
`:open`, keyed by rf2-drpa3.182.3. As merged, the suite REQUIRED that note
to be present — so whoever settles .182.3 would have had to edit this suite
to land their fix. That is the same mutually-invalidating trap as pinning the
behaviour, one level up.

The row is now conditional: while a note is present it must name its
boundary and state the question; when it goes, the row goes quiet on its
own. Retiring the note is a one-line delete in the fixture with nothing here
to chase.

To be explicit for the .182.3 worker: **this roster pins nothing about what
`:map-props` accepts or renames.** It records only that the question is
open.

Likewise for the .182.4 worker fixing seed overlap, reset-materializing-nil
and the `composing?` branch: FH-CTRL-018's record names its mounted suite
and the evidence a run leaves. It does not pin seed or reset behaviour.

## Quality gates

| Gate | Result |
|---|---|
| `clojure -M:test -r "re-frame\.freehand\.roster.*"` | 20 tests / 159 assertions, 0F/0E, **EXIT=0** |
| `npm run test:freehand` (node lane) | 1271 tests / 6996 assertions, 0F/0E, **EXIT=0** |
| `clojure -M:test` (full freehand JVM) | 1206 tests / 8042 assertions, 0F/0E, **EXIT=0** |
| `check_freehand_conformance_index.py --verbose` | 108 rows, 107 active, **EXIT=0** |

## Still outstanding on rf2-drpa3.182.7

Acceptance 3 (mounted lifecycle and override cleanup exact, no residue) is
NOT in this PR. The `re-frame.freehand.test` mounted lifecycle facade the
bead says to consume **does not exist** — rf2-gzmg0 shipped a Story presence
bridge, not the facade — so the three DOM suites still hand-roll their own
`act` / `setup!` / `teardown!`. See the report on the bead.

---

## 4. `:residue` is now a claim a checker can refuse — acceptance 3 (added after review)

As merged in #7098, all three spine records declared `:residue :none` and
**nothing checked it**. An unenforced absence claim is the most expensive
kind of green: a leaked React root contaminates every later suite sharing
the process, and this corpus has seen one leak produce failures across
dozens of unrelated suites.

Auditing the three mounted suites against their own claim, two were
overclaiming:

| Law | Reality | Now says |
|---|---|---|
| `FH-BEHAVIOR-005` | both projections read the substrate's books empty after teardown as exact zeros — `connection-count`, `command-log`, `nothing-survived!` | **`:none`** (earned) |
| `FH-CTRL-018` | `.unmount` + `.remove`, asserts nothing about what survived | `:unasserted` |
| `FH-REACT-007` | resets the host registry and boundary table in its per-test `:init-fn` — cleanup BEFORE each test, not an assertion after one, so a retained boundary is masked by the next test's reset | `:unasserted` |

`:residue` is a closed two-value vocabulary with **no way to say "probably
clean"**, and a JVM row refuses a `:none` claim whose mounted projections
make no emptiness assertion. A companion row runs that rule against an
unmount-and-remove teardown and requires it to be **refused**, so the rule
is not one that has only ever seen input it passes.

The gap is now countable rather than hidden. Earning the other two `:none`
values is the remaining acceptance-3 work.

## The facade gap, precisely

The bead says to consume the `re-frame.freehand.test` mounted lifecycle
facade owned by rf2-gzmg0. **It does not exist** — rf2-gzmg0 shipped a Story
presence bridge (`tools/story/.../presence_host.cljc`), not a facade. What
the three suites actually share and duplicate is narrower than "everything",
and worth stating exactly:

* **Already shared, working:** frame/runtime reset — all three use
  `test-support/make-reset-runtime-fixture`.
* **Duplicated verbatim:** the React 19 `act`-as-promise wrapper is
  **byte-identical in all three files** (7 lines, one carrying a docstring
  the others dropped).
* **Duplicated near-verbatim:** `setup!` / `teardown!` — container create /
  append / `createRoot`, then `.unmount` + `.remove`. The two teardowns are
  the same two lines.
* **Present in one file only:** the leak assertion. `nothing-survived!`
  lives in `behavior_async_dom_cljs_test` and has no counterpart in the
  other two — which is exactly why they cannot honestly claim `:residue
  :none`.

That is the specification for whoever owns the facade: `act`, root/container
lifecycle, and a shared residue assertion. Frame reset is done.

## Updated quality gates

| Gate | Result |
|---|---|
| `clojure -M:test -r "re-frame\.freehand\.roster.*"` | 23 tests / 170 assertions, 0F/0E, **EXIT=0** |
| `clojure -M:test` (full freehand JVM) | 1209 tests / 8058 assertions, 0F/0E, **EXIT=0** |
| `npm run test:freehand` (node lane) | 1271 tests / 7002 assertions, 0F/0E, **EXIT=0** |
| `check_freehand_conformance_index.py --verbose` | 108 rows / 107 active, **EXIT=0** |

---

## Rebased onto the settled `:map-props` law (#7103)

While this PR was open, rf2-drpa3.182.3 settled the very question FH-REACT-007
had recorded under `:open`. The note worked exactly as intended: **nothing of
mine had to be unpicked.** #7103 put the answer in `:prop-names`
§`:map-props-adapter` — key-set EQUALITY, the adapter's answer carries exactly
the keys the call authored, both directions, enforced once at
`react.cljs/host-element` — removed the note, and inverted this suite's row
into a ratchet on any NEW open note.

Resolution took main's side in both hunks, because my intent *was* the note
and the note has been honoured and consumed. One thing was carried across
rather than dropped: alongside main's ratchet (`the-spine-holds-no-open-boundary`,
which asserts the list is empty), the row now also asserts the SHAPE any
future note must take — keyed by an owning bead, stated in words. Vacuous
today by design, and it is the half that survives the list going empty, so a
note added later cannot be an unattributable shrug.

`:residue :unasserted` on FH-REACT-007 auto-merged cleanly and stands — #7103
added a key-set witness, not a residue assertion.

**This roster pins nothing about `:map-props`, seed, or reset behaviour.** The
only mentions of `:map-props` in the roster suites are main's own prose. So
#7104's two form laws (seed holding an edited leaf a payload overlaps; a
scoped reset restoring ABSENT rather than a materialised nil) need nothing
here, and neither will the outstanding `composing?` fix.

No `:open` note anywhere in the spine, so the new ratchet is satisfied.

### Gates re-run on the rebased tip

| Gate | Result |
|---|---|
| `clojure -M:test` (full freehand JVM) | 1213 tests / 8086 assertions, 0F/0E, **EXIT=0** |
| `npm run test:freehand` (node lane) | 1275 tests / 7038 assertions, 0F/0E, **EXIT=0** |
| `check_freehand_conformance_index.py` | **EXIT=0** |
| GitHub CI | **41 SUCCESS / 35 SKIPPED / 0 failures** |
