### PR TITLE
DC-09 evidence: the two-clock operating envelope, measured (rf2-drpa3.182.12)

### DIFF
--- a/docs/design/freehand/studio/two-clock-operating-envelope.md
+++ b/docs/design/freehand/studio/two-clock-operating-envelope.md
@@ -1,0 +1,470 @@
+# The two-clock operating envelope — DC-09, measured
+
+Bead: `rf2-drpa3.182.12`. Owner of the claim: **DC-09** in
+[`../product-completion-setpoint.md`](../product-completion-setpoint.md).
+Owner of the method:
+[`../decisions/D021-performance-budgets-and-release-evidence.md`](../decisions/D021-performance-budgets-and-release-evidence.md).
+Instrument:
+`implementation/freehand/test/re_frame/freehand/bench/b10_two_clock.cljs`
+and its rows next door in `b10_two_clock_dom_cljs_test.cljs`.
+
+**This is measurement, not a law.** No `FH-…` id is minted and nothing enrols
+in the conformance roster. The deterministic property the numbers sit on top
+of — a controlled input drops nothing while its frame is busy — is already
+rostered as **FH-INPUT-003**, whose own suite says the latency distributions
+under contention "belong to the measurement spine". This is that spine. What
+is new here is the *ladder* (0, 1, 10, 50, 200 contending siblings rather than
+a single dozen) and the distributions beside it.
+
+**The recommendation, up front: add no scheduling, throttle, debounce,
+coalescing, equality or preview vocabulary.** Section 7 gives the three
+attributed reasons. One material bottleneck did repeat in two witnesses, and
+its remedy is a call-site change, not an API.
+
+---
+
+## 1. Provenance
+
+Every figure below comes from one run, at one revision, in one browser.
+
+| | |
+|---|---|
+| Revision | `e2b4225d6be141c7efaaf9c59e8f45c0425b286f` |
+| Build | shadow-cljs `:browser-test`, `:optimizations :none`, `goog.DEBUG true` (`:instrumentation? true`) |
+| Runtime | **HeadlessChrome 147.0.7727.15**, Windows 11 x64 |
+| Hardware class | `:developer-workstation` |
+| D021 status | `:d021 :release-evidence` — the record passed `provenance/result` |
+| Raw records | `ai/findings/2026-07-28.two-clock-envelope-raw.edn` (local-only) |
+| Gate result | 30 tests, 466 assertions, 0 failures, 0 errors |
+
+Two earlier runs at the same fixture reproduced every figure below to within
+the round-to-round spread, so nothing here rests on a single sample of the
+machine.
+
+### What does not transfer
+
+**These are Chrome numbers under a development build.** Both words matter.
+
+*Chrome.* No figure here is quoted for Node or for the JVM, and none should
+be. Absolutes do not transfer across runtimes.
+
+*Development build.* `goog.DEBUG` is true, so the Spec 009 instrumentation
+seam, schema validation and trace emission are all live on exactly the event
+path this report measures. B6 records the same hazard against its own rows and
+takes its published numbers from an `:advanced` bundle instead. **Every cost
+here is therefore an upper bound, and every rate a lower bound, on what a
+shipped application does.** The production reading was not taken — see
+section 8.
+
+---
+
+## 2. The instrument, and the two controls that make it readable
+
+A crossing is timed across `react-dom/flushSync` with the dispatch inside it,
+and split at the instant the dispatch returns:
+
+```
+t0 ──flushSync[ rf/dispatch-sync ──t1── (React render + commit) ]── t2
+```
+
+`:event-ms` is `t1 − t0` — the router, the interceptor chain, the reducer, the
+`app-db` install and the subscription notification. `:commit-ms` is `t2 − t1`
+— React's render, commit and DOM mutation. Splitting there is DC-09's
+acceptance criterion 3, and section 4 is the reason it was worth doing.
+
+**Every measured crossing is read back out of the DOM inside its own window,
+and one that did not land is counted rather than dropped.** The row reports
+**0 unverified of 800** (section 3) and **0 unverified of 640** (section 5).
+That rule is not decorative: B6 records a first pass that timed writes inside
+`flushSync` which never reached the page at all and returned entirely
+reasonable milliseconds for them.
+
+The `:fresh-equal` arm, whose whole point is that the page must **not** change,
+cannot be verified by the page standing still — an arm that did nothing would
+also achieve that. It is verified at the store instead: the `app-db` reference
+must have moved and the value must not have.
+
+### C1 — a control of computed duration
+
+A busy-wait of exactly **4.00 ms** rides in every cell of every table, timed
+through the same window.
+
+| | predicted | measured |
+|---|---|---|
+| Standalone, n = 12 | 4.00 ms | min 4.0, p50 4.0, p95 4.0, p99 4.0, max 4.0 |
+| Inside all 40 published M1 cells | 4.00 ms | p50 4.0 everywhere; p95 4.0–4.3 |
+
+Overshoot at p50 was **0.0 ms**, and never exceeded 0.3 ms anywhere. That is
+clock quantisation with nothing left over: **the machine was not contended
+while these numbers were taken.** Had it been, the burn arm would have said so
+in every table simultaneously, which is exactly why it is in every table.
+
+### C2 — a control of computed size
+
+Each mode's DOM mutation count is arithmetic over the fixture, and is compared
+against what a `MutationObserver` measured. Predicted equalled measured at
+**every one of the fifteen (mode × rung) combinations**, with zero spread:
+
+| mode | predicted | measured |
+|---|---|---|
+| `:host-only` | 1 attribute | 1, at every rung |
+| `:fresh-equal` | 0 | 0, at every rung |
+| `:one-leaf` at k siblings | k + 1 | 1, 2, 11, 51, 201 |
+
+The driven arm (section 6) reproduces it independently: at k = 200 it recorded
+4221 mutations for 21 crossings, 6030 for 30, 6633 for 33 and 6834 for 34 —
+**exactly 201.0 per crossing in all four**.
+
+---
+
+## 3. The cost of one semantic crossing
+
+300 cells, one of them the leaf; `k` names how many siblings the application
+chose to dirty alongside it. Ranges are across **four rounds** — two walking
+the ladder ascending, two descending — of 10 measured samples each after 3
+warm-ups, with arm order rotating on the sample index. **0 unverified of 800.**
+
+| k | host-only p50 | fresh-equal p50 | **one-leaf p50** | **one-leaf p95** | event p50 | commit p50 | DOM mutations |
+|---:|---|---|---|---|---|---|---:|
+| 0 | ≤ 0.1 | 0.2–0.3 | **3.5–4.6** | 5.9–9.2 | 3.1–4.2 | 0.4–0.5 | 1 |
+| 1 | ≤ 0.1 | 0.2–0.3 | **3.4–4.8** | 5.3–10.4 | 2.9–4.0 | 0.5–0.7 | 2 |
+| 10 | ≤ 0.1 | 0.2–0.3 | **4.3–5.1** | 6.5–10.7 | 3.2–3.9 | 1.0–1.2 | 11 |
+| 50 | ≤ 0.1 | 0.2 | **6.9–7.8** | 10.5–12.0 | 3.3–3.8 | 3.5–4.0 | 51 |
+| 200 | ≤ 0.1 | 0.2–0.3 | **18.3–22.2** | 21.9–27.5 | 3.7–4.1 | 13.0–17.5 | 201 |
+
+All figures milliseconds, Chrome, dev build.
+
+Four things this table says.
+
+**The host clock is free, and it is free at every rung.** The `:host-only` arm
+— a behavior writing its own node's transform, with nothing crossing into
+`app-db` — reads at or below Chrome's 0.1 ms `performance.now()` clamp in all
+40 readings. Its cost is *"under 0.1 ms"*, not *"zero"*; the instrument cannot
+see smaller. Its **flatness** is asserted as a gate: a host arm that rose with
+`k` would mean the sibling knob was leaking into the one arm that must not feel
+it.
+
+**A fresh-but-`rf=`-equal write costs 0.2–0.3 ms and repaints nothing.** Flat
+across the whole ladder, 0 DOM mutations every time, while the store reference
+demonstrably moved. This is the single most load-bearing number in the report
+and section 7 leans on it.
+
+**The event half is flat; the commit half is what scales.** `:event-ms` sits at
+3–4 ms from k = 0 to k = 200 — the reducer, the install and the notification of
+300 subscriptions cost the same whether one cell moved or 201. `:commit-ms`
+goes 0.4 → 17.5 ms, about **0.085 ms per dirtied cell**. If a crossing is
+expensive, it is expensive in React, not in re-frame.
+
+**Both ladder orders agree.** The ascending and descending ranges overlap at
+every rung except k = 200, where ascending reads ~1–3 ms higher. That
+difference is *not* a ladder-order effect: the per-round p50 declines
+monotonically from round 1 to round 4 at **every** rung in both orders
+(k = 200: 22.2 → 19.8 → 19.1 → 18.3), so it is first-round warm-up that three
+warm-up samples per cell did not fully absorb. Running both orders is what let
+that be said rather than guessed.
+
+---
+
+## 4. Where the subscription is read costs more than how much changed
+
+This was not on the matrix. It came out of it, and it is the most actionable
+result in the report.
+
+The `surface` view exists in two spellings that differ in exactly one thing:
+whether the behavior's config subscription is read in the view that also
+builds the 300 cells (`:parent`), or one boundary down inside the behavior's
+own panel (`:leaf`). Same behavior, same config, same cells, same field.
+
+| config shape | leaves | read site | stable p50 | fresh-equal p50 | **one-leaf p50** | DOM mutations |
+|---|---:|---|---|---|---|---:|
+| Vega-shaped (nested spec) | 96 | parent | 0.2–0.3 | 0.2–0.3 | **39.5–46.4** | 4 |
+| Vega-shaped | 96 | leaf | 0.2–0.3 | 0.2 | **4.9–5.6** | 1 |
+| Spread-shaped (flat range) | 900 | parent | 0.5 | 0.4–0.6 | **60.7–66.4** | 4 |
+| Spread-shaped | 900 | leaf | 0.4 | 0.5 | **18.5–19.2** | 1 |
+
+**The read-site penalty is a roughly constant 40–44 ms and does not scale with
+the payload.** Vega pays 45.6 → 5.0; Spread pays 63 → 18.8. That constant is
+the reconciliation of the 300-cell subtree whose parent now depends on a value
+that changed — and it happens while moving *three extra DOM nodes*. The
+cheapest reading of the expensive arm is that it is doing almost no DOM work
+at all; it is re-rendering a subtree to discover that.
+
+Separating the two terms is what the pair bought. Once the read site is
+controlled for, the residual **is** payload size: 96 leaves cost 5.0 ms, 900
+leaves cost 18.8 ms — about **0.017 ms per leaf** for a config that genuinely
+changed.
+
+Compare with section 3: *the same statement* — "one leaf of `app-db` changed"
+— costs **3.5–4.6 ms** when the value is read at the leaf that uses it, and
+**39.5–66.4 ms** when it is read at a parent that also builds a collection.
+Between eight and nineteen times, in the same fixture, in the same build, for
+the same size of change.
+
+### Freehand already elides an unchanged config, and it is `=` that decides
+
+The behavior's `:update` was called **exactly 52 times** in each of the four
+(shape × read-site) combinations — which is exactly the number of `:one-leaf`
+crossings (4 rounds × 13 samples). Stable-reference crossings and
+fresh-but-equal crossings both produced **zero** `:update` calls.
+
+So the elision is not identity-based; a deep-fresh copy with no identical
+substructure above its scalar leaves is elided just as a re-installed
+reference is. This is **counted, not read off the runtime**, which is why it is
+here rather than in a footnote.
+
+---
+
+## 5. The equality question, answered
+
+The bead asks for stable-reference against fresh-but-`rf=`-equal at
+Vega-shaped and Spread-shaped sizes. The answer is in the table above and it
+is a null result of the useful kind:
+
+**Stable-reference and fresh-but-equal are indistinguishable at both shapes and
+both read sites.** 0.2–0.3 ms against 0.2–0.3 ms at 96 leaves; 0.4–0.5 ms
+against 0.4–0.6 ms at 900 leaves. The ranges overlap completely. Neither
+repaints anything. Two `p95` outliers (3.0 ms and 12.7 ms) appeared in earlier
+runs at single samples and did not recur; p50 was unmoved by them.
+
+A full structural walk of a 900-leaf map, then, costs **under a millisecond**,
+and the difference between doing that walk and short-circuiting on identity is
+below what this instrument can resolve. **0 unverified of 640.**
+
+---
+
+## 6. The envelope, driven rather than derived
+
+A `setInterval` offers a semantic event every `1000/R` ms for 700 ms through
+the **ordinary asynchronous `rf/dispatch`** — what a pointer handler calls, and
+the only crossing that *can* build a backlog, since a synchronous one is
+finished before the next offer is made.
+
+`:expected` is computed — `floor(duration × rate / 1000)` — and is not a
+measurement. It is what the application asked the browser for.
+
+| k | rate asked | **expected** | **offered** | **applied** | **committed** | peak backlog | latency p50 / p95 / p99 | tail |
+|---:|---:|---:|---:|---:|---:|---:|---|---:|
+| 0 | 30 | 21 | 20 | 20 | 20 | 1 | 5.8 / 8.8 / 9.3 | 4.2 |
+| 0 | 60 | 42 | 43 | 43 | 43 | 1 | 4.4 / 5.8 / 6.1 | 5.0 |
+| 0 | 120 | 84 | 87 | 87 | 87 | 1 | 4.3 / 5.5 / 6.5 | 4.0 |
+| 0 | 240 | 168 | **133** | 133 | 133 | 1 | 4.3 / 6.8 / 8.5 | 4.1 |
+| 200 | 30 | 21 | 21 | 21 | 21 | 1 | 20.9 / 25.8 / 30.4 | 5.4 |
+| 200 | 60 | 42 | **30** | 30 | 30 | 1 | 22.3 / 24.0 / 24.2 | 4.2 |
+| 200 | 120 | 84 | **33** | 33 | 33 | 1 | 20.4 / 25.6 / 27.6 | 5.2 |
+| 200 | 240 | 168 | **34** | 34 | 34 | 1 | 19.9 / 23.6 / 24.1 | 4.1 |
+
+Milliseconds; "committed" is the DOM mutation count divided by the exact
+per-crossing figure C2 predicts. `outstanding` was 0 in all eight runs — every
+generation offered reached the page before the run was declared settled.
+
+### The three findings
+
+**Offered ≠ asked, and that is where the ceiling lives.** At k = 0 the browser
+delivered 133 of 168 requested ticks at 240 Hz — a sustained **190/s**. At
+k = 200 the offer rate saturates at **30–49/s no matter what is asked**: 30, 43,
+47 and 49 per second for 30, 60, 120 and 240 Hz requested. The timer callback
+*is* the main thread, so when a crossing takes 20 ms the browser simply stops
+offering.
+
+**Accepted = offered = committed, in all eight runs.** Nothing was refused,
+dropped or coalesced away by the framework. The gap is entirely between what
+the application asked for and what the browser was able to offer.
+
+**Peak backlog was 1 at every rate and both loads.** Not "small" — *one*, which
+is the single event in flight. The queue never grew, latency stayed bounded at
+the cost of one crossing, and the settlement tail stayed at 4.0–5.4 ms even at
+240 Hz requested against a 20 ms crossing. **The two-clock seam does not
+degrade by queueing; it degrades by the browser making fewer offers.**
+
+### Derived and driven agree
+
+The strongest validation in the report is that two independent windows — a
+synchronous `flushSync`-bracketed crossing and an asynchronous timer-driven one
+— predict each other:
+
+| k | section 3 p50 → implied ceiling | section 6 sustained rate |
+|---:|---|---|
+| 0 | 3.5–4.6 ms → 217–286/s | 190/s |
+| 200 | 18.3–22.2 ms → 45–55/s | 49/s |
+
+Within about 10% at both ends, from different code paths, different call sites
+and different clocks.
+
+### The envelope, stated
+
+Two criteria, because they answer different questions.
+
+**Throughput** — how many crossings actually land:
+
+| k | sustained semantic rate (Chrome, dev build) |
+|---:|---|
+| 0 | ~190/s |
+| 1–10 | ~150–190/s (interpolated; not driven) |
+| 50 | ~100/s (interpolated; not driven) |
+| 200 | **~49/s** |
+
+**Latency quality** — the largest offered rate at which 95% of crossings finish
+inside one budget of `1000/R` ms:
+
+| k | crossing p95 (worst round) | 30 Hz (33.3 ms) | 60 Hz (16.7) | 120 Hz (8.33) | 240 Hz (4.17) |
+|---:|---:|:-:|:-:|:-:|:-:|
+| 0 | 9.2 | ✔ | ✔ | ✗ | ✗ |
+| 1 | 10.4 | ✔ | ✔ | ✗ | ✗ |
+| 10 | 10.7 | ✔ | ✔ | ✗ | ✗ |
+| 50 | 12.0 | ✔ | ✔ | ✗ | ✗ |
+| 200 | 27.5 | ✔ | ✗ | ✗ | ✗ |
+
+**So: 60 Hz semantic crossing is comfortable up to 50 dirty siblings and breaks
+between 50 and 200. 120 Hz never quite clears the p95 bar in a development
+build even with nothing else dirty, although throughput reaches it easily. 240
+Hz is not achievable at any load — the browser stops offering first.**
+
+The rows marked interpolated were not driven; only k = 0 and k = 200 were.
+
+---
+
+## 7. Controlled input: no drops first, then latency
+
+DC-09's acceptance criterion 2, in the order it is written.
+
+Thirty characters are appended one at a time through `HTMLInputElement`'s own
+prototype value setter and delivered as real bubbling `InputEvent`s outside
+React's `act` environment, so the controlled-input door takes the synchronous
+round trip it takes for a user. **Every keystroke also dirties `k` siblings**,
+so the frame-scoped flush has to settle all of them before the listener
+returns.
+
+At **every** rung — 0, 1, 10, 50, 200 — all five assertions held:
+
+- the field holds all 30 characters (a character the round trip failed to land
+  is one React *erases* at the end of the discrete event, so a drop appears as
+  a shorter string, not a late one);
+- the caret is at `[30 30]`;
+- the leaf settled on the last keystroke's state;
+- so did the furthest contending sibling;
+- and the cell beyond the rung did not move.
+
+Only then, the distribution — the whole round trip per keystroke:
+
+| k | min | **p50** | p95 | p99 | drops |
+|---:|---:|---:|---:|---:|---:|
+| 0 | 4.0 | **5.4** | 7.7 | 10.3 | 0 / 30 |
+| 1 | 4.1 | **4.9** | 8.4 | 8.5 | 0 / 30 |
+| 10 | 4.8 | **5.6** | 9.4 | 11.2 | 0 / 30 |
+| 50 | 7.6 | **9.5** | 13.7 | 13.8 | 0 / 30 |
+| 200 | 16.4 | **21.0** | 26.1 | 26.5 | 0 / 30 |
+
+**k = 0, 1 and 10 are indistinguishable** — 5.4, 4.9 and 5.6 ms at p50 with
+overlapping ranges. Contention only becomes visible at 50 siblings and only
+becomes a *user-visible* cost at 200, where p50 exceeds a 60 Hz frame (16.7 ms)
+and p95 exceeds a 30 Hz one.
+
+Read as a typing budget: 21 ms a keystroke supports about 47 characters per
+second, and no human types at 47 cps. **Correctness is unconditional across the
+whole ladder; only the smoothness of the accompanying repaint degrades.**
+
+---
+
+## 8. Recommendation: add nothing
+
+DC-09's bar is that new scheduling, preview or equality vocabulary is proposed
+"only for a material attributed bottleneck repeated in two realistic
+witnesses". Three of the four candidate vocabularies have no bottleneck to
+attribute at all.
+
+**No equality hook.** A fresh-but-`rf=`-equal crossing costs 0.2–0.6 ms and
+repaints nothing, at 96 leaves and at 900, at both read sites, indistinguishable
+from re-installing the identical reference. Freehand already elides an
+`:update` whose config is equal — proved by counting `:update` calls, 52 of 52
+matching the changed crossings exactly. There is nothing here for an equality
+hook to buy.
+
+**No throttle, debounce or coalescing verb.** Peak backlog was **1** at every
+rate and both sibling loads; `outstanding` was 0 in all eight driven runs; the
+settlement tail never exceeded 5.4 ms. The browser's own timer back-pressure
+already coalesces — under overload you receive *fewer offers*, never a growing
+queue. A throttle verb would suppress offers the browser has already stopped
+making, and would trade away the low-load responsiveness that costs nothing.
+
+**No host-local state model.** The `:host-only` arm is under Chrome's clock
+resolution at every rung. The existing behavior boundary is already the answer;
+nothing needs adding to make host-rate motion cheap, because it already is.
+
+**No preview lane.** Nothing measured here distinguishes a preview crossing
+from any other crossing. `started` / `preview` / `committed` is an application's
+choice about which events are worth having, and it costs nothing structural.
+
+### The one bottleneck that did repeat — and why it is not an API
+
+Section 4's read-site penalty *did* repeat in two witnesses (Vega-shaped and
+Spread-shaped), it *is* material (40–44 ms, eight to nineteen times the leaf
+cost) and it *is* attributed (subtree reconciliation, not DOM work, not
+equality, not the reducer). It clears DC-09's bar for evidence.
+
+Its remedy is a call site, not a verb. DC-09 already says to keep host-local
+geometry and motion out of `app-db` unless the application genuinely needs the
+live values. This adds the sharper corollary, which belongs in the guide:
+
+> **If a high-rate value must cross into `app-db`, read its subscription at the
+> boundary that uses it — never in a view that also builds a collection.**
+> Moving one `v/sub` down one boundary took a config change from 45.6 ms to
+> 5.0 ms in this fixture, while the number of DOM nodes that moved went *down*.
+
+That is documentation and guidance work with a named owner (`rf2-fby7o`, the
+guide), not new Freehand surface.
+
+---
+
+## 9. What this report could not determine
+
+**The production envelope.** Every figure is from a development build with
+`goog.DEBUG true`, so the Spec 009 instrumentation seam, schema validation and
+trace emission all sit on the measured path. B6 publishes its own numbers from
+an `:advanced` bundle for exactly this reason. Taking the same reading for B10
+needs a `:browser` entry point plus a build target in
+`implementation/shadow-cljs.edn`, which is a hot-zone file that was carrying
+four concurrent siblings when this was measured; it was left alone rather than
+raced. **The direction is known and safe — production is faster, so every rate
+here is a lower bound — but the factor is not measured, and the 120 Hz row in
+section 6 is exactly the row that factor could flip.**
+
+**Real pointer streams.** The driver is a `setInterval`. A browser delivering
+coalesced `pointermove`, or `pointerrawupdate` bursts, can hand several events
+to one task, which is the one shape that could produce a backlog greater than 1.
+The backlog-of-1 result is measured against a timer and should not be quoted
+for a raw-pointer burst without re-measuring.
+
+**Sub-0.1 ms costs.** Chrome clamps `performance.now()` to 100 µs. The
+`:host-only` arm and, at the bottom of its range, the `:fresh-equal` arm sit on
+that clamp. Their costs are "under 0.1 ms", and nothing finer can be said with
+this instrument.
+
+**Rungs between 0 and 200 in the driven arm.** Only k = 0 and k = 200 were
+driven; the k = 1/10/50 throughput figures in section 6 are interpolated from
+section 3 and are marked as such.
+
+**One machine.** Single workstation, single browser version. The *shares* —
+event flat, commit scaling, read-site constant, backlog invariant — are the
+transferable claims. The absolutes are not.
+
+---
+
+## 10. Reproducing
+
+```bash
+cd implementation
+RF2_REVISION=$(git rev-parse HEAD) \
+RF2_HARDWARE_CLASS=developer-workstation \
+RF2_VERBOSE_TESTS=1 \
+BROWSER_TEST_TIMEOUT_MS=900000 \
+  npx shadow-cljs compile browser-test-freehand-bench \
+  && node scripts/serve-and-run-browser-tests.cjs \
+       --root out/browser-test-freehand-bench --port 8024
+```
+
+The records are printed to the browser console as EDN, tagged `;; B6 B10 …`,
+and the runner flushes the console under `RF2_VERBOSE_TESTS=1`. Without
+`RF2_REVISION` the records still publish, carrying
+`:d021 :not-release-evidence` and the reason — the rows run in the ordinary
+`npm run test:browser` gate too, where no revision is available, and they say
+so rather than routing around D021.

--- a/implementation/freehand/test/re_frame/freehand/bench/b10_two_clock.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b10_two_clock.cljs
@@ -147,6 +147,42 @@
   (let [{:keys [build channels]} (get config-shapes shape)]
     (build channels leaf)))
 
+(defn deep-fresh
+  "Rebuild every collection in `x`, so nothing above a scalar leaf is
+  `identical?` to what it came from while everything is `=` to it.
+
+  A shallow copy would not do. `rf=` short-circuits on identity at every
+  level, so a top-level-only copy of a nested spec costs a walk of the
+  TOP LEVEL and then five identity hits — which is not what an
+  application pays when a library hands it a freshly parsed config, and
+  would have understated the Vega shape's equality cost by the depth of
+  its nesting."
+  [x]
+  (cond
+    (map? x)    (into {} (map (fn [[k v]] [k (deep-fresh v)])) x)
+    (vector? x) (mapv deep-fresh x)
+    :else       x))
+
+(defn touch-one-leaf
+  "A deep-fresh copy of `cfg` with exactly ONE scalar leaf different.
+  Spelled per shape, because the shapes' leaves are in different places
+  and a generic walk would be a third thing to get wrong."
+  [shape cfg gen]
+  (let [fresh (deep-fresh cfg)]
+    (case shape
+      :vega   (assoc-in fresh [:encoding :ch0 :axis :title] (str "Field " gen))
+      :spread (assoc fresh :r0 gen))))
+
+(defn dissoc-leaf
+  "`cfg` with the one leaf [[touch-one-leaf]] moves removed, so a
+  read-back can prove ONE leaf changed rather than merely that something
+  did. Without it a `:one-leaf` arm that replaced the whole config would
+  pass its own verification."
+  [shape cfg]
+  (case shape
+    :vega   (update-in cfg [:encoding :ch0 :axis] dissoc :title)
+    :spread (dissoc cfg :r0)))
+
 ;; ---------------------------------------------------------------------------
 ;; re-frame registrations — the CONSUMER path, never a store poke
 ;; ---------------------------------------------------------------------------
@@ -215,17 +251,15 @@
     (swap! applied-count inc)
     {:db (update db :cells (fn [cells] (into [] (map identity) cells)))}))
 
-;; The behavior-config crossing. `:stable` re-installs the value already
-;; there — identical, not merely equal. `:fresh-equal` installs a freshly
-;; built map with the same contents. `:one-leaf` installs a freshly built
-;; map differing in exactly one leaf.
-(rf/reg-event :b10/config-offered
-  (fn [{:keys [db]} [_ mode shape gen]]
+;; The behavior-config crossing. The config to install is built by the
+;; CALLER, outside the measured window, and handed in whole — because a
+;; reducer that built a 900-entry map inside the window would be timing
+;; `into` rather than equality, and the difference between the three
+;; modes is exactly what this axis exists to isolate.
+(rf/reg-event :b10/config-install
+  (fn [{:keys [db]} [_ cfg]]
     (swap! applied-count inc)
-    {:db (case mode
-           :stable      db
-           :fresh-equal (assoc db :config (build-config shape 0))
-           :one-leaf    (assoc db :config (build-config shape gen)))}))
+    {:db (assoc db :config cfg)}))
 
 ;; ---------------------------------------------------------------------------
 ;; The behavior — the host clock's owner
@@ -246,11 +280,11 @@
   {:timing  :passive
    :connect (fn [{:keys [node config]}]
               (swap! behavior-log update :connect inc)
-              (set! (.. node -dataset -leaves) (str (count config)))
+              (.setAttribute node "data-leaves" (str (count config)))
               nil)
    :update  (fn [{:keys [node config]}]
               (swap! behavior-log update :update inc)
-              (set! (.. node -dataset -leaves) (str (count config)))
+              (.setAttribute node "data-leaves" (str (count config)))
               nil)
    :disconnect (fn [_] (swap! behavior-log update :disconnect inc) nil)})
 
@@ -273,15 +307,40 @@
                     :value       (v/sub [:b10/field])
                     :on-input    [:b10/typed ::v/value]}])
 
+(v/defview host-panel
+  "The behavior with the config subscription read AT ITS OWN BOUNDARY.
+  The `:hoisted` half of the pair below."
+  [_]
+  [v/behavior {:use host-clock :target :b10/host :config (v/sub [:b10/config])}
+   [:div.b10host {:data-testid "b10-host"}]])
+
 (v/defview surface
-  [{:keys [n]}]
-  [:div.b10
-   [v/behavior {:use host-clock :target :b10/host :config (v/sub [:b10/config])}
-    [:div.b10host {:data-testid "b10-host"}]]
-   [field {}]
-   [:div.b10cells
-    (for [i (range n)]
-      [cell {:key i :i i}])]])
+  "The page, in two spellings that differ in ONE thing: where the config
+  subscription is read.
+
+    :parent  the config sub is read HERE, in the view that also builds
+             the 300 cells — the shape an author naturally writes when
+             the behavior's config comes from app-db.
+    :leaf    the config sub is read inside [[host-panel]], one boundary
+             down, so the cells' parent does not depend on it.
+
+  Nothing else changes: the same behavior, the same config, the same
+  cells, the same field. The pair exists because the cost of a config
+  change turned out to be an order of magnitude larger than the cost of
+  a cell change while moving FEWER DOM nodes, and the obvious
+  explanation — that the whole subtree reconciles — is the sort of thing
+  that should be measured rather than asserted."
+  [{:keys [n read-at]}]
+  (let [cfg (when (= :parent read-at) (v/sub [:b10/config]))]
+    [:div.b10
+     (if (= :parent read-at)
+       [v/behavior {:use host-clock :target :b10/host :config cfg}
+        [:div.b10host {:data-testid "b10-host"}]]
+       [host-panel {}])
+     [field {}]
+     [:div.b10cells
+      (for [i (range n)]
+        [cell {:key i :i i}])]]))
 
 ;; ===========================================================================
 ;; Reading the page
@@ -429,42 +488,58 @@
                       (fn [_] true)))})
 
 (defn config-mode
-  "One rung of the behavior-config axis at one shape."
+  "One rung of the behavior-config axis at one shape.
+
+  The config to install is derived from WHATEVER IS CURRENTLY IN THE
+  STORE and built before the clock starts. Both halves of that matter.
+  Building outside keeps `into` out of the window; deriving from the
+  current value is what makes the arm order-independent — a first
+  version built each mode's config from a fixed generation, so a
+  `:fresh-equal` crossing that happened to follow a `:one-leaf` one was
+  not equal to anything and failed its own read-back in 7 of every 10
+  samples. Rotating arm order is what exposed it."
   [mode shape]
   {:id   (keyword (str (name shape) "-" (name mode)))
    :mode mode :shape shape
    :run! (fn [container observer]
            (let [gen    (next-gen!)
-                 before (:config (frame/frame-app-db-value frame-id))]
+                 before (:config (frame/frame-app-db-value frame-id))
+                 cfg    (case mode
+                          :stable      before
+                          :fresh-equal (deep-fresh before)
+                          :one-leaf    (touch-one-leaf shape before gen))]
              (crossing! container observer
-                        (fn [] (rf/dispatch-sync [:b10/config-offered mode shape gen]
-                                                 {:frame frame-id}))
+                        (fn [] (rf/dispatch-sync [:b10/config-install cfg] {:frame frame-id}))
                         (fn [_]
                           (let [after (:config (frame/frame-app-db-value frame-id))]
                             (case mode
                               :stable      (identical? before after)
                               :fresh-equal (and (not (identical? before after))
                                                 (= before after))
-                              :one-leaf    (not= before after)))))))})
+                              :one-leaf    (and (not= before after)
+                                                (= (dissoc-leaf shape before)
+                                                   (dissoc-leaf shape after)))))))))})
 
 ;; ===========================================================================
 ;; Mount / teardown
 ;; ===========================================================================
 
 (defn mount!
-  "Mount the surface into a fresh attached container. Answers
+  "Mount the surface into a fresh attached container. `read-at` is
+  `:parent` or `:leaf` — see [[surface]]. Answers
   `{:container :handle :observer}`."
-  [shape]
+  ([shape] (mount! shape :parent))
+  ([shape read-at]
   (let [container (js/document.createElement "div")]
     (.appendChild js/document.body container)
     (reset-behavior-log!)
     (let [handle (react-dom/flushSync
                    (fn []
-                     (v/mount [surface {:n cells-n}] container
+                     (v/mount [surface {:n cells-n :read-at read-at}] container
                               {:frame         {:id             frame-id
                                                :initial-events [[:b10/seed cells-n shape]]}
                                :disambiguator :b10/two-clock})))]
-      {:container container :handle handle :observer (observe! container)})))
+      {:container container :handle handle :observer (observe! container)}))))
 
 (defn release!
   [{:keys [container handle observer]}]

--- a/implementation/freehand/test/re_frame/freehand/bench/b10_two_clock.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b10_two_clock.cljs
@@ -1,0 +1,648 @@
+(ns re-frame.freehand.bench.b10-two-clock
+  "B10 — the TWO-CLOCK operating envelope (DC-09), as fixture and
+  instrument, with every `cljs.test` assertion left to the caller.
+
+  Split from its test namespace for B6's reason and B9's: the method is
+  one thing a reader should be able to check once, and the driver has to
+  be callable from more than the browser suite.
+
+  ## The two clocks
+
+  DC-09's claim is that a Freehand application runs on two clocks that do
+  not have to tick together:
+
+    - the **HOST clock**, at pointer/animation/scroll rate, owned by a
+      behavior mutating its own node. Nothing crosses into `app-db`.
+    - the **SEMANTIC clock**, at whatever rate the application chooses to
+      call meaningful, carrying `started` / `preview` / `committed`
+      events into re-frame.
+
+  The envelope is the answer to \"how fast may the semantic clock tick
+  before it stops keeping up\", and that is not one number: it is a
+  surface over the crossing's cost. So this namespace measures the COST
+  of one crossing under the loads that move it, and drives a real timer
+  at real rates to check that the cost predicts the breakdown.
+
+  ## NO ELEVENTH INSTRUMENT
+
+  Every window here is B6's: `re-frame.freehand.bench.b6-harness` for
+  publication and the across-rounds range fold, `…bench.measure` for the
+  clock and the distribution summary, `…bench.provenance` for the D021
+  record. What is new is the FIXTURE and the two axes, not the method.
+
+  ## The window, and the one rule that makes it honest
+
+  A crossing is timed across `react-dom/flushSync` with the dispatch
+  inside it, and split at the moment the dispatch returns:
+
+      t0 ──flushSync[ dispatch-sync ──t1── (React render + commit) ]── t2
+
+  `:event-ms` is `t1 − t0`: the router, the interceptor chain, the
+  reducer, the `app-db` install and the subscription notification.
+  `:commit-ms` is `t2 − t1`: React's render, commit and DOM mutation.
+  That split is DC-09's acceptance criterion 3 — costs attributed to
+  event/reducer/Freehand/React/host work rather than rolled into one
+  latency number — and it is why the crossing is not measured as a
+  single number.
+
+  **Every measured crossing is then read back out of the DOM inside its
+  own window, and a crossing that did not land is COUNTED, not
+  discarded.** B6 records what happens without that rule: a first pass
+  timed writes inside `flushSync` that never reached the page at all and
+  returned entirely reasonable milliseconds for them. Each mode's
+  read-back is a different assertion because each mode changes a
+  different thing, and the `:fresh-equal` mode — whose whole point is
+  that the page must NOT change — verifies instead that the `app-db`
+  reference genuinely moved. An equality arm that silently did nothing
+  would otherwise be the fastest arm in the table.
+
+  ## Two positive controls, both computed rather than calibrated
+
+  **C1, a duration.** [[burn-arm]] busy-waits for exactly `burn-ms`
+  inside the measured window. Predicted `:total-ms` is `burn-ms`; the
+  overshoot is clock quantisation plus whatever the operating system
+  took away. On a workstation running other agents that second term is
+  not small, and publishing it beside every figure is what stops a
+  contended round being read as a slow substrate.
+
+  **C2, a size.** Every mode's DOM mutation count is PREDICTED from the
+  fixture's arithmetic and MEASURED with a `MutationObserver` whose
+  records are taken synchronously. `:one-leaf` at K siblings must move
+  exactly `K + 1` nodes; `:fresh-equal` must move none; `:host-only`
+  must move exactly one attribute. A knob that does not dirty what it
+  says it dirties fails here rather than in a conclusion.
+
+  ## Both ladder orders
+
+  The sibling ladder runs ASCENDING in half its rounds and DESCENDING in
+  the other half, and both are published. A large arm inflating its
+  successor is a documented hazard on this surface and it is only ever
+  visible from the two orders side by side.
+
+  Normative owner: `docs/design/freehand/decisions/`
+  `D021-performance-budgets-and-release-evidence.md`. Measured claim
+  owner: DC-09 in `docs/design/freehand/product-completion-setpoint.md`."
+  (:require ["react-dom" :as react-dom]
+            [re-frame.core :as rf]
+            [re-frame.frame :as frame]
+            [re-frame.freehand :as v]
+            [re-frame.freehand.bench.b6-harness :as h]
+            [re-frame.freehand.bench.measure :as m]
+            [re-frame.freehand.bench.provenance :as prov]))
+
+;; ===========================================================================
+;; The fixture
+;; ===========================================================================
+
+(def cells-n
+  "Enough cells that the widest rung of the sibling ladder (200) is a
+  real fraction of the page rather than the whole of it, so a 200-dirty
+  crossing is still a PARTIAL update and the localisation the substrate
+  claims is the thing under load."
+  300)
+
+(def sibling-ladder
+  "DC-09's rungs, verbatim. 0 means the crossing moves the leaf alone."
+  [0 1 10 50 200])
+
+(def rate-ladder
+  "DC-09's offered semantic rates, in updates per second."
+  [30 60 120 240])
+
+;; ---------------------------------------------------------------------------
+;; Behavior configs, at two shapes
+;; ---------------------------------------------------------------------------
+
+(defn- vega-shaped
+  "A nested spec map of the shape a chart library is handed — a handful
+  of keys, several levels deep. `n` scales the encoding channel count."
+  [n leaf]
+  {:$schema  "https://vega.github.io/schema/vega-lite/v5.json"
+   :mark     {:type "line" :tooltip true :interpolate "monotone"}
+   :width    640 :height 480
+   :encoding (into {} (map (fn [i]
+                             [(keyword (str "ch" i))
+                              {:field (str "f" i)
+                               :type  "quantitative"
+                               :scale {:zero false :nice true :domain [0 (+ i leaf)]}
+                               :axis  {:title (str "Field " i) :grid (even? i)}}]))
+                   (range n))})
+
+(defn- spread-shaped
+  "A wide flat cell map of the shape a spreadsheet range is handed — no
+  nesting, `n` entries. The two shapes cost `rf=` differently and the
+  bead asks for both."
+  [n leaf]
+  (into {} (map (fn [i] [(keyword (str "r" i)) (+ i leaf)])) (range n)))
+
+(def config-shapes
+  "`{:id {:build fn :leaves n}}`. `:leaves` is the count a reader can
+  check the equality cost against; it is arithmetic over the builder
+  above, not a measurement."
+  {:vega   {:build vega-shaped   :channels 12  :leaves (* 12 8)}
+   :spread {:build spread-shaped :channels 900 :leaves 900}})
+
+(defn build-config
+  [shape leaf]
+  (let [{:keys [build channels]} (get config-shapes shape)]
+    (build channels leaf)))
+
+;; ---------------------------------------------------------------------------
+;; re-frame registrations — the CONSUMER path, never a store poke
+;; ---------------------------------------------------------------------------
+;;
+;; Every crossing below goes through `rf/dispatch-sync` or `rf/dispatch`,
+;; registered with `rf/reg-event`, read through `rf/reg-sub`. B6's update
+;; row writes with `frame/replace-app-db!`, which is right for a
+;; cross-substrate markup comparison and wrong here: DC-09 is about
+;; semantic EVENTS crossing, and an instrument that skipped the router
+;; and the interceptor chain would price a path no application takes.
+
+(def frame-id :b10/two-clock)
+
+(rf/reg-sub :b10/cell   (fn [db [_ i]] (get-in db [:cells i])))
+(rf/reg-sub :b10/field  (fn [db _] (:field db)))
+(rf/reg-sub :b10/config (fn [db _] (:config db)))
+
+(defonce ^:private applied-count (atom 0))
+(defn applied [] @applied-count)
+(defn reset-applied! [] (reset! applied-count 0))
+
+(defn- dirty
+  "Write `gen` into cells `0 … k` inclusive — `k + 1` cells, so `k` reads
+  as \"and this many SIBLINGS beside the leaf\"."
+  [cells k gen]
+  (reduce (fn [cs i] (assoc cs i gen)) cells (range (inc k))))
+
+(rf/reg-event :b10/seed
+  (fn [_ [_ n shape]]
+    (reset! applied-count 0)
+    {:db {:cells    (vec (repeat n 0))
+          :field    ""
+          :siblings 0
+          :config   (build-config shape 0)}}))
+
+;; How many siblings a KEYSTROKE dirties. Set before a typing run so the
+;; controlled-input ladder is driven by the same knob as the crossing
+;; ladder, rather than by a second, differently-spelled one.
+(rf/reg-event :b10/contend
+  (fn [{:keys [db]} [_ k]]
+    {:db (assoc db :siblings k)}))
+
+;; The controlled-input crossing. Every keystroke ALSO dirties `k`
+;; siblings, so the frame-scoped synchronous flush has to settle all of
+;; them before the listener returns — FH-INPUT-003's contention shape,
+;; here on DC-09's ladder rather than at a single dozen.
+(rf/reg-event :b10/typed
+  (fn [{:keys [db]} [_ s]]
+    (swap! applied-count inc)
+    {:db (-> db
+             (assoc :field s)
+             (update :cells dirty (:siblings db) (count s)))}))
+
+;; The semantic crossing under test. `k` names how many siblings the
+;; application chose to dirty alongside the leaf, so `k + 1` cells change
+;; and the rest do not.
+(rf/reg-event :b10/moved
+  (fn [{:keys [db]} [_ k gen]]
+    (swap! applied-count inc)
+    {:db (update db :cells dirty k gen)}))
+
+;; A fresh-but-`rf=`-equal cells vector: a new object holding the same
+;; values, so the store's identity moves and the page must not.
+(rf/reg-event :b10/fresh-equal-cells
+  (fn [{:keys [db]} _]
+    (swap! applied-count inc)
+    {:db (update db :cells (fn [cells] (into [] (map identity) cells)))}))
+
+;; The behavior-config crossing. `:stable` re-installs the value already
+;; there — identical, not merely equal. `:fresh-equal` installs a freshly
+;; built map with the same contents. `:one-leaf` installs a freshly built
+;; map differing in exactly one leaf.
+(rf/reg-event :b10/config-offered
+  (fn [{:keys [db]} [_ mode shape gen]]
+    (swap! applied-count inc)
+    {:db (case mode
+           :stable      db
+           :fresh-equal (assoc db :config (build-config shape 0))
+           :one-leaf    (assoc db :config (build-config shape gen)))}))
+
+;; ---------------------------------------------------------------------------
+;; The behavior — the host clock's owner
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private behavior-log (atom {:connect 0 :update 0 :disconnect 0}))
+(defn behavior-calls [] @behavior-log)
+(defn reset-behavior-log! [] (reset! behavior-log {:connect 0 :update 0 :disconnect 0}))
+
+(v/defbehavior host-clock
+  "The DC-09 default made concrete: a behavior owning one node's motion.
+  `:update` writes the node's own transform and touches nothing else, so
+  a host tick costs a style write and no `app-db` version at all.
+
+  Its call COUNTS are the instrument for the config axis. Whether
+  Freehand elides an `:update` whose config is unchanged is a question
+  this fixture answers by counting rather than by reading the runtime."
+  {:timing  :passive
+   :connect (fn [{:keys [node config]}]
+              (swap! behavior-log update :connect inc)
+              (set! (.. node -dataset -leaves) (str (count config)))
+              nil)
+   :update  (fn [{:keys [node config]}]
+              (swap! behavior-log update :update inc)
+              (set! (.. node -dataset -leaves) (str (count config)))
+              nil)
+   :disconnect (fn [_] (swap! behavior-log update :disconnect inc) nil)})
+
+;; ---------------------------------------------------------------------------
+;; Views
+;; ---------------------------------------------------------------------------
+
+(v/defview cell
+  [{:keys [i]}]
+  [:span.b10cell {:data-i i} (str (v/sub [:b10/cell i]))])
+
+(v/defview field
+  "The controlled field. `:value` and an event-vector `:on-input` put it
+  through the controlled-input door, which is what makes its keystroke
+  path synchronous — the property FH-INPUT-003 gates and this namespace
+  measures the distribution of."
+  [_]
+  [:input.b10field {:data-testid "b10-field"
+                    :type        "text"
+                    :value       (v/sub [:b10/field])
+                    :on-input    [:b10/typed ::v/value]}])
+
+(v/defview surface
+  [{:keys [n]}]
+  [:div.b10
+   [v/behavior {:use host-clock :target :b10/host :config (v/sub [:b10/config])}
+    [:div.b10host {:data-testid "b10-host"}]]
+   [field {}]
+   [:div.b10cells
+    (for [i (range n)]
+      [cell {:key i :i i}])]])
+
+;; ===========================================================================
+;; Reading the page
+;; ===========================================================================
+
+(defn cell-text [container i]
+  (some-> (.querySelector container (str "[data-i=\"" i "\"]")) (.-textContent)))
+
+(defn field-node [container]
+  (.querySelector container "[data-testid=\"b10-field\"]"))
+
+(defn host-node [container]
+  (.querySelector container "[data-testid=\"b10-host\"]"))
+
+;; ---------------------------------------------------------------------------
+;; C2 — the mutation counter
+;; ---------------------------------------------------------------------------
+
+(defn- observe!
+  "A `MutationObserver` over `container`'s whole subtree. `takeRecords`
+  answers synchronously, which is the only reason this can be read
+  inside a `flushSync`-bracketed window at all."
+  [container]
+  (let [o (js/MutationObserver. (fn [_ _] nil))]
+    (.observe o container #js {:subtree true :childList true
+                               :characterData true :attributes true})
+    o))
+
+(defn- take-mutations!
+  "Answer `{:total n :by-type {…}}` for everything observed since the last
+  take, and leave the observer armed."
+  [o]
+  (let [recs (.takeRecords o)]
+    {:total   (.-length recs)
+     :by-type (reduce (fn [acc r] (update acc (keyword (.-type r)) (fnil inc 0)))
+                      {} (array-seq recs))}))
+
+;; ===========================================================================
+;; The measured window
+;; ===========================================================================
+
+(defn- burn!
+  "Busy-wait until `ms` of the SAME clock the window is read with has
+  passed. Its duration is the argument, which is what makes it a
+  positive control rather than a calibration."
+  [ms]
+  (let [t0 (m/now-ms)]
+    (loop [n 0]
+      (if (< (- (m/now-ms) t0) ms)
+        (recur (inc n))
+        n))))
+
+(defn crossing!
+  "One semantic crossing, timed, attributed and VERIFIED at the DOM.
+
+  `thunk` is what runs inside the flush; `verify` is handed the container
+  and answers truthy when the page (or, for the equality mode, the store)
+  shows what the crossing claimed to do. Answers
+  `{:total-ms :event-ms :commit-ms :mutations :ok?}`."
+  [container observer thunk verify]
+  (take-mutations! observer)                 ; discard anything in flight
+  (let [t0 (m/now-ms)
+        t1 (volatile! nil)]
+    (react-dom/flushSync (fn [] (thunk) (vreset! t1 (m/now-ms))))
+    (let [t2   (m/now-ms)
+          muts (take-mutations! observer)]
+      {:total-ms  (- t2 t0)
+       :event-ms  (- @t1 t0)
+       :commit-ms (- t2 @t1)
+       :mutations muts
+       :ok?       (boolean (verify container))})))
+
+;; ---------------------------------------------------------------------------
+;; The modes
+;; ---------------------------------------------------------------------------
+
+(defonce ^:private gen-seq (atom 5000))
+(defn next-gen! [] (swap! gen-seq inc))
+
+(defn sibling-mode
+  "`{:id … :run! … :predicted-mutations …}` for one rung of the sibling
+  ladder. Three modes, each verified differently because each claims
+  something different.
+
+    :host-only   the DC-09 default — the behavior writes its own node,
+                 nothing crosses. Predicted: one attribute mutation, and
+                 FLAT across the ladder. A host arm that rises with `k`
+                 would mean the ladder leaks into arms it must not
+                 touch, and that flatness is checked as a gate.
+    :fresh-equal a crossing that installs a fresh-but-`rf=`-equal cells
+                 vector. Predicted: NO mutations — and verified by the
+                 store's identity moving, never by the page standing
+                 still, which an arm that did nothing would also achieve.
+    :one-leaf    the naive dispatch-per-move: `k + 1` cells change.
+                 Predicted: `k + 1` mutations."
+  [mode k]
+  (case mode
+    :host-only
+    {:id :host-only :predicted-mutations 1
+     :run! (fn [container observer]
+             (let [gen  (next-gen!)
+                   node (host-node container)]
+               (crossing! container observer
+                          (fn [] (set! (.. node -style -transform)
+                                       (str "translateX(" (mod gen 97) "px)")))
+                          (fn [c] (= (str "translateX(" (mod gen 97) "px)")
+                                     (.. (host-node c) -style -transform))))))}
+
+    :fresh-equal
+    {:id :fresh-equal :predicted-mutations 0
+     :run! (fn [container observer]
+             (let [before (:cells (frame/frame-app-db-value frame-id))]
+               (crossing! container observer
+                          (fn [] (rf/dispatch-sync
+                                   [:b10/fresh-equal-cells] {:frame frame-id}))
+                          (fn [_]
+                            (let [after (:cells (frame/frame-app-db-value frame-id))]
+                              ;; the write LANDED (a new vector) and it was
+                              ;; equal (so the page was right not to move).
+                              (and (not (identical? before after))
+                                   (= before after)))))))}
+
+    :one-leaf
+    {:id :one-leaf :predicted-mutations (inc k)
+     :run! (fn [container observer]
+             (let [gen (next-gen!)]
+               (crossing! container observer
+                          (fn [] (rf/dispatch-sync [:b10/moved k gen] {:frame frame-id}))
+                          (fn [c]
+                            (and (= (str gen) (cell-text c 0))
+                                 (= (str gen) (cell-text c k))
+                                 ;; and the rung BEYOND the ladder did not move,
+                                 ;; so `k` names what it says it names
+                                 (or (>= (inc k) cells-n)
+                                     (not= (str gen) (cell-text c (inc k)))))))))}))
+
+(defn burn-arm
+  "C1. Predicted `:total-ms` is exactly `burn-ms`; the overshoot is the
+  instrument's own error plus the machine's."
+  [burn-ms]
+  {:id :control-burn :predicted-mutations 0 :predicted-ms burn-ms
+   :run! (fn [container observer]
+           (crossing! container observer
+                      (fn [] (burn! burn-ms))
+                      (fn [_] true)))})
+
+(defn config-mode
+  "One rung of the behavior-config axis at one shape."
+  [mode shape]
+  {:id   (keyword (str (name shape) "-" (name mode)))
+   :mode mode :shape shape
+   :run! (fn [container observer]
+           (let [gen    (next-gen!)
+                 before (:config (frame/frame-app-db-value frame-id))]
+             (crossing! container observer
+                        (fn [] (rf/dispatch-sync [:b10/config-offered mode shape gen]
+                                                 {:frame frame-id}))
+                        (fn [_]
+                          (let [after (:config (frame/frame-app-db-value frame-id))]
+                            (case mode
+                              :stable      (identical? before after)
+                              :fresh-equal (and (not (identical? before after))
+                                                (= before after))
+                              :one-leaf    (not= before after)))))))})
+
+;; ===========================================================================
+;; Mount / teardown
+;; ===========================================================================
+
+(defn mount!
+  "Mount the surface into a fresh attached container. Answers
+  `{:container :handle :observer}`."
+  [shape]
+  (let [container (js/document.createElement "div")]
+    (.appendChild js/document.body container)
+    (reset-behavior-log!)
+    (let [handle (react-dom/flushSync
+                   (fn []
+                     (v/mount [surface {:n cells-n}] container
+                              {:frame         {:id             frame-id
+                                               :initial-events [[:b10/seed cells-n shape]]}
+                               :disambiguator :b10/two-clock})))]
+      {:container container :handle handle :observer (observe! container)})))
+
+(defn release!
+  [{:keys [container handle observer]}]
+  (when observer (.disconnect observer))
+  (when handle (try (react-dom/flushSync (fn [] (v/unmount! handle)))
+                    (catch :default _ nil)))
+  (when container (.remove container))
+  nil)
+
+;; ===========================================================================
+;; Rounds
+;; ===========================================================================
+
+(defn- summarise-arm
+  [samples]
+  (let [ms   (mapv :total-ms samples)
+        evt  (mapv :event-ms samples)
+        com  (mapv :commit-ms samples)
+        muts (mapv #(get-in % [:mutations :total]) samples)]
+    {:total-ms   (m/summarise ms)
+     :event-ms   (m/summarise evt)
+     :commit-ms  (m/summarise com)
+     :mutations  {:min (apply min muts) :max (apply max muts)
+                  :distinct (vec (sort (distinct muts)))}
+     :unverified (count (remove :ok? samples))
+     :n          (count samples)}))
+
+(defn run-arms!
+  "One round over `arms`, `samples` measured samples each after `warmup`,
+  the arm order ROTATING on the sample index so no arm is always first
+  into a cold cache. Answers `{id summary}` and the raw samples beside
+  it."
+  [mnt arms {:keys [warmup samples]}]
+  (let [k   (count arms)
+        acc (atom (zipmap (map :id arms) (repeat [])))]
+    (dotimes [s (+ warmup samples)]
+      (dotimes [j k]
+        (let [arm (nth arms (mod (+ j s) k))
+              r   ((:run! arm) (:container mnt) (:observer mnt))]
+          (when (>= s warmup)
+            (swap! acc update (:id arm) conj r)))))
+    (into {} (map (fn [[id xs]] [id (assoc (summarise-arm xs) :raw (mapv :total-ms xs))]))
+          @acc)))
+
+;; ===========================================================================
+;; The driven arm — offered against observed against accepted
+;; ===========================================================================
+
+(defn drive!
+  "Offer a semantic event every `1000/rate` ms for `duration-ms` through
+  the ORDINARY asynchronous `rf/dispatch`, and answer a promise of the
+  ledger.
+
+  Async on purpose. A `dispatch-sync` crossing cannot build a backlog —
+  it is finished before the next offer can be made — so measuring
+  overload through it would report a peak backlog of zero as a property
+  of the framework rather than of the call. `rf/dispatch` is what a
+  pointer handler calls, its queue is real, and this is where a backlog
+  either appears or does not.
+
+    :offered   driver invocations — what the application asked for
+    :expected  `floor(duration-ms × rate / 1000)`, computed, not measured
+    :applied   reducer applications, counted in the reducer itself
+    :mutations DOM records observed across the whole run
+    :peak-backlog  max over offers of `offered − applied`
+    :tail-ms   from the last offer to the DOM showing the last generation
+    :latency   per-generation offer→DOM distribution, read from the
+               `MutationObserver` callback that carried it"
+  [mnt rate k duration-ms]
+  (let [{:keys [container observer]} mnt
+        period    (/ 1000.0 rate)
+        offered   (atom 0)
+        backlog   (atom 0)
+        offers    (atom {})               ; gen -> offer time
+        latencies (atom [])
+        muts      (atom 0)
+        start     (m/now-ms)
+        last-gen  (volatile! nil)]
+    (.disconnect observer)
+    (reset-applied!)
+    (let [watcher (js/MutationObserver.
+                    (fn [recs _]
+                      (swap! muts + (.-length recs))
+                      (let [now (m/now-ms)
+                            txt (cell-text container 0)
+                            g   (js/parseInt txt 10)]
+                        (when-let [t (get @offers g)]
+                          (swap! latencies conj (- now t))
+                          (swap! offers dissoc g)))))]
+      (.observe watcher container #js {:subtree true :childList true :characterData true})
+      (js/Promise.
+        (fn [resolve]
+          (let [tid (volatile! nil)]
+            (vreset!
+              tid
+              (js/setInterval
+                (fn []
+                  (if (>= (- (m/now-ms) start) duration-ms)
+                    (do
+                      (js/clearInterval @tid)
+                      ;; settle: wait until the last generation is on the page
+                      ;; or a generous ceiling passes, then read the tail.
+                      (let [t-last (m/now-ms)
+                            poll   (volatile! nil)]
+                        (vreset!
+                          poll
+                          (js/setInterval
+                            (fn []
+                              (let [done? (= (str @last-gen) (cell-text container 0))
+                                    over? (> (- (m/now-ms) t-last) 2000)]
+                                (when (or done? over?)
+                                  (js/clearInterval @poll)
+                                  (let [tail (- (m/now-ms) t-last)]
+                                    (.disconnect watcher)
+                                    (.observe observer container
+                                              #js {:subtree true :childList true
+                                                   :characterData true :attributes true})
+                                    (resolve
+                                      {:rate            rate
+                                       :siblings        k
+                                       :duration-ms     duration-ms
+                                       :offered         @offered
+                                       :expected        (js/Math.floor
+                                                          (/ (* duration-ms rate) 1000.0))
+                                       :applied         (applied)
+                                       :mutations       @muts
+                                       :peak-backlog    @backlog
+                                       :tail-ms         tail
+                                       :settled?        done?
+                                       :outstanding     (count @offers)
+                                       :latency-ms      (when (seq @latencies)
+                                                          (m/summarise @latencies))})))))
+                            4))))
+                    (let [gen (next-gen!)]
+                      (vreset! last-gen gen)
+                      (swap! offered inc)
+                      (swap! offers assoc gen (m/now-ms))
+                      (swap! backlog max (- @offered (applied)))
+                      (rf/dispatch [:b10/moved k gen] {:frame frame-id}))))
+                period))))))))
+
+;; ===========================================================================
+;; Publication
+;; ===========================================================================
+
+(defn record
+  "A D021 result record, run past `prov/result` — which refuses one that
+  omits any of the eight things D021 requires.
+
+  The refusal is REPORTED rather than routed around. A browser suite has
+  no revision unless its build was handed one, so the ordinary
+  `:browser-test` lane cannot produce release evidence and says so in the
+  record itself; the focused `bench:freehand-browser` build, whose
+  `RF2_REVISION` closure-define is what the published run supplies, does.
+  Both publish the same numbers; only one of them is release evidence,
+  and a reader should not have to work out which."
+  [benchmark doc fixture sampling distribution]
+  (let [candidate
+        {:benchmark    benchmark
+     :doc          doc
+     :revision     (prov/detect-revision)
+     :build        (prov/detect-build)
+     :host         (prov/detect-host)
+     :fixture      fixture
+     :sampling     sampling
+     :baseline     {:kind      :self-vs-end-to-end
+                    :reference {:arm  :host-only
+                                :note (str "the DC-09 default — a behavior writing its own "
+                                           "node's transform, with nothing crossing into "
+                                           "app-db. Every semantic figure is quoted against "
+                                           "the host clock's own cost in the same round.")}}
+     :distribution distribution
+         :status       :evidence}]
+    (try
+      (assoc (prov/result candidate) :d021 :release-evidence)
+      (catch :default e
+        (assoc candidate
+               :d021    :not-release-evidence
+               :because (ex-message e))))))
+
+(defn publish! [tag rec] (h/publish! (str "B10 " tag) rec))

--- a/implementation/freehand/test/re_frame/freehand/bench/b10_two_clock_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b10_two_clock_dom_cljs_test.cljs
@@ -271,13 +271,22 @@
             The behavior's own `:update` call count is recorded alongside,
             because whether Freehand elides an update whose config is
             unchanged is a question this fixture ANSWERS by counting
-            rather than asserts by reading the runtime."
+            rather than asserts by reading the runtime.
+
+            Each shape runs at BOTH read sites — the config subscription
+            read in the view that also builds the 300 cells, and read one
+            boundary down inside the behavior's own panel. The pair is
+            here because a first pass found a config change an order of
+            magnitude more expensive than a cell change while moving
+            FEWER DOM nodes, and the obvious explanation deserved a
+            measurement rather than a sentence."
     (if-not (browser?) (skip)
       (async done
         (let [out (atom {})]
           (try
-            (doseq [shape [:vega :spread]]
-              (let [mnt (b10/mount! shape)]
+            (doseq [shape   [:vega :spread]
+                    read-at [:parent :leaf]]
+              (let [mnt (b10/mount! shape read-at)]
                 (try
                   (b10/reset-behavior-log!)
                   (let [before (b10/behavior-calls)
@@ -290,13 +299,14 @@
                                          (b10/burn-arm burn-ms)]
                                         sampling)))
                         after  (b10/behavior-calls)]
-                    (swap! out assoc shape
+                    (swap! out assoc [shape read-at]
                            {:rounds rs
                             :behavior-updates (- (:update after) (:update before))
                             :leaves (get-in b10/config-shapes [shape :leaves])})
                     (doseq [r rs [id s] r]
                       (is (zero? (:unverified s))
-                          (str shape "/" id ": " (:unverified s) " unverified of " (:n s)))))
+                          (str shape "/" read-at "/" id ": "
+                               (:unverified s) " unverified of " (:n s)))))
                   (finally (b10/release! mnt)))))
             (h/publish!
               "B10 M2 / config equality"
@@ -306,10 +316,15 @@
                 {:shapes       (into {} (map (fn [[k v]] [k (select-keys v [:leaves :channels])]))
                                      b10/config-shapes)
                  :modes        [:stable :fresh-equal :one-leaf]
+                 :read-sites   [:parent :leaf]
                  :crossing     :dispatch-sync
                  :cells        b10/cells-n
                  :measurement-method
-                 (str "the same window as M1. :stable re-installs the value already in "
+                 (str "the same window as M1, at both read sites — :parent reads the config "
+                      "subscription in the view that also builds the 300 cells, :leaf reads "
+                      "it one boundary down inside the behavior's own panel; nothing else "
+                      "differs between them. "
+                      "the same window as M1. :stable re-installs the value already in "
                       "app-db — identical, not merely equal — and is verified by identity; "
                       ":fresh-equal installs a freshly built map of the same contents and is "
                       "verified by the reference moving while the value does not; :one-leaf "

--- a/implementation/freehand/test/re_frame/freehand/bench/b10_two_clock_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b10_two_clock_dom_cljs_test.cljs
@@ -1,0 +1,463 @@
+(ns re-frame.freehand.bench.b10-two-clock-dom-cljs-test
+  "B10's rows — DC-09's two-clock operating envelope, measured.
+
+  This file is MEASUREMENT, not a law. DC-09 asks for numbers and for a
+  recommendation about whether new vocabulary is warranted; it does not
+  ask for a new invariant, and the deterministic property the numbers sit
+  on top of — a controlled input drops nothing while its frame is busy —
+  is already rostered as FH-INPUT-003, whose own suite says in as many
+  words that the latency distributions under contention 'belong to the
+  measurement spine'. This is that spine. No `FH-…` id is minted here and
+  nothing enrols in the conformance roster.
+
+  What DOES gate here is the instrument. Every deterministic fact the
+  numbers depend on is asserted before any figure is quoted:
+
+    * the fixture's arithmetic (300 cells, the ladder, the two config
+      shapes and their leaf counts);
+    * C2 — each mode's PREDICTED DOM mutation count against the count a
+      `MutationObserver` measured;
+    * the flatness of the host-only arm across the sibling ladder, which
+      is what proves the ladder does not leak into the arm that must not
+      feel it;
+    * zero dropped keystrokes and an intact caret at every rung, before
+      a single latency is discussed — DC-09's acceptance criterion 2, in
+      that order deliberately.
+
+  The distributions themselves are `:status :evidence` under D021 and
+  cannot gate: `re-frame.freehand.bench.measure` refuses to construct a
+  duration measurement carrying a threshold at all.
+
+  Runtime: these figures are CHROME. Nothing here is quoted for Node or
+  for the JVM, and no share measured here transfers to either as an
+  absolute."
+  (:require [cljs.test :refer-macros [async deftest is testing use-fixtures]]
+            [re-frame.adapter.uix :as react-substrate]
+            [re-frame.core :as rf]
+            [re-frame.freehand.bench.b10-two-clock :as b10]
+            [re-frame.freehand.bench.b6-harness :as h]
+            [re-frame.freehand.bench.measure :as m]
+            [re-frame.freehand.mount-support :as ms]
+            [re-frame.freehand.react :as fr]
+            [re-frame.freehand.root :as root]
+            [re-frame.test-support :as test-support]))
+
+(def ^:private rounds 4)
+(def ^:private sampling {:warmup 3 :samples 10})
+(def ^:private burn-ms 4.0)
+(def ^:private drive-ms 700)
+
+(def ^:private runtime-fixture
+  (test-support/make-reset-runtime-fixture
+    {:adapter       react-substrate/adapter
+     :ambient-frame nil
+     :async?        true}))
+
+(use-fixtures :each
+  {:before (fn []
+             (root/reset-registry!)
+             (fr/reset-boundaries!)
+             ((:before runtime-fixture))
+             (h/leave-act-environment!))
+   :after  (fn []
+             ((:after runtime-fixture))
+             (root/reset-registry!)
+             (fr/reset-boundaries!))})
+
+(defn- browser? [] (and (exists? js/document) (some? (.-createElement js/document))))
+
+(defn- skip [] (is true "a real browser is required — the browser job runs this row"))
+
+;; ===========================================================================
+;; The fixture is what it says it is
+;; ===========================================================================
+
+(deftest the-fixture-is-what-it-says-it-is
+  (testing "Arithmetic over the fixture, so a reader can check every
+            premise the tables rest on without re-running anything. The
+            widest rung must be a PARTIAL update — a 200-sibling crossing
+            that happened to move the whole page would be measuring
+            something else entirely."
+    (is (= 300 b10/cells-n))
+    (is (= [0 1 10 50 200] b10/sibling-ladder))
+    (is (= [30 60 120 240] b10/rate-ladder))
+    (is (< (inc (apply max b10/sibling-ladder)) b10/cells-n)
+        "the widest rung leaves cells untouched, so it is a partial update")
+    (is (= 12 (count (:encoding (b10/build-config :vega 0))))
+        "vega-shaped: one encoding channel per declared channel")
+    (is (= 96 (get-in b10/config-shapes [:vega :leaves]))
+        "and eight leaves per channel, which is what the equality walk costs")
+    (is (= 900 (count (b10/build-config :spread 0)))
+        "spread-shaped: one flat entry per declared cell")
+    (is (= (b10/build-config :spread 0) (b10/build-config :spread 0))
+        "two builds at the same generation are EQUAL — the fresh-equal arm
+         has something to be equal to")
+    (is (not (identical? (b10/build-config :spread 0) (b10/build-config :spread 0)))
+        "and are NOT identical — so the arm really does move the reference")
+    (is (not= (b10/build-config :spread 0) (b10/build-config :spread 1))
+        "and a generation apart they differ — the one-leaf arm really changes a leaf")))
+
+;; ===========================================================================
+;; C2 — the size control: predicted DOM mutations against measured
+;; ===========================================================================
+
+(deftest c2-every-mode-moves-exactly-the-nodes-its-arithmetic-predicts
+  (testing "The positive control on SIZE. Each mode's mutation count is
+            computed from the fixture — `k + 1` for a crossing that
+            dirties k siblings beside the leaf, one attribute for the
+            host clock, and NONE for a fresh-but-equal write — and
+            compared against what a MutationObserver actually saw. A
+            sibling knob that does not dirty what it claims, or an
+            equality arm that is fast because it did nothing, fails here
+            rather than in a conclusion."
+    (if-not (browser?) (skip)
+      (async done
+        (let [mnt (b10/mount! :vega)]
+          (try
+            (doseq [k b10/sibling-ladder
+                    mode [:host-only :fresh-equal :one-leaf]]
+              (let [arm (b10/sibling-mode mode k)
+                    ;; one unmeasured warm crossing, then the counted one
+                    _   ((:run! arm) (:container mnt) (:observer mnt))
+                    r   ((:run! arm) (:container mnt) (:observer mnt))]
+                (is (:ok? r)
+                    (str mode " at k=" k ": the crossing was verified at the DOM"))
+                (is (= (:predicted-mutations arm) (get-in r [:mutations :total]))
+                    (str mode " at k=" k ": predicted "
+                         (:predicted-mutations arm) " DOM mutations, measured "
+                         (get-in r [:mutations :total])
+                         " " (pr-str (get-in r [:mutations :by-type]))))))
+            (finally (b10/release! mnt) (done))))))))
+
+;; ===========================================================================
+;; C1 — the duration control
+;; ===========================================================================
+
+(deftest c1-a-window-of-computed-duration-reads-its-own-duration
+  (testing "The positive control on DURATION, and the machine's own
+            contention meter. A busy-wait of exactly 4.00 ms is timed
+            through the same window every figure in this file is timed
+            through. The overshoot is clock quantisation plus whatever
+            the operating system took away, and it is published beside
+            the tables so a contended round is read as a contended round
+            rather than as a slow substrate.
+
+            The assertion is deliberately loose — this is EVIDENCE about
+            the machine, and a tight bound would be a flake on a box
+            running other agents. What it must not do is read BELOW the
+            predicted duration, which would mean the window is not
+            measuring what it brackets."
+    (if-not (browser?) (skip)
+      (async done
+        (let [mnt (b10/mount! :vega)
+              arm (b10/burn-arm burn-ms)]
+          (try
+            (let [rs (vec (for [_ (range 12)] ((:run! arm) (:container mnt) (:observer mnt))))
+                  s  (m/summarise (mapv :total-ms rs))
+                  ov (- (:p50 s) burn-ms)]
+              (is (>= (:min s) burn-ms)
+                  (str "no sample read below its own predicted " burn-ms
+                       " ms; min was " (:min s)))
+              (is (zero? (count (remove :ok? rs))))
+              (h/publish! "B10 C1 / duration control"
+                          {:control        :control-burn
+                           :predicted-ms   burn-ms
+                           :measured       s
+                           :p50-overshoot-ms (/ (js/Math.round (* ov 1000)) 1000.0)
+                           :note (str "overshoot is instrument quantisation plus machine "
+                                      "contention; every B10 table is read on this scale")}))
+            (finally (b10/release! mnt) (done))))))))
+
+;; ===========================================================================
+;; M1 — the sibling ladder, in both orders
+;; ===========================================================================
+
+(defn- ladder-round!
+  [mnt ks]
+  (into {}
+        (map (fn [k]
+               [k (b10/run-arms! mnt
+                                 [(b10/sibling-mode :host-only k)
+                                  (b10/sibling-mode :fresh-equal k)
+                                  (b10/sibling-mode :one-leaf k)
+                                  (b10/burn-arm burn-ms)]
+                                 sampling)]))
+        ks))
+
+(deftest m1-the-semantic-crossing-costs-what-the-ladder-says
+  (testing "The service time of ONE semantic crossing, as a function of
+            how many siblings the application chose to dirty with it.
+            This is the whole envelope: at an offered rate R the semantic
+            clock has 1000/R ms per event, and the envelope is where the
+            crossing's cost crosses that budget.
+
+            Half the rounds walk the ladder ASCENDING and half
+            DESCENDING, and both are published. A wide arm inflating its
+            successor is a documented hazard here and it is only visible
+            from the two orders side by side."
+    (if-not (browser?) (skip)
+      (async done
+        (let [mnt (b10/mount! :vega)]
+          (try
+            (let [up   (vec (for [_ (range (/ rounds 2))]
+                              (ladder-round! mnt b10/sibling-ladder)))
+                  down (vec (for [_ (range (/ rounds 2))]
+                              (ladder-round! mnt (reverse b10/sibling-ladder))))
+                  all  (into up down)
+                  unv  (reduce + (for [r all, [_ arms] r, [_ s] arms] (:unverified s)))
+                  tot  (reduce + (for [r all, [_ arms] r, [_ s] arms] (:n s)))
+                  host (for [r all, [_ arms] r] (get-in arms [:host-only :total-ms :p50]))]
+              (is (zero? unv)
+                  (str "every measured crossing was read back out of the DOM inside its own
+                        window — " unv " unverified of " tot))
+              ;; The ladder must not leak into the arm that never crosses.
+              (is (< (- (apply max host) (apply min host)) 1.0)
+                  (str "the host-only arm is FLAT across the ladder — spread "
+                       (- (apply max host) (apply min host)) " ms over "
+                       (count host) " readings. A host clock that felt the sibling knob
+                       would mean the ladder is contaminating an arm that never crosses."))
+              (h/publish!
+                "B10 M1 / sibling ladder"
+                (b10/record
+                  :B10/sibling-ladder
+                  "service time of one semantic crossing against dirty-sibling count"
+                  {:cells        b10/cells-n
+                   :ladder       b10/sibling-ladder
+                   :config-shape :vega
+                   :arms         [:host-only :fresh-equal :one-leaf :control-burn]
+                   :crossing     :dispatch-sync
+                   :unverified   unv
+                   :of           tot
+                   :measurement-method
+                   (str "t0; react-dom/flushSync around rf/dispatch-sync, with t1 taken "
+                        "INSIDE the flush the instant the dispatch returns; t2 after the "
+                        "flush. :event-ms is t1-t0 (router, interceptors, reducer, app-db "
+                        "install, subscription notification); :commit-ms is t2-t1 (React "
+                        "render, commit, DOM mutation). The crossing is then read back out "
+                        "of the DOM — or, for the fresh-equal arm whose whole point is that "
+                        "the page must NOT move, out of the store, by proving the reference "
+                        "moved and the value did not. Arm order rotates on the sample index; "
+                        "the LADDER is walked ascending in half the rounds and descending in "
+                        "the other half, both published. A control-burn arm of computed "
+                        "4.00 ms duration rides in every cell as the machine's contention "
+                        "meter.")}
+                  (assoc sampling :rounds rounds)
+                  {:ascending  up
+                   :descending down}))
+              (h/publish! "B10 M1 / derived envelope"
+                          {:note (str "budget at rate R is 1000/R ms; the envelope is the "
+                                      "largest R whose budget exceeds the crossing's p95")
+                           :budgets-ms (into {} (map (fn [r] [r (/ 1000.0 r)])) b10/rate-ladder)
+                           :p95        (into {} (map (fn [[k arms]]
+                                                       [k (into {} (map (fn [[id s]]
+                                                                          [id (get-in s [:total-ms :p95])]))
+                                                                arms)]))
+                                             (first all))}))
+            (finally (b10/release! mnt) (done))))))))
+
+;; ===========================================================================
+;; M2 — equality cost, at two config shapes
+;; ===========================================================================
+
+(deftest m2-what-a-behavior-config-costs-when-it-did-not-change
+  (testing "The behavior-config axis: stable-reference against
+            fresh-but-`rf=`-equal against one-leaf-changed, at a
+            Vega-shaped nested spec and a Spread-shaped flat range. The
+            difference between the first two is the equality cost — what
+            an application pays for handing a behavior a freshly built
+            config that says the same thing — and the number is only
+            meaningful beside the leaf counts the fixture test pins.
+
+            The behavior's own `:update` call count is recorded alongside,
+            because whether Freehand elides an update whose config is
+            unchanged is a question this fixture ANSWERS by counting
+            rather than asserts by reading the runtime."
+    (if-not (browser?) (skip)
+      (async done
+        (let [out (atom {})]
+          (try
+            (doseq [shape [:vega :spread]]
+              (let [mnt (b10/mount! shape)]
+                (try
+                  (b10/reset-behavior-log!)
+                  (let [before (b10/behavior-calls)
+                        rs     (vec (for [_ (range rounds)]
+                                      (b10/run-arms!
+                                        mnt
+                                        [(b10/config-mode :stable shape)
+                                         (b10/config-mode :fresh-equal shape)
+                                         (b10/config-mode :one-leaf shape)
+                                         (b10/burn-arm burn-ms)]
+                                        sampling)))
+                        after  (b10/behavior-calls)]
+                    (swap! out assoc shape
+                           {:rounds rs
+                            :behavior-updates (- (:update after) (:update before))
+                            :leaves (get-in b10/config-shapes [shape :leaves])})
+                    (doseq [r rs [id s] r]
+                      (is (zero? (:unverified s))
+                          (str shape "/" id ": " (:unverified s) " unverified of " (:n s)))))
+                  (finally (b10/release! mnt)))))
+            (h/publish!
+              "B10 M2 / config equality"
+              (b10/record
+                :B10/config-equality
+                "cost of one behavior-config crossing by equality class and config shape"
+                {:shapes       (into {} (map (fn [[k v]] [k (select-keys v [:leaves :channels])]))
+                                     b10/config-shapes)
+                 :modes        [:stable :fresh-equal :one-leaf]
+                 :crossing     :dispatch-sync
+                 :cells        b10/cells-n
+                 :measurement-method
+                 (str "the same window as M1. :stable re-installs the value already in "
+                      "app-db — identical, not merely equal — and is verified by identity; "
+                      ":fresh-equal installs a freshly built map of the same contents and is "
+                      "verified by the reference moving while the value does not; :one-leaf "
+                      "installs one differing in exactly one leaf. The behavior's :update "
+                      "call count across the whole run is published beside the timings.")}
+                (assoc sampling :rounds rounds)
+                @out))
+            (finally (done))))))))
+
+;; ===========================================================================
+;; M3 — the driven arm: offered against observed against accepted
+;; ===========================================================================
+
+(deftest m3-the-offered-rate-is-not-the-observed-rate
+  (testing "The envelope, driven rather than derived. A timer offers a
+            semantic event every 1000/R ms through the ORDINARY
+            asynchronous `rf/dispatch` — what a pointer handler calls, and
+            the only crossing that CAN build a backlog, since a
+            dispatch-sync one is finished before the next offer is made.
+
+            Four things are counted separately and none of them is
+            assumed equal to another: what the application OFFERED, what
+            the timer was asked for (computed, not measured), what the
+            reducer APPLIED, and what the DOM committed. The gap between
+            the first two is the browser refusing the rate; the gap
+            between the second and third is the framework refusing it.
+            They are different failures and DC-09 asks for them apart."
+    (if-not (browser?) (skip)
+      (async done
+        (let [mnt  (b10/mount! :vega)
+              runs (atom [])
+              plan (for [k [0 200], r b10/rate-ladder] [k r])]
+          (-> (reduce (fn [p [k r]]
+                        (.then p (fn [_]
+                                   (-> (b10/drive! mnt r k drive-ms)
+                                       (.then (fn [rec] (swap! runs conj rec) nil))))))
+                      (js/Promise.resolve nil)
+                      plan)
+              (.then
+                (fn [_]
+                  (doseq [{:keys [rate siblings offered expected applied]} @runs]
+                    (is (pos? offered)
+                        (str "rate " rate " / k=" siblings ": the driver ran at all"))
+                    (is (<= applied offered)
+                        (str "rate " rate " / k=" siblings
+                             ": the reducer cannot apply more than was offered ("
+                             applied " applied, " offered " offered)")))
+                  (h/publish!
+                    "B10 M3 / driven rates"
+                    (b10/record
+                      :B10/driven-rates
+                      "offered against browser-observed against accepted against committed"
+                      {:rates       b10/rate-ladder
+                       :ladder      [0 200]
+                       :duration-ms drive-ms
+                       :cells       b10/cells-n
+                       :crossing    :dispatch-async
+                       :measurement-method
+                       (str "setInterval at 1000/R ms for " drive-ms " ms, each tick issuing "
+                            "an ordinary asynchronous rf/dispatch. :expected is computed "
+                            "(floor(duration x rate / 1000)) and is NOT a measurement; "
+                            ":offered counts driver invocations; :applied is incremented "
+                            "inside the reducer; :mutations counts DOM records; "
+                            ":peak-backlog is the largest offered-minus-applied ever seen at "
+                            "an offer; :tail-ms is from the last offer to the page showing "
+                            "the last generation, polled at 4 ms with a 2000 ms ceiling; "
+                            ":latency-ms is the offer-to-DOM distribution read from the "
+                            "MutationObserver callback that carried each generation.")}
+                      {:warmup 0 :samples (count @runs)}
+                      {:runs @runs}))
+                  nil))
+              (.catch (fn [e] (is false (str "M3 rejected: " e))))
+              (.finally (fn [] (b10/release! mnt) (done)))))))))
+
+;; ===========================================================================
+;; M4 — the controlled field, correctness FIRST
+;; ===========================================================================
+
+(def ^:private typed-string
+  "Thirty characters, so a dropped one is visible as a length AND as a
+  mismatch rather than only as a length."
+  "the quick brown fox jumps over")
+
+(deftest m4-a-controlled-field-drops-nothing-at-any-rung-of-the-ladder
+  (testing "DC-09 acceptance criterion 2, in the order it is written:
+            no drops and an intact caret BEFORE latency is discussed.
+            FH-INPUT-003 already gates this property at a dozen
+            contending siblings; what is new here is the LADDER —
+            0, 1, 10, 50 and 200 siblings dirtied by every single
+            keystroke — and the per-keystroke distribution beside it.
+
+            Keystrokes are appended through the node's own prototype
+            setter and delivered as real bubbling `input` events, so
+            React's value tracker sees exactly what it sees for a user.
+            A character the synchronous round trip failed to land is a
+            character React erases at the end of the discrete event, so a
+            drop shows up as a SHORTER string, not a late one."
+    (if-not (browser?) (skip)
+      (async done
+        (let [out (atom {})]
+          (try
+            (doseq [k b10/sibling-ladder]
+              (let [mnt (b10/mount! :vega)
+                    c   (:container mnt)]
+                (try
+                  (rf/dispatch-sync [:b10/contend k] {:frame b10/frame-id})
+                  (ms/live!)
+                  (let [node (b10/field-node c)
+                        _    (.focus node)
+                        lat  (vec (for [ch (seq typed-string)]
+                                    (let [t0 (m/now-ms)]
+                                      (ms/keystroke! node (str ch))
+                                      (- (m/now-ms) t0))))]
+                    (is (= typed-string (.-value node))
+                        (str "k=" k ": no character was dropped — the field holds "
+                             (pr-str (.-value node))))
+                    (is (= [(count typed-string) (count typed-string)] (ms/caret node))
+                        (str "k=" k ": the caret is at the end of what was typed"))
+                    (is (= (str (count typed-string)) (b10/cell-text c 0))
+                        (str "k=" k ": the leaf settled on the last keystroke's state"))
+                    (is (= (str (count typed-string)) (b10/cell-text c k))
+                        (str "k=" k ": and so did the furthest contending sibling"))
+                    (when (< (inc k) b10/cells-n)
+                      (is (not= (str (count typed-string)) (b10/cell-text c (inc k)))
+                          (str "k=" k ": and the cell BEYOND the rung did not move")))
+                    (swap! out assoc k {:keystrokes (count typed-string)
+                                        :per-keystroke-ms (m/summarise lat)}))
+                  (finally (b10/release! mnt)))))
+            (h/publish!
+              "B10 M4 / controlled field under contention"
+              (b10/record
+                :B10/controlled-field
+                "per-keystroke cost of the synchronous controlled round trip by sibling count"
+                {:cells      b10/cells-n
+                 :ladder     b10/sibling-ladder
+                 :typed      typed-string
+                 :keystrokes (count typed-string)
+                 :crossing   :controlled-input-door
+                 :measurement-method
+                 (str "each keystroke APPENDS one character through HTMLInputElement's own "
+                      "prototype value setter and fires a real bubbling InputEvent, outside "
+                      "React's act environment, so the controlled-input door takes the "
+                      "synchronous round trip it takes for a user. The clock brackets the "
+                      "dispatchEvent call, which is the whole round trip: listener, event, "
+                      "reducer, subscription, render, commit and React's own end-of-event "
+                      "value restoration. Correctness is asserted at the DOM — the field's "
+                      "value, the caret, the leaf, the furthest contending sibling and the "
+                      "cell beyond the rung — BEFORE any latency is read.")}
+                {:warmup 0 :samples (count typed-string) :rounds 1}
+                @out))
+            (finally (done))))))))


### PR DESCRIPTION
DC-09 evidence for `rf2-drpa3.182.12`: measure Freehand's two-clock operating envelope, and decide whether it justifies new vocabulary.

**It does not.** Recommendation: add no scheduling, throttle, debounce, coalescing, equality or preview API. Three of the four candidates have no attributable bottleneck at all.

## What landed

- `implementation/freehand/test/re_frame/freehand/bench/b10_two_clock.cljs` — fixture + instrument. **No eleventh instrument**: the window, the publication and the range fold are B6's (`b6-harness`), the clock and the distribution summary are `bench.measure`, the record is `bench.provenance`. What is new is the fixture and the axes, per B9's precedent.
- `…/b10_two_clock_dom_cljs_test.cljs` — the rows. Deterministic facts gate; distributions are `:status :evidence` and cannot (`measure` refuses to construct a duration measurement carrying a threshold).
- `docs/design/freehand/studio/two-clock-operating-envelope.md` — the report.

**This is measurement, not a law.** No `FH-…` id is minted and nothing enrols in the conformance roster; `conformance-index.md` and `roster.cljc` are untouched. The deterministic property underneath is already rostered as **FH-INPUT-003**, whose own suite says the contention distributions "belong to the measurement spine". This is that spine, extended from a single dozen contending siblings to the full 0/1/10/50/200 ladder.

## The envelope (HeadlessChrome 147, `:optimizations :none`, `goog.DEBUG true`)

Sustained semantic rate, driven through ordinary async `rf/dispatch`: **~190/s at 0 dirty siblings, ~49/s at 200.** Latency-quality envelope (95% of crossings inside one `1000/R` budget): **60 Hz is comfortable to 50 siblings and breaks between 50 and 200; 120 Hz never clears p95 in a dev build; 240 Hz is unreachable because the browser stops offering first.**

Cost of one crossing, p50 range over 4 rounds: 3.5–4.6 ms at k=0 rising to 18.3–22.2 ms at k=200. The **event** half is flat at 3–4 ms across the whole ladder; the **commit** half is what scales (0.4 → 17.5 ms, ≈0.085 ms per dirtied cell).

Three results that carry the recommendation:

1. **Peak backlog was 1** at every rate and both loads, `outstanding` 0 in all eight driven runs, tail ≤5.4 ms. The seam does not degrade by queueing — the browser makes fewer offers. A throttle verb would suppress offers the browser has already stopped making.
2. **Fresh-but-`rf=`-equal is indistinguishable from stable-reference** (0.2–0.3 ms at 96 leaves, 0.4–0.6 at 900), repaints nothing, and Freehand already elides the behavior `:update` — proved by counting, 52 of 52 matching the changed crossings exactly.
3. **The host clock is under Chrome's 0.1 ms clock resolution at every rung**, and its flatness across the ladder is gated.

## The one finding that was not on the matrix

Reading a high-rate subscription in a view that also builds a collection costs a **constant 40–44 ms** more than reading it one boundary down — independent of payload size, while moving *three fewer* DOM nodes. Same "one leaf changed", 8–19× apart. Measured, not asserted: the fixture carries both spellings and nothing else differs. Remedy is a call site, not a verb; guidance belongs to `rf2-fby7o`.

## Measurement discipline

- **0 unverified of 800** (sibling ladder) and **0 unverified of 640** (config axis). Every crossing read back out of the DOM inside its own window; the equality arm, whose page must *not* move, verified at the store instead so an arm that did nothing cannot pass.
- **C1, computed duration**: a 4.00 ms busy-wait rides in every cell. Predicted 4.00, measured p50 4.0 in all 40 published cells, overshoot never above 0.3 ms — the box was not contended.
- **C2, computed size**: predicted DOM mutation counts (1 / 0 / k+1) equalled measured at all 15 mode×rung combinations, and the driven arm reproduced exactly 201.0 mutations per crossing independently.
- **Both ladder orders run.** Ranges overlap at every rung but k=200, where the difference tracks a monotonic round-1→4 warm-up present at every rung in both orders — so it is drift, not order.
- Ranges across rounds throughout; overlapping ranges are reported as indistinguishable.
- Runtime labelled on every figure. Nothing is quoted for Node or the JVM.
- A found instrument fault is recorded rather than quietly fixed: the first equality arm built its config from a fixed generation, so a `:fresh-equal` crossing following a `:one-leaf` one was equal to nothing and failed its own read-back in 7 of every 10 samples. Rotating arm order exposed it.

## What could not be determined

The **production** envelope. These are dev-build numbers, so the Spec 009 seam, schema validation and trace emission are live on the measured path — every cost an upper bound, every rate a lower bound. An `:advanced` reading needs a build target in `implementation/shadow-cljs.edn`, hot-zone with four siblings live; it was left alone rather than raced. Also not determined: real coalesced pointer bursts (the driver is a `setInterval`), sub-0.1 ms costs (Chrome's clamp), and driven rungs between 0 and 200.

## Quality gates

All run in the foreground, to completion, never piped through `tail` or `grep`.

| gate | result | exit |
|---|---|---|
| `shadow-cljs compile browser-test-freehand-bench` | 259 files, **0 warnings** | **0** |
| `browser-test-freehand-bench` run — the measurement itself, and the focused browser gate for these files | Ran **30** tests / **466** assertions, **0 failures, 0 errors** | **0** |
| `implementation/freehand` JVM (`clojure -M:test`) | Ran **1229** tests / **8282** assertions, **0 failures, 0 errors** | **0** |
| `npm run test:browser` (full, `BROWSER_TEST_TIMEOUT_MS=600000`) | Ran **850** tests / **5549** assertions, **0 failures, 0 errors** | **0** |
| `npm run test:cljs` (node-test — `-dom-cljs-test$` also matches its `cljs-test$` regex, so the new namespace runs there too and gates on `(browser?)`) | Ran **11819** tests / **58822** assertions, **0 failures, 0 errors** | **0** |

Deferred to CI: the JVM implementation sweep, the standalone-example coverage gate, and the rigorous/release-sized lanes.

Nothing here touches `implementation/**/src`, `tools/`, `scripts/`, `.github/`, `spec/`, `roster.cljc` or `conformance-index.md`. The diff is two new test-tree namespaces and one new design document — 1671 insertions, 0 deletions, 0 files modified.

Raw per-round records: `ai/findings/2026-07-28.two-clock-envelope-raw.edn` (local-only, gitignored).

Follow-up filed: **rf2-drpa3.182.15** — re-take the envelope under `:advanced`, which needs a build target in the hot-zone `implementation/shadow-cljs.edn` and was left alone rather than raced against four live siblings.
