### PR TITLE
perf(core): the production write path's two remaining named costs (rf2-zxv06, rf2-78ejq)

### DIFF
--- a/implementation/core/src/re_frame/frame.cljc
+++ b/implementation/core/src/re_frame/frame.cljc
@@ -1309,11 +1309,20 @@
 (defonce ^:private frame-commit-epochs
   (atom {}))
 
+(def ^:private inc-commit-epoch
+  "`(fnil inc 0)`, hoisted. `fnil` is a CALL that builds a fresh closure —
+  and, being multi-arity + variadic, an expensive one — so spelling it at
+  the `swap!` site below built a new one on every commit to express a
+  constant. Measured at 745 B per write on node V8 (rf2-78ejq), 21% of what
+  a zero-subscription write costs. The value is the same function either
+  way; only the number of times it is constructed changes."
+  (fnil inc 0))
+
 (defn- bump-commit-epoch!
   "Advance frame `id`'s commit epoch by one. Called at BOTH physical
   frame-state write chokepoints, after the container install. INTERNAL."
   [id]
-  (swap! frame-commit-epochs update id (fnil inc 0))
+  (swap! frame-commit-epochs update id inc-commit-epoch)
   nil)
 
 (defn frame-commit-epoch

--- a/implementation/core/src/re_frame/subs/memo.cljc
+++ b/implementation/core/src/re_frame/subs/memo.cljc
@@ -221,13 +221,25 @@
   `last-result` cell, `::unset` on first recompute) and `prev-in-vals`
   (the wrapper's last-seen input value(s), `::unset` on first recompute,
   else a coll parallel to `input-signals`)."
-  [body-fn in-vals query-id query-v frame-id input-signals sub-meta
+  [body-fn in-vals query-id query-v frame-id input-signals sub-meta sub-scope
    prev-value prev-in-vals vector-inputs?]
   ;; Publish the sub's HandlerScope for the duration of body-fn
   ;; invocation + validation + the `:rf.sub/run` emit. Per Spec 009
   ;; §:rf.trace/trigger-handler the sub's source-coord rides every emit
   ;; (`:rf.sub/run` success, `:rf.error/sub-exception` / schema-validation /
   ;; transitive sub-miss errors). The emit MUST sit inside the scope.
+  ;;
+  ;; `sub-scope` arrives PRE-BUILT from the memo wrapper's closure rather
+  ;; than being derived here (rf2-zxv06). It is a pure function of
+  ;; `(:sub query-id sub-meta)`, all three fixed for the life of the cache
+  ;; entry, so deriving it per recompute rebuilt an identical record — plus
+  ;; its `:trigger-handler` source-coord map — on every write, in
+  ;; production, where the whole trace body around it is DCE-ed. This is
+  ;; the treatment `views.cljs` already gives a view's scope (pre-computed
+  ;; once at `reg-view`); the sub path was the outlier. The scope is still
+  ;; bound on every recompute and every slot still reads the same, so the
+  ;; always-on readers — the EP-0027 `make-frame`-in-handler guard and the
+  ;; `:dispatch-id` correlation reads — are untouched.
   ;;
   ;; `vector-inputs?`: when true, the body ALWAYS receives the
   ;; resolved inputs as a VECTOR (in producer order) — the contract for a
@@ -237,7 +249,7 @@
   ;; convention holds: a single `:<-` input is delivered as the bare value,
   ;; ≥2 inputs as a vector. The layer-1 / single-`:<-` wrappers pass false.
   (trace/with-handler-scope
-    (trace/handler-scope-from-meta :sub query-id sub-meta)
+    sub-scope
     (try
       ;; Wall-clock the sub body (dev-only) so `:rf.sub/run`
       ;; carries `:rf.sub/elapsed-ms` — the per-op duration the Trace
@@ -464,11 +476,14 @@
   `input-paths-unchanged` is the inputs-stable set (`[]` for layer-1, the
   realized `:<-` query-vectors for layer-n). Outer `interop/debug-enabled?`
   gate elides the tag-map construction + emit in CLJS production (Closure DCE
-  under `:advanced` + `goog.DEBUG=false`)."
-  [query-id query-v frame-id sub-meta input-paths-unchanged]
+  under `:advanced` + `goog.DEBUG=false`).
+
+  `sub-scope` is the wrapper's pre-built HandlerScope — the same constant
+  the recompute path binds (rf2-zxv06)."
+  [query-id query-v frame-id sub-scope input-paths-unchanged]
   (when interop/debug-enabled?
     (trace/with-handler-scope
-      (trace/handler-scope-from-meta :sub query-id sub-meta)
+      sub-scope
       (trace/emit! :rf.sub :rf.sub/skip
                    {:frame                        frame-id
                     :rf.sub/id                    query-id
@@ -492,7 +507,8 @@
   recomputes (the sentinel is never `=` to any db value)."
   [body-fn query-id query-v frame-id sub-meta]
   (let [last-db     (volatile! ::unset)
-        last-result (volatile! nil)]
+        last-result (volatile! nil)
+        sub-scope   (trace/handler-scope-from-meta :sub query-id sub-meta)]
     (fn [db]
       (when body-fn
         (if (= @last-db db)
@@ -502,7 +518,7 @@
           ;; reactive cascade DAG. Layer-1 has no upstream
           ;; sub inputs, so `:input-paths-unchanged` is `[]`.
           (do
-            (emit-sub-skip! query-id query-v frame-id sub-meta [])
+            (emit-sub-skip! query-id query-v frame-id sub-scope [])
             @last-result)
           ;; Capture the prior cells BEFORE the recompute so the
           ;; `:rf.sub/run` attribution can report value-change
@@ -523,7 +539,8 @@
           (let [prev-result (if (= ::unset @last-db) unset @last-result)
                 computed    (validate-and-trace
                               body-fn (list db) query-id query-v
-                              frame-id [] sub-meta prev-result unset false)]
+                              frame-id [] sub-meta sub-scope
+                              prev-result unset false)]
             (vreset! last-db db)
             (vreset! last-result computed)
             computed))))))
@@ -549,7 +566,8 @@
   inside the validate/trace bracket."
   [body-fn query-id query-v frame-id input-signals sub-meta]
   (let [last-v0     (volatile! ::unset)
-        last-result (volatile! nil)]
+        last-result (volatile! nil)
+        sub-scope   (trace/handler-scope-from-meta :sub query-id sub-meta)]
     (fn [v0]
       (when body-fn
         (if (= @last-v0 v0)
@@ -559,7 +577,7 @@
           ;; stable; layer-2+ subs name their inputs by `[query-id args]`
           ;; rather than db-paths.
           (do
-            (emit-sub-skip! query-id query-v frame-id sub-meta (vec input-signals))
+            (emit-sub-skip! query-id query-v frame-id sub-scope (vec input-signals))
             @last-result)
           ;; Capture prior cells BEFORE the recompute for the `:rf.sub/run`
           ;; attribution. `prev-in-vals` is the last-seen
@@ -580,7 +598,7 @@
                                (list prev-v0))
                 computed     (validate-and-trace
                                body-fn (list v0) query-id query-v
-                               frame-id input-signals sub-meta
+                               frame-id input-signals sub-meta sub-scope
                                prev-result prev-in-vals false)]
             (vreset! last-v0 v0)
             (vreset! last-result computed)
@@ -611,7 +629,8 @@
      body-fn query-id query-v frame-id input-signals sub-meta false))
   ([body-fn query-id query-v frame-id input-signals sub-meta vector-inputs?]
   (let [last-in-vals (volatile! ::unset)
-        last-result  (volatile! nil)]
+        last-result  (volatile! nil)
+        sub-scope    (trace/handler-scope-from-meta :sub query-id sub-meta)]
     (fn [& in-vals]
       (when body-fn
         (if (= @last-in-vals in-vals)
@@ -621,7 +640,7 @@
           ;; stable (the varargs path has ≥2 inputs and the memo
           ;; compare is whole-seq `=`, so every input was stable).
           (do
-            (emit-sub-skip! query-id query-v frame-id sub-meta (vec input-signals))
+            (emit-sub-skip! query-id query-v frame-id sub-scope (vec input-signals))
             @last-result)
           ;; Capture prior cells BEFORE the recompute for the `:rf.sub/run`
           ;; attribution. `prev-in-vals` is the last-seen
@@ -638,7 +657,7 @@
                 prev-in-vals @last-in-vals
                 computed     (validate-and-trace
                                body-fn in-vals query-id query-v
-                               frame-id input-signals sub-meta
+                               frame-id input-signals sub-meta sub-scope
                                prev-result prev-in-vals vector-inputs?)]
             (vreset! last-in-vals in-vals)
             (vreset! last-result computed)

--- a/implementation/core/src/re_frame/trace.cljc
+++ b/implementation/core/src/re_frame/trace.cljc
@@ -262,13 +262,28 @@
 (defn inherit-scope
   "Merge `parent`'s `:call-site` and `:dispatch-id` into `new-scope`
   where `new-scope`'s value is nil. Meta-derived slots are preserved
-  as-is (innermost-wins). Per Spec 009 §Handler-scope §Composition."
+  as-is (innermost-wins). Per Spec 009 §Handler-scope §Composition.
+
+  Each arm asks TWO questions — is mine empty, AND does the parent
+  actually have one to give? The second is what stops a nil being
+  assoc-ed over a nil: that writes no information but still copies the
+  whole record, and in a production build BOTH parent slots are always
+  nil (the router mints `:dispatch-id` and reads the macro-stamped
+  `:call-site` only under `interop/debug-enabled?`). So the one-question
+  form copied the record twice on entry to every handler — every event,
+  every fx, every cofx, every view render, every subscription recompute
+  — to change nothing. A record's declared fields exist whether or not
+  they are assoc-ed, so the two spellings are indistinguishable to
+  every reader of a scope (rf2-zxv06)."
   [new-scope parent]
   (if (nil? parent)
     new-scope
     (cond-> new-scope
-      (nil? (:call-site new-scope))   (assoc :call-site   (:call-site parent))
-      (nil? (:dispatch-id new-scope)) (assoc :dispatch-id (:dispatch-id parent)))))
+      (and (nil? (:call-site new-scope))   (some? (:call-site parent)))
+      (assoc :call-site   (:call-site parent))
+
+      (and (nil? (:dispatch-id new-scope)) (some? (:dispatch-id parent)))
+      (assoc :dispatch-id (:dispatch-id parent)))))
 
 #?(:clj
    (defmacro with-handler-scope

--- a/implementation/core/test/re_frame/bench/write_attribution.cljs
+++ b/implementation/core/test/re_frame/bench/write_attribution.cljs
@@ -288,6 +288,119 @@
     (frame/replace-app-db! f (update (frame/frame-app-db-value f) :cells assoc i v))
     nil))
 
+;; ---- rf2-78ejq: the rungs UNDER RFWRITE-0 ---------------------------------
+;;
+;; `RFWRITE-0` — a write to a frame with ZERO subscriptions — was measured by
+;; rf2-jr76s as ONE number. It is a CONSTANT, so at 300 subs it is 1.6% of the
+;; write and invisible; at the 10 subs a small app or a per-frame tool panel
+;; actually has, it is a THIRD of it. These arms split it.
+;;
+;; Each component is measured on its own, through public fns where the surface
+;; is public and by re-spelling the private expression inline where it is not —
+;; the `Q-SCHED` discipline, which keeps the measured expression pinned in the
+;; harness so it cannot drift under the thing it is attributed to. The sum is
+;; checked against the `RFWRITE-0 − SPINE0` delta and the residual is printed,
+;; so an attribution that does not add up says so.
+;;
+;;   C-FRAME    `(frame/frame id)` — the registry lookup `commit-frame-
+;;              transition!` does before anything else
+;;   C-PARTS    `commit-frame-record-transition!`'s partition bookkeeping:
+;;              the two `contains?`, the four `get`, the `next-fs` map, the
+;;              `changed` cond-> set, the two `not=` partition comparisons and
+;;              the two `identical?` no-op checks. NO container write, NO
+;;              new-db construction — those are their own rungs.
+;;   C-TAGPAIR  the two `[::ok v]` tagged pairs `call-exact-frame-callback`
+;;              allocates per commit (one for `read-container`, one for
+;;              `replace-container!`)
+;;   C-BUMP     `bump-commit-epoch!` in its RETIRED spelling — `(fnil inc 0)`
+;;              built fresh on every write
+;;   C-BUMPH    the same in the SHIPPED spelling, the wrapper hoisted to a
+;;              namespace constant. PAIRED CONTROL.
+;;   SPINE0B    `replace-container!` of a PRE-BUILT frame-state map onto a
+;;              container with NO derived values — the write with nothing
+;;              layered over it
+;;   SPINE0P    the same write onto a container carrying the TWO partition
+;;              projections (`:rf.db/app` / `:rf.db/runtime`) a real frame
+;;              wires. `SPINE0P − SPINE0B` is therefore the cost of the two
+;;              projections recomputing and draining, and that term is the
+;;              one Spec 002 §One physical container, two projection reactions
+;;              makes non-negotiable.
+
+(defonce ^:private bump-epochs (atom {}))
+
+(def ^:private hoisted-fnil-inc
+  "The SHIPPED spelling's hoisted wrapper. `(fnil inc 0)` is a function CALL
+  that returns a fresh closure, so writing it at the `swap!` site allocates
+  one per write."
+  (fnil inc 0))
+
+(defn- arm-c-frame []
+  (keep! (frame/frame fid))
+  nil)
+
+(defn- arm-c-parts []
+  (let [{:keys [fs-a fs-b db-a db-b]} @rig
+        e?         (even? @gen)
+        ;; Alternate so the two `not=` comparisons do the work a real commit
+        ;; makes them do — a genuinely different app-db value, one cell apart,
+        ;; which `=` walks element-wise exactly as it does on the real path.
+        current    (if e? fs-a fs-b)
+        partitions (if e? {frame/app-partition-key db-b}
+                          {frame/app-partition-key db-a})
+        app-given? (contains? partitions frame/app-partition-key)
+        rt-given?  (contains? partitions frame/runtime-partition-key)
+        next-app   (if app-given? (get partitions frame/app-partition-key)
+                       (get current frame/app-partition-key))
+        next-rt    (if rt-given? (get partitions frame/runtime-partition-key)
+                       (get current frame/runtime-partition-key))
+        next-fs    {frame/app-partition-key     next-app
+                    frame/runtime-partition-key next-rt}
+        changed    (cond-> #{}
+                     (and app-given?
+                          (not= next-app (get current frame/app-partition-key)))
+                     (conj frame/app-partition-key)
+                     (and rt-given?
+                          (not= next-rt (get current frame/runtime-partition-key)))
+                     (conj frame/runtime-partition-key))]
+    (keep! (and (identical? next-app (get current frame/app-partition-key))
+                (identical? next-rt  (get current frame/runtime-partition-key))))
+    (next-gen!)
+    ;; Sink the two results SEPARATELY. Wrapping them in a `[next-fs changed]`
+    ;; pair to sink them in one go allocates a vector this arm is not
+    ;; measuring, and charges it to the bookkeeping — the control error that
+    ;; standing method says to suspect first.
+    (vreset! sink2 next-fs)
+    (keep! changed)
+    nil))
+
+(defn- arm-c-tagpair []
+  (let [{:keys [db-a]} @rig]
+    ;; TWO pairs, sunk separately — one per host-adapter callback. An
+    ;; enclosing `[pair pair]` vector would make this arm read three.
+    (vreset! sink2 [::ok db-a])
+    (vreset! sink2 [::ok nil])
+    nil))
+
+(defn- arm-c-bump []
+  (swap! bump-epochs update fid (fnil inc 0))
+  nil)
+
+(defn- arm-c-bump-h []
+  (swap! bump-epochs update fid hoisted-fnil-inc)
+  nil)
+
+(defn- arm-spine0b []
+  (let [{:keys [fs-a fs-b bare-fs-container]} @rig]
+    (adapter/replace-container! bare-fs-container (if (even? @gen) fs-a fs-b))
+    (next-gen!)
+    nil))
+
+(defn- arm-spine0p []
+  (let [{:keys [fs-a fs-b proj-fs-container]} @rig]
+    (adapter/replace-container! proj-fs-container (if (even? @gen) fs-a fs-b))
+    (next-gen!)
+    nil))
+
 ;; ---- the per-subscription pieces ------------------------------------------
 
 (defn- arm-p-body []
@@ -306,6 +419,66 @@
       (trace/with-handler-scope
         (trace/handler-scope-from-meta :sub (nth qids k) nil)
         (keep! true)))))
+
+;; rf2-zxv06 — the handler-scope bracket, in BOTH spellings, one process, the
+;; same sub-ids. `P-SCOPE` above is kept EXACTLY as rf2-jr76s left it (nil
+;; meta) so its 120.8 B figure stays comparable, but nil meta is not the
+;; production shape: a macro-registered sub carries `:ns` / `:file` / `:line`
+;; (`:column` is dev-only and absent under `:advanced` + goog.DEBUG=false), and
+;; those are what make `trigger-handler-from-meta` build a coord map AND a
+;; three-key trigger map on top of the record. So:
+;;
+;;   P-SCOPEM  the RETIRED spelling with REALISTIC registration meta — build
+;;             the scope per recompute, the way `validate-and-trace` did
+;;   P-SCOPEH  the SHIPPED spelling — the scope built ONCE per cache entry and
+;;             closed over, so the per-recompute cost is the `binding` and
+;;             `inherit-scope` alone (rf2-zxv06)
+;;
+;; and, because `inherit-scope`'s copies only happen when a PARENT scope is
+;; bound — which is the real shape, since an app's write runs inside the
+;; router's event scope, but is NOT the shape of the RFWRITE ladder below,
+;; where nothing binds a parent:
+;;
+;;   P-INHER   the RETIRED `inherit-scope` under a bound parent whose
+;;             `:call-site` / `:dispatch-id` are both nil, as they always are
+;;             in a production build
+;;   P-INHERH  the SHIPPED one under the same parent
+;;
+;; P-INHER − P-INHERH is therefore a saving the ladder here CANNOT show and a
+;; real application does get. It is quoted separately rather than folded in.
+
+(def ^:private prod-sub-meta
+  "What `reg-sub`'s macro path leaves in the registrar slot for a PRODUCTION
+  build: `:ns` / `:file` / `:line` are the locked coord keys; `:column` is
+  dev-only (`source-coords/prod-coords-form`) so it is absent here."
+  {:ns 'wa.bench :file "wa/bench.cljs" :line 42})
+
+(defn- arm-p-scope-m []
+  (let [{:keys [n qids]} @rig]
+    (dotimes [k n]
+      (trace/with-handler-scope
+        (trace/handler-scope-from-meta :sub (nth qids k) prod-sub-meta)
+        (keep! true)))))
+
+(defn- arm-p-scope-h []
+  (let [{:keys [n sub-scopes]} @rig]
+    (dotimes [k n]
+      (trace/with-handler-scope (nth sub-scopes k) (keep! true)))))
+
+(defn- arm-p-inher []
+  (let [{:keys [n sub-scopes parent-scope]} @rig]
+    (dotimes [k n]
+      (let [s (nth sub-scopes k)]
+        ;; the RETIRED expression, pinned here so it cannot drift under the
+        ;; shipped one: assoc unconditionally wherever the child's slot is nil
+        (keep! (cond-> s
+                 (nil? (:call-site s))   (assoc :call-site   (:call-site parent-scope))
+                 (nil? (:dispatch-id s)) (assoc :dispatch-id (:dispatch-id parent-scope))))))))
+
+(defn- arm-p-inher-h []
+  (let [{:keys [n sub-scopes parent-scope]} @rig]
+    (dotimes [k n]
+      (keep! (trace/inherit-scope (nth sub-scopes k) parent-scope)))))
 
 (defn- arm-p-emit []
   (let [{:keys [n qids qvs]} @rig]
@@ -445,7 +618,20 @@
                                (subvec qvs 0 cnt))))
                      frames ns-per-frame)
         db-a  (db-of cells-n 7)
-        db-b  (update (db-of cells-n 7) :cells assoc (dec cells-n) 8)]
+        db-b  (update (db-of cells-n 7) :cells assoc (dec cells-n) 8)
+        ;; rf2-78ejq — the two frame-state values a commit alternates between,
+        ;; PRE-BUILT so the SPINE0B / SPINE0P arms measure the container write
+        ;; and the projections alone, with no value construction folded in.
+        fs-a  {frame/app-partition-key db-a frame/runtime-partition-key {}}
+        fs-b  {frame/app-partition-key db-b frame/runtime-partition-key {}}
+        ;; A container with NOTHING layered over it, and the same container
+        ;; shape carrying the TWO partition projections a real frame wires
+        ;; (`frame.cljc`'s `(make-derived-value [frame-state] :rf.db/app)` and
+        ;; its `:rf.db/runtime` sibling). The pair isolates the projections.
+        bare-fs-container (adapter/make-state-container fs-a)
+        proj-fs-container (adapter/make-state-container fs-a)
+        _proj (mapv (fn [k] (adapter/make-derived-value [proj-fs-container] k))
+                    [frame/app-partition-key frame/runtime-partition-key])]
     (vreset! rig
              {:n        n
               :cells-n  cells-n
@@ -458,6 +644,20 @@
               :spine-container (adapter/make-state-container (db-of cells-n 0))
               :db-a     db-a
               :db-b     db-b
+              :fs-a     fs-a
+              :fs-b     fs-b
+              :bare-fs-container bare-fs-container
+              :proj-fs-container proj-fs-container
+              :projections       _proj
+              ;; rf2-zxv06 — one PRE-BUILT scope per sub, the shipped shape
+              ;; (`subs.memo`'s wrappers now close over exactly this), plus a
+              ;; parent whose inheritable slots are both nil, which is what a
+              ;; production build always presents to `inherit-scope`.
+              :sub-scopes   (mapv #(trace/handler-scope-from-meta
+                                     :sub % prod-sub-meta)
+                                  qids)
+              :parent-scope (trace/handler-scope-from-meta
+                              :event :wa/parent prod-sub-meta)
               ;; the shipped memo wrapper, one per subscription
               :memos    (mapv (fn [i]
                                 (subs-memo/make-layer-1-memoised-body
@@ -518,7 +718,15 @@
                                     (map (fn [d] [(ctl-key "SMI" d) (arm-ctl "SMI" d) 1]) ctl-smi-ds)))
                        [["MKDB"      arm-mkdb             1]
                         ["BAREATOM"  arm-bareatom         1]
-                        ["SPINE0"    arm-spine0           1]])
+                        ["SPINE0"    arm-spine0           1]
+                        ;; rf2-78ejq — the rungs under RFWRITE-0
+                        ["SPINE0B"   arm-spine0b          1]
+                        ["SPINE0P"   arm-spine0p          1]
+                        ["C-FRAME"   arm-c-frame          1]
+                        ["C-PARTS"   arm-c-parts          1]
+                        ["C-TAGPAIR" arm-c-tagpair        1]
+                        ["C-BUMP"    arm-c-bump           1]
+                        ["C-BUMPH"   arm-c-bump-h         1]])
                  true (into (map-indexed
                               (fn [k cnt]
                                 [(str "RFWRITE-" cnt) (fn [] (arm-rfwrite k)) 1])
@@ -526,6 +734,11 @@
                  true (into [["P-BODY"  arm-p-body  n]
                              ["P-EQDB"  arm-p-eqdb  n]
                              ["P-SCOPE" arm-p-scope n]
+                             ;; rf2-zxv06 paired controls
+                             ["P-SCOPEM"  arm-p-scope-m n]
+                             ["P-SCOPEH"  arm-p-scope-h n]
+                             ["P-INHER"   arm-p-inher   n]
+                             ["P-INHERH"  arm-p-inher-h n]
                              ["P-EMIT"  arm-p-emit  n]
                              ["P-MEMO"  arm-p-memo  n]
                              ["Q-SCHED" arm-q-sched n]
@@ -580,11 +793,53 @@
         (println (gstring/format ";;   PER-SUBSCRIPTION SLOPE  %s B / sub / write" (fmt slope)))
         (println ";;")
         (println ";; WHERE THE PER-SUBSCRIPTION BYTES GO (each arm × n, reported per sub)")
-        (doseq [l ["P-BODY" "P-EQDB" "P-SCOPE" "P-EMIT" "P-MEMO" "Q-SCHED" "Q-SCHEDJS" "P-VALS" "P-RKV"]]
+        (doseq [l ["P-BODY" "P-EQDB" "P-SCOPE" "P-SCOPEM" "P-SCOPEH" "P-INHER" "P-INHERH"
+                   "P-EMIT" "P-MEMO" "Q-SCHED" "Q-SCHEDJS" "P-VALS" "P-RKV"]]
           (let [v (/ (b l) n)]
             (println (gstring/format ";;   %-10s %10s B/sub   %5.1f%% of the slope"
                              l (fmt v) (* 100.0 (/ v slope))))))
         (println (gstring/format ";;   %-10s %10s B/sub"
                          "RESIDUAL" (fmt (- slope (/ (b "P-MEMO") n)
-                                            (/ (b "Q-SCHEDJS") n) (/ (b "P-RKV") n)))))))
+                                            (/ (b "Q-SCHEDJS") n) (/ (b "P-RKV") n)))))
+        (println ";;")
+        (println ";; rf2-zxv06 — THE HANDLER-SCOPE BRACKET, PAIRED")
+        (println (gstring/format
+                   ";;   P-SCOPEM (retired, prod meta)   %10s B/sub" (fmt (/ (b "P-SCOPEM") n))))
+        (println (gstring/format
+                   ";;   P-SCOPEH (shipped, hoisted)     %10s B/sub" (fmt (/ (b "P-SCOPEH") n))))
+        (println (gstring/format
+                   ";;   -> hoist predicts               %10s B/sub saved"
+                   (fmt (/ (- (b "P-SCOPEM") (b "P-SCOPEH")) n))))
+        (println (gstring/format
+                   ";;   P-INHER  (retired inherit)      %10s B/sub" (fmt (/ (b "P-INHER") n))))
+        (println (gstring/format
+                   ";;   P-INHERH (shipped inherit)      %10s B/sub" (fmt (/ (b "P-INHERH") n))))
+        (println (gstring/format
+                   ";;   -> inherit predicts             %10s B/sub saved  (ONLY under a bound parent — a real app's write; NOT visible in the ladder above)"
+                   (fmt (/ (- (b "P-INHER") (b "P-INHERH")) n)))))
+      (println ";;")
+      (println ";; rf2-78ejq — WHERE RFWRITE-0's CONSTANT GOES")
+      (let [rf0    (b "RFWRITE-0")
+            sp0    (b "SPINE0")
+            delta  (- rf0 sp0)
+            proj   (- (b "SPINE0P") (b "SPINE0B"))
+            comps  [["C-FRAME    (frame id) registry lookup" (b "C-FRAME")]
+                    ["C-PARTS    partition bookkeeping"      (b "C-PARTS")]
+                    ["C-TAGPAIR  two [::ok v] pairs"         (b "C-TAGPAIR")]
+                    ["C-PROJ     the two projections"        proj]
+                    ["C-BUMP     bump-commit-epoch!"         (b "C-BUMP")]]
+            summed (reduce + (map second comps))]
+        (println (gstring/format ";;   RFWRITE-0 %s B  −  SPINE0 %s B  =  %s B to attribute"
+                         (fmt rf0) (fmt sp0) (fmt delta)))
+        (doseq [[lbl v] comps]
+          (println (gstring/format ";;     %-42s %10s B   %5.1f%% of the delta"
+                           lbl (fmt v) (* 100.0 (/ v delta)))))
+        (println (gstring/format ";;     %-42s %10s B   %5.1f%%"
+                         "RESIDUAL" (fmt (- delta summed))
+                         (* 100.0 (/ (- delta summed) delta))))
+        (println (gstring/format ";;   SPINE0B (bare container write) %s B ; SPINE0P (+2 projections) %s B"
+                         (fmt (b "SPINE0B")) (fmt (b "SPINE0P"))))
+        (println (gstring/format ";;   C-BUMP %s B vs C-BUMPH %s B  -> hoisting (fnil inc 0) predicts %s B/write"
+                         (fmt (b "C-BUMP")) (fmt (b "C-BUMPH"))
+                         (fmt (- (b "C-BUMP") (b "C-BUMPH")))))))
     (println (gstring/format ";; sink %s %s" @sink (some? @sink2)))))

--- a/implementation/core/test/re_frame/bench/write_attribution.cljs
+++ b/implementation/core/test/re_frame/bench/write_attribution.cljs
@@ -583,13 +583,28 @@
 ;; ---------------------------------------------------------------------------
 ;; rig construction
 
-(defn- build-rig! [n cells-n ns-per-frame]
+(defn- build-rig! [n cells-n ns-per-frame coords?]
   ;; One sub-id per cell, exactly B6's `:b6/cell` shape but registered per
   ;; index so every subscription is a distinct cache entry with a distinct
   ;; body closure — the shape a real application's 300 boundaries have.
+  ;;
+  ;; `coords?` (WA_COORDS=1) decides whether those registrations carry SOURCE
+  ;; COORDS, and it is not a detail (rf2-zxv06). This ns requires
+  ;; `re-frame.core` WITHOUT `:include-macros true`, so `rf/reg-sub` here is
+  ;; the plain FUNCTION and no call site is captured — the registrar slot
+  ;; comes out `{}`. A real application writes `(rf/reg-sub …)` in a namespace
+  ;; that does get the macro, so its slots carry `:ns` / `:file` / `:line`
+  ;; (`:column` is dev-only and absent under `:advanced` + goog.DEBUG=false).
+  ;; That is the difference between `P-SCOPE` and `P-SCOPEM` — a factor of six
+  ;; — so the ladder can be run either way and the header prints which it is.
+  ;; The DEFAULT stays coord-less, which is what rf2-jr76s measured, so the
+  ;; recorded slope remains comparable.
   (doseq [i (range cells-n)]
-    (rf/reg-sub (keyword "wa" (str "cell" i))
-                (fn [db _] (get-in db [:cells i]))))
+    (let [body (fn [db _] (get-in db [:cells i]))
+          qid  (keyword "wa" (str "cell" i))]
+      (if coords?
+        (rf/reg-sub qid prod-sub-meta body)
+        (rf/reg-sub qid body))))
   (let [qids  (mapv #(keyword "wa" (str "cell" %)) (range cells-n))
         qvs   (mapv vector qids)
         ;; One frame per subscription count, each with its OWN held
@@ -678,6 +693,7 @@
         samples  (env-int "WA_SAMPLES" 40)
         warmup   (env-int "WA_WARMUP" 3)
         rev?     (= "rev" (env "WA_ORDER" ""))
+        coords?  (= "1" (env "WA_COORDS" ""))
         ns-per-frame [0 (js/Math.round (/ n 4)) (js/Math.round (/ n 2)) n]]
     (rf/init! (spine/make-react-adapter
                 (spine/make-react-spine
@@ -692,7 +708,7 @@
     (vreset! ctl-templates
              (into {} (concat (map (fn [d] [(ctl-key "DBL" d) (packed-doubles d)]) ctl-double-ds)
                               (map (fn [d] [(ctl-key "SMI" d) (packed-smis d)]) ctl-smi-ds))))
-    (build-rig! n n ns-per-frame)
+    (build-rig! n n ns-per-frame coords?)
     (println (gstring/format ";; rf2-jr76s WRITE attribution — node V8, :advanced"))
     (println (gstring/format ";; debug-enabled? = %s   gc-exposed? = %s"
                      interop/debug-enabled?
@@ -700,9 +716,22 @@
     (println (gstring/format ";; node %s  V8 %s  pointer-compression=%s (Chrome ships it ON: a tagged slot is 4 B there, 8 B here)"
                      (.-node js/process.versions) (.-v8 js/process.versions)
                      (if (= 1 (gobj/getValueByKeys js/process "config" "variables" "v8_enable_pointer_compression")) "ON" "OFF")))
-    (println (gstring/format ";; n=%d samples=%d warmup=%d order=%s frames=%s"
+    (println (gstring/format ";; n=%d samples=%d warmup=%d order=%s frames=%s coords=%s"
                      n samples warmup (if rev? "REVERSED" "forward")
-                     (pr-str ns-per-frame)))
+                     (pr-str ns-per-frame) (if coords? "ON" "off")))
+    ;; PROVENANCE, not decoration (rf2-zxv06). `handler-scope-from-meta`'s cost
+    ;; is dominated by whether the registrar slot carries source coords: with
+    ;; `:ns` / `:file` / `:line` it builds a coord map AND a trigger map on top
+    ;; of the record; without them `trigger-handler-from-meta` returns nil and
+    ;; the record is all there is. So which of `P-SCOPE` (coord-less) and
+    ;; `P-SCOPEM` (coord-carrying) predicts the ladder's slope depends on a
+    ;; fact about THIS build, and guessing it would be guessing the headline.
+    (let [slot (registrar/lookup :sub (first (:qids @rig)))]
+      (println (gstring/format ";; registered sub-meta coord keys = %s  (trigger-handler %s)"
+                       (pr-str (select-keys slot [:ns :file :line :column]))
+                       (if (trace/trigger-handler-from-meta :sub :probe slot)
+                         "BUILT — P-SCOPEM is the predictive arm"
+                         "nil — P-SCOPE is the predictive arm"))))
     ;; Agreement gate: every held subscription must read what the writer
     ;; wrote, or the graph is not wired and nothing below is evidence.
     (let [f (last (:frames @rig))


### PR DESCRIPTION
Closes rf2-zxv06 and rf2-78ejq — the two named costs left on the production write path after #7156.

**Runtime label for every figure: node 24.13.0, V8 13.6.233.17, `:advanced`, `goog.DEBUG false`, pointer compression OFF.** Shares transfer; absolutes do not.

## rf2-zxv06 — every reader of the scope, and a cheaper representation

**The bead's premise is false and the conclusion survives anyway.** The bead says the scope must not be dev-gated because the always-on SSR error path reads it. It does not:

* `implementation/ssr/src/**` contains **zero** references to `handler-scope`.
* `re-frame.error-emit` never reads `*handler-scope*` either — its only `trace/` uses are `continuation-live?` (a different var) and `emit-error!` (wholly inside the debug gate).
* The failing sub's source-coord comes from `error-emit/error-source-coord` to `source-coords/error-coords-for :sub id`, an **id-keyed always-on registry**.

**But the scope still must not be dev-gated**, for two reasons the bead did not name. `frame.cljc:2855`'s EP-0027 `make-frame`-in-handler guard uses scope **presence** as the signal for "am I inside a handler", and a sub body binds one; and `frame.cljc:605`, `router.cljc:2599`, `freehand/cell.cljc:1177` read `:dispatch-id` outside the debug gate. Everything in `trace.cljc` that reads the scope (`build-event`, both `:no-emit?` short-circuits) is dev-only.

So nothing here is dev-gated. Two allocations inside the always-on bracket were artefacts:

1. **The scope was derived per recompute** from `(:sub query-id sub-meta)` — all three fixed for the life of the cache entry. Hoisted into the three memo wrappers' closures. This is the treatment `views.cljs:620` already gives a view's scope at `reg-view`; the sub path was the outlier. HMR/incarnation replacement builds a new sub-cache and therefore a new wrapper, so invalidation is free.
2. **`inherit-scope` assoc-ed the parent's `:call-site` / `:dispatch-id` whenever the child's slot was nil**, without asking whether the parent had one to give. In production both parent slots are always nil, so it copied the record twice on entry to every handler to write nil over nil.

### An instrument fault found first

The ladder registered its 300 subs through `re-frame.core`'s `reg-sub` **function** (this ns has no `:include-macros true`), so every registrar slot came out `{}` with no source coords. A real app's subs are macro-registered and carry `:ns`/`:file`/`:line`, and `trigger-handler-from-meta` then builds a coord map **and** a trigger map on top of the record — a **factor of six**. The harness now prints which shape it measures; `WA_COORDS=1` measures the realistic one. **rf2-jr76s's recorded 121 B/sub is the coord-less figure; a real application was paying ~744.**

### Before/after — per-subscription slope, node, both arm orders

| ladder | BEFORE | AFTER | drop | paired control predicts |
|---|---:|---:|---:|---:|
| coord-less (rf2-jr76s-comparable) | 938.1 / 939.9 | 815.9 / 818.3 | **121.9** | 120.0 -> **+1.6%** |
| coord-carrying (a real app) | 1724.6 / 1567.5 | 834.2 / 818.5 | 890.4 / **749.0** | 744.1 -> **+0.7% reversed** |

Ranges disjoint in both. The coord-carrying BEFORE disagrees 10% across arm orders, and that is the known rf2-88pie class — `RFWRITE-300` is the largest arm (521 KB/call pre-fix) and in forward order it is the inflated successor of `RFWRITE-150`; in reversed it follows the tiny `RFWRITE-0` and is clean, which is why the reversed reading lands on the prediction to 0.7%. The post-fix ladder, whose largest arm is half the size, agrees across orders to 1.9%.

### Paired controls (both spellings live in one process, same sub-ids)

| arm | B/sub |
|---|---:|
| `P-SCOPEM` retired, production registration meta | 744.2 |
| `P-SCOPEH` shipped, hoisted | 0.0–0.1 |
| `P-INHER` retired inherit, parent bound | 240.1–240.2 |
| `P-INHERH` shipped inherit, same parent | 0.0–0.2 |

`P-SCOPEH` at 0.0 B also confirms a CLJS `binding` allocates nothing — the JVM intuition does not transfer. The `inherit-scope` saving (240 B/sub) is **not visible in this ladder at all**, because nothing binds a parent scope here; a real app's write runs inside the router's event scope and does get it.

## rf2-78ejq — the 4,470 B itemised

`RFWRITE-0` measures 4,311.7 B, `SPINE0` 1,003.7 B, so **3,308.0 B** is what `replace-app-db!` adds on a frame with no subscriptions.

| component | B/write | share | verdict |
|---|---:|---:|---|
| `C-BUMP` `bump-commit-epoch!` | 881.1 | 26.6% | **745.0 of it ARTEFACT** |
| `C-PARTS` partition bookkeeping | 705.8 | 21.3% | intrinsic |
| `C-PROJ` the two partition projections | 670.3 | 20.3% | intrinsic |
| `C-TAGPAIR` two `[::ok v]` pairs | 232.1 | 7.0% | exact-incarnation callback discipline |
| `C-FRAME` `(frame id)` lookup | 0.0 | 0.0% | — |
| residual | 818.6 | 24.7% | named below |

**The one artefact: `bump-commit-epoch!` spelled `(fnil inc 0)` inline.** `fnil` is a *call* returning a fresh closure — multi-arity and variadic, so an expensive one — built on every commit to express a constant. Paired control `C-BUMP` 881.1 B vs `C-BUMPH` 136.0 B gives **745.0 B/write**, 22.5% of the whole constant. Hoisted to a namespace `def`.

**Everything else is the two-partition contract and is left alone.** `C-PARTS` is the two `not=` comparisons, the `next-fs` map and the `changed` set — what produces the changed-partition set the change traces and projection agreement depend on. `C-PROJ` is measured as `SPINE0P` minus `SPINE0B` (the same container write with and without the two `make-derived-value` projections) and is exactly what Spec 002 §One physical container, two projection reactions requires. The 24.7% residual is the `{:rf.db/app v}` partitions map, `frame-app-db-value`, `read-container`, and the two-entry-map write vs `SPINE0`'s bare value.

`RFWRITE-0` BEFORE **[4223.5 – 4414.7]** to AFTER **[3268.0 – 3532.6]**, disjoint. Measured drop ~878 B against a predicted 745 B; the gap is within the noise of differencing two ~4 kB p50s each carrying ±5%, so the paired control rather than the difference is the load-bearing evidence.

At the 10 subscriptions a small app or a per-frame tool panel actually has, a write goes from ~21.5 kB to ~11.6 kB.

## Controls

`DBL` small pair 8.0446 B/double (predicted 8.0000, +0.56%); large pair +9.11%, the known page-tail miss confined to the large-object regime; `SMI` carries no weight (rf2-88pie). One-sided zero checks: `P-EMIT` 0.2 B/sub, `P-RKV` 0.3 B/sub.

**Two of my own control arms were wrong and were fixed before any figure was quoted**, per "suspect the control first": `C-PARTS` and `C-TAGPAIR` each sank their result through an enclosing vector, charging themselves an allocation they were not measuring — `C-TAGPAIR` read 472.3 B for what is actually 232.1 B, i.e. three vectors, not two.

## The clarity trade, in one sentence

Two constants moved to where they are constant — a sub's scope to the memo wrapper that already closes over everything it is built from, and `(fnil inc 0)` to a `def` — plus one predicate that now asks the question it always meant (*does the parent have a call-site to give?* rather than *is mine empty?*); each carries a comment naming the cost, and `validate-and-trace` gains one parameter, which is the only place the diff spends any clarity at all.

## Quality gates

| gate | result |
|---|---|
| `implementation/core` `clojure -M:test` | **exit 0** — 2153 tests / 10621 assertions, 0 failures 0 errors |
| `npm run test:cljs` | **exit 0** — 11799 tests / 58740 assertions, 0 failures 0 errors |
| `clojure -M:slow-test` (the `^:stress` lane) | **exit 0** — the three 8-thread concurrency races, run because `bump-commit-epoch!` sits on a shared-atom `swap!` (the CAS discipline is unchanged; only the function handed to `update` moved) |
| bench build + 8 measurement runs (2 ladders x before/after x both orders) | exit 0, 0 samples dropped in every arm of every run |

Deferred to CI: the full spine, browser smoke, bundle-isolation and the perf-bundle gate.

Raw data: `ai/findings/2026-07-27.prod-write-costs*` (local-only tree).
