### PR TITLE
bench(freehand): cross-substrate retained heap per boundary — Freehand loses on memory too (rf2-9oj7v, rf2-prjh0)

### DIFF
--- a/docs/design/freehand/studio/freehand-vs-reagent-memory.md
+++ b/docs/design/freehand/studio/freehand-vs-reagent-memory.md
@@ -1,0 +1,374 @@
+# What does a boundary cost in memory, on Freehand and on Reagent?
+
+Seat: EVIDENCE SPIKE. Beads `rf2-9oj7v` and `rf2-prjh0`.
+
+Measured: 2026-07-27, against `worker/heap-and-mount-bench` at the commit
+that carries this page — the instrument ships in the same PR. Reagent
+**2.0.1**, UIx **1.4.4**, React **19.2.0**. Host: Windows 11, headless
+Chromium 147 via Playwright, single developer workstation with other
+agents running concurrently. Every arm is an `:advanced` ClojureScript
+bundle with `goog.DEBUG false`. Current `main`, so the extra React commit
+per render batch that PR #7133 arms is included.
+
+**Only the interpreted tier is measured.** The compiled tier is ruled out
+and no compiled arm appears here.
+
+[`freehand-vs-reagent.md`](freehand-vs-reagent.md) closes with memory as
+the one axis it did not touch — *"the obvious next measurement and might
+well be the more decisive one"* — on the strength of
+[`compiled-tier-browser-worth-it.md`](compiled-tier-browser-worth-it.md)
+§1a, which found 6.26× retained heap per elidable boundary **within**
+Freehand and measured no competing substrate at all. This page runs that
+measurement.
+
+---
+
+## The answer, first
+
+**Freehand loses on memory, and it loses by more than it loses on the
+clock.** A boundary that does nothing costs Freehand **5.93× what it
+costs Reagent** and **9.67× what it costs UIx**. A boundary that reads
+its own fine-grained signal costs Freehand **4.19× what it costs
+Reagent**. Every one of those ranges is disjoint across six rounds, and
+two independent instruments agree on every figure to better than 1%.
+
+This was the hypothesis that memory might be the axis where Freehand's
+design wins outright. It is falsified. Memory is not a rescue; on this
+witness it is the worst axis measured so far.
+
+Three things to take, and the second is the one that closes the escape
+hatch.
+
+1. **Per reactive boundary, above the React floor: Freehand 4,346 bytes,
+   Reagent 1,037 bytes.** At 300 boundaries that is 1.24 MB against
+   0.30 MB; at 3,000, **12.4 MB against 3.0 MB**. The absolute figures
+   are small enough that no ordinary page will run out of memory over
+   them — this is a ratio result about a substrate's design, not a
+   crash report.
+2. **It is not re-frame's fault.** The obvious rebuttal is the one
+   `freehand-vs-reagent.md` §2a used on the clock: the Freehand arm reads
+   through `app-db` and a subscription graph while the Reagent arm reads a
+   bare `reagent.core/atom`, so it carries more framework. But the worst
+   ratio here is on the witness with **no reactivity on either side** —
+   300 bodies that read nothing, no `app-db`, no subscription, no cursor.
+   There Freehand costs **2,430 bytes a boundary against Reagent's 410**,
+   and that 5.93× is the ViewCell wrapper alone. Adding the reactive leg
+   *narrows* the gap to 4.19×, because Freehand's increment for going
+   reactive (1,916 B) is only 3.06× Reagent's (627 B). The framework
+   asymmetry is real and it is the *smaller* half of the finding.
+3. **UIx costs less than Reagent, which costs far less than Freehand.**
+   251 B, 410 B, 2,430 B a boundary. The ordering is the same one the
+   mount clock gives, and the spread is much wider.
+
+And a null result on a second question, reported here because it lands on
+the same release row:
+
+4. **B6's published mount row does NOT overstate the substrate**, and the
+   bug behind `rf2-prjh0` does not exist. See [§3](#3-the-mount-window-does-not-contain-a-frame).
+
+---
+
+## Method, and the instrument that had to be rebuilt
+
+**Retention, never allocation.** V8's CDP *sampling* heap profiler drops
+the samples of collected objects. Pointed at a mount/unmount loop it
+reports the residue of a page that has already been discarded, not the
+cost of the page: the same 80,000 objects read **4.77 MB when a global
+held them and 0.00 MB when nothing did**. That fault has already produced
+one wrong table on this surface, and the reasoning that rationalised it —
+*allocation is a counter, a collection inside the window cannot make it
+smaller* — is simply false of a sampler.
+
+So nothing here counts allocations. A reading is: **mount K roots and
+keep them**, force a full collection, read the heap; release, collect,
+read again. `K = 10` roots × 300 boundaries = **3,000 boundaries held**
+per reading, six rounds, arm order rotating with the round.
+
+**Three readers, and an honest account of how independent they are.**
+
+| | reader |
+|---|---|
+| **A** | CDP `Runtime.getHeapUsage().usedSize`, after three forced collections |
+| **B** | in-page `performance.memory.usedJSHeapSize`, same moment, under `--enable-precise-memory-info` |
+| **C** | a full heap **snapshot**, with every node's `self_size` summed by a streaming scan |
+
+**A and B are not independent of each other, and this page does not bank
+them as if they were.** Pointed at 80,000 held objects they returned the
+identical figure to the byte — 3,868,954 both — because they are two
+doors onto one V8 counter. B is a cross-check that the page and the
+debugger see the same heap, nothing more. **C is the independent
+reader**: it walks the object graph and sums what is actually there, and
+it is the one that makes the table falsifiable. It is slow, so it runs as
+its own pass rather than in every round.
+
+**The positive control rides every round, and its size is predicted
+rather than observed.** A dense JS array of 587,500 doubles, which V8
+stores as unboxed 8-byte slots: **4,700,000 bytes, known before anything
+is measured** — deliberately the same ~4.7 MB the broken sampler reported
+as 0.00 MB.
+
+| control | predicted | measured | error |
+|---|---:|---:|---:|
+| **A** | 4,700,000 B | 4,692,044 B [4,654,514–4,700,974] | **−0.17%** |
+| **B** | 4,700,000 B | 4,691,993 B | −0.17% |
+| **C** | 4,700,000 B | **4,700,024 B** | **+0.0005%** |
+
+> The control's own first draft was a flat one-byte string of 4,700,000
+> characters, on the reasoning that a `SeqOneByteString` costs its length
+> plus a header. **It read as six kilobytes on all three readers** — V8
+> does not materialise `'x'.repeat(n)`. Had it shipped, the control would
+> have missed by three orders of magnitude every round and the natural
+> conclusion would have been that the instrument was broken, when the
+> instrument was fine and the control was a fiction. It is recorded
+> because it is the same class of mistake as the sampler, caught one step
+> earlier, and because it is the argument for running a control rather
+> than reasoning one out.
+
+**Every mount is verified at the DOM, inside its own reading.** After
+each mount the boundary elements the arm should have produced are counted
+against `K × 300`. An arm that silently rendered nothing would otherwise
+read as the cheapest substrate in the table. **0 unverified of 56
+mounts.**
+
+**A warm-up pass precedes the rounds and is never read.** The first mount
+of any arm allocates things that are not the page and never go away —
+compiled code for the paths it just took, inline caches, interned
+keywords, one-time module state. A smoke run charged those to round 1 and
+saw 400–700 KB of unreleasable residue per arm; after the warm-up the
+residue is 4–30 KB against multi-megabyte retentions, which is what a
+clean release looks like.
+
+**The floor is subtracted, and that is what makes the figure a substrate
+figure.** DOM nodes live in Blink's C++ heap, not V8's, so none of these
+readings contain the elements themselves. Every arm builds the identical
+DOM — B6's canonical-DOM parity gate is what establishes that — so the
+omission cancels exactly in `arm − floor`, which is the column quoted.
+The absolute column is a JS-heap figure and is labelled as one.
+
+**Two witnesses.** **`storm`** is 300 sub-free leaf boundaries per root,
+301 elements — B6's W2 shape, in four dialects. It prices the wrapper and
+only the wrapper. **`reactive`** is 300 cells per root each reading its
+own fine-grained signal, Freehand's `v/sub` against Reagent's
+`r/cursor` — B6's update grid, held rather than driven. All K roots of an
+arm share one state cell (one `reagent.core/atom`, one frame), because
+that is how an application is shaped and K stores would price the store
+rather than the boundary.
+
+---
+
+## 1. Retained heap per boundary
+
+**Absolute**, JS heap only, mean of six rounds with the range in
+brackets, instrument C beside it:
+
+| arm | A — B/boundary | C |
+|---|---:|---:|
+| `storm` floor — no substrate | 244 [241–247] | 472 |
+| `storm` **UIx** | 496 [488–501] | 725 |
+| `storm` **Reagent** | 654 [647–661] | 879 |
+| `storm` **Freehand** | **2,675** [2,662–2,693] | 2,899 |
+| `reactive` floor — no substrate | 244 [241–246] | 474 |
+| `reactive` **Reagent** `r/cursor` | 1,281 [1,276–1,284] | 1,508 |
+| `reactive` **Freehand** `v/sub` | **4,590** [4,576–4,604] | 4,804 |
+
+C sits about 228 B/boundary above A on *every* arm, which is a constant
+offset in what the two readers count as heap and not a disagreement about
+any substrate. Subtract the floor and the two agree almost exactly:
+
+**Above the React floor**, paired within each round:
+
+| arm | A — B/boundary above floor | C | A vs C |
+|---|---:|---:|---:|
+| `storm` **UIx** | 251 [248–255] | 253 | 0.60% |
+| `storm` **Reagent** | 410 [406–416] | 407 | 0.85% |
+| `storm` **Freehand** | **2,430** [2,417–2,450] | 2,427 | **0.16%** |
+| `reactive` **Reagent** | 1,037 [1,035–1,039] | 1,034 | 0.29% |
+| `reactive` **Freehand** | **4,346** [4,332–4,361] | 4,330 | 0.37% |
+
+Two readers that share no code agree to within 1% on every row. This is
+by a wide margin the best-conditioned measurement in the studio: the
+clock rows in the sibling reports live with a floor that moves 20–58%
+between rounds, and these ranges are ±0.7%.
+
+**The ratios**, computed per round and then summarised, so the box's
+drift cancels:
+
+| | mean [min–max] |
+|---|---|
+| `storm` **Freehand ÷ Reagent** | **5.928** [5.867–5.993] |
+| `storm` **Freehand ÷ UIx** | **9.668** [9.512–9.822] |
+| `storm` Reagent ÷ UIx | 1.631 [1.598–1.643] |
+| `reactive` **Freehand ÷ Reagent** | **4.190** [4.173–4.201] |
+
+**What it comes to on a page**, reactive boundaries, above the floor:
+
+| boundaries | Freehand | Reagent | difference |
+|---:|---:|---:|---:|
+| 300 | 1.24 MB | 0.30 MB | 0.95 MB |
+| 1,000 | 4.15 MB | 0.99 MB | 3.16 MB |
+| 3,000 | 12.44 MB | 2.97 MB | 9.47 MB |
+
+A megabyte on a 300-boundary page will not sink an application, and this
+page does not claim it would. What it claims is the ratio, and the ratio
+is not close.
+
+### 1a. It is the wrapper, not re-frame
+
+The standing rebuttal to every cross-substrate figure in this studio is
+that the Freehand arm carries more framework than the Reagent arm: it
+reads `app-db` through a subscription graph where Reagent reads a bare
+ratom. `freehand-vs-reagent.md` §2a used exactly that to cut the narrow
+update result from 15× to roughly parity, and it was right to.
+
+It does not work here, and the two witnesses are what show why.
+
+| | Freehand | Reagent | ratio |
+|---|---:|---:|---:|
+| a boundary that reads **nothing** | 2,430 B | 410 B | **5.93×** |
+| the **increment** for reading a signal | 1,916 B | 627 B | 3.06× |
+| a boundary that reads a signal | 4,346 B | 1,037 B | 4.19× |
+
+The `storm` witness has no `app-db`, no subscription, no cursor and no
+reactivity of any kind on either side — 300 bodies that read nothing.
+There is no framework asymmetry left to appeal to, and that is where the
+gap is **widest**. Going reactive *narrows* it, because Freehand's
+increment for a signal is 3.06× Reagent's while its wrapper is 5.93×.
+
+So the finding decomposes the other way round from the clock's: the
+larger term is the ViewCell wrapper, which is Freehand's own, and the
+smaller term is the one re-frame could be blamed for.
+
+### 1b. What it corroborates
+
+The within-Freehand ablation in
+[`compiled-tier-browser-worth-it.md`](compiled-tier-browser-worth-it.md)
+§1a priced **one kept ViewCell at 2,348 bytes** of standing heap and a
+reactive boundary at **4,134 bytes over the React floor**, from a
+different instrument, a different comparison basis and a different
+build. This page reads **2,430** and **4,346** — within 3.5% and 5%.
+
+That is the answer `rf2-9oj7v` asked for in its own terms: **B2's elided
+boundary is worth 2,430 bytes of standing heap** (2,427 on the
+independent reader), and the elision count it gates can now be
+multiplied out rather than merely counted. It also means the ablation's
+figure was sound, which was not certain — it was taken with the same
+family of tooling that produced the wrong table beside it.
+
+---
+
+## 2. What this does not cover
+
+- **One shape, held still.** Two purpose-built witnesses, mounted and
+  never touched. Nothing here measures heap *under* update, and a
+  substrate can trade standing bytes for churn — Freehand's fine-grained
+  path might allocate less per write than Reagent's, and this instrument
+  cannot see it. That is the obvious next measurement, and it is now the
+  only memory question with an argument left in it for Freehand.
+- **Transient garbage is invisible, by construction.** Retention cannot
+  see what the interpreted walk allocates and drops. §1a of the
+  predecessor report flagged the same limit.
+- **The JS heap only.** No DOM, no detached-node accounting, no
+  Blink-side cost. The floor subtraction is what makes this safe, and it
+  is safe only because the parity gate proves the pages identical.
+- **No compiled tier.** Ruled out; not measured.
+- **UIx on the reactive witness.** UIx's update story is `use-state` and
+  React's own scheduler, a different mechanism that needs its own arm.
+- **Bundle size, SSR, hydration.** None of it.
+- **A real application.** Two witnesses on a loaded developer
+  workstation — though the ranges here are tight enough that a quiet
+  machine would move the third digit, not the first.
+
+---
+
+## 3. The mount window does not contain a frame
+
+`rf2-prjh0` reported that B6's Freehand mount arm passes no `:frame`, so
+`v/mount` would create a **fresh frame per sample inside the timed
+`flushSync`** while the floor arm — a bare `createRoot` — never pays it.
+If that were so, a measurable slice of interpreted W1's 2.987× would be
+frame construction rather than view substrate, and a row on the release
+gate would be too harsh.
+
+**The premise does not hold.** `plan-for` in `root.cljs` answers `nil`
+when `opts` carries no `:frame`, `preflight!` opens `(when (some? plan)
+…)`, and `root-element` wraps the root form in the frame provider only
+`(if (some? frame-id) …)`. A frameless mount runs no plan, creates no
+frame and binds none. The published arm is not paying for a frame — it is
+doing **less** than a mount that names one.
+
+Which inverts the question rather than closing it, so it was measured.
+Four arms differing in the `:frame` opt and nothing else, on B6's
+harness unchanged, six interleaved rounds of 5 warm-up + 20 samples,
+every figure a ratio to the floor of that same round:
+
+| Witness | floor | `fh-no-frame` — **the published arm** | `fh-shared-frame` | `fh-frame-per-sample` | Reagent |
+|---|---:|---:|---:|---:|---:|
+| **W1** 1,203 el | 1.000 | **3.109** [2.889–3.588] | 3.229 [3.000–3.706] | 3.347 [3.111–4.059] | 1.545 [1.471–1.647] |
+| **W2** 301 el | 1.000 | **8.667** [7.00–10.00] | 9.611 [7.67–11.00] | 9.917 [7.00–11.50] | 2.528 [1.67–3.00] |
+
+`fh-shared-frame` scopes a frame stood up before the run — the studio
+fixture's shape, the one the bead proposes as the correction.
+`fh-frame-per-sample` ensures a **fresh** frame id every sample: the
+counterfactual, priced so the report can say what the mistake would have
+been worth had it been real.
+
+**The three Freehand arms' ranges overlap, so on ranges alone they are
+indistinguishable** — which is what this studio's method requires be said
+first. But the arms are interleaved *within* each round, so the paired
+comparison is available and is far stronger than the ranges:
+
+| paired, per round | W1 | W2 |
+|---|---|---|
+| `fh-shared-frame` ÷ `fh-no-frame` | **×1.038**, higher in **6 of 6** rounds | **×1.109**, higher in **6 of 6** |
+| `fh-frame-per-sample` ÷ `fh-no-frame` | **×1.074**, higher in **6 of 6** | ×1.138, higher in 5 of 6 |
+
+Six of six in one direction is a real effect, and the direction is the
+opposite of the bead's. **The published arm is the cheapest of the three
+Freehand shapes.** Correcting the row to the studio fixture's shared
+frame would move interpreted W1 mount *up* by 3.8% and W2 up by 10.9%;
+naming a fresh frame per sample — the thing feared — would have cost 7.4%
+on W1, so even had the bug been real it would have been worth a fraction
+of a 2× gap.
+
+**So the mount row stands, and no published figure changes.** If it is
+generous to Freehand it is generous by ~4% on W1, in the direction of
+flattering rather than punishing the substrate. The `:frame` opt costs
+what a frame provider costs — a ledger read and one more React context
+above the tree — and B6's arm does not pay it.
+
+**The row reproduces.** This harness is B6's, re-run on a different day
+against current `main`. Reagent W1 comes back at **1.545 [1.471–1.647]**
+against B6's published **1.554 [1.520–1.583]**, and interpreted Freehand
+W1 at **3.109 [2.889–3.588]** against **2.987 [2.840–3.167]** — both
+overlapping, the Freehand arm ~4% higher, consistent with PR #7133's
+extra React commit per render batch landing inside the window plus a
+differently loaded box. The mount row is reproducible to within its own
+stated ranges, which had not previously been shown.
+
+---
+
+## Provenance
+
+- Fixtures: `storm` = 300 sub-free leaf boundaries, 301 elements (B6's
+  W2); `reactive` = 300 cells each reading their own signal, 301 elements
+  (B6's update grid); W1 = 300 rows, 1,203 elements.
+- Heap sampling: 10 roots × 300 boundaries held per reading, 6 rounds,
+  arm order rotating with the round, one un-read warm-up pass first.
+  Snapshot pass separate, once per arm.
+- Mount sampling: 6 rounds × (5 warm-up + 20 samples) per arm, arms
+  interleaved at the sample level with the order rotating on the sample
+  index; every figure a ratio to the floor of that round.
+- Gates green before any figure was read: canonical-DOM equality across
+  all five mount arms with the written element counts (1,203 / 301), and
+  a DOM read-back of every heap mount — **0 unverified of 56**.
+- Build: `:advanced`, `goog.DEBUG false`, via `--config-merge` on the
+  existing `:freehand-release` build id. `implementation/shadow-cljs.edn`
+  is unchanged.
+- Source:
+  `implementation/freehand/test/re_frame/freehand/bench/b7_heap.cljs`
+  (the arms and the retention door),
+  `b7_mount_frame.cljs` (the four `:frame` arms), `b7_app.cljs` (the
+  `:advanced` entry) and `b7_run.cjs` (the collector, the three readers
+  and the positive control).
+- Reproduce:
+  `node implementation/freehand/test/re_frame/freehand/bench/b7_run.cjs`.

--- a/docs/design/freehand/studio/freehand-vs-reagent-memory.md
+++ b/docs/design/freehand/studio/freehand-vs-reagent-memory.md
@@ -364,6 +364,16 @@ stated ranges, which had not previously been shown.
 - Build: `:advanced`, `goog.DEBUG false`, via `--config-merge` on the
   existing `:freehand-release` build id. `implementation/shadow-cljs.edn`
   is unchanged.
+- **Base commit, and one thing that landed after it.** Every figure was
+  taken against `aa77d1d573`. `rf2-wxrrp` (`e5cf299fc2`, *fold the
+  commit-side read, the tear check and the bundle into one pass*) merged
+  to `main` while this ran and is **not** in these numbers. It is an
+  update-path change, so the mount and standing-heap rows here are
+  unlikely to move — but "unlikely" is not "measured", and a ViewCell
+  that folds three passes into one could plausibly retain differently.
+  Whoever next touches this instrument should re-take the two Freehand
+  arms on a base that includes it before quoting these figures as
+  current.
 - Source:
   `implementation/freehand/test/re_frame/freehand/bench/b7_heap.cljs`
   (the arms and the retention door),

--- a/docs/design/freehand/studio/freehand-vs-reagent.md
+++ b/docs/design/freehand/studio/freehand-vs-reagent.md
@@ -169,9 +169,10 @@ unchanged.
   to a sample for exactly this reason; the broad row does not need to.
 - **Any range that straddles 1.0 is reported as indistinguishable**, not
   as a win. One does: UIx on W3.
-- **No memory claim of any kind.** The predecessor report's retained-heap
-  instrument was not re-run across substrates; the allocation question is
-  open and is the obvious next measurement.
+- **No memory claim of any kind** *in this report*. It has since been
+  measured: see
+  [`freehand-vs-reagent-memory.md`](freehand-vs-reagent-memory.md), and
+  §3 below.
 - **No claim about a real application.** These are six purpose-built
   witnesses.
 
@@ -203,6 +204,18 @@ neither does UIx. It is here because the predecessor report measured it.
 four arms overlap; UIx's range includes 1.0, so **UIx and the floor are
 indistinguishable on the form**, and the four substrate arms are barely
 separable from each other.
+
+> **Does the Freehand mount arm bill frame construction to the
+> substrate?** It was put to this row as `rf2-prjh0`, on the grounds that
+> the arm passes no `:frame` and would therefore create one per sample
+> inside the timed `flushSync`. **It does not** — a frameless `v/mount`
+> runs no plan and creates no frame — and measuring the three shapes
+> found the published arm is the *cheapest* of them: a shared
+> pre-created frame costs 3.8% **more** on W1 and 10.9% more on W2, in
+> 6 of 6 paired rounds. No figure in this table changes. The row also
+> reproduced on a later day against current `main`, Reagent W1 at 1.545
+> [1.471–1.647] against the 1.554 above. Detail in
+> [`freehand-vs-reagent-memory.md`](freehand-vs-reagent-memory.md) §3.
 
 **And in milliseconds, because a ratio on a sub-millisecond operation is
 not a product decision** (p50, round 4 of six — the same round §2a
@@ -379,11 +392,19 @@ without the microtask yield; it has not been re-taken.
 
 Stated plainly, because the omissions are load-bearing.
 
-- **Memory.** Nothing. The predecessor report's retained-heap instrument
-  was not run across substrates. Given it found 6.26× retained heap per
-  elidable boundary *within* Freehand, a Reagent comparison on standing
-  heap is the obvious next measurement and might well be the more
-  decisive one.
+- **Memory.** Nothing, in this report — and it turned out to matter.
+  [`freehand-vs-reagent-memory.md`](freehand-vs-reagent-memory.md) ran
+  the comparison this bullet asked for and **the answer went against
+  Freehand, harder than the clock does**: a boundary that reads nothing
+  costs Freehand 2,430 bytes of standing heap against Reagent's 410 and
+  UIx's 251 — **5.93×** and **9.67×** — and a boundary reading its own
+  signal costs 4,346 against Reagent's 1,037, **4.19×**. Two independent
+  readers agree to within 1% and every range is disjoint. Crucially the
+  §2a rebuttal below does *not* apply: the widest gap is on the witness
+  with no reactivity and no `app-db` on either side, so the larger term
+  is the ViewCell wrapper rather than re-frame's write path. Heap *under
+  update* is still unmeasured and is the one memory question left with an
+  argument in it.
 - **Reagent reading re-frame.** The Reagent arm reads a bare
   `reagent.core/atom`, which is Reagent's own idiom but is *less
   framework* than the Freehand arm carries. §2a bounds the effect rather
@@ -429,7 +450,11 @@ Stated plainly, because the omissions are load-bearing.
    batch (a two-fiber detached root rendering nil); it lands outside the
    current window but would move inside a re-taken one, so whoever
    re-takes the row should report it rather than absorb it.
-4. **The memory row.** See above.
+4. **~~The memory row.~~ DONE — and it did not help.**
+   [`freehand-vs-reagent-memory.md`](freehand-vs-reagent-memory.md).
+   Freehand costs 5.93× Reagent per sub-free boundary in standing heap
+   and 4.19× per reactive one. What remains open is heap *under update*,
+   where a fine-grained substrate could still come out ahead.
 
 ## Provenance
 

--- a/implementation/freehand/test/re_frame/freehand/bench/b7_app.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b7_app.cljs
@@ -1,0 +1,80 @@
+(ns re-frame.freehand.bench.b7-app
+  "B7's `:advanced` entry — one bundle, two modes.
+
+  Both B7 rows have to be read from the artefact a consumer ships
+  (`:advanced`, `goog.DEBUG false`) for the reason B6's production entry
+  gives: Spec 009 instrumentation, schema validation and trace emission
+  are all `goog.DEBUG`-gated, all sit on the paths being measured, and
+  Reagent has no counterpart to any of them, so a development build
+  penalises Freehand in one direction only. And `:advanced` cannot compile
+  shadow's `:browser-test` target, so the reading needs a plain `:browser`
+  entry — this one.
+
+  `?mode=mount-frame` runs `rf2-prjh0`'s row to completion in the page and
+  parks the records on `window.B7_RESULTS`.
+
+  `?mode=heap` installs `rf2-9oj7v`'s retention instrument on
+  `window.B7H` and then does nothing at all. Heap readings belong to the
+  DRIVER, which owns the collector: the page cannot force a garbage
+  collection, and a page that tried to decide when a heap reading was
+  taken would be reading whatever the collector happened to have done.
+
+  Built and driven by
+  `implementation/freehand/test/re_frame/freehand/bench/b7_run.cjs`."
+  (:require [re-frame.adapter.uix :as react-substrate]
+            [re-frame.core :as rf]
+            [re-frame.freehand.bench.b6-harness :as h]
+            [re-frame.freehand.bench.b7-heap :as heap]
+            [re-frame.freehand.bench.b7-mount-frame :as mf]))
+
+(defn- q
+  "A query-string integer, or `default`. The published run takes the
+  defaults — B6's own sampling, so the two rows are comparable — and the
+  overrides exist so a smoke run can prove the harness wires up without
+  paying for six rounds of it."
+  [k default]
+  (if-some [v (.get (js/URLSearchParams. (.-search js/location)) k)]
+    (js/parseInt v 10)
+    default))
+
+(defn- fail! [why]
+  (set! (.-B7_ERROR js/window) (str why))
+  (js/console.error (str ";; B7 FAILED — " why)))
+
+(defn- record! [k v]
+  (let [acc (or (.-B7_RESULTS js/window) #js {})]
+    (aset acc (name k) (pr-str v))
+    (set! (.-B7_RESULTS js/window) acc)
+    v))
+
+(defn- run-mount-frame!
+  []
+  (mf/ensure-shared-frame!)
+  (let [rounds   (q "rounds" 6)
+        sampling {:warmup (q "warmup" 5) :samples (q "samples" 20)}
+        problems (into [] (mapcat mf/parity-problems) mf/witnesses)]
+    (record! :parity {:problems problems :ok? (empty? problems)})
+    (if (seq problems)
+      (fail! (str "the arms do not build the same page under :advanced — " (pr-str problems)))
+      (doseq [w mf/witnesses]
+        (record! (:id w) (:record (mf/measure! w rounds sampling)))))))
+
+(defn- mode []
+  (or (.get (js/URLSearchParams. (.-search js/location)) "mode") "mount-frame"))
+
+(defn ^:export -main
+  []
+  (try
+    (rf/init! react-substrate/adapter)
+    (h/leave-act-environment!)
+    (case (mode)
+      "heap" (do (heap/install!)
+                 (js/console.log ";; B7 heap instrument installed")
+                 (set! (.-B7_READY js/window) true))
+      (do (run-mount-frame!)
+          (set! (.-B7_DONE js/window) true)
+          (js/console.log ";; B7 DONE")))
+    (catch :default e
+      (fail! (str "b7 run threw: " e))
+      (set! (.-B7_DONE js/window) true)
+      (set! (.-B7_READY js/window) true))))

--- a/implementation/freehand/test/re_frame/freehand/bench/b7_heap.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b7_heap.cljs
@@ -1,0 +1,281 @@
+(ns re-frame.freehand.bench.b7-heap
+  "B7 — RETAINED HEAP per live boundary, ACROSS substrates.
+
+  The one axis the cross-substrate comparison never measured. B6 prices
+  mount and update on the wall clock and says so plainly in its §3: *no
+  memory claim of any kind*. `compiled-tier-browser-worth-it.md` §1a
+  priced retained heap per boundary, but only *within* Freehand — one
+  substrate against itself. So the question `docs/design/freehand/studio/`
+  `freehand-vs-reagent.md` names as \"the obvious next measurement\" —
+  what does a boundary cost in standing bytes on Freehand versus on
+  Reagent — has no answer anywhere. This namespace is that answer's
+  instrument.
+
+  ## Why this is not the allocation counter, and why that matters
+
+  V8's CDP SAMPLING heap profiler **drops the samples of collected
+  objects**. Pointed at a mount/unmount loop it reports the residue of a
+  page that has already been discarded, not the cost of the page: the
+  same 80,000 objects read **4.77 MB when a global held them and 0.00 MB
+  when nothing did**. That fault has already produced one wrong table on
+  this surface, and the intuition that rationalised it — \"allocation is
+  a counter, a collection inside the window cannot make it smaller\" — is
+  simply false of a sampler.
+
+  So nothing here counts allocations. The instrument is RETENTION, which
+  is the right question anyway: a ViewCell is a cell object, a hook
+  record, a subscription registration and two layout effects that live as
+  long as the mount, and what an application pays for a boundary is what
+  the boundary keeps standing, not what it touched on the way up.
+
+  ## The shape of a reading
+
+  **Mount K roots and KEEP them.** The driver
+  (`b7_run.cjs`) forces a full garbage collection through CDP, reads the
+  heap, and only then asks this namespace to mount. Nothing is timed;
+  nothing is unmounted inside a window. Then the roots are released, the
+  heap is collected and read again — and that second read is a control in
+  its own right, because a substrate whose released heap does not return
+  to baseline is retaining something after unmount, which is a different
+  and worse finding than a large per-boundary figure.
+
+  **Every mount is verified at the DOM.** `mount!` counts the boundary
+  elements the arm should have produced and answers the count beside the
+  expectation. An arm that silently rendered nothing would otherwise read
+  as the cheapest substrate in the table, which is exactly the shape of
+  the fault this instrument exists to avoid.
+
+  **A positive control of known size rides every round.** [[control!]]
+  allocates a flat one-byte string of exactly N characters and holds it on
+  a global. A `SeqOneByteString` of length N occupies N bytes of character
+  data plus a small fixed header, so its retained size is PREDICTED, not
+  merely observed, and the round reports predicted against measured. If
+  the collector or the reader were not doing what this namespace claims,
+  the control would miss, and \"this arm is cheap\" and \"the instrument
+  is not running\" would stop being the same number.
+
+  ## The two witness families
+
+  **`storm`** — 300 sub-free leaf boundaries per root, 301 elements. The
+  same W2 shape B6 mounts, in all four dialects. It prices a boundary that
+  does nothing: the wrapper, and only the wrapper.
+
+  **`reactive`** — 300 cells per root, each reading its own fine-grained
+  signal: Freehand's `v/sub` against Reagent's `r/cursor`, the same pairing
+  B6's update rows drive. It prices a boundary an application would
+  actually write. The floor arm renders the identical 301-element DOM with
+  no reactivity at all, so `arm − floor` is the substrate's own standing
+  cost and not a number dominated by React fibers both arms pay for.
+
+  All K roots of an arm share ONE state cell — one `reagent.core/atom` for
+  Reagent, one frame for Freehand — because that is how an application is
+  shaped and because K independent stores would price the store rather
+  than the boundary.
+
+  ## What a JS-heap reading cannot see
+
+  DOM nodes live in Blink's C++ heap, not V8's, so none of these figures
+  contain the elements themselves. Every arm builds the identical DOM —
+  the canonical-DOM parity gate in B6 is what establishes that — so the
+  omission cancels exactly in `arm − floor`, which is the figure the
+  report quotes. The absolute per-boundary column is a JS-heap figure and
+  is labelled as one.
+
+  Normative owner: `docs/design/freehand/decisions/`
+  `D021-performance-budgets-and-release-evidence.md`."
+  (:require ["react-dom" :as react-dom]
+            ["react-dom/client" :as react-dom-client]
+            [reagent.dom.client :as rdc]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.bench.b6-floor :as floor]
+            [re-frame.freehand.bench.b6-reagent :as rg]
+            [re-frame.freehand.bench.b6-rows :as rows]
+            [re-frame.freehand.bench.b6-uix :as ux]
+            [re-frame.freehand.bench.b6-witnesses :as fh]
+            [uix.core :refer [$]]
+            [uix.dom :as uix-dom]))
+
+(def per-root
+  "Boundaries in one root. The same 300 B6 mounts, so a per-boundary
+  figure here and a mount ratio there describe the same page."
+  rows/cells-n)
+
+(def shared-frame-id
+  "ONE frame behind every root of the reactive Freehand arm — the
+  counterpart of the single `reagent.core/atom` behind every root of the
+  reactive Reagent arm. K separate frames would price frame construction,
+  which is not what a per-boundary figure is for."
+  :b7/grid)
+
+;; ---------------------------------------------------------------------------
+;; Arms
+;; ---------------------------------------------------------------------------
+
+(defn- container! []
+  (let [c (js/document.createElement "div")]
+    (.appendChild js/document.body c)
+    c))
+
+(defn- react-root-arm
+  "The floor, and the UIx arm — neither has a mount door of its own."
+  [element-of]
+  {:mount-one   (fn [c _i]
+                  (let [r (react-dom-client/createRoot c)]
+                    (react-dom/flushSync (fn [] (.render r (element-of))))
+                    r))
+   :unmount-one (fn [r] (react-dom/flushSync (fn [] (.unmount r))))})
+
+(def arms
+  "id → `{:selector … :mount-one … :unmount-one …}`. `:selector` is the
+  DOM read-back: the class every boundary of that witness puts on the
+  page, counted after the mount against `K × per-root`."
+  {;; --- storm: a boundary that reads nothing -------------------------------
+   :storm/floor
+   (assoc (react-root-arm #(floor/w2 per-root)) :selector ".leaf")
+
+   :storm/freehand
+   {:selector    ".leaf"
+    :mount-one   (fn [c i]
+                   (react-dom/flushSync
+                     (fn [] (v/mount [fh/w2 {:n per-root}] c
+                                     {:disambiguator (keyword "b7h" (str "storm-" i))}))))
+    :unmount-one (fn [m] (react-dom/flushSync (fn [] (v/unmount! m))))}
+
+   :storm/reagent
+   {:selector    ".leaf"
+    :mount-one   (fn [c _i]
+                   (let [rt (rdc/create-root c)]
+                     (react-dom/flushSync (fn [] (rdc/render rt [rg/w2 per-root])))
+                     rt))
+    :unmount-one (fn [rt] (react-dom/flushSync (fn [] (rdc/unmount rt))))}
+
+   :storm/uix
+   {:selector    ".leaf"
+    :mount-one   (fn [c _i]
+                   (let [rt (uix-dom/create-root c)]
+                     (react-dom/flushSync
+                       (fn [] (uix-dom/render-root ($ ux/w2 {:n per-root}) rt)))
+                     rt))
+    :unmount-one (fn [rt] (react-dom/flushSync (fn [] (uix-dom/unmount-root rt))))}
+
+   ;; --- reactive: a boundary an application would write --------------------
+   :reactive/floor
+   (assoc (react-root-arm #(floor/u-grid (vec (repeat per-root 0)))) :selector ".cell")
+
+   :reactive/freehand
+   {:selector    ".cell"
+    ;; Root 0 ENSUREs the frame and owns it; every later root SCOPEs the
+    ;; same one. A config-bearing ensure from a second root-id is refused
+    ;; by design (Spec 004C §7, one frame one plan) and would be the wrong
+    ;; shape anyway — K roots over one store is the application shape.
+    :mount-one   (fn [c i]
+                   (react-dom/flushSync
+                     (fn []
+                       (v/mount [fh/u-grid {:n per-root}] c
+                                {:disambiguator (keyword "b7h" (str "grid-" i))
+                                 :frame         (if (zero? i)
+                                                  {:id             shared-frame-id
+                                                   :initial-events [[:b6/seed per-root]]}
+                                                  shared-frame-id)}))))
+    :unmount-one (fn [m] (react-dom/flushSync (fn [] (v/unmount! m))))}
+
+   :reactive/reagent
+   {:selector    ".cell"
+    :mount-one   (fn [c _i]
+                   (let [rt (rdc/create-root c)]
+                     (react-dom/flushSync (fn [] (rdc/render rt [rg/u-grid per-root])))
+                     rt))
+    :unmount-one (fn [rt] (react-dom/flushSync (fn [] (rdc/unmount rt))))}})
+
+;; ---------------------------------------------------------------------------
+;; Holding, and letting go
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private held (atom nil))
+
+(defn- release!*
+  "Unmount in REVERSE mount order and detach every container. Reverse,
+  because the reactive Freehand arm's root 0 owns the frame the others
+  scope: tearing the owner down first would unmount live scopers from
+  underneath."
+  []
+  (when-some [{:keys [arm handles containers]} @held]
+    (let [{:keys [unmount-one]} (get arms arm)]
+      (doseq [h (reverse handles)]
+        (try (unmount-one h) (catch :default _ nil))))
+    (doseq [c containers] (.remove c))
+    (reset! held nil))
+  nil)
+
+(defn mount!
+  "Mount `k` roots of `arm-id` and KEEP them. Answers
+  `{:elements n :expected n :ok? bool}` — the DOM read-back, taken after
+  the mount, over the boundary class the arm should have produced."
+  [arm-id k]
+  (release!*)
+  (when (= :reactive/reagent arm-id)
+    (reset! rg/cells (vec (repeat per-root 0))))
+  (let [{:keys [mount-one selector]} (get arms arm-id)
+        containers (mapv (fn [_] (container!)) (range k))
+        handles    (into [] (map-indexed (fn [i c] (mount-one c i))) containers)
+        elements   (.-length (.querySelectorAll js/document selector))
+        expected   (* k per-root)]
+    (reset! held {:arm arm-id :handles handles :containers containers})
+    ;; A literal `#js` object rather than `clj->js`, because `clj->js`
+    ;; renders `:ok?` as the key `"ok?"` and the driver reading `verify.ok`
+    ;; would see `undefined` — every mount would report unverified while
+    ;; every mount was in fact fine. It did, on the first run.
+    #js {:elements elements :expected expected :ok (= elements expected)}))
+
+;; ---------------------------------------------------------------------------
+;; The positive control
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private control-cell (atom nil))
+
+(defn control!
+  "Hold a dense JS array of exactly `n` doubles, and answer its length so
+  the allocation cannot be proved dead and elided.
+
+  V8 stores a packed double array as `n` unboxed 8-byte slots behind a
+  small header, so the retained cost is **8n bytes**, PREDICTED rather
+  than merely observed. That is the entire point of a control: a figure
+  the instrument has to hit, not one it gets to report.
+
+  The first draft of this control was a flat one-byte string of `8n`
+  characters, on the same reasoning. **It was wrong, and only running it
+  found that out**: a 4.7 MB `'x'.repeat(…)` reads as 6 KB on all three
+  readers, so V8 is not materialising the characters. Had it shipped, the
+  control would have missed by three orders of magnitude every round and
+  the natural conclusion would have been that the instrument was broken —
+  when the instrument was fine and the control was a fiction. It is
+  recorded here because it is the same class of mistake as the sampling
+  profiler this whole namespace exists to avoid, caught one step earlier."
+  [n]
+  (let [a (js/Array. n)]
+    (dotimes [i n] (aset a i (+ i 0.5)))
+    (reset! control-cell a)
+    (.-length a)))
+
+(defn control-release! [] (reset! control-cell nil) 0)
+
+;; ---------------------------------------------------------------------------
+;; The page-side door
+;; ---------------------------------------------------------------------------
+
+(defn install!
+  "Publish the instrument on `window.B7H` for the CDP driver, which owns
+  the collector and both heap readers. The page mounts; it never decides
+  when a reading is taken."
+  []
+  (set! (.-B7H js/window)
+        #js {:mount          (fn [arm k] (mount! (keyword arm) k))
+             :release        (fn [] (release!*) true)
+             :control        (fn [n] (control! n))
+             :controlRelease (fn [] (control-release!))
+             :perfMem        (fn []
+                               (if-some [m (.-memory js/performance)]
+                                 (.-usedJSHeapSize m)
+                                 -1))
+             :perRoot        per-root})
+  nil)

--- a/implementation/freehand/test/re_frame/freehand/bench/b7_mount_frame.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b7_mount_frame.cljs
@@ -1,0 +1,200 @@
+(ns re-frame.freehand.bench.b7-mount-frame
+  "B7 — what does the `:frame` opt cost inside B6's timed mount window?
+
+  `rf2-prjh0` asks whether B6's published mount row overstates the
+  substrate. Its premise is that B6's Freehand arm passes no `:frame`, so
+  `v/mount` creates a FRESH FRAME per sample inside the `flushSync` the
+  harness is timing, while the floor arm — a bare `createRoot` — never
+  pays it. If that were true a measurable slice of interpreted W1's
+  2.987× would be frame construction rather than view substrate, and a
+  release-gate row would be too harsh.
+
+  **The premise does not survive reading `root.cljs`.** `plan-for`
+  answers `nil` when `opts` carries no `:frame`, and `preflight!` opens
+  `(when (some? plan) …)`. A frameless mount runs no plan, creates no
+  frame, and binds none: `root-element` wraps the root form in the frame
+  provider only `(if (some? frame-id) …)`. So the published arm is not
+  paying for a frame — it is paying for LESS than a mount that names one.
+
+  Which turns the bead's question round, and makes it worth measuring
+  rather than merely answering. Four arms, each one step from the last, so
+  the direction and the size are both readings rather than deductions:
+
+  | arm | `:frame` opt | what it prices |
+  |---|---|---|
+  | `floor` | — | React alone; the in-run calibrator |
+  | `fh-no-frame` | absent | **exactly the published arm** |
+  | `fh-shared-frame` | `:b7mf/shared` (SCOPE) | the studio fixture's shape: ledger read + context provider, no construction |
+  | `fh-frame-per-sample` | `{:id …unique…}` (ENSURE) | the counterfactual — what per-sample frame construction WOULD have cost |
+  | `reagent` | — | the substrate the row is quoted against |
+
+  `fh-shared-frame − fh-no-frame` is the correction the bead asks for and
+  is expected to be NEGATIVE — the published arm is the cheaper shape, so
+  moving to a shared frame cannot flatter it.
+  `fh-frame-per-sample − fh-no-frame` is the bead's feared term, priced so
+  the report can say what the mistake would have been worth had it been
+  real.
+
+  Everything else is B6's instrument unchanged — `b6-harness`'s timed
+  `flushSync`, sample-level interleaving with the order rotating on the
+  sample index, and every figure a ratio to the floor measured in that
+  same round. A second copy of the method would be a second place for it
+  to drift.
+
+  Normative owner: `docs/design/freehand/decisions/`
+  `D021-performance-budgets-and-release-evidence.md`."
+  (:require ["react-dom" :as react-dom]
+            ["react-dom/client" :as react-dom-client]
+            [reagent.dom.client :as rdc]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.bench.b6-floor :as floor]
+            [re-frame.freehand.bench.b6-harness :as h]
+            [re-frame.freehand.bench.b6-reagent :as rg]
+            [re-frame.freehand.bench.b6-rows :as rows]
+            [re-frame.freehand.bench.b6-witnesses :as fh]
+            [re-frame.freehand.bench.provenance :as prov]))
+
+(def shared-frame-id :b7mf/shared)
+
+(defonce ^:private frame-owner
+  (atom nil))
+
+(defn ensure-shared-frame!
+  "Stand a tiny root up over [[shared-frame-id]] and LEAVE IT MOUNTED for
+  the run, so the shared-frame arm can SCOPE a frame that already exists
+  rather than ensure one. Its view is `w2` at `n = 0` — one `div`, so the
+  owner costs a boundary and a frame and contributes nothing to any
+  sample."
+  []
+  (when (nil? @frame-owner)
+    (let [c (js/document.createElement "div")]
+      (.appendChild js/document.body c)
+      (reset! frame-owner
+              (v/mount [fh/w2 {:n 0}] c
+                       {:disambiguator :b7mf/owner
+                        :frame         {:id shared-frame-id}}))))
+  @frame-owner)
+
+;; ---------------------------------------------------------------------------
+;; Arms
+;; ---------------------------------------------------------------------------
+
+(defn- floor-arm [element-of]
+  {:id      :floor
+   :mount   (fn [container props _n]
+              (let [r (react-dom-client/createRoot container)]
+                (.render r (element-of props))
+                r))
+   :unmount (fn [r] (.unmount r))})
+
+(defn- freehand-arm
+  "`frame-opt-of` is handed the sample's mount sequence number and answers
+  the `:frame` opt — `nil` for the published shape, a keyword for the
+  shared scope, a fresh map for the per-sample ensure. It is the ONLY
+  difference between the three Freehand arms, which is what makes the
+  deltas readings of the frame opt and of nothing else."
+  [id view frame-opt-of]
+  {:id      id
+   :mount   (fn [container props n]
+              (v/mount [view props] container
+                       (cond-> {:disambiguator (keyword "b7mf" (str (name id) "-" n))}
+                         (some? (frame-opt-of n)) (assoc :frame (frame-opt-of n)))))
+   :unmount (fn [mounted] (v/unmount! mounted))})
+
+(defn- reagent-arm [form-of]
+  {:id      :reagent
+   :mount   (fn [container props _n]
+              (let [r (rdc/create-root container)]
+                (rdc/render r (form-of props))
+                r))
+   :unmount (fn [r] (rdc/unmount r))})
+
+(defn- arms-for [fh-view floor-of reagent-of]
+  [(floor-arm floor-of)
+   (freehand-arm :fh-no-frame        fh-view (fn [_] nil))
+   (freehand-arm :fh-shared-frame    fh-view (fn [_] shared-frame-id))
+   (freehand-arm :fh-frame-per-sample fh-view (fn [n] {:id (keyword "b7mf" (str "f" n))}))
+   (reagent-arm reagent-of)])
+
+(def witnesses
+  "W1 and W2 — the two mount witnesses whose Freehand arms the bead
+  names. W3 is omitted: its absolute times are 0.3–1.0 ms against a
+  0.1 ms clock quantum, so it cannot resolve a term this small and
+  quoting it would only add a number nobody may read."
+  [{:id       :W1
+    :doc      "a large template — 300 rows under one boundary each, 1,203 elements"
+    :props    {:rows rows/w1-rows}
+    :elements (rows/w1-elements rows/w1-rows)
+    :arms     (arms-for fh/w1
+                        (fn [{:keys [rows]}] (floor/w1 rows))
+                        (fn [{:keys [rows]}] [rg/w1 rows]))}
+   {:id       :W2
+    :doc      "300 sub-free leaf boundaries, 301 elements"
+    :props    {:n rows/w2-n}
+    :elements (rows/w2-elements rows/w2-n)
+    :arms     (arms-for fh/w2
+                        (fn [{:keys [n]}] (floor/w2 n))
+                        (fn [{:keys [n]}] [rg/w2 n]))}])
+
+;; ---------------------------------------------------------------------------
+;; The measurement
+;; ---------------------------------------------------------------------------
+
+(defn parity-problems
+  "Mount every arm at once and answer what disagrees — empty when all five
+  build one page with the written element count. Run before any clock,
+  because three Freehand arms differing only in a `:frame` opt MUST build
+  identical DOM and an arm that did not would be measuring a different
+  page."
+  [{:keys [id arms props elements]}]
+  (let [{:keys [mounts agree? counts disagree]} (h/parity arms props)]
+    (try
+      (cond-> []
+        (not agree?)
+        (conj {:witness id :problem :canonical-dom-disagreement :arms disagree})
+
+        (not (every? #(= elements %) (vals counts)))
+        (conj {:witness id :problem :element-count :expected elements :got counts}))
+      (finally (doseq [m mounts] (h/release! m))))))
+
+(defn measure!
+  "Measure one witness across `rounds` interleaved rounds and answer
+  `{:id … :summary … :record …}`."
+  [{:keys [id doc props arms elements]} rounds sampling]
+  (let [raw     (mapv (fn [_] (h/round! arms props sampling)) (range rounds))
+        norm    (mapv #(h/normalise % :floor) raw)
+        summary (h/across-rounds (mapv :ratio norm))
+        record
+        {:benchmark      (keyword "B7" (str "mount-frame-" (name id)))
+         :doc            doc
+         :bead           :rf2-prjh0
+         :question       (str "does B6's published mount row overstate the substrate because "
+                              "v/mount creates a frame per sample inside the timed window?")
+         :revision       (prov/detect-revision)
+         :build          (prov/detect-build)
+         :host           (prov/detect-host)
+         :fixture        {:witness  id
+                          :props    props
+                          :elements elements
+                          :arms     (mapv :id arms)
+                          :arm-notes
+                          {:fh-no-frame         "EXACTLY the published B6 arm: no :frame opt at all"
+                           :fh-shared-frame     "SCOPE a frame stood up before the run — the studio fixture's shape"
+                           :fh-frame-per-sample "ENSURE a FRESH frame id per sample — the bead's feared counterfactual"}
+                          :measurement-method
+                          (str "b6-harness unchanged: wall time across react-dom/flushSync "
+                               "around each arm's own mount door into a container attached "
+                               "before the window; arms interleaved at the SAMPLE level with "
+                               "the order rotating on the sample index; " rounds " rounds of "
+                               (:warmup sampling) " warmup + " (:samples sampling)
+                               " samples per arm per round; every figure a ratio to the FLOOR "
+                               "measured in that same round")}
+         :sampling       sampling
+         :baseline       {:kind      :within-freehand-ablation
+                          :reference {:arm  :fh-no-frame
+                                      :note "the published B6 arm; the other two Freehand arms differ from it in the :frame opt and nothing else"}}
+         :per-round      {:p50 (mapv :p50 norm) :ratio (mapv :ratio norm)}
+         :ratio-to-floor summary
+         :status         :evidence}]
+    (h/publish! (str "mount-frame / " (name id)) record)
+    {:id id :summary summary :norm norm :record record}))

--- a/implementation/freehand/test/re_frame/freehand/bench/b7_run.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b7_run.cjs
@@ -1,0 +1,503 @@
+#!/usr/bin/env node
+// B7's driver — build the `:advanced` bundle once, then run both rows.
+//
+//   node implementation/freehand/test/re_frame/freehand/bench/b7_run.cjs
+//   node .../b7_run.cjs --only heap
+//   node .../b7_run.cjs --only mount-frame
+//   B7_ROUNDS=6 B7_ROOTS=10 B7_SNAPSHOT=1 node .../b7_run.cjs
+//
+// Two rows, one bundle:
+//
+//   `mount-frame` (rf2-prjh0) runs entirely in the page and prints the
+//   published EDN records.
+//
+//   `heap`       (rf2-9oj7v) runs HERE, because the page cannot force a
+//                garbage collection and therefore cannot decide when a
+//                retained-heap reading is taken. The page only mounts and
+//                holds; this driver collects and reads.
+//
+// THE INSTRUMENT WARNING, which is the reason this file exists at all.
+// V8's CDP SAMPLING heap profiler drops the samples of collected objects,
+// so pointed at a mount/unmount loop it reports the residue of a page that
+// has already been discarded — the same 80,000 objects read 4.77 MB when a
+// global held them and 0.00 MB when nothing did. Nothing here samples
+// allocation. Every figure is a RETENTION reading: mount K roots, keep
+// them, collect, read; release, collect, read again.
+//
+// Three readers, and an honest account of how independent they are:
+//
+//   A  CDP `Runtime.getHeapUsage().usedSize`, after a forced collection.
+//   B  in-page `performance.memory.usedJSHeapSize`, same moment, under
+//      `--enable-precise-memory-info`.
+//   C  a full heap SNAPSHOT, with every node's `self_size` summed by the
+//      streaming scanner below.
+//
+// **A and B are NOT independent of each other**, and this file says so
+// rather than banking two agreeing numbers as corroboration: pointed at
+// 80,000 ordinary held objects they returned the identical figure to the
+// byte (3,868,954 both), because they are two doors onto one V8 counter.
+// C is the reader that is genuinely independent — it walks the object
+// graph and sums what is actually there. It is slow, so it runs as its
+// own pass rather than in every round.
+//
+// And a POSITIVE CONTROL of PREDICTED size rides every round: a dense
+// array of N doubles, which V8 stores as N unboxed 8-byte slots, so the
+// retained cost is 8N bytes before anything is measured. Every round
+// reports predicted against measured on every reader. A number nobody
+// can falsify is not a measurement.
+//
+// The control's own first draft was a 4.7 MB one-byte string, and it
+// read as SIX KILOBYTES on all three readers — V8 does not materialise
+// `'x'.repeat(n)`. The instrument was fine and the control was a
+// fiction. It is worth knowing that a control can fail this way.
+
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const http = require('node:http');
+const path = require('node:path');
+
+const IMPL = path.resolve(__dirname, '../../../../..');
+const OUT = path.join(IMPL, 'out', 'b7');
+const PORT = Number(process.env.B7_PORT || 8131);
+
+const ROUNDS = Number(process.env.B7_ROUNDS || 6);
+const ROOTS = Number(process.env.B7_ROOTS || 10);
+// 587,500 unboxed doubles = 4,700,000 bytes — the same ~4.7 MB the
+// predecessor report's failed sampler reported as 0.00 MB.
+const CONTROL_DOUBLES = Number(process.env.B7_CONTROL_DOUBLES || 587500);
+const CONTROL_PREDICTED = CONTROL_DOUBLES * 8;
+const WANT_SNAPSHOT = process.env.B7_SNAPSHOT !== '0';
+
+const HEAP_ARMS = [
+  'storm/floor',
+  'storm/freehand',
+  'storm/reagent',
+  'storm/uix',
+  'reactive/floor',
+  'reactive/freehand',
+  'reactive/reagent',
+];
+
+const ONLY = (() => {
+  const i = process.argv.indexOf('--only');
+  return i === -1 ? null : process.argv[i + 1];
+})();
+
+// ---------------------------------------------------------------------------
+// Build and serve
+// ---------------------------------------------------------------------------
+
+// ONE LINE, deliberately: shadow-cljs's CLI re-splits `--config-merge` on
+// whitespace when the EDN contains a newline and then reports `EOF while
+// reading` from a fragment.
+const CONFIG_MERGE =
+  '{:output-dir "out/b7" :asset-path "." ' +
+  ':modules {:main {:init-fn re-frame.freehand.bench.b7-app/-main}}}';
+
+function build() {
+  console.error('[b7] building :advanced bundle ...');
+  const runner = path.join(IMPL, 'node_modules', 'shadow-cljs', 'cli', 'runner.js');
+  const r = spawnSync(
+    process.execPath,
+    [runner, 'release', 'freehand-release', '--config-merge', CONFIG_MERGE],
+    { cwd: IMPL, stdio: ['ignore', 'inherit', 'inherit'] }
+  );
+  if (r.status !== 0) {
+    console.error(`[b7] build failed with status ${r.status}`);
+    process.exit(1);
+  }
+}
+
+const MIME = { '.js': 'text/javascript', '.html': 'text/html', '.map': 'application/json' };
+
+function serve() {
+  fs.writeFileSync(
+    path.join(OUT, 'index.html'),
+    '<!doctype html><html><head><meta charset="utf-8"><title>B7</title></head>' +
+      '<body><div id="app"></div><script src="main.js"></script></body></html>'
+  );
+  return http
+    .createServer((req, res) => {
+      const rel = decodeURIComponent(req.url.split('?')[0]);
+      const file = path.join(OUT, rel === '/' ? 'index.html' : rel);
+      if (!file.startsWith(OUT) || !fs.existsSync(file)) {
+        res.writeHead(404).end('not found');
+        return;
+      }
+      res.writeHead(200, { 'content-type': MIME[path.extname(file)] || 'application/octet-stream' });
+      fs.createReadStream(file).pipe(res);
+    })
+    .listen(PORT);
+}
+
+async function newPage(chromium, query) {
+  const browser = await chromium.launch({
+    args: ['--enable-precise-memory-info', '--js-flags=--expose-gc'],
+  });
+  const page = await browser.newPage();
+  page.on('console', (m) => {
+    const t = m.text();
+    if (t.startsWith(';; B7')) console.log(t);
+  });
+  page.on('pageerror', (e) => console.error('[b7] page error:', e.message));
+  await page.goto(`http://127.0.0.1:${PORT}/${query}`, { waitUntil: 'load' });
+  return { browser, page };
+}
+
+// ---------------------------------------------------------------------------
+// The collector and the readers
+// ---------------------------------------------------------------------------
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function makeReaders(page) {
+  const cdp = await page.context().newCDPSession(page);
+  await cdp.send('HeapProfiler.enable');
+  await cdp.send('Runtime.enable');
+
+  // Three collections with a beat between them. One is not enough: React
+  // roots die in stages (fibers, then the host instances they point at),
+  // and a single pass leaves the second stage standing.
+  const gc = async () => {
+    for (let i = 0; i < 3; i++) {
+      await cdp.send('HeapProfiler.collectGarbage');
+      await sleep(80);
+    }
+  };
+
+  const read = async () => {
+    const { usedSize } = await cdp.send('Runtime.getHeapUsage');
+    const perf = await page.evaluate(() => window.B7H.perfMem());
+    return { cdp: usedSize, perf };
+  };
+
+  return { cdp, gc, read };
+}
+
+// Sum every node's `self_size` out of a streaming heap snapshot.
+//
+// The snapshot arrives as JSON text in chunks and can be hundreds of
+// megabytes, so it is never assembled or `JSON.parse`d. The `nodes` array
+// is a flat run of integers, `node_fields` names the stride, and the scan
+// below consumes complete integers per chunk and carries the partial one.
+// This is the only reader here that walks the object graph, which is what
+// makes it a check on the other two rather than a restatement of them.
+function snapshotTotal(cdp) {
+  return new Promise((resolve, reject) => {
+    let phase = 0;
+    let buf = '';
+    let nFields = 0;
+    let selfIdx = -1;
+    let idx = 0;
+    let total = 0;
+    let nodeCount = 0;
+
+    const onChunk = ({ chunk }) => {
+      if (phase === 2) return;
+      buf += chunk;
+      if (phase === 0) {
+        const at = buf.indexOf('"nodes":[');
+        if (at === -1) return;
+        const fm = /"node_fields":\s*\[([^\]]*)\]/.exec(buf.slice(0, at));
+        if (!fm) {
+          phase = 2;
+          reject(new Error('node_fields absent from snapshot header'));
+          return;
+        }
+        const fields = fm[1].split(',').map((s) => s.trim().replace(/^"|"$/g, ''));
+        nFields = fields.length;
+        selfIdx = fields.indexOf('self_size');
+        if (selfIdx < 0) {
+          phase = 2;
+          reject(new Error('self_size absent from node_fields'));
+          return;
+        }
+        buf = buf.slice(at + '"nodes":['.length);
+        phase = 1;
+      }
+      let last = 0;
+      let done = false;
+      for (let i = 0; i < buf.length; i++) {
+        const c = buf.charCodeAt(i);
+        if (c === 44 || c === 93) {
+          const s = buf.slice(last, i);
+          if (s.length) {
+            if (idx % nFields === selfIdx) total += Number(s);
+            if (idx % nFields === 0) nodeCount++;
+            idx++;
+          }
+          last = i + 1;
+          if (c === 93) {
+            done = true;
+            break;
+          }
+        }
+      }
+      buf = done ? '' : buf.slice(last);
+      if (done) phase = 2;
+    };
+
+    cdp.on('HeapProfiler.addHeapSnapshotChunk', onChunk);
+    cdp
+      .send('HeapProfiler.takeHeapSnapshot', { reportProgress: false })
+      .then(() => {
+        cdp.off('HeapProfiler.addHeapSnapshotChunk', onChunk);
+        resolve({ totalSelfSize: total, nodeCount });
+      })
+      .catch((e) => {
+        cdp.off('HeapProfiler.addHeapSnapshotChunk', onChunk);
+        reject(e);
+      });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// The heap row
+// ---------------------------------------------------------------------------
+
+async function heapRow(chromium) {
+  const { browser, page } = await newPage(chromium, '?mode=heap');
+  await page.waitForFunction('window.B7_READY === true || window.B7_ERROR', null, { timeout: 120000 });
+  const err = await page.evaluate('window.B7_ERROR || null');
+  if (err) {
+    await browser.close();
+    throw new Error(`heap page failed to initialise: ${err}`);
+  }
+  const perRoot = await page.evaluate(() => window.B7H.perRoot);
+  const boundaries = ROOTS * perRoot;
+  const { cdp, gc, read } = await makeReaders(page);
+
+  const rounds = [];
+  let unverified = 0;
+  let mounts = 0;
+
+  // A WARM-UP PASS, mounted and released once per arm and never read.
+  // The first mount of any arm allocates things that are not the page and
+  // never go away: compiled code for the paths it just took, inline
+  // caches, interned keywords, one-time module state. Charged to round 1
+  // they read as retention per boundary, and they are not — a smoke run
+  // put 400–700 KB of unreleasable residue on every arm's first mount and
+  // essentially none on its later ones.
+  console.error('[b7] heap warm-up pass ...');
+  for (const arm of HEAP_ARMS) {
+    const v = await page.evaluate(([a, k]) => window.B7H.mount(a, k), [arm, ROOTS]);
+    mounts++;
+    if (!v.ok) unverified++;
+    await page.evaluate(() => window.B7H.release());
+  }
+  await page.evaluate((n) => window.B7H.control(n), CONTROL_DOUBLES);
+  await page.evaluate(() => window.B7H.controlRelease());
+
+  for (let round = 0; round < ROUNDS; round++) {
+    console.error(`[b7] heap round ${round + 1}/${ROUNDS}`);
+
+    // --- the positive control, in situ, before this round's arms ---------
+    await gc();
+    const ctlBefore = await read();
+    const ctlLen = await page.evaluate((n) => window.B7H.control(n), CONTROL_DOUBLES);
+    await gc();
+    const ctlHeld = await read();
+    await page.evaluate(() => window.B7H.controlRelease());
+    await gc();
+    const ctlAfter = await read();
+    const control = {
+      doubles: ctlLen,
+      predictedBytes: CONTROL_PREDICTED,
+      measuredCdp: ctlHeld.cdp - (ctlBefore.cdp + ctlAfter.cdp) / 2,
+      measuredPerf: ctlHeld.perf - (ctlBefore.perf + ctlAfter.perf) / 2,
+      baselineDriftCdp: ctlAfter.cdp - ctlBefore.cdp,
+    };
+
+    // --- the arms, order rotating with the round -------------------------
+    const arms = {};
+    for (let j = 0; j < HEAP_ARMS.length; j++) {
+      const arm = HEAP_ARMS[(j + round) % HEAP_ARMS.length];
+      await gc();
+      const pre = await read();
+      const verify = await page.evaluate(
+        ([a, k]) => window.B7H.mount(a, k),
+        [arm, ROOTS]
+      );
+      mounts++;
+      if (!verify.ok) unverified++;
+      await gc();
+      const held = await read();
+      await page.evaluate(() => window.B7H.release());
+      await gc();
+      const post = await read();
+      arms[arm] = {
+        verify,
+        retainedCdp: held.cdp - pre.cdp,
+        retainedPerf: held.perf - pre.perf,
+        residueCdp: post.cdp - pre.cdp,
+        bytesPerBoundaryCdp: (held.cdp - pre.cdp) / boundaries,
+        bytesPerBoundaryPerf: (held.perf - pre.perf) / boundaries,
+        raw: { pre, held, post },
+      };
+    }
+    rounds.push({ round, control, arms });
+  }
+
+  // --- the independent reader, as its own pass ---------------------------
+  let snapshots = null;
+  if (WANT_SNAPSHOT) {
+    snapshots = {};
+    try {
+      for (const arm of HEAP_ARMS) {
+        console.error(`[b7] snapshot pass: ${arm}`);
+        await gc();
+        const pre = await snapshotTotal(cdp);
+        const verify = await page.evaluate(([a, k]) => window.B7H.mount(a, k), [arm, ROOTS]);
+        mounts++;
+        if (!verify.ok) unverified++;
+        await gc();
+        const held = await snapshotTotal(cdp);
+        await page.evaluate(() => window.B7H.release());
+        snapshots[arm] = {
+          verify,
+          retained: held.totalSelfSize - pre.totalSelfSize,
+          bytesPerBoundary: (held.totalSelfSize - pre.totalSelfSize) / boundaries,
+          nodeDelta: held.nodeCount - pre.nodeCount,
+          raw: { pre, held },
+        };
+      }
+      // The control, read the same independent way.
+      await gc();
+      const cpre = await snapshotTotal(cdp);
+      await page.evaluate((n) => window.B7H.control(n), CONTROL_DOUBLES);
+      await gc();
+      const cheld = await snapshotTotal(cdp);
+      await page.evaluate(() => window.B7H.controlRelease());
+      snapshots.control = {
+        predictedBytes: CONTROL_PREDICTED,
+        measured: cheld.totalSelfSize - cpre.totalSelfSize,
+      };
+    } catch (e) {
+      snapshots = { error: String(e && e.message ? e.message : e) };
+    }
+  }
+
+  await browser.close();
+  return {
+    benchmark: 'B7:heap-per-boundary',
+    bead: 'rf2-9oj7v',
+    roots: ROOTS,
+    perRoot,
+    boundaries,
+    rounds: ROUNDS,
+    arms: HEAP_ARMS,
+    instruments: {
+      A: 'CDP Runtime.getHeapUsage().usedSize after 3x HeapProfiler.collectGarbage',
+      B: 'in-page performance.memory.usedJSHeapSize, same moment, --enable-precise-memory-info',
+      C: 'full heap snapshot, every node self_size summed by a streaming scan (own pass)',
+      note:
+        'A and B are two doors onto one V8 counter and are NOT independent — on 80,000 held ' +
+        'objects they returned 3868954 both. C walks the object graph and is the independent one.',
+    },
+    control: { shape: 'dense JS array of doubles', doubles: CONTROL_DOUBLES, predictedBytes: CONTROL_PREDICTED },
+    verification: { mounts, unverified },
+    perRound: rounds,
+    snapshots,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The mount-frame row
+// ---------------------------------------------------------------------------
+
+async function mountFrameRow(chromium) {
+  const q = process.env.B7_MOUNT_QUERY || '';
+  const { browser, page } = await newPage(chromium, `?mode=mount-frame${q}`);
+  await page.waitForFunction('window.B7_DONE === true || window.B7_ERROR', null, {
+    timeout: 15 * 60 * 1000,
+  });
+  const err = await page.evaluate('window.B7_ERROR || null');
+  const results = await page.evaluate('window.B7_RESULTS || {}');
+  await browser.close();
+  return { err, results };
+}
+
+// ---------------------------------------------------------------------------
+
+function summariseHeap(row) {
+  const stat = (xs) => {
+    const s = [...xs].sort((a, b) => a - b);
+    const mean = s.reduce((a, b) => a + b, 0) / s.length;
+    return { mean, min: s[0], max: s[s.length - 1] };
+  };
+  console.log('\n;; ==== B7 HEAP — retained bytes per boundary ====');
+  console.log(`;; ${row.roots} roots x ${row.perRoot} boundaries = ${row.boundaries} boundaries held`);
+  const ctlPred = row.perRound[0].control.predictedBytes;
+  const ctlA = stat(row.perRound.map((r) => r.control.measuredCdp));
+  const ctlB = stat(row.perRound.map((r) => r.control.measuredPerf));
+  console.log(
+    `;; positive control: predicted ${ctlPred} B  |  A measured ${Math.round(ctlA.mean)} B ` +
+      `[${Math.round(ctlA.min)}–${Math.round(ctlA.max)}]  |  B measured ${Math.round(ctlB.mean)} B ` +
+      `[${Math.round(ctlB.min)}–${Math.round(ctlB.max)}]`
+  );
+  if (row.snapshots && row.snapshots.control) {
+    console.log(
+      `;; positive control, instrument C: predicted ${row.snapshots.control.predictedBytes} B  |  ` +
+        `measured ${row.snapshots.control.measured} B`
+    );
+  }
+  console.log(`;; verification: ${row.verification.unverified} unverified of ${row.verification.mounts} mounts`);
+  console.log(';;');
+  console.log(';; arm                 A B/boundary [min-max]        B B/bnd    C B/bnd    residue B (mean)');
+  for (const arm of row.arms) {
+    const a = stat(row.perRound.map((r) => r.arms[arm].bytesPerBoundaryCdp));
+    const b = stat(row.perRound.map((r) => r.arms[arm].bytesPerBoundaryPerf));
+    const res = stat(row.perRound.map((r) => r.arms[arm].residueCdp));
+    const c =
+      row.snapshots && row.snapshots[arm] ? Math.round(row.snapshots[arm].bytesPerBoundary) : null;
+    console.log(
+      `;; ${arm.padEnd(20)} ${String(Math.round(a.mean)).padStart(6)} ` +
+        `[${Math.round(a.min)}–${Math.round(a.max)}]`.padEnd(18) +
+        `${String(Math.round(b.mean)).padStart(8)}   ${String(c === null ? '-' : c).padStart(8)}   ` +
+        `${String(Math.round(res.mean)).padStart(10)}`
+    );
+  }
+}
+
+(async () => {
+  build();
+  const server = serve();
+  const { chromium } = require('playwright');
+  const out = { generatedAt: new Date().toISOString() };
+  let failed = null;
+  try {
+    if (ONLY !== 'heap') {
+      console.error('[b7] mount-frame row ...');
+      const mf = await mountFrameRow(chromium);
+      out.mountFrame = mf.results;
+      for (const [k, v] of Object.entries(mf.results)) {
+        console.log(`;; ==== B7 mount-frame ${k} ====`);
+        console.log(v);
+      }
+      if (mf.err) failed = `mount-frame: ${mf.err}`;
+    }
+    if (ONLY !== 'mount-frame') {
+      console.error('[b7] heap row ...');
+      out.heap = await heapRow(chromium);
+      summariseHeap(out.heap);
+      if (out.heap.verification.unverified > 0) {
+        failed = `heap: ${out.heap.verification.unverified} unverified mounts`;
+      }
+    }
+  } catch (e) {
+    failed = String(e && e.stack ? e.stack : e);
+  } finally {
+    server.close();
+  }
+  const raw = process.env.B7_RAW_OUT;
+  if (raw) {
+    fs.mkdirSync(path.dirname(raw), { recursive: true });
+    fs.writeFileSync(raw, JSON.stringify(out, null, 2));
+    console.error(`[b7] raw data -> ${raw}`);
+  }
+  if (failed) {
+    console.error(`[b7] FAILED: ${failed}`);
+    process.exit(1);
+  }
+  console.error('[b7] ok');
+})();


### PR DESCRIPTION
Two P1 beads, one instrument surface. **The headline result is against Freehand** and is reported as such.

## 1. Freehand loses on memory (rf2-9oj7v)

Memory was the one axis never measured across substrates, and the hypothesis was that it might be where Freehand's design wins outright. **It is falsified.**

Retained bytes per boundary, **above the React floor**, 10 roots x 300 boundaries held, 6 rounds:

| witness | Freehand | Reagent | UIx | ratio |
|---|---:|---:|---:|---|
| a boundary that reads **nothing** | **2,430** [2,417-2,450] | 410 [406-416] | 251 [248-255] | **5.93x** Reagent, **9.67x** UIx |
| a boundary reading its own signal | **4,346** [4,332-4,361] | 1,037 [1,035-1,039] | - | **4.19x** Reagent |

Every range disjoint. Two independent readers agree to within 1% on every row.

**The usual rebuttal does not save it.** The standing answer to a cross-substrate gap is that the Freehand arm reads `app-db` through a subscription graph while Reagent reads a bare ratom, so it carries more framework — that is how `freehand-vs-reagent.md` §2a cut the narrow-update result from 15x to parity. Here the **widest** gap is on the witness with no reactivity, no `app-db` and no cursor on either side. Going reactive **narrows** the ratio, because Freehand's increment for a signal is 3.06x Reagent's while its wrapper is 5.93x. The larger term is the ViewCell, which is Freehand's own.

Corroborates the within-Freehand ablation from a different instrument and basis: 2,430 B here against its 2,348 B per kept ViewCell, 4,346 against its 4,134 for a reactive boundary. So `rf2-9oj7v` is answered in its own terms too — **B2's elided boundary is worth 2,430 bytes of standing heap**, and the count it gates can now be multiplied out.

### The instrument, because a previous one was wrong

Nothing samples allocation. V8's CDP sampling profiler drops the samples of collected objects, so pointed at a mount/unmount loop it reports the residue of a discarded page. Every figure is **retention**: mount K roots and keep them, collect, read; release, collect, read again.

Three readers, with an honest account of their independence: CDP `Runtime.getHeapUsage` and `performance.memory` are **two doors onto one V8 counter** (3,868,954 both, to the byte, on 80,000 held objects) and are not corroboration. A **heap snapshot with every node's `self_size` summed by a streaming scan** walks the object graph and is the independent one.

A **positive control of predicted size rides every round**: 587,500 unboxed doubles = 4,700,000 bytes, known before measurement.

| control | predicted | measured | error |
|---|---:|---:|---:|
| CDP usedSize | 4,700,000 B | 4,692,044 B | -0.17% |
| snapshot self_size | 4,700,000 B | 4,700,024 B | **+0.0005%** |

The control's first draft was a 4.7 MB `'x'.repeat(n)` string and read as **six kilobytes** on all three readers — V8 does not materialise it. It would have missed by three orders of magnitude every round and looked exactly like a broken instrument. Documented in the source, because it is the argument for running a control rather than reasoning one out.

**0 unverified of 56 mounts** — every mount's boundary elements counted at the DOM against `K x 300`.

## 2. The mount row does not overstate — null result (rf2-prjh0)

The bead's premise is that B6's Freehand arm passes no `:frame` so `v/mount` creates a fresh frame per sample inside the timed `flushSync`. **It does not.** `plan-for` answers `nil` with no `:frame`, `preflight!` opens `(when (some? plan) ...)`, and the provider wraps only `(if (some? frame-id) ...)`. A frameless mount runs no plan and creates no frame.

Measured anyway, four arms differing only in the `:frame` opt, B6's harness unchanged:

| paired, per round | W1 | W2 |
|---|---|---|
| shared pre-created frame vs published arm | **+3.8%**, higher in **6 of 6** rounds | **+10.9%**, 6 of 6 |
| fresh frame per sample vs published arm | +7.4%, 6 of 6 | +13.8%, 5 of 6 |

The published arm is the **cheapest** of the three shapes. Ranges overlap, so the paired within-round comparison is what carries it — and 6/6 in one direction is a real effect whose direction is the opposite of the bead's. **No published figure changes.** Had the bug been real it would have been worth 7.4% against a 2x gap.

The row also **reproduced** against current `main` (including PR #7133's extra React commit): Reagent W1 at 1.545 [1.471-1.647] against the published 1.554 [1.520-1.583]; interpreted Freehand W1 at 3.109 [2.889-3.588] against 2.987 [2.840-3.167].

## What this does not cover

Heap **under update** is unmeasured, and it is the one memory question with an argument left in it for Freehand — a fine-grained substrate can trade standing bytes for churn. Also: JS heap only (the floor subtraction is what makes that safe), retention cannot see transient garbage, no compiled tier, no UIx on the reactive witness, two purpose-built witnesses on a loaded workstation.

## Quality gates

| gate | exit |
|---|---|
| `npm run test:cljs` (11,794 tests / 58,711 assertions, 0 failures, 0 errors) | **0** |
| `clojure -M:test` in `implementation/freehand` (1,218 tests / 8,212 assertions, 0 failures, 0 errors) | **0** |
| `b7_run.cjs --only heap` — 6 rounds, snapshot pass, 0 unverified of 56 | **0** |
| `b7_run.cjs --only mount-frame` — parity green, 6 rounds x (5 warm-up + 20 samples) | **0** |
| `mkdocs build --strict` | **not run** — `mkdocs` is not on this box's PATH; deferred to CI |

Slower gates (full spine, browser suite, bundle/perf gates) deferred to CI. The bench runs above are the subject of the change rather than a gate on it, and are reported with their exit codes for that reason.

Beads: `rf2-9oj7v`, `rf2-prjh0`. Raw per-round data in `ai/findings/2026-07-27.b7-heap-raw.json` and `2026-07-27.b7-mountframe-raw.json` (local-only tree, not committed).
