### PR TITLE
xray: declare schema 4 reload-required for a donor-resident process (rf2-7gth0)

### DIFF
--- a/tools/xray/spec/014-Registry-Catalogue.md
+++ b/tools/xray/spec/014-Registry-Catalogue.md
@@ -142,11 +142,18 @@ Version `3` (rf2-sa8j3) is the first REPLACEMENT delta — the
 `:rf.xray/reactive-show-unchanged?` quick-toggle + the Settings
 show-unchanged pin), so the clause re-runs the owning `reactive-panel`
 facade's `install!` to re-register it (evicting the stale two-input
-reaction). Version `4` (rf2-7gth0) is the Freehand tool-door cutover — three
-NEW sub ids (`:rf.xray/mounted-views`, `:rf.xray/mounted-views-schema`,
-`:rf.xray/mounted-view-sites`) replacing the donor evidence subs and their
-ownership event/sub pair, installed via
-`reactive-panel/install-mounted-views-subs!` so the reads stay panel-owned.
+reaction). Version `4` (rf2-7gth0) is the Freehand tool-door cutover, and the first
+delta with a REMOVAL in it — three NEW sub ids (`:rf.xray/mounted-views`,
+`:rf.xray/mounted-views-schema`, `:rf.xray/mounted-view-sites`) installed via
+`reactive-panel/install-mounted-views-subs!` so the reads stay panel-owned,
+plus five donor-era registrations cleared: the subs
+`:rf.xray/viewcell-evidence`, `:rf.xray/viewcell-evidence-version`,
+`:rf.xray/view-evidence-sites` and `:rf.xray/viewcell-evidence-ownership`,
+and the event `:rf.xray/viewcell-evidence-ownership-changed`. A removal needs
+its own clause for the mirror image of the reason a replacement does: the fn
+that installed those ids is deleted, so no re-registration happens and the
+umbrella has nothing to compare against — left alone they resolve forever as
+phantom ids backed by a deleted namespace's resident closures.
 `migrate-schema!` reaches each delta through the `reactive-panel` facade the
 orchestrator already requires (the idempotent re-install applies only the
 missing/changed delta).
@@ -163,6 +170,59 @@ number: the governance pin
 any gated registration edit — add or replace — must consciously bump
 `schema-version` (or record an explicit no-migration rationale) and update
 the pin.
+
+#### Schema 4 is reload-required for a donor-resident process (rf2-7gth0)
+
+The seam migrates REGISTRATIONS, and registrations are the only thing a live
+upgrade can migrate. Schema 4 is the first version whose delta also includes
+state that is **not** a registration, so it is the first version that can
+fail to complete — and the seam reports that instead of hiding it.
+
+A schema-3 process claimed the donor `re-frame.ui.tool.evidence` projection
+at boot under the owner id `:rf.xray/viewcell-evidence`. Releasing it means
+calling that tier's `uninstall!`, which schema-4 code cannot do: `re-frame.ui`
+is off `tools/xray/deps.edn` and must stay off it, because dropping that
+coordinate is the cutover. Re-adding it to run a teardown would reinstate the
+donor coupling this version exists to remove, for a tier the donor-deletion
+chain removes outright — the teardown would be dead code the day it shipped.
+Deleting a namespace from source does not execute teardown in a process that
+already loaded it, so the projection stays owned, its sink stays armed, its
+entries stay retained, and another tool is refused the slot.
+
+So the clause splits:
+
+- **The registrar half always migrates.** The three Freehand reads install
+  and the five donor-era ids are cleared, live, exactly like any other delta.
+  A process the developer does not reload is left as current as a live
+  process can be.
+- **The ownership half is reload-only, and is declared so.** When the process
+  carries the donor claim, `migrate-schema!` returns false: the process is
+  **not** stamped current, and one `console.warn` names the owner id still
+  holding the donor slot and the reload that ends it. `register-xray-handlers!`
+  stamps `installed-schema` only on a true return, so a live upgrade can never
+  assert an upgrade that did not finish. A subsequent `:after-load` repeats
+  both the refusal and the warning; only a page reload — which discards the
+  whole module registry, donor state included — clears the condition.
+
+The probe is Xray's own `js/globalThis` marker
+(`__day8_re_frame2_xray_viewcell_evidence`), which the deleted
+`viewcell_evidence.cljs` wrote on a successful acquire and removed on
+release. Reading it needs no donor dependency, which is exactly why it is the
+probe — the tier's own `installed-owner` is not askable from an artefact that
+does not depend on it. A process that booted at schema 4, and an older
+process whose acquire was rejected by a foreign owner, both read false and
+upgrade to completion. `reset-for-test!` clears the marker along with the
+sentinels, since no registrar rollback or `defonce` reset reaches a
+`globalThis` key.
+
+`registry/installed-schema-version` is the read-only diagnostic counterpart to
+`schema-version`: equal means current, behind means a reload is outstanding.
+Regressions: `schema-4-migrates-the-registrar-half-of-the-donor-cutover-rf2-7gth0`
+(the completing path) and
+`schema-4-refuses-to-stamp-a-donor-resident-process-rf2-7gth0` (the
+reload-required path — registrar half migrated, stamp withheld, warning
+emitted, refusal stable across a second `:after-load`, and current the instant
+the residue goes).
 
 #### Fresh-install atomicity (rf2-g2jf3)
 

--- a/tools/xray/src/day8/re_frame2_xray/registry.cljs
+++ b/tools/xray/src/day8/re_frame2_xray/registry.cljs
@@ -30,7 +30,8 @@
   panel owns its subs / events / fxs colocated with the view that
   reads them. Sub-registration order is purely cosmetic — re-frame
   resolves `:<-` chains lazily at subscribe time, not register time."
-  (:require [re-frame.core :as rf]
+  (:require [goog.object :as gobj]
+            [re-frame.core :as rf]
             [day8.re-frame2-xray.config :as config]
             ;; Load the first-class edn-inspector widget ns so its
             ;; top-level `reg-sub` / `reg-event` calls land in
@@ -163,13 +164,26 @@
         surface crossed off the donor `re-frame.ui.tool` evidence tier onto
         `re-frame.freehand.tool`. Three sub ids are NEW
         (`:rf.xray/mounted-views`, `:rf.xray/mounted-views-schema`,
-        `:rf.xray/mounted-view-sites`) and four registrations are GONE
+        `:rf.xray/mounted-view-sites`) and five registrations are GONE
         (`:rf.xray/viewcell-evidence`, `:rf.xray/viewcell-evidence-version`,
         `:rf.xray/view-evidence-sites`, and the
-        `:rf.xray/viewcell-evidence-ownership` event/sub pair whose ownership
-        plane has no Freehand counterpart and was deleted rather than ported).
-        A schema-3 process has the old ids cached and none of the new ones, so
-        the migration installs the delta."
+        `:rf.xray/viewcell-evidence-ownership` sub /
+        `:rf.xray/viewcell-evidence-ownership-changed` event pair whose
+        ownership plane has no Freehand counterpart and was deleted rather
+        than ported). A schema-3 process has the old ids registered and none
+        of the new ones, so the migration installs the delta AND clears the
+        five.
+
+        Schema 4 is the ONE version that is RELOAD-REQUIRED for part of its
+        delta, and the migration says so rather than pretending otherwise
+        (see `migrate-schema!`). The registrar half migrates live like every
+        other clause. The half that does not is the donor evidence
+        projection a schema-3 process ACQUIRED at boot: releasing it means
+        calling `re-frame.ui.tool.evidence/uninstall!`, and this build has no
+        dependency on `re-frame.ui` — nor may it acquire one, since dropping
+        that coordinate is the whole point of the cutover. So a process
+        carrying that residue is NOT stamped current; it is told, once and
+        loudly, to reload."
   4)
 
 (defonce ^:private installed-schema
@@ -182,18 +196,95 @@
   ;; reloads — a current process re-loading itself no-ops the migration.
   (atom nil))
 
+;; ---- schema 4: what a live upgrade can and cannot reach (rf2-7gth0) ------
+;;
+;; The migration seam moves REGISTRATIONS, and registrations are the only
+;; thing a live upgrade can move. Schema 3 also left non-registration state
+;; behind, and the honest handling of it is what the three defs below are
+;; for. See `migrate-schema!` for the verdict they feed.
+
+(def ^:private schema-3-subs-removed
+  "The `:rf.xray/*` SUBS schema 3 registered and schema 4 removed. A
+  live-upgraded process still has all four in the registrar: they were
+  installed by `reactive-panel-subs/install-viewcell-evidence-bridge!`, a fn
+  that no longer exists, so nothing re-registers or replaces them and the
+  umbrella cannot notice their absence from the current install. Left alone
+  they are FOUR PHANTOM IDS — resolvable, backed by a deleted namespace's
+  resident closures, read by no view, and enumerated by every tool that walks
+  the `:rf.xray/*` surface. The schema-4 clause clears them."
+  [:rf.xray/viewcell-evidence
+   :rf.xray/viewcell-evidence-version
+   :rf.xray/view-evidence-sites
+   :rf.xray/viewcell-evidence-ownership])
+
+(def ^:private schema-3-events-removed
+  "The `:rf.xray/*` EVENTS schema 3 registered and schema 4 removed — the
+  other half of the deleted ownership pair. Its handler wrote the donor
+  ownership revision into `:rf/xray` app-db at a key nothing reads any more."
+  [:rf.xray/viewcell-evidence-ownership-changed])
+
+(def ^:private donor-ownership-marker
+  "The `js/globalThis` key the DELETED `day8.re-frame2-xray.viewcell-evidence`
+  wrote on a successful donor acquire and removed on release. Its presence in
+  a live process is exact evidence of the one piece of schema-3 state this
+  build cannot reach: the `re-frame.ui.tool.evidence` projection is still
+  OWNED by `:rf.xray/viewcell-evidence`, with the tier's sink armed and its
+  entries retained.
+
+  The marker is read here, never written. Reading it needs no donor
+  dependency — it is Xray's own key, in Xray's own namespace prefix — which
+  is precisely why it is the probe: `re-frame.ui` is off this artefact's
+  classpath (`tools/xray/deps.edn`) and must stay off it, so the tier's own
+  `installed-owner` is not askable and neither is its `uninstall!` callable."
+  "__day8_re_frame2_xray_viewcell_evidence")
+
+(defn- donor-ownership-resident?
+  "True when this process acquired the donor evidence projection under
+  schema 3 and never released it — see `donor-ownership-marker`. False in
+  every process that booted at schema 4, and in any older process whose
+  acquire was rejected by a foreign owner (nothing was claimed, so nothing
+  is held)."
+  []
+  (and (exists? js/globalThis)
+       (some? (gobj/get js/globalThis donor-ownership-marker))))
+
+(defn- warn-donor-ownership-resident!
+  "Say the one true thing, once, at the moment the seam discovers it: the
+  registrar is current, the donor projection is not, and only a reload
+  finishes the job. Loud beats silent — the alternative the audit of this
+  cutover caught was stamping the process current and letting the developer
+  find out later that a second tool could not claim the slot."
+  []
+  (when (exists? js/console)
+    (.warn js/console
+           (str "[re-frame2 Xray] Registration schema 4 needs a page reload "
+                "to finish. This process claimed the re-frame.ui ViewCell "
+                "evidence projection under schema 3 (owner "
+                ":rf.xray/viewcell-evidence). Schema 4 reads views through "
+                "re-frame.freehand.tool and has no re-frame.ui dependency, so "
+                "it cannot release that claim: the donor tier keeps Xray as "
+                "owner, keeps its sink armed, and refuses another tool the "
+                "slot until this page is RELOADED. The Xray registrations "
+                "themselves have already migrated. rf2-7gth0."))))
+
 (defn- migrate-schema!
   "Bring an already-registered older-schema process up to `schema-version`
   by installing EXACTLY the bounded delta newer schema versions introduce —
-  a handler newer versions ADD, or a gated registration whose BODY/topology
-  newer versions CHANGE (replace) — the live-upgrade seam (rf2-ykaq4u /
-  rf2-sa8j3). `from` is the process's installed schema (0 ⇒
-  pre-schema-versioning, i.e. a pre-#5915 process). Each clause is idempotent
-  (re-frame's registrar replaces in place; replacing a sub also evicts its
-  stale cache via the registrar replacement-hook), and gated on `from`
+  a handler newer versions ADD, a gated registration whose BODY/topology
+  newer versions CHANGE (replace), or a registration newer versions REMOVE —
+  the live-upgrade seam (rf2-ykaq4u / rf2-sa8j3). `from` is the process's
+  installed schema (0 ⇒ pre-schema-versioning, i.e. a pre-#5915 process).
+  Each clause is idempotent (re-frame's registrar replaces in place;
+  replacing a sub also evicts its stale cache via the registrar
+  replacement-hook; clearing an absent id is a no-op), and gated on `from`
   predating the version that introduced its delta — so this is NOT an
   unconditional whole-registry re-registration; only the missing/changed
-  delta is installed, and only for a process that is behind.
+  delta is applied, and only for a process that is behind.
+
+  Returns TRUE when the process is now genuinely at `schema-version` and may
+  be stamped current, FALSE when it is not and must reload — the caller
+  stamps only on true. Every clause but one always returns true; schema 4 is
+  the exception and its docstring entry says why.
 
   Schemas 1 and 2 have NO clause. Both installed the donor ViewCell evidence
   reactivity bridge, and rf2-7gth0 deleted that bridge along with the donor
@@ -219,16 +310,41 @@
     ;; block, so the seam's `(< schema-version schema-version)` guard is false
     ;; there and this clause never double-registers on a fresh boot.
     (reactive-panel/install!))
-  (when (< from 4)
-    ;; schema 4 — the Freehand tool-door reads (rf2-7gth0). Three NEW sub ids
-    ;; (`:rf.xray/mounted-views`, `-schema`, `:rf.xray/mounted-view-sites`)
-    ;; replaced the donor evidence subs, so a schema-3 process has none of
-    ;; them: its cached `:rf.xray/viewcell-evidence` sub names a consumer that
-    ;; no longer exists and the Views panel would render nothing. Install the
-    ;; three through the `reactive-panel` facade the orchestrator already
-    ;; requires — the reads stay panel-owned. Idempotent (reg-sub replaces in
-    ;; place), and reached only for a behind process.
-    (reactive-panel/install-mounted-views-subs!)))
+  (if (< from 4)
+    ;; schema 4 — the Freehand tool-door cutover (rf2-7gth0). Two halves,
+    ;; and they do NOT have the same reach.
+    ;;
+    ;; The REGISTRAR half migrates live, like every clause before it. Five
+    ;; donor-era ids go (nothing else would ever remove them — the fn that
+    ;; installed them is deleted, so neither the umbrella nor a replacement
+    ;; can notice) and the three Freehand reads arrive through the
+    ;; `reactive-panel` facade the orchestrator already requires, so the
+    ;; reads stay panel-owned. Both idempotent, both reached only for a
+    ;; behind process.
+    (do
+      (run! rf/clear-sub schema-3-subs-removed)
+      (run! rf/clear-event schema-3-events-removed)
+      (reactive-panel/install-mounted-views-subs!)
+      ;; The OWNERSHIP half does not migrate live, and this is where the
+      ;; seam stops pretending. A schema-3 process acquired the
+      ;; `re-frame.ui.tool.evidence` projection at boot; releasing it means
+      ;; calling that tier's `uninstall!`. This build cannot: `re-frame.ui`
+      ;; is not on the artefact's classpath, and putting it back to run a
+      ;; teardown would reinstate exactly the donor coupling the cutover
+      ;; exists to remove — for a tier that F6e deletes outright, which
+      ;; would make the teardown dead code the day it shipped. Xray's own
+      ;; ownership listener is in the same deleted namespace and is
+      ;; unreachable too, but it is also provably INERT: it fires only from
+      ;; `acquire!`/`release-span!`, and no call site for either survives.
+      ;;
+      ;; So: refuse the stamp and say so. The process keeps a donor owner it
+      ;; cannot drop, and a reload — which discards the whole module
+      ;; registry, donor state included — is the only thing that finishes
+      ;; the upgrade.
+      (if (donor-ownership-resident?)
+        (do (warn-donor-ownership-resident!) false)
+        true))
+    true))
 
 (defn register-xray-handlers!
   "Idempotent registration of Xray's :rf.xray/* events, subs, fxs.
@@ -1172,22 +1288,45 @@
   ;; INDEPENDENT of the umbrella gate above. An already-registered process
   ;; running OLDER-schema code left `registered?` set, so the fresh-install
   ;; block no-ops — but it may lack handlers newer schema versions add.
-  ;; Bring it up to `schema-version`, then stamp current. Idempotent: once
-  ;; at `schema-version` (a fresh boot, or a completed upgrade) this
-  ;; no-ops, so a current process re-loading itself emits no handler-
-  ;; replaced flood and installs exactly one ownership listener.
+  ;; Bring it up to `schema-version`, then stamp current — but ONLY when the
+  ;; migration reports the process genuinely reached it (rf2-7gth0). A
+  ;; schema-3 process holding donor evidence ownership this build cannot
+  ;; release stays stamped 3 and is told to reload; stamping it current
+  ;; would be the registry asserting an upgrade that did not finish.
+  ;; Idempotent: once at `schema-version` (a fresh boot, or a completed
+  ;; upgrade) this no-ops, so a current process re-loading itself emits no
+  ;; handler-replaced flood.
   (when (< (or @installed-schema 0) schema-version)
-    (migrate-schema! (or @installed-schema 0))
-    (reset! installed-schema schema-version))
+    (when (migrate-schema! (or @installed-schema 0))
+      (reset! installed-schema schema-version)))
   nil)
+
+(defn installed-schema-version
+  "The registration schema this process has FULLY installed, or nil when it
+  registered before schema-versioning existed. Compare with `schema-version`:
+  equal means the process is current; behind means a live upgrade could not
+  complete and a page reload is outstanding (schema 4 — see
+  `migrate-schema!`). A read-only diagnostic; the stamp itself is private."
+  []
+  @installed-schema)
 
 (defn reset-for-test!
   "Reset the registry's idempotency sentinel + schema stamp so test
   fixtures can drive multiple registration cycles from a clean slate.
-  Test-only — never call from production code."
+  Test-only — never call from production code.
+
+  Also drops the donor-era ownership marker (rf2-7gth0). It is a
+  `js/globalThis` key, so no registrar rollback or `defonce` reset reaches
+  it: a fixture that poses a donor-resident schema-3 process would otherwise
+  leave every later live-upgrade fixture in the process reading `reload
+  required` — a cross-test leak of exactly the kind this tier exists to
+  close. Production never clears it; there, its presence is a true fact
+  about the process until the page reloads."
   []
   (reset! registered? false)
   (reset! installed-schema nil)
+  (when (exists? js/globalThis)
+    (gobj/remove js/globalThis donor-ownership-marker))
   nil)
 
 (defn simulate-legacy-registration!

--- a/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
@@ -53,6 +53,7 @@
   this file's job is the smoke surface + the registered-fx isolation
   + the cross-panel slots no single panel test owns."
   (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [goog.object :as gobj]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.registrar :as registrar]
@@ -1187,6 +1188,191 @@
                    (:show-unchanged? @(rf/subscribe [:rf.xray/reactive-data]))))
           "the replaced four-input sub resolves show-unchanged? through the
            reactive axis — the stale two-input reaction was evicted"))))
+
+;; ---- schema 4: the donor cutover's live upgrade (rf2-7gth0) -------------
+;;
+;; Merged-PR audit #7038 reopened rf2-7gth0 on this seam. The cutover deleted
+;; the donor ownership plane from SOURCE, but deleting a namespace does not
+;; execute teardown in a process that already loaded it. A schema-3 process
+;; that hot-reloads into schema-4 code carries two distinct residues:
+;;
+;;   1. FIVE registrar entries — four subs + one event — installed by a fn
+;;      that no longer exists. Nothing re-registers or replaces them, so the
+;;      umbrella cannot notice, and they resolve forever as phantom ids.
+;;   2. The donor `re-frame.ui.tool.evidence` projection, still OWNED by
+;;      `:rf.xray/viewcell-evidence`, sink armed, entries retained, and
+;;      refusing the slot to any other tool.
+;;
+;; (1) is Xray's own and migrates live. (2) is not: releasing it means
+;; calling the donor tier's `uninstall!`, and `re-frame.ui` is off this
+;; artefact's classpath — deliberately and permanently, since dropping that
+;; coordinate IS the cutover. So schema 4 is reload-required whenever (2) is
+;; present, and the seam must say so instead of stamping the process current.
+;;
+;; The fixture below reproduces both residues as faithfully as an artefact
+;; without the donor can. (1) is exact: the same five ids in the registrar,
+;; with the same input topology; only the handler BODIES are stand-ins,
+;; because the donor reads they closed over are precisely what is
+;; unreachable. (2) is reproduced through its observable — the byte-identical
+;; `js/globalThis` key the deleted `viewcell_evidence.cljs` wrote on a
+;; successful acquire (`sync-sentinel!`, commit 46577c549a^). That key is
+;; spelled out as a literal here rather than read off `registry`, so a
+;; rename on the production side fails this test instead of silently
+;; agreeing with it.
+
+(def ^:private donor-ownership-marker-key
+  "The literal `js/globalThis` key `viewcell_evidence.cljs` used, pinned
+  independently of the production constant. See the block comment above."
+  "__day8_re_frame2_xray_viewcell_evidence")
+
+(def ^:private schema-3-donor-sub-ids
+  [:rf.xray/viewcell-evidence
+   :rf.xray/viewcell-evidence-version
+   :rf.xray/view-evidence-sites
+   :rf.xray/viewcell-evidence-ownership])
+
+(def ^:private schema-3-donor-event-id
+  :rf.xray/viewcell-evidence-ownership-changed)
+
+(def ^:private schema-4-sub-ids
+  [:rf.xray/mounted-views
+   :rf.xray/mounted-views-schema
+   :rf.xray/mounted-view-sites])
+
+(defn- pose-schema-3-registry!
+  "Turn the just-booted current registry into the REGISTRAR image a schema-3
+  process carries: the three Freehand reads absent (schema 3 never had them)
+  and the five donor-era ids present, with the ownership sub reading the
+  app-db key its deleted event handler wrote. Poses the registrar only —
+  `simulate-registration-at-schema!` poses the sentinels."
+  []
+  (run! rf/clear-sub schema-4-sub-ids)
+  (rf/reg-event schema-3-donor-event-id
+    {:rf.trace/no-emit? true}
+    (fn [{:keys [db]} [_ revision]]
+      {:db (assoc db :viewcell-evidence-ownership-rev revision)}))
+  (rf/reg-sub :rf.xray/viewcell-evidence-ownership
+    (fn [db _query]
+      (get db :viewcell-evidence-ownership-rev 0)))
+  (rf/reg-sub :rf.xray/viewcell-evidence
+    :<- [:rf.xray/epoch-history]
+    :<- [:rf.xray/viewcell-evidence-ownership]
+    (fn [[_history _rev] _query] []))
+  (rf/reg-sub :rf.xray/viewcell-evidence-version
+    :<- [:rf.xray/epoch-history]
+    :<- [:rf.xray/viewcell-evidence-ownership]
+    (fn [[_history _rev] _query] {:status :supported}))
+  (rf/reg-sub :rf.xray/view-evidence-sites
+    :<- [:rf.xray/viewcell-evidence]
+    (fn [_rows _query] {}))
+  nil)
+
+(defn- registered-ids
+  "The subset of `ids` under `kind` the registrar currently resolves."
+  [kind ids]
+  (into #{} (filter #(some? (registrar/handler kind %))) ids))
+
+(defn- pose-donor-ownership-marker! []
+  (gobj/set js/globalThis donor-ownership-marker-key
+            (js-obj "owner" ":rf.xray/viewcell-evidence"
+                    "installed" (.now js/Date))))
+
+(deftest schema-4-migrates-the-registrar-half-of-the-donor-cutover-rf2-7gth0
+  (testing "rf2-7gth0 — a schema-3 process that never claimed the donor
+            projection upgrades fully in place: the three Freehand reads
+            arrive, the five donor-era ids go, and the process is stamped
+            current"
+    (setup-xray-frame!)
+    (pose-schema-3-registry!)
+    (registry/simulate-registration-at-schema! 3)
+
+    (testing "PRECONDITION — the posed process is a schema-3 registrar"
+      (is (= (set schema-3-donor-sub-ids)
+             (registered-ids :sub schema-3-donor-sub-ids))
+          "all four donor-era subs are registered")
+      (is (some? (registrar/handler :event schema-3-donor-event-id))
+          "the donor-era ownership event is registered")
+      (is (= #{} (registered-ids :sub schema-4-sub-ids))
+          "none of the three Freehand reads exists yet"))
+
+    ;; The live upgrade: `:after-load` re-runs `register-xray-handlers!`.
+    (registry/register-xray-handlers!)
+
+    (testing "the three Freehand reads installed and resolve"
+      (is (= (set schema-4-sub-ids) (registered-ids :sub schema-4-sub-ids)))
+      (rf/with-frame :rf/xray
+        (doseq [q-v schema-4-sub-ids]
+          (is (some? (rf/subscribe [q-v]))
+              (str q-v " must resolve after the schema-4 migration")))))
+    (testing "the five donor-era registrations are GONE — nothing else in the
+              process would ever remove them"
+      (is (= #{} (registered-ids :sub schema-3-donor-sub-ids)))
+      (is (nil? (registrar/handler :event schema-3-donor-event-id))))
+    (testing "and the process is stamped current — no donor claim was held,
+              so there is nothing a reload would add"
+      (is (= registry/schema-version (registry/installed-schema-version))))))
+
+(deftest schema-4-refuses-to-stamp-a-donor-resident-process-rf2-7gth0
+  (testing "rf2-7gth0 (audit #7038) — a schema-3 process that DID claim the
+            donor evidence projection migrates its registrar half, is told
+            once and loudly to reload, and is NOT stamped current"
+    (setup-xray-frame!)
+    (pose-schema-3-registry!)
+    (pose-donor-ownership-marker!)
+    (registry/simulate-registration-at-schema! 3)
+
+    (let [prior-console js/console
+          warns         (atom [])]
+      (set! js/console (js-obj "warn" (fn [& args] (swap! warns conj (apply str args)) nil)
+                               "error" (fn [& _args] nil)
+                               "log"   (fn [& _args] nil)))
+      (try
+        ;; The live upgrade.
+        (registry/register-xray-handlers!)
+
+        (testing "the registrar half migrated anyway — the panel is left as
+                  current as a live process can be"
+          (is (= (set schema-4-sub-ids) (registered-ids :sub schema-4-sub-ids))
+              "the three Freehand reads installed")
+          (is (= #{} (registered-ids :sub schema-3-donor-sub-ids))
+              "the four donor-era subs were cleared")
+          (is (nil? (registrar/handler :event schema-3-donor-event-id))
+              "the donor-era ownership event was cleared"))
+
+        (testing "the process is NOT stamped current — the donor projection
+                  it still owns cannot be released by this build, and a
+                  registry that stamped 4 here would be asserting an upgrade
+                  that did not finish (audit #7038)"
+          (is (= 3 (registry/installed-schema-version)))
+          (is (not= registry/schema-version (registry/installed-schema-version))))
+
+        (testing "one warning for the attempt, and it names the reload and
+                  the ownership it cannot drop"
+          (is (= 1 (count @warns)) "exactly one console.warn per attempt")
+          (let [msg (first @warns)]
+            (is (re-find #"(?i)reload" msg) "the message names the reload")
+            (is (re-find #"re-frame\.ui" msg)
+                "the message names the tier still owned")
+            (is (re-find #":rf\.xray/viewcell-evidence" msg)
+                "the message names the owner id holding the slot")))
+
+        (testing "a second `:after-load` still refuses and says so again —
+                  the residue is still resident, so the refusal is a stable
+                  fact about the process, not a one-shot the developer can
+                  miss by saving a file"
+          (registry/register-xray-handlers!)
+          (is (= 3 (registry/installed-schema-version)))
+          (is (= 2 (count @warns))))
+
+        (testing "the residue is the ONLY thing holding the stamp back: drop
+                  the marker (what a real page reload does to the whole
+                  module registry) and the very next call stamps current"
+          (gobj/remove js/globalThis donor-ownership-marker-key)
+          (registry/register-xray-handlers!)
+          (is (= registry/schema-version (registry/installed-schema-version))))
+        (finally
+          (set! js/console prior-console)
+          (gobj/remove js/globalThis donor-ownership-marker-key))))))
 
 ;; ---- schema-delta governance pin (rf2-sa8j3) ----------------------------
 ;;

--- a/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
+++ b/tools/xray/test/day8/re_frame2_xray/registry_cljs_test.cljs
@@ -1321,11 +1321,13 @@
     (pose-donor-ownership-marker!)
     (registry/simulate-registration-at-schema! 3)
 
-    (let [prior-console js/console
-          warns         (atom [])]
-      (set! js/console (js-obj "warn" (fn [& args] (swap! warns conj (apply str args)) nil)
-                               "error" (fn [& _args] nil)
-                               "log"   (fn [& _args] nil)))
+    ;; Capture ONLY `.warn`, on the real console object. Swapping the whole
+    ;; console out would also swallow `println`, and with it every failure
+    ;; this deftest exists to report.
+    (let [prior-warn (.-warn js/console)
+          warns      (atom [])]
+      (set! (.-warn js/console)
+            (fn [& args] (swap! warns conj (apply str args)) nil))
       (try
         ;; The live upgrade.
         (registry/register-xray-handlers!)
@@ -1371,7 +1373,7 @@
           (registry/register-xray-handlers!)
           (is (= registry/schema-version (registry/installed-schema-version))))
         (finally
-          (set! js/console prior-console)
+          (set! (.-warn js/console) prior-warn)
           (gobj/remove js/globalThis donor-ownership-marker-key))))))
 
 ;; ---- schema-delta governance pin (rf2-sa8j3) ----------------------------


### PR DESCRIPTION
Follow-up to the Freehand tool-door cutover, reopened by the merged-PR audit of
#7038. The cutover deleted the donor ownership plane from **source**; deleting a
namespace does not execute teardown in a process that has already loaded it. So a
schema-3 Xray process that hot-reloads into schema-4 code was left carrying donor
state while the registry stamped it current.

## The ruling this work serves

The operator ruling recorded on the driving bead, verbatim:

> "But xray and story should not be using the donor, they should be across onto freehand"

> "We intend to remove the donor (re-frame.ui)"

The reasoning: the donor evidence tier is scheduled for deletion, so a tool still
reading it is not a stable position — it is a dependency on an artefact scheduled
for removal. Crossing over means serving the need through what Freehand actually
offers, and saying so explicitly where a donor-shaped fact has no Freehand
counterpart, rather than inventing a registry to preserve the old shape.

That ruling is what decides this PR, below.

## What a schema-3 process was actually left holding

Two residues, with very different reach:

1. **Five registrar entries** — the subs `:rf.xray/viewcell-evidence`,
   `:rf.xray/viewcell-evidence-version`, `:rf.xray/view-evidence-sites`,
   `:rf.xray/viewcell-evidence-ownership` and the event
   `:rf.xray/viewcell-evidence-ownership-changed`. They were installed by
   `install-viewcell-evidence-bridge!`, a fn the cutover deleted. Nothing
   re-registers or replaces them, so neither the `registered?` umbrella nor a
   replacement delta can notice, and they resolve forever as phantom ids backed
   by a deleted namespace's resident closures.
2. **The donor `re-frame.ui.tool.evidence` projection**, still owned by
   `:rf.xray/viewcell-evidence`, sink armed, entries retained, and refusing the
   slot to any other tool.

## The decision: reload-required, declared — not a cross-generation teardown

The audit named two legitimate outcomes. This PR takes the second, and the reason
is the ruling above.

Releasing (2) means calling the donor tier's `uninstall!`. `re-frame.ui` is not on
`tools/xray/deps.edn` — dropping that coordinate **is** the cutover, and it is what
lets the donor inventory ledger reach zero and the donor be deleted. Putting the
coordinate back to run a teardown would reinstate exactly the coupling this work
exists to remove, and it would do so for a tier that is being deleted outright:
the teardown would be dead code the day it shipped. Reaching the resident donor
module reflectively by munged global name would be the same coupling in string
form, and untestable from an artefact that cannot compile against it.

So schema 4 is **reload-required** for the ownership half, and the seam now says
so rather than stamping the process current over state it cannot release. The
smaller honest answer: declare the reload, fail loud, and do not build a
cross-generation teardown registry to avoid admitting one.

The clause therefore splits:

- **The registrar half always migrates**, live, like every delta before it. The
  five donor-era ids are cleared and the three Freehand reads install. A process
  the developer does not reload is left as current as a live process can be.
- **The ownership half is declared reload-only.** When the donor claim is
  resident, `migrate-schema!` returns false; `register-xray-handlers!` stamps
  `installed-schema` only on a true return, so the registry can never assert an
  upgrade that did not finish. One `console.warn` names the owner id still holding
  the donor slot and the reload that ends it. A subsequent `:after-load` repeats
  both the refusal and the warning — the condition is a stable fact about the
  process, not a one-shot the developer can miss by saving a file.

Xray's own ownership listener lives in the same deleted namespace and is equally
unreachable, but it is also provably **inert**: it fires only from `acquire!` /
`release-span!`, and no call site for either survives.

### The probe, and why it needs no donor dependency

`__day8_re_frame2_xray_viewcell_evidence` — the `js/globalThis` key the deleted
`viewcell_evidence.cljs` wrote on a successful acquire and removed on release.
Reading it is the one way to observe the donor claim from an artefact that does
not depend on the donor: the tier's own `installed-owner` is not askable and its
`uninstall!` is not callable. A process that booted at schema 4, and an older
process whose acquire was rejected by a foreign owner, both read false and upgrade
to completion. `reset-for-test!` clears the marker along with the sentinels, since
no registrar rollback or `defonce` reset reaches a `globalThis` key.

## The no-reload claim is gone

`schema-version`'s history entry for 4 previously implied the same in-place
upgrade every other version gets. It now states the split and names the reason.
`tools/xray/spec/014-Registry-Catalogue.md` gains *"Schema 4 is reload-required
for a donor-resident process"*, and its version-4 paragraph now records the delta
as the first one containing a **removal** — with the reason a removal needs its own
clause: the fn that installed those ids is deleted, so no re-registration happens
and the umbrella has nothing to compare against. A repo-wide grep for a surviving
no-reload schema-4 promise turns up nothing else.

## What the proof asserts, and on what

The load-bearing assertion is on **state with a schema**, not on a console
sentence: `registry/installed-schema-version` (a new read-only diagnostic
counterpart to the existing public `schema-version`) must read `3`, not `4`, after
a donor-resident process meets schema-4 code. The console text is asserted only as
secondary corroboration, and only in the node lane, where rebinding `.warn` on the
real console object demonstrably intercepts — and where the capture is shown below
to both count non-zero and red when the count is wrong.

- `schema-4-migrates-the-registrar-half-of-the-donor-cutover-rf2-7gth0` — the
  completing path: three Freehand reads installed and resolving, five donor-era
  ids gone, process stamped current.
- `schema-4-refuses-to-stamp-a-donor-resident-process-rf2-7gth0` — the
  reload-required path: registrar half migrated anyway, stamp withheld at 3, one
  warning naming the reload / the tier / the owner id, refusal stable across a
  second `:after-load`, and current the instant the residue goes.

### Honest limit of the fixture

The donor span itself cannot be *genuinely acquired* from `tools/xray`, because the
donor artefact is not on its classpath and — per the ruling — must not be put back.
The fixture reproduces residue (1) exactly (the same five ids in the registrar with
the same input topology; only the handler bodies are stand-ins, because the donor
reads they closed over are precisely what is unreachable) and residue (2) through
its observable: the byte-identical `globalThis` key the deleted `sync-sentinel!`
wrote, spelled as a literal in the test rather than read off `registry`, so a
rename on the production side fails the test instead of silently agreeing with it.
That unreachability is not a gap in the proof — it is the fact the reload-required
verdict exists to state.

## Mutation proof

**Defect 1 — restore the unconditional stamp** (the audit's core complaint).
`register-xray-handlers!` reverted to `(migrate-schema! …)` followed by an
unconditional `(reset! installed-schema schema-version)`.

Mutation confirmed applied before reading any verdict: `git diff --stat` →
`registry.cljs | 4 ++--`, and `grep -n "when (migrate-schema!"` returned rc=1 —
the guard token was gone.

`npm run test:cljs` → **EXIT=1**, `4 failures, 0 errors`, all four naming the new
test:

```
FAIL in (schema-4-refuses-to-stamp-a-donor-resident-process-rf2-7gth0) (registry_cljs_test.cljs:1348:15)
FAIL in (schema-4-refuses-to-stamp-a-donor-resident-process-rf2-7gth0) (registry_cljs_test.cljs:1349:15)
FAIL in (schema-4-refuses-to-stamp-a-donor-resident-process-rf2-7gth0) (registry_cljs_test.cljs:1366:15)
FAIL in (schema-4-refuses-to-stamp-a-donor-resident-process-rf2-7gth0) (registry_cljs_test.cljs:1367:15)
```

1348/1349 are the withheld stamp; 1366/1367 are the second `:after-load` (with the
stamp mis-advanced the seam no-ops, so the refusal and its warning never repeat).

**The warn capture was made to fail on purpose, and did.** Line 1367 is
`(= 2 (count @warns))`: under the mutation the counter read `1` and the assertion
failed — so it demonstrably counts real emissions and demonstrably reds when the
count is wrong. It is not true-by-emptiness. (An earlier attempt replaced the whole
`js/console` object; that swallowed `println` and with it cljs.test's own failure
reporting — four failures, none named. Fixed in its own commit by rebinding only
`.warn` on the real console.)

Mutation restored, tree byte-identical to the committed state
(`git status --porcelain` reports registry.cljs unmodified), then green.

## Quality gates

- `npm run test:cljs` (implementation `node-test`; carries the whole `tools/xray`
  CLJS suite) — **EXIT=0**, `Ran 11551 tests containing 57830 assertions. 0
  failures, 0 errors.`
- Re-run in progress on the rebased tree (this branch was 88 commits behind and has
  been rebased onto current `main`). Reported here as reliance-on-CI if it has not
  landed in this body by merge time.

## Spec

`tools/xray/spec/014-Registry-Catalogue.md` updated in this PR, per the standing
rule for this tree.
