### PR TITLE
fix(core): dispatch-sync silently ran nothing under -Dre-frame.debug=false — the frame's sealed generation was never refreshed (rf2-9c2jf)

### DIFF
--- a/implementation/core/src/re_frame/live_frame.cljc
+++ b/implementation/core/src/re_frame/live_frame.cljc
@@ -349,15 +349,21 @@
   registration issued after `make-frame` is deterministically visible to the
   very next dispatch / subscribe in the SAME tick, not only after the deferred
   `next-tick` flush happens to run. This strengthens the EP-0023 §Default Image
-  Semantics dev guarantee from \"reprojected at the next macrotask boundary\" to
+  Semantics guarantee from \"reprojected at the next macrotask boundary\" to
   \"reprojected before the next resolution\" — with `make-frame` as the ONE
   constructor, every frame is image-loaded, and the
   register-then-dispatch-sync sequence (tests, REPL, setup code) must not race
   the deferred tick. Coalescing is UNCHANGED: a synchronous `reg-*` burst still
   sets one flag and is flushed ONCE, by whichever comes first — this read or
-  the scheduled tick. Gated on `interop/debug-enabled?` (the flag can only be
-  set by the dev-only registration hook, and the gate lets `:advanced` +
-  `goog.DEBUG=false` builds DCE the read entirely — zero production cost).
+  the scheduled tick.
+
+  rf2-9c2jf: this flush is NOT gated on `interop/debug-enabled?`. It was, and
+  because `make-frame` seals a generation unconditionally the production gate
+  froze each frame's view of the registration pool at construction time — every
+  handler registered afterwards dispatched as `:rf.error/no-such-handler`. The
+  consult is by late-bind KEYWORD and its publisher is rooted from
+  `make-frame`, so an app that never constructs a frame still DCEs the whole
+  reprojection + assembly graph and pays nothing here.
 
   EP-0024 (rf2-tu2vr7): `frame-target` may be a frame VALUE (`make-frame`'s
   return token) or a frame id — the generation is read from the record by id, so
@@ -1102,12 +1108,23 @@
 ;;
 ;; ## Production elision
 ;;
-;; Reprojection is a DEV hot-reload concern: in production the source registrar
-;; stops changing after boot (EP-0023:530 — "the default path feels sealed for
-;; the lifetime of the frame"), so there is nothing to reproject. The whole
-;; wiring is therefore gated on `interop/debug-enabled?` — under `:advanced` +
-;; `goog.DEBUG=false` the gate constant-folds to `false`, the `defonce` install
-;; body DCEs, and the registration path carries ZERO reprojection cost. The
+;; Reprojection USED to be treated as a DEV hot-reload concern and the whole
+;; wiring was gated on `interop/debug-enabled?`, on the reasoning that "in
+;; production the source registrar stops changing after boot, so there is
+;; nothing to reproject". rf2-9c2jf retired that gate: nothing orders all
+;; registrations before all frame construction, `make-frame` seals a generation
+;; UNCONDITIONALLY (EP-0026 §Default Image), and `registrar/lookup` resolves
+;; through that seal — so under the gate the ordinary
+;; `make-frame` → `reg-*` → `dispatch` sequence resolved nothing and reported
+;; `:rf.error/no-such-handler`. Keeping a frame's generation in step with the
+;; registration pool is a CORRECTNESS invariant, not a diagnostic.
+;;
+;; The elision it bought is preserved differently: the wiring is now installed
+;; by `ensure-reprojection-installed!`, which ONLY `make-frame` reaches. An app
+;; that never constructs a frame never roots the reprojection + assembly graph,
+;; so `:advanced` + `goog.DEBUG=false` still trims it (`check-elision.cjs`
+;; PROD_ABSENT_WHEN_UNUSED); an app that DOES construct a frame already roots
+;; `assemble-default` through `make-frame` itself. The
 ;; hook adds NO new ALWAYS-ON error id: assembly errors never reach the
 ;; always-on axis (Spec 009 §Observability channels) here — they are diagnosed
 ;; on the trace DIAGNOSTIC channel only (`:rf.warning/reprojection-failed`,

--- a/implementation/core/src/re_frame/live_frame.cljc
+++ b/implementation/core/src/re_frame/live_frame.cljc
@@ -374,13 +374,17 @@
   ;; whole reprojection + image-assembly graph, which must DCE out of
   ;; production bundles that never root `make-frame`/`assemble` (the Spec 009
   ;; elision probe pins `resolve-within-image` ABSENT-when-unused). The
-  ;; dev-only publisher lives in the debug-gated auto-reprojection `defonce`
-  ;; below, so under `:advanced` + `goog.DEBUG=false` nothing references the
-  ;; flush and the graph folds away — the same seam the deferred tick's hook
-  ;; install already rides.
-  (when interop/debug-enabled?
-    (when-let [flush! (late-bind/get-fn-cached :live-frame/flush-projection!)]
-      (flush!)))
+  ;; publisher is `ensure-reprojection-installed!`, rooted from `make-frame`,
+  ;; so a bundle that never constructs a frame still folds the graph away —
+  ;; the keyword consult here roots nothing on its own.
+  ;;
+  ;; rf2-9c2jf: NOT gated on `interop/debug-enabled?`. `make-frame` seals a
+  ;; generation unconditionally and this seam binds it for every lookup in the
+  ;; cascade, so skipping the flush in production froze the frame's view of the
+  ;; registration pool at construction time and turned every later-registered
+  ;; handler into `:rf.error/no-such-handler`.
+  (when-let [flush! (late-bind/get-fn-cached :live-frame/flush-projection!)]
+    (flush!))
   (if-let [gen (frame-resolution-generation frame-target)]
     (binding [registrar/*generation* gen]
       (thunk))
@@ -501,6 +505,13 @@
   key. A supplied `:capabilities` now flows through to the engine as
   record-config (an ordinary config key)."
   #{:images :id :adapter})
+
+;; Forward reference: the reprojection wiring is defined at the bottom of this
+;; ns (it closes over the flush/mark fns, which in turn close over the
+;; reprojection sweep) but is ROOTED from `make-frame` below — see
+;; `ensure-reprojection-installed!` for why the install hangs off frame
+;; construction rather than namespace load (rf2-9c2jf).
+(declare ensure-reprojection-installed!)
 
 ;; ===========================================================================
 ;; Generation resolution (shared by make-frame and reproject-live-frame!)
@@ -694,6 +705,13 @@
    ;; argument cannot silently register a garbage default frame or fail by an
    ;; obscure host ClassCastException.
    (validate-opts! opts)
+   ;; rf2-9c2jf: a frame resolves every `(kind, id)` through the SEALED
+   ;; generation assembled below, so from this call onward the generation must
+   ;; be kept in step with the registration pool. Root the freshener here —
+   ;; idempotent, no debug gate — so the invariant holds on both hosts and
+   ;; under the production gate, while an app that never constructs a frame
+   ;; still DCEs the whole reprojection + assembly graph.
+   (ensure-reprojection-installed!)
    (let [{:keys [images id adapter]} opts
          ;; The frame id the record is keyed by: the public `:id` when supplied
          ;; (so `(rf/dispatch [...] {:frame :counter/main})` finds the same
@@ -1216,7 +1234,14 @@
   `flush-pending-reprojection!` and the direct `reproject-live-frames!` keep
   their all-or-nothing throw-through contract UNCHANGED — a REPL/test caller
   wants immediate fail-loud feedback, not a partially-applied sweep; only
-  THIS deferred path is resilient + defensive. Returns nil."
+  THIS deferred path is resilient + defensive. Returns nil.
+
+  rf2-9c2jf: this consult now runs on the PRODUCTION resolution path too. The
+  JVM `locking` stays UNCONDITIONAL — a fast-path `@pending-reprojection?` read
+  outside the monitor would return immediately while another thread's sweep is
+  mid-flight (that sweep has already cleared the flag), which is precisely the
+  stale-record race the lock exists to close. The uncontended acquire is the
+  price of that guarantee."
   []
   (try
     (flush-projection-if-dirty!)
@@ -1297,18 +1322,53 @@
   [_event]
   (mark-dirty-and-schedule!))
 
-;; Install the reprojection hook ONCE per process. `defonce` over the install so
-;; a dev `:reload` of THIS ns does not push a duplicate hook into the registrar's
-;; `registration-hooks` vector (it dedupes none, and `clear-all!` does not clear
-;; it) — the same "install a registrar hook once, survive hot-reload" pattern
-;; `re-frame.substrate.observation`'s `_registrar-hooks` and
-;; `re-frame.subs.cache`'s `_hot-reload-hook` use.
-;; Gated on `interop/debug-enabled?` so the
-;; whole install (and thus any reprojection cost on the registration path) is
-;; constant-folded away under `:advanced` + `goog.DEBUG=false`: production stops
-;; `reg-*`-ing after boot, so there is nothing to reproject (EP-0023:530).
-(defonce ^:private _auto-reprojection-hook
-  (when interop/debug-enabled?
+(defonce ^:private reprojection-installed? (atom false))
+
+(defn ^:no-doc ensure-reprojection-installed!
+  "Install the reprojection wiring ONCE per process: the registrar registration
+  hook plus the two late-bind keys the registrar's removal paths and the
+  resolution seams consult. Idempotent — `compare-and-set!` makes the
+  install-decision atomic, so a concurrent `make-frame` burst installs exactly
+  one hook (the registrar's `registration-hooks` vector dedupes none, and
+  `clear-all!` does not clear it).
+
+  ROOTED FROM `make-frame`, NOT FROM NAMESPACE LOAD, and carrying NO
+  `interop/debug-enabled?` gate (rf2-9c2jf). Both properties matter:
+
+  * NO DEBUG GATE, because the invariant it maintains — a frame's sealed
+    generation reflects the registration pool at resolution time — is a
+    CORRECTNESS invariant, not a diagnostic. `make-frame` assembles a
+    generation UNCONDITIONALLY (EP-0026 §Default Image: every frame is
+    image-loaded, so the absence-is-default registrar-atom fall-through never
+    fires on the make-frame path), and `registrar/lookup` resolves through that
+    generation for every dispatch / subscribe / fx / cofx inside
+    `call-with-frame-resolution`. Gating only the MAINTAINER left the PRODUCER
+    unconditional: under `-Dre-frame.debug=false` (and `:advanced` +
+    `goog.DEBUG=false`) the generation froze at `make-frame` time and every
+    later `reg-*` became invisible to dispatch — a `registrar/lookup` that
+    succeeded on the atom while the same lookup inside the cascade returned
+    nil and the event failed with `:rf.error/no-such-handler`. The gate's
+    former justification (\"production stops `reg-*`-ing after boot, so there
+    is nothing to reproject\") does not hold: nothing orders all registrations
+    before all frame construction, and the ordinary
+    `make-frame` → `reg-*` → `dispatch` sequence is exactly the broken one.
+
+  * ROOTED FROM `make-frame`, because that preserves the reachability-DCE
+    contract the former ns-load `defonce` bought with its debug gate
+    (`check-elision.cjs` PROD_ABSENT_WHEN_UNUSED pins
+    `image-assembly/resolve-within-image` ABSENT when the probe never calls
+    `make-frame`/`assemble`). An app that never constructs a frame never
+    reaches this fn, so Closure still trims the whole reprojection + assembly
+    graph; an app that DOES construct a frame already roots `assemble-default`
+    through `make-frame` itself, so the freshener costs it no new class of
+    code. The freshener is installed by the same call that creates the thing
+    which goes stale.
+
+  Nothing is lost by deferring the install: `mark-dirty-and-schedule!` skips
+  when no image-loaded frame exists, so the hook was a guaranteed no-op before
+  the first `make-frame` anyway."
+  []
+  (when (compare-and-set! reprojection-installed? false true)
     (registrar/add-registration-hook! reproject-on-registration-change!)
     ;; The REMOVAL twin (rf2-h1vqa4): `unregister!` / `clear-kind!` /
     ;; `clear-all!` are source-store changes exactly like a `reg-*` — a
@@ -1318,8 +1378,8 @@
     ;; its removal paths; same dirty-mark + coalescing as the register side.
     (late-bind/set-fn! :live-frame/mark-projection-dirty! mark-dirty-and-schedule!)
     ;; The read-time coalesced flush consult in `call-with-frame-resolution`
-    ;; (rf2-h1vqa4) — published HERE, inside the debug gate, so production
-    ;; bundles never reference the flush body and the reprojection +
-    ;; assembly graph DCEs (Spec 009 elision probe).
-    (late-bind/set-fn! :live-frame/flush-projection! flush-projection-if-dirty!)
-    :installed))
+    ;; and `router/process-event!` (rf2-h1vqa4). Both consult by KEYWORD
+    ;; through `late-bind`, so the consult sites themselves root nothing —
+    ;; only this publication does, and only `make-frame` reaches it.
+    (late-bind/set-fn! :live-frame/flush-projection! flush-projection-if-dirty!))
+  nil)

--- a/implementation/core/src/re_frame/registrar.cljc
+++ b/implementation/core/src/re_frame/registrar.cljc
@@ -693,10 +693,13 @@
     ;; projection dirty (late-bound; the register side rides the registration
     ;; hook, removals ride this) so default-image frames drop the cleared
     ;; handler at their next resolution rather than resolving a stale sealed
-    ;; generation. Dev-only (production stops mutating the registrar).
-    (when interop/debug-enabled?
-      (when-let [mark-dirty! (late-bind/get-fn :live-frame/mark-projection-dirty!)]
-        (mark-dirty!)))
+    ;; generation. rf2-9c2jf: NOT gated on `interop/debug-enabled?` — the
+    ;; sealed generation is produced unconditionally by `make-frame`, so
+    ;; skipping the dirty mark in production left a cleared handler resolving
+    ;; forever out of a store that no longer backs it. Late-bound by keyword;
+    ;; unpublished (no frame ever constructed) means no-op.
+    (when-let [mark-dirty! (late-bind/get-fn :live-frame/mark-projection-dirty!)]
+      (mark-dirty!))
     ;; Per Spec 009 §:op-type vocabulary: :rf.registry/handler-cleared
     ;; fires on explicit removal so hot-reload tools can update their
     ;; views. Only emit when something was actually present.
@@ -731,10 +734,10 @@
     ;; source-store generation) to HIT and return a stale generation that still
     ;; resolves the just-cleared `(kind, id)`s.
     (source-store/clear-kind! kind)
-    ;; rf2-h1vqa4: same removal dirty-mark as `unregister!` (see there).
-    (when interop/debug-enabled?
-      (when-let [mark-dirty! (late-bind/get-fn :live-frame/mark-projection-dirty!)]
-        (mark-dirty!)))
+    ;; rf2-h1vqa4 / rf2-9c2jf: same ungated removal dirty-mark as
+    ;; `unregister!` (see there).
+    (when-let [mark-dirty! (late-bind/get-fn :live-frame/mark-projection-dirty!)]
+      (mark-dirty!))
     (swap! missing-doc-warned clear-kind)
     (swap! collision-warned   clear-kind)
     ;; Per Spec 009 §:op-type vocabulary: :rf.registry/handler-cleared
@@ -771,10 +774,10 @@
   ;; namespace-string pool) in lockstep with the process-default resolver map,
   ;; so a test fixture starts each case from a clean state on both surfaces.
   (source-store/clear-all!)
-  ;; rf2-h1vqa4: same removal dirty-mark as `unregister!` (see there).
-  (when interop/debug-enabled?
-    (when-let [mark-dirty! (late-bind/get-fn :live-frame/mark-projection-dirty!)]
-      (mark-dirty!)))
+  ;; rf2-h1vqa4 / rf2-9c2jf: same ungated removal dirty-mark as `unregister!`
+  ;; (see there).
+  (when-let [mark-dirty! (late-bind/get-fn :live-frame/mark-projection-dirty!)]
+    (mark-dirty!))
   ;; Also clear the always-on error-coord parallel registry
   ;; so test cases start from a clean state on both surfaces.
   (source-coords/forget-error-coords!)

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -2900,18 +2900,24 @@
           ;; exact ownership around the callback and then derive generation
           ;; from the still-A record. Never let the generic bare-id resolver
           ;; redirect this already-dequeued envelope into same-id B.
-          (when interop/debug-enabled?
-            (when (frame/event-owner-live? (:frame envelope))
-              (when-let [flush! (late-bind/get-fn-cached
-                                  :live-frame/flush-projection!)]
-                (try
-                  (flush!)
-                  (catch #?(:clj Throwable :cljs :default) e
-                    ;; The projection callback is framework-owned. Preserve a
-                    ;; real failure while A owns the event; a destroy+throw is
-                    ;; inert with the rest of A's abandoned tail.
-                    (when (frame/event-owner-live? (:frame envelope))
-                      (throw e)))))))
+          ;; rf2-9c2jf: NOT gated on `interop/debug-enabled?`. The generation
+          ;; this cascade resolves through is sealed unconditionally by
+          ;; `make-frame`, so a skipped flush froze the frame's view of the
+          ;; registration pool in production and every later-registered handler
+          ;; dispatched as `:rf.error/no-such-handler`. The consult is by
+          ;; late-bind KEYWORD and its publisher is rooted from `make-frame`,
+          ;; so a bundle that never constructs a frame still DCEs the graph.
+          (when (frame/event-owner-live? (:frame envelope))
+            (when-let [flush! (late-bind/get-fn-cached
+                                :live-frame/flush-projection!)]
+              (try
+                (flush!)
+                (catch #?(:clj Throwable :cljs :default) e
+                  ;; The projection callback is framework-owned. Preserve a
+                  ;; real failure while A owns the event; a destroy+throw is
+                  ;; inert with the rest of A's abandoned tail.
+                  (when (frame/event-owner-live? (:frame envelope))
+                    (throw e))))))
           (when (frame/event-owner-live? (:frame envelope))
             (let [active-record (frame/frame (:frame envelope))]
               (when (and active-record

--- a/implementation/core/test/re_frame/prod_gate_dispatch_jvm_test.clj
+++ b/implementation/core/test/re_frame/prod_gate_dispatch_jvm_test.clj
@@ -1,0 +1,157 @@
+(ns re-frame.prod-gate-dispatch-jvm-test
+  "rf2-9c2jf — dispatch under the REAL documented production gate.
+
+  SECURITY.md documents `-Dre-frame.debug=false` (and `RE_FRAME_DEBUG=false`) as
+  the JVM/SSR production setting. Under it, a plain
+  `make-frame` → `reg-event` → `dispatch-sync` sequence silently ran NOTHING:
+  handler-runs 0, app-db untouched, `:rf.error/no-such-handler` emitted — while
+  `registrar/lookup` returned the handler at that same moment.
+
+  ## What was actually broken, and why nothing caught it
+
+  `make-frame` assembles an image generation UNCONDITIONALLY (EP-0026 §Default
+  Image), and `registrar/lookup` resolves through that sealed generation for
+  every `(kind, id)` inside `live-frame/call-with-frame-resolution`. The
+  machinery that keeps the generation in step with the registration pool — the
+  reprojection hook install, the read-time flush consults, the registrar's
+  removal dirty-marks — was gated on `interop/debug-enabled?`. The PRODUCER of
+  the sealed generation was unconditional; only its MAINTAINER was gated, so
+  under the production gate the generation froze at construction time and every
+  later `reg-*` became invisible to dispatch.
+
+  Nothing caught it because `interop/debug-enabled?` is read ONCE at
+  namespace-load time and every existing prod-gate suite rebinds that Var with
+  `with-redefs` AFTER the framework has loaded. A load-time `defonce` whose body
+  was skipped is invisible to `with-redefs`, so the whole family of \"production
+  gate\" tests could stay green while the documented production configuration
+  did not dispatch.
+
+  ## Therefore: a real gate, in a real JVM
+
+  This suite relaunches a FRESH JVM with `-Dre-frame.debug=false` actually on
+  the command line (the same `java.home` + `java.class.path` relaunch pattern
+  `re-frame.test-quiet` uses) running `re-frame.prod-gate-dispatch-probe`, and
+  asserts on what that child observed. `gate-was-really-off` pins the harness
+  itself: if the property ever stops reaching the child, THAT assertion fails
+  rather than the suite passing vacuously on a dev-mode run."
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
+            [re-frame.prod-gate-dispatch-probe :as probe]))
+
+;; ---------------------------------------------------------------------------
+;; child-JVM harness
+;; ---------------------------------------------------------------------------
+
+(defn- java-binary []
+  (let [win? (str/includes? (str/lower-case (System/getProperty "os.name")) "win")]
+    (str (io/file (System/getProperty "java.home") "bin"
+                  (if win? "java.exe" "java")))))
+
+(defn- drain
+  "Read `stream` to EOF on its own thread. Both pipes must be drained
+  concurrently — slurping stdout fully and only THEN reading stderr deadlocks a
+  child that fills the stderr pipe."
+  [stream]
+  (future (slurp (io/reader stream))))
+
+(defn- run-probe
+  "Relaunch a fresh JVM on THIS process's classpath running the probe's `-main`,
+  with `jvm-opts` prepended. Returns `{:exit :out :err}`."
+  [jvm-opts]
+  (let [cmd  (into [(java-binary)]
+                   (concat jvm-opts
+                           ["-cp" (System/getProperty "java.class.path")
+                            "clojure.main"
+                            "-m" "re-frame.prod-gate-dispatch-probe"]))
+        proc (-> (ProcessBuilder. ^java.util.List cmd)
+                 (.redirectErrorStream false)
+                 (.start))
+        out  (drain (.getInputStream proc))
+        err  (drain (.getErrorStream proc))]
+    {:exit (.waitFor proc) :out @out :err @err}))
+
+(defn- parse-result
+  "Pull the probe's single marker line out of `out` and read it back as EDN."
+  [out]
+  (some->> (str/split-lines out)
+           (filter #(str/starts-with? % probe/result-marker))
+           first
+           (drop (count probe/result-marker))
+           (apply str)
+           edn/read-string))
+
+;; One child JVM serves every assertion below — the relaunch costs a JVM boot
+;; plus a `re-frame.core` load, so it runs once and the deftests read the same
+;; observation map.
+(def ^:private observed
+  (delay
+    (let [{:keys [exit out err] :as raw} (run-probe ["-Dre-frame.debug=false"])]
+      (assoc raw :result (parse-result out) :exit exit :err err))))
+
+;; ---------------------------------------------------------------------------
+;; the harness must be real before any assertion about it means anything
+;; ---------------------------------------------------------------------------
+
+(deftest probe-child-runs-cleanly
+  (testing "the relaunched JVM completes and reports a result line"
+    (let [{:keys [exit err result]} @observed]
+      (is (zero? exit) (str "probe JVM exited " exit "; stderr:\n" err))
+      (is (some? result)
+          (str "no `" probe/result-marker "` line on the probe's stdout;"
+               " stderr:\n" err))
+      (is (nil? (:probe-threw result))
+          (str "the probe threw: " (:probe-threw result))))))
+
+(deftest gate-was-really-off
+  (testing "rf2-9c2jf — the child really loaded under `-Dre-frame.debug=false`.
+            Without this pin the rest of the suite would pass vacuously the
+            moment the property stopped reaching the child, which is precisely
+            how the defect survived: every other prod-gate suite asserts against
+            a `with-redefs` stand-in that cannot reproduce a load-time gate."
+    (let [{:keys [result]} @observed]
+      (is (false? (:debug-enabled? result))
+          "interop/debug-enabled? must read false in the probe JVM"))))
+
+;; ---------------------------------------------------------------------------
+;; the defect itself
+;; ---------------------------------------------------------------------------
+
+(deftest dispatch-sync-runs-its-handler-under-the-production-gate
+  (testing "rf2-9c2jf — under `-Dre-frame.debug=false`, a handler registered
+            AFTER `make-frame` still runs and still commits `:db`. This is the
+            documented production configuration; before the fix the dispatch was
+            a silent no-op."
+    (let [{:keys [result]} @observed]
+      (is (= 1 (:handler-runs result))
+          "dispatch-sync must run the handler exactly once under the prod gate")
+      (is (= {:n 1} (:app-db result))
+          "the handler's `:db` effect must be committed under the prod gate")
+      (is (empty? (:errors result))
+          (str "the dispatch must emit no error under the prod gate; got "
+               (pr-str (:errors result)))))))
+
+(deftest resolution-and-registration-agree-under-the-production-gate
+  (testing "rf2-9c2jf — the whole finding in one assertion: a registry lookup
+            that SUCCEEDS while the dispatch reports `:rf.error/no-such-handler`
+            is a contradiction. The bare lookup reads the registrar atom; the
+            cascade's lookup reads the frame's sealed generation. They must
+            answer the same question the same way."
+    (let [{:keys [result]} @observed]
+      (is (true? (:bare-lookup-found? result))
+          "sanity: the registrar atom holds the handler")
+      (is (not (some #{:rf.error/no-such-handler} (:errors result)))
+          "the frame's generation must resolve what the registrar atom holds"))))
+
+(deftest cleared-registration-disappears-under-the-production-gate
+  (testing "rf2-9c2jf — the removal twin. `unregister!`'s dirty-mark was gated
+            on the same flag, so under the production gate a cleared handler
+            kept resolving out of a sealed generation the source store no longer
+            backs. After the clear the event must genuinely have no handler."
+    (let [{:keys [result]} @observed]
+      (is (= 1 (:runs-after-unregister result))
+          "the cleared handler must NOT run a second time")
+      (is (some #{:rf.error/no-such-handler} (:errors-after-unregister result))
+          (str "dispatching a cleared event must report no-such-handler; got "
+               (pr-str (:errors-after-unregister result)))))))

--- a/implementation/core/test/re_frame/prod_gate_dispatch_probe.clj
+++ b/implementation/core/test/re_frame/prod_gate_dispatch_probe.clj
@@ -1,0 +1,83 @@
+(ns re-frame.prod-gate-dispatch-probe
+  "The CHILD half of `re-frame.prod-gate-dispatch-jvm-test` (rf2-9c2jf).
+
+  This namespace is NOT a test namespace — cognitect-test-runner discovers
+  `.*-test$` only, so nothing here runs on the ordinary suite. It is a `-main`
+  program the parent test relaunches in a FRESH JVM under
+  `-Dre-frame.debug=false`.
+
+  ## Why a separate JVM rather than `with-redefs`
+
+  `re-frame.interop/debug-enabled?` is read ONCE, at namespace-load time, from
+  the `re-frame.debug` system property. Every existing \"production gate\" suite
+  rebinds that Var with `with-redefs` AFTER the framework has loaded, which
+  cannot exercise anything the gate decided at load time — and the rf2-9c2jf
+  defect was exactly that: a load-time `defonce` whose body was skipped, so the
+  frame-generation freshener was never installed and every handler registered
+  after `make-frame` dispatched as `:rf.error/no-such-handler`. A test that
+  cannot fail under the real property is worthless for this class of bug, so the
+  gate has to be set before the JVM loads `re-frame.interop`.
+
+  Reports its observations as one EDN map on stdout, prefixed by
+  `result-marker`. Assertions live in the parent."
+  (:require [re-frame.core :as rf]
+            [re-frame.error-emit :as error-emit]
+            [re-frame.interop :as interop]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]))
+
+(def result-marker
+  "Line prefix the parent greps for. Distinctive enough that unrelated
+  framework chatter on stdout cannot be mistaken for the result line."
+  "RF2-PROD-GATE-PROBE ")
+
+(def ^:private frame-id :rf2-9c2jf/probe)
+(def ^:private event-id :rf2-9c2jf/bump)
+
+(defn probe
+  "Run the rf2-9c2jf scenario and return the observation map.
+
+  The ORDER is the whole point: `make-frame` FIRST, `reg-event` SECOND. A frame
+  seals an image generation at construction (EP-0026 §Default Image — every
+  frame is image-loaded, so `registrar/lookup` inside the cascade resolves
+  through that generation, not the registrar atom), and the registration lands
+  after the seal. Nothing in re-frame2 orders all registrations before all frame
+  construction, so this is an ordinary app/REPL/test sequence — and under the
+  production gate it used to silently no-op."
+  []
+  (let [runs   (atom 0)
+        errors (atom [])]
+    (rf/init! plain-atom/adapter)
+    (error-emit/register-error-listener!
+      ::probe (fn [record] (swap! errors conj (:error record))))
+    (rf/make-frame {:id frame-id})
+    (rf/reg-event event-id
+                  (fn [{:keys [db]} _]
+                    (swap! runs inc)
+                    {:db (update db :n (fnil inc 0))}))
+    (rf/with-frame frame-id
+      (rf/dispatch-sync [event-id]))
+    (let [after-dispatch {:debug-enabled?     interop/debug-enabled?
+                          :bare-lookup-found? (some? (registrar/lookup :event event-id))
+                          :handler-runs       @runs
+                          :app-db             (rf/app-db-value frame-id)
+                          :errors             @errors}]
+      ;; The REMOVAL twin: clearing a registration must likewise reach the
+      ;; frame's sealed generation, so a cleared handler stops resolving rather
+      ;; than lingering in a store that no longer backs it.
+      (reset! errors [])
+      (registrar/unregister! :event event-id)
+      (rf/with-frame frame-id
+        (rf/dispatch-sync [event-id]))
+      (assoc after-dispatch
+             :runs-after-unregister      @runs
+             :errors-after-unregister    @errors))))
+
+(defn -main [& _]
+  (let [result (try
+                 (probe)
+                 (catch Throwable t
+                   {:probe-threw (str (class t) ": " (.getMessage t))}))]
+    (.print (System/out) (str result-marker (pr-str result) "\n"))
+    (.flush (System/out))
+    (System/exit 0)))

--- a/implementation/core/test/re_frame/prod_gate_dispatch_probe.clj
+++ b/implementation/core/test/re_frame/prod_gate_dispatch_probe.clj
@@ -78,6 +78,10 @@
                  (probe)
                  (catch Throwable t
                    {:probe-threw (str (class t) ": " (.getMessage t))}))]
-    (.print (System/out) (str result-marker (pr-str result) "\n"))
-    (.flush (System/out))
+    ;; `System/out` is a static FIELD — referenced without parens. Writing it
+    ;; and flushing explicitly (rather than `println`) is deliberate: the child
+    ;; calls `System/exit` immediately after, and an unflushed stdout buffer
+    ;; would lose the marker line the parent parses.
+    (.print System/out (str result-marker (pr-str result) "\n"))
+    (.flush System/out)
     (System/exit 0)))


### PR DESCRIPTION
Closes rf2-9c2jf.

## Verdict: REPRODUCED on a plain boot — this was a real release blocker

The bead's first instruction was to establish whether the failure exists outside the test harness. It does. No test harness, no fixture, no `with-redefs` — just `clojure -J-Dre-frame.debug=false` and the documented API:

```clj
(rf/init! plain-atom/adapter)
(rf/make-frame {:id :fb})
(rf/reg-event :b (fn [{:keys [db]} _] ...))   ;; registered AFTER make-frame
(rf/with-frame :fb (rf/dispatch-sync [:b]))
```

| | handler runs | app-db | error emitted |
|---|---|---|---|
| flag absent (dev) | 1 | `{:b true}` | — |
| `-Dre-frame.debug=false` | **0** | `{}` | `:rf.error/no-such-handler` |

…while `(registrar/lookup :event :b)` returned the handler at that same moment. Registering *before* `make-frame` worked under both settings.

## Root cause: the two registries were never in disagreement — they were different registries

The bead flagged "a registry lookup succeeding while the invocation reports no-such-handler is a contradiction that should be impossible". It isn't a contradiction, and neither side was wrong about what "registered" means. They read different things:

- `registrar/lookup` resolves through `registrar/*generation*` when it is bound.
- `process-event!` binds it, via `live-frame/call-with-frame-resolution`, to the frame's **sealed image generation**.
- `make-frame` assembles that generation **unconditionally** — EP-0026 §Default Image made every frame image-loaded, so the absence-is-default registrar-atom fall-through never fires on the `make-frame` path.

So the *producer* of the sealed generation is unconditional. Its *maintainer* was debug-gated:

| site | what the gate removed |
|---|---|
| `live_frame.cljc` `_auto-reprojection-hook` (ns-load `defonce`) | the registration hook was never installed, and neither `:live-frame/mark-projection-dirty!` nor `:live-frame/flush-projection!` was ever published |
| `live_frame.cljc` `call-with-frame-resolution` | the read-time coalesced flush |
| `router.cljc` `process-event!` | the same flush on the dispatch path |
| `registrar.cljc` `unregister!` / `clear-kind!` / `clear-all!` | the removal dirty-marks |

Net effect under the production gate: the generation froze at `make-frame` time, every later `reg-*` was invisible to dispatch, and every cleared handler kept resolving forever.

The gate's stated justification — *"production stops `reg-*`-ing after boot, so there is nothing to reproject"* — does not hold. Nothing orders all registrations before all frame construction, and `make-frame` → `reg-*` → `dispatch` is an ordinary app / REPL / setup sequence. **This was not JVM-only**: the same shape applies under `:advanced` + `goog.DEBUG=false`.

## The fix

Keeping a frame's generation in step with the registration pool is a **correctness invariant, not a diagnostic**, so it carries no debug gate. But the gate was buying something real — `check-elision.cjs` `PROD_ABSENT_WHEN_UNUSED` pins `image-assembly/resolve-within-image` ABSENT when the probe never calls `make-frame`/`assemble`, and a blanket un-gate would root the reprojection + assembly graph from namespace load and red that contract.

So the installer is **rooted from `make-frame`** instead of from a debug-gated ns-load `defonce`:

- `ensure-reprojection-installed!` — idempotent (`compare-and-set!`), no debug gate, called by `make-frame`.
- An app that never constructs a frame never reaches it, so Closure still trims the whole graph and the elision contract is preserved by reachability rather than by a gate.
- An app that *does* construct a frame already roots `assemble-default` through `make-frame` itself, so the freshener costs it no new class of code.
- Nothing is lost by deferring the install: `mark-dirty-and-schedule!` skips when no image-loaded frame exists, so the hook was a guaranteed no-op before the first `make-frame` anyway.

The two flush consults and the three removal dirty-marks lose their gate. All five consult by late-bind **keyword**, so the consult sites root nothing on their own — only the publication does, and only `make-frame` reaches that.

One thing I deliberately did **not** do: I tried adding a `@pending-reprojection?` fast-path read outside `projection-flush-lock` (the consult now runs on the production path, so the uncontended monitor is a new cost there). It is wrong — a mid-flight sweep on another thread has *already* cleared the flag, so the fast path would return immediately and skip the wait, reintroducing exactly the stale-record race that lock exists to close. Reverted; the `locking` stays unconditional and the reasoning is recorded in the docstring.

## The regression test, and why the whole family of existing ones could not catch this

`interop/debug-enabled?` is read **once, at namespace-load time**. Every existing production-gate suite in the repo (`jvm_prod_gate_integration_test`, `ep0008_producers_jvm_gate_test`, and friends) rebinds that Var with `with-redefs` *after* the framework has loaded. A load-time `defonce` whose body was skipped is invisible to `with-redefs` — which is why a total dispatch failure under the documented production configuration sat green.

`prod_gate_dispatch_jvm_test.clj` therefore relaunches a **fresh JVM with `-Dre-frame.debug=false` actually on the command line** (the `java.home` + `java.class.path` relaunch pattern `test-quiet` already uses) running `prod_gate_dispatch_probe.clj`, and asserts on what that child observed. `gate-was-really-off` pins the harness itself, so the suite cannot pass vacuously if the property ever stops reaching the child.

**Verified to have teeth**: against the pre-fix source (`git checkout HEAD~1 -- <the three src files>`) it fails **5 failures / 11 assertions**; with the fix, 0. The `gate-was-really-off` pin passed in both runs, confirming the child really loaded under the gate.

## Follow-ons filed (not implemented here)

- **rf2-f8x2i** (P1) — CI never runs *any* suite under the real production gate. This PR closes the hole for one defect with one hand-written probe; a real lane needs a workflow + alias edit, both hot-zone, so it is the mayor's to sequence.
- **rf2-hsg8w** (P2) — audit which of the ~990 `interop/debug-enabled?` sites guard correctness rather than diagnostics. Late-bind `set-fn!` publications inside a debug gate are the suspicious shape: they silently remove a capability from production while the consuming site reads as a harmless `when-let`.
- **rf2-cx3ze** (P2) — `spec/009-Instrumentation.md` still carries the retired "production never re-registers after boot" rationale on two catalogue rows. Hot-zone file, so reported rather than edited, per the dispatch fence.

## Quality gates

| Gate | Result | Exit code |
|---|---|---|
| **clj-kondo** — `clj-kondo --parallel --fail-level error --lint implementation` (the gate that was red) | see note below | 3 locally, 0 for this diff's files |
| clj-kondo scoped to the two files this PR adds | **errors: 0**, 1 informational warning | **0** |
| `implementation/core` JVM (`clojure -M:test`) | 2131 tests / 10503 assertions — 0 failures, 0 errors | 0 |
| `npm run test:cljs` (from `implementation/`) | 11583 tests / 58140 assertions — 0 failures, 0 errors | 0 |
| `sh scripts/test-fast-pr.sh` | `PASS fast PR spine` — JVM tier 2131/10503 green, node tier 11583/58140 green, test-lane bijection 1673 files/45 lanes all selected, per-ns isolation 17/17 standalone | 0 |
| **Production gate** — `re-frame.prod-gate-dispatch-jvm-test` under real `-Dre-frame.debug=false` | 5 tests / 11 assertions — 0 failures, 0 errors | 0 |
| Production-gate probe run directly as a child JVM | printed its marker; `:debug-enabled? false`, `:handler-runs 1`, `:app-db {:n 1}`, `:errors []` | 0 |
| Regression-test teeth, re-verified after the lint fix | **5 failures / 11 assertions** against pre-fix source | 1 (expected) |
| Namespace load check (`live-frame` / `router` / `registrar`) | `LOAD-OK` | 0 |

### On the clj-kondo result

The two CI errors were `(System/out)` in `prod_gate_dispatch_probe.clj` — a static *field* referenced with parens. Fixed to `(.print System/out …)` / `(.flush System/out)`.

The local run of the full `--lint implementation` surface still exits 3, and that needs stating plainly rather than glossing: **local clj-kondo is `v2025.10.23`; CI pins `2026.04.15`.** The older local version reports 10 `Expected: throwable, received: …` errors that CI's version does not. All 10 are in files this branch never touches — `implementation/ui/test/**` and `implementation/epoch/test/**` — which is why CI reported `errors: 2` (both mine) on the same tree.

Two checks make that more than an assertion:

1. **Scoped to the files this PR adds, local clj-kondo reports `errors: 0`, exit 0.**
2. **The local linter does still enforce the rule that failed.** Re-introducing `(System/out)` in a scratch file reproduces the exact CI message — `Static fields should be referenced without parens unless they are intended as function calls`, 2 errors, exit 3. So its silence on the fixed file is a real signal, not a version gap swallowing the check.

The `.print` / `.flush` pair is deliberately kept over `println`: the child calls `System/exit` immediately afterwards, and an unflushed buffer would drop the marker line the parent parses. That is now a comment in the file so it does not get "simplified" back into a lost-output bug. The probe was re-run directly as a child JVM after the change to prove the marker still lands, and the regression test's teeth were re-verified (5 failures against pre-fix source) because the parens change touches a real call path.

The ~3790-4309 warnings are pre-existing across `examples/` and elsewhere and are informational under `--fail-level error`. Not touched.

**Skipped, with reason:**

- `npm run test:elision` (CLJS `:advanced` production-elision gate) — **not run locally**; it needs two `shadow-cljs release` builds and is CI-only per `TESTING.md` (the fast-PR spine names it in its own NOT-RUN list). It is the gate most relevant to this change, so the reasoning is spelled out above rather than assumed: the `PROD_ABSENT_WHEN_UNUSED` sentinel is a *reachability* contract, the probe does not call `make-frame`/`assemble` (stated in `check-elision.cjs`'s own comment at the `resolve-within-image` entry), and the new installer is reachable only from `make-frame` — so nothing newly rooted. CI owns the verification.
- JVM artefact suites the diff did not touch (21 of them, enumerated by the spine's own NOT-RUN line) — CI runs all via `scripts/test-jvm-implementation.sh`.
- Documentation gates — no documentation surface in the diff.
- Browser lanes, bundle-isolation, perf-bundle, adapter probes/smokes, Xray feature matrix, mcp-conformance, tool JVM suites — CI-only, in no tier of the local spine.

Local-green is not CI-green; the CI gates above are the ones that decide.
