### PR TITLE
ci: the browser lane profiles itself, and a double-fired done is fatal (rf2-76lhy, rf2-u0cy4)

### DIFF
--- a/implementation/scripts/_impl-browser-runners-verdict-policy.test.cjs
+++ b/implementation/scripts/_impl-browser-runners-verdict-policy.test.cjs
@@ -11,7 +11,10 @@
  *      (rf2-mwx08);
  *   2. a lane that ran ZERO tests, whose `Ran 0 tests containing 0
  *      assertions. / 0 failures, 0 errors.` summary satisfies a
- *      failure-tally-only verdict (rf2-qqzmf).
+ *      failure-tally-only verdict (rf2-qqzmf);
+ *   3. a cljs.test async row that called `done` twice, which `run-block`
+ *      degrades to a `println` on the already-realized continuation and so
+ *      can never reach the failure tally (rf2-u0cy4).
  *
  * Both are pinned statically for the same reason: these runners drive a
  * headless Chromium end-to-end, so their verdict paths are not cleanly
@@ -136,6 +139,59 @@ test('run-browser-tests: a malformed floor is refused, never a silent default (r
     src,
     /if\s*\(\s*minTests\s*===\s*null\s*\)\s*return\s+2\s*;/,
     'a malformed floor must exit 2 (configuration error), distinct from 1 (red)',
+  );
+});
+
+test('run-browser-tests: a double-fired cljs.test `done` is fatal, not diagnostic noise (rf2-u0cy4)', () => {
+  const src = read('run-browser-tests.cjs');
+  // The literal cljs.test emits from run-block's realized? branch. If this
+  // string drifts in a ClojureScript upgrade the guard silently stops
+  // matching, so pin the literal itself as well as the wiring.
+  assert.match(
+    src,
+    /Async test called done more than one time/,
+    'must match the cljs.test duplicate-done warning literal',
+  );
+  assert.match(
+    src,
+    /const\s+fatalConsole\s*=\s*\[\]/,
+    'must track fatal console lines in a dedicated array, not merely in diagnostics',
+  );
+  assert.match(
+    src,
+    /page\.on\(\s*['"]console['"][\s\S]{0,320}?fatalConsole\.push\(/,
+    'the console handler must push matching lines into the dedicated array',
+  );
+  assert.match(
+    src,
+    /if\s*\(\s*fatalConsole\.length\s*>\s*0\s*\)\s*\{[\s\S]{0,900}?return\s+1\s*;/,
+    'must fail the run (return 1) when a duplicate `done` was captured, even on a green summary',
+  );
+  // Like the pageerror arm, the check is worthless after the green return.
+  const fatalIdx = src.search(/if\s*\(\s*fatalConsole\.length\s*>\s*0\s*\)/);
+  const greenIdx = src.search(/formatCompactSummary\(/);
+  assert.ok(fatalIdx > -1 && greenIdx > -1, 'both call-sites must exist');
+  assert.ok(
+    fatalIdx < greenIdx,
+    'the duplicate-done fatal check must precede the green compact-summary return',
+  );
+});
+
+test('run-browser-tests: diagnostics are stamped at capture time, not flush time (rf2-76lhy)', () => {
+  const src = read('run-browser-tests.cjs');
+  // The buffer flushes in one burst, so a timeout trail without capture-time
+  // offsets records WHICH namespaces a run reached and nothing about how long
+  // any of them took. This is dormant in a healthy tree — only a timeout ever
+  // flushes it — so it needs a static pin exactly like the test-count floor.
+  assert.match(
+    src,
+    /process\.hrtime\.bigint\(\)/,
+    'must take a monotonic clock reading, not Date.now()',
+  );
+  assert.match(
+    src,
+    /page\.on\(\s*['"]console['"][\s\S]{0,320}?diagnostics\.add\(\s*`\$\{capturedAt\(\)\}/,
+    'the console handler must stamp each captured line as it arrives',
   );
 });
 

--- a/implementation/scripts/run-browser-tests.cjs
+++ b/implementation/scripts/run-browser-tests.cjs
@@ -88,6 +88,25 @@ const RUN_STARTED_AT = process.hrtime.bigint();
 const capturedAt = () =>
   `[+${(Number(process.hrtime.bigint() - RUN_STARTED_AT) / 1e9).toFixed(2)}s]`;
 
+// rf2-u0cy4: the one console line that is a DEFECT, not noise.
+//
+// Console output is diagnostic-only here by deliberate design (rf2-mwx08) —
+// only `pageerror` is fatal. That policy has one hole. When a cljs.test async
+// row calls `done` twice, `run-block` finds its continuation already realized
+// and degrades the second call to a `println`:
+//
+//     (if (realized? d) (println "WARNING: Async test called done more than one time.") @d)
+//
+// So the defect cannot reach the failure tally — it is structurally incapable
+// of failing an assertion. It shipped to main exactly once already (PR #7162
+// swapped in a teardown helper that calls `done`, leaving five pre-existing
+// trailing `(done)` calls, so every async row in that suite double-fired); the
+// lane was green and a human reading the diff caught it (rf2-0ke4x, #7164).
+//
+// Promoting the literal is general across the whole mounted tier rather than a
+// textual lint over one suite's source, which is why it belongs here.
+const FATAL_CONSOLE_RE = /Async test called done more than one time/;
+
 // The test-count floor (rf2-qqzmf). ONE name across every whole-suite lane:
 // the JVM runner (re-frame.test-quiet.runner) and the CLJS node runner
 // (re-frame.test-quiet.shadow-node) read the same variable. Because it is
@@ -233,10 +252,15 @@ async function main() {
     // suite happened not to assert on). Console output stays diagnostic-
     // only; only `pageerror` is fatal. Mirrors the rf2-wf5al fix.
     const pageErrors = [];
+    // rf2-u0cy4: tracked separately from `consoleLines` for the same reason
+    // `pageErrors` is — a fatal signal must not be recoverable only by
+    // re-scanning diagnostics that a green run never flushes.
+    const fatalConsole = [];
     diagnostics.add(`URL: ${URL}`);
     page.on('console', (msg) => {
       const text = msg.text();
       consoleLines.push(text);
+      if (FATAL_CONSOLE_RE.test(text)) fatalConsole.push(text);
       diagnostics.add(`${capturedAt()} [browser:${msg.type()}] ${text}`);
     });
     page.on('pageerror', (err) => {
@@ -328,6 +352,23 @@ async function main() {
         `cljs.test summary was green, but the browser emitted ` +
           `${pageErrors.length} uncaught pageerror(s) — failing the run (rf2-mwx08).`,
       );
+      printSummaryDetails(summary);
+      flushDiagnostics(diagnostics);
+      return 1;
+    }
+
+    // rf2-u0cy4: likewise for a double-fired cljs.test `done`. cljs.test
+    // degrades it to a console warning, so the tally above can never see it.
+    if (fatalConsole.length > 0) {
+      console.error(
+        `cljs.test summary was green, but ${fatalConsole.length} async ` +
+          `row(s) called \`done\` more than once — failing the run (rf2-u0cy4). ` +
+          `A duplicate \`done\` means the row's continuation was already ` +
+          `realized: usually a teardown fixture that calls \`done\` alongside ` +
+          `a trailing \`(done)\` the test still makes itself. cljs.test cannot ` +
+          `fail this, so the lane must.`,
+      );
+      for (const line of fatalConsole) console.error(`  ${line}`);
       printSummaryDetails(summary);
       flushDiagnostics(diagnostics);
       return 1;

--- a/implementation/scripts/run-browser-tests.cjs
+++ b/implementation/scripts/run-browser-tests.cjs
@@ -73,6 +73,21 @@ const TIMEOUT_MS = parseInt(process.env.BROWSER_TEST_TIMEOUT_MS || String(DEFAUL
 const POLL_MS = 200;
 const VERBOSE_TESTS = isVerboseTests();
 
+// rf2-76lhy: stamp diagnostics at CAPTURE time, not at flush time.
+//
+// The buffer is flushed in a single burst, so every line lands on the log
+// within the same millisecond and the surrounding log's own timestamps say
+// nothing about when the line was produced — verified on a real CI timeout,
+// where all 66 buffered `Testing <ns>` lines carried the same flush stamp.
+// Without a capture-time offset, "namespace 66 was still running when the
+// clock expired" is indistinguishable from "namespace 66 never returned".
+// With one, the trail a timeout already dumps IS a per-namespace duration
+// profile: consecutive `Testing <ns>` offsets subtract to that namespace's
+// wall-clock cost, and the outlier names itself.
+const RUN_STARTED_AT = process.hrtime.bigint();
+const capturedAt = () =>
+  `[+${(Number(process.hrtime.bigint() - RUN_STARTED_AT) / 1e9).toFixed(2)}s]`;
+
 // The test-count floor (rf2-qqzmf). ONE name across every whole-suite lane:
 // the JVM runner (re-frame.test-quiet.runner) and the CLJS node runner
 // (re-frame.test-quiet.shadow-node) read the same variable. Because it is
@@ -222,16 +237,16 @@ async function main() {
     page.on('console', (msg) => {
       const text = msg.text();
       consoleLines.push(text);
-      diagnostics.add(`[browser:${msg.type()}] ${text}`);
+      diagnostics.add(`${capturedAt()} [browser:${msg.type()}] ${text}`);
     });
     page.on('pageerror', (err) => {
       pageErrors.push(err.stack || err.message);
-      diagnostics.add(`[browser:pageerror] ${err.message}`, 'stderr');
+      diagnostics.add(`${capturedAt()} [browser:pageerror] ${err.message}`, 'stderr');
       if (err.stack) diagnostics.add(err.stack, 'stderr');
     });
     page.on('framenavigated', (frame) => {
       if (frame === page.mainFrame()) {
-        diagnostics.add(`[browser:navigation] ${frame.url()}`);
+        diagnostics.add(`${capturedAt()} [browser:navigation] ${frame.url()}`);
       }
     });
 


### PR DESCRIPTION
Two small changes to `implementation/scripts/run-browser-tests.cjs`, one per bead. The first is a diagnostic; the second is a verdict. Together they make the browser lane report on itself instead of being reasoned about from the outside.

## rf2-76lhy — the lane profiles itself

The runner buffers the page console and flushes it in one burst on failure, so every buffered line lands on the log within the same millisecond. A real CI timeout log carries 66 `Testing <ns>` lines all stamped to the same hundredth of a second. The trail could say *which* namespaces a run reached and nothing about how long any of them took, so "namespace 66 was still running when the clock expired" and "namespace 66 never returned" produced an identical log.

Take a monotonic offset as each line is captured. That is the whole change — no aggregation, no thresholds, no reporting. The trail a timeout already dumps now *is* a per-namespace duration profile.

### It found something on the first run

Sample of the flushed trail, ordinals 25–34 of a green local bundle:

```
[+8.02s]   ns  25  re-frame.freehand.behaviors-dom-cljs-test              ->  0.15s
[+8.17s]   ns  26  re-frame.freehand.bench.b1-dom-cljs-test               ->  0.11s
[+8.28s]   ns  27  re-frame.freehand.bench.b10-two-clock-dom-cljs-test    -> 35.85s   <=
[+44.13s]  ns  28  re-frame.freehand.bench.b2-dom-cljs-test               ->  0.78s
[+44.91s]  ns  29  re-frame.freehand.bench.b4-dom-cljs-test               ->  0.49s
[+45.40s]  ns  30  re-frame.freehand.bench.b5-mount-dom-cljs-test         ->  0.03s
[+45.43s]  ns  31  re-frame.freehand.bench.b6-mount-dom-cljs-test         ->  4.48s
[+49.91s]  ns  32  re-frame.freehand.bench.b6-update-dom-cljs-test        -> 10.23s
[+60.14s]  ns  33  re-frame.freehand.buffered-controller-dom-cljs-test    ->  0.58s
[+60.72s]  ns  34  re-frame.freehand.client-only-dom-cljs-test            ->  0.63s
```

Across two green runs of the same bundle (855 tests / 5609 assertions, 148 namespaces):

| | run A | run B |
|---|---|---|
| `bench.b10-two-clock` | 43.3s (53%) | 35.9s (50%) |
| the 7 `bench.*` namespaces | 60.0s (73%) | 52.0s (73%) |
| median namespace | 0.040s | 0.040s |
| lane total | 81.7s | 71.5s |

**Namespace count is not a clock for this lane.** 73% of its wall clock is 7 of its 148 namespaces; the other 141 are a dense tail averaging 40 ms. rf2-76lhy derived "3.1–4.7× slower in CI" and "3–4× run-to-run variance on identical code" from per-namespace rates. Placed on the measured wall clock, the three recorded CI stop points are:

| CI stop | share of namespaces | reached locally at | share of **wall clock** |
|---|---|---|---|
| ns 66 | 45% | +67.9s | **92%** |
| ns 93 | 63% | +69.0s | **94%** |
| ns 99 | 67% | +71.0s | **97%** |

All three died in the last 8% of the lane, within 5 points of each other. The run-to-run "variance" was the denominator. CI spent 120 s reaching a point this box reaches at ~68 s — about 1.7×, uniform, not 4.7× — and job 90071495499 completing the same bundle in 146 s is that same factor. 82 s × ~1.75 ≈ 143 s against a 120 s ceiling predicts exactly what was observed: three runs dying a few seconds short.

A leaked `IS_REACT_ACT_ENVIRONMENT` is not needed to explain any of it. The 73-file ad-hoc set/restore is still a hazard on its own terms, but this bead's evidence no longer points at it. I did not re-measure CI — those are the bead's own recorded numbers against a corrected denominator, on one dev box. The profile now ships, so the next CI timeout answers this with its own stamps rather than by inference.

Filed from this, both out of fence here: **rf2-mf4uy** (a benchmark is half the correctness gate; the `browser-test-freehand-bench` build already exists) and **rf2-dczpv** (a *second* undocumented ceiling — Playwright's default 30 s `page.goto` `load` timeout, which fired once locally during this measurement and which the 360 s budget raise does not touch).

## rf2-u0cy4 — a double-fired `done` is fatal

Console output here is diagnostic-only by design (rf2-mwx08); only `pageerror` is fatal. That policy has one hole. When a cljs.test async row calls `done` twice, `run-block` finds its continuation already realized and degrades the second call to a `println`:

```clojure
(if (realized? d) (println "WARNING: Async test called done more than one time.") @d)
```

The defect is structurally incapable of reaching the failure tally. It is not hypothetical: PR #7162 swapped in a teardown helper that calls `done` and left five pre-existing trailing `(done)` calls behind it, so every async row in that suite double-fired. The lane was green. A human reading the diff caught it (rf2-0ke4x, fixed in #7164).

Promoted to a fatal console pattern beside the existing `pageErrors` arm — general across the whole mounted tier, rather than a textual lint over one suite's source. Tracked in its own array for the same reason `pageErrors` is: a fatal signal must not be recoverable only by re-scanning diagnostics a green run never flushes.

**Verified it does not red main today.** A full local bundle — 855 tests / 5609 assertions, 0 failures — emits **zero** duplicate-`done` warnings, before and after the promotion.

**Verified it fires.** A fixture page emitting the literal alongside a green summary exits 1; the same page without it exits 0:

```
=== CONTROL: clean page ===
Browser tests: Ran 3 tests containing 5 assertions. 0 failures, 0 errors.
CLEAN_EXIT=0

=== MUTANT: duplicate done ===
cljs.test summary was green, but 1 async row(s) called `done` more than once —
failing the run (rf2-u0cy4). ...
DUP_EXIT=1
```

Both classes are pinned statically in `_impl-browser-runners-verdict-policy.test.cjs` alongside the existing pageerror and test-count-floor pins — including the cljs.test literal itself, so a ClojureScript upgrade that reworded the warning trips the gate rather than silently disarming it. The capture-time stamping is pinned there too: it is dormant in a healthy tree, since only a timeout ever flushes the buffer, so ordinary CI would never notice it being refactored away.

## Quality gates

| gate | exit |
|---|---|
| `node --check scripts/run-browser-tests.cjs` | **0** |
| `node --check scripts/_impl-browser-runners-verdict-policy.test.cjs` | **0** |
| `node scripts/_impl-browser-runners-verdict-policy.test.cjs` — 11 passed | **0** |
| `shadow-cljs compile browser-test` — 1076 files, 0 warnings, 54.30s | **0** |
| full browser bundle, run A (`RF2_VERBOSE_TESTS=1`) — 855 tests / 5609 assertions, 0 failures | **0** |
| full browser bundle, run B, **with the promotion in place** — 855 tests / 5609 assertions, 0 failures, 0 duplicate-`done` | **0** |
| negative control — clean fixture page | **0** |
| negative control — duplicate-`done` fixture page (expected red) | **1** |

One earlier local bundle attempt died at `page.goto: Timeout 30000ms exceeded` after 21 namespaces; the two immediately following runs of the identical bundle passed. That is rf2-dczpv, filed above — a pre-existing second ceiling, unrelated to these changes (a string prefix in a console handler cannot delay page load).

Everything else is deferred to CI: no full-spine gate was run, and the runner touched here is exercised by every browser lane in the matrix.

Line counts: rf2-76lhy is 3 code lines plus its comment and 3 call-site prefixes; rf2-u0cy4 is 1 pattern constant, 2 capture lines and a 13-line fatal arm, plus 2 policy tests.
