### PR TITLE
perf(subs): decompose subscribe's cache-HIT allocation, and write out the ref-count attach (rf2-j8ls2, rf2-ncjyt)

### DIFF
--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -511,6 +511,37 @@
   [query-v]
   query-v)
 
+(defn- bump-ref-count-fn
+  "The ref-count ATTACH, as a `swap-vals!` function — the ONE expression of
+  Spec 006 §Lookup algorithm's CAS-after-snapshot discipline, shared by the
+  three sites that adopt an already-cached node (`subscribe`'s hit path,
+  `compute-and-cache!`'s lost-the-install-race adoption, and the observation
+  port's `acquire!`).
+
+  Bumps `[k :ref-count]` ONLY while the slot is still present holding the SAME
+  `reaction` the caller snapshotted; otherwise answers `m` untouched, so the
+  caller can read `[old new]` and see that the bump did not land. A concurrent
+  evictor (hot-reload re-registration, `clear-sub-cache!`) that won the race
+  therefore cannot be handed a phantom entry with no `:reaction` alongside a
+  now-disposed reaction — the caller falls through to a fresh build instead.
+  On single-threaded CLJS the re-check always succeeds; the rebuild branch is
+  concurrency-host-only. PURE: safe to re-run, as a `swap!` fn must be.
+
+  rf2-j8ls2: the two-level update is written out rather than spelled
+  `(update-in m [k :ref-count] (fnil inc 0))`. Same result, and it reuses the
+  `get` the identity guard already performed instead of walking to the slot
+  twice. `update-in` costs 224 - 248 B/call more than this form on the JVM
+  (measured, `re-frame.bench.read-attribution` arms RC-ATTACH / RC-CAND, 9
+  rounds, paired, never negative) — it allocates a fresh `[k :ref-count]` path
+  vector, a `fnil` closure, and a level of sequence destructuring per call, and
+  `subscribe` runs this on EVERY cache hit of every render."
+  [k reaction]
+  (fn [m]
+    (let [slot (get m k)]
+      (if (identical? reaction (:reaction slot))
+        (assoc m k (assoc slot :ref-count (inc (or (:ref-count slot) 0))))
+        m))))
+
 ;; ---- dev-only cache-fragmentation guardrail (rf2-re5a98) ------------------
 ;;
 ;; `cache-key` keys the per-frame sub-cache by query-vector identity (`=`),
@@ -1339,12 +1370,7 @@
               (interop/dispose! reaction)
               (let [winner-reaction (:reaction (get installed k))
                     [_old post]
-                    (swap-vals! cache
-                                (fn [m]
-                                  (if (identical? winner-reaction
-                                                  (:reaction (get m k)))
-                                    (update-in m [k :ref-count] (fnil inc 0))
-                                    m)))]
+                    (swap-vals! cache (bump-ref-count-fn k winner-reaction))]
                 (if (identical? winner-reaction (:reaction (get post k)))
                   winner-reaction
                   ;; rf2-7w1im: the collision-retry rebuild stays fenced to the
@@ -1636,27 +1662,15 @@
          (let [cache (:sub-cache frame-record)
                k     (cache-key query-v)]
            (if-let [entry (get @cache k)]
-             ;; Hit. Bump ref-count under CAS-after-snapshot discipline so a
-             ;; concurrent evictor (hot-reload re-registration, `clear-sub-
-             ;; cache!`) that won the race cannot resurrect a phantom entry
-             ;; with no `:reaction` AND hand back the now-disposed reaction.
-             ;; The pure-swap-fn only bumps when the slot is still present
-             ;; holding the SAME reaction; reading `[old new]` from the
-             ;; snapshot pair tells us whether the bump landed. If the slot
-             ;; was concurrently evicted (or rebuilt under a different
-             ;; reaction), fall through to a fresh build — the same
-             ;; CAS-after-snapshot discipline `re-frame.subs.cache` uses.
-             ;; On single-threaded CLJS the re-check always succeeds (no
-             ;; concurrent evictor can interleave), so the rebuild branch
-             ;; is concurrency-host-only.
+             ;; Hit. Bump ref-count under the CAS-after-snapshot discipline
+             ;; `bump-ref-count-fn` carries: reading `[old new]` from the
+             ;; snapshot pair tells us whether the bump landed. If the slot was
+             ;; concurrently evicted (or rebuilt under a different reaction),
+             ;; fall through to a fresh build — the same discipline
+             ;; `re-frame.subs.cache` uses.
              (let [reaction (:reaction entry)
                    [_old new]
-                   (swap-vals! cache
-                               (fn [m]
-                                 (if (identical? reaction
-                                                 (:reaction (get m k)))
-                                   (update-in m [k :ref-count] (fnil inc 0))
-                                   m)))]
+                   (swap-vals! cache (bump-ref-count-fn k reaction))]
                (if (identical? reaction (:reaction (get new k)))
                  reaction
                  ;; rf2-7w1im: the hit's concurrent-eviction rebuild carries the
@@ -2298,13 +2312,7 @@
             ;; (concurrent eviction / rebuild) fall through to a fresh
             ;; build.
             (let [reaction (:reaction entry)
-                  [_old new]
-                  (swap-vals! cache
-                              (fn [m]
-                                (if (identical? reaction
-                                                (:reaction (get m k)))
-                                  (update-in m [k :ref-count] (fnil inc 0))
-                                  m)))]
+                  [_old new] (swap-vals! cache (bump-ref-count-fn k reaction))]
               (if (identical? reaction (:reaction (get new k)))
                 {:reaction reaction}
                 (build-and-classify! frame-id query-v k)))

--- a/implementation/core/test/re_frame/bench/read_attribution.clj
+++ b/implementation/core/test/re_frame/bench/read_attribution.clj
@@ -42,6 +42,40 @@
     CACHEGET  the bare `(get @sub-cache q)` the port performs.
     PORT      the whole port call.
 
+  ## The `subs` suite — inside `subscribe` (rf2-j8ls2 / rf2-ncjyt)
+
+  `RM_SUITE=subs` runs a SECOND ladder that opens `subscribe`'s cache-HIT
+  path the same way `PRELUDE` / `PRENODE` opened `probe`'s. Arms S1..S4
+  are strict prefixes of `RGSUB`, re-walked through public functions
+  only, so neighbour subtraction attributes bytes to a step:
+
+    S1-CURFRM  `require-current-frame!` + the `{:where :event-id}` extra
+               map `subscribe`'s 1-arity builds on EVERY call
+    S2-RESTGT  + `frame-target->id` + `frame-resolution-target`
+    S3-CWFR    + `call-with-frame-resolution` around an empty thunk —
+               the flush consult, the generation read, the `binding`
+    S4-PRELOOK + `(frame/frame id)` + `(get @cache q)` inside the thunk:
+               everything up to the ref-count attach
+    RGSUB      + the ref-count attach and the post-swap re-check
+
+  `RGSUB - S4-PRELOOK` is then the ref-count attach, and the `RC-*` arms
+  price its parts against the REAL 300-entry cache map:
+
+    RC-ATTACH  the shipped `swap-vals!` form, standalone
+    RC-GUARD   the same `swap-vals!` whose fn returns `m` UNCHANGED —
+               swap machinery + the identity guard, no update
+    RC-SWAPID  `(swap-vals! cache identity)` — the machinery alone
+    RC-UPDIN   pure `(update-in m [k :ref-count] (fnil inc 0))`
+    RC-NEST    pure hand-rolled two-level update, same result
+    RC-ASSOC   pure `(assoc m k entry)` — the OUTER HAMT path copy alone,
+               the irreducible cost of a persistent one-key change
+    RC-EASSOC  pure `(assoc entry :ref-count n)` — the INNER copy alone
+
+  The `N-*` arms open rf2-ncjyt's `PRELUDE` the same way: the throwaway
+  frame VALUE `frame-resolution-target` mints, the late-bind flush
+  consult, the generation read, the `binding` alone, and `registrar/
+  lookup` on both its branches (generation-bound and registrar-atom).
+
   ## The instrument, and why its controls are the shape they are
 
   Allocation is exact TLAB accounting via
@@ -80,10 +114,12 @@
   Environment: RM_N (dependencies, default 300), RM_ITERS, RM_WARMUP,
   RM_ALLOC, RM_ORDER=rev (run the arms back-to-front — if the answer
   survives that, arm order and the JIT state each arm inherits are not
-  confounds)."
+  confounds), RM_SUITE=port|subs|all (which ladder to run; `port` is the
+  default and is exactly the original thirteen arms)."
   (:require [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.interop :as interop]
+            [re-frame.late-bind :as late-bind]
             [re-frame.live-frame :as live-frame]
             [re-frame.registrar :as registrar]
             [re-frame.subs :as subs]
@@ -228,6 +264,188 @@
               (vreset! sink (if (deref r) 1 0)))))))))
 
 ;; ---------------------------------------------------------------------------
+;; rf2-j8ls2 — INSIDE `subscribe`'s cache-HIT path.
+;;
+;; S1..S4 re-walk `subs/subscribe`'s 1-arity through public functions only,
+;; each a strict prefix of the next and of `RGSUB`. If they do not bracket
+;; `RGSUB` they are not tracking `subscribe` and must not be quoted.
+
+(defn- arm-s1-curfrm [n]
+  (let [qs (:qs @rig)]
+    (dotimes [k n]
+      (vreset! sink
+               (if (frame/require-current-frame!
+                     :subscribe
+                     {:where    're-frame.subs/subscribe
+                      :event-id (first (nth qs k))})
+                 1 0)))))
+
+(defn- arm-s2-restgt [n]
+  (let [qs (:qs @rig)]
+    (dotimes [k n]
+      (let [fid* (frame/frame-target->id
+                   (frame/require-current-frame!
+                     :subscribe
+                     {:where    're-frame.subs/subscribe
+                      :event-id (first (nth qs k))}))]
+        (vreset! sink (if (live-frame/frame-resolution-target fid*) 1 0))))))
+
+(defn- arm-s3-cwfr [n]
+  (let [qs (:qs @rig)]
+    (dotimes [k n]
+      (let [fid* (frame/frame-target->id
+                   (frame/require-current-frame!
+                     :subscribe
+                     {:where    're-frame.subs/subscribe
+                      :event-id (first (nth qs k))}))]
+        (live-frame/call-with-frame-resolution
+          (live-frame/frame-resolution-target fid*)
+          (fn [] (vreset! sink 1)))))))
+
+(defn- arm-s4-prelook [n]
+  (let [qs (:qs @rig)]
+    (dotimes [k n]
+      (let [q    (nth qs k)
+            fid* (frame/frame-target->id
+                   (frame/require-current-frame!
+                     :subscribe
+                     {:where    're-frame.subs/subscribe
+                      :event-id (first q)}))]
+        (live-frame/call-with-frame-resolution
+          (live-frame/frame-resolution-target fid*)
+          (fn []
+            (let [cache* (:sub-cache (frame/frame fid*))]
+              (vreset! sink (if (get @cache* q) 1 0)))))))))
+
+;; ---- the ref-count attach, part by part -----------------------------------
+;;
+;; RC-ATTACH is the shipped form verbatim. The rest strip ONE thing each, so
+;; a difference names a part rather than a suspicion. The `RC-*` pure arms run
+;; against a SNAPSHOT of the same 300-entry cache map, so the outer HAMT they
+;; copy is the real one.
+
+(defn- arm-rc-attach [n]
+  (let [{:keys [qs cache reactions]} @rig]
+    (dotimes [k n]
+      (let [q        (nth qs k)
+            reaction (nth reactions k)
+            [_old new]
+            (swap-vals! cache
+                        (fn [m]
+                          (if (identical? reaction (:reaction (get m q)))
+                            (update-in m [q :ref-count] (fnil inc 0))
+                            m)))]
+        (vreset! sink (if (identical? reaction (:reaction (get new q))) 1 0))))))
+
+(defn- arm-rc-guard [n]
+  (let [{:keys [qs cache reactions]} @rig]
+    (dotimes [k n]
+      (let [q        (nth qs k)
+            reaction (nth reactions k)
+            [_old new]
+            (swap-vals! cache
+                        (fn [m]
+                          (if (identical? reaction (:reaction (get m q)))
+                            m
+                            m)))]
+        (vreset! sink (if (identical? reaction (:reaction (get new q))) 1 0))))))
+
+(defn- arm-rc-swapid [n]
+  (let [{:keys [cache]} @rig]
+    (dotimes [_ n]
+      (let [[_old new] (swap-vals! cache identity)]
+        (vreset! sink (if new 1 0))))))
+
+(defn- arm-rc-updin [n]
+  (let [{:keys [qs snap]} @rig]
+    (dotimes [k n]
+      (vreset! sink
+               (if (update-in snap [(nth qs k) :ref-count] (fnil inc 0)) 1 0)))))
+
+(defn- arm-rc-nest [n]
+  (let [{:keys [qs snap]} @rig]
+    (dotimes [k n]
+      (let [q (nth qs k)
+            e (get snap q)]
+        (vreset! sink
+                 (if (assoc snap q (assoc e :ref-count (inc (long (:ref-count e 0)))))
+                   1 0))))))
+
+;; The outer HAMT path copy, and NOTHING else. `bumped` is a DISTINCT entry
+;; object prepared once, because `PersistentHashMap.assoc` short-circuits and
+;; returns `this` when the new value is `identical?` to the old one — assoc-ing
+;; an entry back over itself measures the no-op path (16 B) and would badly
+;; understate the copy this arm exists to price.
+(defn- arm-rc-assoc [n]
+  (let [{:keys [qs snap bumped]} @rig]
+    (dotimes [k n]
+      (vreset! sink (if (assoc snap (nth qs k) (nth bumped k)) 1 0)))))
+
+(defn- arm-rc-eassoc [n]
+  (let [{:keys [qs snap]} @rig]
+    (dotimes [k n]
+      (vreset! sink (if (assoc (get snap (nth qs k)) :ref-count 2) 1 0)))))
+
+;; The CANDIDATE attach: the same `swap-vals!` under the same CAS-after-
+;; snapshot discipline and the same identity guard, with the two-level
+;; `update-in` written out. Same result, same semantics; measured beside
+;; RC-ATTACH so the difference is the whole claim.
+(defn- arm-rc-cand [n]
+  (let [{:keys [qs cache reactions]} @rig]
+    (dotimes [k n]
+      (let [q        (nth qs k)
+            reaction (nth reactions k)
+            [_old new]
+            (swap-vals! cache
+                        (fn [m]
+                          (let [e (get m q)]
+                            (if (identical? reaction (:reaction e))
+                              (assoc m q (assoc e :ref-count
+                                                (inc (long (:ref-count e 0)))))
+                              m))))]
+        (vreset! sink (if (identical? reaction (:reaction (get new q))) 1 0))))))
+
+;; ---- rf2-ncjyt — the pre-node lookups -------------------------------------
+
+;; `call-with-frame-resolution` with a target that names no image-loaded frame:
+;; the late-bind flush consult, the generation read and the thunk call, with NO
+;; `binding`. S3-CWFR minus this is the dynamic binding, isolated.
+(defn- arm-n-cwfr-nogen [n]
+  (dotimes [_ n]
+    (live-frame/call-with-frame-resolution nil (fn [] (vreset! sink 1)))))
+
+(defn- arm-n-restgt [n]
+  (dotimes [_ n]
+    (vreset! sink (if (live-frame/frame-resolution-target fid) 1 0))))
+
+(defn- arm-n-genread [n]
+  (dotimes [_ n]
+    (vreset! sink (if (live-frame/frame-resolution-generation fid) 1 0))))
+
+(defn- arm-n-flush [n]
+  (dotimes [_ n]
+    (when-let [flush! (late-bind/get-fn-cached :live-frame/flush-projection!)]
+      (flush!))
+    (vreset! sink 1)))
+
+(defn- arm-n-bindonly [n]
+  (let [gen (:gen @rig)]
+    (dotimes [_ n]
+      (binding [registrar/*generation* gen]
+        (vreset! sink (if registrar/*generation* 1 0))))))
+
+(defn- arm-n-lookgen [n]
+  (let [{:keys [qs gen]} @rig]
+    (binding [registrar/*generation* gen]
+      (dotimes [k n]
+        (vreset! sink (if (registrar/lookup :sub (first (nth qs k))) 1 0))))))
+
+(defn- arm-n-lookatom [n]
+  (let [qs (:qs @rig)]
+    (dotimes [k n]
+      (vreset! sink (if (registrar/lookup :sub (first (nth qs k))) 1 0)))))
+
+;; ---------------------------------------------------------------------------
 
 (defn- census
   "How many of the n probes hit a LIVE cache node, and how many compute
@@ -244,8 +462,9 @@
 
 (defn run
   "Measure every arm and print the attribution. Answers the results map."
-  [{:keys [n iters warmup alloc-iters reverse-order?]
-    :or   {n 300 iters 400 warmup 400 alloc-iters 200 reverse-order? false}}]
+  [{:keys [n iters warmup alloc-iters reverse-order? suite]
+    :or   {n 300 iters 400 warmup 400 alloc-iters 200 reverse-order? false
+           suite "port"}}]
   (.setThreadAllocatedMemoryEnabled tmx true)
   (let [sub-ids (mapv #(keyword "ra" (str "s" %)) (range n))
         qs      (mapv vector sub-ids)
@@ -255,9 +474,9 @@
       (rf/reg-sub id (fn [db _] (get-in db [:items i]))))
     (live-frame/make-frame {:id fid})
     (frame/replace-app-db! fid (db-of 0))
-    (println (format ";; debug-enabled? = %s  n=%d iters=%d warmup=%d alloc-iters=%d order=%s"
+    (println (format ";; debug-enabled? = %s  n=%d iters=%d warmup=%d alloc-iters=%d order=%s suite=%s"
                      interop/debug-enabled? n iters warmup alloc-iters
-                     (if reverse-order? "REVERSED" "forward")))
+                     (if reverse-order? "REVERSED" "forward") suite))
     (binding [frame/*current-frame* fid]
       ;; Hold n subscriptions the way a mounted application holds them, so
       ;; every node is live for the whole run — which is what makes `probe`
@@ -265,13 +484,22 @@
       ;; DEREF something to deref.
       (let [held  (mapv subs/subscribe qs)
             src   (frame/app-db-container fid)
+            cache (:sub-cache (frame/frame fid))
             raw   (mapv (fn [i] (interop/make-reaction (fn [] (get-in @src [:items i]))))
                         (range n))]
         (vreset! rig {:qs           qs
-                      :cache        (:sub-cache (frame/frame fid))
+                      :cache        cache
                       :held         held
                       :raw          raw
-                      :db-container src}))
+                      :db-container src
+                      ;; rf2-j8ls2: the `RC-*` arms need the exact reaction the
+                      ;; shipped `identical?` guard compares against, a SNAPSHOT
+                      ;; of the real 300-entry cache map for the pure arms, and
+                      ;; the frame's sealed generation for the binding arms.
+                      :reactions    (mapv #(:reaction (get @cache %)) qs)
+                      :snap         @cache
+                      :bumped       (mapv #(update (get @cache %) :ref-count inc) qs)
+                      :gen          (live-frame/frame-resolution-generation fid)}))
       (let [[live cold] (census n)]
         (println (format ";; probe census: %d LIVE / %d COLD of %d" live cold n)))
       (vswap! gen inc)
@@ -314,13 +542,33 @@
                                  label us bs (/ bs (double n))))
                 (flush)
                 {:label label :us us :bytes bs}))
-            plan [["NOOP"     arm-noop]     ["CTRL-S"   arm-ctrl-small]
-                  ["CTRL-L"   arm-ctrl-large] ["RESOLVE" arm-resolve]
-                  ["PORT"     arm-port]     ["CACHEGET" arm-cacheget]
-                  ["DEREF"    arm-deref]    ["RGSUB"    arm-rgsub]
-                  ["RGREAD"   arm-rgread]   ["RAWREACT" arm-rawreact]
-                  ["GETIN"    arm-getin]   ["PRELUDE"  arm-probe-prelude]
-                  ["PRENODE"  arm-probe-prenode]]
+            controls [["NOOP"    arm-noop]
+                      ["CTRL-S"  arm-ctrl-small]
+                      ["CTRL-L"  arm-ctrl-large]]
+            port-plan [["RESOLVE" arm-resolve]  ["PORT"     arm-port]
+                       ["CACHEGET" arm-cacheget] ["DEREF"   arm-deref]
+                       ["RGSUB"   arm-rgsub]    ["RGREAD"   arm-rgread]
+                       ["RAWREACT" arm-rawreact] ["GETIN"   arm-getin]
+                       ["PRELUDE" arm-probe-prelude]
+                       ["PRENODE" arm-probe-prenode]]
+            ;; rf2-j8ls2 / rf2-ncjyt. RGSUB is in BOTH plans because it is the
+            ;; whole that S1..S4 + the attach must add back up to.
+            subs-plan [["RGSUB"     arm-rgsub]
+                       ["S1-CURFRM" arm-s1-curfrm]  ["S2-RESTGT" arm-s2-restgt]
+                       ["S3-CWFR"   arm-s3-cwfr]    ["S4-PRELOOK" arm-s4-prelook]
+                       ["RC-ATTACH" arm-rc-attach]  ["RC-GUARD"  arm-rc-guard]
+                       ["RC-SWAPID" arm-rc-swapid]  ["RC-UPDIN"  arm-rc-updin]
+                       ["RC-NEST"   arm-rc-nest]    ["RC-ASSOC"  arm-rc-assoc]
+                       ["RC-EASSOC" arm-rc-eassoc]  ["RC-CAND"   arm-rc-cand]
+                       ["N-RESTGT"  arm-n-restgt]   ["N-GENREAD" arm-n-genread]
+                       ["N-FLUSH"   arm-n-flush]    ["N-BINDONLY" arm-n-bindonly]
+                       ["N-CWFRNOG" arm-n-cwfr-nogen]
+                       ["N-LOOKGEN" arm-n-lookgen]  ["N-LOOKATOM" arm-n-lookatom]]
+            port?     (contains? #{"port" "all"} suite)
+            subs?     (contains? #{"subs" "all"} suite)
+            plan (concat controls
+                         (when port? port-plan)
+                         (when subs? (if port? (rest subs-plan) subs-plan)))
             res  (reduce (fn [acc [l f]] (assoc acc l (measure l f)))
                          {}
                          (if reverse-order? (reverse plan) plan))
@@ -336,10 +584,40 @@
                              (* 100.0 (/ (- (net lbl) pred) pred))))))
         (println ";;")
         (println (format ";; NOOP fixed per-pass overhead %10.0f B" noop))
-        (doseq [l ["GETIN" "RAWREACT" "DEREF" "RGSUB" "RGREAD"
-                   "RESOLVE" "CACHEGET" "PRELUDE" "PRENODE" "PORT"]]
-          (println (format ";; %-9s raw %11.0f B   net %11.0f B   %9.1f B/read"
+        (doseq [l (map first (rest plan))]
+          (println (format ";; %-10s raw %11.0f B   net %11.0f B   %9.1f B/read"
                            l (b l) (net l) (per l))))
+        (when subs?
+          (println ";;")
+          (println ";; rf2-j8ls2 — INSIDE subscribe's cache-HIT path (prefix ladder)")
+          (doseq [[lbl v] [["require-current-frame! (S1)"            (net "S1-CURFRM")]
+                           ["+ resolution target    (S2-S1)"         (- (net "S2-RESTGT") (net "S1-CURFRM"))]
+                           ["+ call-with-frame-res  (S3-S2)"         (- (net "S3-CWFR") (net "S2-RESTGT"))]
+                           ["+ frame + cache get    (S4-S3)"         (- (net "S4-PRELOOK") (net "S3-CWFR"))]
+                           ["+ the REF-COUNT ATTACH (RGSUB-S4)"      (- (net "RGSUB") (net "S4-PRELOOK"))]
+                           ["= subscribe            (RGSUB)"         (net "RGSUB")]]]
+            (println (format ";;   %-38s %8.1f B/call" lbl (/ v (double n)))))
+          (println ";; the attach, part by part (RC-ATTACH is the shipped form):")
+          (doseq [l ["RC-ATTACH" "RC-CAND" "RC-GUARD" "RC-SWAPID" "RC-UPDIN"
+                     "RC-NEST" "RC-ASSOC" "RC-EASSOC"]]
+            (println (format ";;   %-38s %8.1f B/call" l (per l))))
+          (println (format ";;   %-38s %8.1f B/call"
+                           "update-in cost (ATTACH-GUARD)"
+                           (- (per "RC-ATTACH") (per "RC-GUARD"))))
+          (println (format ";;   %-38s %8.1f B/call"
+                           "irreducible persistent write (ASSOC+EASSOC)"
+                           (+ (per "RC-ASSOC") (per "RC-EASSOC"))))
+          (println (format ";;   %-38s %8.1f B/call"
+                           "ATTACH - CAND (what the rewrite saves)"
+                           (- (per "RC-ATTACH") (per "RC-CAND"))))
+          (println ";; rf2-ncjyt — the pre-node lookups:")
+          (doseq [l ["N-RESTGT" "N-GENREAD" "N-FLUSH" "N-BINDONLY" "N-CWFRNOG"
+                     "N-LOOKGEN" "N-LOOKATOM"]]
+            (println (format ";;   %-38s %8.1f B/call" l (per l))))
+          (println (format ";;   %-38s %8.1f B/call"
+                           "the dynamic binding (S3-S2 - N-CWFRNOG)"
+                           (- (per "S3-CWFR") (per "S2-RESTGT") (per "N-CWFRNOG")))))
+        (when port?
         (println ";;")
         (println ";; ATTRIBUTION")
         (println (format ";;   PORT   (freehand's per-read)          %9.1f B/read" (per "PORT")))
@@ -369,7 +647,7 @@
                          ["freehand: probe shell (PORT-RESOLVE-DEREF)"
                           (- (net "PORT") (net "RESOLVE") (net "DEREF"))]]]
           (println (format ";;   %-38s %8.1f B/read  %5.1f%% of PORT"
-                           lbl (/ v (double n)) (* 100.0 (/ v (net "PORT"))))))
+                           lbl (/ v (double n)) (* 100.0 (/ v (net "PORT")))))))
         res))))
 
 (defn -main [& _]
@@ -379,5 +657,6 @@
            :iters          (env-int "RM_ITERS" 400)
            :warmup         (env-int "RM_WARMUP" 400)
            :alloc-iters    (env-int "RM_ALLOC" 200)
+           :suite          (or (System/getenv "RM_SUITE") "port")
            :reverse-order? (= "rev" (System/getenv "RM_ORDER"))})))
   (shutdown-agents))

--- a/implementation/core/test/re_frame/bench/read_attribution.clj
+++ b/implementation/core/test/re_frame/bench/read_attribution.clj
@@ -61,7 +61,9 @@
   `RGSUB - S4-PRELOOK` is then the ref-count attach, and the `RC-*` arms
   price its parts against the REAL 300-entry cache map:
 
-    RC-ATTACH  the shipped `swap-vals!` form, standalone
+    RC-ATTACH  the PRE-rf2-j8ls2 `swap-vals!` form (the `update-in`
+               spelling), kept as the paired control
+    RC-CAND    the form that replaced it in `subs/bump-ref-count-fn`
     RC-GUARD   the same `swap-vals!` whose fn returns `m` UNCHANGED —
                swap machinery + the identity guard, no update
     RC-SWAPID  `(swap-vals! cache identity)` — the machinery alone
@@ -324,6 +326,10 @@
 ;; against a SNAPSHOT of the same 300-entry cache map, so the outer HAMT they
 ;; copy is the real one.
 
+;; The PRE-rf2-j8ls2 attach, held here verbatim as the paired control for the
+;; form that replaced it (RC-CAND). It is deliberately NOT a call into
+;; `subs/bump-ref-count-fn`: the whole point is to keep the retired expression
+;; measurable beside the shipped one, in the same process, on the same map.
 (defn- arm-rc-attach [n]
   (let [{:keys [qs cache reactions]} @rig]
     (dotimes [k n]
@@ -386,10 +392,12 @@
     (dotimes [k n]
       (vreset! sink (if (assoc (get snap (nth qs k)) :ref-count 2) 1 0)))))
 
-;; The CANDIDATE attach: the same `swap-vals!` under the same CAS-after-
-;; snapshot discipline and the same identity guard, with the two-level
-;; `update-in` written out. Same result, same semantics; measured beside
-;; RC-ATTACH so the difference is the whole claim.
+;; The SHIPPED attach (rf2-j8ls2 — `subs/bump-ref-count-fn`): the same
+;; `swap-vals!` under the same CAS-after-snapshot discipline and the same
+;; identity guard, with the two-level `update-in` written out. Same result,
+;; same semantics; measured beside RC-ATTACH so the difference is the whole
+;; claim. Spelled out here rather than called, so the pair stays a comparison
+;; of two EXPRESSIONS and neither arm can drift under the other.
 (defn- arm-rc-cand [n]
   (let [{:keys [qs cache reactions]} @rig]
     (dotimes [k n]


### PR DESCRIPTION
Answers rf2-j8ls2 (decompose `subscribe`'s ~1.8 KB cache-HIT allocation) and rf2-ncjyt (`probe`'s ~1120 B pre-node lookups), and lands the one fix that was both obvious and clean.

## The answer

**The 1.8 KB is not the HAMT path copy.** The path copy is 356 B — 19% of it.

`subscribe`, cache HIT, no deref. JVM, `-Dre-frame.debug=false`, n=300 live entries, `ThreadMXBean/getThreadAllocatedBytes`, 9 rounds (6 forward + 3 with the arm order reversed), controls **+0.000% predicted-vs-measured in all 18 rounds**, `NOOP` exactly 0 B:

| step (each arm a strict prefix of the next) | B/call | verdict |
|---|---:|---|
| `require-current-frame!` + its eagerly-built error payload | 136 | artefact |
| + `frame-target->id` + `frame-resolution-target` | 200 | artefact |
| + `call-with-frame-resolution` | 720–800 | **JVM-only** |
| + `(frame/frame id)` + `(get @cache k)` | 0–8 | free |
| + the ref-count attach | 732–772 | mixed |
| **= `subscribe`, cache hit** | **1796–1892** | |

Each step cross-checks against an independently measured standalone arm.

### Intrinsic, or artefact?

**~428 B (23%) is intrinsic.** Producing a new persistent map with one entry's `:ref-count` changed costs the outer HAMT path copy (356 B) plus the entry-map copy (72 B). With the `swap-vals!` CAS pair and the identity guard (88 B) that the CAS-after-snapshot discipline requires, ~516 B of the attach is the price of a correct lock-free persistent ref-count. A mutable ref-count would not be an optimisation of this — it would be a different lifecycle model, and it is not proposed.

**~760 B (41%) is the JVM's dynamic `binding`** of `registrar/*generation*`, and it **does not transfer to ClojureScript**: CLJS `binding` expands through `with-redefs` to `let` + `set!` + `try`/`finally` restore — no allocation. Confirmed from `cljs/core.cljc` in clojurescript-1.12.145 on the classpath.

**Scaling.** The bead asked whether per-call cost tracks cache SIZE. It does, **logarithmically, exactly as a HAMT must** — the path copy reads 283.7 / 356.0 / 467.9 B at n = 30 / 300 / 3000, about one more node clone per trie level. Every other term is flat in n. Not the "different and worse bug" the bead flagged as possible.

## The fix

`(update-in m [k :ref-count] (fnil inc 0))` → written out, reusing the `get` the identity guard already performed. The three byte-identical copies of the swap fn (subscribe's hit path, `compute-and-cache!`'s lost-race adoption, the observation port's `acquire!`) collapse onto one named `bump-ref-count-fn` stating the CAS-after-snapshot discipline once.

| | B/call |
|---|---|
| `subscribe`, cache hit — **before** | **1796 – 1892** |
| `subscribe`, cache hit — **after** | **1612 – 1668** |

Ranges do not overlap. The isolated paired difference (`RC-ATTACH` − `RC-CAND`, both expressions live in the same process on the same map) is **224 B in all six forward rounds and 248 B in all three reversed rounds — never negative**. Every other arm is byte-identical pre and post, which is the internal control that only `subscribe` moved.

No change to lifetime, disposal, or ref-count correctness. `(:ref-count slot)` is wrapped in `or` so an entry carrying an explicit `nil` behaves exactly as `fnil` did.

Clarity: one line longer at the point of use, but it names the slot it had already fetched instead of walking to it twice, and replaces three copies of a subtle concurrency invariant with one documented function.

## rf2-ncjyt

The ~1120 B/read decomposes to: the JVM `binding` ~760 B (JVM-only); `frame-resolution-target`'s throwaway frame value 200 B; `registrar/lookup`'s generation-routed `[kind id]` key vector ~98 B; `(first query-v)` 40 B; and the late-bind flush consult + generation read at **0 B** — which removes one suspect outright. Sums to ~1098 against the ~1120 attributed. Everything but the fix above is filed rather than done: it lands outside this worker's fence or is operator-grade.

## Also here

The first two commits are `worker/port-attribution-mvqwe`'s (PR #7151) harness, cherry-picked so this branch could extend it rather than build a third instrument. If #7151 merges first they rebase away identically.

## Gates

- `implementation/core` JVM `clojure -M:test` — **exit 0**, 2152 tests / 10616 assertions, 0 failures
- `implementation/core` `clojure -M:test:slow-test` (the `^:stress` concurrency lane — this change touches a CAS discipline) — **exit 0**
- 18 measurement rounds — exit 0, controls +0.000% in every one
- `npm run test:cljs` — **deferred to CI** (no `node_modules` in this worktree; the change uses only `get` / `assoc` / `identical?` / `inc` / `or`, no reader conditionals)

Beads filed for everything not done.
