### PR TITLE
fix(resources): recognise a scoped key whose canonical params are not a map (rf2-xx4ty, rf2-wd9im)

### DIFF
--- a/implementation/epoch/test/re_frame/epoch_egress_resource_trace_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_egress_resource_trace_test.clj
@@ -2963,3 +2963,121 @@
       (is (= [k1] (:identities (:tags plan))) "raw :identities rides")
       (is (= work-id (:work/id (:tags work))) "raw embedded work-id key rides"))))
 
+
+;; ---------------------------------------------------------------------------
+;; (3) the FOREIGN CARRIER — rf2-xx4ty's own surface, one params shape over
+;; ---------------------------------------------------------------------------
+
+(deftest fx-carrier-non-map-param-key-projects-under-a-family-named-slot
+  (testing "rf2-xx4ty / rf2-wd9im audit #7013 — inside an fx carrier the
+            reply's `:value` / `:params` tokenized (the owner read never needed
+            the params SHAPE), while the `:resource/key` beside them and the key
+            embedded in `:rf.reply/work-id` rode RAW — the redact-and-leak-the-
+            same-bytes shape this family keeps regressing into, now with the two
+            halves inside ONE map."
+    (let [k1        (sk :rf.scope/global :secret/vector-params vector-params)
+          reply     (read-reply k1 :rf.scope/global {:email (str vector-secret "@example.com")})
+          projected (epoch/projected-record (reply-carrier-record reply))
+          replies   (carrier-replies projected)]
+      (is (= 2 (count replies)) "one reply per carrier")
+      (doseq [r replies]
+        (is (redacted-component? (:value r)) "the decoded body tokenizes")
+        (is (redacted-component? (:params r)) "the VECTOR params slot tokenizes")
+        (is (= :secret/vector-params (second (:resource/key r)))
+            "the sibling key's resource-id survives")
+        (is (redacted-component? (nth (:resource/key r) 2))
+            "and its VECTOR params component tokenizes")
+        (is (redacted-component? (nth (second (:rf.reply/work-id r)) 2))
+            "as does the key embedded in the reply's own work-id")
+        (is (redacted-component?
+              (nth (:rf.reply/resource-key (:correlation r)) 2))
+            "as does the reply envelope's correlation key"))
+      (is (= [] (secret-leak-paths projected))
+          "nothing raw survives anywhere in the record"))))
+
+(deftest fx-carrier-named-slot-fails-closed-for-an-unregistered-non-map-params-owner
+  (testing "rf2-wd9im audit #7013 — `named?` exists so the fail-closed arm stays
+            reachable for a genuine key whose owner was cleared or hot-reloaded
+            away. Requiring a params `map?` on top of `named?` took that away:
+            an UNREGISTERED owner's vector-params key under the family's own
+            reserved `:resource/key` rode a carrier verbatim, which is the one
+            case the projector is least entitled to trust."
+    (let [gone      [:rf.scope/global :gone/vector-params [vector-secret]]
+          reply     (assoc (read-reply gone :rf.scope/global {:ok true})
+                           :resource :gone/vector-params)
+          projected (epoch/projected-record (reply-carrier-record reply))
+          replies   (carrier-replies projected)]
+      (is (= 2 (count replies)))
+      (doseq [r replies]
+        (is (= :gone/vector-params (second (:resource/key r)))
+            "attribution survives — the resource-id always rides")
+        (is (redacted-component? (nth (:resource/key r) 2))
+            "an unreadable owner's params FAIL CLOSED rather than riding raw"))
+      (is (= [] (secret-leak-paths projected))))))
+
+;; ---------------------------------------------------------------------------
+;; (4) the acceptance arm — a REAL reply-to read over a vector-params owner
+;; ---------------------------------------------------------------------------
+
+(def ^:private vector-reply-value
+  "The decoded body of the vector-params read. Carries the secret so the scan
+  below cannot pass by finding nothing to find."
+  {:email (str vector-secret "@example.com")})
+
+(defn- drive-vector-params-reply-to-read!
+  "`drive-reply-to-read!` against the `[:vector :string]` params owner: one REAL
+  `[:rf.resource/ensure … :reply-to …]`, its terminal reply replayed through the
+  runtime's own internal reply event, then a SECOND ensure that finds the entry
+  fresh — so one call produces both the async accepted fan-out
+  (`:cache-hit? false`) and the fresh-skip immediate dispatch
+  (`:cache-hit? true`). `:secret/vector-params` is `:rf.scope/global`, so nothing
+  here reaches the app-db axis and any surviving copy came off a trace carrier."
+  []
+  (rf/configure! {:epoch-history {:trace-events-keep 80}})
+  (let [captured (atom nil)]
+    (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! captured args) nil))
+    (rf/reg-event :app/read-loaded (fn [_ _ev] {}))
+    (rf/dispatch-sync [:rf.resource/ensure
+                       {:resource :secret/vector-params :params vector-params
+                        :owner    real-owner :reply-to read-reply-target}]
+                      {:frame :test/rt})
+    (rf/dispatch-sync (conj (:on-success @captured) {:status :ok :value vector-reply-value})
+                      {:frame :test/rt})
+    (rf/dispatch-sync [:rf.resource/ensure
+                       {:resource :secret/vector-params :params vector-params
+                        :owner    [:app :reader 2] :reply-to read-reply-target}]
+                      {:frame :test/rt})
+    (rf/epoch-history :test/rt)))
+
+(deftest real-vector-params-reply-to-read-leaks-nothing-into-fx-carriers
+  (testing "rf2-xx4ty / rf2-wd9im audit #7013 ACCEPTANCE — `projected-record`
+            over the records a REAL `[:rf.resource/ensure … :reply-to …]`
+            settles for a `:sensitive?` owner with NON-MAP canonical params must
+            carry the raw params at ZERO paths of its trace carriers, on BOTH
+            continuation paths. This is the public-path reproduction the audit
+            specified, driven through the runtime rather than assembled."
+    (let [records (drive-vector-params-reply-to-read!)]
+      (doseq [[label cache-hit?] [["async settle" false] ["fresh-skip cache hit" true]]]
+        (testing label
+          (let [raw       (record-carrying-reply records cache-hit?)
+                projected (epoch/projected-record raw)]
+            (testing "FIXTURE — the producer really put the vector params on the
+                      fx carriers"
+              (is (some? raw) "the continuation reached an fx carrier at all")
+              (is (every? #(= vector-params (:params %)) (carrier-replies raw))
+                  "every carrier's reply carries the RAW vector params")
+              (is (seq (secret-leak-paths (mapv :tags (:trace-events raw))))
+                  "the unprojected carriers leak — the projector's input is the
+                   runtime's own output, not an invented tag map"))
+            (testing "ACCEPTANCE — nothing raw survives on any trace carrier"
+              (is (= [] (secret-leak-paths (mapv :tags (:trace-events projected))))
+                  "every leaking path is named here; before the repair this
+                   printed the [… :rf.fx/args 1 :resource/key 2 0] shape, and
+                   the same key again inside :rf.reply/work-id, :correlation
+                   and :rf.event/fx"))
+            (testing "and the row still reads as a resource row"
+              (doseq [r (carrier-replies projected)]
+                (is (= :secret/vector-params (:resource r))
+                    "the resource id rides verbatim")
+                (is (= cache-hit? (:cache-hit? r)))
+                (is (= :ok (:status r)))))))))))

--- a/implementation/epoch/test/re_frame/epoch_egress_resource_trace_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_egress_resource_trace_test.clj
@@ -147,6 +147,25 @@
                    :page->items     :items
                    :params-schema   [:map [:filter :keyword]]}
                   (fn [_ _] {:request {:method :get :url "/f"}}))
+                ;; rf2-wd9im (merged-PR audit #7013) — a :sensitive? owner whose
+                ;; REQUIRED :params-schema legally admits NON-MAP canonical
+                ;; params. Nothing exotic: `[:vector :string]` is an ordinary
+                ;; schema, and the resource registrar validates + canonicalizes
+                ;; against whatever the owner declared. Its scoped key wears the
+                ;; positional skeleton of every other key but has no MAP at
+                ;; position 2, which is the only proof the shape read used to
+                ;; take.
+                (rf/reg-resource :secret/vector-params
+                  {:scope         :rf.scope/global
+                   :sensitive?    true
+                   :params-schema [:vector :string]}
+                  (fn [_ _] {:request {:method :get :url "/g"}}))
+                ;; …and its over-redaction control: same params SHAPE, no
+                ;; coarse claim, so its key must ride verbatim.
+                (rf/reg-resource :plain/vector-params
+                  {:scope         :rf.scope/global
+                   :params-schema [:vector :string]}
+                  (fn [_ _] {:request {:method :get :url "/h"}}))
                 ;; a PLAIN resource under a CONCRETE (non-global) scope — the
                 ;; over-redaction control for the FREE `:scope` tag (rf2-1zc33).
                 ;; Its scoped KEY must keep scope AND params verbatim, which is
@@ -2750,3 +2769,197 @@
       (is (= [declared-feed-items declared-feed-items]
              (mapv :value (carrier-replies projected)))
           "every carrier's raw merged item list rides with :include-sensitive?"))))
+
+;; ===========================================================================
+;; (rf2-wd9im audit #7013, and with it rf2-xx4ty's own carrier) NON-MAP
+;; CANONICAL PARAMS — the shape read under-recognised a legal scoped key.
+;; ===========================================================================
+;;
+;; rf2-wd9im replaced the projector's slot-NAME roster with a shape read, so a
+;; scoped key sitting in a slot nobody had enumerated (`:blocking` /
+;; `:identities`, an embedded `:work/id`) projects through its owner exactly as
+;; a named slot's keys do. The shape it read was
+;; `[<scope> <resource-id keyword> <params MAP>]`, and the `map?` at position 2
+;; was the whole discrimination: `:owner [:app :l 1]` and
+;; `:cause [:mutation :m/save 7]` wear the same skeleton and MUST ride verbatim.
+;;
+;; But `:params-schema` is REQUIRED and free. `[:vector :string]` is an ordinary
+;; schema, and the registrar validates + canonicalizes params against whatever
+;; the owner declared — so a REGISTERED owner's canonical params are legally a
+;; vector, a scalar, or nil. Such a key wore the skeleton and failed the only
+;; proof, so it fell through the recursive walk as a bag of structural scalars:
+;; owner-aware projection never ran, the row was NOT stamped `:sensitive?`, and
+;; a `:sensitive?` owner's resolved scope + canonical params egressed RAW —
+;; under `:blocking` / `:identities`, inside every `:work/id`, and (the
+;; rf2-xx4ty surface) inside a `:reply-to` read continuation riding
+;; `:rf.fx/args` / `:rf.event/fx`, one slot from the `:value` and `:params` that
+;; DID tokenize because the reply's owner read never needed the params shape.
+;;
+;; THE SECOND PROOF is the resource REGISTRY — the family's own authority
+;; answering "is this one of mine?", which `carrier-family-value?` already read
+;; one carrier out for exactly this question. It is not a roster and cannot rot,
+;; and it says nothing about `:owner`'s `:l` or `:cause`'s `:m/save`: a MUTATION
+;; id is not in the RESOURCE registrar. The controls below assert that
+;; explicitly, including on a `:branch` of THREE route ids — the structural
+;; 3-vector a bare "redact any vector-of-vectors" guard could never have kept.
+
+(def ^:private vector-secret
+  "The secret carried by a NON-MAP canonical params value. Distinct from
+  `secret` so a failing path names which class leaked."
+  (str secret "-vector"))
+
+(def ^:private vector-params
+  "Canonical params of a `[:vector :string]` owner — a legal params value with
+  no MAP anywhere in it, which is exactly what the old shape read could not
+  recognise."
+  [vector-secret])
+
+;; ---------------------------------------------------------------------------
+;; (1) family rows — the unnamed plan-membership slots and the embedded work-id
+;; ---------------------------------------------------------------------------
+
+(deftest off-box-redacts-non-map-param-keys-in-unnamed-plan-slots
+  (testing "rf2-wd9im audit #7013 — a :rf.resource/route-plan row's :blocking /
+            :identities carrying a :sensitive? owner's key whose canonical
+            params are a VECTOR must tokenize per key. Before the repair the key
+            failed the params `map?` proof, fell through the recursive walk as
+            structural scalars, and the raw scope + params rode out with the row
+            unstamped."
+    (let [k1        (sk :rf.scope/global :secret/vector-params vector-params)
+          k2        (sk :rf.scope/global :secret/vector-params
+                        [(str vector-secret "-2")])
+          record    (record-with
+                      [(event :rf.resource/route-plan (route-plan-tags [k1] [k1 k2]))])
+          projected (epoch/projected-record record)
+          tags      (:tags (first (:trace-events projected)))
+          [bscope brid bparams] (first (:blocking tags))]
+      (testing ":blocking tokenizes per key"
+        (is (= :secret/vector-params brid) "the resource-id (position 1) survives")
+        (is (redacted-component? bscope) "the scope is tokenized")
+        (is (redacted-component? bparams) "the VECTOR params are tokenized"))
+      (testing ":identities keeps per-key DISTINCTNESS so a tool's joins survive"
+        (is (= 2 (count (:identities tags))))
+        (is (every? #(redacted-component? (nth % 2)) (:identities tags)))
+        (is (apply not= (map #(nth % 2) (:identities tags)))
+            "two distinct vector-params keys keep two distinct digests"))
+      (is (true? (:sensitive? tags)) "the row is stamped :sensitive?")
+      (testing "the plan's structural attribution still rides verbatim"
+        (is (= [:r/root :r/article] (:branch tags)))
+        (is (= 1 (:removed tags)) "the INT count is untouched"))
+      (testing "NO raw secret survives anywhere in the projected record"
+        (is (= [] (secret-leak-paths projected)))))))
+
+(deftest unnamed-slot-non-map-params-projects-identically-to-named-slot
+  (testing "rf2-wd9im audit #7013 anti-drift — the SAME vector-params keys under
+            a NAMED slot (:matched, projected BY POSITION and therefore never
+            affected by the params shape) and under the UNNAMED :blocking /
+            :identities must project IDENTICALLY. This is the assertion that
+            reds hardest before the repair: the named slot tokenized while the
+            unnamed one rode raw, on one row, for one key."
+    (let [ks        [(sk :rf.scope/global :secret/vector-params vector-params)
+                     (sk :rf.scope/global :secret/vector-params [(str vector-secret "-2")])]
+          record    (record-with
+                      [(event :rf.resource/route-plan
+                              {:rf.frame/id :test/rt
+                               :matched     ks     ; NAMED   -> position arm
+                               :blocking    ks     ; UNNAMED -> shape arm
+                               :identities  ks})])
+          projected (epoch/projected-record record)
+          tags      (:tags (first (:trace-events projected)))]
+      (is (= (:matched tags) (:blocking tags))
+          ":blocking projects exactly as the NAMED :matched does")
+      (is (= (:matched tags) (:identities tags))
+          ":identities projects exactly as the NAMED :matched does")
+      (is (= [] (secret-leak-paths projected))))))
+
+(deftest off-box-redacts-non-map-param-key-embedded-in-resource-work-id
+  (testing "rf2-wd9im audit #7013 — the embedded work-id key is the SHARED path
+            the audit names: `[:rf.work/resource <scoped-key> <generation>]`
+            rides the majority of rows in the family and no roster names
+            :work/id, so a vector-params key one level down inside it egressed
+            raw on every one of them."
+    (let [scoped-key (sk :rf.scope/global :secret/vector-params vector-params)
+          work-id    (work-ledger/resource-work-id scoped-key 3)
+          record     (record-with
+                       [(event :rf.resource/work-started
+                               {:rf.frame/id :test/rt :resource/key scoped-key
+                                :generation 3 :work/id work-id
+                                :status :running :cause :ensure})])
+          projected  (epoch/projected-record record)
+          tags       (:tags (first (:trace-events projected)))
+          [marker embedded generation] (:work/id tags)]
+      (is (= :rf.work/resource marker) "the work-kind marker rides verbatim")
+      (is (= 3 generation) "the generation rides verbatim")
+      (is (= :secret/vector-params (second embedded)) "the resource-id survives")
+      (is (redacted-component? (first embedded)) "the embedded scope is tokenized")
+      (is (redacted-component? (nth embedded 2)) "the embedded VECTOR params are tokenized")
+      (is (= (:resource/key tags) embedded)
+          "the embedded key projects exactly as the row's own :resource/key —
+           the NAMED slot that was already right, which is what makes the
+           mismatch the bug rather than a preference")
+      (is (true? (:sensitive? tags)) "the row is stamped :sensitive?")
+      (is (= [] (secret-leak-paths projected))))))
+
+;; ---------------------------------------------------------------------------
+;; (2) the two-sided controls — the registry proof must not over-redact
+;; ---------------------------------------------------------------------------
+
+(deftest off-box-keeps-plain-owner-non-map-param-plan-membership-verbatim
+  (testing "rf2-wd9im audit #7013 guard — a PLAIN owner's vector-params keys
+            ride VERBATIM. The widened recognition routes through the OWNER
+            classification exactly as the map-params keys do, so recognising
+            more keys buys no extra redaction."
+    (let [k1        (sk :rf.scope/global :plain/vector-params ["welcome"])
+          record    (record-with
+                      [(event :rf.resource/route-plan (route-plan-tags [k1] [k1]))])
+          projected (epoch/projected-record record)
+          tags      (:tags (first (:trace-events projected)))]
+      (is (= [k1] (:blocking tags)) "a plain owner's :blocking rides verbatim")
+      (is (= [k1] (:identities tags)) "a plain owner's :identities rides verbatim")
+      (is (not (:sensitive? tags)) "a plain row is NOT stamped sensitive"))))
+
+(deftest off-box-keeps-structural-three-vectors-verbatim-under-unnamed-slots
+  (testing "rf2-wd9im audit #7013 guard — the NEGATIVE control the audit names.
+            The family's other 3-element vectors wear the same positional
+            skeleton as a scoped key and MUST ride verbatim: `:owner` (a view
+            path), `:cause` (a mutation attribution triple), and a `:branch` of
+            THREE route ids — the case a bare 'redact any 3-vector' or
+            'redact any vector-of-vectors' guard could not have kept. None of
+            their position-1 keywords is in the RESOURCE registrar (a MUTATION
+            id is registered in a different registrar), which is precisely why
+            the registry is a safe second proof."
+    (let [record    (record-with
+                      [(event :rf.resource/route-plan
+                              {:rf.frame/id :test/rt
+                               :owner       [:app :l 1]
+                               :cause       [:mutation :m/save 7]
+                               :branch      [:r/root :r/article :r/comments]
+                               :nav-token   7})])
+          projected (epoch/projected-record record)
+          tags      (:tags (first (:trace-events projected)))]
+      (is (= [:app :l 1] (:owner tags)) "a view path rides verbatim")
+      (is (= [:mutation :m/save 7] (:cause tags))
+          "a mutation attribution triple rides verbatim")
+      (is (= [:r/root :r/article :r/comments] (:branch tags))
+          "a THREE-id route branch rides verbatim")
+      (is (= 7 (:nav-token tags)))
+      (is (not (:sensitive? tags))
+          "a row of purely structural vectors is NOT stamped sensitive"))))
+
+(deftest trusted-local-include-sensitive-keeps-raw-non-map-param-keys
+  (testing "rf2-wd9im audit #7013 — the redaction is the off-box DEFAULT, not an
+            unconditional strip: the trusted-local :include-sensitive? opt-in
+            keeps the raw vector-params plan membership and the raw embedded
+            work-id key."
+    (let [k1        (sk :rf.scope/global :secret/vector-params vector-params)
+          work-id   (work-ledger/resource-work-id k1 3)
+          record    (record-with
+                      [(event :rf.resource/route-plan (route-plan-tags [k1] [k1]))
+                       (event :rf.resource/work-started
+                              {:rf.frame/id :test/rt :work/id work-id})])
+          projected (epoch/projected-record record {:include-sensitive? true})
+          [plan work] (:trace-events projected)]
+      (is (= [k1] (:blocking (:tags plan))) "raw :blocking rides")
+      (is (= [k1] (:identities (:tags plan))) "raw :identities rides")
+      (is (= work-id (:work/id (:tags work))) "raw embedded work-id key rides"))))
+

--- a/implementation/resources/src/re_frame/resources/trace_egress.cljc
+++ b/implementation/resources/src/re_frame/resources/trace_egress.cljc
@@ -316,25 +316,65 @@
   vocabulary so a row's nested scoped keys never leak."
   #{:patch-summary :invalidation})
 
-(defn- scoped-key-shape?
-  "Whether `v` has the SHAPE of a scoped resource key
-  `[scope resource-id canonical-params]`: a 3-vector whose position 1 is the
-  resource-id KEYWORD and whose position 2 is the canonical params MAP. Read
-  ONLY by the shape-driven fail-closed default below, to recognise a scoped key
-  sitting in a slot the vocabulary does not name (rf2-wd9im).
-
-  The params `map?` test is what discriminates a real key from the family's
-  OTHER 3-element vectors, and it is the whole reason a shape read is safe here:
-  `:owner [:app :l 1]` (a view path) and `:cause [:mutation :m/save 7]` both
-  have a keyword at position 1 and a SCALAR at position 2, and both MUST ride
-  verbatim — tokenizing them would destroy attribution for no security gain.
-  A `:params-schema` may admit non-map params (a vector / an explicit nil), and
-  such a key is deliberately NOT recognised here; it falls to the recursive walk
-  instead, which still tokenizes every map the key contains (a `{:from-db …}`
-  resolved scope's value map included). The walk is the guarantee, this
-  predicate is the fidelity arm."
+(defn- scoped-key-frame?
+  "The positional SKELETON of a scoped resource key
+  `[scope resource-id canonical-params]`: a 3-vector with the resource-id
+  KEYWORD at position 1. Necessary for both readers below, sufficient for
+  neither — each adds its own proof that the 3-vector is the resource family's
+  (`scoped-key-shape?` on a family ROW, `carrier-family-value?` inside a
+  FOREIGN carrier)."
   [v]
-  (and (vector? v) (= 3 (count v)) (keyword? (nth v 1)) (map? (nth v 2))))
+  (and (vector? v) (= 3 (count v)) (keyword? (nth v 1))))
+
+(defn- scoped-key-shape?
+  "Whether `v` is recognisably a scoped resource key
+  `[scope resource-id canonical-params]` — the `scoped-key-frame?` skeleton
+  PLUS a proof that the 3-vector is a key rather than one of the family's other
+  3-element vectors. Read by the shape-driven fail-closed default below, to
+  recognise a scoped key sitting in a slot the vocabulary does not name
+  (rf2-wd9im).
+
+  ## What has to be discriminated, and the two proofs that do it
+
+  `:owner [:app :l 1]` (a view path) and `:cause [:mutation :m/save 7]` both
+  wear the skeleton — keyword at position 1 — and both MUST ride verbatim, since
+  tokenizing them destroys attribution for no security gain. So the skeleton
+  alone is never enough. Either proof suffices:
+
+    - a MAP at position 2. The canonical params of the overwhelming majority of
+      resources, and nothing structural in the family puts a map there;
+    - the resource REGISTRY knows position 1. The family's own authority
+      answering \"is this one of mine?\" — the same proof `carrier-family-value?`
+      reads one carrier out, for the same question.
+
+  ## Why the registry proof had to be added (merged-PR audit #7013)
+
+  `map?` at position 2 was the ONLY test, and `:params-schema` is REQUIRED but
+  free: `[:vector :string]`, `:string`, `[:maybe [:map …]]` are all legal, so a
+  REGISTERED owner's canonical params are legally a vector, a scalar, or nil.
+  Such a key wore the skeleton and failed the only proof, so on a family row it
+  fell through the recursive walk as a bag of structural scalars — owner-aware
+  projection never ran, the row was not stamped `:sensitive?`, and a
+  `:sensitive?` owner's resolved scope + canonical params egressed RAW under
+  `:blocking` / `:identities` and inside every `:work/id`. The identical leak
+  rf2-wd9im closed for map params, one params shape over. The registry is not a
+  roster and cannot rot: it costs one lookup and it says nothing about `:owner`'s
+  `:l` or `:cause`'s `:m/save` (a MUTATION id is not in the RESOURCE registrar).
+
+  ## The one case deliberately left to the walk
+
+  A non-map-params key naming an UNREGISTERED owner. Both proofs are gone — no
+  map at position 2, no registry entry — and nothing distinguishes it from
+  `[:app :l 1]`, so redacting it would mean redacting every structural 3-vector
+  in the family. It stays with the walk, which still tokenizes every MAP inside
+  it. The fail-closed arm is unreachable only for an unnamed slot on a family
+  row: a NAMED slot projects by position rather than by shape
+  (`scoped-key-slot` / `scoped-keys-slot`), and inside a carrier `named?` does
+  the same."
+  [v]
+  (and (scoped-key-frame? v)
+       (or (map? (nth v 2))
+           (some? (registry/resource-meta (nth v 1))))))
 
 (defn- project-unknown-slot-value
   "SHAPE-DRIVEN fail-closed projection of ONE tag value under a slot the
@@ -584,9 +624,18 @@
       registered owner's key still projects from a carrier slot nobody has
       looked at yet.
 
-  A shape match with neither proof is somebody else's data and rides verbatim."
+  A shape match with neither proof is somebody else's data and rides verbatim.
+
+  Note this reads the bare `scoped-key-frame?` SKELETON and not
+  `scoped-key-shape?`: the params `map?` test that predicate uses as ONE of its
+  two proofs would be a THIRD requirement here, and a redundant one — either
+  proof above is already stronger. Requiring it is what made the `named?` arm
+  above contradict its own docstring: a genuine `:resource/key` whose owner was
+  cleared or hot-reloaded away, carrying legal NON-MAP canonical params, failed
+  the map test and rode a carrier verbatim, so the fail-closed arm `named?`
+  exists to keep reachable was not reached (merged-PR audit #7013)."
   [v named?]
-  (and (scoped-key-shape? v)
+  (and (scoped-key-frame? v)
        (or named? (some? (registry/resource-meta (nth v 1))))))
 
 (def ^:private fx-carrier-slot


### PR DESCRIPTION
Two coupled P1s on one file — `implementation/resources/src/re_frame/resources/trace_egress.cljc` — because one under-recognition closes both.

## What was actually left

Both beads' headline repairs are already on `main` (`e478b9c2de` for rf2-wd9im, `96c2867a55` for rf2-xx4ty, plus the `rf2-1kiuj` audit #7059 narrowing and `rf2-ko5lm`'s declaration arm). What remained is the **merged-PR audit #7013** finding recorded on rf2-wd9im, and it reaches rf2-xx4ty's own carrier as well.

`scoped-key-shape?` recognised a scoped key as `[<scope> <resource-id keyword> <params MAP>]`. The `map?` at position 2 was the entire discrimination against the family's other 3-element vectors — `:owner [:app :l 1]` (a view path), `:cause [:mutation :m/save 7]` — which must ride verbatim or attribution dies for no security gain.

But `:params-schema` is REQUIRED and free. `[:vector :string]` is an ordinary schema, and the registrar validates + canonicalizes params against whatever the owner declared, so a **registered** owner's canonical params are legally a vector, a scalar, or nil. Such a key wears the skeleton and fails the only proof, so it fell through the recursive walk as a bag of structural scalars: owner-aware projection never ran, the row was not stamped `:sensitive?`, and a `:sensitive?` owner's resolved scope + canonical params egressed **raw**.

Measured on the parent commit, through the public `epoch/projected-record`, driving a real `[:rf.resource/ensure … :reply-to …]`:

```
async settle (11 paths)
  [2 :work/id 1 2 0]                                       "topsecret-PII-vector"
  [3 :work/id 1 2 0]                                       …
  [4 :work/id 1 2 0]                                       …
  [7 :rf.fx/args :resource/key 2 0]                        …
  [8 :rf.fx/args 1 :correlation :rf.reply/resource-key 2 0] …
  [8 :rf.fx/args 1 :rf.reply/work-id 1 2 0]                …
  [8 :rf.fx/args 1 :resource/key 2 0]                      …
  [9 :rf.event/fx 0 1 :resource/key 2 0]                   …
  [9 :rf.event/fx 1 1 1 :correlation :rf.reply/resource-key 2 0] …
  [9 :rf.event/fx 1 1 1 :rf.reply/work-id 1 2 0]           …
  [9 :rf.event/fx 1 1 1 :resource/key 2 0]                 …

fresh-skip cache hit (7 paths — same shape, one fewer work row)
```

That is the rf2-xx4ty surface in its sharpest form yet: on **one reply map** the `:value` and `:params` slots tokenized correctly (the owner read never needed the params shape) while three copies of the same canonical params — `:resource/key`, `:rf.reply/work-id`'s embedded key, and `:correlation`'s `:rf.reply/resource-key` — rode out in the clear. Redact-and-leak-the-same-bytes, inside a single map.

## The design decision

**The second proof is the resource REGISTRY, not another slot name and not a shape heuristic.**

`carrier-family-value?` already reads the registry one carrier out, for exactly this question — "is this one of mine?". It is the family's own authority, it is not a roster, it cannot rot, and it costs one lookup. Crucially it says nothing about `:owner`'s `:l` or `:cause`'s `:m/save`: a **mutation** id lives in a different registrar, so the negative controls the audit named hold by construction.

- `scoped-key-frame?` (new, private) — the shared positional skeleton: 3-vector, keyword at position 1. Necessary for both readers, sufficient for neither.
- `scoped-key-shape?` — skeleton **plus** "map at position 2 **OR** the registry knows position 1".
- `carrier-family-value?` — now reads the bare skeleton plus its own two proofs (`named?` / registry), instead of stacking `scoped-key-shape?`'s redundant map test on top of them. That stacking is what made its `named?` arm contradict its own docstring: `named?` exists so the fail-closed arm stays reachable for a genuine key whose owner was cleared or hot-reloaded away, and the map test took that away.

**Rejected: a vector-of-vectors shape guard.** The bead itself weighed it. `:branch` is a vector of route ids on the very row this started from and MUST ride verbatim; the new negative control asserts a `:branch` of **three** route ids rides untouched, which is precisely the case a shape guard cannot make.

**Deliberately NOT closed:** a non-map-params key naming an **unregistered** owner, under an **unnamed** slot on a family row. Both proofs are gone and nothing tells it from `[:app :l 1]`, so redacting it would mean redacting every structural 3-vector in the family. It stays with the walk (which still tokenizes every map inside it); a NAMED slot projects by position and a carrier's `named?` does the same, so the uncovered case is exactly that one. Documented in the docstring and filed as **rf2-pwxsk** (P3) for triage, with "close as accepted boundary" as the recommendation.

**Out of scope, deliberately:** the read-FAILURE continuation's `:error` envelope. rf2-rnsv2 owns it under a pre-committed operator ruling, and this diff stays on the success-reply path plus the plan/work-id keys so that fix rebases cleanly.

## Two-sided controls

Green in **both** directions (they do not appear in the red control's failure list):

- a PLAIN `[:vector :string]` owner's `:blocking` / `:identities` ride byte-verbatim and the row is not stamped;
- `:owner [:app :l 1]`, `:cause [:mutation :m/save 7]`, and `:branch [:r/root :r/article :r/comments]` all ride verbatim under unnamed slots;
- `:include-sensitive?` still returns the raw plan membership and the raw embedded work-id key — the redaction is the off-box default, not a strip.

## Negative control (structural)

Reverting only `scoped-key-shape?` / `carrier-family-value?` on the final tree reds the epoch suite at **523 tests / 6931 assertions, 24 failures, 0 errors, rc=1** — identical test and assertion counts to green, differing only in failures. All 24 land in the 9 new deftests; nothing pre-existing moves.

## Quality gates

| Gate | Result | Exit |
| --- | --- | --- |
| `implementation/epoch` — `clojure -M:test` | 523 tests / 6931 assertions, 0 failures, 0 errors | 0 |
| `implementation/resources` — `clojure -M:test` | 734 tests / 6820 assertions, 0 failures, 0 errors | 0 |
| `implementation/core` — `clojure -M:test` (transitive: `late_bind/directory.cljc` publishes both hooks; `fx_args_trace_egress_cljs_test`) | 2126 tests / 10492 assertions, 0 failures, 0 errors | 0 |
| `scripts/test-fast-pr.sh` (repo root) | `PASS fast PR spine` — static/drift tier, JVM tier (core + epoch + resources, selected by changed surface), node tier: CLJS node integration **11583 tests / 58140 assertions, 0 failures, 0 errors**, per-ns isolation 17/17 | 0 |
| NEGATIVE CONTROL — epoch with the projector reverted | 523 tests / 6931 assertions, **24 failures**, 0 errors | 1 |

Transitive surface: `grep` over `implementation/` + `tools/` for `:require`rs of `re-frame.resources.trace-egress` returns the resources facade, the epoch tool-pair (via the late-bind hook), and nothing under `tools/` — tools consume the projector's *output* through the epoch tool-pair, which the epoch suite (including `epoch_mcp_egress_conformance_test`) gates. No tool JVM lane reaches this diff through a require edge.

The spine's first invocation failed at `CLJS node integration` with `'shadow-cljs' is not recognized` — a fresh worktree with no `implementation/node_modules`. `npm ci` (exit 0), then the spine re-run above; both logs kept worktree-local.

Not run locally: the browser lanes, bundle-isolation, perf-bundle, Xray feature matrix, adapter smokes, mcp-conformance, and the JVM artefact suites the diff does not touch — no tier of `test-fast-pr.sh` (it names all three groups on its own PASS line), and none of them reaches a CLJC projector change through a require edge. CI owns them.

Closes rf2-wd9im, rf2-xx4ty.
