### PR TITLE
test(freehand): rf2-3slzz spike probes — is the {:reactive false} runtime check total?

### DIFF
--- a/implementation/freehand/test/re_frame/freehand/reactive_false_check_elision_prod_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/reactive_false_check_elision_prod_test.cljs
@@ -29,8 +29,9 @@
   `{goog.DEBUG false}`, runner `re-frame.prod-elision-runner`). The
   default `:browser-test` / `:node-test` regexes do not match this
   suffix, so nothing here runs in a development posture."
-  (:require ["react" :as react]
-            [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+  (:require ["react-dom" :as react-dom]
+            ["react-dom/client" :as rdc]
+            [cljs.test :refer-macros [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.freehand :as v]
@@ -65,13 +66,14 @@
 (defn- browser? []
   (and (exists? js/document) (some? (.-createElement js/document))))
 
-(defn- act
-  [thunk]
-  (try
-    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
-    (js/Promise.resolve (react/act (fn [] (js/Promise.resolve (thunk)))))
-    (catch :default e
-      (js/Promise.reject e))))
+;; `react/act` is a DEVELOPMENT-only export: the production React build
+;; does not carry it, and reaching for it here answered
+;; `TypeError: act is not a function` — which is itself a small reminder
+;; that a browser assertion written in a dev posture is not automatically
+;; a production one. `react-dom/flushSync` is the production-available
+;; way to force the mount's render to run synchronously, so a render that
+;; throws rethrows to THIS caller instead of surfacing as an unhandled
+;; asynchronous error nothing here could observe.
 
 (defn- caught-id
   [thunk]
@@ -142,30 +144,44 @@
   (testing "The whole question, in the configuration it will actually
             ship in: a boundary with NO ViewCell, mounted through React,
             in an `:advanced` bundle with the debug gate folded away. The
-            body reads; the read has no owner; the render fails loud
-            instead of committing a page that will never update again."
+            body reads; the read has no owner; the render fails loud and
+            NOTHING is committed, rather than a page that will never
+            update again being put on screen.
+
+            HOW the failure arrives is a production fact worth recording,
+            because it is not how it arrives in development. React 19
+            routes an uncaught render error to the root's
+            `onUncaughtError` and does NOT rethrow it to the caller that
+            asked for the render — not even inside `flushSync`. In
+            development `react/act` collects and rethrows it, so a dev
+            assertion can simply catch the mount; in production the same
+            error reaches the page as an uncaught error instead. It is
+            still loud (a `window` error event, the console, and any
+            `onerror` reporter an application has installed) and the
+            boundary is still not committed — but a caller cannot
+            `try`/`catch` it, which is exactly the kind of difference this
+            file exists to find."
     (if-not (browser?)
       (is true "a real React mount needs a DOM host")
-      (async done
+      (let [container  (js/document.createElement "div")
+            caught     (atom nil)
+            react-root (rdc/createRoot
+                         container
+                         #js {:onUncaughtError (fn [e _info] (reset! caught e))})]
         (register!)
         (seed! {:total 41})
         (is (= :elided (:view-cell (v/manifest elided-but-reads)))
             "non-vacuous: the analysis really did elide the ViewCell")
-        (let [container (js/document.createElement "div")]
-          (.appendChild js/document.body container)
-          (-> (act #(v/mount [elided-but-reads {}] container {:frame fid}))
-              (.then (fn [mounted]
-                       (is false
-                           (str "the shell-free mount SUCCEEDED in production and rendered "
-                                (pr-str (some-> (.querySelector container "#leak")
-                                                .-textContent))
-                                " — a read with no owner was not refused"))
-                       (when mounted (.unmount (.-react-root ^root/Root mounted)))
-                       (.remove container)
-                       (done)))
-              (.catch (fn [e]
-                        (is (= outside-render (:rf.error/id (ex-data e)))
-                            (str "refused loudly at the read, in production; got "
-                                 (pr-str e)))
-                        (.remove container)
-                        (done)))))))))
+        (.appendChild js/document.body container)
+        (try
+          (try
+            (react-dom/flushSync
+              (fn [] (.render react-root (fr/element [elided-but-reads {}]))))
+            (catch :default e (reset! caught e)))
+          (is (= outside-render (:rf.error/id (ex-data @caught)))
+              (str "refused with the stable id in a production bundle; got "
+                   (pr-str @caught)))
+          (is (nil? (some-> (.querySelector container "#leak") .-textContent))
+              "and NOTHING was committed — no silently stale boundary reached the page")
+          (finally
+            (.remove container)))))))

--- a/implementation/freehand/test/re_frame/freehand/reactive_false_check_elision_prod_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/reactive_false_check_elision_prod_test.cljs
@@ -1,0 +1,171 @@
+(ns re-frame.freehand.reactive-false-check-elision-prod-test
+  "SPIKE rf2-3slzz — the PRODUCTION half of the `{:reactive false}`
+  totality question, proved under real `:advanced` + `goog.DEBUG=false`
+  compilation rather than argued from source.
+
+  The flag's check is a SAFETY mechanism, not authoring lint: a boundary
+  the author wrongly declared shell-free must fail at the first offending
+  render in a shipped bundle, not only in development. This repository
+  has repeatedly found checks that exist only in dev — `reg-app-schema`
+  validation is a production no-op, and several \"production\" suites
+  turned out to rebind `interop/debug-enabled?` with `with-redefs`, which
+  cannot reach a load-time gate at all. So the claim is made HERE, where
+  Closure has already folded the gate to `false` and DCE'd everything
+  behind it.
+
+  What it pins:
+
+  1. the posture is real — `interop/debug-enabled?` is genuinely false;
+  2. a reactive read with no candidate still raises, and still carries
+     its stable `:rf.error/view-read-outside-render` id;
+  3. the same refusal reaches through an ordinary helper, which is the
+     shape no build-time analysis can see;
+  4. and it fires on a REAL MOUNT of a genuinely shell-free boundary —
+     a `{:compiled true}` declaration the analyzer proved inert, whose
+     body reads through that helper anyway.
+
+  Naming convention: files ending in `-elision-prod-test.cljs` are picked
+  up ONLY by the `:browser-test-prod-elision` build (`:advanced` +
+  `{goog.DEBUG false}`, runner `re-frame.prod-elision-runner`). The
+  default `:browser-test` / `:node-test` regexes do not match this
+  suffix, so nothing here runs in a development posture."
+  (:require ["react" :as react]
+            [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.cell :as cell]
+            [re-frame.freehand.react :as fr]
+            [re-frame.freehand.root :as root]
+            [re-frame.freehand.tree :as tree]
+            [re-frame.interop :as interop]
+            [re-frame.live-frame :as live-frame]
+            [re-frame.adapter.uix :as react-substrate]
+            [re-frame.test-support :as test-support]))
+
+(def ^:private fid :spike-prod/frame)
+(def ^:private outside-render :rf.error/view-read-outside-render)
+
+(def ^:private runtime-fixture
+  (test-support/make-reset-runtime-fixture
+    {:adapter       react-substrate/adapter
+     :ambient-frame nil
+     :async?        true}))
+
+(use-fixtures :each
+  {:before (fn []
+             (root/reset-registry!)
+             (fr/reset-boundaries!)
+             ((:before runtime-fixture)))
+   :after  (fn []
+             ((:after runtime-fixture))
+             (root/reset-registry!)
+             (fr/reset-boundaries!))})
+
+(defn- browser? []
+  (and (exists? js/document) (some? (.-createElement js/document))))
+
+(defn- act
+  [thunk]
+  (try
+    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+    (js/Promise.resolve (react/act (fn [] (js/Promise.resolve (thunk)))))
+    (catch :default e
+      (js/Promise.reject e))))
+
+(defn- caught-id
+  [thunk]
+  (try (thunk) ::no-throw (catch :default e (or (:rf.error/id (ex-data e)) ::no-id))))
+
+(defn- register! []
+  (rf/reg-sub :spike/total (fn [db _] (:total db))))
+
+(defn- seed! [db]
+  (live-frame/make-frame {:id fid})
+  (frame/replace-app-db! fid db)
+  fid)
+
+(defn- helper-sub
+  "An ORDINARY defn performing the read — the helper-mediated shape."
+  []
+  (str (v/sub [:spike/total])))
+
+(v/defview reads-through-helper
+  "Interpreted; reads through the helper."
+  [_]
+  [:p (helper-sub)])
+
+(v/defview elided-but-reads
+  "`{:compiled true}` and PROVED inert by the analyzer — no lexical `sub`
+  site, so `:view-cell :elided` and NO ViewCell is minted — yet the body
+  reads through an ordinary helper. The compiled tier's own proof is
+  defeated here; the runtime candidate check is what stops it becoming a
+  silently stale page, and it is the same check `{:reactive false}` would
+  rest on."
+  {:compiled true}
+  [_]
+  [:p#leak (helper-sub)])
+
+;; ===========================================================================
+
+(deftest the-posture-is-genuinely-production
+  (testing "Non-vacuity for everything below: this build really did fold
+            the debug gate away. A `with-redefs` rebind could not have
+            produced this — `debug-enabled?` is a load-time constant."
+    (is (false? interop/debug-enabled?)
+        "interop/debug-enabled? is false under :advanced + goog.DEBUG=false")))
+
+(deftest a-read-with-no-candidate-still-raises-in-production
+  (testing "The candidate consultation in `cell/observe!` is an
+            unconditional `when`, and `error/throw-error!` is not gated —
+            so the refusal survives `:advanced`, with its stable
+            diagnostic id intact. A keyword id is data, not a message, so
+            it is the thing a production caller can still branch on."
+    (register!)
+    (seed! {:total 7})
+    (is (false? (cell/observing?)) "non-vacuous: no candidate is open")
+    (is (= outside-render (caught-id #(rf/with-frame fid (v/sub [:spike/total]))))
+        "refused, with the id, in a production bundle")))
+
+(deftest a-helper-mediated-read-with-no-candidate-still-raises-in-production
+  (testing "The shape a build-time proof cannot see. Capture is dynamic,
+            so the refusal reaches through an arbitrary ordinary helper
+            exactly as it does an inline read — in production as in
+            development."
+    (register!)
+    (seed! {:total 7})
+    (is (= outside-render
+           (caught-id #(rf/with-frame fid (tree/render [reads-through-helper {}]))))
+        "the helper-mediated read was refused in a production bundle")))
+
+(deftest a-mounted-shell-free-boundary-refuses-its-read-in-production
+  (testing "The whole question, in the configuration it will actually
+            ship in: a boundary with NO ViewCell, mounted through React,
+            in an `:advanced` bundle with the debug gate folded away. The
+            body reads; the read has no owner; the render fails loud
+            instead of committing a page that will never update again."
+    (if-not (browser?)
+      (is true "a real React mount needs a DOM host")
+      (async done
+        (register!)
+        (seed! {:total 41})
+        (is (= :elided (:view-cell (v/manifest elided-but-reads)))
+            "non-vacuous: the analysis really did elide the ViewCell")
+        (let [container (js/document.createElement "div")]
+          (.appendChild js/document.body container)
+          (-> (act #(v/mount [elided-but-reads {}] container {:frame fid}))
+              (.then (fn [mounted]
+                       (is false
+                           (str "the shell-free mount SUCCEEDED in production and rendered "
+                                (pr-str (some-> (.querySelector container "#leak")
+                                                .-textContent))
+                                " — a read with no owner was not refused"))
+                       (when mounted (.unmount (.-react-root ^root/Root mounted)))
+                       (.remove container)
+                       (done)))
+              (.catch (fn [e]
+                        (is (= outside-render (:rf.error/id (ex-data e)))
+                            (str "refused loudly at the read, in production; got "
+                                 (pr-str e)))
+                        (.remove container)
+                        (done)))))))))

--- a/implementation/freehand/test/re_frame/freehand/reactive_false_shell_free_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/reactive_false_shell_free_dom_cljs_test.cljs
@@ -129,6 +129,16 @@
   [_]
   [:div#parent [reactive-child {}]])
 
+(v/defview elided-snapshot-read
+  "Elided by proof, and it performs the NON-reactive read the flag's
+  contract names as staying legal: the ambient 1-arity
+  `rf/subscribe-once`. The analyzer records no site for it — it is an
+  ordinary function call, not a `sub` — so the ViewCell is elided, and
+  the ambient form then has no frame scope to resolve against."
+  {:compiled true}
+  [_]
+  [:p#snapshot (str (rf/subscribe-once [:spike/total]))])
+
 (v/defview owning-button
   "The CONTROL for the event arms: the identical authored markup inside a
   boundary that DOES own a shell, so the site is committed and the click
@@ -171,6 +181,49 @@
                         (is (= :rf.error/view-read-outside-render
                                (:rf.error/id (ex-data e)))
                             (str "refused loudly at the read; got " (pr-str e)))
+                        (.remove container)
+                        (done)))))))))
+
+(deftest a-shell-free-boundary-still-resolves-a-frame-for-a-snapshot-read
+  (testing "The ruling keeps `rf/subscribe-once` legal under the flag — a
+            snapshot the programmer asked for — and this checks that the
+            promise survives losing the shell, because it was not obvious
+            that it would. The shell's `cell/with-capture` binds
+            `frame/*current-frame*`, and a shell-free boundary gets no
+            such binding; the reason the ambient 1-arity still resolves
+            is the OTHER scope tier. `frame/resolve-current-frame` reads
+            the React frame CONTEXT through the `:adapter/current-frame`
+            hook, and a context value is available to any component
+            rendering under the provider `v/mount` installs — shell or no
+            shell. So the snapshot read resolves the mounting frame and
+            returns its value.
+
+            What the boundary does NOT acquire is a `useContext`
+            SUBSCRIPTION to that context, because it calls no hook. It
+            performs no reactive read either, so there is nothing for a
+            provider retarget to invalidate — and its reactive children
+            each own their own `useContext`. See
+            `a-reactive-child-of-a-shell-free-parent-keeps-its-own-shell`."
+    (if-not (browser?)
+      (skip! "the browser job runs the mount assertions")
+      (async done
+        (register!)
+        (seed! {:total 41})
+        (is (= :elided (:view-cell (v/manifest elided-snapshot-read)))
+            "non-vacuous: a subscribe-once is not a site, so the cell is elided")
+        (let [container (host-node!)]
+          (-> (act #(v/mount [elided-snapshot-read {}] container {:frame fid}))
+              (.then (fn [mounted]
+                       (is (= "41" (text container "#snapshot"))
+                           "the ambient one-shot read resolved the mounting frame
+                            through the React frame context, with no shell above it")
+                       (when mounted (.unmount (.-react-root ^root/Root mounted)))
+                       (.remove container)
+                       (done)))
+              (.catch (fn [e]
+                        (is false
+                            (str "the snapshot read failed in a shell-free boundary: "
+                                 (pr-str e)))
                         (.remove container)
                         (done)))))))))
 
@@ -263,6 +316,21 @@
         (let [container (host-node!)]
           (-> (act #(v/mount [owning-button {}] container {:frame fid}))
               (.then (fn [mounted]
+                       ;; The HOT-RELOAD AXIS, pinned where it currently
+                       ;; stands. `shell-signature` is
+                       ;; `[lowering (:view-cell (manifest view))]`, and an
+                       ;; interpreted declaration has no manifest — so today
+                       ;; every interpreted view signs `[:interpreted nil]`.
+                       ;; `{:reactive false}` must move that second element
+                       ;; (the compiled tier already signs `[:compiled
+                       ;; :elided]` vs `[:compiled :present]`), which is what
+                       ;; mints a new component type and buys the ONE clean
+                       ;; remount acceptance 5 asks for. Nothing else has to
+                       ;; be built for it.
+                       (is (= [:interpreted nil]
+                              (:signature (get (fr/boundary-cache)
+                                               (:view-id (v/describe owning-button)))))
+                           "the interpreted shell signature is the axis the flag must move")
                        (-> (act #(click! container "#owned"))
                            (.then (fn [_]
                                     (is (true? (:pressed (db)))

--- a/implementation/freehand/test/re_frame/freehand/reactive_false_shell_free_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/reactive_false_shell_free_dom_cljs_test.cljs
@@ -1,0 +1,412 @@
+(ns re-frame.freehand.reactive-false-shell-free-dom-cljs-test
+  "SPIKE rf2-3slzz — what a SHELL-FREE boundary actually does, in a real
+  browser, to the two site families a ViewCell owns.
+
+  `{:reactive false}` would declare a boundary shell-free: no `v/sub`
+  read and no committed event site in its OWN render, so no ViewCell.
+  Nothing proves the declaration; the runtime checks it. The JVM sibling
+  (`reactive-false-totality-jvm-test`) pins the READ half. This file is
+  the EVENT half, plus the two mounted acceptance shapes that only a real
+  React commit can answer.
+
+  ## Why `fr/element` is the faithful stand-in for the flag
+
+  A shell-free interpreted boundary would run `(emit nil form)` — the
+  interpreted walk with NO candidate threaded. That is exactly what the
+  public `fr/element` does (\"There is no boundary above this call, so no
+  candidate\"), so the arms below exercise the same fork in
+  `handler-proxy` / `host-props` the flag would put a declared body
+  through, without shipping the flag.
+
+  ## What they find
+
+  The reactive-READ door refuses. The EVENT door does not: with no
+  candidate, a declarative `:on-click [:evt]` is DROPPED — the prop is
+  never written, nothing throws, and only the DOM knows. A `v/defhost`
+  declared callback degrades the other way: the authored function is
+  handed to the foreign component raw, so a `v/event` carrier's returned
+  intent is discarded by whoever called it. Both are chokepoints — one
+  `(some? cand)` fork each — so a masking assertion context can make them
+  RAISE. Until it does, the flag is not total on the event half.
+
+  Rides the browser lane through the `-dom-cljs-test` suffix; under the
+  node suites it has no DOM and says so."
+  (:require ["react" :as react]
+            ["react-dom/client" :as rdc]
+            [cljs.test :refer [async deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.cell :as cell]
+            [re-frame.freehand.react :as fr]
+            [re-frame.freehand.root :as root]
+            [re-frame.live-frame :as live-frame]
+            [re-frame.adapter.uix :as react-substrate]
+            [re-frame.test-support :as test-support]))
+
+(def ^:private fid :spike-shell-free/frame)
+
+(def ^:private runtime-fixture
+  (test-support/make-reset-runtime-fixture
+    {:adapter       react-substrate/adapter
+     :ambient-frame nil
+     :async?        true}))
+
+(use-fixtures :each
+  {:before (fn []
+             (root/reset-registry!)
+             (fr/reset-boundaries!)
+             ((:before runtime-fixture)))
+   :after  (fn []
+             ((:after runtime-fixture))
+             (root/reset-registry!)
+             (fr/reset-boundaries!))})
+
+(defn- browser? []
+  (and (exists? js/document) (some? (.-createElement js/document))))
+
+(defn- skip! [why] (is true (str "a real React mount needs a DOM host — " why)))
+
+(defn- act
+  [thunk]
+  (try
+    (set! (.-IS_REACT_ACT_ENVIRONMENT js/globalThis) true)
+    (js/Promise.resolve (react/act (fn [] (js/Promise.resolve (thunk)))))
+    (catch :default e
+      (js/Promise.reject e))))
+
+(defn- host-node! []
+  (let [container (js/document.createElement "div")]
+    (.appendChild js/document.body container)
+    container))
+
+(defn- register! []
+  (rf/reg-event :spike/pressed (fn [{:keys [db]} _] {:db (assoc db :pressed true)}))
+  (rf/reg-sub :spike/total (fn [db _] (:total db))))
+
+(defn- seed! [db]
+  (live-frame/make-frame {:id fid})
+  (frame/replace-app-db! fid db)
+  fid)
+
+(defn- db [] (frame/frame-app-db-value fid))
+
+(defn- text [container selector]
+  (some-> (.querySelector container selector) .-textContent))
+
+;; ---------------------------------------------------------------------------
+;; The bodies
+;; ---------------------------------------------------------------------------
+
+(defn- helper-sub
+  "An ORDINARY defn that performs the read. No analyzer sees through it,
+  which is the whole point: this is the shape the flag's runtime check has
+  to catch and a build-time proof cannot."
+  []
+  (str (v/sub [:spike/total])))
+
+(v/defview elided-but-reads
+  "DECLARED `{:compiled true}` and PROVED inert — its body carries no
+  lexical `sub` site, so the analyzer elides the ViewCell — yet it reads
+  through an ordinary helper. This is the compiler's OWN proof being
+  defeated, and what stops it becoming a silently stale view is the
+  runtime candidate check, the very check `{:reactive false}` would
+  rely on."
+  {:compiled true}
+  [_]
+  [:p#leak (helper-sub)])
+
+(v/defview reactive-child
+  "An ordinary reactive interpreted boundary. It owns its own shell
+  wherever it is mounted."
+  [_]
+  [:span#child (str (v/sub [:spike/total]))])
+
+(v/defview shell-free-parent
+  "Elided by proof, and it mounts a reactive child. The child's
+  reactivity must be untouched by the parent having no shell."
+  {:compiled true}
+  [_]
+  [:div#parent [reactive-child {}]])
+
+(v/defview owning-button
+  "The CONTROL for the event arms: the identical authored markup inside a
+  boundary that DOES own a shell, so the site is committed and the click
+  dispatches."
+  [_]
+  [:button#owned {:on-click [:spike/pressed]} "go"])
+
+;; ===========================================================================
+;; 1 — the read door, in the real shell-free mount
+;; ===========================================================================
+
+(deftest a-shell-free-boundary-refuses-a-helper-mediated-read-at-first-render
+  (testing "The compiled analyzer proved this body inert — no lexical
+            `sub` site, `:view-cell :elided` — and it was WRONG, because
+            the read reaches the shell through an ordinary helper the
+            analysis cannot see through. The mount does not produce a
+            silently stale page: the read finds no candidate and raises
+            `:rf.error/view-read-outside-render` at the first offending
+            render. The check `{:reactive false}` would depend on is
+            therefore already load-bearing for the compiled tier's own
+            elision."
+    (if-not (browser?)
+      (skip! "the browser job runs the mount assertions")
+      (async done
+        (register!)
+        (seed! {:total 41})
+        (is (= :elided (:view-cell (v/manifest elided-but-reads)))
+            "non-vacuous: the analysis really did elide the ViewCell for this body")
+        (let [container (host-node!)]
+          (-> (act #(v/mount [elided-but-reads {}] container {:frame fid}))
+              (.then (fn [mounted]
+                       (is false
+                           (str "the shell-free mount SUCCEEDED and rendered "
+                                (pr-str (text container "#leak"))
+                                " — a read with no owner was not refused"))
+                       (when mounted (.unmount (.-react-root ^root/Root mounted)))
+                       (.remove container)
+                       (done)))
+              (.catch (fn [e]
+                        (is (= :rf.error/view-read-outside-render
+                               (:rf.error/id (ex-data e)))
+                            (str "refused loudly at the read; got " (pr-str e)))
+                        (.remove container)
+                        (done)))))))))
+
+;; ===========================================================================
+;; 2 — a reactive child of a shell-free parent stays reactive
+;; ===========================================================================
+
+(deftest a-reactive-child-of-a-shell-free-parent-keeps-its-own-shell
+  (testing "Acceptance 4. The parent's analysis elided its ViewCell; the
+            child declares a subscription and therefore owns one. React
+            renders the child in its own component, so the parent having
+            no shell cannot reach it: the child observes the current
+            value and repaints when it moves."
+    (if-not (browser?)
+      (skip! "the browser job runs the mount assertions")
+      (async done
+        (register!)
+        (seed! {:total 41})
+        (let [container (host-node!)]
+          (-> (act #(v/mount [shell-free-parent {}] container {:frame fid}))
+              (.then (fn [mounted]
+                       (is (= :elided (:view-cell (v/manifest shell-free-parent)))
+                           "non-vacuous: the parent really is shell-free")
+                       (is (= "41" (text container "#child"))
+                           "the child observed the current value under a shell-free parent")
+                       (-> (act (fn []
+                                  (frame/replace-app-db! fid {:total 42})
+                                  (cell/flush!)))
+                           (.then (fn [_]
+                                    (is (= "42" (text container "#child"))
+                                        "and it repainted when the value moved")
+                                    (when mounted
+                                      (.unmount (.-react-root ^root/Root mounted)))
+                                    (.remove container)
+                                    (done))))))
+              (.catch (fn [e]
+                        (is false (str "shell-free parent mount rejected: " e))
+                        (.remove container)
+                        (done)))))))))
+
+;; ===========================================================================
+;; 3 — the event door, with no candidate: SILENT LOSS
+;; ===========================================================================
+
+(defn- click! [container selector]
+  (some-> (.querySelector container selector) .click))
+
+(deftest a-declarative-intent-with-no-candidate-is-silently-dropped
+  (testing "THE HOLE ON THE EVENT HALF. `(emit nil form)` is the walk a
+            shell-free boundary performs. A declarative `:on-click
+            [:spike/pressed]` reached there is classified, finds no
+            candidate to own it, and `handler-proxy` answers nil — so the
+            prop is never written. Nothing throws, nothing warns, and the
+            page renders a button that does nothing. Under the flag this
+            position must RAISE; it is a single `(some? cand)` fork, so it
+            can."
+    (if-not (browser?)
+      (skip! "the browser job runs the mount assertions")
+      (async done
+        (register!)
+        (seed! {})
+        (let [container (host-node!)
+              react-root (rdc/createRoot container)]
+          (-> (act #(.render react-root
+                             (fr/element [:button#orphan {:on-click [:spike/pressed]} "go"])))
+              (.then (fn [_]
+                       (is (some? (.querySelector container "#orphan"))
+                           "the element mounted — the loss is the HANDLER, not the markup")
+                       (act #(click! container "#orphan"))))
+              (.then (fn [_]
+                       (is (nil? (:pressed (db)))
+                           "the click dispatched NOTHING — the authored intent vanished")
+                       (act #(.unmount react-root))))
+              (.then (fn [_] (.remove container) (done)))
+              (.catch (fn [e]
+                        (is false (str "orphan mount rejected: " e))
+                        (.remove container)
+                        (done)))))))))
+
+(deftest the-same-markup-inside-a-shell-owning-boundary-dispatches
+  (testing "The CONTROL for the arm above, and the reason it is a LOSS
+            rather than a documented no-op: the identical authored
+            markup, inside a boundary that owns a shell, commits its site
+            and dispatches into the committed frame."
+    (if-not (browser?)
+      (skip! "the browser job runs the mount assertions")
+      (async done
+        (register!)
+        (seed! {})
+        (let [container (host-node!)]
+          (-> (act #(v/mount [owning-button {}] container {:frame fid}))
+              (.then (fn [mounted]
+                       (-> (act #(click! container "#owned"))
+                           (.then (fn [_]
+                                    (is (true? (:pressed (db)))
+                                        "the committed site dispatched into the frame")
+                                    (when mounted
+                                      (.unmount (.-react-root ^root/Root mounted)))
+                                    (.remove container)
+                                    (done))))))
+              (.catch (fn [e]
+                        (is false (str "owned mount rejected: " e))
+                        (.remove container)
+                        (done)))))))))
+
+(deftest a-v-event-carrier-with-no-candidate-loses-its-conversion
+  (testing "The `v/event` spelling degrades on the same fork, and worse:
+            `handler-proxy`'s no-candidate arm answers the CARRIER only if
+            it is a function, so what reaches React is either nothing at
+            all or a value with none of the committed-site guarantees.
+            Either way the conversion the author declared never runs
+            against a dispatcher. The assertion pins the OBSERVABLE — no
+            dispatch — because that is what an application sees."
+    (if-not (browser?)
+      (skip! "the browser job runs the mount assertions")
+      (async done
+        (register!)
+        (seed! {})
+        (let [container (host-node!)
+              react-root (rdc/createRoot container)]
+          (-> (act #(.render react-root
+                             (fr/element
+                               [:button#carrier
+                                {:on-click (v/event [_] [:spike/pressed])}
+                                "go"])))
+              (.then (fn [_]
+                       (is (some? (.querySelector container "#carrier"))
+                           "the element mounted")
+                       (act #(click! container "#carrier"))))
+              (.then (fn [_]
+                       (is (nil? (:pressed (db)))
+                           "the declared conversion never reached a dispatcher")
+                       (act #(.unmount react-root))))
+              (.then (fn [_] (.remove container) (done)))
+              (.catch (fn [e]
+                        ;; A THROW here is a perfectly good outcome for the
+                        ;; spike's purposes — it would mean the position
+                        ;; already fails loud. Record which happened.
+                        (is (some? (:rf.error/id (ex-data e)))
+                            (str "the carrier position raised rather than degraded: "
+                                 (pr-str (ex-data e))))
+                        (.remove container)
+                        (done)))))))))
+
+(deftest a-bare-function-with-no-candidate-keeps-working-and-loses-its-site
+  (testing "The THIRD degradation, and the most dangerous of the three
+            for an OPT-IN, because it looks like success. A bare function
+            at a native `:on-*` is the one value `handler-proxy`'s
+            no-candidate arm hands back — so it is attached as an ordinary
+            DOM handler and it FIRES. What it silently loses is everything
+            a committed site is: the frame the commit bound, `:once`,
+            retirement at unmount, the controlled-input door verdict, and
+            a stable identity across re-renders. An author who wrongly
+            declared a boundary shell-free would get no signal at all
+            here — which is exactly why this position has to raise rather
+            than pass the function through."
+    (if-not (browser?)
+      (skip! "the browser job runs the mount assertions")
+      (async done
+        (register!)
+        (seed! {})
+        (let [fired      (atom 0)
+              container  (host-node!)
+              react-root (rdc/createRoot container)]
+          (-> (act #(.render react-root
+                             (fr/element
+                               [:button#bare {:on-click (fn [_] (swap! fired inc))} "go"])))
+              (.then (fn [_] (act #(click! container "#bare"))))
+              (.then (fn [_]
+                       (is (= 1 @fired)
+                           "the bare function fired — nothing signalled that the
+                            boundary above it owns no commit")
+                       (is (nil? (:pressed (db)))
+                           "non-vacuous: no re-frame site was involved; this is a raw
+                            DOM callback with none of D008's identity laws")
+                       (act #(.unmount react-root))))
+              (.then (fn [_] (.remove container) (done)))
+              (.catch (fn [e]
+                        (is false (str "bare-fn mount rejected: " e))
+                        (.remove container)
+                        (done)))))))))
+
+;; ===========================================================================
+;; 4 — the declared-host callback door, with no candidate
+;; ===========================================================================
+
+(defn- pick-panel
+  "A foreign React component that CALLS the callback prop it was handed and
+  ignores whatever it answers — the ordinary foreign contract, and the
+  reason a returned intent vector is not a dispatch."
+  [js-props]
+  (let [on-select (aget js-props "onSelect")]
+    (react/createElement
+      "button"
+      #js {:id "host" :onClick (fn [_] (when (fn? on-select) (on-select "x")))}
+      "pick")))
+
+(v/defhost pick-host
+  "A declared crossing with one `:event` callback position."
+  pick-panel
+  {:callbacks {:onSelect :event}
+   :children  :none
+   :ssr       :client-only})
+
+(deftest a-declared-host-callback-with-no-candidate-is-handed-over-raw
+  (testing "The SECOND no-candidate fallback: `host-props` answers
+            `events/callback-fn` — the authored function with EXACTLY its
+            supplied identity and none of the site's guarantees. A
+            `v/event` carrier's body then answers an intent vector to a
+            foreign caller that discards return values, so the declared
+            conversion is silently inert. Under the flag this position
+            must raise too; like the element fork it is one
+            `(some? cand)` test."
+    (if-not (browser?)
+      (skip! "the browser job runs the mount assertions")
+      (async done
+        (register!)
+        (seed! {})
+        (let [container (host-node!)
+              react-root (rdc/createRoot container)]
+          (-> (act #(.render react-root
+                              (fr/element
+                                [pick-host {:onSelect (v/event [_] [:spike/pressed])}])))
+              (.then (fn [_]
+                       (is (some? (.querySelector container "#host"))
+                           "the host crossed and mounted")
+                       (act #(click! container "#host"))))
+              (.then (fn [_]
+                       (is (nil? (:pressed (db)))
+                           "the host called the raw carrier fn; the intent it answered
+                            was discarded and nothing dispatched")
+                       (act #(.unmount react-root))))
+              (.then (fn [_] (.remove container) (done)))
+              (.catch (fn [e]
+                        (is (some? (:rf.error/id (ex-data e)))
+                            (str "the host callback position raised rather than degraded: "
+                                 (pr-str (ex-data e))))
+                        (.remove container)
+                        (done)))))))))

--- a/implementation/freehand/test/re_frame/freehand/reactive_false_totality_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/reactive_false_totality_jvm_test.clj
@@ -106,6 +106,14 @@
   [_]
   [:div [inline-read {}]])
 
+(v/defview snapshot-read
+  "The NON-reactive read the flag is documented to leave legal: a one-shot
+  `rf/subscribe-once`, a snapshot the programmer asked for. Its ambient
+  1-arity resolves the frame through the scope chain — and a shell is one
+  of the things that establishes that scope."
+  [_]
+  [:p (str (rf/subscribe-once [:spike/n]))])
+
 ;; ===========================================================================
 ;; 1 — the single door
 ;; ===========================================================================
@@ -197,7 +205,48 @@
           (str "refused with debug-enabled? = " interop/debug-enabled?)))))
 
 ;; ===========================================================================
-;; 3 — the hole: an OUTER candidate is donated to, not masked
+;; 3 — the shell binds the ambient frame, and shell-free loses it
+;; ===========================================================================
+
+(deftest the-shell-is-what-binds-the-ambient-frame
+  (testing "A THIRD thing the ViewCell owns, beyond reads and event
+            sites: `cell/with-capture` establishes the candidate's frame
+            as `frame/*current-frame*` for the body's synchronous extent,
+            and nothing else does. A shell-free boundary therefore runs
+            under whatever ambient frame its CALLER happened to have —
+            which, under React, is none, because a component's render is
+            not inside its parent's dynamic extent.
+
+            That turns out NOT to cost the flag anything, and the reason
+            is worth recording next to the mechanism: ambient frame
+            resolution has a SECOND tier. `frame/resolve-current-frame`
+            reads the React frame context through the
+            `:adapter/current-frame` hook, which any component under the
+            provider can see, so the ambient `rf/subscribe-once` the
+            flag's contract keeps legal still resolves in a shell-free
+            boundary —
+            `reactive-false-shell-free-dom-cljs-test` mounts exactly that
+            and reads the value back off the DOM. What is isolated here
+            is the dynamic-var tier alone, with a DIFFERENT frame on the
+            candidate so the binding is visible whatever the caller's own
+            scope already is."
+    (seed! {:n 5})
+    (let [other   :spike/other-frame
+          cand    (cell/candidate (cell/cell :spike/snapshot) other)
+          outside frame/*current-frame*]
+      (is (not= other outside)
+          "non-vacuous: the candidate's frame is not the ambient one already")
+      (cell/with-capture cand
+        (fn []
+          (is (= other frame/*current-frame*)
+              "inside the shell, the ambient frame IS the candidate's")
+          (is (map? (tree/render [snapshot-read {}]))
+              "so an ambient one-shot read in the body resolves")))
+      (is (= outside frame/*current-frame*)
+          "and the binding is scoped to the body's extent, nothing wider"))))
+
+;; ===========================================================================
+;; 4 — the hole: an OUTER candidate is donated to, not masked
 ;; ===========================================================================
 
 (deftest a-nested-body-donates-its-read-to-an-open-outer-candidate

--- a/implementation/freehand/test/re_frame/freehand/reactive_false_totality_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/reactive_false_totality_jvm_test.clj
@@ -1,0 +1,221 @@
+(ns re-frame.freehand.reactive-false-totality-jvm-test
+  "SPIKE rf2-3slzz — is the `{:reactive false}` RUNTIME check TOTAL?
+
+  The proposed opt-out lets an author declare a boundary SHELL-FREE: its
+  own render performs no `v/sub` read and produces no committed event
+  site, so the ViewCell (2,348 bytes of standing heap per boundary) is
+  never minted. Nothing PROVES the declaration; the runtime CHECKS it.
+  This file is the check's totality evidence on the reactive-READ half.
+
+  ## What is actually under test, and why it needs no new code
+
+  A shell-free boundary is EXACTLY a body evaluated with no render
+  candidate open — which is what `re-frame.freehand.cell`'s ambient
+  `*render*` already answers `nil` for, and what the compiled tier's
+  `:elided` path already does today. So the flag's runtime check is not
+  hypothetical: `cell/observe!` consults the candidate BEFORE it resolves
+  or probes, and an absent candidate is already
+  `:rf.error/view-read-outside-render`. What this file proves is that the
+  refusal is TOTAL over the shapes a real body can reach a read through —
+  inline, through an ordinary helper, through a helper reached only on a
+  branch a later render takes, through a lazily realised child run — and
+  that none of it is behind a development gate.
+
+  ## The one hole this file also proves
+
+  `deep-inside-an-open-capture-a-nested-body-donates-its-read` is a
+  DELIBERATE failing-shape witness written as a passing assertion: with
+  an OUTER candidate open, a nested body's read is silently recorded on
+  the outer boundary. On the JVM structural host and inside
+  `t/with-render` that is the ordinary, correct behaviour — one walk, one
+  candidate — but it is also exactly why the flag's assertion context
+  must MASK the outer candidate rather than merely rely on there not
+  being one.
+
+  Runs identically under `-Dre-frame.debug=false`: nothing on the path
+  reads `interop/debug-enabled?`, and
+  `the-refusal-is-not-behind-the-debug-gate` asserts the refusal against
+  whatever posture the JVM was launched in."
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.cell :as cell]
+            [re-frame.freehand.conformance :as conf]
+            [re-frame.freehand.tree :as tree]
+            [re-frame.interop :as interop]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter}))
+
+(def ^:private fid :rf/default)
+(def ^:private outside-render :rf.error/view-read-outside-render)
+
+(defn- seed!
+  [db]
+  (rf/reg-sub :spike/n (fn [db _] (:n db)))
+  (frame/replace-app-db! fid db))
+
+;; ---------------------------------------------------------------------------
+;; The bodies. Ordinary declarations and ordinary helpers — every one of
+;; them is a shape the compiled analyzer either cannot see through
+;; (`via-helper`) or would have to be re-run to see (`later-branch`).
+;; ---------------------------------------------------------------------------
+
+(defn- via-helper
+  "An ORDINARY defn — no view, no macro, nothing the flag could annotate
+  — that performs the read. The capture is dynamic, so where the call
+  lexically sits is irrelevant."
+  []
+  (str (v/sub [:spike/n])))
+
+(defn- via-two-helpers [] (via-helper))
+
+(v/defview inline-read
+  "The inline shape."
+  [_]
+  [:p (str (v/sub [:spike/n]))])
+
+(v/defview helper-read
+  "The helper-mediated shape — invisible to any lexical analysis of THIS
+  body."
+  [_]
+  [:p (via-two-helpers)])
+
+(v/defview later-branch-read
+  "A props-controlled branch. The first render takes the inert arm; a
+  later render with different props takes the reading arm. Nothing about
+  the first render can diagnose the second."
+  [{:keys [expand?]}]
+  [:p (if expand? (via-helper) "inert")])
+
+(v/defview lazy-child-read
+  "The read sits inside a lazy seq the WALK realises, not the body — so
+  it happens after the body has returned, while the emitter is
+  normalising what it got back."
+  [_]
+  [:ul (for [i [1 2 3]] [:li {:key i} (via-helper)])])
+
+(v/defview inert-parent
+  "Reads nothing itself; mounts a reading child. The child is the
+  boundary that would need the shell."
+  [_]
+  [:div [inline-read {}]])
+
+;; ===========================================================================
+;; 1 — the single door
+;; ===========================================================================
+
+(def ^:private freehand-src
+  (some-> (io/resource "re_frame/freehand/cell.cljc") io/file .getParentFile))
+
+(deftest exactly-one-freehand-namespace-reaches-the-observation-port
+  (testing "Totality rests on there being ONE reactive-read door. The
+            observation port (`re-frame.substrate.observation`) is what a
+            reactive read resolves and probes through, and exactly one
+            Freehand source file requires it: `cell.cljc`, which is where
+            the candidate consultation lives. A second requirer would be a
+            second door, and the check would not be total."
+    (if (and freehand-src (.isDirectory freehand-src))
+      (let [sources (->> (file-seq freehand-src)
+                         (filter #(.isFile ^java.io.File %))
+                         (filter #(re-find #"\.clj[cs]?$" (.getName ^java.io.File %))))
+            requirers (->> sources
+                           (filter #(str/includes? (slurp %) "re-frame.substrate.observation"))
+                           (mapv #(.getName ^java.io.File %))
+                           sort
+                           vec)]
+        (is (seq sources) "non-vacuous: the source tree was found and read")
+        (is (= ["cell.cljc"] requirers)
+            "cell.cljc is the ONLY Freehand namespace that reaches the observation port"))
+      (is true "src is not on a directory classpath here — claim carried by the browser lane"))))
+
+(deftest the-public-read-verb-is-the-candidate-consulting-function
+  (testing "`v/sub` is not a wrapper over the shell — it IS
+            `cell/observe!`, the function that consults the ambient
+            candidate before it resolves anything. There is no layer at
+            which a read could be routed past the check."
+    (is (identical? v/sub cell/observe!)
+        "the authoring verb and the recorder are one var")))
+
+;; ===========================================================================
+;; 2 — every shape of read is refused with no candidate open
+;; ===========================================================================
+
+(defn- render-shell-free
+  "Render `form` the way a SHELL-FREE boundary would run: no candidate
+  open, so `cell/observing?` is false for the whole walk. This is
+  literally the compiled `:elided` path's posture, and the posture
+  `{:reactive false}` would put an interpreted body in."
+  [form]
+  (rf/with-frame fid (tree/render form)))
+
+(deftest a-shell-free-body-cannot-read-through-any-shape
+  (seed! {:n 7})
+  (is (false? (cell/observing?)) "non-vacuous: no candidate is open")
+  (testing "INLINE — the shape a lexical analysis would catch anyway"
+    (is (= outside-render (conf/caught-id #(render-shell-free [inline-read {}])))))
+  (testing "HELPER-MEDIATED, through two ordinary defns — the shape no
+            analysis of the body can see"
+    (is (= outside-render (conf/caught-id #(render-shell-free [helper-read {}])))))
+  (testing "LAZILY REALISED — the read happens while the WALK normalises
+            what the body returned, after the body itself has returned"
+    (is (= outside-render (conf/caught-id #(render-shell-free [lazy-child-read {}])))))
+  (testing "A LATER BRANCH — the first render is clean and publishes
+            nothing stale; the render that actually reaches the read is
+            the one that fails, which is the whole first-offending-render
+            contract"
+    (is (map? (render-shell-free [later-branch-read {:expand? false}]))
+        "the inert arm renders normally — no false positive")
+    (is (= outside-render
+           (conf/caught-id #(render-shell-free [later-branch-read {:expand? true}])))
+        "and the branch that reads fails at the read, not silently")))
+
+(deftest the-refusal-is-not-behind-the-debug-gate
+  (testing "`cell/observe!`'s candidate check is an unconditional `when`,
+            and `error/throw-error!` is not gated either — so the refusal
+            holds under whatever debug posture this JVM was launched in.
+            Run this file a second time with `-Dre-frame.debug=false` and
+            the assertion below is the SAME assertion against the OTHER
+            value of the gate."
+    (seed! {:n 1})
+    ;; The posture is READ, not assumed, and it is read from the same
+    ;; load-time source `interop` reads — so the second run of this file
+    ;; is demonstrably a different posture rather than the same one twice.
+    ;; `with-redefs` on the flag would prove nothing here: `debug-enabled?`
+    ;; is a `def` evaluated once at namespace load.
+    (let [property (System/getProperty "re-frame.debug")]
+      (is (= (not= "false" property) (boolean interop/debug-enabled?))
+          (str "the live gate matches -Dre-frame.debug=" (pr-str property)
+               " — this run is the " (if interop/debug-enabled? "DEV" "PRODUCTION")
+               " posture"))
+      (is (= outside-render (conf/caught-id #(render-shell-free [helper-read {}])))
+          (str "refused with debug-enabled? = " interop/debug-enabled?)))))
+
+;; ===========================================================================
+;; 3 — the hole: an OUTER candidate is donated to, not masked
+;; ===========================================================================
+
+(deftest a-nested-body-donates-its-read-to-an-open-outer-candidate
+  (testing "THE REASON THE FLAG NEEDS A MASKING CONTEXT, not merely an
+            absent candidate. The JVM structural host runs a nested view's
+            body INLINE, inside the caller's dynamic extent, so one
+            `t/with-render` bracket covers the whole tree. A boundary
+            declared shell-free and rendered there would find a candidate
+            — the OUTER one — and its read would be silently recorded
+            against the outer boundary instead of refused. `cell/observe!`
+            cannot tell the two apart; only a context that MASKS the outer
+            candidate for the duration of the declared-inert body can."
+    (seed! {:n 42})
+    (let [c    (cell/cell :spike/outer)
+          cand (cell/candidate c fid)
+          tree (cell/with-capture cand #(tree/render [inert-parent {}]))]
+      (is (map? tree) "the nested reading body rendered WITHOUT any refusal")
+      (is (= 1 (count (cell/candidate-reads cand)))
+          "and its read was recorded against the OUTER boundary's candidate")
+      (is (= [[:spike/n]] (mapv :query (vals (cell/candidate-reads cand))))
+          "non-vacuous: the donated read is the child's own query"))))


### PR DESCRIPTION
Spike scaffolding for **rf2-3slzz** — *is the `{:reactive false}` runtime check TOTAL?*

Three probe suites, no production code. They answer the spike's question by running the violating shapes rather than reasoning about them, and they are worth keeping because they pin the properties the flag will rest on.

## The verdict they support

**TOTAL on the reactive-read half. NOT total on the event half, and not total across an open outer capture.** Both gaps are single `(some? cand)` forks — chokepoints, not an analysis problem — so a bounded fix closes them.

## What each file proves

**`reactive_false_totality_jvm_test.clj`** — the read door. Exactly one Freehand namespace reaches the observation port (`cell.cljc`), and `v/sub` *is* `cell/observe!`, so there is no second door. With no candidate open, a read is refused inline, through two ordinary `defn`s, through a lazily realised child run, and on a props-controlled branch only a later render reaches — and refused identically under `-Dre-frame.debug=false`, with the posture read from the live property rather than rebound. It also pins, as a passing witness, that an **outer** open candidate is silently **donated** to: the flag's assertion context must MASK, not merely check for absence.

**`reactive_false_shell_free_dom_cljs_test.cljs`** — the event door, in a real browser, running `(emit nil form)` (which is what `fr/element` does and what a shell-free boundary would do). Three distinct degradations, each with a shell-owning control arm: a declarative `:on-click [:evt]` is **dropped** (prop never written, nothing throws, only the DOM knows); a `v/event` carrier is dropped the same way (a `Callback` deftype is deliberately not `fn?`); a bare function is **passed through and fires** with none of the committed-site guarantees — the failure mode that looks like success. Also: a `{:compiled true}` view the analyzer *proved* inert but which reads through a helper fails loudly at mount, and a reactive child of a shell-free parent stays fully reactive.

**`reactive_false_check_elision_prod_test.cljs`** — the same claims under real `:advanced` + `goog.DEBUG=false`, asserting the folded gate first so the run is demonstrably a production posture. `react/act` is a development-only export and `flushSync` does not rethrow, so the mount is captured through the root's `onUncaughtError`: the read is refused with its stable id and nothing is committed, but a caller cannot `try`/`catch` it.

## Gates

| gate | exit |
| --- | --- |
| `implementation/freehand` JVM, focused ns, dev | 0 |
| `implementation/freehand` JVM, focused ns, `-Dre-frame.debug=false` | 0 |
| `implementation/freehand` JVM, full suite (1227 tests) | 0 |
| `npm run test:cljs` (11809 tests) | 0 |
| `npm run test:browser` (843 tests) | 0 |
| `npm run test:browser-prod-elision` — `:advanced` (120 tests) | 0 |
| `check_test_lane_bijection.py` / `check_jvm_lane_rosters.py` / `check_freehand_conformance_index.py` | 0 |

Findings doc is local-only in `ai/findings/`; nothing under `implementation/freehand/src/` is touched.
