### PR TITLE
bench,docs(freehand): measure Freehand against Reagent on the shared React floor (rf2-dq20a)

### DIFF
--- a/docs/design/freehand/studio/freehand-vs-reagent.md
+++ b/docs/design/freehand/studio/freehand-vs-reagent.md
@@ -1,0 +1,445 @@
+# How fast is Freehand, relative to Reagent?
+
+Seat: EVIDENCE SPIKE. Bead `rf2-dq20a`, answering the operator's question
+of 2026-07-27 verbatim.
+
+Measured: 2026-07-27, against `bc0af9d69e` (branch `worker/bench-vs-reagent`).
+Reagent **2.0.1**, UIx **1.4.4**, React **19.2.0**. Host: Windows 11,
+headless Chromium 147 via Playwright 1.59.1, single developer workstation
+with other agents running concurrently. Every arm is an `:advanced`
+ClojureScript bundle with `goog.DEBUG false` — the artefact a consumer
+ships. Nothing here is a release-worker number, and the
+[method](#method-and-what-it-refuses-to-claim) says where that matters.
+
+This is the companion to
+[`compiled-tier-browser-worth-it.md`](compiled-tier-browser-worth-it.md),
+which measured Freehand against *itself* — interpreted against compiled,
+both against a hand-built React floor. It measured no competing
+substrate. This one adds Reagent, and UIx, on the same floor, building
+the same DOM, so the rows slot into that report's table rather than
+starting a second incomparable one.
+
+---
+
+## The answer, first
+
+**On mount, compiled Freehand is slightly faster than Reagent and
+interpreted Freehand is about twice as slow. On update, Reagent is
+between 3× and 15× faster — and the decomposition says most of that gap
+is not Freehand at all. It is `re-frame`'s write path.**
+
+Four findings, and the third is the one that changes what to do about it.
+
+1. **Mount: compiled Freehand wins narrowly, interpreted Freehand loses
+   clearly.** On the large template compiled Freehand is **1.30× the
+   floor** against Reagent's **1.55×** — a 16% advantage, with disjoint
+   ranges. Interpreted Freehand is **2.99×**, which is **1.9× slower than
+   Reagent**. On the ordinary form all three are within a whisker of each
+   other and of the floor.
+2. **Update: Reagent is far ahead on the wall clock.** A write that
+   repaints 300 boundaries costs Freehand **6.4–7.4 ms** and Reagent
+   **0.6–0.7 ms** — **10× **. A write that repaints one costs Freehand
+   **≈0.9 ms** and Reagent **≈0.065 ms** — **≈14×**. On the narrow write
+   Freehand is also **8.8× slower than a plain top-down React re-render
+   of all three hundred cells**, which is the reading that should be
+   uncomfortable.
+3. **But on a narrow write, ~90% of Freehand's cost is the `app-db`
+   write and its subscription recompute, not rendering.** Splitting the
+   window into its legs: of Freehand's ≈0.9 ms, **≈0.85 ms is
+   `frame/replace-app-db!` plus the signal graph** and only ≈0.07 ms is
+   React render and commit — which is *the same* as Reagent's ≈0.06 ms.
+   **A Reagent application reading re-frame subscriptions would pay that
+   same write leg.** The 14× is mostly a re-frame-versus-bare-ratom
+   result wearing a Freehand-versus-Reagent label, and the honest
+   Freehand-specific number is much smaller.
+4. **Where Freehand's view layer really is slower is bulk re-render.** On
+   the broad write, render is 70% of Freehand's cost and Freehand's
+   render leg is **4.0–5.4 ms against Reagent's 0.6–0.7 ms** — a genuine
+   **≈7× on re-rendering 300 boundaries**, which no accounting moves.
+
+And one property that is not a number: **Freehand cannot commit a state
+change synchronously.** A write made inside `react-dom/flushSync` has not
+reached the DOM when the flush returns; the notification rides a
+microtask. Reagent and plain React both commit in that window. It is
+filed as `rf2-w2m25`, it forced this report's whole measurement shape,
+and it is the finding most likely to matter to somebody writing an
+application.
+
+**What this does *not* say.** It does not say Freehand should adopt
+ratoms, and it does not say the compiled tier is vindicated. The mount
+advantage is real but small; the update deficit is real and large; and
+the largest single term in the update deficit is owned by `re-frame`
+rather than by either view substrate.
+
+---
+
+## Method, and what it refuses to claim
+
+The instrument is
+[`compiled-tier-browser-worth-it.md`](compiled-tier-browser-worth-it.md)'s,
+reused rather than rebuilt: the same hand-written `react/createElement`
+floor, the same shapes, the same in-run floor normalisation, the same
+refusal to quote a number whose range straddles 1.0. Source is
+`implementation/freehand/test/re_frame/freehand/bench/b6_*`.
+
+**Five arms, one page.** The React floor, interpreted Freehand, compiled
+Freehand, Reagent, and UIx each carry their *own* declaration of each
+witness, in their own dialect. The Reagent arm is written as a Reagent
+user writes it — plain Hiccup with class sugar, ordinary `defn`
+components, `^{:key i}` metadata on seq children, a form-2 component with
+`reagent.core/cursor` over a `reagent.core/atom`, and
+`reagent.dom.client` for the mount. No `:>` shortcut appears, nothing is
+pre-adapted, and no React class is hand-built. The UIx arm uses the `$`
+macro, because the point of including it is that `$` expands to
+`react/createElement` at compile time.
+
+**The fairness gate is canonical DOM, and it runs before any clock.**
+Every arm mounts simultaneously and the browser's own DOM is serialised
+with attribute names *sorted* — comparing `innerHTML` compares the
+serialiser's insertion order, which is how the predecessor report's first
+run nearly concluded that two identical pages differed. All five arms
+agree exactly, at both the stress and the small size, on all three
+witnesses, and the element counts match written arithmetic
+(1203/301/51). Without that gate this document would be comparing five
+different pages.
+
+**Interleaved at the sample level.** Every sample index mounts every arm,
+in an order that rotates with the index, so no arm is always first into a
+cold cache. Six rounds. Every figure is a **ratio to the floor measured
+in that same round** — the floor contains no substrate and cannot be
+changed by anything here, so it is the in-run calibrator for a box that
+drifts more across rounds than several of these effects are large.
+
+**The update window, and the fact that forced its shape.** The first
+update instrument bracketed each write in `react-dom/flushSync`, exactly
+as the mount row does. It measured nothing at all for two of the four
+arms, and the DOM read-back is what caught it: after every Freehand write
+the cell still held its old value. Measured directly:
+
+| how the write was driven | did the DOM change? |
+|---|---|
+| `flushSync(write)` | **no** |
+| `write`, one microtask, `flushSync(noop)` | yes, ~1 ms |
+| `write`, `setTimeout 0` | yes, ~2 ms |
+| `write`, `requestAnimationFrame` | yes, ~32 ms (two frames) |
+
+So every arm is timed through one shape, and it is the shape the slowest
+arm requires: **write, yield one microtask, force that substrate's own
+documented synchronous drain, stop the clock** — an empty `flushSync` for
+the floor and both Freehand arms, `reagent.core/flush` for Reagent.
+Nothing runs inside `act`, which diverts work to its own queue and,
+measured, cost 600 ms a call.
+
+**Every measured write is verified at the DOM, inside the window.** The
+cell just written is read back and the sample is rejected if it does not
+hold the value written. Both published rows report **0 rejected of 384**.
+This is not ceremony: it caught two instrument faults that would each
+have produced a confident wrong table. The first is the one above. The
+second is that an *empty* `flushSync` flushes only React's sync lane, so
+the floor arm's `root.render` — scheduled at the default lane — has to be
+issued *inside* the flush; until it was, 80 of 320 floor samples ended
+with the old value on screen and every other arm's ratio was inflated
+against a floor that had not rendered.
+
+**Production compilation, deliberately.** Spec 009 instrumentation,
+schema validation and trace emission are all `goog.DEBUG`-gated and all
+sit on the path the update row measures. Reagent has no counterpart to
+any of them, so a development build penalises Freehand in one direction
+only — and measurably: under `:none`/`goog.DEBUG true` the same rows put
+Freehand's broad update at 6.6–8.0× the floor, where production puts it
+at 24.8–27.8×, and put mount W2's interpreted arm at 5.4× where
+production says 7.5×. Neither build is "the" answer, but the shipped one
+is the one a user experiences. `:advanced` cannot compile shadow's
+`:browser-test` target — `cljs-test-display`'s `goog.define`s collide —
+so the production reading rides a plain `:browser` entry point built by
+merging an output directory and an `:init-fn` into the existing
+`:freehand-release` build id. `implementation/shadow-cljs.edn` is
+unchanged.
+
+**Six things this report refuses to claim.**
+
+- **No claim about `:none` builds** beyond the direction noted above.
+- **No absolute number is comparable across rounds.** The floor moved
+  20–30% within this run.
+- **W2 and W3's absolute times sit near Chrome's 100 µs `performance.now`
+  clamp** (0.3–1.0 ms). Their ratios are correspondingly coarse — read W1
+  for a resolved mount reading. The narrow update row batches 20 writes
+  to a sample for exactly this reason; the broad row does not need to.
+- **Any range that straddles 1.0 is reported as indistinguishable**, not
+  as a win. One does: UIx on W3.
+- **No memory claim of any kind.** The predecessor report's retained-heap
+  instrument was not re-run across substrates; the allocation question is
+  open and is the obvious next measurement.
+- **No claim about a real application.** These are six purpose-built
+  witnesses.
+
+---
+
+## 1. Mount
+
+Fixture: **W1** 300 rows under one boundary each, multi-class sugar, a
+style map, a `data-*` passthrough, 1,203 elements. **W2** 300 sub-free
+leaf boundaries, 301 elements. **W3** a 12-field form with controlled
+inputs, per-field error lines and a disabled submit gate, 51 elements.
+6 rounds × (5 warm-up + 20 samples) per arm, arms interleaved.
+
+**Mount cost as a ratio to the in-run React floor** — mean of six rounds,
+range in brackets:
+
+| Witness | Freehand interpreted | Freehand compiled | **Reagent** | UIx |
+|---|---:|---:|---:|---:|
+| **W1** large template, 1,203 el | 2.987 [2.840–3.167] | **1.304** [1.280–1.333] | 1.554 [1.520–1.583] | 1.163 [1.120–1.208] |
+| **W2** 300 elidable boundaries † | 7.472 [6.250–8.333] | 2.139 [1.750–2.333] | 2.500 [2.000–3.000] | **1.361** [1.250–1.667] |
+| **W3** ordinary form, 51 el ‡ | 1.664 [1.400–2.000] | 1.325 [1.167–1.667] | 1.394 [1.200–1.667] | 1.153 [1.000–1.333] |
+
+† **W2 overstates Freehand's advantage and is not a headline.** Its
+bodies read nothing, so Freehand's compiled tier can *prove* them
+sub-free and drop 300 ViewCells. Reagent has no elision concept and
+neither does UIx. It is here because the predecessor report measured it.
+
+‡ W3's absolute times are 0.3–1.0 ms against a 0.1 ms clock quantum. All
+four arms overlap; UIx's range includes 1.0, so **UIx and the floor are
+indistinguishable on the form**, and the four substrate arms are barely
+separable from each other.
+
+**And in milliseconds, because a ratio on a sub-millisecond operation is
+not a product decision** (p50, representative round):
+
+| Witness | floor | FH interp | FH compiled | Reagent | UIx |
+|---|---:|---:|---:|---:|---:|
+| W1 | 2.4 | 7.2 | 3.2 | 3.8 | 2.9 |
+| W2 | 0.3 | 2.4 | 0.7 | 0.8 | 0.4 |
+| W3 | 0.4 | 0.7 | 0.5 | 0.6 | 0.5 |
+
+**The three readings that matter.**
+
+**Compiled Freehand beats Reagent on the large template, by 16%.** 1.304
+against 1.554, ranges disjoint (1.333 vs 1.520). In substrate-overhead
+terms — subtracting the floor — that is 0.304 against 0.554, so compiled
+Freehand's own cost above React is **45% lower than Reagent's**. It is a
+real win and it is a modest one: 3.2 ms against 3.8 ms on a 1,203-element
+page.
+
+**Interpreted Freehand loses to Reagent, clearly, on every witness.**
+2.987 against 1.554 on W1 — **1.9× slower**, or 3.6× on substrate
+overhead alone. That is the tier most applications would actually be
+running.
+
+**UIx sits at the floor, and the operator's hypothesis holds.** 1.163 on
+W1, 1.361 on W2, 1.153 on W3 — nearest the floor on every witness. `$`
+expands to `react/createElement` at compile time, so there is no runtime
+walk to pay for, exactly as predicted.
+
+**And UIx beats compiled Freehand on the boundary storm** — 1.361 against
+2.139 — which is the contrast worth pausing on. W2 is the shape that
+maximises ViewCell elision, UIx has no elision at all, and UIx still
+wins. Elision buys the compiled tier a large gain *over interpreted
+Freehand* (7.472 → 2.139); it does not buy it a lead over a substrate
+that never created a wrapper to elide.
+
+---
+
+## 2. Update
+
+This is the half the predecessor report returned a null result on
+(0.2–0.5 ms p50 on every arm, indistinguishable at the timer), and the
+half Reagent is actually designed for.
+
+Fixture: a 300-cell grid, one reactive leaf per cell. Freehand reads
+`(v/sub [:b6/cell i])` per cell and is written with
+`frame/replace-app-db!` on its own frame. Reagent reads an `r/cursor` per
+cell over a `reagent.core/atom` and is written with `swap!`. The floor
+has no substrate and re-renders top-down. 6 rounds × (4 warm-up + 12
+samples).
+
+**BROAD** is one write every cell reads — 300 boundaries repaint. It
+prices throughput, where fine grain buys nothing because all the work is
+required. **NARROW** is one write one cell reads. It prices localisation.
+
+| Row | Freehand interpreted | Freehand compiled | **Reagent** |
+|---|---:|---:|---:|
+| **broad** — 300 cells repaint | 27.78 [21.33–35.00] | 24.83 [19.00–30.50] | **2.639** [2.000–3.500] |
+| **narrow** — 1 cell repaints | 8.802 [7.636–9.954] | 8.194 [7.000–9.636] | **0.587** [0.565–0.609] |
+
+Ratios to the in-run floor, as everywhere else — but **the update floor
+is a plain top-down React re-render and is NOT a lower bound.** A
+fine-grained substrate can and should beat it on a narrow write, and
+Reagent does: 0.587 means Reagent moves one cell in 59% of the time it
+takes plain React to re-render all three hundred. Freehand takes **8.8×**
+that.
+
+In milliseconds (p50; the narrow row's sample is 20 writes, so its
+per-write figure is one twentieth):
+
+| Row | floor | FH interp | FH compiled | **Reagent** |
+|---|---:|---:|---:|---:|
+| broad, per write | 0.2–0.3 | 6.4–7.4 | 5.7–6.9 | **0.6–0.7** |
+| narrow, per write | ≈0.115 | ≈0.9 | ≈0.85 | **≈0.065** |
+
+**So: Reagent is ~10× faster than Freehand on a broad write and ~14×
+faster on a narrow one.** That is the answer to the question as asked,
+and it should be quoted with the next section attached to it.
+
+### 2a. Where the update time actually goes
+
+The measured window is split into three legs, and the split is the most
+useful thing in this report. `write` is the state install and everything
+it synchronously triggers — for Freehand that is `frame/replace-app-db!`
+and the subscription recompute. `gap` is the microtask boundary. `force`
+is React render and commit.
+
+p50 milliseconds per sample, representative round:
+
+| Row / arm | write | gap | force | total |
+|---|---:|---:|---:|---:|
+| **broad** floor | 0.0 | 0.0 | 0.2 | 0.2 |
+| **broad** FH interpreted | 1.5 | 0.3 | **4.6** | 6.4 |
+| **broad** FH compiled | 1.4 | 0.3 | **4.0** | 5.7 |
+| **broad** Reagent | 0.0 | 0.0 | **0.6** | 0.6 |
+| **narrow** floor (20 writes) | 0.0 | 0.0 | 2.3 | 2.3 |
+| **narrow** FH interpreted (20) | **19.8** | 0.2 | 1.4 | 21.4 |
+| **narrow** FH compiled (20) | **19.2** | 0.1 | 1.1 | 20.4 |
+| **narrow** Reagent (20) | 0.1 | 0.0 | 1.2 | 1.3 |
+
+Three things fall straight out.
+
+**On a narrow write, Freehand's rendering is not the problem — the write
+is.** 19.8 ms of a 21.4 ms sample is `frame/replace-app-db!` and the
+signal graph; React render is 1.4 ms, against Reagent's 1.2 ms and the
+floor's 2.3 ms. **Freehand's view layer is doing a narrow update at
+Reagent's speed and beating plain React.** Everything else is re-frame's
+write path, which a Reagent application reading re-frame subscriptions
+would pay too. The honest Freehand-specific narrow-update number is
+therefore roughly parity, not 14×.
+
+**On a broad write, rendering *is* the problem.** 4.6 ms of 6.4 ms is
+React render and commit, against Reagent's 0.6 ms — **≈7×** on
+re-rendering 300 boundaries, with the write leg only 1.5 ms. Compiling
+moves it a little (4.6 → 4.0 ms) and does not close it. This is the one
+number in the update section that is squarely Freehand's own, and it is
+the one to act on.
+
+**The microtask yield costs nothing, and the control is in situ.** The
+floor and Reagent arms — which do not need it — report `gap` of exactly
+0.0 ms in every round of both rows. What appears in Freehand's gap is
+Freehand's own notification callback running there, and it scales as it
+should: ≈0.35 ms when a broad write moves 300 subscriptions, ≈0.01 ms
+when a narrow one moves one.
+
+> A first attempt priced the yield by chaining 2,000 bare
+> `js/Promise.resolve`s and dividing, and reported ≈1 ms a hop — larger
+> than an entire measured Reagent write, and therefore impossible. It was
+> measuring the construction of a 2,000-deep promise chain. It was
+> deleted rather than published with a caveat, and it is recorded here
+> because it is the same class of mistake as the predecessor report's
+> heap sampler.
+
+### 2b. Freehand cannot commit synchronously
+
+Not a timing result, and probably the most consequential thing here.
+
+A write made inside `react-dom/flushSync` has **not** reached the DOM when
+the flush returns — through any door: `frame/replace-app-db!`,
+`rf/dispatch-sync` with an explicit `:frame`, or a
+`capture-frame` handle's `dispatch-sync`. The store is written and the
+subscription recomputes; React learns about it on a microtask. Reagent
+(`swap!` + `reagent.core/flush`) and plain React (`root.render` inside
+`flushSync`) both commit inside that window. The UIx adapter's own
+`flush-views!` did not commit the write when measured, and `react/act`
+did but cost ≈600 ms a call.
+
+The consequence for an application author is that **there is no public
+door that makes a state change observable in the DOM before the current
+task ends** — which anything that measures, scrolls, focuses or asserts
+immediately after a write has to work around, undocumented. Filed as
+`rf2-w2m25` (P1), and pinned as a regression test by
+`a-freehand-write-does-not-commit-inside-flushsync`, so if Freehand gains
+a synchronous commit the test goes red and this row should be re-taken
+without the microtask yield.
+
+---
+
+## 3. What this does not cover
+
+Stated plainly, because the omissions are load-bearing.
+
+- **Memory.** Nothing. The predecessor report's retained-heap instrument
+  was not run across substrates. Given it found 6.26× retained heap per
+  elidable boundary *within* Freehand, a Reagent comparison on standing
+  heap is the obvious next measurement and might well be the more
+  decisive one.
+- **Reagent reading re-frame.** The Reagent arm reads a bare
+  `reagent.core/atom`, which is Reagent's own idiom but is *less
+  framework* than the Freehand arm carries. §2a bounds the effect rather
+  than removing it: the write leg is measured separately so a reader can
+  see how much of the gap a re-frame-shaped Reagent app would also have
+  paid. A direct Freehand-vs-Reagent-vs-re-frame row is not possible in
+  one page today — Freehand's `v/sub` is inert under a ratom adapter
+  (`rf2-8cnxg`, `rf2-jt8vz`) — and would need two adapter phases bridged
+  by the floor.
+- **The event leg.** Every arm is driven by a direct state install.
+  `dispatch` and the event queue are excluded, identically, from all of
+  them.
+- **Handlers and interaction.** W1 carries no `:on-click`: Freehand's
+  paved path is an event vector and Reagent's is a closure, and putting
+  one in each would compare two mechanisms inside a markup row. W3's
+  inputs are `:read-only` rather than carrying a change handler, so the
+  `value` slot exercises the controlled-input door without dragging a
+  second dispatch mechanism into a mount measurement. Editing latency
+  under contention is B4's row, and is Freehand-only.
+- **UIx on update.** Mount only. UIx's update story is `use-state` and
+  React's own scheduler, a different mechanism that needs its own row.
+- **Bundle size.** Not measured here for any substrate.
+- **SSR, hydration, streaming, error boundaries, suspense.** None.
+- **A real application.** Six purpose-built witnesses on a loaded
+  developer workstation. A quiet pinned machine would turn several
+  directional claims into numbers.
+
+## 4. What would change the answer
+
+1. **Cheapen the `app-db` write path.** It is 90% of a narrow update and
+   it is not owned by the view layer at all, so it is the one fix that
+   would help every re-frame consumer on every substrate. Measuring
+   where inside `commit-frame-transition!` plus the signal graph the
+   ≈0.85 ms goes is a small, high-leverage spike.
+2. **Cheapen bulk re-render of boundaries.** The ≈7× on 300 repainting
+   boundaries is Freehand's own, and compiling barely moves it, which
+   suggests the cost is in the ViewCell wrapper rather than in the
+   markup walk — the same term §1a of the predecessor report priced at
+   2,348 bytes of standing heap per kept ViewCell.
+3. **A synchronous commit door.** `rf2-w2m25`. It would also let the
+   update row be re-taken without a microtask yield, which would tighten
+   every figure in §2.
+4. **The memory row.** See above.
+
+## Provenance
+
+- Fixtures: W1 300 rows / 1,203 elements; W2 300 sub-free boundaries /
+  301 elements; W3 12-field form / 51 elements; update grid 300 reactive
+  cells / 301 elements.
+- Versions: Reagent 2.0.1, UIx 1.4.4 (`uix.core/$`), React and react-dom
+  19.2.0, ClojureScript via shadow-cljs 3.4.10.
+- Mount sampling: 5 warm-up + 20 samples per arm per round, arms
+  interleaved at the sample level with the order rotating on the sample
+  index, 6 rounds.
+- Update sampling: 4 warm-up + 12 samples per arm per round, 6 rounds;
+  broad = 1 write a sample, narrow = 20.
+- Determinism gates, green before any timing was read: canonical-DOM
+  equality across all five arms at both sizes on all three witnesses;
+  element counts against written arithmetic; and, per measured write, a
+  DOM read-back of the written cell — **0 rejected of 384** in each
+  update row.
+- Build: `:advanced`, `goog.DEBUG false`, via `--config-merge` on the
+  existing `:freehand-release` build id.
+  `implementation/shadow-cljs.edn` is unchanged.
+- Source, all of it shipped rather than deleted:
+  `implementation/freehand/test/re_frame/freehand/bench/b6_witnesses.cljc`
+  and `b6_witnesses_compiled.cljc` (Freehand, two lowerings),
+  `b6_reagent.cljs`, `b6_uix.cljs`, `b6_floor.cljs`, `b6_harness.cljs`
+  (canonical DOM, interleaving, floor normalisation), `b6_rows.cljs` (the
+  arms and both measurements), `b6_mount_dom_cljs_test.cljs` and
+  `b6_update_dom_cljs_test.cljs` (the deterministic gates, which ride the
+  ordinary `npm run bench:freehand-browser` lane), and `b6_prod_app.cljs`
+  + `b6_prod_run.cjs` (the `:advanced` reading).
+- Reproduce:
+  `node implementation/freehand/test/re_frame/freehand/bench/b6_prod_run.cjs`.

--- a/docs/design/freehand/studio/freehand-vs-reagent.md
+++ b/docs/design/freehand/studio/freehand-vs-reagent.md
@@ -3,7 +3,8 @@
 Seat: EVIDENCE SPIKE. Bead `rf2-dq20a`, answering the operator's question
 of 2026-07-27 verbatim.
 
-Measured: 2026-07-27, against `bc0af9d69e` (branch `worker/bench-vs-reagent`).
+Measured: 2026-07-27, against branch `worker/bench-vs-reagent` at the
+commit that carries this page — every arm in it ships in the same PR.
 Reagent **2.0.1**, UIx **1.4.4**, React **19.2.0**. Host: Windows 11,
 headless Chromium 147 via Playwright 1.59.1, single developer workstation
 with other agents running concurrently. Every arm is an `:advanced`
@@ -25,7 +26,7 @@ starting a second incomparable one.
 
 **On mount, compiled Freehand is slightly faster than Reagent and
 interpreted Freehand is about twice as slow. On update, Reagent is
-between 3× and 15× faster — and the decomposition says most of that gap
+between 9× and 15× faster — and the decomposition says most of that gap
 is not Freehand at all. It is `re-frame`'s write path.**
 
 Four findings, and the third is the one that changes what to do about it.
@@ -34,28 +35,28 @@ Four findings, and the third is the one that changes what to do about it.
    clearly.** On the large template compiled Freehand is **1.30× the
    floor** against Reagent's **1.55×** — a 16% advantage, with disjoint
    ranges. Interpreted Freehand is **2.99×**, which is **1.9× slower than
-   Reagent**. On the ordinary form all three are within a whisker of each
-   other and of the floor.
+   Reagent**. On the ordinary form all four substrate arms are within a
+   whisker of each other and of the floor.
 2. **Update: Reagent is far ahead on the wall clock.** A write that
    repaints 300 boundaries costs Freehand **6.4–7.4 ms** and Reagent
-   **0.6–0.7 ms** — **10× **. A write that repaints one costs Freehand
-   **≈0.9 ms** and Reagent **≈0.065 ms** — **≈14×**. On the narrow write
+   **0.6–0.7 ms** — **≈10×**. A write that repaints one costs Freehand
+   **≈1.0 ms** and Reagent **≈0.065 ms** — **≈15×**. On the narrow write
    Freehand is also **8.8× slower than a plain top-down React re-render
    of all three hundred cells**, which is the reading that should be
    uncomfortable.
 3. **But on a narrow write, ~90% of Freehand's cost is the `app-db`
    write and its subscription recompute, not rendering.** Splitting the
-   window into its legs: of Freehand's ≈0.9 ms, **≈0.85 ms is
-   `frame/replace-app-db!` plus the signal graph** and only ≈0.07 ms is
+   window into its legs: of Freehand's ≈1.0 ms, **≈0.9 ms is
+   `frame/replace-app-db!` plus the signal graph** and only ≈0.075 ms is
    React render and commit — which is *the same* as Reagent's ≈0.06 ms.
    **A Reagent application reading re-frame subscriptions would pay that
-   same write leg.** The 14× is mostly a re-frame-versus-bare-ratom
+   same write leg.** The 15× is mostly a re-frame-versus-bare-ratom
    result wearing a Freehand-versus-Reagent label, and the honest
    Freehand-specific number is much smaller.
 4. **Where Freehand's view layer really is slower is bulk re-render.** On
-   the broad write, render is 70% of Freehand's cost and Freehand's
+   the broad write, render is ~72% of Freehand's cost and Freehand's
    render leg is **4.0–5.4 ms against Reagent's 0.6–0.7 ms** — a genuine
-   **≈7× on re-rendering 300 boundaries**, which no accounting moves.
+   **≈7–8× on re-rendering 300 boundaries**, which no accounting moves.
 
 And one property that is not a number: **Freehand cannot commit a state
 change synchronously.** A write made inside `react-dom/flushSync` has not
@@ -203,13 +204,14 @@ indistinguishable on the form**, and the four substrate arms are barely
 separable from each other.
 
 **And in milliseconds, because a ratio on a sub-millisecond operation is
-not a product decision** (p50, representative round):
+not a product decision** (p50, round 4 of six — the same round §2a
+decomposes):
 
 | Witness | floor | FH interp | FH compiled | Reagent | UIx |
 |---|---:|---:|---:|---:|---:|
-| W1 | 2.4 | 7.2 | 3.2 | 3.8 | 2.9 |
+| W1 | 2.4 | 7.3 | 3.2 | 3.8 | 2.9 |
 | W2 | 0.3 | 2.4 | 0.7 | 0.8 | 0.4 |
-| W3 | 0.4 | 0.7 | 0.5 | 0.6 | 0.5 |
+| W3 | 0.5 | 0.7 | 0.6 | 0.6 | 0.5 |
 
 **The three readings that matter.**
 
@@ -274,9 +276,9 @@ per-write figure is one twentieth):
 | Row | floor | FH interp | FH compiled | **Reagent** |
 |---|---:|---:|---:|---:|
 | broad, per write | 0.2–0.3 | 6.4–7.4 | 5.7–6.9 | **0.6–0.7** |
-| narrow, per write | ≈0.115 | ≈0.9 | ≈0.85 | **≈0.065** |
+| narrow, per write | 0.11–0.12 | 0.84–1.12 | 0.77–1.09 | **0.065–0.070** |
 
-**So: Reagent is ~10× faster than Freehand on a broad write and ~14×
+**So: Reagent is ~10× faster than Freehand on a broad write and ~15×
 faster on a narrow one.** That is the answer to the question as asked,
 and it should be quoted with the next section attached to it.
 
@@ -288,36 +290,39 @@ it synchronously triggers — for Freehand that is `frame/replace-app-db!`
 and the subscription recompute. `gap` is the microtask boundary. `force`
 is React render and commit.
 
-p50 milliseconds per sample, representative round:
+p50 milliseconds per sample, round 4 of six throughout. Each leg is its
+own p50, so the three do not sum exactly to the sample's p50 — medians do
+not add; the totals column is the measured figure the ratios use.
 
 | Row / arm | write | gap | force | total |
 |---|---:|---:|---:|---:|
-| **broad** floor | 0.0 | 0.0 | 0.2 | 0.2 |
-| **broad** FH interpreted | 1.5 | 0.3 | **4.6** | 6.4 |
-| **broad** FH compiled | 1.4 | 0.3 | **4.0** | 5.7 |
+| **broad** floor | 0.0 | 0.0 | 0.2 | 0.3 |
+| **broad** FH interpreted | 1.5 | 0.3 | **4.7** | 6.5 |
+| **broad** FH compiled | 1.4 | 0.4 | **4.1** | 5.7 |
 | **broad** Reagent | 0.0 | 0.0 | **0.6** | 0.6 |
-| **narrow** floor (20 writes) | 0.0 | 0.0 | 2.3 | 2.3 |
-| **narrow** FH interpreted (20) | **19.8** | 0.2 | 1.4 | 21.4 |
-| **narrow** FH compiled (20) | **19.2** | 0.1 | 1.1 | 20.4 |
-| **narrow** Reagent (20) | 0.1 | 0.0 | 1.2 | 1.3 |
+| **narrow** floor (20 writes) | 0.0 | 0.0 | 2.4 | 2.4 |
+| **narrow** FH interpreted (20) | **19.8** | 0.2 | 1.4 | 22.4 |
+| **narrow** FH compiled (20) | **19.2** | 0.1 | 1.1 | 21.7 |
+| **narrow** Reagent (20) | 0.0 | 0.0 | 1.3 | 1.4 |
 
 Three things fall straight out.
 
 **On a narrow write, Freehand's rendering is not the problem — the write
-is.** 19.8 ms of a 21.4 ms sample is `frame/replace-app-db!` and the
-signal graph; React render is 1.4 ms, against Reagent's 1.2 ms and the
-floor's 2.3 ms. **Freehand's view layer is doing a narrow update at
+is.** The write leg is **19.8 ms** against a render leg of **1.4 ms**:
+`frame/replace-app-db!` and the signal graph are ~90% of the sample.
+And that 1.4 ms of React render sits against Reagent's 1.3 ms and the
+floor's 2.4 ms. **Freehand's view layer is doing a narrow update at
 Reagent's speed and beating plain React.** Everything else is re-frame's
 write path, which a Reagent application reading re-frame subscriptions
 would pay too. The honest Freehand-specific narrow-update number is
-therefore roughly parity, not 14×.
+therefore roughly parity, not 15×.
 
-**On a broad write, rendering *is* the problem.** 4.6 ms of 6.4 ms is
-React render and commit, against Reagent's 0.6 ms — **≈7×** on
-re-rendering 300 boundaries, with the write leg only 1.5 ms. Compiling
-moves it a little (4.6 → 4.0 ms) and does not close it. This is the one
-number in the update section that is squarely Freehand's own, and it is
-the one to act on.
+**On a broad write, rendering *is* the problem.** 4.7 ms of a 6.5 ms
+sample is React render and commit, against Reagent's 0.6 ms — **≈7–8×**
+on re-rendering 300 boundaries, with the write leg only 1.5 ms.
+Compiling moves it a little (4.7 → 4.1 ms) and does not close it. This is
+the one number in the update section that is squarely Freehand's own, and
+it is the one to act on.
 
 **The microtask yield costs nothing, and the control is in situ.** The
 floor and Reagent arms — which do not need it — report `gap` of exactly
@@ -402,7 +407,7 @@ Stated plainly, because the omissions are load-bearing.
    would help every re-frame consumer on every substrate. Measuring
    where inside `commit-frame-transition!` plus the signal graph the
    ≈0.85 ms goes is a small, high-leverage spike.
-2. **Cheapen bulk re-render of boundaries.** The ≈7× on 300 repainting
+2. **Cheapen bulk re-render of boundaries.** The ≈7–8× on 300 repainting
    boundaries is Freehand's own, and compiling barely moves it, which
    suggests the cost is in the ViewCell wrapper rather than in the
    markup walk — the same term §1a of the predecessor report priced at

--- a/implementation/freehand/test/re_frame/freehand/bench/b6_floor.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b6_floor.cljs
@@ -1,0 +1,124 @@
+(ns re-frame.freehand.bench.b6-floor
+  "B6's React FLOOR — the same three pages, built by hand with
+  `react/createElement` and no substrate at all.
+
+  The single most useful instrument in this comparison is an arm that is
+  not an arm. It has no boundary, no ViewCell, no reactive wrapper, no
+  props map, no attribute walk and no conversion table; it has no state,
+  no events and no identity, so nobody could ship it. That is the point.
+  It is the irreducible cost of asking React to build this page, so
+  `freehand − floor` and `reagent − floor` are the substrates' OWN
+  overheads rather than two numbers dominated by a reconciliation both
+  pay identically.
+
+  It is also the calibrator. This box drifts — the predecessor report
+  watched the floor move 37% across five rounds on an arm no change in it
+  could touch — so absolute milliseconds are not comparable between
+  rounds and every comparative figure B6 publishes is a ratio to the
+  floor measured IN THAT SAME RUN.
+
+  The floor is gated on canonical-DOM equality with every other arm, so a
+  hand transcription that drifted fails rather than flatters itself.
+
+  ## The update floor is NOT a lower bound, and the report says so
+
+  On mount, the floor is genuinely a floor: nothing can build this DOM
+  with less work than a bare `createElement` walk. On UPDATE it is
+  something else — a plain top-down React re-render, which is what an
+  application with no reactive substrate at all actually costs. A
+  fine-grained substrate can and should beat it on a narrow write, and
+  when it does the ratio drops below 1.0. That is a real result about
+  fine-grained reactivity, not an instrument fault, and it is reported as
+  such.
+
+  Normative owner: `docs/design/freehand/decisions/`
+  `D021-performance-budgets-and-release-evidence.md`."
+  (:require ["react" :as react]))
+
+(defn- el
+  "`react/createElement` under a shorter name, with the children already
+  in an array."
+  ([tag props] (react/createElement tag props))
+  ([tag props children] (react/createElement tag props children)))
+
+;; ---------------------------------------------------------------------------
+;; W1 — the large template
+;; ---------------------------------------------------------------------------
+
+(def ^:private row-style
+  #js {:paddingLeft "4px" :color "rebeccapurple"})
+
+(defn- w1-row-el [i]
+  (el "li" #js {:key i :className "row cell wide" :style row-style :data-index i}
+      #js [(el "img" #js {:key "a" :className "avatar" :src "/avatar.png" :alt ""})
+           (el "span" #js {:key "b" :className "label"} "row ")
+           (el "em" #js {:key "c" :className "n"} (str i))]))
+
+(defn w1
+  "The large template, floor arm."
+  [rows]
+  (el "section" #js {:className "panel" :aria-label "bench rows"}
+      #js [(el "h1" #js {:key "h" :className "title"} "Rows")
+           (el "ul" #js {:key "l" :className "rows" :role "list"}
+               (into-array (map w1-row-el (range rows))))]))
+
+;; ---------------------------------------------------------------------------
+;; W2 — the boundary storm, with no boundaries
+;; ---------------------------------------------------------------------------
+
+(defn w2
+  "300 leaves, floor arm. The floor has no component per leaf — that IS
+  the elision the compiled tier has to prove its way to, handed over for
+  free because a hand-written arm never created the wrapper in the first
+  place."
+  [n]
+  (el "div" #js {:className "storm"}
+      (into-array
+        (map (fn [i] (el "span" #js {:key i :className "leaf"} "leaf")) (range n)))))
+
+;; ---------------------------------------------------------------------------
+;; W3 — the ordinary form
+;; ---------------------------------------------------------------------------
+
+(defn- w3-field-el [i value error]
+  (el "div" #js {:key i :className "field"}
+      #js [(el "label" #js {:key "l" :className "lbl" :htmlFor (str "f" i)}
+               (str "Field " i))
+           (el "input" #js {:key      "i"
+                            :className "inp"
+                            :id       (str "f" i)
+                            :name     (str "f" i)
+                            :type     "text"
+                            :value    value
+                            :readOnly true})
+           (el "p" #js {:key "p" :className "err"} error)]))
+
+(defn w3
+  "The 12-field form, floor arm."
+  [fields]
+  (el "form" #js {:className "w3form"}
+      #js [(el "fieldset" #js {:key "f" :className "fields"}
+               (into-array
+                 (map (fn [i]
+                        (w3-field-el i
+                                     (str "value " i)
+                                     (if (even? i) "" (str "field " i " is required"))))
+                      (range fields))))
+           (el "button" #js {:key "b" :className "submit" :type "submit" :disabled true}
+               "Submit")]))
+
+;; ---------------------------------------------------------------------------
+;; U — the update witness
+;; ---------------------------------------------------------------------------
+
+(defn u-grid
+  "The update grid over an explicit `cells` vector. There is no state and
+  no hook: an update is the caller re-rendering the whole root with a new
+  vector, which is precisely the top-down re-render this arm is here to
+  price."
+  [cells]
+  (el "div" #js {:className "ugrid"}
+      (into-array
+        (map-indexed
+          (fn [i v] (el "span" #js {:key i :className "cell" :data-i i} (str v)))
+          cells))))

--- a/implementation/freehand/test/re_frame/freehand/bench/b6_harness.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b6_harness.cljs
@@ -1,0 +1,227 @@
+(ns re-frame.freehand.bench.b6-harness
+  "B6's instrument — the shared plumbing every cross-substrate row runs
+  on: canonical DOM, one timed commit, interleaved rounds, and floor
+  normalisation.
+
+  Kept apart from the rows that use it so the METHOD is one thing a
+  reader can check once, rather than three near-copies whose differences
+  they would have to diff.
+
+  ## What a reading is
+
+  `react-dom/flushSync` brackets the commit, so the measured window
+  contains the substrate's element construction AND React's render,
+  commit and DOM mutation, with nothing scheduled out of it. Nothing runs
+  in an `act` environment: `act` diverts work to its own queue, which is
+  not what a browser does, and the whole point of the window is that it
+  is the browser's.
+
+  ## Interleaving, and why at the SAMPLE level
+
+  A box with six other agents on it drifts, and it drifts on a timescale
+  that runs all of one arm and then all of another straight into a
+  systematic error. So every sample index mounts every arm, in an order
+  that ROTATES with the sample index — no arm is always first into a cold
+  cache, and no arm is always last into a loaded one.
+
+  ## Every figure is a ratio to the floor measured in the same round
+
+  Absolute milliseconds are published, because a 3× ratio on a 0.2 ms
+  operation is not a product decision and a reader is owed the size of
+  the thing. But no cross-round absolute claim is made: the calibrator is
+  the floor arm, which is the same work in every round and contains no
+  substrate at all. Rounds are reported as a RANGE, and a range that
+  straddles 1.0 is reported as indistinguishable rather than as a
+  winner.
+
+  Normative owner: `docs/design/freehand/decisions/`
+  `D021-performance-budgets-and-release-evidence.md`."
+  (:require ["react-dom" :as react-dom]
+            [clojure.string :as str]
+            [re-frame.freehand.bench.measure :as m]))
+
+;; ---------------------------------------------------------------------------
+;; Canonical DOM — the fairness gate
+;; ---------------------------------------------------------------------------
+
+(defn canonical
+  "Serialise `node`'s subtree with every element's attribute names SORTED.
+
+  `innerHTML` preserves insertion order, and two front ends write props
+  in different orders, so comparing it compares the serialiser rather
+  than the page — the predecessor report's first run reported two
+  witnesses as producing different pages on exactly this mistake, and
+  they did not. Sorting the names compares the DOM.
+
+  This is the entire fairness guarantee of the comparison. Without it,
+  two arms could be timed against each other while building different
+  pages."
+  [node]
+  (let [out (array)]
+    (letfn [(walk [n]
+              (case (.-nodeType n)
+                1 (let [tag   (str/lower-case (.-tagName n))
+                        attrs (->> (array-seq (.-attributes n))
+                                   (map (fn [a] [(.-name a) (.-value a)]))
+                                   (sort-by first))]
+                    (.push out (str "<" tag))
+                    (doseq [[k v] attrs]
+                      (.push out (str " " k "=\"" v "\"")))
+                    (.push out ">")
+                    (doseq [c (array-seq (.-childNodes n))] (walk c))
+                    (.push out (str "</" tag ">")))
+                3 (.push out (.-nodeValue n))
+                8 nil
+                (.push out (str "#" (.-nodeType n)))))]
+      (doseq [c (array-seq (.-childNodes node))] (walk c)))
+    (.join out "")))
+
+(defn element-count
+  [node]
+  (.-length (.querySelectorAll node "*")))
+
+;; ---------------------------------------------------------------------------
+;; Hosts
+;; ---------------------------------------------------------------------------
+
+(defn browser?
+  []
+  (and (exists? js/document) (some? (.-createElement js/document))))
+
+(defn leave-act-environment!
+  "React's `act` queue is not the browser's scheduler. Every B6 reading is
+  taken outside it, so a commit measured here is the commit a user's page
+  performs."
+  []
+  (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+  nil)
+
+(defn- fresh-container! []
+  (let [c (js/document.createElement "div")]
+    (.appendChild js/document.body c)
+    c))
+
+;; ---------------------------------------------------------------------------
+;; One timed commit
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private mount-seq (atom 0))
+
+(defn mount-arm!
+  "Mount `arm` over `props` into a fresh host and answer
+  `{:ms … :container … :handle …}`.
+
+  `:ms` is the wall time across `flushSync`, so it contains construction
+  and commit and nothing scheduled out. The container is created and
+  attached OUTSIDE the window: a `document.createElement` billed to one
+  arm and not another would be a systematic error the size of some of the
+  effects here."
+  [arm props]
+  (let [n         (swap! mount-seq inc)
+        container (fresh-container!)
+        handle    (volatile! nil)
+        t0        (m/now-ms)]
+    (react-dom/flushSync (fn [] (vreset! handle ((:mount arm) container props n))))
+    (let [ms (- (m/now-ms) t0)]
+      {:ms ms :container container :handle @handle :arm arm})))
+
+(defn release!
+  "Unmount and detach. Never timed."
+  [{:keys [arm handle container]}]
+  (when handle
+    (try (react-dom/flushSync (fn [] ((:unmount arm) handle)))
+         (catch :default _ nil)))
+  (when container (.remove container))
+  nil)
+
+;; ---------------------------------------------------------------------------
+;; Parity — run before any clock is read
+;; ---------------------------------------------------------------------------
+
+(defn parity
+  "Mount every arm at once, answer
+  `{:agree? bool :counts {id n} :canon {id html} :reference html}`, and
+  leave the mounts standing for the caller to release.
+
+  Every arm mounted simultaneously rather than one at a time, because the
+  comparison is of pages and a page is what is in the document."
+  [arms props]
+  (let [mounts (mapv (fn [a] (mount-arm! a props)) arms)
+        canon  (into {} (map (fn [m] [(:id (:arm m)) (canonical (:container m))]) mounts))
+        counts (into {} (map (fn [m] [(:id (:arm m)) (element-count (:container m))]) mounts))
+        ref    (get canon (:id (:arm (first mounts))))]
+    {:mounts    mounts
+     :canon     canon
+     :counts    counts
+     :reference ref
+     :agree?    (every? #(= ref %) (vals canon))
+     :disagree  (into [] (comp (remove (fn [[_ h]] (= ref h))) (map first)) canon)}))
+
+;; ---------------------------------------------------------------------------
+;; Interleaved rounds
+;; ---------------------------------------------------------------------------
+
+(defn- round4
+  "Four decimal places. `measure`'s own rounder is private, and a second
+  three-line copy is cheaper than widening that namespace's surface for a
+  bench row."
+  [x]
+  (/ (js/Math.round (* (double x) 10000.0)) 10000.0))
+
+(defn- p50 [xs] (:p50 (m/summarise xs)))
+
+(defn round!
+  "One round: `(+ warmup samples)` sample indices, every arm mounted at
+  every index, arm order rotating with the index. Answers `{id [ms …]}`
+  over the measured indices only."
+  [arms props {:keys [warmup samples]}]
+  (let [k   (count arms)
+        acc (atom (zipmap (map :id arms) (repeat [])))]
+    (dotimes [s (+ warmup samples)]
+      (dotimes [j k]
+        (let [arm (nth arms (mod (+ j s) k))
+              mnt (mount-arm! arm props)]
+          (when (>= s warmup)
+            (swap! acc update (:id arm) conj (:ms mnt)))
+          (release! mnt))))
+    @acc))
+
+(defn normalise
+  "Turn one round's raw readings into `{:p50 {id ms} :ratio {id r}}`,
+  every ratio against the floor measured in THIS round."
+  [readings floor-id]
+  (let [p50s  (into {} (map (fn [[id xs]] [id (p50 xs)])) readings)
+        floor (get p50s floor-id)]
+    {:p50   p50s
+     :ratio (into {} (map (fn [[id v]] [id (round4 (/ v floor))])) p50s)}))
+
+(defn across-rounds
+  "Fold per-round ratio maps into `{id {:mean … :min … :max … :rounds n
+  :straddles-1? bool}}`.
+
+  `:straddles-1?` is the honesty flag: when an arm's range includes 1.0
+  the report must say the arms are indistinguishable rather than quote
+  the mean as a winner."
+  [round-ratios]
+  (let [ids (keys (first round-ratios))]
+    (into {}
+          (map (fn [id]
+                 (let [vs (mapv #(get % id) round-ratios)]
+                   [id {:mean         (round4 (/ (reduce + 0.0 vs) (count vs)))
+                        :min          (round4 (apply min vs))
+                        :max          (round4 (apply max vs))
+                        :rounds       (count vs)
+                        :straddles-1? (and (<= (apply min vs) 1.0)
+                                           (>= (apply max vs) 1.0))}])))
+          ids)))
+
+;; ---------------------------------------------------------------------------
+;; Publication
+;; ---------------------------------------------------------------------------
+
+(defn publish!
+  "Write one record to the console as EDN. The browser runner flushes the
+  console on failure and under `RF2_VERBOSE_TESTS=1`, which is how the
+  evidence lane reads these."
+  [tag record]
+  (js/console.log (str ";; B6 " tag "\n" (pr-str record))))

--- a/implementation/freehand/test/re_frame/freehand/bench/b6_mount_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b6_mount_dom_cljs_test.cljs
@@ -1,0 +1,333 @@
+(ns re-frame.freehand.bench.b6-mount-dom-cljs-test
+  "B6's MOUNT row — Freehand against Reagent (and UIx) on one React floor.
+
+  The question this file answers is the operator's, verbatim: *how fast is
+  Freehand relative to Reagent?* Every earlier B-spine row compares
+  Freehand to itself; this one puts a second and a third substrate on the
+  same page, building the same DOM, into the same React, and prices all
+  of them against the same hand-written `createElement` floor.
+
+  ## Mount is only half, and it is the misleading half
+
+  Reagent's design point is not mount. It is fine-grained ratom
+  reactivity on UPDATE, and a mount-only answer would flatter whichever
+  substrate happens to construct elements fastest while saying nothing
+  about the thing Reagent is for.
+  [[re-frame.freehand.bench.b6-update-dom-cljs-test]] is the other half,
+  and neither is quotable without the other.
+
+  ## What gates and what does not
+
+    - **DETERMINISTIC, and these gate**: canonical-DOM equality across
+      EVERY arm, and an element count against written arithmetic, at both
+      the stress and the small size. That equality is the entire fairness
+      guarantee of the comparison — without it, two arms are being timed
+      while building two different pages, and the predecessor report
+      records a first run in which exactly that was nearly believed.
+    - **EVIDENCE, and this gates nothing**: the timings. D021 sets no
+      threshold, and one set here would be measuring this workstation.
+      The clock row asserts only that the timer moved.
+
+  ## The honest reading of W2
+
+  W2 is 300 leaf boundaries whose bodies read nothing. Freehand's
+  compiled tier can PROVE that and drop the ViewCell; Reagent has no such
+  concept, and neither does UIx. It is therefore the shape that maximally
+  overstates Freehand's advantage, it is reported with that warning
+  attached, and W1 and W3 are the headline shapes.
+
+  Normative owner: `docs/design/freehand/decisions/`
+  `D021-performance-budgets-and-release-evidence.md`."
+  (:require ["react-dom/client" :as react-dom-client]
+            [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [reagent.dom.client :as rdc]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.bench.b6-floor :as floor]
+            [re-frame.freehand.bench.b6-harness :as h]
+            [re-frame.freehand.bench.b6-reagent :as rg]
+            [re-frame.freehand.bench.b6-uix :as ux]
+            [re-frame.freehand.bench.b6-witnesses :as fh]
+            [re-frame.freehand.bench.b6-witnesses-compiled :as fhc]
+            [re-frame.freehand.bench.provenance :as prov]
+            [re-frame.freehand.react :as fr]
+            [re-frame.freehand.root :as root]
+            [uix.core :refer [$]]
+            [uix.dom :as uix-dom]))
+
+;; ---------------------------------------------------------------------------
+;; Fixture sizes — parameters, not language constants
+;; ---------------------------------------------------------------------------
+
+(def ^:private w1-rows 300)
+(def ^:private w1-small-rows 6)
+(def ^:private w2-n 300)
+(def ^:private w3-fields 12)
+
+(def ^:private rounds 5)
+(def ^:private sampling {:warmup 5 :samples 20})
+
+(defn w1-elements
+  "Three for the skeleton — the section, the heading and the list — then
+  four per row: the row, its image, its label and its number. Arithmetic,
+  so the gate is against a written expectation rather than against
+  whatever the mount happened to produce."
+  [rows]
+  (+ 3 (* 4 rows)))
+
+(defn w2-elements [n] (+ 1 n))
+
+(defn w3-elements
+  "Three for the skeleton — the form, the fieldset and the submit button —
+  then four per field: the wrapper, the label, the input and the error
+  line."
+  [fields]
+  (+ 3 (* 4 fields)))
+
+;; ---------------------------------------------------------------------------
+;; The arms
+;; ---------------------------------------------------------------------------
+
+(defn- react-root-arm
+  "An arm over a bare `react-dom/client` root — the floor and the UIx arm
+  both mount this way, because neither has a mount door of its own."
+  [id element-of]
+  {:id      id
+   :mount   (fn [container props _n]
+              (let [r (react-dom-client/createRoot container)]
+                (.render r (element-of props))
+                r))
+   :unmount (fn [r] (.unmount r))})
+
+(defn- freehand-arm
+  [id view]
+  {:id      id
+   :mount   (fn [container props n]
+              (v/mount [view props] container
+                       {:disambiguator (keyword "b6" (str (name id) "-" n))}))
+   :unmount (fn [mounted] (v/unmount! mounted))})
+
+(defn- reagent-arm
+  "Reagent's own mount door — `reagent.dom.client/create-root` and
+  `render`, which is what a Reagent application calls."
+  [id form-of]
+  {:id      id
+   :mount   (fn [container props _n]
+              (let [r (rdc/create-root container)]
+                (rdc/render r (form-of props))
+                r))
+   :unmount (fn [r] (rdc/unmount r))})
+
+(defn- uix-arm
+  [id element-of]
+  {:id      id
+   :mount   (fn [container props _n]
+              (let [r (uix-dom/create-root container)]
+                (uix-dom/render-root (element-of props) r)
+                r))
+   :unmount (fn [r] (uix-dom/unmount-root r))})
+
+(def ^:private witnesses
+  "The three witnesses, each with its arms, its fixture and its written
+  element arithmetic. A table, because the method is one method and three
+  near-copies of a driver would be three places for it to drift."
+  [{:id      :W1
+    :doc     "a large template — 300 rows under one boundary each, rich attributes"
+    :headline? true
+    :props   {:rows w1-rows}
+    :small   {:rows w1-small-rows}
+    :elements (w1-elements w1-rows)
+    :small-elements (w1-elements w1-small-rows)
+    :arms    [(react-root-arm :floor       (fn [{:keys [rows]}] (floor/w1 rows)))
+              (freehand-arm   :freehand-interpreted fh/w1)
+              (freehand-arm   :freehand-compiled    fhc/w1)
+              (reagent-arm    :reagent     (fn [{:keys [rows]}] [rg/w1 rows]))
+              (uix-arm        :uix         (fn [{:keys [rows]}] ($ ux/w1 {:rows rows})))]}
+
+   {:id      :W2
+    :doc     "300 sub-free leaf boundaries — the ELISION-MAXIMISING shape"
+    :headline? false
+    :warning "Freehand's compiled tier proves these bodies sub-free and drops
+              300 ViewCells. Reagent and UIx have no elision concept and cannot.
+              This row therefore OVERSTATES Freehand's advantage and must not be
+              quoted as the headline."
+    :props   {:n w2-n}
+    :small   {:n 6}
+    :elements (w2-elements w2-n)
+    :small-elements (w2-elements 6)
+    :arms    [(react-root-arm :floor       (fn [{:keys [n]}] (floor/w2 n)))
+              (freehand-arm   :freehand-interpreted fh/w2)
+              (freehand-arm   :freehand-compiled    fhc/w2)
+              (reagent-arm    :reagent     (fn [{:keys [n]}] [rg/w2 n]))
+              (uix-arm        :uix         (fn [{:keys [n]}] ($ ux/w2 {:n n})))]}
+
+   {:id      :W3
+    :doc     "an ordinary 12-field form with controlled inputs — the shape most applications are made of"
+    :headline? true
+    :props   {:fields w3-fields}
+    :small   {:fields 3}
+    :elements (w3-elements w3-fields)
+    :small-elements (w3-elements 3)
+    :arms    [(react-root-arm :floor       (fn [{:keys [fields]}] (floor/w3 fields)))
+              (freehand-arm   :freehand-interpreted fh/w3)
+              (freehand-arm   :freehand-compiled    fhc/w3)
+              (reagent-arm    :reagent     (fn [{:keys [fields]}] [rg/w3 fields]))
+              (uix-arm        :uix         (fn [{:keys [fields]}] ($ ux/w3 {:fields fields})))]}])
+
+;; ---------------------------------------------------------------------------
+;; Fixtures
+;; ---------------------------------------------------------------------------
+
+(use-fixtures :each
+  {:before (fn [] (root/reset-registry!) (fr/reset-boundaries!) (h/leave-act-environment!))
+   :after  (fn [] (root/reset-registry!) (fr/reset-boundaries!))})
+
+;; ===========================================================================
+;; The fairness gate — canonical DOM, every arm, before any clock
+;; ===========================================================================
+
+(defn- assert-parity!
+  [{:keys [id arms]} props expected-elements what]
+  (let [{:keys [mounts canon counts agree? disagree]} (h/parity arms props)]
+    (try
+      (is agree?
+          (str (name id) " / " what
+               ": every arm built the SAME page, compared as canonical DOM"
+               (when-not agree?
+                 (str " — these disagreed with the floor: " (pr-str disagree)
+                      "\nfloor: " (pr-str (subs (get canon :floor "") 0 (min 600 (count (get canon :floor "")))))
+                      "\nother: " (pr-str (into {} (map (fn [k] [k (subs (get canon k "") 0 (min 600 (count (get canon k ""))))])) disagree))))))
+      (doseq [[arm-id n] counts]
+        (is (= expected-elements n)
+            (str (name id) " / " what " / " (name arm-id)
+                 ": built the " expected-elements " elements the witness's arithmetic predicts")))
+      (is (pos? (count (get canon :floor ""))) "and it built a page, rather than nothing at all")
+      (finally
+        (doseq [m mounts] (h/release! m))))))
+
+(deftest every-arm-builds-the-same-page-at-stress
+  (testing "The fairness guarantee, stated first because nothing below it
+            means anything without it: the React floor, interpreted
+            Freehand, compiled Freehand, Reagent and UIx each mount their
+            own declaration of the same three witnesses, and the browser
+            builds ONE page from all five — compared as canonical DOM,
+            with attribute names sorted so the comparison is of the DOM
+            rather than of the browser's insertion-ordered serialiser."
+    (if-not (h/browser?)
+      (is true "a real browser mount is required — the browser job runs this row")
+      (doseq [{:keys [props elements] :as w} witnesses]
+        (assert-parity! w props elements "stress")))))
+
+(deftest every-arm-builds-the-same-page-at-small
+  (testing "The same equality at the small realistic size D021 requires
+            beside every stress case, so parity is not a property of one
+            synthetic extreme."
+    (if-not (h/browser?)
+      (is true "a real browser mount is required — the browser job runs this row")
+      (doseq [{:keys [small small-elements] :as w} witnesses]
+        (assert-parity! w small small-elements "small")))))
+
+(deftest the-parity-comparison-can-fail
+  (testing "A comparison nobody has watched answer false is not evidence
+            that two things agree. The same arm at two DIFFERENT sizes,
+            through the same mount path, compared the same way, must
+            disagree — and if it ever does not, every equality in this
+            file is passing for a reason that has nothing to do with the
+            substrates."
+    (if-not (h/browser?)
+      (is true "a real browser mount is required — the browser job runs this row")
+      (let [arm (freehand-arm :freehand-interpreted fh/w1)
+            a   (h/mount-arm! arm {:rows 6})
+            b   (h/mount-arm! arm {:rows 7})]
+        (try
+          (is (not= (h/canonical (:container a)) (h/canonical (:container b)))
+              "one row's difference is visible to the comparison the parity row is made with")
+          (is (= (h/canonical (:container a)) (h/canonical (:container a)))
+              "and the comparison is stable on one page")
+          (finally (h/release! a) (h/release! b)))))))
+
+;; ===========================================================================
+;; The clock — evidence, gated against nothing
+;; ===========================================================================
+
+(defn- measure-witness!
+  [{:keys [id doc props arms headline? warning elements]}]
+  (let [raw     (mapv (fn [_] (h/round! arms props sampling)) (range rounds))
+        norm    (mapv #(h/normalise % :floor) raw)
+        summary (h/across-rounds (mapv :ratio norm))]
+    (h/publish!
+      (str "mount / " (name id))
+      {:benchmark    (keyword "B6" (str "mount-" (name id)))
+       :doc          doc
+       :headline?    headline?
+       :warning      warning
+       :revision     (prov/detect-revision)
+       :build        (prov/detect-build)
+       :host         (prov/detect-host)
+       :fixture      {:witness  id
+                      :props    props
+                      :elements elements
+                      :arms     (mapv :id arms)
+                      :reagent-version "2.0.1"
+                      :uix-version     "1.4.4"
+                      :measurement-method
+                      (str "wall time across react-dom/flushSync around each arm's own "
+                           "mount door, into a fresh container attached before the window; "
+                           "arms interleaved at the SAMPLE level with the order rotating "
+                           "on the sample index; " rounds " rounds of "
+                           (:warmup sampling) " warmup + " (:samples sampling)
+                           " samples per arm per round; every figure a ratio to the FLOOR "
+                           "measured in that same round, because this workstation drifts "
+                           "further across rounds than several of the effects being measured")}
+       :sampling     sampling
+       :baseline     {:kind      :cross-substrate
+                      :reference {:arm  :floor
+                                  :note "the same DOM built by hand with react/createElement
+                                         and no substrate at all"}}
+       :per-round    {:p50   (mapv :p50 norm)
+                      :ratio (mapv :ratio norm)}
+       :ratio-to-floor summary
+       :status       :evidence})
+    {:id id :summary summary :norm norm}))
+
+(deftest mount-cost-against-the-shared-react-floor
+  (testing "The measurement itself: five interleaved rounds per witness,
+            every arm's p50 divided by the floor's p50 in the same round.
+            Published as a distribution with provenance and a per-round
+            range, and asserted against NOTHING except that the timer
+            moved and the floor did not somehow come out at zero — D021
+            sets no threshold and one set here would be measuring this
+            box."
+    (if-not (h/browser?)
+      (is true "a real browser mount is required — the browser job runs this row")
+      (doseq [w witnesses]
+        (let [{:keys [summary norm]} (measure-witness! w)]
+          (is (= rounds (count norm))
+              (str (name (:id w)) ": every round produced a reading"))
+          (is (every? (fn [{:keys [p50]}] (pos? (get p50 :floor)))
+                      norm)
+              (str (name (:id w)) ": the floor arm took measurable time in every round"))
+          (is (= 1.0 (get-in summary [:floor :mean]))
+              (str (name (:id w)) ": the floor is its own calibrator and normalises to exactly 1.0"))
+          (is (every? #(pos? (:mean %)) (vals summary))
+              (str (name (:id w)) ": every arm produced a positive ratio")))))))
+
+;; ===========================================================================
+;; Non-vacuity
+;; ===========================================================================
+
+(deftest the-arms-really-are-five-substrates
+  (testing "A cross-substrate ratio is only a cross-substrate ratio if the
+            arms are different substrates. The two Freehand arms are two
+            lowerings of one declaration; the Reagent and UIx arms are
+            plain functions of their own libraries; the floor is neither."
+    (is (= :interpreted (:lowering (v/describe fh/w1)))
+        "the Freehand reference arm is genuinely interpreted")
+    (is (= :compiled (:lowering (v/describe fhc/w1)))
+        "and the compared Freehand arm is genuinely compiled")
+    (is (not= (:view-id (v/describe fh/w1)) (:view-id (v/describe fhc/w1)))
+        "they are two declarations, in two namespaces")
+    (is (false? (v/view? rg/w1)) "the Reagent arm is NOT a Freehand declaration")
+    (is (fn? rg/w1) "it is an ordinary function returning Hiccup, as a Reagent user writes")
+    (is (= 1203 (w1-elements w1-rows)) "W1's element arithmetic is arithmetic, not a recorded observation")
+    (is (= 301 (w2-elements w2-n)) "and so is W2's")
+    (is (= 51 (w3-elements w3-fields)) "and so is W3's")))

--- a/implementation/freehand/test/re_frame/freehand/bench/b6_mount_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b6_mount_dom_cljs_test.cljs
@@ -11,12 +11,12 @@
 
   Reagent's design point is not mount. It is fine-grained ratom
   reactivity on UPDATE, and a mount-only answer would flatter whichever
-  substrate happens to construct elements fastest while saying nothing
-  about the thing Reagent is for.
+  substrate constructs elements fastest while saying nothing about the
+  thing Reagent is for.
   [[re-frame.freehand.bench.b6-update-dom-cljs-test]] is the other half,
   and neither is quotable without the other.
 
-  ## What gates and what does not
+  ## What gates here, and what does not
 
     - **DETERMINISTIC, and these gate**: canonical-DOM equality across
       EVERY arm, and an element count against written arithmetic, at both
@@ -26,7 +26,17 @@
       records a first run in which exactly that was nearly believed.
     - **EVIDENCE, and this gates nothing**: the timings. D021 sets no
       threshold, and one set here would be measuring this workstation.
-      The clock row asserts only that the timer moved.
+
+  ## The numbers this file takes are not the published ones
+
+  This build is `:optimizations :none` with `goog.DEBUG true`, so Spec 009
+  instrumentation, schema validation and trace emission are all live —
+  and Reagent has no counterpart to any of them, so a development build
+  systematically penalises Freehand. The reading that goes in the report
+  is taken by [[re-frame.freehand.bench.b6-prod-app]] under `:advanced`
+  with `goog.DEBUG false`. What this file is for is the gate: proving,
+  every time the browser suite runs, that the five arms still build one
+  page.
 
   ## The honest reading of W2
 
@@ -38,144 +48,18 @@
 
   Normative owner: `docs/design/freehand/decisions/`
   `D021-performance-budgets-and-release-evidence.md`."
-  (:require ["react-dom/client" :as react-dom-client]
-            [cljs.test :refer-macros [deftest is testing use-fixtures]]
-            [reagent.dom.client :as rdc]
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.freehand :as v]
-            [re-frame.freehand.bench.b6-floor :as floor]
             [re-frame.freehand.bench.b6-harness :as h]
             [re-frame.freehand.bench.b6-reagent :as rg]
-            [re-frame.freehand.bench.b6-uix :as ux]
+            [re-frame.freehand.bench.b6-rows :as rows]
             [re-frame.freehand.bench.b6-witnesses :as fh]
             [re-frame.freehand.bench.b6-witnesses-compiled :as fhc]
-            [re-frame.freehand.bench.provenance :as prov]
             [re-frame.freehand.react :as fr]
-            [re-frame.freehand.root :as root]
-            [uix.core :refer [$]]
-            [uix.dom :as uix-dom]))
+            [re-frame.freehand.root :as root]))
 
-;; ---------------------------------------------------------------------------
-;; Fixture sizes — parameters, not language constants
-;; ---------------------------------------------------------------------------
-
-(def ^:private w1-rows 300)
-(def ^:private w1-small-rows 6)
-(def ^:private w2-n 300)
-(def ^:private w3-fields 12)
-
-(def ^:private rounds 5)
-(def ^:private sampling {:warmup 5 :samples 20})
-
-(defn w1-elements
-  "Three for the skeleton — the section, the heading and the list — then
-  four per row: the row, its image, its label and its number. Arithmetic,
-  so the gate is against a written expectation rather than against
-  whatever the mount happened to produce."
-  [rows]
-  (+ 3 (* 4 rows)))
-
-(defn w2-elements [n] (+ 1 n))
-
-(defn w3-elements
-  "Three for the skeleton — the form, the fieldset and the submit button —
-  then four per field: the wrapper, the label, the input and the error
-  line."
-  [fields]
-  (+ 3 (* 4 fields)))
-
-;; ---------------------------------------------------------------------------
-;; The arms
-;; ---------------------------------------------------------------------------
-
-(defn- react-root-arm
-  "An arm over a bare `react-dom/client` root — the floor and the UIx arm
-  both mount this way, because neither has a mount door of its own."
-  [id element-of]
-  {:id      id
-   :mount   (fn [container props _n]
-              (let [r (react-dom-client/createRoot container)]
-                (.render r (element-of props))
-                r))
-   :unmount (fn [r] (.unmount r))})
-
-(defn- freehand-arm
-  [id view]
-  {:id      id
-   :mount   (fn [container props n]
-              (v/mount [view props] container
-                       {:disambiguator (keyword "b6" (str (name id) "-" n))}))
-   :unmount (fn [mounted] (v/unmount! mounted))})
-
-(defn- reagent-arm
-  "Reagent's own mount door — `reagent.dom.client/create-root` and
-  `render`, which is what a Reagent application calls."
-  [id form-of]
-  {:id      id
-   :mount   (fn [container props _n]
-              (let [r (rdc/create-root container)]
-                (rdc/render r (form-of props))
-                r))
-   :unmount (fn [r] (rdc/unmount r))})
-
-(defn- uix-arm
-  [id element-of]
-  {:id      id
-   :mount   (fn [container props _n]
-              (let [r (uix-dom/create-root container)]
-                (uix-dom/render-root (element-of props) r)
-                r))
-   :unmount (fn [r] (uix-dom/unmount-root r))})
-
-(def ^:private witnesses
-  "The three witnesses, each with its arms, its fixture and its written
-  element arithmetic. A table, because the method is one method and three
-  near-copies of a driver would be three places for it to drift."
-  [{:id      :W1
-    :doc     "a large template — 300 rows under one boundary each, rich attributes"
-    :headline? true
-    :props   {:rows w1-rows}
-    :small   {:rows w1-small-rows}
-    :elements (w1-elements w1-rows)
-    :small-elements (w1-elements w1-small-rows)
-    :arms    [(react-root-arm :floor       (fn [{:keys [rows]}] (floor/w1 rows)))
-              (freehand-arm   :freehand-interpreted fh/w1)
-              (freehand-arm   :freehand-compiled    fhc/w1)
-              (reagent-arm    :reagent     (fn [{:keys [rows]}] [rg/w1 rows]))
-              (uix-arm        :uix         (fn [{:keys [rows]}] ($ ux/w1 {:rows rows})))]}
-
-   {:id      :W2
-    :doc     "300 sub-free leaf boundaries — the ELISION-MAXIMISING shape"
-    :headline? false
-    :warning "Freehand's compiled tier proves these bodies sub-free and drops
-              300 ViewCells. Reagent and UIx have no elision concept and cannot.
-              This row therefore OVERSTATES Freehand's advantage and must not be
-              quoted as the headline."
-    :props   {:n w2-n}
-    :small   {:n 6}
-    :elements (w2-elements w2-n)
-    :small-elements (w2-elements 6)
-    :arms    [(react-root-arm :floor       (fn [{:keys [n]}] (floor/w2 n)))
-              (freehand-arm   :freehand-interpreted fh/w2)
-              (freehand-arm   :freehand-compiled    fhc/w2)
-              (reagent-arm    :reagent     (fn [{:keys [n]}] [rg/w2 n]))
-              (uix-arm        :uix         (fn [{:keys [n]}] ($ ux/w2 {:n n})))]}
-
-   {:id      :W3
-    :doc     "an ordinary 12-field form with controlled inputs — the shape most applications are made of"
-    :headline? true
-    :props   {:fields w3-fields}
-    :small   {:fields 3}
-    :elements (w3-elements w3-fields)
-    :small-elements (w3-elements 3)
-    :arms    [(react-root-arm :floor       (fn [{:keys [fields]}] (floor/w3 fields)))
-              (freehand-arm   :freehand-interpreted fh/w3)
-              (freehand-arm   :freehand-compiled    fhc/w3)
-              (reagent-arm    :reagent     (fn [{:keys [fields]}] [rg/w3 fields]))
-              (uix-arm        :uix         (fn [{:keys [fields]}] ($ ux/w3 {:fields fields})))]}])
-
-;; ---------------------------------------------------------------------------
-;; Fixtures
-;; ---------------------------------------------------------------------------
+(def ^:private rounds 3)
+(def ^:private sampling {:warmup 3 :samples 10})
 
 (use-fixtures :each
   {:before (fn [] (root/reset-registry!) (fr/reset-boundaries!) (h/leave-act-environment!))
@@ -186,21 +70,21 @@
 ;; ===========================================================================
 
 (defn- assert-parity!
-  [{:keys [id arms]} props expected-elements what]
-  (let [{:keys [mounts canon counts agree? disagree]} (h/parity arms props)]
+  [{:keys [id] :as witness} props expected-elements what]
+  (let [{:keys [mounts canon counts agree? disagree]} (rows/mount-parity witness props)]
     (try
       (is agree?
           (str (name id) " / " what
                ": every arm built the SAME page, compared as canonical DOM"
                (when-not agree?
-                 (str " — these disagreed with the floor: " (pr-str disagree)
-                      "\nfloor: " (pr-str (subs (get canon :floor "") 0 (min 600 (count (get canon :floor "")))))
-                      "\nother: " (pr-str (into {} (map (fn [k] [k (subs (get canon k "") 0 (min 600 (count (get canon k ""))))])) disagree))))))
+                 (str " — these disagreed with the floor: " (pr-str disagree)))))
       (doseq [[arm-id n] counts]
         (is (= expected-elements n)
             (str (name id) " / " what " / " (name arm-id)
-                 ": built the " expected-elements " elements the witness's arithmetic predicts")))
-      (is (pos? (count (get canon :floor ""))) "and it built a page, rather than nothing at all")
+                 ": built the " expected-elements
+                 " elements the witness's arithmetic predicts")))
+      (is (pos? (count (get canon :floor "")))
+          "and it built a page, rather than nothing at all")
       (finally
         (doseq [m mounts] (h/release! m))))))
 
@@ -214,7 +98,7 @@
             rather than of the browser's insertion-ordered serialiser."
     (if-not (h/browser?)
       (is true "a real browser mount is required — the browser job runs this row")
-      (doseq [{:keys [props elements] :as w} witnesses]
+      (doseq [{:keys [props elements] :as w} rows/mount-witnesses]
         (assert-parity! w props elements "stress")))))
 
 (deftest every-arm-builds-the-same-page-at-small
@@ -223,91 +107,51 @@
             synthetic extreme."
     (if-not (h/browser?)
       (is true "a real browser mount is required — the browser job runs this row")
-      (doseq [{:keys [small small-elements] :as w} witnesses]
+      (doseq [{:keys [small small-elements] :as w} rows/mount-witnesses]
         (assert-parity! w small small-elements "small")))))
 
 (deftest the-parity-comparison-can-fail
   (testing "A comparison nobody has watched answer false is not evidence
-            that two things agree. The same arm at two DIFFERENT sizes,
-            through the same mount path, compared the same way, must
-            disagree — and if it ever does not, every equality in this
-            file is passing for a reason that has nothing to do with the
-            substrates."
+            that two things agree. The same witness at two DIFFERENT sizes,
+            compared the same way, must disagree — and if it ever does
+            not, every equality in this file is passing for a reason that
+            has nothing to do with the substrates."
     (if-not (h/browser?)
       (is true "a real browser mount is required — the browser job runs this row")
-      (let [arm (freehand-arm :freehand-interpreted fh/w1)
-            a   (h/mount-arm! arm {:rows 6})
-            b   (h/mount-arm! arm {:rows 7})]
+      (let [w  (first rows/mount-witnesses)
+            a  (rows/mount-parity w {:rows 6})
+            b  (rows/mount-parity w {:rows 7})]
         (try
-          (is (not= (h/canonical (:container a)) (h/canonical (:container b)))
+          (is (not= (:reference a) (:reference b))
               "one row's difference is visible to the comparison the parity row is made with")
-          (is (= (h/canonical (:container a)) (h/canonical (:container a)))
-              "and the comparison is stable on one page")
-          (finally (h/release! a) (h/release! b)))))))
+          (is (true? (:agree? a)) "and both sizes are internally consistent across arms")
+          (is (true? (:agree? b)) "at the other size too")
+          (finally
+            (doseq [m (:mounts a)] (h/release! m))
+            (doseq [m (:mounts b)] (h/release! m))))))))
 
 ;; ===========================================================================
 ;; The clock — evidence, gated against nothing
 ;; ===========================================================================
 
-(defn- measure-witness!
-  [{:keys [id doc props arms headline? warning elements]}]
-  (let [raw     (mapv (fn [_] (h/round! arms props sampling)) (range rounds))
-        norm    (mapv #(h/normalise % :floor) raw)
-        summary (h/across-rounds (mapv :ratio norm))]
-    (h/publish!
-      (str "mount / " (name id))
-      {:benchmark    (keyword "B6" (str "mount-" (name id)))
-       :doc          doc
-       :headline?    headline?
-       :warning      warning
-       :revision     (prov/detect-revision)
-       :build        (prov/detect-build)
-       :host         (prov/detect-host)
-       :fixture      {:witness  id
-                      :props    props
-                      :elements elements
-                      :arms     (mapv :id arms)
-                      :reagent-version "2.0.1"
-                      :uix-version     "1.4.4"
-                      :measurement-method
-                      (str "wall time across react-dom/flushSync around each arm's own "
-                           "mount door, into a fresh container attached before the window; "
-                           "arms interleaved at the SAMPLE level with the order rotating "
-                           "on the sample index; " rounds " rounds of "
-                           (:warmup sampling) " warmup + " (:samples sampling)
-                           " samples per arm per round; every figure a ratio to the FLOOR "
-                           "measured in that same round, because this workstation drifts "
-                           "further across rounds than several of the effects being measured")}
-       :sampling     sampling
-       :baseline     {:kind      :cross-substrate
-                      :reference {:arm  :floor
-                                  :note "the same DOM built by hand with react/createElement
-                                         and no substrate at all"}}
-       :per-round    {:p50   (mapv :p50 norm)
-                      :ratio (mapv :ratio norm)}
-       :ratio-to-floor summary
-       :status       :evidence})
-    {:id id :summary summary :norm norm}))
-
 (deftest mount-cost-against-the-shared-react-floor
-  (testing "The measurement itself: five interleaved rounds per witness,
-            every arm's p50 divided by the floor's p50 in the same round.
-            Published as a distribution with provenance and a per-round
-            range, and asserted against NOTHING except that the timer
-            moved and the floor did not somehow come out at zero — D021
-            sets no threshold and one set here would be measuring this
-            box."
+  (testing "The measurement, taken here only to prove the instrument runs
+            and reports — the PUBLISHED numbers come from the `:advanced`
+            production entry, because this build's instrumentation is live
+            and Reagent has no counterpart to it. Asserted against NOTHING
+            except that the timer moved and the floor normalises to
+            itself; D021 sets no threshold and one set here would be
+            measuring this box."
     (if-not (h/browser?)
       (is true "a real browser mount is required — the browser job runs this row")
-      (doseq [w witnesses]
-        (let [{:keys [summary norm]} (measure-witness! w)]
+      (doseq [w rows/mount-witnesses]
+        (let [{:keys [summary norm]} (rows/measure-mount! w rounds sampling)]
           (is (= rounds (count norm))
               (str (name (:id w)) ": every round produced a reading"))
-          (is (every? (fn [{:keys [p50]}] (pos? (get p50 :floor)))
-                      norm)
+          (is (every? (fn [{:keys [p50]}] (pos? (get p50 :floor))) norm)
               (str (name (:id w)) ": the floor arm took measurable time in every round"))
           (is (= 1.0 (get-in summary [:floor :mean]))
-              (str (name (:id w)) ": the floor is its own calibrator and normalises to exactly 1.0"))
+              (str (name (:id w)) ": the floor is its own calibrator and normalises to 1.0"))
           (is (every? #(pos? (:mean %)) (vals summary))
               (str (name (:id w)) ": every arm produced a positive ratio")))))))
 
@@ -328,6 +172,7 @@
         "they are two declarations, in two namespaces")
     (is (false? (v/view? rg/w1)) "the Reagent arm is NOT a Freehand declaration")
     (is (fn? rg/w1) "it is an ordinary function returning Hiccup, as a Reagent user writes")
-    (is (= 1203 (w1-elements w1-rows)) "W1's element arithmetic is arithmetic, not a recorded observation")
-    (is (= 301 (w2-elements w2-n)) "and so is W2's")
-    (is (= 51 (w3-elements w3-fields)) "and so is W3's")))
+    (is (= 1203 (rows/w1-elements rows/w1-rows))
+        "W1's element arithmetic is arithmetic, not a recorded observation")
+    (is (= 301 (rows/w2-elements rows/w2-n)) "and so is W2's")
+    (is (= 51 (rows/w3-elements rows/w3-fields)) "and so is W3's")))

--- a/implementation/freehand/test/re_frame/freehand/bench/b6_prod_app.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b6_prod_app.cljs
@@ -1,0 +1,114 @@
+(ns re-frame.freehand.bench.b6-prod-app
+  "B6's PRODUCTION entry — the same rows, taken from an `:advanced` bundle
+  with `goog.DEBUG false`.
+
+  This namespace exists because the numbers B6 publishes must come from
+  the artefact a consumer ships, and B6's ordinary browser suite cannot
+  supply them. Two independent reasons:
+
+  1. **Development builds systematically penalise Freehand.** The Spec 009
+     instrumentation seam, schema validation and trace emission are all
+     `goog.DEBUG`-gated, and all of them sit on the subscription/render
+     path the update row measures. Reagent has no counterpart to any of
+     them. Publishing a development ratio would report a cost no user
+     pays and would do it in one direction only.
+  2. **`:advanced` cannot compile shadow's `:browser-test` target** —
+     `cljs-test-display`'s `goog.define`s collide under the Closure
+     compiler. So the production reading needs a plain `:browser` entry,
+     which is this one.
+
+  Nothing here is a second harness. Every arm, every witness and both
+  measurements are [[re-frame.freehand.bench.b6-rows]]'s, unchanged; this
+  file installs the adapter, runs them, and parks the records on
+  `window.B6_RESULTS` for the driver to read. The DETERMINISTIC gates
+  stay where they belong, in the `-dom-cljs-test` namespaces the ordinary
+  browser suite runs — but the parity check is repeated here too, because
+  a parity that held under `:none` and failed under `:advanced` would be
+  a renaming bug silently deciding the comparison.
+
+  Built and driven by
+  `implementation/freehand/test/re_frame/freehand/bench/b6_prod_run.cjs`.
+
+  Normative owner: `docs/design/freehand/decisions/`
+  `D021-performance-budgets-and-release-evidence.md`."
+  (:require [re-frame.adapter.uix :as react-substrate]
+            [re-frame.core :as rf]
+            [re-frame.freehand.bench.b6-harness :as h]
+            [re-frame.freehand.bench.b6-rows :as rows]))
+
+(def ^:private rounds 6)
+(def ^:private mount-sampling {:warmup 5 :samples 20})
+(def ^:private update-sampling {:warmup 4 :samples 12})
+
+(defn- fail! [why]
+  (set! (.-B6_ERROR js/window) (str why))
+  (js/console.error (str ";; B6 PROD FAILED — " why)))
+
+(defn- record! [k v]
+  (let [acc (or (.-B6_RESULTS js/window) #js {})]
+    (aset acc (name k) (pr-str v))
+    (set! (.-B6_RESULTS js/window) acc)
+    v))
+
+(defn- parity-of!
+  "Re-run the mount parity gate under `:advanced`. Answers a vector of
+  problems, empty when every arm still builds one page."
+  []
+  (reduce
+    (fn [problems {:keys [id props elements] :as w}]
+      (let [{:keys [mounts agree? counts disagree]} (rows/mount-parity w props)]
+        (try
+          (cond-> problems
+            (not agree?)
+            (conj {:witness id :problem :canonical-dom-disagreement :arms disagree})
+
+            (not (every? #(= elements %) (vals counts)))
+            (conj {:witness id :problem :element-count :expected elements :got counts}))
+          (finally (doseq [m mounts] (h/release! m))))))
+    []
+    rows/mount-witnesses))
+
+(defn ^:export -main
+  []
+  (try
+    (rf/init! react-substrate/adapter)
+    (h/leave-act-environment!)
+    (let [problems (parity-of!)]
+      (record! :parity {:problems problems :ok? (empty? problems)})
+      (if (seq problems)
+        (fail! (str "the arms do not build the same page under :advanced — " (pr-str problems)))
+        (do
+          (record! :mount
+                   (into {} (map (fn [w]
+                                   (let [{:keys [id record]} (rows/measure-mount!
+                                                               w rounds mount-sampling)]
+                                     [id record])))
+                         rows/mount-witnesses))
+          (let [mounts (rows/mount-update-arms! (rows/make-update-arms))]
+            (-> (rows/write-and-compare! mounts)
+                (.then (fn [{:keys [ids before after]}]
+                         (when-not (apply = after)
+                           (fail! (str "update arms disagree under :advanced: " (pr-str ids))))
+                         (when (some true? (map = before after))
+                           (fail! "an update arm's DOM did not change under :advanced"))
+                         (rows/measure-update!
+                           mounts :broad "one write that all 300 cells read"
+                           rounds update-sampling)))
+                (.then (fn [res]
+                         (record! :update-broad (:record res))
+                         (rows/measure-update!
+                           mounts :narrow "one write exactly one of 300 cells reads"
+                           rounds update-sampling)))
+                (.then (fn [res]
+                         (record! :update-narrow (:record res))
+                         (rows/release-update-arms! mounts)
+                         (set! (.-B6_DONE js/window) true)
+                         (js/console.log ";; B6 PROD DONE")
+                         nil))
+                (.catch (fn [e]
+                          (rows/release-update-arms! mounts)
+                          (fail! (str "update rows rejected: " e))
+                          (set! (.-B6_DONE js/window) true))))))))
+    (catch :default e
+      (fail! (str "prod run threw: " e))
+      (set! (.-B6_DONE js/window) true))))

--- a/implementation/freehand/test/re_frame/freehand/bench/b6_prod_run.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b6_prod_run.cjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+// B6's production driver — build, serve, run, print.
+//
+// The numbers B6 publishes have to come from the artefact a consumer
+// ships (`:advanced`, `goog.DEBUG false`), and shadow's `:browser-test`
+// target cannot be compiled that way — `cljs-test-display`'s
+// `goog.define`s collide under the Closure compiler. So the production
+// reading rides a plain `:browser` module built by merging an output
+// directory and an `:init-fn` into the existing `:freehand-release`
+// build id. Nothing in `implementation/shadow-cljs.edn` changes.
+//
+//   node implementation/freehand/test/re_frame/freehand/bench/b6_prod_run.cjs
+//
+// Prints every published record as EDN on stdout and exits non-zero if
+// the run did not reach its own parity gate.
+
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const http = require('node:http');
+const path = require('node:path');
+
+const IMPL = path.resolve(__dirname, '../../../../..');
+const OUT = path.join(IMPL, 'out', 'b6-prod');
+const PORT = Number(process.env.B6_PORT || 8127);
+
+// ONE LINE, deliberately: shadow-cljs's CLI re-splits `--config-merge` on
+// whitespace when the EDN contains a newline, and reports
+// `EOF while reading` from a fragment. Keep it on one line.
+const CONFIG_MERGE =
+  '{:output-dir "out/b6-prod" :asset-path "." ' +
+  ':modules {:main {:init-fn re-frame.freehand.bench.b6-prod-app/-main}}}';
+
+function build() {
+  console.error('[b6] building :advanced bundle ...');
+  // `node cli/runner.js` rather than the `.cmd` shim: spawning a shim on
+  // Windows needs `shell: true`, and a shell concatenates argv, which is
+  // the other way the config-merge EDN gets torn in half.
+  const runner = path.join(IMPL, 'node_modules', 'shadow-cljs', 'cli', 'runner.js');
+  const r = spawnSync(
+    process.execPath,
+    [runner, 'release', 'freehand-release', '--config-merge', CONFIG_MERGE],
+    { cwd: IMPL, stdio: ['ignore', 'inherit', 'inherit'] }
+  );
+  if (r.status !== 0) {
+    console.error(`[b6] build failed with status ${r.status}`);
+    process.exit(1);
+  }
+}
+
+const MIME = { '.js': 'text/javascript', '.html': 'text/html', '.map': 'application/json' };
+
+function serve() {
+  fs.writeFileSync(
+    path.join(OUT, 'index.html'),
+    '<!doctype html><html><head><meta charset="utf-8"><title>B6</title></head>' +
+      '<body><div id="app"></div><script src="main.js"></script></body></html>'
+  );
+  return http
+    .createServer((req, res) => {
+      const rel = decodeURIComponent(req.url.split('?')[0]);
+      const file = path.join(OUT, rel === '/' ? 'index.html' : rel);
+      if (!file.startsWith(OUT) || !fs.existsSync(file)) {
+        res.writeHead(404).end('not found');
+        return;
+      }
+      res.writeHead(200, { 'content-type': MIME[path.extname(file)] || 'application/octet-stream' });
+      fs.createReadStream(file).pipe(res);
+    })
+    .listen(PORT);
+}
+
+async function run() {
+  const { chromium } = require('playwright');
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  page.on('console', (msg) => {
+    const t = msg.text();
+    if (t.startsWith(';; B6')) console.log(t);
+  });
+  page.on('pageerror', (e) => console.error('[b6] page error:', e.message));
+  await page.goto(`http://127.0.0.1:${PORT}/`, { waitUntil: 'load' });
+  await page.waitForFunction('window.B6_DONE === true || window.B6_ERROR', null, {
+    timeout: 15 * 60 * 1000,
+  });
+  const err = await page.evaluate('window.B6_ERROR || null');
+  const results = await page.evaluate('window.B6_RESULTS || {}');
+  await browser.close();
+  return { err, results };
+}
+
+(async () => {
+  build();
+  const server = serve();
+  let outcome;
+  try {
+    outcome = await run();
+  } finally {
+    server.close();
+  }
+  for (const [k, v] of Object.entries(outcome.results)) {
+    console.log(`;; ==== B6 PROD ${k} ====`);
+    console.log(v);
+  }
+  if (outcome.err) {
+    console.error(`[b6] FAILED: ${outcome.err}`);
+    process.exit(1);
+  }
+  console.error('[b6] ok');
+})();

--- a/implementation/freehand/test/re_frame/freehand/bench/b6_reagent.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b6_reagent.cljs
@@ -1,0 +1,127 @@
+(ns re-frame.freehand.bench.b6-reagent
+  "B6's witnesses, declared in REAGENT — the compared substrate.
+
+  Written the way a Reagent user actually writes them, because a
+  strawman arm would make the whole comparison worthless: plain Hiccup
+  with class sugar, ordinary `defn` components referenced as
+  `[component arg]`, `^{:key i}` metadata on the seq children (which is
+  Reagent's own spelling, not Freehand's), a form-2 component with
+  `reagent.core/cursor` over a `reagent.core/atom` where a fine-grained
+  local model is wanted, and `reagent.dom.client` for the mount.
+
+  Nothing here is pre-adapted, no `:>` shortcut appears, and no React
+  class is hand-built. If any of that had been done the Reagent arm would
+  be measuring something no Reagent application contains.
+
+  ## The markup is character-for-character the Freehand arm's
+
+  Read this file beside [[re-frame.freehand.bench.b6-witnesses]]: the tag
+  sugar, the attribute names, the attribute order and the text are the
+  same, because the suite gates canonical-DOM equality across every arm
+  before it reads a clock and a divergence would fail rather than
+  flatter. Hiccup is a shared dialect, so this is not a translation so
+  much as the same source under a different reader — which is exactly the
+  condition that makes the ratio a substrate ratio.
+
+  ## What Reagent does that Freehand's compiled tier does not
+
+  Every `[component …]` here becomes a Reagent component with its own
+  reactive wrapper, whether or not its body dereferences anything.
+  Reagent has no elision concept: there is no analysis pass, so there is
+  nothing that could prove a body sub-free and drop the wrapper. That is
+  why W2 — 300 bodies that read nothing — is reported with a warning
+  attached rather than as a headline.
+
+  Normative owner: `docs/design/freehand/decisions/`
+  `D021-performance-budgets-and-release-evidence.md`."
+  (:require [reagent.core :as r]))
+
+;; ---------------------------------------------------------------------------
+;; W1 — the large template
+;; ---------------------------------------------------------------------------
+
+(defn w1-row
+  "One row. A form-1 component: Reagent calls it on every render of its
+  parent, and gives it its own reactive wrapper."
+  [i]
+  [:li.row.cell.wide {:style      {:padding-left "4px" :color "rebeccapurple"}
+                      :data-index i}
+   [:img.avatar {:src "/avatar.png" :alt ""}]
+   [:span.label "row "]
+   [:em.n (str i)]])
+
+(defn w1
+  [rows]
+  [:section.panel {:aria-label "bench rows"}
+   [:h1.title "Rows"]
+   [:ul.rows {:role "list"}
+    (for [i (range rows)]
+      ^{:key i} [w1-row i])]])
+
+;; ---------------------------------------------------------------------------
+;; W2 — the boundary storm
+;; ---------------------------------------------------------------------------
+
+(defn w2-leaf
+  "A leaf that reads nothing. Reagent still wraps it — it has no way to
+  know, and no pass in which it could find out."
+  []
+  [:span.leaf "leaf"])
+
+(defn w2
+  [n]
+  [:div.storm
+   (for [i (range n)]
+     ^{:key i} [w2-leaf])])
+
+;; ---------------------------------------------------------------------------
+;; W3 — the ordinary form
+;; ---------------------------------------------------------------------------
+
+(defn w3-field
+  [i value error]
+  [:div.field
+   [:label.lbl {:for (str "f" i)} (str "Field " i)]
+   [:input.inp {:id        (str "f" i)
+                :name      (str "f" i)
+                :type      "text"
+                :value     value
+                :read-only true}]
+   [:p.err error]])
+
+(defn w3
+  [fields]
+  [:form.w3form
+   [:fieldset.fields
+    (for [i (range fields)]
+      ^{:key i} [w3-field i
+                          (str "value " i)
+                          (if (even? i) "" (str "field " i " is required"))])]
+   [:button.submit {:type "submit" :disabled true} "Submit"]])
+
+;; ---------------------------------------------------------------------------
+;; U — the update witness, on Reagent's own reactivity
+;; ---------------------------------------------------------------------------
+
+;; The local model. A `reagent.core/atom` is Reagent's own reactive
+;; primitive and the thing its design is actually about, so this is what
+;; the update rows drive. `defonce` takes no docstring, hence the comment.
+(defonce cells (r/atom []))
+
+(defn u-cell
+  "A FORM-2 component: the outer call mints a `cursor` once, per mounted
+  occurrence, and the returned render fn dereferences only that cursor.
+  This is the idiomatic Reagent spelling of a fine-grained reactive leaf
+  — the reason a single-cell write re-renders one component rather than
+  three hundred — and the counterpart of the Freehand arm's per-cell
+  `v/sub`."
+  [i]
+  (let [c (r/cursor cells [i])]
+    (fn [i]
+      [:span.cell {:data-i i} (str @c)])))
+
+(defn u-grid
+  [n]
+  [:div.ugrid
+   (for [i (range n)]
+     ^{:key i} [u-cell i])])

--- a/implementation/freehand/test/re_frame/freehand/bench/b6_rows.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b6_rows.cljs
@@ -1,0 +1,416 @@
+(ns re-frame.freehand.bench.b6-rows
+  "B6's rows, as data and functions — the arms, the witness table, and the
+  two measurements, with every `cljs.test` assertion left to the caller.
+
+  This split exists for one reason and it is a methodological one. B6's
+  numbers must be taken from an `:advanced` bundle with `goog.DEBUG
+  false` — the artefact a consumer ships — because the Spec 009
+  instrumentation seam, schema validation and trace emission are all
+  `goog.DEBUG`-gated and all of them sit on the update path. Reagent has
+  no counterpart, so a development build systematically penalises
+  Freehand and would publish a number no user ever experiences. But
+  `:advanced` cannot compile shadow's `:browser-test` target
+  (`cljs-test-display`'s `goog.define`s collide), so the production
+  reading has to come from a plain `:browser` entry point instead.
+
+  So the rows live here, callable from both: from
+  [[re-frame.freehand.bench.b6-mount-dom-cljs-test]] and
+  [[re-frame.freehand.bench.b6-update-dom-cljs-test]], which gate the
+  DETERMINISTIC half in the ordinary browser suite, and from
+  [[re-frame.freehand.bench.b6-prod-app]], which takes the numbers under
+  the compilation a user actually ships.
+
+  Normative owner: `docs/design/freehand/decisions/`
+  `D021-performance-budgets-and-release-evidence.md`."
+  (:require ["react-dom" :as react-dom]
+            ["react-dom/client" :as react-dom-client]
+            [reagent.core :as r]
+            [reagent.dom.client :as rdc]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.bench.b6-floor :as floor]
+            [re-frame.freehand.bench.b6-harness :as h]
+            [re-frame.freehand.bench.b6-reagent :as rg]
+            [re-frame.freehand.bench.b6-uix :as ux]
+            [re-frame.freehand.bench.b6-witnesses :as fh]
+            [re-frame.freehand.bench.b6-witnesses-compiled :as fhc]
+            [re-frame.freehand.bench.measure :as m]
+            [re-frame.freehand.bench.provenance :as prov]
+            [uix.core :refer [$]]
+            [uix.dom :as uix-dom]))
+
+;; ---------------------------------------------------------------------------
+;; re-frame registrations for the update row
+;; ---------------------------------------------------------------------------
+
+(def cells-n 300)
+
+(rf/reg-sub :b6/cell (fn [db [_ i]] (get-in db [:cells i])))
+(rf/reg-event :b6/seed (fn [_ [_ n]] {:db {:cells (vec (repeat n 0))}}))
+
+;; ===========================================================================
+;; MOUNT
+;; ===========================================================================
+
+(def w1-rows 300)
+(def w1-small-rows 6)
+(def w2-n 300)
+(def w3-fields 12)
+
+(defn w1-elements
+  "Three for the skeleton — the section, the heading and the list — then
+  four per row: the row, its image, its label and its number. Arithmetic,
+  so the gate is against a written expectation rather than against
+  whatever the mount happened to produce."
+  [rows]
+  (+ 3 (* 4 rows)))
+
+(defn w2-elements [n] (+ 1 n))
+
+(defn w3-elements
+  "Three for the skeleton — the form, the fieldset and the submit button —
+  then four per field: the wrapper, the label, the input and the error
+  line."
+  [fields]
+  (+ 3 (* 4 fields)))
+
+(defn- react-root-arm
+  "An arm over a bare `react-dom/client` root — the floor and the UIx arm
+  both mount this way, because neither has a mount door of its own."
+  [id element-of]
+  {:id      id
+   :mount   (fn [container props _n]
+              (let [r (react-dom-client/createRoot container)]
+                (.render r (element-of props))
+                r))
+   :unmount (fn [r] (.unmount r))})
+
+(defn- freehand-mount-arm [id view]
+  {:id      id
+   :mount   (fn [container props n]
+              (v/mount [view props] container
+                       {:disambiguator (keyword "b6" (str (name id) "-" n))}))
+   :unmount (fn [mounted] (v/unmount! mounted))})
+
+(defn- reagent-mount-arm
+  "Reagent's own mount door — `reagent.dom.client/create-root` and
+  `render`, which is what a Reagent application calls."
+  [id form-of]
+  {:id      id
+   :mount   (fn [container props _n]
+              (let [r (rdc/create-root container)]
+                (rdc/render r (form-of props))
+                r))
+   :unmount (fn [r] (rdc/unmount r))})
+
+(defn- uix-mount-arm [id element-of]
+  {:id      id
+   :mount   (fn [container props _n]
+              (let [r (uix-dom/create-root container)]
+                (uix-dom/render-root (element-of props) r)
+                r))
+   :unmount (fn [r] (uix-dom/unmount-root r))})
+
+(def mount-witnesses
+  "The three mount witnesses, each with its arms, its fixture and its
+  written element arithmetic. A table, because the method is one method
+  and three near-copies of a driver would be three places for it to
+  drift."
+  [{:id             :W1
+    :doc            "a large template — 300 rows under one boundary each, rich attributes"
+    :headline?      true
+    :props          {:rows w1-rows}
+    :small          {:rows w1-small-rows}
+    :elements       (w1-elements w1-rows)
+    :small-elements (w1-elements w1-small-rows)
+    :arms [(react-root-arm    :floor (fn [{:keys [rows]}] (floor/w1 rows)))
+           (freehand-mount-arm :freehand-interpreted fh/w1)
+           (freehand-mount-arm :freehand-compiled    fhc/w1)
+           (reagent-mount-arm  :reagent (fn [{:keys [rows]}] [rg/w1 rows]))
+           (uix-mount-arm      :uix     (fn [{:keys [rows]}] ($ ux/w1 {:rows rows})))]}
+
+   {:id             :W2
+    :doc            "300 sub-free leaf boundaries — the ELISION-MAXIMISING shape"
+    :headline?      false
+    :warning        (str "Freehand's compiled tier proves these bodies sub-free and drops 300 "
+                         "ViewCells. Reagent and UIx have no elision concept and cannot. This "
+                         "row therefore OVERSTATES Freehand's advantage and must not be quoted "
+                         "as the headline.")
+    :props          {:n w2-n}
+    :small          {:n 6}
+    :elements       (w2-elements w2-n)
+    :small-elements (w2-elements 6)
+    :arms [(react-root-arm    :floor (fn [{:keys [n]}] (floor/w2 n)))
+           (freehand-mount-arm :freehand-interpreted fh/w2)
+           (freehand-mount-arm :freehand-compiled    fhc/w2)
+           (reagent-mount-arm  :reagent (fn [{:keys [n]}] [rg/w2 n]))
+           (uix-mount-arm      :uix     (fn [{:keys [n]}] ($ ux/w2 {:n n})))]}
+
+   {:id             :W3
+    :doc            (str "an ordinary 12-field form with controlled inputs — the shape most "
+                         "applications are made of")
+    :headline?      true
+    :props          {:fields w3-fields}
+    :small          {:fields 3}
+    :elements       (w3-elements w3-fields)
+    :small-elements (w3-elements 3)
+    :arms [(react-root-arm    :floor (fn [{:keys [fields]}] (floor/w3 fields)))
+           (freehand-mount-arm :freehand-interpreted fh/w3)
+           (freehand-mount-arm :freehand-compiled    fhc/w3)
+           (reagent-mount-arm  :reagent (fn [{:keys [fields]}] [rg/w3 fields]))
+           (uix-mount-arm      :uix     (fn [{:keys [fields]}] ($ ux/w3 {:fields fields})))]}])
+
+(defn mount-parity
+  "Mount every arm of `witness` at `props` at once and answer the parity
+  result. LEAVES THE MOUNTS STANDING — the caller releases them, so it
+  can read the pages before they go."
+  [witness props]
+  (h/parity (:arms witness) props))
+
+(defn measure-mount!
+  "Measure one witness and publish its record. Answers
+  `{:id … :summary … :per-round …}`."
+  [{:keys [id doc props arms headline? warning elements]} rounds sampling]
+  (let [raw     (mapv (fn [_] (h/round! arms props sampling)) (range rounds))
+        norm    (mapv #(h/normalise % :floor) raw)
+        summary (h/across-rounds (mapv :ratio norm))
+        record
+        {:benchmark      (keyword "B6" (str "mount-" (name id)))
+         :doc            doc
+         :headline?      headline?
+         :warning        warning
+         :revision       (prov/detect-revision)
+         :build          (prov/detect-build)
+         :host           (prov/detect-host)
+         :fixture        {:witness         id
+                          :props           props
+                          :elements        elements
+                          :arms            (mapv :id arms)
+                          :reagent-version "2.0.1"
+                          :uix-version     "1.4.4"
+                          :measurement-method
+                          (str "wall time across react-dom/flushSync around each arm's own "
+                               "mount door, into a fresh container attached before the window; "
+                               "arms interleaved at the SAMPLE level with the order rotating on "
+                               "the sample index; " rounds " rounds of " (:warmup sampling)
+                               " warmup + " (:samples sampling) " samples per arm per round; "
+                               "every figure a ratio to the FLOOR measured in that same round, "
+                               "because this workstation drifts further across rounds than "
+                               "several of the effects being measured")}
+         :sampling       sampling
+         :baseline       {:kind      :cross-substrate
+                          :reference {:arm  :floor
+                                      :note (str "the same DOM built by hand with "
+                                                 "react/createElement and no substrate at all")}}
+         :per-round      {:p50 (mapv :p50 norm) :ratio (mapv :ratio norm)}
+         :ratio-to-floor summary
+         :status         :evidence}]
+    (h/publish! (str "mount / " (name id)) record)
+    {:id id :summary summary :norm norm :record record}))
+
+;; ===========================================================================
+;; UPDATE
+;; ===========================================================================
+
+(defonce ^:private gen-seq (atom 1000))
+(defn next-gen! [] (swap! gen-seq inc))
+
+(defn- floor-update-arm
+  "The floor's `force!` renders INSIDE the `flushSync`, and that is not a
+  convenience. `root.render` called outside a React event schedules at
+  React's default lane, and an EMPTY `flushSync` flushes only the sync
+  lane — so a floor arm that rendered in `write!` and flushed in `force!`
+  would have its commit land outside the measured window entirely. The
+  DOM verification caught exactly that: 80 of 320 floor samples ended
+  with the cell still holding its old value. Freehand and Reagent are
+  unaffected, because a `useSyncExternalStore` notification and a
+  `reagent.core/flush` both put their work on the sync lane."
+  []
+  (let [state (atom (vec (repeat cells-n 0)))
+        rt    (volatile! nil)]
+    {:id      :floor
+     :mount   (fn [container]
+                (let [r (react-dom-client/createRoot container)]
+                  (vreset! rt r)
+                  (react-dom/flushSync (fn [] (.render r (floor/u-grid @state))))
+                  r))
+     :write!  (fn [i val]
+                (if (= i :all)
+                  (reset! state (vec (repeat cells-n val)))
+                  (swap! state assoc i val)))
+     :force!  (fn [] (react-dom/flushSync
+                       (fn [] (.render ^js @rt (floor/u-grid @state)))))
+     :unmount (fn [r] (react-dom/flushSync (fn [] (.unmount r))))}))
+
+(defn- freehand-update-arm [id view]
+  (let [fid (keyword "b6-update" (name id))]
+    {:id      id
+     :mount   (fn [container]
+                (react-dom/flushSync
+                  (fn [] (v/mount [view {:n cells-n}] container
+                                  {:frame         {:id fid :initial-events [[:b6/seed cells-n]]}
+                                   :disambiguator (keyword "b6u" (name id))}))))
+     :write!  (fn [i val]
+                (if (= i :all)
+                  (frame/replace-app-db! fid {:cells (vec (repeat cells-n val))})
+                  (frame/replace-app-db!
+                    fid (update (frame/frame-app-db-value fid) :cells assoc i val))))
+     ;; Freehand's notification has already been queued by the write; the
+     ;; empty flushSync is what makes React commit it in this window rather
+     ;; than on its own scheduler a couple of milliseconds later.
+     :force!  (fn [] (react-dom/flushSync (fn [] nil)))
+     :unmount (fn [mounted] (react-dom/flushSync (fn [] (v/unmount! mounted))))}))
+
+(defn- reagent-update-arm []
+  {:id      :reagent
+   :mount   (fn [container]
+              (reset! rg/cells (vec (repeat cells-n 0)))
+              (let [rt (rdc/create-root container)]
+                (react-dom/flushSync (fn [] (rdc/render rt [rg/u-grid cells-n])))
+                rt))
+   :write!  (fn [i val]
+              (if (= i :all)
+                (reset! rg/cells (vec (repeat cells-n val)))
+                (swap! rg/cells assoc i val)))
+   ;; `reagent.core/flush` is Reagent's own documented synchronous render
+   ;; drain — the counterpart of the empty `flushSync` the other arms use.
+   :force!  (fn [] (react-dom/flushSync (fn [] (r/flush))))
+   :unmount (fn [rt] (react-dom/flushSync (fn [] (rdc/unmount rt))))})
+
+(defn make-update-arms []
+  [(floor-update-arm)
+   (freehand-update-arm :freehand-interpreted fh/u-grid)
+   (freehand-update-arm :freehand-compiled fhc/u-grid)
+   (reagent-update-arm)])
+
+(defn cell-text
+  [container i]
+  (some-> (.querySelector container (str "[data-i=\"" i "\"]")) (.-textContent)))
+
+(defn mount-update-arms!
+  [arms]
+  (mapv (fn [a]
+          (let [c (js/document.createElement "div")]
+            (.appendChild js/document.body c)
+            {:arm a :container c :handle ((:mount a) c)}))
+        arms))
+
+(defn release-update-arms!
+  [mounts]
+  (doseq [{:keys [arm handle container]} mounts]
+    (try ((:unmount arm) handle) (catch :default _ nil))
+    (.remove container)))
+
+(defn timed-write!
+  "Write, yield ONE microtask, force the arm's own synchronous drain, stop
+  the clock — then VERIFY at the DOM that the cell holds what was written.
+  Answers a promise of `{:ms … :ok? …}`."
+  [{:keys [arm container]} i val]
+  (let [t0 (m/now-ms)]
+    ((:write! arm) i val)
+    (-> (js/Promise.resolve nil)
+        (.then (fn [_]
+                 ((:force! arm))
+                 (let [ms    (- (m/now-ms) t0)
+                       probe (if (= i :all) 0 i)]
+                   {:ms   ms
+                    :ok?  (= (str val) (cell-text container probe))
+                    :ok2? (or (not= i :all)
+                              (= (str val) (cell-text container (dec cells-n))))}))))))
+
+(defn chain
+  "Fold `xs` into a serial promise chain, threading an accumulator."
+  [init xs f]
+  (reduce (fn [p x] (.then p (fn [acc] (f acc x)))) (js/Promise.resolve init) xs))
+
+(defn- update-round!
+  [mounts kind sampling]
+  (let [k     (count mounts)
+        total (+ (:warmup sampling) (:samples sampling))]
+    (chain {:readings (zipmap (map #(:id (:arm %)) mounts) (repeat []))
+            :bad      0}
+           (for [s (range total) j (range k)] [s j])
+           (fn [acc [s j]]
+             (let [mnt (nth mounts (mod (+ j s) k))
+                   val (next-gen!)
+                   i   (if (= kind :broad) :all (mod val cells-n))]
+               (-> (timed-write! mnt i val)
+                   (.then (fn [{:keys [ms ok? ok2?]}]
+                            (cond-> acc
+                              (not (and ok? ok2?)) (update :bad inc)
+                              (>= s (:warmup sampling))
+                              (update-in [:readings (:id (:arm mnt))] conj ms))))))))))
+
+(defn seed-update-arms! [mounts]
+  (chain nil mounts (fn [_ mnt] (-> (timed-write! mnt :all 0) (.then (fn [_] nil))))))
+
+(defn canon-of [mounts] (mapv (fn [m] (h/canonical (:container m))) mounts))
+
+(defn write-and-compare!
+  "Write the same broad value into every arm and answer
+  `{:ids … :before [..] :after [..]}` — the caller decides what to assert."
+  [mounts]
+  (let [before (canon-of mounts)
+        val    (next-gen!)]
+    (-> (chain nil mounts (fn [_ mnt] (-> (timed-write! mnt :all val) (.then (fn [_] nil)))))
+        (.then (fn [_] {:ids    (mapv #(:id (:arm %)) mounts)
+                        :before before
+                        :after  (canon-of mounts)})))))
+
+(defn measure-update!
+  "Run the `kind` update row over already-mounted `mounts`. Answers a
+  promise of `{:summary … :norm … :bad … :record …}` and publishes the
+  record."
+  [mounts kind doc rounds sampling]
+  (-> (chain [] (range rounds)
+             (fn [acc _]
+               (-> (seed-update-arms! mounts)
+                   (.then (fn [_] (update-round! mounts kind sampling)))
+                   (.then (fn [rd] (conj acc rd))))))
+      (.then (fn [rds]
+               (let [bad  (reduce + (map :bad rds))
+                     norm (mapv #(h/normalise (:readings %) :floor) rds)
+                     summ (h/across-rounds (mapv :ratio norm))
+                     record
+                     {:benchmark      (keyword "B6" (str "update-" (name kind)))
+                      :doc            doc
+                      :revision       (prov/detect-revision)
+                      :build          (prov/detect-build)
+                      :host           (prov/detect-host)
+                      :fixture        {:cells             cells-n
+                                       :kind              kind
+                                       :arms              (mapv #(:id (:arm %)) mounts)
+                                       :adapter           :rf.adapter/uix
+                                       :reagent-version   "2.0.1"
+                                       :unverified-writes bad
+                                       :measurement-method
+                                       (str "per write: t0; the arm's own state install; ONE "
+                                            "microtask yield; the arm's own synchronous drain "
+                                            "(empty react-dom/flushSync for the floor and both "
+                                            "Freehand arms, reagent.core/flush inside one for "
+                                            "Reagent); t1 — then the written cell is read back "
+                                            "out of the DOM and the sample is rejected if it "
+                                            "does not hold the written value. The microtask is "
+                                            "STRUCTURAL: a mounted Freehand v/sub does not "
+                                            "repaint inside flushSync, its notification rides a "
+                                            "microtask, and a first pass that timed inside "
+                                            "flushSync measured Freehand writes that never "
+                                            "reached the DOM at all. Arms interleaved at the "
+                                            "sample level, order rotating on the sample index; "
+                                            rounds " rounds of " (:warmup sampling)
+                                            " warmup + " (:samples sampling) " samples; every "
+                                            "figure a ratio to the floor measured in that same "
+                                            "round. The UPDATE floor is a plain top-down React "
+                                            "re-render and is NOT a lower bound")}
+                      :sampling       sampling
+                      :baseline       {:kind      :cross-substrate
+                                       :reference {:arm  :floor
+                                                   :note "plain top-down React re-render, no substrate"}}
+                      :per-round      {:p50 (mapv :p50 norm) :ratio (mapv :ratio norm)}
+                      :ratio-to-floor summ
+                      :status         :evidence}]
+                 (h/publish! (str "update / " (name kind)) record)
+                 {:summary summ :norm norm :bad bad :rounds rounds
+                  :samples-per-round (* (count mounts) (+ (:warmup sampling) (:samples sampling)))
+                  :record record})))))

--- a/implementation/freehand/test/re_frame/freehand/bench/b6_rows.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b6_rows.cljs
@@ -305,42 +305,126 @@
 (defn timed-write!
   "Write, yield ONE microtask, force the arm's own synchronous drain, stop
   the clock — then VERIFY at the DOM that the cell holds what was written.
-  Answers a promise of `{:ms … :ok? …}`."
+  Answers a promise of `{:ms … :write-ms … :force-ms … :ok? …}`.
+
+  The window is SPLIT because the split answers the comparison's biggest
+  fairness question. This row pits Freehand reading re-frame `app-db`
+  against Reagent reading a bare `reagent.core/atom`, which is each
+  substrate's own idiom but is NOT the same amount of framework: a
+  Reagent application that used re-frame subscriptions would pay a
+  re-frame write and a re-frame signal graph too. `:write-ms` is exactly
+  that leg — `frame/replace-app-db!` and the subscription recompute it
+  triggers, before React is involved — so a reader can see how much of
+  the gap a re-frame-shaped Reagent app would also have paid, instead of
+  being asked to take a sentence for it."
   [{:keys [arm container]} i val]
   (let [t0 (m/now-ms)]
     ((:write! arm) i val)
-    (-> (js/Promise.resolve nil)
-        (.then (fn [_]
-                 ((:force! arm))
-                 (let [ms    (- (m/now-ms) t0)
-                       probe (if (= i :all) 0 i)]
-                   {:ms   ms
-                    :ok?  (= (str val) (cell-text container probe))
-                    :ok2? (or (not= i :all)
-                              (= (str val) (cell-text container (dec cells-n))))}))))))
+    (let [t1 (m/now-ms)]
+      (-> (js/Promise.resolve nil)
+          (.then (fn [_]
+                   (let [t2 (m/now-ms)]
+                     ((:force! arm))
+                     (let [t3    (m/now-ms)
+                           probe (if (= i :all) 0 i)]
+                       ;; `:ms` is the WHOLE window, microtask boundary
+                       ;; included — the elapsed time to get this write onto
+                       ;; the page, which is the figure the ratios use. The
+                       ;; three legs are published beside it so the boundary
+                       ;; is visible rather than assumed empty: whatever
+                       ;; Freehand's notification does, it does it there.
+                       {:ms       (- t3 t0)
+                        :write-ms (- t1 t0)
+                        :gap-ms   (- t2 t1)
+                        :force-ms (- t3 t2)
+                        :ok?      (= (str val) (cell-text container probe))
+                        :ok2?     (or (not= i :all)
+                                      (= (str val) (cell-text container (dec cells-n))))}))))))))
 
 (defn chain
   "Fold `xs` into a serial promise chain, threading an accumulator."
   [init xs f]
   (reduce (fn [p x] (.then p (fn [acc] (f acc x)))) (js/Promise.resolve init) xs))
 
+(def writes-per-sample
+  "How many writes one SAMPLE of each row contains.
+
+  Chrome clamps `performance.now()` to 100 µs. A broad write costs every
+  arm well above that, so one write is a sample. A NARROW write does not:
+  measured one at a time, Reagent and the floor both returned exactly
+  0.1 ms — the quantum itself — which is the predecessor report's null
+  result wearing a different hat. Twenty writes to a sample lifts every
+  arm clear of the clamp, and the per-write figure is the sample divided
+  by twenty."
+  {:broad 1 :narrow 20})
+
+(defn- n-writes!
+  "`n` writes on one arm, timed as one sample. Every write carries a fresh
+  value and every one is verified at the DOM."
+  [mnt kind n]
+  (chain {:ms 0 :write-ms 0 :gap-ms 0 :force-ms 0 :bad 0} (range n)
+         (fn [acc _]
+           (let [val (next-gen!)
+                 i   (if (= kind :broad) :all (mod val cells-n))]
+             (-> (timed-write! mnt i val)
+                 (.then (fn [{:keys [ms write-ms gap-ms force-ms ok? ok2?]}]
+                          (cond-> (-> acc
+                                      (update :ms + ms)
+                                      (update :write-ms + write-ms)
+                                      (update :gap-ms + gap-ms)
+                                      (update :force-ms + force-ms))
+                            (not (and ok? ok2?)) (update :bad inc)))))))))
+
 (defn- update-round!
   [mounts kind sampling]
   (let [k     (count mounts)
-        total (+ (:warmup sampling) (:samples sampling))]
+        total (+ (:warmup sampling) (:samples sampling))
+        n     (get writes-per-sample kind)]
     (chain {:readings (zipmap (map #(:id (:arm %)) mounts) (repeat []))
+            :legs     (zipmap (map #(:id (:arm %)) mounts) (repeat []))
             :bad      0}
            (for [s (range total) j (range k)] [s j])
            (fn [acc [s j]]
              (let [mnt (nth mounts (mod (+ j s) k))
-                   val (next-gen!)
-                   i   (if (= kind :broad) :all (mod val cells-n))]
-               (-> (timed-write! mnt i val)
-                   (.then (fn [{:keys [ms ok? ok2?]}]
-                            (cond-> acc
-                              (not (and ok? ok2?)) (update :bad inc)
+                   id  (:id (:arm mnt))]
+               (-> (n-writes! mnt kind n)
+                   (.then (fn [{:keys [ms write-ms gap-ms force-ms bad]}]
+                            (cond-> (update acc :bad + bad)
                               (>= s (:warmup sampling))
-                              (update-in [:readings (:id (:arm mnt))] conj ms))))))))))
+                              (-> (update-in [:readings id] conj ms)
+                                  (update-in [:legs id] conj
+                                             {:write write-ms
+                                              :gap   gap-ms
+                                              :force force-ms})))))))))))
+
+(defn- leg-summary
+  "Per-arm p50 of each leg of the window, in milliseconds per SAMPLE."
+  [legs]
+  (into {}
+        (map (fn [[id xs]]
+               [id (when (seq xs)
+                     {:write-ms (:p50 (m/summarise (map :write xs)))
+                      :gap-ms   (:p50 (m/summarise (map :gap xs)))
+                      :force-ms (:p50 (m/summarise (map :force xs)))})]))
+        legs))
+
+;; THE MICROTASK YIELD IS PRICED IN SITU, BY THE ARMS THAT DO NOT NEED IT.
+;;
+;; Every measured write pays one microtask yield, because the slowest arm
+;; requires one, so a reader is owed the size of that constant. The
+;; measurement is `:gap-ms` in the `:legs` decomposition, and the control
+;; is that the floor and Reagent arms — which commit without it — report
+;; `:gap-ms 0.0` in every round of both rows. The yield costs nothing;
+;; what shows up in the Freehand arms' gap is Freehand's own notification
+;; callback running there, and it scales with the write exactly as it
+;; should (≈0.35 ms when a broad write moves 300 subscriptions, ≈0.01 ms
+;; when a narrow one moves one).
+;;
+;; A first attempt priced it instead by chaining 2,000 bare
+;; `js/Promise.resolve`s and dividing, which reported ≈1 ms a hop — larger
+;; than an entire measured Reagent write, and therefore impossible. That
+;; control was measuring the construction of a 2,000-deep promise chain,
+;; not a microtask. It was removed rather than published with a caveat.
 
 (defn seed-update-arms! [mounts]
   (chain nil mounts (fn [_ mnt] (-> (timed-write! mnt :all 0) (.then (fn [_] nil))))))
@@ -384,8 +468,14 @@
                                        :adapter           :rf.adapter/uix
                                        :reagent-version   "2.0.1"
                                        :unverified-writes bad
+                                       :writes-per-sample (get writes-per-sample kind)
                                        :measurement-method
-                                       (str "per write: t0; the arm's own state install; ONE "
+                                       (str "a SAMPLE is " (get writes-per-sample kind)
+                                            " write(s); Chrome clamps performance.now() to "
+                                            "100 us and a single narrow write sits on that "
+                                            "clamp for the floor and Reagent alike, so the "
+                                            "narrow row batches to lift every arm clear of it. "
+                                            "Per write: t0; the arm's own state install; ONE "
                                             "microtask yield; the arm's own synchronous drain "
                                             "(empty react-dom/flushSync for the floor and both "
                                             "Freehand arms, reagent.core/flush inside one for "
@@ -408,6 +498,7 @@
                                        :reference {:arm  :floor
                                                    :note "plain top-down React re-render, no substrate"}}
                       :per-round      {:p50 (mapv :p50 norm) :ratio (mapv :ratio norm)}
+                      :legs           (mapv #(leg-summary (:legs %)) rds)
                       :ratio-to-floor summ
                       :status         :evidence}]
                  (h/publish! (str "update / " (name kind)) record)

--- a/implementation/freehand/test/re_frame/freehand/bench/b6_uix.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b6_uix.cljs
@@ -1,0 +1,84 @@
+(ns re-frame.freehand.bench.b6-uix
+  "B6's mount witnesses, declared in UIX — the third substrate, and the
+  one whose position the comparison predicts rather than discovers.
+
+  The hypothesis under test is structural: UIx's `$` is a MACRO that
+  expands to `react/createElement` at compile time, which puts it in the
+  same position as Freehand's compiled tier — the markup is resolved
+  before the browser sees it, so there is no runtime walk to pay for. If
+  that is right, the UIx arm should sit near the floor on every mount
+  witness.
+
+  It should NOT inherit the compiled tier's boundary-storm win, because
+  UIx has no elision concept: a `defui` is a React function component and
+  stays one. W2's contrast between compiled Freehand and UIx is therefore
+  the cleanest reading in the report of what elision is worth as
+  distinct from what compilation is worth.
+
+  The `$` spelling is the whole point of including this arm. The UIx
+  adapter also exposes `set-hiccup-emitter!`, and an arm written through
+  that would be measuring a hiccup interpreter again — the opposite of
+  the hypothesis.
+
+  MOUNT ONLY. UIx's update story is `use-state` and React's own
+  scheduler, which is a different mechanism from a reactive substrate's
+  and would need its own row to be measured honestly; the report says so
+  rather than quietly extrapolating.
+
+  Normative owner: `docs/design/freehand/decisions/`
+  `D021-performance-budgets-and-release-evidence.md`."
+  (:require [uix.core :refer [$ defui]]))
+
+;; ---------------------------------------------------------------------------
+;; W1 — the large template
+;; ---------------------------------------------------------------------------
+
+(defui w1-row [{:keys [i]}]
+  ($ :li.row.cell.wide {:style      {:padding-left "4px" :color "rebeccapurple"}
+                        :data-index i}
+     ($ :img.avatar {:src "/avatar.png" :alt ""})
+     ($ :span.label "row ")
+     ($ :em.n (str i))))
+
+(defui w1 [{:keys [rows]}]
+  ($ :section.panel {:aria-label "bench rows"}
+     ($ :h1.title "Rows")
+     ($ :ul.rows {:role "list"}
+        (for [i (range rows)]
+          ($ w1-row {:key i :i i})))))
+
+;; ---------------------------------------------------------------------------
+;; W2 — the boundary storm
+;; ---------------------------------------------------------------------------
+
+(defui w2-leaf [_]
+  ($ :span.leaf "leaf"))
+
+(defui w2 [{:keys [n]}]
+  ($ :div.storm
+     (for [i (range n)]
+       ($ w2-leaf {:key i}))))
+
+;; ---------------------------------------------------------------------------
+;; W3 — the ordinary form
+;; ---------------------------------------------------------------------------
+
+(defui w3-field [{:keys [i value error]}]
+  ($ :div.field
+     ($ :label.lbl {:for (str "f" i)} (str "Field " i))
+     ($ :input.inp {:id        (str "f" i)
+                    :name      (str "f" i)
+                    :type      "text"
+                    :value     value
+                    :read-only true})
+     ($ :p.err error)))
+
+(defui w3 [{:keys [fields]}]
+  ($ :form.w3form
+     ($ :fieldset.fields
+        (for [i (range fields)]
+          ($ w3-field {:key   i
+                       :i     i
+                       :value (str "value " i)
+                       :error (if (even? i) "" (str "field " i " is required"))})))
+     ($ :button.submit {:type "submit" :disabled true} "Submit")))

--- a/implementation/freehand/test/re_frame/freehand/bench/b6_update_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b6_update_dom_cljs_test.cljs
@@ -15,11 +15,12 @@
 
   A first pass timed each write inside `react-dom/flushSync`, exactly as
   the mount row does. **It measured nothing for two of the four arms**,
-  and the parity gate is what caught it: after every Freehand write the
-  DOM still read `0`. A mounted Freehand `v/sub` does not repaint inside
-  `flushSync` — its notification rides a MICROTASK, so the store is
-  written, the subscription is recomputed, and React is told about it
-  only after the current task's stack unwinds. Measured directly:
+  and the DOM verification is what caught it: after every Freehand write
+  the DOM still read `0`. A mounted Freehand `v/sub` does not repaint
+  inside `flushSync` — its notification rides a MICROTASK, so React
+  learns about it only after the current task's stack unwinds. Measured
+  directly, and pinned by [[a-freehand-write-does-not-commit-inside-flushsync]]
+  below:
 
   | how the write was driven | did the DOM change? |
   |---|---|
@@ -28,12 +29,20 @@
   | `write` then `setTimeout 0` | yes, ~2 ms |
   | `write` then `requestAnimationFrame` | yes, ~32 ms (two frames) |
 
-  So every arm is timed through ONE shape, and it is the shape the slowest
-  arm requires: **write, yield one microtask, force the substrate's own
-  synchronous drain, stop the clock.** Floor and Reagent do not need the
-  microtask and pay it anyway, which costs them a constant every arm
-  pays. Nothing here is measured inside an `act` environment — `act`
-  diverts work to its own queue and, measured, cost 600 ms a call.
+  So every arm is timed through ONE shape, and it is the shape the
+  slowest arm requires: **write, yield one microtask, force the
+  substrate's own synchronous drain, stop the clock.** Floor and Reagent
+  do not need the microtask and pay it anyway. Nothing is measured inside
+  an `act` environment — `act` diverts work to its own queue and,
+  measured, cost 600 ms a call.
+
+  A second instrument fault the same verification caught: an EMPTY
+  `flushSync` flushes only React's sync lane, so the floor arm's
+  `root.render` — scheduled at the default lane — has to be issued INSIDE
+  the flush. Until it was, 80 of 320 floor samples ended with the cell
+  still holding its old value, and every other arm's ratio was inflated
+  by the difference. Both faults are the same lesson: **verify at the DOM,
+  inside the window, or the fastest arm is the one that did nothing.**
 
   ## Two writes, because they ask different questions
 
@@ -45,156 +54,31 @@
       above the timer under this window, which is what replaces the
       predecessor report's null result.
 
-  ## The arms, and what each writes
+  ## The numbers this file takes are not the published ones
 
-  Every arm is driven by a DIRECT STATE INSTALL through its own public
-  write and its own documented synchronous drain, so no arm is charged
-  for an event queue another arm does not have:
-
-    - `floor` — no substrate. The whole root is re-rendered top down. On
-      a broad write that is the same work everyone does; on a narrow one
-      it is 300 re-renders to move one cell, which is what an
-      application with no reactive substrate really pays. **The update
-      floor is therefore NOT a lower bound**, and a fine-grained arm
-      beating it — a ratio under 1.0 — is the result, not a fault.
-    - `freehand-interpreted` / `freehand-compiled` — `v/sub` per cell,
-      driven by `frame/replace-app-db!` on that arm's OWN frame, so the
-      two Freehand arms never re-render into each other's window.
-    - `reagent` — `r/cursor` per cell over a `reagent.core/atom`, written
-      with `swap!` and drained with `reagent.core/flush`.
-
-  What is excluded, identically from every arm, is the event-dispatch
-  leg: a re-frame application adds one `dispatch-sync` on top of any of
-  these, and adds it to Reagent and Freehand alike.
-
-  ## Gates
-
-  Every measured write is verified AT THE DOM: the cell it wrote must
-  hold the value it wrote by the time the clock stops. A write that
-  silently did nothing would be the fastest arm in any benchmark, and
-  this row exists because the first version of it was exactly that.
-  Canonical-DOM equality across all four arms is checked before and
-  after the whole run on top.
+  Same reason as the mount row: this build has `goog.DEBUG true`, so the
+  Spec 009 instrumentation seam, schema validation and trace emission are
+  all live on exactly the path this row measures, and Reagent has no
+  counterpart to any of them. The published reading is taken by
+  [[re-frame.freehand.bench.b6-prod-app]] under `:advanced`.
 
   Normative owner: `docs/design/freehand/decisions/`
   `D021-performance-budgets-and-release-evidence.md`."
   (:require ["react-dom" :as react-dom]
-            ["react-dom/client" :as react-dom-client]
             [cljs.test :refer-macros [async deftest is testing use-fixtures]]
-            [reagent.core :as r]
-            [reagent.dom.client :as rdc]
             [re-frame.adapter.uix :as react-substrate]
-            [re-frame.core :as rf]
-            [re-frame.frame :as frame]
             [re-frame.freehand :as v]
-            [re-frame.freehand.bench.b6-floor :as floor]
             [re-frame.freehand.bench.b6-harness :as h]
             [re-frame.freehand.bench.b6-reagent :as rg]
+            [re-frame.freehand.bench.b6-rows :as rows]
             [re-frame.freehand.bench.b6-witnesses :as fh]
             [re-frame.freehand.bench.b6-witnesses-compiled :as fhc]
-            [re-frame.freehand.bench.measure :as m]
-            [re-frame.freehand.bench.provenance :as prov]
             [re-frame.freehand.react :as fr]
             [re-frame.freehand.root :as root]
             [re-frame.test-support :as test-support]))
 
-;; ---------------------------------------------------------------------------
-;; re-frame registrations — FIRST, so this ns's own fixture baseline carries
-;; them. `make-reset-runtime-fixture` pins the registrar as it stood when the
-;; fixture was BUILT; a registration made after that line is wiped before
-;; every test in this file.
-;; ---------------------------------------------------------------------------
-
-(rf/reg-sub :b6/cell (fn [db [_ i]] (get-in db [:cells i])))
-(rf/reg-event :b6/seed (fn [_ [_ n]] {:db {:cells (vec (repeat n 0))}}))
-
-;; ---------------------------------------------------------------------------
-;; Fixture parameters
-;; ---------------------------------------------------------------------------
-
-(def ^:private cells-n 300)
-(def ^:private rounds 5)
-(def ^:private sampling {:warmup 4 :samples 12})
-(def ^:private total-samples (+ (:warmup sampling) (:samples sampling)))
-
-(defonce ^:private gen-seq (atom 1000))
-(defn- next-gen! [] (swap! gen-seq inc))
-
-;; ---------------------------------------------------------------------------
-;; The arms
-;; ---------------------------------------------------------------------------
-
-(defn- floor-arm
-  "The floor's `force!` renders INSIDE the `flushSync`, and that is not a
-  convenience. `root.render` called outside a React event schedules at
-  React's default lane, and an EMPTY `flushSync` flushes only the sync
-  lane — so a floor arm that rendered in `write!` and flushed in `force!`
-  would have its commit land outside the measured window entirely. The
-  DOM verification caught exactly that: 80 of 320 floor samples ended
-  with the cell still holding its old value. Freehand and Reagent are
-  unaffected, because a `useSyncExternalStore` notification and a
-  `reagent.core/flush` both put their work on the sync lane."
-  []
-  (let [state (atom (vec (repeat cells-n 0)))
-        rt    (volatile! nil)]
-    {:id      :floor
-     :mount   (fn [container]
-                (let [r (react-dom-client/createRoot container)]
-                  (vreset! rt r)
-                  (react-dom/flushSync (fn [] (.render r (floor/u-grid @state))))
-                  r))
-     :write!  (fn [i val]
-                (if (= i :all)
-                  (reset! state (vec (repeat cells-n val)))
-                  (swap! state assoc i val)))
-     :force!  (fn [] (react-dom/flushSync
-                       (fn [] (.render ^js @rt (floor/u-grid @state)))))
-     :unmount (fn [r] (react-dom/flushSync (fn [] (.unmount r))))}))
-
-(defn- freehand-arm [id view]
-  (let [fid (keyword "b6-update" (name id))]
-    {:id      id
-     :mount   (fn [container]
-                (react-dom/flushSync
-                  (fn [] (v/mount [view {:n cells-n}] container
-                                  {:frame         {:id fid :initial-events [[:b6/seed cells-n]]}
-                                   :disambiguator (keyword "b6u" (name id))}))))
-     :write!  (fn [i val]
-                (if (= i :all)
-                  (frame/replace-app-db! fid {:cells (vec (repeat cells-n val))})
-                  (frame/replace-app-db!
-                    fid (update (frame/frame-app-db-value fid) :cells assoc i val))))
-     ;; Freehand's notification has already been queued by the write; the
-     ;; empty flushSync is what makes React commit it in this window rather
-     ;; than on its own scheduler two milliseconds later.
-     :force!  (fn [] (react-dom/flushSync (fn [] nil)))
-     :unmount (fn [mounted] (react-dom/flushSync (fn [] (v/unmount! mounted))))}))
-
-(defn- reagent-arm []
-  {:id      :reagent
-   :mount   (fn [container]
-              (reset! rg/cells (vec (repeat cells-n 0)))
-              (let [rt (rdc/create-root container)]
-                (react-dom/flushSync (fn [] (rdc/render rt [rg/u-grid cells-n])))
-                rt))
-   :write!  (fn [i val]
-              (if (= i :all)
-                (reset! rg/cells (vec (repeat cells-n val)))
-                (swap! rg/cells assoc i val)))
-   ;; `reagent.core/flush` is Reagent's own documented synchronous render
-   ;; drain — the counterpart of the empty `flushSync` the other arms use.
-   :force!  (fn [] (react-dom/flushSync (fn [] (r/flush))))
-   :unmount (fn [rt] (react-dom/flushSync (fn [] (rdc/unmount rt))))})
-
-(defn- make-arms []
-  [(floor-arm)
-   (freehand-arm :freehand-interpreted fh/u-grid)
-   (freehand-arm :freehand-compiled fhc/u-grid)
-   (reagent-arm)])
-
-;; ---------------------------------------------------------------------------
-;; Fixtures
-;; ---------------------------------------------------------------------------
+(def ^:private rounds 3)
+(def ^:private sampling {:warmup 3 :samples 8})
 
 (def ^:private runtime-fixture
   ;; The UIx adapter, because Freehand's `v/sub` needs a non-ratom
@@ -220,165 +104,39 @@
              (fr/reset-boundaries!))})
 
 ;; ---------------------------------------------------------------------------
-;; One timed write
+;; The row
 ;; ---------------------------------------------------------------------------
 
-(defn- cell-text
-  [container i]
-  (some-> (.querySelector container (str "[data-i=\"" i "\"]")) (.-textContent)))
-
-(defn- timed-write!
-  "Write, yield ONE microtask, force the arm's own synchronous drain, stop
-  the clock — then VERIFY at the DOM that the cell holds what was written.
-  Answers a promise of `{:ms … :ok? …}`."
-  [{:keys [arm container]} i val]
-  (let [t0 (m/now-ms)]
-    ((:write! arm) i val)
-    (-> (js/Promise.resolve nil)
-        (.then (fn [_]
-                 ((:force! arm))
-                 (let [ms    (- (m/now-ms) t0)
-                       probe (if (= i :all) 0 i)]
-                   {:ms  ms
-                    :ok? (= (str val) (cell-text container probe))
-                    :ok2? (or (not= i :all)
-                              (= (str val) (cell-text container (dec cells-n))))}))))))
-
-;; ---------------------------------------------------------------------------
-;; Rounds
-;; ---------------------------------------------------------------------------
-
-(defn- chain
-  "Fold `xs` into a serial promise chain, threading an accumulator."
-  [init xs f]
-  (reduce (fn [p x] (.then p (fn [acc] (f acc x)))) (js/Promise.resolve init) xs))
-
-(defn- round!
-  "One round, arms interleaved at the sample level with the order rotating
-  on the sample index."
-  [mounts kind]
-  (let [k (count mounts)]
-    (chain {:readings (zipmap (map #(:id (:arm %)) mounts) (repeat []))
-            :bad      0}
-           (for [s (range total-samples) j (range k)] [s j])
-           (fn [acc [s j]]
-             (let [mnt (nth mounts (mod (+ j s) k))
-                   val (next-gen!)
-                   i   (if (= kind :broad) :all (mod val cells-n))]
-               (-> (timed-write! mnt i val)
-                   (.then (fn [{:keys [ms ok? ok2?]}]
-                            (cond-> acc
-                              (not (and ok? ok2?)) (update :bad inc)
-                              (>= s (:warmup sampling))
-                              (update-in [:readings (:id (:arm mnt))] conj ms))))))))))
-
-(defn- seed-all! [mounts]
-  (chain nil mounts (fn [_ mnt] (-> (timed-write! mnt :all 0) (.then (fn [_] nil))))))
-
-(defn- canon-of [mounts] (mapv (fn [m] (h/canonical (:container m))) mounts))
-
-(defn- assert-agreement!
-  [mounts label]
-  (let [before (canon-of mounts)
-        val    (next-gen!)]
-    (-> (chain nil mounts (fn [_ mnt] (-> (timed-write! mnt :all val) (.then (fn [_] nil)))))
-        (.then (fn [_]
-                 (let [after (canon-of mounts)
-                       ids   (mapv #(:id (:arm %)) mounts)]
-                   (is (apply = after)
-                       (str label ": every arm's page agrees after the write, compared as
-                             canonical DOM"
-                            (when-not (apply = after)
-                              (str " — arms " (pr-str ids) " produced "
-                                   (count (distinct after)) " distinct pages"))))
-                   (doseq [[id b a] (map vector ids before after)]
-                     (is (not= b a)
-                         (str label " / " (name id)
-                              ": the write actually changed this arm's DOM")))
-                   nil))))))
-
-;; ---------------------------------------------------------------------------
-;; The rows
-;; ---------------------------------------------------------------------------
-
-(defn- mount-all! [arms]
-  (mapv (fn [a]
-          (let [c (js/document.createElement "div")]
-            (.appendChild js/document.body c)
-            {:arm a :container c :handle ((:mount a) c)}))
-        arms))
-
-(defn- release-all! [mounts]
-  (doseq [{:keys [arm handle container]} mounts]
-    (try ((:unmount arm) handle) (catch :default _ nil))
-    (.remove container)))
-
-(defn- measure! [kind doc done]
-  (let [arms   (make-arms)
-        mounts (mount-all! arms)]
-    (-> (assert-agreement! mounts (str (name kind) " (before)"))
-        (.then (fn [_]
-                 (chain [] (range rounds)
-                        (fn [acc _]
-                          (-> (seed-all! mounts)
-                              (.then (fn [_] (round! mounts kind)))
-                              (.then (fn [rd] (conj acc rd))))))))
-        (.then (fn [rds]
-                 (let [bad  (reduce + (map :bad rds))
-                       norm (mapv #(h/normalise (:readings %) :floor) rds)
-                       summ (h/across-rounds (mapv :ratio norm))]
-                   (is (zero? bad)
-                       (str (name kind) ": every measured write was verified AT THE DOM "
-                            "before the clock stopped — " bad " of "
-                            (* rounds total-samples (count arms))
-                            " did not land"))
-                   (h/publish!
-                     (str "update / " (name kind))
-                     {:benchmark    (keyword "B6" (str "update-" (name kind)))
-                      :doc          doc
-                      :revision     (prov/detect-revision)
-                      :build        (prov/detect-build)
-                      :host         (prov/detect-host)
-                      :fixture      {:cells         cells-n
-                                     :kind          kind
-                                     :arms          (mapv :id arms)
-                                     :adapter       :rf.adapter/uix
-                                     :reagent-version "2.0.1"
-                                     :unverified-writes bad
-                                     :measurement-method
-                                     (str "per write: t0; the arm's own state install; ONE "
-                                          "microtask yield; the arm's own synchronous drain "
-                                          "(empty react-dom/flushSync for the floor and both "
-                                          "Freehand arms, reagent.core/flush inside one for "
-                                          "Reagent); t1 — then the written cell is read back "
-                                          "out of the DOM and the sample is rejected if it "
-                                          "does not hold the written value. The microtask is "
-                                          "STRUCTURAL: a mounted Freehand v/sub does not "
-                                          "repaint inside flushSync, its notification rides a "
-                                          "microtask, and a first pass that timed inside "
-                                          "flushSync measured Freehand writes that never "
-                                          "reached the DOM at all. Arms interleaved at the "
-                                          "sample level, order rotating on the sample index; "
-                                          (str rounds) " rounds of " (:warmup sampling)
-                                          " warmup + " (:samples sampling) " samples; every "
-                                          "figure a ratio to the floor measured in that same "
-                                          "round. The UPDATE floor is a plain top-down React "
-                                          "re-render and is NOT a lower bound")}
-                      :sampling     sampling
-                      :baseline     {:kind      :cross-substrate
-                                     :reference {:arm  :floor
-                                                 :note "plain top-down React re-render, no substrate"}}
-                      :per-round    {:p50 (mapv :p50 norm) :ratio (mapv :ratio norm)}
-                      :ratio-to-floor summ
-                      :status       :evidence})
-                   (is (= rounds (count norm)) "every round produced a reading")
-                   (is (every? (fn [{:keys [p50]}] (pos? (:floor p50))) norm)
-                       "the floor arm took measurable time in every round")
-                   (is (every? #(pos? (:mean %)) (vals summ))
-                       "every arm produced a positive ratio")
-                   nil)))
+(defn- row! [kind doc done]
+  (let [mounts (rows/mount-update-arms! (rows/make-update-arms))]
+    (-> (rows/write-and-compare! mounts)
+        (.then (fn [{:keys [ids before after]}]
+                 (is (apply = after)
+                     (str (name kind)
+                          ": every arm's page agrees after one broad write, compared as
+                           canonical DOM"
+                          (when-not (apply = after)
+                            (str " — arms " (pr-str ids) " produced "
+                                 (count (distinct after)) " distinct pages"))))
+                 (doseq [[id b a] (map vector ids before after)]
+                   (is (not= b a)
+                       (str (name kind) " / " (name id)
+                            ": the write actually changed this arm's DOM")))
+                 (rows/measure-update! mounts kind doc rounds sampling)))
+        (.then (fn [{:keys [bad norm summary samples-per-round]}]
+                 (is (zero? bad)
+                     (str (name kind)
+                          ": every measured write was verified AT THE DOM before the clock
+                           stopped — " bad " of " (* rounds samples-per-round)
+                          " did not land"))
+                 (is (= rounds (count norm)) "every round produced a reading")
+                 (is (every? (fn [{:keys [p50]}] (pos? (:floor p50))) norm)
+                     "the floor arm took measurable time in every round")
+                 (is (every? #(pos? (:mean %)) (vals summary))
+                     "every arm produced a positive ratio")
+                 nil))
         (.catch (fn [e] (is false (str (name kind) " row rejected: " e))))
-        (.finally (fn [] (release-all! mounts) (done))))))
+        (.finally (fn [] (rows/release-update-arms! mounts) (done))))))
 
 (deftest broad-update-throughput
   (testing "One write that every one of 300 cells reads, so every cell
@@ -387,7 +145,7 @@
             sample is verified at the DOM before its clock stops."
     (if-not (h/browser?)
       (is true "a real browser is required — the browser job runs this row")
-      (async done (measure! :broad "one write that all 300 cells read" done)))))
+      (async done (row! :broad "one write that all 300 cells read" done)))))
 
 (deftest narrow-update-localisation
   (testing "One write that exactly ONE of 300 cells reads. This is where
@@ -398,7 +156,7 @@
             replaces the predecessor report's null result."
     (if-not (h/browser?)
       (is true "a real browser is required — the browser job runs this row")
-      (async done (measure! :narrow "one write exactly one of 300 cells reads" done)))))
+      (async done (row! :narrow "one write exactly one of 300 cells reads" done)))))
 
 ;; ===========================================================================
 ;; Non-vacuity
@@ -417,18 +175,19 @@
     (if-not (h/browser?)
       (is true "a real browser is required — the browser job runs this row")
       (async done
-        (let [arm       (freehand-arm :freehand-interpreted fh/u-grid)
+        (let [arm       (first (filter #(= :freehand-interpreted (:id %))
+                                       (rows/make-update-arms)))
               container (js/document.createElement "div")]
           (.appendChild js/document.body container)
           (let [mounted ((:mount arm) container)]
-            (is (= "0" (cell-text container 0)) "the grid mounted and the cell reads 0")
+            (is (= "0" (rows/cell-text container 0)) "the grid mounted and the cell reads 0")
             (react-dom/flushSync (fn [] ((:write! arm) 0 4242)))
-            (is (not= "4242" (cell-text container 0))
+            (is (not= "4242" (rows/cell-text container 0))
                 "a write inside flushSync has NOT reached the DOM when the flush returns")
             (-> (js/Promise.resolve nil)
                 (.then (fn [_]
                          ((:force! arm))
-                         (is (= "4242" (cell-text container 0))
+                         (is (= "4242" (rows/cell-text container 0))
                              "and one microtask plus a forced drain later, it has")
                          ((:unmount arm) mounted)
                          (.remove container)
@@ -441,8 +200,9 @@
 (deftest the-fixture-is-what-it-says-it-is
   (testing "Arithmetic over the fixture, so a reader can check the row's
             premises without re-running anything."
-    (is (= 300 cells-n) "300 cells, so a broad write really does move every one")
+    (is (= 300 rows/cells-n) "300 cells, so a broad write really does move every one")
     (is (= :interpreted (:lowering (v/describe fh/u-grid))) "one Freehand arm is interpreted")
     (is (= :compiled (:lowering (v/describe fhc/u-grid))) "and one is compiled")
     (is (fn? rg/u-grid) "the Reagent arm is an ordinary function returning Hiccup")
-    (is (not= (next-gen!) (next-gen!)) "no two writes ever install the same value")))
+    (is (not= (rows/next-gen!) (rows/next-gen!))
+        "no two writes ever install the same value")))

--- a/implementation/freehand/test/re_frame/freehand/bench/b6_update_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b6_update_dom_cljs_test.cljs
@@ -1,0 +1,448 @@
+(ns re-frame.freehand.bench.b6-update-dom-cljs-test
+  "B6's UPDATE row — the half of the Freehand/Reagent question that
+  actually matters, and the half the predecessor report returned a null
+  result on.
+
+  `docs/design/freehand/studio/compiled-tier-browser-worth-it.md`
+  measured a state change through to committed DOM at 0.2–0.5 ms p50 on
+  every arm of every witness: indistinguishable at the timer's
+  resolution, and therefore no answer at all. Reagent's whole design
+  point is fine-grained ratom reactivity on UPDATE, so a mount-only
+  comparison would flatter whichever substrate constructs elements
+  fastest while saying nothing about the thing Reagent exists for.
+
+  ## The window, and the fact that forced this shape
+
+  A first pass timed each write inside `react-dom/flushSync`, exactly as
+  the mount row does. **It measured nothing for two of the four arms**,
+  and the parity gate is what caught it: after every Freehand write the
+  DOM still read `0`. A mounted Freehand `v/sub` does not repaint inside
+  `flushSync` — its notification rides a MICROTASK, so the store is
+  written, the subscription is recomputed, and React is told about it
+  only after the current task's stack unwinds. Measured directly:
+
+  | how the write was driven | did the DOM change? |
+  |---|---|
+  | `flushSync(write)` | **no** |
+  | `write` then a microtask then `flushSync(noop)` | yes, ~1 ms |
+  | `write` then `setTimeout 0` | yes, ~2 ms |
+  | `write` then `requestAnimationFrame` | yes, ~32 ms (two frames) |
+
+  So every arm is timed through ONE shape, and it is the shape the slowest
+  arm requires: **write, yield one microtask, force the substrate's own
+  synchronous drain, stop the clock.** Floor and Reagent do not need the
+  microtask and pay it anyway, which costs them a constant every arm
+  pays. Nothing here is measured inside an `act` environment — `act`
+  diverts work to its own queue and, measured, cost 600 ms a call.
+
+  ## Two writes, because they ask different questions
+
+    - **BROAD** — one write every one of 300 cells reads. Every cell
+      re-renders. This prices re-render THROUGHPUT, where fine grain buys
+      nothing because all the work is genuinely required.
+    - **NARROW** — one write ONE cell reads. This prices LOCALISATION,
+      and it is where fine grain either shows up or does not. It is well
+      above the timer under this window, which is what replaces the
+      predecessor report's null result.
+
+  ## The arms, and what each writes
+
+  Every arm is driven by a DIRECT STATE INSTALL through its own public
+  write and its own documented synchronous drain, so no arm is charged
+  for an event queue another arm does not have:
+
+    - `floor` — no substrate. The whole root is re-rendered top down. On
+      a broad write that is the same work everyone does; on a narrow one
+      it is 300 re-renders to move one cell, which is what an
+      application with no reactive substrate really pays. **The update
+      floor is therefore NOT a lower bound**, and a fine-grained arm
+      beating it — a ratio under 1.0 — is the result, not a fault.
+    - `freehand-interpreted` / `freehand-compiled` — `v/sub` per cell,
+      driven by `frame/replace-app-db!` on that arm's OWN frame, so the
+      two Freehand arms never re-render into each other's window.
+    - `reagent` — `r/cursor` per cell over a `reagent.core/atom`, written
+      with `swap!` and drained with `reagent.core/flush`.
+
+  What is excluded, identically from every arm, is the event-dispatch
+  leg: a re-frame application adds one `dispatch-sync` on top of any of
+  these, and adds it to Reagent and Freehand alike.
+
+  ## Gates
+
+  Every measured write is verified AT THE DOM: the cell it wrote must
+  hold the value it wrote by the time the clock stops. A write that
+  silently did nothing would be the fastest arm in any benchmark, and
+  this row exists because the first version of it was exactly that.
+  Canonical-DOM equality across all four arms is checked before and
+  after the whole run on top.
+
+  Normative owner: `docs/design/freehand/decisions/`
+  `D021-performance-budgets-and-release-evidence.md`."
+  (:require ["react-dom" :as react-dom]
+            ["react-dom/client" :as react-dom-client]
+            [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [reagent.core :as r]
+            [reagent.dom.client :as rdc]
+            [re-frame.adapter.uix :as react-substrate]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.bench.b6-floor :as floor]
+            [re-frame.freehand.bench.b6-harness :as h]
+            [re-frame.freehand.bench.b6-reagent :as rg]
+            [re-frame.freehand.bench.b6-witnesses :as fh]
+            [re-frame.freehand.bench.b6-witnesses-compiled :as fhc]
+            [re-frame.freehand.bench.measure :as m]
+            [re-frame.freehand.bench.provenance :as prov]
+            [re-frame.freehand.react :as fr]
+            [re-frame.freehand.root :as root]
+            [re-frame.test-support :as test-support]))
+
+;; ---------------------------------------------------------------------------
+;; re-frame registrations — FIRST, so this ns's own fixture baseline carries
+;; them. `make-reset-runtime-fixture` pins the registrar as it stood when the
+;; fixture was BUILT; a registration made after that line is wiped before
+;; every test in this file.
+;; ---------------------------------------------------------------------------
+
+(rf/reg-sub :b6/cell (fn [db [_ i]] (get-in db [:cells i])))
+(rf/reg-event :b6/seed (fn [_ [_ n]] {:db {:cells (vec (repeat n 0))}}))
+
+;; ---------------------------------------------------------------------------
+;; Fixture parameters
+;; ---------------------------------------------------------------------------
+
+(def ^:private cells-n 300)
+(def ^:private rounds 5)
+(def ^:private sampling {:warmup 4 :samples 12})
+(def ^:private total-samples (+ (:warmup sampling) (:samples sampling)))
+
+(defonce ^:private gen-seq (atom 1000))
+(defn- next-gen! [] (swap! gen-seq inc))
+
+;; ---------------------------------------------------------------------------
+;; The arms
+;; ---------------------------------------------------------------------------
+
+(defn- floor-arm
+  "The floor's `force!` renders INSIDE the `flushSync`, and that is not a
+  convenience. `root.render` called outside a React event schedules at
+  React's default lane, and an EMPTY `flushSync` flushes only the sync
+  lane — so a floor arm that rendered in `write!` and flushed in `force!`
+  would have its commit land outside the measured window entirely. The
+  DOM verification caught exactly that: 80 of 320 floor samples ended
+  with the cell still holding its old value. Freehand and Reagent are
+  unaffected, because a `useSyncExternalStore` notification and a
+  `reagent.core/flush` both put their work on the sync lane."
+  []
+  (let [state (atom (vec (repeat cells-n 0)))
+        rt    (volatile! nil)]
+    {:id      :floor
+     :mount   (fn [container]
+                (let [r (react-dom-client/createRoot container)]
+                  (vreset! rt r)
+                  (react-dom/flushSync (fn [] (.render r (floor/u-grid @state))))
+                  r))
+     :write!  (fn [i val]
+                (if (= i :all)
+                  (reset! state (vec (repeat cells-n val)))
+                  (swap! state assoc i val)))
+     :force!  (fn [] (react-dom/flushSync
+                       (fn [] (.render ^js @rt (floor/u-grid @state)))))
+     :unmount (fn [r] (react-dom/flushSync (fn [] (.unmount r))))}))
+
+(defn- freehand-arm [id view]
+  (let [fid (keyword "b6-update" (name id))]
+    {:id      id
+     :mount   (fn [container]
+                (react-dom/flushSync
+                  (fn [] (v/mount [view {:n cells-n}] container
+                                  {:frame         {:id fid :initial-events [[:b6/seed cells-n]]}
+                                   :disambiguator (keyword "b6u" (name id))}))))
+     :write!  (fn [i val]
+                (if (= i :all)
+                  (frame/replace-app-db! fid {:cells (vec (repeat cells-n val))})
+                  (frame/replace-app-db!
+                    fid (update (frame/frame-app-db-value fid) :cells assoc i val))))
+     ;; Freehand's notification has already been queued by the write; the
+     ;; empty flushSync is what makes React commit it in this window rather
+     ;; than on its own scheduler two milliseconds later.
+     :force!  (fn [] (react-dom/flushSync (fn [] nil)))
+     :unmount (fn [mounted] (react-dom/flushSync (fn [] (v/unmount! mounted))))}))
+
+(defn- reagent-arm []
+  {:id      :reagent
+   :mount   (fn [container]
+              (reset! rg/cells (vec (repeat cells-n 0)))
+              (let [rt (rdc/create-root container)]
+                (react-dom/flushSync (fn [] (rdc/render rt [rg/u-grid cells-n])))
+                rt))
+   :write!  (fn [i val]
+              (if (= i :all)
+                (reset! rg/cells (vec (repeat cells-n val)))
+                (swap! rg/cells assoc i val)))
+   ;; `reagent.core/flush` is Reagent's own documented synchronous render
+   ;; drain — the counterpart of the empty `flushSync` the other arms use.
+   :force!  (fn [] (react-dom/flushSync (fn [] (r/flush))))
+   :unmount (fn [rt] (react-dom/flushSync (fn [] (rdc/unmount rt))))})
+
+(defn- make-arms []
+  [(floor-arm)
+   (freehand-arm :freehand-interpreted fh/u-grid)
+   (freehand-arm :freehand-compiled fhc/u-grid)
+   (reagent-arm)])
+
+;; ---------------------------------------------------------------------------
+;; Fixtures
+;; ---------------------------------------------------------------------------
+
+(def ^:private runtime-fixture
+  ;; The UIx adapter, because Freehand's `v/sub` needs a non-ratom
+  ;; substrate (rf2-8cnxg). The Reagent arm is untouched by the choice: a
+  ;; `reagent.core/atom` and a `cursor` over it are pure Reagent and know
+  ;; nothing about which re-frame adapter is installed, which is exactly
+  ;; what lets both substrates run on one page in one interleaved run.
+  ;; `:async? true` selects the `{:before :after}` RETURN SHAPE only.
+  (test-support/make-reset-runtime-fixture
+    {:adapter       react-substrate/adapter
+     :ambient-frame nil
+     :async?        true}))
+
+(use-fixtures :each
+  {:before (fn []
+             (root/reset-registry!)
+             (fr/reset-boundaries!)
+             ((:before runtime-fixture))
+             (h/leave-act-environment!))
+   :after  (fn []
+             ((:after runtime-fixture))
+             (root/reset-registry!)
+             (fr/reset-boundaries!))})
+
+;; ---------------------------------------------------------------------------
+;; One timed write
+;; ---------------------------------------------------------------------------
+
+(defn- cell-text
+  [container i]
+  (some-> (.querySelector container (str "[data-i=\"" i "\"]")) (.-textContent)))
+
+(defn- timed-write!
+  "Write, yield ONE microtask, force the arm's own synchronous drain, stop
+  the clock — then VERIFY at the DOM that the cell holds what was written.
+  Answers a promise of `{:ms … :ok? …}`."
+  [{:keys [arm container]} i val]
+  (let [t0 (m/now-ms)]
+    ((:write! arm) i val)
+    (-> (js/Promise.resolve nil)
+        (.then (fn [_]
+                 ((:force! arm))
+                 (let [ms    (- (m/now-ms) t0)
+                       probe (if (= i :all) 0 i)]
+                   {:ms  ms
+                    :ok? (= (str val) (cell-text container probe))
+                    :ok2? (or (not= i :all)
+                              (= (str val) (cell-text container (dec cells-n))))}))))))
+
+;; ---------------------------------------------------------------------------
+;; Rounds
+;; ---------------------------------------------------------------------------
+
+(defn- chain
+  "Fold `xs` into a serial promise chain, threading an accumulator."
+  [init xs f]
+  (reduce (fn [p x] (.then p (fn [acc] (f acc x)))) (js/Promise.resolve init) xs))
+
+(defn- round!
+  "One round, arms interleaved at the sample level with the order rotating
+  on the sample index."
+  [mounts kind]
+  (let [k (count mounts)]
+    (chain {:readings (zipmap (map #(:id (:arm %)) mounts) (repeat []))
+            :bad      0}
+           (for [s (range total-samples) j (range k)] [s j])
+           (fn [acc [s j]]
+             (let [mnt (nth mounts (mod (+ j s) k))
+                   val (next-gen!)
+                   i   (if (= kind :broad) :all (mod val cells-n))]
+               (-> (timed-write! mnt i val)
+                   (.then (fn [{:keys [ms ok? ok2?]}]
+                            (cond-> acc
+                              (not (and ok? ok2?)) (update :bad inc)
+                              (>= s (:warmup sampling))
+                              (update-in [:readings (:id (:arm mnt))] conj ms))))))))))
+
+(defn- seed-all! [mounts]
+  (chain nil mounts (fn [_ mnt] (-> (timed-write! mnt :all 0) (.then (fn [_] nil))))))
+
+(defn- canon-of [mounts] (mapv (fn [m] (h/canonical (:container m))) mounts))
+
+(defn- assert-agreement!
+  [mounts label]
+  (let [before (canon-of mounts)
+        val    (next-gen!)]
+    (-> (chain nil mounts (fn [_ mnt] (-> (timed-write! mnt :all val) (.then (fn [_] nil)))))
+        (.then (fn [_]
+                 (let [after (canon-of mounts)
+                       ids   (mapv #(:id (:arm %)) mounts)]
+                   (is (apply = after)
+                       (str label ": every arm's page agrees after the write, compared as
+                             canonical DOM"
+                            (when-not (apply = after)
+                              (str " — arms " (pr-str ids) " produced "
+                                   (count (distinct after)) " distinct pages"))))
+                   (doseq [[id b a] (map vector ids before after)]
+                     (is (not= b a)
+                         (str label " / " (name id)
+                              ": the write actually changed this arm's DOM")))
+                   nil))))))
+
+;; ---------------------------------------------------------------------------
+;; The rows
+;; ---------------------------------------------------------------------------
+
+(defn- mount-all! [arms]
+  (mapv (fn [a]
+          (let [c (js/document.createElement "div")]
+            (.appendChild js/document.body c)
+            {:arm a :container c :handle ((:mount a) c)}))
+        arms))
+
+(defn- release-all! [mounts]
+  (doseq [{:keys [arm handle container]} mounts]
+    (try ((:unmount arm) handle) (catch :default _ nil))
+    (.remove container)))
+
+(defn- measure! [kind doc done]
+  (let [arms   (make-arms)
+        mounts (mount-all! arms)]
+    (-> (assert-agreement! mounts (str (name kind) " (before)"))
+        (.then (fn [_]
+                 (chain [] (range rounds)
+                        (fn [acc _]
+                          (-> (seed-all! mounts)
+                              (.then (fn [_] (round! mounts kind)))
+                              (.then (fn [rd] (conj acc rd))))))))
+        (.then (fn [rds]
+                 (let [bad  (reduce + (map :bad rds))
+                       norm (mapv #(h/normalise (:readings %) :floor) rds)
+                       summ (h/across-rounds (mapv :ratio norm))]
+                   (is (zero? bad)
+                       (str (name kind) ": every measured write was verified AT THE DOM "
+                            "before the clock stopped — " bad " of "
+                            (* rounds total-samples (count arms))
+                            " did not land"))
+                   (h/publish!
+                     (str "update / " (name kind))
+                     {:benchmark    (keyword "B6" (str "update-" (name kind)))
+                      :doc          doc
+                      :revision     (prov/detect-revision)
+                      :build        (prov/detect-build)
+                      :host         (prov/detect-host)
+                      :fixture      {:cells         cells-n
+                                     :kind          kind
+                                     :arms          (mapv :id arms)
+                                     :adapter       :rf.adapter/uix
+                                     :reagent-version "2.0.1"
+                                     :unverified-writes bad
+                                     :measurement-method
+                                     (str "per write: t0; the arm's own state install; ONE "
+                                          "microtask yield; the arm's own synchronous drain "
+                                          "(empty react-dom/flushSync for the floor and both "
+                                          "Freehand arms, reagent.core/flush inside one for "
+                                          "Reagent); t1 — then the written cell is read back "
+                                          "out of the DOM and the sample is rejected if it "
+                                          "does not hold the written value. The microtask is "
+                                          "STRUCTURAL: a mounted Freehand v/sub does not "
+                                          "repaint inside flushSync, its notification rides a "
+                                          "microtask, and a first pass that timed inside "
+                                          "flushSync measured Freehand writes that never "
+                                          "reached the DOM at all. Arms interleaved at the "
+                                          "sample level, order rotating on the sample index; "
+                                          (str rounds) " rounds of " (:warmup sampling)
+                                          " warmup + " (:samples sampling) " samples; every "
+                                          "figure a ratio to the floor measured in that same "
+                                          "round. The UPDATE floor is a plain top-down React "
+                                          "re-render and is NOT a lower bound")}
+                      :sampling     sampling
+                      :baseline     {:kind      :cross-substrate
+                                     :reference {:arm  :floor
+                                                 :note "plain top-down React re-render, no substrate"}}
+                      :per-round    {:p50 (mapv :p50 norm) :ratio (mapv :ratio norm)}
+                      :ratio-to-floor summ
+                      :status       :evidence})
+                   (is (= rounds (count norm)) "every round produced a reading")
+                   (is (every? (fn [{:keys [p50]}] (pos? (:floor p50))) norm)
+                       "the floor arm took measurable time in every round")
+                   (is (every? #(pos? (:mean %)) (vals summ))
+                       "every arm produced a positive ratio")
+                   nil)))
+        (.catch (fn [e] (is false (str (name kind) " row rejected: " e))))
+        (.finally (fn [] (release-all! mounts) (done))))))
+
+(deftest broad-update-throughput
+  (testing "One write that every one of 300 cells reads, so every cell
+            re-renders. This prices re-render throughput, where fine grain
+            buys nothing because all the work is genuinely required. Every
+            sample is verified at the DOM before its clock stops."
+    (if-not (h/browser?)
+      (is true "a real browser is required — the browser job runs this row")
+      (async done (measure! :broad "one write that all 300 cells read" done)))))
+
+(deftest narrow-update-localisation
+  (testing "One write that exactly ONE of 300 cells reads. This is where
+            fine-grained reactivity either shows up or does not: the floor
+            re-renders 300 cells to move one, and a substrate that
+            re-renders one should beat it outright. Under this window a
+            single narrow write is well above the timer, which is what
+            replaces the predecessor report's null result."
+    (if-not (h/browser?)
+      (is true "a real browser is required — the browser job runs this row")
+      (async done (measure! :narrow "one write exactly one of 300 cells reads" done)))))
+
+;; ===========================================================================
+;; Non-vacuity
+;; ===========================================================================
+
+(deftest a-freehand-write-does-not-commit-inside-flushsync
+  (testing "The window's shape is not a style choice, and this is the
+            observation that forced it: a mounted Freehand `v/sub` is NOT
+            repainted by a write made inside `react-dom/flushSync`. The
+            store is written and the subscription recomputes, but React
+            learns about it on a microtask, so the commit lands after the
+            flush has returned. Reagent and the floor commit in the same
+            window. If this test ever starts failing, Freehand has gained
+            a synchronous commit and the update row should be re-taken
+            without the microtask yield."
+    (if-not (h/browser?)
+      (is true "a real browser is required — the browser job runs this row")
+      (async done
+        (let [arm       (freehand-arm :freehand-interpreted fh/u-grid)
+              container (js/document.createElement "div")]
+          (.appendChild js/document.body container)
+          (let [mounted ((:mount arm) container)]
+            (is (= "0" (cell-text container 0)) "the grid mounted and the cell reads 0")
+            (react-dom/flushSync (fn [] ((:write! arm) 0 4242)))
+            (is (not= "4242" (cell-text container 0))
+                "a write inside flushSync has NOT reached the DOM when the flush returns")
+            (-> (js/Promise.resolve nil)
+                (.then (fn [_]
+                         ((:force! arm))
+                         (is (= "4242" (cell-text container 0))
+                             "and one microtask plus a forced drain later, it has")
+                         ((:unmount arm) mounted)
+                         (.remove container)
+                         (done)))
+                (.catch (fn [e]
+                          (is false (str "rejected: " e))
+                          (.remove container)
+                          (done))))))))))
+
+(deftest the-fixture-is-what-it-says-it-is
+  (testing "Arithmetic over the fixture, so a reader can check the row's
+            premises without re-running anything."
+    (is (= 300 cells-n) "300 cells, so a broad write really does move every one")
+    (is (= :interpreted (:lowering (v/describe fh/u-grid))) "one Freehand arm is interpreted")
+    (is (= :compiled (:lowering (v/describe fhc/u-grid))) "and one is compiled")
+    (is (fn? rg/u-grid) "the Reagent arm is an ordinary function returning Hiccup")
+    (is (not= (next-gen!) (next-gen!)) "no two writes ever install the same value")))

--- a/implementation/freehand/test/re_frame/freehand/bench/b6_witnesses.cljc
+++ b/implementation/freehand/test/re_frame/freehand/bench/b6_witnesses.cljc
@@ -1,0 +1,151 @@
+(ns re-frame.freehand.bench.b6-witnesses
+  "B6's witnesses, declared in FREEHAND and INTERPRETED — the reference arm
+  of the cross-substrate comparison.
+
+  B6 asks one question the rest of the B-spine never asks: how does
+  Freehand compare against a DIFFERENT substrate rendering the same page
+  to the same React? Every earlier row compares Freehand to Freehand
+  (interpreted against compiled) or to a hand-built React floor. This one
+  adds Reagent — and, on the mount rows, UIx.
+
+  ## The three witnesses, and why these three
+
+  Deliberately the shapes
+  `docs/design/freehand/studio/compiled-tier-browser-worth-it.md`
+  already measured, so B6's ratios slot into that report's table rather
+  than starting a second, incomparable one:
+
+    - **W1** a large template — 300 rows under one boundary each, with
+      multi-class sugar, a style map, a `data-*` passthrough and text.
+      1,203 elements. The honest headline shape.
+    - **W2** a boundary storm — 300 leaf boundaries whose bodies read
+      nothing. 301 elements. Deliberately the shape that MAXIMISES
+      Freehand's ViewCell elision, which Reagent has no concept of; the
+      report flags it as overstating the gap rather than quietly banking
+      it.
+    - **W3** an ordinary form — 12 fields, each a label, a controlled
+      input and an error line, under a derived submit gate. 51 elements.
+      The shape most applications are actually made of.
+
+  ## Every arm must build the same page
+
+  The comparison is only fair if the arms are rendering one page, so the
+  suite gates canonical-DOM equality across all of them before it reads a
+  clock — the same discipline, and the same reason, as B1's DOM row. That
+  is why the markup below uses **multi-class sugar** rather than a
+  `:class` prop composed with sugar: sugar composition is real work every
+  front end does, and it is spelled identically in Freehand hiccup and
+  Reagent hiccup, so an equality here is a claim about the substrates
+  rather than about two different class-composition conventions.
+
+  ## No handlers, and why
+
+  W1 carries no `:on-click`. Freehand's paved path for a handler is an
+  EVENT VECTOR resolved against a frame; Reagent's is a closure. Putting
+  one in each arm would compare two different mechanisms inside a mount
+  row that is otherwise about markup, and putting one in neither keeps
+  the row about what it says it is about. The event path is measured
+  where it belongs — the update rows, which are about exactly that.
+
+  Its twin in [[re-frame.freehand.bench.b6-witnesses-compiled]] is this
+  file's declarations with `{:compiled true}` added and nothing else
+  changed.
+
+  Normative owner: `docs/design/freehand/decisions/`
+  `D021-performance-budgets-and-release-evidence.md`."
+  (:require [re-frame.freehand :as v]))
+
+;; ---------------------------------------------------------------------------
+;; W1 — the large template
+;; ---------------------------------------------------------------------------
+
+(v/defview w1-row
+  "One row of the large template: multi-class sugar, a style map, a
+  `data-*` name that passes through verbatim, and a group of three
+  children — an element with two attributes, an element with static text,
+  and an element with dynamic text."
+  [{:keys [i]}]
+  [:li.row.cell.wide {:style      {:padding-left "4px" :color "rebeccapurple"}
+                      :data-index i}
+   [:img.avatar {:src "/avatar.png" :alt ""}]
+   [:span.label "row "]
+   [:em.n (str i)]])
+
+(v/defview w1
+  "The large template — a fixed skeleton over a keyed run of row
+  boundaries."
+  [{:keys [rows]}]
+  [:section.panel {:aria-label "bench rows"}
+   [:h1.title "Rows"]
+   [:ul.rows {:role "list"}
+    (for [i (range rows)]
+      [w1-row {:key i :i i}])]])
+
+;; ---------------------------------------------------------------------------
+;; W2 — the boundary storm
+;; ---------------------------------------------------------------------------
+
+(v/defview w2-leaf
+  "A leaf boundary whose body reads nothing — so Freehand's analyzer can
+  prove it has no reactive site and elide its ViewCell, and Reagent
+  cannot, because Reagent has no such concept."
+  [_]
+  [:span.leaf "leaf"])
+
+(v/defview w2
+  "300 leaf boundaries under one parent."
+  [{:keys [n]}]
+  [:div.storm
+   (for [i (range n)]
+     [w2-leaf {:key i}])])
+
+;; ---------------------------------------------------------------------------
+;; W3 — the ordinary form
+;; ---------------------------------------------------------------------------
+
+(v/defview w3-field
+  "One field: a label, a controlled input carrying a `value`, and an
+  error line. `:read-only` rather than a change handler, for the reason
+  the namespace docstring gives — the `value` slot is what puts the
+  element through the controlled-input door, and the handler would be a
+  second, differently-spelled mechanism inside a markup row."
+  [{:keys [i value error]}]
+  [:div.field
+   [:label.lbl {:for (str "f" i)} (str "Field " i)]
+   [:input.inp {:id        (str "f" i)
+                :name      (str "f" i)
+                :type      "text"
+                :value     value
+                :read-only true}]
+   [:p.err error]])
+
+(v/defview w3
+  "The 12-field form under a derived submit gate."
+  [{:keys [fields]}]
+  [:form.w3form
+   [:fieldset.fields
+    (for [i (range fields)]
+      [w3-field {:key   i
+                 :i     i
+                 :value (str "value " i)
+                 :error (if (even? i) "" (str "field " i " is required"))}])]
+   [:button.submit {:type "submit" :disabled true} "Submit"]])
+
+;; ---------------------------------------------------------------------------
+;; U — the update witness
+;; ---------------------------------------------------------------------------
+
+(v/defview u-cell
+  "One cell of the update grid, reading its own subscription. This is the
+  paved Freehand spelling of a fine-grained reactive leaf, and the
+  counterpart of the Reagent arm's `r/cursor`."
+  [{:keys [i]}]
+  [:span.cell {:data-i i} (str (v/sub [:b6/cell i]))])
+
+(v/defview u-grid
+  "300 independently-reactive cells — the surface both the broad and the
+  narrow update rows drive."
+  [{:keys [n]}]
+  [:div.ugrid
+   (for [i (range n)]
+     [u-cell {:key i :i i}])])

--- a/implementation/freehand/test/re_frame/freehand/bench/b6_witnesses_compiled.cljc
+++ b/implementation/freehand/test/re_frame/freehand/bench/b6_witnesses_compiled.cljc
@@ -1,0 +1,118 @@
+(ns re-frame.freehand.bench.b6-witnesses-compiled
+  "B6's witnesses, PROMOTED — [[re-frame.freehand.bench.b6-witnesses]]'s
+  declarations with `{:compiled true}` added and nothing else changed.
+
+  The two files exist separately only because a view id is derived from
+  where a declaration LIVES, so two declarations of one name cannot share
+  a namespace. Keeping the bodies character-identical is what makes B6's
+  compiled column a claim about LOWERING rather than about two templates:
+  a timing comparison between two arms that are not the same page is a
+  comparison of two pages, which is why the suite gates canonical-DOM
+  equality across every arm before it reads a clock.
+
+  Normative owner: `docs/design/freehand/decisions/`
+  `D021-performance-budgets-and-release-evidence.md`."
+  (:require [re-frame.freehand :as v]))
+
+;; ---------------------------------------------------------------------------
+;; W1 — the large template
+;; ---------------------------------------------------------------------------
+
+(v/defview w1-row
+  "One row of the large template: multi-class sugar, a style map, a
+  `data-*` name that passes through verbatim, and a group of three
+  children — an element with two attributes, an element with static text,
+  and an element with dynamic text."
+  {:compiled true}
+  [{:keys [i]}]
+  [:li.row.cell.wide {:style      {:padding-left "4px" :color "rebeccapurple"}
+                      :data-index i}
+   [:img.avatar {:src "/avatar.png" :alt ""}]
+   [:span.label "row "]
+   [:em.n (str i)]])
+
+(v/defview w1
+  "The large template — a fixed skeleton over a keyed run of row
+  boundaries."
+  {:compiled true}
+  [{:keys [rows]}]
+  [:section.panel {:aria-label "bench rows"}
+   [:h1.title "Rows"]
+   [:ul.rows {:role "list"}
+    (for [i (range rows)]
+      [w1-row {:key i :i i}])]])
+
+;; ---------------------------------------------------------------------------
+;; W2 — the boundary storm
+;; ---------------------------------------------------------------------------
+
+(v/defview w2-leaf
+  "A leaf boundary whose body reads nothing — so Freehand's analyzer can
+  prove it has no reactive site and elide its ViewCell, and Reagent
+  cannot, because Reagent has no such concept."
+  {:compiled true}
+  [_]
+  [:span.leaf "leaf"])
+
+(v/defview w2
+  "300 leaf boundaries under one parent."
+  {:compiled true}
+  [{:keys [n]}]
+  [:div.storm
+   (for [i (range n)]
+     [w2-leaf {:key i}])])
+
+;; ---------------------------------------------------------------------------
+;; W3 — the ordinary form
+;; ---------------------------------------------------------------------------
+
+(v/defview w3-field
+  "One field: a label, a controlled input carrying a `value`, and an
+  error line. `:read-only` rather than a change handler, for the reason
+  the namespace docstring gives — the `value` slot is what puts the
+  element through the controlled-input door, and the handler would be a
+  second, differently-spelled mechanism inside a markup row."
+  {:compiled true}
+  [{:keys [i value error]}]
+  [:div.field
+   [:label.lbl {:for (str "f" i)} (str "Field " i)]
+   [:input.inp {:id        (str "f" i)
+                :name      (str "f" i)
+                :type      "text"
+                :value     value
+                :read-only true}]
+   [:p.err error]])
+
+(v/defview w3
+  "The 12-field form under a derived submit gate."
+  {:compiled true}
+  [{:keys [fields]}]
+  [:form.w3form
+   [:fieldset.fields
+    (for [i (range fields)]
+      [w3-field {:key   i
+                 :i     i
+                 :value (str "value " i)
+                 :error (if (even? i) "" (str "field " i " is required"))}])]
+   [:button.submit {:type "submit" :disabled true} "Submit"]])
+
+;; ---------------------------------------------------------------------------
+;; U — the update witness
+;; ---------------------------------------------------------------------------
+
+(v/defview u-cell
+  "One cell of the update grid, reading its own subscription. This is the
+  paved Freehand spelling of a fine-grained reactive leaf, and the
+  counterpart of the Reagent arm's `r/cursor`."
+  {:compiled true}
+  [{:keys [i]}]
+  [:span.cell {:data-i i} (str (v/sub [:b6/cell i]))])
+
+(v/defview u-grid
+  "300 independently-reactive cells — the surface both the broad and the
+  narrow update rows drive."
+  {:compiled true}
+  [{:keys [n]}]
+  [:div.ugrid
+   (for [i (range n)]
+     [u-cell {:key i :i i}])])


### PR DESCRIPTION
Answers the operator's question of 2026-07-27, verbatim: *how fast is Freehand relative to Reagent?* (`rf2-dq20a`)

Adds a five-arm cross-substrate row to the existing B-spine bench — the hand-built `react/createElement` floor, interpreted Freehand, compiled Freehand, **idiomatic Reagent 2.0.1**, and **UIx 1.4.4** via `$` — all rendering the same three witnesses into the same React, all gated on canonical-DOM equality before any clock is read. Plus an **update** row, mount being only half the question and the misleading half.

`implementation/shadow-cljs.edn` and every `deps.edn` are **unchanged**: the deterministic gates ride the existing `:browser-test-freehand-bench` build id (whose `ns-regexp` already matches `bench.*-dom-cljs-test`), and the `:advanced` reading rides a `--config-merge` on the existing `:freehand-release` id.

## The result

**Mount** — ratio to the in-run React floor, mean over 6 rounds:

| Witness | FH interpreted | FH compiled | Reagent | UIx |
|---|---:|---:|---:|---:|
| W1 large template, 1,203 el | 2.987 | **1.304** | 1.554 | 1.163 |
| W2 300 elidable boundaries † | 7.472 | 2.139 | 2.500 | **1.361** |
| W3 ordinary form, 51 el ‡ | 1.664 | 1.325 | 1.394 | 1.153 |

Compiled Freehand beats Reagent by 16% on the large template, ranges disjoint. Interpreted Freehand is **1.9× slower than Reagent**. UIx sits nearest the floor on every witness — the `$`-expands-to-`createElement` hypothesis holds — and beats compiled Freehand even on the elision-maximising boundary storm.

† W2 overstates Freehand's advantage: Reagent and UIx have no elision concept. Flagged, not banked.
‡ W3's absolutes are 0.3–1.0 ms against a 0.1 ms clock quantum; UIx's range includes 1.0.

**Update** — Reagent is **~10× faster on a broad write and ~15× on a narrow one**. Stated plainly, because it is the answer.

**But the leg decomposition changes what to do about it.** On a narrow write ~90% of Freehand's cost is `frame/replace-app-db!` plus the signal graph, not rendering — Freehand's render leg (1.4 ms per 20 writes) matches Reagent's (1.3 ms) and beats the floor's (2.4 ms). A Reagent app reading re-frame subscriptions would pay that same write leg. Freehand's own deficit is **bulk re-render: ~7–8× Reagent on 300 repainting boundaries**, and compiling barely moves it.

## Two instrument faults the DOM verification caught

Both would have produced a confident wrong table; both are written into the source.

1. **A mounted Freehand `v/sub` does not repaint inside `react-dom/flushSync`** — its notification rides a microtask. The first update instrument timed Freehand writes that never reached the DOM, and the timings looked *reasonable*. Filed as **rf2-w2m25** (P1) and pinned as a regression test.
2. **An empty `flushSync` flushes only React's sync lane**, so the floor arm's default-lane `root.render` has to be issued inside the flush. Until it was, 80 of 320 floor samples ended with the old value on screen and every other arm's ratio was inflated against a floor that had not rendered.

Hence: every measured write is read back out of the DOM inside its own window. **0 rejected of 384** in each published row.

Also deleted rather than caveated: a microtask "control" that chained 2,000 `js/Promise.resolve`s and reported ~1 ms a hop — larger than an entire measured Reagent write, so impossible. It was measuring chain construction. The real control was already there: the arms that don't need the yield report `gap = 0.0`.

## Files

- Report: `docs/design/freehand/studio/freehand-vs-reagent.md` — sibling to `compiled-tier-browser-worth-it.md`, whose method and table it reuses. (`docs/design/freehand/` is excluded from the mkdocs scan, so no nav entry and no link-validator surface.)
- Arms: `b6_witnesses.cljc` + `b6_witnesses_compiled.cljc` (Freehand, two lowerings), `b6_reagent.cljs`, `b6_uix.cljs`, `b6_floor.cljs`.
- Instrument: `b6_harness.cljs` (canonical DOM, sample-level interleaving, floor normalisation), `b6_rows.cljs` (arms + both measurements).
- Gates: `b6_mount_dom_cljs_test.cljs`, `b6_update_dom_cljs_test.cljs`.
- `:advanced` reading: `b6_prod_app.cljs` + `b6_prod_run.cjs`. Reproduce with `node implementation/freehand/test/re_frame/freehand/bench/b6_prod_run.cjs`.

All under `implementation/freehand/test/re_frame/freehand/bench/`. Unlike the predecessor spike, the scaffolding **ships** rather than being reverted.

## Follow-ups filed

- **rf2-w2m25** (P1 bug) — Freehand has no public door that makes a state change observable in the DOM before the current task ends.
- **rf2-n91mv** (P3) — add the B6 twin pair to `compiled_source_delta_jvm_test`'s `twin-files` table; that file was outside this bead's fence.

## Quality gates

| Gate | Command | Result | Exit |
|---|---|---|---|
| Freehand JVM suite | `clojure -M:test` from `implementation/freehand` | 1215 tests / 8130 assertions, **0 failures, 0 errors** | **0** |
| CLJS node suite | `npm run test:cljs` from `implementation` | 11592 tests / 58166 assertions, **0 failures, 0 errors** | **0** |
| Docs | `python -m mkdocs build --strict` from repo root | built in 20.51 s | **0** |
| Fast PR spine | `sh scripts/test-fast-pr.sh` from repo root | `PASS fast PR spine`; per-ns isolation 17/17 | **0** |
| Freehand browser bench lane | `npm run bench:freehand-browser` (port-overridden) | **Ran 23 tests / 316 assertions, 0 failures, 0 errors** — includes the canonical-DOM parity gates for all five arms | **0** |

The fast-PR spine soft-skipped its own mkdocs step (`mkdocs not on PATH` under that shell); `python -m mkdocs build --strict` was run separately and is the row above. Not run: production-elision / bundle-isolation / perf-bundle / adapter-smoke / Xray / mcp-conformance — CI-only per `TESTING.md`, and this diff touches no surface they gate (the new code is test-tree only; nothing under `implementation/*/src/` requires it).
