### PR TITLE
fix(core): the initial-events cascade sees the pool it will be reprojected against (rf2-rt4jz)

### DIFF
--- a/implementation/core/src/re_frame/live_frame.cljc
+++ b/implementation/core/src/re_frame/live_frame.cljc
@@ -596,29 +596,93 @@
 ;; bookkeeping in this ns. Trade-off accepted: a frame id that is destroyed
 ;; and never reused leaves a residual entry for the remainder of the process
 ;; (no destroy-time cleanup hook here) — harmless, since `reproject-live-frame!`
-;; is already a no-op for an unregistered id and a REUSED id's entry is always
-;; freshly overwritten by the next `make-frame` call, so the residue is never
-;; read incorrectly; only dev-process memory, bounded by the number of
-;; distinct frame ids ever created in a session.
+;; is already a no-op for an unregistered id and a REUSED id's entry is
+;; overwritten BEFORE the next `make-frame`'s engine commit (see the WHEN
+;; section below), so the residue is never read incorrectly; only dev-process
+;; memory, bounded by the number of distinct frame ids ever created in a
+;; session.
+;;
+;; ---- WHEN the row is written, and why that is load-bearing (rf2-rt4jz) ----
+;;
+;; The row is written BEFORE the `upsert-frame!` engine commit and rolled back
+;; EXACTLY on failure. It used to be written after the commit returned, which
+;; reads as the safer order — a failed construction cannot leave residue if it
+;; never writes — but it is not, because the record and the row are two stores
+;; and the frame is REPROJECTABLE the moment the first of them lands.
+;;
+;; `upsert-frame!` publishes the record carrying the new generation and then,
+;; still inside the call, runs the `:initial-events` setup steps (EP-0027).
+;; Those steps dispatch, so they pass through `call-with-frame-resolution`,
+;; whose read-time consult flushes any PENDING reprojection (rf2-h1vqa4 /
+;; rf2-9c2jf). Under the old order that flush read a row belonging to some
+;; PREVIOUS incarnation of the id — or to no generation at all — re-resolved
+;; the frame's composition against that wrong pool, and `set-generation!`d the
+;; result over the generation the constructor had just installed. The
+;; constructor returned having silently lost its own swap, with the row ending
+;; up correct and the GENERATION wrong. Not a race: one synchronous call, both
+;; hosts (`make-frame-generation-pool-window-jvm-test` reproduces it with no
+;; threads and no barrier).
+;;
+;; Writing FIRST makes the setup cascade's flush re-resolve the frame against
+;; the pool it was actually sealed from, which is a byte-for-byte identical
+;; generation and therefore no swap at all. rf2-ktmto9's no-residue contract —
+;; a failed creation records nothing, a failed re-construction preserves the
+;; old row — is then held EXPLICITLY by `restore-frame-generation-pool!`
+;; rather than implicitly by ordering, which is the stronger statement: it says
+;; what it means at the site, instead of depending on nothing ever resolving
+;; between the two writes.
+;;
+;; The one thing the early write does NOT buy: on a RE-construction the row
+;; names the incoming pool for the brief interval before `upsert-frame!`'s
+;; surgical swap installs the incoming generation, so a JVM-concurrent flush
+;; landing in THAT interval re-resolves the OUTGOING composition against the
+;; INCOMING pool. That is transient and self-correcting — the swap that
+;; follows overwrites it unconditionally, so no completed call can observe it —
+;; whereas the window it replaces corrupted the value the constructor returned.
+;; The remaining exposure is at worst one spurious
+;; `:rf.warning/reprojection-failed` diagnostic on the dev channel.
 
 (defonce ^{:private true
            :doc "frame id -> the descriptor pool its CURRENT generation was
   resolved against: nil for the live source store, a real descriptors value
-  for an explicit pool (`make-frame`'s 2-arity). Recorded by `make-frame` on
-  every SUCCESSFUL call (creation + hot-reload re-construction), AFTER the
-  `upsert-frame!` engine commit returns (rf2-ktmto9 — a failed creation records
-  nothing; a failed re-construction preserves the old row), so reprojection
-  re-resolves against the SAME provenance (rf2-rf3zgt) instead of silently
-  defaulting to the live store for a frame that was never resolved against
-  it. See the §Generation PROVENANCE section above for the full rationale."}
+  for an explicit pool (`make-frame`'s 2-arity). Written by `make-frame`
+  (creation + hot-reload re-construction) BEFORE the `upsert-frame!` engine
+  commit, so the row is already in step the moment the record can be
+  reprojected — in particular for the `:initial-events` cascade that runs
+  INSIDE that commit (rf2-rt4jz) — and rolled back exactly on failure by
+  `restore-frame-generation-pool!`, which is how rf2-ktmto9's contract (a
+  failed creation records nothing; a failed re-construction preserves the old
+  row) is kept. Reprojection then re-resolves against the SAME provenance
+  (rf2-rf3zgt) instead of silently defaulting to the live store for a frame
+  that was never resolved against it. See the §Generation PROVENANCE section
+  above for the full rationale."}
   frame-generation-pool
   (atom {}))
 
 (defn- record-frame-generation-pool!
-  "Record that `runnable-id`'s generation was just resolved against `descriptors`
-  (nil for the live store) — see `frame-generation-pool`. Returns nil."
+  "Record that `runnable-id`'s generation is being resolved against
+  `descriptors` (nil for the live store) — see `frame-generation-pool`.
+  Returns the PRIOR row as `[had-row? prior-descriptors]`, the exact input
+  `restore-frame-generation-pool!` needs to undo this write."
   [runnable-id descriptors]
-  (swap! frame-generation-pool assoc runnable-id descriptors)
+  (let [before (deref frame-generation-pool)]
+    (swap! frame-generation-pool assoc runnable-id descriptors)
+    [(contains? before runnable-id) (get before runnable-id)]))
+
+(defn- restore-frame-generation-pool!
+  "Undo one `record-frame-generation-pool!` write on `runnable-id`, restoring
+  the row to EXACTLY what it was: `prior` when the id had one, ABSENT when it
+  did not. The two cases are distinct and both matter — `nil` is a legitimate
+  recorded pool (it means \"the live source store\"), so an absent row cannot be
+  spelled by assoc'ing nil.
+
+  This is rf2-ktmto9's no-residue contract, stated (rf2-rt4jz): a failed
+  creation records nothing, and a failed re-construction preserves the old row.
+  Returns nil."
+  [runnable-id had-row? prior]
+  (if had-row?
+    (swap! frame-generation-pool assoc runnable-id prior)
+    (swap! frame-generation-pool dissoc runnable-id))
   nil)
 
 ;; ===========================================================================
@@ -833,19 +897,37 @@
      ;; VALUE (below) is what gives an owner exact teardown authority — with NO
      ;; post-return `frame-incarnation-token` re-sample that a concurrent
      ;; destroy + same-id reseat could race into a successor's token.
-     (let [token-box (volatile! nil)]
-       (frame/upsert-frame! runnable-id record-config token-box)
-       ;; Record which pool this generation was resolved against AFTER the engine
-       ;; commit returns successfully — see §Generation PROVENANCE above
-       ;; (rf2-rf3zgt): a later reprojection reads this back so it re-resolves
-       ;; against the SAME pool (explicit or live) rather than always falling
-       ;; through to the live store. Recorded on every SUCCESSFUL call (creation +
-       ;; hot-reload re-construction), so a re-`make-frame` that changes arity
-       ;; keeps the record current — and ordered after `upsert-frame!` (rf2-ktmto9,
-       ;; the failure-atomicity completion) so a FAILED creation records nothing
-       ;; and a FAILED re-construction preserves the OLD provenance row, matching
-       ;; the engine's own no-residue-on-failure contract.
-       (record-frame-generation-pool! runnable-id descriptors)
+     (let [token-box (volatile! nil)
+           ;; Record which pool this generation was resolved against — see
+           ;; §Generation PROVENANCE above (rf2-rf3zgt): a later reprojection
+           ;; reads this back so it re-resolves against the SAME pool (explicit
+           ;; or live) rather than always falling through to the live store.
+           ;; Written on every call (creation + hot-reload re-construction), so a
+           ;; re-`make-frame` that changes arity keeps the row current.
+           ;;
+           ;; rf2-rt4jz — BEFORE the engine commit, not after it. The record and
+           ;; this row are two stores, and the frame becomes REPROJECTABLE the
+           ;; moment the FIRST of them lands: `upsert-frame!` publishes the record
+           ;; carrying the new generation and then, still inside the call, runs
+           ;; the `:initial-events` setup steps, whose dispatches flush any
+           ;; pending reprojection through `call-with-frame-resolution`. Recording
+           ;; afterwards left that flush reading a PREVIOUS incarnation's row: it
+           ;; re-resolved the frame against the wrong pool and `set-generation!`d
+           ;; the result over what had just been installed, so the constructor
+           ;; returned having silently lost its own swap. One synchronous call,
+           ;; both hosts, no race.
+           ;;
+           ;; rf2-ktmto9's no-residue contract survives the move by being STATED
+           ;; instead of implied: the prior row is captured here and restored
+           ;; exactly if the commit throws, so a FAILED creation still records
+           ;; nothing and a FAILED re-construction still preserves the OLD row.
+           [had-pool-row? prior-pool]
+           (record-frame-generation-pool! runnable-id descriptors)]
+       (try
+         (frame/upsert-frame! runnable-id record-config token-box)
+         (catch #?(:clj Throwable :cljs :default) e
+           (restore-frame-generation-pool! runnable-id had-pool-row? prior-pool)
+           (throw e)))
        ;; rf2-djkr0 — THE INVARIANT: a PARTIALLY-CONSTRUCTED frame is never
        ;; observable as live, so a registration that lands while a frame is
        ;; mid-construction is never lost.
@@ -870,13 +952,26 @@
        ;; this point on any further `reg-*` sees the frame and marks for itself.
        ;; The window is closed end to end.
        ;;
-       ;; CONDITIONAL, because an unconditional mark is not free of consequence:
-       ;; it would leave the projection dirty after EVERY construction, and a
-       ;; flag set here is flushed by some later, unrelated resolution. Marking
-       ;; only when the pool actually MOVED under us keeps every non-racing
-       ;; construction — which is all of them outside this defect — byte-for-byte
-       ;; as before. The comparison is exact: any `reg-*` / `forget-*` / `clear-*`
-       ;; / `register-standard!` bumps a leg of `registration-pool-mark`.
+       ;; CONDITIONAL. Marking only when the pool actually MOVED under us keeps
+       ;; every non-racing construction — which is all of them outside this
+       ;; defect — byte-for-byte as before: no flag, and so no reprojection sweep
+       ;; over every image-loaded frame armed by an ordinary `make-frame`. The
+       ;; comparison is exact: any `reg-*` / `forget-*` / `clear-*` /
+       ;; `register-standard!` bumps a leg of `registration-pool-mark`.
+       ;;
+       ;; When rf2-djkr0 shipped, the conditionality was ALSO load-bearing for
+       ;; correctness: an unconditional mark leaves the projection dirty after
+       ;; every construction, a flag set here is flushed by some later unrelated
+       ;; resolution, and one of those was the `:initial-events` cascade running
+       ;; inside `upsert-frame!` — which reprojected against a stale provenance
+       ;; row and clobbered the generation a re-construction had just installed.
+       ;; rf2-rt4jz CLOSED that (the row is now written before the engine commit,
+       ;; §Generation PROVENANCE above), and the closure is measured, not
+       ;; assumed: with the row written first, forcing this mark unconditional
+       ;; leaves `live-frame-reload-cljs-test` — the suite that reddened under
+       ;; exactly that configuration — green. So the conditional now stands on
+       ;; the cost argument ALONE, and it stands: it is the cheaper shape, and
+       ;; `make-frame-generation-seal-race-jvm-test` §4 keeps it pinned.
        ;;
        ;; The armed flush is the RESILIENT sweep — per-frame conditional (a frame
        ;; whose composition re-resolves identically is left untouched, a

--- a/implementation/core/test/re_frame/make_frame_generation_pool_window_jvm_test.clj
+++ b/implementation/core/test/re_frame/make_frame_generation_pool_window_jvm_test.clj
@@ -1,0 +1,247 @@
+(ns re-frame.make-frame-generation-pool-window-jvm-test
+  "rf2-rt4jz — a frame's GENERATION and the POOL that generation was resolved
+  against must never be observable OUT OF STEP.
+
+  THE WINDOW. `re-frame.live-frame/make-frame` does two things in order:
+
+      (frame/upsert-frame! runnable-id record-config token-box) ;; INSTALL the generation
+      (record-frame-generation-pool! runnable-id descriptors)   ;; RECORD the pool it came from
+
+  Between them the record already carries the NEW generation while the
+  provenance row (rf2-rf3zgt — `frame-generation-pool`, the per-frame row naming
+  WHICH descriptor pool a generation was resolved against) still names the pool
+  of some PREVIOUS incarnation, or names nothing at all. Anything that reprojects
+  the frame inside that window re-resolves its composition against the WRONG pool
+  and `frame/set-generation!`s the result over the generation the constructor
+  had just installed. The constructor returns having silently lost its own swap.
+
+  AND SOMETHING DOES REPROJECT INSIDE IT — synchronously, on the constructing
+  thread, on BOTH hosts. `upsert-frame!` runs the `:initial-events` setup steps
+  (EP-0027) INSIDE the call, after the record is published. Those steps dispatch,
+  so they go through `call-with-frame-resolution`, whose read-time consult
+  flushes any PENDING reprojection (rf2-h1vqa4 / rf2-9c2jf). That flush is the
+  reprojection, and it runs while the provenance row is still stale.
+
+  So the reproduction below needs NO threads and NO barrier — unlike its sibling
+  `make-frame-generation-seal-race-jvm-test` (rf2-djkr0), whose window is a
+  genuine two-thread race. This one is a plain ordering wart, reachable by a
+  single synchronous call:
+
+    1. `:pool-window/target` is created against explicit pool V1 and destroyed —
+       the provenance row survives the destroy (documented residue: there is no
+       destroy-time cleanup hook, and a REUSED id's row is supposed to be
+       overwritten by the next `make-frame`).
+    2. A `reg-*` arms `pending-reprojection?` (an image-loaded decoy frame is
+       standing, so the hook does not take its no-image-loaded-frame skip; on the
+       JVM `mark-dirty-and-schedule!` schedules no tick, so the flag simply
+       waits for the next resolution).
+    3. `:pool-window/target` is re-created against explicit pool V2, carrying
+       `:initial-events`. The setup cascade flushes → the sweep reaches the
+       just-published frame → reads the row, which still says V1 → re-resolves
+       against V1 and swaps THAT over the V2 generation.
+
+  PRE-FIX the constructor returns a frame running the V1 descriptors it was
+  never asked for. POST-FIX the row is written BEFORE the engine commit (and
+  rolled back exactly on failure, preserving rf2-ktmto9's no-residue contract
+  EXPLICITLY rather than by ordering), so the cascade's flush re-resolves the
+  frame against the pool it was actually sealed from — a byte-for-byte identical
+  generation, hence no swap at all.
+
+  WHY THE `_jvm_test` SUFFIX WHEN THE DEFECT IS COMMON. The defect is NOT
+  JVM-only — the read-time flush in `call-with-frame-resolution` is synchronous
+  on both hosts, so CLJS reaches the same clobber inside the same synchronous
+  `make-frame` call (this is the rf2-djkr0 relationship INVERTED: that one was a
+  JVM-only race with a common-code repair; this one is a common-code defect).
+  The CLJS side is covered where the wart was first observed —
+  `live-frame-reload-cljs-test/reload-swaps-generation-preserving-frame-memory`,
+  which rides `npm run test:cljs` and reddens under an unconditional
+  construction-path dirty mark. This namespace is the DETERMINISTIC, defect-
+  specific reproduction, and it is JVM-scoped so it can arm the dirty flag
+  without racing a scheduled `next-tick` flush (CLJS schedules one; the JVM does
+  not — `mark-dirty-and-schedule!`).
+
+  See also `make-frame-generation-seal-race-jvm-test` §4, which pins that
+  rf2-djkr0's construction-path dirty mark is CONDITIONAL. That conditionality
+  is what keeps this wart out of the ordinary quiet-construction path; it is not
+  what closes the wart, and it stays exactly as it is."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [re-frame.core :as rf]
+            [re-frame.events :as events]
+            [re-frame.image :as image]
+            [re-frame.image-assembly :as asm]
+            [re-frame.live-frame :as lf]
+            [re-frame.substrate.plain-atom :as plain-atom]
+            [re-frame.test-support :as test-support]))
+
+;; ---------------------------------------------------------------------------
+;; White-box handles. The whole defect lives in the relationship between two
+;; PRIVATE pieces of process-local bookkeeping — the coalescing dirty flag and
+;; the generation-provenance table — so the reproduction observes both directly,
+;; exactly as `make-frame-generation-seal-race-jvm-test` does.
+;; ---------------------------------------------------------------------------
+
+(def ^:private dirty-flag #'lf/pending-reprojection?)
+(def ^:private provenance #'lf/frame-generation-pool)
+
+(defn- pool-row [id] (get (deref @provenance) id))
+
+(use-fixtures :each
+  (test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+  (fn [t]
+    ;; A flag left dirty by an earlier case would have this case's FIRST
+    ;; resolution flush — repairing (or provoking) the staleness for the wrong
+    ;; reason and reporting a result that proves nothing. Clear either side.
+    (reset! @dirty-flag false)
+    ;; The provenance table is process-local `defonce` bookkeeping that no
+    ;; fixture resets (a destroyed id's row deliberately survives). Clear this
+    ;; namespace's own ids so a re-run inside one JVM starts from the documented
+    ;; "no row" state.
+    (swap! @provenance dissoc :pool-window/target :pool-window/decoy :pool-window/rollback)
+    (t)
+    (reset! @dirty-flag false)))
+
+;; ---------------------------------------------------------------------------
+;; Two explicit descriptor pools selected by the SAME image — the reload shape
+;; (`live-frame-reload-cljs-test`'s pools, renamed for this namespace). Both
+;; carry the frame's namespace, so a reprojection against the WRONG one resolves
+;; happily rather than zero-matching: the clobber is SILENT, which is precisely
+;; what makes it worth a regression test.
+;; ---------------------------------------------------------------------------
+
+(defn- reg-desc [provenance-ns kind id impl]
+  {:rf.provenance/ns provenance-ns
+   :kind             kind
+   :id               id
+   :handler-fn       impl})
+
+(def ^:private pool-v1
+  [(reg-desc "pool.window.core" :event :pool-window/inc ::inc-v1)])
+
+(def ^:private pool-v2
+  [(reg-desc "pool.window.core" :event :pool-window/inc   ::inc-v2)
+   (reg-desc "pool.window.core" :event :pool-window/reset ::reset)])
+
+(def ^:private img
+  (image/image {:id :pool-window/img :select-ns {:include ["pool.window.core"]}}))
+
+(defn- inc-impl
+  "The `:pool-window/inc` implementation the frame's CURRENT generation resolves
+  — `::inc-v1` when the frame is running pool V1, `::inc-v2` for pool V2. The
+  one-line discriminator between the pool the constructor asked for and the pool
+  a stale provenance row reprojected it onto."
+  [id]
+  (:handler-fn (asm/resolve-descriptor (lf/frame-generation id) :event :pool-window/inc)))
+
+;; ---------------------------------------------------------------------------
+;; 1. THE REPRODUCTION.
+;; ---------------------------------------------------------------------------
+
+(deftest initial-events-cascade-does-not-reproject-onto-the-previous-pool
+  (testing "a make-frame whose :initial-events cascade flushes a pending
+            reprojection returns the generation it sealed — the flush sees the
+            pool the constructor is installing, not the row left by a previous
+            incarnation of the same id"
+    ;; `:initial-events` dispatches `:rf/set-db`, which must resolve through the
+    ;; frame's OWN sealed generation (the framework-standard registry is unioned
+    ;; into every assembly). Idempotent.
+    (events/register-set-db-standard!)
+
+    ;; A standing image-loaded frame, so the registration hook below does NOT
+    ;; take `mark-dirty-and-schedule!`'s no-image-loaded-frame skip (rf2-h4q6cy).
+    (rf/make-frame {:id :pool-window/decoy})
+
+    ;; The id's FIRST incarnation, against pool V1. Destroying it leaves the
+    ;; provenance row behind — the documented residue the next `make-frame`
+    ;; against this id is supposed to overwrite.
+    (lf/make-frame {:id :pool-window/target :images [img]} pool-v1)
+    (is (= ::inc-v1 (inc-impl :pool-window/target))
+        "control: the first incarnation resolved against pool V1")
+    (rf/destroy-frame! :pool-window/target)
+    (is (= pool-v1 (pool-row :pool-window/target))
+        "control: the destroyed id's provenance row still names pool V1")
+
+    ;; ARM the coalesced reprojection. On the JVM this schedules no tick — the
+    ;; flag waits for the next resolution, which will be the setup cascade's.
+    (reset! @dirty-flag false)
+    (rf/reg-event :pool-window/armer (fn [{:keys [db]} _] {:db db}))
+    (is (true? @@dirty-flag)
+        "control: a reprojection is pending as the constructor is entered")
+
+    ;; THE CONSTRUCTION UNDER TEST. Its `:initial-events` step dispatches inside
+    ;; `upsert-frame!`, whose `call-with-frame-resolution` consult flushes the
+    ;; pending reprojection while the frame is published but its provenance row
+    ;; is (pre-fix) still the destroyed incarnation's.
+    (lf/make-frame {:id             :pool-window/target
+                    :images         [img]
+                    :initial-events [[:rf/set-db {:seeded true}]]}
+                   pool-v2)
+
+    (is (= ::inc-v2 (inc-impl :pool-window/target))
+        (str "the constructor's own generation survived its :initial-events "
+             "cascade — pre-fix the cascade's flush reprojected the frame "
+             "against the PREVIOUS incarnation's pool (V1) and swapped that "
+             "over the V2 generation the constructor had just installed"))
+    (is (some? (asm/resolve-descriptor (lf/frame-generation :pool-window/target)
+                                       :event :pool-window/reset))
+        "the V2-only registration is resolvable — the frame is running V2")
+    (is (= pool-v2 (pool-row :pool-window/target))
+        "the provenance row names the pool the frame is actually running")
+    (is (= {:seeded true} (rf/app-db-value :pool-window/target))
+        "the setup cascade itself still ran (the flush is not being skipped)")))
+
+;; ---------------------------------------------------------------------------
+;; 2. THE SAME WINDOW WITHOUT :initial-events. The clobber needs a resolution
+;;    inside `upsert-frame!` to trigger it, and `:initial-events` is the only
+;;    one on the construction path — so a construction with no setup steps must
+;;    come through unharmed both before AND after the fix. This case exists so
+;;    the reproduction above cannot be mistaken for "re-construction is broken":
+;;    it pins the trigger precisely.
+;; ---------------------------------------------------------------------------
+
+(deftest construction-without-setup-steps-was-never-in-the-window
+  (testing "with no :initial-events there is no in-upsert resolution to flush
+            the pending reprojection, so the constructor's generation stands —
+            the trigger is the setup cascade, not re-construction itself"
+    (rf/make-frame {:id :pool-window/decoy})
+    (lf/make-frame {:id :pool-window/target :images [img]} pool-v1)
+    (rf/destroy-frame! :pool-window/target)
+    (reset! @dirty-flag false)
+    (rf/reg-event :pool-window/armer-2 (fn [{:keys [db]} _] {:db db}))
+    (is (true? @@dirty-flag) "control: a reprojection is pending")
+    (lf/make-frame {:id :pool-window/target :images [img]} pool-v2)
+    (is (= ::inc-v2 (inc-impl :pool-window/target)))))
+
+;; ---------------------------------------------------------------------------
+;; 3. THE ROLLBACK. Moving the provenance write AHEAD of the engine commit is
+;;    only safe because the write is UNDONE exactly when the commit fails —
+;;    rf2-ktmto9's contract (a failed creation records nothing; a failed
+;;    re-construction preserves the OLD row) now holds by explicit rollback
+;;    rather than by ordering. `live-frame-reload-cljs-test` pins the contract's
+;;    OBSERVABLE consequence (reprojection still resolves against the original
+;;    pool); these two pin the row itself, which is the thing the fix moved.
+;; ---------------------------------------------------------------------------
+
+(deftest failed-re-construction-restores-the-previous-provenance-row
+  (testing "a re-make-frame that fails in the engine leaves the provenance row
+            exactly as the successful creation left it — the early write is
+            rolled back, not merely overwritten later"
+    (lf/make-frame {:id :pool-window/rollback :images [img]} pool-v1)
+    (is (= pool-v1 (pool-row :pool-window/rollback)) "control: V1 recorded")
+    (is (thrown? clojure.lang.ExceptionInfo
+                 ;; `:on-create` is retired and fails loud INSIDE the engine —
+                 ;; i.e. after the early provenance write, which is the branch
+                 ;; the rollback exists for.
+                 (lf/make-frame {:id :pool-window/rollback :on-create [:boom]} pool-v2)))
+    (is (= pool-v1 (pool-row :pool-window/rollback))
+        "the failed re-construction preserved the ORIGINAL provenance row")))
+
+(deftest failed-first-construction-leaves-no-provenance-row
+  (testing "a FIRST make-frame that fails in the engine leaves NO row behind —
+            the early write is removed, not left as residue for an id that
+            never became a frame"
+    (is (not (contains? (deref @provenance) :pool-window/never))
+        "control: the id has no row")
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (lf/make-frame {:id :pool-window/never :on-create [:boom]} pool-v1)))
+    (is (not (contains? (deref @provenance) :pool-window/never))
+        "the failed creation recorded nothing")))


### PR DESCRIPTION
Closes rf2-rt4jz.

## The defect

`make-frame` wrote the generation-provenance row (rf2-rf3zgt — which descriptor pool a frame's generation was resolved against) **after** the `upsert-frame!` engine commit returned. That reads as the safer order, and it is the order rf2-ktmto9 deliberately chose: a failed construction cannot leave residue if it never writes.

It is nonetheless wrong, because the record and the row are **two stores**, and the frame is REPROJECTABLE the moment the first of them lands. `upsert-frame!` publishes the record carrying the new generation and then, still inside the call, runs the `:initial-events` setup steps (EP-0027). Those steps dispatch, so they pass through `call-with-frame-resolution`, whose read-time consult flushes any pending reprojection (rf2-h1vqa4 / rf2-9c2jf). That flush read a row belonging to a PREVIOUS incarnation of the id, re-resolved the frame's composition against that pool, and `set-generation!`d the result over what the constructor had just installed.

The constructor returned having silently lost its own swap — with the **row** ending up correct and the **generation** wrong, which is what made it invisible.

**Not a race, and not JVM-only.** One synchronous call reaches it on both hosts: the read-time flush is synchronous everywhere and the deferred tick is not involved. This is rf2-djkr0 inverted — that was a JVM-only race with a common-code repair; this is a common-code defect with a common-code repair.

## Reproduced first

`implementation/core/test/re_frame/make_frame_generation_pool_window_jvm_test.clj` — no threads, no barrier, unlike its rf2-djkr0 sibling. Create `:pool-window/target` against pool V1, destroy it (the row survives — documented residue), arm `pending-reprojection?` with a `reg-*` while a decoy frame stands, re-create the id against pool V2 with `:initial-events`.

```
BEFORE (278088ea, reproduction alone)      exit=1
  expected: ::inc-v2   actual: ::inc-v1
  the V2-only :pool-window/reset is not resolvable at all
  Ran 4 tests containing 15 assertions. 2 failures, 0 errors.

AFTER  (27cc6d5c, + the fix)               exit=0
  Ran 4 tests containing 15 assertions. 0 failures, 0 errors.
```

Two scope guards ship with it so the reproduction cannot be misread. §2 pins that a construction with **no** setup steps is unaffected — the trigger is precisely the `:initial-events` cascade, not re-construction itself. §3 pins rf2-ktmto9's no-residue contract at the row level, which is the thing the fix moved.

## The fix, and what it does not buy

Write the row **before** the commit; roll it back **exactly** on failure. rf2-ktmto9's contract is then stated rather than implied — `restore-frame-generation-pool!` distinguishes "no row" from "a row whose value is nil", which matters because `nil` is a legitimate recorded pool meaning "the live source store". With the row written first, the setup cascade's flush re-resolves the frame against the pool it was actually sealed from: a byte-for-byte identical generation, hence no swap at all.

Named at the site rather than left for the next audit to find: on a **re**-construction the row names the incoming pool for the brief interval before `upsert-frame!`'s surgical swap installs the incoming generation, so a JVM-concurrent flush landing in THAT interval re-resolves the outgoing composition against the incoming pool. Transient and self-correcting — the swap that follows overwrites it unconditionally, so no completed call can observe it — where the window it replaces corrupted the value the constructor **returned**. Residual exposure is at worst one spurious `:rf.warning/reprojection-failed` on the dev diagnostic channel.

Reordering was not assumed to be the answer: flushing at the top of `make-frame` only narrows the window (a JVM `reg-*` re-arms inside it) and does nothing for the concurrent instance, and suppressing the flush for the frame under construction needs a counted under-construction table to be exact under same-id contention. Making the two writes one write is what actually closes it.

## rf2-djkr0's conditional mark is UNCHANGED — and here is why, measured

#7188's mark is conditional on the registration pool having moved. One of its two justifications was **this** wart. That leg is now gone, and the closure is measured rather than assumed — the full 2×2:

| | provenance written AFTER commit | provenance written BEFORE commit |
|---|---|---|
| **conditional mark** (shipped) | reload suite green; new reproduction **RED** | reload suite green; reproduction **green** |
| **unconditional mark** | `reload-swaps-generation-preserving-frame-memory` **RED** at lines 152–153 | **green** |

So the unconditional form is now genuinely safe. It is **not** adopted: the conditional's other justification stands on its own — an unconditional mark arms a full reprojection sweep over every image-loaded frame after *every* construction, which is a cost, not a simplification. The comment at the site now says which leg it stands on, and `make-frame-generation-seal-race-jvm-test` §4 keeps it pinned.

## Invariants

*A partially-constructed frame must never be observable as live* — kept, and kept stated. The fix strengthens it: the row is now in step for the whole interval in which the record can be reprojected, instead of only after the constructor returns.

**No spec promise moved.** `spec/` and `docs/` are untouched; the provenance table is private process-local bookkeeping (`defonce` atom, `^:private`), and nothing about frame construction or `:initial-events` ordering as specified changes. `:initial-events` still runs synchronously inside the commit, in order, before `:rf.frame/created`.

**Platform.** The change is common `.cljc`. CLJS **is** affected by the defect (the read-time flush is synchronous on both hosts) and is fixed by the same code — unlike rf2-djkr0, which was a JVM-only defect with common-code repair.

## Quality gates

Run foreground from `C:/Users/miket/code/re-frame2-worktrees/initial-events-rt4jz`, logs worktree-local, never piped.

| gate | result |
|---|---|
| `clojure -M:test` (core dev posture) | **exit 0** — 2163 tests, 10745 assertions, 0 failures, 0 errors |
| `bash scripts/test-core-prod-gate.sh` (`-Dre-frame.debug=false`) | **exit 0** — 1196 tests, 5530 assertions, 0 failures, 0 errors; **102 namespaces** (101 + this PR's new one — the transitive `egress_chokepoint_conformance_test` source-scan lane did not regress) |
| `clojure -M:test:slow-test` (`^:stress`) | **exit 0** — 4 tests, 8 assertions, 0 failures, 0 errors (run because the fix touches shared process-local state) |
| reproduction, before the fix | **exit 1** — 2 failures, as quoted above |
| reproduction, after the fix | **exit 0** |
| neighbouring suites (`live-frame-reload-cljs-test`, `live-frame-cljs-test`, `hot-reload-test`, `make-frame-generation-seal-race-jvm-test`, `reprojection-install-race-jvm-test`) | **exit 0** — 47 tests, 231 assertions |

**Deferred to CI:** `npm run test:cljs`. The worktree has no `node_modules` and installing one is slower than the lane is worth locally. The suite that matters there — `live-frame-reload-cljs-test` — is `.cljc` and also rides `clojure -M:test`, where it was exercised in all four configurations of the table above.
