### PR TITLE
test(ssr): flows-integration-test comes off the production-gate roster; one line remains behind rf2-dtpfv (rf2-lwtlk)

### DIFF
--- a/implementation/ssr/test/re_frame/flows_integration_test.clj
+++ b/implementation/ssr/test/re_frame/flows_integration_test.clj
@@ -29,7 +29,13 @@
       candidate BEFORE install (rf2-uhk9ko, Option B): NO `db-changed` at
       all — the trace signature is the lone `:rf.error/schema-validation-
       failure` (`:rollback? true` = transaction rejected), and app-db
-      (including the flow's write) never changes.
+      (including the flow's write) never changes. This one bullet is a
+      DEV-POSTURE contract, and knowingly so: rf2-bkvu5 RULED (a) on
+      2026-07-27 that `reg-app-schema` candidate validation is a
+      DEVELOPMENT-ONLY assertion as designed — production trusts the
+      programmer, and a violating candidate installs. Both postures are
+      executed, in the two arms of
+      `flow-output-schema-failure-rejects-candidate-before-install`.
     - A flow THROW is a PRE-install throw: the event aborts, the pending
       `:db` is discarded, NO `db-changed`, no partial commit. The two
       recovery paths (schema-rejection vs flow-throw-abort) produce DISTINCT
@@ -134,6 +140,17 @@
 ;; `scripts/test-ssr-prod-gate.sh`.  The trace assertions are the
 ;; trace-LEVEL restatement each deftest's own comments already call
 ;; trace-level confirmation and trace signature.
+;;
+;; ONE arm in this file is NOT about the trace bus, and it is why this
+;; namespace was the last entry but one on the
+;; `scripts/test-ssr-prod-gate.sh` roster:
+;; `flow-output-schema-failure-rejects-candidate-before-install`'s REJECTION
+;; genuinely does not happen under the gate.  rf2-bkvu5 RULED (a) that this is
+;; by design — `reg-app-schema` is a development-only assertion; production
+;; trusts the programmer — so that deftest splits into a dev arm holding the
+;; rejection VERBATIM and a `when-not` arm that executes the ruled production
+;; behaviour.  Read its comments there before touching either arm: neither is
+;; a workaround for a red.
 
 (defn- snapshot
   "Read the snapshot for `machine-id` from the default frame's app-db."
@@ -260,7 +277,10 @@
             whole candidate before install (rf2-uhk9ko): ONE schema-
             validation-failure, ZERO db-changed, and the WHOLE db (handler
             write AND flow write) keeps the pre-handler value — the
-            container is never touched"
+            container is never touched.  That rejection is a DEV-POSTURE
+            contract (rf2-bkvu5 RULED (a)); under -Dre-frame.debug=false
+            there is no validator and the violating candidate installs
+            whole, which the `when-not` arm executes"
     ;; Malli app-db schema: [:derived :doubled] must be a NON-NEGATIVE int.
     (rf/reg-app-schema [:derived] [:map [:doubled [:int {:min 0}]]])
     (rf/reg-event :seed (fn [{:keys [db]} _] {:db {:n 1 :derived {:doubled 0}}}))
@@ -285,14 +305,52 @@
         (reset! flow-outputs [])
         (rf/dispatch-sync [:set-n -3])
 
-        ;; The candidate never installed — neither the handler's :n write NOR
-        ;; the flow's bad output ever reached the container.
-        (is (= baseline-db (rf/app-db-value :rf/default))
-            "the whole db keeps the pre-handler value — the flow write rode
-             the same rejected candidate as the handler's :db")
-        (is (= 1 (get (rf/app-db-value :rf/default) :n))
-            ":n stayed at the pre-handler value (1) — the handler's own write
-             was rejected too (atomic candidate boundary)")
+        ;; ---- POSTURE SPLIT (rf2-lwtlk), on the rf2-bkvu5 ruling ----------
+        ;;
+        ;; rf2-bkvu5 RULED (a) on 2026-07-27: `reg-app-schema` candidate
+        ;; validation is a DEVELOPMENT-ONLY assertion, AS DESIGNED —
+        ;; production trusts the programmer. `router.cljc`'s `validate-event!`
+        ;; and `schemas/validate.cljc` each wrap the whole validator body in
+        ;; its own `(if interop/debug-enabled? … true)` gate, read ONCE at
+        ;; namespace-load time, so under `-Dre-frame.debug=false` nothing
+        ;; validates and there is nothing to reject.
+        ;;
+        ;; This is the one arm in this file that could NOT be cleared with a
+        ;; production-visible witness instead of a guard, and the reason is
+        ;; worth stating: the always-on error axis carries no
+        ;; `:rf.error/schema-validation-failure` here NOT because the emit is
+        ;; dev-only, but because the VALIDATION never runs to emit anything.
+        ;; The subject itself is absent. So the rejection assertions are kept
+        ;; VERBATIM in a dev arm, and the posture that ships gets its own arm
+        ;; below rather than silence.
+        (when interop/debug-enabled?
+          ;; The candidate never installed — neither the handler's :n write NOR
+          ;; the flow's bad output ever reached the container.
+          (is (= baseline-db (rf/app-db-value :rf/default))
+              "the whole db keeps the pre-handler value — the flow write rode
+               the same rejected candidate as the handler's :db")
+          (is (= 1 (get (rf/app-db-value :rf/default) :n))
+              ":n stayed at the pre-handler value (1) — the handler's own write
+               was rejected too (atomic candidate boundary)"))
+
+        ;; THE RULED PRODUCTION POSTURE, EXECUTED (rf2-lwtlk / rf2-bkvu5 (a)).
+        ;; Without this arm the deftest would fall silent under the gate on
+        ;; the very outcome it exists to pin, and this namespace's most
+        ;; consequential claim would go unasserted in the posture that ships.
+        ;; It is also the standing regression guard on the ruling: shapes (b)
+        ;; and (c) — validation surviving the gate, with or without rollback —
+        ;; were both REJECTED, so a change that quietly made `reg-app-schema`
+        ;; always-on reddens here and sends the reader to the bead.
+        (when-not interop/debug-enabled?
+          (is (= {:n -3 :derived {:doubled -6}} (rf/app-db-value :rf/default))
+              "with no validator to reject it, the SCHEMA-VIOLATING candidate
+               installs WHOLE — the flow's -6 and the handler's :n -3 land
+               together, so the atomic candidate boundary is intact and it is
+               the VALIDATION that is absent, not the all-or-nothing commit")
+          (is (= -6 (get-in (rf/app-db-value :rf/default) [:derived :doubled]))
+              "the named consequence of rf2-bkvu5 (a), read through the
+               ordinary app-db surface: a value the registered schema declares
+               impossible ([:int {:min 0}]) is live on a production server"))
 
         ;; SEMANTIC, posture-independent (rf2-lwtlk): the flow COMPUTED (its
         ;; bad output is what tripped the validator) even though nothing

--- a/scripts/test-ssr-prod-gate.sh
+++ b/scripts/test-ssr-prod-gate.sh
@@ -388,10 +388,18 @@ fi
 #
 # RAISED 380 -> 410 by rf2-76gom / rf2-lwtlk.  The roster is down to 2 entries
 # and the lane runs 473 tests / 2093 assertions across 48 of 50 namespaces.
-# Raise it once more when `ssr-end-to-end-test` comes off behind rf2-dtpfv;
-# that is the last entry other than the rf2-bkvu5 hold, and the `-n`
-# machinery goes away with it.
-export RF2_MIN_TESTS="${RF2_MIN_TESTS:-410}"
+#
+# RAISED 410 -> 425 by rf2-lwtlk when `flows-integration-test` came off behind
+# the rf2-bkvu5 ruling.  This raise is CONVENTION MAINTENANCE, not a response
+# to that one namespace: 9 tests is 1.8% of the lane and no floor with usable
+# headroom could ever notice 9 tests vanishing.  What had drifted is the
+# headroom itself — the lane grew 473 -> 490 tests (2093 -> 2184 assertions,
+# now 50 of 51 namespaces) while the floor stayed at 410, widening the gap
+# from the ~13% this file has twice calibrated to, to 16.3%.  425 restores
+# ~13% against the observed 490.  Raise it once more when
+# `ssr-end-to-end-test` comes off behind rf2-dtpfv; that is the LAST entry,
+# and the `-n` machinery goes away with it.
+export RF2_MIN_TESTS="${RF2_MIN_TESTS:-425}"
 
 args=()
 for ns in $runnable; do

--- a/scripts/test-ssr-prod-gate.sh
+++ b/scripts/test-ssr-prod-gate.sh
@@ -221,28 +221,43 @@ known_red=(
   #    `:platforms #{:client}` gate, and a proof that a DOUBLE mismatch
   #    neither throws nor stops the effect queued behind it.
 
-  # ── rf2-bkvu5 — HELD FOR A RULING.  ONE deftest,
-  #    `flow-output-schema-failure-rejects-candidate-before-install`, fails
-  #    for a REAL reason: under `-Dre-frame.debug=false` a flow output that
-  #    violates the registered app-db schema is NOT rejected — the invalid
-  #    candidate INSTALLS, and the handler's own `:db` installs with it.
-  #    That is not trace spelling.  `router.cljc`'s `validate-event!` and
-  #    `schemas/validate.cljc` both document it: every `validate-*!` body
-  #    sits inside its own `(if interop/debug-enabled? … true)` gate and
-  #    "Production builds return `true` unconditionally".  So `reg-app-schema`
-  #    is a no-op in production and the EP-0025 atomic-candidate-rejection
-  #    contract is a DEV-POSTURE contract.  Adjacent to rf2-rqje9 in class —
-  #    a documented choice whose consequence nobody had executed — but a
-  #    different surface, and none of rf2-rqje9's three candidate shapes
-  #    addresses it, so it has its own bead.
+  # ── rf2-bkvu5 — RULING LANDED (2026-07-27); CLEARED.  One deftest,
+  #    `flow-output-schema-failure-rejects-candidate-before-install`, used to
+  #    fail here for a REAL reason rather than trace spelling: under
+  #    `-Dre-frame.debug=false` a flow output that violates the registered
+  #    app-db schema is NOT rejected — the invalid candidate INSTALLS, and
+  #    the handler's own `:db` installs with it.  `router.cljc`'s
+  #    `validate-event!` and `schemas/validate.cljc` both document why: every
+  #    `validate-*!` body sits inside its own `(if interop/debug-enabled? …
+  #    true)` gate and "Production builds return `true` unconditionally".
   #
-  #    Every OTHER assertion in this namespace has already been posture-split
+  #    Mike RULED (a): that is BY DESIGN.  `reg-app-schema` candidate
+  #    validation is a DEVELOPMENT-ONLY assertion; production trusts the
+  #    programmer; EP-0025's atomic-candidate-rejection contract is a
+  #    dev-posture contract.  Shapes (b) (always-on validation) and (c) (a
+  #    middle knob) were both rejected.
+  #
+  #    SO THE DEFTEST DID NOT CLEAR — IT SPLIT, and this is the one arm in
+  #    the artefact that could not be re-pointed at a production-visible
+  #    witness instead of a guard.  The distinction matters for whoever
+  #    reads it next: the always-on error axis carries no
+  #    `:rf.error/schema-validation-failure` here NOT because that emit is
+  #    dev-only, but because the VALIDATION never runs to emit anything —
+  #    the subject is absent, not merely unobservable.  The rejection
+  #    assertions are kept VERBATIM in a `(when interop/debug-enabled? …)`
+  #    arm, and a `when-not` arm EXECUTES the ruled production behaviour
+  #    (the schema-violating candidate installs whole, `:derived :doubled`
+  #    = -6 through the ordinary app-db surface).  That arm is also the
+  #    standing regression guard on the ruling itself: it reddens if
+  #    `reg-app-schema` ever quietly becomes always-on.
+  #
+  #    Every OTHER assertion in the namespace had already been posture-split
   #    by rf2-lwtlk (the `by-op` / `ops` trace signatures are in dev arms, and
   #    two flow-eval witnesses were added off the trace bus so "the flow
-  #    computed its bad output" and "the flow threw" survive the gate).  The
-  #    line below therefore comes out with a one-line change once rf2-bkvu5
-  #    lands.  Do not split that one deftest before it does.
-  re-frame.flows-integration-test                 #   2
+  #    computed its bad output" and "the flow threw" survive the gate), so
+  #    the namespace now runs in this lane: 9 tests, 39 assertions under the
+  #    gate (was 39 with TWO of them red) against 55 in dev posture (was 55 —
+  #    the rejection pair moved into the arm, it did not leave).
 
   # ── rf2-lwtlk / rf2-76gom — the conformance corpus.  CLEARED, and it did
   #    NOT clear by guarding.  Nine `ssr-*.edn` fixtures used to fail here,
@@ -347,7 +362,7 @@ total_count="$(printf '%s\n' "$all_nses" | grep -c . || true)"
 printf '==> implementation/ssr under the REAL production gate\n'
 printf '    jvm property : -Dre-frame.debug=false (implementation/ssr/deps.edn, :prod-gate :jvm-opts)\n'
 printf '    posture pin  : re-frame.ssr-prod-gate-lane-pin-test (red if the property did not arrive)\n'
-printf '    namespaces   : %s of %s (%s excluded as known-red — rf2-lwtlk, rf2-rqje9)\n' \
+printf '    namespaces   : %s of %s (%s excluded as known-red — rf2-dtpfv)\n' \
   "$runnable_count" "$total_count" "$excluded_count"
 
 if [ "${1:-}" = "--plan" ]; then


### PR DESCRIPTION
`re-frame.flows-integration-test` comes off the `scripts/test-ssr-prod-gate.sh`
roster. **One line remains, and it is not mine to take** — see the last section.

## The split

rf2-bkvu5 RULED (a): `reg-app-schema` candidate validation is a
DEVELOPMENT-ONLY assertion, as designed. Production trusts the programmer, and
a schema-violating candidate installs.

So `flow-output-schema-failure-rejects-candidate-before-install` did not
**clear** — it **split**. It is the one arm in this artefact that could not be
re-pointed at a production-visible witness instead of a guard, and the reason
is recorded at both sites because the next reader will otherwise assume the
usual shape: the always-on error axis carries no
`:rf.error/schema-validation-failure` here **not** because that emit is
dev-only, but because the VALIDATION never runs to emit anything. The subject
is absent, not merely unobservable.

- the two rejection assertions are kept **verbatim** inside
  `(when interop/debug-enabled? …)`;
- a `when-not` arm **executes the ruled production behaviour** — the violating
  candidate installs whole (`:n -3` and the flow's `-6` land together, so the
  atomic candidate boundary is intact and it is the validation that is gone),
  and `[:derived :doubled]` reads `-6` through the ordinary `app-db` surface.
  That is rf2-bkvu5's named consequence asserted rather than described.

Without that second arm the deftest would fall silent under the gate on the
very outcome it exists to pin. It doubles as the standing regression guard on
the ruling: shapes (b) and (c) were both rejected, so a change that quietly
made `reg-app-schema` always-on reddens here and sends the reader to the bead.

The ns docstring's contract bullet is qualified as dev-posture in the same
change, and the posture-split note above the helpers now says which arm is
about the trace bus and which is not.

## Roster: before / after

| | before | after |
|---|---|---|
| lane namespaces | 49 of 51 | **50 of 51** |
| roster entries | 2 | **1** (`ssr-end-to-end-test`, rf2-dtpfv) |
| lane tests / assertions | 481 / 2145 | **490 / 2184** |

The lane figures are measured after; the delta is exactly the newly admitted
namespace, measured on its own at 9 tests / 39 assertions.

## Nothing was lost

`re-frame.flows-integration-test`, single namespace:

| posture | before | after |
|---|---|---|
| dev (`-M:test`) | 9 tests / **55** assertions | 9 tests / **55** assertions |
| gate (`-M:test:prod-gate`) | 9 tests / 39 assertions, **2 RED** | 9 tests / 39 assertions, **0 red** |

Test count held at 9; dev-posture assertion count level at 55. The rejection
pair moved *into* the arm — it did not leave — and the two assertions that were
failing under the gate are replaced by two that assert the posture that ships.

## `RF2_MIN_TESTS`: 410 -> 425

Convention maintenance, not a response to the 9 tests this adds: no floor with
usable headroom notices 9 tests (1.8% of the lane) vanishing. What drifted is
the headroom — the lane grew 473 -> 490 tests while the floor stayed at 410,
widening the gap from the ~13% this file has twice calibrated to, to 16.3%.
425 restores ~13% against the observed 490. A floor left calibrated against an
older, smaller run stops being a floor and becomes a formality, which is the
failure mode the previous raise (380 -> 410) was written to fix.

## The line that remains, and why it cannot come off here

`re-frame.ssr-end-to-end-test` stays rostered, behind **rf2-dtpfv (P1, open)**.

This is not deferred triage. rf2-dtpfv is RULED (b) — the reserved
`:rf.server/*` fx family must guard its own args **unconditionally** — and that
bead **is the implementation owner**. Clearing this line requires production
source and hot-zone spec that this PR deliberately does not touch:
`implementation/ssr/src/re_frame/ssr/response.cljc`,
`.../server_fx_schemas.cljc`, `implementation/ssr-ring/src/…/pipeline.clj`,
plus `spec/010-Schemas.md` and `spec/011-SSR.md`.

Its remaining 116 reds are 39 deftests of mechanical trace-sourcing plus
`ssr-server-fx-args-schema-boundary`, which fails for a **real** reason: the
Spec 010 step-5 fx-args boundary does not run in a release build, so a
malformed `:rf.server/*` fx runs and its args reach the response accumulator.
Those seven semantic assertions must be **rewritten as a two-posture contract
once the guards land** — not split. The roster comment already carries the
per-cluster method for the other 39 verbatim, and rf2-dtpfv's contract has them
riding its own PR, so splitting them here would buy the lane nothing (the
namespace stays excluded either way) while conflicting with that bead's owner.

rf2-lwtlk therefore stays **OPEN**.

## Quality gates

All run from the worker worktree, foreground, unpiped, exit codes captured.

| gate | result |
|---|---|
| `bash scripts/test-ssr-prod-gate.sh` (final, committed state) | **exit 0** — 490 tests / 2184 assertions, 50 of 51 namespaces, 0 failures |
| `clojure -M:test` (full ssr dev suite) | **exit 0** — 559 tests / 2705 assertions, 0 failures |
| `clojure -M:test:prod-gate -n re-frame.flows-integration-test` | **exit 0** — 9 / 39, 0 failures (was exit 1, 2 failures) |
| `clojure -M:test -n re-frame.flows-integration-test` | **exit 0** — 9 / 55, 0 failures |
| `python scripts/check_jvm_lane_rosters.py` | **exit 0** — 31 rostered artefacts, **0 baselined** |

No core-lane run is owed: `egress_chokepoint_conformance_test` source-scans
`src/` trees only (and guards with an explicit `/test/` exclusion), and this PR
touches no `src/` file in any artefact.

Deferred to CI: the full JVM implementation sweep and the CLJS suites — nothing
here is reachable from them.
