### PR TITLE
perf(freehand): retained-set fast path in cell/commit! (rf2-wxrrp)

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/cell.cljc
+++ b/implementation/freehand/src/re_frame/freehand/cell.cljc
@@ -48,19 +48,23 @@
   3. **Read and re-check.** Every staged handle's commit-time evidence is
      read — a fail-loud, callback-capable operation that runs INSIDE the
      pre-publication transaction, so a read that throws rolls the fresh
-     staging back exactly as an acquisition failure does. Currency is then
-     re-read at the narrowest boundary — after ALL callback-capable work,
-     the reads included, with nothing callback-capable between it and the
-     publish — so a hot reload (or a read that re-entered and advanced
-     authority) landing mid-commit cannot publish a stale body.
+     staging back exactly as an acquisition failure does. Each reading is
+     compared against its own render probe as it is taken (step 6's
+     verdict) and recorded as the bundle's evidence, because all three
+     are views of one read. Currency is then re-read at the narrowest
+     boundary — after ALL callback-capable work, the reads included, with
+     nothing callback-capable between it and the publish — so a hot reload
+     (or a read that re-entered and advanced authority) landing mid-commit
+     cannot publish a stale body.
   4. **Publish.** Frame, dependencies, evidence and the event site table
      become live with no host yield between them. Nothing can observe a
      partial bundle.
   5. **Release.** Only now are the superseded handles released.
   6. **Correct.** Every acquired handle — retained as well as staged —
      has its commit-time reading compared against the render's probe
-     evidence; movement in the render→commit gap advances the cell's
-     revision so the host corrects before paint.
+     evidence, at step 3 where the reading is taken; movement in the
+     render→commit gap advances the cell's revision HERE, once the bundle
+     is live, so the host corrects before paint.
 
   Everything here is **common** — the same value shapes, the same laws
   and the same diagnostics on the JVM and in ClojureScript. The React
@@ -829,59 +833,133 @@
 
 (defn- stage!
   "Acquire every newly-observed or retargeted target, in render order,
-  BEFORE anything is released. Returns `{site-key record}` with each
-  record's `:handle` either RETAINED from the prior committed set (the
-  kept-check held, and the handle is not touched) or freshly acquired.
+  BEFORE anything is released. Answers `{:staged {site-key record}
+  :acquired [handle …]}` — each record's `:handle` either RETAINED from
+  the prior committed set (the kept-check held, and the handle is not
+  touched) or freshly acquired, and `:acquired` exactly the handles THIS
+  staging acquired, in ACQUISITION order.
+
+  `:acquired` is REPORTED rather than reconstructed. Its reverse is the
+  release order for every pre-publication rollback — a failed
+  acquisition, a commit-side read that throws, a lost currency re-check —
+  so layered acquisitions unwind symmetrically, and a retained prior
+  handle, untouched by this candidate and still owned by the installed
+  set, is never in it. Staging is the one place that fact is known
+  first-hand. Deriving it afterwards instead meant flagging every record
+  `:retained?` on every commit to answer a question only a rollback ever
+  asks, and then re-deriving the order by walking the render order again.
+
+  The staged map is built through a TRANSIENT. It is a value under
+  construction that no other code can reach until this function returns
+  it — exactly the condition transience asks for — and a boundary
+  holding hundreds of dependencies otherwise allocates one intermediate
+  map per site to reach the same answer.
 
   Transactional: an acquisition failure releases the handles this staging
-  acquired — in reverse acquisition order, so layered acquisitions unwind
-  symmetrically — and rethrows, leaving the prior committed set
-  installed."
+  acquired — in reverse acquisition order — and rethrows, leaving the
+  prior committed set installed."
   [^ViewCell cell prior order reads]
-  (let [acquired (volatile! [])]
+  (let [acquired (volatile! [])
+        n        (count order)]
     (try
-      (reduce
-        (fn [staged site-key]
-          (let [{:keys [target] :as record} (get reads site-key)
-                kept                        (get prior site-key)]
-            (if (and (some? kept) (obs/current? (:handle kept) target))
-              (assoc staged site-key (assoc record :handle (:handle kept) :retained? true))
-              (let [h (obs/acquire! target (fn on-change [cause] (mark-dirty! cell cause)))]
-                (vswap! acquired conj h)
-                (assoc staged site-key (assoc record :handle h :retained? false))))))
-        {} order)
+      (loop [i      0
+             staged (transient {})]
+        (if (< i n)
+          (let [site-key (nth order i)
+                record   (get reads site-key)
+                target   (:target record)
+                kept     (get prior site-key)
+                handle   (if (and (some? kept) (obs/current? (:handle kept) target))
+                           (:handle kept)
+                           (let [h (obs/acquire!
+                                     target
+                                     (fn on-change [cause] (mark-dirty! cell cause)))]
+                             (vswap! acquired conj h)
+                             h))]
+            (recur (inc i) (assoc! staged site-key (assoc record :handle handle))))
+          {:staged (persistent! staged) :acquired @acquired}))
       (catch #?(:clj Throwable :cljs :default) e
         (release-all! (rseq @acquired))
         (throw e)))))
 
-(defn- fresh-handles
-  "The handles THIS candidate freshly acquired — the render `order`
-  restricted to the sites [[stage!]] acquired rather than RETAINED from
-  the prior committed set — in ACQUISITION order.
-
-  Its reverse is the release order for any pre-publication rollback (a
-  read failure or a lost currency re-check): layered acquisitions unwind
-  symmetrically, and a retained prior handle — untouched by this
-  candidate and still owned by the installed set — is never in it, so a
-  rollback releases exactly what this candidate acquired and nothing the
-  prior bundle still needs."
-  [order staged]
-  (into []
-        (keep (fn [site-key]
-                (let [record (get staged site-key)]
-                  (when (and record (not (:retained? record))) (:handle record)))))
-        order))
-
 (defn- superseded-handles
   "The handles the PRIOR committed set owned that the new one does not —
   a dropped site's handle, and a retargeted site's OLD handle. Compared
-  by identity, because a handle IS its owner token."
-  [prior staged]
-  (into []
-        (keep (fn [[site-key {:keys [handle]}]]
-                (let [now (get-in staged [site-key :handle])]
-                  (when-not (identical? now handle) handle))))
-        prior))
+  by identity, because a handle IS its owner token.
+
+  THE FULLY-RETAINED SET IS ANSWERED BY COUNTING, and it is the same
+  answer rather than a weaker one. When staging acquired NOTHING, every
+  staged handle came from `prior` at its own site key, so the staged key
+  set is a subset of the prior one; if the two are also the same SIZE
+  they are the same set, every handle is the prior handle by identity,
+  and there is nothing to supersede. Any acquisition, any dropped site
+  and any retarget fails one of those two tests and takes the scan.
+
+  It is worth the sentence because the fully-retained set is not an edge
+  case: it is what a broad write IS — every site re-reading the same
+  query through the same handle — and it is the shape where the scan
+  costs the most, one map walk and two lookups per dependency to
+  conclude that nothing changed."
+  [prior staged acquired]
+  (if (and (empty? acquired) (= (count staged) (count prior)))
+    []
+    (into []
+          (keep (fn [[site-key {:keys [handle]}]]
+                  (let [now (get-in staged [site-key :handle])]
+                    (when-not (identical? now handle) handle))))
+          prior)))
+
+(defn- commit-readings
+  "Step 3 of the commit, in ONE pass over the render order: read every
+  staged handle's commit-time evidence, compare it against the evidence
+  that site's own render probed, and record what the bundle publishes.
+  Answers `{:observations [record …] :moved? bool}`.
+
+  THE READ IS THE TEAR CHECK, and that is why it is here rather than
+  cached away. Spec 006 §The six frozen invariants, invariant 5: at
+  commit, EVERY acquired node — the handles RETAINED from the prior
+  committed set as well as the newly staged ones — has its identity
+  (`:node-key`), version and frame/registry epochs compared against the
+  render's probe, and any movement in the render→commit gap advances the
+  cell's revision so the host corrects before paint. On a non-watchable
+  headless host a retained site has no value-movement watch, so this
+  comparison is its ONLY correction channel.
+
+  The three things fold into one pass because they are three views of
+  one read. Nothing is skipped: every handle is read, every reading is
+  compared. What folding removes is the intermediate map the readings
+  used to be collected into, the map entries produced by walking that
+  map again to build the observations, and the third walk that looked
+  each reading back up to ask whether it had moved.
+
+  `:moved?` stops COMPARING once one site has moved, exactly as the
+  `some` it replaces did — movement anywhere advances the revision once,
+  so a second answer to a settled question buys nothing. The READS never
+  stop, because reading is the check.
+
+  Fail-loud: `obs/read` may re-enter application subscription code and
+  throw. The whole pass therefore runs inside the caller's rollback
+  guard, which releases exactly what this candidate acquired and leaves
+  the prior committed set installed."
+  [order staged]
+  (let [n (count order)]
+    (loop [i     0
+           moved false
+           obs   (transient [])]
+      (if (< i n)
+        (let [site-key (nth order i)
+              record   (get staged site-key)
+              handle   (:handle record)
+              reading  (obs/read handle)]
+          (recur (inc i)
+                 (or moved (moved? reading (:evidence record)))
+                 (conj! obs {:site-key site-key
+                             :query    (:query record)
+                             :frame-id (:frame-id (:target record))
+                             :value    (:value reading)
+                             :owned?   (obs/owned? handle)})))
+        {:observations (persistent! obs)
+         :moved?       moved}))))
 
 ;; ---------------------------------------------------------------------------
 ;; The dev-gated occurrence-record emission seam (rf2-3naow, F4g)
@@ -1185,7 +1263,7 @@
       (let [{:keys [order by-site]} @(.-reads cand)
             prior  (:deps s0)
             fid    (.-frame cand)
-            staged (stage! owner-cell prior order by-site)
+            {:keys [staged acquired]} (stage! owner-cell prior order by-site)
             ;; The commit-side reads are part of the pre-publication
             ;; TRANSACTION, not a step past it. `obs/read` is a fail-loud
             ;; port op that may deref application subscription code — it can
@@ -1194,13 +1272,19 @@
             ;; releases every handle THIS candidate freshly acquired, in
             ;; reverse acquisition order, leaves the prior committed set
             ;; installed, and rethrows the ORIGINAL failure untranslated.
-            readings (try
-                       (into {}
-                             (map (fn [[k {:keys [handle]}]] [k (obs/read handle)]))
-                             staged)
-                       (catch #?(:clj Throwable :cljs :default) e
-                         (release-all! (rseq (fresh-handles order staged)))
-                         (throw e)))]
+            ;;
+            ;; [[commit-readings]] carries the invariant-5 comparison and the
+            ;; bundle's observations out of the same pass, so the reading of a
+            ;; site is compared and recorded where it is taken. `obs/owned?`
+            ;; joins it: a total, no-throw predicate over handle state, not
+            ;; callback-capable, so folding it in moves NOTHING across the
+            ;; currency boundary below — it only leaves less on the far side
+            ;; of it.
+            scan (try
+                   (commit-readings order staged)
+                   (catch #?(:clj Throwable :cljs :default) e
+                     (release-all! (rseq acquired))
+                     (throw e)))]
         ;; The narrowest publication boundary: acquisition AND the
         ;; commit-side reads ran cache installs, disposal hooks and
         ;; application recompute, any of which can synchronously advance the
@@ -1211,18 +1295,11 @@
         ;; staging and publishes nothing rather than publishing stale
         ;; ownership.
         (if-not (current? cand @(st owner-cell))
-          (do (release-all! (rseq (fresh-handles order staged)))
+          (do (release-all! (rseq acquired))
               :abandoned)
           (let [bundle   {:frame        fid
                           :generation   (.-generation cand)
-                          :observations (mapv (fn [k]
-                                                (let [r (get staged k)]
-                                                  {:site-key k
-                                                   :query    (:query r)
-                                                   :frame-id (:frame-id (:target r))
-                                                   :value    (:value (get readings k))
-                                                   :owned?   (obs/owned? (:handle r))}))
-                                              order)}
+                          :observations (:observations scan)}
                 ;; Build and VALIDATE the dev evidence BEFORE the publish below —
                 ;; the two-plane split: a malformed FRAMEWORK projection or
                 ;; record fails loud here, so a commit the schema would refuse
@@ -1240,17 +1317,22 @@
                 captured (try
                            (commit-evidence owner-cell lowering bundle)
                            (catch #?(:clj Throwable :cljs :default) e
-                             (release-all! (rseq (fresh-handles order staged)))
+                             (release-all! (rseq acquired))
                              (throw e)))]
             ;; ONE publication. Dependencies, frame and evidence become
             ;; live in a single write, and the event site table becomes
             ;; live against this exact frame with no host yield between
             ;; them — nothing can observe a partial bundle.
+            ;; `order` is the candidate's own render order and is already a
+            ;; vector — the reads volatile opens at `[]` and only ever
+            ;; `conj`es — so it is published as it stands. Sharing it is safe
+            ;; whatever the candidate does next: a persistent vector's `conj`
+            ;; answers a new vector and cannot reach this one.
             (swap! (st owner-cell) assoc
                    :lifecycle :connected
                    :frame     fid
                    :deps      staged
-                   :dep-order (vec order)
+                   :dep-order order
                    :evidence  bundle)
             (events/commit! (.-events cand)
                             (frame-dispatcher fid)
@@ -1258,11 +1340,12 @@
             ;; Only now: the prior set's superseded handles. Acquire
             ;; before release is what keeps a shared node off its
             ;; zero-owner disposal edge mid-reconciliation.
-            (release-all! (superseded-handles prior staged))
-            ;; Invariant 5 — every acquired handle, retained as well as
-            ;; staged, so a retained site on a host with no value watch
-            ;; is still corrected.
-            (when (some (fn [[k {:keys [evidence]}]] (moved? (get readings k) evidence)) staged)
+            (release-all! (superseded-handles prior staged acquired))
+            ;; Invariant 5 — the verdict [[commit-readings]] reached while it
+            ;; read, over every acquired handle, retained as well as staged,
+            ;; so a retained site on a host with no value watch is still
+            ;; corrected.
+            (when (:moved? scan)
               (advance-revision! owner-cell))
             ;; The dev-gated occurrence-record seam (rf2-3naow, rf2-xftdv): a
             ;; SELECTED commit is the one place the whole bundle is live, so it

--- a/implementation/freehand/test/re_frame/freehand/shell_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/shell_cljs_test.cljc
@@ -723,6 +723,120 @@
            (is (= (:recorded-sites sub-007) (count (cell/candidate-reads cand)))))))))
 
 ;; ===========================================================================
+;; Invariant 5 — moved evidence corrects before paint, on the RETAINED set
+;; ===========================================================================
+;;
+;; Spec 006 §The six frozen invariants, invariant 5. These two rows exist to
+;; make one failure mode LOUD: a commit that stops re-reading a retained
+;; dependency — because every site kept its query, its target and its handle,
+;; so re-reading looks like work worth skipping — is not faster, it is torn.
+;; The retained site is precisely the one with no other correction channel on
+;; a host whose derived values are not watchable, which is this fixture's
+;; host and the headless contract generally.
+;;
+;; Each row therefore carries its own falsification. The mocked row moves ONE
+;; evidence axis at a time and pairs every moved arm with an UNMOVED control,
+;; so it fails both if an axis stops being compared and if the comparison
+;; degenerates into always correcting. The real-port row does the same over
+;; the actual observation port and the actual sub-cache, because a mock can
+;; drift away from the port it stands for.
+
+(def ^:private tear-probe
+  "What the RENDER probed: one live node, one identity, one version, one
+  frame epoch, one registry epoch."
+  {:value       :v0  :node-version   7 :node-key :node/a
+   :frame-epoch 3    :registry-epoch 2 :live?    true})
+
+(def ^:private tear-reading-unmoved
+  "What a commit-time `obs/read` answers when NOTHING moved in the gap — the
+  same node, the same version, the same epochs. `read` spells the version
+  `:version` where `probe` spells it `:node-version`; comparing that pair is
+  the tear check."
+  {:value :v0 :version 7 :node-key :node/a :frame-epoch 3 :registry-epoch 2})
+
+(defn- retained-recommit
+  "Commit twice over a fully MOCKED observation port whose kept-check always
+  holds, so the second commit's site is RETAINED — the same handle, never
+  re-acquired. Answers `{:delta … :retained? …}`: how far the cell's revision
+  moved on that second commit, and whether the handle really was the first
+  commit's, which is what makes the row a statement about the retained set
+  rather than about staging."
+  [reading]
+  (let [q [:tear/site]
+        c (cell/cell :shell/panel)]
+    (with-redefs [obs/resolve-target (mock-fn (fn [{:keys [query-v]}] {:query-v query-v}))
+                  obs/probe          (mock-fn (fn [_target] tear-probe))
+                  obs/acquire!       (mock-fn (fn [target] {:handle-for (:query-v target)}))
+                  obs/current?       (mock-fn (fn [_handle] true))
+                  obs/read           (mock-fn (fn [_handle] reading))
+                  obs/owned?         (mock-fn (fn [_handle] true))
+                  obs/release!       (mock-fn (fn [_handle] nil))]
+      ;; The first commit stages fresh and publishes; it is the prior set the
+      ;; second one retains from, and its own correction is not what is read.
+      (cell/commit! (render! c nil [q]))
+      (let [h0     (:handle (get (cell/dependencies c) 0))
+            before (cell/revision c)]
+        (cell/commit! (render! c nil [q]))
+        {:delta     (- (cell/revision c) before)
+         :retained? (identical? h0 (:handle (get (cell/dependencies c) 0)))}))))
+
+(deftest invariant-5-every-axis-is-still-compared-on-a-retained-handle
+  (testing "Per invariant 5: at commit, EVERY acquired node — the handles
+            RETAINED from the prior committed set as well as the newly
+            staged ones — has its identity, its version and the frame and
+            registry epochs compared against the render's probe evidence, and
+            movement on ANY of those axes advances the cell's revision so the
+            host corrects before paint.
+
+            Each axis is moved ALONE, so the row fails if any single one
+            stops being compared; and the unmoved control fails if the
+            comparison degenerates into correcting unconditionally, which is
+            the other way a broken check passes a movement test."
+    (is (= {:delta 0 :retained? true}
+           (retained-recommit tear-reading-unmoved))
+        "the control — nothing moved in the gap, so nothing is corrected")
+    (doseq [[axis moved] {:node-key       (assoc tear-reading-unmoved :node-key :node/b)
+                          :version        (assoc tear-reading-unmoved :version 8)
+                          :frame-epoch    (assoc tear-reading-unmoved :frame-epoch 4)
+                          :registry-epoch (assoc tear-reading-unmoved :registry-epoch 3)}]
+      (is (= {:delta 1 :retained? true} (retained-recommit moved))
+          (str "movement on the " axis " axis ALONE is caught on the retained "
+               "handle and corrects before paint")))))
+
+(deftest invariant-5-a-real-node-moving-in-the-gap-corrects-a-retained-site
+  (testing "The same law over the REAL observation port and the REAL
+            sub-cache: a site committed once, re-rendered, and then moved
+            underneath the candidate before its commit runs. This fixture's
+            plain-atom derived values are not watchable, so nothing notifies
+            this cell — the commit's own comparison is the only channel there
+            is, and the site is RETAINED, which is exactly the comparison a
+            fast path removes if it removes anything."
+    (let [q [:tear/v]]
+      (rf/reg-sub (first q) (fn [db _] (:v db)))
+      (seed! fid {:v 1})
+      (let [c (cell/cell :shell/panel)]
+        (render+commit! c fid [q])
+        (let [h0     (:handle (get (cell/dependencies c) 0))
+              before (cell/revision c)]
+          (testing "the control: a re-commit with nothing moving corrects nothing"
+            (render+commit! c fid [q])
+            (is (= before (cell/revision c)))
+            (is (identical? h0 (:handle (get (cell/dependencies c) 0)))))
+          (let [cand (render! c fid [q])]
+            ;; THE GAP: the node moves after this render probed it and before
+            ;; the commit reads it.
+            (seed! fid {:v 2})
+            (is (= :published (cell/commit! cand)))
+            (is (identical? h0 (:handle (get (cell/dependencies c) 0)))
+                "the site was RETAINED — the same handle, never re-acquired")
+            (is (= 2 (:value (first (:observations (cell/evidence c)))))
+                "and the published evidence carries what the COMMIT read, not
+                 what the render probed")
+            (is (> (cell/revision c) before)
+                "movement in the render→commit gap advanced the revision, so
+                 the host corrects before paint")))))))
+
+;; ===========================================================================
 ;; The shell's own value surface
 ;; ===========================================================================
 


### PR DESCRIPTION
Closes rf2-wxrrp.

## The answer, first

**`commit!` got ≈25% cheaper on a fully-retained 300-dependency broad
update, with disjoint ranges. B6's broad-update row cannot see it, and says
so.** The term is 29% of the window and the row's round-to-round noise is
±10–15%, so a quarter off the term is ≈7% of the window — under the
instrument. Both instruments are reported, including the one that returned
nothing.

**Invariant 5 is untouched, and is now tested for the first time.** Every
acquired handle — retained as well as staged — is still read at commit and
still compared against its own render probe on all four axes. Two
deliberately broken commits prove the new rows bite, including the exact
fast path this bead hypothesised.

**The bead's premise turned out to be false, and that is the most useful
finding here.** rf2-wxrrp proposed that on a broad write "the dependency set
is structurally the prior one; the staged map could be republished by
identity instead of rebuilt." It cannot. A retained record carries the
render's `:value` and `:evidence`, and on a broad write both have moved —
that is what a broad write *is*. Republishing the prior map by identity
would publish last render's values into the next render's stabilization,
where `record-read!` compares against them. There is no identity republish
available on this row at any price. What *is* available is the bookkeeping
between the reads, and that is what this PR takes.

## What changed

`commit!` walked its dependencies four times. Staging allocated two maps a
site and flagged each one `:retained?`; the commit-side reads were collected
into an intermediate map; the bundle's observations walked the render order
looking each reading back up; and a fourth walk looked them up *again* to ask
whether any had moved. Then the superseded scan walked the prior set with two
lookups a site to conclude, on a broad write, that nothing had changed.

- **`stage!` reports the handles it acquired** instead of flagging every
  record so a rollback can re-derive them. `fresh-handles` and `:retained?`
  are both deleted: staging is the one place that fact is known first-hand,
  and only a rollback ever asks. The staged map is built through a transient.
- **`commit-readings` reads, compares and records each site in one pass.**
  The intermediate readings map, its map entries, and two re-lookups per
  dependency go with it. `obs/owned?` joins the pass — a total, no-throw
  predicate over handle state, not callback-capable, so nothing moves across
  the currency boundary; it only leaves *less* on the far side of it.
- **`superseded-handles` answers the fully-retained set in two counts.**
  Nothing acquired ⟹ every staged handle came from `prior` at its own site
  key ⟹ the staged key set is a subset of the prior one; equal cardinality
  then makes them the same set with every handle identical, so there is
  nothing to supersede. Any acquisition, drop or retarget fails one of the
  two tests and takes the scan.
- **`:dep-order` publishes the candidate's own render order** rather than
  copying it. `vec` on a ClojureScript vector rebuilds; the order is a
  vector by construction and a persistent `conj` cannot reach the published
  one.

Net: `cell.cljc` loses a helper, loses a derived flag, and turns four walks
into one. The clarity trade is a gain, not a cost — see below.

## Before / after

### The B6 broad-update row — no resolvable change

Two whole `b6_prod_run.cjs` runs per arm, 6 rounds each, `:advanced` with
`goog.DEBUG false`, four arms interleaved at the sample level, headless
Chromium. **0 unverified writes** in every update row of all four runs.

The published `:ratio-to-floor` is not usable on this row: the floor's p50 is
0.2–0.3 ms — two or three of Chrome's 100 µs `performance.now` quanta — so
the denominator moves in ±33% steps. BEFORE r1 reports ratio 37 for a
freehand p50 of 7.4 ms and ratio 24 for 7.2 ms; the difference is entirely
the floor. The honest normaliser is **Reagent measured in the same round**,
which is also the comparator the P0 standard is written against.

| freehand-interpreted ÷ reagent, per round | rounds | range | mean |
|---|---:|---:|---:|
| **BEFORE** | 12 | **9.20 – 11.17** | 9.91 |
| **AFTER** | 12 | **8.29 – 11.17** | 9.66 |

**The ranges overlap almost entirely. This is indistinguishable, and it is
reported as indistinguishable rather than as a 2.5% mean improvement.** The
other two rows behave the same way — narrow update 13.90 → 12.85 mean,
mount 1.98 → 1.91 mean, both with overlapping ranges — and neither is
claimed.

### `commit!` in isolation — disjoint, ≈25%

B6 cannot resolve a term worth a few percent of its window, so the term was
measured directly. Real observation port, real sub-cache, plain-atom adapter,
one cell holding 300 subscriptions. Per iteration: one broad
`replace-app-db!`, one **untimed** render, one **timed** `commit!` — every
site retained, same query, same target, same handle, which is the B6
broad-update shape. 400 warmup, then rounds of 400 timed commits, p50 per
round. Arms interleaved **A, B, A, B**.

| `commit!`, 300 retained dependencies | rounds | p50 range | per dependency |
|---|---:|---:|---:|
| **BEFORE** | 16 | **371.5 – 411.7 µs** | ≈1.33 µs |
| **AFTER** | 16 | **287.5 – 333.7 µs** | ≈1.00 µs |

**Disjoint.** Median of round p50s ≈400 → ≈300 µs.

Against PR #7139's single-arm profile — `cell/commit!` at 1.19 ms of a
4.05 ms broad-update window — a quarter off the term is ≈0.30 ms, ≈7% of the
window and ≈8% of the 3.65 ms deficit over Reagent. That is exactly the size
that disappears into B6's ±10–15% round noise, so the two instruments agree
about why the row did not move.

### Instrument scepticism, and the fault it caught

- **A positive control of known shape.** A zero-dependency commit measures
  1.3–2.5 µs against the 300-dependency commit's 300–400 µs, so the clock is
  reading per-dependency work and not fixed overhead.
- **Every measured commit verified.** The written value is read back out of
  the published bundle's first *and* last observation — the JVM counterpart
  of B6's per-write DOM read-back. **0 unverified commits** across every
  round of every run. Without it a write that never reached the
  subscriptions would still have returned a plausible number.
- **A fault fired, and the first numbers were discarded.**
  `re-frame.interop/debug-enabled?` defaults to **true** on the JVM, so the
  first pass was also timing the dev evidence plane — including
  `commit-facts`' 300-element `mapv select-keys` — which Closure DCEs out of
  the `goog.DEBUG=false` bundle B6 measures. It was ≈70% of the measurement
  and it does not exist in the artefact under test (`commit!` reads ~1000 µs
  with it, ~300 µs without). Everything quoted above is taken with
  `-Dre-frame.debug=false` and `RE_FRAME_DEBUG=false`, and the run prints the
  flag it observed.
- **What this measurement does not cover.** It is the JVM, not
  ClojureScript, and it is JIT-warmed: absolutes do not transfer to the
  browser, and only the before/after ratio is offered — about `commit!`,
  never about the row. It is one boundary holding 300 dependencies, not 300
  boundaries holding one. It says nothing about memory. And the browser row
  it stands in for remains, honestly, a null result.

## The tear-check proof

**The commit-side re-read is invariant 5 and it was not weakened, moved
earlier, made conditional, or cached.** `obs/read` still runs on every
acquired handle, and `moved?` still compares node-key, version, frame epoch
and registry epoch against that site's own render probe. The comparison now
happens where the reading is taken rather than in a fourth walk that looked
it back up; the *correction* still fires after the bundle is live, exactly
where it did.

Before this branch the repository had **no invariant-5 coverage at all** —
`git grep` for `node-key` or "before paint" over
`implementation/freehand/test/` returned no row asserting the correction.
Two rows now do, each carrying its own falsification:

1. **Every axis, on a RETAINED handle.** A mocked port with the kept-check
   held open, so the second commit's site is retained — same handle, never
   re-acquired, asserted. Each of `:node-key`, `:version`, `:frame-epoch`
   and `:registry-epoch` is moved **alone**, so the row fails if any single
   axis stops being compared. Paired with an **unmoved control**, so it also
   fails if the check degenerates into correcting unconditionally.
2. **A real node moving in the real gap.** The real observation port and the
   real sub-cache: a site committed once, re-rendered, then moved underneath
   the candidate before its commit runs. The fixture's plain-atom derived
   values are not watchable, so nothing notifies the cell and the commit's
   own comparison is the only channel there is. Asserts the handle was
   retained, that the published evidence carries what the **commit** read
   rather than what the render probed, and that the revision advanced. Also
   carries an unmoved control.

**Both rows were falsified against deliberately broken commits.** The full
freehand JVM suite — 1220 tests, 8225 assertions — was run twice against
mutants:

| mutant | result |
|---|---|
| the comparison dropped: the fast path never re-checks | **exit 1**, 5 failures, exactly the 5 new invariant-5 assertions |
| correction skipped when staging acquired nothing — the fully-retained set assumed unmoved, i.e. **the exact fast path this bead hypothesised** | **exit 1**, 5 failures, the same 5 |

Nothing else in 8225 assertions moved for either mutant. That is the point:
a fast path that skipped the tear check would have been silently correct
against every other test in the repository.

## Spec

No change to what Spec 006 promises, so `spec/**` is untouched. §The six
frozen invariants, invariant 5 requires that at commit each acquired node —
retained and staged — has its identity, version and frame/registry epochs
compared against the render's probe evidence. Every one of those reads and
comparisons still happens, on the same set, from the same evidence. §The
Freehand atomic shell's ordering also holds: the reads remain inside the
pre-publication transaction, the currency re-check still sits after all
callback-capable work with nothing callback-capable between it and the
publish — and there is now less between them, not more.

## Clarity

One sentence, as the standard asks: `cell.cljc` ends up shorter and more
direct — one helper and one derived flag deleted, four walks over the
dependency set collapsed into the single pass step 3 of the namespace
docstring already described — with the two shortcuts that *are* shortcuts
(the counted retained-set check, the shared `:dep-order`) each carrying the
one-sentence proof that they reach the same answer.

## Follow-on

**rf2-21pck (the mutable dependency ledger) is warranted, and its cheapest
first move is on the render leg, not the commit leg.** `record-read!` rebuilds
the candidate's `{:order … :by-site …}` wrapper **twice per reactive read** —
once for `(update :order conj …)` and once for `(assoc-in [:by-site …] …)` —
so 300 reads allocate 600 wrapper maps nobody looks at, on a leg PR #7139
profiled at 0.77 ms. Splitting the reads volatile into two fields, or
collapsing the wrapper to one allocation, is a bounded change with no
invariant attached to it. That is a different bead and a different leg; it is
named here because this bead's measurement is where it surfaced.

## Quality gates

Run in this worktree, foreground, exit codes echoed.

| gate | exit | result |
|---|---:|---|
| `clojure -M:test` (freehand JVM) | **0** | 1220 tests / 8225 assertions, 0 failures |
| `npm run test:cljs` | **0** | 11796 tests / 58722 assertions, 0 failures |
| `BROWSER_TEST_TIMEOUT_MS=600000 npm run test:browser` | **0** | 833 tests / 5313 assertions, 0 failures |
| `b6_prod_run.cjs` × 4 (2 before, 2 after) | **0** | 0 unverified writes in every update row |
| mutation runs × 2 | **1** (intended) | 5 failures each, all 5 the new invariant-5 assertions |

**Deferred to CI:** `scripts/test-fast-pr.sh`, `test-jvm-implementation.sh`,
`test-jvm-tools.sh`, `test-rigorous-local.sh`, `mkdocs build --strict`, the
bundle-isolation and Xray feature-matrix gates. This branch touches one
source file and one of its test namespaces and adds no dependency, so CI is
the merge gate for the rest.
