### PR TITLE
fix,docs(tools): correct the Xray testbed record, reconcile the release inventories, and isolate the recorder flake (rf2-r83ni, rf2-gugc3, rf2-zrdog)

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,8 +235,9 @@ tools/                         CLJS dev/inspection tools that consume re-frame2'
   testbed-support/             Shared testbed helpers (re-frame.testbed.config project-root resolver
                                + re-frame.testbed.story-host hash-toggle host); consumed by the
                                framework testbed builds
-  mcp-base/                    Shared CLJC library for the MCP servers (arg parsing, redaction,
-                               cap, overflow); bundle-isolated boundary helpers
+  mcp-base/                    day8/re-frame2-mcp-base — shared CLJC library for the MCP servers
+                               (arg parsing, redaction, cap, overflow); bundle-isolated boundary
+                               helpers
   mcp-conformance/             Cross-server MCP conformance harness — gates wire-vocabulary parity
                                in CI
 skills/                        Claude skills

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -6,6 +6,8 @@
 
 re-frame2 ships as a coordinated set of Maven artefacts, all driven from a single repo-root [`VERSION`](../VERSION) file. This doc is the operational guide for how a release flows through CI, what gates exist, and how to recover when something goes wrong mid-deploy.
 
+Two tiers ship from this repo and they move on separate triggers. The **framework tier** is the thirteen artefacts under `implementation/`, and a `v*` tag ships all of them together — that is what §Topological deploy DAG below describes. The **tools tier** is the jars under `tools/`, which share the same lockstep VERSION but ship on their own per-tool tags and are not touched by a `v*` tag at all; [§The tools tier](#the-tools-tier) is their runbook.
+
 ## Policy
 
 The release pipeline reflects a small set of decisions Mike made up front. They are recorded here so future contributors don't have to re-derive them from the workflow.
@@ -14,7 +16,7 @@ The release pipeline reflects a small set of decisions Mike made up front. They 
 2. **Channel gating — pre-1.0 = alpha/beta, post-1.0 = stable.** Pre-1.0 releases tag as `v0.0.1.alpha` (and `v0.0.1.alpha-N` / `v0.0.2.alpha` etc. for subsequent alphas; the same pattern with `.beta` once we promote). Post-1.0 releases tag as `vX.Y.Z` per Semantic Versioning. The release workflow flags any tag containing `beta`, `alpha`, or `rc` as a GitHub `prerelease` automatically.
 3. **First publish — manual cut, all artefacts together.** Mike triggers the first `v0.0.1.alpha` deploy by hand once the policy text and the workflow have been reviewed against an actual tag. After the first cut, subsequent releases run automatically on tag push. The first cut ships the **full artefact set** — core plus every leaf: `schemas`, `reagent`, `reagent-slim`, `uix`, `machines`, `routing`, `flows`, `http`, `ssr`, `ssr-ring`, `resources`, `epoch`; no artefact "comes later" — they all ship together at every release per the lockstep contract below. The compiled-view substrate `re-frame.ui` is **not** in that set and never will be: Mike ruled on 2026-07-22 that `day8/re-frame2-ui` is not to be published, since it is donor-only code being absorbed into Freehand and the standalone artefact is deleted at the EP-0036 F6e gate (rf2-a32r7).
 4. **Atomic rollback — NOT POLICY.** Clojars does not support yanking a published version, and re-frame2 does not invest in machinery that would make it look like it does. If a deploy fails part-way through, recovery is **bump VERSION + re-tag + re-run** (see [§Recovery from a partial deploy](#recovery-from-a-partial-deploy) for the procedure). The partial-release artefacts from a failed run remain on Clojars, tombstoned-by-supersession; consumers pin the bumped version and pull a coherent set. Manual recovery is acceptable; we do not build atomic-rollback or partial-deploy-replay machinery.
-5. **Artefact set ships together at lockstep VERSION.** Every artefact ships at every release at the same VERSION, sourced from the repo-root [`VERSION`](../VERSION) file. The lockstep contract is enforced before any deploy by [`./.github/scripts/verify-version-lockstep.sh`](../.github/scripts/verify-version-lockstep.sh). Independent versioning is revisited post-1.0; until then, every published Maven coord moves in lockstep.
+5. **Artefact set ships together at lockstep VERSION.** Every framework artefact ships at every release at the same VERSION, sourced from the repo-root [`VERSION`](../VERSION) file. The lockstep contract is enforced before any deploy by [`./.github/scripts/verify-version-lockstep.sh`](../.github/scripts/verify-version-lockstep.sh). Independent versioning is revisited post-1.0; until then, every published Maven coord moves in lockstep. The tool jars share that VERSION but not that trigger — they ship on per-tool tags at their own cadence, which is a difference of *when*, never of *what version* (see [§The tools tier](#the-tools-tier)).
 
 ## Tag format
 
@@ -115,6 +117,44 @@ So `ssr-ring` ships in a stage of its own, `deploy-ssr-ring`, with `needs: [depl
 
 That edge is stronger than the pom requires — it also blocks `ssr-ring` behind leaves it does not depend on — and deliberately so: under [Recovery](#recovery-from-a-partial-deploy) any leaf failure is resolved by bumping `VERSION` and re-shipping every artefact, so a leaf skipped because a sibling failed was going to be superseded regardless. Blocking costs nothing; publishing an unresolvable coordinate cannot be undone. `implementation/scripts/_release-dag-policy.test.cjs` parses the workflow's job graph on every PR and fails if a leaf carrying a second in-repo coordinate is placed back in the matrix, or if the ordering edge disappears (rf2-p4a93).
 
+## The tools tier
+
+`tools/` is versioned in lockstep with the framework — every tool jar reads the same repo-root `VERSION`, and [`verify-version-lockstep.sh`](../.github/scripts/verify-version-lockstep.sh) gates them alongside the framework artefacts — but **a `v*` tag publishes none of it.** Each tool ships on its own tag prefix, so a Xray-only fix does not republish thirteen framework artefacts and a framework release does not accidentally republish Xray. Five tool jars carry Clojars coordinates:
+
+| Artefact | Coordinate | Tag | Workflow |
+|---|---|---|---|
+| `tools/xray/` | `day8/re-frame2-xray` | `xray-v*` | [`release-xray.yml`](../.github/workflows/release-xray.yml) |
+| `tools/story/` | `day8/re-frame2-story` | `story-v*` | [`release-story.yml`](../.github/workflows/release-story.yml) |
+| `tools/machines-viz/` | `day8/re-frame2-machines-viz` | `machines-viz-v*` | [`release-machines-viz.yml`](../.github/workflows/release-machines-viz.yml) |
+| `tools/story-mcp/` | `day8/re-frame2-story-mcp` | — | none yet (see below) |
+| `tools/mcp-base/` | `day8/re-frame2-mcp-base` | — | none yet (see below) |
+
+Two further tools sit outside Clojars entirely and outside this runbook: the pair MCP server ships on npm as `@day8/re-frame2-pair-mcp`, and the app template ships as a git coordinate on a `template-v*` tag via [`template-release.yml`](../.github/workflows/template-release.yml). Neither carries a `:clein/build` alias, which is why the lockstep script's tools inventory excludes them.
+
+### Release order
+
+Tool jars pin their in-repo siblings at the lockstep VERSION, and those siblings have to be **on Clojars already** when the tool's tag lands. So for a given VERSION the tags go out in this order:
+
+1. `v<VERSION>` — the framework tier: core and every leaf.
+2. `machines-viz-v<VERSION>` and `xray-v<VERSION>` — both consume core only.
+3. `story-v<VERSION>` — Story pins five siblings, Xray among them.
+
+That ordering is enforced structurally rather than by this list. After each workflow rewrites `:local/root` → `:mvn/version`, `clojure -P` resolves the rewritten graph from Clojars, so a coordinate that has not published yet fails the job at classpath resolution — before `clein deploy` can touch Clojars. Story goes further and adds a package preflight that parses the *generated* pom and refuses to deploy unless all five coordinates are present at the exact VERSION. That gate reads the artefact rather than the inputs that were supposed to produce it, which is the right posture in front of an irreversible act.
+
+> **Open question — Xray's pom (rf2-5dut1).** `tools/xray/deps.edn` declares ten in-repo runtime coordinates, but `release-xray.yml` rewrites only two of them and the lockstep inventory names only one. Since `clein pom` silently skips `:local/root`, a jar cut from that workflow today would ship a pom missing eight dependencies — and one of them, `day8/re-frame2-freehand`, cannot be pinned at all because `implementation/freehand/` is deliberately unpublished until the EP-0036 F6 gate. Treat `xray-v*` as unproven until that is settled.
+
+### The two without a publish path
+
+`story-mcp` and `mcp-base` carry Clojars coordinates and pass the lockstep gate, but neither can ship yet. Both declare `day8/de-dupe` as a runtime dependency via a git coordinate; `clein pom` drops git coordinates silently, and the library is not on Clojars, so a jar built today would publish a pom missing a runtime dep. Because story-mcp depends on mcp-base, neither moves until the other does. Publishing, vendoring or dropping `de-dupe` is the open decision — **rf2-2ii52, held pending an operator ruling.** Until it is settled, do not cut a tag for either.
+
+### Recovery
+
+Identical to the framework tier: Clojars has no yank, so recovery is bump-and-supersede. Do not re-run a failed tool deploy on the same tag — Clojars 409s on the duplicate upload. Bump `VERSION`, retag with the bumped value (`xray-v0.0.1.alpha-1`), rerun. See [§Recovery from a partial deploy](#recovery-from-a-partial-deploy) for the full procedure; the only difference is that bumping VERSION for a tool fix puts the framework tier out of lockstep until its next `v*` tag, which is expected and is what the per-tool cadence buys.
+
+### First publish
+
+Every tool workflow has the same first-publish protocol as the framework: Mike pushes the first tag by hand once the Clojars secrets are wired and the tags this tool depends on have published. Subsequent releases run automatically on tag push.
+
 ## Pre-flight checklist
 
 Before tagging:
@@ -173,13 +213,18 @@ Apps that ship a perf-instrumented prod bundle alongside their default release s
 - the `tests` workflow on every PR (`verify-version-lockstep` job — fast, runs in parallel with the test jobs);
 - the `release` workflow as the first gate before any deploy (`verify-version-lockstep` job — gates `test`, which gates `deploy-core`).
 
+It covers **eighteen** artefacts — the thirteen under `implementation/` plus the five tool jars — and prints that count on success, so a summary line naming any other number is itself the drift signal.
+
 The contract:
 
 - Repo root has a non-empty `VERSION` file.
-- Every artefact's `:clein/build` declares `:version "../../VERSION"` (i.e. defers to the single source).
-- Every non-core artefact references core via `day8/re-frame2 {:local/root "../core"}` (the release workflow rewrites this to `:mvn/version` at deploy time).
+- Every artefact's `:clein/build` defers to that single source through a relative `:version` path. The path differs by tier: `"../../VERSION"` for core, the per-feature artefacts and the tool jars; `"../../../VERSION"` for the adapters, which sit one level deeper under `implementation/adapters/`.
+- Every non-core artefact references core by `:local/root` — `"../core"` from a per-feature artefact, `"../../core"` from an adapter, `"../../implementation/core"` from a tool. The release workflow rewrites these to `:mvn/version` at deploy time.
 - No artefact's committed `deps.edn` carries a literal `:mvn/version` for any `day8/re-frame2-*` artefact in a non-comment line.
 - Every `implementation/*/deps.edn` declaring a `:clein/build` alias appears in the lockstep inventory **and** `release.yml`'s deploy jobs (the inventory guard), so a new publishable artefact cannot be omitted silently.
+- Each tool jar is *packageable*, not merely version-pinned: `:clein/build` carries the `:main` key clein's spec requires, and no runtime coordinate is a form `clein pom` cannot express. Both classes had already shipped unnoticed before rf2-2ii52 added the checks — an artefact can be perfectly pinned and still impossible to build.
+
+The tools half of the inventory is narrower than the implementation half: it asserts the coordinates listed in the script's `TOOLS_LOCAL_ROOTS`, which is a hand-maintained list rather than a scan of each tool's `:deps`. A coordinate absent from that list is a coordinate nothing asserts is rewritable — see the Xray caveat under [§The tools tier](#the-tools-tier).
 
 Run locally any time:
 
@@ -199,7 +244,10 @@ There is intentionally no per-artefact version override. Adding one would break 
 
 ## Cross-references
 
-- [.github/workflows/release.yml](../.github/workflows/release.yml) — the release pipeline.
+- [.github/workflows/release.yml](../.github/workflows/release.yml) — the release pipeline for the framework tier.
+- [.github/workflows/release-xray.yml](../.github/workflows/release-xray.yml), [release-story.yml](../.github/workflows/release-story.yml), [release-machines-viz.yml](../.github/workflows/release-machines-viz.yml) — the per-tool release pipelines; each header carries the rationale for its own rewrite set.
+- [.github/workflows/template-release.yml](../.github/workflows/template-release.yml) — the app template's git-coordinate release.
+- [tools/README.md](../tools/README.md) — what each tool is and which coordinate it publishes under.
 - [.github/workflows/test.yml](../.github/workflows/test.yml) — PR-time tests including lockstep drift detection.
 - [.github/scripts/verify-version-lockstep.sh](../.github/scripts/verify-version-lockstep.sh) — the lockstep contract script.
 - [spec/Conventions.md §Packaging conventions](../spec/Conventions.md#packaging-conventions) — artefact naming, the independence rule, the bundle-isolation argument.

--- a/implementation/shadow-cljs.edn
+++ b/implementation/shadow-cljs.edn
@@ -1748,9 +1748,14 @@
   ;; refuses the React-element-shaped adapters including
   ;; `:rf.adapter/freehand` (rf2-qgfo4), so on a host that installed
   ;; `v/adapter` there is no Views panel to populate at all. The adapter
-  ;; supplies the OBSERVATION half a ViewCell's reads need (a watchable
-  ;; derived value) plus the `:render` slot the shell mounts through;
-  ;; Freehand renders itself through react-dom/client either way. That
+  ;; supplies the OBSERVATION half a ViewCell's reads need — which takes
+  ;; more than a watchable derived value, since a `reagent.ratom/Reaction`
+  ;; captures its sources only through `deref-capture` and a ViewCell is not
+  ;; a component; Reagent closes that by publishing
+  ;; `:adapter/activate-derived-value!`, so a cell here genuinely REPAINTS
+  ;; (rf2-8cnxg / rf2-jt8vz) — plus the `:render` slot the shell mounts
+  ;; through; Freehand renders itself through react-dom/client either way.
+  ;; That
   ;; arrangement is blessed by the substrate contract itself
   ;; (`re-frame.freehand.substrate`: bring-your-own adapter stays legitimate
   ;; for a mixed application). Nothing on the page is Reagent-rendered.

--- a/tools/deps.edn
+++ b/tools/deps.edn
@@ -1,18 +1,39 @@
 ;; Top-level tools coordinator (rf2-nuuk3).
 ;;
-;; The published artefacts are
-;;   - xray/       (day8/re-frame2-xray)
+;; The published artefacts, grouped by the channel they actually ship
+;; on — the three are gated differently and the flat list this note
+;; used to carry hid that (rf2-gugc3):
+;;
+;;   Clojars, per-tool tag, in the lockstep inventory
+;;   (.github/scripts/verify-version-lockstep.sh TOOLS — these five and
+;;   only these five):
+;;   - xray/         (day8/re-frame2-xray)
+;;   - story/        (day8/re-frame2-story)
+;;   - story-mcp/    (day8/re-frame2-story-mcp)
 ;;   - machines-viz/ (day8/re-frame2-machines-viz)
-;;   - mcp-base/    (day8/re-frame2-mcp-base)
-;;   - re-frame2-pair-mcp/   (@day8/re-frame2-pair-mcp, npm only)
-;;   - story/       (day8/re-frame2-story)
-;;   - story-mcp/   (day8/re-frame2-story-mcp)
-;;   - template/    (day8/re-frame2-template — git-coord, not Clojars
-;;                   per rf2-dolpf §2.5)
+;;   - mcp-base/     (day8/re-frame2-mcp-base)
+;;
+;;   Of those five, only xray, story and machines-viz have a release
+;;   workflow today. story-mcp and mcp-base carry coordinates but no
+;;   publish path: both declare day8/de-dupe by git coordinate, which
+;;   `clein pom` drops silently and which is not on Clojars. That is
+;;   rf2-2ii52, held pending an operator ruling — do not cut a tag for
+;;   either until it lands.
+;;
+;;   npm, not Clojars, no :clein/build, deliberately outside the
+;;   lockstep inventory:
+;;   - re-frame2-pair-mcp/  (@day8/re-frame2-pair-mcp)
+;;
+;;   git coordinate on a template-v* tag, not Clojars, guarded by its
+;;   own in-template version_lockstep_test.clj rather than by the
+;;   repo-level script (rf2-40vmd / rf2-dolpf §2.5):
+;;   - template/     (day8/re-frame2-template)
+;;
 ;; see tools/xray/deps.edn, tools/machines-viz/deps.edn,
 ;; tools/mcp-base/deps.edn, tools/re-frame2-pair-mcp/deps.edn,
 ;; tools/story/deps.edn, tools/story-mcp/deps.edn, and
-;; tools/template/deps.edn.
+;; tools/template/deps.edn. The operational runbook for all of it is
+;; docs/release-process.md §The tools tier.
 ;;
 ;; Other tool directories (machines-viz-mcp/, mcp-conformance/) are
 ;; spec-only or Node-only today — no `deps.edn` / CLJ surface to

--- a/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
@@ -33,7 +33,8 @@
             [re-frame.story-mcp.tools.lifecycle :as lifecycle]
             [re-frame.story-mcp.tools.recorder :as recorder-tool]
             [re-frame.story-mcp.tools.registry :as registry]
-            [re-frame.substrate.plain-atom :as plain-atom]))
+            [re-frame.substrate.plain-atom :as plain-atom])
+  (:import (java.util.concurrent CountDownLatch TimeUnit)))
 
 ;; ResultIO mirror over story-mcp's CLJ-map result shape — used by the
 ;; cap-honours-default test to sum tokens without reaching into cap's
@@ -1784,8 +1785,32 @@
 
   Returns the worker thread so a test can `.join` (with timeout) when
   it needs determinism on whether the worker has finished pushing.
-  Most callers just spawn-and-forget — the `:duration-ms` window the
-  tool sleeps in is more than long enough for the polled push.
+
+  rf2-zrdog — why the caller blocks on a start latch. Polling
+  `recording?` fixes the *stop* end of the race but not the *start*
+  end: the caller used to spawn the thread and immediately invoke the
+  tool, so the window the worker had to hit was a fixed 100ms of wall
+  clock measured from `start-recording!`, while the worker's
+  start-to-first-poll latency was whatever the OS scheduler felt like.
+  Idle, that latency measures under 1ms and the push always lands. With
+  the cores saturated — which is exactly what a full-namespace
+  aggregate run does — it was measured at 82ms, leaving 18ms of margin
+  against the window; one more scheduling hiccup and the worker reaches
+  its first poll after `stop-recording!` has already closed the window.
+  `record-event!` then no-ops (`append` appends only while
+  `:recording?`), the capture comes back empty, and the test fails on
+  `(pos? 0)` having done nothing wrong. That is a load-dependent flake,
+  not shared recorder state — the recorder atom is reset per test by the
+  fixture and no leftover worker was ever observed firing into another
+  test's window.
+
+  So the handoff is synchronised rather than assumed: the worker counts
+  down `polling` as its first act, and this fn does not return until
+  that latch trips. By the time the caller opens the window the thread
+  is live and in its poll loop, and the unbounded thread-start term is
+  out of the race entirely. The latch wait carries the same 5s bound as
+  the poll itself so a thread that never starts fails the test rather
+  than hanging the suite.
 
   EP-0017: the 2-arity `(drive-events-during-recording
   events cofx-vec)` pushes a parallel, index-aligned vector of captured
@@ -1795,30 +1820,40 @@
   same way the live trace listener does."
   ([events] (drive-events-during-recording events nil))
   ([events cofx-vec]
-   (let [cofx-vec (vec (or cofx-vec []))]
-     (doto (Thread.
-             ^Runnable
-             (fn []
-               ;; Poll `recording?` with a 1ms park between probes — fine-
-               ;; grained so the worker fires promptly once the window opens.
-               ;; Bails after 5s if the recorder never opens (a tool bug;
-               ;; the test assertions will catch it).
-               (let [deadline (+ (System/nanoTime) (* 5 1000000000))]
-                 (loop []
-                   (cond
-                     (recorder/recording?)
-                     (doseq [[i ev] (map-indexed vector events)]
-                       (recorder/record-event! ev (get cofx-vec i)))
+   (let [cofx-vec (vec (or cofx-vec []))
+         ;; Trips the moment the worker is live and about to poll, so the
+         ;; caller can open the recording window knowing the thread is
+         ;; already running rather than merely created (rf2-zrdog).
+         polling  (CountDownLatch. 1)
+         worker   (doto (Thread.
+                          ^Runnable
+                          (fn []
+                            (.countDown polling)
+                            ;; Poll `recording?` with a 1ms park between probes —
+                            ;; fine-grained so the worker fires promptly once the
+                            ;; window opens. Bails after 5s if the recorder never
+                            ;; opens (a tool bug; the test assertions will catch it).
+                            (let [deadline (+ (System/nanoTime) (* 5 1000000000))]
+                              (loop []
+                                (cond
+                                  (recorder/recording?)
+                                  (doseq [[i ev] (map-indexed vector events)]
+                                    (recorder/record-event! ev (get cofx-vec i)))
 
-                     (< (System/nanoTime) deadline)
-                     (do (Thread/sleep 1)
-                         (recur))
+                                  (< (System/nanoTime) deadline)
+                                  (do (Thread/sleep 1)
+                                      (recur))
 
-                     ;; Timed out; bail. The test's :recorded-event-count
-                     ;; assertion will surface the miss.
-                     :else nil)))))
-       (.setDaemon true)
-       (.start)))))
+                                  ;; Timed out; bail. The test's
+                                  ;; :recorded-event-count assertion will
+                                  ;; surface the miss.
+                                  :else nil)))))
+                    (.setDaemon true)
+                    (.start))]
+     ;; Bounded so a thread that never starts fails the assertion below
+     ;; rather than hanging the suite.
+     (.await polling 5 TimeUnit/SECONDS)
+     worker)))
 
 (deftest record-as-variant-not-found
   (testing "unknown source variant ⇒ tool-execution error"

--- a/tools/xray/spec/017-Test-Coverage-Matrix.md
+++ b/tools/xray/spec/017-Test-Coverage-Matrix.md
@@ -300,21 +300,34 @@ and what the Freehand door deliberately does not, cannot. `:generation` is NOT
 the fact under test: it is the hot-reload body revision, not a render tally,
 so `gen 0` on every row is correct for a page that is never hot-reloaded.
 
-**The host constraint, stated because it bounds what any browser gate over
-this panel can assert.** The deck installs the REAGENT adapter and renders
-Freehand views — a mixed application, which the substrate contract blesses
-(`re-frame.freehand.substrate`: bring-your-own adapter stays legitimate under
-the single-adapter runtime). It is not a convenience: Xray's shell is hiccup,
-and `day8.re-frame2-xray.mount` refuses the React-element-shaped adapters
-including `:rf.adapter/freehand` (rf2-qgfo4), so on a host that installed
-`v/adapter` there is no Views panel to populate at all. On the Reagent host
-the converse limitation applies — a dispatch lands and app-db moves, but the
-cell's committed read receives no change notification (`cell/pending-count`
-stays 0) and the cell never repaints. So **no single host today both repaints
-a Freehand cell reactively and renders Xray's Views panel**, and no browser
-gate over this panel can currently assert a reactively-driven re-render. The
-scenario therefore drives commits through the mount verb, which reads current
-values regardless of the notification channel.
+**The host shape, and what it no longer bounds.** The deck installs the
+REAGENT adapter and renders Freehand views — a mixed application, which the
+substrate contract blesses (`re-frame.freehand.substrate`: bring-your-own
+adapter stays legitimate under the single-adapter runtime). It is not a
+convenience: Xray's shell is hiccup, and `day8.re-frame2-xray.mount` refuses
+the React-element-shaped adapters including `:rf.adapter/freehand`
+(rf2-qgfo4), so on a host that installed `v/adapter` there is no Views panel
+to populate at all. That refusal is unchanged.
+
+What HAS changed is the converse. This section used to record a second
+limitation on the Reagent side — a dispatch landed and app-db moved, but the
+cell's committed read received no change notification and the cell never
+repainted — and concluded that **no single host both repaints a Freehand cell
+reactively and renders Xray's Views panel**, so no browser gate over this
+panel could assert a reactively-driven re-render. That headline no longer
+holds (rf2-8cnxg / rf2-jt8vz). The cause was never the host: the observation
+port installed a watch on a `reagent.ratom/Reaction` that had captured no
+sources, because a `Reaction` learns them only through `deref-capture` and a
+ViewCell — not being a component — supplies no capture context. The port now
+ACTIVATES the value through the optional `:adapter/activate-derived-value!`
+late-bind hook, which Reagent publishes, so a Reagent host **both** repaints a
+Freehand cell and mounts Xray's shell. A browser gate over this panel is no
+longer bounded by that constraint.
+
+The scenario still drives commits through the mount verb, which reads current
+values regardless of the notification channel. That is now a choice rather
+than the only option available; asserting a reactively-driven repaint on this
+deck has become possible and is tracked separately.
 
 ## Cross-references
 

--- a/tools/xray/testbeds/freehand_views/core.cljs
+++ b/tools/xray/testbeds/freehand_views/core.cljs
@@ -33,9 +33,19 @@
   contract does bless is exactly this arrangement — \"bring-your-own adapter
   ... stays legitimate for a mixed application under the single-adapter
   runtime\" (`re-frame.freehand.substrate`). The adapter supplies the
-  OBSERVATION half (a watchable derived value, which is all a ViewCell's
-  reads need); Freehand renders itself through `react-dom/client` either
-  way.
+  OBSERVATION half, and supplying it takes more than handing back a
+  watchable derived value. Reagent's are demand-driven: a
+  `reagent.ratom/Reaction` learns its sources only by being run through
+  `deref-capture`, so a read taken outside a reactive context leaves it
+  subscribed to nothing — watchable, and silent for as long as it lives. A
+  Reagent COMPONENT never meets that, because its render IS the capture
+  context; a ViewCell is not a component, so nothing supplies one on its
+  behalf. Reagent closes the gap by publishing the optional
+  `:adapter/activate-derived-value!` late-bind hook, which puts the value on
+  the substrate's push path (spec/006 §Reactive substrate — watchable is
+  necessary, not sufficient; rf2-8cnxg). With that, a cell on this page
+  genuinely REPAINTS when app-db moves. Freehand renders itself through
+  `react-dom/client` either way.
 
   So the split is clean and deliberate:
 
@@ -85,10 +95,11 @@
   rule for every deck under `tools/xray/testbeds/`."
   (:require [re-frame.core :as rf]
             [re-frame.freehand :as v]
-            ;; The OBSERVATION half of the substrate contract, and the
-            ;; `:render` slot Xray's hiccup shell needs. See the ns
-            ;; docstring: this is a blessed mixed host, not a stand-in for
-            ;; `v/adapter`.
+            ;; The OBSERVATION half of the substrate contract — including
+            ;; the `:adapter/activate-derived-value!` hook a ViewCell's reads
+            ;; need to be live at all — and the `:render` slot Xray's hiccup
+            ;; shell needs. See the ns docstring: this is a blessed mixed
+            ;; host, not a stand-in for `v/adapter`.
             [re-frame.adapter.reagent :as reagent-adapter]
             ;; Xray's `configure!` to seed `:project-root` so the per-site
             ;; `[code]` chips in Declared View Sites resolve a
@@ -124,8 +135,10 @@
 
 (v/defview controls
   "The dispatching view — compiled, so its declaration carries a proven
-  event site, and the only handler on the page. Pressing `+` moves app-db,
-  which advances [[readout]]'s committed generation."
+  event site, and the only handler on the page. Pressing `+` moves app-db
+  and [[readout]] repaints. Not its `:generation` — that is the hot-reload
+  body revision, not a render tally, and it stays 0 here (see the ns
+  docstring)."
   {:compiled true}
   [_]
   [:div {:data-testid "fh-controls"}
@@ -154,19 +167,21 @@
 ;; freshly minted occurrences. `v/mount` is idempotent per root, so the same
 ;; button re-renders a live root and mounts a fresh one after an unmount.
 ;;
-;; `Mount root` is also the only way to move a Freehand cell on THIS host,
-;; and the reason is worth stating plainly rather than leaving a reader to
-;; discover it by clicking `+` and watching nothing happen. The `+` dispatch
-;; DOES land — app-db moves, the Xray App-db panel shows `{:count 1 ← was 0}`
-;; — but under a ratom-family adapter the cell's committed read receives no
-;; change notification: `cell/pending-count` stays 0, the cell is never
-;; marked dirty, and it never repaints. Under Freehand's OWN adapter the same
-;; page repaints correctly (0 → 1 → 2), and Xray then refuses to mount
-;; (rf2-qgfo4). So on today's substrate no single host both repaints a
-;; Freehand cell reactively AND shows Xray's Views panel. Filed as a
-;; follow-up bead; this deck is built on the half that works, and a render is
-;; that half — it reads current values regardless of the notification
-;; channel, which is why `+` then `Mount root` shows the moved count.
+;; They are NOT how you move a cell, though this comment used to say they
+;; were. Pressing `+` repaints [[readout]] directly: the dispatch lands, the
+;; App-db panel shows `{:count 1 ← was 0}`, and the cell follows. It did not
+;; always — under a ratom-family adapter the cell's committed read once
+;; received no change notification at all, so `cell/pending-count` stayed 0
+;; and the readout sat at its first value while app-db moved underneath it.
+;; The cause was in the observation port, not the host: it installed a watch
+;; on a `reagent.ratom/Reaction` that had captured no sources, because a
+;; `Reaction` captures only through `deref-capture` and a ViewCell, not being
+;; a component, supplies no capture context. The port now ACTIVATES the value
+;; through `:adapter/activate-derived-value!` (rf2-8cnxg / rf2-jt8vz), so
+;; this host both repaints a Freehand cell and shows Xray's Views panel. The
+;; only refusal still standing is Xray's own: it will not mount on the
+;; React-element-shaped adapters, `:rf.adapter/freehand` among them
+;; (rf2-qgfo4).
 
 (defn- resolve-source-root []
   (testbed-config/resolve-source-root "tools/xray/testbeds"))


### PR DESCRIPTION
Three disjoint surfaces, one commit each.

## rf2-zrdog — the recorder flake, root-caused rather than re-run

`record-as-variant-no-cofx-is-byte-identical` failed once with
`:recorded-event-count` 0 in a full aggregate run. The bead's first suspect was
shared recorder state — specifically a frame left over from a prior test
misdirecting the capture.

That is not it, and instrumenting the helper across a full aggregate run says so
directly: no leftover worker ever fired into another test's window, and no worker
ever fired into a non-empty one. The fixture's `recorder/clear!` does its job, and
`recorder/append` consults only `:recording?` — never the frame — so a stray frame
cannot misdirect anything.

The measurement found a race on the **start** of the window instead. The helper
spawned its worker thread and immediately invoked the tool, so the worker had to
reach its first poll inside a fixed 100ms of wall clock while its
start-to-first-poll latency was left to the OS scheduler:

| | idle box | 40-way CPU saturation |
|---|---|---|
| max start→first-poll latency | 0.95 ms | **82.1 ms** |
| first polls over 50 ms | 0 / 15 | 4 / 15 |
| margin against the 100 ms window | ~99 ms | **~18 ms** |

One more scheduling hiccup past that and the worker arrives after
`stop-recording!` has closed the window, `record-event!` no-ops, and the capture
comes back empty. So it is **load** dependence, not order dependence — which is
exactly why it only ever showed in aggregate runs, the one time the box is busy.

Fixed by synchronising the handoff instead of assuming it: the worker counts down
a `CountDownLatch` as its first act and the helper does not return until it trips,
putting thread creation and first schedule provably outside the window. The wait
carries the same 5s bound as the poll, so a thread that never starts fails the
assertion rather than hanging the suite. No retry, no sleep, no fixture-global
state. This also covers `record-as-variant-captures-events-during-window`, which
asserts a hard count of 2 and was exposed to the same miss.

## rf2-gugc3 — authoritative inventory, and one discrepancy escalated

**Treated `.github/scripts/verify-version-lockstep.sh` as the source of truth**,
because it is the only inventory that gates: it runs on every PR and again as the
first job of the release workflow, and no deploy proceeds past it. Its `TOOLS`
array names five (xray, story, story-mcp, machines-viz, mcp-base) and excludes
pair-mcp and template with documented reasoning. Checked against ground truth and
it agrees — exactly those five `tools/*/deps.edn` declare a `:clein/build`, and
the count it prints is 18.

Reconciled toward it:

- **`docs/release-process.md`** gains §The tools tier: the five coordinates and
  their tags, the release order (framework → machines-viz/xray → story) and why it
  is enforced structurally rather than by prose, the two with coordinates but no
  publish path, recovery, first publish. §Lockstep verification also stops being
  implementation-only, and its `:version "../../VERSION"` bullet was wrong for the
  adapters, which read `"../../../VERSION"`.
- **`tools/deps.edn`** listed seven artefacts flat under "The published artefacts
  are", hiding that they ship on three channels with three gates. Regrouped.
- **`README.md`** gave every publishable tool its Clojars coordinate except
  `mcp-base/`. Added.
- **`CHANGELOG.md` needed nothing** — rf2-2ii52's PR already moved it to five and
  it agrees with the authority.

`story-mcp` and `mcp-base` are recorded as having coordinates but no publish path,
which is the current truth. **rf2-2ii52 is held and nothing here resolves or works
around it.**

> **Needs a ruling — filed as rf2-5dut1 (P1).** `tools/xray/deps.edn` declares
> **ten** in-repo runtime coordinates; `release-xray.yml` rewrites **two**; the
> lockstep inventory names **one**. Since `clein pom` silently skips `:local/root`,
> a jar cut from that workflow today would ship a pom missing eight — the exact
> failure class Story's rewrite + pom preflight exist to prevent (rf2-wht9a /
> rf2-r8trk). Worse, one of them, `day8/re-frame2-freehand`, cannot be pinned at
> all: `implementation/freehand/` deliberately carries no `:clein/build` until the
> EP-0036 F6 gate. Either Xray is not publishable until Freehand ships, or that
> edge moves to late-bind. The fix lands in `.github/workflows/` +
> `.github/scripts/`, both fenced to other lanes — so §The tools tier records the
> caveat rather than asserting `xray-v*` works.

## rf2-r83ni — the testbed no longer records a falsehood

The old prose blamed the host. It was the observation port: `build-node-handle!`
installed a watch assuming a watched reaction is live, but a
`reagent.ratom/Reaction` captures sources only through `deref-capture`, so a
`deref` outside `*ratom-context*` left `watching` nil and the watch could never
fire. Watchable, and silent for as long as it lived. Corrected to name ACTIVATION
via `:adapter/activate-derived-value!`.

- **testbed `core.cljs`** — ns docstring reworded off "a watchable derived value,
  which is all a ViewCell's reads need". The `core.cljs:128` audit item was real
  and was an internal contradiction: `controls` said `+` "advances [[readout]]'s
  committed generation" while the ns docstring three paragraphs above correctly
  said `:generation` is the hot-reload body revision, not a render tally. Fixed.
  **A fourth instance the bead did not name** — the boot-script comment telling a
  reader that `Mount root` was the only way to move a cell and inviting them to
  click `+` and watch nothing happen — was the most explicitly wrong of the set
  and is rewritten.
- **`tools/xray/spec/017-Test-Coverage-Matrix.md`** — spec updated in this PR per
  the standing rule. rf2-jt8vz's "no single host does both" headline is retired; a
  Reagent host now does both. Xray's refusal of the React-element-shaped adapters
  (rf2-qgfo4) is unchanged and stated as the one still standing.
- **`implementation/shadow-cljs.edn`** (hot-zone) — same stale wording in the
  freehand-views build comment. **Comment-only; nothing else in the file is
  touched.**

Filed **rf2-2t126** (P3): the sweep still drives commits through the mount verb,
now a choice rather than the only option — a reactively-driven repaint has become
assertable on this deck.

## Quality gates

| Gate | Scope | Exit |
|---|---|---|
| `tools/story-mcp` `clojure -M:test` — baseline | 306 tests / 1605 assertions | **0** |
| `tools/story-mcp` `clojure -M:test` — under 40-way CPU load, run 1 (post-fix) | 306 / 1605 | **0** |
| `tools/story-mcp` `clojure -M:test` — under 40-way CPU load, run 2 (post-fix) | 306 / 1605 | **0** |
| `tools/xray` `clojure -M:test` | 1271 tests / 5909 assertions | **0** |
| `python -m mkdocs build --strict` | full docs site | **0** |
| `python scripts/check_doc_slugs.py` (run twice) | doc slugs | **0** |
| `implementation/shadow-cljs.edn` EDN parse | 90 builds, freehand-views intact | **0** |
| `freehand_views/core.cljs` reader parse | 14 top-level forms | **0** |

The recorder suite was run under deliberate CPU saturation because that is the
condition that reproduced the flake; both post-fix runs are green, and the
pre-fix instrumented run under the same load is the 82 ms measurement above.

**Deferred to CI:** the `:testbeds/freehand-views` browser build and the Xray
feature-matrix sweep. The worktree has no `node_modules`, and junctioning into the
mayor checkout is the known-hazardous move, so the shadow-cljs build could not run
locally — it did parse the edited config before failing on the npm resolve, and
the EDN parse above is the conclusive check for a comment-only diff. Also
deferred: the full `test-fast-pr` spine and the mcp-conformance gate.
