### PR TITLE
test(routing): clear the last two prod-gate roster lines (rf2-o5dbf)

### DIFF
--- a/implementation/routing/test/re_frame/routing_navigation_test.clj
+++ b/implementation/routing/test/re_frame/routing_navigation_test.clj
@@ -4,16 +4,101 @@
   `:rf.route/handle-url-change` entry points (fragment handling,
   not-found fallback, fail-closed hostile-URL handling, no-op /
   fragment-only short-circuits, address-bar parity, arity misuse). Split
-  from routing_test.clj per rf2-u8qe7y finding 3."
+  from routing_test.clj per rf2-u8qe7y finding 3.
+
+  ## Posture split (rf2-o5dbf)
+
+  Navigation is production-real and most of this namespace carries no posture
+  guard: the slice writes, the fragment normalisations, the not-found
+  fallbacks and their address-bar parity, the rule-3 / fragment-only
+  short-circuits, `:on-match` fire-and-forget ordering, the in-place +
+  `:query-merge` grammar, the fail-closed open-redirect matrix and the
+  structural gate's REJECTIONS all run in the ordinary `clojure -M:test` suite
+  AND in `scripts/test-routing-prod-gate.sh` (the `-Dre-frame.debug=false`
+  lane).
+
+  What is dev-only is the CHANNEL each of those was observed through. Three
+  families of assertion read the trace bus, which `interop/debug-enabled?`
+  closes at namespace-load time:
+
+    * the lifecycle / nav-token / fragment-changed / plan traces
+      (`trace/emit!`);
+    * the fail-closed advisories `:rf.warning/malformed-url` and
+      `:rf.warning/no-not-found-route`;
+    * and the two error channels — `:rf.error/navigate-bad-request` (the
+      structural gate's DIAGNOSTIC) and `:rf.error/schema-validation-failure`
+      (the param-validation diagnostic).
+
+  Their assertions are kept VERBATIM inside `(when interop/debug-enabled? …)`
+  arms marked `rf2-o5dbf`.
+
+  READ THIS BEFORE FILING THE NEXT LOOK-ALIKE AS A DEFECT. Every rejection
+  those suites assert DOES survive production — none is an rf2-9c2jf-class
+  defect. `re-frame.routing.address/classify` and the event-shape gate run
+  unconditionally and return `{}` from the handler, so a malformed request
+  leaves the slice untouched and pushes no URL under the gate exactly as it
+  does in dev; only the `trace/emit-error!` beside them goes quiet. The
+  param-validation reject at the navigate boundary behaves the same way — the
+  slice is unchanged in BOTH postures — which is a different shape from
+  `routing-nav-fx-schemas-test`'s fx-args gate, where the VERDICT itself
+  short-circuits to `true` under the gate (Spec 010 §Production builds).
+
+  EIGHT assertions here would have passed VACUOUSLY the moment the roster
+  line came off, each a negative over a ring the gate leaves empty:
+  `transitioned-well-formed-url-does-not-emit-malformed-trace` (its ONLY
+  assertion), the `:rf.error/schema-validation-failure` denial on the
+  unmatched-without-404 commit, the two nav-token-allocated denials on the
+  rule-3 / popstate short-circuits, the two on the programmatic fragment-only
+  nav, the `:rf.route/fragment-changed` denial on the identical-target no-op,
+  and — the sharpest — `(is (empty? (filter …)))` in
+  `commit-traces-suppressed-from-trace-disabled-frame`, which is the whole
+  POINT of that deftest and would have certified a leak-suppression the
+  framework never had occasion to perform.
+
+  PRODUCTION WITNESSES were added rather than assertions dropped:
+
+    * `address/classify` is the very fn the handler consults, pure and
+      always-on, so every structural-gate `:reason` / `:keys` claim is now
+      asserted against ITS verdict outside the arm — same rule, same input,
+      no gate between the call and the answer. That also re-proves the
+      heterogeneous-key case's real subject: the canonical ordering that
+      keeps a mixed-kind key set off a `compare`-based `sort`.
+    * the `:frame` tag family is an ATTRIBUTION claim, and attribution is a
+      frame-state fact: each of those deftests now asserts that the commit
+      landed in the non-default frame's own runtime-db and left `:rf/default`
+      alone.
+    * the fragment / nav-token / warning traces announce runtime-db moves,
+      so each now asserts the move — the fragment really steps
+      nil → \"scroll-restoration\" → \"fragments\", the nav-token really is a
+      fresh string, the malformed URL really lands `:reason :malformed-url`,
+      and \"emits none\" really is \"allocated no token, re-fired no loader\".
+
+  Nothing was deleted or weakened."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.fx :as fx]
             [re-frame.identity :as identity]
+            [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
+            [re-frame.routing.address :as address]
             [re-frame.routing.test-support]
             [re-frame.routing-test-support :as rts]))
 
 (use-fixtures :each rts/reset-runtime)
+
+;; ---- rf2-o5dbf: the runtime-db facts a navigation leaves behind -----------
+;;
+;; The trace bus closes under `-Dre-frame.debug=false`; frame state does not.
+;; `frame-slice` reads the route slice of an ARBITRARY frame, which is what
+;; makes the `:frame`-tag deftests below checkable in both postures: a trace
+;; stamped `:frame :route/owner` is claiming the commit belongs to that frame,
+;; and that is a frame-state fact.
+
+(defn- frame-slice
+  "The current route slice for `frame-id`."
+  [frame-id]
+  (get-in (:rf.db/runtime (rf/frame-state-value frame-id))
+          [:rf.runtime/routing :current]))
 
 ;; ---- Spec 012 §Navigation is an event -------------------------------------
 
@@ -308,15 +393,22 @@
       (is (= ["/no/such/path"] @pushed)
           ":rf.nav/push-url pushed the REQUESTED url verbatim — NOT a
            fabricated /404, and no rejection")
-      (is (some (fn [ev] (= :rf.warning/no-not-found-route (:operation ev)))
-                @traces)
-          ":rf.warning/no-not-found-route fires when no 404 route is
-           registered — same signal as the URL-driven path")
-      (is (not-any? (fn [ev]
-                      (= :rf.error/schema-validation-failure (:operation ev)))
-                    @traces)
-          "no schema-validation-failure error — the unmatched path no longer
-           rejects via a route-url throw"))))
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring). BOTH legs read
+      ;; the trace ring, which the gate empties: the second is a NEGATIVE and
+      ;; would have gone green for free. Its real subject — "the unmatched path
+      ;; no longer REJECTS" — is the always-on pair above: the slice committed
+      ;; to :rf.route/not-found and the requested url was pushed. A rejection
+      ;; would have left both empty.
+      (when interop/debug-enabled?
+        (is (some (fn [ev] (= :rf.warning/no-not-found-route (:operation ev)))
+                  @traces)
+            ":rf.warning/no-not-found-route fires when no 404 route is
+             registered — same signal as the URL-driven path")
+        (is (not-any? (fn [ev]
+                        (= :rf.error/schema-validation-failure (:operation ev)))
+                      @traces)
+            "no schema-validation-failure error — the unmatched path no longer
+             rejects via a route-url throw")))))
 
 ;; ---- rf2-0zr2o: programmatic-miss and URL-driven-miss agree on the URL ----
 ;;
@@ -405,8 +497,13 @@
           "external URL is classified before :rf.nav/push-url")
       (is (= :route/home (get-in (:rf.db/runtime (rf/frame-state-value :rf/default)) [:rf.runtime/routing :current :route-id]))
           "external URL does not become an app not-found route")
-      (is (some #(= :rf.route/external-url-requested (:operation %)) @traces)
-          "external classification is observable in the trace stream"))))
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring). The
+      ;; CLASSIFICATION is always-on (the two legs above are its production
+      ;; consequence: no push, no slice rewrite); only its OBSERVABILITY is a
+      ;; trace-stream fact, and the assertion says so in as many words.
+      (when interop/debug-enabled?
+        (is (some #(= :rf.route/external-url-requested (:operation %)) @traces)
+            "external classification is observable in the trace stream")))))
 
 ;; ---- rf2-zlr9k: :rf.route/navigate writes fragment + nav-token + trace --
 ;;
@@ -430,11 +527,14 @@
             ":fragment is assoc'd into the slice (pre-fix: missing)")
         (is (some? (:nav-token slice))
             ":nav-token is allocated (pre-fix: missing)"))
-      (is (some (fn [ev]
-                  (and (= :rf.route.nav-token/allocated (:operation ev))
-                       (= :route/docs (-> ev :tags :route-id))))
-                @traces)
-          ":rf.route.nav-token/allocated trace fires (pre-fix: never)"))))
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring). The ALLOCATION
+      ;; the trace announces is the slice fact asserted just above.
+      (when interop/debug-enabled?
+        (is (some (fn [ev]
+                    (and (= :rf.route.nav-token/allocated (:operation ev))
+                         (= :route/docs (-> ev :tags :route-id))))
+                  @traces)
+            ":rf.route.nav-token/allocated trace fires (pre-fix: never)")))))
 
 (deftest navigate-no-fragment-still-allocates-nav-token
   (testing ":rf.route/navigate without a :fragment opt still writes :nav-token"
@@ -491,12 +591,25 @@
                              (fn [ev] (swap! traces conj ev)))
       (rf/dispatch-sync [:rf.route/handle-url-change "/"])
       (rf/unregister-listener! :trace ::handle-url-token)
-      (is (some (fn [ev]
-                  (and (= :rf.route.nav-token/allocated (:operation ev))
-                       (= :route/home (-> ev :tags :route-id))
-                       (string? (-> ev :tags :nav-token))))
-                @traces)
-          ":rf.route.nav-token/allocated trace fires with the route-id and a fresh token"))))
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): the trace leg below was
+      ;; this deftest's ONLY assertion, so under the gate it would have
+      ;; executed nothing at all. The three facts the trace tags spell — that
+      ;; the URL-driven door allocated, which route it allocated FOR, and that
+      ;; the token is a fresh string — are all on the slice.
+      (let [slice (get-in (:rf.db/runtime (rf/frame-state-value :rf/default))
+                          [:rf.runtime/routing :current])]
+        (is (= :route/home (:route-id slice))
+            "the allocation belongs to the matched route")
+        (is (string? (:nav-token slice))
+            "…and the allocated token is a string, exactly as the tag reports it"))
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (some (fn [ev]
+                    (and (= :rf.route.nav-token/allocated (:operation ev))
+                         (= :route/home (-> ev :tags :route-id))
+                         (string? (-> ev :tags :nav-token))))
+                  @traces)
+            ":rf.route.nav-token/allocated trace fires with the route-id and a fresh token")))))
 
 ;; ---- rf2-h4r9n: unmatched URL writes :rf.route/not-found slice -----------
 ;;
@@ -544,11 +657,16 @@
       (rf/unregister-listener! :trace ::no-not-found)
       (let [slice (get-in (:rf.db/runtime (rf/frame-state-value :rf/default)) [:rf.runtime/routing :current])]
         (is (= :rf.route/not-found (:route-id slice))
-            "slice still rewrites to :rf.route/not-found"))
-      (is (some (fn [ev]
-                  (= :rf.warning/no-not-found-route (:operation ev)))
-                @traces)
-          ":rf.warning/no-not-found-route trace fires when no 404 route is registered"))))
+            "slice still rewrites to :rf.route/not-found")
+        (is (= {:url "/somewhere/unknown"} (:params slice))
+            "…carrying the unmatched URL, which is the CONDITION the advisory
+             reports on — an unmatched URL with no route to render it"))
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (some (fn [ev]
+                    (= :rf.warning/no-not-found-route (:operation ev)))
+                  @traces)
+            ":rf.warning/no-not-found-route trace fires when no 404 route is registered")))))
 
 ;; ---- rf2-4ic0f: malformed URL fail-closed at :rf.route/transitioned -------------
 ;;
@@ -607,17 +725,29 @@
                              (fn [ev] (swap! traces conj ev)))
       (rf/dispatch-sync [:rf.route/transitioned "/articles/%"])
       (rf/unregister-listener! :trace ::malformed-trace)
-      (is (some (fn [ev]
-                  (and (= :rf.warning/malformed-url (:operation ev))
-                       (= "/articles/%" (-> ev :tags :url))))
-                @traces)
-          ":rf.warning/malformed-url trace carries the offending URL")
-      (is (some (fn [ev]
-                  (and (= :rf.error/no-such-handler (:operation ev))
-                       (= :route (-> ev :tags :kind))
-                       (= :malformed-url (-> ev :tags :reason))))
-                @traces)
-          ":rf.error/no-such-handler carries `:reason :malformed-url`"))))
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): both legs below read the
+      ;; trace ring, so under the gate this deftest would have executed
+      ;; nothing. The two facts those tags spell — WHICH url offended, and
+      ;; that the reason is `:malformed-url` rather than a bare miss — are
+      ;; both on the slice, which is what a per-route error UI branches on
+      ;; (Spec 012 §Routing failure semantics).
+      (is (= {:url "/articles/%" :reason :malformed-url}
+             (:params (get-in (:rf.db/runtime (rf/frame-state-value :rf/default))
+                              [:rf.runtime/routing :current])))
+          "the offending URL and its :malformed-url reason reach the slice")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (some (fn [ev]
+                    (and (= :rf.warning/malformed-url (:operation ev))
+                         (= "/articles/%" (-> ev :tags :url))))
+                  @traces)
+            ":rf.warning/malformed-url trace carries the offending URL")
+        (is (some (fn [ev]
+                    (and (= :rf.error/no-such-handler (:operation ev))
+                         (= :route (-> ev :tags :kind))
+                         (= :malformed-url (-> ev :tags :reason))))
+                  @traces)
+            ":rf.error/no-such-handler carries `:reason :malformed-url`")))))
 
 (deftest transitioned-forward-nav-traces-carry-frame-rf2-w3qgc
   (testing "rf2-w3qgc: forward URL-driven nav (`:rf.route/transitioned`)
@@ -637,24 +767,41 @@
                {:platforms #{:server :client}}
                (fn [_ _] nil))
 
+    ;; rf2-o5dbf: every assertion in this deftest reads a trace tag, so under
+    ;; `-Dre-frame.debug=false` it would execute nothing. What each tag CLAIMS,
+    ;; though, is an attribution — "this diagnostic belongs to :route/owner" —
+    ;; and attribution is a frame-state fact. Each block therefore asserts,
+    ;; always-on, that the nav really was carried out in the named frame and
+    ;; left the OTHER frame alone. A regression that re-hardcoded `:rf/default`
+    ;; in `url-change-fx`'s frame threading would move the commit too.
+
     (testing "non-default frame: malformed URL → frame-tagged traces"
       (let [traces (atom [])]
         (rf/register-listener! :trace ::w3qgc-malformed
                                (fn [ev] (swap! traces conj ev)))
         (rf/dispatch-sync [:rf.route/transitioned "/articles/%"] {:frame :route/owner})
         (rf/unregister-listener! :trace ::w3qgc-malformed)
-        (is (some (fn [ev]
-                    (and (= :rf.warning/malformed-url (:operation ev))
-                         (= "/articles/%" (-> ev :tags :url))
-                         (= :route/owner (-> ev :tags :frame))))
-                  @traces)
-            ":rf.warning/malformed-url carries :frame :route/owner on forward nav")
-        (is (some (fn [ev]
-                    (and (= :rf.error/no-such-handler (:operation ev))
-                         (= :route (-> ev :tags :kind))
-                         (= :route/owner (-> ev :tags :frame))))
-                  @traces)
-            ":rf.error/no-such-handler {:kind :route} carries :frame :route/owner")))
+        ;; SEMANTIC, posture-independent (rf2-o5dbf).
+        (is (= {:url "/articles/%" :reason :malformed-url}
+               (:params (frame-slice :route/owner)))
+            "the malformed nav was carried out IN :route/owner — the same frame
+             the diagnostics claim")
+        (is (nil? (:route-id (frame-slice :rf/default)))
+            "…and :rf/default was not touched")
+        ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+        (when interop/debug-enabled?
+          (is (some (fn [ev]
+                      (and (= :rf.warning/malformed-url (:operation ev))
+                           (= "/articles/%" (-> ev :tags :url))
+                           (= :route/owner (-> ev :tags :frame))))
+                    @traces)
+              ":rf.warning/malformed-url carries :frame :route/owner on forward nav")
+          (is (some (fn [ev]
+                      (and (= :rf.error/no-such-handler (:operation ev))
+                           (= :route (-> ev :tags :kind))
+                           (= :route/owner (-> ev :tags :frame))))
+                    @traces)
+              ":rf.error/no-such-handler {:kind :route} carries :frame :route/owner"))))
 
     (testing "non-default frame: bare miss with no 404 route → frame-tagged
               :rf.warning/no-not-found-route + :rf.error/no-such-handler"
@@ -663,16 +810,23 @@
                                (fn [ev] (swap! traces conj ev)))
         (rf/dispatch-sync [:rf.route/transitioned "/no/such/route"] {:frame :route/owner})
         (rf/unregister-listener! :trace ::w3qgc-nonotfound)
-        (is (some (fn [ev]
-                    (and (= :rf.warning/no-not-found-route (:operation ev))
-                         (= :route/owner (-> ev :tags :frame))))
-                  @traces)
-            ":rf.warning/no-not-found-route carries :frame :route/owner")
-        (is (some (fn [ev]
-                    (and (= :rf.error/no-such-handler (:operation ev))
-                         (= :route/owner (-> ev :tags :frame))))
-                  @traces)
-            ":rf.error/no-such-handler carries :frame :route/owner")))
+        ;; SEMANTIC, posture-independent (rf2-o5dbf).
+        (is (= {:url "/no/such/route"} (:params (frame-slice :route/owner)))
+            "the bare miss was carried out IN :route/owner")
+        (is (nil? (:route-id (frame-slice :rf/default)))
+            "…and :rf/default was not touched")
+        ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+        (when interop/debug-enabled?
+          (is (some (fn [ev]
+                      (and (= :rf.warning/no-not-found-route (:operation ev))
+                           (= :route/owner (-> ev :tags :frame))))
+                    @traces)
+              ":rf.warning/no-not-found-route carries :frame :route/owner")
+          (is (some (fn [ev]
+                      (and (= :rf.error/no-such-handler (:operation ev))
+                           (= :route/owner (-> ev :tags :frame))))
+                    @traces)
+              ":rf.error/no-such-handler carries :frame :route/owner"))))
 
     (testing "default-frame forward nav STILL tags :rf/default (regression guard)"
       (let [traces (atom [])]
@@ -680,12 +834,20 @@
                                (fn [ev] (swap! traces conj ev)))
         (rf/dispatch-sync [:rf.route/transitioned "/articles/%"] {:frame :rf/default})
         (rf/unregister-listener! :trace ::w3qgc-default)
-        (is (some (fn [ev]
-                    (and (= :rf.error/no-such-handler (:operation ev))
-                         (= :rf/default (-> ev :tags :frame))))
-                  @traces)
-            "default-frame dispatch tags :rf/default (not nil) — matches the
-             popstate/SSR sibling and the programmatic path")))))
+        ;; SEMANTIC, posture-independent (rf2-o5dbf): the regression this
+        ;; guards against is a nil / synthesised frame, and the commit landing
+        ;; in :rf/default is the same statement about the same threaded stamp.
+        (is (= {:url "/articles/%" :reason :malformed-url}
+               (:params (frame-slice :rf/default)))
+            "the default-frame dispatch really was carried out in :rf/default")
+        ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+        (when interop/debug-enabled?
+          (is (some (fn [ev]
+                      (and (= :rf.error/no-such-handler (:operation ev))
+                           (= :rf/default (-> ev :tags :frame))))
+                    @traces)
+              "default-frame dispatch tags :rf/default (not nil) — matches the
+               popstate/SSR sibling and the programmatic path"))))))
 
 (deftest transitioned-well-formed-url-does-not-emit-malformed-trace
   (testing "the regular happy path emits NO :rf.warning/malformed-url"
@@ -699,9 +861,23 @@
                              (fn [ev] (swap! traces conj ev)))
       (rf/dispatch-sync [:rf.route/transitioned "/search?q=clojure"])
       (rf/unregister-listener! :trace ::no-malformed-trace)
-      (is (not-any? (fn [ev] (= :rf.warning/malformed-url (:operation ev)))
-                    @traces)
-          "well-formed URL → no malformed-URL trace"))))
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): the leg below is a NEGATIVE
+      ;; over the trace ring AND was this deftest's only assertion, so under
+      ;; the gate it would have certified "no malformed-URL diagnostic" for a
+      ;; diagnostic channel that emits nothing at all. The always-on spelling
+      ;; of "this URL is well-formed" is the slice: it MATCHED, and it carries
+      ;; no `:reason` discriminator.
+      (let [slice (get-in (:rf.db/runtime (rf/frame-state-value :rf/default))
+                          [:rf.runtime/routing :current])]
+        (is (= :route/search (:route-id slice))
+            "the well-formed URL matched its route — no fail-closed fallback")
+        (is (= {} (:params slice))
+            "…with no {:url … :reason :malformed-url} not-found params"))
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (not-any? (fn [ev] (= :rf.warning/malformed-url (:operation ev)))
+                      @traces)
+            "well-formed URL → no malformed-URL trace")))))
 
 ;; ---- EP-0037 R1: :on-match is fire-and-forget, never drives readiness ----
 ;;
@@ -786,38 +962,55 @@
                (fn [_ _] nil))
     ;; Land on /docs/routing first (no fragment).
     (rf/dispatch-sync [:rf.route/transitioned "/docs/routing"])
-    (let [traces (atom [])]
+    (let [traces    (atom [])
+          observed  (atom [])
+          record!   #(swap! observed conj (:fragment (frame-slice :rf/default)))]
+      (record!)
       (rf/register-listener! :trace ::frag-only (fn [ev] (swap! traces conj ev)))
       ;; Same path/query, different fragment → fragment-only nav.
       (rf/dispatch-sync [:rf.route/transitioned "/docs/routing#scroll-restoration"])
+      (record!)
       ;; And again — prev→next this time.
       (rf/dispatch-sync [:rf.route/transitioned "/docs/routing#fragments"])
+      (record!)
       (rf/unregister-listener! :trace ::frag-only)
-      (let [frag-events (filter #(= :rf.route/fragment-changed (:operation %)) @traces)]
-        (is (= 2 (count frag-events))
-            "two fragment-only changes emit two :rf.route/fragment-changed traces")
-        (let [first-ev  (first  frag-events)
-              second-ev (second frag-events)]
-          (is (= :route/docs (-> first-ev :tags :route-id))
-              "first trace tags :route-id")
-          (is (nil? (-> first-ev :tags :prev-fragment))
-              "first transition: prev-fragment is nil (no fragment before)")
-          (is (= "scroll-restoration" (-> first-ev :tags :next-fragment))
-              "first transition: next-fragment is the new value")
-          (is (= "scroll-restoration" (-> second-ev :tags :prev-fragment))
-              "second transition: prev-fragment is the previous value")
-          (is (= "fragments" (-> second-ev :tags :next-fragment))
-              "second transition: next-fragment is the new value")
-          ;; rf2-n0851k: the fragment-only trace must carry the frame
-          ;; stamp under :tags :frame (Spec 012 §Multi-frame routing /
-          ;; Spec 009). Without it the trace is dropped from epoch/Xray
-          ;; capture (which buffers only frame-tagged events) and bypasses
-          ;; the frame-level trace-disable gate. The forward-nav
-          ;; (:rf.route/transitioned) path runs on the :rf/default frame.
-          (is (= :rf/default (-> first-ev :tags :frame))
-              "rf2-n0851k: forward-nav fragment-only trace is frame-attributed")
-          (is (= :rf/default (-> second-ev :tags :frame))
-              "rf2-n0851k: second fragment-only trace is frame-attributed too"))))))
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): every assertion below reads
+      ;; the trace bus, so under the gate this deftest would execute nothing.
+      ;; What the :prev-fragment / :next-fragment pair REPORTS, though, is the
+      ;; slice stepping through those exact values — recorded here as it goes,
+      ;; which is the only way to see a "prev" after the fact.
+      (is (= [nil "scroll-restoration" "fragments"] @observed)
+          "the slice's :fragment really stepped nil → #scroll-restoration →
+           #fragments — the two transitions the two traces report")
+      (is (= :route/docs (:route-id (frame-slice :rf/default)))
+          "…on :route/docs, the route the traces tag")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (let [frag-events (filter #(= :rf.route/fragment-changed (:operation %)) @traces)]
+          (is (= 2 (count frag-events))
+              "two fragment-only changes emit two :rf.route/fragment-changed traces")
+          (let [first-ev  (first  frag-events)
+                second-ev (second frag-events)]
+            (is (= :route/docs (-> first-ev :tags :route-id))
+                "first trace tags :route-id")
+            (is (nil? (-> first-ev :tags :prev-fragment))
+                "first transition: prev-fragment is nil (no fragment before)")
+            (is (= "scroll-restoration" (-> first-ev :tags :next-fragment))
+                "first transition: next-fragment is the new value")
+            (is (= "scroll-restoration" (-> second-ev :tags :prev-fragment))
+                "second transition: prev-fragment is the previous value")
+            (is (= "fragments" (-> second-ev :tags :next-fragment))
+                "second transition: next-fragment is the new value")
+            ;; rf2-n0851k: the fragment-only trace must carry the frame
+            ;; stamp under :tags :frame (Spec 012 §Multi-frame routing /
+            ;; Spec 009). Without it the trace is dropped from epoch/Xray
+            ;; capture (which buffers only frame-tagged events) and bypasses
+            ;; the frame-level trace-disable gate. The forward-nav
+            ;; (:rf.route/transitioned) path runs on the :rf/default frame.
+            (is (= :rf/default (-> first-ev :tags :frame))
+                "rf2-n0851k: forward-nav fragment-only trace is frame-attributed")
+            (is (= :rf/default (-> second-ev :tags :frame))
+                "rf2-n0851k: second fragment-only trace is frame-attributed too")))))))
 
 ;; ---- rf2-8oxj6: popstate honours the fragment-only rule ----------------
 ;;
@@ -868,19 +1061,27 @@
               "rule 4: :on-match did NOT re-fire on fragment-only popstate"))
         ;; The fragment-only branch emits :rf.route/fragment-changed and
         ;; NEVER a :rf.route.nav-token/allocated on the same drain.
-        (is (some #(= :rf.route/fragment-changed (:operation %)) @traces)
-            "fragment-only popstate emits :rf.route/fragment-changed")
-        (is (not-any? #(= :rf.route.nav-token/allocated (:operation %)) @traces)
-            "fragment-only popstate emits NO :rf.route.nav-token/allocated")
-        ;; rf2-n0851k: the popstate (handle-url-change) fragment-only trace
-        ;; carries the frame stamp too — same contract as the forward-nav
-        ;; path, so epoch/Xray capture and the frame trace-disable gate
-        ;; cover popstate fragment-only changes.
-        (is (= :rf/default
-               (some->> @traces
-                        (filter #(= :rf.route/fragment-changed (:operation %)))
-                        first :tags :frame))
-            "rf2-n0851k: popstate fragment-only trace is frame-attributed")))))
+        ;;
+        ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring). The three
+        ;; runtime-db legs just above ARE these three traces' subject: the
+        ;; fragment moved (fragment-changed), no token was allocated (the
+        ;; nav-token denial — a NEGATIVE over the ring, green for free under
+        ;; the gate), and the whole nav ran on the :rf/default frame whose
+        ;; slice those legs read (the frame stamp).
+        (when interop/debug-enabled?
+          (is (some #(= :rf.route/fragment-changed (:operation %)) @traces)
+              "fragment-only popstate emits :rf.route/fragment-changed")
+          (is (not-any? #(= :rf.route.nav-token/allocated (:operation %)) @traces)
+              "fragment-only popstate emits NO :rf.route.nav-token/allocated")
+          ;; rf2-n0851k: the popstate (handle-url-change) fragment-only trace
+          ;; carries the frame stamp too — same contract as the forward-nav
+          ;; path, so epoch/Xray capture and the frame trace-disable gate
+          ;; cover popstate fragment-only changes.
+          (is (= :rf/default
+                 (some->> @traces
+                          (filter #(= :rf.route/fragment-changed (:operation %)))
+                          first :tags :frame))
+              "rf2-n0851k: popstate fragment-only trace is frame-attributed"))))))
 
 ;; ============================================================================
 ;; rf2-ee38b.8 — Spec 012 §Per-route data loading rule 3:
@@ -921,8 +1122,13 @@
               "rule 3: no NEW nav-token on identical re-navigation")
           (is (= 1 @on-match-calls)
               "rule 3: :on-match did NOT re-fire on identical re-navigation"))
-        (is (not-any? #(= :rf.route.nav-token/allocated (:operation %)) @traces)
-            "identical re-navigation emits NO :rf.route.nav-token/allocated")))))
+        ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring). A NEGATIVE
+        ;; over the trace ring: green for free under the gate. Its subject —
+        ;; "no fresh token was allocated" — is the `(= "nav-1" (:nav-token …))`
+        ;; leg above, which is always-on and has teeth.
+        (when interop/debug-enabled?
+          (is (not-any? #(= :rf.route.nav-token/allocated (:operation %)) @traces)
+              "identical re-navigation emits NO :rf.route.nav-token/allocated"))))))
 
 (deftest changed-params-still-refires-on-match
   (testing "rf2-ee38b.8 / Spec 012 rule 3: CHANGED params DO re-fire
@@ -1005,13 +1211,26 @@
                 "slice still on the previously-valid route (not desynced)")
             (is (empty? @pushed)
                 "rejected navigation pushes NO URL (no recovery to \"/\")")
-            (let [err (first (filter #(= :rf.error/schema-validation-failure
-                                         (:operation %))
-                                     @traces))]
-              (is (some? err)
-                  ":rf.error/schema-validation-failure emitted on reject")
-              (is (= :event (-> err :tags :where))
-                  "error tags :where :event (event-boundary path)"))))
+            ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+            ;;
+            ;; READ THIS BEFORE CALLING THE NEXT LOOK-ALIKE A DEFECT: the
+            ;; REJECT ITSELF survives production. The three legs above run
+            ;; unguarded under `-Dre-frame.debug=false` and pass — slice
+            ;; identical, route unchanged, nothing pushed — so a caller bug
+            ;; still fails closed in a production build. Only the
+            ;; `:rf.error/schema-validation-failure` DIAGNOSTIC is dev-only
+            ;; (`trace/emit-error!`). That is a different shape from the
+            ;; fx-args gate in `routing-nav-fx-schemas-test`, where the
+            ;; VERDICT short-circuits to `true` under the gate per Spec 010
+            ;; §Production builds; here the verdict is computed either way.
+            (when interop/debug-enabled?
+              (let [err (first (filter #(= :rf.error/schema-validation-failure
+                                           (:operation %))
+                                       @traces))]
+                (is (some? err)
+                    ":rf.error/schema-validation-failure emitted on reject")
+                (is (= :event (-> err :tags :where))
+                    "error tags :where :event (event-boundary path)")))))
         (finally (restore))))))
 
 ;; ---- T8: :fragment in slice after URL-driven nav -----------------------
@@ -1257,40 +1476,65 @@
     (fx/reg-fx :rf.nav/push-url
                {:platforms #{:server :client}}
                (fn [_ _] nil))
+    ;; rf2-o5dbf: every assertion here reads a trace tag. The tags' CLAIM is
+    ;; that the activate / deactivate / allocate lifecycle belongs to
+    ;; :route/owner, and that is a frame-state fact — so each block asserts,
+    ;; always-on, that the route really activated in :route/owner's runtime-db
+    ;; and that :rf/default never moved. A regression that re-hardcoded
+    ;; `:rf/default` on the commit path fails here in BOTH postures.
+    ;;
     ;; First nav (no prior route): only nav-token-allocated + activated fire.
     (let [traces (atom [])]
       (rf/register-listener! :trace ::dbmj6x-nav1 (fn [ev] (swap! traces conj ev)))
       (rf/dispatch-sync [:rf.route/navigate {:to :route/from}] {:frame :route/owner})
       (rf/unregister-listener! :trace ::dbmj6x-nav1)
-      (is (some (fn [ev]
-                  (and (= :rf.route.nav-token/allocated (:operation ev))
-                       (= :route/from (-> ev :tags :route-id))
-                       (= :route/owner (-> ev :tags :frame))))
-                @traces)
-          ":rf.route.nav-token/allocated carries :frame :route/owner (pre-fix: absent)")
-      (is (some (fn [ev]
-                  (and (= :rf.route/activated (:operation ev))
-                       (= :route/from (-> ev :tags :route-id))
-                       (= :route/owner (-> ev :tags :frame))))
-                @traces)
-          ":rf.route/activated carries :frame :route/owner (pre-fix: absent)"))
+      ;; SEMANTIC, posture-independent (rf2-o5dbf).
+      (is (= :route/from (:route-id (frame-slice :route/owner)))
+          ":route/from ACTIVATED in :route/owner — the frame the traces tag")
+      (is (some? (:nav-token (frame-slice :route/owner)))
+          "…and the nav-token was allocated into that frame's slice")
+      (is (nil? (:route-id (frame-slice :rf/default)))
+          "…while :rf/default never moved")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (some (fn [ev]
+                    (and (= :rf.route.nav-token/allocated (:operation ev))
+                         (= :route/from (-> ev :tags :route-id))
+                         (= :route/owner (-> ev :tags :frame))))
+                  @traces)
+            ":rf.route.nav-token/allocated carries :frame :route/owner (pre-fix: absent)")
+        (is (some (fn [ev]
+                    (and (= :rf.route/activated (:operation ev))
+                         (= :route/from (-> ev :tags :route-id))
+                         (= :route/owner (-> ev :tags :frame))))
+                  @traces)
+            ":rf.route/activated carries :frame :route/owner (pre-fix: absent)")))
     ;; Cross-route nav: deactivated + activated both carry the frame.
     (let [traces (atom [])]
       (rf/register-listener! :trace ::dbmj6x-nav2 (fn [ev] (swap! traces conj ev)))
       (rf/dispatch-sync [:rf.route/navigate {:to :route/to}] {:frame :route/owner})
       (rf/unregister-listener! :trace ::dbmj6x-nav2)
-      (is (some (fn [ev]
-                  (and (= :rf.route/deactivated (:operation ev))
-                       (= :route/from (-> ev :tags :route-id))
-                       (= :route/owner (-> ev :tags :frame))))
-                @traces)
-          ":rf.route/deactivated carries :frame :route/owner (pre-fix: absent)")
-      (is (some (fn [ev]
-                  (and (= :rf.route/activated (:operation ev))
-                       (= :route/to (-> ev :tags :route-id))
-                       (= :route/owner (-> ev :tags :frame))))
-                @traces)
-          ":rf.route/activated (cross-route) carries :frame :route/owner"))))
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): the cross-route move —
+      ;; :route/from DEACTIVATED, :route/to ACTIVATED — is one slice write in
+      ;; :route/owner, and :rf/default still holds neither route.
+      (is (= :route/to (:route-id (frame-slice :route/owner)))
+          "the cross-route move landed in :route/owner")
+      (is (nil? (:route-id (frame-slice :rf/default)))
+          "…and :rf/default still never moved")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (some (fn [ev]
+                    (and (= :rf.route/deactivated (:operation ev))
+                         (= :route/from (-> ev :tags :route-id))
+                         (= :route/owner (-> ev :tags :frame))))
+                  @traces)
+            ":rf.route/deactivated carries :frame :route/owner (pre-fix: absent)")
+        (is (some (fn [ev]
+                    (and (= :rf.route/activated (:operation ev))
+                         (= :route/to (-> ev :tags :route-id))
+                         (= :route/owner (-> ev :tags :frame))))
+                  @traces)
+            ":rf.route/activated (cross-route) carries :frame :route/owner")))))
 
 (deftest commit-traces-carry-frame-url-driven-rf2-dbmj6x
   (testing "rf2-dbmj6x: URL-driven `:rf.route/transitioned` /
@@ -1303,38 +1547,58 @@
     (fx/reg-fx :rf.nav/push-url
                {:platforms #{:server :client}}
                (fn [_ _] nil))
+    ;; rf2-o5dbf: as in the programmatic sibling above, the tags claim an
+    ;; ATTRIBUTION, and attribution is checkable off frame state in both
+    ;; postures.
+    ;;
     ;; :rf.route/transitioned (forward nav).
     (let [traces (atom [])]
       (rf/register-listener! :trace ::dbmj6x-url1 (fn [ev] (swap! traces conj ev)))
       (rf/dispatch-sync [:rf.route/transitioned "/from"] {:frame :route/owner})
       (rf/unregister-listener! :trace ::dbmj6x-url1)
-      (is (some (fn [ev]
-                  (and (= :rf.route.nav-token/allocated (:operation ev))
-                       (= :route/owner (-> ev :tags :frame))))
-                @traces)
-          "transitioned: :rf.route.nav-token/allocated carries :frame :route/owner")
-      (is (some (fn [ev]
-                  (and (= :rf.route/activated (:operation ev))
-                       (= :route/owner (-> ev :tags :frame))))
-                @traces)
-          "transitioned: :rf.route/activated carries :frame :route/owner"))
+      ;; SEMANTIC, posture-independent (rf2-o5dbf).
+      (is (= :route/from (:route-id (frame-slice :route/owner)))
+          "transitioned: the forward nav activated in :route/owner")
+      (is (some? (:nav-token (frame-slice :route/owner)))
+          "transitioned: …allocating into that frame's slice")
+      (is (nil? (:route-id (frame-slice :rf/default)))
+          "transitioned: …and :rf/default never moved")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (some (fn [ev]
+                    (and (= :rf.route.nav-token/allocated (:operation ev))
+                         (= :route/owner (-> ev :tags :frame))))
+                  @traces)
+            "transitioned: :rf.route.nav-token/allocated carries :frame :route/owner")
+        (is (some (fn [ev]
+                    (and (= :rf.route/activated (:operation ev))
+                         (= :route/owner (-> ev :tags :frame))))
+                  @traces)
+            "transitioned: :rf.route/activated carries :frame :route/owner")))
     ;; :rf.route/handle-url-change (popstate / SSR) cross-route → deactivated.
     (let [traces (atom [])]
       (rf/register-listener! :trace ::dbmj6x-url2 (fn [ev] (swap! traces conj ev)))
       (rf/dispatch-sync [:rf.route/handle-url-change "/to"] {:frame :route/owner})
       (rf/unregister-listener! :trace ::dbmj6x-url2)
-      (is (some (fn [ev]
-                  (and (= :rf.route/deactivated (:operation ev))
-                       (= :route/from (-> ev :tags :route-id))
-                       (= :route/owner (-> ev :tags :frame))))
-                @traces)
-          "handle-url-change: :rf.route/deactivated carries :frame :route/owner")
-      (is (some (fn [ev]
-                  (and (= :rf.route/activated (:operation ev))
-                       (= :route/to (-> ev :tags :route-id))
-                       (= :route/owner (-> ev :tags :frame))))
-                @traces)
-          "handle-url-change: :rf.route/activated carries :frame :route/owner"))))
+      ;; SEMANTIC, posture-independent (rf2-o5dbf).
+      (is (= :route/to (:route-id (frame-slice :route/owner)))
+          "handle-url-change: the cross-route move landed in :route/owner")
+      (is (nil? (:route-id (frame-slice :rf/default)))
+          "handle-url-change: …and :rf/default still never moved")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (some (fn [ev]
+                    (and (= :rf.route/deactivated (:operation ev))
+                         (= :route/from (-> ev :tags :route-id))
+                         (= :route/owner (-> ev :tags :frame))))
+                  @traces)
+            "handle-url-change: :rf.route/deactivated carries :frame :route/owner")
+        (is (some (fn [ev]
+                    (and (= :rf.route/activated (:operation ev))
+                         (= :route/to (-> ev :tags :route-id))
+                         (= :route/owner (-> ev :tags :frame))))
+                  @traces)
+            "handle-url-change: :rf.route/activated carries :frame :route/owner")))))
 
 ;; ---- rf2-dbmj6x regression: trace-disabled frame suppresses commit traces -
 ;;
@@ -1368,25 +1632,49 @@
       (rf/register-listener! :trace ::dbmj6x-tool (fn [ev] (swap! tool-traces conj ev)))
       (rf/dispatch-sync [:rf.route/navigate {:to :route/to}] {:frame :rf/tool})
       (rf/unregister-listener! :trace ::dbmj6x-tool)
-      (is (empty? (filter #(#{:rf.route.nav-token/allocated
-                              :rf.route/activated
-                              :rf.route/deactivated}
-                            (:operation %))
-                          @tool-traces))
-          "no lifecycle / nav-token trace leaks from a :rf.trace/frame-no-emit?
-           frame (pre-fix the unframed emits leaked past the gate)"))
+      ;; SEMANTIC, posture-independent (rf2-o5dbf). The suppression leg below
+      ;; is the whole POINT of this deftest and is a NEGATIVE over the trace
+      ;; ring — under `-Dre-frame.debug=false` the ring is empty for EVERY
+      ;; frame, so it would certify a leak-suppression the framework never had
+      ;; occasion to perform. The premise it rests on — that the lifecycle
+      ;; events carry the `:frame` the gate keys off — is a frame-state fact:
+      ;; the whole navigation is attributed to :rf/tool and :rf/default is
+      ;; untouched. An unframed commit could not do that.
+      (is (= :route/to (:route-id (frame-slice :rf/tool)))
+          "the tool frame's own navigation really committed there")
+      (is (nil? (:route-id (frame-slice :rf/default)))
+          "…and :rf/default was never entered by it — the commit is
+           frame-attributed, which is the same `:tags :frame` condition the
+           suppression gate and epoch capture both read")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (empty? (filter #(#{:rf.route.nav-token/allocated
+                                :rf.route/activated
+                                :rf.route/deactivated}
+                              (:operation %))
+                            @tool-traces))
+            "no lifecycle / nav-token trace leaks from a :rf.trace/frame-no-emit?
+             frame (pre-fix the unframed emits leaked past the gate)")))
     ;; Control: the identical events DO fire from an ordinary emitting frame.
     (rf/dispatch-sync [:rf.route/navigate {:to :route/from}] {:frame :rf/default})
     (let [app-traces (atom [])]
       (rf/register-listener! :trace ::dbmj6x-app (fn [ev] (swap! app-traces conj ev)))
       (rf/dispatch-sync [:rf.route/navigate {:to :route/to}] {:frame :rf/default})
       (rf/unregister-listener! :trace ::dbmj6x-app)
-      (is (some #(= :rf.route.nav-token/allocated (:operation %)) @app-traces)
-          "control: :rf.route.nav-token/allocated DOES fire from an emitting frame")
-      (is (some #(= :rf.route/activated (:operation %)) @app-traces)
-          "control: :rf.route/activated DOES fire from an emitting frame")
-      (is (some #(= :rf.route/deactivated (:operation %)) @app-traces)
-          "control: :rf.route/deactivated DOES fire from an emitting frame"))))
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): the control's job is to
+      ;; prove the suppression above is not vacuous, so it needs a
+      ;; posture-independent half of its own — the SAME dispatch on an
+      ;; ordinary frame really does drive the same cross-route commit.
+      (is (= :route/to (:route-id (frame-slice :rf/default)))
+          "control: the identical dispatch commits from an ordinary frame")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (some #(= :rf.route.nav-token/allocated (:operation %)) @app-traces)
+            "control: :rf.route.nav-token/allocated DOES fire from an emitting frame")
+        (is (some #(= :rf.route/activated (:operation %)) @app-traces)
+            "control: :rf.route/activated DOES fire from an emitting frame")
+        (is (some #(= :rf.route/deactivated (:operation %)) @app-traces)
+            "control: :rf.route/deactivated DOES fire from an emitting frame")))))
 
 ;; ---- rf2-vwwvp — Spec 012 §In-place navigation + §The :query-merge key -----
 

--- a/implementation/routing/test/re_frame/routing_navigation_test.clj
+++ b/implementation/routing/test/re_frame/routing_navigation_test.clj
@@ -1681,7 +1681,21 @@
 (defn- nav-slice
   "The current route slice for the default frame."
   []
-  (get-in (:rf.db/runtime (rf/frame-state-value :rf/default)) [:rf.runtime/routing :current]))
+  (frame-slice :rf/default))
+
+(defn- gate-verdict
+  "The always-on structural gate's OWN verdict on `request` —
+  `re-frame.routing.address/classify`, the exact fn `navigate-handler` calls,
+  against the live current slice. Returns nil when well-formed, else
+  `{:reason … :keys …}`.
+
+  rf2-o5dbf: the handler's `:rf.error/navigate-bad-request` DIAGNOSTIC rides
+  `trace/emit-error!` and closes under `-Dre-frame.debug=false`; the gate that
+  produces it does not — a malformed request still leaves the slice untouched
+  and pushes no URL. This reads the same rule on the same input with no bus in
+  between: what the reject WOULD report."
+  [request]
+  (address/classify request (nav-slice)))
 
 (deftest routing-in-place-target-stays-on-current-route
   (testing "an in-place request patches the CURRENT route's query, holding id + path-params"
@@ -1826,10 +1840,17 @@
       (rf/unregister-listener! :trace ::qm-reject)
       (is (= :route/a (:route-id (nav-slice))) "the destination nav is rejected; slice unchanged")
       (is (empty? @pushed) "no URL is pushed")
-      (let [err (first (filter #(= :rf.error/navigate-bad-request (:operation %)) @errors))]
-        (is (some? err) ":rf.error/navigate-bad-request emitted")
-        (is (= :query-merge-in-place-only (-> err :tags :reason))
-            ":reason names the query-merge-on-destination violation")))))
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): the rule-4 violation is the
+      ;; always-on gate's own verdict, not something the diagnostic invents.
+      (is (= :query-merge-in-place-only
+             (:reason (gate-verdict {:to :route/b :query-merge {:page 3}})))
+          "the gate names the query-merge-on-destination violation")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (let [err (first (filter #(= :rf.error/navigate-bad-request (:operation %)) @errors))]
+          (is (some? err) ":rf.error/navigate-bad-request emitted")
+          (is (= :query-merge-in-place-only (-> err :tags :reason))
+              ":reason names the query-merge-on-destination violation"))))))
 
 (deftest routing-in-place-before-first-nav-rejects
   (testing "an in-place request before any navigation fails closed (no current route)"
@@ -1845,16 +1866,23 @@
       (rf/register-listener! :trace ::inplace-reject
                              (fn [ev] (when (= :error (:op-type ev))
                                         (swap! errors conj ev))))
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): the rule-7 violation is the
+      ;; always-on gate's own verdict, read BEFORE the dispatch — while there
+      ;; genuinely is no current route, which is the condition under test.
+      (is (= :no-current-route (:reason (gate-verdict {:query-merge {:page 1}})))
+          "the gate names the no-current-route violation")
       (rf/dispatch-sync [:rf.route/navigate {:query-merge {:page 1}}])
       (rf/unregister-listener! :trace ::inplace-reject)
       (is (empty? @pushed)
           "no URL is pushed for an in-place nav with no current route")
       (is (nil? (:route-id (nav-slice)))
           "the route slice stays empty (unchanged)")
-      (let [err (first (filter #(= :rf.error/navigate-bad-request (:operation %)) @errors))]
-        (is (some? err) ":rf.error/navigate-bad-request emitted")
-        (is (= :no-current-route (-> err :tags :reason))
-            ":reason names the no-current-route violation")))))
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (let [err (first (filter #(= :rf.error/navigate-bad-request (:operation %)) @errors))]
+          (is (some? err) ":rf.error/navigate-bad-request emitted")
+          (is (= :no-current-route (-> err :tags :reason))
+              ":reason names the no-current-route violation"))))))
 
 (deftest routing-in-place-query-merge-no-op-when-unchanged
   (testing "in-place :query-merge to the SAME query is a rule-3 no-op"
@@ -1948,18 +1976,30 @@
                   "the slice is byte-for-byte identical except :fragment — :transition
                    / :error / :nav-token / :route-id / :params / :query preserved")
               ;; TEETH 4 — one fragment-changed, no allocation trace.
-              (let [frag (filter #(= :rf.route/fragment-changed (:operation %)) @traces)
-                    tags (-> frag first :tags)]
-                (is (= 1 (count frag))
-                    "exactly one :rf.route/fragment-changed emitted")
-                (is (= :route/docs (:route-id tags))      "fragment-changed carries :route-id")
-                (is (= "a" (:prev-fragment tags))         "fragment-changed carries :prev-fragment")
-                (is (= "b" (:next-fragment tags))         "fragment-changed carries :next-fragment")
-                (is (= :rf/default (:frame tags))         "fragment-changed carries :frame (rf2-n0851k parity)"))
-              (is (not-any? #(= :rf.route.nav-token/allocated (:operation %)) @traces)
-                  "NO :rf.route.nav-token/allocated on the fragment-only nav")
-              (is (not-any? #(= :rf.route/activated (:operation %)) @traces)
-                  "NO :rf.route/activated on the fragment-only nav (route stays active)")
+              ;;
+              ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring). This
+              ;; whole block reads the trace bus, and its last two legs are
+              ;; NEGATIVES over the ring: green for free under the gate. Every
+              ;; claim in it has an always-on counterpart in TEETH 1-3 — the
+              ;; prev→next pair and the "exactly one" are the byte-for-byte
+              ;; `(= (assoc slice-before :fragment "b") slice-after)` above
+              ;; (one field moved, once), the nav-token denial is `(= "nav-1"
+              ;; (:nav-token slice-after))`, the activated denial is
+              ;; `(= 1 @on-match-calls)`, and the `:frame` tag is the fact that
+              ;; this default-frame nav moved the default frame's slice.
+              (when interop/debug-enabled?
+                (let [frag (filter #(= :rf.route/fragment-changed (:operation %)) @traces)
+                      tags (-> frag first :tags)]
+                  (is (= 1 (count frag))
+                      "exactly one :rf.route/fragment-changed emitted")
+                  (is (= :route/docs (:route-id tags))      "fragment-changed carries :route-id")
+                  (is (= "a" (:prev-fragment tags))         "fragment-changed carries :prev-fragment")
+                  (is (= "b" (:next-fragment tags))         "fragment-changed carries :next-fragment")
+                  (is (= :rf/default (:frame tags))         "fragment-changed carries :frame (rf2-n0851k parity)"))
+                (is (not-any? #(= :rf.route.nav-token/allocated (:operation %)) @traces)
+                    "NO :rf.route.nav-token/allocated on the fragment-only nav")
+                (is (not-any? #(= :rf.route/activated (:operation %)) @traces)
+                    "NO :rf.route/activated on the fragment-only nav (route stays active)"))
               ;; History: a push for the new fragment URL.
               (is (= ["/docs/routing#a" "/docs/routing#b"] @(:push fxs))
                   "the fragment-only nav pushed /docs/routing#b via :rf.nav/push-url")
@@ -2055,8 +2095,15 @@
         (is (= token-before (:nav-token (nav-slice))) "identical target: token unchanged")
         (is (empty? @(:push fxs))    "identical target: no push")
         (is (empty? @(:replace fxs)) "identical target: no replace even with :replace? true")
-        (is (not-any? #(= :rf.route/fragment-changed (:operation %)) @traces)
-            "identical target emits NO :rf.route/fragment-changed (it is a complete no-op)")))))
+        (is (= "a" (:fragment (nav-slice)))
+            "identical target: the fragment did not move, so there was nothing
+             for a fragment-changed to report")
+        ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring). A NEGATIVE
+        ;; over the trace ring, green for free under the gate; the always-on
+        ;; legs above are what "complete no-op" means in runtime-db terms.
+        (when interop/debug-enabled?
+          (is (not-any? #(= :rf.route/fragment-changed (:operation %)) @traces)
+              "identical target emits NO :rf.route/fragment-changed (it is a complete no-op)"))))))
 
 (deftest navigate-fragment-only-does-not-replan-resources-rf2-k4exp1
   (testing "rf2-k4exp1: a fragment-only nav does NOT invoke the route-entry
@@ -2238,35 +2285,69 @@
     (rf/dispatch-sync [:rf.route/navigate {:to :route/gate-a}])
     (reset! pushed [])
 
+    ;; rf2-o5dbf: the gate is ALWAYS-ON and so is its consequence — the two
+    ;; closing legs of this deftest run under `-Dre-frame.debug=false` and
+    ;; pass. What is dev-only is the `:rf.error/navigate-bad-request`
+    ;; DIAGNOSTIC each block reads. Every `:reason` / `:keys` claim therefore
+    ;; gets an always-on counterpart from `gate-verdict` — the same
+    ;; `address/classify` call the handler makes, on the same request, with no
+    ;; bus in between. Without it, the per-rule discrimination would go
+    ;; untested under the gate and only the coarse "nothing moved" pair below
+    ;; would survive.
+
     (testing "empty map rejects (:no-destination-or-change)"
+      (is (= :no-destination-or-change (:reason (gate-verdict {}))))
       (let [err (gate-reject {} pushed)]
-        (is (= :no-destination-or-change (-> err :tags :reason)))
-        (is (= :event (-> err :tags :where)))
+        (when interop/debug-enabled?
+          (is (= :no-destination-or-change (-> err :tags :reason)))
+          (is (= :event (-> err :tags :where))))
         (is (empty? @pushed))))
 
     (testing "pure-policy map rejects (:no-destination-or-change)"
-      (is (= :no-destination-or-change (-> (gate-reject {:replace? true} pushed) :tags :reason)))
+      (is (= :no-destination-or-change (:reason (gate-verdict {:replace? true}))))
+      (let [err (gate-reject {:replace? true} pushed)]
+        (when interop/debug-enabled?
+          (is (= :no-destination-or-change (-> err :tags :reason)))))
       (is (empty? @pushed)))
 
     (testing ":to + :url are mutually exclusive"
-      (is (= :to-url-exclusive (-> (gate-reject {:to :route/gate-b :url "/gate-b"} pushed) :tags :reason))))
+      (is (= :to-url-exclusive (:reason (gate-verdict {:to :route/gate-b :url "/gate-b"}))))
+      (let [err (gate-reject {:to :route/gate-b :url "/gate-b"} pushed)]
+        (when interop/debug-enabled?
+          (is (= :to-url-exclusive (-> err :tags :reason))))))
 
     (testing ":url excludes :params / :query / :query-merge"
-      (is (= :url-excludes-address (-> (gate-reject {:url "/gate-b" :query {:q "x"}} pushed) :tags :reason))))
+      (is (= :url-excludes-address (:reason (gate-verdict {:url "/gate-b" :query {:q "x"}}))))
+      (let [err (gate-reject {:url "/gate-b" :query {:q "x"}} pushed)]
+        (when interop/debug-enabled?
+          (is (= :url-excludes-address (-> err :tags :reason))))))
 
     (testing ":query + :query-merge are mutually exclusive"
-      (is (= :query-exclusive (-> (gate-reject {:query {:q "x"} :query-merge {:q "y"}} pushed) :tags :reason))))
+      (is (= :query-exclusive (:reason (gate-verdict {:query {:q "x"} :query-merge {:q "y"}}))))
+      (let [err (gate-reject {:query {:q "x"} :query-merge {:q "y"}} pushed)]
+        (when interop/debug-enabled?
+          (is (= :query-exclusive (-> err :tags :reason))))))
 
     (testing ":query-merge on a destination request rejects"
       (is (= :query-merge-in-place-only
-             (-> (gate-reject {:to :route/gate-b :query-merge {:q "x"}} pushed) :tags :reason))))
+             (:reason (gate-verdict {:to :route/gate-b :query-merge {:q "x"}}))))
+      (let [err (gate-reject {:to :route/gate-b :query-merge {:q "x"}} pushed)]
+        (when interop/debug-enabled?
+          (is (= :query-merge-in-place-only (-> err :tags :reason))))))
 
     (testing "unknown keys reject (namespaced INCLUDED)"
-      (is (= :unknown-keys (-> (gate-reject {:to :route/gate-b :bogus 1} pushed) :tags :reason)))
+      (is (= :unknown-keys (:reason (gate-verdict {:to :route/gate-b :bogus 1}))))
+      (let [err (gate-reject {:to :route/gate-b :bogus 1} pushed)]
+        (when interop/debug-enabled?
+          (is (= :unknown-keys (-> err :tags :reason)))))
+      (is (= {:reason :unknown-keys :keys [:my-app/replace?]}
+             (gate-verdict {:to :route/gate-b :my-app/replace? true}))
+          "a namespaced unknown key fails as loudly as a bare typo")
       (let [err (gate-reject {:to :route/gate-b :my-app/replace? true} pushed)]
-        (is (= :unknown-keys (-> err :tags :reason)))
-        (is (= [:my-app/replace?] (-> err :tags :keys))
-            "a namespaced unknown key fails as loudly as a bare typo")))
+        (when interop/debug-enabled?
+          (is (= :unknown-keys (-> err :tags :reason)))
+          (is (= [:my-app/replace?] (-> err :tags :keys))
+              "a namespaced unknown key fails as loudly as a bare typo"))))
 
     (is (= :route/gate-a (:route-id (slice)))
         "every rejected request left the slice on the original route (unchanged)")
@@ -2289,11 +2370,19 @@
       (is (nil? (:route-id (get-in (:rf.db/runtime (rf/frame-state-value :rf/default))
                                    [:rf.runtime/routing :current])))
           "the malformed request navigated nowhere")
-      (is (some (fn [ev] (and (= :rf.error/navigate-bad-request (:operation ev))
-                              (= :unknown-keys (-> ev :tags :reason))
-                              (= [:rf.route/enter-attempts] (-> ev :tags :keys))))
-                @errors)
-          "the retired rider is rejected LOUD as an unknown request key"))))
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): "the roster is CLOSED with
+      ;; no exemption" is a statement about the always-on gate, so read it
+      ;; there. The trace leg below is that same verdict's dev-only diagnostic.
+      (is (= {:reason :unknown-keys :keys [:rf.route/enter-attempts]}
+             (gate-verdict {:to :route/rider :rf.route/enter-attempts 2}))
+          "the retired rider is an ORDINARY unknown key to the closed roster")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (some (fn [ev] (and (= :rf.error/navigate-bad-request (:operation ev))
+                                (= :unknown-keys (-> ev :tags :reason))
+                                (= [:rf.route/enter-attempts] (-> ev :tags :keys))))
+                  @errors)
+            "the retired rider is rejected LOUD as an unknown request key")))))
 
 ;; ============================================================================
 ;; rf2-0zsvw — explicit :fragment override on an UNMATCHED raw-URL navigate
@@ -2386,17 +2475,26 @@
                                         (swap! errors conj ev))))
       ;; The reproduction: :params beside an in-place :fragment. Pre-fix this
       ;; emitted NO error and pushed /items/old#x with :params silently ignored.
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): rule 3 is the always-on
+      ;; gate's own verdict, `:keys` included — read it before the dispatch,
+      ;; from the very slice the handler will read.
+      (is (= {:reason :params-requires-destination :keys [:params]}
+             (gate-verdict {:params {:id "new"} :fragment "x"}))
+          "the gate names the params-without-destination violation and the
+           offending key")
       (rf/dispatch-sync [:rf.route/navigate {:params {:id "new"} :fragment "x"}])
       (rf/unregister-listener! :trace ::params-reject)
       (is (= {:id "old"} (:params (nav-slice)))
           "the slice params are UNCHANGED — the supplied :params did not sneak in")
       (is (empty? @pushed) "no URL is pushed for the rejected request")
-      (let [err (first (filter #(= :rf.error/navigate-bad-request (:operation %)) @errors))]
-        (is (some? err) ":rf.error/navigate-bad-request emitted")
-        (is (= :params-requires-destination (-> err :tags :reason))
-            ":reason names the params-without-destination violation")
-        (is (= [:params] (-> err :tags :keys))
-            ":keys names the offending :params key")))))
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (let [err (first (filter #(= :rf.error/navigate-bad-request (:operation %)) @errors))]
+          (is (some? err) ":rf.error/navigate-bad-request emitted")
+          (is (= :params-requires-destination (-> err :tags :reason))
+              ":reason names the params-without-destination violation")
+          (is (= [:params] (-> err :tags :keys))
+              ":keys names the offending :params key"))))))
 
 (deftest navigate-non-map-payload-and-extra-element-reject
   (testing "a non-map payload and a third event element reject LOUD rather than
@@ -2419,21 +2517,43 @@
                              (fn [ev] (when (= :error (:op-type ev))
                                         (swap! errors conj ev))))
 
+      ;; rf2-o5dbf: the event-VECTOR shape gate is `navigate-handler`'s own
+      ;; first step and is always-on, so both rejections below survive
+      ;; `-Dre-frame.debug=false`; only their `:rf.error/navigate-bad-request`
+      ;; diagnostic is dev-only. Each block therefore keeps a
+      ;; posture-independent leg naming exactly what the pre-fix bug DID — a
+      ;; raw host throw, and a silently-dropped extra element.
+
       (testing "non-map payload rejects with :request-not-a-map (no raw throw)"
         (reset! errors [])
         ;; Pre-fix this reached `(dissoc \"/dest\" …)` and threw a host exception.
         (rf/dispatch-sync [:rf.route/navigate "/dest"])
-        (let [err (first (filter #(= :rf.error/navigate-bad-request (:operation %)) @errors))]
-          (is (some? err) ":rf.error/navigate-bad-request emitted for a non-map payload")
-          (is (= :request-not-a-map (-> err :tags :reason)))))
+        ;; SEMANTIC, posture-independent (rf2-o5dbf): reaching this line at all
+        ;; is the "no raw throw" half — `dispatch-sync` propagates a handler
+        ;; throw — and the slice is the "rejected, not navigated" half.
+        (is (= :route/home (:route-id (nav-slice)))
+            "the non-map payload neither threw nor navigated")
+        ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+        (when interop/debug-enabled?
+          (let [err (first (filter #(= :rf.error/navigate-bad-request (:operation %)) @errors))]
+            (is (some? err) ":rf.error/navigate-bad-request emitted for a non-map payload")
+            (is (= :request-not-a-map (-> err :tags :reason))))))
 
       (testing "extra event element rejects with :bad-event-arity (not dropped)"
         (reset! errors [])
         ;; Pre-fix this navigated to :route/dest while dropping {:replace? true}.
         (rf/dispatch-sync [:rf.route/navigate {:to :route/dest} {:replace? true}])
-        (let [err (first (filter #(= :rf.error/navigate-bad-request (:operation %)) @errors))]
-          (is (some? err) ":rf.error/navigate-bad-request emitted for a 3-element event")
-          (is (= :bad-event-arity (-> err :tags :reason)))))
+        ;; SEMANTIC, posture-independent (rf2-o5dbf): TEETH — the pre-fix bug
+        ;; was a SILENT SUCCESS, so "still on :route/home" is the whole claim
+        ;; and it needs no bus.
+        (is (= :route/home (:route-id (nav-slice)))
+            "the 3-element event did NOT navigate to :route/dest — the extra
+             element was rejected, not dropped")
+        ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+        (when interop/debug-enabled?
+          (let [err (first (filter #(= :rf.error/navigate-bad-request (:operation %)) @errors))]
+            (is (some? err) ":rf.error/navigate-bad-request emitted for a 3-element event")
+            (is (= :bad-event-arity (-> err :tags :reason))))))
 
       (rf/unregister-listener! :trace ::shape-reject)
       (is (= :route/home (:route-id (nav-slice)))
@@ -2457,12 +2577,25 @@
                                         (swap! errors conj ev))))
       ;; :a/b, "s", and 3 are all unknown keys of DIFFERENT kinds — a plain
       ;; `(sort #{:a/b "s" 3})` throws a ClassCastException on the JVM.
+      ;;
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): the ORDERING is computed
+      ;; inside `address/classify`, which is where the raw `compare` throw
+      ;; would happen — so the always-on gate's verdict is the direct witness
+      ;; for both halves of this deftest's title, and it is the total order
+      ;; the diagnostic merely relays.
+      (is (= {:reason :unknown-keys
+              :keys   (vec (sort-by identity/canonical-bytes #{:a/b "s" 3}))}
+             (gate-verdict {:to :route/gate :a/b 1 "s" 2 3 4}))
+          "the gate orders the heterogeneous unknown keys canonically, with no
+           raw compare throw")
       (rf/dispatch-sync [:rf.route/navigate {:to :route/gate :a/b 1 "s" 2 3 4}])
       (rf/unregister-listener! :trace ::hetero)
-      (let [err (first (filter #(= :rf.error/navigate-bad-request (:operation %)) @errors))]
-        (is (some? err) ":rf.error/navigate-bad-request emitted (no raw compare throw)")
-        (is (= :unknown-keys (-> err :tags :reason)))
-        (is (= (vec (sort-by identity/canonical-bytes #{:a/b "s" 3}))
-               (-> err :tags :keys))
-            ":keys are the heterogeneous unknown keys in total canonical order"))
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (let [err (first (filter #(= :rf.error/navigate-bad-request (:operation %)) @errors))]
+          (is (some? err) ":rf.error/navigate-bad-request emitted (no raw compare throw)")
+          (is (= :unknown-keys (-> err :tags :reason)))
+          (is (= (vec (sort-by identity/canonical-bytes #{:a/b "s" 3}))
+                 (-> err :tags :keys))
+              ":keys are the heterogeneous unknown keys in total canonical order")))
       (is (empty? @pushed) "no URL is pushed for the rejected request"))))

--- a/implementation/routing/test/re_frame/routing_plan_seam_test.clj
+++ b/implementation/routing/test/re_frame/routing_plan_seam_test.clj
@@ -14,11 +14,60 @@
   the commit hop resolve one URL to ONE target, and that the URL-change door
   reports which of its three sub-doors fired. A test that only loops
   `resolver/causes` against the pure constructor cannot fail when a door passes
-  the wrong cause or resolves its own target."
+  the wrong cause or resolves its own target.
+
+  ## Posture split (rf2-o5dbf)
+
+  The SEAM ITSELF is production-real and carries no posture guard. Every pure
+  constructor test — `resolved-target`, the nil-query strip, the fragment
+  collapse, `:query-defaults`, `route-plan`, the fail-loud `:branch` walk,
+  `leaf-plan-of`, `plan-projection`, `plan-trace-tags` and `url-resolution` —
+  runs in the ordinary `clojure -M:test` suite AND in
+  `scripts/test-routing-prod-gate.sh` (the `-Dre-frame.debug=false` lane). So
+  do the door-wiring tests at the foot: the link/commit agreement, the exact
+  no-op, the shared not-found `:reason` vocabulary and `url-change-cause`.
+
+  What IS dev-only is the `:rf.route/planned` TRACE — the one bus the R0
+  projection rides — and the two `:rf.warning/*` fail-closed advisories. All
+  three go through `trace/emit!` / `trace/emit-error!`, gated on
+  `interop/debug-enabled?` and read once at load time. Their assertions are
+  kept VERBATIM inside `(when interop/debug-enabled? …)` arms marked
+  `rf2-o5dbf`.
+
+  EIGHT assertions in this namespace would have passed VACUOUSLY the moment
+  the roster line came off, because under the gate the trace ring is empty and
+  `(:tags (first ts))` is nil:
+
+    * `(is (empty? (planned …)))` twice — the two NON-commit branches. A
+      negative over an empty ring is green whether or not the door plans.
+    * `(is (= [] (:warnings url-driven) (:warnings programmatic)))` — the
+      well-formed miss's advisory-quiet leg.
+    * three legs of `planned-traces-branch-agrees-with-the-activation`:
+      `not-any? #{:route/nowhere}` over a nil `:branch`, `(not (contains?
+      tags :branch-error))` over a nil tag map, and the `:branch-error`
+      metadata scan over `(pr-str nil)`.
+    * and the sharpest pair, in
+      `an-executed-navigations-plan-trace-is-not-a-carrier`:
+      `(is (not (re-find #\"SECRET100\" (pr-str tags))))` and its `tok-99`
+      sibling would have certified that a real navigation's secret query
+      value and fragment stayed out of an egress copy THAT WAS NEVER MADE.
+
+  PRODUCTION WITNESSES were added rather than assertions dropped. The
+  projection is a PURE function (`resolver/plan-trace-tags`, pinned
+  posture-independently above), so the redaction the trace relies on is
+  checkable with no gate between the call and the verdict — read it as \"what
+  the bus WOULD carry if the emit were running\". The commits themselves are
+  runtime-db facts: the slice moves, the `:on-match` leaf plan really
+  dispatches, the nav-token really does NOT move on a no-op, and the
+  `:routing/on-route-entry` late-bind hook — a FN, not a trace — really does
+  receive the fail-loud `:branch-error` the activation composes over. Nothing
+  was deleted or weakened."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.fx :as fx]
+            [re-frame.interop :as interop]
+            [re-frame.late-bind :as late-bind]
             [re-frame.registrar :as registrar]
             [re-frame.routing :as routing]
             [re-frame.routing.events :as routing-events]
@@ -391,6 +440,34 @@
         (is (= [] (:leaf-plan-ids bare)))
         (is (= "/section" (:url bare)) "a bare path is not a carrier — verbatim")))))
 
+;; ---- the runtime-db facts a door commit leaves behind ---------------------
+;;
+;; rf2-o5dbf: these are what the `:rf.route/planned` trace ANNOUNCES, and
+;; unlike the trace they survive `-Dre-frame.debug=false`. The door-wiring
+;; section at the foot reads the same slice through the same helpers.
+
+(defn- rdb [] (:rf.db/runtime (rf/frame-state-value :rf/default)))
+(defn- nav-slice [] (get-in (rdb) [:rf.runtime/routing :current]))
+(defn- current-id [] (:route-id (nav-slice)))
+
+(defn- with-route-entry-spy!
+  "Install a spy on the `:routing/on-route-entry` late-bind hook — the FN
+  `commit-navigation` hands the resolved `:branch` (contributors) and
+  `:branch-error` to — run `f`, restore the prior binding, and return the
+  recorded contexts.
+
+  rf2-o5dbf: this is the production-visible counterpart of the
+  `:rf.route/planned` trace's `:branch` / `:branch-error` tags. A late-bound fn
+  is not a trace, so the activation's copy of the fail-loud walk arrives under
+  `-Dre-frame.debug=false` exactly as it does in dev."
+  [f]
+  (let [seen  (atom [])
+        prior (late-bind/get-fn :routing/on-route-entry)]
+    (late-bind/set-fn! :routing/on-route-entry (fn [ctx] (swap! seen conj ctx) {}))
+    (try (f)
+         (finally (late-bind/set-fn! :routing/on-route-entry prior)))
+    @seen))
+
 (defn- quiet-nav-fx!
   "No-op the host navigation fx so a JVM navigation commits without reaching a
   browser-only handler."
@@ -411,43 +488,108 @@
   (routing/reg-route :route/home {} "/")
   (routing/reg-route :route/article {:on-match [[:article/load]]} "/articles/:slug")
   (quiet-nav-fx!)
-  (testing "the PROGRAMMATIC door — the projection is now reachable from an
-            executed navigation, which is the whole completeness obligation"
-    (let [ts (planned (rf/dispatch-sync [:rf.route/navigate {:to :route/article
-                                                             :params {:slug "a"}}]))]
-      (is (= 1 (count ts)) "exactly one plan trace per commit")
-      (let [{:keys [cause route-id branch leaf-plan-ids frame]} (:tags (first ts))]
-        (is (= :navigate cause))
-        (is (= :route/article route-id))
-        (is (= [:route/article] branch))
-        (is (= [:article/load] leaf-plan-ids))
-        (is (= :rf/default frame)
-            "frame-stamped — epoch capture admits only frame-tagged traces"))))
-  (testing "the URL-driven door reports which of its four sub-doors fired"
-    (doseq [[cause dispatch] {:link     [:rf.route/transitioned "/articles/b"]
-                              :popstate [:rf.route/handle-url-change "/articles/c"
-                                         {:rf.route/cause :popstate}]
-                              :initial  [:rf.route/handle-url-change "/articles/d"]}]
-      (let [ts (planned (rf/dispatch-sync dispatch))]
-        (is (= 1 (count ts)) (str cause " emitted exactly one plan trace"))
-        (is (= cause (:cause (:tags (first ts))))
-            (str "a door that hardcoded one cause for four sub-doors fails here"))
-        (is (= :rf/default (:frame (:tags (first ts))))))))
-  (testing "the SSR feed reports :ssr off the frame's :platform"
-    (let [f  (frame/make-anon-frame-record! {:platform :server})
-          ts (planned (rf/dispatch-sync [:rf.route/handle-url-change "/articles/e"]
-                                        {:frame f}))]
-      (is (= 1 (count ts)))
-      (is (= :ssr (:cause (:tags (first ts)))))
-      (is (= f (:frame (:tags (first ts))))
-          "attributed to the SERVER frame, not the ambient :rf/default")))
-  (testing "the NON-commit branches emit none — an exact no-op and a
-            fragment-only anchor change are not plan commits"
-    (rf/dispatch-sync [:rf.route/handle-url-change "/articles/f"])
-    (is (empty? (planned (rf/dispatch-sync [:rf.route/handle-url-change "/articles/f"])))
-        "an exact no-op plans nothing")
-    (is (empty? (planned (rf/dispatch-sync [:rf.route/handle-url-change "/articles/f#anchor"])))
-        "a fragment-only transition plans nothing (no nav-token, no re-plan)")))
+  ;; rf2-o5dbf — the LEAF PLAN made production-visible. `:leaf-plan-ids` on the
+  ;; trace names the loaders the plan carries; registering that loader turns
+  ;; "which ids ride the tag" into "which loaders actually dispatched" — the
+  ;; same claim, with no bus between the door and the verdict.
+  (let [loaded (atom [])]
+    (rf/reg-event :article/load
+                  (fn [{:keys [db]} _]
+                    (swap! loaded conj (:slug (:params (nav-slice))))
+                    {:db db}))
+
+    (testing "the PROGRAMMATIC door — the projection is now reachable from an
+              executed navigation, which is the whole completeness obligation"
+      (let [ts (planned (rf/dispatch-sync [:rf.route/navigate {:to :route/article
+                                                               :params {:slug "a"}}]))]
+        ;; SEMANTIC, posture-independent (rf2-o5dbf): the door COMMITTED, and
+        ;; the leaf plan the projection names really ran. Without these the
+        ;; whole deftest is a statement about a bus production does not run.
+        (is (= :route/article (current-id)) "the programmatic door committed its target")
+        (is (= {:slug "a"} (:params (nav-slice))))
+        (is (= ["a"] @loaded) "the :leaf-plan the projection names really dispatched")
+        ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+        (when interop/debug-enabled?
+          (is (= 1 (count ts)) "exactly one plan trace per commit")
+          (let [{:keys [cause route-id branch leaf-plan-ids frame]} (:tags (first ts))]
+            (is (= :navigate cause))
+            (is (= :route/article route-id))
+            (is (= [:route/article] branch))
+            (is (= [:article/load] leaf-plan-ids))
+            (is (= :rf/default frame)
+                "frame-stamped — epoch capture admits only frame-tagged traces")))))
+    (testing "the URL-driven door reports which of its four sub-doors fired"
+      ;; A VECTOR of triples, not a map — the slug pairs positionally with the
+      ;; cause, and the iteration order is then the written order.
+      (doseq [[cause dispatch slug] [[:link     [:rf.route/transitioned "/articles/b"] "b"]
+                                     [:popstate [:rf.route/handle-url-change "/articles/c"
+                                                 {:rf.route/cause :popstate}] "c"]
+                                     [:initial  [:rf.route/handle-url-change "/articles/d"] "d"]]]
+        (let [ts (planned (rf/dispatch-sync dispatch))]
+          ;; SEMANTIC, posture-independent (rf2-o5dbf): every sub-door really
+          ;; commits and really re-runs the leaf plan. Which CAUSE each reports
+          ;; has its own always-on witness in
+          ;; `executed-url-change-navigation-carries-its-true-cause` below,
+          ;; where the cause rides an application `:rf.route/entry-denied`
+          ;; payload rather than the trace bus.
+          (is (= {:slug slug} (:params (nav-slice)))
+              (str cause " committed /articles/" slug))
+          (is (= slug (last @loaded))
+              (str cause " re-ran the leaf plan for /articles/" slug))
+          ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+          (when interop/debug-enabled?
+            (is (= 1 (count ts)) (str cause " emitted exactly one plan trace"))
+            (is (= cause (:cause (:tags (first ts))))
+                (str "a door that hardcoded one cause for four sub-doors fails here"))
+            (is (= :rf/default (:frame (:tags (first ts)))))))))
+    (testing "the SSR feed reports :ssr off the frame's :platform"
+      (let [f  (frame/make-anon-frame-record! {:platform :server})
+            ts (planned (rf/dispatch-sync [:rf.route/handle-url-change "/articles/e"]
+                                          {:frame f}))]
+        ;; SEMANTIC, posture-independent (rf2-o5dbf): the ATTRIBUTION the
+        ;; `:frame` tag claims is a frame-state fact — the server frame's own
+        ;; slice moved and the ambient `:rf/default` one did not.
+        (is (= {:slug "e"}
+               (get-in (:rf.db/runtime (rf/frame-state-value f))
+                       [:rf.runtime/routing :current :params]))
+            "the SSR door committed into the SERVER frame")
+        (is (= {:slug "d"} (:params (nav-slice)))
+            "…and left the ambient :rf/default frame's slice alone")
+        ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+        (when interop/debug-enabled?
+          (is (= 1 (count ts)))
+          (is (= :ssr (:cause (:tags (first ts)))))
+          (is (= f (:frame (:tags (first ts))))
+              "attributed to the SERVER frame, not the ambient :rf/default"))))
+    (testing "the NON-commit branches emit none — an exact no-op and a
+              fragment-only anchor change are not plan commits"
+      (rf/dispatch-sync [:rf.route/handle-url-change "/articles/f"])
+      (let [token (:nav-token (nav-slice))
+            loads (count @loaded)]
+        ;; SEMANTIC, posture-independent (rf2-o5dbf): "plans nothing" is a
+        ;; runtime-db claim before it is a trace claim. Both `(is (empty? …))`
+        ;; legs below are NEGATIVES over the trace ring, which the gate empties
+        ;; by design — they would have gone green the moment the roster line
+        ;; came off, whatever the door did. What a plan commit WOULD leave
+        ;; behind is a fresh nav-token and a re-fired leaf plan, so that is
+        ;; what the always-on legs deny.
+        (let [ts (planned (rf/dispatch-sync [:rf.route/handle-url-change "/articles/f"]))]
+          (is (= token (:nav-token (nav-slice)))
+              "an exact no-op allocates no fresh nav-token")
+          (is (= loads (count @loaded))
+              "an exact no-op re-fires no loader")
+          (when interop/debug-enabled?
+            (is (empty? ts) "an exact no-op plans nothing")))
+        (let [ts (planned (rf/dispatch-sync [:rf.route/handle-url-change "/articles/f#anchor"]))]
+          (is (= "anchor" (:fragment (nav-slice)))
+              "the fragment-only change DID land — the door ran, it just did not plan")
+          (is (= token (:nav-token (nav-slice)))
+              "…with no fresh nav-token")
+          (is (= loads (count @loaded))
+              "…and no leaf-plan re-fire")
+          (when interop/debug-enabled?
+            (is (empty? ts)
+                "a fragment-only transition plans nothing (no nav-token, no re-plan)")))))))
 
 (deftest an-executed-navigations-plan-trace-is-not-a-carrier
   (routing/reg-route :route/home {} "/")
@@ -456,20 +598,56 @@
   (testing "a real navigation carrying a secret in its query and fragment emits a
             plan trace that reproduces NEITHER — the projection became reachable
             without becoming a carrier"
-    (let [ts (planned
-               (rf/dispatch-sync [:rf.route/navigate
-                                  {:to       :route/invite
-                                   :params   {:id "acct-42"}
-                                   :query    {:invite "SECRET100"}
-                                   :fragment "tok-99"}]))
-          tags (:tags (first ts))]
-      (is (= 1 (count ts)))
-      (is (= [:id] (:param-keys tags)))
-      (is (= [:invite] (:query-keys tags)))
-      (is (not (re-find #"SECRET100" (pr-str tags))))
-      (is (not (re-find #"tok-99" (pr-str tags))))
-      (is (= "/invite/acct-42?invite=rf/redacted#rf/redacted" (:url tags))
-          "the structured PATH survives — it is what a consumer branches on"))))
+    (let [request {:to       :route/invite
+                   :params   {:id "acct-42"}
+                   :query    {:invite "SECRET100"}
+                   :fragment "tok-99"}
+          ts   (planned (rf/dispatch-sync [:rf.route/navigate request]))
+          tags (:tags (first ts))
+          ;; rf2-o5dbf — WHAT THE BUS WOULD CARRY. The two `re-find` legs in
+          ;; the arm below are the sharpest vacuous pass in this artefact:
+          ;; under `-Dre-frame.debug=false` `ts` is empty, so `tags` is nil,
+          ;; `(pr-str nil)` is "nil", and both would certify that a real
+          ;; navigation's secret query value and fragment stayed out of an
+          ;; egress copy the framework NEVER MADE. `plan-trace-tags` is a pure
+          ;; fn the emit site calls, though — pinned posture-independently in
+          ;; `plan-trace-tags-carries-the-projection-without-the-carriers` —
+          ;; so the redaction is checkable with no gate in between.
+          would-carry (resolver/plan-trace-tags
+                        (resolver/route-plan
+                          {:cause  :navigate
+                           :source request
+                           :target (resolver/resolved-target
+                                     {:route-id :route/invite
+                                      :params   {:id "acct-42"}
+                                      :query    {:invite "SECRET100"}
+                                      :fragment "tok-99"
+                                      :url      "/invite/acct-42?invite=SECRET100#tok-99"})}))]
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): the navigation really
+      ;; happened, and the projection over its address really does redact.
+      (is (= :route/invite (current-id)) "the navigation committed")
+      (is (= {:invite "SECRET100"} (:query (nav-slice)))
+          "IN PROCESS the carrier rides raw — redaction is an egress rule, not
+           a storage rule (the same distinction routing_egress_test pins)")
+      (is (= "tok-99" (:fragment (nav-slice))))
+      (is (= [:id] (:param-keys would-carry)))
+      (is (= [:invite] (:query-keys would-carry)))
+      (is (not (re-find #"SECRET100" (pr-str would-carry)))
+          "the projection the emit site consults reproduces no query VALUE")
+      (is (not (re-find #"tok-99" (pr-str would-carry)))
+          "…and no fragment")
+      (is (= "/invite/acct-42?invite=rf/redacted#rf/redacted" (:url would-carry))
+          "the structured PATH survives — it is what a consumer branches on")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring): the same
+      ;; guarantees, read off the bus that actually carried them.
+      (when interop/debug-enabled?
+        (is (= 1 (count ts)))
+        (is (= [:id] (:param-keys tags)))
+        (is (= [:invite] (:query-keys tags)))
+        (is (not (re-find #"SECRET100" (pr-str tags))))
+        (is (not (re-find #"tok-99" (pr-str tags))))
+        (is (= "/invite/acct-42?invite=rf/redacted#rf/redacted" (:url tags))
+            "the structured PATH survives — it is what a consumer branches on")))))
 
 (deftest planned-traces-branch-agrees-with-the-activation-rf2-cqyq2
   (routing/reg-route :route/home {} "/")
@@ -482,35 +660,80 @@
             :branch [:route/nowhere :route/leaf] — a plausible two-segment
             branch naming a route that does not exist — with no hint that
             planning had failed on that very chain."
-    (let [ts   (planned (rf/dispatch-sync [:rf.route/navigate {:to :route/leaf}]))
-          tags (:tags (first ts))]
-      (is (= 1 (count ts)))
-      (is (= [] (:branch tags)))
-      (is (not-any? #{:route/nowhere} (:branch tags))
-          "a tool reading the trace is not told a route exists that does not")
-      (is (= (select-keys (:branch-error (routing-events/resolve-branch :route/leaf))
-                          [:kind :route-id*])
-             (:branch-error tags))
-          "the trace's failure signal IS the activation's")))
+    (let [entries (atom [])
+          ts      (planned
+                    (reset! entries
+                            (with-route-entry-spy!
+                              #(rf/dispatch-sync [:rf.route/navigate {:to :route/leaf}]))))
+          tags    (:tags (first ts))]
+      ;; SEMANTIC, posture-independent (rf2-o5dbf). The trace's whole claim is
+      ;; "the failure signal a TOOL reads is the one the ACTIVATION composes
+      ;; over", and the activation's copy arrives through the
+      ;; `:routing/on-route-entry` late-bind hook — a fn, not a trace. Without
+      ;; this half, `not-any? #{:route/nowhere}` over a nil `:branch` is a
+      ;; negative over nothing and passes under the gate for free.
+      (is (= 1 (count @entries)) "the activation ran its route-entry plan once")
+      (is (= [] (:branch (first @entries)))
+          "the activation composes over NO branch — not a plausible two-segment
+           one naming :route/nowhere")
+      (is (= {:kind :unknown-parent :route-id* :route/nowhere}
+             (select-keys (:branch-error (first @entries)) [:kind :route-id*]))
+          "…and carries the fail-loud error itself")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (= 1 (count ts)))
+        (is (= [] (:branch tags)))
+        (is (not-any? #{:route/nowhere} (:branch tags))
+            "a tool reading the trace is not told a route exists that does not")
+        (is (= (select-keys (:branch-error (routing-events/resolve-branch :route/leaf))
+                            [:kind :route-id*])
+               (:branch-error tags))
+            "the trace's failure signal IS the activation's"))))
   (testing "and a well-formed branch carries no :branch-error at all — the tag is
             a failure signal, not a slot that is always present"
     (routing/reg-route :route/shell {} "/shell")
     (routing/reg-route :route/child {:parent :route/shell} "/shell/child")
-    (let [tags (:tags (first (planned (rf/dispatch-sync
-                                        [:rf.route/navigate {:to :route/child}]))))]
-      (is (= [:route/shell :route/child] (:branch tags)))
-      (is (not (contains? tags :branch-error)))))
+    (let [entries (atom [])
+          tags    (:tags (first (planned
+                                  (reset! entries
+                                          (with-route-entry-spy!
+                                            #(rf/dispatch-sync
+                                               [:rf.route/navigate {:to :route/child}]))))))]
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): `(not (contains? tags
+      ;; :branch-error))` is true of ANY nil tag map, so the fact that the
+      ;; well-formed case genuinely has no error needs its own witness.
+      (is (= [:route/shell :route/child] (mapv :route-id (:branch (first @entries))))
+          "the activation composes over the parent-to-leaf branch")
+      (is (nil? (:branch-error (first @entries)))
+          "…and the well-formed walk really produced no error to report")
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (= [:route/shell :route/child] (:branch tags)))
+        (is (not (contains? tags :branch-error))))))
   (testing "the :branch-error tag carries only registration-time identifiers —
             a kind and a route id, never a route-meta map (a cycle's :chain
             rides on the plan value, not on the trace bus)"
     (routing/reg-route :route/ping {:parent :route/pong} "/ping")
     (routing/reg-route :route/pong {:parent :route/ping} "/pong")
     (rf/dispatch-sync [:rf.route/handle-url-change "/"])
-    (let [tags (:tags (first (planned (rf/dispatch-sync
-                                        [:rf.route/navigate {:to :route/ping}]))))]
-      (is (= {:kind :parent-cycle :route-id* :route/ping} (:branch-error tags)))
-      (is (not (re-find #":path|:rf.route/compiled|:chain" (pr-str (:branch-error tags))))
-          "no route metadata and no meta-bearing :chain reaches the trace"))))
+    (let [entries (atom [])
+          tags    (:tags (first (planned
+                                  (reset! entries
+                                          (with-route-entry-spy!
+                                            #(rf/dispatch-sync
+                                               [:rf.route/navigate {:to :route/ping}]))))))]
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): the cycle really is what
+      ;; the activation is handed. The trace's REDACTION of it to two keys is
+      ;; the dev-only half — and the `(not (re-find …))` scan over
+      ;; `(pr-str nil)` would pass under the gate whatever rode the bus.
+      (is (= :parent-cycle (:kind (:branch-error (first @entries))))
+          "the activation is handed the cycle, not a silently truncated chain")
+      (is (= :route/ping (:route-id* (:branch-error (first @entries)))))
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (= {:kind :parent-cycle :route-id* :route/ping} (:branch-error tags)))
+        (is (not (re-find #":path|:rf.route/compiled|:chain" (pr-str (:branch-error tags))))
+            "no route metadata and no meta-bearing :chain reaches the trace")))))
 
 ;; ---- the URL -> ResolvedTarget extraction (ONE definition) ----------------
 
@@ -551,9 +774,6 @@
 ;; ===========================================================================
 ;; Door wiring — the doors REACH the seam
 ;; ===========================================================================
-
-(defn- rdb [] (:rf.db/runtime (rf/frame-state-value :rf/default)))
-(defn- current-id [] (get-in (rdb) [:rf.runtime/routing :current :route-id]))
 
 (defn- register-denying-not-found!
   "A `:home` route plus a registered `:rf.route/not-found` whose `:can-enter`
@@ -654,8 +874,18 @@
       (is (= :rf.route/not-found (:route-id url-driven) (:route-id programmatic)))
       (is (= {:url "/miss-a"} (:params url-driven)))
       (is (= {:url "/miss-b"} (:params programmatic)))
-      (is (= [] (:warnings url-driven) (:warnings programmatic))
-          "a well-formed miss is not a malformed URL")))
+      ;; SEMANTIC, posture-independent (rf2-o5dbf): "not a malformed URL" is
+      ;; spelled on the SLICE as the ABSENCE of a `:reason` — and the two
+      ;; `{:url …}` equalities above already say exactly that, key-for-key.
+      ;; The `(= [] …)` leg below is a negative over the trace ring, which the
+      ;; gate empties by design, so it is inside the arm.
+      (is (not (contains? (:params url-driven) :reason))
+          "a well-formed miss stamps no :reason on the slice")
+      (is (not (contains? (:params programmatic) :reason)))
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (= [] (:warnings url-driven) (:warnings programmatic))
+            "a well-formed miss is not a malformed URL"))))
   (testing "a MALFORMED percent-encoding — the discriminator that did NOT agree.
             The programmatic door yielded {:url …} and emitted no warning at
             all, so a per-route error UI branching on :reason (Spec 012) and the
@@ -667,9 +897,13 @@
       (is (= :malformed-url (:reason (:params url-driven))))
       (is (= :malformed-url (:reason (:params programmatic)))
           "the two doors stamp the SAME :reason for the same class of URL")
-      (is (= [:rf.warning/malformed-url] (:warnings url-driven)))
-      (is (= [:rf.warning/malformed-url] (:warnings programmatic))
-          "EP-0015's malformed-URL diagnostic fires on BOTH doors")))
+      ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring). The
+      ;; per-route error UI branches on the always-on `:reason` above; the
+      ;; EP-0015 DIAGNOSTIC rides `trace/emit!` and is dev-only.
+      (when interop/debug-enabled?
+        (is (= [:rf.warning/malformed-url] (:warnings url-driven)))
+        (is (= [:rf.warning/malformed-url] (:warnings programmatic))
+            "EP-0015's malformed-URL diagnostic fires on BOTH doors"))))
   (testing "a match-url THROW — the second discriminator that already agreed,
             pinned so the merge onto the shared extraction cannot lose it"
     (with-redefs [registry/match-url
@@ -679,8 +913,10 @@
         (is (= :rf.route/not-found (:route-id url-driven) (:route-id programmatic)))
         (is (= {:url "/throw-a" :reason :match-error} (:params url-driven)))
         (is (= {:url "/throw-b" :reason :match-error} (:params programmatic)))
-        (is (= [:rf.warning/malformed-url] (:warnings url-driven)))
-        (is (= [:rf.warning/malformed-url] (:warnings programmatic))))))
+        ;; rf2-o5dbf — dev-instrumentation arm (see ns docstring).
+        (when interop/debug-enabled?
+          (is (= [:rf.warning/malformed-url] (:warnings url-driven)))
+          (is (= [:rf.warning/malformed-url] (:warnings programmatic)))))))
   (testing "a VALIDATION miss is the RATIFIED asymmetry, not a defect: Spec 012's
             resolve-target table and §Validation-error surfacing ratify
             URL-driven-routes-to-not-found vs programmatic-caller-bug-rejects.

--- a/scripts/test-routing-prod-gate.sh
+++ b/scripts/test-routing-prod-gate.sh
@@ -65,8 +65,12 @@
 # BY DEFAULT and has to be excluded deliberately, so a new suite that breaks
 # under the production gate reddens this job the day it lands.  An allowlist
 # would have the opposite failure mode — silently not covering the new thing.
-# The list shrinks as rf2-o5dbf lands; when it reaches zero, this script is one
-# line and the `-n` machinery goes away.
+#
+# THE ROSTER IS NOW EMPTY (rf2-o5dbf, 2026-07-27).  All 19 entries were triaged
+# and split; every one of this artefact's test namespaces runs under the gate.
+# The `-n` machinery STAYS: it is what makes the exclusion polarity above real,
+# so the next namespace that goes red under the gate has a documented place to
+# be rostered — with a bead — instead of quietly reddening the job forever.
 
 set -euo pipefail
 
@@ -166,8 +170,45 @@ known_red=(
   #    state that does execute.  Be clear-eyed about the trade: under the
   #    production gate this namespace contributes routing semantics, not the
   #    ownership contract it is named for.
-  re-frame.routing-navigation-test                # 64
-  re-frame.routing-plan-seam-test                 # 31
+  #    CLEARED 2026-07-27 (rf2-o5dbf, batch 8 — THE LAST TWO):
+  #    routing-navigation, routing-plan-seam.  With these the roster is
+  #    EMPTY: every one of this artefact's 37 test namespaces now runs under
+  #    `-Dre-frame.debug=false`, and the `-n` selector list is the whole set.
+  #
+  #    `routing-plan-seam` carried the sharpest vacuous pass the programme has
+  #    found.  `an-executed-navigations-plan-trace-is-not-a-carrier` asserts
+  #    `(is (not (re-find #"SECRET100" (pr-str tags))))` over a REAL
+  #    navigation's plan trace — and under the gate `tags` is nil, so it
+  #    certified that a secret stayed out of an egress copy the framework
+  #    never made.  Its `tok-99` fragment sibling is the same.  Both are
+  #    inside the posture arm now; outside it the suite asserts
+  #    `resolver/plan-trace-tags` — the PURE fn the emit site calls — over the
+  #    same address, which is the redaction itself with no bus in between.
+  #
+  #    `routing-navigation` is the artefact's LOUD-REJECTION verdict, and it
+  #    matches the four tripwires batch 1 read: EVERY rejection survives
+  #    production.  `address/classify` and the event-shape gate run
+  #    unconditionally and return `{}` from the handler, so a malformed
+  #    request leaves the slice untouched and pushes no URL under the gate
+  #    exactly as in dev — only the `:rf.error/navigate-bad-request`
+  #    diagnostic beside them goes quiet.  Because that diagnostic was the
+  #    only place the PER-RULE discrimination was read, the always-on
+  #    replacement is `address/classify` itself: same fn the handler calls,
+  #    same request, no gate between the call and the verdict.  The same
+  #    holds for the param-validation reject — slice unchanged in BOTH
+  #    postures — which is a DIFFERENT shape from the nav-fx-schemas note
+  #    below, where the verdict itself short-circuits to `true`.
+  #
+  #    Eight more negatives-over-an-empty-ring across the two: the only
+  #    assertion in `transitioned-well-formed-url-does-not-emit-malformed-
+  #    trace`, the two `(is (empty? (planned …)))` non-commit legs, three
+  #    nav-token/fragment-changed denials on the short-circuit paths, the
+  #    schema-validation denial on the unmatched-without-404 commit, and —
+  #    worst — `(is (empty? (filter …)))` in
+  #    `commit-traces-suppressed-from-trace-disabled-frame`, which IS that
+  #    deftest's point and would have certified a leak-suppression the
+  #    framework had no occasion to perform.
+  #
   #    CLEARED 2026-07-27 (rf2-o5dbf, batch 7): routing-nav-fx-schemas.
   #    READ THIS ONE BEFORE ASSUMING THE NEXT LOOK-ALIKE IS A DEFECT.  Its
   #    failures were `(is (false? (validate-through-hook …)))` returning
@@ -302,12 +343,14 @@ fi
 # green with `Ran 0 tests`.  Calibrated below the observed count with room for
 # ordinary churn; raise it when the roster grows materially.
 #
-# rf2-o5dbf raised this 85 -> 380.  The original 85 was calibrated against an
-# observed 98 (~87%); the lane now runs 438, so an 85 floor sat FIVE TIMES
-# below what it guards — a roster collapse to a fifth of the lane would still
-# have reported green.  380 restores the same ~87% ratio against the current
-# observation.  Raise it again the next time the roster shrinks materially.
-export RF2_MIN_TESTS="${RF2_MIN_TESTS:-380}"
+# rf2-o5dbf raised this 85 -> 380 -> 455.  The original 85 was calibrated
+# against an observed 98 (~87%); by the time the roster was down to two entries
+# the lane ran 438, so an 85 floor sat FIVE TIMES below what it guards — a
+# roster collapse to a fifth of the lane would still have reported green.  With
+# the roster now EMPTY the lane runs 524, and 455 restores the same ~87% ratio.
+# That is also the floor's final job: with no exclusions left, this is the only
+# thing standing between a `-n` list that matched nothing and a green report.
+export RF2_MIN_TESTS="${RF2_MIN_TESTS:-455}"
 
 args=()
 for ns in $runnable; do


### PR DESCRIPTION
`routing-navigation-test` (64 red) and `routing-plan-seam-test` (31 red) were the last two entries in `scripts/test-routing-prod-gate.sh`'s known-red roster. Both are split; both lines are gone.

**The roster is now EMPTY.** All 37 of this artefact's test namespaces run under `-Dre-frame.debug=false`. The `-n` machinery stays — it is what makes the exclusion polarity real, so the next namespace that goes red under the gate has a documented place to be rostered, with a bead, instead of quietly reddening the job forever.

Same shape as batches 1–7: instrumentation assertions kept **verbatim** inside `(when interop/debug-enabled? …)` arms marked `rf2-o5dbf`, everything outside such an arm posture-independent, a `## Posture split (rf2-o5dbf)` section in each ns docstring. Nothing was deleted or weakened.

## The loud-rejection verdict

`routing-navigation-test` is mostly a rejection suite, and it matches what batch 1 found in the four tripwires: **every rejection it asserts survives production.** `address/classify` and the event-shape gate run unconditionally and the handler returns `{}`, so a malformed request leaves the slice untouched and pushes no URL under the gate exactly as in dev; only the `:rf.error/navigate-bad-request` diagnostic beside them goes quiet. Same for the param-validation reject — the slice is byte-identical in both postures.

That is a **different shape** from batch 7's fx-args gate, where `validate-fx!` short-circuits the verdict itself to `true` per Spec 010 §Production builds. Nothing here is an rf2-9c2jf-class defect; no operator-grade finding came out of these two.

Because the diagnostic was the only place the *per-rule* discrimination was read, the always-on replacement is `address/classify` itself, through a `gate-verdict` helper: same fn the handler calls, same request, the live current slice, no bus between the call and the answer. It also re-proves the heterogeneous-key case's real subject — the canonical ordering that keeps a mixed-kind key set off a `compare`-based `sort` is computed *inside* `classify`, which is where the raw throw would happen.

## Sixteen vacuous passes found and neutralised

Eight in `plan-seam`:

- two `(is (empty? (planned …)))` legs for the non-commit branches;
- `(is (= [] (:warnings url-driven) (:warnings programmatic)))`;
- three legs of `planned-traces-branch-agrees-with-the-activation` — `not-any? #{:route/nowhere}` over a nil `:branch`, `(not (contains? tags :branch-error))` over a nil tag map, and the `:branch-error` metadata scan over `(pr-str nil)`;
- and the sharpest pair the programme has turned up: `(is (not (re-find #"SECRET100" (pr-str tags))))` and its `tok-99` sibling in `an-executed-navigations-plan-trace-is-not-a-carrier`, certifying that a **real** navigation's secret query value and fragment stayed out of an egress copy that was never made.

Eight in `navigation`:

- `transitioned-well-formed-url-does-not-emit-malformed-trace` — its **only** assertion;
- `(is (empty? (filter …)))` in `commit-traces-suppressed-from-trace-disabled-frame` — the whole *point* of that deftest, certifying a leak-suppression the framework had no occasion to perform;
- three `:rf.route.nav-token/allocated` denials and one `:rf.route/fragment-changed` denial on the rule-3 / popstate / programmatic-fragment-only short-circuits;
- the `:rf.route/activated` denial on the fragment-only nav;
- the `:rf.error/schema-validation-failure` denial on the unmatched-without-404 commit.

## Production witnesses added, rather than assertions dropped

- **`plan-trace-tags` is a pure fn the emit site calls**, so the executed navigation now asserts the redaction on *what the bus would carry* — plus that the carriers really do ride raw in-process, which is the distinction `routing_egress_test` pins.
- **`:branch` / `:branch-error` reach the activation through `:routing/on-route-entry`** — a late-bound fn, not a trace. A spy on it proves "the trace's failure signal IS the activation's" from the activation end, in both postures.
- **The `:frame` tag family is an attribution claim, and attribution is frame state.** Four deftests now assert the commit landed in the non-default frame's own runtime-db and that `:rf/default` never moved. An unframed commit could not do that — the same premise the suppression gate and epoch capture both read.
- **`fragment-only-url-change-trace-payload`** records the slice's `:fragment` as the navigations go, so `nil → #scroll-restoration → #fragments` is asserted directly. A "prev" is not otherwise visible after the fact.
- **`handle-url-change-allocates-nav-token-trace`** and **`transitioned-malformed-url-emits-structured-trace`** were 100% trace and would have executed nothing; each gained the slice fact its tags spell.
- Every door commit in `every-door-commit-branch-emits-one-plan-trace` is now a runtime-db assertion: the slice moves, the `:on-match` leaf plan the projection names really dispatches, the SSR feed commits into the **server** frame and leaves `:rf/default` alone, and "plans nothing" is spelled as "allocated no token, re-fired no loader".

## Quality gates

| Gate | Result |
|---|---|
| `bash scripts/test-routing-prod-gate.sh` | **exit 0** — 37 of 37 namespaces, 524 tests / 2641 assertions, 0 failures / 0 errors |
| `clojure -M:test` (routing, dev posture) | **exit 0** — 522 tests / 3001 assertions, 0 failures / 0 errors |
| `clojure -J-Dre-frame.debug=false -M:test:prod-gate -n re-frame.routing-navigation-test` | **exit 0** — 64 tests / 290 assertions (was 64 red) |
| `clojure -J-Dre-frame.debug=false -M:test:prod-gate -n re-frame.routing-plan-seam-test` | **exit 0** — 22 tests / 160 assertions (was 31 red) |
| `bash scripts/test-routing-prod-gate.sh --plan` | **exit 0** — `37 of 37 (0 excluded as known-red)` |

Deferred to CI: the full JVM implementation sweep (`scripts/test-jvm-implementation.sh`), the CLJS substrate suites, and the tool JVM artefacts. This change touches two routing JVM test namespaces and the routing lane script only; nothing under `implementation/routing/src/` was modified, so no other artefact's behaviour can move.

### Lane, before → after

| | before | after |
|---|---|---|
| roster entries | 2 | **0** |
| namespaces | 35 of 37 | **37 of 37** |
| tests | 438 | **524** |
| assertions | 2191 | **2641** |
| `RF2_MIN_TESTS` | 380 | **455** |

`RF2_MIN_TESTS` keeps the ~87 % of observed the previous raise used. With no exclusions left it is the only thing standing between an `-n` list that matched nothing and a green report.

### Dev-posture assertion count

Whole artefact, `clojure -M:test`: **522 tests / 2926 → 3001 assertions.** The two touched namespaces: **86 tests / 487 → 562 assertions.** Test count unchanged, assertion count up in both — the mechanical proof that nothing was deleted.
