### PR TITLE
docs,spec,skills: correct the live wrong-arity reg-* examples (rf2-rzuc7)

### DIFF
--- a/docs/core/derivations-and-algebra-views.md
+++ b/docs/core/derivations-and-algebra-views.md
@@ -64,11 +64,10 @@ with the identical formula:
   (fn [[items discounts] _] (sum-cart items discounts)))
 
 ;; Source form B — a flow. The same function.
-(rf/reg-flow
-  {:id     :cart/materialized-total
-   :inputs [[:cart :items] [:pricing :discounts]]
-   :derive (fn [items discounts] (sum-cart items discounts))
-   :output-path [:cart :total]})
+(rf/reg-flow :cart/materialized-total
+  {:inputs      [[:cart :items] [:pricing :discounts]]
+   :output-path [:cart :total]}
+  (fn [items discounts] (sum-cart items discounts)))
 ```
 
 `sum-cart` is one whole-value function. Both forms compute the cart total the same

--- a/docs/core/glossary.md
+++ b/docs/core/glossary.md
@@ -272,13 +272,13 @@ Related: [Introduction](introduction.md).
 
 A pure derivation re-frame2 keeps materialised at a path in [app-db](#app-db). Because the value lives *in* app-db, [event handlers](#event-handler) can read it as plain state — unlike a [subscription](#subscription), whose value is for [views](#view).
 
-Declare `:inputs`, a pure `:derive`, and `:output-path`. When an input changes, the runtime re-runs `:derive` and writes the result in step with the [event pipeline](#event-pipeline):
+Declare `:inputs` and an `:output-path` in the metadata map, with the pure derive fn as the third slot. When an input changes, the runtime re-runs that fn and writes the result in step with the [event pipeline](#event-pipeline):
 
 ```clojure
-(rf/reg-flow
-  {:id :cart/total :inputs [[:cart :items]]
-   :derive (fn [items] (reduce + (map :price items)))
-   :output-path [:cart :total]})
+(rf/reg-flow :cart/total
+  {:inputs      [[:cart :items]]
+   :output-path [:cart :total]}
+  (fn [items] (reduce + (map :price items))))
 ```
 
 Use a flow to collate many facts into one (e.g. several error flags → `:any-errors?`). Inputs may read framework state under `:rf.db/runtime`. Flows can be [added and removed dynamically](../api/re-frame.flows.md) via effects.

--- a/docs/core/how-to/keep-secrets-out-of-traces.md
+++ b/docs/core/how-to/keep-secrets-out-of-traces.md
@@ -209,7 +209,12 @@ So a route carrying a token in its query string (`?reset_token=…`) classifies 
   "/reset")
 
 (rf/reg-resource :user-profile
-  {:sensitive [[:data :ssn]] :large [[:data :avatar-bytes]]})
+  {:sensitive     [[:data :ssn]]
+   :large         [[:data :avatar-bytes]]
+   :scope         {:from-db :app/session}
+   :params-schema [:map [:user-id :string]]}
+  (fn [{:keys [user-id]} _ctx]
+    {:request {:method :get :url (str "/api/users/" user-id)}}))
 ```
 
 A malformed subsystem declaration fails loud at registration under its own per-subsystem error id — `reg-machine` raises `:rf.error/invalid-machine-classification`, a bad resource spec folds into `:rf.error/resource-bad-spec`.

--- a/docs/core/where-state-lives.md
+++ b/docs/core/where-state-lives.md
@@ -70,16 +70,15 @@ This is the moment the value wants to be *part of the application's state*. That
 
 ;; AFTER — a flow. Same formula, but the result is WRITTEN into app-db,
 ;; where handlers read it as plain data and your schema can cover it.
-(rf/reg-flow
-  {:id          :cart/total
-   :inputs      [[:cart :items]]                 ;; app-db paths to watch
-   :derive      (fn [items] (reduce + (map :price items)))
-   :output-path [:cart/total]})                  ;; where the result is written
+(rf/reg-flow :cart/total                         ;; the flow's id
+  {:inputs      [[:cart :items]]                 ;; app-db paths to watch
+   :output-path [:cart/total]}                   ;; where the result is written
+  (fn [items] (reduce + (map :price items))))    ;; the pure recompute
 ```
 
 The formula is identical. What changed is *where the value lives*. Your checkout handler now reads `(:cart/total db)` like any other state, and because the value is part of the [frame](glossary.md#frame)'s state, it rides time-travel and SSR. Dispatch a cart event with [Xray](glossary.md#xray) open and you'll watch the flow's recompute ride the very [pipeline run](glossary.md#run) that changed its inputs — so the total becomes part of the event's *outcome*, not a render-time afterthought.
 
-Those four keys are the whole core of a flow: `:id` names it, `:inputs` is the ordered vector of paths to watch (each value arrives positionally to `:derive`), `:derive` is the pure recompute, and `:output-path` is the `app-db` path written for you.
+Those four things are the whole core of a flow: the id names it, `:inputs` is the ordered vector of paths to watch (each value arrives positionally to the derive fn), the third slot is the pure recompute, and `:output-path` is the `app-db` path written for you.
 
 The rent is real: an `app-db` write on every recompute, plus a piece of registered runtime. You pay it *because a handler needs the value as data*, and not before. Rule of thumb: a typical app has dozens of subscriptions and a *handful* of flows. If no handler reads a flow's output, you're over-paying — go back to a sub.
 
@@ -89,7 +88,7 @@ The rent is real: an `app-db` write on every recompute, plus a piece of register
 
 !!! note "Two more knobs worth knowing"
 
-    First, **`:inputs` can read [runtime-db](glossary.md#runtime-db), not just `app-db`.** Alongside your `app-db`, the framework keeps its own slice of frame state — *runtime-db* — where it stashes things like machine snapshots and the current route (you'll meet it again in Question 4). A bare input path like `[:cart :items]` reads `app-db`; a path led by `:rf.db/runtime` reads that runtime partition — so a flow can derive an `app-db` value from a machine's snapshot or the current route, e.g. `[:rf.db/runtime :rf.runtime/machines :snapshots :checkout/flow :state]`. The **write side stays `app-db`-only**, always: a flow's `:output-path` is never a runtime-db path. Second, **flows are frame-scoped.** `reg-flow` registers against the surrounding frame; pass `{:frame …}` as a second argument (or wrap the call in `with-frame`) to target a specific one. A bare `(reg-flow …)` outside any frame scope fails loud with `:rf.error/no-frame-context` rather than guessing a default.
+    First, **`:inputs` can read [runtime-db](glossary.md#runtime-db), not just `app-db`.** Alongside your `app-db`, the framework keeps its own slice of frame state — *runtime-db* — where it stashes things like machine snapshots and the current route (you'll meet it again in Question 4). A bare input path like `[:cart :items]` reads `app-db`; a path led by `:rf.db/runtime` reads that runtime partition — so a flow can derive an `app-db` value from a machine's snapshot or the current route, e.g. `[:rf.db/runtime :rf.runtime/machines :snapshots :checkout/flow :state]`. The **write side stays `app-db`-only**, always: a flow's `:output-path` is never a runtime-db path. Second, **flows are frame-scoped.** `reg-flow` registers against the surrounding frame; add a `:frame` key to the metadata map (or wrap the call in `with-frame`) to target a specific one. A bare `(reg-flow …)` outside any frame scope fails loud with `:rf.error/no-frame-context` rather than guessing a default.
 
 !!! note "Flows fail loud, at registration, before they can bite"
 

--- a/skills/re-frame-migration/references/auto-call-site-rewrites.md
+++ b/skills/re-frame-migration/references/auto-call-site-rewrites.md
@@ -132,7 +132,7 @@ Same for the `uix` variant.
 (reg :sub :id ...)                   → (reg-sub :id ...)
 (reg :fx :id ...)                    → (reg-fx :id ...)
 (reg :cofx :id ...)                  → (reg-cofx :id ...)
-(reg :flow :id ...)                  → (reg-flow ...)
+(reg :flow :id ...)                  → (reg-flow :id {…} derive-fn)   ; 3 slots — the :derive fn moves OUT of the map
 (sub <vector>)                       → (subscribe <vector>)   ; EXCEPT inside a reg-sub signal/input fn, per M-71 (below)
 (sub {:re-frame/q ::id :param 1})    → (subscribe [::id 1])   ; vectorize the query-map
 ```

--- a/skills/re-frame2/references/cross-cutting/privacy-and-elision.md
+++ b/skills/re-frame2/references/cross-cutting/privacy-and-elision.md
@@ -89,7 +89,12 @@ A runtime subsystem owns its storage, so you never name an absolute runtime path
    :states  {,,,}})
 
 (rf/reg-resource :user-profile
-  {:sensitive [[:data :ssn]] :large [[:data :avatar-bytes]]})
+  {:sensitive     [[:data :ssn]]
+   :large         [[:data :avatar-bytes]]
+   :scope         {:from-db :app/session}
+   :params-schema [:map [:user-id :string]]}
+  (fn [{:keys [user-id]} _ctx]
+    {:request {:method :get :url (str "/api/users/" user-id)}}))
 ```
 
 The `[:data :payment :token]` declaration redacts that slot everywhere the machine snapshot egresses (every transition's before/after, the Xray Machine Inspector, the pair-MCP wire, the epoch record), for **every spawned actor instance**, with no per-instance author code. Rename the slot in the declaration and the classification moves with it. A malformed declaration is rejected fail-loud at registration.

--- a/spec/015-Data-Classification.md
+++ b/spec/015-Data-Classification.md
@@ -169,7 +169,12 @@ A runtime subsystem owns its runtime storage, so the author never names an absol
 
 ;; a resource declares its own statically-known sensitive / large fields
 (rf/reg-resource :user-profile
-  {:sensitive [[:data :ssn]] :large [[:data :avatar-bytes]]})
+  {:sensitive     [[:data :ssn]]
+   :large         [[:data :avatar-bytes]]
+   :scope         {:from-db :app/session}
+   :params-schema [:map [:user-id :string]]}
+  (fn [{:keys [user-id]} _ctx]
+    {:request {:method :get :url (str "/api/users/" user-id)}}))
 ```
 
 Each subsystem **owns the arrangement that fits it** — the projection root and any nesting that reads naturally for it (a route isn't a cache entry isn't an actor). The only shared invariant is the **axis vocabulary** over projection-relative paths; the rest is the subsystem's ergonomic call.

--- a/spec/016-Resources.md
+++ b/spec/016-Resources.md
@@ -1378,21 +1378,6 @@ An **infinite resource** is a resource registered with `:infinite true`. It reus
    ;; / trace). Schemas VALIDATE; they do NOT classify durably.
    :sensitive        [[:data :author-email]]
 
-   ;; :request keeps its settled (params ctx) shape; the RESERVED ctx now
-   ;; carries the resolved page context for THIS page (nil/empty for a
-   ;; non-infinite resource). NO new arity.
-   :request
-   (fn [{:keys [filter]} {:rf.resource/keys [page-param page-index]}]
-     {:request {:method :get
-                :url    "/api/timeline"
-                :params (cond-> {:filter filter :limit 20}
-                          page-param (assoc :cursor page-param))}
-      ;; per-page VALIDATION: a Malli schema on :decode validates ONE page
-      ;; (the decode target) before the success reply exists — the per-page
-      ;; validation surface for a feed, applied on page 0, load-more, and every
-      ;; refetch leg.
-      :decode  :app/timeline-page})
-
    ;; REQUIRED for :infinite. Derive the NEXT page param from the last loaded
    ;; page + all pages so far. Returns nil to signal "no more pages" (the single
    ;; terminal). Pure. TanStack getNextPageParam(lastPage, allPages) analogue.
@@ -1414,7 +1399,21 @@ An **infinite resource** is a resource registered with `:infinite true`. It reus
 
    :tags             (fn [{:keys [filter]} _data] #{[:feed filter]})
    :stale-after-ms   60000
-   :gc-after-ms      300000})
+   :gc-after-ms      300000}
+
+  ;; The :request handler is the THIRD slot, and keeps its settled
+  ;; (params ctx) shape; the RESERVED ctx now carries the resolved page context
+  ;; for THIS page (nil/empty for a non-infinite resource). NO new arity.
+  (fn [{:keys [filter]} {:rf.resource/keys [page-param page-index]}]
+    {:request {:method :get
+               :url    "/api/timeline"
+               :params (cond-> {:filter filter :limit 20}
+                         page-param (assoc :cursor page-param))}
+     ;; per-page VALIDATION: a Malli schema on :decode validates ONE page
+     ;; (the decode target) before the success reply exists — the per-page
+     ;; validation surface for a feed, applied on page 0, load-more, and every
+     ;; refetch leg.
+     :decode  :app/timeline-page}))
 ```
 
 Registration rules (MUST):
@@ -1706,12 +1705,12 @@ The artefact adds a `:rf.resource/*` trace family with operations such as `:rf.r
   {:params-schema [:map [:slug :string]]
    :data-schema   :app/article
    :scope         {:from-db :realworld/session}   ;; named resolver — viewer-scoped
-   :request (fn [{:keys [slug]} _]
-              {:request {:method :get :url (str "/api/articles/" slug)}
-               :decode :app/article})
    :stale-after-ms 60000
    :gc-after-ms    (* 5 60 1000)
-   :tags (fn [{:keys [slug]} _] #{[:article slug]})})
+   :tags (fn [{:keys [slug]} _] #{[:article slug]})}
+  (fn [{:keys [slug]} _]
+    {:request {:method :get :url (str "/api/articles/" slug)}
+     :decode :app/article}))
 
 (rf/reg-route
   :route/article


### PR DESCRIPTION
Fixes the **live, reader-facing** half of rf2-rzuc7. `docs/EP/` is left untouched by ruling — see the last section.

## The defect

Three public `reg-*` verbs are **single-arity**, verified against live source in this tree:

| verb | arglist | source |
|---|---|---|
| `reg-resource` | `[resource-id metadata request-fn]` | `implementation/resources/src/re_frame/resources/registry.cljc:466` |
| `reg-mutation` | `[mutation-id metadata request-fn]` | `implementation/resources/src/re_frame/resources/mutation_registry.cljc:258` |
| `reg-flow` | `[flow-id metadata derive-fn]` | `implementation/flows/src/re_frame/flows/registry.cljc:575` |

None has a 2-arg (or 1-arg) arity. A short call raises a raw `clojure.lang.ArityException` at registration — no `:rf.error/*` id, no grammar hint — so the registration never happens and everything downstream in the worked example is inert.

Two of the three carry a second, independent trap that a bare arity bump does **not** clear:

- `reg-resource`'s registrar rejects a `:request` left **inside** the metadata map as a mislocated key, and its gate additionally **requires** `:scope` (fail-closed, `:rf.error/resource-missing-scope-policy`) and `:params-schema` (`:rf.error/resource-bad-spec`).
- `reconstruct-flow` rejects a `:derive` left inside the metadata map with `:rf.error/invalid-flow-metadata`.

So the two populations needed different work: the `spec/016` sites had a `:request` fn to **promote** into the third slot; the `spec/015`, `docs/core` and `skills` sites had no handler at all and needed one **authored**, along with the required registration keys.

## True count of live sites fixed: 9

Re-scanned the whole tree independently — a paren-balanced reader over every fenced `clojure`/`edn` block in all 795 tracked `.md` files, with `;`-comments masked and string/char literals masked to opaque atoms so they still count as one form. 48 wrong-arity `reg-resource` / `reg-mutation` / `reg-flow` / `reg-route` calls in total: **10 live, 38 under `docs/EP/`**. One of the 10 live is a **false positive**, so **9 real live sites**, all fixed here:

| file | verb | shape |
|---|---|---|
| `spec/015-Data-Classification.md` | `reg-resource` | authored third slot + `:scope` + `:params-schema` |
| `spec/016-Resources.md` §Registration — `:infinite` | `reg-resource` | promoted `:request` to the third slot |
| `spec/016-Resources.md` §Examples — Route-driven page load | `reg-resource` | promoted `:request` to the third slot |
| `docs/core/how-to/keep-secrets-out-of-traces.md` | `reg-resource` | authored third slot |
| `skills/re-frame2/references/cross-cutting/privacy-and-elision.md` | `reg-resource` | authored third slot |
| `docs/core/derivations-and-algebra-views.md` | `reg-flow` | fused 1-arg map to 3 slots |
| `docs/core/glossary.md` | `reg-flow` | fused 1-arg map to 3 slots |
| `docs/core/where-state-lives.md` | `reg-flow` | fused 1-arg map to 3 slots |
| `skills/re-frame-migration/references/auto-call-site-rewrites.md` | `reg-flow` | M-23 rewrite row named no slots |

The bead's own inventory counted 9 for this set and the prior verification pass said 11. **9 is the number**, and the discrepancy is fully accounted for: the prior count included `spec/Derivations.md:537` (a two-column `SOURCE FORM | ALGEBRA VIEW` ASCII layout inside a single fence — the `reg-flow` call in it is a correct 3-arg call, and a scanner reads the second column as extra args) and `docs/core/derivations-and-algebra-views.md:255` (a `;; STATIC ALGEBRA VIEW of (rf/reg-resource …)` **comment mention**, not a call). Both re-confirmed as non-defects here, and both deliberately left alone.

`keep-secrets-out-of-traces.md` is the block PR #7094 **half-fixed** — it corrected the `reg-route` and left the `reg-resource` in the same fenced block, so the page still did not paste. It pastes now.

I also swept for the **sibling** defect: a correct-arity call whose metadata map still carries the mislocated `:request` / `:derive` key. **Zero remaining repo-wide, `docs/EP/` included** — the EP forms are the genuinely fused old grammar, and the two `spec/016` sites were the only mislocated ones anywhere.

## Choices worth flagging

- **Scope is `{:from-db :app/session}`, not `:rf.scope/global`.** The authored resources are user profiles carrying an SSN. Spec 016 §Scope resolution calls a session-dependent `:rf.scope/global` claim precisely the shape Xray should flag, so a global claim would have made the example teach the wrong thing. A `{:from-db …}` reference is valid at registration without the resolver being registered (`valid-scope-policy?`, `registry.cljc:91-105`), so the blocks still paste standalone.
- **Prose was touched only where it described a block I changed and would otherwise contradict it**: glossary's "Declare `:inputs`, a pure `:derive`, and `:output-path`"; where-state-lives' "those four keys" sentence; and where-state-lives' "pass `{:frame …}` as a second argument", which is this same ArityException in prose form — `:frame` is a key *in* the metadata map (`reconstruct-flow` reads `(:frame metadata)`). The `spec/` diff is arity-only, with no prose changes.

## Quality gates

| gate | result | exit |
|---|---|---|
| `python -m mkdocs build --strict` | PASS — built in 113.40s, zero strict warnings | `0` |
| `python scripts/check_keyword_catalogue_drift.py` | PASS | `0` |
| `python scripts/check_doc_slugs.py` | PASS | `0` |
| `python scripts/check_skill_migration_contract_drift.py --verbose --ci` | PASS — 23 files / 8029 lines scanned, no contract drift | `0` |
| `python scripts/check_skill_re_frame2_drift.py --verbose --ci` | PASS — 50 user-facing leaves / 7470 lines scanned | `0` |
| `sh scripts/test-fast-pr.sh` | PASS — docs tier armed (`docs=true jvm=false node=false`); README link/anchor, doc-slug, EP status-sync (+self-test), runtime-subsystem grading (+self-test), version lockstep, skill/MCP drift, migration cite-integrity, implementor order (+self-test), eval-docs (+self-test), README inventory, retired-spelling (+self-test), thrown-error message (+self-test), UI Root lifecycle (+self-test), ambient-durable-read (+self-test), test-lane bijection (+self-test: 1672 test-defining files, 45 lanes) | `0` |

Each gate was run foreground to completion, unpiped, captured to a worktree-local log.

**Gates deliberately not run, with reasons:**

- **Fenced-block coverage gate — not applicable, and verified rather than assumed.** The one gate that digest-pins fenced blocks is `implementation/freehand/test/re_frame/freehand/guide/samples_coverage_jvm_test.clj`, whose `guide-dir` is `"docs/core/freehand"` (line 86). This PR touches no file under `docs/core/freehand/`, so no block edited here is hashed by any coverage gate.
- **JVM artefact suites / npm-CLJS / node** — not armed. The diff is docs-and-spec only, so `implementation_jvm` and `cljs_node_test` both classify false; the spine's own classifier confirms.
- `test-fast-pr.sh` soft-skipped its own `mkdocs` step (`mkdocs` is not on PATH as a bare binary on this Windows host). That gap is covered: `python -m mkdocs build --strict` was run explicitly at exit `0`, row 1 above.

## `docs/EP/` was left untouched BY RULING — please do not "discover" this again

38 wrong-arity `reg-*` calls remain under `docs/EP/` (28 from this bead's inventory, plus the 10 `reg-route` residue rf2-txe8o left behind). **They are not a bug, and correcting them would be a regression.** Recording the evidence here so the next scanner run does not reopen it:

1. **`.github/workflows/docs.yml:467` states verbatim that `docs/EP/**` is the allowlisted historical record.** `check_donor_inventory.py:178` comments it identically; `check_inject_cofx_residue.py` and `check_retired_composition_vocab.py` both allowlist it the same way. EP-0009 rule 1 ("EPs are never deleted") and rule 3 ("preserving the original text — freeze meaning, not bytes") point the same way.
2. **These examples were CORRECT WHEN WRITTEN.** The fused 2-slot to 3-slot split is rf2-wvh95f (commit `037dffd1fd`), which moved the handler out of the fused spec to restore clean doc-DCE. Everything predating it is *period spelling in a historical record*, not a typo.
3. **The tree was skipped deliberately, three times.** (a) The rf2-wvh95f migration campaign — 8+ commits titled "docs: migrate reg-* examples to new grammar" — touched **zero** `docs/EP/` files. (b) rf2-txe8o / PR #7094 is titled "…in the 8 **live** worked examples" and touched only `docs/core/how-to/`, `spec/012`, `spec/016` and `spec/Derivations`. (c) That ruling is still visible in the tree today as the 10 surviving 2-arg `reg-route` calls.

Editing the EP tree would reverse three recorded decisions and leave EP-0003 / 0012 / 0014 / 0016 / 0020 **internally incoherent** — each holds both a `reg-resource`/`reg-flow`/`reg-mutation` and an untouched 2-arg `reg-route`, several in the *same fenced block*. Nor would it deliver paste-ability: the tree carries 103 fenced blocks across eight retired-grammar tokens (`reg-event-fx` 34, `:include-ns` 21, `:initial-db` 11, `reg-event-db` 10, `:on-create` 9, `:rf.world/inputs` 9, `:data-schema` 6, `:exclude-ns` 3). If that ruling is ever reversed, the EP pass must take all 38 at once — the 10 `reg-route` sites included — as one mechanical commit.

Closes rf2-rzuc7.
