### PR TITLE
freehand: pin the remembered projections by answer, not by store (rf2-xu6rx)

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/rules.cljc
+++ b/implementation/freehand/src/re_frame/freehand/rules.cljc
@@ -2094,10 +2094,10 @@
 ;; no longer only that. `re-frame.freehand.controlled/prop-slot` delegates to
 ;; it, `controlled-props?` maps that over EVERY attribute key of an element to
 ;; settle the controlled-input door, and the interpreted React walk asks
-;; `controlled-props?` TWICE per element — once in `react-props` and once for
-;; the `put-caller!` fold. So an ordinary four-attribute element re-derives
-;; eight slot names per render, and a keyed run of 300 such rows re-derives
-;; 2,400.
+;; `controlled-props?` once for every element it renders — both writers of an
+;; element's props share the one verdict. So an ordinary four-attribute element
+;; re-derives four slot names per render, and a keyed run of 300 such rows
+;; re-derives 1,200.
 ;;
 ;; The projection is `react-prop-name`, whose camelization is a `str/replace`
 ;; over a regex with a function replacement. A CPU profile of the interpreted

--- a/implementation/freehand/test/re_frame/freehand/conversion_memo_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/conversion_memo_cljs_test.cljc
@@ -1,0 +1,130 @@
+(ns re-frame.freehand.conversion-memo-cljs-test
+  "The remembered projections of `re-frame.freehand.conversion`, pinned by
+  what they ANSWER rather than by how they store it.
+
+  These caches changed representation under rf2-xu6rx: on ClojureScript the
+  store is now the host's own `js/Map` and on the JVM it stays a persistent
+  map in an atom, because a persistent map read on every attribute of every
+  element was itself 3.04% of an interpreted mount. A representation swap is
+  exactly the kind of change that can be invisible in the common case and
+  wrong at an edge, so what is asserted here is the contract a caller can
+  actually observe — the answer, the key space, and the bound — and never
+  the store. Nothing below reaches for `js/Map` or for an atom, and the file
+  is `.cljc` so both hosts answer the same table.
+
+  Each projection has an UNCACHED oracle in `re-frame.freehand.rules`, and
+  every assertion compares against that rather than against a literal, so a
+  cache that went stale or keyed wrongly fails here even if the expected
+  spelling were ever revised."
+  (:require #?(:clj  [clojure.test :refer [deftest is testing]]
+               :cljs [cljs.test :refer-macros [deftest is testing]])
+            [re-frame.freehand.conversion :as conv]
+            [re-frame.freehand.rules :as rules]))
+
+;; ===========================================================================
+;; The answer, on a miss and again on the hit
+;; ===========================================================================
+
+(def ^:private prop-names
+  ["class" "for" "tab-index" "read-only" "data-thing" "aria-label"
+   "not-a-real-attribute"])
+
+(def ^:private event-names
+  ["on-click" "on-double-click" "on-pointer-down"])
+
+(def ^:private style-names
+  ["font-size" "background-color" "-webkit-line-clamp" "-moz-appearance"
+   "-ms-flex" "--brand-accent" "color"])
+
+(deftest remembered-answers-what-the-uncached-projection-answers
+  (testing "asked once (a miss) and again (a hit), against the rules oracle"
+    (doseq [n prop-names]
+      (let [expected (rules/react-prop-name n)]
+        (is (= expected (conv/react-prop-name (keyword n))) n)
+        (is (= expected (conv/react-prop-name (keyword n))) n)))
+
+    (doseq [n event-names]
+      (let [expected (rules/react-event-name n)]
+        (is (= expected (conv/react-event-name (keyword n))) n)
+        (is (= expected (conv/react-event-name (keyword n))) n)))
+
+    (doseq [n style-names]
+      (let [expected (rules/react-style-name n)]
+        (is (= expected (conv/react-style-name n)) n)
+        (is (= expected (conv/react-style-name n)) n)))
+
+    (doseq [n prop-names]
+      (let [expected (rules/custom-element-property-name n)]
+        (is (= expected (conv/custom-element-property-name (keyword n))) n)
+        (is (= expected (conv/custom-element-property-name (keyword n))) n)))))
+
+;; ===========================================================================
+;; The key space — a cache MISS is a speed cost, never a different answer
+;; ===========================================================================
+;;
+;; `js/Map` compares strings by VALUE and everything else by IDENTITY, so a
+;; caller that mints `(keyword "class")` afresh on each render can miss a
+;; cache the persistent map would have hit. That trade is documented in
+;; `conversion` §The store, and it is only ever allowed to cost time: the
+;; projections are pure, so a miss recomputes the same answer. This is the
+;; assertion that keeps it that way. It deliberately does NOT assert
+;; anything about `identical?` — whether a given host interns a keyword is
+;; the representation detail this file refuses to depend on.
+
+(deftest a-freshly-minted-key-agrees-with-the-interned-one
+  (testing "keyword-keyed projections"
+    (doseq [n prop-names]
+      ;; The literal path first, so the cache is warm on the interned key
+      ;; before the minted one is asked.
+      (let [warm   (conv/react-prop-name (keyword n))
+            minted (conv/react-prop-name (keyword (str n)))]
+        (is (= warm minted) n)
+        (is (= (rules/react-prop-name n) minted) n))))
+
+  (testing "a string-keyed projection, where js/Map compares by value"
+    (doseq [n style-names]
+      (let [warm  (conv/react-style-name n)
+            built (conv/react-style-name (str n))]
+        (is (= warm built) n)
+        (is (= (rules/react-style-name n) built) n)))))
+
+;; ===========================================================================
+;; The bound — a cache limit, not a correctness limit
+;; ===========================================================================
+;;
+;; Every projection stops STORING past `conversion`'s 4096-entry limit and
+;; nothing is ever evicted, so a key space larger than the bound degrades to
+;; what the projection always cost. That is unchanged by the representation
+;; swap, and it is the property worth pinning: unbounded growth is refused,
+;; and refusing it never changes an answer.
+;;
+;; This saturates a real, shared, module-level cache, which is why it picks
+;; `custom-element-property-name` — the narrowest-traffic projection of the
+;; four. All of them share one `remembered`, so the mechanism is pinned by
+;; saturating any one of them, and the cost of doing it here is that later
+;; tests recompute this one projection instead of reading it. Correct either
+;; way, which is precisely the claim.
+
+(def ^:private beyond-the-bound 5000)
+
+(deftest past-the-bound-the-projection-is-still-total
+  (let [early :saturation-probe-early]
+    (testing "a key cached before the bound still answers"
+      (is (= (rules/custom-element-property-name (name early))
+             (conv/custom-element-property-name early))))
+
+    (dotimes [i beyond-the-bound]
+      (conv/custom-element-property-name (keyword (str "saturation-probe-" i))))
+
+    (testing "the early key still answers after the cache filled"
+      (is (= (rules/custom-element-property-name (name early))
+             (conv/custom-element-property-name early))))
+
+    (testing "a key first asked PAST the bound answers correctly, uncached"
+      (doseq [n ["past-the-bound-one" "past-the-bound-two"]]
+        (let [k (keyword n)]
+          (is (= (rules/custom-element-property-name n)
+                 (conv/custom-element-property-name k)) n)
+          ;; And again — an uncached projection is still idempotent.
+          (is (= (rules/custom-element-property-name n)
+                 (conv/custom-element-property-name k)) n))))))


### PR DESCRIPTION
Closes rf2-xu6rx.

## What this PR is, and what it is not

**The `js/Map` swap this bead asked for already landed**, in PR #7077 (merged
2026-07-26T05:12:59Z). `conversion.cljc` has carried
`#?(:cljs (js/Map.) :clj (atom {}))` since `bcfc568c69` — verifiable on `main`
independently of this branch.

This PR therefore contains **no runtime change at all**. Its `src` diff is
comment-only; the whole of it is two residuals that #7077 left behind.

### 1. A rationale block that described the call graph #7077 replaced

The comment above `caller-key-slot` still said the interpreted walk asks
`controlled-props?` **twice** per element, deriving eight slot names for a
four-attribute element and 2,400 for a keyed run of 300 rows. #7077
deliberately made it **one** question per element, settled once in
`element-node` and shared by both writers of the props.

The cache's justification is unchanged — the projection is still asked for
every attribute key of every element — so only the count moves: four per
element, 1,200 for the same 300 rows. The history of *why* it changed stays
beside the call site in `react.cljs`, rather than being told twice.

Named by the merged-PR audit of #7077.

### 2. Nothing pinned the caches across the representation swap

The store changed from a persistent map in an atom to a `js/Map` on
ClojureScript, and no test observed the difference either way.
`conversion-memo-cljs-test` now does, deliberately without naming `js/Map` or
an atom anywhere — it asserts what a caller can observe, never the store:

- **The answer**, on the miss and again on the hit, compared against each
  projection's *uncached* `rules` oracle rather than a literal.
- **The key space.** `js/Map` compares strings by value and everything else by
  **identity**, so a caller minting keywords per render misses a cache the
  persistent map would have hit. The documented trade is that this costs
  *time*; this is the assertion that keeps it from costing correctness.
- **The bound.** Past the 4096-entry limit the projection is still total.
  Nothing is evicted and nothing is stored past the limit, so a larger key
  space degrades to what the projection always cost — the same absence of
  eviction as before the swap.

The file is `.cljc`, so both hosts answer the same table and both arms of the
reader conditional inside `remembered` are covered.

## Measurement

**These are #7077's numbers, not this PR's.** This diff cannot move them —
re-running the bench on an arm that cannot change is exactly what the report's
Method section warns produces garbage (wall clock drifts 37% on this box on an
unchanged arm), so it was not re-run.

Floor-normalised in-run, alternated arms, 4 rounds clock + 2 rounds profile:

| Measure | Before | After |
|---|---|---|
| Substrate share of the W1 mount | 35.24% [35.08–35.39] | **30.91% [30.76–31.06]** |
| W1 interpreted / React floor | 2.568 | **1.904** (ranges disjoint) |
| W1 substrate overhead / floor | 1.568 | **0.904** (−42.4%) |
| W1 interpreted heap per mount | 10.22 MB | **5.71 MB** (−44.1%) |
| W1 **compiled** / floor (control) | 1.148 | 1.139 (ranges **overlap**, as required) |

Per-caller, as an inclusive share of the W1 interpreted mount — the two this
bead named:

| Caller | Before | After |
|---|---|---|
| `conversion/remembered` | 3.04% | **0.75%** |
| `rules/caller-key-slot` | 2.01% | **0.43%** |

The win is real rather than a straddle: the interpreted-arm ranges are
disjoint, and the compiled control's ranges overlap, which is the check that
says the mount got faster rather than the box getting quieter. `parity agree?`
was true in all 8 runs.

Bead candidate 2 (`top-layer/present?` via `contains?`) was **measured at 0.55%
and declined** in #7077 — settling it once needs wider `without`/`install!`
signatures for half a point.

## The clarity trade

The reader conditional doubles the body of `remembered`, so that one function
is modestly harder to read than the persistent-map version was — but the cost
is confined to a single 14-line private function plus a one-line constructor,
and all eight call sites still read exactly as before
(`(remembered style-name-cache css-name react-style-name*)`), which is why the
trade was judged worth 4.3 points of the mount.

## Quality gates

| Gate | Result | Exit |
|---|---|---|
| `clojure -M:test -n re-frame.freehand.conversion-memo-cljs-test` (JVM arm) | 3 tests, 82 assertions, 0 failures | `0` |
| `clojure -M:test` (full freehand JVM suite) | 1218 tests, 8212 assertions, 0 failures | `0` |
| `npm run test:cljs` | 11760 tests, 58599 assertions, 0 failures | `0` |
| `node out/node-test.js --test=re-frame.freehand.conversion-memo-cljs-test` (`js/Map` arm) | 3 tests, 82 assertions, 0 failures | `0` |

Both hosts report the same 3 tests / 82 assertions, which is the count the
table predicts (48 + 28 + 6) — the `doseq` bodies execute rather than passing
vacuously.

Anything heavier is deferred to CI.

## Risks

`past-the-bound-the-projection-is-still-total` saturates a real, shared,
module-level cache, so for the remainder of a test run
`custom-element-property-name` recomputes instead of reading. That projection
was chosen precisely because it is the narrowest-traffic of the four, all four
share one `remembered`, and correctness is unaffected — which is the claim the
test makes. Both full suites pass with it in place.
