### PR TITLE
ci,test: make lockstep see all ten Xray coordinates and witness attribution in production (rf2-7fxf8, rf2-mlh1h)

### DIFF
--- a/.github/scripts/verify-version-lockstep.sh
+++ b/.github/scripts/verify-version-lockstep.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # verify-version-lockstep.sh (rf2-ace2; substrate-paths updated rf2-zha9;
-# adapters/ rename rf2-0imy; tools/ coverage rf2-lwtke)
+# adapters/ rename rf2-0imy; tools/ coverage rf2-lwtke; coordinate-inventory
+# completeness rf2-7fxf8)
 #
 # Asserts the lockstep-version contract documented in spec/Conventions.md
 # §Packaging conventions: every published artefact picks up its version
@@ -169,6 +170,98 @@ check_version_and_no_mvn_literal() {
   fi
 }
 
+# ---- rf2-7fxf8: the inventory must be COMPLETE, not merely correct -------
+#
+# Every check in this script asks one direction of the question: "is the
+# coordinate this script expects present in deps.edn?". Nothing asked the
+# converse — "is every coordinate deps.edn declares present in this
+# script?" — and the converse is the direction the gate actually drifted.
+# tools/xray/deps.edn grew from one in-repo `:local/root` coordinate to TEN
+# (core, epoch, routing, flows, schemas, resources, machines, freehand,
+# machines-viz, reagent-slim) while TOOLS_LOCAL_ROOTS below kept listing
+# one; tools/story-mcp/deps.edn grew a second (mcp-base) while its entry
+# kept listing one. Throughout, the gate printed "PASSED — all 18
+# artefacts" while blind to ten of the eighteen in-repo coordinates the
+# release workflows have to rewrite. A one-directional roster cannot report
+# on what it does not list, so its green is an ACTIVE false assurance
+# rather than a merely missing check.
+#
+# Every roster entry is therefore cross-checked against the set DERIVED
+# from the committed deps.edn. Same principle as
+# .github/scripts/preflight-xray-package.sh (rf2-5dut1), which derives its
+# required set instead of hand-listing it for exactly this reason — with a
+# different vehicle: the preflight is the tag-push arm and runs where
+# clojure is installed, whereas this gate is the ORDINARY-CI arm (test.yml
+# runs it on a bare `actions/checkout` with no JDK), so it reads EDN
+# through the same node authority the inventory guard above uses
+# (implementation/scripts/lib/edn.cjs, rf2-zef0e). Structure, never a text
+# grep: a reformatted deps.edn, or a coordinate quoted in a `;;` comment or
+# inside a `#_` discard, must not be able to produce the false PASS this
+# check exists to prevent.
+EDN_READER="${REPO_ROOT}/implementation/scripts/lib/edn.cjs"
+
+# Every in-repo coordinate the deps.edn at $1 declares, one rendered
+# `lib {:local/root "path"}` line each, in declaration order. Alias
+# :extra-deps are out of scope by design: they are build-time (clein,
+# test-runner, test-quiet) and never reach a published pom — the same
+# main-:deps scoping check_no_git_coords_in_runtime_deps uses.
+local_root_coords() {
+  node -e '
+    const fs = require("fs");
+    const { readEdn, isMap, mapGetKeyword } = require(process.argv[1]);
+    const top = readEdn(fs.readFileSync(process.argv[2], "utf8"));
+    if (!isMap(top)) throw new Error("top-level form is not a map");
+    const deps = mapGetKeyword(top, "deps");
+    if (deps === undefined) process.exit(0);
+    if (!isMap(deps)) throw new Error(":deps is not a map");
+    for (const [lib, coord] of deps.entries) {
+      if (!isMap(coord)) continue;
+      const root = mapGetKeyword(coord, "local/root");
+      if (root === undefined) continue;
+      if (root === null || root.edn !== "string") {
+        throw new Error(":local/root value is not a string literal");
+      }
+      process.stdout.write(lib.name + " {:local/root \"" + root.value + "\"}\n");
+    }
+  ' "${EDN_READER}" "$1"
+}
+
+# The "and nothing else" half of the contract: every coordinate $1 declares
+# must appear verbatim in the newline-separated expected set $3, which the
+# checks below ACCUMULATE as they run — so the set means precisely "the
+# coordinates this script asserted", and a coordinate added to deps.edn
+# without a matching roster line fails here.
+#
+# Fail-closed on an unreadable deps.edn (exit, not a counted drift): a
+# reader that could not enumerate the coordinates cannot be the basis for
+# reporting that they are all inventoried.
+coords_checked=0
+assert_local_roots_inventoried() {
+  local deps_file="$1"
+  local rel_label="$2"
+  local expected="$3"
+  local derived coord
+
+  if ! derived="$(local_root_coords "${deps_file}")"; then
+    echo "::error file=${rel_label}::failed to read this deps.edn's :local/root coordinates structurally via implementation/scripts/lib/edn.cjs (is node on PATH? is the EDN well-formed?) — refusing to report an inventory this script could not verify"
+    exit 2
+  fi
+
+  while IFS= read -r coord; do
+    [[ -z "${coord}" ]] && continue
+    coords_checked=$((coords_checked + 1))
+    if ! grep -qxF "${coord}" <<< "${expected}"; then
+      echo "::error file=${rel_label}::in-repo coordinate '${coord}' is declared at :local/root but is NOT in this script's inventory, so NOTHING asserts the release workflow rewrites it to :mvn/version. 'clein pom' SKIPS :local/root coordinates silently, so the published pom would omit this runtime dependency and Clojars has no yank (rf2-7fxf8). Add it to this script AND to the rewrite step of the artefact's release workflow, in the same PR."
+      errors=$((errors + 1))
+    fi
+  done <<< "${derived}"
+}
+
+# Populated by the :local/root presence checks below, then consumed by the
+# completeness pass. Keyed by artefact name; value is a newline-separated
+# list of rendered coordinates.
+declare -A IMPL_EXPECTED_LOCAL_ROOTS=()
+
 for artefact in "${ARTEFACTS[@]}"; do
   subpath="${ARTEFACT_PATHS[$artefact]}"
   deps_file="${REPO_ROOT}/implementation/${subpath}/deps.edn"
@@ -219,6 +312,7 @@ for artefact in "${NON_CORE[@]}"; do
     echo "::error file=${rel_label}::expected '${expected_local_root}' (lockstep contract; the release workflow rewrites this to :mvn/version at deploy time)"
     errors=$((errors + 1))
   fi
+  IMPL_EXPECTED_LOCAL_ROOTS["${artefact}"]+="${expected_local_root}"$'\n'
 done
 
 # rf2-qmhysc — ssr-ring is the one implementation artefact whose
@@ -236,7 +330,23 @@ if [[ -f "${SSR_RING_DEPS}" ]]; then
     echo "::error file=implementation/ssr-ring/deps.edn::expected 'day8/re-frame2-ssr {:local/root \"../ssr\"}' (lockstep contract; ssr-ring depends on ssr and the release workflow rewrites this to :mvn/version at deploy time)"
     errors=$((errors + 1))
   fi
+  IMPL_EXPECTED_LOCAL_ROOTS[ssr-ring]+='day8/re-frame2-ssr {:local/root "../ssr"}'$'\n'
 fi
+
+# rf2-7fxf8 — and the converse, for every implementation artefact including
+# core (whose expected set is empty: core is the lockstep root and must
+# stay dependency-free within the repo). release.yml's rewrite is a
+# hand-written matrix of one `local-root` value per leaf — ssr-ring is off
+# that matrix precisely because it has a SECOND coordinate — so an in-repo
+# edge nobody inventoried here is an edge nobody rewrites there.
+for artefact in "${ARTEFACTS[@]}"; do
+  deps_file="${REPO_ROOT}/implementation/${ARTEFACT_PATHS[$artefact]}/deps.edn"
+  [[ -f "${deps_file}" ]] || continue
+  assert_local_roots_inventoried \
+    "${deps_file}" \
+    "implementation/${ARTEFACT_PATHS[$artefact]}/deps.edn" \
+    "${IMPL_EXPECTED_LOCAL_ROOTS[$artefact]:-}"
+done
 
 # rf2-qmhysc — inventory drift guard. The whole risk this script exists
 # to close is "a publishable artefact ships at a stale version / broken
@@ -324,8 +434,34 @@ declare -A TOOLS_PATHS=(
 # would need to rewrite to :mvn/version at deploy time. A bash
 # associative array can't carry multi-valued entries cleanly, so we use
 # a single multi-line string and split on `|`.
+#
+# rf2-7fxf8 — Xray's entry listed ONE of its ten in-repo coordinates and
+# story-mcp's listed one of its two, so ten of the eighteen coordinates the
+# release workflows must rewrite were asserted by nothing at all. The
+# completeness pass at the end of the tools loop now derives the true set
+# from each deps.edn, so this list cannot silently fall behind again.
+#
+# Xray's `day8/re-frame2-freehand` line asserts ONLY what the loop below
+# asserts of every entry: that the coordinate is declared at `:local/root`
+# in the committed deps.edn, which is true today and green. It does NOT
+# assert that freehand is publishable — implementation/freehand/deps.edn
+# deliberately carries no `:clein/build` (publication is EP-0036 F6
+# territory), so `day8/re-frame2-freehand` cannot be rewritten to any
+# `:mvn/version`. Whether Xray is publishable before Freehand ships is an
+# OPEN OPERATOR DECISION (rf2-5dut1) that this gate neither makes nor
+# routes around; preflight-xray-package.sh is where it comes due, by
+# refusing the deploy.
 TOOLS_LOCAL_ROOTS=$(cat <<'EOF'
 xray|day8/re-frame2 {:local/root "../../implementation/core"}
+xray|day8/re-frame2-epoch {:local/root "../../implementation/epoch"}
+xray|day8/re-frame2-routing {:local/root "../../implementation/routing"}
+xray|day8/re-frame2-flows {:local/root "../../implementation/flows"}
+xray|day8/re-frame2-schemas {:local/root "../../implementation/schemas"}
+xray|day8/re-frame2-resources {:local/root "../../implementation/resources"}
+xray|day8/re-frame2-machines {:local/root "../../implementation/machines"}
+xray|day8/re-frame2-freehand {:local/root "../../implementation/freehand"}
+xray|day8/re-frame2-machines-viz {:local/root "../machines-viz"}
+xray|day8/reagent-slim {:local/root "../../implementation/adapters/reagent-slim"}
 story|day8/re-frame2 {:local/root "../../implementation/core"}
 story|day8/re-frame2-reagent {:local/root "../../implementation/adapters/reagent"}
 story|day8/re-frame2-machines {:local/root "../../implementation/machines"}
@@ -337,6 +473,7 @@ story|day8/re-frame2-machines {:local/root "../../implementation/machines"}
 story|day8/re-frame2-http {:local/root "../../implementation/http"}
 story|day8/re-frame2-xray {:local/root "../xray"}
 story-mcp|day8/re-frame2-story {:local/root "../story"}
+story-mcp|day8/re-frame2-mcp-base {:local/root "../mcp-base"}
 machines-viz|day8/re-frame2 {:local/root "../../implementation/core"}
 EOF
 )
@@ -440,6 +577,7 @@ for tool in "${TOOLS[@]}"; do
   # (`day8/re-frame2          {:local/root …}`) so we collapse all
   # runs of whitespace to a single space before matching.
   normalised="$(tr -s '[:space:]' ' ' < "${deps_file}")"
+  tool_expected=""
   while IFS='|' read -r entry_tool entry_local_root; do
     [[ -z "${entry_tool}" ]] && continue
     [[ "${entry_tool}" == "${tool}" ]] || continue
@@ -447,7 +585,12 @@ for tool in "${TOOLS[@]}"; do
       echo "::error file=${rel_label}::expected '${entry_local_root}' (lockstep contract; the release workflow rewrites this to :mvn/version at deploy time)"
       errors=$((errors + 1))
     fi
+    tool_expected+="${entry_local_root}"$'\n'
   done <<< "${TOOLS_LOCAL_ROOTS}"
+
+  # rf2-7fxf8 — and the converse. This is the direction that was missing,
+  # and the direction Xray drifted in.
+  assert_local_roots_inventoried "${deps_file}" "${rel_label}" "${tool_expected}"
 done
 
 if [[ "${errors}" -gt 0 ]]; then
@@ -457,4 +600,9 @@ fi
 
 total_count=$((${#ARTEFACTS[@]} + ${#TOOLS[@]}))
 echo "lockstep version verification PASSED — all ${total_count} artefacts (${#ARTEFACTS[@]} implementation/ + ${#TOOLS[@]} tools/) pinned to repo-root VERSION ${VERSION}"
+# rf2-7fxf8 — report what was actually SEEN, not merely what was listed.
+# The line above was printed unchanged while ten in-repo coordinates were
+# outside the inventory entirely; this one is derived from the committed
+# deps.edn files, so it cannot overstate the gate's reach.
+echo "lockstep coordinate inventory COMPLETE — ${coords_checked} in-repo :local/root coordinate(s) declared across those artefacts, every one of them inventoried here"
 exit 0

--- a/implementation/core/test/re_frame/interceptor_test.clj
+++ b/implementation/core/test/re_frame/interceptor_test.clj
@@ -798,6 +798,17 @@
 ;; category with :failing-id = the true failing component, mirroring the
 ;; already-distinct flow (:rf.error/flow-eval-exception) and fx
 ;; (:rf.error/fx-handler-exception) categories.
+;;
+;; PRODUCTION TWIN (rf2-mlh1h). The attribution below is read off the DEV
+;; TRACE, which emits nothing under -Dre-frame.debug=false — hence the
+;; `(when interop/debug-enabled? …)` arms. The contract itself is
+;; production-real: `error-emit/emit-error-both!` lifts `:failing-id` +
+;; `:reason` onto the ALWAYS-ON record whenever the failing id differs from
+;; `:event-id`. That half is witnessed in `re-frame.on-error-cljs-test`
+;; (rf2-n4x74b's four `*-record-carries-failing-*-id` deftests, plus
+;; rf2-mlh1h's phase / event-id pair), which captures through the `:errors`
+;; stream and runs in BOTH postures. Do not conclude from the dev-only arms
+;; here that the production lifting is unasserted — it is asserted there.
 
 (defn- capture-error-traces
   "Dispatch `event` and return the vector of emitted :op-type :error trace

--- a/implementation/core/test/re_frame/on_error_cljs_test.cljc
+++ b/implementation/core/test/re_frame/on_error_cljs_test.cljc
@@ -13,10 +13,23 @@
     - `:elapsed-ms` is an integer on every platform (rf2-ph8pa
       contract).
 
-  Dev-side coverage (runs under `:node-test` / `:browser-test` /
-  `clojure -M:test`). The CLJS production-mode counterpart lives in
-  `re-frame.on-error-elision-prod-test` — that suite pins the same
-  contract under `:advanced` + `goog.DEBUG=false`."
+  Runs under `:node-test` / `:browser-test` / `clojure -M:test`. The CLJS
+  production-mode counterpart lives in `re-frame.on-error-elision-prod-test`
+  — that suite pins the same contract under `:advanced` + `goog.DEBUG=false`.
+
+  ## Posture (rf2-mlh1h)
+
+  POSTURE-INDEPENDENT throughout, and that is the point of the namespace.
+  Every assertion here captures through the ALWAYS-ON `:errors` stream, never
+  the dev-only `:trace` stream, so this namespace is deliberately NOT on
+  `scripts/test-core-prod-gate.sh`'s exclusion roster and runs under
+  `-Dre-frame.debug=false` as well as in the ordinary suite. It is therefore
+  the production witness for the rf2-mszrz / rf2-n4x74b component-attribution
+  contract (`:failing-id` + `:reason` lifted onto the record for the
+  interceptor and coeffect categories, and NOT stamped for handler-exception,
+  whose failing id already equals `:event-id`). Keep it that way: an
+  assertion here that only holds in dev belongs in the dev-posture twin
+  (`re-frame.interceptor-test`), not in this file."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
@@ -560,6 +573,93 @@
              redundant with :event-id — the tight shape is preserved)")
         (is (= :n4x74b/handler-throws (:event-id r))
             ":event-id carries the event id (the failing handler IS the event)")))))
+
+;; ----------------------------------------------------------------------------
+;; rf2-mlh1h — the residue of the rf2-mszrz attribution contract the four
+;; twins above do not reach.
+;;
+;; They pin `:failing-id` on the always-on record, which is the load-bearing
+;; half and the half rf2-mlh1h was filed about. But rf2-mszrz's contract also
+;; discriminates the two INTERCEPTOR PHASES, and `:phase` is deliberately NOT
+;; lifted: `error-emit/emit-error-both!` lifts exactly `:failing-id` +
+;; `:reason`, keeping the record tight. So in production the phase is
+;; observable through the `:reason` STRING and nowhere else — and both
+;; interceptor twins above assert only `(string? (:reason r))`. Drop the phase
+;; from that string and an off-box shipper silently loses the ability to tell
+;; a `:before` failure from an `:after` one, with nothing red in either
+;; posture.
+;;
+;; The dev-posture assertions in `re-frame.interceptor-test`'s
+;; `pipeline-exception-attributed-to-true-component` read `:phase` off the
+;; trace tags directly. That arm is correct and stays; this is its
+;; production-axis counterpart, in the rf2-7vk3z twin shape.
+;; ----------------------------------------------------------------------------
+
+(defn- record-for
+  "Dispatch `event`, return the first ALWAYS-ON record whose `:error` is
+  `category`. Captures through the `:errors` stream — never the dev-only
+  `:trace` stream, which emits nothing under `-Dre-frame.debug=false`, so
+  every assertion built on this helper means the same thing in both postures."
+  [category event]
+  (let [seen (atom [])]
+    (rf/register-listener! :errors :test/recorder
+                           (fn [record] (swap! seen conj record)))
+    (try (rf/dispatch-sync event)
+         (catch #?(:clj clojure.lang.ExceptionInfo :cljs :default) _ nil))
+    (some (fn [x] (when (= category (:error x)) x)) @seen)))
+
+(deftest interceptor-exception-record-discriminates-phase-in-production
+  (testing "Per rf2-mlh1h: `:phase` is not lifted onto the tight always-on
+            record, so an off-box shipper tells a `:before` failure from an
+            `:after` one through `:reason` alone. Both phases pinned here, in
+            every posture."
+    (rf/reg-interceptor :mlh1h/boom-before
+      (rf/->interceptor :id     :mlh1h/boom-before
+                        :before (fn [_ctx] (throw (ex-info "before boom" {})))))
+    (rf/reg-event :mlh1h/before-throws
+                  {:interceptors [:mlh1h/boom-before]}
+                  (fn [{:keys [db]} _] {:db db}))
+    (rf/reg-interceptor :mlh1h/boom-after
+      (rf/->interceptor :id    :mlh1h/boom-after
+                        :after (fn [_ctx] (throw (ex-info "after boom" {})))))
+    (rf/reg-event :mlh1h/after-throws
+                  {:interceptors [:mlh1h/boom-after]}
+                  (fn [{:keys [db]} _] {:db db}))
+    (let [before (record-for :rf.error/interceptor-exception [:mlh1h/before-throws])
+          after  (record-for :rf.error/interceptor-exception [:mlh1h/after-throws])]
+      (is (some? before) "the always-on record fired for the :before throw")
+      (is (some? after) "the always-on record fired for the :after throw")
+      ;; NOT a vacuous negative: the record above is asserted present first,
+      ;; and it is the always-on one, which fires in both postures.
+      (is (nil? (:phase before))
+          ":phase is absent from the record by design — it rides the dev trace
+           tags only, and the tight record shape is the contract")
+      (is (re-find #"`before` phase" (:reason before))
+          ":reason names the :before phase — the ONLY production-visible
+           discriminator between the two interceptor phases")
+      (is (re-find #"`after` phase" (:reason after))
+          ":reason names the :after phase")
+      (is (re-find #":mlh1h/boom-before" (:reason before))
+          ":reason names the failing interceptor, agreeing with :failing-id"))))
+
+(deftest coeffect-exception-record-keeps-the-event-in-event-id
+  (testing "Per rf2-mlh1h: the lift is GUARDED on `:failing-id` differing from
+            `:event-id`, so the coeffect twin above only means what it claims
+            if `:event-id` really carries the dispatched EVENT. Pin the other
+            half of that pair — otherwise a supplier id in BOTH slots would
+            satisfy the twin while telling the shipper nothing."
+    (rf/reg-cofx :mlh1h/boom-cofx (fn [] (throw (ex-info "cofx boom" {}))))
+    (rf/reg-event :mlh1h/needs-boom-cofx
+                  {:rf.cofx/requires [:mlh1h/boom-cofx]}
+                  (fn [_ _] {}))
+    (let [r (record-for :rf.error/coeffect-exception [:mlh1h/needs-boom-cofx])]
+      (is (some? r) "the always-on record fired")
+      (is (= :mlh1h/needs-boom-cofx (:event-id r))
+          ":event-id is the dispatched EVENT, not the failing supplier")
+      (is (= :mlh1h/boom-cofx (:failing-id r))
+          ":failing-id is the failing SUPPLIER")
+      (is (not= (:event-id r) (:failing-id r))
+          "the two are DISTINCT — exactly the condition the lift is guarded on"))))
 
 ;; ============================================================================
 ;; rf2-bxud9v — sub error records carry the failing SUB's source-coord.


### PR DESCRIPTION
Two beads, disjoint surfaces.

## rf2-7fxf8 — the lockstep gate was reporting PASSED while blind to ten of eighteen coordinates

**Counts verified against current source, not taken from the bead.** `tools/xray/deps.edn` declares **ten** `:local/root` coordinates in its main `:deps` (core, epoch, routing, flows, schemas, resources, machines, freehand, machines-viz, reagent-slim); `TOOLS_LOCAL_ROOTS` listed **one**.

**A second hole the bead did not name:** `tools/story-mcp/deps.edn` declares **two** (story, mcp-base); its entry listed **one**. So ten of the eighteen in-repo coordinates the release workflows must rewrite were asserted by nothing at all, while the gate printed `PASSED — all 18 artefacts`.

The root cause is that every check in the script only ever asked one direction — *"is the coordinate the script expects present in deps.edn?"*. Completing the roster by hand fixes today and leaves tomorrow open, so the roster is now **cross-checked against the set derived from the committed deps.edn**.

Same principle as `preflight-xray-package.sh` (rf2-5dut1), which derives rather than hand-lists for exactly this reason — **different vehicle, deliberately**: the preflight is the tag-push arm and runs where `clojure` is installed, whereas this gate is the ordinary-CI arm and `test.yml` runs it on a bare `actions/checkout` with **no JDK**. It therefore reads EDN structurally through the same node authority the publishable-artefact inventory guard already uses (`implementation/scripts/lib/edn.cjs`, rf2-zef0e), never a text grep. Incidental confirmation: `implementation/core/deps.edn` mentions `day8/re-frame2-flows` in a `;;` comment and declares it for real in a `:test` alias `:extra-deps`; the reader flags neither.

The completeness pass covers `implementation/` too, including `core` (expected set empty — core is the lockstep root). `release.yml`'s rewrite is likewise a hand-written matrix of one `local-root` per leaf, with `ssr-ring` off it precisely because it has a second coordinate, so the same class of hole is open on that side.

### Does the gate now report a drift it previously hid? No — and I checked.

All ten coordinates it was blind to are correctly at `:local/root` today, so the gate stays green. The blindness was to *future* drift, and to the release workflows' rewrite lists falling behind — which is exactly what happened to `release-xray.yml` (it rewrites two of ten). **That is rf2-5dut1 and it is untouched here**; `preflight-xray-package.sh` is where it comes due, by refusing the deploy.

The gate now also prints what it actually saw, so the summary cannot overstate its reach again:

```
lockstep version verification PASSED — all 18 artefacts (13 implementation/ + 5 tools/) pinned to repo-root VERSION 0.0.1.alpha
lockstep coordinate inventory COMPLETE — 31 in-repo :local/root coordinate(s) declared across those artefacts, every one of them inventoried here
```

**Not resolved here, deliberately:** whether Xray is publishable before Freehand ships (rf2-5dut1). Xray's `day8/re-frame2-freehand` roster line asserts only what every entry asserts — that the coordinate *is* at `:local/root`, which is true and green. It asserts nothing about publishability, and `implementation/freehand/deps.edn` still deliberately carries no `:clein/build`. The loop's semantics were checked before adding it, per the bead.

**Xray spec unchanged because** no Xray surface or behaviour changed — `tools/xray/**` is untouched in this diff (it was mutated only transiently for the proof below, and restored). The change is to a CI gate that *reads* `tools/xray/deps.edn`.

## rf2-mlh1h — the production witness already existed; what was missing was `:phase`

**Premise correction, and it is the headline.** The bead states the attribution contract "is asserted NOWHERE, in either posture". That is true of `re-frame.interceptor-test`, but not of the repo: `re-frame.on-error-cljs-test` already carries rf2-n4x74b's four deftests, which capture through the **always-on `:errors` stream** and assert precisely what the bead asks for — `:failing-id` = the interceptor id, = the cofx id, and the negative control that handler-exception stamps nothing extra. That namespace is **not** on `scripts/test-core-prod-gate.sh`'s exclusion roster, so it has been running under `-Dre-frame.debug=false` all along.

Proven, not assumed: deleting the `:failing-id` / `:reason` lift from `error_emit.cljc` §`emit-error-both!` reds the gated run with **5 failures**.

**No roster line comes off** — none was ever on. The lane count is unchanged at 94 namespaces.

**What was genuinely missing** is the contract's other clause. `emit-error-both!` lifts exactly `:failing-id` + `:reason`, keeping the record tight, so **`:phase` is not on the always-on record**: in production the two interceptor phases are distinguishable through the `:reason` *string* and nowhere else. Both existing twins assert only `(string? (:reason r))`. Drop the phase from that string and an off-box shipper silently loses `:before` vs `:after`, with nothing red in either posture. Separately, the lift is *guarded* on `:failing-id` differing from `:event-id`, and nothing asserted that `:event-id` really carries the dispatched event for the coeffect case — a supplier id in both slots would have satisfied the existing twin while telling the shipper nothing.

Two deftests close both, placed next to their siblings. No production instrumentation was added to manufacture an observable; both facts are already on the record a shipper receives.

Neither vacuous-pass trap applies: the one negative assertion (`:phase` absent) is over an always-on record asserted present first, not over an empty trace ring; and the namespace is not 100% dev instrumentation — every assertion in it is posture-independent by construction.

The dev-posture assertions in `interceptor-test` are untouched per the rf2-7vk3z twin rule. It gains a comment pointing at its production counterpart, so this gap is not re-filed from the dev-only arms a third time.

## Quality gates

All foreground, to completion, exit codes echoed.

| Gate | Result |
|---|---|
| `.github/scripts/verify-version-lockstep.sh` | **0** — PASSED, 18 artefacts, 31 coordinates inventoried |
| `tools/xray` JVM (`clojure -M:test`) | **0** — 1271 tests, 5909 assertions, 0 failures |
| `scripts/test-core-prod-gate.sh` (full lane, `-Dre-frame.debug=false`) | **0** — 94 namespaces, **1105 tests, 5130 assertions** (was 1103 / 5120) |
| `clojure -M:test` on `on-error-cljs-test` + `interceptor-test` (dev posture) | **0** — 66 tests, 295 assertions |

Deferred to CI: the full fast-PR spine, the CLJS/browser suites, bundle-isolation, and the `release-*` workflow paths.

### Mutation evidence

**1. Lockstep — a coordinate knocked out of step.** `tools/xray/deps.edn`'s epoch coordinate repointed to `../../implementation/epoch-STALE`, run against the script at `HEAD` and against this branch:

```
===== OLD script (HEAD) =====
lockstep version verification PASSED — all 18 artefacts ...
OLD_EXIT=0                                    <- the drift is invisible

===== NEW script =====
::error file=tools/xray/deps.edn::expected 'day8/re-frame2-epoch {:local/root "../../implementation/epoch"}' ...
::error file=tools/xray/deps.edn::in-repo coordinate 'day8/re-frame2-epoch {:local/root "../../implementation/epoch-STALE"}' is declared at :local/root but is NOT in this script's inventory ...
::error::lockstep version verification FAILED (2 drift(s) detected)
NEW_EXIT=1
```

**2. Lockstep — the actual drift class: a new un-inventoried coordinate.** An eleventh coordinate added to `tools/xray/deps.edn`, and an in-repo edge added to `implementation/core/deps.edn` (which must have none):

```
OLD_EXIT=0                                    <- exactly how xray reached 1-of-10

NEW: ::error file=implementation/core/deps.edn::in-repo coordinate 'day8/re-frame2-flows {:local/root "../flows"}' ... NOT in this script's inventory
     ::error file=tools/xray/deps.edn::in-repo coordinate 'day8/re-frame2-http {:local/root "../../implementation/http"}' ... NOT in this script's inventory
NEW_EXIT=1
```

**3. Attribution — the pre-existing witness.** `:failing-id` / `:reason` lift deleted from `emit-error-both!`, run under the gate:

```
FAIL interceptor-exception-record-carries-failing-interceptor-id
  expected: (= :n4x74b/boom-after (:failing-id r))   actual: (not (= :n4x74b/boom-after nil))
Ran 44 tests containing 171 assertions.  5 failures, 0 errors.   EXIT=1
```

**4. Attribution — the new phase pin.** Phase dropped from `router.cljc`'s `classify-pipeline-exception` `:reason`, under the gate:

```
expected: (re-find #"`before` phase" (:reason before))
  actual: (not (re-find #"`before` phase" "Interceptor `:mlh1h/boom-before` threw."))
2 failures, 0 errors.   EXIT=1
```

**5. Attribution — the new event-id pin.** The coeffect record's positional `event-id` fed the *supplier* id, collapsing the distinct-id guard:

```
expected: (= :mlh1h/needs-boom-cofx (:event-id r))   actual: (not (= :mlh1h/needs-boom-cofx :mlh1h/boom-cofx))
4 failures, 0 errors.   EXIT=1
```

All five mutations reverted; `git diff --stat` against `origin/main` is the three files above and nothing else.
