### PR TITLE
perf(freehand): the selected render is one bundle (rf2-9f1s7)

### DIFF
--- a/implementation/freehand/src/re_frame/freehand/cell.cljc
+++ b/implementation/freehand/src/re_frame/freehand/cell.cljc
@@ -169,20 +169,35 @@
 
   A fresh cell owns nothing: no dependencies, no committed frame, and an
   event owner that has never been committed. It becomes `:connected`
-  only when a render is SELECTED."
+  only when a render is SELECTED.
+
+  THE SELECTED RENDER IS ONE VALUE, held under `:bundle`. Spec 006 §The
+  selected render bundle names what a commit publishes as one bundle with
+  all-or-nothing publication, and [[commit!]]'s docstring says the same
+  thing in as many words; this state map says it too. The frame, the
+  dependency set, the render order and the observations are not four
+  slots that a commit happens to write together — they are one value,
+  written once, and there is no shape in which three of them agree and
+  the fourth is a render behind. It also removes the frame's second
+  home: a cell used to hold `:frame` at top level AND inside the
+  evidence it published.
+
+  What stays TOP-LEVEL is `:generation`, and the distinction is
+  load-bearing: the top-level one is the cell's current BODY AUTHORITY,
+  which [[advance-generation!]] moves on hot reload before any render
+  commits against it, while the bundle's is the generation of the last
+  SELECTED commit. They are allowed to differ, and that difference is
+  exactly what [[current?]] tests."
   [view-id]
   (->ViewCell
     (atom {:view-id    view-id
            :generation 0
            :lifecycle  :new
-           :frame      nil
-           :deps       {}
-           :dep-order  []
            :events     (events/owner view-id)
            :revision   0
            :listeners  {}
            :dirty      nil
-           :evidence   nil})))
+           :bundle     nil})))
 
 (defn cell?
   "True when `x` is a [[cell]]."
@@ -191,18 +206,38 @@
 
 (defn view-id     "The cell's authoring identity."             [^ViewCell c] (:view-id @(st c)))
 (defn lifecycle   "`:new`, `:connected`, or `:disconnected`."   [^ViewCell c] (:lifecycle @(st c)))
-(defn committed-frame "The frame the SELECTED commit bound to." [^ViewCell c] (:frame @(st c)))
 (defn generation  "The body revision the cell is current at."   [^ViewCell c] (:generation @(st c)))
 (defn revision    "The repaint counter the host snapshots."     [^ViewCell c] (:revision @(st c)))
 (defn events-owner "The cell's committed event owner."          [^ViewCell c] (:events @(st c)))
-(defn evidence    "The SELECTED commit's published evidence."   [^ViewCell c] (:evidence @(st c)))
+
+(defn evidence
+  "The bundle the SELECTED commit published — `{:frame :generation :deps
+  :dep-order :observations}` — or `nil` for a cell that has never had a
+  render selected, and `nil` again after [[disconnect!]].
+
+  This is the WHOLE bundle rather than a summary of it, because there is
+  only one thing here to read: Spec 006 §The selected render bundle names
+  what a commit publishes as one value, and the cell holds it as one
+  value. The three projections below are doors onto THIS map, not onto
+  slots of their own, so they cannot disagree with it or with each
+  other."
+  [^ViewCell c]
+  (:bundle @(st c)))
+
+(defn committed-frame
+  "The frame the SELECTED commit bound to."
+  [^ViewCell c]
+  (:frame (evidence c)))
 
 (defn dependencies
   "The committed dependency map — `{site-key {:query :target :handle
   :value :evidence}}`. Empty for a cell that has never had a render
-  selected, and empty again after [[disconnect!]]."
+  selected, and empty again after [[disconnect!]] — the absence of a
+  bundle reads as an empty set rather than as `nil`, because \"this cell
+  owns nothing\" is what both states mean and a caller counting or
+  walking them should not have to tell them apart."
   [^ViewCell cell]
-  (:deps @(st cell)))
+  (:deps (evidence cell) {}))
 
 (defn dependency-queries
   "The queries the SELECTED commit owns, in RENDER order.
@@ -211,9 +246,12 @@
   A site key is whatever the tier that recorded it uses — the
   interpreted walk's document ordinal, the compiled tier's proven lexical
   site id — and only an ordinal happens to sort into render order. Reading
-  the published order keeps this projection true for both."
+  the published order keeps this projection true for both.
+
+  Both halves come off the SAME bundle in one read, so the order can
+  never name a site the map has since stopped holding."
   [^ViewCell cell]
-  (let [{:keys [deps dep-order]} @(st cell)]
+  (let [{:keys [deps dep-order]} (evidence cell)]
     (mapv #(:query (get deps %)) dep-order)))
 
 ;; ---------------------------------------------------------------------------
@@ -374,7 +412,7 @@
   and no disposal obligation."
   [^RenderCandidate cand site-key query]
   (let [^ViewCell owner-cell (.-cell cand)
-        prior     (get (:deps @(st owner-cell)) site-key)
+        prior     (get (dependencies owner-cell) site-key)
         query*    (if (and prior (eq/rf= query (:query prior))) (:query prior) query)
         target    (obs/resolve-target {:query-v query*})
         ev        (obs/probe target)
@@ -660,7 +698,7 @@
         (keep (fn [{:keys [target handle]}]
                 (when (and (some? handle) (= :subscription (:kind target)))
                   (:frame-id target))))
-        (vals (:deps @(st cell)))))
+        (vals (dependencies cell))))
 
 (defn observes-frame?
   "Does `cell`'s committed dependency set include a site resolved in frame
@@ -945,12 +983,30 @@
   Fail-loud: `obs/read` may re-enter application subscription code and
   throw. The whole pass therefore runs inside the caller's rollback
   guard, which releases exactly what this candidate acquired and leaves
-  the prior committed set installed."
+  the prior committed set installed.
+
+  THE ACCUMULATOR IS A PLAIN VECTOR, not a transient, and that is a
+  RETENTION decision rather than a throughput one. A transient is the
+  right tool for a large accumulator thrown away at the end; this one is
+  small and then LIVES, for as long as the boundary is mounted, inside
+  the bundle. `persistent!` hands back a vector still holding the
+  editable root the transient cloned — a `VectorNode` over a 32-slot
+  array — where `conj` onto a tail-only vector shares
+  `PersistentVector.EMPTY`'s root and allocates no node at all. Five heap
+  nodes per mounted boundary, for a vector that is almost always shorter
+  than the tail.
+
+  The trade is honest and runs the other way for a boundary that reads a
+  great many sites, where the transient's in-place growth would win.
+  That shape is the one Freehand's own witnesses call an attribution
+  ablation rather than a shape anybody should write: the reads a view
+  makes are the reads its author wrote, and fine-grained boundaries with
+  a handful of sites each are what the library encourages."
   [order staged]
   (let [n (count order)]
     (loop [i     0
            moved false
-           obs   (transient [])]
+           obs   []]
       (if (< i n)
         (let [site-key (nth order i)
               record   (get staged site-key)
@@ -958,12 +1014,12 @@
               reading  (obs/read handle)]
           (recur (inc i)
                  (or moved (moved? reading (:evidence record)))
-                 (conj! obs {:site-key site-key
-                             :query    (:query record)
-                             :frame-id (:frame-id (:target record))
-                             :value    (:value reading)
-                             :owned?   (obs/owned? handle)})))
-        {:observations (persistent! obs)
+                 (conj obs {:site-key site-key
+                            :query    (:query record)
+                            :frame-id (:frame-id (:target record))
+                            :value    (:value reading)
+                            :owned?   (obs/owned? handle)})))
+        {:observations obs
          :moved?       moved}))))
 
 ;; ---------------------------------------------------------------------------
@@ -1267,7 +1323,7 @@
       :abandoned
       (let [order   @(.-order cand)
             by-site @(.-by-site cand)
-            prior   (:deps s0)
+            prior   (:deps (:bundle s0) {})
             fid     (.-frame cand)
             {:keys [staged acquired]} (stage! owner-cell prior order by-site)
             ;; The commit-side reads are part of the pre-publication
@@ -1303,8 +1359,17 @@
         (if-not (current? cand @(st owner-cell))
           (do (release-all! (rseq acquired))
               :abandoned)
-          (let [bundle   {:frame        fid
+          (let [;; THE BUNDLE IS THE WHOLE PUBLICATION, assembled before any
+                ;; of it is live. `order` is the candidate's own render order
+                ;; and is already a vector — the order volatile opens at `[]`
+                ;; and only ever `conj`es — so it is carried as it stands.
+                ;; Sharing it is safe whatever the candidate does next: a
+                ;; persistent vector's `conj` answers a new vector and cannot
+                ;; reach this one.
+                bundle   {:frame        fid
                           :generation   (.-generation cand)
+                          :deps         staged
+                          :dep-order    order
                           :observations (:observations scan)}
                 ;; Build and VALIDATE the dev evidence BEFORE the publish below —
                 ;; the two-plane split: a malformed FRAMEWORK projection or
@@ -1325,21 +1390,16 @@
                            (catch #?(:clj Throwable :cljs :default) e
                              (release-all! (rseq acquired))
                              (throw e)))]
-            ;; ONE publication. Dependencies, frame and evidence become
-            ;; live in a single write, and the event site table becomes
-            ;; live against this exact frame with no host yield between
-            ;; them — nothing can observe a partial bundle.
-            ;; `order` is the candidate's own render order and is already a
-            ;; vector — the order volatile opens at `[]` and only ever
-            ;; `conj`es — so it is published as it stands. Sharing it is safe
-            ;; whatever the candidate does next: a persistent vector's `conj`
-            ;; answers a new vector and cannot reach this one.
+            ;; ONE publication, and now literally one value. Dependencies,
+            ;; frame and evidence become live in a single write, and the
+            ;; event site table becomes live against this exact frame with
+            ;; no host yield between them — nothing can observe a partial
+            ;; bundle. The atomicity was always in the single `swap!`; what
+            ;; the one `:bundle` slot adds is that there is no longer a
+            ;; SHAPE in which a partial bundle could be written at all.
             (swap! (st owner-cell) assoc
                    :lifecycle :connected
-                   :frame     fid
-                   :deps      staged
-                   :dep-order order
-                   :evidence  bundle)
+                   :bundle    bundle)
             (events/commit! (.-events cand)
                             (frame-dispatcher fid)
                             (frame-door-dispatcher fid))
@@ -1397,15 +1457,17 @@
   (let [s @(st cell)]
     (when-not (= :disconnected (:lifecycle s))
       (events/retire! (:events s))
+      ;; Dropping the bundle is the whole disownership, for the same reason
+      ;; installing it was the whole publication: there is one slot, so a
+      ;; disconnect cannot half-happen either.
       (swap! (st cell) assoc
              :lifecycle :disconnected
-             :frame     nil
-             :deps      {}
-             :dep-order []
-             :evidence  nil
+             :bundle    nil
              :dirty     nil)
       (swap! pending-cells disj cell)
       (when interop/debug-enabled?
         (occurrences/forget! (occurrence-of cell)))
-      (release-all! (map :handle (vals (:deps s))))))
+      ;; `s` is the pre-swap snapshot, so this still reaches the handles the
+      ;; cell owned a moment ago.
+      (release-all! (map :handle (vals (:deps (:bundle s) {}))))))
   nil)

--- a/implementation/freehand/test/re_frame/freehand/shell_cljs_test.cljc
+++ b/implementation/freehand/test/re_frame/freehand/shell_cljs_test.cljc
@@ -134,6 +134,53 @@
             (is (every? :owned? (:observations (cell/evidence c)))
                 "and reports ownership honestly")))))))
 
+(deftest fh-sub-001-the-selected-render-is-one-bundle
+  (testing "Per FH-SUB-001 and Spec 006 §The selected render bundle: what a
+            commit publishes is ONE value, and each projection is a door onto
+            that value rather than a slot of its own.
+
+            The previous row proves the bundle becomes live TOGETHER. This
+            one proves there is only one thing to become live: held as four
+            independent slots, a cell could be left with three of them
+            agreeing and the fourth a render behind, and the frame in
+            particular had two homes — once at top level and once inside the
+            evidence it published. So the assertions here are about IDENTITY
+            and about the bundle's key set, not about equality: an equal copy
+            in a second slot is exactly the shape being ruled out."
+    (let [{:keys [a b]} (:queries sub-001)]
+      (rf/reg-sub (first a) (fn [db _] (:a db)))
+      (rf/reg-sub (first b) (fn [db _] (:b db)))
+      (seed! fid (:db sub-001))
+      (let [c (cell/cell :shell/panel)]
+        (testing "before any render is selected there is no bundle at all"
+          (is (nil? (cell/evidence c)))
+          (is (nil? (cell/committed-frame c)))
+          (is (= {} (cell/dependencies c))
+              "and an absent bundle reads as an empty set rather than nil")
+          (is (= [] (cell/dependency-queries c))))
+        (is (= :published (render+commit! c fid [a b])))
+        (let [bundle (cell/evidence c)]
+          (testing "the selected commit published exactly one bundle"
+            (is (= #{:frame :generation :deps :dep-order :observations}
+                   (set (keys bundle)))
+                "the frame, the dependency set, the render order and the
+                 observations are ONE value"))
+          (testing "and every door reads through THAT value"
+            (is (identical? (:deps bundle) (cell/dependencies c))
+                "the dependency map is the bundle's own, not a copy of it")
+            (is (= fid (:frame bundle) (cell/committed-frame c)))
+            (is (= [a b] (cell/dependency-queries c)))
+            (is (= (mapv :query (:observations bundle))
+                   (cell/dependency-queries c))
+                "so the render order, the dependency map and the observations
+                 cannot disagree about what this render read")))
+        (testing "and dropping the one slot is the whole disownership"
+          (cell/disconnect! c)
+          (is (nil? (cell/evidence c)))
+          (is (nil? (cell/committed-frame c)))
+          (is (= {} (cell/dependencies c)))
+          (is (= [] (cell/dependency-queries c))))))))
+
 (deftest fh-sub-001-an-unchanged-site-is-retained-untouched
   (testing "Per FH-SUB-001: the commit kept-check retains an unchanged
             live handle UNTOUCHED — the same handle object, no


### PR DESCRIPTION
Ships both costed ViewCell memory levers from **rf2-9f1s7**, together, as the ruling directs.

## Lever 1 — the selected render is ONE value

The cell's state map held `:frame`, `:deps`, `:dep-order` and `:evidence` as four independent slots. They are now one `:bundle`.

This is not "a smaller map" — it is the model Spec 006 §The selected render bundle already describes, and the one `commit!`'s own docstring already claims: *"ONE publication … dependencies, frame and evidence become live in a single write"*. The state now says it too. Four slots could be left three-agreeing and one a render behind; there is no such shape any more. It also gives the frame back its single home — the cell used to hold it at top level **and** again inside the evidence it published.

`committed-frame`, `dependencies`, `dependency-queries` and `evidence` remain the projection doors, now reading *through* the one value rather than through slots of their own, so they cannot disagree with it or with each other.

The authority `:generation` deliberately stays **top-level**. It is the cell's current *body authority*, which `advance-generation!` moves on hot reload before any render commits against it; the bundle's `:generation` is the generation of the last *selected* commit. They are allowed to differ, and that difference is exactly what `current?` tests.

Eleven keys made the state map a `PersistentHashMap`; eight make it a `PersistentArrayMap`.

## Lever 2 — the observations vector is not a transient

`commit-readings` answered `(persistent! obs)` over a `(transient [])`. `persistent!` hands back a vector still holding the editable root the transient cloned — a `VectorNode` over a 32-slot array — where `conj` onto a tail-only vector shares `PersistentVector.EMPTY`'s root and allocates no node at all.

A transient is the right tool for a large accumulator thrown away at the end. This one is small and then **lives**, for as long as the boundary is mounted, inside the bundle.

The staged-dependency transient in `stage!` is deliberately **kept**: it is a value under construction nothing else can reach, it was measured at a fifth of the observations vector's cost, and a boundary with hundreds of dependencies is the shape it is right for.

## Measured — retained heap

**Runtime: headless Chromium 147 via Playwright, `:advanced` ClojureScript bundle, `goog.DEBUG false`, 6 rounds, 10 roots × 300 boundaries.** Reader A is CDP `Runtime.getHeapUsage` after a forced collection; reader C is a full heap snapshot with every node's `self_size` summed — an independent instrument, not a second door onto the same counter. Bytes per boundary, ranges across rounds in brackets.

Three builds, so each lever is attributed rather than apportioned:

| arm | baseline | lever 1 only | both levers |
|---|---:|---:|---:|
| `storm/freehand` (reads nothing) | 2681 [2670–2703] | 2483 [2472–2499] | **2250 [2238–2267]** |
| `reactive/freehand` (reads one sub) | 4635 [4620–4645] | 4464 [4434–4479] | **4293 [4278–4303]** |
| `storm/floor` — *control* | 244 [240–245] | 243 [241–245] | 244 [241–245] |
| `storm/reagent` — *control* | 655 [647–660] | 655 [647–661] | 655 [647–662] |
| `storm/uix` — *control* | 495 [488–499] | 496 [488–500] | 495 [489–500] |
| `reactive/floor` — *control* | 244 [240–246] | 244 [240–246] | 244 [240–246] |
| `reactive/reagent` — *control* | 1282 [1275–1285] | 1282 [1278–1285] | 1282 [1278–1286] |

Every range on the two Freehand arms is **disjoint** from its neighbours. Every untouched control arm is flat to the byte across all three builds — Reagent reads 655 and 1282 in all three — which is what says the movement is this change and nothing else.

**Per lever, boundary that reads nothing** (the arm the bead priced):

| lever | reader A | reader C | bead |
|---|---:|---:|---:|
| 1 — the state map's key count | **198 B** | 195 B | 193 B [189–204] |
| 2 — the observations transient | **233 B** | 230 B | 231 B [226–235] |
| together | **431 B** | 425 B | 424 B |

Both land inside the bead's ranges, on two independent readers agreeing to within 5 B. Nothing has drifted.

**Per lever, boundary that reads one sub:** lever 1 **171 B**, lever 2 **171 B**, together **342 B**. Lever 2 returning less on a boundary that reads is exactly what the bead predicted from its own second probe (172 B [168–178] at four observations) — it is the editable root, and the wider the vector the less that root costs relative to the tail.

Ratio to Reagent above the shared in-run React floor: **5.93× → 4.88×** sub-free (the bead projected 5.86× → 4.85×), **4.23× → 3.90×** reactive.

## Measured — the other side of the trade

Lever 2 buys retention with render-leg throughput, so the broad row is the half that could falsify it. **B6 production broad row, same runtime, 6 rounds, ratio to the in-run React floor**, chronological:

| run | FH-interpreted | reagent — *untouched control* | FH ÷ reagent |
|---|---:|---:|---:|
| BASELINE-1 (pre-lever) | 23.92 [19–41] | 3.00 [2–5] | 7.97 |
| AFTER-1 (both levers) | 28.75 [17–36] | 3.33 [2–4] | 8.63 |
| AFTER-2 (both levers) | 33.08 [17.5–41] | 4.08 [2.5–5] | 8.10 |
| BASELINE-2 (pre-lever, re-run last) | 33.08 [19.5–39] | 4.08 [2.5–5] | 8.10 |

Read naively, the first two rows look like a 20% regression. They are not. **The Reagent arm contains no Freehand code and cannot be affected by `cell.cljc`, and it rose by the same fraction** (3.00 → 4.08, +36%, against Freehand's +38%). So the pre-lever code was re-measured **last**, under the drifted machine — and it reads **33.08, identical to the levered build measured immediately before it**, on every arm.

Measured back-to-back under one machine state, the two conditions are **indistinguishable**. All ranges overlap heavily in every pairing. The bead's falsification condition — *"if the B6 broad row regresses beyond noise, revert the lever-2 half"* — is **not met**. This row cannot resolve an effect of this size, and says so honestly rather than banking a mean.

Mount and narrow rows moved the same way and overlap identically; no row resolves an effect.

## What is untouched

**Spec 006 invariant 5 is not weakened, and the commit-side re-read is not touched.** The currency re-check `(if-not (current? cand @(st owner-cell)) …)`, the `moved?` comparison over every acquired handle, `advance-revision!`, and all three rollback guards are byte-identical. Lever 2 changes the accumulator that `commit-readings` collects into and nothing about what it reads or compares. No spec change; `spec/**` untouched.

## Proof

Lever 1 is behaviourally observable and has a new row, `fh-sub-001-the-selected-render-is-one-bundle`, asserting **identity** rather than equality — the bundle's key set, and that `dependencies` answers the bundle's own map rather than a copy. Both halves were mutation-proved: reverting `evidence` to the pre-lever published shape fails it on the key set *and* on `identical?`, and dropping the empty-set default fails it on both empty assertions (and takes an existing invariant-5 staged-site row with it, which is what says that contract is load-bearing).

**Lever 2 is deliberately not asserted, because it is not observable.** Both shapes are value-equal persistent vectors. That was verified rather than assumed: reverting lever 2 alone leaves the whole suite green (0 failures). Its proof is the heap probe above, not a test — stating that is more honest than inventing an assertion that would pass either way.

## Quality gates

| gate | result | exit |
|---|---|---:|
| `implementation/freehand` JVM — `clojure -M:test` | 1284 tests, **8803 assertions, 0 failures, 0 errors** | 0 |
| `npm run test:browser` | 841 tests, **5459 assertions, 0 failures, 0 errors** | 0 |
| `npm run test:browser-prod-elision` | 120 tests, 527 assertions, 0 failures, 0 errors; `ui mounted production elision: PASS` | 0 |
| `scripts/test-freehand-prod-gate.sh` | **137 of 137 namespaces, 0 excluded as known-red**; 1286 tests, 8574 assertions, 0 failures, 0 errors | 0 |
| mutation A — `evidence` reverted to the pre-lever shape | new row **fails** (key set + `identical?`), 13 failures | 1 |
| mutation B — `dependencies` empty-set default dropped | new row **fails** on both empty assertions, 6 failures | 1 |
| mutation C — lever 2 reverted | suite **green**, confirming lever 2 is not observable | 0 |

The prod-gate lane's roster is still **empty**; it reads 137 of 137 rather than the 135 of 135 recorded earlier because `main` has grown two namespaces since. Not a regression.

Anything heavier than the above is deferred to CI.

Closes rf2-9f1s7.
