### PR TITLE
test(freehand): split dev instrumentation from semantics so the prod-gate lane can grow (rf2-74a89)

### DIFF
--- a/implementation/freehand/test/re_frame/freehand/behaviors_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/behaviors_cljs_test.cljc
@@ -7,14 +7,33 @@
   the closures are one answer rather than two that agree. The mounted half
   — commit-only connection, total cleanup, and the command channel against
   a live node — is `behaviors_dom_cljs_test`, because those are DOM facts
-  and nothing else can prove them."
+  and nothing else can prove them.
+
+  ## Posture split (rf2-74a89)
+
+  Exactly ONE row of the FH-BEHAVIOR-002 table changes under the real
+  `-Dre-frame.debug=false` gate, and it is worth reading before anyone
+  reports an acceptance regression: `:unknown-option`. Its refusal is the
+  boundary's CLOSED PROPS SCHEMA (`:rf.error/view-bad-props`), and
+  `descriptor.cljc` gates the whole closing-schema arm on
+  `interop/debug-enabled?` because \"a schema is a compile-time and tooling
+  fact\". Under the gate that arm is gone — but the call is STILL REFUSED,
+  by the behavior door's OWN always-on roster check
+  (`:rf.error/behavior-bad-args`). Only the diagnostic id differs.
+
+  So that row asserts REFUSED posture-independently, with the exact id kept
+  verbatim in a `(when interop/debug-enabled? …)` arm. Every other row —
+  every `:rf.error/behavior-bad-args` refusal and every `:renders`
+  acceptance — keeps its exact outcome asserted in both postures, because
+  the behavior door owns those checks and they are always on."
   (:require [clojure.edn :as edn]
             [clojure.test :refer [deftest is testing]]
             [re-frame.freehand :as v]
             [re-frame.freehand.behavior-views :as bv]
             [re-frame.freehand.behaviors :as behaviors]
             [re-frame.freehand.conformance :as conf]
-            [re-frame.freehand.test :as t]))
+            [re-frame.freehand.test :as t]
+            [re-frame.interop :as interop]))
 
 ;; ---------------------------------------------------------------------------
 ;; FH-BEHAVIOR-001 — the registration roster
@@ -119,8 +138,21 @@
       (let [declaration (get declarations view)
             _           (is (some? declaration) (str note " — the fixture names a real view"))
             got         (conf/caught-id #(t/render [declaration {}]))]
-        (if (= :renders outcome)
+        (cond
+          (= :renders outcome)
           (is (= conf/no-throw got) note)
+
+          ;; rf2-74a89 — the ONE row the props-schema closure owns (see the
+          ;; ns docstring's "Posture split"). Refusal is posture-independent
+          ;; and asserted as such; only WHICH id fires is dev-gated.
+          (= :rf.error/view-bad-props outcome)
+          (do
+            (is (not= conf/no-throw got)
+                (str note " — refused in either posture"))
+            (when interop/debug-enabled?
+              (is (= outcome got) note)))
+
+          :else
           (is (= outcome got) note))))))
 
 (deftest fh-behavior-002-a-refusal-names-the-behavior-surface

--- a/implementation/freehand/test/re_frame/freehand/errors_tree_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/errors_tree_cljs_test.cljc
@@ -7,14 +7,34 @@
   a render-class throw below the boundary is CONTAINED — the boundary node
   holds the fallback subtree — while every SIBLING node the surrounding walk
   built keeps its place. The browser realises the same law through a React
-  class boundary; here it is proven as a pure structural value."
+  class boundary; here it is proven as a pure structural value.
+
+  ## Posture split (rf2-74a89)
+
+  ONE assertion in this namespace changes under the real
+  `-Dre-frame.debug=false` gate: the closed-option-roster refusal in
+  `the-rest-of-the-error-boundary-grammar-is-refused-arm-by-arm`. That
+  refusal belongs to the boundary's CLOSED PROPS SCHEMA
+  (`:rf.error/view-bad-props`), and `descriptor.cljc` gates the whole
+  closing-schema arm on `interop/debug-enabled?` because \"a schema is a
+  compile-time and tooling fact\". Under the gate the call is STILL REFUSED
+  — the boundary's own always-on `read-opts` check fires instead
+  (`:rf.error/error-boundary-bad-args`) — so only the diagnostic id
+  differs. Do not read it as an acceptance regression.
+
+  REFUSED is therefore asserted posture-independently and the exact id is
+  kept verbatim in a `(when interop/debug-enabled? …)` arm. Everything else
+  here — containment, sibling survival, attribution, and the other three
+  `read-opts` refusals — is the boundary's own always-on machinery and is
+  asserted unchanged in both postures."
   (:require #?(:clj  [clojure.test :refer [deftest is testing]]
                :cljs [cljs.test :refer-macros [deftest is testing]])
             [re-frame.freehand :as v]
             [re-frame.freehand.conformance :as conf]
             [re-frame.freehand.descriptor :as descriptor]
             [re-frame.freehand.errors :as eb]
-            [re-frame.freehand.tree :as tree]))
+            [re-frame.freehand.tree :as tree]
+            [re-frame.interop :as interop]))
 
 (def error-001 (conf/fixture :FH-ERROR-001))
 
@@ -269,12 +289,18 @@
             it actually fires rather than as a reader might assume."
     ;; The option roster is CLOSED — a one-character typo must not produce a
     ;; boundary that quietly means something other than it says.
-    (is (= :rf.error/view-bad-props
-           (conf/caught-id
-             #(tree/render [v/error-boundary {:fallback (:fallback error-001)
-                                              :catch    true}
-                            [ok-child {}]])))
-        "an option outside the roster is refused, not ignored")
+    (let [got (conf/caught-id
+                (fn []
+                  (tree/render [v/error-boundary {:fallback (:fallback error-001)
+                                                  :catch    true}
+                                [ok-child {}]])))]
+      (is (not= conf/no-throw got)
+          "an option outside the roster is refused, not ignored — in either posture")
+      ;; rf2-74a89 — dev-instrumentation arm (see ns docstring). WHICH check
+      ;; owns the refusal is what the gate changes; that it IS refused is not.
+      (when interop/debug-enabled?
+        (is (= :rf.error/view-bad-props got)
+            "an option outside the roster is refused, not ignored")))
     ;; A boundary with no fallback would show NOTHING on failure — the one
     ;; outcome worse than the failure itself.
     (is (= :rf.error/error-boundary-bad-args

--- a/implementation/freehand/test/re_frame/freehand/evidence_seam_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/evidence_seam_cljs_test.cljc
@@ -26,7 +26,42 @@
   The PRODUCTION-ISOLATION half of the acceptance (the record and the
   evidence schema it reaches DCE out of the `:advanced` / `goog.DEBUG=false`
   bundle) is proven by a bundle probe against `:freehand-release`, not from
-  here — a running test cannot observe what dead-code elimination removed."
+  here — a running test cannot observe what dead-code elimination removed.
+
+  ## Posture split (rf2-74a89)
+
+  `cell.cljc` puts the `interop/debug-enabled?` gate alone as the outermost
+  form of BOTH halves of this seam — the capture that builds the record and
+  the delivery that hands it to a sink — precisely so Closure folds them
+  away. Under the real `-Dre-frame.debug=false` gate there is therefore no
+  record, no delivery, no escape slot and no index row: the entire
+  observable subject of this suite is gone.
+
+  So every assertion ABOUT a record — its fields, its projections, its
+  delivery count, the contained escape — is kept VERBATIM inside a
+  `(when interop/debug-enabled? …)` arm. The negatives travel with the
+  positives for the usual reason: under the gate `(= [] seen)` and
+  `(nil? (last-evidence-sink-escape))` are satisfied by a seam that does
+  nothing for every input, so leaving them outside the arm would report a
+  green that proved nothing.
+
+  Two things are posture-independent, and they are what this namespace
+  contributes to `scripts/test-freehand-prod-gate.sh`:
+
+    - THE COMMIT'S OWN CONTRACT. Every deftest still drives a real render
+      and a real `cell/commit!`, and the attributed terminal state —
+      `:published`, a `:connected` cell owning exactly the dependency the
+      render read, a committed frame — is asserted outside the arm. That is
+      the bundle publication the seam hangs off, and it holds in both
+      postures.
+    - THE ELISION ITSELF, witnessed through the real load-time gate rather
+      than a `with-redefs` rebind, which cannot reach one (rf2-9c2jf). Each
+      of the four sink deftests carries a `(if interop/debug-enabled? …)`
+      whose production arm states the positive production fact rather than
+      an absence: an installed sink is called ZERO times, a THROWING sink is
+      unreachable rather than merely contained, and a record the evidence
+      schema would refuse is not a production failure mode at all, because
+      no record is built to refuse."
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.core :as rf]
@@ -36,6 +71,7 @@
             [re-frame.freehand.evidence :as evidence]
             [re-frame.freehand.test :as t]
             [re-frame.freehand.tool :as tool]
+            [re-frame.interop :as interop]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]))
 
@@ -94,35 +130,42 @@
     (seed! {:count 3})
     (let [seen (with-capturing-sink
                  (fn [] (commit-under! ::seam-a :interpreted)))]
-      (is (= 1 (count seen)) "exactly one record per commit")
-      (let [rec (first seen)]
-        (is (= evidence/schema (:schema rec)) "carries the schema version")
-        (is (= ::seam-a (:view-id rec)) "names the authoring view")
-        (is (= :interpreted (:lowering rec)) "names the lowering it ran under")
-        (is (nat-int? (:generation rec)) "a monotonic generation")
-        (is (evidence/occurrence? (:occurrence rec))
-            "a runtime occurrence key — parent + key both present")
-        (is (nil? (:parent (:occurrence rec))) "a root occurrence has no parent")
-        (is (some? (:key (:occurrence rec))) "keyed by runtime identity")
-        (let [proj (get-in rec [:projections :commit])]
-          (is (= :observation (:basis proj)) "the commit is an observation")
-          (is (true? (:complete? proj)) "complete for the generation it names")
-          (is (nil? (:loss proj)) "and lossless")
-          (is (= {:committed-generation (:generation rec)} (:scope proj))
-              "scoped to exactly the committed generation")
-          (is (= fid (:frame proj)) "naming the frame the commit bound to")
-          (is (= [[::count]] (mapv :query (:reads proj)))
-              "and the subscription sites THIS commit staged — its own dependency
-               set, not a union over the occurrence's life")
-          (is (every? #(= #{:site-key :query :frame-id :owned?} (set (keys %)))
-                      (:reads proj))
-              "each read stating where it came from and who owns it, and NOT the
-               value it returned: a value is application data, and an evidence
-               read is not a second egress path for it"))
-        ;; The record the seam emitted is one `evidence/record` would accept —
-        ;; the seam validated it, and re-validating is idempotent.
-        (is (= rec (evidence/record rec))
-            "the emitted record passes the evidence door unchanged")))))
+      ;; The commit itself ran and published — `commit-under!` asserts that
+      ;; outside this arm, in either posture.
+      ;;
+      ;; rf2-74a89 — dev-instrumentation arm (see ns docstring). Everything
+      ;; below observes the RECORD, and under `-Dre-frame.debug=false` the
+      ;; capture half of the seam builds none.
+      (when interop/debug-enabled?
+        (is (= 1 (count seen)) "exactly one record per commit")
+        (let [rec (first seen)]
+          (is (= evidence/schema (:schema rec)) "carries the schema version")
+          (is (= ::seam-a (:view-id rec)) "names the authoring view")
+          (is (= :interpreted (:lowering rec)) "names the lowering it ran under")
+          (is (nat-int? (:generation rec)) "a monotonic generation")
+          (is (evidence/occurrence? (:occurrence rec))
+              "a runtime occurrence key — parent + key both present")
+          (is (nil? (:parent (:occurrence rec))) "a root occurrence has no parent")
+          (is (some? (:key (:occurrence rec))) "keyed by runtime identity")
+          (let [proj (get-in rec [:projections :commit])]
+            (is (= :observation (:basis proj)) "the commit is an observation")
+            (is (true? (:complete? proj)) "complete for the generation it names")
+            (is (nil? (:loss proj)) "and lossless")
+            (is (= {:committed-generation (:generation rec)} (:scope proj))
+                "scoped to exactly the committed generation")
+            (is (= fid (:frame proj)) "naming the frame the commit bound to")
+            (is (= [[::count]] (mapv :query (:reads proj)))
+                "and the subscription sites THIS commit staged — its own dependency
+                 set, not a union over the occurrence's life")
+            (is (every? #(= #{:site-key :query :frame-id :owned?} (set (keys %)))
+                        (:reads proj))
+                "each read stating where it came from and who owns it, and NOT the
+                 value it returned: a value is application data, and an evidence
+                 read is not a second egress path for it"))
+          ;; The record the seam emitted is one `evidence/record` would accept —
+          ;; the seam validated it, and re-validating is idempotent.
+          (is (= rec (evidence/record rec))
+              "the emitted record passes the evidence door unchanged"))))))
 
 (deftest the-lowering-is-carried-through-not-inferred
   (testing "A compiled commit's record names `:compiled`; the seam reports the
@@ -131,8 +174,10 @@
     (seed! {:count 0})
     (let [seen (with-capturing-sink
                  (fn [] (commit-under! ::seam-compiled :compiled)))]
-      (is (= :compiled (:lowering (first seen)))
-          "the lowering the commit was given rides the record"))))
+      ;; rf2-74a89 — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (= :compiled (:lowering (first seen)))
+            "the lowering the commit was given rides the record")))))
 
 ;; ---------------------------------------------------------------------------
 ;; A throwing sink is CONTAINED — it cannot fail a published commit
@@ -157,6 +202,12 @@
                  (fn [_] (throw (ex-info "audit-sink-failure" {:probe true}))))]
       (try
         (cell/with-capture cand (fn [] (t/render [counter {}])))
+        ;; rf2-74a89 — every row below is the COMMIT's own terminal state and
+        ;; is asserted in both postures. What differs is WHY the throw cannot
+        ;; reach it: in dev the containment guard holds it, and under the real
+        ;; gate the seam never calls the sink at all. That second reason is
+        ;; asserted rather than assumed, one deftest down, so this deftest's
+        ;; NAMED claim is not left resting on a sink nothing invoked.
         (is (= :published (cell/commit! cand :interpreted))
             "a throwing sink is contained; the commit still reports :published")
         (is (= :connected (cell/lifecycle c))
@@ -186,13 +237,27 @@
         (cell/with-capture cand (fn [] (t/render [counter {}])))
         (is (= :published (cell/commit! cand :interpreted))
             "the commit stands despite the throw")
-        (is (= 1 @calls)
-            "the sink ran exactly once — the report never routes back through it")
-        (let [escape (cell/last-evidence-sink-escape)]
-          (is (= ::seam-once (:view-id escape))
-              "the contained escape names the offending view")
-          (is (some? (:error escape))
-              "and carries the cause, so the escape is never silent"))
+        (if interop/debug-enabled?
+          ;; rf2-74a89 — dev-instrumentation arm (see ns docstring), verbatim.
+          (do
+            (is (= 1 @calls)
+                "the sink ran exactly once — the report never routes back through it")
+            (let [escape (cell/last-evidence-sink-escape)]
+              (is (= ::seam-once (:view-id escape))
+                  "the contained escape names the offending view")
+              (is (some? (:error escape))
+                  "and carries the cause, so the escape is never silent")))
+          ;; rf2-74a89 — and the production posture, through the REAL load-time
+          ;; gate rather than a `with-redefs` rebind that cannot reach one
+          ;; (rf2-9c2jf). Stated as the positive fact it is: the delivery half
+          ;; of the seam is elided, so a throwing sink is UNREACHABLE rather
+          ;; than merely contained, and the escape slot has nothing to report.
+          (do
+            (is (= 0 @calls)
+                "under the gate the seam never calls an installed sink at all")
+            (is (nil? (cell/last-evidence-sink-escape))
+                "so there is no contained escape — nothing threw, because
+                 nothing ran")))
         (finally (cell/set-evidence-sink! prev))))))
 
 (deftest a-normal-sink-receives-the-record-once-per-commit
@@ -207,9 +272,17 @@
                  (fn []
                    (commit-under! ::seam-twice :interpreted)
                    (commit-under! ::seam-twice :interpreted)))]
-      (is (= 2 (count seen)) "one record per commit — exactly once each")
-      (is (every? #(= ::seam-twice (:view-id %)) seen)
-          "each names the committing view"))))
+      (if interop/debug-enabled?
+        ;; rf2-74a89 — dev-instrumentation arm (see ns docstring), verbatim.
+        (do
+          (is (= 2 (count seen)) "one record per commit — exactly once each")
+          (is (every? #(= ::seam-twice (:view-id %)) seen)
+              "each names the committing view"))
+        ;; Both commits published (`commit-under!` says so, outside this arm),
+        ;; and the sink still received NOTHING — delivery is elided, not merely
+        ;; quiet about a commit that failed to happen.
+        (is (= [] seen)
+            "under the gate two selected commits deliver zero records")))))
 
 ;; ---------------------------------------------------------------------------
 ;; A malformed FRAMEWORK record stays FAIL-LOUD, before publication
@@ -235,15 +308,34 @@
           prev (cell/set-evidence-sink! (fn [_] nil))]
       (cell/with-capture cand (fn [] (t/render [counter {}])))
       (try
-        (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs :default)
-              (cell/commit! cand :interpreted))
-            "the malformed framework record fails loud at the seam")
-        (is (not= :connected (cell/lifecycle c))
-            "the cell never connected — publication did not happen")
-        (is (empty? (cell/dependency-queries c))
-            "and it published no dependency: a refused record publishes nothing")
-        (is (nil? (cell/committed-frame c))
-            "nor a frame — the all-or-nothing boundary held before publication")
+        (if interop/debug-enabled?
+          ;; rf2-74a89 — dev-instrumentation arm (see ns docstring), verbatim.
+          (do
+            (is (thrown? #?(:clj clojure.lang.ExceptionInfo :cljs :default)
+                  (cell/commit! cand :interpreted))
+                "the malformed framework record fails loud at the seam")
+            (is (not= :connected (cell/lifecycle c))
+                "the cell never connected — publication did not happen")
+            (is (empty? (cell/dependency-queries c))
+                "and it published no dependency: a refused record publishes nothing")
+            (is (nil? (cell/committed-frame c))
+                "nor a frame — the all-or-nothing boundary held before publication"))
+          ;; rf2-74a89 — the production posture, and it is a statement rather
+          ;; than an absence: the FRAMEWORK plane's fail-loud validation lives
+          ;; inside the elided capture, so under the gate an unqualified
+          ;; view-id is not a production failure mode at all — no record is
+          ;; built, so there is none to refuse, and the same cell publishes its
+          ;; whole bundle normally. The evidence schema is a DEV contract, and
+          ;; this is the shape of that being true.
+          (do
+            (is (= :published (cell/commit! cand :interpreted))
+                "no record is built, so nothing refuses one and the commit stands")
+            (is (= :connected (cell/lifecycle c))
+                "the cell owns its bundle")
+            (is (= [[::count]] (cell/dependency-queries c))
+                "including the dependency the render read")
+            (is (some? (cell/committed-frame c))
+                "and the frame it bound to")))
         (finally (cell/set-evidence-sink! prev))))))
 
 ;; ---------------------------------------------------------------------------
@@ -267,6 +359,17 @@
     (let [c (commit-under! ::seam-nosink :interpreted)]
       (is (= [[::count]] (cell/dependency-queries c))
           "the commit published its dependency exactly as it would with no seam")
-      (is (some #(= ::seam-nosink (:view-id %))
-                (:occurrences (tool/read-mounted-views)))
-          "and the occurrence is current, with no sink ever installed"))))
+      (if interop/debug-enabled?
+        ;; rf2-74a89 — dev-instrumentation arm (see ns docstring), verbatim.
+        (is (some #(= ::seam-nosink (:view-id %))
+                  (:occurrences (tool/read-mounted-views)))
+            "and the occurrence is current, with no sink ever installed")
+        ;; The production counterpart, and the reason the index is worth
+        ;; asserting about at all: the row is built inside the same elided
+        ;; capture, so a production build does not accumulate a row per
+        ;; mounted occurrence. `read-mounted-views` is itself gated and
+        ;; answers nil — an absence a consumer distinguishes the way it
+        ;; distinguishes any other, by asking about a view it knows is
+        ;; declared (`tool.cljc` §DEV-ONLY).
+        (is (nil? (tool/read-mounted-views))
+            "under the gate the read is inert and the index rowed nothing")))))

--- a/implementation/freehand/test/re_frame/freehand/explain_render_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/explain_render_cljs_test.cljc
@@ -32,7 +32,47 @@
   Driving it through the real emit door — the same door the framework's own
   ops go through, with the same tags — exercises the same retention rule
   (`frame` + `dispatch-id` or nothing) rather than a hand-built ring that could
-  agree with the fold while disagreeing with Spec 009."
+  agree with the fold while disagreeing with Spec 009.
+
+  ## Posture split (rf2-74a89)
+
+  This is the most one-sided split in the artefact, and the docstring says so
+  rather than dressing it up. `tool/explain-render` is gated AT THE DOOR
+  (`tool.cljc` §DEV-ONLY) and answers nil under `-Dre-frame.debug=false`; so
+  do the two structures it folds — the current-occurrence index, whose every
+  write is inside `interop/debug-enabled?`, and Spec 009's retained ring. The
+  read's entire output is therefore absent in the production posture, and
+  EVERY assertion about an explanation lives inside a
+  `(when interop/debug-enabled? …)` arm marked `rf2-74a89`, kept verbatim.
+
+  The negatives travel with the positives, and there are many of them here:
+  `(nil? (:loss e))`, `(nil? (:cause e))`, `(nil? (:dispatch-id e))`,
+  `(= [] (:candidates e))`, `(every? #(not (contains? % :value)) …)` over an
+  empty read set, and `an-undeclared-id-answers-nil` are each satisfied by a
+  read that answers nil for every input. Leaving any of them outside the arm
+  would report a green that proved nothing — the exact false green this lane
+  exists to close.
+
+  What the namespace contributes to `scripts/test-freehand-prod-gate.sh` is
+  two things, and neither is borrowed from a sibling suite:
+
+    - THE CORRELATED COMMIT PATH. `connect!` binds `trace/*handler-scope*`
+      and commits inside a cascade, and `retain-run!` drives the real
+      `trace/emit!` door beside it. Nothing else in the artefact's suites
+      exercises a Freehand commit with a run on the stack, and the commit
+      seam reads `trace/*handler-scope*` only from inside the elided arm —
+      so \"the correlated commit still publishes under the gate\" is a real
+      production path with a real way to break. Every deftest drives it and
+      asserts `:published` outside the arm.
+    - THE READ IS INERT, NOT PARTIALLY ANSWERING.
+      `whether-the-read-answers-at-all-is-decided-by-the-load-time-gate`
+      pins that under the real gate a DECLARED, MOUNTED, CORRELATED view
+      answers `nil` — never an envelope carrying `:explanations []` with
+      `:complete? true` on it. That distinction is the whole point of gating
+      at the door: an empty-but-confident answer would tell a tool that
+      nothing is rendering in a build where plenty is, which is worse than
+      no answer at all. Witnessed through the real load-time gate rather
+      than a `with-redefs` rebind, which cannot reach one (rf2-9c2jf)."
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.core :as rf]
@@ -42,6 +82,7 @@
             [re-frame.freehand.occurrences :as occurrences]
             [re-frame.freehand.test :as t]
             [re-frame.freehand.tool :as tool]
+            [re-frame.interop :as interop]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]
             [re-frame.trace :as trace]
@@ -110,22 +151,26 @@
     (let [did (retain-run! 4141 ::count)
           c   (connect! ::explained did)
           e   (explanation-for ::explained)]
-      (is (some? e) "the occurrence has an explanation")
-      (is (true? (:complete? e)) "and it is complete — the run is still retained")
-      (is (nil? (:loss e)) "so there is no loss to account for")
-      (is (= did (:dispatch-id e))
-          "the explanation names the run the commit was correlated to")
-      (is (= did (:dispatch-id (:cause e))) "and the cause IS that run")
-      (is (= ::bump (:cause-event-id (:cause e)))
-          "named by its event ID — a keyword, never the event vector, because an
-           event's args are application data")
-      (is (= #{::count} (:sub-ids (:cause e)))
-          "and by the subscriptions it recomputed that this commit reads")
-      (is (= fid (:frame e)) "the explanation is scoped to the commit's frame")
-      (is (pos? (:retained-runs (:scope e)))
-          "the scope states how much window was folded")
-      (is (true? (:spans-commit? (:scope e)))
-          "and that the window reaches back past the commit")
+      ;; rf2-74a89 — dev-instrumentation arm (see ns docstring). The
+      ;; correlated commit itself ran and published in either posture;
+      ;; `connect!` says so outside this arm.
+      (when interop/debug-enabled?
+        (is (some? e) "the occurrence has an explanation")
+        (is (true? (:complete? e)) "and it is complete — the run is still retained")
+        (is (nil? (:loss e)) "so there is no loss to account for")
+        (is (= did (:dispatch-id e))
+            "the explanation names the run the commit was correlated to")
+        (is (= did (:dispatch-id (:cause e))) "and the cause IS that run")
+        (is (= ::bump (:cause-event-id (:cause e)))
+            "named by its event ID — a keyword, never the event vector, because an
+             event's args are application data")
+        (is (= #{::count} (:sub-ids (:cause e)))
+            "and by the subscriptions it recomputed that this commit reads")
+        (is (= fid (:frame e)) "the explanation is scoped to the commit's frame")
+        (is (pos? (:retained-runs (:scope e)))
+            "the scope states how much window was folded")
+        (is (true? (:spans-commit? (:scope e)))
+            "and that the window reaches back past the commit"))
       (cell/disconnect! c))))
 
 (deftest the-explanation-carries-the-commit-it-explains
@@ -137,11 +182,15 @@
     (let [did (retain-run! 5151 ::count)
           c   (connect! ::carries did)
           e   (explanation-for ::carries)]
-      (is (= {:committed-generation (:generation e)} (:scope (:commit e))))
-      (is (= [[::count]] (mapv :query (:reads (:commit e))))
-          "the commit's own dependency set")
-      (is (every? #(not (contains? % :value)) (:reads (:commit e)))
-          "and never what those reads returned")
+      ;; rf2-74a89 — dev-instrumentation arm (see ns docstring). The
+      ;; `every?` row travels inside it too: over an empty read set it is
+      ;; satisfied by an explanation that carries no reads at all.
+      (when interop/debug-enabled?
+        (is (= {:committed-generation (:generation e)} (:scope (:commit e))))
+        (is (= [[::count]] (mapv :query (:reads (:commit e))))
+            "the commit's own dependency set")
+        (is (every? #(not (contains? % :value)) (:reads (:commit e)))
+            "and never what those reads returned"))
       (cell/disconnect! c))))
 
 (deftest no-arg-spans-every-current-occurrence
@@ -154,8 +203,10 @@
           a   (connect! ::span-a did)
           b   (connect! ::span-b did)
           ids (set (map :view-id (:explanations (tool/explain-render))))]
-      (is (contains? ids ::span-a))
-      (is (contains? ids ::span-b))
+      ;; rf2-74a89 — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (contains? ids ::span-a))
+        (is (contains? ids ::span-b)))
       (cell/disconnect! a)
       (cell/disconnect! b))))
 
@@ -170,19 +221,28 @@
     (seed! {:count 0})
     (let [c (connect! ::split)                   ;; uncorrelated on purpose
           r (tool/explain-render ::split)]
-      (is (true? (:complete? r)) "the roster is complete")
-      (is (nil? (:loss r)))
-      (is (= :explain-render (:read r)))
-      (is (= :re-frame.freehand.evidence/v1 (:schema r)))
-      (is (false? (:complete? (first (:explanations r))))
-          "while the explanation inside it is not")
+      ;; rf2-74a89 — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (true? (:complete? r)) "the roster is complete")
+        (is (nil? (:loss r)))
+        (is (= :explain-render (:read r)))
+        (is (= :re-frame.freehand.evidence/v1 (:schema r)))
+        (is (false? (:complete? (first (:explanations r))))
+            "while the explanation inside it is not"))
       (cell/disconnect! c))))
 
 (deftest an-undeclared-id-answers-nil
   (testing "Absence is absence, the same way every increment-1 read reports it:
             a tool sweeping ids it was handed must not be told that an id naming
             no view is a view with nothing mounted."
-    (is (nil? (tool/explain-render :nobody/declared-this)))))
+    ;; rf2-74a89 — dev-instrumentation arm (see ns docstring). Under the gate
+    ;; the read answers nil for EVERY id, so this row would hold without the
+    ;; door telling declared from undeclared at all. Its production
+    ;; counterpart —
+    ;; `whether-the-read-answers-at-all-is-decided-by-the-load-time-gate` —
+    ;; states the nil as a claim about the gate rather than about the id.
+    (when interop/debug-enabled?
+      (is (nil? (tool/explain-render :nobody/declared-this))))))
 
 (deftest a-declared-but-unmounted-view-has-an-empty-roster-and-says-so-honestly
   (testing "This is the one empty answer that IS a clean bill of health, because
@@ -190,10 +250,12 @@
             mounted, and reporting loss here would be inventing doubt."
     (register!)
     (let [r (tool/explain-render ::counter)]
-      (is (some? r) "the view is declared, so the read answers")
-      (is (= [] (:explanations r)))
-      (is (true? (:complete? r)))
-      (is (nil? (:loss r))))))
+      ;; rf2-74a89 — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (some? r) "the view is declared, so the read answers")
+        (is (= [] (:explanations r)))
+        (is (true? (:complete? r)))
+        (is (nil? (:loss r)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; 5 — eviction and missing correlation are reported as LOSS
@@ -211,17 +273,21 @@
     (retain-run! 7171 ::count)
     (let [c (connect! ::uncorrelated)          ;; no cascade in scope
           e (explanation-for ::uncorrelated)]
-      (is (nil? (:dispatch-id e))
-          "the commit named no run, and the row says nil rather than minting one")
-      (is (false? (:complete? e)))
-      (is (= {:reason :uncorrelated :dropped :unknown} (:loss e)))
-      (is (nil? (:cause e)) "there is no cause to name")
-      (is (= [{:dispatch-id 7171 :cause-event-id ::bump :sub-ids #{::count}}]
-             (:candidates e))
-          "the runs the window holds that recomputed a subscription this commit
-           reads are offered as CANDIDATES — leads, explicitly not the answer,
-           because presenting a lead as a cause is the shape a false
-           `:complete? true` would have")
+      ;; rf2-74a89 — dev-instrumentation arm (see ns docstring). The two nil
+      ;; rows travel inside it with the rest: over an explanation that does
+      ;; not exist they are satisfied for every input.
+      (when interop/debug-enabled?
+        (is (nil? (:dispatch-id e))
+            "the commit named no run, and the row says nil rather than minting one")
+        (is (false? (:complete? e)))
+        (is (= {:reason :uncorrelated :dropped :unknown} (:loss e)))
+        (is (nil? (:cause e)) "there is no cause to name")
+        (is (= [{:dispatch-id 7171 :cause-event-id ::bump :sub-ids #{::count}}]
+               (:candidates e))
+            "the runs the window holds that recomputed a subscription this commit
+             reads are offered as CANDIDATES — leads, explicitly not the answer,
+             because presenting a lead as a cause is the shape a false
+             `:complete? true` would have"))
       (cell/disconnect! c))))
 
 (deftest an-evicted-run-is-reported-as-cap-loss-provably
@@ -233,19 +299,22 @@
     (seed! {:count 5})
     (let [did (retain-run! 8181 ::count)
           c   (connect! ::evicted did)]
-      (is (true? (:complete? (explanation-for ::evicted)))
-          "the run is retained to begin with — the eviction below is a change,
-           not the initial state")
+      ;; rf2-74a89 — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (is (true? (:complete? (explanation-for ::evicted)))
+            "the run is retained to begin with — the eviction below is a change,
+             not the initial state"))
       ;; Evict it: a fresh window that no longer holds the commit's run.
       (trace-tooling/clear-trace-buffer! fid)
       (retain-run! 8282 ::count)
-      (let [e (explanation-for ::evicted)]
-        (is (= did (:dispatch-id e)) "the commit still names the run it ran under")
-        (is (false? (:complete? e)))
-        (is (= {:reason :cap :dropped :unknown} (:loss e)))
-        (is (nil? (:cause e))
-            "and no other run is promoted into its place — a window that has
-             forgotten why a view rendered says so"))
+      (when interop/debug-enabled?
+        (let [e (explanation-for ::evicted)]
+          (is (= did (:dispatch-id e)) "the commit still names the run it ran under")
+          (is (false? (:complete? e)))
+          (is (= {:reason :cap :dropped :unknown} (:loss e)))
+          (is (nil? (:cause e))
+              "and no other run is promoted into its place — a window that has
+               forgotten why a view rendered says so")))
       (cell/disconnect! c))))
 
 (deftest an-empty-window-is-reported-as-cap-loss
@@ -257,12 +326,14 @@
     (seed! {:count 0})
     (let [c (connect! ::empty-window 9191)]
       (trace-tooling/clear-trace-rings!)
-      (let [e (explanation-for ::empty-window)]
-        (is (false? (:complete? e)))
-        (is (= {:reason :cap :dropped :unknown} (:loss e)))
-        (is (= 0 (:retained-runs (:scope e))) "and the scope states the window is empty")
-        (is (false? (:spans-commit? (:scope e)))
-            "an empty window reaches back to nothing"))
+      ;; rf2-74a89 — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (let [e (explanation-for ::empty-window)]
+          (is (false? (:complete? e)))
+          (is (= {:reason :cap :dropped :unknown} (:loss e)))
+          (is (= 0 (:retained-runs (:scope e))) "and the scope states the window is empty")
+          (is (false? (:spans-commit? (:scope e)))
+              "an empty window reaches back to nothing")))
       (cell/disconnect! c))))
 
 (deftest the-configured-retention-knob-is-the-one-that-governs
@@ -276,10 +347,14 @@
     (retain-run! 9292 ::count)
     (let [c (connect! ::knob 9292)
           e (explanation-for ::knob)]
-      (is (= 0 (:retained-runs (:scope e)))
-          "the ring allocated nothing at the configured cap")
-      (is (false? (:complete? e)))
-      (is (= :cap (:reason (:loss e))))
+      ;; rf2-74a89 — dev-instrumentation arm (see ns docstring). The
+      ;; `rf/configure!` call and the correlated commit under it run in both
+      ;; postures; only the fold's report of them is gated.
+      (when interop/debug-enabled?
+        (is (= 0 (:retained-runs (:scope e)))
+            "the ring allocated nothing at the configured cap")
+        (is (false? (:complete? e)))
+        (is (= :cap (:reason (:loss e)))))
       (cell/disconnect! c))))
 
 (deftest a-candidate-must-actually-touch-one-of-the-commits-reads
@@ -291,8 +366,60 @@
     (retain-run! 9393 ::something-else)
     (let [c (connect! ::narrow)
           e (explanation-for ::narrow)]
-      (is (= [] (:candidates e))
-          "a run that touched none of this commit's reads is not a candidate")
-      (is (= :uncorrelated (:reason (:loss e)))
-          "and the explanation still reports why it cannot say more")
+      ;; rf2-74a89 — dev-instrumentation arm (see ns docstring). The empty
+      ;; `:candidates` row is a NEGATIVE over a fold that produced nothing —
+      ;; the first of the four vacuous shapes, and the reason it travels
+      ;; inside the arm rather than standing as this deftest's own witness.
+      (when interop/debug-enabled?
+        (is (= [] (:candidates e))
+            "a run that touched none of this commit's reads is not a candidate")
+        (is (= :uncorrelated (:reason (:loss e)))
+            "and the explanation still reports why it cannot say more"))
+      (cell/disconnect! c))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-74a89 — the door, and the posture that decides whether it opens
+;; ---------------------------------------------------------------------------
+
+(deftest whether-the-read-answers-at-all-is-decided-by-the-load-time-gate
+  (testing "The production-real half of this namespace, witnessed through the
+            REAL load-time gate rather than a `with-redefs` rebind, which
+            cannot reach one (rf2-9c2jf).
+
+            A view is declared, mounted, and committed WITH A CASCADE ON THE
+            STACK — the correlated path this suite's `connect!` is the only
+            thing in the artefact's suites to drive, and the path the commit
+            seam reads `trace/*handler-scope*` from. It publishes in either
+            posture, which is asserted first, because a read answering nil
+            about a commit that never happened would prove nothing about the
+            read.
+
+            Then the door. Under `-Dre-frame.debug=false` it answers `nil` —
+            NOT an envelope carrying `:explanations []` with `:complete? true`
+            on it. That distinction is the whole reason the gate sits at the
+            door rather than one level in: an empty-but-confident answer would
+            tell a tool that nothing is rendering in a build where plenty is,
+            which is worse than no answer at all."
+    (register!)
+    (seed! {:count 8})
+    (let [did (retain-run! 1010 ::count)
+          c   (connect! ::inert did)]
+      (is (= did 1010) "the run was retained under the id the commit ran with")
+      (is (= :connected (cell/lifecycle c))
+          "the correlated commit published its whole bundle, in either posture")
+      (is (= [[::count]] (cell/dependency-queries c))
+          "owning exactly the dependency the render read")
+      (if interop/debug-enabled?
+        (do
+          (is (some? (tool/explain-render ::inert))
+              "dev: the door answers for a mounted, declared view")
+          (is (some? (tool/explain-render))
+              "and for the no-arg arity"))
+        (do
+          (is (nil? (tool/explain-render ::inert))
+              "production: nil for a view that IS declared and IS mounted —
+               inert, never an empty roster wearing a completeness claim")
+          (is (nil? (tool/explain-render))
+              "and the no-arg arity likewise, so a sweep gets no false
+               all-clear either")))
       (cell/disconnect! c))))

--- a/implementation/freehand/test/re_frame/freehand/manifest_source_coord_jvm_test.clj
+++ b/implementation/freehand/test/re_frame/freehand/manifest_source_coord_jvm_test.clj
@@ -40,9 +40,36 @@
   `:source-coord` at all — is `FH-STRUCT-010`, asserted on both hosts in
   `re-frame.freehand.manifest-census-cljs-test`; the declaration nothing
   anchored, whose entries omit the field, is
-  `re-frame.freehand.manifest-total-or-absent-coord-jvm-test`."
+  `re-frame.freehand.manifest-total-or-absent-coord-jvm-test`.
+
+  ## Posture split (rf2-74a89)
+
+  The MANIFEST's coordinates are a compile-time analyzer fact and survive
+  `-Dre-frame.debug=false` intact — every expectation below about a
+  `:source-coord` therefore holds in both postures, and the always-on arm
+  `every-roster-coordinate-is-total-in-either-posture` states that
+  directly, because it is the property production most needs and the one
+  an over-eager elision would take.
+
+  What the gate DOES elide is the DESCRIPTOR's own `:source`: `defview`
+  emits `(if interop/debug-enabled? coords-form prod-coords-form)`
+  (`freehand.cljc` ~354 / ~2221) and the slim prod form omits `:column`
+  entirely, matching core's `reg-*` elision (`source-coords.cljc`
+  §Production elision). So `[[declaration]]` — read through `v/describe` —
+  is `{:line n}` under the gate and `{:line n :column 1}` in dev.
+
+  That is a fact about REGISTRATION METADATA, not about the manifest, so
+  the inheritance claim keeps its full strength in both postures by
+  naming the declaration's column as [[declaration-column]], the same
+  discipline [[event-column]] already uses. The verbatim descriptor
+  equality — the proof that the stated column really is what `describe`
+  reads — is kept inside a `(when interop/debug-enabled? …)` arm, and a
+  `(when-not interop/debug-enabled? …)` arm witnesses the elision itself
+  through the real gate rather than through a `with-redefs` rebind, which
+  cannot reach a load-time gate (rf2-9c2jf)."
   (:require [clojure.test :refer [deftest is testing]]
-            [re-frame.freehand :as v]))
+            [re-frame.freehand :as v]
+            [re-frame.interop :as interop]))
 
 (v/defview coord-child
   "The crossing's target. Nothing about it is under test; it exists so the
@@ -70,7 +97,13 @@
   Not its `:file`: the descriptor resolves the declaring file to an
   absolute path for an editor to open, while a manifest site names the
   classpath-relative path the compiler read — two true answers to two
-  different questions, so [[source-file]] is stated rather than borrowed."
+  different questions, so [[source-file]] is stated rather than borrowed.
+
+  Under `-Dre-frame.debug=false` this map is `{:line n}`: the descriptor's
+  `:source` is registration metadata and its `:column` is prod-elided (see
+  the ns docstring's \"Posture split\"). [[declaration-column]] states the
+  column instead, so the inheritance claim below keeps its full strength in
+  either posture."
   (select-keys (:source (v/describe coord-probe)) [:line :column]))
 
 (def ^:private source-file
@@ -84,6 +117,12 @@
 ;; inherits, so its offset is zero by contract rather than by counting.
 (def ^:private event-line-offset 5)
 (def ^:private event-column 27)
+
+;; And the declaration's own column, stated in the same way — `(v/defview
+;; coord-probe …)` is a top-level form, so it opens at column 1. Stated
+;; rather than read from [[declaration]] because the descriptor's `:column`
+;; is prod-elided; the dev arm below proves the two agree.
+(def ^:private declaration-column 1)
 
 (deftest a-list-anchored-site-reports-its-own-position
   (testing "the (v/event …) handler is a list, so the reader anchored it and
@@ -106,12 +145,23 @@
             precise false one"
     (let [[entry :as roster] (:crossings manifest)]
       (is (= 1 (count roster)) "one crossing, so the row below is unambiguous")
-      (is (= (assoc declaration :file source-file)
+      (is (= {:file   source-file
+              :line   (:line declaration)
+              :column declaration-column}
              (:source-coord entry))
           "exactly the declaration's coordinates — inherited, not fabricated")
       (is (= :re-frame.freehand.manifest-source-coord-jvm-test/coord-child
              (:view-id entry))
-          "and the crossing's existing facts are untouched by the addition"))))
+          "and the crossing's existing facts are untouched by the addition")
+      ;; rf2-74a89 — dev-instrumentation arm (see ns docstring). The
+      ;; descriptor's `:source` carries `:column` only in dev, and this is
+      ;; where the stated `declaration-column` above is proved to be the
+      ;; column `describe` itself reads rather than a number that merely
+      ;; happens to match.
+      (when interop/debug-enabled?
+        (is (= (assoc declaration :file source-file)
+               (:source-coord entry))
+            "exactly the declaration's coordinates — inherited, not fabricated")))))
 
 (deftest the-two-site-kinds-are-distinguishable
   (testing "the point of per-site coordinates: two sites in ONE declaration
@@ -123,3 +173,46 @@
       (is (not= event-coord crossing-coord))
       (is (< (:line crossing-coord) (:line event-coord))
           "and the anchored site really is further into the declaration"))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-74a89 — the manifest survives the production gate; the descriptor's
+;; registration coord does not
+;; ---------------------------------------------------------------------------
+
+(deftest every-roster-coordinate-is-total-in-either-posture
+  (testing "The manifest is built at macro expansion and its coordinates are a
+            COMPILE-TIME fact, so nothing about them is a dev affordance: under
+            `-Dre-frame.debug=false` every roster entry still carries a whole
+            `{:file :line :column}`. Stated here as its own row because it is
+            the property a production consumer depends on and the one an
+            over-eager elision would silently take — leaving a manifest that
+            still had entries and could no longer say where any of them is."
+    (let [entries (concat (:events manifest) (:crossings manifest))]
+      (is (= 2 (count entries))
+          "both site kinds are present, so the row below is about both")
+      (doseq [entry entries]
+        (let [coord (:source-coord entry)]
+          (is (= #{:file :line :column} (set (keys coord)))
+              "a coordinate is TOTAL — never partial, in either posture")
+          (is (= source-file (:file coord)))
+          (is (pos-int? (:line coord)))
+          (is (pos-int? (:column coord))))))))
+
+(deftest the-descriptors-registration-coord-is-elided-under-the-real-gate
+  (testing "The counterpart fact, witnessed through the REAL load-time gate
+            rather than a `with-redefs` rebind, which cannot reach one
+            (rf2-9c2jf). `v/describe`'s `:source` is registration metadata:
+            `defview` emits the slim `prod-coords-form` under the gate, which
+            omits `:column`. The elision is asymmetric ON PURPOSE — the coord a
+            TOOL opens an editor at is dev-only, the coord a MANIFEST reports
+            is not — and asserting each half against the other is what keeps
+            the asymmetry a decision rather than a drift."
+    (let [described (:source (v/describe coord-probe))]
+      (is (= (:line (:source-coord (first (:crossings manifest))))
+             (:line described))
+          "both halves agree about the LINE in either posture")
+      (if interop/debug-enabled?
+        (is (= declaration-column (:column described))
+            "dev keeps the column, and it is the one the manifest inherited")
+        (is (not (contains? described :column))
+            "and production drops it — the whole key, not a nil under it")))))

--- a/implementation/freehand/test/re_frame/freehand/occurrence_index_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/occurrence_index_cljs_test.cljc
@@ -27,7 +27,39 @@
   occurrence ever observed. Those are not facts this slice happens not to have
   got to: rf2-drpa3.167 ruled the cumulative per-occurrence accumulator out
   permanently. The rows' own `occurrence-facts` roster is asserted as an
-  EQUALITY below so a member cannot be added without a test saying so."
+  EQUALITY below so a member cannot be added without a test saying so.
+
+  ## Posture split (rf2-74a89)
+
+  The index is DEV-ONLY, and `occurrences.cljc`'s own docstring says so:
+  every call site that writes to it is inside `interop/debug-enabled?`, and
+  the read over it (`tool/read-mounted-views`) is gated too. Under the real
+  `-Dre-frame.debug=false` gate the structure is therefore empty for every
+  input and the read answers nil.
+
+  Which makes this namespace the textbook case for the vacuous pass, and
+  most of it is on the NEGATIVE side. `(= [] (rows-for …))` after a
+  disconnect, after an abandoned render, and before a reconnect are each
+  satisfied by an index that never held anything — as is `(nil? (:loss r))`
+  over a nil projection. Those travel into the
+  `(when interop/debug-enabled? …)` arms WITH the positive rows they are the
+  control for, kept verbatim, rather than being left outside to report a
+  green that proved nothing.
+
+  What holds in both postures, and is what this namespace contributes to
+  `scripts/test-freehand-prod-gate.sh`, is the CELL LIFECYCLE the index
+  mirrors. Every deftest still drives real renders and real commits, and
+  `:published` / `:abandoned`, `:connected` / `:disconnected`, and the
+  reconnect that follows a `disconnect!` are asserted outside the arm. The
+  index is a projection of those facts; they are the facts.
+
+  Beside them, `the-index-costs-a-production-build-nothing` states the
+  elision as a positive production property rather than an absence, through
+  the real load-time gate rather than a `with-redefs` rebind that cannot
+  reach one (rf2-9c2jf): live occurrences accumulate NO rows under the gate.
+  That is not a tidiness point — an index that kept a row per mounted
+  boundary in a production build would be unbounded growth in the one build
+  where nothing ever reads it."
   (:require #?(:clj  [clojure.test :refer [deftest is testing use-fixtures]]
                :cljs [cljs.test :refer-macros [deftest is testing use-fixtures]])
             [re-frame.core :as rf]
@@ -37,6 +69,7 @@
             [re-frame.freehand.occurrences :as occurrences]
             [re-frame.freehand.test :as t]
             [re-frame.freehand.tool :as tool]
+            [re-frame.interop :as interop]
             [re-frame.substrate.plain-atom :as plain-atom]
             [re-frame.test-support :as test-support]))
 
@@ -89,18 +122,28 @@
     (let [a    (connect! ::twice)
           b    (connect! ::twice)
           rows (rows-for ::twice)]
-      (is (= 2 (count rows)) "two occurrences, two rows")
-      (is (= 2 (count (set (map :occurrence rows))))
-          "and their occurrence keys are distinct — the rows are addressable
-           separately, which is what makes them distinguishable rather than
-           merely countable")
-      (is (= #{::twice} (set (map :view-id rows)))
-          "both naming the one view they are occurrences of")
+      ;; rf2-74a89 — dev-instrumentation arm (see ns docstring). Both cells
+      ;; published (`connect!` asserts that outside this arm, in either
+      ;; posture); the ROWS are what the gate elides.
+      (when interop/debug-enabled?
+        (is (= 2 (count rows)) "two occurrences, two rows")
+        (is (= 2 (count (set (map :occurrence rows))))
+            "and their occurrence keys are distinct — the rows are addressable
+             separately, which is what makes them distinguishable rather than
+             merely countable")
+        (is (= #{::twice} (set (map :view-id rows)))
+            "both naming the one view they are occurrences of"))
       ;; Non-vacuity for the row above: disconnecting ONE leaves the OTHER,
       ;; which an index that had merged them could not do.
       (cell/disconnect! a)
-      (is (= 1 (count (rows-for ::twice)))
-          "disconnecting one occurrence leaves the other connected")
+      (is (= :disconnected (cell/lifecycle a))
+          "the disconnected cell says so — the fact the index mirrors, in
+           either posture")
+      (is (= :connected (cell/lifecycle b))
+          "and the other is untouched by its sibling's teardown")
+      (when interop/debug-enabled?
+        (is (= 1 (count (rows-for ::twice)))
+            "disconnecting one occurrence leaves the other connected"))
       (cell/disconnect! b))))
 
 (deftest a-second-commit-replaces-a-row-rather-than-adding-one
@@ -112,20 +155,29 @@
     (register!)
     (seed! {:count 0})
     (let [c      (connect! ::replaced)
-          first- (first (rows-for ::replaced))]
+          first- (first (rows-for ::replaced))
+          gen-0  (cell/generation c)]
       ;; A COMPATIBLE reload: the view's body revision advances, every live
       ;; occurrence lands on the same number, and each re-renders and commits.
       (cell/advance-generation! c (inc (cell/generation c)))
       (let [cand (cell/candidate c fid)]
         (cell/with-capture cand (fn [] (t/render [counter {}])))
         (is (= :published (cell/commit! cand :interpreted))))
-      (let [rows (rows-for ::replaced)]
-        (is (= 1 (count rows)) "one occurrence is still one row after two commits")
-        (is (= (:occurrence first-) (:occurrence (first rows)))
-            "the same occurrence — a compatible reload does not remount it")
-        (is (< (:generation first-) (:generation (first rows)))
-            "and the row states the LATEST committed generation — a fact about
-             now, never a tally of how many there have been"))
+      (is (< gen-0 (cell/generation c))
+          "the cell's own generation advanced — the reload the rows below are
+           about really happened, in either posture")
+      (is (= :connected (cell/lifecycle c))
+          "and the SAME cell is still connected: a compatible reload
+           re-renders an occurrence, it does not remount one")
+      ;; rf2-74a89 — dev-instrumentation arm (see ns docstring).
+      (when interop/debug-enabled?
+        (let [rows (rows-for ::replaced)]
+          (is (= 1 (count rows)) "one occurrence is still one row after two commits")
+          (is (= (:occurrence first-) (:occurrence (first rows)))
+              "the same occurrence — a compatible reload does not remount it")
+          (is (< (:generation first-) (:generation (first rows)))
+              "and the row states the LATEST committed generation — a fact about
+               now, never a tally of how many there have been")))
       (cell/disconnect! c))))
 
 ;; ---------------------------------------------------------------------------
@@ -146,14 +198,22 @@
           b (connect! ::late-b :compiled)
           seen (:occurrences (tool/read-mounted-views))
           by-id (into {} (map (juxt :view-id identity)) seen)]
-      (is (contains? by-id ::late-a) "the first occurrence is current")
-      (is (contains? by-id ::late-b) "and so is the second")
-      (is (= :compiled (:lowering (get by-id ::late-b)))
-          "each row NAMES its lowering rather than leaving a reader to infer it
-           from how much its evidence claims")
-      (is (= fid (:frame (:commit (get by-id ::late-a))))
-          "and the frame the commit bound to, so a reader in one frame's context
-           can tell whose occurrence this is")
+      (is (= :connected (cell/lifecycle a))
+          "both cells published and are connected, in either posture")
+      (is (= :connected (cell/lifecycle b)))
+      ;; rf2-74a89 — dev-instrumentation arm (see ns docstring). The whole
+      ;; late-reader requirement is a claim about the INDEX, which the gate
+      ;; elides; under it `read-mounted-views` answers nil and `seen` is empty
+      ;; for every input.
+      (when interop/debug-enabled?
+        (is (contains? by-id ::late-a) "the first occurrence is current")
+        (is (contains? by-id ::late-b) "and so is the second")
+        (is (= :compiled (:lowering (get by-id ::late-b)))
+            "each row NAMES its lowering rather than leaving a reader to infer it
+             from how much its evidence claims")
+        (is (= fid (:frame (:commit (get by-id ::late-a))))
+            "and the frame the commit bound to, so a reader in one frame's context
+             can tell whose occurrence this is"))
       (cell/disconnect! a)
       (cell/disconnect! b))))
 
@@ -174,17 +234,20 @@
     (let [c   (connect! ::facts)
           r   (tool/read-mounted-views)
           row (first (rows-for ::facts))]
-      (is (= #{:view-id :occurrence :lowering :generation :connection :root
-               :dispatch-id :at :commit}
-             (:occurrence-facts r))
-          "the roster is closed and named")
-      (is (= (:occurrence-facts r) (set (keys row)))
-          "and a row states exactly those facts — no more, no fewer")
-      (is (= :unknown (:root row))
-          "root identity is reported UNKNOWN explicitly; an absent key would
-           read as `none`, which is the one shape this schema exists to refuse")
-      (is (= :connected (:connection row)))
-      (is (number? (:at row)) "the commit's clock reading is a single number")
+      ;; rf2-74a89 — dev-instrumentation arm (see ns docstring). A roster
+      ;; EQUALITY is meaningless over a read that answered nil.
+      (when interop/debug-enabled?
+        (is (= #{:view-id :occurrence :lowering :generation :connection :root
+                 :dispatch-id :at :commit}
+               (:occurrence-facts r))
+            "the roster is closed and named")
+        (is (= (:occurrence-facts r) (set (keys row)))
+            "and a row states exactly those facts — no more, no fewer")
+        (is (= :unknown (:root row))
+            "root identity is reported UNKNOWN explicitly; an absent key would
+             read as `none`, which is the one shape this schema exists to refuse")
+        (is (= :connected (:connection row)))
+        (is (number? (:at row)) "the commit's clock reading is a single number"))
       (cell/disconnect! c))))
 
 (deftest the-read-projects-its-own-honesty
@@ -197,14 +260,19 @@
     (seed! {:count 0})
     (let [c (connect! ::projected)
           r (tool/read-mounted-views)]
-      (is (= :re-frame.freehand.evidence/v1 (:schema r))
-          "stamped with the version a consumer validates FIRST")
-      (is (= :mounted-views (:read r)) "and with WHICH read answered")
-      (is (= :connected-occurrences (:scope r)))
-      (is (= :observation (:basis r))
-          "written from what renders DID, never from what a grammar could prove")
-      (is (true? (:complete? r)))
-      (is (nil? (:loss r)))
+      ;; rf2-74a89 — dev-instrumentation arm (see ns docstring). `(nil? (:loss
+      ;; r))` travels INSIDE it with the rest: over a read that answered nil it
+      ;; is satisfied by every input, which is the vacuous negative this lane
+      ;; exists to close.
+      (when interop/debug-enabled?
+        (is (= :re-frame.freehand.evidence/v1 (:schema r))
+            "stamped with the version a consumer validates FIRST")
+        (is (= :mounted-views (:read r)) "and with WHICH read answered")
+        (is (= :connected-occurrences (:scope r)))
+        (is (= :observation (:basis r))
+            "written from what renders DID, never from what a grammar could prove")
+        (is (true? (:complete? r)))
+        (is (nil? (:loss r))))
       (cell/disconnect! c))))
 
 ;; ---------------------------------------------------------------------------
@@ -220,12 +288,21 @@
     (register!)
     (seed! {:count 9})
     (let [c (connect! ::released)]
-      (is (= 1 (count (rows-for ::released))) "connected, and rowed")
-      (is (some? (occurrences/row (:occurrence (first (rows-for ::released)))))
-          "the row is reachable by its occurrence key")
+      ;; rf2-74a89 — dev-instrumentation arm (see ns docstring). BOTH halves
+      ;; are inside it, including the `(= [] …)` negative: over an index that
+      ;; never held a row, "it is gone after teardown" is satisfied by an index
+      ;; that was never populated, and outside the arm it would report a green
+      ;; that proved nothing.
+      (when interop/debug-enabled?
+        (is (= 1 (count (rows-for ::released))) "connected, and rowed")
+        (is (some? (occurrences/row (:occurrence (first (rows-for ::released)))))
+            "the row is reachable by its occurrence key"))
+      (is (= :connected (cell/lifecycle c))
+          "connected before the teardown, in either posture")
       (cell/disconnect! c)
-      (is (= [] (rows-for ::released))
-          "and after the host's teardown it is gone — absent, not marked")
+      (when interop/debug-enabled?
+        (is (= [] (rows-for ::released))
+            "and after the host's teardown it is gone — absent, not marked"))
       (is (= :disconnected (cell/lifecycle c))
           "the cell agrees, which is the fact the index is mirroring"))))
 
@@ -239,12 +316,21 @@
     (seed! {:count 3})
     (let [c (connect! ::reconnects)]
       (cell/disconnect! c)
-      (is (= [] (rows-for ::reconnects)))
+      (is (= :disconnected (cell/lifecycle c))
+          "disconnected, and `disconnect!` is deliberately not terminal")
+      ;; rf2-74a89 — dev-instrumentation arm (see ns docstring). Vacuous under
+      ;; the gate: an index that never rowed anything is empty here too.
+      (when interop/debug-enabled?
+        (is (= [] (rows-for ::reconnects))))
       (let [cand (cell/candidate c fid)]
         (cell/with-capture cand (fn [] (t/render [counter {}])))
         (is (= :published (cell/commit! cand :interpreted))))
-      (is (= 1 (count (rows-for ::reconnects)))
-          "reconnected, and rowed exactly once")
+      (is (= :connected (cell/lifecycle c))
+          "the SAME cell reconnected — one occurrence, not a second beside a
+           stale first")
+      (when interop/debug-enabled?
+        (is (= 1 (count (rows-for ::reconnects)))
+            "reconnected, and rowed exactly once"))
       (cell/disconnect! c))))
 
 (deftest an-abandoned-render-leaves-no-row
@@ -261,7 +347,54 @@
       ;; the render-to-commit gap — so the commit below is no longer current.
       (cell/advance-generation! c (inc (cell/generation c)))
       (is (= :abandoned (cell/commit! cand :interpreted)))
-      (is (= [] (rows-for ::abandoned))
-          "nothing published, so nothing is current")
+      ;; rf2-74a89 — dev-instrumentation arm (see ns docstring). Vacuous under
+      ;; the gate for the usual reason, and it travels with the deftest whose
+      ;; discrimination it IS: `the-index-costs-a-production-build-nothing`
+      ;; below is what says an empty index in production means something.
+      (when interop/debug-enabled?
+        (is (= [] (rows-for ::abandoned))
+            "nothing published, so nothing is current"))
       (is (not= :connected (cell/lifecycle c))
           "and the cell says the same"))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-74a89 — what the index costs a production build
+;; ---------------------------------------------------------------------------
+
+(deftest the-index-costs-a-production-build-nothing
+  (testing "The elision, stated as a positive production property rather than
+            an absence, and witnessed through the REAL load-time gate rather
+            than a `with-redefs` rebind that cannot reach one (rf2-9c2jf).
+
+            Two occurrences connect here and stay connected across the read, so
+            an index that recorded anything at all in production would have two
+            rows to show. Under `-Dre-frame.debug=false` it has none, and
+            `read-mounted-views` answers nil rather than an empty envelope — a
+            consumer distinguishes THAT from an unmounted view the way it
+            distinguishes any absence, by asking about a view it knows is
+            declared (`tool.cljc` §DEV-ONLY).
+
+            This is the row that makes the `(= [] (rows-for …))` negatives
+            above worth their dev arm: it is the only place the empty answer is
+            a claim rather than the default."
+    (register!)
+    (seed! {:count 1})
+    (let [a (connect! ::cost-a)
+          b (connect! ::cost-b :compiled)]
+      (is (= :connected (cell/lifecycle a)) "two live occurrences, in either posture")
+      (is (= :connected (cell/lifecycle b)))
+      (if interop/debug-enabled?
+        (do
+          (is (= 2 (count (concat (rows-for ::cost-a) (rows-for ::cost-b))))
+              "dev: two connected occurrences, two rows")
+          (is (some? (tool/read-mounted-views))
+              "and the read answers"))
+        (do
+          (is (empty? (occurrences/rows))
+              "production: two connected occurrences and the index holds NOTHING
+               — a row per mounted boundary would be unbounded growth in the one
+               build where nothing ever reads it")
+          (is (nil? (tool/read-mounted-views))
+              "and the read over it is inert, not merely empty")))
+      (cell/disconnect! a)
+      (cell/disconnect! b))))

--- a/implementation/freehand/test/re_frame/freehand/props_schema_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/props_schema_cljs_test.cljc
@@ -38,7 +38,46 @@
 
   Host-neutral throughout: the boundary is shared machinery and the analyzer
   is pure with resolution injected, so every row runs under
-  `clojure -M:test` and `npm run test:freehand` alike."
+  `clojure -M:test` and `npm run test:freehand` alike.
+
+  ## Posture split (rf2-74a89)
+
+  Read this one before reporting an acceptance regression, because the
+  honest answer is not the convenient one: **the closing schema is DEV-ONLY
+  BY EXPLICIT DESIGN.** `descriptor.cljc` gates the whole closing-schema arm
+  on `interop/debug-enabled?` and says why — \"a schema is a compile-time
+  and tooling fact: production renders the same tree either way, and the
+  CLJS branch folds away\". So under the real `-Dre-frame.debug=false` gate
+  the BOUNDARY accepts an undeclared prop. That is the same class as Spec
+  010's `validate-fx!`, and it is NOT the rf2-9c2jf class: the tier that
+  actually holds the line for a compiled build — the ANALYZER, at build
+  time — refuses the identical row in either posture.
+
+  Which makes the split unusually sharp, and the vacuous-pass trap unusually
+  easy to walk into. Under the gate every boundary row answers `:accept`, so
+  every deftest asserting a boundary `:accept` — the schema-less arm, the
+  open escape, the opaque schema, the two-modes-agree row — passes for the
+  wrong reason: nothing ran, so nothing objected. Those travel into the
+  `(when interop/debug-enabled? …)` arm WITH the reject rows, kept verbatim,
+  rather than being left outside it to report a green that proved nothing.
+
+  What this namespace contributes to `scripts/test-freehand-prod-gate.sh` is
+  therefore everything that is not the boundary's schema check, and it is
+  most of the file: the whole ANALYZER surface (three deftests, every row of
+  the matrix, in both postures); the declaration-time refusal of a reserved
+  slot, which is macro machinery and runs at expansion; the reserved-slot
+  and opacity projections, which are pure functions over the authored form;
+  and `describe`'s `:props-schema`, which is carried in production — so
+  `absence-is-reported-as-absence-never-as-any` is a real absence rather
+  than a key the gate elided wholesale.
+
+  Beside them, `which-tier-refuses-an-undeclared-prop-depends-on-the-posture`
+  states the arrangement above directly, through the real load-time gate
+  rather than a `with-redefs` rebind that cannot reach one (rf2-9c2jf): the
+  analyzer refuses every reject row in either posture, the boundary refuses
+  exactly when the gate is open, and a non-map props slot is refused in BOTH
+  — the call ABI is always on, which is what makes the boundary's `:accept`
+  a verdict rather than an absent check."
   (:require [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]
             [re-frame.freehand :as v]
@@ -46,7 +85,8 @@
             [re-frame.freehand.compiler.env :as env]
             [re-frame.freehand.conformance :as conf]
             [re-frame.freehand.descriptor :as descriptor]
-            [re-frame.freehand.props-schema :as props-schema]))
+            [re-frame.freehand.props-schema :as props-schema]
+            [re-frame.interop :as interop]))
 
 (def props-004 (conf/fixture :FH-PROPS-004))
 
@@ -155,16 +195,23 @@
       (is (<= 2 (count (filter #(= :reject (:verdict %)) (:calls props-004))))
           "and more than one way to be rejected"))))
 
+;; rf2-74a89 — the three deftests below are the BOUNDARY's schema check, which
+;; the production gate elides wholesale (see the ns docstring's "Posture
+;; split"). Their reject rows go red under the gate and their accept rows pass
+;; vacuously, so both halves are kept verbatim inside the dev arm rather than
+;; one half being left outside it to report a green that proved nothing.
+
 (deftest the-boundary-returns-the-declared-verdict-in-both-modes
   (testing "Per FH-PROPS-004: the same schema, the same props, the same
             answer — whichever mode the declaration selected. `normalize-call`
             is the normalizer both emitters share, so this is the delivered-
             props arm for the compiled tier as much as the interpreted one."
-    (doseq [{:keys [props verdict why]} (:calls props-004)
-            [mode view] by-mode]
-      (is (= verdict (boundary-verdict view props))
-          (str mode " — " (pr-str props) " is " (name verdict)
-               (when why (str ": " why)))))))
+    (when interop/debug-enabled?
+      (doseq [{:keys [props verdict why]} (:calls props-004)
+              [mode view] by-mode]
+        (is (= verdict (boundary-verdict view props))
+            (str mode " — " (pr-str props) " is " (name verdict)
+                 (when why (str ": " why))))))))
 
 (deftest the-two-modes-never-disagree
   (testing "Stated as its own row rather than inferred from the two above: a
@@ -172,22 +219,25 @@
             two red assertions and no statement of what they mean. THIS is the
             promotion claim — `{:compiled true}` changes the lowering, never
             the contract."
-    (doseq [{:keys [props]} (:calls props-004)]
-      (is (= (boundary-verdict interpreted-row props)
-             (boundary-verdict compiled-row props))
-          (str "interpreted and compiled agree about " (pr-str props))))))
+    (when interop/debug-enabled?
+      (doseq [{:keys [props]} (:calls props-004)]
+        (is (= (boundary-verdict interpreted-row props)
+               (boundary-verdict compiled-row props))
+            (str "interpreted and compiled agree about " (pr-str props)))))))
 
 (deftest a-rejection-names-the-undeclared-props-and-the-declared-roster
   (testing "A rejection that only said `no` would send an author looking. The
             message names every offending key — not just the first — and the
             roster the schema declared, so the fix is visible without opening
             the declaration."
-    (let [msg (conf/caught-message
-               #(descriptor/normalize-call compiled-row [{:extra 1 :other 2}]))]
-      (is (some? msg) "the breach raises")
-      (doseq [k [":extra" ":other" ":id" ":label"]]
-        (is (re-find (re-pattern k) msg)
-            (str "the message names " k))))))
+    (when interop/debug-enabled?
+      (let [msg (conf/caught-message
+                 #(descriptor/normalize-call compiled-row [{:extra 1 :other 2}]))]
+        (is (some? msg) "the breach raises")
+        (doseq [k [":extra" ":other" ":id" ":label"]]
+          (is (re-find (re-pattern k) msg)
+              (str "the message names " k)))))))
+
 
 ;; ---------------------------------------------------------------------------
 ;; Surface 3 — the analyzer, at build time
@@ -254,6 +304,43 @@
           (str "no schema, no closure: " (pr-str props))))))
 
 ;; ---------------------------------------------------------------------------
+;; rf2-74a89 — WHICH tier holds the closure, in each posture
+;; ---------------------------------------------------------------------------
+
+(deftest which-tier-refuses-an-undeclared-prop-depends-on-the-posture
+  (testing "The arrangement the ns docstring describes, asserted through the
+            REAL load-time gate rather than a `with-redefs` rebind that cannot
+            reach one (rf2-9c2jf). Three claims over the SAME reject rows:
+
+            the ANALYZER refuses each of them in either posture — that is the
+            tier a compiled build's guarantee actually rests on, and it is
+            unconditional; the BOUNDARY refuses them exactly when the gate is
+            open, which is the dev-only closing-schema arm stated as a fact
+            rather than left as an unexplained red; and a NON-MAP props slot is
+            refused in both postures, because the call ABI is always on. That
+            last row is what makes the boundary's production `:accept` a
+            verdict rather than an absent check — without it, `normalize-call`
+            doing nothing at all would look identical."
+    (let [rejects (filterv #(= :reject (:verdict %)) (:calls props-004))]
+      (is (<= 2 (count rejects))
+          "more than one reject row, so the rows below are about a decision
+           rather than a case")
+      (doseq [{:keys [props why]} rejects]
+        (is (= :reject (analyzer-verdict 'schema-child props))
+            (str "analyzer, in either posture — " (pr-str props)
+                 (when why (str ": " why))))
+        (is (= (if interop/debug-enabled? :reject :accept)
+               (boundary-verdict compiled-row props))
+            (str "boundary — " (pr-str props)
+                 (if interop/debug-enabled?
+                   ": refused, the closing-schema arm is live"
+                   ": ACCEPTED, the closing-schema arm is elided by design"))))
+      (is (= :reject (boundary-verdict compiled-row nil))
+          "and the call ABI is always on: a non-map props slot is refused in
+           either posture, so an `:accept` above is a verdict the boundary
+           reached and not a check that never ran"))))
+
+;; ---------------------------------------------------------------------------
 ;; The escape, and the reserved slots
 ;; ---------------------------------------------------------------------------
 
@@ -264,8 +351,13 @@
             declaration option. Proven at both surfaces, because an escape
             honoured at render and ignored at build would be worse than none."
     (doseq [{:keys [props verdict]} (:open-calls props-004)]
-      (is (= verdict (boundary-verdict open-row props))
-          (str "boundary, open schema — " (pr-str props)))
+      ;; rf2-74a89 — dev-instrumentation arm (see ns docstring). Every
+      ;; `:open-calls` verdict is `:accept`, and under the gate the boundary
+      ;; accepts everything, so this row would pass without an escape existing
+      ;; at all. The ANALYZER row beside it holds in both postures.
+      (when interop/debug-enabled?
+        (is (= verdict (boundary-verdict open-row props))
+            (str "boundary, open schema — " (pr-str props))))
       (is (= verdict (analyzer-verdict 'open-child props))
           (str "analyzer, open schema — " (pr-str props))))))
 
@@ -290,10 +382,17 @@
             declaration is an ordinary view in both modes — it accepts every
             props map the matrix carries, including the ones the schema'd view
             refuses, because it made no statement about them."
-    (doseq [view [schema-less-row compiled-schema-less-row]
-            {:keys [props]} (:calls props-004)]
-      (is (= :accept (boundary-verdict view props))
-          (str (:view-id (v/describe view)) " accepts " (pr-str props))))))
+    ;; rf2-74a89 — dev-instrumentation arm (see ns docstring). Under the gate
+    ;; EVERY declaration accepts every props map, so "the schema-less one
+    ;; accepts them" would say nothing about being schema-less. The always-on
+    ;; half of the optional arm is the analyzer's
+    ;; (`an-unschemad-child-closes-nothing-at-a-compiled-call-site`) and the
+    ;; projection's (`absence-is-reported-as-absence-never-as-any`).
+    (when interop/debug-enabled?
+      (doseq [view [schema-less-row compiled-schema-less-row]
+              {:keys [props]} (:calls props-004)]
+        (is (= :accept (boundary-verdict view props))
+            (str (:view-id (v/describe view)) " accepts " (pr-str props)))))))
 
 (deftest absence-is-reported-as-absence-never-as-any
   (testing "Per FH-PROPS-004: an undeclared contract and a deliberately
@@ -335,10 +434,17 @@
             surface that reads the schema as a VALUE as well as the one that
             reads it as a form: an opacity honoured at build time and forgotten
             at render would be two contracts wearing one name."
-    (doseq [{:keys [props]} (:calls props-004)
-            [mode view]     (assoc opaque-by-mode :reference registry-row)]
-      (is (= :accept (boundary-verdict view props))
-          (str mode " — an opaque schema admits " (pr-str props))))
+    ;; rf2-74a89 — dev-instrumentation arm (see ns docstring). Same vacuity as
+    ;; the schema-less arm: under the gate nothing closes, so "the opaque one
+    ;; closes nothing" is satisfied by a boundary that never looked. The cause
+    ;; these rows are the symptom of —
+    ;; `an-opaque-schema-derives-no-closing-roster-from-what-tooling-reads` —
+    ;; is pure over the authored form and holds in both postures.
+    (when interop/debug-enabled?
+      (doseq [{:keys [props]} (:calls props-004)
+              [mode view]     (assoc opaque-by-mode :reference registry-row)]
+        (is (= :accept (boundary-verdict view props))
+            (str mode " — an opaque schema admits " (pr-str props)))))
     (is (true? (:closes-nothing-at-every-surface? (:opaque props-004)))
         "the fixture states the same expectation the rows above assert")))
 

--- a/implementation/freehand/test/re_frame/freehand/tool_reads_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/tool_reads_cljs_test.cljc
@@ -35,11 +35,52 @@
   would leave the one host that matters to Pair unexercised, which is exactly
   the defect rf2-hytu5 fixed for the value-taking reader. The expansion-shape
   row is JVM-only, and says so: `expand-defview` is macro machinery and exists
-  on the JVM alone."
+  on the JVM alone.
+
+  ## Posture split (rf2-74a89)
+
+  Both halves of this slice are DEV-ONLY, and the docstring above already
+  says why the index is: `v/defview` emits its `registry/register!` call
+  behind `interop/debug-enabled?` precisely so Closure folds the call, its
+  descriptor argument and every path into the index out of a release bundle.
+  The three reads are gated at the door too (`tool.cljc` §DEV-ONLY). So under
+  `-Dre-frame.debug=false` the index is empty and every read answers nil.
+
+  What that does NOT elide is the manifest. `v/manifest` is the total,
+  value-taking read — the one read `tool.cljc` exempts from the gate — and it
+  is byte-identical in both postures, because the analyzer ran at macro
+  expansion and its rosters are compile-time facts. The three id-taking reads
+  are PROJECTIONS of it. That is the whole shape of the split here:
+
+    - every assertion reading `registry/*` or `tool/read-view-*` is kept
+      VERBATIM inside a `(when interop/debug-enabled? …)` arm marked
+      `rf2-74a89`, negatives included — `an-undeclared-id-answers-nil-from-
+      every-read` and `(nil? (registry/lookup :nobody/declared-this))` are
+      satisfied under the gate by reads that answer nil for EVERY id, which
+      is the vacuous absence this lane exists to close;
+    - `the-census-manifest-is-the-substrate-the-three-reads-project` asserts
+      the SAME census facts through `v/manifest`, in both postures: two
+      subscription sites, four event sites, the five per-site facts rf2-z0blg
+      made the manifest publish, and the interpreted declaration's absent
+      analysis. When a projection and its substrate disagree it is the
+      substrate that is right, and this is the row that says what it holds;
+    - `the-index-holds-one-row-per-declaration-not-a-history` needs no arm at
+      all. `registry/register!` is the index's own door and is ungated — only
+      the CALL SITE inside the expansion carries the gate — so the
+      replace-not-append law is driven through explicit registrations and
+      holds in both postures;
+    - `the-registration-is-gated-in-the-expansion` is unchanged and is the
+      decisive production fact: the gate is IN the emitted form, where
+      Closure can fold it, rather than one function call deeper;
+    - and `neither-the-index-nor-its-reads-survive-the-production-gate`
+      states the elision as a positive fact, through the real load-time gate
+      rather than a `with-redefs` rebind, which cannot reach one
+      (rf2-9c2jf)."
   (:require [clojure.test :refer [deftest is testing]]
             [re-frame.freehand :as v]
             [re-frame.freehand.registry :as registry]
-            [re-frame.freehand.tool :as tool]))
+            [re-frame.freehand.tool :as tool]
+            [re-frame.interop :as interop]))
 
 ;; ---------------------------------------------------------------------------
 ;; The census — one compiled declaration carrying every roster under test,
@@ -104,21 +145,37 @@
             dev-only index as it is declared, so an inspector that ATTACHES
             LATE — to an application that finished loading long before it
             arrived — can still resolve an id it was handed over a wire."
-    (is (= basket (registry/lookup basket-id))
-        "the compiled declaration resolves to the declaration value itself")
-    (is (= plain-list (registry/lookup plain-id))
-        "and so does the interpreted one — both lowerings are inspectable")
-    (is (nil? (registry/lookup :nobody/declared-this))
-        "an id nothing declared answers nil rather than throwing")
-    (is (contains? (registry/view-ids) basket-id)
-        "and the roster a sweep enumerates carries it")))
+    ;; rf2-74a89 — dev-instrumentation arm (see ns docstring). The whole
+    ;; deftest is about what `v/defview`'s own gated call site records, and
+    ;; the `nil` row travels inside it because under the gate EVERY id
+    ;; answers nil.
+    (when interop/debug-enabled?
+      (is (= basket (registry/lookup basket-id))
+          "the compiled declaration resolves to the declaration value itself")
+      (is (= plain-list (registry/lookup plain-id))
+          "and so does the interpreted one — both lowerings are inspectable")
+      (is (nil? (registry/lookup :nobody/declared-this))
+          "an id nothing declared answers nil rather than throwing")
+      (is (contains? (registry/view-ids) basket-id)
+          "and the roster a sweep enumerates carries it"))))
 
 (deftest the-index-holds-one-row-per-declaration-not-a-history
   (testing "Re-registration REPLACES. A reloaded declaration is the SAME view,
             and an index that appended would be the cumulative store
             rf2-drpa3.167 ruled out — under a different name. Asserted over the
-            roster's cardinality, which an appending index could not keep."
+            roster's cardinality, which an appending index could not keep.
+
+            No posture arm (rf2-74a89): `registry/register!` is the index's own
+            door and is ungated — the gate is on the CALL SITE inside
+            `v/defview`'s expansion, which is what
+            `the-registration-is-gated-in-the-expansion` checks. So the law is
+            driven through explicit registrations here and holds in both
+            postures; the seeding row below is what makes the count start from
+            a known state under the gate, where nothing declared above is in
+            the index."
+    (registry/register! basket-id basket)
     (let [before (count (registry/view-ids))]
+      (is (pos? before) "the seeded row is there to be replaced")
       (registry/register! basket-id basket)
       (registry/register! basket-id basket)
       (is (= before (count (registry/view-ids)))
@@ -134,53 +191,73 @@
   (testing "The manifest rides VERBATIM under `:manifest` — the declaration's
             own data, not a second projection of it — inside the envelope a
             consumer validates before parsing anything."
-    (let [r (tool/read-view-manifest basket-id)]
-      (is (some? r) "a declared compiled view answers")
-      (is (= :re-frame.freehand.evidence/v1 (:schema r))
-          "stamped with the schema version a consumer checks FIRST")
-      (is (= :view-manifest (:read r))
-          "and with WHICH read answered, so two reads' answers cannot be confused")
-      (is (= basket-id (:view-id r)))
-      (is (= :compiled (:lowering r))
-          "the lowering is NAMED, never inferred from how much the evidence claims")
-      (is (= (v/manifest basket) (:manifest r))
-          "one value published twice — the tool read and the application read
-           cannot drift, because there is only one projection"))))
+    ;; rf2-74a89 — dev-instrumentation arm (see ns docstring). The MANIFEST
+    ;; inside the envelope is posture-independent and is asserted directly by
+    ;; `the-census-manifest-is-the-substrate-the-three-reads-project`; the
+    ;; envelope around it is the gated read's.
+    (when interop/debug-enabled?
+      (let [r (tool/read-view-manifest basket-id)]
+        (is (some? r) "a declared compiled view answers")
+        (is (= :re-frame.freehand.evidence/v1 (:schema r))
+            "stamped with the schema version a consumer checks FIRST")
+        (is (= :view-manifest (:read r))
+            "and with WHICH read answered, so two reads' answers cannot be confused")
+        (is (= basket-id (:view-id r)))
+        (is (= :compiled (:lowering r))
+            "the lowering is NAMED, never inferred from how much the evidence claims")
+        (is (= (v/manifest basket) (:manifest r))
+            "one value published twice — the tool read and the application read
+             cannot drift, because there is only one projection")))))
 
 (deftest a-compiled-declaration-claims-static-proof-and-no-loss
   (testing "The analyzer walked the whole body and the grammar is finite, so the
             roster is every site there CAN be: complete for `:possible-sites`,
             and lossless."
-    (let [r (tool/read-view-manifest basket-id)]
-      (is (= :possible-sites (:scope r)))
-      (is (= :static-proof (:basis r)))
-      (is (true? (:complete? r)))
-      (is (nil? (:loss r))))))
+    ;; rf2-74a89 — dev-instrumentation arm (see ns docstring).
+    (when interop/debug-enabled?
+      (let [r (tool/read-view-manifest basket-id)]
+        (is (= :possible-sites (:scope r)))
+        (is (= :static-proof (:basis r)))
+        (is (true? (:complete? r)))
+        (is (nil? (:loss r)))))))
 
 (deftest an-interpreted-declaration-reports-the-absence-of-analysis
   (testing "The arm the projection vocabulary exists for. An interpreted body
             has no analysis step, so what it could reach is not merely uncounted
             — it is unknowable without running it. `:complete? true :loss nil`
             here would be a clean bill of health nobody issued."
-    (let [r (tool/read-view-manifest plain-id)]
-      (is (some? r) "an interpreted declaration is still readable")
-      (is (= :interpreted (:lowering r)))
-      (is (nil? (:manifest r)) "with no manifest, because there is no analysis")
-      (is (= :opaque (:basis r)))
-      (is (false? (:complete? r)))
-      (is (= {:reason :no-static-analysis :dropped :unknown} (:loss r))
-          "and the loss NAMED, with an explicit :unknown — an absent :dropped
-           reads as none, which is the one shape this schema exists to refuse"))))
+    ;; rf2-74a89 — dev-instrumentation arm (see ns docstring). The FACT the
+    ;; vocabulary is reporting — that an interpreted declaration carries no
+    ;; manifest at all — is posture-independent and is asserted by
+    ;; `the-census-manifest-is-the-substrate-the-three-reads-project`.
+    (when interop/debug-enabled?
+      (let [r (tool/read-view-manifest plain-id)]
+        (is (some? r) "an interpreted declaration is still readable")
+        (is (= :interpreted (:lowering r)))
+        (is (nil? (:manifest r)) "with no manifest, because there is no analysis")
+        (is (= :opaque (:basis r)))
+        (is (false? (:complete? r)))
+        (is (= {:reason :no-static-analysis :dropped :unknown} (:loss r))
+            "and the loss NAMED, with an explicit :unknown — an absent :dropped
+             reads as none, which is the one shape this schema exists to refuse")))))
 
 (deftest an-undeclared-id-answers-nil-from-every-read
   (testing "Absence is absence. A tool sweeping ids it was handed cannot assume
             each one names a view in THIS build, and a read that invented an
             empty answer would report a view that does not exist as a view with
             nothing in it."
-    (doseq [read-fn [tool/read-view-manifest
-                     tool/read-view-dependencies
-                     tool/read-view-event-sites]]
-      (is (nil? (read-fn :nobody/declared-this))))))
+    ;; rf2-74a89 — dev-instrumentation arm (see ns docstring). Under the gate
+    ;; all three reads answer nil for every id, declared or not, so this row
+    ;; would hold without the reads telling one from the other. Its production
+    ;; counterpart is
+    ;; `neither-the-index-nor-its-reads-survive-the-production-gate`, which
+    ;; asserts the same nil about ids that ARE declared — a claim about the
+    ;; gate rather than about the id.
+    (when interop/debug-enabled?
+      (doseq [read-fn [tool/read-view-manifest
+                       tool/read-view-dependencies
+                       tool/read-view-event-sites]]
+        (is (nil? (read-fn :nobody/declared-this)))))))
 
 ;; ---------------------------------------------------------------------------
 ;; read-view-dependencies — the literal/dynamic split
@@ -189,25 +266,32 @@
 (deftest read-view-dependencies-projects-the-declared-subscription-sites
   (testing "SITES, not reads: one entry per lexical `v/sub`, read from the
             manifest and so available before anything mounts."
-    (let [r (tool/read-view-dependencies basket-id)]
-      (is (= :view-dependencies (:read r)))
-      (is (= 2 (count (:subscriptions r)))
-          "exactly the two `v/sub` sites the body carries")
-      (doseq [site (:subscriptions r)]
-        (is (string? (:sid site)) "under the compiler-minted stable site id")
-        (is (vector? (:path site)) "with its deterministic occurrence coordinate")
-        (is (contains? site :dynamic?)
-            "and its query-shape honesty stated on the entry, never left to be
-             inferred from whether :query happens to be present")))))
+    ;; rf2-74a89 — dev-instrumentation arm (see ns docstring). The two SITES
+    ;; and their `:sid` / `:path` are manifest facts, asserted in both
+    ;; postures by `the-census-manifest-is-the-substrate-the-three-reads-
+    ;; project`; `:dynamic?` is minted by this read and gated with it.
+    (when interop/debug-enabled?
+      (let [r (tool/read-view-dependencies basket-id)]
+        (is (= :view-dependencies (:read r)))
+        (is (= 2 (count (:subscriptions r)))
+            "exactly the two `v/sub` sites the body carries")
+        (doseq [site (:subscriptions r)]
+          (is (string? (:sid site)) "under the compiler-minted stable site id")
+          (is (vector? (:path site)) "with its deterministic occurrence coordinate")
+          (is (contains? site :dynamic?)
+              "and its query-shape honesty stated on the entry, never left to be
+               inferred from whether :query happens to be present"))))))
 
 (deftest a-literal-query-is-projected-as-the-value-it-is
   (testing "A fully-literal query IS the authored runtime shape, so it is safe
             to show verbatim."
-    (let [sites   (:subscriptions (tool/read-view-dependencies basket-id))
-          literal (first (remove :dynamic? sites))]
-      (is (some? literal) "the body carries a literal-query site")
-      (is (= [:basket/total] (:query literal))
-          "shown as data, because that is what it is"))))
+    ;; rf2-74a89 — dev-instrumentation arm (see ns docstring).
+    (when interop/debug-enabled?
+      (let [sites   (:subscriptions (tool/read-view-dependencies basket-id))
+            literal (first (remove :dynamic? sites))]
+        (is (some? literal) "the body carries a literal-query site")
+        (is (= [:basket/total] (:query literal))
+            "shown as data, because that is what it is")))))
 
 (deftest a-captured-local-is-dynamic-and-shows-only-what-is-known
   (testing "`(v/sub [:basket/line row-id])` closes over a template local, so its
@@ -215,29 +299,36 @@
             though it were the query would be handing a reader source code where
             they asked for data — but the HEAD is genuinely known, so it is
             still shown."
-    (let [sites   (:subscriptions (tool/read-view-dependencies basket-id))
-          dynamic (first (filter :dynamic? sites))]
-      (is (some? dynamic) "the body carries a captured-local site")
-      (is (not (contains? dynamic :query))
-          "no :query is offered, because there is no query yet")
-      (is (= :basket/line (:query-id dynamic))
-          "the literal query-id IS known and is shown — absence is reported
-           where it exists, not spread over the parts that are certain"))))
+    ;; rf2-74a89 — dev-instrumentation arm (see ns docstring).
+    (when interop/debug-enabled?
+      (let [sites   (:subscriptions (tool/read-view-dependencies basket-id))
+            dynamic (first (filter :dynamic? sites))]
+        (is (some? dynamic) "the body carries a captured-local site")
+        (is (not (contains? dynamic :query))
+            "no :query is offered, because there is no query yet")
+        (is (= :basket/line (:query-id dynamic))
+            "the literal query-id IS known and is shown — absence is reported
+             where it exists, not spread over the parts that are certain")))))
 
 (deftest the-literal-dynamic-split-is-a-discrimination
   (testing "Non-vacuity for the two rows above: the census carries one of each,
             so a projection that answered `:dynamic? true` to everything — or
             `false` to everything — cannot pass both."
-    (let [sites (:subscriptions (tool/read-view-dependencies basket-id))]
-      (is (= #{true false} (set (map :dynamic? sites)))))))
+    ;; rf2-74a89 — dev-instrumentation arm (see ns docstring).
+    (when interop/debug-enabled?
+      (let [sites (:subscriptions (tool/read-view-dependencies basket-id))]
+        (is (= #{true false} (set (map :dynamic? sites))))))))
 
 (deftest an-interpreted-declaration-has-no-dependency-roster-to-claim
   (testing "Same honesty as the manifest read: an empty roster, and the reason
             it is empty, rather than an empty roster presented as a survey."
-    (let [r (tool/read-view-dependencies plain-id)]
-      (is (= [] (:subscriptions r)))
-      (is (false? (:complete? r)))
-      (is (= :no-static-analysis (:reason (:loss r)))))))
+    ;; rf2-74a89 — dev-instrumentation arm (see ns docstring). `(= [] …)` over
+    ;; a read that answered nil is the vacuous negative, so it travels inside.
+    (when interop/debug-enabled?
+      (let [r (tool/read-view-dependencies plain-id)]
+        (is (= [] (:subscriptions r)))
+        (is (false? (:complete? r)))
+        (is (= :no-static-analysis (:reason (:loss r))))))))
 
 ;; ---------------------------------------------------------------------------
 ;; read-view-event-sites — complete roster, narrower entries, said so
@@ -246,13 +337,17 @@
 (deftest read-view-event-sites-projects-every-declared-event-site
   (testing "The ROSTER is complete and lossless: every event site the grammar
             can see is here."
-    (let [r (tool/read-view-event-sites basket-id)]
-      (is (= :view-event-sites (:read r)))
-      (is (= 4 (count (:event-sites r)))
-          "exactly the four event sites the body carries — three `:on-click`
-           handlers and one committed callback at the child's prop")
-      (is (true? (:complete? r)))
-      (is (nil? (:loss r))))))
+    ;; rf2-74a89 — dev-instrumentation arm (see ns docstring). The four sites
+    ;; are a manifest fact and are counted in both postures by
+    ;; `the-census-manifest-is-the-substrate-the-three-reads-project`.
+    (when interop/debug-enabled?
+      (let [r (tool/read-view-event-sites basket-id)]
+        (is (= :view-event-sites (:read r)))
+        (is (= 4 (count (:event-sites r)))
+            "exactly the four event sites the body carries — three `:on-click`
+             handlers and one committed callback at the child's prop")
+        (is (true? (:complete? r)))
+        (is (nil? (:loss r)))))))
 
 (deftest an-event-site-states-the-closed-set-of-facts-it-carries
   (testing "The analyzer records `:prop`, `:classification`, `:serializable?`,
@@ -265,42 +360,52 @@
             side can drift: a manifest that stopped publishing a fact reds here,
             and so does one that starts publishing a fact this set does not
             name."
-    (let [r (tool/read-view-event-sites basket-id)]
-      (is (= #{:sid :source-coord :path :prop :classification :serializable?
-               :sync? :handler :event-id}
-             (:site-facts r)))
-      (doseq [site (:event-sites r)]
-        (is (= (:site-facts r) (set (keys site)))
-            "every entry states exactly the facts the read says it states")))))
+    ;; rf2-74a89 — dev-instrumentation arm (see ns docstring). `:site-facts`
+    ;; and `:event-id` are minted by this read; the five facts the MANIFEST
+    ;; publishes are asserted in both postures by
+    ;; `the-census-manifest-is-the-substrate-the-three-reads-project`, which
+    ;; is the half that would red if a manifest stopped publishing one.
+    (when interop/debug-enabled?
+      (let [r (tool/read-view-event-sites basket-id)]
+        (is (= #{:sid :source-coord :path :prop :classification :serializable?
+                 :sync? :handler :event-id}
+               (:site-facts r)))
+        (doseq [site (:event-sites r)]
+          (is (= (:site-facts r) (set (keys site)))
+              "every entry states exactly the facts the read says it states"))))))
 
 (deftest a-literal-handler-is-projected-as-the-event-vector-it-is
   (testing "A fully-literal handler IS the vector that will dispatch, so it is
             safe to show verbatim — the same rule a fully-literal query gets."
-    (let [sites (:event-sites (tool/read-view-event-sites basket-id))
-          site  (first (filter #(= :basket/clear (:event-id %)) sites))]
-      (is (some? site) "the body carries a literal-handler site")
-      (is (= [:basket/clear] (:handler site))
-          "shown as data, because that is what it is")
-      (is (= :on-click (:prop site)) "under the prop the author wrote it at")
-      (is (= :vector (:classification site)))
-      (is (true? (:serializable? site)))
-      (is (false? (:sync? site))
-          "a `:button` `:on-click` is not the controlled-input synchronous
-           door — the fact is STATED, not left to be assumed from absence"))))
+    ;; rf2-74a89 — dev-instrumentation arm (see ns docstring).
+    (when interop/debug-enabled?
+      (let [sites (:event-sites (tool/read-view-event-sites basket-id))
+            site  (first (filter #(= :basket/clear (:event-id %)) sites))]
+        (is (some? site) "the body carries a literal-handler site")
+        (is (= [:basket/clear] (:handler site))
+            "shown as data, because that is what it is")
+        (is (= :on-click (:prop site)) "under the prop the author wrote it at")
+        (is (= :vector (:classification site)))
+        (is (true? (:serializable? site)))
+        (is (false? (:sync? site))
+            "a `:button` `:on-click` is not the controlled-input synchronous
+             door — the fact is STATED, not left to be assumed from absence")))))
 
 (deftest a-captured-local-in-an-event-vector-shows-only-what-is-known
   (testing "`[:basket/remove row-id]` closes over a template local, so the vector
             that will dispatch does not exist until the view renders. Showing the
             form would be handing a reader source code where they asked for data
             — but the event-id is genuinely known, so it is still shown."
-    (let [sites (:event-sites (tool/read-view-event-sites basket-id))
-          site  (first (filter #(= :basket/remove (:event-id %)) sites))]
-      (is (some? site) "the body carries a captured-local handler site")
-      (is (= :opaque (:handler site))
-          "no handler value is offered, because there is no event vector yet")
-      (is (= :vector (:classification site))
-          "and the classification keeps it apart from a callback body: this IS
-           an event vector, with one argument that is not known yet"))))
+    ;; rf2-74a89 — dev-instrumentation arm (see ns docstring).
+    (when interop/debug-enabled?
+      (let [sites (:event-sites (tool/read-view-event-sites basket-id))
+            site  (first (filter #(= :basket/remove (:event-id %)) sites))]
+        (is (some? site) "the body carries a captured-local handler site")
+        (is (= :opaque (:handler site))
+            "no handler value is offered, because there is no event vector yet")
+        (is (= :vector (:classification site))
+            "and the classification keeps it apart from a callback body: this IS
+             an event vector, with one argument that is not known yet")))))
 
 (deftest an-options-map-handler-carries-the-vector-it-wraps
   (testing "The listener OPTIONS map is the other spelling that carries an event
@@ -308,56 +413,149 @@
             because `:prevent-default` is part of what the site DOES — and the
             `:event-id` is read from the vector the map wraps rather than from
             the map's own keys, which have no head to name."
-    (let [r     (tool/read-view-event-sites options-id)
-          sites (:event-sites r)
-          site  (first sites)]
-      (is (= 1 (count sites)) "one event site, hand-countable from the body")
-      (is (= :options (:classification site)))
-      (is (= {:event [:basket/print] :prevent-default true} (:handler site))
-          "the authored options map, verbatim")
-      (is (= :basket/print (:event-id site))
-          "read from the wrapped vector, not from the map")
-      (is (true? (:serializable? site)))
-      (is (= (:site-facts r) (set (keys site)))
-          "and the closed key set holds over this classification too"))))
+    ;; rf2-74a89 — dev-instrumentation arm (see ns docstring).
+    (when interop/debug-enabled?
+      (let [r     (tool/read-view-event-sites options-id)
+            sites (:event-sites r)
+            site  (first sites)]
+        (is (= 1 (count sites)) "one event site, hand-countable from the body")
+        (is (= :options (:classification site)))
+        (is (= {:event [:basket/print] :prevent-default true} (:handler site))
+            "the authored options map, verbatim")
+        (is (= :basket/print (:event-id site))
+            "read from the wrapped vector, not from the map")
+        (is (true? (:serializable? site)))
+        (is (= (:site-facts r) (set (keys site)))
+            "and the closed key set holds over this classification too")))))
 
 (deftest an-opaque-callback-claims-nothing-about-its-body
   (testing "A `v/event` body is CODE. It carries no event vector, so there is no
             event-id either — and that absence is STATED rather than left as a
             missing key a reader has to interpret. It is also the component-prop
             arm, whose `:sync?` was absent rather than false until rf2-z0blg."
-    (let [sites (:event-sites (tool/read-view-event-sites basket-id))
-          site  (first (filter #(= :ui-event (:classification %)) sites))]
-      (is (some? site) "the body mounts a child with a committed callback prop")
-      (is (= :on-remove (:prop site)))
-      (is (= :opaque (:handler site)))
-      (is (nil? (:event-id site)) "no event vector, so no head to name")
-      (is (false? (:serializable? site)))
-      (is (false? (:sync? site))
-          "a component prop is not a DOM controlled-input door site — false is
-           the fact, and stating it is what makes the row's key set whole"))))
+    ;; rf2-74a89 — dev-instrumentation arm (see ns docstring). `(nil?
+    ;; (:event-id site))` travels inside with the rest: over a read that
+    ;; answered nil, `site` is nil and every key of it is too.
+    (when interop/debug-enabled?
+      (let [sites (:event-sites (tool/read-view-event-sites basket-id))
+            site  (first (filter #(= :ui-event (:classification %)) sites))]
+        (is (some? site) "the body mounts a child with a committed callback prop")
+        (is (= :on-remove (:prop site)))
+        (is (= :opaque (:handler site)))
+        (is (nil? (:event-id site)) "no event vector, so no head to name")
+        (is (false? (:serializable? site)))
+        (is (false? (:sync? site))
+            "a component prop is not a DOM controlled-input door site — false is
+             the fact, and stating it is what makes the row's key set whole")))))
 
 (deftest the-handler-honesty-split-is-a-discrimination
   (testing "Non-vacuity for the three rows above: the census carries one site of
             each class, so a projection that answered `:opaque` to everything —
             or showed every recorded handler verbatim — cannot pass all three."
-    (let [sites (:event-sites (tool/read-view-event-sites basket-id))]
-      (is (= 2 (count (remove #(= :opaque (:handler %)) sites)))
-          "two literal handlers, projected verbatim")
-      (is (= 1 (count (filter #(and (= :opaque (:handler %)) (some? (:event-id %)))
-                              sites)))
-          "one dynamic event vector — opaque handler, known event-id")
-      (is (= 1 (count (filter #(and (= :opaque (:handler %)) (nil? (:event-id %)))
-                              sites)))
-          "and one callback body — opaque handler, and no event-id to know"))))
+    ;; rf2-74a89 — dev-instrumentation arm (see ns docstring). The CENSUS this
+    ;; discriminates over is a manifest fact and is counted in both postures
+    ;; by `the-census-manifest-is-the-substrate-the-three-reads-project`; the
+    ;; honesty projection over it is this read's, and gated with it.
+    (when interop/debug-enabled?
+      (let [sites (:event-sites (tool/read-view-event-sites basket-id))]
+        (is (= 2 (count (remove #(= :opaque (:handler %)) sites)))
+            "two literal handlers, projected verbatim")
+        (is (= 1 (count (filter #(and (= :opaque (:handler %)) (some? (:event-id %)))
+                                sites)))
+            "one dynamic event vector — opaque handler, known event-id")
+        (is (= 1 (count (filter #(and (= :opaque (:handler %)) (nil? (:event-id %)))
+                                sites)))
+            "and one callback body — opaque handler, and no event-id to know")))))
 
 (deftest an-interpreted-declaration-has-no-event-roster-to-claim
   (testing "The third read's honesty arm, asserted rather than assumed to
             follow from its siblings'."
-    (let [r (tool/read-view-event-sites plain-id)]
-      (is (= [] (:event-sites r)))
-      (is (= :opaque (:basis r)))
-      (is (= :unknown (:dropped (:loss r)))))))
+    ;; rf2-74a89 — dev-instrumentation arm (see ns docstring).
+    (when interop/debug-enabled?
+      (let [r (tool/read-view-event-sites plain-id)]
+        (is (= [] (:event-sites r)))
+        (is (= :opaque (:basis r)))
+        (is (= :unknown (:dropped (:loss r))))))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-74a89 — the SUBSTRATE the three reads project, and what survives the gate
+;; ---------------------------------------------------------------------------
+
+(deftest the-census-manifest-is-the-substrate-the-three-reads-project
+  (testing "`v/manifest` is the total, value-taking read — the one read
+            `tool.cljc` exempts from the dev gate — and it is byte-identical in
+            both postures, because the analyzer ran at macro expansion and its
+            rosters are compile-time facts. Every id-taking read above is a
+            PROJECTION of this value, so this is where the census itself is
+            asserted: two subscription sites, four event sites, and the five
+            per-site facts rf2-z0blg made the manifest publish.
+
+            Which makes it the half that reds when a manifest STOPS publishing
+            a fact — the failure the gated `:site-facts` equality is there to
+            catch in dev, and could not catch in a production build. Asserted
+            as key-set equalities for the same reason it is asserted there: so
+            neither side can drift into decoration."
+    (let [m (v/manifest basket)]
+      (is (= 2 (count (:subscriptions m)))
+          "exactly the two `v/sub` sites the body carries")
+      (is (= 4 (count (:events m)))
+          "and the four event sites — three `:on-click` handlers and one
+           committed callback at the child's prop")
+      (doseq [site (:subscriptions m)]
+        (is (= #{:sid :query :source-coord :path} (set (keys site)))
+            "a subscription site states exactly the facts the analyzer knows"))
+      (doseq [site (:events m)]
+        (is (= #{:sid :source-coord :path :prop :classification :serializable?
+                 :sync? :handler}
+               (set (keys site)))
+            "and an event site the five rf2-z0blg made it publish, beside its
+             site id, coordinate and path"))
+      (is (= #{:vector :ui-event} (set (map :classification (:events m))))
+          "the census really does carry more than one class, so the honesty
+           split the gated read applies over it is a discrimination")
+      (is (= #{true false} (set (map :serializable? (:events m))))
+          "and more than one serializability, for the same reason"))
+    (is (= 1 (count (:events (v/manifest print-button))))
+        "the options-map spelling is one site, hand-countable from the body")
+    (is (nil? (v/manifest plain-list))
+        "and an INTERPRETED declaration carries no manifest at all — the fact
+         `an-interpreted-declaration-reports-the-absence-of-analysis` reports
+         through the gated read, stated here at its source")))
+
+(deftest neither-the-index-nor-its-reads-survive-the-production-gate
+  (testing "The elision as a positive fact, witnessed through the REAL
+            load-time gate rather than a `with-redefs` rebind, which cannot
+            reach one (rf2-9c2jf).
+
+            Asked about ids that are genuinely DECLARED in this build — and
+            that nothing in this namespace registers explicitly, so the answer
+            is the gate's and not a test's — the index answers nil and all
+            three reads answer nil. That is what makes
+            `an-undeclared-id-answers-nil-from-every-read` a dev-arm row: under
+            the gate every id answers nil, so nil says nothing about the id.
+
+            Under the gate this is also the whole of the bundle-size claim the
+            expansion test makes structurally: an index that held a row per
+            DECLARATION in a production build would keep every descriptor —
+            manifest, render fn and all — reachable from a live registry."
+    (if interop/debug-enabled?
+      (do
+        (is (contains? (registry/view-ids) plain-id)
+            "dev: a declared view is in the index")
+        (is (some? (tool/read-view-manifest options-id))
+            "and the reads answer for it"))
+      (do
+        (is (nil? (registry/lookup plain-id))
+            "production: a DECLARED view does not resolve — the gated
+             registration call site never ran")
+        (is (not (contains? (registry/view-ids) options-id))
+            "nor is it in the roster a sweep enumerates")
+        (doseq [read-fn [tool/read-view-manifest
+                         tool/read-view-dependencies
+                         tool/read-view-event-sites]]
+          (is (nil? (read-fn options-id))
+              "and every read is inert for it — nil, never an empty roster
+               wearing a completeness claim"))))))
 
 ;; ---------------------------------------------------------------------------
 ;; The dev gate — visible in the expansion, which is where it can fold away

--- a/scripts/test-freehand-prod-gate.sh
+++ b/scripts/test-freehand-prod-gate.sh
@@ -122,22 +122,105 @@ known_red=(
   #    pass (the `ssr-compatibility-checks-test` treatment), not a blanket
   #    posture guard.
   #
-  #    TWO OF THE FOUR ARE CLEARED (rf2-74a89, and read them before triaging
-  #    the two below — they are the worked examples).  `evidence-seam-` and
-  #    `occurrence-index-cljs-test` now assert the CELL LIFECYCLE both
-  #    surfaces are a projection OF — `:published` / `:abandoned`,
-  #    `:connected` / `:disconnected`, the published dependency set and
-  #    committed frame, the advanced generation of a compatible reload —
-  #    outside the arm, with every record / row / escape assertion kept
-  #    verbatim inside it, NEGATIVES INCLUDED.  Each also gained the
-  #    production-real counterpart this note asks for, stated as a positive
-  #    fact rather than an absence: an installed sink is called ZERO times, a
-  #    throwing sink is unreachable rather than merely contained, a record the
-  #    evidence schema would refuse is not a production failure mode at all
-  #    because none is built, and `the-index-costs-a-production-build-nothing`
-  #    holds two live occurrences across a read and finds no rows.
-  re-frame.freehand.explain-render-cljs-test      #  35 + 1 error
-  re-frame.freehand.tool-reads-cljs-test          #  58
+  #    ALL FOUR CLEARED 2026-07-28 (rf2-74a89).  Each keeps every record /
+  #    row / escape / read assertion VERBATIM inside a
+  #    `(when interop/debug-enabled? …)` arm, NEGATIVES INCLUDED, and each
+  #    gained the production-real counterpart this note asks for — stated as
+  #    a POSITIVE fact rather than an absence, because "nothing happened" is
+  #    what a vacuous pass says too:
+  #
+  #      * `evidence-seam` / `occurrence-index` assert the CELL LIFECYCLE
+  #        both surfaces are a projection OF — `:published` / `:abandoned`,
+  #        `:connected` / `:disconnected`, the published dependency set and
+  #        committed frame, the advanced generation of a compatible reload —
+  #        outside the arm.  Beside them: an installed sink is called ZERO
+  #        times, a throwing sink is UNREACHABLE rather than merely
+  #        contained, a record the evidence schema would refuse is not a
+  #        production failure mode at all because none is built, and
+  #        `the-index-costs-a-production-build-nothing` holds two live
+  #        occurrences across a read and finds no rows — not tidiness, but
+  #        unbounded growth avoided in the one build where nothing reads it.
+  #      * `tool-reads` was the largest entry and had the cleanest answer:
+  #        `v/manifest` is the ONE read `tool.cljc` exempts from the gate,
+  #        and it is byte-identical in both postures, because the analyzer
+  #        ran at macro expansion.  The three id-taking reads are
+  #        PROJECTIONS of it, so the census itself —
+  #        two subscription sites, four event sites, the five per-site facts
+  #        rf2-z0blg made the manifest publish, and the interpreted
+  #        declaration's absent analysis — is now asserted at its source in
+  #        both postures.  `the-index-holds-one-row-per-declaration-not-a-
+  #        history` needed no arm at all: `registry/register!` is ungated,
+  #        only the CALL SITE in the expansion carries the gate.
+  #      * `explain-render` is the most one-sided, and its docstring says so
+  #        rather than dressing it up: the read is gated at the door and both
+  #        structures it folds are dev-only.  It earns its place on the
+  #        CORRELATED COMMIT PATH — `connect!` binds `trace/*handler-scope*`
+  #        and commits inside a cascade, which nothing else in the artefact's
+  #        suites drives — plus the door's inertness: under the gate a
+  #        DECLARED, MOUNTED, CORRELATED view answers `nil`, never an
+  #        envelope carrying `:explanations []` with `:complete? true` on it.
+  #        An empty-but-confident answer would tell a tool nothing is
+  #        rendering in a build where plenty is, which is worse than no
+  #        answer at all.
+  #
+  #    THE VACUOUS PASSES THIS ROSTER LINE WAS HIDING, so the next reader
+  #    knows the shape: `(= [] seen)` and `(nil? (last-evidence-sink-escape))`
+  #    over an elided seam; `(= [] (rows-for …))` after a disconnect, after an
+  #    abandoned render and before a reconnect; `(nil? (:loss r))` over a nil
+  #    projection; `(nil? (:cause e))`, `(nil? (:dispatch-id e))` and
+  #    `(= [] (:candidates e))` over an explanation that does not exist;
+  #    `(every? #(not (contains? % :value)) …)` over an empty read set; and
+  #    `an-undeclared-id-answers-nil` in TWO namespaces, where under the gate
+  #    every id answers nil so the nil says nothing about the id.  Each is
+  #    inside its posture arm now.
+
+  # ── rf2-74a89 — THE PROPS-SCHEMA CLOSURE, CLEARED 2026-07-28.  READ THIS
+  #    ONE BEFORE ASSUMING THE NEXT LOOK-ALIKE IS A DEFECT.
+  #    `descriptor.cljc` ~line 591 gates the whole closing-schema arm and
+  #    says why: "a schema is a compile-time and tooling fact: production
+  #    renders the same tree either way, and the CLJS branch folds away".  So
+  #    under the gate an UNDECLARED prop on a closing schema is ACCEPTED.
+  #    That is the same class as Spec 010's `validate-fx!` (routing's
+  #    `nav-fx-schemas`, rf2-o5dbf batch 7) and NOT the rf2-9c2jf class: the
+  #    COMPILED tier still refuses the identical row statically at analyze
+  #    time, in either posture, and that is now asserted directly by
+  #    `which-tier-refuses-an-undeclared-prop-depends-on-the-posture` — with
+  #    a non-map props slot refused in BOTH postures beside it, because the
+  #    call ABI is always on and that is what makes the boundary's production
+  #    `:accept` a verdict rather than a check that never ran.
+  #
+  #    `behaviors-` and `errors-tree-cljs-test` were the same mechanism seen
+  #    from a caller: each drove a malformed boundary call and asserted
+  #    `:rf.error/view-bad-props`.  Under the gate the call is STILL REFUSED
+  #    — the door's OWN always-on roster check fires instead — so REFUSED is
+  #    asserted posture-independently (neither namespace stated it before)
+  #    and only the id rides the dev arm.
+  #
+  #    AND THE TRAP ON THE WAY OUT, which was the bulk of the work here: this
+  #    suite's POSITIVE controls passed under the gate for the wrong reason.
+  #    The schema-less arm, the open escape and the opaque-schema arm all
+  #    assert a boundary `:accept`, and under the gate EVERYTHING accepts.
+  #    All three travel inside the posture arm with the reject rows.
+
+  # ── rf2-74a89 — SOURCE-COORD ELISION, CLEARED 2026-07-28.  `v/describe`'s
+  #    `:source` is REGISTRATION metadata and `defview` emits the slim
+  #    `prod-coords-form` for it under the gate, which omits `:column` —
+  #    matching core's `reg-*` elision.  The MANIFEST's coordinates are a
+  #    compile-time analyzer fact and survive byte-identical, so the
+  #    inheritance claim keeps its full strength by naming the declaration's
+  #    column the same way `event-column` was already named, with the
+  #    verbatim descriptor equality in the dev arm proving the two agree.
+  #    Two always-on rows were added: every roster coordinate is TOTAL in
+  #    either posture (the property production depends on, and the one an
+  #    over-eager elision would take), and the registration coord really is
+  #    elided — so the asymmetry is a decision rather than a drift.
+
+  # ── THE ROSTER IS EMPTY, and the `-n` machinery STAYS (see
+  #    `test-routing-prod-gate.sh`, cleared the same way).  It is what makes
+  #    the exclusion polarity real: every one of this artefact's test
+  #    namespaces now runs under `-Dre-frame.debug=false` BY DEFAULT, and the
+  #    next namespace that goes red under the gate has a documented place to
+  #    be rostered — with a bead — instead of quietly reddening the job.
 )
 
 # ---------------------------------------------------------------------------
@@ -230,11 +313,14 @@ fi
 # ordinary churn; raise it when the roster shrinks materially.
 #
 # Calibrated against the first green run: 125 namespaces / 1159 tests / 7930
-# assertions (2026-07-28).  1000 is ~14% headroom, the same ratio
-# `test-routing-prod-gate.sh` and `test-ssr-prod-gate.sh` settled on — low
-# enough not to trip on ordinary churn, high enough that losing a tenth of the
-# lane cannot report itself green.
-export RF2_MIN_TESTS="${RF2_MIN_TESTS:-1000}"
+# assertions (2026-07-28), floor 1000.  RAISED to 1090 with the roster's last
+# line (rf2-74a89, 2026-07-28): the lane now runs 135 of 135 namespaces / 1268
+# tests / 8457 assertions, and a floor left at the 125-namespace number would
+# no longer notice the whole triage batch disappearing.  1090 keeps the same
+# ~14% headroom `test-routing-prod-gate.sh` and `test-ssr-prod-gate.sh`
+# settled on — low enough not to trip on ordinary churn, high enough that
+# losing a tenth of the lane cannot report itself green.
+export RF2_MIN_TESTS="${RF2_MIN_TESTS:-1090}"
 
 args=()
 for ns in $runnable; do

--- a/scripts/test-freehand-prod-gate.sh
+++ b/scripts/test-freehand-prod-gate.sh
@@ -121,45 +121,23 @@ known_red=(
   #    the lane excludes, or a production-real counterpart added in the same
   #    pass (the `ssr-compatibility-checks-test` treatment), not a blanket
   #    posture guard.
-  re-frame.freehand.evidence-seam-cljs-test       #  22 + 1 error
+  #
+  #    TWO OF THE FOUR ARE CLEARED (rf2-74a89, and read them before triaging
+  #    the two below — they are the worked examples).  `evidence-seam-` and
+  #    `occurrence-index-cljs-test` now assert the CELL LIFECYCLE both
+  #    surfaces are a projection OF — `:published` / `:abandoned`,
+  #    `:connected` / `:disconnected`, the published dependency set and
+  #    committed frame, the advanced generation of a compatible reload —
+  #    outside the arm, with every record / row / escape assertion kept
+  #    verbatim inside it, NEGATIVES INCLUDED.  Each also gained the
+  #    production-real counterpart this note asks for, stated as a positive
+  #    fact rather than an absence: an installed sink is called ZERO times, a
+  #    throwing sink is unreachable rather than merely contained, a record the
+  #    evidence schema would refuse is not a production failure mode at all
+  #    because none is built, and `the-index-costs-a-production-build-nothing`
+  #    holds two live occurrences across a read and finds no rows.
   re-frame.freehand.explain-render-cljs-test      #  35 + 1 error
-  re-frame.freehand.occurrence-index-cljs-test    #  22 + 1 error
   re-frame.freehand.tool-reads-cljs-test          #  58
-
-  # ── rf2-74a89 — THE PROPS-SCHEMA CLOSURE.  Dev-only by EXPLICIT design, and
-  #    the entry to read before assuming the next look-alike is a defect.
-  #    `descriptor.cljc` ~line 591 gates the whole closing-schema arm and says
-  #    why: "a schema is a compile-time and tooling fact: production renders
-  #    the same tree either way, and the CLJS branch folds away".  So under
-  #    the gate an UNDECLARED prop on a closing schema is ACCEPTED rather than
-  #    refused, and `props-schema-cljs-test`'s "the breach raises" reads
-  #    `(some? msg)` over nil.  That is the same class as Spec 010's
-  #    `validate-fx!` (routing's `nav-fx-schemas`, rf2-o5dbf batch 7) and NOT
-  #    the rf2-9c2jf class: the COMPILED tier still refuses the same
-  #    declaration statically at analyze time, in either posture.
-  #
-  #    THE OTHER TWO ARE THE SAME MECHANISM SEEN FROM A CALLER, and their
-  #    shape is worth reading before anyone reports an acceptance regression:
-  #    each drives a malformed boundary call and asserts the id
-  #    `:rf.error/view-bad-props`.  Under the gate the call is STILL REFUSED —
-  #    the boundary's OWN always-on roster check fires instead
-  #    (`:rf.error/behavior-bad-args`, `:rf.error/error-boundary-bad-args`).
-  #    Only the diagnostic id differs, so the always-on witness to assert in
-  #    their place is "refused", with the id itself in the dev arm.
-  #
-  #    And note the trap on the way out: this suite's POSITIVE control passes
-  #    under the gate for the wrong reason — nothing ran, so nothing objected.
-  re-frame.freehand.behaviors-cljs-test           #   1
-  re-frame.freehand.errors-tree-cljs-test         #   1
-  re-frame.freehand.props-schema-cljs-test        #   7 + 4 errors
-
-  # ── rf2-74a89 — SOURCE-COORD ELISION, prod-elided at the core `reg-view`
-  #    registration boundary.  Same class as core's
-  #    `source-coord-prod-elision-test`; here the declaration's coord loses
-  #    its `:column` under the gate and the inheritance assertion compares
-  #    unequal maps.  Dev arm for the coord itself; the manifest SHAPE around
-  #    it is posture-independent and should be asserted outside the arm.
-  re-frame.freehand.manifest-source-coord-jvm-test #  1
 )
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Triage of the Freehand production-gate known-red roster (rf2-74a89). **All eight rostered namespaces come off. The roster is EMPTY.**

## The lane, before and after

| | before (PR #7191) | after |
|---|---|---|
| namespaces | 125 of 133 | **135 of 135** |
| tests | 1159 | **1268** |
| assertions | 7930 | **8457** |
| roster lines | 8 | **0** |
| `RF2_MIN_TESTS` | 1000 | **1090** |

`check_jvm_lane_rosters.py`'s baseline stays **EMPTY**. The `-n` machinery stays too — it is what makes the exclusion polarity real, so the next namespace that goes red under the gate has a documented place to be rostered, with a bead, instead of quietly reddening the job.

## Nothing failed for a real reason

Every one of the 147 failures / 7 errors was dev instrumentation asserted inline with semantics. Three of the eight needed a ruling read carefully before they could be written off, and the bead had already made it:

**The props-schema closure is dev-only BY EXPLICIT DESIGN.** `descriptor.cljc` ~591 gates the whole closing-schema arm and says why — *"a schema is a compile-time and tooling fact"*. Under the gate the BOUNDARY accepts an undeclared prop. Same class as Spec 010's `validate-fx!`; **not** the rf2-9c2jf class, because the tier a compiled build's guarantee rests on — the analyzer, at build time — refuses the identical row in either posture. `behaviors-` and `errors-tree-cljs-test` are the same mechanism seen from a caller: under the gate the malformed call is **still refused**, by the door's own always-on roster check, and only the diagnostic id differs.

## Vacuous passes found — all four classes

The bulk of the work was **not** the reds. It was the assertions already GREEN under the gate for the wrong reason. Each travelled into the posture arm with the rows it is the control for:

1. **a negative over an empty ring/index** — `(= [] seen)`, `(nil? (last-evidence-sink-escape))`, `(= [] (rows-for …))` after a disconnect / after an abandoned render / before a reconnect, `(nil? (:loss r))` over a nil projection, `(nil? (:cause e))`, `(nil? (:dispatch-id e))`, `(= [] (:candidates e))`, `(every? #(not (contains? % :value)) …)` over an empty read set.
2. **a namespace that is 100% dev instrumentation** — `explain-render` came closest and says so in its own docstring rather than dressing it up. It stays in the lane on the correlated-commit path plus a real door witness; it was not rostered off, and it was not guarded wholesale.
3. **a positive the gate short-circuits** — `props-schema`'s schema-less arm, open escape and opaque-schema arm each assert a boundary `:accept`, and under the gate *everything* accepts. `a-throwing-sink-does-not-fail-the-commit` passed because the sink was never called.
4. **absence of a key the gate elides wholesale** — `an-undeclared-id-answers-nil` in **two** namespaces: under the gate every id answers nil, so the nil says nothing about the id. Checked and NOT found for `absence-is-reported-as-absence-never-as-any` — `describe`'s `:props-schema` is carried in production, so that absence is real.

## Nothing was deleted or weakened

Every dev-instrumentation assertion is kept **verbatim** inside a `(when interop/debug-enabled? …)` arm marked `rf2-74a89`. The dev-posture proof, over the eight namespaces:

```
before:  87 tests / 508 assertions / exit 0
after:   94 tests / 566 assertions / exit 0
```

**+7 tests, +58 assertions, nothing removed.**

## The production-real coverage that earns each removal

Stated as positive facts through the REAL load-time gate, never a `with-redefs` rebind (which cannot reach one — rf2-9c2jf):

- **`tool-reads`** — the cleanest answer of the eight. `v/manifest` is the one read `tool.cljc` exempts from the gate and is byte-identical in both postures; the three id-taking reads are projections of it. `the-census-manifest-is-the-substrate-the-three-reads-project` asserts the census at its source in both postures. `the-index-holds-one-row-per-declaration-not-a-history` needed **no arm at all** — `registry/register!` is ungated, only the call site in the expansion carries the gate.
- **`occurrence-index`** — `the-index-costs-a-production-build-nothing` holds two live occurrences across a read and finds no rows. Not tidiness: a row per mounted boundary would be unbounded growth in the one build where nothing ever reads it.
- **`evidence-seam`** — an installed sink is called **zero** times; a throwing sink is **unreachable** rather than merely contained; a record the evidence schema would refuse is not a production failure mode at all, because none is built. The cell lifecycle both surfaces project — `:published` / `:abandoned`, `:connected` / `:disconnected`, the published dependency set and committed frame — is asserted outside the arms.
- **`explain-render`** — the correlated commit path (nothing else in the artefact drives a Freehand commit with a run on the stack), plus: under the gate a declared, mounted, correlated view answers `nil`, never an empty roster wearing a completeness claim.
- **`props-schema`** — `which-tier-refuses-an-undeclared-prop-depends-on-the-posture`: the analyzer refuses every reject row in either posture; the boundary refuses exactly when the gate is open; and a non-map props slot is refused in **both**, because the call ABI is always on. That last row is what makes the boundary's production `:accept` a verdict rather than an absent check.
- **`manifest-source-coord`** — `every-roster-coordinate-is-total-in-either-posture` (the property production depends on, and the one an over-eager elision would take) and `the-descriptors-registration-coord-is-elided-under-the-real-gate`, so the asymmetry between the two coord sinks is a decision rather than a drift.
- **`behaviors` / `errors-tree`** — REFUSED asserted posture-independently. Neither namespace stated it before; this is new coverage, not a weakening.

## `RF2_MIN_TESTS`

**Raised 1000 → 1090.** The shrink warrants it: the lane went 1159 → 1268 tests, and a floor calibrated against the 125-namespace run would no longer notice this whole triage batch disappearing. 1090 keeps the same ~14% headroom `test-routing-prod-gate.sh` and `test-ssr-prod-gate.sh` settled on.

## Quality gates

Foreground, worktree-local, exit codes echoed. No pipes — a `tail` would mask the runner's status.

| gate | result |
|---|---|
| `bash scripts/test-freehand-prod-gate.sh` | **exit 0** — 135 of 135 namespaces, 0 excluded, 1268 tests / 8457 assertions, 0 failures / 0 errors |
| `clojure -M:test` (whole artefact, dev posture) | **exit 0** — 1266 tests / 8686 assertions |
| `clojure -M:test` over the 8 formerly-rostered namespaces | **exit 0** — 94 tests / 566 assertions (was 87 / 508) |
| `clojure -J-Dre-frame.debug=false -M:test -n <ns>` per namespace | **exit 0** for all eight |
| pin-teeth inversion — `clojure -J-Dre-frame.debug=true -M:test:prod-gate` | **exit 1**, 1268 tests / 8688 assertions, **2 failures**: `the-property-really-reached-this-jvm` and `the-framework-really-read-the-gate`. Exactly the pin's two deftests and nothing else — the teeth are intact |

Deferred to CI: the full JVM implementation sweep, the CLJS browser suites, and the `cljs-freehand-evidence-elision` bundle probe. This diff touches test sources plus the roster block and the coverage floor of one script; no production source is modified.
