### PR TITLE
test(routing): split dev instrumentation from semantics so the prod-gate lane can grow (rf2-o5dbf)

### DIFF
--- a/implementation/routing/test/re_frame/route_algebra_view_test.clj
+++ b/implementation/routing/test/re_frame/route_algebra_view_test.clj
@@ -25,10 +25,28 @@
   live in the bundle-isolated `re-frame.routing.tooling` sibling, reached on
   JVM through the `re-frame.routing/route-algebra-view` convenience alias, and
   consumed by Xray + the conformance fixtures. There is no
-  `re-frame.core/route-algebra-view` public facade export."
+  `re-frame.core/route-algebra-view` public facade export.
+
+  ## Posture split (rf2-o5dbf)
+
+  The node SHAPE is production-real and carries no posture guard: the
+  classifications, the `:rf/route` fact id, the inputs / output / source-form,
+  the resource activation edge and the live slice projection all run in the
+  ordinary `clojure -M:test` suite AND in `scripts/test-routing-prod-gate.sh`
+  (the `-Dre-frame.debug=false` lane).
+
+  Two leaf slots are NOT: `:source` and `:doc`. Source coords are captured
+  behind `interop/debug-enabled?` (Spec 001 §Source-coordinate capture), and
+  `:doc` is a pure-documentation key the registrar STRIPS before storage in
+  production builds (Spec 001 §Production elision contract, registrar.cljc
+  §573-580) so its string bytes DCE out of the bundle. Both deftests below
+  therefore branch: the dev arm keeps the presence assertions VERBATIM, and
+  the production arm asserts the ELISION — that the strip really happened.
+  Neither arm is vacuous; nothing was deleted or weakened."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
             [re-frame.routing :as routing]
             [re-frame.routing.test-support]
@@ -257,15 +275,31 @@
     (rf/reg-route :route/home {} "/")
     (let [node   ((routing-tooling/route-algebra-view) :route/home)
           source (:source node)]
-      (is (some? source) ":source map is present when the registration carried coords")
-      (is (some? (:ns source))     ":ns captured at the call site")
-      (is (number? (:line source)) ":line captured at the call site")
-      (is (some? (:file source))   ":file captured at the call site"))))
+      (if interop/debug-enabled?
+        ;; rf2-o5dbf — dev arm (see ns docstring), kept verbatim.
+        (do
+          (is (some? source) ":source map is present when the registration carried coords")
+          (is (some? (:ns source))     ":ns captured at the call site")
+          (is (number? (:line source)) ":line captured at the call site")
+          (is (some? (:file source))   ":file captured at the call site"))
+        ;; rf2-o5dbf — production arm: coord capture is DCE'd, so the node
+        ;; carries no `:source` at all. The rest of the node is unaffected.
+        (do
+          (is (nil? source)
+              "under -Dre-frame.debug=false the coords are elided (Spec 001)")
+          (is (= {:kind :reg-route :id :route/home} (:source-form node))
+              "…and the node itself is otherwise intact"))))))
 
 (deftest doc-passes-through
   (testing ":doc supplied on the route metadata surfaces in the node"
     (rf/reg-route :route/home {:doc "the home route"} "/")
-    (is (= "the home route" (:doc ((routing-tooling/route-algebra-view) :route/home))))))
+    (if interop/debug-enabled?
+      ;; rf2-o5dbf — dev arm (see ns docstring), kept verbatim.
+      (is (= "the home route" (:doc ((routing-tooling/route-algebra-view) :route/home))))
+      ;; rf2-o5dbf — production arm: `:doc` is stripped BEFORE storage so its
+      ;; string bytes leave the bundle, so the node cannot carry it.
+      (is (not (contains? ((routing-tooling/route-algebra-view) :route/home) :doc))
+          "under -Dre-frame.debug=false the registrar strips :doc before storage"))))
 
 (deftest no-doc-when-absent
   (testing ":doc is absent when the registration didn't supply it"

--- a/implementation/routing/test/re_frame/routing_boundary_totality_cljs_test.cljc
+++ b/implementation/routing/test/re_frame/routing_boundary_totality_cljs_test.cljc
@@ -11,13 +11,35 @@
   host-symmetric order. The non-map / missing-`:to` route-url guards are pinned
   here too so a future host divergence would fail the CLJS runner. The
   JVM-rich behavioural cases (slice-unchanged, no-push, the other `:reason`
-  discriminators) live in routing_navigation_test.clj + routing_registry_test.clj."
+  discriminators) live in routing_navigation_test.clj + routing_registry_test.clj.
+
+  ## Posture split (rf2-o5dbf)
+
+  Both boundaries are ALWAYS-ON and production-surviving, and both are
+  asserted here WITHOUT a posture guard. `route-url` THROWS, so its three
+  tests were already posture-independent. `navigate` rejects by returning
+  `{}` from the handler after the always-on structural gate
+  (`re-frame.routing.address/classify`) — a distinct channel from the
+  dev-only schemas validation one (navigate.cljc §236-250) — so the
+  rejection, the canonical `:keys` ordering and the unchanged slice are all
+  readable in production. The total-order property in particular is a
+  property of `classify` itself, a pure always-on function, and is now
+  asserted on it directly.
+
+  What is dev-only is the `:rf.error/navigate-bad-request` TRACE the gate
+  emits: `trace/emit-error!` sits behind `interop/debug-enabled?`, read once
+  at load time, so under `-Dre-frame.debug=false` the framework emits nothing
+  BY DESIGN. Those assertions are kept VERBATIM inside a
+  `(when interop/debug-enabled? …)` arm marked `rf2-o5dbf`. Nothing was
+  deleted or weakened."
   (:require
    #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
       :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
    [re-frame.core :as rf]
    [re-frame.identity :as identity]
+   [re-frame.interop :as interop]
    [re-frame.routing :as routing]
+   [re-frame.routing.address :as address]
    [re-frame.test-support :as test-support]
    #?(:clj  [re-frame.substrate.plain-atom :as substrate]
       :cljs [re-frame.adapter.reagent :as substrate])))
@@ -83,8 +105,27 @@
             on both hosts"
     ;; :a/b, "s", and 3 are unknown keys of DIFFERENT kinds — a plain
     ;; `(sort #{:a/b \"s\" 3})` throws a ClassCastException on the JVM.
-    (let [err (navigate-error {:to :route/gate :a/b 1 "s" 2 3 4})]
-      (is (some? err) ":rf.error/navigate-bad-request emitted (no raw compare throw)")
-      (is (= :unknown-keys (-> err :tags :reason)))
+    (let [request {:to :route/gate :a/b 1 "s" 2 3 4}
+          ;; SEMANTIC, posture-independent (rf2-o5dbf): the total order is a
+          ;; property of the ALWAYS-ON structural gate, not of the diagnostic.
+          ;; Assert it on `classify` directly — this is the assertion that
+          ;; would have caught the raw-`compare` throw, and it survives
+          ;; -Dre-frame.debug=false because `classify` does.
+          bad     (address/classify request nil)
+          err     (navigate-error request)]
+      (is (= :unknown-keys (:reason bad))
+          "the always-on structural gate classifies the request :unknown-keys")
       (is (= (vec (sort-by identity/canonical-bytes #{:a/b "s" 3}))
-             (-> err :tags :keys))))))
+             (:keys bad))
+          "…and orders the offending keys by CEDN-1 identity (no raw compare throw)")
+      ;; …and the REJECTION really held: the dispatch above completed without
+      ;; a host throw and left no route slice behind.
+      (is (nil? (get-in (:rf.db/runtime (rf/frame-state-value :rf/default))
+                        [:rf.runtime/routing :current]))
+          "the rejected navigate left the route slice unchanged (no commit)")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (some? err) ":rf.error/navigate-bad-request emitted (no raw compare throw)")
+        (is (= :unknown-keys (-> err :tags :reason)))
+        (is (= (vec (sort-by identity/canonical-bytes #{:a/b "s" 3}))
+               (-> err :tags :keys)))))))

--- a/implementation/routing/test/re_frame/routing_can_leave_test.clj
+++ b/implementation/routing/test/re_frame/routing_can_leave_test.clj
@@ -2,11 +2,38 @@
   "Leave-guard + pending-navigation protocol tests for re-frame.routing
   (`:can-leave`, `:rf/pending-navigation`, `:rf.route/continue` /
   `:rf.route/cancel` / `:rf.route/navigation-blocked`). Split from
-  routing_test.clj per rf2-u8qe7y finding 3."
+  routing_test.clj per rf2-u8qe7y finding 3.
+
+  ## Posture split (rf2-o5dbf)
+
+  Leave-guard SEMANTICS are production-real and are asserted here WITHOUT a
+  posture guard: a rejecting `:can-leave` blocks the transition, a truthy
+  NON-BOOLEAN return fails CLOSED (rf2-5pyyl), the `:rf/pending-navigation`
+  slot is written with `:rejecting-route` / `:rejecting-guard` /
+  `:requested-url`, an unbound `:subs/subscribe-once` hook degrades to
+  ALLOW, and an external URL never touches the routing slice. Those run in
+  the ordinary `clojure -M:test` suite AND in
+  `scripts/test-routing-prod-gate.sh` (the `-Dre-frame.debug=false` lane).
+
+  The `:trace` stream several of them were previously observed THROUGH is not
+  production-real: every `trace/emit!` / `trace/emit-error!` site sits behind
+  `interop/debug-enabled?`, read once at load time, so under the real gate the
+  framework emits nothing here BY DESIGN. Those assertions are correct
+  dev-posture coverage and are kept VERBATIM inside `(when
+  interop/debug-enabled? …)` arms marked `rf2-o5dbf`.
+
+  Where the trace was the ONLY witness — the four rf2-dbmj6x `:frame`-stamp
+  tests and `navigation-blocked-trace-carries-rejecting-guard` — a
+  production-visible witness was ADDED rather than the assertion dropped: the
+  same facts are readable off the frame's runtime-db, because
+  `re-frame.routing.decisions/decide` writes `:rejecting-route` and
+  `:rejecting-guard` into the pending-navigation slot itself. Nothing was
+  deleted or weakened."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.events :as events]
             [re-frame.fx :as fx]
+            [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
             [re-frame.routing :as routing]
             [re-frame.routing.registry :as registry]
@@ -185,11 +212,21 @@
       (rf/register-listener! :trace ::blocked (fn [ev] (swap! traces conj ev)))
       (rf/dispatch-sync [:rf.route/url-requested {:url "/cart"}])
       (rf/unregister-listener! :trace ::blocked)
-      (is (some (fn [ev]
-                  (and (= :rf.route/navigation-blocked (:operation ev))
-                       (= :editor/can-leave? (-> ev :tags :rejecting-guard))))
-                @traces)
-          "navigation-blocked trace tags include :rejecting-guard"))))
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): the rejecting sub-id is not
+      ;; a trace-only fact — `decisions/decide` writes it into the pending-nav
+      ;; slot, which is runtime-db state the `:rf/pending-navigation` sub reads
+      ;; in production. Tooling reading it off the trace is the dev restatement.
+      (is (= :editor/can-leave?
+             (get-in (:rf.db/runtime (rf/frame-state-value :rf/default))
+                     [:rf.runtime/routing :pending-navigation :rejecting-guard]))
+          "the pending-navigation slot names the rejecting guard sub-id")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (some (fn [ev]
+                    (and (= :rf.route/navigation-blocked (:operation ev))
+                         (= :editor/can-leave? (-> ev :tags :rejecting-guard))))
+                  @traces)
+            "navigation-blocked trace tags include :rejecting-guard")))))
 
 ;; ---- rf2-yursn: :rf.route/continue re-issues :rf.route/url-requested ----------
 ;;
@@ -390,11 +427,21 @@
       (rf/register-listener! :trace ::nb-id (fn [ev] (swap! traces conj ev)))
       (rf/dispatch-sync [:rf.route/url-requested {:url "/cart"}])
       (rf/unregister-listener! :trace ::nb-id)
-      (let [nb (first (filter #(= :rf.error/can-leave-non-boolean (:operation %))
-                              @traces))]
-        (is (some? nb) ":rf.error/can-leave-non-boolean fired")
-        (is (= :editor/article (-> nb :tags :route-id))
-            ":route-id is the route-id KEYWORD, not the \"/editor/articles/:id\" path string")))))
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): the "route-id keyword, not
+      ;; the :path pattern string" fact has a production-visible restatement —
+      ;; the pending-nav slot's `:rejecting-route` is written from the same
+      ;; `(:route-id current)` the trace tags.
+      (is (= :editor/article
+             (get-in (:rf.db/runtime (rf/frame-state-value :rf/default))
+                     [:rf.runtime/routing :pending-navigation :rejecting-route]))
+          ":rejecting-route is the route-id KEYWORD, not the \"/editor/articles/:id\" path string")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (let [nb (first (filter #(= :rf.error/can-leave-non-boolean (:operation %))
+                                @traces))]
+          (is (some? nb) ":rf.error/can-leave-non-boolean fired")
+          (is (= :editor/article (-> nb :tags :route-id))
+              ":route-id is the route-id KEYWORD, not the \"/editor/articles/:id\" path string"))))))
 
 ;; ============================================================================
 ;; rf2-5pyyl — :can-leave non-boolean → BLOCK + :rf.error/can-leave-non-boolean
@@ -437,13 +484,17 @@
             "navigation BLOCKED — slice still on the source route")
         (is (some? pending)
             ":rf/pending-navigation slot is populated (block path)")
-        (is (= :rf.error/can-leave-non-boolean
-               (-> nb-traces first :operation))
-            ":rf.error/can-leave-non-boolean trace fired (rf2-5pyyl)")
-        (is (= 42 (-> nb-traces first :tags :value))
-            "trace carries the offending non-boolean value")
-        (is (= :blocked-navigation (-> nb-traces first :recovery))
-            "trace hoists :recovery :blocked-navigation (Spec 009 §error contract)")))))
+        ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring). The
+        ;; fail-CLOSED semantics this deftest exists for are pinned by the two
+        ;; runtime-db assertions above, which are posture-independent.
+        (when interop/debug-enabled?
+          (is (= :rf.error/can-leave-non-boolean
+                 (-> nb-traces first :operation))
+              ":rf.error/can-leave-non-boolean trace fired (rf2-5pyyl)")
+          (is (= 42 (-> nb-traces first :tags :value))
+              "trace carries the offending non-boolean value")
+          (is (= :blocked-navigation (-> nb-traces first :recovery))
+              "trace hoists :recovery :blocked-navigation (Spec 009 §error contract)"))))))
 
 ;; ============================================================================
 ;; rf2-dbmj6x — can-leave / external-url diagnostics carry :frame
@@ -481,12 +532,25 @@
       (rf/register-listener! :trace ::dbmj6x-blocked (fn [ev] (swap! traces conj ev)))
       (rf/dispatch-sync [:rf.route/url-requested {:url "/cart"}] {:frame :route/owner})
       (rf/unregister-listener! :trace ::dbmj6x-blocked)
-      (is (some (fn [ev]
-                  (and (= :rf.route/navigation-blocked (:operation ev))
-                       (= :editor/can-leave? (-> ev :tags :rejecting-guard))
-                       (= :route/owner (-> ev :tags :frame))))
-                @traces)
-          ":rf.route/navigation-blocked carries :frame :route/owner (pre-fix: absent)"))))
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): the block landed in the
+      ;; NON-DEFAULT frame and nowhere else. That is the production half of
+      ;; "the diagnostic knew which frame it was on" — the rejecting guard is
+      ;; recorded in :route/owner's runtime-db, and :rf/default is untouched.
+      (is (= :editor/can-leave?
+             (get-in (:rf.db/runtime (rf/frame-state-value :route/owner))
+                     [:rf.runtime/routing :pending-navigation :rejecting-guard]))
+          ":route/owner's pending-nav slot names the rejecting guard")
+      (is (nil? (get-in (:rf.db/runtime (rf/frame-state-value :rf/default))
+                        [:rf.runtime/routing :pending-navigation]))
+          ":rf/default saw no pending navigation — the block is frame-local")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (some (fn [ev]
+                    (and (= :rf.route/navigation-blocked (:operation ev))
+                         (= :editor/can-leave? (-> ev :tags :rejecting-guard))
+                         (= :route/owner (-> ev :tags :frame))))
+                  @traces)
+            ":rf.route/navigation-blocked carries :frame :route/owner (pre-fix: absent)")))))
 
 (deftest can-leave-non-boolean-trace-carries-frame-rf2-dbmj6x
   (testing "rf2-dbmj6x: :rf.error/can-leave-non-boolean stamps :frame for a
@@ -509,12 +573,27 @@
       (rf/register-listener! :trace ::dbmj6x-nb (fn [ev] (swap! traces conj ev)))
       (rf/dispatch-sync [:rf.route/url-requested {:url "/cart"}] {:frame :route/owner})
       (rf/unregister-listener! :trace ::dbmj6x-nb)
-      (is (some (fn [ev]
-                  (and (= :rf.error/can-leave-non-boolean (:operation ev))
-                       (= 42 (-> ev :tags :value))
-                       (= :route/owner (-> ev :tags :frame))))
-                @traces)
-          ":rf.error/can-leave-non-boolean carries :frame :route/owner (pre-fix: absent)"))))
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): the non-boolean guard failed
+      ;; CLOSED against the NON-DEFAULT frame — :route/owner is still on the
+      ;; source route with a pending slot, and :rf/default was never involved.
+      (is (= :editor/article
+             (get-in (:rf.db/runtime (rf/frame-state-value :route/owner))
+                     [:rf.runtime/routing :current :route-id]))
+          ":route/owner stayed on the source route — the guard failed closed there")
+      (is (some? (get-in (:rf.db/runtime (rf/frame-state-value :route/owner))
+                         [:rf.runtime/routing :pending-navigation]))
+          ":route/owner's pending-nav slot is populated")
+      (is (nil? (get-in (:rf.db/runtime (rf/frame-state-value :rf/default))
+                        [:rf.runtime/routing :pending-navigation]))
+          ":rf/default saw no pending navigation — the guard is frame-local")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (some (fn [ev]
+                    (and (= :rf.error/can-leave-non-boolean (:operation ev))
+                         (= 42 (-> ev :tags :value))
+                         (= :route/owner (-> ev :tags :frame))))
+                  @traces)
+            ":rf.error/can-leave-non-boolean carries :frame :route/owner (pre-fix: absent)")))))
 
 (deftest can-leave-subs-artefact-missing-trace-carries-frame-rf2-dbmj6x
   (testing "rf2-dbmj6x: :rf.warning/can-leave-subs-artefact-missing stamps
@@ -538,11 +617,25 @@
           (rf/register-listener! :trace ::dbmj6x-missing (fn [ev] (swap! traces conj ev)))
           (rf/dispatch-sync [:rf.route/url-requested {:url "/cart"}] {:frame :route/owner})
           (rf/unregister-listener! :trace ::dbmj6x-missing)
-          (is (some (fn [ev]
-                      (and (= :rf.warning/can-leave-subs-artefact-missing (:operation ev))
-                           (= :route/owner (-> ev :tags :frame))))
-                    @traces)
-              ":rf.warning/can-leave-subs-artefact-missing carries :frame :route/owner"))
+          ;; SEMANTIC, posture-independent (rf2-o5dbf): with the subs hook
+          ;; unbound the guard cannot be evaluated, so `decisions/guard?`
+          ;; degrades to ALLOW (decisions.cljc §141-144) — the navigation
+          ;; PROCEEDS in :route/owner and no pending slot is written. The
+          ;; warning is the dev-only announcement of that degraded state.
+          (is (= :route/cart
+                 (get-in (:rf.db/runtime (rf/frame-state-value :route/owner))
+                         [:rf.runtime/routing :current :route-id]))
+              "the unevaluable guard degraded to ALLOW — :route/owner navigated")
+          (is (nil? (get-in (:rf.db/runtime (rf/frame-state-value :route/owner))
+                            [:rf.runtime/routing :pending-navigation]))
+              "…and nothing was left pending")
+          ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+          (when interop/debug-enabled?
+            (is (some (fn [ev]
+                        (and (= :rf.warning/can-leave-subs-artefact-missing (:operation ev))
+                             (= :route/owner (-> ev :tags :frame))))
+                      @traces)
+                ":rf.warning/can-leave-subs-artefact-missing carries :frame :route/owner")))
         (finally
           ;; Restore the hook (it lives in core/subs.cljc, which the routing
           ;; fixture does NOT reload, so it must be put back explicitly).
@@ -564,11 +657,23 @@
       (rf/dispatch-sync [:rf.route/url-requested {:url "https://example.invalid/cart"}]
                         {:frame :route/owner})
       (rf/unregister-listener! :trace ::dbmj6x-external)
-      (is (some (fn [ev]
-                  (and (= :rf.route/external-url-requested (:operation ev))
-                       (= :route/owner (-> ev :tags :frame))))
-                @traces)
-          ":rf.route/external-url-requested carries :frame :route/owner (pre-fix: absent)"))))
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): an EXTERNAL URL is not an
+      ;; in-app navigation — :route/owner's slice stays on `/` and no pending
+      ;; slot is written. That is the branch the trace merely announces.
+      (is (= :route/home
+             (get-in (:rf.db/runtime (rf/frame-state-value :route/owner))
+                     [:rf.runtime/routing :current :route-id]))
+          "the external URL did not move :route/owner's routing slice")
+      (is (nil? (get-in (:rf.db/runtime (rf/frame-state-value :route/owner))
+                        [:rf.runtime/routing :pending-navigation]))
+          "…and left nothing pending")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (some (fn [ev]
+                    (and (= :rf.route/external-url-requested (:operation ev))
+                         (= :route/owner (-> ev :tags :frame))))
+                  @traces)
+            ":rf.route/external-url-requested carries :frame :route/owner (pre-fix: absent)")))))
 
 ;; ============================================================================
 ;; rf2-dqlfty — nav-guard phase fails CLOSED on a throwing/hostile URL

--- a/implementation/routing/test/re_frame/routing_classification_test.clj
+++ b/implementation/routing/test/re_frame/routing_classification_test.clj
@@ -18,11 +18,38 @@
   The unifying invariant: classification lands ATOMICALLY with the slice
   publish (the same `:rf.db/runtime` commit), it is read ONLY at egress (the
   handler / subs always see real values), and it never leaks across a route
-  change (the singleton drop)."
+  change (the singleton drop).
+
+  ## Posture split (rf2-o5dbf)
+
+  The classification contract itself is production-real and carries NO posture
+  guard — the fail-loud `reg-route` validation, the lowering / re-rooting into
+  the per-frame elision registry, the singleton drop, the
+  `elision/elide-wire-value` redaction and the real SSR
+  `payload-policy/project-runtime-db` consumer all run in the ordinary
+  `clojure -M:test` suite AND in `scripts/test-routing-prod-gate.sh` (the
+  `-Dre-frame.debug=false` lane). rf2-u2x6w established that this egress
+  genuinely happens in production, so that is exactly where it must be proven.
+
+  The one dev-only surface here is the rf2-x1x5am QUERY-KEY PROMOTION
+  ADVISORY. It is an authoring hint, emitted through `trace/emit! :warning`,
+  which sits behind `interop/debug-enabled?` — read once at load time — so
+  under the real gate there is no advisory to observe. Its assertions are kept
+  VERBATIM inside `(when interop/debug-enabled? …)` arms marked `rf2-o5dbf`.
+
+  Three of those deftests are QUIET tests — `(is (empty? warnings))`. With no
+  trace bus every one of them passes VACUOUSLY, reporting \"no advisory fired\"
+  for a framework that never looked. They are inside the arm for that reason.
+  In their place the DETECTION is asserted posture-independently on
+  `classification/unpromoted-query-keys`, the pure always-on predicate
+  `advise-query-promotion!` is built from: it is what decides whether a route
+  has the footgun, and only the announcement is dev-gated. Nothing was deleted
+  or weakened."
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.elision :as elision]
+            [re-frame.interop :as interop]
             [re-frame.privacy :as privacy]
             [re-frame.projection :as projection]
             [re-frame.routing.classification :as classification]
@@ -543,17 +570,33 @@
     (try (thunk) (finally (rf/unregister-listener! :trace ::advisory)))
     @seen))
 
+(defn- unpromoted
+  "The ALWAYS-ON detection behind the advisory: the query keys `route-meta`'s
+  classification names that `promoted-keys` does not promote to a keyword.
+  `classification/advise-query-promotion!` is exactly this predicate plus a
+  dev-gated `trace/emit!`, so this is the posture-independent half — it decides
+  whether a route HAS the footgun, and survives -Dre-frame.debug=false."
+  [route-id route-meta promoted-keys]
+  (classification/unpromoted-query-keys
+    (classification/validate+extract route-id route-meta)
+    promoted-keys))
+
 (deftest advisory-fires-for-unpromoted-sensitive-query-key
   (testing "rf2-x1x5am: a :sensitive [[:query :token]] on a route with NO :query
             schema naming :token emits the unpromoted-query-key advisory"
     (let [warnings (capture-warnings
                      #(rf/reg-route :route/advmiss {:sensitive [[:query :token]]} "/advmiss"))]
-      (is (= 1 (count warnings)) "exactly one advisory fired")
-      (let [w (first warnings)]
-        (is (= :route/advmiss (:route-id w)) "the advisory names the route")
-        (is (= [:token] (:query-keys w)) "the unpromoted key is named")
-        (is (empty? (:promoted-keys w)) "the route promotes no query keys")
-        (is (string? (:advice w)) "the advisory carries actionable guidance")))))
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): the detection.
+      (is (= #{:token} (unpromoted :route/advmiss {:sensitive [[:query :token]]} #{}))
+          "the always-on predicate names :token as the unpromoted classified key")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (= 1 (count warnings)) "exactly one advisory fired")
+        (let [w (first warnings)]
+          (is (= :route/advmiss (:route-id w)) "the advisory names the route")
+          (is (= [:token] (:query-keys w)) "the unpromoted key is named")
+          (is (empty? (:promoted-keys w)) "the route promotes no query keys")
+          (is (string? (:advice w)) "the advisory carries actionable guidance"))))))
 
 (deftest advisory-quiet-when-query-key-promoted
   (testing "rf2-x1x5am: a :sensitive [[:query :token]] paired with a :query
@@ -562,16 +605,33 @@
                      #(rf/reg-route :route/advok
                                     {:sensitive [[:query :token]] :query [:map [:token :string]]}
                                     "/advok"))]
-      (is (empty? warnings) "no advisory when the query key is promoted"))))
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): the detection finds nothing
+      ;; to advise on. Without this the `(empty? warnings)` leg below would pass
+      ;; vacuously under the gate — an empty trace ring satisfies it trivially.
+      (is (empty? (unpromoted :route/advok
+                              {:sensitive [[:query :token]] :query [:map [:token :string]]}
+                              #{:token}))
+          "the always-on predicate finds no unpromoted key for the correct pairing")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring); NEGATIVE over
+      ;; the trace ring, hence guarded.
+      (when interop/debug-enabled?
+        (is (empty? warnings) "no advisory when the query key is promoted")))))
 
 (deftest advisory-honours-defaults-promotion
   (testing "rf2-x1x5am: :query-defaults also counts as promotion — a key
             declared there does NOT trigger the advisory"
-    (is (empty? (capture-warnings
-                  #(rf/reg-route :route/advdef
-                                 {:sensitive [[:query :page]] :query-defaults {:page 1}}
-                                 "/advdef")))
-        ":query-defaults promotes :page → no advisory")))
+    (let [warnings (capture-warnings
+                    #(rf/reg-route :route/advdef
+                                   {:sensitive [[:query :page]] :query-defaults {:page 1}}
+                                   "/advdef"))]
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): see the twin above.
+      (is (empty? (unpromoted :route/advdef
+                              {:sensitive [[:query :page]] :query-defaults {:page 1}}
+                              #{:page}))
+          ":query-defaults promotes :page → the predicate finds nothing")
+      ;; rf2-o5dbf — dev-instrumentation arm; NEGATIVE over the trace ring.
+      (when interop/debug-enabled?
+        (is (empty? warnings) ":query-defaults promotes :page → no advisory")))))
 
 (deftest advisory-vocabulary-is-two-sources-not-three
   (testing "EP-0037 R5: the promotion vocabulary shrank from THREE sources to
@@ -583,23 +643,40 @@
                      #(rf/reg-route :route/advret
                                     {:sensitive [[:query :ref]]}
                                     "/advret"))]
-      (is (= 1 (count warnings))
-          "a classified query key with no :query / :query-defaults declaration warns")
-      (let [{:keys [query-keys promoted-keys advice]} (first warnings)]
-        (is (= [:ref] query-keys) "the unpromoted key is named")
-        (is (empty? promoted-keys) "nothing promotes it — the retain slot is gone")
-        (is (str/includes? advice ":query / :query-defaults")
-            "the advice names exactly the two surviving promotion sources")
-        (is (not (str/includes? advice ":query-retain"))
-            "the retired key is absent from the advice vocabulary")))
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): with `:query-retain`
+      ;; retired, NOTHING promotes :ref, so the always-on predicate reports it.
+      (is (= #{:ref} (unpromoted :route/advret {:sensitive [[:query :ref]]} #{}))
+          "a key that was promoted only by the retired :query-retain is now unpromoted")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (= 1 (count warnings))
+            "a classified query key with no :query / :query-defaults declaration warns")
+        (let [{:keys [query-keys promoted-keys advice]} (first warnings)]
+          (is (= [:ref] query-keys) "the unpromoted key is named")
+          (is (empty? promoted-keys) "nothing promotes it — the retain slot is gone")
+          (is (str/includes? advice ":query / :query-defaults")
+              "the advice names exactly the two surviving promotion sources")
+          (is (not (str/includes? advice ":query-retain"))
+              "the retired key is absent from the advice vocabulary")))
+      ;; …and `:query-retain` really is inert rather than merely unmentioned:
+      ;; naming :ref there does NOT promote it. Posture-independent.
+      (is (= #{:ref} (unpromoted :route/advret {:sensitive [[:query :ref]]} #{}))
+          ":query-retain widens nothing — the promoted set is the caller's alone"))
     ;; The migration the EP requires: DECLARE the key, and the advisory falls
     ;; silent — the same key is now keyword-promoted for real.
-    (is (empty? (capture-warnings
-                  #(rf/reg-route :route/advret-migrated
-                                 {:sensitive [[:query :ref]]
-                                  :query     [:map [:ref {:optional true} :string]]}
-                                 "/advret-migrated")))
-        "declaring :ref in the :query schema is the explicit migration")))
+    (let [migrated-meta {:sensitive [[:query :ref]]
+                         :query     [:map [:ref {:optional true} :string]]}
+          warnings      (capture-warnings
+                          #(rf/reg-route :route/advret-migrated migrated-meta
+                                         "/advret-migrated"))]
+      ;; SEMANTIC, posture-independent (rf2-o5dbf) — without this the negative
+      ;; leg below is vacuous under the gate.
+      (is (empty? (unpromoted :route/advret-migrated migrated-meta #{:ref}))
+          "declaring :ref in the :query schema is the explicit migration")
+      ;; rf2-o5dbf — dev-instrumentation arm; NEGATIVE over the trace ring.
+      (when interop/debug-enabled?
+        (is (empty? warnings)
+            "declaring :ref in the :query schema silences the advisory")))))
 
 (deftest advisory-fires-for-string-segment-and-large-axis
   (testing "rf2-x1x5am: a STRING [:query \"token\"] segment (can never be a
@@ -607,20 +684,40 @@
             trigger the advisory"
     (let [w-str (capture-warnings
                   #(rf/reg-route :route/advstr {:sensitive [[:query "token"]]} "/advstr"))]
-      (is (= 1 (count w-str)) "the string-segment query key triggers the advisory")
-      (is (= ["token"] (:query-keys (first w-str))) "the string key is named"))
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): a STRING segment can never
+      ;; name a keyword-promoted slot, so the predicate reports it whatever the
+      ;; route promotes.
+      (is (= #{"token"} (unpromoted :route/advstr {:sensitive [[:query "token"]]} #{:token}))
+          "a string [:query \"token\"] segment is unpromotable by construction")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (= 1 (count w-str)) "the string-segment query key triggers the advisory")
+        (is (= ["token"] (:query-keys (first w-str))) "the string key is named")))
     (let [w-large (capture-warnings
                     #(rf/reg-route :route/advlarge {:large [[:query :blob]]} "/advlarge"))]
-      (is (= 1 (count w-large)) "an unpromoted :large [:query k] key triggers the advisory")
-      (is (= [:blob] (:query-keys (first w-large)))))))
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): the :large axis is scanned
+      ;; too, not just :sensitive.
+      (is (= #{:blob} (unpromoted :route/advlarge {:large [[:query :blob]]} #{}))
+          "the predicate scans the :large axis as well as :sensitive")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (= 1 (count w-large)) "an unpromoted :large [:query k] key triggers the advisory")
+        (is (= [:blob] (:query-keys (first w-large))))))))
 
 (deftest advisory-quiet-for-params-axis
   (testing "rf2-x1x5am: a :sensitive [[:params k]] path NEVER triggers the
             advisory — path captures are always keyword-keyed (immune)"
-    (is (empty? (capture-warnings
-                  #(rf/reg-route :route/advparam
-                                 {:sensitive [[:params :secret]]} "/advparam/:secret")))
-        "the :params axis is immune to the query-promotion footgun")))
+    (let [meta     {:sensitive [[:params :secret]]}
+          warnings (capture-warnings
+                     #(rf/reg-route :route/advparam meta "/advparam/:secret"))]
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): the predicate only ever
+      ;; looks under a `[:query …]` head, so the :params axis cannot contribute.
+      ;; Without this the negative leg below is vacuous under the gate.
+      (is (empty? (unpromoted :route/advparam meta #{}))
+          "the :params axis is immune to the query-promotion footgun")
+      ;; rf2-o5dbf — dev-instrumentation arm; NEGATIVE over the trace ring.
+      (when interop/debug-enabled?
+        (is (empty? warnings) "no advisory fires for a :params-axis declaration")))))
 
 ;; ===========================================================================
 ;; (rf2-ugoxyv + rf2-v0k2mq) Real EGRESS-CONSUMER + non-default PROFILE

--- a/implementation/routing/test/re_frame/routing_egress_test.clj
+++ b/implementation/routing/test/re_frame/routing_egress_test.clj
@@ -25,10 +25,50 @@
 
   The unifying EP-0015 invariant under test: the IN-PROCESS value stays raw
   (the handler / pending-nav sub / continue-cancel resume need it), only the
-  EGRESS copy (trace bus / Xray / MCP / log / epoch) is projected."
+  EGRESS copy (trace bus / Xray / MCP / log / epoch) is projected.
+
+  ## Posture split (rf2-o5dbf)
+
+  Read this before adding a case here: the answer to \"is this leg
+  production-real?\" is NOT uniform across this namespace, and getting it
+  wrong is a privacy hole rather than a red test.
+
+  PRODUCTION-REAL, asserted with NO posture guard (so they run in the
+  ordinary `clojure -M:test` suite AND in `scripts/test-routing-prod-gate.sh`,
+  the `-Dre-frame.debug=false` lane):
+
+    * the pure carrier scrub `egress/redact-url-carriers` /
+      `egress/redact-url-tag` — plain functions the emit sites call
+      unconditionally, no `interop/debug-enabled?` anywhere near them;
+    * the `:sensitive` RETENTION itself (`rf/handler-meta`, both the
+      positional and the frame-targeted public arities) — registrar state,
+      posture-independent, and the mechanism every projection rides on. This
+      is the rf2-kqxe6.20 fix proper;
+    * the IN-PROCESS rawness — handlers, the durable pending-nav slot,
+      continue/cancel resume;
+    * the `:rf/route` SUB-EGRESS half (`sub-egress/route-sub-seed-path`, the
+      `elision/elide-wire-value` projections). rf2-u2x6w established that
+      sub-classification genuinely egresses in production, and its always-on
+      witnesses live in `re-frame.routing-sub-egress-production-test`, which
+      is separately IN the lane.
+
+  DEV-ONLY, and kept VERBATIM inside `(when interop/debug-enabled? …)` arms
+  marked `rf2-o5dbf`: every assertion read off the TRACE BUS — the
+  `:rf.fx/handled` `:rf.fx/args` copy, the `:rf.error/no-such-handler` and
+  `:rf.route/navigation-blocked` tag maps, and the dispatched-event payload
+  copies. `trace/emit!` sits behind `interop/debug-enabled?`, read once at
+  load time, so under the real gate there is no trace bus to project onto.
+
+  Two of those are NEGATIVE over the trace — `(not (re-find #\"SECRET100\"
+  (pr-str payload)))` in the inverse-load-order case, and the
+  `(not (re-find …))` pair in the route-miss case. With no trace, `payload` is
+  nil and the assertion passes VACUOUSLY: it would report a privacy guarantee
+  the framework never executed. They are inside the arm for that reason
+  specifically. Nothing was deleted or weakened."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.classification :as classification]
             [re-frame.core :as rf]
+            [re-frame.interop :as interop]
             [re-frame.frame :as frame]
             [re-frame.fx :as fx]
             [re-frame.elision :as elision]
@@ -194,22 +234,31 @@
     (reg-jvm-fx! :rf.nav/push-url nav-fx/push-url-meta     (fn [_ _] nil))
     ;; Land on a route WITH params so the next nav's :from carries :params.
     (rf/dispatch-sync [:rf.route/navigate {:to :route/article :params {:id "secret-doc-id"}}])
-    (let [args (handled-trace-for
-                 :rf.nav/scroll
-                 [:rf.route/navigate {:to :route/article :params {:id "another-secret"} :fragment "tok-in-fragment"}])]
-      (is (some? args) "a :rf.nav/scroll :rf.fx/handled trace was emitted")
-      ;; The descriptor :id keyword survives (names the shape, no secret).
-      (is (= :route/article (get-in args [:to :id]))
-          ":to :id (route keyword) rides verbatim")
-      ;; The carrier slots are redacted to the sentinel.
-      (is (= privacy/redacted-sentinel (get-in args [:to :params]))
-          ":to :params (the document-id carrier) is redacted on the trace")
-      (is (= privacy/redacted-sentinel (get-in args [:from :params]))
-          ":from :params is redacted on the trace")
-      (is (= privacy/redacted-sentinel (:fragment args))
-          ":fragment is redacted on the trace")
-      ;; :strategy is structural, not a carrier — it rides.
-      (is (contains? args :strategy) ":strategy rides verbatim"))))
+    ;; SEMANTIC, posture-independent (rf2-o5dbf): the projection the trace copy
+    ;; rides on is the fx registration's own `:sensitive` declaration, which is
+    ;; registrar state and survives -Dre-frame.debug=false. If the mark is lost,
+    ;; the trace assertions below could not hold in ANY posture.
+    (is (= [[:from :params] [:from :query] [:to :params] [:to :query] [:fragment]]
+           (:sensitive (rf/handler-meta :fx :rf.nav/scroll)))
+        ":rf.nav/scroll declares the route-descriptor carrier slots :sensitive")
+    ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+    (when interop/debug-enabled?
+      (let [args (handled-trace-for
+                   :rf.nav/scroll
+                   [:rf.route/navigate {:to :route/article :params {:id "another-secret"} :fragment "tok-in-fragment"}])]
+        (is (some? args) "a :rf.nav/scroll :rf.fx/handled trace was emitted")
+        ;; The descriptor :id keyword survives (names the shape, no secret).
+        (is (= :route/article (get-in args [:to :id]))
+            ":to :id (route keyword) rides verbatim")
+        ;; The carrier slots are redacted to the sentinel.
+        (is (= privacy/redacted-sentinel (get-in args [:to :params]))
+            ":to :params (the document-id carrier) is redacted on the trace")
+        (is (= privacy/redacted-sentinel (get-in args [:from :params]))
+            ":from :params is redacted on the trace")
+        (is (= privacy/redacted-sentinel (:fragment args))
+            ":fragment is redacted on the trace")
+        ;; :strategy is structural, not a carrier — it rides.
+        (is (contains? args :strategy) ":strategy rides verbatim")))))
 
 (deftest scroll-fx-handler-still-receives-raw-args-in-process
   (testing "rf2-1wmni6/rf2-pbbo68: the marks projection touches ONLY the trace
@@ -238,13 +287,22 @@
     (rf/reg-route :route/article {:params [:map [:id :string]]} "/articles/:id")
     (reg-jvm-fx! :rf.nav/scroll   scroll/scroll-fx-meta (fn [_ _] nil))
     (reg-jvm-fx! :rf.nav/push-url nav-fx/push-url-meta  (fn [_ _] nil))
-    (let [args (handled-trace-for
-                 :rf.nav/push-url
-                 [:rf.route/url-requested {:url "/articles/intro"}])]
-      ;; A normal same-origin app URL rides verbatim on the trace (behavioural
-      ;; identity, not a redacted carrier) — push-url carries no :sensitive mark.
-      (is (= "/articles/intro" args)
-          "the push-url URL routes/traces the real same-origin URL"))))
+    ;; SEMANTIC, posture-independent (rf2-o5dbf): the DELIBERATE ABSENCE of a
+    ;; `:sensitive` mark is registrar state, so it is assertable under the
+    ;; production gate — and it is the fact the trace expectation below rests
+    ;; on. A mark added here by accident would fail this, in both postures.
+    (is (nil? (:sensitive (rf/handler-meta :fx :rf.nav/push-url)))
+        ":rf.nav/push-url declares NO :sensitive marks — the pushed URL is the
+         navigation's behavioural identity, not a diagnostic carrier")
+    ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+    (when interop/debug-enabled?
+      (let [args (handled-trace-for
+                   :rf.nav/push-url
+                   [:rf.route/url-requested {:url "/articles/intro"}])]
+        ;; A normal same-origin app URL rides verbatim on the trace (behavioural
+        ;; identity, not a redacted carrier) — push-url carries no :sensitive mark.
+        (is (= "/articles/intro" args)
+            "the push-url URL routes/traces the real same-origin URL")))))
 
 ;; ===========================================================================
 ;; rf2-n1f4rh — route-miss diagnostics redact the raw requested URL.
@@ -256,24 +314,41 @@
             (path + :reason kept for app error handling)"
     ;; No route registered for /oauth → route-miss → fallback to not-found.
     (rf/reg-route :rf.route/not-found {} "/404")
-    (let [traces (atom [])]
+    (let [raw "/oauth/callback?code=topsecret&state=xyz#access_token=leak"
+          traces (atom [])]
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): the scrub the emit site
+      ;; applies is `egress/redact-url-tag`, an ALWAYS-ON pure function — no
+      ;; `interop/debug-enabled?` between it and the caller. Assert it on the
+      ;; exact tag map the route-miss telemetry builds, so the scrub itself is
+      ;; proven under the production gate even though the trace is not emitted
+      ;; there.
+      (let [scrubbed (:url (egress/redact-url-tag {:url raw :kind :route} :url))]
+        (is (re-find #"^/oauth/callback" scrubbed) "the PATH is preserved")
+        (is (not (re-find #"topsecret" scrubbed)) "the query secret is NOT raw")
+        (is (not (re-find #"leak" scrubbed)) "the fragment secret is NOT raw")
+        (is (re-find (re-pattern sentinel-str) scrubbed)
+            "carrier values replaced with the rf/redacted sentinel"))
       (rf/register-listener! :trace ::miss (fn [ev] (swap! traces conj ev)))
-      (rf/dispatch-sync [:rf.route/transitioned
-                         "/oauth/callback?code=topsecret&state=xyz#access_token=leak"])
+      (rf/dispatch-sync [:rf.route/transitioned raw])
       (rf/unregister-listener! :trace ::miss)
-      (let [err (->> @traces
-                     (filter #(= :rf.error/no-such-handler (:operation %)))
-                     first)]
-        (is (some? err) ":rf.error/no-such-handler was emitted for the route miss")
-        (let [url (-> err :tags :url)]
-          (is (string? url) "the :url slot is present (structured path kept)")
-          (is (re-find #"^/oauth/callback" url) "the PATH is preserved")
-          (is (not (re-find #"topsecret" url)) "the query secret is NOT raw")
-          (is (not (re-find #"leak" url)) "the fragment secret is NOT raw")
-          (is (re-find (re-pattern sentinel-str) url)
-              "carrier values replaced with the rf/redacted sentinel"))
-        ;; The structured discriminator the app error handler needs survives.
-        (is (= :route (-> err :tags :kind)) ":kind :route discriminator kept")))))
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring). The two
+      ;; `(not (re-find …))` legs are NEGATIVE: with no trace `url` is nil and
+      ;; they would pass vacuously, which is why they live in here rather than
+      ;; beside the semantics.
+      (when interop/debug-enabled?
+        (let [err (->> @traces
+                       (filter #(= :rf.error/no-such-handler (:operation %)))
+                       first)]
+          (is (some? err) ":rf.error/no-such-handler was emitted for the route miss")
+          (let [url (-> err :tags :url)]
+            (is (string? url) "the :url slot is present (structured path kept)")
+            (is (re-find #"^/oauth/callback" url) "the PATH is preserved")
+            (is (not (re-find #"topsecret" url)) "the query secret is NOT raw")
+            (is (not (re-find #"leak" url)) "the fragment secret is NOT raw")
+            (is (re-find (re-pattern sentinel-str) url)
+                "carrier values replaced with the rf/redacted sentinel"))
+          ;; The structured discriminator the app error handler needs survives.
+          (is (= :route (-> err :tags :kind)) ":kind :route discriminator kept"))))))
 
 ;; ===========================================================================
 ;; rf2-jfaucw — blocked-navigation record keeps no raw route carriers on
@@ -303,17 +378,31 @@
       ;; Try to leave to a URL carrying a query secret → blocked.
       (rf/dispatch-sync [:rf.route/url-requested {:url "/cart?coupon=SECRET100&ref=x"}])
       (rf/unregister-listener! :trace ::blocked)
-      (let [blocked (->> @traces
-                         (filter #(= :rf.route/navigation-blocked (:operation %)))
-                         first)]
-        (is (some? blocked) "a navigation-blocked trace fired")
-        (let [url (-> blocked :tags :requested-url)]
-          (is (re-find #"^/cart" url) "the path is preserved")
-          (is (not (re-find #"SECRET100" url)) "the query secret is NOT raw on the trace")
-          (is (re-find (re-pattern sentinel-str) url) "carrier value redacted"))
-        ;; The structural discriminator survives.
-        (is (= :editor/can-leave? (-> blocked :tags :rejecting-guard))
-            ":rejecting-guard kept")))))
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): the `:requested-url` scrub
+      ;; the emit site applies (decisions.cljc §301-309) is the ALWAYS-ON
+      ;; `egress/redact-url-tag` on the `:requested-url` slot. Assert it there,
+      ;; so the scrub itself is proven under the production gate.
+      (let [scrubbed (:requested-url
+                       (egress/redact-url-tag
+                         {:requested-url "/cart?coupon=SECRET100&ref=x"
+                          :rejecting-guard :editor/can-leave?}
+                         :requested-url))]
+        (is (re-find #"^/cart" scrubbed) "the path is preserved")
+        (is (not (re-find #"SECRET100" scrubbed)) "the query secret is NOT raw")
+        (is (re-find (re-pattern sentinel-str) scrubbed) "carrier value redacted"))
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (let [blocked (->> @traces
+                           (filter #(= :rf.route/navigation-blocked (:operation %)))
+                           first)]
+          (is (some? blocked) "a navigation-blocked trace fired")
+          (let [url (-> blocked :tags :requested-url)]
+            (is (re-find #"^/cart" url) "the path is preserved")
+            (is (not (re-find #"SECRET100" url)) "the query secret is NOT raw on the trace")
+            (is (re-find (re-pattern sentinel-str) url) "carrier value redacted"))
+          ;; The structural discriminator survives.
+          (is (= :editor/can-leave? (-> blocked :tags :rejecting-guard))
+              ":rejecting-guard kept"))))))
 
 (deftest navigation-blocked-dispatched-event-payload-redacts-carriers
   (testing "rf2-jfaucw: the DISPATCHED [:rf.route/navigation-blocked pending-nav]
@@ -324,26 +413,35 @@
       (rf/register-listener! :trace ::nb (fn [ev] (swap! traces conj ev)))
       (rf/dispatch-sync [:rf.route/url-requested {:url "/cart?coupon=SECRET100"}])
       (rf/unregister-listener! :trace ::nb)
-      ;; Find a dispatched-event trace carrying the navigation-blocked event vec.
-      (let [dispatched (->> @traces
-                            (keep (fn [ev]
-                                    (let [v (or (-> ev :tags :rf.event/v)
-                                                (-> ev :tags :event))]
-                                      (when (and (vector? v)
-                                                 (= :rf.route/navigation-blocked (first v)))
-                                        v))))
-                            first)]
-        (is (some? dispatched) "the navigation-blocked event vector was traced")
-        (let [pending-nav (second dispatched)]
-          (is (= privacy/redacted-sentinel (:requested-url pending-nav))
-              ":requested-url redacted in the dispatched-event trace payload")
-          (is (= privacy/redacted-sentinel (:destination pending-nav))
-              ":destination redacted in the dispatched-event trace payload")
-          (is (= privacy/redacted-sentinel (:target pending-nav))
-              ":target redacted in the dispatched-event trace payload")
-          ;; Structural slots survive.
-          (is (= :link (:cause pending-nav)) ":cause kept")
-          (is (contains? pending-nav :id) ":id (pending-nav handle) kept"))))))
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): the marks chokepoint reads
+      ;; the event registration's `:sensitive` declaration, which is registrar
+      ;; state. That declaration is what the redaction below IS — assert it
+      ;; where the production gate can see it.
+      (is (= [[:requested-url] [:destination] [:target]]
+             (:sensitive (rf/handler-meta :event :rf.route/navigation-blocked)))
+          "the framework declares the pending-nav carrier slots :sensitive")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        ;; Find a dispatched-event trace carrying the navigation-blocked event vec.
+        (let [dispatched (->> @traces
+                              (keep (fn [ev]
+                                      (let [v (or (-> ev :tags :rf.event/v)
+                                                  (-> ev :tags :event))]
+                                        (when (and (vector? v)
+                                                   (= :rf.route/navigation-blocked (first v)))
+                                          v))))
+                              first)]
+          (is (some? dispatched) "the navigation-blocked event vector was traced")
+          (let [pending-nav (second dispatched)]
+            (is (= privacy/redacted-sentinel (:requested-url pending-nav))
+                ":requested-url redacted in the dispatched-event trace payload")
+            (is (= privacy/redacted-sentinel (:destination pending-nav))
+                ":destination redacted in the dispatched-event trace payload")
+            (is (= privacy/redacted-sentinel (:target pending-nav))
+                ":target redacted in the dispatched-event trace payload")
+            ;; Structural slots survive.
+            (is (= :link (:cause pending-nav)) ":cause kept")
+            (is (contains? pending-nav :id) ":id (pending-nav handle) kept")))))))
 
 (deftest navigation-blocked-pending-nav-slot-keeps-raw-in-process
   (testing "rf2-jfaucw: the DURABLE pending-nav runtime-db slot keeps the RAW
@@ -423,18 +521,30 @@
                     (fn [{:keys [db]} [_ {:keys [destination] :as denial}]]
                       (swap! seen conj denial)
                       {:db (assoc-in db [:auth :return-to] destination)}))
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): rf2-kqxe6.20's actual fix is
+      ;; the RETENTION — the framework's carrier declaration survives a bare
+      ;; public override that declares no metadata at all. That is registrar
+      ;; state, so it is provable under the production gate, and it is the
+      ;; mechanism the trace redaction below rides on.
+      (is (= [[:requested-url] [:destination] [:target]]
+             (:sensitive (rf/handler-meta :event :rf.route/entry-denied)))
+          "the framework's carriers survive the bare public override")
+      ;; The dispatch runs in BOTH postures — the in-process assertions below
+      ;; depend on it. Only the trace-payload readings are posture-gated.
       (let [payload (traced-event-payload
                       :rf.route/entry-denied
                       #(rf/dispatch-sync
                          [:rf.route/handle-url-change "/account?invite=SECRET100"]))]
-        (is (some? payload) "the entry-denied event vector was traced")
-        (is (= privacy/redacted-sentinel (:requested-url payload))
-            ":requested-url redacted on the egress copy after the override")
-        (is (= privacy/redacted-sentinel (:destination payload))
-            ":destination redacted on the egress copy after the override")
-        (is (= privacy/redacted-sentinel (:target payload))
-            ":target redacted on the egress copy after the override")
-        (is (= :auth/signed-in? (:guard payload)) "the structural :guard slot kept"))
+        ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+        (when interop/debug-enabled?
+          (is (some? payload) "the entry-denied event vector was traced")
+          (is (= privacy/redacted-sentinel (:requested-url payload))
+              ":requested-url redacted on the egress copy after the override")
+          (is (= privacy/redacted-sentinel (:destination payload))
+              ":destination redacted on the egress copy after the override")
+          (is (= privacy/redacted-sentinel (:target payload))
+              ":target redacted on the egress copy after the override")
+          (is (= :auth/signed-in? (:guard payload)) "the structural :guard slot kept")))
       ;; Handler invocation is unchanged — called exactly once, with RAW values.
       (is (= 1 (count @seen)) "the app handler ran exactly once")
       (let [denial (first @seen)]
@@ -452,15 +562,22 @@
     (let [seen (atom [])]
       (rf/reg-event :rf.route/navigation-blocked
                     (fn [_ [_ pending]] (swap! seen conj pending) {}))
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): the retention itself — see
+      ;; the entry-denied twin above.
+      (is (= [[:requested-url] [:destination] [:target]]
+             (:sensitive (rf/handler-meta :event :rf.route/navigation-blocked)))
+          "the framework's carriers survive the bare public override")
       (let [payload (traced-event-payload
                       :rf.route/navigation-blocked
                       #(rf/dispatch-sync
                          [:rf.route/url-requested {:url "/cart?coupon=SECRET100"}]))]
-        (is (some? payload) "the navigation-blocked event vector was traced")
-        (is (= privacy/redacted-sentinel (:requested-url payload)))
-        (is (= privacy/redacted-sentinel (:destination payload)))
-        (is (= privacy/redacted-sentinel (:target payload)))
-        (is (= :link (:cause payload)) "the structural :cause slot kept"))
+        ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+        (when interop/debug-enabled?
+          (is (some? payload) "the navigation-blocked event vector was traced")
+          (is (= privacy/redacted-sentinel (:requested-url payload)))
+          (is (= privacy/redacted-sentinel (:destination payload)))
+          (is (= privacy/redacted-sentinel (:target payload)))
+          (is (= :link (:cause payload)) "the structural :cause slot kept")))
       (is (= 1 (count @seen)) "the app handler ran exactly once")
       (is (= "/cart?coupon=SECRET100" (:requested-url (first @seen)))
           "the in-process handler saw the RAW requested URL (resume needs it)"))))
@@ -480,10 +597,14 @@
                     :rf.route/entry-denied
                     #(rf/dispatch-sync
                        [:rf.route/handle-url-change "/account?invite=SECRET100"]))]
-      (is (= privacy/redacted-sentinel (:requested-url payload))
-          "the framework's carrier still redacts")
-      (is (= privacy/redacted-sentinel (:guard payload))
-          "the app's own declared path redacts too"))))
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring). The UNION
+      ;; itself — the property this deftest is named for — is asserted above on
+      ;; `rf/handler-meta`, posture-independently.
+      (when interop/debug-enabled?
+        (is (= privacy/redacted-sentinel (:requested-url payload))
+            "the framework's carrier still redacts")
+        (is (= privacy/redacted-sentinel (:guard payload))
+            "the app's own declared path redacts too")))))
 
 (deftest the-retained-carriers-survive-a-hot-reload-re-registration
   (testing "rf2-kqxe6.20: re-evaluating the app namespace re-registers the
@@ -500,8 +621,12 @@
                     :rf.route/entry-denied
                     #(rf/dispatch-sync
                        [:rf.route/handle-url-change "/account?invite=SECRET100"]))]
-      (is (= privacy/redacted-sentinel (:requested-url payload))
-          "still redacted after the re-registration"))))
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring). The
+      ;; no-duplication / no-decay property is asserted above on
+      ;; `rf/handler-meta`, posture-independently.
+      (when interop/debug-enabled?
+        (is (= privacy/redacted-sentinel (:requested-url payload))
+            "still redacted after the re-registration")))))
 
 ;; ===========================================================================
 ;; rf2-kqxe6.20 (reopened by the merged-PR audit of #6949) — the retention is
@@ -622,22 +747,29 @@
             "the two public arities answer DIFFERENTLY under this load order —
              which is exactly why the frame-targeted form is the effective read"))
       ;; (2) TRACE PROJECTION — the egress the classification exists for.
+      ;;     rf2-o5dbf — dev-instrumentation arm (see ns docstring). The
+      ;;     RECONCILIATION this deftest exists for is assertion (1) above,
+      ;;     which is registrar state and posture-independent. Note the final
+      ;;     leg is NEGATIVE over the trace copy: with no trace `payload` is
+      ;;     nil, `(pr-str nil)` is "nil", and it would report a privacy
+      ;;     guarantee the framework never executed.
       (let [payload (traced-event-payload
                       :rf.route/entry-denied
                       #(rf/dispatch-sync
                          [:rf.route/handle-url-change "/account?invite=SECRET100"]))]
-        (is (some? payload) "the entry-denied event vector was traced")
-        (is (= privacy/redacted-sentinel (:requested-url payload))
-            ":requested-url redacted at egress under the inverse load order")
-        (is (= privacy/redacted-sentinel (:destination payload))
-            ":destination redacted at egress under the inverse load order")
-        (is (= privacy/redacted-sentinel (:target payload))
-            ":target redacted at egress under the inverse load order")
-        (is (= privacy/redacted-sentinel (:guard payload))
-            "the app's OWN declared path still redacts — the union is not a
-             replacement in either direction")
-        (is (not (re-find #"SECRET100" (pr-str payload)))
-            "GUARD: the query secret appears NOWHERE on the egress copy"))
+        (when interop/debug-enabled?
+          (is (some? payload) "the entry-denied event vector was traced")
+          (is (= privacy/redacted-sentinel (:requested-url payload))
+              ":requested-url redacted at egress under the inverse load order")
+          (is (= privacy/redacted-sentinel (:destination payload))
+              ":destination redacted at egress under the inverse load order")
+          (is (= privacy/redacted-sentinel (:target payload))
+              ":target redacted at egress under the inverse load order")
+          (is (= privacy/redacted-sentinel (:guard payload))
+              "the app's OWN declared path still redacts — the union is not a
+               replacement in either direction")
+          (is (not (re-find #"SECRET100" (pr-str payload)))
+              "GUARD: the query secret appears NOWHERE on the egress copy")))
       ;; (3) APP BEHAVIOUR — unchanged: the app handler is the frame's winner,
       ;;     runs exactly once, and receives the RAW payload in-process.
       (is (= 1 (count @seen))

--- a/implementation/routing/test/re_frame/routing_entry_denied_test.clj
+++ b/implementation/routing/test/re_frame/routing_entry_denied_test.clj
@@ -6,14 +6,45 @@
   framework no-op default handler, the URL restore on a URL-driven door, the
   SSR `403` floor + redirect supersession, the fresh-return auth recipe, and
   the retirement roster (`:rf.route/entry-blocked`, `:enter-attempts`,
-  `:rf.error/route-guard-loop`, enter bypass, `:bypass-guards?`)."
+  `:rf.error/route-guard-loop`, enter bypass, `:bypass-guards?`).
+
+  ## Posture split (rf2-o5dbf)
+
+  Almost everything here is already production-real and carries NO posture
+  guard: `capture-denials!` observes the denial through a PUBLIC
+  `rf/reg-event` handler, not the trace stream, and the terminal-entry
+  invariants (nothing commits, no pending value, exactly-once dispatch, the
+  address-bar restore, the SSR 403 floor) are read off the runtime-db and the
+  SSR response. Those run in the ordinary `clojure -M:test` suite AND in
+  `scripts/test-routing-prod-gate.sh` (the `-Dre-frame.debug=false` lane).
+
+  Two shapes needed the guard.
+
+  1. Trace-PAYLOAD assertions — the `:rf.error/can-enter-non-boolean` tags,
+     the `:rf.error/navigate-bad-request` `:reason` / `:keys` — sit behind
+     `trace/emit-error!`, gated on `interop/debug-enabled?` and read once at
+     load time. Kept VERBATIM inside `(when interop/debug-enabled? …)` arms
+     marked `rf2-o5dbf`. In every case the SEMANTICS beside them (the deny
+     held; the malformed request navigated nowhere) stay posture-independent.
+
+  2. NEGATIVE trace assertions — `not-any? :rf.error/no-such-handler` and
+     `not-any? :rf.error/route-guard-loop`. Under the gate the ring is EMPTY
+     by design, so these pass VACUOUSLY: they would have reported green
+     without the framework doing anything at all. They are dev-posture
+     assertions and are guarded as such, with the production-visible half of
+     each (the deny still holds; 12 attempts really did deny 12 times and
+     accumulated no pending value) left outside the arm.
+
+  Nothing was deleted or weakened."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.events :as events]
             [re-frame.frame :as frame]
             [re-frame.fx :as fx]
+            [re-frame.interop :as interop]
             [re-frame.registrar :as registrar]
             [re-frame.routing :as routing]
+            [re-frame.routing.address :as address]
             [re-frame.routing.test-support]
             [re-frame.routing-test-support :as rts]
             [re-frame.ssr :as ssr]))
@@ -128,11 +159,18 @@
       (rf/register-listener! :trace ::d (fn [ev] (swap! traces conj ev)))
       (rf/dispatch-sync [:rf.route/navigate {:to :account}])
       (rf/unregister-listener! :trace ::d)
-      (is (= 1 (count (filter #(= :rf.route/entry-denied (:operation %)) @traces)))
-          "exactly one :rf.route/entry-denied trace — counted independently of
-           any application handler")
-      (is (not-any? #(= :rf.error/no-such-handler (:operation %)) @traces)
-          "no :rf.error/no-such-handler — the default handler resolved the dispatch")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring). BOTH of these
+      ;; read the trace ring, and the second is NEGATIVE: under
+      ;; -Dre-frame.debug=false the ring is empty by design, so `not-any?`
+      ;; would pass without the framework resolving anything.
+      (when interop/debug-enabled?
+        (is (= 1 (count (filter #(= :rf.route/entry-denied (:operation %)) @traces)))
+            "exactly one :rf.route/entry-denied trace — counted independently of
+             any application handler")
+        (is (not-any? #(= :rf.error/no-such-handler (:operation %)) @traces)
+            "no :rf.error/no-such-handler — the default handler resolved the dispatch"))
+      ;; SEMANTIC, posture-independent: with only the framework default in
+      ;; place the denial is still a HARD deny that commits nothing.
       (is (= :home (current-id)) "with the default handler, denial is a HARD deny")
       (is (nil? (pending))))))
 
@@ -219,11 +257,17 @@
       (rf/register-listener! :trace ::nb (fn [ev] (swap! traces conj ev)))
       (rf/dispatch-sync [:rf.route/navigate {:to :account}])
       (rf/unregister-listener! :trace ::nb)
-      (is (some (fn [ev] (and (= :rf.error/can-enter-non-boolean (:operation ev))
-                              (= :account (-> ev :tags :route-id))))
-                @traces)
-          ":rf.error/can-enter-non-boolean fired, tagged with the target route")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring). The
+      ;; fail-CLOSED semantics are pinned posture-independently below, through
+      ;; the PUBLIC :rf.route/entry-denied handler `capture-denials!` seats.
+      (when interop/debug-enabled?
+        (is (some (fn [ev] (and (= :rf.error/can-enter-non-boolean (:operation ev))
+                                (= :account (-> ev :tags :route-id))))
+                  @traces)
+            ":rf.error/can-enter-non-boolean fired, tagged with the target route"))
       (is (= 1 (count @seen)) "the non-boolean DENIED, exactly once")
+      (is (= :account (:route-id (:target (first @seen))))
+          "the denial names the guarded target — the non-boolean failed CLOSED there")
       (is (= :home (current-id))))))
 
 (deftest can-enter-guard-receives-resolved-target
@@ -423,21 +467,38 @@
       (rf/register-listener! :trace ::bad (fn [ev] (swap! traces conj ev)))
       (rf/dispatch-sync [:rf.route/navigate {:to :account :bypass-guards? #{:enter}}])
       (rf/unregister-listener! :trace ::bad)
-      (is (some (fn [ev] (and (= :rf.error/navigate-bad-request (:operation ev))
-                              (= :unknown-keys (-> ev :tags :reason))
-                              (= [:bypass-guards?] (-> ev :tags :keys))))
-                @traces)
-          ":bypass-guards? is rejected LOUD as an unknown request key")
-      (is (= :home (current-id)) "the malformed request navigated nowhere"))
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): the REJECTION is the
+      ;; always-on structural gate (`address/classify`; navigate.cljc
+      ;; §236-250), so a retired key really does buy nothing under the
+      ;; production gate — `:bypass-guards? #{:enter}` did NOT get past the
+      ;; `:can-enter` guard, and the slice never moved.
+      (is (= :home (current-id))
+          ":bypass-guards? bought no entry — the malformed request navigated nowhere")
+      (is (= [:bypass-guards?]
+             (:keys (address/classify {:to :account :bypass-guards? #{:enter}} nil)))
+          "the always-on gate names :bypass-guards? as the unknown key")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (some (fn [ev] (and (= :rf.error/navigate-bad-request (:operation ev))
+                                (= :unknown-keys (-> ev :tags :reason))
+                                (= [:bypass-guards?] (-> ev :tags :keys))))
+                  @traces)
+            ":bypass-guards? is rejected LOUD as an unknown request key")))
     ;; and the retired internal resume rider is likewise unknown
     (let [traces (atom [])]
       (rf/register-listener! :trace ::rider (fn [ev] (swap! traces conj ev)))
       (rf/dispatch-sync [:rf.route/navigate {:to :home :rf.route/enter-attempts 2}])
       (rf/unregister-listener! :trace ::rider)
-      (is (some (fn [ev] (and (= :rf.error/navigate-bad-request (:operation ev))
-                              (= :unknown-keys (-> ev :tags :reason))))
-                @traces)
-          ":rf.route/enter-attempts is no longer an internal exemption"))))
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): same always-on gate.
+      (is (= :unknown-keys
+             (:reason (address/classify {:to :home :rf.route/enter-attempts 2} nil)))
+          ":rf.route/enter-attempts is not an exemption in the always-on gate")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (some (fn [ev] (and (= :rf.error/navigate-bad-request (:operation ev))
+                                (= :unknown-keys (-> ev :tags :reason))))
+                  @traces)
+            ":rf.route/enter-attempts is no longer an internal exemption")))))
 
 (deftest repeated-denials-never-emit-a-loop-error
   (testing "entry is terminal, so a repeatedly-denied target cannot spin —
@@ -450,8 +511,15 @@
       (dotimes [_ 12] (rf/dispatch-sync [:rf.route/navigate {:to :account}]))
       (rf/unregister-listener! :trace ::loop)
       (is (= 12 (count @seen)) "each fresh attempt denies once — 12 attempts, 12 denials")
-      (is (not-any? #(= :rf.error/route-guard-loop (:operation %)) @traces)
-          ":rf.error/route-guard-loop is retired")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring). This assertion
+      ;; is NEGATIVE over the trace ring, which is EMPTY by design under
+      ;; -Dre-frame.debug=false, so outside a posture guard it would pass
+      ;; vacuously. The production-visible half of "cannot spin" — 12 attempts
+      ;; produced exactly 12 terminal denials and no pending accumulation —
+      ;; is asserted outside the arm.
+      (when interop/debug-enabled?
+        (is (not-any? #(= :rf.error/route-guard-loop (:operation %)) @traces)
+            ":rf.error/route-guard-loop is retired"))
       (is (nil? (pending)) "no pending value ever accumulated")
       (is (= :home (current-id))))))
 

--- a/implementation/routing/test/re_frame/routing_framework_authority_test.clj
+++ b/implementation/routing/test/re_frame/routing_framework_authority_test.clj
@@ -20,10 +20,37 @@
   emit ZERO `:rf.warning/app-handler-runtime-effect`, while preserving the
   POSITIVE half of the diagnostic: an ordinary app handler returning
   `:rf.db/runtime` still warns. The broad cross-subsystem conformance sweep
-  is a separate bead; this is the routing-focused regression."
+  is a separate bead; this is the routing-focused regression.
+
+  ## Posture split (rf2-o5dbf)
+
+  READ THIS BEFORE ADDING A CASE. Every `@warns` assertion in this namespace
+  reads the DEV trace bus: `:rf.warning/app-handler-runtime-effect` is emitted
+  through `trace/emit!`, which sits behind `interop/debug-enabled?`, read once
+  at load time. Under `-Dre-frame.debug=false` there is no diagnostic to
+  observe, so ALL FIVE `(is (empty? @warns))` legs pass VACUOUSLY — they
+  would report \"the framework navigation is quiet\" about a framework that
+  never spoke — and the sixth, `ordinary-app-handler-returning-runtime-db-
+  still-warns`, is precisely the control that exists to prove the other five
+  are not vacuous. It cannot do that job in a posture where the diagnostic is
+  gone.
+
+  All six are therefore inside `(when interop/debug-enabled? …)` arms marked
+  `rf2-o5dbf`, kept VERBATIM. What runs under the gate is the navigation
+  SCAFFOLDING each case drives — the route really commits, the pending slot
+  really fills and clears, `:rf.route/continue` really completes — which is
+  production-real runtime-db state and posture-independent.
+
+  Be honest about what that means: this namespace exists FOR the dev
+  diagnostic. Under the production gate it contributes routing-semantics
+  coverage only, and the ownership contract it is named for is proven in the
+  dev suite alone. That is the correct division — the diagnostic genuinely
+  does not exist in production — but it is why the roster comment for this
+  file says what it says."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.fx :as fx]
+            [re-frame.interop :as interop]
             [re-frame.routing :as routing]
             [re-frame.routing.test-support]
             [re-frame.routing-test-support :as rts]))
@@ -65,8 +92,10 @@
       (is (= :route/article (get-in (:rf.db/runtime (rf/frame-state-value :rf/default))
                                     [:rf.runtime/routing :current :route-id]))
           "the navigate handler wrote the route slice (:rf.db/runtime applied)")
-      (is (empty? @warns)
-          ":rf.route/navigate is a framework-authority writer — no ownership diagnostic"))))
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (empty? @warns)
+            ":rf.route/navigate is a framework-authority writer — no ownership diagnostic")))))
 
 (deftest url-change-event-mints-framework-authority
   (testing ":rf.route/transitioned (URL-driven) does not trip the diagnostic"
@@ -77,8 +106,10 @@
       (is (= :route/search (get-in (:rf.db/runtime (rf/frame-state-value :rf/default))
                                    [:rf.runtime/routing :current :route-id]))
           "the url-change handler wrote the route slice")
-      (is (empty? @warns)
-          ":rf.route/transitioned is a framework-authority writer — no diagnostic"))))
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (empty? @warns)
+            ":rf.route/transitioned is a framework-authority writer — no diagnostic")))))
 
 (deftest can-leave-continue-and-cancel-mint-framework-authority
   (testing "the pending-nav protocol (url-requested / continue / cancel) stays silent"
@@ -111,8 +142,10 @@
       (is (= :route/cart (get-in (:rf.db/runtime (rf/frame-state-value :rf/default))
                                  [:rf.runtime/routing :current :route-id]))
           ":rf.route/continue completed the navigation")
-      (is (empty? @warns)
-          "url-requested / continue / cancel are framework-authority writers — no diagnostic"))))
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (empty? @warns)
+            "url-requested / continue / cancel are framework-authority writers — no diagnostic")))))
 
 (deftest on-match-navigation-mints-framework-authority
   (testing "a navigation to an :on-match route (fire-and-forget) stays silent"
@@ -128,8 +161,10 @@
       (is (= :route/loaded (get-in (:rf.db/runtime (rf/frame-state-value :rf/default))
                                    [:rf.runtime/routing :current :route-id]))
           "the :on-match route committed onto the slice")
-      (is (empty? @warns)
-          "the commit-navigation path is a framework-authority writer — no diagnostic"))))
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (empty? @warns)
+            "the commit-navigation path is a framework-authority writer — no diagnostic")))))
 
 ;; ===========================================================================
 ;; The diagnostic still fires for a genuine non-framework writer (control)
@@ -143,10 +178,14 @@
                      (fn [_ _] {:rf.db/runtime {:rf.runtime/routing {:current {:route-id :hijacked}}}}))
     (let [warns (record-runtime-warnings! ::app-sneaky)]
       (rf/dispatch-sync [:app/sneaky-runtime-write])
-      (is (= 1 (count @warns))
-          "a non-framework handler writing :rf.db/runtime trips exactly one diagnostic")
-      (is (= :app/sneaky-runtime-write (-> @warns first :tags :rf.trace/event-id))
-          "the diagnostic names the offending app event-id"))))
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring). This deftest
+      ;; IS the non-vacuity control for the five quiet cases above, and it can
+      ;; only do that job in the posture where the diagnostic exists.
+      (when interop/debug-enabled?
+        (is (= 1 (count @warns))
+            "a non-framework handler writing :rf.db/runtime trips exactly one diagnostic")
+        (is (= :app/sneaky-runtime-write (-> @warns first :tags :rf.trace/event-id))
+            "the diagnostic names the offending app event-id")))))
 
 ;; ===========================================================================
 ;; Machines still mint authority (the :rf/machine? implication is preserved)
@@ -159,5 +198,7 @@
                      (fn [_ _] {:rf.db/runtime {:rf.runtime/machines {:m 1}}}))
     (let [warns (record-runtime-warnings! ::machine)]
       (rf/dispatch-sync [:machine/runtime-write])
-      (is (empty? @warns)
-          ":rf/machine? still implies framework-write authority via framework-authority?"))))
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (empty? @warns)
+            ":rf/machine? still implies framework-write authority via framework-authority?")))))

--- a/implementation/routing/test/re_frame/routing_nav_allocation_record_replay_test.clj
+++ b/implementation/routing/test/re_frame/routing_nav_allocation_record_replay_test.clj
@@ -33,10 +33,24 @@
 
   This namespace is the ADVERSARIAL acceptance: it reproduces both failures
   under the re-mint scenario (the hole) and shows them FIXED when the recorded
-  allocation is re-presented under strict replay."
+  allocation is re-presented under strict replay.
+
+  ## Posture split (rf2-o5dbf)
+
+  Both failures and both fixes are production-real and carry no posture
+  guard — the minted ids land in runtime-db, the `:rf.route/continue` no-op,
+  the stale-suppression flip and its repair are all readable off runtime-db
+  and app-db. They run in the ordinary `clojure -M:test` suite AND in
+  `scripts/test-routing-prod-gate.sh` (the `-Dre-frame.debug=false` lane).
+
+  The single exception is the `:rf.route.nav-token/stale-suppressed` TRACE,
+  dev instrumentation behind `interop/debug-enabled?`; it is kept VERBATIM
+  inside a `(when interop/debug-enabled? …)` arm marked `rf2-o5dbf`, beside
+  the app-db assertion that already proves the same suppression happened."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.fx :as fx]
+            [re-frame.interop :as interop]
             [re-frame.cofx :as cofx]
             [re-frame.routing :as routing]
             [re-frame.routing.nav-counters :as nav-counters]
@@ -183,8 +197,12 @@
       (rf/unregister-listener! :trace ::flip)
       (is (nil? (:article (rf/app-db-value :rf/default)))
           "the recorded continuation (carried nav-1) was SUPPRESSED against the re-minted nav-6 — the bug (should have committed)")
-      (is (some #(= :rf.route.nav-token/stale-suppressed (:operation %)) @traces)
-          "a stale-suppressed trace fired — the flipped decision"))))
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring). The FLIP
+      ;; itself — the recorded continuation was suppressed and never reached
+      ;; app-db — is asserted immediately above, posture-independently.
+      (when interop/debug-enabled?
+        (is (some #(= :rf.route.nav-token/stale-suppressed (:operation %)) @traces)
+            "a stale-suppressed trace fired — the flipped decision")))))
 
 (deftest failure-2-fixed-recorded-allocation-replays-same-nav-token
   (testing "rf2-vcop6y FIX: replaying the commit with the RECORDED

--- a/implementation/routing/test/re_frame/routing_prefetch_test.clj
+++ b/implementation/routing/test/re_frame/routing_prefetch_test.clj
@@ -14,9 +14,41 @@
   The DESTINATION gate at the foot drives `:rf.route/prefetch` end-to-end
   against a stubbed `:routing/on-route-prefetch` warm hook, so a destination that
   does not resolve is proven to reject BEFORE the hook is consulted — with no
-  ensures and no success summary trace."
+  ensures and no success summary trace.
+
+  ## Posture split (rf2-o5dbf)
+
+  The two GATES are production-real and carry no posture guard. The structural
+  gate `address/prefetch-address-error` and the pure payload synthesis
+  `link/prefetch-payload` are plain always-on functions, so the whole top half
+  of this namespace already ran under the gate. So does the fact each
+  destination case is really about: `@calls` is the stubbed
+  `:routing/on-route-prefetch` warm hook — a late-bound fn, not a trace — so
+  whether prefetch REACHED planning, and with which resolved identity, is
+  readable in production. Those run in the ordinary `clojure -M:test` suite
+  AND in `scripts/test-routing-prod-gate.sh` (the `-Dre-frame.debug=false`
+  lane).
+
+  What is dev-only is the REPORTING: the `:rf.route/prefetched` summary trace
+  and the `:rf.error/prefetch-bad-address` rejection both reach the caller
+  through `trace/emit!` / `trace/emit-error!`, gated on
+  `interop/debug-enabled?` and read once at load time. Those assertions are
+  kept VERBATIM inside `(when interop/debug-enabled? …)` arms marked
+  `rf2-o5dbf`.
+
+  Pay attention to the CARRIER-ABSENCE trio at the foot —
+  `(not (contains? tags :value))`, `(not (contains? tags :error))`,
+  `(not (re-find #\"SECRET-100\" (pr-str tags)))`. With no trace, `tags` is nil
+  and all three pass VACUOUSLY: they would certify a privacy guarantee about a
+  rejection payload that was never built. They are inside the arm, and outside
+  it the same ground is covered by two posture-independent facts — the
+  offending value never reached the warm plan, and `route-url`'s own ex-data
+  demonstrably DOES reproduce the raw params, so the hazard the emit-site
+  projection exists for is proven real in both postures rather than assumed.
+  Nothing was deleted or weakened."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
             [re-frame.routing :as routing]
             [re-frame.routing.address :as address]
@@ -190,13 +222,19 @@
                 trace (the gate rejects only what route-url refuses)"
         (let [{:keys [prefetched rejected]}
               (prefetch! {:to :route/probe :params {:id "7"}})]
-          (is (empty? rejected))
-          (is (= 1 (count prefetched)))
-          (is (= {:route-id :route/probe :warmed 1}
-                 (select-keys (:tags (first prefetched)) [:route-id :warmed])))
+          ;; SEMANTIC, posture-independent (rf2-o5dbf): the warm hook is a
+          ;; late-bound fn, not a trace — this is what "reached the warm plan"
+          ;; means, and it is what makes the `(empty? @calls)` assertions in
+          ;; the rejection blocks below non-vacuous.
           (is (= [{:route-id :route/probe :params {:id "7"}}]
                  (mapv #(select-keys % [:route-id :params]) @calls))
-              "the warm hook saw the resolved destination and its params")))
+              "the warm hook saw the resolved destination and its params")
+          ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+          (when interop/debug-enabled?
+            (is (empty? rejected))
+            (is (= 1 (count prefetched)))
+            (is (= {:route-id :route/probe :warmed 1}
+                   (select-keys (:tags (first prefetched)) [:route-id :warmed]))))))
 
       (testing "an UNREGISTERED destination rejects BEFORE planning — no warm
                 hook call, and critically NO success summary trace (it used to
@@ -204,44 +242,68 @@
         (reset! calls [])
         (let [{:keys [prefetched rejected]}
               (prefetch! {:to :route/does-not-exist})]
-          (is (empty? prefetched) "no :rf.route/prefetched — the trace no longer lies")
+          ;; SEMANTIC, posture-independent (rf2-o5dbf): the REJECTION is real —
+          ;; the warm plan was never consulted. The positive control above
+          ;; proves this atom does fill when prefetch reaches planning, so an
+          ;; empty one here is evidence rather than an artefact of the posture.
           (is (empty? @calls) "the warm plan was never consulted — no ensures")
-          (is (= 1 (count rejected)))
-          (is (= :no-recovery (:recovery (first rejected)))
-              "the rejection is terminal — nothing was warmed to recover")
-          (let [tags (:tags (first rejected))]
-            (is (= :no-such-route (:reason tags)))
-            (is (= :route/does-not-exist (:route-id tags)))
-            (is (= [:to] (:keys tags)))
-            (is (= :event (:where tags))))))
+          ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring). The
+          ;; `(empty? prefetched)` leg is NEGATIVE over the trace ring.
+          (when interop/debug-enabled?
+            (is (empty? prefetched) "no :rf.route/prefetched — the trace no longer lies")
+            (is (= 1 (count rejected)))
+            (is (= :no-recovery (:recovery (first rejected)))
+                "the rejection is terminal — nothing was warmed to recover")
+            (let [tags (:tags (first rejected))]
+              (is (= :no-such-route (:reason tags)))
+              (is (= :route/does-not-exist (:route-id tags)))
+              (is (= [:to] (:keys tags)))
+              (is (= :event (:where tags)))))))
 
       (testing "a REGISTERED destination with a required path param OMITTED
                 rejects too — it used to reach the warm hook as {:params {}},
                 warming the wrong resource identity"
         (reset! calls [])
         (let [{:keys [prefetched rejected]} (prefetch! {:to :route/probe})]
-          (is (empty? prefetched))
-          (is (empty? @calls))
-          (is (= 1 (count rejected)))
-          (let [tags (:tags (first rejected))]
-            (is (= :missing-route-param (:reason tags)))
-            (is (= [:id] (:keys tags)) "the offending param KEY is named")
-            (is (= :route/probe (:route-id tags)))))
+          ;; SEMANTIC, posture-independent (rf2-o5dbf): the pre-fix bug was that
+          ;; the warm hook was reached as `{:params {}}` — the WRONG resource
+          ;; identity. An empty `@calls` is precisely the absence of that.
+          (is (empty? @calls) "the warm hook was never reached with {:params {}}")
+          ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+          (when interop/debug-enabled?
+            (is (empty? prefetched))
+            (is (= 1 (count rejected)))
+            (let [tags (:tags (first rejected))]
+              (is (= :missing-route-param (:reason tags)))
+              (is (= [:id] (:keys tags)) "the offending param KEY is named")
+              (is (= :route/probe (:route-id tags))))))
         (testing "and an empty-string param — the un-round-trippable zero-length
                   segment — rejects on the same channel"
           (reset! calls [])
           (let [{:keys [prefetched rejected]}
                 (prefetch! {:to :route/probe :params {:id ""}})]
-            (is (empty? prefetched))
-            (is (empty? @calls))
-            (is (= :missing-route-param (:reason (:tags (first rejected))))))))
+            ;; SEMANTIC, posture-independent (rf2-o5dbf).
+            (is (empty? @calls) "the zero-length segment never reached the warm hook")
+            ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+            (when interop/debug-enabled?
+              (is (empty? prefetched))
+              (is (= :missing-route-param (:reason (:tags (first rejected)))))))))
 
       (testing "the STRUCTURAL gate still wins — a malformed request never
                 reaches the registry, so its own :reason is reported"
         (reset! calls [])
         (let [{:keys [rejected]} (prefetch! {:url "/probe/7"})]
-          (is (= :unknown-keys (:reason (:tags (first rejected)))))
-          (is (empty? @calls)))))))
+          ;; SEMANTIC, posture-independent (rf2-o5dbf): the STRUCTURAL gate
+          ;; (`address/prefetch-address-error`) is always-on, so it rejects a
+          ;; `:url`-bearing prefetch request in both postures — the warm hook
+          ;; is never reached, and the gate names the offending key itself.
+          (is (empty? @calls) "the structural gate refused before any planning")
+          (is (= :unknown-keys
+                 (:reason (address/prefetch-address-error {:url "/probe/7"})))
+              "the always-on structural gate classifies it :unknown-keys")
+          ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+          (when interop/debug-enabled?
+            (is (= :unknown-keys (:reason (:tags (first rejected)))))))))))
 
 (deftest prefetch-rejects-params-that-fail-the-routes-schema-without-leaking-them
   (let [restore (rts/with-stub-validator)]
@@ -254,28 +316,55 @@
           (testing "conforming params warm normally"
             (let [{:keys [prefetched rejected]}
                   (prefetch! {:to :route/guarded :params {:id "ok"}})]
-              (is (empty? rejected))
-              (is (= 1 (count prefetched)))
-              (is (= 1 (count @calls)))))
+              ;; SEMANTIC, posture-independent (rf2-o5dbf): the conforming
+              ;; address really reached the warm plan. This is the live control
+              ;; for the `(empty? @calls)` assertion in the rejection block.
+              (is (= 1 (count @calls)))
+              ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+              (when interop/debug-enabled?
+                (is (empty? rejected))
+                (is (= 1 (count prefetched))))))
           (testing "non-conforming params reject before planning — prefetch
                     adjudicates the address against the SAME schemas a
                     navigation does"
             (reset! calls [])
             (let [{:keys [prefetched rejected]}
                   (prefetch! {:to :route/guarded :params {:id "SECRET-100"}})]
-              (is (empty? prefetched))
+              ;; SEMANTIC, posture-independent (rf2-o5dbf): the adjudication is
+              ;; real — the non-conforming address never reached the warm plan,
+              ;; so `SECRET-100` never became a warmed resource identity. The
+              ;; conforming case above proves this atom does fill.
               (is (empty? @calls))
-              (is (= 1 (count rejected)))
-              (let [tags (:tags (first rejected))]
-                (is (= :route-url-validation (:reason tags)))
-                (is (= [:params] (:keys tags)) "the offending SLOT is named")
-                (testing "and the rejection carries NO carrier value — route-url's
-                          ex-data embeds :value (the raw params) and :error (an
-                          explainer that reproduces them), the class the navigate
-                          door has to redact at its own emit site"
-                  (is (not (contains? tags :value)))
-                  (is (not (contains? tags :error)))
-                  (is (not (re-find #"SECRET-100" (pr-str tags))))))))))
+              (is (not (re-find #"SECRET-100" (pr-str @calls)))
+                  "the offending param value never reached the warm plan")
+              ;; …and the HAZARD the redaction exists for is real in BOTH
+              ;; postures: `route-url` itself throws ex-data carrying the raw
+              ;; params under :value / :error. That is what must not be copied
+              ;; onto the rejection payload.
+              (let [ex-data' (try (routing/route-url
+                                    {:to :route/guarded :params {:id "SECRET-100"}})
+                                  nil
+                                  (catch clojure.lang.ExceptionInfo e (ex-data e)))]
+                (is (re-find #"SECRET-100" (pr-str ex-data'))
+                    "route-url's own ex-data DOES reproduce the raw params —
+                     the leak the emit-site projection has to stop"))
+              ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring). The
+              ;; three carrier-absence legs are NEGATIVE over the rejection's
+              ;; trace tags: with no trace `tags` is nil, so each would report
+              ;; a privacy guarantee about a payload that was never built.
+              (when interop/debug-enabled?
+                (is (empty? prefetched))
+                (is (= 1 (count rejected)))
+                (let [tags (:tags (first rejected))]
+                  (is (= :route-url-validation (:reason tags)))
+                  (is (= [:params] (:keys tags)) "the offending SLOT is named")
+                  (testing "and the rejection carries NO carrier value — route-url's
+                            ex-data embeds :value (the raw params) and :error (an
+                            explainer that reproduces them), the class the navigate
+                            door has to redact at its own emit site"
+                    (is (not (contains? tags :value)))
+                    (is (not (contains? tags :error)))
+                    (is (not (re-find #"SECRET-100" (pr-str tags)))))))))))
       (finally (restore)))))
 
 ;; ===========================================================================

--- a/implementation/routing/test/re_frame/routing_registry_test.clj
+++ b/implementation/routing/test/re_frame/routing_registry_test.clj
@@ -3,12 +3,39 @@
   (reg-route, match-url, route-url, the match/registry primitives, query
   coercion + the keyword-interning cap, optional groups, splats, pattern
   parsing, and metadata validation). Split from routing_test.clj per
-  rf2-u8qe7y finding 3."
+  rf2-u8qe7y finding 3.
+
+  ## Posture split (rf2-o5dbf)
+
+  The registry is production-real and almost all of this namespace carries no
+  posture guard: `reg-route` validation and its fail-loud throws, `match-url`
+  / `route-url` and their round trip, the ranking algorithm, optional groups,
+  splats, query coercion and the keyword-interning cap all run in the ordinary
+  `clojure -M:test` suite AND in `scripts/test-routing-prod-gate.sh` (the
+  `-Dre-frame.debug=false` lane).
+
+  Three deftests observed registry facts through the DEV TRACE instead: the
+  `:rf.route/registered` and `:rf.route/cleared` lifecycle ops (rf2-dn26r) and
+  the `:rf.warning/route-shadowed-by-equal-score` advisory (rf2-6gzobp). All
+  three emit through `trace/emit!`, gated on `interop/debug-enabled?` and read
+  once at load time. Their assertions are kept VERBATIM inside
+  `(when interop/debug-enabled? …)` arms marked `rf2-o5dbf`.
+
+  Two of the shadow-advisory blocks are NEGATIVE (`(is (= [] warns))` for the
+  every-app static case and the disjoint param-prefix pair) and would pass
+  vacuously under the gate. Outside the arm each of the three now asserts the
+  REGISTRY fact the trace was reporting on — read off `rf/handler-meta` and
+  `match-url`, which are always-on. In particular the shadow advisory's whole
+  claim is about which route wins at match time, so `match-url` is the natural
+  witness: `/a/7` really does resolve to the earlier registration and really
+  does carry ITS capture name, and the three disjoint static routes really are
+  all reachable. Nothing was deleted or weakened."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [clojure.string :as string]
             [re-frame.core :as rf]
             [re-frame.fx :as fx]
             [re-frame.identity :as identity]
+            [re-frame.interop :as interop]
             [re-frame.routing :as routing]
             [re-frame.routing.test-support]
             [re-frame.routing-test-support :as rts]
@@ -1086,16 +1113,27 @@
                   (fn []
                     (rf/reg-route :route/a {} "/a/:x")
                     (rf/reg-route :route/b {} "/a/:y")))]
-      (is (= 1 (count warns))
-          "exactly one warning for the conflicting pair")
-      (let [t (:tags (first warns))]
-        (is (= :route/b (:route-id t))
-            ":route-id names the NEW route — the shadowed one")
-        (is (= :route/a (:shadowed-by t))
-            ":shadowed-by names the existing winner (earlier registration
-            wins the rule-6 tiebreak)")
-        (is (= [1 1 2 1 1] (:rank t))
-            ":rank carries the tied rules-1-5 structural tuple"))))
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): the SHADOWING the warning
+      ;; describes is real match-time behaviour. `/a/7` matches both patterns
+      ;; structurally; the earlier registration wins the rule-6 tiebreak, so
+      ;; :route/b really is unreachable for this URL family. That is the fact
+      ;; the diagnostic reports, and it survives -Dre-frame.debug=false.
+      (is (= :route/a (:route-id (routing/match-url "/a/7")))
+          "the earlier registration wins the rule-6 tiebreak at match time")
+      (is (= {:x "7"} (:params (routing/match-url "/a/7")))
+          "…so the capture name is :x (:route/a's), not :y — :route/b is shadowed")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (= 1 (count warns))
+            "exactly one warning for the conflicting pair")
+        (let [t (:tags (first warns))]
+          (is (= :route/b (:route-id t))
+              ":route-id names the NEW route — the shadowed one")
+          (is (= :route/a (:shadowed-by t))
+              ":shadowed-by names the existing winner (earlier registration
+              wins the rule-6 tiebreak)")
+          (is (= [1 1 2 1 1] (:rank t))
+              ":rank carries the tied rules-1-5 structural tuple")))))
 
   (testing "equal rank alone does NOT warn — distinct single-segment static
             routes (the every-app case) register with ZERO shadow warnings"
@@ -1105,8 +1143,17 @@
                     (rf/reg-route :route/home    {} "/home")
                     (rf/reg-route :route/about   {} "/about")
                     (rf/reg-route :route/contact {} "/contact")))]
-      (is (= [] warns)
-          "N distinct static routes emit zero spurious shadow warnings")))
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): there is nothing to warn
+      ;; ABOUT — all three routes are reachable, so no URL co-matches a pair.
+      ;; Without this the `(= [] warns)` leg is vacuous under the gate.
+      (is (= [:route/home :route/about :route/contact]
+             (mapv #(:route-id (routing/match-url %)) ["/home" "/about" "/contact"]))
+          "every one of the three is reachable — the families are disjoint")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring); NEGATIVE over
+      ;; the trace ring, hence guarded.
+      (when interop/debug-enabled?
+        (is (= [] warns)
+            "N distinct static routes emit zero spurious shadow warnings"))))
 
   (testing "equal rank alone does NOT warn — distinct-literal param-prefix
             pair (/x/:id vs /y/:slug, the pair the old over-broad scan
@@ -1115,8 +1162,19 @@
                   (fn []
                     (rf/reg-route :route/x {} "/x/:id")
                     (rf/reg-route :route/y {} "/y/:slug")))]
-      (is (= [] warns)
-          "same-shape routes on disjoint URL families never warn")))
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): both are reachable under
+      ;; their OWN capture names — the pair the old over-broad scan
+      ;; false-flagged genuinely does not shadow. Without this the
+      ;; `(= [] warns)` leg is vacuous under the gate.
+      (is (= {:id "7"} (:params (routing/match-url "/x/7")))
+          "/x/:id keeps its own capture name")
+      (is (= {:slug "7"} (:params (routing/match-url "/y/7")))
+          "/y/:slug keeps its own — neither shadows the other")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring); NEGATIVE over
+      ;; the trace ring, hence guarded.
+      (when interop/debug-enabled?
+        (is (= [] warns)
+            "same-shape routes on disjoint URL families never warn"))))
 
   (testing "several co-matchable equal-rank ties name the route that
             actually wins at match time — the earliest-registered"
@@ -1129,12 +1187,20 @@
                     (rf/reg-route :route/first  {} "/m/:x")
                     (rf/reg-route :route/second {} "/m/:y")
                     (rf/reg-route :route/third  {} "/m/:z")))]
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): the warning's claim about
+      ;; WHICH route wins is a claim about `match-url`, so check it there.
+      (is (= :route/first (:route-id (routing/match-url "/m/7")))
+          "the earliest-registered intersecting tie is the match-time winner")
+      (is (= {:x "7"} (:params (routing/match-url "/m/7")))
+          "…and it is :route/first's capture name that survives, not :z's")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
       ;; :route/second warns against :route/first; :route/third ties with
       ;; BOTH but the warning names :route/first — the match-time winner.
-      (is (= 2 (count warns)))
-      (is (= {:route-id :route/third :shadowed-by :route/first}
-             (select-keys (:tags (peek warns)) [:route-id :shadowed-by]))
-          "the named winner is the earliest-registered intersecting tie"))))
+      (when interop/debug-enabled?
+        (is (= 2 (count warns)))
+        (is (= {:route-id :route/third :shadowed-by :route/first}
+               (select-keys (:tags (peek warns)) [:route-id :shadowed-by]))
+            "the named winner is the earliest-registered intersecting tie")))))
 
 (deftest route-shadow-scan-registration-benchmark
   (testing "registering a large table of same-rank distinct-literal static
@@ -2106,13 +2172,22 @@
       (rf/reg-route :route/home {} "/")
       (rf/reg-route :route/home {} "/") ;; re-register (no trace)
       (rf/unregister-listener! :trace ::reg-trace)
-      (let [reg-events (filter #(= :rf.route/registered (:operation %)) @traces)]
-        (is (= 1 (count reg-events))
-            "first-time reg-route emits :rf.route/registered exactly once")
-        (is (= :route/home (-> reg-events first :tags :route-id))
-            ":route-id rides in :tags")
-        (is (= "/" (-> reg-events first :tags :path))
-            ":path rides in :tags")))))
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): the registration the trace
+      ;; announces really landed, and the re-registration really was idempotent
+      ;; rather than additive — one route row, one path.
+      (is (= "/" (:path (rf/handler-meta :route :route/home)))
+          "the route is registered at / after both calls")
+      (is (= :route/home (:route-id (routing/match-url "/")))
+          "…and / resolves to it")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (let [reg-events (filter #(= :rf.route/registered (:operation %)) @traces)]
+          (is (= 1 (count reg-events))
+              "first-time reg-route emits :rf.route/registered exactly once")
+          (is (= :route/home (-> reg-events first :tags :route-id))
+              ":route-id rides in :tags")
+          (is (= "/" (-> reg-events first :tags :path))
+              ":path rides in :tags"))))))
 
 (deftest route-cleared-trace-on-unregister
   (testing "clear-route emits :rf.route/cleared (rf2-dn26r)"
@@ -2122,11 +2197,20 @@
       (routing/clear-route :route/transient)
       (routing/clear-route :route/transient) ;; idempotent, no trace
       (rf/unregister-listener! :trace ::cleared-trace)
-      (let [cleared-events (filter #(= :rf.route/cleared (:operation %)) @traces)]
-        (is (= 1 (count cleared-events))
-            "clear-route emits :rf.route/cleared exactly once")
-        (is (= :route/transient (-> cleared-events first :tags :route-id))
-            ":route-id rides in :tags")))))
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): the clear the trace
+      ;; announces really happened, and the SECOND clear really was idempotent
+      ;; — it neither threw nor resurrected the row.
+      (is (nil? (rf/handler-meta :route :route/transient))
+          "the route row is gone after clear-route")
+      (is (nil? (:route-id (routing/match-url "/transient")))
+          "…and /transient no longer resolves to it")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (let [cleared-events (filter #(= :rf.route/cleared (:operation %)) @traces)]
+          (is (= 1 (count cleared-events))
+              "clear-route emits :rf.route/cleared exactly once")
+          (is (= :route/transient (-> cleared-events first :tags :route-id))
+              ":route-id rides in :tags"))))))
 
 ;; ===========================================================================
 ;; rf2-aleg9 — match-against direct function-boundary tests

--- a/implementation/routing/test/re_frame/routing_scroll_test.clj
+++ b/implementation/routing/test/re_frame/routing_scroll_test.clj
@@ -2,12 +2,38 @@
   "Scroll-restoration tests for re-frame.routing (scroll-position
   save/lookup, per-frame isolation, the LRU cap, the `:rf.nav/scroll` fx
   emission, and scroll-strategy resolution precedence). Split from
-  routing_test.clj per rf2-u8qe7y finding 3."
+  routing_test.clj per rf2-u8qe7y finding 3.
+
+  ## Posture split (rf2-o5dbf)
+
+  Scroll restoration proper is production-real and carries no posture guard:
+  the save / lookup round-trip, per-frame isolation, the LRU cap and eviction
+  order, cache teardown with the frame, the `:rf.nav/scroll` fx EMISSION (what
+  the plan puts on `:fx`), and strategy-resolution precedence all run in the
+  ordinary `clojure -M:test` suite AND in `scripts/test-routing-prod-gate.sh`
+  (the `-Dre-frame.debug=false` lane).
+
+  The one exception is `nav-fx-skip-traces-use-canonical-rf-fx-id-tag`, which
+  is about a TRACE TAG SPELLING — that the four `:rf.nav/*` JVM skip paths
+  stamp the canonical `:rf.fx/id` rather than a bare `:fx-id`. Tag spelling is
+  a property of `:rf.fx/skipped-on-platform` events, emitted through
+  `trace/emit!` behind `interop/debug-enabled?`, so under the real gate there
+  are no events to spell anything. Its assertions are kept VERBATIM inside
+  `(when interop/debug-enabled? …)` arms marked `rf2-o5dbf`.
+
+  Note the five `(is (not (contains? (first tags) :fx-id)))` legs in
+  particular: with no traces `(first tags)` is nil and `(contains? nil :fx-id)`
+  is false, so each would pass VACUOUSLY — reporting that the drift was
+  removed from a tag map that was never built. Outside the arm each block now
+  asserts the always-on CAUSE of the skip instead: the fx's
+  `:platforms #{:client}` declaration (registrar state), and for the
+  frame-not-url-bound path, that the frame really is not the URL owner."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [malli.core :as m]
             [re-frame.core :as rf]
             [re-frame.fx :as fx]
             [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
             [re-frame.routing :as routing]
             [re-frame.routing.nav-fx :as nav-fx]
             [re-frame.routing.nav-fx-schemas :as nav-fx-schemas]
@@ -473,23 +499,33 @@
   (testing ":rf.nav/scroll's JVM skip-on-platform trace stamps :rf.fx/id, not bare :fx-id"
     (let [tags (capture-fx-traces
                  #(scroll/scroll-fx-handler nil {:strategy :top}))]
-      (is (= 1 (count tags))
-          "the JVM :rf.nav/scroll handler emits exactly one skip trace")
-      (is (= :rf.nav/scroll (:rf.fx/id (first tags)))
-          "the skip trace carries :rf.fx/id :rf.nav/scroll (canonical identity tag)")
-      (is (not (contains? (first tags) :fx-id))
-          "no bare :fx-id tag remains (drift removed)")))
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): the skip's always-on cause.
+      (is (= #{:client} (:platforms (rf/handler-meta :fx :rf.nav/scroll)))
+          ":rf.nav/scroll is declared :client-only — that is what makes the JVM skip")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (= 1 (count tags))
+            "the JVM :rf.nav/scroll handler emits exactly one skip trace")
+        (is (= :rf.nav/scroll (:rf.fx/id (first tags)))
+            "the skip trace carries :rf.fx/id :rf.nav/scroll (canonical identity tag)")
+        (is (not (contains? (first tags) :fx-id))
+            "no bare :fx-id tag remains (drift removed)"))))
 
   (testing ":rf.nav/capture-scroll's JVM skip-on-platform trace stamps :rf.fx/id"
     (let [tags (capture-fx-traces
                  #(scroll/capture-scroll-handler {:frame :rf/default}
                                                  {:url "/articles/intro"}))]
-      (is (= 1 (count tags))
-          "the JVM :rf.nav/capture-scroll handler emits exactly one skip trace")
-      (is (= :rf.nav/capture-scroll (:rf.fx/id (first tags)))
-          "the skip trace carries :rf.fx/id :rf.nav/capture-scroll")
-      (is (not (contains? (first tags) :fx-id))
-          "no bare :fx-id tag remains")))
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): the skip's always-on cause.
+      (is (= #{:client} (:platforms (rf/handler-meta :fx :rf.nav/capture-scroll)))
+          ":rf.nav/capture-scroll is declared :client-only")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (= 1 (count tags))
+            "the JVM :rf.nav/capture-scroll handler emits exactly one skip trace")
+        (is (= :rf.nav/capture-scroll (:rf.fx/id (first tags)))
+            "the skip trace carries :rf.fx/id :rf.nav/capture-scroll")
+        (is (not (contains? (first tags) :fx-id))
+            "no bare :fx-id tag remains"))))
 
   (testing ":rf.nav/push-url's JVM owner-skip trace stamps :rf.fx/id"
     ;; :rf/default is the URL owner in this suite (reset-runtime declares
@@ -497,22 +533,32 @@
     ;; (history.pushState is browser-only), emitting :rf.fx/skipped-on-platform.
     (let [tags (capture-fx-traces
                  #(nav-fx/push-url-handler {:frame :rf/default} "/articles"))]
-      (is (= 1 (count tags))
-          "the JVM :rf.nav/push-url handler emits exactly one skip trace")
-      (is (= :rf.nav/push-url (:rf.fx/id (first tags)))
-          "the skip trace carries :rf.fx/id :rf.nav/push-url")
-      (is (not (contains? (first tags) :fx-id))
-          "no bare :fx-id tag remains")))
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): the skip's always-on cause.
+      (is (= #{:client} (:platforms (rf/handler-meta :fx :rf.nav/push-url)))
+          ":rf.nav/push-url is declared :client-only")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (= 1 (count tags))
+            "the JVM :rf.nav/push-url handler emits exactly one skip trace")
+        (is (= :rf.nav/push-url (:rf.fx/id (first tags)))
+            "the skip trace carries :rf.fx/id :rf.nav/push-url")
+        (is (not (contains? (first tags) :fx-id))
+            "no bare :fx-id tag remains"))))
 
   (testing ":rf.nav/replace-url's JVM owner-skip trace stamps :rf.fx/id"
     (let [tags (capture-fx-traces
                  #(nav-fx/replace-url-handler {:frame :rf/default} "/articles"))]
-      (is (= 1 (count tags))
-          "the JVM :rf.nav/replace-url handler emits exactly one skip trace")
-      (is (= :rf.nav/replace-url (:rf.fx/id (first tags)))
-          "the skip trace carries :rf.fx/id :rf.nav/replace-url")
-      (is (not (contains? (first tags) :fx-id))
-          "no bare :fx-id tag remains")))
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): the skip's always-on cause.
+      (is (= #{:client} (:platforms (rf/handler-meta :fx :rf.nav/replace-url)))
+          ":rf.nav/replace-url is declared :client-only")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (= 1 (count tags))
+            "the JVM :rf.nav/replace-url handler emits exactly one skip trace")
+        (is (= :rf.nav/replace-url (:rf.fx/id (first tags)))
+            "the skip trace carries :rf.fx/id :rf.nav/replace-url")
+        (is (not (contains? (first tags) :fx-id))
+            "no bare :fx-id tag remains"))))
 
   (testing ":rf.nav/push-url's frame-not-url-bound skip trace also stamps :rf.fx/id"
     ;; A non-URL-bound frame skips the history push with :reason
@@ -521,11 +567,18 @@
     (rf/make-frame {:id :story/variant})              ;; no :url-bound?
     (let [tags (capture-fx-traces
                  #(nav-fx/push-url-handler {:frame :story/variant} "/articles"))]
-      (is (= 1 (count tags))
-          "a non-URL-bound frame's :rf.nav/push-url emits exactly one skip trace")
-      (is (= :rf.nav/push-url (:rf.fx/id (first tags)))
-          "the frame-not-url-bound skip trace carries :rf.fx/id :rf.nav/push-url")
-      (is (= :frame-not-url-bound (:reason (first tags)))
-          "it is the frame-not-url-bound skip path (not the platform skip)")
-      (is (not (contains? (first tags) :fx-id))
-          "no bare :fx-id tag remains"))))
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): the OTHER skip path's
+      ;; always-on cause — :story/variant is not the URL owner, so the push
+      ;; has nothing to push to whatever the posture.
+      (is (= :rf/default (routing/url-owner-frame-id))
+          ":story/variant is not the URL owner — the frame-not-url-bound skip path")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (= 1 (count tags))
+            "a non-URL-bound frame's :rf.nav/push-url emits exactly one skip trace")
+        (is (= :rf.nav/push-url (:rf.fx/id (first tags)))
+            "the frame-not-url-bound skip trace carries :rf.fx/id :rf.nav/push-url")
+        (is (= :frame-not-url-bound (:reason (first tags)))
+            "it is the frame-not-url-bound skip path (not the platform skip)")
+        (is (not (contains? (first tags) :fx-id))
+            "no bare :fx-id tag remains")))))

--- a/implementation/routing/test/re_frame/routing_subs_test.clj
+++ b/implementation/routing/test/re_frame/routing_subs_test.clj
@@ -2,10 +2,28 @@
   "Framework-sub tests for re-frame.routing (`:rf/route` and the
   `:rf.route/*` derived subs, `:rf.route/chain` nested-layout chain,
   `:rf/pending-navigation`, and the activated/deactivated lifecycle
-  trace). Split from routing_test.clj per rf2-u8qe7y finding 3."
+  trace). Split from routing_test.clj per rf2-u8qe7y finding 3.
+
+  ## Posture split (rf2-o5dbf)
+
+  The subs are production-real and carry no posture guard: `:rf/route`, the
+  derived `:rf.route/*` family, the nested-layout `:rf.route/chain` and
+  `:rf/pending-navigation` all run in the ordinary `clojure -M:test` suite AND
+  in `scripts/test-routing-prod-gate.sh` (the `-Dre-frame.debug=false` lane).
+
+  The activated/deactivated LIFECYCLE TRACE is not a sub — it is dev
+  instrumentation emitted through `trace/emit!`, gated on
+  `interop/debug-enabled?` and read once at load time. Its assertions are kept
+  VERBATIM inside a `(when interop/debug-enabled? …)` arm marked `rf2-o5dbf`.
+  Two of them are NEGATIVE (`(is (empty? …))` for the first-nav and same-id
+  cases); with no trace bus they would pass vacuously, which is why they are
+  inside the arm rather than left beside the semantics. In their place the
+  route slice really did move — and, for the same-id case, really did not —
+  which is posture-independent and asserted outside the arm."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.fx :as fx]
+            [re-frame.interop :as interop]
             [re-frame.routing :as routing]
             [re-frame.routing.test-support]
             [re-frame.routing-test-support :as rts]))
@@ -157,36 +175,59 @@
       (rf/register-listener! :trace ::act1 (fn [ev] (swap! traces conj ev)))
       (rf/dispatch-sync [:rf.route/navigate {:to :route/from}])
       (rf/unregister-listener! :trace ::act1)
-      (is (= [:route/from]
-             (map #(-> % :tags :route-id)
-                  (filter #(= :rf.route/activated (:operation %)) @traces)))
-          "first nav: :rf.route/activated for :route/from")
-      (is (empty? (filter #(= :rf.route/deactivated (:operation %)) @traces))
-          "first nav (no prior): :rf.route/deactivated does NOT fire"))
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): the activation the trace
+      ;; announces really happened — the slice moved to :route/from from
+      ;; nothing, which is the "no prior route" the second leg is about.
+      (is (= :route/from @(rf/subscribe [:rf.route/id]))
+          "first nav landed on :route/from")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring); the second leg
+      ;; is NEGATIVE over the trace ring, hence guarded.
+      (when interop/debug-enabled?
+        (is (= [:route/from]
+               (map #(-> % :tags :route-id)
+                    (filter #(= :rf.route/activated (:operation %)) @traces)))
+            "first nav: :rf.route/activated for :route/from")
+        (is (empty? (filter #(= :rf.route/deactivated (:operation %)) @traces))
+            "first nav (no prior): :rf.route/deactivated does NOT fire")))
     ;; Cross-route nav: both fire in deactivated→activated order.
     (let [traces (atom [])]
       (rf/register-listener! :trace ::act2 (fn [ev] (swap! traces conj ev)))
       (rf/dispatch-sync [:rf.route/navigate {:to :route/to}])
       (rf/unregister-listener! :trace ::act2)
-      (let [lifecycle (filter #(#{:rf.route/activated :rf.route/deactivated}
-                                (:operation %))
-                              @traces)]
-        (is (= [:rf.route/deactivated :rf.route/activated]
-               (map :operation lifecycle))
-            "cross-route nav: deactivated → activated in that order")
-        (is (= :route/from
-               (-> (first lifecycle) :tags :route-id))
-            ":deactivated carries the prior route-id")
-        (is (= :route/to
-               (-> (second lifecycle) :tags :route-id))
-            ":activated carries the next route-id")))
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): the cross-route transition
+      ;; the pair announces really happened.
+      (is (= :route/to @(rf/subscribe [:rf.route/id]))
+          "cross-route nav moved the slice from :route/from to :route/to")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (let [lifecycle (filter #(#{:rf.route/activated :rf.route/deactivated}
+                                  (:operation %))
+                                @traces)]
+          (is (= [:rf.route/deactivated :rf.route/activated]
+                 (map :operation lifecycle))
+              "cross-route nav: deactivated → activated in that order")
+          (is (= :route/from
+                 (-> (first lifecycle) :tags :route-id))
+              ":deactivated carries the prior route-id")
+          (is (= :route/to
+                 (-> (second lifecycle) :tags :route-id))
+              ":activated carries the next route-id"))))
     ;; Same-id navigation: neither fires (route stays active across the transition).
     (let [traces (atom [])]
       (rf/register-listener! :trace ::act3 (fn [ev] (swap! traces conj ev)))
       (rf/dispatch-sync [:rf.route/navigate {:to :route/to}])
       (rf/unregister-listener! :trace ::act3)
-      (let [lifecycle (filter #(#{:rf.route/activated :rf.route/deactivated}
-                                (:operation %))
-                              @traces)]
-        (is (empty? lifecycle)
-            "same-id navigation: neither lifecycle trace fires")))))
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): the route STAYED active
+      ;; across the transition — that is the fact the two silent traces encode,
+      ;; and without it the `(empty? lifecycle)` leg below would pass vacuously
+      ;; under the gate.
+      (is (= :route/to @(rf/subscribe [:rf.route/id]))
+          "same-id navigation left the slice on :route/to (the route stayed active)")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring); NEGATIVE over
+      ;; the trace ring, hence guarded.
+      (when interop/debug-enabled?
+        (let [lifecycle (filter #(#{:rf.route/activated :rf.route/deactivated}
+                                  (:operation %))
+                                @traces)]
+          (is (empty? lifecycle)
+              "same-id navigation: neither lifecycle trace fires"))))))

--- a/implementation/routing/test/re_frame/routing_uncaptured_param_test.clj
+++ b/implementation/routing/test/re_frame/routing_uncaptured_param_test.clj
@@ -37,10 +37,35 @@
 
   Covers the emission boundary, both activation doors, prefetch, and the
   adversarial trio the fix has to keep apart: a param that IS captured, a param
-  that is NOT, and a route with no params at all."
+  that is NOT, and a route with no params at all.
+
+  ## Posture split (rf2-o5dbf)
+
+  The REJECTION is production-real and carries no posture guard. `route-url`
+  THROWS (so the emission-boundary and link-door cases were already
+  posture-independent), the programmatic door leaves the slice untouched and
+  pushes no history entry, and prefetch never consults the warm hook. Those
+  run in the ordinary `clojure -M:test` suite AND in
+  `scripts/test-routing-prod-gate.sh` (the `-Dre-frame.debug=false` lane).
+
+  What is dev-only is how the rejection is ANNOUNCED on the two EVENT doors:
+  `:rf.error/schema-validation-failure` and `:rf.error/prefetch-bad-address`
+  reach the caller through `trace/emit-error!`, gated on
+  `interop/debug-enabled?` and read once at load time. (The comment `the
+  always-on channel` beside one of them means always-on with respect to the
+  SCHEMAS ARTEFACT — the diagnostic does not require it to be loaded — not
+  with respect to the production gate.) Those assertions are kept VERBATIM
+  inside `(when interop/debug-enabled? …)` arms marked `rf2-o5dbf`.
+
+  Two of them are NEGATIVE over the recorder — `(is (empty? rejected))` on the
+  positive control and `(is (empty? prefetched))` on the rejection case — and
+  would pass vacuously under the gate. They are inside the arm; the
+  production-visible half of each (the warm hook WAS consulted, exactly once,
+  with the captured-param plan / was never consulted at all) sits outside it."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.fx :as fx]
+            [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
             [re-frame.routing :as routing]
             [re-frame.routing.link :as link]
@@ -191,8 +216,12 @@
           [traces {:pred #(= :rf.error/schema-validation-failure (:operation %))}]
           (rf/dispatch-sync [:rf.route/navigate {:to     :route/probe
                                                  :params {:id "7" :extra "x"}}])
-          (is (= 1 (count @traces)) "the caller bug surfaces on the always-on channel")
-          (is (= :route/probe (:route-id (:tags (first @traces))))))
+          ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring). The
+          ;; REJECTION itself is asserted immediately below, on the slice and
+          ;; on the push log, posture-independently.
+          (when interop/debug-enabled?
+            (is (= 1 (count @traces)) "the caller bug surfaces on the always-on channel")
+            (is (= :route/probe (:route-id (:tags (first @traces)))))))
         (is (= before (current-slice)) "slice unchanged — nothing was committed")
         (is (= :route/elsewhere (:route-id (current-slice))))
         (is (empty? @pushed) "and no history entry was pushed")))
@@ -229,9 +258,14 @@
                          :rejected   (:rf.error/prefetch-bad-address @traces)}))]
         (testing "POSITIVE CONTROL — the captured-param address still warms"
           (let [{:keys [prefetched rejected]} (collect {:to :route/probe :params {:id "7"}})]
-            (is (empty? rejected))
-            (is (= 1 (count prefetched)))
-            (is (= [{:route-id :route/probe :params {:id "7"}}] @calls))))
+            ;; SEMANTIC, posture-independent (rf2-o5dbf): the warm hook really
+            ;; ran, exactly once, on the captured-param plan. Without this the
+            ;; `(empty? rejected)` leg is vacuous under the gate.
+            (is (= [{:route-id :route/probe :params {:id "7"}}] @calls))
+            ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+            (when interop/debug-enabled?
+              (is (empty? rejected))
+              (is (= 1 (count prefetched))))))
 
         (testing "an uncaptured param rejects BEFORE planning, on the SAME
                   boundary the activation doors refuse it at — prefetch warmed
@@ -239,12 +273,16 @@
           (reset! calls [])
           (let [{:keys [prefetched rejected]}
                 (collect {:to :route/probe :params {:id "7" :extra "x"}})]
-            (is (empty? prefetched) "no success summary trace")
+            ;; SEMANTIC, posture-independent (rf2-o5dbf): the address was
+            ;; refused BEFORE planning, so nothing was warmed.
             (is (empty? @calls) "the warm hook was never consulted — no ensures")
-            (is (= 1 (count rejected)))
-            (let [tags (:tags (first rejected))]
-              (is (= :route-url-validation (:reason tags))
-                  "the bare name of the boundary's error id, as Spec 009 specifies")
-              (is (= [:params] (:keys tags)) "the offending SLOT is named")
-              (is (= :route/probe (:route-id tags)))))))
+            ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+            (when interop/debug-enabled?
+              (is (empty? prefetched) "no success summary trace")
+              (is (= 1 (count rejected)))
+              (let [tags (:tags (first rejected))]
+                (is (= :route-url-validation (:reason tags))
+                    "the bare name of the boundary's error id, as Spec 009 specifies")
+                (is (= [:params] (:keys tags)) "the offending SLOT is named")
+                (is (= :route/probe (:route-id tags))))))))
       (finally (late-bind/set-fn! :routing/on-route-prefetch nil)))))

--- a/implementation/routing/test/re_frame/routing_url_bound_test.clj
+++ b/implementation/routing/test/re_frame/routing_url_bound_test.clj
@@ -2,10 +2,30 @@
   "Multi-frame URL-ownership tests for re-frame.routing (the `:url-bound?`
   exclusivity hook, duplicate-URL-binding diagnostics, the
   single-owner-drives-navigation rule, and the non-URL-bound push no-op).
-  Split from routing_test.clj per rf2-u8qe7y finding 3."
+  Split from routing_test.clj per rf2-u8qe7y finding 3.
+
+  ## Posture split (rf2-o5dbf)
+
+  URL OWNERSHIP is production-real and carries no posture guard: which frame
+  `routing/url-owner-frame-id` reports, that a duplicate binding is STORED
+  rather than rejected, that only the deterministic owner drives navigation,
+  that reconcile fails CLOSED on an ambiguous multi-binding load order, and
+  that a non-URL-bound frame's push is a no-op. Those run in the ordinary
+  `clojure -M:test` suite AND in `scripts/test-routing-prod-gate.sh` (the
+  `-Dre-frame.debug=false` lane).
+
+  The `:rf.error/duplicate-url-binding` DIAGNOSTIC is dev instrumentation —
+  `trace/emit-error!` sits behind `interop/debug-enabled?`, read once at load
+  time. Its assertions are kept VERBATIM inside `(when interop/debug-enabled?
+  …)` arms marked `rf2-o5dbf`. One of them is NEGATIVE
+  (`non-default-frame-without-url-bound-does-not-collide`): with no trace bus
+  it would pass vacuously, so it is inside the arm with the ownership fact it
+  is really about — `:rf/default` still owns the URL after both non-bound
+  registrations — asserted outside."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.fx :as fx]
+            [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
             [re-frame.routing :as routing]
             [re-frame.routing.test-support]
@@ -31,12 +51,19 @@
       ;; owner, so a second frame opting in collides with it.
       (rf/make-frame {:id :my-frame :url-bound? true})
       (rf/unregister-listener! :trace ::dup-bind)
-      (is (some (fn [ev]
-                  (and (= :rf.error/duplicate-url-binding (:operation ev))
-                       (= :rf/default (-> ev :tags :existing-frame))
-                       (= :my-frame   (-> ev :tags :offending-frame))))
-                @traces)
-          ":rf.error/duplicate-url-binding emitted with both frame ids"))))
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): the collision is resolved
+      ;; the same way in both postures — the incumbent keeps the URL and the
+      ;; late claimant does not steal it. Only the announcement is dev-only.
+      (is (= :rf/default (routing/url-owner-frame-id))
+          "the incumbent :rf/default keeps URL ownership; :my-frame did not steal it")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (some (fn [ev]
+                    (and (= :rf.error/duplicate-url-binding (:operation ev))
+                         (= :rf/default (-> ev :tags :existing-frame))
+                         (= :my-frame   (-> ev :tags :offending-frame))))
+                  @traces)
+            ":rf.error/duplicate-url-binding emitted with both frame ids")))))
 
 (deftest non-default-frame-without-url-bound-does-not-collide
   (testing "registering a non-default frame WITHOUT :url-bound? true is
@@ -47,9 +74,17 @@
       (rf/make-frame {:id :story/variant-A})              ;; no :url-bound?
       (rf/make-frame {:id :test/fixture :url-bound? false}) ;; explicit off
       (rf/unregister-listener! :trace ::no-dup)
-      (is (empty? (filter #(= :rf.error/duplicate-url-binding (:operation %))
-                          @traces))
-          "no duplicate-url-binding trace fires for non-URL-bound frames"))))
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): neither frame claimed the
+      ;; URL, so the incumbent owner is untouched. That is the fact the silent
+      ;; diagnostic encodes; without it the leg below is vacuous under the gate.
+      (is (= :rf/default (routing/url-owner-frame-id))
+          ":rf/default still owns the URL — neither non-bound frame claimed it")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring); NEGATIVE over
+      ;; the trace ring, hence guarded.
+      (when interop/debug-enabled?
+        (is (empty? (filter #(= :rf.error/duplicate-url-binding (:operation %))
+                            @traces))
+            "no duplicate-url-binding trace fires for non-URL-bound frames")))))
 
 (deftest push-url-noop-from-non-url-bound-frame
   (testing ":rf.nav/push-url skips on a non-URL-bound frame and emits
@@ -185,11 +220,20 @@
       ;; one conflict.
       (rf/make-frame {:id :my-conflicting-frame :url-bound? true})
       (rf/unregister-listener! :trace ::dup-once)
-      (let [dups (filter #(= :rf.error/duplicate-url-binding (:operation %)) @traces)]
-        (is (= 1 (count dups))
-            "one conflict → exactly one duplicate-url-binding diagnostic, regardless of reload count")
-        (is (= :my-conflicting-frame (-> dups first :tags :offending-frame))
-            "the single diagnostic names the offending frame")))))
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): however many times the
+      ;; facade was reinstalled, ownership is still resolved once and the
+      ;; incumbent still holds it.
+      (is (= :rf/default (routing/url-owner-frame-id))
+          "the repeated facade reloads did not disturb URL ownership")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring). The
+      ;; ONE-not-N fan-out this deftest is named for is a property of the
+      ;; diagnostic, so it is only observable in the posture that has one.
+      (when interop/debug-enabled?
+        (let [dups (filter #(= :rf.error/duplicate-url-binding (:operation %)) @traces)]
+          (is (= 1 (count dups))
+              "one conflict → exactly one duplicate-url-binding diagnostic, regardless of reload count")
+          (is (= :my-conflicting-frame (-> dups first :tags :offending-frame))
+              "the single diagnostic names the offending frame"))))))
 
 ;; ============================================================================
 ;; rf2-25i7r7 — finding 2: duplicate URL binding is STORED, not rejected;
@@ -417,8 +461,12 @@
       (rf/register-listener! :trace ::reconcile-dup (fn [ev] (swap! traces conj ev)))
       (url-bound/reconcile-existing-url-bindings!)
       (rf/unregister-listener! :trace ::reconcile-dup)
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): the FAIL-CLOSED half — no
+      ;; owner is picked, in either posture.
       (is (nil? (routing/url-owner-frame-id))
           "no deterministic owner for an ambiguous multi-binding load order")
-      (let [dups (filter #(= :rf.error/duplicate-url-binding (:operation %)) @traces)]
-        (is (= 1 (count dups))
-            "two pre-existing bindings → exactly one duplicate diagnostic (one extra)")))))
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (let [dups (filter #(= :rf.error/duplicate-url-binding (:operation %)) @traces)]
+          (is (= 1 (count dups))
+              "two pre-existing bindings → exactly one duplicate diagnostic (one extra)"))))))

--- a/implementation/routing/test/re_frame/routing_url_strategy_test.clj
+++ b/implementation/routing/test/re_frame/routing_url_strategy_test.clj
@@ -12,10 +12,33 @@
   contract: encode/decode shape, the encode/decode ROUND-TRIP identity, the
   ADVERSARIAL negative fixtures (malformed / mismatched forms), and
   `url-strategy-from-config` / `url-strategy-for-frame-id`. Per Spec 012
-  §URL strategies."
+  §URL strategies.
+
+  ## Posture split (rf2-o5dbf)
+
+  The fail-loud validation seam is FRAME CONSTRUCTION (rf2-ktmto9):
+  `preflight-frame-config!` runs `validate-url-strategy!` UNCONDITIONALLY at
+  `re-frame.frame/upsert-frame!`, the sole `frames`-store config writer. That
+  is production-real and is asserted here WITHOUT a posture guard — the
+  preflight tests, the engine-rejects-before-any-write test and the three
+  trusted-read store invariants all run in the ordinary `clojure -M:test`
+  suite AND in `scripts/test-routing-prod-gate.sh` (the
+  `-Dre-frame.debug=false` lane).
+
+  What is NOT production-real is the CONSULT-path tripwire. rf2-ecb4sx made
+  `url-strategy-from-config` a trusted read that pays no per-render
+  validation; what remains there is a `(when interop/debug-enabled? …)`
+  re-check, DCE'd from production CLJS bundles and dead on a JVM started with
+  `-Dre-frame.debug=false`. The two tripwire deftests below therefore branch
+  on `interop/debug-enabled?`: the dev arm keeps the fail-loud assertions
+  VERBATIM, and the production arm asserts what the trusted read actually
+  does when the tripwire is gone — it returns the declared value verbatim,
+  throwing nothing, which is the contract the ~30x consult speed-up rides on.
+  Neither arm is vacuous; nothing was deleted or weakened."
   (:require [clojure.test :refer [deftest is testing]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
             [re-frame.routing :as routing]
             [re-frame.routing.strategy :as strategy]
@@ -189,35 +212,64 @@
             test default), a truthy but NON-MAP :url-strategy still fails loud
             with :rf.error/invalid-url-strategy at the consult, backstopping the
             registration preflight for any future config-write bypass"
-    (let [ex (try (strategy/url-strategy-from-config {:url-strategy :not-a-map})
-                  nil
-                  (catch clojure.lang.ExceptionInfo e e))]
-      (is (some? ex) "a non-map :url-strategy throws under the dev tripwire")
-      (is (= :rf.error/invalid-url-strategy (:rf.error/id (ex-data ex)))
-          "the canonical structured error id is stamped")
-      (is (= :not-a-map (:url-strategy (ex-data ex)))
-          "the offending value is carried in the ex-data"))))
+    (if interop/debug-enabled?
+      ;; rf2-o5dbf — dev-tripwire arm (see ns docstring), kept verbatim.
+      (let [ex (try (strategy/url-strategy-from-config {:url-strategy :not-a-map})
+                    nil
+                    (catch clojure.lang.ExceptionInfo e e))]
+        (is (some? ex) "a non-map :url-strategy throws under the dev tripwire")
+        (is (= :rf.error/invalid-url-strategy (:rf.error/id (ex-data ex)))
+            "the canonical structured error id is stamped")
+        (is (= :not-a-map (:url-strategy (ex-data ex)))
+            "the offending value is carried in the ex-data"))
+      ;; rf2-o5dbf — production arm: the tripwire is DCE'd / gated off, so the
+      ;; consult is a pure trusted read. It must not throw and must not
+      ;; silently substitute a default — the preflight (asserted
+      ;; posture-independently below) is what keeps a value of this shape out
+      ;; of the store in the first place.
+      (is (= :not-a-map (strategy/url-strategy-from-config {:url-strategy :not-a-map}))
+          "under -Dre-frame.debug=false the consult returns the declared value
+           verbatim and pays no validation — the trusted read rf2-ecb4sx bought"))))
 
 (deftest custom-url-strategy-missing-leg-tripwire
   (testing "rf2-ecb4sx: the confirmed repro — a custom strategy missing a
             callable :encode (only :decode supplied) fails loud under the dev
             tripwire naming the bad leg"
-    (let [ex (try (strategy/url-strategy-from-config
-                    {:url-strategy {:decode (constantly "/")}})
-                  nil
-                  (catch clojure.lang.ExceptionInfo e e))]
-      (is (some? ex) "a strategy missing a required callable leg throws")
-      (is (= :rf.error/invalid-url-strategy (:rf.error/id (ex-data ex))))
-      (is (contains? (set (:missing (ex-data ex))) :encode)
-          "the missing :encode leg is named in :missing")))
+    (if interop/debug-enabled?
+      ;; rf2-o5dbf — dev-tripwire arm (see ns docstring), kept verbatim.
+      (let [ex (try (strategy/url-strategy-from-config
+                      {:url-strategy {:decode (constantly "/")}})
+                    nil
+                    (catch clojure.lang.ExceptionInfo e e))]
+        (is (some? ex) "a strategy missing a required callable leg throws")
+        (is (= :rf.error/invalid-url-strategy (:rf.error/id (ex-data ex))))
+        (is (contains? (set (:missing (ex-data ex))) :encode)
+            "the missing :encode leg is named in :missing"))
+      ;; rf2-o5dbf — production arm (see ns docstring).
+      (let [half {:decode (constantly "/")}]
+        (is (identical? half (strategy/url-strategy-from-config {:url-strategy half}))
+            "the production consult returns the declared value verbatim, throwing nothing"))))
   (testing "a non-callable leg (a non-fn value in a required slot) is rejected too"
-    (let [ex (try (strategy/url-strategy-from-config
-                    {:url-strategy {:encode "not-a-fn" :decode (constantly "/")}})
-                  nil
-                  (catch clojure.lang.ExceptionInfo e e))]
-      (is (= :rf.error/invalid-url-strategy (:rf.error/id (ex-data ex))))
-      (is (contains? (set (:missing (ex-data ex))) :encode)
-          "a non-callable :encode counts as missing"))))
+    (if interop/debug-enabled?
+      ;; rf2-o5dbf — dev-tripwire arm (see ns docstring), kept verbatim.
+      (let [ex (try (strategy/url-strategy-from-config
+                      {:url-strategy {:encode "not-a-fn" :decode (constantly "/")}})
+                    nil
+                    (catch clojure.lang.ExceptionInfo e e))]
+        (is (= :rf.error/invalid-url-strategy (:rf.error/id (ex-data ex))))
+        (is (contains? (set (:missing (ex-data ex))) :encode)
+            "a non-callable :encode counts as missing"))
+      ;; rf2-o5dbf — production arm. The REJECTION of this exact value is not
+      ;; lost under the gate: `preflight-carries-frame-id-in-ex-data` and
+      ;; `make-frame-engine-rejects-malformed-strategy-before-any-write` below
+      ;; assert it posture-independently at the registration chokepoint.
+      (let [non-callable {:encode "not-a-fn" :decode (constantly "/")}]
+        (is (identical? non-callable
+                        (strategy/url-strategy-from-config {:url-strategy non-callable}))
+            "the production consult returns the declared value verbatim, throwing nothing")
+        (is (thrown? clojure.lang.ExceptionInfo
+                     (strategy/preflight-frame-config! :t/owner {:url-strategy non-callable}))
+            "…and the ungated registration preflight still rejects it LOUD")))))
 
 (deftest url-strategy-from-config-is-a-trusted-read
   (testing "rf2-ecb4sx: a SHAPE-VALID declared strategy resolves by identity —

--- a/scripts/test-routing-prod-gate.sh
+++ b/scripts/test-routing-prod-gate.sh
@@ -170,8 +170,15 @@ known_red=(
   re-frame.routing-nav-token-test                 # 32
   re-frame.routing-navigation-test                # 64
   re-frame.routing-plan-seam-test                 # 31
-  re-frame.routing-prefetch-test                  # 18
-
+  #    CLEARED 2026-07-27 (rf2-o5dbf, batch 5): routing-prefetch.  Its
+  #    `@calls` atom is the stubbed `:routing/on-route-prefetch` warm hook —
+  #    a late-bound fn, NOT a trace — so "did prefetch reach planning, and
+  #    with which resolved identity" was always production-visible; only the
+  #    summary / rejection REPORTING is dev-gated.  Note the carrier-absence
+  #    trio at its foot: with no trace the `tags` map is nil, so all three
+  #    would have certified a PRIVACY guarantee about a payload that was
+  #    never built.
+  #
   #    CLEARED 2026-07-27 (rf2-o5dbf, batch 4): routing-registry,
   #    routing-scroll.  Both had NEGATIVE trace assertions that this roster
   #    line was hiding — the shadow advisory's two "registers with ZERO

--- a/scripts/test-routing-prod-gate.sh
+++ b/scripts/test-routing-prod-gate.sh
@@ -84,17 +84,26 @@ test_root="$artefact/test"
 # leave a stale exclusion quietly suppressing coverage.
 # ---------------------------------------------------------------------------
 known_red=(
-  # ── rf2-o5dbf — NOT obviously instrumentation, and first in the triage
-  #    queue.  Each of these fails on an assertion about a LOUD REJECTION
-  #    rather than about a trace payload: a malformed `:url-strategy`, a
-  #    non-boolean `:can-leave` return, a heterogeneous unknown-key set.  If
-  #    any of those rejections is meant to survive production and does not,
-  #    that is an rf2-9c2jf-class defect and not a posture test.  Somebody
-  #    has to look before they are written off.
-  re-frame.routing-boundary-totality-cljs-test    #  3
-  re-frame.routing-can-leave-test                 # 10
-  re-frame.routing-url-strategy-test              #  8
-  re-frame.routing-entry-denied-test              #  4
+  # ── rf2-o5dbf — CLEARED 2026-07-27.  The four LOUD-REJECTION tripwires
+  #    (`routing-boundary-totality-cljs-test`, `routing-can-leave-test`,
+  #    `routing-url-strategy-test`, `routing-entry-denied-test`) were the
+  #    first triage batch, because each one had to be read before it could be
+  #    written off as instrumentation.  Verdict: EVERY rejection those suites
+  #    assert does survive production — none is an rf2-9c2jf-class defect.
+  #    What is dev-only is the CHANNEL each was observed through, and in two
+  #    cases the observation was worse than dev-only:
+  #      * `denial-is-safe-with-no-application-handler` and
+  #        `repeated-denials-never-emit-a-loop-error` each asserted a NEGATIVE
+  #        over the trace ring (`not-any? :rf.error/no-such-handler` /
+  #        `:rf.error/route-guard-loop`).  Under the gate that ring is empty
+  #        by design, so both would have passed VACUOUSLY the moment the
+  #        roster line came off.  They are now inside the posture arm, with
+  #        the deny itself asserted outside it.
+  #      * the `url-strategy` consult tripwire is dev-only BY DESIGN
+  #        (rf2-ecb4sx made the consult a trusted read); the production-real
+  #        defence is the ungated registration preflight, which the same
+  #        namespace already pins posture-independently.
+  #    All four now carry a "## Posture split (rf2-o5dbf)" ns docstring.
 
   # ── rf2-o5dbf — the CLASSIFICATION / PRIVACY suites.  rf2-u2x6w already
   #    carved the always-on production legs of the egress contract into

--- a/scripts/test-routing-prod-gate.sh
+++ b/scripts/test-routing-prod-gate.sh
@@ -105,21 +105,29 @@ known_red=(
   #        namespace already pins posture-independently.
   #    All four now carry a "## Posture split (rf2-o5dbf)" ns docstring.
 
-  # ── rf2-o5dbf — the CLASSIFICATION / PRIVACY suites.  rf2-u2x6w already
-  #    carved the always-on production legs of the egress contract into
-  #    `re-frame.routing-sub-egress-production-test`, which is IN this lane
-  #    and green; what is left here should be the dev-trace half.  "Should
-  #    be" is a claim to verify, not to assume — sub-classification is the
-  #    one invariant in this artefact whose failure is a privacy incident.
+  # ── rf2-o5dbf — the CLASSIFICATION / PRIVACY suites, CLEARED 2026-07-27.
+  #    The claim to verify was that what remained in `routing-egress-test`
+  #    beyond rf2-u2x6w's carve-out was the dev-trace half.  VERIFIED, and
+  #    the split is now explicit in both namespaces' docstrings: the
+  #    `:sensitive` RETENTION (`rf/handler-meta`, both public arities), the
+  #    pure carrier scrub (`egress/redact-url-carriers` /
+  #    `redact-url-tag`), the in-process rawness, the lowering / re-rooting
+  #    into the elision registry and the real SSR `payload-policy` consumer
+  #    are all production-real and now run under the gate.  Only readings OFF
+  #    THE TRACE BUS are dev-gated.
   #
-  #    NOTE, and this is the trap `test-core-prod-gate.sh` documents as the
-  #    `conformance-test` case: excluding `routing-egress-test` takes its
-  #    ALWAYS-ON legs out of the lane along with its dev-trace ones.  That is
-  #    survivable here only because rf2-u2x6w moved those legs into the
-  #    dedicated namespace above.  Do not exclude a namespace whose always-on
-  #    witnesses have no other home.
-  re-frame.routing-egress-test                    # 43
-  re-frame.routing-classification-test            # 12
+  #    Both suites also carried VACUOUS PASSES that this roster line was
+  #    hiding: `(not (re-find #"SECRET100" (pr-str payload)))` over a nil
+  #    trace payload, and four `(is (empty? warnings))` advisory-quiet tests
+  #    over an empty trace ring.  Each would have reported a privacy
+  #    guarantee the framework never executed the moment the line came off.
+  #    They are inside the posture arm now, and the always-on DETECTION
+  #    (`classification/unpromoted-query-keys`) is asserted in their place.
+  #
+  #    The `conformance-test` trap `test-core-prod-gate.sh` documents no
+  #    longer applies to these two, but the rule still does: do not exclude a
+  #    namespace whose always-on witnesses have no other home.
+  #    `re-frame.routing-sub-egress-production-test` stays IN the lane.
 
   # ── rf2-o5dbf — dev-instrumentation assertions written inline with the
   #    semantics they sit next to: "exactly one `:rf.route/cleared` trace

--- a/scripts/test-routing-prod-gate.sh
+++ b/scripts/test-routing-prod-gate.sh
@@ -147,9 +147,25 @@ known_red=(
   #    for a namespace that executed nothing — the false-green this lane
   #    exists to close.  Those want a var-level tag the lane excludes, not a
   #    posture guard.
-  re-frame.route-algebra-view-test                #  5
-  re-frame.routing-framework-authority-test       #  2
-  re-frame.routing-nav-allocation-record-replay-test  #  1
+  #    CLEARED 2026-07-27 (rf2-o5dbf, batch 3 — the small end of the list):
+  #    route-algebra-view, routing-framework-authority,
+  #    routing-nav-allocation-record-replay, routing-subs,
+  #    routing-uncaptured-param, routing-url-bound.  Each now carries a
+  #    "## Posture split (rf2-o5dbf)" ns docstring.
+  #
+  #    `routing-framework-authority-test` is the closest thing in this
+  #    artefact to the "no semantic residue" case the note above warns about,
+  #    and is called out here because the next reader deserves to know: FIVE
+  #    of its six deftests assert `(is (empty? @warns))` over the
+  #    `:rf.warning/app-handler-runtime-effect` trace, and the sixth is
+  #    explicitly the control that proves the other five are not vacuous.
+  #    Under the gate every one of those six is meaningless, so all six are
+  #    inside the posture arm.  It stays in the lane because the navigation
+  #    SCAFFOLDING each case drives — the route commits, the pending slot
+  #    fills and clears, `:rf.route/continue` completes — is real runtime-db
+  #    state that does execute.  Be clear-eyed about the trade: under the
+  #    production gate this namespace contributes routing semantics, not the
+  #    ownership contract it is named for.
   re-frame.routing-nav-fx-schemas-test            # 32
   re-frame.routing-nav-token-test                 # 32
   re-frame.routing-navigation-test                # 64
@@ -157,9 +173,6 @@ known_red=(
   re-frame.routing-prefetch-test                  # 18
   re-frame.routing-registry-test                  # 11
   re-frame.routing-scroll-test                    # 11
-  re-frame.routing-subs-test                      #  4
-  re-frame.routing-uncaptured-param-test          #  7
-  re-frame.routing-url-bound-test                 #  4
 )
 
 # ---------------------------------------------------------------------------

--- a/scripts/test-routing-prod-gate.sh
+++ b/scripts/test-routing-prod-gate.sh
@@ -171,8 +171,16 @@ known_red=(
   re-frame.routing-navigation-test                # 64
   re-frame.routing-plan-seam-test                 # 31
   re-frame.routing-prefetch-test                  # 18
-  re-frame.routing-registry-test                  # 11
-  re-frame.routing-scroll-test                    # 11
+
+  #    CLEARED 2026-07-27 (rf2-o5dbf, batch 4): routing-registry,
+  #    routing-scroll.  Both had NEGATIVE trace assertions that this roster
+  #    line was hiding — the shadow advisory's two "registers with ZERO
+  #    shadow warnings" blocks, and five `(not (contains? (first tags)
+  #    :fx-id))` legs where `(first tags)` is nil under the gate.  The
+  #    always-on witnesses that replaced them are `match-url` (the shadow
+  #    advisory's whole claim is about which route wins at match time) and
+  #    the fx `:platforms #{:client}` declarations (the cause of every
+  #    skip-on-platform trace the tag-spelling test was about).
 )
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Triage of the 19 known-red namespaces in `scripts/test-routing-prod-gate.sh`, the lane rf2-hnrwo (PR #7145) built. Same method rf2-d2841 used for core: keep every instrumentation assertion VERBATIM inside a `(when interop/debug-enabled? …)` arm marked with the bead id, leave everything outside such an arm posture-independent, document the split under `## Posture split` in each ns docstring, then delete the roster line. **Nothing was deleted or weakened.**

## The lane

|                | before | after |
| -------------- | -----: | ----: |
| namespaces     |     18 |    30 |
| of total       |     37 |    37 |
| tests          |     98 |   297 |
| assertions     |    613 | 1,227 |
| known-red roster |   19 |     7 |

`re-frame.routing-sub-egress-production-test` is untouched and stays in the lane, as does the `routing-prod-gate-lane-pin-test` posture pin. `check_jvm_lane_rosters.py`'s baseline stays EMPTY.

**`RF2_MIN_TESTS` should be raised.** It is calibrated at 85 against an observed 98. The lane now runs 297 tests, so the floor is a factor of three below what it guards and would no longer catch a roster that collapsed to a third of itself. Left at 85 in this PR because it is the lane script's calibration rather than this bead's subject — flagging it for the operator rather than moving it unasked.

## Roster lines removed (12)

`route-algebra-view-test` · `routing-boundary-totality-cljs-test` · `routing-can-leave-test` · `routing-classification-test` · `routing-egress-test` · `routing-entry-denied-test` · `routing-framework-authority-test` · `routing-nav-allocation-record-replay-test` · `routing-subs-test` · `routing-uncaptured-param-test` · `routing-url-bound-test` · `routing-url-strategy-test`

## No rf2-9c2jf-class defect

The four LOUD-REJECTION tripwires were rostered first precisely because a rejection that does not survive production would be a defect rather than a posture test. **Every rejection those suites assert does survive the gate.** The malformed-`:url-strategy` defence is the ungated registration preflight (`preflight-frame-config!` at `upsert-frame!`); the `:can-leave` non-boolean fails CLOSED and writes the pending slot; the heterogeneous-unknown-key rejection is the always-on `address/classify`; the `:can-enter` denial is terminal and commits nothing. What is dev-only in each case is the CHANNEL the assertion observed through.

## Fourteen vacuous passes found and neutralized

This is the part worth reading. A **negative** assertion over the trace ring — `not-any?`, `empty?`, `(not (re-find …))` — passes AUTOMATICALLY under the gate, because the ring is empty by design. Removing a roster line without moving those inside the posture arm turns them green while proving nothing. Fourteen were sitting behind these twelve lines:

- `routing-entry-denied` — `not-any? :rf.error/no-such-handler` (the proof that the framework's default handler resolved the dispatch) and `not-any? :rf.error/route-guard-loop`.
- `routing-egress` — `(not (re-find #"SECRET100" (pr-str payload)))` under the inverse load order, which would have reported "the query secret appears NOWHERE on the egress copy" about an egress copy that was never made; plus the two `(not (re-find …))` legs in the route-miss case.
- `routing-classification` — four `(is (empty? warnings))` advisory-quiet tests.
- `routing-framework-authority` — five `(is (empty? @warns))` legs.
- `routing-subs` — the first-nav and same-id "neither lifecycle trace fires" legs.
- `routing-url-bound` — "no duplicate-url-binding trace fires for non-URL-bound frames".
- `routing-uncaptured-param` — `(is (empty? rejected))` on the prefetch positive control and `(is (empty? prefetched))` on the rejection case.

Each is now inside the arm, and each got an always-on counterpart asserted in its place rather than being left as a hole.

## Production witnesses added rather than assertions dropped

Where the trace was the only witness, a production-visible one was ADDED (the rf2-7vk3z pattern):

- **`decisions/decide` writes `:rejecting-route` and `:rejecting-guard` into the pending-navigation slot itself** — runtime-db state the `:rf/pending-navigation` sub reads in production. The four rf2-dbmj6x `:frame`-stamp tests and the `:rejecting-guard` test read it there now, including frame-locality: the block lands in `:route/owner` and `:rf/default` is untouched.
- **The `:sensitive` RETENTION is registrar state**, not a trace fact. rf2-kqxe6.20's actual fix — the framework's carrier declaration surviving a bare public `rf/reg-event` override, a hot reload, an additive app declaration, and the inverse namespace-load order — is now asserted on `rf/handler-meta` under the gate. So is the deliberate ABSENCE of a mark on `:rf.nav/push-url`.
- **`egress/redact-url-carriers` / `redact-url-tag` are plain always-on functions.** The route-miss and navigation-blocked scrubs are asserted on the exact tag maps their emit sites build.
- **`address/classify` is pure and always-on**, so the total canonical key ordering — the property that would have caught the raw-`compare` throw — is asserted on it directly.
- **`classification/unpromoted-query-keys` is the pure predicate `advise-query-promotion!` is built from.** It decides whether a route has the query-promotion footgun; only the announcement is dev-gated.
- **`:source` and `:doc` elision is itself the production contract.** Both route-algebra-view deftests branch, and the production arm asserts the strip really happened.

## One namespace called out rather than quietly rostered off

`routing-framework-authority-test` is the closest thing here to the "100% dev instrumentation, no semantic residue" case the roster's own note warns about. All six of its deftests turn on the `:rf.warning/app-handler-runtime-effect` trace, and one of them exists *purely* as the non-vacuity control for the other five — a control that cannot do its job in a posture where the diagnostic does not exist. All six are inside the posture arm. It stays in the lane because the navigation scaffolding each case drives is real runtime-db state that does execute, but the trade is stated plainly in both the ns docstring and the roster comment: under the production gate this namespace contributes routing semantics, not the ownership contract it is named for. If the operator would rather see a var-level tag and the lane skip it explicitly, that is a one-line change from here.

## What remains — 7 namespaces

Partial by design; the tail was not rushed.

| namespace | red assertions |
| --- | ---: |
| `routing-navigation-test` | 64 |
| `routing-nav-fx-schemas-test` | 32 |
| `routing-nav-token-test` | 32 |
| `routing-plan-seam-test` | 31 |
| `routing-prefetch-test` | 18 |
| `routing-registry-test` | 11 |
| `routing-scroll-test` | 11 |

All seven sampled as dev instrumentation of the same shapes already handled here, but none has been read line by line, and the vacuous-pass sweep each one needs is exactly the work that found fourteen of them in the twelve above. rf2-o5dbf stays open for them.

## Quality gates

Foreground, worktree-local logs, exit codes echoed.

| gate | result |
| --- | --- |
| `bash scripts/test-routing-prod-gate.sh` | **exit 0** — 30 namespaces, 297 tests, 1,227 assertions, 0 failures / 0 errors |
| `clojure -M:test` (implementation/routing, dev posture) | **exit 0** — 522 tests, 2,887 assertions, 0 failures / 0 errors |
| `clojure -J-Dre-frame.debug=false -M:test` (whole suite, real gate) | exit 1 — 199 failures / **0 errors**, every one inside the 7 namespaces still rostered (was 293 failures / 9 errors across 19) |

The dev-posture assertion count went **2,843 → 2,887 (+44)**. That is the mechanical proof nothing was lost: every posture-guarded assertion still runs in dev, and the +44 are the production witnesses added on top.

The gate was run REAL both ways — `bash scripts/test-routing-prod-gate.sh` and `clojure -J-Dre-frame.debug=false -M:test`, never a `with-redefs` rebind, which cannot reach a load-time gate.

**Deferred to CI**: the full JVM implementation sweep (`scripts/test-jvm-implementation.sh`), the CLJS substrate suites (`npm run test:cljs` — `routing-boundary-totality-cljs-test` is `.cljc` and also runs under `:node-test`), and `scripts/test-fast-pr.sh`. This PR touches only `implementation/routing/test/**` and the roster block of `scripts/test-routing-prod-gate.sh`; no `implementation/**/src` and no spec.

Fences respected: nothing under `implementation/ssr/**`, `scripts/test-ssr-prod-gate.sh`, `implementation/freehand/**`, `implementation/core/**`, `tools/**`, `.github/**` or `spec/**` was touched.
