### PR TITLE
docs(core): state the candidate-set invariant precisely in the path walker (rf2-zaopo)

### DIFF
--- a/implementation/core/src/re_frame/classification.cljc
+++ b/implementation/core/src/re_frame/classification.cljc
@@ -236,13 +236,18 @@
 ;; The walker threads `[path candidates]`: the CONCRETE runtime path (which
 ;; drives the `:large` marker's `:path` / `:handle`) beside a SET of candidate
 ;; DECLARATION coordinates — the positions in declaration space the walker
-;; could currently be standing at. In the default mode the two never diverge
-;; and the set is the singleton `#{path}`; `:index-free?` is what makes them
-;; differ. Both are pruned against the prefix set of every declared path, so a
-;; candidate that can never reach a declaration is dropped and the set stays
-;; bounded by the declaration cardinality. The same device
+;; could currently be standing at.
+;;
+;; Candidates are pruned against the prefix set of every declared path, so one
+;; that can never reach a declaration is dropped and the set stays bounded by
+;; the declaration cardinality. In the DEFAULT mode that makes the set exactly
+;; `#{path}` while `path` is still some declaration's prefix and `#{}` the
+;; moment it is not — which is the exact path membership test spelled through
+;; the same machinery, since a declared path is always its own prefix.
+;; `:index-free?` is the only thing that lets the two diverge. The same device
 ;; `re-frame.elision`'s schema-first walker uses, at the grain this walker
-;; needs.
+;; needs — index fork only, no `:map-of` key skip, so this walker stays
+;; strictly MORE precise than the durable side's.
 
 (defn- path-prefixes
   "Every non-empty prefix of `path`, the full path included."


### PR DESCRIPTION
Follow-up to #7099, which merged while this was in flight. Comment-only — no
behaviour change, no new test.

#7099 replaced `walk-with-paths`' bare-path traversal state with `[path
candidates]`, and its section comment claimed the default (non-`:index-free?`)
mode's candidate set "is the singleton `#{path}`". That is true only while `path`
is still some declaration's prefix; the moment it is not, the set prunes to
`#{}`. Stating it precisely matters because *that* is the argument for the change
being behaviour-identical for the five callers left on the exact match: a
declared path is always its own prefix, so a path that can still match survives
pruning as `#{path}` and a path that cannot is dropped — the exact membership
test spelled through the candidate machinery, not a widening of it.

Also names the deliberate narrowing, which the original comment left implicit:
the fork is INDEX-only, with no `:map-of` key-skip fork, so this walker stays
strictly MORE precise than the durable side's `elide-wire-value`.

## Quality gates

- `implementation/core` `clojure -M:test -n re-frame.projection-cljs-test` (the
  walker's own suite) — 30 tests / 115 assertions / 0 failures / 0 errors, **EXIT=0**
- `implementation/core` `clojure -M:test` — 2126 tests / 10492 assertions / 0
  failures / 0 errors, **EXIT=0** (run on the same working tree, pre-split)
- `implementation/epoch` `clojure -M:test -n re-frame.epoch-egress-resource-trace-test`
  — 58 tests / 395 assertions / 0 failures / 0 errors, **EXIT=0**

A comment change cannot alter any of these; they are recorded because the tree
they ran against is the tree this commit contains.
