### PR TITLE
perf(freehand): split the render candidate's ledger into two fields

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/cell.cljc
+++ b/implementation/freehand/src/re_frame/freehand/cell.cljc
@@ -220,7 +220,15 @@
 ;; The render candidate — a value the caller holds
 ;; ---------------------------------------------------------------------------
 
-(deftype RenderCandidate [cell generation frame incarnation reads events sites thread])
+;; THE LEDGER IS TWO FIELDS, NOT ONE WRAPPER. `order` is the render order —
+;; the site keys as the walk reached them — and `by-site` is what each of
+;; those sites read. They are written by the same [[record-read!]] and read
+;; by the same [[commit!]], but nothing ever wants them as one value: the
+;; commit destructures them apart again on the first line. Holding them in
+;; one map instead cost a rebuilt wrapper per read — `update :order conj`
+;; answered one throwaway map and `assoc-in [:by-site …]` answered another,
+;; and neither was ever read.
+(deftype RenderCandidate [cell generation frame incarnation order by-site events sites thread])
 
 (defn candidate?
   "True when `x` is a [[candidate]]."
@@ -247,7 +255,8 @@
                        (:generation s)
                        frame
                        (when (some? frame) (frame/frame-incarnation-token frame))
-                       (volatile! {:order [] :by-site {}})
+                       (volatile! [])
+                       (volatile! {})
                        (events/candidate (:events s))
                        (volatile! 0)
                        (render-thread))))
@@ -283,7 +292,7 @@
   recorded — an inspection seam for tools and tests, never a
   publication."
   [^RenderCandidate cand]
-  (:by-site @(.-reads cand)))
+  @(.-by-site cand))
 
 ;; ---------------------------------------------------------------------------
 ;; Ambient capture — the one thing that cannot be threaded
@@ -365,19 +374,15 @@
   and no disposal obligation."
   [^RenderCandidate cand site-key query]
   (let [^ViewCell owner-cell (.-cell cand)
-        reads     (.-reads cand)
         prior     (get (:deps @(st owner-cell)) site-key)
         query*    (if (and prior (eq/rf= query (:query prior))) (:query prior) query)
         target    (obs/resolve-target {:query-v query*})
         ev        (obs/probe target)
         v         (:value ev)
         v*        (if (and prior (eq/rf= v (:value prior))) (:value prior) v)]
-    (vswap! reads
-            (fn [r]
-              (-> r
-                  (update :order conj site-key)
-                  (assoc-in [:by-site site-key]
-                            {:query query* :target target :evidence ev :value v*}))))
+    (vswap! (.-order cand) conj site-key)
+    (vswap! (.-by-site cand) assoc site-key
+            {:query query* :target target :evidence ev :value v*})
     v*))
 
 (defn observe!
@@ -409,7 +414,7 @@
     (when (nil? cand)
       (read-outside-render! query))
     (ensure-render-thread! cand query)
-    (record-read! cand (count (:order @(.-reads cand))) query)))
+    (record-read! cand (count @(.-order cand)) query)))
 
 (defn observe-site!
   "The SAME render-time read as [[observe!]], recorded under the site key
@@ -1260,9 +1265,10 @@
         s0                   @(st owner-cell)]
     (if-not (current? cand s0)
       :abandoned
-      (let [{:keys [order by-site]} @(.-reads cand)
-            prior  (:deps s0)
-            fid    (.-frame cand)
+      (let [order   @(.-order cand)
+            by-site @(.-by-site cand)
+            prior   (:deps s0)
+            fid     (.-frame cand)
             {:keys [staged acquired]} (stage! owner-cell prior order by-site)
             ;; The commit-side reads are part of the pre-publication
             ;; TRANSACTION, not a step past it. `obs/read` is a fail-loud
@@ -1324,7 +1330,7 @@
             ;; live against this exact frame with no host yield between
             ;; them — nothing can observe a partial bundle.
             ;; `order` is the candidate's own render order and is already a
-            ;; vector — the reads volatile opens at `[]` and only ever
+            ;; vector — the order volatile opens at `[]` and only ever
             ;; `conj`es — so it is published as it stands. Sharing it is safe
             ;; whatever the candidate does next: a persistent vector's `conj`
             ;; answers a new vector and cannot reach this one.


### PR DESCRIPTION
Closes rf2-21pck.

`record-read!` held the render candidate's ledger in ONE volatile carrying
`{:order [] :by-site {}}`, and wrote it with

```clj
(vswap! reads (fn [r] (-> r (update :order conj site-key)
                            (assoc-in [:by-site site-key] {…}))))
```

`update` answered one rebuilt wrapper map and `assoc-in` answered another,
plus the path vector and the seq its destructuring took. **None of the four
was ever read.** `commit!` destructures the wrapper apart again on its first
line and `candidate-reads` projects one key out of it — nothing anywhere
wants the two halves as one value. The candidate now carries `order` and
`by-site` as two volatiles, so a read is one vector `conj` and one map
`assoc` and no wrapper at all.

Behaviour is unchanged: same site keys, same render order, same
stabilization, same published bundle. Only the container the render
accumulates into moved.

## What this does NOT do

**It does not move the B6 broad-update row, and it was never going to.**
The render leg is ~19% of the 4.05 ms broad-update window (PR #7139's
profile) and this takes 6% off its allocation, so the window sees about 1%
— an order of magnitude under the row's ±15% round noise. The row is
reported below as the honest check, not as a result.

## Before / after

Two instruments. The sharp one is a JVM microbench of the render leg in
isolation at 300 dependencies, production-gated (`-Dre-frame.debug=false`
— `interop/debug-enabled?` defaults to TRUE on the JVM and an ungated run
times a dev plane Closure DCEs out of the artefact B6 measures), 4 runs per
arm INTERLEAVED across separate JVMs, 8 rounds each. The honest check is
B6's production row, 4 whole runs interleaved, 6 rounds each.

### clock

| | rounds | render-leg p50 range | B6 broad, freehand ÷ reagent same round |
|---|---|---|---|
| BEFORE | 32 / 12 | 473.7 – 610.4 µs | 7.80 – 11.25 (mean 9.42) |
| AFTER | 32 / 12 | 454.9 – 596.0 µs | 8.60 – 11.25 (mean 9.73) |

**Both overlap almost entirely — INDISTINGUISHABLE on both instruments.**
The render-leg median is 9.4% lower, but one AFTER run is worse than three
of the four BEFORE runs, and B6's AFTER mean is marginally *worse*. Neither
is quoted as a win.

### allocation

Measured with `com.sun.management.ThreadMXBean/getThreadAllocatedBytes`
over 200 renders per round — exact TLAB accounting, not a sampling
profiler.

| | rounds | bytes per render | per dependency |
|---|---|---|---|
| BEFORE | 24 | **1 347 936 – 1 347 976** | 4493.1 B |
| AFTER | 32 | **1 266 288 – 1 266 288** | 4221.0 B |

**Disjoint by ~2000× the within-arm spread: −81 672 B per render, −6.06%,
−272.1 B per read.** The reading is identical *to the byte* in every round
of every run.

The control that makes that mean something: an ablation arm in the same
process measuring `resolve-target` + `probe` with no ledger at all reads
**1 095 448 B before and 1 095 400 B after — 48 bytes apart in 1.1 MB.**
The observation port did not move; the entire delta is the ledger.

Zero-read positive control: 0.4–0.8 µs and ~1.4 KB against the
300-dependency render's ~500 µs and ~1.3 MB. Verification: every timed
render's site count and its first and last site's observed value read back
out of `candidate-reads` — `unverified 0 of 5200` in every run, and
`unverified-writes 0` in every B6 update-broad row.

So yes: the 600 throwaway maps per render are gone, and there were another
~43 KB of `assoc-in` path vectors and destructuring seqs with them.

**Retained heap is unchanged, by construction.** Every object removed is
garbage that dies inside `record-read!`; nothing that survives a commit
changed shape. This cuts GC pressure, and it contributes nothing to the
cross-substrate retention question (rf2-9oj7v) — it should not be counted
toward it.

## The decision on the representation

The bead asks for one, and names a `js/Map` store behind a reader
conditional. Measured, all four candidates in one process against the real
port and a real 300-entry prior committed set — ledger write only:

| representation | B/read | % of shipped |
|---|---|---|
| shipped — one volatile, `update` + `assoc-in` | 758.7 | 100% |
| **two volatiles, persistent — THIS PR** | **462.4** | **60.9%** |
| two volatiles holding TRANSIENTS | 63.4 | 8.4% |
| `ArrayList` + `HashMap` (the js-array/js-Map shape) | 78.9 | 10.4% |

Two findings, and then the ruling.

**The bead's named representation is the wrong mutable store.** Clojure
transients beat host-mutable collections here — 63.4 vs 78.9 B/read — and
need no reader conditional, no host split, and no new concept: `stage!` in
this same file already accumulates through a transient and already
documents why ("a value under construction that no other code can reach
until this function returns it"). If a mutable ledger is ever ruled in it
is transients, not `js/Map`.

**And they are rejected here, on clarity.** A transient ledger cannot be
sealed by `commit!`, because `persistent!` is one-shot and `commit!` runs
TWICE on one candidate under React StrictMode's mount/cleanup/mount replay
— the path `current?`'s docstring already names. The seal would have to
move into `with-capture`'s `finally`, introducing a lifecycle rule that
does not exist today ("the ledger is transient for exactly the extent of
the render body") plus a latent throw for any candidate that reaches
`commit!` without having passed through a capture. That buys another 8.7%
of the render leg's allocation — about 1.7% of the broad-update window,
under every instrument in this repository.

The change in this PR is a strict clarity gain instead: two direct `vswap!`s
replace a `->` threading `update` and `assoc-in` through an anonymous
rebuild fn, and `observe!`'s site key goes from
`(count (:order @(.-reads cand)))` to `(count @(.-order cand))`.

## The finding this leaves on the table

**The observation port is 81.5% of the render leg's allocation.** Same
attribution run: `resolve-target` + `probe` alone cost 1 119 944 of the
1 374 416 bytes a 300-dependency render allocates — 3733 B per dependency,
for a subscription whose entire body is `(get-in db [:items i])`. The
stabilization is 2.0% and the ledger write is 16.6%.

That is where this leg's cost actually lives, it is in
`re-frame.substrate.observation` and the sub-cache rather than in Freehand,
and it is outside this bead's fence. Worth its own bead.

## Quality gates

Focused gates, foreground, run to completion:

| gate | exit | result |
|---|---|---|
| `implementation/freehand` JVM — `clojure -M:test` | 0 | 1220 tests / 8225 assertions |
| invariant-5 axis row, run alone | 0 | 1 test / 5 assertions |
| `npm run test:cljs` | 0 | 11796 tests / 58722 assertions |
| `BROWSER_TEST_TIMEOUT_MS=600000 npm run test:browser` | 0 | 833 tests / 5313 assertions |
| `b6_prod_run.cjs` × 4 (before/after ×2) | 0 | 0 unverified writes in every update-broad row |

PR #7143's two invariant-5 rows are in that freehand JVM suite and green;
the axis row was also run alone to be sure it was reached. Nothing in this
change goes near the commit-side re-read — the tear check is untouched, and
so is `record-read!`'s stabilization: a retained record still carries its
own render's `:value` and `:evidence`, and no identity is reused across
renders.

Deferred to CI: the full spine, `test-jvm-implementation`, `test-jvm-tools`,
the Xray feature-matrix gate, bundle isolation, the perf-bundle gate and
mcp-conformance.

## What the measurement does not cover

- **JVM, not ClojureScript.** The allocation figures are `clojure.lang`
  persistent collections under HotSpot. The code is `.cljc` and identical
  on both hosts, so the *shape* of the win transfers — 600 fewer
  allocations per 300-read render is a source fact — but the byte figures
  do not, and V8's escape analysis may already have removed some of them.
- **One boundary, 300 dependencies, all values moving.** That is the broad
  update B6 measures. A narrow update, where stabilization returns the
  prior value and most sites are unchanged, was not measured on this leg.
- **`:advanced` DCE.** The B6 row is the only reading taken from a
  production bundle, and it cannot resolve a change this size.
