### PR TITLE
spec(conformance): fh-ctrl-018 and fh-react-007 now assert residue (rf2-n9rzw)

### DIFF
--- a/implementation/freehand/test/re_frame/freehand/roster_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/roster_jvm_test.clj
@@ -160,8 +160,10 @@
             Every mounted projection of a `:residue :none` record must read
             an absence after teardown. A record whose suites only unmount
             and remove, without asserting what survived, says
-            `:unasserted` — which is honest, countable, and what two of the
-            three spine members currently say."
+            `:unasserted` — honest, countable, and what two of the three
+            spine members said until they took the shared assertion
+            (rf2-n9rzw). All three carry `:none` now, so this row is
+            carrying all three rather than one."
     (doseq [record roster/spine
             :when  (= :none (get-in record [:fh/record :evidence :residue]))
             entry  (roster/tier record :mounted)]
@@ -205,18 +207,26 @@
       (is (some #(re-find % shared-assert) emptiness-assertion)
           "and reading the shared residue assertion afterwards is what earns the claim"))))
 
-(deftest the-spine-records-what-it-has-not-yet-earned
+(deftest the-spine-records-what-it-has-earned
   (testing "Per rf2-drpa3.182.7 acceptance 3: the roster's value here is
-            that the gap is COUNTABLE rather than hidden. FH-BEHAVIOR-005
-            earns `:residue :none` — both its projections read the
-            substrate's books empty after teardown, as exact zeros. The
-            other two tear down and assert nothing, and say so.
+            that the residue claim is COUNTABLE rather than hidden. All
+            three spine members now claim `:residue :none`, and the row
+            above is what holds each of them to it.
 
-            This row is a statement of the CURRENT state, and it is meant to
-            be edited when the mounted-lifecycle facade lands and the other
-            two earn `:none`. It is here so that happens deliberately."
-    (is (= {:FH-REACT-007    :unasserted
-            :FH-CTRL-018     :unasserted
+            Two of them arrived (rf2-n9rzw), and the gap each closed was a
+            different one. FH-CTRL-018 tore its root down and asserted
+            nothing about what survived. FH-REACT-007 reset its registries
+            in a per-test `:init-fn`, which is cleanup BEFORE a test rather
+            than evidence about the one that just ran — a retained boundary
+            was masked by the next reset instead of reported. Both now end
+            at the shared `residue-clean!`, read after teardown.
+
+            This row remains a statement of the CURRENT state, and that is
+            its job in both directions: a record regressing to
+            `:unasserted`, or a fourth member enrolled without a residue
+            claim, reds HERE rather than passing quietly."
+    (is (= {:FH-REACT-007    :none
+            :FH-CTRL-018     :none
             :FH-BEHAVIOR-005 :none}
            (into {} (map (fn [id]
                            [id (get-in (roster/by-id id)

--- a/spec/conformance/freehand/fixtures/fh-ctrl-018.edn
+++ b/spec/conformance/freehand/fixtures/fh-ctrl-018.edn
@@ -82,17 +82,23 @@
   ;; the DOM node actually held, and the count of commits that reached
   ;; dispatch. Both are read off the substrate rather than off the test's
   ;; own bookkeeping.
-  ;; `:residue :unasserted`, and it is the truthful answer rather than a
-  ;; placeholder. The suite tears its root down — `.unmount` then
-  ;; `.remove` — but asserts NOTHING about what survived: no book is read
-  ;; empty afterwards, and a root that failed to unmount would go
-  ;; unnoticed here and contaminate every later suite in the same process.
-  ;; Earning `:residue :none` is rf2-drpa3.182.7 acceptance 3's remaining
-  ;; work, and it wants the shared mounted-lifecycle facade rather than a
-  ;; fourth hand-rolled teardown.
+  ;; `:residue :none`, and the suite earns it rather than asserting it.
+  ;; Every row ends at `finish!`, which tears the mount down through the
+  ;; shared lifecycle and then reads `ms/residue-clean!` — every root the
+  ;; row created retired, each one leaving its container empty and
+  ;; detached. The read happens AFTER teardown, which is the whole point:
+  ;; the same read before a test masks a retained root instead of
+  ;; reporting it.
+  ;;
+  ;; This said `:unasserted` for as long as the suite only unmounted and
+  ;; removed, because a teardown proves nothing about what survived it and
+  ;; a root that failed to unmount would have gone unnoticed here and
+  ;; contaminated every later suite in the same process. It reds here now
+  ;; (rf2-n9rzw), and `roster-jvm-test` refuses the claim below unless the
+  ;; mounted proof makes that assertion.
   :evidence
   {:reads    [:dom/value :dom/selection-start]
    :counts   [:form/commits :form/attempts]
-   :residue  :unasserted}
+   :residue  :none}
 
   :prose :executable}}

--- a/spec/conformance/freehand/fixtures/fh-react-007.edn
+++ b/spec/conformance/freehand/fixtures/fh-react-007.edn
@@ -158,15 +158,23 @@
   ;; perfectly and breaks every memoised consumer downstream, so the
   ;; recorded object is what a run leaves and `identical?` is what reads
   ;; it.
-  ;; `:residue :unasserted`. The mounted suite resets the host registry and
-  ;; the boundary table in its per-test `:init-fn`, which cleans up BEFORE
-  ;; each test rather than asserting anything AFTER one — so a crossing that
-  ;; retained a boundary would be masked by the next test's reset instead of
-  ;; reported. Earning `:residue :none` is acceptance 3's remaining work.
+  ;; `:residue :none`, and the mounted suite earns it. Every row that
+  ;; commits ends at `released!`, which reads the shared lifecycle's books
+  ;; — every container retired, empty and detached — together with the
+  ;; door's own live-root registry, AFTER the crossing unmounts through
+  ;; `v/unmount!`. The rows that mount nothing, the emitter-only adapter
+  ;; refusals, have no residue to read and assert none.
+  ;;
+  ;; This said `:unasserted` for as long as the per-test `:init-fn` was the
+  ;; only cleanup there was. Resetting the host registry and the boundary
+  ;; table BEFORE each test is not evidence about the test that just ran: a
+  ;; crossing that retained a boundary would be swallowed by the next
+  ;; test's reset rather than reported by its own. Moving the read to the
+  ;; END of the test is what made the absence falsifiable (rf2-n9rzw).
   :evidence
   {:reads   [:host/props :host/callback-identity]
    :counts  [:host/commits]
-   :residue :unasserted}
+   :residue :none}
 
   ;; The `:map-props` key-set boundary was recorded OPEN here (rf2-drpa3.182.3,
   ;; from the merged-PR audit of #7081) rather than pinned to the behaviour


### PR DESCRIPTION
PR #7162 migrated all four mounted projections of the Freehand spine onto `re-frame.freehand.mount-support`, taking `residue-clean!`/`reset-ledger!` from zero executable call sites to eight. It was fenced out of `spec/`, so the conformance claim was left one flip behind the code: both fixtures went on saying `:residue :unasserted` while their suites had already started reading the books empty after teardown.

This is that flip, plus the prose that justified the old answer — a comment defending a claim nobody is making any more is worse than no comment.

## What was verified before flipping

`roster-jvm-test`'s rule (`a-residue-none-claim-is-backed-by-an-emptiness-assertion`) requires every **mounted** projection of a `:residue :none` record to carry an emptiness assertion. Both suites satisfy it at a real executable site after teardown, not merely in text:

- **FH-CTRL-018** → `controls-kit-dom-cljs-test`. `finish!` calls `ms/destroy-root!` then `ms/residue-clean!`, and every one of the five mounting rows ends there.
- **FH-REACT-007** → `host-mounted-dom-cljs-test`. `released!` calls `ms/residue-clean!` over the door's own live-root registry after `teardown!` (`v/unmount!` + `ms/remove-node!`), and all three mounting rows end there. Its other two rows mount nothing — they are emitter-only adapter refusals — so they have no residue to read.

`residue-clean!` carries its own non-vacuity: a suite that tore no root down through the facade reds on `(is (pos? (count retired)))`.

The current-state roster row is renamed to what it now says and stays a statement of the present, so a record regressing to `:unasserted` still reds there.

## Quality gates

| Gate | Result | Exit |
|---|---|---|
| `implementation/freehand` JVM `clojure -M:test` | 1222 tests / **8233 assertions**, 0 failures, 0 errors | **0** |
| `roster-jvm-test` focused, mutation A | 10 tests / 37 assertions, 0 failures | **0** |
| `roster-jvm-test` focused, mutation B | 10 tests / 37 assertions, **1 failure** (intended) | **1** |
| `roster-jvm-test` focused, restored | 10 tests / 37 assertions, 0 failures | **0** |

Assertion count moved 8231 → 8233 because the residue rule now scans FH-CTRL-018's and FH-REACT-007's mounted proofs as well as FH-BEHAVIOR-005's two.

`npm run test:browser` deferred to CI: this branch touches no mounted suite. The executed evidence that these assertions actually run is #7162's browser gate — 835 tests, 5323 → 5383 assertions, exit 0, test count identical, the +60 being the residue rows themselves.

## Mutation evidence

**Mutation B — the rule bites.** `ms/residue-clean!` removed from `finish!` *and* the one comment that mentioned it, leaving the file with no emptiness-assertion text at all:

```
FAIL in (a-residue-none-claim-is-backed-by-an-emptiness-assertion) (roster_jvm_test.clj:172)
FH-CTRL-018 claims :residue :none, but its mounted proof
re-frame.freehand.controls-kit-dom-cljs-test makes no emptiness assertion
— either it asserts what survived, or the record says :unasserted
Ran 10 tests containing 37 assertions.  1 failures, 0 errors.   exit 1
```

Restored: 10 tests / 37 assertions, 0 failures, exit 0, `git diff --stat` empty.

**Mutation A — and the honest half.** Removing only the *executable* `ms/residue-clean!` call, leaving the comment on line 67 that names it, stayed **green at exit 0**. The rule is a whole-file text scan, so a comment satisfies it.

That is not a regression from this PR and it is not this bead's to fix — it is precisely the weakness the merged-PR audit of #7105 recorded against the still-open parent **rf2-drpa3.182.7** ("a comment saying `(zero? ...)`, an unrelated zero assertion, or a helper never called after teardown all satisfy it; the audit reproduced both false positives directly"). Reporting it because the flip's honesty rests on the *executable* call sites listed above rather than on the scanner, and a reader should know which of the two is load-bearing. `host-mounted-dom-cljs-test` has the same property from a different direction: it carries an unrelated `(is (= [] (read* ...)))` that would satisfy the scanner on its own.

Filed separately: **rf2-0ke4x** — the five double-`done` calls PR #7162 left in `controls_kit_dom_cljs_test.cljs`.
