### PR TITLE
bench,studio(freehand): allocation under update, the re-taken broad row, and two recorded decisions (rf2-lcsjg, rf2-huhno, rf2-g88fx, rf2-dkcor)

### DIFF
--- a/docs/design/freehand/studio/bulk-rerender-where-the-time-goes.md
+++ b/docs/design/freehand/studio/bulk-rerender-where-the-time-goes.md
@@ -276,6 +276,20 @@ code. Each is filed as its own bead.
    the deficit and the least tractable of the three, because each hook is
    named in the shell's contract.
 
+   **Decision, 2026-07-27 (`rf2-dkcor`): the contract stands and this is
+   not taken.** Every one of those six hooks is named normatively in
+   `spec/006-ReactiveSubstrate.md` §The Freehand atomic shell and in
+   `shell.cljs` — one `useSyncExternalStore` per view so N moving targets
+   settle in one pass, the reconcile effect publishing each render's
+   bundle, the lifecycle effect owning connect/disconnect. Removing one
+   means weakening a stated guarantee, and the arithmetic does not
+   justify it: §6's re-take puts the total at 4.8 ms against Reagent's
+   ≈0.8, so the deficit is now ≈4.0 ms and the ablation's 0.9 ms is
+   **≈22%** of it rather than 25% — *assuming the constant itself is
+   unchanged, which has not been re-measured*. Twenty-two percent does
+   not close a 10× gap, and it is the smallest of the three levers while
+   being the only one that costs a contract. Recorded, not actioned.
+
 Not on this list: the interpreted markup walk. `react/emit` is 0.47 ms of
 4.05 — even a 30% cut is 4% of the deficit. #7077 already took 26% out of
 that walk on the mount path; the update row is not where it lives.

--- a/docs/design/freehand/studio/bulk-rerender-where-the-time-goes.md
+++ b/docs/design/freehand/studio/bulk-rerender-where-the-time-goes.md
@@ -290,6 +290,97 @@ should be re-taken once #7133 lands.
 
 ---
 
+## 6. The re-take, 2026-07-27 — the window moved (`rf2-huhno`)
+
+#7133 has landed, and so have two changes that pull the other way:
+`rf2-wxrrp` (`e5cf299fc2`, *fold the commit-side read, the tear check and
+the bundle into one pass*) and `rf2-40kdm` (#7147, *split the render
+candidate's ledger into two fields*). Re-taken against `main` at
+`7c41225b4b`, which carries all three. Same instrument, same window, same
+`--writes 500`, three rounds.
+
+**The headline is not the totals. It is that the window RESTRUCTURED.**
+
+| leg, p50 ms | §1 (pre-#7133) | re-take | |
+|---|---:|---:|---|
+| **total** | **4.0** [3.9–4.5] | **4.8** [4.6–4.9] | **+20%**, disjoint |
+| write | 0.7–0.8 | 0.9–1.0 | +25% |
+| **gap** (the microtask) | **~0.2** | **3.6–3.9** | **×18** |
+| **force** (the empty `flushSync`) | **3.0–3.5** | **~0.0** | **collapsed** |
+
+**Freehand's render has moved out of the measured `flushSync` and into
+the microtask before it.** The empty `react-dom/flushSync` that used to
+carry 3.0–3.5 ms now costs 0.0 — by the time it runs there is nothing
+left to do, because #7133's flush already committed. Nothing has
+disappeared; the same work is in the gap.
+
+That matters beyond bookkeeping. §1's table and `b6-rows`' own commentary
+both treat `:gap-ms` as a near-empty constant priced by the floor and
+Reagent arms reporting `0.0`. **For Freehand that is no longer true**,
+and a reader who takes the force leg as "Freehand's React time" will now
+read 0.0 and conclude the substrate became free.
+
+### The phase shares, same capture method
+
+One 500-write capture, shares converted at the capture's own wall ÷
+writes. Idle 0.07%, GC 1.92%.
+
+| | §2 (pre-#7133) | re-take |
+|---|---:|---:|
+| capture wall ÷ writes | 4.055 ms | 5.148 ms |
+| React **render** (`Kh`) | 37.70% → 1.53 ms | 39.44% → **2.03 ms** |
+| React **commit** layout effects (`Wk`) | 30.48% → 1.23 ms | 26.77% → **1.38 ms** |
+
+The commit phase's *share* fell (30.48% → 26.77%) while its *milliseconds*
+rose (1.23 → 1.38). Both are true and the second is the one to quote: the
+share fell only because the window around it grew. **#7133's extra commit
+pass is visible and it costs about 0.15 ms**, which is roughly what an
+extra pass over the tree should cost and is not the +0.8 ms the total
+moved.
+
+### The published interleaved row, and the ratio that did not move
+
+`b6_prod_run.cjs`, six rounds, arms interleaved at the sample level.
+**0 unverified writes.**
+
+| broad update | published | re-take |
+|---|---:|---:|
+| Freehand interpreted, p50 | 5.4–7.4 ms | 6.9–9.0 ms |
+| Reagent, p50 | — | 0.7–0.9 ms |
+| floor, p50 | — | 0.2–0.3 ms |
+| **Freehand ÷ Reagent** | **10.5×** | **9.9×** |
+
+**The ratio is unchanged within this suite's noise — 10.5× against 9.9×
+— and the absolute got worse.** The operator's standard is a comparison,
+so the conclusion of this page stands exactly as written: the broad
+update is ≈10× Reagent and it is architectural.
+
+Note the `:ratio-to-floor` column is not quoted, and deliberately. The
+broad floor's p50 is 0.2–0.3 ms — two or three of Chrome's 100 µs
+quanta — so the published ratio steps ±33% between rounds and reads
+33.44 [25.67–45.00] for a quantity the direct p50s put at ≈30. The
+Freehand ÷ Reagent ratio above is taken from the p50s directly, which is
+the sharp instrument at this scale.
+
+### What the re-take does NOT settle
+
+`rf2-huhno` also asked whether the row should be re-taken **without** the
+microtask yield, on the reasoning that #7133 gives Freehand a synchronous
+commit and the yield is now historical. **The measurement says the yield
+is still load-bearing for this window, and dropping it is not the
+tightening it sounds like:** the 3.6–3.9 ms now in the gap is Freehand's
+notification and React's render and commit *running inside that
+microtask*. Remove the yield and the work does not vanish — it either
+moves into the `flushSync` or, if the notification has not yet fired,
+lands after the measured window and the DOM read-back fails, which is the
+exact fault `b6-rows` records from the first attempt at this row.
+
+Deciding it needs the non-vacuity check `rf2-0fgth` added, run against a
+yield-free window. Filed as `rf2-vxfjt`; it is a change to the published
+window and does not belong in a re-take.
+
+---
+
 ## Appendix: the W1 interpreted-mount discrepancy, resolved
 
 Two numbers for "interpreted Freehand's W1 mount" were 57% apart and both

--- a/docs/design/freehand/studio/freehand-vs-reagent-allocation.md
+++ b/docs/design/freehand/studio/freehand-vs-reagent-allocation.md
@@ -1,0 +1,372 @@
+# What does a WRITE cost in bytes, on Freehand and on Reagent?
+
+Seat: EVIDENCE SPIKE. Bead `rf2-lcsjg`.
+
+Measured 2026-07-27 against `main` at `7c666f3996`. Reagent **2.0.1**,
+React **19.2.0**, headless Chromium 147 via Playwright, `:advanced` with
+`goog.DEBUG false` — the artefact a consumer ships. Windows 11
+workstation with other agents running concurrently.
+
+**Only the interpreted tier is measured.** The compiled tier is ruled out
+and no compiled arm appears here.
+
+[`freehand-vs-reagent-memory.md`](freehand-vs-reagent-memory.md) settled
+retained heap and Freehand lost it: **2,430 bytes per sub-free boundary
+against Reagent's 410 and UIx's 251**, ranges disjoint, and widest on the
+witness with no reactivity at all — so it is the ViewCell wrapper itself.
+That page closes by naming the one memory question it could not answer:
+
+> Nothing here measures heap *under* update, and a substrate can trade
+> standing bytes for churn — Freehand's fine-grained path might allocate
+> less per write than Reagent's, and this instrument cannot see it. That
+> is the obvious next measurement, and it is now the only memory question
+> with an argument left in it for Freehand.
+
+This page runs that measurement.
+
+---
+
+## The answer, first
+
+**Freehand does not win here either.** On every arm and both write
+shapes it allocates more than Reagent, with disjoint ranges. The
+hypothesis that a fine-grained substrate trades standing bytes for lower
+churn is **falsified on this witness**.
+
+But the two write shapes say very different things, and the second is
+the one worth reading twice.
+
+1. **The broad write — 300 cells change.** Freehand allocates **4,572,680
+   bytes** against Reagent's **269,229** and a bare React floor's
+   **144,039**: **17.0×** Reagent overall, **13.5×** on the view leg
+   alone. Ranges disjoint. **But that view-leg figure is an UPPER BOUND
+   on the substrate difference, not the substrate difference** — see
+   [§3](#3-the-figure-that-is-an-upper-bound-not-a-result).
+
+2. **The narrow write — one cell changes — is where Freehand comes
+   closest to parity of anything measured in this studio.** Strip the
+   re-frame write leg and Freehand's view substrate allocates **21,376
+   bytes against Reagent's 19,307** — **1.107×** [worst case 1.082],
+   disjoint but within eleven percent. And both are about **seven times
+   better than the top-down React floor's 139,461 B**. Fine-grained
+   reactivity is doing exactly what it claims on this shape. Freehand
+   simply does not do it *better* than Reagent does.
+
+3. **The narrow write's headline 20.2× is almost entirely re-frame, not
+   Freehand.** Of Freehand's 478,787 bytes for changing one cell,
+   **457,181 — 95.5% — is the write leg**: `frame/replace-app-db!` and a
+   subscription graph re-evaluating all 300 `:b6/cell` subscriptions to
+   discover that 299 of them did not change. The view substrate's share
+   is 21,376. A Reagent application built on re-frame subscriptions would
+   pay that write leg too; this one resets a bare `reagent.core/atom` and
+   pays 4,018.
+
+So the honest summary is that **memory is not a rescue on either axis**,
+and that the one number in this page that flatters Freehand — the narrow
+view leg at 1.107× — is a near-tie rather than a win.
+
+---
+
+## Method, and the instrument that had to be built third
+
+Three instruments now exist on this surface and each answers a different
+question. Getting the wrong one is how two published tables went wrong.
+
+| | instrument | sees |
+|---|---|---|
+| **B7** | retention: mount, collect, read | what a boundary KEEPS |
+| **B7 (rejected)** | CDP *sampling* heap profiler | what SURVIVED — useless for churn |
+| **B8, here** | a window with no collection in it | what a write ALLOCATES, garbage included |
+
+**The method in one sentence.** If no garbage collection runs between two
+readings of V8's used-heap counter, the difference between them is the
+number of bytes allocated in between — **including every byte already
+unreachable**, because nothing has reclaimed it yet. Garbage is visible
+precisely because it has not been collected.
+
+**Every adjacent pair of readings is one STEP.** The counter is sampled
+at every leg boundary of every write. Rising steps accumulate to an
+allocation total; falling steps are collections and accumulate
+separately, so a collection is *excluded* from the total rather than
+netted against it. Where nothing fell, the rising-step sum, the endpoint
+difference and the driver's independent CDP bracket are three ways of
+computing one number.
+
+**Windows are sized per arm, and that mattered.** The arms differ by
+three orders of magnitude in what they allocate — the empty-harness arm
+438 B a write, Freehand's broad write four and a half megabytes — so one
+write count cannot suit them all. A first run used 25 writes for
+everything: comfortably collection-free for Reagent, and a dozen
+collections for Freehand, whose windows were then all discarded by the
+gate. That is a selection effect that would have produced a table with no
+Freehand row in it. Each arm now gets a calibration probe and the number
+of writes that fits its own allocation into one nursery — Freehand's
+broad window is **2 writes**, Reagent's narrow window is **40**.
+
+**Only collection-free windows are quoted.** Every figure in this page
+comes from a window in which the counter never fell. Windows with a
+collection in them are retained in the raw data and excluded from the
+tables.
+
+### The controls, and all five fired
+
+- **The bookkeeping identity, exact.** Rising steps plus falling steps
+  must equal the last reading minus the first, in every window, by
+  construction. **120 of 120 mirror windows exact, residual 0 bytes.**
+
+- **THE DECISIVE ONE — can the counter see garbage as well as it sees
+  survivors?** This is the question that broke the sampler, and an
+  instrument that fails it is a retention instrument wearing a different
+  name. So the identical loop was run twice on the empty-harness arm at
+  the same control size, with one difference: whether each control copy
+  is kept or dropped.
+
+  | | allocated per copy | retained per copy afterwards |
+  |---|---:|---:|
+  | copies **dropped** | 125,121 B | **11 B** |
+  | copies **kept** | 125,139 B | **99,417 B** |
+  | **kept ÷ dropped** | **1.0001** | |
+
+  The counter reports the same bytes to within **0.01%** whether the
+  object survives or is thrown away. **It does not care.** That is the
+  claim this whole page rests on, demonstrated rather than asserted.
+
+- **The positive control, predicted and then corrected by measurement.**
+  The control allocates one `.slice()` copy of a prebuilt array of 12,500
+  doubles per write and drops it. **Predicted 8 bytes a double —
+  100,000 B — and that prediction was WRONG.** Priced independently by
+  retention on the same object it reads **16.002 B/double (200,029 B a
+  copy, identical on 20 and 40 copies, residue exactly 0)**, because
+  `.slice()` of a *holey* double array does not take the packed fast path.
+  A third reading — the kept-vs-dropped pass, same counter, same window —
+  puts the copy at 99,417 B retained and 125,139 B allocated, ≈8 and ≈10
+  B/double, so the *construction* differs between the two call sites and
+  the two references are not the same object.
+
+  > This is B7's lesson repeating one bead later. Its own control was a
+  > 4.7 MB `'x'.repeat(n)` string that read as six kilobytes, and the
+  > instrument was fine — the control was a fiction. Here the arithmetic
+  > was again the fiction. **The finding is that a predicted size is a
+  > hypothesis, not a calibration**, and the only reason it was caught is
+  > that the same object was priced a second way.
+
+- **The negative control — the tool that would have been used.** The CDP
+  sampling heap profiler, pointed at a window whose garbage content is
+  known and read *after* a forced collection, reports **1,204,640 B where
+  the counter saw 9,253,676** — **13%**. It reports what survived. It is
+  not usable for this question and it is not used.
+
+- **Every write verified at the DOM, inside its own window.** **0
+  unverified of 2,400** on each of the two rows (the empty-harness arm
+  renders no cell and is excluded from the count).
+
+- **The measured window is B6's, and that is a measured claim.** The
+  instrument reads the counter where `b6-rows/timed-write!` reads the
+  clock, which makes it a mirror rather than the published function. So
+  the driver *also* runs the published `timed-write!` verbatim over the
+  same window and brackets it with CDP. **Mirror against published:
+  Freehand +0.4% broad, +0.3% narrow; Reagent −0.3% and +0.2%; the floor
+  +0.3% and −0.9%.** The mirror's five counter reads a write do not
+  disturb what it measures.
+
+- **The harness reads the keys it writes, proved inside the shipped
+  bundle.** See [§4](#4-an-eighth-instrument-fault-class-caught-by-a-crash-that-was-luck).
+
+---
+
+## 1. Bytes allocated per write
+
+Collection-free windows only; mean with the range across windows in
+brackets. The legs are `timed-write!`'s own — the state install, the
+single microtask yield, and the arm's synchronous drain.
+
+**Broad write — all 300 cells change:**
+
+| arm | total B/write | write leg | **view leg** (gap + force) |
+|---|---:|---:|---:|
+| floor — top-down React, no substrate | 144,039 [143,575–144,828] | 2,390 | 141,346 [140,897–142,269] |
+| **Reagent** | 269,229 [266,080–271,279] | 5,952 | **262,954** [259,880–264,811] |
+| **Freehand interpreted** | **4,572,680** [4,526,429–4,607,207] | 1,017,629 | **3,554,871** [3,509,533–3,581,467] |
+
+Freehand ÷ Reagent: **16.98×** on the total, **13.52×** on the view leg
+[worst case for Freehand 13.25×]. Both disjoint.
+
+**Narrow write — one cell changes:**
+
+| arm | total B/write | write leg | **view leg** (gap + force) |
+|---|---:|---:|---:|
+| floor — top-down React re-render | 140,158 [139,349–140,621] | 405 | 139,461 [138,677–139,872] |
+| **Reagent** `r/cursor` | 23,648 [23,526–23,844] | 4,018 | **19,307** [19,295–19,350] |
+| **Freehand interpreted** `v/sub` | 478,787 [474,377–483,475] | 457,181 | **21,376** [20,944–21,859] |
+
+Freehand ÷ Reagent: **20.25×** on the total, **1.107×** on the view leg
+[worst case 1.082×]. Both disjoint.
+
+**The narrow floor is not a lower bound and must not be read as one.**
+B6's update floor is a plain top-down React re-render, so it repaints all
+301 elements to change one — 139,461 B where Reagent spends 19,307 and
+Freehand 21,376. Both fine-grained substrates are ≈7× *better* than the
+floor here, which is the entire point of fine-grained reactivity and is
+the one place in this studio where the mechanism visibly pays.
+Subtracting this floor would produce a negative number for Reagent, which
+is why the narrow row is quoted absolute.
+
+---
+
+## 2. Where Freehand's broad write puts its bytes
+
+Freehand's broad write allocates 4.57 MB. It divides:
+
+| leg | B/write | share | what it is |
+|---|---:|---:|---|
+| write | 1,017,629 | 22.3% | `frame/replace-app-db!` and the signal graph |
+| **gap** | **3,554,823** | **77.7%** | the microtask — Freehand's notification, and React's render and commit |
+| force | 48 | 0.0% | the empty `flushSync`, which finds nothing left to do |
+
+**Read the last row.** Freehand's synchronous drain allocates
+48 bytes because by the time it runs, everything has already happened in
+the microtask. Reagent is the mirror image: its gap is 212 B and its
+`r/flush` inside `flushSync` carries 262,742. A table that reported only
+"write leg" and "force leg" — the two legs the clock report names — would
+have shown Freehand allocating almost nothing for its render and been
+completely wrong. The legs are not comparable arm-to-arm; only their sum
+is.
+
+This also corroborates the clock report's account of the broad update
+from an instrument that shares no code with it.
+[`bulk-rerender-where-the-time-goes.md`](bulk-rerender-where-the-time-goes.md)
+concluded the deficit is *"allocation churn spread thin across a lot of
+bookkeeping"* — a profile inference it explicitly declined to call a
+memory measurement:
+
+> **No memory claim.** The allocation reading the profile implies — that
+> this is churn — is not a heap measurement and is not offered as one.
+
+It is now a heap measurement, and the inference was right.
+
+---
+
+## 3. The figure that is an upper bound, not a result
+
+**The 13.5× broad view-leg ratio overstates the substrate difference, and
+this page will not quote it as a substrate result.**
+
+The two arms do not carry the same framework. Freehand's grid reads 300
+`v/sub` subscriptions through re-frame's subscription graph; the Reagent
+grid reads 300 `r/cursor` derefs on a bare `reagent.core/atom`. That is
+each substrate's own idiom — it is what B6 measures and why its rows are
+comparable to each other — but it is *not* the same amount of machinery,
+and `freehand-vs-reagent.md` §2a has used exactly this to cut an earlier
+result from 15× to roughly parity.
+
+It matters more here than it did there. `rf2-40kdm` (PR #7151) measured
+the read path directly and found that **an idiomatic Reagent view body
+reading `@(subscribe q)` pays 95.3–97.4% of what Freehand's port pays**
+per read. Nearly all of the per-read render allocation is *shared
+reactive-system cost*, not substrate cost. Freehand's arm pays it 300
+times a broad write; this Reagent arm pays none of it.
+
+So the broad view-leg gap is **an upper bound that contains an unknown
+but large amount of re-frame**. Closing it needs a third arm — Reagent
+mounted on re-frame subscriptions — which B6 does not have. Filed as
+`rf2-mapni`.
+
+**The narrow row is much less exposed to this**, and that is why it
+carries the more trustworthy substrate reading: a narrow write re-renders
+one boundary, so each arm performs one read rather than three hundred and
+the shared term is small in absolute bytes. **1.107× is the closest thing
+to a like-for-like view-substrate comparison in this page.**
+
+---
+
+## 4. An eighth instrument fault class, caught by a crash that was luck
+
+The first draft of this harness used `#js {:h …}` literals with `(.-h o)`
+accessors. Under `:advanced`, Closure renames the accessor and not the
+literal key:
+
+```
+construction   return {h:[f,g,k,l,p], ok:…}
+read           var l = k.Me, p = l[0]
+```
+
+`k.Me` is `undefined`, `undefined[0]` throws, and that is the only reason
+it was found. **In the same build, three other keys were renamed and none
+of them would have thrown.** `(.-bad a)` became `e.Mc` and
+`(.-decreases a)` became `e.fc`, while their literal keys stayed `bad`
+and `decreases`. `undefined + 1` is `NaN`, the literals' zeros would have
+stood untouched, and the driver would have read **zero unverified writes,
+always** — and for `decreases`, which is the gate that rejects a window
+with a collection in it, **a constant zero: every truncated window
+accepted and averaged in.**
+
+The keys that survived did so by accident. `ok`, `control`, `write`,
+`gap`, `force`, `total`, `first` and `last` all appear in Closure's
+browser externs — `Response.ok`, `Touch.force`, `document.write`, CSS
+`gap` — and Closure will not rename a name it finds there. `h`, `bad`,
+`decreases` and `worstDrop` do not appear, so they were renamed.
+
+Every boundary name is now a string literal through `js-obj` /
+`goog.object`, which compiles to a dynamic index and is never renamed.
+And because "it looks right" is what failed, `integrity-probe` writes
+known values through the measured path's own accessors and reads them
+back **inside the shipped `:advanced` bundle**; the driver refuses to
+measure until it passes. This is a general hazard for any measurement
+harness in this repository, not a B8 quirk.
+
+---
+
+## 5. What this does not cover
+
+- **The broad view-leg ratio is an upper bound**, not a substrate result.
+  §3 says why, and `rf2-mapni` is the arm that would close it.
+- **Absolute bytes are this counter's, not a second opinion.** Every
+  figure comes from V8's used-heap counter; the CDP bracket and the
+  in-page reading are two doors onto it and agree to 2.3% worst case, but
+  they are not independent of each other. The kept-vs-dropped test
+  establishes that the counter does not discriminate against garbage; it
+  does not establish that its absolute scale matches a heap snapshot's.
+  **Ratios between arms are read by one instrument in one window and are
+  unaffected by any common scale.**
+- **One fixture, two write shapes.** B6's 300-cell grid, held to the
+  published window. Nothing here is a real application, and a page whose
+  boundaries are not all subscribed to one changing key will behave
+  differently.
+- **No mount.** This is the update path only. Mount allocation is
+  unmeasured.
+- **No GC-pause claim.** Allocation drives collection frequency, but no
+  pause was timed and none is claimed. That 4.57 MB a broad write fills a
+  nursery every two writes is visible in the window sizing and nowhere
+  else.
+- **No compiled tier**, and **no UIx** — UIx has no update arm in B6.
+- **The JS heap only.** DOM nodes live in Blink's C++ heap.
+
+---
+
+## Provenance
+
+- Fixture: B6's update grid — 300 reactive cells, 301 elements, one
+  `v/sub` per cell against one `r/cursor` per cell; broad write = one
+  `frame/replace-app-db!` every cell reads, narrow = one cell.
+- Window: `b6-rows/timed-write!`'s legs, mirrored so the counter is read
+  where the clock is, and cross-checked against the published function
+  run verbatim in the same driver (agreement ≤0.9% on every arm).
+- Sampling: 6 rounds, arm order rotating with the round, per-arm window
+  sizing from a calibration probe, one un-read warm-up window per cell.
+  Collection-free windows only.
+- Gates green before any figure was read: bookkeeping identity exact in
+  120/120 windows; kept÷dropped 1.0001; DOM read-back 0 unverified of
+  2,400 per row; harness integrity probe passing inside the `:advanced`
+  bundle; sampling profiler negative control at 13%.
+- Build: `:advanced`, `goog.DEBUG false`, via `--config-merge` on the
+  existing `:freehand-release` build id. `implementation/shadow-cljs.edn`
+  is unchanged. Chromium launched with `--enable-precise-memory-info`
+  (asserted at runtime) and an enlarged nursery.
+- Source:
+  `implementation/freehand/test/re_frame/freehand/bench/b8_alloc.cljs`
+  (the instrument and the controls), `b8_app.cljs` (the `:advanced`
+  entry), `b8_run.cjs` (the driver, the window sizing and the four
+  controls).
+- Raw data: `ai/findings/2026-07-27.b8-alloc-under-update.json`.
+- Reproduce:
+  `node implementation/freehand/test/re_frame/freehand/bench/b8_run.cjs`.

--- a/docs/design/freehand/studio/freehand-vs-reagent.md
+++ b/docs/design/freehand/studio/freehand-vs-reagent.md
@@ -216,6 +216,19 @@ separable from each other.
 > reproduced on a later day against current `main`, Reagent W1 at 1.545
 > [1.471–1.647] against the 1.554 above. Detail in
 > [`freehand-vs-reagent-memory.md`](freehand-vs-reagent-memory.md) §3.
+>
+> **The row is therefore ~4% generous to Freehand on W1, and the table
+> keeps it** (`rf2-g88fx`). Every real application binds a frame; this arm
+> passes only a `:disambiguator`, so it prices the cheapest mount shape
+> rather than the shipped one. Re-taken on `main` at `7c41225b4b` on
+> 2026-07-27 the published arm reads **3.056 × floor** [2.931–3.226]
+> against Reagent's **1.588** [1.500–1.742] — **1.92× Reagent**. Applying
+> the measured ×1.038 puts the shape an application actually ships at
+> **≈2.00× Reagent**. That is the number to quote for a consumer, and it
+> is the same conclusion: interpreted mount is about twice Reagent.
+> Changing the arm was rejected because the correction is smaller than
+> the row's own round-to-round spread and re-basing a release-gate row
+> costs more than the third digit it buys.
 
 **And in milliseconds, because a ratio on a sub-millisecond operation is
 not a product decision** (p50, round 4 of six — the same round §2a

--- a/implementation/freehand/test/re_frame/freehand/bench/b8_alloc.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b8_alloc.cljs
@@ -31,12 +31,28 @@
   visible precisely because it has not been collected.
 
   So a reading is: force a full collection; read; run N writes; read.
-  The whole method rests on the middle step containing no collection, so
-  that is not assumed — it is **detected and the window is rejected**.
-  The used-heap counter is sampled at every leg boundary of every write
-  into a preallocated buffer, and a counter that only ever rises is a
-  window in which nothing was reclaimed. One decrease anywhere and the
-  window is thrown away rather than averaged in.
+  The counter is sampled at every leg boundary of every write, and every
+  adjacent pair is one STEP — rising steps are allocation, falling steps
+  are collections, and the two are accumulated SEPARATELY. The published
+  figure is the sum of the rising steps, which is an allocation total
+  whether or not a collection intervened, because a collection is
+  excluded from it rather than netted against it.
+
+  A window in which nothing fell is one in which nothing was reclaimed,
+  and there the rising-step sum, the difference of the endpoints and the
+  driver's CDP bracket are three ways of computing one number. They must
+  agree, and the driver reports the worst disagreement. That identity is
+  the instrument's consistency check; those windows are the validation
+  set, not the whole sample.
+
+  Where a collection did land, the rising-step sum is a slight
+  UNDER-estimate — the allocation between the last reading before the
+  collection and the collection itself is netted away inside that single
+  step. The bias is one-directional, bounded by one leg per collection,
+  and the collection count is published beside every figure. This
+  matters most for Freehand, which allocates enough per write to provoke
+  collections the other arms do not, so the bias runs in Freehand's
+  FAVOUR and any deficit reported here is a floor on the real one.
 
   ## The positive control is a piece of garbage of predicted size
 
@@ -134,6 +150,7 @@
 
 (defn- fresh-acc []
   (js-obj "control" 0 "write" 0 "gap" 0 "force" 0 "total" 0
+          "posSum" 0 "negSum" 0
           "bad" 0 "decreases" 0 "worstDrop" 0 "first" 0 "last" 0))
 
 (defn integrity-probe
@@ -262,23 +279,44 @@
                                                    (= (str val)
                                                       (rows/cell-text
                                                         container
-                                                        (dec rows/cells-n)))))))))))))))
+                                                        (dec rows/cells-n))))))))))))))))
 
 (defn run-window!
-  "N writes over one arm, inside one collection-free window.
+  "N writes over one arm, with the counter read at every leg boundary.
 
   Answers a promise of the accumulated legs, the count of writes whose
-  DOM read-back failed, and — the gate — the number of places where the
-  used-heap counter went DOWN. A window with any decrease had a
-  collection in it and is not a measurement of allocation; the driver
-  drops it."
+  DOM read-back failed, and the two quantities that make the reading
+  robust to a collection landing inside the window:
+
+  `posSum` — the sum of the RISING steps, which is an allocation total
+  whether or not a collection intervened, because a collection is a
+  falling step and is excluded from it rather than netted against it.
+
+  `decreases` / `negSum` / `worstDrop` — the collections themselves.
+  A window with `decreases` zero is one in which nothing was reclaimed,
+  and there `posSum` and the endpoint difference are the SAME NUMBER by
+  construction. That identity is the instrument's own consistency check
+  and the driver reports it.
+
+  Where a collection did land, `posSum` is a slight UNDER-estimate: the
+  allocation between the last reading before the collection and the
+  collection itself is netted away inside that one step. The bias is
+  one-directional, bounded by one leg per collection, and reported."
   [mnt kind n]
   (let [acc  (fresh-acc)
         prev (volatile! nil)
-        drop! (fn [a x y]
-                (when (< y x)
-                  (bump! a "decreases" 1)
-                  (gobj/set a "worstDrop" (min (gobj/get a "worstDrop") (- y x)))))]
+        ;; Every adjacent pair of readings is one STEP. A step that rises
+        ;; is allocation; a step that falls is a collection, and the two
+        ;; are accumulated separately. `posSum` is therefore an allocation
+        ;; total that survives a collection landing inside the window,
+        ;; where the endpoint difference does not.
+        step! (fn [a x y]
+                (let [d (- y x)]
+                  (if (neg? d)
+                    (do (bump! a "decreases" 1)
+                        (bump! a "negSum" d)
+                        (gobj/set a "worstDrop" (min (gobj/get a "worstDrop") d)))
+                    (bump! a "posSum" d))))]
     (rows/chain acc (range n)
       (fn [a _]
         (let [val (rows/next-gen!)
@@ -291,9 +329,9 @@
                          ;; Decreases are counted across the WHOLE window,
                          ;; including the seam between one write's last
                          ;; reading and the next write's first.
-                         (when-some [p @prev] (drop! a p h0))
-                         (drop! a h0 hc) (drop! a hc h1)
-                         (drop! a h1 h2) (drop! a h2 h3)
+                         (when-some [p @prev] (step! a p h0))
+                         (step! a h0 hc) (step! a hc h1)
+                         (step! a h1 h2) (step! a h2 h3)
                          (when (nil? @prev) (gobj/set a "first" h0))
                          (vreset! prev h3)
                          (gobj/set a "last" h3)

--- a/implementation/freehand/test/re_frame/freehand/bench/b8_alloc.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b8_alloc.cljs
@@ -203,6 +203,33 @@
 
 (defonce ^:private ctl-template (volatile! nil))
 (defonce ^:private ctl-sink (volatile! 0.0))
+(defonce ^:private ctl-held (volatile! nil))
+
+(defn control-hold!
+  "Hold `k` copies of the control object so the driver can price ONE of
+  them by RETENTION — mount, collect, read — which is B7's instrument and
+  is proven on this surface to 0.17% against a predicted size.
+
+  This exists because the allocation instrument and the prediction
+  disagreed. `8·D` assumed `.slice()` of a double array costs one 8-byte
+  slot per element and nothing else; the measured slope came back at
+  12.06 B/double, twice, in independent runs — a stable, linear,
+  reproducible number that is simply not 8.
+
+  Either the instrument is wrong or the arithmetic is, and a control
+  whose size is asserted rather than checked cannot tell you which. B7's
+  own control failed exactly this way: a 4.7 MB `'x'.repeat(n)` string
+  read as six kilobytes on all three readers, and the instrument was
+  fine. So the object is priced by an instrument that is already trusted,
+  and the two readings are published side by side."
+  [k]
+  (vreset! ctl-held
+           (when (pos? k)
+             (let [a (js/Array. k)]
+               (dotimes [i k] (aset a i (.slice @ctl-template)))
+               a))))
+
+(defn control-release! [] (vreset! ctl-held nil))
 
 (defn control-prepare!
   "Build the template ONCE, outside every window. `js/Array` + `fill`
@@ -310,13 +337,21 @@
         ;; are accumulated separately. `posSum` is therefore an allocation
         ;; total that survives a collection landing inside the window,
         ;; where the endpoint difference does not.
-        step! (fn [a x y]
+        ;; `leg` is nil for the seam between one write and the next, which
+        ;; belongs to no leg but must still be counted in the window total.
+        step! (fn [a leg x y]
                 (let [d (- y x)]
                   (if (neg? d)
                     (do (bump! a "decreases" 1)
                         (bump! a "negSum" d)
                         (gobj/set a "worstDrop" (min (gobj/get a "worstDrop") d)))
-                    (bump! a "posSum" d))))]
+                    (do (bump! a "posSum" d)
+                        ;; Legs accumulate RISING steps only, for the same
+                        ;; reason the window total does: a collection landing
+                        ;; inside a leg would otherwise net against that leg's
+                        ;; allocation and attribute the loss to whichever leg
+                        ;; happened to contain it.
+                        (when leg (bump! a leg d))))))]
     (rows/chain acc (range n)
       (fn [a _]
         (let [val (rows/next-gen!)
@@ -329,17 +364,15 @@
                          ;; Decreases are counted across the WHOLE window,
                          ;; including the seam between one write's last
                          ;; reading and the next write's first.
-                         (when-some [p @prev] (step! a p h0))
-                         (step! a h0 hc) (step! a hc h1)
-                         (step! a h1 h2) (step! a h2 h3)
+                         (when-some [p @prev] (step! a nil p h0))
+                         (step! a "control" h0 hc)
+                         (step! a "write"   hc h1)
+                         (step! a "gap"     h1 h2)
+                         (step! a "force"   h2 h3)
                          (when (nil? @prev) (gobj/set a "first" h0))
                          (vreset! prev h3)
                          (gobj/set a "last" h3)
-                         (bump! a "control" (- hc h0))
-                         (bump! a "write"   (- h1 hc))
-                         (bump! a "gap"     (- h2 h1))
-                         (bump! a "force"   (- h3 h2))
-                         (bump! a "total"   (- h3 h0))
+                         (bump! a "total" (- h3 h0))
                          (when-not (gobj/get r "ok") (bump! a "bad" 1))
                          a)))))))))
 

--- a/implementation/freehand/test/re_frame/freehand/bench/b8_alloc.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b8_alloc.cljs
@@ -239,8 +239,36 @@
   (vreset! ctl-template (when (pos? d) (.fill (js/Array. d) 0.5)))
   (vreset! ctl-sink 0.0))
 
+(defonce ^:private ctl-keep (volatile! nil))
+
+(defn control-keep!
+  "Switch the control between DROPPING each copy and KEEPING it.
+
+  This is the instrument's decisive self-test and the reason it exists.
+  The allocation instrument and the retention instrument disagree about
+  the same object — allocation reads about 12 B/double where retention
+  reads 16.00 — and there are two possible explanations with opposite
+  consequences:
+
+  either the used-heap counter reads ALL allocation at a scale of its own
+  (in which case absolute figures need that scale and ratios between arms
+  are untouched), or it reads DROPPED objects less completely than kept
+  ones (in which case it is partly a retention instrument too, which is
+  the exact fault that disqualified the sampler and would disqualify this).
+
+  Running the identical loop with the copies kept and with them dropped
+  separates the two. If both read the same per copy, the counter does not
+  care whether an object survives and the discrepancy is a scale. If
+  keeping reads higher, transient garbage is partly invisible and no
+  allocation figure here may be quoted as absolute."
+  [keep?]
+  (vreset! ctl-keep (when keep? (array))))
+
+(defn control-kept-count [] (if-some [k @ctl-keep] (alength k) 0))
+
 (defn control-alloc!
-  "Allocate 8·D bytes of immediate garbage.
+  "Allocate one control copy — a piece of garbage whose size the retention
+  pass measures independently.
 
   The slot read into a live sink is not decoration: Closure is entitled
   to delete an expression whose value nothing reads, and this surface has
@@ -250,7 +278,8 @@
   []
   (when-some [t @ctl-template]
     (let [c (.slice t)]
-      (vreset! ctl-sink (+ @ctl-sink (aget c 0))))))
+      (vreset! ctl-sink (+ @ctl-sink (aget c 0)))
+      (when-some [k @ctl-keep] (.push k c)))))
 
 ;; ---------------------------------------------------------------------------
 ;; Arms

--- a/implementation/freehand/test/re_frame/freehand/bench/b8_alloc.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b8_alloc.cljs
@@ -87,7 +87,75 @@
 
   Normative owner: `docs/design/freehand/decisions/`
   `D021-performance-budgets-and-release-evidence.md`."
-  (:require [re-frame.freehand.bench.b6-rows :as rows]))
+  (:require [goog.object :as gobj]
+            [re-frame.freehand.bench.b6-rows :as rows]))
+
+;; ---------------------------------------------------------------------------
+;; Why every property below is a STRING LITERAL through `goog.object`
+;; ---------------------------------------------------------------------------
+;;
+;; The first draft of this namespace used `#js {:h …}` literals and
+;; `(.-h o)` accessors, and under `:advanced` it produced this:
+;;
+;;     construction   return {h:[f,g,k,l,p], ok:…}
+;;     read           var l = k.Me, p = l[0]
+;;
+;; `(.-h r)` was renamed to `Me`; the literal key was not. `k.Me` is
+;; `undefined` and `undefined[0]` throws, which is how it was caught.
+;;
+;; THE CRASH WAS LUCK, AND THAT IS THE POINT. In the same build:
+;;
+;;     (.-decreases a) -> e.fc      literal key `decreases`
+;;     (.-worstDrop a) -> e.oc      literal key `worstDrop`
+;;     (.-bad a)       -> e.Mc      literal key `bad`
+;;     (.-control a)   -> e.control literal key `control`   (survived)
+;;     (.-ok r)        -> k.ok      literal key `ok`        (survived)
+;;
+;; The survivors survived by ACCIDENT: `ok`, `control`, `write`, `gap`,
+;; `force`, `total`, `first` and `last` all appear in Closure's browser
+;; externs (`Response.ok`, `Touch.force`, `document.write`, CSS `gap`, …)
+;; and Closure will not rename a name it finds there. `h`, `decreases`,
+;; `worstDrop` and `bad` do not, so they were renamed.
+;;
+;; None of the survivors would have thrown. `e.Mc += 1` on an undefined
+;; slot yields `NaN` and leaves the literal's `bad: 0` untouched, so the
+;; driver would have read **zero unverified writes, always**. `decreases`
+;; is worse: it is the GATE that rejects a window with a collection in
+;; it, and it would have read a constant zero — every window accepted,
+;; including the ones whose totals a collection had silently truncated.
+;;
+;; That is a plausible wrong number produced by a harness that looks
+;; green, which is the failure mode this whole surface exists to avoid.
+;; So: string literals through `goog.object`, which compile to a dynamic
+;; index and are never renamed — and [[integrity-probe]], which proves it
+;; from inside the shipped bundle before any figure is taken.
+
+(defn- bump! [o k v] (gobj/set o k (+ (gobj/get o k) v)))
+
+(defn- fresh-acc []
+  (js-obj "control" 0 "write" 0 "gap" 0 "force" 0 "total" 0
+          "bad" 0 "decreases" 0 "worstDrop" 0 "first" 0 "last" 0))
+
+(defn integrity-probe
+  "Prove, inside the `:advanced` bundle, that this namespace reads the
+  keys it writes.
+
+  Runs before any measurement. Writes known values through exactly the
+  accessors the measured path uses and hands back both the values and
+  the object's own key list, so the driver can assert on names it never
+  sees renamed. A renaming mismatch makes this return `null` or the
+  wrong number, and the driver refuses to measure."
+  []
+  (let [o (fresh-acc)]
+    (bump! o "control" 7)
+    (bump! o "decreases" 3)
+    (bump! o "worstDrop" -11)
+    (bump! o "bad" 5)
+    (js-obj "control"   (gobj/get o "control")
+            "decreases" (gobj/get o "decreases")
+            "worstDrop" (gobj/get o "worstDrop")
+            "bad"       (gobj/get o "bad")
+            "keys"      (.join (js/Object.keys o) ","))))
 
 ;; ---------------------------------------------------------------------------
 ;; The reader
@@ -187,13 +255,14 @@
                        ((:force! arm))
                        (let [h3    (mem)
                              probe (if (= i :all) 0 i)]
-                         #js {:h #js [h0 hc h1 h2 h3]
-                              :ok (or (boolean (:skip-verify? arm))
-                                      (and (= (str val) (rows/cell-text container probe))
-                                           (or (not= i :all)
-                                               (= (str val)
-                                                  (rows/cell-text container
-                                                                  (dec rows/cells-n))))))})))))))))
+                         (js-obj "readings" (array h0 hc h1 h2 h3)
+                                 "ok" (or (boolean (:skip-verify? arm))
+                                          (and (= (str val) (rows/cell-text container probe))
+                                               (or (not= i :all)
+                                                   (= (str val)
+                                                      (rows/cell-text
+                                                        container
+                                                        (dec rows/cells-n)))))))))))))))
 
 (defn run-window!
   "N writes over one arm, inside one collection-free window.
@@ -204,40 +273,36 @@
   collection in it and is not a measurement of allocation; the driver
   drops it."
   [mnt kind n]
-  ;; camelCase deliberately: ClojureScript munges `-` to `_` in `(.-a-b x)`
-  ;; property access, which would silently miss a `#js {:a-b …}` key.
-  (let [acc #js {:control 0 :write 0 :gap 0 :force 0 :total 0
-                 :bad 0 :decreases 0 :worstDrop 0 :first 0 :last 0}
-        prev (volatile! nil)]
+  (let [acc  (fresh-acc)
+        prev (volatile! nil)
+        drop! (fn [a x y]
+                (when (< y x)
+                  (bump! a "decreases" 1)
+                  (gobj/set a "worstDrop" (min (gobj/get a "worstDrop") (- y x)))))]
     (rows/chain acc (range n)
       (fn [a _]
         (let [val (rows/next-gen!)
               i   (if (= kind :broad) :all (mod val rows/cells-n))]
           (-> (alloc-write! mnt i val)
               (.then (fn [r]
-                       (let [h  (.-h r)
+                       (let [h  (gobj/get r "readings")
                              h0 (aget h 0) hc (aget h 1) h1 (aget h 2)
                              h2 (aget h 3) h3 (aget h 4)]
                          ;; Decreases are counted across the WHOLE window,
                          ;; including the seam between one write's last
                          ;; reading and the next write's first.
-                         (when-some [p @prev]
-                           (when (< h0 p)
-                             (set! (.-decreases a) (inc (.-decreases a)))
-                             (set! (.-worstDrop a) (min (.-worstDrop a) (- h0 p)))))
-                         (doseq [[x y] [[h0 hc] [hc h1] [h1 h2] [h2 h3]]]
-                           (when (< y x)
-                             (set! (.-decreases a) (inc (.-decreases a)))
-                             (set! (.-worstDrop a) (min (.-worstDrop a) (- y x)))))
-                         (when (nil? @prev) (set! (.-first a) h0))
+                         (when-some [p @prev] (drop! a p h0))
+                         (drop! a h0 hc) (drop! a hc h1)
+                         (drop! a h1 h2) (drop! a h2 h3)
+                         (when (nil? @prev) (gobj/set a "first" h0))
                          (vreset! prev h3)
-                         (set! (.-last a) h3)
-                         (set! (.-control a) (+ (.-control a) (- hc h0)))
-                         (set! (.-write a) (+ (.-write a) (- h1 hc)))
-                         (set! (.-gap a) (+ (.-gap a) (- h2 h1)))
-                         (set! (.-force a) (+ (.-force a) (- h3 h2)))
-                         (set! (.-total a) (+ (.-total a) (- h3 h0)))
-                         (when-not (.-ok r) (set! (.-bad a) (inc (.-bad a))))
+                         (gobj/set a "last" h3)
+                         (bump! a "control" (- hc h0))
+                         (bump! a "write"   (- h1 hc))
+                         (bump! a "gap"     (- h2 h1))
+                         (bump! a "force"   (- h3 h2))
+                         (bump! a "total"   (- h3 h0))
+                         (when-not (gobj/get r "ok") (bump! a "bad" 1))
                          a)))))))))
 
 (defn run-published-window!
@@ -251,12 +316,13 @@
   and one not reading it at all, must allocate the same bytes to within
   the instrument's own footprint."
   [mnt kind n]
-  (rows/chain #js {:bad 0} (range n)
-    (fn [a _]
-      (let [val (rows/next-gen!)
-            i   (if (= kind :broad) :all (mod val rows/cells-n))]
-        (control-alloc!)
-        (-> (rows/timed-write! mnt i val)
-            (.then (fn [{:keys [ok? ok2?]}]
-                     (when-not (and ok? ok2?) (set! (.-bad a) (inc (.-bad a))))
-                     a)))))))
+  (let [skip? (boolean (:skip-verify? (:arm mnt)))]
+    (rows/chain (js-obj "bad" 0) (range n)
+      (fn [a _]
+        (let [val (rows/next-gen!)
+              i   (if (= kind :broad) :all (mod val rows/cells-n))]
+          (control-alloc!)
+          (-> (rows/timed-write! mnt i val)
+              (.then (fn [{:keys [ok? ok2?]}]
+                       (when-not (or skip? (and ok? ok2?)) (bump! a "bad" 1))
+                       a))))))))

--- a/implementation/freehand/test/re_frame/freehand/bench/b8_alloc.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b8_alloc.cljs
@@ -1,0 +1,262 @@
+(ns re-frame.freehand.bench.b8-alloc
+  "B8 — bytes ALLOCATED per write, across substrates.
+
+  B7 measured what a boundary KEEPS. This measures what a write TOUCHES
+  and throws away. They are different questions and they need different
+  instruments, and the whole difficulty of this namespace is that the
+  obvious instruments answer the first question while appearing to answer
+  the second.
+
+  ## Why the two obvious instruments cannot be used
+
+  **V8's CDP sampling heap profiler drops the samples of collected
+  objects.** Pointed at an allocate-and-drop loop it reports the residue,
+  not the traffic: B7's predecessor watched the same 80,000 objects read
+  4.77 MB when a global held them and 0.00 MB when nothing did. A sampler
+  is a retention instrument wearing an allocation instrument's name, and
+  it has already produced one wrong table on this surface. It is not used
+  here, and [[re-frame.freehand.bench.b8-alloc]]'s driver runs it once as
+  a NEGATIVE control so the claim is demonstrated rather than asserted.
+
+  **B7's own retention door cannot answer it either**, by construction:
+  mount, collect, read measures what survived a collection, and transient
+  garbage is exactly what does not.
+
+  ## The instrument: a window with no collection in it
+
+  If no garbage collection runs between two readings of V8's used-heap
+  counter, then the difference between them is the number of bytes
+  allocated in between — **including every byte that is already
+  unreachable**, because nothing has reclaimed it yet. Garbage is fully
+  visible precisely because it has not been collected.
+
+  So a reading is: force a full collection; read; run N writes; read.
+  The whole method rests on the middle step containing no collection, so
+  that is not assumed — it is **detected and the window is rejected**.
+  The used-heap counter is sampled at every leg boundary of every write
+  into a preallocated buffer, and a counter that only ever rises is a
+  window in which nothing was reclaimed. One decrease anywhere and the
+  window is thrown away rather than averaged in.
+
+  ## The positive control is a piece of garbage of predicted size
+
+  [[control-alloc!]] copies a prebuilt packed array of D doubles with
+  `.slice()` and immediately drops the copy. V8 stores such an array as
+  D unboxed 8-byte slots, so the copy costs a **predicted 8D bytes**, and
+  `.slice()` of an already-double-typed array allocates the result
+  directly with no intermediate `FixedArray` to transition away from —
+  which `new Array(D).fill(0.5)` would have had, and which would have made
+  the prediction 12D and this comment an excuse.
+
+  Nothing holds the copy past the statement that makes it. So:
+
+  - it is measured **directly**, as its own leg of the window, and
+  - it is measured **differentially**, as the slope between two values of
+    D across otherwise identical runs, which cancels every constant.
+
+  A retention instrument reads this control as ZERO. An instrument that
+  reads it as 8D per write can see garbage, and that is the entire claim
+  this namespace needs to establish before any arm is quoted.
+
+  B7's control failed in draft — a 4.7 MB `'x'.repeat(n)` string read as
+  six kilobytes on all three readers, because V8 does not materialise it.
+  The lesson taken here is that a control is only worth having if its
+  size is predicted before it is measured, so both numbers are reported
+  every round.
+
+  ## The window is B6's, and the legs are split
+
+  The measured window mirrors
+  [[re-frame.freehand.bench.b6-rows/timed-write!]] leg for leg — the same
+  state install, the same single microtask yield, the same empty
+  `react-dom/flushSync` drain, the same per-write read-back of the written
+  cell out of the DOM — with the used-heap counter read where that
+  function reads the clock. It is a mirror rather than a call because the
+  published function reads `performance.now()` and nothing else; the
+  driver ALSO runs the published function verbatim over the same window
+  and checks the two totals against each other, so the mirror's fidelity
+  is a measured claim and not a promise in a docstring.
+
+  The split matters for the same reason it matters on the clock, and
+  `freehand-vs-reagent.md` §2a is the reason: the Freehand arm reads
+  `app-db` through a subscription graph while the Reagent arm reads a
+  bare `reagent.core/atom`. `:write-bytes` is that leg alone — the
+  re-frame write and the signal graph, before React is involved — so a
+  reader can see how much of any gap a re-frame-shaped Reagent
+  application would also have paid.
+
+  Normative owner: `docs/design/freehand/decisions/`
+  `D021-performance-budgets-and-release-evidence.md`."
+  (:require [re-frame.freehand.bench.b6-rows :as rows]))
+
+;; ---------------------------------------------------------------------------
+;; The reader
+;; ---------------------------------------------------------------------------
+
+(defn mem
+  "V8's used-heap counter, in bytes, read from inside the page.
+
+  Requires `--enable-precise-memory-info`; without it Chrome quantises
+  this to 100 KB buckets and every figure below would be noise. The
+  driver asserts the flag took by checking that the value is not a round
+  multiple of 100,000 across several reads.
+
+  This is the SAME counter CDP's `Runtime.getHeapUsage` returns — B7
+  established that they agree to the byte on 80,000 held objects, and
+  this namespace does not pretend otherwise. It is read here rather than
+  over CDP for one reason: a CDP round trip costs about a millisecond and
+  there are five readings per write, which would cost more than the
+  window being measured. The driver's CDP readings bracket the whole
+  window and are what the in-page sum is checked against."
+  []
+  (let [m (.-memory js/performance)]
+    (if (some? m) (.-usedJSHeapSize m) -1)))
+
+;; ---------------------------------------------------------------------------
+;; The positive control — garbage of predicted size
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private ctl-template (volatile! nil))
+(defonce ^:private ctl-sink (volatile! 0.0))
+
+(defn control-prepare!
+  "Build the template ONCE, outside every window. `js/Array` + `fill`
+  transitions the elements kind and allocates twice; doing it here means
+  the copy taken inside the window is a single clean `FixedDoubleArray`."
+  [d]
+  (vreset! ctl-template (when (pos? d) (.fill (js/Array. d) 0.5)))
+  (vreset! ctl-sink 0.0))
+
+(defn control-alloc!
+  "Allocate 8·D bytes of immediate garbage.
+
+  The slot read into a live sink is not decoration: Closure is entitled
+  to delete an expression whose value nothing reads, and this surface has
+  already published a `layout-ms` of exactly 0.000 in every arm because a
+  property read was dropped. One element of the copy is summed into a
+  volatile that outlives the call, so the copy must exist."
+  []
+  (when-some [t @ctl-template]
+    (let [c (.slice t)]
+      (vreset! ctl-sink (+ @ctl-sink (aget c 0))))))
+
+;; ---------------------------------------------------------------------------
+;; Arms
+;; ---------------------------------------------------------------------------
+
+(def ^:private wanted
+  "The compiled tier is ruled out and is not mounted. UIx has no update
+  arm in B6 — its update story is `use-state` and React's own scheduler,
+  a different mechanism that would need an arm of its own."
+  #{:floor :freehand-interpreted :reagent})
+
+(defn- instrument-arm
+  "A pseudo-arm that installs no state and drains nothing, so a window
+  over it contains the harness and NOTHING ELSE — five `mem` reads, one
+  promise, one accumulate. It prices the instrument's own footprint,
+  which is otherwise an unexamined constant sitting inside every figure
+  in the table. Its read-back is skipped and it is counted separately
+  from the arms, because it renders no cell to read back."
+  []
+  {:id :instrument :skip-verify? true
+   :mount   (fn [container] container)
+   :write!  (fn [_ _] nil)
+   :force!  (fn [] nil)
+   :unmount (fn [_] nil)})
+
+(defn make-arms []
+  (conj (filterv #(wanted (:id %)) (rows/make-update-arms))
+        (instrument-arm)))
+
+;; ---------------------------------------------------------------------------
+;; The measured window — B6's, with the counter read where the clock is
+;; ---------------------------------------------------------------------------
+
+(defn- alloc-write!
+  "One write, with the used-heap counter read at every leg boundary.
+  Answers a promise of a five-reading vector plus the read-back verdict."
+  [{:keys [arm container]} i val]
+  (let [h0 (mem)]
+    (control-alloc!)
+    (let [hc (mem)]
+      ((:write! arm) i val)
+      (let [h1 (mem)]
+        (-> (js/Promise.resolve nil)
+            (.then (fn [_]
+                     (let [h2 (mem)]
+                       ((:force! arm))
+                       (let [h3    (mem)
+                             probe (if (= i :all) 0 i)]
+                         #js {:h #js [h0 hc h1 h2 h3]
+                              :ok (or (boolean (:skip-verify? arm))
+                                      (and (= (str val) (rows/cell-text container probe))
+                                           (or (not= i :all)
+                                               (= (str val)
+                                                  (rows/cell-text container
+                                                                  (dec rows/cells-n))))))})))))))))
+
+(defn run-window!
+  "N writes over one arm, inside one collection-free window.
+
+  Answers a promise of the accumulated legs, the count of writes whose
+  DOM read-back failed, and — the gate — the number of places where the
+  used-heap counter went DOWN. A window with any decrease had a
+  collection in it and is not a measurement of allocation; the driver
+  drops it."
+  [mnt kind n]
+  ;; camelCase deliberately: ClojureScript munges `-` to `_` in `(.-a-b x)`
+  ;; property access, which would silently miss a `#js {:a-b …}` key.
+  (let [acc #js {:control 0 :write 0 :gap 0 :force 0 :total 0
+                 :bad 0 :decreases 0 :worstDrop 0 :first 0 :last 0}
+        prev (volatile! nil)]
+    (rows/chain acc (range n)
+      (fn [a _]
+        (let [val (rows/next-gen!)
+              i   (if (= kind :broad) :all (mod val rows/cells-n))]
+          (-> (alloc-write! mnt i val)
+              (.then (fn [r]
+                       (let [h  (.-h r)
+                             h0 (aget h 0) hc (aget h 1) h1 (aget h 2)
+                             h2 (aget h 3) h3 (aget h 4)]
+                         ;; Decreases are counted across the WHOLE window,
+                         ;; including the seam between one write's last
+                         ;; reading and the next write's first.
+                         (when-some [p @prev]
+                           (when (< h0 p)
+                             (set! (.-decreases a) (inc (.-decreases a)))
+                             (set! (.-worstDrop a) (min (.-worstDrop a) (- h0 p)))))
+                         (doseq [[x y] [[h0 hc] [hc h1] [h1 h2] [h2 h3]]]
+                           (when (< y x)
+                             (set! (.-decreases a) (inc (.-decreases a)))
+                             (set! (.-worstDrop a) (min (.-worstDrop a) (- y x)))))
+                         (when (nil? @prev) (set! (.-first a) h0))
+                         (vreset! prev h3)
+                         (set! (.-last a) h3)
+                         (set! (.-control a) (+ (.-control a) (- hc h0)))
+                         (set! (.-write a) (+ (.-write a) (- h1 hc)))
+                         (set! (.-gap a) (+ (.-gap a) (- h2 h1)))
+                         (set! (.-force a) (+ (.-force a) (- h3 h2)))
+                         (set! (.-total a) (+ (.-total a) (- h3 h0)))
+                         (when-not (.-ok r) (set! (.-bad a) (inc (.-bad a))))
+                         a)))))))))
+
+(defn run-published-window!
+  "The same N writes through
+  [[re-frame.freehand.bench.b6-rows/timed-write!]] VERBATIM — the
+  published function, not a mirror of it.
+
+  The driver brackets this with CDP heap readings. Its total against the
+  mirror's total is what makes the mirror's leg split trustworthy: two
+  loops over the same window, one reading the counter five times a write
+  and one not reading it at all, must allocate the same bytes to within
+  the instrument's own footprint."
+  [mnt kind n]
+  (rows/chain #js {:bad 0} (range n)
+    (fn [a _]
+      (let [val (rows/next-gen!)
+            i   (if (= kind :broad) :all (mod val rows/cells-n))]
+        (control-alloc!)
+        (-> (rows/timed-write! mnt i val)
+            (.then (fn [{:keys [ok? ok2?]}]
+                     (when-not (and ok? ok2?) (set! (.-bad a) (inc (.-bad a))))
+                     a)))))))

--- a/implementation/freehand/test/re_frame/freehand/bench/b8_app.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b8_app.cljs
@@ -1,0 +1,44 @@
+(ns re-frame.freehand.bench.b8-app
+  "B8's `:advanced` entry — mounts the update arms once and hands the page
+  to `b8_run.cjs`.
+
+  The driver owns every window boundary, because the page cannot force a
+  garbage collection and therefore cannot decide when a window starts.
+  This namespace only mounts, seeds, and exposes the doors."
+  (:require [re-frame.adapter.uix :as react-substrate]
+            [re-frame.core :as rf]
+            [re-frame.freehand.bench.b6-harness :as h]
+            [re-frame.freehand.bench.b6-rows :as rows]
+            [re-frame.freehand.bench.b8-alloc :as b8]))
+
+(defn ^:export -main
+  []
+  (try
+    (rf/init! react-substrate/adapter)
+    (h/leave-act-environment!)
+    (let [arms   (b8/make-arms)
+          mounts (rows/mount-update-arms! arms)
+          by-id  (into {} (map (fn [m] [(name (:id (:arm m))) m])) mounts)]
+      (set! (.-B8 js/window)
+            #js {:mem     (fn [] (b8/mem))
+                 :arms    (clj->js (mapv #(name (:id %)) arms))
+                 :prepare (fn [d] (b8/control-prepare! d))
+                 ;; One window: `n` writes on one arm, counter read at every
+                 ;; leg boundary. The driver collects before and reads after.
+                 :run     (fn [arm kind n]
+                            (b8/run-window! (get by-id arm) (keyword kind) n))
+                 ;; The same window through the PUBLISHED timed-write!,
+                 ;; unmirrored, for the cross-check.
+                 :runPub  (fn [arm kind n]
+                            (b8/run-published-window! (get by-id arm) (keyword kind) n))
+                 ;; Re-seed every arm to a known state between windows so no
+                 ;; window inherits another's growth.
+                 :seed    (fn [] (rows/seed-update-arms! mounts))})
+      (-> (rows/seed-update-arms! mounts)
+          (.then (fn [_]
+                   (set! (.-B8_READY js/window) true)
+                   (js/console.log ";; B8 READY")
+                   nil))))
+    (catch :default e
+      (set! (.-B8_ERROR js/window) (str e))
+      (js/console.error (str ";; B8 FAILED — " e)))))

--- a/implementation/freehand/test/re_frame/freehand/bench/b8_app.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b8_app.cljs
@@ -35,6 +35,10 @@
           ;; it writes, under the renaming it was actually compiled with.
           "integrity" (fn [] (b8/integrity-probe))
           "prepare"   (fn [d] (b8/control-prepare! d))
+          ;; The control object priced by RETENTION instead — B7's
+          ;; instrument, on the same object, so the two can be compared.
+          "hold"      (fn [k] (b8/control-hold! k))
+          "unhold"    (fn [] (b8/control-release!))
           ;; One window: `n` writes on one arm, counter read at every leg
           ;; boundary. The driver collects before and reads after.
           "run"       (fn [arm kind n]

--- a/implementation/freehand/test/re_frame/freehand/bench/b8_app.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b8_app.cljs
@@ -39,6 +39,10 @@
           ;; instrument, on the same object, so the two can be compared.
           "hold"      (fn [k] (b8/control-hold! k))
           "unhold"    (fn [] (b8/control-release!))
+          ;; The decisive self-test: the same loop with the control's
+          ;; copies kept and with them dropped.
+          "keep"      (fn [b] (b8/control-keep! b))
+          "kept"      (fn [] (b8/control-kept-count))
           ;; One window: `n` writes on one arm, counter read at every leg
           ;; boundary. The driver collects before and reads after.
           "run"       (fn [arm kind n]

--- a/implementation/freehand/test/re_frame/freehand/bench/b8_app.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b8_app.cljs
@@ -4,8 +4,16 @@
 
   The driver owns every window boundary, because the page cannot force a
   garbage collection and therefore cannot decide when a window starts.
-  This namespace only mounts, seeds, and exposes the doors."
-  (:require [re-frame.adapter.uix :as react-substrate]
+  This namespace only mounts, seeds, and exposes the doors.
+
+  Every name crossing the JS boundary is a STRING LITERAL through
+  `js-obj` / `goog.object`, never a `#js {:kw …}` literal read back with
+  `(.-kw o)`. Under `:advanced` those two disagree — the compiled
+  evidence is recorded at the head of
+  [[re-frame.freehand.bench.b8-alloc]] — and the disagreement is SILENT
+  for any key that happens to collide with Closure's browser externs."
+  (:require [goog.object :as gobj]
+            [re-frame.adapter.uix :as react-substrate]
             [re-frame.core :as rf]
             [re-frame.freehand.bench.b6-harness :as h]
             [re-frame.freehand.bench.b6-rows :as rows]
@@ -19,26 +27,30 @@
     (let [arms   (b8/make-arms)
           mounts (rows/mount-update-arms! arms)
           by-id  (into {} (map (fn [m] [(name (:id (:arm m))) m])) mounts)]
-      (set! (.-B8 js/window)
-            #js {:mem     (fn [] (b8/mem))
-                 :arms    (clj->js (mapv #(name (:id %)) arms))
-                 :prepare (fn [d] (b8/control-prepare! d))
-                 ;; One window: `n` writes on one arm, counter read at every
-                 ;; leg boundary. The driver collects before and reads after.
-                 :run     (fn [arm kind n]
-                            (b8/run-window! (get by-id arm) (keyword kind) n))
-                 ;; The same window through the PUBLISHED timed-write!,
-                 ;; unmirrored, for the cross-check.
-                 :runPub  (fn [arm kind n]
-                            (b8/run-published-window! (get by-id arm) (keyword kind) n))
-                 ;; Re-seed every arm to a known state between windows so no
-                 ;; window inherits another's growth.
-                 :seed    (fn [] (rows/seed-update-arms! mounts))})
+      (gobj/set js/window "B8"
+        (js-obj
+          "mem"       (fn [] (b8/mem))
+          "arms"      (clj->js (mapv #(name (:id %)) arms))
+          ;; Run before any measurement: proves this bundle reads the keys
+          ;; it writes, under the renaming it was actually compiled with.
+          "integrity" (fn [] (b8/integrity-probe))
+          "prepare"   (fn [d] (b8/control-prepare! d))
+          ;; One window: `n` writes on one arm, counter read at every leg
+          ;; boundary. The driver collects before and reads after.
+          "run"       (fn [arm kind n]
+                        (b8/run-window! (get by-id arm) (keyword kind) n))
+          ;; The same window through the PUBLISHED timed-write!, unmirrored,
+          ;; for the cross-check.
+          "runPub"    (fn [arm kind n]
+                        (b8/run-published-window! (get by-id arm) (keyword kind) n))
+          ;; Re-seed every arm to a known state between windows so no window
+          ;; inherits another's growth.
+          "seed"      (fn [] (rows/seed-update-arms! mounts))))
       (-> (rows/seed-update-arms! mounts)
           (.then (fn [_]
-                   (set! (.-B8_READY js/window) true)
+                   (gobj/set js/window "B8_READY" true)
                    (js/console.log ";; B8 READY")
                    nil))))
     (catch :default e
-      (set! (.-B8_ERROR js/window) (str e))
+      (gobj/set js/window "B8_ERROR" (str e))
       (js/console.error (str ";; B8 FAILED — " e)))))

--- a/implementation/freehand/test/re_frame/freehand/bench/b8_run.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b8_run.cjs
@@ -161,7 +161,8 @@ async function main() {
   // back. Nothing is measured until it does.
   const integ = await page.evaluate(() => window.B8.integrity());
   const wantKeys = [
-    'control', 'write', 'gap', 'force', 'total', 'bad', 'decreases', 'worstDrop', 'first', 'last',
+    'control', 'write', 'gap', 'force', 'total', 'posSum', 'negSum',
+    'bad', 'decreases', 'worstDrop', 'first', 'last',
   ];
   const gotKeys = integ && typeof integ.keys === 'string' ? integ.keys.split(',') : [];
   const missing = wantKeys.filter((k) => !gotKeys.includes(k));
@@ -241,7 +242,9 @@ async function main() {
         ? null
         : {
             total: r.total,
-            perWrite: r.total / WRITES,
+            posSum: r.posSum,
+            negSum: r.negSum,
+            perWrite: r.posSum / WRITES,
             control: r.control,
             write: r.write,
             gap: r.gap,
@@ -250,9 +253,15 @@ async function main() {
             worstDrop: r.worstDrop,
           },
       bad: r.bad,
-      // THE GATE. Any decrease means a collection ran inside the window and
-      // the difference of the endpoints is not an allocation total.
-      accepted: published ? r.bad === 0 : r.decreases === 0 && r.bad === 0,
+      // COLLECTION-FREE, which is not the same as usable. `posSum` is an
+      // allocation total either way, because a collection is a FALLING step
+      // and is accumulated separately rather than netted against the rising
+      // ones. What a collection-free window buys is the identity
+      // `posSum === last − first === the CDP bracket`, which is the
+      // instrument's consistency check — so these windows are the
+      // validation set, not the whole sample.
+      collectionFree: !published && r.decreases === 0,
+      accepted: r.bad === 0,
     };
   }
 
@@ -271,6 +280,14 @@ async function main() {
       ['freehand-interpreted', kind, WRITES]
     );
     const post = await readCdp();
+    // COLLECT BEFORE READING THE SAMPLER, and that is the whole point.
+    // Inside a collection-free window the garbage is still standing, so
+    // the sampler can still see it and reports a large number — which is
+    // not the fault being demonstrated. The fault is that it reports what
+    // SURVIVES: after a full collection the samples of the collected
+    // objects are dropped and the same window reads as almost nothing,
+    // while the counter's reading of that window does not move.
+    await gc();
     const { profile } = await cdp.send('HeapProfiler.stopSampling');
     let sampled = 0;
     (function walk(node) {
@@ -353,9 +370,25 @@ function report(out) {
     console.log(`\n;; ==== B8 — bytes allocated per ${kind.toUpperCase()} write ====`);
     const all = rows.filter((r) => r.kind === kind);
     const acc = all.filter((r) => r.accepted);
+    const mir = all.filter((r) => !r.published && r.accepted);
+    const cf = mir.filter((r) => r.collectionFree);
     console.log(
-      `;; windows: ${acc.length} accepted of ${all.length}; ` +
-        `${all.length - acc.length} rejected for a collection inside the window`
+      `;; windows: ${acc.length} of ${all.length} verified at the DOM; of the ${mir.length} ` +
+        `mirror windows ${cf.length} were collection-free`
+    );
+    // THE IDENTITY. Where nothing was reclaimed, the sum of the rising
+    // steps, the endpoint difference and the CDP bracket are three ways of
+    // computing one number and must agree. Quoted as the worst case.
+    let worstId = 0;
+    let worstCdp = 0;
+    for (const r of cf) {
+      worstId = Math.max(worstId, Math.abs(r.inPage.posSum / r.inPage.total - 1));
+      worstCdp = Math.max(worstCdp, Math.abs(r.inPage.posSum / r.cdpAllocated - 1));
+    }
+    console.log(
+      `;; collection-free identity: rising-step sum vs endpoint difference, worst ` +
+        `${(worstId * 100).toFixed(3)}%; vs the CDP bracket, worst ${(worstCdp * 100).toFixed(2)}% ` +
+        `(the CDP bracket also contains the inter-write seam the legs do not)`
     );
     console.log(
       `;; unverified writes: ${all.reduce((a, r) => a + (r.arm === 'instrument' ? 0 : r.bad), 0)} of ` +
@@ -395,40 +428,51 @@ function report(out) {
 
     // --- the table --------------------------------------------------------
     console.log(';;');
-    console.log(';; arm                  B/write (counter)     in-page      write leg   force leg   retained');
+    console.log(';; arm                  B/write (rising-step sum)   CDP     write leg   force leg   retained   GCs');
     const per = {};
     for (const arm of ARMS) {
       const ws = of(arm, 0, false);
-      const cdpS = stat(ws.map((r) => r.cdpPerWrite));
       const inS = stat(ws.map((r) => r.inPage.perWrite));
+      const cdpS = stat(ws.map((r) => r.cdpPerWrite));
+      const gcS = stat(ws.map((r) => r.inPage.decreases));
       const wS = stat(ws.map((r) => r.inPage.write / r.writes));
       const fS = stat(ws.map((r) => r.inPage.force / r.writes));
       const gS = stat(ws.map((r) => r.inPage.gap / r.writes));
       const rS = stat(ws.map((r) => r.retained / r.writes));
       const pub = stat(of(arm, 0, true).map((r) => r.cdpPerWrite));
-      per[arm] = { cdp: cdpS, inPage: inS, write: wS, gap: gS, force: fS, retained: rS, published: pub };
-      if (!cdpS) continue;
+      per[arm] = { cdp: cdpS, inPage: inS, write: wS, gap: gS, force: fS, retained: rS,
+                   published: pub, gcs: gcS };
+      if (!inS) continue;
       console.log(
-        `;; ${arm.padEnd(20)} ${fmt(cdpS.mean).padStart(9)} ` +
-          `[${fmt(cdpS.min)}–${fmt(cdpS.max)}]`.padEnd(21) +
-          `${fmt(inS && inS.mean).padStart(9)}  ${fmt(wS && wS.mean).padStart(10)}` +
-          `  ${fmt(fS && fS.mean).padStart(10)}  ${fmt(rS && rS.mean).padStart(9)}`
+        `;; ${arm.padEnd(20)} ${fmt(inS.mean).padStart(9)} ` +
+          `[${fmt(inS.min)}–${fmt(inS.max)}]`.padEnd(21) +
+          `${fmt(cdpS && cdpS.mean).padStart(9)}  ${fmt(wS && wS.mean).padStart(10)}` +
+          `  ${fmt(fS && fS.mean).padStart(10)}  ${fmt(rS && rS.mean).padStart(9)}` +
+          `  ${(gcS ? gcS.mean.toFixed(1) : '-').padStart(5)}`
       );
     }
 
     // --- mirror vs published ---------------------------------------------
     console.log(';;');
-    console.log(';; MIRROR vs PUBLISHED window (counter B/write), and in-page vs CDP:');
+    // Does the MIRROR allocate what the PUBLISHED window allocates? The
+    // mirror reads the counter five times a write and the published
+    // `timed-write!` reads it not at all, so if the mirror's own footprint
+    // were material this is where it would show. Restricted to
+    // collection-free mirror windows, because the published loop carries no
+    // in-page sampling and so cannot be gated the same way.
+    console.log(';; MIRROR vs PUBLISHED window, CDP-bracketed B/write:');
     for (const arm of ARMS) {
       const p = per[arm];
-      if (!p || !p.cdp) continue;
-      const mirrorVsPub = p.published ? (p.cdp.mean / p.published.mean - 1) * 100 : null;
-      const inVsCdp = p.inPage ? (p.inPage.mean / p.cdp.mean - 1) * 100 : null;
+      if (!p) continue;
+      const mCf = stat(
+        of(arm, 0, false).filter((r) => r.collectionFree).map((r) => r.cdpPerWrite)
+      );
+      const mirrorVsPub = mCf && p.published ? (mCf.mean / p.published.mean - 1) * 100 : null;
       console.log(
-        `;;   ${arm.padEnd(20)} mirror ${fmt(p.cdp.mean).padStart(9)}  published ` +
+        `;;   ${arm.padEnd(20)} mirror ${fmt(mCf && mCf.mean).padStart(9)}  published ` +
           `${fmt(p.published && p.published.mean).padStart(9)}  ` +
-          `mirror−published ${mirrorVsPub === null ? '-' : mirrorVsPub.toFixed(1) + '%'}  ` +
-          `in-page−CDP ${inVsCdp === null ? '-' : inVsCdp.toFixed(2) + '%'}`
+          `mirror−published ${mirrorVsPub === null ? '-' : mirrorVsPub.toFixed(1) + '%'}` +
+          `   (collection-free mirror windows: ${mCf ? mCf.n : 0})`
       );
     }
 
@@ -437,7 +481,7 @@ function report(out) {
     console.log(';; ABOVE THE FLOOR, paired within round:');
     const byRound = (arm) => {
       const m = {};
-      for (const r of of(arm, 0, false)) m[r.round] = r.cdpPerWrite;
+      for (const r of of(arm, 0, false)) m[r.round] = r.inPage.perWrite;
       return m;
     };
     const fl = byRound('floor');
@@ -477,7 +521,11 @@ function report(out) {
   console.log('\n;; ==== NEGATIVE CONTROL — the sampling heap profiler on the same window ====');
   console.log(`;;   garbage allocated by the control, by construction: ${fmt(sampler.controlGarbageBytes)} B`);
   console.log(`;;   the used-heap counter saw:                         ${fmt(sampler.counterAllocated)} B`);
-  console.log(`;;   HeapProfiler sampling total:                       ${fmt(sampler.samplerTotal)} B`);
+  console.log(`;;   HeapProfiler sampling total, read after a collect: ${fmt(sampler.samplerTotal)} B`);
+  console.log(
+    `;;   -> the sampler reports ${((sampler.samplerTotal / sampler.counterAllocated) * 100).toFixed(1)}%` +
+      ` of what was allocated; it is a retention instrument.`
+  );
 
   return summary;
 }

--- a/implementation/freehand/test/re_frame/freehand/bench/b8_run.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b8_run.cjs
@@ -327,7 +327,13 @@ async function main() {
       const r = await page.evaluate(([a, k, w]) => window.B8.run(a, k, w), ['instrument', kind, n]);
       const post = await readCdp();
       const kept = await page.evaluate(() => window.B8.kept());
-      // Release and settle, so the next pass starts clean.
+      // Collect while the copies are STILL HELD. For the kept pass this is
+      // the same counter's reading of the same objects' RETAINED size, in
+      // the same window that just measured their allocation — so the two
+      // questions are put to one reader instead of two.
+      await gc();
+      const held = await readCdp();
+      // Now release and settle, so the next pass starts clean.
       await page.evaluate(() => window.B8.keep(false));
       await gc();
       const settled = await readCdp();
@@ -336,7 +342,8 @@ async function main() {
         copiesHeld: kept,
         counterPerCopy: r.posSum / n,
         cdpPerCopy: (post - pre) / n,
-        retainedAfter: settled - pre,
+        retainedWhileHeldPerCopy: (held - pre) / n,
+        residueAfterRelease: settled - pre,
         decreases: r.decreases,
       };
     }
@@ -751,9 +758,10 @@ function report(out) {
     for (const k of ['dropped', 'kept']) {
       const v = kd[k];
       console.log(
-        `;;   ${k.padEnd(8)} counter ${fmt(v.counterPerCopy).padStart(9)} B/copy   CDP ` +
-          `${fmt(v.cdpPerCopy).padStart(9)}   held afterwards ${String(v.copiesHeld).padStart(3)}` +
-          `   retained ${fmt(v.retainedAfter).padStart(9)}   GCs ${v.decreases}`
+        `;;   ${k.padEnd(8)} allocated ${fmt(v.counterPerCopy).padStart(9)} B/copy   CDP ` +
+          `${fmt(v.cdpPerCopy).padStart(9)}   still held ${String(v.copiesHeld).padStart(3)}` +
+          `   retained/copy ${fmt(v.retainedWhileHeldPerCopy).padStart(9)}` +
+          `   residue ${fmt(v.residueAfterRelease).padStart(9)}   GCs ${v.decreases}`
       );
     }
     console.log(`;;   kept / dropped = ${kd.ratioKeptOverDropped.toFixed(4)}`);

--- a/implementation/freehand/test/re_frame/freehand/bench/b8_run.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b8_run.cjs
@@ -303,6 +303,48 @@ async function main() {
   }
 
   // -------------------------------------------------------------------------
+  // KEPT vs DROPPED — does the counter see garbage as fully as it sees
+  // survivors?
+  // -------------------------------------------------------------------------
+  //
+  // The identical loop, on the instrument arm, at the same D, run twice:
+  // once with each control copy kept and once with each dropped. Same
+  // code path, same allocation, one difference. If the counter reports
+  // the same bytes per copy either way, it does not care whether an
+  // object survives — the instrument sees garbage exactly as well as it
+  // sees anything, and the residual disagreement with retention is a
+  // property of the counter's scale that cancels in every ratio. If
+  // keeping reads higher, then garbage is partly invisible and this
+  // instrument shares the sampler's disease.
+  async function keptVsDropped(kind, n) {
+    const out = {};
+    for (const keep of [false, true]) {
+      await page.evaluate((d) => window.B8.prepare(d), CTL_2);
+      await page.evaluate((b) => window.B8.keep(b), keep);
+      await page.evaluate(() => window.B8.seed());
+      await gc();
+      const pre = await readCdp();
+      const r = await page.evaluate(([a, k, w]) => window.B8.run(a, k, w), ['instrument', kind, n]);
+      const post = await readCdp();
+      const kept = await page.evaluate(() => window.B8.kept());
+      // Release and settle, so the next pass starts clean.
+      await page.evaluate(() => window.B8.keep(false));
+      await gc();
+      const settled = await readCdp();
+      out[keep ? 'kept' : 'dropped'] = {
+        writes: n,
+        copiesHeld: kept,
+        counterPerCopy: r.posSum / n,
+        cdpPerCopy: (post - pre) / n,
+        retainedAfter: settled - pre,
+        decreases: r.decreases,
+      };
+    }
+    out.ratioKeptOverDropped = out.kept.counterPerCopy / out.dropped.counterPerCopy;
+    return out;
+  }
+
+  // -------------------------------------------------------------------------
   // The sampling profiler, as a NEGATIVE control
   // -------------------------------------------------------------------------
 
@@ -413,11 +455,14 @@ async function main() {
   // the baseline, and a residue of zero says the release was clean.
   const refBpd = retention[retention.length - 1].bytesPerDouble;
 
+  console.error('[b8] kept-vs-dropped self-test ...');
+  const keptDropped = await keptVsDropped(KINDS[0], 12);
+
   console.error('[b8] sampler negative control ...');
   const sampler = await samplerControl(KINDS[0], nFor[KINDS[0]]['freehand-interpreted'][0], refBpd);
 
   await browser.close();
-  return { rows, sampler, retention, refBytesPerDouble: refBpd, nFor,
+  return { rows, sampler, retention, keptDropped, refBytesPerDouble: refBpd, nFor,
            integrity: integ, precise: { probes } };
 }
 
@@ -698,6 +743,21 @@ function report(out) {
   console.log(
     ';;   take the packed fast path. The instrument was fine; the arithmetic was the fiction.'
   );
+
+  const kd = out.keptDropped;
+  if (kd) {
+    console.log('\n;; ==== KEPT vs DROPPED — can the counter see garbage as well as survivors? ====');
+    console.log(';;   the identical loop, same D, one difference: whether the copy is kept');
+    for (const k of ['dropped', 'kept']) {
+      const v = kd[k];
+      console.log(
+        `;;   ${k.padEnd(8)} counter ${fmt(v.counterPerCopy).padStart(9)} B/copy   CDP ` +
+          `${fmt(v.cdpPerCopy).padStart(9)}   held afterwards ${String(v.copiesHeld).padStart(3)}` +
+          `   retained ${fmt(v.retainedAfter).padStart(9)}   GCs ${v.decreases}`
+      );
+    }
+    console.log(`;;   kept / dropped = ${kd.ratioKeptOverDropped.toFixed(4)}`);
+  }
 
   console.log('\n;; ==== NEGATIVE CONTROL — the sampling heap profiler on the same window ====');
   console.log(`;;   garbage allocated by the control, by construction: ${fmt(sampler.controlGarbageBytes)} B`);

--- a/implementation/freehand/test/re_frame/freehand/bench/b8_run.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b8_run.cjs
@@ -209,7 +209,8 @@ async function main() {
   // One window
   // -------------------------------------------------------------------------
 
-  async function window_(arm, kind, doubles, published) {
+  async function window_(arm, kind, doubles, published, writes) {
+    const WRITES = writes;
     await page.evaluate((d) => window.B8.prepare(d), doubles);
     await page.evaluate(() => window.B8.seed());
     await gc();
@@ -305,15 +306,15 @@ async function main() {
   // The sampling profiler, as a NEGATIVE control
   // -------------------------------------------------------------------------
 
-  async function samplerControl(kind) {
+  async function samplerControl(kind, n, bytesPerDouble) {
     await page.evaluate((d) => window.B8.prepare(d), CTL_2);
     await page.evaluate(() => window.B8.seed());
     await gc();
     await cdp.send('HeapProfiler.startSampling', { samplingInterval: 4096 });
     const pre = await readCdp();
     const r = await page.evaluate(
-      ([a, k, n]) => window.B8.run(a, k, n),
-      ['freehand-interpreted', kind, WRITES]
+      ([a, k, w]) => window.B8.run(a, k, w),
+      ['freehand-interpreted', kind, n]
     );
     const post = await readCdp();
     // COLLECT BEFORE READING THE SAMPLER, and that is the whole point.
@@ -331,9 +332,9 @@ async function main() {
       for (const c of node.children || []) walk(c);
     })(profile.head);
     return {
-      // Known by construction: the control allocates and drops 8·CTL_2
-      // bytes on every one of WRITES writes, and nothing holds any of it.
-      controlGarbageBytes: 8 * CTL_2 * WRITES,
+      // Known by MEASUREMENT, not by arithmetic: the retention pass prices
+      // one control copy, and the loop drops one on every write.
+      controlGarbageBytes: bytesPerDouble * CTL_2 * n,
       counterAllocated: post - pre,
       samplerTotal: sampled,
       note:
@@ -346,23 +347,57 @@ async function main() {
   // Rounds
   // -------------------------------------------------------------------------
 
+  // -------------------------------------------------------------------------
+  // How many writes fit in a window before V8 collects
+  // -------------------------------------------------------------------------
+  //
+  // A collection inside the window costs accuracy: the rising-step sum
+  // nets the reclaimed bytes away inside whichever step contained the
+  // collection, so it UNDER-states. The first full run measured exactly
+  // that — the control's slope read 12.06 B/double where retention says
+  // the object is 16.00, and the gap is the bias.
+  //
+  // The fix is not a bigger correction, it is a shorter window. Arms
+  // differ by three orders of magnitude in what they allocate per write —
+  // the instrument arm 438 B, Freehand's broad write about four
+  // megabytes — so ONE write count cannot suit them all: 25 writes is
+  // comfortably collection-free for Reagent and guarantees a dozen
+  // collections for Freehand. So each arm, at each control level, gets
+  // the number of writes that fits its own allocation into one nursery.
+  const TARGET = Number(process.env.B8_TARGET_BYTES || 3.0e6);
+  const nFor = {};
+  for (const kind of KINDS) {
+    nFor[kind] = {};
+    for (const arm of ARMS) {
+      nFor[kind][arm] = {};
+      for (const d of arm === 'instrument' || LADDER_ARMS.includes(arm) ? [0, CTL_1, CTL_2] : [0]) {
+        // A calibration window, never read as data. It doubles as the
+        // warm-up pass — first-call compilation, inline caches and
+        // one-time module state are not what this asks about, and charged
+        // to round 1 they read as allocation per write.
+        const probe = await window_(arm, kind, d, false, 4);
+        const perWrite = Math.max(1, probe.inPage.posSum / 4);
+        const n = Math.max(2, Math.min(WRITES, Math.round(TARGET / perWrite)));
+        nFor[kind][arm][d] = n;
+        console.error(
+          `[b8] ${kind}/${arm}/D=${d}: ~${Math.round(perWrite)} B per write -> ${n} writes per window`
+        );
+      }
+    }
+  }
+
   const rows = [];
   for (const kind of KINDS) {
-    // A warm-up window per arm, never read: first-call compilation, inline
-    // caches and one-time module state are not what this asks about, and
-    // charged to round 1 they read as allocation per write.
-    console.error(`[b8] ${kind}: warm-up ...`);
-    for (const arm of ARMS) await window_(arm, kind, 0, false);
-
     for (let round = 0; round < ROUNDS; round++) {
       console.error(`[b8] ${kind}: round ${round + 1}/${ROUNDS}`);
       for (let j = 0; j < ARMS.length; j++) {
         const arm = ARMS[(j + round) % ARMS.length];
-        rows.push({ round, ...(await window_(arm, kind, 0, false)) });
-        rows.push({ round, ...(await window_(arm, kind, 0, true)) });
+        const n0 = nFor[kind][arm][0];
+        rows.push({ round, ...(await window_(arm, kind, 0, false, n0)) });
+        rows.push({ round, ...(await window_(arm, kind, 0, true, n0)) });
         if (LADDER_ARMS.includes(arm)) {
-          rows.push({ round, ...(await window_(arm, kind, CTL_1, false)) });
-          rows.push({ round, ...(await window_(arm, kind, CTL_2, false)) });
+          rows.push({ round, ...(await window_(arm, kind, CTL_1, false, nFor[kind][arm][CTL_1])) });
+          rows.push({ round, ...(await window_(arm, kind, CTL_2, false, nFor[kind][arm][CTL_2])) });
         }
       }
     }
@@ -373,12 +408,17 @@ async function main() {
   for (const d of [CTL_1, CTL_2]) {
     for (const k of [20, 40]) retention.push(await controlRetention(d, k));
   }
+  // The retention reading at the larger D and larger copy count is the
+  // reference: more copies means the per-copy figure is less sensitive to
+  // the baseline, and a residue of zero says the release was clean.
+  const refBpd = retention[retention.length - 1].bytesPerDouble;
 
   console.error('[b8] sampler negative control ...');
-  const sampler = await samplerControl(KINDS[0]);
+  const sampler = await samplerControl(KINDS[0], nFor[KINDS[0]]['freehand-interpreted'][0], refBpd);
 
   await browser.close();
-  return { rows, sampler, retention, integrity: integ, precise: { probes } };
+  return { rows, sampler, retention, refBytesPerDouble: refBpd, nFor,
+           integrity: integ, precise: { probes } };
 }
 
 // ---------------------------------------------------------------------------
@@ -395,6 +435,13 @@ const fmt = (v) => (v === null || v === undefined ? '-' : Math.round(v).toLocale
 
 function report(out) {
   const { rows, sampler } = out;
+  // The control's per-double cost, MEASURED by the retention pass rather
+  // than predicted. `8·D` was the arithmetic and it was wrong: `.slice()`
+  // of a HOLEY double array does not take the packed fast path, so a copy
+  // costs a 4-byte pointer slot plus a boxed 12-byte HeapNumber per
+  // element, not one unboxed 8-byte slot. Retention reads 16.002 B/double
+  // on two copy counts with a residue of zero.
+  const REF = out.refBytesPerDouble;
   const kinds = [...new Set(rows.map((r) => r.kind))];
   const summary = {};
 
@@ -460,8 +507,14 @@ function report(out) {
 
     // --- positive control -------------------------------------------------
     console.log(';;');
-    console.log(';; POSITIVE CONTROL — garbage of predicted size, seen by the instrument');
-    console.log(';;   arm                 direct leg B/write   slope B/double [pred 8.000]');
+    console.log(
+      ';; POSITIVE CONTROL — garbage whose size is known from the retention pass, seen by ' +
+        'the allocation instrument'
+    );
+    console.log(
+      `;;   reference: ${REF.toFixed(3)} B/double, measured by retention on the same object`
+    );
+    console.log(';;   arm                 direct leg B/write        slope B/double   error');
     const ctl = {};
     for (const arm of LADDER_ARMS) {
       const d1 = of(arm, CTL_1, false);
@@ -473,7 +526,8 @@ function report(out) {
       const slope = b1 && b2 ? (b2.mean - b1.mean) / (CTL_2 - CTL_1) : null;
       const slope0 = b0 && b2 ? (b2.mean - b0.mean) / CTL_2 : null;
       ctl[arm] = {
-        predictedPerWriteAtCtl2: 8 * CTL_2,
+        referenceBytesPerDouble: REF,
+        expectedPerWriteAtCtl2: REF * CTL_2,
         directLegAtCtl2: leg2,
         slopeBytesPerDouble: slope,
         slopeFromZero: slope0,
@@ -481,9 +535,11 @@ function report(out) {
         at1: b1,
         at2: b2,
       };
+      const err = slope === null ? null : (slope / REF - 1) * 100;
       console.log(
         `;;   ${arm.padEnd(20)} ${fmt(leg2 && leg2.mean).padStart(12)}` +
-          `   [pred ${fmt(8 * CTL_2)}]   ${slope === null ? '-' : slope.toFixed(3)}` +
+          `  [expect ${fmt(REF * CTL_2)}]   ${slope === null ? '   -  ' : slope.toFixed(3)}` +
+          `   ${err === null ? '-' : (err > 0 ? '+' : '') + err.toFixed(1) + '%'}` +
           `   (from 0: ${slope0 === null ? '-' : slope0.toFixed(3)})`
       );
     }
@@ -628,14 +684,20 @@ function report(out) {
   }
 
   console.log('\n;; ==== CONTROL CROSS-CALIBRATION — the same object, priced two ways ====');
-  console.log(';;   D doubles  copies   retained B/copy   B/double   [8·D predicts 8.000]   residue');
+  console.log(';;   D doubles  copies   retained B/copy   B/double   residue after release');
   for (const r of out.retention || []) {
     console.log(
       `;;   ${String(r.doubles).padStart(9)}  ${String(r.copies).padStart(6)}   ` +
-        `${fmt(r.retainedPerCopy).padStart(14)}   ${r.bytesPerDouble.toFixed(3).padStart(8)}` +
-        `                          ${fmt(r.residue).padStart(8)}`
+        `${fmt(r.retainedPerCopy).padStart(14)}   ${r.bytesPerDouble.toFixed(3).padStart(8)}   ` +
+        `${fmt(r.residue).padStart(14)}`
     );
   }
+  console.log(
+    ';;   `8·D` predicted 8.000 and was WRONG — a .slice() of a HOLEY double array does not'
+  );
+  console.log(
+    ';;   take the packed fast path. The instrument was fine; the arithmetic was the fiction.'
+  );
 
   console.log('\n;; ==== NEGATIVE CONTROL — the sampling heap profiler on the same window ====');
   console.log(`;;   garbage allocated by the control, by construction: ${fmt(sampler.controlGarbageBytes)} B`);

--- a/implementation/freehand/test/re_frame/freehand/bench/b8_run.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b8_run.cjs
@@ -1,0 +1,475 @@
+#!/usr/bin/env node
+// B8's driver — bytes ALLOCATED per write, across substrates.
+//
+//   node implementation/freehand/test/re_frame/freehand/bench/b8_run.cjs
+//   B8_ROUNDS=5 B8_WRITES=40 node .../b8_run.cjs --kind broad
+//
+// THE METHOD, in one paragraph. If no garbage collection runs between two
+// readings of V8's used-heap counter, their difference is the bytes
+// allocated in between — INCLUDING the bytes already unreachable, because
+// nothing has reclaimed them yet. That is the only way a counter of this
+// kind can see garbage, and it is why the window has to be short. So:
+// collect, read, run N writes, read. The middle step containing no
+// collection is not assumed — the page samples the counter at every leg
+// boundary of every write, and any window in which it went DOWN is thrown
+// away rather than averaged in.
+//
+// WHY NOT THE OBVIOUS TOOL. V8's CDP *sampling* heap profiler drops the
+// samples of collected objects, so it reports retention while looking
+// like it reports allocation; B7's predecessor watched the same 80,000
+// objects read 4.77 MB held and 0.00 MB dropped. This file runs that
+// sampler ONCE, over a window whose garbage content is known by
+// construction, as a NEGATIVE control — see `samplerControl` below.
+//
+// WHY NOT A HEAP SNAPSHOT. `takeHeapSnapshot` collects before it walks,
+// so it destroys the very bytes in question. It is B7's independent
+// reader and it is useless here.
+//
+// THE POSITIVE CONTROL is a piece of garbage of PREDICTED size: a
+// `.slice()` of a prebuilt packed array of D doubles, dropped on the next
+// statement, costing 8D bytes. It is read two ways — directly as its own
+// leg, and as the SLOPE between two values of D, which cancels every
+// constant including the instrument's own footprint. A retention
+// instrument reads this control as zero.
+
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const http = require('node:http');
+const path = require('node:path');
+
+const IMPL = path.resolve(__dirname, '../../../../..');
+const OUT = path.join(IMPL, 'out', 'b8');
+const PORT = Number(process.env.B8_PORT || 8133);
+
+function arg(name, dflt) {
+  const i = process.argv.indexOf(`--${name}`);
+  return i === -1 ? dflt : process.argv[i + 1];
+}
+
+const ROUNDS = Number(process.env.B8_ROUNDS || 5);
+const WRITES = Number(process.env.B8_WRITES || 40);
+const KINDS = (arg('kind', 'broad,narrow')).split(',');
+const NO_BUILD = process.argv.includes('--no-build');
+
+// 6,250 doubles = 50,000 B; 12,500 = 100,000 B. Two rungs so the slope is
+// available; small enough that the ladder does not itself provoke a
+// collection inside a 40-write window.
+const CTL_1 = Number(process.env.B8_CTL_1 || 6250);
+const CTL_2 = Number(process.env.B8_CTL_2 || 12500);
+
+const ARMS = ['instrument', 'floor', 'reagent', 'freehand-interpreted'];
+// The control ladder runs on the instrument (where nothing else moves),
+// and on both substantive arms, so the calibration is per-arm rather than
+// borrowed from one arm and assumed of the others.
+const LADDER_ARMS = ['instrument', 'reagent', 'freehand-interpreted'];
+
+const CONFIG_MERGE =
+  '{:output-dir "out/b8" :asset-path "." ' +
+  ':modules {:main {:init-fn re-frame.freehand.bench.b8-app/-main}}}';
+
+function build() {
+  console.error('[b8] building :advanced bundle ...');
+  const runner = path.join(IMPL, 'node_modules', 'shadow-cljs', 'cli', 'runner.js');
+  const r = spawnSync(
+    process.execPath,
+    [runner, 'release', 'freehand-release', '--config-merge', CONFIG_MERGE],
+    { cwd: IMPL, stdio: ['ignore', 'inherit', 'inherit'] }
+  );
+  if (r.status !== 0) {
+    console.error(`[b8] build failed with status ${r.status}`);
+    process.exit(1);
+  }
+}
+
+const MIME = { '.js': 'text/javascript', '.html': 'text/html', '.map': 'application/json' };
+
+function serve() {
+  fs.mkdirSync(OUT, { recursive: true });
+  fs.writeFileSync(
+    path.join(OUT, 'index.html'),
+    '<!doctype html><html><head><meta charset="utf-8"><title>B8</title></head>' +
+      '<body><div id="app"></div><script src="main.js"></script></body></html>'
+  );
+  return http
+    .createServer((req, res) => {
+      const rel = decodeURIComponent(req.url.split('?')[0]);
+      const file = path.join(OUT, rel === '/' ? 'index.html' : rel);
+      if (!file.startsWith(OUT) || !fs.existsSync(file)) {
+        res.writeHead(404).end('not found');
+        return;
+      }
+      res.writeHead(200, { 'content-type': MIME[path.extname(file)] || 'application/octet-stream' });
+      fs.createReadStream(file).pipe(res);
+    })
+    .listen(PORT);
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const { chromium } = require('playwright');
+  const browser = await chromium.launch({
+    args: [
+      '--enable-precise-memory-info',
+      // A larger young generation means more writes fit before a scavenge,
+      // which is what makes a collection-free window of useful length
+      // possible at all. It changes when V8 collects, not what it
+      // allocates, and the monotonicity gate does not care either way.
+      '--js-flags=--expose-gc --min-semi-space-size=32 --max-semi-space-size=64',
+    ],
+  });
+  const page = await browser.newPage();
+  page.on('console', (m) => {
+    const t = m.text();
+    if (t.startsWith(';; B8')) console.error(t);
+  });
+  page.on('pageerror', (e) => console.error('[b8] page error:', e.message));
+  await page.goto(`http://127.0.0.1:${PORT}/`, { waitUntil: 'load' });
+  await page.waitForFunction('window.B8_READY === true || window.B8_ERROR', null, {
+    timeout: 5 * 60 * 1000,
+  });
+  const err = await page.evaluate('window.B8_ERROR || null');
+  if (err) throw new Error(`page failed to initialise: ${err}`);
+
+  const cdp = await page.context().newCDPSession(page);
+  await cdp.send('HeapProfiler.enable');
+  await cdp.send('Runtime.enable');
+
+  const gc = async () => {
+    for (let i = 0; i < 3; i++) {
+      await cdp.send('HeapProfiler.collectGarbage');
+      await sleep(60);
+    }
+  };
+  const readCdp = async () => (await cdp.send('Runtime.getHeapUsage')).usedSize;
+
+  // --- is the precise-memory flag actually on? --------------------------
+  // Without it Chrome quantises usedJSHeapSize to 100 KB and every figure
+  // below would be a rounding artefact. Quantised readings are exact
+  // multiples of 100000; precise ones essentially never are.
+  const probes = await page.evaluate(() => {
+    const xs = [];
+    let sink = 0;
+    for (let i = 0; i < 8; i++) {
+      const a = new Array(2000).fill(0.5);
+      sink += a[0];
+      xs.push(window.B8.mem());
+    }
+    window.__b8sink = sink;
+    return xs;
+  });
+  const precise = probes.some((v) => v > 0 && v % 100000 !== 0);
+  if (!precise) {
+    throw new Error(
+      `--enable-precise-memory-info did not take: readings ${JSON.stringify(probes)} are all ` +
+        `multiples of 100000, so usedJSHeapSize is quantised and unusable`
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // One window
+  // -------------------------------------------------------------------------
+
+  async function window_(arm, kind, doubles, published) {
+    await page.evaluate((d) => window.B8.prepare(d), doubles);
+    await page.evaluate(() => window.B8.seed());
+    await gc();
+    const pre = await readCdp();
+    const r = published
+      ? await page.evaluate(
+          ([a, k, n]) => window.B8.runPub(a, k, n),
+          [arm, kind, WRITES]
+        )
+      : await page.evaluate(
+          ([a, k, n]) => window.B8.run(a, k, n),
+          [arm, kind, WRITES]
+        );
+    const post = await readCdp();
+    await gc();
+    const settled = await readCdp();
+    return {
+      arm,
+      kind,
+      doubles,
+      published: !!published,
+      writes: WRITES,
+      cdpAllocated: post - pre,
+      cdpPerWrite: (post - pre) / WRITES,
+      // What survived a full collection: the retention answer to the same
+      // window. If this is a rounding error against cdpAllocated then what
+      // was measured was garbage, which is the whole point.
+      retained: settled - pre,
+      inPage: published
+        ? null
+        : {
+            total: r.total,
+            perWrite: r.total / WRITES,
+            control: r.control,
+            write: r.write,
+            gap: r.gap,
+            force: r.force,
+            decreases: r.decreases,
+            worstDrop: r['worst-drop'],
+          },
+      bad: r.bad,
+      // THE GATE. Any decrease means a collection ran inside the window and
+      // the difference of the endpoints is not an allocation total.
+      accepted: published ? r.bad === 0 : r.decreases === 0 && r.bad === 0,
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // The sampling profiler, as a NEGATIVE control
+  // -------------------------------------------------------------------------
+
+  async function samplerControl(kind) {
+    await page.evaluate((d) => window.B8.prepare(d), CTL_2);
+    await page.evaluate(() => window.B8.seed());
+    await gc();
+    await cdp.send('HeapProfiler.startSampling', { samplingInterval: 4096 });
+    const pre = await readCdp();
+    const r = await page.evaluate(
+      ([a, k, n]) => window.B8.run(a, k, n),
+      ['freehand-interpreted', kind, WRITES]
+    );
+    const post = await readCdp();
+    const { profile } = await cdp.send('HeapProfiler.stopSampling');
+    let sampled = 0;
+    (function walk(node) {
+      for (const s of node.selfSize !== undefined ? [node] : []) sampled += s.selfSize;
+      for (const c of node.children || []) walk(c);
+    })(profile.head);
+    return {
+      // Known by construction: the control allocates and drops 8·CTL_2
+      // bytes on every one of WRITES writes, and nothing holds any of it.
+      controlGarbageBytes: 8 * CTL_2 * WRITES,
+      counterAllocated: post - pre,
+      samplerTotal: sampled,
+      note:
+        'the sampler is pointed at a window whose garbage content is known; it reports what ' +
+        'survived, not what was allocated',
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // Rounds
+  // -------------------------------------------------------------------------
+
+  const rows = [];
+  for (const kind of KINDS) {
+    // A warm-up window per arm, never read: first-call compilation, inline
+    // caches and one-time module state are not what this asks about, and
+    // charged to round 1 they read as allocation per write.
+    console.error(`[b8] ${kind}: warm-up ...`);
+    for (const arm of ARMS) await window_(arm, kind, 0, false);
+
+    for (let round = 0; round < ROUNDS; round++) {
+      console.error(`[b8] ${kind}: round ${round + 1}/${ROUNDS}`);
+      for (let j = 0; j < ARMS.length; j++) {
+        const arm = ARMS[(j + round) % ARMS.length];
+        rows.push({ round, ...(await window_(arm, kind, 0, false)) });
+        rows.push({ round, ...(await window_(arm, kind, 0, true)) });
+        if (LADDER_ARMS.includes(arm)) {
+          rows.push({ round, ...(await window_(arm, kind, CTL_1, false)) });
+          rows.push({ round, ...(await window_(arm, kind, CTL_2, false)) });
+        }
+      }
+    }
+  }
+
+  console.error('[b8] sampler negative control ...');
+  const sampler = await samplerControl(KINDS[0]);
+
+  await browser.close();
+  return { rows, sampler, precise: { probes } };
+}
+
+// ---------------------------------------------------------------------------
+// Report
+// ---------------------------------------------------------------------------
+
+function stat(xs) {
+  if (!xs.length) return null;
+  const s = [...xs].sort((a, b) => a - b);
+  const mean = s.reduce((a, b) => a + b, 0) / s.length;
+  return { mean, min: s[0], max: s[s.length - 1], n: s.length };
+}
+const fmt = (v) => (v === null || v === undefined ? '-' : Math.round(v).toLocaleString('en-US'));
+
+function report(out) {
+  const { rows, sampler } = out;
+  const kinds = [...new Set(rows.map((r) => r.kind))];
+  const summary = {};
+
+  for (const kind of kinds) {
+    const of = (arm, doubles, published) =>
+      rows.filter(
+        (r) =>
+          r.kind === kind &&
+          r.arm === arm &&
+          r.doubles === doubles &&
+          r.published === !!published &&
+          r.accepted
+      );
+
+    console.log(`\n;; ==== B8 — bytes allocated per ${kind.toUpperCase()} write ====`);
+    const all = rows.filter((r) => r.kind === kind);
+    const acc = all.filter((r) => r.accepted);
+    console.log(
+      `;; windows: ${acc.length} accepted of ${all.length}; ` +
+        `${all.length - acc.length} rejected for a collection inside the window`
+    );
+    console.log(
+      `;; unverified writes: ${all.reduce((a, r) => a + (r.arm === 'instrument' ? 0 : r.bad), 0)} of ` +
+        `${all.filter((r) => r.arm !== 'instrument').length * WRITES} ` +
+        `(the instrument arm renders no cell and is excluded)`
+    );
+
+    // --- positive control -------------------------------------------------
+    console.log(';;');
+    console.log(';; POSITIVE CONTROL — garbage of predicted size, seen by the instrument');
+    console.log(';;   arm                 direct leg B/write   slope B/double [pred 8.000]');
+    const ctl = {};
+    for (const arm of LADDER_ARMS) {
+      const d1 = of(arm, CTL_1, false);
+      const d2 = of(arm, CTL_2, false);
+      const b0 = stat(of(arm, 0, false).map((r) => r.inPage.perWrite));
+      const b1 = stat(d1.map((r) => r.inPage.perWrite));
+      const b2 = stat(d2.map((r) => r.inPage.perWrite));
+      const leg2 = stat(d2.map((r) => r.inPage.control / r.writes));
+      const slope = b1 && b2 ? (b2.mean - b1.mean) / (CTL_2 - CTL_1) : null;
+      const slope0 = b0 && b2 ? (b2.mean - b0.mean) / CTL_2 : null;
+      ctl[arm] = {
+        predictedPerWriteAtCtl2: 8 * CTL_2,
+        directLegAtCtl2: leg2,
+        slopeBytesPerDouble: slope,
+        slopeFromZero: slope0,
+        atZero: b0,
+        at1: b1,
+        at2: b2,
+      };
+      console.log(
+        `;;   ${arm.padEnd(20)} ${fmt(leg2 && leg2.mean).padStart(12)}` +
+          `   [pred ${fmt(8 * CTL_2)}]   ${slope === null ? '-' : slope.toFixed(3)}` +
+          `   (from 0: ${slope0 === null ? '-' : slope0.toFixed(3)})`
+      );
+    }
+
+    // --- the table --------------------------------------------------------
+    console.log(';;');
+    console.log(';; arm                  B/write (counter)     in-page      write leg   force leg   retained');
+    const per = {};
+    for (const arm of ARMS) {
+      const ws = of(arm, 0, false);
+      const cdpS = stat(ws.map((r) => r.cdpPerWrite));
+      const inS = stat(ws.map((r) => r.inPage.perWrite));
+      const wS = stat(ws.map((r) => r.inPage.write / r.writes));
+      const fS = stat(ws.map((r) => r.inPage.force / r.writes));
+      const gS = stat(ws.map((r) => r.inPage.gap / r.writes));
+      const rS = stat(ws.map((r) => r.retained / r.writes));
+      const pub = stat(of(arm, 0, true).map((r) => r.cdpPerWrite));
+      per[arm] = { cdp: cdpS, inPage: inS, write: wS, gap: gS, force: fS, retained: rS, published: pub };
+      if (!cdpS) continue;
+      console.log(
+        `;; ${arm.padEnd(20)} ${fmt(cdpS.mean).padStart(9)} ` +
+          `[${fmt(cdpS.min)}–${fmt(cdpS.max)}]`.padEnd(21) +
+          `${fmt(inS && inS.mean).padStart(9)}  ${fmt(wS && wS.mean).padStart(10)}` +
+          `  ${fmt(fS && fS.mean).padStart(10)}  ${fmt(rS && rS.mean).padStart(9)}`
+      );
+    }
+
+    // --- mirror vs published ---------------------------------------------
+    console.log(';;');
+    console.log(';; MIRROR vs PUBLISHED window (counter B/write), and in-page vs CDP:');
+    for (const arm of ARMS) {
+      const p = per[arm];
+      if (!p || !p.cdp) continue;
+      const mirrorVsPub = p.published ? (p.cdp.mean / p.published.mean - 1) * 100 : null;
+      const inVsCdp = p.inPage ? (p.inPage.mean / p.cdp.mean - 1) * 100 : null;
+      console.log(
+        `;;   ${arm.padEnd(20)} mirror ${fmt(p.cdp.mean).padStart(9)}  published ` +
+          `${fmt(p.published && p.published.mean).padStart(9)}  ` +
+          `mirror−published ${mirrorVsPub === null ? '-' : mirrorVsPub.toFixed(1) + '%'}  ` +
+          `in-page−CDP ${inVsCdp === null ? '-' : inVsCdp.toFixed(2) + '%'}`
+      );
+    }
+
+    // --- above floor, paired within round ---------------------------------
+    console.log(';;');
+    console.log(';; ABOVE THE FLOOR, paired within round:');
+    const byRound = (arm) => {
+      const m = {};
+      for (const r of of(arm, 0, false)) m[r.round] = r.cdpPerWrite;
+      return m;
+    };
+    const fl = byRound('floor');
+    const above = {};
+    for (const arm of ['reagent', 'freehand-interpreted']) {
+      const a = byRound(arm);
+      const xs = Object.keys(a)
+        .filter((k) => fl[k] !== undefined)
+        .map((k) => a[k] - fl[k]);
+      above[arm] = stat(xs);
+      console.log(
+        `;;   ${arm.padEnd(20)} ${fmt(above[arm] && above[arm].mean).padStart(9)} ` +
+          `[${fmt(above[arm] && above[arm].min)}–${fmt(above[arm] && above[arm].max)}]`
+      );
+    }
+    const ra = byRound('reagent');
+    const fa = byRound('freehand-interpreted');
+    const ratios = Object.keys(fa)
+      .filter((k) => ra[k] !== undefined && ra[k] - fl[k] > 0)
+      .map((k) => (fa[k] - fl[k]) / (ra[k] - fl[k]));
+    const rs = stat(ratios);
+    const rawRatios = Object.keys(fa)
+      .filter((k) => ra[k] > 0)
+      .map((k) => fa[k] / ra[k]);
+    const rrs = stat(rawRatios);
+    console.log(
+      `;;   Freehand ÷ Reagent, above floor: ` +
+        (rs ? `${rs.mean.toFixed(3)} [${rs.min.toFixed(3)}–${rs.max.toFixed(3)}]` : '-') +
+        `   absolute: ` +
+        (rrs ? `${rrs.mean.toFixed(3)} [${rrs.min.toFixed(3)}–${rrs.max.toFixed(3)}]` : '-')
+    );
+
+    summary[kind] = { per, above, ratioAboveFloor: rs, ratioAbsolute: rrs, control: ctl,
+                      windows: { accepted: acc.length, total: all.length } };
+  }
+
+  console.log('\n;; ==== NEGATIVE CONTROL — the sampling heap profiler on the same window ====');
+  console.log(`;;   garbage allocated by the control, by construction: ${fmt(sampler.controlGarbageBytes)} B`);
+  console.log(`;;   the used-heap counter saw:                         ${fmt(sampler.counterAllocated)} B`);
+  console.log(`;;   HeapProfiler sampling total:                       ${fmt(sampler.samplerTotal)} B`);
+
+  return summary;
+}
+
+// ---------------------------------------------------------------------------
+
+(async () => {
+  if (!NO_BUILD) build();
+  const server = serve();
+  let out;
+  let failed = null;
+  try {
+    out = await main();
+    out.summary = report(out);
+  } catch (e) {
+    failed = String(e && e.stack ? e.stack : e);
+  } finally {
+    server.close();
+  }
+  const raw = process.env.B8_RAW_OUT;
+  if (raw && out) {
+    fs.mkdirSync(path.dirname(raw), { recursive: true });
+    fs.writeFileSync(raw, JSON.stringify(out, null, 2));
+    console.error(`[b8] raw data -> ${raw}`);
+  }
+  if (failed) {
+    console.error(`[b8] FAILED: ${failed}`);
+    process.exit(1);
+  }
+  console.error('[b8] ok');
+})();

--- a/implementation/freehand/test/re_frame/freehand/bench/b8_run.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b8_run.cjs
@@ -251,6 +251,8 @@ async function main() {
             force: r.force,
             decreases: r.decreases,
             worstDrop: r.worstDrop,
+            first: r.first,
+            last: r.last,
           },
       bad: r.bad,
       // COLLECTION-FREE, which is not the same as usable. `posSum` is an
@@ -262,6 +264,40 @@ async function main() {
       // validation set, not the whole sample.
       collectionFree: !published && r.decreases === 0,
       accepted: r.bad === 0,
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // The control object, priced by RETENTION — the cross-calibration
+  // -------------------------------------------------------------------------
+  //
+  // `8·D` is arithmetic, not a measurement: it assumes `.slice()` of a
+  // double array costs one 8-byte slot per element and nothing else. The
+  // allocation instrument disagrees with it, stably and reproducibly. So
+  // the same object is priced a second way — hold K copies, collect, read,
+  // release, read — which is B7's instrument, proven on this surface to
+  // 0.17% against a control whose size WAS known.
+  //
+  // If retention and allocation agree on bytes-per-copy, then the object
+  // costs what they both say and the arithmetic was the fiction. If they
+  // disagree, one of the instruments is wrong and no arm should be quoted.
+  async function controlRetention(doubles, k) {
+    await page.evaluate((d) => window.B8.prepare(d), doubles);
+    await gc();
+    const pre = await readCdp();
+    await page.evaluate((n) => window.B8.hold(n), k);
+    await gc();
+    const held = await readCdp();
+    await page.evaluate(() => window.B8.unhold());
+    await gc();
+    const post = await readCdp();
+    return {
+      doubles,
+      copies: k,
+      predictedPerCopy8D: 8 * doubles,
+      retainedPerCopy: (held - pre) / k,
+      bytesPerDouble: (held - pre) / k / doubles,
+      residue: post - pre,
     };
   }
 
@@ -332,11 +368,17 @@ async function main() {
     }
   }
 
+  console.error('[b8] control retention cross-calibration ...');
+  const retention = [];
+  for (const d of [CTL_1, CTL_2]) {
+    for (const k of [20, 40]) retention.push(await controlRetention(d, k));
+  }
+
   console.error('[b8] sampler negative control ...');
   const sampler = await samplerControl(KINDS[0]);
 
   await browser.close();
-  return { rows, sampler, integrity: integ, precise: { probes } };
+  return { rows, sampler, retention, integrity: integ, precise: { probes } };
 }
 
 // ---------------------------------------------------------------------------
@@ -379,16 +421,36 @@ function report(out) {
     // THE IDENTITY. Where nothing was reclaimed, the sum of the rising
     // steps, the endpoint difference and the CDP bracket are three ways of
     // computing one number and must agree. Quoted as the worst case.
-    let worstId = 0;
+    // Two checks, and they answer different questions.
+    //
+    // The BOOKKEEPING identity holds in every window by construction:
+    // rising steps plus falling steps must equal the difference between
+    // the first and last readings. A non-zero here is an arithmetic bug in
+    // the accumulator, nothing to do with V8.
+    //
+    // The INSTRUMENT check holds only where nothing was reclaimed: there
+    // the in-page rising-step sum and the driver's CDP bracket are two
+    // separate readers on one window and must agree. Restricted to arms
+    // that allocate enough for a percentage to mean anything — the
+    // instrument arm's own window is a few hundred bytes wide and a 1 KB
+    // difference there is 100%, which says nothing about the table.
+    let worstBook = 0;
+    for (const r of mir) {
+      worstBook = Math.max(
+        worstBook,
+        Math.abs(r.inPage.posSum + r.inPage.negSum - (r.inPage.last - r.inPage.first))
+      );
+    }
     let worstCdp = 0;
-    for (const r of cf) {
-      worstId = Math.max(worstId, Math.abs(r.inPage.posSum / r.inPage.total - 1));
+    for (const r of cf.filter((x) => x.arm !== 'instrument')) {
       worstCdp = Math.max(worstCdp, Math.abs(r.inPage.posSum / r.cdpAllocated - 1));
     }
     console.log(
-      `;; collection-free identity: rising-step sum vs endpoint difference, worst ` +
-        `${(worstId * 100).toFixed(3)}%; vs the CDP bracket, worst ${(worstCdp * 100).toFixed(2)}% ` +
-        `(the CDP bracket also contains the inter-write seam the legs do not)`
+      `;; bookkeeping identity (rising + falling = last − first): worst residual ${worstBook} B`
+    );
+    console.log(
+      `;; instrument agreement on collection-free windows, in-page rising-step sum vs the CDP ` +
+        `bracket: worst ${(worstCdp * 100).toFixed(2)}%`
     );
     console.log(
       `;; unverified writes: ${all.reduce((a, r) => a + (r.arm === 'instrument' ? 0 : r.bad), 0)} of ` +
@@ -428,7 +490,15 @@ function report(out) {
 
     // --- the table --------------------------------------------------------
     console.log(';;');
-    console.log(';; arm                  B/write (rising-step sum)   CDP     write leg   force leg   retained   GCs');
+    // The legs are `timed-write!`'s own: the state install, the single
+    // microtask yield, and the arm's synchronous drain. WHERE a substrate
+    // does its rendering differs between arms and the split is what shows
+    // it — Freehand's notification runs in the microtask, so its render
+    // lands in the GAP and its `flushSync` is empty; Reagent's `r/flush`
+    // runs inside the drain, so its render lands in FORCE.
+    console.log(
+      ';; arm                  B/write (rising-step sum)   write leg     gap leg   force leg   retained   GCs'
+    );
     const per = {};
     for (const arm of ARMS) {
       const ws = of(arm, 0, false);
@@ -445,8 +515,8 @@ function report(out) {
       if (!inS) continue;
       console.log(
         `;; ${arm.padEnd(20)} ${fmt(inS.mean).padStart(9)} ` +
-          `[${fmt(inS.min)}–${fmt(inS.max)}]`.padEnd(21) +
-          `${fmt(cdpS && cdpS.mean).padStart(9)}  ${fmt(wS && wS.mean).padStart(10)}` +
+          `[${fmt(inS.min)}–${fmt(inS.max)}]`.padEnd(23) +
+          `${fmt(wS && wS.mean).padStart(9)}  ${fmt(gS && gS.mean).padStart(10)}` +
           `  ${fmt(fS && fS.mean).padStart(10)}  ${fmt(rS && rS.mean).padStart(9)}` +
           `  ${(gcS ? gcS.mean.toFixed(1) : '-').padStart(5)}`
       );
@@ -514,8 +584,57 @@ function report(out) {
         (rrs ? `${rrs.mean.toFixed(3)} [${rrs.min.toFixed(3)}–${rrs.max.toFixed(3)}]` : '-')
     );
 
+    // THE FAIRNESS SPLIT, and it is the one `freehand-vs-reagent.md` §2a
+    // insists on. The Freehand arm installs its state through
+    // `frame/replace-app-db!` and a re-frame subscription graph; the
+    // Reagent arm resets a bare `reagent.core/atom`. That is each
+    // substrate's own idiom but it is NOT the same amount of framework,
+    // and a re-frame-shaped Reagent application would pay the write leg
+    // too. So the view leg — the microtask the notification runs in, plus
+    // the synchronous drain — is reported on its own, and it is the
+    // number that is about the VIEW SUBSTRATE rather than about re-frame.
+    console.log(';;');
+    console.log(';; THE VIEW LEG ALONE (gap + force), with the re-frame write leg removed:');
+    const viewByRound = (arm) => {
+      const m = {};
+      for (const r of of(arm, 0, false)) m[r.round] = (r.inPage.gap + r.inPage.force) / r.writes;
+      return m;
+    };
+    const vR = viewByRound('reagent');
+    const vF = viewByRound('freehand-interpreted');
+    const vRs = stat(Object.values(vR));
+    const vFs = stat(Object.values(vF));
+    const vRatio = stat(
+      Object.keys(vF).filter((k) => vR[k] > 0).map((k) => vF[k] / vR[k])
+    );
+    console.log(`;;   reagent              ${fmt(vRs && vRs.mean).padStart(9)} [${fmt(vRs && vRs.min)}–${fmt(vRs && vRs.max)}]`);
+    console.log(`;;   freehand-interpreted ${fmt(vFs && vFs.mean).padStart(9)} [${fmt(vFs && vFs.min)}–${fmt(vFs && vFs.max)}]`);
+    console.log(
+      `;;   Freehand ÷ Reagent on the view leg: ` +
+        (vRatio ? `${vRatio.mean.toFixed(3)} [${vRatio.min.toFixed(3)}–${vRatio.max.toFixed(3)}]` : '-')
+    );
+    const wR = stat(of('reagent', 0, false).map((r) => r.inPage.write / r.writes));
+    const wF = stat(of('freehand-interpreted', 0, false).map((r) => r.inPage.write / r.writes));
+    console.log(
+      `;;   write leg (re-frame vs a bare ratom): freehand ${fmt(wF && wF.mean)} B vs reagent ` +
+        `${fmt(wR && wR.mean)} B`
+    );
+
     summary[kind] = { per, above, ratioAboveFloor: rs, ratioAbsolute: rrs, control: ctl,
-                      windows: { accepted: acc.length, total: all.length } };
+                      viewLeg: { reagent: vRs, freehand: vFs, ratio: vRatio },
+                      writeLeg: { reagent: wR, freehand: wF },
+                      windows: { accepted: acc.length, total: all.length,
+                                 collectionFree: cf.length, mirror: mir.length } };
+  }
+
+  console.log('\n;; ==== CONTROL CROSS-CALIBRATION — the same object, priced two ways ====');
+  console.log(';;   D doubles  copies   retained B/copy   B/double   [8·D predicts 8.000]   residue');
+  for (const r of out.retention || []) {
+    console.log(
+      `;;   ${String(r.doubles).padStart(9)}  ${String(r.copies).padStart(6)}   ` +
+        `${fmt(r.retainedPerCopy).padStart(14)}   ${r.bytesPerDouble.toFixed(3).padStart(8)}` +
+        `                          ${fmt(r.residue).padStart(8)}`
+    );
   }
 
   console.log('\n;; ==== NEGATIVE CONTROL — the sampling heap profiler on the same window ====');

--- a/implementation/freehand/test/re_frame/freehand/bench/b8_run.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b8_run.cjs
@@ -145,6 +145,42 @@ async function main() {
   };
   const readCdp = async () => (await cdp.send('Runtime.getHeapUsage')).usedSize;
 
+  // --- does the bundle read the keys it writes? -------------------------
+  // Closure's advanced renaming does not touch a quoted string key, but it
+  // DOES rename a `(.-foo o)` accessor — and the first draft of this
+  // harness shipped both. `(.-h r)` became `k.Me` while the literal kept
+  // `h`; `(.-bad a)` became `e.Mc` while the literal kept `bad`. The first
+  // threw. The second would not have: `undefined + 1` is `NaN`, the
+  // literal's `bad: 0` would have stood, and the driver would have read
+  // ZERO unverified writes for the rest of time. `decreases` — the gate
+  // that rejects a window with a collection in it — would have read a
+  // constant zero and accepted every window.
+  //
+  // So the bundle is asked, in the build about to be measured, to write
+  // known values through the measured path's own accessors and read them
+  // back. Nothing is measured until it does.
+  const integ = await page.evaluate(() => window.B8.integrity());
+  const wantKeys = [
+    'control', 'write', 'gap', 'force', 'total', 'bad', 'decreases', 'worstDrop', 'first', 'last',
+  ];
+  const gotKeys = integ && typeof integ.keys === 'string' ? integ.keys.split(',') : [];
+  const missing = wantKeys.filter((k) => !gotKeys.includes(k));
+  if (
+    !integ ||
+    integ.control !== 7 ||
+    integ.decreases !== 3 ||
+    integ.worstDrop !== -11 ||
+    integ.bad !== 5 ||
+    missing.length
+  ) {
+    throw new Error(
+      `harness integrity probe FAILED — the :advanced bundle does not read the keys it writes. ` +
+        `got ${JSON.stringify(integ)}; expected control=7 decreases=3 worstDrop=-11 bad=5; ` +
+        `missing keys: ${JSON.stringify(missing)}`
+    );
+  }
+  console.error(`[b8] integrity probe ok — keys ${gotKeys.join(',')}`);
+
   // --- is the precise-memory flag actually on? --------------------------
   // Without it Chrome quantises usedJSHeapSize to 100 KB and every figure
   // below would be a rounding artefact. Quantised readings are exact
@@ -211,7 +247,7 @@ async function main() {
             gap: r.gap,
             force: r.force,
             decreases: r.decreases,
-            worstDrop: r['worst-drop'],
+            worstDrop: r.worstDrop,
           },
       bad: r.bad,
       // THE GATE. Any decrease means a collection ran inside the window and
@@ -283,7 +319,7 @@ async function main() {
   const sampler = await samplerControl(KINDS[0]);
 
   await browser.close();
-  return { rows, sampler, precise: { probes } };
+  return { rows, sampler, integrity: integ, precise: { probes } };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Four beads on the Freehand bench surface. The first is the substantive one.

## 1. rf2-lcsjg — heap UNDER UPDATE: Freehand loses on allocation too

`freehand-vs-reagent-memory.md` (#7146) settled RETAINED heap and Freehand lost it — 2,430 B per sub-free boundary against Reagent's 410 and UIx's 251. It closed by naming the one thing retention cannot see: whether a fine-grained substrate trades standing bytes for lower churn. **It does not.**

| | Freehand | Reagent | floor | ratio |
|---|---:|---:|---:|---:|
| **broad** write, total | 4,572,680 | 269,229 | 144,039 | **17.0×** |
| **broad**, view leg | 3,554,871 | 262,954 | 141,346 | **13.5×** ¹ |
| **narrow** write, total | 478,787 | 23,648 | 140,158 | **20.2×** |
| **narrow**, view leg | 21,376 | 19,307 | 139,461 | **1.107×** |

All ranges disjoint. Two things worth reading twice:

**The narrow write's 20.2× is 95.5% re-frame, not Freehand.** Of the 478,787 B to change one cell, **457,181 is the write leg** — the subscription graph re-evaluating 300 subs to discover 299 unchanged (`rf2-jr76s`). Strip it and Freehand's view substrate is **within 11% of Reagent's**, and *both are ~7× better than the top-down React floor*. Fine-grained reactivity is doing what it claims; Freehand just does not do it better.

¹ **The broad view-leg 13.5× is published as an UPPER BOUND, not a substrate result.** Freehand's arm reads 300 re-frame subscriptions where the Reagent arm reads 300 cursors on a bare ratom, and `rf2-40kdm` (#7151) measured the read path as **95.3–97.4% shared reactive-system cost**. `rf2-mapni` files the arm that would close it.

### The instrument, and why it can see garbage

A collection-free window over V8's used-heap counter: if nothing is reclaimed between two readings, their difference is what was allocated, *including what is already unreachable*. Rising steps accumulate to the total; falling steps are collections and are excluded rather than netted against it. Windows are sized per arm from a calibration probe — a fixed window collection-free for Reagent guarantees a dozen collections for Freehand, a selection effect that would have produced a table with no Freehand row.

**The decisive control — kept vs dropped.** Identical loop, one difference:

| | allocated/copy | retained/copy after |
|---|---:|---:|
| copies **dropped** | 125,121 B | **11 B** |
| copies **kept** | 125,139 B | **99,417 B** |
| **kept ÷ dropped** | **1.0001** | |

The counter reports the same bytes to 0.01% whether the object survives or is thrown away. The CDP sampling profiler, on the same window after a collection, reports **13%** of what was allocated — it is a retention instrument and is not used.

**The positive control's prediction was WRONG and that is reported.** `8 B/double` was arithmetic, not calibration; retention prices the same object at **16.002 B/double** (200,029 B/copy, identical on 20 and 40 copies, residue 0). B7's control failed the same way one bead earlier.

**An eighth instrument fault class.** `#js {:h …}` literals with `(.-h o)` accessors: under `:advanced` Closure renames the accessor and not the key. `k.Me` threw — but in the same build `(.-bad a)` became `e.Mc` and `(.-decreases a)` became `e.fc`, and **neither would have thrown**. `undefined + 1` is `NaN`, the literals' zeros stand, and the driver would have read zero unverified writes forever and — for `decreases`, the gate rejecting windows with a collection in them — a constant zero. The survivors survived only by colliding with Closure's browser externs. Every boundary name is now a string literal through `goog.object`, and `integrity-probe` proves it inside the shipped bundle before anything is measured.

Bookkeeping identity exact in **120/120** windows; **0 unverified of 2,400** writes per row; mirror-vs-published window agreement ≤0.9% on every arm.

## 2. rf2-huhno — the broad row re-taken: the window MOVED

Re-taken on `main` at `7c41225b4b` (carries #7133, `rf2-wxrrp`, #7147).

| leg, p50 ms | pre-#7133 | re-take | |
|---|---:|---:|---|
| **total** | 4.0 [3.9–4.5] | **4.8** [4.6–4.9] | +20%, disjoint |
| **gap** (microtask) | ~0.2 | **3.6–3.9** | ×18 |
| **force** (empty `flushSync`) | 3.0–3.5 | **~0.0** | collapsed |

**Freehand's render moved out of the measured `flushSync` and into the microtask before it.** Nothing vanished — but a reader taking the force leg as Freehand's React time now reads 0.0 and would conclude the substrate became free, and `b6-rows` still describes the gap as a near-empty constant.

Commit phase: *share* fell 30.48% → 26.77% while *milliseconds* rose 1.23 → 1.38. #7133's extra pass costs ≈0.15 ms, not the +0.8 the total moved. **The published interleaved ratio is unchanged: 10.5× → 9.9×**, 0 unverified writes. The page's conclusion stands.

`:ratio-to-floor` deliberately not quoted — the broad floor p50 is 0.2–0.3 ms and it reads 33.44 [25.67–45.00] for a quantity the direct p50s put at ≈30.

Re-taking without the microtask yield is answered **no, not for free** — the 3.6–3.9 ms now in the gap *is* the work. Filed as `rf2-vxfjt`.

## 3. rf2-g88fx — the mount row keeps the frameless arm, and now says what the shipped shape costs

Option (b). The mount row was re-taken in the same run: published arm **3.056 × floor** [2.931–3.226] against Reagent's **1.588** — **1.92× Reagent**; applying #7146's measured ×1.038 puts the shape an application actually ships at **≈2.00× Reagent**. Both numbers and the rejection rationale now sit in the table's own note instead of a linked report. Changing the arm was rejected: the 3.8% correction is smaller than the row's round-to-round spread and re-basing a release-gate row costs more than the third digit it buys.

## 4. rf2-dkcor — the per-boundary constant: recorded, not actioned

The contract stands. All six hooks are named normatively in `spec/006` §The Freehand atomic shell. And the share shrank: with the deficit now ≈4.0 ms the ablation's 0.9 ms is **≈22%**, not 25% — assuming the constant is unchanged, which has not been re-measured. 22% does not close a 10× gap and it is the only lever that costs a contract.

## Beads filed

- `rf2-mapni` (P2) — a Reagent-on-re-frame arm, so the broad view-leg gap stops being an upper bound
- `rf2-jr76s` (P2) — a one-cell write allocates 457 KB re-evaluating 300 unchanged subscriptions
- `rf2-vxfjt` (P3) — re-take the update row without the microtask yield, gated on the non-vacuity check

## Quality gates

| gate | exit |
|---|---|
| `npm run test:freehand` — 1299 tests, 7205 assertions, 0 failures 0 errors (re-run after rebase onto #7147) | **0** |
| `npm run test:cljs` — 11798 tests, 58732 assertions, 0 failures 0 errors | **0** |
| `b8_run.cjs` full run, broad + narrow, 6 rounds — the subject of §1 | **0** |
| `b6_profile_run.cjs` × 3 rounds + `b6_profile_report.cjs` — §2 | **0** |
| `b6_prod_run.cjs` published suite, 0 unverified writes — §2, §3 | **0** |
| `:advanced` release builds of the B8 and profile bundles | **0** |

Deferred to CI: `test:browser`, `mkdocs build --strict` (mkdocs not on PATH), and the full spine.

Raw per-round data: `ai/findings/2026-07-27.b8-alloc-under-update.json` (local-only tree).