### PR TITLE
ci: the navigation ceiling names itself, and a Maven 403 is not mistaken for a diff (rf2-bhjzn, rf2-vm036)

### DIFF
--- a/.github/scripts/resolve-clojure-deps.sh
+++ b/.github/scripts/resolve-clojure-deps.sh
@@ -45,6 +45,35 @@
 # useless one. If resolution succeeds and the suite then fails, that failure
 # stands, first time, unretried.
 #
+# And, since the merged-PR audit of #7132, not every resolution failure either.
+# The first cut retried EVERY nonzero exit and then annotated it categorically
+# as "INFRASTRUCTURE, not this diff" — which is a lie for the failures a diff
+# owns. Driven locally against the real resolver, a nonexistent coordinate and
+# a malformed `deps.edn` each earned three attempts, 45s of sleeping, and an
+# annotation telling the author to re-run a deterministic failure and to look
+# away from their own change. That is worse than no annotation: it is a
+# confident wrong answer, and this script exists precisely because a confident
+# wrong answer about a dependency failure costs diagnosis time.
+#
+# So the output is CLASSIFIED, and the classification is deliberately narrow —
+# a short, explicit list of transport signatures, matched or not matched:
+#
+#   MATCHED    the failure is a fault of the network path to the repository.
+#              Retry (a throttle window may clear), and if it survives all
+#              attempts, name it as infrastructure AND quote the signature that
+#              earned that verdict, so the reader can check the reasoning
+#              instead of trusting the label.
+#
+#   UNMATCHED  say so, and say only that. No retry — a bad coordinate resolves
+#              exactly as badly the third time, so the 45s is pure waste — and
+#              no claim about whose fault it is beyond the honest one: nothing
+#              here looks like a transport fault, so read the resolver output.
+#
+# The bias is that an unrecognised transient fault degrades to "we do not know"
+# rather than to "not your diff". Widening the list when a new signature is
+# actually observed is the intended maintenance; guessing at signatures that
+# have never been seen is not.
+#
 # This mirrors `install-clojure-cli.sh`, the repo's existing single owner of
 # "transient network failure in CI setup reds a job before any test runs"
 # (rf2-9sgj8 / rf2-e7ja9) — same class of fault, one layer further down the
@@ -65,16 +94,43 @@ set -euo pipefail
 
 attempts=3
 
+log="$(mktemp)"
+trap 'rm -f "$log"' EXIT
+
+# The transport signatures that earn a retry and the INFRASTRUCTURE verdict.
+# Every entry is a fault of the network path to the repository, never of a
+# coordinate: rate-limiting and throttling (the observed rf2-vm036 fault),
+# server-side errors, and connection-level breakage.
+#
+# `Error building classpath` and `Failed to read artifact descriptor` are
+# NOT here, deliberately. tools.deps prints them for every resolution failure
+# whatever the cause, so they discriminate nothing — matching on them is how
+# the first cut came to call a bad coordinate infrastructure.
+#
+# Nor is `Could not find artifact`: that is Maven's 404, which means the
+# coordinate is wrong, which means it belongs to the diff.
+TRANSIENT_SIGNATURES='status code: (403|408|429|5[0-9][0-9])|Too Many Requests|Service Unavailable|Bad Gateway|Gateway Time-?out|ArtifactTransportException|MetadataTransportException|Connect(ion)? (reset|refused|timed out)|Read timed out|SocketTimeoutException|ConnectTimeoutException|UnknownHostException|NoRouteToHostException|Premature end of Content-Length|Remote host terminated the handshake|Broken pipe'
+
 for attempt in 1 2 3; do
-  if clojure -P "$@"; then
+  # `tee` so the resolver's own output still streams into the CI log live —
+  # the classification reads a copy, it does not replace what a human sees.
+  if clojure -P "$@" 2>&1 | tee "$log"; then
     exit 0
   fi
+
+  signature="$(grep -m1 -E -o "$TRANSIENT_SIGNATURES" "$log" || true)"
+
+  if [ -z "$signature" ]; then
+    echo "::error title=Dependency resolution failed — no transient transport signature::\`clojure -P${*:+ $*}\` failed in $(pwd), and nothing in its output matches a known transient transport fault (rate-limiting, a 5xx, a dropped connection). A re-run is therefore unlikely to help, and this step is NOT claiming the cause is infrastructure. Read the resolver output above: a resolution failure that is not a transport fault is usually a dependency this change owns — a coordinate that does not exist, a malformed deps.edn, or an alias that is not defined (rf2-vm036)."
+    exit 1
+  fi
+
   if [ "$attempt" -lt "$attempts" ]; then
     delay=$((attempt * 15))
-    echo "Clojure dependency resolution attempt ${attempt}/${attempts} failed in $(pwd); retrying in ${delay}s"
+    echo "Clojure dependency resolution attempt ${attempt}/${attempts} failed in $(pwd) with a transient transport signature ('${signature}'); retrying in ${delay}s"
     sleep "$delay"
   fi
 done
 
-echo "::error title=Dependency resolution failed — INFRASTRUCTURE, not this diff::\`clojure -P${*:+ $*}\` failed ${attempts} times in $(pwd). This step only downloads dependencies; it runs no test and no server, so the cause is the dependency infrastructure, not the code under review. Maven Central returns 403 Forbidden to CI runners under concurrent load (rf2-vm036) and tools.deps reports it as 'Error building classpath'. Re-run the job."
+echo "::error title=Dependency resolution failed — INFRASTRUCTURE, not this diff::\`clojure -P${*:+ $*}\` failed ${attempts} times in $(pwd), every time with a transient transport signature ('${signature}') — a fault of the network path to the repository, not of any coordinate. This step only downloads dependencies; it runs no test and no server, so no code under review has executed. Maven Central returns 403 Forbidden to CI runners under concurrent load (rf2-vm036) and tools.deps reports it as 'Error building classpath'. Re-run the job."
 exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4615,9 +4615,11 @@ jobs:
       # reads like a code fault and cost real diagnosis time twice. With this
       # step the resolve is warm before the harness starts, and a genuine
       # resolution failure fails here, named, with an ::error:: annotation
-      # saying it is infrastructure. See the script for why caching (already
-      # configured above) was not the missing piece.
-      - name: Pre-resolve story-mcp classpath (a failure here is dependency infrastructure, not the diff)
+      # that says WHICH kind of failure it was — the script classifies the
+      # resolver output, and only a recognised transport signature earns the
+      # "infrastructure, re-run" verdict. See the script for why caching
+      # (already configured above) was not the missing piece.
+      - name: Pre-resolve story-mcp classpath (a failure here is dependency resolution, before any code runs)
         working-directory: tools/story-mcp
         run: "$GITHUB_WORKSPACE/.github/scripts/resolve-clojure-deps.sh"
 
@@ -4699,7 +4701,7 @@ jobs:
       # window clears inside the run instead of costing a re-run. Splitting the
       # resolve out also keeps the retry off the SUITE — the step below runs
       # exactly once, so a real test failure is never re-rolled.
-      - name: Pre-resolve wire-vocab classpath (a failure here is dependency infrastructure, not the diff)
+      - name: Pre-resolve wire-vocab classpath (a failure here is dependency resolution, before any code runs)
         run: "$GITHUB_WORKSPACE/.github/scripts/resolve-clojure-deps.sh -M:test"
 
       - name: Run JVM wire-vocab conformance gates

--- a/implementation/scripts/_impl-browser-runners-verdict-policy.test.cjs
+++ b/implementation/scripts/_impl-browser-runners-verdict-policy.test.cjs
@@ -18,7 +18,11 @@
  *      can never reach the failure tally (rf2-u0cy4);
  *   4. a navigation that inherited Playwright's default 30s `load` ceiling —
  *      a SECOND budget BROWSER_TEST_TIMEOUT_MS cannot reach, whose CI log
- *      line reads like the summary timeout it is not (rf2-dczpv).
+ *      line reads like the summary timeout it is not (rf2-dczpv), and which
+ *      turned out to be a CLASS rather than one site: run-ui-g8.cjs had the
+ *      same defect one file over (rf2-bhjzn). Pinned as a SWEEP over every
+ *      runner in this directory, so the next `page.goto` cannot reintroduce
+ *      it.
  *
  * Both are pinned statically for the same reason: these runners drive a
  * headless Chromium end-to-end, so their verdict paths are not cleanly
@@ -304,6 +308,106 @@ test('tenant-switcher-testbed: a captured pageerror fails the spec even when ass
   assert.ok(
     throwIdx < passedIdx,
     'the pageerror fatal check must precede `passed = true`',
+  );
+});
+
+// ---- the navigation-ceiling sweep (rf2-dczpv → rf2-bhjzn) ----
+//
+// rf2-dczpv fixed one `page.goto` that inherited Playwright's 30s default;
+// rf2-bhjzn found the identical defect in run-ui-g8.cjs, which passed no
+// options at all. Two instances is a class, so this is pinned by SWEEP rather
+// than by naming files: every `page.goto` in this directory must carry its own
+// explicit `timeout:`, tied to the lane's own budget.
+//
+// Why it needs a static pin: the ceiling is DORMANT in a healthy tree —
+// navigation normally completes in milliseconds — so ordinary CI would never
+// notice a new bare `goto` until a loaded runner turned it into a flake whose
+// log line names the wrong budget.
+
+test('every runner navigation carries an EXPLICIT timeout, never Playwright\'s 30s default (rf2-dczpv, rf2-bhjzn)', () => {
+  const runners = fs
+    .readdirSync(SCRIPTS_DIR)
+    .filter((f) => f.endsWith('.cjs') && !f.startsWith('_'));
+  assert.ok(runners.length > 0, 'the sweep must actually find runners to check');
+
+  // Whole-line comments only. A `//` mid-line would truncate the very
+  // `http://…` URLs these calls navigate to, taking the `timeout:` with it.
+  const codeOnly = (src) => src
+    .split('\n')
+    .filter((line) => !/^\s*(\/\/|\*|\/\*)/.test(line))
+    .join('\n');
+
+  const offenders = [];
+  let navigations = 0;
+  for (const file of runners) {
+    const src = codeOnly(read(file));
+    for (let i = src.indexOf('.goto('); i !== -1; i = src.indexOf('.goto(', i + 1)) {
+      navigations += 1;
+      // The call's arguments, bounded — long enough to span a multi-line
+      // options object, short enough not to reach an unrelated `timeout:`.
+      const call = src.slice(i, i + 300);
+      if (!/\btimeout:/.test(call)) {
+        offenders.push(`${file}: ${call.split('\n')[0].trim()}`);
+      }
+    }
+  }
+
+  assert.ok(navigations > 0, 'the sweep must actually find navigations to check');
+  assert.deepEqual(
+    offenders,
+    [],
+    'page.goto must pass an EXPLICIT timeout tied to the lane\'s own budget. ' +
+      'Without one Playwright applies a 30s default that no lane budget can ' +
+      'reach, and whose CI failure line reads like the lane timeout it is not',
+  );
+});
+
+// ---- run-ui-g8.cjs (rf2-bhjzn) ----
+
+test('run-ui-g8: navigation has its own named ceiling, and does not wait on `load` (rf2-bhjzn)', () => {
+  const src = read('run-ui-g8.cjs');
+  // `load` cannot fire until the un-optimized :ui-g8 bundle has arrived AND
+  // run its synchronous portion — which is where the fixture's warm-up and
+  // sample collection live. Waiting for it is waiting for the fixture, which
+  // is the waitForFunction poll's job against TIMEOUT.
+  assert.match(
+    src,
+    /NAV_WAIT_UNTIL\s*=\s*'commit'/,
+    "the G-8 navigation must commit, not wait on `load` — `load` waits for the fixture",
+  );
+  assert.match(
+    src,
+    /NAV_TIMEOUT\s*=\s*TIMEOUT\b/,
+    'the navigation budget must be the gate\'s own TIMEOUT, so the lane has ONE number',
+  );
+  assert.match(
+    src,
+    /page\.goto\([\s\S]{0,400}?catch[\s\S]{0,600}?NAVIGATION FAILED/,
+    'a failed navigation must name itself as the navigation ceiling, not the fixture-result budget',
+  );
+});
+
+// ---- check-story-static.cjs navigation ceiling (rf2-bhjzn) ----
+
+test('check-story-static: the navigation budget is named, not a bare literal (rf2-bhjzn)', () => {
+  const src = read('check-story-static.cjs');
+  // This smoke always passed an explicit timeout, so it never INHERITED the
+  // default — but the literal 30000 sat beside a READY_TIMEOUT_MS of 30000,
+  // two different budgets printing one number.
+  assert.match(
+    src,
+    /const\s+NAV_TIMEOUT_MS\s*=/,
+    'the navigation budget must be a named constant, distinct from READY_TIMEOUT_MS',
+  );
+  assert.doesNotMatch(
+    src,
+    /page\.goto\([^)]*timeout:\s*\d/,
+    'the navigation timeout must not be an anonymous numeric literal',
+  );
+  assert.match(
+    src,
+    /page\.goto\([\s\S]{0,300}?catch[\s\S]{0,600}?NAVIGATION FAILED/,
+    'a failed navigation must say which of the two 30000ms budgets fired',
   );
 });
 

--- a/implementation/scripts/check-story-static.cjs
+++ b/implementation/scripts/check-story-static.cjs
@@ -69,6 +69,24 @@ const HTTP_SERVER_BIN = require.resolve('http-server/bin/http-server', {
 });
 const DEFAULT_PORT = 8040;
 const READY_TIMEOUT_MS = 30000;
+
+// rf2-bhjzn — the navigation's own ceiling, named rather than left a literal.
+//
+// Unlike run-ui-g8.cjs this smoke never INHERITED Playwright's default: it
+// always passed an explicit `timeout: 30000`. But an unnamed 30000 sitting
+// beside a READY_TIMEOUT_MS that is also 30000 is its own trap — the two are
+// different budgets (owned-http-server readiness vs. the navigation) printing
+// the same number, so `page.goto: Timeout 30000ms exceeded` in a CI log points
+// at the wrong one. Named here, and the failure below says which fired.
+//
+// `waitUntil: 'load'` is KEPT deliberately. This page is a static export whose
+// script does not run a suite during load, and the assertions that follow have
+// short budgets of their own (a 15s wait for `story-canvas-empty`, then 5s
+// waits) which assume a loaded document. Switching to `'commit'` the way
+// rf2-dczpv/rf2-bhjzn did for the two suite-running runners would move the
+// bundle download-and-boot wait onto that 15s locator budget and make this
+// lane FLAKIER, not tighter.
+const NAV_TIMEOUT_MS = 30000;
 const POLL_MS = 200;
 const VERBOSE_TESTS = isVerboseTests();
 const diagnostics = createDiagnosticBuffer();
@@ -228,7 +246,19 @@ async function smokeTest(baseUrl, diagnostics) {
   });
 
   try {
-    await page.goto(baseUrl, { waitUntil: 'load', timeout: 30000 });
+    try {
+      await page.goto(baseUrl, { waitUntil: 'load', timeout: NAV_TIMEOUT_MS });
+    } catch (err) {
+      // rf2-bhjzn: name the ceiling that fired. This is the navigation's
+      // budget, not the server-readiness wait that carries the same number.
+      diagnostics.add(
+        `NAVIGATION FAILED — this is the page.goto ceiling ` +
+          `(waitUntil: 'load', timeout: ${NAV_TIMEOUT_MS}ms), NOT the ` +
+          `${READY_TIMEOUT_MS}ms owned-http-server readiness wait, which had ` +
+          `already succeeded. No assertion ran (rf2-bhjzn).`,
+        'stderr');
+      throw err;
+    }
 
     // The shell renders its empty-state canvas ("No variant selected" +
     // a pick-from-the-sidebar hint) when no variant / workspace is selected.

--- a/implementation/scripts/run-ui-g8.cjs
+++ b/implementation/scripts/run-ui-g8.cjs
@@ -57,6 +57,37 @@ const DEV = path.join(OUT, 'ui-g8');
 const REPORT = path.join(OUT, 'ui-g8.json');
 const TIMEOUT = 90000;
 
+// rf2-bhjzn — the gate's OTHER ceiling, now named and disarmed. Same class
+// rf2-dczpv removed from run-browser-tests.cjs, one file over.
+//
+// `page.goto(url)` was called with no options at all, so it took BOTH of
+// Playwright's defaults: `waitUntil: 'load'` AND a 30s timeout. That 30s is a
+// second budget on this gate, entirely separate from TIMEOUT above — and the
+// very next line already passes TIMEOUT explicitly to `waitForFunction`, so the
+// file already knew the pattern. Nothing named the ceiling, which is the part
+// that costs money: a `page.goto: Timeout 30000ms exceeded` line in a CI log
+// reads like this gate's own budget, so the fix reached for is a bigger
+// TIMEOUT, which cannot touch it.
+//
+// `'load'` is the WRONG event to wait on here, not merely a tight one. It
+// cannot fire until `main.js` — an un-optimized `:ui-g8` dev bundle — has both
+// arrived and run its synchronous portion, and the fixture's warm-up and
+// RECORDED_SAMPLES collection happen inside that window. Waiting for `load` is
+// waiting for the fixture, which is the `waitForFunction` poll's job, against
+// the budget documented for it.
+//
+// Demonstrated both ways with `load` held 35s against this exact page shape
+// (rf2-bhjzn): a bare `page.goto(url)` dies at 30082ms — with TIMEOUT sitting
+// unused at 90000ms — whether the delay is a slow subresource or a synchronous
+// burn during load; `'commit'` with an explicit timeout passes at ~35s in both.
+//
+// `'commit'` resolves as soon as the response is received, which no page script
+// can delay, and everything this runner does afterwards (`waitForFunction`,
+// `page.evaluate`) auto-waits on the execution context by itself. A genuine
+// server-not-listening failure still fails — at the navigation, naming itself.
+const NAV_WAIT_UNTIL = 'commit';
+const NAV_TIMEOUT = TIMEOUT;
+
 // The two real engines. Chromium AND WebKit are both mandatory (EP-0035): the
 // IME composition, caret-on-restore, and paint scheduling under test differ by
 // engine, and jsdom fakes none of them.
@@ -297,7 +328,19 @@ async function driveEngine(name, url) {
     const page = await browser.newPage();
     const pageErrors = [];
     page.on('pageerror', (e) => pageErrors.push(e.stack || String(e)));
-    await page.goto(url);
+    try {
+      await page.goto(url, { waitUntil: NAV_WAIT_UNTIL, timeout: NAV_TIMEOUT });
+    } catch (err) {
+      // rf2-bhjzn: name the ceiling that actually fired. `page.goto: Timeout
+      // …ms exceeded` and this gate's own fixture-result timeout are two
+      // different budgets that read alike in a CI log.
+      fail(
+        `[${name}] NAVIGATION FAILED — this is the page.goto ceiling ` +
+          `(waitUntil: '${NAV_WAIT_UNTIL}', timeout: ${NAV_TIMEOUT}ms), NOT the ` +
+          `${TIMEOUT}ms wait for __RF2_G8_RESULT__. The fixture was never ` +
+          `observed, so no result and no matrix verdict exist to read. Raising ` +
+          `TIMEOUT will not help (rf2-bhjzn). Underlying: ${err.message}`);
+    }
     await page.waitForFunction(
       () => globalThis.__RF2_G8_RESULT__ || globalThis.__RF2_G8_ERROR__,
       null, { timeout: TIMEOUT });


### PR DESCRIPTION
Two CI failure modes that cost diagnosis time rather than correctness. Both were
**demonstrated before being fixed** — a ceiling you cannot show yourself hitting
is a ceiling you cannot show you moved.

## rf2-bhjzn — the G-8 navigation ceiling

`run-ui-g8.cjs:300` called `page.goto(url)` with **no options at all**, so it
took both of Playwright's defaults: `waitUntil: 'load'` and a 30s timeout. That
30s is a second budget on the gate, separate from its own `TIMEOUT = 90000` —
which the very next line already passes explicitly to `waitForFunction`. Same
defect rf2-dczpv removed from `run-browser-tests.cjs` (#7193) one file over, and
the reasoning transfers: `'load'` cannot fire until `main.js` — an un-optimized
`:ui-g8` dev bundle — has both arrived and run its synchronous portion, which is
where the fixture's warm-up and `RECORDED_SAMPLES` collection live.

Demonstrated against the exact two-line document `writePage` emits, with `load`
held 35s (inside the gate's 90s budget, outside Playwright's 30s default), by
each of the two mechanisms that can hold it here:

| scenario | arm | result |
|---|---|---|
| slow subresource | `page.goto(url)` (today) | **+30082ms FAIL** `page.goto: Timeout 30000ms exceeded.` |
| slow subresource | `commit` + `timeout: TIMEOUT` | +35097ms PASS |
| sync burn during load | `page.goto(url)` (today) | **+30080ms FAIL** `page.goto: Timeout 30000ms exceeded.` |
| sync burn during load | `commit` + `timeout: TIMEOUT` | +35087ms PASS |

Raising `TIMEOUT` moves neither FAIL arm. That is the point, and why a failed
navigation now prints **which** of the two ceilings fired.

Two instances is a class, so the pin is a **sweep**: every `page.goto` under
`implementation/scripts/` must carry an explicit `timeout:`. It needs to be
static because the ceiling is dormant in a healthy tree — navigation normally
completes in milliseconds, so ordinary CI would never notice a fourth site
appearing. Every existing site passes it; only `run-ui-g8.cjs` did not.

`check-story-static.cjs` was the third site the bead flagged, and the decision
there is **different**. It never inherited the default — it always passed
`timeout: 30000` — so `'load'` stays: that page is a static export whose script
runs no suite during load, and the assertions after it have short budgets of
their own (15s, then 5s) that assume a loaded document. Switching it to
`'commit'` would move the bundle boot onto the 15s locator budget and make the
lane **flakier**, not tighter. What was wrong was the anonymous `30000` sitting
beside a `READY_TIMEOUT_MS` that is also `30000` — two different budgets
printing one number. Named, and its failure now says which one fired.

Nine more sites outside this worker's fence (`freehand` benches, `tools/**`, the
UIx testbed) still inherit the default — filed as **rf2-taj9b** with per-file
evidence rather than reached for here. The sharp end is the freehand benches:
`b10_prod_run.cjs` already carries `{waitUntil:'commit', timeout:60000}`, which
is the tell that this ceiling was hit there before; its b6/b7/b8 siblings never
got the same treatment.

## rf2-vm036 — a Maven 403 is infrastructure; a bad coordinate is not

The pre-resolution wrapper landed in #7132 retried **every** nonzero `clojure -P`
exit and then annotated it categorically as `INFRASTRUCTURE, not this diff`. The
merged-PR audit on the bead caught what that costs: a deterministic, diff-owned
failure gets three attempts, 45s of sleeping, and a CI annotation telling the
author to re-run it and to look away from their own change.

Demonstrated against the real resolver. A local HTTPS repo answering 403 to
everything, with the JVM given its cert so a **real** 403 comes back through the
real Aether transport — the first attempt at this demo used plain `http://`,
which tools.deps refuses outright as a config error and which therefore proved
nothing. Beside it, a nonexistent coordinate and a malformed `deps.edn`:

| case | before | after |
|---|---|---|
| real 403 | 47s, `INFRASTRUCTURE, not this diff … Re-run the job.` | 48s, retried 3x, signature `status code: 403`, `INFRASTRUCTURE, not this diff … Re-run.` |
| nonexistent coordinate | 55s, `INFRASTRUCTURE, not this diff … Re-run the job.` | **2s**, `no transient transport signature` |
| malformed `deps.edn` | 47s, `INFRASTRUCTURE, not this diff … Re-run the job.` | **0s**, `no transient transport signature` |

Three different causes, one verdict, verbatim — and two of the three wrong.

The output is now classified against a short, explicit list of transport
signatures (rate-limiting, 5xx, connection-level breakage). **Matched**: retry,
and if it survives all attempts, name it infrastructure *and quote the signature
that earned the verdict*, so a reader can check the reasoning instead of
trusting the label. **Unmatched**: no retry — a bad coordinate resolves exactly
as badly the third time — and no claim about whose fault it is beyond the honest
one.

`Error building classpath` and `Failed to read artifact descriptor` are excluded
from the list on purpose: tools.deps prints them for *every* resolution failure
whatever the cause, so they discriminate nothing, and matching on them is how
the first cut came to call a bad coordinate infrastructure. The 403 arm proves
it — its headline line **is** `Failed to read artifact descriptor`, and the
`status code: 403` that makes it transient sits further down the captured
output.

Not a retry framework, and no new dependency caching: the bead's cheapest
hypothesis (caching missing on these lanes) was already disproved in #7132 —
all three MCP conformance jobs restore `~/.m2` + `~/.gitlibs` + `~/.deps.clj`,
and a cache *miss* is exactly when the lane must go to Central. The bias is that
an unrecognised transient fault degrades to "we do not know" rather than to "not
your diff"; widening the list when a new signature is actually observed is the
intended maintenance.

No `TESTING.md` entry: the annotation now appears in the CI log at the point of
failure, which beats a recognition rule a reader has to remember to look up.

## Does any currently-passing lane change behaviour?

**No.** G-8 navigates a small local fixture that commits in milliseconds and the
ceiling has never been observed firing there; what changes is the failure it
would produce under load. The resolver's happy path still exits 0 silently
(verified), and a genuine transient failure still gets the same three attempts
and the same verdict. The only behaviour change on a *failing* lane is that a
diff-owned resolution failure now fails 45s sooner and stops claiming to be
someone else's problem. The two workflow step names claimed the same thing the
annotation did, so they now say "dependency resolution, before any code runs" —
the part that is true of every failure there.

## Quality gates

Run to completion in the worker worktree, foreground, unpiped.

| gate | exit |
|---|---|
| `npm run test:script-policy` (the lane changed; 28 policy suites incl. the extended `_impl-browser-runners-verdict-policy`) | **0** |
| `node --check implementation/scripts/run-ui-g8.cjs` | **0** |
| `node --check implementation/scripts/check-story-static.cjs` | **0** |
| `node --check implementation/scripts/_impl-browser-runners-verdict-policy.test.cjs` | **0** |
| `bash -n` over `git ls-files '.github/scripts/*.sh'` | **0** |
| `python -c yaml.safe_load(.github/workflows/test.yml)` — 69 jobs | **0** |
| rf2-bhjzn demonstration (4 arms, real Chromium) | **0** — reproduced at +30082/+30080ms, fixed arms pass |
| rf2-vm036 demonstration (real HTTPS 403 + 2 deterministic cases, real resolver) | **0** — before/after table above |
| rf2-vm036 resolver happy path (`clojure -P`, valid `deps.edn`) | **0**, silent, no annotation |
| classifier regex vs. the recorded incident strings from #7117 / #7123 | matches `status code: 403`, `ArtifactTransportException`; does **not** match `Could not find artifact`, `Error building classpath`, `Failed to read artifact descriptor` |

`shellcheck` is not installed on this Windows box, so the `.github/scripts/*.sh`
shellcheck in `portability.yml` is **deferred to CI**; the edit keeps the loop
form already proven clean there (`for attempt in 1 2 3`) and adds no construct
outside it. The G-8 gate itself, the story-static smoke and the MCP conformance
lanes are likewise deferred to CI — each needs a cold shadow-cljs compile or a
live Central, and the mechanisms they would exercise are demonstrated directly
above.
