### PR TITLE
fix(core): the no-such-fx record names the missing fx, and make-frame publishes atomically (rf2-g0mep, rf2-djkr0)

### DIFF
--- a/implementation/core/src/re_frame/fx.cljc
+++ b/implementation/core/src/re_frame/fx.cljc
@@ -1620,12 +1620,32 @@
       ;; always-on listener so load-order / optional-artefact mistakes are
       ;; visible in production, not only under dev traces. The fx is
       ;; dropped; the cascade continues with the remaining `:fx` entries.
+      ;;
+      ;; rf2-g0mep — `:failing-id fx-id` is what makes the ALWAYS-ON record
+      ;; name WHICH fx was missing. Spec 009 §Observability channels states
+      ;; the attribution rule generally: every always-on error record carries
+      ;; `:failing-id` naming the failing COMPONENT's own code identifier
+      ;; whenever that component is DISTINCT from the dispatched event. Here
+      ;; `:event-id` is the DISPATCHING event and the unregistered fx-id is the
+      ;; failing component, so `emit-error-both!`'s lift applies — without this
+      ;; key the id rode ONLY `:rf.fx/id` on the dev-trace tags (DCE'd under
+      ;; `:advanced` + `goog.DEBUG=false`) and an off-box shipper learnt an fx
+      ;; was missing but not which one. The three sibling fx emit sites in this
+      ;; file (`fx-handler-exception`, `override-fallthrough`,
+      ;; `reserved-fx-override`) all stamp it; this was the lone outlier.
+      ;;
+      ;; The lifted slot is a bare code identifier — the same privacy class as
+      ;; `:event-id`, and the tight-record discipline is intact: `:rf.fx/args`
+      ;; stays on the dev trace and does NOT reach the production record.
+      ;; This category defines no `:reason`, and `dispatch-on-error!` drops
+      ;; nil-valued attribution slots, so the record gains exactly one key.
       (emit-fx-error! :rf.error/no-such-fx
                       origin-event
                       origin-event-id
                       frame-id
                       nil
-                      {:rf.fx/id   fx-id
+                      {:failing-id fx-id
+                       :rf.fx/id   fx-id
                        :rf.fx/args args
                        :frame      frame-id
                        :recovery   :no-recovery})))))))))

--- a/implementation/core/src/re_frame/live_frame.cljc
+++ b/implementation/core/src/re_frame/live_frame.cljc
@@ -512,6 +512,15 @@
 ;; construction rather than namespace load (rf2-9c2jf).
 (declare ensure-reprojection-installed!)
 
+;; Forward reference: the coalescing dirty-mark, likewise defined at the bottom
+;; of this ns beside the reprojection wiring it arms. `make-frame` calls it
+;; DIRECTLY (not through the `:live-frame/mark-projection-dirty!` late-bind the
+;; registrar's removal paths use — that key exists to keep `registrar` free of a
+;; require cycle, which does not apply within this ns) to make, after the record
+;; is published, the mark the registration hook could not make for an unpublished
+;; frame — see rf2-djkr0 at the call site.
+(declare mark-dirty-and-schedule!)
+
 ;; ===========================================================================
 ;; Generation resolution (shared by make-frame and reproject-live-frame!)
 ;; ===========================================================================
@@ -804,6 +813,40 @@
        ;; and a FAILED re-construction preserves the OLD provenance row, matching
        ;; the engine's own no-residue-on-failure contract.
        (record-frame-generation-pool! runnable-id descriptors)
+       ;; rf2-djkr0 — THE INVARIANT: a registration that lands while a frame is
+       ;; mid-construction is never lost.
+       ;;
+       ;; The generation above was SEALED before `upsert-frame!` published the
+       ;; record (it has to be: a bad `:images` must fail loud BEFORE any record
+       ;; exists, so a conflict leaves no half-created frame). Between those two
+       ;; points the frame is not in `frames`, so it is not in `live-frame-ids`
+       ;; — and a `reg-*` racing that gap fires the registration hook against an
+       ;; EMPTY live-frame set. `mark-dirty-and-schedule!` correctly skips there
+       ;; (rf2-h4q6cy: with nothing image-loaded a flush is a guaranteed no-op,
+       ;; and every `reg-event` / `reg-sub` / `reg-fx` fires that hook, so the
+       ;; skip is a real hot-path win). The consequence was that the mark was
+       ;; never made for THIS frame either, and the record landed carrying a
+       ;; generation predating the registration with nothing left to flush it —
+       ;; permanently stale, `dispatch` reporting `:rf.error/no-such-handler`
+       ;; for a handler `registrar/lookup` was holding at that moment.
+       ;;
+       ;; So the CONSTRUCTOR makes the mark the hook could not make on its
+       ;; behalf. Unconditional, and here rather than in the hook: the record is
+       ;; published by now, so the frame is image-loaded and the hook's skip is
+       ;; left exactly as it was; and from this point on any further `reg-*`
+       ;; DOES see the frame and marks for itself. The coalescing gate means a
+       ;; burst of constructions still arms at most ONE flush, and that flush is
+       ;; the RESILIENT sweep — per-frame conditional (a frame whose composition
+       ;; re-resolves identically is left untouched, a cache hit) and
+       ;; diagnosing rather than throwing, so this adds no failure mode to the
+       ;; construction path.
+       ;;
+       ;; JVM-only as a DEFECT (CLJS is single-threaded: no `reg-*` can
+       ;; interleave between the seal and the publish, both inside one
+       ;; synchronous call), but the repair is common `.cljc` code — on CLJS it
+       ;; is simply a mark the next `reg-*` would have made anyway, coalesced
+       ;; into the same single `next-tick` flush.
+       (mark-dirty-and-schedule!)
        ;; Return the frame VALUE — the lifecycle token (generation not embedded;
        ;; read from the record by id). It carries the exact incarnation token
        ;; (`@token-box`) so `destroy-frame!` of this value is incarnation-EXACT.

--- a/implementation/core/src/re_frame/live_frame.cljc
+++ b/implementation/core/src/re_frame/live_frame.cljc
@@ -144,6 +144,7 @@
   and `re-frame.error` (fail-loud diagnostics) — all already in the core spine."
   (:require [re-frame.image-assembly :as asm]
             [re-frame.registrar      :as registrar]
+            [re-frame.source-store   :as source-store]
             [re-frame.frame          :as frame]
             [re-frame.interop        :as interop]
             [re-frame.error          :as error]
@@ -621,6 +622,30 @@
   nil)
 
 ;; ===========================================================================
+;; Construction-window pool mark (rf2-djkr0)
+;; ===========================================================================
+
+(defn- registration-pool-mark
+  "A cheap VALUE identifying the registration pool a generation would be sealed
+  against right now. Equal marks across two reads ⇒ no `reg-*` / `forget-*` /
+  `clear-*` / `register-standard!` landed between them.
+
+  The three legs are exactly the live-store legs of `image-assembly`'s
+  resolved-generation cache key, and for the same reason: the monotonic
+  `store-generation` bumps on every source-store mutation, `store-identity`
+  disambiguates two distinct stores sitting at the same generation integer
+  (rf2-1x2zuc), and `standard-generation` bumps on any framework-standard
+  registration. Cheap enough to read twice per construction — two map lookups
+  and an atom deref.
+
+  `make-frame` reads it either side of the seal→publish window; see the
+  rf2-djkr0 invariant at that call site for what the comparison decides."
+  []
+  [(source-store/store-identity)
+   (source-store/store-generation)
+   (asm/standard-generation)])
+
+;; ===========================================================================
 ;; make-frame — the ONE public constructor (EP-0024 §One constructor)
 ;; ===========================================================================
 
@@ -726,6 +751,14 @@
          ;; record), else a process-unique anonymous id so a no-id (direct) value
          ;; is still runnable while bypassing the PUBLIC frame-id space.
          runnable-id (if (some? id) id (frame/anon-frame-id))
+         ;; rf2-djkr0 — the pool as it stands BEFORE the seal. Compared against a
+         ;; second reading after the record is published; see the invariant at
+         ;; that comparison below. Read here (not after the seal) so the window
+         ;; the comparison covers is never SHORTER than the real one: a
+         ;; registration landing between this read and the assembly is already
+         ;; IN the sealed generation, so the mark it provokes is at worst
+         ;; redundant, and the flush it arms is a per-frame no-op.
+         pool-mark   (registration-pool-mark)
          ;; Resolve the generation FIRST so a bad `:images` fails loud BEFORE any
          ;; record is created — a conflict leaves no half-created frame.
          ;;
@@ -813,40 +846,49 @@
        ;; and a FAILED re-construction preserves the OLD provenance row, matching
        ;; the engine's own no-residue-on-failure contract.
        (record-frame-generation-pool! runnable-id descriptors)
-       ;; rf2-djkr0 — THE INVARIANT: a registration that lands while a frame is
+       ;; rf2-djkr0 — THE INVARIANT: a PARTIALLY-CONSTRUCTED frame is never
+       ;; observable as live, so a registration that lands while a frame is
        ;; mid-construction is never lost.
        ;;
        ;; The generation above was SEALED before `upsert-frame!` published the
-       ;; record (it has to be: a bad `:images` must fail loud BEFORE any record
-       ;; exists, so a conflict leaves no half-created frame). Between those two
-       ;; points the frame is not in `frames`, so it is not in `live-frame-ids`
-       ;; — and a `reg-*` racing that gap fires the registration hook against an
-       ;; EMPTY live-frame set. `mark-dirty-and-schedule!` correctly skips there
-       ;; (rf2-h4q6cy: with nothing image-loaded a flush is a guaranteed no-op,
-       ;; and every `reg-event` / `reg-sub` / `reg-fx` fires that hook, so the
-       ;; skip is a real hot-path win). The consequence was that the mark was
-       ;; never made for THIS frame either, and the record landed carrying a
-       ;; generation predating the registration with nothing left to flush it —
-       ;; permanently stale, `dispatch` reporting `:rf.error/no-such-handler`
-       ;; for a handler `registrar/lookup` was holding at that moment.
+       ;; record, and it has to be: a bad `:images` must fail loud BEFORE any
+       ;; record exists, so a conflict leaves no half-created frame. Between
+       ;; those two points the frame is not in `frames`, hence not in
+       ;; `live-frame-ids` — and a `reg-*` racing that gap fires the registration
+       ;; hook against an EMPTY live-frame set. `mark-dirty-and-schedule!`
+       ;; correctly skips there (rf2-h4q6cy: with nothing image-loaded a flush is
+       ;; a guaranteed no-op, and every `reg-event` / `reg-sub` / `reg-fx` fires
+       ;; that hook, so the skip is a real hot-path win). The consequence was
+       ;; that no mark was made for THIS frame either: the record landed carrying
+       ;; a generation predating the registration, with nothing left to flush it.
+       ;; Permanently stale — `dispatch` reporting `:rf.error/no-such-handler`
+       ;; for a handler `registrar/lookup` was holding at that very moment.
        ;;
        ;; So the CONSTRUCTOR makes the mark the hook could not make on its
-       ;; behalf. Unconditional, and here rather than in the hook: the record is
-       ;; published by now, so the frame is image-loaded and the hook's skip is
-       ;; left exactly as it was; and from this point on any further `reg-*`
-       ;; DOES see the frame and marks for itself. The coalescing gate means a
-       ;; burst of constructions still arms at most ONE flush, and that flush is
-       ;; the RESILIENT sweep — per-frame conditional (a frame whose composition
-       ;; re-resolves identically is left untouched, a cache hit) and
-       ;; diagnosing rather than throwing, so this adds no failure mode to the
-       ;; construction path.
+       ;; behalf, and makes it HERE, after publication: by now the frame is
+       ;; image-loaded, so the hook's skip is left exactly as it was, and from
+       ;; this point on any further `reg-*` sees the frame and marks for itself.
+       ;; The window is closed end to end.
+       ;;
+       ;; CONDITIONAL, because an unconditional mark is not free of consequence:
+       ;; it would leave the projection dirty after EVERY construction, and a
+       ;; flag set here is flushed by some later, unrelated resolution. Marking
+       ;; only when the pool actually MOVED under us keeps every non-racing
+       ;; construction — which is all of them outside this defect — byte-for-byte
+       ;; as before. The comparison is exact: any `reg-*` / `forget-*` / `clear-*`
+       ;; / `register-standard!` bumps a leg of `registration-pool-mark`.
+       ;;
+       ;; The armed flush is the RESILIENT sweep — per-frame conditional (a frame
+       ;; whose composition re-resolves identically is left untouched, a
+       ;; generation-cache hit) and diagnosing rather than throwing — so this
+       ;; adds NO failure mode to the construction path.
        ;;
        ;; JVM-only as a DEFECT (CLJS is single-threaded: no `reg-*` can
        ;; interleave between the seal and the publish, both inside one
-       ;; synchronous call), but the repair is common `.cljc` code — on CLJS it
-       ;; is simply a mark the next `reg-*` would have made anyway, coalesced
-       ;; into the same single `next-tick` flush.
-       (mark-dirty-and-schedule!)
+       ;; synchronous call), but the repair is common `.cljc` code — on CLJS the
+       ;; comparison simply never differs.
+       (when (not= pool-mark (registration-pool-mark))
+         (mark-dirty-and-schedule!))
        ;; Return the frame VALUE — the lifecycle token (generation not embedded;
        ;; read from the record by id). It carries the exact incarnation token
        ;; (`@token-box`) so `destroy-frame!` of this value is incarnation-EXACT.

--- a/implementation/core/test/re_frame/fx_test.clj
+++ b/implementation/core/test/re_frame/fx_test.clj
@@ -389,16 +389,16 @@
       ;; `:rf.error/no-such-fx` ALWAYS-ON, so an unknown fx-id is observable
       ;; off-box under `-Dre-frame.debug=false`.
       ;;
-      ;; NOTE (rf2-g0mep, filed): the always-on RECORD does not name WHICH
-      ;; fx-id was unknown. `fx.cljc`'s `:rf.error/no-such-fx` trace-payload
-      ;; omits `:failing-id`, so `emit-error-both!`'s attribution lift does
-      ;; not fire and `:rf.fx/id` stays on the DCE'd trace tags — even though
-      ;; Spec 009 §Component attribution states the rule as "every always-on
-      ;; error record carries `:failing-id` naming the failing COMPONENT
-      ;; whenever that component is DISTINCT from the dispatched event", and
-      ;; the three sibling emit sites in the same file (`fx-handler-exception`,
-      ;; `override-fallthrough`, `reserved-fx-override`) all stamp it. That is
-      ;; a production-source question, filed rather than papered over here.
+      ;; rf2-g0mep — the record must name WHICH fx-id was unknown. Spec 009
+      ;; §Observability channels states the attribution rule generally: every
+      ;; always-on error record carries `:failing-id` naming the failing
+      ;; COMPONENT whenever that component is DISTINCT from the dispatched
+      ;; event. Here `:event-id` is the DISPATCHING event, so the unregistered
+      ;; fx-id is exactly such a component. `fx.cljc`'s trace-payload stamps
+      ;; `:failing-id fx-id` and `emit-error-both!` lifts it onto the always-on
+      ;; record; remove that key from the emit site and the `:failing-id`
+      ;; assertion below reds while the dev-trace arm stays green — the fx-id
+      ;; would once again ride ONLY the DCE'd `:rf.fx/id` tag.
       (let [records (filter #(= :rf.error/no-such-fx (:error %)) @errors)]
         (is (= 1 (count records))
             "exactly ONE always-on record reached the :errors listener")
@@ -407,9 +407,28 @@
               ":event-id carries the dispatching event id")
           (is (= [:fx-test/missing] (:event r)))
           (is (= :rf/default (:frame r))
-              ":frame names the frame the unknown fx-id was dispatched in")))
-      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring). The offending
-      ;; fx-id itself is observable only here (see the NOTE above).
+              ":frame names the frame the unknown fx-id was dispatched in")
+          (is (= :fx-test/never-registered (:failing-id r))
+              ":failing-id names the UNKNOWN fx-id — the failing component,
+               distinct from the dispatched event (rf2-g0mep)")
+          ;; The record is a PRODUCTION EGRESS surface: every slot here reaches
+          ;; off-box shippers (Sentry / Datadog) through the frame-owned
+          ;; `:observability :errors` sink. Pin the key set CLOSED so a future
+          ;; slot is a deliberate decision, not a drive-by. `:rf.fx/args` in
+          ;; particular must NOT appear — an unregistered fx-id has no
+          ;; registration to read a `:sensitive` declaration off, so its args
+          ;; are the documented EP-0025 fail-open and stay on the dev trace.
+          (is (= #{:error :event :event-id :frame :time :exception :elapsed-ms
+                   :failing-id :source-coord}
+                 (set (keys r)))
+              "the always-on record carries the tight rf2-bacs4 keys, the
+               rf2-3un2g :source-coord for the dispatching event, and exactly
+               one attribution slot — :failing-id (rf2-g0mep). No :reason (the
+               category defines none, and nil attribution slots are dropped)
+               and no :rf.fx/args.")))
+      ;; rf2-d2841 — dev-instrumentation arm (see ns docstring). `:rf.fx/id` is
+      ;; the dev-trace spelling of the same id the always-on record now carries
+      ;; as `:failing-id`.
       (when interop/debug-enabled?
         (let [missing-traces (filter #(= :rf.error/no-such-fx (:operation %))
                                      @traces)]

--- a/implementation/core/test/re_frame/make_frame_generation_seal_race_jvm_test.clj
+++ b/implementation/core/test/re_frame/make_frame_generation_seal_race_jvm_test.clj
@@ -1,0 +1,221 @@
+(ns re-frame.make-frame-generation-seal-race-jvm-test
+  "rf2-djkr0 — a PARTIALLY-CONSTRUCTED frame must never be observable as LIVE.
+
+  THE WINDOW (JVM-only). `re-frame.live-frame/make-frame` does two things in
+  order, with real work between them:
+
+      generation  (asm/assemble-default …)   ;; SEAL   — the pool, frozen
+      …
+      (frame/upsert-frame! runnable-id …)    ;; PUBLISH — the record appears
+
+  Between them the frame EXISTS as a sealed generation but is absent from
+  `frames`, so `live-frame/live-frame-ids` does not see it. A `reg-*` issued on
+  another thread in that gap fires the registration hook →
+  `reproject-on-registration-change!` → `mark-dirty-and-schedule!`, which SKIPS
+  when `(seq (live-frame-ids))` is empty — the rf2-h4q6cy hot-path
+  optimisation, and a correct one: reprojection only ever touches image-loaded
+  frames, so with none there is genuinely nothing to mark. The in-flight frame
+  does not count, so NO dirty mark is set. `upsert-frame!` then publishes a
+  record whose generation PREDATES that registration, and nothing is left to
+  flush it. The frame is permanently stale: `dispatch` reports
+  `:rf.error/no-such-handler` for a handler `registrar/lookup` is holding at
+  that very moment.
+
+  THE INVARIANT, stated as this namespace tests it: *a registration that lands
+  while a frame is mid-construction is never lost — the constructor itself
+  performs the dirty-mark the registration hook could not make on its behalf,
+  because at hook time the frame was not yet in `frames` to be seen.*
+
+  SCOPE — and why it needed reproducing rather than reasoning about. This is
+  the residual half of rf2-9c2jf (`ensure-reprojection-installed!` publishing
+  its once-flag before its side effects), deliberately not folded into it, and
+  it is NARROWER: it bites only when NO image-loaded frame exists at hook time,
+  i.e. the FIRST `make-frame` in a process racing a `reg-*`. With any other
+  frame already live the hook DOES mark dirty, and by the time the read-time
+  flush in `call-with-frame-resolution` runs, the new frame IS in `frames`, so
+  the resilient sweep picks it up. `frame-not-first-in-the-process-is-swept-by-
+  the-ordinary-mark` below pins that half, so the fix cannot be mistaken for
+  the thing that was already working.
+
+  THE HARNESS is the rf2-9c2jf one's sibling: a deterministic barrier, no
+  sleeps deciding anything. It parks the constructor inside the window using
+  `frame/*upsert-decide-probe*` — the `nil`-in-production JVM linearization
+  seam `frame_upsert_linearization_jvm_test.clj` already uses, fired ONCE after
+  the per-id construction transaction is acquired and BEFORE the authoritative
+  registry decision. Parked there the generation is sealed and the record is
+  provably not yet in `frames`, which is exactly the window's interior. The
+  racing `reg-*` then runs on the test thread while the constructor is held.
+
+  CLJS IS UNAFFECTED and has no counterpart here: it is single-threaded, so no
+  `reg-*` can interleave between the seal and the publish — both run inside one
+  synchronous `make-frame` call. The fix is nonetheless in `.cljc` common code
+  (an unconditional mark on the construction path), where on CLJS it is simply
+  a mark that the very next `reg-*` would have made anyway."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.flows :as flows]
+            [re-frame.frame :as frame]
+            [re-frame.live-frame :as live-frame]
+            [re-frame.registrar :as registrar]
+            [re-frame.schemas :as schemas]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.trace :as trace])
+  (:import [java.util.concurrent CountDownLatch TimeUnit]))
+
+;; ---------------------------------------------------------------------------
+;; White-box handle on the coalescing dirty flag.
+;;
+;; A deliberate private-var read: the whole defect is that this flag is NOT set
+;; when it must be, so observing it is how the narrow-case control below proves
+;; the hot-path skip is still intact after the fix.
+;; ---------------------------------------------------------------------------
+
+(def ^:private dirty-flag #'live-frame/pending-reprojection?)
+
+(defn- reset-runtime [test-fn]
+  (try
+    (registrar/clear-all!)
+    (reset! frame/frames {})
+    (flows/reset-flows!)
+    (schemas/clear-schemas-by-frame!)
+    (trace/clear-listeners!)
+    (rf/init! plain-atom/adapter)
+    ;; Framework registrations live at namespace-load time; `clear-all!` wiped
+    ;; them. Re-eval so the rest of the suite is not left short.
+    (require 're-frame.routing :reload)
+    (require 're-frame.ssr :reload)
+    ;; LOAD-BEARING, and it must come LAST. `registrar/clear-all!` is itself a
+    ;; source-store change and marks the projection dirty (via the removal
+    ;; late-bind) whenever a live frame is still standing from an earlier test.
+    ;; A test that starts with the flag already true would have its first
+    ;; resolution flush — repairing the staleness for the wrong reason and
+    ;; reporting a green that proves nothing.
+    (reset! @dirty-flag false)
+    (test-fn)
+    (finally
+      (registrar/clear-all!)
+      (reset! frame/frames {})
+      (reset! @dirty-flag false))))
+
+(use-fixtures :each reset-runtime)
+
+;; A latch we expect to FIRE waits this long; it only bounds a hang.
+(def ^:private ^:const settle-ms 10000)
+
+(defn- await! [^CountDownLatch latch ^long ms]
+  (.await latch ms TimeUnit/MILLISECONDS))
+
+;; Park the constructor of `target` INSIDE the window: the transaction is held,
+;; the generation is sealed, the record is not yet in `frames`.
+(defn- window-probe [target ^CountDownLatch reached ^CountDownLatch release]
+  (fn [id]
+    (when (= id target)
+      (.countDown reached)
+      (.await release settle-ms TimeUnit/MILLISECONDS))))
+
+;; ---------------------------------------------------------------------------
+;; 1. THE REPRODUCTION. The first frame in the process, racing a `reg-*`.
+;; ---------------------------------------------------------------------------
+
+(deftest registration-racing-the-generation-seal-is-not-lost
+  (testing "a reg-* issued while the FIRST make-frame is between its sealed
+            generation and its published record is not lost — the frame is not
+            left permanently stale"
+    (let [reached (CountDownLatch. 1)
+          release (CountDownLatch. 1)
+          runs    (atom 0)
+          errors  (atom [])]
+      (rf/register-listener! :errors ::recorder
+                             (fn [record] (swap! errors conj record)))
+      (let [a (binding [frame/*upsert-decide-probe*
+                        (window-probe :seal-race/a reached release)]
+                (future (rf/make-frame {:id  :seal-race/a
+                                        :doc "the constructor parked mid-window"})))]
+        (is (await! reached settle-ms)
+            "the constructor parked inside the window")
+
+        ;; THE PRECONDITION that makes this defect the narrow one it is. The
+        ;; in-flight frame is NOT in `frames`, so the registration hook about
+        ;; to fire sees nothing image-loaded and takes the hot-path skip.
+        (is (nil? (frame/frame :seal-race/a))
+            "the parked constructor's record is not published yet")
+        (is (empty? (live-frame/live-frame-ids))
+            "NO image-loaded frame exists — the hook's skip will fire")
+
+        ;; THE RACING REGISTRATION. Its hook fires now, against an empty
+        ;; live-frame set, and marks nothing.
+        (rf/reg-event :seal-race/late
+          (fn [{:keys [db]} _]
+            (swap! runs inc)
+            {:db (assoc db :late :ran)}))
+
+        (.countDown release)
+        (is (some? (deref a settle-ms ::timeout)) "the constructor completed")
+        (is (some? (frame/frame :seal-race/a)) "the frame is published")
+
+        ;; THE END STATE. Without the fix the frame resolves through a
+        ;; generation sealed BEFORE `:seal-race/late` was registered, so this
+        ;; dispatch is a no-op reported as `:rf.error/no-such-handler` — for a
+        ;; handler `registrar/lookup` is holding at this very moment.
+        (rf/dispatch-sync [:seal-race/late] {:frame :seal-race/a})
+        (rf/unregister-listener! :errors ::recorder)
+
+        (is (empty? (filter #(= :rf.error/no-such-handler (:error %)) @errors))
+            (str "the frame resolved :seal-race/late through a generation "
+                 "sealed before it was registered — the registration issued "
+                 "during construction was LOST"))
+        (is (= 1 @runs)
+            "the handler registered during construction ran exactly once")
+        (is (= :ran (:late (rf/app-db-value :seal-race/a)))
+            "the frame is not permanently stale")))))
+
+;; ---------------------------------------------------------------------------
+;; 2. THE SCOPE CONTROL. The same race with a frame ALREADY live takes the
+;;    ordinary hook path — this half was never broken, and must stay that way.
+;; ---------------------------------------------------------------------------
+
+(deftest frame-not-first-in-the-process-is-swept-by-the-ordinary-mark
+  (testing "with an image-loaded frame already standing, the racing reg-*'s
+            hook marks dirty as usual and the in-flight frame is swept by the
+            read-time flush — the half rf2-djkr0 was NOT about"
+    (let [reached (CountDownLatch. 1)
+          release (CountDownLatch. 1)
+          runs    (atom 0)]
+      (rf/make-frame {:id :seal-race/incumbent})
+      (reset! @dirty-flag false)
+      (is (seq (live-frame/live-frame-ids))
+          "an image-loaded frame is standing before the race")
+      (let [a (binding [frame/*upsert-decide-probe*
+                        (window-probe :seal-race/b reached release)]
+                (future (rf/make-frame {:id :seal-race/b})))]
+        (is (await! reached settle-ms) "the constructor parked inside the window")
+        (rf/reg-event :seal-race/late-b
+          (fn [{:keys [db]} _]
+            (swap! runs inc)
+            {:db (assoc db :late :ran)}))
+        (is (true? @@dirty-flag)
+            "the hook DID mark dirty — an image-loaded frame was visible to it")
+        (.countDown release)
+        (is (some? (deref a settle-ms ::timeout)) "the constructor completed")
+        (rf/dispatch-sync [:seal-race/late-b] {:frame :seal-race/b})
+        (is (= 1 @runs) "the handler ran")
+        (is (= :ran (:late (rf/app-db-value :seal-race/b))))))))
+
+;; ---------------------------------------------------------------------------
+;; 3. THE HOT-PATH SKIP the fix must not spend. `mark-dirty-and-schedule!`'s
+;;    no-image-loaded-frame skip (rf2-h4q6cy) is a real win — every
+;;    `reg-event` / `reg-sub` / `reg-fx` fires that hook, and the overwhelming
+;;    majority run at app boot or in handler-only tests with no frame standing.
+;;    The rf2-djkr0 repair belongs on the CONSTRUCTION path, not in the hook.
+;; ---------------------------------------------------------------------------
+
+(deftest registration-with-no-live-frame-still-marks-nothing
+  (testing "a reg-* with no image-loaded frame standing sets no dirty flag and
+            schedules no flush — the rf2-h4q6cy hot-path skip survives the
+            rf2-djkr0 fix"
+    (is (empty? (live-frame/live-frame-ids)) "no frame is standing")
+    (is (false? @@dirty-flag) "the flag starts clear")
+    (rf/reg-event :seal-race/boot-time (fn [{:keys [db]} _] {:db db}))
+    (rf/reg-sub :seal-race/boot-sub (fn [db _] db))
+    (is (false? @@dirty-flag)
+        "the registration hook took the no-image-loaded-frame skip")))

--- a/implementation/core/test/re_frame/make_frame_generation_seal_race_jvm_test.clj
+++ b/implementation/core/test/re_frame/make_frame_generation_seal_race_jvm_test.clj
@@ -219,3 +219,31 @@
     (rf/reg-sub :seal-race/boot-sub (fn [db _] db))
     (is (false? @@dirty-flag)
         "the registration hook took the no-image-loaded-frame skip")))
+
+;; ---------------------------------------------------------------------------
+;; 4. THE MARK IS CONDITIONAL, and that is load-bearing rather than an
+;;    optimisation. An UNCONDITIONAL mark on the construction path leaves the
+;;    projection dirty after every `make-frame`, and a flag set here is flushed
+;;    by some later, unrelated resolution — which is observable: it reprojects a
+;;    frame mid-`upsert-frame!`, before `record-frame-generation-pool!` has
+;;    updated the provenance row, so a re-`make-frame` reload resolves against
+;;    the PREVIOUS pool and its freshly installed generation is clobbered.
+;;    (`live-frame-reload-cljs-test/reload-swaps-generation-preserving-frame-
+;;    memory` is where that surfaces.) An ordinary construction must therefore
+;;    leave global projection state exactly as it found it.
+;; ---------------------------------------------------------------------------
+
+(deftest construction-with-no-racing-registration-leaves-the-projection-clean
+  (testing "a make-frame that nothing raced marks nothing — the pool did not
+            move across its seal→publish window"
+    (is (false? @@dirty-flag) "the flag starts clear")
+    (rf/reg-event :seal-race/quiet (fn [{:keys [db]} _] {:db db}))
+    (rf/make-frame {:id :seal-race/quiet-frame})
+    (is (false? @@dirty-flag)
+        "an unraced construction left the projection clean")
+    ;; And a SECOND construction with a frame already standing likewise — this
+    ;; is the shape that leaks a flag into an unrelated test when the mark is
+    ;; unconditional.
+    (rf/make-frame {:id :seal-race/quiet-frame-2})
+    (is (false? @@dirty-flag)
+        "a second unraced construction left the projection clean too")))

--- a/implementation/core/test/re_frame/on_error_cljs_test.cljc
+++ b/implementation/core/test/re_frame/on_error_cljs_test.cljc
@@ -406,7 +406,8 @@
 (deftest listener-fires-on-no-such-fx
   (testing "Per rf2-goum9x: an unknown fx-id fans `:rf.error/no-such-fx`
             through the always-on listener (previously dev-trace-only).
-            The fx is dropped; the cascade continues."
+            The fx is dropped; the cascade continues.
+            Per rf2-g0mep the record also NAMES the unknown fx-id."
     (let [seen (atom [])]
       (rf/register-listener! :errors :test/recorder
                                    (fn [record] (swap! seen conj record)))
@@ -417,7 +418,19 @@
         (is (some? r) "listener received :rf.error/no-such-fx")
         (is (= [:goum9x/run-unknown-fx] (:event r)))
         (is (= :goum9x/run-unknown-fx (:event-id r)))
-        (is (= :rf/default (:frame r)))))))
+        (is (= :rf/default (:frame r)))
+        ;; rf2-g0mep — `:event-id` is the DISPATCHING event, so the
+        ;; unregistered fx-id is a DISTINCT failing component and Spec 009's
+        ;; attribution rule applies: `fx.cljc` stamps `:failing-id` on the
+        ;; trace-payload and `emit-error-both!` lifts it onto this record.
+        ;; Without it an off-box shipper learns an fx was missing but not which.
+        (is (= :goum9x/never-registered (:failing-id r))
+            ":failing-id names the UNKNOWN fx-id")
+        ;; The fx ARGS stay on the dev trace: an unregistered fx-id has no
+        ;; registration to read a `:sensitive` declaration off, so they must
+        ;; not reach this production-surviving record.
+        (is (not (contains? r :rf.fx/args))
+            "the unaddressable args do NOT ride the always-on record")))))
 
 (deftest listener-fires-on-override-fallthrough
   (testing "Per rf2-goum9x: an `:fx-overrides` entry redirecting to an

--- a/implementation/core/test/re_frame/on_error_elision_prod_test.cljs
+++ b/implementation/core/test/re_frame/on_error_elision_prod_test.cljs
@@ -329,7 +329,10 @@
 
 (deftest no-such-fx-listener-survives-prod
   (testing "Per rf2-goum9x: an unknown fx-id fans `:rf.error/no-such-fx`
-            through the always-on listener under `goog.DEBUG=false`."
+            through the always-on listener under `goog.DEBUG=false`.
+            Per rf2-g0mep the record NAMES the unknown fx-id under that gate —
+            this is the posture the defect was invisible in, because the fx-id
+            rode only `:rf.fx/id` on the DCE'd dev-trace tags."
     (let [seen (atom [])]
       (rf/register-listener! :errors :prod/recorder
                                    (fn [record] (swap! seen conj record)))
@@ -339,7 +342,10 @@
       (let [r (some (fn [x] (when (= :rf.error/no-such-fx (:error x)) x)) @seen)]
         (is (some? r) "listener received :rf.error/no-such-fx under prod")
         (is (= :goum9x/prod-unknown-fx (:event-id r)))
-        (is (= :rf/default (:frame r)))))))
+        (is (= :rf/default (:frame r)))
+        (is (= :goum9x/prod-never (:failing-id r))
+            ":failing-id names the UNKNOWN fx-id under `goog.DEBUG=false`
+             (rf2-g0mep) — the whole point of the always-on record")))))
 
 (deftest override-fallthrough-listener-survives-prod
   (testing "Per rf2-goum9x: an `:fx-overrides` redirect to an unregistered


### PR DESCRIPTION
Two P2 defects in core, both on always-on / correctness surfaces. Fence: `implementation/core/**` only.

---

## rf2-g0mep — the always-on `no-such-fx` record now names the missing fx

`:rf.error/no-such-fx` is catalogued **always-on** in Spec 009, but its emit site in `fx.cljc` built its trace-payload without `:failing-id`, so `error-emit/emit-error-both!`'s attribution lift never fired. Production learnt that *an* fx was missing but not **which one** — the id rode only `:rf.fx/id` on the dev-trace tags, which DCE under `:advanced` + `goog.DEBUG=false`.

**The rule was checked first, as instructed.** Spec 009 §Observability channels states attribution generally — *"every always-on error record carries `:failing-id` naming the failing COMPONENT's own code identifier whenever that component is DISTINCT from (or more specific than) the dispatched event"* — and enumerates the interceptor / cofx / machine categories explicitly as **instances of the one rule**, not as its extent. Here `:event-id` is the dispatching event and the unregistered fx-id is the failing component, so the rule applies. **Nothing Spec 009 promises changes**; this is the code catching up to the promise, so no spec edit and no hot-zone touch. The three sibling fx emit sites in the same file (`fx-handler-exception`, `override-fallthrough`, `reserved-fx-override`) all already stamp it — verified directly — so `no-such-fx` was the lone outlier rather than a carve-out.

### Egress review

This record is a production egress surface: it reaches off-box shippers through the frame-owned `:observability :errors` sink.

* The lifted slot is a bare keyword code identifier — the same privacy class as `:event-id`.
* `:rf.fx/args` stays on the dev trace and does **not** reach the record. An unregistered fx-id has no `reg-fx` registration to read a `:sensitive` declaration off — the documented EP-0025 fail-open — which is precisely why its args must not egress.
* The category defines no `:reason`, and `dispatch-on-error!` drops nil-valued attribution slots, so the record gains **exactly one key**.
* The resulting key set is now **pinned closed** by test, on the same grounds as the sibling PR: any slot added here reaches Sentry / Datadog, so it should be a deliberate decision rather than a drive-by.

### Proof

`fx-test/unknown-fx-id-is-logged-and-skipped` asserts `:failing-id` == the unknown fx-id and pins the record's key set closed. **Mutation-proved under the REAL production gate** (`-Dre-frame.debug=false`, the posture the defect was invisible in): deleting `:failing-id` from the emit site reds both assertions and names the missing key, while the dev-trace arm stays green. Restored; `git diff --stat` clean. The CLJS always-on witnesses carry the same assertion, the elision one under `goog.DEBUG=false`.

---

## rf2-djkr0 — REPRODUCED, then fixed

**Reproduced first, as the bead demanded.** `make_frame_generation_seal_race_jvm_test.clj` parks a constructor **inside** the window using `frame/*upsert-decide-probe*` — the `nil`-in-production JVM linearization seam, fired once after the per-id construction transaction is acquired and before the authoritative registry decision, so the generation is sealed and the record provably absent from `frames` — and issues the racing `reg-*` from the test thread while it is held. No sleeps decide anything; the harness is a sibling of rf2-9c2jf's `reprojection_install_race_jvm_test.clj`.

Against unmodified source it reproduces the bead's exact end state:

```
{:error :rf.error/no-such-handler :event [:seal-race/late]
 :event-id :seal-race/late :frame :seal-race/a ...}
```

handler run **0** times, app-db untouched — for a handler `registrar/lookup` was holding at that very moment.

### The window

`make-frame` **seals** its generation before `frame/upsert-frame!` **publishes** the record, and it has to: a bad `:images` must fail loud before any record exists, so a conflict leaves no half-created frame. Between the two the frame is not in `frames`, hence not in `live-frame-ids`, so a `reg-*` racing the gap fires the registration hook against an **empty** live-frame set and `mark-dirty-and-schedule!` takes its no-image-loaded-frame skip. Nothing marked the in-flight frame; once published, nothing was left to flush it.

### The fix, and the invariant stated at the site

> **A partially-constructed frame is never observable as live, so a registration that lands while a frame is mid-construction is never lost** — the constructor itself makes the dirty-mark the hook could not make on its behalf, because at hook time the frame was not yet in `frames` to be seen.

The mark is made **after publication**, so the frame is image-loaded by then and `mark-dirty-and-schedule!`'s rf2-h4q6cy skip is left exactly as it was — the bead's stated preference, and a real hot-path win since every `reg-event` / `reg-sub` / `reg-fx` fires that hook. From that point on any further `reg-*` sees the frame and marks for itself, so the window closes end to end.

It is **conditional** on the registration pool having actually moved across the window, and that is load-bearing rather than an optimisation. The unconditional version (first commit on this branch) reds `live-frame-reload-cljs-test/reload-swaps-generation-preserving-frame-memory`: a flag left dirty after every construction is flushed by some later unrelated resolution, and one of those is the `:initial-events` cascade running **inside** `upsert-frame!` — before `record-frame-generation-pool!` has updated the provenance row (deliberately: rf2-ktmto9 orders it after the engine commit so a failed construction records nothing). That flush reprojects against the *previous* pool and clobbers the generation the reload had just installed. A latent ordering wart, unreachable before, made reachable by marking on a path where nothing changed. `registration-pool-mark` compares the three live-store legs of `image-assembly`'s resolved-generation cache key — `store-identity`, the monotonic `store-generation`, and `standard-generation` — so any `reg-*` / `forget-*` / `clear-*` / `register-standard!` in the window moves a leg. Two map lookups and an atom deref per construction.

The armed flush is the **resilient** sweep — per-frame conditional and diagnosing rather than throwing — so this adds **no failure mode** to the construction path.

### Platform

**JVM-only as a defect.** CLJS is single-threaded: no `reg-*` can interleave between the seal and the publish, both inside one synchronous `make-frame`. The repair is nonetheless common `.cljc` code, where on CLJS the comparison simply never differs.

### Guards shipped with the reproduction

* `frame-not-first-in-the-process-is-swept-by-the-ordinary-mark` — the same race with an incumbent frame standing. **Green before the fix**: the half rf2-9c2jf's resilient sweep already covered, and the scope claim that made rf2-djkr0 narrow. The fix cannot be mistaken for something that already worked.
* `registration-with-no-live-frame-still-marks-nothing` — pins the rf2-h4q6cy hot-path skip intact.
* `construction-with-no-racing-registration-leaves-the-projection-clean` — pins the conditionality, so the blunt version cannot come back by accident.

Re-mutation-proved after the refinement: forcing the mark off reds the reproduction's three assertions; with it on, the reproduction and all three guards are green.

---

## Quality gates

Run from the worker worktree, foreground, unpiped, exit codes echoed.

| Gate | Command | Exit | Result |
|---|---|---|---|
| core — dev posture (full) | `clojure -M:test` | **0** | 2159 tests, 10724 assertions, 0 failures |
| core — REAL production gate | `bash scripts/test-core-prod-gate.sh` | **0** | 101 namespaces, 1192 tests, 5509 assertions — the lane grew from 100 to 101 (the new reproduction namespace joins by default and is green under the gate); no regression |
| `^:stress` lane | `clojure -M:test:slow-test` | **0** | 4 tests, 8 assertions |
| rf2-g0mep mutation proof | `clojure -M:test:prod-gate -v re-frame.fx-test/unknown-fx-id-is-logged-and-skipped`, with `:failing-id` deleted from the emit site | **1** | 2 failures naming the missing key — restored, then **0** |
| rf2-djkr0 reproduction | `clojure -M:test -n re-frame.make-frame-generation-seal-race-jvm-test` against unmodified `live_frame.cljc` | **1** | 3 failures, the bead's exact `:rf.error/no-such-handler` end state |
| rf2-djkr0 with the fix | same, both postures (`:test` and `:test:prod-gate`) | **0** | 4 tests, 20 assertions |

The transitive egress surface was gated deliberately: `egress-chokepoint-conformance-test`, `error-catalogue-channel-conformance-test` and `always-on-axis-conformance-cljs-test` all pass, and both full core postures were run because this touches an always-on record and a core `src/` tree that the chokepoint test source-scans as text.

**Deferred to CI:** the CLJS browser / advanced-compile suites (`npm run test:cljs`, the elision probe, bundle-isolation) and every downstream artefact lane — `live_frame.cljc` is common code consumed by `ssr` / `routing` / `ui` / `flows` / `machines`.

Closes rf2-g0mep. Closes rf2-djkr0.
