### PR TITLE
ci: give the browser lane headroom for the control witnesses

### DIFF
--- a/.github/workflows/freehand-bench.yml
+++ b/.github/workflows/freehand-bench.yml
@@ -353,10 +353,13 @@ jobs:
       # or under this flag. Here the console IS the evidence, so it is always
       # wanted.
       RF2_VERBOSE_TESTS: '1'
-      # The default 120s covers a normal DOM suite; this page mounts B2's
-      # storm at two scales through four arms, B4's contended row and B5's
-      # sampled mounts, so it is given room rather than raced.
-      BROWSER_TEST_TIMEOUT_MS: '300000'
+      # This lane used to pin BROWSER_TEST_TIMEOUT_MS=300000, because it
+      # mounts B2's storm at two scales through four arms, B4's contended row
+      # and B5's sampled mounts, and 300s was room against a 120s default.
+      # The runner's default is now 360s (rf2-15047), so the pin had become
+      # an inversion — a bench lane held to a SHORTER budget than an ordinary
+      # one. Dropped rather than re-tuned: the inherited default already
+      # covers this page, and one number is easier to keep honest than two.
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 

--- a/implementation/scripts/run-browser-tests.cjs
+++ b/implementation/scripts/run-browser-tests.cjs
@@ -64,9 +64,10 @@ const URL = process.env.BROWSER_TEST_URL || 'http://localhost:8021';
 // and it fails through THIS runner — which dumps the console trail and the
 // namespaces reached — rather than as an opaque runner kill.
 //
-// Per-lane needs differ; $BROWSER_TEST_TIMEOUT_MS remains the override (see
-// check-ui-mounted-prod-elision.cjs, which pins its negative-control run
-// lower on purpose).
+// Per-lane needs differ; $BROWSER_TEST_TIMEOUT_MS remains the override.
+// check-ui-mounted-prod-elision.cjs still pins 120000 for its negative-
+// control mutant run — left alone deliberately: that run is EXPECTED to
+// fail, so it wants a short leash, not this budget.
 const DEFAULT_TIMEOUT_MS = 360000;
 const TIMEOUT_MS = parseInt(process.env.BROWSER_TEST_TIMEOUT_MS || String(DEFAULT_TIMEOUT_MS), 10);
 const POLL_MS = 200;

--- a/implementation/scripts/run-browser-tests.cjs
+++ b/implementation/scripts/run-browser-tests.cjs
@@ -43,7 +43,32 @@ const {
 const { sleep } = require('./lib/local-browser-harness.cjs');
 
 const URL = process.env.BROWSER_TEST_URL || 'http://localhost:8021';
-const TIMEOUT_MS = parseInt(process.env.BROWSER_TEST_TIMEOUT_MS || '120000', 10);
+// How long to wait for the cljs.test summary before calling it a timeout.
+//
+// This is a BUDGET, not a correctness bound: the suite either prints a
+// summary or it does not, and the number only decides how long we let it
+// try. It was 120s, chosen when the `:browser-test` bundle was a fast DOM
+// suite. It is now the long pole of a growing control-witness corpus —
+// mounted rows driven through real-time settles with 2-4s poll budgets, so
+// each witness costs ~35-40s of mostly WALL-CLOCK (not CPU) for ~5-12
+// tests. Measured on the same bundle: 843 tests / 58s on the pre-witness
+// main, 855 tests / 99s once the splitter witness landed. Three more
+// witnesses were queued behind that, i.e. ~+120s, which exceeds 120s on
+// arithmetic alone — and CI is slower than a dev box on the compute half,
+// so a lane that passes locally at ~95s times out there (rf2-15047).
+//
+// 360s restores roughly the headroom the lane had before the witnesses
+// (~3.6x the current green run) and leaves room for a few more of them
+// before this recurs. It is deliberately NOT larger: a genuine hang still
+// fails inside 6 minutes, well under the job's own `timeout-minutes: 45`,
+// and it fails through THIS runner — which dumps the console trail and the
+// namespaces reached — rather than as an opaque runner kill.
+//
+// Per-lane needs differ; $BROWSER_TEST_TIMEOUT_MS remains the override (see
+// check-ui-mounted-prod-elision.cjs, which pins its negative-control run
+// lower on purpose).
+const DEFAULT_TIMEOUT_MS = 360000;
+const TIMEOUT_MS = parseInt(process.env.BROWSER_TEST_TIMEOUT_MS || String(DEFAULT_TIMEOUT_MS), 10);
 const POLL_MS = 200;
 const VERBOSE_TESTS = isVerboseTests();
 


### PR DESCRIPTION
The `:browser-test` lane waits for the cljs.test summary and gives up after a budget. That budget was **120 s**, chosen when the bundle was a fast DOM suite. It no longer is.

**This is not a prediction about queued PRs — `main` is already red on this lane.** Run [`30291716420`](https://github.com/day8/re-frame2/actions/runs/30291716420) (sha `079905169`, 17:59): `Timed out after 120000ms waiting for cljs.test summary`, 93 of the bundle's 149 namespaces reached, no summary, no failing assertion.

Closes rf2-15047. Files **rf2-76lhy** (P1) for the thing this deliberately does *not* fix — please read "Is this hiding a hang?", because the answer is **partly yes**.

## Before / after, and why 360 s

Browser **run phase** only (`Serving ...` to summary line), measured in CI:

| bundle | tests | run phase | outcome |
|---|---:|---:|---|
| `main`, pre-witness (job `90042176242`) | 843 | 58 s | green |
| `main` + splitter witness, **as merged** (job `90063630119`) | 855 | **>120 s** | **RED — timed out at 93/149 ns** |
| `main` + splitter + **this change** (job `90071495499`) | 855 | **146 s** | **green** |

That last row is the direct proof. Same code as `main`, plus one integer. It needed **146 s** and it got them.

Local measurement agrees on the shape: each control witness costs **~35-40 s for ~5-12 tests** — mounted rows driven through real-time settles with 2-4 s poll budgets, so the cost is mostly *wall-clock*, not CPU. Three more are queued (#7180, #7182, #7183).

**120000 -> 360000.** The reasoning:

- **~2.5x the run that just went red** (146 s), and ~3.6x the 99 s the lane was measured at before the splitter landed. That restores roughly the headroom the lane had pre-witness (52% at 58 s / 120 s) and leaves room for the three queued witnesses plus a couple more.
- **300 s was considered and rejected.** At 146 s today plus three queued witnesses it is uncomfortable; and #7183's *actual* degraded CI run (below) extrapolates to **~271 s** for the full bundle. 300 s would have been marginal against a case already observed. 360 s covers it.
- **Deliberately not larger.** A genuine hang still fails inside 6 minutes — well under this job's own `timeout-minutes: 45` — and it fails *through this runner*, which dumps the console trail and the namespaces reached, rather than as an opaque runner kill that tells you nothing.

## Where it belongs: the runner's default, not a workflow override

The suite's size is not CI policy. `npm run test:browser` needs the same number on a laptop that it needs on a runner, and **six** workflow steps across `test.yml` and `expensive-tests.yml` call into this runner. A workflow-only override would fix one of them and *widen* the local/CI divergence that made #7183 confusing in the first place ("passes locally, times out in CI").

`$BROWSER_TEST_TIMEOUT_MS` stays exactly as it is — the per-lane escape hatch.

Two consequences, both handled:

- **`freehand-bench.yml`'s `BROWSER_TEST_TIMEOUT_MS: '300000'` is dropped.** At a 360 s default that pin had become an *inversion* — a bench lane held to a **shorter** budget than an ordinary one. Removed rather than re-tuned: the inherited default already covers that page, and one number is easier to keep honest than two. No workflow in the repo now sets this variable.
- **`check-ui-mounted-prod-elision.cjs`'s `BROWSER_TEST_TIMEOUT_MS: '120000'` is left alone**, and the runner now says why: that is the *negative-control mutant* run, which is **expected to fail**. It wants a short leash, not this budget.

## Is this hiding a hang?

**Partly, yes — and I want that on the record rather than buried.** I started convinced this was pure budget arithmetic. Measurement changed my mind.

The suspicion on record: both observed stalls landed in *hydration* suites, which toggle the process-global `IS_REACT_ACT_ENVIRONMENT`, and 73 test files manipulate that global with ad-hoc set/restore.

**What is ruled out — a fixed deadlock.** Three timeouts are now on record, and cljs.test runs namespaces alphabetically:

| run | job | namespaces reached | last namespace |
|---|---|---:|---|
| #7183 attempt 1 | `90055797170` | 66 | `re-frame.freehand.root-hydration-…` |
| `main` | `90063630119` | 93 | `re-frame.ssr.phase-flip-hydration-…` |
| #7183 attempt 2 | `90062056406` | 99 | `re-frame.ssr.streaming-hydration-lifecycle-…` |

Every one of those stop points is *passed* by one of the others. No namespace is a fixed stall site, and all three runs make broad progress rather than stopping dead. That is why this stayed a lane tweak rather than becoming a defect hunt. (The "always a hydration suite" pattern is likewise weaker than it looks: all three stops fall in the contiguous ns-66..99 band, which is simply where minute two lands — and that band *is* the hydration/SSR block.)

**What is not explained — the magnitude.** The bundle is **149 namespaces** (counted with `RF2_VERBOSE_TESTS=1`, which flushes the diagnostics buffer on success too). Five consecutive local runs of #7183's branch, warm:

```
iter=1 exit=0  68s  149 namespaces  851 tests / 5520 assertions / 0 failures
iter=2 exit=0  52s  149 namespaces  851 tests / 5520 assertions / 0 failures
iter=3 exit=0  51s  149 namespaces  851 tests / 5520 assertions / 0 failures
iter=4 exit=0  65s  149 namespaces  851 tests / 5520 assertions / 0 failures
iter=5 exit=0  57s  149 namespaces  851 tests / 5520 assertions / 0 failures
```

Per-namespace rate, same bundle:

| run | namespaces / time | s per ns | vs CI green `main` |
|---|---|---:|---|
| CI green `main` pre-witness | 149 / 58 s | 0.39 | — completes |
| local #7183, 5 runs | 149 / 51-68 s | 0.34-0.46 | ~1x — completes 5/5 |
| CI `main` (red) | 93 / >120 s | >1.29 | **3.3x slower** |
| CI #7183 attempt 2 | 99 / >120 s | >1.21 | **3.1x slower** |
| CI #7183 attempt 1 | 66 / >120 s | >1.82 | **4.7x slower** |

Two things fall out of that table. **#7183 adds eight tests, and eight tests do not make a bundle 3-5x slower** — and attempt 1 was already 4.7x off the pace by namespace 66, across a stretch of the alphabet #7183 does not touch. Second, and worse: **the red `main` row and the green `main` row are the same lane, one witness apart.** That single 12-test witness took `main` from 58 s to >120 s (and to 146 s on this PR). At the ~38 s/witness rate measured locally that should have been ~96 s.

So the witness arithmetic is real and independently justifies this raise — but the *observed* CI costs run roughly double it, with 3-4x run-to-run variance on identical code.

**My read on what.** A broad, uniform, intermittent slowdown that begins partway through a run and affects everything after it is the signature of a **leaked process-global**, not of a hung test. If `IS_REACT_ACT_ENVIRONMENT` is left true by a test that throws between its ad-hoc set and its restore, every subsequent React render takes the `act()` path with its extra flush/settle work. That predicts what is observed: everything after the leak point runs several times slower, the leak point moves run to run, no assertion ever fails, and it does not reproduce on a differently-timed local machine where the throwing race may not fire.

I did not chase it further — 73 files is its own piece of work, and this is a lane tweak.

**What I could not do, and why.** I cannot locate the leak from existing logs: this runner buffers the browser console and flushes it only on failure, so every `Testing <ns>` line in a timeout log carries the same *flush* timestamp (verified — all 66 lines of #7183 attempt 1 are stamped `17:35:28.09x`). With no per-namespace timing, "ns 93 was still running" cannot be distinguished from "ns 93 never returned".

**rf2-76lhy** (raised to **P1**) carries all of this, with the cheap next step named: stamp each diagnostics line with a monotonic offset at *capture* time rather than at flush time. One line, and the next timeout log becomes a per-namespace duration profile that names the leak point.

**The risk this PR creates, stated plainly:** at 360 s the lane goes green *while still degraded*, so the symptom leaves CI without the cause being fixed. That is exactly what rf2-76lhy exists to hold, and why I raised its priority rather than filing it as a footnote.

## Quality gates

Run from `C:/Users/miket/code/re-frame2-worktrees/browser-budget`, foreground, exit codes echoed.

| gate | command | exit |
|---|---|---:|
| `:browser-test` compile | `npx shadow-cljs compile browser-test` | **0** (1076 files, 1075 compiled, **0 warnings**, 131.77 s) |
| **Full browser bundle, to completion** | `node scripts/serve-and-run-browser-tests.cjs` | **0** |
| Runner syntax | `node --check implementation/scripts/run-browser-tests.cjs` | **0** |
| YAML parse, `freehand-bench.yml` | `yaml.safe_load` | **0** (3 jobs) |
| YAML parse, `test.yml` | `yaml.safe_load` | **0** (68 jobs) |

Full-bundle completion evidence, this branch (`origin/main` + this change):

```
RUN_START 2026-07-28T04:26:40
Serving .../implementation/out/browser-test on http://127.0.0.1:8021
Browser tests: Ran 855 tests containing 5609 assertions. 0 failures, 0 errors.
RUN_END 2026-07-28T04:28:55
BROWSER_RUN_EXIT=0
```

**855 tests, 5609 assertions, 0 failures, 0 errors, exit 0.**

**Direct test against #7183's branch** (`worker/witness-ownership-1829` + this change, local branch, not pushed), at the old budget and the new one:

```
RUN A  BROWSER_TEST_TIMEOUT_MS=120000  ->  851 tests / 5520 assertions / 0 failures, 0 errors.  exit 0  (56 s)
RUN B  default (=360000)               ->  851 tests / 5520 assertions / 0 failures, 0 errors.  exit 0  (43 s)
```

Reported honestly: **this machine cannot reproduce #7183's CI timeout** — the bundle completes here in 43-68 s across seven runs, inside even the old budget. So the local run is not the direct proof it was hoped to be; it is what *established* that the CI slowdown is anomalous rather than arithmetic. The direct proof is CI job `90071495499` above: this branch, 146 s, green, where `main` without it went red at 120 s.

Deferred to CI: everything outside the browser lane. This change moves one integer that only `run-browser-tests.cjs` reads.
