### PR TITLE
docs(studio): the render leg is 95%+ shared re-frame cost, not Freehand's (rf2-9f2w4)

### DIFF
--- a/docs/design/freehand/studio/bulk-rerender-where-the-time-goes.md
+++ b/docs/design/freehand/studio/bulk-rerender-where-the-time-goes.md
@@ -1,10 +1,17 @@
 # Where does Freehand's bulk re-render time go?
 
 Seat: PROFILE SPIKE. Answering the one row
-[`freehand-vs-reagent.md`](freehand-vs-reagent.md) identified as squarely
-Freehand's own — **the broad update, ≈10× Reagent on repainting 300
-boundaries** — and the operator's standard of 2026-07-27, verbatim:
-*"Freehand can't be used if it is slower than Reagent."*
+[`freehand-vs-reagent.md`](freehand-vs-reagent.md) identified as
+Freehand's own on the clock — **the broad update, ≈10× Reagent on
+repainting 300 boundaries** — and the operator's standard of 2026-07-27,
+verbatim: *"Freehand can't be used if it is slower than Reagent."*
+
+That report has since narrowed the claim it made about this leg: it is
+Freehand's own on the **clock**, but 95%+ of what the leg *allocates* per
+dependency read is shared re-frame cost that any substrate reading a
+subscription would pay (`rf2-9f2w4`). This page is a clock profile and is
+unaffected by the correction — but §5's candidates should be read knowing
+that bytes shed on this path are mostly not Freehand's to shed.
 
 Measured 2026-07-27 against `main` at `2b02616db0`. Reagent **2.0.1**,
 React **19.2.0**, headless Chromium 147 via Playwright, `:advanced` with

--- a/docs/design/freehand/studio/freehand-vs-reagent.md
+++ b/docs/design/freehand/studio/freehand-vs-reagent.md
@@ -53,10 +53,15 @@ Four findings, and the third is the one that changes what to do about it.
    same write leg.** The 15× is mostly a re-frame-versus-bare-ratom
    result wearing a Freehand-versus-Reagent label, and the honest
    Freehand-specific number is much smaller.
-4. **Where Freehand's view layer really is slower is bulk re-render.** On
-   the broad write, render is ~72% of Freehand's cost and Freehand's
-   render leg is **4.0–5.4 ms against Reagent's 0.6–0.7 ms** — a genuine
-   **≈7–8× on re-rendering 300 boundaries**, which no accounting moves.
+4. **Where Freehand's view layer really is slower, on the clock, is bulk
+   re-render.** On the broad write, render is ~72% of Freehand's cost and
+   Freehand's render leg is **4.0–5.4 ms against Reagent's 0.6–0.7 ms** —
+   a genuine **≈7–8× on re-rendering 300 boundaries**, which no accounting
+   moves. But this report used to call that leg *squarely Freehand's own*,
+   without qualification, and on the **allocation** axis that has been
+   measured and is false: 95%+ of what a dependency read costs in bytes is
+   paid by any reader of a re-frame subscription, whatever substrate
+   surrounds it. See §2a.
 
 And one property that is not a number: **Freehand could not commit a
 state change synchronously.** A write made inside `react-dom/flushSync`
@@ -71,7 +76,12 @@ below was taken before the fix, through the window it forced.
 ratoms, and it does not say the compiled tier is vindicated. The mount
 advantage is real but small; the update deficit is real and large; and
 the largest single term in the update deficit is owned by `re-frame`
-rather than by either view substrate.
+rather than by either view substrate. Nor does it say these rows isolate
+the view substrate: the Freehand arm reads a re-frame subscription and
+the Reagent arm reads a bare `reagent.core/atom`, so **every
+cross-substrate row below compares a substrate difference confounded with
+a reactive-system difference**, on both legs and not only on the write.
+§2 and §3 say how far that reaches.
 
 ---
 
@@ -290,6 +300,21 @@ required. **NARROW** is one write one cell reads. It prices localisation.
 | **broad** — 300 cells repaint | 27.78 [21.33–35.00] | 24.83 [19.00–30.50] | **2.639** [2.000–3.500] |
 | **narrow** — 1 cell repaints | 8.802 [7.636–9.954] | 8.194 [7.000–9.636] | **0.587** [0.565–0.609] |
 
+> **The two arms do not read the same way, and this is the row where that
+> costs most.** Freehand's cell reads a re-frame subscription; Reagent's
+> derefs an `r/cursor` over a bare `reagent.core/atom` and never calls
+> `subscribe` at all. Each is its own substrate's idiom, which is why
+> these rows are comparable to one another — but it means **neither row
+> is a view-substrate comparison with the reactive system held fixed.**
+> On the allocation axis that difference has been measured and it is
+> large: 95%+ of what a single dependency read costs is paid by any
+> reader of a re-frame subscription, whatever substrate surrounds it
+> (§2a). No browser clock stands behind that measurement, so **no ratio
+> in this table moves because of it** — but read both rows as a substrate
+> difference *plus* an unquantified reactive-system difference, until a
+> B6 arm exists that holds the reactive system fixed (`rf2-mapni`,
+> `rf2-m7xs7`).
+
 Ratios to the in-run floor, as everywhere else — but **the update floor
 is a plain top-down React re-render and is NOT a lower bound.** A
 fine-grained substrate can and should beat it on a narrow write, and
@@ -344,12 +369,46 @@ write path, which a Reagent application reading re-frame subscriptions
 would pay too. The honest Freehand-specific narrow-update number is
 therefore roughly parity, not 15×.
 
-**On a broad write, rendering *is* the problem.** 4.7 ms of a 6.5 ms
-sample is React render and commit, against Reagent's 0.6 ms — **≈7–8×**
-on re-rendering 300 boundaries, with the write leg only 1.5 ms.
-Compiling moves it a little (4.7 → 4.1 ms) and does not close it. This is
-the one number in the update section that is squarely Freehand's own, and
-it is the one to act on.
+**On a broad write, rendering *is* the problem — on the clock.** 4.7 ms
+of a 6.5 ms sample is React render and commit, against Reagent's 0.6 ms —
+**≈7–8×** on re-rendering 300 boundaries, with the write leg only 1.5 ms.
+Compiling moves it a little (4.7 → 4.1 ms) and does not close it. It is
+the largest clock gap in the update section and it is the one to act on.
+
+**"Squarely Freehand's own" is retired as an unqualified claim, because
+the allocation axis says otherwise.** `rf2-mvqwe` (PR #7151) priced one
+dependency read on the JVM against a substrate-free reader — no view
+layer at all — in the same process, against the same subscription cache
+and the same 300 live nodes, over nine rounds. An idiomatic view body
+reading `@(subscribe q)` allocates **95.3%–97.4%** of what Freehand's
+observation port allocates, in every one of the nine, with a paired
+per-round difference of **100–172 B/read** that is never negative. A
+Reagent form-2 component that holds its reaction still pays 48%.
+**Freehand's own share of a read is under 5%.** The bytes this leg burns
+are therefore overwhelmingly re-frame's, paid by every substrate that
+reads a subscription — and paid by our Reagent arm not at all, because it
+reads a ratom.
+
+**No ratio in this report changes on that finding, and the refusal is
+deliberate.** It is an allocation result, taken on the JVM. There is no
+browser clock and no ClojureScript figure behind it, and revising a clock
+number on the strength of an allocation one would be exactly the error
+this correction exists to undo, only pointing the other way. What changes
+is the claim, not the number: the ≈7–8× stands as measured, and stands
+unqualified **only as a clock reading**.
+
+> **Two caveats travel with those bytes.** The absolutes above are JVM
+> bytes, and the largest single term inside `subscribe`'s cost — ≈760 B,
+> 41% of it — is the JVM's dynamic `binding`, which has no ClojureScript
+> counterpart at all (`rf2-j8ls2`). Absolute per-call figures from a JVM
+> run may therefore mis-rank for a browser. The *attribution* is the
+> sturdier half, because both readers pay the JVM-only terms alike:
+> strip the JVM adapter's recompute-on-every-deref out of both and the
+> shared share moves only from 97.4% to 94.9%. Second, `rf2-j8ls2` has
+> since taken ~230 B off every `subscribe` cache hit, and a single
+> post-fix round read the shared share at 89.7%. One round is not a
+> range; nothing here is restated on it, and a nine-round re-run is what
+> would move the figure.
 
 **The microtask yield costs nothing, and the control is in situ.** The
 floor and Reagent arms — which do not need it — report `gap` of exactly

--- a/docs/design/freehand/studio/freehand-vs-reagent.md
+++ b/docs/design/freehand/studio/freehand-vs-reagent.md
@@ -357,7 +357,8 @@ not add; the totals column is the measured figure the ratios use.
 | **narrow** FH compiled (20) | **19.2** | 0.1 | 1.1 | 21.7 |
 | **narrow** Reagent (20) | 0.0 | 0.0 | 1.3 | 1.4 |
 
-Three things fall straight out.
+Three things fall straight out, and the second has since had a correction
+attached to it.
 
 **On a narrow write, Freehand's rendering is not the problem — the write
 is.** The write leg is **19.8 ms** against a render leg of **1.4 ms**:
@@ -382,8 +383,8 @@ layer at all — in the same process, against the same subscription cache
 and the same 300 live nodes, over nine rounds. An idiomatic view body
 reading `@(subscribe q)` allocates **95.3%–97.4%** of what Freehand's
 observation port allocates, in every one of the nine, with a paired
-per-round difference of **100–172 B/read** that is never negative. A
-Reagent form-2 component that holds its reaction still pays 48%.
+per-round difference of **100–172 B/read** that is never negative. Even a
+Reagent form-2 component that holds its reaction pays **48–49%**.
 **Freehand's own share of a read is under 5%.** The bytes this leg burns
 are therefore overwhelmingly re-frame's, paid by every substrate that
 reads a subscription — and paid by our Reagent arm not at all, because it
@@ -405,7 +406,7 @@ unqualified **only as a clock reading**.
 > sturdier half, because both readers pay the JVM-only terms alike:
 > strip the JVM adapter's recompute-on-every-deref out of both and the
 > shared share moves only from 97.4% to 94.9%. Second, `rf2-j8ls2` has
-> since taken ~230 B off every `subscribe` cache hit, and a single
+> since taken 224–248 B off every `subscribe` cache hit, and a single
 > post-fix round read the shared share at 89.7%. One round is not a
 > range; nothing here is restated on it, and a nine-round re-run is what
 > would move the figure.
@@ -471,21 +472,34 @@ Stated plainly, because the omissions are load-bearing.
   costs Freehand 2,430 bytes of standing heap against Reagent's 410 and
   UIx's 251 — **5.93×** and **9.67×** — and a boundary reading its own
   signal costs 4,346 against Reagent's 1,037, **4.19×**. Two independent
-  readers agree to within 1% and every range is disjoint. Crucially the
-  §2a rebuttal below does *not* apply: the widest gap is on the witness
-  with no reactivity and no `app-db` on either side, so the larger term
-  is the ViewCell wrapper rather than re-frame's write path. Heap *under
-  update* is still unmeasured and is the one memory question left with an
-  argument in it.
+  readers agree to within 1% and every range is disjoint. Crucially
+  **neither half of §2a's rebuttal applies here** — not the write leg and
+  not the render leg. The widest gap is on the witness with no reactivity
+  and no `app-db` on either side, so the larger term is the ViewCell
+  wrapper rather than any part of re-frame. That wrapper has since been
+  decomposed (`rf2-oob3g`): ~51% of the per-boundary cost is the ViewCell
+  itself and **42% is React's own six hooks**, so a ViewCell driven all
+  the way to zero would still leave **2.80×** Reagent on standing heap.
+  Heap *under* update has since been measured too, and also went against
+  Freehand:
+  [`freehand-vs-reagent-allocation.md`](freehand-vs-reagent-allocation.md).
 - **Reagent reading re-frame.** The Reagent arm reads a bare
-  `reagent.core/atom`, which is Reagent's own idiom but is *less
-  framework* than the Freehand arm carries. §2a bounds the effect rather
-  than removing it: the write leg is measured separately so a reader can
-  see how much of the gap a re-frame-shaped Reagent app would also have
-  paid. A direct Freehand-vs-Reagent-vs-re-frame row is not possible in
-  one page today — Freehand's `v/sub` is inert under a ratom adapter
-  (`rf2-8cnxg`, `rf2-jt8vz`) — and would need two adapter phases bridged
-  by the floor.
+  `reagent.core/atom` and **never calls `subscribe` at all**, which is
+  Reagent's own idiom but is *less framework* than the Freehand arm
+  carries — so it has not been paying what a real re-frame **plus**
+  Reagent application pays, down to the ~1.8 KB a cache-*hitting*
+  `subscribe` costs on the JVM (`rf2-j8ls2`). This once read as a
+  write-leg caveat, and §2a bounds that half by measuring the write leg
+  separately, so a reader can see how much of the gap a re-frame-shaped
+  Reagent app would also have paid. **It was never confined to the write
+  leg.** The render leg carries a shared re-frame cost too, one per
+  dependency read, and 95%+ of it is shared — which is why **every
+  cross-substrate row on this page is a substrate difference confounded
+  with a reactive-system difference**, and will stay one until a B6 arm
+  holds the reactive system fixed (`rf2-mapni`, `rf2-m7xs7`). A direct
+  Freehand-vs-Reagent-vs-re-frame row is not possible in one page today —
+  Freehand's `v/sub` is inert under a ratom adapter (`rf2-8cnxg`,
+  `rf2-jt8vz`) — and would need two adapter phases bridged by the floor.
 - **The event leg.** Every arm is driven by a direct state install.
   `dispatch` and the event queue are excluded, identically, from all of
   them.
@@ -512,10 +526,15 @@ Stated plainly, because the omissions are load-bearing.
    where inside `commit-frame-transition!` plus the signal graph the
    ≈0.85 ms goes is a small, high-leverage spike.
 2. **Cheapen bulk re-render of boundaries.** The ≈7–8× on 300 repainting
-   boundaries is Freehand's own, and compiling barely moves it, which
-   suggests the cost is in the ViewCell wrapper rather than in the
+   boundaries is Freehand's own *on the clock*, and compiling barely
+   moves it, which pointed at the ViewCell wrapper rather than at the
    markup walk — the same term §1a of the predecessor report priced at
-   2,348 bytes of standing heap per kept ViewCell.
+   2,348 bytes of standing heap per kept ViewCell. Two later measurements
+   sharpen that target and also cap it. On allocation the leg is 95%+
+   shared re-frame cost (§2a), so bytes shed here are mostly not
+   Freehand's to shed. And on standing heap the wrapper is only about
+   half the boundary (`rf2-oob3g`) — React's six hooks are 42% — which
+   bounds what any work confined to `cell.cljc` can return.
 3. **~~A synchronous commit door.~~ DONE — `rf2-w2m25`.** Re-take the
    update row without the microtask yield, which would tighten every
    figure in §2. Note that the fix arms one extra React commit per render


### PR DESCRIPTION
Prose-only correction to a published comparison. **No code, no test, no benchmark re-run, and no measurement taken.** `bd show rf2-9f2w4` carries the mayor ruling this implements verbatim; all three of its recommendations are adopted.

## What changed

`docs/design/freehand/studio/freehand-vs-reagent.md` called the broad-update render leg *"squarely Freehand's own"*, without qualification. PR #7151 (`rf2-mvqwe`) disproved that on the allocation axis: an idiomatic view body reading `@(subscribe q)` allocates **95.3%–97.4%** of what Freehand's observation port allocates per dependency read, in every one of nine rounds, paired difference 100–172 B/read, never negative. Freehand's own share is under 5%.

1. **The caveat moved to the number.** "The Reagent arm reads an `r/cursor` over a bare `reagent.core/atom` and never calls `subscribe`; the Freehand arm reads a re-frame subscription" is no longer only an entry in the limitations list at the end of the page. It now sits directly beneath the broad/narrow update table in §2, and again in the answer-first section.
2. **"Squarely Freehand's own" is retired as an unqualified claim** (§2a). It stands as a **clock** reading and only as a clock reading; on allocation the leg is overwhelmingly shared re-frame cost.
3. **No ratio is restated, and the report now says why.** #7151 measured allocation on the JVM. There is no browser clock and no ClojureScript figure behind it, and revising a clock number on the strength of an allocation one would repeat the original error pointing the other way. Every published figure in the report is unchanged.

The correction also states the deeper problem plainly, where a reader meets the numbers rather than only in a closing caveat: our Reagent arm never calls `subscribe`, so it has not been paying what a real re-frame + Reagent application pays — and **until a B6 arm holds the reactive system fixed (`rf2-mapni`, `rf2-m7xs7`), every cross-substrate row on the page is a substrate difference confounded with a reactive-system difference**, on both legs and not only on the write.

## What the correction must not be read as saying

Recorded on the page so it is not over-read:

- **Retained heap is untouched and still loses badly** — 2,430 B/boundary against Reagent's 410 and UIx's 251, widest on the witness that reads nothing at all. That is the ViewCell wrapper, not the read path.
- The **broad-update clock gap** and the **mount** rows are unchanged.
- Per `rf2-oob3g`, even a ViewCell driven to zero still leaves **2.80×** Reagent on standing heap, because 42% of the per-boundary cost is React's own six hooks. That bounds what any work confined to `cell.cljc` can return, and §4 item 2 now says so.

## Number hygiene

- **The drift note on the bead is reconciled, not acted on.** `rf2-j8ls2` (PR #7154) has since taken 224–248 B off every `subscribe` cache hit, and one post-fix round read the shared share at 89.7% against #7151's 95.3%–97.4%. **One round is not a result.** No published figure moves on it; the page carries it as an unreplicated observation needing a nine-round range.
- **A runtime caveat now travels with the bytes.** The largest single term in `subscribe`'s cost — about 760 B, 41% — is the JVM's dynamic `binding`, which does not exist in ClojureScript, so absolute JVM byte figures may mis-rank for a browser. The 95% *attribution* survives, because both readers pay the JVM-only terms alike: strip the JVM adapter's recompute-on-every-deref out of both and the shared share moves only 97.4% → 94.9%. Every absolute quoted says JVM.

A second file, `bulk-rerender-where-the-time-goes.md`, opened by citing the retired claim verbatim ("identified as squarely Freehand's own"). Retiring a claim in one document while its sibling quotes it is a half-done correction, so its header now reads "Freehand's own on the clock" and notes that the page is a clock profile and is unaffected.

## Quality gates

Foreground, worktree-local logs, exit codes echoed.

| gate | exit |
|---|---|
| `python scripts/check_doc_slugs.py` | **0** (no output) |
| `python -m mkdocs build --strict` | **0** (built in 15.77 s; INFO-only, all pre-existing and unrelated) |

`docs/design/freehand/` is listed in `mkdocs.yml` `exclude_docs`, so these two files carry no nav or link-validator exposure — the strict build is a whole-site regression check here rather than a check of the changed pages. No code or test changed, so no test suite applies; anything slower is **deferred to CI**, which is the merge gate.
