### PR TITLE
fix(pair-mcp): (A) err->result relays the ex-message too, not just ex-data (rf2-6tzm5)

### DIFF
--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/server.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/server.cljs
@@ -529,7 +529,26 @@
   through `wire/result` so the structuredContent projection preserves
   keyword namespaces (a raw `clj->js` would truncate `:rf.error/*` reason
   values). Shared by the connected path (`handle-call*`) and the
-  closed-world pre-connection path (`handle-call-local`)."
+  closed-world pre-connection path (`handle-call-local`).
+
+  ## RELAY 1 of two — this one keeps the MESSAGE
+
+  pair-mcp has exactly two consumer-facing error relays, and WHERE in a
+  tool body a throw fires decides which one it meets. This one is
+  reached by anything thrown while the tool body BUILDS its request,
+  before the nREPL round-trip; `probe/err->result` (relay 2) is reached
+  by anything thrown from an `eval-after-runtime!` `on-value` callback,
+  i.e. all response shaping after it. So a throw site's ex-message is
+  load-bearing HERE and its ex-data is dropped — the reverse of what a
+  reader who has only seen relay 2 would assume.
+
+  That asymmetry is a known wart, half-fixed: relay 2 now carries both
+  halves (rf2-6tzm5), while this relay still drops `(ex-data err)` —
+  including the `:rf.error/id` an agent would rather branch on than
+  regex out of the message. rf2-qoih4 tracks closing it. Until then,
+  a throw site reached from here MUST put its actionable content in the
+  message; `tools/eval_form.cljs` `emit-name` is the live example, and
+  `error_boundary_test` pins both relays at the real MCP boundary."
   [conn name args extra]
   (-> (tools/invoke conn name args extra)
       (.catch (fn [err]

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/probe.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/probe.cljs
@@ -746,11 +746,40 @@
   `wire/err-text` (not `wire/ok-text`) is what makes that true: the host
   surfaces the failure to the LLM as an error rather than a success-shaped
   value, AND the response cache (which bypasses `:isError` results) can no
-  longer cache a transient failure and mask a later successful read."
+  longer cache a transient failure and mask a later successful read.
+
+  ## RELAY 2 of two — and it carries BOTH halves of the exception
+
+  pair-mcp has exactly two consumer-facing error relays, and WHERE in a
+  tool body a throw fires decides which one it meets:
+
+    - `server.cljs` `invoke-and-guard` (relay 1) — reached by anything
+      thrown while the tool body BUILDS its request, before the nREPL
+      round-trip. Keeps the message; drops the ex-data (rf2-qoih4).
+    - this fn (relay 2) — reached by anything thrown from an
+      `eval-after-runtime!` / `eval-after-runtime-signalled!`
+      `on-value` callback, i.e. ALL response shaping, after the
+      round-trip.
+
+  Relay 2 used to keep only the ex-data, dropping `(ex-message err)`
+  entirely — so a Spec 009 canonical message composed at a
+  response-shaping throw site (`wire-pipeline`'s unknown-`:kind` being
+  the live example) reached NO consumer, and any future author writing
+  one there would silently waste it (rf2-6tzm5). It now merges the
+  message in alongside, matching `result_envelope/envelope->result`,
+  which already ships `:reason` + `:message` + `:ex-data` together on
+  this same eval-path error surface.
+
+  `data` merges OVER the derived `:message`, so an ex-data map that
+  deliberately carries its own `:message` still wins. A blank/absent
+  ex-message adds no slot rather than shipping `:message nil`."
   [fallback-reason err]
-  (if-let [data (ex-data err)]
-    (wire/err-text (merge {:ok? false} data))
-    (wire/err-text {:ok? false :reason fallback-reason :message (.-message err)})))
+  (let [msg (.-message err)]
+    (if-let [data (ex-data err)]
+      (wire/err-text (merge (cond-> {:ok? false}
+                              (not-empty msg) (assoc :message msg))
+                            data))
+      (wire/err-text {:ok? false :reason fallback-reason :message msg}))))
 
 ;; ---------------------------------------------------------------------------
 ;; Shared eval-prelude.

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/wire_pipeline.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/wire_pipeline.cljs
@@ -267,11 +267,19 @@
           :scalar-value (run-scalar-value payload opts)
           ;; Canonical thrown-error shape per Spec 009 §The thrown-error shape:
           ;; the human sentence + a trailing `[:rf.error/<id>]` token IS the
-          ;; ex-message. Load-bearing here (rf2-jquiy) — `server.cljs`'s
-          ;; `invoke-and-guard` relays `(.-message err)` into the
-          ;; `:handler-threw` envelope, so this text is what the agent on the
-          ;; other end of the MCP wire reads. Hand-rolled inline: `tools/`
-          ;; MUST NOT `:require re-frame.*`.
+          ;; ex-message. Load-bearing here (rf2-jquiy), but via RELAY 2, not
+          ;; relay 1: all five `run-wire-pipeline` call sites sit inside an
+          ;; `eval-after-runtime!` `on-value`, so this throw fires during
+          ;; response shaping and meets `probe/err->result` — NOT
+          ;; `server.cljs`'s `invoke-and-guard`, which only catches throws
+          ;; raised before the nREPL round-trip. The two relays keep opposite
+          ;; halves of the exception; `err->result` merges both since
+          ;; rf2-6tzm5, which is what makes this message reach the agent at
+          ;; all (before it, only the ex-data below did, and this text was
+          ;; dead prose). The ex-data therefore carries the agent's branchable
+          ;; slots — `:rf.error/id`, `:kind`, `:valid` — and the message
+          ;; carries the sentence; `error_boundary_test` pins both.
+          ;; Hand-rolled inline: `tools/` MUST NOT `:require re-frame.*`.
           (throw (ex-info (str "run-wire-pipeline got an unknown :kind "
                                (pr-str kind)
                                " — expected one of :snapshot-map, :epoch-vector, "

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/error_boundary_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/error_boundary_test.cljs
@@ -16,19 +16,19 @@
 
   `tools/re-frame2-pair-mcp/src` has exactly four `throw` sites, and a
   throw reaches the agent by one of two DIFFERENT relays depending on
-  WHERE in a tool body it fires. The two relays keep opposite halves of
-  the exception:
+  WHERE in a tool body it fires. The relays are still asymmetric, but
+  only one-sidedly so now:
 
   - `server.cljs` `invoke-and-guard` → `{:reason :handler-threw :message
     (.-message err)}`. Keeps the MESSAGE, drops the ex-data. Reached by
     anything thrown while the tool body builds its request — before the
-    nREPL round-trip.
+    nREPL round-trip. (Its dropped ex-data half is rf2-qoih4.)
 
-  - `tools/probe.cljs` `err->result` → `(merge {:ok? false} (ex-data
-    err))`. Keeps the EX-DATA, drops the message entirely. Reached by
-    anything thrown from the `on-value` callback of
-    `eval-after-runtime!` / `eval-after-runtime-signalled!` — i.e. all
-    response shaping, after the round-trip.
+  - `tools/probe.cljs` `err->result` → the ex-data merged over
+    `{:ok? false :message (ex-message err)}`. Carries BOTH halves since
+    rf2-6tzm5. Reached by anything thrown from the `on-value` callback
+    of `eval-after-runtime!` / `eval-after-runtime-signalled!` — i.e.
+    all response shaping, after the round-trip.
 
   Which relay a given throw meets decides which half of the Spec 009
   shape the agent can read, so each is pinned here at its own boundary:
@@ -41,10 +41,13 @@
   - **unknown wire `:kind`** (`tools/wire-pipeline` `run-wire-pipeline`)
     fires only from response shaping — all five call sites across
     `snapshot`, `get-path`, `read-sub`, `trace-window` and `watch-epochs`
-    sit inside an `on-value` callback — so it meets `err->result`, whose
-    ex-data half carries the agent's sentence in `:reason` and its
-    discriminator in `:rf.error/id`. That is what the second test pins.
-    Its ex-MESSAGE is unreachable by any consumer; see rf2-6tzm5.
+    sit inside an `on-value` callback — so it meets `err->result`. The
+    second test pins BOTH halves it now relays: the ex-data's `:reason`
+    sentence and `:rf.error/id` discriminator, AND the ex-message's own
+    sentence plus trailing token. Before rf2-6tzm5 that message reached
+    no consumer at all, which is precisely why it needs a tripwire: a
+    relay that silently discards a canonical message is invisible to
+    every test that only reads ex-data.
 
   The other two throws (`server.cljs`'s `:rf.error/pair-mcp-ambiguous-shadow`
   and `:rf.error/pair-mcp-nrepl-port-not-found`) are raised inside discovery
@@ -202,12 +205,15 @@
         done))))
 
 ;; ---------------------------------------------------------------------------
-;; Relay 2 — `probe/err->result`: the EX-DATA is the consumer contract.
+;; Relay 2 — `probe/err->result`: the EX-DATA *and* the MESSAGE are the
+;; consumer contract (rf2-6tzm5 — the message half used to be dropped).
 ;; ---------------------------------------------------------------------------
 
 (deftest unknown-wire-pipeline-kind-reaches-the-agent-as-readable-ex-data
   ;; Reverting the ex-data's `:reason` to a bare keyword reds the sentence
-  ;; assertion; dropping `:rf.error/id` reds the discriminator assertion.
+  ;; assertion; dropping `:rf.error/id` reds the discriminator assertion;
+  ;; reverting `err->result` to `(merge {:ok? false} data)` — the shape that
+  ;; made this message dead prose — reds the two ex-message assertions.
   (async done
     (let [orig wp/run-wire-pipeline
           ;; The REAL pipeline, handed a `:kind` outside its closed
@@ -235,13 +241,21 @@
                      (pr-str (:reason edn))))
             (is (= :not-a-wire-kind (:kind edn))
                 "along with the actionable slot — WHICH kind was unknown")
-            ;; The finding, made durable. `err->result` relays ex-data and
-            ;; DROPS `(ex-message err)`, so `run-wire-pipeline`'s carefully
-            ;; composed message — and the `[:rf.error/…]` token in it —
-            ;; reaches nobody. If this ever goes non-nil, that is the
-            ;; improvement rf2-6tzm5 asks for: assert the message here and
-            ;; correct the claim in `wire_pipeline.cljs`'s throw comment,
-            ;; which today describes relay 1's behaviour at a relay-2 site.
-            (is (nil? (:message edn))
-                "the ex-MESSAGE does not reach a consumer at this relay")))
+            ;; The tripwire the finding earned (rf2-6tzm5). `err->result`
+            ;; used to relay ex-data and DROP `(ex-message err)`, so
+            ;; `run-wire-pipeline`'s carefully composed message — and the
+            ;; `[:rf.error/…]` token in it — reached nobody. Nothing else on
+            ;; this surface can notice that: every other assertion here reads
+            ;; ex-data, which the old relay preserved. These two rows are the
+            ;; only thing standing between a future `(merge {:ok? false}
+            ;; data)` and a second round of silently dead prose.
+            (let [msg (:message edn)]
+              (is (re-find #"unknown :kind" (str msg))
+                  (str "the ex-MESSAGE reaches the agent at this relay too\n  got: "
+                       (pr-str msg)))
+              (is (str/includes?
+                    (str msg)
+                    "[:rf.error/pair-mcp-unknown-wire-pipeline-kind]")
+                  (str "carrying the canonical [:rf.error/…] token\n  got: "
+                       (pr-str msg))))))
         done))))


### PR DESCRIPTION
Closes rf2-6tzm5.

## The two-relay asymmetry (inherit this, don't rediscover it)

pair-mcp has exactly **two** consumer-facing error relays, and *where in a tool body a throw fires* decides which one it meets. They kept **opposite halves** of the exception:

| | reached by | keeps | drops |
|---|---|---|---|
| **Relay 1** — `server.cljs` `invoke-and-guard` | throws while the tool body **builds its request**, before the nREPL round-trip | the **message** | the ex-data |
| **Relay 2** — `probe.cljs` `err->result` | throws from an `eval-after-runtime!` / `…-signalled!` `on-value` — i.e. **all response shaping**, after the round-trip | the **ex-data** | the **message, entirely** |

All five `run-wire-pipeline` call sites (`snapshot`, `get-path`, `read-sub`, `trace-window`, `watch-epochs`) sit inside an `on-value`, so its unknown-`:kind` throw fires only during response shaping and meets **relay 2**. Its canonical Spec 009 ex-message — human sentence plus trailing `[:rf.error/…]` token — therefore reached **no consumer at all**, while a comment at the throw site asserted relay 1 would carry it. The comment was true of the codebase, false of that site.

## Option taken: **(A)** — make relay 2 carry both halves

Not (B). The bead offered "correct the comment" as the cheap option; the measurement said (A) is nearly as cheap and fixes the actual defect.

```clojure
(let [msg (.-message err)]
  (if-let [data (ex-data err)]
    (wire/err-text (merge (cond-> {:ok? false}
                            (not-empty msg) (assoc :message msg))
                          data))
    (wire/err-text {:ok? false :reason fallback-reason :message msg})))
```

`data` merges **over** the derived `:message`, so an ex-data map that deliberately carries its own `:message` stays authoritative. A blank/absent ex-message adds no slot rather than shipping `:message nil`.

### The evidence that decided it

I checked every consumer of `err->result`'s shape before touching it:

1. **Relay 2 was the outlier, not the norm.** `result_envelope.cljs` `envelope->result` — the sibling error projection on this *same* eval-path surface — already ships `{:ok? false :reason … :ex … :message … :ex-data …}`. A `:message` slot beside a structured reason is the established shape here; `err->result` was the one place it was thrown away.
2. **No key collision.** Zero ex-data payloads in `pair-mcp/src` carry a `:message` key — every one uses `:reason` / `:build` / `:running-builds` / `:hint` / `:err` (checked all 18 `ex-info` sites plus `diagnose-preload-failure!`'s four-branch ladder). `subscribe`'s `:message` and `cap/cap-message` are the *progress-notification* slot, a different path that never reaches this fn.
3. **Nothing pins the key set.** Conformance fixtures assert `:edn-submap` (submap, additive-safe); `probe_test` and `cache_test` assert key-wise. No descriptor enumerates an exhaustive error-key list.
4. **The wire cap already anticipated it.** `cap.cljs` explicitly reasons about "an error response can itself carry an oversize `:message` blob" and caps `:isError` results like any other payload — the byte budget already covers the new slot.
5. **Empirically additive.** Reverting the relay (mutation 2 below) reds *only* the two new assertions out of 4299 — nothing else in the suite reads this slot.

So the blast radius is: every eval-path tool failure gains a `:message` slot carrying information the agent previously could not see. That is the point.

## Mutation proof — the tripwire is live

PR #7127 left a commented tripwire on exactly this dropped message. It is now **active**, and I proved it fails for both reasons it must.

**Mutation 1 — degrade the canonical ex-message** to a bare `(str error-kw)` at the `wire_pipeline` throw site:

```
FAIL in (unknown-wire-pipeline-kind-reaches-the-agent-as-readable-ex-data) (error_boundary_test.cljs:253:19)
  actual: (not (re-find #"unknown :kind" ":rf.error/pair-mcp-unknown-wire-pipeline-kind"))
FAIL ... (error_boundary_test.cljs:256:19)
  actual: (not (str/includes? ":rf.error/…-kind" "[:rf.error/pair-mcp-unknown-wire-pipeline-kind]"))
Ran 1217 tests containing 4299 assertions. 2 failures, 0 errors.   [exit 1]
```

**Mutation 2 — revert the relay** to `(merge {:ok? false} data)`, the shape that made the message dead prose:

```
FAIL ... (error_boundary_test.cljs:253:19)   actual: (not (re-find #"unknown :kind" ""))
FAIL ... (error_boundary_test.cljs:256:19)   actual: (not (str/includes? "" "[:rf.error/…-kind]"))
Ran 1217 tests containing 4299 assertions. 2 failures, 0 errors.   [exit 1]
```

Mutation 1 proves the tripwire guards the *message text*; mutation 2 proves it guards the *relay*. Both restored; `git diff --stat` and `git status --porcelain` both empty at HEAD, and the final full-suite run is green (below). That only 2 of 4299 assertions notice either mutation is the whole argument for the tripwire existing: every other assertion on this surface reads ex-data, which both regressions preserve.

## Comments at both relay sites

Per the brief, the asymmetry is now documented *in place* at both ends — `invoke-and-guard` ("RELAY 1 of two — this one keeps the MESSAGE"), `err->result` ("RELAY 2 of two — and it carries BOTH halves"), and the `wire_pipeline` throw comment corrected to name relay 2 instead of relay 1. A reader landing on any one of the three now sees the other.

## Follow-on

**rf2-qoih4** (P3, filed): relay 1 still drops `(ex-data err)` — the mirror-image defect. A request-construction throw loses its `:rf.error/id`, the machine discriminator an agent would rather branch on than regex out of prose. Not folded in here: it is a distinct blast radius (every `:handler-threw` envelope gains ex-data slots, with the *opposite* merge precedence since relay 1's own `:reason` is the envelope discriminator), and relay 1's consumers are unmeasured. This PR measured relay 2's.

## Quality gates

All foreground, worktree-local logs, exit codes echoed.

| Gate | Command | Exit |
|---|---|---|
| Full pair-mcp suite (`:server-test`) | `npm test` — 1217 tests / 4299 assertions, 0 failures 0 errors | **0** |
| Descriptor manifest | `npm run check:descriptors` — "in sync (35 tools)" | **0** |
| Shipped `:server` build | `npm run build` — 140 files, 0 warnings | **0** |
| MCP-client conformance (pair-mcp) | `npm run test:re-frame2-pair` — "CONFORMANCE GREEN" | **0** |
| Mutation 1 (message degraded) | `npm test` — reds 2 assertions, names the path | **1** (expected) |
| Mutation 2 (relay reverted) | `npm test` — reds the same 2, `msg` nil | **1** (expected) |
| Final suite, restored tree | `npm test` — 0 failures 0 errors | **0** |

Conformance was re-run against the freshly built `:server`, so the shipped artefact is what the harness drove. Deferred to CI: `scripts/test-fast-pr.sh` and the full-spine gates (out of turn budget; CI is the merge gate), plus the live/hermetic conformance lanes that need a running app.

Spec unchanged because neither xray nor machines-viz touched.
