### PR TITLE
fix(resources): close the read/mutation failure-continuation :error egress and make the gate see the class (rf2-rnsv2, rf2-uufoe)

### DIFF
--- a/implementation/epoch/test/re_frame/epoch_egress_resource_trace_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_egress_resource_trace_test.clj
@@ -3081,3 +3081,436 @@
                     "the resource id rides verbatim")
                 (is (= cache-hit? (:cache-hit? r)))
                 (is (= :ok (:status r)))))))))))
+
+;; ===========================================================================
+;; (rf2-rnsv2) the SAME two carriers, the FAILURE half of the SAME reply: the
+;; transport's `:rf.http/*` envelope under `:error`.
+;; ===========================================================================
+;;
+;; §(rf2-xx4ty) closed the reply a read SUCCEEDS with. A read that FAILS settles
+;; the same carriers with the same canonical reply — `reply/failure-reply`
+;; composes the same `base-reply` — carrying the transport's classified envelope
+;; under `:error`:
+;;
+;;   {:status :error                                ; or :cancelled, on an abort
+;;    :error  {:kind :rf.http/http-4xx :status 422
+;;             :body {…} :body-text "…" :detail {…}} ← the leak
+;;    :rf.reply/work-kind :resource                  ; the DISCRIMINATOR
+;;    :params …, :scope …, :resource/key …, …}       ; closed by the earlier arms
+;;
+;; That envelope is the app's own data coming back out. `re-frame.http.privacy`
+;; enumerates `:body` / `:body-text` / `:decoded` / `:detail` / `:headers` as
+;; its app-bearing slots, and `:detail` is the app's domain failure map — so a
+;; 422 echoes the SUBMITTED FORM FIELDS. It arrives RAW: the transport's
+;; `dispatch-failure!` hands `:on-failure` the unredacted envelope and
+;; `privacy/prepare-emit-failure` touches only HTTP's own trace row.
+;;
+;; THE GRAIN IS NEITHER OF THE TWO ABOVE, and the tests below are arranged
+;; around that. `:error` is UNCONDITIONAL INSIDE THE FAMILY REPLY MARKER — no
+;; owner read at all — because the family's OWN rows tokenize this envelope
+;; unconditionally (`error-envelope-slot` on `:rf.resource/failed` /
+;; `:rf.resource/page-failed` / `:rf.mutation/failed`). An owner-conditional arm
+;; here — i.e. adding `:error` to `reply-payload-slot` — would tokenize a
+;; `:serialize` owner's envelope on the ROW and let the identical bytes ride on
+;; the CARRIER: the rf2-irwsq disagreement, in mirror image. So the plain-owner
+;; test below is an ACCEPTANCE test, not an over-redaction control, and it is
+;; the one that fails if somebody re-implements the rejected remedy.
+;;
+;; …AND IT SPANS READS AND MUTATIONS. `resource-reply?` excludes
+;; `:rf.reply/work-kind :mutation` deliberately — the mutation redacts its OWN
+;; `:value` / `:params` / `:scope` at the source, through
+;; `classification/redact-continuation-reply`. That function re-roots the spec's
+;; projection-relative declarations and never touches `:error`, correctly, since
+;; `:error` is not a projection of owner data and no declaration can name it. So
+;; the mutation failure continuation leaked the identical envelope by the
+;; identical route, seen by nobody. The `:error` arm therefore gates on BOTH
+;; work kinds; §(6) below is that half.
+
+(def ^:private failure-envelope
+  "The classified `:rf.http/*` failure envelope a 422 settles with. Carries the
+  secret in the two slots that actually echo user input — `:body` (the decoded
+  error body) and `:detail` (the app's own domain failure map, HTTP's
+  `:rf.http/accept-failure` slot). `:kind` / `:status` are the attribution
+  scalars, which the row's siblings preserve."
+  {:kind      :rf.http/http-4xx
+   :status    422
+   :body      {:email (str secret "@example.com")}
+   :body-text (str "email " secret " is already registered")
+   :detail    {:errors [{:field :email :value secret}]}})
+
+(def ^:private other-failure-envelope
+  "A SECOND, different envelope — same shape, different bytes. The distinctness
+  control: content-addressed tokenization must keep two failures joinable as two
+  failures."
+  {:kind :rf.http/http-5xx :status 503 :body {:reason "upstream down"}})
+
+(def ^:private abort-envelope
+  "An `:rf.http/aborted` envelope. `reply/failure-reply` lowers it to
+  `:status :cancelled` — and still puts it under `:error`. The reason `:status`
+  is NOT the gate."
+  {:kind :rf.http/aborted :reason :user-abort :detail {:draft {:email secret}}})
+
+(defn- family-carrier-replies
+  "`carrier-replies` widened to the FAMILY's two work kinds — a read completion
+  (`:resource`) and a mutation completion (`:mutation`). The mutation half of
+  this section needs it; `carrier-replies` stays read-only so the §(rf2-xx4ty)
+  assertions above keep saying exactly what they said."
+  [record]
+  (let [found (atom [])
+        walk  (fn walk [v]
+                (cond
+                  (map? v)  (do (when (#{:resource :mutation} (:rf.reply/work-kind v))
+                                  (swap! found conj v))
+                                (run! walk (vals v)))
+                  (coll? v) (run! walk v)))]
+    (doseq [tags (map :tags (:trace-events record))
+            slot [:rf.fx/args :rf.event/fx]
+            :when (contains? tags slot)]
+      (walk (get tags slot)))
+    @found))
+
+(defn- drive-failing-reply-to-read!
+  "The FAILURE counterpart of `drive-reply-to-read!` (rf2-uufoe): drive a REAL
+  `[:rf.resource/ensure … :reply-to …]` and replay the transport's `:on-failure`
+  with `envelope`, so the runtime's own `failed-handler` builds the canonical
+  failure reply and fans it out through its own `[:dispatch …]` continuation fx.
+
+  `params` is the caller's, so a PLAIN owner can be driven with a secret-free
+  key and a secret-BEARING envelope — which is what makes the plain-owner sweep
+  below name exactly one leaking datum."
+  [resource-id params envelope]
+  (rf/configure! {:epoch-history {:trace-events-keep 80}})
+  (let [captured (atom nil)]
+    (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! captured args) nil))
+    (rf/reg-event :app/read-loaded (fn [_ _ev] {}))
+    (frame/swap-runtime-db! :test/rt
+      (fn [rt] (elision/apply-classification-effects
+                 rt {:sensitive [[:auth :user :username]]})))
+    (frame/swap-frame-db! :test/rt assoc-in [:auth :user :username] secret)
+    (rf/dispatch-sync [:rf.resource/ensure
+                       {:resource resource-id :params params
+                        :owner    real-owner  :reply-to read-reply-target}]
+                      {:frame :test/rt})
+    (rf/dispatch-sync (conj (:on-failure @captured) {:status :error :error envelope})
+                      {:frame :test/rt})
+    (rf/epoch-history :test/rt)))
+
+;; ---------------------------------------------------------------------------
+;; (1) THE ACCEPTANCE ARM — a REAL failing reply-to read, sensitive owner
+;; ---------------------------------------------------------------------------
+
+(deftest real-failing-reply-to-read-leaks-no-error-envelope-into-fx-carriers
+  (testing "rf2-rnsv2 — `projected-record` over the records a REAL
+            `[:rf.resource/ensure … :reply-to …]` settles into FAILURE must
+            carry the decoded error body at ZERO paths. Before the repair the
+            envelope rode raw on both carriers, at
+            [… :rf.fx/args 1 :error :body :email] and its :body-text / :detail
+            siblings, and again under :rf.event/fx."
+    (let [records   (drive-failing-reply-to-read! :derived/profile reply-params
+                                                  failure-envelope)
+          raw       (record-carrying-reply records false)
+          projected (epoch/projected-record raw)]
+
+      (testing "FIXTURE — the producer really put the envelope on the fx
+                carriers, so the sweep below is not passing over an empty set"
+        (is (some? raw) "the failure continuation reached an fx carrier at all")
+        (is (seq (carrier-replies raw)) "and the reply map is findable on it")
+        (is (every? #(= failure-envelope (:error %)) (carrier-replies raw))
+            "every carrier's reply carries the RAW envelope")
+        (is (seq (secret-leak-paths raw))
+            "the unprojected record leaks — the projector's input is the
+             runtime's own output, not an invented tag map"))
+
+      (testing "ACCEPTANCE — nothing raw survives anywhere in the projected
+                record"
+        (is (= [] (secret-leak-paths projected))))
+
+      (testing "and each reply's envelope is TOKENIZED, not merely absent"
+        (is (= (count (carrier-replies raw)) (count (carrier-replies projected)))
+            "projection neither drops nor invents a carrier reply")
+        (is (every? #(redacted-component? (:error %)) (carrier-replies projected))
+            "the envelope is an opaque content-addressed token"))
+
+      (testing "the whole reply still reads as a FAILED reply — the attribution
+                the family's own rows also preserve"
+        (let [r (first (carrier-replies projected))]
+          (is (= :error (:status r)) "the status rides verbatim")
+          (is (= :failed (:rf.reply/work-status r)))
+          (is (= :derived/profile (:resource r)) "and the resource id")
+          (is (redacted-component? (first (:resource/key r)))
+              "rf2-1kiuj — the sibling key's scope component is still tokenized")
+          (is (tokenized-scope? (:scope r))
+              "rf2-425mm — and the free :scope beside it"))))))
+
+;; ---------------------------------------------------------------------------
+;; (2) THE ANTI-OWNER-CONDITIONAL CONTROL — the point of the bead
+;; ---------------------------------------------------------------------------
+
+(deftest real-failing-reply-to-read-tokenizes-a-plain-owners-envelope-too
+  (testing "rf2-rnsv2 — a PLAIN (`:serialize`, undeclared) owner's failure
+            envelope tokenizes JUST THE SAME. This is an ACCEPTANCE test, not an
+            over-redaction control: `error-envelope-slot` tokenizes the identical
+            envelope on `:rf.resource/failed` UNCONDITIONALLY, so an
+            owner-conditional carrier arm — i.e. `:error` dropped into
+            `reply-payload-slot` — would make the two carriers of one envelope
+            disagree. This test is what fails if somebody makes that edit.
+
+            The key here carries NO secret (`:plain/article` + a plain slug), so
+            the sweep below names exactly one leaking datum: the envelope."
+    (let [records   (drive-failing-reply-to-read! :plain/article {:slug plain-slug}
+                                                  failure-envelope)
+          raw       (record-carrying-reply records false)
+          projected (epoch/projected-record raw)]
+      (testing "FIXTURE — a plain owner, and the envelope is the ONLY secret"
+        (is (some? raw))
+        (is (every? #(= failure-envelope (:error %)) (carrier-replies raw)))
+        (is (seq (secret-leak-paths raw))
+            "the unprojected record leaks the envelope")
+        (is (= [] (secret-leak-paths (mapv #(dissoc % :error) (carrier-replies raw))))
+            "and with `:error` removed the reply carries NO secret at all —
+             the envelope is the only leaking datum on a plain owner's reply, so
+             the acceptance below cannot pass for some other repair's reason"))
+      (testing "ACCEPTANCE — the plain owner's envelope tokenizes anyway"
+        (is (= [] (secret-leak-paths projected)))
+        (is (every? #(redacted-component? (:error %)) (carrier-replies projected))))
+      (testing "and the owner's OWN data still rides verbatim — the arm is
+                marker-gated, not owner-gated, so nothing else moved"
+        (let [r (first (carrier-replies projected))]
+          (is (= {:slug plain-slug} (:params r))
+              "rf2-xx4ty's arm is still owner-conditional and still silent here")
+          (is (= :rf.scope/global (:scope r)))
+          (is (= [:rf.scope/global :plain/article {:slug plain-slug}]
+                 (:resource/key r))
+              "and the plain owner's scoped key is untouched"))))))
+
+;; ---------------------------------------------------------------------------
+;; (3) the same shape assembled — the two carriers of ONE envelope AGREE
+;; ---------------------------------------------------------------------------
+
+(defn- failure-read-reply
+  "The continuation reply `events/read-continuation-reply` builds on the FAILURE
+  branch — `reply/failure-reply` plus the top-level read facts."
+  [scoped-key scope envelope]
+  (let [[_ resource-id params] scoped-key
+        abort? (= :rf.http/aborted (:kind envelope))]
+    (cond-> {:status               (if abort? :cancelled :error)
+             :error                envelope
+             :rf.reply/work-id     [:rf.work/resource scoped-key 1]
+             :rf.reply/work-kind   :resource
+             :rf.reply/work-status (if abort? :cancelled :failed)
+             :rf.frame/id          :test/rt
+             :completed-at         0
+             :correlation          {:scope scope :generation 1
+                                    :rf.reply/resource-key scoped-key}
+             :resource             resource-id
+             :params               params
+             :scope                scope
+             :resource/key         scoped-key
+             :cache-hit?           false}
+      abort? (assoc :cancelled? true :rf.reply/cancel-reason (:reason envelope)))))
+
+(defn- both-carriers-of
+  "A record carrying BOTH copies of one envelope: the family's OWN
+  `:rf.resource/failed` row (whose `:error` `error-envelope-slot` tokenizes
+  unconditionally) AND the two fx carriers of the continuation reply. The whole
+  bead is that these two must agree, so one record holds both and the assertion
+  is an equality rather than two independent shape checks.
+
+  The effect vector deliberately also carries
+  `[:rf.resource/commit-generation {:value 1}]` — a FOREIGN map on the same
+  vector, the control that a name-only arm would fail."
+  [scoped-key reply]
+  (let [ev (conj read-reply-target reply)]
+    (record-with
+      [(event :rf.resource/failed
+              {:rf.frame/id :test/rt :resource/key scoped-key
+               :work/id [:rf.work/resource scoped-key 1] :generation 1
+               :error (:error reply)})
+       (event :rf.fx/handled
+              {:rf.frame/id :test/rt :frame :test/rt
+               :rf.fx/id :dispatch :rf.fx/args ev})
+       (event :rf.fx/do-fx
+              {:rf.frame/id :test/rt :frame :test/rt
+               :rf.event/fx [[:rf.resource/commit-generation {:value 1}]
+                             [:dispatch ev]]})])))
+
+(deftest fx-carrier-error-envelope-agrees-with-the-family-row
+  (testing "rf2-rnsv2 — the ROW copy and the CARRIER copies of ONE envelope must
+            project to the SAME content-addressed token. Run over a PLAIN owner,
+            because that is exactly the case an owner-conditional arm would
+            split."
+    (let [k         (sk :rf.scope/global :plain/article {:slug plain-slug})
+          reply     (failure-read-reply k :rf.scope/global failure-envelope)
+          projected (epoch/projected-record (both-carriers-of k reply))
+          row-error (:error (:tags (first (:trace-events projected))))
+          replies   (family-carrier-replies projected)]
+      (is (= 2 (count replies)) "one reply per carrier")
+      (is (redacted-component? row-error) "the row copy tokenizes (it always did)")
+      (is (every? #(= row-error (:error %)) replies)
+          "and the carrier copies tokenize to the SAME digest — the two carriers
+           of one envelope agree, which is the whole ruling")
+      (is (= [] (secret-leak-paths projected)))
+      (is (every? #(true? (:sensitive? (:tags %))) (:trace-events projected))
+          "every row that carried the envelope is stamped :sensitive?"))))
+
+(deftest fx-carrier-error-envelope-tokenizes-on-a-cancelled-reply
+  (testing "rf2-rnsv2 — `:status` is NOT the gate. An `:rf.http/aborted`
+            envelope settles `:status :cancelled` and still rides under
+            `:error`, so it must tokenize on the cancel branch too."
+    (let [k         (sk :rf.scope/global :plain/article {:slug plain-slug})
+          reply     (failure-read-reply k :rf.scope/global abort-envelope)
+          projected (epoch/projected-record (both-carriers-of k reply))
+          replies   (family-carrier-replies projected)]
+      (is (= :cancelled (:status (first replies))) "it really is the cancel branch")
+      (is (= :user-abort (:rf.reply/cancel-reason (first replies)))
+          "and the cancel reason rides verbatim — attribution survives")
+      (is (every? #(redacted-component? (:error %)) replies))
+      (is (= [] (secret-leak-paths projected))))))
+
+(deftest fx-carrier-error-tokens-stay-distinct-per-envelope
+  (testing "rf2-rnsv2 — content-addressed, so two different failures keep two
+            different digests and a tool's per-failure joins survive."
+    (let [k    (sk :rf.scope/global :plain/article {:slug plain-slug})
+          tok  (fn [envelope]
+                 (-> (both-carriers-of k (failure-read-reply k :rf.scope/global envelope))
+                     epoch/projected-record
+                     family-carrier-replies
+                     first
+                     :error))]
+      (is (not= (tok failure-envelope) (tok other-failure-envelope))
+          "distinct envelopes ⇒ distinct tokens")
+      (is (= (tok failure-envelope) (tok failure-envelope))
+          "and the SAME envelope ⇒ the same token (stable, so joins work)"))))
+
+(deftest fx-carrier-error-projection-is-idempotent
+  (testing "rf2-rnsv2 — an already-projected record re-projects to itself; the
+            token is not re-digested (the `redacted-token?` guard)."
+    (let [k     (sk :rf.scope/global :plain/article {:slug plain-slug})
+          once  (epoch/projected-record
+                  (both-carriers-of k (failure-read-reply k :rf.scope/global failure-envelope)))
+          twice (epoch/projected-record once)]
+      (is (= once twice)))))
+
+;; ---------------------------------------------------------------------------
+;; (4) the OVER-REDACTION controls — the family speaks only for what it planted
+;; ---------------------------------------------------------------------------
+
+(deftest fx-carrier-leaves-the-fx-familys-own-error-verbatim
+  (testing "rf2-rnsv2 — `:error` is an FX-FAMILY WORD. A map carrying `:error`
+            with NO `:rf.reply/work-kind` is somebody else's data and must ride
+            byte-identical — which is why the arm is marker-gated and not a
+            name-only unconditional redaction."
+    (let [foreign   {:error {:message "boom" :detail {:slug plain-slug}}}
+          record    (record-with
+                      [(event :rf.fx/do-fx
+                              {:rf.frame/id :test/rt :frame :test/rt
+                               :rf.event/fx [[:rf.error/report foreign]
+                                             [:dispatch [:app/oops foreign]]]})])
+          projected (epoch/projected-record record)
+          tags      (:tags (first (:trace-events projected)))]
+      (is (= [[:rf.error/report foreign] [:dispatch [:app/oops foreign]]]
+             (:rf.event/fx tags))
+          "the fx family's own :error rides byte-identical")
+      (is (not (true? (:sensitive? tags)))
+          "and the row is not stamped — an over-redaction is as much a defect
+           as the leak (rf2-1kiuj)"))))
+
+(deftest fx-carrier-leaves-a-foreign-familys-reply-error-verbatim
+  (testing "rf2-rnsv2 — the marker is ENUMERATED, never `(some? work-kind)`.
+            Managed HTTP stamps `:rf.reply/work-kind :http` on its own canonical
+            reply, and an HTTP reply riding these carriers is the HTTP family's
+            data to classify. The resources projector must leave it alone."
+    (let [http-reply {:status :error
+                      :rf.reply/work-kind   :http
+                      :rf.reply/work-status :failed
+                      :error failure-envelope}
+          record     (record-with
+                       [(event :rf.fx/handled
+                               {:rf.frame/id :test/rt :frame :test/rt
+                                :rf.fx/id :dispatch
+                                :rf.fx/args [:app/http-done http-reply]})])
+          projected  (epoch/projected-record record)
+          tags       (:tags (first (:trace-events projected)))]
+      (is (= [:app/http-done http-reply] (:rf.fx/args tags))
+          "the HTTP family's reply rides through this projector untouched"))))
+
+;; ---------------------------------------------------------------------------
+;; (5) the trusted-local opt-in — the tokenization is the off-box default
+;; ---------------------------------------------------------------------------
+
+(deftest trusted-local-include-sensitive-keeps-raw-fx-carrier-error
+  (testing "rf2-rnsv2 — `:include-sensitive?` still shows the raw envelope. The
+            redaction is the OFF-BOX default, not a strip: a local operator
+            debugging a 422 needs the body."
+    (let [k         (sk :rf.scope/global :plain/article {:slug plain-slug})
+          reply     (failure-read-reply k :rf.scope/global failure-envelope)
+          projected (epoch/projected-record (both-carriers-of k reply)
+                                            {:include-sensitive? true})]
+      (is (= [failure-envelope failure-envelope]
+             (mapv :error (family-carrier-replies projected)))
+          "every carrier's raw envelope rides with :include-sensitive?")
+      (is (= failure-envelope (:error (:tags (first (:trace-events projected)))))
+          "and so does the family row's copy"))))
+
+;; ---------------------------------------------------------------------------
+;; (6) THE SEVENTH LEAK — the MUTATION continuation, closed in the same arm
+;; ---------------------------------------------------------------------------
+
+(def ^:private mutation-reply-target
+  "The mutation call-site `:reply-to`."
+  [:app/save-replied])
+
+(defn- drive-failing-mutation-reply-to!
+  "Drive a REAL `[:rf.mutation/execute … :reply-to …]` against a mutation that
+  declares NOTHING — so `classification/redact-continuation-reply` substitutes
+  nothing at the source and any redaction observed came from the egress
+  projector — and replay the transport's `:on-failure` with `envelope`."
+  [envelope]
+  (rf/configure! {:epoch-history {:trace-events-keep 80}})
+  (let [captured (atom nil)]
+    (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! captured args) nil))
+    (rf/reg-event :app/save-replied (fn [_ _ev] {}))
+    (rf/reg-mutation :m/save
+      {:params-schema [:map [:slug :string]]}
+      (fn [{:keys [slug]} _] {:request {:method :put :url (str "/a/" slug)}}))
+    (rf/dispatch-sync [:rf.mutation/execute
+                       {:mutation :m/save :params {:slug plain-slug}
+                        :instance :mf1 :reply-to mutation-reply-target}]
+                      {:frame :test/rt})
+    (rf/dispatch-sync (conj (:on-failure @captured) {:status :error :error envelope})
+                      {:frame :test/rt})
+    (rf/epoch-history :test/rt)))
+
+(deftest real-failing-mutation-reply-to-leaks-no-error-envelope
+  (testing "rf2-rnsv2 §the seventh leak — the MUTATION continuation reply leaks
+            `:error` by the identical route. `redact-continuation-reply`
+            re-roots only the spec's `:value` / `:params` / `:scope`
+            declarations and never touches `:error` (correctly — `:error` is a
+            transport envelope, not a projection of owner data), and the reply
+            stamps `:rf.reply/work-kind :mutation`, so `resource-reply?` is false
+            and NOTHING looked at it. One keyword wider in the same predicate;
+            omitting it would have shipped the seventh leak in the commit that
+            closed the sixth."
+    (let [records   (drive-failing-mutation-reply-to! failure-envelope)
+          raw       (first (filter #(seq (family-carrier-replies %)) records))
+          projected (epoch/projected-record raw)]
+      (testing "FIXTURE — the producer really put the envelope on the carriers"
+        (is (some? raw) "the mutation continuation reached an fx carrier")
+        (is (every? #(= :mutation (:rf.reply/work-kind %))
+                    (family-carrier-replies raw))
+            "and it really is the MUTATION reply, not a read one")
+        (is (every? #(= failure-envelope (:error %)) (family-carrier-replies raw))
+            "carrying the RAW envelope")
+        (is (seq (secret-leak-paths raw))
+            "the unprojected record leaks"))
+      (testing "ACCEPTANCE — nothing raw survives"
+        (is (= [] (secret-leak-paths projected)))
+        (is (every? #(redacted-component? (:error %))
+                    (family-carrier-replies projected))))
+      (testing "and the reply still reads as a failed mutation reply"
+        (let [r (first (family-carrier-replies projected))]
+          (is (= :error (:status r)))
+          (is (= :m/save (:mutation r)))
+          (is (= :mf1 (:instance r)))
+          (is (= [:mutation :m/save :mf1] (:cause r))
+              "the causal explanation rides verbatim"))))))

--- a/implementation/epoch/test/re_frame/epoch_egress_resource_trace_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_egress_resource_trace_test.clj
@@ -3514,3 +3514,177 @@
           (is (= :mf1 (:instance r)))
           (is (= [:mutation :m/save :mf1] (:cause r))
               "the causal explanation rides verbatim"))))))
+
+;; ===========================================================================
+;; (rf2-uufoe) the DRIVE matrix — every settle branch that fans out a
+;; continuation, not just the one that succeeds.
+;; ===========================================================================
+;;
+;; Six leaks in this family were found by workers and none by a gate, and for
+;; the sixth the blindness was structural rather than inattentive. Every
+;; producer-driven assertion about a `:reply-to` continuation reaching off-box
+;; egress lived in §(rf2-xx4ty) above, and every one of those drives replayed a
+;; SUCCESS reply. The sibling conformance fixture
+;; (`epoch_mcp_egress_conformance_test`) drives no `:reply-to` at all and points
+;; here as the home of that coverage — so the coverage it points at existed for
+;; one branch out of five.
+;;
+;; FIVE settle branches fan out a continuation reply, and each builds it
+;; through a DIFFERENT handler:
+;;
+;;   events/succeeded-handler     — the success settle    §(rf2-xx4ty)
+;;   events/failed-handler        — the failure settle    §(rf2-rnsv2)(1)
+;;   events/failed-handler        — its ABORT branch      here
+;;   events/aborted-handler       — the legacy abort event here
+;;   events/page-failed-handler   — the infinite-feed page failure   here
+;;   mutation_events (failure settle)                     §(rf2-rnsv2)(6) + here
+;;
+;; THE UNIT OF COVERAGE IS THE BRANCH, NOT THE SLOT. Each drive below is one
+;; canary sweep over the whole projected record — zero secret paths — plus the
+;; FIXTURE assertion that the unprojected record does leak. That catches the
+;; CLASS: whatever slot a future continuation gains, on any of these branches,
+;; the sweep sees it. One assertion per named slot would only ever catch the
+;; instance somebody already found, which is how five of them got here.
+;;
+;; THE STANDING RULE THIS ENCODES: a new settle branch that fans out a
+;; continuation reply gets a canary drive here, in the same PR that adds it.
+;; A branch with no drive is not "untested" in the ordinary sense — it is
+;; INVISIBLE to every assertion in this namespace, because they all read what a
+;; drive produced.
+
+(defn- record-with-family-reply
+  "The first record of `records` whose fx carriers carry ANY family
+  continuation reply — read or mutation. The failure / cancel branches settle
+  through different handlers and different cascades, so selecting by record
+  index would encode each branch's fx order; selecting by the reply's own
+  marker does not."
+  [records]
+  (first (filter #(seq (family-carrier-replies %)) records)))
+
+(defn- assert-branch-sweep!
+  "The canary sweep every branch drive below runs: the unprojected record must
+  LEAK (so the sweep is not passing over an empty set) and the projected record
+  must leak at ZERO paths. `expect` is the reply facts that name the branch, so
+  a drive that silently stopped reaching the branch it names fails loudly
+  instead of passing vacuously."
+  [raw expect]
+  (is (some? raw) "the continuation reached an fx carrier at all")
+  (is (seq (family-carrier-replies raw)) "and the reply map is findable on it")
+  (doseq [[k v] expect]
+    (is (every? #(= v (k %)) (family-carrier-replies raw))
+        (str "the drive really settled the named branch — " k " = " v)))
+  (is (seq (secret-leak-paths raw))
+      "FIXTURE — the unprojected record leaks, so the sweep below is real")
+  (is (= [] (secret-leak-paths (epoch/projected-record raw)))
+      "ACCEPTANCE — the canary survives at zero paths of the projected record"))
+
+;; ---------------------------------------------------------------------------
+;; (1) `failed-handler`'s ABORT branch — a transport `:rf.http/aborted`
+;; ---------------------------------------------------------------------------
+
+(deftest real-transport-abort-reply-to-read-leaks-nothing-into-fx-carriers
+  (testing "rf2-uufoe — the production abort arrives as an `:rf.http/aborted`
+            FAILURE through `failed-handler`, which lowers it to
+            `:status :cancelled` and still carries the envelope under `:error`.
+            A separate branch of a handler whose error branch §(rf2-rnsv2)(1)
+            covers — and the branch on which `:status` would have been the wrong
+            gate."
+    (let [records (drive-failing-reply-to-read! :plain/article {:slug plain-slug}
+                                                abort-envelope)]
+      (assert-branch-sweep! (record-carrying-reply records false)
+                            {:status :cancelled
+                             :rf.reply/work-status :cancelled}))))
+
+;; ---------------------------------------------------------------------------
+;; (2) `aborted-handler` — the legacy `:rf.resource.internal/aborted` event
+;; ---------------------------------------------------------------------------
+
+(defn- drive-aborted-event-reply-to-read!
+  "Drive a REAL `[:rf.resource/ensure … :reply-to …]` and settle it through the
+  LEGACY `:rf.resource.internal/aborted` event rather than a transport failure.
+  That handler synthesises its own `{:kind :rf.http/aborted :reason :aborted}`
+  envelope, so the canary here is not the envelope but the OWNER'S data the
+  continuation reply carries beside it — `:params`, the resolved `:scope`, the
+  `:resource/key`. Which is the point of a whole-record sweep: the branch is
+  covered whatever slot the leak would land in."
+  [resource-id]
+  (rf/configure! {:epoch-history {:trace-events-keep 80}})
+  (let [captured (atom nil)]
+    (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! captured args) nil))
+    (rf/reg-event :app/read-loaded (fn [_ _ev] {}))
+    (frame/swap-runtime-db! :test/rt
+      (fn [rt] (elision/apply-classification-effects
+                 rt {:sensitive [[:auth :user :username]]})))
+    (frame/swap-frame-db! :test/rt assoc-in [:auth :user :username] secret)
+    (rf/dispatch-sync [:rf.resource/ensure
+                       {:resource resource-id :params reply-params
+                        :owner    real-owner  :reply-to read-reply-target}]
+                      {:frame :test/rt})
+    ;; the verification payload the lowering stamped — the second element of the
+    ;; `:on-failure` target, which the legacy abort event takes as its only arg.
+    (rf/dispatch-sync [:rf.resource.internal/aborted (second (:on-failure @captured))]
+                      {:frame :test/rt})
+    (rf/epoch-history :test/rt)))
+
+(deftest real-aborted-event-reply-to-read-leaks-nothing-into-fx-carriers
+  (testing "rf2-uufoe — `aborted-handler`'s accepted-cancellation fan-out. A
+            THIRD handler building a continuation reply, reached by no drive in
+            this namespace before now."
+    (let [records (drive-aborted-event-reply-to-read! :derived/profile)]
+      (assert-branch-sweep! (record-carrying-reply records false)
+                            {:status :cancelled
+                             :resource :derived/profile}))))
+
+;; ---------------------------------------------------------------------------
+;; (3) `page-failed-handler` — the infinite feed's page fetch
+;; ---------------------------------------------------------------------------
+
+(defn- drive-failing-feed-reply-to-read!
+  "Drive a REAL `[:rf.resource/ensure … :reply-to …]` against an INFINITE FEED
+  and fail its page-0 fetch. An infinite resource lowers its `:on-failure` to
+  `:rf.resource.internal/page-failed`, so this settles through
+  `page-failed-handler` — a fourth handler, with its own first-load-vs-load-more
+  split — rather than `failed-handler`.
+
+  `:plain/feed` declares nothing and its params carry no secret, so the envelope
+  is the only canary and the sweep names exactly one datum.
+
+  Returns `[records on-failure-id]` — the id is the runtime's own proof of which
+  handler this drive reached, asserted below rather than assumed."
+  [envelope]
+  (rf/configure! {:epoch-history {:trace-events-keep 80}})
+  (let [captured (atom nil)]
+    (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! captured args) nil))
+    (rf/reg-event :app/read-loaded (fn [_ _ev] {}))
+    (rf/dispatch-sync [:rf.resource/ensure
+                       {:resource :plain/feed :params {:filter :all}
+                        :owner    real-owner  :reply-to read-reply-target}]
+                      {:frame :test/rt})
+    (rf/dispatch-sync (conj (:on-failure @captured) {:status :error :error envelope})
+                      {:frame :test/rt})
+    [(rf/epoch-history :test/rt) (first (:on-failure @captured))]))
+
+(deftest real-failing-feed-reply-to-read-leaks-nothing-into-fx-carriers
+  (testing "rf2-uufoe — `page-failed-handler`'s continuation fan-out, driven
+            through a real infinite-feed page-0 failure."
+    (let [[records on-failure-id] (drive-failing-feed-reply-to-read! failure-envelope)]
+      (is (= :rf.resource.internal/page-failed on-failure-id)
+          "the feed really lowered to the page-failure reply event — this drive
+           reaches `page-failed-handler` and not `failed-handler`")
+      (assert-branch-sweep! (record-carrying-reply records false)
+                            {:status :error :resource :plain/feed}))))
+
+;; ---------------------------------------------------------------------------
+;; (4) the MUTATION cancel settle — the sibling of §(rf2-rnsv2)(6)
+;; ---------------------------------------------------------------------------
+
+(deftest real-cancelled-mutation-reply-to-leaks-nothing-into-fx-carriers
+  (testing "rf2-uufoe — the mutation failure settle also lowers an
+            `:rf.http/aborted` envelope to `:status :cancelled`, and an accepted
+            terminal cancellation fans out its `:reply-to` too. §(rf2-rnsv2)(6)
+            drove the `:error` half of that settle; this is the cancel half."
+    (let [records (drive-failing-mutation-reply-to! abort-envelope)]
+      (assert-branch-sweep! (record-with-family-reply records)
+                            {:status :cancelled
+                             :rf.reply/work-kind :mutation
+                             :mutation :m/save}))))

--- a/implementation/epoch/test/re_frame/epoch_mcp_egress_conformance_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_mcp_egress_conformance_test.clj
@@ -620,14 +620,28 @@
     `:rf.mutation/*` rows here.
   - a call-site `:reply-to` READ CONTINUATION (rf2-xx4ty). No `ensure` here
     carries one and no reply is replayed, so the continuation reply map — with
-    its `:value` (the decoded response body), `:params` and `:correlation` —
-    never reaches this fixture's carriers. The session `ensure` above does NOT
-    close that axis and does not pretend to: it settles no reply. Note the
-    carriers themselves ARE visible here (`fx-carrier-rows` reads the RECORD by
-    SLOT, exactly as the projector does, not through `resource-family-row?`), so
-    what is missing is the DRIVE, not the harvest. The dedicated
-    producer-driven coverage lives in `epoch_egress_resource_trace_test` §(1),
-    which replays a real reply through the internal reply event.
+    its `:value` (the decoded response body), `:params`, `:error` and
+    `:correlation` — never reaches this fixture's carriers. The session `ensure`
+    above does NOT close that axis and does not pretend to: it settles no reply.
+    Note the carriers themselves ARE visible here (`fx-carrier-rows` reads the
+    RECORD by SLOT, exactly as the projector does, not through
+    `resource-family-row?`), so what is missing is the DRIVE, not the harvest.
+    The dedicated producer-driven coverage lives in
+    `epoch_egress_resource_trace_test`, which replays real replies through the
+    internal reply events.
+
+    THAT POINTER USED TO BE HALF TRUE, and the half it missed is why rf2-rnsv2
+    reached main (rf2-uufoe). Until rf2-uufoe every drive over there replayed a
+    SUCCESS reply, so the branch this fixture delegates was one of five: the
+    failure settle, `failed-handler`'s abort branch, the legacy abort event, the
+    infinite-feed page failure and the mutation failure settle each build a
+    continuation reply through a DIFFERENT handler, and none had ever been
+    projected. The read-failure `:error` envelope — the decoded error body,
+    which routinely echoes the submitted form fields — was structurally
+    unreachable by the suite rather than merely unnoticed. All five now carry a
+    whole-record canary drive there, and the standing rule is stated on
+    §(rf2-uufoe): a new settle branch that fans out a continuation gets a canary
+    drive in the PR that adds it.
 
   The rows are harvested off the trace bus rather than read out of the settled
   epoch records because ONE record is one dequeued event: this cascade is five

--- a/implementation/resources/src/re_frame/resources/trace_egress.cljc
+++ b/implementation/resources/src/re_frame/resources/trace_egress.cljc
@@ -282,6 +282,55 @@
   safe to read: it says the map is a RESOURCE reply and names whose."
   #{:params :value})
 
+(def ^:private reply-error-slot
+  "The FAILURE ENVELOPE slot of a canonical resource-FAMILY continuation reply
+  (rf2-rnsv2): `:error`, the closed `:rf.http/*` envelope
+  `reply/failure-reply` stamps on both the `:status :error` and the
+  `:status :cancelled` (abort) reply. `error-envelope-slot` above is the same
+  envelope's ROW spelling; this is its CARRIER spelling, and the two are
+  deliberately separate sets — the row also spells it `:page-error` on the
+  load-more failure, while a reply never does.
+
+  ## Grain: MARKER-GATED, UNCONDITIONAL INSIDE THE MARKER
+
+  Tokenized whenever the map carrying it is provably a family reply
+  (`family-reply?`), with no owner read and no status read. That is what keeps
+  the envelope's two carriers in agreement: `error-envelope-slot` is consumed
+  UNCONDITIONALLY on the family's own `:rf.resource/failed` /
+  `:rf.resource/page-failed` / `:rf.mutation/failed` rows, so an owner-
+  conditional carrier arm would tokenize the row copy of an envelope and let the
+  carrier copy of the SAME bytes ride — the rf2-irwsq disagreement, in mirror
+  image.
+
+  ## …which is why `:error` IS NOT IN `reply-payload-slot`
+
+  That set is consumed under `(and owner-redacts? …)` in `project-embedded-keys`
+  below, so dropping `:error` into it is a one-token edit that LOOKS like
+  reusing the proven rf2-xx4ty pattern and in fact implements the
+  owner-conditional remedy the paragraph above rejects. The two sets differ in
+  GRAIN, not merely in membership, and that is the whole reason there are two:
+  `:value` / `:params` are the OWNER'S data, so the owner's coarse claim decides
+  (and an unconditional arm would over-redact a plain resource's reply);
+  `:error` is the TRANSPORT'S envelope, which no owner classification speaks
+  for and which the family's own rows tokenize regardless of owner.
+
+  The envelope really does carry app data: `re-frame.http.privacy` enumerates
+  `:body` / `:body-text` / `:decoded` / `:detail` / `:headers` / `:cause` as its
+  app-bearing slots, `:detail` being the app's own domain failure map — so a
+  422 validation failure echoes the SUBMITTED FORM FIELDS straight back out.
+  And it arrives here RAW: the transport's `dispatch-failure!` hands the
+  unredacted envelope to `:on-failure`, `privacy/prepare-emit-failure` touching
+  only HTTP's own trace row.
+
+  Two non-traps, stated so nobody 'fixes' them. `:status` is NOT the gate — an
+  abort settles `:status :cancelled` and still carries `:error`, so the slot
+  name inside a recognized reply is the whole test. And tokenizing the envelope
+  whole loses the HTTP status code off-box, which is already true of the
+  family's own rows (they carry `:status-before` / `:status-after`, not the HTTP
+  code); preserving envelope scalars on the carrier ONLY would re-create the
+  disagreement this exists to prevent."
+  #{:error})
+
 (defn- row-owner-redacts?
   "Whether the resource OWNER named by this trace row's `:resource/key`
   classifies non-`:serialize` (sensitive / large, or UNREGISTERED →
@@ -519,6 +568,36 @@
   its payload is redacted at source (`classification/redact-continuation-reply`)."
   [m]
   (= resources-reply/work-kind-resource (:rf.reply/work-kind m)))
+
+(def ^:private family-reply-kinds
+  "The resource FAMILY's two canonical reply `:rf.reply/work-kind`s — a read
+  completion (`:resource`) and a mutation completion (`:mutation`)
+  (`resources.reply/work-kind-resource` / `work-kind-mutation`). Read by
+  `family-reply?` below.
+
+  ENUMERATED, never `(some? (:rf.reply/work-kind m))`. `:rf.reply/work-kind` is
+  the SHARED `re-frame.reply` substrate's marker, not this family's: managed
+  HTTP stamps `:http` on its own canonical reply (`re-frame.http.reply`), and an
+  HTTP reply riding these same carriers is the HTTP family's data to classify.
+  The resources projector speaks only for what the resources runtime planted."
+  #{resources-reply/work-kind-resource
+    resources-reply/work-kind-mutation})
+
+(defn- family-reply?
+  "Whether MAP `m` is a canonical reply of the resource FAMILY — a read
+  completion OR a mutation completion — by the same marker `resource-reply?`
+  reads, widened to both work kinds (rf2-rnsv2).
+
+  The widening exists because the two halves diverge on the OWNER'S data and
+  agree on the TRANSPORT ENVELOPE. `:value` / `:params` are the owner's, and the
+  mutation redacts its own at the source (`classification/redact-continuation-
+  reply`), so `resource-reply?` deliberately excludes `:mutation` there.
+  `:error` is the transport's `:rf.http/*` failure envelope — no projection of
+  owner data, so no source-side redaction reaches it on EITHER half — and both
+  halves stamp it identically through the one `reply/failure-reply`. One datum,
+  one rule, hence one predicate over both kinds."
+  [m]
+  (boolean (family-reply-kinds (:rf.reply/work-kind m))))
 
 (defn- redact-reply-declarations
   "The READ-CONTINUATION analogue of the mutation's source-side
@@ -823,7 +902,51 @@
   owner's spec, and the two arms compose by grain rather than overlap: coarse
   claim ⇒ the whole `:value` / `:params` tokenize; declaration only ⇒ the
   declared paths substitute in place and their undeclared siblings ride;
-  neither ⇒ the reply is byte-identical. Pure."
+  neither ⇒ the reply is byte-identical. Pure.
+
+  ## …AND the FAILURE ENVELOPE, on BOTH halves of the family (rf2-rnsv2)
+
+  Everything above is about the reply the read SUCCEEDED with. A read that
+  FAILS settles the same carriers with the same canonical reply — `failure-reply`
+  composes the same `base-reply` — carrying the transport's classified
+  `:rf.http/*` envelope under `:error`. That envelope is the app's own data
+  coming back out: HTTP's own redactor enumerates `:body` / `:body-text` /
+  `:decoded` / `:detail` / `:headers` as its app-bearing slots, and a 422's
+  `:detail` is the app's domain failure map — the SUBMITTED FORM FIELDS. It
+  arrives raw, because the transport redacts only its OWN trace row and hands
+  `:on-failure` the envelope verbatim. Every other slot of that reply was
+  already classified by the arms above; `:error` alone rode the `:else` walk out
+  as an ordinary map.
+
+  ### The grain here is neither of the two above, and that is the point
+
+  `:error` is UNCONDITIONAL INSIDE THE FAMILY MARKER — no owner read at all.
+  The full argument is on `reply-error-slot`; the one-line form is that the
+  family's own rows tokenize this envelope regardless of owner
+  (`error-envelope-slot`, consumed unconditionally), so an owner-conditional
+  carrier arm would leave a `:serialize` owner's envelope raw on the carrier
+  while the identical bytes on `:rf.resource/failed` tokenize. The three grains
+  now in this walk each answer to WHOSE datum it is: `:scope` is the runtime's
+  (unconditional inside the payload proof), `:value` / `:params` are the OWNER'S
+  (conditional on the owner's claim), `:error` is the TRANSPORT'S (unconditional
+  inside the reply proof — no owner speaks for it).
+
+  ### …and it is the one arm that spans reads AND mutations
+
+  `resource-reply?` excludes `:rf.reply/work-kind :mutation` deliberately,
+  because the mutation redacts its OWN `:value` / `:params` / `:scope` at the
+  source. `redact-continuation-reply` re-roots the spec's projection-relative
+  declarations and never touches `:error` — correctly, since `:error` is not a
+  projection of owner data and no declaration can name it. So the mutation
+  failure continuation leaked the identical envelope by the identical route,
+  seen by nobody. The `:error` arm therefore gates on `family-reply?` — both
+  work kinds — while the arm above it keeps `resource-reply?`. One keyword
+  wider, and it is what stops this repair shipping its own sibling leak.
+
+  On `failed-handler`'s branch the carrier is not merely a disagreeing second
+  copy but the ONLY off-box copy: that settle row (`:rf.resource/failed` /
+  `:rf.resource/refresh-failed`) stamps `:status-before` / `:status-after` and
+  no `:error` at all."
   [v frame-id named?]
   (cond
     (redacted-token? v) [v true]
@@ -843,9 +966,13 @@
           ;; exactly as `project-tags*` reads it once per row for the cursor).
           ;; Gated on the canonical reply MARKER (audit #7059), not on the mere
           ;; presence of a sibling key.
-          owner-redacts? (and (map? v)
-                              (resource-reply? v)
-                              (row-owner-redacts? v frame-id))
+          ;; the two RECOGNITION reads, hoisted out of the classification so
+          ;; each arm below takes only the proof it needs: the `:value` /
+          ;; `:params` arm is a READ reply PLUS the owner's coarse claim, the
+          ;; `:error` arm (rf2-rnsv2) is the FAMILY marker alone.
+          reply?         (and (map? v) (resource-reply? v))
+          fam-reply?     (and (map? v) (family-reply? v))
+          owner-redacts? (and reply? (row-owner-redacts? v frame-id))
           ;; rf2-ko5lm — …and, when that COARSE read says nothing (a
           ;; `:serialize` owner, which is what a spec declaring only
           ;; projection-relative paths classifies as), the owner's DECLARED
@@ -855,7 +982,7 @@
           ;; `:rf/redacted` / size-marker sentinels ride out as the scalars they
           ;; are. Reference-preserving — and stamp-precise: a declaration that
           ;; matched nothing in THIS reply leaves the row unstamped.
-          v        (if (and (map? v) (not owner-redacts?) (resource-reply? v))
+          v        (if (and reply? (not owner-redacts?))
                      (let [v' (redact-reply-declarations v)]
                        (if (= v' v) v (note! true v')))
                      v)
@@ -873,6 +1000,19 @@
                        (and payload? (= :scope k))
                        (let [[pv s] (project-unknown-slot-value x frame-id)]
                          (note! s pv))
+
+                       ;; rf2-rnsv2 — the TRANSPORT FAILURE ENVELOPE of a family
+                       ;; reply (read OR mutation). Tokenized UNCONDITIONALLY
+                       ;; inside the marker, matching `error-envelope-slot`'s
+                       ;; unconditional treatment on the family's own
+                       ;; `:rf.resource/failed` / `:rf.mutation/failed` rows, so
+                       ;; the two carriers of one envelope agree. Deliberately
+                       ;; NOT a member of `reply-payload-slot` — that set is
+                       ;; owner-conditional and this must not be (see the
+                       ;; `reply-error-slot` docstring). Placed FIRST so the
+                       ;; precedence is explicit.
+                       (and fam-reply? (reply-error-slot k) (some? x))
+                       (note! true (if (redacted-token? x) x (ssr/redact-value x)))
 
                        ;; the owner's own reply data — tokenized
                        ;; content-addressed iff THIS reply's owner redacts, so a
@@ -1123,10 +1263,16 @@
   (rf2-ko5lm) that same reply's owner-DECLARED projection-relative paths, which
   a coarse-only owner read cannot see, substituted through the mutation half's
   own `redact-continuation-reply` so the continuation echo classifies exactly
-  as the durable entry it echoes.
+  as the durable entry it echoes, and (rf2-rnsv2) the transport FAILURE ENVELOPE
+  under `:error` on the failing / cancelled counterpart of that same reply —
+  the decoded error body, which routinely echoes the SUBMITTED FORM FIELDS —
+  tokenized UNCONDITIONALLY inside the family reply marker, on the MUTATION
+  continuation as well as the read one, because the envelope belongs to the
+  transport rather than to any resource owner and the family's own rows tokenize
+  it regardless of owner.
 
   \"Speaks only for the data it planted\" is enforced, not merely intended:
-  each of those three arms fires on PROOF that the runtime planted the value —
+  each of those arms fires on PROOF that the runtime planted the value —
   the family's reserved keyword namespace, its work-id head, the canonical
   reply marker, or the resource registry — never on a local cue that ordinary
   application data hits by coincidence. See `project-embedded-keys` §`named?`.


### PR DESCRIPTION
Closes the sixth **and seventh** leaks of the resource-family off-box egress line, and — the actual point — makes the gate able to see the class rather than the instance.

## The leak

A read that **fails** settles the same two foreign carriers rf2-1kiuj / rf2-425mm / rf2-xx4ty addressed, with the same canonical reply: `reply/failure-reply` composes the same `base-reply`, and the transport's classified `:rf.http/*` envelope rides under `:error`. Every other slot of that reply is classified today — `:resource/key`, the key embedded in `:rf.reply/work-id`, `:correlation`'s `:rf.reply/resource-key`, the free `:scope`, `:value`, `:params`. `:error` alone took the `:else` walk out raw, at `[… :rf.fx/args 1 :error :body :detail]` and again under `:rf.event/fx`.

That envelope is app data coming back out. `re-frame.http.privacy` enumerates `:body` / `:body-text` / `:decoded` / `:detail` / `:headers` as its app-bearing slots, and `:detail` is the app's own domain failure map — so a 422 echoes the **submitted form fields**. It arrives here raw: the transport's `dispatch-failure!` hands `:on-failure` the unredacted envelope, and `privacy/prepare-emit-failure` touches only HTTP's own trace row.

On `failed-handler`'s branch the fx carrier is not merely a disagreeing second copy but the **only** off-box copy — that settle row stamps `:status-before` / `:status-after` and no `:error` at all.

## Which arm fired, and why

**Arm (a): the discriminator already EXISTS, so nothing is emitted.** It is `:rf.reply/work-kind` — the canonical reply marker `resource-reply?` already reads, and already the gate on the fifth leak's `:value` / `:params` arm. `base-reply` stamps it *before* the status branch, so `failure-reply` carries it on both `:status :error` and `:status :cancelled`. The bead asked for a "`:resource/key`-equivalent sibling discriminator"; the marker is strictly better — rf2-1kiuj audit #7059 already proved a bare sibling `:resource/key` is a classification handle, not a recognition proof, and replaced it with this marker.

The grain is **marker-gated, unconditional inside the marker**. That is what keeps the two carriers of one envelope in agreement: `error-envelope-slot` is consumed *unconditionally* on the family's own `:rf.resource/failed` / `:rf.resource/page-failed` / `:rf.mutation/failed` rows.

## `reply-payload-slot` was deliberately NOT used

`:error` is **not** a member of `reply-payload-slot`, and that is the whole ruling rather than a style choice. That set is consumed under `(and owner-redacts? …)`, so joining it is a one-token edit that *looks* like reusing the proven rf2-xx4ty pattern and in fact implements the explicitly **rejected owner-conditional remedy**: a `:serialize` owner's envelope would tokenize on `:rf.resource/failed` and ride verbatim on the carrier — the rf2-irwsq disagreement, in mirror image. It is a **separate arm** of the `entry` cond.

The two sets differ in **grain**, not membership, and that is why there are two:

| slot | whose datum | grain |
|---|---|---|
| `:scope` | the runtime's | unconditional inside the payload proof |
| `:value` / `:params` | the **owner's** | conditional on the owner's coarse claim (an unconditional arm would over-redact a plain resource's reply) |
| `:error` | the **transport's** | unconditional inside the reply proof — no owner speaks for it |

Name-only unconditional redaction was also rejected and is covered by a control: `:error` is an fx-family word, and an ordinary `{:error …}` under `:rf.fx/args` with no marker must ride byte-identical.

## The seventh leak closed in the same commit

The **mutation** continuation reply leaked `:error` identically. `classification/redact-continuation-reply` re-roots only the spec's `:value` / `:params` / `:scope` declarations and never touches `:error` — correctly, since `:error` is a transport envelope and not a projection of owner data, so no declaration can name it — and the reply stamps `:rf.reply/work-kind :mutation`, so `resource-reply?` is false and nothing looked at it. Meanwhile `:rf.mutation/failed` tokenizes the same envelope on the row.

One keyword wider in the same predicate. Omitting it would have shipped the seventh leak in the very commit that closed the sixth. The new arm therefore gates on `family-reply?` — the family's **two** work kinds, enumerated — never `(some? (:rf.reply/work-kind m))`: managed HTTP stamps `:http` on its own canonical reply and is not ours. There is a control for that too.

## rf2-uufoe — making the gate see the class

Six leaks, six found by workers, none by a gate. For this one the blindness was **structural**. Every producer-driven assertion about a `:reply-to` continuation reaching off-box egress lived in `epoch_egress_resource_trace_test`, and every one of those drives replayed a **success** reply. The sibling conformance fixture drives no `:reply-to` at all and points at that file as the home of the coverage — so the coverage it delegated existed for one branch out of five.

Five settle branches fan out a continuation reply, each through a **different handler**. All now carry a whole-record canary drive:

| branch | handler | added by |
|---|---|---|
| success settle | `succeeded-handler` | pre-existing (rf2-xx4ty) |
| failure settle | `failed-handler` (error branch) | commit 1 |
| transport abort | `failed-handler` (cancel branch) | commit 2 |
| legacy abort event | `aborted-handler` | commit 2 |
| infinite-feed page failure | `page-failed-handler` | commit 2 |
| mutation failure / cancel | mutation settle | commits 1 & 2 |

**The unit of coverage is the BRANCH, not the slot.** Each drive is one canary sweep over the whole projected record — zero secret paths — plus a fixture assertion that the *unprojected* record does leak. That catches the class: whatever slot a future continuation gains, on any of these branches, the sweep sees it. One assertion per named slot only ever catches the instance somebody already found, which is how five of these got here. The legacy abort event synthesises its own envelope carrying no canary, so its canary is the owner data the reply carries beside it — precisely why the sweep is whole-record and not `:error`-shaped. The feed drive asserts the runtime really lowered to `:rf.resource.internal/page-failed`, so it cannot silently reach the wrong handler and pass.

The standing rule is stated in the section header and echoed on the conformance fixture's delegation note: **a new settle branch that fans out a continuation gets a canary drive in the PR that adds it.**

### Non-vacuity evidence

With `trace_egress.cljc` reverted to its pre-fix state and the extended test file unchanged:

```
Ran 81 tests containing 541 assertions.
14 failures, 0 errors.
```

Red across eight deftests, including **three of the four new rf2-uufoe branch drives** (`real-transport-abort-…`, `real-failing-feed-…`, `real-cancelled-mutation-…`, all failing at the `assert-branch-sweep!` acceptance line) and both halves of rf2-rnsv2's own acceptance. The fourth new drive — the legacy abort event — stays green under revert by construction, because that handler synthesises an envelope with no canary in it; it is a branch-reachability drive, not an `:error` drive.

With the fix applied:

```
Ran 81 tests containing 541 assertions.
0 failures, 0 errors.
```

That is the evidence the gate can now see the class. The plain-owner test in particular is the one that fails if somebody later re-implements the rejected owner-conditional remedy: it asserts the **row** copy and both **carrier** copies of one envelope project to the *same* content-addressed digest.

## Quality gates

Run foreground, captured to worktree-local logs, exit codes echoed.

| gate | command | result |
|---|---|---|
| epoch JVM (full) | `clojure -M:test` in `implementation/epoch` | **exit 0** — 537 tests, 7005 assertions, 0 failures |
| resources JVM (full) | `clojure -M:test` in `implementation/resources` | **exit 0** — 734 tests, 6820 assertions, 0 failures |
| focused egress namespace | `clojure -M:test -n re-frame.epoch-egress-resource-trace-test` | **exit 0** — 81 tests, 541 assertions (was 77 / 515) |
| focused conformance namespace | `clojure -M:test -n re-frame.epoch-mcp-egress-conformance-test` | **exit 0** — 22 tests, 212 assertions |
| non-vacuity (fix reverted) | same focused egress namespace | **exit 1** — 14 failures, as designed |

Deferred to CI, which runs the same surface: the full pre-checkin spine (`scripts/test-fast-pr.sh`), the CLJS lane, the browser smokes and the bundle-isolation / perf gates. Nothing here touches a CLJS-only path, a view, a build id or a bundle boundary — the change is one `.cljc` projector plus two JVM test files.
