### PR TITLE
ABLATION (rf2-so3io): what dropping the concurrent-store contract gives back — clock, heap, and whether the cheap path is separable

### DIFF
--- a/docs/design/freehand/studio/concurrent-store-ablation.md
+++ b/docs/design/freehand/studio/concurrent-store-ablation.md
@@ -1,0 +1,545 @@
+# What does dropping the concurrent-store contract give back?
+
+Seat: ABLATION SPIKE. Bead `rf2-so3io`, operator-authorised, answering the
+one remaining measurement that could **change** the answer on `rf2-lbs3y`
+rather than refine it.
+
+Measured 2026-07-27 against `main` at `109dd53002`, on branch
+`worker/uses-ablation-so3io` at the commit that carries this page — the
+instrument ships in the same PR. Reagent **2.0.1**, UIx **1.4.4**, React
+**19.2.0**. Host: Windows 11, headless Chromium 147 via Playwright, single
+developer workstation. Every figure is an `:advanced` ClojureScript bundle
+with `goog.DEBUG false` — the artefact a consumer ships.
+
+**This is an ablation, not a proposal.** Nothing here changes the shipped
+path; `implementation/freehand/src/` is byte-identical to `origin/main`.
+The ablated boundary lives entirely in `implementation/freehand/test/…/bench/`
+as an extra arm on B6's clock window and B7's heap door.
+
+---
+
+## The answer, first
+
+**The two worst rows are not one row, and neither of them moves enough.**
+
+The hypothesis this bead was filed on was that `useSyncExternalStore` and
+the commit-side invariant-5 re-read are two faces of one contract, so
+dropping it might recover a large slice of retained heap **and** a large
+slice of clock at once. Both halves were ablated, together and separately,
+and measured on both axes in both arm orders.
+
+1. **Clock: the broad update gets ≈14% cheaper. Nothing else moves.**
+   A write that repaints 300 boundaries costs the reference boundary
+   3.1–4.1 ms and the ablated one 2.7–3.6 ms — **cheaper in 12 of 12
+   paired rounds**, by 0.3–0.7 ms, mean **13.6%–14.8%**. It takes the
+   Freehand-shaped boundary from **6.3–6.5× Reagent to 5.4–5.5×**. The
+   narrow update is a **null result** (the direction flips between arm
+   orders) and mount moves by **≤0.1 ms**, which is Chrome's clock
+   quantum.
+2. **Heap: 363–376 bytes a boundary come back, and every one of them is
+   the hook, not the commit.** Above the React floor, the sub-free
+   boundary goes from **2,416–2,431 B to 2,041–2,062 B** and the reactive
+   one from **4,281–4,294 B to 3,918 B**. Ranges disjoint in both orders,
+   the independent snapshot reader agreeing to within 1.5%. Against
+   Reagent that is **5.88–5.94× → 4.97–5.04×** on the sub-free witness
+   and **4.14–4.18× → 3.79–3.81×** on the reactive one.
+3. **The hypothesis is falsified in a specific and useful way.** An
+   isolating rung — React's six hooks over a two-field JS object, no
+   ViewCell, no CLJS data structure — gives back **355–357 B**, which is
+   **95%–97% of the whole heap return**. The commit-side re-read retains
+   **8–20 B a boundary**, i.e. nothing: it publishes the same five-key
+   observation record either way. So the heap return comes from the hook
+   half and the clock return comes from the commit half; they are two
+   levers on two axes, not one lever on both.
+4. **And the cheap path is not free even where it wins.** Without
+   `useSyncExternalStore` a boundary **cannot repaint inside
+   `react-dom/flushSync`** — measured, not reasoned: `{:ref true,
+   :nc false}` on the same probe in both runs. `useSyncExternalStore`'s
+   listener schedules at React's **sync lane**; nothing else available to
+   a function component does, and an empty `flushSync` flushes only that
+   lane. `rf2-w2m25`'s synchronous commit door is built on it.
+
+**What the guarantee buys, measured.** A source moved in the render→commit
+gap, on a **watchable browser host** — where the standing rebuttal is that
+the change watch would catch it anyway:
+
+| site | commit | revision advanced? | cell left dirty? | value published |
+|---|---|---|---|---|
+| **retained** | shipped | **yes** | no | **fresh** |
+| **retained** | ablated | no | yes | stale |
+| **staged** | shipped | **yes** | no | **fresh** |
+| **staged** | ablated | no | **no** | **stale** |
+
+The retained row self-heals one window later, because its watch was
+installed by an earlier commit and did fire. **The staged row does not
+heal at all.** `obs/acquire!` installs the watch *during this commit* —
+after the move has already happened — so there is no channel left, and the
+boundary paints the stale value and keeps it until something else moves
+that source. That is the first render of a dependency: a panel mounting
+while a permission drops, a user switches, a record is redacted. It is not
+a hypothetical class; it is the row above.
+
+---
+
+## Method
+
+**No sixth instrument.** The clock is B6's `timed-write!` window called
+unchanged — same state install, same single microtask yield, same
+per-write read-back of the written cell out of the DOM, same interleaving
+with the arm order rotating on the sample index, same in-run floor
+normalisation. The heap is B7's door, B7's collector, B7's three readers,
+B7's forced collections and B7's positive control, over a merged arm
+table. The two drivers gained purely additive `B6_INIT_FN` / `B7_INIT_FN`
+/ `B7_ARMS` environment seams; with them unset both files are
+byte-for-byte the published instruments.
+
+**The ladder has a reference rung, and that is what makes it an
+ablation.** Comparing a hand-built ablated boundary against the *published*
+Freehand arm would measure the ablation plus every other difference
+between a hand-built body and the interpreted emitter walk. So each pair
+is:
+
+| rung | body | shell | commit |
+|---|---|---|---|
+| `ref` | hand-built | real `shell/render` | real `cell/commit!` |
+| `nc` | **identical** | no `useSyncExternalStore` | no commit-side re-read |
+
+and the contract's price is `ref − nc`, with everything else held
+identical. The published arms ride alongside in the same run on the same
+box, so `published − ref` is visible as the emitter walk this pair does
+not contain (≈0.7–1.3 ms on the broad write, ≈20 B on standing heap).
+
+**What `nc` is, exactly.**
+
+- `useSyncExternalStore` → `useReducer` force-update, with the
+  subscription folded into the lifecycle layout effect. **Five hooks
+  against the shell's six** — `useContext`, `useRef`, `useReducer`, and
+  the same two `useLayoutEffect`s.
+- `cell/commit-readings`'s per-handle `obs/read`, and the `moved?`
+  comparison it feeds, deleted. The bundle's observations are published
+  from the value the **render** read. `obs/owned?` stays — a total,
+  no-throw predicate that is not part of the contract being priced.
+- Everything else in the commit is copied unchanged: staging, the
+  acquire-before-release order, the rollback guard, the currency
+  re-check, superseded-handle release, the event-table publication.
+
+**The repaint channel the ablation is forced into, and why the window is
+still B6's.** Because the sync lane is lost (finding 4), the `nc` arm
+takes Reagent's shape instead: a notification *enqueues* the boundary's
+force-update and a drain runs the enqueued bumps inside the caller's
+`flushSync`, where they take the sync lane. That is `reagent.core/flush`
+in Freehand spelling, and it is what the Reagent arm this whole studio
+compares against has always done. Both B9 rungs run `cell/flush!` inside
+their `force!` so the two windows are identical and the pair's difference
+is the contract rather than the drain. The consequence is visible in the
+leg split and is bookkeeping, not a saving: on the broad write the
+reference rung reads `gap 2.8–2.9 ms / force 0.0` and the ablated one
+`gap 0.2–0.3 ms / force 2.0–2.3`.
+
+**Gates green before any figure was read.**
+
+- **Canonical-DOM parity across all seven mount arms** — floor, Freehand
+  interpreted, Freehand compiled, Reagent, UIx, `b9-ref`, `b9-nc` — with
+  the written element count (301) on every one, in both arm orders.
+- **Canonical-DOM parity across all six update arms**, plus the check
+  that every arm's DOM actually *moved*, in both orders.
+- **Per-write DOM read-back: 0 unverified writes** in every published
+  clock row, both orders.
+- **Per-mount DOM read-back on the heap door: 0 unverified of 195
+  mounts** across the two heap runs.
+- **The positive control**, a dense JS array of 587,500 doubles that V8
+  stores as unboxed 8-byte slots, so its retained size is **4,700,000
+  bytes predicted before anything is measured**:
+
+  | run | reader | predicted | measured | error |
+  |---|---|---|---:|---:|
+  | forward | A | 4,700,000 | 4,697,146 [4,681,918–4,700,942] | −0.061% |
+  | forward | **C** | 4,700,000 | **4,700,024** | **+0.0005%** |
+  | reversed | A | 4,700,000 | 4,697,236 [4,691,344–4,701,266] | −0.059% |
+
+  The control did not miss. It has missed on this surface before — a flat
+  one-byte string of 4,700,000 characters read as six kilobytes, because
+  V8 does not materialise `'x'.repeat(n)` — which is why it is a
+  predicted figure rather than an observed one.
+
+**Both arm orders, always.** Every row below was taken twice, once with
+the arm list forward and once reversed. B6 already rotates the order on
+the sample index and B7 rotates it on the round, but a large-object arm
+has been observed to inflate its successor 2× reproducibly on this surface
+(`rf2-88pie`), and only running both orders can see that. It did not
+happen here: every conclusion holds in both.
+
+---
+
+## 1. The clock
+
+### 1a. Broad update — one write, 300 boundaries repaint
+
+p50 milliseconds per write, six rounds, range across rounds in brackets.
+
+| arm | forward | reversed |
+|---|---:|---:|
+| floor — top-down React, no substrate | 0.1–0.2 | 0.1–0.2 |
+| **Reagent** | **0.5–0.7** | **0.5–0.6** |
+| Freehand interpreted (published arm) | 4.3–5.4 | 3.6–4.1 |
+| Freehand compiled | 3.7–4.7 | 3.2–3.8 |
+| **`b9-ref`** — hand-built, contract intact | **3.4–4.1** | **3.1–3.9** |
+| **`b9-nc`** — hand-built, contract ablated | **3.0–3.6** | **2.7–3.2** |
+
+**The `ref` and `nc` ranges overlap, so on ranges alone they are
+indistinguishable** — which is what this studio's method requires be said
+first. The arms are interleaved *within* each round, so the paired
+comparison is available and is far stronger:
+
+| paired, per round | forward | reversed |
+|---|---|---|
+| `nc` ÷ `ref` | **×0.864**, cheaper in **6 of 6** | **×0.852**, cheaper in **6 of 6** |
+| `ref − nc`, ms | 0.4–0.7, mean 0.52 | 0.3–0.7, mean 0.50 |
+
+**Twelve of twelve rounds in one direction is a real effect**, and it is
+worth **≈14%** of the broad-write window.
+
+Against Reagent, computed per round so the box's drift cancels:
+
+| ÷ Reagent, broad write | forward | reversed |
+|---|---:|---:|
+| Freehand interpreted, published arm | 8.00 [7.5–8.6] | 7.27 [6.83–7.8] |
+| `b9-ref` | 6.30 [5.86–6.83] | 6.48 [6.2–6.8] |
+| **`b9-nc`** | **5.44** [5.14–6.0] | **5.52** [5.33–5.8] |
+
+So the ablation moves the boundary from ≈6.4× Reagent to ≈5.5×. Applying
+the same measured ×0.86 to the published interpreted arm puts it at
+≈6.3–6.9× rather than ≈7.3–8.0×.
+
+> **These are not the published row's absolutes.** Six arms interleave
+> here where the published row interleaves four, on a differently loaded
+> box and a different day, and the two B9 arms carry a `cell/flush!` in
+> their `force!` that the published arm does not. The published broad row
+> reads **9.9× Reagent**; this run reads the same arm at 7.3–8.0×. **The
+> ratio inside this run is what transfers, and the pair is what this page
+> claims** — not the absolute.
+
+### 1b. Narrow update — one write, one boundary repaints: a null result
+
+p50 milliseconds per **sample of 20 writes**.
+
+| arm | forward | reversed |
+|---|---:|---:|
+| Reagent | 1.0–1.2 | 1.1–1.3 |
+| Freehand interpreted | 10.2–12.4 | 9.9–12.6 |
+| `b9-ref` | 9.9–12.3 | 9.6–12.6 |
+| `b9-nc` | 10.1–12.3 | 9.4–11.8 |
+
+Paired: `nc ÷ ref` is **×1.027** forward and **×0.970** reversed — the
+direction **flips between arm orders**, which is what a null result looks
+like when it is honest. Nothing here is distinguishable.
+
+It should not be. B6's own leg split puts ≈90% of a narrow write in
+`frame/replace-app-db!` and the signal graph, before React is involved,
+and the commit-side re-read the ablation removes is **one** handle read
+rather than three hundred. There is nothing for the ablation to take.
+
+### 1c. Mount — 300 sub-free boundaries: ≤0.1 ms
+
+p50 milliseconds, B6's W2 storm shape, all seven arms gated on canonical
+DOM first.
+
+| arm | forward | reversed |
+|---|---:|---:|
+| floor | 0.2–0.3 | 0.2 |
+| UIx | 0.3 | 0.3–0.4 |
+| Freehand compiled | 0.5 | 0.4–0.5 |
+| **Reagent** | **0.5–0.6** | **0.5–0.6** |
+| **`b9-ref`** | **0.9–1.1** | **0.8–1.1** |
+| **`b9-nc`** | **0.9–1.0** | **0.8–1.0** |
+| Freehand interpreted (published arm) | 1.7–2.2 | 1.6–2.0 |
+
+`nc` is never *more* expensive than `ref` in any of the twelve rounds, and
+never cheaper by more than **0.1 ms — Chrome's `performance.now` quantum**
+across three hundred boundaries. Read it as a bound rather than a
+measurement: **the hook swap is worth at most 0.1 ms of a 0.9 ms mount.**
+
+That bound is useful for the broad-update row, because the storm witness
+has no dependencies at all — its commit loops over zero sites — so this
+pair isolates the **hook** half of the ablation exactly. At most 0.1 ms of
+the broad write's 0.5 ms saving can be the hooks; **at least 0.4 ms of it
+is the commit-side re-read.**
+
+And note where a contract-free Freehand boundary still stands: **0.8–1.1
+ms against Reagent's 0.5–0.6**, on the shape with no reactivity on either
+side.
+
+---
+
+## 2. The heap
+
+Retained bytes per boundary, `arm − floor`, 10 roots × 300 boundaries =
+3,000 boundaries held per reading, six rounds, one un-read warm-up pass
+first. Reader **A** is CDP `Runtime.getHeapUsage` after three forced
+collections; reader **C** is a full heap snapshot with every node's
+`self_size` summed by a streaming scan, run once as its own pass.
+
+Each arm's floor is subtracted **within its own round**, so the box's
+drift cancels; the bracket is the range across the six rounds.
+
+| arm | A, forward | A, reversed | C |
+|---|---:|---:|---:|
+| `storm` UIx | 251 [244–257] | 252 [250–254] | 251 |
+| `storm` **Reagent** | **411** [405–417] | **409** [407–413] | **403** |
+| `storm` Freehand (published arm) | 2,436 [2,431–2,444] | 2,434 [2,426–2,441] | 2,428 |
+| `storm` **`b9-ref`** | **2,416** [2,397–2,428] | **2,431** [2,401–2,439] | 2,396 |
+| `storm` **`b9-nc`** | **2,041** [2,024–2,053] | **2,062** [2,053–2,072] | 2,042 |
+| `storm` hooks-only `ref` — six hooks, no ViewCell | 1,199 [1,191–1,203] | 1,200 [1,194–1,207] | 1,193 |
+| `storm` hooks-only `nc` — five hooks, no ViewCell | 842 [837–847] | 845 [840–849] | 839 |
+| `reactive` **Reagent** | **1,027** [1,024–1,034] | **1,034** [1,030–1,039] | 944 |
+| `reactive` Freehand (published arm) | 4,395 [4,374–4,413] | 4,390 [4,370–4,408] | 4,402 |
+| `reactive` **`b9-ref`** | **4,294** [4,284–4,300] | **4,281** [4,270–4,305] | 4,305 |
+| `reactive` **`b9-nc`** | **3,918** [3,913–3,924] | **3,918** [3,912–3,926] | 3,930 |
+
+**The published rows reproduce.** UIx 251 against the published 251,
+Reagent 411/409 against 410, Freehand 2,436/2,434 against 2,430, reactive
+Reagent 1,027/1,034 against 1,037, reactive Freehand 4,395/4,390 against
+4,346. That is a different day, a different bundle and a thirteen-arm
+table landing on the published table to better than 1.2%, which is what
+makes the new rows beside them readable. Reader C's `reactive` Reagent is
+the one row that does not (944 against the published 1,034), and it is not
+reconciled away here — the snapshot pass is a single reading per arm and
+the two readers' constant offset is known to be arm-dependent.
+
+**What the ablation returns**, paired within each round:
+
+| pair | forward | reversed | reader C |
+|---|---:|---:|---:|
+| `storm` `ref − nc` | **375 B** [352–402], lower in **6/6** | **369 B** [348–383], **6/6** | 354 B |
+| `reactive` `ref − nc` | **376 B** [366–387], **6/6** | **363 B** [352–386], **6/6** | 375 B |
+| hooks-only `ref − nc` | **357 B** [352–363], **6/6** | **355 B** [351–361], **6/6** | 354 B |
+
+The `ref` and `nc` ranges are **disjoint on every witness in both orders**
+— 2,416 [2,397–2,428] against 2,041 [2,024–2,053], 4,294 [4,284–4,300]
+against 3,918 [3,913–3,924], and the same in reverse — so this is a real
+effect by this studio's own rule, not a paired inference.
+
+**And the hooks-only rung accounts for essentially all of it.** 355–357 B
+of a 363–376 B return, which is **95%–97%**. The remaining 8–20 B is the
+difference between publishing a five-key observation record built from a
+commit-time reading and one built from the render's — which is to say,
+nothing. **The commit-side re-read costs clock, not heap.**
+
+Where that leaves the ratio, computed per round and then summarised:
+
+| | Freehand ÷ Reagent | Freehand ÷ UIx |
+|---|---:|---:|
+| `storm`, contract intact | **5.884** [5.755–5.982] / **5.941** [5.820–5.988] | 9.627 / 9.648 |
+| `storm`, contract ablated | **4.969** [4.911–5.064] / **5.039** [4.977–5.092] | 8.131 / 8.184 |
+| `reactive`, contract intact | **4.180** [4.144–4.196] / **4.139** [4.112–4.178] | — |
+| `reactive`, contract ablated | **3.814** [3.788–3.827] / **3.788** [3.765–3.807] | — |
+
+(forward / reversed; every pair of ranges disjoint.)
+
+### 2a. Read against `rf2-oob3g`'s ceiling
+
+`rf2-oob3g` decomposed the 2,430 B sub-free boundary and put React's six
+hooks at 1,171 B, of which `useSyncExternalStore` alone was **516 B** —
+more than Reagent's whole boundary. This ladder's hooks rung reads
+**1,199–1,200 B**, within **2.4%** of that figure from a differently
+built instrument, which is the cross-check that lets the two pages be read
+together.
+
+But 516 B is what `useSyncExternalStore` *costs*, not what removing it
+*returns*, and the difference is the whole point of measuring rather than
+subtracting. The ablated rung still needs a repaint channel: a
+`useReducer` and a subscription registration folded into the lifecycle
+effect. Those cost **≈304 B** (the 516 B store plus the 145 B
+`useCallback` that fed it, less the 357 B actually returned). **The
+headline number a subtraction would have produced — 661 B — is 1.85× the
+truth.**
+
+`rf2-oob3g`'s ceiling therefore stands and tightens. It found that a
+Freehand boundary with the ViewCell driven **to zero** would still retain
+1,171 B against Reagent's 418 — **2.80×**. With the concurrent-store
+contract *also* gone, that floor moves to 842–845 B, **2.05–2.07×
+Reagent**. Both levers, taken together and taken to their limits, do not
+reach parity.
+
+---
+
+## 3. What the contract is load-bearing for
+
+Two of these are measured on this page; the third is read out of the
+source and is stated as such.
+
+**3a. The synchronous commit door — measured, `{:ref true, :nc false}`.**
+`useSyncExternalStore`'s listener calls React's `forceStoreRerender`,
+which schedules at the **sync lane**. A `useReducer` dispatch issued from
+a plain microtask takes the **default** lane, and an empty
+`react-dom/flushSync` flushes only the sync lane — the fault B6 already
+records against its own floor arm. So the ablated boundary put through
+B6's published window — write, one microtask, empty `flushSync`, read the
+DOM — **still holds the old value when the flush returns**, in both runs.
+
+`rf2-w2m25` is exactly that guarantee, and it is pinned in both
+directions by `a-freehand-write-commits-inside-flushsync`. A cheap path
+would have to rebuild it: the substrate keeps its own queue of pending
+force-updates and drains it inside a synchronous commit boundary, which is
+what this page's `nc` arm does and what `reagent.core/flush` is. That is
+recoverable — 14,000 verified writes here say so — but it means
+re-implementing the piece of Reagent's batching that
+`useSyncExternalStore` exists to make unnecessary.
+
+**3b. What invariant 5 catches that a watch does not — measured.** The
+table in *The answer, first*. On a **watchable** host, a **retained**
+site's mid-gap move is caught by both channels and the ablation is one
+window late; a **staged** site's is caught by **neither**, because
+`obs/acquire!` installs the watch during the same commit that needed it.
+The published bundle carries the stale value, the cell is not dirty, and
+nothing will correct it.
+
+Spec 006's own statement of invariant 5 rests on the headless case — *"on
+a non-watchable headless host a retained site has no value-movement
+watch, so this comparison is its only correction"*. This measurement adds
+the browser case, which is stronger than the spec claims and is the case
+a product decision is actually about.
+
+**3c. In the adapters, `useSyncExternalStore` is load-bearing for
+ownership, not tearing.** Not measured here; read out of
+`implementation/core/src/re_frame/substrate/spine.cljs`. The spine's
+`use-subscribe` puts the durable sub-cache acquire/release **inside**
+`useSyncExternalStore`'s subscribe callback precisely because React never
+runs that callback for a render it does not commit — *"an abandoned render
+acquires NOTHING; the leak is gone BY CONSTRUCTION"* (`rf2-es09qq`, after
+`rf2-879fe`). Freehand does not depend on that: its ownership is acquired
+in a layout effect, which React also only runs for committed renders. But
+any ablation framed as a re-frame-wide policy would hit the adapters, and
+there it reintroduces a ref-count leak class rather than a tear class.
+
+---
+
+## 4. Is the cheap path separable?
+
+**The commit half is separable cheaply. The hook half is separable
+expensively. The *decision* is not separable at all, and that is the one
+that settles it.**
+
+**The commit half — one branch.** The ablated `commit-readings` differs
+from the shipped one by which value the observation record carries and
+whether a comparison runs. Inside `cell.cljc` that is a branch in one
+function plus a flag on the cell, on the order of a dozen lines. This
+page's copy is ~115 lines of duplicated staging, currency, rollback and
+publication, but that duplication is an artefact of those functions being
+**private** to `cell.cljc` — it is the price of measuring from outside,
+not the price of the design. It should not be quoted as the cost of the
+feature.
+
+**The hook half — two component types, and a fork in the checkpoint.**
+Hooks cannot be called conditionally, so a per-boundary choice between
+`useSyncExternalStore` and `useReducer` is two `shell/render`s and two
+component types, chosen at component-construction time and keyed into
+`shell-signature` so that flipping the choice **remounts** rather than
+running a different hook order against the old Fiber's hook state. That
+machinery already exists and is already exercised by the lowering axis, so
+the shape is available — but it is a second shell, permanently, and it
+drags `checkpoint.cljs` with it: the pending window's host-visible closer
+would have to drain the cheap boundaries' force-updates from inside the
+sentinel's layout effect (§3a), so the substrate acquires a render queue
+of its own that today it does not have.
+
+**The decision cannot be automated, and its failure mode is silent.** The
+switch is supposed to be "cheap by default, guarantee on when a consumer
+uses concurrent features". **Nothing in re-frame2 can observe that.**
+`startTransition`, `useDeferredValue` and `<Suspense>` are React APIs the
+consumer calls in their own tree; the substrate mounts through
+`createRoot` and sees no signal from any of them. The only detector for
+"this render was interrupted" is `useSyncExternalStore` itself, which is
+the thing being switched off — the detection is circular. So the switch
+must be **declared**, and a wrong declaration produces exactly the class
+of bug the guarantee deletes: a silent wrong render, in a build that was
+told it did not need checking.
+
+**And it cannot be per-boundary even if it were declarable.** A tear is
+not local. The ugly instance is a stale panel *beside* a fresh one, so a
+tree where some boundaries are cheap and some are guaranteed is torn
+across the boundary between them. Any honest switch is at least
+per-root — which makes it a build-or-mount-level mode, not an authoring
+convenience.
+
+**The permanent clarity cost, stated plainly.** Two shells, two hook
+skeletons, a flag threaded through commit, a fork in the window closer,
+and — the part that does not shrink — **every ViewCell law verified in
+both modes, or the cheap mode is unverified**. Spec 006 freezes six
+invariants; invariant 5 is one of them and invariant 6's window-closing
+contract is entangled with §3a. This is a spec change, not a patch, and
+`spec/` is not this bead's to edit.
+
+**The arithmetic that should be read beside all of it.** A boundary with
+the whole contract removed is still **5.0× Reagent** on standing heap,
+**3.8×** on the reactive witness, **≈5.5× Reagent** on a broad write, and
+**1.6× Reagent** on mount. The contract is not what puts Freehand behind
+Reagent; it is 14% of one row and 15% of another.
+
+---
+
+## 5. What this page does not cover
+
+- **No compiled tier.** Ruled out; not measured, not quoted.
+- **The `nc` pair's bodies are hand-built**, so neither rung contains the
+  interpreted emitter walk. The walk is visible beside them as
+  `published − ref` — ≈0.7–1.3 ms on the broad write, ≈20 B of standing
+  heap — and it is absent from **both** rungs, so it cannot affect the
+  pair's difference. It does mean the pair's *ratios* to Reagent are for a
+  hand-built Freehand boundary, not for `v/defview`.
+- **The `nc` arm's window puts its React work in a different leg.** Total
+  window is what the ratios use and it is the same window on both rungs,
+  but a reader comparing leg splits across rungs is comparing bookkeeping.
+- **Heap under update.** Standing retention only, exactly as B7 measures
+  it. `freehand-vs-reagent-allocation.md` owns the other question.
+- **SSR and hydration.** `useSyncExternalStore`'s `getServerSnapshot` has
+  no counterpart in the ablated shell. Nothing here measures what that
+  would do to hydration; it is named as unmeasured rather than assumed
+  harmless.
+- **A real application.** Two purpose-built witnesses on a loaded
+  developer workstation.
+- **A failing-test demonstration inside the shipped suite.** §3b's tear is
+  measured through a probe over the real port, not as a `deftest`. The
+  shipped invariant-5 rows (`invariant-5-every-axis-is-still-compared-on-a-retained-handle`,
+  `invariant-5-a-real-node-moving-in-the-gap-corrects-a-retained-site`)
+  cover the retained case and stayed green throughout; **the staged case
+  has no shipped row**, and on this page's evidence it is the worse one.
+
+## Provenance
+
+- Fixtures: `storm` = 300 sub-free leaf boundaries, 301 elements (B6's
+  W2); `reactive` / update grid = 300 cells each reading their own
+  `[:b6/cell i]`, 301 elements.
+- Clock sampling: mount 6 rounds × (5 warm-up + 20 samples) per arm;
+  update 6 rounds × (4 warm-up + 12 samples), broad = 1 write a sample,
+  narrow = 20. Arms interleaved at the sample level with the order
+  rotating on the sample index. Every published row taken twice, forward
+  and reversed.
+- Heap sampling: 10 roots × 300 boundaries held per reading, 6 rounds,
+  arm order rotating with the round, one un-read warm-up pass first;
+  snapshot pass separate, once per arm, on the forward run only.
+- Verification: 0 unverified writes in every clock row; 0 unverified of
+  195 heap mounts; canonical-DOM parity across 7 mount arms and 6 update
+  arms in both orders; positive control within 0.061% on reader A and
+  0.0005% on reader C.
+- Build: `:advanced`, `goog.DEBUG false`, via `--config-merge` on the
+  existing `:freehand-release` build id.
+  `implementation/shadow-cljs.edn` is unchanged.
+- Source, shipped rather than deleted:
+  `implementation/freehand/test/re_frame/freehand/bench/b9_nc.cljs` (the
+  ablated commit, the ablated shell, both rungs of each pair, the heap
+  arms, the clock arms, and the two probes) and `b9_app.cljs` (the
+  `:advanced` entry). The drivers are B6's `b6_prod_run.cjs` and B7's
+  `b7_run.cjs`, unchanged except for additive environment seams.
+- Reproduce:
+
+  ```sh
+  cd implementation
+  B6_INIT_FN=re-frame.freehand.bench.b9-app/-main B6_OUT_DIR=out/b9-clock \
+    node freehand/test/re_frame/freehand/bench/b6_prod_run.cjs
+  B6_INIT_FN=… B6_QUERY='?reverse=1' node …/b6_prod_run.cjs
+  B7_INIT_FN=re-frame.freehand.bench.b9-app/-main B7_OUT_DIR=out/b9-heap \
+    B7_ARMS='storm/floor,storm/uix,storm/reagent,storm/freehand,b9/storm-hooks-ref,b9/storm-hooks-nc,b9/storm-ref,b9/storm-nc,reactive/floor,reactive/reagent,reactive/freehand,b9/reactive-ref,b9/reactive-nc' \
+    node freehand/test/re_frame/freehand/bench/b7_run.cjs --only heap
+  B6_INIT_FN=… B6_QUERY='?mode=probe' node …/b6_prod_run.cjs
+  ```

--- a/implementation/freehand/test/re_frame/freehand/bench/b6_prod_run.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b6_prod_run.cjs
@@ -20,15 +20,23 @@ const http = require('node:http');
 const path = require('node:path');
 
 const IMPL = path.resolve(__dirname, '../../../../..');
-const OUT = path.join(IMPL, 'out', 'b6-prod');
+// `B6_INIT_FN` / `B6_OUT_DIR` point this driver at a different entry —
+// the seam an ABLATION LADDER rides so that it reuses this window rather
+// than growing a second one. With both unset the file is byte-for-byte
+// the published instrument.
+const OUT_DIR = process.env.B6_OUT_DIR || 'out/b6-prod';
+const INIT_FN = process.env.B6_INIT_FN || 're-frame.freehand.bench.b6-prod-app/-main';
+
+const OUT = path.join(IMPL, OUT_DIR);
 const PORT = Number(process.env.B6_PORT || 8127);
+const QUERY = process.env.B6_QUERY || '';
 
 // ONE LINE, deliberately: shadow-cljs's CLI re-splits `--config-merge` on
 // whitespace when the EDN contains a newline, and reports
 // `EOF while reading` from a fragment. Keep it on one line.
 const CONFIG_MERGE =
-  '{:output-dir "out/b6-prod" :asset-path "." ' +
-  ':modules {:main {:init-fn re-frame.freehand.bench.b6-prod-app/-main}}}';
+  `{:output-dir "${OUT_DIR}" :asset-path "." ` +
+  `:modules {:main {:init-fn ${INIT_FN}}}}`;
 
 function build() {
   console.error('[b6] building :advanced bundle ...');
@@ -78,7 +86,7 @@ async function run() {
     if (t.startsWith(';; B6')) console.log(t);
   });
   page.on('pageerror', (e) => console.error('[b6] page error:', e.message));
-  await page.goto(`http://127.0.0.1:${PORT}/`, { waitUntil: 'load' });
+  await page.goto(`http://127.0.0.1:${PORT}/${QUERY}`, { waitUntil: 'load' });
   await page.waitForFunction('window.B6_DONE === true || window.B6_ERROR', null, {
     timeout: 15 * 60 * 1000,
   });

--- a/implementation/freehand/test/re_frame/freehand/bench/b7_run.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b7_run.cjs
@@ -57,7 +57,7 @@ const http = require('node:http');
 const path = require('node:path');
 
 const IMPL = path.resolve(__dirname, '../../../../..');
-const OUT = path.join(IMPL, 'out', 'b7');
+const OUT = path.join(IMPL, process.env.B7_OUT_DIR || path.join('out', 'b7'));
 const PORT = Number(process.env.B7_PORT || 8131);
 
 const ROUNDS = Number(process.env.B7_ROUNDS || 6);
@@ -68,7 +68,12 @@ const CONTROL_DOUBLES = Number(process.env.B7_CONTROL_DOUBLES || 587500);
 const CONTROL_PREDICTED = CONTROL_DOUBLES * 8;
 const WANT_SNAPSHOT = process.env.B7_SNAPSHOT !== '0';
 
-const HEAP_ARMS = [
+// The published arm set. `B7_ARMS` (comma-separated) overrides it, and
+// `B7_INIT_FN` points the bundle at a different `:init-fn` — the two seams
+// an ABLATION LADDER needs in order to ride this collector rather than
+// grow a second one. Neither has a default that changes anything: with
+// both unset this file is byte-for-byte the published instrument.
+const HEAP_ARMS = (process.env.B7_ARMS || [
   'storm/floor',
   'storm/freehand',
   'storm/reagent',
@@ -76,7 +81,10 @@ const HEAP_ARMS = [
   'reactive/floor',
   'reactive/freehand',
   'reactive/reagent',
-];
+].join(',')).split(',').map((s) => s.trim()).filter(Boolean);
+
+const INIT_FN = process.env.B7_INIT_FN || 're-frame.freehand.bench.b7-app/-main';
+const OUT_DIR = process.env.B7_OUT_DIR || 'out/b7';
 
 const ONLY = (() => {
   const i = process.argv.indexOf('--only');
@@ -91,8 +99,8 @@ const ONLY = (() => {
 // whitespace when the EDN contains a newline and then reports `EOF while
 // reading` from a fragment.
 const CONFIG_MERGE =
-  '{:output-dir "out/b7" :asset-path "." ' +
-  ':modules {:main {:init-fn re-frame.freehand.bench.b7-app/-main}}}';
+  `{:output-dir "${OUT_DIR}" :asset-path "." ` +
+  `:modules {:main {:init-fn ${INIT_FN}}}}`;
 
 function build() {
   console.error('[b7] building :advanced bundle ...');

--- a/implementation/freehand/test/re_frame/freehand/bench/b9_app.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b9_app.cljs
@@ -22,8 +22,13 @@
             [re-frame.freehand.bench.b6-rows :as rows]
             [re-frame.freehand.bench.b9-nc :as nc]))
 
-(def ^:private rounds 6)
-(def ^:private update-sampling {:warmup 4 :samples 12})
+(defn- q
+  "A query-string integer, or `default` — B7's own smoke seam. The
+  published run takes the defaults, which are B6's."
+  [k default]
+  (if-some [v (.get (js/URLSearchParams. (.-search js/location)) k)]
+    (js/parseInt v 10)
+    default))
 
 (defn- fail! [why]
   (set! (.-B6_ERROR js/window) (str why))
@@ -35,8 +40,36 @@
     (set! (.-B6_RESULTS js/window) acc)
     v))
 
+(defn- flag? [k]
+  (= "1" (.get (js/URLSearchParams. (.-search js/location)) k)))
+
+(defn- run-mount!
+  "B6's mount measurement over the W2 storm, with the two B9 rungs added.
+  Gated on B6's own canonical-DOM parity before a clock is read."
+  [rounds sampling reversed?]
+  (let [w                (nc/mount-witness reversed?)
+        {:keys [mounts agree? counts disagree]} (rows/mount-parity w (:props w))
+        problems (cond-> []
+                   (not agree?) (conj {:problem :canonical-dom :arms disagree})
+                   (not (every? #(= (:elements w) %) (vals counts)))
+                   (conj {:problem :element-count :expected (:elements w) :got counts}))]
+    (doseq [m mounts] (h/release! m))
+    (record! :mount-parity {:problems problems :ok? (empty? problems) :counts counts})
+    (if (seq problems)
+      (fail! (str "mount arms do not build the same page: " (pr-str problems)))
+      (record! :mount-storm (:record (rows/measure-mount! w rounds sampling))))))
+
 (defn- run-clock! []
-  (let [mounts (rows/mount-update-arms! (nc/make-update-arms))]
+  (let [rounds          (q "rounds" 6)
+        update-sampling {:warmup (q "warmup" 4) :samples (q "samples" 12)}
+        mount-sampling  {:warmup (q "warmup" 5) :samples (q "samples" 20)}
+        reversed?       (flag? "reverse")
+        ;; The mount row runs FIRST and on an otherwise empty page: the
+        ;; update grids would otherwise stand behind it, six roots of 300
+        ;; boundaries each, while a mount is timed.
+        _               (do (record! :arm-order (if reversed? :reversed :forward))
+                            (run-mount! rounds mount-sampling reversed?))
+        mounts          (rows/mount-update-arms! (nc/make-update-arms reversed?))]
     (-> (nc/sync-lane-probe!)
         (.then (fn [probe]
                  (record! :sync-lane-probe probe)

--- a/implementation/freehand/test/re_frame/freehand/bench/b9_app.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b9_app.cljs
@@ -70,6 +70,8 @@
         _               (do (record! :arm-order (if reversed? :reversed :forward))
                             (run-mount! rounds mount-sampling reversed?))
         mounts          (rows/mount-update-arms! (nc/make-update-arms reversed?))]
+    (record! :tear-probe (doto (nc/tear-probe!)
+                           (#(js/console.log (str ";; B6 tear probe " (pr-str %))))))
     (-> (nc/sync-lane-probe!)
         (.then (fn [probe]
                  (record! :sync-lane-probe probe)
@@ -117,6 +119,18 @@
       "heap" (do (nc/install-heap-door!)
                  (js/console.log ";; B7 heap instrument installed (B9 arms)")
                  (set! (.-B7_READY js/window) true))
+      ;; The two probes on their own, with no clock beside them — they are
+      ;; deterministic controls, not timings, and running them does not
+      ;; need six rounds of anything.
+      "probe" (do (record! :tear-probe (nc/tear-probe!))
+                  (-> (nc/sync-lane-probe!)
+                      (.then (fn [p]
+                               (record! :sync-lane-probe p)
+                               (set! (.-B6_DONE js/window) true)
+                               (js/console.log ";; B6 PROD DONE")))
+                      (.catch (fn [e]
+                                (fail! (str "probe rejected: " e))
+                                (set! (.-B6_DONE js/window) true)))))
       (run-clock!))
     (catch :default e
       (fail! (str "b9 run threw: " e))

--- a/implementation/freehand/test/re_frame/freehand/bench/b9_app.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b9_app.cljs
@@ -1,0 +1,91 @@
+(ns re-frame.freehand.bench.b9-app
+  "B9's `:advanced` entry — SCAFFOLDING for `rf2-so3io`.
+
+  One bundle, two modes, both of them existing instruments with extra
+  arms:
+
+  - `?mode=heap` installs `window.B7H` over
+    [[re-frame.freehand.bench.b9-nc/heap-arms]] — B7's own door, B7's own
+    collector, B7's own positive control, B7's own DOM read-back.
+  - the default mode runs B6's update rows over
+    [[re-frame.freehand.bench.b9-nc/make-update-arms]] — B6's own
+    `timed-write!` window, B6's own interleaving, B6's own floor
+    normalisation — and prints the sync-lane probe beside them.
+
+  Built and driven by
+  `implementation/freehand/test/re_frame/freehand/bench/b6_prod_run.cjs`
+  and `b7_run.cjs`, both pointed here through their `*_INIT_FN` /
+  `*_ARMS` environment seams. Neither driver's defaults change."
+  (:require [re-frame.adapter.uix :as react-substrate]
+            [re-frame.core :as rf]
+            [re-frame.freehand.bench.b6-harness :as h]
+            [re-frame.freehand.bench.b6-rows :as rows]
+            [re-frame.freehand.bench.b9-nc :as nc]))
+
+(def ^:private rounds 6)
+(def ^:private update-sampling {:warmup 4 :samples 12})
+
+(defn- fail! [why]
+  (set! (.-B6_ERROR js/window) (str why))
+  (js/console.error (str ";; B6 PROD FAILED — " why)))
+
+(defn- record! [k v]
+  (let [acc (or (.-B6_RESULTS js/window) #js {})]
+    (aset acc (name k) (pr-str v))
+    (set! (.-B6_RESULTS js/window) acc)
+    v))
+
+(defn- run-clock! []
+  (let [mounts (rows/mount-update-arms! (nc/make-update-arms))]
+    (-> (nc/sync-lane-probe!)
+        (.then (fn [probe]
+                 (record! :sync-lane-probe probe)
+                 (js/console.log (str ";; B6 sync-lane probe " (pr-str probe)))
+                 (rows/write-and-compare! mounts)))
+        (.then (fn [{:keys [ids before after]}]
+                 ;; THE FAIRNESS GATE, and it is not ceremony: an ablation arm
+                 ;; that rendered a different page — or no page — would read as
+                 ;; the fastest substrate in the table. B6's own canonical-DOM
+                 ;; comparison, over the extended arm set.
+                 (record! :update-parity {:ids ids :agree? (apply = after)
+                                          :moved? (mapv not= before after)})
+                 (when-not (apply = after)
+                   (fail! (str "update arms disagree under :advanced: " (pr-str ids))))
+                 (when (some true? (map = before after))
+                   (fail! "an update arm's DOM did not change under :advanced"))
+                 (rows/measure-update!
+                   mounts :broad "one write that all 300 cells read"
+                   rounds update-sampling)))
+        (.then (fn [res]
+                 (record! :update-broad (:record res))
+                 (rows/measure-update!
+                   mounts :narrow "one write exactly one of 300 cells reads"
+                   rounds update-sampling)))
+        (.then (fn [res]
+                 (record! :update-narrow (:record res))
+                 (rows/release-update-arms! mounts)
+                 (set! (.-B6_DONE js/window) true)
+                 (js/console.log ";; B6 PROD DONE")
+                 nil))
+        (.catch (fn [e]
+                  (rows/release-update-arms! mounts)
+                  (fail! (str "b9 clock rows rejected: " e))
+                  (set! (.-B6_DONE js/window) true))))))
+
+(defn- mode []
+  (or (.get (js/URLSearchParams. (.-search js/location)) "mode") "clock"))
+
+(defn ^:export -main
+  []
+  (try
+    (rf/init! react-substrate/adapter)
+    (h/leave-act-environment!)
+    (case (mode)
+      "heap" (do (nc/install-heap-door!)
+                 (js/console.log ";; B7 heap instrument installed (B9 arms)")
+                 (set! (.-B7_READY js/window) true))
+      (run-clock!))
+    (catch :default e
+      (fail! (str "b9 run threw: " e))
+      (set! (.-B6_DONE js/window) true)
+      (set! (.-B7_READY js/window) true))))

--- a/implementation/freehand/test/re_frame/freehand/bench/b9_nc.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b9_nc.cljs
@@ -535,11 +535,52 @@
 
 (defn make-update-arms
   "B6's published arms, plus the two B9 rungs. The published arms are
-  re-taken in the same run so the anchor and the ablation share a box."
-  []
-  (conj (rows/make-update-arms)
-        (b9-update-arm :b9-ref cell-leaf-ref :b9-ref/grid false)
-        (b9-update-arm :b9-nc  cell-leaf-nc  :b9-nc/grid  true)))
+  re-taken in the same run so the anchor and the ablation share a box.
+
+  `reversed?` runs the whole arm list back to front. B6 already rotates
+  the arm order on the SAMPLE index, so no arm is permanently first into
+  a cold cache — but a large-object arm has been observed to inflate its
+  successor 2× reproducibly on this surface (`rf2-88pie`), and the only
+  way to see that is to run both orders."
+  ([] (make-update-arms false))
+  ([reversed?]
+   (let [arms (conj (rows/make-update-arms)
+                    (b9-update-arm :b9-ref cell-leaf-ref :b9-ref/grid false)
+                    (b9-update-arm :b9-nc  cell-leaf-nc  :b9-nc/grid  true))]
+     (if reversed? (vec (reverse arms)) arms))))
+
+;; --- the MOUNT row, over B6's W2 storm shape --------------------------------
+;;
+;; The update row prices the contract on a write. Mount is the other axis
+;; the release gate carries, and `useSyncExternalStore` is paid on every
+;; mount whether anything ever moves or not — so the storm witness runs
+;; the same six arms through B6's mount measurement.
+
+(defn- b9-mount-arm [id leaf]
+  {:id      id
+   :mount   (fn [container _props _n]
+              (let [r (react-dom-client/createRoot container)]
+                (.render r (storm-of leaf))
+                r))
+   :unmount (fn [r] (.unmount r))})
+
+(defn mount-witness
+  "B6's W2 witness — 300 sub-free leaf boundaries, 301 elements — with the
+  two B9 rungs added to its published arms.
+
+  W2 is deliberately the shape that MAXIMISES Freehand's compiled elision,
+  and B6 flags it as overstating Freehand's advantage. That warning is
+  irrelevant to the pair measured here, which is interpreted-shaped on
+  both sides and differs only in the contract."
+  [reversed?]
+  (let [w    (first (filter #(= :W2 (:id %)) rows/mount-witnesses))
+        arms (into (vec (:arms w))
+                   [(b9-mount-arm :b9-ref-storm storm-leaf-ref)
+                    (b9-mount-arm :b9-nc-storm  storm-leaf-nc)])]
+    (assoc w
+           :id :W2-B9
+           :headline? false
+           :arms (if reversed? (vec (reverse arms)) arms))))
 
 ;; ===========================================================================
 ;; 8. The sync-lane probe — the claim in the docstring, measured

--- a/implementation/freehand/test/re_frame/freehand/bench/b9_nc.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b9_nc.cljs
@@ -352,11 +352,21 @@
 
 (defn- trivial-store [] #js {:revision 0 :listeners #js {}})
 
-(defn- trivial-subscribe [st]
+(defn- trivial-subscribe
+  "The trivial store's subscribe. NULL-SAFE on unsubscribe, and that is
+  not defensive noise: React runs a layout effect's cleanup BEFORE the
+  passive cleanup `useSyncExternalStore` unsubscribes through, so a
+  lifecycle effect that cleared the listener table left the later
+  unsubscribe dereferencing `null`. `rf2-oob3g`'s ladder carried the same
+  shape and threw on every unmount of this rung; it is fixed here rather
+  than reproduced."
+  [st]
   (fn [listener]
     (let [k (js-obj)]
       (aset (.-listeners st) k listener)
-      (fn unsubscribe [] (js-delete (.-listeners st) k) nil))))
+      (fn unsubscribe []
+        (when-some [ls (.-listeners st)] (js-delete ls k))
+        nil))))
 
 (defn- hooks-leaf-ref
   "The shell's exact six hooks over a trivial store — `rf2-oob3g`'s L2."
@@ -395,10 +405,14 @@
 ;; ===========================================================================
 
 (def frame-id
-  "The one frame behind every reactive B9 root — B7's own, so the reactive
-  rungs sit on the identical store the published `reactive/freehand` arm
-  sits on."
-  heap/shared-frame-id)
+  "The one frame behind every reactive B9 root. Deliberately NOT B7's
+  `:b7/grid`: that id is ensured CONFIG-BEARING by the published
+  `reactive/freehand` arm's root 0, and a second config-bearing ensure of
+  one id is refused by design (Spec 004C §7). One frame per arm against
+  3,000 held boundaries is 1/3000 of a reading, so a separate id costs the
+  comparison nothing and removes an ordering coupling between two arms
+  that must be free to run in either order."
+  :b9/grid)
 
 (defn- storm-of [leaf]
   (el "div" #js {:className "storm"}

--- a/implementation/freehand/test/re_frame/freehand/bench/b9_nc.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b9_nc.cljs
@@ -600,6 +600,58 @@
 ;; 8. The sync-lane probe — the claim in the docstring, measured
 ;; ===========================================================================
 
+(defn tear-probe!
+  "WHAT THE GUARANTEE BUYS, measured on a WATCHABLE host — the browser,
+  where a retained dependency has a change watch and the headless
+  argument for invariant 5 does not apply.
+
+  Two cases, each run through both commits, each moving the source in the
+  render→commit gap:
+
+  - **retained** — the site was committed once already, so its handle
+    carries a watch installed at the FIRST commit. The move therefore
+    marks the cell through the ordinary channel as well.
+  - **staged** — a FIRST commit of that site. `obs/acquire!` installs the
+    watch DURING this commit, which is after the move already happened,
+    so the watch has nothing to fire about.
+
+  Answers, per case per commit: `:revision-delta` (did invariant 5
+  correct?), `:dirty?` (is the ordinary notification channel going to
+  correct it at the next window?) and `:published` (what value the
+  committed bundle carries).
+
+  This is the difference between reporting a bug class and asserting one."
+  []
+  (let [fid :b9-tear/frame
+        q   [:b6/cell 0]
+        run (fn [commit! retained?]
+              (when (nil? (frame/frame fid)) (rf/make-frame {:id fid}))
+              (frame/replace-app-db! fid {:cells [:v0]})
+              (let [c (cell/cell :b9/tear)]
+                (when retained?
+                  ;; One earlier commit, so the site's handle — and its
+                  ;; change watch — already exist when the move happens.
+                  (let [cand0 (cell/candidate c fid)]
+                    (cell/with-capture cand0 (fn [] (cell/observe! q)))
+                    (commit! cand0)))
+                (let [cand   (cell/candidate c fid)
+                      _      (cell/with-capture cand (fn [] (cell/observe! q)))
+                      before (cell/revision c)
+                      ;; THE GAP: the source moves after the render probed
+                      ;; it and before the commit publishes it.
+                      _      (frame/replace-app-db! fid {:cells [:v1]})
+                      result (commit! cand)
+                      out    {:commit         result
+                              :revision-delta (- (cell/revision c) before)
+                              :dirty?         (cell/dirty? c)
+                              :published      (str (:value (first (:observations (cell/evidence c)))))}]
+                  (cell/disconnect! c)
+                  out)))]
+    {:retained {:shipped  (run cell/commit! true)
+                :ablated  (run nc-commit!   true)}
+     :staged   {:shipped  (run cell/commit! false)
+                :ablated  (run nc-commit!   false)}}))
+
 (defn sync-lane-probe!
   "Does a boundary WITHOUT `useSyncExternalStore` repaint inside an empty
   `react-dom/flushSync`, the way `rf2-w2m25`'s synchronous commit door

--- a/implementation/freehand/test/re_frame/freehand/bench/b9_nc.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b9_nc.cljs
@@ -1,0 +1,585 @@
+(ns re-frame.freehand.bench.b9-nc
+  "B9 — SCAFFOLDING. The concurrent-store contract, ABLATED, so it can be
+  priced on the clock and on the heap (`rf2-so3io`).
+
+  **Nothing here ships and nothing here changes the shipped path.** Every
+  arm is an extra arm on an existing door: the heap arms merge onto
+  [[re-frame.freehand.bench.b7-heap/arms]] and are read through B7's own
+  collector; the clock arms are built from
+  [[re-frame.freehand.bench.b6-rows]]'s constructors and are measured
+  through B6's own `timed-write!` window. No sixth instrument.
+
+  ## What \"the concurrent-store contract\" means here, exactly
+
+  Two mechanisms, both servicing React's concurrent-rendering contract,
+  both ablated together and each also ablated on its own:
+
+  1. **`useSyncExternalStore`.** `shell/use-revision!` installs one per
+     boundary. It is what lets React detect that a store moved during a
+     time-sliced render and restart, and it is 516 B of the ~1,171 B
+     React's six hooks retain per boundary (`rf2-oob3g`'s ladder).
+  2. **The commit-side re-read.** `cell/commit-readings` calls `obs/read`
+     on EVERY staged handle and compares node-key, version and
+     frame/registry epochs against the render's probe — Spec 006
+     invariant 5, the render→commit tear check. It is O(dependencies) and
+     it is the largest single term in the commit-phase layout effect
+     (`bulk-rerender-where-the-time-goes.md` §4).
+
+  ## The ladder, and why it has a REFERENCE rung
+
+  A hand-built ablation arm compared against the published Freehand arm
+  would measure the ablation PLUS every other difference between a
+  hand-built body and the interpreted emitter walk. So the ladder carries
+  a reference rung — the same hand-built body under the REAL shell and
+  the REAL `cell/commit!` — and the contract's price is the
+  `ref − nc` difference, taken with everything else held identical. The
+  published arm rides alongside as the anchor, and `published − ref` is
+  the emitter walk this pair does not contain.
+
+    ref   hand-built body + `shell/render`    + `cell/commit!`
+    nc    hand-built body + [[nc-render]]     + [[nc-commit!]]
+
+  ## Why the ablated commit is a COPY rather than a flag
+
+  It is a copy on purpose, and the copy is the answer to the bead's second
+  question. `cell/commit!`'s staging, its currency re-check, its rollback
+  discipline, its superseded-handle release and its event-table
+  publication are all PRIVATE to `cell.cljc` and all indifferent to
+  whether the tear check runs. Ablating one step therefore means
+  duplicating every step around it — which is exactly the shape a
+  \"cheap by default, guarantee on demand\" build would take if it were
+  spelled as a second commit path. The line count below is the price.
+
+  ## The repaint channel the ablation is forced into
+
+  `useSyncExternalStore`'s listener calls React's `forceStoreRerender`,
+  which schedules at the **sync lane**. Nothing else available to a
+  function component does: a `useReducer` dispatch issued from a plain
+  microtask takes the DEFAULT lane, and an EMPTY `react-dom/flushSync`
+  flushes only the sync lane (the fault B6 records against its own floor
+  arm). So a boundary without `useSyncExternalStore` cannot repaint
+  inside `flushSync` through the door `rf2-w2m25` opened.
+
+  The ablation therefore takes Reagent's shape, which is the substrate
+  being compared against: a notification ENQUEUES the boundary's
+  force-update, and a drain runs the enqueued bumps inside the caller's
+  `flushSync`, where they take the sync lane. That is
+  `reagent.core/flush` in Freehand spelling, and it is what the `nc`
+  arm's `force!` calls. [[sync-lane-probe!]] measures the claim rather
+  than asserting it."
+  (:require ["react" :as react]
+            ["react-dom" :as react-dom]
+            ["react-dom/client" :as react-dom-client]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.freehand.bench.b6-rows :as rows]
+            [re-frame.freehand.bench.b7-heap :as heap]
+            [re-frame.freehand.cell :as cell]
+            [re-frame.freehand.events :as events]
+            [re-frame.freehand.shell :as shell]
+            [re-frame.router :as router]
+            [re-frame.substrate.observation :as obs]))
+
+(def ^:private el react/createElement)
+(def ^:private empty-deps #js [])
+
+(def per-root
+  "Boundaries in one root — B7's own, so a per-boundary figure here and a
+  per-boundary figure there describe the same page."
+  heap/per-root)
+
+;; ===========================================================================
+;; 1. The ablated commit — cell/commit! WITHOUT the invariant-5 re-read
+;; ===========================================================================
+;;
+;; Everything in this section is a near-verbatim copy of a PRIVATE function
+;; in `cell.cljc`. It is copied rather than called because it is private,
+;; and it is private because nothing outside the commit has any business
+;; running it. That is the point: see the namespace docstring.
+
+(defn- nc-current?
+  "`cell/current?` — the candidate's body revision is still the cell's and
+  the frame incarnation it resolved against is still live. UNCHANGED by
+  the ablation; copied because it is private."
+  [cand s]
+  (and (= (.-generation cand) (:generation s))
+       (let [f (.-frame cand)]
+         (or (nil? f)
+             (frame/frame-incarnation-live? f (.-incarnation cand))))))
+
+(defn- nc-release-all! [handles]
+  (doseq [h handles] (obs/release! h))
+  nil)
+
+(defn- nc-stage!
+  "`cell/stage!` — acquire every newly-observed or retargeted target in
+  render order, before anything is released, with the same
+  release-in-reverse rollback on failure. UNCHANGED by the ablation."
+  [c prior order reads]
+  (let [acquired (volatile! [])
+        n        (count order)]
+    (try
+      (loop [i      0
+             staged (transient {})]
+        (if (< i n)
+          (let [site-key (nth order i)
+                record   (get reads site-key)
+                target   (:target record)
+                kept     (get prior site-key)
+                handle   (if (and (some? kept) (obs/current? (:handle kept) target))
+                           (:handle kept)
+                           (let [h (obs/acquire!
+                                     target
+                                     (fn on-change [cause] (cell/mark-dirty! c cause)))]
+                             (vswap! acquired conj h)
+                             h))]
+            (recur (inc i) (assoc! staged site-key (assoc record :handle handle))))
+          {:staged (persistent! staged) :acquired @acquired}))
+      (catch :default e
+        (nc-release-all! (rseq @acquired))
+        (throw e)))))
+
+(defn- nc-superseded-handles
+  "`cell/superseded-handles`. UNCHANGED by the ablation."
+  [prior staged acquired]
+  (if (and (empty? acquired) (= (count staged) (count prior)))
+    []
+    (into []
+          (keep (fn [[site-key {:keys [handle]}]]
+                  (let [now (get-in staged [site-key :handle])]
+                    (when-not (identical? now handle) handle))))
+          prior)))
+
+(defn- nc-observations
+  "**THE ABLATION.** `cell/commit-readings` with the `obs/read` removed.
+
+  The shipped pass reads every staged handle a SECOND time — after the
+  render already read it — and compares node-key, version and
+  frame/registry epochs against the render's probe. That read is the
+  invariant-5 tear check; the observations it publishes are a by-product
+  of it.
+
+  Here the observations are published from the value the RENDER read, so
+  no handle is read twice and nothing is compared. `obs/owned?` stays: it
+  is a total, no-throw predicate over handle state, it is not
+  callback-capable, and it is not part of the contract being priced.
+
+  There is no `:moved?`, so there is no revision advance at commit and no
+  correction before paint. A source that moved in the render→commit gap
+  is corrected only by its own change watch — which a RETAINED handle has
+  on a watchable host and does NOT have on a headless one."
+  [order staged]
+  (let [n (count order)]
+    (loop [i 0
+           o (transient [])]
+      (if (< i n)
+        (let [site-key (nth order i)
+              record   (get staged site-key)]
+          (recur (inc i)
+                 (conj! o {:site-key site-key
+                           :query    (:query record)
+                           :frame-id (:frame-id (:target record))
+                           :value    (:value record)
+                           :owned?   (obs/owned? (:handle record))})))
+        (persistent! o)))))
+
+(defn- nc-frame-dispatcher
+  "`cell/frame-dispatcher`. UNCHANGED by the ablation."
+  [frame-id]
+  (if (some? frame-id)
+    (fn dispatch-into-frame [event] (router/dispatch! event {:frame frame-id :source :ui}))
+    (fn dispatch-ambient [event] (router/dispatch! event {:source :ui}))))
+
+(defn- nc-frame-door-dispatcher
+  "`cell/frame-door-dispatcher`. UNCHANGED by the ablation."
+  [frame-id]
+  (when (some? frame-id)
+    (fn dispatch-through-door [event]
+      (router/dispatch-sync! event {:frame frame-id :source :ui})
+      (cell/flush-frame! frame-id)
+      nil)))
+
+(defn nc-commit!
+  "`cell/commit!` with the invariant-5 commit-side re-read removed, and
+  nothing else changed. Answers `:published` or `:abandoned`.
+
+  The currency re-check STAYS: `nc-stage!`'s `obs/acquire!` is still
+  callback-capable, so a publication that skipped it could publish stale
+  ownership. Only the tear check goes."
+  [cand]
+  (let [c  (.-cell cand)
+        s0 @(.-state c)]
+    (if-not (nc-current? cand s0)
+      :abandoned
+      (let [order   @(.-order cand)
+            by-site @(.-by-site cand)
+            prior   (:deps s0)
+            fid     (.-frame cand)
+            {:keys [staged acquired]} (nc-stage! c prior order by-site)
+            observations (try
+                           (nc-observations order staged)
+                           (catch :default e
+                             (nc-release-all! (rseq acquired))
+                             (throw e)))]
+        (if-not (nc-current? cand @(.-state c))
+          (do (nc-release-all! (rseq acquired))
+              :abandoned)
+          (let [bundle {:frame        fid
+                        :generation   (.-generation cand)
+                        :observations observations}]
+            (swap! (.-state c) assoc
+                   :lifecycle :connected
+                   :frame     fid
+                   :deps      staged
+                   :dep-order order
+                   :evidence  bundle)
+            (events/commit! (.-events cand)
+                            (nc-frame-dispatcher fid)
+                            (nc-frame-door-dispatcher fid))
+            (nc-release-all! (nc-superseded-handles prior staged acquired))
+            :published))))))
+
+;; ===========================================================================
+;; 2. The ablated repaint channel — no useSyncExternalStore
+;; ===========================================================================
+
+(defonce ^:private pending-bumps (js/Set.))
+
+(defn drain!
+  "Run every enqueued force-update. Called INSIDE the caller's
+  `react-dom/flushSync`, so the updates it issues take the sync lane and
+  commit before that flush returns — the same contract
+  `reagent.core/flush` has, and the only one available to a boundary that
+  does not hold a `useSyncExternalStore`.
+
+  Answers how many boundaries were bumped, so a caller can see the
+  channel is not silently empty."
+  []
+  (let [n (.-size pending-bumps)]
+    (when (pos? n)
+      (let [bs (js/Array.from pending-bumps)]
+        (.clear pending-bumps)
+        (.forEach bs (fn [b] (b)))))
+    n))
+
+(defn- tick [n _] (inc n))
+
+;; ===========================================================================
+;; 3. The two shells
+;; ===========================================================================
+
+(defn ref-render
+  "The REFERENCE rung: the real [[re-frame.freehand.shell/render]],
+  unchanged. Present so the ablation is a paired difference rather than a
+  comparison against a different body."
+  [view-id render-candidate]
+  (shell/render view-id 0 :interpreted render-candidate))
+
+(defn nc-render
+  "The ABLATED rung: `shell/render` with `useSyncExternalStore` replaced
+  by an enqueued force-update and `cell/commit!` replaced by
+  [[nc-commit!]].
+
+  FIVE hooks against the shell's six — `useContext`, `useRef`,
+  `useReducer`, and the same two `useLayoutEffect`s. The subscription is
+  folded into the lifecycle effect, which is where a real implementation
+  would put it and which is why no third effect appears.
+
+  The hole this opens is the reason `useSyncExternalStore` exists: the
+  store is subscribed to at COMMIT, not during render, so a move between
+  this render and its commit is not noticed here at all — and
+  [[nc-commit!]] no longer notices it either."
+  [view-id render-candidate]
+  (let [frame-id (shell/frame-context-frame)
+        cell-ref (react/useRef nil)
+        _        (when (nil? (.-current cell-ref))
+                   (set! (.-current cell-ref) (cell/cell view-id)))
+        c        (.-current cell-ref)
+        bump     (aget (react/useReducer tick 0) 1)
+        _        (cell/advance-generation! c 0)
+        cand     (cell/candidate c frame-id)
+        element  (render-candidate cand)]
+    (react/useLayoutEffect
+      (fn reconcile []
+        (nc-commit! cand)
+        js/undefined))
+    (react/useLayoutEffect
+      (fn lifecycle []
+        (let [unsub (cell/subscribe c (fn notify [] (.add pending-bumps bump) nil))]
+          (fn cleanup []
+            (unsub)
+            (.delete pending-bumps bump)
+            (cell/disconnect! c))))
+      empty-deps)
+    element))
+
+;; ===========================================================================
+;; 4. The bodies — hand-built, identical across both rungs
+;; ===========================================================================
+
+(defn- storm-body
+  "B6's W2 leaf, hand-built: `[:span.leaf \"leaf\"]`, no reactive read."
+  [_cand]
+  (el "span" #js {:className "leaf"} "leaf"))
+
+(defn- cell-body
+  "B6's update-grid leaf, hand-built: one `v/sub` and one span. `v/sub` IS
+  `cell/observe!`, so this is the same read the interpreted witness makes
+  — what is missing is only the emitter walk around it."
+  [i]
+  (fn [cand]
+    (cell/with-capture cand
+      (fn []
+        (el "span" #js {:className "cell" :data-i i}
+            (str (cell/observe! [:b6/cell i])))))))
+
+(defn- storm-leaf-ref [_props] (ref-render :b9/storm storm-body))
+(defn- storm-leaf-nc  [_props] (nc-render  :b9/storm storm-body))
+
+(defn- cell-leaf-ref [props]
+  (let [i (aget props "i")] (ref-render :b9/cell (cell-body i))))
+
+(defn- cell-leaf-nc [props]
+  (let [i (aget props "i")] (nc-render :b9/cell (cell-body i))))
+
+;; --- the hooks-only rungs, for the heap ladder ------------------------------
+;;
+;; `rf2-oob3g` priced React's six hooks over a TWO-FIELD JS OBJECT at
+;; 1,171 B a boundary, of which `useSyncExternalStore` was 516. These two
+;; rungs reproduce that rung and its ablated twin, so the hook half of the
+;; answer is read on its own, with no ViewCell and no CLJS data structure
+;; anywhere in it.
+
+(defn- trivial-store [] #js {:revision 0 :listeners #js {}})
+
+(defn- trivial-subscribe [st]
+  (fn [listener]
+    (let [k (js-obj)]
+      (aset (.-listeners st) k listener)
+      (fn unsubscribe [] (js-delete (.-listeners st) k) nil))))
+
+(defn- hooks-leaf-ref
+  "The shell's exact six hooks over a trivial store — `rf2-oob3g`'s L2."
+  [_props]
+  (let [_ctx (shell/frame-context-frame)
+        ref  (react/useRef nil)
+        _    (when (nil? (.-current ref)) (set! (.-current ref) (trivial-store)))
+        st   (.-current ref)
+        subscribe (react/useCallback (trivial-subscribe st) #js [st])]
+    (react/useSyncExternalStore subscribe (fn [] (.-revision st)) (fn [] 0))
+    (react/useLayoutEffect (fn reconcile [] js/undefined))
+    (react/useLayoutEffect (fn lifecycle [] (fn cleanup [] (set! (.-listeners st) nil)))
+                           empty-deps)
+    (el "span" #js {:className "leaf"} "leaf")))
+
+(defn- hooks-leaf-nc
+  "The same rung with the concurrent-store contract removed: no
+  `useCallback`, no `useSyncExternalStore`, a `useReducer` force-update,
+  and the subscription folded into the lifecycle effect."
+  [_props]
+  (let [_ctx (shell/frame-context-frame)
+        ref  (react/useRef nil)
+        _    (when (nil? (.-current ref)) (set! (.-current ref) (trivial-store)))
+        st   (.-current ref)
+        bump (aget (react/useReducer tick 0) 1)]
+    (react/useLayoutEffect (fn reconcile [] js/undefined))
+    (react/useLayoutEffect
+      (fn lifecycle []
+        (let [unsub ((trivial-subscribe st) (fn [] (.add pending-bumps bump) nil))]
+          (fn cleanup [] (unsub) (.delete pending-bumps bump) (set! (.-listeners st) nil))))
+      empty-deps)
+    (el "span" #js {:className "leaf"} "leaf")))
+
+;; ===========================================================================
+;; 5. The trees
+;; ===========================================================================
+
+(def frame-id
+  "The one frame behind every reactive B9 root — B7's own, so the reactive
+  rungs sit on the identical store the published `reactive/freehand` arm
+  sits on."
+  heap/shared-frame-id)
+
+(defn- storm-of [leaf]
+  (el "div" #js {:className "storm"}
+      (into-array (map (fn [i] (el leaf #js {:key i})) (range per-root)))))
+
+(defn- grid-of [leaf fid]
+  (shell/provide-frame fid
+    (el "div" #js {:className "ugrid"}
+        (into-array (map (fn [i] (el leaf #js {:key i :i i})) (range per-root))))))
+
+(defn ensure-frame!
+  "Stand the reactive rungs' frame up and seed it. `rf/make-frame` is the
+  public constructor and is idempotent for the same id, so this is safe to
+  call before every mount."
+  [fid n]
+  (when (nil? (frame/frame fid))
+    (rf/make-frame {:id fid}))
+  (frame/replace-app-db! fid {:cells (vec (repeat n 0))})
+  nil)
+
+;; ===========================================================================
+;; 6. Heap arms — merged onto B7's own table, read through B7's collector
+;; ===========================================================================
+
+(defn- react-root-arm [selector element-of]
+  {:selector    selector
+   :mount-one   (fn [c _i]
+                  (let [r (react-dom-client/createRoot c)]
+                    (react-dom/flushSync (fn [] (.render r (element-of))))
+                    r))
+   :unmount-one (fn [r] (react-dom/flushSync (fn [] (.unmount r))))})
+
+(defn- reactive-root-arm [leaf]
+  {:selector    ".cell"
+   :mount-one   (fn [c _i]
+                  (ensure-frame! frame-id per-root)
+                  (let [r (react-dom-client/createRoot c)]
+                    (react-dom/flushSync (fn [] (.render r (grid-of leaf frame-id))))
+                    r))
+   :unmount-one (fn [r] (react-dom/flushSync (fn [] (.unmount r))))})
+
+(def heap-arms
+  "B7's arms, plus B9's rungs. Merged rather than replaced so the published
+  rows are re-taken in the same run as the ablation and on the same box —
+  a ratio against a figure from another day is not a ratio."
+  (merge heap/arms
+         {:b9/storm-hooks-ref (react-root-arm ".leaf" #(storm-of hooks-leaf-ref))
+          :b9/storm-hooks-nc  (react-root-arm ".leaf" #(storm-of hooks-leaf-nc))
+          :b9/storm-ref       (react-root-arm ".leaf" #(storm-of storm-leaf-ref))
+          :b9/storm-nc        (react-root-arm ".leaf" #(storm-of storm-leaf-nc))
+          :b9/reactive-ref    (reactive-root-arm cell-leaf-ref)
+          :b9/reactive-nc     (reactive-root-arm cell-leaf-nc)}))
+
+;; --- B7's holding door, over the extended table ----------------------------
+
+(defonce ^:private held (atom nil))
+
+(defn- release!* []
+  (when-some [{:keys [arm handles containers]} @held]
+    (let [{:keys [unmount-one]} (get heap-arms arm)]
+      (doseq [h (reverse handles)]
+        (try (unmount-one h) (catch :default _ nil))))
+    (doseq [c containers] (.remove c))
+    (reset! held nil))
+  nil)
+
+(defn- container! []
+  (let [c (js/document.createElement "div")]
+    (.appendChild js/document.body c)
+    c))
+
+(defn mount!
+  "B7's `mount!`, over the extended arm table."
+  [arm-id k]
+  (release!*)
+  (let [{:keys [mount-one selector]} (get heap-arms arm-id)
+        containers (mapv (fn [_] (container!)) (range k))
+        handles    (into [] (map-indexed (fn [i c] (mount-one c i))) containers)
+        elements   (.-length (.querySelectorAll js/document selector))
+        expected   (* k per-root)]
+    (reset! held {:arm arm-id :handles handles :containers containers})
+    #js {:elements elements :expected expected :ok (= elements expected)}))
+
+(defn install-heap-door!
+  "Publish the SAME `window.B7H` surface B7's collector drives, over the
+  extended arm table. The collector, the readers, the forced collections
+  and the positive control are B7's and are untouched."
+  []
+  (set! (.-B7H js/window)
+        #js {:mount          (fn [arm k] (mount! (keyword arm) k))
+             :release        (fn [] (release!*) true)
+             :control        (fn [n] (heap/control! n))
+             :controlRelease (fn [] (heap/control-release!))
+             :perfMem        (fn []
+                               (if-some [m (.-memory js/performance)]
+                                 (.-usedJSHeapSize m)
+                                 -1))
+             :perRoot        per-root})
+  nil)
+
+;; ===========================================================================
+;; 7. Clock arms — built for B6's own window
+;; ===========================================================================
+
+(defn- b9-update-arm
+  "An update arm over a hand-built grid, in B6's arm shape. `write!` is
+  B6's `frame/replace-app-db!` verbatim; the only thing that varies across
+  the two rungs is which shell the leaf renders through and, for the
+  ablated rung, what `force!` has to do.
+
+  Both rungs' `force!` runs `cell/flush!` inside the `flushSync` before
+  draining. It is idempotent — the microtask closer has normally already
+  closed the window by then — and it is what makes the two rungs' windows
+  identical, so the pair's difference is the contract and not the drain."
+  [id leaf fid nc?]
+  {:id      id
+   :mount   (fn [container]
+              (ensure-frame! fid rows/cells-n)
+              (let [r (react-dom-client/createRoot container)]
+                (react-dom/flushSync (fn [] (.render r (grid-of leaf fid))))
+                r))
+   :write!  (fn [i val]
+              (if (= i :all)
+                (frame/replace-app-db! fid {:cells (vec (repeat rows/cells-n val))})
+                (frame/replace-app-db!
+                  fid (update (frame/frame-app-db-value fid) :cells assoc i val))))
+   :force!  (fn []
+              (react-dom/flushSync
+                (fn []
+                  (cell/flush!)
+                  (when nc? (drain!))
+                  nil)))
+   :unmount (fn [r] (react-dom/flushSync (fn [] (.unmount r))))})
+
+(defn make-update-arms
+  "B6's published arms, plus the two B9 rungs. The published arms are
+  re-taken in the same run so the anchor and the ablation share a box."
+  []
+  (conj (rows/make-update-arms)
+        (b9-update-arm :b9-ref cell-leaf-ref :b9-ref/grid false)
+        (b9-update-arm :b9-nc  cell-leaf-nc  :b9-nc/grid  true)))
+
+;; ===========================================================================
+;; 8. The sync-lane probe — the claim in the docstring, measured
+;; ===========================================================================
+
+(defn sync-lane-probe!
+  "Does a boundary WITHOUT `useSyncExternalStore` repaint inside an empty
+  `react-dom/flushSync`, the way `rf2-w2m25`'s synchronous commit door
+  promises?
+
+  Mounts one grid of each rung, writes, yields ONE microtask, runs an
+  EMPTY `flushSync` — B6's published window, with no drain — and reads the
+  written cell back out of the DOM. Answers a promise of
+  `{:ref <bool> :nc <bool>}`: whether each rung's DOM held the value that
+  was written.
+
+  This is a control, not a row. It costs two mounts and two writes, and it
+  is the difference between reporting a scheduling consequence and
+  asserting one."
+  []
+  (let [mk (fn [leaf fid]
+             (let [c (js/document.createElement "div")]
+               (.appendChild js/document.body c)
+               (ensure-frame! fid rows/cells-n)
+               (let [r (react-dom-client/createRoot c)]
+                 (react-dom/flushSync (fn [] (.render r (grid-of leaf fid))))
+                 {:container c :root r :fid fid})))
+        ref (mk cell-leaf-ref :b9-probe-ref/grid)
+        nc  (mk cell-leaf-nc  :b9-probe-nc/grid)
+        one (fn [{:keys [container fid]} val]
+              (frame/replace-app-db! fid {:cells (vec (repeat rows/cells-n val))})
+              (-> (js/Promise.resolve nil)
+                  (.then (fn [_]
+                           (react-dom/flushSync (fn [] nil))
+                           (= (str val) (rows/cell-text container 0))))))]
+    (-> (one ref 90001)
+        (.then (fn [ref-ok]
+                 (-> (one nc 90002)
+                     (.then (fn [nc-ok]
+                              (doseq [{:keys [container root]} [ref nc]]
+                                (react-dom/flushSync (fn [] (.unmount root)))
+                                (.remove container))
+                              {:ref ref-ok :nc nc-ok}))))))))


### PR DESCRIPTION
**Scaffolding + a report. `implementation/*/src` and `spec/` are untouched — `git diff origin/main -- implementation/core/src implementation/freehand/src spec` is empty. Invariant 5 is not dropped anywhere.**

Answers `rf2-so3io` (P0, operator-authorised): price the concurrent-store contract — `useSyncExternalStore` plus the commit-side invariant-5 re-read — on **clock and heap**, against the published arms, and establish whether the cheap path is separable.

## What comes back

The bead's hypothesis was that the two worst rows might be one row. **They are not**, and the way they are not is the useful part.

| axis | intact | ablated | return |
|---|---:|---:|---|
| broad update, ms/write | 3.4–4.1 fwd / 3.1–3.9 rev | 3.0–3.6 / 2.7–3.2 | **−13.6% / −14.8%, 12 of 12 paired rounds** |
| narrow update | 9.9–12.3 / 9.6–12.6 | 10.1–12.3 / 9.4–11.8 | **null** — direction flips between arm orders |
| mount, 300 boundaries | 0.9–1.1 / 0.8–1.1 | 0.9–1.0 / 0.8–1.0 | ≤0.1 ms — the clock quantum |
| retained heap, sub-free B/bnd | 2,416 / 2,431 | 2,041 / 2,062 | **−375 / −369 B**, ranges disjoint |
| retained heap, reactive B/bnd | 4,294 / 4,281 | 3,918 / 3,918 | **−376 / −363 B**, ranges disjoint |

An isolating rung — React's six hooks over a two-field JS object, no ViewCell — returns **355–357 B**, i.e. **95–97% of the whole heap return**. The commit-side re-read retains 8–20 B: nothing. And the sub-free mount pair (zero dependencies, so its commit loops over zero sites) bounds the hook half at ≤0.1 ms. **The heap return is the hook; the clock return is the commit.** Two levers, two axes, neither large.

A contract-free Freehand boundary is still **4.97–5.04× Reagent** on sub-free standing heap, **3.79–3.81×** on the reactive witness, **≈5.5×** on a broad write and **≈1.6×** on mount.

## Is the cheap path separable

The commit half is a branch (~12 lines in `cell.cljc`; the ~115 duplicated lines here are an artefact of privacy, not of design). The hook half is two component types keyed into `shell-signature`, plus a fork in `checkpoint.cljs`. **The decision is not separable at all**: nothing in re-frame2 can observe that a consumer used `startTransition`, `useDeferredValue` or `<Suspense>` — the only detector for an interrupted render is `useSyncExternalStore`, the thing being switched off. So the switch must be declared, its failure mode is a silent wrong render, and it cannot be per-boundary because a tear is not local.

## Two things measured rather than argued

- **`{:ref true, :nc false}`** — without `useSyncExternalStore` a boundary **cannot repaint inside `react-dom/flushSync`**. Its listener schedules at the sync lane; a `useReducer` dispatch from a microtask does not, and an empty `flushSync` flushes only that lane. `rf2-w2m25`'s synchronous commit door goes with the store unless the substrate rebuilds its own render queue.
- **The staged tear**, on a *watchable* browser host: a dependency moving in the render→commit gap on its **first** commit is corrected by **nothing** without invariant 5 — `obs/acquire!` installs the watch during that same commit, after the move. Revision does not advance, the cell is not dirty, and the stale value is published and painted. (A **retained** site self-heals one window late.) Spec 006 justifies invariant 5 on the headless case; the browser case is stronger than the spec claims.

## Method

No sixth instrument: B6's `timed-write!` window and B7's door/collector/readers/control, called unchanged, with additive `B6_INIT_FN` / `B7_INIT_FN` / `B7_ARMS` env seams (defaults byte-identical). Every row taken in **both arm orders**. Each pair carries a **reference rung** — same hand-built body, real shell, real commit — so the difference is the contract and nothing else; the published arms ride alongside in the same run.

Gates before any figure: canonical-DOM parity across 7 mount arms and 6 update arms in both orders; **0 unverified writes**; **0 unverified of 195 heap mounts**; positive control (587,500 unboxed doubles, 4,700,000 B predicted) within **0.061%** on reader A and **0.0005%** on the independent snapshot reader. The published heap rows reproduce to better than 1.2%.

## Gates

| gate | result | exit |
|---|---|---|
| `clojure -M:test` (implementation/freehand) | 1220 tests / 8225 assertions / 0 failures | 0 |
| PR #7143's two invariant-5 rows, by name | 2 tests / 11 assertions / 0 failures | 0 |
| `npm run test:cljs` | 11799 tests / 58740 assertions / 0 failures | 0 |
| `npm run test:browser` (`BROWSER_TEST_TIMEOUT_MS=600000`) | 833 tests / 5313 assertions / 0 failures | 0 |

Slower suites deferred to CI.

Report: `docs/design/freehand/studio/concurrent-store-ablation.md`. Raw data and working: `ai/findings/2026-07-27.concurrent-store-ablation-so3io.md` + `ai/findings/rf2-so3io-raw/` (local).