### PR TITLE
perf(core): remove three measured read-path allocation artefacts (rf2-ezwnl, rf2-a8bw0, rf2-8gb3t)

### DIFF
--- a/implementation/core/src/re_frame/live_frame.cljc
+++ b/implementation/core/src/re_frame/live_frame.cljc
@@ -130,7 +130,7 @@
   of `image-assembly/assemble` plus one registry `swap!`. An app that never
   calls `make-frame` with `:images` never reaches these fns (Closure DCE removes
   them). The resolution seam adds a single dynamic binding around the cascade
-  (the no-generation default path pays one `frame-object?` predicate then runs
+  (the no-generation default path pays one record read then runs
   with zero binding cost — see [[call-with-frame-resolution]]). Reload runs on
   the development hot-reload / explicit re-`make-frame` reload path (not a
   per-event hot path, not a DEBUG-gated branch): pure re-assembly via
@@ -188,7 +188,8 @@
 ;; Back-compat internal alias: the resolution seam below was written against
 ;; `frame-object?`; EP-0024 renames the concept to `frame-value?` (a value, not
 ;; an object) but keeps the predicate available under both spellings for the
-;; internal callers (router / subs frame-resolution-target) until they migrate.
+;; internal callers (`re-frame.core/resolve-live-frame-object`) until they
+;; migrate.
 (def ^{:doc "Internal alias of `frame-value?` (EP-0024 renamed frame OBJECT →
   frame VALUE); the dispatch/subscribe resolution-target helpers still spell it
   `frame-object?`. Pure."}
@@ -302,24 +303,16 @@
 ;; not inferred from process state. A plain fn (not a macro) so CLJS sibling-ns
 ;; callers use it with no `:require-macros` plumbing.
 
-(defn frame-resolution-target
-  "EP-0023 §Frame-derived live registration resolution (rf2-uejnt3): given the
-  CARRIED frame `target` a caller holds (a `subscribe` `frame-id` slot or a
-  dispatch envelope's `:frame`), return the EP-0023 frame OBJECT to derive the
-  resolution generation from — the object itself when the target IS one (the
-  direct-object form), or the live-frame registry's object for a frame-id
-  KEYWORD. nil for any target that names no live image-loaded frame — the
-  absence-is-default signal that [[call-with-frame-resolution]] binds NOTHING
-  and the build/dispatch resolves through the registrar atom path,
-  byte-identical for every existing caller. The shared resolution-target read
-  the subscribe-side (`subs`) and dispatch-side (`router`) twins collapsed onto
-  (rf2-6zfzxy) — both held a byte-identical copy. Pure read of the carried
-  target + the process-local live-frame registry."
-  [target]
-  (cond
-    (frame-object? target) target
-    (keyword? target)      (live-frame target)
-    :else                  nil))
+;; RETIRED: `frame-resolution-target` (rf2-8gb3t). It sat between every caller
+;; and [[call-with-frame-resolution]], turning a frame-id KEYWORD into a freshly
+;; minted frame VALUE — which [[frame-resolution-generation]] then normalized
+;; straight back to that same keyword to read the record's `:generation`. Pass
+;; the CARRIED target itself: a frame value, a frame id, or nil are all already
+;; the seam's documented input, and each resolves the same generation by the
+;; same path (`frame-value->id` is identity on a keyword, and on anything that
+;; is not a frame value; an unregistered address reads nil). The wrapper was
+;; therefore a no-op that allocated a throwaway map per subscribe / probe /
+;; dispatch.
 
 (defn frame-resolution-generation
   "Return the resolved image generation a `frame-target` resolves registrations

--- a/implementation/core/src/re_frame/registrar.cljc
+++ b/implementation/core/src/re_frame/registrar.cljc
@@ -808,9 +808,20 @@
   dispatch) — resolution targets the `active-registrar` atom, one `nil?` branch
   on the read.
 
-  Uses paired `get` calls rather than `(get-in ... [kind id])` — `get-in`
-  allocates a path vector per call, and `lookup` runs per
-  dispatch (event handler), per fx (handler), and per sub (handler)."
+  The REGISTRAR-ATOM branch uses paired `get` calls rather than
+  `(get-in ... [kind id])` — `get-in` allocates a path vector per call, and
+  `lookup` runs per dispatch (event handler), per fx (handler), and per sub
+  (handler).
+
+  The GENERATION-ROUTED branch pays that cost anyway, and cannot avoid it here:
+  the resolver is keyed by a `[kind id]` PAIR, so the routed lookup must build
+  one. Measured at ~98 B/call on the JVM (rf2-ezwnl). The remedy is to re-key
+  the resolver `{kind {id descriptor}}` so both branches read the same paired
+  `get` — but `:rf.gen/resolver`'s `{[kind id] descriptor}` shape is normative
+  (Spec API.md §`frame-generation`, Conventions.md §`:rf.gen/*`) and is read as
+  plain data by Xray, the Pair MCP runtime and Story, so that is a spec change
+  and not a local one. Until then this comment is the honest version of the
+  paragraph above: the paired-`get` claim covers ONE of the two branches."
   [kind id]
   (if-let [resolver (generation-resolver)]
     (get resolver [kind id])

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -333,10 +333,9 @@
         ;; carries a keyword `:frame` and every bare-`frame-id`-keyed cascade
         ;; operation downstream (the router queue/drain, `frame-state-value`,
         ;; the commit path, the sub-cache) stays byte-identical. The
-        ;; generation-resolution seam re-resolves the object from this id via the
-        ;; live-frame registry (`frame-resolution-target`), so an object target
-        ;; and a child dispatch carrying the same id BOTH route the frame's
-        ;; image. A keyword target (and the scope/hold-resolved frame) passes
+        ;; generation-resolution seam reads the sealed generation off the record
+        ;; by this id, so an object target and a child dispatch carrying the same
+        ;; id BOTH route the frame's image. A keyword target (and the scope/hold-resolved frame) passes
         ;; through `frame-target->id` unchanged.
          frame              (when (trace/continuation-live?)
                               (try
@@ -2874,8 +2873,8 @@
       resolve the same `[kind id]` to their own image's descriptor
       (ALL-OR-NOTHING — `call-with-frame-resolution` covers the whole
       thunk). The generation is DERIVED from the carried frame target
-      (`frame-resolution-target` resolves a direct frame OBJECT verbatim,
-      a frame-id keyword through the live-frame registry), never an
+      (a direct frame VALUE and a frame-id keyword normalize to the same
+      record address, so both read the same sealed generation), never an
       ambient binding (EP-0002). A target that names no live image-loaded
       frame yields no generation, so `call-with-frame-resolution` binds
       NOTHING and resolution falls through to the registrar-atom path,
@@ -3755,7 +3754,7 @@
          handler-meta (when (and event-id (continue?))
                         (try
                           (live-frame/call-with-frame-resolution
-                            (live-frame/frame-resolution-target (:frame envelope))
+                            (:frame envelope)
                             (fn [] (registrar/lookup :event event-id)))
                           (catch #?(:clj Throwable :cljs :default) e
                             ;; Resolution is callback-bearing. A destroy+throw

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -1494,10 +1494,10 @@
   normalized here to its runnable-id ADDRESS via `frame/frame-target->id`
   so the sub-cache lookup (`(frame/frame frame-id)`), the override seam,
   and the error payloads all key the backing record unchanged — a keyword
-  passes through. The generation-resolution seam (`frame-resolution-target`)
-  then re-resolves the frame's image from this id via the live-frame
-  registry — so a value target builds against its OWN image, byte-identical
-  to the keyword form. Mirrors the dispatch-side normalization in
+  passes through. The generation-resolution seam
+  (`live-frame/call-with-frame-resolution`) then reads the frame's sealed
+  generation off the record by this id — so a value target builds against its
+  OWN image, byte-identical to the keyword form. Mirrors the dispatch-side normalization in
   `re-frame.router/build-envelope`.
 
   Per Spec 006 §The sub-override subscribe seam (CLJS /
@@ -1596,7 +1596,7 @@
    ;; and the build resolves through the registrar atom directly
    ;; (absence-is-default). DERIVED from the carried target (EP-0002).
    (live-frame/call-with-frame-resolution
-     (live-frame/frame-resolution-target frame-id)
+     frame-id
      (fn []
    (let [frame-record (frame/frame frame-id)
          ;; rf2-7w1im: resolve the record ONCE and decide supersession up front,
@@ -2302,7 +2302,7 @@
   `release!`), or `unsubscribe`."
   [frame-id query-v]
   (live-frame/call-with-frame-resolution
-    (live-frame/frame-resolution-target frame-id)
+    frame-id
     (fn []
       (if-let [cache (:sub-cache (frame/frame frame-id))]
         (let [k (cache-key query-v)]

--- a/implementation/core/src/re_frame/subs.cljc
+++ b/implementation/core/src/re_frame/subs.cljc
@@ -1744,10 +1744,21 @@
    ;; than silently reading the wrong frame's app-db. The `extra` threads
    ;; the sub-id into the error payload's `:event-id` slot so a frameless
    ;; subscribe's error is attributed to the query it carried.
-   (subscribe-in-frame (frame/require-current-frame!
-                         :subscribe
-                         {:where    're-frame.subs/subscribe
-                          :event-id (first query-v)})
+   ;;
+   ;; rf2-a8bw0: the reader FIRST, then the require — which is what
+   ;; `require-current-frame!` does internally, written out here so the
+   ;; `extra` payload is built only on the path that reads it. The error is
+   ;; unchanged: when the reader finds nothing, `require-current-frame!`
+   ;; runs with the same `extra` and emits + throws the same
+   ;; `:rf.error/no-frame-context`. `subscribe`'s 1-arity is the framework's
+   ;; per-read path — one call per reactive read per render — and it is the
+   ;; only 1-arity spelled this way; `subscribe-once` / `unsubscribe` run
+   ;; once per slot and keep the plain call. Do NOT collapse this back.
+   (subscribe-in-frame (or (frame/resolve-current-frame)
+                           (frame/require-current-frame!
+                             :subscribe
+                             {:where    're-frame.subs/subscribe
+                              :event-id (first query-v)}))
                        query-v))
   ([query-v opts]
    ;; API-shrink #1 (rf2-csbbwu): the 2-arity is `[query-v opts]` ONLY — no

--- a/implementation/core/src/re_frame/substrate/observation.cljc
+++ b/implementation/core/src/re_frame/substrate/observation.cljc
@@ -1670,7 +1670,7 @@
          (throw-frame-destroyed! 're-frame.substrate.observation/probe
                                  frame-id query))
        (live-frame/call-with-frame-resolution
-         (live-frame/frame-resolution-target frame-id)
+         frame-id
          (fn []
            (when (nil? (registrar/lookup :sub (first query)))
              (throw-no-such-sub! 're-frame.substrate.observation/probe
@@ -2141,7 +2141,7 @@
         (throw-frame-destroyed! 're-frame.substrate.observation/acquire!
                                 frame-id query))
       (live-frame/call-with-frame-resolution
-        (live-frame/frame-resolution-target frame-id)
+        frame-id
         (fn []
           (when (nil? (registrar/lookup :sub (first query)))
             (throw-no-such-sub! 're-frame.substrate.observation/acquire!

--- a/implementation/core/test/re_frame/bench/read_attribution.clj
+++ b/implementation/core/test/re_frame/bench/read_attribution.clj
@@ -49,14 +49,26 @@
   are strict prefixes of `RGSUB`, re-walked through public functions
   only, so neighbour subtraction attributes bytes to a step:
 
-    S1-CURFRM  `require-current-frame!` + the `{:where :event-id}` extra
-               map `subscribe`'s 1-arity builds on EVERY call
-    S2-RESTGT  + `frame-target->id` + `frame-resolution-target`
+    S1-CURFRM  `require-current-frame!` on the happy path — the SHIPPED
+               reader-then-require spelling (rf2-a8bw0)
+    S2-TGTID   + `frame-target->id`
     S3-CWFR    + `call-with-frame-resolution` around an empty thunk —
                the flush consult, the generation read, the `binding`
     S4-PRELOOK + `(frame/frame id)` + `(get @cache q)` inside the thunk:
                everything up to the ref-count attach
     RGSUB      + the ref-count attach and the post-swap re-check
+
+  Two RETIRED spellings are kept live beside their replacements as
+  PAIRED CONTROLS in the same process, so each saving is a falsifiable
+  prediction rather than a before/after story:
+
+    S1-EAGER   `require-current-frame!` with the `{:where :event-id}`
+               extra map built EAGERLY — what `subscribe`'s 1-arity did
+               before rf2-a8bw0.  S1-EAGER - S1-CURFRM is the saving.
+    N-CWFRWRAP `call-with-frame-resolution` behind the retired
+               `frame-resolution-target` wrapper (rf2-8gb3t), against
+    N-CWFRRAW  the shipped form, which passes the carried target itself.
+               N-CWFRWRAP - N-CWFRRAW must equal N-RESTGT.
 
   `RGSUB - S4-PRELOOK` is then the ref-count attach, and the `RC-*` arms
   price its parts against the REAL 300-entry cache map:
@@ -74,8 +86,8 @@
     RC-EASSOC  pure `(assoc entry :ref-count n)` — the INNER copy alone
 
   The `N-*` arms open rf2-ncjyt's `PRELUDE` the same way: the throwaway
-  frame VALUE `frame-resolution-target` mints, the late-bind flush
-  consult, the generation read, the `binding` alone, and `registrar/
+  frame VALUE the retired `frame-resolution-target` minted, the late-bind
+  flush consult, the generation read, the `binding` alone, and `registrar/
   lookup` on both its branches (generation-bound and registrar-atom).
 
   ## The instrument, and why its controls are the shape they are
@@ -173,6 +185,42 @@
 (defn- arm-noop [_n] nil)
 
 ;; ---------------------------------------------------------------------------
+;; the RETIRED spellings, held here verbatim as paired controls
+;;
+;; Each is deliberately NOT a call into the shipped source: the whole point is
+;; to keep the retired EXPRESSION measurable beside the one that replaced it,
+;; in the same process, against the same live frame — so a claimed saving is a
+;; prediction the instrument can falsify rather than a before/after story.
+
+;; rf2-8gb3t. `live-frame/frame-resolution-target`, as it stood before the
+;; wrapper was retired: a frame VALUE verbatim, a frame-id keyword through
+;; `live-frame` (which MINTS a fresh frame value), anything else nil.
+(defn- retired-resolution-target [target]
+  (cond
+    (live-frame/frame-value? target) target
+    (keyword? target)                (live-frame/live-frame target)
+    :else                            nil))
+
+;; rf2-a8bw0. `subscribe`'s 1-arity, as it stood before the payload was
+;; deferred: the `{:where :event-id}` extra map built on EVERY call, read only
+;; on the `:rf.error/no-frame-context` path.
+(defn- retired-current-frame! [query-v]
+  (frame/require-current-frame!
+    :subscribe
+    {:where    're-frame.subs/subscribe
+     :event-id (first query-v)}))
+
+;; The SHIPPED spelling (rf2-a8bw0): the scope reader first, and the payload —
+;; with `require-current-frame!` building it — only when the reader found
+;; nothing. Same error, same content, same call site; built lazily.
+(defn- shipped-current-frame! [query-v]
+  (or (frame/resolve-current-frame)
+      (frame/require-current-frame!
+        :subscribe
+        {:where    're-frame.subs/subscribe
+         :event-id (first query-v)})))
+
+;; ---------------------------------------------------------------------------
 ;; the arms
 
 (defn- arm-resolve [n]
@@ -246,7 +294,7 @@
             query  (:query target)]
         (when (nil? (frame/frame fid*)) (throw (ex-info "no frame" {})))
         (live-frame/call-with-frame-resolution
-          (live-frame/frame-resolution-target fid*)
+          fid*
           (fn []
             (registrar/lookup :sub (first query))
             (vreset! sink (if (:reaction (get @cache query)) 1 0))))))))
@@ -259,7 +307,7 @@
             query  (:query target)]
         (when (nil? (frame/frame fid*)) (throw (ex-info "no frame" {})))
         (live-frame/call-with-frame-resolution
-          (live-frame/frame-resolution-target fid*)
+          fid*
           (fn []
             (registrar/lookup :sub (first query))
             (let [r (:reaction (get @cache query))]
@@ -275,46 +323,36 @@
 (defn- arm-s1-curfrm [n]
   (let [qs (:qs @rig)]
     (dotimes [k n]
-      (vreset! sink
-               (if (frame/require-current-frame!
-                     :subscribe
-                     {:where    're-frame.subs/subscribe
-                      :event-id (first (nth qs k))})
-                 1 0)))))
+      (vreset! sink (if (shipped-current-frame! (nth qs k)) 1 0)))))
 
-(defn- arm-s2-restgt [n]
+;; The paired control for S1-CURFRM: the eager-payload spelling rf2-a8bw0
+;; retired. S1-EAGER - S1-CURFRM is the whole of what deferring it saves.
+(defn- arm-s1-eager [n]
   (let [qs (:qs @rig)]
     (dotimes [k n]
-      (let [fid* (frame/frame-target->id
-                   (frame/require-current-frame!
-                     :subscribe
-                     {:where    're-frame.subs/subscribe
-                      :event-id (first (nth qs k))}))]
-        (vreset! sink (if (live-frame/frame-resolution-target fid*) 1 0))))))
+      (vreset! sink (if (retired-current-frame! (nth qs k)) 1 0)))))
+
+(defn- arm-s2-tgtid [n]
+  (let [qs (:qs @rig)]
+    (dotimes [k n]
+      (let [fid* (frame/frame-target->id (shipped-current-frame! (nth qs k)))]
+        (vreset! sink (if fid* 1 0))))))
 
 (defn- arm-s3-cwfr [n]
   (let [qs (:qs @rig)]
     (dotimes [k n]
-      (let [fid* (frame/frame-target->id
-                   (frame/require-current-frame!
-                     :subscribe
-                     {:where    're-frame.subs/subscribe
-                      :event-id (first (nth qs k))}))]
+      (let [fid* (frame/frame-target->id (shipped-current-frame! (nth qs k)))]
         (live-frame/call-with-frame-resolution
-          (live-frame/frame-resolution-target fid*)
+          fid*
           (fn [] (vreset! sink 1)))))))
 
 (defn- arm-s4-prelook [n]
   (let [qs (:qs @rig)]
     (dotimes [k n]
       (let [q    (nth qs k)
-            fid* (frame/frame-target->id
-                   (frame/require-current-frame!
-                     :subscribe
-                     {:where    're-frame.subs/subscribe
-                      :event-id (first q)}))]
+            fid* (frame/frame-target->id (shipped-current-frame! q))]
         (live-frame/call-with-frame-resolution
-          (live-frame/frame-resolution-target fid*)
+          fid*
           (fn []
             (let [cache* (:sub-cache (frame/frame fid*))]
               (vreset! sink (if (get @cache* q) 1 0)))))))))
@@ -424,7 +462,21 @@
 
 (defn- arm-n-restgt [n]
   (dotimes [_ n]
-    (vreset! sink (if (live-frame/frame-resolution-target fid) 1 0))))
+    (vreset! sink (if (retired-resolution-target fid) 1 0))))
+
+;; rf2-8gb3t, the falsifiable pair: the RETIRED composition every caller wrote
+;; (`(cwfr (frame-resolution-target X) thunk)`) against the SHIPPED one
+;; (`(cwfr X thunk)`). Their difference must be N-RESTGT — the wrapper and
+;; nothing else.
+(defn- arm-n-cwfr-wrap [n]
+  (dotimes [_ n]
+    (live-frame/call-with-frame-resolution
+      (retired-resolution-target fid)
+      (fn [] (vreset! sink 1)))))
+
+(defn- arm-n-cwfr-raw [n]
+  (dotimes [_ n]
+    (live-frame/call-with-frame-resolution fid (fn [] (vreset! sink 1)))))
 
 (defn- arm-n-genread [n]
   (dotimes [_ n]
@@ -562,13 +614,15 @@
             ;; rf2-j8ls2 / rf2-ncjyt. RGSUB is in BOTH plans because it is the
             ;; whole that S1..S4 + the attach must add back up to.
             subs-plan [["RGSUB"     arm-rgsub]
-                       ["S1-CURFRM" arm-s1-curfrm]  ["S2-RESTGT" arm-s2-restgt]
+                       ["S1-CURFRM" arm-s1-curfrm]  ["S1-EAGER"  arm-s1-eager]
+                       ["S2-TGTID"  arm-s2-tgtid]
                        ["S3-CWFR"   arm-s3-cwfr]    ["S4-PRELOOK" arm-s4-prelook]
                        ["RC-ATTACH" arm-rc-attach]  ["RC-GUARD"  arm-rc-guard]
                        ["RC-SWAPID" arm-rc-swapid]  ["RC-UPDIN"  arm-rc-updin]
                        ["RC-NEST"   arm-rc-nest]    ["RC-ASSOC"  arm-rc-assoc]
                        ["RC-EASSOC" arm-rc-eassoc]  ["RC-CAND"   arm-rc-cand]
                        ["N-RESTGT"  arm-n-restgt]   ["N-GENREAD" arm-n-genread]
+                       ["N-CWFRWRAP" arm-n-cwfr-wrap] ["N-CWFRRAW" arm-n-cwfr-raw]
                        ["N-FLUSH"   arm-n-flush]    ["N-BINDONLY" arm-n-bindonly]
                        ["N-CWFRNOG" arm-n-cwfr-nogen]
                        ["N-LOOKGEN" arm-n-lookgen]  ["N-LOOKATOM" arm-n-lookatom]]
@@ -599,12 +653,21 @@
           (println ";;")
           (println ";; rf2-j8ls2 — INSIDE subscribe's cache-HIT path (prefix ladder)")
           (doseq [[lbl v] [["require-current-frame! (S1)"            (net "S1-CURFRM")]
-                           ["+ resolution target    (S2-S1)"         (- (net "S2-RESTGT") (net "S1-CURFRM"))]
-                           ["+ call-with-frame-res  (S3-S2)"         (- (net "S3-CWFR") (net "S2-RESTGT"))]
+                           ["+ frame-target->id     (S2-S1)"         (- (net "S2-TGTID") (net "S1-CURFRM"))]
+                           ["+ call-with-frame-res  (S3-S2)"         (- (net "S3-CWFR") (net "S2-TGTID"))]
                            ["+ frame + cache get    (S4-S3)"         (- (net "S4-PRELOOK") (net "S3-CWFR"))]
                            ["+ the REF-COUNT ATTACH (RGSUB-S4)"      (- (net "RGSUB") (net "S4-PRELOOK"))]
                            ["= subscribe            (RGSUB)"         (net "RGSUB")]]]
             (println (format ";;   %-38s %8.1f B/call" lbl (/ v (double n)))))
+          (println ";; the retired spellings, as paired controls:")
+          (doseq [[lbl v] [["S1-EAGER (retired eager payload)"       (per "S1-EAGER")]
+                           ["S1-CURFRM (shipped, deferred)"          (per "S1-CURFRM")]
+                           ["rf2-a8bw0 saves (S1-EAGER - S1-CURFRM)" (- (per "S1-EAGER") (per "S1-CURFRM"))]
+                           ["N-CWFRWRAP (retired target wrapper)"    (per "N-CWFRWRAP")]
+                           ["N-CWFRRAW  (shipped, carried target)"   (per "N-CWFRRAW")]
+                           ["rf2-8gb3t saves (WRAP - RAW)"           (- (per "N-CWFRWRAP") (per "N-CWFRRAW"))]
+                           ["  ... predicted by N-RESTGT"            (per "N-RESTGT")]]]
+            (println (format ";;   %-38s %8.1f B/call" lbl v)))
           (println ";; the attach, part by part (RC-ATTACH is the shipped form):")
           (doseq [l ["RC-ATTACH" "RC-CAND" "RC-GUARD" "RC-SWAPID" "RC-UPDIN"
                      "RC-NEST" "RC-ASSOC" "RC-EASSOC"]]
@@ -624,7 +687,7 @@
             (println (format ";;   %-38s %8.1f B/call" l (per l))))
           (println (format ";;   %-38s %8.1f B/call"
                            "the dynamic binding (S3-S2 - N-CWFRNOG)"
-                           (- (per "S3-CWFR") (per "S2-RESTGT") (per "N-CWFRNOG")))))
+                           (- (per "S3-CWFR") (per "S2-TGTID") (per "N-CWFRNOG")))))
         (when port?
         (println ";;")
         (println ";; ATTRIBUTION")

--- a/implementation/core/test/re_frame/subscribe_opts_arity_cljs_test.cljc
+++ b/implementation/core/test/re_frame/subscribe_opts_arity_cljs_test.cljc
@@ -58,6 +58,28 @@
        (catch #?(:clj clojure.lang.ExceptionInfo :cljs cljs.core/ExceptionInfo) e
          (:rf.error/id (ex-data e)))))
 
+(deftest ambient-1-arity-no-frame-context-payload-is-fully-attributed
+  (testing "rf2-a8bw0: the 1-arity builds its `:rf.error/no-frame-context`
+            payload LAZILY — the scope reader runs first and the `extra` map is
+            constructed only once absence is known. The error a caller sees must
+            therefore be identical to the eagerly-built one: the same
+            discriminator, the same `:operation`, the same `:where` naming the
+            resolving fn, and the same `:event-id` carrying the query's sub-id
+            so a frameless subscribe is attributed to the query it held.
+            Deferring construction must never degrade the message."
+    (setup!)
+    (let [data (try @(rf/subscribe [:soa/val]) nil
+                    (catch #?(:clj clojure.lang.ExceptionInfo
+                              :cljs cljs.core/ExceptionInfo) e
+                      (ex-data e)))]
+      (is (some? data) "an ambient subscribe under no scope throws")
+      (is (= :rf.error/no-frame-context (:rf.error/id data)))
+      (is (= :subscribe (:operation data)))
+      (is (= 're-frame.subs/subscribe (:where data))
+          ":where still names the resolving fn")
+      (is (= :soa/val (:event-id data))
+          ":event-id still carries the sub-id off the query the caller held"))))
+
 (deftest opts-map-frame-targets-the-named-frame
   (testing "(subscribe query-v {:frame f}) reads f's app-db"
     (setup!)

--- a/implementation/ui/src/re_frame/ui/reactive.cljc
+++ b/implementation/ui/src/re_frame/ui/reactive.cljc
@@ -313,7 +313,7 @@
   [query-v]
   (if-some [frame-id (frame/resolve-current-frame)]
     (live-frame/call-with-frame-resolution
-      (live-frame/frame-resolution-target frame-id)
+      frame-id
       (fn [] [(registrar/lookup :sub (first query-v)) frame-id]))
     [(registrar/lookup :sub (first query-v)) nil]))
 


### PR DESCRIPTION
Three allocation artefacts on the read path, each filed with a measured cost already attached. Two are removed; the third is **verified and deliberately not fixed** — its remedy is a normative spec change, not a local one, and this PR says so rather than reaching for it.

An artefact here means eager work on a path that discards it. None of these is a design cost.

## rf2-8gb3t — `frame-resolution-target` was a no-op that minted a frame value per read

`frame-resolution-target` sat between every caller and `call-with-frame-resolution`, and on a frame-id KEYWORD it called `live-frame`, which mints a fresh frame VALUE via `make-frame-value`. Its sole consumer then called `frame-resolution-generation` on that value, which normalized it *straight back* to the keyword it was built from (`frame-value->id`) and read the record's `:generation` slot.

**What reads the value: nothing.** Every one of the seven call sites in the repo has the identical shape `(call-with-frame-resolution (frame-resolution-target X) thunk)`, and the value is discarded within one function call of being built. So the composition was provably an identity:

```
(call-with-frame-resolution (frame-resolution-target X) thunk)
  =  (call-with-frame-resolution X thunk)
```

for every X — a frame VALUE (returned verbatim by both paths), a frame id (`frame-value->id` is identity on a keyword), nil, or anything else (`frame/frame` is a total `(get @frames id)` read that emits nothing for an unknown address). `call-with-frame-resolution`'s own docstring **already** documents accepting "a frame VALUE … or a frame id", and `frame_resolution_cljs_test` / `ep0023_conformance_cljs_test` **already** call it directly with values, keywords and nil.

So the seam is **removed** rather than made cheaper. Seven call sites lose a wrapper call, `live-frame.cljc` loses a function, and nothing gains a concept. `frame-resolution-target` appears in no spec, no EP, no doc and no test; `live-frame`, `frame-value?`, `frame-object?` and `frame-resolution-generation` are untouched, as is the absence-is-default fall-through.

## rf2-a8bw0 — `subscribe`'s error payload was built on every call

`subscribe`'s 1-arity built its `{:where :event-id}` `extra` map on **every** call. `require-current-frame!` reads that map only when `resolve-current-frame` returns nil — the `:rf.error/no-frame-context` path. On the happy path it was pure garbage.

The fix is the reader first, then the require — which is exactly what `require-current-frame!` does internally ("built on this reader", its own docstring), written out at the one call site hot enough to care:

```clojure
(subscribe-in-frame (or (frame/resolve-current-frame)
                        (frame/require-current-frame!
                          :subscribe
                          {:where    're-frame.subs/subscribe
                           :event-id (first query-v)}))
                    query-v)
```

**Nothing about the error changes.** Same `extra`, same payload, same emit, same throw, same capture-site ancestry — it is merely constructed after the failure is known rather than before. A new `.cljc` test pins all four fields a caller on that path sees (`:rf.error/id`, `:operation`, `:where`, `:event-id`); existing coverage asserted the discriminator only, so nothing would have caught a payload that quietly lost its attribution.

Scoped deliberately to `subscribe`: it is the framework's per-read path, one call per reactive read per render. `subscribe-once` and `unsubscribe` run once per slot and keep the plain call, so the unusual spelling stays confined to the one place it is earned, with a comment saying why.

## rf2-ezwnl — verified, and NOT fixed

The finding is real and reproduces exactly. `registrar/lookup`'s docstring says it uses paired `get` calls rather than `get-in` because "`get-in` allocates a path vector per call" — and its generation-routed branch, which is the ordinary path since `make-frame` seals a generation on every frame, then allocates exactly such a vector, because the resolver is keyed by a `[kind id]` pair.

The remedy is to re-key the resolver `{kind {id descriptor}}`. That is **out of fence**: `:rf.gen/resolver`'s `{[kind id] descriptor}` shape is normative — `spec/API.md` pins it as one of `frame-generation`'s "four documented stable public keys" and `spec/Conventions.md` fixes the `:rf.gen/*` member set as additive-by-Spec-change — and it is read as plain data by `tools/xray` (which compares `[kind id]` KEYSETS across frames), the Pair MCP runtime, `tools/story`, and ~50 core test assertions. Adding a fifth `:rf.gen/*` key is equally a spec change.

So what lands is the honest paragraph: the docstring now says which branch the paired-`get` claim covers, what the other costs, and what removing it would take. **~98 B/call, 5% of `subscribe`, left on the table on purpose.** The bead stays open with the blast radius recorded.

## Measured

**Runtime: JVM**, `-Dre-frame.debug=false`, `ThreadMXBean/getThreadAllocatedBytes` (exact TLAB accounting), n=300 subscriptions, the committed `implementation/core/test/re_frame/bench/read_attribution.clj` harness, `RM_SUITE=subs`. **5 rounds per arm — 3 forward, 2 with `RM_ORDER=rev`.** Before/after are two worktrees off the same base commit; no arm was reformulated between them.

| | before (JVM) | after (JVM) |
|---|---:|---:|
| `subscribe`, whole (`RGSUB`) | 1,612.0 B/call<br>[1,460.0 – 1,668.0] | **1,308.0 B/call**<br>[1,220.0 – 1,364.0] |

**Ranges disjoint** — the largest "after" round (1,364.0) sits below the smallest "before" round (1,460.0), and that holds across both arm orders.

### The paired controls — the saving as a falsifiable prediction

Both retired spellings are kept **live in the harness beside the shipped ones**, in the same process, against the same live frame (the `RC-ATTACH`/`RC-CAND` discipline from #7156). They are inlined expressions, not calls into the source, so neither arm can drift under the other.

| | retired (JVM) | shipped (JVM) | difference |
|---|---:|---:|---:|
| rf2-8gb3t: `(cwfr (frame-resolution-target X) …)` vs `(cwfr X …)` | `N-CWFRWRAP` 920.0 – 976.0 | `N-CWFRRAW` 720.0 – 776.0 | **200.0 B/call, all 5 rounds** |
| rf2-a8bw0: eager payload vs deferred | `S1-EAGER` 72.0 – 136.0 | `S1-CURFRM` **32.0 flat** | 40.0 – 104.0 B/call |

**The rf2-8gb3t prediction lands exactly.** The wrapper measured independently (`N-RESTGT`) is 200.0 B/call [200.0 – 200.0]. `N-CWFRWRAP − N-CWFRRAW` is **200.0 B/call in every one of the 5 rounds, in both arm orders** — predicted 200.0, measured 200.0, **0.0%**.

**The rf2-a8bw0 arm is bimodal, and that is reported rather than averaged away.** `S1-EAGER` reads 136.0 in all three forward rounds and 72.0 in both reversed rounds. The decomposition explains it: 32 B is the JVM's thread-bound `*current-frame*` deref (`Var.getThreadBinding` allocates a `MapEntry` per read), 40 B is `(first query-v)` seqing the vector, and 64 B is the two-entry payload map — which **escape analysis scalar-replaces** when the arm runs earlier in the plan and `require-current-frame!` inlines into it. The shipped arm is **32.0 B in all ten measurements, both orders**, because on the happy path neither the map nor `(first query-v)` is evaluated at all. So the saving is 40 – 104 B/call and is real in every round; quoting a single number for it would be dishonest.

### Controls

Built from a type whose size is computable from the JVM object model — a `long-array` of n is a 16-byte header plus 8 bytes an element, 8-aligned — two of them a decade apart, so a constant error and a scale error look different.

| control | predicted | measured (net) | error |
|---|---:|---:|---:|
| `CTRL-S` (300 × `long-array` 100) | 244,800 B | 244,800 B | **+0.000%** |
| `CTRL-L` (300 × `long-array` 1000) | 2,404,800 B | 2,404,800 B | **+0.000%** |

Both landed at +0.000% in **all ten rounds**, before and after, forward and reversed.

### The noise floor, named

`N-BINDONLY` [752.0 – 808.0] and `N-CWFRNOG` [16.0 – 40.0] are **unchanged code** and wobble identically in both trees. That ±56 B on the dynamic-binding term is the common-mode noise inside `S3-CWFR`, `S4-PRELOOK` and `RGSUB`; it is why those carry ranges rather than a figure.

### rf2-ezwnl, measured and left

`N-LOOKGEN` 138.3 – 138.5 B/call against `N-LOOKATOM` 40.0 B/call, unchanged by this PR. The 40 B on **both** arms is the arm's own `(first query-v)`, so the registrar-atom branch is ~0 B and the generation-routed branch ~98 B.

### What does not transfer

**Absolutes here are the JVM's.** The largest term in `subscribe` on this runtime — the ~760 B dynamic `binding` — **does not exist in ClojureScript**, and neither does the 32 B thread-binding `MapEntry` that both rf2-a8bw0 arms pay. Node and Chrome differ ~2× again on pointer compression. Shares and ratios transfer; byte counts do not, which is why every figure above carries its runtime. What *is* a source fact, and does transfer, is the shape: a map built and discarded per call, and a key vector built per lookup.

## The clarity trade

- **rf2-8gb3t is a clarity gain**: a function is deleted, seven call sites get shorter, and the seam's documented input (`call-with-frame-resolution` already accepts a value, an id, or nil) is now what callers actually pass.
- **rf2-a8bw0 is a small, contained clarity cost**: the `or` reads as a redundant double-resolve unless you know why, so a comment says why, names the one call site it applies to, and says not to collapse it back. Paid at one call site for 8% of `subscribe`.
- **rf2-ezwnl would have been a clarity cost** — a second index, a hidden metadata cache, or a spec-visible reshape — so it is not taken here.

## Scope note

`implementation/ui/src/re_frame/ui/reactive.cljc` is touched for **one line** — the seventh `frame-resolution-target` call site, which had to move with the function. No other file outside `implementation/core/` is modified.

## Quality gates

- `implementation/core` JVM `clojure -M:test` — **exit 0**, 2,152 tests / 10,616 assertions, 0 failures 0 errors
- `npm run test:cljs` — **exit 0**, 11,799 tests / 58,740 assertions, 0 failures 0 errors
- `re-frame.subscribe-opts-arity-cljs-test` (the new payload pin), JVM — **exit 0**, 6 tests / 15 assertions
- Before/after allocation runs, 5 rounds each tree, both arm orders — **exit 0**, controls +0.000% throughout
- **`^:stress` concurrency lane: not run, and not applicable.** No change here touches an atom, a CAS, a `swap-vals!` or any shared mutable state — `frame-resolution-target` and the `subscribe` payload are both pure per-call reads, and the ref-count attach is untouched.
- Everything else deferred to CI.
