### PR TITLE
fix(core): a partially-installed reprojection is never observable as installed (rf2-9c2jf)

### DIFF
--- a/implementation/core/src/re_frame/live_frame.cljc
+++ b/implementation/core/src/re_frame/live_frame.cljc
@@ -1332,15 +1332,102 @@
   [_event]
   (mark-dirty-and-schedule!))
 
-(defonce ^:private reprojection-installed? (atom false))
+(defonce ^{:private true
+           :doc "Process-local ONCE-flag for the reprojection wiring. Written
+  LAST, and only from inside `reprojection-install-lock` on the JVM — see
+  `ensure-reprojection-installed!` for why the ordering is load-bearing:
+  `true` here is a PROMISE that the registrar hook and both late-bind keys are
+  already in place, and a partially-installed reprojection must never be
+  observable as installed."}
+  reprojection-installed?
+  (atom false))
+
+#?(:clj
+   (defonce ^{:private true
+              :doc "JVM monitor serializing the reprojection once-install
+  (rf2-9c2jf, the merged-PR-#7114 audit). The install has THREE side effects
+  and every one of them is part of what the once-flag promises, so the whole
+  body — the flag read, the three effects, and the flag write — must be ONE
+  critical section. A `compare-and-set!` on the flag alone is not enough: CAS
+  ELECTS an installer but does not make the LOSERS WAIT for it to finish, so a
+  concurrent `make-frame` read `true` mid-install and proceeded. `locking`
+  makes a concurrent caller either do the install or BLOCK until the elected
+  installer has finished it.
+
+  DEADLOCK-FREE BY CONSTRUCTION: the body calls only
+  `registrar/add-registration-hook!` and `late-bind/set-fn!` — three
+  bookkeeping `swap!`s that run no user code, acquire no other monitor (in
+  particular NOT `projection-flush-lock`), and never re-enter `make-frame`. The
+  monitor is released before `make-frame` does anything else, so nothing
+  downstream — `:initial-events` draining, a read-time flush — ever runs
+  underneath it. CLJS is single-threaded: no caller can observe the once-body
+  mid-flight, so no lock exists there."}
+     reprojection-install-lock
+     (Object.)))
+
+(defn- install-reprojection!
+  "The reprojection once-body, ALWAYS called with the install serialized (the
+  JVM monitor above; CLJS's single thread). Performs the three side effects and
+  only THEN publishes the once-flag.
+
+  PUBLISH-LAST IS THE INVARIANT, not a style choice: `reprojection-installed?`
+  is read by every `make-frame`, and `true` must mean \"all three are in
+  place\". Setting it first (the `compare-and-set!` this replaced) made
+  `true` mean only \"someone has started\", which let a concurrent `make-frame`
+  seal a generation with no registration hook behind it. Publishing last also
+  makes the install FAILURE-ATOMIC: if a side effect throws, the flag stays
+  false and the next `make-frame` retries, rather than the wiring being
+  permanently missing behind a `true` flag. Returns nil."
+  []
+  (when-not @reprojection-installed?
+    (registrar/add-registration-hook! reproject-on-registration-change!)
+    ;; The REMOVAL twin (rf2-h1vqa4): `unregister!` / `clear-kind!` /
+    ;; `clear-all!` are source-store changes exactly like a `reg-*` — a
+    ;; cleared handler must DISAPPEAR from live default-image frames, not
+    ;; linger in a sealed generation the store no longer backs. The registrar
+    ;; cannot require this ns (cycle), so it consults this late-bind key on
+    ;; its removal paths; same dirty-mark + coalescing as the register side.
+    (late-bind/set-fn! :live-frame/mark-projection-dirty! mark-dirty-and-schedule!)
+    ;; The read-time coalesced flush consult in `call-with-frame-resolution`
+    ;; and `router/process-event!` (rf2-h1vqa4). Both consult by KEYWORD
+    ;; through `late-bind`, so the consult sites themselves root nothing —
+    ;; only this publication does, and only `make-frame` reaches it.
+    (late-bind/set-fn! :live-frame/flush-projection! flush-projection-if-dirty!)
+    ;; …and ONLY NOW is the wiring observable as installed.
+    (reset! reprojection-installed? true))
+  nil)
 
 (defn ^:no-doc ensure-reprojection-installed!
   "Install the reprojection wiring ONCE per process: the registrar registration
   hook plus the two late-bind keys the registrar's removal paths and the
-  resolution seams consult. Idempotent — `compare-and-set!` makes the
-  install-decision atomic, so a concurrent `make-frame` burst installs exactly
-  one hook (the registrar's `registration-hooks` vector dedupes none, and
-  `clear-all!` does not clear it).
+  resolution seams consult. Idempotent, and — on the JVM — a BARRIER: a
+  concurrent `make-frame` either performs the install or WAITS for the caller
+  performing it, so it can never proceed on a half-installed one.
+
+  A PARTIALLY-INSTALLED REPROJECTION IS NEVER OBSERVABLE AS INSTALLED. That is
+  the invariant, and it is what makes the once-flag safe to read. This used to
+  be spelled `(when (compare-and-set! reprojection-installed? false true) …
+  side effects …)`, on the reasoning that CAS made the install-decision atomic
+  and therefore made a concurrent `make-frame` burst safe. It does not (rf2-9c2jf,
+  the merged-PR-#7114 audit): CAS ELECTS one installer, it does not make the
+  LOSERS WAIT for that installer's side effects to land. A second `make-frame`
+  read the flag as `true` while the elected installer was still between the CAS
+  and `add-registration-hook!`, concluded the wiring was in place, and SEALED
+  ITS GENERATION — the seal `registrar/lookup` resolves every `(kind, id)`
+  through. A `reg-event` in that window fired no hook because no hook existed,
+  and once the installer finished there was no dirty mark left for anything to
+  flush: that frame was PERMANENTLY STALE, reporting
+  `:rf.error/no-such-handler` for a handler `registrar/lookup` was holding at
+  that very moment. The original release blocker, recreated with no debug gate
+  in sight. Pinned by `reprojection_install_race_jvm_test.clj`.
+
+  So the whole once-body — flag read, three side effects, flag write — is ONE
+  critical section under `reprojection-install-lock`, and the flag is published
+  LAST (`install-reprojection!`). JVM ONLY: CLJS is single-threaded, so no
+  caller can observe the once-body mid-flight and the CLJS path stays
+  lock-free, carrying only the publish-last ordering. The monitor is
+  uncontended after the first `make-frame` and is never held across user code —
+  see `reprojection-install-lock` for the deadlock argument.
 
   ROOTED FROM `make-frame`, NOT FROM NAMESPACE LOAD, and carrying NO
   `interop/debug-enabled?` gate (rf2-9c2jf). Both properties matter:
@@ -1378,18 +1465,7 @@
   when no image-loaded frame exists, so the hook was a guaranteed no-op before
   the first `make-frame` anyway."
   []
-  (when (compare-and-set! reprojection-installed? false true)
-    (registrar/add-registration-hook! reproject-on-registration-change!)
-    ;; The REMOVAL twin (rf2-h1vqa4): `unregister!` / `clear-kind!` /
-    ;; `clear-all!` are source-store changes exactly like a `reg-*` — a
-    ;; cleared handler must DISAPPEAR from live default-image frames, not
-    ;; linger in a sealed generation the store no longer backs. The registrar
-    ;; cannot require this ns (cycle), so it consults this late-bind key on
-    ;; its removal paths; same dirty-mark + coalescing as the register side.
-    (late-bind/set-fn! :live-frame/mark-projection-dirty! mark-dirty-and-schedule!)
-    ;; The read-time coalesced flush consult in `call-with-frame-resolution`
-    ;; and `router/process-event!` (rf2-h1vqa4). Both consult by KEYWORD
-    ;; through `late-bind`, so the consult sites themselves root nothing —
-    ;; only this publication does, and only `make-frame` reaches it.
-    (late-bind/set-fn! :live-frame/flush-projection! flush-projection-if-dirty!))
+  #?(:clj  (locking reprojection-install-lock
+             (install-reprojection!))
+     :cljs (install-reprojection!))
   nil)

--- a/implementation/core/test/re_frame/reprojection_install_race_jvm_test.clj
+++ b/implementation/core/test/re_frame/reprojection_install_race_jvm_test.clj
@@ -1,0 +1,261 @@
+(ns re-frame.reprojection-install-race-jvm-test
+  "rf2-9c2jf (the MERGED-PR-#7114 audit reopen) — a PARTIALLY-INSTALLED
+  reprojection must never be observable as INSTALLED.
+
+  THE DEFECT. `re-frame.live-frame/ensure-reprojection-installed!` used to
+  publish its once-flag with `compare-and-set!` FIRST and perform the three side
+  effects the flag PROMISES afterwards:
+
+      (when (compare-and-set! reprojection-installed? false true)   ;; publish
+        (registrar/add-registration-hook! reproject-on-registration-change!)
+        (late-bind/set-fn! :live-frame/mark-projection-dirty! …)
+        (late-bind/set-fn! :live-frame/flush-projection!      …))
+
+  `compare-and-set!` ELECTS one installer; it does not make the LOSERS WAIT for
+  that installer to finish. A second `make-frame` on another thread reads the
+  flag as `true` while the elected installer is still between the CAS and the
+  hook, concludes the wiring is in place, and proceeds to SEAL ITS GENERATION —
+  the seal `registrar/lookup` resolves every `(kind, id)` through
+  (`call-with-frame-resolution`). A `reg-event` issued in that window fires NO
+  hook, because no hook exists yet. When the elected installer finally finishes
+  there is no dirty mark left for anything to flush, so that second frame stays
+  PERMANENTLY STALE: `dispatch` reports `:rf.error/no-such-handler` for a
+  handler `registrar/lookup` is holding at that very moment. That is the
+  original rf2-9c2jf release blocker, recreated WITHOUT the debug gate.
+
+  THE INVARIANT, stated as this namespace tests it: *completion is observable
+  only after every side effect the flag promises is in place.* The repair
+  publishes the flag LAST and serializes the whole once-body under a JVM
+  monitor, so a concurrent caller either does the install or BLOCKS until the
+  installer has finished it — it can never pass the boundary early.
+
+  THE HARNESS. Both tests open the window DETERMINISTICALLY with a
+  `with-redefs` barrier on one of the three side effects, so the installer
+  thread parks INSIDE the once-body with the flag in whatever state the
+  implementation put it in. No sleeps decide anything: the negative assertion
+  (\"the second caller has NOT returned\") is the one the fix makes IMPOSSIBLE
+  to violate — with the fix the second caller is blocked on a monitor the
+  installer holds until the test releases it, so it cannot return at any
+  timeout; without the fix it returns in microseconds.
+
+    * `install-boundary-not-passable-before-the-registration-hook` parks at the
+      FIRST side effect (the registrar hook) and pins the full stale-frame end
+      state — the exact reproduction the audit recorded.
+    * `install-boundary-not-passable-before-the-flush-late-bind` parks at the
+      LAST side effect (`:live-frame/flush-projection!`, the read-time flush
+      consult whose removal twin `:live-frame/mark-projection-dirty!` the
+      registrar's `unregister!` / `clear-kind!` / `clear-all!` paths consult) and
+      pins that even the final publication precedes observability.
+
+  CLJS IS UNAFFECTED and has no counterpart here: it is single-threaded, so no
+  second caller can observe the once-body mid-flight. The repair keeps the CLJS
+  path lock-free (publish-last only).
+
+  THE FIXTURE REWINDS THE ONCE-FLAG. `reprojection-installed?` is a process-wide
+  `defonce`, so by the time this namespace runs some earlier `make-frame` has
+  usually installed the wiring already. The fixture snapshots and restores the
+  three pieces of process state the once-body writes — the flag, the registrar's
+  registration-hook vector, and `late-bind/hooks` — so each test opens the SAME
+  window a fresh JVM's very first `make-frame` opens, and leaves the process
+  exactly as it found it."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.flows :as flows]
+            [re-frame.frame :as frame]
+            [re-frame.late-bind :as late-bind]
+            [re-frame.live-frame :as live-frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.trace :as trace])
+  (:import [java.util.concurrent CountDownLatch TimeUnit]))
+
+;; ---------------------------------------------------------------------------
+;; White-box handles on the once-initialization's process state.
+;;
+;; These are deliberate private-var reads: the whole point of the test is that
+;; the once-body's INTERMEDIATE state must never be observable, and observing it
+;; is how we prove it. `reproject-on-registration-change!` is public, so hook
+;; presence is an ordinary identity check.
+;; ---------------------------------------------------------------------------
+
+(def ^:private installed-flag       #'live-frame/reprojection-installed?)
+(def ^:private registration-hooks   #'registrar/registration-hooks)
+
+(defn- reprojection-hook-installed? []
+  (boolean (some #{live-frame/reproject-on-registration-change!}
+                 @@registration-hooks)))
+
+(def ^:private published-keys
+  [:live-frame/mark-projection-dirty! :live-frame/flush-projection!])
+
+(defn- reset-runtime [test-fn]
+  (let [hooks-before     @@registration-hooks
+        late-bind-before @late-bind/hooks
+        flag-before      @@installed-flag]
+    (try
+      (registrar/clear-all!)
+      (reset! frame/frames {})
+      (flows/reset-flows!)
+      (schemas/clear-schemas-by-frame!)
+      (trace/clear-listeners!)
+      (rf/init! plain-atom/adapter)
+      ;; Framework registrations live at namespace-load time; `clear-all!` wiped
+      ;; them. Re-eval so the rest of the suite is not left short.
+      (require 're-frame.routing :reload)
+      (require 're-frame.ssr :reload)
+      ;; Rewind the once-initialization AFTER those reloads (a reload re-adds
+      ;; the artefact's own registration hooks): drop ONLY the reprojection
+      ;; hook, un-publish ONLY the two late-bind keys the once-body owns, and
+      ;; clear the flag. Anything else in the vector / hook map is left alone.
+      (swap! @registration-hooks
+             (fn [hs] (vec (remove #{live-frame/reproject-on-registration-change!} hs))))
+      (swap! late-bind/hooks #(apply dissoc % published-keys))
+      (run! late-bind/invalidate-cache! published-keys)
+      (reset! @installed-flag false)
+      (test-fn)
+      (finally
+        (reset! @registration-hooks hooks-before)
+        (reset! late-bind/hooks late-bind-before)
+        (run! late-bind/invalidate-cache! published-keys)
+        (reset! @installed-flag flag-before)
+        (registrar/clear-all!)
+        (reset! frame/frames {})))))
+
+(use-fixtures :each reset-runtime)
+
+;; A latch we expect to FIRE waits this long; the fix makes every such wait
+;; return promptly, so the number only bounds a hang.
+(def ^:private ^:const settle-ms 10000)
+
+;; A latch we expect NOT to fire waits this long. With the fix the second caller
+;; is parked on a monitor the barriered installer holds, so no value of this
+;; number can produce a false failure; without the fix it returns immediately,
+;; so no value can produce a false pass either.
+(def ^:private ^:const window-ms 2000)
+
+(defn- await! [^CountDownLatch latch ^long ms]
+  (.await latch ms TimeUnit/MILLISECONDS))
+
+;; ---------------------------------------------------------------------------
+;; 1. The audit's reproduction: park at the FIRST side effect (the registrar
+;;    registration hook) and show the second frame go permanently stale.
+;; ---------------------------------------------------------------------------
+
+(deftest install-boundary-not-passable-before-the-registration-hook
+  (testing "a second make-frame cannot observe the reprojection as installed
+            while the elected installer is still adding the registrar hook"
+    (let [add-hook!  registrar/add-registration-hook!
+          at-barrier (CountDownLatch. 1)   ;; installer A has parked mid-install
+          release    (CountDownLatch. 1)   ;; …and may now finish
+          b-started  (CountDownLatch. 1)   ;; contender B's thread is running
+          b-returned (CountDownLatch. 1)   ;; …and its make-frame has returned
+          b-saw      (atom nil)
+          runs       (atom 0)
+          dispatch-throw (atom nil)]
+      (rf/reg-event :audit/early (fn [{:keys [db]} _] {:db (assoc db :early true)}))
+      (with-redefs [registrar/add-registration-hook!
+                    (fn [f]
+                      ;; Park INSIDE the once-body, before the first of the
+                      ;; three side effects lands.
+                      (.countDown at-barrier)
+                      (await! release settle-ms)
+                      (add-hook! f))]
+        (let [a (future (rf/make-frame {:id :audit/a :doc "the elected installer"}))
+              _ (is (await! at-barrier settle-ms)
+                    "the elected installer parked inside ensure-reprojection-installed!")
+              b (future
+                  (.countDown b-started)
+                  (rf/make-frame {:id :audit/b :doc "the concurrent contender"})
+                  ;; What the contender can SEE the instant its frame exists —
+                  ;; i.e. the instant its generation is sealed and resolvable.
+                  (reset! b-saw {:hook?  (reprojection-hook-installed?)
+                                 :mark?  (some? (late-bind/get-fn :live-frame/mark-projection-dirty!))
+                                 :flush? (some? (late-bind/get-fn :live-frame/flush-projection!))})
+                  ;; The `reg-*` that must reach the just-sealed generation.
+                  (rf/reg-event :audit/late
+                    (fn [{:keys [db]} _]
+                      (swap! runs inc)
+                      {:db (assoc db :late :ran)}))
+                  (.countDown b-returned)
+                  :done)]
+          (is (await! b-started settle-ms) "the contender thread started")
+
+          ;; THE INVARIANT. The contender must NOT be able to complete
+          ;; construction while the installer is parked mid-install.
+          (is (not (await! b-returned window-ms))
+              (str "a concurrent make-frame passed the install boundary while the "
+                   "elected installer was still between the once-flag and the "
+                   "registrar hook — it sealed a generation with no hook behind it"))
+
+          (.countDown release)
+          (is (await! b-returned settle-ms) "the contender completed once released")
+          (is (= :done (deref b settle-ms ::timeout)) "contender thread finished")
+          (is (some? (deref a settle-ms ::timeout)) "installer thread finished")
+
+          ;; Everything the flag promises was in place when the contender
+          ;; observed it — including the removal twin the registrar's
+          ;; `unregister!` / `clear-kind!` / `clear-all!` paths consult.
+          (is (= {:hook? true :mark? true :flush? true} @b-saw)
+              "the contender observed the FULL wiring, not a partial install")
+
+          ;; And the end state: the contender's frame is NOT stale. A handler
+          ;; registered after its construction resolves on the very next
+          ;; dispatch into it.
+          (try
+            (rf/dispatch-sync [:audit/late] {:frame :audit/b})
+            (catch Throwable t (reset! dispatch-throw t)))
+          (is (nil? @dispatch-throw)
+              (str "dispatch into the contender's frame threw: " @dispatch-throw))
+          (is (= 1 @runs)
+              "the handler registered after the contender's make-frame ran exactly once")
+          (is (= :ran (:late (rf/app-db-value :audit/b)))
+              "the contender's frame is not permanently stale"))))))
+
+;; ---------------------------------------------------------------------------
+;; 2. Park at the LAST side effect — the `:live-frame/flush-projection!`
+;;    publication, whose twin `:live-frame/mark-projection-dirty!` is the
+;;    registrar REMOVAL late-bind. Even the final publication must precede
+;;    observability.
+;; ---------------------------------------------------------------------------
+
+(deftest install-boundary-not-passable-before-the-flush-late-bind
+  (testing "a second make-frame cannot observe the reprojection as installed
+            while the elected installer is still publishing the late-bind keys"
+    (let [set-fn!    late-bind/set-fn!
+          at-barrier (CountDownLatch. 1)
+          release    (CountDownLatch. 1)
+          b-started  (CountDownLatch. 1)
+          b-returned (CountDownLatch. 1)
+          b-saw      (atom nil)]
+      (with-redefs [late-bind/set-fn!
+                    (fn [k f]
+                      ;; Park just before the LAST of the three side effects:
+                      ;; the hook is added and the removal twin is published,
+                      ;; only the read-time flush consult is outstanding.
+                      (when (= k :live-frame/flush-projection!)
+                        (.countDown at-barrier)
+                        (await! release settle-ms))
+                      (set-fn! k f))]
+        (let [a (future (rf/make-frame {:id :audit.flush/a}))
+              _ (is (await! at-barrier settle-ms)
+                    "the elected installer parked before the last publication")
+              b (future
+                  (.countDown b-started)
+                  (rf/make-frame {:id :audit.flush/b})
+                  (reset! b-saw {:hook?  (reprojection-hook-installed?)
+                                 :mark?  (some? (late-bind/get-fn :live-frame/mark-projection-dirty!))
+                                 :flush? (some? (late-bind/get-fn :live-frame/flush-projection!))})
+                  (.countDown b-returned)
+                  :done)]
+          (is (await! b-started settle-ms) "the contender thread started")
+          (is (not (await! b-returned window-ms))
+              (str "a concurrent make-frame passed the install boundary with the "
+                   ":live-frame/flush-projection! consult still unpublished — its "
+                   "frame would resolve without ever flushing a dirty projection"))
+          (.countDown release)
+          (is (await! b-returned settle-ms) "the contender completed once released")
+          (is (= :done (deref b settle-ms ::timeout)) "contender thread finished")
+          (is (some? (deref a settle-ms ::timeout)) "installer thread finished")
+          (is (= {:hook? true :mark? true :flush? true} @b-saw)
+              "the contender observed the FULL wiring, not a partial install"))))))


### PR DESCRIPTION
Closes the merged-PR-#7114 audit reopen of **rf2-9c2jf**.

## The defect

`re-frame.live-frame/ensure-reprojection-installed!` published its once-flag on the way **in**:

```clj
(when (compare-and-set! reprojection-installed? false true)   ;; publish FIRST
  (registrar/add-registration-hook! reproject-on-registration-change!)
  (late-bind/set-fn! :live-frame/mark-projection-dirty! ...)
  (late-bind/set-fn! :live-frame/flush-projection!      ...))
```

The docstring claimed CAS made a concurrent `make-frame` burst safe. It does not. **CAS elects one installer; it does not make the losers wait for that installer's side effects to land.** A second `make-frame` on another thread reads the flag as `true` while the elected installer is still between the CAS and `add-registration-hook!`, concludes the wiring is in place, and **seals its generation** — the seal `registrar/lookup` resolves every `(kind, id)` through. A `reg-event` issued in that window fires **no hook, because no hook exists yet**. When the installer finally finishes there is **no dirty mark left for anything to flush**, so that frame stays **permanently stale**: `dispatch` reports `:rf.error/no-such-handler` for a handler `registrar/lookup` is holding at that very moment.

That is the original rf2-9c2jf release blocker, recreated with **no debug gate in sight**.

## The ordering fix

The whole once-body — flag read, three side effects, flag write — is now **one critical section** under a new `reprojection-install-lock`, and the flag is **published last**. A concurrent caller therefore either performs the install or **blocks until the elected installer has finished it**; `true` now means what every reader of it already assumed: all three side effects are in place.

Publishing last is also **failure-atomic**: a throw in a side effect leaves the flag `false` and the next `make-frame` retries, instead of the wiring being permanently missing behind a `true` flag.

**Deadlock-free by construction.** The body calls only `registrar/add-registration-hook!` and `late-bind/set-fn!` — three bookkeeping `swap!`s that run no user code, take no other monitor (in particular **not** `projection-flush-lock`), and never re-enter `make-frame`. The monitor is released before `make-frame` does anything else, so `:initial-events` draining and read-time flushes never run underneath it.

**JVM only.** CLJS is single-threaded — no caller can observe the once-body mid-flight — so that path stays lock-free and carries only the publish-last ordering.

**Reachability/DCE design unchanged**, and no general initialization framework: the sole publisher is still reached only from `make-frame`, so a bundle that never constructs a frame still folds the reprojection + image-assembly graph away (`check-elision.cjs` `PROD_ABSENT_WHEN_UNUSED`).

**No spec promise moves.** Frame construction and late-bind installation promise exactly what they promised before; this makes the promise true under concurrency. Nothing under `spec/` is touched.

## Reproduction, before and after

`implementation/core/test/re_frame/reprojection_install_race_jvm_test.clj` — two deterministic `with-redefs` barrier tests that park the elected installer inside the once-body and assert a concurrent `make-frame` cannot pass the boundary. One parks at the **first** side effect (the registrar hook) and pins the full stale-frame end state; one parks at the **last** (`:live-frame/flush-projection!`, whose twin `:live-frame/mark-projection-dirty!` is the registrar **removal** late-bind). The fixture snapshots and restores the three pieces of process state the once-body writes, so each test opens the same window a fresh JVM's first `make-frame` opens.

No sleep decides anything. The negative assertion ("the contender has not returned") is the one the fix makes *impossible* to violate — with the fix the contender is parked on a monitor the barriered installer holds until the test releases it; without the fix it returns in microseconds.

**BEFORE** the fix (at commit `50de1b4`, `clojure -M:test -n re-frame.reprojection-install-race-jvm-test`) — **exit 1**, 6 failures / 17 assertions:

```
FAIL a concurrent make-frame passed the install boundary while the elected installer was
     still between the once-flag and the registrar hook - it sealed a generation with no
     hook behind it
FAIL the contender observed the FULL wiring, not a partial install
     expected: {:hook? true, :mark? true, :flush? true}
       actual: {:hook? false, :mark? false, :flush? false}
FAIL the handler registered after the contender's make-frame ran exactly once
     expected: (= 1 0)
FAIL the contender's frame is not permanently stale
     expected: (= :ran nil)
FAIL a concurrent make-frame passed the install boundary with the
     :live-frame/flush-projection! consult still unpublished
     expected: {:hook? true, :mark? true, :flush? true}
       actual: {:hook? true, :mark? true, :flush? false}

Ran 2 tests containing 17 assertions.
6 failures, 0 errors.
```

**AFTER** the fix (at commit `be6aeb3`) — **exit 0**:

```
Ran 2 tests containing 17 assertions.
0 failures, 0 errors.
```

## Quality gates

Foreground, unpiped, from `C:/Users/miket/code/re-frame2-worktrees/reproj-race-9c2jf`.

| gate | command | exit | result |
|---|---|---|---|
| reproduction, pre-fix | `clojure -M:test -n re-frame.reprojection-install-race-jvm-test` @ `50de1b4` | **1** | 6 failures / 17 assertions — the stale frame, reproduced |
| reproduction, post-fix | `clojure -M:test -n re-frame.reprojection-install-race-jvm-test` @ `be6aeb3` | **0** | 2 tests / 17 assertions / 0 failures |
| core, dev posture | `cd implementation/core && clojure -M:test` | **0** | 2155 tests / 10700 assertions / 0 failures |
| core, production gate | `bash scripts/test-core-prod-gate.sh` | **0** | 100 namespaces / 1188 tests / 5485 assertions / 0 failures |
| `^:stress` concurrency lane | `cd implementation/core && clojure -M:test:slow-test` | **0** | 4 tests / 8 assertions / 0 failures |

The **transitive surface** is covered: `egress_chokepoint_conformance_test.clj` source-scans every artefact's `src/` tree as text, and this diff edits core `src/`, so both core lanes above exercised it. Both went green.

The prod-gate lane **grew** rather than regressed — 99 to 100 namespaces, 1186 to 1188 tests, 5468 to 5485 assertions. The new namespace joined the lane by default (the roster is an exclusion list) and passes under the real `-Dre-frame.debug=false`. The lane-size figures in `scripts/test-core-prod-gate.sh`'s header comment are consequently one namespace stale; deliberately not edited here — that file is being actively rewritten by the roster-shrinking beads (rf2-o5dbf, rf2-lwtlk) and a cosmetic count bump is not worth the conflict.

**Deferred to CI:** the CLJS lanes (`npm run test:cljs`, the `check-elision.cjs` `PROD_ABSENT_WHEN_UNUSED` probe) and the rest of the spine. The CLJS-visible delta is five lines using only `when-not` / `reset!` / a private `defn`; the `#?(:clj ...)` monitor is invisible to ClojureScript, matching the existing `projection-flush-lock` idiom in the same namespace.

## Follow-up filed, not fixed here

A **distinct** residual window in `make-frame` itself, out of this bead's scope: the generation is sealed at the top of the `let` but the record is not written until `frame/upsert-frame!` further down. A `reg-*` racing that gap fires the registration hook while `(seq (live-frame-ids))` is still empty, so `mark-dirty-and-schedule!` skips, and the frame lands carrying a generation that predates the registration with nothing left to flush it. Filed separately rather than folded in.
