### PR TITLE
test(ssr): split dev instrumentation from semantics so the prod-gate lane can grow (rf2-lwtlk)

### DIFF
--- a/implementation/ssr/test/re_frame/flows_integration_test.clj
+++ b/implementation/ssr/test/re_frame/flows_integration_test.clj
@@ -61,6 +61,7 @@
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.error-emit :as error-emit]
+            [re-frame.interop :as interop]
             [re-frame.schemas :as schemas]
             ;; Loading the Malli adapter publishes the
             ;; `:schemas/malli-validate` late-bind hook the default
@@ -117,6 +118,22 @@
   "Captured trace events whose `:operation` is `op`, in capture order."
   [op]
   (filterv #(= op (:operation %)) @*captured*))
+
+;; rf2-lwtlk — POSTURE SPLIT.  `ops` and `by-op` read the DEV trace bus, and
+;; every emit site behind them is gated on `interop/debug-enabled?`, read once
+;; at namespace-load time.  Under `-Dre-frame.debug=false` the capture atom is
+;; empty for every input, so a `by-op` assertion FAILS and — more dangerously
+;; — an `(is (not-any? … (ops)))` assertion PASSES without distinguishing the
+;; case it exists to distinguish.
+;;
+;; Both kinds are kept verbatim, wrapped in `(when interop/debug-enabled? …)`
+;; arms marked with this bead id.  Every interaction this suite pins has a
+;; posture-independent witness OUTSIDE the arm — the flow-eval log, the
+;; flow-input log, the installed app-db value, the untouched route slice, the
+;; :on-match fx counter — and those are what now run in
+;; `scripts/test-ssr-prod-gate.sh`.  The trace assertions are the
+;; trace-LEVEL restatement each deftest's own comments already call
+;; trace-level confirmation and trace signature.
 
 (defn- snapshot
   "Read the snapshot for `machine-id` from the default frame's app-db."
@@ -208,9 +225,12 @@
           "the flow output (derived from the settled machine snapshot)
            landed in app-db")
       ;; Trace-level confirmation: a single :rf.flow/computed for the event.
-      (is (= 1 (count (by-op :rf.flow/computed)))
-          "exactly one :rf.flow/computed trace fired for the macrostep
-           dispatch — no double / missed eval"))))
+      ;; rf2-lwtlk — dev-instrumentation arm. The eval COUNT it restates is
+      ;; pinned posture-independently by `(= 1 (count @flow-evals))` above.
+      (when interop/debug-enabled?
+        (is (= 1 (count (by-op :rf.flow/computed)))
+            "exactly one :rf.flow/computed trace fired for the macrostep
+             dispatch — no double / missed eval")))))
 
 ;; ===========================================================================
 ;; 2. flow-write × schema-rejection — the subtlest interaction. Two
@@ -247,51 +267,72 @@
     ;; The handler writes :n; the flow reads :n and writes a value that the
     ;; app-db schema will REJECT (negative when :n is negative).
     (rf/reg-event :set-n (fn [{:keys [db]} [_ v]] {:db (assoc db :n v)}))
-    (rf/reg-flow :doubler {:inputs [[:n]] :output-path [:derived :doubled]} (fn [n] (* 2 n)))
-    ;; Seed a conforming baseline (n=1 → doubled=2, conforms).
-    (rf/dispatch-sync [:seed])
-    (is (= 2 (get-in (rf/app-db-value :rf/default) [:derived :doubled]))
-        "baseline: flow wrote a conforming value")
-    (let [baseline-db (rf/app-db-value :rf/default)]
-      ;; Now drive :n negative → flow computes -6 → app-db schema rejects
-      ;; the candidate.
-      (reset! *captured* [])
-      (rf/dispatch-sync [:set-n -3])
+    ;; rf2-lwtlk — record what the flow COMPUTED, so that the flow having run
+    ;; and its VALUE having been rejected has a witness off the trace bus.
+    ;; That is this deftest's discriminator against path (b) below, and it
+    ;; previously existed only as a `:rf.flow/computed` trace tag.
+    (let [flow-outputs (atom [])]
+      (rf/reg-flow :doubler {:inputs [[:n]] :output-path [:derived :doubled]}
+                   (fn [n] (let [out (* 2 n)] (swap! flow-outputs conj out) out)))
+      ;; Seed a conforming baseline (n=1 → doubled=2, conforms).
+      (rf/dispatch-sync [:seed])
+      (is (= 2 (get-in (rf/app-db-value :rf/default) [:derived :doubled]))
+          "baseline: flow wrote a conforming value")
+      (let [baseline-db (rf/app-db-value :rf/default)]
+        ;; Now drive :n negative → flow computes -6 → app-db schema rejects
+        ;; the candidate.
+        (reset! *captured* [])
+        (reset! flow-outputs [])
+        (rf/dispatch-sync [:set-n -3])
 
-      ;; The candidate never installed — neither the handler's :n write NOR
-      ;; the flow's bad output ever reached the container.
-      (is (= baseline-db (rf/app-db-value :rf/default))
-          "the whole db keeps the pre-handler value — the flow write rode
-           the same rejected candidate as the handler's :db")
-      (is (= 1 (get (rf/app-db-value :rf/default) :n))
-          ":n stayed at the pre-handler value (1) — the handler's own write
-           was rejected too (atomic candidate boundary)")
+        ;; The candidate never installed — neither the handler's :n write NOR
+        ;; the flow's bad output ever reached the container.
+        (is (= baseline-db (rf/app-db-value :rf/default))
+            "the whole db keeps the pre-handler value — the flow write rode
+             the same rejected candidate as the handler's :db")
+        (is (= 1 (get (rf/app-db-value :rf/default) :n))
+            ":n stayed at the pre-handler value (1) — the handler's own write
+             was rejected too (atomic candidate boundary)")
 
-      ;; Trace signature (a): exactly one schema failure, ZERO db-changed —
-      ;; and no :rf.trace/phase :rollback anywhere (the phase has no
-      ;; producer under validate-before-install).
-      (let [sig (filterv #{:rf.event/db-changed
-                           :rf.error/schema-validation-failure}
-                         (ops))]
-        (is (= [:rf.error/schema-validation-failure]
-               sig)
-            "rejection signature: one schema-validation-failure, zero
-             db-changed (the candidate never installed)")
-        (is (not-any? #(= :rollback (-> % :tags :rf.trace/phase)) @*captured*)
-            "no trace carries :rf.trace/phase :rollback")
-        (is (true? (-> (by-op :rf.error/schema-validation-failure)
-                       first :tags :rollback?))
-            "the failure trace carries :rollback? true — the public
-             transaction-REJECTED vocabulary")
-        ;; The flow DID compute (its bad output is what tripped the
-        ;; validator) — the rejection is a candidate-validation reject of a
-        ;; computed value, not a flow-eval skip/throw.
-        (is (= 1 (count (by-op :rf.flow/computed)))
-            "the flow computed its (bad) output — the failure is a
-             candidate rejection, not a flow-eval skip")
-        (is (= -6 (-> (by-op :rf.flow/computed) first :tags :result))
-            "the flow's computed result (-6) is what the app-db schema
-             rejected")))))
+        ;; SEMANTIC, posture-independent (rf2-lwtlk): the flow COMPUTED (its
+        ;; bad output is what tripped the validator) even though nothing
+        ;; installed. That is the whole discriminator between path (a) — a
+        ;; candidate-validation reject of a computed VALUE — and path (b), a
+        ;; flow-eval throw, and outside the trace it had no witness at all.
+        (is (= [-6] @flow-outputs)
+            "the flow ran and produced its (bad) -6 output — the rejection is
+             a candidate reject of a computed value, not a flow-eval skip")
+
+        ;; Trace signature (a): exactly one schema failure, ZERO db-changed —
+        ;; and no :rf.trace/phase :rollback anywhere (the phase has no
+        ;; producer under validate-before-install).
+        ;;
+        ;; rf2-lwtlk — dev-instrumentation arm. Note the `not-any?` and the
+        ;; zero-db-changed half of `sig`: both are negatives over the trace
+        ;; ring and would pass vacuously under the gate.
+        (when interop/debug-enabled?
+          (let [sig (filterv #{:rf.event/db-changed
+                               :rf.error/schema-validation-failure}
+                             (ops))]
+            (is (= [:rf.error/schema-validation-failure]
+                   sig)
+                "rejection signature: one schema-validation-failure, zero
+                 db-changed (the candidate never installed)")
+            (is (not-any? #(= :rollback (-> % :tags :rf.trace/phase)) @*captured*)
+                "no trace carries :rf.trace/phase :rollback")
+            (is (true? (-> (by-op :rf.error/schema-validation-failure)
+                           first :tags :rollback?))
+                "the failure trace carries :rollback? true — the public
+                 transaction-REJECTED vocabulary")
+            ;; The flow DID compute (its bad output is what tripped the
+            ;; validator) — the rejection is a candidate-validation reject of a
+            ;; computed value, not a flow-eval skip/throw.
+            (is (= 1 (count (by-op :rf.flow/computed)))
+                "the flow computed its (bad) output — the failure is a
+                 candidate rejection, not a flow-eval skip")
+            (is (= -6 (-> (by-op :rf.flow/computed) first :tags :result))
+                "the flow's computed result (-6) is what the app-db schema
+                 rejected")))))))
 
 (deftest flow-throw-aborts-event-no-db-changed-no-partial-commit
   (testing "(b) a flow THROW aborts the event PRE-install: the pending :db
@@ -307,26 +348,47 @@
     (rf/dispatch-sync [:seed])
     (is (= {:n 0} (rf/app-db-value :rf/default))
         "baseline seeded before the throwing flow is registered")
-    (rf/reg-flow :boom {:inputs [[:n]] :output-path [:derived :doomed]} (fn [_] (throw (ex-info "flow boom" {:why :test}))))
-    (reset! *captured* [])
-    (rf/dispatch-sync [:bump])
+    ;; rf2-lwtlk — count the eval ATTEMPTS so that the flow having run and
+    ;; thrown has a witness off the trace bus. The contrast this deftest
+    ;; draws against path (a) is about WHICH stage failed, and an abort is
+    ;; otherwise indistinguishable from the flow never having been reached.
+    (let [flow-attempts (atom 0)]
+      (rf/reg-flow :boom {:inputs [[:n]] :output-path [:derived :doomed]}
+                   (fn [_]
+                     (swap! flow-attempts inc)
+                     (throw (ex-info "flow boom" {:why :test}))))
+      (reset! *captured* [])
+      (rf/dispatch-sync [:bump])
 
-    ;; The handler's :db did NOT land — the flow throw aborted the event.
-    (is (= {:n 0} (rf/app-db-value :rf/default))
-        ":n did NOT increment — a flow throw is a pre-install throw; the
-         pending :db (handler write + flow write) was discarded wholesale")
+      ;; The handler's :db did NOT land — the flow throw aborted the event.
+      (is (= {:n 0} (rf/app-db-value :rf/default))
+          ":n did NOT increment — a flow throw is a pre-install throw; the
+           pending :db (handler write + flow write) was discarded wholesale")
 
-    ;; Trace signature (b): ZERO db-changed, a flow-eval-exception present.
-    (is (not-any? #(= :rf.event/db-changed %) (ops))
-        "NO :rf.event/db-changed in the throw stream — the event aborted
-         before install (the schema-rejection path (a) also emits zero
-         db-changed; the discriminator is the ERROR op)")
-    (is (seq (by-op :rf.flow/failed))
-        ":rf.flow/failed fired — the flow eval threw")
-    (is (not-any? #(= :rf.error/schema-validation-failure %) (ops))
-        "no schema-validation-failure — the abort discards the pending :db
-         BEFORE candidate validation would run (contrast (a), whose flow
-         computed cleanly and whose VALUE failed validation)")))
+      ;; SEMANTIC, posture-independent (rf2-lwtlk): the flow really was
+      ;; EVALUATED and really did throw. Without this the abort is
+      ;; indistinguishable from the flow never having run — and the
+      ;; contrast with path (a), which this deftest exists to draw, is
+      ;; precisely about WHICH stage failed.
+      (is (= 1 @flow-attempts)
+          "the flow eval was attempted exactly once and threw — the abort is
+           a pre-install THROW, not a skipped eval")
+
+      ;; rf2-lwtlk — dev-instrumentation arm. Both `not-any?` halves are
+      ;; negatives over the trace ring; under the gate they hold whatever the
+      ;; drain did.
+      (when interop/debug-enabled?
+        ;; Trace signature (b): ZERO db-changed, a flow-eval-exception present.
+        (is (not-any? #(= :rf.event/db-changed %) (ops))
+            "NO :rf.event/db-changed in the throw stream — the event aborted
+             before install (the schema-rejection path (a) also emits zero
+             db-changed; the discriminator is the ERROR op)")
+        (is (seq (by-op :rf.flow/failed))
+            ":rf.flow/failed fired — the flow eval threw")
+        (is (not-any? #(= :rf.error/schema-validation-failure %) (ops))
+            "no schema-validation-failure — the abort discards the pending :db
+             BEFORE candidate validation would run (contrast (a), whose flow
+             computed cleanly and whose VALUE failed validation)")))))
 
 ;; ===========================================================================
 ;; 3. flow × SSR sync-drain — under SSR's synchronous drain, a sub over a
@@ -411,13 +473,17 @@
            (10 * 2), not the parent's (10 * 1)")
       ;; Trace-level confirmation: two :rf.flow/computed events (one per
       ;; event), each carrying its own input value.
-      (let [computes (by-op :rf.flow/computed)]
-        (is (= 2 (count computes))
-            "exactly two :rf.flow/computed traces — one per dispatched event")
-        (is (= [[1] [2]]
-               (mapv #(-> % :tags :input-values) computes))
-            "each compute observed its own event's input — parent saw [1],
-             child saw [2] — independent evals, not a shared one")))))
+      ;; rf2-lwtlk — dev-instrumentation arm. Both assertions restate
+      ;; `(= [1 2] @flow-inputs)` above, which is posture-independent and is
+      ;; the same claim read off the flow itself rather than off the bus.
+      (when interop/debug-enabled?
+        (let [computes (by-op :rf.flow/computed)]
+          (is (= 2 (count computes))
+              "exactly two :rf.flow/computed traces — one per dispatched event")
+          (is (= [[1] [2]]
+                 (mapv #(-> % :tags :input-values) computes))
+              "each compute observed its own event's input — parent saw [1],
+               child saw [2] — independent evals, not a shared one"))))))
 
 ;; ===========================================================================
 ;; 5. flow × routing (rf2-qm8m3) — a flow over the [:rf.runtime/routing
@@ -501,14 +567,18 @@
 
       ;; Trace signature: exactly one :rf.flow/computed for the dispatched
       ;; transition, with the post-transition route id as input.
-      (let [computes (by-op :rf.flow/computed)]
-        (is (= 1 (count computes))
-            "exactly one :rf.flow/computed trace for the transition
-             dispatch — no double / missed eval")
-        (is (= [:route/article]
-               (-> computes first :tags :input-values))
-            "the :rf.flow/computed trace's :input-values carries the
-             post-transition route id")))))
+      ;; rf2-lwtlk — dev-instrumentation arm. Both restate
+      ;; `(= [:route/article] @flow-inputs)` above, which is
+      ;; posture-independent.
+      (when interop/debug-enabled?
+        (let [computes (by-op :rf.flow/computed)]
+          (is (= 1 (count computes))
+              "exactly one :rf.flow/computed trace for the transition
+               dispatch — no double / missed eval")
+          (is (= [:route/article]
+                 (-> computes first :tags :input-values))
+              "the :rf.flow/computed trace's :input-values carries the
+               post-transition route id"))))))
 
 ;; EP-0001 §535-551 (rf2-4eisfr) — RE-ENABLED. The throwing flow reads the
 ;; route slice via the qualified runtime-db input
@@ -570,14 +640,21 @@
             ":route/load-article was NOT invoked — the :on-match :dispatch
              sat in the handler's :fx; a flow throw skips :fx entirely")
 
-        ;; Trace signature: :rf.flow/failed fired, but NO :rf.event/db-changed
-        ;; for this dispatch — the event aborted before install.
-        (is (seq (by-op :rf.flow/failed))
-            ":rf.flow/failed fired — the flow eval threw")
-        (is (not-any? #(= :rf.event/db-changed %) (ops))
-            "NO :rf.event/db-changed in the throw stream — the event
-             aborted before install (contrast: a clean transition would
-             emit one :rf.event/db-changed for the slice rewrite)")))))
+        ;; rf2-lwtlk — dev-instrumentation arm. The atomicity contract this
+        ;; deftest pins — neither partition installed, `:fx` skipped
+        ;; wholesale — is fully covered outside the arm by the unchanged
+        ;; app-db, the unchanged route slice and the zero `:on-match`
+        ;; invocations. The `not-any?` half is a negative over the ring and
+        ;; would pass vacuously under the gate.
+        (when interop/debug-enabled?
+          ;; Trace signature: :rf.flow/failed fired, but NO :rf.event/db-changed
+          ;; for this dispatch — the event aborted before install.
+          (is (seq (by-op :rf.flow/failed))
+              ":rf.flow/failed fired — the flow eval threw")
+          (is (not-any? #(= :rf.event/db-changed %) (ops))
+              "NO :rf.event/db-changed in the throw stream — the event
+               aborted before install (contrast: a clean transition would
+               emit one :rf.event/db-changed for the slice rewrite)"))))))
 
 ;; ===========================================================================
 ;; 6. dual-partition TRIGGER (EP-0001 §542-544, rf2-4eisfr) — a RUNTIME-ONLY
@@ -653,8 +730,12 @@
           "a transition to the SAME route does NOT recompute the flow — the
            runtime-db route id is value-equal, so the dirty-check skips
            (widening the trigger to runtime-db preserves the skip)")
-      (is (seq (by-op :rf.flow/skip))
-          ":rf.flow/skip fired for the value-equal re-transition"))))
+      ;; rf2-lwtlk — dev-instrumentation arm. The SKIP itself is pinned
+      ;; posture-independently by `(= [] @flow-evals)` above — the flow body
+      ;; did not run — which is the observation the trace announces.
+      (when interop/debug-enabled?
+        (is (seq (by-op :rf.flow/skip))
+            ":rf.flow/skip fired for the value-equal re-transition")))))
 
 ;; ===========================================================================
 ;; 7. binary-syntax mixed inputs (EP-0001 §535-538, rf2-4eisfr) — ONE flow

--- a/implementation/ssr/test/re_frame/framework_zero_ownership_diagnostics_test.clj
+++ b/implementation/ssr/test/re_frame/framework_zero_ownership_diagnostics_test.clj
@@ -55,10 +55,44 @@
   The control deftest at the bottom proves the recorder + diagnostic are
   LIVE in this fixture: an ordinary (non-framework) app handler returning
   `:rf.db/runtime` DOES fire the warning, so the framework-quiet assertions
-  above are not vacuously empty."
+  above are not vacuously empty.
+
+  ## Posture split (rf2-lwtlk)
+
+  This namespace is the sharpest instance of the vacuous-pass trap the
+  production-gate lane exists to close, and the split has to be read with
+  that in mind. Every `(is (empty? @diags) …)` above is a NEGATIVE assertion
+  over the trace ring. The three ownership diagnostics are emitted through
+  `trace/emit-error!` / the warning bus, gated on `interop/debug-enabled?`
+  and read once at namespace-load time — so under `-Dre-frame.debug=false`
+  the ring is empty for EVERY input, and `empty?` is satisfied without the
+  framework having demonstrated anything at all. The control deftest is
+  precisely the assertion that fails first in that posture, which is the
+  system telling the truth: with the recorder dead, the sweep is vacuous.
+
+  So all five `empty?` assertions are kept VERBATIM inside
+  `(when interop/debug-enabled? …)` arms marked `rf2-lwtlk`. They are correct
+  dev-posture coverage and nothing about them is weakened; they simply stop
+  claiming to have run under a gate that makes them unfalsifiable.
+
+  What remains outside the arms is production-real and substantial: every
+  deftest already pins the runtime-db WRITE its flow performs — the route
+  slice after navigate / transitioned / handle-url-change / on-match, the
+  pending-navigation slot through the can-leave protocol, the machine
+  snapshots through bootstrap / spawn / destroy, the elision declarations,
+  the `:rf/hydrate` app-db replacement and server-hash. Those are the flows
+  themselves and they run in the lane.
+
+  The control deftest gains a PRODUCTION witness rather than being guarded
+  away wholesale (which would report green for a deftest that executed
+  nothing). Per the Mike ruling this file cites, `:rf.db/runtime` is
+  reserved BY CONVENTION and surfaced through a dev diagnostic rather than
+  ENFORCED — so in production the sneaky write LANDS. That is the policy's
+  production face and nothing asserted it in either posture before."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.fx :as fx]
+            [re-frame.interop :as interop]
             [re-frame.elision :as elision]
             ;; The routing / ssr / machines subsystem namespaces are loaded
             ;; (and re-installed between tests) by `tf/reset-runtime`, so
@@ -142,9 +176,13 @@
                                    [:rf.runtime/routing :current :route-id]))
           "the :on-match route settled onto the slice")
 
-      (is (empty? @diags)
-          (str "routing navigation events are framework-authority writers — "
-               "no ownership diagnostic; got " (diagnostic-ids diags))))))
+      ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). Vacuous
+      ;; under the gate: the diagnostic ring is empty for every input there.
+      ;; The four route-slice writes above are the posture-independent half.
+      (when interop/debug-enabled?
+        (is (empty? @diags)
+            (str "routing navigation events are framework-authority writers — "
+                 "no ownership diagnostic; got " (diagnostic-ids diags)))))))
 
 (deftest can-leave-pending-nav-fires-no-ownership-diagnostic
   (testing "the pending-nav protocol (url-requested / cancel / continue) stays silent"
@@ -177,9 +215,12 @@
       (is (= :route/cart (get-in (:rf.db/runtime (rf/frame-state-value :rf/default))
                                  [:rf.runtime/routing :current :route-id]))
           ":rf.route/continue completed the navigation")
-      (is (empty? @diags)
-          (str "url-requested / cancel / continue are framework-authority "
-               "writers — no ownership diagnostic; got " (diagnostic-ids diags))))))
+      ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). Vacuous
+      ;; under the gate; the pending-slot writes above are the residue.
+      (when interop/debug-enabled?
+        (is (empty? @diags)
+            (str "url-requested / cancel / continue are framework-authority "
+                 "writers — no ownership diagnostic; got " (diagnostic-ids diags)))))))
 
 ;; ===========================================================================
 ;; Machines — :rf/machine? implies framework-write authority
@@ -224,10 +265,22 @@
       ;; (c) explicit destroy — the destroy fx clears the actor from runtime-db.
       (rf/dispatch-sync [:zod/parent [:kill]])
 
-      (is (empty? @diags)
-          (str "machine reg / dispatch / spawn / destroy are framework-"
-               "authority writers (via :rf/machine?) — no ownership "
-               "diagnostic; got " (diagnostic-ids diags))))))
+      ;; SEMANTIC, posture-independent (rf2-lwtlk): the explicit destroy
+      ;; above had no witness at all — its only assertion was the vacuous
+      ;; `empty?`. The parent's `:tearing` entry fires
+      ;; `[:rf.machine/destroy :zod/child]`, so the child's snapshot must be
+      ;; gone from runtime-db while the parent's remains.
+      (is (nil? (get-in (:rf.db/runtime (rf/frame-state-value :rf/default))
+                        [:rf.runtime/machines :snapshots :zod/child]))
+          "the explicit destroy fx cleared the child actor from runtime-db")
+
+      ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). Vacuous
+      ;; under the gate.
+      (when interop/debug-enabled?
+        (is (empty? @diags)
+            (str "machine reg / dispatch / spawn / destroy are framework-"
+                 "authority writers (via :rf/machine?) — no ownership "
+                 "diagnostic; got " (diagnostic-ids diags)))))))
 
 ;; ===========================================================================
 ;; Elision — frame-owned classification install goes through privileged
@@ -261,10 +314,14 @@
       (is (some? (get-in (:rf.db/runtime (rf/frame-state-value :rf/default))
                          [:rf.runtime/elision]))
           "the commit-plane effect wrote its declaration registry into runtime-db")
-      (is (empty? @diags)
-          (str "commit-plane classification effects write runtime-db through "
-               "the privileged frame-state commit — no ownership diagnostic; got "
-               (diagnostic-ids diags))))))
+      ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). Vacuous
+      ;; under the gate; the three elision-registry pins above are the
+      ;; posture-independent half.
+      (when interop/debug-enabled?
+        (is (empty? @diags)
+            (str "commit-plane classification effects write runtime-db through "
+                 "the privileged frame-state commit — no ownership diagnostic; got "
+                 (diagnostic-ids diags)))))))
 
 ;; ===========================================================================
 ;; SSR hydrate — :rf/hydrate is stamped :rf/framework-authority? true
@@ -288,10 +345,14 @@
       (is (= "deadbeef" (get-in (:rf.db/runtime (rf/frame-state-value :rf/default))
                                 [:rf.runtime/ssr :hydration :server-hash]))
           ":rf/hydrate stashed the server-hash into the runtime-db partition")
-      (is (empty? @diags)
-          (str ":rf/hydrate is a framework-authority writer "
-               "(:rf/framework-authority? true) — no ownership diagnostic; got "
-               (diagnostic-ids diags))))))
+      ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). Vacuous
+      ;; under the gate; the app-db replacement + server-hash pins above are
+      ;; the posture-independent half.
+      (when interop/debug-enabled?
+        (is (empty? @diags)
+            (str ":rf/hydrate is a framework-authority writer "
+                 "(:rf/framework-authority? true) — no ownership diagnostic; got "
+                 (diagnostic-ids diags)))))))
 
 ;; ===========================================================================
 ;; Control — an ordinary app handler DOES fire the diagnostic
@@ -306,7 +367,25 @@
                      (fn [_ _] {:rf.db/runtime {:rf.runtime/routing {:current {:route-id :hijacked}}}}))
     (let [diags (record-ownership-diagnostics! ::app-sneaky)]
       (rf/dispatch-sync [:app/sneaky-runtime-write])
-      (is (= [:rf.warning/app-handler-runtime-effect] (diagnostic-ids diags))
-          "a non-framework handler writing :rf.db/runtime trips exactly the warning")
-      (is (= :app/sneaky-runtime-write (-> @diags first :tags :rf.trace/event-id))
-          "the diagnostic names the offending app event-id"))))
+
+      ;; SEMANTIC, posture-independent (rf2-lwtlk), and the reason this
+      ;; deftest is not simply guarded away: `:rf.db/runtime` is reserved BY
+      ;; CONVENTION and surfaced through a DIAGNOSTIC, not enforced (Mike
+      ;; ruling #4, cited in the ns docstring). So the write LANDS — in dev,
+      ;; noisily; in production, silently. That is the policy's production
+      ;; face, and nothing asserted it in either posture before. If a future
+      ;; change turns the warning into a rejection, this is where it surfaces.
+      (is (= :hijacked (get-in (:rf.db/runtime (rf/frame-state-value :rf/default))
+                               [:rf.runtime/routing :current :route-id]))
+          "the diagnostic is advisory, not enforcement — the app handler's
+           :rf.db/runtime write reaches runtime-db in both postures")
+
+      ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). This is the
+      ;; CONTROL for the five `empty?` assertions above, and it is the one
+      ;; that goes red first under the gate — correctly, because with the
+      ;; diagnostic elided there is nothing for a control to control.
+      (when interop/debug-enabled?
+        (is (= [:rf.warning/app-handler-runtime-effect] (diagnostic-ids diags))
+            "a non-framework handler writing :rf.db/runtime trips exactly the warning")
+        (is (= :app/sneaky-runtime-write (-> @diags first :tags :rf.trace/event-id))
+            "the diagnostic names the offending app event-id")))))

--- a/implementation/ssr/test/re_frame/source_coord_parity_test.clj
+++ b/implementation/ssr/test/re_frame/source_coord_parity_test.clj
@@ -24,9 +24,26 @@
   (`implementation/adapters/reagent/test/re_frame/source_coord_parity_cljs_test.cljs`)
   exercises the CLJS formatters against the SAME fixtures and asserts the
   SAME literals. The literals ARE the cross-host byte-comparison point —
-  if either host's formatter drifts, its test fails."
+  if either host's formatter drifts, its test fails.
+
+  ## Posture split (rf2-lwtlk)
+
+  The FORMATTERS are ordinary pure functions and the neutral-owner aliasing
+  is ordinary Var identity: neither is gated, so every deftest above the
+  end-to-end one runs unchanged in both postures and always did.
+
+  The end-to-end render is the exception. The attributes only reach server
+  markup because `reg-view` installs the annotation wrapper, and it installs
+  it only under `interop/debug-enabled?` — read once at namespace-load time,
+  so under the real `-Dre-frame.debug=false` gate the markup is bare by
+  design. Those three assertions are kept verbatim inside a
+  `(when interop/debug-enabled? …)` arm; alongside them sits the
+  posture-independent half — that the callable head renders the registered
+  view's own `<p>body</p>` root at all — plus a `when-not` arm pinning the
+  exact bare bytes the production gate emits."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.interop :as interop]
             [re-frame.source-coords :as source-coords]
             [re-frame.ssr :as ssr]
             [re-frame.ssr.test-fixture :as tf]
@@ -146,14 +163,31 @@
           ;; a hardcoded copy of it.
           coord   (jvm-annot/format-source-coord fixture-id fixture-coords)
           view-id (jvm-annot/format-view-id fixture-id)]
-      (is (.contains html (str "data-rf2-source-coord=\"" coord "\""))
-          (str "server markup must carry the source-coord attribute; got: "
-               (pr-str html)))
-      (is (.contains html (str "data-rf-view=\"" view-id "\""))
-          (str "server markup must carry the view-id attribute (rf2-8vi4q); "
-               "got: " (pr-str html)))
-      (is (= (str "<p data-rf2-source-coord=\"" coord "\""
-                  " data-rf-view=\"" view-id "\">body</p>")
-             html)
-          (str "the full annotated root, both attributes present; got: "
-               (pr-str html))))))
+      ;; SEMANTIC, posture-independent (rf2-lwtlk): `(rf/view id)` resolves to
+      ;; the registered view and the view renders its own root and body. The
+      ;; gate can remove the attributes; it can never remove the element.
+      (is (.startsWith html "<p") (pr-str html))
+      (is (.endsWith html ">body</p>") (pr-str html))
+
+      ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (.contains html (str "data-rf2-source-coord=\"" coord "\""))
+            (str "server markup must carry the source-coord attribute; got: "
+                 (pr-str html)))
+        (is (.contains html (str "data-rf-view=\"" view-id "\""))
+            (str "server markup must carry the view-id attribute (rf2-8vi4q); "
+                 "got: " (pr-str html)))
+        (is (= (str "<p data-rf2-source-coord=\"" coord "\""
+                    " data-rf-view=\"" view-id "\">body</p>")
+               html)
+            (str "the full annotated root, both attributes present; got: "
+                 (pr-str html))))
+
+      ;; rf2-lwtlk — the REAL-gate arm. Under `-Dre-frame.debug=false` the
+      ;; wrapper is never installed, so the same callable head renders the
+      ;; SAME element with neither attribute. Pinned by `=` rather than by a
+      ;; `not contains?` pair, which would pass vacuously.
+      (when-not interop/debug-enabled?
+        (is (= "<p>body</p>" html)
+            (str "under the production gate the callable head must render the "
+                 "bare root, both annotations elided; got: " (pr-str html)))))))

--- a/implementation/ssr/test/re_frame/ssr/payload_policy_cljs_test.cljc
+++ b/implementation/ssr/test/re_frame/ssr/payload_policy_cljs_test.cljc
@@ -26,10 +26,30 @@
   value's SHAPE (sequential collection vs keyword).
 
   These tests run on both JVM and Node — the policy logic is
-  platform-neutral .cljc."
+  platform-neutral .cljc.
+
+  ## Posture split (rf2-lwtlk)
+
+  This namespace guards `project-routing-egress` — what leaves the server
+  inside a hydration payload — so its exclusion from
+  `scripts/test-ssr-prod-gate.sh` was checked rather than assumed. The one
+  assertion that was red under `-Dre-frame.debug=false` is the
+  `:rf.ssr/invalid-version` WARNING trace in
+  `resolve-version-coerces-and-rejects-to-integer`: the dev half. The
+  REJECTION it accompanies — a semver string never reaches `:rf/version`,
+  which falls back to the integer v1 — is asserted immediately above it and
+  passes in both postures, so nothing that decides what egresses was
+  affected. The always-on privacy witness for the egress itself is
+  `re-frame.ssr-routing-egress-production-test` (rf2-u2x6w), which has been
+  in the lane and green throughout.
+
+  The trace assertions are kept verbatim inside a
+  `(when interop/debug-enabled? …)` arm. Everything else in this namespace
+  is pure policy logic and was always posture-independent."
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
             [malli.core :as m]
+            [re-frame.interop :as interop]
             [re-frame.ssr.payload-policy :as payload-policy]
             #?(:clj  [re-frame.test-support :refer [with-trace-recorder!]]
                :cljs [re-frame.test-support :refer-macros [with-trace-recorder!]])))
@@ -476,17 +496,21 @@
         ;; :rf.ssr/invalid-version warning carrying the rejected source value and
         ;; a top-level :recovery :rejected-and-fell-back, so a stray non-integer
         ;; :version surfaces in dev/CI rather than defaulting quietly.
-        (let [hits (filterv #(= :rf.ssr/invalid-version (:operation %)) @traces)]
-          (is (= 1 (count hits))
-              (str "expected exactly one :rf.ssr/invalid-version trace; saw: "
-                   (pr-str (mapv :operation @traces))))
-          (when (seq hits)
-            (let [ev (first hits)]
-              (is (= :warning (:op-type ev)))
-              (is (= "1.0.0" (-> ev :tags :value))
-                  "the rejected source value rides the trace")
-              (is (= :rejected-and-fell-back (:recovery ev))
-                  ":recovery rides at top-level per Spec 009")))))))
+        ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). The
+        ;; REJECTION is pinned above and is what governs the wire; this is
+        ;; the developer-facing announcement of it.
+        (when interop/debug-enabled?
+          (let [hits (filterv #(= :rf.ssr/invalid-version (:operation %)) @traces)]
+            (is (= 1 (count hits))
+                (str "expected exactly one :rf.ssr/invalid-version trace; saw: "
+                     (pr-str (mapv :operation @traces))))
+            (when (seq hits)
+              (let [ev (first hits)]
+                (is (= :warning (:op-type ev)))
+                (is (= "1.0.0" (-> ev :tags :value))
+                    "the rejected source value rides the trace")
+                (is (= :rejected-and-fell-back (:recovery ev))
+                    ":recovery rides at top-level per Spec 009"))))))))
 
   (testing "no :version → the SSR-owned pattern-protocol constant (v1 = 1)"
     ;; rf2-qfb1i: the late-bind version hook was removed — with no explicit

--- a/implementation/ssr/test/re_frame/ssr_compatibility_checks_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_compatibility_checks_test.clj
@@ -9,11 +9,42 @@
 
     - matching values → silent (no mismatch trace fires)
     - mismatching values → :rf.ssr/version-mismatch / :rf.ssr/schema-digest-
-      mismatch trace fires with :expected + :actual + :recovery shape."
+      mismatch trace fires with :expected + :actual + :recovery shape.
+
+  ## Posture split (rf2-lwtlk)
+
+  Read this one carefully, because the honest answer here is not the
+  convenient one. Both fxs are BEST-EFFORT: they change no state, return no
+  value a handler can see, and stop nothing. Their entire observable output
+  IS the trace. So under `-Dre-frame.debug=false`, where every emit site is
+  elided, the mismatch deftests fail and — worse — the MATCHING deftests
+  would pass VACUOUSLY, since `(empty? (traces-of …))` is satisfied by a ring
+  that is empty for every input. Guarding all of it and deleting the roster
+  line would have reported GREEN for a namespace that proved nothing: the
+  exact false green this lane exists to close.
+
+  Every trace assertion, positive and negative alike, is therefore kept
+  VERBATIM inside a `(when interop/debug-enabled? …)` arm marked
+  `rf2-lwtlk`. What earns the namespace its place in
+  `scripts/test-ssr-prod-gate.sh` is NEW, production-real coverage of the
+  two properties the docstring above claims and that nothing asserted in
+  either posture before:
+
+    - the two fx ids are REGISTERED, carrying the `:platforms #{:client}`
+      gate the runtime actually dispatches on — `registrar/lookup`, not a
+      trace;
+    - `best-effort` means what it says. A MISMATCHING check does not throw,
+      does not abort the drain, and does not stop the effects queued after
+      it. `compatibility-checks-are-best-effort-and-never-halt-the-drain`
+      pins the whole of degraded-but-running-never-crash — the only part of
+      this surface a production server ever experiences."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.fx :as fx]
+            [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
+            [re-frame.registrar :as registrar]
             [re-frame.ssr.payload-policy :as payload-policy]
             [re-frame.ssr.test-fixture :as tf]
             [re-frame.test-support :refer [with-trace-recorder!]]))
@@ -25,6 +56,61 @@
 
 (defn- traces-of [traces op]
   (filterv #(= op (:operation %)) traces))
+
+;; ===========================================================================
+;; PRODUCTION-REAL surface (rf2-lwtlk)
+;; ===========================================================================
+;;
+;; Everything below this block observes the two fxs through the DEV trace
+;; bus, which is the whole of their output and none of which survives
+;; `-Dre-frame.debug=false`.  These two deftests are what this namespace
+;; contributes to `scripts/test-ssr-prod-gate.sh`: the registrations the
+;; runtime dispatches on, and the best-effort contract the ns docstring
+;; promises but nothing previously asserted in either posture.
+
+(deftest compatibility-check-fxs-are-registered-client-only
+  (testing "rf2-lwtlk — both compatibility-check fx ids resolve in the fx
+            registry with the :platforms #{:client} gate. This is the
+            RETAINED half of each registration (`:doc` is stripped in
+            production per Spec 001 §Production elision contract) and it is
+            what decides whether the fx runs at all."
+    (doseq [id [:rf.ssr/check-version :rf.ssr/check-schema-digest]]
+      (let [meta (registrar/lookup :fx id)]
+        (is (some? meta) (str id " resolves in the :fx registry"))
+        (is (fn? (:handler-fn meta)) (str id " carries a :handler-fn"))
+        (is (= #{:client} (:platforms meta))
+            (str id " is client-only per Spec 011 §The :rf/hydrate event"))))))
+
+(deftest compatibility-checks-are-best-effort-and-never-halt-the-drain
+  (testing "rf2-lwtlk — 'best-effort' is a PRODUCTION contract, not a trace:
+            a MISMATCHING check must not throw and must not stop the effects
+            queued behind it, so a version- or digest-skewed client hydrates
+            degraded-but-running. Under `-Dre-frame.debug=false` nothing is
+            emitted, which is exactly when this property matters most and is
+            the only way to observe it."
+    (let [ran (atom [])]
+      ;; A marker fx queued AFTER both checks. If a mismatching check threw,
+      ;; or aborted the drain, this never runs.
+      (fx/reg-fx ::after-checks
+                 {:platforms #{:client}}
+                 (fn [_ v] (swap! ran conj v)))
+      (rf/reg-event ::probe-best-effort
+        {:platforms #{:client}}
+        (fn [{:keys [db]} _]
+          {:db (assoc db :probe/handler-ran true)
+           :fx [[:rf.ssr/check-version       {:expected 1 :actual 2}]
+                [:rf.ssr/check-schema-digest {:expected "sha256:aaaa"
+                                              :actual   "sha256:bbbb"}]
+                [::after-checks :marker]]}))
+
+      (let [f (frame/make-anon-frame-record! {:platform :client})]
+        (is (nil? (rf/dispatch-sync [::probe-best-effort] {:frame f}))
+            "a double mismatch does not throw out of dispatch-sync")
+        (is (true? (:probe/handler-ran (frame/frame-app-db-value f)))
+            "the handler's :db write committed alongside the failing checks")
+        (is (= [:marker] @ran)
+            "the effect queued AFTER both mismatching checks still ran —
+             the drain was never halted")))))
 
 ;; ===========================================================================
 ;; :rf.ssr/check-version
@@ -48,10 +134,14 @@
     (let [f (frame/make-anon-frame-record! {:platform :client})]
       (with-trace-recorder! [traces]
         (rf/dispatch-sync [::probe-check-version-match] {:frame f})
-        (is (empty? (traces-of @traces :rf.ssr/version-mismatch))
-            "matching version → no mismatch trace")
-        (is (empty? (traces-of @traces :rf.ssr/compatibility-check-skipped))
-            "both sides supplied → no skipped trace either")))))
+        ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). BOTH of
+        ;; these are negatives over the trace ring, and both pass vacuously
+        ;; under the gate, where the ring is empty whatever the fx did.
+        (when interop/debug-enabled?
+          (is (empty? (traces-of @traces :rf.ssr/version-mismatch))
+              "matching version → no mismatch trace")
+          (is (empty? (traces-of @traces :rf.ssr/compatibility-check-skipped))
+              "both sides supplied → no skipped trace either"))))))
 
 (deftest check-version-mismatch-emits-trace
   (testing "differing expected + actual → :rf.ssr/version-mismatch warning trace"
@@ -63,17 +153,22 @@
     (let [f (frame/make-anon-frame-record! {:platform :client})]
       (with-trace-recorder! [traces]
         (rf/dispatch-sync [::probe-check-version-mismatch] {:frame f})
-        (let [hits (traces-of @traces :rf.ssr/version-mismatch)]
-          (is (= 1 (count hits))
-              (str "expected one :rf.ssr/version-mismatch trace; saw: "
-                   (pr-str (mapv :operation @traces))))
-          (when (seq hits)
-            (let [ev (first hits)]
-              (is (= :warning              (:op-type ev)))
-              (is (= 1                     (-> ev :tags :expected)))
-              (is (= 2                     (-> ev :tags :actual)))
-              (is (= :warned-and-applied   (:recovery ev))
-                  ":recovery rides at top-level per Spec 009"))))))))
+        ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). The trace
+        ;; is this fx's ONLY output; its production behaviour — do not throw,
+        ;; do not halt the drain — is pinned by
+        ;; `compatibility-checks-are-best-effort-and-never-halt-the-drain`.
+        (when interop/debug-enabled?
+          (let [hits (traces-of @traces :rf.ssr/version-mismatch)]
+            (is (= 1 (count hits))
+                (str "expected one :rf.ssr/version-mismatch trace; saw: "
+                     (pr-str (mapv :operation @traces))))
+            (when (seq hits)
+              (let [ev (first hits)]
+                (is (= :warning              (:op-type ev)))
+                (is (= 1                     (-> ev :tags :expected)))
+                (is (= 2                     (-> ev :tags :actual)))
+                (is (= :warned-and-applied   (:recovery ev))
+                    ":recovery rides at top-level per Spec 009")))))))))
 
 ;; ===========================================================================
 ;; :rf.ssr/check-schema-digest
@@ -99,10 +194,13 @@
     (let [f (frame/make-anon-frame-record! {:platform :client})]
       (with-trace-recorder! [traces]
         (rf/dispatch-sync [::probe-check-digest-match] {:frame f})
-        (is (empty? (traces-of @traces :rf.ssr/schema-digest-mismatch))
-            "matching digest → no mismatch trace")
-        (is (empty? (traces-of @traces :rf.ssr/compatibility-check-skipped))
-            "both sides supplied → no skipped trace either")))))
+        ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). Vacuous
+        ;; under the gate — both are negatives over an empty ring.
+        (when interop/debug-enabled?
+          (is (empty? (traces-of @traces :rf.ssr/schema-digest-mismatch))
+              "matching digest → no mismatch trace")
+          (is (empty? (traces-of @traces :rf.ssr/compatibility-check-skipped))
+              "both sides supplied → no skipped trace either"))))))
 
 (deftest check-schema-digest-mismatch-emits-trace
   (testing "differing expected + actual → :rf.ssr/schema-digest-mismatch warning trace"
@@ -116,16 +214,18 @@
     (let [f (frame/make-anon-frame-record! {:platform :client})]
       (with-trace-recorder! [traces]
         (rf/dispatch-sync [::probe-check-digest-mismatch] {:frame f})
-        (let [hits (traces-of @traces :rf.ssr/schema-digest-mismatch)]
-          (is (= 1 (count hits))
-              (str "expected one :rf.ssr/schema-digest-mismatch trace; saw: "
-                   (pr-str (mapv :operation @traces))))
-          (when (seq hits)
-            (let [ev (first hits)]
-              (is (= :warning                              (:op-type ev)))
-              (is (= "sha256:deadbeefcafef00d"             (-> ev :tags :expected)))
-              (is (= "sha256:0000000000000000"             (-> ev :tags :actual)))
-              (is (= :warned-and-applied                   (:recovery ev))))))))))
+        ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring).
+        (when interop/debug-enabled?
+          (let [hits (traces-of @traces :rf.ssr/schema-digest-mismatch)]
+            (is (= 1 (count hits))
+                (str "expected one :rf.ssr/schema-digest-mismatch trace; saw: "
+                     (pr-str (mapv :operation @traces))))
+            (when (seq hits)
+              (let [ev (first hits)]
+                (is (= :warning                              (:op-type ev)))
+                (is (= "sha256:deadbeefcafef00d"             (-> ev :tags :expected)))
+                (is (= "sha256:0000000000000000"             (-> ev :tags :actual)))
+                (is (= :warned-and-applied                   (:recovery ev)))))))))))
 
 ;; ===========================================================================
 ;; SCALAR-form paths — rf2-ooj41 / rf2-qfb1i
@@ -159,10 +259,13 @@
     (let [f (frame/make-anon-frame-record! {:platform :client})]
       (with-trace-recorder! [traces]
         (rf/dispatch-sync [::probe-check-version-scalar-matches] {:frame f})
-        (is (empty? (traces-of @traces :rf.ssr/compatibility-check-skipped))
-            "version scalar resolves via the SSR constant → never skipped")
-        (is (empty? (traces-of @traces :rf.ssr/version-mismatch))
-            "scalar == the SSR constant → silent match")))))
+        ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). Vacuous
+        ;; under the gate — both are negatives over an empty ring.
+        (when interop/debug-enabled?
+          (is (empty? (traces-of @traces :rf.ssr/compatibility-check-skipped))
+              "version scalar resolves via the SSR constant → never skipped")
+          (is (empty? (traces-of @traces :rf.ssr/version-mismatch))
+              "scalar == the SSR constant → silent match"))))))
 
 (deftest check-version-scalar-differs-from-ssr-constant-emits-mismatch
   (testing "scalar form differing from the SSR-owned constant → :rf.ssr/version-mismatch"
@@ -179,18 +282,20 @@
       (let [f (frame/make-anon-frame-record! {:platform :client})]
         (with-trace-recorder! [traces]
           (rf/dispatch-sync [::probe-check-version-scalar-differs] {:frame f})
-          (let [hits (traces-of @traces :rf.ssr/version-mismatch)]
-            (is (empty? (traces-of @traces :rf.ssr/compatibility-check-skipped))
-                "version scalar resolves via the SSR constant → never skipped")
-            (is (= 1 (count hits))
-                (str "expected one :rf.ssr/version-mismatch trace; saw: "
-                     (pr-str (mapv :operation @traces))))
-            (when (seq hits)
-              (let [ev (first hits)]
-                (is (= server-version (-> ev :tags :expected))
-                    "scalar arg is :expected (server side)")
-                (is (= payload-policy/pattern-protocol-version (-> ev :tags :actual))
-                    ":actual sourced from the SSR-owned pattern-protocol constant")))))))))
+          ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring).
+          (when interop/debug-enabled?
+            (let [hits (traces-of @traces :rf.ssr/version-mismatch)]
+              (is (empty? (traces-of @traces :rf.ssr/compatibility-check-skipped))
+                  "version scalar resolves via the SSR constant → never skipped")
+              (is (= 1 (count hits))
+                  (str "expected one :rf.ssr/version-mismatch trace; saw: "
+                       (pr-str (mapv :operation @traces))))
+              (when (seq hits)
+                (let [ev (first hits)]
+                  (is (= server-version (-> ev :tags :expected))
+                      "scalar arg is :expected (server side)")
+                  (is (= payload-policy/pattern-protocol-version (-> ev :tags :actual))
+                      ":actual sourced from the SSR-owned pattern-protocol constant"))))))))))
 
 (deftest check-schema-digest-scalar-with-no-hook-emits-skipped
   (testing "scalar form + absent :schemas/app-schemas-digest hook → skipped"
@@ -208,13 +313,15 @@
         (let [f (frame/make-anon-frame-record! {:platform :client})]
           (with-trace-recorder! [traces]
             (rf/dispatch-sync [::probe-check-digest-scalar-no-hook] {:frame f})
-            (let [hits (traces-of @traces :rf.ssr/compatibility-check-skipped)]
-              (is (= 1 (count hits)))
-              (when (seq hits)
-                (let [ev (first hits)]
-                  (is (= :rf.ssr/check-schema-digest (-> ev :tags :check)))
-                  (is (= "sha256:deadbeefcafef00d"   (-> ev :tags :expected)))
-                  (is (= :skipped                    (:recovery ev))))))))
+            ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring).
+            (when interop/debug-enabled?
+              (let [hits (traces-of @traces :rf.ssr/compatibility-check-skipped)]
+                (is (= 1 (count hits)))
+                (when (seq hits)
+                  (let [ev (first hits)]
+                    (is (= :rf.ssr/check-schema-digest (-> ev :tags :check)))
+                    (is (= "sha256:deadbeefcafef00d"   (-> ev :tags :expected)))
+                    (is (= :skipped                    (:recovery ev)))))))))
         (finally
           (when prior-hook
             (late-bind/set-fn! :schemas/app-schemas-digest prior-hook)))))))

--- a/implementation/ssr/test/re_frame/ssr_head_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_head_test.clj
@@ -13,11 +13,34 @@
     - :rf.error/no-such-head raised for unregistered ids
     - reg-head is idempotent — re-registering replaces the slot
 
-  Mirrors the reset-runtime fixture pattern from ssr_end_to_end_test.clj."
+  Mirrors the reset-runtime fixture pattern from ssr_end_to_end_test.clj.
+
+  ## Posture split (rf2-lwtlk)
+
+  Two assertions here were about DEV-ONLY surfaces and dragged the rest of
+  the namespace out of `scripts/test-ssr-prod-gate.sh` with them.
+
+  `reg-head-accepts-metadata-arity` asserted `:doc` on the registry slot.
+  `:doc` is a pure-documentation key: `registrar/strip-pure-documentation`
+  drops it when `interop/debug-enabled?` is false, per Spec 001 §Production
+  elision contract. So its absence under the gate is the elision working.
+  The `:doc` assertion is kept verbatim in a `(when interop/debug-enabled? …)`
+  arm; what the deftest is really for — that the 3-arity is a REGISTRATION
+  arity, storing a working `:handler-fn` under the id — is asserted outside
+  it, and a `when-not` arm pins the elision itself under the real gate.
+
+  `head-cleanup-throw-emits-warning-trace` asserted the
+  `:rf.ssr.head/cleanup-failed` warning, which is emitted through the gated
+  trace bus. Kept verbatim in a dev arm. Its production-real half — that the
+  destroy COMPLETES rather than propagating the hook's throw — was previously
+  witnessed only by an `(is false …)` in a catch, which contributes no
+  assertion at all on the happy path; it now has a positive flag witness that
+  the throwing path could never set."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [clojure.string :as str]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
             [re-frame.registrar :as registrar]
             [re-frame.ssr :as ssr]
@@ -52,8 +75,30 @@
                  {:doc "Article-page head model"}
                  (fn [_db _route] {:title "x"}))
     (let [m (registrar/lookup :head :head/with-meta)]
-      (is (= "Article-page head model" (:doc m))
-          ":doc metadata is preserved on the registry slot"))))
+      ;; SEMANTIC, posture-independent (rf2-lwtlk): the 3-arity is above all a
+      ;; REGISTRATION arity — the extra metadata argument must not displace
+      ;; the head-fn, and the slot must be usable.
+      (is (some? m) "the 3-arity registered a slot")
+      (is (fn? (:handler-fn m))
+          "the head-fn is stored under :handler-fn, not shifted by the metadata arg")
+      (is (= {:title "x"} ((:handler-fn m) {} nil))
+          "the stored head-fn is the one passed, and it runs")
+
+      ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). `:doc` is a
+      ;; pure-documentation key, dropped by
+      ;; `registrar/strip-pure-documentation` under the production gate per
+      ;; Spec 001 §Production elision contract.
+      (when interop/debug-enabled?
+        (is (= "Article-page head model" (:doc m))
+            ":doc metadata is preserved on the registry slot"))
+
+      ;; rf2-lwtlk — the REAL-gate arm: the elision itself, witnessed on a JVM
+      ;; actually started with `-Dre-frame.debug=false` rather than through a
+      ;; `with-redefs` rebind that a load-time gate cannot see (rf2-9c2jf).
+      (when-not interop/debug-enabled?
+        (is (nil? (:doc m))
+            ":doc is elided from the registry slot in production builds
+             (Spec 001 §Production elision contract)")))))
 
 (deftest reg-head-is-idempotent
   (testing "re-registering the same id replaces the slot (registrar contract)"
@@ -680,30 +725,44 @@
         (rf/register-listener! :trace ::head-clean (fn [ev] (swap! traces conj ev)))
         ;; Drive the destroy hook directly — that's the path Mark-3
         ;; teardown takes per the late-bind chaining.
-        (try (ssr-request :test/frame-id)
-             (catch Throwable _
-               ;; The hook must NOT propagate the exception — fail the
-               ;; test if it does.
-               (is false "on-frame-destroyed! must catch head-cleanup throws")))
+        ;;
+        ;; SEMANTIC, posture-independent (rf2-lwtlk): the `:warned-and-skipped`
+        ;; policy's PRODUCTION half is that teardown continues — the trace is
+        ;; only how a developer finds out. The `(is false …)` below fires only
+        ;; on the failing path, i.e. contributes no assertion when the code is
+        ;; correct, so the completion is witnessed positively by a flag the
+        ;; throwing path can never reach.
+        (let [completed? (atom false)]
+          (try (ssr-request :test/frame-id)
+               (reset! completed? true)
+               (catch Throwable _
+                 ;; The hook must NOT propagate the exception — fail the
+                 ;; test if it does.
+                 (is false "on-frame-destroyed! must catch head-cleanup throws")))
+          (is (true? @completed?)
+              "on-frame-destroyed! returned normally despite the head-cleanup
+               hook throwing — the destroy completed"))
         (rf/unregister-listener! :trace ::head-clean)
 
-        (let [hits (filterv #(= :rf.ssr.head/cleanup-failed (:operation %)) @traces)]
-          (is (= 1 (count hits))
-              (str "expected one :rf.ssr.head/cleanup-failed trace; saw: "
-                   (pr-str (mapv :operation @traces))))
-          (when (seq hits)
-            (let [ev (first hits)]
-              (is (= :warning (:op-type ev)))
-              (is (= :test/frame-id (-> ev :tags :frame))
-                  ":frame tag identifies which frame's cleanup failed")
-              (is (= :ssr/head-on-frame-destroyed (-> ev :tags :hook))
-                  ":hook tag identifies which hook misbehaved")
-              (is (string? (-> ev :tags :reason))
-                  ":reason carries the throwable's message")
-              (is (string? (-> ev :tags :ex-class))
-                  ":ex-class carries the throwable's class name")
-              (is (= :warned-and-skipped (:recovery ev))
-                  ":recovery names the policy — observed and continued"))))
+        ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring).
+        (when interop/debug-enabled?
+          (let [hits (filterv #(= :rf.ssr.head/cleanup-failed (:operation %)) @traces)]
+            (is (= 1 (count hits))
+                (str "expected one :rf.ssr.head/cleanup-failed trace; saw: "
+                     (pr-str (mapv :operation @traces))))
+            (when (seq hits)
+              (let [ev (first hits)]
+                (is (= :warning (:op-type ev)))
+                (is (= :test/frame-id (-> ev :tags :frame))
+                    ":frame tag identifies which frame's cleanup failed")
+                (is (= :ssr/head-on-frame-destroyed (-> ev :tags :hook))
+                    ":hook tag identifies which hook misbehaved")
+                (is (string? (-> ev :tags :reason))
+                    ":reason carries the throwable's message")
+                (is (string? (-> ev :tags :ex-class))
+                    ":ex-class carries the throwable's class name")
+                (is (= :warned-and-skipped (:recovery ev))
+                    ":recovery names the policy — observed and continued")))))
         (finally
           ;; Restore the prior hook so subsequent tests see normal behaviour.
           (if prior-hook

--- a/implementation/ssr/test/re_frame/ssr_hydration_mismatch_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_hydration_mismatch_test.clj
@@ -38,11 +38,49 @@
   Migration-Audit classifies them (C); per the rf2-pxb7t bead the
   whole `spec.cjs` is dropped and those two assertions retire
   alongside (substrate mount is covered by the 3 adapter smokes per
-  the audit's §Drop-or-keep recommendation)."
+  the audit's §Drop-or-keep recommendation).
+
+  ## Posture split (rf2-lwtlk)
+
+  `verify-hydration!` has TWO output channels for one detection, and only
+  one of them survives production. The `:rf.ssr/hydration-mismatch` TRACE
+  goes through the `:trace/emit-error!` late-bind hook, whose emit site is
+  gated on `interop/debug-enabled?` — read once at namespace-load time, so
+  under `-Dre-frame.debug=false` nothing is emitted. The strict-mode THROW
+  is always-on: `hydrate.cljc` builds ONE shared payload and uses it for
+  both, so `:server-hash`, `:client-hash`, `:failing-id`, `:recovery`,
+  `:reason` and `:where` are observable in production through
+  `ex-data` even though the trace carrying the identical map is not.
+
+  That is why `mismatch-strict-mode-throws-with-structured-payload` was
+  already green under the gate, and it is the production witness the trace
+  assertions lean on. Each trace assertion here is kept verbatim inside a
+  `(when interop/debug-enabled? …)` arm marked `rf2-lwtlk`.
+
+  Two deftests would otherwise have been left with nothing to prove, and
+  both gained a production witness rather than being guarded away:
+
+    - `mismatch-detection-defaults-on-when-knob-absent` and
+      `mismatch-detection-disabled-skips-comparison` are about the
+      `:detect-mismatch?` knob, and both observed it ONLY through the
+      trace — including a `(is (empty? mismatches))` that is satisfied
+      automatically under the gate. Each now drives the SAME knob through
+      a frame that also sets `:on-mismatch :hard-error`, where detection-on
+      throws and detection-off does not. The knob's effect is then visible
+      on the always-on channel, in either posture.
+    - `mismatch-trace-client-hash-is-8-char-lowercase-hex` pinned the shape
+      of `render-tree-hash`'s output by reading it back off a trace tag. The
+      shape claim is about the hash function, so it is now also asserted
+      directly against `rf/render-tree-hash`, which is not gated at all.
+    - `mismatch-trace-is-an-error-op-type-event` asserts an
+      ERROR-severity classification; its always-on counterpart is that the
+      same condition carries `:rf.error/id :rf.ssr/hydration-mismatch` — an
+      error id — in the strict-mode throw's `ex-data`."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.error :as error]
             [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
             [re-frame.subs :as subs]
             [re-frame.ssr :as ssr]
             [re-frame.ssr.test-fixture :as tf]
@@ -121,28 +159,33 @@
           ;; A second 8-hex string — anything other than \"deadbeef\".
           client-hash    "0badf00d"]
       (rf/dispatch-sync [:rf/hydrate mismatch-payload] {:frame client-frame})
-      (with-trace-recorder! [traces]
-        (ssr/verify-hydration! client-frame client-hash)
-        (let [mismatches (filter #(= :rf.ssr/hydration-mismatch (:operation %))
-                                 @traces)]
-          (is (= 1 (count mismatches))
-              (str "expected exactly one :rf.ssr/hydration-mismatch trace; saw: "
-                   (pr-str (mapv :operation @traces))))
-          (when (seq mismatches)
-            (let [ev (first mismatches)]
-              (is (= "deadbeef" (-> ev :tags :server-hash))
-                  ":tags :server-hash echoes the payload's known-wrong literal")
-              (is (= client-hash (-> ev :tags :client-hash))
-                  ":tags :client-hash echoes the value we passed to
-                   verify-hydration!")
-              (is (= :rf/hydrate (-> ev :tags :failing-id))
-                  ":tags :failing-id discriminator per Spec 011 v1
-                   (body-mismatch; runtime head-mismatch reserved for the
-                   still-deferred post-v1 head-only-hash extension —
-                   reg-head itself has already shipped)")
-              (is (= :warned-and-replaced (:recovery ev))
-                  ":recovery hoisted onto the envelope top-level
-                   (Spec 009 §Error event shape)"))))))))
+      ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). The
+      ;; identical payload map is observable in production through the
+      ;; strict-mode throw's ex-data, pinned by
+      ;; `mismatch-strict-mode-throws-with-structured-payload`.
+      (when interop/debug-enabled?
+        (with-trace-recorder! [traces]
+          (ssr/verify-hydration! client-frame client-hash)
+          (let [mismatches (filter #(= :rf.ssr/hydration-mismatch (:operation %))
+                                   @traces)]
+            (is (= 1 (count mismatches))
+                (str "expected exactly one :rf.ssr/hydration-mismatch trace; saw: "
+                     (pr-str (mapv :operation @traces))))
+            (when (seq mismatches)
+              (let [ev (first mismatches)]
+                (is (= "deadbeef" (-> ev :tags :server-hash))
+                    ":tags :server-hash echoes the payload's known-wrong literal")
+                (is (= client-hash (-> ev :tags :client-hash))
+                    ":tags :client-hash echoes the value we passed to
+                     verify-hydration!")
+                (is (= :rf/hydrate (-> ev :tags :failing-id))
+                    ":tags :failing-id discriminator per Spec 011 v1
+                     (body-mismatch; runtime head-mismatch reserved for the
+                     still-deferred post-v1 head-only-hash extension —
+                     reg-head itself has already shipped)")
+                (is (= :warned-and-replaced (:recovery ev))
+                    ":recovery hoisted onto the envelope top-level
+                     (Spec 009 §Error event shape)")))))))))
 
 (deftest mismatch-trace-client-hash-is-8-char-lowercase-hex
   (testing "Migrated from testbeds/ssr_hydration_mismatch/spec.cjs
@@ -164,29 +207,49 @@
                         [:p "count=" [:span {:data-testid "count"} 0]]]
           client-hash  (rf/render-tree-hash render-tree)]
       (rf/dispatch-sync [:rf/hydrate mismatch-payload] {:frame client-frame})
-      (with-trace-recorder! [traces]
-        (ssr/verify-hydration! client-frame render-tree)
-        (let [mismatch (first (filter #(= :rf.ssr/hydration-mismatch
-                                          (:operation %))
-                                      @traces))]
-          (is (some? mismatch)
-              ":rf.ssr/hydration-mismatch fires when the resolved tree
-               hashes to anything other than 'deadbeef'")
-          (when mismatch
-            (let [observed (-> mismatch :tags :client-hash)]
-              (is (and (string? observed) (= 8 (count observed)))
-                  (str "computed client-hash is exactly 8 chars; got "
-                       (pr-str observed)))
-              (is (re-matches hex-8-pattern observed)
-                  (str "computed client-hash is 8-char lowercase hex; got "
-                       (pr-str observed)))
-              (is (= client-hash observed)
-                  "the trace echoes the same hash render-tree-hash
-                   computes when called directly on the input")
-              (is (not= "deadbeef" observed)
-                  "client-hash never equals the (deliberately wrong)
-                   server-hash — that would be a hash-collision spec
-                   violation"))))))))
+
+      ;; SEMANTIC, posture-independent (rf2-lwtlk): the SHAPE claim is about
+      ;; `render-tree-hash`, which is not gated at all — reading it back off
+      ;; a trace tag was only ever a detour. Both spec.cjs assertions this
+      ;; deftest migrated (#5 shape, #6 not-equal-deadbeef) are stated here
+      ;; against the hash function itself.
+      (is (and (string? client-hash) (= 8 (count client-hash)))
+          (str "render-tree-hash emits exactly 8 chars; got "
+               (pr-str client-hash)))
+      (is (re-matches hex-8-pattern client-hash)
+          (str "render-tree-hash emits 8-char lowercase hex; got "
+               (pr-str client-hash)))
+      (is (not= "deadbeef" client-hash)
+          "the computed hash never equals the (deliberately wrong)
+           server-hash — that would be a hash-collision spec violation")
+
+      ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). What is
+      ;; left here that is genuinely ABOUT the trace: that the tag echoes
+      ;; the same value `render-tree-hash` computes directly.
+      (when interop/debug-enabled?
+        (with-trace-recorder! [traces]
+          (ssr/verify-hydration! client-frame render-tree)
+          (let [mismatch (first (filter #(= :rf.ssr/hydration-mismatch
+                                            (:operation %))
+                                        @traces))]
+            (is (some? mismatch)
+                ":rf.ssr/hydration-mismatch fires when the resolved tree
+                 hashes to anything other than 'deadbeef'")
+            (when mismatch
+              (let [observed (-> mismatch :tags :client-hash)]
+                (is (and (string? observed) (= 8 (count observed)))
+                    (str "computed client-hash is exactly 8 chars; got "
+                         (pr-str observed)))
+                (is (re-matches hex-8-pattern observed)
+                    (str "computed client-hash is 8-char lowercase hex; got "
+                         (pr-str observed)))
+                (is (= client-hash observed)
+                    "the trace echoes the same hash render-tree-hash
+                     computes when called directly on the input")
+                (is (not= "deadbeef" observed)
+                    "client-hash never equals the (deliberately wrong)
+                     server-hash — that would be a hash-collision spec
+                     violation")))))))))
 
 ;; ===========================================================================
 ;; spec.cjs §(3) → the trace's :op-type is :error
@@ -203,15 +266,36 @@
     (let [client-frame (frame/make-anon-frame-record! {:doc "ssr-mismatch client frame"
                                        :platform :client})]
       (rf/dispatch-sync [:rf/hydrate mismatch-payload] {:frame client-frame})
-      (with-trace-recorder! [traces]
-        (ssr/verify-hydration! client-frame "0badf00d")
-        (let [mismatch (first (filter #(= :rf.ssr/hydration-mismatch
-                                          (:operation %))
-                                      @traces))]
-          (is (some? mismatch))
-          (when mismatch
-            (is (= :error (:op-type mismatch))
-                ":op-type is :error — Spec 009 categorisation")))))))
+
+      ;; SEMANTIC, posture-independent (rf2-lwtlk): the ERROR-severity
+      ;; classification has an always-on counterpart — the same condition,
+      ;; escalated, carries an `:rf.error/id` (not a `:rf.warning/…` id) in
+      ;; the strict-mode throw's ex-data. Spec 009 categorisation is
+      ;; therefore witnessed in both postures, not only on the trace bus.
+      (let [strict-frame (frame/make-anon-frame-record!
+                           {:doc      "ssr-mismatch severity frame"
+                            :platform :client
+                            :ssr      {:on-mismatch :hard-error}})]
+        (rf/dispatch-sync [:rf/hydrate mismatch-payload] {:frame strict-frame})
+        (let [thrown (try (ssr/verify-hydration! strict-frame "0badf00d")
+                          nil
+                          (catch clojure.lang.ExceptionInfo e e))]
+          (is (some? thrown) "the mismatch escalates when strict")
+          (is (= :rf.ssr/hydration-mismatch (:rf.error/id (ex-data thrown)))
+              "the condition is catalogued under :rf.error/… — an ERROR
+               severity, matching the trace's :op-type :error")))
+
+      ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (with-trace-recorder! [traces]
+          (ssr/verify-hydration! client-frame "0badf00d")
+          (let [mismatch (first (filter #(= :rf.ssr/hydration-mismatch
+                                            (:operation %))
+                                        @traces))]
+            (is (some? mismatch))
+            (when mismatch
+              (is (= :error (:op-type mismatch))
+                  ":op-type is :error — Spec 009 categorisation"))))))))
 
 ;; ===========================================================================
 ;; spec.cjs §(4) → page is still interactive post-mismatch
@@ -302,15 +386,20 @@
                                        :platform :client
                                        :ssr {:on-mismatch :hard-error}})]
       (rf/dispatch-sync [:rf/hydrate mismatch-payload] {:frame client-frame})
-      (with-trace-recorder! [traces]
-        (try (ssr/verify-hydration! client-frame "0badf00d")
-             (catch clojure.lang.ExceptionInfo _ nil))
-        (let [mismatch (first (filter #(= :rf.ssr/hydration-mismatch (:operation %))
-                                      @traces))]
-          (is (some? mismatch)
-              "the mismatch trace fires even in strict mode")
-          (is (= :hard-error (:recovery mismatch))
-              "the trace's :recovery reflects strict mode"))))))
+      ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). This
+      ;; deftest's subject is the TRACE half of the emit-then-throw pair; the
+      ;; throw half is `mismatch-strict-mode-throws-with-structured-payload`,
+      ;; which runs in both postures.
+      (when interop/debug-enabled?
+        (with-trace-recorder! [traces]
+          (try (ssr/verify-hydration! client-frame "0badf00d")
+               (catch clojure.lang.ExceptionInfo _ nil))
+          (let [mismatch (first (filter #(= :rf.ssr/hydration-mismatch (:operation %))
+                                        @traces))]
+            (is (some? mismatch)
+                "the mismatch trace fires even in strict mode")
+            (is (= :hard-error (:recovery mismatch))
+                "the trace's :recovery reflects strict mode")))))))
 
 (deftest mismatch-detection-disabled-skips-comparison
   (testing "rf2-ee38b.10 — a frame with :ssr {:detect-mismatch? false}
@@ -321,13 +410,35 @@
                                        :platform :client
                                        :ssr {:detect-mismatch? false}})]
       (rf/dispatch-sync [:rf/hydrate mismatch-payload] {:frame client-frame})
-      (with-trace-recorder! [traces]
-        (is (nil? (ssr/verify-hydration! client-frame "0badf00d"))
-            "verify-hydration! is a no-op when detection is off")
-        (let [mismatches (filter #(= :rf.ssr/hydration-mismatch (:operation %))
-                                 @traces)]
-          (is (empty? mismatches)
-              "no mismatch trace fires when :detect-mismatch? is false"))))))
+      (is (nil? (ssr/verify-hydration! client-frame "0badf00d"))
+          "verify-hydration! is a no-op when detection is off")
+
+      ;; SEMANTIC, posture-independent (rf2-lwtlk): a no-op return value is
+      ;; also what the DETECTING path returns, so it cannot on its own tell
+      ;; the short-circuit from a completed comparison. Drive the same knob
+      ;; on a frame that ALSO asks for `:on-mismatch :hard-error`: with
+      ;; detection off there is nothing to escalate, so it must not throw.
+      ;; That reaches the always-on channel and holds in either posture.
+      (let [off-strict (frame/make-anon-frame-record!
+                         {:doc      "ssr detection-off strict frame"
+                          :platform :client
+                          :ssr      {:detect-mismatch? false
+                                     :on-mismatch      :hard-error}})]
+        (rf/dispatch-sync [:rf/hydrate mismatch-payload] {:frame off-strict})
+        (is (nil? (ssr/verify-hydration! off-strict "0badf00d"))
+            ":detect-mismatch? false short-circuits BEFORE the comparison —
+             even :on-mismatch :hard-error has nothing to escalate"))
+
+      ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). A NEGATIVE
+      ;; over the trace ring: vacuous under the gate, where no mismatch
+      ;; trace fires whether detection ran or not.
+      (when interop/debug-enabled?
+        (with-trace-recorder! [traces]
+          (ssr/verify-hydration! client-frame "0badf00d")
+          (let [mismatches (filter #(= :rf.ssr/hydration-mismatch (:operation %))
+                                   @traces)]
+            (is (empty? mismatches)
+                "no mismatch trace fires when :detect-mismatch? is false")))))))
 
 (deftest mismatch-detection-defaults-on-when-knob-absent
   (testing "rf2-ee38b.10 — absence of the :detect-mismatch? knob (the
@@ -338,10 +449,38 @@
     (let [client-frame (frame/make-anon-frame-record! {:doc "ssr default frame"
                                        :platform :client})]
       (rf/dispatch-sync [:rf/hydrate mismatch-payload] {:frame client-frame})
-      (with-trace-recorder! [traces]
-        (ssr/verify-hydration! client-frame "0badf00d")
-        (let [mismatch (first (filter #(= :rf.ssr/hydration-mismatch (:operation %))
-                                      @traces))]
-          (is (some? mismatch) "detection defaults on")
-          (is (= :warned-and-replaced (:recovery mismatch))
-              "the default recovery is warn-and-replace (not hard-error)"))))))
+
+      ;; SEMANTIC, posture-independent (rf2-lwtlk): the default this deftest
+      ;; exists to pin is `:detect-mismatch?` ABSENT ⇒ detection ON, and it
+      ;; was observable only through the trace. Drive the same absent knob on
+      ;; a frame that asks for `:on-mismatch :hard-error`: if detection had
+      ;; silently defaulted off there would be nothing to escalate and no
+      ;; throw. The throw is always-on, so the default is now pinned in both
+      ;; postures — which is precisely the refactor this deftest guards
+      ;; against.
+      (let [default-strict (frame/make-anon-frame-record!
+                             {:doc      "ssr default-detection strict frame"
+                              :platform :client
+                              :ssr      {:on-mismatch :hard-error}})]
+        (rf/dispatch-sync [:rf/hydrate mismatch-payload] {:frame default-strict})
+        (let [thrown (try (ssr/verify-hydration! default-strict "0badf00d")
+                          nil
+                          (catch clojure.lang.ExceptionInfo e e))]
+          (is (some? thrown)
+              "with :detect-mismatch? absent the comparison still ran —
+               detection defaults ON")
+          (is (= "0badf00d" (:client-hash (ex-data thrown)))
+              "…and it compared the hashes it was given, rather than
+               short-circuiting")))
+
+      ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). The default
+      ;; RECOVERY (`:warned-and-replaced` rather than `:hard-error`) is only
+      ;; observable on the trace: the warn path throws nothing by definition.
+      (when interop/debug-enabled?
+        (with-trace-recorder! [traces]
+          (ssr/verify-hydration! client-frame "0badf00d")
+          (let [mismatch (first (filter #(= :rf.ssr/hydration-mismatch (:operation %))
+                                        @traces))]
+            (is (some? mismatch) "detection defaults on")
+            (is (= :warned-and-replaced (:recovery mismatch))
+                "the default recovery is warn-and-replace (not hard-error)")))))))

--- a/implementation/ssr/test/re_frame/ssr_hydration_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_hydration_test.clj
@@ -43,10 +43,63 @@
   are pure DOM-mount probes — the Migration-Audit classifies them (C);
   per the rf2-pxb7t bead the whole `spec.cjs` is dropped and those
   two assertions retire alongside (substrate mount is already covered
-  by the 3 adapter smokes per the audit's §Drop-or-keep recommendation)."
+  by the 3 adapter smokes per the audit's §Drop-or-keep recommendation).
+
+  ## Posture split (rf2-lwtlk)
+
+  The hydration CONTRACT is production-real throughout and is asserted here
+  without a posture guard: which slice replaces app-db, which is rejected,
+  that a rejected payload leaves BOTH partitions untouched and stashes no
+  metadata, that the retired plain `:app-db` alias stays dead, that
+  `hydrate!` establishes frame scope for its `:render-tree-fn`. None of that
+  needed changing — it was already green under `-Dre-frame.debug=false`.
+
+  What kept the namespace off `scripts/test-ssr-prod-gate.sh` is the
+  DIAGNOSTIC that accompanies each rejection. `:rf.error/malformed-hydration-
+  payload`, `:rf.error/hydration-frame-id-mismatch`,
+  `:rf.ssr/hydration-mismatch` and the `:rf.ssr/version-mismatch` family all
+  emit behind `interop/debug-enabled?`, read once at namespace-load time, so
+  under the gate the framework announces none of it. Fail-CLOSED is the
+  contract; the trace is how a developer hears about it. Every such assertion
+  is kept VERBATIM inside a `(when interop/debug-enabled? …)` arm marked
+  `rf2-lwtlk`.
+
+  The larger half of this split is the NEGATIVE trace assertions, none of
+  which were failing — which is exactly why they had to move. A dozen
+  `(is (not-any? … @traces))` / `(is (empty? (filter … @traces)))` forms say,
+  variously, that the well-formed payload did NOT trip the malformed
+  diagnostic, that matching hashes produced no mismatch, that the server-side
+  gate emitted no skipped-on-platform warning. Under the gate the ring is
+  empty for every input, so each is satisfied without distinguishing the case
+  it exists to distinguish. They sit in the dev arms with their positive
+  counterparts.
+
+  Three claims were observable ONLY through the trace and got a
+  production-visible witness instead of being guarded away (the rf2-7vk3z
+  shape):
+
+    - whether the `:rf.ssr/check-*` fxs were ENQUEUED. Both the server-side
+      skip and the client-side counter-test now re-register the two fx ids
+      with a recording stub and read the recorded dispatches directly. That
+      is a stronger statement than either the absence of a
+      `:rf.fx/skipped-on-platform` warning or the presence of a
+      `:rf.ssr/version-mismatch`, and it holds in both postures.
+    - whether `verify-hydration!` SHORT-CIRCUITS on a nil server hash, and
+      whether `hydrate!`'s verify step RUNS at all. Both drive the same
+      condition on a frame carrying `:ssr {:on-mismatch :hard-error}`, where
+      a detected mismatch escalates to a throw — an always-on channel, since
+      `hydrate.cljc` builds one shared payload for the trace and the throw
+      alike. A nil server hash must not throw; a divergent hash must.
+
+  `b5-...` at the foot of the namespace was already posture-correct: it reads
+  the ALWAYS-ON `:errors` axis and guards its dev-trace half with
+  `(when dev-trace …)`. It is the shape the rest of this file now follows."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.fx :as fx]
+            [re-frame.interop :as interop]
+            [re-frame.registrar :as registrar]
             [re-frame.subs :as subs]
             [re-frame.ssr :as ssr]
             [re-frame.ssr.payload-policy :as payload-policy]
@@ -54,6 +107,33 @@
             [re-frame.test-support :refer [with-trace-recorder!]]))
 
 (use-fixtures :each tf/reset-runtime)
+
+;; rf2-lwtlk — a production-visible probe for "were the compatibility-check
+;; fxs ENQUEUED?".  Re-registers the two `:rf.ssr/check-*` fx ids with a
+;; DECORATOR that records the dispatch and then delegates to the real
+;; handler-fn, so the observation is additive: the checks still run and still
+;; emit their dev traces, and the deftests' dev arms keep asserting them.  The
+;; `tf/reset-runtime` fixture restores the untouched registrations between
+;; deftests.
+;;
+;; The point is that the handler's platform gate is a statement about the
+;; EFFECT QUEUE, and this reads the queue.  Inferring it from the presence or
+;; absence of a `:rf.fx/skipped-on-platform` / `:rf.ssr/version-mismatch`
+;; trace cannot tell "never enqueued" from "warning elided", which is
+;; precisely the distinction that disappears under `-Dre-frame.debug=false`.
+;;
+;; Returns the recording atom: a vector of `[fx-id value]`.
+(defn- record-check-fx-dispatches! []
+  (let [seen (atom [])]
+    (doseq [id [:rf.ssr/check-version :rf.ssr/check-schema-digest]]
+      (let [slot (registrar/lookup :fx id)
+            real (:handler-fn slot)]
+        (fx/reg-fx id
+                   (select-keys slot [:platforms :schema])
+                   (fn [frame-id v]
+                     (swap! seen conj [id v])
+                     (when real (real frame-id v))))))
+    seen))
 
 ;; The payload the testbed's `<script id=\"__rf_payload\">` bakes verbatim
 ;; (testbeds/ssr_basic/index.html lines 58-73). Pinning the literal here
@@ -236,11 +316,15 @@
           payload      (materialise-response baseline-payload)]
       (with-trace-recorder! [traces]
         (rf/dispatch-sync [:rf/hydrate payload] {:frame client-frame})
-        (is (empty? (filter #(= :rf.ssr/compatibility-check-skipped (:operation %)) @traces))
-            (str "version check resolves via the SSR constant → never skipped; "
-                 "saw operations: " (pr-str (mapv :operation @traces))))
-        (is (empty? (filter #(= :rf.ssr/version-mismatch (:operation %)) @traces))
-            "payload :rf/version == the SSR constant → silent match")))))
+        ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). BOTH are
+        ;; negatives over the trace ring: vacuous under the gate, where a
+        ;; skewed version would look identical to a matching one.
+        (when interop/debug-enabled?
+          (is (empty? (filter #(= :rf.ssr/compatibility-check-skipped (:operation %)) @traces))
+              (str "version check resolves via the SSR constant → never skipped; "
+                   "saw operations: " (pr-str (mapv :operation @traces))))
+          (is (empty? (filter #(= :rf.ssr/version-mismatch (:operation %)) @traces))
+              "payload :rf/version == the SSR constant → silent match"))))))
 
 ;; ===========================================================================
 ;; spec.cjs §(7) → NO mismatch trace on the baseline
@@ -269,23 +353,33 @@
           payload      (-> baseline-payload
                            (assoc :rf/schema-digest "test-digest-abc")
                            materialise-response)]
-      (with-trace-recorder! [traces]
-        (rf/dispatch-sync [:rf/hydrate payload] {:frame server-frame})
-        (let [skipped-checks
-              (filter (fn [ev]
-                        (and (= :rf.fx/skipped-on-platform (:operation ev))
-                             (#{:rf.ssr/check-version :rf.ssr/check-schema-digest}
-                              (-> ev :tags :rf.fx/id))))
-                      @traces)]
-          (is (empty? skipped-checks)
-              (str "expected zero :rf.fx/skipped-on-platform traces for the two "
-                   ":rf.ssr/check-* fxs on a :server-platform :rf/hydrate; saw: "
-                   (pr-str (mapv (juxt :operation #(-> % :tags :rf.fx/id))
-                                 skipped-checks))))
+      (let [dispatched (record-check-fx-dispatches!)]
+        (with-trace-recorder! [traces]
+          (rf/dispatch-sync [:rf/hydrate payload] {:frame server-frame})
+          ;; SEMANTIC, posture-independent (rf2-lwtlk): the handler-level gate
+          ;; is a statement about the EFFECT QUEUE, so read the queue. The
+          ;; original assertion inferred it from the absence of a dev warning,
+          ;; which cannot tell "never enqueued" from "warning elided".
+          (is (= [] @dispatched)
+              (str "the handler enqueued NEITHER :rf.ssr/check-* fx on a "
+                   ":server-platform :rf/hydrate; saw: " (pr-str @dispatched)))
           ;; Sanity: the handler still landed the app-db swap + metadata —
           ;; the gate skipped only the check-fx dispatches, not the rest.
           (is (= 7 (rf/subscribe-once [:count] {:frame server-frame}))
-              ":rf/app-db still applied on the server-side run"))))))
+              ":rf/app-db still applied on the server-side run")
+          ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring).
+          (when interop/debug-enabled?
+            (let [skipped-checks
+                  (filter (fn [ev]
+                            (and (= :rf.fx/skipped-on-platform (:operation ev))
+                                 (#{:rf.ssr/check-version :rf.ssr/check-schema-digest}
+                                  (-> ev :tags :rf.fx/id))))
+                          @traces)]
+              (is (empty? skipped-checks)
+                  (str "expected zero :rf.fx/skipped-on-platform traces for the two "
+                       ":rf.ssr/check-* fxs on a :server-platform :rf/hydrate; saw: "
+                       (pr-str (mapv (juxt :operation #(-> % :tags :rf.fx/id))
+                                     skipped-checks)))))))))))
 
 (deftest hydration-on-client-platform-still-dispatches-check-fxs
   (testing "Per rf2-7bcn0 (counter-test to the server-side skip): on a
@@ -306,13 +400,27 @@
           payload      (-> baseline-payload
                            (assoc :rf/version (inc payload-policy/pattern-protocol-version))
                            materialise-response)]
-      (with-trace-recorder! [traces]
-        (rf/dispatch-sync [:rf/hydrate payload] {:frame client-frame})
-        (let [mismatch (filter #(= :rf.ssr/version-mismatch (:operation %)) @traces)]
-          (is (seq mismatch)
-              (str "on :client the :rf.ssr/check-version fx still fires and "
-                   "emits :rf.ssr/version-mismatch on a skewed :rf/version; "
-                   "saw operations: " (pr-str (mapv :operation @traces)))))))))
+      (let [dispatched (record-check-fx-dispatches!)]
+        (with-trace-recorder! [traces]
+          (rf/dispatch-sync [:rf/hydrate payload] {:frame client-frame})
+          ;; SEMANTIC, posture-independent (rf2-lwtlk): the counter-test's
+          ;; claim is that the rf2-7bcn0 server-side gate did NOT over-skip on
+          ;; :client — i.e. the fx was ENQUEUED. Read the effect queue, which
+          ;; says so directly and in both postures; the mismatch trace was
+          ;; only ever a proxy for it.
+          (is (contains? (set (map first @dispatched)) :rf.ssr/check-version)
+              (str "on :client the handler still enqueued :rf.ssr/check-version; "
+                   "saw: " (pr-str @dispatched)))
+          (is (= (inc payload-policy/pattern-protocol-version)
+                 (some (fn [[id v]] (when (= :rf.ssr/check-version id) v)) @dispatched))
+              "…carrying the payload's skewed :rf/version as its argument")
+          ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring).
+          (when interop/debug-enabled?
+            (let [mismatch (filter #(= :rf.ssr/version-mismatch (:operation %)) @traces)]
+              (is (seq mismatch)
+                  (str "on :client the :rf.ssr/check-version fx still fires and "
+                       "emits :rf.ssr/version-mismatch on a skewed :rf/version; "
+                       "saw operations: " (pr-str (mapv :operation @traces)))))))))))
 
 (deftest hydration-baseline-no-mismatch-trace-when-server-hash-nil
   (testing "Migrated from testbeds/ssr_basic/spec.cjs assertion #13.
@@ -337,10 +445,30 @@
         ;; value (Spec 011 — `(when (and server-hash
         ;; client-hash ...) ...)` short-circuits).
         (ssr/verify-hydration! client-frame "abcdef01")
-        (is (not-any? #(= :rf.ssr/hydration-mismatch (:operation %)) @traces)
-            (str "no :rf.ssr/hydration-mismatch on the baseline (server-"
-                 "hash was nil); saw: "
-                 (pr-str (mapv :operation @traces))))))))
+        ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). A NEGATIVE
+        ;; over the trace ring, and this deftest's ONLY assertion: under the
+        ;; gate it would have passed without the short-circuit existing.
+        (when interop/debug-enabled?
+          (is (not-any? #(= :rf.ssr/hydration-mismatch (:operation %)) @traces)
+              (str "no :rf.ssr/hydration-mismatch on the baseline (server-"
+                   "hash was nil); saw: "
+                   (pr-str (mapv :operation @traces))))))
+
+      ;; SEMANTIC, posture-independent (rf2-lwtlk): drive the SAME nil-server-
+      ;; hash condition on a frame that asks for `:ssr {:on-mismatch
+      ;; :hard-error}`. A detected mismatch escalates to a throw — always-on,
+      ;; since hydrate.cljc builds one shared payload for the trace and the
+      ;; throw alike. Nothing thrown means the comparison genuinely
+      ;; short-circuited rather than merely failing to announce itself.
+      (let [strict-frame (frame/make-anon-frame-record!
+                           {:doc      "nil-server-hash strict frame"
+                            :platform :client
+                            :ssr      {:on-mismatch :hard-error}})]
+        (rf/dispatch-sync [:rf/hydrate (materialise-response baseline-payload)]
+                          {:frame strict-frame})
+        (is (nil? (ssr/verify-hydration! strict-frame "abcdef01"))
+            "a nil server-hash short-circuits BEFORE the comparison — even
+             :on-mismatch :hard-error has nothing to escalate")))))
 
 ;; ===========================================================================
 ;; rf2-gro94 — fail CLOSED on a malformed / untrusted hydration payload
@@ -387,10 +515,15 @@
           (is (false? (rf/subscribe-once [:hydrated?] {:frame client-frame}))
               (str (pr-str bad-payload)
                    " must NOT stash hydration metadata (rejected, not applied)"))
-          (is (some #(= :rf.error/malformed-hydration-payload (:operation %)) @traces)
-              (str (pr-str bad-payload)
-                   " must emit :rf.error/malformed-hydration-payload; saw: "
-                   (pr-str (mapv :operation @traces)))))))))
+          ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). FAIL
+          ;; CLOSED is the contract and is pinned by the three assertions
+          ;; above, all posture-independent; the diagnostic is how a
+          ;; developer learns which payload was rejected and why.
+          (when interop/debug-enabled?
+            (is (some #(= :rf.error/malformed-hydration-payload (:operation %)) @traces)
+                (str (pr-str bad-payload)
+                     " must emit :rf.error/malformed-hydration-payload; saw: "
+                     (pr-str (mapv :operation @traces))))))))))
 
 (deftest wellformed-hydration-payload-still-applies-through-router
   (testing "rf2-gro94 — the fail-closed guard is precise: a well-formed
@@ -406,8 +539,12 @@
                           {:frame client-frame})
         (is (= 7 (rf/subscribe-once [:count] {:frame client-frame})) "server slice installed")
         (is (= "seeded" (rf/subscribe-once [:title] {:frame client-frame})))
-        (is (not-any? #(= :rf.error/malformed-hydration-payload (:operation %)) @traces)
-            "no malformed diagnostic on a well-formed payload")))
+        ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). Vacuous
+        ;; under the gate; the PRECISION this deftest is for — the payload
+        ;; was accepted — is pinned by the installed slice above.
+        (when interop/debug-enabled?
+          (is (not-any? #(= :rf.error/malformed-hydration-payload (:operation %)) @traces)
+              "no malformed diagnostic on a well-formed payload"))))
     ;; (b) map payload with no app-db slice → existing client data survives.
     (let [client-frame (frame/make-anon-frame-record! {:doc "client frame b" :platform :client})]
       (rf/dispatch-sync [::set-title "kept"] {:frame client-frame})
@@ -415,8 +552,11 @@
         (rf/dispatch-sync [:rf/hydrate {:rf/version 1}] {:frame client-frame})
         (is (= "kept" (rf/subscribe-once [:title] {:frame client-frame}))
             "no-slice payload preserves the existing client slice")
-        (is (not-any? #(= :rf.error/malformed-hydration-payload (:operation %)) @traces)
-            "a no-slice map payload is the legitimate client-only fallback, not malformed")))))
+        ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). Vacuous
+        ;; under the gate.
+        (when interop/debug-enabled?
+          (is (not-any? #(= :rf.error/malformed-hydration-payload (:operation %)) @traces)
+              "a no-slice map payload is the legitimate client-only fallback, not malformed"))))))
 
 ;; ===========================================================================
 ;; rf2-g00l2t — fail CLOSED on a present-but-non-map :rf/runtime-db slice
@@ -486,18 +626,25 @@
             (is (false? (rf/subscribe-once [:hydrated?] {:frame client-frame}))
                 (str (pr-str bad-rt)
                      " must NOT stash hydration metadata (rejected, not applied)"))
-            ;; the malformed diagnostic fires.
-            (is (some #(= :rf.error/malformed-hydration-payload (:operation %)) @traces)
-                (str (pr-str bad-rt)
-                     " must emit :rf.error/malformed-hydration-payload; saw: "
-                     (pr-str (mapv :operation @traces))))
-            ;; no compatibility-check fxs fire on the rejected path.
-            (is (not-any? #(#{:rf.ssr/version-mismatch
-                              :rf.ssr/schema-digest-mismatch
-                              :rf.ssr/compatibility-check-skipped}
-                            (:operation %)) @traces)
-                (str (pr-str bad-rt)
-                     " must NOT fire compatibility-check fxs on the rejected path"))))))))
+            ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). Both
+            ;; halves belong here: the malformed diagnostic FAILS under the
+            ;; gate, and "no compatibility-check fxs on the rejected path" is
+            ;; a negative over the same empty ring, so it would have PASSED
+            ;; without the rejection short-circuit existing. The rejection
+            ;; itself is pinned by the four partition assertions above.
+            (when interop/debug-enabled?
+              ;; the malformed diagnostic fires.
+              (is (some #(= :rf.error/malformed-hydration-payload (:operation %)) @traces)
+                  (str (pr-str bad-rt)
+                       " must emit :rf.error/malformed-hydration-payload; saw: "
+                       (pr-str (mapv :operation @traces))))
+              ;; no compatibility-check fxs fire on the rejected path.
+              (is (not-any? #(#{:rf.ssr/version-mismatch
+                                :rf.ssr/schema-digest-mismatch
+                                :rf.ssr/compatibility-check-skipped}
+                              (:operation %)) @traces)
+                  (str (pr-str bad-rt)
+                       " must NOT fire compatibility-check fxs on the rejected path")))))))))
 
 (deftest wellformed-runtime-db-slice-still-installs-through-router
   (testing "rf2-g00l2t — the runtime-db guard is precise: a well-formed map
@@ -516,15 +663,21 @@
         (is (= 7 (rf/subscribe-once [:count] {:frame client-frame})) "app-db slice installed")
         (is (= {:route-id :home} (rf/subscribe-once [:route-current] {:frame client-frame}))
             "the runtime-db route slice rode the payload and installed")
-        (is (not-any? #(= :rf.error/malformed-hydration-payload (:operation %)) @traces)
-            "no malformed diagnostic on a well-formed two-partition payload")))
+        ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). Vacuous
+        ;; under the gate; the installed route slice above is the acceptance.
+        (when interop/debug-enabled?
+          (is (not-any? #(= :rf.error/malformed-hydration-payload (:operation %)) @traces)
+              "no malformed diagnostic on a well-formed two-partition payload"))))
     ;; (b) wholly-absent :rf/runtime-db key → no-server-runtime fallback.
     (let [client-frame (frame/make-anon-frame-record! {:doc "rt-absent client frame" :platform :client})]
       (with-trace-recorder! [traces]
         (rf/dispatch-sync [:rf/hydrate {:rf/app-db {:count 3}}] {:frame client-frame})
         (is (= 3 (rf/subscribe-once [:count] {:frame client-frame})) "app-db slice installed")
-        (is (not-any? #(= :rf.error/malformed-hydration-payload (:operation %)) @traces)
-            "an absent :rf/runtime-db key is the no-server-runtime fallback, not malformed")))))
+        ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). Vacuous
+        ;; under the gate.
+        (when interop/debug-enabled?
+          (is (not-any? #(= :rf.error/malformed-hydration-payload (:operation %)) @traces)
+              "an absent :rf/runtime-db key is the no-server-runtime fallback, not malformed"))))))
 
 ;; ===========================================================================
 ;; rf2-1qem4q — the retired plain :app-db hydration alias stays DEAD
@@ -568,10 +721,14 @@
         (is (false? (rf/subscribe-once [:hydrated?] {:frame client-frame}))
             "no hydration metadata stashed — the :rf/render-hash / :rf/version
              keys are absent, so the no-slice payload installs no metadata")
-        (is (not-any? #(= :rf.error/malformed-hydration-payload (:operation %)) @traces)
-            (str "a {:app-db {…}} payload is a map with no :rf/app-db key — the "
-                 "legitimate client-only no-slice fallback, NOT malformed; saw: "
-                 (pr-str (mapv :operation @traces))))))))
+        ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). Vacuous
+        ;; under the gate; the alias-stays-dead claim is pinned by the three
+        ;; posture-independent assertions above.
+        (when interop/debug-enabled?
+          (is (not-any? #(= :rf.error/malformed-hydration-payload (:operation %)) @traces)
+              (str "a {:app-db {…}} payload is a map with no :rf/app-db key — the "
+                   "legitimate client-only no-slice fallback, NOT malformed; saw: "
+                   (pr-str (mapv :operation @traces)))))))))
 
 ;; ===========================================================================
 ;; rf2-lq2ou — client-side hydration boot helper (ssr/hydrate!)
@@ -675,10 +832,44 @@
           {:frame          client-frame
            :payload        payload
            :render-tree-fn (fn [] [:div.app [:span "client-render"]])})
-        (is (some #(= :rf.ssr/hydration-mismatch (:operation %)) @traces)
-            (str "verify step fired a :rf.ssr/hydration-mismatch (server hash "
-                 "'server00' != client render-tree hash); saw: "
-                 (pr-str (mapv :operation @traces))))))))
+        ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring).
+        (when interop/debug-enabled?
+          (is (some #(= :rf.ssr/hydration-mismatch (:operation %)) @traces)
+              (str "verify step fired a :rf.ssr/hydration-mismatch (server hash "
+                   "'server00' != client render-tree hash); saw: "
+                   (pr-str (mapv :operation @traces))))))
+
+      ;; SEMANTIC, posture-independent (rf2-lwtlk): "the boot helper wires
+      ;; mismatch detection" is the claim, and it has an always-on channel.
+      ;; Run the SAME divergent-hash boot on a frame carrying
+      ;; `:ssr {:on-mismatch :hard-error}`: hydrate! must escalate, and the
+      ;; ex-data must name the server hash the payload carried and the hash of
+      ;; the tree `:render-tree-fn` actually returned. Nothing else in this
+      ;; deftest proves the verify step ran.
+      (let [strict-frame (frame/make-anon-frame-record!
+                           {:doc      "boot-helper verify strict frame"
+                            :platform :client
+                            :ssr      {:detect-mismatch? true
+                                       :on-mismatch      :hard-error}})
+            client-tree  [:div.app [:span "client-render"]]
+            strict-pl    (build-server-payload
+                           strict-frame {:count 7 :title "seeded"}
+                           "server00"
+                           {:version 1 :payload [:count :title]})
+            thrown       (try (ssr/hydrate!
+                                {:frame          strict-frame
+                                 :payload        strict-pl
+                                 :render-tree-fn (fn [] client-tree)})
+                              nil
+                              (catch clojure.lang.ExceptionInfo e e))]
+        (is (some? thrown)
+            "hydrate!'s verify step ran and escalated the divergent hash")
+        (is (= :rf.ssr/hydration-mismatch (:rf.error/id (ex-data thrown))))
+        (is (= "server00" (:server-hash (ex-data thrown)))
+            "the payload's server hash reached the comparison")
+        (is (= (ssr/render-tree-hash client-tree) (:client-hash (ex-data thrown)))
+            "…and it was compared against the hash of the tree
+             :render-tree-fn returned, so the verify step really rendered")))))
 
 (deftest boot-hydrate-verify-step-silent-on-matching-render
   (testing "rf2-lq2ou: when the client render-tree hash MATCHES the server
@@ -703,12 +894,35 @@
           {:frame          client-frame
            :payload        payload
            :render-tree-fn (fn [] client-tree)})
-        (is (not-any? #(= :rf.ssr/hydration-mismatch (:operation %)) @traces)
-            (str "matching hashes → no :rf.ssr/hydration-mismatch; saw: "
-                 (pr-str (mapv :operation @traces))))
+        ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). A NEGATIVE
+        ;; over the trace ring: vacuous under the gate, where a DIVERGENT
+        ;; render would look identical to a matching one.
+        (when interop/debug-enabled?
+          (is (not-any? #(= :rf.ssr/hydration-mismatch (:operation %)) @traces)
+              (str "matching hashes → no :rf.ssr/hydration-mismatch; saw: "
+                   (pr-str (mapv :operation @traces)))))
         ;; Sanity: the seed still landed (the verify step doesn't gate hydrate).
         (is (= 7 (rf/subscribe-once [:count] {:frame client-frame}))
-            ":rf/hydrate still applied the seeded slice")))))
+            ":rf/hydrate still applied the seeded slice"))
+
+      ;; SEMANTIC, posture-independent (rf2-lwtlk): the false-positive guard
+      ;; this deftest exists to be needs an always-on channel too. Same
+      ;; matching-hash boot on an `:on-mismatch :hard-error` frame: it must
+      ;; NOT throw, which the divergent case above proves it would.
+      (let [strict-frame (frame/make-anon-frame-record!
+                           {:doc      "boot-helper verify-match strict frame"
+                            :platform :client
+                            :ssr      {:detect-mismatch? true
+                                       :on-mismatch      :hard-error}})
+            strict-pl    (build-server-payload
+                           strict-frame {:count 7 :title "seeded"}
+                           matched-hash
+                           {:version 1 :payload [:count :title]})]
+        (is (some? (ssr/hydrate! {:frame          strict-frame
+                                  :payload        strict-pl
+                                  :render-tree-fn (fn [] client-tree)}))
+            "matching hashes do not escalate even under :on-mismatch
+             :hard-error — the verify step is not a false-positive generator")))))
 
 (deftest boot-hydrate-scopes-render-tree-fn-to-target-frame
   (testing "rf2-0vk7b: hydrate! calls :render-tree-fn UNDER the target frame's
@@ -737,7 +951,13 @@
           ;; The unwrapped idiom, distilled: reads an AMBIENT frame-scoped
           ;; subscription (exactly what a reg-view's injected `subscribe` does),
           ;; so it can ONLY succeed if hydrate! provides the frame scope.
-          render-tree-fn (fn [] [:div.app [:span (rf/subscribe-once [:count])]])]
+          ;; rf2-lwtlk — count the invocations so "it ran under frame scope"
+          ;; is witnessed positively rather than inferred from the absence of
+          ;; a throw.
+          render-tree-fn-calls (atom 0)
+          render-tree-fn (fn []
+                           (swap! render-tree-fn-calls inc)
+                           [:div.app [:span (rf/subscribe-once [:count])]])]
       (with-trace-recorder! [traces]
         ;; Simulate the BROWSER's client-boot condition: no ambient frame. The
         ;; ssr test fixture otherwise pins `*current-frame*` to `:rf/default`
@@ -754,10 +974,20 @@
                 "hydrate! completed — the subscribing render-tree-fn did NOT
                  raise :rf.error/no-frame-context (it ran under the target frame
                  scope hydrate! established)")
-            (is (some #(= :rf.ssr/hydration-mismatch (:operation %)) @traces)
-                (str "verify ran the subscribing render-tree-fn under frame scope "
-                     "(server hash 'server00' != client render-tree hash); saw: "
-                     (pr-str (mapv :operation @traces))))))))))
+            ;; SEMANTIC, posture-independent (rf2-lwtlk): the render-tree-fn
+            ;; was actually INVOKED. `(some? returned)` alone would also hold
+            ;; if hydrate! had skipped the verify step entirely and so never
+            ;; needed a frame scope — the exact regression this deftest
+            ;; guards against.
+            (is (= 1 @render-tree-fn-calls)
+                "hydrate! invoked :render-tree-fn exactly once, under the
+                 target frame's scope")
+            ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring).
+            (when interop/debug-enabled?
+              (is (some #(= :rf.ssr/hydration-mismatch (:operation %)) @traces)
+                  (str "verify ran the subscribing render-tree-fn under frame scope "
+                       "(server hash 'server00' != client render-tree hash); saw: "
+                       (pr-str (mapv :operation @traces)))))))))))
 
 ;; ===========================================================================
 ;; rf2-acjknb — EP-0002: hydrate! requires :frame; payload :rf/frame-id is
@@ -864,18 +1094,25 @@
           (is (nil? (get-in (:rf.db/runtime (rf/frame-state-value client-frame))
                             [:rf.runtime/machines :snapshots]))
               "the payload's runtime-db slice did NOT land — runtime-db untouched")
-          ;; the structured mismatch surfaced, carrying the two frames.
-          (let [mismatch (first (filter #(= :rf.error/hydration-frame-id-mismatch
-                                            (:operation %))
-                                        @traces))]
-            (is (some? mismatch)
-                (str "must emit :rf.error/hydration-frame-id-mismatch; saw: "
-                     (pr-str (mapv :operation @traces))))
-            (when mismatch
-              (is (= client-frame (-> mismatch :tags :target-frame))
-                  ":target-frame is the dispatch target frame")
-              (is (= :some/other-frame (-> mismatch :tags :payload-frame-id))
-                  ":payload-frame-id is the payload's (server) frame stamp"))))))))
+          ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). The
+          ;; BYPASS this deftest names — a direct dispatch reaching only the
+          ;; handler — is closed by the four partition assertions above, all
+          ;; posture-independent. The always-on fan-out of this same category
+          ;; is pinned on the `:errors` axis by the b5- deftest below, which
+          ;; has been green under the gate throughout.
+          (when interop/debug-enabled?
+            ;; the structured mismatch surfaced, carrying the two frames.
+            (let [mismatch (first (filter #(= :rf.error/hydration-frame-id-mismatch
+                                              (:operation %))
+                                          @traces))]
+              (is (some? mismatch)
+                  (str "must emit :rf.error/hydration-frame-id-mismatch; saw: "
+                       (pr-str (mapv :operation @traces))))
+              (when mismatch
+                (is (= client-frame (-> mismatch :tags :target-frame))
+                    ":target-frame is the dispatch target frame")
+                (is (= :some/other-frame (-> mismatch :tags :payload-frame-id))
+                    ":payload-frame-id is the payload's (server) frame stamp")))))))))
 
 ;; ===========================================================================
 ;; rf2-7qbxbm / rf2-mrtis6 census B5 — the always-on corpus leg of the

--- a/implementation/ssr/test/re_frame/ssr_keyword_head_contract_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_keyword_head_contract_test.clj
@@ -47,10 +47,25 @@
   The client half of the same contract is pinned substrate-side in
   `implementation/adapters/reagent/test/re_frame/ssr_keyword_head_contract_cljs_test.cljs`,
   which asserts the SAME head paints the SAME element AND the same bytes.
-  Together the two files are the cross-host proof."
+  Together the two files are the cross-host proof.
+
+  ## Posture split (rf2-lwtlk)
+
+  The head grammar itself is production-real and is asserted throughout
+  without a posture guard. The single exception is inside
+  `views-are-referenced-by-callable-head`, whose `(rf/view :id)` arm pins the
+  registration-boundary annotations byte for byte. Those attributes exist
+  only under `interop/debug-enabled?` (read once at namespace-load time), so
+  under `-Dre-frame.debug=false` the registered handle renders the same view
+  subtree without them. The annotated literal is kept verbatim in a
+  `(when interop/debug-enabled? …)` arm; the arm's actual claim — that BOTH
+  spellings resolve the same view — is restated posture-independently by
+  comparing the two renders directly, which is a stronger statement than the
+  `str/includes?` triple it replaces and holds in both postures."
   (:require [clojure.string :as str]
             [clojure.test :refer [are deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.interop :as interop]
             [re-frame.ssr.emit :as emit]
             [re-frame.ssr.streaming :as streaming]
             [re-frame.ssr.test-fixture :as tf]))
@@ -173,15 +188,18 @@
       (is (= "<div class=\"card\"><h3>:revenue</h3></div>"
              (emit/render-to-string [card-view :revenue] nil))))
 
-    (testing "`(rf/view :id)` — the REGISTERED handle — resolves the view AND
-              carries both dev annotations (rf2-8vi4q). In idiomatic usage
-              the symbol `reg-view` defs IS `(rf/view id)`, so THIS is what a
-              real Var reference emits."
-      (is (= (str "<div class=\"card\""
-                  " data-rf2-source-coord=\"dashboard:card:?:?\""
-                  " data-rf-view=\":dashboard/card\">"
-                  "<h3>:revenue</h3></div>")
-             (emit/render-to-string [(rf/view :dashboard/card) :revenue] nil))))
+    ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). The registered
+    ;; handle carries the annotations only under `interop/debug-enabled?`.
+    (when interop/debug-enabled?
+      (testing "`(rf/view :id)` — the REGISTERED handle — resolves the view AND
+                carries both dev annotations (rf2-8vi4q). In idiomatic usage
+                the symbol `reg-view` defs IS `(rf/view id)`, so THIS is what a
+                real Var reference emits."
+        (is (= (str "<div class=\"card\""
+                    " data-rf2-source-coord=\"dashboard:card:?:?\""
+                    " data-rf-view=\":dashboard/card\">"
+                    "<h3>:revenue</h3></div>")
+               (emit/render-to-string [(rf/view :dashboard/card) :revenue] nil)))))
 
     (testing "both spellings resolve to the SAME view subtree — the class and
               child agree; the registered handle merely adds the debug-gated
@@ -191,7 +209,20 @@
       (is (str/includes? (emit/render-to-string [(rf/view :dashboard/card) :revenue] nil)
                          "class=\"card\""))
       (is (str/includes? (emit/render-to-string [(rf/view :dashboard/card) :revenue] nil)
-                         "<h3>:revenue</h3>")))))
+                         "<h3>:revenue</h3>")))
+
+    ;; rf2-lwtlk — the REAL-gate arm. With no annotation wrapper installed the
+    ;; two spellings are not merely "the same subtree modulo attributes", they
+    ;; are byte-identical — which is the head-grammar claim in its purest
+    ;; form, and is only observable in this posture.
+    (when-not interop/debug-enabled?
+      (testing "under -Dre-frame.debug=false the registered handle and the bare
+                Var render byte-identically — nothing but the debug-gated
+                attributes ever separated them"
+        (is (= (emit/render-to-string [card-view :revenue] nil)
+               (emit/render-to-string [(rf/view :dashboard/card) :revenue] nil)))
+        (is (= "<div class=\"card\"><h3>:revenue</h3></div>"
+               (emit/render-to-string [(rf/view :dashboard/card) :revenue] nil)))))))
 
 ;; ===========================================================================
 ;; The streaming shell walker — `render-shell`

--- a/implementation/ssr/test/re_frame/ssr_render_failed_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_render_failed_test.clj
@@ -21,10 +21,34 @@
   fire from a documented emit-site with the documented tags. The status-
   stamping behaviour is covered by the cross-cutting end-to-end suites
   (`ssr_end_to_end_test`, `ssr_error_projector_substrate_test`,
-  `ssr-ring/ring_e2e_validator_test`); this suite isolates the trace."
+  `ssr-ring/ring_e2e_validator_test`); this suite isolates the trace.
+
+  ## Posture split (rf2-lwtlk)
+
+  `project-render-exception!` does TWO things and only one of them survives
+  production. The PROJECTION — returning a public-error map with the
+  projector's `:status` — is always-on, and it is what a server actually
+  ships. The TRACE is emitted through `trace/emit-error!`, whose site is
+  gated on `interop/debug-enabled?`, read once at namespace-load time; under
+  `-Dre-frame.debug=false` nothing is emitted, by design.
+
+  So every assertion about the trace — its count, its envelope, its
+  catalogued tags — sits inside a `(when interop/debug-enabled? …)` arm,
+  verbatim. The projection assertions sit outside and now run in
+  `scripts/test-ssr-prod-gate.sh`.
+
+  The NEGATIVE trace assertions moved into the arm too, and that is the
+  load-bearing half of this split. `(zero? (count @traces))` in the
+  non-server-frame and `:on-view-exception :throw` deftests is satisfied
+  automatically under the gate, where the ring is empty for every input —
+  a green that proves nothing. Each is replaced outside the arm by a
+  production-visible witness of the same claim: the client-frame call
+  returns `nil` without projecting, and the escape-hatch re-throws the
+  original Throwable instead of returning a public-error map."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
             [re-frame.ssr :as ssr]
             [re-frame.ssr.test-fixture :as tf]))
 
@@ -57,43 +81,47 @@
             (is (= 500 (:status public))
                 "the default projector maps the synthesised category to 500"))
 
-          (testing "exactly one `:rf.error/ssr-render-failed` trace
-                    fired (Spec 009 §Error event catalogue)"
-            (is (= 1 (count @traces))
-                (str "expected one trace; saw " (count @traces)
-                     " — operations: "
-                     (pr-str (mapv :operation @traces)))))
+          ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). The
+          ;; projection above is the production-real half and is asserted
+          ;; outside it; everything from here down is the trace envelope.
+          (when interop/debug-enabled?
+            (testing "exactly one `:rf.error/ssr-render-failed` trace
+                      fired (Spec 009 §Error event catalogue)"
+              (is (= 1 (count @traces))
+                  (str "expected one trace; saw " (count @traces)
+                       " — operations: "
+                       (pr-str (mapv :operation @traces)))))
 
-          (when (seq @traces)
-            (let [ev (first @traces)]
-              (testing "envelope shape per Spec 009 §Error event catalogue"
-                (is (= :error (:op-type ev))
-                    "severity discriminator is `:error`")
-                (is (= :rf.error/ssr-render-failed (:operation ev))
-                    "category keyword names the catalogued operation"))
+            (when (seq @traces)
+              (let [ev (first @traces)]
+                (testing "envelope shape per Spec 009 §Error event catalogue"
+                  (is (= :error (:op-type ev))
+                      "severity discriminator is `:error`")
+                  (is (= :rf.error/ssr-render-failed (:operation ev))
+                      "category keyword names the catalogued operation"))
 
-              (testing "tags shape per Spec 009 §Error event catalogue row
-                        (`:frame`, `:exception`, `:exception-message`,
-                        `:ex-class`)"
-                (is (= f (-> ev :tags :frame))
-                    "`:frame` identifies the server frame the render
-                     failed on")
-                (is (identical? t (-> ev :tags :exception))
-                    "`:exception` carries the caught Throwable verbatim")
-                (is (= "synthetic render-time failure"
-                       (-> ev :tags :exception-message))
-                    "`:exception-message` is the throwable's message
-                     (cheap-to-log replica of the throw)")
-                (is (= "clojure.lang.ExceptionInfo"
-                       (-> ev :tags :ex-class))
-                    "`:ex-class` carries the throwable's class name as a
-                     string — class-aware filtering without ferrying
-                     the live Throwable through trace consumers")
-                (is (= :projected-to-public-error
-                       (:recovery ev))
-                    "`:recovery` is hoisted to the envelope top-level
-                     (per Spec 009 §Error event shape) — the catalogue
-                     row's locked policy")))))
+                (testing "tags shape per Spec 009 §Error event catalogue row
+                          (`:frame`, `:exception`, `:exception-message`,
+                          `:ex-class`)"
+                  (is (= f (-> ev :tags :frame))
+                      "`:frame` identifies the server frame the render
+                       failed on")
+                  (is (identical? t (-> ev :tags :exception))
+                      "`:exception` carries the caught Throwable verbatim")
+                  (is (= "synthetic render-time failure"
+                         (-> ev :tags :exception-message))
+                      "`:exception-message` is the throwable's message
+                       (cheap-to-log replica of the throw)")
+                  (is (= "clojure.lang.ExceptionInfo"
+                         (-> ev :tags :ex-class))
+                      "`:ex-class` carries the throwable's class name as a
+                       string — class-aware filtering without ferrying
+                       the live Throwable through trace consumers")
+                  (is (= :projected-to-public-error
+                         (:recovery ev))
+                      "`:recovery` is hoisted to the envelope top-level
+                       (per Spec 009 §Error event shape) — the catalogue
+                       row's locked policy"))))))
         (finally
           (rf/unregister-listener! :trace ::srf))))))
 
@@ -114,11 +142,17 @@
         (let [f      (frame/make-anon-frame-record! {})
               t      (ex-info "should not fire" {})
               result (ssr/project-render-exception! f t)]
+          ;; SEMANTIC, posture-independent (rf2-lwtlk): `nil` rather than a
+          ;; public-error map IS the short-circuit, observable in production.
           (is (nil? result)
               "client-frame call returns nil — projector not invoked")
-          (is (zero? (count @traces))
-              "no `:rf.error/ssr-render-failed` trace fires for a
-               non-server frame"))
+          ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). Vacuous
+          ;; under the gate: the ring is empty for every input there, so
+          ;; `zero?` cannot distinguish a short-circuit from a full run.
+          (when interop/debug-enabled?
+            (is (zero? (count @traces))
+                "no `:rf.error/ssr-render-failed` trace fires for a
+                 non-server frame")))
         (finally
           (rf/unregister-listener! :trace ::srf-client))))))
 
@@ -139,13 +173,20 @@
                    :ssr      {:public-error-id   :rf.ssr/default-error-projector
                               :on-view-exception :throw}})
               t (ex-info "eager dev failure" {:reason :test})]
+          ;; SEMANTIC, posture-independent (rf2-lwtlk): the re-throw IS the
+          ;; escape-hatch, and it is what a host observes in either posture.
+          ;; That it threw rather than returned also witnesses that the
+          ;; projection path was skipped — no public-error map came back.
           (is (thrown-with-msg? clojure.lang.ExceptionInfo
                                 #"eager dev failure"
                                 (ssr/project-render-exception! f t))
               "the original throwable surfaces unchanged to the host")
-          (is (zero? (count @traces))
-              "the projection path (and its trace) is skipped when the
-               dev escape-hatch is on — the host's outer handler owns it"))
+          ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). Vacuous
+          ;; under the gate, where no trace fires on any path.
+          (when interop/debug-enabled?
+            (is (zero? (count @traces))
+                "the projection path (and its trace) is skipped when the
+                 dev escape-hatch is on — the host's outer handler owns it")))
         (finally
           (rf/unregister-listener! :trace ::srf-throw))))))
 

--- a/implementation/ssr/test/re_frame/ssr_request_cofx_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_request_cofx_test.clj
@@ -22,10 +22,30 @@
   gating (client-side dispatches silently no-op), the frame-isolation
   invariant (two simultaneous per-request frames don't leak), and the
   set-request! seam tests/harnesses use to drive the drain without a host
-  adapter."
+  adapter.
+
+  ## Posture split (rf2-lwtlk)
+
+  Two dev-only surfaces were asserted inline here and kept the whole
+  namespace out of `scripts/test-ssr-prod-gate.sh`.
+
+  `:doc` on the cofx registry slot is a pure-documentation key, dropped by
+  `registrar/strip-pure-documentation` when `interop/debug-enabled?` is false
+  (Spec 001 §Production elision contract). Kept verbatim in a
+  `(when interop/debug-enabled? …)` arm; the RETAINED half of the same
+  registration — the `:handler-fn` and the `:platforms #{:server}` gate that
+  actually decides whether the cofx runs — stays outside and now runs in the
+  lane.
+
+  The `:rf.cofx/skipped-on-platform` trace is emitted through the gated trace
+  bus. Kept verbatim in a dev arm. What it announces is production-real and
+  is asserted outside it: on a `:platform :client` frame the cofx does not
+  run, so `:rf.server/request` is ABSENT from the coeffect map — the
+  behaviour the trace merely narrates."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
             [re-frame.registrar :as registrar]
             [re-frame.ssr :as ssr]
             [re-frame.ssr.test-fixture :as tf]
@@ -48,8 +68,18 @@
           "the entry carries a :handler-fn")
       (is (= #{:server} (:platforms meta))
           ":platforms #{:server} per Spec 011 §634-642 — server-only")
-      (is (string? (:doc meta))
-          "the registration carries a :doc string"))))
+      ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). `:doc` is a
+      ;; pure-documentation key and is stripped in production builds; the
+      ;; three RETAINED keys above are the ones the runtime acts on.
+      (when interop/debug-enabled?
+        (is (string? (:doc meta))
+            "the registration carries a :doc string"))
+      ;; rf2-lwtlk — the REAL-gate arm: the elision itself, witnessed on a
+      ;; JVM actually started with `-Dre-frame.debug=false`.
+      (when-not interop/debug-enabled?
+        (is (nil? (:doc meta))
+            ":doc is elided from the registry slot in production builds
+             (Spec 001 §Production elision contract)")))))
 
 ;; ---- read path: populated slot ---------------------------------------------
 ;;
@@ -142,22 +172,28 @@
             {}))
         (rf/dispatch-sync [:req-test/read-on-client] {:frame client-frame})
 
+        ;; SEMANTIC, posture-independent (rf2-lwtlk): the platform gate really
+        ;; excluded the cofx. `:absent` (not merely nil-valued) is the
+        ;; production-visible witness — the coeffect KEY is missing, which is
+        ;; exactly what the trace below narrates.
         (is (= [:absent nil] @observed)
             "the cofx did NOT run — :rf.server/request is absent from coeffects")
 
-        (let [skips (filter #(= :rf.cofx/skipped-on-platform (:operation %))
-                            @traces)]
-          (is (= 1 (count skips))
-              "exactly one :rf.cofx/skipped-on-platform trace was emitted")
-          (let [t (first skips)]
-            (is (= :rf.server/request (get-in t [:tags :rf.cofx/id]))
-                ":rf.cofx/id identifies the gated cofx")
-            (is (= :client (get-in t [:tags :rf.cofx/platform]))
-                ":rf.cofx/platform carries the active platform that excluded the cofx")
-            (is (= #{:server} (get-in t [:tags :rf.cofx/registered-platforms]))
-                ":rf.cofx/registered-platforms surfaces the cofx's declared set")
-            (is (= :skipped (:recovery t))
-                ":recovery is :skipped — the runtime declined to act")))))))
+        ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring).
+        (when interop/debug-enabled?
+          (let [skips (filter #(= :rf.cofx/skipped-on-platform (:operation %))
+                              @traces)]
+            (is (= 1 (count skips))
+                "exactly one :rf.cofx/skipped-on-platform trace was emitted")
+            (let [t (first skips)]
+              (is (= :rf.server/request (get-in t [:tags :rf.cofx/id]))
+                  ":rf.cofx/id identifies the gated cofx")
+              (is (= :client (get-in t [:tags :rf.cofx/platform]))
+                  ":rf.cofx/platform carries the active platform that excluded the cofx")
+              (is (= #{:server} (get-in t [:tags :rf.cofx/registered-platforms]))
+                  ":rf.cofx/registered-platforms surfaces the cofx's declared set")
+              (is (= :skipped (:recovery t))
+                  ":recovery is :skipped — the runtime declined to act"))))))))
 
 ;; ---- frame isolation -------------------------------------------------------
 ;;

--- a/implementation/ssr/test/re_frame/ssr_request_durable_fact_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_request_durable_fact_test.clj
@@ -21,10 +21,28 @@
 
   This pins both shapes producing the durable app-db slice, the fail-loud on a
   missing provided fact, AND the contrast that the ambient `:rf.server/request`
-  value is NOT recorded on the token (the symptom the pattern avoids)."
+  value is NOT recorded on the token (the symptom the pattern avoids).
+
+  ## Posture split (rf2-lwtlk)
+
+  Everything this namespace pins is production-real — the durable app-db
+  writes, the fail-closed throw, the absence of the ambient request from the
+  causal token — with one exception: the `:rf.error/missing-required-cofx`
+  TRACE in `missing-provided-request-fact-fails-loud`. Trace emission runs
+  through `trace/emit-error!`, gated on `interop/debug-enabled?` and read once
+  at namespace-load time, so under `-Dre-frame.debug=false` the recorder sees
+  nothing. That one assertion is kept verbatim inside a
+  `(when interop/debug-enabled? …)` arm; the fail-closed contract it sits
+  beside — the throw, its `:rf.error/id`, and the absent durable write — is
+  what a production server observes and runs in both postures.
+
+  `ambient-request-read-is-not-recorded-on-the-token` gained a positive pin
+  that the `:rf.cofx` record EXISTS before asserting what is not in it, so
+  the two negatives cannot pass by the record being absent altogether."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
             [re-frame.ssr :as ssr]
             [re-frame.ssr.test-fixture :as tf]
             [re-frame.test-support :refer [with-trace-recorder!]]))
@@ -100,8 +118,13 @@
           (is (some? ex) "dispatch threw rather than silently delivering nil")
           (is (= :rf.error/missing-required-cofx (:rf.error/id (ex-data ex)))
               "the throw is :rf.error/missing-required-cofx (fail-closed)")
-          (is (seq (filter #(= :rf.error/missing-required-cofx (:operation %)) @traces))
-              "a :rf.error/missing-required-cofx error trace was emitted")
+          ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). The
+          ;; fail-closed contract is pinned by the throw and its
+          ;; `:rf.error/id` above, both production-real; this is the dev
+          ;; trace restating the same category on the trace bus.
+          (when interop/debug-enabled?
+            (is (seq (filter #(= :rf.error/missing-required-cofx (:operation %)) @traces))
+                "a :rf.error/missing-required-cofx error trace was emitted"))
           ;; And no durable write landed.
           (is (nil? (:auth/user (frame/frame-app-db-value server-frame)))
               "no durable app-db slice was written from a missing provided fact"))))))
@@ -126,6 +149,12 @@
           (reset! seen-cofx (:rf.cofx ctx))
           {}))
       (rf/dispatch-sync [:req/inspect-record] {:frame server-frame})
+      ;; rf2-lwtlk — pin that there IS a record to inspect before asserting
+      ;; what is missing from it. Without this the two negatives below would
+      ;; also hold if `:rf.cofx` were absent from the context entirely, which
+      ;; is a different (and much worse) world than the one under test.
+      (is (map? @seen-cofx)
+          "the handler ran and the context carried a :rf.cofx record")
       (is (not (contains? (or @seen-cofx {}) :rf.server/request))
           "the ambient request value is NOT on the token's :rf.cofx record")
       (is (not (.contains (pr-str @seen-cofx) "raw-secret"))

--- a/implementation/ssr/test/re_frame/ssr_source_coord_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_source_coord_test.clj
@@ -25,7 +25,36 @@
   `annotated`, and the production-gate arm is reinstated at the new site.
 
   A keyword head is still NOT a view and still NOT annotated — it is a DOM
-  element, unchanged by this bead (`keyword-head-*` below)."
+  element, unchanged by this bead (`keyword-head-*` below).
+
+  ## Posture split (rf2-lwtlk)
+
+  The annotations this namespace is named for are DEV-ONLY BY DESIGN: the
+  wrapper `re-frame.views/jvm-source-coord-annotation` is installed at
+  `reg-view` REGISTRATION time behind `interop/debug-enabled?`, which the JVM
+  reads once at namespace-load time.  Under the real
+  `-Dre-frame.debug=false` gate no view is ever wrapped, so no server markup
+  carries `data-rf2-source-coord` or `data-rf-view`.  That is the elision
+  working, not a defect.
+
+  So every assertion ABOUT an annotation — present or absent — lives inside a
+  `(when interop/debug-enabled? …)` arm marked `rf2-lwtlk`, kept verbatim.
+  The negative ones travel with the positive ones deliberately: \"the outer
+  view did not stamp itself\", \"a fragment root is not annotated\", \"a
+  keyword head is not annotated\" all pass VACUOUSLY under the gate, where
+  nothing stamps anything, so leaving them outside the arm would report a
+  green that proved nothing.
+
+  What is posture-independent, and therefore what this namespace now
+  contributes to `scripts/test-ssr-prod-gate.sh`, is the RENDER: which
+  element each head shape resolves to and what it emits.  A Form-2 view's
+  inner output is the thing rendered; a fragment root emits its children
+  unwrapped; a keyword head is an element, not a view; a nested view-ref root
+  renders the inner view.  Those hold in both postures and are asserted
+  outside the arm.  `production-build-emits-no-annotation` gains a REAL-gate
+  arm (`when-not interop/debug-enabled?`) so the production posture is
+  witnessed by the gate itself rather than only by a `with-redefs` rebind,
+  which cannot reach a load-time gate (rf2-9c2jf)."
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
@@ -52,19 +81,34 @@
     (rf/reg-view ^{:rf/id :ssr-coord-test/banner} banner-view []
       [:h1 "hi"])
 
-    (testing "Var head"
-      (is (both-annotations? (ssr/render-to-string [banner-view] {}))))
+    ;; SEMANTIC, posture-independent (rf2-lwtlk): both head shapes resolve to
+    ;; the same registered view, and it renders ITS OWN root carrying ITS OWN
+    ;; content — the "not swallowed" property below, stated without reference
+    ;; to the dev attributes that happen to sit on that root in dev posture.
+    (testing "both head shapes render the registered view's own <h1> root"
+      (doseq [[label html] [["Var head"
+                             (ssr/render-to-string [banner-view] {})]
+                            ["`(rf/view :id)` head"
+                             (ssr/render-to-string
+                               [(rf/view :ssr-coord-test/banner)] {})]]]
+        (is (str/starts-with? html "<h1") label)
+        (is (str/ends-with? html ">hi</h1>") label)))
 
-    (testing "`(rf/view :id)` head"
-      (is (both-annotations?
-            (ssr/render-to-string [(rf/view :ssr-coord-test/banner)] {}))))
+    ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring).
+    (when interop/debug-enabled?
+      (testing "Var head"
+        (is (both-annotations? (ssr/render-to-string [banner-view] {}))))
 
-    (testing "the data-rf-view value is `(str id)`"
-      (is (str/includes? (ssr/render-to-string [banner-view] {})
-                         "data-rf-view=\":ssr-coord-test/banner\"")))
+      (testing "`(rf/view :id)` head"
+        (is (both-annotations?
+              (ssr/render-to-string [(rf/view :ssr-coord-test/banner)] {}))))
 
-    (testing "the view genuinely rendered its own root — not swallowed"
-      (is (str/starts-with? (ssr/render-to-string [banner-view] {}) "<h1 ")))))
+      (testing "the data-rf-view value is `(str id)`"
+        (is (str/includes? (ssr/render-to-string [banner-view] {})
+                           "data-rf-view=\":ssr-coord-test/banner\"")))
+
+      (testing "the view genuinely rendered its own root — not swallowed"
+        (is (str/starts-with? (ssr/render-to-string [banner-view] {}) "<h1 "))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Exact byte shape for a programmatic (coordless) registration — degrade
@@ -76,11 +120,21 @@
             hosts match on the programmatic path too."
     (rf/reg-view* :ssr-coord-test/prog {} (fn [] [:div "prog"]))
     (let [html (ssr/render-to-string [(rf/view :ssr-coord-test/prog)] {})]
-      (is (= (str "<div data-rf2-source-coord=\"ssr-coord-test:prog:?:?\""
-                  " data-rf-view=\":ssr-coord-test/prog\">prog</div>")
-             html)
-          (str "coordless degrade must produce exactly the client shape; got: "
-               (pr-str html))))))
+      ;; SEMANTIC, posture-independent (rf2-lwtlk): a programmatic
+      ;; registration renders at all, and renders its own root and body.
+      ;; The gate removes the ATTRIBUTES, never the element.
+      (is (str/starts-with? html "<div") (pr-str html))
+      (is (str/ends-with? html ">prog</div>") (pr-str html))
+
+      ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). The exact
+      ;; byte shape of the `?:?` degrade is the whole point of this deftest
+      ;; and is a statement about the dev annotation dialect.
+      (when interop/debug-enabled?
+        (is (= (str "<div data-rf2-source-coord=\"ssr-coord-test:prog:?:?\""
+                    " data-rf-view=\":ssr-coord-test/prog\">prog</div>")
+               html)
+            (str "coordless degrade must produce exactly the client shape; got: "
+                 (pr-str html)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Author-supplied attribute values are PRESERVED
@@ -94,12 +148,24 @@
                   (fn [] [:div {:data-rf-view "author-owned"
                                 :id           "x"} "a"]))
     (let [html (ssr/render-to-string [(rf/view :ssr-coord-test/authored)] {})]
+      ;; SEMANTIC, posture-independent (rf2-lwtlk): the author's OWN attribute
+      ;; map is emitted whatever the posture — `data-rf-view` here is an
+      ;; author-owned attribute that merely shares a name with the framework's,
+      ;; and `:id` is an ordinary one. Neither is elided by the gate.
       (is (str/includes? html "data-rf-view=\"author-owned\"")
           "the author's data-rf-view value survives")
-      (is (not (str/includes? html "data-rf-view=\":ssr-coord-test/authored\""))
-          "the wrapper did not overwrite it")
-      (is (source-coord? html)
-          "the missing key IS still filled by the wrapper"))))
+      (is (str/includes? html "id=\"x\"")
+          "the author's other attributes survive alongside it")
+
+      ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). Both of these
+      ;; are about the WRAPPER: that it declined to overwrite, and that it
+      ;; filled the key the author left out. Under the gate no wrapper exists,
+      ;; so "did not overwrite" would pass vacuously.
+      (when interop/debug-enabled?
+        (is (not (str/includes? html "data-rf-view=\":ssr-coord-test/authored\""))
+            "the wrapper did not overwrite it")
+        (is (source-coord? html)
+            "the missing key IS still filled by the wrapper")))))
 
 ;; ---------------------------------------------------------------------------
 ;; Form-2 views: the inner render fn's output is annotated
@@ -113,9 +179,19 @@
     (rf/reg-view* :ssr-coord-test/form2 {}
                   (fn [] (fn [] [:section "inner"])))
     (let [html (ssr/render-to-string [(rf/view :ssr-coord-test/form2)] {})]
-      (is (both-annotations? html)
-          (str "Form-2 inner output must be annotated; got: " (pr-str html)))
-      (is (str/starts-with? html "<section ")))))
+      ;; SEMANTIC, posture-independent (rf2-lwtlk): the emitter unwraps the
+      ;; outer fn and renders the INNER fn's hiccup. That is Form-2 support
+      ;; itself, and it holds with or without the annotation wrapper.
+      (is (str/starts-with? html "<section") (pr-str html))
+      (is (str/ends-with? html ">inner</section>") (pr-str html))
+
+      ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). The wrapper's
+      ;; Form-2 branch re-wraps so the INNER hiccup gets the attributes; the
+      ;; trailing space in "<section " is what proves an attribute landed.
+      (when interop/debug-enabled?
+        (is (both-annotations? html)
+            (str "Form-2 inner output must be annotated; got: " (pr-str html)))
+        (is (str/starts-with? html "<section "))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Non-DOM roots (fragment, nested view-ref head) skip — documented exemption
@@ -128,8 +204,17 @@
     (rf/reg-view* :ssr-coord-test/frag {}
                   (fn [] [:<> [:p "a"] [:p "b"]]))
     (let [html (ssr/render-to-string [(rf/view :ssr-coord-test/frag)] {})]
+      ;; SEMANTIC, posture-independent (rf2-lwtlk): a `:<>` root emits its
+      ;; children and nothing else — no wrapper element is invented for it.
       (is (= "<p>a</p><p>b</p>" html))
-      (is (not (both-annotations? html))))))
+
+      ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). "not
+      ;; annotated" is vacuously true under the gate, where NOTHING is
+      ;; annotated; it only says something where the wrapper exists and
+      ;; deliberately skipped a non-DOM root. The `=` above already pins the
+      ;; byte shape in both postures.
+      (when interop/debug-enabled?
+        (is (not (both-annotations? html)))))))
 
 (deftest nested-view-ref-root-is-not-doubly-annotated
   (testing "rf2-8vi4q — a view whose root is ANOTHER view-ref (a callable
@@ -140,12 +225,25 @@
     (rf/reg-view* :ssr-coord-test/outer {}
                   (fn [] [(rf/view :ssr-coord-test/inner)]))
     (let [html (ssr/render-to-string [(rf/view :ssr-coord-test/outer)] {})]
-      (is (str/includes? html "data-rf-view=\":ssr-coord-test/inner\"")
-          "the inner view annotated its own root")
-      (is (not (str/includes? html "data-rf-view=\":ssr-coord-test/outer\""))
-          "the outer view (callable-head root) did not stamp itself")
-      (is (= 1 (count (re-seq #"data-rf-view=" html)))
-          (str "exactly one annotated element; got: " (pr-str html))))))
+      ;; SEMANTIC, posture-independent (rf2-lwtlk): a view whose root is
+      ;; another view-ref resolves through to the inner view and emits the
+      ;; inner view's element ONCE — no wrapper element, no duplication.
+      (is (str/starts-with? html "<span") (pr-str html))
+      (is (str/ends-with? html ">in</span>") (pr-str html))
+      (is (= 1 (count (re-seq #"<span" html)))
+          (str "the inner view rendered exactly once; got: " (pr-str html)))
+
+      ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). All three
+      ;; original assertions are about WHICH element carries the stamp; under
+      ;; the gate no element does, so the two negatives pass vacuously and the
+      ;; count is trivially 0.
+      (when interop/debug-enabled?
+        (is (str/includes? html "data-rf-view=\":ssr-coord-test/inner\"")
+            "the inner view annotated its own root")
+        (is (not (str/includes? html "data-rf-view=\":ssr-coord-test/outer\""))
+            "the outer view (callable-head root) did not stamp itself")
+        (is (= 1 (count (re-seq #"data-rf-view=" html)))
+            (str "exactly one annotated element; got: " (pr-str html)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The streaming shell walker inherits annotation through the handler-fn
@@ -159,10 +257,26 @@
             worried about is gone: one wrapper, both paths."
     (rf/reg-view ^{:rf/id :ssr-coord-test/shell} shell-view []
       [:main "shell"])
-    (let [{:keys [shell-html]} (streaming/render-shell [shell-view])]
-      (is (both-annotations? shell-html)
-          (str "streamed shell must be annotated; got: " (pr-str shell-html)))
-      (is (str/includes? shell-html "data-rf-view=\":ssr-coord-test/shell\"")))))
+    (let [{:keys [shell-html]} (streaming/render-shell [shell-view])
+          sync-html            (ssr/render-to-string [shell-view] {})]
+      ;; SEMANTIC, posture-independent (rf2-lwtlk), and a STRONGER statement
+      ;; of this deftest's actual claim: the streaming walker carries no
+      ;; annotation logic of its own because it resolves callable heads
+      ;; through the same handler-fn as the sync path. Comparing the two
+      ;; renders proves "one wrapper, both paths" in EITHER posture — in dev
+      ;; both are annotated identically, under the gate both are bare.
+      (is (= sync-html shell-html)
+          (str "streamed shell must match the sync render byte for byte; got: "
+               (pr-str shell-html) " vs " (pr-str sync-html)))
+      (is (str/starts-with? shell-html "<main") (pr-str shell-html))
+      (is (str/ends-with? shell-html ">shell</main>") (pr-str shell-html))
+
+      ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (both-annotations? shell-html)
+            (str "streamed shell must be annotated; got: " (pr-str shell-html)))
+        (is (str/includes? shell-html
+                           "data-rf-view=\":ssr-coord-test/shell\""))))))
 
 ;; ---------------------------------------------------------------------------
 ;; A keyword head is an element, still NOT a view, still NOT annotated
@@ -174,12 +288,30 @@
             annotation even when a view of the same id is registered."
     (rf/reg-view* :coord-demo/card {} (fn [_] [:div.card "x"]))
     (let [html (ssr/render-to-string [:coord-demo/card :revenue] {})]
+      ;; SEMANTIC, posture-independent (rf2-lwtlk): the keyword head is
+      ;; emitted as a CUSTOM ELEMENT with its argument as a child, and the
+      ;; identically-named registered view is NOT invoked (no `.card` div).
+      ;; That resolution rule is the load-bearing half and is posture-free;
+      ;; the `=` pins it exactly.
       (is (= "<card>revenue</card>" html))
-      (is (not (both-annotations? html))))))
+
+      ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). Vacuous under
+      ;; the gate, where nothing anywhere is annotated.
+      (when interop/debug-enabled?
+        (is (not (both-annotations? html)))))))
 
 (deftest plain-hiccup-not-annotated
   (testing "unchanged — ordinary tags were never annotated"
-    (is (not (both-annotations? (ssr/render-to-string [:div [:span "x"]] {}))))))
+    ;; SEMANTIC, posture-independent (rf2-lwtlk): ordinary hiccup emits
+    ;; exactly itself. Without this the deftest has no residue under the
+    ;; gate at all — `not annotated` is trivially true when the wrapper does
+    ;; not exist.
+    (is (= "<div><span>x</span></div>"
+           (ssr/render-to-string [:div [:span "x"]] {})))
+
+    ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring).
+    (when interop/debug-enabled?
+      (is (not (both-annotations? (ssr/render-to-string [:div [:span "x"]] {})))))))
 
 ;; ---------------------------------------------------------------------------
 ;; Production gate (rf2-wtd8z finding 3) — reinstated at the new site
@@ -200,11 +332,15 @@
             symmetric with the CLJS :advanced + goog.DEBUG=false build that
             Closure DCEs the client walk. The dev arm annotates; the prod
             arm does not."
-    (testing "debug ON at registration — annotated (the load-bearing arm)"
-      (rf/reg-view* :ssr-coord-test/gated-dev {} (fn [] [:h2 "g"]))
-      (let [html (ssr/render-to-string [(rf/view :ssr-coord-test/gated-dev)] {})]
-        (is (str/starts-with? html "<h2 "))
-        (is (both-annotations? html))))
+    ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). Under the real
+    ;; `-Dre-frame.debug=false` gate there is no "debug ON at registration"
+    ;; to have: the flag was read before this namespace loaded.
+    (when interop/debug-enabled?
+      (testing "debug ON at registration — annotated (the load-bearing arm)"
+        (rf/reg-view* :ssr-coord-test/gated-dev {} (fn [] [:h2 "g"]))
+        (let [html (ssr/render-to-string [(rf/view :ssr-coord-test/gated-dev)] {})]
+          (is (str/starts-with? html "<h2 "))
+          (is (both-annotations? html)))))
 
     (testing "debug OFF at registration — NOT annotated"
       (with-redefs [interop/debug-enabled? false]
@@ -213,7 +349,29 @@
       ;; at registration, so the markup is unannotated regardless.
       (let [html (ssr/render-to-string [(rf/view :ssr-coord-test/gated-prod)] {})]
         (is (= "<h2>g</h2>" html))
-        (is (not (both-annotations? html)))))))
+        (is (not (both-annotations? html)))))
+
+    ;; rf2-lwtlk — the REAL-gate arm, and the reason this deftest is worth
+    ;; running in `scripts/test-ssr-prod-gate.sh` at all. The `with-redefs`
+    ;; above rebinds the Var AFTER the framework has loaded; a load-time gate
+    ;; is invisible to that (rf2-9c2jf), so it proves the wrapper's own
+    ;; branch and nothing about the documented production posture. This arm
+    ;; runs only when the JVM was actually started with
+    ;; `-Dre-frame.debug=false`, and registers under it for real.
+    (when-not interop/debug-enabled?
+      (testing "-Dre-frame.debug=false on the JVM — NOT annotated, for real"
+        (rf/reg-view* :ssr-coord-test/real-gate {} (fn [] [:h2 "g"]))
+        (let [html (ssr/render-to-string
+                     [(rf/view :ssr-coord-test/real-gate)] {})]
+          (is (= "<h2>g</h2>" html)
+              (str "the real production gate must elide both annotations; got: "
+                   (pr-str html))))
+        (rf/reg-view ^{:rf/id :ssr-coord-test/real-gate-macro} real-gate-macro []
+          [:h3 "m"])
+        (let [html (ssr/render-to-string [real-gate-macro] {})]
+          (is (= "<h3>m</h3>" html)
+              (str "…including on the macro path, which is where the coords "
+                   "would have come from; got: " (pr-str html))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The formatter unit itself degrades — belt-and-braces on the shared dialect

--- a/implementation/ssr/test/re_frame/ssr_streaming_corner_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_streaming_corner_test.clj
@@ -20,11 +20,31 @@
   sibling ns'.
 
   All tests are JVM-only — streaming SSR is JVM-only by design (Ring is
-  Clojure-on-the-JVM)."
+  Clojure-on-the-JVM).
+
+  ## Posture split (rf2-lwtlk)
+
+  Every composition corner pinned here is production-real and is asserted
+  without a posture guard. Two assertions were not: the
+  `:rf.error/suspense-boundary-duplicate-id` trace in the N=3 dedup corner,
+  and the `:rf.ssr/suspense-boundary-failed` trace in the double-throw
+  corner. Both emit behind `interop/debug-enabled?`, read once at
+  namespace-load time, so under `-Dre-frame.debug=false` neither fires — a
+  duplicate boundary id is a programmer error the framework announces in dev
+  and silently applies last-write-wins to in production. Both are kept
+  verbatim inside `(when interop/debug-enabled? …)` arms.
+
+  What each corner is actually FOR survives outside the arms and now runs in
+  `scripts/test-ssr-prod-gate.sh`: N=3 dedup keeps the third registration's
+  `:fallback` AND drains the third body, and the double-throw continuation
+  returns `:failed? true` with empty `:html` instead of escaping — which is
+  the MUST-NOT-ESCAPE contract, and the one that would matter most in
+  production."
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
             [re-frame.ssr.streaming :as streaming]
             [re-frame.ssr.test-fixture :as tf]
             [re-frame.test-support :refer [with-trace-recorder!]]))
@@ -344,24 +364,30 @@
              the first or middle. Per Spec 011 §Boundary nesting and
              recursion: 'the second registration overwrites the first'
              generalises to N-deep — every-but-last is dropped."))
-      (is (some #(= :rf.error/suspense-boundary-duplicate-id (:operation %))
-                captured-traces)
-          "the duplicate-id trace still fires across N=3 duplicates")
-      (let [dup-traces (filterv #(= :rf.error/suspense-boundary-duplicate-id
-                                    (:operation %))
-                                captured-traces)]
-        (is (= 1 (count dup-traces))
-            "one trace, not three — dedup groups all duplicates of
-             the same id into a single trace event")
-        (when (seq dup-traces)
-          (let [ev   (first dup-traces)
-                tags (:tags ev)]
-            (is (= 3 (:count tags))
-                ":count tag reports the duplicate cardinality (3)")
-            (is (= :last-write-wins (:recovery ev))
-                ":recovery is hoisted to top-level of the trace
-                 envelope per Spec 009 §Error event shape — names the
-                 policy applied")))))))
+      ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). The
+      ;; N=3 last-write-wins SEMANTICS are pinned above by the surviving
+      ;; entry's `:fallback` and the drained chunk's body, both
+      ;; posture-independent; a duplicate boundary id is a programmer error
+      ;; the framework ANNOUNCES in dev and silently applies in production.
+      (when interop/debug-enabled?
+        (is (some #(= :rf.error/suspense-boundary-duplicate-id (:operation %))
+                  captured-traces)
+            "the duplicate-id trace still fires across N=3 duplicates")
+        (let [dup-traces (filterv #(= :rf.error/suspense-boundary-duplicate-id
+                                      (:operation %))
+                                  captured-traces)]
+          (is (= 1 (count dup-traces))
+              "one trace, not three — dedup groups all duplicates of
+               the same id into a single trace event")
+          (when (seq dup-traces)
+            (let [ev   (first dup-traces)
+                  tags (:tags ev)]
+              (is (= 3 (:count tags))
+                  ":count tag reports the duplicate cardinality (3)")
+              (is (= :last-write-wins (:recovery ev))
+                  ":recovery is hoisted to top-level of the trace
+                   envelope per Spec 009 §Error event shape — names the
+                   policy applied"))))))))
 
 ;; ===========================================================================
 ;; render-continuation — fallback-render throw + delta + stale frame
@@ -397,12 +423,18 @@
                throw)")
           (is (nil? (:delta result))
               "delta still omitted on failure")
-          (is (some #(= :rf.ssr/suspense-boundary-failed (:operation %))
-                    @captured)
-              "the suspense-boundary-failed trace still fires for the
-               subtree throw — even though the fallback also failed
-               (the trace describes the SUBTREE failure, which is what
-               the client cares about)"))))))
+          ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). The
+          ;; MUST-NOT-ESCAPE contract this deftest exists for is pinned
+          ;; posture-independently above: `render-continuation` returned at
+          ;; all, with `:failed? true` and empty `:html`, despite BOTH the
+          ;; subtree and the fallback throwing.
+          (when interop/debug-enabled?
+            (is (some #(= :rf.ssr/suspense-boundary-failed (:operation %))
+                      @captured)
+                "the suspense-boundary-failed trace still fires for the
+                 subtree throw — even though the fallback also failed
+                 (the trace describes the SUBTREE failure, which is what
+                 the client cares about)")))))))
 
 (deftest render-continuation-delta-captures-app-db-change-during-render
   (testing "rf2-u91hb: render-continuation snapshots app-db before

--- a/implementation/ssr/test/re_frame/ssr_streaming_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_streaming_test.clj
@@ -1,11 +1,33 @@
 (ns re-frame.ssr-streaming-test
   "Streaming SSR — `:rf/suspense-boundary` walker, continuation drain,
   failure semantics, per-subtree hydration delta. Per Spec 011 §Streaming
-  SSR (rf2-ojakd / rf2-olb64 (a))."
+  SSR (rf2-ojakd / rf2-olb64 (a)).
+
+  ## Posture split (rf2-lwtlk)
+
+  The streaming SEMANTICS are production-real and are asserted here without a
+  posture guard: which continuations survive dedup, which registration
+  last-write-wins keeps, that a failed subtree materialises its declared
+  fallback rather than empty html, and what the wire attributes carry.
+
+  The `:rf.ssr/suspense-boundary-failed` and
+  `:rf.error/suspense-boundary-duplicate-id` TRACES are not. Both are emitted
+  behind `interop/debug-enabled?`, read once at namespace-load time, so under
+  `-Dre-frame.debug=false` neither fires — a duplicate boundary id is a
+  programmer error the framework announces in dev and silently applies
+  last-write-wins to in production. Those assertions are kept verbatim inside
+  `(when interop/debug-enabled? …)` arms marked `rf2-lwtlk`.
+
+  `distinct-wire-ids-are-not-deduped`'s no-duplicate-id-trace assertion is a
+  NEGATIVE over the trace ring and moves into the arm with them: under the gate the
+  ring is empty for colliding and distinct ids alike, so it would have passed
+  without distinguishing the two. Its posture-independent half — that both
+  continuations survive — already sits outside."
   (:require [clojure.edn :as edn]
             [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
+            [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
             [re-frame.ssr :as ssr]
             [re-frame.ssr.html-helpers :as html]
@@ -197,9 +219,13 @@
           (is (nil? (:delta result)) "delta omitted on failure")
           (is (= "<p>Loading…</p>" (:html result))
               "declared fallback hiccup materialised in place (not empty)")
-          (is (some #(= :rf.ssr/suspense-boundary-failed (:operation %))
-                    @captured)
-              ":rf.ssr/suspense-boundary-failed trace emitted"))))))
+          ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). The
+          ;; failure's production face is `:failed?` + the materialised
+          ;; fallback above; this is how a developer hears about it.
+          (when interop/debug-enabled?
+            (is (some #(= :rf.ssr/suspense-boundary-failed (:operation %))
+                      @captured)
+                ":rf.ssr/suspense-boundary-failed trace emitted")))))))
 
 (deftest duplicate-id-emits-trace-and-keeps-last
   (testing "Two boundaries with the same :id emit :rf.error/suspense-boundary-duplicate-id"
@@ -209,9 +235,16 @@
       (with-trace-recorder! [captured]
         (let [{:keys [continuations]} (streaming/render-shell tree)]
           (is (= 1 (count continuations)) "only one continuation survives dedup")
-          (is (some #(= :rf.error/suspense-boundary-duplicate-id (:operation %))
-                    @captured)
-              ":rf.error/suspense-boundary-duplicate-id trace emitted"))))))
+          ;; SEMANTIC, posture-independent (rf2-lwtlk): last-write-wins is the
+          ;; recovery the trace merely NAMES, and it applies in both postures.
+          ;; Without this the surviving continuation could be either one.
+          (is (= [:p "second"] (:fallback (first continuations)))
+              "the surviving continuation is the LAST registration")
+          ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring).
+          (when interop/debug-enabled?
+            (is (some #(= :rf.error/suspense-boundary-duplicate-id (:operation %))
+                      @captured)
+                ":rf.error/suspense-boundary-duplicate-id trace emitted")))))))
 
 ;; ===========================================================================
 ;; rf2-yvc0t7 — duplicate detection keys on the WIRE id, not the raw :id
@@ -254,22 +287,27 @@
               "last-write-wins keeps the LAST registration (the string id)")
           (is (= [:p "second"] (:fallback (first continuations)))
               "the surviving entry carries the last registration's :fallback")
-          ;; The documented programmer-error trace fires.
-          (let [dup-traces (filterv #(= :rf.error/suspense-boundary-duplicate-id
-                                        (:operation %))
-                                    @captured)]
-            (is (= 1 (count dup-traces))
-                ":rf.error/suspense-boundary-duplicate-id fires once for the
-                 colliding pair")
-            (when-let [ev (first dup-traces)]
-              (is (= ":a" (get-in ev [:tags :id]))
-                  "the trace reports the colliding WIRE id")
-              (is (= 2 (get-in ev [:tags :count]))
-                  ":count reports the colliding cardinality")
-              (is (= [:a ":a"] (get-in ev [:tags :raw-ids]))
-                  ":raw-ids surfaces the distinct raw ids that collided")
-              (is (= :last-write-wins (:recovery ev))
-                  ":recovery names the applied policy"))))))))
+          ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). The
+          ;; documented programmer-error trace fires in dev only; the
+          ;; COLLISION and the last-write-wins recovery it names are pinned
+          ;; posture-independently above, on the wire attributes and the
+          ;; surviving entry.
+          (when interop/debug-enabled?
+            (let [dup-traces (filterv #(= :rf.error/suspense-boundary-duplicate-id
+                                          (:operation %))
+                                      @captured)]
+              (is (= 1 (count dup-traces))
+                  ":rf.error/suspense-boundary-duplicate-id fires once for the
+                   colliding pair")
+              (when-let [ev (first dup-traces)]
+                (is (= ":a" (get-in ev [:tags :id]))
+                    "the trace reports the colliding WIRE id")
+                (is (= 2 (get-in ev [:tags :count]))
+                    ":count reports the colliding cardinality")
+                (is (= [:a ":a"] (get-in ev [:tags :raw-ids]))
+                    ":raw-ids surfaces the distinct raw ids that collided")
+                (is (= :last-write-wins (:recovery ev))
+                    ":recovery names the applied policy")))))))))
 
 (deftest distinct-wire-ids-are-not-deduped
   (testing "rf2-yvc0t7 guard: boundaries with genuinely distinct wire ids
@@ -281,10 +319,14 @@
         (let [{:keys [continuations]} (streaming/render-shell tree)]
           (is (= 2 (count continuations))
               "distinct wire ids both survive — no false collapse")
-          (is (empty? (filterv #(= :rf.error/suspense-boundary-duplicate-id
-                                   (:operation %))
-                               @captured))
-              "no duplicate-id trace for distinct ids"))))))
+          ;; rf2-lwtlk — dev-instrumentation arm (see ns docstring). A
+          ;; NEGATIVE over the trace ring: vacuous under the gate, where the
+          ;; ring is empty for colliding and distinct ids alike.
+          (when interop/debug-enabled?
+            (is (empty? (filterv #(= :rf.error/suspense-boundary-duplicate-id
+                                     (:operation %))
+                                 @captured))
+                "no duplicate-id trace for distinct ids")))))))
 
 (deftest build-final-payload-shape
   (testing "Final payload carries the canonical :rf/hydration-payload shape"

--- a/scripts/test-ssr-prod-gate.sh
+++ b/scripts/test-ssr-prod-gate.sh
@@ -139,10 +139,7 @@ known_red=(
   #    posture guard.
   re-frame.flows-integration-test                 #  14
   re-frame.ssr-conformance-test                   #   1
-  re-frame.ssr-hydration-mismatch-test            #   7
   re-frame.ssr-hydration-test                     #  15
-  re-frame.ssr-streaming-corner-test              #   3
-  re-frame.ssr-streaming-test                     #   3
 
   # ── rf2-lwtlk — the PAYLOAD-POLICY suite.  CLEARED, and the roster note
   #    that asked for verification rather than assumption was answered:

--- a/scripts/test-ssr-prod-gate.sh
+++ b/scripts/test-ssr-prod-gate.sh
@@ -120,26 +120,81 @@ known_red=(
   #    where nothing stamps anything.
 
   # ── rf2-lwtlk — dev-instrumentation assertions written inline with the
-  #    semantics they sit next to: "exactly one `:rf.ssr/schema-digest-
-  #    mismatch` trace", "`:doc` preserved on the reg-head registry slot", "a
-  #    `:rf.ssr.head/cleanup-failed` warning surfaced", "`:rf.cofx/skipped-on-
-  #    platform` fired once", the `:rf.ssr/suspense-boundary-failed` and
-  #    `-duplicate-id` streaming traces, the hydration-mismatch trace's
-  #    `:server-hash` / `:client-hash` tags.  Under `-Dre-frame.debug=false`
-  #    the framework emits none of it, by design, so these are legitimate
-  #    dev-posture tests — but they drag their semantic neighbours out of this
-  #    lane with them.  Every line removed from here is a namespace whose
-  #    semantics are now proven under the production posture.
+  #    semantics they sit next to.  CLEARED for eleven namespaces: the
+  #    `:rf.ssr/schema-digest-mismatch` / `-version-mismatch` traces, `:doc`
+  #    on the reg-head and reg-cofx registry slots, the
+  #    `:rf.ssr.head/cleanup-failed` warning, `:rf.cofx/skipped-on-platform`,
+  #    the `:rf.ssr/suspense-boundary-failed` / `-duplicate-id` streaming
+  #    traces, the hydration-mismatch trace's `:server-hash` /
+  #    `:client-hash` tags, the EP-0001 ownership diagnostics, and the
+  #    `:rf.error/malformed-hydration-payload` /
+  #    `-hydration-frame-id-mismatch` rejection diagnostics.  Each is kept
+  #    VERBATIM inside a `(when interop/debug-enabled? …)` arm marked
+  #    `rf2-lwtlk`, with a `## Posture split` section in the ns docstring;
+  #    the semantics they were entangled with now run in this lane.
+  #
+  #    THE LARGER HALF WAS THE ASSERTIONS THAT WERE NOT FAILING.  A NEGATIVE
+  #    over the trace ring — `(is (empty? @diags))`, `(is (not-any? …
+  #    (ops)))`, "no malformed diagnostic on a well-formed payload" — passes
+  #    AUTOMATICALLY under this gate, where the ring is empty for every
+  #    input.  Roughly two dozen such assertions moved into the dev arms
+  #    alongside their positive counterparts.  Left outside they would have
+  #    been the quiet half of the same false green.
   #
   #    NOTE for whoever finishes this list: a namespace whose EVERY deftest is
   #    about the dev trace has no semantic residue to run under the gate.
   #    Guarding it wholesale and deleting its roster line would report GREEN
   #    for a namespace that executed nothing — the false-green this lane
-  #    exists to close.  Those want a var-level tag the lane excludes, not a
-  #    posture guard.
-  re-frame.flows-integration-test                 #  14
+  #    exists to close.  `ssr-compatibility-checks-test` was exactly that
+  #    (both fxs are best-effort: no state change, no return value, the trace
+  #    IS the output), and rather than roster it off it gained two
+  #    production-real deftests — the fx registrations with their
+  #    `:platforms #{:client}` gate, and a proof that a DOUBLE mismatch
+  #    neither throws nor stops the effect queued behind it.
+
+  # ── rf2-bkvu5 — HELD FOR A RULING.  ONE deftest,
+  #    `flow-output-schema-failure-rejects-candidate-before-install`, fails
+  #    for a REAL reason: under `-Dre-frame.debug=false` a flow output that
+  #    violates the registered app-db schema is NOT rejected — the invalid
+  #    candidate INSTALLS, and the handler's own `:db` installs with it.
+  #    That is not trace spelling.  `router.cljc`'s `validate-event!` and
+  #    `schemas/validate.cljc` both document it: every `validate-*!` body
+  #    sits inside its own `(if interop/debug-enabled? … true)` gate and
+  #    "Production builds return `true` unconditionally".  So `reg-app-schema`
+  #    is a no-op in production and the EP-0025 atomic-candidate-rejection
+  #    contract is a DEV-POSTURE contract.  Adjacent to rf2-rqje9 in class —
+  #    a documented choice whose consequence nobody had executed — but a
+  #    different surface, and none of rf2-rqje9's three candidate shapes
+  #    addresses it, so it has its own bead.
+  #
+  #    Every OTHER assertion in this namespace has already been posture-split
+  #    by rf2-lwtlk (the `by-op` / `ops` trace signatures are in dev arms, and
+  #    two flow-eval witnesses were added off the trace bus so "the flow
+  #    computed its bad output" and "the flow threw" survive the gate).  The
+  #    line below therefore comes out with a one-line change once rf2-bkvu5
+  #    lands.  Do not split that one deftest before it does.
+  re-frame.flows-integration-test                 #   2
+
+  # ── rf2-rqje9 — HELD, via the conformance corpus.  Nine `ssr-*.edn`
+  #    fixtures fail under the gate.  Eight are `:trace-emissions` claims
+  #    (`:rf.event/run-start` for `:rf/server-init` / `:rf/hydrate`), i.e.
+  #    the dev bus.  The ninth, `:ssr/error-known-mapping`, is the rqje9
+  #    cluster itself: "the buffered `:rf.error/no-such-handler` projects 404".
+  #    Because the corpus is one `(is (zero? (count failed)))` over every
+  #    fixture, that one fixture keeps the whole namespace red.
+  #
+  #    FINDING for whoever picks this up, so the runner is not misread as a
+  #    second defect: `:ssr/error-sanitisation` ALSO reports
+  #    `public-error actual: nil` under the gate, but its category is
+  #    `:rf.error/handler-exception`, which IS on the always-on
+  #    `re-frame.error-emit` axis.  It fails only because the runner's
+  #    `pe-check` sources its error event from `@traces` — the DEV bus —
+  #    before feeding it to `ssr/project-error`.  The projector itself is
+  #    fine under the gate: `re-frame.ssr-error-projector-substrate-test` is
+  #    IN this lane and green.  Re-sourcing `pe-check` from the always-on
+  #    axis is the rf2-7vk3z shape and would clear that fixture; it will not
+  #    clear `:ssr/error-known-mapping`, which needs the ruling.
   re-frame.ssr-conformance-test                   #   1
-  re-frame.ssr-hydration-test                     #  15
 
   # ── rf2-lwtlk — the PAYLOAD-POLICY suite.  CLEARED, and the roster note
   #    that asked for verification rather than assumption was answered:
@@ -235,7 +290,15 @@ fi
 # renamed directory, an `-n` list that matched nothing — cannot report itself
 # green with `Ran 0 tests`.  Calibrated below the observed count with room for
 # ordinary churn; raise it when the roster grows materially.
-export RF2_MIN_TESTS="${RF2_MIN_TESTS:-215}"
+#
+# RAISED 215 -> 380 by rf2-lwtlk.  The original figure was calibrated against
+# 247 observed tests across 28 namespaces.  The roster has since shrunk from
+# 21 entries to 7, and the lane runs 436 tests / 2014 assertions across 42 —
+# so 215 had stopped being a floor and become a formality: the lane could have
+# lost HALF its namespaces and still cleared it.  380 restores the original
+# ~13% headroom against the current observed count.  Raise it again as the
+# remaining seven come off.
+export RF2_MIN_TESTS="${RF2_MIN_TESTS:-380}"
 
 args=()
 for ns in $runnable; do

--- a/scripts/test-ssr-prod-gate.sh
+++ b/scripts/test-ssr-prod-gate.sh
@@ -108,15 +108,16 @@ known_red=(
   re-frame.ssr-flush-response-result-test         #  12
   re-frame.ssr-head-resolution-no-project-test    #   2
 
-  # ── rf2-lwtlk — SOURCE-COORD ANNOTATION.  These assert
-  #    `data-rf2-source-coord` / `data-rf-view` on rendered HTML.  Those
-  #    attributes are prod-elided at the core `reg-view` registration
-  #    boundary and merely serialised by the SSR emitter, so their absence
-  #    under the gate is the elision working as specified — the same shape as
-  #    core's `source-coord-prod-elision-test` cluster.
-  re-frame.source-coord-parity-test               #   3
-  re-frame.ssr-keyword-head-contract-test         #   1
-  re-frame.ssr-source-coord-test                  #  14
+  # ── rf2-lwtlk — SOURCE-COORD ANNOTATION.  CLEARED.  All three namespaces
+  #    (`source-coord-parity-test`, `ssr-keyword-head-contract-test`,
+  #    `ssr-source-coord-test`) now split their posture: the
+  #    `data-rf2-source-coord` / `data-rf-view` assertions are kept verbatim
+  #    inside `(when interop/debug-enabled? …)` arms, the RENDER they were
+  #    entangled with is asserted posture-independently, and each gained a
+  #    `when-not` arm that pins the bare bytes the REAL gate emits.  The
+  #    negative annotation assertions moved into the dev arm WITH the
+  #    positives: "the outer view did not stamp itself" is vacuously true
+  #    where nothing stamps anything.
 
   # ── rf2-lwtlk — dev-instrumentation assertions written inline with the
   #    semantics they sit next to: "exactly one `:rf.ssr/schema-digest-

--- a/scripts/test-ssr-prod-gate.sh
+++ b/scripts/test-ssr-prod-gate.sh
@@ -138,27 +138,21 @@ known_red=(
   #    exists to close.  Those want a var-level tag the lane excludes, not a
   #    posture guard.
   re-frame.flows-integration-test                 #  14
-  re-frame.framework-zero-ownership-diagnostics-test  #   2
-  re-frame.ssr-compatibility-checks-test          #   4
   re-frame.ssr-conformance-test                   #   1
-  re-frame.ssr-head-test                          #   2
   re-frame.ssr-hydration-mismatch-test            #   7
   re-frame.ssr-hydration-test                     #  15
-  re-frame.ssr-render-failed-test                 #   1
-  re-frame.ssr-request-cofx-test                  #   6
-  re-frame.ssr-request-durable-fact-test          #   1
   re-frame.ssr-streaming-corner-test              #   3
   re-frame.ssr-streaming-test                     #   3
 
-  # ── rf2-lwtlk — the PAYLOAD-POLICY suite, listed apart because of what it
-  #    guards.  `re-frame.ssr.payload-policy/project-routing-egress` is the
-  #    sub-classification egress rf2-u2x6w traced into production; its
-  #    always-on witness is `re-frame.ssr-routing-egress-production-test`,
-  #    which is IN this lane and green.  The single red assertion here is a
-  #    `:rf.ssr/invalid-version` WARNING trace, i.e. the dev half — but this
-  #    is the one namespace in the artefact whose failure could be a privacy
-  #    incident, so verify that rather than assume it.
-  re-frame.ssr.payload-policy-cljs-test           #   1
+  # ── rf2-lwtlk — the PAYLOAD-POLICY suite.  CLEARED, and the roster note
+  #    that asked for verification rather than assumption was answered:
+  #    the single red assertion was the `:rf.ssr/invalid-version` WARNING
+  #    trace, the dev half of a rejection whose PRODUCTION half — a semver
+  #    string never reaching `:rf/version`, which falls back to the integer
+  #    v1 — was green under the gate throughout.  Nothing that decides what
+  #    egresses was involved.  The always-on privacy witness for the egress
+  #    proper, `re-frame.ssr-routing-egress-production-test` (rf2-u2x6w),
+  #    has been in this lane and green since it was built.
 )
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`scripts/test-ssr-prod-gate.sh` (rf2-hnrwo) ran `implementation/ssr` under the real `-Dre-frame.debug=false` gate for the first time and found 21 of 49 namespaces red. This is the triage stream that empties that roster.

**14 namespaces cleared. 7 remain, all of them blocked on an operator ruling — 5 on rf2-rqje9, 2 more that this bead surfaced.**

## Lane before / after

|  | before | after |
|---|---|---|
| namespaces | 28 of 49 | **42 of 49** |
| tests | 247 | **436** |
| assertions | 1,379 | **2,014** |
| rostered known-red | 21 | **7** |

Dev posture, the proof nothing was lost: **532 → 534 tests, 2,554 → 2,609 assertions, green.** The count goes UP because production witnesses were added, never because assertions moved out of reach.

`RF2_MIN_TESTS` raised **215 → 380**. The old figure was calibrated against 247 observed tests; at 436 it had stopped being a floor — the lane could have lost half its namespaces and still cleared it. 380 restores the original ~13% headroom.

`check_jvm_lane_rosters.py`'s baseline is still **empty** (`0 baselined`).

## The split shape

rf2-d2841's, unchanged: the instrumentation assertion is kept **verbatim** inside a `(when interop/debug-enabled? …)` arm marked with the bead id; everything outside such an arm is posture-independent; each namespace gains a `## Posture split` section in its docstring. No new namespaces, no `^:dev-only` tags, no `deps.edn` change. Nothing was deleted, skipped or weakened.

Two elision surfaces are involved, both documented:

- **trace emission** — every `trace/emit-error!` site sits behind `interop/debug-enabled?`, read once at namespace-load time.
- **`:doc` on a registry slot** — a pure-documentation key dropped by `registrar/strip-pure-documentation` per Spec 001 §Production elision contract (`ssr-head-test`, `ssr-request-cofx-test`). Both gained a `when-not` arm pinning the elision on a JVM actually started with the property, which a `with-redefs` rebind cannot witness (rf2-9c2jf).

## The larger half: assertions that were not failing

Roughly two dozen assertions moved into dev arms **without ever having been red**, and that is the part of this PR that matters most. A negative over the trace ring passes automatically under a gate whose entire point is that the ring is empty:

- `framework-zero-ownership-diagnostics-test` — all five `(is (empty? @diags))`. This namespace is the sharpest case in the artefact: its whole subject is that the framework never trips its own EP-0001 ownership diagnostics, and with the diagnostics elided that claim is unfalsifiable. Its **control** deftest — which exists precisely to prove the recorder is live — is the one that went red first. The suite told the truth about itself.
- `ssr-compatibility-checks-test` — all four `(is (empty? (traces-of …)))`.
- `ssr-hydration-test` — a dozen `(is (not-any? … @traces))`: the well-formed payload did not trip the malformed diagnostic, matching hashes produced no mismatch, the server-side gate emitted no skipped-on-platform warning.
- `flows-integration-test` — the `not-any?` halves of both recovery-path trace signatures.
- `ssr-source-coord-test` and friends — "the outer view did not stamp itself", "a fragment root is not annotated". Vacuously true where nothing stamps anything.

## Production witnesses added, not assertions dropped

The rf2-7vk3z shape, applied wherever a production-real invariant was observed only through a dev channel:

- **`ssr-compatibility-checks-test` was 100% dev instrumentation** — both fxs are best-effort, change no state and return nothing, so the trace IS the output. Guarding it wholesale and deleting its roster line would have reported green for a namespace that executed nothing. Instead it gained two production-real deftests: the fx registrations with their `:platforms #{:client}` gate, and `compatibility-checks-are-best-effort-and-never-halt-the-drain`, which proves a **double** mismatch neither throws nor stops the effect queued behind it. That is the whole of degraded-but-running-never-crash and it was asserted nowhere.
- **The ownership diagnostic is advisory, not enforcement** (the Mike ruling the file cites), so in production the app handler's `:rf.db/runtime` write **lands**. Now pinned. The machine deftest's explicit destroy likewise had no witness beyond the vacuous `empty?`; the child's snapshot is now asserted gone from runtime-db.
- **Were the `:rf.ssr/check-*` fxs enqueued?** Both the server-side skip and the client-side counter-test now decorate the two fx ids with a recording pass-through and read the effect queue directly. The platform gate is a statement about the queue; a `:rf.fx/skipped-on-platform` trace cannot tell "never enqueued" from "warning elided".
- **Does `verify-hydration!` short-circuit, and does `hydrate!`'s verify step run?** `hydrate.cljc` builds **one** payload for the dev trace and the strict-mode throw alike, so `ex-data` is an always-on channel. Both now drive the condition on an `:ssr {:on-mismatch :hard-error}` frame: a nil server hash must not escalate, a divergent one must, and the ex-data's `:client-hash` proves the verify step really rendered the tree `:render-tree-fn` returned. The same channel gives `mismatch-detection-defaults-on-when-knob-absent` its first posture-independent proof that detection defaults ON.
- **`render-tree-hash` shape** — `mismatch-trace-client-hash-is-8-char-lowercase-hex` pinned it by reading a trace tag. The claim is about the hash function, so both migrated spec.cjs assertions now hold against `rf/render-tree-hash` directly.
- **Source-coord** — `production-build-emits-no-annotation` gains a `when-not` arm that registers under the real JVM gate on both the `reg-view*` and macro paths. Under the gate the bare Var and the registered `(rf/view :id)` handle render **byte-identically**, which is the head-grammar claim in its purest form and is observable only in this posture. "One wrapper, both paths" is now proven by comparing the streamed shell against the sync render, which holds in either posture.
- **`ssr-head-test`** — "the destroy still completes" was witnessed only by an `(is false …)` inside a catch, which contributes no assertion on the happy path. It now has a positive flag the throwing path can never set.
- **`flows-integration-test`** — two flow-eval witnesses off the trace bus, so "the flow computed its bad output" and "the flow was evaluated and threw" — the discriminator between the two recovery paths the suite exists to distinguish — survive the gate.
- **`ssr-streaming-test`** — `duplicate-id-emits-trace-and-keeps-last` asserted that ONE continuation survived, never WHICH. The surviving entry's `:fallback` now pins last-write-wins itself.

## Left rostered

**rf2-rqje9 — the five held namespaces, untouched.** `ssr-end-to-end-test` (119), `ssr-flush-response-result-test` (12), `ssr-error-two-frame-attribution-test` (5), `ssr-error-view-failed-no-project-test` (2), `ssr-head-resolution-no-project-test` (2). Not read, not split, no remedy chosen.

**`ssr-conformance-test` — rqje9, via the corpus.** Eight of its nine failing fixtures are `:trace-emissions` claims, but the ninth is `:ssr/error-known-mapping` — "the buffered `:rf.error/no-such-handler` projects 404" — the held cluster itself, and the corpus is one `(is (zero? (count failed)))` over every fixture. The roster records a finding for whoever picks it up: `:ssr/error-sanitisation` also reports a nil public-error, but its category IS on the always-on error-emit axis; it fails only because the runner's `pe-check` sources its error event from the **dev** trace bus before feeding `ssr/project-error`. The projector is fine under the gate — `ssr-error-projector-substrate-test` is in the lane and green. Re-sourcing `pe-check` would clear that fixture and not the other.

**`flows-integration-test` — a NEW finding, rf2-bkvu5 (P1) filed.** Twelve of its fourteen reds were trace signatures and are split. The remaining two are **not** trace spelling:

> Under `-Dre-frame.debug=false` a flow output that violates the registered app-db schema is **not rejected** — the invalid candidate INSTALLS, and the handler's own `:db` installs with it.

`router.cljc`'s `validate-event!` and `schemas/validate.cljc` both document the gate — *"Production builds return `true` unconditionally — the rollback path is dev-only"*. So `reg-app-schema` is a no-op in production and the EP-0025 atomic-candidate-rejection contract is a **dev-posture** contract. Adjacent to rf2-rqje9 in class — a documented choice whose consequence nobody had executed — but a different surface, and none of rf2-rqje9's three candidate shapes addresses it. Not a worker's call; the bead carries three options for the operator. Every other assertion in the namespace is already split, so the roster line comes out with a one-line change once the ruling lands.

## Quality gates

| gate | command | exit | result |
|---|---|---|---|
| SSR production-gate lane | `bash scripts/test-ssr-prod-gate.sh` | **0** | 436 tests / 2,014 assertions, 0 failures, 42 of 49 namespaces |
| SSR dev posture (full suite) | `clojure -M:test` in `implementation/ssr` | **0** | 534 tests / 2,609 assertions, 0 failures |
| JVM lane roster bijection | `python scripts/check_jvm_lane_rosters.py` | **0** | 31 rostered artefacts, **0 baselined** |

Both postures green, foreground, unpiped, from the worker worktree. Every namespace touched was also run individually under both postures while splitting.

Deferred to CI: the full JVM implementation sweep, the CLJS suites, and the browser gates. Nothing here is CLJS-visible — the only `.cljc` file touched is a test, and its dev arm compiles identically on both hosts.
