### PR TITLE
feat(resources): the route-plan trace carries the identity partition (rf2-dlkou)

### DIFF
--- a/docs/EP/EP-0037-route-planning-and-activation-ownership.md
+++ b/docs/EP/EP-0037-route-planning-and-activation-ownership.md
@@ -1017,6 +1017,24 @@ dedupe advisories, the grouped order, and the identity diff. R6 proves the
 integrated view. No slice is permission to build a second Xray graph or a
 general-purpose public plan debugger.
 
+> **Erratum — 2026-07-27 (rf2-dlkou, recording the rf2-9sluz ruling).** R2's
+> **identity diff** ships as the identity partition on the existing activation
+> `:rf.resource/route-plan` row — `:ensured-identities` / `:kept-identities` /
+> `:removed-identities` beside the `:ensured` / `:kept` / `:removed` counts,
+> with `:identities` carrying the planner's grouped plan order. The vectors are
+> named for what the runtime **did**, not for the diff: a retained-but-unusable
+> identity takes the ordinary ensure path, so a vector named `:added` would
+> disagree with the `:ensured` count beside it. Everything else in the bullet
+> list above is **deliberately not projected**: occurrence/dependency groups,
+> the per-contributor requirement mapping, and local `:after` edges are internal
+> planning mechanics, and Xray's static route/resource graph, the
+> planning-failure evidence, and `:redundant-children` are the authorities for
+> what a reader would otherwise want from them. No route-plan panel, no public
+> plan value, and **no eleventh conformance row** — conformance for the
+> correction is the enriched shape pinned in the R2 partial-activation fixture
+> plus the shape-driven egress test. A future EP that graduates a plan
+> projection owns its own row.
+
 `:rf.resource/route-plan` is the existing Spec 016 route/resource graph
 operation and is extended rather than replaced by a parallel trace. Prefetch
 emits one `:rf.route/prefetched` summary trace; its plan trace carries

--- a/implementation/epoch/test/re_frame/epoch_egress_resource_trace_test.clj
+++ b/implementation/epoch/test/re_frame/epoch_egress_resource_trace_test.clj
@@ -677,6 +677,74 @@
       (testing "NO raw secret survives anywhere in the projected record"
         (is (not (contains-secret? projected)))))))
 
+(deftest off-box-redacts-route-plan-identity-partition
+  (testing "rf2-dlkou — the activation row's IDENTITY PARTITION
+            (:ensured-identities / :kept-identities / :removed-identities) is
+            three more vectors of scoped keys under no NAMED slot. The safety
+            closes by SHAPE, so they were covered the moment they were emitted;
+            this pins it, because the partition is the one place a route's
+            path parameters ride the trace three times over"
+    (let [ensured   (sk :rf.scope/global :secret/article {:auth-token secret})
+          kept      (sk :rf.scope/global :secret/article
+                        {:auth-token (str secret "-kept")})
+          removed   (sk :rf.scope/global :secret/article
+                        {:auth-token (str secret "-gone")})
+          record    (record-with
+                      [(event :rf.resource/route-plan
+                              {:rf.frame/id        :test/rt
+                               :route-id           :r/article
+                               :nav-token          7
+                               :branch             [:r/root :r/article]
+                               :ensured            1
+                               :kept               1
+                               :removed            1
+                               :blocking           [ensured]
+                               :identities         [kept ensured]
+                               :ensured-identities [ensured]
+                               :kept-identities    [kept]
+                               :removed-identities [removed]})])
+          projected (epoch/projected-record record)
+          tags      (:tags (first (:trace-events projected)))
+          partition-slots (juxt :ensured-identities :kept-identities
+                                :removed-identities)]
+      (testing "every partition slot tokenizes per key, exactly as :identities does"
+        (doseq [ks (partition-slots tags)]
+          (is (= 1 (count ks)))
+          (is (= :secret/article (second (first ks)))
+              "the resource-id (position 1) survives")
+          (is (redacted-component? (first (first ks))) "the scope is tokenized")
+          (is (redacted-component? (nth (first ks) 2))
+              "the canonical params — a route's path parameters — are tokenized")))
+      (testing "three DISTINCT identities keep three distinct digests, so the
+                partition a tool reads off one row is still a partition"
+        (is (= 3 (count (set (map #(nth (first %) 2) (partition-slots tags)))))))
+      (is (true? (:sensitive? tags)) "the row is stamped :sensitive?")
+      (testing "the counts beside the vectors are structural scalars and ride"
+        (is (= 1 (:ensured tags)))
+        (is (= 1 (:kept tags)))
+        (is (= 1 (:removed tags))))
+      (testing "NO raw secret survives anywhere in the projected record"
+        (is (not (contains-secret? projected)))))))
+
+(deftest off-box-keeps-plain-owner-identity-partition-verbatim
+  (testing "rf2-dlkou guard — a PLAIN owner's identity partition rides VERBATIM.
+            The partition is a debugging aid, so closing the leak must cost no
+            over-redaction on the ordinary route plan"
+    (let [k1        (sk :rf.scope/global :plain/article {:slug plain-slug})
+          k2        (sk :rf.scope/global :plain/article {:slug "other"})
+          record    (record-with
+                      [(event :rf.resource/route-plan
+                              (assoc (route-plan-tags [k1] [k1])
+                                     :ensured-identities [k1]
+                                     :kept-identities    []
+                                     :removed-identities [k2]))])
+          projected (epoch/projected-record record)
+          tags      (:tags (first (:trace-events projected)))]
+      (is (= [k1] (:ensured-identities tags)))
+      (is (= [] (:kept-identities tags)) "an empty partition slot survives empty")
+      (is (= [k2] (:removed-identities tags)))
+      (is (not (:sensitive? tags)) "a plain row is NOT stamped sensitive"))))
+
 (deftest unnamed-slot-projects-identically-to-named-slot
   (testing "rf2-wd9im anti-drift — the SAME scoped keys under a NAMED slot
             (:matched) and under UNNAMED slots (:blocking / :identities) must
@@ -689,16 +757,24 @@
           ks        [k1 k2]
           record    (record-with
                       [(event :rf.resource/route-plan
-                              {:rf.frame/id :test/rt
-                               :matched     ks     ; NAMED  → roster arm
-                               :blocking    ks     ; UNNAMED → shape arm
-                               :identities  ks})]) ; UNNAMED → shape arm
+                              {:rf.frame/id        :test/rt
+                               :matched            ks   ; NAMED  → roster arm
+                               :blocking           ks   ; UNNAMED → shape arm
+                               :identities         ks   ; UNNAMED → shape arm
+                               ;; rf2-dlkou — the identity partition, three more
+                               ;; UNNAMED slots on the same row.
+                               :ensured-identities ks
+                               :kept-identities    ks
+                               :removed-identities ks})])
           projected (epoch/projected-record record)
           tags      (:tags (first (:trace-events projected)))]
       (is (= (:matched tags) (:blocking tags))
           ":blocking projects exactly as the NAMED :matched does")
       (is (= (:matched tags) (:identities tags))
           ":identities projects exactly as the NAMED :matched does")
+      (doseq [slot [:ensured-identities :kept-identities :removed-identities]]
+        (is (= (:matched tags) (slot tags))
+            (str slot " projects exactly as the NAMED :matched does")))
       (is (every? redacted-component? (map first (:blocking tags)))
           "both keys' scopes tokenized (the derived scope included)")
       (is (not (contains-secret? projected))))))

--- a/implementation/resources/src/re_frame/resources/route.cljc
+++ b/implementation/resources/src/re_frame/resources/route.cljc
@@ -1097,17 +1097,49 @@
         ;; `:removed` the prior-plan identities this plan drops. A retained
         ;; identity that could not be adopted counts as ensured, so the trace
         ;; reports what actually happened.
-        added-count   (count (remove adopted? ordered))
-        removed-count (count (remove next-ids prev-ids))]
+        ;;
+        ;; rf2-dlkou (the rf2-9sluz ruling) — the counts stay as the compact
+        ;; headline and the row ALSO carries the exact partition, so one trace
+        ;; answers "which identity was ensured / kept / removed on this
+        ;; navigation" without diffing two consecutive rows. The vectors are
+        ;; named for what the runtime DID rather than for the diff: since the
+        ;; retained-entry liveness repair a retained-but-unusable identity takes
+        ;; the ordinary ensure path, so a vector named `:added` would disagree
+        ;; with the `:ensured` count beside it. `:ensured-identities` /
+        ;; `:kept-identities` ride `ordered`'s grouped plan order — the same
+        ;; order `:identities` carries. `:removed-identities` filters
+        ;; `prev-identities` IN PLACE rather than iterating the derived
+        ;; `prev-ids` set, so the prior plan's own order survives for any caller
+        ;; that threads a sequential collection (routing threads the set
+        ;; `commit-navigation` recorded, whose iteration order is at least
+        ;; content-stable). Nothing else from the EP's §Tooling list is
+        ;; projected — no occurrence/dependency groups, no per-contributor
+        ;; requirement mapping, no local `:after` edges (internal planning
+        ;; mechanics; Xray's static route/resource graph, the planning-failure
+        ;; evidence, and `:redundant-children` are the authorities).
+        ensured-identities (into [] (comp (remove adopted?) (map :scoped-key)) ordered)
+        kept-identities    (into [] (comp (filter adopted?) (map :scoped-key)) ordered)
+        removed-identities (filterv (complement next-ids) prev-identities)
+        added-count        (count ensured-identities)
+        removed-count      (count (remove next-ids prev-ids))]
     (trace/emit! :rf.event :rf.resource/route-plan
-                 (cond-> {:route-id   route-id
-                          :nav-token  nav-token
-                          :branch     (mapv :route-id branch)
-                          :ensured    added-count
-                          :kept       (- (count ordered) added-count)
-                          :removed    removed-count
-                          :blocking   (vec blocking)
-                          :identities (vec next-ids)}
+                 (cond-> {:route-id           route-id
+                          :nav-token          nav-token
+                          :branch             (mapv :route-id branch)
+                          :ensured            added-count
+                          :kept               (- (count ordered) added-count)
+                          :removed            removed-count
+                          :blocking           (vec blocking)
+                          ;; the planner's GROUPED PLAN ORDER — `ordered` is
+                          ;; post-dedupe (one entry per collapsed identity
+                          ;; group), so this carries each identity exactly once,
+                          ;; in the order the plan executes. `next-ids` is the
+                          ;; same content as a SET and rides the RETURN map
+                          ;; below, which `commit-navigation` consumes.
+                          :identities         (mapv :scoped-key ordered)
+                          :ensured-identities ensured-identities
+                          :kept-identities    kept-identities
+                          :removed-identities removed-identities}
                    (seq advisories) (assoc :redundant-children advisories)
                    plan-error       (assoc :plan-error true)))
     ;; The blocking set, identity set + plan-error ride back to

--- a/implementation/resources/test/re_frame/resources_route_cljs_test.cljc
+++ b/implementation/resources/test/re_frame/resources_route_cljs_test.cljc
@@ -34,6 +34,7 @@
    [re-frame.core :as rf]
    [re-frame.fx :as fx]
    [re-frame.error :as error]
+   [re-frame.interop :as interop]
    ;; load-bearing side-effecting requires: register the routing + resources
    ;; events / subs and resources' late-bound :routing/* integration hooks.
    [re-frame.resources]
@@ -134,6 +135,19 @@
 
 (defn- errors-of [traces op]
   (filterv #(= op (:operation %)) traces))
+
+(defn- record-op-traces!
+  "Run `body-fn` with a trace listener installed; return the vector of every
+  trace event whose `:operation` is `op` (capture order). The sibling of
+  `record-error-traces!` for an ordinary `:rf.event` row — used by the
+  rf2-dlkou `:rf.resource/route-plan` plan-diff assertions."
+  [op body-fn]
+  (let [seen (atom [])
+        k    ::route-op-recorder]
+    (trace-tooling/register-listener!
+      k (fn [ev] (when (= op (:operation ev)) (swap! seen conj ev))))
+    (try (body-fn) (finally (trace-tooling/unregister-listener! k)))
+    @seen))
 
 ;; ===========================================================================
 ;; 1. Accepted-key extension
@@ -854,6 +868,63 @@
     (testing "the prior plan owner release is dispatched LAST (attach-before-release)"
       (is (= :rf.resource/release-owner (first (last ds))))
       (is (= [:route :route/p.a 1] (:owner (second (last ds)))) "releases the superseded owner"))))
+
+(deftest r2-plan-diff-trace-carries-the-identity-partition
+  ;; rf2-dlkou (the rf2-9sluz ruling) — the SAME sibling-leaf navigation as the
+  ;; test above, read off the `:rf.resource/route-plan` TRACE rather than the
+  ;; returned fx: one row must answer "which identity was ensured / kept /
+  ;; removed on this navigation" without diffing two consecutive rows. The
+  ;; counts stay as the compact headline and keep their existing values.
+  (rf/reg-resource :sh/v (article-spec {}) article-spec-request)
+  (rf/reg-resource :lf/a (article-spec {}) article-spec-request)
+  (rf/reg-resource :lf/b (article-spec {}) article-spec-request)
+  (let [parent-meta {:resources [{:resource :sh/v :params (fn [_] {:slug "v"}) :blocking? true}]}
+        shared-key  (state/scoped-resource-key* :rf.scope/global :sh/v {:slug "v"})
+        a-key       (state/scoped-resource-key* :rf.scope/global :lf/a {:slug "a"})
+        b-key       (state/scoped-resource-key* :rf.scope/global :lf/b {:slug "b"})
+        branch1 [{:route-id :route/p   :route-meta parent-meta}
+                 {:route-id :route/p.a :route-meta {:resources [{:resource :lf/a :params (fn [_] {:slug "a"})}]}}]
+        branch2 [{:route-id :route/p   :route-meta parent-meta}
+                 {:route-id :route/p.b :route-meta {:resources [{:resource :lf/b :params (fn [_] {:slug "b"})}]}}]
+        plan1 (route/route-resource-plan {:id :route/p.a :params {} :query {}} {}
+                                         {:nav-token 1 :branch branch1})
+        ;; plan1's shared identity has since LOADED — the reusable kept case.
+        rdb   {:rf.runtime/resources
+               {:entries {(state/key-id shared-key)
+                          {:resource/id :sh/v :resource/key shared-key
+                           :status :loaded :data {:n 1} :attempt 1}}}}
+        traces (record-op-traces!
+                 :rf.resource/route-plan
+                 (fn [] (route/route-resource-plan
+                          {:id :route/p.b :params {} :query {}} {}
+                          {:nav-token 2 :prev-id :route/p.a :prev-nav-token 1
+                           :prev-identities (:identities plan1) :branch branch2
+                           :runtime-db rdb})))]
+    ;; rf2-o5dbf — `trace/emit!` sits behind `interop/debug-enabled?`, so the
+    ;; row exists only in the dev posture. Under `-Dre-frame.debug=false` there
+    ;; is no row to read and the plan-diff assertions are vacuous by design.
+    (when interop/debug-enabled?
+      (let [tags (:tags (first traces))]
+        (is (some? tags) "the activation emits one :rf.resource/route-plan row")
+        (testing "the counts are unchanged — the compact headline still reads
+                  1 ensured / 1 kept / 1 removed"
+          (is (= 1 (:ensured tags)))
+          (is (= 1 (:kept tags)))
+          (is (= 1 (:removed tags))))
+        (testing "and the row names WHICH identity took each path"
+          (is (= [b-key] (:ensured-identities tags))
+              "the added leaf took the real ensure path")
+          (is (= [shared-key] (:kept-identities tags))
+              "the shared parent was adopted without a fetch")
+          (is (= [a-key] (:removed-identities tags))
+              "the departed leaf is the prior-plan identity this plan drops"))
+        (testing "each vector agrees with the count beside it"
+          (is (= (:ensured tags) (count (:ensured-identities tags))))
+          (is (= (:kept tags) (count (:kept-identities tags))))
+          (is (= (:removed tags) (count (:removed-identities tags)))))
+        (testing ":identities carries the planner's GROUPED PLAN ORDER —
+                  parent-most first, one entry per collapsed identity"
+          (is (= [shared-key b-key] (:identities tags))))))))
 
 (deftest r2-branch-resolve-fails-loud
   ;; A :parent naming an unregistered route aborts the plan (a committed failed

--- a/spec/conformance/fixtures/ep-0037-r2-partial-activation.edn
+++ b/spec/conformance/fixtures/ep-0037-r2-partial-activation.edn
@@ -8,12 +8,16 @@
 ;; navigation projects the diff: :kept 1 (the parent :acct/viewer, adopted),
 ;; :ensured 1 (the added leaf :acct/b), :removed 1 (the departed leaf :acct/a).
 ;;
+;; rf2-dlkou (the rf2-9sluz ruling) — the row also names WHICH identity took each
+;; path, so one trace answers the question without diffing two consecutive rows,
+;; and :identities carries the planner's grouped plan order (parent-most first).
+;;
 ;; Per [016 §Plan diff and owner handoff](../../016-Resources.md#plan-diff-and-owner-handoff).
 
 {:fixture/id           :ep-0037/r2-partial-activation
  :fixture/spec-version "1.0"
  :fixture/capabilities #{:routing/match-url :resources/ensure :core/event-handler}
- :fixture/doc          "EP-0037 R2: sibling-leaf navigation under a shared parent keeps the parent identity (adopted, not re-ensured — the partial-revalidation law), adds the new leaf, and removes the departed leaf. The second navigation's route-plan trace projects :kept 1 / :ensured 1 / :removed 1."
+ :fixture/doc          "EP-0037 R2: sibling-leaf navigation under a shared parent keeps the parent identity (adopted, not re-ensured — the partial-revalidation law), adds the new leaf, and removes the departed leaf. The second navigation's route-plan trace projects :kept 1 / :ensured 1 / :removed 1, names the identity behind each count, and carries :identities in grouped plan order."
 
  :fixture/registry
  {:route
@@ -49,8 +53,18 @@
   ;; parent :acct/viewer is kept + adopted, not re-ensured).
   :trace-emissions
   [{:operation :rf.resource/route-plan
-    :tags      {:route-id :route/account.b
-                :branch   [:route/account :route/account.b]
-                :ensured  1
-                :kept     1
-                :removed  1}}]}}
+    :tags      {:route-id           :route/account.b
+                :branch             [:route/account :route/account.b]
+                ;; the compact headline …
+                :ensured            1
+                :kept               1
+                :removed            1
+                ;; … and the exact partition beside it: which identity was
+                ;; ensured, which was kept, which the plan dropped.
+                :ensured-identities [[:rf.scope/global :acct/b {}]]
+                :kept-identities    [[:rf.scope/global :acct/viewer {}]]
+                :removed-identities [[:rf.scope/global :acct/a {}]]
+                ;; :identities is the planner's GROUPED PLAN ORDER — the shared
+                ;; ancestor first, then the leaf.
+                :identities         [[:rf.scope/global :acct/viewer {}]
+                                     [:rf.scope/global :acct/b {}]]}}]}}


### PR DESCRIPTION
Implements the **rf2-9sluz ruling** (option B, delegated by Mike 2026-07-27) on **rf2-dlkou**. EP-0037 §Tooling's R2 "identity diff" ships as the exact identity partition on the existing activation `:rf.resource/route-plan` trace row — and nothing more.

## What changed

`implementation/resources/src/re_frame/resources/route.cljc`, the one activation `trace/emit!`:

- **added** `:ensured-identities` (requirements taking the real ensure path, plan order), `:kept-identities` (genuinely adopted — owner handoff, no fetch, plan order), `:removed-identities` (prior-plan identities this plan drops, filtered over `prev-identities` in place rather than over the derived `prev-ids` SET);
- **corrected** `:identities` from `(vec next-ids)` — a vector built from a SET, so it never carried the order the EP names — to `(mapv :scoped-key ordered)`, the planner's grouped plan order. `ordered` is post-dedupe (one entry per collapsed identity group), so no scoped-key appears twice;
- **the RETURN map is untouched**: `:identities next-ids` stays the set `commit-navigation` records under the nav-token and diffs against on the next activation.

The names are the ruling's and they are load-bearing: since the retained-entry liveness repair a retained-but-unusable identity takes the ordinary ensure path, so a vector named `:added` would disagree with the `:ensured` count beside it. The vectors say what the runtime *did*.

**The counts are unchanged.** `:ensured` / `:kept` / `:removed` keep their existing values and stay the compact headline; `added-count` is now `(count ensured-identities)` — the same number by construction, one traversal fewer — and count/vector agreement is pinned by test. A consumer reading only the counts today keeps working.

**No eleventh conformance row.** EP-0037's matrix is untouched; conformance for the correction is the enriched shape pinned in the existing R2 partial-activation fixture plus the shape-driven egress test, exactly as the ruling directs. No panel, no public plan value, no second graph.

## Egress — the row is dev-only, and the identities close by shape

`:rf.resource/route-plan` is a **dev trace**: `trace/emit!` sits behind `interop/debug-enabled?`, so production CLJS bundles DCE the emit entirely. It reaches off-box only through an epoch record's `:trace-events`.

On that path the three vectors are already safe, and safe by the *existing* discipline rather than a new one. `re-frame.resources.trace-egress/project-resource-trace-egress` routes every slot its vocabulary does not NAME through the shape-driven fail-closed default `project-unknown-slot-value` (rf2-wd9im): a scoped-key-shaped vector anywhere inside the value projects through `project-trace-scoped-key` — the same owner classification the NAMED slots use. A `:sensitive?` / `:large?` / **unregistered** owner's resolved scope and canonical params (which is where a route's path parameters live) tokenize to `{:rf/redacted <digest>}` per key, distinct keys keeping distinct digests; a plain owner's key rides verbatim. Nothing was added to the slot roster — that roster's own docstring says not to grow it, because a name list cannot cover a slot nobody has looked at yet while the shape read covers the ones added next year. These three are precisely such slots. Pinned below rather than assumed.

## Erratum

One blockquote in `docs/EP/EP-0037-…` §Tooling records the disposition beside the staging clause: the identity diff ships as the partition; occurrence/dependency groups, per-contributor requirement mapping, and local `:after` edges are deliberately not projected (internal planning mechanics — Xray's static route/resource graph, the planning-failure evidence, and `:redundant-children` are the authorities); no panel, no public plan value, no eleventh row.

## Quality gates

Foreground, worktree-local, exit codes as printed.

| gate | command (cwd) | exit |
|---|---|---|
| resources — route suite, dev posture | `clojure -M:test -n re-frame.resources-route-cljs-test` (`implementation/resources`) | **0** — 49 tests / 265 assertions |
| resources — full artefact, dev posture | `clojure -M:test` (`implementation/resources`) | **0** — 742 tests / 6864 assertions |
| resources — new test only, dev posture | `clojure -M:test -v …/r2-plan-diff-trace-carries-the-identity-partition` | **0** — 1 test / **11 assertions** |
| resources — new test only, prod posture | `clojure -J-Dre-frame.debug=false -M:test -v …/r2-plan-diff-trace-carries-the-identity-partition` | **0** — 1 test / **0 assertions** (the row does not exist under the gate; guarded by `interop/debug-enabled?`, vacuous by design) |
| epoch — egress projector | `clojure -M:test -n re-frame.epoch-egress-resource-trace-test` (`implementation/epoch`) | **0** — 83 tests / 667 assertions |
| conformance corpus (JVM) | `clojure -M:test -n re-frame.conformance-test` (`implementation/core`) | **0** — 5 tests / 18 assertions |

**Prod posture over the whole route suite** — `clojure -J-Dre-frame.debug=false -M:test -n re-frame.resources-route-cljs-test` exits **1** with 17 failures, **all pre-existing on `origin/main`** and none of them mine: they are `errors-of traces :rf.error/…` assertions in `blocking-first-load-failure-emits-error-trace`, `nil-params-resolver-is-a-planning-error`, `after-missing-target-is-a-planning-error`, `r2-ancestor-planning-failure-…` and `reconcile-readiness-…`, which read error traces `trace/emit-error!` does not emit under the gate. This artefact has no prod-gate lane (the `-Dre-frame.debug=false` lanes are core, routing and ssr) and the suite was never made posture-clean. That the failures cannot be mine is mechanical: `git diff origin/main -- implementation/resources/test/` is **71 insertions, 0 deletions**, and my own test is green in that posture (row above).

### Mutation evidence

**1. The partition (source mutation).** Moved the shared identity from kept to removed in `route.cljc` — `kept-identities` gained a `(drop 1)`, `removed-identities` gained the adopted keys:

```
FAIL r2-plan-diff-trace-carries-the-identity-partition (resources_route_cljs_test.cljc:917)
  the shared parent was adopted without a fetch
  expected: (= [shared-key] (:kept-identities tags))
    actual: (not (= [[:rf.scope/global :sh/v {:slug "v"}]] []))

FAIL … (:919) the departed leaf is the prior-plan identity this plan drops
  expected: (= [a-key] (:removed-identities tags))
    actual: (not (= [[:rf.scope/global :lf/a {:slug "a"}]]
                    [[:rf.scope/global :lf/a {:slug "a"}] [:rf.scope/global :sh/v {:slug "v"}]]))

FAIL … (:923) expected: (= (:kept tags) (count (:kept-identities tags)))       actual: (not (= 1 0))
FAIL … (:924) expected: (= (:removed tags) (count (:removed-identities tags))) actual: (not (= 1 2))

Ran 49 tests containing 265 assertions.  4 failures, 0 errors.    EXIT=1
```

The moved identity is named in the message, and the count/vector agreement assertions catch it *while the counts themselves stay 1/1/1* — which is the point of shipping the vectors. Restored → **EXIT 0**, and `git diff --stat -- implementation/resources/src` **empty**.

**2. The fixture.** Perturbed `:kept-identities` in `ep-0037-r2-partial-activation.edn` to name `:acct/a` instead of `:acct/viewer`:

```
Failures:
   :ep-0037/r2-partial-activation
    trace: expected trace not seen: {:operation :rf.resource/route-plan, :tags {…}}
Ran 5 tests containing 18 assertions.  1 failures, 0 errors.      EXIT=1
```

The corpus runner aggregates fixtures into few assertions, so this proves the new pins are actually evaluated rather than carried along. Restored → **EXIT 0**, tree clean.

### Deferred to CI

The CLJS/node suites for resources and epoch, the full epoch and routing artefacts, the browser smokes, and `mkdocs build --strict` over the EP edit.

## Notes for the reviewer

- **Two files sit outside the dispatching fence** and are here because the bead's acceptance names them: `spec/conformance/fixtures/ep-0037-r2-partial-activation.edn` (the ruling's designated conformance for this correction — the bead's own dispatch note flags it as sequenced spec/ work) and the EP erratum. Neither is touched by any branch currently in flight (checked against the six live worker branches).
- **`spec/009-Instrumentation.md` is NOT updated here, deliberately.** 009:1059 carries the row's full activation tag roster and now under-describes it. The file is hot-zone *and* currently being edited by the ssr-prod-404 worker, and the bead scopes the doc change to the EP erratum. Filed as a follow-up bead.
- `:removed-identities` filters `prev-identities` in place so the prior plan's order survives; today routing threads the recorded identity SET, so the order is that set's (content-stable) iteration order. The fixture and the unit test each have exactly one removed identity, so nothing here depends on it.
