### PR TITLE
docs,spec: the schema-validation 400 is dev-only, and so is reg-app-schema (rf2-byexd, rf2-pn648)

### DIFF
--- a/docs/api/re-frame.ssr.md
+++ b/docs/api/re-frame.ssr.md
@@ -409,10 +409,11 @@ A frame opts into SSR error projection via the `:ssr {:public-error-id ... :dev-
   (default-error-projector-fn trace-event) → :rf/public-error
   ```
 - **Description**: The runtime's built-in default projector, registered under `:rf.ssr/default-error-projector`. Maps trace events to public errors:
-  - `:rf.error/no-such-handler`, `:rf.error/no-such-route` → `404 :not-found`.
+  - `:rf.error/no-such-handler` → `404 :not-found`. This is the arm that answers an unroutable URL, and it survives production hardening. Its sibling `:rf.error/no-such-route` maps to `404` too, but that category is caller misuse of `route-url` and rides the dev-gated trace stream, so a release build never reaches this arm through it.
   - `:rf.error/cofx-value-invalid` (a client-supplied coeffect rejected at the dispatch boundary) → `400 :bad-request`.
-  - `:rf.error/schema-validation-failure` → `400 :bad-request`, but only when the failure's `:where` tag is `:event` (a client-supplied event payload). Server-side surfaces such as `:where :fx-args` fall through.
+  - `:rf.error/schema-validation-failure` → `400 :bad-request`, but only when the failure's `:where` tag is `:event` (a client-supplied event payload). Server-side surfaces such as `:where :fx-args` fall through. **This arm is dev-only** — see below.
   - Everything else → the locked generic `500 :internal-error` ([`fallback-public-error`](#fallback-public-error)).
+- **The `400`-for-schema-validation-failure arm never fires in a production build.** Schema validation is a development-build assertion ([Spec 010 §Production builds](../../spec/010-Schemas.md#production-builds)): under `:advanced` + `goog.DEBUG=false`, or the JVM `-Dre-frame.debug=false` hardening an SSR service is required to set, every validator returns `true` unconditionally. The candidate is never rejected, `:rf.error/schema-validation-failure` is never emitted, and the projector is handed nothing to map — so a malformed request body flows into the handler and the endpoint answers `200`. Do not wire an endpoint's rejection to this arm. **A server that must answer `400` produces that status itself**: validate the payload in the handler body and emit `[:rf.server/set-status 400]`. See [Pattern-FormAction §Validation is the handler's job](../../spec/Pattern-FormAction.md#validation-is-the-handlers-job) for the worked shape, and [Spec 011 §Substrate](../../spec/011-SSR.md#server-error-projection) for the categories that *do* reach the projector under production hardening.
 
 ### `apply-error-projection!`
 

--- a/examples/capabilities/ssr/ssr/README.md
+++ b/examples/capabilities/ssr/ssr/README.md
@@ -120,7 +120,15 @@ exercising the load-bearing subtleties, not just the happy path:
   registered explicitly against *each* frame at its entry point — so
   the server commit and the client commit validate against the same
   contract. (It's `[:maybe …]` because the slice is legitimately absent
-  until the fetch lands.)
+  until the fetch lands.) That validation is a development-time
+  assertion on both sides: a production build performs the registration
+  and elides the check ([Spec 010 §Production
+  builds](../../../../spec/010-Schemas.md#production-builds)), so
+  neither commit is verified in a release build. The symmetry is still
+  the point — one declared contract, two frames — but a server that has
+  to *reject* a malformed request does that in its handler, not through
+  the schema ([Pattern-FormAction §Validation is the handler's
+  job](../../../../spec/Pattern-FormAction.md#validation-is-the-handlers-job)).
 - **Per-request teardown is load-bearing.** `handle-request` ends with
   `destroy-frame!` in a `finally`, on both the success and the throw
   path. A long-running server then can't leak a frame (and its request

--- a/examples/capabilities/ssr/ssr_streaming/README.md
+++ b/examples/capabilities/ssr/ssr_streaming/README.md
@@ -110,9 +110,13 @@ The server renders under a fresh per-request frame (a gensym, in
 in `run`). The same
 [schema](../../../../docs/core/glossary.md#schema) is registered explicitly
 against *each* with a `{:frame …}` override, because that's where the
-`:cards` commit actually validates on either side. The server then drops
-its per-request frame-id from the payload, so the client's explicit
-`:frame` stands rather than tripping a frame-id mismatch.
+`:cards` commit actually validates on either side. That validation is a
+development-time assertion: a production build performs the registration
+and elides the check ([Spec 010 §Production
+builds](../../../../spec/010-Schemas.md#production-builds)), so neither
+commit is verified in a release build. The server then drops its
+per-request frame-id from the payload, so the client's explicit `:frame`
+stands rather than tripping a frame-id mismatch.
 
 The other subtlety is the boundary itself. `ssr/boundary` is a
 **component**, not a hiccup keyword, and that is load-bearing rather than

--- a/spec/Construction-Prompts.md
+++ b/spec/Construction-Prompts.md
@@ -635,7 +635,7 @@ A feature ships these artefacts as a coherent bundle:
 
 | Artefact | Required | Convention |
 |---|---|---|
-| **Schema** for the feature's `app-db` slice | yes | `(rf/reg-app-schema [:feature] FeatureSchema)` |
+| **Schema** for the feature's `app-db` slice | yes | `(rf/reg-app-schema [:feature] FeatureSchema)` — a dev-time assertion and an introspection surface, not a production guard (see below) |
 | **`:initial-events` init event** | yes | `:feature/initialise` — sets the slice to its initial value |
 | **State events** (the feature's instruction set) | yes | `:feature/verb-noun`, `:feature.subarea/verb-noun` |
 | **Subscriptions** | yes | `:feature/property` reading from `[:feature ...]` |
@@ -643,6 +643,18 @@ A feature ships these artefacts as a coherent bundle:
 | **Machine** for stateful flows | optional | `:feature.flow/machine` if the feature has multi-step interactions |
 | **Routes** | optional | If the feature has its own URL surface |
 | **Smoke test** covering the happy path | yes | Drives feature events, asserts state and renders |
+
+**What the schema row buys — and what it does not.** `reg-app-schema` is
+required because the registration is genuinely wanted: it documents the slice's
+shape, it catches your own mistakes the moment you make them, and it is what
+tools and agents read back through `(rf/app-schemas)`. But registering a schema
+and checking one are two different acts. A production build performs the
+registration and elides the check ([010 §Production
+builds](010-Schemas.md#production-builds)), so a candidate that violates
+`FeatureSchema` installs silently there — no rejection, no rollback, no trace.
+Write any rule that must hold in production as a branch in the handler, and put
+untrusted input behind the `:rf.schema/at-boundary` interceptor, which is the
+one validation seam that survives the gate.
 
 **Directory / namespace convention (CLJS reference):**
 

--- a/spec/Conventions.md
+++ b/spec/Conventions.md
@@ -320,13 +320,21 @@ one vocabulary rule, not four accidents:
 |---|---|---|---|
 | `reg-event` `:schema` | `:schema` (the `reg-event` metadata-map key) | the **event args** — the payload positions of the event vector | app-owned, per-handler ([§Reserved registration metadata](#reserved-registration-metadata-framework-owned), [API.md §`reg-event`](API.md)) |
 | machine `:data-schema` | `:data-schema` (the `reg-machine` key) | a machine's **`:data`** context map | app-owned, per-machine. Qualified — not bare `:schema` — because a visible sibling (the transition table, the spawn spec) makes a generic `:schema` ambiguous about *which* fact it bounds. The rename is [EP-0005](../docs/EP/EP-0005-machine-data-schema.md); it is this rule's worked precedent |
-| `reg-app-schema` | the registrar name itself (the validator *is* the registration) | **app-db paths** — a value at a `[:k …]` path in the app-db partition | app-owned, per-frame side-table ([010-Schemas §Per-frame schemas](010-Schemas.md#per-frame-schemas)). Validates app-db **only** (per [010 §App schemas validate the app-db partition only](010-Schemas.md#app-schemas-validate-the-app-db-partition-only)) |
+| `reg-app-schema` | the registrar name itself (no sibling key needs disambiguating, so the registrar carries the word) | **app-db paths** — a value at a `[:k …]` path in the app-db partition | app-owned, per-frame side-table ([010-Schemas §Per-frame schemas](010-Schemas.md#per-frame-schemas)). Validates app-db **only** (per [010 §App schemas validate the app-db partition only](010-Schemas.md#app-schemas-validate-the-app-db-partition-only)) |
 | runtime-db schema | registered at boot as a runtime-db validator (NOT via `reg-app-schema`) | the **runtime-db partition** (`:rf.runtime/*` subsystem state, machine `:snapshots`, …) | **framework-owned** — registered by the runtime, refined per-machine from registered `:data` shapes; user code MUST NOT register against it ([§Reserved runtime-db keys](#reserved-runtime-db-keys)) |
 
 The shared
 `schema` word is *kept* across the four — the discipline is to qualify (rule 3)
 where a sibling creates ambiguity, not to mint four unrelated words for one
 concept (which rule 1 would forbid in reverse).
+
+The table settles what each name *means*, not when it runs. On that second
+question all four agree: registering a schema is not the same act as checking
+one. A production build performs every registration above — the schemas stay
+introspectable, which is why tools and agents can read them — and elides the
+checking ([010 §Production builds](010-Schemas.md#production-builds)). An
+invariant that must hold in production belongs in handler code; the
+`:rf.schema/at-boundary` interceptor is the one seam that survives the gate.
 
 **Enforcement.** A retired spelling appearing in framework source is a CI
 failure (the no-floor-lint treatment) where the shape allows it, not a doc note.


### PR DESCRIPTION
Applies the operator ruling on rf2-bkvu5 — `reg-app-schema` app-db candidate validation is a **development-only assertion, as designed; production trusts the programmer** — to the four sites the earlier passes (#7166, #7172, #7173) were fenced out of.

## rf2-byexd — the SSR 400 is dev-only

The doc site promised a `400` on schema-validation-failure. That `400` never arrives in a production build: boundary validation is itself elided under the gate, and the category it would report rides `trace/emit-error!`, which opens with `(when interop/debug-enabled? ...)`. The projector is handed nothing to map. A reader wiring an SSR service on that promise ships an endpoint that **answers 200 on malformed input**.

- **`docs/api/re-frame.ssr.md`, `default-error-projector-fn`.** The `400` row keeps its `:where :event` gate and gains a plain statement that the arm is dev-only, plus a paragraph saying what production actually does: a server that must answer `400` validates in the handler body and emits `[:rf.server/set-status 400]`. It points at `spec/Pattern-FormAction` §Validation is the handler's job (the shape #7172 established) and at `spec/011` §Substrate for the categories that *do* survive production hardening.
- **Same list, the `404` row** — an unbeaded site of the same class, found in the file I already owned. It paired `:rf.error/no-such-handler` with `:rf.error/no-such-route` as if both were production-reachable. Per `spec/011`, only the first is: `:rf.error/no-such-route` is caller misuse of `route-url` and dev-gated. The row now separates them.
- **`examples/capabilities/ssr/ssr/README.md`, "Two frame families, one schema".** The symmetry claim survives — it *is* the same registered contract on both sides, which is the paragraph's point — and now carries the qualification that neither commit is checked in a release build.
- **`examples/capabilities/ssr/ssr_streaming/README.md`** carries a near-clone of that paragraph, with the same flat present-tense "actually validates on either side". It gets the same sentence. Correcting one and leaving its twin in the sibling directory seemed worse than correcting neither.

## rf2-pn648 — `reg-app-schema` is not a production guard

- **`spec/Conventions.md`**, schema-vocabulary table. The gloss "the validator *is* the registration" is exactly the conflation elision breaks: the registration happens in every build, the validation does not. The row is about *naming* and the naming claim is fine, so only the gloss changed.
- **`spec/Construction-Prompts.md`**, the per-feature artefact table. This one is read literally by agents constructing apps, so an unqualified REQUIRED row is how the misunderstanding gets manufactured at scale. The row **stays required** — the registration is genuinely wanted, and `(rf/app-schemas)` is what tools and agents read back — and now says what it does and does not buy.

**One addition beyond the two named lines, flagged for review.** Tagging only the `reg-app-schema` row of the Conventions table with a build-posture fact would imply the other three validators are always-on, which is false — `010` §Production builds wraps *every* `validate-*!` in the debug gate. So a short paragraph under that table states the fact once for the family. It adds a cross-reference; it changes no normative statement.

## The sweep — four beads filed

Every pass in this sequence has found sites beyond its bead by hunting for guidance that describes a dev-only mechanism as a production guarantee. This one found seven. Two were inside the fence and are fixed above (the `404` row, the streaming twin). The other five are filed, none previously beaded:

| Bead | Sites | Why |
|---|---|---|
| **rf2-ueopx** (P1) | `spec/Security.md` :30, :52, :56, matrix row :263; `implementation/SECURITY.md` :116 | The security-posture spec says schema-driven validation "**gates** structured-input surfaces" against "attacker-controllable input", and rows it in the defence-in-depth matrix beside genuinely always-on defences (CRLF fail-fast, safe-redirect, keyword-interning cap) with no gating entry. `:56` describes the dev-only `validate-event!`/`-sub!`/`-fx!` family without ever naming `:rf.schema/at-boundary`, the seam that actually survives. In `implementation/SECURITY.md` the overclaim is by omission: every neighbouring table row is annotated `always-on` or `dev-mode`; this one is not. P1 because a reader auditing the threat model is the reader least able to absorb the error. |
| **rf2-0l4r7** (P2) | `docs/ssr/concepts.md` :310, :332, :334 | The SSR concept page's canonical statement of the projector contract, promising "a *client-surface* schema-validation failure to `400 :bad-request`". The section's only dev/prod sentence is about `:dev-error-detail?`, which reads as "production just loses the `:details` key" and so reinforces the wrong belief. |
| **rf2-2hjk3** (P2) | `tools/template/.../_shared/README_with_ssr.md` :103-104, :123, :218; `.../root/README.md` :371-375 | The scaffold README a developer reads while starting a real app — four separate claims. The worst tells the user that "wrong writes are caught at the boundary" and that the error "flows through the error sink above", i.e. into their production monitoring. The elision notes exist but sit 56 and 110 lines away, phrased as bundle-*cost* facts. |
| **rf2-bjkkd** (P2) | `examples/core/login/README.md` :29 | "a too-short password or a malformed email is **rejected at the door**, and the handler never runs" — on a credential ingress, with no `:rf.schema/at-boundary` registered. The bead offers the mayor a choice: qualify the prose, or make the example correct by construction (a login handler is the canonical at-boundary case). The second is a code change, so it is a ruling, not a mechanical fix. |

Also checked and found clean: `spec/012-Routing.md` :766 and the routing docs (the `::reject` sentinel and `route-url`'s throw are genuinely ungated), plus `docs/machines/`, `docs/routing/`, `docs/resources/`, `docs/story/`, `docs/xray/`, `tools/*/spec/`, `migration/`, `testbeds/`, and the remaining example READMEs.

## Quality gates

Run from the worktree, foreground, unpiped:

| Gate | Exit |
|---|---|
| `python -m mkdocs build --strict` | `0` |
| `python scripts/check_doc_slugs.py` | `0` |
| `python scripts/check_keyword_catalogue_drift.py` | `0` |
| `scripts/check_skill_*.py` (all 14) | `0` each |

`mkdocs build --strict` was re-run after the streaming-README commit; still `0`. Deferred to CI: the full test spine (`scripts/test-fast-pr.sh`) and every CLJS/JVM suite. This diff is five Markdown files and changes no code, so nothing it touches is exercised by them.

Closes rf2-byexd, rf2-pn648.
