### PR TITLE
fix(routing): reject a path param the route pattern does not capture (rf2-0iuh3)

### DIFF
--- a/implementation/routing/src/re_frame/routing/registry.cljc
+++ b/implementation/routing/src/re_frame/routing/registry.cljc
@@ -1602,6 +1602,44 @@
               :slot     :fragment
               :value    fragment}))))
 
+(defn- uncaptured-param-keys
+  "The `:params` keys whose route PATTERN has no `:name` / `*name` segment to
+  put them in — the address keys `route-url` would otherwise ignore in silence
+  (rf2-0iuh3). Returns them in the total canonical order
+  (`identity/canonical-bytes`) the rest of routing reports key sets in, or nil
+  when every supplied key is captured.
+
+  The capture vocabulary is the compiled pattern's `:names`
+  (`match/parse-pattern`, precomputed at registration into
+  `:rf.route/compiled`) — the SAME left-to-right capture list `match-against`
+  zips a matched URL's groups onto, so what counts as a path param on the
+  emission side is exactly what counts on the matching side. An optional
+  group's inner name is captured whether or not the group ends up emitted:
+  elision is a value-level decision, not a vocabulary one.
+
+  The reserved `:rf.route/not-found` route is EXEMPT, and it is the only
+  exemption. Its slice `:params` are not path captures at all — they are the
+  framework's fact record of the miss (`{:url … :reason …}`, built by the one
+  producer `plan/not-found-params`), so the fallback route's pattern is not
+  their source and has no say over their vocabulary. Without the exemption the
+  address-bar restore after a URL-driven rejection
+  (`decisions/current-slice->url`) would silently stop rebuilding a registered
+  not-found route's URL.
+
+  Nil-safe over a non-map `:params`: such an address keeps its existing
+  failure mode (a missing required segment) rather than throwing a host
+  `ClassCastException` out of `keys`."
+  [route-id route-meta pattern path-params]
+  (when (and (map? path-params)
+             (seq path-params)
+             (not= :rf.route/not-found route-id))
+    (let [names      (or (:names (:rf.route/compiled route-meta))
+                         (:names (match/parse-pattern pattern)))
+          captured   (into #{} (map keyword) names)
+          uncaptured (remove captured (keys path-params))]
+      (when (seq uncaptured)
+        (vec (sort-by identity/canonical-bytes uncaptured))))))
+
 (defn route-url
   "Per Spec 012 §Bidirectional URL ↔ params. Build a URL string from a
   single ADDRESS map `{:to <route-id> :params <path-params> :query
@@ -1613,6 +1651,32 @@
   (`:rf.error/route-url-validation`, `:reason :bad-address-keys`) rather than
   silently ignored. There is no in-place form (a pure helper cannot read the
   current route); callers project their request/target into the address map.
+
+  The same closure holds one level down, over the CONTENTS of `:params`
+  (rf2-0iuh3): a path param the route's pattern does not capture is rejected
+  LOUD (`:rf.error/route-url-validation`, `:reason :uncaptured-params`) rather
+  than dropped on the floor. `/probe/:id` with `{:id \"7\" :extra \"x\"}` used
+  to build `/probe/7` and say nothing, which split the navigation doors: the
+  programmatic door committed `:params {:id \"7\" :extra \"x\"}` (a slice its
+  own address bar could not spell, and a reload could not reproduce) while a
+  `route-link` CLICK resolved through the URL and committed `{:id \"7\"}` —
+  and `[:rf.route/prefetch …]` followed the programmatic answer, so hovering a
+  link warmed one resource identity and clicking that same link activated
+  another. This is the emission boundary all three named-address doors already
+  share (the programmatic door's URL build, `route-link`'s href synthesis, and
+  prefetch's destination gate), so one rule here settles all three; the
+  URL-driven doors need no rule, because a URL physically cannot carry an
+  uncaptured param.
+
+  Rejecting rather than truncating is the same fail-closed-on-emission rule
+  this fn already applies to every other input that breaks the
+  `route-url` / `match-url` prism — the empty-string segment and the
+  sequential-optional-group prefix chain below both refuse to emit a URL that
+  cannot round-trip, and Spec 012 §Validity rules rule 2 names silently-ignored
+  address keys as \"the exact failure class this grammar exists to kill\".
+  Truncation would also lose a typo class nothing else catches: on
+  `/docs{/:section}?`, `{:sction \"x\"}` elides the group and builds `/docs`
+  clean, so `:rf.error/missing-route-param` never fires.
 
   Optional groups ({...}?) are emitted only when ALL their inner params
   are supplied in `:params`; otherwise the group is silently elided.
@@ -1746,6 +1810,32 @@
                 'rf.routing/route-url
                 (str "no route is registered under id " route-id)
                 {:route-id route-id})))
+     ;; rf2-0iuh3 — the address closure, one level down. A `:params` key the
+     ;; pattern does not capture has no URL to go to and no `match-url` reading
+     ;; that recovers it, so it is rejected here rather than ignored (see this
+     ;; fn's docstring for the door split silence produced). Checked BEFORE the
+     ;; `:params` schema below: an unknown key is a fact about the ROUTE, not
+     ;; about the author's declared value shape, and naming it is the more
+     ;; useful diagnostic when both are wrong. Reports STRUCTURE only — the
+     ;; offending keys and the slot, never a value — so an uncaptured
+     ;; `{:token "…"}` cannot ride an error surface (the navigate door's
+     ;; `redact-route-error-tags` scrubs `:value`-bearing ex-data only on a
+     ;; `:sensitive?` route; this shape has nothing to scrub on any route).
+     (when-let [uncaptured (uncaptured-param-keys route-id route-meta pattern path-params)]
+       (throw (route-error
+                :rf.error/route-url-validation
+                'rf.routing/route-url
+                (str "route " route-id " has no path segment for param(s) "
+                     (pr-str uncaptured) " — its pattern " (pr-str pattern)
+                     " captures "
+                     (pr-str (mapv keyword (:names (:rf.route/compiled route-meta))))
+                     ", so route-url cannot put them in the URL and match-url "
+                     "cannot read them back. Drop them from :params, move them "
+                     "to :query, or add the segment to the route's pattern.")
+                {:route-id route-id
+                 :slot     :params
+                 :keys     uncaptured
+                 :reason   :uncaptured-params})))
      ;; Per Spec 012 §Bidirectional URL ↔ params: validate the caller's
      ;; inputs against the route's :params / :query schemas BEFORE
      ;; emitting the URL. A schema mismatch is a caller bug; raise with

--- a/implementation/routing/test/re_frame/routing_prefetch_test.clj
+++ b/implementation/routing/test/re_frame/routing_prefetch_test.clj
@@ -301,12 +301,14 @@
 ;; Each case additionally pins the canonical expected identity as a literal, so
 ;; neither arm can pass merely because its two sides match.
 ;;
-;; KNOWN GAP, deliberately not asserted either way here: a path param the route
-;; PATTERN does not capture (`{:id "7" :extra "x"}` on `/probe/:id`). The
-;; programmatic door commits it, a link click drops it (the URL cannot carry
-;; it), and prefetch follows the programmatic door. That is a disagreement
-;; between the two ACTIVATION doors which prefetch merely inherits, and
-;; resolving it is a contract ruling on `:rf.route/navigate` — rf2-0iuh3.
+;; The former KNOWN GAP here — a path param the route PATTERN does not capture
+;; (`{:id "7" :extra "x"}` on `/probe/:id`), which the programmatic door
+;; committed, a link click dropped, and prefetch inherited from the
+;; programmatic door — is SETTLED (rf2-0iuh3): neither committed value wins;
+;; the address rejects LOUD at `route-url`, the shared emission boundary all
+;; three named-address doors already run through. Prefetch therefore refuses it
+;; through the destination gate above, needing no code of its own. Asserted in
+;; `re-frame.routing-uncaptured-param-test`.
 
 (defn- with-identity-hooks
   "Publish BOTH late-bound resource hooks — the prefetch WARM plan and the

--- a/implementation/routing/test/re_frame/routing_registry_test.clj
+++ b/implementation/routing/test/re_frame/routing_registry_test.clj
@@ -765,26 +765,58 @@
            (routing/route-url {:to :route/docs3 :params {:page "x"} :query {} :fragment "scroll-restoration"}))
         "safe characters (letters, digits, `-`) are not percent-encoded")))
 
-;; ---- route-url ignores path-params not named by the pattern --------------
+;; ---- route-url REJECTS path-params not named by the pattern --------------
 ;;
-;; route-url's emitter consumes only the `:`/`*` segments it walks in the
-;; pattern. Extra keys in path-params (a common call-site over-supply, e.g.
-;; passing the whole slice's :params back through) must be silently ignored,
-;; not leaked into the URL. Pinned here so a future emitter refactor can't
-;; start round-tripping stray keys into the path.
+;; FLIPPED from `route-url-ignores-extra-path-params` (rf2-0iuh3). This test
+;; used to pin the opposite answer — that route-url's emitter consumes only the
+;; `:`/`*` segments it walks, so extra keys in path-params are SILENTLY
+;; ignored — on the reasoning that a call site might over-supply by passing a
+;; whole slice's `:params` back through.
+;;
+;; That silence split the navigation doors. `/probe/:id` with
+;; `{:id "7" :extra "x"}` built `/probe/7`, so the programmatic door committed
+;; `:params {:id "7" :extra "x"}` (a slice its own address bar could not spell,
+;; and a page reload could not reproduce) while a route-link CLICK resolved
+;; through that URL and committed `{:id "7"}` — with `[:rf.route/prefetch …]`
+;; following the programmatic answer, so hovering a link warmed one resource
+;; identity and clicking the same link activated another. An uncaptured path
+;; param is a prism break, and route-url already fails closed on emission for
+;; every other one (the empty-string segment; the sequential-optional-group
+;; prefix chain). The over-supply case the old reasoning protected is real but
+;; narrow — a slice's params came FROM a match, so they are captured by
+;; construction — and the one framework instance of it, the reserved
+;; `:rf.route/not-found` slice's `{:url … :reason …}` fact record, is exempt.
+;;
+;; Cross-door coverage (both activation doors + prefetch + the optional-group
+;; typo the missing-param error can never catch) lives in
+;; `re-frame.routing-uncaptured-param-test`.
 
-(deftest route-url-ignores-extra-path-params
-  (testing "path-params keys not named by the route pattern are ignored"
+(deftest route-url-rejects-extra-path-params
+  (testing "path-params keys not named by the route pattern reject LOUD"
     (rf/reg-route :route/article {} "/articles/:id")
     (is (= "/articles/intro"
-           (routing/route-url {:to :route/article :params {:id "intro" :stray "ignored" :extra 99}}))
-        "only the pattern's :id segment is emitted; :stray / :extra are dropped"))
+           (routing/route-url {:to :route/article :params {:id "intro"}}))
+        "POSITIVE CONTROL — the captured param still emits its segment")
+    (let [data (try (routing/route-url {:to     :route/article
+                                        :params {:id "intro" :stray "x" :extra 99}})
+                    nil
+                    (catch Throwable ex (ex-data ex)))]
+      (is (= :rf.error/route-url-validation (:rf.error/id data))
+          ":stray / :extra are named, not dropped on the floor")
+      (is (= :uncaptured-params (:reason data)))
+      (is (= [:extra :stray] (:keys data))
+          "every uncaptured key, in the total canonical order")
+      (is (= :route/article (:route-id data)))))
 
-  (testing "a route with no path params ignores any supplied path-params"
+  (testing "a route with no path params rejects any supplied path-param"
     (rf/reg-route :route/home {} "/")
-    (is (= "/"
-           (routing/route-url {:to :route/home :params {:anything "here"}}))
-        "a param-less pattern emits its literal path regardless of supplied params")))
+    (is (= "/" (routing/route-url {:to :route/home :params {}}))
+        "POSITIVE CONTROL — a param-less pattern emits its literal path")
+    (let [data (try (routing/route-url {:to :route/home :params {:anything "here"}})
+                    nil
+                    (catch Throwable ex (ex-data ex)))]
+      (is (= :uncaptured-params (:reason data)))
+      (is (= [:anything] (:keys data))))))
 
 (deftest match-url-flags-validation-failure
   (testing "match-url surfaces :validation-failed? + :validation-error

--- a/implementation/routing/test/re_frame/routing_uncaptured_param_test.clj
+++ b/implementation/routing/test/re_frame/routing_uncaptured_param_test.clj
@@ -145,7 +145,21 @@
     (let [data (thrown-data #(registry/route-url {:to     :route/plain
                                                   :params {:url "/nope"}}))]
       (is (= :uncaptured-params (:reason data)))
-      (is (= [:url] (:keys data))))))
+      (is (= [:url] (:keys data)))))
+
+  (testing "the exemption is load-bearing on a LIVE door, not just on the
+            best-effort address-bar restore: an in-place query edit while
+            parked on the fallback carries the miss record back through
+            route-url, and an unexempted fallback would reject it"
+    (rf/dispatch-sync [:rf.route/transitioned "/nope"])
+    (is (= :rf.route/not-found (:route-id (current-slice))))
+    (is (= {:url "/nope"} (:params (current-slice)))
+        "the miss record is the fallback's :params — never path captures")
+    (rf/dispatch-sync [:rf.route/navigate {:query {:x "1"}}])
+    (is (= {:x "1"} (:query (current-slice)))
+        "the in-place edit committed rather than rejecting")
+    (is (= {:url "/nope"} (:params (current-slice)))
+        "and the miss record survived the edit unchanged")))
 
 ;; ===========================================================================
 ;; The two ACTIVATION doors agree

--- a/implementation/routing/test/re_frame/routing_uncaptured_param_test.clj
+++ b/implementation/routing/test/re_frame/routing_uncaptured_param_test.clj
@@ -1,0 +1,216 @@
+(ns re-frame.routing-uncaptured-param-test
+  "rf2-0iuh3 — a `:params` key the route PATTERN does not capture.
+
+  Route `/probe/:id`, address `{:to :route/probe :params {:id \"7\" :extra \"x\"}}`.
+  `:extra` names no `:name` / `*name` segment, so `route-url` cannot put it in
+  the URL and `match-url` cannot read it back. Before this namespace the two
+  ACTIVATION doors disagreed about what that address MEANS:
+
+      [:rf.route/navigate {:to :route/probe :params {:id \"7\" :extra \"x\"}}]
+        committed  :params {:id \"7\" :extra \"x\"}
+      a route-link CLICK -> [:rf.route/url-requested {:url \"/probe/7\" …}]
+        committed  :params {:id \"7\"}        (it resolves through the URL)
+      [:rf.route/prefetch …] warmed {:id \"7\" :extra \"x\"}
+
+  So hovering a link warmed one resource identity and clicking that SAME link
+  activated another. The root cause is the door disagreement, not prefetch:
+  Spec 012 §The one planning pipeline says doors differ in cause and history /
+  scroll policy, NOT in target.
+
+  THE ANSWER: neither committed value. An uncaptured path param is REJECTED
+  LOUD at `route-url`, the one registry-aware emission boundary all three
+  named-address doors already share. Spec 012 §Validity rules rule 2 already
+  states the principle in as many words — letting address keys \"ride beside it
+  and be silently ignored is the exact failure class this grammar exists to
+  kill\" — and `route-url` already fails CLOSED on emission for every other
+  input that breaks the `route-url` / `match-url` prism: the empty-string
+  segment (`\"\"` cannot round-trip through trailing-slash normalisation) and
+  the sequential-optional-group prefix rule (a later group emitted after an
+  earlier one elided lands in the wrong capture slot). An uncaptured param is
+  the same class and was the one remaining hole.
+
+  Truncating instead (committing `{:id \"7\"}` from every door) would have been
+  silent but total, and it loses the typo an optional group can hide:
+  `/docs{/:section}?` with `{:sction \"x\"}` elides the group, builds `/docs`,
+  and throws nothing — so `route-url`'s own `:rf.error/missing-route-param` can
+  never catch that misspelling. Rejecting does.
+
+  Covers the emission boundary, both activation doors, prefetch, and the
+  adversarial trio the fix has to keep apart: a param that IS captured, a param
+  that is NOT, and a route with no params at all."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.fx :as fx]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.routing :as routing]
+            [re-frame.routing.link :as link]
+            [re-frame.routing.registry :as registry]
+            [re-frame.routing-test-support :as rts]
+            [re-frame.test-support :refer [with-trace-recorder!]]))
+
+(use-fixtures :each rts/reset-runtime)
+
+;; ---- fixtures --------------------------------------------------------------
+
+(defn- register-routes! []
+  (routing/reg-route :route/elsewhere {} "/elsewhere")
+  (routing/reg-route :route/probe     {} "/probe/:id")
+  (routing/reg-route :route/plain     {} "/plain")
+  (routing/reg-route :route/docs      {} "/docs{/:section}?")
+  (routing/reg-route :route/files     {} "/files/*rest"))
+
+(defn- current-slice []
+  (get-in (:rf.db/runtime (rf/frame-state-value :rf/default))
+          [:rf.runtime/routing :current]))
+
+(defn- thrown-data
+  "`(ex-data ...)` of the throw `f` raises, or nil when it returns normally."
+  [f]
+  (try (f) nil
+       (catch Throwable ex (ex-data ex))))
+
+;; ===========================================================================
+;; The emission boundary — route-url
+;; ===========================================================================
+
+(deftest route-url-rejects-a-path-param-the-pattern-does-not-capture
+  (register-routes!)
+
+  (testing "POSITIVE CONTROL — a param the pattern DOES capture builds its URL"
+    (is (= "/probe/7" (registry/route-url {:to :route/probe :params {:id "7"}})))
+    (is (= "/plain"   (registry/route-url {:to :route/plain :params {}})))
+    (is (= "/plain"   (registry/route-url {:to :route/plain})))
+    (testing "including an optional-group inner name, present or elided"
+      (is (= "/docs/api" (registry/route-url {:to :route/docs :params {:section "api"}})))
+      (is (= "/docs"     (registry/route-url {:to :route/docs :params {}}))))
+    (testing "and a splat name"
+      (is (= "/files/a/b" (registry/route-url {:to :route/files :params {:rest "a/b"}})))))
+
+  (testing "a param the pattern does not capture is rejected LOUD"
+    (let [data (thrown-data #(registry/route-url {:to     :route/probe
+                                                  :params {:id "7" :extra "x"}}))]
+      (is (some? data) "route-url threw rather than silently building /probe/7")
+      (is (= :rf.error/route-url-validation (:rf.error/id data)))
+      (is (= :uncaptured-params (:reason data)))
+      (is (= [:extra] (:keys data)) "the offending param KEY is named")
+      (is (= :params (:slot data)) "the offending SLOT is named, for prefetch's projection")
+      (is (= :route/probe (:route-id data)))
+      (is (= 'rf.routing/route-url (:where data)))))
+
+  (testing "a route with NO path params at all rejects any param"
+    (let [data (thrown-data #(registry/route-url {:to :route/plain :params {:anything 1}}))]
+      (is (= :uncaptured-params (:reason data)))
+      (is (= [:anything] (:keys data)))
+      (is (= :route/plain (:route-id data)))))
+
+  (testing "an optional group's inner name is CAPTURED even when the group
+            elides — the typo beside it is what rejects"
+    (is (= "/docs" (registry/route-url {:to :route/docs :params {}})))
+    (let [data (thrown-data #(registry/route-url {:to :route/docs :params {:sction "x"}}))]
+      (is (= :uncaptured-params (:reason data))
+          "the misspelling `:sction` is caught — route-url's own
+           :rf.error/missing-route-param never could, because the group simply
+           elides and /docs builds cleanly")
+      (is (= [:sction] (:keys data)))))
+
+  (testing "every uncaptured key is named, in the total canonical order the
+            rest of routing reports key sets in"
+    (let [data (thrown-data #(registry/route-url {:to     :route/probe
+                                                 :params {:id "7" :zeta 1 :alpha 2}}))]
+      (is (= [:alpha :zeta] (:keys data)))))
+
+  (testing "the rejection names STRUCTURE only — it carries no param VALUE, so
+            a secret in an uncaptured key never reaches an error surface"
+    (let [data (thrown-data #(registry/route-url {:to     :route/probe
+                                                 :params {:id "7" :token "SECRET-100"}}))]
+      (is (not (contains? data :value)))
+      (is (not (re-find #"SECRET-100" (pr-str data))))
+      (is (not (re-find #"SECRET-100" (pr-str (:keys data))))))))
+
+;; ===========================================================================
+;; The two ACTIVATION doors agree
+;; ===========================================================================
+
+(deftest both-activation-doors-agree-on-an-uncaptured-param
+  (register-routes!)
+  (let [pushed (atom [])]
+    (fx/reg-fx :rf.nav/push-url {:platforms #{:server :client}}
+               (fn [_ url] (swap! pushed conj url)))
+
+    (testing "POSITIVE CONTROL — the well-formed sibling address commits the
+              SAME params through both doors"
+      (rf/dispatch-sync [:rf.route/navigate {:to :route/probe :params {:id "7"}}])
+      (is (= {:id "7"} (:params (current-slice))) "programmatic door")
+      (rf/dispatch-sync [:rf.route/navigate {:to :route/elsewhere}])
+      (rf/dispatch-sync (:payload (link/link-model {:to :route/probe :params {:id "7"}}
+                                                   :rf/default)))
+      (is (= :route/probe (:route-id (current-slice))))
+      (is (= {:id "7"} (:params (current-slice))) "link door"))
+
+    (testing "the PROGRAMMATIC door rejects an uncaptured param — it used to
+              commit :params {:id \"7\" :extra \"x\"}, a slice the address bar
+              could not spell and a reload could not reproduce"
+      (rf/dispatch-sync [:rf.route/navigate {:to :route/elsewhere}])
+      (reset! pushed [])
+      (let [before (current-slice)]
+        (with-trace-recorder!
+          [traces {:pred #(= :rf.error/schema-validation-failure (:operation %))}]
+          (rf/dispatch-sync [:rf.route/navigate {:to     :route/probe
+                                                 :params {:id "7" :extra "x"}}])
+          (is (= 1 (count @traces)) "the caller bug surfaces on the always-on channel")
+          (is (= :route/probe (:route-id (:tags (first @traces))))))
+        (is (= before (current-slice)) "slice unchanged — nothing was committed")
+        (is (= :route/elsewhere (:route-id (current-slice))))
+        (is (empty? @pushed) "and no history entry was pushed")))
+
+    (testing "the LINK door rejects the same address at href synthesis, so the
+              click payload that used to commit :params {:id \"7\"} can never be
+              built — the two doors no longer disagree, they agree to refuse"
+      (let [data (thrown-data #(link/link-model {:to     :route/probe
+                                                 :params {:id "7" :extra "x"}}
+                                                :rf/default))]
+        (is (= :rf.error/route-url-validation (:rf.error/id data)))
+        (is (= :uncaptured-params (:reason data)))
+        (is (= [:extra] (:keys data)))))))
+
+;; ===========================================================================
+;; Prefetch inherits the agreed answer
+;; ===========================================================================
+
+(deftest prefetch-rejects-the-address-both-activation-doors-refuse
+  (register-routes!)
+  (let [calls (atom [])]
+    (late-bind/set-fn! :routing/on-route-prefetch
+                       (fn [plan] (swap! calls conj (select-keys plan [:route-id :params]))
+                         {:warmed 1 :fx []}))
+    (try
+      (let [collect (fn [address]
+                      (with-trace-recorder!
+                        [traces {:pred  #(contains? #{:rf.route/prefetched
+                                                      :rf.error/prefetch-bad-address}
+                                                    (:operation %))
+                                 :shape :by-op}]
+                        (rf/dispatch-sync [:rf.route/prefetch address])
+                        {:prefetched (:rf.route/prefetched @traces)
+                         :rejected   (:rf.error/prefetch-bad-address @traces)}))]
+        (testing "POSITIVE CONTROL — the captured-param address still warms"
+          (let [{:keys [prefetched rejected]} (collect {:to :route/probe :params {:id "7"}})]
+            (is (empty? rejected))
+            (is (= 1 (count prefetched)))
+            (is (= [{:route-id :route/probe :params {:id "7"}}] @calls))))
+
+        (testing "an uncaptured param rejects BEFORE planning, on the SAME
+                  boundary the activation doors refuse it at — prefetch warmed
+                  {:id \"7\" :extra \"x\"} while a click activated {:id \"7\"}"
+          (reset! calls [])
+          (let [{:keys [prefetched rejected]}
+                (collect {:to :route/probe :params {:id "7" :extra "x"}})]
+            (is (empty? prefetched) "no success summary trace")
+            (is (empty? @calls) "the warm hook was never consulted — no ensures")
+            (is (= 1 (count rejected)))
+            (let [tags (:tags (first rejected))]
+              (is (= :route-url-validation (:reason tags))
+                  "the bare name of the boundary's error id, as Spec 009 specifies")
+              (is (= [:params] (:keys tags)) "the offending SLOT is named")
+              (is (= :route/probe (:route-id tags)))))))
+      (finally (late-bind/set-fn! :routing/on-route-prefetch nil)))))

--- a/implementation/routing/test/re_frame/routing_uncaptured_param_test.clj
+++ b/implementation/routing/test/re_frame/routing_uncaptured_param_test.clj
@@ -127,6 +127,26 @@
       (is (not (re-find #"SECRET-100" (pr-str data))))
       (is (not (re-find #"SECRET-100" (pr-str (:keys data))))))))
 
+(deftest the-reserved-not-found-route-is-the-one-exemption
+  ;; `:rf.route/not-found`'s slice `:params` are the framework's FACT record of
+  ;; the miss (`plan/not-found-params` → `{:url … :reason …}`), not path
+  ;; captures, so the fallback route's pattern has no say over their
+  ;; vocabulary. Without the exemption the address-bar restore after a
+  ;; URL-driven rejection (`decisions/current-slice->url`, which rebuilds the
+  ;; CURRENT slice through route-url) would silently stop rebuilding a
+  ;; registered not-found route's URL.
+  (register-routes!)
+  (routing/reg-route :rf.route/not-found {} "/404")
+  (is (= "/404" (registry/route-url {:to     :rf.route/not-found
+                                     :params {:url "/nope" :reason :malformed-url}}))
+      "the miss record rides through rather than rejecting")
+  (testing "and the exemption is scoped to that ONE reserved id — an ordinary
+            route with the same-shaped params still rejects"
+    (let [data (thrown-data #(registry/route-url {:to     :route/plain
+                                                  :params {:url "/nope"}}))]
+      (is (= :uncaptured-params (:reason data)))
+      (is (= [:url] (:keys data))))))
+
 ;; ===========================================================================
 ;; The two ACTIVATION doors agree
 ;; ===========================================================================


### PR DESCRIPTION
Closes rf2-0iuh3.

## The disagreement

Route `/probe/:id`. Address `{:to :route/probe :params {:id "7" :extra "x"}}` — `:extra` names no capture, so `route-url` silently built `/probe/7`. The two **activation doors** then disagreed about what that address meant. Reproduced on the JVM by the new test **before** any behaviour changed (27 failing assertions, and the failure output is the bead's measurement verbatim):

| door | committed / warmed |
|---|---|
| `[:rf.route/navigate {:to … :params {:id "7" :extra "x"}}]` | `:params {:id "7" :extra "x"}`, pushed `/probe/7` |
| a `route-link` CLICK → `[:rf.route/url-requested {:url "/probe/7" …}]` | `:params {:id "7"}` — it resolves through the URL |
| `[:rf.route/prefetch …]` | warmed `{:id "7" :extra "x"}` — it follows the programmatic door |

So hovering a link warmed one resource identity and clicking that same link activated another — EP-0037 R3's original failure mode by a different route. Prefetch was never the origin; it inherits one of the two answers.

## The decision, and why

**Neither committed value wins. An uncaptured path param is rejected LOUD at `route-url`** — `:rf.error/route-url-validation`, `:reason :uncaptured-params` — which is option (a) on the bead (fail-loud at the address gate), sited at the one **registry-aware** boundary rather than the registry-free structural gate.

The round-trip argument decides it against keeping `:extra`: a param the URL cannot carry makes in-memory state diverge from URL state, so a reload does not reproduce the slice and any subscriber reading `:extra` sees something a reloaded session will not have. But truncating to `{:id "7"}` is the *other* wrong answer, for three reasons:

1. **The spec already states the principle.** Spec 012 §Validity rules rule 2 rejects `:params` riding beside a `:url` because "letting address keys ride beside it and be silently ignored is **the exact failure class this grammar exists to kill**". An uncaptured `:params` key is that same class, one level down — inside the params map instead of beside it. This is a conformance gap, not a new contract.
2. **`route-url` already fails closed on emission for every other prism break.** The empty-string segment (`""` → `/articles/`, erased by trailing-slash normalisation, so it cannot round-trip) and the sequential-optional-group prefix chain (a later group emitted after an earlier one elided lands in the wrong capture slot) both refuse to emit rather than emit a URL `match-url` reads back differently. An uncaptured param is the same class and was the one remaining hole.
3. **Truncation loses a typo class nothing else catches.** On `/docs{/:section}?`, `{:sction "x"}` elides the group and builds `/docs` cleanly — `:rf.error/missing-route-param` can never fire on it. Silent truncation swallows the misspelling; rejection names it.

**Why this site settles all the doors with one rule.** `route-url` is the emission boundary the three *named-address* doors already share: the programmatic door's URL build, `route-link`'s href synthesis, and prefetch's destination gate (which maps `route-url`'s error ids verbatim per Spec 009, so prefetch needed **no code change** — it now reports `:reason :route-url-validation`, `:keys [:params]`). The URL-driven doors (link click, popstate, initial load, SSR) need no rule at all: a URL physically cannot carry an uncaptured param, so they were always right. Not a per-door patch.

**The one exemption: `:rf.route/not-found`.** Its slice `:params` are the framework's fact record of the miss (`{:url … :reason …}`, single producer `plan/not-found-params`) — not path captures, so the fallback's pattern has no say over their vocabulary. Without the exemption an ordinary in-place `[:rf.route/navigate {:query …}]` while parked on a registered not-found route would reject, and the post-rejection address-bar restore (`decisions/current-slice->url`) would silently stop rebuilding. Both are pinned by tests.

The rejection reports **structure only** — the offending keys plus `:slot :params`, never a value — so an uncaptured `{:token "…"}` cannot ride an error surface.

## Spec follow-up (not in this PR)

`spec/**` is fenced for this worker, so no spec text changed. The behaviour is already implied by Spec 012 §Validity rules rule 2, but two places should record it explicitly and a follow-on bead is filed: Spec 012 §Bidirectional URL ↔ params (the `route-url` rejection, beside the nil-policy table) and the `:rf.error/route-url-validation` row in Spec 009 §Error catalogue (the new `:reason :uncaptured-params` discriminator). **The mayor should sequence that**, and should ratify the choice above — the bead flagged this as a contract ruling, and flipping to silent truncation is a ~10-line change (swap the throw for a `select-keys`) plus flipping the pinned tests.

## Changed files

- `implementation/routing/src/re_frame/routing/registry.cljc` — new private `uncaptured-param-keys`; one rejection in `route-url` after the `no-such-route` check and before `:params` schema validation. **No other source file changed** — `core_routing.cljc` was not touched.
- `implementation/routing/test/re_frame/routing_uncaptured_param_test.clj` — new: the cross-door reproduction, the emission boundary, the adversarial trio, and the exemption.
- `implementation/routing/test/re_frame/routing_registry_test.clj` — `route-url-ignores-extra-path-params` **flipped and renamed** to `route-url-rejects-extra-path-params`, both of its cases kept, a positive control added to each, and the reason for the flip recorded in the section comment rather than deleted.
- `implementation/routing/test/re_frame/routing_prefetch_test.clj` — the KNOWN-GAP note that pointed at this bead is replaced by the settled answer and a pointer to where it is asserted.

## Test deltas

The routing JVM suite goes from 511 tests to **515** — `+4` deftests in the new namespace, plus one deftest flipped and renamed in place (not added, not deleted). Adversarial coverage: a param that **is** captured (top-level, optional-group inner, splat), a param that is **not**, a route with **no** params at all, a misspelling an optional group hides, multiple uncaptured keys in canonical order, a value that must not leak into the error, and the reserved-route exemption on both a helper and a live door.

The reproduction is recorded as a run, not a claim: the new namespace was run against unmodified source first and failed **27 of 43 assertions** — every positive control green, every door-agreement assertion red, printing the committed `{:id "7", :extra "x"}` slice, the `/probe/7` push, and the warmed `{:id "7", :extra "x"}` verbatim.

## Quality gates

| gate | result | exit |
|---|---|---|
| `implementation/routing` JVM (`clojure -M:test`) | **PASS** — 515 tests, 2827 assertions, 0 failures, 0 errors | 0 |
| `implementation/core` JVM (`clojure -M:test`, via the spine) | **PASS** — 2126 tests, 10492 assertions, 0 failures, 0 errors | 0 |
| `implementation/resources` JVM (transitive: routing's `:routing/on-route-entry` / `:routing/on-route-prefetch` consumer) | **PASS** — 734 tests, 6820 assertions, 0 failures, 0 errors | 0 |
| `npm run test:cljs` (from `implementation/`) | **PASS** — 11583 tests, 58140 assertions, 0 failures, 0 errors (run twice, identical) | 0 |
| `sh scripts/test-fast-pr.sh` (repo root) | **PASS fast PR spine** | 0 |

One note on the spine, since a green claim should say what it cost. Its first run in this fresh worktree failed at `CLJS node integration` for want of `node_modules` (`'shadow-cljs' is not recognized`); after `npm ci`, a second run failed the same step with a shadow-cljs **par-compile abort** in `re-frame.story.play.presence-*` — a Story namespace this diff cannot reach (nothing in `implementation/story` or the Story test tree requires routing, and the diff is four files under `implementation/routing`). The abort printed only cascade "still waiting for" frames and no root compile error, the signature of a stale `.shadow-cljs` cache / concurrent-compile artefact on a box running several worker worktrees. `npm run test:cljs` was then run standalone twice, both times **11583 tests / 58140 assertions / 0 failures / exit 0**, and the spine was re-run to completion for the row above. Reported rather than quietly re-run.

Each was run in the foreground to completion, redirected to a worktree-local log under `ai/logs/` (never piped, so no exit status is masked) and its exit code echoed explicitly.

**Not run locally, left to CI** (no tier of the fast-PR spine covers them, and none can reach this diff — `route-url` has no caller in `tools/**`, and `tools/xray` requires only `re-frame.routing.match` / `re-frame.routing.tooling`): the browser lanes, adapter smokes, bundle-isolation / perf-bundle / production-elision gates, the Xray feature matrix, mcp-conformance, and `scripts/test-jvm-tools.sh`.

Every `reg-route` in `examples/` and the testbeds was checked by hand: all supply only captured params, and each app's `:rf.route/not-found` registration (`/404`, `/_404`) is exactly the case the exemption protects.
