### PR TITLE
test: derive the canary set and witness sub-classification egress in production (rf2-k8vyi, rf2-u2x6w)

### DIFF
--- a/implementation/epoch/test/re_frame/epoch_egress_resource_trace_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_egress_resource_trace_test.clj
@@ -3476,30 +3476,54 @@
   the outcome's own `:status`, so one fn drives BOTH mutation settle handlers.
 
   `mutation-id` picks the owner, and the two owners are the two halves of the
-  mutation family's redaction story. `:m/save` declares NOTHING, so
-  `classification/redact-continuation-reply` substitutes nothing at the source
-  and any redaction observed on its reply came from the EGRESS projector.
+  mutation family's redaction story. `:m/save` declares nothing that can reach
+  `:error`, so `classification/redact-continuation-reply` substitutes nothing
+  into the failure envelope at the source and any redaction observed on it came
+  from the EGRESS projector.
   `:m/save-declared` names `[:value :email]` sensitive, so its result is
   redacted at the SOURCE, before the reply reaches a carrier at all — which is
   the only canary the SUCCESS settle has, there being no failure envelope on
   that branch and no arm of the egress projector that owns an undeclared
   mutation's `:value` (§rf2-xx4ty — the app's own continuation handler is
   entitled to it, and the coarse claim a resource would make has no mutation
-  counterpart)."
+  counterpart).
+
+  rf2-k8vyi — THE CALL SITE PLANTS THE FAMILY'S IDENTITY. `:scope` is a public
+  ScopeInput on the execute payload, and this drive used to pass none: every
+  scope it produced was `:rf.scope/global`, the one scope shape with nothing in
+  it to leak, so `:correlation :scope` carried no canary on either mutation
+  branch and the ninth leak (rf2-l6wjl) was invisible to the namespace built to
+  see it. `:params` is planted the same way and for the same reason — the
+  request fns below deliberately do not echo the slug into their URL, because a
+  resource's own request map is the FX family's data and rides untouched by
+  design (rf2-1kiuj), which would make the sweep red on a by-design slot.
+
+  Both owners therefore also declare `:sensitive [[:params :slug]]`. There is
+  no coarse `:sensitive?` root prop on `reg-mutation` (§rf2-xx4ty), so a
+  projection-relative params declaration is the ONLY spelling by which a
+  mutation can claim its own params — and without one a secret-bearing
+  `:params` would ride verbatim on the carrier, symmetrically with an
+  undeclared resource's (§rf2-rnsv2 drives `:plain/article` with a plain slug
+  for exactly that reason). Declaring it is what makes the mutation branches
+  carry the family's identity in `:params` at all, and it is the only proof
+  anywhere that a mutation's `[:params …]` declaration reaches a continuation
+  reply."
   [mutation-id {:keys [status] :as outcome}]
   (rf/configure! {:epoch-history {:trace-events-keep 80}})
   (let [captured (atom nil)]
     (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! captured args) nil))
     (rf/reg-event :app/save-replied (fn [_ _ev] {}))
     (rf/reg-mutation :m/save
-      {:params-schema [:map [:slug :string]]}
-      (fn [{:keys [slug]} _] {:request {:method :put :url (str "/a/" slug)}}))
-    (rf/reg-mutation :m/save-declared
-      {:sensitive     [[:data :email]]
+      {:sensitive     [[:params :slug]]
        :params-schema [:map [:slug :string]]}
-      (fn [{:keys [slug]} _] {:request {:method :put :url (str "/b/" slug)}}))
+      (fn [_ _] {:request {:method :put :url "/a"}}))
+    (rf/reg-mutation :m/save-declared
+      {:sensitive     [[:data :email] [:params :slug]]
+       :params-schema [:map [:slug :string]]}
+      (fn [_ _] {:request {:method :put :url "/b"}}))
     (rf/dispatch-sync [:rf.mutation/execute
-                       {:mutation mutation-id :params {:slug plain-slug}
+                       {:mutation mutation-id :params reply-params
+                        :scope    session-scope
                         :instance :mf1 :reply-to mutation-reply-target}]
                       {:frame :test/rt})
     (rf/dispatch-sync (conj (get @captured (if (= :ok status) :on-success :on-failure))
@@ -3810,25 +3834,52 @@
                       {:frame :test/rt})
     (rf/epoch-history :test/rt)))
 
-(defn- drive-failing-feed-reply-to-read!
+(defn- drive-session-feed-reply-to!
   "Drive a REAL `[:rf.resource/ensure … :reply-to …]` against an INFINITE FEED
-  and fail its page-0 fetch. An infinite resource lowers its `:on-failure` to
-  `:rf.resource.internal/page-failed`, so this settles through
-  `page-failed-handler` — with its own first-load-vs-load-more split — rather
-  than `failed-handler`.
+  and settle its page-0 fetch with `outcome`, the canonical transport reply.
+  An infinite resource lowers into its OWN pair of settle events
+  (`:rf.resource.internal/page-succeeded` / `…/page-failed`, each with its own
+  first-load-vs-load-more split), so one fn drives both feed branches of the
+  inventory.
 
-  `:plain/feed` declares nothing and its params carry no secret, so the
-  envelope is the only canary and the sweep names exactly one datum."
-  [envelope]
+  rf2-k8vyi — THE FEED IS SESSION-SCOPED, registered here rather than taken
+  from the shared fixture. Every feed in that fixture scopes `:rf.scope/global`
+  because the sections that own them are about the `[:data …]` declaration axis,
+  and a global scope is a SCALAR: `:scope`, `:correlation`, `:resource/key` and
+  `:rf.reply/work-id` all carried nothing on the two feed branches. A
+  `{:from-db …}` resolver puts an identity MAP in all four, and the params carry
+  the canary too — so this drive plants the family's identity everywhere the
+  reply can hold it, which is the whole point of an inventory."
+  [outcome]
   (rf/configure! {:epoch-history {:trace-events-keep 80}})
   (let [captured (atom nil)]
     (fx/reg-fx :rf.http/managed (fn [_ctx args] (reset! captured args) nil))
     (rf/reg-event :app/read-loaded (fn [_ _ev] {}))
+    (rf/reg-resource :derived/feed
+      {:scope           {:from-db :rt/session}
+       :infinite        true
+       :next-page-param (fn [_last _all] nil)
+       :page->items     :items
+       ;; the COARSE claim, as `:derived/profile` makes it on the scalar
+       ;; branches. A projection-relative `[[:data …]]` declaration would leave
+       ;; `row-owner-redacts?` false and the owner's scoped KEY riding verbatim
+       ;; — correct (rf2-1zc33 made only the FREE `:scope` tag unconditional;
+       ;; the key belongs to its owner) but it would make a whole-record sweep
+       ;; red on by-design egress. The `[:data …]` axis has its own coverage in
+       ;; §(rf2-zaopo); what the inventory needs from a feed is the branch.
+       :sensitive?      true
+       :params-schema   [:map [:slug :string]]}
+      (fn [_ _] {:request {:method :get :url "/i"}}))
+    (frame/swap-runtime-db! :test/rt
+      (fn [rt] (elision/apply-classification-effects
+                 rt {:sensitive [[:auth :user :username]]})))
+    (frame/swap-frame-db! :test/rt assoc-in [:auth :user :username] secret)
     (rf/dispatch-sync [:rf.resource/ensure
-                       {:resource :plain/feed :params {:filter :all}
-                        :owner    real-owner  :reply-to read-reply-target}]
+                       {:resource :derived/feed :params reply-params
+                        :owner    real-owner   :reply-to read-reply-target}]
                       {:frame :test/rt})
-    (rf/dispatch-sync (conj (:on-failure @captured) {:status :error :error envelope})
+    (rf/dispatch-sync (conj (get @captured (if (= :ok (:status outcome)) :on-success :on-failure))
+                            outcome)
                       {:frame :test/rt})
     (rf/epoch-history :test/rt)))
 
@@ -3860,6 +3911,18 @@
       ;; SETUP, and they legitimately fan out.
       (drop before (rf/epoch-history :test/rt)))))
 
+(def ^:private mutation-work-id-is-instance-keyed
+  "rf2-k8vyi §the canary set — the one reply slot a MUTATION drive cannot plant.
+  A resource's `:rf.reply/work-id` is `[:rf.work/resource <scoped-key>
+  <generation>]` and so embeds the resolved scope and the caller's params; a
+  mutation's is `[:rf.work/resource [:rf.mutation <instance-id>] <generation>]`
+  — three app-authored keywords and an integer, with no resolved-from-app-db
+  component for identity to enter through. Nothing the caller supplies reaches
+  it, so there is no canary to plant, and its absence is not a gap."
+  {:rf.reply/work-id
+   "a mutation work id is keyed by its INSTANCE, not by a scoped key — no
+    caller-supplied or resolver-derived value reaches it"})
+
 (def ^:private continuation-settle-drives
   "One entry per inventoried settle path, KEYED BY THE EVENT ID the inventory
   derives from source. The keys are asserted equal to the inventory, so this
@@ -3876,14 +3939,14 @@
           still carrying the abort under `:error`. `:status` is not the gate,
           which is exactly why both arms are driven"
     :drives [{:drive  #(record-carrying-reply
-                         (drive-failing-reply-to-read! :plain/article
-                                                       {:slug plain-slug}
+                         (drive-failing-reply-to-read! :derived/profile
+                                                       reply-params
                                                        failure-envelope)
                          false)
               :expect {:status :error :rf.reply/work-status :failed}}
              {:drive  #(record-carrying-reply
-                         (drive-failing-reply-to-read! :plain/article
-                                                       {:slug plain-slug}
+                         (drive-failing-reply-to-read! :derived/profile
+                                                       reply-params
                                                        abort-envelope)
                          false)
               :expect {:status :cancelled :rf.reply/work-status :cancelled}}]}
@@ -3893,20 +3956,34 @@
           envelope, so its canary is the owner data the reply carries beside
           it — which is why the sweep is whole-record and not `:error`-shaped"
     :drives [{:drive  #(record-carrying-reply (drive-aborted-event-reply-to-read! :derived/profile) false)
-              :expect {:status :cancelled :resource :derived/profile}}]}
+              :expect {:status :cancelled :resource :derived/profile}
+              ;; the ONE slot on the ONE branch no drive can reach. An
+              ;; exemption here is not the hand-list §(rf2-k8vyi) retired: the
+              ;; polarity is inverted — the derived union is the default and an
+              ;; exemption has to be written down with its reason, so a slot
+              ;; nobody thought about is COVERED rather than omitted.
+              :unplantable {:error "the legacy abort event SYNTHESISES its
+                                    `{:kind :rf.http/aborted :reason :aborted}`
+                                    envelope from nothing the caller supplies —
+                                    there is no input through which a drive
+                                    could plant a canary in it"}}]}
 
    :rf.resource.internal/page-succeeded
    {:why "the infinite feed's page settle. A DIFFERENT handler from the scalar
           success, with its own append-vs-replace split, delivering the MERGED
           item list under `:value`"
-    :drives [{:drive  #(record-carrying-reply (drive-feed-reply-to-read! :declared/feed) false)
-              :expect {:status :ok :resource :declared/feed}}]}
+    :drives [{:drive  #(record-carrying-reply
+                         (drive-session-feed-reply-to! {:status :ok :value declared-feed-page})
+                         false)
+              :expect {:status :ok :resource :derived/feed}}]}
 
    :rf.resource.internal/page-failed
    {:why "the infinite feed's page FAILURE — the family's third error channel,
           reached only through an `:infinite` resource's lowering"
-    :drives [{:drive  #(record-carrying-reply (drive-failing-feed-reply-to-read! failure-envelope) false)
-              :expect {:status :error :resource :plain/feed}}]}
+    :drives [{:drive  #(record-carrying-reply
+                         (drive-session-feed-reply-to! {:status :error :error failure-envelope})
+                         false)
+              :expect {:status :error :resource :derived/feed}}]}
 
    :rf.mutation.internal/succeeded
    {:why "the mutation WRITE settle — a fourth reply builder on a fourth
@@ -3919,7 +3996,8 @@
                          (drive-mutation-reply-to! :m/save-declared
                                                    {:status :ok :value mutation-value}))
               :expect {:status :ok :rf.reply/work-kind :mutation
-                       :mutation :m/save-declared}}]}
+                       :mutation :m/save-declared}
+              :unplantable mutation-work-id-is-instance-keyed}]}
 
    :rf.mutation.internal/failed
    {:why "the mutation failure settle, and — like its read sibling — its
@@ -3930,11 +4008,13 @@
     :drives [{:drive  #(record-with-family-reply
                          (drive-mutation-reply-to! :m/save
                                                    {:status :error :error failure-envelope}))
-              :expect {:status :error :rf.reply/work-kind :mutation}}
+              :expect {:status :error :rf.reply/work-kind :mutation}
+              :unplantable mutation-work-id-is-instance-keyed}
              {:drive  #(record-with-family-reply
                          (drive-mutation-reply-to! :m/save
                                                    {:status :error :error abort-envelope}))
-              :expect {:status :cancelled :rf.reply/work-kind :mutation}}]}
+              :expect {:status :cancelled :rf.reply/work-kind :mutation}
+              :unplantable mutation-work-id-is-instance-keyed}]}
 
    :rf.resource/ensure
    {:why "the SYNCHRONOUS fan-out: a fresh-skip cache hit has no work record
@@ -3998,3 +4078,155 @@
                       "the drive settled the branch it is filed under — the
                        record's own event id, not the drive's say-so")
                   (assert-branch-sweep! raw expect))))))))))
+
+;; ===========================================================================
+;; (rf2-k8vyi) the CANARY SET — derived from the family's own replies, because
+;; a sweep only ever finds what the drive PLANTED.
+;; ===========================================================================
+;;
+;; The inventory above generalises two of the three things a canary suite is
+;; made of. The DRIVE SET is read out of the family's source, so a settle branch
+;; joins it the moment its source is written. The HARVEST is a whole-record
+;; sweep, so whatever slot a continuation gains, `assert-branch-sweep!` sees it.
+;;
+;; THE CANARY SET WAS STILL A HAND LIST, and it was the gap the ninth leak
+;; (rf2-l6wjl) walked through. `drive-mutation-reply-to!` passed no `:scope` at
+;; all, so every scope it produced was `:rf.scope/global` — a SCALAR, the one
+;; scope shape with nothing in it to leak. `:correlation :scope` therefore
+;; carried no canary on either mutation branch, the sweep swept a slot that was
+;; empty by construction, and a leak this namespace exists to catch shipped
+;; green. The fixture assertion did not help: `(seq (secret-leak-paths raw))`
+;; only asks whether the record leaks SOMEWHERE, and the failure envelope alone
+;; satisfied it.
+;;
+;; SO THE CANARY SET IS DERIVED TOO, and it is derived from the same place the
+;; drive set is — the family's own behaviour rather than an author's memory:
+;;
+;;   1. THE FLOOR, which is not derived and does not need to be. Every drive
+;;      plants a resolved `[tier {identity}]` scope bearing the canary. One
+;;      assertion, no list, true of every branch: a `:rf.scope/global` reply is
+;;      a reply whose scope, correlation, resource key and work id are all
+;;      structurally incapable of leaking, and a suite of those proves nothing
+;;      about a projector.
+;;
+;;   2. THE PARITY, which is. `identity-bearing-reply-slots` is the union, over
+;;      every inventoried drive, of the reply slots that DEMONSTRABLY carry
+;;      identity — a slot bearing the canary, or bearing a redaction token
+;;      (which proves the SOURCE cleaned identity out of it before the carrier
+;;      saw it). Every drive is then held to that union: a slot in it, present
+;;      on this branch and barren, is a canary the drive forgot to plant.
+;;
+;; WHY PARITY IS THE RIGHT GENERALISATION. The ninth leak was not a slot nobody
+;; had thought about — `:correlation :scope` was canaried, cleaned and asserted
+;; on every READ branch at the time it shipped. It was the SAME slot, unplanted
+;; on a sibling branch, and no assertion in this namespace compared the two.
+;; The union does exactly that comparison, and it grows by itself: the day any
+;; drive plants a canary in a slot nobody had considered, every other branch
+;; carrying that slot owes one too, and reds until it has it.
+;;
+;; WHAT IT DOES NOT CLAIM. Parity is a consistency proof, not a completeness
+;; one. A slot that NO drive canaries stays out of the union — `:cause` and
+;; `:affected-keys` are barren on every branch today — so this cannot be the
+;; only thing standing between the family and its tenth leak. The floor is what
+;; keeps the union from collapsing: it pins the four scope-derived slots
+;; unconditionally, on every branch, whatever the rest of the suite does.
+
+(defn- carries-redaction-token?
+  "Whether `x` carries a redaction token anywhere — the `{:rf/redacted …}`
+  component the egress projector substitutes, or the bare `:rf/redacted`
+  keyword a SOURCE-side declaration leaves in place of a value. Either one is
+  proof that identity was in this slot and something took it out, which is what
+  makes the slot count as planted."
+  [x]
+  (let [found (volatile! false)]
+    (walk/postwalk (fn [v]
+                     (when (or (= :rf/redacted v) (redacted-component? v))
+                       (vreset! found true))
+                     v)
+                   x)
+    @found))
+
+(defn- reply-slot-facts
+  "Per-slot canary classification of every family continuation reply riding
+  `raw`'s carriers: `:canaried` (the drive's identity is in this slot raw),
+  `:redacted-at-source` (it was, and a declaration removed it), `:barren`
+  (nothing identity-bearing is in this slot at all)."
+  [raw]
+  (mapv (fn [reply]
+          (into {}
+                (map (fn [[k v]]
+                       [k (cond
+                            (contains-secret? v)         :canaried
+                            (carries-redaction-token? v) :redacted-at-source
+                            :else                        :barren)]))
+                reply))
+        (family-carrier-replies raw)))
+
+(defn- resolved-identity-scope?
+  "Whether `s` is a resolved `[tier {identity}]` scope — the only scope shape
+  with anything in it to leak."
+  [s]
+  (and (vector? s) (= 2 (count s)) (keyword? (first s)) (map? (second s))))
+
+(defn- observe-inventoried-drives!
+  "Run every inventoried drive once, each in its own runtime, and return what
+  each one PLANTED: the reply scopes and the per-slot canary facts. Read from
+  the RAW record only, so unlike the sweep it does not need the frame to still
+  be alive when it is judged."
+  []
+  (let [observed (atom [])]
+    (doseq [[settle-id {:keys [drives]}] continuation-settle-drives
+            [i {:keys [drive unplantable]}] (map-indexed vector drives)]
+      (in-an-isolated-runtime
+        (fn []
+          (let [raw (drive)]
+            (swap! observed conj
+                   {:settle-id   settle-id
+                    :arm         i
+                    :unplantable (set (keys unplantable))
+                    :scopes      (mapv :scope (family-carrier-replies raw))
+                    :facts       (reply-slot-facts raw)})))))
+    @observed))
+
+(deftest every-inventoried-drive-plants-an-identity-bearing-scope
+  (testing "rf2-k8vyi §the floor — a drive whose scope is `:rf.scope/global`
+            sweeps a `:scope`, a `:correlation`, a `:resource/key` and a
+            `:rf.reply/work-id` that are all scalars-all-the-way-down, and
+            proves nothing about the projector that would have to clean them.
+            Every inventoried drive plants a resolved `[tier {identity}]` scope
+            carrying the canary, so all four slots are live on every branch."
+    (doseq [{:keys [settle-id arm scopes]} (observe-inventoried-drives!)]
+      (testing (str settle-id " arm " arm)
+        (is (seq scopes) "the reply carries a `:scope` slot at all")
+        (doseq [s scopes]
+          (is (and (resolved-identity-scope? s) (contains-secret? (second s)))
+              (str "the drive planted an identity-bearing scope; got " (pr-str s))))))))
+
+(deftest every-inventoried-drive-canaries-every-slot-the-family-can-carry-identity-in
+  (testing "rf2-k8vyi §the parity — the canary set is the UNION of the slots
+            the drives themselves demonstrate can carry identity, and every
+            branch owes the whole union. The ninth leak was `:correlation
+            :scope` canaried on every read branch and unplanted on both
+            mutation ones; nothing compared them."
+    (let [observed         (observe-inventoried-drives!)
+          identity-bearing (into #{} (for [{:keys [facts]} observed
+                                           slots facts
+                                           [k classification] slots
+                                           :when (not= :barren classification)]
+                                       k))]
+      (testing "the derived canary set is not vacuously empty"
+        (is (seq identity-bearing)
+            "no inventoried drive planted identity in any reply slot — the
+             canary vocabulary was renamed and this whole section stopped
+             checking anything"))
+      (doseq [{:keys [settle-id arm unplantable facts]} observed]
+        (testing (str settle-id " arm " arm)
+          (doseq [slots facts]
+            (is (= #{} (into #{} (for [[k classification] slots
+                                       :when (and (= :barren classification)
+                                                  (identity-bearing k)
+                                                  (not (unplantable k)))]
+                                   k)))
+                "every slot this family is known to carry identity in is
+                 planted on this branch too — a barren one is a canary the
+                 drive forgot, and a sweep over it can only ever pass")))))))

--- a/implementation/routing/test/re_frame/routing_sub_egress_production_test.clj
+++ b/implementation/routing/test/re_frame/routing_sub_egress_production_test.clj
@@ -1,0 +1,218 @@
+(ns re-frame.routing-sub-egress-production-test
+  "rf2-u2x6w — route sub-classification egresses in PRODUCTION, and this is the
+  namespace that says so under the real gate.
+
+  ## Why this exists beside `routing-egress-test`
+
+  rf2-7vk3z established that \"no cross-frame classification bleed\" is a
+  PRODUCTION-real privacy invariant and built a production-visible witness for
+  it inside `implementation/core`. It also found the boundary of what core can
+  witness: the PROJECTION half of sub classification has no production egress
+  there at all, because `classification/project-sub-tags` is reached only from
+  `trace/build-event` inside `trace/emit!`'s `interop/debug-enabled?` gate.
+  Under `-Dre-frame.debug=false` no `:rf.sub/run` event is built, so there is
+  nothing to project. That is correct and expected.
+
+  BUT SUB CLASSIFICATION DOES EGRESS IN PRODUCTION, from two sites outside
+  core, and this is one of them: the `:routing/route-sub-egress-path` hook,
+  which re-seeds `elision/elide-wire-value` at a route sub's runtime-db storage
+  position so the route's re-rooted `:sensitive` / `:large` declarations match
+  the BARE slice value the sub returns. Nothing on that path reads
+  `interop/debug-enabled?` — not route activation's classification lowering, not
+  the per-frame elision registry, not the wire walker — so every off-box
+  direct-read surface that names a sub through `:query-v` (Pair MCP `read-sub`,
+  `list-subscriptions :include-values`, `snapshot :sub-cache`, Xray) redacts in
+  a production build exactly as it does in a dev one. This namespace is the
+  proof of that sentence.
+
+  `re-frame.routing-egress-test` already covers the mechanism, but it CANNOT
+  carry this claim: run under the gate it is 36 failures / 7 errors, because it
+  interleaves the always-on egress legs with `:rf.fx/handled` /
+  `:rf.route/navigation-blocked` TRACE assertions that a production build does
+  not emit. A lane would have to exclude the whole namespace, and — exactly as
+  `scripts/test-core-prod-gate.sh` warns of `conformance-test` — excluding it
+  for the trace legs takes the always-on legs with it. So the production-real
+  half lives here, in a namespace that is green in BOTH postures and can join a
+  gate lane by default.
+
+  ## Posture
+
+  Every assertion below holds in dev AND under `-Dre-frame.debug=false`.
+  Nothing here rebinds `interop/debug-enabled?`: the flag is read once at
+  namespace-load time and a `with-redefs` cannot reach it (rf2-f7qj4), so a
+  rebind would prove nothing about the gate. The posture is supplied by the
+  JVM:
+
+      clojure -J-Dre-frame.debug=false -M:test -n re-frame.routing-sub-egress-production-test
+
+  Measured both ways at rf2-u2x6w: 7 tests / 16 assertions, 0 failures, exit 0.
+
+  There is no `jvm-routing-prod-gate` job today — `jvm-core-prod-gate` covers
+  `implementation/core` only, so neither this artefact nor `ssr` is in its
+  reach. The lane recommendation is recorded on rf2-u2x6w."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.elision :as elision]
+            [re-frame.frame :as frame]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.privacy :as privacy]
+            [re-frame.routing.sub-egress :as sub-egress]
+            [re-frame.routing-test-support :as rts]))
+
+(use-fixtures :each rts/reset-runtime)
+
+(def ^:private token-secret "secret-oauth-token-u2x6w")
+(def ^:private param-secret "topsecret-upload-key")
+
+(defn- navigate-to-classified-route!
+  "Register an OAuth-callback-shaped route carrying a projection-relative
+  `:sensitive` / `:large` declaration and navigate to it FOR REAL — `reg-route`
+  plus a genuine `:rf.route/transitioned`, so the classification reaches the
+  live frame's elision registry through the production activation lowering
+  (`routing.classification/apply-route-classification`, `:source :route`) rather
+  than through a hand-installed registry. That the lowering is a production path
+  is half of what this namespace claims; a hand-seeded registry would assume it."
+  []
+  (rf/reg-route :route/oauth
+                {:sensitive [[:query :token]]
+                 :large     [[:query :payload]]
+                 :query     [:map [:token :string] [:payload :string]]}
+                "/oauth")
+  (rf/dispatch-sync [:rf.route/transitioned
+                     (str "/oauth?token=" token-secret "&payload=blobdata")]))
+
+(defn- route-slice
+  "The raw durable route slice from `:rf/default`'s runtime-db — byte-for-byte
+  what `@(rf/subscribe [:rf/route])` returns in-process, and what an off-box
+  read surface hands to the wire walker."
+  []
+  (get-in (:rf.db/runtime (rf/frame-state-value :rf/default))
+          [:rf.runtime/routing :current]))
+
+;; ===========================================================================
+;; (1) The always-on precondition — activation really lowers, in this posture
+;; ===========================================================================
+
+(deftest route-activation-lowers-its-classification-in-this-posture
+  (testing "rf2-u2x6w — every redaction below is downstream of ONE always-on
+            fact: navigating to a classified route re-roots its
+            projection-relative declarations to absolute runtime-db paths and
+            writes them into the live frame's per-frame elision registry. If a
+            production build ever stopped doing that, the redactions below would
+            go quiet rather than red — nothing would be declared, so nothing
+            would be withheld, and a value-shaped assertion cannot tell that
+            apart from a clean walk. This is the non-vacuity pin that can."
+    (navigate-to-classified-route!)
+    (let [reg (:rf.runtime/elision (frame/frame-runtime-db-value :rf/default))]
+      (is (contains? (:sensitive-declarations reg)
+                     [:rf.runtime/routing :current :query :token])
+          "the `:sensitive [[:query :token]]` decl re-rooted to its absolute
+           runtime-db path")
+      (is (contains? (:declarations reg)
+                     [:rf.runtime/routing :current :query :payload])
+          "and the `:large` one alongside it"))
+    (testing "and the routing artefact really published the seam core consults"
+      (is (some? (late-bind/get-fn :routing/route-sub-egress-path))
+          "`:routing/route-sub-egress-path` is bound — core reaches routing
+           through this hook and nothing else"))))
+
+;; ===========================================================================
+;; (2) The egress site itself — off-box direct reads redact in production
+;; ===========================================================================
+
+(deftest route-sub-egress-redacts-the-classified-slice-off-box
+  (testing "rf2-u2x6w — the Pair MCP `read-sub` server-side call shape:
+            `elide-wire-value` naming the sub through `:query-v` consults the
+            routing-owned seed table and walks the BARE slice at the slice's
+            runtime-db storage position, so the registry's re-rooted absolute
+            declarations match. This is the production egress of a route sub's
+            classification, and it is not behind any debug gate."
+    (navigate-to-classified-route!)
+    (let [wire (rf/elide-wire-value (route-slice)
+                                    {:query-v [:rf/route] :frame :rf/default})]
+      (is (= privacy/redacted-sentinel (get-in wire [:query :token]))
+          "the `:sensitive` query value redacts off-box")
+      (is (elision/marker? (get-in wire [:query :payload]))
+          "the `:large` one elides to the size marker")
+      (is (= :route/oauth (:route-id wire))
+          "unclassified structural facts ride verbatim — the walk is
+           path-precise, not a blanket scrub")
+      (is (not (.contains (pr-str wire) token-secret))
+          "GUARD: the raw token appears NOWHERE on the wire value"))))
+
+(deftest the-re-seed-is-what-does-it
+  (testing "rf2-u2x6w — the counterfactual, and the reason the assertion above
+            is not passing for some unrelated reason. The SAME value walked
+            WITHOUT `:query-v` gets no route seed, so the whole-value root never
+            meets the re-rooted absolute declaration and the token rides raw.
+            The hook is the mechanism; remove it and this suite reds rather than
+            silently over-approving."
+    (navigate-to-classified-route!)
+    (let [wire (rf/elide-wire-value (route-slice) {:frame :rf/default})]
+      (is (= token-secret (get-in wire [:query :token]))
+          "no `:query-v` ⇒ no re-seed ⇒ the bare slice walks at the root"))))
+
+(deftest the-other-two-seed-table-entries-redact-too
+  (testing "rf2-u2x6w — `:rf.route/query` and `:rf.route/params` return
+            SUB-projections of the same durable slice, each with its own storage
+            position. A seed table that covered only `:rf/route` would leave
+            both shipping raw, so both are driven here rather than asserted from
+            the table's data."
+    (navigate-to-classified-route!)
+    (let [wire (rf/elide-wire-value (:query (route-slice))
+                                    {:query-v [:rf.route/query] :frame :rf/default})]
+      (is (= privacy/redacted-sentinel (:token wire))
+          "`:rf.route/query`'s bare query map redacts through its own seed"))
+    (rf/reg-route :route/upload {:sensitive [[:params :secret]]} "/upload/:secret")
+    (rf/dispatch-sync [:rf.route/transitioned (str "/upload/" param-secret)])
+    (let [wire (rf/elide-wire-value (:params (route-slice))
+                                    {:query-v [:rf.route/params] :frame :rf/default})]
+      (is (= privacy/redacted-sentinel (:secret wire))
+          "`:rf.route/params`' bare params map redacts through its own seed"))))
+
+;; ===========================================================================
+;; (3) The two boundaries the projection must not cross
+;; ===========================================================================
+
+(deftest the-in-process-read-stays-raw-in-production
+  (testing "rf2-u2x6w — classification is read ONLY at egress. The durable
+            slice the handler, the views and the app's own subs see keeps the
+            real values, in a production build as in a dev one; a redaction that
+            reached in-process would be a correctness bug wearing a privacy
+            fix's clothes."
+    (navigate-to-classified-route!)
+    (let [slice (route-slice)]
+      (is (= token-secret (get-in slice [:query :token])))
+      (is (= "blobdata" (get-in slice [:query :payload]))))))
+
+(deftest a-non-route-sub-is-untouched
+  (testing "rf2-u2x6w — NARROW, and deliberately so: this is not generic
+            sub-output propagation. Only the framework-owned route read surfaces
+            are treated as alternate projections of the route-owned durable
+            fact; an app sub whose value happens to wear the same shape gets no
+            seed and no projection."
+    (navigate-to-classified-route!)
+    (is (= {:query {:token token-secret}}
+           (sub-egress/project-route-sub-egress
+             :some-app/sub {:query {:token token-secret}} {:frame :rf/default}))
+        "a non-route sub-id rides verbatim through the projector")
+    (is (nil? (sub-egress/route-sub-seed-path :rf.route/id))
+        "and a route sub OUTSIDE the classification contract resolves no seed")))
+
+(deftest frameless-route-sub-egress-fails-closed-in-production
+  (testing "rf2-u2x6w — the fail-closed posture is the half of this that a
+            production build most needs, because it is the half that runs when
+            something has gone wrong. With no LIVE frame the per-frame registry
+            is unreachable, so there is no policy to walk under; the value
+            redacts WHOLE rather than falling through to a permissive identity
+            walk that would ship every route slot verbatim."
+    (navigate-to-classified-route!)
+    (let [slice (route-slice)]
+      (is (= privacy/redacted-sentinel
+             (rf/elide-wire-value slice {:query-v [:rf/route] :frame :no/such-frame}))
+          "an explicit frame id that resolves to no LIVE frame redacts the
+           whole slice — a stale carried scope is treated exactly like no
+           scope at all")
+      (is (= privacy/redacted-sentinel
+             (rf/elide-wire-value slice {:query-v [:rf/route] :frame :rf/destroyed}))
+          "and the same holds for any id the frame registry does not know"))))

--- a/implementation/ssr/test/re_frame/ssr_routing_egress_production_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_routing_egress_production_test.clj
@@ -1,0 +1,178 @@
+(ns re-frame.ssr-routing-egress-production-test
+  "rf2-u2x6w — route sub-classification egresses in PRODUCTION here too, and
+  this namespace says so under the real gate.
+
+  ## What this adds to `ssr-route-slice-projection-test`
+
+  rf2-7vk3z established that \"no cross-frame classification bleed\" is a
+  PRODUCTION-real privacy invariant, and found the boundary of what
+  `implementation/core` can witness: the PROJECTION half of sub classification
+  has no production egress inside core, because
+  `classification/project-sub-tags` is reached only from `trace/build-event`
+  inside `trace/emit!`'s `interop/debug-enabled?` gate. Under
+  `-Dre-frame.debug=false` no `:rf.sub/run` event is built at all.
+
+  `payload-policy/project-routing-egress` is one of the two sites outside core
+  where that classification DOES leave the box in a production build — the
+  hydration blob every visitor receives. `ssr-route-slice-projection-test`
+  already pins the projector and is, as it happens, green under the gate; what
+  it does not do is drive the LOWERING. It installs the re-rooted declarations
+  directly (`elision/swap-elision-slot!` over
+  `routing.classification/apply-route-classification`), which proves the
+  projector reads what is in the registry but ASSUMES the thing that puts it
+  there. Route activation is the other half of the production path, and it is
+  the half a debug gate could plausibly be added to. So this namespace drives
+  `reg-route` plus a real `:rf.route/transitioned` and projects the frame's
+  ACTUAL runtime-db, end to end.
+
+  The two namespaces are therefore complements, not duplicates: one pins the
+  projector against a known registry, this one pins the whole chain —
+  activation → per-frame registry → `project-runtime-db` → `build-payload` —
+  in the posture a shipped server runs in.
+
+  ## Posture
+
+  Every assertion below holds in dev AND under `-Dre-frame.debug=false`.
+  Nothing here rebinds `interop/debug-enabled?`: the flag is read once at
+  namespace-load time and a `with-redefs` cannot reach it (rf2-f7qj4). The
+  posture is supplied by the JVM:
+
+      clojure -J-Dre-frame.debug=false -M:test -n re-frame.ssr-routing-egress-production-test
+
+  Measured both ways at rf2-u2x6w: 4 tests / 15 assertions, 0 failures, exit 0.
+
+  There is no `jvm-ssr-prod-gate` job today — `jvm-core-prod-gate` covers
+  `implementation/core` only, so this artefact is not in its reach. The lane
+  recommendation is recorded on rf2-u2x6w."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.elision :as elision]
+            [re-frame.frame :as frame]
+            ;; Loading routing publishes the route classification machinery and
+            ;; the routing events; the reset fixture reloads it.
+            [re-frame.routing]
+            [re-frame.ssr.payload-policy :as payload-policy]
+            [re-frame.ssr.test-fixture :as tf]))
+
+(use-fixtures :each tf/reset-runtime)
+
+(def ^:private token-secret "secret-oauth-token-u2x6w")
+(def ^:private blob-secret "huge-callback-blob-value-u2x6w")
+
+(defn- navigate-to-classified-route!
+  "Register an OAuth-callback-shaped route with a projection-relative
+  `:sensitive` / `:large` declaration and navigate to it FOR REAL. `reg-route`
+  plus a genuine `:rf.route/transitioned` runs the production activation
+  lowering (`routing.classification/apply-route-classification`, `:source
+  :route`), which is what writes the re-rooted absolute declarations into
+  `:rf/default`'s per-frame elision registry. `:return-to` is a plain
+  navigation breadcrumb classified by nothing — the over-redaction control."
+  []
+  (rf/reg-route :route/oauth-callback
+                {:sensitive [[:query :token]]
+                 :large     [[:query :payload]]
+                 :query     [:map
+                             [:token     :string]
+                             [:payload   :string]
+                             [:return-to :string]]}
+                "/oauth/callback")
+  (rf/dispatch-sync [:rf.route/transitioned
+                     (str "/oauth/callback?token=" token-secret
+                          "&payload=" blob-secret
+                          "&return-to=/dashboard")]))
+
+(defn- live-runtime-db
+  "`:rf/default`'s ACTUAL runtime-db — the state a request frame would be
+  holding when the hydration payload is built, not a hand-written fixture map."
+  []
+  (frame/frame-runtime-db-value :rf/default))
+
+;; ===========================================================================
+;; (1) The always-on precondition — activation really lowers, in this posture
+;; ===========================================================================
+
+(deftest route-activation-lowers-its-classification-in-this-posture
+  (testing "rf2-u2x6w — the hydration redaction below is downstream of ONE
+            always-on fact: a real navigation re-roots the route's
+            projection-relative declarations to absolute runtime-db paths and
+            writes them into the live frame's elision registry. If a production
+            build ever stopped doing that the payload assertions would go quiet
+            rather than red — an empty registry withholds nothing and a
+            value-shaped assertion cannot tell that apart from a clean walk."
+    (navigate-to-classified-route!)
+    (let [reg (:rf.runtime/elision (live-runtime-db))]
+      (is (contains? (:sensitive-declarations reg)
+                     [:rf.runtime/routing :current :query :token])
+          "the `:sensitive` decl re-rooted to its absolute runtime-db path")
+      (is (contains? (:declarations reg)
+                     [:rf.runtime/routing :current :query :payload])
+          "and the `:large` one alongside it"))
+    (testing "and the durable slice really is carrying the secret in-process"
+      (is (= token-secret
+             (get-in (live-runtime-db)
+                     [:rf.runtime/routing :current :query :token]))
+          "FIXTURE — the runtime-db the projection is about does hold the raw
+           value, so a clean payload below is a redaction and not an absence"))))
+
+;; ===========================================================================
+;; (2) The egress site itself — the hydration blob redacts in production
+;; ===========================================================================
+
+(deftest hydration-runtime-db-redacts-the-live-classified-route-slice
+  (testing "rf2-u2x6w — `project-runtime-db` over the frame's REAL runtime-db,
+            under the explicit target frame the security-critical builders
+            carry. The allowlisted durable routing slice goes through
+            `project-routing-egress` at the `[:rf.runtime/routing]` offset, so
+            the registry's re-rooted absolute route paths match and the
+            classified values never reach the wire."
+    (navigate-to-classified-route!)
+    (let [slice   (payload-policy/project-runtime-db (live-runtime-db) :rf/default)
+          current (get-in slice [:rf.runtime/routing :current])]
+      (is (= :rf/redacted (get-in current [:query :token]))
+          "the `:sensitive` query value redacts in the hydration slice")
+      (is (elision/marker? (get-in current [:query :payload]))
+          "the `:large` one elides to the size marker")
+      (is (= "/dashboard" (get-in current [:query :return-to]))
+          "the unclassified sibling rides verbatim — path-precise, not a
+           blanket scrub")
+      (is (= :route/oauth-callback (:route-id current))
+          "and so does the structural `:route-id`")
+      (is (not (.contains (pr-str slice) token-secret))
+          "GUARD: no raw token anywhere in the projected runtime-db")
+      (is (not (.contains (pr-str slice) blob-secret))
+          "GUARD: nor the large value"))))
+
+(deftest the-hydration-payload-a-visitor-receives-carries-no-raw-route-secret
+  (testing "rf2-u2x6w — one step further out, at the artefact a browser
+            actually gets. `build-payload` is where the projected runtime-db
+            becomes the serialized hydration blob; asserting on the projector's
+            return value alone would leave the last hop unwitnessed."
+    (navigate-to-classified-route!)
+    (let [rt-slice (payload-policy/project-runtime-db (live-runtime-db) :rf/default)
+          payload  (payload-policy/build-payload
+                     :rf/default {:public/page :callback} "h1"
+                     {:version 1 :runtime-db rt-slice})
+          current  (get-in payload [:rf/runtime-db :rf.runtime/routing :current])]
+      (is (= :rf/redacted (get-in current [:query :token])))
+      (is (elision/marker? (get-in current [:query :payload])))
+      (is (not (.contains (pr-str payload) token-secret))
+          "GUARD: the blob the client receives carries no raw secret")
+      (is (not (.contains (pr-str payload) blob-secret))))))
+
+;; ===========================================================================
+;; (3) The boundary — an unclassified route is not over-redacted
+;; ===========================================================================
+
+(deftest an-unclassified-route-ships-its-slice-verbatim
+  (testing "rf2-u2x6w — the over-redaction control, driven through the same
+            real activation. A route that declares nothing lowers nothing, and
+            its durable slice rides the hydration wire intact. Without this the
+            assertions above would also pass under a blanket scrub, which would
+            be a different framework."
+    (rf/reg-route :route/home {:query [:map [:token :string]]} "/home")
+    (rf/dispatch-sync [:rf.route/transitioned "/home?token=not-classified"])
+    (let [slice   (payload-policy/project-runtime-db (live-runtime-db) :rf/default)
+          current (get-in slice [:rf.runtime/routing :current])]
+      (is (= "not-classified" (get-in current [:query :token]))
+          "an unclassified route query rides the hydration wire verbatim")
+      (is (= :route/home (:route-id current))))))


### PR DESCRIPTION
Two coverage gaps, each found by a worker who was fenced out of fixing it.

## rf2-k8vyi — the canary set is now derived, not listed

The rf2-22ij6 inventory generalised two of the three things a canary suite is made of. The DRIVE SET is read out of the family's source, so a settle branch joins it the moment its source is written. The HARVEST is a whole-record sweep, so whatever slot a continuation gains, it is seen.

The CANARY SET was still a hand list, and it is what the ninth leak (rf2-l6wjl) walked through. `drive-mutation-reply-to!` passed no `:scope`, so every scope it produced was `:rf.scope/global` — a scalar, the one scope shape with nothing in it to leak. `:correlation :scope` therefore carried no canary on either mutation branch, and the sweep swept a slot that was empty by construction. The fixture assertion did not help: `(seq (secret-leak-paths raw))` only asks whether the record leaks SOMEWHERE, and the failure envelope alone satisfied it.

**DERIVED, and here is what that means.** The canary set now comes from the same place the drive set does — the family's own behaviour rather than an author's memory:

- **The floor.** Every inventoried drive plants a resolved `[tier {identity}]` scope bearing the canary. One assertion, no list, true of every branch. The mutation drives pass `:scope` on the execute payload; the two feed branches move to a session-scoped feed; the `:rf.resource.internal/failed` entry moves off the plain owner it shared with the over-redaction controls.
- **The parity.** `identity-bearing-reply-slots` is the union, over every inventoried drive, of the reply slots that demonstrably carry identity — bearing the canary, or bearing a redaction token (proof the SOURCE cleaned identity out before the carrier saw it). Every branch is then held to that union, so a slot planted anywhere is owed everywhere. The union grows by itself: the day any drive plants a canary in a slot nobody had considered, every other branch carrying that slot owes one too.

Parity is the right generalisation because the ninth leak was **not** a slot nobody had thought about. `:correlation :scope` was canaried, cleaned and asserted on every READ branch at the time it shipped. It was the same slot, unplanted on a sibling branch, and no assertion compared the two.

Two exemptions, each with its reason recorded on the inventory entry. The polarity is the point — the union is the default and an exemption must be written down, so a slot nobody considered is covered rather than omitted. The legacy abort event synthesises its own envelope from nothing the caller supplies; a mutation's work id is keyed by its instance rather than by a scoped key.

**What it does not claim.** Parity is a consistency proof, not a completeness one — a slot no drive canaries stays out of the union (`:cause` and `:affected-keys` are barren on every branch today). That is why the floor exists: it pins the four scope-derived slots unconditionally, whatever the rest of the suite does.

Planting the canary forced two drive corrections that are coverage in their own right. Both mutations now declare `:sensitive [[:params :slug]]` — `reg-mutation` has no coarse `:sensitive?` root prop, so a projection-relative params declaration is the only spelling by which a mutation can claim its own params, and this is the only proof anywhere that one reaches a continuation reply. The inventory's feed takes the coarse claim `:derived/profile` makes on the scalar branches, because a projection-relative declaration leaves `row-owner-redacts?` false and the owner's scoped key riding verbatim — correct (rf2-1zc33 made only the FREE `:scope` tag unconditional) but not something a whole-record sweep can be pointed at.

## rf2-u2x6w — the two non-core classification egresses now have production witnesses

rf2-7vk3z found the boundary of what `implementation/core` can witness: the PROJECTION half of sub classification has no production egress there, because `classification/project-sub-tags` is reached only from `trace/build-event` inside `emit!`'s debug gate. Under `-Dre-frame.debug=false` no `:rf.sub/run` event is built at all.

Sub classification nonetheless egresses in production from two sites outside core, and neither had a production-posture test — routing's `:routing/route-sub-egress-path` (every off-box direct read that names a sub through `:query-v`) and ssr's `payload-policy/project-routing-egress` (the hydration blob every visitor receives). `jvm-core-prod-gate` covers `implementation/core` only, so neither is in its reach.

Two namespaces, each green in BOTH postures, neither rebinding `interop/debug-enabled?` — the flag is read once at namespace-load time and a `with-redefs` cannot reach it (rf2-f7qj4), so a rebind would prove nothing about the gate. Both drive the REAL activation lowering (`reg-route` plus a genuine `:rf.route/transitioned`) rather than installing the re-rooted declarations by hand, because activation is the other half of the production path and the half a debug gate could plausibly be added to. Each opens with a non-vacuity pin on the registry: an empty registry withholds nothing, and a value-shaped assertion cannot tell that apart from a clean walk.

New namespaces rather than edits to the existing ones, for a reason each. `re-frame.routing-egress-test` covers the mechanism but cannot carry the claim: under the gate it is 36 failures / 7 errors, because it interleaves the always-on egress legs with TRACE assertions a production build does not emit — and excluding it for the trace legs takes the always-on legs with it, exactly as `scripts/test-core-prod-gate.sh` warns of `conformance-test`. `ssr-route-slice-projection-test` IS green under the gate but installs the lowered registry directly, so it proves the projector reads what is in the registry while assuming the thing that puts it there.

No production instrumentation was added to manufacture an observable.

**Lane scoping — reported, not actioned.** Each artefact needs its own lane row on the core lane's exclusion-roster pattern; `test-core-prod-gate.sh` must not be extended to reach them. Neither artefact is green under the gate as a whole (routing 293 failures / 9 errors across 19 of 44 test files; ssr 217 failures / 1 error across 21), the core roster is core-specific and hard-errors on a stale entry, the flag belongs in a per-artefact `:prod-gate` alias, and the exclusion polarity only holds when roster and namespace set live in the same artefact. Filed as **rf2-hnrwo**, including the `.github/workflows/test.yml` change, which is left for the operator to sequence.

## Quality gates

Foreground, worktree-local, exit codes echoed.

| gate | result | exit |
|---|---|---|
| `implementation/epoch` JVM (`clojure -M:test`) | 537 tests / 7106 assertions / 0 failures | 0 |
| `implementation/resources` JVM | 741 tests / 6853 assertions / 0 failures | 0 |
| `implementation/routing` JVM | 522 tests / 2843 assertions / 0 failures | 0 |
| `implementation/ssr` JVM | 532 tests / 2554 assertions / 0 failures | 0 |
| `routing-sub-egress-production-test`, dev posture | 7 tests / 16 assertions / 0 failures | 0 |
| `routing-sub-egress-production-test`, `-J-Dre-frame.debug=false` | 7 tests / 16 assertions / 0 failures | 0 |
| `ssr-routing-egress-production-test`, dev posture | 4 tests / 15 assertions / 0 failures | 0 |
| `ssr-routing-egress-production-test`, `-J-Dre-frame.debug=false` | 4 tests / 15 assertions / 0 failures | 0 |

Deferred to CI: the CLJS suites, the browser smokes, the Xray feature-matrix gate, bundle-isolation, the perf-bundle gate, mcp-conformance, and `mkdocs build --strict`. Nothing in this PR touches production source, a build file, a workflow, or a doc.

### Mutation evidence

**rf2-k8vyi — the unaided catch.** Reverting #7137's `reply-correlation-slot` arm to the read-only gate it replaced (`fam-reply?` to `reply?`, one symbol), and running the canary namespace in both states:

```
main's canary  + the leak     79 tests / 591 assertions / 0 failures   exit 0   BLIND
this canary    + the leak     81 tests / 642 assertions / 4 failures   exit 1
this canary    + the fix      81 tests / 642 assertions / 0 failures   exit 0
```

The four failures are `real-failing-mutation-reply-to-leaks-no-error-envelope` plus all three mutation branches of `every-inventoried-settle-path-survives-the-canary`, leaking at

```
[:trace-events N :tags :rf.fx/args 1 :correlation :scope 1 :username]
[:trace-events N :tags :rf.event/fx 0 1 1 :correlation :scope 1 :username]
```

— the exact two paths rf2-l6wjl named, caught by the generic whole-record sweep with no assertion anywhere naming `:correlation` or `:scope`. The catch is unaided in the strict sense: the sweep did not learn about this leak, it learned to plant an identity the leak could carry.

**rf2-u2x6w — non-vacuity.** Both measured under `-J-Dre-frame.debug=false`:

| mutation | result |
|---|---|
| `route-sub-seed-path` returns `nil` | 5 of 16 assertions red |
| `project-runtime-db` skips `project-routing-egress` | 8 of 15 assertions red |

All three source mutations were reverted before commit; the diff is test-only.
