### PR TITLE
fix(tools): carry ex-data on relay 1 and refuse an under-specified Xray pom (rf2-qoih4, rf2-5dut1)

### DIFF
--- a/.github/scripts/preflight-xray-package.sh
+++ b/.github/scripts/preflight-xray-package.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env sh
+# preflight-xray-package.sh (rf2-5dut1)
+#
+# # Why this exists
+#
+# `clein pom` SILENTLY SKIPS `:local/root` coordinates. tools/xray/deps.edn
+# declares TEN of them in its main `:deps` — core, epoch, routing, flows,
+# schemas, resources, machines, freehand, machines-viz and reagent-slim —
+# and release-xray.yml rewrites only TWO (core, reagent-slim). Run against
+# the in-tree deps.edn today, `clein pom` prints ten `Skipping coordinate`
+# lines and writes a pom whose `<dependencies>` are four third-party
+# artefacts and nothing else. A jar cut from the release workflow would
+# therefore publish a pom declaring two of Xray's ten in-repo runtime
+# dependencies.
+#
+# That is precisely the failure class rf2-wht9a found in Story and closed
+# with preflight-story-package.sh: the consumer installs the artefact,
+# resolves a pom with holes in it, and hits
+#
+#     No such namespace: day8.re-frame2-epoch.…
+#
+# at compile time. Clojars has no yank, so the mistake is unrecoverable —
+# bump-and-supersede only. This script is the gate that proves the rewrite
+# took effect, run AFTER the rewrite and BEFORE `clojure -M:clein deploy`.
+#
+# # The required set is DERIVED, never hand-maintained
+#
+# This is the one place this script deliberately departs from its Story
+# sibling, and the reason is the bug it exists for. Story's expected set is
+# a literal in the script; Xray's rewrite list was a literal in the
+# workflow, and it drifted from two coordinates to two-of-ten without a
+# single gate noticing, because nothing tied either literal back to
+# deps.edn. So the required set here is READ OUT OF deps.edn itself, from
+# the PRISTINE committed copy (`git show HEAD:tools/xray/deps.edn` — the
+# workspace copy has already been rewritten in place by the time this
+# runs). Add an eleventh `:local/root` coordinate to Xray and this gate
+# demands its rewrite on the next release with no edit here.
+#
+# The EDN is parsed with Clojure's own reader rather than grepped: this is
+# the last gate before an irreversible publish, and a text parser that
+# mis-reads a reformatted deps.edn would produce exactly the false PASS the
+# script exists to prevent. The pom is parsed with ElementTree for the same
+# reason (mirroring preflight-story-package.sh).
+#
+# # Assertions
+#
+#   1. every DIRECT dependency in the generated pom carries a COMPLETE
+#      coordinate — non-empty groupId, artifactId AND version. A published
+#      GAV with a hole in it is unresolvable on the consumer's machine.
+#   2. every in-repo coordinate deps.edn declares at `:local/root` is
+#      PRESENT in the pom. This is the skipped-coordinate hole itself.
+#   3. every one of them is pinned to the exact lockstep VERSION. A rewrite
+#      that fired with the wrong value is as broken as one that did not
+#      fire — per spec/Conventions.md §Packaging conventions every
+#      published artefact ships at the repo-root VERSION.
+#
+# There is deliberately NO "no unexpected extras" assertion (Story has
+# one). That half needs a hand-maintained roster of third-party deps, which
+# is the maintenance shape this script is avoiding, and Xray's third-party
+# pins are already guarded in deps.edn by the lockstep script.
+#
+# # This gate is EXPECTED TO FAIL TODAY, and that is the point
+#
+# Eight of Xray's ten coordinates are unrewritten, so the first `xray-v*`
+# tag push after this lands will be REFUSED here, with all eight named,
+# instead of publishing a broken pom quietly. Seven of the eight are a
+# mechanical fix — add the rewrite line, add the coordinate to
+# TOOLS_LOCAL_ROOTS in .github/scripts/verify-version-lockstep.sh.
+#
+# The eighth is an OPEN OPERATOR DECISION and this script does not make it:
+# `day8/re-frame2-freehand` CANNOT be rewritten to a `:mvn/version` at all.
+# implementation/freehand/deps.edn carries no `:clein/build` — deliberately
+# ("NO :clein deploy aliases — deliberate, not an omission. Publication is
+# F6 territory"). So Xray declares a runtime dependency on an artefact that
+# is not publishable until the EP-0036 F6 gate. Either Xray is not
+# publishable until Freehand ships, or the Freehand edge moves to
+# late-bind. Until that is ruled on, refusing the release is the correct
+# outcome, not an obstacle to route around.
+#
+# # Runner / portability
+#
+# Linux-runner-only by design (sole caller is release-xray.yml on
+# ubuntu-latest). POSIX sh + python3 — python3 is already a runner
+# requirement for the rewrite step that runs immediately before this, and
+# ships on ubuntu-latest. No .ps1 sibling (same rationale as
+# preflight-story-package.sh).
+#
+# # Usage
+#
+#   ./.github/scripts/preflight-xray-package.sh VERSION [XRAY_DIR]
+#
+# XRAY_DIR defaults to the current working directory (release-xray.yml runs
+# it with working-directory: tools/xray).
+
+set -eu
+
+VERSION="${1:?usage: preflight-xray-package.sh VERSION [XRAY_DIR]}"
+XRAY_DIR="${2:-.}"
+cd "$XRAY_DIR"
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+PRISTINE_DEPS=$(mktemp)
+REQUIRED_FILE=$(mktemp)
+trap 'rm -f "$PRISTINE_DEPS" "$REQUIRED_FILE"' EXIT
+
+# The COMMITTED deps.edn — the workspace copy has already been rewritten
+# in place by release-xray.yml's rewrite step, so it can no longer say
+# which coordinates were supposed to be rewritten.
+git -C "$REPO_ROOT" show HEAD:tools/xray/deps.edn > "$PRISTINE_DEPS"
+
+echo "preflight: reading Xray's in-repo runtime coordinates from the committed deps.edn"
+clojure -Sdeps '{:paths []}' -M -e "
+(require '[clojure.edn :as edn] '[clojure.string :as str])
+(let [deps (:deps (edn/read-string (slurp \"$PRISTINE_DEPS\")))]
+  (spit \"$REQUIRED_FILE\"
+        (str/join (for [[lib coord] (sort-by key deps)
+                        :when (:local/root coord)]
+                    (str lib \"\n\")))))" > /dev/null
+
+REQUIRED_COUNT=$(grep -c . "$REQUIRED_FILE" || true)
+if [ "${REQUIRED_COUNT}" -eq 0 ]; then
+  echo "::error::preflight: found ZERO :local/root coordinates in the committed tools/xray/deps.edn — the reader found nothing to require, which means this gate would pass vacuously. Refusing."
+  exit 2
+fi
+echo "preflight: ${REQUIRED_COUNT} in-repo coordinate(s) must appear in the published pom:"
+sed 's/^/  /' "$REQUIRED_FILE"
+
+echo "preflight: building Xray pom at lockstep version ${VERSION} (build only — NOT deploy)"
+clojure -M:clein pom
+
+# clein writes the pom under target/classes/META-INF/maven/<group>/<artifact>/pom.xml
+POM="target/classes/META-INF/maven/day8/re-frame2-xray/pom.xml"
+if [ ! -f "$POM" ]; then
+  echo "::error::preflight: expected pom not found at $POM"
+  exit 2
+fi
+echo "preflight: pom = $POM"
+
+if ! VERSION="$VERSION" REQUIRED_FILE="$REQUIRED_FILE" python3 - "$POM" <<'PYTHON'
+import os
+import sys
+import xml.etree.ElementTree as ET
+
+pom_path = sys.argv[1]
+version = os.environ["VERSION"]
+
+with open(os.environ["REQUIRED_FILE"]) as handle:
+    # Each line is a Clojure lib symbol, `group/artifact`, straight from
+    # deps.edn. A group-less symbol is not a legal deps.edn coordinate for
+    # a Maven artefact, so the split is total.
+    REQUIRED = set()
+    for line in handle:
+        line = line.strip()
+        if not line:
+            continue
+        group, _, artifact = line.partition("/")
+        REQUIRED.add((group, artifact))
+
+FREEHAND = ("day8", "re-frame2-freehand")
+
+MISSING_HINT = (
+    " NB: `clein pom` SKIPS :local/root coordinates outright, so this is"
+    " exactly the pom produced when release-xray.yml's :local/root ->"
+    " :mvn/version rewrite did not cover this coordinate. Publishing it"
+    " would ship an Xray that cannot compile on a consumer's machine."
+    " Fix: add the coordinate to the rewrite step in"
+    " .github/workflows/release-xray.yml AND to TOOLS_LOCAL_ROOTS in"
+    " .github/scripts/verify-version-lockstep.sh, in the same PR."
+)
+
+FREEHAND_HINT = (
+    " THIS ONE IS NOT A MECHANICAL FIX AND MUST NOT BE TREATED AS ONE"
+    " (rf2-5dut1). day8/re-frame2-freehand cannot be rewritten to any"
+    " :mvn/version, because implementation/freehand/deps.edn carries no"
+    " :clein/build — deliberately; publication is EP-0036 F6 territory."
+    " Xray therefore declares a RUNTIME dependency on an artefact that is"
+    " not publishable yet. Either Xray is not publishable until Freehand"
+    " ships, or the Freehand edge moves to late-bind. That is an operator"
+    " decision; until it is made, this refusal is the correct outcome."
+)
+
+
+def localname(tag):
+    """Tag name without its {namespace} prefix."""
+    return tag.rsplit("}", 1)[-1]
+
+
+def child_text(parent, name):
+    for el in parent:
+        if localname(el.tag) == name:
+            return (el.text or "").strip()
+    return ""
+
+
+errors = []
+
+try:
+    root = ET.parse(pom_path).getroot()
+except ET.ParseError as exc:
+    print("::error::preflight: pom is not well-formed XML: %s" % exc)
+    sys.exit(1)
+
+# Only <project>'s DIRECT <dependencies> child, never a
+# <dependencyManagement> block's (which declares versions but not deps).
+dependencies = []
+for container in root:
+    if localname(container.tag) != "dependencies":
+        continue
+    dependencies.extend(
+        el for el in container if localname(el.tag) == "dependency"
+    )
+
+declared = {}
+for index, dep in enumerate(dependencies, start=1):
+    gav = {name: child_text(dep, name)
+           for name in ("groupId", "artifactId", "version")}
+    label = "%s/%s" % (gav["groupId"] or "<no groupId>",
+                       gav["artifactId"] or "<no artifactId>")
+    for name in ("groupId", "artifactId", "version"):
+        if not gav[name]:
+            errors.append(
+                "dependency #%d (%s) has a missing or empty <%s> — an"
+                " incomplete GAV is unresolvable for consumers"
+                % (index, label, name)
+            )
+    if gav["groupId"] and gav["artifactId"]:
+        declared[(gav["groupId"], gav["artifactId"])] = gav["version"]
+
+declared_set = set(declared)
+missing = sorted(REQUIRED - declared_set)
+
+for coord in missing:
+    errors.append(
+        "pom is MISSING the in-repo dependency %s/%s, which"
+        " tools/xray/deps.edn declares at :local/root.%s%s"
+        % (coord[0], coord[1], MISSING_HINT,
+           FREEHAND_HINT if coord == FREEHAND else "")
+    )
+
+# Lockstep: every in-repo coordinate that DID land, at the exact VERSION.
+for coord in sorted(REQUIRED & declared_set):
+    found = declared[coord]
+    if found != version:
+        errors.append(
+            "in-repo dependency %s/%s is at version '%s', expected the"
+            " lockstep '%s'. Every published artefact ships at the repo-root"
+            " VERSION (spec/Conventions.md #packaging-conventions) — a"
+            " rewrite that fired with the wrong value is as broken as one"
+            " that did not fire at all."
+            % (coord[0], coord[1], found, version)
+        )
+
+for message in errors:
+    print("::error::preflight: %s" % message)
+
+if errors:
+    if missing:
+        print(
+            "::error::preflight: %d of %d in-repo coordinate(s) are absent"
+            " from the pom: %s"
+            % (len(missing), len(REQUIRED),
+               ", ".join("%s/%s" % c for c in missing))
+        )
+    sys.exit(1)
+
+print("preflight: pom declares all %d in-repo coordinate(s) at lockstep %s"
+      % (len(REQUIRED), version))
+print("  %s" % ", ".join("%s/%s" % c for c in sorted(REQUIRED)))
+PYTHON
+then
+  echo "::error::preflight: Xray published-package verification FAILED — ABORTING before clein deploy touches Clojars"
+  exit 1
+fi
+
+echo "preflight: Xray published-package verification PASSED"
+exit 0

--- a/.github/workflows/release-xray.yml
+++ b/.github/workflows/release-xray.yml
@@ -25,14 +25,36 @@
 # `xray-v`) matches the repo-root VERSION — a mismatched tag is
 # refused before any deploy step runs.
 #
-# # :local/root → :mvn/version rewrite
+# # :local/root → :mvn/version rewrite, and the hole in it
 #
-# tools/xray/deps.edn references core + reagent-slim via
-# `:local/root` for in-tree development. The release workflow
-# rewrites both to `:mvn/version "${VERSION}"` on the throwaway
-# runner checkout before invoking clein — same pattern as the
-# framework release workflow's deploy-leaf jobs. The rewrite is
-# never committed.
+# tools/xray/deps.edn declares TEN in-repo runtime coordinates via
+# `:local/root` for in-tree development — core, epoch, routing,
+# flows, schemas, resources, machines, freehand, machines-viz and
+# reagent-slim. The rewrite step below covers TWO of them (core and
+# reagent-slim), and `clein pom` SILENTLY SKIPS every `:local/root`
+# coordinate it is handed, so the other eight would simply be absent
+# from the published pom. Run against the in-tree deps.edn today,
+# `clein pom` prints ten `Skipping coordinate` lines and writes a pom
+# carrying four third-party artefacts and nothing else.
+#
+# That gap is rf2-5dut1 and it is NOT closed here. What IS closed is
+# the silence: the package-preflight step reads the GENERATED pom and
+# REFUSES the deploy unless every coordinate the committed deps.edn
+# declares at `:local/root` is present at the lockstep VERSION. So an
+# `xray-v*` tag pushed today fails loudly with the eight named,
+# rather than publishing an unusable pom to a registry that has no
+# yank. See .github/scripts/preflight-xray-package.sh.
+#
+# Seven of the eight are a mechanical fix (a rewrite line here, an
+# entry in verify-version-lockstep.sh's TOOLS_LOCAL_ROOTS). The
+# eighth, `day8/re-frame2-freehand`, is an OPEN OPERATOR DECISION:
+# implementation/freehand/deps.edn carries no `:clein/build`, on
+# purpose — publication is EP-0036 F6 territory — so it cannot be
+# pinned to any `:mvn/version` at all. Either Xray is not publishable
+# until Freehand ships, or the Freehand edge moves to late-bind. Do
+# not route around it by dropping the coordinate from the preflight.
+#
+# The rewrite is never committed.
 #
 # # Failure recovery
 #
@@ -179,11 +201,18 @@ jobs:
 
       # ─────────────────────────────────────────────────────────────
       # Rewrite :local/root → :mvn/version on the throwaway runner
-      # checkout (never committed). Xray's deps.edn references two
-      # framework artefacts; both pivot to the same lockstep VERSION.
-      # The literal substring match + python single-occurrence
-      # assertion is the same shape used by the framework release.yml
-      # deploy-leaf job — fails loudly if the source ever drifts.
+      # checkout (never committed). The literal substring match +
+      # python single-occurrence assertion is the same shape used by
+      # the framework release.yml deploy-leaf job — fails loudly if
+      # the source ever drifts.
+      #
+      # This list covers TWO of the TEN in-repo coordinates Xray's
+      # deps.edn declares (rf2-5dut1 — see the header). It is NOT
+      # extended here, because one of the eight it omits cannot be
+      # rewritten at all until an operator ruling on Freehand, and a
+      # partial extension would trade a loud failure for a quieter
+      # one. The preflight step below is what makes the gap fatal
+      # instead of invisible.
       # ─────────────────────────────────────────────────────────────
       - name: Rewrite Xray :local/root → :mvn/version
         working-directory: tools/xray
@@ -206,6 +235,29 @@ jobs:
           rewrite ':local/root "../../implementation/adapters/reagent-slim"' ":mvn/version \"${VERSION}\""
           echo "--- Rewritten dep coords:"
           grep -E "day8/(re-frame2|reagent-slim)" deps.edn
+
+      # ─────────────────────────────────────────────────────────────
+      # Package preflight (rf2-5dut1). Read the GENERATED pom and
+      # refuse to deploy unless every coordinate the COMMITTED
+      # deps.edn declares at :local/root is present at the lockstep
+      # VERSION. `clein pom` skips :local/root coordinates silently,
+      # so without this a partial rewrite ships a pom with holes in
+      # it to a registry that has no yank.
+      #
+      # The required set is derived from deps.edn rather than listed
+      # in the script — a hand-maintained roster drifting from
+      # deps.edn is the exact defect this gate exists for. Mirrors
+      # release-story.yml's preflight (rf2-wht9a).
+      #
+      # EXPECTED TO FAIL on the first tag push after it lands: eight
+      # coordinates are unrewritten, one of them pending an operator
+      # ruling. That refusal is the deliverable.
+      # ─────────────────────────────────────────────────────────────
+      - name: Preflight — Xray published package
+        working-directory: tools/xray
+        env:
+          VERSION: ${{ needs.verify-version.outputs.version }}
+        run: "$GITHUB_WORKSPACE/.github/scripts/preflight-xray-package.sh \"$VERSION\""
 
       - name: Deploy day8/re-frame2-xray
         working-directory: tools/xray

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/server.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/server.cljs
@@ -531,31 +531,59 @@
   values). Shared by the connected path (`handle-call*`) and the
   closed-world pre-connection path (`handle-call-local`).
 
-  ## RELAY 1 of two — this one keeps the MESSAGE
+  ## RELAY 1 of two — and it carries BOTH halves of the exception
 
   pair-mcp has exactly two consumer-facing error relays, and WHERE in a
   tool body a throw fires decides which one it meets. This one is
   reached by anything thrown while the tool body BUILDS its request,
   before the nREPL round-trip; `probe/err->result` (relay 2) is reached
   by anything thrown from an `eval-after-runtime!` `on-value` callback,
-  i.e. all response shaping after it. So a throw site's ex-message is
-  load-bearing HERE and its ex-data is dropped — the reverse of what a
-  reader who has only seen relay 2 would assume.
+  i.e. all response shaping after it.
 
-  That asymmetry is a known wart, half-fixed: relay 2 now carries both
-  halves (rf2-6tzm5), while this relay still drops `(ex-data err)` —
-  including the `:rf.error/id` an agent would rather branch on than
-  regex out of the message. rf2-qoih4 tracks closing it. Until then,
-  a throw site reached from here MUST put its actionable content in the
-  message; `tools/eval_form.cljs` `emit-name` is the live example, and
-  `error_boundary_test` pins both relays at the real MCP boundary."
+  The two relays used to keep OPPOSITE halves — this one the message,
+  relay 2 the ex-data — so wherever a throw fired, half of what its
+  author wrote for the agent was discarded. Relay 2 closed its half in
+  rf2-6tzm5; this is the other (rf2-qoih4). `(ex-data err)` now merges
+  into the envelope, so the `:rf.error/id` an agent BRANCHES on arrives
+  as a keyword slot instead of a token the agent has to regex out of
+  prose, and the actionable slots beside it (`:where`, `:recovery`, and
+  whatever the site carries) arrive at all.
+
+  ## Precedence runs the OPPOSITE way from relay 2
+
+  ex-data merges UNDER `:reason` and `:message`, not over them. At relay
+  2 the ex-data's `:reason` IS the payload's discriminator, so it wins
+  there. Here `:reason :handler-threw` is the ENVELOPE's discriminator —
+  it is how an agent knows the tool body threw before reaching the
+  runtime at all — and a site's own `:reason` (`eval_form`'s `emit-name`
+  carries one) must not silently replace it. The site's discriminator
+  has its own uncontested slot in `:rf.error/id`. Likewise `:message`:
+  the relayed ex-message is the Spec 009 canonical sentence, and no
+  in-repo ex-data carries a competing `:message` key.
+
+  ## A relayed throw's ex-data is WIRE DATA
+
+  True of relay 2 all along, and true here now: every value in an
+  ex-data map that can reach a relay MUST be EDN-round-trippable. The
+  envelope's canonical slot is `(pr-str v)` and the consumer's agent
+  reads it back with an EDN reader, so ONE unreadable value does not
+  merely go missing — it reds the read of the WHOLE envelope
+  (`No reader function for tag object`) and costs the agent the message
+  as well. `emit-name` carried exactly such a value (`(type n)`, a JS
+  constructor) for as long as this relay dropped ex-data and nobody
+  could tell; promoting ex-data to the wire is what made it matter, and
+  `error_boundary_test`'s relay-1 rows are what would have said so.
+
+  `error_boundary_test` pins both relays at the real MCP boundary,
+  including this precedence rule."
   [conn name args extra]
   (-> (tools/invoke conn name args extra)
       (.catch (fn [err]
                 (log! "handler threw for" name "—" (.-message err))
-                (wire/result {:ok?     false
-                              :reason  :handler-threw
-                              :message (.-message err)}
+                (wire/result (merge {:ok? false}
+                                    (ex-data err)
+                                    {:reason  :handler-threw
+                                     :message (.-message err)})
                              true)))))
 
 (defn- handle-call-local

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/eval_form.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/eval_form.cljs
@@ -127,9 +127,26 @@
   (when-not (symbol? n)
     ;; Canonical thrown-error shape per Spec 009 §The thrown-error shape: the
     ;; human sentence + a trailing `[:rf.error/<id>]` token IS the ex-message.
-    ;; Load-bearing here (rf2-jquiy) — `server.cljs`'s `invoke-and-guard`
-    ;; relays `(.-message err)` into the `:handler-threw` envelope, so this
-    ;; text is what the agent on the other end of the MCP wire reads.
+    ;; Load-bearing here (rf2-jquiy) — this fires during synchronous form
+    ;; construction, so it meets RELAY 1 (`server.cljs`'s `invoke-and-guard`),
+    ;; which relays `(.-message err)` into the `:handler-threw` envelope.
+    ;; Since rf2-qoih4 relay 1 merges this ex-data in alongside, so the slots
+    ;; below reach the agent as slots — `:rf.error/id` is the discriminator it
+    ;; branches on, and it no longer has to regex the token out of the
+    ;; sentence. `:reason` stays a courtesy restatement: relay 1's envelope
+    ;; `:reason` is `:handler-threw` and takes precedence over this one.
+    ;;
+    ;; That promotion makes this ex-data WIRE DATA, so every value in it must
+    ;; be EDN-round-trippable — the envelope's canonical slot is `(pr-str v)`
+    ;; and the agent reads it back with an EDN reader. `:name` is therefore
+    ;; `(pr-str n)`: `n` is by definition NOT a symbol here, so it can be any
+    ;; junk a mis-built binding vector carries, and its printed form is both
+    ;; the whole of the information and the only total rendering of it. A
+    ;; former `:type (type n)` slot is gone for the same reason — `(type "x")`
+    ;; is a JS constructor, which `pr-str`s to `#object[Function …]` and reds
+    ;; every EDN reader downstream with `No reader function for tag object`,
+    ;; costing the agent the message too. It told the agent nothing `:name`
+    ;; does not.
     ;; Hand-rolled inline: `tools/` MUST NOT `:require re-frame.*`.
     (throw (ex-info (str "rt-let binding name must be a symbol, got "
                          (pr-str n)
@@ -138,8 +155,7 @@
                      :where    're-frame2-pair-mcp/rt-let
                      :recovery :no-recovery
                      :reason   "rt-let binding name must be a symbol"
-                     :name     n
-                     :type     (type n)})))
+                     :name     (pr-str n)})))
   (name n))
 
 (defn- emit-body [forms]

--- a/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/probe.cljs
+++ b/tools/re-frame2-pair-mcp/src/re_frame2_pair_mcp/tools/probe.cljs
@@ -755,11 +755,17 @@
 
     - `server.cljs` `invoke-and-guard` (relay 1) — reached by anything
       thrown while the tool body BUILDS its request, before the nREPL
-      round-trip. Keeps the message; drops the ex-data (rf2-qoih4).
+      round-trip.
     - this fn (relay 2) — reached by anything thrown from an
       `eval-after-runtime!` / `eval-after-runtime-signalled!`
       `on-value` callback, i.e. ALL response shaping, after the
       round-trip.
+
+  Both now carry the message AND the ex-data; they differ only in
+  PRECEDENCE, and deliberately. Here the ex-data's `:reason` is the
+  payload's own discriminator so it wins; at relay 1 `:reason` is the
+  envelope's `:handler-threw` discriminator so the relay's wins and the
+  site's rides in `:rf.error/id` (rf2-qoih4).
 
   Relay 2 used to keep only the ex-data, dropping `(ex-message err)`
   entirely — so a Spec 009 canonical message composed at a

--- a/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/error_boundary_test.cljs
+++ b/tools/re-frame2-pair-mcp/test/re_frame2_pair_mcp/error_boundary_test.cljs
@@ -16,27 +16,39 @@
 
   `tools/re-frame2-pair-mcp/src` has exactly four `throw` sites, and a
   throw reaches the agent by one of two DIFFERENT relays depending on
-  WHERE in a tool body it fires. The relays are still asymmetric, but
-  only one-sidedly so now:
+  WHERE in a tool body it fires. The two relays used to keep OPPOSITE
+  halves of the exception; both now carry the whole of it, and differ
+  only in the precedence they give the two `:reason` slots:
 
-  - `server.cljs` `invoke-and-guard` → `{:reason :handler-threw :message
-    (.-message err)}`. Keeps the MESSAGE, drops the ex-data. Reached by
-    anything thrown while the tool body builds its request — before the
-    nREPL round-trip. (Its dropped ex-data half is rf2-qoih4.)
+  - `server.cljs` `invoke-and-guard` → the ex-data merged UNDER
+    `{:reason :handler-threw :message (.-message err)}`. Carries both
+    halves since rf2-qoih4. Reached by anything thrown while the tool
+    body builds its request — before the nREPL round-trip. `:reason`
+    is the ENVELOPE's discriminator here, so it outranks a site's own;
+    the site's rides in `:rf.error/id`.
 
-  - `tools/probe.cljs` `err->result` → the ex-data merged over
-    `{:ok? false :message (ex-message err)}`. Carries BOTH halves since
+  - `tools/probe.cljs` `err->result` → the ex-data merged OVER
+    `{:ok? false :message (ex-message err)}`. Carries both halves since
     rf2-6tzm5. Reached by anything thrown from the `on-value` callback
     of `eval-after-runtime!` / `eval-after-runtime-signalled!` — i.e.
-    all response shaping, after the round-trip.
+    all response shaping, after the round-trip. Here the ex-data's
+    `:reason` IS the payload's discriminator, so it wins.
 
-  Which relay a given throw meets decides which half of the Spec 009
-  shape the agent can read, so each is pinned here at its own boundary:
+  Both relays put ex-data on the wire, which makes a relayed throw's
+  ex-data WIRE DATA: every value in it must be EDN-round-trippable,
+  because the envelope's canonical slot is `(pr-str v)` and one
+  unreadable value reds the consumer's read of the WHOLE envelope
+  rather than merely going missing.
+
+  Each relay is pinned here at its own boundary:
 
   - **rt-let binding shape** (`tools/eval-form` `emit-name`) fires during
-    synchronous form construction, so it meets `invoke-and-guard`. Its
-    message IS the consumer contract, and the first test pins the human
-    sentence and the token end to end.
+    synchronous form construction, so it meets `invoke-and-guard`. The
+    first test pins both halves: the human sentence and the token in the
+    message, and `:rf.error/id` / `:where` / `:recovery` / `:name` as
+    ex-data slots — plus the precedence rule, since `emit-name`'s
+    ex-data carries a `:reason` of its own that must NOT displace
+    `:handler-threw`.
 
   - **unknown wire `:kind`** (`tools/wire-pipeline` `run-wire-pipeline`)
     fires only from response shaping — all five call sites across
@@ -154,8 +166,17 @@
 (deftest rt-let-binding-shape-reaches-the-agent-as-a-readable-message
   ;; Reverting `emit-name`'s message to a bare `(str error-kw)` reds the
   ;; sentence assertion; dropping the trailing token reds the token
-  ;; assertion; a regression that turns the tool error into a rejected
-  ;; promise reds `tu/error?` and takes the whole row with it.
+  ;; assertion; reverting `invoke-and-guard` to `{:reason :handler-threw
+  ;; :message …}` — the shape that made this ex-data unreachable — reds the
+  ;; four ex-data rows; a regression that turns the tool error into a
+  ;; rejected promise reds `tu/error?` and takes the whole row with it.
+  ;;
+  ;; And the row is a tripwire for the hazard that promotion introduces, at
+  ;; no extra cost: `tu/extract-edn` IS the consumer's EDN reader, so a
+  ;; single non-EDN value anywhere in a relayed ex-data reds EVERY assertion
+  ;; below at once with `No reader function for tag object`. `emit-name`
+  ;; carried one (`:type (type n)`, a JS constructor) harmlessly for as long
+  ;; as relay 1 dropped ex-data; putting it back demonstrates the failure.
   (async done
     (let [orig ef/rt-let
           ;; The REAL constructor, handed a binding name that is not a
@@ -180,7 +201,32 @@
                      (pr-str msg)))
             (is (str/includes? msg "[:rf.error/pair-mcp-rt-let-binding-bad-shape]")
                 (str "the canonical [:rf.error/…] token rides the message\n  got: "
-                     (pr-str msg)))))
+                     (pr-str msg)))
+            ;; The other half, closed by rf2-qoih4. Relay 1 used to relay the
+            ;; message and DROP `(ex-data err)`, so the discriminator an agent
+            ;; BRANCHES on arrived only as a token embedded in prose — it had
+            ;; to regex it back out — and the actionable slots beside it did
+            ;; not arrive at all. Nothing else on this surface can notice
+            ;; that: every other assertion here reads the message, which the
+            ;; old relay preserved. These rows are the only thing standing
+            ;; between a future `{:reason :handler-threw :message …}` and a
+            ;; second round of ex-data that reaches nobody.
+            (is (= :rf.error/pair-mcp-rt-let-binding-bad-shape
+                   (:rf.error/id edn))
+                "the machine discriminator rides as a SLOT, namespace intact")
+            (is (= 're-frame2-pair-mcp/rt-let (:where edn))
+                "along with the rest of the site's actionable ex-data")
+            (is (= :no-recovery (:recovery edn)))
+            (is (= (pr-str "not-a-symbol") (:name edn))
+                "and the offending value, in its total pr-str rendering")
+            ;; Precedence, and it is the OPPOSITE of relay 2's. `emit-name`'s
+            ;; ex-data carries its own `:reason` string; the `:handler-threw`
+            ;; row above passes only because the relay's `:reason` wins over
+            ;; it. Merge the ex-data OVER instead and that row reds, because
+            ;; the agent loses the one key telling it the tool body threw
+            ;; before the runtime was ever reached.
+            (is (= :handler-threw (:reason edn))
+                "the envelope discriminator survives an ex-data :reason")))
         done))))
 
 (deftest invoke-and-guard-relays-the-producers-message-verbatim


### PR DESCRIPTION
Two disjoint tools-surface defects, one commit each.

---

## 1 — `rf2-qoih4` · relay 1 carries the ex-data too

PR #7135 established that a pair-mcp throw reaches the consumer's agent by one of **two** relays keeping **opposite** halves of the exception. It closed relay 2 (`probe/err->result`, which dropped the message). This closes relay 1 (`server.cljs` `invoke-and-guard`, which dropped the ex-data).

A throw firing while a tool body *builds* its request now reaches the agent with its `:rf.error/id` as a keyword slot — the discriminator it branches on, previously recoverable only by regexing the `[:rf.error/…]` token out of prose — plus `:where`, `:recovery` and the per-site payload.

**Precedence runs the opposite way from relay 2, deliberately.** ex-data merges *under* `:reason` and `:message`. At relay 2 the ex-data's `:reason` is the payload's own discriminator, so it wins there. Here `:reason :handler-threw` is the *envelope's* discriminator — how an agent knows the body threw before the runtime was reached at all — and `emit-name` carries a `:reason` of its own that must not displace it. The site's discriminator has an uncontested slot in `:rf.error/id`.

### Measured, not inherited — and the ripple was **not** nil

#7135's ripple was nil because `envelope->result` already shipped all three parts on that surface. Relay 1 is different, and the first run said so:

```
FAIL in (rt-let-binding-shape-reaches-the-agent-as-a-readable-message)
the boundary drive rejected: No reader function for tag object.
```

Promoting ex-data to the wire makes it **wire data**. The envelope's canonical slot is `(pr-str v)` and the consumer reads it back with an EDN reader, so one unreadable value does not go quietly missing — it reds the read of the *whole* envelope and costs the agent the message as well. `emit-name` shipped exactly such a value: `:type (type n)` is a JS constructor, which `pr-str`s to `#object[Function …]`. It sat there harmlessly for as long as relay 1 dropped ex-data.

It is gone — it told the agent nothing `:name` does not — and `:name` is now `(pr-str n)`: `n` is by definition not a symbol here, so its printed form is both the whole of the information and the only total rendering of it. The rule is now stated at both relay docstrings and at the throw site.

What else was measured, and came back clean:

- **no `:message` key collision** — the only `:message` producers in `src/` are the two relay envelopes, `subscribe`'s stream payload and `view_tool`'s runtime-composed result map. No ex-data map carries one.
- **no `:handler-threw` conformance fixture exists at all**, and every fixture asserts `:edn-submap` (additive-safe), so nothing pins the key set.
- **mcp-base is not a source of relay-1 ex-data** — `cursor.cljc`'s three throws never escape `decode-cursor`'s own try, `diff_encode`'s family is unreachable (Malli absent plus DCE'd), `descriptor_manifest`'s is generation-time.
- **the two `server.cljs` discovery throws** are caught by `handle-call*`'s own arm, which rebuilds its payload and never reaches this relay.

`error_boundary_test`'s relay-1 row is the only consumer. Extended here.

### Mutation proof

Revert `invoke-and-guard` to the old flat envelope, everything else unchanged:

```
FAIL … (error_boundary_test.cljs:214) the machine discriminator rides as a SLOT, namespace intact
  expected: (= :rf.error/pair-mcp-rt-let-binding-bad-shape (:rf.error/id edn))
    actual: (not (= :rf.error/pair-mcp-rt-let-binding-bad-shape nil))
FAIL … (error_boundary_test.cljs:217) along with the rest of the site's actionable ex-data
  expected: (= (quote re-frame2-pair-mcp/rt-let) (:where edn))
    actual: (not (= re-frame2-pair-mcp/rt-let nil))
FAIL … (error_boundary_test.cljs:219)
  expected: (= :no-recovery (:recovery edn))   actual: (not (= :no-recovery nil))
FAIL … (error_boundary_test.cljs:220) and the offending value, in its total pr-str rendering
  expected: (= (pr-str "not-a-symbol") (:name edn))
    actual: (not (= "\"not-a-symbol\"" nil))
Ran 1217 tests containing 4304 assertions.  ->  exit 1
```

Restored: `1217 tests / 4304 assertions, 0 failures, 0 errors`, exit 0. `git diff --stat` back to the intended four files.

The precedence rule is proven for free by the same row: `emit-name`'s ex-data carries a `:reason` string, so `(= :handler-threw (:reason edn))` passes **only** because the relay's key wins. Merge the other way and it reds.

---

## 2 — `rf2-5dut1` · an Xray release is now refused when its pom would be under-specified

### Counts re-verified against current source

| | count | detail |
|---|---|---|
| `tools/xray/deps.edn` `:local/root` in main `:deps` | **10** | lines 19, 23, 27, 31, 34, 38, 42, 53, 57, 62 — core, epoch, routing, flows, schemas, resources, machines, freehand, machines-viz, reagent-slim |
| `release-xray.yml` rewrites | **2** | core (line 205), reagent-slim (line 206) |
| `verify-version-lockstep.sh` `TOOLS_LOCAL_ROOTS` for xray | **1** | core |

(An eleventh `:local/root` sits under the `:test` alias — `test-quiet`, line 86 — correctly out of scope.)

The bead's numbers hold exactly. And `clein pom`'s silent skip is not inferred — `clojure -M:clein pom` in `tools/xray` prints **ten** `Skipping coordinate` lines and writes a pom whose `<dependencies>` are `org.clojure/clojure 1.11.2`, `zprint/zprint 1.3.0`, `reagent/reagent 2.0.1`, `juji/editscript 0.6.5`.

None of Xray's ten. With the workflow's rewrite applied first, a released jar ships **two of ten**. `verify-version-lockstep.sh` reports `PASSED — all 18 artefacts … 0 drifts` while blind to nine of them.

### What this PR does — and what it deliberately does not

It does **not** close the gap. It makes it **fatal instead of silent**.

New `.github/scripts/preflight-xray-package.sh`, wired into `release-xray.yml` after the rewrite and before `clojure -M:clein deploy`. It reads the **generated** pom and refuses the deploy unless every coordinate the **committed** `deps.edn` declares at `:local/root` is present at the lockstep `VERSION`, naming each absentee. So the first `xray-v*` tag pushed after this **fails loudly with the eight named**, instead of publishing an unusable pom to a registry with no yank.

The required set is **derived** from `deps.edn` — read with Clojure's own reader from `git show HEAD:tools/xray/deps.edn`, since the workspace copy has been rewritten in place by then. This is the one deliberate departure from `preflight-story-package.sh`, and the reason is the bug itself: Xray's rewrite roster was a literal that drifted to two-of-ten because nothing tied it back to `deps.edn`. An eleventh coordinate now demands its rewrite with no edit to the gate.

### THE FREEHAND QUESTION IS LEFT **OPEN** FOR THE OPERATOR

The rewrite step is **not** extended, and that is on purpose. Seven of the eight are mechanical. The eighth is not:

**`day8/re-frame2-freehand` cannot be pinned to any `:mvn/version` at all.** `implementation/freehand/deps.edn` carries no `:clein/build` — deliberately, per its own header: *"NO :clein deploy aliases — deliberate, not an omission. Publication is F6 territory."* So Xray declares a **runtime** dependency on an artefact that is not publishable until the EP-0036 F6 gate.

**Either Xray is not publishable until Freehand ships, or the Freehand edge moves to late-bind. That is Mike's call, not a reconciliation, and nothing in this PR decides it.** The gate states the question in its failure message and tells the reader explicitly not to route around it by dropping the coordinate. A partial extension of the rewrite would only have traded a loud failure for a quieter one.

`CHANGELOG.md`'s claim that xray, story and machines-viz "each have a release workflow" stays optimistic for xray until that ruling lands. Not touched here.

### Red / green proof of the gate

End-to-end against the real repo (no rewrite applied, so all ten are absent):

```
preflight: 10 in-repo coordinate(s) must appear in the published pom:  [all ten listed]
::error::preflight: pom is MISSING the in-repo dependency day8/re-frame2-freehand … THIS ONE IS NOT
  A MECHANICAL FIX AND MUST NOT BE TREATED AS ONE (rf2-5dut1) … That is an operator decision;
  until it is made, this refusal is the correct outcome.
::error::preflight: 10 of 10 in-repo coordinate(s) are absent from the pom: …
::error::preflight: Xray published-package verification FAILED — ABORTING before clein deploy touches Clojars
EXIT=1
```

A gate that can only fail is useless, so the assertion body was driven three ways against synthetic poms (the python extracted verbatim from the script under test):

| case | result |
|---|---|
| all ten present at lockstep | `pom declares all 10 in-repo coordinate(s) at lockstep 0.0.1.alpha` — **exit 0** |
| one omitted (`epoch`) | names `day8/re-frame2-epoch`, `1 of 10 … absent` — **exit 1** |
| all ten present, core at `9.9.9` | names the lockstep drift, no false "missing" — **exit 1** |

### Fence notes

- `release-xray.yml` edited under the brief's explicit grant. Diff is the header (which claimed Xray "references core + reagent-slim" — never true of a ten-coordinate file), a comment on the rewrite step, and the seven-line preflight step.
- `.github/scripts/preflight-xray-package.sh` is a **new file** — zero collision surface, and it is where this repo's two precedents (`preflight-story-package.sh`, `preflight-reagent-slim-package.sh`) live. Flagged rather than assumed.
- **`.github/scripts/verify-version-lockstep.sh` NOT touched** — outside the grant. Filed as **`rf2-7fxf8`** (P2): the ordinary-CI arm should see all ten so drift reds on the PR that introduces it, not on the release attempt.
- **`tools/xray/spec/*` unchanged because no file under `tools/xray/` was modified** — this half of the PR is release plumbing only.

---

## Quality gates

All foreground, worktree-local logs, exit codes echoed.

| gate | exit | result |
|---|---|---|
| `tools/re-frame2-pair-mcp` `npm test` | **0** | 1217 tests, 4304 assertions, 0 failures, 0 errors |
| `npm run check:descriptors` | **0** | `tool-descriptors.edn in sync (35 tools)` |
| `npm run build` (shipped `:server`) | **0** | 140 files, 0 warnings |
| `tools/mcp-conformance` `npm run test:unit` | **0** | 114 tests, 105 pass, 0 fail, 9 skipped |
| `tools/xray` `clojure -M:test` | **0** | 1271 tests, 5909 assertions, 0 failures, 0 errors |
| `tools/xray` `clojure -M:clein pom` | **0** | 10 `Skipping coordinate` lines — the defect, reproduced |
| `.github/scripts/verify-version-lockstep.sh` | **0** | 18 artefacts, 0 drifts — green *while blind*, which is `rf2-7fxf8` |
| `preflight-xray-package.sh` end-to-end | **1** | refuses, naming all ten — **the deliverable** |
| preflight assertion body, 3 synthetic poms | 0 / 1 / 1 | green · missing · drift, all correct |
| `release-xray.yml` YAML parse | **0** | parses |
| **mutation: relay 1 reverted** | **1** | 4 targeted failures naming the path |
| **mutation: restored** | **0** | green, `git diff --stat` clean |

`tools/re-frame2-pair-mcp` has no lockfile — `npm install`, not `npm ci` (exit 0).

**Deferred to CI:** the full `mcp-conformance` SDK-driven e2e (`test:re-frame2-pair`, needs a live shadow-cljs fixture build plus a browser runtime), `expensive-tests.yml`'s live hermetic suite, the browser smoke gates, and the docs build. Nothing in this diff touches a happy-path envelope: the relay change is error-path-only with no `:handler-threw` fixture in the corpus, and the Xray half is release plumbing that no CI job outside a tag push executes.

**Not merged.**
