### PR TITLE
test(xray): pin the CLJS camel-boundary regression directly (rf2-odlm3)

### DIFF
--- a/tools/xray/test/day8/re_frame2_xray/palette/fuzzy_cljs_test.cljc
+++ b/tools/xray/test/day8/re_frame2_xray/palette/fuzzy_cljs_test.cljc
@@ -64,6 +64,30 @@
           "ED on the EventDetail camel boundaries should beat Ed at
            the start of Editable"))))
 
+(deftest camel-boundary-credited-on-both-runtimes
+  ;; rf2-odlm3 REGRESSION PIN for a bug that shipped and ran in production.
+  ;;
+  ;; `upper?` / `lower?` read a character's code unit, and they used to do it
+  ;; with `(int ch)`. That is the code point on the JVM, but `cljs.core/int` is
+  ;; `(bit-or x 0)`, and JavaScript coerces a non-numeric string to 0 — and
+  ;; `(nth some-string idx)` yields a one-character STRING under CLJS. Both
+  ;; predicates therefore answered false for EVERY character in the browser,
+  ;; which is the only place the palette runs, so both bonuses that depend on
+  ;; them went dead: `word-start?`'s camelCase branch and the explicit
+  ;; camel-boundary bonus in the scoring loop. Separator word-starts were
+  ;; unaffected — `\- `\_ and friends compare fine as one-character strings —
+  ;; which is exactly why nothing else in this file noticed.
+  ;;
+  ;; The two candidates below are the SAME LENGTH, the query matches at the
+  ;; SAME TWO INDICES in both, and neither contains a separator. Prefix, gap,
+  ;; run and word-start-by-separator contributions are therefore identical, and
+  ;; the camelCase boundary is the only thing that can separate the scores.
+  ;; This cannot be satisfied by the separator path, and it fails on any host
+  ;; where `char-code` regresses.
+  (testing "a camelCase boundary outscores the same match with no boundary"
+    (is (> (fuzzy/score "openTimeTravel" "tt")
+           (fuzzy/score "opentimetravel" "tt")))))
+
 (deftest consecutive-match-run-bonus
   (testing "consecutive matched chars score higher than scattered ones"
     (let [run        (fuzzy/score "abcdef" "abc")


### PR DESCRIPTION
Follow-up to #7116, which merged while this commit was in flight — so it is the one piece of that cluster not on `main`.

#7116 fixed a real production bug in Xray's command palette: `palette/fuzzy.cljc` computed `(int ch)` on a character taken from a string, which is a code point on the JVM but `(bit-or x 0)` in CLJS, where `(nth some-string idx)` yields a one-character **string** that JavaScript coerces to `0`. `upper?` and `lower?` therefore answered false for every character in the browser — the only place the palette runs — and both bonuses depending on them went dead. The `char-code` fix is on `main`; this adds the pin that keeps it there.

## Why the existing test is not enough

`camelcase-boundary-bonus` caught the defect, but **incidentally**. It compares two different strings (`"EventDetail"`/`"ED"` vs `"Editable"`/`"Ed"`), so prefix, gap and run contributions all differ too — a future weight change could make it pass for the wrong reason, and the pin would stop pinning without anyone noticing.

`camel-boundary-credited-on-both-runtimes` isolates the mechanism. Both candidates are the same length, contain **no separator**, and the query matches at the **same two indices** in each, so prefix, gap, run and word-start-by-separator contributions are identical and the camelCase boundary is the only thing that can separate the scores. It cannot be satisfied by the separator path — which is exactly the path that kept working under CLJS and hid the defect from every other test in the file.

## Quality gates

| gate | result | exit |
|---|---|---|
| `cd tools/xray && clojure -M:test` (on this branch, rebased on current `main`) | **PASS** — 1271 tests / 5909 assertions, 0 failures | **0** |
| `npm run test:cljs` (`:node-test`) — run on the pre-merge branch carrying this identical commit | **PASS** — 11758 tests / 58518 assertions, 0 failures | **0** |

**Mutation-proved both directions** on the real node-test lane: restore `(int ch)` and this test plus `camelcase-boundary-bonus` fail (2 failures, rc=1, 11758 tests); restore the portable `char-code` and the same 11758 pass, rc=0. A regression test that has not been seen to fail is not one.

Test-only, one file, 24 insertions. `tools/xray/spec/*` unchanged because this adds no contract — `spec/007-UX-IA.md` already specifies the camelCase-boundary behaviour correctly, and #7116 updated `017-Test-Coverage-Matrix.md` for the rename.