### PR TITLE
fix(ssr): pe-check reads the always-on axis, and the prod-gate roster shrinks (rf2-76gom, rf2-lwtlk)

### DIFF
--- a/implementation/ssr/test/re_frame/ssr_conformance_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_conformance_test.clj
@@ -71,6 +71,52 @@
        - `:ssr/html-attr-present` (the rendered root element carries
          the named data-attribute).
 
+  ## Posture split (rf2-lwtlk / rf2-76gom)
+
+  This runner executes under BOTH `clojure -M:test` and the REAL
+  production gate `-Dre-frame.debug=false`
+  (`scripts/test-ssr-prod-gate.sh`), and the two postures do not observe
+  the same channels.
+
+    - `:trace-emissions` / `:trace-not-emitted` read `@traces`, the DEV
+      trace bus. Every emit site on it sits inside `interop/debug-enabled?`,
+      a LOAD-TIME gate, so under `-Dre-frame.debug=false` the ring is empty
+      for every fixture. Both channels are kept VERBATIM and adjudicated in
+      dev posture only. The negative channel is the one that matters most
+      here: `:trace-not-emitted` over an empty ring passes automatically —
+      it would hold with the runtime removed — so leaving it outside the
+      guard would have been a false green, not extra coverage.
+
+    - The `run-start` half of `:trace-emissions` DOES have a
+      production-visible counterpart, and it is used rather than skipped. A
+      `{:operation :rf.event/run-start :tags {:rf.trace/event-id X}}` claim
+      says event X RAN, and the always-on `:events` substrate (Spec 009
+      §Event-emit listener) records exactly that, in production.
+      `check-always-on-events` adjudicates those claims under BOTH postures;
+      an event that never ran reds it. Nine of the fifteen fixtures depend
+      on this for their only trace-shaped coverage under the gate.
+
+    - `:ssr/public-error` sources its error event from whichever axis
+      carries it — dev bus first (a superset in dev), else the always-on
+      `:errors` axis, synthesised into the projector's envelope by
+      `error-record->trace-event`. Sourcing it from `@traces` ALONE
+      reported `:actual nil` under the gate for every fixture whatever the
+      framework did (rf2-76gom); the always-on axis is the projector's
+      production status source of truth, so under the gate this channel now
+      adjudicates the wire.
+
+    - Every other channel — `:final-app-db`, `:sub-values`,
+      `:ssr/active-head`, `:ssr/request-result`,
+      `:ssr/rendered-head-contains`, `:ssr/html-attr-present`,
+      `:fixture/calls`, `:expect-error` — is posture-independent and runs
+      under the gate unchanged.
+
+  Two claims in the corpus have NO production counterpart and are dev-only
+  by design: `:rf.ssr/hydration-mismatch` (emitted solely through
+  `trace/emit-error!`, `hydrate.cljc`) and the `:source :ssr-hydration`
+  slot on a `run-start` trace (the always-on event record carries no
+  `:source`). Both remain asserted verbatim in the dev arm.
+
   ## Capability claim
 
   Per `spec/conformance/README.md` §Capability tagging, the runner
@@ -100,6 +146,7 @@
             [re-frame.core :as rf]
             [re-frame.events :as events]
             [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
             [re-frame.registrar :as registrar]
             [re-frame.ssr :as ssr]
             [re-frame.ssr.head :as ssr-head]
@@ -404,13 +451,73 @@
 ;; ---- trace capture -------------------------------------------------------
 
 (defn- collect-traces
-  "Register a trace listener for the fixture's run; the returned atom
-  accumulates every captured trace event."
+  "Register a DEV trace listener for the fixture's run; the returned atom
+  accumulates every captured trace event.
+
+  DEV-ONLY BY CONSTRUCTION. `trace/register-listener!` feeds the
+  development trace bus, and every emit site on it sits inside
+  `interop/debug-enabled?` — a load-time gate. Under
+  `-Dre-frame.debug=false` this atom stays EMPTY for every fixture, which
+  is why the always-on captures below exist alongside it."
   [fixture-id]
   (let [traces (atom [])]
     (trace/register-listener! [fixture-id]
                               (fn [ev] (swap! traces conj ev)))
     traces))
+
+;; ---- always-on capture (rf2-76gom) ---------------------------------------
+;;
+;; Surface #4 — the `error-emit` / `event-emit` substrates, which survive
+;; `-Dre-frame.debug=false` and are what a production JVM SSR host actually
+;; ships off-box. These are NOT a fallback rendering of the dev bus: the
+;; always-on error axis is the SSR projector's production status source of
+;; truth (`re-frame.ssr.error-listener/error-emit-projection-listener`), so
+;; a fixture adjudicated against it is adjudicating the wire.
+
+(def ^:private always-on-error-listener-id ::always-on-errors)
+(def ^:private always-on-event-listener-id ::always-on-events)
+
+(defn- error-record->trace-event
+  "Synthesise the `{:operation :op-type :tags}` envelope the projector
+  pipeline consumes from an EP-0008 union error record `{:error <kw>
+  :frame <id> :time <ms> + flat category keys}`.
+
+  This is the SAME generic lift `error-emit-projection-listener`
+  performs — every non-`:error` slot rides onto `:tags`, `:recovery`
+  defaults to `:no-recovery` — so an event handed to `ssr/project-error`
+  from here is byte-for-byte the event the runtime's own always-on
+  projection listener would have handed it."
+  [record]
+  {:op-type   :error
+   :operation (:error record)
+   :tags      (-> (dissoc record :error)
+                  (update :recovery #(or % :no-recovery)))})
+
+(defn- collect-always-on-errors
+  "Register a listener on the ALWAYS-ON `:errors` stream for the fixture's
+  run; the returned atom accumulates every record, already in the
+  projector's trace-event envelope."
+  []
+  (let [records (atom [])]
+    (rf/register-listener! :errors always-on-error-listener-id
+                           (fn [record]
+                             (swap! records conj (error-record->trace-event record))))
+    records))
+
+(defn- collect-always-on-events
+  "Register a listener on the ALWAYS-ON `:events` stream for the fixture's
+  run; the returned atom accumulates one record per PROCESSED event (Spec
+  009 §Event-emit listener). This is the production counterpart of the dev
+  bus's `:rf.event/run-start` trace."
+  []
+  (let [records (atom [])]
+    (rf/register-listener! :events always-on-event-listener-id
+                           (fn [record] (swap! records conj record)))
+    records))
+
+(defn- clear-always-on-listeners! []
+  (rf/unregister-listener! :errors always-on-error-listener-id)
+  (rf/unregister-listener! :events always-on-event-listener-id))
 
 ;; ---- matchers ------------------------------------------------------------
 
@@ -470,6 +577,54 @@
             (when (some #(trace-matches? nt %) actual)
               (str "trace that should NOT have fired did: " (pr-str nt))))
           not-traces)))
+
+;; ---- the always-on counterpart of :trace-emissions (rf2-lwtlk) ------------
+
+(defn- expected-event-ids
+  "The event-ids a fixture's `:trace-emissions` names on its
+  `:rf.event/run-start` claims, in declaration order.
+
+  A `run-start` claim says THIS EVENT RAN. On the dev bus that is a
+  `:rf.event/run-start` trace; on the always-on `:events` substrate (Spec
+  009 §Event-emit listener) it is one record per PROCESSED event carrying
+  `:event-id`. The claim therefore has a production counterpart, and
+  `check-always-on-events` adjudicates it in BOTH postures."
+  [expected]
+  (into []
+        (keep (fn [exp]
+                (when (= :rf.event/run-start (:operation exp))
+                  (get-in exp [:tags :rf.trace/event-id]))))
+        expected))
+
+(defn- check-always-on-events
+  "Order-preserving subset match of the fixture's `run-start` event-ids
+  against the ALWAYS-ON `:events` records. Extras tolerated, exactly like
+  `check-trace-emissions`.
+
+  This runs under BOTH postures and is the reason nine fixtures adjudicate
+  something real under `-Dre-frame.debug=false` instead of being skipped:
+  an event that never ran produces no always-on record and reds here."
+  [expected event-records]
+  (loop [actual   (mapv :event-id event-records)
+         wanted   (expected-event-ids expected)
+         failures []]
+    (cond
+      (empty? wanted) failures
+      (empty? actual)
+      (into failures
+            (map #(str "expected always-on event record not seen: " (pr-str %)))
+            wanted)
+      :else
+      (let [want (first wanted)
+            i    (->> actual
+                      (map-indexed vector)
+                      (some (fn [[i a]] (when (= want a) i))))]
+        (if i
+          (recur (drop (inc i) actual) (rest wanted) failures)
+          (recur actual (rest wanted)
+                 (conj failures
+                       (str "expected always-on event record not seen: "
+                            (pr-str want)))))))))
 
 ;; ---- :fixture/calls runner -----------------------------------------------
 
@@ -628,6 +783,11 @@
   (try
     (let [fid          (:fixture/id fixture)
           traces       (collect-traces fid)
+          ;; rf2-76gom — the always-on axes, captured alongside the dev bus.
+          ;; Registered BEFORE `realise-handlers` / `make-frame` so the
+          ;; `:initial-events` cascade (`:rf/server-init`) is observed.
+          ao-errors    (collect-always-on-errors)
+          ao-events    (collect-always-on-events)
           _            (realise-handlers fixture)
           frame-config (or (:fixture/frame-config fixture) {})
           ;; `reset-runtime` already created :rf/default WITHOUT any
@@ -744,24 +904,60 @@
                 {:query    query-v
                  :expected expected-val
                  :actual   (rf/subscribe-once query-v {:frame :rf/default})}))
-            trace-failures (check-trace-emissions @traces
-                                                  (:trace-emissions expect))
-            not-emit-failures (check-trace-not-emitted @traces
-                                                       (:trace-not-emitted expect))
+            ;; ---- :trace-emissions / :trace-not-emitted ----------------
+            ;; POSTURE SPLIT (rf2-lwtlk). Both channels read `@traces`, the
+            ;; DEV trace bus, whose every emit site sits inside the
+            ;; load-time `interop/debug-enabled?` gate. Under
+            ;; `-Dre-frame.debug=false` the ring is empty for EVERY fixture,
+            ;; so `check-trace-emissions` reports a miss for a trace the
+            ;; framework was never going to emit, and — the quieter half —
+            ;; `check-trace-not-emitted` passes AUTOMATICALLY, a negative
+            ;; over an empty ring that would hold with the whole runtime
+            ;; ripped out. Kept VERBATIM, adjudicated in dev posture only.
+            ;;
+            ;; The production counterpart is `always-on-failures` below; the
+            ;; two are complementary, not a substitution.
+            trace-failures (when interop/debug-enabled?
+                             (check-trace-emissions @traces
+                                                    (:trace-emissions expect)))
+            not-emit-failures (when interop/debug-enabled?
+                                (check-trace-not-emitted @traces
+                                                         (:trace-not-emitted expect)))
+            ;; ---- the always-on counterpart (rf2-lwtlk) ----------------
+            ;; POSTURE-INDEPENDENT — runs under both. Every `run-start`
+            ;; claim in `:trace-emissions` asserts that an event RAN, and
+            ;; that fact survives the gate on the `:events` substrate. So
+            ;; the nine fixtures whose dev-bus claims elide still adjudicate
+            ;; a real, production-visible fact here rather than nothing.
+            always-on-failures (check-always-on-events (:trace-emissions expect)
+                                                       @ao-events)
+            always-on-claims   (count (expected-event-ids (:trace-emissions expect)))
             ;; ---- :ssr/public-error -----------------------------------
             expected-pe   (:ssr/public-error expect)
+            ;; rf2-76gom — SOURCE THE ERROR FROM WHICHEVER AXIS CARRIES IT.
+            ;; `@traces` is the DEV bus: under the production gate it is
+            ;; empty, so sourcing the error event from it alone reported
+            ;; `:actual nil` for BOTH public-error fixtures whatever the
+            ;; framework did — the check adjudicated a dev artefact, not the
+            ;; wire, and no framework fix could have moved it. The ALWAYS-ON
+            ;; `:errors` axis is the SSR projector's production status
+            ;; source of truth (`error-emit-projection-listener` is what
+            ;; stamps `:status` on a `-Dre-frame.debug=false` JVM), and
+            ;; `error-record->trace-event` hands `project-error` the same
+            ;; envelope that listener builds. Dev posture is unchanged: the
+            ;; dev bus is a superset there and still wins.
+            last-error    (or (last (filter #(= :error (:op-type %)) @traces))
+                              (last @ao-errors))
             pe-check
             (when expected-pe
-              (let [error-events (filter #(= :error (:op-type %)) @traces)
-                    last-error   (last error-events)]
-                (if last-error
-                  (let [actual (ssr/project-error :rf/default last-error)]
-                    {:expected expected-pe
-                     :actual   actual
-                     :passed?  (= expected-pe actual)})
+              (if last-error
+                (let [actual (ssr/project-error :rf/default last-error)]
                   {:expected expected-pe
-                   :actual   nil
-                   :passed?  false})))
+                   :actual   actual
+                   :passed?  (= expected-pe actual)})
+                {:expected expected-pe
+                 :actual   nil
+                 :passed?  false}))
             ;; ---- :ssr/active-head ------------------------------------
             expected-head (:ssr/active-head expect)
             head-check
@@ -804,6 +1000,7 @@
                                  (every? #(= (:expected %) (:actual %)) sub-checks)
                                  (empty? trace-failures)
                                  (empty? not-emit-failures)
+                                 (empty? always-on-failures)
                                  (empty? @dispatch-error-failures)
                                  (or (nil? pe-check) (:passed? pe-check))
                                  (or (nil? head-check) (:passed? head-check))
@@ -814,6 +1011,8 @@
          :sub-checks        sub-checks
          :trace-failures    trace-failures
          :not-emit-failures not-emit-failures
+         :always-on-failures always-on-failures
+         :always-on-claims  always-on-claims
          :dispatch-error-failures @dispatch-error-failures
          :pe-check          pe-check
          :head-check        head-check
@@ -823,7 +1022,13 @@
       {:fixture-id (:fixture/id fixture)
        :passed?    false
        :error      (.getMessage e)
-       :exception  e})))
+       :exception  e})
+    (finally
+      ;; rf2-76gom — the always-on registries are corpus-wide and are NOT
+      ;; cleared by `tf/reset-runtime` (the `re-frame.ssr` façade's own
+      ;; `::error-projection` listener lives there and must survive). Drop
+      ;; ONLY the two stand-ins this run registered, on every exit path.
+      (clear-always-on-listeners!))))
 
 ;; ---- the test entrypoint -------------------------------------------------
 
@@ -873,6 +1078,21 @@
           (str "ssr corpus runnable-fixture floor (>= 10): only "
                (count run) " executed — a fixtures-dir/cwd fault or a "
                "capability-vocab rename has orphaned the corpus."))
+      ;; rf2-lwtlk — the ALWAYS-ON claim floor, the same non-empty guard one
+      ;; level down. `check-always-on-events` is what keeps the corpus
+      ;; load-bearing under `-Dre-frame.debug=false`, where the dev-bus
+      ;; channels are (correctly) not adjudicated. A translation that
+      ;; silently stopped producing claims — a fixture rewrite that dropped
+      ;; its `:trace-emissions`, an `:rf.trace/event-id` rename — would leave
+      ;; the production posture asserting nothing on this channel while
+      ;; still reporting green. Today's corpus yields 17.
+      (is (>= (reduce + 0 (map #(:always-on-claims % 0) run)) 12)
+          (str "always-on event-claim floor (>= 12): the corpus produced "
+               (reduce + 0 (map #(:always-on-claims % 0) run))
+               " `:rf.event/run-start` claims translatable onto the "
+               "always-on `:events` substrate. Under the production gate "
+               "this channel is the one adjudicating :trace-emissions at "
+               "all — a collapse here is a silent loss of coverage."))
       ;; Silent-on-success (rf2-try1x): summary prints only on failure.
       (when (seq failed)
         (println)
@@ -907,6 +1127,8 @@
             (println "    trace:" tf))
           (doseq [nef (:not-emit-failures f)]
             (println "    not-emit:" nef))
+          (doseq [aof (:always-on-failures f)]
+            (println "    always-on:" aof))
           (doseq [def (:dispatch-error-failures f)]
             (println "    expect-error:" def))
           (when-let [pe (:pe-check f)]

--- a/implementation/ssr/test/re_frame/ssr_error_two_frame_attribution_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_error_two_frame_attribution_test.clj
@@ -42,11 +42,35 @@
       error-emit substrate install under production hardening.
     - `re-frame.ssr.ring.concurrency-stress-test` — the live-host
       concurrent-frame stress shape this regression's two-frame setup
-      mirrors at the unit level."
+      mirrors at the unit level.
+
+  ## Posture split (rf2-lwtlk)
+
+  Tests (1)-(3) drive the attribution contract through ONE trigger — the
+  navigate-reject — and that trigger does not exist in a production build.
+  `route-url`'s `:params` check is boundary validation, and every
+  `validate-*!` body returns `true` unconditionally under
+  `-Dre-frame.debug=false` (Spec 010 §Production builds), so no reject
+  fires, no `:rf.error/schema-validation-failure` is emitted, and the
+  responses stay 200. They are kept VERBATIM inside
+  `(when interop/debug-enabled? …)` arms. Test (3) is doubly dev-scoped:
+  it reads the DEV trace bus and its subject is epoch / Xray capture.
+
+  GUARDING THEM ALONE WOULD HAVE BEEN A FALSE GREEN. Per-frame error
+  attribution is not a dev contract — it is the invariant that stops one
+  concurrent request's failure stamping another's response, and it is
+  worth most on a production server. So test (4) pins the SAME contract
+  through a trigger that survives the gate: a real throwing handler, whose
+  `:rf.error/handler-exception` rides the always-on axis through
+  `dispatch-on-error!` and is routed by `error-emit-projection-listener`'s
+  own `(:frame record)` attribution — a DIFFERENT code path from the dev
+  listener's `candidate-frame-for-error`, and one nothing else pinned with
+  a sibling server frame live."
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.fx :as fx]
+            [re-frame.interop :as interop]
             [re-frame.schemas :as schemas]
             [re-frame.ssr :as ssr]
             [re-frame.ssr.test-fixture :as tf]))
@@ -124,29 +148,34 @@
             `:frame` stamp routes per-frame and the removed single-frame
             fallback does not regress (the fallback returned nil with >1
             server frame, stamping nothing)."
-    (let [restore (with-stub-validator)]
-      (try
-        (register-routes-and-fx!)
-        (let [fa (make-server-frame frame-a)
-              fb (make-server-frame frame-b)]
-          ;; BOTH frames are live + registered server frames — the exact
-          ;; >1-server-frame shape the removed fallback could not handle.
-          ;; Caller bug routed to frame-a only: `:id "zoo"` fails the
-          ;; route's `:params` predicate → reject → schema-validation-failure.
-          (rf/dispatch-sync [:rf.route/navigate {:to :route/article :params {:id "zoo"}}]
-                            {:frame fa})
+    ;; rf2-lwtlk — DEV ARM. The navigate-reject trigger is production-elided
+    ;; (Spec 010 §Production builds): under the gate the params validate
+    ;; vacuously, nothing is rejected, and both frames would sit at 200. The
+    ;; production-posture pin for this same contract is test (4).
+    (when interop/debug-enabled?
+      (let [restore (with-stub-validator)]
+        (try
+          (register-routes-and-fx!)
+          (let [fa (make-server-frame frame-a)
+                fb (make-server-frame frame-b)]
+            ;; BOTH frames are live + registered server frames — the exact
+            ;; >1-server-frame shape the removed fallback could not handle.
+            ;; Caller bug routed to frame-a only: `:id "zoo"` fails the
+            ;; route's `:params` predicate → reject → schema-validation-failure.
+            (rf/dispatch-sync [:rf.route/navigate {:to :route/article :params {:id "zoo"}}]
+                              {:frame fa})
 
-          (is (= 400 (:status (ssr/get-response fa)))
-              "frame-a's navigate-reject is projected to 400 on frame-a's
-               response — the `:frame` stamp routed the trace to the
-               emitting frame even with a sibling server frame live")
-          (is (= 200 (:status (ssr/get-response fb)))
-              "frame-b's response stays at the default 200 (Spec 011
-               §Status defaults) — the error did not bleed onto the
-               sibling. The removed single-frame fallback would have
-               no-op'd with >1 server frame, masking the per-frame
-               contract this asserts."))
-        (finally (restore))))))
+            (is (= 400 (:status (ssr/get-response fa)))
+                "frame-a's navigate-reject is projected to 400 on frame-a's
+                 response — the `:frame` stamp routed the trace to the
+                 emitting frame even with a sibling server frame live")
+            (is (= 200 (:status (ssr/get-response fb)))
+                "frame-b's response stays at the default 200 (Spec 011
+                 §Status defaults) — the error did not bleed onto the
+                 sibling. The removed single-frame fallback would have
+                 no-op'd with >1 server frame, masking the per-frame
+                 contract this asserts."))
+          (finally (restore)))))))
 
 ;; ===========================================================================
 ;; (2) The other frame can ALSO reject independently — symmetry check that
@@ -158,18 +187,21 @@
             frame-a stays clean — the mirror of test (1), proving
             attribution follows the EMITTING frame in both directions
             (not a fixed/first-registered server frame)."
-    (let [restore (with-stub-validator)]
-      (try
-        (register-routes-and-fx!)
-        (let [fa (make-server-frame frame-a)
-              fb (make-server-frame frame-b)]
-          (rf/dispatch-sync [:rf.route/navigate {:to :route/article :params {:id "zoo"}}]
-                            {:frame fb})
-          (is (= 400 (:status (ssr/get-response fb)))
-              "frame-b (the emitting frame) gets the projected 400")
-          (is (= 200 (:status (ssr/get-response fa)))
-              "frame-a stays at the default 200 — clean"))
-        (finally (restore))))))
+    ;; rf2-lwtlk — DEV ARM, same reason as test (1). Test (4) mirrors this
+    ;; symmetry check on the always-on axis.
+    (when interop/debug-enabled?
+      (let [restore (with-stub-validator)]
+        (try
+          (register-routes-and-fx!)
+          (let [fa (make-server-frame frame-a)
+                fb (make-server-frame frame-b)]
+            (rf/dispatch-sync [:rf.route/navigate {:to :route/article :params {:id "zoo"}}]
+                              {:frame fb})
+            (is (= 400 (:status (ssr/get-response fb)))
+                "frame-b (the emitting frame) gets the projected 400")
+            (is (= 200 (:status (ssr/get-response fa)))
+                "frame-a stays at the default 200 — clean"))
+          (finally (restore)))))))
 
 ;; ===========================================================================
 ;; (3) Epoch-visibility precondition — the navigate-reject trace now carries
@@ -187,25 +219,68 @@
             Issues / Schema-timeline lens). Asserted at the trace-tag
             level so this suite does not pull the epoch artefact onto the
             ssr test classpath."
-    (let [restore (with-stub-validator)
-          traces  (atom [])]
-      (try
-        (register-routes-and-fx!)
-        (let [fa (make-server-frame frame-a)]
-          (rf/register-listener! :trace ::cap (fn [ev] (swap! traces conj ev)))
-          (rf/dispatch-sync [:rf.route/navigate {:to :route/article :params {:id "zoo"}}]
-                            {:frame fa})
-          (rf/unregister-listener! :trace ::cap)
-          (let [err (first (filter #(= :rf.error/schema-validation-failure
-                                       (:operation %))
-                                   @traces))]
-            (is (some? err)
-                ":rf.error/schema-validation-failure emitted on the reject")
-            (is (= :event (-> err :tags :where))
-                "the navigate-reject path tags :where :event")
-            (is (= fa (-> err :tags :frame))
-                "the trace carries [:tags :frame] = the emitting frame —
-                 the precondition epoch capture gates on, so the violation
-                 lands in frame-a's epoch record (visible to Xray) rather
-                 than being dropped")))
-        (finally (restore))))))
+    ;; rf2-lwtlk — DEV ARM, doubly so: the trigger is production-elided AND
+    ;; the assertions read the DEV trace bus, whose subject here (epoch /
+    ;; Xray capture) is dev tooling. Nothing about this test has a
+    ;; production counterpart, and that is correct rather than a gap.
+    (when interop/debug-enabled?
+      (let [restore (with-stub-validator)
+            traces  (atom [])]
+        (try
+          (register-routes-and-fx!)
+          (let [fa (make-server-frame frame-a)]
+            (rf/register-listener! :trace ::cap (fn [ev] (swap! traces conj ev)))
+            (rf/dispatch-sync [:rf.route/navigate {:to :route/article :params {:id "zoo"}}]
+                              {:frame fa})
+            (rf/unregister-listener! :trace ::cap)
+            (let [err (first (filter #(= :rf.error/schema-validation-failure
+                                         (:operation %))
+                                     @traces))]
+              (is (some? err)
+                  ":rf.error/schema-validation-failure emitted on the reject")
+              (is (= :event (-> err :tags :where))
+                  "the navigate-reject path tags :where :event")
+              (is (= fa (-> err :tags :frame))
+                  "the trace carries [:tags :frame] = the emitting frame —
+                   the precondition epoch capture gates on, so the violation
+                   lands in frame-a's epoch record (visible to Xray) rather
+                   than being dropped")))
+          (finally (restore)))))))
+
+;; ===========================================================================
+;; (4) THE PRODUCTION-POSTURE PIN (rf2-lwtlk). The same per-frame
+;;     attribution contract, driven by a trigger that survives
+;;     `-Dre-frame.debug=false`: a handler that throws. Its
+;;     `:rf.error/handler-exception` rides the always-on axis via
+;;     `dispatch-on-error!`, and `error-emit-projection-listener` routes it
+;;     by the record's own `:frame` slot — a different attribution path
+;;     from the dev listener's `candidate-frame-for-error`, exercised here
+;;     with a sibling server frame live in both directions.
+;; ===========================================================================
+
+(deftest always-on-handler-exception-attributes-each-frame-independently
+  (testing "rf2-7d30s / rf2-lwtlk: with TWO live server frames, a throwing
+            handler dispatched to frame-a projects 500 on frame-a's
+            response ONLY — frame-b keeps its default 200 — and the mirror
+            holds when frame-b is the one that throws. This is the
+            concurrent-SSR invariant on the axis that actually ships: with
+            no per-record `:frame`, or with a first-registered-frame
+            fallback, one request's crash would stamp a sibling request's
+            response."
+    (register-routes-and-fx!)
+    (rf/reg-event :boom/throw (fn [_ _] (throw (ex-info "handler boom" {}))))
+    (let [fa (make-server-frame frame-a)
+          fb (make-server-frame frame-b)]
+      (rf/dispatch-sync [:boom/throw] {:frame fa})
+      (is (= 500 (:status (ssr/get-response fa)))
+          "frame-a's handler exception is projected to 500 on frame-a's
+           response — the always-on record carried the emitting frame")
+      (is (= 200 (:status (ssr/get-response fb)))
+          "frame-b's response stays at the default 200 — no bleed onto the
+           concurrent sibling")
+
+      (rf/dispatch-sync [:boom/throw] {:frame fb})
+      (is (= 500 (:status (ssr/get-response fb)))
+          "and the mirror: frame-b now carries its OWN 500, so attribution
+           follows the emitting frame in both directions rather than a
+           fixed / first-registered server frame"))))

--- a/implementation/ssr/test/re_frame/ssr_error_view_failed_no_project_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_error_view_failed_no_project_test.clj
@@ -44,7 +44,25 @@
   substrate carried it. The Ring-level wire pin (the boundary still
   ships a 500 with the default template) lives in
   `re-frame.ssr.ring-test/handler-error-view-throw-falls-back-to-default-
-  template`; this suite pins the SKIP directly at the core level."
+  template`; this suite pins the SKIP directly at the core level.
+
+  ## Posture split (rf2-lwtlk)
+
+  Tests (1) and (2) drive the DEV bus through `trace/emit-error!`, whose
+  emit site sits inside the load-time `interop/debug-enabled?` gate. Under
+  `-Dre-frame.debug=false` nothing is emitted, so (1) — a NEGATIVE, 'not
+  buffered, still 200' — passes for the wrong reason (it would pass with
+  the listener deleted) and (2)'s control reds on an empty buffer. Both
+  are kept VERBATIM inside `(when interop/debug-enabled? …)` arms: they
+  are assertions ABOUT the dev listener, which is the surface their names
+  and docstrings claim.
+
+  Tests (3) and (4) are the production-visible counterparts and run under
+  BOTH postures, calling `error-emit-projection-listener` DIRECTLY — the
+  always-on path a `-Dre-frame.debug=false` JVM SSR host uses. (4) is what
+  stops the guard costing coverage: `:rf.error/sub-exception` genuinely
+  reaches production on that axis, so the no-over-skip control is
+  adjudicated for real under the gate rather than only in dev."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.interop :as interop]
@@ -81,20 +99,26 @@
             and does NOT flip the response status off 200 — the dev-only
             `error-projection-listener` skips the category by design."
     (let [fid (make-server-frame)]
-      ;; Stamp the frame exactly as resolve-error-body's catch arm does.
-      (trace/emit-error! :rf.error/ssr-ring-error-view-failed
-                         {:frame     fid
-                          :exception "synthetic error-view failure"
-                          :ex-class  "clojure.lang.ExceptionInfo"
-                          :recovery  :fell-back-to-default-error-template})
-      (is (empty? (get @error-listener/pending-error-traces fid))
-          "the error-view-failed trace was SKIPPED — not buffered into
-           pending-error-traces (so a later get-response / re-flush can't
-           re-project it and flip the already-stamped status)")
-      (is (= 200 (:status (ssr/get-response fid)))
-          "status stays 200 — the error-view failure degraded gracefully
-           to the locked default template; the default projector (→ 500)
-           never ran for this category"))))
+      ;; rf2-lwtlk — DEV ARM. `trace/emit-error!` no-ops under
+      ;; `-Dre-frame.debug=false`, so both assertions below would hold with
+      ;; the listener ripped out: a negative over a bus that emitted
+      ;; nothing. The production counterpart is test (3), which calls the
+      ;; always-on listener directly and is posture-independent.
+      (when interop/debug-enabled?
+        ;; Stamp the frame exactly as resolve-error-body's catch arm does.
+        (trace/emit-error! :rf.error/ssr-ring-error-view-failed
+                           {:frame     fid
+                            :exception "synthetic error-view failure"
+                            :ex-class  "clojure.lang.ExceptionInfo"
+                            :recovery  :fell-back-to-default-error-template})
+        (is (empty? (get @error-listener/pending-error-traces fid))
+            "the error-view-failed trace was SKIPPED — not buffered into
+             pending-error-traces (so a later get-response / re-flush can't
+             re-project it and flip the already-stamped status)")
+        (is (= 200 (:status (ssr/get-response fid)))
+            "status stays 200 — the error-view failure degraded gracefully
+             to the locked default template; the default projector (→ 500)
+             never ran for this category")))))
 
 ;; ===========================================================================
 ;; (2) NO OVER-SKIP — a GENUINE drain-time error fired through the same
@@ -111,16 +135,21 @@
             non-200 — confirming the error-view-failed skip is targeted,
             not a listener that silently drops everything."
     (let [fid (make-server-frame)]
-      (trace/emit-error! :rf.error/sub-exception
-                         {:frame     fid
-                          :exception (ex-info "sub boom" {})
-                          :recovery  :no-recovery})
-      (is (seq (get @error-listener/pending-error-traces fid))
-          "a genuine drain-time failure IS buffered for projection")
-      (is (not= 200 (:status (ssr/get-response fid)))
-          "and it projects a non-200 — the listener is doing real work;
-           the error-view-failed skip in (1) is therefore meaningful and
-           does NOT over-skip a real failure's fail-closed status"))))
+      ;; rf2-lwtlk — DEV ARM: the emit is `trace/emit-error!`, so under the
+      ;; production gate this control observes an empty buffer. The category
+      ;; itself DOES reach production, so the control is not lost — it is
+      ;; re-run on the always-on axis by test (4).
+      (when interop/debug-enabled?
+        (trace/emit-error! :rf.error/sub-exception
+                           {:frame     fid
+                            :exception (ex-info "sub boom" {})
+                            :recovery  :no-recovery})
+        (is (seq (get @error-listener/pending-error-traces fid))
+            "a genuine drain-time failure IS buffered for projection")
+        (is (not= 200 (:status (ssr/get-response fid)))
+            "and it projects a non-200 — the listener is doing real work;
+             the error-view-failed skip in (1) is therefore meaningful and
+             does NOT over-skip a real failure's fail-closed status")))))
 
 ;; ===========================================================================
 ;; (3) Always-on substrate — symmetry guard. The error-view-failed trace
@@ -140,18 +169,58 @@
             buffered nor projected. Symmetric with the dev path so the
             contract holds whichever substrate carries the trace."
     (let [fid (make-server-frame)]
-      (with-redefs [interop/debug-enabled? false]
-        ;; The error-emit record shape per `error-emit/dispatch-on-error!`.
-        (error-listener/error-emit-projection-listener
-          {:error      :rf.error/ssr-ring-error-view-failed
-           :event      nil
-           :event-id   nil
-           :frame      fid
-           :time       0
-           :exception  (ex-info "synthetic error-view failure" {})
-           :elapsed-ms 0})
-        (is (empty? (get @error-listener/pending-error-traces fid))
-            "the always-on listener also skips the error-view-failed
-             category — not buffered")
-        (is (= 200 (:status (ssr/get-response fid)))
-            "status stays 200 on the production substrate too")))))
+      ;; rf2-lwtlk — the `with-redefs [interop/debug-enabled? false]` this
+      ;; test used to wrap has been dropped, not replaced. `debug-enabled?`
+      ;; is read ONCE at namespace-load time, so a rebind cannot reach the
+      ;; gate, and this test calls the always-on listener DIRECTLY anyway —
+      ;; there is no gate on the path. The namespace now runs in
+      ;; `scripts/test-ssr-prod-gate.sh`, where the property is false for
+      ;; real; that is the evidence.
+      ;;
+      ;; The error-emit record shape per `error-emit/dispatch-on-error!`.
+      (error-listener/error-emit-projection-listener
+        {:error      :rf.error/ssr-ring-error-view-failed
+         :event      nil
+         :event-id   nil
+         :frame      fid
+         :time       0
+         :exception  (ex-info "synthetic error-view failure" {})
+         :elapsed-ms 0})
+      (is (empty? (get @error-listener/pending-error-traces fid))
+          "the always-on listener also skips the error-view-failed
+           category — not buffered")
+      (is (= 200 (:status (ssr/get-response fid)))
+          "status stays 200 on the production substrate too"))))
+
+;; ===========================================================================
+;; (4) Always-on NO-OVER-SKIP control — the production counterpart of (2).
+;;     rf2-lwtlk. On a `-Dre-frame.debug=false` JVM the dev bus is silent,
+;;     so "the error-view-failed record was not buffered" is only meaningful
+;;     next to "a genuine drain-time record on the SAME listener WAS".
+;; ===========================================================================
+
+(deftest always-on-path-genuine-drain-time-error-still-projects-non-200
+  (testing "rf2-sccp5 / rf2-lwtlk (no over-skip, always-on):
+            `:rf.error/sub-exception` — a reactive sub throwing mid-render,
+            fail-closed per rf2-vvwmi — delivered to the ALWAYS-ON
+            `error-emit-projection-listener` IS buffered and projects a
+            non-200. The category rides `dispatch-on-error!` in production,
+            so unlike the dev control this one has a live producer in the
+            posture that ships: an over-broad skip would silently turn an
+            unusable page into a 200 on a real server."
+    (let [fid (make-server-frame)]
+      (error-listener/error-emit-projection-listener
+        {:error      :rf.error/sub-exception
+         :event      nil
+         :event-id   nil
+         :frame      fid
+         :time       0
+         :exception  (ex-info "sub boom" {})
+         :elapsed-ms 0})
+      (is (seq (get @error-listener/pending-error-traces fid))
+          "a genuine drain-time failure IS buffered by the always-on listener")
+      (is (= 500 (:status (ssr/get-response fid)))
+          "and it projects the default projector's fail-closed 500 — the
+           always-on listener is doing real work in this posture, so the
+           error-view-failed skip in (3) is targeted and does not swallow a
+           real failure's status"))))

--- a/implementation/ssr/test/re_frame/ssr_flush_response_result_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_flush_response_result_test.clj
@@ -24,16 +24,23 @@
             [re-frame.core :as rf]
             [re-frame.error-emit :as error-emit]
             [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
             [re-frame.ssr :as ssr]
             [re-frame.ssr.test-fixture :as tf]
             [re-frame.trace :as trace]))
 
+;; rf2-lwtlk — ORDER MATTERS. The wholesale `clear-error-listeners!` used to
+;; run INSIDE `reset-runtime`'s body, i.e. AFTER it. `reset-runtime` re-installs
+;; the `re-frame.ssr` façade's own ALWAYS-ON `::error-projection` listener (via
+;; `(require 're-frame.ssr :reload)`), and that listener IS the production
+;; status-projection path — clearing it afterwards left the always-on axis
+;; unarmed for every test here, so the namespace could only ever observe the
+;; dev bus. Clear FIRST (drop whatever a prior namespace left), then let the
+;; reset arm the projector.
 (use-fixtures :each
   (fn [t]
-    (tf/reset-runtime
-      (fn []
-        (error-emit/clear-error-listeners!)
-        (t)))))
+    (error-emit/clear-error-listeners!)
+    (tf/reset-runtime t)))
 
 (defn- make-server-frame
   "A `:server`-platform frame using the default projector (no-such-handler →
@@ -45,19 +52,45 @@
   id)
 
 (defn- buffer-error!
-  "Buffer a projecting error trace against `frame-id` through the dev trace
-  listener (debug-on default), exactly as a drain-time error would. The
-  settle-point drain in `flush-response-result!` then projects it.
+  "Buffer a projecting error trace against `frame-id` exactly as a drain-time
+  error would. The settle-point drain in `flush-response-result!` then
+  projects it.
+
+  BOTH AXES, deliberately (rf2-lwtlk). This helper used to fire
+  `trace/emit-error!` alone — the DEV bus, whose emit sites sit inside the
+  load-time `interop/debug-enabled?` gate. Under `-Dre-frame.debug=false`
+  nothing was ever buffered, so twelve assertions below observed a clean
+  200 / a nil public-error and this namespace was rostered known-red: the
+  drain-classification contract had never executed in the posture that
+  ships. It is not a dev contract. `flush-response-result!` is the surface
+  a HOST ADAPTER calls on a production JVM to decide the 4xx app arm from
+  the 5xx error arm.
+
+  Both categories used here are on the ALWAYS-ON error axis in production —
+  `:rf.error/handler-exception` through `dispatch-on-error!`, and
+  `:rf.error/no-such-handler {:kind :route}` through
+  `dispatch-error-record!` since rf2-ov56u. So the honest fix is a
+  production-reachable channel, not a `(when interop/debug-enabled? …)`
+  guard: emit on both, the way a real always-on-catalogued site does
+  (`emit-error-both!`), and the whole namespace becomes
+  posture-independent. In dev both listeners buffer and last-write-wins
+  makes the duplicate benign — the same benign duplication
+  `error-projection-listener`'s own docstring records.
 
   `extra-tags` carries any discriminator the default projector's arm is
   GATED on — for `:rf.error/no-such-handler` that is `:kind :route`
   (rf2-ov56u): the 404 arm fires only for the URL-driven miss, so a
   kind-less synthetic trace projects the locked 500 and would silently
-  turn a 404 assertion into a false negative."
+  turn a 404 assertion into a false negative. It rides `:tags` on the dev
+  trace and a flat slot on the always-on record; the always-on projection
+  listener lifts every flat slot back onto `:tags`, so the projector sees
+  the same event either way."
   ([frame-id operation] (buffer-error! frame-id operation nil))
   ([frame-id operation extra-tags]
-   (trace/emit-error! operation
-                      (merge {:frame frame-id :recovery :for-test} extra-tags))))
+   (let [tags (merge {:frame frame-id :recovery :for-test} extra-tags)]
+     (trace/emit-error! operation tags)
+     (error-emit/dispatch-error-record!
+       (merge {:error operation :time (interop/now-ms)} tags)))))
 
 ;; ===========================================================================
 ;; flush-response-result! — returns the projected public-error alongside resp

--- a/implementation/ssr/test/re_frame/ssr_head_resolution_no_project_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_head_resolution_no_project_test.clj
@@ -31,7 +31,28 @@
   substrate carried it. This suite pins the skip directly at the core
   level, independent of the Ring handler (whose own wire-level pin lives
   in `re-frame.ssr.ring-test/handler-throwing-head-fn-ships-degraded-200-
-  not-projected-error`)."
+  not-projected-error`).
+
+  ## Posture split (rf2-lwtlk)
+
+  Tests (1) and (2) drive the DEV bus through `trace/emit-error!`, whose
+  emit site sits inside the load-time `interop/debug-enabled?` gate. Under
+  `-Dre-frame.debug=false` nothing is emitted, so (1) — a NEGATIVE, 'not
+  buffered, still 200' — passes for the wrong reason (it would pass with
+  the listener deleted), and (2)'s control observes an empty buffer and
+  reds. Both are kept VERBATIM inside `(when interop/debug-enabled? …)`
+  arms: they are assertions ABOUT the dev listener, and (2) additionally
+  uses `:rf.error/schema-validation-failure`, a category that is dev-only
+  by design (boundary validation is itself production-elided, Spec 010
+  §Production builds).
+
+  Tests (3) and (4) are the production-visible counterparts and run under
+  BOTH postures: they call `error-emit-projection-listener` DIRECTLY — the
+  always-on path a `-Dre-frame.debug=false` JVM SSR host actually uses —
+  so the skip AND its control are adjudicated for real under the gate. (4)
+  is the one that stops the guard costing coverage: without a positive
+  control on the always-on axis, (3) alone would be a negative nobody had
+  proved could ever be positive."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.interop :as interop]
@@ -68,17 +89,23 @@
             and does NOT flip the response status off 200 — the dev-only
             `error-projection-listener` skips the category by design."
     (let [fid (make-server-frame)]
-      ;; Stamp the frame exactly as resolve-head's catch arm does.
-      (trace/emit-error! :rf.error/ssr-head-resolution-failed
-                         {:frame     fid
-                          :exception (ex-info "synthetic head failure" {:reason :test})
-                          :recovery  :no-recovery})
-      (is (empty? (get @error-listener/pending-error-traces fid))
-          "the head trace was SKIPPED — not buffered into
-           pending-error-traces (so a later get-response can't project it)")
-      (is (= 200 (:status (ssr/get-response fid)))
-          "status stays 200 — the head failure degraded gracefully; the
-           default projector (→ 500) never ran for this category"))))
+      ;; rf2-lwtlk — DEV ARM. `trace/emit-error!` no-ops under
+      ;; `-Dre-frame.debug=false`, so both assertions below would hold with
+      ;; the listener ripped out: a negative over a bus that emitted
+      ;; nothing. The production counterpart is test (3), which calls the
+      ;; always-on listener directly and is posture-independent.
+      (when interop/debug-enabled?
+        ;; Stamp the frame exactly as resolve-head's catch arm does.
+        (trace/emit-error! :rf.error/ssr-head-resolution-failed
+                           {:frame     fid
+                            :exception (ex-info "synthetic head failure" {:reason :test})
+                            :recovery  :no-recovery})
+        (is (empty? (get @error-listener/pending-error-traces fid))
+            "the head trace was SKIPPED — not buffered into
+             pending-error-traces (so a later get-response can't project it)")
+        (is (= 200 (:status (ssr/get-response fid)))
+            "status stays 200 — the head failure degraded gracefully; the
+             default projector (→ 500) never ran for this category")))))
 
 ;; ===========================================================================
 ;; (2) A buffering chokepoint contrast — a NON-degradation category fired
@@ -93,15 +120,22 @@
             confirming the head-category skip is targeted, not a listener
             that silently drops everything."
     (let [fid (make-server-frame)]
-      (trace/emit-error! :rf.error/schema-validation-failure
-                         {:frame     fid
-                          :exception (ex-info "schema boom" {})
-                          :recovery  :no-recovery})
-      (is (seq (get @error-listener/pending-error-traces fid))
-          "a non-degradation category IS buffered for projection")
-      (is (not= 200 (:status (ssr/get-response fid)))
-          "and it projects a non-200 — the listener is doing real work;
-           the head-category skip in (1) is therefore meaningful"))))
+      ;; rf2-lwtlk — DEV ARM, on two counts. `trace/emit-error!` is
+      ;; dev-gated, AND `:rf.error/schema-validation-failure` is a
+      ;; DELIBERATELY dev-only category: boundary validation is itself
+      ;; production-elided (Spec 010 §Production builds), so no production
+      ;; reject exists for this control to observe. The always-on control
+      ;; is test (4).
+      (when interop/debug-enabled?
+        (trace/emit-error! :rf.error/schema-validation-failure
+                           {:frame     fid
+                            :exception (ex-info "schema boom" {})
+                            :recovery  :no-recovery})
+        (is (seq (get @error-listener/pending-error-traces fid))
+            "a non-degradation category IS buffered for projection")
+        (is (not= 200 (:status (ssr/get-response fid)))
+            "and it projects a non-200 — the listener is doing real work;
+             the head-category skip in (1) is therefore meaningful")))))
 
 ;; ===========================================================================
 ;; (3) Always-on substrate — symmetry guard. Post-rf2-hhutya the head trace
@@ -123,18 +157,59 @@
             with the dev path so the contract holds whichever substrate
             carries the trace."
     (let [fid (make-server-frame)]
-      (with-redefs [interop/debug-enabled? false]
-        ;; The error-emit record shape per `error-emit/dispatch-on-error!`.
-        (error-listener/error-emit-projection-listener
-          {:error      :rf.error/ssr-head-resolution-failed
-           :event      nil
-           :event-id   nil
-           :frame      fid
-           :time       0
-           :exception  (ex-info "synthetic head failure" {})
-           :elapsed-ms 0})
-        (is (empty? (get @error-listener/pending-error-traces fid))
-            "the always-on listener also skips the head category — not
-             buffered")
-        (is (= 200 (:status (ssr/get-response fid)))
-            "status stays 200 on the production substrate too")))))
+      ;; rf2-lwtlk — the `with-redefs [interop/debug-enabled? false]` this
+      ;; test used to wrap has been dropped, not replaced. It never bought
+      ;; anything: `interop/debug-enabled?` is read ONCE at namespace-load
+      ;; time, so a rebind cannot reach the gate, and this test calls the
+      ;; always-on listener DIRECTLY anyway — there is no gate on the path.
+      ;; The namespace now runs in `scripts/test-ssr-prod-gate.sh`, where
+      ;; the property is false for real; that is the evidence.
+      ;;
+      ;; The error-emit record shape per `error-emit/dispatch-on-error!`.
+      (error-listener/error-emit-projection-listener
+        {:error      :rf.error/ssr-head-resolution-failed
+         :event      nil
+         :event-id   nil
+         :frame      fid
+         :time       0
+         :exception  (ex-info "synthetic head failure" {})
+         :elapsed-ms 0})
+      (is (empty? (get @error-listener/pending-error-traces fid))
+          "the always-on listener also skips the head category — not
+           buffered")
+      (is (= 200 (:status (ssr/get-response fid)))
+          "status stays 200 on the production substrate too"))))
+
+;; ===========================================================================
+;; (4) Always-on CONTROL — the production counterpart of (2). rf2-lwtlk.
+;;     Without this, the guard on (2) would leave the always-on skip in (3)
+;;     as a negative nobody had proved could ever be positive: on a
+;;     `-Dre-frame.debug=false` JVM the dev bus is silent, so "the head
+;;     record was not buffered" is only meaningful next to "a
+;;     non-degradation record on the SAME listener WAS".
+;; ===========================================================================
+
+(deftest always-on-path-control-non-head-error-still-projects
+  (testing "rf2-lia3i / rf2-lwtlk (control, always-on): a frame-stamped
+            NON-degradation category delivered to the ALWAYS-ON
+            `error-emit-projection-listener` IS buffered and projects a
+            non-200. `:rf.error/handler-exception` is used deliberately —
+            unlike the dev control's `:rf.error/schema-validation-failure`
+            it really does reach production (via `dispatch-on-error!`), so
+            this control has a live producer in the posture that ships."
+    (let [fid (make-server-frame)]
+      (error-listener/error-emit-projection-listener
+        {:error      :rf.error/handler-exception
+         :event      [:load/article]
+         :event-id   :load/article
+         :frame      fid
+         :time       0
+         :exception  (ex-info "handler boom" {})
+         :elapsed-ms 0})
+      (is (seq (get @error-listener/pending-error-traces fid))
+          "a non-degradation category IS buffered by the always-on listener")
+      (is (= 500 (:status (ssr/get-response fid)))
+          "and it projects the default projector's generic 500 — the
+           always-on listener is doing real work in this posture, so the
+           head-category skip in (3) is a targeted skip and not a listener
+           that drops everything"))))

--- a/scripts/test-ssr-prod-gate.sh
+++ b/scripts/test-ssr-prod-gate.sh
@@ -108,11 +108,27 @@ known_red=(
   #    rf2-ov56u's merge; that wait is over.  Re-run and split; do not read
   #    a red here as the 200-for-404 defect returning, and check
   #    `ssr-route-miss-404-production-test` first if you suspect it has.
+  #
+  #    FOUR OF THE FIVE ARE NOW CLEARED, and only ONE of them cleared by
+  #    guarding.  `ssr-flush-response-result-test`'s helper was re-pointed
+  #    at the ALWAYS-ON axis instead — both categories it uses
+  #    (`handler-exception`, `no-such-handler {:kind :route}`) reach
+  #    production, so the drain-classification contract a host adapter
+  #    depends on now executes in the posture that ships, with no guard and
+  #    no assertion moved.  Its fixture also stopped calling
+  #    `clear-error-listeners!` AFTER `reset-runtime`, which had been
+  #    wiping the `re-frame.ssr` façade's own always-on `::error-projection`
+  #    listener and leaving the production path unarmed for every test in
+  #    the file.  `ssr-head-resolution-no-project-test`,
+  #    `ssr-error-view-failed-no-project-test` and
+  #    `ssr-error-two-frame-attribution-test` DID need dev arms for their
+  #    `trace/emit-error!` halves — including two NEGATIVES that were
+  #    passing vacuously over an empty ring — and each gained a
+  #    production-posture counterpart so the guard did not cost coverage:
+  #    an always-on positive control for the two skip-set suites, and a
+  #    throwing-handler two-frame attribution pin for the third (whose only
+  #    trigger, the navigate-reject, is production-elided per Spec 010).
   re-frame.ssr-end-to-end-test                    # 119
-  re-frame.ssr-error-two-frame-attribution-test   #   5
-  re-frame.ssr-error-view-failed-no-project-test  #   2
-  re-frame.ssr-flush-response-result-test         #  12
-  re-frame.ssr-head-resolution-no-project-test    #   2
 
   # ── rf2-lwtlk — SOURCE-COORD ANNOTATION.  CLEARED.  All three namespaces
   #    (`source-coord-parity-test`, `ssr-keyword-head-contract-test`,

--- a/scripts/test-ssr-prod-gate.sh
+++ b/scripts/test-ssr-prod-gate.sh
@@ -128,7 +128,54 @@ known_red=(
   #    an always-on positive control for the two skip-set suites, and a
   #    throwing-handler two-frame attribution pin for the third (whose only
   #    trigger, the navigate-reject, is production-elided per Spec 010).
-  re-frame.ssr-end-to-end-test                    # 119
+  #
+  #    THE FIFTH IS HELD ON A NEW FINDING — rf2-dtpfv (P1).  Re-measured
+  #    2026-07-28, `ssr-end-to-end-test` is 116 reds across 40 deftests.  39
+  #    of those deftests are mechanical trace-sourcing.  ONE is not:
+  #    `ssr-server-fx-args-schema-boundary` fails SEVEN SEMANTIC assertions
+  #    because the behaviour genuinely differs.  `validate-fx!` is
+  #    `(if interop/debug-enabled? (run-validation …) true)`, so the Spec 010
+  #    §Validation-order step-5 fx-args boundary does not run in a release
+  #    build and its documented `:skipped` recovery never happens: a
+  #    malformed `:rf.server/*` fx RUNS and its args land on the response
+  #    accumulator.  Measured at `ssr/get-response`:
+  #    `[:rf.server/set-status "not-an-int"]` leaves `:status "not-an-int"`;
+  #    a `:value`-less `set-header` leaves `["X-Foo" nil]`; a `:value`-less
+  #    `set-cookie` leaves `{:name "session"}`; a non-int safe-redirect
+  #    `:status` lands whole.  ssr-ring's `fail-closed-status` saves the WIRE
+  #    on a Ring host — but that net is host-specific and its only signal is
+  #    a dev-bus warning.  Do NOT split those seven to green the namespace;
+  #    rf2-dtpfv carries the ruling.
+  #
+  #    THE OTHER 39 ARE READY the moment it lands, and the method per
+  #    cluster is known — measured, not guessed:
+  #      * fx-handler-exception (~60 reds: header / cookie / redirect-spelling
+  #        / CRLF-NUL gates).  NO GUARD.  `emit-fx-error!` fans BOTH axes
+  #        (fx.cljc `emit-error-both!`), so re-point `capture-fx-traces!` at
+  #        the `:errors` stream alongside `:trace`, normalising the union
+  #        record to `{:operation :op-type :tags}`.  Every consumer reads
+  #        only `(-> ev :tags :exception)`, and the exception object is the
+  #        same on both axes, so nothing else moves.  Note the gates
+  #        THEMSELVES are production-live — only their observation was
+  #        dev-sourced.
+  #      * the two `ssr-default-error-projector-*` tests, the
+  #        `:rf.error/sanitised-on-projection` diagnostics, and
+  #        `direct-ssr-layer-projects-view-time-exception`.  Same treatment:
+  #        all three categories ride the always-on axis today
+  #        (`dispatch-on-error!`, `emit-always-on-error!`).  Watch the
+  #        `(not-any? … :sanitised-on-projection …)` NEGATIVE at ~line 951 —
+  #        it is vacuous under the gate and becomes real with dual capture.
+  #      * the `:rf.warning/*` cluster (`multiple-status-set`,
+  #        `multiple-redirects`), `:rf.ssr/hydration-mismatch` and the
+  #        head-mismatch trace.  Genuinely dev-only warnings — dev arms; the
+  #        last-write-wins SEMANTICS they sit beside are already
+  #        posture-independent and green here.
+  #      * the `safe-redirect` cluster (~17 reds).  Dev arms, and file
+  #        nothing new: rf2-6jqa8 already records WHY.  The rejection
+  #        assertions — `(nil? (:redirect (get-response f)))`, the
+  #        security-load-bearing half — are posture-independent and green
+  #        under the gate TODAY.  Only the diagnostic is dev-only.
+  re-frame.ssr-end-to-end-test                    # 116 (rf2-dtpfv)
 
   # ── rf2-lwtlk — SOURCE-COORD ANNOTATION.  CLEARED.  All three namespaces
   #    (`source-coord-parity-test`, `ssr-keyword-head-contract-test`,
@@ -322,9 +369,14 @@ fi
 # 21 entries to 7, and the lane runs 436 tests / 2014 assertions across 42 —
 # so 215 had stopped being a floor and become a formality: the lane could have
 # lost HALF its namespaces and still cleared it.  380 restores the original
-# ~13% headroom against the current observed count.  Raise it again as the
-# remaining seven come off.
-export RF2_MIN_TESTS="${RF2_MIN_TESTS:-380}"
+# ~13% headroom against the current observed count.
+#
+# RAISED 380 -> 410 by rf2-76gom / rf2-lwtlk.  The roster is down to 2 entries
+# and the lane runs 473 tests / 2093 assertions across 48 of 50 namespaces.
+# Raise it once more when `ssr-end-to-end-test` comes off behind rf2-dtpfv;
+# that is the last entry other than the rf2-bkvu5 hold, and the `-n`
+# machinery goes away with it.
+export RF2_MIN_TESTS="${RF2_MIN_TESTS:-410}"
 
 args=()
 for ns in $runnable; do

--- a/scripts/test-ssr-prod-gate.sh
+++ b/scripts/test-ssr-prod-gate.sh
@@ -181,30 +181,30 @@ known_red=(
   #    lands.  Do not split that one deftest before it does.
   re-frame.flows-integration-test                 #   2
 
-  # ── rf2-lwtlk / rf2-7vk3z — the conformance corpus.  Nine `ssr-*.edn`
-  #    fixtures fail under the gate, all nine on `:trace-emissions` claims
-  #    (`:rf.event/run-start` for `:rf/server-init` / `:rf/hydrate`), i.e.
-  #    the dev bus — the ordinary posture split.  Because the corpus is one
-  #    `(is (zero? (count failed)))` over every fixture, any one of them
-  #    keeps the whole namespace red.
+  # ── rf2-lwtlk / rf2-76gom — the conformance corpus.  CLEARED, and it did
+  #    NOT clear by guarding.  Nine `ssr-*.edn` fixtures used to fail here,
+  #    all nine on `:trace-emissions` claims read off the DEV bus, and two
+  #    of them ALSO reported `public-error actual: nil`.
   #
-  #    TWO of the nine ALSO report `public-error actual: nil`, and BOTH do so
-  #    for the same runner-side reason — not for a framework one.  The
-  #    runner's `pe-check` (ssr_conformance_test.clj ~753) sources its error
-  #    event from `@traces`, the DEV bus, before feeding it to
-  #    `ssr/project-error`; under the gate that collection is empty, so
-  #    `pe-check` reports nil whatever the framework did.  This is true of
-  #    `:ssr/error-sanitisation` (category `:rf.error/handler-exception`,
-  #    always-on) and — VERIFIED 2026-07-27, after rf2-ov56u landed — equally
-  #    of `:ssr/error-known-mapping` (the route miss, now always-on too).
-  #    rf2-ov56u did NOT clear that fixture, contrary to the rf2-rqje9
-  #    ruling's expectation; re-sourcing `pe-check` from the always-on axis
-  #    (the rf2-7vk3z shape) is what clears both, and it depends on no
-  #    ruling.  The framework behaviour the fixture is ABOUT is separately
-  #    proven in this lane by
-  #    `re-frame.ssr-route-miss-404-production-test`, and the projector
-  #    itself is green here via `re-frame.ssr-error-projector-substrate-test`.
-  re-frame.ssr-conformance-test                   #   1
+  #    The public-error half was never a framework fault: the runner's
+  #    `pe-check` sourced its error event from `@traces` before feeding
+  #    `ssr/project-error`, so under the gate it reported nil whatever the
+  #    framework did — `:ssr/error-known-mapping` did NOT clear with
+  #    rf2-ov56u for that reason, contrary to the rf2-rqje9 ruling's
+  #    expectation.  rf2-76gom re-sourced it from the ALWAYS-ON `:errors`
+  #    axis, synthesised into the projector's envelope by the same generic
+  #    lift `error-emit-projection-listener` performs, so both fixtures now
+  #    adjudicate the wire under the gate.  Mutation-proved: remove the
+  #    fallback and exactly those two go red here.
+  #
+  #    The `:trace-emissions` half kept its dev-bus assertions VERBATIM in a
+  #    dev arm AND gained a production counterpart rather than a hole: a
+  #    `{:operation :rf.event/run-start :tags {:rf.trace/event-id X}}` claim
+  #    says event X RAN, which the always-on `:events` substrate records in
+  #    production, so all 17 such claims are adjudicated under BOTH postures
+  #    (mutation-proved: stub the capture and nine fixtures go red).
+  #    `:trace-not-emitted` moved into the dev arm with them — a negative
+  #    over an empty ring passes with the runtime removed.
 
   # ── rf2-lwtlk — the PAYLOAD-POLICY suite.  CLEARED, and the roster note
   #    that asked for verification rather than assumption was answered:


### PR DESCRIPTION
Clears the SSR production-gate triage that the rf2-rqje9 ruling (PR #7168) unblocked. **Roster 7 → 2.** No `src/` file in any artefact is touched — this is entirely test + roster.

## rf2-76gom — `pe-check` was reading the dev bus

`ssr-conformance-test`'s `:ssr/public-error` channel sourced its error event from `@traces`, the DEV trace bus, before feeding `ssr/project-error`. Every emit site on that bus sits inside the load-time `interop/debug-enabled?` gate, so under `-Dre-frame.debug=false` the collection is empty for every fixture and `pe-check` reported `:actual nil` **whatever the framework did**. That is why `:ssr/error-known-mapping` did not clear when rf2-ov56u promoted the route miss to the always-on axis, contrary to the ruling's expectation — and why `:ssr/error-sanitisation` failed beside it despite its category having been always-on all along.

The runner now captures the always-on `:errors` stream alongside the dev bus and falls back to it, synthesising the projector's `{:operation :op-type :tags}` envelope with the same generic lift `error-emit-projection-listener` performs. Dev posture is unchanged — the dev bus is a superset there and still wins.

**Fixtures that cleared: `:ssr/error-known-mapping` and `:ssr/error-sanitisation`, and no others.** Exactly what the ruling predicted, verified rather than assumed. Mutation-proved: replace the fallback with `nil` and precisely those two go red under the gate.

The namespace's other seven failing fixtures were the `:trace-emissions` posture split. They did **not** get a bare guard — see below.

## rf2-lwtlk — five namespaces off the roster

Only three needed a `(when interop/debug-enabled? …)` guard, and none of the three got one without a production-posture counterpart landing beside it.

| namespace | how it cleared |
|---|---|
| `ssr-conformance-test` | dev arms for the dev-bus channels **plus** a new always-on `:events` counterpart |
| `ssr-flush-response-result-test` | **no guard** — helper re-pointed at the always-on axis |
| `ssr-head-resolution-no-project-test` | dev arms + a new always-on positive control |
| `ssr-error-view-failed-no-project-test` | dev arms + a new always-on positive control |
| `ssr-error-two-frame-attribution-test` | dev arms + a new always-on two-frame attribution pin |

**`ssr-flush-response-result-test`** needed no guard at all. Its `buffer-error!` helper fired `trace/emit-error!` alone, so under the gate nothing buffered and twelve assertions observed a clean 200 / nil public-error. Both categories it uses are always-on in production, so the helper now emits on **both** axes the way a real catalogued site does. `flush-response-result!` is what a host adapter calls on a production JVM to tell the 4xx app arm from the 5xx error arm; that contract now executes in the posture that ships, with no assertion moved.

Found while doing it: the fixture called `error-emit/clear-error-listeners!` *inside* `reset-runtime`'s body — i.e. after it — wiping the `re-frame.ssr` façade's own always-on `::error-projection` listener that `reset-runtime` had just re-installed. The production projection path was unarmed for every test in the file. The clear now runs first.

**`ssr-conformance-test`'s `:trace-emissions`.** Guarding alone would have left nine fixtures adjudicating nothing trace-shaped under the gate, so the `run-start` half gained a production counterpart instead: a `{:operation :rf.event/run-start :tags {:rf.trace/event-id X}}` claim says event X *ran*, and the always-on `:events` substrate records exactly that in production. All 17 such claims are now adjudicated under **both** postures — mutation-proved by stubbing the capture, which reds nine fixtures. A corpus-wide floor (>= 12 claims) stops the translation silently collapsing to zero.

### Vacuous passes found

- **Class 1, negative over an empty ring** — the `dev-path-*-is-not-buffered-or-projected` negatives in both skip-set suites (passing under the gate because nothing was emitted; they would hold with the listener deleted); `:trace-not-emitted` in the conformance runner; the `(not-any? … :sanitised-on-projection …)` negative noted for the follow-up.
- **Class 2, 100% dev instrumentation** — `ssr-error-two-frame-attribution-test` would have become exactly this. Its only trigger, the navigate-reject, does not exist in a release build (boundary validation returns `true` unconditionally, Spec 010 §Production builds). Per-frame attribution is emphatically not a dev contract — it is what stops one concurrent request's failure stamping another's response — so a fourth test pins it through a throwing handler on the always-on axis, exercising `error-emit-projection-listener`'s own `(:frame record)` routing rather than the dev listener's `candidate-frame-for-error`.
- Two decorative `with-redefs [interop/debug-enabled? false]` wrappers dropped. The property is read once at namespace-load time, so the rebind never reached a gate; those tests call the always-on listener directly anyway, and the namespaces now run in the real lane where the property is false for real.

## Two findings — `ssr-end-to-end-test` stays rostered

Re-measured under the gate it is 116 reds across 40 deftests. 39 are mechanical trace-sourcing. **One is not.**

**rf2-dtpfv (P1, filed).** `ssr-server-fx-args-schema-boundary` fails seven *semantic* assertions because the behaviour genuinely differs. `validate-fx!` is `(if interop/debug-enabled? (run-validation …) true)`, so the Spec 010 §Validation-order step-5 fx-args boundary does not run in a release build and its documented `:skipped` recovery never happens — a malformed `:rf.server/*` fx **runs**, and its args land on the response accumulator. Measured at `ssr/get-response`:

```
[:rf.server/set-status "not-an-int"]        prod: :status  "not-an-int"   (dev: skipped, 200)
[:rf.server/set-header {:name "X-Foo"}]     prod: :headers [... ["X-Foo" nil]]
[:rf.server/set-cookie {:name "session"}]   prod: :cookies [{:name "session"}]
[:rf.server/safe-redirect {:location "/ok" :status "not-int"}]
                                            prod: :redirect {:location "/ok" :status "not-int"}
```

rf2-kjf3m.2 built this boundary for exactly the first case. ssr-ring's `fail-closed-status` saves the wire on a Ring host — but that net is host-specific (nothing obliges a non-Ring adapter to re-implement it) and its only signal is a dev-bus warning, so the 200 → 500 flip is silent in production. **Not fixed here, not split here** — the roster line stays and the bead carries the ruling with three named options.

**rf2-6jqa8 (P2, filed).** The safe-redirect gate *rejects* correctly under the gate — every `(nil? (:redirect (get-response f)))` assertion is green — but `emit-safe-redirect-error!` is `trace/emit-error!` only, so an attempted open-redirect or `javascript:` scheme reaches **no off-box shipper on either axis** in production. Not a security defect; a security-observability gap, and an egress-surface change needing the same review rf2-ov56u carried. Note the asymmetry it leaves: the CRLF gate on the *same fx* throws, so it rides `:rf.error/fx-handler-exception` and *is* always-on.

The roster comment now records the measured per-cluster method for the other 39 so the follow-up does not re-derive it.

## Quality gates

Foreground, worktree-local logs, exit codes echoed, never piped through `tail`/`grep`.

| gate | exit |
|---|---|
| `bash scripts/test-ssr-prod-gate.sh` | **0** |
| `clojure -M:test` (implementation/ssr, dev posture) | **0** |
| `python scripts/check_jvm_lane_rosters.py` | **0** |
| `clojure -M:test -n re-frame.egress-chokepoint-conformance-test` (core) | **0** |

The conformance corpus runs inside both ssr gates above. The core chokepoint gate was run because a `dispatch-error-record!` caller was added — in `implementation/ssr/test/`, and that scan's roots are the artefacts' `src/` trees, none of which this PR touches. The full core lane, the CLJS suites and every other artefact lane are **deferred to CI**.

### Roster before / after

| | before | after |
|---|---|---|
| roster entries | 7 | **2** |
| namespaces run | 43 of 50 | **48 of 50** |
| tests | 450 | **473** |
| assertions | 2050 | **2093** |

Remaining: `re-frame.ssr-end-to-end-test` (rf2-dtpfv) and `re-frame.flows-integration-test` (rf2-bkvu5, untouched — see below).

`RF2_MIN_TESTS` raised 380 → 410, the same ~13% headroom.
`check_jvm_lane_rosters.py` baseline stays **0**.

### Dev-posture assertion count

Whole `implementation/ssr` suite under `clojure -M:test`:

|  | tests | assertions |
|---|---|---|
| before | 548 | 2645 |
| after | **551** | **2653** |

Both **up**, with the test count held or raised in every namespace touched. Per namespace:

```
ssr-conformance-test                    1 test,       3 ->  4 assertions
ssr-flush-response-result-test         10 tests,     28 -> 28 assertions
ssr-head-resolution-no-project-test     3 -> 4 tests,  6 ->  8 assertions
ssr-error-view-failed-no-project-test   3 -> 4 tests,  6 ->  8 assertions
ssr-error-two-frame-attribution-test    3 -> 4 tests,  7 -> 10 assertions
```

### `flows-integration-test`

Left alone, and it does **not** look clearable. rf2-bkvu5 was ruled *(a) dev-only as designed* — `reg-app-schema` is a no-op in production, so the held deftest's subject genuinely does not exist under the gate. Its line comes off with a one-line change once rf2-bkvu5's documentation work lands; nothing in this PR moves it.
