### PR TITLE
feat(freehand): the executable fixture spine and workshop roster (rf2-drpa3.182.7)

### DIFF
--- a/implementation/freehand/test/re_frame/freehand/roster.cljc
+++ b/implementation/freehand/test/re_frame/freehand/roster.cljc
@@ -30,9 +30,49 @@
 
   The join is likewise a READ, not a copy. `:modes`, `:hosts`, `:status`
   and `:paragraph` are parsed out of the index row at macro-expansion time
-  and are never restated in the fixture — and [[defects]] fails a fixture
-  whose `:fh/law` disagrees with the index's, so the two files cannot drift
-  apart quietly.
+  and are never restated in the fixture.
+
+  What is NOT checked, and deliberately: that a fixture's `:fh/law` matches
+  its index row's word for word. The two state the same law at different
+  lengths on purpose — the row is the addressed one-line statement, the
+  fixture's is the header over the values below it — and every row in the
+  ledger is written that way, so gating equality would force a hundred
+  prose rewrites to satisfy a law the corpus never held. The relationship
+  the join DOES hold is the id: a fixture whose `:fh/id` disagrees with the
+  file it is filed under, or with a row the index does not carry, is a
+  COMPILE failure in [[read-roster]] rather than a record that quietly
+  drops out.
+
+  ## Enrolling — a witness adds no line to any shared file
+
+  Membership is a property of the FIXTURE: a law is rostered exactly when
+  its fixture carries `:fh/record`. Nothing here lists the members, so the
+  roster grows without a shared file to edit — which matters because the
+  control witnesses (rf2-drpa3.182.8 through .12) land in parallel, and a
+  hand-maintained membership vector would have made five workers queue
+  behind one line of it.
+
+  So a witness writes, in ITS OWN files only:
+
+    1. a row in the conformance index addressing its id, with a fixture
+       path and status `active` (the index owns addressing — see that
+       directory's `README.md`);
+    2. `:fh/record` on its fixture, naming `:source`, `:evidence`, `:prose`
+       and at least one proof tier;
+    3. the suites that tier names.
+
+  Then every projection below carries it, and every rule below holds it.
+  The ones a new record meets first:
+
+    * a proof namespace RESOLVES to a file, and CITES its own id in its
+      text (`roster-jvm-test`), so the vertical is legible from both ends;
+    * a `:mounted` tier names a `-dom-cljs-test` namespace — the suffix
+      the browser lane selects on — and a `:structural` tier does not;
+    * a tier the index row's host axis rules out is a defect, so a record
+      cannot advertise a browser proof for a JVM-only law;
+    * `:residue :none` is refused unless the mounted proof CALLS the
+      shared residue assertion (see [[residue-statuses]]);
+    * and every message names the id.
 
   ## Failures name the id
 
@@ -50,6 +90,15 @@
   [[re-frame.freehand.conformance/fixture]] reads a fixture and for the
   same cache-invalidation reason. The JVM suite and the ClojureScript suite
   therefore project the same bytes.
+
+  Enrolment-by-discovery makes the read WIDER than the roster: every
+  fixture the index names is read, because whether a fixture carries a
+  record is a question only its bytes answer. That width is what makes the
+  cache edge hold in both directions — adding a row to the index
+  invalidates through the index, and adding `:fh/record` to a fixture that
+  was already addressed invalidates through that fixture — where a read
+  scoped to the members would have registered a dependency only on files
+  that were ALREADY members and missed every new one.
 
   ### The cache edge, MEASURED rather than inherited
 
@@ -119,7 +168,10 @@
 
     `:none`        the mounted suites assert the absence: after teardown the
                    substrate's own books read empty, as an exact zero rather
-                   than a threshold.
+                   than a threshold. Every mounted projection of the record
+                   must CALL `re-frame.freehand.mount-support/residue-clean!`
+                   — the one shared assertion, checked as a call site rather
+                   than as text that resembles one (`roster-jvm-test`).
     `:unasserted`  the suites tear their roots down but assert nothing about
                    residue. An honest gap, and countable.
 
@@ -156,12 +208,20 @@
   #{:source :structural :mounted :ssr :evidence :open :prose})
 
 (def ^:private required-record-keys
-  "Every record names its canonical source and its prose status. The tier
-  entries are optional because a law that binds only on one tier should say
-  so by omission rather than by an empty placeholder — but [[defects]]
-  requires at least one tier, so a record cannot claim a law is executable
-  and name nowhere it executes."
-  #{:source :prose})
+  "Every record names its canonical source, what a run LEAVES BEHIND, and
+  its prose status. The tier entries are optional because a law that binds
+  only on one tier should say so by omission rather than by an empty
+  placeholder — but [[defects]] requires at least one tier, so a record
+  cannot claim a law is executable and name nowhere it executes.
+
+  `:evidence` is required rather than merely validated-when-present, and
+  the difference is the whole point of the key. A record that omitted it
+  would be making no claim about residue at all, while the roster's own
+  narration says every record declares one — so a future member could have
+  slipped past the residue rule by saying nothing, with the gate green
+  (merged-PR audit #7098). Saying `:unasserted` is the honest way to
+  decline; saying nothing is not one."
+  #{:source :evidence :prose})
 
 ;; ---------------------------------------------------------------------------
 ;; Applicability — the index's two-axis cell, as data
@@ -351,31 +411,43 @@
    :mounted    #{:browser}
    :ssr        #{:ssr}})
 
+(defn tier-hosts-of
+  "The index row's host axis, reduced to the plain hosts a TIER runs on.
+
+  A qualified boundary — `host:vega`, `host:google-maps` — reads as
+  `[:host \"…\"]` so its name survives the parse, and it names a foreign
+  door that exists only in a browser. So it counts as `:browser` here and
+  nowhere else: a law narrowed to a named third-party host is still
+  browser-bound, and a record proving it in a mounted suite is making the
+  only claim available to it. Without this the ownership-routing witnesses
+  — whose rows are exactly the `host:<name>` ones — could not declare the
+  mounted tier they live on."
+  [hosts]
+  (into #{} (map (fn [h] (if (vector? h) :browser h))) hosts))
+
 (defn- join-defects
   "The defects that are properties of the JOIN — a record read against the
   index row that addresses it.
 
-  Only one law is stated here, and deliberately only one. It is tempting to
-  also require that a fixture's `:fh/law` match its index row's word for
-  word, and that would be wrong: the two say the same law at different
-  lengths on purpose — the index row is the addressed one-line statement, a
-  fixture's `:fh/law` is the header over the values below it — and every
-  row in the ledger is written that way. Gating equality would force a
-  hundred prose rewrites to satisfy a law the corpus never held.
-
-  What IS checkable is that a record does not claim a tier the ledger's
-  host axis rules out."
+  One law is stated here: a record does not claim a tier the ledger's host
+  axis rules out. The other relationship between the two files — that they
+  address the same id — is held earlier and harder, as a COMPILE failure in
+  [[read-roster]], so by the time a record reaches here the id is not in
+  question. What is deliberately never compared is the two prose statements;
+  see this namespace's docstring for why byte equality would be the wrong
+  law."
   [{id :fh/id :keys [hosts fh/record]}]
   (when (and (map? record) (set? hosts))
-    (keep (fn [[t possible]]
-            (when (and (contains? record t)
-                       (empty? (set/intersection hosts possible)))
-              (defect id t
-                      (str "claims a " (name t) " proof, but the index row binds "
-                           "this law to " (pr-str (sort-by str hosts))
-                           " — that tier can only run on "
-                           (pr-str (sort-by str possible)) "."))))
-          tier-hosts)))
+    (let [reachable (tier-hosts-of hosts)]
+      (keep (fn [[t possible]]
+              (when (and (contains? record t)
+                         (empty? (set/intersection reachable possible)))
+                (defect id t
+                        (str "claims a " (name t) " proof, but the index row binds "
+                             "this law to " (pr-str (sort-by str hosts))
+                             " — that tier can only run on "
+                             (pr-str (sort-by str possible)) "."))))
+            tier-hosts))))
 
 (defn roster-defects
   "Every defect across `records`, plus the two that are properties of the
@@ -404,9 +476,20 @@
      "conformance/freehand/conformance-index.md"))
 
 #?(:clj
+   (def ^:private fixture-cell-prefix
+     "The Fixture cell is written repo-relative in backticks; `spec-resource`
+     resolves against `spec/` itself. Trimming the root here is what keeps
+     the index the single place a fixture path is spelled."
+     "spec/conformance/freehand/fixtures/"))
+
+#?(:clj
    (defn- fixture-path
-     [id]
-     (str "conformance/freehand/fixtures/" (str/lower-case id) ".edn")))
+     "The `spec-resource` path the row's Fixture cell names, or nil where it
+     names none — a `planned` or `retired` row writes `—` there."
+     [cell]
+     (let [c (str/replace (str/trim (or cell "")) "`" "")]
+       (when (str/starts-with? c fixture-cell-prefix)
+         (subs c (count "spec/"))))))
 
 #?(:clj
    (defn- index-rows
@@ -429,70 +512,88 @@
                        (when (>= (count cells) 6)
                          (let [id (str/replace (nth cells 0) "`" "")]
                            (when (re-matches #"FH-[A-Z]+-\d{3}" id)
-                             [id {:fh/id      id
-                                  :index/law  (nth cells 1)
-                                  :paragraph  (nth cells 2)
-                                  :index/cell (nth cells 3)
-                                  :status     (keyword (nth cells 5))}])))))))
+                             [id {:fh/id         id
+                                  :index/law     (nth cells 1)
+                                  :paragraph     (nth cells 2)
+                                  :index/cell    (nth cells 3)
+                                  :index/fixture (nth cells 4)
+                                  :status        (keyword (nth cells 5))}])))))))
            (str/split-lines text))))
 
 #?(:clj
-   (defn ^:no-doc read-roster
-     "Join the fixtures for `ids` with their index rows, in the
-     macro-expansion environment `env`.
+   (defn- join-row
+     "One row joined with the fixture it names, or nil when that fixture
+     carries no `:fh/record` — which is how a law declines enrolment.
 
-     Throws when an id is absent from the index, when its fixture is
-     missing or misfiled, or when its applicability cell will not parse.
-     Those are COMPILE failures on purpose: a roster that quietly shrank to
-     the ids it could resolve would let a suite pass over a law it stopped
-     loading, which is the worst failure a table-driven gate can have."
-     [env ids]
+     Throws when the fixture and the row disagree about the id, or when the
+     row's applicability cell will not parse. Those are COMPILE failures on
+     purpose: a roster that quietly shrank to the records it could resolve
+     would let a suite pass over a law it stopped loading, which is the
+     worst failure a table-driven gate can have."
+     [env {:keys [fh/id index/cell index/fixture] :as row}]
+     (when-let [path (fixture-path fixture)]
+       (let [fix (edn/read-string (spec-resource/slurp-resource env path))]
+         (when (:fh/record fix)
+           (when-not (= id (:fh/id fix))
+             (throw (ex-info (str "Freehand roster: " path " is named by index row " id
+                                  " but declares :fh/id " (pr-str (:fh/id fix))
+                                  " — the file and the id disagree.")
+                             {:fh/id id :declared (:fh/id fix)})))
+           (let [app (or (parse-applicability cell)
+                         (throw (ex-info (str "Freehand roster: " id " has an "
+                                              "unparseable applicability cell "
+                                              (pr-str cell) ".")
+                                         {:fh/id id})))]
+             (merge (dissoc row :index/cell :index/fixture)
+                    app
+                    (select-keys fix [:fh/id :fh/law :fh/record]))))))))
+
+#?(:clj
+   (defn ^:no-doc read-roster
+     "Every enrolled record, joined with its index row, in the
+     macro-expansion environment `env` — id-sorted, so the value is stable
+     across filesystems and a diff of it reads.
+
+     Enrolment is DISCOVERED rather than listed: every fixture the index
+     names is read, and the ones carrying `:fh/record` are the roster. A
+     witness therefore enrols by editing its own two files and no shared
+     one — see this namespace's docstring."
+     [env]
      (let [rows (index-rows (spec-resource/slurp-resource env index-path))]
-       (mapv (fn [id]
-               (let [id  (name id)
-                     row (or (get rows id)
-                             (throw (ex-info (str "Freehand roster: " id " is not a row of "
-                                                  index-path " — an id must be addressed "
-                                                  "before it can be rostered.")
-                                             {:fh/id id})))
-                     fix (edn/read-string
-                           (spec-resource/slurp-resource env (fixture-path id)))
-                     app (or (parse-applicability (:index/cell row))
-                             (throw (ex-info (str "Freehand roster: " id " has an "
-                                                  "unparseable applicability cell "
-                                                  (pr-str (:index/cell row)) ".")
-                                             {:fh/id id})))]
-                 (when-not (= id (:fh/id fix))
-                   (throw (ex-info (str "Freehand roster: fixture for " id " declares :fh/id "
-                                        (pr-str (:fh/id fix)) " — the file and the id disagree.")
-                                   {:fh/id id :declared (:fh/id fix)})))
-                 (merge (dissoc row :index/cell)
-                        app
-                        (select-keys fix [:fh/id :fh/law :fh/record]))))
-             ids))))
+       (into [] (comp (map val) (keep #(join-row env %)))
+             (sort-by key rows)))))
 
 #?(:clj
    (defmacro roster
-     "Inline the joined roster records for `ids` as a quoted literal, read
-     at macro-expansion time.
-
-         (def spine (roster [:FH-REACT-007 :FH-CTRL-018 :FH-BEHAVIOR-005]))
+     "Inline every enrolled roster record as a quoted literal, read at
+     macro-expansion time.
 
      Identical data on the JVM and in ClojureScript, and — in
-     ClojureScript — a build dependency of the calling namespace, so an
-     edit to the index or to any rostered fixture recompiles this call
-     site."
-     [ids]
-     (list 'quote (read-roster &env ids))))
+     ClojureScript — a build dependency of the calling namespace on the
+     index AND on every fixture the index names, so adding a row, or adding
+     a record to a fixture already addressed, recompiles this call site."
+     []
+     (list 'quote (read-roster &env))))
 
 ;; ---------------------------------------------------------------------------
-;; The spine — the members rf2-drpa3.182.7 integrates
+;; The roster
 ;; ---------------------------------------------------------------------------
 
-(def spine-ids
-  "The three vertical fixtures the initial spine integrates, per
-  rf2-drpa3.182.7 §INITIAL SPINE — the declared host, the serious form, and
-  the deferred foreign-handle surrogate.
+(def records
+  "Every enrolled record — the value every projection of the roster reads,
+  on both hosts, id-sorted."
+  (roster))
+
+(def ids
+  "The ids of [[records]], in the same order. Strings, as they appear in
+  the index and in every failure message."
+  (mapv :fh/id records))
+
+(def initial-spine-ids
+  "The three vertical fixtures rf2-drpa3.182.7 §INITIAL SPINE integrates —
+  the declared host, the serious form, and the deferred foreign-handle
+  surrogate. Named because acceptance 2 is about THESE three running
+  through one roster; the roster itself is [[ids]], which grows past them.
 
   The surrogate is rostered as `FH-BEHAVIOR-005` rather than under an id of
   its own, and that is the point of it: the recipe adds no verb, no
@@ -501,21 +602,12 @@
   Promise-returning third-party initializer — the shape where a release can
   arrive after the owner is gone. Minting a second id for the same law
   would have split one identity in exactly the way this roster exists to
-  prevent.
-
-  Named as data so a projection can assert enrolment. The roster grows for
-  Maps, Framer Motion, SpreadJS, Radix and the control witnesses as those
-  slices land; this vector is the seam they extend."
-  [:FH-REACT-007 :FH-CTRL-018 :FH-BEHAVIOR-005])
-
-(def spine
-  "The joined roster records for [[spine-ids]] — the value every projection
-  of the spine reads, on both hosts."
-  (roster [:FH-REACT-007 :FH-CTRL-018 :FH-BEHAVIOR-005]))
+  prevent."
+  ["FH-BEHAVIOR-005" "FH-CTRL-018" "FH-REACT-007"])
 
 (defn by-id
   "The rostered record for `id` (a string or keyword), or nil."
-  ([id] (by-id spine id))
+  ([id] (by-id records id))
   ([records id]
    (let [id (name id)]
      (first (filter #(= id (:fh/id %)) records)))))

--- a/implementation/freehand/test/re_frame/freehand/roster.cljc
+++ b/implementation/freehand/test/re_frame/freehand/roster.cljc
@@ -127,10 +127,28 @@
   mutation itself, arriving through the cache. The edge holds in both
   directions.
 
-  If a future change makes step 2 pass, the roster has decoupled from the
-  index. The fix is to restore the dependency edge; it is NOT to clear the
-  cache, because clearing the cache is the broken state's own behaviour and
-  hides exactly the defect being looked for.
+  Enrolment-by-discovery widened that read to every fixture the index
+  names, and the widening was measured the same way rather than assumed —
+  it is a stronger claim than the first, because it is about a file the
+  roster had NEVER read:
+
+      1. warm cache, unmodified          1311 tests, 0 failures   (3 compiled)
+      2. `:fh/record` added to
+         `fh-call-001.edn`, a law that
+         was not enrolled and whose
+         fixture nothing here had read,
+         `.shadow-cljs` left alone       3 rows red               (3 compiled)
+      3. reverted, cache still warm      1311 tests, 0 failures   (3 compiled)
+
+  Step 2 red on `enrolment-is-a-property-of-the-fixture`, on
+  `the-roster-is-sound` and on the resolution rows, every message naming
+  FH-CALL-001 — a record ARRIVING through the cache, which is the case a
+  witness creates the first time it enrols.
+
+  If a future change makes either step 2 pass, the roster has decoupled
+  from the file it read. The fix is to restore the dependency edge; it is
+  NOT to clear the cache, because clearing the cache is the broken state's
+  own behaviour and hides exactly the defect being looked for.
 
   Dev/test scope ONLY. This namespace lives under `test/` and nothing in a
   production bundle may reach it."

--- a/implementation/freehand/test/re_frame/freehand/roster_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/roster_cljs_test.cljc
@@ -61,7 +61,22 @@
     (is (every? (set roster/ids) roster/initial-spine-ids)
         "the initial spine is enrolled")
     (is (= roster/ids (sort roster/ids))
-        "and the roster is id-ordered, so its value is stable to read and diff")))
+        "and the roster is id-ordered, so its value is stable to read and diff"))
+
+  (testing "NON-VACUITY for discovery itself, which is the row that matters
+            most about it. The conformance index carries a hundred laws
+            with fixtures; a reader that enrolled every fixture it could
+            open would satisfy every membership assertion above and make
+            the whole roster meaningless, and it would do it QUIETLY —
+            each of those records would simply be reported missing a
+            `:fh/record`. So the discriminating half is asserted directly:
+            a law whose fixture carries no record is NOT rostered."
+    (is (nil? (roster/by-id :FH-CALL-001))
+        "FH-CALL-001 is an active law with a fixture and no roster record")
+    (is (nil? (roster/by-id :FH-PROPS-001))
+        "and so is FH-PROPS-001")
+    (is (nil? (roster/by-id :FH-EVENT-005))
+        "a retired law, whose row names no fixture at all, is not rostered either")))
 
 (deftest every-rostered-record-carries-its-whole-identity
   (testing "Per rf2-drpa3.182.7 acceptance 1: one record answers every

--- a/implementation/freehand/test/re_frame/freehand/roster_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/roster_cljs_test.cljc
@@ -27,22 +27,41 @@
 ;; Enrolment — the spine is the three vertical fixtures, and it is complete
 ;; ---------------------------------------------------------------------------
 
-(deftest the-spine-is-enrolled-and-nothing-loaded-empty
+(deftest the-initial-spine-is-enrolled-and-nothing-loaded-empty
   (testing "Per rf2-drpa3.182.7 §INITIAL SPINE: the declared host, the
             serious form and the deferred foreign-handle surrogate are all
-            rostered, and each resolved to a real joined record. A roster
-            that quietly shrank to the ids it could resolve would let this
-            suite pass over a law it stopped loading — the worst failure a
-            table-driven gate has — so the COUNT is asserted alongside the
-            membership."
-    (is (= 3 (count roster/spine))
-        "three records, one per spine member")
-    (is (= #{"FH-REACT-007" "FH-CTRL-018" "FH-BEHAVIOR-005"}
-           (set (map :fh/id roster/spine)))
-        "and they are the three the spine names")
-    (doseq [id roster/spine-ids]
+            rostered, and each resolved to a real joined record.
+
+            Membership is DISCOVERED — a law is rostered exactly when its
+            fixture carries `:fh/record` — so this row states a floor and
+            not a total: the control witnesses enrol by editing their own
+            fixtures, and a row asserting `(= 3 (count …))` would have made
+            each of them edit this file to land. What still has to hold is
+            that discovery found something and found THESE: a roster that
+            quietly shrank to the records it could resolve would let this
+            suite pass over a law it stopped loading, which is the worst
+            failure a table-driven gate has."
+    (is (seq roster/records) "discovery enrolled something at all")
+    (is (= (count roster/records) (count (set roster/ids)))
+        "and every enrolled record has a distinct id")
+    (doseq [id roster/initial-spine-ids]
       (is (some? (roster/by-id id))
-          (str (name id) " resolves to a rostered record")))))
+          (str id " resolves to a rostered record")))))
+
+(deftest enrolment-is-a-property-of-the-fixture
+  (testing "Per rf2-drpa3.182.7 §INITIAL SPINE, and what makes the roster
+            EXTENSIBLE rather than a list: `roster/ids` is derived from the
+            fixtures that carry a record, not authored. So a witness enrols
+            by writing its own index row and its own `:fh/record`, and the
+            five control witnesses can land in parallel without queueing
+            behind one line of a shared vector.
+
+            The initial three are a SUBSET of the roster, and stating that
+            as `every?` rather than as equality is the whole difference."
+    (is (every? (set roster/ids) roster/initial-spine-ids)
+        "the initial spine is enrolled")
+    (is (= roster/ids (sort roster/ids))
+        "and the roster is id-ordered, so its value is stable to read and diff")))
 
 (deftest every-rostered-record-carries-its-whole-identity
   (testing "Per rf2-drpa3.182.7 acceptance 1: one record answers every
@@ -54,7 +73,7 @@
             lost one of them names WHICH."
     (doseq [{id :fh/id law :fh/law index-law :index/law record :fh/record
              :keys [paragraph modes hosts status]}
-            roster/spine]
+            roster/records]
       (is (seq law)          (str id " states its law"))
       (is (seq index-law)    (str id " is addressed by an index row"))
       (is (seq paragraph)    (str id " cites a canonical spec paragraph"))
@@ -63,16 +82,28 @@
       (is (= :active status) (str id " is an active law"))
       (is (seq (:source record))
           (str id " names the source it is a law about"))
+      (is (seq (:evidence record))
+          (str id " states what a run leaves behind"))
       (is (contains? roster/prose-statuses (:prose record))
           (str id " declares the status of the prose describing it")))))
 
 (deftest the-roster-is-sound
   (testing "Per rf2-drpa3.182.7 acceptance 1: the whole roster validates —
-            no malformed record, no duplicated id, and no fixture whose
-            `:fh/law` has drifted from the index row that addresses it. The
-            failure message is the defect list itself, so a red row reads as
-            a sentence about a law."
-    (let [ds (roster/roster-defects roster/spine)]
+            no malformed record, no duplicated id, and no record claiming a
+            proof tier the index row's host axis rules out. The failure
+            message is the defect list itself, so a red row reads as a
+            sentence about a law.
+
+            NOT among those, and stated here because a previous version of
+            this narration claimed it (merged-PR audit #7098): the fixture's
+            `:fh/law` and the index row's are never compared. They say the
+            same law at different lengths by convention, so equality would
+            be the wrong law — and a gate whose prose claims a check it does
+            not perform is worse than no check, because a reader stops
+            looking. The relationship the two files DO hold is the id, and
+            it is held harder than a defect: a fixture whose `:fh/id`
+            disagrees with the row that names its file fails the COMPILE."
+    (let [ds (roster/roster-defects roster/records)]
       (is (= [] ds) (str "roster defects:\n" (pr-str ds))))))
 
 ;; ---------------------------------------------------------------------------
@@ -87,7 +118,7 @@
             it carries, and no two proofs of one law state the SAME law — a
             record that gave two projections one sentence would be
             describing neither."
-    (doseq [{:keys [fh/id] :as record} roster/spine]
+    (doseq [{:keys [fh/id] :as record} roster/records]
       (let [ps (roster/proofs record)]
         (is (seq ps) (str id " names at least one proof"))
         (doseq [{:keys [tier ns law]} ps]
@@ -168,14 +199,14 @@
             diffs. It says nothing about which answers the settled rows
             reached — those rows assert themselves."
     (is (= [] (filterv #(seq (get-in (roster/by-id %) [:fh/record :open]))
-                       roster/spine-ids))
-        "no spine member is holding an open question")
+                       roster/initial-spine-ids))
+        "no initial-spine member is holding an open question")
     (testing "and whatever a FUTURE note says, its shape holds: keyed by the
               bead that owns the question, stated in words. Vacuous today by
               design — the row above is what keeps it that way — and it is
               the half that survives the list going empty, so a note added
               later cannot be an unattributable shrug."
-      (doseq [id   roster/spine-ids
+      (doseq [id   roster/ids
               :let [open (get-in (roster/by-id id) [:fh/record :open])]]
         (is (every? keyword? (keys open))
             (str id " keys each open question by the bead that owns it"))
@@ -231,6 +262,14 @@
    :index/law "a probe law"
    :fh/record {:source     '[re-frame.freehand.probe]
                :structural [{:ns 're-frame.freehand.probe-cljs-test :law "headlessly"}]
+               ;; `:evidence` is on the CONTROL because it is required, and
+               ;; it was not always: while it was optional this record
+               ;; omitted it and was asserted valid, so a future member
+               ;; could have declined to say what it left behind with the
+               ;; whole roster gate green (merged-PR audit #7098). A control
+               ;; that is missing a mandatory key is a control that proves
+               ;; the key is not mandatory.
+               :evidence   {:residue :unasserted}
                :prose      :executable}})
 
 (defn- one-defect
@@ -260,6 +299,8 @@
               (assoc-in sound [:fh/record :wombat] 1)                       :fh/record]
              ["a missing required key"
               (update sound :fh/record dissoc :source)                      :fh/record]
+             ["a record that declines to say what a run leaves behind"
+              (update sound :fh/record dissoc :evidence)                    :fh/record]
              ["a source that is not a vector of namespace symbols"
               (assoc-in sound [:fh/record :source] "re-frame.freehand")     :source]
              ["an empty source vector — a law is about SOMETHING"
@@ -356,4 +397,28 @@
                             [(assoc sound :hosts #{:jvm :browser}
                                     :fh/record (assoc (:fh/record sound)
                                                  :ssr [{:ns 're-frame.freehand.probe-ssr-jvm-test
-                                                        :law "to HTML"}]))])))))))
+                                                        :law "to HTML"}]))])))))
+    (testing "and a QUALIFIED host — `host:google-maps`, `host:framer-motion`
+              — reaches the browser, because a named third-party door exists
+              nowhere else. Without this the ownership-routing witnesses
+              could not declare the mounted tier they live on: their index
+              rows are exactly the `host:<name>` ones, and a rule reading
+              that axis literally would have called every one of their
+              mounted proofs a defect."
+      (is (= #{:browser} (roster/tier-hosts-of #{[:host "google-maps"]})))
+      (is (= #{:jvm :browser} (roster/tier-hosts-of #{:jvm [:host "vega"]})))
+      (is (= [] (roster/roster-defects
+                  [(assoc sound :hosts #{[:host "google-maps"]}
+                          :fh/record (-> (:fh/record sound)
+                                         (dissoc :structural)
+                                         (assoc :mounted
+                                                [{:ns 're-frame.freehand.probe-dom-cljs-test
+                                                  :law "against the real Maps door"}])))]))
+          "a qualified-host law proves itself mounted")
+      (is (= [:ssr] (mapv :field
+                          (roster/roster-defects
+                            [(assoc sound :hosts #{[:host "google-maps"]}
+                                    :fh/record (assoc (:fh/record sound)
+                                                 :ssr [{:ns 're-frame.freehand.probe-ssr-jvm-test
+                                                        :law "to HTML"}]))])))
+          "and reaching the browser is not reaching SSR"))))

--- a/implementation/freehand/test/re_frame/freehand/roster_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/roster_jvm_test.clj
@@ -62,7 +62,7 @@
             deleting or renaming the thing a record describes reds THIS row
             — naming the law — rather than leaving the roster quietly
             describing something that is gone."
-    (doseq [record roster/spine
+    (doseq [record roster/records
             [field ns-sym] (declared-namespaces record)]
       (is (some? (ns->resource ns-sym))
           (str (:fh/id record) " — " field " names " ns-sym
@@ -73,7 +73,7 @@
             all empty would pass every resolution check by having nothing to
             resolve, which is the failure mode a table-driven gate is most
             prone to."
-    (doseq [record roster/spine]
+    (doseq [record roster/records]
       (is (<= 3 (count (declared-namespaces record)))
           (str (:fh/id record) " names its source and at least one proof")))))
 
@@ -89,7 +89,7 @@
             roster, invisible from the code. Every proof namespace carries
             its `FH-…` id in its own text, so the link is legible from both
             ends and a `git grep FH-CTRL-018` finds the whole vertical."
-    (doseq [record            roster/spine
+    (doseq [record            roster/records
             {:keys [tier ns]} (roster/proofs record)]
       (let [id  (:fh/id record)
             res (ns->resource ns)]
@@ -108,7 +108,7 @@
             `-cljs-test` namespace as its mounted tier would advertise a
             mounted proof that the browser lane never schedules, and no
             other projection would notice."
-    (doseq [record roster/spine
+    (doseq [record roster/records
             entry  (roster/tier record :mounted)]
       (is (str/ends-with? (name (:ns entry)) "-dom-cljs-test")
           (str (:fh/id record) " — the mounted tier names " (:ns entry)
@@ -120,7 +120,7 @@
             HEADLESSLY, on both hosts, from one `.cljc`. Pointing it at a
             `-dom-cljs-test` would make the record say a browser run is the
             headless proof."
-    (doseq [record roster/spine
+    (doseq [record roster/records
             entry  (roster/tier record :structural)]
       (is (not (str/ends-with? (name (:ns entry)) "-dom-cljs-test"))
           (str (:fh/id record) " — the structural tier names a browser suite, "
@@ -130,26 +130,66 @@
 ;; `:residue :none` is a claim a checker can refuse — acceptance 3
 ;; ---------------------------------------------------------------------------
 
-(def ^:private emptiness-assertion
-  "The shapes a residue assertion takes in this corpus. A leak assertion is
-  always an ABSENCE read after teardown — an exact zero or an empty
-  collection off the substrate's own book — so these are what one looks
-  like, not an arbitrary keyword list.
+(defn code-only
+  "`text` with every line comment and string literal blanked out, so what
+  remains is the CODE a namespace runs.
 
-  `residue-clean!` is the SHARED one (rf2-n9rzw): the mounted-lifecycle
-  facade's assertion, read after teardown over every root the test created
-  plus whatever substrate books the caller names. It leads the list because
-  it is what a mounted suite should reach for; the inline spellings behind
-  it are the local reads that predate it and remain perfectly good evidence.
+  Pure and exported, because the rule below is only as good as this is and
+  a scanner nobody can exercise is the thing the merged-PR audit of #7105
+  caught: the previous residue rule slurped a whole file and accepted any
+  of five regex tokens ANYWHERE in it, so a comment naming the assertion,
+  or an unrelated zero, satisfied it. Both false positives were reproduced.
+  A claim backed by a sentence about the code is not backed by the code.
 
-  `nothing-survived` is included because the async surrogate factors its
-  absence check into a named helper and calls it from every case; a rule
-  that only recognised the inline spellings would refuse the most thorough
-  suite in the set."
-  [#"residue-clean!" #"\(zero\?" #"\(empty\?" #"nothing-survived"
-   #"\(= \[\] " #"\(= 0 \(count"])
+  Each removed character becomes a space rather than vanishing, so nothing
+  is glued to its neighbour and every offset a caller might report survives.
+  Four states are enough for Clojure: code, a string (where `\\` escapes
+  the next character), a line comment (to end of line), and the one
+  character after a `\\` char literal — which is what stops `\\;` and `\\\"`
+  opening a comment or a string."
+  [^String text]
+  (let [n (count text)
+        sb (StringBuilder.)]
+    (loop [i 0, state :code]
+      (if (>= i n)
+        (str sb)
+        (let [c (.charAt text i)]
+          (case state
+            :code    (cond
+                       (= c \;)  (do (.append sb \space) (recur (inc i) :comment))
+                       (= c \")  (do (.append sb \space) (recur (inc i) :string))
+                       (= c \\)  (do (.append sb "  ") (recur (+ i 2) :code))
+                       :else     (do (.append sb c) (recur (inc i) :code)))
+            :comment (do (.append sb (if (= c \newline) \newline \space))
+                         (recur (inc i) (if (= c \newline) :code :comment)))
+            :string  (cond
+                       (= c \\) (do (.append sb "  ") (recur (+ i 2) :string))
+                       (= c \") (do (.append sb \space) (recur (inc i) :code))
+                       :else    (do (.append sb (if (= c \newline) \newline \space))
+                                    (recur (inc i) :string)))))))))
 
-(deftest a-residue-none-claim-is-backed-by-an-emptiness-assertion
+(def ^:private residue-call
+  "An INVOCATION of the shared residue assertion — an open paren, an
+  optional namespace alias, then `residue-clean!` in head position.
+
+  The shared assertion is the one the rf2-drpa3.182.7 acceptance names, and
+  naming exactly one is the point. The predecessor rule listed five
+  look-alike spellings (`(zero? …)`, `(empty? …)`, `nothing-survived`, …)
+  so that a suite reading its own book inline still counted; the cost was
+  that ANY of those anywhere in the file counted, including in prose. One
+  call to one assertion is both narrower and stronger, and it is the
+  assertion that carries its own non-vacuity — `residue-clean!` reds a
+  suite that tore no root down through the facade, so the call cannot be
+  satisfied by a mount that never happened."
+  #"\(\s*(?:[^\s()\\/]+/)?residue-clean![\s)]")
+
+(defn residue-asserted?
+  "Does `source` CALL the shared residue assertion? Pure, so the rows below
+  can drive it with the exact shapes the audit reproduced."
+  [source]
+  (boolean (re-find residue-call (code-only source))))
+
+(deftest a-residue-none-claim-is-backed-by-the-shared-residue-assertion
   (testing "Per rf2-drpa3.182.7 acceptance 3: mounted cleanup is EXACT, and
             `:residue :none` is the record saying so. An unenforced `:none`
             would be the most expensive kind of green — a leaked React root
@@ -157,81 +197,133 @@
             corpus has seen one leak produce failures across dozens of
             unrelated suites — so the claim is checked rather than read.
 
-            Every mounted projection of a `:residue :none` record must read
-            an absence after teardown. A record whose suites only unmount
-            and remove, without asserting what survived, says
+            Every mounted projection of a `:residue :none` record CALLS
+            `mount-support/residue-clean!`, after teardown, over the
+            facade's own books plus whatever substrate books it names.
+            A record whose suites only unmount and remove says
             `:unasserted` — honest, countable, and what two of the three
-            spine members said until they took the shared assertion
-            (rf2-n9rzw). All three carry `:none` now, so this row is
-            carrying all three rather than one."
-    (doseq [record roster/spine
+            initial members said until they took the shared assertion
+            (rf2-n9rzw).
+
+            What this row proves and what it does not, stated plainly. The
+            executed evidence is the browser lane's: `residue-clean!` runs
+            in Chromium and its messages name the law. What is checked HERE
+            is that the call SITE exists in every projection the record
+            claims — so a `:none` cannot be made by a suite that never
+            calls it, which is the gap the merged-PR audit of #7105 found
+            when the rule was a five-token text resemblance."
+    (doseq [record roster/records
             :when  (= :none (get-in record [:fh/record :evidence :residue]))
             entry  (roster/tier record :mounted)]
       (let [res  (ns->resource (:ns entry))
             text (some-> res slurp)]
-        (is (and text (some #(re-find % text) emptiness-assertion))
+        (is (and text (residue-asserted? text))
             (str (:fh/id record) " claims :residue :none, but its mounted proof "
-                 (:ns entry) " makes no emptiness assertion — either it asserts "
-                 "what survived, or the record says :unasserted"))))))
+                 (:ns entry) " never calls mount-support/residue-clean! — either "
+                 "it reads the books empty after teardown, or the record says "
+                 ":unasserted"))))))
 
-(deftest the-residue-rule-would-refuse-a-suite-that-asserts-nothing
-  (testing "NON-VACUITY for the row above, which is otherwise a rule that
-            has only ever seen input it passes. A teardown that unmounts and
-            removes and reads nothing is exactly the suite the rule exists
-            to refuse, so it is run against that text directly."
-    (let [teardown-only "(defn- teardown! [c r] (.unmount r) (.remove c) nil)"
-          with-absence  (str teardown-only "\n(is (zero? (connection-count)))")]
-      (is (not-any? #(re-find % teardown-only) emptiness-assertion)
-          "an unmount-and-remove teardown is not a residue assertion")
-      (is (some #(re-find % with-absence) emptiness-assertion)
-          "and reading a book empty afterwards is"))))
+(deftest the-residue-rule-refuses-every-shape-that-only-looks-like-a-proof
+  (testing "NON-VACUITY, and specifically for the two false positives the
+            merged-PR audit of #7105 reproduced against the predecessor
+            rule. A gate that has only ever seen input it passes has not
+            been tested, and this one guards a claim whose failure mode is
+            silent contamination of unrelated suites."
+    (doseq [[note source]
+            [["an unmount-and-remove teardown asserts nothing about what survived"
+              "(defn- teardown! [c r] (.unmount r) (.remove c) nil)"]
 
-(deftest the-residue-rule-refuses-the-shared-teardown-without-the-shared-assertion
-  (testing "The mutation the shared facade makes possible, and the one this
-            rule now has to survive (rf2-n9rzw). Consuming
-            `mount-support`'s lifecycle is not the same as reading its
-            books: a suite can call `destroy-root!` — a real, correct
-            teardown — and never call `residue-clean!`, which is precisely
-            the state FH-CTRL-018 and FH-REACT-007 were in.
+             ["tearing down through the SHARED lifecycle is still not reading its books"
+              "(defn- finish! [c r] (ms/destroy-root! c r))"]
 
-            A rule that recognised the facade by NAME rather than by the
-            assertion would go green on the first half and stop refusing
-            anything, so it is run against both halves directly. A shared
-            assertion that cannot fail is the defect this whole seam exists
-            to remove."
-    (let [shared-teardown "(ms/destroy-root! container root)"
-          shared-assert   (str shared-teardown
-                               "\n(ms/residue-clean! \"FH-CTRL-018 — after teardown\")")]
-      (is (not-any? #(re-find % shared-teardown) emptiness-assertion)
-          "tearing down through the shared lifecycle asserts nothing on its own")
-      (is (some #(re-find % shared-assert) emptiness-assertion)
-          "and reading the shared residue assertion afterwards is what earns the claim"))))
+             ["a COMMENT naming the assertion is prose about the code, not the code"
+              ";; every row ends at ms/residue-clean!, which reads the books empty\n(ms/destroy-root! c r)"]
 
-(deftest the-spine-records-what-it-has-earned
+             ["and so is the assertion named inside a docstring"
+              "(defn finish! \"tears down, then ms/residue-clean!\" [c r] (ms/destroy-root! c r))"]
+
+             ["an UNRELATED emptiness read is not a residue assertion"
+              "(is (= [] (rows-rendered container)))\n(is (zero? (retry-count)))"]
+
+             ["nor is the assertion named in a message string"
+              "(is (pos? n) \"call ms/residue-clean! after teardown\")"]
+
+             ["nor a var whose name merely ends in it"
+              "(def my-residue-clean! 1)"]]]
+      (is (not (residue-asserted? source)) note))
+
+    (doseq [[note source]
+            [["a call through the facade's alias is the proof"
+              "(ms/residue-clean! \"FH-CTRL-018 — after teardown\")"]
+
+             ["so is a referred call"
+              "(residue-clean! where [[\"the connection table\" #(count @table)]])"]
+
+             ["and a call carrying books, after a shared teardown, in the real shape"
+              (str "(ms/destroy-root! container root)\n"
+                   ";; and now read what survived it\n"
+                   "(ms/residue-clean! where [[\"the registry\" #(root/live-root-ids)]])")]]]
+      (is (residue-asserted? source) note))))
+
+(deftest the-comment-stripper-leaves-the-code-and-only-the-code
+  (testing "The rule above is exactly as good as this function, so it is
+            driven rather than trusted — including the shapes that make a
+            naive stripper wrong: a `;` inside a string, an escaped quote,
+            and a char literal spelling either.
+
+            Offsets are preserved (a removed character becomes a space), so
+            the assertions below are about WHAT SURVIVES rather than about
+            spacing."
+    (let [tokens (fn [s] (remove empty? (str/split (code-only s) #"\s+")))]
+      (is (= ["(f" "1)"] (tokens "(f 1) ; a comment"))
+          "a line comment is gone")
+      (is (= ["(f" ")"] (tokens "(f \"a ; b\") ; c"))
+          "a semicolon inside a string neither opens a comment nor survives")
+      (is (= ["(f" ")"] (tokens "(f \"she said \\\"hi\\\"\")"))
+          "an escaped quote does not close the string early")
+      (is (= ["(f" ")"] (tokens "(f \\; \\\")"))
+          "a char literal semicolon or quote is neither delimiter")
+      (is (= ["(a)" "(b)"] (tokens "(a) ;; gone\n(b)"))
+          "a line comment ends at its newline, and the code after it survives")
+      (is (= ["(re-find" "#" "x)"] (tokens "(re-find #\"\\(zero\\?\" x)"))
+          "a regex literal is a string — its dispatch `#` is code, and the
+           pattern inside it never is, so a rule looking for a call cannot
+           be satisfied by one written in a pattern"))
+    (testing "and the newline structure survives, so a reported line number would"
+      (is (= 3 (count (str/split-lines (code-only "(a) ; x\n;; y\n(b)"))))))))
+
+(deftest every-record-declares-a-residue-claim-it-can-be-held-to
   (testing "Per rf2-drpa3.182.7 acceptance 3: the roster's value here is
-            that the residue claim is COUNTABLE rather than hidden. All
-            three spine members now claim `:residue :none`, and the row
-            above is what holds each of them to it.
+            that the residue claim is COUNTABLE rather than hidden. This
+            row is the census, and it holds in both directions — a record
+            regressing from `:none` to `:unasserted` reds, and so does a
+            newly enrolled witness whose claim is neither.
 
-            Two of them arrived (rf2-n9rzw), and the gap each closed was a
-            different one. FH-CTRL-018 tore its root down and asserted
-            nothing about what survived. FH-REACT-007 reset its registries
-            in a per-test `:init-fn`, which is cleanup BEFORE a test rather
-            than evidence about the one that just ran — a retained boundary
-            was masked by the next reset instead of reported. Both now end
-            at the shared `residue-clean!`, read after teardown.
+            It is stated over the WHOLE roster rather than over a hardcoded
+            three, which is what lets the control witnesses enrol without
+            editing this file. `:evidence` is a required record key, so
+            there is no third answer — a record cannot decline to say.
 
-            This row remains a statement of the CURRENT state, and that is
-            its job in both directions: a record regressing to
-            `:unasserted`, or a fourth member enrolled without a residue
-            claim, reds HERE rather than passing quietly."
-    (is (= {:FH-REACT-007    :none
-            :FH-CTRL-018     :none
-            :FH-BEHAVIOR-005 :none}
+            The initial three are named separately because acceptance 3 was
+            about them, and the gap each closed was a different one.
+            FH-CTRL-018 tore its root down and asserted nothing about what
+            survived. FH-REACT-007 reset its registries in a per-test
+            `:init-fn`, which is cleanup BEFORE a test rather than evidence
+            about the one that just ran — a retained boundary was masked by
+            the next reset instead of reported. Both now end at the shared
+            `residue-clean!`, read after teardown (rf2-n9rzw)."
+    (doseq [record roster/records]
+      (is (contains? roster/residue-statuses
+                     (get-in record [:fh/record :evidence :residue]))
+          (str (:fh/id record) " declares what a mounted run leaves behind")))
+    (is (= {"FH-BEHAVIOR-005" :none
+            "FH-CTRL-018"     :none
+            "FH-REACT-007"    :none}
            (into {} (map (fn [id]
                            [id (get-in (roster/by-id id)
                                        [:fh/record :evidence :residue])])
-                         roster/spine-ids))))))
+                         roster/initial-spine-ids)))
+        "and the three initial-spine members have each EARNED :none")))
 
 ;; ---------------------------------------------------------------------------
 ;; The resolver itself


### PR DESCRIPTION
Continues **rf2-drpa3.182.7**. The bead stays **OPEN** — this is the slice that unblocks the five control witnesses (rf2-drpa3.182.8 through .12), plus the three defects the merged-PR audits of #7098 and #7105 recorded against the landed partial.

## Enrolment is a property of the fixture

What was blocking the five witnesses was not a missing mechanism — it was the **shared membership list**. Enrolment was a hand-maintained vector spelled twice in `roster.cljc`, with three more hardcoded rosters in the projections behind it: a count of 3, an id set, and a three-key residue map. Five parallel workers would each have edited four shared lists.

A law is now rostered exactly when its fixture carries `:fh/record`. Nothing lists the members. **A witness touches no file it does not own.** It writes:

1. an index row addressing its id, with a fixture path and status `active`;
2. `:fh/record` on its own fixture — `:source` (a vector of resolvable ns symbols), at least one of `:structural` / `:mounted` / `:ssr` as a non-empty vector of `{:ns … :law "one line"}`, `:evidence {… :residue :none|:unasserted}`, and `:prose`;
3. the suites those tiers name.

The read widened to match: every fixture the index names is read, because whether one carries a record is a question only its bytes answer. That width is what keeps the shadow cache edge honest in both directions — a new index row invalidates through the index, a record added to an already-addressed fixture invalidates through that fixture. **Measured, not assumed** (below).

## A trap removed from rf2-drpa3.182.9's path

`host:google-maps`, `host:framer-motion` — the rows the ownership-routing witness will write — parse to `[:host "…"]`, which intersected no tier's host set. Every mounted proof of a qualified-host law would have been reported a defect. A qualified host now reaches the browser, and nowhere else.

## The three recorded defects

- **`:evidence` is required**, not validated-when-present. The roster narrated that every record declares what a run leaves behind while `required-record-keys` was `#{:source :prose}` — and the negative-test control omitted `:evidence` and was asserted valid, so a future member could have declined to say with the gate green (#7098). The control carries one now; a missing-key witness drives the refusal.
- **The `:fh/law` drift narration is gone.** Two docstrings and a test claimed the gate refused a fixture whose law had drifted from its index row; `join-defects` deliberately does not compare them, and reasonably so — the two state the same law at different lengths by convention. The prose now says what is enforced, and names the id relationship that *is* held, harder than a defect: a compile failure in `read-roster`.
- **`:residue :none` is backed by a call, not a resemblance.** The rule slurped a namespace and accepted any of five regex tokens anywhere in it, so a comment naming the assertion, or an unrelated zero, satisfied it — both reproduced by the #7105 audit, and all four mounted proofs carry such a comment. It now blanks comments and string literals and requires an invocation of the one shared assertion, `mount-support/residue-clean!`. Seven refusals are driven, including both false positives; the stripper is driven separately.

## Measured

- **Residue mutation, on the real file.** Removed the executable `ms/residue-clean!` from `controls-kit-dom-cljs-test` and **left the comment naming it** — the shape that stayed green under the old rule. Exit 1: *"FH-CTRL-018 claims :residue :none, but its mounted proof … never calls mount-support/residue-clean!"*. Restored: exit 0, `git diff` empty.
- **Cache edge, for the widened read.** Added `:fh/record` to `fh-call-001.edn` — a law that was not enrolled, whose fixture nothing here had ever read — with `.shadow-cljs` untouched. 3 rows red, every message naming FH-CALL-001, 3 files compiled. Reverted: green, 3 compiled. That is exactly the case a witness creates the first time it enrols.
- **Guide digest gate, proven live.** Mutated a fenced block in `authoring/forms.md`: red naming the page, the ordinal *and* the classification. Restored byte-clean.

## What remains on the bead

Acceptance 4 clause 1 (*guide code mechanically checked against canonical source*) is **met by an existing mechanism the audit did not credit** — `samples-coverage-jvm-test` (rf2-qwsmv) digest-pins all 138 fenced blocks under `docs/core/freehand/`, 114 owned by a fixture var a `deftest` reaches and 24 by a closed reason set.

Clause 2 (*illustrative blocks are labelled*) holds on the page in prose, but is **not joined to the roster**: a record's `:prose` status is a declaration nothing checks, in exactly the way `:residue :none` was. Closing it needs a guide-page key on `:fh/record`, which lives under `spec/conformance/freehand/fixtures/` — `spec/**`, fenced report-don't-edit for this dispatch. **Needs one hand allowed to touch `spec/`**, and folds naturally into rf2-fby7o.

## Quality gates

All foreground, worktree-local logs, exit codes echoed.

| Gate | Result | Exit |
|---|---|---|
| `implementation/freehand` JVM `clojure -M:test` | 1229 tests / 8279 assertions, 0 failures, 0 errors | **0** |
| `npm run test:freehand` (node) | 1311 tests / 7242 assertions, 0 failures, 0 errors | **0** |
| `npm run test:browser` (`BROWSER_TEST_TIMEOUT_MS=600000`) | 843 tests / 5400 assertions, 0 failures, 0 errors | **0** |
| `npm run test:browser-prod-elision` | 120 tests / 526 assertions, 0 failures, 0 errors | **0** |
| focused roster JVM (`roster-jvm-test` + `roster-cljs-test`) | 25 tests / 204 assertions | **0** |

Mutation runs, all reverted with `git status` clean: residue rule red at exit 1 then green at 0; cache-edge probe red then green; guide digest red then green.

Everything slower is deferred to CI.