### PR TITLE
test(core): split dev instrumentation from semantics — fx-test and the tail (rf2-d2841)

### DIFF
--- a/implementation/core/test/re_frame/db_noop_commit_test.clj
+++ b/implementation/core/test/re_frame/db_noop_commit_test.clj
@@ -29,10 +29,39 @@
     - the nil-coercion path commits `{}` (never nil) + fires the diagnostic.
 
   Contract — Spec 009 §Canonical per-event trace sequence + §Error event
-  catalogue (`:rf.warning/db-nil-coerced` is a diagnostic-channel warning)."
+  catalogue (`:rf.warning/db-nil-coerced` is a diagnostic-channel warning).
+
+  ## Posture split (rf2-d2841)
+
+  The COMMIT SEMANTICS are production-real and are asserted WITHOUT a posture
+  guard, so they run in the ordinary `clojure -M:test` suite AND in
+  `scripts/test-core-prod-gate.sh` (the `-Dre-frame.debug=false` lane). That
+  is the whole of point 1 and the substance of point 3: whether
+  `replace-container!` was skipped (frame-state object identity before vs
+  after — the adversarial discriminator this namespace was written for),
+  whether a `=`-but-distinct value still installs a new object, and that a
+  `{:db nil}` return lands `{}` rather than nil. Those are facts about the
+  container, readable straight off `frame/frame-state-value` and
+  `frame/frame-app-db-value`, and they need no trace surface.
+
+  Point 2 — the `:rf.event/db-noop` / `:rf.event/db-changed` complement — and
+  the `:rf.warning/db-nil-coerced` diagnostic are DEV-ONLY. Both are
+  `trace/emit!` sites with no always-on twin (`:rf.warning/db-nil-coerced` is
+  catalogued diagnostic-channel, per this docstring's own contract line), so
+  under the real gate nothing is emitted BY DESIGN. Their assertions are kept
+  verbatim inside a `(when interop/debug-enabled? …)` arm marked `rf2-d2841`.
+
+  The NEGATIVE trace assertions move inside the arm with their positive
+  partners, and that is the point rather than tidiness: `(not (some #{…} ops))`
+  over an empty `ops` passes automatically under the gate. Left outside they
+  would report that `db-changed` correctly did not fire on a no-op — while in
+  fact NOTHING fired, including the `db-noop` that should have. \"Exactly one
+  of the two fires\" is a claim about a dev channel and is only meaningful
+  where that channel exists."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
             [re-frame.registrar :as registrar]
             [re-frame.schemas :as schemas]
             [re-frame.substrate.plain-atom :as plain-atom]))
@@ -83,12 +112,14 @@
           (is (identical? fs-before fs-after)
               "identical?-noop SKIPPED replace-container! — the stored
                frame-state object is the SAME object (no equal value re-installed)")
-          (is (some #{:rf.event/db-noop} ops)
-              ":rf.event/db-noop fired on the unchanged-db commit")
-          (is (not (some #{:rf.event/db-changed} ops))
-              ":rf.event/db-changed did NOT fire (exactly one of the two fires)")
           (is (= {:counter 1 :seeded? true} (frame/frame-app-db-value :rf/default))
-              "app-db is unchanged"))
+              "app-db is unchanged")
+          ;; rf2-d2841 — dev-instrumentation arm (see ns docstring).
+          (when interop/debug-enabled?
+            (is (some #{:rf.event/db-noop} ops)
+                ":rf.event/db-noop fired on the unchanged-db commit")
+            (is (not (some #{:rf.event/db-changed} ops))
+                ":rf.event/db-changed did NOT fire (exactly one of the two fires)")))
         (finally
           (rf/unregister-listener! :trace ::identical-noop))))))
 
@@ -108,10 +139,12 @@
               ops      (ops-of acc)]
           (is (not (identical? fs-before fs-after))
               "a real change installed a new frame-state object (write happened)")
-          (is (some #{:rf.event/db-changed} ops) ":rf.event/db-changed fired")
-          (is (not (some #{:rf.event/db-noop} ops)) ":rf.event/db-noop did NOT fire")
           (is (= 2 (:counter (frame/frame-app-db-value :rf/default)))
-              "the counter incremented"))
+              "the counter incremented")
+          ;; rf2-d2841 — dev-instrumentation arm (see ns docstring).
+          (when interop/debug-enabled?
+            (is (some #{:rf.event/db-changed} ops) ":rf.event/db-changed fired")
+            (is (not (some #{:rf.event/db-noop} ops)) ":rf.event/db-noop did NOT fire")))
         (finally
           (rf/unregister-listener! :trace ::changed))))))
 
@@ -146,10 +179,12 @@
                new frame-state object (only identical? short-circuits)")
           ;; Change-detection is `=`, so no app-db change is reported →
           ;; :rf.event/db-noop is the signal (not db-changed).
-          (is (some #{:rf.event/db-noop} ops)
-              "=-equal commit reports no change → db-noop fires")
-          (is (not (some #{:rf.event/db-changed} ops))
-              "db-changed does NOT fire for a =-equal value"))
+          ;; rf2-d2841 — dev-instrumentation arm (see ns docstring).
+          (when interop/debug-enabled?
+            (is (some #{:rf.event/db-noop} ops)
+                "=-equal commit reports no change → db-noop fires")
+            (is (not (some #{:rf.event/db-changed} ops))
+                "db-changed does NOT fire for a =-equal value")))
         (finally
           (rf/unregister-listener! :trace ::eq-distinct))))))
 
@@ -170,11 +205,16 @@
               warn (first (filterv #(= :rf.warning/db-nil-coerced (:operation %)) @acc))]
           (is (= {} db) "app-db was coerced to {} (NOT nil)")
           (is (map? db) "app-db is a map after a {:db nil} return")
-          (is (some? warn) ":rf.warning/db-nil-coerced diagnostic fired")
-          (is (= :warning (:op-type warn)) "the diagnostic rides the :warning severity")
-          (is (some #{:rf.event/db-changed} ops)
-              "the coerced {} differs from the seeded {:counter 7}, so it COMMITS
-               (db-changed), not a no-op"))
+          ;; rf2-d2841 — dev-instrumentation arm (see ns docstring). The
+          ;; COERCION is production-real and asserted above; the diagnostic
+          ;; that announces it is diagnostic-channel, and so is the
+          ;; db-changed/db-noop discrimination of its outcome.
+          (when interop/debug-enabled?
+            (is (some? warn) ":rf.warning/db-nil-coerced diagnostic fired")
+            (is (= :warning (:op-type warn)) "the diagnostic rides the :warning severity")
+            (is (some #{:rf.event/db-changed} ops)
+                "the coerced {} differs from the seeded {:counter 7}, so it COMMITS
+                 (db-changed), not a no-op")))
         (finally
           (rf/unregister-listener! :trace ::nil-coerce))))))
 
@@ -184,16 +224,25 @@
     (rf/reg-event :clear/seed (fn [{:keys [db]} _] {:db {:counter 7}}))
     (rf/reg-event :clear/empty (fn [{:keys [db]} _] {:db {}}))
     (rf/dispatch-sync [:clear/seed])
-    (let [acc (collect-traces! ::deliberate-clear)]
+    (let [fs-before (frame/frame-state-value :rf/default)
+          acc       (collect-traces! ::deliberate-clear)]
       (try
         (rf/dispatch-sync [:clear/empty])
         (let [db   (frame/frame-app-db-value :rf/default)
               ops  (ops-of acc)]
           (is (= {} db) "app-db is the deliberate empty map")
-          (is (not (some #{:rf.warning/db-nil-coerced} ops))
-              "no db-nil-coerced diagnostic for a deliberate {:db {}} clear")
-          (is (some #{:rf.event/db-changed} ops)
-              "the {} differs from {:counter 7} → it commits (db-changed)"))
+          (is (not (identical? fs-before (frame/frame-state-value :rf/default)))
+              "the deliberate clear COMMITTED — a new frame-state object was
+               installed (the production-visible half of db-changed)")
+          ;; rf2-d2841 — dev-instrumentation arm (see ns docstring). Both of
+          ;; these read the dev trace, and the NEGATIVE especially must sit
+          ;; here: over an empty `ops` it would report that no spurious
+          ;; diagnostic fired when in fact no diagnostic exists to fire.
+          (when interop/debug-enabled?
+            (is (not (some #{:rf.warning/db-nil-coerced} ops))
+                "no db-nil-coerced diagnostic for a deliberate {:db {}} clear")
+            (is (some #{:rf.event/db-changed} ops)
+                "the {} differs from {:counter 7} → it commits (db-changed)")))
         (finally
           (rf/unregister-listener! :trace ::deliberate-clear))))))
 
@@ -211,11 +260,13 @@
         (let [db  (frame/frame-app-db-value :rf/default)
               ops (ops-of acc)]
           (is (= {} db) "app-db is {} (never nil)")
-          (is (some #{:rf.warning/db-nil-coerced} ops)
-              "the diagnostic fires whenever the supplied :db was literally nil")
-          (is (some #{:rf.event/db-noop} ops)
-              "coerced {} == current {} → no change → db-noop")
-          (is (not (some #{:rf.event/db-changed} ops))
-              "no db-changed for the no-op coerced commit"))
+          ;; rf2-d2841 — dev-instrumentation arm (see ns docstring).
+          (when interop/debug-enabled?
+            (is (some #{:rf.warning/db-nil-coerced} ops)
+                "the diagnostic fires whenever the supplied :db was literally nil")
+            (is (some #{:rf.event/db-noop} ops)
+                "coerced {} == current {} → no change → db-noop")
+            (is (not (some #{:rf.event/db-changed} ops))
+                "no db-changed for the no-op coerced commit")))
         (finally
           (rf/unregister-listener! :trace ::nil-noop))))))

--- a/implementation/core/test/re_frame/fx_test.clj
+++ b/implementation/core/test/re_frame/fx_test.clj
@@ -1202,22 +1202,35 @@
 
 (deftest fx-overrides-fn-value-emits-applied-trace
   (testing "fn-value override emits :rf.fx/override-applied (per spec/009)"
-    (let [traces (collect-traces! ::fn-override-trace)]
+    (let [traces         (collect-traces! ::fn-override-trace)
+          original-fired (atom 0)
+          override-fired (atom 0)]
       (rf/reg-fx :fx-test/http-traced
                  {:platforms #{:client :server}}
-                 (fn [_ _] nil))
+                 (fn [_ _] (swap! original-fired inc)))
       (rf/reg-event :fx-test/issue-traced
         (fn [_ _] {:fx [[:fx-test/http-traced {}]]}))
       (rf/dispatch-sync
         [:fx-test/issue-traced]
-        {:fx-overrides {:fx-test/http-traced (fn [_ _] :ok)}})
+        {:fx-overrides {:fx-test/http-traced (fn [_ _] (swap! override-fired inc) :ok)}})
       (rf/unregister-listener! :trace ::fn-override-trace)
-      (let [applied (filter #(= :rf.fx/override-applied (:operation %)) @traces)]
-        (is (= 1 (count applied))
-            "exactly one :rf.fx/override-applied trace for the fn-value override")
-        (let [t (first applied)]
-          (is (= :fx-test/http-traced (get-in t [:tags :rf.fx/from]))
-              ":rf.fx/from carries the original fx-id"))))))
+      ;; PRODUCTION-VISIBLE WITNESS (rf2-d2841). The trace is `:rf.fx/override-
+      ;; applied`, a bare `trace/emit!` with no always-on twin — but the FACT
+      ;; the trace reports ("the override applied, exactly once, in place of
+      ;; the original") is a fact about EXECUTION, so count the bodies. Without
+      ;; this the deftest would execute nothing under the production gate.
+      (is (= 1 @override-fired)
+          "the fn-value override body ran exactly once")
+      (is (= 0 @original-fired)
+          "the registered fx did NOT also run — the override replaced it")
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (let [applied (filter #(= :rf.fx/override-applied (:operation %)) @traces)]
+          (is (= 1 (count applied))
+              "exactly one :rf.fx/override-applied trace for the fn-value override")
+          (let [t (first applied)]
+            (is (= :fx-test/http-traced (get-in t [:tags :rf.fx/from]))
+                ":rf.fx/from carries the original fx-id")))))))
 
 (deftest fx-overrides-fn-value-receives-origin-event
   (testing "fn-value override receives :event in ctx when the dispatch carries one"
@@ -1294,19 +1307,35 @@
     ;; rf2-nnma3: the trace previously fired at resolution time even though
     ;; the reserved body ran instead. It now rides the actual override-fn
     ;; invocation — fires when the override applies, absent otherwise.
-    (let [traces (collect-traces! ::reserved-override-trace)]
-      (rf/reg-event :fx-test.nrpj1/sink (fn [{:keys [db]} _] {:db db}))
+    (let [traces     (collect-traces! ::reserved-override-trace)
+          stub-fired (atom 0)
+          sink-ran   (atom 0)]
+      (rf/reg-event :fx-test.nrpj1/sink
+        (fn [{:keys [db]} _] (swap! sink-ran inc) {:db db}))
       (rf/reg-event :fx-test.nrpj1/traced-dispatch
         (fn [_ _] {:fx [[:dispatch [:fx-test.nrpj1/sink]]]}))
       (rf/dispatch-sync
         [:fx-test.nrpj1/traced-dispatch]
-        {:fx-overrides {:dispatch (fn [_ _] :stubbed)}})
+        {:fx-overrides {:dispatch (fn [_ _] (swap! stub-fired inc) :stubbed)}})
       (rf/unregister-listener! :trace ::reserved-override-trace)
-      (let [applied (filter #(= :rf.fx/override-applied (:operation %)) @traces)]
-        (is (= 1 (count applied))
-            "exactly one :rf.fx/override-applied trace — emitted because the override fired")
-        (is (= :dispatch (get-in (first applied) [:tags :rf.fx/from]))
-            ":rf.fx/from carries the reserved fx-id that was overridden")))))
+      ;; PRODUCTION-VISIBLE WITNESS (rf2-d2841). "The trace fires only when
+      ;; the override TRULY applies" presupposes a fact about execution — that
+      ;; the override ran and the reserved body did not — and that fact is
+      ;; production-real. The rf2-nnma3 regression (trace at resolution time
+      ;; while the reserved body ran instead) is exactly a divergence between
+      ;; these two counters and the trace, so pinning them here is the
+      ;; substantive half of "trace honesty".
+      (is (= 1 @stub-fired)
+          "the :dispatch override body ran exactly once")
+      (is (= 0 @sink-ran)
+          "the reserved :dispatch body did NOT run — nothing was queued")
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (let [applied (filter #(= :rf.fx/override-applied (:operation %)) @traces)]
+          (is (= 1 (count applied))
+              "exactly one :rf.fx/override-applied trace — emitted because the override fired")
+          (is (= :dispatch (get-in (first applied) [:tags :rf.fx/from]))
+              ":rf.fx/from carries the reserved fx-id that was overridden"))))))
 
 (deftest reserved-fx-with-no-override-runs-reserved-body
   (testing "a reserved :dispatch with NO override still queues + runs the real event"
@@ -1330,7 +1359,8 @@
     ;; so a keyword-redirect targeting one is a coherent, surfaced no-op. This
     ;; behaviour is intentionally UNCHANGED by rf2-nrpj1.
     (let [original-fired (atom 0)
-          traces         (collect-traces! ::redirect-to-reserved)]
+          traces         (collect-traces! ::redirect-to-reserved)
+          errors         (collect-errors! ::redirect-to-reserved-errors)]
       (rf/reg-fx :fx-test.nrpj1/my-fx
                  {:platforms #{:client :server}}
                  (fn [_ _] (swap! original-fired inc)))
@@ -1339,12 +1369,31 @@
       (rf/dispatch-sync
         [:fx-test.nrpj1/issue-redirect]
         {:fx-overrides {:fx-test.nrpj1/my-fx :dispatch}})
-      (rf/unregister-listener! :trace ::redirect-to-reserved)
+      (rf/unregister-listener! :trace  ::redirect-to-reserved)
+      (rf/unregister-listener! :errors ::redirect-to-reserved-errors)
       (is (= 1 @original-fired)
           "the original :fx-test.nrpj1/my-fx ran — the redirect to the un-registered :dispatch fell through")
-      (let [fallthrough (filter #(= :rf.error/override-fallthrough (:operation %)) @traces)]
-        (is (= 1 (count fallthrough))
-            "exactly one :rf.error/override-fallthrough trace surfaced the un-registered redirect target")))))
+      ;; PRODUCTION-VISIBLE WITNESS (rf2-d2841). `:rf.error/override-fallthrough`
+      ;; is ALWAYS-ON (Spec 009 §Observability channels) and its emit stamps
+      ;; `:failing-id` = the ORIGINAL fx-id, which differs from the dispatched
+      ;; `:event-id`, so `emit-error-both!` lifts `:failing-id` + `:reason`
+      ;; onto the production record. The "coherent, surfaced no-op" this
+      ;; deftest is named for is therefore surfaced under the gate too.
+      (let [records (filter #(= :rf.error/override-fallthrough (:error %)) @errors)]
+        (is (= 1 (count records))
+            "exactly ONE always-on record surfaced the un-registered redirect target")
+        (let [r (first records)]
+          (is (= :fx-test.nrpj1/my-fx (:failing-id r))
+              ":failing-id names the fx whose override fell through")
+          (is (= :fx-test.nrpj1/issue-redirect (:event-id r)))
+          (is (= :rf/default (:frame r)))
+          (is (re-find #"not registered" (:reason r))
+              ":reason names the un-registered redirect target as the cause")))
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (let [fallthrough (filter #(= :rf.error/override-fallthrough (:operation %)) @traces)]
+          (is (= 1 (count fallthrough))
+              "exactly one :rf.error/override-fallthrough trace surfaced the un-registered redirect target"))))))
 
 (deftest malformed-fx-override-value-fails-loud
   (testing "a non-fn / non-keyword / non-nil :fx-overrides value (number / string
@@ -1352,7 +1401,8 @@
             no longer silently swallowed (rf2-3az1vn P2)"
     (doseq [bad-value [42 "not-an-override" {:also :bad} [:vec :tor]]]
       (let [original-fired (atom 0)
-            traces         (collect-traces! ::malformed-override)]
+            traces         (collect-traces! ::malformed-override)
+            errors         (collect-errors! ::malformed-override-errors)]
         (rf/reg-fx :fx-test.3az1vn/target
                    {:platforms #{:client :server}}
                    (fn [_ _] (swap! original-fired inc)))
@@ -1361,14 +1411,31 @@
         (rf/dispatch-sync
           [:fx-test.3az1vn/issue]
           {:fx-overrides {:fx-test.3az1vn/target bad-value}})
-        (rf/unregister-listener! :trace ::malformed-override)
+        (rf/unregister-listener! :trace  ::malformed-override)
+        (rf/unregister-listener! :errors ::malformed-override-errors)
         (is (= 1 @original-fired)
             (str "the original fx ran (recovery :replaced-with-default) for "
                  (pr-str bad-value)))
-        (let [fallthrough (filter #(= :rf.error/override-fallthrough (:operation %)) @traces)]
-          (is (= 1 (count fallthrough))
-              (str "exactly one :rf.error/override-fallthrough surfaced the malformed "
-                   "override value " (pr-str bad-value))))))))
+        ;; PRODUCTION-VISIBLE WITNESS (rf2-d2841). "No longer silently
+        ;; swallowed" is rf2-3az1vn's whole point, and `:rf.error/override-
+        ;; fallthrough` is ALWAYS-ON — so the loudness is assertable under
+        ;; `-Dre-frame.debug=false`, where a misconfigured override map is
+        ;; most likely to be discovered.
+        (let [records (filter #(= :rf.error/override-fallthrough (:error %)) @errors)]
+          (is (= 1 (count records))
+              (str "exactly ONE always-on record surfaced the malformed override value "
+                   (pr-str bad-value)))
+          (is (= :fx-test.3az1vn/target (:failing-id (first records)))
+              (str ":failing-id names the overridden fx for " (pr-str bad-value)))
+          (is (re-find #"not a valid" (:reason (first records)))
+              (str ":reason states the value is not a valid :fx-overrides value for "
+                   (pr-str bad-value))))
+        ;; rf2-d2841 — dev-instrumentation arm (see ns docstring).
+        (when interop/debug-enabled?
+          (let [fallthrough (filter #(= :rf.error/override-fallthrough (:operation %)) @traces)]
+            (is (= 1 (count fallthrough))
+                (str "exactly one :rf.error/override-fallthrough surfaced the malformed "
+                     "override value " (pr-str bad-value)))))))))
 
 (deftest nil-and-false-fx-override-values-stay-silent
   (testing "nil and false :fx-overrides values are the documented noop placeholder
@@ -1377,7 +1444,8 @@
             no-op is intentionally KEPT)"
     (doseq [noop-value [nil false]]
       (let [original-fired (atom 0)
-            traces         (collect-traces! ::noop-override)]
+            traces         (collect-traces! ::noop-override)
+            errors         (collect-errors! ::noop-override-errors)]
         (rf/reg-fx :fx-test.3az1vn/noop-target
                    {:platforms #{:client :server}}
                    (fn [_ _] (swap! original-fired inc)))
@@ -1386,13 +1454,27 @@
         (rf/dispatch-sync
           [:fx-test.3az1vn/noop-issue]
           {:fx-overrides {:fx-test.3az1vn/noop-target noop-value}})
-        (rf/unregister-listener! :trace ::noop-override)
+        (rf/unregister-listener! :trace  ::noop-override)
+        (rf/unregister-listener! :errors ::noop-override-errors)
         (is (= 1 @original-fired)
             (str "the original fx ran for the noop placeholder " (pr-str noop-value)))
-        (let [fallthrough (filter #(= :rf.error/override-fallthrough (:operation %)) @traces)]
-          (is (empty? fallthrough)
-              (str "no override-fallthrough trace for the documented noop value "
-                   (pr-str noop-value))))))))
+        ;; PRODUCTION-VISIBLE WITNESS (rf2-d2841). A NEGATIVE, so it has to be
+        ;; asserted on an axis that is LIVE in the posture being tested — the
+        ;; always-on `:errors` stream, whose positive twin is
+        ;; `malformed-fx-override-value-fails-loud` directly above. Over the
+        ;; dev trace ring this same claim passes for free under the gate.
+        ;; "Silent" is a production-reachable promise: an app that ships the
+        ;; `{:some-fx (when cond? stub)}` idiom must not spray records at its
+        ;; off-box shipper on every dispatch.
+        (is (empty? (filter #(= :rf.error/override-fallthrough (:error %)) @errors))
+            (str "no override-fallthrough record on the ALWAYS-ON axis for the "
+                 "documented noop value " (pr-str noop-value)))
+        ;; rf2-d2841 — dev-instrumentation arm (see ns docstring).
+        (when interop/debug-enabled?
+          (let [fallthrough (filter #(= :rf.error/override-fallthrough (:operation %)) @traces)]
+            (is (empty? fallthrough)
+                (str "no override-fallthrough trace for the documented noop value "
+                     (pr-str noop-value)))))))))
 
 ;; ---- 7c. reserved-fx OVERRIDE TIER (rf2-snsup5) ---------------------------
 ;;
@@ -1420,6 +1502,7 @@
     ;; tier). A fn-value override that stubs it out would silently leave the
     ;; flow unregistered; the reject runs the reserved body so the flow lands.
     (let [traces        (collect-traces! ::reject-reg-flow)
+          errors        (collect-errors! ::reject-reg-flow-errors)
           stub-fired    (atom 0)
           ;; rf2-bqstzr — :rf.fx/reg-flow carries the 3-slot triple
           ;; [flow-id metadata derive-fn].
@@ -1432,22 +1515,39 @@
       (rf/dispatch-sync
         [:fx-test.snsup5/install-flow]
         {:fx-overrides {:rf.fx/reg-flow (fn [_ _] (swap! stub-fired inc))}})
-      (rf/unregister-listener! :trace ::reject-reg-flow)
+      (rf/unregister-listener! :trace  ::reject-reg-flow)
+      (rf/unregister-listener! :errors ::reject-reg-flow-errors)
       (is (= 0 @stub-fired)
           "the fn-value override stub MUST NOT fire — the reject pre-empts it")
       (is (contains? (get (flows/flows-snapshot) :rf/default) :fx-test.snsup5/a-flow)
           "the reserved :rf.fx/reg-flow body ran — the flow is registered")
-      (let [rejected (filter #(= :rf.error/reserved-fx-override (:operation %)) @traces)]
-        (is (= 1 (count rejected))
-            "exactly one :rf.error/reserved-fx-override trace fired")
-        (is (= :rf.fx/reg-flow (get-in (first rejected) [:tags :rf.fx/id]))
-            ":rf.fx/id names the rejected reserved fx-id")
-        (is (= :reserved-body-ran (:recovery (first rejected)))
-            ":recovery is :reserved-body-ran"))))
+      ;; PRODUCTION-VISIBLE WITNESS (rf2-d2841). `:rf.error/reserved-fx-override`
+      ;; is ALWAYS-ON and stamps `:failing-id` = the rejected reserved fx-id,
+      ;; distinct from `:event-id`, so both it and the id-specific `:reason`
+      ;; ride the production record (Spec 009 §Component attribution).
+      ;; `reject-tier-override-fans-out-on-always-on-axis` below pins the
+      ;; record's full shape; this pins that the DEV per-call reject site
+      ;; (`handle-one-fx`, not the prod-strip) reaches the same axis.
+      (let [records (filter #(= :rf.error/reserved-fx-override (:error %)) @errors)]
+        (is (= 1 (count records))
+            "exactly ONE always-on reserved-fx-override record")
+        (is (= :rf.fx/reg-flow (:failing-id (first records)))
+            ":failing-id names the rejected reserved fx-id in production too"))
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring). `:recovery`
+      ;; and the `:rf.fx/id` tag spelling are trace-shape, not record-shape.
+      (when interop/debug-enabled?
+        (let [rejected (filter #(= :rf.error/reserved-fx-override (:operation %)) @traces)]
+          (is (= 1 (count rejected))
+              "exactly one :rf.error/reserved-fx-override trace fired")
+          (is (= :rf.fx/reg-flow (get-in (first rejected) [:tags :rf.fx/id]))
+              ":rf.fx/id names the rejected reserved fx-id")
+          (is (= :reserved-body-ran (:recovery (first rejected)))
+              ":recovery is :reserved-body-ran")))))
 
   (testing "keyword-redirect override of a reject-tier id is ALSO ignored"
     ;; The reject covers both override shapes — fn-value AND keyword-redirect.
     (let [traces     (collect-traces! ::reject-redirect)
+          errors     (collect-errors! ::reject-redirect-errors)
           redir-ran  (atom 0)]
       (rf/reg-fx :fx-test.snsup5/redir-target
                  {:platforms #{:client :server}}
@@ -1457,13 +1557,19 @@
       (rf/dispatch-sync
         [:fx-test.snsup5/install-flow-2]
         {:fx-overrides {:rf.fx/reg-flow :fx-test.snsup5/redir-target}})
-      (rf/unregister-listener! :trace ::reject-redirect)
+      (rf/unregister-listener! :trace  ::reject-redirect)
+      (rf/unregister-listener! :errors ::reject-redirect-errors)
       (is (= 0 @redir-ran)
           "the keyword-redirect target MUST NOT fire — the reject pre-empts it")
       (is (contains? (get (flows/flows-snapshot) :rf/default) :fx-test.snsup5/b-flow)
           "the reserved :rf.fx/reg-flow body ran despite the redirect")
-      (is (= 1 (count (filter #(= :rf.error/reserved-fx-override (:operation %)) @traces)))
-          "one :rf.error/reserved-fx-override trace fired for the redirect form too"))))
+      ;; PRODUCTION-VISIBLE WITNESS (rf2-d2841) — the always-on axis, as above.
+      (is (= 1 (count (filter #(= :rf.error/reserved-fx-override (:error %)) @errors)))
+          "one always-on reserved-fx-override record for the redirect form too")
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (= 1 (count (filter #(= :rf.error/reserved-fx-override (:operation %)) @traces)))
+            "one :rf.error/reserved-fx-override trace fired for the redirect form too")))))
 
 (deftest reject-tier-override-fans-out-on-always-on-axis
   ;; rf2-uh5ic5: the existing reserved-fx tests above assert the dev-only
@@ -1528,28 +1634,43 @@
     ;; override fires and pre-empts the reserved body.
     (let [captured   (atom nil)
           target-ran (atom 0)
-          traces     (collect-traces! ::overridable-no-reject)]
+          traces     (collect-traces! ::overridable-no-reject)
+          errors     (collect-errors! ::overridable-no-reject-errors)]
       (rf/reg-event :fx-test.snsup5/target (fn [{:keys [db]} _] (swap! target-ran inc) {:db db}))
       (rf/reg-event :fx-test.snsup5/emits-dispatch
         (fn [_ _] {:fx [[:dispatch [:fx-test.snsup5/target]]]}))
       (rf/dispatch-sync
         [:fx-test.snsup5/emits-dispatch]
         {:fx-overrides {:dispatch (fn [_ ev] (reset! captured ev))}})
-      (rf/unregister-listener! :trace ::overridable-no-reject)
+      (rf/unregister-listener! :trace  ::overridable-no-reject)
+      (rf/unregister-listener! :errors ::overridable-no-reject-errors)
       (is (= [:fx-test.snsup5/target] @captured)
           "the :dispatch fn-value override fired (OVERRIDABLE tier — unchanged)")
       (is (= 0 @target-ran)
           "the reserved :dispatch body did NOT run — the override pre-empted it")
-      (is (empty? (filter #(= :rf.error/reserved-fx-override (:operation %)) @traces))
-          "NO :rf.error/reserved-fx-override fired for an OVERRIDABLE id"))))
+      ;; PRODUCTION-VISIBLE WITNESS (rf2-d2841). A NEGATIVE, so it rides the
+      ;; ALWAYS-ON axis where the category is live in both postures rather
+      ;; than the dev ring where it would pass for free under the gate. The
+      ;; tier boundary matters most in production: `strip-rejected-overrides`
+      ;; runs there, and stripping `:dispatch` would break stubbed routing.
+      (is (empty? (filter #(= :rf.error/reserved-fx-override (:error %)) @errors))
+          "NO always-on reserved-fx-override record for an OVERRIDABLE id")
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (empty? (filter #(= :rf.error/reserved-fx-override (:operation %)) @traces))
+            "NO :rf.error/reserved-fx-override fired for an OVERRIDABLE id")))))
 
 (deftest production-prod-strip-drops-reject-tier-loudly
   (testing "strip-rejected-overrides removes reject-tier keys + emits one error per key"
-    ;; The production prod-strip is exercised as a unit (it runs only under
-    ;; `(not interop/debug-enabled?)` in the router; the JVM dev fixture leaves
-    ;; the flag true, so the per-call reject fires on the dispatch path). The
-    ;; fn is pure-ish: filter the effective merged override map, emit loudly.
+    ;; The production prod-strip is exercised as a unit — the router calls it
+    ;; only under `(not interop/debug-enabled?)`, so in the ordinary dev suite
+    ;; the per-call reject is what fires on the dispatch path and this fn has
+    ;; to be reached directly. Under `scripts/test-core-prod-gate.sh` the same
+    ;; call IS the live router path, which is the posture this unit test was
+    ;; always describing. The fn is pure-ish: filter the effective merged
+    ;; override map, emit loudly.
     (let [traces   (collect-traces! ::prod-strip)
+          errors   (collect-errors! ::prod-strip-errors)
           stub     (fn [_ _] :stub)
           stripped (fx/strip-rejected-overrides
                      {:rf.machine/spawn        stub        ;; reject
@@ -1559,17 +1680,36 @@
                       :my-app/http             stub}       ;; user fx — kept
                      :rf/default
                      [:some/event])]
-      (rf/unregister-listener! :trace ::prod-strip)
+      (rf/unregister-listener! :trace  ::prod-strip)
+      (rf/unregister-listener! :errors ::prod-strip-errors)
       (is (= #{:dispatch :my-app/http} (set (keys stripped)))
           "every reject-tier key is stripped; OVERRIDABLE + user keys survive")
-      (let [rejected (filter #(= :rf.error/reserved-fx-override (:operation %)) @traces)]
-        (is (= 3 (count rejected))
-            "one :rf.error/reserved-fx-override trace per stripped reject-tier key")
+      ;; PRODUCTION-VISIBLE WITNESS (rf2-d2841). "LOUDLY" is the deftest's
+      ;; own claim and it must hold in the posture the fn exists for: the
+      ;; always-on axis carries one record per stripped key, each naming its
+      ;; own id through the lifted `:failing-id`.
+      (let [records (filter #(= :rf.error/reserved-fx-override (:error %)) @errors)]
+        (is (= 3 (count records))
+            "one always-on reserved-fx-override record per stripped reject-tier key")
         (is (= #{:rf.machine/spawn :rf.fx/reg-flow :rf.route/with-nav-token}
-               (set (map #(get-in % [:tags :rf.fx/id]) rejected)))
-            "the three rejected ids are named")
-        (is (every? #(= :production-strip (get-in % [:tags :where])) rejected)
-            ":where discriminates the production prod-strip site"))))
+               (set (map :failing-id records)))
+            "the three rejected ids are named on the production records")
+        (is (every? #(and (string? (:reason %))
+                          (re-find #"may NOT be overridden" (:reason %)))
+                    records)
+            "each production record carries the human-facing rejection reason"))
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring). `:where`,
+      ;; which discriminates the prod-strip site from the per-call one, is a
+      ;; trace-tag only — it is not lifted onto the always-on record.
+      (when interop/debug-enabled?
+        (let [rejected (filter #(= :rf.error/reserved-fx-override (:operation %)) @traces)]
+          (is (= 3 (count rejected))
+              "one :rf.error/reserved-fx-override trace per stripped reject-tier key")
+          (is (= #{:rf.machine/spawn :rf.fx/reg-flow :rf.route/with-nav-token}
+                 (set (map #(get-in % [:tags :rf.fx/id]) rejected)))
+              "the three rejected ids are named")
+          (is (every? #(= :production-strip (get-in % [:tags :where])) rejected)
+              ":where discriminates the production prod-strip site")))))
 
   (testing "strip-rejected-overrides is identity when no reject-tier key present"
     (let [m {:dispatch (fn [_ _]) :my-app/http (fn [_ _])}]
@@ -1603,20 +1743,27 @@
           {:fx-overrides {:rf.fx/reg-flow noop-value}})
         (rf/unregister-listener! :trace  ::reject-noop-trace)
         (rf/unregister-listener! :errors ::reject-noop-errors)
-        (is (empty? (filter #(= :rf.error/reserved-fx-override (:operation %)) @traces))
-            (str "NO reserved-fx-override trace for the nil/false placeholder "
-                 (pr-str noop-value)))
+        ;; The ALWAYS-ON leg is the load-bearing one and stays posture-
+        ;; independent: rf2-x76af2.27's actual symptom was a spurious record
+        ;; sprayed onto the production error channel PER DISPATCHED EVENT, so
+        ;; silence has to be proven in the posture that channel serves.
         (is (empty? (filter #(= :rf.error/reserved-fx-override (:error %)) @errors))
             (str "NO reserved-fx-override on the always-on axis for the "
                  "nil/false placeholder " (pr-str noop-value)))
         (is (contains? (get (flows/flows-snapshot) :rf/default) :fx-test.x76af2-27/flow)
             (str "the reserved :rf.fx/reg-flow body ran (silent fall-through) for "
-                 (pr-str noop-value))))))
+                 (pr-str noop-value)))
+        ;; rf2-d2841 — dev-instrumentation arm (negative over the trace ring).
+        (when interop/debug-enabled?
+          (is (empty? (filter #(= :rf.error/reserved-fx-override (:operation %)) @traces))
+              (str "NO reserved-fx-override trace for the nil/false placeholder "
+                   (pr-str noop-value)))))))
 
   (testing "production prod-strip: a nil/false reject-tier override is NOT
             stripped and emits NO error; a REAL reject-tier override IS still
             stripped + emitted (one error, naming the real override only)"
     (let [traces   (collect-traces! ::reject-noop-strip)
+          errors   (collect-errors! ::reject-noop-strip-errors)
           stub     (fn [_ _] :stub)
           stripped (fx/strip-rejected-overrides
                      {:rf.fx/reg-flow   nil    ;; reject-tier NO-OP — kept, silent
@@ -1625,15 +1772,26 @@
                       :my-app/http      stub}  ;; user fx — kept
                      :rf/default
                      [:some/event])]
-      (rf/unregister-listener! :trace ::reject-noop-strip)
+      (rf/unregister-listener! :trace  ::reject-noop-strip)
+      (rf/unregister-listener! :errors ::reject-noop-strip-errors)
       (is (= {:rf.fx/reg-flow nil :rf.fx/clear-flow false :my-app/http stub}
              stripped)
           "the nil/false reject-tier placeholders fall through untouched; only the real override is stripped")
-      (let [rejected (filter #(= :rf.error/reserved-fx-override (:operation %)) @traces)]
-        (is (= 1 (count rejected))
-            "exactly ONE reserved-fx-override — for the real :rf.machine/spawn override only")
-        (is (= :rf.machine/spawn (get-in (first rejected) [:tags :rf.fx/id]))
-            "the emitted error names the REAL override, not the nil/false placeholders"))))
+      ;; PRODUCTION-VISIBLE WITNESS (rf2-d2841) — this is the prod-strip, so
+      ;; its "exactly one, naming the REAL override" claim is asserted on the
+      ;; axis that survives the gate.
+      (let [records (filter #(= :rf.error/reserved-fx-override (:error %)) @errors)]
+        (is (= 1 (count records))
+            "exactly ONE always-on record — for the real :rf.machine/spawn override only")
+        (is (= :rf.machine/spawn (:failing-id (first records)))
+            "the production record names the REAL override, not the nil/false placeholders"))
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (let [rejected (filter #(= :rf.error/reserved-fx-override (:operation %)) @traces)]
+          (is (= 1 (count rejected))
+              "exactly ONE reserved-fx-override — for the real :rf.machine/spawn override only")
+          (is (= :rf.machine/spawn (get-in (first rejected) [:tags :rf.fx/id]))
+              "the emitted error names the REAL override, not the nil/false placeholders")))))
 
   (testing "an all-nil/false reject-tier override map is returned by identity
             (no churn) — the guard sees no REAL reject-tier override"
@@ -1649,6 +1807,7 @@
     ;; child's :rf.fx/reg-flow runs its reserved body (flow registered) — the
     ;; reject-tier override is gone by the time the child cascade resolves.
     (let [traces      (collect-traces! ::cascade-exclude)
+          errors      (collect-errors! ::cascade-exclude-errors)
           child-stub  (atom 0)]
       (rf/reg-event :fx-test.snsup5/child-installs-flow
         (fn [_ _] {:fx [[:rf.fx/reg-flow [:fx-test.snsup5/child-flow {:inputs [[:fx-test.snsup5 :seed]] :output-path [:fx-test.snsup5 :child]} (fn [_] 7)]]]}))
@@ -1659,7 +1818,8 @@
       (rf/dispatch-sync
         [:fx-test.snsup5/parent-cascades]
         {:fx-overrides {:rf.fx/reg-flow (fn [_ _] (swap! child-stub inc))}})
-      (rf/unregister-listener! :trace ::cascade-exclude)
+      (rf/unregister-listener! :trace  ::cascade-exclude)
+      (rf/unregister-listener! :errors ::cascade-exclude-errors)
       (is (= 0 @child-stub)
           "the reject-tier override did not fire in the child cascade either")
       (is (contains? (get (flows/flows-snapshot) :rf/default) :fx-test.snsup5/child-flow)
@@ -1670,8 +1830,27 @@
       ;; (the override was excluded from the child opts, so the child never
       ;; sees it to reject). The child's :rf.fx/reg-flow resolves with NO
       ;; override → zero reject emits attributable to the child.
-      (is (zero? (count (filter #(= :rf.error/reserved-fx-override (:operation %)) @traces)))
-          "no :rf.error/reserved-fx-override fired — the override was excluded from the child opts (not inherited-then-rejected)"))))
+      ;;
+      ;; PRODUCTION-VISIBLE WITNESS (rf2-d2841), and it is ATTRIBUTED rather
+      ;; than a bare zero, because the total is genuinely posture-dependent
+      ;; here. Under `-Dre-frame.debug=false` the router runs
+      ;; `strip-rejected-overrides` over the PARENT's effective override map
+      ;; (router.cljc §do-fx-for), which legitimately emits ONE always-on
+      ;; record attributed to the parent event. What must be zero in BOTH
+      ;; postures is any record attributed to the CHILD — that is exactly the
+      ;; claim "the reject-tier override was excluded from the child opts,
+      ;; not inherited-then-rejected", and asserting it this way makes the
+      ;; cascade-exclusion load-bearing in the posture where the prod-strip
+      ;; is the live path rather than a unit-tested one.
+      (is (empty? (filter #(and (= :rf.error/reserved-fx-override (:error %))
+                                (= :fx-test.snsup5/child-installs-flow (:event-id %)))
+                          @errors))
+          "no always-on reserved-fx-override attributed to the CHILD — the override was excluded from the child opts (not inherited-then-rejected)")
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring). In the dev
+      ;; posture there is no prod-strip at all, so the total is zero.
+      (when interop/debug-enabled?
+        (is (zero? (count (filter #(= :rf.error/reserved-fx-override (:operation %)) @traces)))
+            "no :rf.error/reserved-fx-override fired — the override was excluded from the child opts (not inherited-then-rejected)")))))
 
 ;; ---- 7d. SOURCE vs TARGET policy separation (rf2-1w4af) -------------------
 ;;
@@ -1728,21 +1907,56 @@
 ;; The reason is now id-specific. TAG SHAPE IS UNCHANGED — `:reason` was
 ;; already a string in `:tags`; only its content is derived per id, so no Spec
 ;; 009 catalogue / Spec-Schemas row moves on the shape axis.
+;;
+;; POSTURE (rf2-d2841). This whole section is PRODUCTION-REAL and needs no
+;; guard. The premise in the paragraph above — "a programmer who overrode it
+;; was handed the wrong reason on a production-reachable error channel" — is
+;; only true if the `:reason` actually reaches that channel, and it does:
+;; `emit-reserved-fx-override!` stamps `:failing-id` = the rejected fx-id,
+;; which differs from `:event-id`, so `error-emit/emit-error-both!` lifts BOTH
+;; `:failing-id` and `:reason` onto the always-on record (Spec 009 §Component
+;; attribution). `reject-reason-for` therefore reads the string off the
+;; ALWAYS-ON axis rather than the DCE'd trace tags, and every assertion below
+;; runs unchanged under `-Dre-frame.debug=false`. Read off the dev trace these
+;; were 21 NPEs under the gate (`re-find` on a nil reason) — the diagnostic
+;; that production actually ships was never being checked.
 
 (defn- reject-reason-for
   "The `:reason` string the reject diagnostic emits for `fx-id`, read off the
-  real producer (the prod-strip emit) rather than reconstructed."
+  real producer (the prod-strip emit) rather than reconstructed — and off the
+  ALWAYS-ON `:errors` axis (rf2-d2841), which is the channel the reason's
+  accuracy actually matters on and the one that survives
+  `-Dre-frame.debug=false`."
   [fx-id]
-  (let [traces (collect-traces! ::reject-reason)]
+  (let [errors (collect-errors! ::reject-reason)]
     (fx/strip-rejected-overrides {fx-id (fn [_ _] :stub)} :rf/default [:some/event])
-    (rf/unregister-listener! :trace ::reject-reason)
-    (->> @traces
-         (filter #(= :rf.error/reserved-fx-override (:operation %)))
+    (rf/unregister-listener! :errors ::reject-reason)
+    (->> @errors
+         (filter #(= :rf.error/reserved-fx-override (:error %)))
          first
-         :tags
          :reason)))
 
 (deftest reject-diagnostic-reason-is-id-specific
+  (testing "the reason rides the ALWAYS-ON record, alongside the :failing-id it
+            is about — the mechanism every assertion below depends on"
+    ;; rf2-d2841: pin the lift itself, so a regression that dropped
+    ;; `:failing-id` from `emit-reserved-fx-override!` (and with it the
+    ;; `:reason`, which `emit-error-both!` lifts only when `:failing-id` is
+    ;; present and distinct from `:event-id`) fails HERE with a clear cause
+    ;; rather than as a wall of nil-reason NPEs below.
+    (let [errors (collect-errors! ::reject-reason-lift)]
+      (fx/strip-rejected-overrides {:rf.machine/spawn (fn [_ _] :stub)}
+                                   :rf/default [:some/event])
+      (rf/unregister-listener! :errors ::reject-reason-lift)
+      (let [r (first (filter #(= :rf.error/reserved-fx-override (:error %)) @errors))]
+        (is (some? r) "the reject reached the always-on error listener")
+        (is (= :rf.machine/spawn (:failing-id r))
+            ":failing-id names the rejected fx-id, DISTINCT from :event-id")
+        (is (= :some/event (:event-id r))
+            ":event-id still carries the dispatched event id")
+        (is (string? (:reason r))
+            ":reason was lifted onto the production record alongside :failing-id"))))
+
   (testing "join-dispatch's reason gives its OWN transport rationale and does
             NOT claim it installs runtime state or threads a nav-token"
     (let [reason (reject-reason-for :rf.machine/join-dispatch)]
@@ -1801,48 +2015,78 @@
 ;; (boolean) onto the :rf.fx/do-fx marker that terminates the do-fx
 ;; walk. Stamps the SHAPE, not deep values; Event lens (rf2-zh2qc)
 ;; consumers can align cascade rows with handler returns.
+;;
+;; POSTURE (rf2-d2841). `:rf.fx/do-fx` is a bare `trace/emit!` marker with no
+;; always-on twin — it exists FOR the Xray Event lens, a dev tool — so every
+;; assertion about its tags rides a `(when interop/debug-enabled? …)` arm. What
+;; the marker REPORTS, though, is a fact about the handler's return being
+;; honoured, and that is production-real: each deftest below now pins the
+;; corresponding execution fact posture-independently, so none of them is a
+;; deftest that executes nothing under the production gate.
 
 (deftest event-do-fx-stamps-fx-and-db-present
   (testing "a reg-event handler returning {:db ... :fx [...]} fires :rf.fx/do-fx
    with :fx (the vector) and :db-present? true under :tags (same slot
    placement as :frame — payload-shaped tags ride under :tags)"
-    (rf/reg-fx :fx-test/do-fx-shape (fn [_ _] :ok))
-    (rf/reg-event :fx-test/returns-db-and-fx
-      (fn [_ _]
-        {:db {:seeded? true}
-         :fx [[:fx-test/do-fx-shape {:k 1}]]}))
-    (let [acc (collect-traces! ::do-fx-shape)]
-      (try
-        (rf/dispatch-sync [:fx-test/returns-db-and-fx])
-        (let [[dof] (filterv #(= :rf.fx/do-fx (:operation %)) @acc)
-              tags  (:tags dof)]
-          (is (some? dof) ":rf.fx/do-fx fired")
-          (is (= true (:rf.event/db-present? tags))
-              ":rf.event/db-present? true because the handler returned a :db slot")
-          (is (= [[:fx-test/do-fx-shape {:k 1}]] (:rf.event/fx tags))
-              ":rf.event/fx vector matches what the handler returned"))
-        (finally
-          (rf/unregister-listener! :trace ::do-fx-shape))))))
+    (let [fx-args (atom ::unfired)]
+      (rf/reg-fx :fx-test/do-fx-shape (fn [_ args] (reset! fx-args args) :ok))
+      (rf/reg-event :fx-test/returns-db-and-fx
+        (fn [_ _]
+          {:db {:seeded? true}
+           :fx [[:fx-test/do-fx-shape {:k 1}]]}))
+      (let [acc (collect-traces! ::do-fx-shape)]
+        (try
+          (rf/dispatch-sync [:fx-test/returns-db-and-fx])
+          ;; Production-visible witness (rf2-d2841): the marker's two tags are
+          ;; a REPORT of what the handler returned; the returns themselves are
+          ;; observable without any trace surface.
+          (is (= {:k 1} @fx-args)
+              "the returned :fx entry actually fired with its args")
+          (is (= true (:seeded? (rf/app-db-value :rf/default)))
+              "the returned :db slot actually committed (:db-present? true's referent)")
+          ;; rf2-d2841 — dev-instrumentation arm (see the section note above).
+          (when interop/debug-enabled?
+            (let [[dof] (filterv #(= :rf.fx/do-fx (:operation %)) @acc)
+                  tags  (:tags dof)]
+              (is (some? dof) ":rf.fx/do-fx fired")
+              (is (= true (:rf.event/db-present? tags))
+                  ":rf.event/db-present? true because the handler returned a :db slot")
+              (is (= [[:fx-test/do-fx-shape {:k 1}]] (:rf.event/fx tags))
+                  ":rf.event/fx vector matches what the handler returned")))
+          (finally
+            (rf/unregister-listener! :trace ::do-fx-shape)))))))
 
 (deftest event-do-fx-stamps-when-only-fx-returned
   (testing "a reg-event handler returning {:fx [...]} only (no :db slot) stamps
    :db-present? false and :fx with the vector"
-    (rf/reg-fx :fx-test/no-db-fx (fn [_ _] :ok))
-    (rf/reg-event :fx-test/fx-only
-      (fn [_ _]
-        {:fx [[:fx-test/no-db-fx {}]]}))
-    (let [acc (collect-traces! ::no-db)]
-      (try
-        (rf/dispatch-sync [:fx-test/fx-only])
-        (let [[dof] (filterv #(= :rf.fx/do-fx (:operation %)) @acc)
-              tags  (:tags dof)]
-          (is (some? dof) ":rf.fx/do-fx fired")
-          (is (= false (:rf.event/db-present? tags))
-              ":rf.event/db-present? false because the handler returned no :db slot")
-          (is (= [[:fx-test/no-db-fx {}]] (:rf.event/fx tags))
-              ":rf.event/fx vector matches what the handler returned"))
-        (finally
-          (rf/unregister-listener! :trace ::no-db))))))
+    (let [fx-fired (atom 0)]
+      (rf/reg-fx :fx-test/no-db-fx (fn [_ _] (swap! fx-fired inc) :ok))
+      (rf/reg-event :fx-test/db-seed
+        (fn [{:keys [db]} _] {:db (assoc db :pre-existing :kept)}))
+      (rf/reg-event :fx-test/fx-only
+        (fn [_ _]
+          {:fx [[:fx-test/no-db-fx {}]]}))
+      (let [acc (collect-traces! ::no-db)]
+        (try
+          (rf/dispatch-sync [:fx-test/db-seed])
+          (rf/dispatch-sync [:fx-test/fx-only])
+          ;; Production-visible witness (rf2-d2841): "no :db slot" means the
+          ;; commit path was not taken, which is observable as app-db being
+          ;; left exactly as the previous event left it.
+          (is (= 1 @fx-fired) "the returned :fx entry fired")
+          (is (= :kept (:pre-existing (rf/app-db-value :rf/default)))
+              "app-db is untouched by the :fx-only handler (:db-present? false's referent)")
+          ;; rf2-d2841 — dev-instrumentation arm (see the section note above).
+          (when interop/debug-enabled?
+            (let [[dof] (filterv #(= :rf.fx/do-fx (:operation %)) @acc)
+                  tags  (:tags dof)]
+              (is (some? dof) ":rf.fx/do-fx fired")
+              (is (= false (:rf.event/db-present? tags))
+                  ":rf.event/db-present? false because the handler returned no :db slot")
+              (is (= [[:fx-test/no-db-fx {}]] (:rf.event/fx tags))
+                  ":rf.event/fx vector matches what the handler returned")))
+          (finally
+            (rf/unregister-listener! :trace ::no-db)))))))
 
 (deftest event-do-fx-stamp-rides-under-tags
   (testing ":fx and :db-present? are payload-shaped slots — they ride
@@ -1855,16 +2099,24 @@
     (let [acc (collect-traces! ::top-level)]
       (try
         (rf/dispatch-sync [:fx-test/top-level-shape])
-        (let [[dof] (filterv #(= :rf.fx/do-fx (:operation %)) @acc)
-              tags  (:tags dof)]
-          (is (some? dof) ":rf.fx/do-fx fired")
-          (is (contains? tags :rf.event/fx)          ":rf.event/fx lives under :tags")
-          (is (contains? tags :rf.event/db-present?) ":rf.event/db-present? lives under :tags")
-          (is (contains? tags :frame)                ":frame is alongside (pre-existing)")
-          (is (not (contains? dof :rf.event/fx))
-              ":rf.event/fx is NOT at top level")
-          (is (not (contains? dof :rf.event/db-present?))
-              ":rf.event/db-present? is NOT at top level"))
+        ;; Production-visible witness (rf2-d2841): an empty `:fx` vector is
+        ;; still a legal return and the `:db` beside it must commit.
+        (is (= 1 (:x (rf/app-db-value :rf/default)))
+            "the {:db … :fx []} return committed its :db slot")
+        ;; rf2-d2841 — dev-instrumentation arm. This deftest is about the
+        ;; SLOT PLACEMENT of two dev-trace tags; that has no production
+        ;; referent at all, so it is guarded whole.
+        (when interop/debug-enabled?
+          (let [[dof] (filterv #(= :rf.fx/do-fx (:operation %)) @acc)
+                tags  (:tags dof)]
+            (is (some? dof) ":rf.fx/do-fx fired")
+            (is (contains? tags :rf.event/fx)          ":rf.event/fx lives under :tags")
+            (is (contains? tags :rf.event/db-present?) ":rf.event/db-present? lives under :tags")
+            (is (contains? tags :frame)                ":frame is alongside (pre-existing)")
+            (is (not (contains? dof :rf.event/fx))
+                ":rf.event/fx is NOT at top level")
+            (is (not (contains? dof :rf.event/db-present?))
+                ":rf.event/db-present? is NOT at top level")))
         (finally
           (rf/unregister-listener! :trace ::top-level))))))
 
@@ -1882,6 +2134,14 @@
 ;; uniformly across event flavours. The substrate-side filter
 ;; (`fx/user-injected-coeffects`) keeps the framework defaults
 ;; (:db :event :frame :source :trace-id) out at emit time.
+;;
+;; POSTURE (rf2-d2841). `:rf.event/run-end` is a dev-only `trace/emit!`, and
+;; the stamp exists to feed the Xray Event lens — a dev tool — so the tag
+;; assertions ride a `(when interop/debug-enabled? …)` arm. Underneath the
+;; stamp sits a production-real fact: the declared `:rf.cofx/requires`
+;; suppliers RAN and their values reached the handler body. Each deftest below
+;; now pins that delivery posture-independently, so the cofx pipeline itself
+;; is covered under the production gate even though its trace stamp is not.
 
 (deftest event-run-end-stamps-user-injected-coeffects-with-fx
   (testing "a handler whose chain injects user coeffects (:now etc.)
@@ -1891,28 +2151,40 @@
     (rf/reg-fx :fx-test/cofx-sink (fn [_ _] :ok))
     (rf/reg-cofx :fx-test/now    (fn [] "2026-05-18T19:00:00Z"))
     (rf/reg-cofx :fx-test/locale (fn [] :en-AU))
-    (rf/reg-event :fx-test/uses-user-cofx
-      {:rf.cofx/requires [:fx-test/now :fx-test/locale]}
-      (fn [_ _] {:db {:k 1}
-                 :fx [[:fx-test/cofx-sink :go]]}))
-    (let [acc (collect-traces! ::user-cofx)]
-      (try
-        (rf/dispatch-sync [:fx-test/uses-user-cofx])
-        (let [[re]  (filterv #(= :rf.event/run-end (:operation %)) @acc)
-              cofx  (get-in re [:tags :rf.event/coeffects])
-              [dof] (filterv #(= :rf.fx/do-fx (:operation %)) @acc)]
-          (is (some? re) ":rf.event/run-end fired")
+    (let [delivered (atom nil)]
+      (rf/reg-event :fx-test/uses-user-cofx
+        {:rf.cofx/requires [:fx-test/now :fx-test/locale]}
+        (fn [ctx _] (reset! delivered (select-keys ctx [:fx-test/now :fx-test/locale]))
+                    {:db {:k 1}
+                     :fx [[:fx-test/cofx-sink :go]]}))
+      (let [acc (collect-traces! ::user-cofx)]
+        (try
+          (rf/dispatch-sync [:fx-test/uses-user-cofx])
+          ;; Production-visible witness (rf2-d2841): the stamp REPORTS the
+          ;; coeffect map the handler was given, and that delivery is
+          ;; production-real — the `:rf.cofx/requires` suppliers run in both
+          ;; postures. Pin what the handler body actually received.
           (is (= {:fx-test/now    "2026-05-18T19:00:00Z"
                   :fx-test/locale :en-AU}
-                 cofx)
-              "only the user-injected coeffects ride under :tags :rf.event/coeffects on run-end")
-          (is (not (contains? cofx :db))    "framework :db NOT stamped")
-          (is (not (contains? cofx :event)) "framework :event NOT stamped")
-          (is (not (contains? cofx :frame)) "framework :frame NOT stamped")
-          (is (not (contains? (:tags dof) :rf.event/coeffects))
-              "the stamp lives on run-end now — :rf.fx/do-fx no longer carries it"))
-        (finally
-          (rf/unregister-listener! :trace ::user-cofx))))))
+                 @delivered)
+              "both declared :rf.cofx/requires suppliers ran and reached the handler body")
+          ;; rf2-d2841 — dev-instrumentation arm (see the section note above).
+          (when interop/debug-enabled?
+            (let [[re]  (filterv #(= :rf.event/run-end (:operation %)) @acc)
+                  cofx  (get-in re [:tags :rf.event/coeffects])
+                  [dof] (filterv #(= :rf.fx/do-fx (:operation %)) @acc)]
+              (is (some? re) ":rf.event/run-end fired")
+              (is (= {:fx-test/now    "2026-05-18T19:00:00Z"
+                      :fx-test/locale :en-AU}
+                     cofx)
+                  "only the user-injected coeffects ride under :tags :rf.event/coeffects on run-end")
+              (is (not (contains? cofx :db))    "framework :db NOT stamped")
+              (is (not (contains? cofx :event)) "framework :event NOT stamped")
+              (is (not (contains? cofx :frame)) "framework :frame NOT stamped")
+              (is (not (contains? (:tags dof) :rf.event/coeffects))
+                  "the stamp lives on run-end now — :rf.fx/do-fx no longer carries it")))
+          (finally
+            (rf/unregister-listener! :trace ::user-cofx)))))))
 
 (deftest event-run-end-stamps-user-injected-coeffects-without-fx
   (testing "rf2-9dk9y bug A — a reg-event handler that injects user cofx and
@@ -1929,16 +2201,24 @@
     (let [acc (collect-traces! ::db-only-cofx)]
       (try
         (rf/dispatch-sync [:fx-test/db-only-with-cofx])
-        (let [[re]  (filterv #(= :rf.event/run-end (:operation %)) @acc)
-              cofx  (get-in re [:tags :rf.event/coeffects])
-              dof   (first (filterv #(= :rf.fx/do-fx (:operation %)) @acc))]
-          (is (some? re) ":rf.event/run-end fired (always — independent of :fx)")
-          (is (= {:fx-test/now "2026-05-18T19:00:00Z"} cofx)
-              "the user-injected cofx surfaces under :tags :rf.event/coeffects
-               EVEN THOUGH the handler returned no :fx — bug A's repro")
-          (is (nil? dof)
-              ":rf.fx/do-fx was correctly NOT emitted (no :fx vector); the
-               cofx stamp would have been dropped if it still rode on do-fx"))
+        ;; Production-visible witness (rf2-d2841): bug A's repro is a handler
+        ;; that injects a cofx and returns ONLY `:db`. That the supplier ran
+        ;; and its value reached the body is production-real and is visible
+        ;; in app-db — the handler writes the injected value straight into it.
+        (is (= "2026-05-18T19:00:00Z" (:stamped-at (rf/app-db-value :rf/default)))
+            "the declared cofx supplier ran and its value reached the handler body")
+        ;; rf2-d2841 — dev-instrumentation arm (see the section note above).
+        (when interop/debug-enabled?
+          (let [[re]  (filterv #(= :rf.event/run-end (:operation %)) @acc)
+                cofx  (get-in re [:tags :rf.event/coeffects])
+                dof   (first (filterv #(= :rf.fx/do-fx (:operation %)) @acc))]
+            (is (some? re) ":rf.event/run-end fired (always — independent of :fx)")
+            (is (= {:fx-test/now "2026-05-18T19:00:00Z"} cofx)
+                "the user-injected cofx surfaces under :tags :rf.event/coeffects
+                 EVEN THOUGH the handler returned no :fx — bug A's repro")
+            (is (nil? dof)
+                ":rf.fx/do-fx was correctly NOT emitted (no :fx vector); the
+                 cofx stamp would have been dropped if it still rode on do-fx")))
         (finally
           (rf/unregister-listener! :trace ::db-only-cofx))))))
 
@@ -1951,11 +2231,20 @@
     (let [acc (collect-traces! ::no-cofx)]
       (try
         (rf/dispatch-sync [:fx-test/no-user-cofx])
-        (let [[re]  (filterv #(= :rf.event/run-end (:operation %)) @acc)
-              tags  (:tags re)]
-          (is (some? re) ":rf.event/run-end fired")
-          (is (not (contains? tags :rf.event/coeffects))
-              ":rf.event/coeffects key ABSENT on :tags when no user cofx injected"))
+        ;; Production-visible witness (rf2-d2841): the handler ran to
+        ;; completion — the precondition for "run-end fired" — and did so
+        ;; without declaring any cofx.
+        (is (= 1 (:k (rf/app-db-value :rf/default)))
+            "the cofx-free handler ran and committed")
+        ;; rf2-d2841 — dev-instrumentation arm. "The key is ABSENT from the
+        ;; stamp" is a claim about a dev-only tag map with no production
+        ;; referent; over an empty ring it would also pass vacuously.
+        (when interop/debug-enabled?
+          (let [[re]  (filterv #(= :rf.event/run-end (:operation %)) @acc)
+                tags  (:tags re)]
+            (is (some? re) ":rf.event/run-end fired")
+            (is (not (contains? tags :rf.event/coeffects))
+                ":rf.event/coeffects key ABSENT on :tags when no user cofx injected")))
         (finally
           (rf/unregister-listener! :trace ::no-cofx))))))
 

--- a/implementation/core/test/re_frame/fx_test.clj
+++ b/implementation/core/test/re_frame/fx_test.clj
@@ -23,11 +23,52 @@
         wild malformation is policed LOUDLY end-to-end, NOT silently truncated.
 
   Per Spec 002 §`:fx` ordering and atomicity guarantees and Spec 009
-  §Error contract."
+  §Error contract.
+
+  ## Posture split (rf2-d2841)
+
+  The fx subsystem's SEMANTICS are production-real and are asserted here
+  WITHOUT a posture guard, so they run in the ordinary `clojure -M:test`
+  suite AND in `scripts/test-core-prod-gate.sh` (the `-Dre-frame.debug=false`
+  lane): source-order walking, override precedence, `:isolated` recovery past
+  a throwing fx, `:platforms` gating, the M-8 / `:fx`-value / `:fx`-entry
+  policing DROPS, the reject-tier neutralisation, prod-strip's returned map,
+  and the registration-time `reg-fx` rejections.
+
+  Two DIAGNOSTIC channels sit beside those semantics, and they are not the
+  same channel:
+
+  * The `:trace` stream (`collect-traces!`) is DEV-ONLY. Every `trace/emit!`
+    / `trace/emit-error!` site rides `interop/debug-enabled?`, which the JVM
+    reads once at load time, so under the real gate the ring is EMPTY BY
+    DESIGN. `:rf.error/effect-map-shape` (Spec 009 catalogue: channel
+    `diagnostic`), `:rf.fx/skipped-on-platform`, `:rf.fx/override-applied`,
+    `:rf.fx/do-fx` and `:rf.event/run-end` live ONLY here. Their assertions
+    are kept VERBATIM inside a `(when interop/debug-enabled? …)` arm marked
+    `rf2-d2841`.
+
+  * The `:errors` stream (`collect-errors!`) is ALWAYS-ON and survives the
+    gate. `:rf.error/fx-handler-exception`, `:rf.error/no-such-fx`,
+    `:rf.error/override-fallthrough` and `:rf.error/reserved-fx-override`
+    fan out through `emit-fx-error!` → `error-emit/emit-error-both!`, which
+    additionally LIFTS `:failing-id` / `:reason` onto the record whenever the
+    failing component differs from the dispatched event (Spec 009 §Component
+    attribution). Where the dev trace had been an assertion's only witness
+    and one of those four categories was available, the assertion gained a
+    production-visible twin on this axis rather than being guarded away —
+    including the NEGATIVE ones, which over the dev ring would pass
+    vacuously under the gate.
+
+  A negative dev-trace assertion (`empty?` / `zero? (count …)`) is the
+  false-green this lane exists to close: left outside an arm it passes
+  because the ring is empty, not because the framework stayed silent. Every
+  one of them here either moved inside the arm or was re-pointed at the
+  always-on axis."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.fx :as fx]
             [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
             [re-frame.registrar :as registrar]
             [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]
@@ -265,6 +306,7 @@
 (deftest fx-handler-exception-is-isolated
   (testing "a throwing fx emits :rf.error/fx-handler-exception, sibling fx still fire"
     (let [traces (collect-traces! ::fx-exc)
+          errors (collect-errors! ::fx-exc-errors)
           fired  (atom [])]
       (rf/reg-fx :fx-test/boom
         (fn [_ _] (throw (ex-info "kaboom" {:why :test}))))
@@ -275,23 +317,46 @@
           {:fx [[:fx-test/boom  {:reason :first}]
                 [:fx-test/after {:reason :sibling}]]}))
       (rf/dispatch-sync [:fx-test/with-bad-fx])
-      (rf/unregister-listener! :trace ::fx-exc)
+      (rf/unregister-listener! :trace  ::fx-exc)
+      (rf/unregister-listener! :errors ::fx-exc-errors)
       ;; Sibling fx ran — recovery is :isolated.
       (is (= [{:reason :sibling}] @fired)
           "the :fx after the throwing entry still fires (Spec 002 rule 4)")
-      ;; The structured trace is present.
-      (let [exc-traces (filter #(= :rf.error/fx-handler-exception (:operation %))
-                               @traces)]
-        (is (= 1 (count exc-traces))
-            "exactly one :rf.error/fx-handler-exception was emitted")
-        (let [t (first exc-traces)]
-          (is (= :error (:op-type t)))
-          (is (= :fx-test/boom (get-in t [:tags :rf.fx/id])))
-          (is (= :fx-test/boom (get-in t [:tags :failing-id])))
-          (is (= {:reason :first} (get-in t [:tags :rf.fx/args]))
-              ":rf.fx/args carry the offending args")
-          (is (string? (get-in t [:tags :exception-message])))
-          (is (some? (get-in t [:tags :exception]))))))))
+      ;; PRODUCTION-VISIBLE WITNESS (rf2-d2841). `:rf.error/fx-handler-exception`
+      ;; is an ALWAYS-ON category (Spec 009 §Observability channels), so the
+      ;; structured diagnostic is observable under `-Dre-frame.debug=false`
+      ;; too — on the `:errors` axis rather than the DCE'd trace ring. The
+      ;; failing fx-id is DISTINCT from the dispatched event-id, so
+      ;; `emit-error-both!` lifts it onto the record as `:failing-id`
+      ;; (Spec 009 §Component attribution).
+      (let [records (filter #(= :rf.error/fx-handler-exception (:error %)) @errors)]
+        (is (= 1 (count records))
+            "exactly ONE always-on record reached the :errors listener")
+        (let [r (first records)]
+          (is (= :fx-test/boom (:failing-id r))
+              ":failing-id names the THROWING fx, not the dispatched event")
+          (is (= :fx-test/with-bad-fx (:event-id r))
+              ":event-id carries the dispatching event id")
+          (is (= [:fx-test/with-bad-fx] (:event r)))
+          (is (= :rf/default (:frame r)))
+          (is (some? (:exception r))
+              "the exception object rides the production record")))
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring). The trace
+      ;; ring carries the RICHER shape (`:rf.fx/args`, `:exception-message`,
+      ;; `:op-type`) that the tight always-on record deliberately omits.
+      (when interop/debug-enabled?
+        (let [exc-traces (filter #(= :rf.error/fx-handler-exception (:operation %))
+                                 @traces)]
+          (is (= 1 (count exc-traces))
+              "exactly one :rf.error/fx-handler-exception was emitted")
+          (let [t (first exc-traces)]
+            (is (= :error (:op-type t)))
+            (is (= :fx-test/boom (get-in t [:tags :rf.fx/id])))
+            (is (= :fx-test/boom (get-in t [:tags :failing-id])))
+            (is (= {:reason :first} (get-in t [:tags :rf.fx/args]))
+                ":rf.fx/args carry the offending args")
+            (is (string? (get-in t [:tags :exception-message])))
+            (is (some? (get-in t [:tags :exception])))))))))
 
 ;; ---- 4. Missing fx-id → :rf.error/no-such-fx ------------------------------
 ;;
@@ -306,6 +371,7 @@
 (deftest unknown-fx-id-is-logged-and-skipped
   (testing "a registered handler returning [:no-such-fx ...] traces and skips"
     (let [traces (collect-traces! ::no-such)
+          errors (collect-errors! ::no-such-errors)
           fired  (atom [])]
       (rf/reg-fx :fx-test/sibling
         (fn [_ args] (swap! fired conj args)))
@@ -314,18 +380,45 @@
           {:fx [[:fx-test/never-registered  {:k 1}]
                 [:fx-test/sibling           {:k 2}]]}))
       (rf/dispatch-sync [:fx-test/missing])
-      (rf/unregister-listener! :trace ::no-such)
+      (rf/unregister-listener! :trace  ::no-such)
+      (rf/unregister-listener! :errors ::no-such-errors)
       ;; Sibling still fires — the unknown fx-id did not halt the walk.
       (is (= [{:k 2}] @fired)
           "the next :fx entry still fires after an unknown fx-id")
-      (let [missing-traces (filter #(= :rf.error/no-such-fx (:operation %))
-                                   @traces)]
-        (is (= 1 (count missing-traces))
-            "exactly one :rf.error/no-such-fx trace was emitted")
-        (let [t (first missing-traces)]
-          (is (= :error (:op-type t)))
-          (is (= :fx-test/never-registered (get-in t [:tags :rf.fx/id])))
-          (is (= :rf/default (get-in t [:tags :frame]))))))))
+      ;; PRODUCTION-VISIBLE WITNESS (rf2-d2841). Spec 009's catalogue marks
+      ;; `:rf.error/no-such-fx` ALWAYS-ON, so an unknown fx-id is observable
+      ;; off-box under `-Dre-frame.debug=false`.
+      ;;
+      ;; NOTE (rf2-g0mep, filed): the always-on RECORD does not name WHICH
+      ;; fx-id was unknown. `fx.cljc`'s `:rf.error/no-such-fx` trace-payload
+      ;; omits `:failing-id`, so `emit-error-both!`'s attribution lift does
+      ;; not fire and `:rf.fx/id` stays on the DCE'd trace tags — even though
+      ;; Spec 009 §Component attribution states the rule as "every always-on
+      ;; error record carries `:failing-id` naming the failing COMPONENT
+      ;; whenever that component is DISTINCT from the dispatched event", and
+      ;; the three sibling emit sites in the same file (`fx-handler-exception`,
+      ;; `override-fallthrough`, `reserved-fx-override`) all stamp it. That is
+      ;; a production-source question, filed rather than papered over here.
+      (let [records (filter #(= :rf.error/no-such-fx (:error %)) @errors)]
+        (is (= 1 (count records))
+            "exactly ONE always-on record reached the :errors listener")
+        (let [r (first records)]
+          (is (= :fx-test/missing (:event-id r))
+              ":event-id carries the dispatching event id")
+          (is (= [:fx-test/missing] (:event r)))
+          (is (= :rf/default (:frame r))
+              ":frame names the frame the unknown fx-id was dispatched in")))
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring). The offending
+      ;; fx-id itself is observable only here (see the NOTE above).
+      (when interop/debug-enabled?
+        (let [missing-traces (filter #(= :rf.error/no-such-fx (:operation %))
+                                     @traces)]
+          (is (= 1 (count missing-traces))
+              "exactly one :rf.error/no-such-fx trace was emitted")
+          (let [t (first missing-traces)]
+            (is (= :error (:op-type t)))
+            (is (= :fx-test/never-registered (get-in t [:tags :rf.fx/id])))
+            (is (= :rf/default (get-in t [:tags :frame])))))))))
 
 ;; ---- 5. :platforms gating -------------------------------------------------
 ;;
@@ -350,16 +443,22 @@
       (rf/unregister-listener! :trace ::plat)
       (is (false? @fired?)
           "the client-only handler did NOT run on the JVM (:server)")
-      (let [skip-traces (filter #(= :rf.fx/skipped-on-platform (:operation %))
-                                @traces)]
-        (is (= 1 (count skip-traces))
-            "exactly one :rf.fx/skipped-on-platform trace was emitted")
-        (let [t (first skip-traces)]
-          (is (= :warning (:op-type t)))
-          (is (= :skipped (:recovery t)))
-          (is (= :fx-test/local-storage (get-in t [:tags :rf.fx/id])))
-          (is (= :server (get-in t [:tags :rf.fx/platform])))
-          (is (= #{:client} (get-in t [:tags :rf.fx/registered-platforms]))))))))
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring).
+      ;; `:rf.fx/skipped-on-platform` is a `trace/emit!` WARNING (fx.cljc
+      ;; §handle-one-fx), not a promoted `:rf.error/*` — it has no always-on
+      ;; twin, so the SKIP itself (asserted above, posture-independently) is
+      ;; the production-visible fact and the diagnostic is dev-only by design.
+      (when interop/debug-enabled?
+        (let [skip-traces (filter #(= :rf.fx/skipped-on-platform (:operation %))
+                                  @traces)]
+          (is (= 1 (count skip-traces))
+              "exactly one :rf.fx/skipped-on-platform trace was emitted")
+          (let [t (first skip-traces)]
+            (is (= :warning (:op-type t)))
+            (is (= :skipped (:recovery t)))
+            (is (= :fx-test/local-storage (get-in t [:tags :rf.fx/id])))
+            (is (= :server (get-in t [:tags :rf.fx/platform])))
+            (is (= #{:client} (get-in t [:tags :rf.fx/registered-platforms])))))))))
 
 ;; ---- 6. Effect-map shape policing (M-8) -----------------------------------
 ;;
@@ -377,6 +476,19 @@
 ;; returned, emitting :rf.error/effect-map-shape per offending top-level key
 ;; with :recovery :logged-and-skipped. The offending keys are dropped from
 ;; the threaded effects map.
+;;
+;; POSTURE (rf2-d2841). The DROP is production-real — `police-effect-map-shape!`,
+;; `fx-value-ok?` and `fx-entry-ok?` run unconditionally, so every "the
+;; offending key/value/entry did NOT take effect, and its siblings did" claim
+;; below is asserted posture-independently and runs under the production gate.
+;; The :rf.error/effect-map-shape DIAGNOSTIC is dev-only, and deliberately so:
+;; Spec 009's catalogue row marks its Channel `diagnostic`, not always-on
+;; (009-Instrumentation.md §Error event catalogue), and all three emit sites
+;; — events.cljc §police-effect-map-shape!, events.cljc §fx-value-ok?,
+;; fx.cljc §fx-entry-ok? — are `trace/emit-error!`, with no `emit-fx-error!`
+;; always-on leg. So the trace assertions ride a `(when interop/debug-enabled? …)`
+;; arm, INCLUDING the negative "no shape trace fired" ones on the clean paths:
+;; over an empty ring those pass automatically and would report a false green.
 
 (deftest legacy-effect-map-key-is-policed
   (testing "a handler returning {:dispatch ...} (legacy v1 top-level key) is policed"
@@ -399,21 +511,23 @@
           "the legacy top-level :dispatch must NOT silently dispatch the event")
       ;; A structured :rf.error/effect-map-shape trace is emitted (Spec
       ;; 009 §Error contract).
-      (let [shape-traces (filter #(= :rf.error/effect-map-shape (:operation %))
-                                 @traces)]
-        (is (= 1 (count shape-traces))
-            "exactly one :rf.error/effect-map-shape trace was emitted")
-        (let [t (first shape-traces)]
-          (is (= :error (:op-type t)))
-          (is (= :logged-and-skipped (:recovery t)))
-          (is (= :dispatch (get-in t [:tags :offending-key]))
-              ":offending-key carries the legacy top-level key")
-          (is (= :fx-test/legacy-dispatch (get-in t [:tags :rf.trace/event-id]))
-              ":event-id carries the dispatching event id")
-          (is (= [:fx-test/sentinel] (get-in t [:tags :value]))
-              ":value carries the offending key's value")
-          (is (string? (get-in t [:tags :reason]))
-              ":reason is a one-sentence human-facing description"))))))
+      ;; rf2-d2841 — dev-instrumentation arm (see the §6 posture note above).
+      (when interop/debug-enabled?
+        (let [shape-traces (filter #(= :rf.error/effect-map-shape (:operation %))
+                                   @traces)]
+          (is (= 1 (count shape-traces))
+              "exactly one :rf.error/effect-map-shape trace was emitted")
+          (let [t (first shape-traces)]
+            (is (= :error (:op-type t)))
+            (is (= :logged-and-skipped (:recovery t)))
+            (is (= :dispatch (get-in t [:tags :offending-key]))
+                ":offending-key carries the legacy top-level key")
+            (is (= :fx-test/legacy-dispatch (get-in t [:tags :rf.trace/event-id]))
+                ":event-id carries the dispatching event id")
+            (is (= [:fx-test/sentinel] (get-in t [:tags :value]))
+                ":value carries the offending key's value")
+            (is (string? (get-in t [:tags :reason]))
+                ":reason is a one-sentence human-facing description")))))))
 
 ;; ---- clear-fx round-trip (rf2-634y) --------------------------------------
 ;;
@@ -448,11 +562,17 @@
       (rf/dispatch-sync [:test.634y/run])
       (is (= 1 @counter)
           "the counter did NOT increment — the cleared fx did not fire")
-      (let [missing (filter #(= :rf.error/no-such-fx (:operation %)) @traces)]
-        (is (pos? (count missing))
-            "a :rf.error/no-such-fx trace fired for the cleared fx-id")
-        (is (some #(= :test.634y/touch (get-in % [:tags :rf.fx/id])) missing)
-            ":rf.fx/id in the trace identifies the cleared handler"))
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring). The
+      ;; production-visible half of "the cleared fx-id is now unknown" is the
+      ;; counter above plus the always-on `:rf.error/no-such-fx` record, which
+      ;; `unknown-fx-id-is-logged-and-skipped` pins on the `:errors` axis; the
+      ;; cleared fx-id's IDENTITY rides only the dev trace (rf2-g0mep).
+      (when interop/debug-enabled?
+        (let [missing (filter #(= :rf.error/no-such-fx (:operation %)) @traces)]
+          (is (pos? (count missing))
+              "a :rf.error/no-such-fx trace fired for the cleared fx-id")
+          (is (some #(= :test.634y/touch (get-in % [:tags :rf.fx/id])) missing)
+              ":rf.fx/id in the trace identifies the cleared handler")))
 
       ;; 4. Re-register and confirm idempotence: clear-fx didn't poison
       ;;    the registrar's per-kind slot machinery.
@@ -478,10 +598,20 @@
 
 (deftest multiple-legacy-effect-map-keys-each-emit-a-trace
   (testing "an effect map with several legacy top-level keys traces each one and still applies :db / :fx"
-    (let [traces (collect-traces! ::shape-multi)
-          fired  (atom [])]
+    (let [traces     (collect-traces! ::shape-multi)
+          fired      (atom [])
+          never-ran  (atom 0)
+          http-fired (atom 0)]
       (rf/reg-fx :fx-test/sibling
         (fn [_ args] (swap! fired conj args)))
+      ;; Production-visible sentinels (rf2-d2841): the DROP is the fact this
+      ;; deftest is really about, and a drop is only observable by giving the
+      ;; policed keys somewhere to land. Both legacy keys name a live target,
+      ;; so "policed" and "silently routed anyway" are now distinguishable
+      ;; under the production gate, not only through the dev trace ring.
+      (rf/reg-event :fx-test/never-runs
+        (fn [{:keys [db]} _] (swap! never-ran inc) {:db db}))
+      (rf/reg-fx :http (fn [_ _] (swap! http-fired inc)))
       (rf/reg-event :fx-test/multi-legacy
         (fn [{:keys [db]} _]
           ;; Mixed: legal :db and :fx alongside two legacy keys.
@@ -494,17 +624,23 @@
       ;; The legitimate :fx entry still ran — policing didn't halt the cascade.
       (is (= [{:k :legit}] @fired)
           "the legal :fx entry still fires after policing rejects sibling top-level keys")
+      (is (= 0 @never-ran)
+          "the legacy top-level :dispatch was DROPPED — its target never ran")
+      (is (= 0 @http-fired)
+          "the legacy top-level :http was DROPPED — it was not routed through the fx machinery")
       ;; The legitimate :db still committed.
       (is (= true (:seeded? (rf/app-db-value :rf/default)))
           ":db still committed alongside policed top-level keys")
       ;; One trace per offending key.
-      (let [shape-traces (filter #(= :rf.error/effect-map-shape (:operation %))
-                                 @traces)
-            offending    (set (map #(get-in % [:tags :offending-key]) shape-traces))]
-        (is (= 2 (count shape-traces))
-            "one :rf.error/effect-map-shape trace per offending top-level key")
-        (is (= #{:dispatch :http} offending)
-            "both legacy keys are flagged")))))
+      ;; rf2-d2841 — dev-instrumentation arm (see the §6 posture note above).
+      (when interop/debug-enabled?
+        (let [shape-traces (filter #(= :rf.error/effect-map-shape (:operation %))
+                                   @traces)
+              offending    (set (map #(get-in % [:tags :offending-key]) shape-traces))]
+          (is (= 2 (count shape-traces))
+              "one :rf.error/effect-map-shape trace per offending top-level key")
+          (is (= #{:dispatch :http} offending)
+              "both legacy keys are flagged"))))))
 
 ;; ---- 6b. :fx VALUE-shape policing (rf2-24zly) -----------------------------
 ;;
@@ -542,23 +678,25 @@
       (is (= true (:seeded? (rf/app-db-value :rf/default)))
           ":db still committed; only the malformed :fx slot was dropped")
       ;; Exactly one structured trace, flagging :fx as the offending slot.
-      (let [shape-traces (filter #(= :rf.error/effect-map-shape (:operation %))
-                                 @traces)]
-        (is (= 1 (count shape-traces))
-            "exactly one :rf.error/effect-map-shape trace for the bad :fx value")
-        (let [t (first shape-traces)]
-          (is (= :error (:op-type t)))
-          (is (= :logged-and-skipped (:recovery t)))
-          (is (= :fx (get-in t [:tags :offending-key]))
-              ":offending-key is :fx (the value-shape gap, not a top-level key)")
-          (is (= :fx-test/fx-is-keyword (get-in t [:tags :rf.trace/event-id]))
-              ":event-id names the offending handler")
-          (is (= :oops (get-in t [:tags :value]))
-              ":value carries the offending non-sequential :fx value")
-          (is (string? (get-in t [:tags :reason]))
-              ":reason is a human-facing description")
-          (is (re-find #"outer vector" (get-in t [:tags :reason]))
-              ":reason hints at the forgot-the-outer-vector typo"))))))
+      ;; rf2-d2841 — dev-instrumentation arm (see the §6 posture note above).
+      (when interop/debug-enabled?
+        (let [shape-traces (filter #(= :rf.error/effect-map-shape (:operation %))
+                                   @traces)]
+          (is (= 1 (count shape-traces))
+              "exactly one :rf.error/effect-map-shape trace for the bad :fx value")
+          (let [t (first shape-traces)]
+            (is (= :error (:op-type t)))
+            (is (= :logged-and-skipped (:recovery t)))
+            (is (= :fx (get-in t [:tags :offending-key]))
+                ":offending-key is :fx (the value-shape gap, not a top-level key)")
+            (is (= :fx-test/fx-is-keyword (get-in t [:tags :rf.trace/event-id]))
+                ":event-id names the offending handler")
+            (is (= :oops (get-in t [:tags :value]))
+                ":value carries the offending non-sequential :fx value")
+            (is (string? (get-in t [:tags :reason]))
+                ":reason is a human-facing description")
+            (is (re-find #"outer vector" (get-in t [:tags :reason]))
+                ":reason hints at the forgot-the-outer-vector typo")))))))
 
 (deftest non-sequential-fx-value-map-is-policed
   (testing "{:fx {:dispatch [...]}} (a map instead of a vector of pairs) is policed —
@@ -578,16 +716,18 @@
       (rf/unregister-listener! :trace ::fx-val-map)
       (is (false? @fired?)
           "the malformed :fx map is dropped wholesale — nothing inside it runs")
-      (let [shape-traces (filter #(= :rf.error/effect-map-shape (:operation %))
-                                 @traces)]
-        (is (= 1 (count shape-traces))
-            "exactly one :rf.error/effect-map-shape trace for the bad :fx value")
-        (let [t (first shape-traces)]
-          (is (= :logged-and-skipped (:recovery t)))
-          (is (= :fx (get-in t [:tags :offending-key])))
-          (is (= :fx-test/fx-is-map (get-in t [:tags :rf.trace/event-id])))
-          (is (= {:dispatch [:fx-test/fx-sentinel]} (get-in t [:tags :value]))
-              ":value carries the offending map"))))))
+      ;; rf2-d2841 — dev-instrumentation arm (see the §6 posture note above).
+      (when interop/debug-enabled?
+        (let [shape-traces (filter #(= :rf.error/effect-map-shape (:operation %))
+                                   @traces)]
+          (is (= 1 (count shape-traces))
+              "exactly one :rf.error/effect-map-shape trace for the bad :fx value")
+          (let [t (first shape-traces)]
+            (is (= :logged-and-skipped (:recovery t)))
+            (is (= :fx (get-in t [:tags :offending-key])))
+            (is (= :fx-test/fx-is-map (get-in t [:tags :rf.trace/event-id])))
+            (is (= {:dispatch [:fx-test/fx-sentinel]} (get-in t [:tags :value]))
+                ":value carries the offending map")))))))
 
 (deftest well-shaped-fx-vector-is-unchanged
   (testing "the normal {:fx [[fx-id args] ...]} path still fires and emits NO shape trace"
@@ -605,8 +745,13 @@
           "the well-shaped :fx entry still fires")
       (is (= true (:seeded? (rf/app-db-value :rf/default)))
           ":db committed alongside the legal :fx")
-      (is (empty? (filter #(= :rf.error/effect-map-shape (:operation %)) @traces))
-          "a well-shaped :fx value emits NO :rf.error/effect-map-shape trace"))))
+      ;; rf2-d2841 — dev-instrumentation arm. A NEGATIVE over the trace ring
+      ;; MUST sit inside the arm: under `-Dre-frame.debug=false` the ring is
+      ;; empty by design, so `empty?` would pass whether the framework stayed
+      ;; silent or shouted — the exact false green this lane exists to close.
+      (when interop/debug-enabled?
+        (is (empty? (filter #(= :rf.error/effect-map-shape (:operation %)) @traces))
+            "a well-shaped :fx value emits NO :rf.error/effect-map-shape trace")))))
 
 (deftest nil-fx-value-is-a-legal-no-op
   (testing "{:db ... :fx nil} is the legal no-op — :db commits, NO shape trace"
@@ -621,8 +766,10 @@
       (rf/unregister-listener! :trace ::fx-val-nil)
       (is (= true (:seeded? (rf/app-db-value :rf/default)))
           ":db committed; nil :fx is a no-op")
-      (is (empty? (filter #(= :rf.error/effect-map-shape (:operation %)) @traces))
-          "nil :fx emits NO :rf.error/effect-map-shape trace — it is the legal no-op"))))
+      ;; rf2-d2841 — dev-instrumentation arm (negative over the trace ring).
+      (when interop/debug-enabled?
+        (is (empty? (filter #(= :rf.error/effect-map-shape (:operation %)) @traces))
+            "nil :fx emits NO :rf.error/effect-map-shape trace — it is the legal no-op")))))
 
 ;; ---- 6c. per-ENTRY :fx-shape policing (rf2-n6d3m) -------------------------
 ;;
@@ -671,25 +818,27 @@
       (is (= true (:seeded? (rf/app-db-value :rf/default)))
           ":db committed; only the malformed entry was dropped")
       ;; Exactly one structured trace, flagging the offending entry.
-      (let [shape-traces (filter #(= :rf.error/effect-map-shape (:operation %))
-                                 @traces)]
-        (is (= 1 (count shape-traces))
-            "exactly one :rf.error/effect-map-shape trace for the bad entry")
-        (let [t (first shape-traces)]
-          (is (= :error (:op-type t)))
-          (is (= :logged-and-skipped (:recovery t)))
-          (is (= :fx (get-in t [:tags :offending-key]))
-              ":offending-key is :fx (a per-entry shape gap)")
-          (is (= :fx-test/entry-is-keyword (get-in t [:tags :rf.trace/event-id]))
-              ":event-id names the offending handler")
-          (is (= :rf/default (get-in t [:tags :frame]))
-              ":frame is stamped (lands in the per-frame epoch trace buffer)")
-          (is (= :oops (get-in t [:tags :value]))
-              ":value carries the offending non-vector entry")
-          (is (string? (get-in t [:tags :reason]))
-              ":reason is a human-facing description")
-          (is (re-find #"inner vector" (get-in t [:tags :reason]))
-              ":reason hints at the forgot-the-inner-vector typo"))))))
+      ;; rf2-d2841 — dev-instrumentation arm (see the §6 posture note above).
+      (when interop/debug-enabled?
+        (let [shape-traces (filter #(= :rf.error/effect-map-shape (:operation %))
+                                   @traces)]
+          (is (= 1 (count shape-traces))
+              "exactly one :rf.error/effect-map-shape trace for the bad entry")
+          (let [t (first shape-traces)]
+            (is (= :error (:op-type t)))
+            (is (= :logged-and-skipped (:recovery t)))
+            (is (= :fx (get-in t [:tags :offending-key]))
+                ":offending-key is :fx (a per-entry shape gap)")
+            (is (= :fx-test/entry-is-keyword (get-in t [:tags :rf.trace/event-id]))
+                ":event-id names the offending handler")
+            (is (= :rf/default (get-in t [:tags :frame]))
+                ":frame is stamped (lands in the per-frame epoch trace buffer)")
+            (is (= :oops (get-in t [:tags :value]))
+                ":value carries the offending non-vector entry")
+            (is (string? (get-in t [:tags :reason]))
+                ":reason is a human-facing description")
+            (is (re-find #"inner vector" (get-in t [:tags :reason]))
+                ":reason hints at the forgot-the-inner-vector typo")))))))
 
 (deftest malformed-map-fx-entry-is-policed
   (testing "a map :fx entry (another non-vector shape) is policed + skipped"
@@ -706,16 +855,18 @@
       (rf/unregister-listener! :trace ::fx-entry-map)
       (is (= [{:k :v}] @fired)
           "the well-shaped sibling still fired; the map entry was dropped")
-      (let [shape-traces (filter #(= :rf.error/effect-map-shape (:operation %))
-                                 @traces)]
-        (is (= 1 (count shape-traces))
-            "exactly one :rf.error/effect-map-shape trace for the map entry")
-        (let [t (first shape-traces)]
-          (is (= :logged-and-skipped (:recovery t)))
-          (is (= :fx (get-in t [:tags :offending-key])))
-          (is (= :fx-test/entry-is-map (get-in t [:tags :rf.trace/event-id])))
-          (is (= {:dispatch [:whatever]} (get-in t [:tags :value]))
-              ":value carries the offending map entry"))))))
+      ;; rf2-d2841 — dev-instrumentation arm (see the §6 posture note above).
+      (when interop/debug-enabled?
+        (let [shape-traces (filter #(= :rf.error/effect-map-shape (:operation %))
+                                   @traces)]
+          (is (= 1 (count shape-traces))
+              "exactly one :rf.error/effect-map-shape trace for the map entry")
+          (let [t (first shape-traces)]
+            (is (= :logged-and-skipped (:recovery t)))
+            (is (= :fx (get-in t [:tags :offending-key])))
+            (is (= :fx-test/entry-is-map (get-in t [:tags :rf.trace/event-id])))
+            (is (= {:dispatch [:whatever]} (get-in t [:tags :value]))
+                ":value carries the offending map entry")))))))
 
 (deftest nil-and-empty-fx-entries-are-silent-no-ops
   (testing "nil and [] :fx entries are the legal conditional-fx no-op — the
@@ -737,8 +888,10 @@
       (rf/unregister-listener! :trace ::fx-entry-nil)
       (is (= [{:k 1} {:k 2}] @fired)
           "both well-shaped entries fired; nil + [] were silent no-ops")
-      (is (empty? (filter #(= :rf.error/effect-map-shape (:operation %)) @traces))
-          "nil + [] entries emit NO :rf.error/effect-map-shape trace — the legal idiom"))))
+      ;; rf2-d2841 — dev-instrumentation arm (negative over the trace ring).
+      (when interop/debug-enabled?
+        (is (empty? (filter #(= :rf.error/effect-map-shape (:operation %)) @traces))
+            "nil + [] entries emit NO :rf.error/effect-map-shape trace — the legal idiom")))))
 
 (deftest well-formed-multi-entry-fx-emits-no-shape-trace
   (testing "a well-formed multi-entry :fx vector runs all entries and emits NO
@@ -755,8 +908,10 @@
       (rf/unregister-listener! :trace ::fx-entry-all-ok)
       (is (= [:a :b] @fired)
           "all well-formed entries ran in source order")
-      (is (empty? (filter #(= :rf.error/effect-map-shape (:operation %)) @traces))
-          "no :rf.error/effect-map-shape trace for a clean multi-entry :fx"))))
+      ;; rf2-d2841 — dev-instrumentation arm (negative over the trace ring).
+      (when interop/debug-enabled?
+        (is (empty? (filter #(= :rf.error/effect-map-shape (:operation %)) @traces))
+            "no :rf.error/effect-map-shape trace for a clean multi-entry :fx")))))
 
 ;; ---- 6d. per-ENTRY arity / fx-id-type policing (rf2-18kwf) ----------------
 ;;
@@ -788,6 +943,7 @@
             shape violation — :rf.error/effect-map-shape, that entry skipped,
             siblings still run — NOT mis-reported as an unknown fx-id"
     (let [traces (collect-traces! ::fx-entry-non-kw)
+          errors (collect-errors! ::fx-entry-non-kw-errors)
           fired  (atom [])]
       (rf/reg-fx :fx-test/entry-nonkw-sibling
         (fn [_ args] (swap! fired conj args)))
@@ -799,31 +955,44 @@
                 [:fx-test/entry-nonkw-sibling {:k 2}]]}))
       (is (nil? (rf/dispatch-sync [:fx-test/entry-non-keyword-head]))
           "dispatch returns normally — no uncaught host exception")
-      (rf/unregister-listener! :trace ::fx-entry-non-kw)
+      (rf/unregister-listener! :trace  ::fx-entry-non-kw)
+      (rf/unregister-listener! :errors ::fx-entry-non-kw-errors)
       (is (= [{:k 1} {:k 2}] @fired)
           "both well-shaped siblings fired in order; the bad-head entry was skipped")
       (is (= true (:seeded? (rf/app-db-value :rf/default)))
           ":db committed; only the malformed entry was dropped")
       ;; The diagnostic must be the SHAPE category, not no-such-fx — a string
       ;; head is a shape violation, not an unregistered keyword id.
-      (is (empty? (filter #(= :rf.error/no-such-fx (:operation %)) @traces))
-          "a non-keyword head is NOT mis-reported as :rf.error/no-such-fx")
-      (let [shape-traces (filter #(= :rf.error/effect-map-shape (:operation %))
-                                 @traces)]
-        (is (= 1 (count shape-traces))
-            "exactly one :rf.error/effect-map-shape trace for the bad-head entry")
-        (let [t (first shape-traces)]
-          (is (= :error (:op-type t)))
-          (is (= :logged-and-skipped (:recovery t)))
-          (is (= :fx (get-in t [:tags :offending-key])))
-          (is (= :fx-test/entry-non-keyword-head (get-in t [:tags :rf.trace/event-id]))
-              ":event-id names the offending handler")
-          (is (= :rf/default (get-in t [:tags :frame])))
-          (is (= ["not-a-keyword" {:x 1}] (get-in t [:tags :value]))
-              ":value carries the offending entry verbatim")
-          (is (string? (get-in t [:tags :reason])))
-          (is (re-find #"fx-id" (get-in t [:tags :reason]))
-              ":reason flags the bad fx-id (the first element)"))))))
+      ;;
+      ;; PRODUCTION-VISIBLE WITNESS (rf2-d2841). This negative is asserted on
+      ;; the ALWAYS-ON `:errors` axis, not over the dev trace ring: an empty
+      ;; ring would satisfy `empty?` under the gate for free, whereas the
+      ;; `:errors` axis is live in both postures (the positive twin is
+      ;; `unknown-fx-id-is-logged-and-skipped`, which sees a record there).
+      ;; So "the bad-head entry was classified as a SHAPE violation and never
+      ;; reached fx lookup" is now proven under `-Dre-frame.debug=false`.
+      (is (empty? (filter #(= :rf.error/no-such-fx (:error %)) @errors))
+          "a non-keyword head is NOT mis-reported as :rf.error/no-such-fx (always-on axis)")
+      ;; rf2-d2841 — dev-instrumentation arm (see the §6 posture note above).
+      (when interop/debug-enabled?
+        (is (empty? (filter #(= :rf.error/no-such-fx (:operation %)) @traces))
+            "a non-keyword head is NOT mis-reported as :rf.error/no-such-fx")
+        (let [shape-traces (filter #(= :rf.error/effect-map-shape (:operation %))
+                                   @traces)]
+          (is (= 1 (count shape-traces))
+              "exactly one :rf.error/effect-map-shape trace for the bad-head entry")
+          (let [t (first shape-traces)]
+            (is (= :error (:op-type t)))
+            (is (= :logged-and-skipped (:recovery t)))
+            (is (= :fx (get-in t [:tags :offending-key])))
+            (is (= :fx-test/entry-non-keyword-head (get-in t [:tags :rf.trace/event-id]))
+                ":event-id names the offending handler")
+            (is (= :rf/default (get-in t [:tags :frame])))
+            (is (= ["not-a-keyword" {:x 1}] (get-in t [:tags :value]))
+                ":value carries the offending entry verbatim")
+            (is (string? (get-in t [:tags :reason])))
+            (is (re-find #"fx-id" (get-in t [:tags :reason]))
+                ":reason flags the bad fx-id (the first element)")))))))
 
 (deftest fx-entry-surplus-third-field-is-policed-not-truncated
   (testing "a vector :fx entry with a surplus 3rd field
@@ -850,20 +1019,22 @@
           "the surplus-field entry was dropped (NOT truncated + fired); siblings ran")
       (is (= true (:seeded? (rf/app-db-value :rf/default)))
           ":db committed; only the malformed entry was dropped")
-      (let [shape-traces (filter #(= :rf.error/effect-map-shape (:operation %))
-                                 @traces)]
-        (is (= 1 (count shape-traces))
-            "exactly one :rf.error/effect-map-shape trace for the surplus-field entry")
-        (let [t (first shape-traces)]
-          (is (= :logged-and-skipped (:recovery t)))
-          (is (= :fx (get-in t [:tags :offending-key])))
-          (is (= :fx-test/entry-surplus-field (get-in t [:tags :rf.trace/event-id])))
-          (is (= [:fx-test/entry-arity3-sink {:used true} {:dropped true}]
-                 (get-in t [:tags :value]))
-              ":value carries the full over-long entry verbatim")
-          (is (string? (get-in t [:tags :reason])))
-          (is (re-find #"two elements|surplus" (get-in t [:tags :reason]))
-              ":reason flags the surplus element(s)"))))))
+      ;; rf2-d2841 — dev-instrumentation arm (see the §6 posture note above).
+      (when interop/debug-enabled?
+        (let [shape-traces (filter #(= :rf.error/effect-map-shape (:operation %))
+                                   @traces)]
+          (is (= 1 (count shape-traces))
+              "exactly one :rf.error/effect-map-shape trace for the surplus-field entry")
+          (let [t (first shape-traces)]
+            (is (= :logged-and-skipped (:recovery t)))
+            (is (= :fx (get-in t [:tags :offending-key])))
+            (is (= :fx-test/entry-surplus-field (get-in t [:tags :rf.trace/event-id])))
+            (is (= [:fx-test/entry-arity3-sink {:used true} {:dropped true}]
+                   (get-in t [:tags :value]))
+                ":value carries the full over-long entry verbatim")
+            (is (string? (get-in t [:tags :reason])))
+            (is (re-find #"two elements|surplus" (get-in t [:tags :reason]))
+                ":reason flags the surplus element(s)")))))))
 
 (deftest fx-entry-no-args-shorthand-is-valid
   (testing "the 1-arity no-args shorthand `[:fx-id]` is a VALID entry — it
@@ -881,8 +1052,13 @@
       (rf/unregister-listener! :trace ::fx-entry-noargs)
       (is (= [nil] @fired)
           "the no-args shorthand fired once with nil args")
-      (is (empty? (filter #(= :rf.error/effect-map-shape (:operation %)) @traces))
-          "the no-args `[:fx-id]` shorthand emits NO shape trace — it is valid"))))
+      ;; rf2-d2841 — dev-instrumentation arm (negative over the trace ring).
+      ;; The production-visible half of "it is VALID" is the `[nil] @fired`
+      ;; assertion above: an entry policed as malformed would be dropped and
+      ;; would never have fired at all.
+      (when interop/debug-enabled?
+        (is (empty? (filter #(= :rf.error/effect-map-shape (:operation %)) @traces))
+            "the no-args `[:fx-id]` shorthand emits NO shape trace — it is valid")))))
 
 ;; ---- 6e. RESERVED-fx 3-element entry is policed loudly (rf2-tbuov) ---------
 ;;
@@ -925,23 +1101,29 @@
           "the malformed 3-element :dispatch was DROPPED, not truncated-and-fired")
       (is (= true (:seeded? (rf/app-db-value :rf/default)))
           ":db still committed; only the malformed fx entry was dropped")
-      (let [shape-traces (filter #(= :rf.error/effect-map-shape (:operation %))
-                                 @traces)]
-        (is (= 1 (count shape-traces))
-            "exactly one :rf.error/effect-map-shape trace — LOUD, not silent")
-        (let [t (first shape-traces)]
-          (is (= :error (:op-type t)))
-          (is (= :logged-and-skipped (:recovery t))
-              "recovery is logged-and-skipped — recover/rollback posture kept, but NOT silent")
-          (is (= :fx (get-in t [:tags :offending-key])))
-          (is (= :fx-test.tbuov/emits-malformed-dispatch
-                 (get-in t [:tags :rf.trace/event-id]))
-              ":event-id names the offending handler")
-          (is (= [:dispatch [:fx-test.tbuov/target] {:frame :rf/default}]
-                 (get-in t [:tags :value]))
-              ":value carries the full malformed entry verbatim")
-          (is (string? (get-in t [:tags :reason]))
-              ":reason is a human-facing diagnostic"))))))
+      ;; rf2-d2841 — dev-instrumentation arm (see the §6 posture note above).
+      ;; "LOUD, not silent" has two halves and only one of them is a trace:
+      ;; the DROP (`@target-ran` = 0, above) is the production-real half and
+      ;; is what distinguishes rf2-tbuov's ruling from the old silent
+      ;; truncate-and-fire. The diagnostic's own loudness is dev-channel.
+      (when interop/debug-enabled?
+        (let [shape-traces (filter #(= :rf.error/effect-map-shape (:operation %))
+                                   @traces)]
+          (is (= 1 (count shape-traces))
+              "exactly one :rf.error/effect-map-shape trace — LOUD, not silent")
+          (let [t (first shape-traces)]
+            (is (= :error (:op-type t)))
+            (is (= :logged-and-skipped (:recovery t))
+                "recovery is logged-and-skipped — recover/rollback posture kept, but NOT silent")
+            (is (= :fx (get-in t [:tags :offending-key])))
+            (is (= :fx-test.tbuov/emits-malformed-dispatch
+                   (get-in t [:tags :rf.trace/event-id]))
+                ":event-id names the offending handler")
+            (is (= [:dispatch [:fx-test.tbuov/target] {:frame :rf/default}]
+                   (get-in t [:tags :value]))
+                ":value carries the full malformed entry verbatim")
+            (is (string? (get-in t [:tags :reason]))
+                ":reason is a human-facing diagnostic")))))))
 
 ;; ---- 7. :fx-overrides function-value branch -------------------------------
 ;;

--- a/implementation/core/test/re_frame/init_platform_test.clj
+++ b/implementation/core/test/re_frame/init_platform_test.clj
@@ -15,7 +15,22 @@
     2. `init-platform` toggles the marker; subsequent `:platforms`
        gating reflects the new value (the gate is the load-bearing
        observable — flipping the marker should flip the trace shape).
-    3. Invalid input raises `:rf.error/invalid-platform`."
+    3. Invalid input raises `:rf.error/invalid-platform`.
+
+  ## Posture split (rf2-d2841)
+
+  All three contract points are production-real and are asserted WITHOUT a
+  posture guard: the default marker read, the flip, the `:platforms` GATE
+  ITSELF (whether the handler body ran — the load-bearing observable named
+  in point 2), and the registration-time throw. They run in the ordinary
+  `clojure -M:test` suite AND in `scripts/test-core-prod-gate.sh`.
+
+  `:rf.fx/skipped-on-platform` is a bare `trace/emit!` warning (fx.cljc
+  §handle-one-fx) with no always-on twin, so under the real gate nothing is
+  emitted BY DESIGN. Its assertions are kept verbatim inside a
+  `(when interop/debug-enabled? …)` arm marked `rf2-d2841` — including the
+  negative on the flip-to-client leg, which over an empty ring would pass
+  whether the gate passed or skipped."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.interop :as interop]
@@ -84,9 +99,14 @@
 
       (is (true? @fired?)
           "the :client-only fx ran because the active platform is now :client")
-      (let [skips (filter #(= :rf.fx/skipped-on-platform (:operation %)) @traces)]
-        (is (empty? skips)
-            "no :rf.fx/skipped-on-platform trace — the gate passed")))))
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring). A NEGATIVE
+      ;; over the trace ring: under `-Dre-frame.debug=false` the ring is empty
+      ;; by design, so `empty?` would pass whether the gate passed or skipped.
+      ;; The production-visible half of "the gate passed" is `@fired?` above.
+      (when interop/debug-enabled?
+        (let [skips (filter #(= :rf.fx/skipped-on-platform (:operation %)) @traces)]
+          (is (empty? skips)
+              "no :rf.fx/skipped-on-platform trace — the gate passed"))))))
 
 (deftest init-platform-flip-to-server-skips-client-only-fx
   (testing "with the default (init-platform :server) marker, a
@@ -109,11 +129,16 @@
 
       (is (false? @fired?)
           "the :client-only fx did NOT run on :server")
-      (let [skips (filter #(= :rf.fx/skipped-on-platform (:operation %)) @traces)]
-        (is (= 1 (count skips))
-            "exactly one :rf.fx/skipped-on-platform trace")
-        (is (= :server (get-in (first skips) [:tags :rf.fx/platform]))
-            ":rf.fx/platform stamp matches the active marker")))))
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring).
+      ;; `:rf.fx/skipped-on-platform` is a bare `trace/emit!` warning with no
+      ;; always-on twin; the SKIP it reports is asserted above and runs in
+      ;; both postures.
+      (when interop/debug-enabled?
+        (let [skips (filter #(= :rf.fx/skipped-on-platform (:operation %)) @traces)]
+          (is (= 1 (count skips))
+              "exactly one :rf.fx/skipped-on-platform trace")
+          (is (= :server (get-in (first skips) [:tags :rf.fx/platform]))
+              ":rf.fx/platform stamp matches the active marker"))))))
 
 ;; ---- 3. Validation ---------------------------------------------------------
 

--- a/implementation/core/test/re_frame/pattern_smoke_test.clj
+++ b/implementation/core/test/re_frame/pattern_smoke_test.clj
@@ -7,10 +7,25 @@
 
   One deftest per pattern. The docstring on each test cites the relevant
   Pattern-*.md section. Each test stays under ~50 lines — pin the shape,
-  not every edge case."
+  not every edge case.
+
+  ## Posture split (rf2-d2841)
+
+  Every pattern's SHAPE is production-real and is asserted WITHOUT a posture
+  guard, so this namespace runs in the ordinary `clojure -M:test` suite AND
+  in `scripts/test-core-prod-gate.sh` (the `-Dre-frame.debug=false` lane).
+
+  One observable is dev-only: the `:rf.machine.timer/stale-after` trace on
+  the stale-`:after`-timer leg of `pattern-stale-detection-shape`. It is a
+  `trace/emit!` with no always-on twin, so under the real gate nothing is
+  emitted BY DESIGN; its assertion is kept verbatim inside a
+  `(when interop/debug-enabled? …)` arm marked `rf2-d2841`. The SUPPRESSION
+  the trace reports — a stale timer leaving the snapshot unchanged — is the
+  production-real half and stays outside the arm."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
             [re-frame.registrar :as registrar]
             [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]
@@ -316,12 +331,17 @@
                           [:rf.machine.timer/after-elapsed 5000 captured [:loading]]))]
           (rf/unregister-listener! :trace ::stale)
           (is (= s3 s4) "stale timer firing leaves snapshot unchanged")
-          (is (some (fn [ev]
-                      (and (= :rf.machine.timer/stale-after (:operation ev))
-                           (= captured (:scheduled-epoch (:tags ev)))
-                           (= 3        (:current-epoch (:tags ev)))))
-                    @traces)
-              "expected :rf.machine.timer/stale-after trace with both epochs"))))))
+          (is (= 3 (get-in s4 [:data :rf/after-epoch [:loading]]))
+              "the live epoch is untouched by the stale firing — the suppression
+               did not consume or reset it")
+          ;; rf2-d2841 — dev-instrumentation arm (see ns docstring).
+          (when interop/debug-enabled?
+            (is (some (fn [ev]
+                        (and (= :rf.machine.timer/stale-after (:operation ev))
+                             (= captured (:scheduled-epoch (:tags ev)))
+                             (= 3        (:current-epoch (:tags ev)))))
+                      @traces)
+                "expected :rf.machine.timer/stale-after trace with both epochs")))))))
 
 ;; ---- Pattern-LongRunningWork ----------------------------------------------
 

--- a/implementation/core/test/re_frame/sub_topology_test.clj
+++ b/implementation/core/test/re_frame/sub_topology_test.clj
@@ -26,11 +26,33 @@
   realized edges live in the cache), and a declared self-reference
   cycle (which is allowed by registration — the topology surface
   reports the static :<- chain regardless of whether the resulting sub
-  would resolve at runtime)."
+  would resolve at runtime).
+
+  ## Posture split (rf2-d2841)
+
+  The topology's SHAPE — `:input-kind` discrimination, the literal `:<-`
+  query-vectors with their args, declaration order, the `:parametric`
+  sentinel, registry add / clear / re-register semantics, and verbatim
+  self-reference reporting — is production-real and is asserted WITHOUT a
+  posture guard, so it runs in the ordinary `clojure -M:test` suite AND in
+  `scripts/test-core-prod-gate.sh` (the `-Dre-frame.debug=false` lane).
+
+  Two of the entry's keys are REFLECTION METADATA and are elided in
+  production by design: `:doc`, and the `:ns` / `:line` / `:file`
+  source-coords `reg-sub` auto-captures. They exist for tooling (the same
+  class as the registry-entry `:doc` covered by
+  `re-frame.doc-metadata-prod-elision-test` and the `->interceptor`
+  `:source-coord`), so under the real gate the entry simply does not carry
+  them. Their assertions are kept verbatim inside a
+  `(when interop/debug-enabled? …)` arm marked `rf2-d2841` — INCLUDING the
+  negative `no-doc-key-when-not-supplied`, which under the gate would pass
+  because `:doc` is never present rather than because the registration
+  omitted it."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.subs :as subs]
             [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
             [re-frame.registrar :as registrar]
             [re-frame.schemas :as schemas]
             [re-frame.flows :as flows]
@@ -160,25 +182,46 @@
 (deftest source-coords-are-included
   (testing ":ns / :line / :file are auto-captured by reg-sub and surface in topology"
     (rf/reg-sub :n (fn [db _] (:n db)))
-    (let [entry ((subs/sub-topology) :n)]
-      (is (some? (:ns entry))   ":ns captured at the call site")
-      (is (number? (:line entry)) ":line captured at the call site")
-      (is (some? (:file entry)) ":file captured at the call site"))))
+    ;; The sub itself is registered and projected in BOTH postures — the
+    ;; production-visible half, and the precondition for reading any coord
+    ;; off the entry at all.
+    (is (contains? (subs/sub-topology) :n)
+        "the sub is projected into the topology regardless of posture")
+    ;; rf2-d2841 — dev-instrumentation arm (see ns docstring). Source coords
+    ;; are reflection metadata, elided in production.
+    (when interop/debug-enabled?
+      (let [entry ((subs/sub-topology) :n)]
+        (is (some? (:ns entry))   ":ns captured at the call site")
+        (is (number? (:line entry)) ":line captured at the call site")
+        (is (some? (:file entry)) ":file captured at the call site")))))
 
 (deftest user-supplied-doc-passes-through
   (testing ":doc supplied via the meta-map first arg surfaces in topology"
     (rf/reg-sub :counter
                 {:doc "Counter sub — a layer-1 sub that reads :n from app-db."}
                 (fn [db _] (:n db)))
-    (is (= "Counter sub — a layer-1 sub that reads :n from app-db."
-           (:doc ((subs/sub-topology) :counter))))))
+    ;; Posture-independent: the meta-map first-arg REGISTRATION FORM is
+    ;; accepted and produces an ordinary layer-1 entry. A `reg-sub` that
+    ;; choked on the meta-map arity would fail here in either posture.
+    (is (= :db (:input-kind ((subs/sub-topology) :counter)))
+        "the meta-map registration form registers an ordinary layer-1 sub")
+    ;; rf2-d2841 — dev-instrumentation arm (see ns docstring).
+    (when interop/debug-enabled?
+      (is (= "Counter sub — a layer-1 sub that reads :n from app-db."
+             (:doc ((subs/sub-topology) :counter)))))))
 
 (deftest no-doc-key-when-not-supplied
   (testing ":doc is absent when the registration didn't supply one"
     ;; Don't surface a nil :doc — match the spec row's "keys present
     ;; when the registration carries them" semantics.
     (rf/reg-sub :n (fn [db _] (:n db)))
-    (is (not (contains? ((subs/sub-topology) :n) :doc)))))
+    ;; rf2-d2841 — dev-instrumentation arm. A NEGATIVE about a key that is
+    ;; ELIDED WHOLESALE under `-Dre-frame.debug=false`: outside the arm it
+    ;; would pass because `:doc` is never present, not because this
+    ;; registration omitted it. Same false-green shape as a negative over an
+    ;; empty trace ring.
+    (when interop/debug-enabled?
+      (is (not (contains? ((subs/sub-topology) :n) :doc))))))
 
 ;; ---- registry semantics --------------------------------------------------
 

--- a/scripts/test-core-prod-gate.sh
+++ b/scripts/test-core-prod-gate.sh
@@ -155,7 +155,6 @@ known_red=(
   re-frame.configure-test
   re-frame.core-epoch-egress-profile-test
   re-frame.cross-frame-dispatch-sync-warn-test
-  re-frame.db-noop-commit-test
   re-frame.db-pending-trace-test
   re-frame.dispatched-trace-cofx-test
   re-frame.doc-metadata-prod-elision-test
@@ -172,7 +171,6 @@ known_red=(
   re-frame.handler-source-test
   re-frame.image-inline-metadata-normalization-cljs-test
   re-frame.image-no-emit-trace-gate-cljs-test
-  re-frame.init-platform-test
   re-frame.interceptor-override-summary-trace-test
   re-frame.live-frame-reload-cljs-test
   re-frame.machine-action-outcome-classification-cljs-test
@@ -180,7 +178,6 @@ known_red=(
   re-frame.non-serialisable-event-payload-warn-test
   re-frame.observation-port-cljs-test
   re-frame.override-capture-trace-test
-  re-frame.pattern-smoke-test
   re-frame.reg-event-cljs-test
   re-frame.reg-meta-noswallow-cljs-test
   re-frame.reg-view-injection-test
@@ -195,7 +192,6 @@ known_red=(
   re-frame.sub-cycle-cljs-test
   re-frame.sub-dispose-trace-test
   re-frame.sub-parametric-inputs-test
-  re-frame.sub-topology-test
   re-frame.subs-inline-normalization-cljs-test
   re-frame.substrate-source-test
   re-frame.substrate.derived-container-replaced-cljs-test

--- a/scripts/test-core-prod-gate.sh
+++ b/scripts/test-core-prod-gate.sh
@@ -44,12 +44,13 @@
 # a rewrite of how those assertions are spelled.  Triage beads are named per
 # cluster below.
 #
-# What is left IS green, and it is not a rump: 95 namespaces, 1153 tests, 5327
+# What is left IS green, and it is not a rump: 99 namespaces, 1186 tests, 5468
 # assertions, exit 0 — versus the zero suites that had ever executed under this
 # posture before.  (It was 88 / 934 / 4340 before rf2-d2841 split the spine's
 # dev-instrumentation assertions away from the semantics beside them, and
 # 94 / 1106 / 5135 before that bead's second pass took `fx-test` — the largest
-# single entry, 107 failures and 25 errors across ~20 deftests — off the list.)
+# single entry, 107 failures and 25 errors across ~20 deftests — plus
+# `sub-topology`, `init-platform`, `pattern-smoke` and `db-noop-commit`.)
 #
 # The roster is therefore an EXCLUSION list, not an allowlist.  The polarity is
 # the point: a namespace added to `implementation/core/test/` joins this lane
@@ -136,6 +137,18 @@ known_red=(
   #    catalogue before guarding anything: `diagnostic` means dev-only by
   #    design (`:rf.error/effect-map-shape`), `always-on` means there is a
   #    production witness to be had.
+  #
+  #    AND THE DEV-ONLY HALF IS NOT ALWAYS A TRACE. `sub-topology-test`'s
+  #    was REFLECTION METADATA — `:doc` and the auto-captured `:ns` / `:line`
+  #    / `:file` source-coords, elided in production — while the topology
+  #    SHAPE around them was entirely posture-independent. The false-green
+  #    that shape produces is worth recognising on sight: a negative about a
+  #    key that is elided WHOLESALE (`no-doc-key-when-not-supplied`) passes
+  #    under the gate because the key never exists, not because the
+  #    registration omitted it. Same class as a negative over an empty ring,
+  #    different subject. `db-noop-commit-test` is the counter-example worth
+  #    copying: its adversarial discriminators read frame-state OBJECT
+  #    IDENTITY off `frame/frame-state-value`, which needs no channel at all.
   #
   #    NOTE for whoever finishes this list: a namespace whose EVERY deftest
   #    is about the dev trace (the `trace-listener-*` cohort, `trace-test`,

--- a/scripts/test-core-prod-gate.sh
+++ b/scripts/test-core-prod-gate.sh
@@ -44,10 +44,12 @@
 # a rewrite of how those assertions are spelled.  Triage beads are named per
 # cluster below.
 #
-# What is left IS green, and it is not a rump: 94 namespaces, 1103 tests, 5120
+# What is left IS green, and it is not a rump: 95 namespaces, 1153 tests, 5327
 # assertions, exit 0 — versus the zero suites that had ever executed under this
 # posture before.  (It was 88 / 934 / 4340 before rf2-d2841 split the spine's
-# dev-instrumentation assertions away from the semantics beside them.)
+# dev-instrumentation assertions away from the semantics beside them, and
+# 94 / 1106 / 5135 before that bead's second pass took `fx-test` — the largest
+# single entry, 107 failures and 25 errors across ~20 deftests — off the list.)
 #
 # The roster is therefore an EXCLUSION list, not an allowlist.  The polarity is
 # the point: a namespace added to `implementation/core/test/` joins this lane
@@ -117,8 +119,23 @@ known_red=(
   #    `(when interop/debug-enabled? …)` arm marked `rf2-d2841`, everything
   #    outside such an arm posture-independent — is documented in each of
   #    those namespaces' docstrings under "## Posture split (rf2-d2841)".
-  #    `fx-test` is the big one still standing (107 failures / 25 errors
-  #    across ~20 deftests under the gate).
+  #    `fx-test` — 107 failures / 25 errors across ~20 deftests, the big one
+  #    — came off in the second pass.
+  #
+  #    THE SPLIT IS NOT ALWAYS A GUARD, AND REACHING FOR ONE FIRST COSTS
+  #    COVERAGE. Four `:rf.error/*` categories in the fx subsystem
+  #    (`fx-handler-exception`, `no-such-fx`, `override-fallthrough`,
+  #    `reserved-fx-override`) are ALWAYS-ON: they fan through
+  #    `emit-fx-error!` → `error-emit/emit-error-both!`, which additionally
+  #    LIFTS `:failing-id` and `:reason` onto the record whenever the failing
+  #    component differs from the dispatched event (Spec 009 §Component
+  #    attribution). Assertions about those survive the gate verbatim once
+  #    they read the `:errors` stream instead of the `:trace` stream — and
+  #    that includes the NEGATIVE ones, which over the dev ring pass for free
+  #    under the gate. Check the category's Channel column in Spec 009's
+  #    catalogue before guarding anything: `diagnostic` means dev-only by
+  #    design (`:rf.error/effect-map-shape`), `always-on` means there is a
+  #    production witness to be had.
   #
   #    NOTE for whoever finishes this list: a namespace whose EVERY deftest
   #    is about the dev trace (the `trace-listener-*` cohort, `trace-test`,
@@ -152,7 +169,6 @@ known_red=(
   re-frame.fx-aggregate-classification-cljs-test
   re-frame.fx-args-trace-egress-cljs-test
   re-frame.fx-redirect-classification-cljs-test
-  re-frame.fx-test
   re-frame.handler-source-test
   re-frame.image-inline-metadata-normalization-cljs-test
   re-frame.image-no-emit-trace-gate-cljs-test


### PR DESCRIPTION
Second pass on rf2-d2841. PR #7142 split the spine (six roster lines, 88 → 94 namespaces); this takes **five more** off, led by `fx-test` — the largest single entry, **107 failures / 25 errors across ~20 deftests in 1826 lines** — plus the roster-group prose the next pass needs.

Roster lines removed: `fx-test`, `sub-topology-test`, `init-platform-test`, `pattern-smoke-test`, `db-noop-commit-test`. All five are **0 failures, 0 errors** under `-Dre-frame.debug=false`.

## What the split found

**Nothing failed for a real reason.** Every gate failure was test spelling. But the pass turned up one production-source finding and eleven vacuous passes.

### Filed, not fixed: rf2-g0mep (P2)

`:rf.error/no-such-fx` is catalogued **always-on** (spec/009 §Error event catalogue), and spec/009 states the attribution rule as *"every always-on error record carries `:failing-id` naming the failing COMPONENT's own code identifier whenever that component is DISTINCT from the dispatched event"*. Its emit site (`fx.cljc` ~L1623) builds its trace-payload **without** `:failing-id`, so `emit-error-both!`'s lift never fires and the production record says an fx was missing but not **which one** — the fx-id rides only the DCE'd dev-trace tags. The three sibling fx emit sites in the same file (`fx-handler-exception`, `override-fallthrough`, `reserved-fx-override`) all stamp it, so this is an outlier rather than a carve-out. Same shape as rf2-mlh1h. Production source is outside this bead's fence; `unknown-fx-id-is-logged-and-skipped` now pins what the record *does* carry and carries a NOTE pointing at the bead.

### The method: read the Channel column before reaching for a guard

The single biggest lever here was **not** guarding. Four `:rf.error/*` categories in the fx subsystem — `fx-handler-exception`, `no-such-fx`, `override-fallthrough`, `reserved-fx-override` — fan through `emit-fx-error!` → `error-emit/emit-error-both!`, which **lifts `:failing-id` and `:reason` onto the always-on record** whenever the failing component differs from the dispatched event (spec/009 §Component attribution). Assertions about those survive the gate verbatim once they read the `:errors` stream instead of the `:trace` stream. Verified against the real gate before relying on it.

`:rf.error/effect-map-shape`, by contrast, has Channel **`diagnostic`** in the catalogue and all three of its emit sites are bare `trace/emit-error!` — dev-only **by design**, so those assertions ride a `(when interop/debug-enabled? …)` arm, kept verbatim.

The clearest payoff is `reject-diagnostic-reason-is-id-specific`: **21 of the namespace's 25 errors** were that one deftest NPEing on a nil `:reason`, because it read the string off the DCE'd trace tags. rf2-0qsp5's entire premise is that a programmer was handed the *wrong reason on a production-reachable error channel* — so the reason is now read off **that channel**. Every assertion survives unchanged and now runs in production posture, plus a new first testing block pins the `:failing-id` / `:reason` lift itself so a regression fails with a cause instead of a wall of NPEs.

### Vacuous passes found: 16, all class 1

Each was green under the gate because its subject does not exist in that posture, not because the framework stayed silent.

Moved **inside** the dev arm (their category is `diagnostic`, so there is no production twin):

- in `fx-test`: `well-shaped-fx-vector-is-unchanged`, `nil-fx-value-is-a-legal-no-op`, `nil-and-empty-fx-entries-are-silent-no-ops`, `well-formed-multi-entry-fx-emits-no-shape-trace`, `fx-entry-no-args-shorthand-is-valid`, `event-run-end-coeffects-stamp-absent-when-no-user-cofx`
- in `init-platform-test`: the flip-to-client leg's "no `:rf.fx/skipped-on-platform` trace — the gate passed"
- in `db-noop-commit-test`: three "the other op did **not** fire" partners. These are worth spelling out, because outside an arm they read as load-bearing: they would report that `db-changed` correctly stayed silent on a no-op commit while in fact **nothing** fired, including the `db-noop` that should have. "Exactly one of the two fires" is only meaningful where both can.

**A variant worth naming** — `sub-topology-test`'s `no-doc-key-when-not-supplied` asserts a key is **absent**, and under the gate `:doc` is elided **wholesale**. It passed because `:doc` never exists, not because that registration omitted it. Same false-green shape as an empty ring, different subject: the dev-only half is not always a trace.

Re-pointed at the **always-on** axis instead — that axis is live in both postures, so these stay load-bearing under the gate:

- `fx-entry-non-keyword-head-…` — "NOT mis-reported as `:rf.error/no-such-fx`". Its positive twin (`unknown-fx-id-is-logged-and-skipped`) sees a record on that same axis, so the negative now proves something.
- `nil-and-false-fx-override-values-stay-silent` — rf2-3az1vn's symptom was a spurious record sprayed at the production shipper *per dispatched event*; silence has to be proven where that shipper listens.
- `overridable-tier-unaffected-by-reject`, `reject-tier-nil-false-placeholder-stays-silent`, `cascade-exclusion-reject-tier-not-inherited`.

`cascade-exclusion` needed care rather than a mechanical move. Under the gate the router runs `strip-rejected-overrides` over the **parent's** override map (`router.cljc` §do-fx-for), which legitimately emits one record — so a bare zero is posture-dependent and would have been a false failure. The assertion is now **attributed**: zero records carrying the *child's* `:event-id`. That is the claim the deftest is actually making, it holds in both postures, and it makes the cascade-exclusion load-bearing in the posture where the prod-strip is the live path rather than a unit-tested one.

### Production witnesses added

Eight deftests were 100% dev-instrumentation and would have executed nothing under the gate. Each gained a production-visible witness rather than a wholesale guard:

- the two `:rf.fx/override-applied` deftests now count override vs original handler bodies — rf2-nnma3's regression (trace fired at resolution time while the reserved body ran instead) is exactly a divergence between those counters and the trace, so this is the substantive half of "trace honesty";
- the three `:rf.fx/do-fx` stamp deftests pin the fx args and the `:db` commit the stamp *reports*;
- the three `:rf.event/run-end` coeffect deftests pin that the declared `:rf.cofx/requires` suppliers ran and reached the handler body — the cofx pipeline is production-real even though its stamp is not.

Plus `multiple-legacy-effect-map-keys-each-emit-a-trace`, which had no non-trace observer of the **drop** at all: it now registers a live `:fx-test/never-runs` handler and a live `:http` fx, so "policed" and "silently routed anyway" are distinguishable without reading a dev channel.

And in the second batch: `pattern-smoke`'s stale-timer leg now pins that the live epoch is **untouched** by the stale firing, not merely that the snapshot compares equal; `db-noop`'s deliberate-clear leg pins that the clear **committed**, via frame-state object identity — `db-changed`'s production-visible half; `sub-topology`'s two metadata deftests pin that the sub is projected at all and that the meta-map registration **arity** is accepted.

### The second batch

`db-noop-commit-test` is the one to copy. Its adversarial discriminators — was `replace-container!` **skipped**, does a `=`-but-distinct value still install a new object, does `{:db nil}` land `{}` — are facts about the **container**, readable straight off `frame/frame-state-value`. They need no channel at all, which is why only the `db-noop`/`db-changed` complement and the diagnostic-channel `:rf.warning/db-nil-coerced` needed an arm.

`sub-topology-test` is the counterpart lesson: its dev-only half is **reflection metadata**, not a trace — `:doc` plus the `:ns` / `:line` / `:file` source-coords `reg-sub` auto-captures, the class rf2-d2841's own notes already flag as elided-by-design. Everything around them (`:input-kind`, the literal `:<-` query-vectors with args, declaration order, the `:parametric` sentinel, add / clear / re-register) was posture-independent all along.

`init-platform-test` and `pattern-smoke-test` are straightforward: `:rf.fx/skipped-on-platform` and `:rf.machine.timer/stale-after` are bare `trace/emit!` sites with no always-on twin, while the facts they report — the fx body did not run; the stale timer left the snapshot unchanged — are production-real and were already asserted beside them.

## Quality gates

| gate | result |
|---|---|
| `bash scripts/test-core-prod-gate.sh` | **exit 0** — 99 namespaces, 1186 tests, 5468 assertions |
| `bash scripts/test-core-prod-gate.sh --plan` | **exit 0** — roster verify clean (no stale entries) |
| `clojure -M:test` (`implementation/core`, dev posture) | **exit 0** — 2153 tests, 10683 assertions |
| `clojure -M:test:prod-gate -n re-frame.fx-test` | **exit 0** — 47 tests, 192 assertions |
| `clojure -M:test -n re-frame.fx-test` (dev posture) | **exit 0** — 47 tests, 323 assertions |
| `clojure -M:test:prod-gate` — the other four | **exit 0** — 33 tests, 141 assertions |
| `clojure -M:test` — the other four (dev posture) | **exit 0** — 33 tests, 164 assertions |

**Lane before → after:** 94 → **99** namespaces, 1106 → **1186** tests, 5135 → **5468** assertions. (Baseline measured on this branch with only the roster lines restored, so the delta is these five namespaces' alone.)

**Nothing was lost — the dev-posture assertion count went UP, in both batches.** Same command, same tree, `origin/main`'s files versus this branch's:

- `fx-test`: **265 → 323 assertions**, tests held at **47**, 0 failures.
- the other four together: **160 → 164 assertions**, tests held at **33**, 0 failures.

Every instrumentation assertion is kept verbatim inside a `(when interop/debug-enabled? …)` arm; the +62 is production witnesses **added**.

Roster lines removed: `re-frame.fx-test`, `re-frame.sub-topology-test`, `re-frame.init-platform-test`, `re-frame.pattern-smoke-test`, `re-frame.db-noop-commit-test`. `check_jvm_lane_rosters.py`'s baseline stays empty.

Deferred to CI: the full JVM implementation sweep and the CLJS suites — nothing here touches production source or any CLJS-only path.

## What remains on rf2-d2841

The bead stays **OPEN**. **76** roster lines are left in the rf2-d2841 group. The two shapes the next pass will meet:

1. **Namespaces with semantic residue** — the same treatment as this PR. Read spec/009's Channel column first: an `always-on` category means the assertion can move to the `:errors` axis and stay load-bearing instead of being guarded away. And check whether the dev-only observable is a trace at all — `sub-topology`'s was reflection metadata.
2. **Namespaces with NO semantic residue** — the `trace-listener-*` cohort, `trace-test`, `db-pending-trace-test`, `sub-dispose-trace-test`. Per the bead's own rule these must **not** come off the roster: guarding them wholesale would report green for a namespace that executed nothing. They want a var-level tag the lane excludes (the `-e :requires-debug` idea in the script header), which is a `deps.edn` `:prod-gate` `:main-opts` change.

Triaged under the gate but **not** attempted here, with failure counts, so the next pass can pick up cold: `registrar-warnings-test` (31), `event-context-partition-test` (29), `cofx-envelope-test` (18), `frame-destroy-composed-test` (16), `cascade-dispatch-id-test` (13), `configure-test` (7). `configure-test`'s cluster is `:rf.warning/trace-buffer-unrecognised-opts` read back off the retained ring — worth a careful look, since the retention it configures *is* production state even though the warning is not.

Also filed: **rf2-g0mep** — `:rf.error/no-such-fx`'s missing `:failing-id`.
