### PR TITLE
test(pair-mcp): pin the consumer-facing error boundary (rf2-eaf20)

### DIFF
--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/error_boundary_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/error_boundary_test.cljs
@@ -1,70 +1,85 @@
 (ns re-frame2-pair-mcp.error-boundary-test
-  "The message a consumer's AI agent READS when a tool handler throws.
+  "What a consumer's AI agent actually READS when a pair-mcp tool throws.
 
-  `server.cljs`'s `invoke-and-guard` catches ANY throw out of a tool
-  handler and puts `(.-message err)` — verbatim, un-rewritten — into the
-  `:handler-threw` envelope the MCP client receives. That makes the
-  ex-message a CONSUMER contract, not tool-internal prose: the reader on
-  the other end is an agent trying to act on it. A bare `(str error-kw)`
-  ships that agent `:rf.error/pair-mcp-rt-let-binding-bad-shape` and
-  strands every actionable word in ex-data, which the relay does not send.
+  A bare-keyword ex-message is tolerable inside a tool's internals. It is
+  not tolerable once it is relayed onto the MCP tool surface, because the
+  reader there is an agent trying to ACT on it: `:rf.error/pair-mcp-…`
+  strands every actionable word somewhere the agent never sees. PR #7036
+  converted this surface's throws to the canonical Spec 009 shape — a
+  human sentence plus a trailing `[:rf.error/<id>]` greppability token —
+  and `tools/` is bundle-isolated from `re-frame.error`, so those
+  messages are hand-rolled at each site and no shared builder can keep
+  them honest. Until this namespace nothing stood behind them but a
+  docstring.
 
-  Every consumer-reachable throw here must therefore carry the canonical
-  Spec 009 shape: a human sentence PLUS a trailing `[:rf.error/<id>]`
-  greppability token. `tools/` is bundle-isolated and MUST NOT
-  `:require re-frame.error`, so these messages are hand-rolled at each
-  throw site and no shared builder can enforce them — only a boundary
-  assertion can. PR #7036 landed the conversions; until this namespace
-  nothing stood behind them but a docstring, and reverting any of them to
-  a bare keyword was a green change.
+  ## Two relays, not one — the finding this bead turned up
 
-  ## Which throws this covers, and why not the others
+  `tools/re-frame2-pair-mcp/src` has exactly four `throw` sites, and a
+  throw reaches the agent by one of two DIFFERENT relays depending on
+  WHERE in a tool body it fires. The two relays keep opposite halves of
+  the exception:
 
-  `tools/re-frame2-pair-mcp/src` has exactly four `throw` sites. Only two
-  are relayed to a consumer as a MESSAGE:
+  - `server.cljs` `invoke-and-guard` → `{:reason :handler-threw :message
+    (.-message err)}`. Keeps the MESSAGE, drops the ex-data. Reached by
+    anything thrown while the tool body builds its request — before the
+    nREPL round-trip.
 
-    - `tools/eval-form`     `emit-name`         — rt-let binding shape.
-    - `tools/wire-pipeline` `run-wire-pipeline` — unknown payload `:kind`.
+  - `tools/probe.cljs` `err->result` → `(merge {:ok? false} (ex-data
+    err))`. Keeps the EX-DATA, drops the message entirely. Reached by
+    anything thrown from the `on-value` callback of
+    `eval-after-runtime!` / `eval-after-runtime-signalled!` — i.e. all
+    response shaping, after the round-trip.
 
-  The other two (`server.cljs`'s `:rf.error/pair-mcp-ambiguous-shadow`
-  and `:rf.error/pair-mcp-nrepl-port-not-found`) are raised INSIDE
-  discovery and caught by `handle-call*`'s own `.catch`, which rebuilds a
-  structured payload from `:rf.error/id` and never reads the message.
-  Their bare-keyword messages are tool-internal and stay that way.
+  Which relay a given throw meets decides which half of the Spec 009
+  shape the agent can read, so each is pinned here at its own boundary:
+
+  - **rt-let binding shape** (`tools/eval-form` `emit-name`) fires during
+    synchronous form construction, so it meets `invoke-and-guard`. Its
+    message IS the consumer contract, and the first test pins the human
+    sentence and the token end to end.
+
+  - **unknown wire `:kind`** (`tools/wire-pipeline` `run-wire-pipeline`)
+    fires only from response shaping — all five call sites across
+    `snapshot`, `get-path`, `read-sub`, `trace-window` and `watch-epochs`
+    sit inside an `on-value` callback — so it meets `err->result`, whose
+    ex-data half carries the agent's sentence in `:reason` and its
+    discriminator in `:rf.error/id`. That is what the second test pins.
+    Its ex-MESSAGE is unreachable by any consumer; see rf2-lqhda.
+
+  The other two throws (`server.cljs`'s `:rf.error/pair-mcp-ambiguous-shadow`
+  and `:rf.error/pair-mcp-nrepl-port-not-found`) are raised inside discovery
+  and caught by `handle-call*`'s own arm, which rebuilds a payload from
+  `:rf.error/id` and never reads the message. Their bare-keyword messages
+  are genuinely tool-internal and stay that way.
 
   The rf2-jquiy audit also named a diff-encode validation family. It is
-  not reachable from this surface: `mcp-base`'s grammar gate resolves
-  `malli.core/validate` at runtime and soft-passes when Malli is absent,
-  and Malli is deliberately absent from pair-mcp's CLJS classpath (see
-  `tools/mcp-base/deps.edn`) — while the SHIPPED `:server` build
-  additionally DCEs the gate outright via `:closure-defines
+  not reachable from this surface at all: mcp-base's grammar gate
+  resolves `malli.core/validate` at runtime and soft-passes when Malli is
+  absent — and Malli is deliberately absent from pair-mcp's CLJS
+  classpath (`tools/mcp-base/deps.edn`) — while the shipped `:server`
+  build additionally DCEs the gate via `:closure-defines
   {re-frame.mcp-base.diff-encode/validate-patches? false}`. A row for it
   could not fail in either build, and a boundary row that cannot fail is
   decoration.
 
-  ## What is real here and what is forced
+  ## What is real here, and what is forced
 
-  Both covered throws are programmer-typo guards: all twelve `rt-let`
-  call sites pass literal quoted symbols, and every `run-wire-pipeline`
-  call site passes a literal `:kind`. No tool ARGUMENT reaches either, so
-  no MCP request can trigger them from outside — which is exactly why
-  they were unpinned, and exactly why the regression they guard against
-  (a future edit reverting the message) is invisible to every other test.
+  Both covered throws are programmer-typo guards: every `rt-let` call
+  site passes literal quoted symbols and every `run-wire-pipeline` call
+  site passes a literal `:kind`, so no tool ARGUMENT reaches either. That
+  is exactly why they were unpinned, and exactly why a future edit
+  reverting one of their messages is invisible to every other test.
 
-  So the exception is produced by the REAL producer — `ef/emit` over a
-  real malformed `ef/rt-let`, and a real `wp/run-wire-pipeline` call with
-  an out-of-vocabulary `:kind`, both public fns, no seam — and then made
-  to escape a real tool handler by seaming the one thing the handler
-  trusts, `nrepl/cljs-eval-value`. Everything downstream of the throw is
-  the shipped path: real `handle-call` → real `ensure-connection!` (over
-  a seeded conn) → real `tools/invoke` → real `invoke-and-guard` → real
-  `wire/result`. The trigger is forced; the message, the relay and the
-  envelope are not.
-
-  `handler-threw-relays-the-producers-message-verbatim` is the control
-  that closes the causal loop: the relay is proven to be a pass-through,
-  so a message regression AT THE PRODUCER is a message regression AT THE
-  CONSUMER."
+  So the seam corrupts only the INPUT, at the production call site, and
+  nothing else: the real `ef/rt-let` builds the malformed binding vector,
+  the real `ef/emit` walks it, the real `emit-name` composes the message,
+  and the real `run-wire-pipeline` rejects the real out-of-vocabulary
+  `:kind`. Downstream of the throw everything is the shipped path — real
+  `handle-call` → real `ensure-connection!` (over a seeded conn) → real
+  `tools/invoke` → real relay → real envelope. `trace-window` is the
+  carrier for both because one tool body reaches both relays: it builds
+  its form with `ef/rt-let` and shapes its response with
+  `run-wire-pipeline`."
   (:require [cljs.test :refer-macros [deftest is testing async use-fixtures]]
             [clojure.string :as str]
             [re-frame2-pair-mcp.nrepl :as nrepl]
@@ -81,110 +96,151 @@
 ;; The real boundary.
 ;; ---------------------------------------------------------------------------
 
-(defn- relay
-  "Drive the REAL `tools/call` path with `thrown` escaping a real tool
-  handler, and return a Promise of the MCP result envelope the SDK ships.
+(def ^:private trace-canned
+  "What `trace-window`'s eval form returns after server-side slicing. An
+  empty page: the rows assert on the ERROR path, so the payload only has
+  to let the happy path reach the response-shaping step."
+  {:epochs [] :id-aged-out? false :requested-id nil
+   :head-id nil :next-id nil :history-count 0 :remaining 0})
+
+(defn- drive
+  "Drive the REAL `tools/call` path for `trace-window` and return a
+  Promise of the MCP result envelope the SDK ships.
 
   Seeding the conn via `mark-discovered-for-tests!` (no port-file, so
-  `ensure-connection!` takes its cached fast path) is what puts the drive
-  through `handle-call*` → `invoke-and-guard` rather than the discovery-
-  error arm — the distinction the `:handler-threw` assertions rest on."
-  [thrown]
+  `ensure-connection!` takes its cached fast path) is what routes the
+  drive through `handle-call*` → `tools/invoke` rather than the
+  discovery-error arm — the distinction every assertion below rests on.
+  The eval stub answers the runtime-preload probe `true` and every other
+  form with `trace-canned`, mirroring `trace_window_test`."
+  []
   (server/reset-session-state-for-tests!)
   (server/mark-discovered-for-tests! (nrepl/make-conn 0 "127.0.0.1"))
   (let [orig nrepl/cljs-eval-value
-        stub (fn [& _] (js/Promise.reject thrown))]
+        answer (fn [form-str]
+                 (js/Promise.resolve
+                   (if (re-find #"__re_frame2_pair_runtime" form-str)
+                     true
+                     trace-canned)))
+        stub (fn
+               ([_conn _build-id form-str] (answer form-str))
+               ([_conn _build-id form-str _opts] (answer form-str)))]
     (set! nrepl/cljs-eval-value stub)
-    (-> (server/handle-call-for-tests {} "snapshot" #js {} nil)
+    (-> (server/handle-call-for-tests {} "trace-window"
+                                      (tu/args->js {:ms 1000}) nil)
         (.finally (fn [] (tu/restore-eval! stub orig))))))
 
-(defn- threw
-  "Return the exception `f` throws. Fails loudly when it does not — a row
-  whose producer stopped throwing would otherwise assert nothing at all."
-  [label f]
-  (let [e (try (f) nil (catch :default e e))]
-    (is (some? e)
-        (str label ": the production producer must still throw"))
-    e))
+(defn- drive-with-seam
+  "Install `seam-fn` over the var `get-orig` reads, drive the boundary,
+  hand the envelope to `check`, and restore. Restore is identity-guarded
+  the same way `tu/restore-eval!` is, so a late `.finally` cannot clobber
+  a neighbouring test's seam."
+  [install! restore! seam check done]
+  (install! seam)
+  (-> (drive)
+      (.then (fn [result] (check result)))
+      (.catch (fn [e]
+                (is false (str "the boundary drive rejected: " (.-message e)))))
+      (.finally (fn [] (restore! seam) (done)))))
 
 ;; ---------------------------------------------------------------------------
-;; The table. One row per consumer-relayed throw family.
+;; Relay 1 — `invoke-and-guard`: the MESSAGE is the consumer contract.
 ;; ---------------------------------------------------------------------------
 
-(def ^:private families
-  [{:label   "an rt-let binding name that is not a symbol"
-    :produce #(ef/emit (ef/rt-let ["snap" (ef/rt-call 'snapshot)]
-                                  (ef/rt-raw "snap")))
-    :human   #"rt-let binding name must be a symbol"
-    :token   "[:rf.error/pair-mcp-rt-let-binding-bad-shape]"}
-
-   {:label   "a wire-pipeline :kind outside the closed dispatch"
-    :produce #(wp/run-wire-pipeline {} {:kind :snapshot-mapp})
-    :human   #"expected one of :snapshot-map, :epoch-vector, :scalar-value"
-    :token   "[:rf.error/pair-mcp-unknown-wire-pipeline-kind]"}])
-
-(deftest thrown-error-shape-reaches-the-consumer-facing-surface
-  ;; Reverting either message to a bare `(str error-kw)` reds the `human`
-  ;; row; dropping the trailing token reds the `token` row; a regression
-  ;; that turns the relay into a rejected promise reds `tool-error?` on
-  ;; every row at once.
+(deftest rt-let-binding-shape-reaches-the-agent-as-a-readable-message
+  ;; Reverting `emit-name`'s message to a bare `(str error-kw)` reds the
+  ;; sentence assertion; dropping the trailing token reds the token
+  ;; assertion; a regression that turns the tool error into a rejected
+  ;; promise reds `tu/error?` and takes the whole row with it.
   (async done
-    (-> (reduce
-          (fn [p {:keys [label produce human token]}]
-            (.then
-              p
-              (fn [_]
-                (let [e   (threw label produce)
-                      msg (ex-message e)]
-                  (testing (str label " — at the producer")
-                    (is (re-find human msg)
-                        (str label ": the message carries the human sentence,"
-                             " not just a keyword\n  got: " (pr-str msg)))
-                    (is (str/includes? msg token)
-                        (str label ": the canonical [:rf.error/…] token rides"
-                             " the message\n  got: " (pr-str msg))))
-                  (-> (relay e)
-                      (.then
-                        (fn [result]
-                          (testing (str label " — at the consumer surface")
-                            (is (tu/error? result)
-                                (str label ": a handler throw is an MCP tool"
-                                     " error, not a rejected promise"))
-                            (let [edn (tu/extract-edn result)]
-                              (is (= :handler-threw (:reason edn))
-                                  (str label ": the drive really went through"
-                                       " invoke-and-guard's relay"))
-                              (is (re-find human (:message edn))
-                                  (str label ": the human sentence survives the"
-                                       " relay to the agent\n  got: "
-                                       (pr-str (:message edn))))
-                              (is (str/includes? (:message edn) token)
-                                  (str label ": the token survives the relay to"
-                                       " the agent\n  got: "
-                                       (pr-str (:message edn)))))))))))))
-          (js/Promise.resolve nil)
-          families)
-        (.then (fn [_] (done)))
-        (.catch (fn [e]
-                  (is false (str "the boundary drive rejected: " (.-message e)))
-                  (done))))))
+    (let [orig ef/rt-let
+          ;; The REAL constructor, handed a binding name that is not a
+          ;; symbol. `trace-window` then emits this form itself, and the
+          ;; real `emit-name` composes the message under test.
+          seam (fn [bindings & body-forms]
+                 (apply orig (assoc (vec bindings) 0 "not-a-symbol") body-forms))]
+      (drive-with-seam
+        (fn [s] (set! ef/rt-let s))
+        (fn [s] (when (identical? ef/rt-let s) (set! ef/rt-let orig)))
+        seam
+        (fn [result]
+          (is (tu/error? result)
+              "a handler throw is an MCP tool error, not a rejected promise")
+          (let [edn (tu/extract-edn result)
+                msg (:message edn)]
+            (is (= :handler-threw (:reason edn))
+                "form construction throws BEFORE the round-trip, so the
+                 drive really did meet invoke-and-guard's relay")
+            (is (re-find #"rt-let binding name must be a symbol" msg)
+                (str "the agent reads a human sentence, not a keyword\n  got: "
+                     (pr-str msg)))
+            (is (str/includes? msg "[:rf.error/pair-mcp-rt-let-binding-bad-shape]")
+                (str "the canonical [:rf.error/…] token rides the message\n  got: "
+                     (pr-str msg)))))
+        done))))
 
-(deftest handler-threw-relays-the-producers-message-verbatim
-  ;; The control, and the reason the producer-side assertions above are
-  ;; load-bearing rather than a unit test in disguise: `invoke-and-guard`
-  ;; adds nothing and rewrites nothing. Whatever the producer put in the
-  ;; message is what the agent reads — so a producer-side regression is a
-  ;; consumer-side regression, with no intermediate to absorb it.
+(deftest invoke-and-guard-relays-the-producers-message-verbatim
+  ;; The control, and the reason the row above is a BOUNDARY row rather
+  ;; than a unit test in disguise: `invoke-and-guard` adds nothing and
+  ;; rewrites nothing. Whatever the producer put in the message is what
+  ;; the agent reads — so a producer-side message regression is, with no
+  ;; intermediate to absorb it, a consumer-side regression.
   (async done
-    (-> (relay (ex-info "a plain sentence with no token at all" {:x 1}))
-        (.then (fn [result]
-                 (is (tu/error? result))
-                 (let [edn (tu/extract-edn result)]
-                   (is (= :handler-threw (:reason edn)))
-                   (is (= "a plain sentence with no token at all"
-                          (:message edn))
-                       "the relay is a pass-through — it neither trims nor
-                        decorates the producer's message"))))
-        (.catch (fn [e]
-                  (is false (str "the boundary drive rejected: " (.-message e)))))
-        (.finally (fn [] (done))))))
+    (let [orig ef/rt-let
+          seam (fn [& _] (throw (ex-info "a plain sentence, no token" {:x 1})))]
+      (drive-with-seam
+        (fn [s] (set! ef/rt-let s))
+        (fn [s] (when (identical? ef/rt-let s) (set! ef/rt-let orig)))
+        seam
+        (fn [result]
+          (is (tu/error? result))
+          (let [edn (tu/extract-edn result)]
+            (is (= :handler-threw (:reason edn)))
+            (is (= "a plain sentence, no token" (:message edn))
+                "the relay neither trims nor decorates the producer's message")))
+        done))))
+
+;; ---------------------------------------------------------------------------
+;; Relay 2 — `probe/err->result`: the EX-DATA is the consumer contract.
+;; ---------------------------------------------------------------------------
+
+(deftest unknown-wire-pipeline-kind-reaches-the-agent-as-readable-ex-data
+  ;; Reverting the ex-data's `:reason` to a bare keyword reds the sentence
+  ;; assertion; dropping `:rf.error/id` reds the discriminator assertion.
+  (async done
+    (let [orig wp/run-wire-pipeline
+          ;; The REAL pipeline, handed a `:kind` outside its closed
+          ;; three-case dispatch — the shape a contributor adding a new
+          ;; payload kind, or typing an existing one, actually produces.
+          seam (fn [payload opts] (orig payload (assoc opts :kind :not-a-wire-kind)))]
+      (drive-with-seam
+        (fn [s] (set! wp/run-wire-pipeline s))
+        (fn [s] (when (identical? wp/run-wire-pipeline s)
+                  (set! wp/run-wire-pipeline orig)))
+        seam
+        (fn [result]
+          (is (tu/error? result)
+              "a response-shaping throw is a tool error, not a rejected promise")
+          (let [edn (tu/extract-edn result)]
+            (is (= false (:ok? edn))
+                "response shaping throws AFTER the round-trip, so the drive
+                 really did meet err->result's relay")
+            (is (= :rf.error/pair-mcp-unknown-wire-pipeline-kind
+                   (:rf.error/id edn))
+                "the machine discriminator the agent BRANCHES on rides the
+                 wire, namespace intact")
+            (is (re-find #"unknown :kind" (str (:reason edn)))
+                (str "and the human sentence the agent READS rides with it\n  got: "
+                     (pr-str (:reason edn))))
+            (is (= :not-a-wire-kind (:kind edn))
+                "along with the actionable slot — WHICH kind was unknown")
+            ;; The finding, made durable. `err->result` relays ex-data and
+            ;; DROPS `(ex-message err)`, so `run-wire-pipeline`'s carefully
+            ;; composed message — and the `[:rf.error/…]` token in it —
+            ;; reaches nobody. If this ever goes non-nil, that is the
+            ;; improvement rf2-lqhda asks for: assert the message here and
+            ;; correct the claim in `wire_pipeline.cljs`'s throw comment,
+            ;; which today describes relay 1's behaviour at a relay-2 site.
+            (is (nil? (:message edn))
+                "the ex-MESSAGE does not reach a consumer at this relay")))
+        done))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/error_boundary_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/error_boundary_test.cljs
@@ -1,0 +1,190 @@
+(ns re-frame2-pair-mcp.error-boundary-test
+  "The message a consumer's AI agent READS when a tool handler throws.
+
+  `server.cljs`'s `invoke-and-guard` catches ANY throw out of a tool
+  handler and puts `(.-message err)` — verbatim, un-rewritten — into the
+  `:handler-threw` envelope the MCP client receives. That makes the
+  ex-message a CONSUMER contract, not tool-internal prose: the reader on
+  the other end is an agent trying to act on it. A bare `(str error-kw)`
+  ships that agent `:rf.error/pair-mcp-rt-let-binding-bad-shape` and
+  strands every actionable word in ex-data, which the relay does not send.
+
+  Every consumer-reachable throw here must therefore carry the canonical
+  Spec 009 shape: a human sentence PLUS a trailing `[:rf.error/<id>]`
+  greppability token. `tools/` is bundle-isolated and MUST NOT
+  `:require re-frame.error`, so these messages are hand-rolled at each
+  throw site and no shared builder can enforce them — only a boundary
+  assertion can. PR #7036 landed the conversions; until this namespace
+  nothing stood behind them but a docstring, and reverting any of them to
+  a bare keyword was a green change.
+
+  ## Which throws this covers, and why not the others
+
+  `tools/re-frame2-pair-mcp/src` has exactly four `throw` sites. Only two
+  are relayed to a consumer as a MESSAGE:
+
+    - `tools/eval-form`     `emit-name`         — rt-let binding shape.
+    - `tools/wire-pipeline` `run-wire-pipeline` — unknown payload `:kind`.
+
+  The other two (`server.cljs`'s `:rf.error/pair-mcp-ambiguous-shadow`
+  and `:rf.error/pair-mcp-nrepl-port-not-found`) are raised INSIDE
+  discovery and caught by `handle-call*`'s own `.catch`, which rebuilds a
+  structured payload from `:rf.error/id` and never reads the message.
+  Their bare-keyword messages are tool-internal and stay that way.
+
+  The rf2-jquiy audit also named a diff-encode validation family. It is
+  not reachable from this surface: `mcp-base`'s grammar gate resolves
+  `malli.core/validate` at runtime and soft-passes when Malli is absent,
+  and Malli is deliberately absent from pair-mcp's CLJS classpath (see
+  `tools/mcp-base/deps.edn`) — while the SHIPPED `:server` build
+  additionally DCEs the gate outright via `:closure-defines
+  {re-frame.mcp-base.diff-encode/validate-patches? false}`. A row for it
+  could not fail in either build, and a boundary row that cannot fail is
+  decoration.
+
+  ## What is real here and what is forced
+
+  Both covered throws are programmer-typo guards: all twelve `rt-let`
+  call sites pass literal quoted symbols, and every `run-wire-pipeline`
+  call site passes a literal `:kind`. No tool ARGUMENT reaches either, so
+  no MCP request can trigger them from outside — which is exactly why
+  they were unpinned, and exactly why the regression they guard against
+  (a future edit reverting the message) is invisible to every other test.
+
+  So the exception is produced by the REAL producer — `ef/emit` over a
+  real malformed `ef/rt-let`, and a real `wp/run-wire-pipeline` call with
+  an out-of-vocabulary `:kind`, both public fns, no seam — and then made
+  to escape a real tool handler by seaming the one thing the handler
+  trusts, `nrepl/cljs-eval-value`. Everything downstream of the throw is
+  the shipped path: real `handle-call` → real `ensure-connection!` (over
+  a seeded conn) → real `tools/invoke` → real `invoke-and-guard` → real
+  `wire/result`. The trigger is forced; the message, the relay and the
+  envelope are not.
+
+  `handler-threw-relays-the-producers-message-verbatim` is the control
+  that closes the causal loop: the relay is proven to be a pass-through,
+  so a message regression AT THE PRODUCER is a message regression AT THE
+  CONSUMER."
+  (:require [cljs.test :refer-macros [deftest is testing async use-fixtures]]
+            [clojure.string :as str]
+            [re-frame2-pair-mcp.nrepl :as nrepl]
+            [re-frame2-pair-mcp.server :as server]
+            [re-frame2-pair-mcp.test-utils :as tu]
+            [re-frame2-pair-mcp.tools.eval-form :as ef]
+            [re-frame2-pair-mcp.tools.wire-pipeline :as wp]))
+
+(use-fixtures :each
+  {:before (fn [] (server/reset-session-state-for-tests!))
+   :after  (fn [] (server/reset-session-state-for-tests!))})
+
+;; ---------------------------------------------------------------------------
+;; The real boundary.
+;; ---------------------------------------------------------------------------
+
+(defn- relay
+  "Drive the REAL `tools/call` path with `thrown` escaping a real tool
+  handler, and return a Promise of the MCP result envelope the SDK ships.
+
+  Seeding the conn via `mark-discovered-for-tests!` (no port-file, so
+  `ensure-connection!` takes its cached fast path) is what puts the drive
+  through `handle-call*` → `invoke-and-guard` rather than the discovery-
+  error arm — the distinction the `:handler-threw` assertions rest on."
+  [thrown]
+  (server/reset-session-state-for-tests!)
+  (server/mark-discovered-for-tests! (nrepl/make-conn 0 "127.0.0.1"))
+  (let [orig nrepl/cljs-eval-value
+        stub (fn [& _] (js/Promise.reject thrown))]
+    (set! nrepl/cljs-eval-value stub)
+    (-> (server/handle-call-for-tests {} "snapshot" #js {} nil)
+        (.finally (fn [] (tu/restore-eval! stub orig))))))
+
+(defn- threw
+  "Return the exception `f` throws. Fails loudly when it does not — a row
+  whose producer stopped throwing would otherwise assert nothing at all."
+  [label f]
+  (let [e (try (f) nil (catch :default e e))]
+    (is (some? e)
+        (str label ": the production producer must still throw"))
+    e))
+
+;; ---------------------------------------------------------------------------
+;; The table. One row per consumer-relayed throw family.
+;; ---------------------------------------------------------------------------
+
+(def ^:private families
+  [{:label   "an rt-let binding name that is not a symbol"
+    :produce #(ef/emit (ef/rt-let ["snap" (ef/rt-call 'snapshot)]
+                                  (ef/rt-raw "snap")))
+    :human   #"rt-let binding name must be a symbol"
+    :token   "[:rf.error/pair-mcp-rt-let-binding-bad-shape]"}
+
+   {:label   "a wire-pipeline :kind outside the closed dispatch"
+    :produce #(wp/run-wire-pipeline {} {:kind :snapshot-mapp})
+    :human   #"expected one of :snapshot-map, :epoch-vector, :scalar-value"
+    :token   "[:rf.error/pair-mcp-unknown-wire-pipeline-kind]"}])
+
+(deftest thrown-error-shape-reaches-the-consumer-facing-surface
+  ;; Reverting either message to a bare `(str error-kw)` reds the `human`
+  ;; row; dropping the trailing token reds the `token` row; a regression
+  ;; that turns the relay into a rejected promise reds `tool-error?` on
+  ;; every row at once.
+  (async done
+    (-> (reduce
+          (fn [p {:keys [label produce human token]}]
+            (.then
+              p
+              (fn [_]
+                (let [e   (threw label produce)
+                      msg (ex-message e)]
+                  (testing (str label " — at the producer")
+                    (is (re-find human msg)
+                        (str label ": the message carries the human sentence,"
+                             " not just a keyword\n  got: " (pr-str msg)))
+                    (is (str/includes? msg token)
+                        (str label ": the canonical [:rf.error/…] token rides"
+                             " the message\n  got: " (pr-str msg))))
+                  (-> (relay e)
+                      (.then
+                        (fn [result]
+                          (testing (str label " — at the consumer surface")
+                            (is (tu/error? result)
+                                (str label ": a handler throw is an MCP tool"
+                                     " error, not a rejected promise"))
+                            (let [edn (tu/extract-edn result)]
+                              (is (= :handler-threw (:reason edn))
+                                  (str label ": the drive really went through"
+                                       " invoke-and-guard's relay"))
+                              (is (re-find human (:message edn))
+                                  (str label ": the human sentence survives the"
+                                       " relay to the agent\n  got: "
+                                       (pr-str (:message edn))))
+                              (is (str/includes? (:message edn) token)
+                                  (str label ": the token survives the relay to"
+                                       " the agent\n  got: "
+                                       (pr-str (:message edn)))))))))))))
+          (js/Promise.resolve nil)
+          families)
+        (.then (fn [_] (done)))
+        (.catch (fn [e]
+                  (is false (str "the boundary drive rejected: " (.-message e)))
+                  (done))))))
+
+(deftest handler-threw-relays-the-producers-message-verbatim
+  ;; The control, and the reason the producer-side assertions above are
+  ;; load-bearing rather than a unit test in disguise: `invoke-and-guard`
+  ;; adds nothing and rewrites nothing. Whatever the producer put in the
+  ;; message is what the agent reads — so a producer-side regression is a
+  ;; consumer-side regression, with no intermediate to absorb it.
+  (async done
+    (-> (relay (ex-info "a plain sentence with no token at all" {:x 1}))
+        (.then (fn [result]
+                 (is (tu/error? result))
+                 (let [edn (tu/extract-edn result)]
+                   (is (= :handler-threw (:reason edn)))
+                   (is (= "a plain sentence with no token at all"
+                          (:message edn))
+                       "the relay is a pass-through — it neither trims nor
+                        decorates the producer's message"))))
+        (.catch (fn [e]
+                  (is false (str "the boundary drive rejected: " (.-message e)))))
+        (.finally (fn [] (done))))))

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/error_boundary_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/error_boundary_test.cljs
@@ -44,7 +44,7 @@
     sit inside an `on-value` callback — so it meets `err->result`, whose
     ex-data half carries the agent's sentence in `:reason` and its
     discriminator in `:rf.error/id`. That is what the second test pins.
-    Its ex-MESSAGE is unreachable by any consumer; see rf2-lqhda.
+    Its ex-MESSAGE is unreachable by any consumer; see rf2-6tzm5.
 
   The other two throws (`server.cljs`'s `:rf.error/pair-mcp-ambiguous-shadow`
   and `:rf.error/pair-mcp-nrepl-port-not-found`) are raised inside discovery
@@ -131,10 +131,11 @@
         (.finally (fn [] (tu/restore-eval! stub orig))))))
 
 (defn- drive-with-seam
-  "Install `seam-fn` over the var `get-orig` reads, drive the boundary,
-  hand the envelope to `check`, and restore. Restore is identity-guarded
-  the same way `tu/restore-eval!` is, so a late `.finally` cannot clobber
-  a neighbouring test's seam."
+  "Install `seam` over its production var, drive the boundary, hand the
+  envelope to `check`, then restore. `install!` / `restore!` are 1-arity
+  fns over the seam because CLJS `set!` needs the var literal at the call
+  site. Restore is identity-guarded the same way `tu/restore-eval!` is,
+  so a late `.finally` cannot clobber a neighbouring test's seam."
   [install! restore! seam check done]
   (install! seam)
   (-> (drive)
@@ -238,7 +239,7 @@
             ;; DROPS `(ex-message err)`, so `run-wire-pipeline`'s carefully
             ;; composed message — and the `[:rf.error/…]` token in it —
             ;; reaches nobody. If this ever goes non-nil, that is the
-            ;; improvement rf2-lqhda asks for: assert the message here and
+            ;; improvement rf2-6tzm5 asks for: assert the message here and
             ;; correct the claim in `wire_pipeline.cljs`'s throw comment,
             ;; which today describes relay 1's behaviour at a relay-2 site.
             (is (nil? (:message edn))


### PR DESCRIPTION
The pair-mcp half of rf2-jquiy's boundary proof. The sibling half (story-mcp) is PR #7123; this one was outside that worker's file-ownership fence.

## Why the proof exists

`server.cljs`'s `invoke-and-guard` relays `(.-message err)` verbatim into the `:handler-threw` envelope an MCP client receives, so a tool handler's ex-message is a **consumer** contract — the reader is an agent trying to act on it, and `:rf.error/pair-mcp-…` on its own strands every actionable word. PR #7036 converted this surface's throws to the canonical Spec 009 shape; nothing but a docstring stood behind them afterwards, and `tools/` is bundle-isolated from `re-frame.error` so no shared builder can enforce them. Reverting either message to a bare `(str error-kw)` was a green change.

## What was already pinned, and what this adds

Nothing was pinned. A grep of the whole pair-mcp + mcp-base test corpus for `pair-mcp-rt-let-binding-bad-shape`, `pair-mcp-unknown-wire-pipeline-kind` and `handler-threw` returns one comment and zero assertions. The nearest existing test, `eval_form_test/rt-let-binding-name-must-be-symbol`, is `(is (thrown? :default …))` — it stays green under every message mutation below. mcp-base's diff-encode tests pin `:rf.error/id` in ex-data, never the message.

## The finding: two relays, not one

Driving the real boundary showed the audit's premise was only half true. A pair-mcp throw reaches the agent by one of **two** relays, and they keep **opposite halves** of the exception:

| relay | keeps | drops | reached from |
|---|---|---|---|
| `server.cljs` `invoke-and-guard` | `(.-message err)` | ex-data | anything thrown while a tool body builds its request, before the nREPL round-trip |
| `tools/probe.cljs` `err->result` | `(ex-data err)` | the message entirely | anything thrown from an `eval-after-runtime!` / `…-signalled!` `on-value` callback — i.e. all response shaping |

So the two throws are pinned at **their own** relays:

- **rt-let binding shape** (`tools/eval_form.cljs` `emit-name`) fires during synchronous form construction, meets `invoke-and-guard`, and its message really is the consumer contract. Pinned end to end: human sentence + the `[:rf.error/pair-mcp-rt-let-binding-bad-shape]` token.
- **unknown wire `:kind`** (`tools/wire_pipeline.cljs` `run-wire-pipeline`) fires only from response shaping — all five call sites (`snapshot`, `get-path`, `read-sub`, `trace-window`, `watch-epochs`) sit inside an `on-value` — so it meets `err->result` and its **ex-message reaches nobody**. Pinned at what the agent actually reads there: `:rf.error/id` + the `:reason` sentence + the actionable `:kind` slot, with a commented tripwire on the dropped message so the asymmetry stays discoverable.

`trace-window` carries both rows because one tool body reaches both relays.

### Deliberately not covered

- `server.cljs`'s `:rf.error/pair-mcp-ambiguous-shadow` / `:rf.error/pair-mcp-nrepl-port-not-found` are caught by `handle-call*`'s discovery arm, which rebuilds a payload from `:rf.error/id` and never reads the message. Their bare-keyword messages are genuinely tool-internal.
- The audit's **diff-encode validation family is unreachable from this surface**. mcp-base's grammar gate resolves `malli.core/validate` at runtime and soft-passes when Malli is absent — and Malli is deliberately absent from pair-mcp's CLJS classpath (`tools/mcp-base/deps.edn`) — while the shipped `:server` build additionally DCEs the gate via `:closure-defines {re-frame.mcp-base.diff-encode/validate-patches? false}`. A row for it could not fail in either build, and a boundary row that cannot fail is decoration.

### What is real, what is forced

Both throws are programmer-typo guards: every `rt-let` call site passes literal quoted symbols, every `run-wire-pipeline` call site passes a literal `:kind`. That is exactly why they were unpinned. The seam therefore corrupts only the **input**, at the production call site — the real `ef/rt-let` builds the malformed binding vector, the real `ef/emit`/`emit-name` composes the message, the real `run-wire-pipeline` rejects the real out-of-vocabulary `:kind`. Downstream of the throw everything is the shipped path: real `handle-call` → real `ensure-connection!` (seeded conn) → real `tools/invoke` → real relay → real envelope. No proxy, no synthetic assertion on a helper.

## Follow-on bead

**rf2-6tzm5** (P2, bug) — `wire_pipeline.cljs`'s throw comment claims `invoke-and-guard` relays its message to the agent. That is false for this throw site: `err->result` drops it. The composed message + token is dead prose. Two candidate fixes (make `err->result` carry both halves, or correct the comment) — a production **source** change, so filed rather than done here.

## Quality gates

Foreground, worktree-local logs, exit codes echoed.

| gate | command | exit |
|---|---|---|
| pair-mcp full CLJS suite | `npm test` (`shadow-cljs :server-test`) — **1217 tests / 4298 assertions, 0 failures, 0 errors** | `0` |
| new ns, focused | `shadow-cljs compile server-test --config-merge` with `:ns-regexp "error-boundary-test$"` — 3 tests / 13 assertions | `0` |
| MCP conformance (pair-mcp) | `tools/mcp-conformance` → `npm run test:re-frame2-pair` — `RE-FRAME2-PAIR-MCP MCP-CLIENT CONFORMANCE GREEN` | `0` |
| tool-descriptor drift | `npm run check:descriptors` — `OK: tool-descriptors.edn in sync (35 tools)` | `0` |
| shipped server bundle | `npm run build` (`shadow-cljs :server`) — 0 warnings | `0` |

Deferred to CI: `scripts/test-fast-pr.sh` and the full spine, the JVM mcp-base suite, and every non-pair-mcp surface. The diff is one new CLJS test file under `tools/re-frame2-pair-mcp/test/`, so no other surface is reachable from it.

### Mutation evidence

A boundary row that cannot fail is decoration, so each row was broken at its producer and observed to red by name.

**1. `eval_form.cljs` — message reverted to a bare keyword.** `(str "rt-let binding name must be a symbol, got " (pr-str n) " [" :rf.error/… "]")` becomes `(str :rf.error/pair-mcp-rt-let-binding-bad-shape)`:

```
[re-frame2-pair-mcp] handler threw for trace-window — :rf.error/pair-mcp-rt-let-binding-bad-shape

FAIL in (rt-let-binding-shape-reaches-the-agent-as-a-readable-message) (error_boundary_test.cljs:174:17)
the agent reads a human sentence, not a keyword
  got: ":rf.error/pair-mcp-rt-let-binding-bad-shape"
  actual: (not (re-find #"rt-let binding name must be a symbol" ":rf.error/pair-mcp-rt-let-binding-bad-shape"))

FAIL in (rt-let-binding-shape-reaches-the-agent-as-a-readable-message) (error_boundary_test.cljs:177:17)
the canonical [:rf.error/…] token rides the message
  actual: (not (str/includes? ":rf.error/pair-mcp-rt-let-binding-bad-shape" "[:rf.error/pair-mcp-rt-let-binding-bad-shape]"))

Ran 3 tests containing 13 assertions.  2 failures, 0 errors.
```

That server log line is the agent's-eye view of the regression: the string is verbatim what an MCP client would have received.

**2. `wire_pipeline.cljs` — ex-data `:reason` reverted to a bare keyword.** `(str "run-wire-pipeline got an unknown :kind " (pr-str kind))` becomes `:rf.error/pair-mcp-unknown-wire-pipeline-kind`:

```
FAIL in (unknown-wire-pipeline-kind-reaches-the-agent-as-readable-ex-data) (error_boundary_test.cljs:232:17)
and the human sentence the agent READS rides with it
  got: :rf.error/pair-mcp-unknown-wire-pipeline-kind
  actual: (not (re-find #"unknown :kind" ":rf.error/pair-mcp-unknown-wire-pipeline-kind"))

Ran 3 tests containing 13 assertions.  1 failures, 0 errors.
```

**3. Restored, re-run, tree clean:**

```
Ran 3 tests containing 13 assertions.  0 failures, 0 errors.
$ git diff --stat      # (empty)
$ git status --short   # (empty)
```

Both mutations were made with a scripted, anchored replace and reverted with `git checkout --`; the final `git diff --stat origin/main...HEAD` is one file, +247, test-only.

## Spec

Touches neither `tools/xray/` nor `tools/machines-viz/`, so no `tools/xray/spec/*` update applies.

Closes rf2-eaf20.
