### PR TITLE
test(freehand): one mounted lifecycle helper for the three DOM suites (rf2-n9rzw)

### DIFF
--- a/implementation/freehand/test/re_frame/freehand/behavior_async_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/behavior_async_dom_cljs_test.cljs
@@ -141,12 +141,11 @@
   unhandled-rejection notification as its own task, so hopping to that task
   is the only way to read the door at all. Every settle in this file is
   still an explicit call."
-  (:require ["react" :as react]
-            ["react-dom/client" :as rdc]
-            [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.freehand :as v]
             [re-frame.freehand.behaviors :as behaviors]
+            [re-frame.freehand.mount-support :as ms]
             [re-frame.freehand.react :as fr]
             [re-frame.freehand.shell :as shell]
             [re-frame.live-frame :as live-frame]
@@ -157,7 +156,12 @@
   (test-support/make-reset-runtime-fixture
     {:adapter       plain-atom/adapter
      :ambient-frame nil
-     :async?        true}))
+     :async?        true
+     ;; Scope the shared lifecycle ledger to this case. Bookkeeping only —
+     ;; it forgets what the previous case mounted and tears nothing down,
+     ;; which is what lets `ms/residue-clean!` report a retained root AFTER
+     ;; a case rather than a reset swallowing it before the next.
+     :init-fn       (fn [] (ms/reset-ledger!))}))
 
 (def ^:private frame-id :dom/behavior-async)
 
@@ -435,37 +439,28 @@
 ;; Harness
 ;; ---------------------------------------------------------------------------
 
-(defn- browser? []
-  (and (exists? js/document) (some? (.-createElement js/document))))
-
-(defn- skip! [why]
-  (is true (str "a real React mount needs a DOM host — " why)))
-
-(defn- act
-  "A React 19 `act` boundary as a promise, so assertions run after the
-  commit AND its flushed effects rather than racing them."
-  [thunk]
-  (try
-    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
-    (js/Promise.resolve (react/act (fn [] (js/Promise.resolve (thunk)))))
-    (catch :default e
-      (js/Promise.reject e))))
+;; The mounted LIFECYCLE — the `act` boundary, the `[container root]` pair
+;; and the teardown — comes from `re-frame.freehand.mount-support`, the one
+;; facade the browser tier shares (rf2-n9rzw). This file used to carry its
+;; own byte-identical copy of each.
 
 (defn- mount!
-  "A React root. With `watch-errors?` the root carries its OWN error
-  callbacks, so a throw React would otherwise hand to `reportError` — which
-  the browser lane counts as an uncaught page error and fails the run on —
-  arrives in `escapes` where a case can assert on it instead."
+  "A root through the shared lifecycle. With `watch-errors?` it carries its
+  OWN error callbacks, so a throw React would otherwise hand to
+  `reportError` — which the browser lane counts as an uncaught page error
+  and fails the run on — arrives in `escapes` where a case can assert on it
+  instead.
+
+  Only the callbacks are this suite's; the root, the container and the
+  enrolment in the residue ledger are the facade's."
   ([] (mount! false))
   ([watch-errors?]
-   (let [container (js/document.createElement "div")
-         opts      (when watch-errors?
-                     #js {:onUncaughtError (fn [e _info]
-                                             (swap! escapes conj [:react/uncaught (ex-message e)]))
-                          :onCaughtError   (fn [e _info]
-                                             (swap! escapes conj [:react/caught (ex-message e)]))})]
-     (.appendChild js/document.body container)
-     [container (rdc/createRoot container opts)])))
+   (ms/create-root!
+     (when watch-errors?
+       {:on-uncaught-error (fn [e _info]
+                             (swap! escapes conj [:react/uncaught (ex-message e)]))
+        :on-caught-error   (fn [e _info]
+                             (swap! escapes conj [:react/caught (ex-message e)]))}))))
 
 (defn- watch-rejections!
   "Open the page's `unhandledrejection` door for one case and answer the
@@ -500,11 +495,6 @@
   (if (or (seq @escapes) (zero? n))
     (js/Promise.resolve nil)
     (.then (task-boundary) (fn [_] (await-escape (dec n))))))
-
-(defn- teardown! [container root]
-  (.unmount root)
-  (.remove container)
-  nil)
 
 (defn- element [form]
   (shell/provide-frame frame-id (fr/element form)))
@@ -544,6 +534,21 @@
   (is (= {} @live)          (str where " — the library holds NO undisposed instance"))
   (owner-released! where))
 
+(defn- released!
+  "[[nothing-survived!]]'s three books, read through the SHARED lifecycle's
+  residue assertion — the terminal form of every case that unmounts.
+
+  It reads the same three absences, and adds the one no per-suite teardown
+  can make: that every ROOT this case created was torn down and left its
+  container empty and detached. That is the leak which contaminates every
+  later suite in the process rather than only this one, and it is the
+  assertion FH-BEHAVIOR-005's `:residue :none` rests on (rf2-n9rzw)."
+  [where]
+  (ms/residue-clean! where
+                     [["the library's undisposed-instance ledger" #(deref live)]
+                      ["the connection table"  #(behaviors/connection-count)]
+                      ["the live target index" #(behaviors/target-ids)]]))
+
 (defn- owner-phase
   "The phase of the one owner cell this case's `:connect` established."
   []
@@ -560,19 +565,19 @@
             with the desired spec; unmount releases it EXACTLY once. The
             CONTROL mount first proves the counters read zero for markup
             that never connected, so the zero at the end is a release."
-    (if-not (browser?)
-      (skip! "the browser job owns the acquisition cases")
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job owns the acquisition cases")
       (async done
         (setup!)
         (let [[cc croot]       (mount!)
               [container root] (mount!)]
-          (-> (act #(.render croot (element [control-panel {}])))
+          (-> (ms/act #(.render croot (element [control-panel {}])))
               (.then (fn [_]
                        (is (= [] @ops) "the CONTROL mount asks the library for nothing")
                        (nothing-survived! "control mounted")
-                       (act #(teardown! cc croot))))
+                       (ms/act #(ms/destroy-root! cc croot))))
 
-              (.then (fn [_] (act #(.render root (element [chart-panel {:series [1 2]}])))))
+              (.then (fn [_] (ms/act #(.render root (element [chart-panel {:series [1 2]}])))))
               (.then (fn [_]
                        (is (= [[:acquire 1 [1 2]]] @ops)
                            "the commit asked for ONE construction and nothing more")
@@ -589,12 +594,12 @@
                        (is (= [[:chart/ready :main]] (events)))
                        (is (= [true] (accepted))
                            "and the LIVE connection's fenced dispatch was accepted")
-                       (act #(teardown! container root))))
+                       (ms/act #(ms/destroy-root! container root))))
 
               (.then (fn [_]
                        (is (= [[:acquire 1 [1 2]] [:set-spec 1 [1 2]] [:dispose 1]] @ops)
                            "unmount released it, exactly once")
-                       (nothing-survived! "after teardown")
+                       (released! "FH-BEHAVIOR-005 — after teardown")
                        (done)))
               (.catch (fn [e] (is false (str "mount rejected: " e)) (done)))))))))
 
@@ -620,17 +625,17 @@
 
             `:disconnect` still ran exactly once: a pending connection is a
             connection."
-    (if-not (browser?)
-      (skip! "the browser job owns the acquisition cases")
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job owns the acquisition cases")
       (async done
         (setup!)
         (let [[container root] (mount!)]
-          (-> (act #(.render root (element [chart-panel {:series [7]}])))
+          (-> (ms/act #(.render root (element [chart-panel {:series [7]}])))
               (.then (fn [_]
                        (is (= [[:acquire 1 [7]]] @ops))
                        (is (= 1 (behaviors/connection-count)))
                        ;; UNMOUNT while the acquisition is still in flight.
-                       (act #(teardown! container root))))
+                       (ms/act #(ms/destroy-root! container root))))
 
               (.then (fn [_]
                        (is (= [[:acquire 1 [7]]] @ops)
@@ -651,7 +656,7 @@
                        (is (= [false] (accepted))
                            "and its outward dispatch was REFUSED — the context is
                             fenced to a generation that is gone")
-                       (nothing-survived! "after the late arrival")
+                       (released! "FH-BEHAVIOR-005 — after the late arrival")
                        (done)))
               (.catch (fn [e] (is false (str "mount rejected: " e)) (done)))))))))
 
@@ -668,12 +673,12 @@
             state into the cell, and the arriving handle is configured ONCE
             with the latest — which is a fact about the cell, not a
             scheduling policy."
-    (if-not (browser?)
-      (skip! "the browser job owns the acquisition cases")
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job owns the acquisition cases")
       (async done
         (setup!)
         (let [[container root] (mount!)
-              render (fn [series] (act #(.render root (element [chart-panel {:series series}]))))]
+              render (fn [series] (ms/act #(.render root (element [chart-panel {:series series}]))))]
           (-> (render [1])
               (.then (fn [_] (render [1 2])))
               (.then (fn [_] (render [1 2 3])))
@@ -692,10 +697,10 @@
               (.then (fn [_]
                        (is (= [[:acquire 1 [1]] [:set-spec 1 [1 2 3]] [:set-spec 1 [9]]] @ops)
                            "once ready, a movement is an ordinary host call")
-                       (act #(teardown! container root))))
+                       (ms/act #(ms/destroy-root! container root))))
               (.then (fn [_]
                        (is (= [:dispose 1] (last @ops)) "and it still releases once")
-                       (nothing-survived! "after teardown")
+                       (released! "FH-BEHAVIOR-005 — after teardown")
                        (done)))
               (.catch (fn [e] (is false (str "mount rejected: " e)) (done)))))))))
 
@@ -717,13 +722,13 @@
             re-enter a live phase, and the next thing to read the phase
             would believe the connection was merely broken rather than
             gone."
-    (if-not (browser?)
-      (skip! "the browser job owns the acquisition cases")
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job owns the acquisition cases")
       (async done
         (setup!)
         (let [[container root] (mount!)]
-          (-> (act #(.render root (element [chart-panel {:series [4]}])))
-              (.then (fn [_] (act #(teardown! container root))))
+          (-> (ms/act #(.render root (element [chart-panel {:series [4]}])))
+              (.then (fn [_] (ms/act #(ms/destroy-root! container root))))
               (.then (fn [_] (settle! 0 :fail)))
               (.then (fn [_]
                        (is (= [[:acquire 1 [4]]] @ops)
@@ -734,7 +739,7 @@
                             has already settled the connection is terminal")
                        (is (= [false] (accepted))
                            "and its dispatch was refused, because the view is gone")
-                       (nothing-survived! "after the late rejection")
+                       (released! "FH-BEHAVIOR-005 — after the late rejection")
                        (done)))
               (.catch (fn [e] (is false (str "mount rejected: " e)) (done)))))))))
 
@@ -750,14 +755,14 @@
             second half is the assertion that matters: when the handle
             arrives, the refused export must NOT run. A queue here would fire
             an export the user asked for and gave up on."
-    (if-not (browser?)
-      (skip! "the browser job owns the acquisition cases")
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job owns the acquisition cases")
       (async done
         (setup!)
         (let [[container root] (mount!)]
-          (-> (act #(.render root (element [chart-panel {:series [5]}])))
+          (-> (ms/act #(.render root (element [chart-panel {:series [5]}])))
               (.then (fn [_]
-                       (act #(rf/dispatch-sync [:chart/command {:target :chart/main
+                       (ms/act #(rf/dispatch-sync [:chart/command {:target :chart/main
                                                                 :op     :export}]
                                                {:frame frame-id}))))
               (.then (fn [_]
@@ -777,17 +782,17 @@
                        (is (= [[:chart/export-refused :pending] [:chart/ready :main]]
                               (events)))
                        ;; the same command, now that there IS a host
-                       (act #(rf/dispatch-sync [:chart/command {:target :chart/main
+                       (ms/act #(rf/dispatch-sync [:chart/command {:target :chart/main
                                                                 :op     :export}]
                                                {:frame frame-id}))))
               (.then (fn [_]
                        (is (= [:export 1] (last @ops))
                            "once ready the very same command reaches the host")
                        (is (= [:chart/exported "png:1"] (last (events))))
-                       (act #(teardown! container root))))
+                       (ms/act #(ms/destroy-root! container root))))
               (.then (fn [_]
                        (is (= [:dispose 1] (last @ops)))
-                       (nothing-survived! "after teardown")
+                       (released! "FH-BEHAVIOR-005 — after teardown")
                        (done)))
               (.catch (fn [e] (is false (str "mount rejected: " e)) (done)))))))))
 
@@ -818,14 +823,14 @@
             boundary the recipe can honestly claim: everything the owner
             controls is released; a handle the library will not release is
             not one of those things."
-    (if-not (browser?)
-      (skip! "the browser job owns the acquisition cases")
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job owns the acquisition cases")
       (async done
         (setup!)
         ;; BOTH doors open, so "which one read" is a measurement.
         (let [close-door       (watch-rejections!)
               [container root] (mount! :watch-errors)]
-          (-> (act #(.render root (element [chart-panel {:series [6]}])))
+          (-> (ms/act #(.render root (element [chart-panel {:series [6]}])))
               (.then (fn [_] (settle! 0 :ok)))
               (.then (fn [_]
                        (is (= [[:acquire 1 [6]] [:set-spec 1 [6]]] @ops)
@@ -834,7 +839,7 @@
                        (is (= :ready (owner-phase)))
                        ;; ARM the failure only now, so it lands on the FIRST release.
                        (reset! brittle #{1})
-                       (-> (act #(teardown! container root))
+                       (-> (ms/act #(ms/destroy-root! container root))
                            (.catch (fn [e]
                                      (swap! escapes conj [:act/rejected (ex-message e)])
                                      nil)))))
@@ -888,15 +893,15 @@
             The owner's side is unchanged and still perfect: `:closed`
             before the handle ever arrived, connection table and target
             index already empty, exactly one release attempted."
-    (if-not (browser?)
-      (skip! "the browser job owns the acquisition cases")
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job owns the acquisition cases")
       (async done
         (setup!)
         ;; BOTH doors open, so "which one read" is a measurement.
         (let [close-door       (watch-rejections!)
               [container root] (mount! :watch-errors)]
-          (-> (act #(.render root (element [chart-panel {:series [7]}])))
-              (.then (fn [_] (act #(teardown! container root))))
+          (-> (ms/act #(.render root (element [chart-panel {:series [7]}])))
+              (.then (fn [_] (ms/act #(ms/destroy-root! container root))))
               (.then (fn [_]
                        (is (= :closed (owner-phase))
                            "torn down while pending — the owner is already terminal")

--- a/implementation/freehand/test/re_frame/freehand/behaviors_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/behaviors_dom_cljs_test.cljs
@@ -33,7 +33,6 @@
   also matches the node suites' broader regex, where it has no DOM to mount
   and says so rather than passing quietly."
   (:require ["react" :as react]
-            ["react-dom/client" :as rdc]
             [cljs.test :refer-macros [async deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             ;; The DOOR, required alongside the internal namespace on
@@ -44,6 +43,7 @@
             [re-frame.freehand.behavior-views :as bv]
             [re-frame.freehand.behaviors :as behaviors]
             [re-frame.freehand.conformance :as conf]
+            [re-frame.freehand.mount-support :as ms]
             [re-frame.freehand.react :as fr]
             [re-frame.freehand.shell :as shell]
             [re-frame.live-frame :as live-frame]
@@ -54,7 +54,12 @@
   (test-support/make-reset-runtime-fixture
     {:adapter       plain-atom/adapter
      :ambient-frame nil
-     :async?        true}))
+     :async?        true
+     ;; Scope the shared lifecycle ledger to this test. Bookkeeping only —
+     ;; it forgets what the previous test mounted and tears nothing down, so
+     ;; `ms/residue-clean!` reads a leak AFTER a test rather than a reset
+     ;; hiding one before the next.
+     :init-fn       (fn [] (ms/reset-ledger!))}))
 
 (def ^:private fh-004 (conf/fixture :FH-BEHAVIOR-004))
 (def ^:private fh-005 (conf/fixture :FH-BEHAVIOR-005))
@@ -71,31 +76,26 @@
   rather than a description."
   :dom/behaviors-other)
 
-(defn- browser? []
-  (and (exists? js/document) (some? (.-createElement js/document))))
+;; The mounted LIFECYCLE — the `act` boundary, the `[container root]` pair
+;; and the teardown — comes from `re-frame.freehand.mount-support`, the one
+;; facade the browser tier shares (rf2-n9rzw). This file used to carry its
+;; own byte-identical copy of each.
 
-(defn- skip! [why]
-  (is true (str "a real React mount needs a DOM host — " why)))
+(defn- released!
+  "FH-BEHAVIOR-005's absence, read AFTER teardown: the facade's own books
+  (every root retired, its container empty and detached) plus the
+  substrate's two — the connection table and the live target index — as
+  EXACT zeros rather than thresholds.
 
-(defn- act
-  "A React 19 `act` boundary as a promise, so assertions run after the
-  commit AND its flushed effects rather than racing them."
-  [thunk]
-  (try
-    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
-    (js/Promise.resolve (react/act (fn [] (js/Promise.resolve (thunk)))))
-    (catch :default e
-      (js/Promise.reject e))))
-
-(defn- mount! []
-  (let [container (js/document.createElement "div")]
-    (.appendChild js/document.body container)
-    [container (rdc/createRoot container)]))
-
-(defn- teardown! [container root]
-  (.unmount root)
-  (.remove container)
-  nil)
+  The rows below already compare those two books against the fixture's
+  stated `:after-teardown` answers, which is what earns the claim. This
+  adds the half no per-suite teardown can make: that the ROOT itself went,
+  which is the leak that contaminates every later suite in the process
+  rather than this one."
+  [where]
+  (ms/residue-clean! where
+                     [["the connection table"  #(behaviors/connection-count)]
+                      ["the live target index" #(behaviors/target-ids)]]))
 
 (defn- setup! []
   (behaviors/reset-connections!)
@@ -159,13 +159,13 @@
             the candidate really runs and really never commits: the lifecycle
             transcript must be empty and the connection table must be zero.
             The same tree, committed, then connects exactly once."
-    (if-not (browser?)
-      (skip! "the browser job runs the commit-only assertions")
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the commit-only assertions")
       (async done
         (setup!)
         (reset! suspender-renders 0)
-        (let [[container root] (mount!)]
-          (-> (act #(.render root (probe-element true)))
+        (let [[container root] (ms/create-root!)]
+          (-> (ms/act #(.render root (probe-element true)))
               (.then (fn [_]
                        (is (pos? @suspender-renders)
                            "the candidate really rendered — it reached the suspending sibling")
@@ -175,18 +175,18 @@
                            "so NOTHING connected")
                        (is (zero? (behaviors/connection-count))
                            "and the connection table is empty")
-                       (act #(.render root (probe-element false)))))
+                       (ms/act #(.render root (probe-element false)))))
               (.then (fn [_]
                        (is (= (:committed fh-004) (bv/ops))
                            "the COMMITTED render connects, exactly once")
                        (is (= 1 (behaviors/connection-count)))
                        (is (= #{:probe/one} (behaviors/target-ids))
                            "and claims the semantic id the use site declared")
-                       (teardown! container root)
+                       (ms/destroy-root! container root)
                        (done)))
               (.catch (fn [e]
                         (is false (str "mount rejected: " e))
-                        (teardown! container root)
+                        (ms/destroy-root! container root)
                         (done)))))))))
 
 (deftest fh-behavior-004-update-observes-movement-not-renders
@@ -196,20 +196,20 @@
             scroll offset for no reason at all — so a re-render carrying an
             equal config must leave the transcript untouched, and a moved one
             must arrive with both the new config and the previous one."
-    (if-not (browser?)
-      (skip! "the browser job runs the update assertions")
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the update assertions")
       (async done
         (setup!)
-        (let [[container root] (mount!)]
-          (-> (act #(.render root (element [bv/plain {:label "a"}])))
+        (let [[container root] (ms/create-root!)]
+          (-> (ms/act #(.render root (element [bv/plain {:label "a"}])))
               (.then (fn [_]
                        (is (= (:committed fh-004) (bv/ops)))
                        ;; an equal config, rendered again
-                       (act #(.render root (element [bv/plain {:label "a"}])))))
+                       (ms/act #(.render root (element [bv/plain {:label "a"}])))))
               (.then (fn [_]
                        (is (= (:equal-config fh-004) (bv/ops))
                            "an rf=-equal config is not movement")
-                       (act #(.render root (element [bv/plain {:label "moved"}])))))
+                       (ms/act #(.render root (element [bv/plain {:label "moved"}])))))
               (.then (fn [_]
                        (is (= (:moved-config fh-004) (bv/ops))
                            "a moved config reconciles the host, once")
@@ -219,11 +219,11 @@
                              "with the previous config alongside the new one")
                          (is (= (:memory (:moved fh-004)) memory)
                              "and the private memory :connect returned"))
-                       (teardown! container root)
+                       (ms/destroy-root! container root)
                        (done)))
               (.catch (fn [e]
                         (is false (str "mount rejected: " e))
-                        (teardown! container root)
+                        (ms/destroy-root! container root)
                         (done)))))))))
 
 (deftest fh-behavior-004-layout-timing-runs-before-passive
@@ -233,12 +233,12 @@
             transcript in document order would prove the timing was ignored.
             The layout connection must come first, and its DOM write must be
             visible on the node."
-    (if-not (browser?)
-      (skip! "the browser job runs the timing assertions")
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the timing assertions")
       (async done
         (setup!)
-        (let [[container root] (mount!)]
-          (-> (act #(.render root (element [bv/mixed-timing {}])))
+        (let [[container root] (ms/create-root!)]
+          (-> (ms/act #(.render root (element [bv/mixed-timing {}])))
               (.then (fn [_]
                        (is (= (:timing-order fh-004) (mapv :behavior @bv/transcript))
                            "the declared timing overrides document order")
@@ -246,11 +246,11 @@
                          (is (= value (attr container ".node[data-id='layout']" attribute))
                              "and the layout behavior's DOM write is on its node"))
                        (is (= 2 (behaviors/connection-count)))
-                       (teardown! container root)
+                       (ms/destroy-root! container root)
                        (done)))
               (.catch (fn [e]
                         (is false (str "mount rejected: " e))
-                        (teardown! container root)
+                        (ms/destroy-root! container root)
                         (done)))))))))
 
 ;; ===========================================================================
@@ -268,13 +268,13 @@
             that was never written. `:disconnect` runs EXACTLY once — both
             timing arms are installed on every render, and only the arm that
             connected may release."
-    (if-not (browser?)
-      (skip! "the browser job runs the teardown assertions")
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the teardown assertions")
       (async done
         (setup!)
-        (let [[control-container control-root] (mount!)
-              [container root]                 (mount!)]
-          (-> (act #(.render control-root (element [bv/control-mount {}])))
+        (let [[control-container control-root] (ms/create-root!)
+              [container root]                 (ms/create-root!)]
+          (-> (ms/act #(.render control-root (element [bv/control-mount {}])))
               (.then (fn [_]
                        (let [{:keys [connections targets lifecycle]} (:control fh-005)]
                          (is (= connections (behaviors/connection-count))
@@ -283,17 +283,17 @@
                          (is (= lifecycle (bv/ops))))
                        (is (some? (.querySelector control-container ".node"))
                            "and it really did mount the same node")
-                       (act #(teardown! control-container control-root))))
+                       (ms/act #(ms/destroy-root! control-container control-root))))
               (.then (fn [_]
                        (is (= 0 (behaviors/connection-count))
                            "tearing the control down changes nothing either")
-                       (act #(.render root (element [bv/plain {}])))))
+                       (ms/act #(.render root (element [bv/plain {}])))))
               (.then (fn [_]
                        (let [{:keys [connections targets lifecycle]} (:mounted fh-005)]
                          (is (= connections (behaviors/connection-count)))
                          (is (= (set targets) (behaviors/target-ids)))
                          (is (= lifecycle (bv/ops))))
-                       (act #(teardown! container root))))
+                       (ms/act #(ms/destroy-root! container root))))
               (.then (fn [_]
                        (let [{:keys [connections targets lifecycle]} (:after-teardown fh-005)]
                          (is (= connections (behaviors/connection-count))
@@ -302,6 +302,10 @@
                              "and the live target index holds nothing")
                          (is (= lifecycle (bv/ops))
                              "with :disconnect having run exactly once"))
+                       ;; BOTH roots — the control and the behaving one —
+                       ;; are read here, which is what the shared ledger
+                       ;; buys over a per-suite teardown.
+                       (released! "FH-BEHAVIOR-005 — after the last unmount")
                        (done)))
               (.catch (fn [e]
                         (is false (str "mount rejected: " e))
@@ -313,21 +317,22 @@
             behavior must be released by the layout arm and by that arm only
             — a second release would show as a duplicate `:disconnect`, and a
             release by the wrong arm would show as none at all."
-    (if-not (browser?)
-      (skip! "the browser job runs the layout teardown assertions")
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the layout teardown assertions")
       (async done
         (setup!)
-        (let [[container root] (mount!)]
-          (-> (act #(.render root (element [bv/layout-timed {}])))
+        (let [[container root] (ms/create-root!)]
+          (-> (ms/act #(.render root (element [bv/layout-timed {}])))
               (.then (fn [_]
                        (is (= 1 (behaviors/connection-count)))
-                       (act #(teardown! container root))))
+                       (ms/act #(ms/destroy-root! container root))))
               (.then (fn [_]
                        (let [{:keys [connections targets lifecycle]}
                              (:layout-after-teardown fh-005)]
                          (is (= connections (behaviors/connection-count)))
                          (is (= (set targets) (behaviors/target-ids)))
                          (is (= lifecycle (bv/ops))))
+                       (released! "FH-BEHAVIOR-005 — after the layout arm releases")
                        (done)))
               (.catch (fn [e]
                         (is false (str "mount rejected: " e))
@@ -339,24 +344,25 @@
             and leaves the other's claim installed. A release keyed on the
             TARGET rather than the connection would be the same test with the
             survivor's claim missing."
-    (if-not (browser?)
-      (skip! "the browser job runs the partial-teardown assertions")
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the partial-teardown assertions")
       (async done
         (setup!)
-        (let [[container root] (mount!)]
-          (-> (act #(.render root (element [bv/pair {}])))
+        (let [[container root] (ms/create-root!)]
+          (-> (ms/act #(.render root (element [bv/pair {}])))
               (.then (fn [_]
                        (is (= 2 (behaviors/connection-count)))
                        (is (= #{:probe/one :probe/two} (behaviors/target-ids)))
-                       (act #(.render root (element [bv/plain {}])))))
+                       (ms/act #(.render root (element [bv/plain {}])))))
               (.then (fn [_]
                        (let [{:keys [connections targets]} (:partial-teardown fh-005)]
                          (is (= connections (behaviors/connection-count)))
                          (is (= (set targets) (behaviors/target-ids))
                              "the survivor's claim is untouched"))
-                       (act #(teardown! container root))))
+                       (ms/act #(ms/destroy-root! container root))))
               (.then (fn [_]
                        (is (zero? (behaviors/connection-count)))
+                       (released! "FH-BEHAVIOR-005 — after the survivor's own unmount")
                        (done)))
               (.catch (fn [e]
                         (is false (str "mount rejected: " e))
@@ -375,16 +381,16 @@
             named node carries the mark and the decoy carries nothing at all.
             It travels the real effect path, dispatched from an ordinary
             re-frame event handler."
-    (if-not (browser?)
-      (skip! "the browser job runs the command-delivery assertions")
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the command-delivery assertions")
       (async done
         (setup!)
-        (let [[container root] (mount!)
+        (let [[container root] (ms/create-root!)
               {:keys [command marked untouched lifecycle]} (:delivered fh-006)]
-          (-> (act #(.render root (element [bv/pair {}])))
+          (-> (ms/act #(.render root (element [bv/pair {}])))
               (.then (fn [_]
                        (is (= 2 (behaviors/connection-count)))
-                       (act #(rf/dispatch-sync [:probe/command command]
+                       (ms/act #(rf/dispatch-sync [:probe/command command]
                                                {:frame frame-id}))))
               (.then (fn [_]
                        (is (= lifecycle (bv/ops))
@@ -397,11 +403,11 @@
                            "and the live DECOY was untouched")
                        (is (= :probe/one (:target (last @bv/transcript)))
                            "the context carried the target it was addressed by")
-                       (teardown! container root)
+                       (ms/destroy-root! container root)
                        (done)))
               (.catch (fn [e]
                         (is false (str "mount rejected: " e))
-                        (teardown! container root)
+                        (ms/destroy-root! container root)
                         (done)))))))))
 
 (deftest fh-behavior-006-a-command-does-not-cross-into-another-frame
@@ -423,14 +429,14 @@
             process-wide at this instant, which is what makes an empty `:live`
             an assertion rather than an accident: naming it would offer a
             recovery the command could never have taken."
-    (if-not (browser?)
-      (skip! "the browser job runs the frame-scope assertions")
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the frame-scope assertions")
       (async done
         (setup!)
-        (let [[container root] (mount!)
+        (let [[container root] (ms/create-root!)
               {:keys [command outcome untouched lifecycle]}
               (:crossing (:frame-scope fh-006))]
-          (-> (act #(.render root (element-in decoy-frame-id [bv/plain {}])))
+          (-> (ms/act #(.render root (element-in decoy-frame-id [bv/plain {}])))
               (.then (fn [_]
                        (is (= 1 (behaviors/connection-count))
                            "the decoy frame really holds the only live claim")
@@ -455,11 +461,11 @@
                            "and the other frame's node was not touched")
                        (is (= lifecycle (bv/ops))
                            "no host work ran at all")
-                       (teardown! container root)
+                       (ms/destroy-root! container root)
                        (done)))
               (.catch (fn [e]
                         (is false (str "mount rejected: " e))
-                        (teardown! container root)
+                        (ms/destroy-root! container root)
                         (done)))))))))
 
 (deftest fh-behavior-006-one-target-per-frame-is-not-ambiguous
@@ -470,25 +476,25 @@
             refused. A process-global target index would collapse the pair and
             refuse both. Both commands travel the real effect path, so the frame
             they are scoped by is the one the fx context supplied."
-    (if-not (browser?)
-      (skip! "the browser job runs the per-frame delivery assertions")
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the per-frame delivery assertions")
       (async done
         (setup!)
-        (let [[container-a root-a] (mount!)
-              [container-b root-b] (mount!)
+        (let [[container-a root-a] (ms/create-root!)
+              [container-b root-b] (ms/create-root!)
               {:keys [per-frame lifecycle]} (:frame-scope fh-006)
               [origin decoy]                per-frame]
-          (-> (act #(.render root-a (element-in frame-id [bv/plain {}])))
-              (.then (fn [_] (act #(.render root-b (element-in decoy-frame-id
+          (-> (ms/act #(.render root-a (element-in frame-id [bv/plain {}])))
+              (.then (fn [_] (ms/act #(.render root-b (element-in decoy-frame-id
                                                                [bv/plain {}])))))
               (.then (fn [_]
                        (is (= 2 (behaviors/connection-count))
                            "two live connections, one per frame")
                        (is (= #{:probe/one} (behaviors/target-ids))
                            "claiming the SAME semantic target")
-                       (act #(rf/dispatch-sync [:probe/command (:command origin)]
+                       (ms/act #(rf/dispatch-sync [:probe/command (:command origin)]
                                                {:frame frame-id}))))
-              (.then (fn [_] (act #(rf/dispatch-sync [:probe/command (:command decoy)]
+              (.then (fn [_] (ms/act #(rf/dispatch-sync [:probe/command (:command decoy)]
                                                      {:frame decoy-frame-id}))))
               (.then (fn [_]
                        (doseq [[container {:keys [note marked]}]
@@ -499,13 +505,13 @@
                              note))
                        (is (= lifecycle (bv/ops))
                            "each command ran exactly once, and neither was refused")
-                       (teardown! container-a root-a)
-                       (teardown! container-b root-b)
+                       (ms/destroy-root! container-a root-a)
+                       (ms/destroy-root! container-b root-b)
                        (done)))
               (.catch (fn [e]
                         (is false (str "mount rejected: " e))
-                        (teardown! container-a root-a)
-                        (teardown! container-b root-b)
+                        (ms/destroy-root! container-a root-a)
+                        (ms/destroy-root! container-b root-b)
                         (done)))))))))
 
 (deftest fh-behavior-006-every-other-outcome-is-a-visible-refusal
@@ -515,14 +521,14 @@
             are driven at the channel itself rather than through the event
             loop, so the assertion is on the diagnostic the channel raises
             rather than on whatever an fx wrapper makes of it."
-    (if-not (browser?)
-      (skip! "the browser job runs the command-refusal assertions")
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the command-refusal assertions")
       (async done
         (setup!)
-        (let [[container root] (mount!)]
+        (let [[container root] (ms/create-root!)]
           (letfn [(step [remaining]
                     (if-let [{:keys [note view command outcome]} (first remaining)]
-                      (-> (act #(.render root (element [(case view
+                      (-> (ms/act #(.render root (element [(case view
                                                           :pair  bv/pair
                                                           :twins bv/twins)
                                                         {}])))
@@ -537,11 +543,11 @@
                       (js/Promise.resolve :done)))]
           (-> (step (:refusals fh-006))
               (.then (fn [_]
-                       (teardown! container root)
+                       (ms/destroy-root! container root)
                        (done)))
               (.catch (fn [e]
                         (is false (str "mount rejected: " e))
-                        (teardown! container root)
+                        (ms/destroy-root! container root)
                         (done))))))))))
 
 (deftest fh-behavior-006-a-command-is-refused-after-teardown-never-queued
@@ -550,20 +556,20 @@
             for a future mount — a queued imperative request would arrive at
             a node the application has since changed its mind about, and a
             future mount is driven by state and config or by a fresh event."
-    (if-not (browser?)
-      (skip! "the browser job runs the post-teardown assertions")
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the post-teardown assertions")
       (async done
         (setup!)
-        (let [[container root] (mount!)
+        (let [[container root] (ms/create-root!)
               {:keys [command outcome]} (:after-teardown fh-006)]
-          (-> (act #(.render root (element [bv/plain {}])))
+          (-> (ms/act #(.render root (element [bv/plain {}])))
               (.then (fn [_]
                        (is (= conf/no-throw
                               (conf/caught-id
                                 #(behaviors/command!
                                    frame-id {:target :probe/one :op :mark})))
                            "the command works while the connection is live")
-                       (act #(teardown! container root))))
+                       (ms/act #(ms/destroy-root! container root))))
               (.then (fn [_]
                        (is (= outcome (conf/caught-id
                                         #(behaviors/command! frame-id command)))
@@ -581,19 +587,19 @@
             must be INERT rather than firing into a successor. The suite holds
             the context past its own teardown, which is the only way to prove
             the fence rather than merely never exercise it."
-    (if-not (browser?)
-      (skip! "the browser job runs the fenced-dispatch assertions")
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the fenced-dispatch assertions")
       (async done
         (setup!)
-        (let [[container root] (mount!)
+        (let [[container root] (ms/create-root!)
               {:keys [event while-live after-teardown]} (:fenced-dispatch fh-006)]
-          (-> (act #(.render root (element [bv/plain {}])))
+          (-> (ms/act #(.render root (element [bv/plain {}])))
               (.then (fn [_]
                        (is (some? @bv/last-dispatch)
                            "connect handed the behavior an outward dispatch")
                        (is (= while-live (@bv/last-dispatch event))
                            "which is live while its connection is")
-                       (act #(teardown! container root))))
+                       (ms/act #(ms/destroy-root! container root))))
               (.then (fn [_]
                        (is (= after-teardown (@bv/last-dispatch event))
                            "and inert the moment the connection is released")
@@ -636,28 +642,28 @@
             step later; and the mutations are read off the instance's OWN cell,
             so the evidence is that the entries ran against the SAME instance
             rather than that some map happened to survive."
-    (if-not (browser?)
-      (skip! "the browser job runs the memory-ownership assertions")
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the memory-ownership assertions")
       (async done
         (setup!)
-        (let [[container root] (mount!)
+        (let [[container root] (ms/create-root!)
               {:keys [lifecycle instance mutations command moved]} fh-009
               memory-at (fn [op] (some #(when (= op (:op %)) (:memory %))
                                        @bv/transcript))]
-          (-> (act #(.render root (element [bv/mutating {}])))
+          (-> (ms/act #(.render root (element [bv/mutating {}])))
               (.then (fn [_]
                        (is (= 1 (behaviors/connection-count)))
                        ;; a MOVED config, so `:update` really runs
-                       (act #(.render root (element [bv/mutating moved])))))
+                       (ms/act #(.render root (element [bv/mutating moved])))))
               (.then (fn [_]
                        (is (= instance (:instance (memory-at :update)))
                            "`:update` receives the instance `:connect` built")
-                       (act #(rf/dispatch-sync [:probe/command command]
+                       (ms/act #(rf/dispatch-sync [:probe/command command]
                                                {:frame frame-id}))))
               (.then (fn [_]
                        (is (= instance (:instance (memory-at :mutate)))
                            "and so does the command, AFTER `:update` returned nothing")
-                       (act #(teardown! container root))))
+                       (ms/act #(ms/destroy-root! container root))))
               (.then (fn [_]
                        (is (= lifecycle (bv/ops))
                            "the whole lifecycle ran, in order")
@@ -671,7 +677,7 @@
                        (done)))
               (.catch (fn [e]
                         (is false (str "mount rejected: " e))
-                        (teardown! container root)
+                        (ms/destroy-root! container root)
                         (done)))))))))
 
 ;; ===========================================================================
@@ -696,15 +702,15 @@
             lifecycle entry and no route to a host instance, absent because
             the projection is built from the record's public half rather
             than filtered out of its whole."
-    (if-not (browser?)
-      (skip! "the browser job runs the projection assertions")
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the projection assertions")
       (async done
         (setup!)
-        (let [[container root]        (mount!)
+        (let [[container root]        (ms/create-root!)
               {:keys [present absent]} (:connection-keys fh-008)
               connected                (:connected fh-008)
               no-target                (:no-target fh-008)]
-          (-> (act #(.render root (element [bv/plain {}])))
+          (-> (ms/act #(.render root (element [bv/plain {}])))
               (.then (fn [_]
                        (let [rows (behaviors/active-connections)
                              row  (first rows)]
@@ -727,24 +733,24 @@
                              "carrying the frame the connection was committed under")
                          (is (pos-int? (:generation row))
                              "and the generation the release will name"))
-                       (act #(.render root (element [bv/no-target {}])))))
+                       (ms/act #(.render root (element [bv/no-target {}])))))
               (.then (fn [_]
                        (let [row (first (behaviors/active-connections))]
                          (is (= (disj (set present) :target) (set (keys row)))
                              "a behavior nothing commands projects NO target — absent, never nil")
                          (is (= (:config no-target) (:config row))))
-                       (act #(.render root (element [bv/pair {}])))))
+                       (ms/act #(.render root (element [bv/pair {}])))))
               (.then (fn [_]
                        (let [rows (behaviors/active-connections)]
                          (is (= 2 (count rows)))
                          (is (= (sort (map :generation rows)) (map :generation rows))
                              "projected oldest first, by the generation that ordered them")
                          (is (= [:probe/one :probe/two] (mapv :target rows))))
-                       (teardown! container root)
+                       (ms/destroy-root! container root)
                        (done)))
               (.catch (fn [e]
                         (is false (str "mount rejected: " e))
-                        (teardown! container root)
+                        (ms/destroy-root! container root)
                         (done)))))))))
 
 (deftest fh-behavior-008-the-command-log-records-what-was-asked-and-decided
@@ -755,14 +761,14 @@
             resolved behavior and generation appear on a delivered row only,
             and the operation's return value — the connection's private
             memory — has no representation here at all."
-    (if-not (browser?)
-      (skip! "the browser job runs the command-traffic assertions")
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the command-traffic assertions")
       (async done
         (setup!)
-        (let [[container root]        (mount!)
+        (let [[container root]        (ms/create-root!)
               {:keys [present absent]} (:log-keys fh-008)
               traffic                  (:traffic fh-008)]
-          (-> (act #(.render root (element [bv/plain {}])))
+          (-> (ms/act #(.render root (element [bv/plain {}])))
               (.then (fn [_]
                        (is (empty? (behaviors/command-log))
                            "a mount commands nothing, so the log starts empty")
@@ -794,11 +800,11 @@
                                      (str note " — and no generation"))))
                            (is (every? (set present) (keys got))
                                (str note " — the key roster is closed"))))
-                       (teardown! container root)
+                       (ms/destroy-root! container root)
                        (done)))
               (.catch (fn [e]
                         (is false (str "mount rejected: " e))
-                        (teardown! container root)
+                        (ms/destroy-root! container root)
                         (done)))))))))
 
 (deftest fh-behavior-008-the-command-log-is-a-bounded-window
@@ -808,13 +814,13 @@
             eviction is proved rather than assumed: the run's only refusal
             is issued FIRST, so a cap that discarded the newest rows would
             still be holding it."
-    (if-not (browser?)
-      (skip! "the browser job runs the bounded-window assertions")
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the bounded-window assertions")
       (async done
         (setup!)
-        (let [[container root] (mount!)
+        (let [[container root] (ms/create-root!)
               {:keys [overflow-by op target evicted]} (:bounded fh-008)]
-          (-> (act #(.render root (element [bv/plain {}])))
+          (-> (ms/act #(.render root (element [bv/plain {}])))
               (.then (fn [_]
                        (conf/caught-id #(behaviors/command! frame-id evicted))
                        (is (= [:refused] (mapv :outcome (behaviors/command-log)))
@@ -826,9 +832,9 @@
                              "the window holds the limit and no more")
                          (is (every? #(= :delivered (:outcome %)) rows)
                              "and the OLDEST rows were the ones dropped"))
-                       (teardown! container root)
+                       (ms/destroy-root! container root)
                        (done)))
               (.catch (fn [e]
                         (is false (str "mount rejected: " e))
-                        (teardown! container root)
+                        (ms/destroy-root! container root)
                         (done)))))))))

--- a/implementation/freehand/test/re_frame/freehand/controls_kit_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/controls_kit_dom_cljs_test.cljs
@@ -44,9 +44,7 @@
   This file rides the browser lane through its `-dom-cljs-test` namespace
   suffix, and it also matches the node suites' broader regex, where it has
   no DOM to mount and says so rather than passing quietly."
-  (:require ["react" :as react]
-            ["react-dom/client" :as rdc]
-            [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
             [re-frame.adapter.uix :as react-substrate]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
@@ -54,6 +52,7 @@
             [re-frame.freehand.conformance :as conf]
             [re-frame.freehand.controls :as c]
             [re-frame.freehand.form :as form]
+            [re-frame.freehand.mount-support :as ms]
             [re-frame.freehand.react :as fr]
             [re-frame.freehand.shell :as shell]
             [re-frame.live-frame :as live-frame]
@@ -63,7 +62,12 @@
   (test-support/make-reset-runtime-fixture
     {:adapter       react-substrate/adapter
      :ambient-frame nil
-     :async?        true}))
+     :async?        true
+     ;; Bookkeeping, not cleanup: it forgets the roots the PREVIOUS test
+     ;; made so `ms/residue-clean!` reads only this one's, and tears
+     ;; nothing down — a teardown here would run before each test and hide
+     ;; exactly what that assertion looks for.
+     :init-fn       (fn [] (ms/reset-ledger!))}))
 
 (def ctrl-018 (conf/fixture :FH-CTRL-018))
 
@@ -127,28 +131,20 @@
                      :on-commit [:editor/committed amount]}])
 
 ;; ---------------------------------------------------------------------------
-;; Browser seams — the same ones the controlled-input suites use
+;; Browser seams
 ;; ---------------------------------------------------------------------------
-
-(defn- browser? []
-  (and (exists? js/document) (some? (.-createElement js/document))))
-
-(defn- skip! [why]
-  (is true (str "a real browser mount is required — " why)))
-
-(defn- act [thunk]
-  (try
-    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
-    (js/Promise.resolve (react/act (fn [] (js/Promise.resolve (thunk)))))
-    (catch :default e
-      (js/Promise.reject e))))
-
-(defn- live!
-  "Leave React's act environment: typing has to reach React as a genuine
-  DISCRETE event, which is the mechanism the synchronous door rides."
-  []
-  (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) false)
-  nil)
+;;
+;; The mounted LIFECYCLE — the `act` boundary, the `[container root]` pair
+;; and the teardown — comes from `re-frame.freehand.mount-support`, the one
+;; facade the browser tier shares (rf2-n9rzw). This file used to carry its
+;; own byte-identical copy of each, which is how it came to tear down
+;; without ever asserting what survived.
+;;
+;; What stays local is the TYPING, and it stays local because it is not the
+;; same as the facade's: an `input` here carries `isComposing false`
+;; explicitly, and a keystroke is delivered as an insert AT THE CARET
+;; rather than an append, because the caret is one of the three facts this
+;; suite exists to measure.
 
 (defn- native-value-setter []
   (.-set (js/Object.getOwnPropertyDescriptor
@@ -214,24 +210,13 @@
 
 (defn- caret [node] [(.-selectionStart node) (.-selectionEnd node)])
 
-(defn- mount! []
-  (let [container (js/document.createElement "div")]
-    (.appendChild js/document.body container)
-    [container (rdc/createRoot container)]))
-
-(defn- teardown! [container root]
-  (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
-  (.unmount root)
-  (.remove container)
-  nil)
-
 (defn- seed! []
   (live-frame/make-frame {:id fid})
   (frame/replace-app-db! fid (assoc-in {} form-path (form/init (:baseline ctrl-018))))
   fid)
 
 (defn- render! [root view]
-  (act #(.render root (shell/provide-frame fid (fr/element [view {}])))))
+  (ms/act #(.render root (shell/provide-frame fid (fr/element [view {}])))))
 
 (defn- app-db [] (frame/frame-app-db-value fid))
 (defn- the-form [] (get-in (app-db) form-path))
@@ -251,10 +236,28 @@
   [pred label]
   (test-support/poll-until pred {:label label :timeout-ms 2000 :interval-ms 5}))
 
-(defn- fail-and-finish! [container root done]
+(defn- finish!
+  "The terminal step of every row here: tear the mount down through the
+  shared lifecycle, assert that NOTHING it created survived, and end the
+  async test.
+
+  The residue assertion is what earns the row's claim rather than asserting
+  it. It runs AFTER teardown, over the facade's own books — every root this
+  test created, and what each left behind — so a root that failed to
+  unmount reds HERE instead of contaminating the next suite in the process."
+  [container root done]
+  (ms/destroy-root! container root)
+  (ms/residue-clean! "FH-CTRL-018 — after teardown")
+  (done))
+
+(defn- fail-and-finish!
+  "The rejection path. It tears down — a rejected row must not leak its root
+  either — but reads no residue: a second failure attributed to the leak
+  rule would bury the one that actually happened."
+  [container root done]
   (fn [e]
     (is false (str "the browser step rejected: " e))
-    (teardown! container root)
+    (ms/destroy-root! container root)
     (done)))
 
 ;; ===========================================================================
@@ -267,17 +270,17 @@
             node, character for character. Each keystroke round-trips
             through application state, so a dropped one is a SHORT
             STRING here rather than a timing observation."
-    (if-not (browser?)
-      (skip! "the browser job runs the typing assertions")
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the typing assertions")
       (async done
         (reg!)
         (let [{:keys [baseline typed value-after-typing]} ctrl-018
               _ (seed!)
-              [container root] (mount!)]
+              [container root] (ms/create-root!)]
           (-> (render! root plain-field)
               (.then
                 (fn [_]
-                  (live!)
+                  (ms/live!)
                   (let [field (.querySelector container "#plain")]
                     (is (= (:amount baseline) (.-value field))
                         "the control starts on the baseline")
@@ -290,7 +293,7 @@
                         "non-vacuous: the typing really moved the value")
                     (is (= (count value-after-typing) (first (caret field)))
                         "with the caret at the end, where the user left it")
-                    (teardown! container root)
+                    (finish! container root done)
                     (done))))
               (.catch (fail-and-finish! container root done))))))))
 
@@ -300,17 +303,17 @@
             than jump to either end — the failure a hand-rolled controlled
             input produces on every keystroke, and one no structural tree
             can show."
-    (if-not (browser?)
-      (skip! "the browser job runs the caret assertions")
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the caret assertions")
       (async done
         (reg!)
         (let [{:keys [insert-at insert-ch value-after-insert caret-after-insert]} ctrl-018
               _ (seed!)
-              [container root] (mount!)]
+              [container root] (ms/create-root!)]
           (-> (render! root plain-field)
               (.then
                 (fn [_]
-                  (live!)
+                  (ms/live!)
                   (let [field (.querySelector container "#plain")]
                     (insert-at! field insert-at insert-ch)
                     (is (= value-after-insert (.-value field))
@@ -322,7 +325,7 @@
                          to the start would also produce")
                     (is (not= (count value-after-insert) caret-after-insert)
                         "nor the position a reset to the END would produce")
-                    (teardown! container root)
+                    (finish! container root done)
                     (done))))
               (.catch (fail-and-finish! container root done))))))))
 
@@ -333,18 +336,18 @@
             controlled node — so it takes the ordinary BATCHED path and
             lands on a later tick. Nothing about it needs to be
             synchronous: the value it commits is already in the frame."
-    (if-not (browser?)
-      (skip! "the browser job runs the blur assertions")
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the blur assertions")
       (async done
         (reg!)
         (let [{:keys [insert-at insert-ch value-after-insert commits-after-plain-enter
                       committed-value]} ctrl-018
               _ (seed!)
-              [container root] (mount!)]
+              [container root] (ms/create-root!)]
           (-> (render! root committing-field)
               (.then
                 (fn [_]
-                  (live!)
+                  (ms/live!)
                   (let [field (.querySelector container "#buffered")]
                     (insert-at! field insert-at insert-ch)
                     (is (= value-after-insert (.-value field))
@@ -357,7 +360,7 @@
                                      "the blur committed")
                                  (is (= committed-value (committed))
                                      "carrying the draft the user could see")
-                                 (teardown! container root)
+                                 (finish! container root done)
                                  (done)))
                         (.catch (fail-and-finish! container root done))))))
               (.catch (fail-and-finish! container root done))))))))
@@ -391,11 +394,11 @@
                 value-after-composing-enter commits-after-plain-enter
                 committed-value]} ctrl-018
         _ (seed!)
-        [container root] (mount!)]
+        [container root] (ms/create-root!)]
     (-> (render! root committing-field)
         (.then
           (fn [_]
-            (live!)
+            (ms/live!)
             (let [field (.querySelector container "#buffered")]
               (insert-at! field insert-at insert-ch)
               (is (= value-after-insert (.-value field))
@@ -425,7 +428,7 @@
                       (is (not= commits-after-composing-enter
                                 commits-after-plain-enter)
                           "non-vacuous: the fixture's two answers really differ")
-                      (teardown! container root)
+                      (finish! container root done)
                       (done)))
                   (.catch (fail-and-finish! container root done))))))
         (.catch (fail-and-finish! container root done)))))
@@ -442,8 +445,8 @@
             CANNOT be withheld by the `keyCode` 229 sentinel the sibling
             row owns. The flag is the only thing standing between this
             press and a commit."
-    (if-not (browser?)
-      (skip! "the browser job runs the composition assertions")
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the composition assertions")
       (async done
         (exactly-one-commit-attempt!
           {:composing? true :key-code (:plain-key-code ctrl-018)}
@@ -462,8 +465,8 @@
             whole reason the sentinel is consulted at all — stayed green.
             Here 229 is the only signal there is, so it is the only thing
             that can withhold the commit."
-    (if-not (browser?)
-      (skip! "the browser job runs the composition assertions")
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the composition assertions")
       (async done
         (exactly-one-commit-attempt!
           {:composing? false :key-code (:composing-key-code ctrl-018)}
@@ -476,18 +479,18 @@
             which is exactly what a key-remount destroys and what no
             structural assertion can see — and the commit that follows
             carries the restored value rather than the refused one."
-    (if-not (browser?)
-      (skip! "the browser job runs the reset assertions")
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the reset assertions")
       (async done
         (reg!)
         (let [{:keys [insert-at insert-ch value-after-insert reasserted-value
                       next-reset-key value-after-reset]} ctrl-018
               _ (seed!)
-              [container root] (mount!)]
+              [container root] (ms/create-root!)]
           (-> (render! root committing-field)
               (.then
                 (fn [_]
-                  (live!)
+                  (ms/live!)
                   (let [field  (.querySelector container "#buffered")
                         before field]
                     (insert-at! field insert-at insert-ch)
@@ -497,7 +500,7 @@
                         "non-vacuous: the caller stands by the value it already had,
                          so nothing derived from the VALUE could observe this")
 
-                    (-> (act #(rf/dispatch-sync [:editor/rejected amount] {:frame fid}))
+                    (-> (ms/act #(rf/dispatch-sync [:editor/rejected amount] {:frame fid}))
                         (.then
                           (fn [_]
                             (is (= value-after-reset (.-value field))
@@ -513,7 +516,7 @@
 
                             ;; A commit now speaks for the NEW generation, and
                             ;; what it carries is the value on screen.
-                            (live!)
+                            (ms/live!)
                             (press-enter! field (plain-enter))
                             (settled #(some? (committed)) "the post-reset commit lands")))
                         (.then
@@ -522,7 +525,7 @@
                                 "the commit that follows carries the restored value")
                             (is (not= value-after-insert (committed))
                                 "non-vacuous: it is not the draft the caller refused")
-                            (teardown! container root)
+                            (finish! container root done)
                             (done)))
                         (.catch (fail-and-finish! container root done))))))
               (.catch (fail-and-finish! container root done))))))))

--- a/implementation/freehand/test/re_frame/freehand/host_mounted_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/host_mounted_dom_cljs_test.cljs
@@ -49,6 +49,7 @@
             [re-frame.frame :as frame]
             [re-frame.freehand :as v]
             [re-frame.freehand.conformance :as conf]
+            [re-frame.freehand.mount-support :as ms]
             [re-frame.freehand.react :as fr]
             [re-frame.freehand.root :as root]
             [re-frame.live-frame :as live-frame]
@@ -286,28 +287,17 @@
      :init-fn       (fn []
                       (reset-ledger!)
                       (root/reset-registry!)
-                      (fr/reset-boundaries!))}))
+                      (fr/reset-boundaries!)
+                      ;; The facade's lifecycle ledger, scoped to this test.
+                      ;; Bookkeeping only — unlike the three resets above it
+                      ;; tears nothing down, which is what lets
+                      ;; `ms/residue-clean!` report a retained root AFTER a
+                      ;; test instead of a reset masking it before the next.
+                      (ms/reset-ledger!))}))
 
-(defn- browser? []
-  (and (exists? js/document) (some? (.-createElement js/document))))
-
-(defn- skip! [why]
-  (is true (str "a real React mount needs a DOM host — " why)))
-
-(defn- act
-  "A React 19 `act` boundary as a promise, so assertions run after the
-  commit AND its flushed effects rather than racing them."
-  [thunk]
-  (try
-    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
-    (js/Promise.resolve (react/act (fn [] (js/Promise.resolve (thunk)))))
-    (catch :default e
-      (js/Promise.reject e))))
-
-(defn- host-node! []
-  (let [container (js/document.createElement "div")]
-    (.appendChild js/document.body container)
-    container))
+;; The mounted LIFECYCLE — the `act` boundary and the container — comes from
+;; `re-frame.freehand.mount-support`, the one facade the browser tier shares
+;; (rf2-n9rzw). This file used to carry its own byte-identical copies.
 
 (defn- setup! [db]
   (live-frame/make-frame {:id fid})
@@ -319,10 +309,28 @@
 (defn- mount! [container form] (v/mount form container {:frame fid}))
 (defn- q [container selector] (.querySelector container selector))
 
-(defn- teardown! [container mounted]
+(defn- teardown!
+  "Unmount through the DOOR — this suite mounts with `v/mount`, so the door
+  owns the React root and `v/unmount!` is the only correct release — then
+  retire the container through the shared lifecycle, which RECORDS what the
+  mount left behind for [[released!]] to read."
+  [container mounted]
   (v/unmount! mounted)
-  (.remove container)
+  (ms/remove-node! container)
   nil)
+
+(defn- released!
+  "Nothing a mounted crossing created survives it. The facade's own books
+  (every container retired, empty and detached) plus the door's live-root
+  registry, read AFTER teardown.
+
+  Reading it here is the whole point. The `:init-fn` above resets the root
+  registry and the boundary table BEFORE each test, so a crossing that
+  retained a root would be swallowed by the next test's reset rather than
+  reported by this one — which is exactly why FH-REACT-007 could not claim
+  `:residue :none` (rf2-n9rzw)."
+  [where]
+  (ms/residue-clean! where [["the door's live-root registry" #(root/live-root-ids)]]))
 
 (def ^:private seed {:label "alpha" :prefix "p1" :selections []})
 
@@ -346,12 +354,12 @@
             recently wrote. A host position that handed over the authored
             closure would pass the second and fail the first; one that
             memoised the closure would pass the first and fail the second."
-    (if-not (browser?)
-      (skip! "the browser job runs the mounted host crossing")
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the mounted host crossing")
       (async done
         (setup! seed)
-        (let [container (host-node!)]
-          (-> (act #(mount! container [panel-page {}]))
+        (let [container (ms/host-node!)]
+          (-> (ms/act #(mount! container [panel-page {}]))
               (.then
                 (fn [mounted]
                   (let [panel (q container ".hook-panel")]
@@ -367,12 +375,12 @@
                          tree, not a portal or a nested root")
                     (is (= 1 (:live-panels @ledger))
                         "the wrapper's own mount effect ran exactly once"))
-                  (act (fn [] (.click (q container "button.select")) mounted))))
+                  (ms/act (fn [] (.click (q container "button.select")) mounted))))
               (.then
                 (fn [mounted]
                   (is (= ["p1-mark"] (read* [:d022/selections]))
                       "the :event position dispatched its event vector")
-                  (act (fn [] (.click (q container "button.note")) mounted))))
+                  (ms/act (fn [] (.click (q container "button.note")) mounted))))
               (.then
                 (fn [mounted]
                   (is (= ["noted"] (:notes @ledger))
@@ -383,7 +391,7 @@
                   ;; A commit that moves BOTH the rendered value and the
                   ;; callback's body, so the next two assertions cannot both
                   ;; be read off a tree that never re-rendered.
-                  (act (fn []
+                  (ms/act (fn []
                          (send! [:d022/prefix-changed "p2"])
                          (send! [:d022/label-changed "beta"])
                          mounted))))
@@ -397,12 +405,12 @@
                       "React was handed the SAME function object every time —
                        a declared position is one site, and a site owns its
                        identity")
-                  (act (fn [] (.click (q container "button.select")) mounted))))
+                  (ms/act (fn [] (.click (q container "button.select")) mounted))))
               (.then
                 (fn [mounted]
                   (is (= ["p1-mark" "p2-mark"] (read* [:d022/selections]))
                       "and that unchanged object ran the LATEST committed body")
-                  (act #(teardown! container mounted))))
+                  (ms/act #(teardown! container mounted))))
               (.then
                 (fn [_]
                   (let [held (first (:callback-ids @ledger))]
@@ -414,6 +422,7 @@
                          whatever owns the frame now"))
                   (is (= 0 (:live-panels @ledger))
                       "and the registered component's own cleanup ran")
+                  (released! "FH-REACT-007 — after the mounted crossing unmounts")
                   (done)))
               (.catch (fn [e]
                         (is false (str "mount rejected: " e))
@@ -429,18 +438,18 @@
             a scheme that keyed identity on either would let the stale
             reference fire into the new occurrence. It must stay inert while
             the successor's own callback works."
-    (if-not (browser?)
-      (skip! "the browser job runs the remount")
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the remount")
       (async done
         (setup! seed)
-        (let [container (host-node!)]
-          (-> (act #(mount! container [panel-page {}]))
-              (.then (fn [mounted] (act #(teardown! container mounted))))
+        (let [container (ms/host-node!)]
+          (-> (ms/act #(mount! container [panel-page {}]))
+              (.then (fn [mounted] (ms/act #(teardown! container mounted))))
               (.then
                 (fn [_]
                   (let [stale     (first (:callback-ids @ledger))
-                        container (host-node!)]
-                    (-> (act #(mount! container [panel-page {}]))
+                        container (ms/host-node!)]
+                    (-> (ms/act #(mount! container [panel-page {}]))
                         (.then
                           (fn [mounted]
                             (stale "from-the-dead")
@@ -451,13 +460,19 @@
                                 "and the successor reused the ONE cached boundary
                                  for this view id, which is the reload invariant
                                  that makes the stale reference plausible")
-                            (act (fn [] (.click (q container "button.select")) mounted))))
+                            (ms/act (fn [] (.click (q container "button.select")) mounted))))
                         (.then
                           (fn [mounted]
                             (is (= ["p1-mark"] (read* [:d022/selections]))
                                 "while the successor's own callback is live")
-                            (act #(teardown! container mounted))))
-                        (.then (fn [_] (done)))
+                            (ms/act #(teardown! container mounted))))
+                        (.then (fn [_]
+                                 ;; BOTH mounts — the original and its
+                                 ;; successor — are read here, which is what
+                                 ;; the ledger buys: a remount that tore down
+                                 ;; only the second would red on the first.
+                                 (released! "FH-REACT-007 — after the remount unmounts")
+                                 (done)))
                         (.catch (fn [e]
                                   (is false (str "remount rejected: " e))
                                   (done)))))))
@@ -479,26 +494,28 @@
             it prepares the ONE value the authored Clojure map could not
             hold, and the crossing itself gains no per-prop conversion
             language for it."
-    (if-not (browser?)
-      (skip! "the browser job runs the chart mount")
+    (if-not (ms/browser?)
+      (ms/skip! "the browser job runs the chart mount")
       (async done
         (setup! seed)
-        (let [container (host-node!)]
-          (-> (act #(mount! container [vega-page {}]))
+        (let [container (ms/host-node!)]
+          (-> (ms/act #(mount! container [vega-page {}]))
               (.then
                 (fn [mounted]
                   (is (= "bar" (.getAttribute (q container ".vega-chart") "data-mark"))
                       "the adapter's JS object reached the library as one")
                   (is (= 2 (.-length (.querySelectorAll container ".vega-mark")))
                       "and the chart rendered from it")
-                  (act (fn [] (.click (q container "button.vega-mark")) mounted))))
+                  (ms/act (fn [] (.click (q container "button.vega-mark")) mounted))))
               (.then
                 (fn [mounted]
                   (is (= ["p1-10"] (read* [:d022/selections]))
                       "a value the LIBRARY chose came back as an ordinary
                        re-frame event")
-                  (act #(teardown! container mounted))))
-              (.then (fn [_] (done)))
+                  (ms/act #(teardown! container mounted))))
+              (.then (fn [_]
+                       (released! "FH-REACT-007 — after the chart unmounts")
+                       (done)))
               (.catch (fn [e]
                         (is false (str "mount rejected: " e))
                         (done)))))))))

--- a/implementation/freehand/test/re_frame/freehand/roster_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/roster_jvm_test.clj
@@ -136,11 +136,18 @@
   collection off the substrate's own book — so these are what one looks
   like, not an arbitrary keyword list.
 
+  `residue-clean!` is the SHARED one (rf2-n9rzw): the mounted-lifecycle
+  facade's assertion, read after teardown over every root the test created
+  plus whatever substrate books the caller names. It leads the list because
+  it is what a mounted suite should reach for; the inline spellings behind
+  it are the local reads that predate it and remain perfectly good evidence.
+
   `nothing-survived` is included because the async surrogate factors its
   absence check into a named helper and calls it from every case; a rule
   that only recognised the inline spellings would refuse the most thorough
   suite in the set."
-  [#"\(zero\?" #"\(empty\?" #"nothing-survived" #"\(= \[\] " #"\(= 0 \(count"])
+  [#"residue-clean!" #"\(zero\?" #"\(empty\?" #"nothing-survived"
+   #"\(= \[\] " #"\(= 0 \(count"])
 
 (deftest a-residue-none-claim-is-backed-by-an-emptiness-assertion
   (testing "Per rf2-drpa3.182.7 acceptance 3: mounted cleanup is EXACT, and
@@ -176,6 +183,27 @@
           "an unmount-and-remove teardown is not a residue assertion")
       (is (some #(re-find % with-absence) emptiness-assertion)
           "and reading a book empty afterwards is"))))
+
+(deftest the-residue-rule-refuses-the-shared-teardown-without-the-shared-assertion
+  (testing "The mutation the shared facade makes possible, and the one this
+            rule now has to survive (rf2-n9rzw). Consuming
+            `mount-support`'s lifecycle is not the same as reading its
+            books: a suite can call `destroy-root!` — a real, correct
+            teardown — and never call `residue-clean!`, which is precisely
+            the state FH-CTRL-018 and FH-REACT-007 were in.
+
+            A rule that recognised the facade by NAME rather than by the
+            assertion would go green on the first half and stop refusing
+            anything, so it is run against both halves directly. A shared
+            assertion that cannot fail is the defect this whole seam exists
+            to remove."
+    (let [shared-teardown "(ms/destroy-root! container root)"
+          shared-assert   (str shared-teardown
+                               "\n(ms/residue-clean! \"FH-CTRL-018 — after teardown\")")]
+      (is (not-any? #(re-find % shared-teardown) emptiness-assertion)
+          "tearing down through the shared lifecycle asserts nothing on its own")
+      (is (some #(re-find % shared-assert) emptiness-assertion)
+          "and reading the shared residue assertion afterwards is what earns the claim"))))
 
 (deftest the-spine-records-what-it-has-not-yet-earned
   (testing "Per rf2-drpa3.182.7 acceptance 3: the roster's value here is


### PR DESCRIPTION
Completes rf2-n9rzw, which the merged-PR audit of #7111 reopened. That PR renamed
`matrix-support` to `mount-support` and gave it a residue assertion, but stopped
there: the suites it was named for never consumed it, and `residue-clean!` /
`reset-ledger!` had **zero executable call sites** in the repository. This is the
migration.

## What is now shared

All four mounted projections of the three spine fixtures take their mounted
lifecycle from `re-frame.freehand.mount-support`:

| suite | fixture | was |
|---|---|---|
| `controls-kit-dom-cljs-test` | FH-CTRL-018 | private `act`, `mount!`, `teardown!`, `browser?`, `skip!`, `live!` |
| `host-mounted-dom-cljs-test` | FH-REACT-007 | private `act`, `host-node!`, `browser?`, `skip!` |
| `behaviors-dom-cljs-test` | FH-BEHAVIOR-005 | private `act`, `mount!`, `teardown!`, `browser?`, `skip!` |
| `behavior-async-dom-cljs-test` | FH-BEHAVIOR-005 | private `act`, `mount!`, `teardown!`, `browser?`, `skip!` |

The `act` body was byte-identical in all four, exactly as the bead measured. Four
copies are gone; `["react"]` / `["react-dom/client"]` requires go with them where
nothing else used them.

**`residue-clean!` and `reset-ledger!` now have 8 executable call sites.** Every
suite scopes the ledger in its `:init-fn` and reads the books AFTER teardown —
which is the whole point, since a reset in an `:init-fn` runs BEFORE each test and
masks the retained root it is supposed to report.

## What was deliberately left alone

- **The frame/runtime reset.** Already shared through
  `test-support/make-reset-runtime-fixture`, exactly as the bead says. Untouched.
- **The controls kit's typing helpers.** They are NOT copies of the facade's: an
  `input` here carries `isComposing false` explicitly, and a keystroke lands AT
  THE CARET rather than appending — the caret is one of the three facts that suite
  exists to measure. Absorbing them would have been a behaviour change dressed as
  deduplication.
- **`host-mounted`'s `teardown!`.** It mounts through the DOOR, so `v/unmount!` is
  the correct release and `destroy-root!` would be wrong. Only the container is
  retired through the facade's ledger.
- **`behavior-async`'s root error callbacks.** Genuinely its own — they route a
  React throw into `escapes` instead of failing the lane. They are now handed to
  the facade under the names it already spells them with, rather than built beside it.

## The JVM rule still refuses an unearned claim

`roster-jvm-test` recognises `residue-clean!` as an emptiness assertion, and gains
the mutation the facade makes possible: a suite can consume the shared TEARDOWN
(`destroy-root!`) and never read the shared BOOKS. The new row runs the rule
against both halves and proves it refuses the first — a shared assertion that
cannot fail is the defect this bead exists to remove.

## Not done — outside this worker's fence

The bead's acceptance also flips two fixture records from `:residue :unasserted`
to `:none`. Those records live under `spec/`, which this dispatch fenced as
hot-zone (report, don't edit). **Both suites now earn the claim** — the rule that
gates it (`a-residue-none-claim-is-backed-by-an-emptiness-assertion`) scans the
mounted proof for an emptiness assertion, and both files now carry
`residue-clean!` — so the remaining change is mechanical and green:

1. `spec/conformance/freehand/fixtures/fh-ctrl-018.edn` — `:residue :unasserted` → `:none`
2. `spec/conformance/freehand/fixtures/fh-react-007.edn` — `:residue :unasserted` → `:none`
3. `roster-jvm-test/the-spine-records-what-it-has-not-yet-earned` — the
   current-state map to `{:FH-REACT-007 :none :FH-CTRL-018 :none :FH-BEHAVIOR-005 :none}`

That row's own docstring says it "is meant to be edited when the mounted-lifecycle
facade lands and the other two earn `:none`". They have; it needs one hand that
may touch `spec/`.

## Quality gates

Run foreground, unpiped, from the worker worktree. Baseline captured by running the
same three gates at `origin/main` (b53421fc81) in the same checkout.

| gate | before | after | exit |
|---|---|---|---|
| `implementation/freehand` JVM `clojure -M:test` | 1221 tests / 8229 assertions | **1222 tests / 8231 assertions** | **0** |
| `npm run test:freehand` (node lane) | 1302 tests / 7219 assertions | **1302 tests / 7219 assertions** | **0** |
| `npm run test:browser` (`BROWSER_TEST_TIMEOUT_MS=600000`) | 835 tests / 5323 assertions | **835 tests / 5383 assertions** | **0** |

0 failures, 0 errors everywhere.

**No test was lost.** The browser lane — the one that matters, since all four
suites are DOM tests — runs the identical 835 tests and gains 60 assertions, which
are the residue rows. The JVM gate gains 1 test / 2 assertions: the refusal
mutation. The node lane is unchanged, because it skips the mounted rows.

Everything else is deferred to CI.
