### PR TITLE
ci: check_clein_main reads structure, and the EDN reader accepts a trailing discard (rf2-1xacx, rf2-vr11t)

### DIFF
--- a/.github/scripts/verify-version-lockstep.sh
+++ b/.github/scripts/verify-version-lockstep.sh
@@ -53,12 +53,15 @@
 #   ./.github/scripts/verify-version-lockstep.sh
 #   ./.github/scripts/verify-version-lockstep.sh --self-test
 #
-# `--self-test` checks the checker rather than the tree: it runs
-# check_no_git_coords_in_runtime_deps over a set of synthetic deps.edn and
-# asserts each verdict. That check shipped once as a line-oriented text grep
-# that only saw a git coordinate when the library symbol and its map sat on
-# the same physical line, so it passed a clean verdict on a tree it had not
-# actually read (rf2-2ii52). Both layouts are pinned there now.
+# `--self-test` checks the CHECKERS rather than the tree: it runs
+# check_no_git_coords_in_runtime_deps and check_clein_main over sets of
+# synthetic deps.edn and asserts each verdict. Both shipped once as
+# line-oriented text greps and both were wrong for the same reason — the first
+# only saw a git coordinate when the library symbol and its map sat on the same
+# physical line (rf2-2ii52), the second asked the WHOLE FILE for a `:main` at
+# the start of a line rather than the `:clein/build` map it claims to check
+# (rf2-1xacx). Each passed a verdict on a tree it had not actually read. Both
+# read EDN structure now, and the layouts are pinned below.
 #
 # rf2-ace2 / rf2-w05l / rf2-zha9 / rf2-lwtke.
 
@@ -371,44 +374,122 @@ check_no_git_coords_in_runtime_deps() {
   done <<< "${derived}"
 }
 
-# `--self-test` — the mutation pin, and the reason the rewrite above is
-# checkable rather than merely asserted. Each case is a deps.edn the checker
-# has to judge; the same-line and multiline forms are the pair the reopen
-# named, and the negative cases pin the scoping the grep also got wrong. Run
-# by .github/workflows/test.yml alongside the gate itself.
+# ---- rf2-1xacx: clein's own spec requires :main in :clein/build ----------
+#
+# Without it every clein invocation in the directory aborts before doing any
+# work:
+#
+#   Error in the :clein/build map: {…} - failed: (contains? % :main)
+#
+# An artefact can therefore be perfectly version-pinned and still be impossible
+# to package. rf2-4u3t1 found this in machines-viz; rf2-2ii52 found the same
+# thing in mcp-base. Asserting it here is what stops a third.
+#
+# THIS CHECK WAS THE SAME FAULT AS ITS SIBLING ABOVE, ONE FUNCTION OVER. It
+# asserted with `grep -qE '^[[:space:]]*:main[[:space:]]' "${deps_file}"` — a
+# WHOLE-FILE text grep that never went near the `:aliases -> :clein/build` map
+# it claims to be reading. It was wrong in both directions at once: a `:main`
+# sitting in any OTHER alias (a `:run` alias, say) satisfied it, so an
+# un-buildable artefact reported clean; and a perfectly good
+# `{:lib day8/x :main day8.x.core}` written on ONE LINE did not, so a buildable
+# one reported broken. A `:main ` at the start of a line inside a multiline
+# STRING satisfied it too. Of six probe shapes it judged three correctly.
+#
+# So it fetches `:aliases`, then `:clein/build`, then `:main` BY KEY, through
+# the same node EDN authority git_coord_libs() and local_root_coords() use —
+# node being the runtime actually available: test.yml runs this gate on a bare
+# `actions/checkout` with no JDK.
+#
+# Scope is NOT narrowed. Everything the grep flagged still reds, and a missing
+# `:clein/build` alias — which the grep only caught by accident, when the file
+# happened to carry no line-initial `:main` anywhere — now reds on its own
+# terms, because an artefact in TOOLS with no build alias is exactly as
+# un-packageable as one whose build alias lacks `:main`.
+
+# `present`, `absent`, or `no-build-alias` for the deps.edn's
+# `:aliases -> :clein/build -> :main`. Sibling of git_coord_libs(): same
+# reader, same fetch-by-key scoping, same fail-closed posture.
+clein_build_main() {
+  node -e '
+    const fs = require("fs");
+    const { readEdn, isMap, mapGetKeyword } = require(process.argv[1]);
+    const top = readEdn(fs.readFileSync(process.argv[2], "utf8"));
+    if (!isMap(top)) throw new Error("top-level form is not a map");
+    const aliases = mapGetKeyword(top, "aliases");
+    if (aliases === undefined) { process.stdout.write("no-build-alias\n"); process.exit(0); }
+    if (!isMap(aliases)) throw new Error(":aliases is not a map");
+    const build = mapGetKeyword(aliases, "clein/build");
+    if (build === undefined) { process.stdout.write("no-build-alias\n"); process.exit(0); }
+    if (!isMap(build)) throw new Error(":clein/build is not a map");
+    process.stdout.write(
+      (mapGetKeyword(build, "main") === undefined ? "absent" : "present") + "\n",
+    );
+  ' "${EDN_READER}" "$1"
+}
+
+# Fail-closed on an unreadable deps.edn (exit, not a counted drift), for the
+# same reason its two siblings do: a reader that could not reach the build
+# alias cannot be the basis for reporting that the artefact is buildable.
+check_clein_main() {
+  local deps_file="$1"
+  local rel_label="$2"
+  local verdict
+
+  if ! verdict="$(clein_build_main "${deps_file}")"; then
+    echo "::error file=${rel_label}::failed to read this deps.edn's :aliases -> :clein/build map structurally via implementation/scripts/lib/edn.cjs (is node on PATH? is the EDN well-formed?) — refusing to report a buildability verdict this script could not verify"
+    exit 2
+  fi
+
+  case "${verdict}" in
+    present) ;;
+    absent)
+      echo "::error file=${rel_label}:::clein/build is missing :main — clein's build-opts spec requires it, so every clein invocation in this directory aborts before doing any work (artefact is un-BUILDABLE)"
+      errors=$((errors + 1))
+      ;;
+    *)
+      echo "::error file=${rel_label}::no :aliases -> :clein/build alias — this artefact is published by clein, and clein has nothing to read here, so it cannot be BUILT at all"
+      errors=$((errors + 1))
+      ;;
+  esac
+}
+
+# `--self-test` — the mutation pin, and the reason the rewrites above are
+# checkable rather than merely asserted. Each case is a deps.edn a checker has
+# to judge. Run by .github/workflows/test.yml alongside the gate itself.
+#
+# $1 checker function, $2 label, $3 expectation (FLAGGED | CLEAN | REFUSED),
+# $4 deps.edn text. The checker runs inside a command substitution so its
+# fail-closed `exit 2` bounds itself to that subshell and its `errors`
+# increment cannot leak into the real tally.
+_self_test_case() {
+  local checker="$1" label="$2" expect="$3" body="$4" out rc verdict mark
+  self_test_cases=$((self_test_cases + 1))
+  printf '%s\n' "${body}" > "${SELF_TEST_TMP}/deps.edn"
+  if out="$("${checker}" "${SELF_TEST_TMP}/deps.edn" "self-test" 2>&1)"; then
+    rc=0
+  else
+    rc=$?
+  fi
+  if [[ "${rc}" -eq 2 ]]; then
+    verdict=REFUSED
+  elif grep -q '::error' <<< "${out}"; then
+    verdict=FLAGGED
+  else
+    verdict=CLEAN
+  fi
+  if [[ "${verdict}" == "${expect}" ]]; then
+    mark="  ok"
+  else
+    mark="FAIL"
+    self_test_failures=$((self_test_failures + 1))
+  fi
+  printf '  %s  %-52s expected %-8s got %s\n' "${mark}" "${label}" "${expect}" "${verdict}"
+}
+
+# The same-line and multiline forms are the pair the rf2-2ii52 reopen named,
+# and the negative cases pin the scoping the grep also got wrong.
 git_coord_self_test() {
-  local tmp failures=0 cases=0
-
-  tmp="$(mktemp -d)"
-
-  # $1 label, $2 expectation (FLAGGED | CLEAN | REFUSED), $3 deps.edn text.
-  # The checker runs inside a command substitution so its fail-closed `exit 2`
-  # bounds itself to that subshell and its `errors` increment cannot leak into
-  # the real tally.
-  _git_coord_case() {
-    local label="$1" expect="$2" body="$3" out rc verdict mark
-    cases=$((cases + 1))
-    printf '%s\n' "${body}" > "${tmp}/deps.edn"
-    if out="$(check_no_git_coords_in_runtime_deps "${tmp}/deps.edn" "self-test" 2>&1)"; then
-      rc=0
-    else
-      rc=$?
-    fi
-    if [[ "${rc}" -eq 2 ]]; then
-      verdict=REFUSED
-    elif grep -q '::error' <<< "${out}"; then
-      verdict=FLAGGED
-    else
-      verdict=CLEAN
-    fi
-    if [[ "${verdict}" == "${expect}" ]]; then
-      mark="  ok"
-    else
-      mark="FAIL"
-      failures=$((failures + 1))
-    fi
-    printf '  %s  %-48s expected %-8s got %s\n' "${mark}" "${label}" "${expect}" "${verdict}"
-  }
+  _git_coord_case() { _self_test_case check_no_git_coords_in_runtime_deps "$@"; }
 
   echo "self-test: check_no_git_coords_in_runtime_deps"
 
@@ -472,19 +553,84 @@ git_coord_self_test() {
   # --- unreadable input is refused, never reported clean -------------------
   _git_coord_case 'malformed EDN' REFUSED \
 '{:deps {org.clojure/clojure {:mvn/version "1.12.0"}'
+}
 
-  rm -rf "${tmp}"
+# rf2-1xacx. The whole-file grep judged three of these six wrongly — in both
+# directions, which is why the pin carries CLEAN cases as well as FLAGGED ones.
+clein_main_self_test() {
+  _clein_main_case() { _self_test_case check_clein_main "$@"; }
 
-  if [[ "${failures}" -gt 0 ]]; then
-    echo "::error::self-test FAILED — ${failures} of ${cases} case(s) misjudged by check_no_git_coords_in_runtime_deps"
-    return 1
-  fi
-  echo "self-test PASSED — all ${cases} cases judged correctly"
-  return 0
+  echo "self-test: check_clein_main"
+
+  # --- :main in the build alias is what makes the artefact buildable -------
+  _clein_main_case ':main in :clein/build, one key per line' CLEAN \
+'{:aliases {:clein/build {:lib day8/re-frame2-xray
+                          :main day8.re-frame2.xray.main
+                          :version "0.0.1"}}}'
+
+  # The layout the grep could not see: nothing starts the line but `{`.
+  _clein_main_case ':main on the same line as :lib' CLEAN \
+'{:aliases {:clein/build {:lib day8/re-frame2-xray :main day8.re-frame2.xray.main}}}'
+
+  # --- and its absence must red however the file is laid out ---------------
+  _clein_main_case ':main absent from :clein/build' FLAGGED \
+'{:aliases {:clein/build {:lib day8/re-frame2-xray :version "0.0.1"}}}'
+
+  # The shape the grep false-PASSED: `:main` is present in the file, but in an
+  # alias clein never reads, so `clojure -M:clein pom` still aborts.
+  _clein_main_case ':main only in an unrelated alias' FLAGGED \
+'{:aliases {:clein/build {:lib day8/re-frame2-xray}
+           :run {:main-opts ["-m" "day8.re-frame2.xray"]
+                 :main day8.re-frame2.xray.main}}}'
+
+  # `:main ` at the start of a line inside a multiline string also satisfied
+  # the grep. Structure does not see into strings.
+  _clein_main_case ':main at line-start inside a string literal' FLAGGED \
+'{:aliases {:clein/build {:lib day8/re-frame2-xray
+                          :doc "usage:
+:main is set below
+"}}}'
+
+  _clein_main_case ':main removed with a #_ discard' FLAGGED \
+'{:aliases {:clein/build {:lib day8/re-frame2-xray
+                          #_:main #_day8.re-frame2.xray.main}}}'
+
+  # --- no build alias at all is un-buildable too, and says so --------------
+  _clein_main_case 'no :clein/build alias' FLAGGED \
+'{:aliases {:test {:extra-paths ["test"]}}}'
+
+  _clein_main_case 'no :aliases map at all' FLAGGED \
+'{:deps {org.clojure/clojure {:mvn/version "1.12.0"}}}'
+
+  # --- rf2-vr11t: the build alias ends with a discarded key ----------------
+  # The reader used to throw `unexpected '}'` on this, which made the WHOLE
+  # gate exit 2 — un-runnable, from an ordinary commented-out last entry.
+  _clein_main_case ':main present, alias ends with a #_ discard' CLEAN \
+'{:aliases {:clein/build {:lib day8/re-frame2-xray
+                          :main day8.re-frame2.xray.main
+                          #_:javac-opts #_["-source" "8"]}}}'
+
+  # --- unreadable input is refused, never reported clean -------------------
+  _clein_main_case 'malformed EDN' REFUSED \
+'{:aliases {:clein/build {:lib day8/re-frame2-xray'
 }
 
 if [[ "${1:-}" == "--self-test" ]]; then
-  if git_coord_self_test; then exit 0; else exit 1; fi
+  SELF_TEST_TMP="$(mktemp -d)"
+  self_test_cases=0
+  self_test_failures=0
+
+  git_coord_self_test
+  clein_main_self_test
+
+  rm -rf "${SELF_TEST_TMP}"
+
+  if [[ "${self_test_failures}" -gt 0 ]]; then
+    echo "::error::self-test FAILED — ${self_test_failures} of ${self_test_cases} case(s) misjudged"
+    exit 1
+  fi
+  echo "self-test PASSED — all ${self_test_cases} cases judged correctly"
+  exit 0
 fi
 
 # Populated by the :local/root presence checks below, then consumed by the
@@ -715,27 +861,10 @@ TOOLS=(xray story story-mcp machines-viz mcp-base)
 # It read `:version` and the `:local/root` coordinates, and nothing else. So
 # it reported "all 17 artefacts pinned" while `day8/re-frame2-machines-viz`
 # could not be BUILT at all, and while two artefacts carried a runtime
-# coordinate `clein pom` silently DROPS. Both are cheap to assert. The second
-# — check_no_git_coords_in_runtime_deps — is defined above, next to the EDN
-# reader it shares with the coordinate-inventory pass; the first is here.
-
-# (1) clein's own spec requires `:main` in `:clein/build`. Without it every
-# clein invocation in the directory aborts before doing any work:
-#
-#   Error in the :clein/build map: {…} - failed: (contains? % :main)
-#
-# An artefact can therefore be perfectly version-pinned and still be
-# impossible to package. rf2-4u3t1 found this in machines-viz; rf2-2ii52
-# found the same thing in mcp-base. Asserting it here is what stops a third.
-check_clein_main() {
-  local deps_file="$1"
-  local rel_label="$2"
-
-  if ! grep -qE '^[[:space:]]*:main[[:space:]]' "${deps_file}"; then
-    echo "::error file=${rel_label}:::clein/build is missing :main — clein's build-opts spec requires it, so every clein invocation in this directory aborts before doing any work (artefact is un-BUILDABLE)"
-    errors=$((errors + 1))
-  fi
-}
+# coordinate `clein pom` silently DROPS. Both are cheap to assert. Both —
+# check_clein_main (rf2-1xacx) and check_no_git_coords_in_runtime_deps
+# (rf2-2ii52) — are defined above, next to the EDN reader they share with the
+# coordinate-inventory pass, and both are pinned by `--self-test`.
 
 for tool in "${TOOLS[@]}"; do
   subpath="${TOOLS_PATHS[$tool]}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,15 +106,19 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      # rf2-2ii52 — check the checker BEFORE trusting its verdict on the tree.
-      # The runtime git-coordinate assertion shipped as a line-oriented text
-      # grep that could only see a coordinate when the library symbol and
-      # `{:git/url` sat on the same physical line; ordinary multiline deps.edn
-      # layout produced no finding, so the gate's green was a property of one
-      # file's whitespace rather than of the tree. It reads EDN structure now,
-      # and this step pins both layouts (plus the comment / `#_` discard /
-      # string-literal / alias-scoping cases the grep also misjudged) so the
-      # regression cannot come back quietly.
+      # rf2-2ii52 / rf2-1xacx — check the checkers BEFORE trusting their
+      # verdict on the tree. Both of this gate's buildability assertions
+      # shipped as line-oriented text greps, and both were wrong for the same
+      # reason. The runtime git-coordinate one could only see a coordinate when
+      # the library symbol and `{:git/url` sat on the same physical line, so
+      # ordinary multiline deps.edn layout produced no finding. The clein
+      # `:main` one asked the WHOLE FILE for a line-initial `:main` rather than
+      # the `:aliases -> :clein/build` map it claims to check, so a `:main` in
+      # any other alias passed it and a one-line build alias failed it. Each
+      # gate's green was a property of one file's whitespace rather than of the
+      # tree. Both read EDN structure now, and this step pins every layout
+      # (plus the comment / `#_` discard / string-literal / alias-scoping cases
+      # the greps also misjudged) so neither regression can come back quietly.
       - name: Self-test the lockstep gate's own checkers
         run: ./.github/scripts/verify-version-lockstep.sh --self-test
 

--- a/implementation/scripts/_ui-deps-edn-boundary.test.cjs
+++ b/implementation/scripts/_ui-deps-edn-boundary.test.cjs
@@ -41,6 +41,8 @@ const assert = require('assert/strict');
 const fs = require('fs');
 const path = require('path');
 const {
+  readEdn,
+  EdnReadError,
   productionDepsMap,
   mapHasSymbolKey,
 } = require('./lib/edn.cjs');
@@ -331,6 +333,76 @@ test('real ui/deps.edn — core coordinate resolves to the configured local root
   // Non-vacuity: the expected root is the real core artefact next to ui/.
   assert.equal(CORE_LOCAL_ROOT, path.resolve(UI_DIR, '..', 'core'));
   assert.ok(fs.existsSync(path.join(CORE_LOCAL_ROOT, 'deps.edn')), 'core artefact exists');
+});
+
+// ---- rf2-vr11t: a `#_` discard is ignorable content, wherever it sits ------
+//
+// The reader is a SHARED authority — this boundary gate, the release lockstep
+// (.github/scripts/verify-version-lockstep.sh, both its :local/root inventory
+// and its runtime git-coordinate check) and the bundle-isolation gate's
+// publishable-artefact discovery (lib/publishable-runtimes.cjs) all read EDN
+// through it — so a hole in it is a hole in all three at once.
+//
+// It could not read a collection whose LAST element was a `#_` discard.
+// readForm consumed the marker, read the datum it drops, then looped round to
+// read "the real next form" — which, in that position, is the CLOSING
+// DELIMITER, so readDatum threw `unexpected '}'`. A discard anywhere else read
+// fine, which is why the shape above ('reader-discarded first :deps form')
+// passed while this one did not.
+//
+// Every consumer fails CLOSED on a throw, so this was never a false green: the
+// lockstep exits 2 refusing to report a verdict, and publishable-runtimes falls
+// back to a raw `:clein/build` text match. But `#_`-commenting out the last
+// dependency in a map while debugging is an entirely ordinary thing to write,
+// and it made those gates UN-RUNNABLE. Discards are now skipped as ignorable
+// content — like whitespace and `;` comments — BEFORE the closing-delimiter
+// test rather than after it, so position stops mattering.
+const DISCARD_SHAPES = [
+  ['last element of a map', '{:deps {org.clojure/clojure {:mvn/version "1.12.0"}\n'
+    + '        #_day8/de-dupe #_{:git/url "https://example.invalid/x.git"}}}'],
+  ['last element of a vector', '[:a :b #_:c]'],
+  ['last element of a list', '(:a :b #_:c)'],
+  ['last element of a set', '#{:a :b #_:c}'],
+  ['the collection\'s ONLY content', '{:deps {#_a #_1}}'],
+  ['before the close, across a newline', '{:deps {:a 1\n        #_:b #_2\n       }}'],
+  ['a `#_ #_ a b` pair-discard at the end', '{:deps {:a 1 #_ #_ :b 2}}'],
+  ['discard then `;` comment then close', '{:deps {:a 1 #_:b ; trailing\n}}'],
+];
+
+for (const [where, text] of DISCARD_SHAPES) {
+  test(`reader contract — trailing #_ discard: ${where}`, () => {
+    assert.doesNotThrow(() => readEdn(text), `readEdn must accept a discard ${where}`);
+  });
+}
+
+// The discard must actually DROP its datum, not merely be tolerated — a reader
+// that skipped the marker and kept the form would read these as clean too.
+test('reader contract — a discarded entry is absent from the parsed map', () => {
+  const top = readEdn('{:deps {org.clojure/clojure {:mvn/version "1.12.0"}\n'
+    + '        #_day8/de-dupe #_{:git/url "https://example.invalid/x.git"}}}');
+  const deps = top.entries.find(([k]) => k.edn === 'keyword' && k.name === 'deps')[1];
+  assert.equal(deps.entries.length, 1, 'the discarded coordinate must not appear as an entry');
+  assert.ok(mapHasSymbolKey(deps, 'org.clojure/clojure'));
+  assert.ok(!mapHasSymbolKey(deps, 'day8/de-dupe'), 'day8/de-dupe was discarded');
+});
+
+test('reader contract — `#_ #_ a b` drops BOTH forms', () => {
+  const top = readEdn('{:deps {#_ #_ day8/de-dupe {:git/url "x"} org.clojure/clojure {:mvn/version "1.12.0"}}}');
+  const deps = top.entries.find(([k]) => k.edn === 'keyword' && k.name === 'deps')[1];
+  assert.equal(deps.entries.length, 1);
+  assert.ok(mapHasSymbolKey(deps, 'org.clojure/clojure'));
+});
+
+// Fail-closed is not weakened: a discard marker with nothing to discard, and a
+// genuinely unbalanced collection, must still be REFUSED rather than read.
+test('reader contract — a discard with no following form is still refused', () => {
+  assert.throws(() => readEdn('{:deps {:a 1 #_'), EdnReadError);
+  assert.throws(() => readEdn('#_'), EdnReadError);
+});
+
+test('reader contract — an unterminated collection is still refused', () => {
+  assert.throws(() => readEdn('{:deps {:a 1 #_:b'), EdnReadError);
+  assert.throws(() => readEdn('{:deps {:a 1}'), EdnReadError);
 });
 
 let failed = 0;

--- a/implementation/scripts/lib/edn.cjs
+++ b/implementation/scripts/lib/edn.cjs
@@ -68,8 +68,31 @@ class Reader {
     return this.pos < this.len ? this.text[this.pos] : EOF;
   }
 
-  // Skip whitespace, commas, and `;`-to-end-of-line comments.
-  skipSpace() {
+  // Skip everything EDN treats as ignorable between data: whitespace, commas,
+  // `;`-to-end-of-line comments, and `#_` discard forms. Leaves `pos` on the
+  // first significant character, which may be a closing delimiter or EOF.
+  //
+  // A discard is ignorable content, not a datum — that is the whole of its
+  // meaning, and putting it HERE rather than in readForm is what fixes
+  // rf2-vr11t. It used to be readForm's job: readForm consumed `#_`, read the
+  // discarded datum, then looped round to read "the real next form" — but
+  // inside a collection whose LAST element is a discard, the real next form is
+  // the CLOSING DELIMITER, and readDatum rejects that. So an entirely ordinary
+  // `#_`-commented-out final dependency
+  //
+  //   {:deps {org.clojure/clojure {:mvn/version "1.12.0"}
+  //           #_day8/de-dupe #_{:git/url "https://example.invalid/x.git"}}}
+  //
+  // threw `unexpected '}'`, and every consumer of this reader — the release
+  // lockstep gate, the bundle-isolation gate — fails CLOSED on a throw. Never a
+  // false pass, but an un-runnable gate, reachable by normal editing.
+  //
+  // Skipping a discard means READING the datum it drops (that is how far it
+  // reaches), so this recurses into readDatum. A `#_ #_ a b` chain drops two
+  // data and falls out of the loop without a special case: the outer marker's
+  // "next form" is itself preceded by a marker, which the recursive
+  // skipIgnored() below consumes first.
+  skipIgnored() {
     for (;;) {
       const ch = this.peek();
       if (ch === EOF) return;
@@ -81,38 +104,40 @@ class Reader {
         while (this.pos < this.len && this.text[this.pos] !== '\n') this.pos += 1;
         continue;
       }
+      if (ch === '#' && this.text[this.pos + 1] === '_') {
+        this.pos += 2; // consume `#_`
+        this.skipIgnored(); // ignorables between the marker and its datum
+        const next = this.peek();
+        if (next === EOF) throw new EdnReadError('#_ with no following form');
+        this.readDatum(next); // read it, drop it
+        continue;
+      }
       return;
     }
   }
 
-  // Read one datum. Returns EOF at end of input. Transparently consumes any
-  // number of leading `#_` discard forms (each drops the following datum).
+  // Read one datum, skipping any ignorable content ahead of it. Returns EOF at
+  // end of input.
   readForm() {
-    for (;;) {
-      this.skipSpace();
-      const ch = this.peek();
-      if (ch === EOF) return EOF;
-      if (ch === '#') {
-        const after = this.pos + 1 < this.len ? this.text[this.pos + 1] : EOF;
-        if (after === '_') {
-          this.pos += 2; // consume `#_`
-          const discarded = this.readForm();
-          if (discarded === EOF) throw new EdnReadError('#_ with no following form');
-          continue; // now read the real next form
-        }
-        if (after === '{') {
-          this.pos += 2; // consume `#{`
-          return { edn: 'set', items: this.readSeq('}') };
-        }
-        throw new EdnReadError(
-          `unsupported reader dispatch #${after === EOF ? '<eof>' : after}`,
-        );
-      }
-      return this.readDatum(ch);
-    }
+    this.skipIgnored();
+    const ch = this.peek();
+    if (ch === EOF) return EOF;
+    return this.readDatum(ch);
   }
 
   readDatum(ch) {
+    if (ch === '#') {
+      // `#_` never reaches here: skipIgnored() consumes discards ahead of every
+      // readDatum call, including its own.
+      const after = this.pos + 1 < this.len ? this.text[this.pos + 1] : EOF;
+      if (after === '{') {
+        this.pos += 2; // consume `#{`
+        return { edn: 'set', items: this.readSeq('}') };
+      }
+      throw new EdnReadError(
+        `unsupported reader dispatch #${after === EOF ? '<eof>' : after}`,
+      );
+    }
     if (ch === '(') {
       this.pos += 1;
       return { edn: 'list', items: this.readSeq(')') };
@@ -133,10 +158,14 @@ class Reader {
     return this.readAtom();
   }
 
+  // Elements up to `close`. Because skipIgnored() now runs BEFORE the
+  // closing-delimiter test on every pass, a discard sitting last in the
+  // collection is gone by the time we look for `}` — the ordering rf2-vr11t
+  // turned on.
   readSeq(close) {
     const items = [];
     for (;;) {
-      this.skipSpace();
+      this.skipIgnored();
       const ch = this.peek();
       if (ch === EOF) {
         throw new EdnReadError(`unterminated collection, expected '${close}'`);
@@ -145,11 +174,7 @@ class Reader {
         this.pos += 1;
         return items;
       }
-      const form = this.readForm();
-      if (form === EOF) {
-        throw new EdnReadError(`unterminated collection, expected '${close}'`);
-      }
-      items.push(form);
+      items.push(this.readDatum(ch));
     }
   }
 


### PR DESCRIPTION
Two defects in the release-lockstep machinery, both filed by PR #7217 while it
fixed a sibling one function over, both left alone there as outside that
reopen's bounded repair. Same shape of fix in both cases: read STRUCTURE, prove
it with a self-test that fails against the code being replaced.

## rf2-1xacx — `check_clein_main` greps the whole file

`check_clein_main` asserts the `:main` key clein's build-opts spec requires.
Without it every clein invocation in the directory aborts before doing any work
(`failed: (contains? % :main)`), so an artefact can be perfectly version-pinned
and still be impossible to package — rf2-4u3t1 found that in machines-viz,
rf2-2ii52 found it again in mcp-base. It asserted with

```
grep -qE '^[[:space:]]*:main[[:space:]]' "${deps_file}"
```

a WHOLE-FILE text grep that never goes near the `:aliases -> :clein/build` map
it claims to check. It was wrong in both directions at once. Six probe shapes,
before and after:

| shape | before | after |
|---|---|---|
| `:main` in `:clein/build`, one key per line | CLEAN | CLEAN |
| `:main` on the same line as `:lib` | **FLAGGED** (false fail) | CLEAN |
| `:main` absent from `:clein/build` | FLAGGED | FLAGGED |
| `:main` only in an unrelated (`:run`) alias | **CLEAN** (false pass) | FLAGGED |
| `:main` line-initial inside a string literal | **CLEAN** (false pass) | FLAGGED |
| `:main` removed with a `#_` discard | FLAGGED | FLAGGED |

It fetches `:aliases`, then `:clein/build`, then `:main` BY KEY now, through
`implementation/scripts/lib/edn.cjs` under node — the same authority
`git_coord_libs()` and `local_root_coords()` already use in this script, and
the runtime that is actually available: `test.yml` runs this gate on a bare
`actions/checkout` with **no JDK**, so anything invoking `clojure` here would
break ordinary CI. Full pom expressibility stays with
`preflight-tool-package.sh` at tag-push, where clojure is installed.

**Scope is not narrowed.** Everything the grep flagged still reds. A missing
`:clein/build` alias — which the grep only caught by accident, when the file
happened to carry no line-initial `:main` anywhere — now reds on its own terms
with its own message. Unreadable EDN is REFUSED (exit 2), matching its sibling.

## rf2-vr11t — the EDN reader throws on a trailing `#_` discard

`Reader.readSeq` could not read a collection whose LAST element was a `#_`
discard. `readForm` consumed the marker, read the datum it drops, then looped
round to read "the real next form" — which, in that position, is the CLOSING
DELIMITER, so `readDatum` threw. A discard anywhere else read fine.

```
{:deps {org.clojure/clojure {:mvn/version "1.12.0"}
        #_day8/de-dupe #_{:git/url "https://example.invalid/x.git"}}}
-> EdnReadError: unexpected '}'
```

This is **fail-closed** — never a false pass — but it made three gates
UN-RUNNABLE from an entirely ordinary commented-out last dependency.

The reader is shared authority; **every consumer was found and checked**:

| consumer | how it reads | effect of the defect |
|---|---|---|
| `.github/scripts/verify-version-lockstep.sh` | `local_root_coords()` + `git_coord_libs()` (and now `clein_build_main()`) | `exit 2`, "failed to read this deps.edn structurally" — whole gate refuses |
| `implementation/scripts/lib/publishable-runtimes.cjs` | `depsDeclaresBuildAlias` | falls back to a raw `/:clein\/build/` text match — the structural rejection of string/comment/discard mentions is lost |
| `implementation/scripts/check-bundle-isolation.cjs` | via `publishable-runtimes.cjs` | inherits the degraded fallback |
| `implementation/scripts/run-ui-g13.cjs` | `productionDepsMap` | G-13 boundary gate fails closed |

The contract is fixed rather than the last position special-cased: a discard is
IGNORABLE CONTENT, which is the whole of what `#_` means. `skipSpace` becomes
`skipIgnored` and consumes `#_ <form>` pairs alongside whitespace, commas and
`;` comments; `readSeq` calls it BEFORE testing for the closing delimiter
instead of after, so position stops mattering. `#_ #_ a b` drops two data with
no special case. Fail-closed is not weakened: `#_` with nothing to discard, and
a genuinely unbalanced collection, are still refused.

## Non-vacuity — every pin fails against the code it replaces

- `--self-test` grows 11 -> **21** cases (the per-case harness is hoisted and
  parameterised by checker rather than copied). Against the retired grep,
  **4 of the 10 new `check_clein_main` cases FAIL**; against the pre-fix EDN
  reader a further **2 FAIL** (the two trailing-discard cases, which the old
  reader turns into REFUSED).
- `_ui-deps-edn-boundary.test.cjs` — the suite that covers `edn.cjs`, already
  run in CI by `npm run test:script-helpers` — grows 49 -> **61** cases.
  **9 of the 12 new cases FAIL against the pre-fix reader.**

## No artefact changes verdict

`verify-version-lockstep.sh` output is byte-identical before and after both
changes, exit 0. `publishable-runtimes.cjs` inventory is byte-identical. All
five publishable tools genuinely carry `:main` in `:clein/build` (xray
`day8.re-frame2-xray.preload`, story `re-frame.story`, story-mcp
`re-frame.story-mcp.server`, machines-viz `day8.re-frame2-machines-viz.chart`,
mcp-base `re-frame.mcp-base.vocab`), and no deps.edn in the tree has a trailing
discard today — so both fixes are prevention, not repair.

## Quality gates

Run locally in this worktree at `d40650cc61`, foreground, exit codes echoed.

| gate | exit |
|---|---|
| `bash .github/scripts/verify-version-lockstep.sh --self-test` (21/21 judged correctly) | 0 |
| `bash .github/scripts/verify-version-lockstep.sh` (real tree, 18 artefacts, 31 coordinates) | 0 |
| `node scripts/_ui-deps-edn-boundary.test.cjs` (61 passed) | 0 |
| `node scripts/check-bundle-isolation.test.cjs` (shares the reader via publishable-runtimes) | 0 |
| `node scripts/_release-dag-policy.test.cjs` (10 passed) | 0 |
| `node scripts/_lint-workflow-policy.test.cjs` (4 passed) | 0 |
| `node scripts/_docs-workflow-policy.test.cjs` (5 passed) | 0 |
| `git ls-files '.github/scripts/*.sh' \| xargs shellcheck` (11 scripts) | 0 |
| `bash -n .github/scripts/verify-version-lockstep.sh` | 0 |
| `node --check implementation/scripts/lib/edn.cjs` | 0 |
| `node --check implementation/scripts/_ui-deps-edn-boundary.test.cjs` | 0 |
| `yaml.safe_load('.github/workflows/test.yml')` (69 jobs, 3 lockstep steps) | 0 |

**Mutation runs** (the proof the pins are not decorations):

| mutation | exit | result |
|---|---|---|
| new self-test vs. the retired `:main` grep | 1 | 4 of 21 misjudged |
| new self-test vs. the pre-fix EDN reader | 1 | 2 of 21 misjudged |
| `_ui-deps-edn-boundary.test.cjs` vs. the pre-fix EDN reader | 1 | 9 of 61 failed |

**Deferred to CI:** `npm run test:script-helpers` / `test:script-policy` in
full, `test:bundle-isolation` (needs a shadow-cljs release build), and the
whole CLJS spine. `node_modules` is not installed in this worktree; the
node-only suites above were run directly.

rf2-1xacx, rf2-vr11t.
