### PR TITLE
fix(freehand): repaint a v/sub read inside react-dom/flushSync (rf2-w2m25)

### DIFF
--- a/docs/design/freehand/studio/freehand-vs-reagent.md
+++ b/docs/design/freehand/studio/freehand-vs-reagent.md
@@ -58,13 +58,14 @@ Four findings, and the third is the one that changes what to do about it.
    render leg is **4.0–5.4 ms against Reagent's 0.6–0.7 ms** — a genuine
    **≈7–8× on re-rendering 300 boundaries**, which no accounting moves.
 
-And one property that is not a number: **Freehand cannot commit a state
-change synchronously.** A write made inside `react-dom/flushSync` has not
-reached the DOM when the flush returns; the notification rides a
-microtask. Reagent and plain React both commit in that window. It is
+And one property that is not a number: **Freehand could not commit a
+state change synchronously.** A write made inside `react-dom/flushSync`
+had not reached the DOM when the flush returned; the notification rode a
+microtask. Reagent and plain React both commit in that window. It was
 filed as `rf2-w2m25`, it forced this report's whole measurement shape,
-and it is the finding most likely to matter to somebody writing an
-application.
+and it was the finding most likely to matter to somebody writing an
+application. **`rf2-w2m25` is now fixed** — see §2b — but every figure
+below was taken before the fix, through the window it forced.
 
 **What this does *not* say.** It does not say Freehand should adopt
 ratoms, and it does not say the compiled tier is vindicated. The mount
@@ -339,28 +340,38 @@ when a narrow one moves one.
 > because it is the same class of mistake as the predecessor report's
 > heap sampler.
 
-### 2b. Freehand cannot commit synchronously
+### 2b. Freehand could not commit synchronously — FIXED
 
 Not a timing result, and probably the most consequential thing here.
 
-A write made inside `react-dom/flushSync` has **not** reached the DOM when
-the flush returns — through any door: `frame/replace-app-db!`,
+> **Resolved.** `rf2-w2m25` landed after this report was taken: the
+> ViewCell pending window gained a second closer that React can see, so a
+> write made inside `react-dom/flushSync` now commits before the flush
+> returns, through every door named below. The microtask closer is
+> untouched, so ordinary batching is unchanged. The rest of this section
+> is kept in the past tense as the record of what was measured, because
+> it is what shaped this report's whole instrument. The figures in §2 were
+> **not** re-taken and still carry the microtask yield the defect forced.
+
+A write made inside `react-dom/flushSync` had **not** reached the DOM when
+the flush returned — through any door: `frame/replace-app-db!`,
 `rf/dispatch-sync` with an explicit `:frame`, or a
-`capture-frame` handle's `dispatch-sync`. The store is written and the
-subscription recomputes; React learns about it on a microtask. Reagent
+`capture-frame` handle's `dispatch-sync`. The store was written and the
+subscription recomputed; React learnt about it on a microtask. Reagent
 (`swap!` + `reagent.core/flush`) and plain React (`root.render` inside
 `flushSync`) both commit inside that window. The UIx adapter's own
 `flush-views!` did not commit the write when measured, and `react/act`
 did but cost ≈600 ms a call.
 
-The consequence for an application author is that **there is no public
-door that makes a state change observable in the DOM before the current
-task ends** — which anything that measures, scrolls, focuses or asserts
-immediately after a write has to work around, undocumented. Filed as
-`rf2-w2m25` (P1), and pinned as a regression test by
-`a-freehand-write-does-not-commit-inside-flushsync`, so if Freehand gains
-a synchronous commit the test goes red and this row should be re-taken
-without the microtask yield.
+The consequence for an application author was that **there was no public
+door that made a state change observable in the DOM before the current
+task ended** — which anything that measures, scrolls, focuses or asserts
+immediately after a write had to work around, undocumented. Filed as
+`rf2-w2m25` (P1) and now fixed; the case is pinned in **both** directions
+by `a-freehand-write-commits-inside-flushsync`, which asserts the commit
+lands inside the flush AND that the microtask window this row is measured
+through still lands its write. The update row is therefore re-takeable
+without the microtask yield; it has not been re-taken.
 
 ---
 
@@ -412,9 +423,12 @@ Stated plainly, because the omissions are load-bearing.
    suggests the cost is in the ViewCell wrapper rather than in the
    markup walk — the same term §1a of the predecessor report priced at
    2,348 bytes of standing heap per kept ViewCell.
-3. **A synchronous commit door.** `rf2-w2m25`. It would also let the
-   update row be re-taken without a microtask yield, which would tighten
-   every figure in §2.
+3. **~~A synchronous commit door.~~ DONE — `rf2-w2m25`.** Re-take the
+   update row without the microtask yield, which would tighten every
+   figure in §2. Note that the fix arms one extra React commit per render
+   batch (a two-fiber detached root rendering nil); it lands outside the
+   current window but would move inside a re-taken one, so whoever
+   re-takes the row should report it rather than absorb it.
 4. **The memory row.** See above.
 
 ## Provenance

--- a/implementation/freehand/src/re_frame/freehand/cell.cljc
+++ b/implementation/freehand/src/re_frame/freehand/cell.cljc
@@ -443,16 +443,69 @@
 ;; checkpoint, so there the window is closed explicitly — by the caller
 ;; that wants the correction, which is the only honest boundary a host
 ;; with no scheduler has.
+;;
+;; ONE WINDOW, TWO CLOSERS (rf2-w2m25). A microtask is invisible to
+;; `react-dom/flushSync`, which returns as soon as the React work
+;; SCHEDULED inside its callback has committed — and a mark schedules no
+;; React work at all. So a write made inside `flushSync` left the DOM
+;; unchanged when the flush returned, silently, and the caller who
+;; reached for `flushSync` precisely because they were about to measure
+;; layout, move focus or drive a caret got the stale page. The window is
+;; therefore armed with TWO closers, not one:
+;;
+;;   1. `js/queueMicrotask` — the host checkpoint the spec names, which
+;;      still owns the ordinary batch and still fires first outside a
+;;      flush (microtasks are FIFO and this one is armed first).
+;;   2. The HOST CLOSER — a zero-arg thunk the React tier installs
+;;      through [[set-host-window-closer!]], which schedules the same
+;;      [[flush!]] through the HOST's own scheduler, where a synchronous
+;;      flush can see it.
+;;
+;; Both call the SAME idempotent [[flush!]]; whichever the host runs
+;; first closes the window and the other finds it empty. Neither can
+;; close it early: both are armed by the mark and neither can run while
+;; the marking stack is still unwinding, so a run-to-completion drain is
+;; still un-splittable and N epochs in one drain still coalesce into one
+;; batch (Spec 006 §Render-batch finalization, guarantees 1–2). What
+;; changes is only WHICH checkpoint may close a window a synchronous
+;; commit is waiting on.
+;;
+;; The slot is a slot rather than a direct call because this namespace is
+;; `.cljc` and host-agnostic: it knows what a checkpoint MEANS and
+;; nothing about React. The JVM host installs none and closes its window
+;; explicitly, exactly as before.
 
 (defonce ^:private pending-cells (atom #{}))
 (defonce ^:private flush-scheduled? (atom false))
+(defonce ^:private host-window-closer (atom nil))
 
 (declare flush!)
+
+(defn set-host-window-closer!
+  "Install `arm!` — a zero-arg thunk that schedules a [[flush!]] through
+  the HOST's own scheduler — as the pending window's second closer, or
+  clear it with `nil`. Returns nil.
+
+  Called once, at load, by the tier that owns the host scheduler
+  (`re-frame.freehand.checkpoint` for React). A host that has no
+  scheduler installs nothing and keeps the microtask-and-explicit-flush
+  behaviour unchanged.
+
+  INTERNAL — a host-tier seam, not application API."
+  [arm!]
+  (reset! host-window-closer arm!)
+  nil)
 
 (defn- schedule-flush!
   []
   #?(:cljs (when (compare-and-set! flush-scheduled? false true)
-             (js/queueMicrotask (fn [] (flush!))))
+             (js/queueMicrotask (fn [] (flush!)))
+             ;; Best-effort, and deliberately AFTER the microtask is armed:
+             ;; the guaranteed closer must never be lost to a host closer
+             ;; that throws. A mark is constant work and a notification
+             ;; sink — it has no caller to report a scheduling failure to.
+             (when-let [arm! @host-window-closer]
+               (try (arm!) (catch :default _ nil))))
      :clj nil))
 
 (defn- notify-listeners!

--- a/implementation/freehand/src/re_frame/freehand/checkpoint.cljs
+++ b/implementation/freehand/src/re_frame/freehand/checkpoint.cljs
@@ -1,0 +1,143 @@
+(ns ^:no-doc re-frame.freehand.checkpoint
+  "The ViewCell pending window's REACT-VISIBLE closer (rf2-w2m25).
+
+  ## The hole this fills
+
+  A mark is constant work: [[re-frame.freehand.cell/mark-dirty!]] records
+  the cause, enrols the cell in the open pending window and arms a
+  microtask. Nothing React can see happens — no component re-renders, no
+  setState lands, no root is scheduled. So `react-dom/flushSync`, which
+  returns as soon as the React work SCHEDULED INSIDE its callback has
+  committed, had nothing to commit:
+
+      (react-dom/flushSync (fn [] (frame/replace-app-db! fid …)))
+      ;; app-db moved, the subscription recomputed, the cell was marked,
+      ;; and the DOM still showed the OLD value when this returned.
+
+  Measured four ways on a mounted 300-cell grid under the UIx adapter
+  (rf2-dq20a): the write-inside-`flushSync` arm never repainted, while
+  the same write followed by a yielded microtask, a `setTimeout 0` or a
+  `requestAnimationFrame` all did. It was silent, and `flushSync` is
+  exactly what a consumer reaches for when the next line measures layout,
+  moves focus, sets a caret or hands off to imperative third-party code.
+
+  ## The fix, and what it deliberately does not do
+
+  The microtask is not abolished. Making a mark notify SYNCHRONOUSLY
+  would recompute and re-render inside the source write — the trap Spec
+  006 invariant 6 exists to forbid — and would dissolve the coalescing
+  every batch in the substrate rests on.
+
+  Instead the window gains a SECOND closer, armed by the same first mark
+  and running the same idempotent [[re-frame.freehand.cell/flush!]]: a
+  render of one nil-returning sentinel component, whose LAYOUT EFFECT
+  closes the window. React's own scheduler then decides when that render
+  happens, and that is the whole point —
+
+    - **inside `flushSync`**, an update issued during the callback takes
+      the SYNC lane, so React renders the sentinel, runs its layout
+      effect, closes the window, and flushes the cells' resulting
+      `useSyncExternalStore` updates before `flushSync` returns. The DOM
+      is current on the next line.
+    - **outside it**, the update takes the default lane and React gets to
+      it later — by which time the microtask closer, armed FIRST and
+      running at the microtask checkpoint, has already closed the window.
+      The sentinel's effect then finds nothing pending and does nothing.
+      Ordinary batching is bit-for-bit what it was.
+
+  Neither closer can run while the marking stack is still unwinding, so
+  Spec 006 §Render-batch finalization guarantees 1 and 2 — a
+  run-to-completion drain cannot be split, and N epochs in one drain
+  coalesce into one batch — hold exactly as before. What changed is only
+  which checkpoint may close a window a SYNCHRONOUS commit is waiting on.
+
+  ## Why a detached root of its own
+
+  A Freehand ViewCell does not need a Freehand root: `v/->react` mounts
+  one inside a foreign React tree, and the sentinel has to reach that
+  cell too. A single detached root — created lazily on the first mark,
+  never attached to the document, rendering nil — covers every mount path
+  with one mechanism, and `flushSync` flushes sync work across ALL roots,
+  so being a separate root costs the mechanism nothing. It is the same
+  shape the spine's after-render driver root already uses
+  (`re-frame.substrate.spine`, rf2-t0x90), for the same reason.
+
+  It holds no application state and is deliberately never torn down: it
+  is one two-fiber tree for the life of the process, reused by every
+  window, and re-creating it per adapter generation would cost more than
+  it could ever save.
+
+  INTERNAL. Nothing here is application API — the door is `v/sub` and the
+  mounting verbs; this is what makes them honest under a synchronous
+  flush.
+
+  Normative owner:
+  [`spec/006-ReactiveSubstrate.md`](../../../../../spec/006-ReactiveSubstrate.md)
+  §Render-batch finalization — the host-checkpoint boundary."
+  (:require ["react" :as react]
+            ["react-dom/client" :as rdc]
+            [re-frame.freehand.cell :as cell]))
+
+(defonce ^:private driver-root (atom nil))
+
+(defonce ^:private window-seq (atom 0))
+
+(defn- close-window-sentinel
+  "The whole component: render nothing, and close the pending window from
+  a LAYOUT effect on every commit.
+
+  A layout effect rather than a passive one because `flushSync` ALWAYS
+  runs layout effects synchronously during the commit — a documented
+  guarantee — while its flushing of passive effects is a React-19
+  implementation detail and not a contract. Under a React that deferred
+  passives this component would close the window after the flush had
+  returned, which is the bug it exists to remove.
+
+  No deps array: firing on every commit IS the contract, because every
+  commit of this root was provoked by a mark that wants the window
+  closed."
+  [_props]
+  (react/useLayoutEffect
+    (fn close-window []
+      (cell/flush!)
+      js/undefined))
+  nil)
+
+(defn- dom-available?
+  "True when a `document` capable of creating elements is reachable — the
+  precondition for the driver root. False under a pure-node runner (no
+  jsdom) and under `react-dom/server`, where there is no synchronous
+  commit to be visible to and the microtask closer is the whole story."
+  []
+  (and (exists? js/document)
+       (some? (.-createElement js/document))))
+
+(defn- ensure-driver-root!
+  "The lazily-created singleton detached root. Never attached to the
+  document: the sentinel renders nil, so a detached host node is
+  sufficient and nothing this creates can be seen."
+  []
+  (or @driver-root
+      (let [host (.createElement js/document "div")
+            root (rdc/createRoot host)]
+        (reset! driver-root root)
+        root)))
+
+(defn arm!
+  "Schedule one sentinel render — the pending window's host-visible
+  closer, installed on [[re-frame.freehand.cell]] at load.
+
+  A FRESH props object every time, deliberately: React bails out of
+  re-rendering a child whose element is identical to the last one, and a
+  bailed-out render runs no layout effect and would close no window.
+
+  Returns nil. A host with no DOM arms nothing and leaves the microtask
+  closer to do the whole job."
+  []
+  (when (dom-available?)
+    (.render (ensure-driver-root!)
+             (react/createElement close-window-sentinel
+                                  #js {:rfWindow (swap! window-seq inc)})))
+  nil)
+
+(cell/set-host-window-closer! arm!)

--- a/implementation/freehand/src/re_frame/freehand/root.cljs
+++ b/implementation/freehand/src/re_frame/freehand/root.cljs
@@ -217,6 +217,14 @@
             [clojure.string :as str]
             [re-frame.error :as error]
             [re-frame.frame :as frame]
+            ;; LOAD ONLY, for its side effect: it installs the ViewCell
+            ;; pending window's React-visible closer, which is what makes a
+            ;; write inside `react-dom/flushSync` repaint (rf2-w2m25). Homed
+            ;; here because this is the namespace that already owns
+            ;; `react-dom/client`, and because the CLJS door requires it — so
+            ;; every mount path, `v/->react` into a foreign tree included,
+            ;; has the closer installed before a cell can be marked.
+            [re-frame.freehand.checkpoint]
             [re-frame.freehand.descriptor :as descriptor]
             [re-frame.freehand.fingerprint :as fingerprint]
             [re-frame.freehand.phase :as phase]

--- a/implementation/freehand/test/re_frame/freehand/bench/b6_rows.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b6_rows.cljs
@@ -411,7 +411,9 @@
 ;; THE MICROTASK YIELD IS PRICED IN SITU, BY THE ARMS THAT DO NOT NEED IT.
 ;;
 ;; Every measured write pays one microtask yield, because the slowest arm
-;; requires one, so a reader is owed the size of that constant. The
+;; required one when this window was designed (rf2-w2m25 has since removed
+;; that requirement; the row has not been re-taken), so a reader is owed
+;; the size of that constant. The
 ;; measurement is `:gap-ms` in the `:legs` decomposition, and the control
 ;; is that the floor and Reagent arms — which commit without it — report
 ;; `:gap-ms 0.0` in every round of both rows. The yield costs nothing;
@@ -482,11 +484,14 @@
                                             "Reagent); t1 — then the written cell is read back "
                                             "out of the DOM and the sample is rejected if it "
                                             "does not hold the written value. The microtask is "
-                                            "STRUCTURAL: a mounted Freehand v/sub does not "
-                                            "repaint inside flushSync, its notification rides a "
-                                            "microtask, and a first pass that timed inside "
-                                            "flushSync measured Freehand writes that never "
-                                            "reached the DOM at all. Arms interleaved at the "
+                                            "HISTORICAL: a mounted Freehand v/sub did not repaint "
+                                            "inside flushSync when this window was designed — its "
+                                            "notification rode a microtask, and a first pass that "
+                                            "timed inside flushSync measured Freehand writes that "
+                                            "never reached the DOM at all. rf2-w2m25 fixed that, so "
+                                            "the yield is no longer required by any arm and the row "
+                                            "is re-takeable without it; these figures were NOT "
+                                            "re-taken, so they still carry it. Arms interleaved at the "
                                             "sample level, order rotating on the sample index; "
                                             rounds " rounds of " (:warmup sampling)
                                             " warmup + " (:samples sampling) " samples; every "

--- a/implementation/freehand/test/re_frame/freehand/bench/b6_update_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b6_update_dom_cljs_test.cljs
@@ -11,30 +11,43 @@
   comparison would flatter whichever substrate constructs elements
   fastest while saying nothing about the thing Reagent exists for.
 
-  ## The window, and the fact that forced this shape
+  ## The window, and the defect that forced this shape
 
   A first pass timed each write inside `react-dom/flushSync`, exactly as
   the mount row does. **It measured nothing for two of the four arms**,
   and the DOM verification is what caught it: after every Freehand write
-  the DOM still read `0`. A mounted Freehand `v/sub` does not repaint
-  inside `flushSync` — its notification rides a MICROTASK, so React
-  learns about it only after the current task's stack unwinds. Measured
-  directly, and pinned by [[a-freehand-write-does-not-commit-inside-flushsync]]
-  below:
+  the DOM still read `0`. A mounted Freehand `v/sub` was not repainted
+  inside `flushSync` — its notification rode a MICROTASK, so React learnt
+  about it only after the current task's stack unwound. Measured directly:
 
-  | how the write was driven | did the DOM change? |
-  |---|---|
-  | `flushSync(write)` | **no** |
-  | `write` then a microtask then `flushSync(noop)` | yes, ~1 ms |
-  | `write` then `setTimeout 0` | yes, ~2 ms |
-  | `write` then `requestAnimationFrame` | yes, ~32 ms (two frames) |
+  | how the write was driven | did the DOM change? | since rf2-w2m25 |
+  |---|---|---|
+  | `flushSync(write)` | **no** | **yes** |
+  | `write` then a microtask then `flushSync(noop)` | yes, ~1 ms | yes |
+  | `write` then `setTimeout 0` | yes, ~2 ms | yes |
+  | `write` then `requestAnimationFrame` | yes, ~32 ms (two frames) | yes |
 
-  So every arm is timed through ONE shape, and it is the shape the
-  slowest arm requires: **write, yield one microtask, force the
-  substrate's own synchronous drain, stop the clock.** Floor and Reagent
-  do not need the microtask and pay it anyway. Nothing is measured inside
-  an `act` environment — `act` diverts work to its own queue and,
-  measured, cost 600 ms a call.
+  **That was a product defect, and it is fixed.** rf2-w2m25 gave the
+  ViewCell pending window a second closer that React can see
+  (`re-frame.freehand.checkpoint`), so a write inside `flushSync` now
+  commits before the flush returns. The right-hand column is what
+  [[a-freehand-write-commits-inside-flushsync]] pins below, and it is
+  where a regression in EITHER direction shows up.
+
+  The window this row is measured through has NOT been re-taken, so it is
+  still the shape the defect forced: **write, yield one microtask, force
+  the substrate's own synchronous drain, stop the clock.** Floor and
+  Reagent do not need the microtask and pay it anyway. Every arm is timed
+  through that ONE shape, so the comparison remains sound — what changed
+  is that it is no longer REQUIRED, and the row is now re-takeable as
+  `flushSync(write)` on all four arms, which would drop a microtask
+  boundary every arm currently pays. Whoever re-takes it should know that
+  the fix arms one extra React commit per render batch — a two-fiber
+  detached root rendering nil — which lands OUTSIDE the current window
+  but would move inside a re-taken one.
+
+  Nothing is measured inside an `act` environment — `act` diverts work to
+  its own queue and, measured, cost 600 ms a call.
 
   A second instrument fault the same verification caught: an EMPTY
   `flushSync` flushes only React's sync lane, so the floor arm's
@@ -162,16 +175,26 @@
 ;; Non-vacuity
 ;; ===========================================================================
 
-(deftest a-freehand-write-does-not-commit-inside-flushsync
-  (testing "The window's shape is not a style choice, and this is the
-            observation that forced it: a mounted Freehand `v/sub` is NOT
-            repainted by a write made inside `react-dom/flushSync`. The
-            store is written and the subscription recomputes, but React
-            learns about it on a microtask, so the commit lands after the
-            flush has returned. Reagent and the floor commit in the same
-            window. If this test ever starts failing, Freehand has gained
-            a synchronous commit and the update row should be re-taken
-            without the microtask yield."
+(deftest a-freehand-write-commits-inside-flushsync
+  (testing "This row was the observation that forced the window's shape,
+            and it now records the opposite fact. It USED to assert that a
+            mounted Freehand `v/sub` is NOT repainted by a write made
+            inside `react-dom/flushSync` — the store written, the
+            subscription recomputed, and React told on a microtask, so the
+            commit landed after the flush had returned while Reagent and
+            the floor both committed in the same window.
+
+            rf2-w2m25 fixed that: the ViewCell pending window gained a
+            SECOND closer React can see, so the write commits inside the
+            flush. The assertion is flipped rather than deleted or
+            loosened, because it is the only coverage of this case in the
+            bench and it has to catch a regression in EITHER direction —
+            a Freehand arm that silently stopped committing here is
+            exactly the fault that cost this row a whole measurement pass.
+
+            Both legs are asserted: the flush window (the new guarantee)
+            and the microtask window (the shape this row is still measured
+            through, so its non-vacuity does not rest on the new one)."
     (if-not (h/browser?)
       (is true "a real browser is required — the browser job runs this row")
       (async done
@@ -182,13 +205,21 @@
           (let [mounted ((:mount arm) container)]
             (is (= "0" (rows/cell-text container 0)) "the grid mounted and the cell reads 0")
             (react-dom/flushSync (fn [] ((:write! arm) 0 4242)))
-            (is (not= "4242" (rows/cell-text container 0))
-                "a write inside flushSync has NOT reached the DOM when the flush returns")
+            (is (= "4242" (rows/cell-text container 0))
+                "a write inside flushSync HAS reached the DOM when the flush
+                 returns — no yield of any kind between the two")
+            ;; The second leg: the window this row is actually measured
+            ;; through — write, yield one microtask, force the drain — still
+            ;; carries a write to the DOM. Re-taking the row without the
+            ;; microtask is now legitimate; until it is, this is the shape
+            ;; whose non-vacuity matters.
+            ((:write! arm) 0 8484)
             (-> (js/Promise.resolve nil)
                 (.then (fn [_]
                          ((:force! arm))
-                         (is (= "4242" (rows/cell-text container 0))
-                             "and one microtask plus a forced drain later, it has")
+                         (is (= "8484" (rows/cell-text container 0))
+                             "and the measured window — write, one microtask,
+                              forced drain — still lands its write too")
                          ((:unmount arm) mounted)
                          (.remove container)
                          (done)))

--- a/implementation/freehand/test/re_frame/freehand/flush_sync_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/flush_sync_dom_cljs_test.cljs
@@ -1,0 +1,388 @@
+(ns re-frame.freehand.flush-sync-dom-cljs-test
+  "rf2-w2m25 — a Freehand `v/sub` read repaints inside `react-dom/flushSync`.
+
+  ## The defect
+
+  Found by the Freehand-vs-Reagent measurement (rf2-dq20a), on the UIx
+  adapter, in a real browser. A mounted Freehand view whose body reads
+  `(v/sub …)` was NOT repainted by a state write made inside
+  `react-dom/flushSync`. The store was written and the subscription
+  recomputed, but `cell/mark-dirty!` schedules no React work at all — it
+  marks the cell and arms a MICROTASK — and `flushSync` returns as soon
+  as the work scheduled inside its callback has committed. So it
+  committed nothing, and said nothing about it.
+
+  Four ways of driving one write were measured on a mounted grid, and
+  only the first failed:
+
+  | how the write was driven | did the DOM change? |
+  |---|---|
+  | `flushSync(write)` | **no** |
+  | `write` then a microtask then `flushSync(noop)` | yes |
+  | `write` then `setTimeout 0` | yes |
+  | `write` then `requestAnimationFrame` | yes |
+
+  All four are asserted below, because a fix verified against fewer than
+  the defect was measured against is not verified — the three that always
+  worked are what say the repair did not simply move the hole.
+
+  ## Why it mattered beyond a bench
+
+  `flushSync` is what a consumer reaches for when the NEXT LINE reads the
+  DOM: measuring layout, moving focus, setting a caret, handing off to
+  imperative third-party code, or asserting in a test. A substrate that
+  silently does nothing there is a trap, and the silence is the worst
+  part — the write lands, the subscription recomputes, and only a DOM
+  read-back inside the same turn can tell you the page never moved.
+
+  ## What the fix does, and the row that proves it did not overreach
+
+  The microtask is NOT abolished. Notifying synchronously from a mark
+  would recompute and re-render inside the source write — the trap Spec
+  006 invariant 6 forbids — so instead the window gained a SECOND closer
+  that React can see (`re-frame.freehand.checkpoint`), armed by the same
+  first mark and running the same idempotent `cell/flush!`. Inside
+  `flushSync` it takes the sync lane and closes the window before the
+  flush returns; outside it, the microtask closer still gets there first
+  and nothing about ordinary batching changes.
+
+  That second claim is the adversarial one, and
+  [[an-ordinary-write-outside-flushsync-still-batches]] is where it is
+  made: three writes in one task must still leave the DOM untouched until
+  the microtask checkpoint, and must still cost exactly ONE render.
+  Proving the batch survived matters as much as proving the flush works.
+
+  Rides the browser lane through its `-dom-cljs-test` suffix; under the
+  node suites there is no DOM to mount and each row says so rather than
+  passing quietly.
+
+  The adapter is UIx, which is the configuration the defect was measured
+  under, and it is also the stronger claim: the repair lives in the
+  ViewCell registry, not in an adapter, so a Freehand root repaints
+  correctly under a substrate that has never heard of Freehand."
+  (:require ["react-dom" :as react-dom]
+            [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as uix-adapter]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.cell :as cell]
+            [re-frame.freehand.react :as fr]
+            [re-frame.freehand.root :as root]
+            [re-frame.live-frame :as live-frame]
+            [re-frame.test-support :as test-support]))
+
+(def ^:private runtime-fixture
+  (test-support/make-reset-runtime-fixture
+    {:adapter       uix-adapter/adapter
+     :ambient-frame nil
+     :async?        true}))
+
+(defn- leave-act-environment!
+  "Every row here is about REAL host scheduling — a sync lane, a
+  microtask, a task, a frame. Inside React's `act` environment React
+  diverts that work to act's own queue, so an assertion made there would
+  be about act's drain order rather than about the substrate."
+  []
+  (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
+  nil)
+
+(use-fixtures :each
+  {:before (fn []
+             (root/reset-registry!)
+             (fr/reset-boundaries!)
+             ((:before runtime-fixture))
+             (leave-act-environment!))
+   :after  (fn []
+             ((:after runtime-fixture))
+             (root/reset-registry!)
+             (fr/reset-boundaries!))})
+
+(defn- browser? []
+  (and (exists? js/document) (some? (.-createElement js/document))))
+
+(defn- skip! [why]
+  (is true (str "a real React mount needs a DOM host — " why)))
+
+;; ---------------------------------------------------------------------------
+;; The application under test
+;; ---------------------------------------------------------------------------
+
+(def ^:private renders
+  "How many times the view body has run. A render counter in a view body
+  is a side effect, and deliberate: it is the only way to say `ONE
+  render` about a batch, and nothing here runs under StrictMode's
+  double-invoke."
+  (atom 0))
+
+(v/defview counter
+  "The smallest view that can show the defect: one reactive read, whose
+  value is the whole of the DOM under test."
+  [_]
+  (swap! renders inc)
+  [:div.counter [:output.count (str (v/sub [::count]))]])
+
+(v/defview app [_] [:main#fh-flush-sync [counter {}]])
+
+(defn- register! []
+  (rf/reg-sub ::count (fn [db _] (:count db)))
+  (rf/reg-event ::set (fn [{:keys [db]} [_ n]] {:db (assoc db :count n)})))
+
+(defn- seed! [frame-id db]
+  (live-frame/make-frame {:id frame-id})
+  (frame/replace-app-db! frame-id db)
+  frame-id)
+
+(defn- text [container]
+  (some-> (.querySelector container ".count") .-textContent))
+
+(defn- host-node! []
+  (let [container (js/document.createElement "div")]
+    (.appendChild js/document.body container)
+    container))
+
+(defn- mount!
+  "Mount inside `flushSync` so the page is on screen when this returns —
+  the same shape the B6 measurement mounts its Freehand arms with, and
+  the one that keeps every row below free of an initial yield."
+  [container frame-id disambiguator]
+  (react-dom/flushSync
+    (fn [] (v/mount [app {}] container {:frame         frame-id
+                                        :disambiguator disambiguator}))))
+
+;; The write the defect was measured with — an out-of-band store write,
+;; not a dispatch, so nothing in the router's drain can be credited with
+;; the repair. `dispatch-sync` gets its own row below.
+(defn- write! [frame-id n]
+  (frame/replace-app-db! frame-id {:count n}))
+
+(defn- microtask [] (js/Promise.resolve nil))
+
+(defn- macrotask []
+  (js/Promise. (fn [resolve] (js/setTimeout #(resolve nil) 0))))
+
+(defn- animation-frame []
+  (js/Promise. (fn [resolve] (js/requestAnimationFrame #(resolve nil)))))
+
+(defn- teardown! [mounted container]
+  (react-dom/flushSync (fn [] (v/unmount! mounted)))
+  (.remove container)
+  nil)
+
+;; ===========================================================================
+;; Case 1 — the defect itself
+;; ===========================================================================
+
+(deftest a-write-inside-flushsync-repaints-before-it-returns
+  (testing "The row rf2-w2m25 exists for. The write moves app-db INSIDE
+            `react-dom/flushSync`; the subscription recomputes and the
+            ViewCell is marked; and the DOM must already carry the new
+            value on the very next line, with no yield of any kind between
+            the flush returning and the read. Before the fix this read the
+            OLD value and nothing said so."
+    (if-not (browser?)
+      (skip! "the browser job runs the flushSync assertions")
+      (async done
+        (register!)
+        (let [fid       (seed! ::flush-sync-write {:count 0})
+              container (host-node!)
+              mounted   (mount! container fid :case-1)]
+          (is (= "0" (text container)) "the page mounted showing the seeded value")
+          (react-dom/flushSync (fn [] (write! fid 4242)))
+          (is (= 4242 (:count (frame/frame-app-db-value fid)))
+              "the store really was written inside the flush")
+          (is (= "4242" (text container))
+              "and the DOM already shows it — NO microtask, NO act queue, NO
+               yield between flushSync returning and this read")
+          (is (zero? (cell/pending-count))
+              "the pending window is quiescent, not merely drained-and-refilled")
+          (teardown! mounted container)
+          (done))))))
+
+;; ===========================================================================
+;; Cases 2, 3, 4 — the three that always worked, and still must
+;; ===========================================================================
+
+(deftest a-write-then-a-microtask-then-an-empty-flushsync-repaints
+  (testing "Case 2 of the measured four: the workaround the B6 update row
+            had to be shaped around. The write's own microtask closes the
+            window and the empty `flushSync` commits it. It must keep
+            working — a fix that moved the notification onto the sync lane
+            and off the microtask would break exactly this."
+    (if-not (browser?)
+      (skip! "the browser job runs the microtask assertions")
+      (async done
+        (register!)
+        (let [fid       (seed! ::flush-sync-microtask {:count 0})
+              container (host-node!)
+              mounted   (mount! container fid :case-2)]
+          (is (= "0" (text container)))
+          (write! fid 7)
+          (-> (microtask)
+              (.then (fn [_]
+                       (react-dom/flushSync (fn [] nil))
+                       (is (= "7" (text container))
+                           "one yielded microtask plus an empty forced drain
+                            later, the page is current")
+                       (teardown! mounted container)
+                       (done)))
+              (.catch (fn [e]
+                        (is false (str "microtask arm rejected: " e))
+                        (teardown! mounted container)
+                        (done)))))))))
+
+(deftest a-write-then-a-task-repaints
+  (testing "Case 3: nothing forces anything. The write is made and one
+            browser TASK is yielded, which is strictly later than the
+            microtask checkpoint the window closes at, so the page must be
+            current with no flush of any kind involved."
+    (if-not (browser?)
+      (skip! "the browser job runs the task assertions")
+      (async done
+        (register!)
+        (let [fid       (seed! ::flush-sync-task {:count 0})
+              container (host-node!)
+              mounted   (mount! container fid :case-3)]
+          (is (= "0" (text container)))
+          (write! fid 11)
+          (-> (macrotask)
+              (.then (fn [_]
+                       (is (= "11" (text container))
+                           "a yielded task is enough on its own — the automatic
+                            repaint channel, unforced")
+                       (teardown! mounted container)
+                       (done)))
+              (.catch (fn [e]
+                        (is false (str "task arm rejected: " e))
+                        (teardown! mounted container)
+                        (done)))))))))
+
+(deftest a-write-then-an-animation-frame-repaints
+  (testing "Case 4: the same claim taken at the paint boundary. The
+            window's microtask checkpoint runs BEFORE the next paint, so a
+            page read inside `requestAnimationFrame` can never show a torn
+            frame."
+    (if-not (browser?)
+      (skip! "the browser job runs the animation-frame assertions")
+      (async done
+        (register!)
+        (let [fid       (seed! ::flush-sync-raf {:count 0})
+              container (host-node!)
+              mounted   (mount! container fid :case-4)]
+          (is (= "0" (text container)))
+          (write! fid 23)
+          (-> (animation-frame)
+              (.then (fn [_]
+                       (is (= "23" (text container))
+                           "current before the frame the browser was about to
+                            paint")
+                       (teardown! mounted container)
+                       (done)))
+              (.catch (fn [e]
+                        (is false (str "animation-frame arm rejected: " e))
+                        (teardown! mounted container)
+                        (done)))))))))
+
+;; ===========================================================================
+;; The adversarial row — batching is UNCHANGED
+;; ===========================================================================
+
+(deftest an-ordinary-write-outside-flushsync-still-batches
+  (testing "The half of the fix that is easiest to break and hardest to
+            notice. Three writes in ONE task, with no flush anywhere, must
+            behave exactly as they did before: nothing repaints while the
+            stack is still unwinding, the pending window stays OPEN across
+            all three, and the whole batch costs exactly ONE render at the
+            microtask checkpoint — not three, and not one per write.
+
+            A repair that made a mark notify synchronously would pass every
+            row above and fail this one, which is why it is here."
+    (if-not (browser?)
+      (skip! "the browser job runs the batching assertions")
+      (async done
+        (register!)
+        (let [fid       (seed! ::flush-sync-batch {:count 0})
+              container (host-node!)
+              mounted   (mount! container fid :case-batch)]
+          (is (= "0" (text container)))
+          (let [before @renders]
+            (write! fid 1)
+            (write! fid 2)
+            (write! fid 3)
+            (is (= "0" (text container))
+                "NOTHING repainted while the stack was still unwinding — three
+                 source writes scheduled work, they did not perform it")
+            (is (pos? (cell/pending-count))
+                "and the pending window is still open, holding all three")
+            (is (= before @renders)
+                "so the view body has not run again either")
+            (-> (microtask)
+                (.then (fn [_]
+                         (is (zero? (cell/pending-count))
+                             "ONE microtask checkpoint later the window is
+                              closed — all three writes, one close")
+                         (macrotask)))
+                (.then (fn [_]
+                         (is (= "3" (text container))
+                             "and the page shows the LAST write")
+                         (is (= 1 (- @renders before))
+                             (str "with the three writes coalesced into exactly
+                                   ONE render — " (- @renders before)
+                                  " observed"))
+                         (macrotask)))
+                (.then (fn [_]
+                         (is (= 1 (- @renders before))
+                             "and nothing rendered afterwards either — the
+                              host-visible closer adds no second pass over the
+                              application's own tree")
+                         (is (= "3" (text container)))
+                         (teardown! mounted container)
+                         (done)))
+                (.catch (fn [e]
+                          (is false (str "batching arm rejected: " e))
+                          (teardown! mounted container)
+                          (done))))))))))
+
+;; ===========================================================================
+;; The other doors the bead named
+;; ===========================================================================
+
+(deftest a-dispatch-sync-inside-flushsync-repaints-before-it-returns
+  (testing "The bead measured three write doors and none of them committed
+            inside the flush. `frame/replace-app-db!` is the row above;
+            this is `rf/dispatch-sync`, which runs a whole
+            run-to-completion drain inside the callback. The drain still
+            cannot be split — the window cannot close while the stack is
+            unwinding — but it must be closed by the time the flush
+            returns."
+    (if-not (browser?)
+      (skip! "the browser job runs the dispatch-sync assertions")
+      (async done
+        (register!)
+        (let [fid       (seed! ::flush-sync-dispatch {:count 0})
+              container (host-node!)
+              mounted   (mount! container fid :case-dispatch)]
+          (is (= "0" (text container)))
+          (react-dom/flushSync
+            (fn [] (rf/dispatch-sync [::set 99] {:frame fid})))
+          (is (= "99" (text container))
+              "the event drained and the page committed, both inside the flush")
+          (teardown! mounted container)
+          (done))))))
+
+;; ===========================================================================
+;; Non-vacuity
+;; ===========================================================================
+
+(deftest the-proof-is-not-vacuous
+  (testing "Every row above rests on the installed adapter really being
+            UIx — the configuration the defect was measured under, and a
+            substrate that knows nothing about Freehand — and on the view
+            really being a reactive declaration. Without this row a suite
+            that had quietly run on Freehand's own adapter, or on a view
+            whose body read nothing, would be green for the wrong reason."
+    (is (= :rf.adapter/uix (rf/current-adapter))
+        "the fixture installed the UIx adapter, not Freehand's own")
+    (is (v/view? counter) "the subject is a declared view")
+    (is (= :interpreted (:lowering (v/describe counter)))
+        "on the interpreted paved path")))


### PR DESCRIPTION
Fixes **rf2-w2m25** (P1). A mounted Freehand view whose body reads `(v/sub …)` was **not repainted** by a state write made inside `react-dom/flushSync`. Found by the Freehand-vs-Reagent measurement (rf2-dq20a), on the UIx adapter, in a real browser.

## Root cause

`cell/mark-dirty!` is constant work: it records the cause, enrols the cell in the open pending window, and arms a `js/queueMicrotask`. It schedules **no React work at all** — no component re-renders, no setState lands, no root is scheduled. `react-dom/flushSync` returns as soon as the work *scheduled inside its callback* has committed, so it committed nothing, and said nothing about it.

## What changed about the scheduling, and why

**The microtask is not abolished.** Making a mark notify synchronously would recompute and re-render inside the source write — the trap Spec 006 invariant 6 exists to forbid — and would dissolve the coalescing every batch in the substrate rests on. It is also the `:auto-run true` shape PR #7118 considered and rejected for the ratom family.

Instead the pending window gains a **second closer**, armed by the same first mark and running the same idempotent `cell/flush!`:

- `cell.cljc` grows one slot (`set-host-window-closer!`) and calls it from `schedule-flush!`, *after* arming the microtask and inside a `try` — the guaranteed closer can never be lost to a host closer that throws, and a mark has no caller to report a scheduling failure to. The namespace stays `.cljc` and host-agnostic: it knows what a checkpoint means and nothing about React.
- New `re-frame.freehand.checkpoint` (CLJS) fills the slot at load. It renders one nil-returning sentinel into a lazily-created **detached** React root; the sentinel's **layout** effect calls `cell/flush!`. Layout rather than passive because `flushSync` *always* runs layout effects synchronously — a documented guarantee — while its flushing of passive effects is a React-19 implementation detail.

The two closers then sort themselves out by lane, which is the whole point:

- **inside `flushSync`** an update issued during the callback takes the **sync lane**, so React renders the sentinel, runs its layout effect, closes the window, and flushes the cells' resulting `useSyncExternalStore` updates (also sync lane) before `flushSync` returns.
- **outside it** the sentinel render takes the default lane and React gets to it later — by which time the microtask closer, armed **first** and therefore FIFO-first, has already closed the window. The sentinel's effect finds nothing pending and does nothing.

Neither closer can run while the marking stack is still unwinding, so Spec 006 §Render-batch finalization guarantees 1 and 2 (a run-to-completion drain cannot be split; N epochs in one drain coalesce into one batch) hold unchanged. What changed is only *which* checkpoint may close a window a synchronous commit is waiting on.

A detached root of its own, rather than a sentinel in the app tree, because `v/->react` mounts a ViewCell inside a *foreign* React tree with no Freehand root in sight — and `flushSync` flushes sync work across all roots, so being separate costs the mechanism nothing. Same shape as the spine's after-render driver root (rf2-t0x90).

## The four measured cases

All four are pinned by the new `implementation/freehand/test/re_frame/freehand/flush_sync_dom_cljs_test.cljs`, under the **UIx adapter** — the configuration the defect was measured under, and the stronger claim, since the repair lives in the ViewCell registry rather than in any adapter.

| case | before | after |
|---|---|---|
| 1. `flushSync(write)` | **FAIL** — DOM read `"0"`, expected `"4242"`; `pending-count` 1 | **PASS** |
| 2. `write` → microtask → `flushSync(noop)` | pass | **PASS** |
| 3. `write` → `setTimeout 0` | pass | **PASS** |
| 4. `write` → `requestAnimationFrame` | pass | **PASS** |
| (also) `flushSync(dispatch-sync)` | **FAIL** — DOM read `"0"`, expected `"99"` | **PASS** |

Reproduced first, in a real browser, on the unmodified tree: `npm run test:browser` reported **5 failures, 0 errors** across 824 tests — all five in `re-frame.freehand.flush-sync-dom-cljs-test`, and nothing else in the browser suite red. Verbatim:

```
FAIL in (a-write-inside-flushsync-repaints-before-it-returns)
  and the DOM already shows it — NO microtask, NO act queue, NO yield ...
  expected: (= "4242" (text container))
    actual: (not (= "4242" "0"))
FAIL in (a-write-inside-flushsync-repaints-before-it-returns)
  the pending window is quiescent, not merely drained-and-refilled
  expected: (zero? (cell/pending-count))
    actual: (not (zero? 1))
FAIL in (a-dispatch-sync-inside-flushsync-repaints-before-it-returns)
  expected: (= "99" (text container))
    actual: (not (= "99" "0"))
```

## Evidence that ordinary batching is unaffected

`an-ordinary-write-outside-flushsync-still-batches` is the adversarial row, and it is deliberately the one a synchronous-notification "fix" would fail. Three writes in **one** task, no flush anywhere:

- the DOM is **unchanged** while the stack is still unwinding — three source writes scheduled work, they did not perform it;
- `cell/pending-count` is still **positive** — the window is open, holding all three;
- the view body has **not** run again;
- one microtask checkpoint later the window is **closed** (`pending-count` zero);
- the page then shows the **last** write, at a cost of **exactly one** render — asserted again a task later, so the host-visible closer is proven to add no second pass over the application's own tree.

Those first three assertions passed identically before and after the change, which is what makes them a baseline rather than a hope.

Beyond that row: the whole browser suite (824 tests) is green, including `substrate_dom_cljs_test`'s automatic-repaint and `flush-render!`-returns-settled rows, `controlled_input_dom_cljs_test` (the D009 frame-scoped synchronous flush), and every adapter suite.

## The B6 flip (rf2-0fgth) — now in this PR

PR #7131 merged `implementation/freehand/test/re_frame/freehand/bench/b6_update_dom_cljs_test.cljs` to `main`, and it contains `a-freehand-write-does-not-commit-inside-flushsync` — a test that pins the **defect** this PR fixes. Rebased onto `origin/main` at `1bb9b6157f` (clean, no conflicts) and flipped it here, because the flip is only correct once the fix exists.

- **Renamed** to `a-freehand-write-commits-inside-flushsync`. Not deleted, not loosened to accept both outcomes: it is the only coverage of this case in the bench and it has to catch a regression in **either** direction. A name saying "does-not-commit" over an assertion that it does would be its own defect.
- It now asserts **both legs**: `flushSync(write)` reaches the DOM before the flush returns (the new guarantee), *and* the microtask window the row is still measured through (`write` → microtask → `force!`) still lands its write — so the row's non-vacuity does not come to rest on the very thing that just changed.
- The **four-way docstring table** gains a `since rf2-w2m25` column, and the paragraph that derived the measurement window's shape from the defect now says plainly that the defect is fixed, that the row has **not** been re-taken, and that the window is now re-takeable as `flushSync(write)` on all four arms.
- `b6_rows.cljs` carried the same claim inside the published `:measurement-method` **provenance string**, which would otherwise ship a false statement with every measurement. Corrected to past tense, with the re-takeability stated.
- The B6 report (`docs/design/freehand/studio/freehand-vs-reagent.md`) §2b is marked **resolved** — kept in the past tense as the record of what was measured, since that is what shaped the whole instrument — and its dangling reference to the old test name is repointed.

**The update row was NOT re-taken.** Re-taking means a full 3-round × (3 warmup + 8 samples) × 4-arm × 2-row bench pass and a fresh set of published figures. The numbers on `main` remain honest for the window they were taken through, and the docstring, the provenance string and the report now all say which window that is.

### Residual, stated so it is not absorbed silently

The fix arms **one extra React commit per render batch** — the two-fiber detached root rendering nil, plus its layout effect. Outside `flushSync` the microtask closer still gets there first, so that commit lands **after** the measured window and finds nothing pending; but it is real wall-clock, and B6's update row is exactly where it would show. It would move **inside** a re-taken `flushSync(write)` window. Whoever re-takes those numbers should report it rather than absorb it — that instruction is now in the test docstring, in the report's recommendation list, and on rf2-0fgth.

## Quality gates

Re-run in full after the rebase.

| gate | exit |
|---|---|
| `npm run test:browser` (`BROWSER_TEST_TIMEOUT_MS=600000`) — 833 tests, 5313 assertions, 0 failures, 0 errors | **0** |
| `npm run bench:freehand-browser` — 23 tests, 316 assertions, 0 failures, 0 errors (the focused B6 lane: the flipped row **and** both live update rows) | **0** |
| `npm run test:cljs` — 11787 tests, 58678 assertions, 0 failures, 0 errors | **0** |
| `npm run test:freehand` (node) — 1297 tests, 7194 assertions, 0 failures, 0 errors | **0** |
| `implementation/freehand` JVM `clojure -M:test` — 1218 tests, 8212 assertions, 0 failures, 0 errors | **0** |
| `npx shadow-cljs compile browser-test` — 1070 files, 0 warnings | **0** |

Everything slower — the full `scripts/test-fast-pr.sh` spine, the release/elision/bundle-isolation gates, mcp-conformance, the adapter smokes, `mkdocs build --strict` — is **deferred to CI**.

## Follow-ons filed

- **rf2-mo5mk** — the Spec 006 sentence. `spec/**` is hot-zone, so this PR touches none of it; §Render-batch finalization currently enumerates the window's closers as "the next CLJS host microtask checkpoint, or an explicit headless/test flush" and now needs the third.
- **rf2-0fgth** — the B6 flip. **Done in this PR** (section above) and closed. The un-re-taken update row is recorded in the test docstring, the provenance string and the report rather than left as an open bead.
