### PR TITLE
feat(core): a rejected boundary reports itself in production (rf2-mwv4e)

### DIFF
--- a/implementation/core/src/re_frame/event_emit.cljc
+++ b/implementation/core/src/re_frame/event_emit.cljc
@@ -34,10 +34,29 @@
                    as evidence that no schema was violated.
     :flow-error  — a flow's `:output` threw (Spec 013 §Failure
                    semantics rule 3); the cascade halted before `:fx`.
+    :rejected    — the `:rf.schema/at-boundary` interceptor REFUSED the
+                   event's payload against the handler's `:schema`
+                   (Spec 010 §Production builds, rf2-mwv4e). The handler
+                   never ran; entered interceptors still unwound in
+                   full. This is the exact COMPLEMENT of `:rolled-back`
+                   on the production question: boundary validation is
+                   the one schema surface Spec 010 keeps UNGATED, so
+                   `:rejected` DOES have a producer in a release build —
+                   it is the outcome to alert on for hostile or
+                   malformed input at an untrusted ingress. Reported
+                   only when the boundary skip is the whole story: a
+                   chain throw (`:error`), a flow throw
+                   (`:flow-error`) or a candidate rollback
+                   (`:rolled-back`) during the unwind still wins.
+                   Paired with one always-on
+                   `:rf.error/schema-validation-failure` record
+                   (`:source :boundary`) on the `:errors` stream, which
+                   carries the identifiers; the offending VALUE rides
+                   the dev-only trace and never egresses.
 
   Every non-`:ok` value surfaces a failed dispatch to off-box shippers
-  so a rolled-back / flow-aborted dispatch is never mis-reported as a
-  clean `:ok`.
+  so a rolled-back / flow-aborted / boundary-refused dispatch is never
+  mis-reported as a clean `:ok`.
 
   Listener REGISTRATION sites SHOULD use `goog.DEBUG=false` as a
   belt-and-braces gate alongside an explicit config flag. The

--- a/implementation/core/src/re_frame/events.cljc
+++ b/implementation/core/src/re_frame/events.cljc
@@ -262,6 +262,27 @@
                   :id     id}}))
   nil)
 
+(defn boundary-guarded-handler?
+  "True when a registered event handler's `handler-meta` REFERENCES the
+  `:rf.schema/at-boundary` interceptor — i.e. the app opted this handler into
+  production-side boundary validation (Spec 010 §Production builds).
+
+  rf2-mwv4e — the DEV half of the boundary-rejection marker. In a dev build the
+  boundary interceptor is a no-op and step-1 `validate-event!` does the
+  refusing, so the router cannot tell a boundary refusal from an ordinary
+  dev-only schema refusal without asking this question. It asks it ONLY on the
+  refusal path (`run-chain`, when `event-ok?` is falsy), so the hot path pays
+  nothing.
+
+  Reads the AUTHORED chain — the same surface `reject-at-boundary-without-
+  schema!` checks at registration time, and the one the docs name as the opt-in
+  (`{:interceptors [:rf.schema/at-boundary]}`). A per-frame `:interceptors`
+  chain that attaches the interceptor globally is deliberately NOT counted: the
+  interceptor is meaningless without the HANDLER's own `:schema`, which is what
+  the registration-time check binds it to."
+  [handler-meta]
+  (attaches-validate-at-boundary-interceptor? (:interceptors handler-meta)))
+
 ;; ---- effect-map shape policing (Spec migration M-8) -----------------------
 ;;
 ;; Per migration/from-re-frame-v1/README.md §M-8 and Spec-Schemas.md §:rf/effect-map,

--- a/implementation/core/src/re_frame/router.cljc
+++ b/implementation/core/src/re_frame/router.cljc
@@ -2043,8 +2043,8 @@
 ;;                               error emit (if any), :db commit (of the
 ;;                               flow-augmented db), then walk :fx in source
 ;;                               order; returns the dispatch outcome keyword
-;;                               (:ok / :error / :rolled-back / :flow-error)
-;;                               for the event-emit record
+;;                               (:ok / :error / :rolled-back / :flow-error /
+;;                               :rejected) for the event-emit record
 ;;   emit-pipeline-trailers!      :run-end trace + always-on event-emit fan-out
 ;;   run-handler-pipeline!        sequence prepare → run → commit → trailers
 ;;                               under `trace/with-handler-scope`
@@ -2339,11 +2339,24 @@
   `rf:event:<event-id>` measure entry under prod builds with the perf
   flag enabled. Default-off; under `:advanced` +
   `re-frame.performance/enabled?=false` the bracket DCEs and the call
-  collapses to a plain `execute-chain` invocation."
-  [event-id full-chain initial-ctx event-ok?]
+  collapses to a plain `execute-chain` invocation.
+
+  rf2-mwv4e — this is the DEV half of the `:rf/boundary-rejected?` marker. When
+  step-1 refused an event whose handler REFERENCES `:rf.schema/at-boundary`,
+  the refusal IS a boundary refusal and takes the same marker the production
+  interceptor stamps (`re-frame.spec`), so the router tail fans one always-on
+  record and settles `:outcome :rejected` in either posture. An ordinary
+  dev-only `:schema` refusal on an UNGUARDED handler is deliberately NOT
+  marked: that surface has no production counterpart (Spec 010 §Production
+  builds, rf2-bkvu5), so marking it would invent a production signal that
+  cannot exist. The predicate runs only on the refusal path — the hot path
+  keeps its single `if`."
+  [event-id full-chain initial-ctx event-ok? handler-meta]
   (let [ctx (if event-ok?
               initial-ctx
-              (assoc initial-ctx :rf/skip-handler? true))]
+              (cond-> (assoc initial-ctx :rf/skip-handler? true)
+                (events/boundary-guarded-handler? handler-meta)
+                (assoc :rf/boundary-rejected? true)))]
     (performance/mark-and-measure :event event-id
       (interceptor/execute-chain
         full-chain ctx
@@ -2417,13 +2430,25 @@
     :flow-error  — a flow's `:derive` threw (Spec 013 §Failure
                    semantics); the event aborted — no install, app-db
                    unchanged, no db-changed, :fx skipped.
+    :rejected    — the `:rf.schema/at-boundary` security gate REFUSED
+                   the event's payload against the handler's `:schema`
+                   (rf2-mwv4e). The handler never ran, so nothing it
+                   would have written exists; entered interceptors
+                   still unwound in full and any effects THEY produced
+                   keep their ordinary treatment. Unlike
+                   `:rolled-back`, this outcome DOES have a producer in
+                   a production build — the boundary check is the one
+                   validation surface Spec 010 keeps ungated.
 
-  All three non-`:ok` values surface to off-box observability shippers
+  All four non-`:ok` values surface to off-box observability shippers
   (Datadog / Sentry / Honeycomb) so a dispatch whose `:db` write was
-  rejected or that aborted on a flow throw is NOT mis-reported as
-  a clean `:ok`. A chain exception is reported as `:error` regardless
-  of any downstream rejection — it is the proximate, most-actionable
-  signal."
+  rejected, that aborted on a flow throw, or whose untrusted payload was
+  refused at the boundary is NOT mis-reported as a clean `:ok`. A chain
+  exception is reported as `:error` regardless of any downstream
+  rejection — it is the proximate, most-actionable signal — and
+  `:rejected` is the LOWEST-priority discriminator: it is selected only
+  when the boundary skip is the whole story, so a chain throw, a flow
+  throw or a candidate rollback during the unwind still wins."
   [final-ctx event-id event frame frame-record fx-overrides envelope start-ms]
   (let [owner-token (frame/current-event-owner-token)
         live?       #(and (not (:rf/stale-incarnation? final-ctx))
@@ -2495,9 +2520,87 @@
                         (run-fx-effects!
                           effects frame frame-record owner-token
                           fx-overrides envelope)]
-                    (if (= ::stale-incarnation fx-result)
-                      ::stale-incarnation
-                      :ok)))))))))))
+                    (cond
+                      (= ::stale-incarnation fx-result) ::stale-incarnation
+                      ;; rf2-mwv4e — LOWEST-priority discriminator. Every
+                      ;; higher-priority outcome has already returned above,
+                      ;; so reaching here with the marker set means the
+                      ;; boundary skip really was the whole story: no chain
+                      ;; throw, no flow throw, no candidate rollback. Before
+                      ;; this, a refused untrusted payload settled `:ok` — the
+                      ;; event stream reporting success for a dispatch whose
+                      ;; handler never ran.
+                      (:rf/boundary-rejected? final-ctx) :rejected
+                      :else                              :ok)))))))))))
+
+;; ---- the boundary-rejection always-on record (rf2-mwv4e) -------------------
+;;
+;; `:rf.schema/at-boundary` is the ONE validation surface Spec 010 keeps
+;; ungated in a production build — the opt-in gate for untrusted system
+;; ingress (an HTTP response, a websocket frame, a `postMessage`, a query
+;; string). Its REFUSAL always survived the gate; its REPORT did not.
+;; `trace/emit-error!` sits behind `interop/debug-enabled?`, so under
+;; `:advanced` + `goog.DEBUG=false` a rejected payload skipped its handler and
+;; told nobody — an opt-in security gate invisible to the person who opted in.
+;;
+;; This is the always-on half. It follows the promotion pattern the URL
+;; route-miss (rf2-ov56u) and the safe-redirect rejections (rf2-6jqa8)
+;; established: keep the rich dev trace exactly as it was, add ONE tight
+;; production fact, let the existing projector consume it.
+;;
+;; STRUCTURAL-ONLY, and here that is stricter than a scrub. A validation
+;; failure's natural detail is THE VALUE THAT FAILED, which on this surface is
+;; attacker-controlled or user-private BY DEFINITION — a rejected payload can
+;; carry secrets in keys the declared schema never anticipated, so no
+;; schema-aware redactor can be trusted to have seen them. So rather than
+;; scrubbing an attacker-controlled slot (the rf2-ov56u / rf2-6jqa8 treatment,
+;; where the URL IS the observability payload), this record OMITS every
+;; payload-derived slot outright: no event vector, no `:value`, no
+;; `:received`, no `:explain`, no schema form, no human `:reason` (which would
+;; interpolate the offending value — the `ssr/hydrate` hazard). What remains is
+;; identifiers, which is enough to COUNT, ATTRIBUTE, ALERT and PROJECT the
+;; rejection; the diagnosis stays on the DCE'd dev trace in `re-frame.spec`.
+;; Per OWASP's Logging Cheat Sheet: log input-validation failures, sanitise
+;; event data arriving from another trust zone.
+;;
+;; PROJECTION-ELIGIBLE, deliberately, and this is where it diverges from
+;; rf2-6jqa8. The three safe-redirect categories joined
+;; `non-projection-eligible-errors` so a hostile probe could not conjure a 500.
+;; A boundary rejection on a server frame is the opposite case: it is exactly a
+;; 400 (RFC 9110 §15.5.1), the SSR default projector already maps
+;; `:rf.error/schema-validation-failure` + `:where :event` to one, and letting
+;; it project is what closes the silent-200 SSR hole that surfaced this bead.
+
+(defn- emit-boundary-rejection-record!
+  "Fan the ONE always-on STRUCTURAL-ONLY record for a boundary rejection.
+
+  The key set is CLOSED and is pinned by
+  `re-frame.always-on-validation-production-test`; a slot added here reaches an
+  off-box shipper (Sentry / Datadog), so read the section comment above before
+  widening it. `:event-id` / `:failing-id` / `:schema-id` are all the event id
+  — the same three-slot shape the dev trace carries, so the two axes name the
+  same fact identically. `:frame` may be nil (the frameless
+  `:rf.error/no-frame-context` precedent).
+
+  Reached through `error-emit/dispatch-error-record!`, the general non-event
+  union-record chokepoint: a refused dispatch is not a dispatched-event
+  FAILURE (nothing threw), so the event-centric `dispatch-on-error!` positional
+  shape — which would carry the `:event` wire value — is both the wrong shape
+  and the wrong egress. Called from the pipeline tail so the dev and production
+  enforcement routes share ONE emit site and a rejection can never produce two
+  records."
+  [event-id frame]
+  (error-emit/dispatch-error-record!
+    {:error      :rf.error/schema-validation-failure
+     :where      :event
+     :source     :boundary
+     :event-id   event-id
+     :failing-id event-id
+     :schema-id  event-id
+     :frame      frame
+     :recovery   :no-recovery
+     :time       (interop/now-ms)})
+  nil)
 
 (defn- emit-pipeline-trailers!
   "Pipeline-run-tail emissions: the dev-only `:run-end` trace then the
@@ -2517,8 +2620,9 @@
   contract holds on both platforms.
 
   `outcome` is the keyword `commit-and-flow!` returns — `:ok`,
-  `:error`, `:rolled-back`, or `:flow-error` — and rides straight onto
-  the event-emit record's `:outcome` slot (Spec 009 §Record shape).
+  `:error`, `:rolled-back`, `:flow-error`, or `:rejected` — and rides
+  straight onto the event-emit record's `:outcome` slot (Spec 009
+  §Record shape).
 
   `handler-elapsed-ms` (rf2-hhh92) is the HANDLER-BODY-only wall-clock
   (the interceptor-chain duration, captured before `commit-and-flow!`),
@@ -2754,7 +2858,8 @@
                                             (frame/current-event-owner-token))))
             final-ctx (if (frame/event-continuation-live?
                             frame (frame/current-event-owner-token))
-                        (run-chain event-id full-chain initial-ctx event-ok?)
+                        (run-chain event-id full-chain initial-ctx event-ok?
+                                   handler-meta)
                         (assoc initial-ctx :rf/stale-incarnation? true))
             ;; rf2-hhh92: the HANDLER-BODY-only elapsed — the interceptor
             ;; chain (`run-chain`) duration, captured BEFORE
@@ -2767,14 +2872,32 @@
             handler-elapsed-ms (when interop/debug-enabled?
                                  (- (interop/now-ms) start-ms))
             ;; `commit-and-flow!` returns the dispatch outcome keyword
-            ;; (:ok / :error / :rolled-back / :flow-error) so the always-on
-            ;; event-emit record reflects schema-rejection and flow-throw
-            ;; failures, not just the chain exception.
+            ;; (:ok / :error / :rolled-back / :flow-error / :rejected) so the
+            ;; always-on event-emit record reflects schema-rejection,
+            ;; flow-throw and boundary-refusal outcomes, not just the chain
+            ;; exception.
             outcome   (commit-and-flow! final-ctx event-id event frame
                                         frame-record fx-overrides envelope start-ms)]
         ;; A stale A tail is deliberately silent: run-end / always-on handled
         ;; records keyed by the bare id would describe fresh same-id B.
         (when-not (= ::stale-incarnation outcome)
+          ;; rf2-mwv4e — the always-on boundary-rejection record LEADS the
+          ;; tail: it is the CAUSE, and the `:events` record the trailers fan
+          ;; carries only its consequence (`:outcome :rejected`). This is the
+          ;; ONE emit site for both enforcement routes — in dev the refusal
+          ;; happens in step-1 `validate-event!`, in production inside the
+          ;; boundary interceptor, and both merely stamp
+          ;; `:rf/boundary-rejected?` for this line to read — so a rejection
+          ;; can never produce two records. It keys off the rejection FACT
+          ;; rather than the outcome, so a refusal whose interceptor unwind
+          ;; then threw reports BOTH the refusal and the throw. Wrapped in the
+          ;; exact-owner fence because the always-on fan-out runs listener
+          ;; callbacks, one of which may destroy this frame; `emit-pipeline-
+          ;; trailers!` re-checks liveness on entry and goes silent if so.
+          (when (:rf/boundary-rejected? final-ctx)
+            (call-while-exact-owner
+              frame (frame/current-event-owner-token)
+              #(emit-boundary-rejection-record! event-id frame)))
           (emit-pipeline-trailers! event-id event emit-event frame outcome
                                   start-ms handler-elapsed-ms final-ctx)))))))))
 

--- a/implementation/core/src/re_frame/spec.cljc
+++ b/implementation/core/src/re_frame/spec.cljc
@@ -116,6 +116,15 @@
 ;; The interceptor's `:id` is `:rf.schema/at-boundary` — renamed from
 ;; `:spec/at-boundary` at rf2-ieu0i and finalised under the schema-
 ;; vocabulary strip in rf2-9brg7 (audit-of-audits schemas #6).
+;;
+;; rf2-mwv4e — the rejection ALSO stamps `:rf/boundary-rejected?` on the
+;; context. That marker is the single internal fact the router's tail reads to
+;; (a) fan ONE always-on structural record and (b) settle the dispatch
+;; `:outcome :rejected` instead of the `:ok` a handler-less run would otherwise
+;; report. The dev route reaches the SAME marker from `re-frame.router`'s
+;; `run-chain` (step-1 refused an event whose handler references this
+;; interceptor), so both enforcement routes converge on one marker and one emit
+;; site. See `router/emit-boundary-rejection-record!`.
 
 (def validate-at-boundary-interceptor
   "Production-side schema validation interceptor VALUE, registered under the
@@ -131,6 +140,14 @@
   a parallel schema. No-op in dev builds (step-1 validation already
   fires); no-op when no validator is registered (`set-schema-validator!`
   was called with `nil`).
+
+  A rejection is OBSERVABLE in a production build (rf2-mwv4e): besides the
+  handler skip it stamps `:rf/boundary-rejected?` on the context, and the
+  router's tail turns that into one always-on
+  `:rf.error/schema-validation-failure` record (`:source :boundary`) plus an
+  `:outcome :rejected` on the event-emit record. Both survive `:advanced` +
+  `goog.DEBUG=false`; the rich `:value` / `:explain` diagnosis stays on the
+  DCE'd dev trace below.
 
   Per rf2-iftj4, registering a handler that attaches `validate-at-boundary-interceptor` but
   carries no `:schema` is rejected at registration time with
@@ -236,13 +253,18 @@
                                                                 (error/type-of-value event) ".")
                                                :recovery   :no-recovery}
                                         frame (assoc :frame frame))]
-                      ;; Emit the failure trace using the same shape as
+                      ;; Axis 2 — the RICH dev trace, using the same shape as
                       ;; dev-mode step-1 (per Spec 010 L149). Per Spec
                       ;; 009 §Production builds `emit-error!` itself
                       ;; elides under `:advanced` + `goog.DEBUG=false`,
                       ;; so this body only fires under JVM / dev-CLJS
                       ;; with debug-enabled? flipped off — exactly the
-                      ;; surface the rf2-r2uh tests exercise.
+                      ;; surface the rf2-r2uh tests exercise. The
+                      ;; payload-bearing slots (`:received` / `:value` /
+                      ;; `:explain` / the interpolated `:reason`) ride HERE
+                      ;; and ONLY here — see the always-on record's
+                      ;; structural-only contract in
+                      ;; `router/emit-boundary-rejection-record!`.
                       (trace/emit-error! :rf.error/schema-validation-failure
                                          (cond-> base-tags
                                            redact-fn (->> (redact-fn schema))))
@@ -250,7 +272,16 @@
                       ;; is not invoked. The handler-as-interceptor
                       ;; checks `:rf/skip-handler?` in its :before slot
                       ;; (see events.cljc).
-                      (assoc ctx :rf/skip-handler? true))))))))))))
+                      ;;
+                      ;; rf2-mwv4e — `:rf/boundary-rejected?` is the second
+                      ;; half: the router tail reads it to fan the always-on
+                      ;; structural record (axis 1) and to settle the dispatch
+                      ;; `:outcome :rejected`. Kept as a context marker rather
+                      ;; than emitting here so the dev and production
+                      ;; enforcement routes share ONE emit site and a rejection
+                      ;; can never produce two records.
+                      (assoc ctx :rf/skip-handler?      true
+                                 :rf/boundary-rejected? true))))))))))))
 
 ;; ---- :rf.schema/at-boundary registration (EP-0022, rf2-i3uxo2) ------------
 ;;

--- a/implementation/core/test/re_frame/always_on_validation_production_test.clj
+++ b/implementation/core/test/re_frame/always_on_validation_production_test.clj
@@ -60,11 +60,29 @@
   step-1 validation really has been elided. Without it, \"the handler did not
   run\" would prove nothing about which mechanism stopped it.
 
+  ## Surface 2 has a SECOND half (rf2-mwv4e)
+
+  Surface 2 above pins that the boundary REFUSAL survives the gate. Until
+  rf2-mwv4e its REPORT did not, and nothing in this namespace noticed: the
+  boundary deftest captured neither axis, unlike its recordable-cofx
+  neighbours, so \"the handler was skipped\" passed while the rejection was
+  silent AND its `:events` record read `:outcome :ok` — an off-box shipper saw
+  a dispatch that succeeded. The rejection now fans one always-on
+  STRUCTURAL-ONLY `:rf.error/schema-validation-failure` record (`:source
+  :boundary`) and settles `:outcome :rejected`, and the deftests below pin
+  BOTH, under this same real gate, including the key set CLOSED and the
+  ABSENCE of every payload-bearing slot. That absence is the egress contract:
+  whatever this record carries ships to Sentry / Datadog, and a rejected
+  boundary payload is attacker-controlled by definition.
+
   Deliberately NOT used: `with-redefs` on `interop/debug-enabled?`. The flag is
   read once at namespace-load time; a rebind cannot reach it (rf2-f7qj4)."
-  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+  (:require [clojure.set :as set]
+            [clojure.string :as str]
+            [clojure.test :refer [deftest is testing use-fixtures]]
             [re-frame.core :as rf]
             [re-frame.error-emit :as error-emit]
+            [re-frame.event-emit :as event-emit]
             [re-frame.frame :as frame]
             [re-frame.interop :as interop]
             [re-frame.registrar :as registrar]
@@ -78,6 +96,7 @@
   (schemas/clear-schemas-by-frame!)
   (trace/clear-listeners!)
   (error-emit/clear-error-listeners!)
+  (event-emit/clear-event-listeners!)
   (rf/init! plain-atom/adapter)
   ;; `registrar/clear-all!` drops the framework-standard interceptor
   ;; registrations; `init!` re-seeds them, including `:rf.schema/at-boundary`
@@ -104,6 +123,57 @@
 
 (defn- record-of [records error-kw]
   (first (filter #(= error-kw (:error %)) records)))
+
+(defn- record-both-axes
+  "Capture BOTH always-on axes across one body — the `:errors` axis
+  (`register-error-listener!`) and the `:events` axis
+  (`register-event-listener!`). Returns `{:errors [...] :events [...]}`.
+
+  Together these two records are the WHOLE of what an off-box shipper receives
+  from a production build: the dev trace surface is gated on
+  `interop/debug-enabled?` and sees nothing here. rf2-mwv4e's defect lived
+  precisely in the gap between them — the `:errors` axis carried no record and
+  the `:events` axis reported `:outcome :ok` — so a test that reads one axis
+  alone cannot see it."
+  [body-fn]
+  (let [errors (atom [])
+        events (atom [])]
+    (error-emit/register-error-listener! ::rec (fn [r] (swap! errors conj r)))
+    (event-emit/register-event-listener! ::rec (fn [r] (swap! events conj r)))
+    (try (body-fn)
+         (finally
+           (error-emit/unregister-error-listener! ::rec)
+           (event-emit/unregister-event-listener! ::rec)))
+    {:errors @errors :events @events}))
+
+(defn- boundary-records [{:keys [errors]}]
+  (filterv #(= :rf.error/schema-validation-failure (:error %)) errors))
+
+(defn- event-record-for [{:keys [events]} event-id]
+  (first (filter #(= event-id (:event-id %)) events)))
+
+(def ^:private boundary-record-keys
+  "The CLOSED key set of the always-on boundary-rejection record (rf2-mwv4e).
+
+  Pinned rather than sampled: this record egresses to Sentry / Datadog, so a
+  slot added later reaches a shipper whether or not anyone reviewed it. Every
+  member is a framework keyword or a structural identifier — `:event-id` /
+  `:failing-id` / `:schema-id` are all the registered handler's id, not caller
+  data. Widening this set is an EGRESS decision; read
+  `re-frame.egress-chokepoint-conformance-test`'s allow-list entry first."
+  #{:error :where :source :event-id :failing-id :schema-id :frame :recovery :time})
+
+(def ^:private payload-bearing-keys
+  "Slots the RICH DEV TRACE carries that the always-on record must NEVER.
+
+  `:value` / `:received` are the rejected event vector itself; `:explain` is
+  the validator's explanation, which quotes it; `:schema` is the declared form;
+  `:reason` is prose that INTERPOLATES the offending value. At a system
+  boundary that value is attacker-controlled or user-private by definition and
+  may carry secrets in keys the schema never declared, so it is omitted
+  outright rather than scrubbed — no schema-aware redactor can be trusted to
+  have seen an undeclared key."
+  #{:event :value :received :explain :schema :reason})
 
 (defn- db-of [] (rf/app-db-value :rf/default))
 
@@ -252,6 +322,168 @@
       (rf/dispatch-sync [:prod/boundary 42])
       (is (= 1 @calls) "the conforming payload reached the handler")
       (is (= 42 (:n (db-of))) "and committed"))))
+
+;; ===========================================================================
+;; Surface 2, second half — the rejection is OBSERVABLE, and says so truthfully
+;; ===========================================================================
+
+(deftest at-boundary-rejection-fans-one-structural-record-in-every-posture
+  (testing "rf2-mwv4e — the refusal reaches an off-box shipper. Before this,
+            a production boundary rejection emitted NOTHING: the check ran, the
+            handler was skipped, and `trace/emit-error!` — its only report —
+            sits behind `interop/debug-enabled?`. An opt-in production security
+            gate was invisible to the person who opted in.
+
+            It now fans exactly ONE always-on record. `EXACTLY ONE` is
+            load-bearing in the DEV arm of this posture-independent deftest:
+            dev refuses in step-1 and production refuses inside the boundary
+            interceptor, and both routes converge on a single emit site in the
+            router tail, so neither posture can double-report a rejection."
+    (let [calls (atom 0)]
+      (rf/reg-event :prod/boundary
+        {:schema       [:cat [:= :prod/boundary] :int]
+         :interceptors [:rf.schema/at-boundary]}
+        (fn [{:keys [db]} [_ n]]
+          (swap! calls inc)
+          {:db (assoc db :n n)}))
+      (let [captured (record-both-axes
+                       #(rf/dispatch-sync [:prod/boundary "not-an-int"]))
+            records  (boundary-records captured)
+            rec      (first records)]
+        (is (zero? @calls)
+            "precondition: the handler was skipped (the security half)")
+        (is (nil? (:n (db-of)))
+            "precondition: nothing committed to app-db")
+        (is (= 1 (count records))
+            (str "EXACTLY ONE always-on boundary record. Red at 0 means the "
+                 "rejection is silent in this posture again — the defect this "
+                 "bead closed. Red above 1 means the dev and production "
+                 "enforcement routes have both emitted, which the single "
+                 "router-tail emit site exists to prevent."))
+        (is (= :event (:where rec))
+            "`:where :event` — the slot the SSR default projector reads to
+             answer 400 rather than the locked generic 500")
+        (is (= :boundary (:source rec))
+            "`:source :boundary` — the discriminator separating this
+             production-reachable arm from the dev-only `validate-*!` arms of
+             the same category")
+        (is (= :prod/boundary (:event-id rec))
+            "attributed to the dispatch, so a shipper can count per-event")
+        (is (= :prod/boundary (:failing-id rec)))
+        (is (= :prod/boundary (:schema-id rec)))
+        (is (= :rf/default (:frame rec))
+            "and to the owning frame, so a multi-frame server host can route
+             it per-request")
+        (is (= :no-recovery (:recovery rec)))
+        (is (number? (:time rec)))))))
+
+(deftest at-boundary-rejection-record-is-structural-only-in-every-posture
+  (testing "rf2-mwv4e — the EGRESS contract. Whatever this record carries ships
+            off-box. A schema failure's natural detail is THE VALUE THAT
+            FAILED, and at a system boundary (an HTTP response, a websocket
+            frame, a `postMessage`, a query string) that value is
+            attacker-controlled or user-private by definition — it can carry
+            secrets in keys the declared schema never anticipated, so no
+            schema-aware redactor can be trusted to have seen them.
+
+            Structural-only is therefore STRICTER here than the EP-0015 scrub
+            the safe-redirect / route-miss records use: there the untrusted URL
+            IS the observability payload and is redacted in place; here every
+            payload-derived slot is omitted OUTRIGHT and no scrub applies.
+
+            The key set is pinned CLOSED, not sampled. A slot added later
+            reaches a shipper whether or not anyone reviewed it, and this
+            assertion is the review."
+    (rf/reg-event :prod/boundary
+      {:schema       [:cat [:= :prod/boundary] :int]
+       :interceptors [:rf.schema/at-boundary]}
+      (fn [{:keys [db]} [_ n]] {:db (assoc db :n n)}))
+    (let [secret   "sentinel-secret-value"
+          captured (record-both-axes
+                     #(rf/dispatch-sync [:prod/boundary {:password secret}]))
+          rec      (first (boundary-records captured))]
+      (is (some? rec) "precondition: the rejection fanned its record")
+      (is (= boundary-record-keys (set (keys rec)))
+          (str "the key set is CLOSED. A NEW slot here is an egress decision: "
+               "read the `re-frame.router` entry on "
+               "`egress-chokepoint-conformance-test`'s structural-only "
+               "allow-list before widening it."))
+      (is (empty? (set/intersection payload-bearing-keys (set (keys rec))))
+          (str "no payload-bearing slot rides the always-on record — the "
+               "event vector, `:value`, `:received`, `:explain`, the schema "
+               "form and the interpolated `:reason` are DEV-TRACE ONLY."))
+      (is (not (str/includes? (pr-str rec) secret))
+          (str "and the rejected payload's own content appears NOWHERE in the "
+               "record, by any route — not in a `:reason` sentence, not in an "
+               "`:explain` map, not stringified into an identifier.")))))
+
+(deftest at-boundary-rejection-settles-outcome-rejected-in-every-posture
+  (testing "rf2-mwv4e — the sharper half of the defect. Silence would have been
+            bad enough; the always-on `:events` record REPORTED SUCCESS. The
+            handler produced no `:db`, so the cascade reached its ordinary tail
+            and settled `:ok` — an off-box shipper watching the event stream
+            saw a dispatch that worked.
+
+            `:rejected` is a public event-outcome addition and it says exactly
+            what happened. Neither existing non-`:ok` value fits: `:error`
+            means the interceptor chain threw (it did not) and `:rolled-back`
+            means a candidate state transition was refused before install (no
+            candidate ever existed — the handler never ran). Overloading either
+            would corrupt working semantics; keeping `:ok` preserved a known
+            lie."
+    (rf/reg-event :prod/boundary
+      {:schema       [:cat [:= :prod/boundary] :int]
+       :interceptors [:rf.schema/at-boundary]}
+      (fn [{:keys [db]} [_ n]] {:db (assoc db :n n)}))
+    (let [captured (record-both-axes
+                     #(rf/dispatch-sync [:prod/boundary "not-an-int"]))
+          evt      (event-record-for captured :prod/boundary)]
+      (is (some? evt) "the always-on `:events` record fired for the dispatch")
+      (is (= :rejected (:outcome evt))
+          (str "`:outcome :rejected`. Red with `:ok` means production "
+               "monitoring is again being told a refused untrusted payload "
+               "settled cleanly — it cannot separate hostile input from a "
+               "healthy dispatch.")))))
+
+(deftest at-boundary-pass-emits-no-record-and-settles-ok-in-every-posture
+  (testing "rf2-mwv4e — the negative control for both halves. The promotion is
+            not simply stamping every dispatch through a guarded handler: a
+            CONFORMING payload fans no boundary record and settles `:ok`, so a
+            shipper's `:rejected` count is a count of real refusals and its
+            silence is real silence."
+    (rf/reg-event :prod/boundary
+      {:schema       [:cat [:= :prod/boundary] :int]
+       :interceptors [:rf.schema/at-boundary]}
+      (fn [{:keys [db]} [_ n]] {:db (assoc db :n n)}))
+    (let [captured (record-both-axes #(rf/dispatch-sync [:prod/boundary 42]))]
+      (is (empty? (boundary-records captured))
+          "a passing payload fans NO always-on boundary record")
+      (is (= :ok (:outcome (event-record-for captured :prod/boundary)))
+          "and settles `:ok`"))))
+
+(deftest unguarded-schema-refusal-is-not-a-boundary-rejection-in-every-posture
+  (testing "rf2-mwv4e — the promotion's NARROWNESS, pinned. A handler carrying
+            a `:schema` but NOT referencing `:rf.schema/at-boundary` is a
+            DEV-ONLY validation surface (Spec 010 §Production builds,
+            rf2-bkvu5): in dev step-1 refuses it, in production it is elided
+            and the handler simply runs. Neither posture may fan the always-on
+            record or report `:rejected` — that would invent a production
+            signal which, for this handler, cannot exist.
+
+            Posture-independent by construction: it asserts only the two facts
+            that hold either way. WHETHER the handler ran differs by posture
+            and is the `^:prod-gate` discriminator's business, not this one's."
+    (rf/reg-event :prod/unguarded-obs
+      {:schema [:cat [:= :prod/unguarded-obs] :int]}      ;; no at-boundary ref
+      (fn [{:keys [db]} [_ n]] {:db (assoc db :n n)}))
+    (let [captured (record-both-axes
+                     #(rf/dispatch-sync [:prod/unguarded-obs "not-an-int"]))]
+      (is (empty? (boundary-records captured))
+          (str "no always-on record: the boundary interceptor is not in this "
+               "handler's chain, so there is no production gate to report on."))
+      (is (not= :rejected (:outcome (event-record-for captured
+                                                      :prod/unguarded-obs)))
+          "and no `:rejected` outcome — `:rejected` means a BOUNDARY refusal"))))
 
 ;; ===========================================================================
 ;; The discriminator — gate lane ONLY

--- a/implementation/core/test/re_frame/egress_chokepoint_conformance_test.clj
+++ b/implementation/core/test/re_frame/egress_chokepoint_conformance_test.clj
@@ -238,6 +238,37 @@
       `:reason` prose + full `:last-event` vector ride the DCE'd dev trace ONLY,
       never this record.
 
+      rf2-mwv4e adds a SECOND record from the same namespace —
+      `emit-boundary-rejection-record!` ships the `:rf.schema/at-boundary`
+      refusal (`:rf.error/schema-validation-failure`, `:source :boundary`) so an
+      opt-in production security gate is observable to the person who opted in;
+      before it, a refused untrusted payload skipped its handler, emitted
+      nothing on either axis, and had its `:events` record report `:outcome
+      :ok`. VETTED structural-only, and on THIS record that is a stricter
+      guarantee than a scrub rather than a weaker one. A validation failure's
+      natural detail is THE VALUE THAT FAILED, which at a system boundary is
+      attacker-controlled or user-private by definition and can carry secrets in
+      keys the declared schema never anticipated — so no schema-aware redactor
+      can be trusted to have seen them, and the sibling treatment on
+      `re-frame.routing.url-change` / `re-frame.ssr.response` (scrub the one
+      untrusted slot, because that slot IS the observability payload) does not
+      transfer. Every payload-derived slot is therefore OMITTED OUTRIGHT: no
+      event vector, no `:value`, no `:received`, no `:explain`, no schema form,
+      and no human `:reason` — the last deliberately, since the dev trace's
+      `:reason` interpolates the offending value and would reintroduce the
+      `ssr/hydrate` prose hazard. What remains is a CLOSED key set of framework
+      keywords and structural identifiers: `:error`, `:where :event`, `:source
+      :boundary`, `:event-id` / `:failing-id` / `:schema-id` (all the event id —
+      a registered handler keyword, not caller data), `:frame`, `:recovery
+      :no-recovery`, `:time`. Nothing lifts a value out of the event vector or an
+      app-db slice, and there is no exception residual (a refusal is a gate
+      decision, not a throw). The key set is pinned CLOSED by
+      `re-frame.always-on-validation-production-test`, which also asserts the
+      ABSENCE of every payload-bearing key by name. The rich diagnosis
+      (`:value` / `:received` / `:explain` / interpolated `:reason`) rides the
+      DCE'd dev trace in `re-frame.spec` ONLY, exactly as the depth-halt prose
+      does — so this namespace's two records share one discipline.
+
   NOTE the census B5 site `re-frame.ssr.hydrate` is DELIBERATELY ABSENT: it
   lifts the untrusted `:payload-frame-id` out of the deserialised payload, so it
   is NOT structural-only — it ROUTES through `project-egress` (the B5 fix) and

--- a/implementation/schemas/test/re_frame/schemas_boundary_prod_test.cljs
+++ b/implementation/schemas/test/re_frame/schemas_boundary_prod_test.cljs
@@ -23,9 +23,21 @@
        boundary's production validation branch runs.
     2. `re-frame.trace/emit-error!` ALSO elides under the same gate
        (its body sits inside `(when interop/debug-enabled? ...)`) — the
-       boundary's failure-trace emission is silent in production.
+       boundary's failure-TRACE emission is silent in production, and
+       stays that way: the rich `:value` / `:explain` diagnosis is
+       exactly what must not egress.
     3. The handler-skip recovery (`:rf/skip-handler?` set on the
-       context) is the load-bearing observable surface.
+       context) is the load-bearing SECURITY surface.
+    4. rf2-mwv4e — and the rejection is now OBSERVABLE here too. The
+       silence in (2) is the trace axis ONLY; the refusal additionally
+       fans one always-on STRUCTURAL-ONLY record through
+       `register-error-listener!`, which carries no gate and survives
+       `:advanced`. That axis is the whole point: before it, this
+       `:advanced` build was the exact configuration in which a refused
+       untrusted payload told nobody. Pinning both here — trace EMPTY,
+       always-on record PRESENT — is what proves the two axes are
+       genuinely separate rather than one surface everyone assumed
+       survived.
 
   We deliberately use the ns suffix `-prod-test` (not `-cljs-test`) so
   the default `:browser-test` and `:node-test` builds (whose regexes
@@ -101,13 +113,16 @@
             builds: under `:advanced` + `goog.DEBUG=false`,
             `trace/emit-error!` also elides (its body sits inside
             `(when interop/debug-enabled? ...)`). The boundary's failure
-            emission therefore does NOT fire a trace in production —
-            the handler-skip is silent.
+            emission therefore does NOT fire a TRACE in production.
 
             This pins the dual-elision contract: trace gate AND boundary
             gate both fold under the same closure-define. A registered
             trace callback would never see a boundary emission because
-            the entire emit body has DCE'd."
+            the entire emit body has DCE'd. rf2-mwv4e keeps this pin
+            deliberately: the trace is where the rejected VALUE and the
+            validator's `:explain` ride, and those are precisely what a
+            production build must not carry. The production REPORT lives
+            on the always-on axis instead — see the deftest below."
     (let [calls (atom 0)]
       (rf/reg-event :api/strict
         {:schema [:cat [:= :api/strict] :int]
@@ -123,6 +138,48 @@
         ;; reach the callback by design.
         (is (empty? @traces)
             "no traces observed — Spec 009 §Production builds elision contract holds")))))
+
+(deftest boundary-rejection-is-observable-on-the-always-on-axis-in-prod
+  (testing "rf2-mwv4e — the counterpart to the elision pin above, in the ONE
+            configuration where it mattered most. Under `:advanced` +
+            `goog.DEBUG=false` the boundary check runs, the handler is skipped,
+            and the trace surface is gone. Until this bead that was the whole
+            story: a refused untrusted payload emitted nothing anywhere, and
+            the always-on `:events` record for the dispatch read `:outcome
+            :ok` — a shipper saw a dispatch that succeeded.
+
+            `register-error-listener!` carries no debug gate, so the structural
+            record below survives the same closure-define that erased the
+            trace. Red here means the promotion did not survive `:advanced`,
+            which is the only build where it was needed."
+    (rf/reg-event :api/strict
+      {:schema [:cat [:= :api/strict] :int]
+       :interceptors [:rf.schema/at-boundary]}
+      (fn [_ _] {}))
+    (let [errors (atom [])
+          events (atom [])]
+      (rf/register-listener! :errors ::rec (fn [r] (swap! errors conj r)))
+      (rf/register-listener! :events ::rec (fn [r] (swap! events conj r)))
+      (try
+        (rf/dispatch-sync [:api/strict "not-an-int"])
+        (finally
+          (rf/unregister-listener! :errors ::rec)
+          (rf/unregister-listener! :events ::rec)))
+      (let [rec (first (filter #(= :rf.error/schema-validation-failure (:error %))
+                               @errors))
+            evt (first (filter #(= :api/strict (:event-id %)) @events))]
+        (is (some? rec)
+            "the always-on boundary record survived :advanced + goog.DEBUG=false")
+        (is (= :boundary (:source rec)) ":source :boundary")
+        (is (= :event (:where rec)) ":where :event")
+        (is (= :api/strict (:event-id rec)) "attributed to the dispatch")
+        ;; Structural-only: the rejected payload must not egress. The JVM
+        ;; namespace `re-frame.always-on-validation-production-test` pins the
+        ;; key set CLOSED; this arm pins the one fact `:advanced` could change.
+        (is (not (re-find #"not-an-int" (pr-str rec)))
+            "and carries NOTHING from the rejected payload")
+        (is (= :rejected (:outcome evt))
+            "the :events record reports :rejected, not the old :ok lie")))))
 
 (deftest boundary-direct-before-invocation-in-prod
   (testing "Per Spec 010 §Per-step recovery step 1: directly invoking the


### PR DESCRIPTION
Closes rf2-mwv4e.

`:rf.schema/at-boundary` is the one validation surface Spec 010 keeps ungated in a production build — the opt-in gate for untrusted system ingress, and the surface the rf2-bkvu5 ruling explicitly designated as the production answer. Its **refusal** always survived the gate. Its **report** did not: `trace/emit-error!` sits behind `interop/debug-enabled?`, so under `:advanced` + `goog.DEBUG=false` a refused payload skipped its handler, emitted nothing on either axis, and — the handler having written no `:db` — had its always-on `:events` record report `:outcome :ok`.

An operator saw a dispatch that succeeded. That is worse than silence: an opt-in security gate invisible to the person who opted in, actively reporting success for a dispatch that never ran.

## What changed

**Two halves, one marker.** Both enforcement routes now stamp `:rf/boundary-rejected?` on the context — the production interceptor when its check fails, `run-chain` when step-1 refuses an event whose handler references the interceptor — and the router tail reads it once to fan one always-on record and to settle `:outcome :rejected`. One marker, one emit site; a rejection cannot double-report, and the two postures cannot disagree.

**The record — structural-only, key set closed:**

```clojure
{:error      :rf.error/schema-validation-failure
 :where      :event
 :source     :boundary
 :event-id   event-id
 :failing-id event-id
 :schema-id  event-id
 :frame      frame
 :recovery   :no-recovery
 :time       now}
```

Structural-only is **stricter** here than the EP-0015 scrub its siblings use, not weaker. A validation failure's natural detail is *the value that failed*, which at a system boundary is attacker-controlled or user-private by definition and can carry secrets in keys the declared schema never anticipated — so no schema-aware redactor can be trusted to have seen them. Where rf2-ov56u / rf2-6jqa8 scrub an untrusted URL *because that URL is the observability payload*, here every payload-derived slot is **omitted outright**: no event vector, no `:value`, no `:received`, no `:explain`, no schema form, and no human `:reason` (which interpolates the offending value — the `ssr/hydrate` prose hazard). Identifiers are enough to count, attribute, alert and project. The diagnosis stays on the DCE'd dev trace.

**Projection-eligible, deliberately** — and this is where it diverges from rf2-6jqa8. Those three safe-redirect categories joined `non-projection-eligible-errors` so a hostile probe could not conjure a 500. A boundary rejection on a server frame is the opposite case: it is exactly a 400 (RFC 9110 §15.5.1), the SSR default projector already maps `:rf.error/schema-validation-failure` + `:where :event` to one, and letting it project is what closes the silent-200 SSR hole that surfaced this bead.

**`:outcome :rejected`** is a public event-outcome addition. Neither existing non-`:ok` value fits: `:error` means the chain threw (it did not), `:rolled-back` means a candidate transition was refused before install (no candidate existed — the handler never ran). It is the lowest-priority discriminator, selected only when the boundary skip is the whole story; a chain throw, flow throw or candidate rollback during the unwind still wins. Semantics are otherwise unchanged: handler still skipped, entered interceptors still unwind in full, effects they produce keep their treatment, no recovery protocol.

## Quality gates

Foreground, worktree-local logs, exit codes echoed.

| Gate | Command | Exit | Result |
|---|---|---|---|
| core, dev posture | `clojure -M:test` (implementation/core) | **0** | 2168 tests / 10766 assertions |
| core, REAL production gate | `sh scripts/test-core-prod-gate.sh` | **0** | 1201 tests / 5551 assertions, 102 namespaces under `-Dre-frame.debug=false` |
| schemas | `clojure -M:test` (implementation/schemas) | **0** | 363 tests / 19188 assertions |
| target ns under the real gate | `clojure -M:test:prod-gate -n re-frame.always-on-validation-production-test` | **0** | 11 tests / 42 assertions (was 6 / 21) |
| conformance trio | `-n error-catalogue-channel-conformance-test -n egress-chokepoint-conformance-test -n always-on-axis-conformance-cljs-test` | **0** | 29 tests / 168 assertions |
| routing at-boundary consumer | `clojure -M:test -n re-frame.routing-nav-fx-schemas-test` | **0** | 13 tests / 166 assertions |

The core lane was run in **both** postures deliberately: the egress-chokepoint test source-scans every artefact's `src/` as text, so a new fan-out caller reddens core even with no core file in the diff. (`re-frame.router` was already an allow-list member for the depth-halt record; its written rationale is extended here to cover the second record it now ships.)

Proof under the real gate, not `with-redefs` — a rebind cannot reach a load-time flag. The `^:prod-gate` discriminator asserts `(false? interop/debug-enabled?)` in the same JVM and that an *unguarded* handler accepts a non-conforming event there, so "the handler did not run" provably is not step-1 doing the work.

### Mutation proof — the record

Neutered the tail fan-out (`(when (and false (:rf/boundary-rejected? final-ctx)) ...)`), same command, same gate:

```
EXIT=1 — Ran 11 tests containing 42 assertions. 11 failures, 0 errors.
FAIL in (at-boundary-rejection-fans-one-structural-record-in-every-posture)
FAIL in (at-boundary-rejection-record-is-structural-only-in-every-posture)
  expected: (some? rec)   actual: (not (some? nil))
```

Restored: 0 failures.

### Mutation proof — the outcome

Reverted the selection to the pre-bead `:ok`:

```
EXIT=1 — Ran 11 tests containing 42 assertions. 1 failures, 0 errors.
FAIL in (at-boundary-rejection-settles-outcome-rejected-in-every-posture)
  expected: (= :rejected (:outcome evt))   actual: (not (= :rejected :ok))
```

Exactly one failure, precisely isolated. Restored: 0 failures.

### Deferred to CI

- `:browser-test-schemas-boundary-prod` (the `:advanced` + `goog.DEBUG=false` Chromium build). Its trace-EMPTY pin is deliberately **kept** — that silence is the rejected value and the validator's explain, which is exactly what must not egress — and gains its counterpart deftest asserting the always-on record survives the same closure-define that erased the trace. That build is the one configuration where the defect actually bit.
- `npm run test:cljs`, the SSR lanes, and the remaining artefact lanes.

## Consumers of `:outcome`

Every consumer was checked; none switches on a closed vocabulary, so `:rejected` rides through:

| Consumer | What it now sees |
|---|---|
| `re-frame.event-emit/dispatch-on-event!` to `:events` listeners | `:outcome :rejected` verbatim on the record. Docstring updated with the full member contract. |
| `re-frame.observability/route-handled-event!` to frame-owned `:observability :handled-events` sinks | `:status :rejected` (pass-through; the slot is positional and unvalidated). |
| `re-frame.projection/project-handled-event` | `:status` is a summary key that passes through unchanged under every egress profile. |
| `re-frame.router` docstrings + the pipeline-phase map comment | Enumerate `:rejected`. |
| SSR `error-emit-projection-listener` | Lifts the record's flat slots onto `:tags` generically, so the default projector's existing `:where :event` arm answers **400**. Unchanged code; the category is not in `non-projection-eligible-errors`. |
| `re-frame.epoch` `:outcome` (`:ok` / `:halted-*`) | **Not a consumer** — a separate vocabulary on a separate record. Untouched. |
| Xray resources / mutation `:outcome` | **Not a consumer** — the optimistic-mutation lifecycle vocabulary. Untouched. |

## Out of fence — reported, not edited

`spec/**` is hot-zone and `implementation/ssr/**` / `docs/**` belong to other live workers. Filed as follow-ups on the bead thread. In particular **spec/009's Channel cell and the `always-on-categories` literal must move in the same PR** — the conformance test asserts they are equal, so either edit alone reds. Nothing here touches either, so the conformance trio is green as landed.
