### PR TITLE
freehand: profile the broad-update row — the ~10x over Reagent is architectural (rf2-dq20a follow-on)

### DIFF
--- a/docs/design/freehand/studio/bulk-rerender-where-the-time-goes.md
+++ b/docs/design/freehand/studio/bulk-rerender-where-the-time-goes.md
@@ -1,0 +1,375 @@
+# Where does Freehand's bulk re-render time go?
+
+Seat: PROFILE SPIKE. Answering the one row
+[`freehand-vs-reagent.md`](freehand-vs-reagent.md) identified as squarely
+Freehand's own — **the broad update, ≈10× Reagent on repainting 300
+boundaries** — and the operator's standard of 2026-07-27, verbatim:
+*"Freehand can't be used if it is slower than Reagent."*
+
+Measured 2026-07-27 against `main` at `2b02616db0`. Reagent **2.0.1**,
+React **19.2.0**, headless Chromium 147 via Playwright, `:advanced` with
+`goog.DEBUG false` — the artefact a consumer ships. Same host and the
+same caveats as the report this extends.
+
+**The compiled tier does not appear here.** It was ruled out on
+2026-07-27 and is not measured, not quoted and not used as a baseline.
+The arms are interpreted Freehand, Reagent, and the hand-built React
+floor.
+
+---
+
+## The answer, first
+
+**It is architectural, not a hot spot.** Three findings, and the second
+is the one that settles it.
+
+1. **There is no hot spot to fix.** In a capture of nothing but broad
+   writes, the largest single self-time frame inside React's render phase
+   is **4.69%** and inside React's commit phase **4.26%** — and neither is
+   a Freehand function. Both phases are flat and are dominated by
+   `cljs.core` collection primitives: `get`, `assoc`, `hash`,
+   `inode-lookup`, `inode-assoc`, `array-index-of`, `-as-transient`,
+   `into`, `reduce-kv`. That is allocation churn spread thin across a lot
+   of bookkeeping. There is no function whose deletion moves the row.
+
+2. **It is not per-boundary either, and an ablation proves it.** Holding
+   the DOM, the reads, the lowering and the emitter constant and varying
+   *only* how many boundaries the 300 reactive reads are spread across,
+   300 boundaries → **1** boundary moves the write from **[3.9–4.5] ms**
+   to **[3.0–3.2] ms**. Real, disjoint, and a minority term: about **25%**
+   of the deficit. **With one boundary Freehand is still ≈9× Reagent.**
+
+3. **What survives the ablation is the observation ledger, and it is
+   O(reactive reads).** Recording 300 reads at render costs **0.77–0.86
+   ms**; re-staging, re-reading and republishing the same 300 dependencies
+   in the commit-phase layout effect costs **0.86–1.23 ms**. Together
+   ≈2.0 ms — **≈55% of the gap** — and neither term scales with boundaries
+   or with elements. It scales with *reads*.
+
+That double accounting is not an accident and not a redundancy. It is the
+atomic shell's contract, stated normatively in
+`spec/006-ReactiveSubstrate.md` §The Freehand atomic shell and repeated in
+`shell.cljs`: **"Render resolves and probes; the LAYOUT COMMIT owns."**
+The commit-side re-read through `obs/read` is the invariant-5 tear check —
+it compares node-key, version and frame/registry epoch between the render
+that produced the element and the commit that publishes it. Reagent has no
+counterpart to any of it: `deref-capture` collects reads into a flat array
+during render and diffs the watch set once, with no commit-phase
+transaction, no all-or-nothing bundle and no per-read map.
+
+Measured on the same React, in the same bundle: **Reagent's entire
+layout-effect commit phase is 0.36% of its capture — 1.4 µs per write —
+against Freehand's 1.23 ms.**
+
+**What this does not say.** It does not say the row cannot be improved.
+It says the improvement is a redesign of the dependency ledger in
+`cell.cljc`, not an optimisation findable in this profile, and §5 names
+the three candidates and ranks them.
+
+---
+
+## Method, and what it refuses to claim
+
+The clock is [`freehand-vs-reagent.md`](freehand-vs-reagent.md)'s,
+unchanged. The **window** is
+`re-frame.freehand.bench.b6-rows/timed-write!` called verbatim — the same
+state install, the same single microtask yield, the same empty
+`react-dom/flushSync` drain, and the same per-write read-back of the
+written cell out of the DOM. Profiling a window that differed from the
+published one would describe a measurement nobody took.
+
+**One arm, alone.** The published suite interleaves four arms at the
+sample level, which is right for the clock and useless for attribution:
+the samples split four ways and most of the capture is scheduler idle.
+Every capture here is one arm in a tight loop — 500 writes for Freehand,
+2,000 for Reagent and the floor — with a 60-write warm-up **outside** the
+capture. Measured idle across the four captures: **0.06%–0.5%**.
+
+**`:pseudo-names`, not a development build.** The profiled twin is the
+same `:advanced` pipeline — same inlining, same DCE, same collapsed
+properties — with the renaming policy changed so symbols survive. React
+and react-dom arrive as *already-minified* npm JavaScript, so nothing can
+name their internals; they are identified by minified symbol and
+`url:line`, and because every arm rides one bundle those symbols are
+**the same frames across arms**, which is what makes the phase comparison
+below legitimate.
+
+### Instrument scepticism, discharged three ways
+
+Two instrument faults on the predecessor bead each produced a plausible
+wrong table. This one carries three checks and **all three fired**.
+
+- **A positive control of known cost.** `window.B6_CONTROL_MS` spins a
+  named function for a set time inside every write. Predicted share
+  2/(2+4.055) = **33.0%**; measured **32.23%**. The profiler and the
+  attribution tool are sound to within a point.
+- **Every write verified at the DOM, inside its own window.** **0
+  unverified writes of 8,500** across every capture and every repeat
+  round in this page.
+- **The ablation arm is gated on canonical DOM.** It had to be: the first
+  version spelled its keys as `^{:key i}` metadata, rendered an **empty
+  page**, and the gate refused it rather than reporting a very fast
+  number for nothing at all. The published arm reports `parity=true`
+  against the reference arm's 11,915-character canonical serialisation.
+
+**And the profile agrees with the clock.** The capture's `flushSync`
+share × wall ÷ writes is **2.97 ms**; the clock's independently measured
+`force-ms` mean is **2.947 ms**. Two instruments, 1% apart.
+
+**Four things this page refuses to claim.**
+
+- **No absolute number here is comparable to the published table's.** A
+  single warm arm in a tight loop does not pay the cache eviction three
+  other substrates cause, so every arm is faster here than in the
+  interleaved suite (Freehand 4.0 ms against the suite's 5.4–7.4 ms).
+  **Ratios transfer; absolutes do not.** The ratio does transfer: **11×**
+  here against the suite's **10.5×**.
+- **Phase shares are single captures.** Only the wall-clock rows carry
+  ranges across rounds. A share quoted to two decimals is one capture's,
+  and should be read as ±1 point.
+- **No claim about mount.** This is the update row only.
+- **No memory claim.** The allocation reading the profile implies — that
+  this is churn — is not a heap measurement and is not offered as one.
+
+---
+
+## 1. The wall clock, three rounds
+
+p50 milliseconds per broad write; each round is 500 writes (Freehand) or
+2,000 (Reagent, floor). Range across three rounds in brackets.
+
+| arm | total | write | gap | force (React) |
+|---|---:|---:|---:|---:|
+| **Freehand interpreted** — 300 boundaries | **4.0** [3.9–4.5] | 0.7–0.8 | ~0.2 | 3.0–3.5 |
+| **Freehand interpreted** — 1 boundary, *same DOM* | **3.1** [3.0–3.2] | 0.7 | ~0.0 | 2.3–2.4 |
+| **Reagent** — 300 components | **0.35** [0.3–0.4] | 0.0 | 0.0 | 0.3–0.4 |
+| floor — top-down React, no substrate | 0.1 [0.1–0.2] | 0.0 | 0.0 | 0.1 |
+
+Freehand ÷ Reagent ≈ **11×**, disjoint ranges. The published interleaved
+suite says 10.5×; the two agree.
+
+---
+
+## 2. Where the 4.05 ms goes
+
+Shares of one 500-write capture, converted to milliseconds per write at
+the capture's own wall ÷ writes. React's phase frames (`Kh` = render,
+`Wk`/`Bl`/`Zb` = the commit-phase layout-effect loop) are the *same
+minified symbols* in every arm, because every arm rides one bundle.
+
+| leg | share | ms/write | what it is |
+|---|---:|---:|---|
+| **`flushSync` total** | 73.38% | **2.97** | React render + commit |
+| — React **render** (`Kh`) | 37.70% | 1.53 | |
+| —— `cell/observe!` → `record-read!` | 19.09% | **0.77** | recording 300 reactive reads on the candidate |
+| —— `react/emit` | 11.62% | 0.47 | the interpreted markup walk |
+| —— React hook machinery, other | ~7% | ~0.29 | 6 hooks × 300 boundaries |
+| — React **commit** layout effects (`Wk`) | 30.48% | **1.23** | |
+| —— `cell/commit!` | 29.43% | 1.19 | staging, re-reading and publishing 300 deps |
+| — React DOM mutation and diff | ~5% | ~0.21 | |
+| **outside `flushSync`** — the write leg | 18.38% | **0.74** | `frame/replace-app-db!` + the signal graph |
+| **outside `flushSync`** — gap, DOM read-back | ~8% | ~0.34 | the microtask, and the instrument's own verification |
+
+### The same three phases, across arms
+
+| arm | `flushSync` | React render `Kh` | **commit layout effects `Wk`** |
+|---|---:|---:|---:|
+| Freehand interpreted | 73.38% → 2.97 ms | 37.70% → 1.53 ms | **30.48% → 1.23 ms** |
+| Freehand, 1 boundary | 75.21% → 2.58 ms | 46.69% → 1.61 ms | **25.03% → 0.86 ms** |
+| **Reagent** | 91.41% → 0.359 ms | 51.01% → 0.200 ms | **0.36% → 0.0014 ms** |
+| floor | 86.25% → 0.153 ms | 6.87% → 0.012 ms | 0.49% → 0.0009 ms |
+
+**Read the last column first.** Freehand spends 1.23 ms in React's
+layout-effect commit loop. Reagent spends 1.4 **microseconds**. This is
+not Freehand doing the same work slowly; it is Freehand doing work Reagent
+does not do at all.
+
+---
+
+## 3. The ablation: is the cost per boundary?
+
+`b6-witnesses-flat/u-grid-flat` declares the same 300 `v/sub` reads and
+emits character-for-character the same DOM from **one** boundary instead
+of 300. The element count, tags, attributes and text are identical — the
+canonical-DOM gate proves it — so the pair varies exactly one thing.
+
+| | 300 boundaries | 1 boundary | delta |
+|---|---:|---:|---:|
+| total ms/write | 4.0 [3.9–4.5] | 3.1 [3.0–3.2] | **−0.9** |
+| React render | 1.53 | 1.61 | +0.08 |
+| `cell/commit!` | 1.23 | 0.86 | −0.37 |
+| write leg | 0.74 | 0.70 | −0.04 |
+
+Two things fall out, and the second is the finding.
+
+**The per-boundary constant is small.** 300 boundaries' worth of shell,
+ViewCell, React component fiber and six hooks each costs ≈0.9 ms — about
+3 µs a boundary, and ≈25% of the deficit.
+
+**`cell/commit!` did not collapse — it only shrank by 30%.** Because its
+cost is **O(dependencies), not O(boundaries)**: one boundary holding 300
+dependencies stages 300 records, re-reads 300 nodes and allocates a
+300-element `:observations` vector, exactly as 300 boundaries holding one
+each do. Collapsing the boundaries moved the fixed per-commit overhead and
+left the per-dependency work untouched.
+
+**And the render leg did not move at all** (1.53 → 1.61). Whatever the
+render costs, it is not the boundaries.
+
+---
+
+## 4. Why `cell/commit!` costs what it costs
+
+Per committed render, for every dependency, `cell/commit!` (`cell.cljc`
+§1107):
+
+1. `stage!` reconciles the prior dependency set against this render's read
+   order. On a broad write **every site is RETAINED** — same query, same
+   target, same handle — and staging still allocates two maps per site to
+   say so.
+2. `readings` calls `obs/read` on every handle. This is a **second deref
+   of every subscription**, after render already read it — and it is
+   load-bearing, not waste: it is the invariant-5 tear check, comparing
+   node-key, version and frame/registry epoch between the render that
+   produced the element and the commit about to publish it.
+3. The `bundle` allocates a 300-element `:observations` vector of five-key
+   maps.
+4. One `swap!` republishes `:deps`, `:dep-order`, `:frame`, `:lifecycle`
+   and the evidence slot.
+
+The dev-gated evidence plane (`commit-evidence`) is correctly absent from
+the capture — `goog.DEBUG false` removes it, and it appears nowhere in the
+profile.
+
+So the commit phase's 1.23 ms is ~8 persistent allocations and one
+subscription re-read per dependency, 300 times, serially, inside React's
+commit. **Nothing in it is a mistake.** Every step buys a guarantee Spec
+006 makes: all-or-nothing publication, rollback on a failed read,
+abandoned-render safety, and tear detection.
+
+That is what "architectural" means here — the cost is the guarantee.
+
+---
+
+## 5. What would have to change
+
+Ranked. **None of these is a bounded optimisation, and all of them are
+`cell.cljc`,** which PR #7133 currently holds — so this page changes no
+code. Each is filed as its own bead.
+
+1. **A retained-set fast path in `cell/commit!`** — the largest single
+   lever, ≈1.2 ms of a ≈3.65 ms deficit. When staging acquires and
+   releases nothing, the dependency set is structurally the prior one;
+   the staged map could be republished by identity instead of rebuilt.
+   The obstacle is step 2 above: the commit-side re-read is the tear
+   check, so this is a change to *when the invariant is checked*, not a
+   caching trick. It needs a spec conversation, not a patch.
+2. **A mutable dependency ledger.** The ledger is persistent maps rebuilt
+   per render; `array-index-of` alone is **10.65% self** of the whole
+   capture, spread across a dozen callers with none above 2.76%, which is
+   the signature of small persistent maps and sets being scanned
+   everywhere. PR #7077 already showed the shape of the win — moving the
+   memo stores to `js/Map` took `conversion/remembered` from 3.04% to
+   0.75%.
+3. **The per-boundary constant, ≈3 µs.** Six React hooks per boundary,
+   two of them layout effects, one a `useSyncExternalStore`. Worth ≈25% of
+   the deficit and the least tractable of the three, because each hook is
+   named in the shell's contract.
+
+Not on this list: the interpreted markup walk. `react/emit` is 0.47 ms of
+4.05 — even a 30% cut is 4% of the deficit. #7077 already took 26% out of
+that walk on the mount path; the update row is not where it lives.
+
+### A known future delta, not measured here
+
+**PR #7133 adds a second React commit per render batch** — a detached root
+whose layout effect calls `cell/flush!`. Everything above is `main`
+*without* it. The broad-update row is precisely where an extra commit pass
+would show, because the commit phase is already 30% of this window. It
+should be re-taken once #7133 lands.
+
+---
+
+## Appendix: the W1 interpreted-mount discrepancy, resolved
+
+Two numbers for "interpreted Freehand's W1 mount" were 57% apart and both
+post-#7077, so one of them was misinforming a P0:
+
+- **`rf2-xu6rx` / PR #7077** reports **1.904× floor** [1.755–2.020].
+- **`rf2-dq20a`** reports **2.987× floor** [2.840–3.167], measured later.
+
+**2.987 is the operative number. 1.904 is not comparable to it, and in
+particular is not comparable to Reagent.**
+
+**The direct evidence.** B6's instrument was re-run unmodified on `main`
+on 2026-07-27: **W1 interpreted = 3.075 [2.947–3.286]**, Reagent = **1.518
+[1.474–1.579]**. That is an independent reproduction of dq20a's
+2.987/1.554 and is nowhere near 1.904.
+
+**Why they differ — they are not measurements of the same thing.** Four
+named differences, ranked by how likely they are to carry the gap. Which
+one dominates is *not* established here; it is filed as its own bead.
+
+1. **Different witness.** #7077's W1 is the `studio` fixture: **1,204**
+   elements, a four-element skeleton (`section`/`h1`/`hr`/`ul#w1list`),
+   and a row carrying `.w1row` sugar *plus* a vector `:class ["cell"
+   "wide"]`, a **numeric** `:padding-left 4`, a `:title`, and a base64
+   data-URI `src`. B6's W1 is **1,203** elements, a three-element
+   skeleton, multi-class sugar only, `:padding-left "4px"`, no `:title`.
+   Different attribute counts and different conversion paths.
+2. **Different mount door.** The studio probe mounts every arm into ONE
+   pre-existing shared frame (`:frame fid`). B6 passes no `:frame`, so
+   `v/mount` creates a **fresh frame per sample, inside the timed
+   `flushSync`** — substrate cost the floor never pays, on every B6 sample
+   and on none of #7077's.
+3. **Different floor.** #7077's floor arm measured **5.2 ms** [4.7–5.7]
+   absolute for W1; B6's floor measures **2.4 ms** for a same-sized page.
+   A ratio is only as meaningful as its denominator, and these denominators
+   differ by ~2×.
+4. **#7077's harness has no Reagent arm at all.** It compares interpreted
+   Freehand to a hand-built React floor and to the compiled tier. 1.904
+   was never a Freehand-versus-Reagent number.
+
+**Neither bead did anything wrong.** #7077's claim is a *before/after on
+one instrument* — "the six cuts took the interpreted walk from 2.568 to
+1.904 on its own witness, alternated, ranges disjoint" — and nothing here
+disturbs it. What is wrong is only the transfer: quoting 1.904 as where
+interpreted mount stands relative to Reagent.
+
+**So the P0 should carry: interpreted W1 mount ≈ 2.99–3.08× floor, ≈1.9–2.0×
+Reagent.**
+
+Difference 2 is worth its own measurement rather than a mention, because
+if per-sample frame creation is material then B6's *mount* row overstates
+the substrate's per-mount cost — and the mount row is also on the release
+gate.
+
+## Provenance
+
+- Fixture: the published update grid — 300 reactive cells, 301 elements,
+  one `v/sub` per cell; broad write = one `frame/replace-app-db!` every
+  cell reads.
+- Window: `b6-rows/timed-write!`, unmodified.
+- Sampling: 60-write warm-up outside the capture; 500 writes (Freehand
+  arms) or 2,000 (Reagent, floor) inside it; CPU profile at a 100 µs
+  sampling interval over CDP.
+- Wall-clock rows: three independent rounds per arm, ranges quoted.
+- Gates green before any number was read: canonical-DOM parity of the
+  ablation arm against the reference arm; per-write DOM read-back, **0
+  unverified of 8,500**; positive control 32.23% against a predicted
+  33.0%; profile/clock agreement within 1%.
+- Build: `:advanced`, `goog.DEBUG false`, plus `:pseudo-names true` for
+  the profiled twin, via `--config-merge` over the existing
+  `:freehand-release` build id. `implementation/shadow-cljs.edn` is
+  unchanged.
+- Source, shipped rather than deleted so the next bead does not have to
+  recover it from a deleted branch:
+  `implementation/freehand/test/re_frame/freehand/bench/b6_profile_app.cljs`
+  (the one-arm driver and the positive control),
+  `b6_profile_run.cjs` (build, serve, CDP capture),
+  `b6_profile_report.cjs` (offline self / inclusive / caller / callee
+  attribution) and `b6_witnesses_flat.cljc` (the ablation witness).
+- Reproduce:
+  `node implementation/freehand/test/re_frame/freehand/bench/b6_profile_run.cjs --arm freehand-interpreted --writes 500`
+  then
+  `node implementation/freehand/test/re_frame/freehand/bench/b6_profile_report.cjs implementation/out/b6-profiles/freehand-interpreted.cpuprofile --under '^Kh$' --under '^Wk$'`.

--- a/implementation/freehand/test/re_frame/freehand/bench/b6_profile_app.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b6_profile_app.cljs
@@ -1,0 +1,156 @@
+(ns re-frame.freehand.bench.b6-profile-app
+  "B6's PROFILING entry — ONE update arm, driven in a tight loop, with no
+  other arm and no harness work sharing the window.
+
+  This namespace exists because
+  [[re-frame.freehand.bench.b6-prod-app]] cannot be profiled. It
+  interleaves four arms at the sample level, which is exactly right for
+  the clock and useless for attribution: a CPU profile of the whole suite
+  puts ~43% of its samples in `(idle)` and splits the rest across four
+  substrates, so no frame's share means anything. Attribution needs one
+  arm, alone, for a long uninterrupted stretch.
+
+  **Nothing about the measured window changes.** The write is
+  [[re-frame.freehand.bench.b6-rows/timed-write!]] verbatim — the same
+  state install, the same single microtask yield, the same empty
+  `react-dom/flushSync` drain, and the same per-write read-back of the
+  written cell out of the DOM. Profiling a window that differs from the
+  published one would describe a measurement nobody took.
+
+  ## The positive control is part of the instrument
+
+  `window.B6_CONTROL_MS` spins [[control-spin!]] for a known number of
+  milliseconds inside every write. It exists to FALSIFY the profiler: a
+  named frame of known cost must appear in the capture at the share
+  arithmetic predicts, or the attribution below it cannot be trusted
+  either. Two instrument faults on the predecessor bead each produced a
+  plausible wrong table, so a capture that cannot be checked against a
+  known quantity is not evidence.
+
+  Driven by
+  `implementation/freehand/test/re_frame/freehand/bench/b6_profile_run.cjs`.
+
+  Normative owner: `docs/design/freehand/decisions/`
+  `D021-performance-budgets-and-release-evidence.md`."
+  (:require [re-frame.adapter.uix :as react-substrate]
+            [re-frame.core :as rf]
+            [re-frame.freehand.bench.b6-harness :as h]
+            [re-frame.freehand.bench.b6-rows :as rows]
+            [re-frame.freehand.bench.b6-witnesses-flat :as flat]
+            [re-frame.freehand.bench.measure :as m]))
+
+;; ---------------------------------------------------------------------------
+;; The positive control
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private spin-sink (volatile! 0.0))
+
+(defn control-spin!
+  "Burn `ms` milliseconds of CPU in a frame with a name a profile can find.
+
+  The result is parked in a live volatile because Closure is entitled to
+  delete a loop whose value nothing reads — the same mistake the
+  predecessor report's forced-reflow reading made, where `layout-ms` came
+  back exactly 0.000 in every arm because the property read had been
+  dropped."
+  [ms]
+  (let [end (+ (m/now-ms) ms)]
+    (loop [x (double @spin-sink)]
+      (if (< (m/now-ms) end)
+        (recur (+ x (js/Math.sqrt (+ 1.0 x))))
+        (vreset! spin-sink x)))))
+
+;; ---------------------------------------------------------------------------
+;; The loop
+;; ---------------------------------------------------------------------------
+
+(defn- arm-named
+  "The four published arms, plus the ABLATION arm — the same 300 reads and
+  the same DOM under ONE boundary instead of three hundred. It is built
+  through [[re-frame.freehand.bench.b6-rows/freehand-update-arm]], the
+  same constructor the published Freehand arm uses, so the two differ in
+  the view they mount and in nothing else."
+  [id]
+  (or (first (filter #(= id (:id %)) (rows/make-update-arms)))
+      (when (= id :freehand-flat)
+        (rows/freehand-update-arm :freehand-flat flat/u-grid-flat))
+      (throw (ex-info "no such arm" {:id id}))))
+
+(defn- run-writes!
+  "`n` broad writes on `mnt`, each through the published window. Answers a
+  promise of the accumulated legs and the count of writes whose DOM
+  read-back FAILED."
+  [mnt n control-ms]
+  (rows/chain {:ms [] :write [] :gap [] :force [] :bad 0} (range n)
+    (fn [acc _]
+      (let [val (rows/next-gen!)]
+        (when (pos? control-ms) (control-spin! control-ms))
+        (-> (rows/timed-write! mnt :all val)
+            (.then (fn [{:keys [ms write-ms gap-ms force-ms ok? ok2?]}]
+                     (cond-> (-> acc
+                                 (update :ms conj ms)
+                                 (update :write conj write-ms)
+                                 (update :gap conj gap-ms)
+                                 (update :force conj force-ms))
+                       (not (and ok? ok2?)) (update :bad inc)))))))))
+
+(defn- summarise
+  [{:keys [ms write gap force bad]} n control-ms]
+  {:writes         n
+   :control-ms     control-ms
+   :unverified     bad
+   :ms             (m/summarise ms)
+   :write-ms       (m/summarise write)
+   :gap-ms         (m/summarise gap)
+   :force-ms       (m/summarise force)
+   :total-ms       (reduce + 0.0 ms)})
+
+(defn ^:export -main
+  []
+  (try
+    (rf/init! react-substrate/adapter)
+    (h/leave-act-environment!)
+    (let [arm-id     (keyword (or (.-B6_ARM js/window) "freehand-interpreted"))
+          control-ms (or (.-B6_CONTROL_MS js/window) 0)
+          mounts     (rows/mount-update-arms! [(arm-named arm-id)])
+          mnt        (first mounts)]
+      ;; The run door. The driver warms, then starts the CPU profiler, then
+      ;; calls this — so the capture contains writes and nothing else.
+      (set! (.-B6_RUN js/window)
+            (fn [n]
+              (-> (run-writes! mnt n control-ms)
+                  (.then (fn [acc]
+                           (let [s (summarise acc n control-ms)]
+                             (set! (.-B6_LAST js/window) (pr-str (assoc s :arm arm-id)))
+                             (clj->js {:unverified (:unverified s)
+                                       :p50        (:p50 (:ms s))
+                                       :edn        (.-B6_LAST js/window)})))))))
+      ;; THE ABLATION ARM IS GATED ON CANONICAL DOM, like every other arm.
+      ;; A one-boundary grid that quietly built a different page would be a
+      ;; fast number for a different measurement — which is exactly the
+      ;; mistake the predecessor report's first parity run nearly published.
+      ;; Only for an arm that is NOT the reference: mounting a second
+      ;; `:freehand-interpreted` root would collide on the reference arm's
+      ;; own root identity, which `v/mount` refuses (idempotent per root).
+      (when (not= arm-id :freehand-interpreted)
+       (let [ref   (rows/mount-update-arms! [(arm-named :freehand-interpreted)])
+            a     (h/canonical (:container (first ref)))
+            b     (h/canonical (:container mnt))
+            same? (= a b)]
+        (rows/release-update-arms! ref)
+        (set! (.-B6_PARITY js/window) same?)
+        (when-not same?
+          (let [n (count (take-while true? (map = a b)))]
+            (throw (ex-info "the profiled arm does not build the reference page"
+                            {:arm arm-id :at n :ref-len (count a) :got-len (count b)
+                             :ref (subs a (max 0 (- n 60)) (min (count a) (+ n 120)))
+                             :got (subs b (max 0 (- n 60)) (min (count b) (+ n 120)))}))))))
+      (-> (rows/seed-update-arms! mounts)
+          (.then (fn [_]
+                   (set! (.-B6_READY js/window) true)
+                   (js/console.log (str ";; B6 PROFILE READY " (name arm-id)
+                                        " parity=" (.-B6_PARITY js/window)))
+                   nil))))
+    (catch :default e
+      (set! (.-B6_ERROR js/window) (str e))
+      (js/console.error (str ";; B6 PROFILE FAILED — " e)))))

--- a/implementation/freehand/test/re_frame/freehand/bench/b6_profile_report.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b6_profile_report.cjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+// Offline attribution over a saved `.cpuprofile`.
+//
+//   node b6_profile_report.cjs <file.cpuprofile> [--top 30] [--callers RE]...
+//
+// SELF TIME NAMES THE FUNCTION; ONLY CALLER ATTRIBUTION NAMES THE FIX.
+// That is the lesson `rf2-lnecd` recorded and `rf2-xu6rx` re-used: self
+// time said `clojure.string/replace`, memoising the obvious caller moved
+// nothing, and walking the parent chain found the real one in a step.
+// So this tool reports three things, and the third is the useful one:
+//
+//   1. self  — samples whose LEAF is this frame.
+//   2. incl  — samples whose ancestry PASSES THROUGH this frame, counted
+//              once per sample even when the frame recurs on the chain.
+//   3. callers of <pattern> — for every sample under a matching frame,
+//              the chain of named ancestors above the NEAREST match,
+//              aggregated. This is what says where a cost comes FROM.
+//
+// Run offline over ONE saved capture rather than one browser run per
+// question: a frame re-profiled is a frame compared against a different
+// profile.
+
+const fs = require('node:fs');
+
+const file = process.argv[2];
+if (!file) {
+  console.error('usage: b6_profile_report.cjs <file.cpuprofile> [--top N] [--callers RE]...');
+  process.exit(2);
+}
+const TOP = Number((process.argv.includes('--top') && process.argv[process.argv.indexOf('--top') + 1]) || 30);
+const PATTERNS = process.argv.reduce(
+  (acc, a, i) => (a === '--callers' ? acc.concat([process.argv[i + 1]]) : acc),
+  []
+);
+const UNDER = process.argv.reduce(
+  (acc, a, i) => (a === '--under' ? acc.concat([process.argv[i + 1]]) : acc),
+  []
+);
+const DEPTH = Number((process.argv.includes('--depth') && process.argv[process.argv.indexOf('--depth') + 1]) || 4);
+
+const profile = JSON.parse(fs.readFileSync(file, 'utf8'));
+const byId = new Map();
+for (const n of profile.nodes) byId.set(n.id, n);
+const parent = new Map();
+for (const n of profile.nodes) for (const c of n.children || []) parent.set(c, n.id);
+
+const nameOf = (n) => {
+  const f = n.callFrame;
+  const nm = f.functionName || '(anonymous)';
+  return nm;
+};
+
+const total = profile.samples.length;
+const selfByNode = new Map();
+for (const s of profile.samples) selfByNode.set(s, (selfByNode.get(s) || 0) + 1);
+
+// --- self / inclusive by name ---------------------------------------------
+const self = new Map();
+const incl = new Map();
+const add = (m, k, v) => m.set(k, (m.get(k) || 0) + v);
+
+const chainCache = new Map();
+function chain(id) {
+  if (chainCache.has(id)) return chainCache.get(id);
+  const out = [];
+  let cur = id;
+  while (cur !== undefined) {
+    out.push(cur);
+    cur = parent.get(cur);
+  }
+  chainCache.set(id, out);
+  return out;
+}
+
+for (const [id, count] of selfByNode) {
+  const node = byId.get(id);
+  if (!node) continue;
+  add(self, nameOf(node), count);
+  const seen = new Set();
+  for (const a of chain(id)) {
+    const nm = nameOf(byId.get(a));
+    if (!seen.has(nm)) {
+      seen.add(nm);
+      add(incl, nm, count);
+    }
+  }
+}
+
+const pct = (n) => ((100 * n) / total).toFixed(2).padStart(6) + '%';
+const sorted = (m) => [...m.entries()].sort((a, b) => b[1] - a[1]);
+
+console.log(`=== ${file}`);
+console.log(`total samples ${total}  (interval ${profile.timeDeltas ? 'variable' : 'n/a'})`);
+const wall = (profile.endTime - profile.startTime) / 1000;
+console.log(`capture wall ${wall.toFixed(1)} ms\n`);
+
+const SYNTH = new Set(['(idle)', '(program)', '(garbage collector)', '(root)']);
+let synth = 0;
+for (const [k, v] of self) if (SYNTH.has(k)) synth += v;
+console.log(`--- synthetic frames (idle/program/GC): ${pct(synth)} of samples`);
+for (const [k, v] of sorted(self)) if (SYNTH.has(k)) console.log(`  ${pct(v)}  ${k}`);
+console.log();
+
+// React and react-dom arrive as ALREADY-MINIFIED npm JavaScript, so
+// `:pseudo-names` cannot name them — it renames ClojureScript symbols, and
+// React's `nl`/`Gl`/`Kh` were minified by React's own build long before
+// Closure saw them. Their `url:line` is the only handle there is, so the
+// self listing carries it and the report identifies React frames by
+// position rather than pretending to a name.
+const locOf = (n) => {
+  const f = n.callFrame;
+  const u = (f.url || '').split('/').pop();
+  return u ? `${u}:${f.lineNumber + 1}:${f.columnNumber + 1}` : '';
+};
+const selfLoc = new Map();
+for (const [id, count] of selfByNode) {
+  const node = byId.get(id);
+  if (!node) continue;
+  add(selfLoc, `${nameOf(node)}   @${locOf(node)}`, count);
+}
+
+console.log(`--- TOP ${TOP} SELF (with location; React frames are pre-minified)`);
+for (const [k, v] of sorted(selfLoc).slice(0, TOP)) console.log(`  ${pct(v)}  ${k}`);
+console.log();
+
+console.log(`--- TOP ${TOP} INCLUSIVE`);
+for (const [k, v] of sorted(incl).slice(0, TOP)) console.log(`  ${pct(v)}  ${k}`);
+console.log();
+
+// --- what a subtree SPENDS ITSELF ON ---------------------------------------
+// The mirror of caller attribution. `--callers` says where a cost comes
+// from; `--under` says what an inclusive share is actually made of, by
+// bucketing every sample beneath a named frame by its own LEAF. Both are
+// needed: a 29% inclusive frame that is 29% one callee is a hot spot, and
+// the same 29% spread across twenty callees is a structure.
+for (const p of UNDER) {
+  const re = new RegExp(p);
+  const leaves = new Map();
+  let hit = 0;
+  for (const [id, count] of selfByNode) {
+    const ch = chain(id);
+    if (!ch.some((a) => re.test(nameOf(byId.get(a))))) continue;
+    hit += count;
+    add(leaves, `${nameOf(byId.get(id))}   @${locOf(byId.get(id))}`, count);
+  }
+  console.log(`--- SELF TIME UNDER /${p}/ : ${pct(hit)} inclusive of ${total} samples`);
+  for (const [k, v] of sorted(leaves).slice(0, TOP)) console.log(`  ${pct(v)}  ${k}`);
+  console.log();
+}
+
+// --- caller attribution ----------------------------------------------------
+for (const p of PATTERNS) {
+  const re = new RegExp(p);
+  const chains = new Map();
+  let hit = 0;
+  for (const [id, count] of selfByNode) {
+    const ch = chain(id); // leaf -> root
+    // NEAREST matching frame: the first on the leaf->root walk.
+    const idx = ch.findIndex((a) => re.test(nameOf(byId.get(a))));
+    if (idx === -1) continue;
+    hit += count;
+    const above = ch.slice(idx + 1, idx + 1 + DEPTH).map((a) => nameOf(byId.get(a)));
+    const key = nameOf(byId.get(ch[idx])) + ' <- ' + (above.join(' <- ') || '(root)');
+    add(chains, key, count);
+  }
+  console.log(`--- callers of /${p}/ : ${pct(hit)} inclusive of ${total} samples`);
+  for (const [k, v] of sorted(chains).slice(0, TOP)) console.log(`  ${pct(v)}  ${k}`);
+  console.log();
+}

--- a/implementation/freehand/test/re_frame/freehand/bench/b6_profile_run.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b6_profile_run.cjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+// B6's PROFILING driver — build one `:advanced` bundle with readable
+// names, run ONE update arm in a tight loop, and save a CDP CPU profile.
+//
+//   node implementation/freehand/test/re_frame/freehand/bench/b6_profile_run.cjs \
+//        --arm freehand-interpreted --writes 400 [--control-ms 1] [--no-build]
+//
+// WHY A SECOND BUILD. The published numbers come from `:advanced` with
+// `goog.DEBUG false`, where every symbol is renamed to `Xa`. A profile of
+// that bundle names nothing. `:pseudo-names true` keeps the same
+// `:advanced` optimisation pipeline — same inlining, same DCE, same
+// collapsed properties — and only changes the renaming policy, so the
+// profiled twin is the shipped artefact with its labels left on.
+//
+// WHY ONE ARM. `b6_prod_run.cjs` interleaves four arms at the sample
+// level, which is right for the clock and useless for attribution: the
+// samples split four ways and most of the capture is scheduler idle.
+//
+// Exits non-zero if any write failed its DOM read-back.
+
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const http = require('node:http');
+const path = require('node:path');
+
+const IMPL = path.resolve(__dirname, '../../../../..');
+const OUT = path.join(IMPL, 'out', 'b6-profile');
+const PORT = Number(process.env.B6_PORT || 8129);
+
+function arg(name, dflt) {
+  const i = process.argv.indexOf(`--${name}`);
+  return i === -1 ? dflt : process.argv[i + 1];
+}
+const ARM = arg('arm', 'freehand-interpreted');
+const WRITES = Number(arg('writes', 400));
+const WARMUP = Number(arg('warmup', 60));
+const CONTROL_MS = Number(arg('control-ms', 0));
+const NO_BUILD = process.argv.includes('--no-build');
+const TAG = arg('tag', ARM + (CONTROL_MS ? `-control${CONTROL_MS}` : ''));
+
+// ONE LINE, deliberately: shadow-cljs's CLI re-splits `--config-merge` on
+// whitespace when the EDN contains a newline. Same trap as b6_prod_run.
+const CONFIG_MERGE =
+  '{:output-dir "out/b6-profile" :asset-path "." ' +
+  ':compiler-options {:pseudo-names true} ' +
+  ':modules {:main {:init-fn re-frame.freehand.bench.b6-profile-app/-main}}}';
+
+function build() {
+  console.error('[b6p] building :advanced + :pseudo-names bundle ...');
+  const runner = path.join(IMPL, 'node_modules', 'shadow-cljs', 'cli', 'runner.js');
+  const r = spawnSync(
+    process.execPath,
+    [runner, 'release', 'freehand-release', '--config-merge', CONFIG_MERGE],
+    { cwd: IMPL, stdio: ['ignore', 'inherit', 'inherit'] }
+  );
+  if (r.status !== 0) {
+    console.error(`[b6p] build failed with status ${r.status}`);
+    process.exit(1);
+  }
+}
+
+const MIME = { '.js': 'text/javascript', '.html': 'text/html', '.map': 'application/json' };
+
+function serve() {
+  fs.writeFileSync(
+    path.join(OUT, 'index.html'),
+    '<!doctype html><html><head><meta charset="utf-8"><title>B6 profile</title></head>' +
+      `<body><div id="app"></div><script>window.B6_ARM=${JSON.stringify(ARM)};` +
+      `window.B6_CONTROL_MS=${CONTROL_MS};</script>` +
+      '<script src="main.js"></script></body></html>'
+  );
+  return http
+    .createServer((req, res) => {
+      const rel = decodeURIComponent(req.url.split('?')[0]);
+      const file = path.join(OUT, rel === '/' ? 'index.html' : rel);
+      if (!file.startsWith(OUT) || !fs.existsSync(file)) {
+        res.writeHead(404).end('not found');
+        return;
+      }
+      res.writeHead(200, { 'content-type': MIME[path.extname(file)] || 'application/octet-stream' });
+      fs.createReadStream(file).pipe(res);
+    })
+    .listen(PORT);
+}
+
+async function run() {
+  const { chromium } = require('playwright');
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  page.on('console', (m) => {
+    const t = m.text();
+    if (t.startsWith(';; B6')) console.error(t);
+  });
+  page.on('pageerror', (e) => console.error('[b6p] page error:', e.message));
+  await page.goto(`http://127.0.0.1:${PORT}/`, { waitUntil: 'load' });
+  await page.waitForFunction('window.B6_READY === true || window.B6_ERROR', null, {
+    timeout: 5 * 60 * 1000,
+  });
+  const err = await page.evaluate('window.B6_ERROR || null');
+  if (err) throw new Error(err);
+
+  // Warm up OUTSIDE the capture: first-call compilation, IC warm-up and
+  // the initial allocation ramp are not what this profile is asking about.
+  console.error(`[b6p] warming ${WARMUP} writes ...`);
+  const warm = await page.evaluate((n) => window.B6_RUN(n), WARMUP);
+  if (warm.unverified > 0) throw new Error(`warm-up had ${warm.unverified} unverified writes`);
+
+  const client = await page.context().newCDPSession(page);
+  await client.send('Profiler.enable');
+  await client.send('Profiler.setSamplingInterval', { interval: 100 });
+  await client.send('Profiler.start');
+  console.error(`[b6p] profiling ${WRITES} writes of arm ${ARM} ...`);
+  const res = await page.evaluate((n) => window.B6_RUN(n), WRITES);
+  const { profile } = await client.send('Profiler.stop');
+  await browser.close();
+  return { res, profile };
+}
+
+(async () => {
+  if (!NO_BUILD) build();
+  fs.mkdirSync(OUT, { recursive: true });
+  const server = serve();
+  let out;
+  try {
+    out = await run();
+  } finally {
+    server.close();
+  }
+  const dir = path.join(IMPL, 'out', 'b6-profiles');
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, `${TAG}.cpuprofile`);
+  fs.writeFileSync(file, JSON.stringify(out.profile));
+  console.log(out.res.edn);
+  console.log(`;; profile -> ${file}`);
+  if (out.res.unverified > 0) {
+    console.error(`[b6p] FAILED: ${out.res.unverified} of ${WRITES} writes did not reach the DOM`);
+    process.exit(1);
+  }
+  console.error('[b6p] ok');
+})();

--- a/implementation/freehand/test/re_frame/freehand/bench/b6_rows.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b6_rows.cljs
@@ -243,7 +243,11 @@
                        (fn [] (.render ^js @rt (floor/u-grid @state)))))
      :unmount (fn [r] (react-dom/flushSync (fn [] (.unmount r))))}))
 
-(defn- freehand-update-arm [id view]
+(defn freehand-update-arm
+  "Public so the PROFILING entry can build an ablation arm through the
+  SAME constructor the published rows use — a second, near-copy arm
+  builder would be a second place for the measured window to drift."
+  [id view]
   (let [fid (keyword "b6-update" (name id))]
     {:id      id
      :mount   (fn [container]

--- a/implementation/freehand/test/re_frame/freehand/bench/b6_witnesses_flat.cljc
+++ b/implementation/freehand/test/re_frame/freehand/bench/b6_witnesses_flat.cljc
@@ -1,0 +1,44 @@
+(ns re-frame.freehand.bench.b6-witnesses-flat
+  "The update grid with ONE boundary instead of three hundred — B6's
+  ABLATION witness, and the control that decides whether the broad-update
+  deficit is per-ELEMENT or per-BOUNDARY.
+
+  [[re-frame.freehand.bench.b6-witnesses/u-grid]] declares a `v/defview`
+  per cell, so a broad write repaints 300 boundaries: 300 shells, 300
+  ViewCells, 300 sets of React hooks, and 300 commit-phase layout effects.
+  This declaration builds **character-for-character the same DOM** from a
+  single boundary that reads all 300 subscriptions itself. The element
+  count, the tags, the attributes and the text are identical — which is
+  what makes the pair an ablation rather than two benchmarks.
+
+  Everything else is held constant: the same `:b6/cell` subscriptions, the
+  same 300 reads, the same interpreted lowering, the same `v/sub` door,
+  the same emitter walk over the same hiccup. The ONLY variable is how
+  many boundaries the 300 reads are spread across.
+
+  So the difference between the two arms is the cost of a BOUNDARY, and
+  nothing else. If bulk re-render were dominated by the interpreted markup
+  walk the two would land together; if it is dominated by per-boundary
+  shell and commit machinery they will not.
+
+  Not a published row and not a shape anybody should write — a real
+  application wants the fine-grained version, because the whole point of a
+  per-cell boundary is that a NARROW write repaints one cell. This exists
+  to attribute a cost.
+
+  Normative owner: `docs/design/freehand/decisions/`
+  `D021-performance-budgets-and-release-evidence.md`."
+  (:require [re-frame.freehand :as v]))
+
+(v/defview u-grid-flat
+  "300 reactive cells under ONE boundary. The `v/sub` calls are the same
+  300 the per-cell version makes, and the emitted markup is the same; they
+  are simply all recorded on one candidate and published by one commit."
+  [{:keys [n]}]
+  [:div.ugrid
+   (for [i (range n)]
+     ;; `:key` in the PROPS MAP, which is Freehand's one spelling for the
+     ;; structural identity slot (`rules/reserved-key-slot`). React consumes
+     ;; it, so it does not reach the DOM and the canonical-DOM gate still
+     ;; sees the reference page.
+     [:span.cell {:key i :data-i i} (str (v/sub [:b6/cell i]))])])


### PR DESCRIPTION
## The two answers, first

**1. The W1-interpreted mount discrepancy: `2.987` is right, `1.904` is not comparable.**

B6's instrument re-run unmodified on `main` today gives **W1 interpreted = 3.075 [2.947–3.286]**, Reagent **1.518 [1.474–1.579]** — an independent reproduction of `rf2-dq20a`. The two figures measure different things: different witness (**1204** vs **1203** elements, vector `:class` + numeric style + `:title` vs multi-class sugar), different mount door (one **shared** frame vs a **fresh frame per sample inside the timed window**), different floor (5.2 ms vs 2.4 ms absolute), and **#7077's harness has no Reagent arm at all**. #7077's own before/after claim stands untouched; only the *transfer* was wrong.

**The P0 should carry ≈2.99–3.08× floor, ≈1.9–2.0× Reagent.**

**2. The broad-update ~10×: ARCHITECTURAL, not a fixable hot spot.**

- **No hot spot exists.** Largest single self frame is **4.69%** (render phase) and **4.26%** (commit phase) — neither is a Freehand function. Both phases are flat `cljs.core` collection primitives.
- **Not per-boundary, and an ablation proves it.** Same DOM, same 300 reads, same lowering, varying *only* boundary count: 300 → 1 moves **[3.9–4.5] ms → [3.0–3.2] ms**. **With one boundary Freehand is still ≈9× Reagent.**
- **What survives is the observation ledger, O(reactive reads).** Recording 300 reads at render 0.77–0.86 ms; re-staging/re-reading/republishing the same 300 deps in the commit-phase layout effect 0.86–1.23 ms. **≈55% of the gap.** Reagent's entire layout-effect commit phase is **0.36% → 1.4 µs** against Freehand's **1.23 ms**, because it has none.

That is Spec 006's atomic shell contract, and the commit-side re-read is the **invariant-5 tear check**. Every step buys a stated guarantee. The cost *is* the guarantee.

## Why this branch changes no product code

All three candidate fixes live in `implementation/freehand/src/re_frame/freehand/cell.cljc`, which **PR #7133 holds**, and none is a bounded optimisation — each is a ledger redesign needing a spec conversation. Per the fence, I stopped and filed beads instead.

## Instrument scepticism — three checks, all three fired

| check | result |
|---|---|
| positive control of known cost | predicted **33.0%**, measured **32.23%** |
| per-write DOM read-back | **0 unverified of 8,500** |
| canonical-DOM gate on the ablation arm | **caught its first version rendering an EMPTY page** and refused it |
| profile vs clock, same quantity | 2.97 ms vs 2.947 ms — **1% apart** |

## Gates

| Gate | Result | Exit |
|---|---|---|
| freehand JVM (`clojure -M:test`) | 1218 tests / 8212 assertions, 0 failures, 0 errors | `0` |
| `npm run test:cljs` | 11780 tests / 58669 assertions, 0 failures, 0 errors | `0` |
| B6 prod run, unmodified, on `main` | reproduces the published table; 0 unverified writes | `0` |

Slower gates (`test:browser`, full spine) deferred to CI. **This branch adds no tests and no product code** — the diff is bench scaffolding under `freehand/test/.../bench/` plus one studio page, and one `defn-` → `defn` so the profiler builds its ablation arm through the published constructor rather than a near-copy.

## Known future delta

**PR #7133 adds a second React commit per render batch.** Everything here is `main` *without* it, and the broad-update row is exactly where an extra commit pass would show — the commit phase is already 30% of this window. Re-take once it lands.

## Scaffolding is shipped, not deleted

`rf2-xu6rx` had to recover `rf2-lnecd`'s deleted probe from a deleted branch. This one ships: `b6_profile_app.cljs`, `b6_profile_run.cjs` (build + serve + CDP capture), `b6_profile_report.cjs` (self / inclusive / caller / callee attribution) and `b6_witnesses_flat.cljc` (the ablation witness).