### PR TITLE
test(routing): continue splitting dev instrumentation from semantics (rf2-o5dbf)

### DIFF
--- a/implementation/routing/test/re_frame/routing_nav_fx_schemas_test.clj
+++ b/implementation/routing/test/re_frame/routing_nav_fx_schemas_test.clj
@@ -34,9 +34,45 @@
   (`routing_nav_fx_schemas_cljs_test.cljs`): all four fx are
   `:platforms #{:client}`, so on the JVM `handle-one-fx` short-circuits
   to `:rf.fx/skipped-on-platform` BEFORE the validation branch — the
-  args gate can only actually fire on the client host."
+  args gate can only actually fire on the client host.
+
+  ## Posture split (rf2-o5dbf)
+
+  Layers 1 and 2 are production-real and carry no posture guard. The
+  `:schema` WIRING is registrar state, and the ADJUDICATION is `m/validate`
+  against the registered schema — a pure Malli call with nothing gated
+  between the test and the verdict. Both run in the ordinary
+  `clojure -M:test` suite AND in `scripts/test-routing-prod-gate.sh` (the
+  `-Dre-frame.debug=false` lane).
+
+  Layer 3, the BOUNDARY, is dev-only BY DESIGN, and it is worth being precise
+  about why because it looks like a defect and is not.
+  `re-frame.schemas.validate/validate-fx!` is literally
+
+      (if interop/debug-enabled? (run-validation …) true)
+
+  so under `-Dre-frame.debug=false` the hot-path fx-args gate returns `true`
+  — accept, do not skip — for EVERY input, conforming or not. That is Spec 010
+  §Production builds: the per-step `validate-*!` hot-path fns are dev-only,
+  and production-build validation is the opt-in boundary interceptor
+  `:rf.schema/at-boundary`, which routes through `validate-with-registered-fn`
+  OUTSIDE the gate. So the layer-3 assertions are kept VERBATIM inside
+  `(when interop/debug-enabled? …)` arms marked `rf2-o5dbf`.
+
+  Note what that short-circuit does to the POSITIVE control. Every
+  `(is (true? (validate-through-hook …)))` still passes under the gate — but
+  for the wrong reason: `true` because validation did not run, not because the
+  args conform. A passing run says nothing. Those are inside the arm too, and
+  outside it the same shapes are adjudicated by `m/validate` against the LIVE
+  registration's `:schema`, which is the always-on half of the wired gate: it
+  proves the schema is installed AND that its verdict on those exact args is
+  the one the hook would relay. The `(is (empty? (filter …
+  :rf.error/schema-validation-failure …)))` leg is the ordinary
+  negative-over-the-ring case and is guarded for the ordinary reason. Nothing
+  was deleted or weakened."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [malli.core :as m]
+            [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
             [re-frame.registrar :as registrar]
             [re-frame.routing.nav-fx :as nav-fx]
@@ -315,11 +351,24 @@
 
 (defn- validate-through-hook
   "Call the live `:schemas/validate-fx!` hook with the LIVE registration
-  meta for `fx-id`. Returns the boolean `handle-one-fx` honours."
+  meta for `fx-id`. Returns the boolean `handle-one-fx` honours.
+
+  DEV-ONLY VERDICT (rf2-o5dbf): under `-Dre-frame.debug=false` this returns
+  `true` unconditionally — see the ns docstring's posture split. Use
+  `schema-verdict` below for the always-on half."
   [fx-id args]
   (let [validate-fx! (late-bind/get-fn :schemas/validate-fx!)]
     (validate-fx! fx-id :test/originating-event args
                   (registrar/lookup :fx fx-id))))
+
+(defn- schema-verdict
+  "The ALWAYS-ON half of the wired gate (rf2-o5dbf): `m/validate` run against
+  the `:schema` on `fx-id`'s LIVE registration — the very schema
+  `validate-fx!` would consult. Pure Malli, no `interop/debug-enabled?`
+  anywhere between the call and the answer, so it holds under the production
+  gate. Read it as \"what the hook WOULD relay if the hot path were running\"."
+  [fx-id args]
+  (m/validate (:schema (registrar/lookup :fx fx-id)) args))
 
 (deftest validate-fx-hook-is-wired-for-the-nav-fx
   (testing "the schemas artefact is on the routing test classpath and has
@@ -329,21 +378,32 @@
 (deftest nav-fx-args-pass-the-real-validation-hook-when-conforming
   (testing "POSITIVE control through the WIRED path: everything the runtime
             legitimately emits passes, fractional :saved-pos included"
-    (with-trace-recorder! [traces]
-      (is (true? (validate-through-hook :rf.nav/push-url "/cart")))
-      (is (true? (validate-through-hook :rf.nav/replace-url "/checkout")))
-      (is (true? (validate-through-hook :rf.nav/capture-scroll {:url "/cart"})))
-      (is (true? (validate-through-hook
-                   :rf.nav/scroll
-                   {:strategy  :restore
-                    :from      {:id :route/cart}
-                    :to        {:id :route/checkout}
-                    :saved-pos [0.5 1234.75]
-                    :fragment  "section-3"}))
-          "the full five-slot args with a FRACTIONAL :saved-pos pass")
-      (is (empty? (filter #(= :rf.error/schema-validation-failure (:operation %))
-                          @traces))
-          "no schema-validation-failure trace fires for conforming nav args"))))
+    (let [full-scroll {:strategy  :restore
+                       :from      {:id :route/cart}
+                       :to        {:id :route/checkout}
+                       :saved-pos [0.5 1234.75]
+                       :fragment  "section-3"}]
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): the LIVE registration's own
+      ;; schema accepts each of these. Under the gate `validate-through-hook`
+      ;; returns true for EVERYTHING, so without this the positive control
+      ;; would pass for the wrong reason and prove nothing.
+      (is (true? (schema-verdict :rf.nav/push-url "/cart")))
+      (is (true? (schema-verdict :rf.nav/replace-url "/checkout")))
+      (is (true? (schema-verdict :rf.nav/capture-scroll {:url "/cart"})))
+      (is (true? (schema-verdict :rf.nav/scroll full-scroll))
+          "the full five-slot args with a FRACTIONAL :saved-pos pass the registered schema")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring): the WIRED
+      ;; hot path, plus a NEGATIVE over the trace ring.
+      (when interop/debug-enabled?
+        (with-trace-recorder! [traces]
+          (is (true? (validate-through-hook :rf.nav/push-url "/cart")))
+          (is (true? (validate-through-hook :rf.nav/replace-url "/checkout")))
+          (is (true? (validate-through-hook :rf.nav/capture-scroll {:url "/cart"})))
+          (is (true? (validate-through-hook :rf.nav/scroll full-scroll))
+              "the full five-slot args with a FRACTIONAL :saved-pos pass")
+          (is (empty? (filter #(= :rf.error/schema-validation-failure (:operation %))
+                              @traces))
+              "no schema-validation-failure trace fires for conforming nav args"))))))
 
 (deftest schema-less-nav-fx-meta-adjudicates-nothing
   (testing "rf2-sqams RED-BEFORE control: the pre-sqams registration meta —
@@ -360,13 +420,26 @@
                               :rf.nav/capture-scroll {:position [0 0]}}]
       (let [validate-fx!    (late-bind/get-fn :schemas/validate-fx!)
             pre-sqams-meta  (dissoc (registrar/lookup :fx fx-id) :schema)]
-        (is (true? (validate-fx! fx-id :test/originating-event
-                                 bad-args pre-sqams-meta))
-            (str fx-id " with a schema-less meta soft-passes " (pr-str bad-args)
-                 " — the pre-sqams behaviour"))
-        (is (false? (validate-through-hook fx-id bad-args))
-            (str fx-id " with the LIVE (schema-bearing) meta rejects the same "
-                 "args — the boundary the spec promises now exists"))))))
+        ;; SEMANTIC, posture-independent (rf2-o5dbf): the control's real
+        ;; subject is that a `:schema` IS installed and DOES reject these
+        ;; args. That is what a future edit dropping a `:schema` would break,
+        ;; and it is checkable without the hot path.
+        (is (some? (:schema (registrar/lookup :fx fx-id)))
+            (str fx-id " still carries a :schema on its live registration"))
+        (is (false? (schema-verdict fx-id bad-args))
+            (str fx-id "'s registered schema rejects " (pr-str bad-args)
+                 " — the boundary the spec promises now exists"))
+        ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring). Both legs
+        ;; go through the hot path, which returns `true` unconditionally under
+        ;; -Dre-frame.debug=false, so neither can discriminate there.
+        (when interop/debug-enabled?
+          (is (true? (validate-fx! fx-id :test/originating-event
+                                   bad-args pre-sqams-meta))
+              (str fx-id " with a schema-less meta soft-passes " (pr-str bad-args)
+                   " — the pre-sqams behaviour"))
+          (is (false? (validate-through-hook fx-id bad-args))
+              (str fx-id " with the LIVE (schema-bearing) meta rejects the same "
+                   "args — the boundary the spec promises now exists")))))))
 
 (deftest nav-fx-args-fail-the-real-validation-hook-when-malformed
   (testing "ADVERSARIAL through the WIRED path: at least one malformed shape
@@ -377,20 +450,27 @@
                               :rf.nav/replace-url    42
                               :rf.nav/scroll         {:strategy :smooth}
                               :rf.nav/capture-scroll {:position [0 0]}}]
-      (with-trace-recorder! [traces]
-        (is (false? (validate-through-hook fx-id bad-args))
-            (str fx-id " with " (pr-str bad-args) " fails the wired gate"))
-        (let [violations (filter #(= :rf.error/schema-validation-failure
-                                     (:operation %))
-                                 @traces)]
-          (is (= 1 (count violations))
-              (str fx-id " emitted exactly one schema-validation-failure"))
-          (let [v (first violations)]
-            (is (= :fx-args (-> v :tags :where))
-                "the violation is tagged :where :fx-args (Spec 010 step 5)")
-            (is (= fx-id (-> v :tags :rf.fx/id)))
-            (is (= fx-id (-> v :tags :failing-id)))
-            (is (= :test/originating-event (-> v :tags :event-id))
-                "the originating event-id threads through")
-            (is (= :skipped (:recovery v))
-                "recovery is :skipped — the offending fx alone is dropped")))))))
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): the VERDICT the wired gate
+      ;; relays is the registered schema's own, and it is `false` for each of
+      ;; these shapes in either posture. Only the relaying is dev-gated.
+      (is (false? (schema-verdict fx-id bad-args))
+          (str fx-id "'s registered schema rejects " (pr-str bad-args)))
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (with-trace-recorder! [traces]
+          (is (false? (validate-through-hook fx-id bad-args))
+              (str fx-id " with " (pr-str bad-args) " fails the wired gate"))
+          (let [violations (filter #(= :rf.error/schema-validation-failure
+                                       (:operation %))
+                                   @traces)]
+            (is (= 1 (count violations))
+                (str fx-id " emitted exactly one schema-validation-failure"))
+            (let [v (first violations)]
+              (is (= :fx-args (-> v :tags :where))
+                  "the violation is tagged :where :fx-args (Spec 010 step 5)")
+              (is (= fx-id (-> v :tags :rf.fx/id)))
+              (is (= fx-id (-> v :tags :failing-id)))
+              (is (= :test/originating-event (-> v :tags :event-id))
+                  "the originating event-id threads through")
+              (is (= :skipped (:recovery v))
+                  "recovery is :skipped — the offending fx alone is dropped"))))))))

--- a/implementation/routing/test/re_frame/routing_nav_token_test.clj
+++ b/implementation/routing/test/re_frame/routing_nav_token_test.clj
@@ -2,10 +2,40 @@
   "Navigation-token stale-result-suppression + `:on-match` loader tests
   for re-frame.routing (nav-token allocation, the `:rf.route/nav-token` cofx, the
   `:rf.route/with-nav-token` fx, and multi-loader `:on-match` ordering /
-  error precedence). Split from routing_test.clj per rf2-u8qe7y finding 3."
+  error precedence). Split from routing_test.clj per rf2-u8qe7y finding 3.
+
+  ## Posture split (rf2-o5dbf)
+
+  STALE-RESULT SUPPRESSION is production-real and carries no posture guard.
+  Suppression is enforcement, not advice: a superseded completion's app
+  `:rf/reply-to` target is never dispatched, so app-db and runtime-db are
+  provably unchanged, and the fresh completion still commits. Every deftest
+  here asserts that outside any arm, so it runs in the ordinary
+  `clojure -M:test` suite AND in `scripts/test-routing-prod-gate.sh` (the
+  `-Dre-frame.debug=false` lane). The `:rf.route/nav-token` /
+  `:rf.route/route-id` cofx values are likewise real — they are read straight
+  out of the capturing handler.
+
+  What is dev-only is the `:rf.route.nav-token/stale-suppressed` TRACE and
+  everything spelled on it: the carried / current token pair, the canonical
+  `:rf.trace/event-id` tag, `:completed-at`, the `:rf.reply/work-id` join key
+  and the EP-0011 `:rf.reply/status` / `:rf.reply/work-status` /
+  `:rf.reply/stale-reason` envelope vocabulary. All of it rides `trace/emit!`,
+  gated on `interop/debug-enabled?` and read once at load time, so under the
+  real gate there is no trace to carry it. Those assertions are kept VERBATIM
+  inside `(when interop/debug-enabled? …)` arms marked `rf2-o5dbf`.
+
+  Four are NEGATIVE over the trace and would pass vacuously under the gate —
+  `(not (contains? (:tags stale) :event-id))`, `(not (contains? (:tags stale)
+  :completed-at))`, the `not-any?` mis-attribution guard, and the `not-any?
+  :rf.error/fx-handler-exception` leg. They are inside the arm. The three
+  `:completed-at` deftests had NO non-trace assertion at all, so each gained
+  the production witness the suppression actually is: the stale payload never
+  reached app-db. Nothing was deleted or weakened."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.fx :as fx]
+            [re-frame.interop :as interop]
             [re-frame.routing :as routing]
             [re-frame.routing.test-support]
             [re-frame.routing-test-support :as rts]))
@@ -61,7 +91,11 @@
              (:article (rf/app-db-value :rf/default)))
           "only B's payload committed; A's was suppressed")
 
-      (is (some (fn [ev]
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring). The
+      ;; SUPPRESSION itself is pinned by the app-db assertion above, which is
+      ;; posture-independent: A's payload never landed.
+      (when interop/debug-enabled?
+       (is (some (fn [ev]
                   (and (= :rf.route.nav-token/stale-suppressed (:operation ev))
                        (= "nav-1" (-> ev :tags :carried-token))
                        (= "nav-2" (-> ev :tags :current-token))
@@ -96,7 +130,7 @@
                        (= [:rf.work/route :route/article "nav-1" :article/loaded]
                           (-> ev :tags :rf.reply/work-id))))
                 @traces)
-          "the stale-suppressed trace is joined to the route :work/id (the carried nav-token rides in the tuple)"))))
+          "the stale-suppressed trace is joined to the route :work/id (the carried nav-token rides in the tuple)")))))
 
 (deftest cross-route-stale-uses-captured-route-id-not-live-route
   (testing "rf2-azcmd3 — when route A's stale completion arrives AFTER navigating to a DIFFERENT route B, the work-id carries route A's CAPTURED id, never route B's live id"
@@ -139,18 +173,23 @@
       (is (nil? (:article (rf/app-db-value :rf/default)))
           "route A's stale loader was suppressed; nothing committed")
 
-      ;; The work-id carries route A's CAPTURED id, NOT route B's live id.
-      (is (some (fn [ev]
-                  (and (= :rf.route.nav-token/stale-suppressed (:operation ev))
-                       (= [:rf.work/route :route/article "nav-1" :article/loaded]
-                          (-> ev :tags :rf.reply/work-id))))
-                @traces)
-          "the stale work-id uses the CAPTURED route id (:route/article), not the live route (:route/profile)")
-      (is (not-any? (fn [ev]
-                      (and (= :rf.route.nav-token/stale-suppressed (:operation ev))
-                           (= :route/profile (first (rest (-> ev :tags :rf.reply/work-id))))))
-                    @traces)
-          "no stale work-id is mis-attributed to the live route B (:route/profile)"))))
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring). The work-id
+      ;; is a trace-only correlation key, and the second leg is NEGATIVE over
+      ;; the ring. The suppression they annotate is pinned by the app-db
+      ;; assertion above, posture-independently.
+      (when interop/debug-enabled?
+        ;; The work-id carries route A's CAPTURED id, NOT route B's live id.
+        (is (some (fn [ev]
+                    (and (= :rf.route.nav-token/stale-suppressed (:operation ev))
+                         (= [:rf.work/route :route/article "nav-1" :article/loaded]
+                            (-> ev :tags :rf.reply/work-id))))
+                  @traces)
+            "the stale work-id uses the CAPTURED route id (:route/article), not the live route (:route/profile)")
+        (is (not-any? (fn [ev]
+                        (and (= :rf.route.nav-token/stale-suppressed (:operation ev))
+                             (= :route/profile (first (rest (-> ev :tags :rf.reply/work-id))))))
+                      @traces)
+            "no stale work-id is mis-attributed to the live route B (:route/profile)")))))
 
 (deftest with-nav-token-fx-suppresses-stale-reply-to-and-commits-fresh
   (testing ":rf.route/with-nav-token fx: stale `:rf/reply-to` is suppressed; fresh `:rf/reply-to` runs"
@@ -230,6 +269,10 @@
              (:article (rf/app-db-value :rf/default)))
           "fresh :rf/reply-to ran end-to-end; stale :rf/reply-to was suppressed before commit")
 
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring). Everything
+      ;; from here to the end of this deftest is spelled ON the trace; the
+      ;; enforcement it annotates is pinned by the app-db assertion above.
+      (when interop/debug-enabled?
       (is (some (fn [ev]
                   (and (= :rf.route.nav-token/stale-suppressed (:operation ev))
                        (= "nav-1" (-> ev :tags :carried-token))
@@ -291,7 +334,7 @@
                                 (= :rf.route.nav-token/stale-suppressed
                                    (:operation ev)))
                               @traces)))
-          "exactly one stale-suppressed trace fired — the fresh :rf/reply-to did NOT trip the validation"))))
+          "exactly one stale-suppressed trace fired — the fresh :rf/reply-to did NOT trip the validation")))))
 
 ;; ---- rf2-ux8sgg — stale route reply preserves the completion time ---------
 ;;
@@ -345,14 +388,21 @@
 
       (rf/unregister-listener! :trace ::completed-at-fx)
 
-      (let [stale (some (fn [ev]
-                          (when (= :rf.route.nav-token/stale-suppressed
-                                   (:operation ev))
-                            ev))
-                        @traces)]
-        (is (some? stale) "a production stale-suppressed trace fired")
-        (is (= completion-ts (-> stale :tags :completed-at))
-            "the stale trace carries the threaded reply completion time (pre-fix: dropped)")))))
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): the suppression this
+      ;; deftest annotates really happened — A's stale payload never reached
+      ;; app-db. Without it this deftest would execute nothing under the gate.
+      (is (nil? (:article (rf/app-db-value :rf/default)))
+          "the stale completion was suppressed — no app-db write")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (let [stale (some (fn [ev]
+                            (when (= :rf.route.nav-token/stale-suppressed
+                                     (:operation ev))
+                              ev))
+                          @traces)]
+          (is (some? stale) "a production stale-suppressed trace fired")
+          (is (= completion-ts (-> stale :tags :completed-at))
+              "the stale trace carries the threaded reply completion time (pre-fix: dropped)"))))))
 
 (deftest with-nav-token-fx-stale-omits-completed-at-when-absent
   (testing "rf2-ux8sgg — when no completion time is threaded, the stale trace
@@ -379,14 +429,22 @@
                           :id               "A"
                           :payload          "A-payload"}])
       (rf/unregister-listener! :trace ::no-completed-at)
-      (let [stale (some (fn [ev]
-                          (when (= :rf.route.nav-token/stale-suppressed
-                                   (:operation ev))
-                            ev))
-                        @traces)]
-        (is (some? stale) "a stale-suppressed trace fired")
-        (is (not (contains? (:tags stale) :completed-at))
-            "no :completed-at tag when none was sourced (slot is optional)")))))
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): the suppression really
+      ;; happened. Without it this deftest would execute nothing under the
+      ;; gate — and its second leg below is NEGATIVE over the ring, so with a
+      ;; nil `stale` it would pass vacuously.
+      (is (nil? (:article (rf/app-db-value :rf/default)))
+          "the stale completion was suppressed — no app-db write")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (let [stale (some (fn [ev]
+                            (when (= :rf.route.nav-token/stale-suppressed
+                                     (:operation ev))
+                              ev))
+                          @traces)]
+          (is (some? stale) "a stale-suppressed trace fired")
+          (is (not (contains? (:tags stale) :completed-at))
+              "no :completed-at tag when none was sourced (slot is optional)"))))))
 
 (deftest simulate-http-resolution-stale-preserves-completed-at
   (testing "rf2-ux8sgg — the test fixture `:rf.test/simulate-http-resolution`
@@ -409,14 +467,20 @@
                           :carried-route-id     :route/article
                           :carried-completed-at completion-ts}])
       (rf/unregister-listener! :trace ::fixture-completed-at)
-      (let [stale (some (fn [ev]
-                          (when (= :rf.route.nav-token/stale-suppressed
-                                   (:operation ev))
-                            ev))
-                        @traces)]
-        (is (some? stale) "the fixture stale-suppressed trace fired")
-        (is (= completion-ts (-> stale :tags :completed-at))
-            "the fixture stale trace carries the captured reply completion time")))))
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): the fixture mirrors the
+      ;; production lane, so it must suppress the same way — no app-db write.
+      (is (nil? (:article (rf/app-db-value :rf/default)))
+          "the fixture's stale completion was suppressed — no app-db write")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (let [stale (some (fn [ev]
+                            (when (= :rf.route.nav-token/stale-suppressed
+                                     (:operation ev))
+                              ev))
+                          @traces)]
+          (is (some? stale) "the fixture stale-suppressed trace fired")
+          (is (= completion-ts (-> stale :tags :completed-at))
+              "the fixture stale trace carries the captured reply completion time"))))))
 
 ;; ---- Spec 012 §Navigation tokens step 2 — the `:rf.route/nav-token` cofx ----------
 ;;
@@ -519,15 +583,19 @@
       (is (= {:id "B" :payload "B-payload"}
              (:article (rf/app-db-value :rf/default)))
           "only B committed — A's stale completion was suppressed via the cofx-captured token")
-      (is (some (fn [ev]
-                  (and (= :rf.route.nav-token/stale-suppressed (:operation ev))
-                       (= :article/loaded (-> ev :tags :rf.trace/event-id))))
-                @traces)
-          "A's stale completion produced :rf.route.nav-token/stale-suppressed")
-      (is (= 1 (count (filter #(= :rf.route.nav-token/stale-suppressed
-                                  (:operation %))
-                              @traces)))
-          "exactly one suppression — B's fresh completion applied cleanly"))))
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring). The
+      ;; documented stale/fresh outcome is pinned by the app-db assertion
+      ;; above, posture-independently: only B committed.
+      (when interop/debug-enabled?
+        (is (some (fn [ev]
+                    (and (= :rf.route.nav-token/stale-suppressed (:operation ev))
+                         (= :article/loaded (-> ev :tags :rf.trace/event-id))))
+                  @traces)
+            "A's stale completion produced :rf.route.nav-token/stale-suppressed")
+        (is (= 1 (count (filter #(= :rf.route.nav-token/stale-suppressed
+                                    (:operation %))
+                                @traces)))
+            "exactly one suppression — B's fresh completion applied cleanly")))))
 
 ;; ---- rf2-ph1grf — the documented path captures a COMPLETE route work-id -----
 ;;
@@ -591,16 +659,24 @@
                           :payload          "A-payload"}])
       (rf/unregister-listener! :trace ::ph1grf)
 
-      (let [stale (some (fn [ev]
-                          (when (= :rf.route.nav-token/stale-suppressed (:operation ev)) ev))
-                        @traces)]
-        (is (some? stale) "A's stale completion produced a suppression trace")
-        (let [wid (-> stale :tags :rf.reply/work-id)]
-          (is (= [:rf.work/route :route/article "nav-1" :article/loaded] wid)
-              "the work-id carries the COMPLETE captured tuple — route-id is NOT nil")
-          (is (not (nil? (second wid)))
-              "rf2-ph1grf — the route-id component is non-nil (the documented path
-               cannot emit a nil-route route work-id)"))))))
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): the documented capture
+      ;; path really suppressed A. The work-id below is a trace-only
+      ;; correlation key, so without this the deftest executes nothing under
+      ;; the gate.
+      (is (nil? (:article (rf/app-db-value :rf/default)))
+          "A's stale completion was suppressed — no app-db write")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (let [stale (some (fn [ev]
+                            (when (= :rf.route.nav-token/stale-suppressed (:operation ev)) ev))
+                          @traces)]
+          (is (some? stale) "A's stale completion produced a suppression trace")
+          (let [wid (-> stale :tags :rf.reply/work-id)]
+            (is (= [:rf.work/route :route/article "nav-1" :article/loaded] wid)
+                "the work-id carries the COMPLETE captured tuple — route-id is NOT nil")
+            (is (not (nil? (second wid)))
+                "rf2-ph1grf — the route-id component is non-nil (the documented path
+                 cannot emit a nil-route route work-id)")))))))
 
 ;; ---- rf2-2avo53 / rf2-068eo5 — with-nav-token continuations lower through :rf/reply-to ----
 ;;
@@ -685,15 +761,19 @@
 
       (is (nil? (:replied (rf/app-db-value :rf/default)))
           "the app :rf/reply-to target was suppressed — no app-db write on a stale completion")
-      (let [stale (some (fn [ev]
-                          (when (= :rf.route.nav-token/stale-suppressed (:operation ev)) ev))
-                        @traces)]
-        (is (some? stale) "a stale-suppressed trace fired for the suppressed reply-to completion")
-        (is (= [:rf.work/route :route/article "nav-1" :article/load-replied]
-               (-> stale :tags :rf.reply/work-id))
-            "the suppression is joined to the route :work/id (loader-id = target event-id)")
-        (is (= :stale (-> stale :tags :rf.reply/status)))
-        (is (= :suppressed (-> stale :tags :rf.reply/work-status)))))))
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring). The
+      ;; enforcement — the app target did NOT run — is pinned by the app-db
+      ;; assertion above, posture-independently.
+      (when interop/debug-enabled?
+        (let [stale (some (fn [ev]
+                            (when (= :rf.route.nav-token/stale-suppressed (:operation ev)) ev))
+                          @traces)]
+          (is (some? stale) "a stale-suppressed trace fired for the suppressed reply-to completion")
+          (is (= [:rf.work/route :route/article "nav-1" :article/load-replied]
+                 (-> stale :tags :rf.reply/work-id))
+              "the suppression is joined to the route :work/id (loader-id = target event-id)")
+          (is (= :stale (-> stale :tags :rf.reply/status)))
+          (is (= :suppressed (-> stale :tags :rf.reply/work-status))))))))
 
 (deftest with-nav-token-never-delivers-stale-to-any-target
   (testing "rf2-j538f7.14 — PRODUCTION-PATH regression (AC4): NO app :rf/reply-to
@@ -744,11 +824,17 @@
           ;; The suppression trace still fires (the only effect of a stale
           ;; completion); no fx-handler exception is raised — suppress no longer
           ;; throws, it silently declines to deliver.
-          (is (some (fn [ev] (= :rf.route.nav-token/stale-suppressed (:operation ev))) @traces)
-              (str "a stale-suppressed trace fired for " (pr-str target)))
-          (is (not-any? (fn [ev] (= :rf.error/fx-handler-exception (:operation ev))) @traces)
-              (str "no fx-handler exception — suppression is silent non-delivery for "
-                   (pr-str target))))))))
+          ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring). The three
+          ;; assertions above — target never ran, app-db unchanged, runtime-db
+          ;; unchanged — are the AC4 property itself and are
+          ;; posture-independent. The second leg here is NEGATIVE over the
+          ;; ring, so outside the arm it would pass vacuously.
+          (when interop/debug-enabled?
+            (is (some (fn [ev] (= :rf.route.nav-token/stale-suppressed (:operation ev))) @traces)
+                (str "a stale-suppressed trace fired for " (pr-str target)))
+            (is (not-any? (fn [ev] (= :rf.error/fx-handler-exception (:operation ev))) @traces)
+                (str "no fx-handler exception — suppression is silent non-delivery for "
+                     (pr-str target)))))))))
 
 ;; ============================================================================
 ;; EP-0037 R1 — :on-match is fire-and-forget; a throw does not flip readiness

--- a/scripts/test-routing-prod-gate.sh
+++ b/scripts/test-routing-prod-gate.sh
@@ -166,9 +166,26 @@ known_red=(
   #    state that does execute.  Be clear-eyed about the trade: under the
   #    production gate this namespace contributes routing semantics, not the
   #    ownership contract it is named for.
-  re-frame.routing-nav-fx-schemas-test            # 32
   re-frame.routing-navigation-test                # 64
   re-frame.routing-plan-seam-test                 # 31
+  #    CLEARED 2026-07-27 (rf2-o5dbf, batch 7): routing-nav-fx-schemas.
+  #    READ THIS ONE BEFORE ASSUMING THE NEXT LOOK-ALIKE IS A DEFECT.  Its
+  #    failures were `(is (false? (validate-through-hook …)))` returning
+  #    TRUE under the gate — the fx-args gate accepting args it rejects in
+  #    dev, which reads exactly like the rf2-9c2jf class.  It is not.
+  #    `re-frame.schemas.validate/validate-fx!` is literally
+  #    `(if interop/debug-enabled? (run-validation …) true)`, per Spec 010
+  #    §Production builds: the per-step `validate-*!` hot-path fns are
+  #    dev-only and production-build validation is the OPT-IN boundary
+  #    interceptor `:rf.schema/at-boundary`, which routes through
+  #    `validate-with-registered-fn` outside the gate.
+  #
+  #    That short-circuit also makes the suite's POSITIVE control pass for
+  #    the wrong reason — `true` because validation did not run, not because
+  #    the args conform.  The always-on replacement is `m/validate` against
+  #    the LIVE registration's `:schema`: same schema the hook consults, no
+  #    gate between the call and the verdict.
+  #
   #    CLEARED 2026-07-27 (rf2-o5dbf, batch 6): routing-nav-token.  Stale
   #    suppression is ENFORCEMENT, not advice — the superseded completion's
   #    app `:rf/reply-to` target is never dispatched, so app-db and

--- a/scripts/test-routing-prod-gate.sh
+++ b/scripts/test-routing-prod-gate.sh
@@ -301,7 +301,13 @@ fi
 # renamed directory, an `-n` list that matched nothing — cannot report itself
 # green with `Ran 0 tests`.  Calibrated below the observed count with room for
 # ordinary churn; raise it when the roster grows materially.
-export RF2_MIN_TESTS="${RF2_MIN_TESTS:-85}"
+#
+# rf2-o5dbf raised this 85 -> 380.  The original 85 was calibrated against an
+# observed 98 (~87%); the lane now runs 438, so an 85 floor sat FIVE TIMES
+# below what it guards — a roster collapse to a fifth of the lane would still
+# have reported green.  380 restores the same ~87% ratio against the current
+# observation.  Raise it again the next time the roster shrinks materially.
+export RF2_MIN_TESTS="${RF2_MIN_TESTS:-380}"
 
 args=()
 for ns in $runnable; do

--- a/scripts/test-routing-prod-gate.sh
+++ b/scripts/test-routing-prod-gate.sh
@@ -167,9 +167,19 @@ known_red=(
   #    production gate this namespace contributes routing semantics, not the
   #    ownership contract it is named for.
   re-frame.routing-nav-fx-schemas-test            # 32
-  re-frame.routing-nav-token-test                 # 32
   re-frame.routing-navigation-test                # 64
   re-frame.routing-plan-seam-test                 # 31
+  #    CLEARED 2026-07-27 (rf2-o5dbf, batch 6): routing-nav-token.  Stale
+  #    suppression is ENFORCEMENT, not advice — the superseded completion's
+  #    app `:rf/reply-to` target is never dispatched, so app-db and
+  #    runtime-db are provably unchanged in either posture.  Everything
+  #    SPELLED on the `:rf.route.nav-token/stale-suppressed` trace (the
+  #    carried/current token pair, `:completed-at`, the `:rf.reply/work-id`
+  #    join key, the EP-0011 envelope vocabulary) is dev-only.  Three
+  #    `:completed-at` deftests had NO non-trace assertion at all and would
+  #    have executed nothing; each gained the app-db witness the suppression
+  #    actually is.
+  #
   #    CLEARED 2026-07-27 (rf2-o5dbf, batch 5): routing-prefetch.  Its
   #    `@calls` atom is the stubbed `:routing/on-route-prefetch` warm hook —
   #    a late-bound fn, NOT a trace — so "did prefetch reach planning, and


### PR DESCRIPTION
Continues **#7148** (merged), which cleared 12 of the 19 known-red namespaces in `scripts/test-routing-prod-gate.sh`. This PR takes two more — `routing-nav-token` and `routing-nav-fx-schemas` — and raises the lane's coverage floor, which #7148's shrink had left five times too loose.

Same method throughout (rf2-d2841's, used for core): instrumentation assertions kept VERBATIM inside a `(when interop/debug-enabled? …)` arm marked with the bead id, everything outside such an arm posture-independent, the split documented under `## Posture split` in each ns docstring. **Nothing was deleted or weakened.**

## The lane

|                    | before | after |
| ------------------ | -----: | ----: |
| namespaces         |     33 |    35 |
| of total           |     37 |    37 |
| tests              |    412 |   438 |
| assertions         |  2,022 | 2,191 |
| known-red roster   |      4 |     2 |

Across both PRs the roster has gone **19 → 2** and the lane **18 → 35** namespaces, **98 → 438** tests, **613 → 2,191** assertions.

`re-frame.routing-sub-egress-production-test` is untouched and stays in the lane, as does the `routing-prod-gate-lane-pin-test` posture pin. `check_jvm_lane_rosters.py`'s baseline stays EMPTY.

## `RF2_MIN_TESTS` raised 85 → 380

Flagged in #7148, actioned here. The floor exists so a collapsed roster cannot report itself green with `Ran 0 tests`. It was calibrated at 85 against an observed 98 (~87%). The lane now runs 438, so **85 sat five times below what it guards** — the roster could have collapsed to a fifth of the lane and still passed. 380 restores the same ~87% ratio, leaving room for ordinary churn.

## `routing-nav-token` — suppression is enforcement, so it splits cleanly

Stale suppression is enforcement, not advice: a superseded completion's app `:rf/reply-to` target is never dispatched, so app-db and runtime-db are provably unchanged and the fresh completion still commits. Every deftest now asserts that outside any arm. The `:rf.route/nav-token` / `:rf.route/route-id` cofx values are likewise real — read straight out of the capturing handler.

Dev-only is everything *spelled on* the `:rf.route.nav-token/stale-suppressed` trace: the carried/current token pair, the canonical `:rf.trace/event-id` tag, `:completed-at`, the `:rf.reply/work-id` join key, and the EP-0011 `:rf.reply/status` / `:rf.reply/work-status` / `:rf.reply/stale-reason` envelope vocabulary.

**Four deftests would have executed nothing.** The `:completed-at` trio and `nav-token+route-id-cofx-yields-complete-route-work-id` had *no* non-trace assertion at all. Guarding them wholesale and deleting the roster line would have reported green for four deftests running zero assertions — the exact false green this lane exists to close. Each gained the production witness the suppression actually is: the stale payload never reached app-db.

## `routing-nav-fx-schemas` — reads like the rf2-9c2jf class, and is not

This one got read before it got touched. Its failures were `(is (false? (validate-through-hook …)))` returning **true** under the gate: the fx-args gate *accepting* args it rejects in dev.

`re-frame.schemas.validate/validate-fx!` is literally `(if interop/debug-enabled? (run-validation …) true)`, and the comment directly beneath it states the design — per **Spec 010 §Production builds** the per-step `validate-*!` hot-path fns are dev-only, and production-build validation is the opt-in boundary interceptor `:rf.schema/at-boundary`, which routes through `validate-with-registered-fn` outside the gate. So this is correct dev-posture coverage, not a defect. The roster comment records the reasoning so the next look-alike gets read rather than assumed.

**A third kind of vacuous pass.** The two traps this triage has been sweeping for are negative-over-the-ring assertions and namespaces with no semantic residue. This suite has a third: a *positive* assertion trivially satisfied by the gate's short-circuit. Every `(is (true? (validate-through-hook …)))` in the conforming control **already passed** under the gate — `true` because validation did not run, not because the args conform. It was green in a way that proved nothing, and would have stayed green if the schema were deleted outright.

The always-on replacement is `schema-verdict`: `m/validate` against the `:schema` on the fx's **live registration** — the very schema `validate-fx!` consults, with nothing gated between the call and the verdict. Every hook assertion now has that counterpart outside the arm, so under the gate the suite proves the schema is installed *and* that its verdict on those exact args is correct, for both conforming and adversarial shapes.

## Vacuous passes neutralized — six more

Both roster lines were hiding assertions that were never red and would have gone green forever the moment the lines came off:

- `(not (contains? (:tags stale) :event-id))` — the rf2-ejitk8 drift guard. With no trace `stale` is nil, so it certifies the bare-`:event-id` spelling is gone from a tag map that was never built.
- `(not (contains? (:tags stale) :completed-at))` — same shape.
- the `not-any?` guard that no stale work-id is mis-attributed to the live route B.
- `(not-any? :rf.error/fx-handler-exception …)` in the AC4 never-delivers-stale sweep — the leg proving suppression is *silent* non-delivery rather than a throw.
- `(is (empty? (filter … :rf.error/schema-validation-failure …)))` in the nav-fx conforming control.
- the four `(is (true? (validate-through-hook …)))` legs described above, which are the novel third class.

Running total across both PRs: **20 vacuous passes** found and closed.

The AC4 sweep is worth noting as the good case: its three real assertions — the target never ran, app-db unchanged, runtime-db unchanged — are the property itself and were already posture-independent, so only the two trace legs moved.

## What remains — 2 namespaces

| namespace | red assertions |
| --- | ---: |
| `routing-navigation-test` | 64 |
| `routing-plan-seam-test` | 31 |

Neither has been read line by line. Both sampled as dev instrumentation of shapes already handled here, but the vacuous-pass sweep each one needs is exactly the work that found 20 of them in the seventeen cleared so far — so they want a proper read, not an extrapolation. rf2-o5dbf stays open for them.

## Quality gates

Foreground, worktree-local logs, exit codes echoed. Run after rebasing onto current `origin/main`.

| gate | result |
| --- | --- |
| `bash scripts/test-routing-prod-gate.sh` | **exit 0** — 35 namespaces, 438 tests, 2,191 assertions, 0 failures / 0 errors (with `RF2_MIN_TESTS` at the new 380) |
| `clojure -M:test` (implementation/routing, dev posture) | **exit 0** — 522 tests, 2,926 assertions, 0 failures / 0 errors |
| `clojure -J-Dre-frame.debug=false -M:test` (whole suite, real gate) | exit 1 — 95 failures / **0 errors**, every one inside the 2 namespaces still rostered (was 293 failures / 9 errors across 19 before #7148) |

**Dev-posture proof that nothing was lost.** For the two namespaces this PR touches, measured by checking out `origin/main`'s copies, running, restoring, and running again: **228 → 248 assertions (+20).** Across both PRs the whole routing dev suite went **2,843 → 2,926 (+83)**, with test count unchanged at 522 — every posture-guarded assertion still runs in dev, and the surplus is the production witnesses added on top.

The gate was run REAL both ways — `bash scripts/test-routing-prod-gate.sh` and `clojure -J-Dre-frame.debug=false -M:test` — never a `with-redefs` rebind, which cannot reach a load-time gate.

**Deferred to CI**: the full JVM implementation sweep (`scripts/test-jvm-implementation.sh`), the CLJS substrate suites (`npm run test:cljs`), and `scripts/test-fast-pr.sh`. This PR touches only two files under `implementation/routing/test/**` plus the roster and floor of `scripts/test-routing-prod-gate.sh`; no `implementation/**/src` and no spec.

Fences respected: nothing under `implementation/ssr/**`, `scripts/test-ssr-prod-gate.sh`, `implementation/freehand/**`, `implementation/core/**`, `tools/**`, `.github/**` or `spec/**` was touched.
