### PR TITLE
fix(ssr): the safe-redirect record carries no URL secrets and no allowlist (rf2-6jqa8)

### DIFF
--- a/implementation/ssr/src/re_frame/ssr/egress.cljc
+++ b/implementation/ssr/src/re_frame/ssr/egress.cljc
@@ -104,11 +104,125 @@
   slot is absent.
 
   Applied by `re-frame.ssr.response`'s `safe-redirect-tags` BEFORE the tag
-  map reaches EITHER error axis, so the always-on production record and the
-  dev trace carry the same already-scrubbed value and cannot disagree about
-  the same rejection."
+  map reaches EITHER error axis, so both the DEV trace and (historically) the
+  always-on record carried the same already-scrubbed value and could not
+  disagree about the same rejection.
+
+  Since rf2-6jqa8's egress tightening the always-on record carries no URL at
+  all — see [[project-safe-redirect-record]] — so this scrub's remaining
+  consumer on THIS path is the dev trace. It stays because the dev trace is
+  still an egress surface in the weaker sense (a local operator's screen, a
+  captured test fixture), and because a scrubbed diagnostic is the honest
+  input to a projection."
   ([tags] (redact-url-tag tags :location))
   ([tags slot]
    (if (contains? tags slot)
      (update tags slot redact-url-carriers)
      tags)))
+
+;; ---------------------------------------------------------------------------
+;; The always-on record projection (rf2-6jqa8 AUDIT-REOPEN)
+;; ---------------------------------------------------------------------------
+;;
+;; WHY A PROJECTION AND NOT A BIGGER SCRUB.  [[redact-url-carriers]] is the
+;; Spec 015 blanket CARRIER policy: it redacts query / fragment values and
+;; keeps everything else, which is exactly right over the app's OWN URL space
+;; (rf2-ov56u's route-miss `:url`, where the path is a route the app authored
+;; and the host is the app's own).  A rejected safe-redirect target is not
+;; that.  It is an ARBITRARY FOREIGN URL chosen by whoever is probing, so
+;; every component is attacker-authored and "keep everything except the
+;; carriers" inverts the burden of proof.  Concretely, the carrier policy does
+;; string surgery only after the first `?` or `#`, so it never reached:
+;;
+;;   - the USERINFO component — `https://alice:pw@host/…` shipped credentials
+;;     whole (RFC 3986 §3.2.1; OpenTelemetry's URL conventions say user /
+;;     password MUST NOT be recorded),
+;;   - the PATH — a password-reset token in a path segment is the canonical
+;;     opaque path-borne secret, and the policy keeps the path DELIBERATELY,
+;;   - a VALUE-LESS query key — preserved by design, because a key names the
+;;     shape rather than the secret; true of the app's own URL space, false
+;;     when the attacker picks the key.
+;;
+;; Widening the scrub to cover those would leave nothing but the scheme and
+;; host anyway, and would still be a DENY-list — one more URL component away
+;; from a leak.  So the record is built the other way round, as an ALLOW-list
+;; over parsed structural components.  That is fail-closed by construction: a
+;; slot added to any emit arm's tag map does not reach a shipper unless
+;; someone edits [[safe-redirect-record-slots]] and reddens the test that pins
+;; it.
+;;
+;; This is the EP-0015 diagnostics/egress relationship in its ordinary form —
+;; the dev trace keeps the rich (scrubbed) map, and the production record is a
+;; strict projection of it, not a copy.
+
+(def safe-redirect-record-slots
+  "The CLOSED set of tag slots the ALWAYS-ON `:rf.error/safe-redirect-*`
+  record may carry off-box, over and above the `:error` / `:time` the
+  union-record helper assoc's.
+
+  Every member is either framework-owned or a PARSED URL COMPONENT — never a
+  URL, never caller-supplied policy data:
+
+    `:frame`     the frame id — attribution, so a multi-tenant host knows
+                 which app was probed.
+    `:recovery`  fixed `:no-recovery`.
+    `:reason`    a closed framework keyword naming which gate arm fired.
+    `:scheme`    the parsed, lower-cased scheme (`\"javascript\"`) — the
+                 aggregatable probe class.
+    `:host`      the parsed, lower-cased host (`\"evil.example.com\"`) — the
+                 target, which an operator can block or recognise as their
+                 own misconfiguration.
+
+  Deliberately ABSENT: `:location` (the attacker's URL, in any form, scrubbed
+  or not) and `:allowlist` (the application's own security configuration —
+  unbounded policy data whose contents hand a reader the exact boundary being
+  probed, and which `:reason :not-in-allowlist` already discriminates without
+  disclosing)."
+  #{:frame :recovery :reason :scheme :host})
+
+(def ^:private normalised-slots
+  "The projected slots that are PARSED URL COMPONENTS, and so must be
+  case-normalised to aggregate. `:frame` / `:recovery` / `:reason` are
+  framework-owned values that already have one spelling each."
+  #{:scheme :host})
+
+(defn- normalise-component
+  "Lower-case a parsed URL component so it AGGREGATES. Schemes are
+  case-insensitive (RFC 3986 §3.1) and DNS labels likewise (RFC 1035 §2.3.3),
+  so without this a prober alternating case fragments one spike across many
+  dashboard buckets — an evasion that costs the attacker nothing and costs
+  the operator the signal. Non-strings ride back unchanged."
+  [v]
+  (if (string? v) (str/lower-case v) v))
+
+(defn safe-redirect-record-tags
+  "Project the safe-redirect DIAGNOSTIC tag map down to the closed structural
+  map the always-on error axis may ship off-box: [[safe-redirect-record-slots]]
+  only, with `:scheme` / `:host` normalised for aggregation.
+
+  Applied by `re-frame.ssr.response`'s `dispatch-safe-redirect-record!` — the
+  one function that reaches the `:error-emit/dispatch-error-record` hook — so
+  the projection is inseparable from the egress rather than being a discipline
+  each of the eight rejection arms has to remember.
+
+  Note the direction: the result is BUILT FROM the closed slot set rather than
+  filtered down to it, so an unrecognised tag has no path into the record even
+  in principle. A slot whose component did not parse is omitted rather than
+  carried as nil, which is why the per-arm key sets differ — each arm names
+  exactly the discriminators it actually had.
+
+  The result is intentionally SMALL. Losing the exact URL in production is a
+  good trade: an operator keeps an aggregatable probe class, the target host,
+  the arm that fired and the frame, without accepting credentials, opaque path
+  material, arbitrary attacker-chosen query keys or unbounded policy data. If
+  richer local diagnosis is wanted, it is already on the dev trace beside
+  this — derive a further view deliberately rather than widening what a
+  `-Dre-frame.debug=false` build sends to Sentry."
+  [tags]
+  (into {}
+        (keep (fn [slot]
+                (when-some [v (get tags slot)]
+                  [slot (if (normalised-slots slot)
+                          (normalise-component v)
+                          v)])))
+        safe-redirect-record-slots))

--- a/implementation/ssr/src/re_frame/ssr/response.cljc
+++ b/implementation/ssr/src/re_frame/ssr/response.cljc
@@ -682,9 +682,16 @@
      nil))
 
 (defn- safe-redirect-tags
-  "The `:rf.error/safe-redirect-*` tag map for a rejected redirect — built
-  ONCE and fanned along BOTH error axes, so the production record and the
-  dev trace cannot disagree about the same rejection.
+  "The `:rf.error/safe-redirect-*` DIAGNOSTIC tag map for a rejected redirect
+  — built ONCE, so the production record and the dev trace cannot disagree
+  about the same rejection.
+
+  This is the RICH map: it goes to the dev trace as-is, and
+  `dispatch-safe-redirect-record!` projects it down to a closed structural
+  subset before the always-on axis sees it (rf2-6jqa8 AUDIT-REOPEN — see
+  `egress/safe-redirect-record-tags`). That is the ordinary EP-0015
+  relationship: a local operator sees their own process in full, and the
+  off-box record is a strict projection of it, never a copy.
 
   EP-0015 (rf2-6jqa8): `:location` is BY CONSTRUCTION caller-untrusted —
   that is the entire reason `:rf.server/safe-redirect` exists as the sibling
@@ -726,16 +733,31 @@
 
   The record is the general NON-EVENT union shape — this is not a dispatched-
   event failure, so it rides `dispatch-error-record!` rather than the
-  event-centric `dispatch-on-error!`. `tags` arrives already redacted (see
-  [[safe-redirect-tags]]). Reached through the
+  event-centric `dispatch-on-error!`. Reached through the
   `:error-emit/dispatch-error-record` late-bind hook, the same indirection
   `ssr/boot` and `ssr/error-projector` use; a no-op when the hook is unbound.
-  Returns nil."
+  Returns nil.
+
+  EGRESS (rf2-6jqa8 AUDIT-REOPEN). `tags` arrives as the DIAGNOSTIC map — the
+  scrubbed `:location`, the `:allowlist`, everything the dev trace shows — and
+  this function is the ONE place that reaches an off-box shipper, so it is
+  where the diagnostics are projected down to
+  `egress/safe-redirect-record-tags`: a closed set of parsed STRUCTURAL
+  components, no URL in any form, no allowlist. Projecting HERE rather than at
+  the eight call sites is what makes it fail-closed — a future emit arm cannot
+  forget, and a tag slot added upstream has no route to Sentry unless someone
+  edits `egress/safe-redirect-record-slots` and reddens the test pinning it.
+
+  Why a projection and not a wider scrub is argued in full in
+  `re-frame.ssr.egress`; the short version is that a rejected target is an
+  ARBITRARY FOREIGN URL, so the carrier scrub's keep-everything-but-the-
+  carriers shape left userinfo credentials, path-borne tokens and
+  attacker-chosen value-less query keys riding out verbatim."
   [operation tags]
   (when-let [dispatch-error-record!
              (late-bind/get-fn :error-emit/dispatch-error-record)]
     (dispatch-error-record!
-      (assoc tags
+      (assoc (egress/safe-redirect-record-tags tags)
              :error operation
              :time  (interop/now-ms))))
   nil)
@@ -745,9 +767,11 @@
   axes and return nil so the fx body can `(or (emit-...) ...)` to a no-op.
 
   Axis 1 is the ALWAYS-ON `error-emit` record (rf2-6jqa8) — the half that
-  reaches an off-box shipper in a production build. Axis 2 is the dev trace,
-  unchanged. The tag map is built once by [[safe-redirect-tags]] so the two
-  cannot disagree, and it is REDACTED before either sees it."
+  reaches an off-box shipper in a production build, and which receives a
+  closed STRUCTURAL PROJECTION of the map rather than the map. Axis 2 is the
+  dev trace, which receives the diagnostics whole. The tag map is built once
+  by [[safe-redirect-tags]], with the URL scrub applied there, so the two
+  cannot disagree about the rejection they describe."
   [operation tags]
   (let [tags (safe-redirect-tags tags)]
     (dispatch-safe-redirect-record! operation tags)
@@ -822,10 +846,16 @@
         (cond
           ;; Step 1: parse failure
           (nil? uri)
+          ;; `:reason` is a closed framework keyword, not prose (rf2-6jqa8):
+          ;; this slot rides the always-on record off-box, where an
+          ;; aggregatable value is worth more than a sentence — and free
+          ;; prose on an attacker-influenced arm is how raw material finds
+          ;; its way back into a record. The sentence lives here, in the
+          ;; source, where a reader who needs it is already standing.
           (emit-safe-redirect-error! :rf.error/safe-redirect-invalid-url
                                      {:frame    frame
                                       :location location
-                                      :reason   "URL did not parse"})
+                                      :reason   :parse-failed})
 
           :else
           (let [scheme    #?(:clj (.getScheme    ^URI uri) :cljs nil)

--- a/implementation/ssr/test/re_frame/ssr_safe_redirect_production_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_safe_redirect_production_test.clj
@@ -40,10 +40,15 @@
     3. The key set, pinned CLOSED. A slot added to this record reaches
        Sentry / Datadog in a production build, so it must be a deliberate
        change rather than a drift.
-    4. The redaction. `:location` is BY CONSTRUCTION attacker-controlled and
-       is the class most likely to carry `?token=…` / `#access_token=…`. The
-       EP-0015 scrub runs INSIDE the tag builder, before either axis sees
-       it.
+    4. The PROJECTION (rf2-6jqa8 AUDIT-REOPEN). The record carries parsed
+       STRUCTURAL components only — never a URL, and never the app's own
+       allowlist. The first shipped shape put a carrier-scrubbed `:location`
+       on the record; that scrub is the right blanket policy over the app's
+       OWN URL space, but it does string surgery only after the first `?` or
+       `#`, so on an arbitrary FOREIGN URL the userinfo (`alice:pw@`), the
+       whole path (a reset token) and any value-less query key rode out
+       verbatim — and `:allowlist` shipped the app's security configuration
+       beside them. One test per leak, each with its own sentinel.
     5. The wire is UNTOUCHED. Promotion changes what shippers see, never
        what the wire does — the rule this artefact's `error_listener.cljc`
        states at the head of `non-projection-eligible-errors`. A rejected
@@ -175,7 +180,13 @@
              [{:location "https://evil.example.com/" :relative-only? true}
               :rf.error/safe-redirect-host-disallowed :relative-only-violation]
              [{:location "https://evil.example.com/" :allow ["app.example.com"]}
-              :rf.error/safe-redirect-host-disallowed :not-in-allowlist]]]
+              :rf.error/safe-redirect-host-disallowed :not-in-allowlist]
+             ;; rf2-6jqa8 AUDIT-REOPEN: this arm's `:reason` used to be the
+             ;; free prose "URL did not parse". A closed keyword is what makes
+             ;; the slot aggregatable AND keeps the vocabulary framework-owned
+             ;; on the one arm whose input did not parse.
+             [{:location ""}
+              :rf.error/safe-redirect-invalid-url :parse-failed]]]
       (let [hits (safe-redirect-records (:records (reject! args)))
             r    (first hits)]
         (is (= 1 (count hits)) (str args " — exactly one record"))
@@ -200,11 +211,16 @@
 
 (deftest the-production-record-carries-exactly-the-enumerated-slots
   (testing "rf2-6jqa8 EGRESS REVIEW: this record is what a
-            `-Dre-frame.debug=false` build sends off-box, so the fail-closed
-            scrub is only half the job — the other half is keeping the shape
-            tight. Pin the key set CLOSED: a slot added here reaches Sentry /
-            Datadog in production, so it must be a deliberate change, not a
-            drift."
+            `-Dre-frame.debug=false` build sends off-box, so pinning the shape
+            is the job. The key set is CLOSED because it is produced by a
+            `select-keys` against one allowlist — a slot added to a tag map at
+            any of the eight emit arms simply does not reach Sentry / Datadog,
+            and WIDENING the record is an edit to
+            `egress/safe-redirect-record-slots` that reddens this test.
+
+            The per-arm sets differ only in which STRUCTURAL discriminator the
+            arm was able to parse. No arm carries `:location`, and none carries
+            `:allowlist`."
     (let [scheme (first (safe-redirect-records
                           (:records (reject! {:location "javascript:alert(1)"}))))
           host   (first (safe-redirect-records
@@ -212,50 +228,163 @@
                                               :allow    ["app.example.com"]}))))
           parse  (first (safe-redirect-records
                           (:records (reject! {:location ""}))))]
-      (is (= #{:error :time :recovery :frame :location :scheme}
+      (is (= #{:error :time :recovery :frame :scheme}
              (set (keys scheme)))
-          "scheme rejection — no :db, no event vector, no exception, no raw carrier")
-      (is (= #{:error :time :recovery :frame :location :host :reason :allowlist}
+          "scheme rejection — the scheme is the discriminator; no raw URL")
+      (is (= #{:error :time :recovery :frame :host :reason}
              (set (keys host)))
-          "host rejection — :allowlist is the CALL'S OWN policy input, not user data")
-      (is (= #{:error :time :recovery :frame :location :reason}
+          "host rejection — the target host and which policy arm fired; the
+           app's OWN allowlist does NOT ship")
+      (is (= #{:error :time :recovery :frame :reason}
              (set (keys parse)))
-          "parse failure — the unparseable location and why"))))
+          "parse failure — nothing parsed, so the category and a closed
+           :reason are all there is to say")
+      (is (every? keyword? (keep :reason [scheme host parse]))
+          "every :reason is a closed keyword, never free prose — prose on an
+           attacker-influenced arm is how raw material re-enters a record"))))
 
 ;; ===========================================================================
-;; (4) THE REDACTION — EP-0015 fail-closed, applied before either axis
+;; (4) THE PROJECTION — no URL secrets, no allowlist
 ;; ===========================================================================
+;;
+;; The AUDIT-REOPEN half of rf2-6jqa8.  The first shipped shape scrubbed the
+;; `:location` with `egress/redact-url-carriers` and put the scrubbed string on
+;; the record.  That is the right blanket policy for ordinary route diagnostics
+;; over the app's OWN URL space (rf2-ov56u's route-miss `:url`), and it is NOT
+;; a fail-closed projection of an ARBITRARY ATTACKER-SUPPLIED FOREIGN URL: the
+;; policy does string surgery only after the first `?` or `#`, so everything to
+;; the LEFT of them — userinfo, the whole path — rode out verbatim, as did a
+;; value-less query key.  The record also shipped the application's own
+;; `:allowlist`.
+;;
+;; So the production record is now a strict STRUCTURAL PROJECTION of the
+;; diagnostics rather than a scrubbed copy of them: parsed components only,
+;; never a URL.  Below is one test per leak, each with a sentinel that is
+;; present in the input by construction, so a regression names its own slot.
 
-(deftest the-attacker-controlled-location-is-scrubbed-before-it-egresses
-  (testing "rf2-6jqa8: `:location` is BY CONSTRUCTION caller-untrusted —
-            that is the entire reason `:rf.server/safe-redirect` exists as
-            the sibling of the caller-trusted `:rf.server/redirect` — and a
-            rejected `?next=` target is the class most likely to carry
-            `?token=…` / `#access_token=…`. The scrub runs INSIDE
-            `safe-redirect-tags`, before either axis sees the map."
-    (let [hostile "https://evil.example.com/cb?code=s3cr3t-query-value&flag#s3cr3t-fragment-value"
-          r       (first (safe-redirect-records
-                           (:records (reject! {:location hostile
-                                               :allow    ["app.example.com"]}))))
-          loc     (:location r)]
-      (is (not (str/includes? loc "s3cr3t-query-value"))
-          "the query carrier VALUE does not egress")
-      (is (not (str/includes? loc "s3cr3t-fragment-value"))
-          "the opaque #fragment does not egress")
-      (is (str/includes? loc "code=")
-          "the query KEY survives — a dashboard still sees a `code` parameter
-           was present, which is the shape signal, not the secret")
-      (is (str/includes? loc "evil.example.com")
-          "the HOST survives: on this path it IS the security signal, and a
-           host cannot carry a query-string carrier")
+(defn- record-strings
+  "Every string anywhere in `record` — the values a shipper serialises. The
+  leak assertions below scan THIS rather than a named slot, so a secret that
+  reappears under some *other* key is caught just as well as one that
+  reappears under `:location`."
+  [record]
+  (filter string? (tree-seq coll? seq record)))
+
+(defn- ships? [record needle]
+  (boolean (some #(str/includes? % needle) (record-strings record))))
+
+(deftest userinfo-does-not-egress
+  (testing "rf2-6jqa8 AUDIT-REOPEN leak 1: a URL's userinfo component carries
+            credentials outright (RFC 3986 §3.2.1; OpenTelemetry's URL
+            conventions say user / password MUST NOT be recorded). It sits
+            LEFT of any `?`, so the carrier scrub never reached it and
+            `https://alice:pw@host/` shipped whole."
+    (let [r (first (safe-redirect-records
+                     (:records (reject! {:location "https://alice:s3cr3t-userinfo-pw@evil.example.com/private"
+                                         :allow    ["app.example.com"]}))))]
+      (is (not (ships? r "s3cr3t-userinfo-pw"))
+          "the password in the userinfo component does not egress")
+      (is (not (ships? r "alice"))
+          "nor the username")
       (is (= "evil.example.com" (:host r))
-          "and it is also named structurally, so a dashboard need not parse"))))
+          "and the record is still worth having: the parsed host — the thing
+           an operator ranks probes by — is named structurally, WITHOUT the
+           credentials that travelled beside it"))))
+
+(deftest path-borne-secrets-do-not-egress
+  (testing "rf2-6jqa8 AUDIT-REOPEN leak 1 (second half): opaque secrets live
+            in PATH segments too — a password-reset token is the canonical
+            case. The path is left of the `?`, so the carrier scrub kept it
+            deliberately ('keep the structured path'), which is right for the
+            app's own URL space and wrong for a foreign one."
+    (let [r (first (safe-redirect-records
+                     (:records (reject! {:location "https://evil.example.com/reset/s3cr3t-path-token?x=1"
+                                         :allow    ["app.example.com"]}))))]
+      (is (not (ships? r "s3cr3t-path-token"))
+          "the opaque path segment does not egress")
+      (is (not (ships? r "/reset/"))
+          "nor the path structure around it"))))
+
+(deftest value-less-query-keys-do-not-egress
+  (testing "rf2-6jqa8 AUDIT-REOPEN leak 1 (third half): the carrier policy
+            PRESERVES a value-less query key by design — the key names the
+            shape, not the secret. True over the app's own URL space; over an
+            attacker's, the attacker chooses the key, so the key IS the
+            payload."
+    (let [r (first (safe-redirect-records
+                     (:records (reject! {:location "https://evil.example.com/x?s3cr3t-bare-flag"
+                                         :allow    ["app.example.com"]}))))]
+      (is (not (ships? r "s3cr3t-bare-flag"))
+          "an attacker-chosen value-less query key does not egress"))))
+
+(deftest the-applications-own-allowlist-does-not-egress
+  (testing "rf2-6jqa8 AUDIT-REOPEN leak 2: `:allowlist` is not user data —
+            it is worse. It is the app's SECURITY CONFIGURATION, unbounded in
+            size, and shipping it off-box hands whoever reads the sink the
+            exact boundary they are probing. `:reason :not-in-allowlist`
+            already says which arm fired; the contents add nothing an operator
+            cannot read from their own config."
+    (let [r (first (safe-redirect-records
+                     (:records (reject! {:location "https://evil.example.com/"
+                                         :allow    ["app.example.com"
+                                                    "s3cr3t-internal-admin.example.com"]}))))]
+      (is (not (ships? r "s3cr3t-internal-admin.example.com"))
+          "no allowlist entry egresses")
+      (is (not (contains? r :allowlist))
+          "and the slot itself is gone, not merely emptied")
+      (is (= :not-in-allowlist (:reason r))
+          "the DISCRIMINATION survives — an operator still knows the
+           allowlist arm rejected this, which is the actionable half"))))
+
+(deftest the-record-still-names-the-failure-it-exists-to-report
+  (testing "rf2-6jqa8: a record scrubbed to uselessness fails the ruling's own
+            purpose — an opt-in security gate must be observable to the person
+            who opted in. Tightening is only defensible while the STRUCTURAL
+            facts survive, so pin them here rather than trusting the key-set
+            test to imply it. The raw URL was never the value; the probe class
+            and the target were."
+    (let [js   (first (safe-redirect-records
+                        (:records (reject! {:location "javascript:alert(1)"}))))
+          host (first (safe-redirect-records
+                        (:records (reject! {:location "https://evil.example.com/x"
+                                            :allow    ["app.example.com"]}))))]
+      (is (= :rf.error/safe-redirect-scheme-rejected (:error js))
+          "which gate refused")
+      (is (= "javascript" (:scheme js))
+          "and the probe class, aggregatable across a spike")
+      (is (= "evil.example.com" (:host host))
+          "and the target host — an operator can block it, or recognise their
+           own misconfiguration in it")
+      (is (every? some? (map :frame [js host]))
+          "frame-attributed, so a multi-tenant host knows WHICH app was probed"))))
+
+(deftest structural-discriminators-are-normalised-for-aggregation
+  (testing "rf2-6jqa8: `:scheme` / `:host` exist to be COUNTED. Schemes are
+            case-insensitive (RFC 3986 §3.1) and DNS names likewise (RFC 1035
+            §2.3.3), so a prober alternating case would otherwise fragment one
+            spike across many dashboard buckets — an evasion that costs the
+            attacker nothing. The projection lower-cases both."
+    (let [scheme (first (safe-redirect-records
+                          (:records (reject! {:location "MAILTO:evil@example.com"}))))
+          host   (first (safe-redirect-records
+                          (:records (reject! {:location "https://EVIL.Example.COM/x"
+                                              :allow    ["app.example.com"]}))))]
+      (is (= "mailto" (:scheme scheme)))
+      (is (= "evil.example.com" (:host host))))))
 
 (deftest the-scrub-is-total-over-the-shapes-a-location-can-take
-  (testing "rf2-6jqa8: `redact-url-carriers` is reached for EVERY rejection
-            arm including the parse-failure one, where `:location` may be
-            nil, blank or a non-string. Asserted on the pure fn so the
-            totality claim needs no bus at all."
+  (testing "rf2-6jqa8: `redact-url-carriers` no longer stands between the
+            attacker's URL and PRODUCTION — the structural projection above
+            does — but it still scrubs the `:location` on the DEV diagnostics
+            (and rf2-ov56u's route-miss `:url`), so its totality is still a
+            claim worth pinning: it is reached for EVERY rejection arm
+            including the parse-failure one, where `:location` may be nil,
+            blank or a non-string. Asserted on the pure fn so the totality
+            claim needs no bus at all.
+
+            Read the two together and the EP-0015 relationship is the point:
+            the dev operator sees their own process in full detail, and the
+            production record is a strict projection of it."
     (is (nil? (egress/redact-url-carriers nil)))
     (is (= 42 (egress/redact-url-carriers 42)))
     (is (= "" (egress/redact-url-carriers "")))


### PR DESCRIPTION
Closes the AUDIT-REOPEN half of rf2-6jqa8. The promotion itself (PR #7191) is ratified and unchanged; this is the EP-0015 obligation it shipped without.

## The two leaks

The shipped record scrubbed `:location` with `egress/redact-url-carriers` and put the scrubbed string on the record. That is the right blanket **carrier** policy over the app's *own* URL space (rf2-ov56u's route-miss `:url`) and it is not a fail-closed projection of an **arbitrary foreign URL**: it does string surgery only after the first `?` or `#`, so everything to the left of them rode out verbatim. The record also shipped the application's own `:allowlist`.

**Before** — captured from a real `-Dre-frame.debug=false` run, target `https://alice:s3cr3t-userinfo-pw@evil.example.com/reset/s3cr3t-path-token?code=v&s3cr3t-bare-flag#frag`, `:allow ["app.example.com" "s3cr3t-internal-admin.example.com"]`:

```clojure
{:recovery  :no-recovery
 :frame     :rf.frame/19876
 :location  "https://alice:s3cr3t-userinfo-pw@evil.example.com/reset/s3cr3t-path-token?code=rf/redacted&s3cr3t-bare-flag#rf/redacted"
 :host      "evil.example.com"
 :reason    :not-in-allowlist
 :allowlist ["app.example.com" "s3cr3t-internal-admin.example.com"]
 :error     :rf.error/safe-redirect-host-disallowed
 :time      1785189973194}
```

Four secrets off-box: the **userinfo password**, the **path-borne reset token**, the attacker-chosen **value-less query key**, and both **allowlist entries** — including the internal host the allowlist exists to name. Only the `code=` value and the fragment were redacted.

**After** — same input, same posture:

```clojure
{:frame    :rf.frame/19881
 :reason   :not-in-allowlist
 :host     "evil.example.com"
 :recovery :no-recovery
 :error    :rf.error/safe-redirect-host-disallowed
 :time     1785190099429}
```

## The shape

Widening the scrub to cover userinfo and path would leave nothing but scheme and host anyway, and would still be a **deny-list** — one more URL component away from the next leak. So the record is built the other way round, from an **allow-list** of parsed structural components:

```clojure
(def safe-redirect-record-slots #{:frame :recovery :reason :scheme :host})
```

`egress/safe-redirect-record-tags` builds the record *from* that set rather than filtering down to it, so an unrecognised tag has no path into a shipper even in principle; a slot whose component did not parse is omitted rather than carried as nil, which is why the per-arm key sets differ. `:scheme` and `:host` are lower-cased — schemes (RFC 3986 §3.1) and DNS labels (RFC 1035 §2.3.3) are case-insensitive, so without it a prober alternating case fragments one spike across dashboard buckets at zero cost to the attacker.

The projection sits in `dispatch-safe-redirect-record!` — the one function that reaches the `:error-emit/dispatch-error-record` hook — so it is inseparable from the egress rather than a discipline each of the eight rejection arms has to remember. The URL scrub stays where it was, inside the shared tag builder, before either axis sees the map.

The dev trace still receives the rich scrubbed diagnostics whole. That is the ordinary EP-0015 relationship restored: the local operator sees their own process, and the off-box record is a **strict projection** of it rather than a copy.

The parse-failure arm's free prose `:reason "URL did not parse"` becomes the closed keyword `:parse-failed` — prose on an attacker-influenced arm is how raw material re-enters a record, and a keyword aggregates.

## Still worth having

A record scrubbed to uselessness would fail the ruling's own purpose. `the-record-still-names-the-failure-it-exists-to-report` pins the structural facts directly: which gate refused (`:error`), the probe class (`:scheme "javascript"`), the target (`:host "evil.example.com"`), and frame attribution so a multi-tenant host knows which app was probed. The raw URL was never the value.

## Untouched

The **eligibility skip is not disturbed** — the three categories stay in `non-projection-eligible-errors` (`error_listener.cljc` is not in this diff). Were they projection-eligible the default projector's `:else` arm would map each record to the locked generic 500 and `?next=javascript:alert(1)` would be a trivial DoS. Rejection semantics are unchanged: `:redirect` nil, status 200, one record per rejection.

## Quality gates

| Gate | Result | Exit |
|---|---|---|
| `ssr-safe-redirect-production-test` under `-J-Dre-frame.debug=false` — **before** | 13 tests / 66 assertions, **14 failures** (both leaks reproduced) | 1 |
| `ssr-safe-redirect-production-test` under `-J-Dre-frame.debug=false` — **after** | 13 tests / 66 assertions, 0 failures | 0 |
| `implementation/ssr` full suite, dev posture (`clojure -M:test`) | 564 tests / 2719 assertions | 0 |
| `bash scripts/test-ssr-prod-gate.sh` (49 of 51 ns, real gate) | 486 tests / 2159 assertions | 0 |
| `implementation/core` full suite, dev posture | 2163 tests / 10745 assertions | 0 |
| `implementation/core` `egress-chokepoint-conformance-test` | 3 tests / 7 assertions | 0 |
| `implementation/core` targeted prod-posture egress namespaces (`egress-chokepoint-conformance`, `privacy-production-egress`, `error-catalogue-channel-conformance`) under `-J-Dre-frame.debug=false` | 28 tests / 73 assertions | 0 |

**On the core lane under the gate.** The *whole* `implementation/core` suite does not run under `-J-Dre-frame.debug=false` and never has — ~1198 of its assertions are dev-surface claims (form-source capture, call-site metadata, trace ordering) that the elided dev trace cannot satisfy. There is no whole-core production lane, which is exactly why the curated `scripts/test-ssr-prod-gate.sh` roster exists on the ssr side. Confirmed pre-existing rather than assumed: `handler-source-test` + `source-coords-test` under the gate give **86 failures / 15 errors identically with and without this diff** (`git checkout HEAD~1 -- implementation/ssr/src`, rerun, restore). The production-posture core coverage that bears on an egress change is the targeted row above, and it is green.

**Mutation proof.** Replacing `(egress/safe-redirect-record-tags tags)` with `tags` in `dispatch-safe-redirect-record!` reddens 12 assertions naming the exact returning slots:

```
actual: (not (= #{:frame :time :error :recovery :scheme}
                #{:frame :time :error :recovery :location :scheme}))
actual: (not (= #{:frame :time :reason :host :error :recovery}
                #{:allowlist :frame :time :reason :host :error :recovery :location}))
```

plus `userinfo-does-not-egress`, `path-borne-secrets-do-not-egress`, `value-less-query-keys-do-not-egress`, `the-applications-own-allowlist-does-not-egress` and the normalisation test. Restored; `git diff --stat` clean.

## Spec

No spec edit in this PR — `spec/**` is hot-zone and rf2-rprfg owns obligation (6). **The Spec 009 catalogue rows now overstate what ships**: all three `:rf.error/safe-redirect-*` rows list `:location` in their Tags column (and `safe-redirect-host-disallowed` lists `:allowlist`), and the always-on paragraph says the record carries a scrubbed `:location`. Those sentences are true of the **dev trace** and no longer of the always-on record. The rows need to distinguish the two axes. No conformance test reds meanwhile: the `always-on-categories` literal is a set of **categories** (unchanged by this PR), and there is no `SafeRedirect*Tags` schema, so the rf2-6tags Tags-column arm has nothing to compare.

## Fence

Three files, all owned: `implementation/ssr/src/re_frame/ssr/egress.cljc`, the safe-redirect tag builder + emit site in `implementation/ssr/src/re_frame/ssr/response.cljc` (all four hunks at line 682+, inside the safe-redirect block), and the witness test. `scripts/test-ssr-prod-gate.sh` (rf2-lwtlk) was run, never edited.

