### PR TITLE
perf(core): decompose the narrow-write leg and remove 66% of it (rf2-jr76s)

### DIFF
--- a/implementation/core/src/re_frame/substrate/spine.cljs
+++ b/implementation/core/src/re_frame/substrate/spine.cljs
@@ -139,12 +139,32 @@
   `reset!` fires that ONE watch, which brackets the whole dependent fan-out
   in a `with-epoch` — so a raw source mutation drains every dependent once
   and surfaces the earliest failure at a REAL terminal, exactly like
-  `replace-container!` (see `ensure-source-coordinator!`)."
+  `replace-container!` (see `ensure-source-coordinator!`).
+
+  `:queue` / `:queued` are the drain's SCRATCH — a JS array and a `js/Set`,
+  mutated in place, rather than a `volatile!` holding a persistent vector
+  and a persistent set (rf2-jr76s). This is the same reasoning that already
+  made `depth` / `flushing?` volatiles one line above: both are written and
+  read only on the single-threaded JS event loop, and neither ever escapes
+  this scheduler. A persistent collection buys immutable sharing that nobody
+  here can observe, and charges for it once per dirty entry: an app-db write
+  that marks D derived values dirty performs D `conj`s onto a growing HAMT
+  and D `disj`s as the drain consumes them, each copying its path. Measured
+  on a 300-subscription frame that was **1,706 bytes per dirty subscription
+  — 60% of the whole per-subscription cost of a narrow write**, and it grew
+  with D, because HAMT path length does.
+
+  `js/Set` membership is SameValueZero, which for the function objects this
+  set holds is reference identity — the same relation `contains?` on a
+  persistent set gave them (CLJS `=` on two distinct functions is
+  `identical?`). Enqueue order, the double-enqueue guard, the drain order,
+  and the re-entrant append the running drain observes are all unchanged;
+  this is a representation change and nothing else."
   []
   {:depth     (volatile! 0)   ;; open-epoch nesting depth
    :flushing? (volatile! false)
-   :queue     (volatile! [])  ;; ordered queue of pending flush thunks
-   :queued    (volatile! #{}) ;; identity set guarding double-enqueue
+   :queue     (array)         ;; ordered queue of pending flush thunks (scratch)
+   :queued    (js/Set.)       ;; identity set guarding double-enqueue (scratch)
    :escaped   (volatile! capture-none) ;; earliest-escape cell (rf2-2u4rw)
    :source-coordinators (js/Map.)}) ;; source -> fan-out coordinator (rf2-7ryt0)
 
@@ -226,20 +246,21 @@
         ;; old head-pop-before-call ordering). The per-thunk `try/catch`
         ;; isolates a throwing thunk (drains the tail) AND retains its escape.
         (loop [cursor 0]
-          (when (< cursor (count @queue))
-            (let [thunk (nth @queue cursor)]
-              (vswap! queued disj thunk)
+          (when (< cursor (alength queue))
+            (let [thunk (aget queue cursor)]
+              (.delete queued thunk)
               (try (thunk)
                    (catch :default e
                      (when (identical? capture-none @escaped)
                        (vreset! escaped e)))))
             (recur (inc cursor))))
         (finally
-          ;; The loop consumes `@queue` to empty on every non-re-entrant exit
+          ;; The loop consumes `queue` to empty on every non-re-entrant exit
           ;; (per-thunk capture means no throw escapes the loop), so this
-          ;; releases the backing vector for the next epoch. Re-entrant drains
-          ;; short-circuit on `@flushing?` above and never reach here.
-          (vreset! queue [])
+          ;; releases the held thunks for the next epoch — truncating a JS
+          ;; array drops the references beyond the new length. Re-entrant
+          ;; drains short-circuit on `@flushing?` above and never reach here.
+          (set! (.-length queue) 0)
           (vreset! flushing? false)))
       ;; Queue/flushing state is restored. Surface ONLY a stale escape — one
       ;; SEEDED at entry (a `with-epoch` body-throw E1). A fresh escape captured
@@ -275,9 +296,9 @@
   short-circuits the inline drain, and the running loop picks the thunk up);
   the depth-zero inline drain is the fallback flush for any other seam."
   [{:keys [depth queue queued] :as scheduler} thunk]
-  (when-not (contains? @queued thunk)
-    (vswap! queued conj thunk)
-    (vswap! queue conj thunk))
+  (when-not (.has queued thunk)
+    (.add queued thunk)
+    (.push queue thunk))
   (when (zero? @depth)
     (drain-scheduler! scheduler)))
 
@@ -681,15 +702,34 @@
                                  ;; Two+ subscribers: attempt each independently,
                                  ;; capture the FIRST escape by presence, re-raise
                                  ;; after delivery (surfaced via the drain).
-                                 ;; `vals` over the map skips a map-entry seq.
+                                 ;;
+                                 ;; `reduce-kv` walks the map's backing nodes
+                                 ;; directly, for the SAME reason `sole-val`
+                                 ;; above does (rf2-2u4rw): `(vals ws)` is
+                                 ;; `(map val (seq ws))`, so it allocates a seq
+                                 ;; node AND a lazy-seq cell PER SUBSCRIBER just
+                                 ;; to hand each one to `run!`. On the app-db
+                                 ;; projection — whose subscriber set is EVERY
+                                 ;; layer-1 subscription in the frame — that was
+                                 ;; measured at 307 bytes per subscription per
+                                 ;; write, 11% of the whole per-subscription cost
+                                 ;; of a narrow write (rf2-jr76s). `reduce-kv`
+                                 ;; visits the same entries in the same order
+                                 ;; with the same per-subscriber isolation and
+                                 ;; the same earliest-capture; `ws` is already
+                                 ;; the immutable snapshot taken above, so the
+                                 ;; add/remove-watch-during-fan-out guarantee is
+                                 ;; untouched.
                                  (let [captured (volatile! capture-none)]
-                                   (run! (fn [w]
-                                           (try
-                                             (w prev nu)
-                                             (catch :default e
-                                               (when (identical? capture-none @captured)
-                                                 (vreset! captured e)))))
-                                         (vals ws))
+                                   (reduce-kv
+                                     (fn [_ _ w]
+                                       (try
+                                         (w prev nu)
+                                         (catch :default e
+                                           (when (identical? capture-none @captured)
+                                             (vreset! captured e))))
+                                       nil)
+                                     nil ws)
                                    (when-not (identical? capture-none @captured)
                                      (throw @captured)))))))
           ;; Baseline derived value. LAZY (rf2-ee38b.1 P2): seeded with the

--- a/implementation/core/test/re_frame/bench/write_attribution.cljs
+++ b/implementation/core/test/re_frame/bench/write_attribution.cljs
@@ -114,7 +114,10 @@
   Environment: WA_N (subscriptions, default 300), WA_SAMPLES,
   WA_WARMUP, WA_ORDER=rev (run the arms back-to-front — if the answer
   survives that, arm order is not a confound)."
-  (:require [re-frame.core :as rf]
+  (:require [goog.object :as gobj]
+            [goog.string :as gstring]
+            [goog.string.format]
+            [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.interop :as interop]
             [re-frame.live-frame :as live-frame]
@@ -132,12 +135,12 @@
   (.-heapUsed (js/process.memoryUsage)))
 
 (defn- collect! []
-  (when-let [g (goog.object/get js/globalThis "gc")]
+  (when-let [g (gobj/get js/globalThis "gc")]
     (g)
     (g)))
 
 (defn- env [k d]
-  (or (goog.object/get (.-env js/process) k) d))
+  (or (gobj/get (.-env js/process) k) d))
 
 (defn- env-int [k d] (js/parseInt (env k (str d)) 10))
 
@@ -396,11 +399,11 @@
     (vreset! ctl-small (packed-doubles ctl-small-d))
     (vreset! ctl-large (packed-doubles ctl-large-d))
     (build-rig! n n ns-per-frame)
-    (println (format ";; rf2-jr76s WRITE attribution — node V8, :advanced"))
-    (println (format ";; debug-enabled? = %s   gc-exposed? = %s"
+    (println (gstring/format ";; rf2-jr76s WRITE attribution — node V8, :advanced"))
+    (println (gstring/format ";; debug-enabled? = %s   gc-exposed? = %s"
                      interop/debug-enabled?
-                     (some? (goog.object/get js/globalThis "gc"))))
-    (println (format ";; n=%d samples=%d warmup=%d order=%s frames=%s"
+                     (some? (gobj/get js/globalThis "gc"))))
+    (println (gstring/format ";; n=%d samples=%d warmup=%d order=%s frames=%s"
                      n samples warmup (if rev? "REVERSED" "forward")
                      (pr-str ns-per-frame)))
     ;; Agreement gate: every held subscription must read what the writer
@@ -409,7 +412,7 @@
           v (next-gen!)]
       (frame/replace-app-db! f (update (frame/frame-app-db-value f) :cells assoc 3 v))
       (let [got (binding [frame/*current-frame* f] (deref (subs/subscribe [(keyword "wa" "cell3")])))]
-        (println (format ";; agreement at cell3: wrote %d read %s -> %s"
+        (println (gstring/format ";; agreement at cell3: wrote %d read %s -> %s"
                          v (pr-str got) (if (= v got) "AGREE" "*** DISAGREE ***")))
         (when-not (= v got)
           (throw (ex-info "graph not wired; measurement is meaningless" {:wrote v :read got})))))
@@ -435,7 +438,7 @@
                    (dotimes [_ warmup] (f))
                    (let [reps (calibrate f 2000000)
                          r    (measure f reps samples)]
-                     (println (format ";; %-12s reps=%-6d %12s B/call  [%s – %s]  per-unit %10s B  (%d ok, %d dropped)"
+                     (println (gstring/format ";; %-12s reps=%-6d %12s B/call  [%s – %s]  per-unit %10s B  (%d ok, %d dropped)"
                                       label reps (fmt (:p50 r)) (fmt (:lo r)) (fmt (:hi r))
                                       (fmt (/ (:p50 r) per)) (:accepted r) (:dropped r)))
                      (assoc acc label (assoc r :per per))))
@@ -445,31 +448,31 @@
       (println ";;")
       (println ";; CONTROL — slope across two decades, predicted 8.000 B/double")
       (let [slope (/ (- (b "CTL-L") (b "CTL-S")) (- ctl-large-d ctl-small-d))]
-        (println (format ";;   small D=%d %s B    large D=%d %s B"
+        (println (gstring/format ";;   small D=%d %s B    large D=%d %s B"
                          ctl-small-d (fmt (b "CTL-S")) ctl-large-d (fmt (b "CTL-L"))))
-        (println (format ";;   measured slope %.4f B/double   predicted 8.0000   %+.3f%%"
+        (println (gstring/format ";;   measured slope %.4f B/double   predicted 8.0000   %+.3f%%"
                          slope 8.0 (* 100.0 (/ (- slope 8.0) 8.0)))))
       (println ";;")
       (println ";; THE LADDER — bytes per WRITE")
       (doseq [[lbl v] [["MKDB      the application's own new-db value" (b "MKDB")]
                        ["BAREATOM  + reset! on a watch-free atom"      (b "BAREATOM")]
                        ["SPINE0    + the substrate's replace-container!" (b "SPINE0")]]]
-        (println (format ";;   %-46s %10s B" lbl (fmt v))))
+        (println (gstring/format ";;   %-46s %10s B" lbl (fmt v))))
       (doseq [cnt ns-per-frame]
-        (println (format ";;   %-46s %10s B"
+        (println (gstring/format ";;   %-46s %10s B"
                          (str "RFWRITE-" cnt "  frame/replace-app-db!, " cnt " subs")
                          (fmt (b (str "RFWRITE-" cnt))))))
       (println ";;")
       (let [lo (first ns-per-frame) hi (last ns-per-frame)
             slope (/ (- (b (str "RFWRITE-" hi)) (b (str "RFWRITE-" lo))) (- hi lo))]
-        (println (format ";;   PER-SUBSCRIPTION SLOPE  %s B / sub / write" (fmt slope)))
+        (println (gstring/format ";;   PER-SUBSCRIPTION SLOPE  %s B / sub / write" (fmt slope)))
         (println ";;")
         (println ";; WHERE THE PER-SUBSCRIPTION BYTES GO (each arm × n, reported per sub)")
         (doseq [l ["P-BODY" "P-EQDB" "P-SCOPE" "P-EMIT" "P-MEMO" "Q-SCHED" "P-VALS"]]
           (let [v (/ (b l) n)]
-            (println (format ";;   %-10s %10s B/sub   %5.1f%% of the slope"
+            (println (gstring/format ";;   %-10s %10s B/sub   %5.1f%% of the slope"
                              l (fmt v) (* 100.0 (/ v slope))))))
-        (println (format ";;   %-10s %10s B/sub"
+        (println (gstring/format ";;   %-10s %10s B/sub"
                          "RESIDUAL" (fmt (- slope (/ (b "P-MEMO") n)
                                             (/ (b "Q-SCHED") n) (/ (b "P-VALS") n)))))))
-    (println (format ";; sink %s %s" @sink (some? @sink2)))))
+    (println (gstring/format ";; sink %s %s" @sink (some? @sink2)))))

--- a/implementation/core/test/re_frame/bench/write_attribution.cljs
+++ b/implementation/core/test/re_frame/bench/write_attribution.cljs
@@ -47,8 +47,8 @@
   A control whose size is asserted rather than checked has already been
   wrong twice on this surface (B7's `'x'.repeat(n)` string that read as six
   kilobytes; B8's `8 B/double` prediction that measured 16.002). So the
-  control here is read as a SLOPE across two decades, which cancels every
-  constant and every header:
+  control here is read as a SLOPE across sizes, which cancels every constant
+  and every header:
 
     `.slice()` of a PACKED double-element JS array of D elements allocates a
     `FixedDoubleArray` of D unboxed 8-byte slots plus a fixed header. V8
@@ -58,7 +58,22 @@
     (4 B/slot compressed, 8 uncompressed).
 
   Predicted and measured are both printed. If they disagree, suspect the
-  control first, and report the miss either way.
+  control first, and report the miss either way. Two misses are on record
+  and both are real:
+
+    * The SMALL double pair (D 100->200) lands, at +0.5%. The LARGE pair
+      (1000->10000) reads +9%, because the 8 B/element model omits V8's
+      page-tail filler — an 87 KB object wastes ~7% of a 256 KB page and
+      that filler is genuine used-heap. It is a LARGE-object effect and
+      every arm here allocates small ones, so the instrument is calibrated
+      in the regime it is used in.
+    * The SMI control reads 16.1 B/slot in forward arm order and 8.0027 in
+      REVERSED order — the difference being whether the 87 KB arm ran
+      immediately before it. A large-object arm inflates its successor,
+      reproducibly, and nothing in the method predicted that (rf2-88pie).
+      It is why every figure here is taken in both orders, and why the
+      pointer-compression regime is read off `process.config` rather than
+      off this control.
 
   ## The ladder
 
@@ -100,11 +115,22 @@
     P-MEMO    the whole shipped memo wrapper
               (`subs.memo/make-layer-1-memoised-body`) invoked with a
               CHANGED db — the sum of the four above plus its own frame
-    Q-SCHED   the epoch scheduler's queue bookkeeping — N `conj` onto the
-              `queued` PersistentHashSet + the `queue` PersistentVector,
-              then N `disj` as the drain consumes them
-    P-VALS    the app-db projection's fan-out — `run!` over `(vals ws)` of
-              an N-entry watcher map, the `case (count ws)` ≥2 branch
+    Q-SCHED   the epoch scheduler's queue bookkeeping in its RETIRED
+              spelling — N `conj` onto a PersistentHashSet + a
+              PersistentVector, then N `disj` as the drain consumes them
+    Q-SCHEDJS the same bookkeeping in the SHIPPED spelling — a `js/Set`
+              and a JS array, mutated in place (rf2-jr76s)
+    P-VALS    the app-db projection's fan-out in its RETIRED spelling —
+              `run!` over `(vals ws)` of an N-entry watcher map
+    P-RKV     the same fan-out in the SHIPPED spelling — `reduce-kv` over
+              the map, no seq (rf2-jr76s)
+
+  The last four are TWO PAIRED CONTROLS, both live in one process on the
+  same objects — the `RC-ATTACH` / `RC-CAND` discipline `read-attribution`
+  established. Keeping the retired expression measurable beside the shipped
+  one is what turns a rewrite's saving into a falsifiable prediction:
+  retired-minus-shipped must equal the drop in the per-subscription slope,
+  and when this landed it did, to 0.3%.
 
   Run it:
 

--- a/implementation/core/test/re_frame/bench/write_attribution.cljs
+++ b/implementation/core/test/re_frame/bench/write_attribution.cljs
@@ -157,11 +157,27 @@
 ;; ---------------------------------------------------------------------------
 ;; the control — a slope, not a prediction
 
-(defonce ^:private ctl-small (volatile! nil))
-(defonce ^:private ctl-large (volatile! nil))
+(defonce ^:private ctl-templates (volatile! {}))
 
-(def ^:private ctl-small-d 1000)
-(def ^:private ctl-large-d 10000)
+(def ^:private ctl-double-ds
+  "Two SMALL sizes a decade apart from the two LARGE ones. Small so the
+  copied object is a fraction of V8's 256 KB heap page and the page-tail
+  filler V8 inserts when the next object will not fit is a rounding error;
+  large so the same slope can be re-read where that filler is 2% of the
+  object and the two readings can be compared. A constant error and a scale
+  error look different across the four."
+  [100 200 1000 10000])
+
+(def ^:private ctl-smi-ds
+  "The SAME `.slice()` over a PACKED SMI array. Its slot width is the ONE
+  thing that differs from the double control: V8 never compresses a double,
+  but a tagged pointer/SMI slot is 4 bytes under pointer compression and 8
+  without it. Node.js ships V8 with pointer compression DISABLED (it caps
+  the heap at 4 GB); Chrome ships it ENABLED. So this pair does not merely
+  check the instrument — it READS OFF which regime this process is in, which
+  is what decides whether an absolute byte count here is comparable to a
+  browser one."
+  [100 200])
 
 (defn- packed-doubles
   "A PACKED double-element JS array. Built by pushing doubles rather than
@@ -173,8 +189,29 @@
     (dotimes [i d] (.push a (+ 0.5 i)))
     a))
 
-(defn- arm-ctl-small [] (let [c (.slice @ctl-small)] (vreset! sink (aget c 0))) nil)
-(defn- arm-ctl-large [] (let [c (.slice @ctl-large)] (vreset! sink (aget c 0))) nil)
+(defn- packed-smis
+  "A PACKED SMI-element JS array — same shape, integer elements, so
+  `.slice()` yields a `FixedArray` of tagged slots rather than a
+  `FixedDoubleArray` of raw doubles."
+  [d]
+  (let [a (array)]
+    (dotimes [i d] (.push a (inc i)))
+    a))
+
+(defn- ctl-key [kind d] (str kind "-" d))
+
+(defn- arm-ctl [kind d]
+  (let [t (get @ctl-templates (ctl-key kind d))]
+    (fn []
+      (let [c (.slice t)]
+        (vreset! sink (aget c 0)))
+      nil)))
+
+(defn- slope
+  "Bytes per element between two control readings — the reading that cancels
+  every header, every constant and every per-sample overhead."
+  [b k1 d1 k2 d2]
+  (/ (- (b k2) (b k1)) (- d2 d1)))
 
 ;; ---------------------------------------------------------------------------
 ;; the rig
@@ -312,7 +349,7 @@
   (let [h0 (used-heap)
         _  (dotimes [_ 4] (f))
         per (max 1 (/ (- (used-heap) h0) 4))]
-    (-> (js/Math.round (/ target per)) (max 1) (min 20000))))
+    (-> (js/Math.round (/ target per)) (max 1) (min 4000))))
 
 ;; ---------------------------------------------------------------------------
 ;; rig construction
@@ -396,13 +433,17 @@
                    :use-callback          (fn [t _] t)
                    :use-context           (fn [_] nil)})
                 {:kind :rf.adapter/write-attribution :frame-provider nil}))
-    (vreset! ctl-small (packed-doubles ctl-small-d))
-    (vreset! ctl-large (packed-doubles ctl-large-d))
+    (vreset! ctl-templates
+             (into {} (concat (map (fn [d] [(ctl-key "DBL" d) (packed-doubles d)]) ctl-double-ds)
+                              (map (fn [d] [(ctl-key "SMI" d) (packed-smis d)]) ctl-smi-ds))))
     (build-rig! n n ns-per-frame)
     (println (gstring/format ";; rf2-jr76s WRITE attribution — node V8, :advanced"))
     (println (gstring/format ";; debug-enabled? = %s   gc-exposed? = %s"
                      interop/debug-enabled?
                      (some? (gobj/get js/globalThis "gc"))))
+    (println (gstring/format ";; node %s  V8 %s  pointer-compression=%s (Chrome ships it ON: a tagged slot is 4 B there, 8 B here)"
+                     (.-node js/process.versions) (.-v8 js/process.versions)
+                     (if (= 1 (gobj/getValueByKeys js/process "config" "variables" "v8_enable_pointer_compression")) "ON" "OFF")))
     (println (gstring/format ";; n=%d samples=%d warmup=%d order=%s frames=%s"
                      n samples warmup (if rev? "REVERSED" "forward")
                      (pr-str ns-per-frame)))
@@ -416,11 +457,12 @@
                          v (pr-str got) (if (= v got) "AGREE" "*** DISAGREE ***")))
         (when-not (= v got)
           (throw (ex-info "graph not wired; measurement is meaningless" {:wrote v :read got})))))
-    (let [plan (cond-> [["CTL-S"     arm-ctl-small        1]
-                        ["CTL-L"     arm-ctl-large        1]
-                        ["MKDB"      arm-mkdb             1]
+    (let [plan (cond-> (into (vec (concat
+                                    (map (fn [d] [(ctl-key "DBL" d) (arm-ctl "DBL" d) 1]) ctl-double-ds)
+                                    (map (fn [d] [(ctl-key "SMI" d) (arm-ctl "SMI" d) 1]) ctl-smi-ds)))
+                       [["MKDB"      arm-mkdb             1]
                         ["BAREATOM"  arm-bareatom         1]
-                        ["SPINE0"    arm-spine0           1]]
+                        ["SPINE0"    arm-spine0           1]])
                  true (into (map-indexed
                               (fn [k cnt]
                                 [(str "RFWRITE-" cnt) (fn [] (arm-rfwrite k)) 1])
@@ -446,12 +488,24 @@
                  plan)
           b    (fn [l] (:p50 (get res l)))]
       (println ";;")
-      (println ";; CONTROL — slope across two decades, predicted 8.000 B/double")
-      (let [slope (/ (- (b "CTL-L") (b "CTL-S")) (- ctl-large-d ctl-small-d))]
-        (println (gstring/format ";;   small D=%d %s B    large D=%d %s B"
-                         ctl-small-d (fmt (b "CTL-S")) ctl-large-d (fmt (b "CTL-L"))))
-        (println (gstring/format ";;   measured slope %.4f B/double   predicted 8.0000   %+.3f%%"
-                         slope 8.0 (* 100.0 (/ (- slope 8.0) 8.0)))))
+      (println ";; CONTROLS")
+      (doseq [d ctl-double-ds]
+        (println (gstring/format ";;   DBL D=%-6d %12s B/copy" d (fmt (b (ctl-key "DBL" d))))))
+      (doseq [d ctl-smi-ds]
+        (println (gstring/format ";;   SMI D=%-6d %12s B/copy" d (fmt (b (ctl-key "SMI" d))))))
+      (let [sm (slope b (ctl-key "DBL" 100) 100 (ctl-key "DBL" 200) 200)
+            lg (slope b (ctl-key "DBL" 1000) 1000 (ctl-key "DBL" 10000) 10000)
+            si (slope b (ctl-key "SMI" 100) 100 (ctl-key "SMI" 200) 200)]
+        (println (gstring/format
+                   ";;   DBL slope, SMALL pair (100->200)     %.4f B/double  predicted 8.0000  %+.2f%%"
+                   sm (* 100.0 (/ (- sm 8.0) 8.0))))
+        (println (gstring/format
+                   ";;   DBL slope, LARGE pair (1000->10000)  %.4f B/double  predicted 8.0000  %+.2f%%"
+                   lg (* 100.0 (/ (- lg 8.0) 8.0))))
+        (println (gstring/format
+                   ";;   SMI slope, SMALL pair (100->200)     %.4f B/slot    -> pointer compression %s"
+                   si (if (< si 6.0) "ON (4 B/slot, Chrome-like)"
+                          "OFF (8 B/slot, Node default)"))))
       (println ";;")
       (println ";; THE LADDER — bytes per WRITE")
       (doseq [[lbl v] [["MKDB      the application's own new-db value" (b "MKDB")]

--- a/implementation/core/test/re_frame/bench/write_attribution.cljs
+++ b/implementation/core/test/re_frame/bench/write_attribution.cljs
@@ -1,0 +1,475 @@
+(ns re-frame.bench.write-attribution
+  "rf2-jr76s — WHERE do the bytes of a NARROW WRITE go?
+
+  B8 (rf2-lcsjg) measured, in a browser, that changing ONE cell of a
+  300-cell grid costs 478,787 bytes, of which **457,181 — 95.5% — is the
+  WRITE LEG**: `frame/replace-app-db!` plus the subscription graph
+  re-evaluating all 300 `:b6/cell` subscriptions to discover that 299 of
+  them did not change. That figure is on record; nothing decomposes it.
+
+  A number you cannot decompose you cannot attack, so this namespace
+  decomposes it.
+
+  ## Why this runs in NODE and not in a browser
+
+  The published figure is a browser reading. The two things that make it
+  what it is are the ENGINE (V8) and the BUILD (`:advanced` with
+  `goog.DEBUG false`, so the Spec 009 trace seam is dead code). Node is
+  the same V8 and the build here is the same `:advanced` +
+  `goog.DEBUG false`, so the DCE profile — which is what decides whether
+  the trace layer is in the picture at all — is identical.
+
+  Node also gives one thing the browser cannot: `process.memoryUsage()`
+  reports V8's used-heap counter UNQUANTISED. Chrome's `performance.memory`
+  is bucketed to 100 KB unless `--enable-precise-memory-info` is passed,
+  which is why B8 needed that flag; here there is no flag and no bucket.
+
+  What does NOT transfer is the HOST: no React, no DOM, no commit. That is
+  deliberate — the write leg B8 isolated is exactly the part that happens
+  BEFORE React is involved (B8's `hc → h1` step, `((:write! arm) i val)`),
+  and that is all this namespace measures.
+
+  ## The instrument
+
+  Same method as B8: if no garbage collection runs between two readings of
+  V8's used-heap counter, the difference is the bytes allocated in between,
+  garbage included, because nothing has reclaimed it yet.
+
+  Here every SAMPLE is bracketed by an explicit `global.gc()` (node
+  `--expose-gc`), and the sample is sized so its whole allocation fits in
+  one nursery. A sample whose counter FELL is discarded and counted. Each
+  arm reports p50 with the full range across accepted samples, per the
+  standing rule that ranges are quoted and overlapping ranges mean
+  INDISTINGUISHABLE.
+
+  ## The control
+
+  A control whose size is asserted rather than checked has already been
+  wrong twice on this surface (B7's `'x'.repeat(n)` string that read as six
+  kilobytes; B8's `8 B/double` prediction that measured 16.002). So the
+  control here is read as a SLOPE across two decades, which cancels every
+  constant and every header:
+
+    `.slice()` of a PACKED double-element JS array of D elements allocates a
+    `FixedDoubleArray` of D unboxed 8-byte slots plus a fixed header. V8
+    never pointer-compresses a double, so the slope is **8.000 B/element
+    exactly**, independent of the pointer-compression regime the node build
+    happens to use — which a `FixedArray`-of-SMI control would NOT have been
+    (4 B/slot compressed, 8 uncompressed).
+
+  Predicted and measured are both printed. If they disagree, suspect the
+  control first, and report the miss either way.
+
+  ## The ladder
+
+  Every arm below is a strict subset of the one under it, so subtracting
+  neighbours attributes bytes to a layer rather than to a guess.
+
+    MKDB      the application's own work — `(update db :cells assoc i v)`,
+              the value B6's narrow `write!` builds before it writes
+    BAREATOM  + `reset!` on a plain `clojure.core/atom` with no watches
+    SPINE0    + the substrate's `replace-container!` — `with-epoch`,
+              the reset, the epoch close, an empty drain — with NO
+              derived values wired to the container
+    RFWRITE-0 + `frame/replace-app-db!`'s own bookkeeping on a REAL frame
+              with ZERO subscriptions: `commit-frame-transition!`, the
+              partition carry-forward, the `changed` set, the two
+              partition projections recomputing and fanning out
+    RFWRITE-N + N held layer-1 subscriptions, each with one watcher, the
+              shape a mounted application has
+
+  `RFWRITE-N` is measured at four values of N and the SLOPE between them is
+  the per-subscription cost — the number the bead is about. A slope cancels
+  every constant in the ladder above it, so it is the one figure that does
+  not depend on any of this attribution being right.
+
+  ## The per-subscription pieces
+
+  Then the slope itself is decomposed. Each arm re-walks ONE step of what a
+  layer-1 subscription does when the graph re-evaluates it, through PUBLIC
+  functions only, N times per call so it is directly comparable to the
+  slope:
+
+    P-BODY    the user's sub body — `(get-in db [:cells k])`
+    P-EQDB    the memo wrapper's guard — `(= last-db db)` against the REAL
+              app-db value, which is what decides whether the body runs
+    P-SCOPE   `trace/with-handler-scope` + `handler-scope-from-meta`, which
+              bracket every recompute and are NOT dev-gated
+    P-EMIT    `trace/emit!` on its production path with the tag map the
+              memo wrapper builds for it
+    P-MEMO    the whole shipped memo wrapper
+              (`subs.memo/make-layer-1-memoised-body`) invoked with a
+              CHANGED db — the sum of the four above plus its own frame
+    Q-SCHED   the epoch scheduler's queue bookkeeping — N `conj` onto the
+              `queued` PersistentHashSet + the `queue` PersistentVector,
+              then N `disj` as the drain consumes them
+    P-VALS    the app-db projection's fan-out — `run!` over `(vals ws)` of
+              an N-entry watcher map, the `case (count ws)` ≥2 branch
+
+  Run it:
+
+      npx shadow-cljs release ui-bench --config-merge '{...}'
+      node --expose-gc out/write-attribution.js
+
+  Environment: WA_N (subscriptions, default 300), WA_SAMPLES,
+  WA_WARMUP, WA_ORDER=rev (run the arms back-to-front — if the answer
+  survives that, arm order is not a confound)."
+  (:require [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
+            [re-frame.live-frame :as live-frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.subs :as subs]
+            [re-frame.subs.memo :as subs-memo]
+            [re-frame.substrate.adapter :as adapter]
+            [re-frame.substrate.spine :as spine]
+            [re-frame.trace :as trace :include-macros true]))
+
+;; ---------------------------------------------------------------------------
+;; the counter
+
+(defn- used-heap ^number []
+  (.-heapUsed (js/process.memoryUsage)))
+
+(defn- collect! []
+  (when-let [g (goog.object/get js/globalThis "gc")]
+    (g)
+    (g)))
+
+(defn- env [k d]
+  (or (goog.object/get (.-env js/process) k) d))
+
+(defn- env-int [k d] (js/parseInt (env k (str d)) 10))
+
+;; ---------------------------------------------------------------------------
+;; sinks — Closure is entitled to delete an expression nothing reads, and this
+;; surface has already published a `layout-ms` of exactly 0.000 because a
+;; property read was dropped. Every arm feeds one of these.
+
+(defonce ^:private sink (volatile! 0))
+(defonce ^:private sink2 (volatile! nil))
+
+(defn- keep! [v] (vreset! sink (if v (inc @sink) @sink)) nil)
+
+;; ---------------------------------------------------------------------------
+;; the control — a slope, not a prediction
+
+(defonce ^:private ctl-small (volatile! nil))
+(defonce ^:private ctl-large (volatile! nil))
+
+(def ^:private ctl-small-d 1000)
+(def ^:private ctl-large-d 10000)
+
+(defn- packed-doubles
+  "A PACKED double-element JS array. Built by pushing doubles rather than
+  `(.fill (js/Array. d) 0.5)`, which produces a HOLEY array whose `.slice()`
+  does not take the packed fast path — the exact construction difference B8
+  found itself on the wrong side of."
+  [d]
+  (let [a (array)]
+    (dotimes [i d] (.push a (+ 0.5 i)))
+    a))
+
+(defn- arm-ctl-small [] (let [c (.slice @ctl-small)] (vreset! sink (aget c 0))) nil)
+(defn- arm-ctl-large [] (let [c (.slice @ctl-large)] (vreset! sink (aget c 0))) nil)
+
+;; ---------------------------------------------------------------------------
+;; the rig
+
+(defonce ^:private rig (volatile! nil))
+(defonce ^:private gen (volatile! 1000))
+
+(defn- next-gen! [] (vswap! gen inc))
+
+(def ^:private fid :wa/frame)
+
+(defn- db-of [cells-n v] {:cells (vec (repeat cells-n v))})
+
+;; ---- the ladder -----------------------------------------------------------
+
+(defn- arm-mkdb []
+  (let [{:keys [cells-n db-cell]} @rig
+        v (next-gen!)
+        i (mod v cells-n)]
+    (vreset! sink2 (update @db-cell :cells assoc i v))
+    nil))
+
+(defn- arm-bareatom []
+  (let [{:keys [cells-n db-cell bare]} @rig
+        v (next-gen!)
+        i (mod v cells-n)]
+    (reset! bare (update @db-cell :cells assoc i v))
+    nil))
+
+(defn- arm-spine0 []
+  (let [{:keys [cells-n db-cell spine-container]} @rig
+        v (next-gen!)
+        i (mod v cells-n)]
+    (adapter/replace-container! spine-container
+                                (update @db-cell :cells assoc i v))
+    nil))
+
+(defn- arm-rfwrite
+  "`frame/replace-app-db!` on the rig's frame `k` (which carries `k`'s own
+  number of held subscriptions). The value written is built the way B6's
+  narrow `write!` builds it — read the frame's current app-db, assoc one
+  cell — so this arm is B8's `write` leg and nothing else."
+  [k]
+  (let [{:keys [cells-n frames]} @rig
+        f (nth frames k)
+        v (next-gen!)
+        i (mod v cells-n)]
+    (frame/replace-app-db! f (update (frame/frame-app-db-value f) :cells assoc i v))
+    nil))
+
+;; ---- the per-subscription pieces ------------------------------------------
+
+(defn- arm-p-body []
+  (let [{:keys [n db-a]} @rig]
+    (dotimes [k n]
+      (keep! (get-in db-a [:cells k])))))
+
+(defn- arm-p-eqdb []
+  (let [{:keys [n db-a db-b]} @rig]
+    (dotimes [_ n]
+      (keep! (= db-a db-b)))))
+
+(defn- arm-p-scope []
+  (let [{:keys [n qids]} @rig]
+    (dotimes [k n]
+      (trace/with-handler-scope
+        (trace/handler-scope-from-meta :sub (nth qids k) nil)
+        (keep! true)))))
+
+(defn- arm-p-emit []
+  (let [{:keys [n qids qvs]} @rig]
+    (dotimes [k n]
+      (trace/emit! :rf.sub :rf.sub/run
+                   {:rf.sub/id      (nth qids k)
+                    :rf.sub/query-v (nth qvs k)
+                    :frame          fid}))))
+
+(defn- arm-p-memo []
+  (let [{:keys [n memos db-a db-b]} @rig]
+    (dotimes [k n]
+      ;; Alternate the db so the guard NEVER hits — which is exactly what a
+      ;; real write does to it.
+      (keep! ((nth memos k) (if (even? @gen) db-a db-b))))
+    (next-gen!)
+    nil))
+
+(defn- arm-q-sched []
+  (let [{:keys [n thunks]} @rig
+        [s q] (loop [k 0 s #{} q []]
+                (if (< k n)
+                  (let [t (nth thunks k)]
+                    (recur (inc k)
+                           (if (contains? s t) s (conj s t))
+                           (if (contains? s t) q (conj q t))))
+                  [s q]))]
+    ;; the drain's `(vswap! queued disj thunk)`, once per entry
+    (vreset! sink2 (loop [k 0 s s] (if (< k n) (recur (inc k) (disj s (nth q k))) s)))
+    nil))
+
+(defn- arm-p-vals []
+  (let [{:keys [watch-map]} @rig]
+    (run! (fn [w] (keep! w)) (vals watch-map))
+    nil))
+
+;; ---------------------------------------------------------------------------
+;; the driver
+
+(defn- measure
+  "Run `f` `reps` times inside one collection-free sample, `samples` times.
+  Answers `{:p50 … :lo … :hi … :accepted … :dropped …}` in bytes per CALL."
+  [f reps samples]
+  (let [acc (array)
+        dropped (volatile! 0)]
+    (dotimes [_ samples]
+      (collect!)
+      (let [h0 (used-heap)]
+        (dotimes [_ reps] (f))
+        (let [d (- (used-heap) h0)]
+          (if (neg? d)
+            (vswap! dropped inc)
+            (.push acc (/ d reps))))))
+    (.sort acc (fn [a b] (- a b)))
+    (let [c (alength acc)]
+      {:p50      (if (pos? c) (aget acc (js/Math.floor (/ c 2))) -1)
+       :lo       (if (pos? c) (aget acc 0) -1)
+       :hi       (if (pos? c) (aget acc (dec c)) -1)
+       :accepted c
+       :dropped  @dropped})))
+
+(defn- calibrate
+  "Pick a rep count that puts one sample near `target` bytes, so no sample
+  outgrows the nursery and no sample is lost in the counter's own noise."
+  [f target]
+  (collect!)
+  (let [h0 (used-heap)
+        _  (dotimes [_ 4] (f))
+        per (max 1 (/ (- (used-heap) h0) 4))]
+    (-> (js/Math.round (/ target per)) (max 1) (min 20000))))
+
+;; ---------------------------------------------------------------------------
+;; rig construction
+
+(defn- build-rig! [n cells-n ns-per-frame]
+  ;; One sub-id per cell, exactly B6's `:b6/cell` shape but registered per
+  ;; index so every subscription is a distinct cache entry with a distinct
+  ;; body closure — the shape a real application's 300 boundaries have.
+  (doseq [i (range cells-n)]
+    (rf/reg-sub (keyword "wa" (str "cell" i))
+                (fn [db _] (get-in db [:cells i]))))
+  (let [qids  (mapv #(keyword "wa" (str "cell" %)) (range cells-n))
+        qvs   (mapv vector qids)
+        ;; One frame per subscription count, each with its OWN held
+        ;; subscriptions, so the N-slope is read across four live graphs
+        ;; rather than by subscribing and unsubscribing between samples.
+        frames (mapv (fn [k]
+                       (let [f (keyword "wa" (str "frame" k))]
+                         (live-frame/make-frame {:id f})
+                         (frame/replace-app-db! f (db-of cells-n 0))
+                         f))
+                     (range (count ns-per-frame)))
+        holds  (mapv (fn [f cnt]
+                       (binding [frame/*current-frame* f]
+                         (mapv (fn [q]
+                                 (let [r (subs/subscribe q)]
+                                   ;; One watcher per reaction — the shape a
+                                   ;; mounted boundary gives it. Without this
+                                   ;; the derived value's fan-out takes its
+                                   ;; zero-subscriber branch and the graph is
+                                   ;; not the graph an application has.
+                                   (adapter/subscribe-container r (fn [_ _] nil))
+                                   ;; Establish the memo baseline the way a
+                                   ;; first render does.
+                                   (deref r)
+                                   r))
+                               (subvec qvs 0 cnt))))
+                     frames ns-per-frame)
+        db-a  (db-of cells-n 7)
+        db-b  (update (db-of cells-n 7) :cells assoc (dec cells-n) 8)]
+    (vreset! rig
+             {:n        n
+              :cells-n  cells-n
+              :qids     qids
+              :qvs      qvs
+              :frames   frames
+              :holds    holds
+              :db-cell  (atom (db-of cells-n 0))
+              :bare     (atom (db-of cells-n 0))
+              :spine-container (adapter/make-state-container (db-of cells-n 0))
+              :db-a     db-a
+              :db-b     db-b
+              ;; the shipped memo wrapper, one per subscription
+              :memos    (mapv (fn [i]
+                                (subs-memo/make-layer-1-memoised-body
+                                  (fn [db _] (get-in db [:cells i]))
+                                  (nth qids i) (nth qvs i) fid {}))
+                              (range n))
+              ;; distinct fn identities, the way the scheduler's queue holds
+              ;; one flush thunk per dirty derived value
+              :thunks    (mapv (fn [i] (fn [] i)) (range n))
+              :watch-map (into {} (map (fn [i] [(gensym "w") (fn [] i)])) (range n))})))
+
+;; ---------------------------------------------------------------------------
+
+(defn- fmt [x] (.toFixed x 1))
+
+(defn ^:export -main [& _]
+  (let [n        (env-int "WA_N" 300)
+        samples  (env-int "WA_SAMPLES" 40)
+        warmup   (env-int "WA_WARMUP" 3)
+        rev?     (= "rev" (env "WA_ORDER" ""))
+        ns-per-frame [0 (js/Math.round (/ n 4)) (js/Math.round (/ n 2)) n]]
+    (rf/init! (spine/make-react-adapter
+                (spine/make-react-spine
+                  {:substrate-name        "write-attribution"
+                   :gensym-prefix-sub     "wa-sub-"
+                   :gensym-prefix-derived "wa-derived-"
+                   :gensym-prefix-use-sub "wa-use-sub-"
+                   :use-memo              (fn [t _] (t))
+                   :use-callback          (fn [t _] t)
+                   :use-context           (fn [_] nil)})
+                {:kind :rf.adapter/write-attribution :frame-provider nil}))
+    (vreset! ctl-small (packed-doubles ctl-small-d))
+    (vreset! ctl-large (packed-doubles ctl-large-d))
+    (build-rig! n n ns-per-frame)
+    (println (format ";; rf2-jr76s WRITE attribution — node V8, :advanced"))
+    (println (format ";; debug-enabled? = %s   gc-exposed? = %s"
+                     interop/debug-enabled?
+                     (some? (goog.object/get js/globalThis "gc"))))
+    (println (format ";; n=%d samples=%d warmup=%d order=%s frames=%s"
+                     n samples warmup (if rev? "REVERSED" "forward")
+                     (pr-str ns-per-frame)))
+    ;; Agreement gate: every held subscription must read what the writer
+    ;; wrote, or the graph is not wired and nothing below is evidence.
+    (let [f (last (:frames @rig))
+          v (next-gen!)]
+      (frame/replace-app-db! f (update (frame/frame-app-db-value f) :cells assoc 3 v))
+      (let [got (binding [frame/*current-frame* f] (deref (subs/subscribe [(keyword "wa" "cell3")])))]
+        (println (format ";; agreement at cell3: wrote %d read %s -> %s"
+                         v (pr-str got) (if (= v got) "AGREE" "*** DISAGREE ***")))
+        (when-not (= v got)
+          (throw (ex-info "graph not wired; measurement is meaningless" {:wrote v :read got})))))
+    (let [plan (cond-> [["CTL-S"     arm-ctl-small        1]
+                        ["CTL-L"     arm-ctl-large        1]
+                        ["MKDB"      arm-mkdb             1]
+                        ["BAREATOM"  arm-bareatom         1]
+                        ["SPINE0"    arm-spine0           1]]
+                 true (into (map-indexed
+                              (fn [k cnt]
+                                [(str "RFWRITE-" cnt) (fn [] (arm-rfwrite k)) 1])
+                              ns-per-frame))
+                 true (into [["P-BODY"  arm-p-body  n]
+                             ["P-EQDB"  arm-p-eqdb  n]
+                             ["P-SCOPE" arm-p-scope n]
+                             ["P-EMIT"  arm-p-emit  n]
+                             ["P-MEMO"  arm-p-memo  n]
+                             ["Q-SCHED" arm-q-sched n]
+                             ["P-VALS"  arm-p-vals  n]]))
+          plan (if rev? (vec (reverse plan)) plan)
+          res  (reduce
+                 (fn [acc [label f per]]
+                   (dotimes [_ warmup] (f))
+                   (let [reps (calibrate f 2000000)
+                         r    (measure f reps samples)]
+                     (println (format ";; %-12s reps=%-6d %12s B/call  [%s – %s]  per-unit %10s B  (%d ok, %d dropped)"
+                                      label reps (fmt (:p50 r)) (fmt (:lo r)) (fmt (:hi r))
+                                      (fmt (/ (:p50 r) per)) (:accepted r) (:dropped r)))
+                     (assoc acc label (assoc r :per per))))
+                 {}
+                 plan)
+          b    (fn [l] (:p50 (get res l)))]
+      (println ";;")
+      (println ";; CONTROL — slope across two decades, predicted 8.000 B/double")
+      (let [slope (/ (- (b "CTL-L") (b "CTL-S")) (- ctl-large-d ctl-small-d))]
+        (println (format ";;   small D=%d %s B    large D=%d %s B"
+                         ctl-small-d (fmt (b "CTL-S")) ctl-large-d (fmt (b "CTL-L"))))
+        (println (format ";;   measured slope %.4f B/double   predicted 8.0000   %+.3f%%"
+                         slope 8.0 (* 100.0 (/ (- slope 8.0) 8.0)))))
+      (println ";;")
+      (println ";; THE LADDER — bytes per WRITE")
+      (doseq [[lbl v] [["MKDB      the application's own new-db value" (b "MKDB")]
+                       ["BAREATOM  + reset! on a watch-free atom"      (b "BAREATOM")]
+                       ["SPINE0    + the substrate's replace-container!" (b "SPINE0")]]]
+        (println (format ";;   %-46s %10s B" lbl (fmt v))))
+      (doseq [cnt ns-per-frame]
+        (println (format ";;   %-46s %10s B"
+                         (str "RFWRITE-" cnt "  frame/replace-app-db!, " cnt " subs")
+                         (fmt (b (str "RFWRITE-" cnt))))))
+      (println ";;")
+      (let [lo (first ns-per-frame) hi (last ns-per-frame)
+            slope (/ (- (b (str "RFWRITE-" hi)) (b (str "RFWRITE-" lo))) (- hi lo))]
+        (println (format ";;   PER-SUBSCRIPTION SLOPE  %s B / sub / write" (fmt slope)))
+        (println ";;")
+        (println ";; WHERE THE PER-SUBSCRIPTION BYTES GO (each arm × n, reported per sub)")
+        (doseq [l ["P-BODY" "P-EQDB" "P-SCOPE" "P-EMIT" "P-MEMO" "Q-SCHED" "P-VALS"]]
+          (let [v (/ (b l) n)]
+            (println (format ";;   %-10s %10s B/sub   %5.1f%% of the slope"
+                             l (fmt v) (* 100.0 (/ v slope))))))
+        (println (format ";;   %-10s %10s B/sub"
+                         "RESIDUAL" (fmt (- slope (/ (b "P-MEMO") n)
+                                            (/ (b "Q-SCHED") n) (/ (b "P-VALS") n)))))))
+    (println (format ";; sink %s %s" @sink (some? @sink2)))))

--- a/implementation/core/test/re_frame/bench/write_attribution.cljs
+++ b/implementation/core/test/re_frame/bench/write_attribution.cljs
@@ -298,6 +298,15 @@
     (next-gen!)
     nil))
 
+;; The scheduler's queue bookkeeping, in BOTH spellings, in one process on the
+;; same 300 thunks — the paired-control discipline `read-attribution`'s
+;; `RC-ATTACH` / `RC-CAND` established. `Q-SCHED` is the RETIRED form (a
+;; volatile over a persistent vector + persistent set); `Q-SCHED-JS` is the
+;; form that replaced it (a JS array + `js/Set`, mutated in place). Neither is
+;; a call into `spine`: the whole point is to keep the retired expression
+;; measurable beside the shipped one so the difference is a comparison of two
+;; EXPRESSIONS and neither arm can drift under the other.
+
 (defn- arm-q-sched []
   (let [{:keys [n thunks]} @rig
         [s q] (loop [k 0 s #{} q []]
@@ -311,9 +320,30 @@
     (vreset! sink2 (loop [k 0 s s] (if (< k n) (recur (inc k) (disj s (nth q k))) s)))
     nil))
 
+(defn- arm-q-sched-js []
+  (let [{:keys [n thunks]} @rig
+        s (js/Set.)
+        q (array)]
+    (dotimes [k n]
+      (let [t (nth thunks k)]
+        (when-not (.has s t) (.add s t) (.push q t))))
+    ;; the drain's `(.delete queued thunk)`, once per entry
+    (dotimes [k n] (.delete s (aget q k)))
+    (vreset! sink2 s)
+    nil))
+
+;; The derived-value fan-out over a two-plus-subscriber watcher map, in BOTH
+;; spellings. `P-VALS` is the RETIRED `(run! f (vals ws))`; `P-RKV` is the
+;; `reduce-kv` walk that replaced it.
+
 (defn- arm-p-vals []
   (let [{:keys [watch-map]} @rig]
     (run! (fn [w] (keep! w)) (vals watch-map))
+    nil))
+
+(defn- arm-p-rkv []
+  (let [{:keys [watch-map]} @rig]
+    (reduce-kv (fn [_ _ w] (keep! w) nil) nil watch-map)
     nil))
 
 ;; ---------------------------------------------------------------------------
@@ -473,7 +503,9 @@
                              ["P-EMIT"  arm-p-emit  n]
                              ["P-MEMO"  arm-p-memo  n]
                              ["Q-SCHED" arm-q-sched n]
-                             ["P-VALS"  arm-p-vals  n]]))
+                             ["Q-SCHEDJS" arm-q-sched-js n]
+                             ["P-VALS"  arm-p-vals  n]
+                             ["P-RKV"   arm-p-rkv   n]]))
           plan (if rev? (vec (reverse plan)) plan)
           res  (reduce
                  (fn [acc [label f per]]
@@ -522,11 +554,11 @@
         (println (gstring/format ";;   PER-SUBSCRIPTION SLOPE  %s B / sub / write" (fmt slope)))
         (println ";;")
         (println ";; WHERE THE PER-SUBSCRIPTION BYTES GO (each arm × n, reported per sub)")
-        (doseq [l ["P-BODY" "P-EQDB" "P-SCOPE" "P-EMIT" "P-MEMO" "Q-SCHED" "P-VALS"]]
+        (doseq [l ["P-BODY" "P-EQDB" "P-SCOPE" "P-EMIT" "P-MEMO" "Q-SCHED" "Q-SCHEDJS" "P-VALS" "P-RKV"]]
           (let [v (/ (b l) n)]
             (println (gstring/format ";;   %-10s %10s B/sub   %5.1f%% of the slope"
                              l (fmt v) (* 100.0 (/ v slope))))))
         (println (gstring/format ";;   %-10s %10s B/sub"
                          "RESIDUAL" (fmt (- slope (/ (b "P-MEMO") n)
-                                            (/ (b "Q-SCHED") n) (/ (b "P-VALS") n)))))))
+                                            (/ (b "Q-SCHEDJS") n) (/ (b "P-RKV") n)))))))
     (println (gstring/format ";; sink %s %s" @sink (some? @sink2)))))

--- a/implementation/core/test/re_frame/substrate/spine_glitch_free_cljs_test.cljs
+++ b/implementation/core/test/re_frame/substrate/spine_glitch_free_cljs_test.cljs
@@ -605,8 +605,12 @@
       ;; Scheduler cells clean after the failed fan-out.
       (is (= 0 @(:depth scheduler)) "depth clean")
       (is (false? @(:flushing? scheduler)) "flushing? clean")
-      (is (= [] @(:queue scheduler)) "queue empty")
-      (is (= #{} @(:queued scheduler)) "queued empty")
+      ;; rf2-jr76s — the drain's scratch is a JS array + `js/Set` mutated in
+      ;; place, not a volatile over persistent collections. The CONTRACT this
+      ;; asserts is unchanged: both are empty after the failed fan-out, so no
+      ;; thunk is stranded and no `queued` entry survives to block a re-mark.
+      (is (zero? (alength (:queue scheduler))) "queue empty")
+      (is (zero? (.-size (:queued scheduler))) "queued empty")
       (is (not (instance? js/Error @(:escaped scheduler)))
           ":escaped retains no failure")
       ;; A DIFFERENT source's clean mutation must NOT receive the retained failure.


### PR DESCRIPTION
## rf2-jr76s — the 457 KB write leg, decomposed, and 66% of it removed

`rf2-jr76s` recorded that changing ONE cell of B6's 300-cell grid allocates 478,787 B, of which **457,181 — 95.5% — is the WRITE LEG**: `frame/replace-app-db!` plus the subscription graph re-evaluating all 300 `:b6/cell` subscriptions to discover 299 did not change. Nothing decomposed it, and the bead deliberately proposed no remedy.

### The answer to the bead's real question

**The CARDINALITY is intrinsic. The PER-EVALUATION COST was 70% artefact.**

A layer-1 `reg-sub` body is `(fn [db query-v] …)` — an opaque function of the whole app-db. No shape of `reg-sub` declares a path, no dependency edge carries one, and the only edge in the graph is `sub → app-db-projection`. So the graph genuinely cannot know that `[:b6/cell 7]` reads only `[:cells 7]` without running it. Re-evaluating 300 subs to find 299 unchanged is intrinsic to the subscription contract, and this PR does not touch it.

What was NOT intrinsic is that each of those 300 re-evaluations of a `get-in` cost **2,830 bytes**.

### What this changes

Two private representation choices in the React-hook spine, neither of which touches when a subscription is considered current:

1. **The epoch scheduler's drain scratch.** `:queue` was a `volatile!` over a persistent vector and `:queued` a `volatile!` over a persistent set. Both are private to the scheduler closure, single-threaded, and never escape — the same reasoning that already made `depth` / `flushing?` volatiles one line above. A persistent collection there buys sharing nobody can observe and charges one HAMT path copy per dirty entry on enqueue and another on drain. Now a JS array and a `js/Set`, mutated in place. `js/Set` membership is SameValueZero, which for the function objects it holds is exactly the reference identity `contains?` gave them.

2. **The derived-value fan-out's two-plus-subscriber branch** walked `(vals ws)`, allocating a seq node and a lazy-seq cell per subscriber purely to feed `run!`. The one-subscriber branch beside it already avoids precisely this with `reduce-kv` (`sole-val`, rf2-2u4rw); this extends the same treatment. On the app-db projection — whose subscriber set is every layer-1 subscription in the frame — that mattered.

Enqueue order, the double-enqueue guard, drain order, the re-entrant append a running drain observes, per-subscriber isolation, earliest-escape capture and re-raise-after-delivery are all unchanged.

### Measured

New harness `implementation/core/test/re_frame/bench/write_attribution.cljs` — node V8, `:advanced`, `goog.DEBUG false` (the same DCE profile as the published browser figure), collection-free windows bracketed by an explicit `gc()`, p50 with full ranges, arms re-run back-to-front as a confound check.

| | before | after |
|---|---:|---:|
| `frame/replace-app-db!`, 300 subs | 854,788 B [851,300–883,696] | **286,714 B** [283,319–290,003] |
| per-subscription slope | 2,830.7 B | **940.8 B** |

Ranges disjoint. Reversed arm order reproduces (2,842.8 → 942.7). **3.0×.**

The harness keeps both spellings of each rewrite as paired controls in one process (the `RC-ATTACH` / `RC-CAND` discipline from `read_attribution`), so the saving is a falsifiable prediction rather than a before/after story: retired-minus-shipped predicts 1,578 + 306 = **1,884 B/sub**; the measured slope drop is **1,889.9 B/sub** — 0.3%.

Control: `.slice()` of a packed double array, read as a slope across a decade, predicted 8.0000 B/double, **measured 8.0446 (+0.56%)**. Two control misses are reported in the findings doc rather than buried — a large-object pair reading +9.11% (V8 page-tail filler, confined to objects far bigger than anything measured here) and an SMI arm that reads 2× when it runs immediately after the 87 KB arm and 8.0027 when it does not.

**Absolutes here are node's, not Chrome's**: `process.config.variables.v8_enable_pointer_compression = 0` in Node, `1` in Chrome, so every tagged slot is 8 B here and 4 B there. Shares and ratios transfer; absolute byte counts do not, and the findings doc says so wherever a number appears.

### Scope, stated plainly

This is the **React-hook spine** (UIx, Freehand, `re-frame.ui`). Reagent-substrate applications go through `make-ratom-spine` and Reagent's own batching, and pay none of the scheduler term. The bead's "every re-frame application pays it" needs that qualification; a Reagent arm is filed as follow-up.

### Gates

- `npm run test:cljs` — exit 0, 11,798 tests / 58,735 assertions, 0 failures 0 errors
- `implementation/core` JVM `clojure -M:test` — exit 0, 2,152 tests / 10,616 assertions, 0 failures 0 errors
- Everything else deferred to CI.

`implementation/shadow-cljs.edn` is unchanged — the harness builds through `--config-merge` on the existing `:ui-bench` id, the same route B8 used.

Full findings, the whole ladder, and what could not be determined: `ai/findings/2026-07-27.jr76s-narrow-write-attribution.md`.
