### PR TITLE
test(ssr): the production-gate roster reaches empty, and the lane budgets are recalibrated (rf2-lwtlk, rf2-15047)

### DIFF
--- a/implementation/scripts/run-browser-tests.cjs
+++ b/implementation/scripts/run-browser-tests.cjs
@@ -64,6 +64,41 @@ const URL = process.env.BROWSER_TEST_URL || 'http://localhost:8021';
 // and it fails through THIS runner — which dumps the console trail and the
 // namespaces reached — rather than as an opaque runner kill.
 //
+// rf2-15047 CALIBRATION, 2026-07-28 — MEASURED, AND 360s STANDS.
+//
+// rf2-mf4uy moved the benches to their own build, and the arithmetic above
+// changed underneath this constant, so it was re-measured rather than left
+// to drift. Two consecutive local runs of the built `:browser-test` bundle:
+// 841 tests / 5459 assertions / 0 failures, 25.9s and 25.2s wall for
+// serve+launch+navigate+suite+teardown, of which the summary wait proper —
+// the only thing TIMEOUT_MS bounds — is ~22.5s. (The 41.5s shadow-cljs
+// compile is NOT on this clock; it happens before the runner starts.) That
+// confirms rf2-mf4uy's 73s -> 22.5s: one namespace really had been half the
+// lane.
+//
+// So 360s is ~16x the local green run and ~9.5x at the measured ~1.7x CI
+// factor, against the ~3.6x rule that produced it. By that rule alone the
+// number wants to be ~140-180s. It is NOT being lowered, for two reasons.
+//
+// FIRST, the growth this budget exists to absorb is WALL-CLOCK, not compute.
+// Each control witness costs ~35-40s of mounted rows driven through
+// real-time settles with 2-4s poll budgets — `setTimeout`, which neither a
+// faster runner nor another bundle split can shrink. The 22.5s figure is the
+// result of a one-off structural change, not a trend; the witness corpus
+// that motivated this bead is still landing steadily. Three more puts the
+// lane near ~135s, where a 180s budget has ~1.3x headroom and needs raising
+// again within weeks.
+//
+// SECOND, the two failure modes are asymmetric. Over-large costs only a
+// slower failure on a genuine hang — still 6 minutes, still far inside
+// `timeout-minutes: 45`, and still through THIS runner with the console
+// trail and the rf2-76lhy per-namespace duration profile. Under-sized costs
+// a FALSE RED on a loaded runner, which is precisely the failure rf2-15047
+// was filed to stop, and it costs a full lane re-run plus an investigation
+// that starts by suspecting the code.
+//
+// Revisit when the lane's own green run passes ~100s, not before.
+//
 // Per-lane needs differ; $BROWSER_TEST_TIMEOUT_MS remains the override.
 // check-ui-mounted-prod-elision.cjs still pins 120000 for its negative-
 // control mutant run — left alone deliberately: that run is EXPECTED to

--- a/implementation/ssr/test/re_frame/ssr_end_to_end_test.clj
+++ b/implementation/ssr/test/re_frame/ssr_end_to_end_test.clj
@@ -29,11 +29,56 @@
   private side-channel atom keyed by frame-id (rf2-jbcmt — Spec 011
   §Response storage substrate; NOT in app-db, so it never rides the
   hydration payload); tests read the resolved shape via
-  re-frame.ssr/get-response."
+  re-frame.ssr/get-response.
+
+  ## Posture split
+
+  rf2-lwtlk — this namespace was the LAST entry on
+  `scripts/test-ssr-prod-gate.sh`'s known-red roster, and it comes off here.
+  Run under the real `-Dre-frame.debug=false` gate it was 109 red assertions
+  across 41 deftests. Almost none of that was a production defect: the
+  SECURITY GATES below (CR/LF and NUL in header values and cookie
+  attributes, the cookie-attribute grammar, the safe-redirect five-step
+  open-redirect gate) are production-live and were rejecting correctly the
+  whole time. What was dev-only was the OBSERVATION — every one of them was
+  watched through `re-frame.trace`, which the gate empties.
+
+  So the split here is deliberately lopsided towards re-pointing rather
+  than guarding, because a `(when interop/debug-enabled? …)` arm around a
+  security assertion buys the lane nothing: the arm does not run in the
+  posture that ships, and the gate it describes does.
+
+    ALWAYS-ON, re-pointed (the large majority). `capture-fx-traces!` and
+    `capture-safe-redirect-traces!` now read the production-survivable
+    `:errors` axis. `re-frame.fx`'s `emit-fx-error!` and
+    `re-frame.ssr.response`'s `emit-safe-redirect-error!` both fan every
+    rejection along BOTH axes, so the same failure is observable in a
+    release build — these assertions now adjudicate the posture that ships
+    instead of the one that does not.
+
+    DEV ARMS, kept VERBATIM inside `(when interop/debug-enabled? …)`. Three
+    things are genuinely dev-only and are marked `rf2-lwtlk` at each site:
+    the `:rf.warning/*` family (`:rf.ssr/multiple-status-set`,
+    `-multiple-redirects`), the `:rf.ssr/hydration-mismatch` /
+    head-mismatch traces, and the RICH diagnostics that the always-on
+    record deliberately does not carry — the Spec 010 step-5
+    `:rf.error/schema-validation-failure`, and safe-redirect's
+    `:allowlist` tag, which `re-frame.ssr.egress/safe-redirect-record-slots`
+    excludes on purpose (an app's own security configuration must not ride
+    off-box).
+
+  NEGATIVES MOVED WITH THEIR POSITIVES. A `(is (empty? traces))` or
+  `(is (not-any? … ))` over the dev trace ring passes AUTOMATICALLY under
+  this gate, where the ring is empty for every input — the quiet half of the
+  same false green. Each one below either moved into the dev arm beside the
+  positive it belongs to, or became REAL because its capture is now
+  always-on."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [clojure.string :as str]
             [re-frame.core :as rf]
+            [re-frame.error-emit :as error-emit]
             [re-frame.frame :as frame]
+            [re-frame.interop :as interop]
             [re-frame.ssr :as ssr]
             [re-frame.ssr.response :as response]
             [re-frame.ssr.test-fixture :as tf]
@@ -218,9 +263,19 @@
               (rf/unregister-listener! :trace ::match)
               (is (= server-hash client-hash-1)
                   "first client render hashes identically to the server hash")
-              (is (not-any? #(= :rf.ssr/hydration-mismatch (:operation %))
-                            @match-traces)
-                  "no :rf.ssr/hydration-mismatch trace when hashes agree"))
+              ;; rf2-lwtlk DEV ARM — `:rf.ssr/hydration-mismatch` is a
+              ;; dev-only diagnostic (Spec 011 §Hydration mismatch: the
+              ;; recovery is `:warned-and-replaced`, and the WARNING is the
+              ;; whole of it). This is also a NEGATIVE over the trace ring, so
+              ;; under the production gate it would pass with hydration
+              ;; verification removed entirely — it moves into the arm WITH
+              ;; the positive it discriminates against, not outside it. The
+              ;; hash equality above is the posture-independent half and stays
+              ;; in this lane.
+              (when interop/debug-enabled?
+                (is (not-any? #(= :rf.ssr/hydration-mismatch (:operation %))
+                              @match-traces)
+                    "no :rf.ssr/hydration-mismatch trace when hashes agree")))
 
             ;; (7) Mutate the hydrated app-db; re-render; hash differs;
             ;;     verify-hydration! emits the mismatch trace.
@@ -241,15 +296,20 @@
 
               (is (not= server-hash client-hash-2)
                   "mutating the hydrated db changes the render hash")
-              (is (some (fn [ev]
-                          (and (= :rf.ssr/hydration-mismatch (:operation ev))
-                               (= :error (:op-type ev))
-                               (= server-hash    (:server-hash (:tags ev)))
-                               (= client-hash-2  (:client-hash (:tags ev)))
-                               (= :warned-and-replaced (:recovery ev))))
-                        @mismatch-traces)
-                  (str "expected :rf.ssr/hydration-mismatch trace; saw: "
-                       (pr-str (mapv :operation @mismatch-traces)))))))))))
+              ;; rf2-lwtlk DEV ARM — the mismatch WARNING, kept verbatim. Its
+              ;; production-visible half is the hash inequality asserted just
+              ;; above: the framework computes the divergence in every build,
+              ;; and only the telling-you-about-it is dev-gated.
+              (when interop/debug-enabled?
+                (is (some (fn [ev]
+                            (and (= :rf.ssr/hydration-mismatch (:operation ev))
+                                 (= :error (:op-type ev))
+                                 (= server-hash    (:server-hash (:tags ev)))
+                                 (= client-hash-2  (:client-hash (:tags ev)))
+                                 (= :warned-and-replaced (:recovery ev))))
+                          @mismatch-traces)
+                    (str "expected :rf.ssr/hydration-mismatch trace; saw: "
+                         (pr-str (mapv :operation @mismatch-traces))))))))))))
 
 ;; ===========================================================================
 ;; ssr-set-status-precedence — last write wins; warn on multi-set
@@ -281,14 +341,20 @@
         (is (= 403 (:status (get-response f)))
             "last write wins — the response status is 403")
 
-        (is (some (fn [ev]
-                    (and (= :rf.warning/multiple-status-set (:operation ev))
-                         (= [401 403] (:writes (:tags ev)))
-                         (= 403       (:final-status (:tags ev)))
-                         (= :warned-and-replaced (:recovery ev))))
-                  @traces)
-            (str "expected :rf.warning/multiple-status-set trace; saw: "
-                 (pr-str (mapv :operation @traces))))))))
+        ;; rf2-lwtlk DEV ARM — the `:rf.warning/*` family is genuinely
+        ;; dev-only: per Spec 011 §Multiple-status policy the POLICY is
+        ;; last-write-wins and the warning is advice to the programmer, not
+        ;; part of the response. The policy itself is asserted above and runs
+        ;; in this lane; only the advice is gated.
+        (when interop/debug-enabled?
+          (is (some (fn [ev]
+                      (and (= :rf.warning/multiple-status-set (:operation ev))
+                           (= [401 403] (:writes (:tags ev)))
+                           (= 403       (:final-status (:tags ev)))
+                           (= :warned-and-replaced (:recovery ev))))
+                    @traces)
+              (str "expected :rf.warning/multiple-status-set trace; saw: "
+                   (pr-str (mapv :operation @traces)))))))))
 
 ;; ===========================================================================
 ;; ssr-multi-cookie — multiple set-cookie fxs accumulate as STRUCTURED MAPS
@@ -403,21 +469,53 @@
 ;; ===========================================================================
 
 (defn- capture-fx-traces!
-  "Install a trace callback that records every fx-handler-exception trace
-  for the duration of `body-fn`. Returns the recorded traces. Strips
-  the callback in `finally` so a failing body doesn't leak listeners."
+  "Record every `:rf.error/fx-handler-exception` the framework emitted during
+  `body-fn`, reading BOTH error axes and returning ONE sequence normalised to
+  the dev-trace shape `{:operation … :tags …}`. Strips both callbacks in
+  `finally` so a failing body doesn't leak listeners.
+
+  rf2-lwtlk — WHY BOTH AXES, AND WHY THIS IS NOT A DEV ARM. This helper used
+  to listen on `:trace` alone. Under `-Dre-frame.debug=false` that ring is
+  empty, so roughly sixty assertions below — the CR/LF and NUL injection
+  gates on `set-header` / `append-header` / `redirect`, the whole
+  cookie-attribute grammar, the retired redirect spellings — saw nothing and
+  went red. NOT because the gates stopped working: every one of them is a
+  `throw` at the fx boundary in `re-frame.ssr.response`, unconditional in
+  every build, and it was rejecting correctly the whole time. It was the
+  OBSERVATION that was dev-only.
+
+  Guarding them would therefore have been the wrong repair twice over: it
+  would move a live security boundary's proof out of the posture that ships,
+  and it would leave the lane asserting nothing about the artefact's most
+  load-bearing code. `re-frame.fx`'s `emit-fx-error!` already fans every
+  contained fx exception through `error-emit/emit-error-both!` — axis 1 the
+  ALWAYS-ON listener record (`{:error :event-id :frame :exception …}`, the
+  off-box shipper's source), axis 2 the dev-only `trace/emit-error!` — so
+  the production-visible witness was there to be read.
+
+  The union is normalised so `expect-fx-error-keyword!` and `fx-error-extra`
+  are unchanged: both read only `(-> ev :tags :exception)`, and that is the
+  SAME exception object on both axes (axis 1 carries it in `:exception`,
+  axis 2 in `:tags :exception`). In a dev build both fire and the sequence
+  carries two entries per error; no consumer counts them — each asks `seq`
+  or `some` — and the duplication is one failure seen twice, not two."
   [body-fn]
   (let [traces (atom [])
-        tag    (keyword (str "::trace-cap-" (gensym)))]
+        tag    (keyword "rf2-lwtlk" (str "fx-cap-" (name (gensym "c"))))]
     (rf/register-listener! :trace tag
       (fn [ev]
         (when (= :rf.error/fx-handler-exception (:operation ev))
           (swap! traces conj ev))))
+    (rf/register-listener! :errors tag
+      (fn [r]
+        (when (= :rf.error/fx-handler-exception (:error r))
+          (swap! traces conj {:operation (:error r) :tags r}))))
     (try
       (body-fn)
       @traces
       (finally
-        (rf/unregister-listener! :trace tag)))))
+        (rf/unregister-listener! :trace tag)
+        (rf/unregister-listener! :errors tag)))))
 
 (defn- expect-fx-error-keyword!
   "Assert that the `traces` collection (output of `capture-fx-traces!`)
@@ -716,6 +814,57 @@
 ;; PROJECTOR's output reaches the response accumulator — not a user-stub-
 ;; rolled :rf.server/set-status.
 
+(defn- error-record->trace-event
+  "Synthesise the `{:operation :op-type :tags}` envelope the projector
+  pipeline consumes from an EP-0008 union error record `{:error <kw> :frame
+  <id> :time <ms> + flat category keys}`.
+
+  This is the SAME generic lift `error-emit-projection-listener` performs —
+  every non-`:error` slot rides onto `:tags`, `:recovery` defaults to
+  `:no-recovery` — so an event handed to `ssr/project-error` from here is the
+  event the runtime's own always-on projection listener would have handed it.
+  Copied deliberately from `re-frame.ssr-conformance-test` (rf2-76gom), which
+  solved the identical sourcing problem for the conformance corpus."
+  [record]
+  {:op-type   :error
+   :operation (:error record)
+   :tags      (-> (dissoc record :error)
+                  (update :recovery #(or % :no-recovery)))})
+
+(defn- with-error-capture!
+  "Run `body-fn` and return `{:result <its value> :events <seq>}`, where
+  `:events` carries every error the framework emitted during it, read from
+  BOTH axes and normalised to the projector's `{:operation :op-type :tags}`
+  envelope.
+
+  rf2-lwtlk — the projector cluster below used to source its error events
+  from `re-frame.trace` alone. Under `-Dre-frame.debug=false` that ring is
+  empty, so `(some? err)` found nothing and the projections those tests exist
+  to pin were never exercised. The categories involved —
+  `:rf.error/no-such-handler` (promoted by rf2-ov56u),
+  `:rf.error/handler-exception`, and `:rf.error/sanitised-on-projection` —
+  ALL ride the always-on axis in a release build; indeed
+  `error-emit-projection-listener` is precisely what stamps `:status` on a
+  production JVM, so the always-on record is the SOURCE OF TRUTH here and the
+  dev bus was the copy. Reading both means these assertions now adjudicate
+  the production projection path rather than a dev artefact.
+
+  A dev build sees both axes and the sequence carries the same failure twice;
+  every consumer below asks `some`, never a count."
+  [body-fn]
+  (let [events (atom [])
+        tag    (keyword "rf2-lwtlk" (str "err-cap-" (name (gensym "c"))))]
+    (rf/register-listener! :trace tag
+      (fn [ev] (when (= :error (:op-type ev)) (swap! events conj ev))))
+    (rf/register-listener! :errors tag
+      (fn [r] (swap! events conj (error-record->trace-event r))))
+    (try
+      (let [result (body-fn)]
+        {:result result :events @events})
+      (finally
+        (rf/unregister-listener! :trace tag)
+        (rf/unregister-listener! :errors tag)))))
+
 (deftest ssr-default-error-projector-no-such-handler
   (testing "routing's :rf.error/no-such-handler → default projector → 404"
     (rf/reg-route :route/home {} "/")
@@ -724,19 +873,22 @@
                            {:platform :server
                             :ssr {:public-error-id   :rf.ssr/default-error-projector
                                   :dev-error-detail? false}})
-          traces         (atom [])]
-      (rf/register-listener! :trace ::nsh (fn [ev] (swap! traces conj ev)))
-      (rf/dispatch-sync [:rf.route/handle-url-change "/no-such-page"] {:frame f})
-      (rf/unregister-listener! :trace ::nsh)
-
+          events         (:events (with-error-capture!
+                                    (fn []
+                                      (rf/dispatch-sync
+                                        [:rf.route/handle-url-change "/no-such-page"]
+                                        {:frame f}))))]
       ;; Runtime's error-projection listener stamps :status 404 on :rf/response.
       (is (= 404 (:status (get-response f)))
           "default projector's :status reaches :rf/response — not a user-stub fx")
       (is (nil? (:redirect (get-response f)))
           "no redirect — the 404 is a status-only response, body still renders")
 
-      ;; The trace stream still carries the internal :rf.error/no-such-handler.
-      (let [err (some #(when (= :rf.error/no-such-handler (:operation %)) %) @traces)]
+      ;; The error stream still carries the internal :rf.error/no-such-handler.
+      ;; rf2-ov56u promoted the URL-driven route miss onto the always-on axis,
+      ;; so this reads in a release build too — which is the whole point: the
+      ;; 404 above is produced BY this record on a production JVM.
+      (let [err (some #(when (= :rf.error/no-such-handler (:operation %)) %) events)]
         (is (some? err)
             "internal trace records :rf.error/no-such-handler")
         ;; Projecting the trace yields the locked public-error shape.
@@ -766,17 +918,15 @@
       (fn [_ _] {}))
 
     (let [project-error  ssr/project-error
-          traces         (atom [])
           f              (frame/make-anon-frame-record!
                            {:platform :server
                             :initial-events [[:rf/server-init]]
                             :ssr {:public-error-id   :rf.ssr/default-error-projector
                                   :dev-error-detail? false}})
-          _              (rf/register-listener! :trace ::he (fn [ev] (swap! traces conj ev)))
-          _              (rf/dispatch-sync [:load/article] {:frame f})
-          _              (rf/unregister-listener! :trace ::he)
+          events         (:events (with-error-capture!
+                                    (fn [] (rf/dispatch-sync [:load/article] {:frame f}))))
           err            (some #(when (= :rf.error/handler-exception (:operation %)) %)
-                               @traces)]
+                               events)]
       (is (some? err)
           "handler-exception fired during the drain")
       (is (= 500 (:status (get-response f)))
@@ -862,18 +1012,18 @@
                           {:platform :server
                            :ssr {:public-error-id   :myapp/buggy-projector
                                  :dev-error-detail? false}})
-          traces        (atom [])
-          _             (rf/register-listener! :trace ::sop (fn [ev] (swap! traces conj ev)))
-          public        (project-error f {:operation :rf.error/handler-exception :tags {}})]
-      (rf/unregister-listener! :trace ::sop)
+          {public :result
+           events :events} (with-error-capture!
+                             (fn [] (project-error
+                                      f {:operation :rf.error/handler-exception :tags {}})))]
       (is (= {:status     500
               :code       :internal-error
               :message    "Something went wrong"
               :retryable? false}
              public)
           "fallback to the locked generic-500 shape — the boundary holds even with a buggy projector")
-      (is (some #(= :rf.error/sanitised-on-projection (:operation %)) @traces)
-          ":rf.error/sanitised-on-projection trace fired so the buggy projector is observable"))))
+      (is (some #(= :rf.error/sanitised-on-projection (:operation %)) events)
+          ":rf.error/sanitised-on-projection fired so the buggy projector is observable"))))
 
 (deftest ssr-error-projector-non-conforming-shape-falls-back
   (testing "projector returns nil / wrong shape → :rf.error/sanitised-on-projection + fallback"
@@ -884,14 +1034,14 @@
           f             (frame/make-anon-frame-record!
                           {:platform :server
                            :ssr {:public-error-id   :myapp/bad-shape}})
-          traces        (atom [])
-          _             (rf/register-listener! :trace ::bs (fn [ev] (swap! traces conj ev)))
-          public        (project-error f {:operation :rf.error/handler-exception :tags {}})]
-      (rf/unregister-listener! :trace ::bs)
+          {public :result
+           events :events} (with-error-capture!
+                             (fn [] (project-error
+                                      f {:operation :rf.error/handler-exception :tags {}})))]
       (is (= 500 (:status public))
           "non-conforming projector output → fallback locked-500")
       (is (= :internal-error (:code public)))
-      (is (some #(= :rf.error/sanitised-on-projection (:operation %)) @traces)))))
+      (is (some #(= :rf.error/sanitised-on-projection (:operation %)) events)))))
 
 (deftest ssr-error-projector-configured-but-unregistered-surfaces-diagnostic
   (testing "rf2-mlodrn — a frame that configures :ssr {:public-error-id …}
@@ -907,19 +1057,21 @@
                           {:platform :server
                            :ssr {:public-error-id   :myapp/never-registered
                                  :dev-error-detail? false}})
-          traces        (atom [])
-          _             (rf/register-listener! :trace ::mp (fn [ev] (swap! traces conj ev)))
           ;; :no-such-handler would have projected to a 404 under a real
           ;; projector — the misconfiguration silently made it a 500.
-          public        (project-error f {:operation :rf.error/no-such-handler :tags {}})]
-      (rf/unregister-listener! :trace ::mp)
+          {public :result
+           events :events} (with-error-capture!
+                             (fn [] (project-error
+                                      f {:operation :rf.error/no-such-handler :tags {}})))]
       ;; The boundary still holds — the fallback is the safe wire shape.
       (is (= 500 (:status public))
           "the locked generic-500 fallback still applies (boundary can't be bypassed)")
       (is (= :internal-error (:code public)))
-      ;; …but the misconfiguration is now OBSERVABLE.
+      ;; …but the misconfiguration is now OBSERVABLE — and, since rf2-lwtlk
+      ;; re-sourced this read, observable in the build that ships rather than
+      ;; only in the one the operator is not running.
       (let [diag (some #(when (= :rf.error/sanitised-on-projection (:operation %)) %)
-                       @traces)]
+                       events)]
         (is (some? diag)
             ":rf.error/sanitised-on-projection fired — the missing configured
              projector is surfaced, not swallowed")
@@ -936,19 +1088,26 @@
             path)."
     (let [project-error ssr/project-error
           f             (frame/make-anon-frame-record! {:platform :server})
-          traces        (atom [])
-          _             (rf/register-listener! :trace ::mp2 (fn [ev] (swap! traces conj ev)))
           ;; rf2-ov56u: the 404 arm is gated on `:kind :route` — the
           ;; URL-driven miss. `:tags {}` now projects 500, so the
           ;; honoured-vs-fallen-back distinction this deftest is about
           ;; needs the route discriminator to be visible.
-          public        (project-error f {:operation :rf.error/no-such-handler
-                                          :tags      {:kind :route}})]
-      (rf/unregister-listener! :trace ::mp2)
+          {public :result
+           events :events} (with-error-capture!
+                             (fn [] (project-error
+                                      f {:operation :rf.error/no-such-handler
+                                         :tags      {:kind :route}})))]
       (is (= 404 (:status public))
           "the built-in default projector maps a :kind :route
            :no-such-handler → 404 (honoured, not fallen-back)")
-      (is (not-any? #(= :rf.error/sanitised-on-projection (:operation %)) @traces)
+      ;; rf2-lwtlk — this NEGATIVE is the one the roster called out by name.
+      ;; Sourced from the dev bus alone it passed AUTOMATICALLY under
+      ;; `-Dre-frame.debug=false`, where the ring is empty for every input:
+      ;; it would have reported "the default path is quiet" in a build where
+      ;; NOTHING can be heard. Reading the always-on axis too makes it a real
+      ;; discriminator again — it now fails if the default path ever starts
+      ;; emitting a missing-projector diagnostic in production.
+      (is (not-any? #(= :rf.error/sanitised-on-projection (:operation %)) events)
           "no sanitised-on-projection diagnostic on the default path — the
            default projector is registered, so it is not a missing-projector"))))
 
@@ -1141,14 +1300,19 @@
           (is (= {:status 301 :location "/canonical"} redirect)
               "last write wins — the response :redirect is the second write"))
 
-        (is (some (fn [ev]
-                    (and (= :rf.warning/multiple-redirects (:operation ev))
-                         (= 2 (count (:writes (:tags ev))))
-                         (= {:status 301 :location "/canonical"} (:final-redirect (:tags ev)))
-                         (= :warned-and-replaced (:recovery ev))))
-                  @traces)
-            (str "expected :rf.warning/multiple-redirects trace; saw: "
-                 (pr-str (mapv :operation @traces))))))))
+        ;; rf2-lwtlk DEV ARM — same shape as :rf.warning/multiple-status-set
+        ;; above: the last-write-wins POLICY is the contract and is asserted
+        ;; posture-independently just above; the warning is programmer advice
+        ;; and is dev-only by design.
+        (when interop/debug-enabled?
+          (is (some (fn [ev]
+                      (and (= :rf.warning/multiple-redirects (:operation ev))
+                           (= 2 (count (:writes (:tags ev))))
+                           (= {:status 301 :location "/canonical"} (:final-redirect (:tags ev)))
+                           (= :warned-and-replaced (:recovery ev))))
+                    @traces)
+              (str "expected :rf.warning/multiple-redirects trace; saw: "
+                   (pr-str (mapv :operation @traces)))))))))
 
 ;; ===========================================================================
 ;; host-supplied :failing-id is surfaced on the unified render-hash channel
@@ -1202,27 +1366,38 @@
                   :first-diff-path [:head :title]})
       (rf/unregister-listener! :trace ::head)
 
-      (is (some (fn [ev]
-                  (and (= :rf.ssr/hydration-mismatch (:operation ev))
-                       (= "head-hash-server-A" (:server-hash (:tags ev)))
-                       (= "head-hash-client-B" (:client-hash (:tags ev)))
-                       (= :rf.ssr/head-mismatch (:failing-id (:tags ev)))
-                       (= [:head :title] (:first-diff-path (:tags ev)))
-                       (= :warned-and-replaced (:recovery ev))))
-                @traces)
-          (str "expected head-mismatch trace; saw: "
-               (pr-str (mapv (juxt :operation #(:failing-id (:tags %))) @traces))))
+      ;; rf2-lwtlk DEV ARM — the host-supplied `:failing-id` seam exists to
+      ;; put a host's own attribution ON THE MISMATCH TRACE, and that trace is
+      ;; the dev-only `:rf.ssr/hydration-mismatch` warning (recovery
+      ;; `:warned-and-replaced` — the client re-renders either way). So the
+      ;; seam is dev-posture by construction. What is NOT dev-posture is the
+      ;; payload stash asserted above: `:rf/hydrate` puts the server hash into
+      ;; the runtime-db partition in every build, and that assertion runs in
+      ;; this lane — which is why guarding here does not leave the deftest
+      ;; executing nothing under the gate.
+      (when interop/debug-enabled?
+        (is (some (fn [ev]
+                    (and (= :rf.ssr/hydration-mismatch (:operation ev))
+                         (= "head-hash-server-A" (:server-hash (:tags ev)))
+                         (= "head-hash-client-B" (:client-hash (:tags ev)))
+                         (= :rf.ssr/head-mismatch (:failing-id (:tags ev)))
+                         (= [:head :title] (:first-diff-path (:tags ev)))
+                         (= :warned-and-replaced (:recovery ev))))
+                  @traces)
+            (str "expected head-mismatch trace; saw: "
+                 (pr-str (mapv (juxt :operation #(:failing-id (:tags %))) @traces))))
 
-      ;; And the SAME hash on both sides → no trace.
-      (let [no-mismatch-traces (atom [])]
-        (rf/register-listener! :trace ::head-ok (fn [ev] (swap! no-mismatch-traces conj ev)))
-        (verify-fn f
-                   "head-hash-server-A"
-                   {:failing-id :rf.ssr/head-mismatch})
-        (rf/unregister-listener! :trace ::head-ok)
-        (is (not-any? #(= :rf.ssr/hydration-mismatch (:operation %))
-                      @no-mismatch-traces)
-            "no head-mismatch trace when client and server hashes agree")))))
+        ;; And the SAME hash on both sides → no trace. A NEGATIVE over the
+        ;; ring, so it belongs in the arm with the positive above it.
+        (let [no-mismatch-traces (atom [])]
+          (rf/register-listener! :trace ::head-ok (fn [ev] (swap! no-mismatch-traces conj ev)))
+          (verify-fn f
+                     "head-hash-server-A"
+                     {:failing-id :rf.ssr/head-mismatch})
+          (rf/unregister-listener! :trace ::head-ok)
+          (is (not-any? #(= :rf.ssr/hydration-mismatch (:operation %))
+                        @no-mismatch-traces)
+              "no head-mismatch trace when client and server hashes agree"))))))
 
 ;; ---- rf2-37pr: install-render-to-string! install contract -----------------
 ;;
@@ -1323,28 +1498,67 @@
 ;; full path runs without involving the Ring adapter.
 
 (deftest direct-ssr-layer-projects-view-time-exception
-  (testing "rf2-dl9yg TC9: a synthetic error trace tagged with a server frame
-            → error-projection-listener buffers → get-response flushes → response
-            :status carries the default projector's 500"
+  ;; rf2-lwtlk — THE ONE DEFTEST IN THIS FILE THAT DRIVES THE DEV BUS AS ITS
+  ;; INPUT, not merely as its observation. `trace/emit!` is a no-op under
+  ;; `-Dre-frame.debug=false`, so under the gate nothing was buffered, nothing
+  ;; projected, and `:status` stayed 200 — the subject was ABSENT, not merely
+  ;; unobservable, and re-pointing the READ could not fix it.
+  ;;
+  ;; Guarding it wholesale was the wrong answer too: it would leave the
+  ;; SUBSTRATE that actually stamps `:status` on a production JVM
+  ;; (`error-emit-projection-listener`, registered always-on in the
+  ;; `re-frame.ssr` façade) with no direct exercise anywhere. So the deftest
+  ;; keeps its dev drive VERBATIM in an arm and gains the symmetric always-on
+  ;; counterpart: the same synthetic error, injected on the other axis.
+  (testing "rf2-dl9yg TC9 / rf2-lwtlk — an always-on error RECORD tagged with a
+            server frame → error-emit-projection-listener buffers →
+            get-response flushes → :status carries the default projector's 500.
+            This is the production path: in a release build this listener, not
+            the trace-cb one, is what produces the status."
     (let [f (frame/make-anon-frame-record!
               {:platform :server
                :ssr      {:public-error-id   :rf.ssr/default-error-projector
                           :dev-error-detail? false}})]
-      ;; Emit a synthetic view-time-style error trace directly. Per
-      ;; the listener contract (`error_listener.cljc:103-115`) it
-      ;; gates on :op-type :error and the frame being a server frame;
-      ;; either condition failing → silent.
-      (trace/emit! :error :rf.error/view-time-exception
-                   {:frame             f
-                    :exception-message "synthetic view-time boom"
-                    :failing-id        :pages/articles
-                    :recovery          :warned-and-projected})
-      ;; Reading the response flushes the projection.
+      ;; The EP-0008 union record shape `{:error <kw> :frame <id> :time <ms>
+      ;; + flat category keys}` — what `dispatch-error-record!` fans to every
+      ;; always-on listener, including SSR's `::error-projection`.
+      (error-emit/dispatch-error-record!
+        {:error             :rf.error/view-time-exception
+         :frame             f
+         :time              (interop/now-ms)
+         :exception-message "synthetic view-time boom"
+         :failing-id        :pages/articles
+         :recovery          :warned-and-projected})
       (let [resp (get-response f)]
         (is (= 500 (:status resp))
-            "synthetic error trace → projector → 500 stamped onto :rf/response")
+            "always-on error record → projector → 500 stamped onto :rf/response")
         (is (nil? (:redirect resp))
-            "no redirect was set; the projector overwrites the status freely")))))
+            "no redirect was set; the projector overwrites the status freely"))))
+
+  (when interop/debug-enabled?
+    (testing "rf2-dl9yg TC9 (dev arm) — the trace-cb buffering path. Kept
+              VERBATIM: `trace/emit!` cannot fire under the production gate,
+              so this half is a genuine dev-posture contract rather than a
+              dev-posture SPELLING of one."
+      (let [f (frame/make-anon-frame-record!
+                {:platform :server
+                 :ssr      {:public-error-id   :rf.ssr/default-error-projector
+                            :dev-error-detail? false}})]
+        ;; Emit a synthetic view-time-style error trace directly. Per
+        ;; the listener contract (`error_listener.cljc:103-115`) it
+        ;; gates on :op-type :error and the frame being a server frame;
+        ;; either condition failing → silent.
+        (trace/emit! :error :rf.error/view-time-exception
+                     {:frame             f
+                      :exception-message "synthetic view-time boom"
+                      :failing-id        :pages/articles
+                      :recovery          :warned-and-projected})
+        ;; Reading the response flushes the projection.
+        (let [resp (get-response f)]
+          (is (= 500 (:status resp))
+              "synthetic error trace → projector → 500 stamped onto :rf/response")
+          (is (nil? (:redirect resp))
+              "no redirect was set; the projector overwrites the status freely"))))))
 
 ;; ===========================================================================
 ;; rf2-ooj41 — direct adapter-contract smoke
@@ -1473,18 +1687,21 @@
     ;; the projector's drain-time domain; were this a construction setup step,
     ;; the now-STRICT :initial-events teardown (EP-0027 §Failure) would tear
     ;; the frame down and raise :rf.error/initial-events-step-failed instead.
-    (let [traces (atom [])
-          f      (frame/make-anon-frame-record!
+    (let [f      (frame/make-anon-frame-record!
                    {:platform  :server
                     :ssr       {:public-error-id   :rf.ssr/default-error-projector
                                 :dev-error-detail? false}})
-          _      (rf/register-listener! :trace ::rpe (fn [ev] (swap! traces conj ev)))
-          _      (rf/dispatch-sync [:redirect-then-error] {:frame f})
-          _      (rf/unregister-listener! :trace ::rpe)
+          events (:events (with-error-capture!
+                            (fn [] (rf/dispatch-sync [:redirect-then-error] {:frame f}))))
           resp   (get-response f)]
-      ;; The handler-exception fired (drain-time trace).
-      (is (some #(= :rf.error/handler-exception (:operation %)) @traces)
-          "the handler-exception was traced during the drain")
+      ;; The handler-exception fired (drain-time). Read off the always-on
+      ;; axis as well as the dev bus (rf2-lwtlk): this assertion is the
+      ;; PREMISE of the two below it — without a real error there is nothing
+      ;; for the projector to overwrite the redirect WITH, so sourcing it
+      ;; dev-only left the redirect-precedence claim resting on nothing under
+      ;; the production gate.
+      (is (some #(= :rf.error/handler-exception (:operation %)) events)
+          "the handler-exception was emitted during the drain")
       ;; The redirect survived: response :status is 302, not 500.
       (is (= 302 (:status resp))
           "redirect wins — projector must not overwrite a redirect's :status (Spec 011 §Redirect precedence)")
@@ -1516,20 +1733,63 @@
 ;;      (:reason :not-in-allowlist)
 ;;   5. pass → set Location header (same shape as redirect-fx).
 
+(defn- safe-redirect-error?
+  "Is `op` one of the `:rf.error/safe-redirect-*` rejection categories?"
+  [op]
+  (and (keyword? op)
+       (= "rf.error" (namespace op))
+       (str/starts-with? (name op) "safe-redirect-")))
+
 (defn- capture-safe-redirect-traces!
-  "Install a trace listener filtering only :rf.error/safe-redirect-* events
-  for the duration of `body-fn`. Returns the captured traces."
+  "Record every `:rf.error/safe-redirect-*` rejection emitted during `body-fn`,
+  reading the ALWAYS-ON `:errors` axis and returning it normalised to the
+  dev-trace shape `{:operation … :tags …}`.
+
+  rf2-lwtlk / rf2-6jqa8 — WHY THE ALWAYS-ON AXIS AND NOT A DEV ARM. This is
+  the open-redirect gate: the one surface in this file where a dev-posture
+  proof would be actively misleading. rf2-6jqa8 PROMOTED these rejections
+  precisely so a production JVM stops swallowing them —
+  `emit-safe-redirect-error!` fans axis 1 (`dispatch-safe-redirect-record!`,
+  the record an off-box shipper sees) beside axis 2 (`trace/emit-error!`).
+  Reading axis 1 means the seventeen assertions below now prove the gate in
+  the build an attacker actually meets.
+
+  ONLY axis 1, deliberately — several of these count (`(= 1 (count hits))`),
+  and a union would report two in a dev build and one in a release build,
+  making the count itself posture-dependent. Axis 1 fires in both, so one
+  reading serves both.
+
+  WHAT AXIS 1 DOES NOT CARRY. The record is a CLOSED STRUCTURAL PROJECTION
+  (`re-frame.ssr.egress/safe-redirect-record-slots` =
+  `#{:frame :recovery :reason :scheme :host}`). `:scheme`, `:host` and
+  `:reason` — everything the assertions below discriminate on — survive it.
+  `:location` and `:allowlist` are excluded ON PURPOSE: the attacker's URL
+  and the application's own security configuration must not ride off-box.
+  The single assertion that reads `:allowlist` is therefore the one genuine
+  dev arm in this cluster, and it is marked as such at its site."
   [body-fn]
   (let [traces (atom [])
-        tag    (keyword (str "::safe-redirect-cap-" (gensym)))
-        prefix "rf.error"
-        match? (fn [op]
-                 (and (keyword? op)
-                      (= prefix (namespace op))
-                      (str/starts-with? (name op) "safe-redirect-")))]
+        tag    (keyword "rf2-lwtlk" (str "sr-cap-" (name (gensym "c"))))]
+    (rf/register-listener! :errors tag
+                           (fn [r]
+                             (when (safe-redirect-error? (:error r))
+                               (swap! traces conj {:operation (:error r)
+                                                   :tags      r}))))
+    (try (body-fn) @traces
+         (finally (rf/unregister-listener! :errors tag)))))
+
+(defn- capture-safe-redirect-dev-traces!
+  "The DEV-ONLY companion to [[capture-safe-redirect-traces!]], reading
+  `trace/emit-error!`'s axis-2 surface — which receives the diagnostics
+  WHOLE rather than projected. rf2-lwtlk: used at exactly one site, for the
+  `:allowlist` tag that `safe-redirect-record-slots` excludes from the
+  always-on record by design."
+  [body-fn]
+  (let [traces (atom [])
+        tag    (keyword "rf2-lwtlk" (str "sr-dev-cap-" (name (gensym "c"))))]
     (rf/register-listener! :trace tag
                            (fn [ev]
-                             (when (match? (:operation ev))
+                             (when (safe-redirect-error? (:operation ev))
                                (swap! traces conj ev))))
     (try (body-fn) @traces
          (finally (rf/unregister-listener! :trace tag)))))
@@ -1688,12 +1948,37 @@
           (is (= :not-in-allowlist (-> ev :tags :reason))
               ":reason discriminates from the relative-only case")
           (is (= "evil.example.com" (-> ev :tags :host))
-              ":host names the rejected host")
+              ":host names the rejected host")))
+      (is (nil? (:redirect (get-response f)))
+          "rejection is a no-op"))
+
+    ;; rf2-lwtlk DEV ARM — the ONE safe-redirect tag that is genuinely
+    ;; dev-only. `:allowlist` is deliberately absent from the always-on
+    ;; record: `re-frame.ssr.egress/safe-redirect-record-slots` excludes it
+    ;; because an application's own security configuration is unbounded
+    ;; policy data whose contents hand a reader the exact boundary being
+    ;; probed. `:reason :not-in-allowlist` already discriminates the arm
+    ;; without disclosing it — which is why the assertions ABOVE stayed
+    ;; always-on and only this one moved. Kept verbatim, read off axis 2,
+    ;; where the diagnostics arrive whole.
+    (when interop/debug-enabled?
+      (testing "rf2-2brsn step 4 (dev diagnostics): the dev trace carries the
+                allowlist vector itself, for the programmer reading a log"
+        (rf/reg-event :sr/not-in-allow-dev
+          (fn [_ _]
+            {:fx [[:rf.server/safe-redirect
+                   {:location "https://evil.example.com/phish"
+                    :allow    ["app.example.com" "alt.example.com"]}]]}))
+        (let [f      (frame/make-anon-frame-record! {:platform :server})
+              traces (capture-safe-redirect-dev-traces!
+                       (fn [] (rf/dispatch-sync [:sr/not-in-allow-dev] {:frame f})))
+              ev     (first (filter #(= :rf.error/safe-redirect-host-disallowed
+                                        (:operation %)) traces))]
+          (is (some? ev)
+              ":rf.error/safe-redirect-host-disallowed reached the dev trace")
           (is (= ["app.example.com" "alt.example.com"]
                  (-> ev :tags :allowlist))
-              ":allowlist tag carries the allowlist vector for diagnostic clarity")))
-      (is (nil? (:redirect (get-response f)))
-          "rejection is a no-op"))))
+              ":allowlist tag carries the allowlist vector for diagnostic clarity"))))))
 
 (deftest safe-redirect-allowlist-accepts-on-allowlist-host
   (testing "rf2-2brsn step 4 happy path: host IN allowlist → redirect succeeds"
@@ -2399,6 +2684,45 @@
 ;; The schemas artefact (transitively Malli) is on the ssr JVM test
 ;; classpath and `re-frame.ssr.test-fixture` requires `re-frame.schemas`,
 ;; so the late-bind validator (`:schemas/validate-fx!`) is LIVE here.
+;;
+;; ---------------------------------------------------------------------------
+;; rf2-lwtlk / rf2-dtpfv — REWRITTEN AS A TWO-POSTURE CONTRACT
+;;
+;; This deftest was the reason `ssr-end-to-end-test` stayed on the prod-gate
+;; roster after every other namespace in the artefact had come off. It was NOT
+;; ordinary trace spelling: under `-Dre-frame.debug=false` it failed for a REAL
+;; reason. `validate-fx!` is `(if interop/debug-enabled? (run-validation …)
+;; true)`, so the Spec 010 §Validation-order step-5 boundary did not run in a
+;; release build at all — and a malformed `:rf.server/*` fx therefore RAN, its
+;; args landing on the response accumulator that `ssr/get-response` publishes
+;; to every host adapter. `[:rf.server/set-status "not-an-int"]` really did
+;; leave a STRING on the HTTP status line.
+;;
+;; rf2-dtpfv ruled and fixed it: the reserved family now guards its OWN args
+;; unconditionally (`re-frame.ssr.response`), while the general step-5 gate for
+;; USER fx stays dev-only — trust-the-programmer covers user declarations, and
+;; validating every fx in every app to protect seven closed framework effects
+;; is posture-hostile.
+;;
+;; So the SEMANTICS below no longer differ by posture, and they are asserted
+;; unguarded in §1. What still differs, by design, is the RECOVERY PATH — and
+;; that is the whole of the split:
+;;
+;;   dev + schemas : Malli step-5 rejects FIRST, the fx is `:skipped`, and the
+;;                   programmer gets the rich `:rf.error/schema-validation-
+;;                   failure` `:where :fx-args` naming the failing path (§2).
+;;   production    : the guard throws, `re-frame.fx` containment catches it,
+;;                   and an ALWAYS-ON `:rf.error/fx-handler-exception` names
+;;                   the offending fx to an off-box shipper (§3).
+;;
+;; Note what that ordering means for §1: it is NOT a claim that one mechanism
+;; fires. It is the claim both mechanisms exist to make, and it holds whichever
+;; of them got there first — which is exactly why it belongs outside both arms.
+;;
+;; `re-frame.ssr-reserved-fx-guards-test` is rf2-dtpfv's own acceptance suite
+;; and reads the PURE accumulator (`ssr/peek-response`). This one is the
+;; END-TO-END view: every read below goes through `get-response`, the public
+;; host-adapter surface, after the error projection has drained.
 ;; ===========================================================================
 
 (defn- capture-schema-failures!
@@ -2437,173 +2761,230 @@
                                                (-> ev :tags :failing-id)])
                                      traces))))))
 
-(deftest ssr-server-fx-args-schema-boundary
-  (testing "rf2-kjf3m.2 — the spec-declared :rf.fx.server/*-args boundary
-            fires on malformed server fx args (Spec 011 §Standard fx /
-            Spec-Schemas §Standard fx args schemas / Spec 010 §step 5)"
+(def ^:private malformed-server-fx
+  "The nine malformed reserved-fx calls this boundary refuses, as
+  `[label fx-id fx-vec]`.
 
-    (testing ":rf.server/set-status with a non-int arg → rejected + skipped + projected 500"
-      ;; The bead's concrete failing scenario: a string status that
-      ;; pre-rf2-kjf3m.2 rode straight onto the wire (Ring then emitted a
-      ;; non-integer status). Now the :schema boundary rejects it before
-      ;; set-status-fx runs, so the malformed "not-an-int" NEVER reaches
-      ;; the accumulator. The fired :rf.error/schema-validation-failure
-      ;; ALSO routes through the always-on SSR error-projection substrate.
+  rf2-dtpfv made the REFUSAL itself posture-independent, so this table drives
+  only the two DIAGNOSTIC arms (§2 / §3), where the recovery path still
+  differs by design. The ACCUMULATOR claims are heterogeneous — each fx family
+  owns a different response slot — so they stay written out, unguarded, in §1."
+  [[":rf.server/set-status with a non-int arg"
+    :rf.server/set-status    [:rf.server/set-status "not-an-int"]]
+   [":rf.server/set-header missing :value"
+    :rf.server/set-header    [:rf.server/set-header {:name "X-Foo"}]]
+   [":rf.server/append-header with a non-string :value"
+    :rf.server/append-header [:rf.server/append-header {:name "X-Bar" :value 42}]]
+   [":rf.server/set-cookie missing :value (via [:ref :rf.server/cookie])"
+    :rf.server/set-cookie    [:rf.server/set-cookie {:name "session"}]]
+   [":rf.server/set-cookie with a bogus :same-site keyword"
+    :rf.server/set-cookie    [:rf.server/set-cookie {:name "s" :value "v"
+                                                     :same-site :bogus}]]
+   [":rf.server/delete-cookie missing :name"
+    :rf.server/delete-cookie [:rf.server/delete-cookie {:path "/"}]]
+   [":rf.server/redirect with a non-int :status"
+    :rf.server/redirect      [:rf.server/redirect {:location "/x" :status "oops"}]]
+   [":rf.server/safe-redirect with a non-int :status"
+    :rf.server/safe-redirect [:rf.server/safe-redirect {:location "/ok"
+                                                        :status   "not-int"}]]
+   [":rf.server/safe-redirect missing :location"
+    :rf.server/safe-redirect [:rf.server/safe-redirect {:status 302}]]])
+
+(defn- drive-server-fx!
+  "Dispatch `fx-vec` on a fresh server frame and return
+  `{:response … :dev-traces … :records …}` — the PUBLIC host-adapter read
+  (`ssr/get-response`, taken after the error projection has drained), every
+  dev `:rf.error/schema-validation-failure` trace, and every record the
+  ALWAYS-ON `:errors` axis saw. One drive, read by all three sections below."
+  [fx-vec]
+  (let [f       (frame/make-anon-frame-record! {:platform :server})
+        ev-id   (keyword "rf2-lwtlk" (str "attempt-" (name (gensym "e"))))
+        tag     (keyword "rf2-lwtlk" (str "sfx-cap-" (name (gensym "c"))))
+        dev     (atom [])
+        records (atom [])]
+    (rf/reg-event ev-id (fn [_ _] {:fx [fx-vec]}))
+    (rf/register-listener! :trace tag
+      (fn [ev] (when (= :rf.error/schema-validation-failure (:operation ev))
+                 (swap! dev conj ev))))
+    (rf/register-listener! :errors tag (fn [r] (swap! records conj r)))
+    (try
+      (rf/dispatch-sync [ev-id] {:frame f})
+      {:response   (get-response f)
+       :dev-traces @dev
+       :records    @records}
+      (finally
+        (rf/unregister-listener! :trace tag)
+        (rf/unregister-listener! :errors tag)))))
+
+(deftest ssr-server-fx-args-schema-boundary
+  ;; -------------------------------------------------------------------------
+  ;; §1 — POSTURE-INDEPENDENT. The malformed args never reach the wire.
+  ;;
+  ;; Not a claim that one MECHANISM fires — it is the claim both mechanisms
+  ;; exist to make, and it holds whichever of them got there first. That is
+  ;; why it sits outside both arms.
+  ;; -------------------------------------------------------------------------
+  (testing "rf2-dtpfv — a malformed :rf.server/* fx never reaches the response
+            accumulator, in EVERY build (Spec 011 §Standard fx / Spec-Schemas
+            §Standard fx args schemas / Spec 010 §Validation order step 5)"
+
+    (testing ":rf.server/set-status with a non-int arg"
+      ;; rf2-kjf3m.2's concrete failing scenario, and rf2-dtpfv's: a string
+      ;; status that rode straight onto the wire, saved only by one host
+      ;; adapter's coercion.
       ;;
       ;; rf2-37o5by — the default projector's 400 arm is GATED on a
-      ;; CLIENT-surface `:where` (`:event` / `:cofx`). This failure is
-      ;; `:where :fx-args` — a SERVER-side defect: a server handler built a
-      ;; malformed fx args map. That is not bad client input, so it must
-      ;; NOT mislabel as a client-facing 400; it falls through to the
-      ;; locked generic-500. End-to-end, the fix still turns a silent wire
-      ;; defect into a clean surfaced failure — now correctly a 500.
-      (rf/reg-event :bad/status
-        (fn [_ _] {:fx [[:rf.server/set-status "not-an-int"]]}))
-      (let [f      (frame/make-anon-frame-record! {:platform :server})
-            traces (capture-schema-failures!
-                     (fn [] (rf/dispatch-sync [:bad/status] {:frame f})))
-            status (:status (get-response f))]
-        (expect-fx-args-schema-failure!
-          traces :rf.server/set-status "string :rf.server/set-status")
-        ;; The malformed string never landed on the accumulator …
-        (is (not= "not-an-int" status)
+      ;; CLIENT-surface `:where` (`:event` / `:cofx`). A server-fx arg failure
+      ;; is a SERVER-side defect: a server handler built a malformed fx args
+      ;; map. That is not bad client input, so it must NOT mislabel as a
+      ;; client-facing 400; it falls through to the locked generic-500.
+      (let [{:keys [response]} (drive-server-fx! [:rf.server/set-status "not-an-int"])]
+        (is (not= "not-an-int" (:status response))
             "the malformed status was skipped — never reached the accumulator")
-        (is (integer? status)
-            "the wire status is an integer (the gap this bead closes)")
-        ;; … and the schema failure surfaced as a 500 via the SSR
-        ;; error-projection substrate — a server-fx arg failure is a
-        ;; server-side defect, NOT a client 400 (rf2-37o5by gated arm).
-        (is (= 500 status)
-            "schema-validation-failure :where :fx-args projected to 500
-             :internal-error — the 400 arm is gated to :where :event/:cofx")))
+        (is (integer? (:status response))
+            "the wire status is an integer (the gap rf2-kjf3m.2 opened and
+             rf2-dtpfv closed in every build)")
+        (is (= 500 (:status response))
+            "surfaced as 500 :internal-error — the 400 arm is gated to
+             :where :event/:cofx")))
 
-    (testing ":rf.server/set-header missing :value → rejected + skipped"
-      (rf/reg-event :bad/header
-        (fn [_ _] {:fx [[:rf.server/set-header {:name "X-Foo"}]]}))   ;; :value absent
-      (let [f      (frame/make-anon-frame-record! {:platform :server})
-            traces (capture-schema-failures!
-                     (fn [] (rf/dispatch-sync [:bad/header] {:frame f})))]
-        (expect-fx-args-schema-failure!
-          traces :rf.server/set-header ":rf.server/set-header missing :value")
-        (is (not-any? (fn [[k _]] (= "X-Foo" k)) (:headers (get-response f)))
+    (testing ":rf.server/set-header missing :value"
+      (let [{:keys [response]} (drive-server-fx! [:rf.server/set-header {:name "X-Foo"}])]
+        (is (not-any? (fn [[k _]] (= "X-Foo" k)) (:headers response))
+            "the malformed header was skipped; nothing landed")
+        (is (not-any? (fn [[_ v]] (nil? v)) (:headers response))
+            "and no header carries a nil value a host would have to invent a
+             meaning for")))
+
+    (testing ":rf.server/append-header with a non-string :value"
+      (let [{:keys [response]} (drive-server-fx! [:rf.server/append-header
+                                                  {:name "X-Bar" :value 42}])]
+        (is (not-any? (fn [[k _]] (= "X-Bar" k)) (:headers response))
             "the malformed header was skipped; nothing landed")))
 
-    (testing ":rf.server/append-header with non-string :value → rejected"
-      (rf/reg-event :bad/append
-        (fn [_ _] {:fx [[:rf.server/append-header {:name "X-Bar" :value 42}]]}))
-      (let [f      (frame/make-anon-frame-record! {:platform :server})
-            traces (capture-schema-failures!
-                     (fn [] (rf/dispatch-sync [:bad/append] {:frame f})))]
-        (expect-fx-args-schema-failure!
-          traces :rf.server/append-header ":rf.server/append-header non-string :value")))
-
-    (testing ":rf.server/set-cookie missing :value → rejected via [:ref :rf.server/cookie]"
-      (rf/reg-event :bad/cookie
-        (fn [_ _] {:fx [[:rf.server/set-cookie {:name "session"}]]})) ;; :value absent
-      (let [f      (frame/make-anon-frame-record! {:platform :server})
-            traces (capture-schema-failures!
-                     (fn [] (rf/dispatch-sync [:bad/cookie] {:frame f})))]
-        (expect-fx-args-schema-failure!
-          traces :rf.server/set-cookie ":rf.server/set-cookie missing :value")
-        (is (empty? (:cookies (get-response f)))
+    (testing ":rf.server/set-cookie missing :value"
+      (let [{:keys [response]} (drive-server-fx! [:rf.server/set-cookie {:name "session"}])]
+        (is (empty? (:cookies response))
             "the malformed cookie was skipped; accumulator stays empty")))
 
-    (testing ":rf.server/set-cookie with bogus :same-site keyword → rejected"
-      ;; :same-site accepts the enum #{:strict :lax :none} (or a string,
-      ;; per the documented divergence) — a bogus KEYWORD is neither.
-      (rf/reg-event :bad/cookie-samesite
-        (fn [_ _] {:fx [[:rf.server/set-cookie
-                         {:name "s" :value "v" :same-site :bogus}]]}))
-      (let [f      (frame/make-anon-frame-record! {:platform :server})
-            traces (capture-schema-failures!
-                     (fn [] (rf/dispatch-sync [:bad/cookie-samesite] {:frame f})))]
-        (expect-fx-args-schema-failure!
-          traces :rf.server/set-cookie ":rf.server/set-cookie bogus :same-site keyword")))
+    (testing ":rf.server/set-cookie with a bogus :same-site keyword"
+      ;; :same-site accepts the enum #{:strict :lax :none} (or a string, per
+      ;; the documented divergence) — a bogus KEYWORD is neither.
+      (let [{:keys [response]} (drive-server-fx! [:rf.server/set-cookie
+                                                  {:name "s" :value "v"
+                                                   :same-site :bogus}])]
+        (is (empty? (:cookies response))
+            "the malformed cookie was skipped; accumulator stays empty")))
 
-    (testing ":rf.server/delete-cookie missing :name → rejected"
-      (rf/reg-event :bad/delete
-        (fn [_ _] {:fx [[:rf.server/delete-cookie {:path "/"}]]}))    ;; :name absent
-      (let [f      (frame/make-anon-frame-record! {:platform :server})
-            traces (capture-schema-failures!
-                     (fn [] (rf/dispatch-sync [:bad/delete] {:frame f})))]
-        (expect-fx-args-schema-failure!
-          traces :rf.server/delete-cookie ":rf.server/delete-cookie missing :name")))
+    (testing ":rf.server/delete-cookie missing :name"
+      (let [{:keys [response]} (drive-server-fx! [:rf.server/delete-cookie {:path "/"}])]
+        (is (empty? (:cookies response))
+            "the nameless delete-cookie was skipped; accumulator stays empty")))
 
-    (testing ":rf.server/redirect with no target key → PASSES the schema (warn path, not 400)"
-      ;; rf2-ee38b.11 + the live half of decision rf2-cwfy2: a redirect
-      ;; with no :location/:url/:to is NOT a structural error — the schema
-      ;; is permissive (all target keys optional, zero allowed) so the
-      ;; no-target case PASSES the Spec 010 §step-5 boundary and falls
-      ;; through to the runtime's graceful no-target path. redirect-fx
-      ;; accepts it (location is caller-trusted/optional), sets :redirect,
-      ;; and the host adapter is the last line — it emits the
-      ;; :rf.ssr/ssr-redirect-no-target WARNING + a 3xx with no Location
-      ;; header so the defect is observable. A schema [:fn] requiring a
-      ;; target would 400 here BEFORE the warn→302 path runs, contradicting
-      ;; ee38b.11; this test pins that the redirect schema stays a pure
-      ;; shape check and does NOT reject the no-target redirect.
-      (rf/reg-event :soft/redirect-no-target
-        (fn [_ _] {:fx [[:rf.server/redirect {:status 302}]]}))
-      (let [f      (frame/make-anon-frame-record! {:platform :server})
-            traces (capture-schema-failures!
-                     (fn [] (rf/dispatch-sync [:soft/redirect-no-target] {:frame f})))]
-        (is (empty? (filter (fn [ev] (and (= :fx-args (-> ev :tags :where))
-                                          (= :rf.server/redirect
-                                             (-> ev :tags :failing-id))))
-                            traces))
-            (str "no :fx-args schema failure for a no-target redirect — "
-                 "the schema permits it; saw: "
-                 (pr-str (mapv (comp :failing-id :tags) traces))))
-        (is (= {:status 302} (:redirect (get-response f)))
-            (str "the no-target redirect passed the schema and set :redirect"
-                 " — the adapter's warn+302 no-target path takes over"
-                 " downstream"))))
+    (testing ":rf.server/redirect with a non-int :status"
+      (let [{:keys [response]} (drive-server-fx! [:rf.server/redirect
+                                                  {:location "/x" :status "oops"}])]
+        (is (nil? (:redirect response))
+            "no :redirect landed")
+        (is (integer? (:status response))
+            "and the non-int status did not flow onto :status via Spec 011
+             §Redirect precedence step 1")))
 
-    (testing ":rf.server/redirect with non-int :status → rejected"
-      (rf/reg-event :bad/redirect-status
-        (fn [_ _] {:fx [[:rf.server/redirect {:location "/x" :status "oops"}]]}))
-      (let [f      (frame/make-anon-frame-record! {:platform :server})
-            traces (capture-schema-failures!
-                     (fn [] (rf/dispatch-sync [:bad/redirect-status] {:frame f})))]
-        (expect-fx-args-schema-failure!
-          traces :rf.server/redirect ":rf.server/redirect non-int :status")))
-
-    (testing ":rf.server/safe-redirect with non-int :status → rejected + response unmodified"
-      ;; rf2-wtd8z finding 1: pre-fix safe-redirect carried only :platforms
-      ;; — no :schema — so a valid-location-but-non-int-:status arg passed
-      ;; the (absent) boundary and safe-redirect-fx's step-5 pass wrote the
-      ;; string :status straight onto the response accumulator. With the new
-      ;; :rf.fx.server/safe-redirect-args schema attached, the malformed
-      ;; :status surfaces at the Spec 010 §step-5 fx-args boundary, the fx
-      ;; is SKIPPED, and the response is left unmodified — matching the
-      ;; sibling six.
-      (rf/reg-event :bad/safe-redirect-status
-        (fn [_ _] {:fx [[:rf.server/safe-redirect
-                         {:location "/ok" :status "not-int"}]]}))
-      (let [f      (frame/make-anon-frame-record! {:platform :server})
-            traces (capture-schema-failures!
-                     (fn [] (rf/dispatch-sync [:bad/safe-redirect-status] {:frame f})))
-            resp   (get-response f)]
-        (expect-fx-args-schema-failure!
-          traces :rf.server/safe-redirect ":rf.server/safe-redirect non-int :status")
-        (is (nil? (:redirect resp))
+    (testing ":rf.server/safe-redirect with a non-int :status"
+      ;; rf2-wtd8z finding 1: pre-fix safe-redirect carried only :platforms —
+      ;; no :schema — so a valid-location-but-non-int-:status arg passed the
+      ;; (absent) boundary and safe-redirect-fx's step-5 pass wrote the string
+      ;; :status straight onto the response accumulator.
+      (let [{:keys [response]} (drive-server-fx! [:rf.server/safe-redirect
+                                                  {:location "/ok" :status "not-int"}])]
+        (is (nil? (:redirect response))
             "the malformed safe-redirect was skipped — no :redirect landed")
-        (is (not= "not-int" (:status resp))
+        (is (not= "not-int" (:status response))
             "the non-int status never reached the response accumulator")))
 
-    (testing ":rf.server/safe-redirect missing :location → rejected"
+    (testing ":rf.server/safe-redirect missing :location"
       ;; safe-redirect REQUIRES a :location (its validation target) — a
       ;; target-less safe-redirect is a programmer error, NOT the documented
       ;; no-target graceful path that the caller-trusted :rf.server/redirect
-      ;; carries. The schema marks :location required, so a no-location call
-      ;; fails the shape gate.
-      (rf/reg-event :bad/safe-redirect-no-location
-        (fn [_ _] {:fx [[:rf.server/safe-redirect {:status 302}]]}))
-      (let [f      (frame/make-anon-frame-record! {:platform :server})
-            traces (capture-schema-failures!
-                     (fn [] (rf/dispatch-sync [:bad/safe-redirect-no-location] {:frame f})))]
+      ;; carries.
+      (let [{:keys [response]} (drive-server-fx! [:rf.server/safe-redirect {:status 302}])]
+        (is (nil? (:redirect response))
+            "the target-less safe-redirect was skipped — no :redirect landed")))
+
+    (testing ":rf.server/redirect with no target key PASSES — the warn path,
+              not a rejection"
+      ;; rf2-ee38b.11 + the live half of decision rf2-cwfy2: a redirect with
+      ;; no :location/:url/:to is NOT a structural error — the schema is
+      ;; permissive (all target keys optional, zero allowed) so the no-target
+      ;; case PASSES the Spec 010 §step-5 boundary and falls through to the
+      ;; runtime's graceful no-target path. redirect-fx accepts it (location
+      ;; is caller-trusted/optional), sets :redirect, and the host adapter is
+      ;; the last line — it emits :rf.ssr/ssr-redirect-no-target + a 3xx with
+      ;; no Location header so the defect is observable. A schema [:fn]
+      ;; requiring a target would 400 here BEFORE the warn→302 path runs,
+      ;; contradicting ee38b.11. This is the NON-VACUITY control for the
+      ;; whole table above: without it, every §1 claim would be satisfied by
+      ;; a boundary that refused everything.
+      (let [{:keys [response]} (drive-server-fx! [:rf.server/redirect {:status 302}])]
+        (is (= {:status 302} (:redirect response))
+            "the no-target redirect passed the boundary and set :redirect —
+             the adapter's warn+302 path takes over downstream"))))
+
+  ;; -------------------------------------------------------------------------
+  ;; §2 — DEV ARM. The rich step-5 diagnostic, kept VERBATIM.
+  ;; -------------------------------------------------------------------------
+  (when interop/debug-enabled?
+    (testing "rf2-lwtlk DEV ARM — with schemas live the Spec 010 §step-5
+              boundary rejects FIRST, so the programmer gets the RICH
+              diagnostic: :rf.error/schema-validation-failure :where :fx-args,
+              naming the failing fx and path, with the fx :skipped and the
+              page still rendering. This is the half that genuinely does not
+              exist in a release build — `validate-fx!` is
+              `(if interop/debug-enabled? (run-validation …) true)`, so there
+              it compiles to `true` and never emits."
+      (doseq [[label fx-id fx-vec] malformed-server-fx]
         (expect-fx-args-schema-failure!
-          traces :rf.server/safe-redirect ":rf.server/safe-redirect missing :location")))))
+          (:dev-traces (drive-server-fx! fx-vec)) fx-id label)))
+
+    (testing "rf2-lwtlk DEV ARM (the negative) — the permissive redirect
+              schema does NOT reject the no-target case. This is a NEGATIVE
+              over the dev trace ring, so under the production gate it would
+              pass with the step-5 boundary removed altogether; it belongs in
+              the arm with the positives it discriminates against, not
+              outside it."
+      (let [{:keys [dev-traces]} (drive-server-fx! [:rf.server/redirect {:status 302}])]
+        (is (empty? (filter (fn [ev] (and (= :fx-args (-> ev :tags :where))
+                                          (= :rf.server/redirect
+                                             (-> ev :tags :failing-id))))
+                            dev-traces))
+            (str "no :fx-args schema failure for a no-target redirect — the"
+                 " schema permits it; saw: "
+                 (pr-str (mapv (comp :failing-id :tags) dev-traces)))))))
+
+  ;; -------------------------------------------------------------------------
+  ;; §3 — PRODUCTION ARM. The always-on witness that makes §1 true in a
+  ;;      release build, and the one an off-box shipper actually receives.
+  ;; -------------------------------------------------------------------------
+  (when-not interop/debug-enabled?
+    (testing "rf2-lwtlk PRODUCTION ARM — with step-5 compiled out, the
+              reserved fx's OWN guard (rf2-dtpfv, re-frame.ssr.response)
+              throws, `re-frame.fx` containment catches it, and
+              `emit-fx-error!` fans an ALWAYS-ON
+              :rf.error/fx-handler-exception naming the offending fx. That
+              record is what reaches Sentry / Datadog / the frame-owned
+              :observability :errors sink in the build that ships — unlike
+              the silent accumulator write this replaced, which was visible
+              only as a malformed HTTP response."
+      (doseq [[label fx-id fx-vec] malformed-server-fx]
+        (let [{:keys [records]} (drive-server-fx! fx-vec)
+              hits (filter #(= :rf.error/fx-handler-exception (:error %)) records)]
+          (is (seq hits)
+              (str label " — an always-on :rf.error/fx-handler-exception"
+                   " record reached the :errors axis; saw: "
+                   (pr-str (mapv :error records))))
+          (is (some #(= fx-id (:failing-id %)) hits)
+              (str label " — the record names " fx-id " as the failing fx;"
+                   " saw: " (pr-str (mapv :failing-id hits)))))))))
 
 (deftest ssr-server-fx-args-schema-accepts-well-formed
   (testing "rf2-kjf3m.2 — regression guard: well-formed server fx args pass
@@ -2625,9 +3006,17 @@
           traces (capture-schema-failures!
                    (fn [] (rf/dispatch-sync [:good/all] {:frame f})))
           resp   (get-response f)]
-      (is (empty? (filter (fn [ev] (= :fx-args (-> ev :tags :where))) traces))
-          (str "no :fx-args schema failure for well-formed args; saw: "
-               (pr-str (mapv (comp :failing-id :tags) traces))))
+      ;; rf2-lwtlk — DEV ARM. A negative over the dev trace ring passes
+      ;; AUTOMATICALLY under `-Dre-frame.debug=false`, where the ring is
+      ;; empty for every input, so outside an arm this would report "the
+      ;; boundary admitted the valid" in a build that has no boundary. The
+      ;; POSTURE-INDEPENDENT half of the same claim is the accumulator reads
+      ;; below: they prove admission by showing the effects LANDED, which is
+      ;; the non-vacuous form and needs no arm.
+      (when interop/debug-enabled?
+        (is (empty? (filter (fn [ev] (= :fx-args (-> ev :tags :where))) traces))
+            (str "no :fx-args schema failure for well-formed args; saw: "
+                 (pr-str (mapv (comp :failing-id :tags) traces)))))
       ;; redirect-fx flows its :status through to the response :status
       ;; (Spec 011 §Redirect precedence step 1), so :status is 302 here.
       (is (= 302 (:status resp)) "redirect status flows through")
@@ -2655,12 +3044,16 @@
           traces (capture-schema-failures!
                    (fn [] (rf/dispatch-sync [:good/safe-redirect] {:frame f})))
           resp   (get-response f)]
-      (is (empty? (filter (fn [ev] (and (= :fx-args (-> ev :tags :where))
-                                        (= :rf.server/safe-redirect
-                                           (-> ev :tags :failing-id))))
-                          traces))
-          (str "no :fx-args schema failure for well-formed safe-redirect; saw: "
-               (pr-str (mapv (comp :failing-id :tags) traces))))
+      ;; rf2-lwtlk — DEV ARM, same reasoning as its sibling above: a negative
+      ;; over an empty ring. The landing assertions that follow carry the
+      ;; posture-independent half.
+      (when interop/debug-enabled?
+        (is (empty? (filter (fn [ev] (and (= :fx-args (-> ev :tags :where))
+                                          (= :rf.server/safe-redirect
+                                             (-> ev :tags :failing-id))))
+                            traces))
+            (str "no :fx-args schema failure for well-formed safe-redirect; saw: "
+                 (pr-str (mapv (comp :failing-id :tags) traces)))))
       (is (= "https://app.example.com/dashboard" (-> resp :redirect :location))
           "the well-formed safe-redirect landed on the response :redirect slot")
       (is (= 302 (-> resp :redirect :status))

--- a/scripts/test-ssr-prod-gate.sh
+++ b/scripts/test-ssr-prod-gate.sh
@@ -25,7 +25,7 @@
 # run: no lane reached this artefact.  This script is that lane.
 #
 #     bash scripts/test-ssr-prod-gate.sh          run the lane
-#     bash scripts/test-ssr-prod-gate.sh --plan   print the roster, run nothing
+#     bash scripts/test-ssr-prod-gate.sh --plan   print the posture, run nothing
 #
 # CI arm: the `jvm-ssr-prod-gate` job in `.github/workflows/test.yml`, which is
 # in `all-required-passed`'s `needs:`.
@@ -47,314 +47,56 @@
 # between the two lanes.  `re-frame.ssr-prod-gate-lane-pin-test` then runs
 # INSIDE the lane and asserts, unconditionally, that the property reached this
 # JVM and that the framework honoured it.  Without that pin a lost flag would
-# not go red: this roster is by construction a subset of what already passes in
-# dev posture, so the lane would go GREEN on the wrong posture — the exact
-# class of false green this whole file exists to close.
+# not go red: this suite passes in dev posture, so the lane would go GREEN on
+# the wrong posture — the exact class of false green this whole file exists to
+# close.  That pin matters MORE now, not less: with the roster gone there is no
+# second signal left that the posture is the one intended.
 #
-# WHY A ROSTER AND NOT THE WHOLE SUITE.  Nobody had ever run the ssr suite
-# under the real gate.  Run on 2026-07-27 it is emphatically RED: 217 failures
-# and 1 error across 21 of its 48 test namespaces.  Three shapes account for
-# all of it — dev-instrumentation assertions written inline with semantics,
-# `data-rf2-source-coord` / `data-rf-view` annotations that are prod-elided at
-# the core `reg-view` boundary, and the error-projection cluster whose status
-# codes depend on the development trace listener.  The first two are legitimate
-# dev-posture tests rather than defects.  The third is a documented design
-# choice with a real production consequence and is under a RULING (rf2-rqje9)
-# before anyone writes it off.  Either way "make the whole suite green under
-# the gate" is not a fix; the triage bead is named per group below.
+# THERE USED TO BE A ROSTER.  IT IS EMPTY, SO IT IS GONE (rf2-lwtlk).
 #
-# The roster is therefore an EXCLUSION list, not an allowlist.  The polarity is
-# the point: a namespace added to `implementation/ssr/test/` joins this lane BY
-# DEFAULT and has to be excluded deliberately, so a new suite that breaks under
-# the production gate reddens this job the day it lands.  An allowlist would
-# have the opposite failure mode — silently not covering the new thing.  The
-# list shrinks as rf2-lwtlk lands; when it reaches zero, this script is one
-# line and the `-n` machinery goes away.
+# Nobody had ever run the ssr suite under the real gate.  Run on 2026-07-27 it
+# was emphatically RED: 217 failures and 1 error across 21 of its 48 test
+# namespaces, and this script carried those 21 as a known-red EXCLUSION list,
+# grouped by cause, each group naming the bead that would clear it.
+#
+# rf2-lwtlk was that triage stream and it has finished.  Four shapes accounted
+# for all 21.  Dev-instrumentation assertions written inline with semantics,
+# and `data-rf2-source-coord` / `data-rf-view` annotations prod-elided at the
+# core `reg-view` boundary: both legitimate dev-posture tests, posture-split so
+# the semantics they were entangled with run here.  The error-projection
+# cluster, which looked like a design choice and was not — rf2-ov56u promoted
+# the URL-driven route miss onto the always-on axis, so a production server no
+# longer answers an unroutable URL with HTTP 200, and
+# `re-frame.ssr-route-miss-404-production-test` is the proof, in this lane.
+# And `ssr-end-to-end-test`, the last line, whose
+# `ssr-server-fx-args-schema-boundary` was failing for a REAL reason: the Spec
+# 010 step-5 fx-args gate does not run in a release build, so a malformed
+# `:rf.server/*` fx RAN and its args landed on the response accumulator.
+# rf2-dtpfv fixed that — the reserved family guards its own args in every build
+# — and the deftest was rewritten as a two-posture contract rather than split.
+#
+# Note how little of the 21 was dev-posture SPELLING once each was actually
+# read: the recurring finding was that a production-visible witness existed and
+# the test was reading the dev copy of it.  Guarding is the last resort in this
+# artefact, not the first move.
+#
+# WHAT REPLACES THE ROSTER.  Nothing — and that is the strongest possible
+# polarity.  The exclusion list's whole virtue was that a namespace added to
+# `implementation/ssr/test/` joined the lane BY DEFAULT and had to be excluded
+# deliberately.  With the list empty, the runner discovers every `.*-test$`
+# namespace under `test/` and runs it, so a new suite that breaks under the
+# production gate reddens this job the day it lands, with nothing to edit and
+# no `-n` selector that could silently fail to match.  The two roster guards
+# (`verify_roster`) existed to keep that selector honest and went with it.
+#
+# If a namespace ever has to be excluded again, do not reintroduce a list
+# without reading the history above first: on this artefact, four of the five
+# "obviously dev-only" clusters turned out to have an always-on witness.
 
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 artefact="$repo_root/implementation/ssr"
-test_root="$artefact/test"
-
-# ---------------------------------------------------------------------------
-# The known-red roster.
-#
-# Every entry is a namespace that FAILS under `-Dre-frame.debug=false` today,
-# grouped by why, with its red-assertion count as measured on 2026-07-27.  The
-# group names the bead that clears it.  An entry that no longer names a real
-# namespace is a hard error (see `verify_roster` below), so a rename cannot
-# leave a stale exclusion quietly suppressing coverage.
-# ---------------------------------------------------------------------------
-known_red=(
-  # ── rf2-rqje9 — RULING LANDED (2026-07-27); THE DEFECT IS FIXED, THE
-  #    RESIDUE IS SPELLING.  These five used to fail on assertions of the
-  #    form "the buffered `:rf.error/no-such-handler` projects 404 onto
-  #    `:status`", and the consequence the gate made visible was that a
-  #    production server answered an unroutable URL with HTTP 200.  The
-  #    ruling was NOT "intended": rf2-ov56u promoted the URL-driven route
-  #    miss onto the always-on error axis and `:kind`-gated the default
-  #    projector's 404 arm, so a production route miss now answers 404 for
-  #    real.  `re-frame.ssr-route-miss-404-production-test` is that proof and
-  #    runs IN this lane.
-  #
-  #    WHAT IS LEFT IS NOT THE DEFECT.  Every remaining red in these five
-  #    synthesises its error straight onto the DEV trace bus
-  #    (`trace/emit-error!` from a test helper, `@traces` reads) rather than
-  #    driving a real emit site, so the gate empties the bus and the
-  #    assertion observes nothing — dev-instrumentation spelling of exactly
-  #    the shape the rest of this roster carries.  They are rf2-lwtlk group
-  #    (c)'s ordinary posture split, which was sequenced to WAIT for
-  #    rf2-ov56u's merge; that wait is over.  Re-run and split; do not read
-  #    a red here as the 200-for-404 defect returning, and check
-  #    `ssr-route-miss-404-production-test` first if you suspect it has.
-  #
-  #    FOUR OF THE FIVE ARE NOW CLEARED, and only ONE of them cleared by
-  #    guarding.  `ssr-flush-response-result-test`'s helper was re-pointed
-  #    at the ALWAYS-ON axis instead — both categories it uses
-  #    (`handler-exception`, `no-such-handler {:kind :route}`) reach
-  #    production, so the drain-classification contract a host adapter
-  #    depends on now executes in the posture that ships, with no guard and
-  #    no assertion moved.  Its fixture also stopped calling
-  #    `clear-error-listeners!` AFTER `reset-runtime`, which had been
-  #    wiping the `re-frame.ssr` façade's own always-on `::error-projection`
-  #    listener and leaving the production path unarmed for every test in
-  #    the file.  `ssr-head-resolution-no-project-test`,
-  #    `ssr-error-view-failed-no-project-test` and
-  #    `ssr-error-two-frame-attribution-test` DID need dev arms for their
-  #    `trace/emit-error!` halves — including two NEGATIVES that were
-  #    passing vacuously over an empty ring — and each gained a
-  #    production-posture counterpart so the guard did not cost coverage:
-  #    an always-on positive control for the two skip-set suites, and a
-  #    throwing-handler two-frame attribution pin for the third (whose only
-  #    trigger, the navigate-reject, is production-elided per Spec 010).
-  #
-  #    THE FIFTH IS HELD ON A NEW FINDING — rf2-dtpfv (P1).  Re-measured
-  #    2026-07-28, `ssr-end-to-end-test` is 116 reds across 40 deftests.  39
-  #    of those deftests are mechanical trace-sourcing.  ONE is not:
-  #    `ssr-server-fx-args-schema-boundary` fails SEVEN SEMANTIC assertions
-  #    because the behaviour genuinely differs.  `validate-fx!` is
-  #    `(if interop/debug-enabled? (run-validation …) true)`, so the Spec 010
-  #    §Validation-order step-5 fx-args boundary does not run in a release
-  #    build and its documented `:skipped` recovery never happens: a
-  #    malformed `:rf.server/*` fx RUNS and its args land on the response
-  #    accumulator.  Measured at `ssr/get-response`:
-  #    `[:rf.server/set-status "not-an-int"]` leaves `:status "not-an-int"`;
-  #    a `:value`-less `set-header` leaves `["X-Foo" nil]`; a `:value`-less
-  #    `set-cookie` leaves `{:name "session"}`; a non-int safe-redirect
-  #    `:status` lands whole.  ssr-ring's `fail-closed-status` saves the WIRE
-  #    on a Ring host — but that net is host-specific and its only signal is
-  #    a dev-bus warning.  Do NOT split those seven to green the namespace;
-  #    rf2-dtpfv carries the ruling.
-  #
-  #    THE OTHER 39 ARE READY the moment it lands, and the method per
-  #    cluster is known — measured, not guessed:
-  #      * fx-handler-exception (~60 reds: header / cookie / redirect-spelling
-  #        / CRLF-NUL gates).  NO GUARD.  `emit-fx-error!` fans BOTH axes
-  #        (fx.cljc `emit-error-both!`), so re-point `capture-fx-traces!` at
-  #        the `:errors` stream alongside `:trace`, normalising the union
-  #        record to `{:operation :op-type :tags}`.  Every consumer reads
-  #        only `(-> ev :tags :exception)`, and the exception object is the
-  #        same on both axes, so nothing else moves.  Note the gates
-  #        THEMSELVES are production-live — only their observation was
-  #        dev-sourced.
-  #      * the two `ssr-default-error-projector-*` tests, the
-  #        `:rf.error/sanitised-on-projection` diagnostics, and
-  #        `direct-ssr-layer-projects-view-time-exception`.  Same treatment:
-  #        all three categories ride the always-on axis today
-  #        (`dispatch-on-error!`, `emit-always-on-error!`).  Watch the
-  #        `(not-any? … :sanitised-on-projection …)` NEGATIVE at ~line 951 —
-  #        it is vacuous under the gate and becomes real with dual capture.
-  #      * the `:rf.warning/*` cluster (`multiple-status-set`,
-  #        `multiple-redirects`), `:rf.ssr/hydration-mismatch` and the
-  #        head-mismatch trace.  Genuinely dev-only warnings — dev arms; the
-  #        last-write-wins SEMANTICS they sit beside are already
-  #        posture-independent and green here.
-  #      * the `safe-redirect` cluster (~17 reds).  Dev arms, and file
-  #        nothing new: rf2-6jqa8 already records WHY.  The rejection
-  #        assertions — `(nil? (:redirect (get-response f)))`, the
-  #        security-load-bearing half — are posture-independent and green
-  #        under the gate TODAY.  Only the diagnostic is dev-only.
-  re-frame.ssr-end-to-end-test                    # 116 (rf2-dtpfv)
-
-  # ── rf2-lwtlk — SOURCE-COORD ANNOTATION.  CLEARED.  All three namespaces
-  #    (`source-coord-parity-test`, `ssr-keyword-head-contract-test`,
-  #    `ssr-source-coord-test`) now split their posture: the
-  #    `data-rf2-source-coord` / `data-rf-view` assertions are kept verbatim
-  #    inside `(when interop/debug-enabled? …)` arms, the RENDER they were
-  #    entangled with is asserted posture-independently, and each gained a
-  #    `when-not` arm that pins the bare bytes the REAL gate emits.  The
-  #    negative annotation assertions moved into the dev arm WITH the
-  #    positives: "the outer view did not stamp itself" is vacuously true
-  #    where nothing stamps anything.
-
-  # ── rf2-lwtlk — dev-instrumentation assertions written inline with the
-  #    semantics they sit next to.  CLEARED for eleven namespaces: the
-  #    `:rf.ssr/schema-digest-mismatch` / `-version-mismatch` traces, `:doc`
-  #    on the reg-head and reg-cofx registry slots, the
-  #    `:rf.ssr.head/cleanup-failed` warning, `:rf.cofx/skipped-on-platform`,
-  #    the `:rf.ssr/suspense-boundary-failed` / `-duplicate-id` streaming
-  #    traces, the hydration-mismatch trace's `:server-hash` /
-  #    `:client-hash` tags, the EP-0001 ownership diagnostics, and the
-  #    `:rf.error/malformed-hydration-payload` /
-  #    `-hydration-frame-id-mismatch` rejection diagnostics.  Each is kept
-  #    VERBATIM inside a `(when interop/debug-enabled? …)` arm marked
-  #    `rf2-lwtlk`, with a `## Posture split` section in the ns docstring;
-  #    the semantics they were entangled with now run in this lane.
-  #
-  #    THE LARGER HALF WAS THE ASSERTIONS THAT WERE NOT FAILING.  A NEGATIVE
-  #    over the trace ring — `(is (empty? @diags))`, `(is (not-any? …
-  #    (ops)))`, "no malformed diagnostic on a well-formed payload" — passes
-  #    AUTOMATICALLY under this gate, where the ring is empty for every
-  #    input.  Roughly two dozen such assertions moved into the dev arms
-  #    alongside their positive counterparts.  Left outside they would have
-  #    been the quiet half of the same false green.
-  #
-  #    NOTE for whoever finishes this list: a namespace whose EVERY deftest is
-  #    about the dev trace has no semantic residue to run under the gate.
-  #    Guarding it wholesale and deleting its roster line would report GREEN
-  #    for a namespace that executed nothing — the false-green this lane
-  #    exists to close.  `ssr-compatibility-checks-test` was exactly that
-  #    (both fxs are best-effort: no state change, no return value, the trace
-  #    IS the output), and rather than roster it off it gained two
-  #    production-real deftests — the fx registrations with their
-  #    `:platforms #{:client}` gate, and a proof that a DOUBLE mismatch
-  #    neither throws nor stops the effect queued behind it.
-
-  # ── rf2-bkvu5 — RULING LANDED (2026-07-27); CLEARED.  One deftest,
-  #    `flow-output-schema-failure-rejects-candidate-before-install`, used to
-  #    fail here for a REAL reason rather than trace spelling: under
-  #    `-Dre-frame.debug=false` a flow output that violates the registered
-  #    app-db schema is NOT rejected — the invalid candidate INSTALLS, and
-  #    the handler's own `:db` installs with it.  `router.cljc`'s
-  #    `validate-event!` and `schemas/validate.cljc` both document why: every
-  #    `validate-*!` body sits inside its own `(if interop/debug-enabled? …
-  #    true)` gate and "Production builds return `true` unconditionally".
-  #
-  #    Mike RULED (a): that is BY DESIGN.  `reg-app-schema` candidate
-  #    validation is a DEVELOPMENT-ONLY assertion; production trusts the
-  #    programmer; EP-0025's atomic-candidate-rejection contract is a
-  #    dev-posture contract.  Shapes (b) (always-on validation) and (c) (a
-  #    middle knob) were both rejected.
-  #
-  #    SO THE DEFTEST DID NOT CLEAR — IT SPLIT, and this is the one arm in
-  #    the artefact that could not be re-pointed at a production-visible
-  #    witness instead of a guard.  The distinction matters for whoever
-  #    reads it next: the always-on error axis carries no
-  #    `:rf.error/schema-validation-failure` here NOT because that emit is
-  #    dev-only, but because the VALIDATION never runs to emit anything —
-  #    the subject is absent, not merely unobservable.  The rejection
-  #    assertions are kept VERBATIM in a `(when interop/debug-enabled? …)`
-  #    arm, and a `when-not` arm EXECUTES the ruled production behaviour
-  #    (the schema-violating candidate installs whole, `:derived :doubled`
-  #    = -6 through the ordinary app-db surface).  That arm is also the
-  #    standing regression guard on the ruling itself: it reddens if
-  #    `reg-app-schema` ever quietly becomes always-on.
-  #
-  #    Every OTHER assertion in the namespace had already been posture-split
-  #    by rf2-lwtlk (the `by-op` / `ops` trace signatures are in dev arms, and
-  #    two flow-eval witnesses were added off the trace bus so "the flow
-  #    computed its bad output" and "the flow threw" survive the gate), so
-  #    the namespace now runs in this lane: 9 tests, 39 assertions under the
-  #    gate (was 39 with TWO of them red) against 55 in dev posture (was 55 —
-  #    the rejection pair moved into the arm, it did not leave).
-
-  # ── rf2-lwtlk / rf2-76gom — the conformance corpus.  CLEARED, and it did
-  #    NOT clear by guarding.  Nine `ssr-*.edn` fixtures used to fail here,
-  #    all nine on `:trace-emissions` claims read off the DEV bus, and two
-  #    of them ALSO reported `public-error actual: nil`.
-  #
-  #    The public-error half was never a framework fault: the runner's
-  #    `pe-check` sourced its error event from `@traces` before feeding
-  #    `ssr/project-error`, so under the gate it reported nil whatever the
-  #    framework did — `:ssr/error-known-mapping` did NOT clear with
-  #    rf2-ov56u for that reason, contrary to the rf2-rqje9 ruling's
-  #    expectation.  rf2-76gom re-sourced it from the ALWAYS-ON `:errors`
-  #    axis, synthesised into the projector's envelope by the same generic
-  #    lift `error-emit-projection-listener` performs, so both fixtures now
-  #    adjudicate the wire under the gate.  Mutation-proved: remove the
-  #    fallback and exactly those two go red here.
-  #
-  #    The `:trace-emissions` half kept its dev-bus assertions VERBATIM in a
-  #    dev arm AND gained a production counterpart rather than a hole: a
-  #    `{:operation :rf.event/run-start :tags {:rf.trace/event-id X}}` claim
-  #    says event X RAN, which the always-on `:events` substrate records in
-  #    production, so all 17 such claims are adjudicated under BOTH postures
-  #    (mutation-proved: stub the capture and nine fixtures go red).
-  #    `:trace-not-emitted` moved into the dev arm with them — a negative
-  #    over an empty ring passes with the runtime removed.
-
-  # ── rf2-lwtlk — the PAYLOAD-POLICY suite.  CLEARED, and the roster note
-  #    that asked for verification rather than assumption was answered:
-  #    the single red assertion was the `:rf.ssr/invalid-version` WARNING
-  #    trace, the dev half of a rejection whose PRODUCTION half — a semver
-  #    string never reaching `:rf/version`, which falls back to the integer
-  #    v1 — was green under the gate throughout.  Nothing that decides what
-  #    egresses was involved.  The always-on privacy witness for the egress
-  #    proper, `re-frame.ssr-routing-egress-production-test` (rf2-u2x6w),
-  #    has been in this lane and green since it was built.
-)
-
-# ---------------------------------------------------------------------------
-# Roster derivation
-# ---------------------------------------------------------------------------
-
-# Every namespace DECLARED under implementation/ssr/test/, read from the `(ns
-# ...)` form rather than derived from the path — a lane selector is applied by
-# the runner to the declared name, so that is the name that has to match.
-declared_nses() {
-  find "$test_root" -type f \( -name '*.clj' -o -name '*.cljc' \) -exec \
-    sed -n 's/^(ns[[:space:]]\{1,\}\(\^{[^}]*}[[:space:]]*\)\{0,1\}\([^[:space:])]\{1,\}\).*/\2/p' {} + \
-    | sort -u
-}
-
-# `cognitect.test-runner` discovers namespaces under `test/` and keeps those
-# matching `.*-test$` (the default `-r`); `-n` then filters that SET.  Mirror
-# the same filter here so the two cannot disagree about what the universe is.
-test_nses() {
-  declared_nses | grep -E -- '-test$'
-}
-
-# Two guards, because a silently-shrinking roster is the failure mode this lane
-# is supposed to make impossible.
-verify_roster() {
-  local nses="$1" files ns_count missing=()
-
-  # 1. The `(ns ...)` scrape must still see every test file.  If the regex ever
-  #    stops matching, the lane quietly narrows and stays green.
-  files="$(find "$test_root" -type f \( -name '*_test.clj' -o -name '*_test.cljc' \) | wc -l)"
-  ns_count="$(printf '%s\n' "$nses" | grep -c . || true)"
-  if [ "$files" -ne "$ns_count" ]; then
-    printf 'FAIL prod-gate roster: %s test files under %s but %s `-test` namespaces scraped.\n' \
-      "$files" "${test_root#"$repo_root"/}" "$ns_count" >&2
-    printf '     The `(ns ...)` scrape in declared_nses() has drifted from the tree.\n' >&2
-    return 1
-  fi
-
-  # 2. Every exclusion must still name a live namespace.  A stale entry is an
-  #    exclusion nobody can see the effect of.
-  for ns in "${known_red[@]}"; do
-    printf '%s\n' "$nses" | grep -q -x -F -- "$ns" || missing+=("$ns")
-  done
-  if [ ${#missing[@]} -ne 0 ]; then
-    printf 'FAIL prod-gate roster: %s known-red entr(y|ies) name no live namespace:\n' \
-      "${#missing[@]}" >&2
-    printf '  %s\n' "${missing[@]}" >&2
-    printf '     Renamed or deleted? Drop the entry from known_red in %s.\n' \
-      "${BASH_SOURCE[0]#"$repo_root"/}" >&2
-    return 1
-  fi
-}
-
-all_nses="$(test_nses)"
-verify_roster "$all_nses"
-
-excluded="$(printf '%s\n' "${known_red[@]}" | sort -u)"
-runnable="$(printf '%s\n' "$all_nses" | grep -v -x -F -f <(printf '%s\n' "$excluded"))"
-
-runnable_count="$(printf '%s\n' "$runnable" | grep -c . || true)"
-excluded_count="$(printf '%s\n' "$excluded" | grep -c . || true)"
-total_count="$(printf '%s\n' "$all_nses" | grep -c . || true)"
 
 # ---------------------------------------------------------------------------
 # Report the posture BEFORE running, so the log carries the evidence
@@ -362,14 +104,14 @@ total_count="$(printf '%s\n' "$all_nses" | grep -c . || true)"
 printf '==> implementation/ssr under the REAL production gate\n'
 printf '    jvm property : -Dre-frame.debug=false (implementation/ssr/deps.edn, :prod-gate :jvm-opts)\n'
 printf '    posture pin  : re-frame.ssr-prod-gate-lane-pin-test (red if the property did not arrive)\n'
-printf '    namespaces   : %s of %s (%s excluded as known-red — rf2-dtpfv)\n' \
-  "$runnable_count" "$total_count" "$excluded_count"
+printf '    namespaces   : the WHOLE suite — every `.*-test$` namespace under\n'
+printf '                   implementation/ssr/test, discovered by the runner.\n'
+printf '                   rf2-lwtlk: the known-red roster reached zero and the\n'
+printf '                   `-n` selector went with it.\n'
 
 if [ "${1:-}" = "--plan" ]; then
-  printf '    runnable:\n'
-  printf '      %s\n' $runnable
-  printf '    excluded:\n'
-  printf '      %s\n' $excluded
+  printf '    runnable     : all of them — there is no selector and no exclusion list\n'
+  printf '    excluded     : none\n'
   exit 0
 fi
 
@@ -399,21 +141,41 @@ fi
 # ~13% against the observed 490.  Raise it once more when
 # `ssr-end-to-end-test` comes off behind rf2-dtpfv; that is the LAST entry,
 # and the `-n` machinery goes away with it.
-export RF2_MIN_TESTS="${RF2_MIN_TESTS:-425}"
-
-args=()
-for ns in $runnable; do
-  args+=(-n "$ns")
-done
+#
+# RAISED 425 -> 510 by rf2-lwtlk — the raise the note above asked for, and the
+# last one this file will describe as roster-driven.  `ssr-end-to-end-test`
+# came off behind rf2-dtpfv, the roster reached ZERO, and the lane is now the
+# whole suite: 589 tests / 2698 assertions, measured green under
+# `-Dre-frame.debug=false` on 2026-07-28.  425 against 589 is 27.8% headroom —
+# the floor had become a formality again, exactly as at 215 and at 380.  510
+# restores the ~13% this file has now calibrated to four times.
+#
+# THIS FLOOR IS NOW THE LANE'S ONLY STRUCTURAL GUARD.  While the roster
+# existed, a collapsed `-n` selector was caught twice over — by
+# `verify_roster` and by this number.  The selector is gone, so if namespace
+# discovery ever silently narrows (a renamed `test/` directory, a runner
+# default changing out from under `.*-test$`), `Ran 0 tests` reaching CI green
+# is prevented HERE and nowhere else.  Keep the headroom tight enough to mean
+# something: a floor the lane could lose half its suite and still clear is not
+# a floor.
+export RF2_MIN_TESTS="${RF2_MIN_TESTS:-510}"
 
 cd "$artefact"
-if ! clojure -M:test:prod-gate "${args[@]}"; then
+if ! clojure -M:test:prod-gate; then
   printf '\nFAIL implementation/ssr under -Dre-frame.debug=false\n' >&2
   printf 'repro: bash scripts/test-ssr-prod-gate.sh\n' >&2
   printf 'A namespace that is green in `clojure -M:test` and red here is asserting\n' >&2
   printf 'DEV INSTRUMENTATION, or it is a genuine production defect (rf2-9c2jf was\n' >&2
-  printf 'the latter). Decide which before touching the known_red roster.\n' >&2
+  printf 'the latter). Decide which BEFORE reaching for a posture guard.\n' >&2
+  printf '\n' >&2
+  printf 'And check for a production-visible witness first. Emptying the roster\n' >&2
+  printf '(rf2-lwtlk) turned up an always-on axis behind four of the five clusters\n' >&2
+  printf 'that looked dev-only: `emit-fx-error!` and `emit-safe-redirect-error!`\n' >&2
+  printf 'fan BOTH axes, and `error-emit-projection-listener` — not the trace-cb\n' >&2
+  printf 'one — is what stamps :status on a production JVM. A `when\n' >&2
+  printf 'interop/debug-enabled?` arm around an assertion that had an always-on\n' >&2
+  printf 'source moves a live contract out of the posture that ships.\n' >&2
   exit 1
 fi
 
-printf 'PASS implementation/ssr under -Dre-frame.debug=false (%s namespaces)\n' "$runnable_count"
+printf 'PASS implementation/ssr under -Dre-frame.debug=false (whole suite, no exclusions)\n'


### PR DESCRIPTION
Closes rf2-lwtlk. Closes rf2-15047.

## rf2-lwtlk — the roster reaches empty

`re-frame.ssr-end-to-end-test` was the last known-red namespace in
`scripts/test-ssr-prod-gate.sh`. It comes off, the roster reaches **zero**, and
the `-n` machinery goes with it: the lane is now the whole suite, discovered by
the runner, with no selector that could silently fail to match.

| | roster entries | namespaces | tests | assertions |
|---|---|---|---|---|
| before | 1 | 50 of 51 | 490 | 2184 |
| **after** | **0** | **all of them** | **589** | **2698** |

### Almost none of it was a defect, and almost none of it wanted a guard

The security gates in this file — CR/LF and NUL in header values and cookie
attributes, the cookie-attribute grammar, safe-redirect's five-step
open-redirect gate — are production-live and were rejecting correctly
throughout. What was dev-only was the **observation**: every one was watched
through `re-frame.trace`, which the gate empties.

So the split is deliberately lopsided towards re-pointing. A
`when interop/debug-enabled?` arm around a security assertion buys the lane
nothing: the arm does not run in the posture that ships, and the gate it
describes does.

- **`capture-fx-traces!`** (~60 reds) now reads **both** axes. `emit-fx-error!`
  fans every contained fx exception through `emit-error-both!`. The union is
  normalised to `{:operation :tags}`, so `expect-fx-error-keyword!` /
  `fx-error-extra` are untouched — both read `(-> ev :tags :exception)`, the
  same object on both axes.
- **`capture-safe-redirect-traces!`** (~17 reds) now reads the **always-on axis
  only**. rf2-6jqa8 promoted these rejections precisely so a production JVM
  stops swallowing them, and `:scheme` / `:host` / `:reason` all survive
  `safe-redirect-record-slots`. Axis 1 alone rather than a union, because
  several of these **count**, and a union would report two in dev and one in
  production. `:allowlist` is excluded from the always-on record by design — an
  application's own security configuration must not ride off-box — so the
  single assertion reading it is the one genuine dev arm in the cluster.
- **The projector cluster** now reads both axes through `with-error-capture!`,
  lifting the union record with the same `error-record->trace-event` that
  rf2-76gom wrote for the conformance corpus. These categories *are* the
  production status source: `error-emit-projection-listener`, not the trace-cb
  one, is what stamps `:status` on a release JVM.
- **`direct-ssr-layer-projects-view-time-exception`** was the only deftest
  driving the dev bus as its **input**. `trace/emit!` is a no-op under the gate,
  so the subject was *absent*, not unobservable, and re-pointing the read could
  not fix it. It keeps its dev drive verbatim in an arm and gains the symmetric
  always-on counterpart via `dispatch-error-record!`.
- **Dev arms, kept verbatim**: the `:rf.warning/*` family (multiple-status-set,
  multiple-redirects — the last-write-wins *policy* is asserted
  posture-independently beside each), the hydration-mismatch and head-mismatch
  traces, and the rich step-5 `:rf.error/schema-validation-failure`.

### `ssr-server-fx-args-schema-boundary` is now a two-posture contract

Not a split. rf2-dtpfv made the refusal itself posture-independent, so **§1**
asserts the accumulator claims unguarded — not a claim that one *mechanism*
fires, but the claim both exist to make, true whichever got there first. **§2**
is the dev step-5 diagnostic. **§3** is the always-on
`:rf.error/fx-handler-exception` that makes §1 true in a release build. Its nine
cases became a table, since the diagnostic halves are uniform while the
accumulator claims are not.

### Vacuous passes

**Five found, all class 1** (a negative over an empty ring), none of them
previously failing: the `not-any? :sanitised-on-projection` the roster called
out by name, the two well-formed-args negatives, the no-target-redirect
negative, and the two hydration "no mismatch when hashes agree" negatives.
Three became **real** (their capture is now always-on); three moved into the arm
holding the positive they discriminate against.

**Dev-posture assertion count: 71 tests / 354 to 364 assertions.** Test count
held, 10 assertions up, nothing lost. Under the gate: 71 / 348 with 109 red
becomes 71 / 360, zero red.

`RF2_MIN_TESTS` 425 to 510 — the raise the file's own note asked for. 425
against 589 is 27.8% headroom; 510 restores the ~13% calibrated here four times
now. This floor is the lane's **only** structural guard now that
`verify_roster` is gone: a silently-narrowing discovery is caught here and
nowhere else.

**No operator-grade findings.** Nothing failed for a reason other than the
already-ruled, already-landed rf2-dtpfv.

## rf2-15047 — the budget is re-measured, and 360s stands

The author of #7193 asked for a baseline before anyone lowered it. Here it is.

**Measured**, two consecutive local runs of the built `:browser-test` bundle:
**841 tests / 5459 assertions / 0 failures**, 25.9s and 25.2s wall for
serve+launch+navigate+suite+teardown, of which the **summary wait proper — the
only thing `TIMEOUT_MS` bounds — is ~22.5s**. The 41.5s shadow-cljs compile is
not on this clock. That confirms rf2-mf4uy's 73s to 22.5s.

So 360s is ~16x the local green run and ~9.5x at the measured ~1.7x CI factor,
against the ~3.6x rule that produced it. By that rule alone the number wants to
be ~140-180s. **Not lowered**, for two reasons, both now recorded in the file:

1. The growth this budget absorbs is **wall-clock, not compute**. Each control
   witness costs ~35-40s of mounted rows driven through real-time settles with
   2-4s poll budgets — `setTimeout`, which neither a faster runner nor another
   bundle split can shrink. 22.5s is a one-off structural change, not a trend,
   and the witness corpus is still landing. Three more puts the lane near ~135s,
   where a 180s budget has ~1.3x headroom and needs raising again within weeks.
2. The failure modes are **asymmetric**. Over-large costs only a slower failure
   on a genuine hang — still 6 minutes, far inside `timeout-minutes: 45`, and
   still through this runner with the console trail and the rf2-76lhy
   per-namespace profile. Under-sized costs a false red on a loaded runner:
   precisely the failure rf2-15047 was filed to stop.

Comment-only; `DEFAULT_TIMEOUT_MS` is unchanged at 360000.

## Quality gates

| gate | result |
|---|---|
| `bash scripts/test-ssr-prod-gate.sh` (real `-Dre-frame.debug=false`, roster empty) | **exit 0** — 589 tests / 2698 assertions, 0 failures |
| `clojure -M:test` (implementation/ssr, full dev suite) | **exit 0** — 587 tests / 2868 assertions, 0 failures |
| `clojure -M:test:prod-gate -n re-frame.ssr-end-to-end-test` | **exit 0** — 71 / 360, 0 failures (was 71 / 348, **109 failures**) |
| `clojure -M:test -n re-frame.ssr-end-to-end-test` (dev posture) | **exit 0** — 71 / 364, 0 failures (was 71 / 354) |
| `bash scripts/test-ssr-prod-gate.sh --plan` | **exit 0** |
| `python scripts/check_jvm_lane_rosters.py` | **exit 0** — 31 artefacts, 0 baselined |
| `npm run test:browser` | **exit 0** — 841 tests / 5459 assertions, 0 failures (3 runs) |
| `node scripts/_browser-test-report.test.cjs` | **exit 0** — 18 passed |

Deferred to CI: the full JVM implementation sweep, the tools lanes, and the
remaining browser bundles (prod-elision, schemas-boundary-prod) — untouched by
this diff, which is two test-surface files and one comment block.
