### PR TITLE
fix(freehand): activate a ratom-family derived value so a ViewCell repaints under Reagent (rf2-8cnxg, rf2-jt8vz)

### DIFF
--- a/implementation/adapters/reagent-slim/IMPL-SPEC.md
+++ b/implementation/adapters/reagent-slim/IMPL-SPEC.md
@@ -257,6 +257,8 @@ Public macros (`reagent2.ratom.clj`):
 
 Symbols **not shipped**: `track`, `track!`, `cursor`, `wrap`, `make-wrapper`, `Track`, `RCursor`, `Wrapper` types, `IRunnable` protocol, `run!` macro. Audit-confirmed zero usage across re-com / 10x / Dash8 / rf8.
 
+Added beyond stock: `activate!` — see §3.2. Stock reaches the same operation through `IRunnable`'s `run`, which this rewrite does not ship.
+
 ### §2.3a Note on dropped types and cross-substrate `ratom?`
 
 Stage 1 §1.6 marked `RAtom`, `Reaction`, `Track`, `RCursor`, `Wrapper` as SHOULD because re-com type-checks against them (`re-com/util.cljs :refer [RAtom Reaction RCursor Track Wrapper]`). However the audit (rf2-cgcv) confirmed re-com's references resolve at compile time and re-com only reaches `RAtom` and `Reaction` at runtime (the others are imported but unused in the surface paths re-com exercises). The rewrite ships **`RAtom` and `Reaction` types only**.
@@ -384,7 +386,7 @@ The `notify-watches` implementation walks the `watches` map and fires each `(f k
 `(deftype Reaction [^:mutable f ^:mutable state ^:mutable dirty? ^:mutable active? ^:mutable watching ^:mutable watches ^:mutable auto-run ^:mutable on-set ^:mutable on-dispose])` — same nine-field shape stock Reagent uses. Implements all the protocols of RAtom (so a Reaction looks like an atom to consumers) plus:
 
 - `IDisposable` — `dispose!` + `add-on-dispose!`. **Critical**: this is the protocol UIx and Helix adapters reify (`uix.cljs:120-126`, `helix.cljs:120-127`) for cross-substrate cache wiring. The shape of `dispose!` and `add-on-dispose!` is part of the cross-substrate ABI and **must not change**.
-- `IRunnable` — NOT implemented. Stage 1 §1.6 marks `IRunnable` CAN-DEPRECATE; DECISION-7 Class A says don't ship.
+- `IRunnable` — NOT implemented. Stage 1 §1.6 marks `IRunnable` CAN-DEPRECATE; DECISION-7 Class A says don't ship. The one operation it carried that re-frame genuinely needs — running the body through `deref-capture` so the reaction subscribes to its sources — ships instead as the named fn `reagent2.ratom/activate!` (rf2-8cnxg). Stock spells it `(run rx)`; the rewrite spells it `(activate! rx)`, idempotent and a no-op off a `Reaction`. Its consumer is `re-frame.substrate.observation/build-node-handle!` via the `:adapter/activate-derived-value!` late-bind hook: a ViewCell is not a component and so never supplies the capture context a component render supplies, and without this the port holds a watch that can never fire.
 
 The compute path (`-deref` on a Reaction): if `dirty?`, run `f`, equality-compare against `state`, conditionally `notify-watches`. Stage 2 §3.2 — equality memoisation kept; this is the right shape.
 

--- a/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
+++ b/implementation/adapters/reagent-slim/src/re_frame/adapter/reagent_slim.cljs
@@ -93,6 +93,12 @@
      :atom              r/atom
      :ratom?            (fn [x] (satisfies? ratom/IReactiveAtom x))
      :make-reaction     ratom/make-reaction
+     ;; rf2-8cnxg — the missing `deref-capture`, same defect and same shape
+     ;; as stock Reagent's (the rewrite keeps stock's nine-field Reaction
+     ;; kernel, demand-driven `-deref` included). `ratom/activate!` is the
+     ;; rewrite's name for stock's `IRunnable` `run`; it is idempotent and
+     ;; a no-op on anything that is not one of its Reactions.
+     :activate-reaction! ratom/activate!
      :disposable?       (fn [a] (satisfies? ratom/IDisposable a))
      :add-on-dispose!   ratom/add-on-dispose!
      :dispose!          ratom/dispose!

--- a/implementation/adapters/reagent-slim/src/reagent2/ratom.cljs
+++ b/implementation/adapters/reagent-slim/src/reagent2/ratom.cljs
@@ -480,6 +480,40 @@
             (._queued-run r)))
         (recur)))))
 
+(defn activate!
+  "Put `rx` on the PUSH path by running its body through `deref-capture`,
+  so it subscribes to the sources it reads. Returns `rx`. rf2-8cnxg.
+
+  WHY THIS EXISTS. A Reaction is DEMAND-driven: `-deref` outside
+  `*ratom-context*` with no `auto-run` takes the fast path — run `f` raw,
+  notify explicit watches if the value moved — and deliberately wires no
+  watcher graph, so `watching` stays nil. `_handle-change` is therefore
+  never called, and `_queued-run` requires `(some? watching)`, so `flush!`
+  moves nothing either. A reader that only ever `add-watch`es (never derefs
+  inside a reactive context) consequently holds a watch that CANNOT fire —
+  which is exactly what a compiled ViewCell does through re-frame's
+  observation port. A component render normally supplies the capture; a
+  ViewCell is not a component, so it asks for it here.
+
+  Idempotent: a Reaction whose `watching` is already populated is on the
+  push path and is left alone rather than recomputed. Total: a no-op on
+  anything that is not a Reaction (an `RAtom` is push-based already).
+
+  This is NOT `:auto-run true`. Activation performs ONE capture run, off
+  the writer's stack, and leaves change handling on the ordinary batched
+  `rea-enqueue` → `flush!` path. `:auto-run true` would instead recompute
+  synchronously inside every source `reset!`.
+
+  Stock Reagent spells the same operation `reagent.ratom/run` (its
+  `IRunnable` protocol). The rewrite dropped `IRunnable` — no audited
+  codebase called it — so the one genuinely-needed use rides this named fn
+  instead of resurrecting the protocol."
+  [rx]
+  (when (and (instance? Reaction rx)
+             (nil? (.-watching ^Reaction rx)))
+    (._run ^Reaction rx false))
+  rx)
+
 (defn make-reaction
   "Construct a Reaction wrapping body fn `f`.
 

--- a/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_late_bind_publication_cljs_test.cljs
+++ b/implementation/adapters/reagent-slim/test/re_frame/adapter/reagent_slim_late_bind_publication_cljs_test.cljs
@@ -40,6 +40,9 @@
     :adapter/ratom
     :adapter/ratom?
     :adapter/make-reaction
+    ;; rf2-8cnxg — push-path activation for a `make-derived-value` result,
+    ;; published by the ratom family alone (`reagent2.ratom/activate!`).
+    :adapter/activate-derived-value!
     :adapter/add-on-dispose!
     :adapter/dispose!
     :adapter/reactive?

--- a/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
+++ b/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
@@ -73,6 +73,27 @@
      :atom              r/atom
      :ratom?            (fn [x] (satisfies? ratom/IReactiveAtom x))
      :make-reaction     ratom/make-reaction
+     ;; rf2-8cnxg — the missing `deref-capture`. A stock `Reaction` learns
+     ;; its sources ONLY by being run through `deref-capture`; `ratom/run`
+     ;; (its `IRunnable` op) is exactly that run, and after it the reaction
+     ;; is on Reagent's ordinary batched push path (`_handle-change` →
+     ;; enqueue → `ratom/flush!` → notify). A plain `deref` outside
+     ;; `*ratom-context*` deliberately does NOT do this, which is why an
+     ;; `add-watch`-only observer — the observation port over a compiled
+     ;; ViewCell — never heard from a Reagent-hosted subscription.
+     ;;
+     ;; Guarded twice, and both guards are load-bearing. `IRunnable` skips
+     ;; anything that is not a Reagent `Reaction` (a base `r/atom`, or a
+     ;; spine-produced derived value inherited through a cross-substrate
+     ;; test bundle — rf2-jicu2). A non-nil `watching` means the reaction is
+     ;; ALREADY capturing, so re-running it would recompute a live node for
+     ;; nothing; skipping keeps activation idempotent across the second and
+     ;; subsequent ViewCells that acquire the same cached node.
+     :activate-reaction! (fn [rx]
+                           (when (and (satisfies? ratom/IRunnable rx)
+                                      (nil? (.-watching rx)))
+                             (ratom/run rx))
+                           nil)
      :disposable?       (fn [a] (satisfies? ratom/IDisposable a))
      :add-on-dispose!   ratom/add-on-dispose!
      :dispose!          ratom/dispose!

--- a/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
+++ b/implementation/adapters/reagent/src/re_frame/adapter/reagent.cljs
@@ -89,9 +89,13 @@
      ;; ALREADY capturing, so re-running it would recompute a live node for
      ;; nothing; skipping keeps activation idempotent across the second and
      ;; subsequent ViewCells that acquire the same cached node.
+     ;; `^clj` on the field read: `watching` is a CLJS deftype field, not a
+     ;; JS-object property, so externs inference must not be asked to
+     ;; reason about it (an inferred extern would also defeat the very
+     ;; renaming that keeps the read correct under `:advanced`).
      :activate-reaction! (fn [rx]
                            (when (and (satisfies? ratom/IRunnable rx)
-                                      (nil? (.-watching rx)))
+                                      (nil? (.-watching ^clj rx)))
                              (ratom/run rx))
                            nil)
      :disposable?       (fn [a] (satisfies? ratom/IDisposable a))

--- a/implementation/adapters/reagent/test/re_frame/freehand_cell_under_ratom_adapter_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/freehand_cell_under_ratom_adapter_dom_cljs_test.cljs
@@ -1,0 +1,307 @@
+(ns re-frame.freehand-cell-under-ratom-adapter-dom-cljs-test
+  "rf2-8cnxg / rf2-jt8vz — a Freehand view, mounted with `v/mount` under the
+  stock REAGENT adapter, in a real browser, repaints when its subscription
+  moves.
+
+  THE REPRODUCTION THIS REPLACES. The operator's report was measured on one
+  page and one build with the installed adapter as the only variable: under
+  `re-frame.freehand/adapter` a click moved the readout 0 → 1 → 2; under
+  `re-frame.adapter.reagent/adapter` the dispatch LANDED (app-db moved, the
+  trace showed the event) and the readout never changed. The decisive number
+  was `cell/pending-count` staying 0 — the cell was never MARKED DIRTY, so
+  nothing downstream of `mark-dirty!` could be at fault. No notification was
+  ever raised at all: the observation port's watch sat on a
+  `reagent.ratom/Reaction` that had never captured its sources, because a
+  ViewCell is not a Reagent component and so supplies no capture context.
+  See the port-level unit arms in
+  `re-frame.observation-port-activates-ratom-node-cljs-test`.
+
+  WHY THE TEST LIVES HERE, AND WHY IT MOUNTS. This is the composition
+  nothing else in the tree exercised: `git grep reagent
+  implementation/freehand/test/` returned only prose. It cannot live under
+  `implementation/freehand/`, whose whole claim is that it names no adapter;
+  it belongs beside the sibling cross-adapter port suites in this directory,
+  which is also where the substrate half of the fix is proved. And it MOUNTS
+  rather than driving the cell by hand, because a hand-driven commit reads
+  current values through `read-container` regardless of the notification
+  channel — exactly the reason a mount-verb-driven scenario stayed green all
+  the way through this bug. Only a repaint the DOM shows can tell the two
+  apart.
+
+  The `-dom-cljs-test` suffix enrols the file in the `:browser-test` build;
+  `:node-test`'s broader `cljs-test$` regex matches it too, where each body
+  says so rather than passing quietly."
+  (:require ["react" :as react]
+            [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.cell :as cell]
+            [re-frame.freehand.react :as fr]
+            [re-frame.freehand.root :as root]
+            [re-frame.live-frame :as live-frame]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.test-support :as test-support]))
+
+;; The stock REAGENT adapter is the host under test — the FOREIGN adapter a
+;; mixed application seats while `docs/core/freehand/adoption.md` tells it to
+;; install Freehand next to what it already ships.
+(def ^:private runtime-fixture
+  (test-support/make-reset-runtime-fixture
+    {:adapter       reagent-adapter/adapter
+     :ambient-frame nil
+     :async?        true}))
+
+(use-fixtures :each
+  {:before (fn []
+             (root/reset-registry!)
+             (fr/reset-boundaries!)
+             ((:before runtime-fixture)))
+   :after  (fn []
+             ((:after runtime-fixture))
+             (root/reset-registry!)
+             (fr/reset-boundaries!))})
+
+(defn- browser? []
+  (and (exists? js/document) (some? (.-createElement js/document))))
+
+(defn- skip! [why]
+  (is true (str "a real React mount needs a DOM host — " why)))
+
+(def ^:private fid :freehand-ratom/frame)
+
+;; ---------------------------------------------------------------------------
+;; the views — one compiled reader, its interpreted twin, one event site
+;; ---------------------------------------------------------------------------
+
+(v/defview readout
+  "The COMPILED arm. Its `v/sub` read routes through `cell/observe-site!`,
+  so the mounted occurrence repaints only if the committed observation is
+  actually notified."
+  {:compiled true}
+  [_]
+  [:output#compiled (str (v/sub [:fh/count]))])
+
+(v/defview readout-interpreted
+  "The INTERPRETED twin, same body without the marker. It reads through the
+  same port, so it is a control for the LOWERING and not for the bug: under
+  the defect BOTH arms froze."
+  [_]
+  [:output#interpreted (str (v/sub [:fh/count]))])
+
+(v/defview bump-button
+  "A committed `:on-click` site — the operator pressed a real button, and a
+  real press is what this drives too."
+  {:compiled true}
+  [_]
+  [:button#bump {:on-click [:fh/bump]} "+"])
+
+(v/defview page
+  "Both readers and the button under ONE Freehand root, so the repaint claim
+  is made about one commit discipline at one moment."
+  [_]
+  [:div#page [readout {}] [readout-interpreted {}] [bump-button {}]])
+
+;; ---------------------------------------------------------------------------
+;; harness
+;; ---------------------------------------------------------------------------
+
+(defn- register! []
+  (rf/reg-sub :fh/count (fn [db _] (:count db)))
+  (rf/reg-event :fh/bump (fn [{:keys [db]} _] {:db (update db :count inc)})))
+
+(defn- seed! [db]
+  (live-frame/make-frame {:id fid})
+  (frame/replace-app-db! fid db)
+  fid)
+
+(defn- act
+  "A React 19 `act` boundary as a promise, so the mount's commit has landed
+  before anything is read back off `document`."
+  [thunk]
+  (try
+    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+    (js/Promise.resolve (react/act (fn [] (js/Promise.resolve (thunk)))))
+    (catch :default e
+      (js/Promise.reject e))))
+
+(defn- live!
+  "Leave the act environment. The repaint under test is driven by a
+  DEPENDENCY rather than by a re-render call, and inside act React diverts
+  that work to the act queue — which would make the assertion a claim about
+  act's drain order instead of about the substrate."
+  []
+  (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+  nil)
+
+(defn- tick! []
+  (js/Promise. (fn [resolve] (js/setTimeout #(resolve nil) 0))))
+
+(defn- settle!
+  "Close the cells' pending window and let the browser paint what that
+  notification scheduled."
+  []
+  (cell/flush!)
+  (tick!))
+
+(defn- host-node! []
+  (let [container (js/document.createElement "div")]
+    (.appendChild js/document.body container)
+    container))
+
+(defn- unmount! [container mounted]
+  (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+  (when (some? mounted)
+    (.unmount (.-react-root ^root/Root mounted)))
+  (.remove container)
+  nil)
+
+(defn- text [container selector]
+  (some-> (.querySelector container selector) .-textContent))
+
+(defn- click! [container selector]
+  (.click (.querySelector container selector)))
+
+;; ===========================================================================
+;; the bead's reproduction, as a gate
+;; ===========================================================================
+
+(deftest a-freehand-cell-repaints-under-the-reagent-adapter
+  (testing "rf2-jt8vz's exact arm (a): one page, one build, the REAGENT
+            adapter installed. A dispatch that moves the subscription must
+            repaint the mounted occurrence — the outcome that did not survive
+            before, when the readout stayed at its first render forever"
+    (if-not (browser?)
+      (skip! "the browser job runs the repaint assertions")
+      (async done
+        (register!)
+        (seed! {:count 0})
+        (let [container (host-node!)
+              mounted   (atom nil)]
+          (->
+           (act #(v/mount [page {}] container {:frame fid}))
+           (.then
+            (fn [m]
+              (reset! mounted m)
+              (is (= "0" (text container "#compiled"))
+                  "the first render observed the seeded value")
+              (is (= "0" (text container "#interpreted")))
+              (live!)
+              (rf/dispatch-sync [:fh/bump] {:frame fid})
+              (is (= 1 (:count (frame/frame-app-db-value fid)))
+                  "precondition — the dispatch LANDS. It always did; the bug
+                   was never that app-db failed to move")
+              (is (pos? (cell/pending-count))
+                  "THE MEASUREMENT THAT WAS ZERO: the observation reached the
+                   cell and marked it dirty. A zero here is the bug itself —
+                   no notification raised, nothing for any flush to drain")
+              (settle!)))
+           (.then
+            (fn [_]
+              (is (= "1" (text container "#compiled"))
+                  "the COMPILED Freehand arm repainted the mounted occurrence
+                   under a foreign ratom adapter")
+              (is (= "1" (text container "#interpreted"))
+                  "and so did its interpreted twin — both ride the same port")
+              ;; A second movement: the channel must stay armed rather than
+              ;; fire once and lapse.
+              (rf/dispatch-sync [:fh/bump] {:frame fid})
+              (settle!)))
+           (.then
+            (fn [_]
+              (is (= "2" (text container "#compiled"))
+                  "0 → 1 → 2, the sequence the Freehand-hosted arm produced
+                   and the Reagent-hosted one could not")
+              (unmount! container @mounted)
+              (done)))
+           (.catch
+            (fn [e]
+              (is false (str "freehand-under-reagent repaint rejected: " e))
+              (unmount! container @mounted)
+              (done)))))))))
+
+(deftest a-real-press-repaints-a-freehand-cell-under-the-reagent-adapter
+  (testing "the operator pressed a button, so drive a real DOM press: the
+            committed `:on-click` dispatches into the frame the commit bound,
+            and the sibling reader repaints off the same movement"
+    (if-not (browser?)
+      (skip! "the browser job runs the press assertions")
+      (async done
+        (register!)
+        (seed! {:count 41})
+        (let [container (host-node!)
+              mounted   (atom nil)]
+          (->
+           (act #(v/mount [page {}] container {:frame fid}))
+           (.then
+            (fn [m]
+              (reset! mounted m)
+              (is (= "41" (text container "#compiled")))
+              (live!)
+              (click! container "#bump")
+              (settle!)))
+           (.then
+            (fn [_]
+              (is (= 42 (:count (frame/frame-app-db-value fid)))
+                  "the press dispatched into the committed frame")
+              (is (= "42" (text container "#compiled"))
+                  "and the mounted Freehand occurrence repainted from it")
+              (unmount! container @mounted)
+              (done)))
+           (.catch
+            (fn [e]
+              (is false (str "freehand-under-reagent press rejected: " e))
+              (unmount! container @mounted)
+              (done)))))))))
+
+(deftest an-unmoved-write-repaints-no-freehand-cell-under-the-reagent-adapter
+  (testing "the adversarial companion. Activating the node must not make the
+            channel chatty: a write that leaves the subscribed value where it
+            was must mark NO cell dirty and repaint nothing. Without this arm
+            a repaint-on-everything regression would read as a pass above"
+    (if-not (browser?)
+      (skip! "the browser job runs the no-movement assertions")
+      (async done
+        (register!)
+        (rf/reg-event :fh/set-unrelated
+                      (fn [{:keys [db]} [_ v]] {:db (assoc db :unrelated v)}))
+        (rf/reg-event :fh/set-count
+                      (fn [{:keys [db]} [_ v]] {:db (assoc db :count v)}))
+        (seed! {:count 5})
+        (let [container (host-node!)
+              mounted   (atom nil)]
+          (->
+           (act #(v/mount [page {}] container {:frame fid}))
+           (.then
+            (fn [m]
+              (reset! mounted m)
+              (is (= "5" (text container "#compiled")))
+              (live!)
+              (rf/dispatch-sync [:fh/set-count 5] {:frame fid})
+              (is (zero? (cell/pending-count))
+                  "an equal re-write moved nothing, so no cell was dirtied")
+              (rf/dispatch-sync [:fh/set-unrelated :noise] {:frame fid})
+              (is (zero? (cell/pending-count))
+                  "…and neither did a write to a key this sub never reads")
+              (settle!)))
+           (.then
+            (fn [_]
+              (is (= "5" (text container "#compiled"))
+                  "the DOM is untouched by either write")
+              ;; Positive control — the silences above are silences, not a
+              ;; dead channel that would make this whole test vacuous.
+              (rf/dispatch-sync [:fh/set-count 6] {:frame fid})
+              (is (pos? (cell/pending-count))
+                  "a REAL movement still dirties the cell")
+              (settle!)))
+           (.then
+            (fn [_]
+              (is (= "6" (text container "#compiled"))
+                  "…and still repaints")
+              (unmount! container @mounted)
+              (done)))
+           (.catch
+            (fn [e]
+              (is false (str "freehand-under-reagent no-movement arm rejected: " e))
+              (unmount! container @mounted)
+              (done)))))))))

--- a/implementation/adapters/reagent/test/re_frame/late_bind_hooks_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/late_bind_hooks_cljs_test.cljs
@@ -49,6 +49,11 @@
     :adapter/ratom
     :adapter/ratom?
     :adapter/make-reaction
+    ;; rf2-8cnxg — the ratom family's push-path activation for a
+    ;; `make-derived-value` result. Published ONLY here and by
+    ;; reagent-slim; the React-hook spine's derived values are push-based
+    ;; from birth and publish nothing.
+    :adapter/activate-derived-value!
     :adapter/add-on-dispose!
     :adapter/dispose!
     :adapter/reactive?

--- a/implementation/adapters/reagent/test/re_frame/observation_port_activates_ratom_node_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/observation_port_activates_ratom_node_cljs_test.cljs
@@ -1,0 +1,284 @@
+(ns re-frame.observation-port-activates-ratom-node-cljs-test
+  "rf2-8cnxg — the observation port puts a ratom-family subscription node on
+  the substrate's PUSH path itself, with NO eager consumer standing behind it.
+
+  THE DEFECT THIS PINS. `build-node-handle!` used to install its per-handle
+  `add-watch` on the stated assumption that \"a watched reaction is live on
+  the reactive hosts\". On the ratom family that is false, and silently so: a
+  `reagent.ratom/Reaction` learns its sources ONLY through `deref-capture`,
+  and a plain `deref` taken outside `*ratom-context*` with no `auto-run`
+  takes the non-reactive branch — it runs the body raw and leaves `watching`
+  nil. `_handle-change` is then never called, `_queued-run` short-circuits on
+  `(some? watching)`, and even `reagent.core/flush` moves nothing. The port
+  held a watch on a node that COULD NOT FIRE, so every ViewCell over a
+  Reagent-hosted subscription rendered once and never again.
+
+  It went undetected because a Reagent COMPONENT supplies the capture as a
+  side effect of rendering, and because the two suites that exercise this
+  channel — `re-frame.observation-port-watchable-host-cljs-test` and its
+  mounted `-dom-` sibling — each stood a `ratom/run!` DRIVER, an auto-running
+  reaction that derefs the sub, to \"keep the lazy reaction on the push
+  path\". That driver was not a test convenience: it was the missing runtime
+  step, hand-supplied. Those files no longer stand one, and this file exists
+  so the fact has a home of its own where the driver was never present to
+  begin with.
+
+  WHAT EACH ARM IS FOR. The first proves the port alone drives the channel.
+  The rest are the adversarial half, because \"make it notify\" has two cheap
+  wrong answers that a movement-only test would rate green:
+
+    - `:auto-run true` on `make-derived-value`, which fixes notification by
+      recomputing EVERY subscription under this substrate synchronously
+      inside the app-db `reset!`. `an-unobserved-subscription-is-never-…`
+      counts compute-fn invocations to reject it: a node no handle observes
+      must not recompute at all.
+    - Activating on every acquire regardless of state, which re-runs a live
+      node for nothing and can fan a phantom note at its existing owners.
+      `activation-is-idempotent-…` pins one note per handle per movement
+      across two owners of one node.
+
+  Plus the totality arms: the op must be silent on a BASE container and on
+  objects that are not this substrate's at all, since a ratom-installed app
+  can hold a spine-produced derived value inherited through a cross-substrate
+  test bundle (rf2-jicu2).
+
+  CLJS-only (Reagent is CLJS); the `-cljs-test` suffix enrols it in the
+  consolidated `:node-test` build — no DOM and no React needed, because the
+  claim is about the notification channel, not about a render. The mounted
+  counterpart, where a real Freehand ViewCell repaints under this adapter,
+  is `re-frame.freehand-cell-under-ratom-adapter-dom-cljs-test`."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [reagent.core :as r]
+            [reagent.ratom :as ratom]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
+            [re-frame.adapter.reagent :as reagent-adapter]
+            [re-frame.substrate.observation :as obs]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter reagent-adapter/adapter}))
+
+(def ^:private fid :rf/default)
+
+(defn- node-reaction [query]
+  (:reaction (get @(:sub-cache (frame/frame fid)) query)))
+
+;; White-box, and deliberately only ever a COROBORATING assertion: `watching`
+;; is the Reagent field that says "this reaction is subscribed to its
+;; sources". Read directly it would go vacuously nil against any object that
+;; is not a Reaction, so every arm that consults it also asserts the
+;; behaviour it is supposed to explain.
+(defn- capturing? [rx]
+  (some? (.-watching rx)))
+
+(def ^:private computes (atom 0))
+
+(defn- register! []
+  (reset! computes 0)
+  (rf/reg-sub :obs/n (fn [db _] (:n db)))
+  (rf/reg-sub :obs/counted (fn [db _] (swap! computes inc) (:n db)))
+  (rf/reg-event :obs/set-n (fn [{:keys [db]} [_ v]] {:db (assoc db :n v)}))
+  (rf/reg-event :obs/set-other (fn [{:keys [db]} [_ v]] {:db (assoc db :other v)})))
+
+(defn- target [query]
+  (obs/resolve-target {:frame fid :query-v query}))
+
+(defn- acquire-recording! [query]
+  (let [notes  (atom [])
+        handle (obs/acquire! (target query) (fn [ev] (swap! notes conj ev)))]
+    [handle notes]))
+
+;; ===========================================================================
+;; the port alone drives the channel
+;; ===========================================================================
+
+(deftest acquire-alone-puts-a-ratom-node-on-the-push-path
+  (testing "a bare acquire! — no driver, no component, nothing deref'ing the
+            sub inside a reactive context — leaves the Reagent node CAPTURING
+            its sources, so a later movement reaches the handle's on-change"
+    (register!)
+    (rf/dispatch-sync [:obs/set-n 1])
+    (let [[handle notes] (acquire-recording! [:obs/n])
+          rx             (node-reaction [:obs/n])]
+      (try
+        (is (obs/handle? handle))
+        (is (satisfies? IWatchable rx)
+            "precondition — the node IS watchable, so a silent channel here
+             would be the port's fault and not the host's")
+        (is (capturing? rx)
+            "acquire! ACTIVATED the node: it is subscribed to its sources.
+             Before rf2-8cnxg this was nil — watchable, watched, and unable
+             to notify")
+        (is (empty? @notes)
+            "activation itself fans nothing at the acquiring handle — it runs
+             BEFORE the watch is installed, so there is no priming note")
+
+        (rf/dispatch-sync [:obs/set-n 2])
+        (ratom/flush!)
+
+        (is (= 1 (count @notes))
+            "the movement reached the handle EXACTLY once — the repaint
+             channel a ViewCell rides")
+        (let [ev (first @notes)]
+          (is (= :subscription (:cause ev)))
+          (is (= (target [:obs/n]) (:target ev))))
+        (is (= 2 (:value (obs/read handle)))
+            "and the port reads the moved value back off the node")
+        (finally
+          (obs/release! handle))))))
+
+;; ===========================================================================
+;; the adversarial half — the cheap wrong answers
+;; ===========================================================================
+
+(deftest an-unobserved-subscription-is-never-made-eager
+  (testing "activation is per-ACQUIRE, not global. A subscription no handle
+            observes must not recompute when app-db moves — which is what
+            `:auto-run true` on make-derived-value (the one-line 'fix') would
+            do to every subscription in the process, synchronously inside the
+            app-db reset!"
+    (register!)
+    (rf/dispatch-sync [:obs/set-n 1])
+    (let [sub (rf/subscribe [:obs/counted])
+          rx  (node-reaction [:obs/counted])]
+      (is (some? sub) "the sub-cache node exists — the arm is not vacuous")
+      (is (not (capturing? rx))
+          "subscribe alone did NOT put it on the push path")
+      (let [before @computes]
+        (rf/dispatch-sync [:obs/set-n 2])
+        (ratom/flush!)
+        (is (= before @computes)
+            "an UNOBSERVED subscription did not recompute on an app-db write"))
+
+      (testing "…and the same node, once acquired, does recompute — proving
+                the counter is a live instrument and not a stuck zero"
+        (let [[handle _] (acquire-recording! [:obs/counted])
+              after-acq  @computes]
+          (try
+            (is (capturing? rx) "the acquire activated THIS node")
+            (is (pos? after-acq) "activation ran the body once, to capture")
+            (rf/dispatch-sync [:obs/set-n 3])
+            (ratom/flush!)
+            (is (> @computes after-acq)
+                "and now a movement DOES recompute it")
+            (finally
+              (obs/release! handle))))))))
+
+(deftest activation-is-idempotent-across-two-owners-of-one-node
+  (testing "the second ViewCell to acquire the same cached node must not
+            re-run a node that is already capturing: no phantom note at the
+            first owner, and one note per handle per movement"
+    (register!)
+    (rf/dispatch-sync [:obs/set-n 1])
+    (let [[h1 notes1] (acquire-recording! [:obs/n])]
+      (try
+        (is (capturing? (node-reaction [:obs/n])))
+        (let [[h2 notes2] (acquire-recording! [:obs/n])]
+          (try
+            (is (empty? @notes1)
+                "the SECOND acquire fanned nothing at the first owner —
+                 re-running a live node would have")
+            (is (empty? @notes2))
+            (rf/dispatch-sync [:obs/set-n 2])
+            (ratom/flush!)
+            (is (= 1 (count @notes1)) "one note for owner 1")
+            (is (= 1 (count @notes2)) "one note for owner 2 — not two, not none")
+            (finally
+              (obs/release! h2))))
+        (finally
+          (obs/release! h1))))))
+
+(deftest a-no-movement-write-stays-silent-on-an-activated-node
+  (testing "activation must not make the channel chatty: a write that leaves
+            the observed value where it was fans nothing, and a write to a key
+            the sub does not read fans nothing either"
+    (register!)
+    (rf/dispatch-sync [:obs/set-n 7])
+    (let [[handle notes] (acquire-recording! [:obs/n])]
+      (try
+        (rf/dispatch-sync [:obs/set-n 7])
+        (ratom/flush!)
+        (is (empty? @notes)
+            "an equal re-write moved nothing, so nothing was fanned")
+
+        (rf/dispatch-sync [:obs/set-other :anything])
+        (ratom/flush!)
+        (is (empty? @notes)
+            "a write to an unrelated app-db key moved nothing this sub reads")
+
+        (testing "positive control — the channel really is armed"
+          (rf/dispatch-sync [:obs/set-n 8])
+          (ratom/flush!)
+          (is (= 1 (count @notes))
+              "so the two silences above are silences, not a dead channel"))
+        (finally
+          (obs/release! handle))))))
+
+(deftest a-released-handle-hears-nothing-while-the-node-stays-live
+  (testing "releasing one owner removes ITS watch without taking the node off
+            the push path for the owner that remains"
+    (register!)
+    (rf/dispatch-sync [:obs/set-n 1])
+    (let [[h1 notes1] (acquire-recording! [:obs/n])
+          [h2 notes2] (acquire-recording! [:obs/n])]
+      (try
+        (obs/release! h1)
+        (rf/dispatch-sync [:obs/set-n 2])
+        (ratom/flush!)
+        (is (empty? @notes1) "the released handle heard nothing")
+        (is (= 1 (count @notes2))
+            "the surviving owner still hears the movement — release did not
+             disarm the node")
+        (finally
+          (obs/release! h2))))))
+
+;; ===========================================================================
+;; totality — the op is silent on everything that is not one of ITS reactions
+;; ===========================================================================
+
+(deftest activate-derived-value-is-a-total-no-op-off-its-own-derived-values
+  (testing "a ratom-installed app can be handed a BASE container, a
+            spine-produced derived value from a cross-substrate bundle
+            (rf2-jicu2), or plain junk. None of those is this substrate's
+            reaction, and the op must return quietly rather than throw or
+            mutate"
+    (let [base (r/atom {:untouched true})]
+      (is (nil? (interop/activate-derived-value! base))
+          "a base r/atom is push-based already — nothing to do")
+      (is (= {:untouched true} @base)
+          "…and it was not disposed, reset, or otherwise disturbed")
+      (is (nil? (interop/activate-derived-value! nil)))
+      (is (nil? (interop/activate-derived-value! #js {:not "a reaction"})))
+      (is (nil? (interop/activate-derived-value! (reify IDeref (-deref [_] 1))))
+          "a bare IDeref test double — the shape the plain-atom port suites
+           use — is left alone"))))
+
+(deftest activate-derived-value-runs-a-reagent-reaction-exactly-once
+  (testing "the op's own contract, read off a raw Reagent reaction with no
+            re-frame around it: one capture run, and the second call is a
+            no-op because the reaction is already capturing"
+    (let [source (r/atom 1)
+          runs   (atom 0)
+          rx     (ratom/make-reaction (fn [] (swap! runs inc) @source))]
+      (try
+        (is (not (capturing? rx)) "a fresh reaction captures nothing")
+        (is (zero? @runs) "…and has not run")
+        (interop/activate-derived-value! rx)
+        (is (capturing? rx) "activation captured the source")
+        (is (= 1 @runs) "exactly one run")
+        (interop/activate-derived-value! rx)
+        (is (= 1 @runs) "the second activation ran nothing — idempotent")
+
+        (let [heard (atom [])]
+          (add-watch rx ::probe (fn [_ _ old nu] (swap! heard conj [old nu])))
+          (reset! source 2)
+          (ratom/flush!)
+          (is (= [[1 2]] @heard)
+              "and the activated reaction NOTIFIES on a source move — the whole
+               point, and the thing a plain deref could never buy"))
+        (finally
+          (remove-watch rx ::probe)
+          (ratom/dispose! rx))))))

--- a/implementation/adapters/reagent/test/re_frame/observation_port_watchable_host_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/observation_port_watchable_host_cljs_test.cljs
@@ -13,24 +13,31 @@
   (`reagent.ratom/Reaction`), so an observed value MOVEMENT actually fires the
   port's watch — the real trigger the reactive-tear gates (.40 / .65) depend on.
 
-  THE EAGER-CONSUMER REQUIREMENT (why we stand a `ratom/run!` driver). The port
-  watch is a PASSIVE observer: it `add-watch`es the node but does not itself
-  keep the (lazy) Reagent reaction on the push path. In production the ViewCell
-  render is the ACTIVE consumer that re-derefs the node every flush, so a value
-  movement re-runs the node and fires the port's watch. A test with only a
-  passive port watch never re-runs the node (a lazy deref pulls once — the same
-  methodological point the standard-epochs diamond fixture makes), so each
-  fixture stands a `reagent.ratom/run!` driver — an auto-running reaction that
-  eagerly derefs the sub, standing in for the mounted ViewCell render. It
-  warms + activates the node BEFORE the handle's baseline observe (mirroring
-  render-then-commit: no first-run priming notification on the measured handle),
-  and keeps it on the push path so the genuine value MOVEMENT fires the watch.
+  THE DRIVER THAT USED TO STAND HERE, AND WHY IT IS GONE (rf2-8cnxg). Every
+  fixture below used to stand a `reagent.ratom/run!` DRIVER — an auto-running
+  reaction that eagerly derefs the sub — explained as \"the port watch is a
+  passive observer; in production the ViewCell render is the active consumer
+  that keeps the lazy reaction on the push path\". BOTH HALVES OF THAT WERE
+  WRONG, and the second one was a live P1 bug wearing a test convenience as a
+  disguise. A ViewCell is not a Reagent component: it never derefs the node
+  inside `*ratom-context*`, so it never supplied the capture the sentence
+  credited it with. The reaction stayed uncaptured, `_handle-change` was never
+  called, and every Freehand / re-frame.ui cell over a Reagent-hosted
+  subscription rendered ONCE and never again. The driver was not standing in
+  for a render — it was hand-supplying a runtime step that did not exist.
 
-  The push path: a `dispatch-sync` MOVES the sub's value; `reagent.ratom/flush!`
-  re-runs the driver (and through it the node), and — the value changed — the
-  node notifies the port watch, which advances the node record with the
-  DELIVERED value (no recompute, I-5) and fans `{:cause :subscription …}` to the
-  handle's own `on-change`.
+  It exists now: `build-node-handle!` calls
+  `re-frame.interop/activate-derived-value!` before installing its watch, so
+  ACQUIRE ALONE puts the node on the push path. The drivers are therefore
+  deleted rather than kept: with one in place these fixtures would stay green
+  against a regression of that fix. `re-frame.observation-port-activates-
+  ratom-node-cljs-test` pins the activation itself.
+
+  The push path: a `dispatch-sync` MOVES the sub's value; the source
+  notification reaches the (now capturing) node, `reagent.ratom/flush!` drains
+  the recompute, and — the value changed — the node notifies the port watch,
+  which advances the node record with the DELIVERED value (no recompute, I-5)
+  and fans `{:cause :subscription …}` to the handle's own `on-change`.
 
   CLJS-only (Reagent is CLJS); ns ends in `-cljs-test` so the consolidated
   shadow-cljs `:node-test` build (`npm run test:cljs`, whose source-paths carry
@@ -97,10 +104,6 @@
   (rf/reg-sub :obs/n (fn [db _] (:n db)))
   (rf/reg-event :obs/set-n (fn [{:keys [db]} [_ v]] {:db (assoc db :n v)})))
 
-;; The eager consumer standing in for a mounted ViewCell render: an
-;; auto-running reaction that derefs the sub, keeping the node warm + on the
-;; push path so a value movement re-runs it (and fires the port's watch).
-(defn- make-driver [] (ratom/run! (deref (rf/subscribe [:obs/n]))))
 
 ;; --- rf2-r09qj NaN-stability helpers ---------------------------------------
 
@@ -146,8 +149,8 @@
             the make-watch-handler channel the plain-atom suites cannot reach"
     (register!)
     (rf/dispatch-sync [:obs/set-n 1])
-    (let [driver (make-driver)]
-      (ratom/flush!)                       ;; settle: node warm + active
+    (do
+      (ratom/flush!)                       ;; settle any pending queue first
       (let [notes  (atom [])
             target (obs/resolve-target {:frame fid :query-v [:obs/n]})
             handle  (obs/acquire! target (fn [ev] (swap! notes conj ev)))]
@@ -186,8 +189,7 @@
                 (is (int? (:frame-epoch ev)))
                 (is (int? (:registry-epoch ev))))))
           (finally
-            (obs/release! handle)
-            (ratom/dispose! driver)))))))
+            (obs/release! handle)))))))
 
 (deftest watchable-host-idempotent-move-does-not-fan-cause-value
   (testing "a commit that leaves the sub value UNMOVED does not fire the
@@ -195,7 +197,7 @@
             node-record's rf= version hold) mean an equal re-commit is silent"
     (register!)
     (rf/dispatch-sync [:obs/set-n 7])
-    (let [driver (make-driver)]
+    (do
       (ratom/flush!)
       (let [notes  (atom [])
             target (obs/resolve-target {:frame fid :query-v [:obs/n]})
@@ -212,8 +214,7 @@
             (is (= v0 (:version (handle-last handle)))
                 "the node-version did not advance for an equal re-commit"))
           (finally
-            (obs/release! handle)
-            (ratom/dispose! driver)))))))
+            (obs/release! handle)))))))
 
 ;; ===========================================================================
 ;; the reentrancy guard on the value-movement fan-out
@@ -226,7 +227,7 @@
             the guard the plain-atom suites cannot reach"
     (register!)
     (rf/dispatch-sync [:obs/set-n 1])
-    (let [driver (make-driver)]
+    (do
       (ratom/flush!)
       (let [target  (obs/resolve-target {:frame fid :query-v [:obs/n]})
             outcome (atom :guard-not-fired)
@@ -250,8 +251,7 @@
           (is (= :live (:status (handle-state @handle)))
               "the guard threw BEFORE any teardown — the handle is untouched")
           (finally
-            (obs/release! @handle)
-            (ratom/dispose! driver)))))))
+            (obs/release! @handle)))))))
 
 ;; ===========================================================================
 ;; rf2-r09qj — NaN moves NaN-STABLY through the PUBLIC acquire path
@@ -266,8 +266,8 @@
             natively) would spuriously fan a phantom value movement."
     (register!)
     (rf/dispatch-sync [:obs/set-n ##NaN])
-    (let [driver (make-driver)]
-      (ratom/flush!)                         ;; settle: node warm + active at NaN
+    (do
+      (ratom/flush!)                         ;; settle any pending queue first
       (let [notes            (atom [])
             target           (obs/resolve-target {:frame fid :query-v [:obs/n]})
             handle            (obs/acquire! target (fn [ev] (swap! notes conj ev)))
@@ -310,8 +310,7 @@
                   "the real value movement advanced the node version EXACTLY once")))
           (finally
             (nan-rm)
-            (obs/release! handle)
-            (ratom/dispose! driver)))))))
+            (obs/release! handle)))))))
 
 ;; ===========================================================================
 ;; rf2-r09qj — NaN moves NaN-STABLY through an integrated ViewCell
@@ -383,7 +382,7 @@
             cannot reach."
     (register!)
     (rf/dispatch-sync [:obs/set-n ##NaN])
-    (let [driver (make-driver)]
+    (do
       (ratom/flush!)
       (let [cell    (reactive/make-cell ::nan-host)
             renders (atom 0)]
@@ -437,5 +436,4 @@
                   "the real move fired exactly one render (listener notification)"))
             (finally
               (nan-rm)
-              (unsub)
-              (ratom/dispose! driver))))))))
+              (unsub))))))))

--- a/implementation/adapters/reagent/test/re_frame/observation_port_watchable_host_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/observation_port_watchable_host_cljs_test.cljs
@@ -149,47 +149,45 @@
             the make-watch-handler channel the plain-atom suites cannot reach"
     (register!)
     (rf/dispatch-sync [:obs/set-n 1])
-    (do
-      (ratom/flush!)                       ;; settle any pending queue first
-      (let [notes  (atom [])
-            target (obs/resolve-target {:frame fid :query-v [:obs/n]})
-            handle  (obs/acquire! target (fn [ev] (swap! notes conj ev)))]
-        (try
-          ;; --- preconditions: the port armed the value-movement channel ---
-          (is (obs/handle? handle))
-          (is (satisfies? IWatchable (node-reaction))
-              "the Reagent sub reaction IS IWatchable — the port installed its
-               per-handle value-movement watch (on a non-watchable host this
-               whole channel is dead, which is the very gap under test)")
-          (is (some? (:watch-key (handle-state handle)))
-              "acquire! registered a per-handle change watch key on the node")
-          (is (empty? @notes)
-              "acquire! on a WARM node fans nothing synchronously (I-5
-               no-sync-fan-out holds on a watchable host too)")
-          (let [v0    (:version (handle-last handle))
-                node0 (:node-key (handle-last handle))]
-            (is (= 1 (:value (handle-last handle))) "baseline observed value")
-            ;; --- MOVE the value; flush the reaction queue (the push) ---
-            (rf/dispatch-sync [:obs/set-n 2])
-            (ratom/flush!)
-            (testing "the value-movement watch fired the {:cause :subscription} channel"
-              (is (pos? (count @notes))
-                  "the port's per-handle watch fired on the value movement")
-              (is (every? #(= :subscription (:cause %)) @notes)
-                  "every fan-out on this path carries {:cause :subscription}")
-              (let [ev (peek @notes)]
-                (is (= target (:target ev)) "the payload carries the handle target")
-                (is (= node0 (:node-key ev)) "same node — a MOVEMENT, not a rebuild")
-                (is (> (:node-version ev) v0)
-                    "the delivered-value node-version ADVANCED past the baseline")
-                (is (= (:node-version ev) (:version (handle-last handle)))
-                    "the handle :last was advanced to the delivered version")
-                (is (= 2 (:value (handle-last handle)))
-                    "the handle :last holds the DELIVERED new value (no recompute)")
-                (is (int? (:frame-epoch ev)))
-                (is (int? (:registry-epoch ev))))))
-          (finally
-            (obs/release! handle)))))))
+    (let [notes  (atom [])
+          target (obs/resolve-target {:frame fid :query-v [:obs/n]})
+          handle  (obs/acquire! target (fn [ev] (swap! notes conj ev)))]
+      (try
+        ;; --- preconditions: the port armed the value-movement channel ---
+        (is (obs/handle? handle))
+        (is (satisfies? IWatchable (node-reaction))
+            "the Reagent sub reaction IS IWatchable — the port installed its
+             per-handle value-movement watch (on a non-watchable host this
+             whole channel is dead, which is the very gap under test)")
+        (is (some? (:watch-key (handle-state handle)))
+            "acquire! registered a per-handle change watch key on the node")
+        (is (empty? @notes)
+            "acquire! on a WARM node fans nothing synchronously (I-5
+             no-sync-fan-out holds on a watchable host too)")
+        (let [v0    (:version (handle-last handle))
+              node0 (:node-key (handle-last handle))]
+          (is (= 1 (:value (handle-last handle))) "baseline observed value")
+          ;; --- MOVE the value; flush the reaction queue (the push) ---
+          (rf/dispatch-sync [:obs/set-n 2])
+          (ratom/flush!)
+          (testing "the value-movement watch fired the {:cause :subscription} channel"
+            (is (pos? (count @notes))
+                "the port's per-handle watch fired on the value movement")
+            (is (every? #(= :subscription (:cause %)) @notes)
+                "every fan-out on this path carries {:cause :subscription}")
+            (let [ev (peek @notes)]
+              (is (= target (:target ev)) "the payload carries the handle target")
+              (is (= node0 (:node-key ev)) "same node — a MOVEMENT, not a rebuild")
+              (is (> (:node-version ev) v0)
+                  "the delivered-value node-version ADVANCED past the baseline")
+              (is (= (:node-version ev) (:version (handle-last handle)))
+                  "the handle :last was advanced to the delivered version")
+              (is (= 2 (:value (handle-last handle)))
+                  "the handle :last holds the DELIVERED new value (no recompute)")
+              (is (int? (:frame-epoch ev)))
+              (is (int? (:registry-epoch ev))))))
+        (finally
+          (obs/release! handle))))))
 
 (deftest watchable-host-idempotent-move-does-not-fan-cause-value
   (testing "a commit that leaves the sub value UNMOVED does not fire the
@@ -197,24 +195,22 @@
             node-record's rf= version hold) mean an equal re-commit is silent"
     (register!)
     (rf/dispatch-sync [:obs/set-n 7])
-    (do
-      (ratom/flush!)
-      (let [notes  (atom [])
-            target (obs/resolve-target {:frame fid :query-v [:obs/n]})
-            handle  (obs/acquire! target (fn [ev] (swap! notes conj ev)))]
-        (try
-          (is (empty? @notes) "acquire! on a WARM node is silent")
-          (let [v0 (:version (handle-last handle))]
-            ;; Re-commit the SAME value: the node re-runs to an equal value, so
-            ;; no watch notification and no version advance.
-            (rf/dispatch-sync [:obs/set-n 7])
-            (ratom/flush!)
-            (is (empty? @notes)
-                "an unmoved value fans nothing on the :subscription channel")
-            (is (= v0 (:version (handle-last handle)))
-                "the node-version did not advance for an equal re-commit"))
-          (finally
-            (obs/release! handle)))))))
+    (let [notes  (atom [])
+          target (obs/resolve-target {:frame fid :query-v [:obs/n]})
+          handle  (obs/acquire! target (fn [ev] (swap! notes conj ev)))]
+      (try
+        (is (empty? @notes) "acquire! on a WARM node is silent")
+        (let [v0 (:version (handle-last handle))]
+          ;; Re-commit the SAME value: the node re-runs to an equal value, so
+          ;; no watch notification and no version advance.
+          (rf/dispatch-sync [:obs/set-n 7])
+          (ratom/flush!)
+          (is (empty? @notes)
+              "an unmoved value fans nothing on the :subscription channel")
+          (is (= v0 (:version (handle-last handle)))
+              "the node-version did not advance for an equal re-commit"))
+        (finally
+          (obs/release! handle))))))
 
 ;; ===========================================================================
 ;; the reentrancy guard on the value-movement fan-out
@@ -227,31 +223,29 @@
             the guard the plain-atom suites cannot reach"
     (register!)
     (rf/dispatch-sync [:obs/set-n 1])
-    (do
-      (ratom/flush!)
-      (let [target  (obs/resolve-target {:frame fid :query-v [:obs/n]})
-            outcome (atom :guard-not-fired)
-            ;; The on-change attempts a FORBIDDEN reentrant self-release from
-            ;; inside the value fan-out; the guard must throw before any
-            ;; teardown, so the handle stays intact and `finally` is a clean op.
-            handle   (atom nil)]
-        (reset! handle
-          (obs/acquire! target
-            (fn [_ev]
-              (reset! outcome
-                (try (obs/release! @handle) :released-no-throw
-                     (catch :default e (:rf.error/id (ex-data e))))))))
-        (try
-          ;; MOVE the value so the measured handle's watch fires on a warm node.
-          (rf/dispatch-sync [:obs/set-n 2])
-          (ratom/flush!)
-          (is (= :rf.error/reentrant-graph-op @outcome)
-              "release! from inside the value-movement fan-out threw the dev
-               reentrant-graph-op assert (fan-out! bound *in-owner-fan-out?*)")
-          (is (= :live (:status (handle-state @handle)))
-              "the guard threw BEFORE any teardown — the handle is untouched")
-          (finally
-            (obs/release! @handle)))))))
+    (let [target  (obs/resolve-target {:frame fid :query-v [:obs/n]})
+          outcome (atom :guard-not-fired)
+          ;; The on-change attempts a FORBIDDEN reentrant self-release from
+          ;; inside the value fan-out; the guard must throw before any
+          ;; teardown, so the handle stays intact and `finally` is a clean op.
+          handle   (atom nil)]
+      (reset! handle
+        (obs/acquire! target
+          (fn [_ev]
+            (reset! outcome
+              (try (obs/release! @handle) :released-no-throw
+                   (catch :default e (:rf.error/id (ex-data e))))))))
+      (try
+        ;; MOVE the value so the measured handle's watch fires on a warm node.
+        (rf/dispatch-sync [:obs/set-n 2])
+        (ratom/flush!)
+        (is (= :rf.error/reentrant-graph-op @outcome)
+            "release! from inside the value-movement fan-out threw the dev
+             reentrant-graph-op assert (fan-out! bound *in-owner-fan-out?*)")
+        (is (= :live (:status (handle-state @handle)))
+            "the guard threw BEFORE any teardown — the handle is untouched")
+        (finally
+          (obs/release! @handle))))))
 
 ;; ===========================================================================
 ;; rf2-r09qj — NaN moves NaN-STABLY through the PUBLIC acquire path
@@ -266,51 +260,49 @@
             natively) would spuriously fan a phantom value movement."
     (register!)
     (rf/dispatch-sync [:obs/set-n ##NaN])
-    (do
-      (ratom/flush!)                         ;; settle any pending queue first
-      (let [notes            (atom [])
-            target           (obs/resolve-target {:frame fid :query-v [:obs/n]})
-            handle            (obs/acquire! target (fn [ev] (swap! notes conj ev)))
-            reaction         (node-reaction)
-            [nan-hits nan-rm] (install-nan-sentinel! reaction)]
-        (try
-          ;; --- preconditions ---
-          (is (obs/handle? handle))
-          (is (satisfies? IWatchable reaction)
-              "the Reagent sub reaction IS IWatchable — the port armed its
-               per-handle value-movement watch")
-          (is (empty? @notes) "acquire! on a warm NaN node fans nothing")
-          (is (nan-num? (:value (handle-last handle))) "baseline observed the host NaN")
-          (let [v0 (:version (handle-last handle))]
-            ;; --- MOVE NaN→NaN: app-db moves (NaN≠NaN under map =), the reaction
-            ;; re-derives NaN, and Reagent's =-gated notify fires (NaN≠NaN). ---
-            (rf/dispatch-sync [:obs/set-n ##NaN])
+    (let [notes            (atom [])
+          target           (obs/resolve-target {:frame fid :query-v [:obs/n]})
+          handle            (obs/acquire! target (fn [ev] (swap! notes conj ev)))
+          reaction         (node-reaction)
+          [nan-hits nan-rm] (install-nan-sentinel! reaction)]
+      (try
+        ;; --- preconditions ---
+        (is (obs/handle? handle))
+        (is (satisfies? IWatchable reaction)
+            "the Reagent sub reaction IS IWatchable — the port armed its
+             per-handle value-movement watch")
+        (is (empty? @notes) "acquire! on a warm NaN node fans nothing")
+        (is (nan-num? (:value (handle-last handle))) "baseline observed the host NaN")
+        (let [v0 (:version (handle-last handle))]
+          ;; --- MOVE NaN→NaN: app-db moves (NaN≠NaN under map =), the reaction
+          ;; re-derives NaN, and Reagent's =-gated notify fires (NaN≠NaN). ---
+          (rf/dispatch-sync [:obs/set-n ##NaN])
+          (ratom/flush!)
+          (testing "the host watch fired but the port fanned nothing"
+            (is (pos? @nan-hits)
+                "the underlying Reagent host watch FIRED for NaN→NaN — the
+                 port's make-watch-handler callback genuinely ran (non-vacuous)")
+            (is (empty? @notes)
+                "NaN→NaN emitted NO {:cause :subscription} note — node-value= suppressed
+                 the fan-out (raw not= would fan a phantom movement)")
+            (is (= v0 (:version (handle-last handle)))
+                "the node version did NOT advance — NaN=NaN under the movement law"))
+          (testing "positive control — a REAL move fans exactly once + advances"
+            (rf/dispatch-sync [:obs/set-n 5])
             (ratom/flush!)
-            (testing "the host watch fired but the port fanned nothing"
-              (is (pos? @nan-hits)
-                  "the underlying Reagent host watch FIRED for NaN→NaN — the
-                   port's make-watch-handler callback genuinely ran (non-vacuous)")
-              (is (empty? @notes)
-                  "NaN→NaN emitted NO {:cause :subscription} note — node-value= suppressed
-                   the fan-out (raw not= would fan a phantom movement)")
-              (is (= v0 (:version (handle-last handle)))
-                  "the node version did NOT advance — NaN=NaN under the movement law"))
-            (testing "positive control — a REAL move fans exactly once + advances"
-              (rf/dispatch-sync [:obs/set-n 5])
-              (ratom/flush!)
-              (is (= 1 (count @notes)) "exactly one {:cause :subscription} for a real move")
-              (is (= :subscription (:cause (first @notes))))
-              ;; EXACT `inc`, not merely `> v0`: `advance-node-record!` advances
-              ;; the node version by exactly `(inc (:version rec))` per real
-              ;; movement (observation.cljc), and between `v0` and this single
-              ;; real move only the NO-move NaN→NaN recompute intervened (version
-              ;; held at `v0`, asserted above). A +2 seam increment — the mutation
-              ;; the loose `> v0` waves through — fails this assertion.
-              (is (= (inc v0) (:version (handle-last handle)))
-                  "the real value movement advanced the node version EXACTLY once")))
-          (finally
-            (nan-rm)
-            (obs/release! handle)))))))
+            (is (= 1 (count @notes)) "exactly one {:cause :subscription} for a real move")
+            (is (= :subscription (:cause (first @notes))))
+            ;; EXACT `inc`, not merely `> v0`: `advance-node-record!` advances
+            ;; the node version by exactly `(inc (:version rec))` per real
+            ;; movement (observation.cljc), and between `v0` and this single
+            ;; real move only the NO-move NaN→NaN recompute intervened (version
+            ;; held at `v0`, asserted above). A +2 seam increment — the mutation
+            ;; the loose `> v0` waves through — fails this assertion.
+            (is (= (inc v0) (:version (handle-last handle)))
+                "the real value movement advanced the node version EXACTLY once")))
+        (finally
+          (nan-rm)
+          (obs/release! handle))))))
 
 ;; ===========================================================================
 ;; rf2-r09qj — NaN moves NaN-STABLY through an integrated ViewCell
@@ -382,58 +374,56 @@
             cannot reach."
     (register!)
     (rf/dispatch-sync [:obs/set-n ##NaN])
-    (do
-      (ratom/flush!)
-      (let [cell    (reactive/make-cell ::nan-host)
-            renders (atom 0)]
-        (render+commit! cell)                ;; commit installs the watch-bearing handle
-        (let [unsub             (reactive/subscribe cell (fn [] (swap! renders inc)))
-              reaction          (node-reaction)
-              [nan-hits nan-rm] (install-nan-sentinel! reaction)
-              handle             (reactive/committed-handle cell (tk [:obs/n]))
-              ver0              (:version (obs/read handle))
-              rev0              (reactive/revision cell)]
-          (try
-            ;; --- preconditions: a real owned, watch-bearing handle at NaN ---
-            (is (some? handle) "the ViewCell committed a handle over the watchable host")
-            (is (obs/owned? handle)
-                "…a REAL owned observation node (so acquire! installed the watch)")
-            (is (nan-num? (get (reactive/committed-values cell) (tk [:obs/n])))
-                "the committed value is the host's NaN")
-            (is (= 0 rev0) "precondition: committed, no revision yet")
-            (is (= 0 @renders) "precondition: no render notifications yet")
-            ;; --- NaN→NaN: host watch fires, the port suppresses everything ---
-            (rf/dispatch-sync [:obs/set-n ##NaN])
+    (let [cell    (reactive/make-cell ::nan-host)
+          renders (atom 0)]
+      (render+commit! cell)                ;; commit installs the watch-bearing handle
+      (let [unsub             (reactive/subscribe cell (fn [] (swap! renders inc)))
+            reaction          (node-reaction)
+            [nan-hits nan-rm] (install-nan-sentinel! reaction)
+            handle             (reactive/committed-handle cell (tk [:obs/n]))
+            ver0              (:version (obs/read handle))
+            rev0              (reactive/revision cell)]
+        (try
+          ;; --- preconditions: a real owned, watch-bearing handle at NaN ---
+          (is (some? handle) "the ViewCell committed a handle over the watchable host")
+          (is (obs/owned? handle)
+              "…a REAL owned observation node (so acquire! installed the watch)")
+          (is (nan-num? (get (reactive/committed-values cell) (tk [:obs/n])))
+              "the committed value is the host's NaN")
+          (is (= 0 rev0) "precondition: committed, no revision yet")
+          (is (= 0 @renders) "precondition: no render notifications yet")
+          ;; --- NaN→NaN: host watch fires, the port suppresses everything ---
+          (rf/dispatch-sync [:obs/set-n ##NaN])
+          (ratom/flush!)
+          (reactive/flush-dirty! cell)     ;; drain any pending notification
+          (testing "NaN→NaN leaves version + revision + render UNMOVED"
+            (is (pos? @nan-hits)
+                "the host watch FIRED for NaN→NaN (the callback genuinely ran)")
+            (is (= ver0 (:version (obs/read handle)))
+                "node version UNMOVED — NaN=NaN under the movement law")
+            (is (= rev0 (reactive/revision cell))
+                "cell revision UNMOVED — make-watch-handler dirtied nothing")
+            (is (= 0 @renders) "ZERO renders — no listener notification fired"))
+          (testing "a re-render+commit finds no movement at step 5 either"
+            (render+commit! cell)
+            (reactive/flush-dirty! cell)
+            (is (= rev0 (reactive/revision cell))
+                "a re-commit over the un-advanced node advances NO revision")
+            (is (= 0 @renders) "…and still no render"))
+          (testing "positive control — a REAL move moves all three EXACTLY once"
+            (rf/dispatch-sync [:obs/set-n 5])
             (ratom/flush!)
-            (reactive/flush-dirty! cell)     ;; drain any pending notification
-            (testing "NaN→NaN leaves version + revision + render UNMOVED"
-              (is (pos? @nan-hits)
-                  "the host watch FIRED for NaN→NaN (the callback genuinely ran)")
-              (is (= ver0 (:version (obs/read handle)))
-                  "node version UNMOVED — NaN=NaN under the movement law")
-              (is (= rev0 (reactive/revision cell))
-                  "cell revision UNMOVED — make-watch-handler dirtied nothing")
-              (is (= 0 @renders) "ZERO renders — no listener notification fired"))
-            (testing "a re-render+commit finds no movement at step 5 either"
-              (render+commit! cell)
-              (reactive/flush-dirty! cell)
-              (is (= rev0 (reactive/revision cell))
-                  "a re-commit over the un-advanced node advances NO revision")
-              (is (= 0 @renders) "…and still no render"))
-            (testing "positive control — a REAL move moves all three EXACTLY once"
-              (rf/dispatch-sync [:obs/set-n 5])
-              (ratom/flush!)
-              (reactive/flush-dirty! cell)
-              ;; EXACT `inc`, matching the revision assertion just below: only
-              ;; the NO-move NaN→NaN recompute(s) intervened between `ver0` and
-              ;; this single real move, so `advance-node-record!` advanced the
-              ;; node version by exactly one. A +2 seam increment fails here.
-              (is (= (inc ver0) (:version (obs/read handle)))
-                  "the real move advanced the node version EXACTLY once")
-              (is (= (inc rev0) (reactive/revision cell))
-                  "the real move advanced the cell revision exactly once")
-              (is (= 1 @renders)
-                  "the real move fired exactly one render (listener notification)"))
-            (finally
-              (nan-rm)
-              (unsub))))))))
+            (reactive/flush-dirty! cell)
+            ;; EXACT `inc`, matching the revision assertion just below: only
+            ;; the NO-move NaN→NaN recompute(s) intervened between `ver0` and
+            ;; this single real move, so `advance-node-record!` advanced the
+            ;; node version by exactly one. A +2 seam increment fails here.
+            (is (= (inc ver0) (:version (obs/read handle)))
+                "the real move advanced the node version EXACTLY once")
+            (is (= (inc rev0) (reactive/revision cell))
+                "the real move advanced the cell revision exactly once")
+            (is (= 1 @renders)
+                "the real move fired exactly one render (listener notification)"))
+          (finally
+            (nan-rm)
+            (unsub)))))))

--- a/implementation/adapters/reagent/test/re_frame/observation_port_watchable_host_mounted_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/observation_port_watchable_host_mounted_dom_cljs_test.cljs
@@ -26,6 +26,10 @@
       `:kind`; there is no adapter-kind gate on the mount path, and sibling
       suites already mount compiled roots under `:kind :custom` adapters.
     - Reagent does NOT keep a compiled view away from the observation port.
+      (This file used to stand a `ratom/run!` driver alongside the mount, on
+      the same false rationale the headless sibling records — rf2-8cnxg. The
+      mount is now the only consumer, which is what makes the mounted counts
+      below attributable to the port rather than to a hand-run reaction.)
       That conflates WHICH ADAPTER SUPPLIES THE WATCHABLE HOST with WHICH
       RENDERER DRIVES THE VIEW; they are independent. A compiled `defview`
       always reads its subs through the observation port into a ViewCell —
@@ -125,13 +129,6 @@
                    (swap! hits inc))))
     [hits (fn remove! [] (remove-watch reaction k))]))
 
-;; The eager consumer that keeps the (lazy) Reagent reaction on the push path,
-;; exactly as the headless sibling stands one: an auto-running reaction that
-;; derefs the sub so a value movement re-runs the node and fires the port's
-;; watch. It renders NOTHING, so it cannot contribute to the mounted render or
-;; commit counts below — those come solely from the compiled view and React.
-(defn- make-driver [] (ratom/run! (deref (rf/subscribe [:obs/n]))))
-
 (defn- nan-commit-profiler
   "Plain React Profiler wrapper — `onRender` fires once per COMMIT of the
   mounted subtree, giving commit-level attribution alongside the compiled
@@ -174,8 +171,8 @@
     (do
       (register!)
       (rf/dispatch-sync [:obs/set-n ##NaN])
-      (let [driver (make-driver)]
-        (ratom/flush!)                       ;; settle: node warm + active at NaN
+      (do
+        (ratom/flush!)                       ;; settle any pending queue first
         (let [baseline (reactive/current-live-cells)
               renders  (atom 0)
               commits  (atom 0)
@@ -184,8 +181,7 @@
               nan-rm*  (atom nil)
               cleanup! (fn []
                          (when-let [rm @nan-rm*] (rm))
-                         (when-let [p @probe*] (obs/release! p))
-                         (ratom/dispose! driver))]
+                         (when-let [p @probe*] (obs/release! p)))]
           (async done
             (->
              (uit/with-root

--- a/implementation/adapters/reagent/test/re_frame/observation_port_watchable_host_mounted_dom_cljs_test.cljs
+++ b/implementation/adapters/reagent/test/re_frame/observation_port_watchable_host_mounted_dom_cljs_test.cljs
@@ -171,103 +171,101 @@
     (do
       (register!)
       (rf/dispatch-sync [:obs/set-n ##NaN])
-      (do
-        (ratom/flush!)                       ;; settle any pending queue first
-        (let [baseline (reactive/current-live-cells)
-              renders  (atom 0)
-              commits  (atom 0)
-              notes    (atom [])
-              probe*   (atom nil)
-              nan-rm*  (atom nil)
-              cleanup! (fn []
-                         (when-let [rm @nan-rm*] (rm))
-                         (when-let [p @probe*] (obs/release! p)))]
-          (async done
-            (->
-             (uit/with-root
-               [root [nan-commit-profiler {:commits commits}
-                      [ui/frame-provider {:frame fid}
-                       [mounted-nan-view {:renders renders}]]]]
-               (let [mounted           (remove baseline (reactive/current-live-cells))
-                     cell              (first mounted)
-                     reaction          (node-reaction)
-                     [nan-hits nan-rm] (install-nan-sentinel! reaction)
-                     ;; An INDEPENDENT probe handle on the SAME node: its
-                     ;; `on-change` is the `{:cause :subscription}` note channel that
-                     ;; the mounted cell's own (cell-dirtying) `on-change`
-                     ;; cannot surface. Same port, same node, same notify sweep
-                     ;; — the standard public `acquire!`, not a test bridge.
-                     probe             (obs/acquire!
-                                        (obs/resolve-target
-                                         {:frame fid :query-v [:obs/n]})
-                                        (fn [ev] (swap! notes conj ev)))
-                     ver0              (:version (obs/read probe))
-                     rev0              (reactive/revision cell)
-                     renders0          @renders
-                     commits0          @commits]
-                 (reset! nan-rm* nan-rm)
-                 (reset! probe* probe)
-                 (testing "preconditions — a REAL mounted ViewCell over the Reagent host"
-                   (is (= 1 (count mounted))
-                       "the compiled sub-reading view mounted exactly one ViewCell")
-                   (is (satisfies? IWatchable reaction)
-                       "the mounted cell reads a Reagent Reaction — an IWatchable host,
-                        so the port armed its per-handle value-movement watch")
-                   (is (obs/owned? (reactive/committed-handle cell (tk [:obs/n])))
-                       "…through a REAL owned observation handle taken by the mounted commit")
-                   (is (nan-num? (get (reactive/committed-values cell) (tk [:obs/n])))
-                       "the mounted cell committed the host's NaN")
-                   (is (= "NaN" (mounted-text root))
-                       "and the MOUNTED DOM carries it — a real render, not a proxy")
-                   (is (= 1 renders0) "the mount rendered the compiled view exactly once")
-                   (is (= 1 commits0) "…in exactly one React commit")
-                   (is (empty? @notes) "acquire! on a warm NaN node fans nothing"))
-                 (->
-                  (move! ##NaN)
-                  (.then
-                   (fn []
-                     (testing "NaN→NaN fires the host watch yet moves NOTHING at the mount"
-                       (is (pos? @nan-hits)
-                           "the Reagent host watch FIRED for NaN→NaN — make-watch-handler
-                            genuinely ran, so the green assertions below are non-vacuous")
-                       (is (empty? @notes)
-                           "ZERO {:cause :subscription} notes — node-value= suppressed the fan-out
-                            (a raw not= at the seam would fan a phantom movement)")
-                       (is (= ver0 (:version (obs/read probe)))
-                           "node version UNMOVED — NaN=NaN under the movement law")
-                       (is (= rev0 (reactive/revision cell))
-                           "mounted ViewCell revision UNMOVED — the cell was never dirtied")
-                       (is (= renders0 @renders)
-                           "ZERO further MOUNTED renders — the compiled view's body
-                            did not re-run at the live mount")
-                       (is (= commits0 @commits)
-                           "ZERO further React commits of the mounted tree")
-                       (is (= "NaN" (mounted-text root))
-                           "the mounted DOM is untouched"))
-                     (move! 5)))
-                  (.then
-                   (fn []
-                     (testing "positive control — a REAL move moves all four EXACTLY once"
-                       (is (= 1 (count @notes))
-                           "exactly one {:cause :subscription} note for the real movement")
-                       (is (= :subscription (:cause (first @notes))))
-                       (is (= (inc ver0) (:version (obs/read probe)))
-                           "the real move advanced the node version EXACTLY once")
-                       (is (= (inc rev0) (reactive/revision cell))
-                           "…and the mounted cell's revision exactly once")
-                       (is (= (inc renders0) @renders)
-                           "…and drove EXACTLY ONE attributable mounted render")
-                       (is (= (inc commits0) @commits)
-                           "…committed through React exactly once")
-                       (is (= "5" (mounted-text root))
-                           "the mounted DOM shows the moved value")))))))
-             ;; `with-root` unmounts the React root and removes its container as
-             ;; part of this awaited chain, so the mount is EXPLICITLY torn down
-             ;; before the fixture's `:after` restores the adapter.
-             (.then (fn []
-                      (cleanup!)
-                      (done))
-                    (fn [e]
-                      (cleanup!)
-                      (is false (str "mounted NaN proof rejected: " e))
-                      (done))))))))))
+            (let [baseline (reactive/current-live-cells)
+            renders  (atom 0)
+            commits  (atom 0)
+            notes    (atom [])
+            probe*   (atom nil)
+            nan-rm*  (atom nil)
+            cleanup! (fn []
+                       (when-let [rm @nan-rm*] (rm))
+                       (when-let [p @probe*] (obs/release! p)))]
+        (async done
+          (->
+           (uit/with-root
+             [root [nan-commit-profiler {:commits commits}
+                    [ui/frame-provider {:frame fid}
+                     [mounted-nan-view {:renders renders}]]]]
+             (let [mounted           (remove baseline (reactive/current-live-cells))
+                   cell              (first mounted)
+                   reaction          (node-reaction)
+                   [nan-hits nan-rm] (install-nan-sentinel! reaction)
+                   ;; An INDEPENDENT probe handle on the SAME node: its
+                   ;; `on-change` is the `{:cause :subscription}` note channel that
+                   ;; the mounted cell's own (cell-dirtying) `on-change`
+                   ;; cannot surface. Same port, same node, same notify sweep
+                   ;; — the standard public `acquire!`, not a test bridge.
+                   probe             (obs/acquire!
+                                      (obs/resolve-target
+                                       {:frame fid :query-v [:obs/n]})
+                                      (fn [ev] (swap! notes conj ev)))
+                   ver0              (:version (obs/read probe))
+                   rev0              (reactive/revision cell)
+                   renders0          @renders
+                   commits0          @commits]
+               (reset! nan-rm* nan-rm)
+               (reset! probe* probe)
+               (testing "preconditions — a REAL mounted ViewCell over the Reagent host"
+                 (is (= 1 (count mounted))
+                     "the compiled sub-reading view mounted exactly one ViewCell")
+                 (is (satisfies? IWatchable reaction)
+                     "the mounted cell reads a Reagent Reaction — an IWatchable host,
+                      so the port armed its per-handle value-movement watch")
+                 (is (obs/owned? (reactive/committed-handle cell (tk [:obs/n])))
+                     "…through a REAL owned observation handle taken by the mounted commit")
+                 (is (nan-num? (get (reactive/committed-values cell) (tk [:obs/n])))
+                     "the mounted cell committed the host's NaN")
+                 (is (= "NaN" (mounted-text root))
+                     "and the MOUNTED DOM carries it — a real render, not a proxy")
+                 (is (= 1 renders0) "the mount rendered the compiled view exactly once")
+                 (is (= 1 commits0) "…in exactly one React commit")
+                 (is (empty? @notes) "acquire! on a warm NaN node fans nothing"))
+               (->
+                (move! ##NaN)
+                (.then
+                 (fn []
+                   (testing "NaN→NaN fires the host watch yet moves NOTHING at the mount"
+                     (is (pos? @nan-hits)
+                         "the Reagent host watch FIRED for NaN→NaN — make-watch-handler
+                          genuinely ran, so the green assertions below are non-vacuous")
+                     (is (empty? @notes)
+                         "ZERO {:cause :subscription} notes — node-value= suppressed the fan-out
+                          (a raw not= at the seam would fan a phantom movement)")
+                     (is (= ver0 (:version (obs/read probe)))
+                         "node version UNMOVED — NaN=NaN under the movement law")
+                     (is (= rev0 (reactive/revision cell))
+                         "mounted ViewCell revision UNMOVED — the cell was never dirtied")
+                     (is (= renders0 @renders)
+                         "ZERO further MOUNTED renders — the compiled view's body
+                          did not re-run at the live mount")
+                     (is (= commits0 @commits)
+                         "ZERO further React commits of the mounted tree")
+                     (is (= "NaN" (mounted-text root))
+                         "the mounted DOM is untouched"))
+                   (move! 5)))
+                (.then
+                 (fn []
+                   (testing "positive control — a REAL move moves all four EXACTLY once"
+                     (is (= 1 (count @notes))
+                         "exactly one {:cause :subscription} note for the real movement")
+                     (is (= :subscription (:cause (first @notes))))
+                     (is (= (inc ver0) (:version (obs/read probe)))
+                         "the real move advanced the node version EXACTLY once")
+                     (is (= (inc rev0) (reactive/revision cell))
+                         "…and the mounted cell's revision exactly once")
+                     (is (= (inc renders0) @renders)
+                         "…and drove EXACTLY ONE attributable mounted render")
+                     (is (= (inc commits0) @commits)
+                         "…committed through React exactly once")
+                     (is (= "5" (mounted-text root))
+                         "the mounted DOM shows the moved value")))))))
+           ;; `with-root` unmounts the React root and removes its container as
+           ;; part of this awaited chain, so the mount is EXPLICITLY torn down
+           ;; before the fixture's `:after` restores the adapter.
+           (.then (fn []
+                    (cleanup!)
+                    (done))
+                  (fn [e]
+                    (cleanup!)
+                    (is false (str "mounted NaN proof rejected: " e))
+                    (done)))))))))

--- a/implementation/core/src/re_frame/interop.clj
+++ b/implementation/core/src/re_frame/interop.clj
@@ -121,6 +121,15 @@
   [f]
   (->Reaction f []))
 
+(defn activate-derived-value!
+  "The JVM twin of the CLJS hook-routed op (rf2-8cnxg / rf2-jt8vz). There is
+  no substrate here and no tracking graph: the JVM `Reaction` recomputes `f`
+  on EVERY deref and has no source-capture step to perform, so there is
+  nothing to activate. Present so the CLJC observation port can call it
+  unconditionally rather than reader-conditionalising the call site."
+  [_derived]
+  nil)
+
 (defn add-on-dispose! [a-ratom f]
   (if (instance? Reaction a-ratom)
     (-add-on-dispose a-ratom f)

--- a/implementation/core/src/re_frame/interop.cljs
+++ b/implementation/core/src/re_frame/interop.cljs
@@ -82,6 +82,42 @@
   (when-let [hook (late-bind/get-fn-cached :adapter/make-reaction)]
     (hook f)))
 
+(defn activate-derived-value!
+  "Put a `make-derived-value` result on the substrate's PUSH path — i.e.
+  make it actually notify its watches when a source moves (rf2-8cnxg /
+  rf2-jt8vz).
+
+  Spec 006 §`make-derived-value` says the derived container \"updates
+  automatically when any source's value changes\" and that
+  `subscribe-container` works on it as on a base container. On the
+  React-hook spine that is true from birth: `make-derived-value-fn` wires one
+  watch per source AT CONSTRUCTION. The ratom family is DEMAND-driven
+  instead: `reagent.ratom/Reaction` captures its sources only through
+  `deref-capture`, and a plain `deref` taken OUTSIDE `*ratom-context*` (with
+  no `auto-run`) runs the body raw and leaves `watching` nil — a reaction
+  that is watchable, and watched, and notifies nobody. A Reagent COMPONENT
+  never notices because its render IS the capture context; a compiled
+  ViewCell is not a component, so nothing supplies it.
+
+  This op is that missing capture, and it is the ONLY thing the ratom family
+  needs to satisfy the spec's push clause: once the sources are captured, a
+  write reaches `_handle-change` → the reaction enqueues itself → the
+  substrate's ordinary batched flush recomputes and notifies. Nothing here
+  makes a subscription EAGER: activation happens at observation-port acquire
+  time, not at construction, so a sub no ViewCell observes is untouched, and
+  the change path stays batched (`:auto-run true` — the one-line \"fix\" —
+  would instead recompute every Reagent-hosted subscription synchronously
+  inside the app-db `reset!`).
+
+  Idempotent and total: adapters whose derived values are already push-based
+  (the React-hook spine: UIx, Helix, re-frame.ui, Freehand) publish no hook
+  and the call is a no-op; the ratom impls no-op on an already-activated
+  reaction and on any container that is not one of their derived values."
+  [derived]
+  (when-let [hook (late-bind/get-fn-cached :adapter/activate-derived-value!)]
+    (hook derived))
+  nil)
+
 (defn add-on-dispose!
   "Register a teardown callback on a-ratom."
   [a-ratom f]

--- a/implementation/core/src/re_frame/late_bind/directory.cljc
+++ b/implementation/core/src/re_frame/late_bind/directory.cljc
@@ -987,6 +987,12 @@
     :chained?    true
     :design-bead "rf2-s36l"
     :description "Substrate-specific make-reaction (re-frame.interop/make-reaction). Per rf2-jicu2 not published by UIx; absent-hook returns nil."}
+   {:key         :adapter/activate-derived-value!
+    :producer-ns '[re-frame.adapter.reagent
+                   re-frame.adapter.reagent-slim]
+    :chained?    true
+    :design-bead "rf2-8cnxg"
+    :description "Put a make-derived-value result on the substrate's PUSH path (re-frame.interop/activate-derived-value!), so a source write actually notifies the derived container's watches — Spec 006 §make-derived-value's \"updates automatically when any source's value changes\" clause. Published by the ratom family ALONE, because they alone are demand-driven: a reagent.ratom/Reaction captures its sources only through deref-capture, and a deref taken outside *ratom-context* with no auto-run runs the body raw and leaves `watching` nil — watchable, watched, and silent. The observation port calls this before installing its per-handle watch, so a compiled ViewCell (which is not a Reagent component and so supplies no capture context of its own) observes a live node. NOT published by the React-hook spine (UIx / Helix / re-frame.ui / Freehand), whose make-derived-value wires one watch per source at CONSTRUCTION and is push-based from birth; the routed chain-bottom returns nil and the port's call is a no-op. Not published by plain-atom / test-react for the same reason."}
    {:key         :adapter/add-on-dispose!
     :producer-ns '[re-frame.adapter.reagent
                    re-frame.adapter.reagent-slim

--- a/implementation/core/src/re_frame/substrate/observation.cljc
+++ b/implementation/core/src/re_frame/substrate/observation.cljc
@@ -1907,7 +1907,9 @@
 
 (defn- build-node-handle!
   "Wrap a CANONICAL cached `reaction` — one `subs/acquire-cache-reaction!` has
-  already taken a real +1 reference on — in a live NODE handle. Register the
+  already taken a real +1 reference on — in a live NODE handle. ACTIVATE the
+  node on its substrate's push path (`interop/activate-derived-value!` —
+  rf2-8cnxg; a no-op on hosts that are push-based from birth), register the
   per-handle change watch (on watchable hosts; `add-watch` never fires
   synchronously), take the baseline observation through the activated node,
   enrol the handle as an active owner, and — whenever the node hook is not yet
@@ -1954,8 +1956,30 @@
                      :on-change  on-change
                      :status     :live})
         handle (->ObservationHandle state)]
-    ;; Watch BEFORE the baseline observe: a watched reaction is live on the
-    ;; reactive hosts, so the observe below reads through the activated node.
+    ;; ACTIVATE, then watch, then observe — and the order is the whole fix
+    ;; for rf2-8cnxg / rf2-jt8vz.
+    ;;
+    ;; This step used to be absent, on the stated assumption that "a watched
+    ;; reaction is live on the reactive hosts". That is FALSE on the ratom
+    ;; family, and silently so. `add-watch` on a `reagent.ratom/Reaction`
+    ;; only RECORDS the callback; the reaction subscribes to its own sources
+    ;; solely through `deref-capture`, which a plain `deref` taken outside a
+    ;; reactive context (and with no `auto-run`) skips — it runs the body raw
+    ;; and leaves `watching` nil. So the port held a watch on a node that
+    ;; could never notify: every ViewCell over a Reagent-hosted subscription
+    ;; rendered ONCE and never again, because the mark-dirty channel was
+    ;; never entered at all. A Reagent COMPONENT never hits this because its
+    ;; render IS the capture context; a ViewCell is not a Reagent component,
+    ;; so nothing but this call supplies one.
+    ;;
+    ;; `interop/activate-derived-value!` is the substrate's own "put this
+    ;; derived value on your push path" op — a no-op for hosts already
+    ;; push-based from birth (the React-hook spine wires one watch per source
+    ;; at construction) and for plain-atom / JVM derived values, which have
+    ;; no capture step. It runs BEFORE `add-watch` so the activation's own
+    ;; first recompute cannot fan a priming notification at this handle, and
+    ;; before the baseline observe so that observe reads a settled node.
+    (interop/activate-derived-value! reaction)
     (when (watchable? reaction)
       (let [wk (gensym "rf-obs-handle")]
         (add-watch reaction wk (make-watch-handler state))

--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -3023,6 +3023,12 @@
       :atom               — (fn [v]) → reactive atom
       :ratom?             — (fn [x]) → boolean (IReactiveAtom check)
       :make-reaction      — (fn [thunk]) → reaction
+      :activate-reaction! — (fn [rx]) → put one of THIS substrate's
+                            reactions on its push path (the missing
+                            `deref-capture`), idempotent and a no-op on
+                            anything that is not one of its reactions.
+                            rf2-8cnxg — see the `:adapter/activate-
+                            derived-value!` routing note below.
       :disposable?        — (fn [x]) → boolean (substrate IDisposable
                             check), used by the dual-protocol dispatch
       :add-on-dispose!    — (fn [a f]) → register a substrate-reaction
@@ -3032,7 +3038,7 @@
       :after-render       — (fn [f]) → schedule post-render callback
 
   Builds the 9-key adapter map, wires the chained SSR emitter install, and
-  routes the nine ratom-family late-bind hooks against the adapter. The two
+  routes the ratom-family late-bind hooks against the adapter. The two
   dual-protocol dispatch hooks (`:adapter/add-on-dispose!` / `:adapter/
   dispose!`) protocol-check the re-frame-owned
   `re-frame.disposable/IDisposable` FIRST (spine-produced derived values
@@ -3046,6 +3052,7 @@
   differ. The former hand-copied route-hook block now lives once."
   [spine-fns {:keys [kind register-context-provider
                      current-frame current-component atom ratom? make-reaction
+                     activate-reaction!
                      disposable? add-on-dispose! dispose! reactive? after-render]}]
   (let [dispose-dispatch (make-ratom-dispose-dispatch disposable? dispose!)
         adapter {:kind                      kind
@@ -3106,6 +3113,33 @@
       (constantly false))
     (substrate-adapter/route-hook! adapter :adapter/make-reaction
       make-reaction)
+    ;; rf2-8cnxg / rf2-jt8vz — the ratom family's derived values are
+    ;; DEMAND-driven, and Spec 006 §`make-derived-value` requires PUSH ("the
+    ;; derived container updates automatically when any source's value
+    ;; changes"; `subscribe-container` "works as on a base container"). A
+    ;; substrate `Reaction` captures its sources only through the
+    ;; substrate's `deref-capture`; a plain `deref` taken OUTSIDE a reactive
+    ;; context, with no `auto-run`, runs the body RAW and leaves the
+    ;; reaction's `watching` nil — so it is watchable, and watched, and
+    ;; notifies nobody. A component render is normally the capture context,
+    ;; which is why an ordinary app never sees this; the observation port's
+    ;; consumer (a compiled ViewCell) is NOT a component of this substrate,
+    ;; so nothing supplies it and the port's `add-watch` observes a node
+    ;; that can never fire. This hook is that missing capture, called by
+    ;; `re-frame.interop/activate-derived-value!` from the port's
+    ;; `build-node-handle!`.
+    ;;
+    ;; ONLY the ratom family publishes it: the React-hook spine's
+    ;; `make-derived-value-fn` wires one watch per source at CONSTRUCTION,
+    ;; so its derived values are push-based from birth and the routed
+    ;; chain-bottom nil is the correct no-op for them. Deliberately NOT
+    ;; `:auto-run true` on `make-derived-value` — that would make every
+    ;; subscription under this substrate recompute SYNCHRONOUSLY inside the
+    ;; app-db `reset!`, discarding the batching this spine's
+    ;; `replace-container!` comment relies on. Activation is per-acquire and
+    ;; idempotent, so an unobserved subscription is never made eager.
+    (substrate-adapter/route-hook! adapter :adapter/activate-derived-value!
+      activate-reaction!)
     (substrate-adapter/route-hook! adapter :adapter/add-on-dispose!
       (fn add-on-dispose!-dispatch [a f]
         (cond

--- a/implementation/freehand/src/re_frame/freehand/substrate.cljs
+++ b/implementation/freehand/src/re_frame/freehand/substrate.cljs
@@ -11,13 +11,24 @@
   Freehand shipped only the first: an interactive Freehand application had to
   install UIx or Reagent to obtain the second.
 
-  The gap was one interface. `re-frame.substrate.plain-atom`'s CLJS derived
-  value reifies `IDeref` but NOT `IWatchable`, and the observation port installs
-  its watch only when the reaction is watchable — so on plain-atom a moving
-  subscription raises no notification at all, and its `:render` slot throws
+  The gap was NOTIFICATION, and `IWatchable` is only half of it.
+  `re-frame.substrate.plain-atom`'s CLJS derived value reifies `IDeref` but NOT
+  `IWatchable`, and the observation port installs its watch only when the
+  reaction is watchable — so on plain-atom a moving subscription raises no
+  notification at all, and its `:render` slot throws
   `:rf.error/render-on-headless-adapter`. `re-frame.substrate.spine`'s derived
-  value DOES reify `IWatchable`. That single difference is the whole reason a
-  Freehand page needed a wrapper library it never rendered through.
+  value DOES reify `IWatchable`, and — the half that matters just as much — it
+  is PUSH-BASED FROM BIRTH: it wires one watch per source at construction, so a
+  watch installed on it genuinely fires.
+
+  Being watchable is necessary and not sufficient, and reading it as sufficient
+  cost a P1 (rf2-8cnxg). A `reagent.ratom/Reaction` is `IWatchable` too, yet it
+  learns its sources only through `deref-capture` — which a ViewCell, not being
+  a Reagent component, never performs — so it satisfied the letter of the test
+  above while notifying nobody. The port now asks the substrate to ACTIVATE a
+  derived value (`re-frame.interop/activate-derived-value!`) rather than
+  assuming a watch suffices; a Freehand cell repaints on the ratom family
+  because of that, not because `Reaction` reifies an interface.
 
   So the spine is what this namespace stands on, and the spine lives in CORE
   (`re-frame.substrate.spine`) — shared by every React-shaped adapter,


### PR DESCRIPTION
Fixes rf2-8cnxg and rf2-jt8vz. They are **one defect seen from two angles**, exactly as suspected: inert subscriptions and a cell that never repaints are the same missing step, one measured at the port and one measured at the DOM.

## The root cause, in one paragraph

`re-frame.substrate.observation/build-node-handle!` installed its per-handle `add-watch` on a stated assumption — *"a watched reaction is live on the reactive hosts, so the observe below reads through the activated node"*. That assumption is **false on the ratom family, and silently so**. A `reagent.ratom/Reaction` learns which sources it depends on **only** by being run through `deref-capture`. `-add-watch` merely records the callback, and `-deref` taken outside `*ratom-context*` with `auto-run` nil takes its non-reactive branch: it runs the body **raw** and leaves `watching` nil. `_handle-change` is therefore never called, `_queued-run` short-circuits on `(some? watching)`, and even `reagent.core/flush` moves nothing. The port held a watch on a node that **could not fire**.

An ordinary Reagent application never notices, because a component render *is* the capture context. A compiled ViewCell is not a Reagent component, so nothing supplied it — and `obs/acquire!` has exactly two production callers, `freehand/cell.cljc` and `ui/reactive.cljc`, both ViewCell substrates. Hence: the dispatch landed, app-db moved, the trace showed the event, `cell/pending-count` stayed **0**, and the DOM never changed.

Read the other way round: Spec 006 §`make-derived-value` already requires push semantics ("the derived container updates automatically when any source's value changes"; `subscribe-container` "works as on a base container"). **Reagent and reagent-slim were non-conformant with that clause** on a surface only ViewCell substrates exercise. The React-hook spine is conformant because `make-derived-value-fn` wires one watch per source *at construction* — push-based from birth.

## The fix

Make the port **activate** the node instead of assuming a watch activates it.

- `re-frame.interop/activate-derived-value!` — routed through a new optional `:adapter/activate-derived-value!` late-bind hook. It rides the late-bind table exactly as `:adapter/derived-container?` does, so **the ten-fn adapter contract shape is unchanged**.
- Published by the **ratom family alone**. Reagent supplies `ratom/run` (its public `IRunnable` op — precisely the capture run); reagent-slim gains `reagent2.ratom/activate!`, because the rewrite deliberately dropped `IRunnable` and only this one operation of it was ever needed. Both are **idempotent** (skip a reaction whose `watching` is already populated) and **total** (no-op off their own derived values — a base `r/atom`, a spine-produced derived value inherited through a cross-substrate bundle, plain junk).
- Absent hook -> routed chain-bottom nil -> **no-op** for the React-hook spine, plain-atom, test-react and the JVM.
- `build-node-handle!` calls it **before** `add-watch` (so activation's own recompute cannot fan a priming note at the acquiring handle) and before the baseline observe, which then reads a settled node — `deref-capture` clears `dirty?`, so activation costs exactly one compute.

**What was deliberately not done.** `:auto-run true` on `make-ratom-spine`'s `make-derived-value` also fixes notification, in one line, and is not shippable: it makes **every** Reagent-hosted subscription recompute *synchronously inside the app-db `reset!`*, discarding the batching this spine's own `replace-container!` comment relies on. Activation is per-**acquire** instead, so an unobserved subscription is never made eager and change handling stays on the ordinary batched path. There is a test that rejects that reading by counting compute-fn invocations.

## What this settles on the beads

- **rf2-8cnxg** — outcome (a): a moving subscription, not a loud refusal. The mixed topology is legitimate.
- **rf2-jt8vz** — remedy (1), not (2). The bead's option (2) ("state plainly that Freehand requires `v/adapter`") was already too strong, and is now moot.
- **The docstrings stand, and are now true.** `re-frame.freehand.substrate` and `v/adapter` bless bring-your-own-adapter for a mixed application; `docs/core/freehand/adoption.md` tells an existing Reagent app to install Freehand next to what it ships. Those needed no retraction — they needed the substrate to keep the promise. **No fenced code block under `docs/core/freehand/` was touched**, so `samples_coverage_jvm_test.clj` is untouched.
- **rf2-jt8vz's headline no longer holds, and that is the point.** "No single host both repaints a Freehand cell reactively AND renders Xray's Views panel" — a **Reagent** host now does both: it repaints (this PR), and Xray's refusal set is `#{:rf.adapter/ui :rf.adapter/uix :rf.adapter/helix :rf.adapter/freehand}`, which does not include Reagent. rf2-qgfo4 remains the route to Xray-over-`v/adapter` and is unaffected.
- One prose correction inside the fence: `re-frame.freehand.substrate`'s "the gap was one interface ... that single difference is the whole reason". `IWatchable` is **necessary and not sufficient**, and reading it as sufficient is what cost this P1.

## The evidence that the tests hit the real failing path

Both new suites were run against a build with the single `(interop/activate-derived-value! reaction)` line commented out.

| falsifier run | result |
|---|---|
| `:node-test`, new port suite only | **11 failures** (green with the fix) |
| `:browser-test`, whole lane | **15 failures** — 7 in the new mounted Freehand suite, 8 in the de-drivered mounted sibling |

The mounted arm reproduces the operator's measurement verbatim:

```
FAIL in (a-freehand-cell-repaints-under-the-reagent-adapter)
  THE MEASUREMENT THAT WAS ZERO: ...
  expected: (pos? (cell/pending-count))
    actual: (not (pos? 0))
  expected: (= "1" (text container "#compiled"))
    actual: (not (= "1" "0"))
```

## Tests

**New — `implementation/adapters/reagent/test/re_frame/`** (beside the sibling cross-adapter port suites; deliberately *not* under `implementation/freehand/`, whose whole claim is that it names no adapter):

- `freehand_cell_under_ratom_adapter_dom_cljs_test.cljs` — mounts a Freehand `v/mount` root under `re-frame.adapter.reagent/adapter` in real Chromium and reads the repaint back off `document`: a `dispatch-sync` arm (0 -> 1 -> 2, asserting `cell/pending-count` moved off 0), a **real DOM press** arm, and an adversarial no-movement arm (an equal re-write and an unrelated-key write dirty no cell and repaint nothing, with a positive control so the silences are not a dead channel).
- `observation_port_activates_ratom_node_cljs_test.cljs` — the port-level unit: acquire **alone**, no driver, puts the node on the push path. Adversarial half: an unobserved subscription is never made eager (compute-count, rejecting `:auto-run true`); activation is idempotent across two owners of one node (no phantom note at owner 1, one note per handle per movement); a released handle hears nothing while the node stays live for the survivor; the op is a total no-op on a base container / nil / a bare `IDeref` double / a raw JS object; and the op's own contract on a raw Reagent reaction (exactly one capture run, second call runs nothing, and it then notifies on a source move).

**Flipped, not deleted.** Both existing port suites stood a `reagent.ratom/run!` **driver**, documented as "the port watch is a passive observer; in production the ViewCell render is the active consumer that keeps the lazy reaction on the push path". Both halves were wrong, and the driver was not a test convenience — it was **this missing runtime step, hand-supplied**, which is precisely why those suites never caught the defect. The drivers are removed and the rationale corrected; the browser falsifier above shows the mounted sibling now fails without the fix, so it has become a genuine regression detector rather than a workaround.

## Quality gates

| gate | result | exit |
|---|---|---|
| `implementation$ npm run test:cljs` | Ran 11593 tests / 58183 assertions — **0 failures, 0 errors** | `0` |
| `implementation$ npm run test:browser` (`:browser-test`, real Chromium) | Ran 817 tests / 5198 assertions — **0 failures, 0 errors** | `0` |
| `implementation/core$ clojure -M:test` | Ran 2126 tests / 10495 assertions — **0 failures, 0 errors** | `0` |
| `implementation/freehand$ clojure -M:test` | Ran 1215 tests / 8130 assertions — **0 failures, 0 errors** | `0` |
| `implementation$ npm run test:adapter-smokes` (reagent + uix + ui testbeds) | Ran 3 adapter-smoke specs — **0 failures** | `0` |
| `implementation$ npm run test:reagent-slim:smoke` | Ran 1 reagent-slim client-runtime smoke — **0 failures** | `0` |
| `scripts/test-fast-pr.sh` | **PASS fast PR spine** — JVM core / adapters.reagent / adapters.reagent-slim / freehand, CLJS node integration, per-ns isolation, path + doc policy | `0` |

Notes on the gates:

- `npm run test:browser` needed `BROWSER_TEST_TIMEOUT_MS=300000`. The first attempt died on Playwright's default **30 s `page.goto`** navigation timeout with only 3 namespaces run, on a machine shared with several concurrent workers. That timeout is hard-coded at `scripts/run-browser-tests.cjs:213` and is *not* governed by the env var above — worth a look, but out of scope here.
- Both ratom adapters changed, so both browser smokes were run. The `:browser-test` lane is the one that actually catches this bug class, so it was not skipped.
- `mkdocs --strict` soft-skipped locally (mkdocs not on PATH); CI runs it. No docs page changed.

## Out of fence, filed rather than done

- **rf2-h24yb** (P2) — spec/006 should say that a derived container must be **activated**, not merely watchable, and document the new hook beside `:adapter/derived-container?`. `spec/006-ReactiveSubstrate.md` is hot-zone; the fix needed no spec change to be conformant, because the spec already required push semantics — the ratom family simply did not deliver them.
- **rf2-r83ni** (P2) — `tools/xray/testbeds/freehand_views/core.cljs`, `tools/xray/spec/017-Test-Coverage-Matrix.md` and `implementation/shadow-cljs.edn` each record "the adapter supplies the observation half (a watchable derived value, which is all a ViewCell's reads need)" as a standing fact. That was false when written and is true now only because of this PR; the wording should name activation. Includes the `core.cljs:128` "advances the committed generation" sentence flagged in the merged-PR audit of #7075 — still wrong, since `cell/generation` is the hot-reload body revision rather than a render tally.
