### PR TITLE
test(freehand): pin the staged invariant-5 case — the one that never self-heals (rf2-anmdr)

### DIFF
--- a/implementation/freehand/test/re_frame/freehand/shell_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/shell_cljs_test.cljc
@@ -723,10 +723,10 @@
            (is (= (:recorded-sites sub-007) (count (cell/candidate-reads cand)))))))))
 
 ;; ===========================================================================
-;; Invariant 5 — moved evidence corrects before paint, on the RETAINED set
+;; Invariant 5 — moved evidence corrects before paint
 ;; ===========================================================================
 ;;
-;; Spec 006 §The six frozen invariants, invariant 5. These two rows exist to
+;; Spec 006 §The six frozen invariants, invariant 5. These rows exist to
 ;; make one failure mode LOUD: a commit that stops re-reading a retained
 ;; dependency — because every site kept its query, its target and its handle,
 ;; so re-reading looks like work worth skipping — is not faster, it is torn.
@@ -740,6 +740,17 @@
 ;; degenerates into always correcting. The real-port row does the same over
 ;; the actual observation port and the actual sub-cache, because a mock can
 ;; drift away from the port it stands for.
+;;
+;; The last row is the STAGED half of the same law, and it is the half with
+;; nothing to fall back on (rf2-anmdr). A retained site's change watch was
+;; installed by an EARLIER commit, so on a host whose derived values ARE
+;; watchable a move the commit misses still self-heals one window later. A
+;; staged site's watch is installed by the very commit that needed it —
+;; after the move — so a commit that skips the comparison publishes the
+;; render's stale value and nothing is left to correct it. That difference is
+;; only visible on a watchable host, where `shell_tear_dom_cljs_test.cljs`
+;; measures it; this row pins the staged behaviour itself, over the same port
+;; and the same fixture as its siblings.
 
 (def ^:private tear-probe
   "What the RENDER probed: one live node, one identity, one version, one
@@ -835,6 +846,79 @@
             (is (> (cell/revision c) before)
                 "movement in the render→commit gap advanced the revision, so
                  the host corrects before paint")))))))
+
+(defn- staged-commit
+  "One FIRST commit of `q` over the REAL observation port and the REAL
+  sub-cache, with `move!` run in the render→commit gap.
+
+  The cell is fresh, so its prior committed set is EMPTY: there is no
+  handle to retain, and `obs/acquire!` — with whatever change watch that
+  acquire installs — runs DURING this commit, which is after `move!` has
+  already happened. That is what makes the site STAGED rather than
+  retained, and `:prior-set` reports it from the cell's own state rather
+  than from the shape of the calling code.
+
+  Answers `:probe` — whether the render found a live node or probed cold,
+  which is which axis the tear check compares — `:delta`, how far the
+  commit moved the revision, and `:published`, the value the bundle
+  carries."
+  [q move!]
+  (let [c      (cell/cell :shell/panel)
+        cand   (render! c fid [q])
+        prior  (cell/dependencies c)
+        probed (:node-version (:evidence (get (cell/candidate-reads cand) 0)))
+        before (cell/revision c)]
+    (move!)
+    (let [out {:commit    (cell/commit! cand)
+               :prior-set prior
+               :probe     (if (nil? probed) :cold :live)
+               :delta     (- (cell/revision c) before)
+               :published (:value (first (:observations (cell/evidence c))))}]
+      (cell/disconnect! c)
+      out)))
+
+(deftest invariant-5-a-real-node-moving-in-the-gap-corrects-a-staged-site
+  (testing "The row above's sibling, over the same real port and the same
+            real sub-cache, but on the site's FIRST commit. `obs/acquire!`
+            installs that site's change watch DURING this commit — after
+            the move — so on ANY host, watchable or not, no watch can have
+            fired about it. The commit's own re-read is the whole of the
+            guarantee here: skip it and the bundle publishes the render's
+            stale value with nothing left to correct it.
+
+            Both probe temperatures are exercised, because the check
+            compares a different axis on each. The first read of a node
+            anywhere probes COLD and the comparison falls back to `rf=` on
+            the value; a panel mounting over a node another boundary
+            already owns probes LIVE and the comparison rides the node
+            version. Each is paired with its UNMOVED control, so the row
+            fails both if the comparison stops happening and if it
+            degenerates into correcting unconditionally."
+    (rf/reg-sub :tear/staged (fn [db _] (:v db)))
+    (testing "cold probe — the first read of this node anywhere"
+      (seed! fid {:v 1})
+      (is (= {:commit :published :prior-set {} :probe :cold :delta 0 :published 1}
+             (staged-commit [:tear/staged :cold-control] (fn [] nil)))
+          "the control — nothing moved in the gap, so nothing is corrected")
+      (is (= {:commit :published :prior-set {} :probe :cold :delta 1 :published 2}
+             (staged-commit [:tear/staged :cold-moved] (fn [] (seed! fid {:v 2}))))
+          "the node moved in the gap, the bundle published what the COMMIT
+           read rather than what the render probed, and the revision
+           advanced so the host corrects before paint"))
+    (testing "live probe — a panel mounting over a node another boundary owns"
+      (seed! fid {:v 1})
+      (let [q     [:tear/staged :live]
+            owner (cell/cell :shell/other)]
+        (render+commit! owner fid [q])
+        (is (= {:commit :published :prior-set {} :probe :live :delta 0 :published 1}
+               (staged-commit q (fn [] nil)))
+            "the control — the node is live and unmoved, so nothing is corrected")
+        (is (= {:commit :published :prior-set {} :probe :live :delta 1 :published 2}
+               (staged-commit q (fn [] (seed! fid {:v 2}))))
+            "and a live node that moves in the gap is caught on the node
+             version axis, on a handle this commit acquired for the first
+             time")
+        (cell/disconnect! owner)))))
 
 ;; ===========================================================================
 ;; The shell's own value surface

--- a/implementation/freehand/test/re_frame/freehand/shell_tear_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/shell_tear_dom_cljs_test.cljs
@@ -1,0 +1,153 @@
+(ns re-frame.freehand.shell-tear-dom-cljs-test
+  "Invariant 5 on a WATCHABLE host — the one where the guarantee's worst
+  failure has no second channel (`rf2-anmdr`).
+
+  Spec 006 argues invariant 5 from the headless case: on a host whose
+  derived values are not watchable, a RETAINED site has no value-movement
+  watch, so the commit's own re-read is its only correction. That argument
+  is true and it is also the WEAKER half, because it stops applying the
+  moment the host does watch. `shell-cljs-test` carries the headless rows
+  over the plain-atom adapter, which is exactly that host.
+
+  This file asks the question the plain-atom fixture cannot. Its substrate
+  is the React spine — the machinery behind every shipped React-family
+  adapter — whose derived values reify `IWatchable`, so a committed site
+  really is notified when its source moves. On that host a retained site
+  that a commit fails to correct still self-heals one window later, because
+  its watch was installed by an EARLIER commit and fires. A STAGED site
+  does not: `obs/acquire!` installs its watch DURING the commit that needed
+  it, which is after the move, so nothing fired and nothing is pending. The
+  boundary paints stale and stays stale until something else moves that
+  source — a panel mounting exactly as a permission drops, a user switches,
+  a record is redacted.
+
+  Measured side by side by the `rf2-so3io` ablation:
+
+      site      commit    revision advanced?  cell dirty?  published
+      retained  shipped   yes                 no           FRESH
+      retained  ablated   no                  YES          stale
+      staged    shipped   yes                 no           FRESH
+      staged    ablated   no                  NO           stale
+
+  The staged row is what this file pins, and the `dirty?` column is why it
+  needs this host: on an unwatchable one `dirty?` is trivially false
+  everywhere and says nothing. So the first test below establishes that
+  this host DOES watch a committed site, and only then does the second read
+  a clean cell as evidence that invariant 5 was the only channel there was.
+
+  No DOM and no React tree — the host under test is the SUBSTRATE, and
+  mounting a boundary would add nothing this asks about. The file rides the
+  browser lane by its `-dom-cljs-test` suffix because the browser is where
+  that substrate is the shipped reality; it runs unchanged under the node
+  suites, which install the same spine."
+  (:require [cljs.test :refer-macros [deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as react-substrate]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.freehand.cell :as cell]
+            [re-frame.live-frame :as live-frame]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture
+    {:adapter       react-substrate/adapter
+     :ambient-frame nil}))
+
+;; ---------------------------------------------------------------------------
+;; Seams. Each test builds its OWN frame: two arms sharing one frame id share
+;; its app-db, which silently couples them to each other's order (the fault
+;; `rf2-so3io`'s first tear probe hit).
+;; ---------------------------------------------------------------------------
+
+(def ^:private q [:tear/v])
+
+(defn- make-frame! [id db]
+  (live-frame/make-frame {:id id})
+  (frame/replace-app-db! id db)
+  id)
+
+(defn- render!
+  "One render pass of `c` bound to frame `f`: probe `q` and answer THIS
+  render's candidate. Nothing is acquired and nothing is published — that
+  is the commit's job, and the gap between the two is what these rows are
+  about."
+  [c f]
+  (let [cand (cell/candidate c f)]
+    (cell/with-capture cand (fn [] (cell/observe! q)))
+    cand))
+
+(defn- published [c]
+  (:value (first (:observations (cell/evidence c)))))
+
+;; ---------------------------------------------------------------------------
+;; The rows
+;; ---------------------------------------------------------------------------
+
+(deftest a-committed-site-on-this-host-really-is-watched
+  (testing "Host honesty, and the precondition for the row below. The
+            React-spine substrate's derived values are watchable, so the
+            change watch `obs/acquire!` installs at commit fires when the
+            source moves — with no commit involved and no render in
+            flight. That is the second channel a RETAINED site has and a
+            staged one does not, and without it on the board the next
+            test's clean cell would be trivially clean and would say
+            nothing at all."
+    (rf/reg-sub (first q) (fn [db _] (:v db)))
+    (let [f (make-frame! :anmdr.watched/frame {:v 1})
+          c (cell/cell :shell/watched)]
+      (is (= :published (cell/commit! (render! c f))))
+      (is (not (cell/dirty? c))
+          "a settled committed cell is clean")
+      (frame/replace-app-db! f {:v 2})
+      (is (cell/dirty? c)
+          "and moving its source marked it — the watch this site's own
+           commit installed fired, so this host notifies")
+      (cell/disconnect! c))))
+
+(deftest invariant-5-a-staged-site-moving-in-the-gap-has-no-second-channel
+  (testing "Per invariant 5, on the host that makes the staged case the
+            worse case. The site is committed for the FIRST time and its
+            source moves between the render's probe and the commit's read.
+
+            Its handle — and the change watch that handle carries — is
+            acquired by THIS commit, so the watch is installed after the
+            move it would have reported. The test above proves this host
+            would have marked the cell had a watch existed; here the cell
+            is clean before the commit and clean after it, which is the
+            ablation table's staged row: nothing was pending, nothing is
+            pending, and a commit that published the render's value would
+            have painted stale and stayed stale.
+
+            It does not. The bundle carries what the COMMIT read and the
+            revision advanced, so the host corrects before paint — and
+            that comparison is the only reason it does."
+    (rf/reg-sub (first q) (fn [db _] (:v db)))
+    (let [f      (make-frame! :anmdr.staged/frame {:v 1})
+          c      (cell/cell :shell/staged)
+          cand   (render! c f)
+          before (cell/revision c)]
+      (is (empty? (cell/dependencies c))
+          "the site is STAGED, not retained: this cell has no prior
+           committed set, so there is no handle to keep and `obs/acquire!`
+           must run inside the commit below")
+      ;; THE GAP: the source moves after this render probed it and before
+      ;; the commit reads it.
+      (frame/replace-app-db! f {:v 2})
+      (is (not (cell/dirty? c))
+          "and the move left NO mark — there was no watch yet to fire, so
+           the ordinary notification channel is not going to correct this")
+      (is (= :published (cell/commit! cand)))
+      (is (= 1 (count (cell/dependencies c)))
+          "the commit acquired the handle it published, which is when the
+           watch was installed — one move too late to have reported it")
+      (is (= 2 (published c))
+          "the bundle published what the COMMIT read, not what the render
+           probed")
+      (is (= (inc before) (cell/revision c))
+          "the commit's own comparison advanced the revision, so the host
+           corrects before paint")
+      (is (not (cell/dirty? c))
+          "and the cell is still clean — no window is coming to fix this
+           one, which is what makes the comparison above load-bearing
+           rather than an optimisation of one")
+      (cell/disconnect! c))))


### PR DESCRIPTION
Closes rf2-anmdr.

PR #7143 added the repo's only invariant-5 coverage — two rows, and **both are the RETAINED case**: each site was committed once before, so its change watch was already installed by that earlier commit. PR #7159's ablation then measured the two cases side by side and found the uncovered one is strictly worse:

| site | commit | revision advanced? | cell dirty? | published |
|---|---|---|---|---|
| retained | shipped | yes | no | FRESH |
| retained | ablated | no | **YES** | stale |
| staged | shipped | yes | no | FRESH |
| staged | ablated | no | **NO** | stale |

`obs/acquire!` installs a site's change watch **during** the commit that needed it. A retained site whose source moves in the render→commit gap therefore self-heals one window later even if the commit skips the comparison — its watch was installed earlier, and it fires. A **staged** site — the first render of a dependency — does not: the watch arrives one move too late, so the bundle publishes the render's stale value, nothing is marked, and **nothing ever corrects it**. A panel mounting exactly as a permission drops, a user switches, a record is redacted.

The shipped code is correct here. It just had no tripwire, and the ablation established that a tear-skipping shortcut "would have been silently correct against every other test in the repository". These rows are that tripwire. **Test only — no production source is touched.**

## What was added

**`shell_cljs_test.cljc`** — `invariant-5-a-real-node-moving-in-the-gap-corrects-a-staged-site`, beside its two siblings, over the same real observation port, the same real sub-cache and the same fixture. Both probe temperatures, because the check compares a different axis on each:

- **cold probe** — the first read of that node anywhere. `:node-version` is nil, so `moved?` falls back to `rf=` on the value.
- **live probe** — a panel mounting over a node another boundary already owns. The comparison rides the node version, on a handle *this* commit acquired for the first time.

Each is paired with its UNMOVED control, so the row fails both if the comparison stops happening and if it degenerates into correcting unconditionally.

**`shell_tear_dom_cljs_test.cljs`** (new) — the same law on a **watchable** host, which is the only place the staged/retained distinction is observable. Its substrate is the React spine (via the UIx adapter), whose derived values reify `IWatchable`. No DOM and no React tree: the host under test is the *substrate*, and mounting a boundary would add nothing this asks about — which also keeps it clear of the layout-cleanup-before-passive-unsubscribe ordering fault `rf2-oob3g`'s hooks rung hit. Two rows:

- `a-committed-site-on-this-host-really-is-watched` — host honesty, and the precondition for the row below. Moving a **committed** site's source marks the cell with no commit involved. Without this on the board, the staged row's `dirty?` assertions would be trivially true and would say nothing.
- `invariant-5-a-staged-site-moving-in-the-gap-has-no-second-channel` — the staged row: FRESH value published, revision advanced, and the cell clean both before and after, i.e. the ablation table's staged line.

Each test builds its **own frame** — two arms sharing one frame id share its app-db, which silently couples them to each other's order (the fault the first tear probe hit).

## How I established I hit the STAGED path, not the retained one

From the cell's own state, not from the shape of the calling code:

- the `.cljc` helper captures `(cell/dependencies c)` **before** the commit and asserts it is `{}` in every arm (`:prior-set {}` is part of the compared map). An empty prior committed set means there is no handle to retain, so the handle in the published bundle was necessarily acquired by this commit.
- the browser row asserts `(empty? (cell/dependencies c))` before the commit and `(= 1 (count (cell/dependencies c)))` after it — the acquire, and therefore the watch install, happened inside the commit under test.
- the browser row additionally asserts `(not (cell/dirty? c))` immediately after the move and before the commit: the move produced **no mark at all**, which is only true because no watch existed yet. The companion test proves this same host *does* mark a committed site, so that clean read is evidence rather than a tautology.

Contrast with #7143's rows, which assert `(identical? h0 (:handle (get (cell/dependencies c) 0)))` — the same handle, never re-acquired. Opposite fact, deliberately.

## Mutation evidence

Ablation applied to `cell/commit-readings` in `cell.cljc` — exactly `b9_nc/nc-observations`: drop the `(obs/read handle)`, publish `(:value record)` (the render's probe) and never compare. **Reverted afterwards; `git diff --stat` clean, and this branch touches no production file.**

`clojure -M:test` (freehand), the three invariant-5 rows by name — **exit 1, 8 failures**:

```
FAIL in (invariant-5-a-real-node-moving-in-the-gap-corrects-a-staged-site) (shell_cljs_test.cljc:903)
  cold probe — the first read of this node anywhere
  expected: {:commit :published, :prior-set {}, :probe :cold, :delta 1, :published 2}
    actual: {:commit :published, :prior-set {}, :probe :cold, :delta 0, :published 1}

FAIL in (invariant-5-a-real-node-moving-in-the-gap-corrects-a-staged-site) (shell_cljs_test.cljc:916)
  live probe — a panel mounting over a node another boundary owns
  expected: {:commit :published, :prior-set {}, :probe :live, :delta 1, :published 2}
    actual: {:commit :published, :prior-set {}, :probe :live, :delta 0, :published 1}
```

`npm run test:browser` — **exit 1, and exactly 2 failures in the whole 835-test suite, both mine**:

```
FAIL in (invariant-5-a-staged-site-moving-in-the-gap-has-no-second-channel) (shell_tear_dom_cljs_test.cljs:143:11)
  the bundle published what the COMMIT read, not what the render probed
  expected: (= 2 (published c))
    actual: (not (= 2 1))

FAIL in (invariant-5-a-staged-site-moving-in-the-gap-has-no-second-channel) (shell_tear_dom_cljs_test.cljs:146:11)
  the commit's own comparison advanced the revision, so the host corrects before paint
  expected: (= (inc before) (cell/revision c))
    actual: (not (= 1 0))
```

That "2 failures out of 835" is itself the finding: before this PR the browser lane had **no** invariant-5 tripwire at all. Both `dirty?` assertions stayed green under ablation, which is the point — the ablated staged case is stale, uncorrected **and** unmarked. Nothing was ever going to fix it.

The unmoved controls stayed green under ablation in both files, so neither row is passing by correcting unconditionally.

#7143's two rows also red under the same ablation (`{:delta 0}` on every axis; `(not (= 2 1))` on the real-port row) and are green on restore — they were run by name in every gate below.

## Quality gates

Run from `implementation/` in the worker worktree, foreground, exit codes echoed.

| gate | exit |
|---|---|
| `clojure -M:test` (implementation/freehand, full JVM artefact) | **0** — Ran 1221 tests, 8229 assertions, 0 failures |
| `clojure -M:test -v …` — #7143's two rows + the new staged row by name | **0** — Ran 3 tests, 15 assertions, 0 failures |
| `npm run test:freehand` (node CLJS, freehand artefact) | **0** — Ran 1302 tests, 7219 assertions, 0 failures |
| `npm run test:cljs` (full node CLJS suite) | **0** — Ran 11802 tests, 58754 assertions, 0 failures |
| `BROWSER_TEST_TIMEOUT_MS=600000 npm run test:browser` | **0** — Ran 835 tests, 5323 assertions, 0 failures |
| mutation proof — ablated JVM focused run | **1** (intended; detail above) |
| mutation proof — ablated `npm run test:browser` | **1** (intended; detail above) |
| post-restore focused JVM run | **0** |
| post-restore `npm run test:browser` | **0** |

Both new namespaces were confirmed compiled into the builds that ran them (`out/browser-test/js/cljs-runtime/re_frame.freehand.shell_tear_dom_cljs_test.js`, and present in `out/node-test-freehand.js`), so neither gate passed by silently skipping them.

Slower gates — the full JVM implementation sweep, tools artefacts, and the rigorous local sweep — **deferred to CI**.

## Reported, not changed

`spec/**` is hot zone, so this is filed rather than edited: **rf2-locmf**. Spec 006's invariant 5 justifies the comparison only in the retained/headless direction — "a staged-only comparison would leave a retained site's headless movement caught by nothing". True, and narrower than the guarantee: it leaves a reader able to conclude that invariant 5 is a headless-only concession, when the staged case makes it load-bearing on a watchable host too. No behaviour disagrees with the spec; only its justification is incomplete.

No production seam was needed and none was added.
