### PR TITLE
test(core): split dev instrumentation from semantics so the prod-gate lane can grow (rf2-d2841)

### DIFF
--- a/implementation/core/test/re_frame/drain_test.clj
+++ b/implementation/core/test/re_frame/drain_test.clj
@@ -5,7 +5,31 @@
   load-bearing properties directly so a future regression in router.cljc
   surfaces here, not from a far-away cascade test.
 
-  Each deftest's docstring cites the specific Spec 002 anchor."
+  Each deftest's docstring cites the specific Spec 002 anchor.
+
+  ## Posture split (rf2-d2841)
+
+  The drain's SEMANTICS — run-to-completion ordering, the exact event count a
+  `:drain-depth` bound admits, per-event durability, per-frame isolation, the
+  rejection of a nested `dispatch-sync` — are production-real and are asserted
+  here WITHOUT a posture guard, so they run in the ordinary `clojure -M:test`
+  suite AND in `scripts/test-core-prod-gate.sh` (the `-Dre-frame.debug=false`
+  lane).
+
+  The `:trace` stream those semantics were previously observed THROUGH is not
+  production-real: every `trace/emit-error!` site sits behind
+  `interop/debug-enabled?`, which the JVM reads once at load time, so under the
+  real gate the framework emits nothing here BY DESIGN. Those assertions are
+  correct dev-posture coverage and are kept verbatim — each simply sits inside
+  a `(when interop/debug-enabled? …)` arm marked `rf2-d2841` so it declares the
+  posture it is about instead of dragging its semantic neighbours out of the
+  production lane with it.
+
+  The production-surviving half of the drain-depth halt has its own
+  posture-independent pin at the foot of this namespace
+  (`drain-depth-exceeded-fans-out-on-the-always-on-axis-with-cycle-evidence`,
+  the always-on `:errors` axis), which is why the halt is still covered under
+  the gate rather than merely guarded away."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.error-emit :as error-emit]
@@ -109,32 +133,42 @@
   ;; The router halts the loop and clears the queue when the bound is hit;
   ;; see implementation/src/re_frame/router.cljc."
   (testing "a self-redispatching handler trips :rf.error/drain-depth-exceeded"
-    (let [traces (atom [])]
+    (let [runs   (atom 0)
+          traces (atom [])]
       (rf/register-listener! :trace ::depth (fn [ev] (swap! traces conj ev)))
       ;; Reg a frame with a small drain-depth so the test runs quickly.
       (rf/make-frame {:id :drain.test/loop :drain-depth 8})
       (rf/reg-event :loop-forever
         (fn [_ _]
+          (swap! runs inc)
           {:fx [[:dispatch [:loop-forever]]]}))
       (rf/dispatch-sync [:loop-forever] {:frame :drain.test/loop})
       (rf/unregister-listener! :trace ::depth)
-      (let [hit (some (fn [ev]
-                        (when (= :rf.error/drain-depth-exceeded
-                                 (:operation ev))
-                          ev))
-                      @traces)]
-        (is (some? hit)
-            "expected :rf.error/drain-depth-exceeded trace event")
-        (when hit
-          (let [tags (:tags hit)]
-            (is (number? (:depth tags))
-                ":depth tag is a number")
-            (is (= :drain.test/loop (:frame tags))
-                ":frame tag identifies the offending frame")
-            (is (vector? (:last-event tags))
-                ":last-event tag carries the most-recently-dequeued event")
-            (is (= [:loop-forever] (:last-event tags))
-                ":last-event is the recursive event that drove the cascade"))))))
+      ;; SEMANTIC, posture-independent: the bound really halted the runaway.
+      ;; `dispatch-sync` returning at all is the witness — an unbounded drain
+      ;; never returns — and it returned after exactly the bound's worth of
+      ;; handler bodies.
+      (is (= 8 @runs)
+          "the drain-depth bound halted the runaway after exactly 8 handler bodies")
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (let [hit (some (fn [ev]
+                          (when (= :rf.error/drain-depth-exceeded
+                                   (:operation ev))
+                            ev))
+                        @traces)]
+          (is (some? hit)
+              "expected :rf.error/drain-depth-exceeded trace event")
+          (when hit
+            (let [tags (:tags hit)]
+              (is (number? (:depth tags))
+                  ":depth tag is a number")
+              (is (= :drain.test/loop (:frame tags))
+                  ":frame tag identifies the offending frame")
+              (is (vector? (:last-event tags))
+                  ":last-event tag carries the most-recently-dequeued event")
+              (is (= [:loop-forever] (:last-event tags))
+                  ":last-event is the recursive event that drove the cascade")))))))
 
   (testing "after the abort the queue is cleared (no stuck pending work)"
     (let [traces (atom [])]
@@ -188,15 +222,19 @@
           "the durable per-event writes survive; there is no whole-drain rollback")
       ;; Sanity: the depth-exceeded trace fired and tags :rollback? false
       ;; (no rollback under per-event epochs).
-      (let [hit (some (fn [ev]
-                        (when (= :rf.error/drain-depth-exceeded
-                                 (:operation ev))
-                          ev))
-                      @traces)]
-        (is (some? hit) "drain-depth-exceeded trace was emitted")
-        (when hit
-          (is (false? (get-in hit [:tags :rollback?]))
-              ":rollback? false — per rf2-nj6p7 there is no whole-drain rollback")))))
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring). The
+      ;; no-rollback SEMANTICS are already pinned above, posture-independently,
+      ;; by the surviving `{:step :mid-drain :counter 4}` app-db value.
+      (when interop/debug-enabled?
+        (let [hit (some (fn [ev]
+                          (when (= :rf.error/drain-depth-exceeded
+                                   (:operation ev))
+                            ev))
+                        @traces)]
+          (is (some? hit) "drain-depth-exceeded trace was emitted")
+          (when hit
+            (is (false? (get-in hit [:tags :rollback?]))
+                ":rollback? false — per rf2-nj6p7 there is no whole-drain rollback"))))))
 
   (testing "earlier clean drains stay durable; an overflow keeps prior-event writes"
     ;; A drain that has already settled cleanly once, then is re-engaged
@@ -252,17 +290,22 @@
         (is (= n @runs)
             (str "exactly " n " handler bodies ran for drain-depth " n
                  " (got " @runs ")"))
-        (let [hit (some (fn [ev]
-                          (when (= :rf.error/drain-depth-exceeded
-                                   (:operation ev))
-                            ev))
-                        @traces)]
-          (is (some? hit)
-              (str "drain-depth-exceeded trace fired for drain-depth " n))
-          (when hit
-            (is (= n (get-in hit [:tags :depth]))
-                (str ":depth tag equals drain-depth " n
-                     " (the halting event's depth = N)"))))))))
+        ;; rf2-d2841 — dev-instrumentation arm (see ns docstring). The
+        ;; off-by-one this deftest exists to catch is pinned by `(= n @runs)`
+        ;; above, which is posture-independent; the `:depth` tag is the
+        ;; dev-trace restatement of the same number.
+        (when interop/debug-enabled?
+          (let [hit (some (fn [ev]
+                            (when (= :rf.error/drain-depth-exceeded
+                                     (:operation ev))
+                              ev))
+                          @traces)]
+            (is (some? hit)
+                (str "drain-depth-exceeded trace fired for drain-depth " n))
+            (when hit
+              (is (= n (get-in hit [:tags :depth]))
+                  (str ":depth tag equals drain-depth " n
+                       " (the halting event's depth = N)")))))))))
 
 ;; ---- 3. dispatch-sync-in-handler ------------------------------------------
 
@@ -285,27 +328,36 @@
           {}))
       (rf/dispatch-sync [:nested-direct])
       (rf/unregister-listener! :trace ::dsih-direct)
-      (let [err (some (fn [ev]
-                        (when (and (= :rf.error/dispatch-sync-in-handler (:operation ev))
-                                   (= :error (:op-type ev))
-                                   (= :no-recovery (:recovery ev)))
-                          ev))
-                      @traces)]
-        (is (some? err)
-            "expected :rf.error/dispatch-sync-in-handler with :no-recovery")
-        ;; rf2-kg0et6 — the rejected inner event vector MUST ride the
-        ;; schema-required `:rf.event/v` tag (Spec-Schemas
-        ;; §DispatchSyncInHandlerTags; Spec 009 §Error event catalogue),
-        ;; NOT the undocumented bare `:event`. Pin both directions so the
-        ;; documented key can't silently drift back.
-        (when err
-          (let [tags (:tags err)]
-            (is (= [:leaf] (:rf.event/v tags))
-                "the rejected inner event vector rides the schema-required :rf.event/v tag")
-            (is (not (contains? tags :event))
-                "the undocumented bare :event tag is not emitted")
-            (is (= :rf/default (:frame tags))
-                "the :frame tag carries the enclosing frame (the default frame here)"))))))
+      ;; SEMANTIC, posture-independent (rf2-d2841). The ban is not a warning:
+      ;; the nested event is REJECTED, so `:leaf`'s handler never runs and its
+      ;; `:db` write never lands. That is the half a production build really
+      ;; enforces, and until rf2-d2841 nothing asserted it in either posture —
+      ;; the whole contract hung off the dev trace below.
+      (is (nil? (:leaf? (rf/app-db-value :rf/default)))
+          "the rejected inner event's handler never ran — no :db write landed")
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (let [err (some (fn [ev]
+                          (when (and (= :rf.error/dispatch-sync-in-handler (:operation ev))
+                                     (= :error (:op-type ev))
+                                     (= :no-recovery (:recovery ev)))
+                            ev))
+                        @traces)]
+          (is (some? err)
+              "expected :rf.error/dispatch-sync-in-handler with :no-recovery")
+          ;; rf2-kg0et6 — the rejected inner event vector MUST ride the
+          ;; schema-required `:rf.event/v` tag (Spec-Schemas
+          ;; §DispatchSyncInHandlerTags; Spec 009 §Error event catalogue),
+          ;; NOT the undocumented bare `:event`. Pin both directions so the
+          ;; documented key can't silently drift back.
+          (when err
+            (let [tags (:tags err)]
+              (is (= [:leaf] (:rf.event/v tags))
+                  "the rejected inner event vector rides the schema-required :rf.event/v tag")
+              (is (not (contains? tags :event))
+                  "the undocumented bare :event tag is not emitted")
+              (is (= :rf/default (:frame tags))
+                  "the :frame tag carries the enclosing frame (the default frame here)")))))))
 
   (testing "calling dispatch-sync TRANSITIVELY through a user fx is also caught"
     ;; Some fx handlers naively call dispatch-sync to chain another event.
@@ -327,10 +379,17 @@
           {:fx [[:user.fx/sync-dispatch [:leaf2]]]}))
       (rf/dispatch-sync [:nested-via-fx])
       (rf/unregister-listener! :trace ::dsih-fx)
-      (is (some (fn [ev]
-                  (= :rf.error/dispatch-sync-in-handler (:operation ev)))
-                @traces)
-          "the transitive (via-fx) dispatch-sync still trips the in-handler guard"))))
+      ;; SEMANTIC, posture-independent (rf2-d2841): the guard keys off the
+      ;; router's :in-drain? flag rather than the call-stack depth, so the
+      ;; transitive call is rejected too — `:leaf2`'s handler never runs.
+      (is (nil? (:leaf2? (rf/app-db-value :rf/default)))
+          "the transitive (via-fx) dispatch-sync was rejected — no :db write landed")
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (some (fn [ev]
+                    (= :rf.error/dispatch-sync-in-handler (:operation ev)))
+                  @traces)
+            "the transitive (via-fx) dispatch-sync still trips the in-handler guard")))))
 
 ;; ---- 4. async vs sync interleaving ----------------------------------------
 
@@ -528,16 +587,20 @@
           ":A's app-db remains exactly its :initial-events state")
 
       ;; --- (c) the depth-exceeded trace carries :B, not :A.
-      (let [hit (some (fn [ev]
-                        (when (= :rf.error/drain-depth-exceeded
-                                 (:operation ev))
-                          ev))
-                      @traces)]
-        (is (some? hit) "drain-depth-exceeded trace was emitted")
-        (is (= :drain.iso/B (get-in hit [:tags :frame]))
-            "the trace's :frame tag is :B (the overflowing frame), not :A")
-        (is (false? (get-in hit [:tags :rollback?]))
-            ":rollback? false — per rf2-nj6p7 there is no whole-drain rollback"))
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring). The isolation
+      ;; CONTRACT is (a) + (b) above, both posture-independent; the trace's
+      ;; `:frame` tag is the dev restatement of which frame overflowed.
+      (when interop/debug-enabled?
+        (let [hit (some (fn [ev]
+                          (when (= :rf.error/drain-depth-exceeded
+                                   (:operation ev))
+                            ev))
+                        @traces)]
+          (is (some? hit) "drain-depth-exceeded trace was emitted")
+          (is (= :drain.iso/B (get-in hit [:tags :frame]))
+              "the trace's :frame tag is :B (the overflowing frame), not :A")
+          (is (false? (get-in hit [:tags :rollback?]))
+              ":rollback? false — per rf2-nj6p7 there is no whole-drain rollback")))
 
       (rf/unregister-listener! :trace ::iso))))
 

--- a/implementation/core/test/re_frame/events_test.clj
+++ b/implementation/core/test/re_frame/events_test.clj
@@ -15,12 +15,32 @@
   This SUPERSEDES the former rf2-bbea warning
   (`:rf.warning/interceptors-in-metadata-map`): `:interceptors` inside the
   metadata-map is now the documented home, not a typo. A malformed
-  `:interceptors` value is a loud `:rf.error/reg-event-bad-interceptors`."
+  `:interceptors` value is a loud `:rf.error/reg-event-bad-interceptors`.
+
+  ## Posture split (rf2-d2841)
+
+  Every assertion here is posture-independent — it holds in the ordinary
+  `clojure -M:test` suite AND under the real production gate
+  (`scripts/test-core-prod-gate.sh`, `-Dre-frame.debug=false`) — UNLESS it sits
+  inside a `(when interop/debug-enabled? …)` arm marked `rf2-d2841`.
+
+  Two things this namespace observes are dev-only BY DESIGN and therefore live
+  in such arms: the `:trace` stream (every `trace/emit-error!` site is gated on
+  `interop/debug-enabled?`) and `:doc` reflection metadata on a registry entry
+  (retained for tooling / agent inspection in dev, elided in production — see
+  `re-frame.doc-metadata-prod-elision-test`).
+
+  Where the trace was the only witness for a REJECTION, a production-visible
+  one was ADDED rather than the assertion dropped: `clear-event` really stops
+  the handler running, and a non-map handler return really yields no `:db` and
+  no `:fx` — a returned `[[:dispatch …]]` vector is NOT quietly honoured as an
+  effects vector."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.events :as events]
             [re-frame.frame :as frame]
             [re-frame.interceptor :as interceptor]
+            [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
             [re-frame.registrar :as registrar]
             [re-frame.substrate.plain-atom :as plain-atom]
@@ -123,8 +143,13 @@
           "the superset form does NOT fire the retired metadata-misuse warning")
       (let [meta (rf/handler-meta :event :test.bpmszk/super)
             ids  (chain-ids (:interceptors meta))]
-        (is (= "Superset form." (:doc meta))
-            "the reflection metadata is retained on the registry entry")
+        ;; rf2-d2841 — dev-instrumentation arm (see ns docstring). `:doc` is
+        ;; retained for tooling in dev and ELIDED in production; the chain
+        ;; threading this deftest is named for is asserted below, in both
+        ;; postures.
+        (when interop/debug-enabled?
+          (is (= "Superset form." (:doc meta))
+              "the reflection metadata is retained on the registry entry"))
         (is (not (contains? meta :interceptors-as-raw))
             "the raw key is not duplicated under another name")
         (is (= [:test/noop :rf/event-handler] ids)
@@ -307,28 +332,39 @@
 (deftest clear-event-removes-a-single-handler
   (testing "(rf/clear-event id) removes the registered :event slot;
             a subsequent dispatch traces :rf.error/no-such-handler"
-    (rf/reg-event :test.6z20/foo (fn [{:keys [db]} _] {:db (assoc db :touched? true)}))
-    ;; Pre-clear: reachable via lookup AND dispatch.
-    (is (some? (registrar/lookup :event :test.6z20/foo))
-        "the event handler is reachable via registrar/lookup pre-clear")
-    (rf/dispatch-sync [:test.6z20/foo])
-    (is (true? (:touched? (rf/app-db-value :rf/default)))
-        "the handler ran when registered")
-
-    ;; Clear.
-    (rf/clear-event :test.6z20/foo)
-
-    ;; Post-clear: gone from the registry, dispatch traces no-such-handler.
-    (is (nil? (registrar/lookup :event :test.6z20/foo))
-        "registry slot is gone after clear-event")
-    (let [recorded (record-traces! ::post-clear)]
+    ;; `runs` is the production-visible witness (rf2-d2841): the integration
+    ;; symptom this deftest exists to catch — "a stale handler still firing"
+    ;; — is a fact about EXECUTION, not about the trace stream, so count the
+    ;; handler bodies rather than reading the count off a dev-only channel.
+    (let [runs (atom 0)]
+      (rf/reg-event :test.6z20/foo
+        (fn [{:keys [db]} _] (swap! runs inc) {:db (assoc db :touched? true)}))
+      ;; Pre-clear: reachable via lookup AND dispatch.
+      (is (some? (registrar/lookup :event :test.6z20/foo))
+          "the event handler is reachable via registrar/lookup pre-clear")
       (rf/dispatch-sync [:test.6z20/foo])
-      (let [errs (filterv #(= :rf.error/no-such-handler (:operation %))
-                          @recorded)]
-        (is (= 1 (count errs))
-            "a subsequent dispatch traces :rf.error/no-such-handler")
-        (is (= :test.6z20/foo (-> errs first :tags :rf.trace/event-id))
-            ":rf.trace/event-id carries the cleared handler's id")))))
+      (is (true? (:touched? (rf/app-db-value :rf/default)))
+          "the handler ran when registered")
+      (is (= 1 @runs) "exactly one handler body ran pre-clear")
+
+      ;; Clear.
+      (rf/clear-event :test.6z20/foo)
+
+      ;; Post-clear: gone from the registry, dispatch traces no-such-handler.
+      (is (nil? (registrar/lookup :event :test.6z20/foo))
+          "registry slot is gone after clear-event")
+      (let [recorded (record-traces! ::post-clear)]
+        (rf/dispatch-sync [:test.6z20/foo])
+        (is (= 1 @runs)
+            "the cleared handler did NOT run on the subsequent dispatch")
+        ;; rf2-d2841 — dev-instrumentation arm (see ns docstring).
+        (when interop/debug-enabled?
+          (let [errs (filterv #(= :rf.error/no-such-handler (:operation %))
+                              @recorded)]
+            (is (= 1 (count errs))
+                "a subsequent dispatch traces :rf.error/no-such-handler")
+            (is (= :test.6z20/foo (-> errs first :tags :rf.trace/event-id))
+                ":rf.trace/event-id carries the cleared handler's id")))))))
 
 (deftest clear-event-no-arg-clears-every-event
   (testing "(rf/clear-event) with no args clears every registered :event id"
@@ -382,37 +418,61 @@
         (fn [_ _] "hello"))
       (let [db-before (rf/app-db-value :rf/default)]
         (rf/dispatch-sync [:test.k3bj/string-return])
-        (let [errs (error-events recorded :rf.error/effect-handler-bad-return)]
-          (is (= 1 (count errs))
-              (str "expected exactly one :rf.error/effect-handler-bad-return, got " (count errs)))
-          (let [t (:tags (first errs))]
-            (is (= :test.k3bj/string-return (:event-id t)))
-            (is (= [:test.k3bj/string-return] (:event t)))
-            (is (= "hello" (:returned t)))
-            (is (= (type "hello") (:returned-type t)))
-            (is (string? (:reason t)))
-            (is (re-find #"non-map" (:reason t))))
-          (is (= :no-recovery (:recovery (first errs)))))
+        ;; rf2-d2841 — dev-instrumentation arm (see ns docstring). The
+        ;; production-real half is the RECOVERY, asserted below in both
+        ;; postures: nothing is extracted from a non-map return, so app-db is
+        ;; untouched.
+        (when interop/debug-enabled?
+          (let [errs (error-events recorded :rf.error/effect-handler-bad-return)]
+            (is (= 1 (count errs))
+                (str "expected exactly one :rf.error/effect-handler-bad-return, got " (count errs)))
+            (let [t (:tags (first errs))]
+              (is (= :test.k3bj/string-return (:event-id t)))
+              (is (= [:test.k3bj/string-return] (:event t)))
+              (is (= "hello" (:returned t)))
+              (is (= (type "hello") (:returned-type t)))
+              (is (string? (:reason t)))
+              (is (re-find #"non-map" (:reason t))))
+            (is (= :no-recovery (:recovery (first errs))))))
         (is (= db-before (rf/app-db-value :rf/default))
             "app-db is unchanged after a no-op recovery"))))
 
   (testing "handler returning a number emits :rf.error/effect-handler-bad-return"
-    (let [recorded (record-traces! ::bad-number)]
+    (let [recorded  (record-traces! ::bad-number)
+          db-before (rf/app-db-value :rf/default)]
       (rf/reg-event :test.k3bj/number-return
         (fn [_ _] 42))
       (rf/dispatch-sync [:test.k3bj/number-return])
-      (let [errs (error-events recorded :rf.error/effect-handler-bad-return)]
-        (is (= 1 (count errs)))
-        (is (= 42 (:returned (:tags (first errs))))))))
+      (is (= db-before (rf/app-db-value :rf/default))
+          "app-db is unchanged — nothing is extracted from a number return")
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (let [errs (error-events recorded :rf.error/effect-handler-bad-return)]
+          (is (= 1 (count errs)))
+          (is (= 42 (:returned (:tags (first errs)))))))))
 
   (testing "handler returning a vector emits :rf.error/effect-handler-bad-return"
-    (let [recorded (record-traces! ::bad-vector)]
+    ;; The vector case carries the sharpest production-real claim in this
+    ;; deftest (rf2-d2841): `[[:dispatch [:other]]]` is exactly the shape of an
+    ;; `:fx` VALUE, so a runtime that shrugged and honoured it would silently
+    ;; dispatch `[:other]`. `other-runs` witnesses that it does not — in both
+    ;; postures, where before only the dev trace said so.
+    (let [recorded   (record-traces! ::bad-vector)
+          other-runs (atom 0)
+          db-before  (rf/app-db-value :rf/default)]
+      (rf/reg-event :other (fn [{:keys [db]} _] (swap! other-runs inc) {:db db}))
       (rf/reg-event :test.k3bj/vector-return
         (fn [_ _] [[:dispatch [:other]]]))
       (rf/dispatch-sync [:test.k3bj/vector-return])
-      (let [errs (error-events recorded :rf.error/effect-handler-bad-return)]
-        (is (= 1 (count errs)))
-        (is (= [[:dispatch [:other]]] (:returned (:tags (first errs)))))))))
+      (is (zero? @other-runs)
+          "the returned vector was NOT honoured as an :fx value — [:other] never dispatched")
+      (is (= db-before (rf/app-db-value :rf/default))
+          "app-db is unchanged — nothing is extracted from a vector return")
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (let [errs (error-events recorded :rf.error/effect-handler-bad-return)]
+          (is (= 1 (count errs)))
+          (is (= [[:dispatch [:other]]] (:returned (:tags (first errs))))))))))
 
 (deftest reg-event-nil-return-stays-silent
   (testing "handler returning nil is a documented legal no-op; no :rf.error/effect-handler-bad-return"
@@ -472,8 +532,13 @@
       (rf/dispatch-sync [:test.fuudi/shape-2])
       (is (true? (:test.fuudi/touched-2? (rf/app-db-value :rf/default))))
       (let [meta (rf/handler-meta :event :test.fuudi/shape-2)]
-        (is (= "metadata-only middle slot" (:doc meta))
-            ":doc from the metadata-map is retained on the registry entry")
+        ;; rf2-d2841 — dev-instrumentation arm (see ns docstring): `:doc` is
+        ;; tooling metadata, retained in dev and elided in production. That the
+        ;; SHAPE was accepted at all is the `:test.fuudi/touched-2?` assertion
+        ;; above, which runs in both postures.
+        (when interop/debug-enabled?
+          (is (= "metadata-only middle slot" (:doc meta))
+              ":doc from the metadata-map is retained on the registry entry"))
         (is (= 1 (count (:interceptors meta)))
             "no user interceptors; chain holds only the runtime :rf/event-handler wrapper")))
 
@@ -496,8 +561,10 @@
       (is (true? (:test.fuudi/touched-4? (rf/app-db-value :rf/default))))
       (let [meta (rf/handler-meta :event :test.fuudi/shape-4)
             ids  (chain-ids (:interceptors meta))]
-        (is (= "metadata AND interceptors" (:doc meta))
-            ":doc from the metadata-map is retained on the registry entry")
+        ;; rf2-d2841 — dev-instrumentation arm (see ns docstring).
+        (when interop/debug-enabled?
+          (is (= "metadata AND interceptors" (:doc meta))
+              ":doc from the metadata-map is retained on the registry entry"))
         (is (= [:test.fuudi/marker :rf/event-handler] ids)
             "the user interceptor ref sits before the runtime wrapper in registration order")))
 
@@ -529,7 +596,9 @@
     (let [meta (rf/handler-meta :event :test.fuudi/ctx-shape-4)
           ids  (chain-ids (:interceptors meta))]
       (is (not (contains? meta :event/kind)))
-      (is (= "interceptor, metadata interceptors" (:doc meta)))
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (= "interceptor, metadata interceptors" (:doc meta))))
       (is (= [:test.fuudi/ctx-marker :rf/event-handler] ids)))))
 
 (deftest normalise-args-rejects-overlong-and-malformed

--- a/implementation/core/test/re_frame/frame_lifecycle_test.clj
+++ b/implementation/core/test/re_frame/frame_lifecycle_test.clj
@@ -4,7 +4,24 @@
   active-machines); this file exercises the edge cases of make-frame,
   make-frame, destroy-frame!, ensure-default-frame!, and the surgical-
   update path. Per Spec 002 §Frames, §Destroy, §make-frame is atomic,
-  §Re-registration — surgical update, §Per-instance frames."
+  §Re-registration — surgical update, §Per-instance frames.
+
+  ## Posture split (rf2-d2841)
+
+  Every assertion here is posture-independent — it holds in the ordinary
+  `clojure -M:test` suite AND under the real production gate
+  (`scripts/test-core-prod-gate.sh`, `-Dre-frame.debug=false`) — UNLESS it sits
+  inside a `(when interop/debug-enabled? …)` arm marked `rf2-d2841`.
+
+  Those arms observe the `:trace` stream, which is dev-only: every
+  `trace/emit-error!` / lifecycle emit site is gated on
+  `interop/debug-enabled?`, read once at namespace-load time, so under the gate
+  the framework emits none of it BY DESIGN. What matters about a destroy is not
+  that it ANNOUNCED itself but that it HAPPENED — the frame left the registry,
+  the sub-cache disposed, the pending events never ran, the teardown continued
+  past a throwing `:on-destroy`. Those are the assertions left outside the
+  arms, and several were ADDED by rf2-d2841 where the trace had been the only
+  witness."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
@@ -138,8 +155,10 @@
         (rf/register-listener! :trace ::after (fn [ev] (swap! t-after conj ev)))
         (rf/dispatch-sync [:tick] {:frame :worker})
         (rf/unregister-listener! :trace ::after)
-        (is (some #(= :rf.error/frame-destroyed (:operation %)) @t-after)
-            "post-destroy dispatch traces :rf.error/frame-destroyed")
+        ;; rf2-d2841 — dev-instrumentation arm (see ns docstring).
+        (when interop/debug-enabled?
+          (is (some #(= :rf.error/frame-destroyed (:operation %)) @t-after)
+              "post-destroy dispatch traces :rf.error/frame-destroyed"))
         ;; The handler did NOT run for the post-destroy attempt — the
         ;; counter stays bounded by what (if anything) drained.
         (is (<= @side-effects 2)
@@ -161,27 +180,41 @@
                     :flow/checkout {:state :reviewing  :data {:cart [1 2]}}
                     :flow/billing  {:state :collected  :data {}}})}))
     (rf/dispatch-sync [:seed-machines] {:frame :ten})
+    ;; SEMANTIC, posture-independent (rf2-d2841): three machine snapshots
+    ;; really are active, so the cascade below has three actors to walk.
+    (is (= #{:flow/login :flow/checkout :flow/billing}
+           (set (keys (get-in (:rf.db/runtime (rf/frame-state-value :ten))
+                              [:rf.runtime/machines :snapshots]))))
+        "three machine snapshots are active on :ten before the destroy")
     (let [traces (atom [])]
       (rf/register-listener! :trace ::cascade (fn [ev] (swap! traces conj ev)))
       (rf/destroy-frame! :ten)
       (rf/unregister-listener! :trace ::cascade)
-      (let [cascade (filter #(= :rf.machine.lifecycle/destroyed (:operation %))
-                            @traces)]
-        (is (= 3 (count cascade))
-            "one trace event per active machine snapshot")
-        (is (every? #(= :ten (:frame (:tags %))) cascade)
-            "all events carry the destroyed frame's id")
-        (is (= #{:flow/login :flow/checkout :flow/billing}
-               (set (map #(:actor-id (:tags %)) cascade)))
-            "every actor-id is signalled exactly once (rf2-ws5thu — the reaped live INSTANCE address; :machine-id reserved for the registered TYPE)")
-        (is (= #{:authed :reviewing :collected}
-               (set (map #(:last-state (:tags %)) cascade)))
-            "each event carries that machine's last-state from the snapshot")
-        (is (every? #(= :parent-frame-destroyed (:reason (:tags %))) cascade)
-            "each event carries :reason :parent-frame-destroyed (the unified discriminator)"))
-      ;; A :rf.frame/destroyed trace is also emitted (after the cascade).
-      (is (some #(= :rf.frame/destroyed (:operation %)) @traces)
-          "expected a :rf.frame/destroyed trace"))))
+      ;; SEMANTIC, posture-independent: the destroy completed — the frame and
+      ;; its three snapshots are gone from the registry.
+      (is (nil? (frame/frame :ten))
+          ":ten (and every snapshot it held) left the registry")
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring). The
+      ;; per-machine SIGNAL is a developer/tooling notification and rides the
+      ;; dev `:trace` stream only.
+      (when interop/debug-enabled?
+        (let [cascade (filter #(= :rf.machine.lifecycle/destroyed (:operation %))
+                              @traces)]
+          (is (= 3 (count cascade))
+              "one trace event per active machine snapshot")
+          (is (every? #(= :ten (:frame (:tags %))) cascade)
+              "all events carry the destroyed frame's id")
+          (is (= #{:flow/login :flow/checkout :flow/billing}
+                 (set (map #(:actor-id (:tags %)) cascade)))
+              "every actor-id is signalled exactly once (rf2-ws5thu — the reaped live INSTANCE address; :machine-id reserved for the registered TYPE)")
+          (is (= #{:authed :reviewing :collected}
+                 (set (map #(:last-state (:tags %)) cascade)))
+              "each event carries that machine's last-state from the snapshot")
+          (is (every? #(= :parent-frame-destroyed (:reason (:tags %))) cascade)
+              "each event carries :reason :parent-frame-destroyed (the unified discriminator)"))
+        ;; A :rf.frame/destroyed trace is also emitted (after the cascade).
+        (is (some #(= :rf.frame/destroyed (:operation %)) @traces)
+            "expected a :rf.frame/destroyed trace")))))
 
 ;; ---- rf2-vsigt — frame destroy runs `:exit` cascades reverse-creation ----
 ;;
@@ -272,8 +305,12 @@
         (rf/unregister-listener! :trace ::sub-destroy)
         (is (= 1 @dispose-fired)
             "on-dispose hook fired exactly once when destroy walked the sub-cache")
-        (is (some #(= :rf.frame/destroyed (:operation %)) @traces)
-            "expected :rf.frame/destroyed trace"))
+        ;; rf2-d2841 — dev-instrumentation arm (see ns docstring). The
+        ;; cache-clearing this deftest is named for is `@dispose-fired` above
+        ;; and the nil post-destroy subscribe below — both posture-independent.
+        (when interop/debug-enabled?
+          (is (some #(= :rf.frame/destroyed (:operation %)) @traces)
+              "expected :rf.frame/destroyed trace")))
 
       ;; Post-destroy subscribe returns nil with :replaced-with-default.
       (let [t-after (atom [])]
@@ -282,11 +319,13 @@
           (is (nil? r3)
               "subscribe against a destroyed frame returns nil"))
         (rf/unregister-listener! :trace ::post)
-        (is (some (fn [ev]
-                    (and (= :rf.error/frame-destroyed (:operation ev))
-                         (= :replaced-with-default (:recovery ev))))
-                  @t-after)
-            "expected :rf.error/frame-destroyed trace with :replaced-with-default recovery")))))
+        ;; rf2-d2841 — dev-instrumentation arm (see ns docstring).
+        (when interop/debug-enabled?
+          (is (some (fn [ev]
+                      (and (= :rf.error/frame-destroyed (:operation ev))
+                           (= :replaced-with-default (:recovery ev))))
+                    @t-after)
+              "expected :rf.error/frame-destroyed trace with :replaced-with-default recovery"))))))
 
 ;; ---- Spec 002 §:rf/default — ensure-default-frame! idempotence -----------
 
@@ -395,6 +434,14 @@
 
         ;; Ordering: the :rf.event/run-end for :boot precedes :rf.frame/created
         ;; (make-frame emits :rf.frame/created AFTER the setup dispatch-syncs).
+        ;;
+        ;; rf2-d2841 — dev-instrumentation arm (see ns docstring). The
+        ;; SYNCHRONY this deftest is named for is the three app-db assertions
+        ;; above, read the instant `make-frame` returned; they run in both
+        ;; postures. The trace ORDER below is the same fact restated on a
+        ;; dev-only channel — under the gate there is no trace ring to index
+        ;; into, so `run-end-idx` / `created-idx` are both nil.
+        (when interop/debug-enabled?
         (let [run-end-idx (->> @traces
                                (keep-indexed
                                  (fn [i ev]
@@ -413,7 +460,7 @@
           (is (some? created-idx)
               "expected a :rf.frame/created trace")
           (is (< run-end-idx created-idx)
-              "the setup's :run-end precedes :rf.frame/created — frame is fully booted before listeners observe it"))))))
+              "the setup's :run-end precedes :rf.frame/created — frame is fully booted before listeners observe it")))))))
 
 ;; ---- rf2-68kok — destroy-frame! interrupts active drain on next dequeue --
 ;;
@@ -493,18 +540,24 @@
 
       ;; Exactly one :rf.frame/drain-interrupted trace fired carrying
       ;; the dropped count (4 ticks queued before the seed).
-      (let [interrupts (filterv (fn [ev]
-                                  (= :rf.frame/drain-interrupted (:operation ev)))
-                                @traces)]
-        (is (= 1 (count interrupts))
-            "exactly one :rf.frame/drain-interrupted trace")
-        (let [ev (first interrupts)]
-          (is (= :rf.frame (:op-type ev))
-              ":op-type is :frame (lifecycle family, not :error)")
-          (is (= :drain-int/worker (:frame (:tags ev)))
-              ":tags carries the destroyed frame id")
-          (is (= 4 (:dropped-count (:tags ev)))
-              ":dropped-count reflects the 4 trailing ticks left in the queue"))))))
+      ;;
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring). The
+      ;; INTERRUPTION itself is `(= [:self-destruct] @ran)` and the empty
+      ;; registry slot above — both posture-independent; the report of how
+      ;; many events were dropped is a dev-tooling detail.
+      (when interop/debug-enabled?
+        (let [interrupts (filterv (fn [ev]
+                                    (= :rf.frame/drain-interrupted (:operation ev)))
+                                  @traces)]
+          (is (= 1 (count interrupts))
+              "exactly one :rf.frame/drain-interrupted trace")
+          (let [ev (first interrupts)]
+            (is (= :rf.frame (:op-type ev))
+                ":op-type is :frame (lifecycle family, not :error)")
+            (is (= :drain-int/worker (:frame (:tags ev)))
+                ":tags carries the destroyed frame id")
+            (is (= 4 (:dropped-count (:tags ev)))
+                ":dropped-count reflects the 4 trailing ticks left in the queue")))))))
 
 (deftest destroy-from-handler-allows-authored-callback-return
   (testing "destroy does not forcibly interrupt authored code already on the
@@ -819,13 +872,18 @@
       ;; Must not throw NPE.
       (is (nil? (adapter/replace-container! nil {:any :value}))
           "nil container is a documented no-op, not an exception")
-      (let [errs (filterv (fn [ev]
-                            (and (= :error (:op-type ev))
-                                 (= :rf.error/write-after-destroy
-                                    (:operation ev))))
-                          @recorded)]
-        (is (= 1 (count errs))
-            "exactly one :rf.error/write-after-destroy trace fired")))))
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring). The guard's
+      ;; production-real half is the no-op-instead-of-NPE assertion above,
+      ;; which is the whole point of the rf2-ft2b fix and runs in both
+      ;; postures; the REPORT of the skipped write is a dev diagnostic.
+      (when interop/debug-enabled?
+        (let [errs (filterv (fn [ev]
+                              (and (= :error (:op-type ev))
+                                   (= :rf.error/write-after-destroy
+                                      (:operation ev))))
+                            @recorded)]
+          (is (= 1 (count errs))
+              "exactly one :rf.error/write-after-destroy trace fired"))))))
 
 (deftest drain-after-destroy-does-not-npe
   ;; Reproducer for the original race (rf2-ft2b): a scheduled drain that
@@ -938,8 +996,13 @@
         (rf/register-listener! :trace ::rf2-dpny-after (fn [ev] (swap! after-traces conj ev)))
         (rf/dispatch-sync [:rf2-dpny/tick] {:frame :rf2-dpny/worker})
         (rf/unregister-listener! :trace ::rf2-dpny-after)
-        (is (some #(= :rf.error/frame-destroyed (:operation %)) @after-traces)
-            "post-destroy dispatch (not the drain) traces :rf.error/frame-destroyed"))
+        ;; rf2-d2841 — dev-instrumentation arm (see ns docstring). NOTE that
+        ;; (b) above is a NEGATIVE trace assertion and is therefore vacuous
+        ;; under the gate; the no-op contract this deftest is named for is
+        ;; carried by (a), (d) and (e), all posture-independent.
+        (when interop/debug-enabled?
+          (is (some #(= :rf.error/frame-destroyed (:operation %)) @after-traces)
+              "post-destroy dispatch (not the drain) traces :rf.error/frame-destroyed")))
 
       ;; (d) The handler still never ran.
       (is (= 0 @side-effects)
@@ -1098,20 +1161,27 @@
                                      #(= :rf.frame/drain-interrupted
                                          (:operation %))
                                      @traces)]
+                  ;; These two are ROUTER STATE — production-real, and they are
+                  ;; the algorithm this deftest pins (Spec 002 §Drain-loop
+                  ;; pseudocode). They stay outside the arm.
                   (is (true? (:destroy-claim-report-emitted? router-state))
                       "the first callback compare-marks this router generation")
                   (is (not (contains? router-state
                                       :destroy-claim-dropped-count))
                       "the first callback atomically consumes claim-time evidence")
-                  (is (= 1 (count interrupts))
-                      "the compare/mark winner emits the one combined report"))
+                  ;; rf2-d2841 — dev-instrumentation arm (see ns docstring).
+                  (when interop/debug-enabled?
+                    (is (= 1 (count interrupts))
+                        "the compare/mark winner emits the one combined report")))
                 (interop/next-tick second-tick)
                 (executor-barrier!)
-                (is (= 1 (count (filter
-                                  #(= :rf.frame/drain-interrupted
-                                      (:operation %))
-                                  @traces)))
-                    "the second captured callback observes the mark and emits nothing"))
+                ;; rf2-d2841 — dev-instrumentation arm (see ns docstring).
+                (when interop/debug-enabled?
+                  (is (= 1 (count (filter
+                                    #(= :rf.frame/drain-interrupted
+                                        (:operation %))
+                                    @traces)))
+                      "the second captured callback observes the mark and emits nothing")))
               (let [record (get @frame/frames frame-id)]
                 (reset! gap-observation
                         {:destroyed? (-> record :lifecycle :destroyed?)
@@ -1129,12 +1199,16 @@
           "a drain-dropped post-claim handler cannot enqueue or run children")
       (is (= {:destroyed? false :queued 0} @gap-observation)
           "the claim predicate emptied the real queue while lifecycle was still live")
-      (let [interrupts (filterv #(= :rf.frame/drain-interrupted (:operation %))
-                                @traces)]
-        (is (= 1 (count interrupts))
-            "the observing drain emits exactly one interruption trace")
-        (is (= 2 (get-in (first interrupts) [:tags :dropped-count]))
-            "dropped-count combines one claim-time and one check-time removal"))
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring). The
+      ;; "never executes" half of this deftest's name is the four zero-count
+      ;; assertions plus `@gap-observation` above, all posture-independent.
+      (when interop/debug-enabled?
+        (let [interrupts (filterv #(= :rf.frame/drain-interrupted (:operation %))
+                                  @traces)]
+          (is (= 1 (count interrupts))
+              "the observing drain emits exactly one interruption trace")
+          (is (= 2 (get-in (first interrupts) [:tags :dropped-count]))
+              "dropped-count combines one claim-time and one check-time removal")))
       (is (nil? (frame/frame frame-id)) "destroy completes after the gap proof"))))
 
 (deftest on-destroy-cascade-is-isolated-from-preclaim-and-bound-work
@@ -1266,13 +1340,17 @@
         ;; Pre-fix: NPE. Post-fix: no-op + always-on error trace.
         (is (nil? (adapter/replace-container! container {:would :have :npe'd true}))
             "writing through the nil container is a documented no-op"))
-      (let [errs (filterv (fn [ev]
-                            (and (= :error (:op-type ev))
-                                 (= :rf.error/write-after-destroy
-                                    (:operation ev))))
-                          @recorded)]
-        (is (pos? (count errs))
-            ":rf.error/write-after-destroy fired for the post-destroy write")))))
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring). The rf2-ft2b
+      ;; NPE this deftest reproduces is closed by the two assertions above,
+      ;; both posture-independent.
+      (when interop/debug-enabled?
+        (let [errs (filterv (fn [ev]
+                              (and (= :error (:op-type ev))
+                                   (= :rf.error/write-after-destroy
+                                      (:operation ev))))
+                            @recorded)]
+          (is (pos? (count errs))
+              ":rf.error/write-after-destroy fired for the post-destroy write"))))))
 
 ;; ---- rf2-2e6k: frame-ids / frame-meta re-export round-trip ----------------
 ;;
@@ -1492,23 +1570,28 @@
       (rf/unregister-listener! :trace ::rf2-r1ciy)
 
       ;; (a) The :rf.error/on-destroy-handler-exception trace fired.
-      (let [errs (filterv (fn [ev]
-                            (and (= :error (:op-type ev))
-                                 (= :rf.error/on-destroy-handler-exception
-                                    (:operation ev))))
-                          @traces)]
-        (is (= 1 (count errs))
-            "exactly one :rf.error/on-destroy-handler-exception trace")
-        (let [ev (first errs)
-              tags (:tags ev)]
-          (is (= :throwy/worker (:frame tags))
-              ":tags carries the destroyed frame id")
-          (is (= [:throwy/blow-up] (:event tags))
-              ":tags carries the :on-destroy event vector")
-          (is (some? (:exception tags))
-              ":tags carries the captured exception")
-          (is (= :fire-on-destroy-event! (:where tags))
-              ":tags carries the call-site :where marker")))
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring). "Does not
+      ;; abort teardown" is (b), (c) and the non-propagating `destroy-frame!`
+      ;; above — all posture-independent; the REPORT of the swallowed throw is
+      ;; a dev diagnostic.
+      (when interop/debug-enabled?
+        (let [errs (filterv (fn [ev]
+                              (and (= :error (:op-type ev))
+                                   (= :rf.error/on-destroy-handler-exception
+                                      (:operation ev))))
+                            @traces)]
+          (is (= 1 (count errs))
+              "exactly one :rf.error/on-destroy-handler-exception trace")
+          (let [ev (first errs)
+                tags (:tags ev)]
+            (is (= :throwy/worker (:frame tags))
+                ":tags carries the destroyed frame id")
+            (is (= [:throwy/blow-up] (:event tags))
+                ":tags carries the :on-destroy event vector")
+            (is (some? (:exception tags))
+                ":tags carries the captured exception")
+            (is (= :fire-on-destroy-event! (:where tags))
+                ":tags carries the call-site :where marker"))))
 
       ;; (b) The frame is fully gone from the registry.
       (is (nil? (frame/frame :throwy/worker))
@@ -1521,8 +1604,10 @@
           "sub-cache disposal ran — on-dispose hook fired once")
 
       ;; (d) :rf.frame/destroyed trace was emitted (post-throw step still ran).
-      (is (some #(= :rf.frame/destroyed (:operation %)) @traces)
-          ":rf.frame/destroyed trace was emitted — teardown continued past the throw"))))
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (some #(= :rf.frame/destroyed (:operation %)) @traces)
+            ":rf.frame/destroyed trace was emitted — teardown continued past the throw")))))
 
 (deftest on-destroy-throw-then-fresh-make-frame-clean
   (testing "after a throwy destroy, the same frame id can be re-registered
@@ -1574,16 +1659,20 @@
           ":on-destroy fired once; the re-entrant destroy-frame! did not re-run it")
 
       ;; (b) Exactly one :rf.frame/destroyed trace emitted.
-      (let [destroyed-traces (filter #(= :rf.frame/destroyed (:operation %)) @traces)]
-        (is (= 1 (count destroyed-traces))
-            "exactly one :rf.frame/destroyed trace — teardown ran end-to-end once"))
-
       ;; (c) No :rf.error/on-destroy-handler-exception (the inner call
       ;;     was a silent no-op, not a throw).
-      (let [errs (filter #(= :rf.error/on-destroy-handler-exception (:operation %))
-                         @traces)]
-        (is (zero? (count errs))
-            "re-entrant no-op is silent — no error trace"))
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring). The
+      ;; re-entrancy guard itself is (a) above, posture-independent; (c) is a
+      ;; NEGATIVE trace assertion and would pass vacuously under the gate,
+      ;; which is why it sits inside the arm rather than outside it.
+      (when interop/debug-enabled?
+        (let [destroyed-traces (filter #(= :rf.frame/destroyed (:operation %)) @traces)]
+          (is (= 1 (count destroyed-traces))
+              "exactly one :rf.frame/destroyed trace — teardown ran end-to-end once"))
+        (let [errs (filter #(= :rf.error/on-destroy-handler-exception (:operation %))
+                           @traces)]
+          (is (zero? (count errs))
+              "re-entrant no-op is silent — no error trace")))
 
       ;; (d) The frame is gone.
       (is (nil? (frame/frame :reent/worker))

--- a/implementation/core/test/re_frame/interceptor_test.clj
+++ b/implementation/core/test/re_frame/interceptor_test.clj
@@ -22,13 +22,43 @@
   after-reverse-order / exception-interruption.
 
   Tests run on the JVM via the plain-atom adapter; per the project
-  invariant the JVM interop layer must work."
+  invariant the JVM interop layer must work.
+
+  ## Posture split (rf2-d2841)
+
+  Every assertion here is posture-independent — it holds in the ordinary
+  `clojure -M:test` suite AND under the real production gate
+  (`scripts/test-core-prod-gate.sh`, `-Dre-frame.debug=false`) — UNLESS it sits
+  inside a `(when interop/debug-enabled? …)` arm marked `rf2-d2841`. That is
+  what lets the bulk of this namespace — chain composition, before-order /
+  after-reverse-order, the `:rf.interceptor/path` ref, ctx-delta — run in the
+  production lane.
+
+  Two surfaces are dev-only BY DESIGN and live in such arms:
+
+    * The `:trace` stream. Every `trace/emit-error!` site is gated on
+      `interop/debug-enabled?`, so `capture-error-traces` returns `[]` under
+      the gate. NOTE that this makes the NEGATIVE controls (`(empty? (filterv
+      …))`) vacuous there, which is why they sit inside the arm too rather than
+      standing outside it looking load-bearing.
+    * `:source-coord`. The `->interceptor` MACRO's production branch omits the
+      `:source-coord` kwarg entirely (core.cljc §`->interceptor`), so the coord
+      is absent under the gate — and so is the fn-path's, which is what makes
+      the macro-vs-fn discriminator dev-only as a pair.
+
+  The rf2-mszrz ATTRIBUTION contract (`:failing-id` = the true failing
+  component) is production-real on the always-on error-emit axis, which lifts
+  `:failing-id` / `:reason` onto its record whenever they differ from
+  `:event-id` (error_emit.cljc §`emit-error-both!`). Giving it a
+  posture-independent `:errors`-axis twin is the rf2-7vk3z shape and is tracked
+  separately; it is deliberately NOT bolted on here."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]
             [re-frame.interceptor :as interceptor]
+            [re-frame.interop :as interop]
             [re-frame.std-interceptors :as std-interceptors]
             [re-frame.trace :as trace]
             [re-frame.registrar :as registrar]
@@ -341,20 +371,24 @@
           "handler runs with the original event vector when the shape check fails")
 
       ;; The structured trace fired.
-      (let [bad-shape (filterv #(= :test.app/unwrap-bad-event-shape (:operation %))
-                               @traces)]
-        (is (= 1 (count bad-shape))
-            "exactly one :test.app/unwrap-bad-event-shape trace was emitted")
-        (let [ev (first bad-shape)]
-          (is (= :error (:op-type ev)))
-          (is (= [:unwrap-bad-test/consume :not-a-map]
-                 (get-in ev [:tags :event]))
-              ":event tag carries the offending event vector")
-          (is (= "[event-id payload-map]"
-                 (get-in ev [:tags :expected]))
-              ":expected describes the canonical envelope shape")
-          (is (= :no-recovery (:recovery ev))
-              ":recovery is :no-recovery — the bad path is documented as not-recoverable")))))
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring). The
+      ;; "keeps-event-unchanged" half of this deftest's name is the
+      ;; `@seen-event` assertion above, which runs in both postures.
+      (when interop/debug-enabled?
+        (let [bad-shape (filterv #(= :test.app/unwrap-bad-event-shape (:operation %))
+                                 @traces)]
+          (is (= 1 (count bad-shape))
+              "exactly one :test.app/unwrap-bad-event-shape trace was emitted")
+          (let [ev (first bad-shape)]
+            (is (= :error (:op-type ev)))
+            (is (= [:unwrap-bad-test/consume :not-a-map]
+                   (get-in ev [:tags :event]))
+                ":event tag carries the offending event vector")
+            (is (= "[event-id payload-map]"
+                   (get-in ev [:tags :expected]))
+                ":expected describes the canonical envelope shape")
+            (is (= :no-recovery (:recovery ev))
+                ":recovery is :no-recovery — the bad path is documented as not-recoverable"))))))
 
   (testing "a project :app/unwrap with a 3-element vector (correct id, wrong arity) traces"
     (let [traces     (atom [])
@@ -369,8 +403,10 @@
       ;; Wrong arity — three elements instead of two.
       (rf/dispatch-sync [:unwrap-bad-test/arity {:ok :map} :extra])
       (rf/unregister-listener! :trace ::unwrap-arity)
-      (is (some #(= :test.app/unwrap-bad-event-shape (:operation %)) @traces)
-          ":test.app/unwrap-bad-event-shape fires for arity mismatch too")
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (some #(= :test.app/unwrap-bad-event-shape (:operation %)) @traces)
+            ":test.app/unwrap-bad-event-shape fires for arity mismatch too"))
       (is (= [:unwrap-bad-test/arity {:ok :map} :extra] @seen-event)
           "handler sees the original (still-wrongly-shaped) event")))
 
@@ -779,19 +815,29 @@
   (testing "event HANDLER throw → :rf.error/handler-exception (failing-id = event)"
     (rf/reg-event :mszrz/handler-boom
                      (fn [{:keys [db]} _] {:db (throw (ex-info "handler blew up" {}))}))
-    (let [errs (capture-error-traces [:mszrz/handler-boom])
-          hx   (filterv #(= :rf.error/handler-exception (:operation %)) errs)]
-      (is (= 1 (count hx)) "exactly one handler-exception")
-      (let [ev (first hx)]
-        (is (= :mszrz/handler-boom (get-in ev [:tags :failing-id]))
-            ":failing-id is the event id")
-        (is (= :mszrz/handler-boom (get-in ev [:tags :handler-id]))
-            ":handler-id is retained for the genuine handler case")
-        (is (= "Event handler threw." (get-in ev [:tags :reason]))))
-      (is (empty? (filterv #(#{:rf.error/coeffect-exception
-                               :rf.error/interceptor-exception}
-                             (:operation %)) errs))
-          "no coeffect / interceptor category for a pure handler throw")))
+    (let [db-before (rf/app-db-value :rf/default)
+          errs      (capture-error-traces [:mszrz/handler-boom])]
+      ;; SEMANTIC, posture-independent (rf2-d2841): the no-abort contract —
+      ;; the throw is contained, `dispatch-sync` returns, and the failed
+      ;; event commits nothing.
+      (is (= db-before (rf/app-db-value :rf/default))
+          "a throwing handler commits nothing; the runtime does not abort")
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring). The negative
+      ;; control is inside the arm too: under the gate `errs` is empty, so
+      ;; `empty?` would pass for the wrong reason.
+      (when interop/debug-enabled?
+        (let [hx (filterv #(= :rf.error/handler-exception (:operation %)) errs)]
+          (is (= 1 (count hx)) "exactly one handler-exception")
+          (let [ev (first hx)]
+            (is (= :mszrz/handler-boom (get-in ev [:tags :failing-id]))
+                ":failing-id is the event id")
+            (is (= :mszrz/handler-boom (get-in ev [:tags :handler-id]))
+                ":handler-id is retained for the genuine handler case")
+            (is (= "Event handler threw." (get-in ev [:tags :reason]))))
+          (is (empty? (filterv #(#{:rf.error/coeffect-exception
+                                   :rf.error/interceptor-exception}
+                                 (:operation %)) errs))
+              "no coeffect / interceptor category for a pure handler throw")))))
 
   ;; The former "coeffect INJECTION throw → :rf.error/coeffect-exception"
   ;; sub-test is retired with `inject-cofx` (EP-0017 slice A.3): coeffect
@@ -804,16 +850,24 @@
     (rf/reg-event :mszrz/before-boom
                      {:interceptors [:mszrz/before-icpt]}
                      (fn [{:keys [db]} _] {:db db}))
-    (let [errs (capture-error-traces [:mszrz/before-boom])
-          ix   (filterv #(= :rf.error/interceptor-exception (:operation %)) errs)]
-      (is (= 1 (count ix)) "exactly one interceptor-exception")
-      (let [ev (first ix)]
-        (is (= :mszrz/before-icpt (get-in ev [:tags :failing-id]))
-            ":failing-id is the interceptor id")
-        (is (= :before (get-in ev [:tags :phase]))
-            ":phase is :before"))
-      (is (empty? (filterv #(= :rf.error/handler-exception (:operation %)) errs))
-          "an interceptor :before throw does NOT report as handler-exception")))
+    (let [db-before (rf/app-db-value :rf/default)
+          errs      (capture-error-traces [:mszrz/before-boom])]
+      ;; SEMANTIC, posture-independent (rf2-d2841): a throwing `:before`
+      ;; interrupts the chain — the handler never commits — without aborting
+      ;; the runtime.
+      (is (= db-before (rf/app-db-value :rf/default))
+          "a throwing :before interrupts the chain; nothing is committed")
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (let [ix (filterv #(= :rf.error/interceptor-exception (:operation %)) errs)]
+          (is (= 1 (count ix)) "exactly one interceptor-exception")
+          (let [ev (first ix)]
+            (is (= :mszrz/before-icpt (get-in ev [:tags :failing-id]))
+                ":failing-id is the interceptor id")
+            (is (= :before (get-in ev [:tags :phase]))
+                ":phase is :before"))
+          (is (empty? (filterv #(= :rf.error/handler-exception (:operation %)) errs))
+              "an interceptor :before throw does NOT report as handler-exception")))))
 
   (testing "user interceptor :AFTER throw → :rf.error/interceptor-exception (failing-id = interceptor, phase :after)"
     ;; The :after chain runs after the handler; an :after throw must
@@ -824,16 +878,18 @@
     (rf/reg-event :mszrz/after-boom
                      {:interceptors [:mszrz/after-icpt]}
                      (fn [{:keys [db]} _] {:db db}))
-    (let [errs (capture-error-traces [:mszrz/after-boom])
-          ix   (filterv #(= :rf.error/interceptor-exception (:operation %)) errs)]
-      (is (= 1 (count ix)) "exactly one interceptor-exception")
-      (let [ev (first ix)]
-        (is (= :mszrz/after-icpt (get-in ev [:tags :failing-id]))
-            ":failing-id is the interceptor id")
-        (is (= :after (get-in ev [:tags :phase]))
-            ":phase is :after — NOT collapsed into the handler"))
-      (is (empty? (filterv #(= :rf.error/handler-exception (:operation %)) errs))
-          "an interceptor :after throw does NOT report as handler-exception"))))
+    (let [errs (capture-error-traces [:mszrz/after-boom])]
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (let [ix (filterv #(= :rf.error/interceptor-exception (:operation %)) errs)]
+          (is (= 1 (count ix)) "exactly one interceptor-exception")
+          (let [ev (first ix)]
+            (is (= :mszrz/after-icpt (get-in ev [:tags :failing-id]))
+                ":failing-id is the interceptor id")
+            (is (= :after (get-in ev [:tags :phase]))
+                ":phase is :after — NOT collapsed into the handler"))
+          (is (empty? (filterv #(= :rf.error/handler-exception (:operation %)) errs))
+              "an interceptor :after throw does NOT report as handler-exception"))))))
 
 ;; ---- macro-path source-coord capture (rf2-siheh) --------------------------
 ;;
@@ -855,26 +911,42 @@
                  :id     :siheh/probe
                  :before identity)
           {:keys [ns file line] :as coord} (:source-coord icpt)]
-      (is (map? coord)
-          "the macro bakes a :source-coord map into the interceptor")
-      (is (= 're-frame.interceptor-test ns)
-          ":ns is the metadata-free consumer namespace symbol")
-      (is (integer? line) ":line is the macro call-site line")
-      (is (string? file) ":file is a string")
-      ;; rf2-wvsxg — the macro feeds the picked :file through
-      ;; absolutise-file at expansion time, so the coord ships an
-      ;; absolute on-disk path (here the classpath resolved the test
-      ;; source under the core artefact's test root).
-      (is (re-find #"interceptor_test\.clj$" file)
-          ":file resolves to this test source file")
-      (is (re-find #"^(?:/|[A-Za-z]:)" file)
-          ":file is absolute (leading slash or drive letter) — absolutised")))
+      ;; SEMANTIC, posture-independent (rf2-d2841): whichever branch the macro
+      ;; expands to, it must still BUILD a usable interceptor. A production
+      ;; branch that dropped more than the coord would be an rf2-9c2jf-class
+      ;; defect, and nothing else in the suite would see it.
+      (is (= :siheh/probe (:id icpt))
+          "the macro builds an interceptor carrying the requested :id")
+      (is (fn? (:before icpt))
+          "the macro builds an interceptor carrying the :before fn")
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring). The macro's
+      ;; PRODUCTION branch omits the `:source-coord` kwarg entirely, by design.
+      (when interop/debug-enabled?
+        (is (map? coord)
+            "the macro bakes a :source-coord map into the interceptor")
+        (is (= 're-frame.interceptor-test ns)
+            ":ns is the metadata-free consumer namespace symbol")
+        (is (integer? line) ":line is the macro call-site line")
+        (is (string? file) ":file is a string")
+        ;; rf2-wvsxg — the macro feeds the picked :file through
+        ;; absolutise-file at expansion time, so the coord ships an
+        ;; absolute on-disk path (here the classpath resolved the test
+        ;; source under the core artefact's test root).
+        (is (re-find #"interceptor_test\.clj$" file)
+            ":file resolves to this test source file")
+        (is (re-find #"^(?:/|[A-Za-z]:)" file)
+            ":file is absolute (leading slash or drive letter) — absolutised"))))
 
   (testing "the ->interceptor* fn path captures NO :source-coord (HoF /
             programmatic — no syntactic call site to attribute)"
     (let [icpt (interceptor/->interceptor* :id :siheh/fn-probe :before identity)]
-      (is (nil? (:source-coord icpt))
-          "fn-built interceptor carries no coord"))))
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring). This is the
+      ;; NEGATIVE half of the macro-vs-fn discriminator above; under the
+      ;; production gate neither path carries a coord, so asserting it there
+      ;; would pass for the wrong reason.
+      (when interop/debug-enabled?
+        (is (nil? (:source-coord icpt))
+            "fn-built interceptor carries no coord")))))
 
 (deftest macro-interceptor-source-coord-rides-the-exception-trace
   (testing "a throwing macro-defined interceptor threads its :source-coord
@@ -891,15 +963,19 @@
     (rf/reg-event :siheh/before-boom
                      {:interceptors [:siheh/before-icpt]}
                      (fn [{:keys [db]} _] {:db db}))
-    (let [errs (capture-error-traces [:siheh/before-boom])
-          ix   (filterv #(= :rf.error/interceptor-exception (:operation %)) errs)]
-      (is (= 1 (count ix)) "exactly one interceptor-exception")
-      (let [coord (get-in (first ix) [:tags :source-coord])]
-        (is (map? coord)
-            "the trace carries the interceptor's :source-coord tag")
-        (is (re-find #"interceptor_test\.clj$" (:file coord))
-            ":file points at this test source")
-        (is (integer? (:line coord)) ":line is captured"))))
+    (let [errs (capture-error-traces [:siheh/before-boom])]
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring): a coord
+      ;; threaded onto a trace tag is dev-only twice over — the coord is not
+      ;; captured in production and the trace is not emitted there either.
+      (when interop/debug-enabled?
+        (let [ix (filterv #(= :rf.error/interceptor-exception (:operation %)) errs)]
+          (is (= 1 (count ix)) "exactly one interceptor-exception")
+          (let [coord (get-in (first ix) [:tags :source-coord])]
+            (is (map? coord)
+                "the trace carries the interceptor's :source-coord tag")
+            (is (re-find #"interceptor_test\.clj$" (:file coord))
+                ":file points at this test source")
+            (is (integer? (:line coord)) ":line is captured"))))))
 
   (testing "a throwing ->interceptor*-built interceptor threads NO
             :source-coord tag (degrades to plain text in the panel)"
@@ -913,11 +989,13 @@
     (rf/reg-event :siheh/fn-before-boom
                      {:interceptors [:siheh/fn-before-icpt]}
                      (fn [{:keys [db]} _] {:db db}))
-    (let [errs (capture-error-traces [:siheh/fn-before-boom])
-          ix   (filterv #(= :rf.error/interceptor-exception (:operation %)) errs)]
-      (is (= 1 (count ix)) "exactly one interceptor-exception")
-      (is (nil? (get-in (first ix) [:tags :source-coord]))
-          "no :source-coord tag — the fn path captured none"))))
+    (let [errs (capture-error-traces [:siheh/fn-before-boom])]
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (let [ix (filterv #(= :rf.error/interceptor-exception (:operation %)) errs)]
+          (is (= 1 (count ix)) "exactly one interceptor-exception")
+          (is (nil? (get-in (first ix) [:tags :source-coord]))
+              "no :source-coord tag — the fn path captured none"))))))
 
 ;; ---- ctx-delta falsy-key correctness (rf2-tq8l9m) -------------------------
 

--- a/implementation/core/test/re_frame/smoke_test.clj
+++ b/implementation/core/test/re_frame/smoke_test.clj
@@ -2,9 +2,28 @@
   "Smoke tests — exercise the foundation end-to-end on the JVM via the
   plain-atom adapter. These are the bare-minimum 'does the dispatch
   pipeline actually work?' tests. Conformance fixtures are a separate
-  TODO."
+  TODO.
+
+  ## Posture split (rf2-d2841)
+
+  Every assertion here is posture-independent — it must hold in the ordinary
+  `clojure -M:test` suite AND under the real production gate
+  (`scripts/test-core-prod-gate.sh`, `-Dre-frame.debug=false`) — UNLESS it sits
+  inside a `(when interop/debug-enabled? …)` arm marked `rf2-d2841`.
+
+  Those arms observe the DEV `:trace` stream (and the debug-gated view
+  annotations), whose emit sites are gated on `interop/debug-enabled?` — read
+  once at namespace-load time on the JVM, constant-folded away by Closure under
+  `goog.DEBUG=false`. Under the gate the framework emits none of it BY DESIGN,
+  so the assertions are correct dev-posture coverage; they are kept verbatim and
+  merely declare the posture they are about, so the semantics they used to be
+  bundled with can run in the production lane. Where a semantic sibling did not
+  previously exist — the `dispatch-sync`-in-handler ban, the machine
+  spawn/destroy fx — one was ADDED against a production-visible witness rather
+  than the trace being dropped."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.interop :as interop]
             [re-frame.routing :as routing]
             [re-frame.machines :as machines]
             [re-frame.frame :as frame]
@@ -124,22 +143,27 @@
       (is (nil? (rf/compute-sub [:boom] {}))
           "compute-sub still returns nil (recovery :replaced-with-default)")
       (rf/unregister-listener! :trace ::boom)
-      (let [ev (some (fn [e]
-                       (when (= :rf.error/sub-exception (:operation e)) e))
-                     @traces)]
-        (is (some? ev) "an :rf.error/sub-exception trace was emitted")
-        (when ev
-          (is (= :error (:op-type ev)) "op-type is :error")
-          ;; `:recovery` is hoisted onto the envelope by build-event.
-          (is (= :replaced-with-default (:recovery ev)))
-          (let [t (:tags ev)]
-            (is (= :boom (:failing-id t)))
-            (is (= :boom (:rf.sub/id t)))
-            (is (= [:boom] (:sub-query t)))
-            (is (= :compute-sub (:where t))
-                ":where distinguishes the pure-compute call site from the reactive memo path")
-            (is (instance? Throwable (:exception t)))
-            (is (= "boom" (:exception-message t))))))))
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring). The
+      ;; production-real half — the throw is CAUGHT and recovery is
+      ;; `:replaced-with-default` (nil), not a propagated exception — is the
+      ;; `(is (nil? …))` above, which runs in both postures.
+      (when interop/debug-enabled?
+        (let [ev (some (fn [e]
+                         (when (= :rf.error/sub-exception (:operation e)) e))
+                       @traces)]
+          (is (some? ev) "an :rf.error/sub-exception trace was emitted")
+          (when ev
+            (is (= :error (:op-type ev)) "op-type is :error")
+            ;; `:recovery` is hoisted onto the envelope by build-event.
+            (is (= :replaced-with-default (:recovery ev)))
+            (let [t (:tags ev)]
+              (is (= :boom (:failing-id t)))
+              (is (= :boom (:rf.sub/id t)))
+              (is (= [:boom] (:sub-query t)))
+              (is (= :compute-sub (:where t))
+                  ":where distinguishes the pure-compute call site from the reactive memo path")
+              (is (instance? Throwable (:exception t)))
+              (is (= "boom" (:exception-message t)))))))))
   (testing "compute-sub emits :rf.error/sub-exception when a layer-2 body throws"
     (rf/reg-sub :n   (fn [db _] (:n db)))
     (rf/reg-sub :n*2 :<- [:n] (fn [_n _q] (throw (ex-info "kaboom" {}))))
@@ -147,12 +171,14 @@
       (rf/register-listener! :trace ::boom2 (fn [ev] (swap! traces conj ev)))
       (is (nil? (rf/compute-sub [:n*2] {:n 7})))
       (rf/unregister-listener! :trace ::boom2)
-      (is (some (fn [e]
-                  (and (= :rf.error/sub-exception (:operation e))
-                       (= :n*2 (:rf.sub/id (:tags e)))
-                       (= :compute-sub (:where (:tags e)))))
-                @traces)
-          "layer-2 throw also emits :rf.error/sub-exception via compute-sub"))))
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (some (fn [e]
+                    (and (= :rf.error/sub-exception (:operation e))
+                         (= :n*2 (:rf.sub/id (:tags e)))
+                         (= :compute-sub (:where (:tags e)))))
+                  @traces)
+            "layer-2 throw also emits :rf.error/sub-exception via compute-sub")))))
 
 (deftest subscribe-handles-missing-frame
   (testing "subscribe / subscribe-once against a missing frame don't throw"
@@ -163,11 +189,15 @@
       (is (nil? (rf/subscribe-once [:n] {:frame :missing/frame}))
           "subscribe-once returns nil")
       (rf/unregister-listener! :trace ::missing)
-      (is (some (fn [ev]
-                  (and (= :rf.error/frame-destroyed (:operation ev))
-                       (= :replaced-with-default (:recovery ev))))
-                @traces)
-          "expected :rf.error/frame-destroyed trace with :replaced-with-default"))))
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring). The
+      ;; production-real half — neither call THROWS, both recover to nil — is
+      ;; the two `(is (nil? …))` assertions above, which run in both postures.
+      (when interop/debug-enabled?
+        (is (some (fn [ev]
+                    (and (= :rf.error/frame-destroyed (:operation ev))
+                         (= :replaced-with-default (:recovery ev))))
+                  @traces)
+            "expected :rf.error/frame-destroyed trace with :replaced-with-default")))))
 
 ;; sub-cache-ref-counting and sub-hot-reload-invalidates-cache moved to
 ;; sub_cache_test.clj; flows-are-frame-scoped and
@@ -204,12 +234,20 @@
           {}))
       (rf/dispatch-sync [:nested])
       (rf/unregister-listener! :trace ::dsih)
-      (is (some (fn [ev]
-                  (and (= :rf.error/dispatch-sync-in-handler (:operation ev))
-                       (= :error (:op-type ev))
-                       (= :no-recovery (:recovery ev))))
-                @traces)
-          "expected :rf.error/dispatch-sync-in-handler trace event"))))
+      ;; SEMANTIC, posture-independent (rf2-d2841): the ban is enforcement,
+      ;; not advice — the nested event is REJECTED, so `:outer`'s handler
+      ;; never runs and its `:db` write never lands. That is the half a
+      ;; production build carries.
+      (is (nil? (:ran? (rf/app-db-value :rf/default)))
+          "the nested event was rejected — :outer's handler never ran")
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (some (fn [ev]
+                    (and (= :rf.error/dispatch-sync-in-handler (:operation ev))
+                         (= :error (:op-type ev))
+                         (= :no-recovery (:recovery ev))))
+                  @traces)
+            "expected :rf.error/dispatch-sync-in-handler trace event")))))
 
 (deftest sync-dispatch-from-handler-body-routes-to-handlers-frame
   ;; Per rf2-l5q3 — the router binds `frame/*current-frame*` to the
@@ -567,13 +605,20 @@
       (rf/register-listener! :trace ::vh (fn [ev] (swap! traces conj ev)))
       (verify-fn :rf/default "client-hash-Y")
       (rf/unregister-listener! :trace ::vh)
-      (is (some (fn [ev]
-                  (and (= :rf.ssr/hydration-mismatch (:operation ev))
-                       (= "server-hash-X" (:server-hash (:tags ev)))
-                       (= "client-hash-Y" (:client-hash (:tags ev)))
-                       (= :warned-and-replaced (:recovery ev))))
-                @traces)
-          "expected :rf.ssr/hydration-mismatch trace with both hashes"))))
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring). The
+      ;; production-real half — `rf/hydrate` really stashed the server hash
+      ;; under `[:rf.runtime/ssr :hydration]`, which is the state
+      ;; `verify-hydration!` compares against — is asserted above, in both
+      ;; postures. The MISMATCH REPORT is a developer diagnostic: the recovery
+      ;; is `:warned-and-replaced`, i.e. the client render wins either way.
+      (when interop/debug-enabled?
+        (is (some (fn [ev]
+                    (and (= :rf.ssr/hydration-mismatch (:operation ev))
+                         (= "server-hash-X" (:server-hash (:tags ev)))
+                         (= "client-hash-Y" (:client-hash (:tags ev)))
+                         (= :warned-and-replaced (:recovery ev))))
+                  @traces)
+            "expected :rf.ssr/hydration-mismatch trace with both hashes")))))
 
 (deftest render-tree-hash-is-stable
   (testing "render-tree-hash is deterministic and order-sensitive on vectors"
@@ -606,22 +651,35 @@
                    {:flow/login    {:state :authed   :data {}}
                     :flow/checkout {:state :pending  :data {}}})}))
     (rf/dispatch-sync [:seed-machines] {:frame :tenant-a})
+    ;; SEMANTIC, posture-independent (rf2-d2841): the two active machines were
+    ;; really there to be signalled, and the teardown really happened.
+    (is (= #{:flow/login :flow/checkout}
+           (set (keys (get-in (:rf.db/runtime (rf/frame-state-value :tenant-a))
+                              [:rf.runtime/machines :snapshots]))))
+        "two machine snapshots are active on :tenant-a before the destroy")
     (let [traces (atom [])]
       (rf/register-listener! :trace ::df (fn [ev] (swap! traces conj ev)))
       (rf/destroy-frame! :tenant-a)
       (rf/unregister-listener! :trace ::df)
-      (let [machine-traces (filter #(= :rf.machine.lifecycle/destroyed
-                                        (:operation %))
-                                   @traces)]
-        (is (= 2 (count machine-traces))
-            "one trace per active machine snapshot")
-        (is (every? #(= :tenant-a (:frame (:tags %))) machine-traces)
-            "all traces carry the destroyed frame's id")
-        (is (= #{:authed :pending}
-               (set (map #(:last-state (:tags %)) machine-traces)))
-            "each trace carries its machine's last-state")
-        (is (every? #(= :parent-frame-destroyed (:reason (:tags %))) machine-traces)
-            "each trace carries :reason :parent-frame-destroyed")))))
+      (is (not (contains? (rf/frame-ids) :tenant-a))
+          ":tenant-a and its machine snapshots are gone after destroy-frame!")
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring). The
+      ;; per-machine SIGNAL is a developer/tooling notification: it rides the
+      ;; dev `:trace` stream only, so under the production gate there is
+      ;; nothing to count.
+      (when interop/debug-enabled?
+        (let [machine-traces (filter #(= :rf.machine.lifecycle/destroyed
+                                          (:operation %))
+                                     @traces)]
+          (is (= 2 (count machine-traces))
+              "one trace per active machine snapshot")
+          (is (every? #(= :tenant-a (:frame (:tags %))) machine-traces)
+              "all traces carry the destroyed frame's id")
+          (is (= #{:authed :pending}
+                 (set (map #(:last-state (:tags %)) machine-traces)))
+              "each trace carries its machine's last-state")
+          (is (every? #(= :parent-frame-destroyed (:reason (:tags %))) machine-traces)
+              "each trace carries :reason :parent-frame-destroyed"))))))
 
 (deftest spawn-id-is-frame-scoped
   (testing "actor-id allocation is scoped per-parent-snapshot — independent frames don't share an actor-id sequence"
@@ -656,30 +714,35 @@
         (rf/dispatch-sync [:flow [:start]] {:frame :left})
         (rf/dispatch-sync [:flow [:start]] {:frame :right})
         (rf/unregister-listener! :trace ::sids)
-        (let [spawn-traces (filter #(= :rf.machine.spawn/spawned (:operation %)) @traces)
-              ids          (mapv #(get-in % [:tags :id-prefix]) spawn-traces)]
-          (is (= 2 (count spawn-traces))
-              "two :rf.machine.spawn/spawned traces — one per frame")
-          (is (every? #(= :worker %) ids)
-              "both spawned the :worker machine")
-          ;; Per rf2-gr8q the spawn-counter is no longer a per-process
-          ;; atom — it lives inside each parent machine's snapshot at
-          ;; `:rf/spawn-counter`. Frame-scoping is inherited from
-          ;; per-frame app-db isolation: each frame owns its own copy of
-          ;; the :flow machine's snapshot at [:rf.runtime/machines :snapshots :flow]; each
-          ;; copy's counter advances independently. Read the counter
-          ;; from each frame's snapshot directly.
-          (let [snap-left  (get-in (:rf.db/runtime (rf/frame-state-value :left)) [:rf.runtime/machines :snapshots :flow])
-                snap-right (get-in (:rf.db/runtime (rf/frame-state-value :right)) [:rf.runtime/machines :snapshots :flow])]
-            (is (= 1 (get-in snap-left  [:rf/spawn-counter :worker]))
-                "left frame's :flow snapshot counts one :worker spawn")
-            (is (= 1 (get-in snap-right [:rf/spawn-counter :worker]))
-                "right frame's :flow snapshot counts one :worker spawn")
-            ;; Sanity: both allocations are independent — neither
-            ;; reached count 2 (cross-frame contamination).
-            (is (every? #(= 1 (get-in % [:rf/spawn-counter :worker]))
-                        [snap-left snap-right])
-                "the per-frame counters didn't share an allocator")))))))
+        ;; rf2-d2841 — dev-instrumentation arm (see ns docstring). The
+        ;; frame-scoping CONTRACT this deftest is named for is the
+        ;; `:rf/spawn-counter` pair below, read straight out of each frame's
+        ;; runtime-db — production-real state, asserted in both postures.
+        (when interop/debug-enabled?
+          (let [spawn-traces (filter #(= :rf.machine.spawn/spawned (:operation %)) @traces)
+                ids          (mapv #(get-in % [:tags :id-prefix]) spawn-traces)]
+            (is (= 2 (count spawn-traces))
+                "two :rf.machine.spawn/spawned traces — one per frame")
+            (is (every? #(= :worker %) ids)
+                "both spawned the :worker machine")))
+        ;; Per rf2-gr8q the spawn-counter is no longer a per-process
+        ;; atom — it lives inside each parent machine's snapshot at
+        ;; `:rf/spawn-counter`. Frame-scoping is inherited from
+        ;; per-frame app-db isolation: each frame owns its own copy of
+        ;; the :flow machine's snapshot at [:rf.runtime/machines :snapshots :flow]; each
+        ;; copy's counter advances independently. Read the counter
+        ;; from each frame's snapshot directly.
+        (let [snap-left  (get-in (:rf.db/runtime (rf/frame-state-value :left)) [:rf.runtime/machines :snapshots :flow])
+              snap-right (get-in (:rf.db/runtime (rf/frame-state-value :right)) [:rf.runtime/machines :snapshots :flow])]
+          (is (= 1 (get-in snap-left  [:rf/spawn-counter :worker]))
+              "left frame's :flow snapshot counts one :worker spawn")
+          (is (= 1 (get-in snap-right [:rf/spawn-counter :worker]))
+              "right frame's :flow snapshot counts one :worker spawn")
+          ;; Sanity: both allocations are independent — neither
+          ;; reached count 2 (cross-frame contamination).
+          (is (every? #(= 1 (get-in % [:rf/spawn-counter :worker]))
+                      [snap-left snap-right])
+              "the per-frame counters didn't share an allocator"))))))
 
 (deftest spawn-and-destroy-machine-fx
   (testing ":rf.machine/spawn and :rf.machine/destroy traverse fx without :rf.error/no-such-fx"
@@ -699,12 +762,27 @@
                         [:rf.machine/destroy :worker#1]]}))
       (rf/dispatch-sync [:do-spawn])
       (rf/unregister-listener! :trace ::spawn)
-      (is (some #(= :rf.machine.spawn/spawned (:operation %)) @traces)
-          "expected :rf.machine.spawn/spawned trace")
-      (is (some #(= :rf.machine/destroyed (:operation %)) @traces)
-          "expected :rf.machine/destroyed trace")
-      (is (not-any? #(= :rf.error/no-such-fx (:operation %)) @traces)
-          ":rf.machine/spawn / :rf.machine/destroy should not raise no-such-fx"))))
+      ;; SEMANTIC, posture-independent (rf2-d2841). "Traversed fx without
+      ;; :rf.error/no-such-fx" read through the trace stream is a VACUOUS pass
+      ;; under the production gate — an empty trace ring satisfies `not-any?`
+      ;; just as well as a correct one. So pin what each fx actually DID, in
+      ;; the frame's runtime-db, which a production build carries: the spawn
+      ;; allocated `:worker#1` (the counter advanced) and the destroy removed
+      ;; its snapshot. Had either fx gone unhandled, neither would hold.
+      (let [machines-rt (:rf.runtime/machines
+                         (:rf.db/runtime (rf/frame-state-value :rf/default)))]
+        (is (= {:worker 1} (:spawn-counter machines-rt))
+            ":rf.machine/spawn was handled — it allocated :worker#1")
+        (is (= {} (:snapshots machines-rt))
+            ":rf.machine/destroy was handled — :worker#1's snapshot is gone"))
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (some #(= :rf.machine.spawn/spawned (:operation %)) @traces)
+            "expected :rf.machine.spawn/spawned trace")
+        (is (some #(= :rf.machine/destroyed (:operation %)) @traces)
+            "expected :rf.machine/destroyed trace")
+        (is (not-any? #(= :rf.error/no-such-fx (:operation %)) @traces)
+            ":rf.machine/spawn / :rf.machine/destroy should not raise no-such-fx")))))
 
 (deftest login-machine-flow
   (testing "Spec 005 machine pattern: login flow as a state machine, end-to-end"
@@ -888,8 +966,16 @@
     (let [html (rf/render-to-string [(rf/view :greet) "world"])]
       (is (clojure.string/includes? html "hello <strong>world</strong>")
           "render-to-string resolves a callable head")
-      (is (clojure.string/starts-with? html "<p ")
-          "the resolved view's <p> root is present (now carrying dev annotations)"))
+      ;; SEMANTIC, posture-independent (rf2-d2841): the resolved view's root
+      ;; really is a <p> element — with attributes in dev, bare in production.
+      (is (re-find #"^<p[ >]" html)
+          "the resolved view's <p> root is present")
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring). The two
+      ;; view annotations are debug-gated, so the root is bare `<p>` under
+      ;; the production gate and attributed `<p …>` in dev.
+      (when interop/debug-enabled?
+        (is (clojure.string/starts-with? html "<p ")
+            "in DEV the resolved root also carries the debug-gated view annotations")))
     (is (fn? (rf/view :greet))
         "view returns the registered render fn")
     (is (nil? (rf/view :no-such-view))))

--- a/implementation/core/test/re_frame/sub_cache_test.clj
+++ b/implementation/core/test/re_frame/sub_cache_test.clj
@@ -11,10 +11,23 @@
   Pre-rf2-cmfln these tests covered both `grace=0` (synchronous) and
   `grace>0` (deferred) paths; the deferred-grace mechanism has been
   retired (clean swap per pre-alpha) so the surface under test is the
-  single sync path."
+  single sync path.
+
+  ## Posture split (rf2-d2841)
+
+  Every assertion here is posture-independent — it holds in the ordinary
+  `clojure -M:test` suite AND under the real production gate
+  (`scripts/test-core-prod-gate.sh`, `-Dre-frame.debug=false`) — UNLESS it sits
+  inside a `(when interop/debug-enabled? …)` arm marked `rf2-d2841`. Those arms
+  observe the DEV `:trace` stream, whose emit sites are gated on
+  `interop/debug-enabled?`; under the gate the framework emits none of it BY
+  DESIGN. The assertions are kept verbatim, they simply stop dragging their
+  semantic neighbours — the cache's ref-count/disposal contract, the recovery
+  value of a missing sub, the post-reload sub body — out of the production lane."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
             [re-frame.live-frame :as live-frame]
             [re-frame.registrar :as registrar]
             [re-frame.schemas :as schemas]
@@ -751,23 +764,28 @@
       (let [r (rf/subscribe [:missing/sub])]
         (is (nil? @r) ":replaced-with-default — the reaction yields nil"))
       (rf/unregister-listener! :trace ::no-such)
-      (let [hit (some (fn [ev]
-                        (when (= :rf.error/no-such-sub (:operation ev)) ev))
-                      @traces)]
-        (is (some? hit) "no-such-sub trace fired")
-        (when hit
-          (let [tags (:tags hit)]
-            ;; Canonical Spec-009 shape.
-            (is (= :missing/sub (:rf.sub/id tags))
-                ":rf.sub/id is the unregistered sub's id")
-            (is (= [:missing/sub] (:unresolved-input tags))
-                ":unresolved-input is the full query-vector that failed to resolve")
-            (is (= [] (:resolved-inputs tags))
-                ":resolved-inputs is empty — the miss is detected before input resolution")
-            (is (contains? tags :frame) ":frame tag retained for routing")
-            ;; The pre-fix shape MUST be gone.
-            (is (not (contains? tags :rf.sub/query-v))
-                "the pre-fix :rf.sub/query-v tag is gone (aligned to Spec 009)")))))))
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring). The
+      ;; production-real half of this contract is the RECOVERY — the miss does
+      ;; not throw, it yields nil — asserted above in both postures; the tag
+      ;; SHAPE is a statement about what dev tooling reads off the trace.
+      (when interop/debug-enabled?
+        (let [hit (some (fn [ev]
+                          (when (= :rf.error/no-such-sub (:operation ev)) ev))
+                        @traces)]
+          (is (some? hit) "no-such-sub trace fired")
+          (when hit
+            (let [tags (:tags hit)]
+              ;; Canonical Spec-009 shape.
+              (is (= :missing/sub (:rf.sub/id tags))
+                  ":rf.sub/id is the unregistered sub's id")
+              (is (= [:missing/sub] (:unresolved-input tags))
+                  ":unresolved-input is the full query-vector that failed to resolve")
+              (is (= [] (:resolved-inputs tags))
+                  ":resolved-inputs is empty — the miss is detected before input resolution")
+              (is (contains? tags :frame) ":frame tag retained for routing")
+              ;; The pre-fix shape MUST be gone.
+              (is (not (contains? tags :rf.sub/query-v))
+                  "the pre-fix :rf.sub/query-v tag is gone (aligned to Spec 009)"))))))))
 
 ;; ---- ref-counting and hot-reload smoke (relocated from smoke_test.clj, rf2-zqar3) ----
 
@@ -809,13 +827,18 @@
       ;; After re-registration, the next subscribe-once sees the new fn.
       (is (= 70 (rf/subscribe-once [:answer]))
           "after re-registration the new sub body is used")
-      (is (some (fn [ev]
-                  (and (= :rf.registry/handler-replaced (:operation ev))
-                       (= :rf.registry (:op-type ev))
-                       (= :sub (:kind (:tags ev)))
-                       (= :answer (:id (:tags ev)))))
-                @traces)
-          "expected :rf.registry/handler-replaced trace"))))
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring). The
+      ;; INVALIDATION this deftest is named for is the `(= 70 …)` above — a
+      ;; stale cached reaction would still answer 7 — and that runs in both
+      ;; postures; the replacement NOTICE is a hot-reload developer signal.
+      (when interop/debug-enabled?
+        (is (some (fn [ev]
+                    (and (= :rf.registry/handler-replaced (:operation ev))
+                         (= :rf.registry (:op-type ev))
+                         (= :sub (:kind (:tags ev)))
+                         (= :answer (:id (:tags ev)))))
+                  @traces)
+            "expected :rf.registry/handler-replaced trace")))))
 
 ;; ===========================================================================
 ;; rf2-jue6sp (EP-0002 §Subscriptions And Read Helpers) — ambient read

--- a/scripts/test-core-prod-gate.sh
+++ b/scripts/test-core-prod-gate.sh
@@ -125,7 +125,6 @@ known_red=(
   re-frame.db-pending-trace-test
   re-frame.dispatched-trace-cofx-test
   re-frame.doc-metadata-prod-elision-test
-  re-frame.drain-test
   re-frame.elision-test
   re-frame.ep0026-inline-grammar-cljs-test
   re-frame.event-context-partition-test
@@ -158,7 +157,6 @@ known_red=(
   re-frame.registrar-warnings-test
   re-frame.router-carried-frame-test
   re-frame.router-front-of-queue-cljs-test
-  re-frame.smoke-test
   re-frame.source-coord-jvm-test
   re-frame.source-coord-prod-elision-test
   re-frame.source-coords-test

--- a/scripts/test-core-prod-gate.sh
+++ b/scripts/test-core-prod-gate.sh
@@ -44,9 +44,10 @@
 # a rewrite of how those assertions are spelled.  Triage beads are named per
 # cluster below.
 #
-# What is left IS green, and it is not a rump: 83 namespaces, 915 tests, 4257
+# What is left IS green, and it is not a rump: 94 namespaces, 1103 tests, 5120
 # assertions, exit 0 — versus the zero suites that had ever executed under this
-# posture before.
+# posture before.  (It was 88 / 934 / 4340 before rf2-d2841 split the spine's
+# dev-instrumentation assertions away from the semantics beside them.)
 #
 # The roster is therefore an EXCLUSION list, not an allowlist.  The polarity is
 # the point: a namespace added to `implementation/core/test/` joins this lane
@@ -106,11 +107,27 @@ known_red=(
   #    :errors sink received", ":doc retained for tooling", "handler-meta
   #    carries :ns". Under -Dre-frame.debug=false the framework emits none
   #    of it, by design, so these are legitimate dev-posture tests — but
-  #    they drag their semantic neighbours out of this lane with them,
-  #    which is why the spine (smoke / drain / fx / events / sub-cache /
-  #    interceptor / frame-lifecycle) is excluded today. Every line removed
-  #    from here is a namespace whose semantics are now proven under the
-  #    production posture.
+  #    they drag their semantic neighbours out of this lane with them.
+  #    Every line removed from here is a namespace whose semantics are now
+  #    proven under the production posture.
+  #
+  #    The SPINE is done: smoke / drain / events / sub-cache / interceptor /
+  #    frame-lifecycle came off in the first rf2-d2841 pass. The split shape
+  #    they use — instrumentation assertions kept VERBATIM inside a
+  #    `(when interop/debug-enabled? …)` arm marked `rf2-d2841`, everything
+  #    outside such an arm posture-independent — is documented in each of
+  #    those namespaces' docstrings under "## Posture split (rf2-d2841)".
+  #    `fx-test` is the big one still standing (107 failures / 25 errors
+  #    across ~20 deftests under the gate).
+  #
+  #    NOTE for whoever finishes this list: a namespace whose EVERY deftest
+  #    is about the dev trace (the `trace-listener-*` cohort, `trace-test`,
+  #    `db-pending-trace-test`, `sub-dispose-trace-test`, …) has no semantic
+  #    residue to run under the gate. Guarding it wholesale and deleting its
+  #    roster line would report GREEN for a namespace that executed nothing
+  #    — the false-green this lane exists to close. Those want a var-level
+  #    tag the lane excludes (the `-e :requires-debug` idea above), not a
+  #    posture guard.
   re-frame.capture-frame-reincarnation-sink-route-cljs-test
   re-frame.capture-frame-test
   re-frame.cascade-dispatch-id-test
@@ -128,11 +145,9 @@ known_red=(
   re-frame.elision-test
   re-frame.ep0026-inline-grammar-cljs-test
   re-frame.event-context-partition-test
-  re-frame.events-test
   re-frame.frame-destroy-composed-test
   re-frame.frame-destroy-incarnation-jvm-test
   re-frame.frame-initial-events-cljs-test
-  re-frame.frame-lifecycle-test
   re-frame.frame-teardown-report-cljs-test
   re-frame.fx-aggregate-classification-cljs-test
   re-frame.fx-args-trace-egress-cljs-test
@@ -143,7 +158,6 @@ known_red=(
   re-frame.image-no-emit-trace-gate-cljs-test
   re-frame.init-platform-test
   re-frame.interceptor-override-summary-trace-test
-  re-frame.interceptor-test
   re-frame.live-frame-reload-cljs-test
   re-frame.machine-action-outcome-classification-cljs-test
   re-frame.machine-routed-event-classification-cljs-test
@@ -162,7 +176,6 @@ known_red=(
   re-frame.source-coords-test
   re-frame.sub-algebra-view-test
   re-frame.sub-arg-fragmentation-warn-test
-  re-frame.sub-cache-test
   re-frame.sub-cycle-cljs-test
   re-frame.sub-dispose-trace-test
   re-frame.sub-parametric-inputs-test


### PR DESCRIPTION
`jvm-core-prod-gate` (rf2-f8x2i) is the first CI lane ever to run
`implementation/core` with `-Dre-frame.debug=false` genuinely on the JVM
command line. It ships over an EXCLUSION roster in
`scripts/test-core-prod-gate.sh`, and the dominant reason a namespace is on
that roster is not a defect — it is that its SEMANTIC assertions were written
inline with assertions about DEV INSTRUMENTATION. Under the gate the framework
emits none of that by design, so the instrumentation assertion drags its
semantic neighbour out of the production lane with it.

This PR splits the spine. Six namespaces come off the roster.

## The split shape

**A posture guard in place.** The instrumentation assertion is kept VERBATIM
and wrapped in a `(when interop/debug-enabled? …)` arm marked `rf2-d2841`.
Everything OUTSIDE such an arm is posture-independent and must hold in both
postures. Nothing was deleted, weakened, or relaxed — the dev-posture assertion
count went UP (10606 assertions, from 10592).

`interop/debug-enabled?` is the framework's own gate — the same symbol the
emit sites are gated on, `def`'d on the JVM and `^boolean goog/DEBUG` in CLJS
— so the guard needs no new namespace, no new alias, and no roster machinery,
and it reads the same way in `.clj` and `.cljc`. Each touched namespace's
docstring gains a `## Posture split (rf2-d2841)` section naming which of its
observables are dev-only and why.

Three observables turn out to be dev-only BY DESIGN:

* the `:trace` stream — every `trace/emit-error!` site is gated on
  `interop/debug-enabled?`, read once at namespace-load time;
* `:doc` reflection metadata on a registry entry — retained for tooling in dev,
  elided in production (`re-frame.doc-metadata-prod-elision-test`);
* `:source-coord` — the `->interceptor` MACRO's production branch omits the
  kwarg entirely (`core.cljc` §`->interceptor`).

## Production witnesses ADDED, not assertions dropped

Where the dev trace had been the ONLY witness for a production-real claim, a
production-visible one was added (the rf2-7vk3z pattern):

* **`dispatch-sync`-in-handler** (drain + smoke) — the ban is enforcement, not
  advice: the nested event is REJECTED, so the inner handler's `:db` write
  never lands. Nothing asserted that in either posture before.
* **`spawn-and-destroy-machine-fx`** — "traversed fx without
  `:rf.error/no-such-fx`" read off the trace ring is a VACUOUS pass under the
  gate, because an empty ring satisfies `not-any?`. Replaced with what each fx
  actually DID in the frame's runtime-db: the spawn advanced `:spawn-counter`
  to `{:worker 1}`, the destroy emptied `:snapshots`.
* **`clear-event-removes-a-single-handler`** — the symptom it exists to catch
  is "a stale handler still firing", a fact about EXECUTION. A `runs` counter
  now proves the cleared handler does not run.
* **`reg-event-non-map-return-…`** — a handler returning `[[:dispatch [:other]]]`
  returns exactly the shape of an `:fx` VALUE. A counter on `:other` proves it
  is not quietly honoured; app-db is pinned unchanged for all three cases.
* **`pipeline-exception-attributed-to-true-component`** — the no-abort contract:
  a throwing handler / throwing `:before` commits nothing, runtime keeps going.
* **destroy suites** — the snapshots really were active pre-destroy and the
  frame really left the registry after; the drain-depth bound really halted the
  runaway after exactly N handler bodies; `reg-view-jvm`'s resolved root really
  is a `<p>` element in both postures (only the ANNOTATIONS are dev-only).

## Negative trace assertions moved inside the arms

`(empty? …)` / `(zero? (count …))` over a trace ring passes under the gate for
the wrong reason — the ring is empty. Every such negative control moved INSIDE
its posture arm rather than being left outside looking load-bearing, with the
reason stated at each site. That is the false-green this lane exists to close.

## Roster lines removed

```
re-frame.drain-test
re-frame.events-test
re-frame.frame-lifecycle-test
re-frame.interceptor-test
re-frame.smoke-test
re-frame.sub-cache-test
```

The lane's stale header count (`83 namespaces, 915 tests, 4257 assertions`) is
corrected to the measured current figures, and the `rf2-d2841` roster group
comment now records the split shape plus a warning for whoever finishes the
list (below).

**The lane: 88 → 94 namespaces, 934 → 1103 tests, 4340 → 5120 assertions.**

## What remains

* **`fx-test`** is the big one still standing — 107 failures / 25 errors across
  ~20 deftests under the gate, in an 1826-line file. Deliberately not rushed
  into this PR.
* The rest of the `rf2-d2841` roster group (~80 lines).
* **A warning recorded in the script:** a namespace whose EVERY deftest is
  about the dev trace — the `trace-listener-*` cohort, `trace-test`,
  `db-pending-trace-test`, `sub-dispose-trace-test` — has no semantic residue
  to run under the gate. Guarding it wholesale and deleting its roster line
  would report GREEN for a namespace that executed nothing. Those want a
  var-level tag the lane excludes (the `-e :requires-debug` idea already
  floated in the script header), not a posture guard. That is a `deps.edn`
  change and outside this PR's fence.
* **rf2-mlh1h** filed: the rf2-mszrz attribution contract (`:failing-id` = the
  true failing component) IS production-real — `emit-error-both!` lifts
  `:failing-id` / `:reason` onto the always-on record whenever they differ from
  `:event-id` — but is asserted only through the dev trace. Per rf2-d2841's own
  rule that is the rf2-7vk3z shape: a separate `:errors`-axis twin, filed
  rather than bolted on here.

Nothing failed for a REAL reason. No behaviour differs under the gate in any of
the six namespaces; every failure was test spelling, as rf2-r9bra found for its
own subset.

## Quality gates

| gate | command | exit |
|---|---|---|
| production-gate lane (the point of the PR) | `bash scripts/test-core-prod-gate.sh` | **0** — 94 namespaces, 1103 tests, 5120 assertions |
| dev-posture core suite | `clojure -M:test` (from `implementation/core`) | **0** — 2150 tests, 10606 assertions |
| baseline lane, for the before-number | `bash scripts/test-core-prod-gate.sh` @ `origin/main` | **0** — 88 namespaces, 934 tests, 4340 assertions |

Both postures green. Per the dispatch ruling the slower spine gates
(`scripts/test-fast-pr.sh`, the JVM/tools sweeps, CLJS) are **deferred to CI** —
this diff is `implementation/core/test/**` plus roster lines, so CI is the merge
gate.