### PR TITLE
fix(freehand): each async row fires done exactly once (rf2-0ke4x)

### DIFF
--- a/implementation/freehand/test/re_frame/freehand/controls_kit_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/controls_kit_dom_cljs_test.cljs
@@ -244,7 +244,15 @@
   The residue assertion is what earns the row's claim rather than asserting
   it. It runs AFTER teardown, over the facade's own books — every root this
   test created, and what each left behind — so a root that failed to
-  unmount reds HERE instead of contaminating the next suite in the process."
+  unmount reds HERE instead of contaminating the next suite in the process.
+
+  It OWNS the `done` call, the way `mount-support`'s `run-async` and
+  `each-mode` own theirs: a row that ends here must NOT call `done` itself.
+  Five did, once this replaced a `teardown!` that left `done` to the caller,
+  and nothing went red — `cljs.test` guards `run-block` with a `realized?`
+  delay, so the second call degrades to a console warning rather than
+  corrupting async state (rf2-0ke4x). A duplicate is therefore invisible to
+  the browser gate and has to be kept out by this rule instead."
   [container root done]
   (ms/destroy-root! container root)
   (ms/residue-clean! "FH-CTRL-018 — after teardown")
@@ -293,8 +301,7 @@
                         "non-vacuous: the typing really moved the value")
                     (is (= (count value-after-typing) (first (caret field)))
                         "with the caret at the end, where the user left it")
-                    (finish! container root done)
-                    (done))))
+                    (finish! container root done))))
               (.catch (fail-and-finish! container root done))))))))
 
 (deftest fh-ctrl-018-a-mid-string-insert-leaves-the-caret-where-the-user-put-it
@@ -325,8 +332,7 @@
                          to the start would also produce")
                     (is (not= (count value-after-insert) caret-after-insert)
                         "nor the position a reset to the END would produce")
-                    (finish! container root done)
-                    (done))))
+                    (finish! container root done))))
               (.catch (fail-and-finish! container root done))))))))
 
 (deftest fh-ctrl-018-a-blur-commits-the-draft
@@ -360,8 +366,7 @@
                                      "the blur committed")
                                  (is (= committed-value (committed))
                                      "carrying the draft the user could see")
-                                 (finish! container root done)
-                                 (done)))
+                                 (finish! container root done)))
                         (.catch (fail-and-finish! container root done))))))
               (.catch (fail-and-finish! container root done))))))))
 
@@ -428,8 +433,7 @@
                       (is (not= commits-after-composing-enter
                                 commits-after-plain-enter)
                           "non-vacuous: the fixture's two answers really differ")
-                      (finish! container root done)
-                      (done)))
+                      (finish! container root done)))
                   (.catch (fail-and-finish! container root done))))))
         (.catch (fail-and-finish! container root done)))))
 
@@ -525,7 +529,6 @@
                                 "the commit that follows carries the restored value")
                             (is (not= value-after-insert (committed))
                                 "non-vacuous: it is not the draft the caller refused")
-                            (finish! container root done)
-                            (done)))
+                            (finish! container root done)))
                         (.catch (fail-and-finish! container root done))))))
               (.catch (fail-and-finish! container root done))))))))


### PR DESCRIPTION
Closes rf2-0ke4x.

PR #7162 migrated this suite onto `re-frame.freehand.mount-support`, replacing its
local `teardown!` — which left `done` to the caller — with `finish!`, which calls
`done` as its last form. The pre-existing trailing `(done)` was left in place at all
five async sites, so every async row fired `done` twice.

## The shape chosen, and why

**`finish!` keeps ownership of `done`; the five trailing `(done)` calls are deleted** —
because `mount-support`'s own terminal helpers already establish that discipline
(`run-async` and `each-mode` are both documented as calling `done` EXACTLY ONCE, and
`run-async` states the rule outright: *"the body never calls `done`, so it cannot
double-fire it"*), so having `finish!` own it puts this suite inside the facade's
contract instead of making it the one place where a terminal helper tears down but
leaves completion to the caller.

Two supporting facts:

- `fail-and-finish!` already owns `done` on the rejection path and never had a
  duplicate, so this makes the success and rejection paths symmetric.
- The alternative — stripping `done` out of `finish!` — was *not* rejected on blast
  radius. `finish!` and `fail-and-finish!` are `defn-` **private to this one file**;
  `host_mounted_dom_cljs_test.cljs`, `behaviors_dom_cljs_test.cljs` and
  `behavior_async_dom_cljs_test.cljs` do not reference them at all (they take `done`
  through `mount-support`'s `run-async`/`each-mode`). Either shape was confined to
  this file, so the decision was made on consistency with the facade rather than on
  cost. **`mount-support`'s contract is unchanged.**

The `finish!` docstring now carries the invariant at the point it was violated.

## Evidence for the double-fire

`cljs.test/run-block` (`cljs/test.cljs`, ClojureScript 1.12.145) guards the
continuation with a `realized?` delay, so the second call degrades to a console
warning rather than corrupting async state — which is exactly why #7162 stayed green
and merged:

```clojure
(obj (let [d (delay (run-block (rest fns)))]
       (fn []
         (if (realized? d)
           (println "WARNING: Async test called done more than one time.")
           @d))))
```

The browser runner taps `page.on('console', …)` and buffers every line, flushing it
only on failure or `RF2_VERBOSE_TESTS=1`. Running the lane with that flag set makes
the defect directly observable — no scratch instrumentation was needed, and the
working tree carries none:

| | double-done warnings | tests | assertions | failures | errors | exit |
|---|---|---|---|---|---|---|
| **before** | **6** | 835 | 5383 | 0 | 0 | 0 |
| **after** | **0** | 835 | 5383 | 0 | 0 | 0 |

Six warnings from five textual sites is the expected count, not a discrepancy: the
site inside the shared helper `exactly-one-commit-attempt!` serves **two** deftests
(the `isComposing` row and the `keyCode` 229 row). Five warnings appeared under the
`controls-kit-dom-cljs-test` header and the sixth landed just after the next
namespace header, as the last row's `done` chain resolved on a later tick — all six
disappear with this change, which confirms none belonged to `custom-element`.

**Test count and assertion count are unchanged (835 / 5383).**

## Guarding it — filed, not built (rf2-u0cy4)

No gate catches a double-fired `done`, which is why this merged. The right guard is
cheap but **out of scope for this PR**, so it is filed as **rf2-u0cy4** rather than
bolted on here.

`implementation/scripts/run-browser-tests.cjs` already has the exact hook: it
collects `consoleLines` and separately treats `pageErrors` as fatal, by deliberate
design (rf2-mwx08 — *"Console output stays diagnostic-only; only `pageerror` is
fatal"*). Promoting the single literal `Async test called done more than one time` to
a fatal console pattern is roughly five lines beside the existing
`pageErrors.length > 0` arm, and it is **general** — it catches any suite in the
mounted tier, which a bespoke textual lint over suite sources would not.

It is excluded here because it sits outside this bead's fence
(`implementation/freehand/test/**`) and because it changes the verdict semantics of
the whole browser lane, so it needs its own full-lane gate rather than riding a
five-line deletion. The after-run above is useful input to that bead: with 0 warnings
across all 835 tests, no other suite is currently double-firing, so the promotion
should not red anything today.

Meanwhile this suite is **correct but unguarded**, and rf2-u0cy4 says so.

## Roster gate

`roster_jvm_test.clj` scans this suite textually for an emptiness assertion backing
its `:residue :none` claim. The read it depends on — `ms/residue-clean!` inside
`finish!` — is untouched; only the caller-side `(done)` lines were removed.

## Quality gates

| Gate | Command | Exit | Result |
|---|---|---|---|
| Browser DOM lane (before) | `BROWSER_TEST_TIMEOUT_MS=600000 RF2_VERBOSE_TESTS=1 npm run test:browser` | **0** | 835 tests, 5383 assertions, 0 failures, 0 errors — **6** double-done warnings |
| Browser DOM lane (after) | `BROWSER_TEST_TIMEOUT_MS=600000 RF2_VERBOSE_TESTS=1 npm run test:browser` | **0** | 835 tests, 5383 assertions, 0 failures, 0 errors — **0** double-done warnings |
| freehand JVM (incl. `roster_jvm_test.clj`) | `clojure -M:test` in `implementation/freehand` | **0** | 1222 tests, 8233 assertions, 0 failures, 0 errors |

Deferred to CI: the full test spine (`scripts/test-fast-pr.sh`, the node CLJS lane,
the xray feature gate, bundle isolation). This change is confined to one browser-tier
test file and CI is the merge gate.
