### PR TITLE
test(core): pin the always-on validation surfaces and stop the dev-only observables lying (rf2-bza6e, rf2-7vk3z, rf2-f7qj4)

### DIFF
--- a/implementation/core/test/re_frame/always_on_validation_production_test.clj
+++ b/implementation/core/test/re_frame/always_on_validation_production_test.clj
@@ -1,0 +1,291 @@
+(ns re-frame.always-on-validation-production-test
+  "rf2-bza6e — the two schema-validation surfaces Spec 010 keeps ALWAYS-ON in
+  production, pinned under the REAL gate.
+
+  ## Why this namespace exists
+
+  Spec 010 §Validation order elides validation by default: every `validate-*!`
+  body sits inside `(when re-frame.interop/debug-enabled? …)`, and
+  `spec/Security.md` §Production gates lists \"schema-validation calls\" among
+  what the production gate strips. Under `-Dre-frame.debug=false` roughly a
+  hundred validation call sites genuinely stop running, and four of the
+  namespaces rf2-r9bra triaged fail in the `jvm-core-prod-gate` lane for
+  exactly that reason — correctly, because they are dev-posture tests.
+
+  Spec 010 carves out TWO surfaces from that elision, and until this namespace
+  NEITHER had a test in any lane that runs under the gate:
+
+    1. **Recordable-coeffect `:schema`** (010:165, 010:179) — \"a PRODUCTION
+       HARD ERROR, not the dev-only schema-validation trace\". A recordable
+       coeffect's value — supplied on the dispatch token, replayed from a
+       record, or freshly generated — is validated as it is satisfied; a
+       mismatch emits `:rf.error/cofx-value-invalid` and THROWS, halting the
+       run before the handler sees it. The spec's rationale: \"Folding an
+       out-of-contract value into the durable causal ledger is corrupt state,
+       so the check fires in production too.\"
+
+    2. **The `:rf.schema/at-boundary` interceptor** (010:204, 010:220) —
+       \"Boundary validation runs even when global validation is elided.\" It
+       is the opt-back-in for handlers fed by an untrusted system boundary
+       (HTTP response, websocket frame, postMessage, query string), and it is
+       INVERTED relative to everything else: a no-op in dev (step-1 already
+       ran) and load-bearing only in production.
+
+  That is precisely the shape that dies silently under a load-time gate — a
+  validation call everyone assumes survives, sitting beside a hundred that
+  provably do not. rf2-9c2jf was the same class of defect: `dispatch-sync`
+  running its handler ZERO times under the documented gate, green the whole
+  time, because nothing had ever executed that posture.
+
+  ## How it is pinned
+
+  Modelled on `re-frame.privacy-production-egress-test` (rf2-r9bra). Every
+  assertion outside the one `^:prod-gate`-tagged deftest is
+  POSTURE-INDEPENDENT and must hold in dev AND under the real gate, so this
+  namespace runs in the ordinary `clojure -M:test` suite and joins
+  `scripts/test-core-prod-gate.sh` automatically (that lane's roster is an
+  EXCLUSION list — a new namespace joins by default).
+
+  Posture-independence is not a weakening here, it is the contract: both
+  surfaces are specified to behave IDENTICALLY in both postures. What differs
+  is only WHICH code enforces surface 2 — step-1 `validate-event!` in dev, the
+  boundary interceptor in production — and the observable (the handler does
+  not run) is the same either way.
+
+  The single `^:prod-gate` deftest at the foot is the discriminator that stops
+  the rest passing vacuously. It runs ONLY in the gate lane (the default
+  `:test` alias excludes the tag) and asserts the NEGATIVE control: in this
+  same JVM, a handler carrying the identical `:schema` but NOT referencing
+  `:rf.schema/at-boundary` accepts a non-conforming event, because ordinary
+  step-1 validation really has been elided. Without it, \"the handler did not
+  run\" would prove nothing about which mechanism stopped it.
+
+  Deliberately NOT used: `with-redefs` on `interop/debug-enabled?`. The flag is
+  read once at namespace-load time; a rebind cannot reach it (rf2-f7qj4)."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.error-emit :as error-emit]
+            [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
+            [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.trace :as trace]))
+
+(defn- reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (schemas/clear-schemas-by-frame!)
+  (trace/clear-listeners!)
+  (error-emit/clear-error-listeners!)
+  (rf/init! plain-atom/adapter)
+  ;; `registrar/clear-all!` drops the framework-standard interceptor
+  ;; registrations; `init!` re-seeds them, including `:rf.schema/at-boundary`
+  ;; (`re-frame.spec/register-schema-interceptors!`). Reloading the schemas
+  ;; artefact republishes the late-bind validation hooks the two surfaces
+  ;; under test reach through.
+  (require 're-frame.schemas :reload)
+  (rf/make-frame {:id :rf/default})
+  (rf/with-frame :rf/default
+    (test-fn)))
+
+(use-fixtures :each reset-runtime)
+
+(defn- record-always-on-errors
+  "Capture through the ALWAYS-ON error registry — NOT `register-listener!
+  :trace`, which is dev-only and sees nothing under the production gate.
+  These records are what an off-box shipper receives from a production build."
+  [body-fn]
+  (let [seen (atom [])]
+    (error-emit/register-error-listener! ::rec (fn [r] (swap! seen conj r)))
+    (try (body-fn)
+         (finally (error-emit/unregister-error-listener! ::rec)))
+    @seen))
+
+(defn- record-of [records error-kw]
+  (first (filter #(= error-kw (:error %)) records)))
+
+(defn- db-of [] (rf/app-db-value :rf/default))
+
+;; ===========================================================================
+;; Surface 1 — recordable-coeffect `:schema` is a PRODUCTION hard error
+;; ===========================================================================
+
+(deftest supplied-recordable-value-violating-its-schema-throws-in-every-posture
+  (testing "rf2-bza6e / Spec 010:179 — a recordable coeffect SUPPLIED on the
+            dispatch token (the replay-hole shape) is validated against its
+            `reg-cofx` `:schema` before it folds into the handler context. A
+            mismatch throws `:rf.error/cofx-value-invalid` and the handler
+            never runs, in dev AND under `-Dre-frame.debug=false`. This is the
+            durable-ledger contract: an out-of-contract recordable value is
+            corrupt state whatever the build."
+    (let [ran (atom false)]
+      (rf/reg-cofx :prod/positive
+        {:recordable? true :schema [:int {:min 1}]}
+        (fn [] 1))
+      (rf/reg-event :prod/uses-positive
+        {:rf.cofx/requires [:prod/positive]}
+        (fn [{:keys [db]} _]
+          (reset! ran true)
+          {:db (assoc db :folded true)}))
+      (let [records (atom nil)
+            ex      (atom nil)]
+        (reset! records
+                (record-always-on-errors
+                  (fn []
+                    (reset! ex (try (rf/dispatch-sync [:prod/uses-positive]
+                                                      {:rf.cofx {:prod/positive -5}})
+                                    nil
+                                    (catch clojure.lang.ExceptionInfo e e))))))
+        (is (some? @ex)
+            "the dispatch THREW rather than folding the out-of-contract value")
+        (is (= :rf.error/cofx-value-invalid (:rf.error/id (ex-data @ex)))
+            "the throw is the specified hard error, not a generic failure")
+        (is (= :prod/positive (:rf.cofx/id (ex-data @ex)))
+            "the ex-data names the offending recordable fact")
+        (is (false? @ran)
+            "the handler never ran — the run halted before the fold")
+        (is (nil? (:folded (db-of)))
+            "app-db is untouched: nothing from the halted run committed")
+        (let [err (record-of @records :rf.error/cofx-value-invalid)]
+          (is (some? err)
+              (str "the ALWAYS-ON error record fired. Red here under the gate "
+                   "means recordable-coeffect validation is elided in "
+                   "production, contradicting Spec 010:179 — an "
+                   "operator-grade finding, not a test-spelling problem."))
+          ;; The offending COFX id rides the throw's `ex-data`, asserted above.
+          ;; It is deliberately absent from the always-on record: this category
+          ;; passes the EVENT id as `:failing-id`, and `emit-error-both!` lifts
+          ;; `:failing-id` / `:reason` onto the record only when they differ
+          ;; from `:event-id`. So the record names the dispatch, not the fact.
+          (is (= :prod/uses-positive (:event-id err))
+              "the off-box record attributes the failure to the dispatch")
+          (is (= :rf/default (:frame err))
+              "and to the owning frame, so a shipper can route it"))))))
+
+(deftest conforming-recordable-value-still-folds-in-every-posture
+  (testing "rf2-bza6e — the negative control for surface 1. A CONFORMING
+            supplied value passes the always-on check and folds normally, so
+            the assertion above is about the schema and not about recordable
+            coeffects being broken outright."
+    (let [seen (atom nil)]
+      (rf/reg-cofx :prod/positive
+        {:recordable? true :schema [:int {:min 1}]}
+        (fn [] 1))
+      (rf/reg-event :prod/uses-positive
+        {:rf.cofx/requires [:prod/positive]}
+        (fn [{:keys [db prod/positive]} _]
+          (reset! seen positive)
+          {:db (assoc db :folded positive)}))
+      (rf/dispatch-sync [:prod/uses-positive] {:rf.cofx {:prod/positive 7}})
+      (is (= 7 @seen) "the conforming supplied value reached the handler")
+      (is (= 7 (:folded (db-of))) "and committed to app-db"))))
+
+(deftest generated-recordable-value-violating-its-schema-throws-in-every-posture
+  (testing "rf2-bza6e / Spec 010:165 — the same hard error on the GENERATED
+            arm. A generator-backed recordable fact runs at processing-start
+            and its produced value is validated BEFORE the write-back into the
+            durable `:rf.cofx` record, so a bad generator cannot poison the
+            epoch ledger in production any more than in dev."
+    (let [ran (atom false)]
+      (rf/reg-cofx :prod/generated-positive
+        {:recordable? true :schema [:int {:min 1}]}
+        (fn [] -5))                                  ;; violates its own schema
+      (rf/reg-event :prod/uses-generated
+        {:rf.cofx/requires [:prod/generated-positive]}
+        (fn [_ _] (reset! ran true) {}))
+      (let [records (atom nil)
+            ex      (atom nil)]
+        (reset! records
+                (record-always-on-errors
+                  (fn []
+                    (reset! ex (try (rf/dispatch-sync [:prod/uses-generated])
+                                    nil
+                                    (catch clojure.lang.ExceptionInfo e e))))))
+        (is (some? @ex) "the generated mismatch threw")
+        (is (= :rf.error/cofx-value-invalid (:rf.error/id (ex-data @ex))))
+        (is (false? @ran) "the handler never ran")
+        (is (some? (record-of @records :rf.error/cofx-value-invalid))
+            "the always-on error record fired for the generated arm too")))))
+
+;; ===========================================================================
+;; Surface 2 — `:rf.schema/at-boundary` runs even when global validation is
+;;             elided
+;; ===========================================================================
+
+(deftest at-boundary-rejects-a-non-conforming-event-in-every-posture
+  (testing "rf2-bza6e / Spec 010:220 — a handler that REFERENCES
+            `:rf.schema/at-boundary` does not run on an event that fails its
+            `:schema`, in dev AND under `-Dre-frame.debug=false`. The
+            enforcing code differs by posture (step-1 `validate-event!` in
+            dev, the boundary interceptor in production); the observable — the
+            handler is skipped and app-db is untouched — does not.
+
+            Red here under the gate means an untrusted system-boundary payload
+            reaches its handler unvalidated in production. That is a live
+            defect of the rf2-9c2jf class, not a test-spelling problem."
+    (let [calls (atom 0)]
+      (rf/reg-event :prod/boundary
+        {:schema       [:cat [:= :prod/boundary] :int]
+         :interceptors [:rf.schema/at-boundary]}
+        (fn [{:keys [db]} [_ n]]
+          (swap! calls inc)
+          {:db (assoc db :n n)}))
+      (rf/dispatch-sync [:prod/boundary "not-an-int"])
+      (is (zero? @calls)
+          "the handler was SKIPPED on the non-conforming payload")
+      (is (nil? (:n (db-of)))
+          "and nothing from it committed to app-db"))))
+
+(deftest at-boundary-passes-a-conforming-event-through-in-every-posture
+  (testing "rf2-bza6e — the negative control for surface 2. The boundary
+            interceptor is not simply breaking every dispatch: a CONFORMING
+            payload flows through and the handler runs exactly once, in both
+            postures."
+    (let [calls (atom 0)]
+      (rf/reg-event :prod/boundary
+        {:schema       [:cat [:= :prod/boundary] :int]
+         :interceptors [:rf.schema/at-boundary]}
+        (fn [{:keys [db]} [_ n]]
+          (swap! calls inc)
+          {:db (assoc db :n n)}))
+      (rf/dispatch-sync [:prod/boundary 42])
+      (is (= 1 @calls) "the conforming payload reached the handler")
+      (is (= 42 (:n (db-of))) "and committed"))))
+
+;; ===========================================================================
+;; The discriminator — gate lane ONLY
+;; ===========================================================================
+
+(deftest ^:prod-gate ordinary-event-schema-validation-really-is-elided-here
+  (testing "rf2-bza6e — the control that stops every posture-independent
+            assertion above from passing vacuously.
+
+            This deftest runs ONLY in the `jvm-core-prod-gate` lane (the
+            default `:test` alias excludes `^:prod-gate`), so it is a
+            statement about the JVM it is running in. It asserts the NEGATIVE:
+            a handler carrying the IDENTICAL `:schema` but NOT referencing
+            `:rf.schema/at-boundary` ACCEPTS a non-conforming event here,
+            because ordinary step-1 validation has been elided by the load-time
+            gate exactly as Spec 010 §Validation order says it should be.
+
+            That is what makes `at-boundary-rejects-a-non-conforming-event-in-
+            every-posture` meaningful under the gate: the rejection cannot be
+            step-1 doing the work, because step-1 demonstrably is not running
+            in this JVM."
+    (is (false? interop/debug-enabled?)
+        "precondition: this JVM really is under the production gate")
+    (let [calls (atom 0)]
+      (rf/reg-event :prod/unguarded
+        {:schema [:cat [:= :prod/unguarded] :int]}      ;; no at-boundary ref
+        (fn [{:keys [db]} [_ n]]
+          (swap! calls inc)
+          {:db (assoc db :n n)}))
+      (rf/dispatch-sync [:prod/unguarded "not-an-int"])
+      (is (= 1 @calls)
+          (str "under the gate an unguarded handler runs on a non-conforming "
+               "event — dev-time step-1 validation is elided. If this is RED, "
+               "step-1 validation is still running in this JVM and the "
+               "at-boundary assertions above are not proving what they claim."))
+      (is (= "not-an-int" (:n (db-of)))
+          "the unvalidated payload committed, as the elision contract implies"))))

--- a/implementation/core/test/re_frame/ep0008_producers_jvm_gate_test.clj
+++ b/implementation/core/test/re_frame/ep0008_producers_jvm_gate_test.clj
@@ -1,18 +1,45 @@
 (ns re-frame.ep0008-producers-jvm-gate-test
-  "EP-0008 / rf2-ntv9i9.3 — the JVM production-gate + raw-payload regressions
+  "rf2-f7qj4 — READ THIS FIRST. Despite the namespace's name, this suite is
+  NOT THE LOAD-TIME GATE.
+
+  `re-frame.interop/debug-enabled?` is read ONCE, at namespace-load time, from
+  `-Dre-frame.debug` / `RE_FRAME_DEBUG`. Every assertion below reaches it with
+  `with-redefs`, AFTER the framework has loaded, so it cannot change anything
+  the gate decided at load. What this suite pins is the REBINDABLE VAR — that
+  the always-on producers do not consult `debug-enabled?` at call time while
+  their dev-only companions do. Real contract, useful test; NOT the production
+  posture, and it must never be counted as coverage of one.
+
+  The lanes that DO reach the load-time gate:
+
+    * `jvm-core-prod-gate` / `sh scripts/test-core-prod-gate.sh` — the core
+      suite with `-Dre-frame.debug=false` genuinely on the JVM command line.
+    * `re-frame.prod-gate-lane-pin-test` — asserts the property really arrived
+      in that lane's JVM.
+    * `re-frame.prod-gate-dispatch-jvm-test` — the child-JVM pattern for a
+      defect that only reproduces at load time.
+
+  rf2-9c2jf was a TOTAL `dispatch-sync` failure under the documented gate that
+  stayed green for as long as it existed, and the full-looking roster of
+  \"production gate\" suites is part of why.
+
+  ## What this suite pins
+
+  EP-0008 / rf2-ntv9i9.3 — the debug-Var-rebind + raw-payload regressions
   for the REAL promoted producers.
 
   ## Why this suite exists (rf2-ntv9i9.3 finding #1)
 
   EP-0008 says the always-on axis survives BOTH CLJS production elision AND
-  JVM `re-frame.debug` / `RE_FRAME_DEBUG` gating. The generic JVM gate
+  JVM `re-frame.debug` / `RE_FRAME_DEBUG` gating. The generic rebind suite
   (`re-frame.jvm-prod-gate-integration-test`) proves a generic handler
   exception reaches `register-error-listener!` with debug disabled — but the
   REAL EP-0008 producers (`:rf.error/frame-teardown-failed`,
   `:rf.error/write-after-destroy`, `:rf.error/on-destroy-handler-exception`)
   were pinned mainly through the CLJS production-elision probe. This suite
-  exercises each REAL producer end-to-end under `debug-enabled? = false` — the
-  SSR-production JVM posture — and asserts:
+  exercises each REAL producer end-to-end with `debug-enabled?` REBOUND to
+  `false` — a model of the SSR-production JVM posture, not the posture itself
+  — and asserts:
 
     (a) each promoted producer's always-on record STILL fires with the dev
         gate off (the producer survives the JVM prod gate);
@@ -23,10 +50,10 @@
 
   ## Why JVM-only (`.clj`, not `.cljc`)
 
-  The gate this suite exercises is the JVM `interop/debug-enabled?` var
-  (`with-redefs`-rebindable here; CLJS uses Closure DCE, exercised by the
-  `prod_elision_runner` probe instead). Naming this `.clj` keeps it on the
-  JVM `clojure -M:test` runner only.
+  The surface this suite exercises is the JVM `interop/debug-enabled?` Var as
+  a REBINDABLE reference (`with-redefs` here; CLJS uses Closure DCE, exercised
+  by the `prod_elision_runner` probe, which is a genuine production build).
+  Naming this `.clj` keeps it on the JVM `clojure -M:test` runner only.
 
   ## Raw-payload regressions (rf2-ntv9i9.3 #2)
 

--- a/implementation/core/test/re_frame/frame_upsert_linearization_production_test.clj
+++ b/implementation/core/test/re_frame/frame_upsert_linearization_production_test.clj
@@ -1,0 +1,227 @@
+(ns re-frame.frame-upsert-linearization-production-test
+  "rf2-7vk3z — frame-upsert linearization, witnessed through PRODUCTION state.
+
+  ## Why this namespace exists
+
+  `re-frame.frame-upsert-linearization-jvm-test` proves a genuinely
+  production-real invariant: which writer wins an exclusive-create race, and
+  whether a failed re-registration rolls back to the pre-attempt generation.
+  Frame construction linearizes identically in a production build; there is
+  nothing dev-only about a last-writer clobber or a resurrected zombie record.
+
+  But several of its assertions reach that invariant through
+  `re-frame.trace.tooling/trace-rings` — the per-frame retention cap, used as
+  a convenient FLAG for \"whose config got published\". The ring is a dev
+  artefact and does not exist under `-Dre-frame.debug=false`, so those
+  assertions read `nil` and the namespace is red in the `jvm-core-prod-gate`
+  lane.
+
+  The tempting rewrite — drop the ring assertions — would make it green while
+  silently retiring live coverage of a concurrency invariant. So this namespace
+  instead re-proves the SAME invariant through witnesses a production build
+  really carries:
+
+    * `frame/frame` — the authoritative registry record: `:config`,
+      `:trace-policy-token`, `:construction :revision`;
+    * `frame/frame-generation` — the generation slot the rollback contract is
+      literally about;
+    * `frame/frame-state-container` / `frame/frame-runtime-db-value` — the
+      durable state a clobbered loser would have orphaned;
+    * `trace/frame-trace-disabled?` — the OTHER frame-scoped policy store.
+      That store is written unconditionally (it survives the gate; only the
+      retention ring does not), so it still witnesses the rf2-umsyo9 contract
+      that auxiliary policy publication linearizes with the registry.
+
+  The one thing genuinely NOT witnessable in production is the retention cap
+  itself, because a retain-N trace ring is not a thing production has. That
+  arm stays in the dev-posture twin, where it belongs.
+
+  ## Posture-independence
+
+  Every assertion holds in dev AND under `-Dre-frame.debug=false`, so this
+  namespace runs in the ordinary `clojure -M:test` suite and joins
+  `scripts/test-core-prod-gate.sh` automatically (that lane's roster is an
+  EXCLUSION list — a new namespace joins by default).
+
+  Windows are opened DETERMINISTICALLY via the `frame/*upsert-decide-probe*` /
+  `frame/*upsert-policy-probe*` JVM linearization seams (nil in production),
+  conveyed into the racing thread by `future` binding-conveyance — no sleeps."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.trace :as trace])
+  (:import [java.util.concurrent CountDownLatch TimeUnit]))
+
+(defn- reset-runtime [test-fn]
+  (registrar/clear-all!)
+  (reset! frame/frames {})
+  (trace/clear-listeners!)
+  (trace/clear-frame-no-emit!)
+  (rf/init! plain-atom/adapter)
+  (test-fn))
+
+(use-fixtures :each reset-runtime)
+
+(defn- err-id [thunk]
+  (try (thunk) nil
+       (catch clojure.lang.ExceptionInfo e (:rf.error/id (ex-data e)))))
+
+(defn- window-probe
+  "Trip a `reached` latch when the transaction reaches its window for `target`,
+  then block on `release` — the deterministic window opener."
+  [target ^CountDownLatch reached ^CountDownLatch release]
+  (fn [id]
+    (when (= id target)
+      (.countDown reached)
+      (.await release 10 TimeUnit/SECONDS))))
+
+;; ===========================================================================
+;; Exclusive create: only the transaction owner may publish.
+;; ===========================================================================
+
+(deftest exclusive-create-loser-cannot-publish-over-the-owner
+  (testing "rf2-7vk3z / rf2-umsyo9 — a same-id contender that arrives while the
+            owner holds an exclusive-create transaction loses at admission with
+            `:rf.error/frame-construction-in-progress`, and neither its config
+            nor its frame-scoped trace policy reaches any store. Witnessed
+            through the registry record and the always-on no-emit policy store,
+            not through the dev-only retention ring."
+    (let [reached (CountDownLatch. 1)
+          release (CountDownLatch. 1)
+          owner   (binding [frame/*upsert-decide-probe*
+                            (window-probe :prod/race reached release)]
+                    (future
+                      (frame/upsert-frame! :prod/race
+                                           {:rf.frame/must-create?    true
+                                            :tags                     #{:owner}
+                                            :rf.trace/frame-no-emit?  false})))]
+      (is (.await reached 10 TimeUnit/SECONDS)
+          "the owner holds the id before publication")
+      (is (= :rf.error/frame-construction-in-progress
+             (err-id #(frame/upsert-frame! :prod/race
+                                           {:tags                    #{:contender}
+                                            :rf.trace/frame-no-emit? true})))
+          "the contender loses at same-id admission")
+      (is (false? (trace/frame-trace-disabled? :prod/race))
+          "no suppression policy is published while the owner is paused")
+      (.countDown release)
+      (is (= :prod/race @owner) "the owner's transaction completes")
+      (is (= #{:owner} (get-in (frame/frame :prod/race) [:config :tags]))
+          "the authoritative registry record is the OWNER's — not a
+           last-writer clobber by the loser")
+      (is (false? (trace/frame-trace-disabled? :prod/race))
+          "and the owner's frame-scoped policy is final")
+      (is (some? (frame/frame-state-container :prod/race))
+          "the owner's full record is published — no orphaned container"))))
+
+(deftest disjoint-ids-stay-independent-under-a-held-transaction
+  (testing "rf2-7vk3z — the negative control. A held transaction on one id does
+            not serialize construction of a DIFFERENT id, so the fail-fast
+            above is same-id admission and not a global construction lock."
+    (let [reached (CountDownLatch. 1)
+          release (CountDownLatch. 1)
+          owner   (binding [frame/*upsert-decide-probe*
+                            (window-probe :prod/held reached release)]
+                    (future
+                      (frame/upsert-frame! :prod/held
+                                           {:rf.frame/must-create? true})))]
+      (is (.await reached 10 TimeUnit/SECONDS) "the owner holds :prod/held")
+      (is (= :prod/other
+             (frame/upsert-frame! :prod/other {:tags #{:disjoint}}))
+          "a disjoint id constructs while :prod/held is mid-transaction")
+      (.countDown release)
+      (is (= :prod/held @owner))
+      (is (= #{:disjoint} (get-in (frame/frame :prod/other) [:config :tags]))))))
+
+;; ===========================================================================
+;; Failed re-registration rolls back to the PRE-ATTEMPT generation.
+;; ===========================================================================
+
+(deftest failed-reregistration-rolls-back-to-the-intervening-generation
+  (testing "rf2-7vk3z / rf2-vxgfnd.197 — the invariant the bead names. A
+            staged re-registration pauses provisional; the image-reprojection
+            path legitimately swaps only the generation in that window; the
+            re-registration's hook then fails. Rollback must restore the
+            constructor's config, policy authority and construction revision
+            WITHOUT replacing the whole record and erasing the intervening
+            generation or the runtime container written during the callback.
+
+            Every witness here is production state: the registry record, the
+            generation slot, the runtime-db partition, and the always-on
+            no-emit policy store."
+    (let [id            :prod/rollback
+          hook-key      :routing/on-frame-registered!
+          original-hook (late-bind/get-fn hook-key)
+          reached       (CountDownLatch. 1)
+          release       (CountDownLatch. 1)]
+      (frame/upsert-frame! id
+                           {:tags                    #{:prior}
+                            :rf.frame/generation     :prior-gen
+                            :rf.trace/frame-no-emit? true})
+      (let [prior-record       (frame/frame id)
+            prior-config       (:config prior-record)
+            prior-policy-token (:trace-policy-token prior-record)
+            prior-revision     (get-in prior-record [:construction :revision])]
+        (try
+          (late-bind/set-fn!
+            hook-key
+            (fn [candidate-id]
+              (when (= id candidate-id)
+                ;; A valid same-owner runtime write during the callback must
+                ;; survive rollback — its container is not construction-owned.
+                (frame/replace-runtime-db! id {:foreign-runtime true})
+                (throw (ex-info "registration hook failed"
+                                {:test/outcome :hook-failed})))))
+          (let [owner (binding [frame/*upsert-policy-probe*
+                                (window-probe id reached release)]
+                        (future
+                          (try
+                            (frame/upsert-frame!
+                              id {:tags                    #{:failed}
+                                  :rf.frame/generation     :failed-gen
+                                  :rf.trace/frame-no-emit? false})
+                            :unexpected-success
+                            (catch clojure.lang.ExceptionInfo e
+                              (:test/outcome (ex-data e))))))]
+            (try
+              (is (.await reached 10 TimeUnit/SECONDS)
+                  "the constructor staged its exact provisional revision")
+              (is (= :provisional
+                     (get-in @frame/frames [id :construction :state])))
+              ;; Mid-transaction the record is provisional, so the resolving
+              ;; readers (`frame-generation` and friends) correctly decline it.
+              ;; These two reads therefore go straight at `frame/frames` — the
+              ;; PRODUCTION registry atom, not a dev instrumentation store.
+              (is (= :failed-gen (get-in @frame/frames [id :generation]))
+                  "the provisional generation is staged mid-transaction")
+              ;; `reproject-live-frame!` resolves outside the registry atom and
+              ;; reaches this raw generation-only mutator after resolution.
+              (frame/set-generation! id :foreign-gen)
+              (is (= :foreign-gen (get-in @frame/frames [id :generation]))
+                  "the intervening generation write linearized before rollback")
+              (finally
+                (.countDown release)))
+            (is (= :hook-failed @owner) "the staged re-registration fails")
+            (is (= :foreign-gen (frame/frame-generation id))
+                "ROLLBACK PRESERVES the valid intervening generation write —
+                 it does not restore the whole record wholesale")
+            (is (= {:foreign-runtime true} (frame/frame-runtime-db-value id))
+                "and preserves runtime updates made during the callback")
+            (is (= #{:prior} (get-in (frame/frame id) [:config :tags]))
+                "the failed constructor's config is NOT retained")
+            (is (= prior-config (:config (frame/frame id)))
+                "the complete prior config is restored, not only its tags")
+            (is (true? (trace/frame-trace-disabled? id))
+                "the pre-attempt frame-scoped policy is restored")
+            (is (identical? prior-policy-token
+                            (:trace-policy-token (frame/frame id)))
+                "as is the record's prior policy authority")
+            (is (identical? prior-revision
+                            (get-in (frame/frame id) [:construction :revision]))
+                "and its prior final construction revision"))
+          (finally
+            (.countDown release)
+            (late-bind/set-fn! hook-key original-hook)))))))

--- a/implementation/core/test/re_frame/interop_debug_gate_test.clj
+++ b/implementation/core/test/re_frame/interop_debug_gate_test.clj
@@ -1,15 +1,35 @@
 (ns re-frame.interop-debug-gate-test
-  "Per rf2-vnjfg / rf2-0la4f (security audit): the JVM-side
+  "rf2-f7qj4 — READ THIS FIRST. Despite the namespace's name, this suite is
+  NOT THE LOAD-TIME GATE. It pins the gate's INPUT VOCABULARY — which strings
+  `read-debug-flag` treats as false — by invoking the private reader directly
+  with `System/setProperty`. The reader is called here at TEST time; the gate
+  itself was decided once, at namespace-load time, long before. Nothing below
+  runs any framework code under the production posture.
+
+  The lanes that DO reach the load-time gate:
+
+    * `jvm-core-prod-gate` / `sh scripts/test-core-prod-gate.sh` — the core
+      suite with `-Dre-frame.debug=false` genuinely on the JVM command line.
+    * `re-frame.prod-gate-lane-pin-test` — asserts the property really arrived
+      in that lane's JVM and that the framework honoured it.
+    * `re-frame.prod-gate-dispatch-jvm-test` — the child-JVM pattern for a
+      defect that only reproduces at load time.
+
+  rf2-9c2jf was a TOTAL `dispatch-sync` failure under the documented gate that
+  stayed green for as long as it existed. Vocabulary coverage is not posture
+  coverage, and this suite must never be counted as the latter.
+
+  ## What this suite pins
+
+  Per rf2-vnjfg / rf2-0la4f (security audit): the JVM-side
   `re-frame.interop/debug-enabled?` gate is the SSR-mode production
   switch — the counterpart to CLJS `goog.DEBUG=false`. This suite
-  pins the gate's vocabulary semantics and its default.
+  pins the gate's vocabulary semantics and its default, so future
+  contributors don't accidentally change a case-sensitivity or
+  vocabulary contract without breaking a test.
 
-  The flag itself is read once at namespace load, so we exercise the
-  underlying private reader directly. The integration story (trace
-  buffer / epoch surfaces respecting the flag) lives in those
-  respective test suites — what THIS suite pins is the gate's input
-  vocabulary, so future contributors don't accidentally change a
-  case-sensitivity or vocabulary contract without breaking a test."
+  The integration story (trace buffer / epoch surfaces respecting a REBOUND
+  flag) lives in those respective suites, which carry the same caveat."
   (:require [clojure.test :refer [deftest is testing]]
             [re-frame.interop :as interop]))
 

--- a/implementation/core/test/re_frame/jvm_prod_gate_integration_test.clj
+++ b/implementation/core/test/re_frame/jvm_prod_gate_integration_test.clj
@@ -1,13 +1,45 @@
 (ns re-frame.jvm-prod-gate-integration-test
-  "Per rf2-vnjfg (MEDIUM finding): JVM/SSR/headless production gate
-  end-to-end. Pins that when `interop/debug-enabled?` reads `false`
-  on the JVM, the dev surfaces (trace ring buffer, trace listener
-  fan-out, registry trace emits) drop to their no-op floor — the
-  same DCE-equivalent surface CLJS `:advanced` + `goog.DEBUG=false`
-  builds get for free.
+  "rf2-f7qj4 — READ THIS FIRST. Despite the namespace's name, this suite is
+  NOT THE LOAD-TIME GATE.
+
+  `re-frame.interop/debug-enabled?` is a `def` read ONCE, at namespace-load
+  time, from `-Dre-frame.debug` / `RE_FRAME_DEBUG`. Every assertion below
+  reaches it with `with-redefs`, which runs AFTER the framework has loaded and
+  therefore cannot change one thing the gate decided at load. What this suite
+  actually pins is the REBINDABLE VAR: that the gated dev surfaces re-read
+  `interop/debug-enabled?` at CALL time rather than caching it, so a rebind
+  silences them. That is a real and useful contract. It is not the production
+  posture, and it must never be counted as coverage of one.
+
+  The lanes that DO reach the load-time gate:
+
+    * `jvm-core-prod-gate` / `sh scripts/test-core-prod-gate.sh` — the core
+      suite run with `-Dre-frame.debug=false` genuinely on the JVM command
+      line (via the `:prod-gate` alias's `:jvm-opts`).
+    * `re-frame.prod-gate-lane-pin-test` — asserts, unconditionally, that the
+      property reached that lane's JVM and that the framework honoured it.
+    * `re-frame.prod-gate-dispatch-jvm-test` — the child-JVM pattern: relaunch
+      a fresh JVM with the property on the command line, for a defect that
+      only reproduces at load time.
+
+  Why the distinction is load-bearing: rf2-9c2jf was a TOTAL `dispatch-sync`
+  failure under the documented production gate — handler run ZERO times — and
+  it stayed green for as long as it existed. Part of why nobody caught it is
+  that the roster of suites calling themselves \"production gate\" tests looked
+  full, and a reviewer reading the file list had no way to see that not one of
+  them ran under the gate.
+
+  ## What this suite pins
+
+  Per rf2-vnjfg (MEDIUM finding): with `interop/debug-enabled?` REBOUND to
+  `false`, the dev surfaces (trace ring buffer, trace listener fan-out,
+  registry trace emits) drop to their no-op floor — the call-time-read
+  equivalent of what CLJS `:advanced` + `goog.DEBUG=false` gets from Closure
+  DCE.
 
   The companion epoch suite (`re-frame.epoch.jvm-prod-gate-test`,
-  rf2-0la4f) pins the same contract for the epoch artefact.
+  rf2-0la4f) rebinds the same Var for the epoch artefact and carries the same
+  caveat.
 
   The unit-level vocabulary semantics live in
   `re-frame.interop-debug-gate-test`; this suite is the end-to-end

--- a/implementation/core/test/re_frame/prod_gate_naming_drift_test.clj
+++ b/implementation/core/test/re_frame/prod_gate_naming_drift_test.clj
@@ -1,0 +1,136 @@
+(ns re-frame.prod-gate-naming-drift-test
+  "rf2-f7qj4 — a namespace whose NAME claims the production/debug gate must
+  either reach that gate for real, or say out loud that it does not.
+
+  ## The failure mode this closes
+
+  `re-frame.interop/debug-enabled?` is read ONCE, at namespace-load time, from
+  `-Dre-frame.debug` / `RE_FRAME_DEBUG`. A suite that reaches it with
+  `with-redefs` runs AFTER the framework has loaded and cannot change one
+  thing the gate decided at load — it pins a rebindable Var, not a posture.
+
+  rf2-9c2jf was a TOTAL `dispatch-sync` failure under the documented
+  production gate — handler run ZERO times — that stayed green for as long as
+  it existed. Part of why nobody caught it: the roster of suites calling
+  themselves \"production gate\" tests looked full, and a reviewer reading the
+  file list had no way to see that not one of them ran under the gate. The
+  names were the camouflage.
+
+  rf2-f7qj4 re-docstringed the three offenders. A docstring decays; this test
+  is what stops the next one being written.
+
+  ## The rule
+
+  DOMAIN — every `.clj` / `.cljc` file under `implementation/core/test/` whose
+  FILE NAME contains `prod_gate`, `jvm_gate`, or `debug_gate`. Those three
+  tokens are the ones that assert, in the file listing itself, \"this exercises
+  the JVM production/debug gate\". Deliberately narrow: `trace_gate` and the
+  `prod_elision` suites make a different claim and are out of scope.
+
+  A file in the domain is HONEST when it does at least one of:
+
+    a. carries `^:prod-gate` metadata — it belongs to the real
+       `jvm-core-prod-gate` lane, which puts `-Dre-frame.debug=false` on the
+       JVM command line via the `:prod-gate` alias's `:jvm-opts`;
+    b. contains the literal `-Dre-frame.debug=false` — it relaunches a child
+       JVM with the property on the command line (the
+       `re-frame.prod-gate-dispatch-jvm-test` pattern);
+    c. contains the disclaimer sentinel below — it states in its own docstring
+       that it is NOT THE LOAD-TIME GATE, so the file listing stops lying.
+
+  This namespace satisfies its own rule through (c): the sentinel is `def`'d
+  below, and this suite makes no claim to run under any particular posture.
+
+  ## Posture-independence
+
+  Every assertion here is a pure filesystem + string check. It holds in dev
+  posture and under `-Dre-frame.debug=false` alike, so this namespace runs in
+  the ordinary `clojure -M:test` suite AND joins `jvm-core-prod-gate`
+  automatically (that lane's roster is an EXCLUSION list — a new namespace
+  joins by default)."
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]))
+
+(def ^:private claim-tokens
+  "File-name substrings that CLAIM the JVM production/debug gate."
+  ["prod_gate" "jvm_gate" "debug_gate"])
+
+(def ^:private disclaimer
+  "The sentinel a claiming suite writes into its ns docstring to say it does
+  not reach the load-time gate. Kept as one exact string so the disclaimer is
+  greppable rather than a paraphrase every author reinvents."
+  "NOT THE LOAD-TIME GATE")
+
+(def ^:private prod-gate-tag "^:prod-gate")
+(def ^:private jvm-property "-Dre-frame.debug=false")
+
+(defn- test-namespace-dir
+  "The on-disk `test/re_frame` directory, resolved off the CLASSPATH rather
+  than the process CWD — `clojure -M:test` and the `jvm-core-prod-gate` lane
+  both run from `implementation/core`, but nothing guarantees a third caller
+  will. Anchored on a file that exists ONLY under `test/` so the `src/`
+  `re_frame` directory cannot win the lookup."
+  ^java.io.File []
+  (some-> (io/resource "re_frame/prod_gate_lane_pin_test.clj")
+          io/as-file
+          .getParentFile))
+
+(defn- claiming-files
+  "Every file in the domain: a `.clj` / `.cljc` source under `test/re_frame`
+  whose name contains one of `claim-tokens`."
+  []
+  (->> (some-> (test-namespace-dir) .listFiles seq)
+       (filter #(.isFile ^java.io.File %))
+       (filter #(re-find #"\.cljc?$" (.getName ^java.io.File %)))
+       (filter (fn [^java.io.File f]
+                 (some #(str/includes? (.getName f) %) claim-tokens)))
+       (sort-by #(.getName ^java.io.File %))
+       vec))
+
+(defn- honest? [^java.io.File f]
+  (let [content (slurp f)]
+    (or (str/includes? content prod-gate-tag)
+        (str/includes? content jvm-property)
+        (str/includes? content disclaimer))))
+
+(deftest the-domain-scan-still-finds-files
+  (testing "rf2-f7qj4 — the guard on the guard. If `test-namespace-dir` stops
+            resolving (a moved test root, a packaged classpath) or the token
+            match stops hitting, the check below passes VACUOUSLY and the
+            naming lie is free to come back. A silently-empty scan is the
+            failure mode this whole namespace exists to prevent, so it is a
+            hard red."
+    (is (some? (test-namespace-dir))
+        (str "could not resolve `test/re_frame` from the classpath via "
+             "`re_frame/prod_gate_lane_pin_test.clj` — has the anchor file "
+             "been renamed or the test root moved?"))
+    (is (<= 3 (count (claiming-files)))
+        (str "expected at least the three known gate-claiming files "
+             "(prod_gate_lane_pin_test, prod_gate_dispatch_jvm_test, "
+             "jvm_prod_gate_integration_test); found "
+             (mapv #(.getName ^java.io.File %) (claiming-files))))))
+
+(deftest every-gate-claiming-namespace-is-honest-about-the-gate
+  (testing "rf2-f7qj4 — a test file whose NAME says it exercises the JVM
+            production/debug gate must either reach that gate for real
+            (`^:prod-gate` in the `jvm-core-prod-gate` lane, or a child JVM
+            launched with `-Dre-frame.debug=false`) or carry the disclaimer
+            sentinel in its docstring. `with-redefs` on
+            `re-frame.interop/debug-enabled?` is neither: the flag is read
+            once at namespace-load time, so a rebind cannot reach it."
+    (let [liars (remove honest? (claiming-files))]
+      (is (empty? liars)
+          (str "these files NAME the production/debug gate but neither reach "
+               "it nor disclaim it: "
+               (mapv #(.getName ^java.io.File %) liars)
+               "\n\nFix by one of:"
+               "\n  a. run in the real lane — tag the deftests `^:prod-gate`"
+               "\n     (see re-frame.prod-gate-lane-pin-test) and add the ns to"
+               "\n     scripts/test-core-prod-gate.sh's lane;"
+               "\n  b. relaunch a child JVM with `" jvm-property "` on its"
+               "\n     command line (see re-frame.prod-gate-dispatch-jvm-test);"
+               "\n  c. state in the ns docstring that the suite is `"
+               disclaimer "`,"
+               "\n     naming what it DOES pin (a rebindable Var is a real"
+               "\n     contract — it is just not the production posture).")))))

--- a/implementation/core/test/re_frame/subs_image_local_classification_production_test.clj
+++ b/implementation/core/test/re_frame/subs_image_local_classification_production_test.clj
@@ -1,0 +1,221 @@
+(ns re-frame.subs-image-local-classification-production-test
+  "rf2-7vk3z — \"no cross-frame classification bleed\", witnessed without the
+  trace stream.
+
+  ## The invariant, and where it really lives
+
+  `re-frame.subs-image-local-classification-cljs-test` proves that two frames
+  installing the SAME inline sub id with DIFFERENT `:sensitive` declarations
+  each redact per their OWN image-local declaration — no bleed from a sibling
+  frame, no fallback to a conflicting same-id GLOBAL registration. It proves it
+  by subscribing on a live frame and reading `:rf.sub/run` off a
+  `register-listener! :trace` stream, which is dev-only, so those legs are red
+  in the `jvm-core-prod-gate` lane.
+
+  Dropping the trace assertions would make that suite green while retiring live
+  coverage of a privacy invariant, so this namespace re-proves it through
+  production-visible witnesses instead. Doing that first required establishing
+  WHICH HALF of the invariant is production-real, because the two halves have
+  different answers:
+
+  **The RESOLUTION half is production-real and is pinned here.** Which image's
+  `sub-meta` a frame's reaction resolves for a given sub id is decided by
+  `registrar/lookup`, through the frame's own generation resolver
+  (`live-frame/call-with-frame-resolution` binds `registrar/*generation*`).
+  That is the same one map from which `re-frame.subs.memo` takes BOTH the
+  `:handler-fn` it runs AND — as `(select-keys sub-meta [:sensitive :large
+  :large?])` — the classification declaration it carries. Nothing on that path
+  consults `interop/debug-enabled?`. A bleed here would hand frame A's reaction
+  frame B's declaration in a production build, so it is witnessable and it is
+  witnessed below: through `@(rf/subscribe …)`, a public return value, and
+  through the resolved metadata map itself.
+
+  **The PROJECTION half has no production egress inside `implementation/core`,
+  and that is a finding rather than a gap.** The carried declaration's only
+  consumer here is `classification/project-sub-tags`, reached only from
+  `trace/build-event` inside `trace/emit!`'s `interop/debug-enabled?` gate.
+  Under the production gate no `:rf.sub/run` event is built at all, so there is
+  no production surface for a sub-output classification to leak onto — the
+  redaction it performs protects the dev / Xray / MCP trace stream. Inventing
+  an observable by adding production instrumentation to make a test possible
+  would be the wrong fix.
+
+  That half is nonetheless already proven under the gate: the projector is a
+  pure function of the tags handed to it, and the five chokepoint fixtures at
+  the head of the dev-posture suite drive it directly and pass in BOTH
+  postures. `projector-redacts-per-the-actually-resolved-declaration` below
+  closes the last link by feeding the projector the declaration the LIVE frame
+  really resolved — reconstructing the carrier exactly as `subs.memo` does —
+  rather than a fabricated one.
+
+  ## Posture-independence
+
+  Every assertion holds in dev AND under `-Dre-frame.debug=false`, so this
+  namespace runs in the ordinary `clojure -M:test` suite and joins
+  `scripts/test-core-prod-gate.sh` automatically (that lane's roster is an
+  EXCLUSION list — a new namespace joins by default). Nothing here rebinds
+  `interop/debug-enabled?`: the flag is read once at namespace-load time and a
+  rebind cannot reach it (rf2-f7qj4)."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.classification :as classification]
+            [re-frame.core :as rf]
+            [re-frame.image :as image]
+            [re-frame.live-frame :as lf]
+            [re-frame.privacy :as privacy]
+            [re-frame.registrar :as registrar]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as ts]))
+
+(use-fixtures :each
+  (ts/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(defn- inline-sub-image
+  "An image whose ONLY registration is an inline layer-1 `:reg-sub` under `id`
+  carrying `classification` metadata and returning the constant `value`. The
+  inline descriptor is normalized and lowered by REAL image assembly when the
+  frame's generation is sealed."
+  [image-id id classification value]
+  (image/image {:id            image-id
+                :registrations {:reg-sub [[id classification (fn [_db _q] value)]]}}))
+
+(defn- install-image-frame!
+  "Seal `frame-id`'s generation from `image` through the real image-assembly
+  path. The empty descriptor pool keeps the generation to the image's own
+  inline registrations (no live source-store contamination)."
+  [frame-id image]
+  (lf/make-frame {:id frame-id :images [image]} []))
+
+(defn- resolved-sub-meta
+  "The registration metadata `frame-id`'s reactions resolve for `sub-id` — the
+  SAME `registrar/lookup` call `re-frame.subs` makes, under the SAME
+  frame-generation binding (`live-frame/call-with-frame-resolution`). Always-on:
+  nothing on this path reads `interop/debug-enabled?`."
+  [frame-id sub-id]
+  (lf/call-with-frame-resolution frame-id #(registrar/lookup :sub sub-id)))
+
+(defn- carried-declaration
+  "Reconstruct the classification carrier exactly as `re-frame.subs.memo` does
+  — `(select-keys sub-meta [:sensitive :large :large?])` off the resolved
+  metadata. This is the value a reaction would hand the trace chokepoint."
+  [frame-id sub-id]
+  (select-keys (resolved-sub-meta frame-id sub-id) [:sensitive :large :large?]))
+
+(defn- project-sub-run
+  "Project a `:rf.sub/run` envelope and return the projected tags — the pure
+  chokepoint, posture-independent."
+  [tags]
+  (-> (classification/project-trace-event
+        {:operation :rf.sub/run :op-type :rf.sub
+         :tags      (merge {:frame :rf/default} tags)})
+      :tags))
+
+;; ===========================================================================
+;; The resolution half — production-visible, per frame, no global fallback
+;; ===========================================================================
+
+(deftest two-frames-resolve-their-own-image-local-declaration-in-every-posture
+  (testing "rf2-7vk3z — two frames install the SAME inline sub id with
+            DIFFERENT `:sensitive` declarations. Each resolves ITS OWN, and
+            neither falls back to the conflicting same-id GLOBAL. Witnessed by
+            the public subscription return value and by the resolved metadata
+            map — not by the dev-only trace stream.
+
+            A bleed here is a production data-exposure defect: frame A's
+            reaction would carry frame B's declaration into every redaction
+            decision made about A's output."
+    ;; Conflicting global: SAME id, NO classification. A fallback to it would
+    ;; leave both frames' values entirely unclassified.
+    (rf/reg-sub :img/read (fn [_db _q] {:token "GLOBAL" :public "GLOBAL"}))
+    (install-image-frame! :img/frame-a
+      (inline-sub-image :img/a :img/read {:sensitive [[:token]]}
+                        {:token "A-SECRET" :public "A-pub"}))
+    (install-image-frame! :img/frame-b
+      (inline-sub-image :img/b :img/read {:sensitive [[:public]]}
+                        {:token "B-tok" :public "B-SECRET"}))
+
+    (testing "the public return value is each frame's OWN image-local sub"
+      (is (= {:token "A-SECRET" :public "A-pub"}
+             @(rf/subscribe [:img/read] {:frame :img/frame-a})))
+      (is (= {:token "B-tok" :public "B-SECRET"}
+             @(rf/subscribe [:img/read] {:frame :img/frame-b}))))
+
+    (testing "and so is the classification declaration on the one resolved
+              metadata map the reaction takes both its handler and its
+              declaration from"
+      (is (= {:sensitive [[:token]]} (carried-declaration :img/frame-a :img/read))
+          "frame A carries ITS declaration")
+      (is (= {:sensitive [[:public]]} (carried-declaration :img/frame-b :img/read))
+          "frame B carries ITS declaration — no bleed from A")
+      (is (empty? (carried-declaration :rf/default :img/read))
+          "and the unclassified GLOBAL supplied neither"))))
+
+(deftest replacing-a-generation-swaps-value-and-declaration-together
+  (testing "rf2-7vk3z — replacing frame A's image generation makes subsequent
+            resolution read the NEW declaration: not the OLD generation's path,
+            and not the conflicting global. Because handler and declaration
+            come from ONE resolved map, a stale-generation read would show up
+            in the public return value too."
+    (rf/reg-sub :img/read (fn [_db _q] {:token "GLOBAL" :public "GLOBAL"}))
+    (install-image-frame! :img/frame-a
+      (inline-sub-image :img/g1 :img/read {:sensitive [[:token]]}
+                        {:token "SECRET" :public "pub"}))
+    (is (= {:sensitive [[:token]]} (carried-declaration :img/frame-a :img/read))
+        "generation 1 classifies :token")
+    (is (= {:token "SECRET" :public "pub"}
+           @(rf/subscribe [:img/read] {:frame :img/frame-a})))
+
+    ;; Generation 2 classifies :public instead. Frame memory (the sub cache) is
+    ;; preserved across the swap, so clear it to force a fresh reaction
+    ;; resolved against the NEW generation — an HMR sub reload.
+    (install-image-frame! :img/frame-a
+      (inline-sub-image :img/g2 :img/read {:sensitive [[:public]]}
+                        {:token "tok2" :public "SECRET2"}))
+    (rf/clear-sub-cache! :img/frame-a)
+
+    (is (= {:sensitive [[:public]]} (carried-declaration :img/frame-a :img/read))
+        "the NEW generation's declaration is what resolves")
+    (is (= {:token "tok2" :public "SECRET2"}
+           @(rf/subscribe [:img/read] {:frame :img/frame-a}))
+        "and the NEW generation's handler is what runs")))
+
+;; ===========================================================================
+;; The last link — the projector, fed what the LIVE frame really resolved
+;; ===========================================================================
+
+(deftest projector-redacts-per-the-actually-resolved-declaration
+  (testing "rf2-7vk3z — the dev-posture suite's chokepoint fixtures HAND the
+            projector a fabricated declaration, so they stay green even if real
+            image-local resolution had fallen back to the global. This closes
+            that gap without a trace listener: the declaration fed in is the one
+            `resolved-sub-meta` really produced for each live frame,
+            reconstructed exactly as `re-frame.subs.memo` reconstructs it.
+
+            `project-trace-event` is a pure function of its argument and is not
+            debug-gated, so this assertion is posture-independent even though
+            the trace stream that would normally call it is dev-only."
+    (rf/reg-sub :img/read (fn [_db _q] {:token "GLOBAL" :public "GLOBAL"}))
+    (install-image-frame! :img/frame-a
+      (inline-sub-image :img/a :img/read {:sensitive [[:token]]}
+                        {:token "A-SECRET" :public "A-pub"}))
+    (install-image-frame! :img/frame-b
+      (inline-sub-image :img/b :img/read {:sensitive [[:public]]}
+                        {:token "B-tok" :public "B-SECRET"}))
+    (let [a (project-sub-run {:rf.sub/id             :img/read
+                              :frame                 :img/frame-a
+                              :rf.sub/value          @(rf/subscribe [:img/read] {:frame :img/frame-a})
+                              :rf.sub/classification (carried-declaration :img/frame-a :img/read)})
+          b (project-sub-run {:rf.sub/id             :img/read
+                              :frame                 :img/frame-b
+                              :rf.sub/value          @(rf/subscribe [:img/read] {:frame :img/frame-b})
+                              :rf.sub/classification (carried-declaration :img/frame-b :img/read)})]
+      (is (= privacy/redacted-sentinel (get-in a [:rf.sub/value :token]))
+          "frame A redacts :token — its own declaration")
+      (is (= "A-pub" (get-in a [:rf.sub/value :public]))
+          "and leaves :public raw")
+      (is (= privacy/redacted-sentinel (get-in b [:rf.sub/value :public]))
+          "frame B redacts :public — ITS declaration, independently")
+      (is (= "B-tok" (get-in b [:rf.sub/value :token]))
+          "and leaves :token raw: no bleed from A's declaration")
+      (is (not (contains? a :rf.sub/classification))
+          "the internal carrier is stripped — it never egresses")
+      (is (not (contains? b :rf.sub/classification))))))


### PR DESCRIPTION
Direct follow-up to rf2-9c2jf (`dispatch-sync` running its handler ZERO times under the documented production gate) and rf2-f8x2i (the `jvm-core-prod-gate` lane, #7128). Three beads, one commit each, one surface: `implementation/core` tests under the real load-time gate.

Headline verdicts up front:

- **rf2-bza6e — both always-on validation surfaces really ARE always-on.** Verified against live source at `-Dre-frame.debug=false`, not by `with-redefs`. No production defect. Both are now pinned, and both pins are shown to bite.
- **rf2-7vk3z — production-visible witnesses found for both invariants**, with one honest finding recorded (below). No coverage was deleted; neither dev-posture original was touched.
- **rf2-f7qj4 — re-docstringed, not renamed.** The rename is fence-blocked; the exact blockers are listed so the mayor can sequence it.

---

## rf2-f7qj4 — the naming lie

`re-frame.interop/debug-enabled?` is read ONCE, at namespace-load time. Three suites named themselves production-gate tests and reached it with `with-redefs`, which runs after the framework has loaded and cannot change one thing the gate decided at load. They pin a rebindable Var, not a posture — and the full-looking roster is part of why a total dispatch failure stayed green.

Each now opens with an explicit `NOT THE LOAD-TIME GATE` banner naming what it *does* pin and pointing at `jvm-core-prod-gate` / `scripts/test-core-prod-gate.sh`, `re-frame.prod-gate-lane-pin-test`, and `re-frame.prod-gate-dispatch-jvm-test` for the child-JVM pattern. No behaviour change; the suites are kept, because rebinding the Var is a legitimate contract to test.

A docstring decays, so `re-frame.prod-gate-naming-drift-test` makes the rule mechanical: every `.clj`/`.cljc` under `implementation/core/test/` whose FILE NAME contains `prod_gate` / `jvm_gate` / `debug_gate` must either carry `^:prod-gate` (the real lane), contain `-Dre-frame.debug=false` (a child JVM), or carry the sentinel. It is posture-independent, joins the gate lane by default, and reds if its own domain scan ever comes back empty.

**RENAME NOT DONE — fence, not oversight.** The bead's wording allows "rename OR re-docstring". Renaming would strand prose cross-references in five files this worker may not touch:

| Reference | Why blocked |
|---|---|
| `scripts/test-core-prod-gate.sh:11` | explicitly fenced ("do NOT change the lane") |
| `.github/workflows/test.yml:880` | held by #7132 |
| `implementation/epoch/test/re_frame/epoch_jvm_prod_gate_test.clj:12-13` | spec-canary cluster owns `implementation/epoch/**` |
| `implementation/ssr/test/re_frame/ssr_error_projector_substrate_test.clj:16,23,28` | outside this worker's ownership |
| `spec/Security.md:264` + `spec/Tool-Pair.md:157` | HOT-ZONE; both cite `interop_debug_gate_test.clj` **by path** |

## rf2-bza6e — the two always-on validation surfaces

Spec 010 elides validation by default; `spec/Security.md` lists "schema-validation calls" among what the gate strips. It then carves out two surfaces as deliberately always-on, and until now NEITHER had a test in any lane that runs under the gate:

1. recordable-coeffect `:schema` (010:165, 010:179) — "a PRODUCTION HARD ERROR": `:rf.error/cofx-value-invalid` emitted and thrown, halting the run before an out-of-contract value folds into the durable causal ledger;
2. the `:rf.schema/at-boundary` interceptor (010:204, 010:220) — "Boundary validation runs even when global validation is elided", the opt-back-in for untrusted system-boundary payloads.

`re-frame.always-on-validation-production-test` pins both, modelled on `re-frame.privacy-production-egress-test` (#7130). Assertions are posture-independent and hold in dev AND under the gate, so the namespace runs in the ordinary suite and joins the lane automatically. Both surfaces get a conforming-value negative control so the pins cannot pass by breaking every dispatch.

One `^:prod-gate`-tagged deftest is the discriminator, running ONLY in the gate lane: in that same JVM, a handler carrying the identical `:schema` but NOT referencing `:rf.schema/at-boundary` **accepts** a non-conforming event, because step-1 validation really has been elided. Without it, "the handler did not run" would not identify which mechanism stopped it.

## rf2-7vk3z — production witnesses, not deleted assertions

Neither dev-posture original is modified. Each gets a posture-independent twin, the same shape #7130 used.

**frame-upsert linearization** goes to `frame_upsert_linearization_production_test.clj`. The dev-only observable is `trace.tooling/trace-rings`, the retention cap used as a flag for "whose config got published". A retain-N ring is not something production has, so that arm stays in the dev twin. The invariant is witnessed through `frame/frame`, `frame/frame-generation`, `:config`, `:trace-policy-token`, `:construction :revision`, `frame-runtime-db-value`, and `trace/frame-trace-disabled?` — the other frame-scoped policy store, which unlike the ring is written unconditionally and still witnesses the rf2-umsyo9 contract.

**No cross-frame classification bleed** goes to `subs_image_local_classification_production_test.clj`. **Witness used:** `@(rf/subscribe ...)` (a public return value) plus the resolved registration metadata read through the same `registrar/lookup` under the same `live-frame/call-with-frame-resolution` binding `re-frame.subs` uses. That one map is where `subs.memo` takes BOTH the `:handler-fn` it runs AND — as `(select-keys sub-meta [:sensitive :large :large?])` — the classification carrier, so per-frame resolution is production-real and a bleed hands frame A's reaction frame B's declaration in a production build. The last test feeds the projector the declaration a LIVE frame really resolved; the dev-posture suite's chokepoint fixtures hand it a *fabricated* one and would stay green even if real resolution had fallen back to the global.

**FINDING, recorded rather than papered over:** the *projection* half has no production egress inside `implementation/core`. The carried declaration's only consumer here is `classification/project-sub-tags`, reached only from `trace/build-event` inside `trace/emit!`'s `debug-enabled?` gate — under the gate no `:rf.sub/run` event is built at all, so there is no core surface for a sub-output classification to leak onto. Sub classification *does* egress in production from other artefacts (`routing`'s `:routing/route-sub-egress-path`, `ssr`'s `payload-policy/project-routing-egress`), both outside this worker's fence. No production instrumentation was added to manufacture an observable.

## Roster

**No line of `scripts/test-core-prod-gate.sh`'s `known_red` should be removed.** The two dev-posture originals are untouched and correctly stay excluded for rf2-d2841 to split. The lane's namespace count moves 83 to 87 purely because the four new namespaces join by default (the roster is an exclusion list).

## Quality gates

| Gate | Command | Exit |
|---|---|---|
| Production gate lane (full) | `bash scripts/test-core-prod-gate.sh` — 87 namespaces, 930 tests, 4328 assertions | **0** |
| Core dev posture (full) | `clojure -M:test` from `implementation/core` — 2146 tests, 10574 assertions | **0** |
| rf2-f7qj4 namespaces, dev | `clojure -M:test` over the drift gate + the three re-docstringed suites | **0** |
| rf2-f7qj4 namespaces, gate | same under `clojure -M:test:prod-gate`, plus the lane pin | **0** |
| rf2-bza6e, dev / gate | `-M:test` / `-M:test:prod-gate -n re-frame.always-on-validation-production-test` | **0** / **0** |
| rf2-7vk3z, dev / gate | both witness namespaces, `-M:test` / `-M:test:prod-gate` | **0** / **0** |

Every gate ran in the foreground, unpiped, captured to worktree-local logs. Deferred to CI: the CLJS suites (`npm run test:cljs`, elision, xray gates) and the rest of the fast-PR spine — no `.cljs` / `.cljc` file is added or modified by this PR.

### Mutation evidence

Every mutation was reverted; `git diff --stat` is clean and the restored run re-verified green in each case.

| Mutation | Result |
|---|---|
| `validate-recordable-value!` gated on `interop/debug-enabled?` | gate lane **exit 1**, 8 assertions red across BOTH the supplied and generated arms — **dev suite exit 0, fully green** |
| `at-boundary`'s `(if (dev-mode?) ctx ...)` forced to the no-op arm | gate lane **exit 1**, red on "the handler was SKIPPED" and on the payload committing to app-db — **dev suite exit 0, fully green** |
| `registrar/lookup` forced past the frame-generation resolver to the ambient registrar (the literal cross-frame bleed) | gate lane **exit 1**, and the failure prints the leak: `(not (= :rf/redacted "GLOBAL"))` — the unclassified global's value riding raw where the frame's own `:sensitive` declaration should have redacted it |
| frame rollback's `(identical? (:generation f) (:generation staged))` guard forced true | gate lane **exit 1**: `(not (= :foreign-gen :prior-gen))` — the intervening generation write erased, the resurrection class rf2-vxgfnd.197 closed |
| a `*_prod_gate_test.clj` added that `with-redefs`es the Var with no disclaimer | drift gate **exit 1**, naming the file: `["mutation_probe_prod_gate_test.clj"]` |

The first two mutations are the point of the whole cluster: **both are completely invisible to the ordinary dev-posture suite** and only the gate lane catches them. That is precisely the class of defect rf2-9c2jf was.

Closes rf2-f7qj4, rf2-bza6e, rf2-7vk3z.
