### PR TITLE
bench,fix: the two-clock envelope under :advanced, and story-mcp's byte-equality row (rf2-drpa3.182.15, rf2-zrdog)

### DIFF
--- a/docs/design/freehand/studio/two-clock-operating-envelope.md
+++ b/docs/design/freehand/studio/two-clock-operating-envelope.md
@@ -1,12 +1,14 @@
 # The two-clock operating envelope — DC-09, measured
 
-Bead: `rf2-drpa3.182.12`. Owner of the claim: **DC-09** in
+Beads: `rf2-drpa3.182.12` (the development reading), `rf2-drpa3.182.15` (the
+production reading). Owner of the claim: **DC-09** in
 [`../product-completion-setpoint.md`](../product-completion-setpoint.md).
 Owner of the method:
 [`../decisions/D021-performance-budgets-and-release-evidence.md`](../decisions/D021-performance-budgets-and-release-evidence.md).
 Instrument:
-`implementation/freehand/test/re_frame/freehand/bench/b10_two_clock.cljs`
-and its rows next door in `b10_two_clock_dom_cljs_test.cljs`.
+`implementation/freehand/test/re_frame/freehand/bench/b10_two_clock.cljs`,
+its rows next door in `b10_two_clock_dom_cljs_test.cljs`, and the production
+entry and driver in `b10_prod_app.cljs` / `b10_prod_run.cjs`.
 
 **This is measurement, not a law.** No `FH-…` id is minted and nothing enrols
 in the conformance roster. The deterministic property the numbers sit on top
@@ -17,44 +19,66 @@ is new here is the *ladder* (0, 1, 10, 50, 200 contending siblings rather than
 a single dozen) and the distributions beside it.
 
 **The recommendation, up front: add no scheduling, throttle, debounce,
-coalescing, equality or preview vocabulary.** Section 7 gives the three
-attributed reasons. One material bottleneck did repeat in two witnesses, and
-its remedy is a call-site change, not an API.
+coalescing, equality or preview vocabulary.** Section 8 gives the attributed
+reasons, and the production reading strengthens every one of them. One
+bottleneck did repeat in two witnesses; its remedy is a call-site change, not
+an API, and production shrank it by an order of magnitude without changing its
+shape.
+
+**And the headline the production reading changed: 120 Hz clears its latency
+budget at every rung of the ladder, including 200 dirty siblings.** In a
+development build it cleared none of them. Section 6 restates the envelope.
 
 ---
 
 ## 1. Provenance
 
-Every figure below comes from one run, at one revision, in one browser.
+Every figure below comes from one of three arms, at one revision each, in one
+browser. The arms differ in the *bundle* and in nothing else that was measured:
+same fixture, same instrument, same constants (4 rounds, 10 samples after 3
+warm-ups, arm order rotating, ladder walked both ways), same machine, same
+Chrome.
 
-| | |
-|---|---|
-| Revision | `e2b4225d6be141c7efaaf9c59e8f45c0425b286f` |
-| Build | shadow-cljs `:browser-test`, `:optimizations :none`, `goog.DEBUG true` (`:instrumentation? true`) |
-| Runtime | **HeadlessChrome 147.0.7727.15**, Windows 11 x64 |
-| Hardware class | `:developer-workstation` |
-| D021 status | `:d021 :release-evidence` — the record passed `provenance/result` |
-| Raw records | `ai/findings/2026-07-28.two-clock-envelope-raw.edn` (local-only) |
-| Gate result | 30 tests, 466 assertions, 0 failures, 0 errors |
+| | **A — development** | **B — ablation** | **C — production** |
+|---|---|---|---|
+| Optimisations | `:none` | `:advanced` | `:advanced` |
+| `goog.DEBUG` | true | **true** | **false** |
+| Instrumentation | live | live | elided |
+| Build id | `:browser-test-freehand-bench` | `:freehand-release` + config-merge | `:freehand-release` + config-merge |
+| Entry | `b10-two-clock-dom-cljs-test` | `b10-prod-app` | `b10-prod-app` |
+| Revision | `e2b4225d6be141c7efaaf9c59e8f45c0425b286f` | `993533f2cca47bc3316e1be51997224f5b914d3c` | `993533f2cca47bc3316e1be51997224f5b914d3c` |
+| Runs | 1 published (2 more reproduced it) | 1 | **3** |
+| Raw records | `ai/findings/2026-07-28.two-clock-envelope-raw.edn` | `…two-clock-debug-1.edn` | `…two-clock-prod-{1,2,3}.edn` |
 
-Two earlier runs at the same fixture reproduced every figure below to within
-the round-to-round spread, so nothing here rests on a single sample of the
-machine.
+Runtime for all three: **HeadlessChrome 147.0.7727.15**, Windows 11 x64,
+hardware class `:developer-workstation`. Arm C's records carry
+`:d021 :release-evidence`; arm B's revision is real but its record reports
+`:optimizations :none`, because `provenance/detect-build` infers the optimiser
+from `goog.DEBUG` and cannot see the difference — **arm B is labelled by its
+build command, not by its own record**, and that is the one provenance claim
+here the run does not self-check.
+
+### Why arm B exists
+
+Arms A and C differ in three things at once — the optimiser, the
+instrumentation define, *and* the build id, page and runner. Reading the whole
+gap as "`:advanced` is faster" would attribute to the optimiser what might be
+any of them. Arm B changes exactly one define against arm C: same entry, same
+page, same driver, same optimiser, `goog.DEBUG` flipped back on. **The A→B step
+is the optimiser and the harness; the B→C step is the Spec 009 instrumentation
+seam alone.** Section 3 shows the two steps are not the same size and do not
+act on the same half of the crossing.
 
 ### What does not transfer
 
-**These are Chrome numbers under a development build.** Both words matter.
+**These are Chrome numbers.** No figure here is quoted for Node or for the
+JVM, and none should be. Absolutes do not transfer across runtimes; the
+*shares* — event flat, commit scaling, read-site constant, backlog invariant —
+are the transferable claims.
 
-*Chrome.* No figure here is quoted for Node or for the JVM, and none should
-be. Absolutes do not transfer across runtimes.
-
-*Development build.* `goog.DEBUG` is true, so the Spec 009 instrumentation
-seam, schema validation and trace emission are all live on exactly the event
-path this report measures. B6 records the same hazard against its own rows and
-takes its published numbers from an `:advanced` bundle instead. **Every cost
-here is therefore an upper bound, and every rate a lower bound, on what a
-shipped application does.** The production reading was not taken — see
-section 8.
+The development figures are retained throughout rather than replaced, because
+the **gap between them and production is itself the measurement**: it is what
+the instrumentation seam costs, and it is worth publishing once.
 
 ---
 
@@ -73,11 +97,12 @@ t0 ──flushSync[ rf/dispatch-sync ──t1── (React render + commit) ]─
 acceptance criterion 3, and section 4 is the reason it was worth doing.
 
 **Every measured crossing is read back out of the DOM inside its own window,
-and one that did not land is counted rather than dropped.** The row reports
-**0 unverified of 800** (section 3) and **0 unverified of 640** (section 5).
-That rule is not decorative: B6 records a first pass that timed writes inside
-`flushSync` which never reached the page at all and returned entirely
-reasonable milliseconds for them.
+and one that did not land is counted rather than dropped.** Every arm reports
+**0 unverified of 800** (section 3) and **0 unverified of 640** (section 5) —
+including all three production runs and the ablation run, so **0 unverified of
+5760 crossings across the whole report**. That rule is not decorative: B6
+records a first pass that timed writes inside `flushSync` which never reached
+the page at all and returned entirely reasonable milliseconds for them.
 
 The `:fresh-equal` arm, whose whole point is that the page must **not** change,
 cannot be verified by the page standing still — an arm that did nothing would
@@ -89,31 +114,53 @@ must have moved and the value must not have.
 A busy-wait of exactly **4.00 ms** rides in every cell of every table, timed
 through the same window.
 
-| | predicted | measured |
-|---|---|---|
-| Standalone, n = 12 | 4.00 ms | min 4.0, p50 4.0, p95 4.0, p99 4.0, max 4.0 |
-| Inside all 40 published M1 cells | 4.00 ms | p50 4.0 everywhere; p95 4.0–4.3 |
+| | predicted | measured (dev) | measured (production) |
+|---|---|---|---|
+| Standalone, n = 12 | 4.00 ms | min 4.0, p50 4.0, p95 4.0, p99 4.0, max 4.0 | identical, in all three runs |
+| Inside all 40 published M1 cells | 4.00 ms | p50 4.0 everywhere; p95 4.0–4.3 | p50 4.0 everywhere; p95 4.0–4.4 |
 
-Overshoot at p50 was **0.0 ms**, and never exceeded 0.3 ms anywhere. That is
-clock quantisation with nothing left over: **the machine was not contended
-while these numbers were taken.** Had it been, the burn arm would have said so
-in every table simultaneously, which is exactly why it is in every table.
+Overshoot at p50 was **0.0 ms** in every arm, and never exceeded 0.4 ms
+anywhere. That is clock quantisation with nothing left over: **no arm was
+measured on a contended machine.** Had one been, the burn arm would have said
+so in every table simultaneously, which is exactly why it is in every table —
+and it is what lets the production numbers below be read as a substrate result
+rather than as an idle box.
+
+`:below-predicted` was **0 of 12** in every production run: no sample read
+under its own computed duration, so the window measures what it brackets under
+`:advanced` too.
 
 ### C2 — a control of computed size
 
 Each mode's DOM mutation count is arithmetic over the fixture, and is compared
 against what a `MutationObserver` measured. Predicted equalled measured at
-**every one of the fifteen (mode × rung) combinations**, with zero spread:
+**every one of the fifteen (mode × rung) combinations, in every arm**, with
+zero spread:
 
-| mode | predicted | measured |
+| mode | predicted | measured (dev and production) |
 |---|---|---|
 | `:host-only` | 1 attribute | 1, at every rung |
 | `:fresh-equal` | 0 | 0, at every rung |
 | `:one-leaf` at k siblings | k + 1 | 1, 2, 11, 51, 201 |
 
-The driven arm (section 6) reproduces it independently: at k = 200 it recorded
-4221 mutations for 21 crossings, 6030 for 30, 6633 for 33 and 6834 for 34 —
-**exactly 201.0 per crossing in all four**.
+Under `:advanced` this control does a second job it does not do under `:none`:
+it is the **externs check**. `MutationObserver.takeRecords`, a record's
+`.type`, `element.style.transform` and `setAttribute` all have to survive
+Closure renaming for these counts to come out right, and the per-crossing DOM
+read-back has to keep finding its nodes. Fifteen exact matches and 0 unverified
+of 800 say they did. A renaming failure here would not have been subtle — it
+would have been zero mutations everywhere, which is exactly the shape of the
+fastest possible wrong answer.
+
+The driven arm (section 6) reproduces it independently, in both bundles. In
+development, at k = 200: 4221 mutations for 21 crossings, 6030 for 30, 6633 for
+33 and 6834 for 34. In production, where the driven arm delivered several times
+as many crossings: 4020 for 20, 8643 for 43, 17487 for 87 and 34371 for 171 —
+**exactly 201.0 per crossing in all eight, across a 8.5× range of crossing
+counts**. A different window, a different clock and a different call site
+agreeing to three significant figures with the fixture's arithmetic is the
+strongest statement this report can make that the thing being timed is the
+thing being described.
 
 ---
 
@@ -122,46 +169,83 @@ The driven arm (section 6) reproduces it independently: at k = 200 it recorded
 300 cells, one of them the leaf; `k` names how many siblings the application
 chose to dirty alongside it. Ranges are across **four rounds** — two walking
 the ladder ascending, two descending — of 10 measured samples each after 3
-warm-ups, with arm order rotating on the sample index. **0 unverified of 800.**
+warm-ups, with arm order rotating on the sample index. **0 unverified of 800,
+in every arm.**
 
-| k | host-only p50 | fresh-equal p50 | **one-leaf p50** | **one-leaf p95** | event p50 | commit p50 | DOM mutations |
+### The shipped cost
+
+Production ranges are the union across **three independent runs** (twelve
+rounds); development is the published single run.
+
+| k | **one-leaf p50, production** | one-leaf p50, dev | **one-leaf p95, production** | one-leaf p95, dev | host-only | fresh-equal (prod) | DOM mutations |
 |---:|---|---|---|---|---|---|---:|
-| 0 | ≤ 0.1 | 0.2–0.3 | **3.5–4.6** | 5.9–9.2 | 3.1–4.2 | 0.4–0.5 | 1 |
-| 1 | ≤ 0.1 | 0.2–0.3 | **3.4–4.8** | 5.3–10.4 | 2.9–4.0 | 0.5–0.7 | 2 |
-| 10 | ≤ 0.1 | 0.2–0.3 | **4.3–5.1** | 6.5–10.7 | 3.2–3.9 | 1.0–1.2 | 11 |
-| 50 | ≤ 0.1 | 0.2 | **6.9–7.8** | 10.5–12.0 | 3.3–3.8 | 3.5–4.0 | 51 |
-| 200 | ≤ 0.1 | 0.2–0.3 | **18.3–22.2** | 21.9–27.5 | 3.7–4.1 | 13.0–17.5 | 201 |
+| 0 | **0.3–0.5** | 3.5–4.6 | **0.4–2.3** | 5.9–9.2 | ≤ 0.1 | ≤ 0.1 | 1 |
+| 1 | **0.3–0.5** | 3.4–4.8 | **0.5–1.2** | 5.3–10.4 | ≤ 0.1 | ≤ 0.2 | 2 |
+| 10 | **0.4–0.7** | 4.3–5.1 | **0.5–2.0** | 6.5–10.7 | ≤ 0.1 | ≤ 0.1 | 11 |
+| 50 | **0.9–1.2** | 6.9–7.8 | **1.1–2.4** | 10.5–12.0 | ≤ 0.1 | ≤ 0.1 | 51 |
+| 200 | **2.6–3.6** | 18.3–22.2 | **3.3–5.1** | 21.9–27.5 | ≤ 0.1 | 0.1 | 201 |
 
-All figures milliseconds, Chrome, dev build.
+All figures milliseconds, Chrome.
 
-Four things this table says.
+**The measured development-to-production factor is 6.0× to 11.6×**, largest at
+the empty end of the ladder and smallest at the loaded end. Per-run p50 factors
+were 5.96–11.57×; the three production runs agreed to within 0.4 ms at every
+rung, so the factor is a property of the bundle rather than of one afternoon.
 
-**The host clock is free, and it is free at every rung.** The `:host-only` arm
-— a behavior writing its own node's transform, with nothing crossing into
-`app-db` — reads at or below Chrome's 0.1 ms `performance.now()` clamp in all
-40 readings. Its cost is *"under 0.1 ms"*, not *"zero"*; the instrument cannot
-see smaller. Its **flatness** is asserted as a gate: a host arm that rose with
-`k` would mean the sibling knob was leaking into the one arm that must not feel
+### Where the factor comes from — and it is not mostly the optimiser
+
+The event/commit split answers this directly, which is why the crossing was
+never measured as a single number.
+
+| k | event p50: A dev → B ablation → **C production** | commit p50: A → B → **C** |
+|---:|---|---|
+| 0 | 3.1–4.2 → 2.8–3.8 → **0.2–0.3** | 0.4–0.5 → 0.1–0.2 → **0.0–0.1** |
+| 200 | 3.7–4.1 → 3.6–4.1 → **0.6–0.7** | 13.0–17.5 → 5.7–6.8 → **2.2–2.5** |
+
+**The flat 3–4 ms event half was the instrumentation seam, essentially in its
+entirety.** `:advanced` on its own (A→B) barely moves it — 3.1–4.2 becomes
+2.8–3.8 at k = 0, and at k = 200 it does not move at all. Flipping `goog.DEBUG`
+false (B→C) collapses it to 0.2–0.3 ms, a factor of about **13×**. The router,
+the interceptor chain, the reducer, the `app-db` install and the notification
+of 300 subscriptions together cost **under a third of a millisecond** in a
+shipped bundle; what the development build was timing was Spec 009's trace
+emission and schema validation sitting on that path.
+
+**The commit half benefits from both, roughly evenly.** At k = 200 the
+optimiser takes 13–17.5 ms to 5.7–6.8 (≈ 2.5×) and the define takes that to
+2.2–2.5 (≈ 2.6×). React's render and DOM mutation are real work in both
+bundles; they are simply cheaper compiled and cheaper without instrumentation
+hooks interleaved.
+
+**So the shape of the claim survives and its magnitude does not.** The event
+half is still flat across the ladder (0.2–0.3 → 0.6–0.7 ms) and the commit half
+is still what scales — but the crossing is now **commit-dominated at every rung
+above k = 10**, where in the development build it was event-dominated below
+k = 50. In production, *"if a crossing is expensive, it is expensive in React"*
+is true almost everywhere; the per-dirtied-cell commit cost is about **0.012
+ms**, down from 0.085.
+
+### The arms that were already free stayed free
+
+**The host clock is free, and it is free at every rung and in every arm.** The
+`:host-only` arm — a behavior writing its own node's transform, with nothing
+crossing into `app-db` — reads at or below Chrome's 0.1 ms `performance.now()`
+clamp in all 40 readings of all five runs. Its cost is *"under 0.1 ms"*, not
+*"zero"*; the instrument cannot see smaller, in either bundle. Its **flatness**
+is a gate: measured spread across the ladder was **0.0 ms** in every production
+run.
+
+**A fresh-but-`rf=`-equal write cost 0.2–0.3 ms in development and now sits on
+the clock clamp**, ≤ 0.1 ms at every rung, still with 0 DOM mutations every
+time and the store reference still demonstrably moved. It was the most
+load-bearing number in the report; production made it smaller than the
+instrument can resolve, which strengthens section 8 rather than complicating
 it.
 
-**A fresh-but-`rf=`-equal write costs 0.2–0.3 ms and repaints nothing.** Flat
-across the whole ladder, 0 DOM mutations every time, while the store reference
-demonstrably moved. This is the single most load-bearing number in the report
-and section 7 leans on it.
-
-**The event half is flat; the commit half is what scales.** `:event-ms` sits at
-3–4 ms from k = 0 to k = 200 — the reducer, the install and the notification of
-300 subscriptions cost the same whether one cell moved or 201. `:commit-ms`
-goes 0.4 → 17.5 ms, about **0.085 ms per dirtied cell**. If a crossing is
-expensive, it is expensive in React, not in re-frame.
-
-**Both ladder orders agree.** The ascending and descending ranges overlap at
-every rung except k = 200, where ascending reads ~1–3 ms higher. That
-difference is *not* a ladder-order effect: the per-round p50 declines
-monotonically from round 1 to round 4 at **every** rung in both orders
-(k = 200: 22.2 → 19.8 → 19.1 → 18.3), so it is first-round warm-up that three
-warm-up samples per cell did not fully absorb. Running both orders is what let
-that be said rather than guessed.
+**Both ladder orders agree**, in production as in development. The
+first-round warm-up effect the development run recorded (per-round p50
+declining monotonically at every rung in both orders) is present but far
+smaller in absolute terms, because everything is smaller.
 
 ---
 
@@ -175,30 +259,46 @@ whether the behavior's config subscription is read in the view that also
 builds the 300 cells (`:parent`), or one boundary down inside the behavior's
 own panel (`:leaf`). Same behavior, same config, same cells, same field.
 
-| config shape | leaves | read site | stable p50 | fresh-equal p50 | **one-leaf p50** | DOM mutations |
+| config shape | leaves | read site | **one-leaf p50, production** | one-leaf p50, dev | stable / fresh-equal (prod) | DOM mutations |
 |---|---:|---|---|---|---|---:|
-| Vega-shaped (nested spec) | 96 | parent | 0.2–0.3 | 0.2–0.3 | **39.5–46.4** | 4 |
-| Vega-shaped | 96 | leaf | 0.2–0.3 | 0.2 | **4.9–5.6** | 1 |
-| Spread-shaped (flat range) | 900 | parent | 0.5 | 0.4–0.6 | **60.7–66.4** | 4 |
-| Spread-shaped | 900 | leaf | 0.4 | 0.5 | **18.5–19.2** | 1 |
+| Vega-shaped (nested spec) | 96 | parent | **4.1–4.7** | 39.5–46.4 | ≤ 0.1 / ≤ 0.1 | 4 |
+| Vega-shaped | 96 | leaf | **1.0–1.1** | 4.9–5.6 | ≤ 0.1 / ≤ 0.1 | 1 |
+| Spread-shaped (flat range) | 900 | parent | **13.1–14.5** | 60.7–66.4 | ≤ 0.1 / 0.1–0.2 | 4 |
+| Spread-shaped | 900 | leaf | **10.0–11.1** | 18.5–19.2 | ≤ 0.1 / 0.2 | 1 |
 
-**The read-site penalty is a roughly constant 40–44 ms and does not scale with
-the payload.** Vega pays 45.6 → 5.0; Spread pays 63 → 18.8. That constant is
-the reconciliation of the 300-cell subtree whose parent now depends on a value
-that changed — and it happens while moving *three extra DOM nodes*. The
-cheapest reading of the expensive arm is that it is doing almost no DOM work
-at all; it is re-rendering a subtree to discover that.
+**The read-site penalty survives as a roughly constant term and shrinks by an
+order of magnitude.** In production Vega pays 4.4 → 1.05 and Spread pays
+13.8 → 10.55: a constant of **3.1–3.3 ms**, against 40–44 ms in development.
+The structural claim is the one that transferred — *the penalty does not scale
+with the payload* — and it now holds across a 9× payload range with the two
+constants within 0.2 ms of each other, which is a tighter agreement than the
+development run could show.
 
-Separating the two terms is what the pair bought. Once the read site is
-controlled for, the residual **is** payload size: 96 leaves cost 5.0 ms, 900
-leaves cost 18.8 ms — about **0.017 ms per leaf** for a config that genuinely
-changed.
+What did **not** transfer is the ratio. "Between eight and nineteen times"
+becomes **between 1.3× and 4.2×**: 4.2× at the Vega shape, 1.3× at the Spread
+shape, where the payload term now dominates the read-site term. The advice is
+unchanged and still free; the urgency is not what the development numbers
+implied.
+
+The ablation arm locates the shrink precisely. At the `:parent` read site,
+`:advanced` alone takes Vega from 39.5–46.4 to 14.3–20.2 and Spread from
+60.7–66.4 to 29.4–36.4 — roughly halving each — because that arm's cost is
+subtree reconciliation, which is React work the optimiser compiles. At the
+`:leaf` read site the ablation arm is *no faster than development* (Vega
+6.6–6.7 against 4.9–5.6; Spread 22.3–26 against 18.5–19.2), because there is no
+subtree to reconcile and what remains is the instrumented event half. Only
+`goog.DEBUG false` moves that. **The two halves of the penalty respond to
+different switches**, which is as strong a confirmation of the attribution as
+this fixture can give.
+
+Once the read site is controlled for, the residual **is** payload size: 96
+leaves cost 1.05 ms, 900 leaves cost 10.55 ms — about **0.012 ms per leaf** for
+a config that genuinely changed, down from 0.017.
 
 Compare with section 3: *the same statement* — "one leaf of `app-db` changed"
-— costs **3.5–4.6 ms** when the value is read at the leaf that uses it, and
-**39.5–66.4 ms** when it is read at a parent that also builds a collection.
-Between eight and nineteen times, in the same fixture, in the same build, for
-the same size of change.
+— costs **0.3–0.5 ms** when the value is read at the leaf that uses it and the
+subtree is cells, and **4.1–14.5 ms** when it is read at a parent that also
+builds a collection.
 
 ### Freehand already elides an unchanged config, and it is `=` that decides
 
@@ -206,6 +306,12 @@ The behavior's `:update` was called **exactly 52 times** in each of the four
 (shape × read-site) combinations — which is exactly the number of `:one-leaf`
 crossings (4 rounds × 13 samples). Stable-reference crossings and
 fresh-but-equal crossings both produced **zero** `:update` calls.
+
+**All sixteen counts are 52 under `:advanced` too**, in every arm: four
+combinations × three arms, no exceptions. That matters more than it looks. The
+elision is a behavioural property that could plausibly have been an artefact of
+a dev-only equality check, and it is not — a shipped bundle elides an `:update`
+whose config is equal exactly as the development one does.
 
 So the elision is not identity-based; a deep-fresh copy with no identical
 substructure above its scalar leaves is elided just as a re-installed
@@ -221,14 +327,18 @@ Vega-shaped and Spread-shaped sizes. The answer is in the table above and it
 is a null result of the useful kind:
 
 **Stable-reference and fresh-but-equal are indistinguishable at both shapes and
-both read sites.** 0.2–0.3 ms against 0.2–0.3 ms at 96 leaves; 0.4–0.5 ms
-against 0.4–0.6 ms at 900 leaves. The ranges overlap completely. Neither
-repaints anything. Two `p95` outliers (3.0 ms and 12.7 ms) appeared in earlier
-runs at single samples and did not recur; p50 was unmoved by them.
+both read sites, in both bundles.** In development, 0.2–0.3 ms against
+0.2–0.3 ms at 96 leaves and 0.4–0.5 against 0.4–0.6 at 900. In production both
+arms sit on or below the 0.1 ms clock clamp at 96 leaves, and at 900 leaves
+read ≤ 0.1 against 0.1–0.2 — ranges that overlap or touch, at the resolution
+floor. Neither repaints anything in either bundle.
 
-A full structural walk of a 900-leaf map, then, costs **under a millisecond**,
-and the difference between doing that walk and short-circuiting on identity is
-below what this instrument can resolve. **0 unverified of 640.**
+A full structural walk of a 900-leaf map, then, costs **at most a couple of
+tenths of a millisecond in a shipped bundle**, and the difference between doing
+that walk and short-circuiting on identity remains below what this instrument
+can resolve. Production did not merely preserve the null result; it pushed both
+arms under the clamp, so the conclusion is now limited by Chrome's timer rather
+than by any measurable difference. **0 unverified of 640, in every arm.**
 
 ---
 
@@ -242,53 +352,61 @@ finished before the next offer is made.
 `:expected` is computed — `floor(duration × rate / 1000)` — and is not a
 measurement. It is what the application asked the browser for.
 
-| k | rate asked | **expected** | **offered** | **applied** | **committed** | peak backlog | latency p50 / p95 / p99 | tail |
-|---:|---:|---:|---:|---:|---:|---:|---|---:|
-| 0 | 30 | 21 | 20 | 20 | 20 | 1 | 5.8 / 8.8 / 9.3 | 4.2 |
-| 0 | 60 | 42 | 43 | 43 | 43 | 1 | 4.4 / 5.8 / 6.1 | 5.0 |
-| 0 | 120 | 84 | 87 | 87 | 87 | 1 | 4.3 / 5.5 / 6.5 | 4.0 |
-| 0 | 240 | 168 | **133** | 133 | 133 | 1 | 4.3 / 6.8 / 8.5 | 4.1 |
-| 200 | 30 | 21 | 21 | 21 | 21 | 1 | 20.9 / 25.8 / 30.4 | 5.4 |
-| 200 | 60 | 42 | **30** | 30 | 30 | 1 | 22.3 / 24.0 / 24.2 | 4.2 |
-| 200 | 120 | 84 | **33** | 33 | 33 | 1 | 20.4 / 25.6 / 27.6 | 5.2 |
-| 200 | 240 | 168 | **34** | 34 | 34 | 1 | 19.9 / 23.6 / 24.1 | 4.1 |
+| k | rate asked | **expected** | offered, dev | **offered, production** | applied = offered? | peak backlog | latency p50, dev → **prod** |
+|---:|---:|---:|---:|---:|:-:|---:|---|
+| 0 | 30 | 21 | 20 | **21** | yes / yes | 1 / 1 | 5.8 → **1.0** |
+| 0 | 60 | 42 | 43 | **43** | yes / yes | 1 / 1 | 4.4 → **0.9** |
+| 0 | 120 | 84 | 87 | **87** | yes / yes | 1 / 1 | 4.3 → **0.6** |
+| 0 | 240 | 168 | **133** | **174** | yes / yes | 1 / 1 | 4.3 → **0.5** |
+| 200 | 30 | 21 | 21 | **20** | yes / yes | 1 / 1 | 20.9 → **3.8** |
+| 200 | 60 | 42 | **30** | **43** | yes / yes | 1 / 1 | 22.3 → **3.8** |
+| 200 | 120 | 84 | **33** | **87** | yes / yes | 1 / 1 | 20.4 → **3.0** |
+| 200 | 240 | 168 | **34** | **171** | yes / yes | 1 / 1 | 19.9 → **3.0** |
 
-Milliseconds; "committed" is the DOM mutation count divided by the exact
-per-crossing figure C2 predicts. `outstanding` was 0 in all eight runs — every
+Milliseconds. `outstanding` was 0 in all eight runs of both arms — every
 generation offered reached the page before the run was declared settled.
 
-### The three findings
+### The three findings, restated
 
-**Offered ≠ asked, and that is where the ceiling lives.** At k = 0 the browser
-delivered 133 of 168 requested ticks at 240 Hz — a sustained **190/s**. At
-k = 200 the offer rate saturates at **30–49/s no matter what is asked**: 30, 43,
-47 and 49 per second for 30, 60, 120 and 240 Hz requested. The timer callback
-*is* the main thread, so when a crossing takes 20 ms the browser simply stops
-offering.
+**The k = 200 ceiling was an artefact of the development build.** In
+development the offer rate saturated at 43–49/s at 200 dirty siblings no matter
+what was asked. In production the browser delivers **61, 124 and 244 offers per
+second** for 60, 120 and 240 Hz requested — essentially the full asked rate,
+at the *loaded* end of the ladder. The ablation arm places the recovery in
+both switches: `:advanced` alone lifts k = 200 from ~47/s to ~104/s at 120 Hz,
+and `goog.DEBUG false` takes it the rest of the way to ~124/s. The mechanism
+the development run identified was right — the timer callback *is* the main
+thread, so a browser stops offering when a crossing is expensive — and
+production simply made the crossing cheap enough that it never stops.
 
-**Accepted = offered = committed, in all eight runs.** Nothing was refused,
-dropped or coalesced away by the framework. The gap is entirely between what
-the application asked for and what the browser was able to offer.
+**Accepted = offered = committed, in all sixteen runs across both arms.**
+Nothing was refused, dropped or coalesced away by the framework, in either
+bundle. This is the finding that transferred completely.
 
-**Peak backlog was 1 at every rate and both loads.** Not "small" — *one*, which
-is the single event in flight. The queue never grew, latency stayed bounded at
-the cost of one crossing, and the settlement tail stayed at 4.0–5.4 ms even at
-240 Hz requested against a 20 ms crossing. **The two-clock seam does not
-degrade by queueing; it degrades by the browser making fewer offers.**
+**Peak backlog was 1 at every rate, both loads and both bundles.** Not
+"small" — *one*, the single event in flight. The queue never grew. This was the
+load-bearing observation for section 8's throttle argument, and production
+tested it under genuinely higher throughput (244 offers/s at k = 200 rather
+than 49) and found the same answer.
 
-### Derived and driven agree
+### Derived and driven agree — in production too
 
-The strongest validation in the report is that two independent windows — a
-synchronous `flushSync`-bracketed crossing and an asynchronous timer-driven one
-— predict each other:
+Two independent windows — a synchronous `flushSync`-bracketed crossing and an
+asynchronous timer-driven one — still predict each other, and the production
+comparison is the sharper test because the driven rates are no longer clipped:
 
-| k | section 3 p50 → implied ceiling | section 6 sustained rate |
+| k | section 3 p50 → implied ceiling | driven sustained rate |
 |---:|---|---|
-| 0 | 3.5–4.6 ms → 217–286/s | 190/s |
-| 200 | 18.3–22.2 ms → 45–55/s | 49/s |
+| 0, dev | 3.5–4.6 ms → 217–286/s | 190/s |
+| 200, dev | 18.3–22.2 ms → 45–55/s | 49/s |
+| 0, **production** | 0.3–0.5 ms → 2000–3300/s | **249/s — timer-bound, not crossing-bound** |
+| 200, **production** | 2.6–3.6 ms → 278–385/s | **244/s** |
 
-Within about 10% at both ends, from different code paths, different call sites
-and different clocks.
+At k = 200 the two windows agree within about 15%. At k = 0 they no longer
+agree, and that is the result: a 0.4 ms crossing implies a ceiling in the
+thousands, while `setInterval` at a requested 240 Hz cannot offer more than
+about 250 times a second. **In production the k = 0 seam is limited by the
+browser's timer, not by the crossing** — the substrate has left the frame.
 
 ### The envelope, stated
 
@@ -296,36 +414,50 @@ Two criteria, because they answer different questions.
 
 **Throughput** — how many crossings actually land:
 
-| k | sustained semantic rate (Chrome, dev build) |
-|---:|---|
-| 0 | ~190/s |
-| 1–10 | ~150–190/s (interpolated; not driven) |
-| 50 | ~100/s (interpolated; not driven) |
-| 200 | **~49/s** |
+| k | sustained rate, dev | **sustained rate, production** |
+|---:|---|---|
+| 0 | ~190/s | **~249/s (timer-bound)** |
+| 200 | ~49/s | **~244/s** |
 
 **Latency quality** — the largest offered rate at which 95% of crossings finish
-inside one budget of `1000/R` ms:
+inside one budget of `1000/R` ms. Production p95 is the worst of twelve rounds
+across three runs:
 
-| k | crossing p95 (worst round) | 30 Hz (33.3 ms) | 60 Hz (16.7) | 120 Hz (8.33) | 240 Hz (4.17) |
-|---:|---:|:-:|:-:|:-:|:-:|
-| 0 | 9.2 | ✔ | ✔ | ✗ | ✗ |
-| 1 | 10.4 | ✔ | ✔ | ✗ | ✗ |
-| 10 | 10.7 | ✔ | ✔ | ✗ | ✗ |
-| 50 | 12.0 | ✔ | ✔ | ✗ | ✗ |
-| 200 | 27.5 | ✔ | ✗ | ✗ | ✗ |
+| k | p95 dev | **p95 prod** | 30 Hz (33.3 ms) | 60 Hz (16.7) | **120 Hz (8.33)** | 240 Hz (4.17) |
+|---:|---:|---:|:-:|:-:|:-:|:-:|
+| 0 | 9.2 | **2.3** | ✔ | ✔ | **✔** (was ✗) | ✔ (was ✗) |
+| 1 | 10.4 | **1.2** | ✔ | ✔ | **✔** (was ✗) | ✔ (was ✗) |
+| 10 | 10.7 | **2.0** | ✔ | ✔ | **✔** (was ✗) | ✔ (was ✗) |
+| 50 | 12.0 | **2.4** | ✔ | ✔ | **✔** (was ✗) | ✔ (was ✗) |
+| 200 | 27.5 | **5.1** | ✔ | ✔ (was ✗) | **✔** (was ✗) | ✗ |
 
-**So: 60 Hz semantic crossing is comfortable up to 50 dirty siblings and breaks
-between 50 and 200. 120 Hz never quite clears the p95 bar in a development
-build even with nothing else dirty, although throughput reaches it easily. 240
-Hz is not achievable at any load — the browser stops offering first.**
+**So the 120 Hz row flipped, and it flipped at every rung.** In a development
+build 120 Hz cleared the p95 bar nowhere, even with nothing else dirty. In the
+shipped bundle it clears everywhere, including 200 dirty siblings, with the
+worst rung reading 5.1 ms against an 8.33 ms budget — 39% of headroom to spare
+rather than a 10% miss. 60 Hz, which broke between 50 and 200 siblings in
+development, is now comfortable across the whole ladder. **240 Hz clears the
+latency bar up to 50 siblings and misses it only at k = 200 (5.1 against
+4.17)** — and at that rate the ceiling is the browser's timer anyway, since the
+driven arm tops out near 250 offers a second.
 
-The rows marked interpolated were not driven; only k = 0 and k = 200 were.
+Only k = 0 and k = 200 were driven; no intermediate throughput row is quoted,
+interpolated or otherwise.
 
 ---
 
 ## 7. Controlled input: no drops first, then latency
 
 DC-09's acceptance criterion 2, in the order it is written.
+
+**This section is development-build only and was not re-taken in production.**
+Its verdict is a correctness one — no drops, intact caret — which the browser
+suite already gates deterministically at every rung, and correctness does not
+move with the bundle. Its latency table is therefore an upper bound like the
+rest of the development figures, and by section 3's factor the production
+per-keystroke cost would be expected somewhere between a sixth and a tenth of
+what is tabulated. That expectation is *not* measured and is not quoted as a
+result anywhere in this report.
 
 Thirty characters are appended one at a time through `HTMLInputElement`'s own
 prototype value setter and delivered as real bubbling `InputEvent`s outside
@@ -354,6 +486,8 @@ Only then, the distribution — the whole round trip per keystroke:
 | 50 | 7.6 | **9.5** | 13.7 | 13.8 | 0 / 30 |
 | 200 | 16.4 | **21.0** | 26.1 | 26.5 | 0 / 30 |
 
+Development build; see the note opening this section.
+
 **k = 0, 1 and 10 are indistinguishable** — 5.4, 4.9 and 5.6 ms at p50 with
 overlapping ranges. Contention only becomes visible at 50 siblings and only
 becomes a *user-visible* cost at 200, where p50 exceeds a 60 Hz frame (16.7 ms)
@@ -372,19 +506,31 @@ DC-09's bar is that new scheduling, preview or equality vocabulary is proposed
 witnesses". Three of the four candidate vocabularies have no bottleneck to
 attribute at all.
 
-**No equality hook.** A fresh-but-`rf=`-equal crossing costs 0.2–0.6 ms and
-repaints nothing, at 96 leaves and at 900, at both read sites, indistinguishable
-from re-installing the identical reference. Freehand already elides an
-`:update` whose config is equal — proved by counting `:update` calls, 52 of 52
-matching the changed crossings exactly. There is nothing here for an equality
-hook to buy.
+**The production reading did not soften this recommendation; it removed the
+only grounds on which it could have been reconsidered.** Every candidate
+vocabulary was argued down from a development figure that was an upper bound on
+cost, so the honest reading in section 9 of the first edition was that the case
+could only get stronger. It did, by 6–11×, and the one row that might have
+argued for scheduling help — 120 Hz missing its p95 budget — now clears it at
+every rung.
+
+**No equality hook.** A fresh-but-`rf=`-equal crossing costs 0.2–0.6 ms in a
+development build and **sits on Chrome's 0.1 ms clock clamp in a shipped one**,
+at 96 leaves and at 900, at both read sites, indistinguishable from
+re-installing the identical reference. Freehand already elides an `:update`
+whose config is equal — proved by counting `:update` calls, 52 of 52 matching
+the changed crossings exactly, in *all three* bundles. There is nothing here
+for an equality hook to buy, and production made the thing it would optimise
+too small to measure.
 
 **No throttle, debounce or coalescing verb.** Peak backlog was **1** at every
-rate and both sibling loads; `outstanding` was 0 in all eight driven runs; the
-settlement tail never exceeded 5.4 ms. The browser's own timer back-pressure
-already coalesces — under overload you receive *fewer offers*, never a growing
-queue. A throttle verb would suppress offers the browser has already stopped
-making, and would trade away the low-load responsiveness that costs nothing.
+rate, both sibling loads and both bundles; `outstanding` was 0 in all sixteen
+driven runs. The browser's own timer back-pressure already coalesces — under
+overload you receive *fewer offers*, never a growing queue. A throttle verb
+would suppress offers the browser has already stopped making, and would trade
+away the low-load responsiveness that costs nothing. Production tested this at
+**five times the development throughput** at k = 200 (244 offers/s against 49)
+and the backlog was still 1.
 
 **No host-local state model.** The `:host-only` arm is under Chrome's clock
 resolution at every rung. The existing behavior boundary is already the answer;
@@ -397,9 +543,17 @@ choice about which events are worth having, and it costs nothing structural.
 ### The one bottleneck that did repeat — and why it is not an API
 
 Section 4's read-site penalty *did* repeat in two witnesses (Vega-shaped and
-Spread-shaped), it *is* material (40–44 ms, eight to nineteen times the leaf
-cost) and it *is* attributed (subtree reconciliation, not DOM work, not
-equality, not the reducer). It clears DC-09's bar for evidence.
+Spread-shaped) and it *is* attributed — subtree reconciliation, not DOM work,
+not equality, not the reducer; the ablation arm confirms the attribution by
+showing the penalty responds to the optimiser while the leaf-read baseline
+responds only to the instrumentation define.
+
+**Its materiality is the one claim production revised down.** In a shipped
+bundle the penalty is a constant **3.1–3.3 ms**, not 40–44, and the ratio is
+1.3–4.2× rather than eight to nineteen. It is still a real cost — 3.3 ms is a
+fifth of a 60 Hz frame, paid for nothing — and it is still worth stating,
+because the fix is free. But it no longer looks like the kind of finding that
+would motivate new surface even if surface were on the table.
 
 Its remedy is a call site, not a verb. DC-09 already says to keep host-local
 geometry and motion out of `app-db` unless the application genuinely needs the
@@ -407,8 +561,9 @@ live values. This adds the sharper corollary, which belongs in the guide:
 
 > **If a high-rate value must cross into `app-db`, read its subscription at the
 > boundary that uses it — never in a view that also builds a collection.**
-> Moving one `v/sub` down one boundary took a config change from 45.6 ms to
-> 5.0 ms in this fixture, while the number of DOM nodes that moved went *down*.
+> Moving one `v/sub` down one boundary took a config change from 4.4 ms to
+> 1.05 ms in a shipped bundle, while the number of DOM nodes that moved went
+> *down*.
 
 That is documentation and guidance work with a named owner (`rf2-fby7o`, the
 guide), not new Freehand surface.
@@ -417,16 +572,24 @@ guide), not new Freehand surface.
 
 ## 9. What this report could not determine
 
-**The production envelope.** Every figure is from a development build with
-`goog.DEBUG true`, so the Spec 009 instrumentation seam, schema validation and
-trace emission all sit on the measured path. B6 publishes its own numbers from
-an `:advanced` bundle for exactly this reason. Taking the same reading for B10
-needs a `:browser` entry point plus a build target in
-`implementation/shadow-cljs.edn`, which is a hot-zone file that was carrying
-four concurrent siblings when this was measured; it was left alone rather than
-raced. **The direction is known and safe — production is faster, so every rate
-here is a lower bound — but the factor is not measured, and the 120 Hz row in
-section 6 is exactly the row that factor could flip.**
+**~~The production envelope.~~** *Resolved by `rf2-drpa3.182.15`; this is what
+the second edition adds.* The first edition recorded that every figure came
+from a development build, that the direction was known and safe, and that the
+120 Hz row was exactly the row the unmeasured factor could flip. The factor is
+now measured at **6.0–11.6×**, decomposed into an optimiser term and an
+instrumentation term by the ablation arm, and **the 120 Hz row did flip, at
+every rung**.
+
+One correction is worth recording, because it was the stated reason the
+reading had not been taken. The first edition said a production run "needs a
+`:browser` entry point plus a build target in
+`implementation/shadow-cljs.edn`", a hot-zone file. The entry point was
+needed; **the build target was not.** B6 had already established the pattern —
+`--config-merge` supplies an `:output-dir` and an `:init-fn` on top of the
+existing `:freehand-release` id, which already carries `:optimizations
+:advanced` and `goog.DEBUG false`, the only two properties the reading is
+about. `b10_prod_run.cjs` does the same and touches no shared configuration at
+all. The hot-zone contention was real; the dependency on it was not.
 
 **Real pointer streams.** The driver is a `setInterval`. A browser delivering
 coalesced `pointermove`, or `pointerrawupdate` bursts, can hand several events
@@ -434,22 +597,68 @@ to one task, which is the one shape that could produce a backlog greater than 1.
 The backlog-of-1 result is measured against a timer and should not be quoted
 for a raw-pointer burst without re-measuring.
 
-**Sub-0.1 ms costs.** Chrome clamps `performance.now()` to 100 µs. The
-`:host-only` arm and, at the bottom of its range, the `:fresh-equal` arm sit on
-that clamp. Their costs are "under 0.1 ms", and nothing finer can be said with
-this instrument.
+**Sub-0.1 ms costs, and there are now many more of them.** Chrome clamps
+`performance.now()` to 100 µs. In the development build only the `:host-only`
+arm and the bottom of the `:fresh-equal` range sat on that clamp. In production
+the `:host-only` arm, the whole `:fresh-equal` arm at every rung, and both
+config-equality arms at 96 leaves all sit there. Their costs are "under
+0.1 ms", and **nothing finer can be said with this instrument** — which means
+the production numbers are, at the small end, a statement about Chrome's timer
+rather than about Freehand. Resolving them would need a different clock, not
+another run.
+
+**The k = 0 driven rate is timer-bound, not crossing-bound.** Section 6's
+~249/s at k = 0 is what `setInterval` could offer, not what the seam could
+absorb; the synchronous window implies a ceiling in the thousands. The two
+windows agreeing was a validation in the development build and is no longer
+available at the empty end of the ladder.
+
+**Arm B's optimiser label.** `provenance/detect-build` infers `:optimizations`
+from `goog.DEBUG`, so the ablation arm's own record reports `:none` although it
+was compiled `:advanced`. The arm is identified by its build command. Every
+other provenance claim in this report is self-checked by the running bundle.
 
 **Rungs between 0 and 200 in the driven arm.** Only k = 0 and k = 200 were
-driven; the k = 1/10/50 throughput figures in section 6 are interpolated from
-section 3 and are marked as such.
+driven, in either bundle. No intermediate throughput figure is quoted.
 
-**One machine.** Single workstation, single browser version. The *shares* —
-event flat, commit scaling, read-site constant, backlog invariant — are the
-transferable claims. The absolutes are not.
+**Controlled input in production.** Section 7 was not re-taken; see the note
+there.
+
+**One machine.** Single workstation, single browser version, five runs. The
+*shares* — event flat, commit scaling, read-site constant, backlog invariant,
+elision exact — are the transferable claims, and all five survived the change
+of bundle. The absolutes are not.
 
 ---
 
 ## 10. Reproducing
+
+**Arm C — the production reading (sections 3–6's headline figures).** No shared
+build configuration is involved; the driver builds, serves, drives and prints
+on its own.
+
+```bash
+cd implementation
+RF2_REVISION=$(git rev-parse HEAD) \
+RF2_HARDWARE_CLASS=developer-workstation \
+  node freehand/test/re_frame/freehand/bench/b10_prod_run.cjs
+```
+
+**Arm B — the ablation.** Identical, plus one define:
+
+```bash
+B10_DEBUG=true \
+RF2_REVISION=$(git rev-parse HEAD) \
+RF2_HARDWARE_CLASS=developer-workstation \
+  node freehand/test/re_frame/freehand/bench/b10_prod_run.cjs
+```
+
+Both print every published record as EDN on stdout, tagged
+`;; ==== B10 PROD … ====`, and exit non-zero if either positive control failed.
+Each arm writes to its own output directory, so the two bundles cannot be
+confused for one another.
+
+**Arm A — the development reading (sections 3–7's dev columns).**
 
 ```bash
 cd implementation

--- a/implementation/freehand/test/re_frame/freehand/bench/b10_prod_app.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b10_prod_app.cljs
@@ -1,0 +1,406 @@
+(ns re-frame.freehand.bench.b10-prod-app
+  "B10's PRODUCTION entry — DC-09's two-clock envelope, taken from an
+  `:advanced` bundle with `goog.DEBUG false`.
+
+  This namespace exists for B6's reason, restated for B10. Every figure
+  in `docs/design/freehand/studio/two-clock-operating-envelope.md` came
+  from `:optimizations :none` with `goog.DEBUG true`, so the Spec 009
+  instrumentation seam, schema validation and trace emission were all
+  live on exactly the measured event path. Every cost there is an UPPER
+  bound and every rate a LOWER bound. The direction was safe; the factor
+  was unmeasured, and the 120 Hz row — 9.2 ms p95 against an 8.33 ms
+  budget at k=0, a miss by 10% — was the row it could flip.
+
+  ## No eleventh instrument, and no twelfth
+
+  Nothing here is a second harness. Every arm, every window, both
+  controls and all three measurements are
+  [[re-frame.freehand.bench.b10-two-clock]]'s, unchanged. This file
+  installs the adapter, runs them in the order the browser suite runs
+  them, and parks the records on `window.B10_RESULTS` for the driver to
+  read. The deterministic gates stay where they belong, in
+  `b10-two-clock-dom-cljs-test`, which the bench browser lane still runs
+  under `:none` — but the two POSITIVE CONTROLS are repeated here,
+  because a control that held under `:none` and failed under `:advanced`
+  would be the Closure compiler quietly deciding the comparison.
+
+  Both controls are hard failures here rather than published rows:
+
+    * **C2, a size.** Each mode's DOM mutation count is predicted from
+      the fixture's arithmetic and measured with a `MutationObserver`.
+      Under `:advanced` this is also the externs check — `.takeRecords`,
+      `.-type`, `.-style`/`-transform` and `.setAttribute` all have to
+      survive renaming, and a mismatch means they did not.
+    * **C1, a duration.** A busy-wait of computed 4.00 ms timed through
+      the same window every figure is timed through. A sample reading
+      BELOW its own predicted duration means the window is not measuring
+      what it brackets, whatever the optimiser did.
+
+  And the same rule the dev run publishes under: **every measured
+  crossing is read back out of the DOM inside its own window, and a
+  crossing that did not land is COUNTED, not discarded.** The unverified
+  count rides in every record.
+
+  ## Runtime
+
+  These figures are CHROME, headless, from the artefact a consumer
+  ships. Nothing here is quoted for Node or for the JVM, and no share
+  measured here transfers to either as an absolute.
+
+  ## Scope
+
+  M1 (sibling ladder, both orders), M2 (config equality at both read
+  sites) and M3 (driven rates) — the three the bead asks for. M4's
+  controlled-field row is not re-taken: it depends on
+  `re-frame.freehand.mount-support`'s act-environment door, its verdict
+  is a correctness one (no drops, intact caret) that the browser suite
+  already gates deterministically, and DC-09 does not read it off the
+  production bundle.
+
+  Built and driven by
+  `implementation/freehand/test/re_frame/freehand/bench/b10_prod_run.cjs`.
+
+  Normative owner: `docs/design/freehand/decisions/`
+  `D021-performance-budgets-and-release-evidence.md`. Measured claim
+  owner: DC-09 in `docs/design/freehand/product-completion-setpoint.md`."
+  (:require [re-frame.adapter.uix :as react-substrate]
+            [re-frame.core :as rf]
+            [re-frame.freehand.bench.b10-two-clock :as b10]
+            [re-frame.freehand.bench.b6-harness :as h]
+            [re-frame.freehand.bench.measure :as m]
+            [re-frame.freehand.bench.provenance :as prov]))
+
+;; The dev run's constants, verbatim. A factor read between two runs that
+;; sampled differently would be a factor over the sampling, so these are
+;; the one thing in this file that must not be tuned.
+(def ^:private rounds 4)
+(def ^:private sampling {:warmup 3 :samples 10})
+(def ^:private burn-ms 4.0)
+(def ^:private drive-ms 700)
+
+(defn- fail! [why]
+  (set! (.-B10_ERROR js/window) (str why))
+  (js/console.error (str ";; B10 PROD FAILED — " why)))
+
+(defn- record! [k v]
+  (let [acc (or (.-B10_RESULTS js/window) #js {})]
+    (aset acc (name k) (pr-str v))
+    (set! (.-B10_RESULTS js/window) acc)
+    v))
+
+(defn- round3 [x] (/ (js/Math.round (* x 1000)) 1000.0))
+
+;; ===========================================================================
+;; C2 — the size control, and the externs check it doubles as
+;; ===========================================================================
+
+(defn- c2!
+  "Predicted DOM mutation count against measured, at every rung and every
+  mode. Answers the rows; sets `B10_ERROR` and answers nil on any
+  mismatch, because a fixture that does not dirty what it says it dirties
+  invalidates every number below it."
+  []
+  (let [mnt (b10/mount! :vega)]
+    (try
+      (let [rows (vec (for [k    b10/sibling-ladder
+                            mode [:host-only :fresh-equal :one-leaf]]
+                        (let [arm (b10/sibling-mode mode k)
+                              ;; one unmeasured warm crossing, then the counted one
+                              _   ((:run! arm) (:container mnt) (:observer mnt))
+                              r   ((:run! arm) (:container mnt) (:observer mnt))]
+                          {:mode      mode
+                           :k         k
+                           :predicted (:predicted-mutations arm)
+                           :measured  (get-in r [:mutations :total])
+                           :by-type   (get-in r [:mutations :by-type])
+                           :verified? (:ok? r)})))
+            bad  (filterv (fn [{:keys [predicted measured verified?]}]
+                            (or (not= predicted measured) (not verified?)))
+                          rows)]
+        (record! :c2 {:control     :mutation-count
+                      :note        (str "predicted from the fixture's arithmetic: k+1 for a "
+                                        "crossing dirtying k siblings beside the leaf, one "
+                                        "attribute for the host clock, none for a "
+                                        "fresh-but-equal write. Under :advanced this is also "
+                                        "the externs check — a renamed MutationObserver or "
+                                        "style property fails here.")
+                      :rows        rows
+                      :mismatches  bad
+                      :ok?         (empty? bad)})
+        (when (seq bad)
+          (fail! (str "C2 — the fixture does not dirty what its arithmetic says under "
+                      ":advanced: " (pr-str bad))))
+        (when (empty? bad) rows))
+      (finally (b10/release! mnt)))))
+
+;; ===========================================================================
+;; C1 — the duration control
+;; ===========================================================================
+
+(defn- c1!
+  "A busy-wait of computed `burn-ms` through the measured window. The
+  overshoot is clock quantisation plus whatever the operating system took
+  away, and it is published beside the tables so a contended run is read
+  as a contended run rather than as a slow substrate. Reading BELOW the
+  predicted duration is the failure."
+  []
+  (let [mnt (b10/mount! :vega)
+        arm (b10/burn-arm burn-ms)]
+    (try
+      (let [rs    (vec (for [_ (range 12)] ((:run! arm) (:container mnt) (:observer mnt))))
+            s     (m/summarise (mapv :total-ms rs))
+            below (count (filter #(< (:total-ms %) burn-ms) rs))
+            unv   (count (remove :ok? rs))]
+        (record! :c1 {:control          :control-burn
+                      :predicted-ms     burn-ms
+                      :measured         s
+                      :p50-overshoot-ms (round3 (- (:p50 s) burn-ms))
+                      :below-predicted  below
+                      :unverified       unv
+                      :of               (count rs)
+                      :note (str "overshoot is instrument quantisation plus machine "
+                                 "contention; every B10 table is read on this scale")})
+        (when (pos? below)
+          (fail! (str "C1 — " below " of " (count rs) " samples read BELOW their own "
+                      "predicted " burn-ms " ms; the window is not measuring what it "
+                      "brackets (min " (:min s) ")")))
+        (when (zero? below) s))
+      (finally (b10/release! mnt)))))
+
+;; ===========================================================================
+;; M1 — the sibling ladder, in both orders
+;; ===========================================================================
+
+(defn- ladder-round!
+  [mnt ks]
+  (into {}
+        (map (fn [k]
+               [k (b10/run-arms! mnt
+                                 [(b10/sibling-mode :host-only k)
+                                  (b10/sibling-mode :fresh-equal k)
+                                  (b10/sibling-mode :one-leaf k)
+                                  (b10/burn-arm burn-ms)]
+                                 sampling)]))
+        ks))
+
+(defn- envelope
+  "The derived envelope, folded ACROSS every round rather than read off
+  one of them. `{k {arm {:p95 {:min :max} :p50 {:min :max}}}}` — a range,
+  because a single round's p95 is a sample of a p95 and two arms whose
+  ranges overlap are indistinguishable."
+  [all]
+  (let [ks   (keys (first all))
+        arms (keys (get (first all) (first ks)))]
+    (into {}
+          (map (fn [k]
+                 [k (into {}
+                          (map (fn [arm]
+                                 (let [p95 (mapv #(get-in % [k arm :total-ms :p95]) all)
+                                       p50 (mapv #(get-in % [k arm :total-ms :p50]) all)]
+                                   [arm {:p95    {:min (apply min p95) :max (apply max p95)}
+                                         :p50    {:min (apply min p50) :max (apply max p50)}
+                                         :rounds (count all)}])))
+                          arms)]))
+          ks)))
+
+(defn- m1!
+  []
+  (let [mnt (b10/mount! :vega)]
+    (try
+      (let [up   (vec (for [_ (range (/ rounds 2))]
+                        (ladder-round! mnt b10/sibling-ladder)))
+            down (vec (for [_ (range (/ rounds 2))]
+                        (ladder-round! mnt (reverse b10/sibling-ladder))))
+            all  (into up down)
+            unv  (reduce + (for [r all, [_ arms] r, [_ s] arms] (:unverified s)))
+            tot  (reduce + (for [r all, [_ arms] r, [_ s] arms] (:n s)))
+            host (for [r all, [_ arms] r] (get-in arms [:host-only :total-ms :p50]))
+            flat (- (apply max host) (apply min host))]
+        (record! :m1
+                 (b10/record
+                   :B10/sibling-ladder
+                   "service time of one semantic crossing against dirty-sibling count"
+                   {:cells        b10/cells-n
+                    :ladder       b10/sibling-ladder
+                    :config-shape :vega
+                    :arms         [:host-only :fresh-equal :one-leaf :control-burn]
+                    :crossing     :dispatch-sync
+                    :unverified   unv
+                    :of           tot
+                    :measurement-method
+                    (str "t0; react-dom/flushSync around rf/dispatch-sync, with t1 taken "
+                         "INSIDE the flush the instant the dispatch returns; t2 after the "
+                         "flush. :event-ms is t1-t0 (router, interceptors, reducer, app-db "
+                         "install, subscription notification); :commit-ms is t2-t1 (React "
+                         "render, commit, DOM mutation). The crossing is then read back out "
+                         "of the DOM — or, for the fresh-equal arm whose whole point is that "
+                         "the page must NOT move, out of the store, by proving the reference "
+                         "moved and the value did not. Arm order rotates on the sample index; "
+                         "the LADDER is walked ascending in half the rounds and descending in "
+                         "the other half, both published. A control-burn arm of computed "
+                         "4.00 ms duration rides in every cell as the machine's contention "
+                         "meter. Same instrument, same constants and same fixture as the "
+                         "development reading; the ONLY difference is the bundle.")}
+                   (assoc sampling :rounds rounds)
+                   {:ascending  up
+                    :descending down}))
+        (record! :m1-envelope
+                 {:note (str "budget at rate R is 1000/R ms; the envelope is the largest R "
+                             "whose budget exceeds the crossing's p95. Ranges are across all "
+                             (count all) " rounds — a single round's p95 is a sample of a "
+                             "p95, and overlapping ranges mean indistinguishable.")
+                  :budgets-ms       (into {} (map (fn [r] [r (round3 (/ 1000.0 r))]))
+                                          b10/rate-ladder)
+                  :across-rounds    (envelope all)
+                  :host-flatness-ms (round3 flat)
+                  :unverified       unv
+                  :of               tot})
+        (when (pos? unv)
+          (fail! (str "M1 — " unv " unverified of " tot
+                      "; a crossing that did not land was timed")))
+        (when (>= flat 1.0)
+          (fail! (str "M1 — the host-only arm is NOT flat across the ladder (spread "
+                      flat " ms); the ladder is contaminating an arm that never crosses")))
+        all)
+      (finally (b10/release! mnt)))))
+
+;; ===========================================================================
+;; M2 — equality cost, at two config shapes, at both read sites
+;; ===========================================================================
+
+(defn- m2!
+  []
+  (let [out (atom {})]
+    (doseq [shape   [:vega :spread]
+            read-at [:parent :leaf]]
+      (let [mnt (b10/mount! shape read-at)]
+        (try
+          (b10/reset-behavior-log!)
+          (let [before (b10/behavior-calls)
+                rs     (vec (for [_ (range rounds)]
+                              (b10/run-arms!
+                                mnt
+                                [(b10/config-mode :stable shape)
+                                 (b10/config-mode :fresh-equal shape)
+                                 (b10/config-mode :one-leaf shape)
+                                 (b10/burn-arm burn-ms)]
+                                sampling)))
+                after  (b10/behavior-calls)]
+            (swap! out assoc [shape read-at]
+                   {:rounds           rs
+                    :behavior-updates (- (:update after) (:update before))
+                    :leaves           (get-in b10/config-shapes [shape :leaves])}))
+          (finally (b10/release! mnt)))))
+    (let [unv (reduce + (for [[_ v] @out, r (:rounds v), [_ s] r] (:unverified s)))
+          tot (reduce + (for [[_ v] @out, r (:rounds v), [_ s] r] (:n s)))]
+      (record! :m2
+               (b10/record
+                 :B10/config-equality
+                 "cost of one behavior-config crossing by equality class and config shape"
+                 {:shapes       (into {} (map (fn [[k v]] [k (select-keys v [:leaves :channels])]))
+                                      b10/config-shapes)
+                  :modes        [:stable :fresh-equal :one-leaf]
+                  :read-sites   [:parent :leaf]
+                  :crossing     :dispatch-sync
+                  :cells        b10/cells-n
+                  :unverified   unv
+                  :of           tot
+                  :measurement-method
+                  (str "the same window as M1, at both read sites — :parent reads the config "
+                       "subscription in the view that also builds the 300 cells, :leaf reads "
+                       "it one boundary down inside the behavior's own panel; nothing else "
+                       "differs between them. :stable re-installs the value already in "
+                       "app-db — identical, not merely equal — and is verified by identity; "
+                       ":fresh-equal installs a freshly built map of the same contents and is "
+                       "verified by the reference moving while the value does not; :one-leaf "
+                       "installs one differing in exactly one leaf. The behavior's :update "
+                       "call count across the whole run is published beside the timings.")}
+                 (assoc sampling :rounds rounds)
+                 @out))
+      (when (pos? unv)
+        (fail! (str "M2 — " unv " unverified of " tot)))
+      @out)))
+
+;; ===========================================================================
+;; M3 — the driven arm
+;; ===========================================================================
+
+(defn- m3!
+  "Async: the driven rates ride real timers, so this answers a promise."
+  []
+  (let [mnt  (b10/mount! :vega)
+        runs (atom [])
+        plan (for [k [0 200], r b10/rate-ladder] [k r])]
+    (-> (reduce (fn [p [k r]]
+                  (.then p (fn [_]
+                             (-> (b10/drive! mnt r k drive-ms)
+                                 (.then (fn [rec] (swap! runs conj rec) nil))))))
+                (js/Promise.resolve nil)
+                plan)
+        (.then
+          (fn [_]
+            (let [bad (filterv (fn [{:keys [offered applied]}]
+                                 (or (not (pos? offered)) (> applied offered)))
+                               @runs)]
+              (record! :m3
+                       (b10/record
+                         :B10/driven-rates
+                         "offered against browser-observed against accepted against committed"
+                         {:rates       b10/rate-ladder
+                          :ladder      [0 200]
+                          :duration-ms drive-ms
+                          :cells       b10/cells-n
+                          :crossing    :dispatch-async
+                          :measurement-method
+                          (str "setInterval at 1000/R ms for " drive-ms " ms, each tick "
+                               "issuing an ordinary asynchronous rf/dispatch. :expected is "
+                               "computed (floor(duration x rate / 1000)) and is NOT a "
+                               "measurement; :offered counts driver invocations; :applied is "
+                               "incremented inside the reducer; :mutations counts DOM "
+                               "records; :peak-backlog is the largest offered-minus-applied "
+                               "ever seen at an offer; :tail-ms is from the last offer to the "
+                               "page showing the last generation, polled at 4 ms with a "
+                               "2000 ms ceiling; :latency-ms is the offer-to-DOM distribution "
+                               "read from the MutationObserver callback that carried each "
+                               "generation.")}
+                         {:warmup 0 :samples (count @runs)}
+                         {:runs @runs}))
+              (when (seq bad)
+                (fail! (str "M3 — a driven run is incoherent (offered/applied): "
+                            (pr-str bad)))))
+            nil))
+        (.finally (fn [] (b10/release! mnt))))))
+
+;; ===========================================================================
+;; Entry
+;; ===========================================================================
+
+(defn ^:export -main
+  []
+  (try
+    (rf/init! react-substrate/adapter)
+    (h/leave-act-environment!)
+    ;; Read off the RUNNING bundle rather than asserted by the driver, so
+    ;; a run that was somehow not the advanced bundle says so in its own
+    ;; output instead of being taken on the build command's word.
+    (record! :build (assoc (prov/detect-build)
+                           :revision (prov/detect-revision)
+                           :host     (prov/detect-host)))
+    ;; Controls FIRST. If the fixture does not dirty what it says it
+    ;; dirties, or the window does not measure what it brackets, nothing
+    ;; below is worth taking.
+    (if-not (and (c2!) (c1!))
+      (set! (.-B10_DONE js/window) true)
+      (-> (js/Promise.resolve nil)
+          (.then (fn [_] (m1!) nil))
+          (.then (fn [_] (m2!) nil))
+          (.then (fn [_] (m3!)))
+          (.then (fn [_] (set! (.-B10_DONE js/window) true) nil))
+          (.catch (fn [e]
+                    (fail! (str "the run threw: " e))
+                    (set! (.-B10_DONE js/window) true)
+                    nil))))
+    (catch :default e
+      (fail! (str "the run threw: " e))
+      (set! (.-B10_DONE js/window) true)))
+  nil)

--- a/implementation/freehand/test/re_frame/freehand/bench/b10_prod_run.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b10_prod_run.cjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+// B10's production driver — build, serve, run, print.
+//
+// The rates B10 publishes should describe the artefact a consumer ships
+// (`:advanced`, `goog.DEBUG false`), and shadow's `:browser-test` target
+// cannot be compiled that way — `cljs-test-display`'s `goog.define`s
+// collide under the Closure compiler. So the production reading rides a
+// plain `:browser` module built by merging an output directory and an
+// `:init-fn` into the existing `:freehand-release` build id, exactly as
+// B6's `b6_prod_run.cjs` does.
+//
+// **Nothing in `implementation/shadow-cljs.edn` changes.** The bead that
+// asked for this run assumed a new build target was needed and named the
+// hot-zone file as the reason it had not been done; B6 had already shown
+// the target is unnecessary. `--config-merge` supplies the two keys that
+// differ, and `:freehand-release` supplies `:optimizations :advanced`
+// and `goog.DEBUG false` — the only two properties this reading is
+// about. The run reports the build it actually got, off `goog.DEBUG`, so
+// the claim is checked rather than assumed.
+//
+//   node implementation/freehand/test/re_frame/freehand/bench/b10_prod_run.cjs
+//
+// Prints every published record as EDN on stdout and exits non-zero if
+// the run did not reach its own controls.
+
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const http = require('node:http');
+const path = require('node:path');
+
+const IMPL = path.resolve(__dirname, '../../../../..');
+const OUT_DIR = process.env.B10_OUT_DIR || 'out/b10-prod';
+const INIT_FN = process.env.B10_INIT_FN || 're-frame.freehand.bench.b10-prod-app/-main';
+
+const PORT = Number(process.env.B10_PORT || 8128);
+
+// A browser has no `process.env`, so provenance reaches the page only as a
+// COMPILE-TIME define — the same route `:browser-test-freehand-bench` uses.
+// Exporting the variables and stopping there would tell this runner and not
+// the bundle, and the record would publish `:d021 :not-release-evidence` with
+// a nil revision. `--config-merge` deep-merges, so `goog.DEBUG false` from
+// `:freehand-release` survives alongside these; the run reports the build it
+// actually got, so a merge that clobbered it would be visible rather than
+// silent.
+const REVISION = process.env.RF2_REVISION || '';
+const HARDWARE = process.env.RF2_HARDWARE_CLASS || '';
+
+// `B10_DEBUG=true` keeps `:advanced` and flips `goog.DEBUG` back ON — the
+// ABLATION arm. The published development figures were taken from a
+// different build id, a different page and a different runner, so reading
+// the dev-to-production gap off them alone attributes it to `:advanced` when
+// part of it could be any of those. This arm changes exactly one define and
+// nothing else: same entry, same page, same driver, same optimiser. What it
+// isolates is the Spec 009 instrumentation seam's own cost, which is the
+// term the bead asks to publish. The run reports the `goog.DEBUG` it
+// actually got, so the arm cannot silently be the wrong one.
+const DEBUG = process.env.B10_DEBUG === 'true';
+// A separate output directory per arm, so the two bundles cannot overwrite
+// each other and a stale one cannot be served as the other.
+const OUT_DIR_D = DEBUG ? `${OUT_DIR}-debug` : OUT_DIR;
+const OUT = path.join(IMPL, OUT_DIR_D);
+
+// ONE LINE, deliberately: shadow-cljs's CLI re-splits `--config-merge` on
+// whitespace when the EDN contains a newline, and reports
+// `EOF while reading` from a fragment. Keep it on one line.
+const CONFIG_MERGE =
+  `{:output-dir "${OUT_DIR_D}" :asset-path "." ` +
+  `:compiler-options {:closure-defines ` +
+  `{goog.DEBUG ${DEBUG} ` +
+  `re-frame.freehand.bench.provenance/build-revision "${REVISION}" ` +
+  `re-frame.freehand.bench.provenance/build-hardware-class "${HARDWARE}"}} ` +
+  `:modules {:main {:init-fn ${INIT_FN}}}}`;
+
+function build() {
+  console.error('[b10] building :advanced bundle ...');
+  // `node cli/runner.js` rather than the `.cmd` shim: spawning a shim on
+  // Windows needs `shell: true`, and a shell concatenates argv, which is
+  // the other way the config-merge EDN gets torn in half.
+  const runner = path.join(IMPL, 'node_modules', 'shadow-cljs', 'cli', 'runner.js');
+  const r = spawnSync(
+    process.execPath,
+    [runner, 'release', 'freehand-release', '--config-merge', CONFIG_MERGE],
+    { cwd: IMPL, stdio: ['ignore', 'inherit', 'inherit'] }
+  );
+  if (r.status !== 0) {
+    console.error(`[b10] build failed with status ${r.status}`);
+    process.exit(1);
+  }
+}
+
+const MIME = { '.js': 'text/javascript', '.html': 'text/html', '.map': 'application/json' };
+
+function serve() {
+  fs.writeFileSync(
+    path.join(OUT, 'index.html'),
+    '<!doctype html><html><head><meta charset="utf-8"><title>B10</title></head>' +
+      '<body><div id="app"></div><script src="main.js"></script></body></html>'
+  );
+  return http
+    .createServer((req, res) => {
+      const rel = decodeURIComponent(req.url.split('?')[0]);
+      const file = path.join(OUT, rel === '/' ? 'index.html' : rel);
+      if (!file.startsWith(OUT) || !fs.existsSync(file)) {
+        res.writeHead(404).end('not found');
+        return;
+      }
+      res.writeHead(200, { 'content-type': MIME[path.extname(file)] || 'application/octet-stream' });
+      fs.createReadStream(file).pipe(res);
+    })
+    .listen(PORT);
+}
+
+async function run() {
+  const { chromium } = require('playwright');
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  page.on('console', (msg) => {
+    const t = msg.text();
+    if (t.startsWith(';; B10') || t.startsWith(';; B6')) console.log(t);
+  });
+  page.on('pageerror', (e) => console.error('[b10] page error:', e.message));
+  // `waitUntil: 'commit'` for rf2-dczpv's reason: the entry starts running
+  // during page load, so the `load` event cannot fire until the whole run
+  // yields — waiting for it would be waiting for the benchmark, against a
+  // budget separate from the one below.
+  await page.goto(`http://127.0.0.1:${PORT}/`, { waitUntil: 'commit', timeout: 60 * 1000 });
+  await page.waitForFunction('window.B10_DONE === true || window.B10_ERROR', null, {
+    timeout: 20 * 60 * 1000,
+  });
+  const err = await page.evaluate('window.B10_ERROR || null');
+  const results = await page.evaluate('window.B10_RESULTS || {}');
+  await browser.close();
+  return { err, results };
+}
+
+(async () => {
+  build();
+  const server = serve();
+  let outcome;
+  try {
+    outcome = await run();
+  } finally {
+    server.close();
+  }
+  for (const [k, v] of Object.entries(outcome.results)) {
+    console.log(`;; ==== B10 PROD ${k} ====`);
+    console.log(v);
+  }
+  if (outcome.err) {
+    console.error(`[b10] FAILED: ${outcome.err}`);
+    process.exit(1);
+  }
+  console.error('[b10] ok');
+})();

--- a/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
+++ b/tools/story-mcp/test/re_frame/story_mcp/tools_test.clj
@@ -33,8 +33,7 @@
             [re-frame.story-mcp.tools.lifecycle :as lifecycle]
             [re-frame.story-mcp.tools.recorder :as recorder-tool]
             [re-frame.story-mcp.tools.registry :as registry]
-            [re-frame.substrate.plain-atom :as plain-atom])
-  (:import (java.util.concurrent CountDownLatch TimeUnit)))
+            [re-frame.substrate.plain-atom :as plain-atom]))
 
 ;; ResultIO mirror over story-mcp's CLJ-map result shape — used by the
 ;; cap-honours-default test to sum tokens without reaching into cap's
@@ -65,6 +64,14 @@
 ;; `reset-story-and-config` can clear it.
 (def ^:private declared-class (atom {}))
 
+;; The single key every driven recorder push registers its `add-watch` under
+;; (see `drive-events-during-recording`). Fixed rather than generated on
+;; purpose: with one key there is at most one driver watch on the recorder at
+;; any moment, a second drive displaces the first instead of stacking, and the
+;; fixture can retract a straggler by name without knowing whether one exists.
+;; Defined here (above the fixture) for the same reason `declared-class` is.
+(def ^:private drive-watch-key ::drive-events-during-recording)
+
 (defn reset-story-and-config
   "Each test gets a fresh Story registry + write-gate set to false (the
   documented default per spec/003-Write-Surface-Gating.md). Tests that need writes flip
@@ -93,6 +100,12 @@
   ;; Recorder atom is per-process — clear between tests so a previous
   ;; test's captured events don't bleed in.
   (recorder/clear!)
+  ;; And retract any driver watch whose window never opened, so a test that
+  ;; armed a push and then failed before invoking the tool cannot have that
+  ;; push fire into the NEXT test's recording (rf2-zrdog). The watch normally
+  ;; retracts itself the instant it fires; this covers the path where it never
+  ;; does. `remove-watch` on an absent key is a no-op.
+  (remove-watch recorder/state drive-watch-key)
   ;; Disable epoch-ring recording for the duration of each story-mcp test
   ;; (restored below). story-mcp's OWN artefact carries NO epoch dep, so a
   ;; standalone `cd tools/story-mcp && clojure -M:test` never loads
@@ -1765,95 +1778,71 @@
 ;;
 ;; The recorder normally captures events off the trace bus; for these tests
 ;; we drive `recorder/record-event!` directly during the tool's blocking
-;; window via a worker thread so the assertions exercise the start →
-;; capture → snippet plumbing without needing a live trace emitter.
+;; window so the assertions exercise the start → capture → snippet
+;; plumbing without needing a live trace emitter.
 ;; ---------------------------------------------------------------------------
 
 (defn- drive-events-during-recording
-  "Spawn a worker thread that polls for the recorder's open window, then
-  pushes `events` once `recording?` flips true. Polling `recording?`
-  avoids a `Thread/sleep delay-ms` race
-  — on a slow CI runner a fixed sleep could either fire BEFORE
-  `start-recording!` (events dropped, capture truncated) or AFTER
-  `stop-recording!` (same outcome). Polling `recording?` from the worker
-  end means we never depend on a sleep window outlasting the tool.
+  "Arrange for `events` to be pushed into the recorder's window the
+  instant that window opens, and return.
 
-  The worker's poll has a hard 5s upper bound — well past any
-  realistic tool latency — and bails silently if the recorder never
-  opens (the test asserts `:recorded-event-count` on the result and
-  catches a truncated capture there).
+  The push rides an `add-watch` on `recorder/state`. `start-recording!`
+  is one `(swap! state start …)`, so the watch runs SYNCHRONOUSLY on the
+  tool's own thread, inside that swap, with `:recording?` already true
+  and `stop-recording!` still an unreached line further down
+  `tool-record-as-variant`. The driver and the window therefore meet
+  causally: there is no interval in which the push can be early or late,
+  because there is no interval at all.
 
-  Returns the worker thread so a test can `.join` (with timeout) when
-  it needs determinism on whether the worker has finished pushing.
+  rf2-zrdog — what this replaces, and why the replacement is not another
+  timing assumption. The capture used to be driven from a worker thread
+  that polled `recording?`, and the flake was a scheduling race at the
+  START of the window: the caller opened a fixed 100 ms window while the
+  worker's start-to-first-poll latency was whatever the OS scheduler
+  felt like — under 1 ms idle, 82 ms measured with the cores saturated,
+  which is exactly what a full-namespace aggregate run does. Past 100 ms
+  the push landed after `stop-recording!`, `record-event!` no-opped
+  (`append` appends only while `:recording?`), and the test failed on
+  `(pos? 0)` having done nothing wrong.
 
-  rf2-zrdog — why the caller blocks on a start latch. Polling
-  `recording?` fixes the *stop* end of the race but not the *start*
-  end: the caller used to spawn the thread and immediately invoke the
-  tool, so the window the worker had to hit was a fixed 100ms of wall
-  clock measured from `start-recording!`, while the worker's
-  start-to-first-poll latency was whatever the OS scheduler felt like.
-  Idle, that latency measures under 1ms and the push always lands. With
-  the cores saturated — which is exactly what a full-namespace
-  aggregate run does — it was measured at 82ms, leaving 18ms of margin
-  against the window; one more scheduling hiccup and the worker reaches
-  its first poll after `stop-recording!` has already closed the window.
-  `record-event!` then no-ops (`append` appends only while
-  `:recording?`), the capture comes back empty, and the test fails on
-  `(pos? 0)` having done nothing wrong. That is a load-dependent flake,
-  not shared recorder state — the recorder atom is reset per test by the
-  fixture and no leftover worker was ever observed firing into another
-  test's window.
+  A `CountDownLatch` handshake was added to close that (PR #7129) and did
+  not: the worker counted the latch down as its FIRST act, before
+  computing its deadline or probing `recording?`, so the caller was
+  released while the worker was merely live rather than actually polling
+  — one deschedule after `.countDown` and the window closed unattended.
+  Worse, the caller ignored `.await`'s boolean and opened the window
+  after a timeout anyway, while the worker's own 5 s deadline was created
+  only when the worker eventually ran; a late worker could therefore
+  still be alive and fire into a LATER test's window. A watch has no
+  thread, no deadline, no timeout path and nothing left running when this
+  fn returns, so all three failure modes are gone by construction rather
+  than by margin.
 
-  So the handoff is synchronised rather than assumed: the worker counts
-  down `polling` as its first act, and this fn does not return until
-  that latch trips. By the time the caller opens the window the thread
-  is live and in its poll loop, and the unbounded thread-start term is
-  out of the race entirely. The latch wait carries the same 5s bound as
-  the poll itself so a thread that never starts fails the test rather
-  than hanging the suite.
+  The watch retracts itself before pushing, which both keeps
+  `record-event!`'s own `swap!` from re-entering it and guarantees that
+  exactly one window is driven per call. `reset-story-and-config`
+  retracts it again for the case the window never opens at all.
 
-  EP-0017: the 2-arity `(drive-events-during-recording
-  events cofx-vec)` pushes a parallel, index-aligned vector of captured
-  flat `:rf.cofx` maps (the framework `:rf/time-ms` + any provided facts
-  a dispatch carried) via the recorder's 2-arity `record-event!`, so a
-  test can exercise the capture→write-back cofx-preservation path the
-  same way the live trace listener does."
+  Capture is now EXACT: every event in `events` lands, so a test may
+  assert the count it drove rather than deriving one from the result.
+
+  EP-0017: the 2-arity `(drive-events-during-recording events cofx-vec)`
+  pushes a parallel, index-aligned vector of captured flat `:rf.cofx`
+  maps (the framework `:rf/time-ms` + any provided facts a dispatch
+  carried) via the recorder's 2-arity `record-event!`, so a test can
+  exercise the capture→write-back cofx-preservation path the same way the
+  live trace listener does."
   ([events] (drive-events-during-recording events nil))
   ([events cofx-vec]
-   (let [cofx-vec (vec (or cofx-vec []))
-         ;; Trips the moment the worker is live and about to poll, so the
-         ;; caller can open the recording window knowing the thread is
-         ;; already running rather than merely created (rf2-zrdog).
-         polling  (CountDownLatch. 1)
-         worker   (doto (Thread.
-                          ^Runnable
-                          (fn []
-                            (.countDown polling)
-                            ;; Poll `recording?` with a 1ms park between probes —
-                            ;; fine-grained so the worker fires promptly once the
-                            ;; window opens. Bails after 5s if the recorder never
-                            ;; opens (a tool bug; the test assertions will catch it).
-                            (let [deadline (+ (System/nanoTime) (* 5 1000000000))]
-                              (loop []
-                                (cond
-                                  (recorder/recording?)
-                                  (doseq [[i ev] (map-indexed vector events)]
-                                    (recorder/record-event! ev (get cofx-vec i)))
-
-                                  (< (System/nanoTime) deadline)
-                                  (do (Thread/sleep 1)
-                                      (recur))
-
-                                  ;; Timed out; bail. The test's
-                                  ;; :recorded-event-count assertion will
-                                  ;; surface the miss.
-                                  :else nil)))))
-                    (.setDaemon true)
-                    (.start))]
-     ;; Bounded so a thread that never starts fails the assertion below
-     ;; rather than hanging the suite.
-     (.await polling 5 TimeUnit/SECONDS)
-     worker)))
+   (let [cofx-vec (vec (or cofx-vec []))]
+     (add-watch recorder/state drive-watch-key
+                (fn [_ _ old new]
+                  (when (and (not (:recording? old)) (:recording? new))
+                    ;; Retract FIRST: `record-event!` swaps this same atom.
+                    (remove-watch recorder/state drive-watch-key)
+                    (doseq [[i ev] (map-indexed vector events)]
+                      (recorder/record-event! ev (get cofx-vec i))))))
+     nil)))
 
 (deftest record-as-variant-not-found
   (testing "unknown source variant ⇒ tool-execution error"
@@ -1927,8 +1916,11 @@
       ;; so the STORED body (`variant->edn`) reads `:play-script` carrying
       ;; the captured events as a LIVE, replayable script. Each captured
       ;; event becomes a `[:dispatch ...]` step.
-      ;; The exact count is derived from `:recorded-event-count` because
-      ;; the live-recorder capture races the :duration-ms window.
+      ;; The count is read back from `:recorded-event-count` rather than
+      ;; hard-coded. It is now deterministic — the driver's push fires inside
+      ;; `start-recording!`'s own swap (rf2-zrdog), so all driven events land —
+      ;; but reading it keeps this test about the SHAPE of the written-back
+      ;; body, with the count itself pinned by the tests that assert it.
       (let [body (story/variant->edn :story.button/primary)]
         (is (nil? (:play body))
             "the legacy dead :play slot must NOT be written")
@@ -1955,8 +1947,8 @@
       (is (= :story.button/recorded (:new-variant-id s)))
       (is (pos? n) "the recorder captured at least one event")
       ;; Write-back assocs the public `:script` slot, lowered to
-      ;; the shipping `:play-script` slot in storage (count derived from
-      ;; `:recorded-event-count` — capture races the :duration-ms window).
+      ;; the shipping `:play-script` slot in storage (count read back from
+      ;; `:recorded-event-count`; deterministic since rf2-zrdog).
       (is (= {:script (vec (repeat n [:dispatch [:counter/inc]])) :auto-run? true}
              (:play-script (story/variant->edn :story.button/recorded))))
       (is (nil? (:play (story/variant->edn :story.button/recorded))))
@@ -2050,14 +2042,14 @@
     ;; against the frame's app-db (proving the slot the runner executes
     ;; is the one write-back wrote).
     ;;
-    ;; The live-recorder capture races the tool's :duration-ms window
-    ;; (the worker may push 1–N of the driven events before
-    ;; `stop-recording!` closes the window), so the EXPECTED replay count
-    ;; is derived from `:recorded-event-count` rather than hard-coded —
-    ;; the invariant under test is "`:n` after replay == number of
-    ;; captured `:test/bump` steps", which holds regardless of how many
-    ;; the race captured. We require at least one capture so the replay
-    ;; path is genuinely exercised.
+    ;; The EXPECTED replay count is read back from `:recorded-event-count`
+    ;; rather than hard-coded, because the invariant under test is "`:n`
+    ;; after replay == number of captured `:test/bump` steps" and that is
+    ;; what should be asserted here whatever the capture was. Capture is no
+    ;; longer a race — the driver's push fires inside `start-recording!`'s own
+    ;; swap (rf2-zrdog), so all three driven events land — and the `(pos? n)`
+    ;; precondition below now reads as a guard on the replay path being
+    ;; genuinely exercised rather than as a hedge against a truncated window.
     (config/set-allow-writes! true)
     ;; A real event handler whose effect is observable in app-db.
     (rf/reg-event :test/bump (fn [{:keys [db]} _] {:db (update db :n (fnil inc 0))}))
@@ -2181,9 +2173,14 @@
           s (:structuredContent r)
           n (:recorded-event-count s)]
       (is (success? r))
-      (is (pos? n))
+      ;; Exactly the two events driven, not merely some (rf2-zrdog): the push
+      ;; now rides a watch that fires inside `start-recording!`'s own swap, so
+      ;; "how many landed" is not a scheduling outcome. `(pos? n)` here was
+      ;; what the old worker-thread race failed, and a derived count would
+      ;; have kept passing had the race merely truncated instead of emptying.
+      (is (= 2 n) "both driven events landed inside the window")
       (let [body (story/variant->edn :story.button/no-cofx)]
-        (is (= {:script    (vec (repeat n [:dispatch [:counter/inc]]))
+        (is (= {:script    [[:dispatch [:counter/inc]] [:dispatch [:counter/inc]]]
                 :auto-run? true}
                (:play-script body))
             "no captured cofx → bare 2-element dispatch steps, unchanged from pre-fix")


### PR DESCRIPTION
Two beads. One is a measurement that was an upper bound and is now a reading;
the other is a flaky test whose harness was wrong about scheduling.

---

## rf2-drpa3.182.15 — the two-clock envelope under `:advanced`

**120 Hz flipped, at every rung.**

Every figure in `docs/design/freehand/studio/two-clock-operating-envelope.md`
came from `:optimizations :none` with `goog.DEBUG true`, so the Spec 009
instrumentation seam, schema validation and trace emission were all live on
exactly the measured event path. Every cost was an upper bound and every rate a
lower bound. The 120 Hz row — 9.2 ms p95 against an 8.33 ms budget, a miss by
10% — was the row the unmeasured factor could flip.

### The measured factor

Crossing p50, union of **three** production runs against the published
development run:

| k | dev | **production** | factor |
|---:|---|---|---|
| 0 | 3.5–4.6 | **0.3–0.5** | 10.1–11.6x |
| 1 | 3.4–4.8 | **0.3–0.5** | 10.3x |
| 10 | 4.3–5.1 | **0.4–0.7** | 7.8–9.4x |
| 50 | 6.9–7.8 | **0.9–1.2** | 6.7–7.4x |
| 200 | 18.3–22.2 | **2.6–3.6** | 6.0–6.8x |

The three runs agreed to within 0.4 ms at every rung, so the factor is a
property of the bundle rather than of one afternoon.

### The 120 Hz row

Worst of twelve rounds against the 8.33 ms budget:

| k | p95 dev | **p95 prod** | 120 Hz |
|---:|---:|---:|:-:|
| 0 | 9.2 | **2.3** | fail then **pass** |
| 1 | 10.4 | **1.2** | fail then **pass** |
| 10 | 10.7 | **2.0** | fail then **pass** |
| 50 | 12.0 | **2.4** | fail then **pass** |
| 200 | 27.5 | **5.1** | fail then **pass** |

60 Hz, which broke between 50 and 200 siblings, is now comfortable across the
whole ladder. 240 Hz clears the latency bar up to k = 50.

The driven arm moved more. At k = 200 the offer rate saturated at 43–49/s in
development no matter what was asked; production delivers **61 / 124 / 244**
offers per second for 60 / 120 / 240 Hz requested. That ceiling was an artefact
of the build, not of the seam.

### An ablation arm, because three things differed at once

Arms A (dev) and C (production) differ in the optimiser, the define **and** the
build id, page and runner. Reading the whole gap as "`:advanced` is faster"
would attribute to the optimiser what could be any of them. Arm B changes
exactly one define against C — same entry, same page, same driver, same
optimiser, `goog.DEBUG` back on. A to B is the optimiser and the harness; B to
C is the instrumentation seam alone.

| | A dev | B ablation | **C production** |
|---|---|---|---|
| event p50, k=0 | 3.1–4.2 | 2.8–3.8 | **0.2–0.3** |
| commit p50, k=200 | 13–17.5 | 5.7–6.8 | **2.2–2.5** |

**The flat 3–4 ms event half was the instrumentation seam essentially in its
entirety** — `:advanced` barely moves it, the define collapses it ~13x. The
commit half benefits about evenly from both. Section 4's read-site penalty
splits the same way, which is what confirms the attribution: the `:parent` arm
halves under the optimiser (React reconciliation), the `:leaf` arm does not
move at all until the define flips.

### No `shadow-cljs.edn` change

The bead named a hot-zone build target as the reason this had not been done.
B6 had already shown it is unnecessary: `--config-merge` supplies an
`:output-dir` and an `:init-fn` on top of `:freehand-release`, which already
carries `:optimizations :advanced` and `goog.DEBUG false` — the only two
properties the reading is about. `b10_prod_run.cjs` does the same and touches
no shared configuration. **The diff to `implementation/shadow-cljs.edn` is
zero.** The report's section 9 records the correction.

The work belongs to the bench lane, not the correctness lane: the two new files
are a `:browser` entry and a node driver, neither matched by any `:ns-regexp`,
so `_browser-dom-lane-partition.test.cjs`'s partition is untouched and nothing
new enters `npm run test:browser` (verified below — same 840/5339 as before).

### Instrument discipline

No new instrument — every arm, window and control is `b10-two-clock`'s,
unchanged, at the dev run's constants verbatim so the factor is over the bundle
and not over the sampling.

* **0 unverified of 800 in every arm** — 0 of 5760 crossings across the report.
* **C2 predicted == measured at all 15 (mode x rung) combinations in every
  arm**, and the driven arm independently reproduced **exactly 201.0 mutations
  per crossing in all eight runs** across an 8.5x range of crossing counts.
  Under `:advanced` C2 doubles as the externs check — a renamed
  `MutationObserver` or style property fails here, and would have failed loudly
  (zero mutations everywhere) rather than subtly.
* **C1 read 0 samples below its own computed 4.00 ms**; p50 overshoot 0.0 ms
  everywhere, so no arm was measured on a contended machine.
* Both ladder orders, arm order rotating, ranges across rounds **and** across
  runs — never a mean alone.
* Runtime labelled beside every figure: HeadlessChrome 147, Windows 11 x64.

Both controls are hard failures in the prod entry rather than published rows,
and the run reports the build it actually got off `goog.DEBUG` rather than
taking the build command's word. The one provenance claim that is **not**
self-checked — arm B's optimiser label, which `detect-build` infers from
`goog.DEBUG` and so cannot see — is called out in section 9 rather than
glossed.

### The recommendation still holds, more strongly

Add no scheduling, throttle, debounce, coalescing, equality or preview
vocabulary. Peak backlog was **1** at every rate, both loads and both bundles,
now tested at five times the development throughput. The equality arms sit on
Chrome's 0.1 ms clock clamp. The `:update` elision counts 52 of 52 in all three
bundles.

**One claim is revised down.** The read-site penalty is a constant
**3.1–3.3 ms** rather than 40–44, a **1.3–4.2x** ratio rather than 8–19x. Still
a real cost and still worth the call-site guidance — the fix is free — but no
longer the kind of finding that would motivate surface even if surface were on
the table. The *structural* claim transferred and got tighter: the penalty is
constant across a 9x payload range, with the two constants within 0.2 ms of
each other.

M4 (controlled field) was not re-taken and the report says so: its verdict is
correctness, already gated deterministically, and outside the bead's scope.

---

## rf2-zrdog — the recorder driver's handoff

**Neither the product nor the byte-equality expectation was wrong. The test
harness was, and it was wrong about scheduling rather than about bytes.**

`record-as-variant-no-cofx-is-byte-identical` failed intermittently on
`(pos? n)` — the recorder captured 0 of the 2 events the test drove.
`(pos? n)` was catching something real (a genuinely empty capture), but the
emptiness was manufactured by the harness, so the fix is in the harness and the
byte-equality row is untouched except to get stronger.

`drive-events-during-recording` pushed events from a worker thread polling
`recording?`. That fixed the *stop* end of the race and left the *start* end
open: the caller opened a fixed 100 ms window while the worker's
start-to-first-poll latency was whatever the scheduler felt like — under 1 ms
idle, 82 ms with the cores saturated, which is exactly what a full-namespace
aggregate run does.

PR #7129's `CountDownLatch` handshake did not close it, and the merged-PR audit
on the bead is right about why:

* the worker called `.countDown` as its **first** act, before computing its
  deadline or probing `recording?`, so the latch established "the thread is
  live", not the claimed "the thread is in its poll loop";
* the caller ignored `.await`'s boolean and opened the window anyway after a
  timeout;
* the worker's own 5 s deadline was created only when the worker eventually
  ran, so a late worker could stay alive and fire into a **later** test's
  window.

Replaced with an `add-watch` on `recorder/state`. `start-recording!` is one
`(swap! state start ...)`, so the watch runs **synchronously on the tool's own
thread, inside that swap**, with `:recording?` already true and
`stop-recording!` an unreached line further down `tool-record-as-variant`.
Driver and window meet causally: there is no interval in which the push can be
early or late because there is no interval at all — and no thread, no deadline,
no timeout path and nothing left running when the fn returns, so all three
audit findings go by construction rather than by margin.

The watch retracts itself before pushing (`record-event!` swaps the same atom,
so this is also what keeps it from re-entering), and the fixture retracts it by
a fixed key for the case where the window never opens at all.

Capture is now exact, so the bead's own test asserts the 2 events it drove
instead of `(pos? n)`, and its written-back body is spelled literally instead
of `(repeat n ...)`. Three comments elsewhere that explained a derived count by
"the capture races the window" now describe a determinism rather than a hedge.

A thread, a latch, a deadline and a poll loop out; a watch in.

## Quality gates

Run in this worktree, foreground, to completion, logs kept beside the tree.

| Gate | Exit | Result |
|---|---|---|
| `tools/story-mcp` `clojure -M:test` | 0 | Ran 306 tests / 1605 assertions, 0 failures, 0 errors |
| same, **3x concurrently** (core-saturating, the flake's own condition) | 0, 0, 0 | 306 / 1605, 0 failures, each |
| `node --check b10_prod_run.cjs` | 0 | |
| `b10_prod_run.cjs` production run 1 | 0 | `:advanced` / `:instrumentation? false`; C1 0 below-predicted; C2 15/15 exact; 0 unverified of 800 |
| `b10_prod_run.cjs` production run 2 | 0 | same, and `:d021 :release-evidence` |
| `b10_prod_run.cjs` production run 3 | 0 | same, and `:d021 :release-evidence` |
| `B10_DEBUG=true b10_prod_run.cjs` ablation | 0 | C1 and C2 clean; 0 unverified of 800 |
| `python -m mkdocs build --strict` (repo root) | 0 | built in 22.89s; remaining INFO lines are pre-existing |
| `npm run test:browser` | 0 | 1055 files, 0 warnings; Ran 840 tests / 5339 assertions, 0 failures — identical to the pre-change lane, so the correctness lane is unaffected |
| `npm run bench:freehand-browser` | 0 | 259 files, 0 warnings; Ran 30 tests / 465 assertions, 0 failures — b10's DOM row still runs under `:none`, and the file count is unchanged, so neither new file entered a test build |

Deferred to CI: the full `test:cljs` node suite, the JVM artefact suites, and
every other browser gate. `implementation/shadow-cljs.edn` is **not** touched,
so no build-id gate is in scope.

Closes rf2-drpa3.182.15, rf2-zrdog.
