### PR TITLE
bench: arm order cannot contaminate a reported figure (rf2-88pie, rf2-vxfjt)

### DIFF
--- a/docs/design/freehand/studio/bulk-rerender-where-the-time-goes.md
+++ b/docs/design/freehand/studio/bulk-rerender-where-the-time-goes.md
@@ -402,6 +402,133 @@ window and does not belong in a re-take.
 
 ---
 
+## 7. The yield-free re-take, 2026-07-28 — the yield stays (`rf2-vxfjt`)
+
+Measured on `worker/bench-method-88pie` off `origin/main` with
+`b6_yield_app`, riding `b6_prod_run.cjs`'s `B6_INIT_FN` seam so the
+driver, the arms and the fixture are the published ones.
+**Chromium 147 headless via Playwright, `:advanced`, `goog.DEBUG false`.
+Six rounds of 3 warm-up + 8 samples; three windows and five arms
+interleaved at the sample level, the window rotating and the arm order
+rotating *and reflecting* (`rf2-88pie`).** Ranges are across rounds.
+
+Three windows, differing only in how the write reaches React:
+
+| | shape |
+|---|---|
+| `yield` | the published one — `write`, one microtask, the arm's drain |
+| `no-yield` | the literal ablation — `write`, the arm's drain |
+| `in-flush` | `flushSync(write)`, then the arm's drain |
+
+### The non-vacuity gate, before any figure
+
+Every arm, every shape, a value no other write installs, read back out of
+the DOM.
+
+| arm | `flushSync(write)` alone | `no-yield` | `in-flush` | `yield` |
+|---|---|---|---|---|
+| floor | no *(by construction)* | **yes** | **yes** | **yes** |
+| freehand-interpreted | yes | **NO** | **yes** | **yes** |
+| freehand-compiled | yes | **NO** | **yes** | **yes** |
+| reagent | no *(by construction)* | **yes** | **yes** | **yes** |
+| `floor+spin` (control) | no *(by construction)* | **yes** | **yes** | **yes** |
+
+The floor and Reagent answer `no` to the first column because their
+`write!` only moves a plain atom — their render lives in `force!` — and
+that is the shape of the arm, not a failure.
+
+### The answer
+
+**Deleting the microtask and changing nothing else is not available.**
+Across both rows, **2,772 writes of 20,790 failed their read-back, and
+every one of them is a Freehand arm in the `no-yield` window**: 66 of 66
+per arm on the broad row, 1,320 of 1,320 per arm on the narrow one, and
+**0 of 66 / 0 of 1,320 in every other one of the fifteen (arm, window)
+cells**. The write sits outside any flush, so #7133's closer never fires,
+the empty `flushSync` after it has nothing to commit, and the clock stops
+on the old value.
+
+| broad, p50 ms/write | `yield` | `no-yield` | `in-flush` |
+|---|---:|---:|---:|
+| floor | 0.1 [0.1–0.2] | 0.1 [0.1–0.2] | 0.2 [0.1–0.2] |
+| **freehand-interpreted** | **3.5** [3.2–4.3] | *0.7* [0.6–0.8] ✗ | **3.5** [3.4–4.7] |
+| **freehand-compiled** | **3.1** [3.0–3.8] | *0.6* [0.6–0.8] ✗ | **3.2** [3.0–3.8] |
+| reagent | 0.4 [0.3–0.5] | 0.4 [0.3–0.5] | 0.3 [0.3–0.5] |
+| `floor+spin` control | 2.1 [2.1–2.1] | 2.1 [2.1–2.1] | 2.1 [2.0–2.1] |
+
+✗ = every write in that cell failed the DOM read-back. **A 5× "speed-up"
+that is the commit landing outside the measured window** — §6 predicted
+exactly this, and it is the fault `b6-rows` records from this row's first
+attempt.
+
+**And the yield-free window that DOES verify buys nothing.** `in-flush`
+reads 3.5 [3.4–4.7] against the published 3.5 [3.2–4.3] on interpreted
+Freehand and 3.2 [3.0–3.8] against 3.1 [3.0–3.8] on compiled —
+**overlapping ranges on every arm, so indistinguishable**. The legs say
+where it went: interpreted Freehand's published window is write 0.6–0.8
+plus gap 2.5–3.2, and `in-flush` is write 3.4–4.7 plus gap 0.0. Same
+work, third re-attribution. `rf2-huhno`'s hoped-for tightening does not
+exist, and #7133's extra commit pass is inside that window and not
+separable from it here.
+
+**So the yield stays**, and `b6-rows`' docstring, its published
+`:measurement-method` string and `b6_update_dom_cljs_test`'s namespace
+docstring have all stopped calling it removable.
+
+### The narrow row is the caution
+
+| narrow, p50 ms per 20-write sample | `yield` | `no-yield` | `in-flush` |
+|---|---:|---:|---:|
+| floor | 1.7 [1.6–2.2] | 1.6 [1.5–2.0] | 1.7 [1.5–1.9] |
+| **freehand-interpreted** | **9.7** [8.9–11.5] | *7.9* [7.5–9.9] ✗ | **10.8** [9.5–11.8] |
+| **freehand-compiled** | **10.8** [9.0–11.8] | *7.2* [6.0–7.8] ✗ | **11.5** [10.6–13.1] |
+| reagent | 1.0 [1.0–1.1] | 1.0 [0.9–1.3] | 1.1 [1.0–1.2] |
+| `floor+spin` control | 41.1 [40.8–41.8] | 41.2 [40.7–41.7] | 41.1 [40.8–41.9] |
+
+On interpreted Freehand the invalid window's range **overlaps** the
+published one — 7.5–9.9 against 8.9–11.5. By this page's own rule that is
+indistinguishable, so **the clock would have accepted a window in which
+1,320 of 1,320 writes never reached the page. Only the DOM read-back
+caught it.**
+
+### The positive control
+
+`floor+spin` is the floor arm with a 2.0 ms CPU spin wrapped around its
+own drain, so its sample must read the floor's plus 2.0 ms *per write of
+the sample*.
+
+| | predicted | measured | error |
+|---|---:|---:|---:|
+| broad, `yield` | 2.1 ms | 2.1 | **0.0** |
+| broad, `no-yield` | 2.1 | 2.1 | **0.0** |
+| broad, `in-flush` | 2.2 | 2.1 | −0.1 (one clock quantum) |
+| narrow, `yield` | 41.7 | 41.1 | −0.6 (**−1.4%**) |
+| narrow, `no-yield` | 41.6 | 41.2 | −0.4 (−1.0%) |
+| narrow, `in-flush` | 41.7 | 41.1 | −0.6 (−1.4%) |
+
+The per-write factor is not decoration: the first run of this ablation
+predicted a flat +2.0 ms and read +39.1 on the narrow row, because a
+narrow sample is twenty writes. **The control caught the harness's own
+arithmetic**, which is what a control is for.
+
+### What this does not settle
+
+- **No re-take of the published figures.** Nothing above changes B6's
+  numbers; it establishes that the window they are taken through is the
+  only sound one.
+- **Chromium only, and per-write absolutes are this machine's.** Ratios
+  transfer, absolutes do not.
+- **UIx has no update arm**, so the ablation is four arms plus a control.
+- **The gate's own bug is on the record.** The first version of the
+  non-vacuity probe ran its shapes back to back with nothing between
+  them, and read `in-flush` as failing on both Freehand arms while the
+  measured `in-flush` window verified 660 of 660 writes. The probe now
+  settles — one microtask plus a drain — before each shape. A probe that
+  contradicts the measurement it gates is the probe's bug, and it is only
+  visible because both were run.
+
+---
+
 ## Appendix: the W1 interpreted-mount discrepancy, resolved
 
 Two numbers for "interpreted Freehand's W1 mount" were 57% apart and both

--- a/docs/design/freehand/studio/freehand-vs-reagent-allocation.md
+++ b/docs/design/freehand/studio/freehand-vs-reagent-allocation.md
@@ -401,10 +401,41 @@ fire on medians 20% apart whose ranges overlap, and catches the
 measured warm-up step — **which the bead's own proposed remedy would
 have missed**, because the predecessor never changes across it.
 
+### What it did on its first real run
+
+`B8_ROUNDS=4 node b8_run.cjs --kind narrow`, in this repository's own
+Chromium harness. **Exit 2. Two findings, neither of them adjacency.**
+
+- **The `instrument` arm reads 4,361 B/write in its first window and
+  440 B in its last** — 9.9×, on the pseudo-arm that installs no state
+  and drains nothing, whose entire purpose is to price the harness's own
+  footprint as a constant. Both factors caught it. It is the same warm-up
+  curve the plain-node sweep above shows, in the real harness, on real
+  data.
+- **`reagent` reads 24,050 B/write early and 30,307 late**, 1.26×.
+
+And the factor the bead named came out **clean on every substantive
+arm**:
+
+| arm | after `instrument/D=12500` | after `reagent/D=12500` | verdict |
+|---|---:|---:|---|
+| floor | 142,167 [141,682–142,652] | 146,232 [143,663–148,801] | within 25% |
+| freehand-interpreted | 171,870 [149,547–194,193] | 157,567 [152,056–163,078] | ranges overlap |
+
+Those predecessors are the ladder's **100 KB-per-write** windows — the
+large-object arms the bead says should double their successor. They do
+not move either arm past this instrument's noise. **The contaminant on
+this surface is how long the process has been running, not what ran
+immediately before.**
+
 **Not fixed here: the warm-up itself.** `b8_run.cjs` warms each arm with
-one four-write calibration window, and the sweep above says a site can
-take six. The guard detects an insufficient warm-up rather than
-preventing it; widening it is unmeasured work.
+one four-write calibration window, and both sweeps say a site can take
+six. The guard detects an insufficient warm-up rather than preventing
+it; widening it, and running enough rounds that the phase strata are not
+single samples, is unmeasured work and is why that run exits 2 rather
+than green.
+
+Raw: `ai/findings/2026-07-28.88pie-b8-order-guard-raw.txt` (local-only).
 
 ---
 

--- a/docs/design/freehand/studio/freehand-vs-reagent-allocation.md
+++ b/docs/design/freehand/studio/freehand-vs-reagent-allocation.md
@@ -316,7 +316,99 @@ harness in this repository, not a B8 quirk.
 
 ---
 
-## 5. What this does not cover
+## 5. A tenth fault class — and the mitigation this page claimed was not one
+
+`rf2-jr76s` filed `rf2-88pie` after a control read **16.1052 B/slot in
+forward arm order and 8.0027 in reversed**, against a prediction of
+8.000. The bead named the cause: *a large-object arm doubles the reading
+of its immediate successor*. The remedy it proposed was to run every
+plan in both orders.
+
+**Two things came out of building that remedy, and the second is the
+one that matters.**
+
+### The mitigation this page's provenance claims does not exist
+
+The Provenance below says "arm order rotating with the round", and
+`b8_run.cjs` really did select the arm for slot `j` of round `r` as
+`ARMS[(j + r) % n]`. **A cyclic rotation changes which arm goes first.
+It does not change which arm follows which.** Arm `a` sits at slot
+`(a − r) mod n` in every round, so its predecessor is arm `(a − 1) mod n`
+in every round. `order_guard.cjs` proves it arithmetically: over six
+rounds of four arms, rotation gives **every arm exactly one within-round
+predecessor**, and the only sample that differs is the one at the round
+seam — one in six.
+
+The same bare rotation was in `b6-harness/round!` and
+`b6-rows/update-round!`, and both published the same sentence in their
+`:measurement-method`. So every figure this page and the B6 rows carry
+was taken under a mitigation that was not one. **The figures are not
+withdrawn** — nothing here says the contamination occurred, only that
+this page could not have detected it — and §4's discipline applies:
+a mitigation that is not checked is an assumption.
+
+All three now rotate **and reflect** on odd indices, which replaces every
+`a → a+1` adjacency with `a → a−1` and gives each arm two predecessors in
+balance.
+
+### What a live reproduction says the cause actually is
+
+`order_guard.cjs --live` rebuilds the control in plain node — a
+`.slice()` of a packed SMI array, predicted 8.000 B/slot plus a
+16-byte header — and separates the factors a reversal moves together.
+**node 24.13.0, V8 13.6, pointer compression OFF**, `--expose-gc
+--min-semi-space-size=32 --max-semi-space-size=64`:
+
+| factor | reading | |
+|---|---|---|
+| **position in the run** — the same control, nothing else varying, sixteen consecutive windows | `10.32 10.26 10.26 10.26 10.33 10.28` then `8.12` ×10 | **+27% for six windows, then a step to the prediction** |
+| **the immediate predecessor** — position held fixed, warm | 8.1377 after an 87 KB-object arm, 8.1377 after a 3-element arm | **identical** |
+| the same, fresh process per reading, both measured first | 10.2900 after the large arm, 10.2588 after the small one | **0.3%** |
+| **window size** — a knob unrelated to order | cold: 16.50 at 32 slices against 8.12 at 8; warm: 8.2515 against 8.1377 | **2.03× cold, +1.4% warm** |
+
+Positive control: predicted **8.016** B/slot, settled **8.1221**
+(+1.3%), cold **10.3193** (+28.7%).
+
+**The immediate predecessor is worth a third of a percent. Everything
+else is one effect wearing three hats** — a site that has not run enough
+times reads 1.26× to 5.3× its settled value — and *both* a plan reversal
+*and* a change of window size move where in that curve an arm is
+measured. That is not a claim about what happened inside `rf2-jr76s`'s
+own harness, which is not reproduced here and whose mechanism stays
+undiagnosed. It is a claim about the remedy: **running a plan in both
+orders confounds adjacency with position, so it cannot say which of them
+it caught.**
+
+### The property, and what it refuses
+
+`order_guard.cjs` partitions every arm's samples by **what ran
+immediately before it** and by **where in the run it was measured**
+(first third against last third, in run order), and applies this
+repository's own rule: overlapping ranges mean indistinguishable, so a
+stratification is a finding only when the ranges are disjoint *and* the
+medians differ by more than a stated tolerance. An arm with one stratum
+on a factor is `unchecked`, and **unchecked refuses as loudly as
+contaminated** — a single-order result has not been checked and may not
+be quoted.
+
+`b8_run.cjs` runs the guard's self-test before the browser starts, the
+way §4's integrity probe runs before any figure is read, and **exits
+non-zero on a refusal** with the table printed but marked unquotable.
+The self-test is fixtures replayed from the recorded readings, so it is
+deterministic: it refuses the 2.01× on strata of one sample each, passes
+the same study's 0.43% slope, refuses a single-order plan, declines to
+fire on medians 20% apart whose ranges overlap, and catches the
+measured warm-up step — **which the bead's own proposed remedy would
+have missed**, because the predecessor never changes across it.
+
+**Not fixed here: the warm-up itself.** `b8_run.cjs` warms each arm with
+one four-write calibration window, and the sweep above says a site can
+take six. The guard detects an insufficient warm-up rather than
+preventing it; widening it is unmeasured work.
+
+---
+
+## 6. What this does not cover
 
 - **The broad view-leg ratio is an upper bound**, not a substrate result.
   §3 says why, and `rf2-mapni` is the arm that would close it.
@@ -353,7 +445,13 @@ harness in this repository, not a B8 quirk.
   run verbatim in the same driver (agreement ≤0.9% on every arm).
 - Sampling: 6 rounds, arm order rotating with the round, per-arm window
   sizing from a calibration probe, one un-read warm-up window per cell.
-  Collection-free windows only.
+  Collection-free windows only. **That rotation was not the mitigation it
+  reads as, and §5 says why**: it varies which arm goes first, not which
+  arm follows which, so these figures were taken with each arm's
+  predecessor effectively fixed. The driver now rotates and reflects, and
+  refuses a figure that either the predecessor or the position in the run
+  separates — a re-take under the guard would be needed to say the
+  figures below were unaffected, and none is claimed.
 - Gates green before any figure was read: bookkeeping identity exact in
   120/120 windows; kept÷dropped 1.0001; DOM read-back 0 unverified of
   2,400 per row; harness integrity probe passing inside the `:advanced`

--- a/implementation/freehand/test/re_frame/freehand/bench/b6_harness.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b6_harness.cljs
@@ -21,8 +21,9 @@
   A box with six other agents on it drifts, and it drifts on a timescale
   that runs all of one arm and then all of another straight into a
   systematic error. So every sample index mounts every arm, in an order
-  that ROTATES with the sample index — no arm is always first into a cold
-  cache, and no arm is always last into a loaded one.
+  that rotates AND REFLECTS with the sample index — see [[slot-order]] —
+  so that no arm is always first into a cold cache, no arm is always last
+  into a loaded one, and no arm always follows the same neighbour.
 
   ## Every figure is a ratio to the floor measured in the same round
 
@@ -170,16 +171,37 @@
 
 (defn- p50 [xs] (:p50 (m/summarise xs)))
 
+(defn slot-order
+  "Slot order for `k` arms at sample index `s`: rotate forward by `s`, then
+  REFLECT on odd indices.
+
+  The reflection is not decoration and this used to be a bare rotation.
+  `rf2-88pie` records a fault class in which an arm's reading depends on
+  what ran immediately before it, and a CYCLIC ROTATION DOES NOT VARY
+  THAT. Arm `a` sits at slot `(a - s) mod k`, so its predecessor is arm
+  `(a - 1) mod k` at every single sample index; rotating changes which arm
+  goes FIRST and nothing else. Every B6 row's published
+  `:measurement-method` said 'order rotating on the sample index' and
+  meant it as a mitigation, and it was not one.
+
+  Reversing a sequence replaces every `a -> a+1` adjacency with
+  `a -> a-1`, so alternating the two gives every arm two predecessors in
+  balance. `order_guard.cjs` carries the arithmetic proof of both halves
+  of that sentence, and the guard that refuses a figure the order moves."
+  [k s]
+  (let [xs (mapv #(mod (+ % s) k) (range k))]
+    (if (odd? s) (vec (rseq xs)) xs)))
+
 (defn round!
   "One round: `(+ warmup samples)` sample indices, every arm mounted at
-  every index, arm order rotating with the index. Answers `{id [ms …]}`
-  over the measured indices only."
+  every index, arm order rotating AND reflecting with the index — see
+  [[slot-order]]. Answers `{id [ms …]}` over the measured indices only."
   [arms props {:keys [warmup samples]}]
   (let [k   (count arms)
         acc (atom (zipmap (map :id arms) (repeat [])))]
     (dotimes [s (+ warmup samples)]
-      (dotimes [j k]
-        (let [arm (nth arms (mod (+ j s) k))
+      (doseq [j (slot-order k s)]
+        (let [arm (nth arms j)
               mnt (mount-arm! arm props)]
           (when (>= s warmup)
             (swap! acc update (:id arm) conj (:ms mnt)))

--- a/implementation/freehand/test/re_frame/freehand/bench/b6_rows.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b6_rows.cljs
@@ -313,6 +313,11 @@
   the clock — then VERIFY at the DOM that the cell holds what was written.
   Answers a promise of `{:ms … :write-ms … :force-ms … :ok? …}`.
 
+  **The yield is not optional and it is not historical.** See the comment
+  above [[timed-write-no-yield!]] and `rf2-vxfjt`: with the microtask
+  deleted, both Freehand arms fail this function's own read-back on every
+  write.
+
   The window is SPLIT because the split answers the comparison's biggest
   fairness question. This row pits Freehand reading re-frame `app-db`
   against Reagent reading a bare `reagent.core/atom`, which is each
@@ -346,6 +351,74 @@
                         :ok?      (= (str val) (cell-text container probe))
                         :ok2?     (or (not= i :all)
                                       (= (str val) (cell-text container (dec cells-n))))}))))))))
+
+(defn timed-write-no-yield!
+  "[[timed-write!]] with the microtask boundary removed and NOTHING else
+  changed: write, force the arm's own synchronous drain, stop the clock,
+  read the written cell back out of the DOM.
+
+  This is not the published window and it is not offered as one. It is the
+  ablation `rf2-vxfjt` asks for — `rf2-w2m25` gave Freehand a synchronous
+  commit, so the yield the published window carries is no longer REQUIRED
+  by any arm, and the question is whether removing it tightens every
+  figure by a microtask boundary or simply moves the same work into the
+  `flushSync` (or, worse, lands the commit after the clock has stopped).
+
+  `:gap-ms` is reported as 0.0 rather than omitted, so a reader diffing
+  the two windows' leg tables is not left wondering which key went
+  missing. The per-write DOM read-back is the whole gate: a window whose
+  commit lands outside it reads the OLD value, which is precisely the
+  fault `b6-rows` records from this row's first attempt — 80 of 320 floor
+  samples ending on a stale cell."
+  [{:keys [arm container]} i val]
+  (let [t0 (m/now-ms)]
+    ((:write! arm) i val)
+    (let [t1 (m/now-ms)]
+      ((:force! arm))
+      (let [t2    (m/now-ms)
+            probe (if (= i :all) 0 i)]
+        (js/Promise.resolve
+          {:ms       (- t2 t0)
+           :write-ms (- t1 t0)
+           :gap-ms   0.0
+           :force-ms (- t2 t1)
+           :ok?      (= (str val) (cell-text container probe))
+           :ok2?     (or (not= i :all)
+                         (= (str val) (cell-text container (dec cells-n))))})))))
+
+(defn timed-write-in-flush!
+  "The OTHER yield-free window: put the write inside a
+  `react-dom/flushSync`, then force the arm's own drain, then stop the
+  clock. Still no microtask.
+
+  This is the shape
+  [[re-frame.freehand.bench.b6-update-dom-cljs-test/a-freehand-write-commits-inside-flushsync]]
+  pins — `rf2-w2m25` gave Freehand's ViewCell pending window a second
+  closer that React can see, so a write made inside a flush commits
+  before the flush returns. [[timed-write-no-yield!]] does NOT have that
+  property, because there the write happens outside any flush and the
+  arm's drain is an EMPTY one.
+
+  The write is inside the flush and the drain is outside it, rather than
+  both inside, because `force!` opens a `flushSync` of its own on every
+  arm and React does not welcome a nested one. That ordering also keeps
+  the floor arm honest: its render lives in `force!` by construction, so
+  a window that flushed only the write would measure nothing for it."
+  [{:keys [arm container]} i val]
+  (let [t0 (m/now-ms)]
+    (react-dom/flushSync (fn [] ((:write! arm) i val)))
+    (let [t1 (m/now-ms)]
+      ((:force! arm))
+      (let [t2    (m/now-ms)
+            probe (if (= i :all) 0 i)]
+        (js/Promise.resolve
+          {:ms       (- t2 t0)
+           :write-ms (- t1 t0)
+           :gap-ms   0.0
+           :force-ms (- t2 t1)
+           :ok?      (= (str val) (cell-text container probe))
+           :ok2?     (or (not= i :all)
+                         (= (str val) (cell-text container (dec cells-n))))})))))
 
 (defn chain
   "Fold `xs` into a serial promise chain, threading an accumulator."
@@ -418,19 +491,35 @@
                       :force-ms (:p50 (m/summarise (map :force xs)))})]))
         legs))
 
-;; THE MICROTASK YIELD IS PRICED IN SITU, BY THE ARMS THAT DO NOT NEED IT.
+;; THE MICROTASK YIELD IS PRICED IN SITU, BY THE ARMS THAT DO NOT NEED IT,
+;; AND IT IS STILL LOAD-BEARING. `rf2-vxfjt` MEASURED THAT.
 ;;
 ;; Every measured write pays one microtask yield, because the slowest arm
-;; required one when this window was designed (rf2-w2m25 has since removed
-;; that requirement; the row has not been re-taken), so a reader is owed
-;; the size of that constant. The
-;; measurement is `:gap-ms` in the `:legs` decomposition, and the control
-;; is that the floor and Reagent arms — which commit without it — report
-;; `:gap-ms 0.0` in every round of both rows. The yield costs nothing;
-;; what shows up in the Freehand arms' gap is Freehand's own notification
-;; callback running there, and it scales with the write exactly as it
-;; should (≈0.35 ms when a broad write moves 300 subscriptions, ≈0.01 ms
-;; when a narrow one moves one).
+;; required one when this window was designed, so a reader is owed the
+;; size of that constant. The measurement is `:gap-ms` in the `:legs`
+;; decomposition, and the control is that the floor and Reagent arms —
+;; which commit without it — report `:gap-ms 0.0` in every round of both
+;; rows. The yield costs nothing; what shows up in the Freehand arms' gap
+;; is Freehand's own notification callback running there.
+;;
+;; THE YIELD IS NOT REMOVABLE, and this comment used to say it was.
+;; `rf2-w2m25` gave a write made INSIDE a `flushSync` a synchronous
+;; commit, and both this file and `b6_update_dom_cljs_test` concluded that
+;; the row could therefore be re-taken without the microtask. It cannot.
+;; `b6_yield_app` ran the ablation against the DOM read-back on every arm,
+;; six rounds, both rows: with the microtask deleted and nothing else
+;; changed, **every single one of the two Freehand arms' writes fails the
+;; read-back** — 66 of 66 per arm broad, 1,320 of 1,320 per arm narrow,
+;; and 0 of 66 / 0 of 1,320 on every other arm. The write is outside any
+;; flush, so `rf2-w2m25`'s closer never fires and the empty `flushSync`
+;; that follows has nothing to commit; the clock stops on the OLD value.
+;;
+;; The one yield-free window that DOES verify is `flushSync(write)` then
+;; the arm's drain, and it is not a tightening: broad, Freehand
+;; interpreted reads 3.5 ms [3.4–4.7] against the published window's
+;; 3.5 [3.2–4.3], ranges overlapping. The same work moves out of the gap
+;; leg and into the write leg (0.6–0.8 + gap 2.5–3.2 becomes 3.4–4.7 + gap
+;; 0.0) and the total does not move. There is nothing to win here.
 ;;
 ;; A first attempt priced it instead by chaining 2,000 bare
 ;; `js/Promise.resolve`s and dividing, which reported ≈1 ms a hop — larger
@@ -494,14 +583,15 @@
                                             "Reagent); t1 — then the written cell is read back "
                                             "out of the DOM and the sample is rejected if it "
                                             "does not hold the written value. The microtask is "
-                                            "HISTORICAL: a mounted Freehand v/sub did not repaint "
-                                            "inside flushSync when this window was designed — its "
-                                            "notification rode a microtask, and a first pass that "
-                                            "timed inside flushSync measured Freehand writes that "
-                                            "never reached the DOM at all. rf2-w2m25 fixed that, so "
-                                            "the yield is no longer required by any arm and the row "
-                                            "is re-takeable without it; these figures were NOT "
-                                            "re-taken, so they still carry it. Arms interleaved at the "
+                                            "LOAD-BEARING and rf2-vxfjt measured that: delete it and "
+                                            "every one of the two Freehand arms' writes fails the DOM "
+                                            "read-back (66 of 66 per arm broad, 1320 of 1320 narrow, "
+                                            "0 on every other arm), because the write is then outside "
+                                            "any flush and rf2-w2m25's synchronous-commit closer never "
+                                            "fires. The one yield-free window that DOES verify — "
+                                            "flushSync(write) then the drain — costs the same to "
+                                            "within overlapping ranges, so there is no tightening "
+                                            "available. Arms interleaved at the "
                                             "sample level, order rotating AND REFLECTING on the sample "
                                             "index so no arm always follows the same neighbour "
                                             "(rf2-88pie: a bare rotation does not vary that); "

--- a/implementation/freehand/test/re_frame/freehand/bench/b6_rows.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b6_rows.cljs
@@ -192,8 +192,10 @@
                           :measurement-method
                           (str "wall time across react-dom/flushSync around each arm's own "
                                "mount door, into a fresh container attached before the window; "
-                               "arms interleaved at the SAMPLE level with the order rotating on "
-                               "the sample index; " rounds " rounds of " (:warmup sampling)
+                               "arms interleaved at the SAMPLE level with the order rotating AND "
+                               "REFLECTING on the sample index, so no arm always follows the same "
+                               "neighbour (a bare rotation does not vary that at all — rf2-88pie); "
+                               rounds " rounds of " (:warmup sampling)
                                " warmup + " (:samples sampling) " samples per arm per round; "
                                "every figure a ratio to the FLOOR measured in that same round, "
                                "because this workstation drifts further across rounds than "
@@ -387,9 +389,13 @@
     (chain {:readings (zipmap (map #(:id (:arm %)) mounts) (repeat []))
             :legs     (zipmap (map #(:id (:arm %)) mounts) (repeat []))
             :bad      0}
-           (for [s (range total) j (range k)] [s j])
+           ;; `h/slot-order` rotates AND reflects. A bare rotation — which
+           ;; this was — leaves every arm with the same immediate
+           ;; predecessor at every sample index, which is the fault class
+           ;; `rf2-88pie` records.
+           (for [s (range total) j (h/slot-order k s)] [s j])
            (fn [acc [s j]]
-             (let [mnt (nth mounts (mod (+ j s) k))
+             (let [mnt (nth mounts j)
                    id  (:id (:arm mnt))]
                (-> (n-writes! mnt kind n)
                    (.then (fn [{:keys [ms write-ms gap-ms force-ms bad]}]
@@ -496,7 +502,9 @@
                                             "the yield is no longer required by any arm and the row "
                                             "is re-takeable without it; these figures were NOT "
                                             "re-taken, so they still carry it. Arms interleaved at the "
-                                            "sample level, order rotating on the sample index; "
+                                            "sample level, order rotating AND REFLECTING on the sample "
+                                            "index so no arm always follows the same neighbour "
+                                            "(rf2-88pie: a bare rotation does not vary that); "
                                             rounds " rounds of " (:warmup sampling)
                                             " warmup + " (:samples sampling) " samples; every "
                                             "figure a ratio to the floor measured in that same "

--- a/implementation/freehand/test/re_frame/freehand/bench/b6_update_dom_cljs_test.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b6_update_dom_cljs_test.cljs
@@ -34,17 +34,37 @@
   [[a-freehand-write-commits-inside-flushsync]] pins below, and it is
   where a regression in EITHER direction shows up.
 
-  The window this row is measured through has NOT been re-taken, so it is
-  still the shape the defect forced: **write, yield one microtask, force
-  the substrate's own synchronous drain, stop the clock.** Floor and
-  Reagent do not need the microtask and pay it anyway. Every arm is timed
-  through that ONE shape, so the comparison remains sound — what changed
-  is that it is no longer REQUIRED, and the row is now re-takeable as
-  `flushSync(write)` on all four arms, which would drop a microtask
-  boundary every arm currently pays. Whoever re-takes it should know that
-  the fix arms one extra React commit per render batch — a two-fiber
-  detached root rendering nil — which lands OUTSIDE the current window
-  but would move inside a re-taken one.
+  The window this row is measured through is still the shape the defect
+  forced: **write, yield one microtask, force the substrate's own
+  synchronous drain, stop the clock.** Floor and Reagent do not need the
+  microtask and pay it anyway. Every arm is timed through that ONE shape,
+  so the comparison remains sound.
+
+  **The yield stays, and that is measured rather than assumed.** This
+  docstring used to say the row was re-takeable as `flushSync(write)` on
+  all four arms, dropping a microtask boundary every arm pays.
+  `rf2-vxfjt` ran the ablation — `b6_yield_app`, six rounds, both rows,
+  every window gated on the per-write DOM read-back — and it says two
+  things.
+
+  - **Deleting the microtask and changing nothing else is not available.**
+    Both Freehand arms then fail the read-back on *every* write: 66 of 66
+    per arm on the broad row, 1,320 of 1,320 per arm on the narrow one,
+    against 0 on the floor, Reagent and the positive-control arms. The
+    write sits outside any flush, so `rf2-w2m25`'s closer never fires and
+    the empty `flushSync` after it has nothing to commit.
+  - **The window that DOES verify buys nothing.** `flushSync(write)` then
+    the arm's drain verifies on all four arms, and reads 3.5 ms
+    [3.4–4.7] for interpreted Freehand against the published window's 3.5
+    [3.2–4.3] — overlapping ranges, indistinguishable. The same work
+    moves out of the gap leg and into the write leg. The extra React
+    commit per render batch that `rf2-w2m25` arms is inside that window
+    and is not separable from it at this instrument's resolution.
+
+  A caution worth carrying: on the NARROW row the invalid yield-free
+  window is *faster* and its range still overlaps the published one, so
+  the clock alone would have accepted it. **Only the DOM read-back caught
+  it.**
 
   Nothing is measured inside an `act` environment — `act` diverts work to
   its own queue and, measured, cost 600 ms a call.
@@ -210,9 +230,10 @@
                  returns — no yield of any kind between the two")
             ;; The second leg: the window this row is actually measured
             ;; through — write, yield one microtask, force the drain — still
-            ;; carries a write to the DOM. Re-taking the row without the
-            ;; microtask is now legitimate; until it is, this is the shape
-            ;; whose non-vacuity matters.
+            ;; carries a write to the DOM. This is the shape whose
+            ;; non-vacuity matters, and rf2-vxfjt established that it is
+            ;; the only one available: the same window with the microtask
+            ;; deleted fails its read-back on every Freehand write.
             ((:write! arm) 0 8484)
             (-> (js/Promise.resolve nil)
                 (.then (fn [_]

--- a/implementation/freehand/test/re_frame/freehand/bench/b6_yield_app.cljs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b6_yield_app.cljs
@@ -1,0 +1,419 @@
+(ns re-frame.freehand.bench.b6-yield-app
+  "Does B6's update window still need its microtask yield? — `rf2-vxfjt`.
+
+  The published window is *write, yield ONE microtask, force the arm's own
+  synchronous drain, stop the clock*, and the yield is there because the
+  slowest arm needed it: a mounted Freehand `v/sub` was not repainted
+  inside `react-dom/flushSync`, so a first pass timed Freehand writes that
+  never reached the DOM at all. `rf2-w2m25` (#7133) fixed that, and
+  `b6-rows`' own docstring has since described the yield as removable.
+
+  `rf2-huhno`'s re-take says removing it is not a free tightening. On main
+  the window RESTRUCTURED: the empty `flushSync` that used to carry
+  3.0–3.5 ms now costs ~0.0 and the gap that used to be ~0.2 ms now
+  carries 3.6–3.9. Freehand's notification, React's render and React's
+  commit all run inside that microtask. So removing it either moves the
+  work into the `flushSync`, leaving the total unchanged and the legs
+  re-attributed again, or the notification has not fired when the empty
+  `flushSync` runs, the commit lands after the measured window, and the
+  DOM read-back fails.
+
+  ## What this entry does, and what it refuses to do
+
+  1. **The non-vacuity gate first, on every arm.** `rf2-0fgth` added the
+     check that a Freehand write inside `flushSync` reaches the DOM before
+     the flush returns; it asks it of one arm. This asks it of every arm,
+     and asks every window shape of every arm. Every probe installs a
+     value no other write ever installs and reads it back out of the DOM.
+     **A measurement of an arm that did nothing is the fault a canonical
+     DOM gate caught once**, when an ablation arm was rendering an empty
+     page — so the gate is on the record before any figure, and the
+     per-write read-back inside every measured window is the same check
+     repeated 3,960 times.
+  2. **A positive control whose size is arithmetic.** `:floor+spin` is the
+     floor arm with a CPU spin of a known number of milliseconds wrapped
+     around its own drain. Its sample must read the floor's plus that
+     number times the sample's write count, in every window, or the clock
+     is not measuring the window it claims to.
+  3. **Three windows interleaved, at the sample level.** Not before and
+     after. A worker on this surface measured a 20% regression that turned
+     out to be machine state, and caught it only by re-running the
+     baseline LAST; the same lesson here is that the windows must rotate
+     inside one round, with the arm order rotating and reflecting
+     (`b6-harness/slot-order`), so no window is systematically first into
+     a cold cache.
+  4. **Ranges across rounds, never a mean.** Overlapping ranges are
+     reported as indistinguishable.
+
+  This entry rides `b6_prod_run.cjs`'s `B6_INIT_FN` seam, which exists for
+  exactly this — an ablation reusing the published driver rather than
+  growing a second one:
+
+      B6_INIT_FN=re-frame.freehand.bench.b6-yield-app/-main \\
+      B6_OUT_DIR=out/b6-yield B6_PORT=8128 \\
+        node implementation/freehand/test/re_frame/freehand/bench/b6_prod_run.cjs
+
+  Normative owner: `docs/design/freehand/decisions/`
+  `D021-performance-budgets-and-release-evidence.md`."
+  (:require ["react-dom" :as react-dom]
+            [re-frame.adapter.uix :as react-substrate]
+            [re-frame.core :as rf]
+            [re-frame.freehand.bench.b6-harness :as h]
+            [re-frame.freehand.bench.b6-profile-app :as prof]
+            [re-frame.freehand.bench.b6-rows :as rows]
+            [re-frame.freehand.bench.measure :as m]
+            [re-frame.freehand.bench.provenance :as prov]))
+
+(def ^:private rounds 6)
+(def ^:private sampling {:warmup 3 :samples 8})
+
+(def ^:private control-ms
+  "The positive control's predicted size, in milliseconds. Large enough to
+  clear Chrome's 100 µs `performance.now()` clamp by a factor of twenty."
+  2.0)
+
+;; ---------------------------------------------------------------------------
+;; Arms
+;; ---------------------------------------------------------------------------
+
+(defn- spin-arm
+  "The floor arm with a spin of `ms` wrapped around its own drain — the
+  positive control. Everything else about the arm is the floor's, so the
+  difference between the two arms' windows is the spin and nothing else,
+  and it is a quantity chosen rather than measured."
+  [ms]
+  (let [floor (first (filter #(= :floor (:id %)) (rows/make-update-arms)))]
+    (assoc floor
+           :id :floor+spin
+           :force! (fn [] (prof/control-spin! ms) ((:force! floor))))))
+
+(defn- make-arms []
+  (conj (rows/make-update-arms) (spin-arm control-ms)))
+
+;; ---------------------------------------------------------------------------
+;; The non-vacuity gate
+;; ---------------------------------------------------------------------------
+
+(defn- settle!
+  "Drain whatever the previous probe left pending: one microtask, then the
+  arm's own synchronous drain.
+
+  Not optional, and the first version of this gate did without it. Every
+  probe deliberately includes a shape that MIGHT leave a commit
+  outstanding, and the very next probe then read the DOM while that
+  commit was landing — so `:commits-in-flush-window?` answered `false`
+  for both Freehand arms while the measured `:in-flush` window verified
+  660 of 660 writes. A probe contradicting the measurement it gates is
+  the probe's bug, not the measurement's."
+  [arm]
+  (-> (js/Promise.resolve nil) (.then (fn [_] ((:force! arm)) nil))))
+
+(def ^:private probe-shapes
+  "The three synchronous window shapes, each as it installs a value.
+
+  `:commits-inside-flushsync?` is `rf2-0fgth`'s check generalised to every
+  arm. The FLOOR arm is expected to answer `false` and that is not a
+  failure: the floor's `write!` only moves a plain atom and its render
+  lives in `force!` by construction, because `root.render` outside a React
+  event schedules at the default lane and an EMPTY `flushSync` does not
+  flush it — the fault that left 80 of 320 floor samples on a stale cell.
+  The probes that gate the re-take are the other two."
+  [[:commits-inside-flushsync?
+    (fn [arm v] (react-dom/flushSync (fn [] ((:write! arm) 0 v))))]
+   [:commits-without-yield?
+    (fn [arm v] ((:write! arm) 0 v) ((:force! arm)))]
+   [:commits-in-flush-window?
+    (fn [arm v] (react-dom/flushSync (fn [] ((:write! arm) 0 v))) ((:force! arm)))]])
+
+(defn- probe-arm!
+  "Every window shape over one arm, each installing a value no other write
+  ever installs, each preceded by a settle, each read back out of the DOM."
+  [{:keys [arm container] :as _mnt}]
+  (-> (rows/chain {:arm (:id arm)} probe-shapes
+        (fn [acc [k install!]]
+          (-> (settle! arm)
+              (.then (fn [_]
+                       (let [v (rows/next-gen!)]
+                         (install! arm v)
+                         (assoc acc k (= (str v) (rows/cell-text container 0)))))))))
+      (.then (fn [acc]
+               ;; The published window last, because it is the one that
+               ;; must never regress and a reader should see it decided
+               ;; from a settled state like the others.
+               (-> (settle! arm)
+                   (.then (fn [_]
+                            (let [v (rows/next-gen!)]
+                              ((:write! arm) 0 v)
+                              (-> (js/Promise.resolve nil)
+                                  (.then (fn [_]
+                                           ((:force! arm))
+                                           (assoc acc :commits-with-yield?
+                                                  (= (str v)
+                                                     (rows/cell-text container 0))))))))))))))
+
+(defn- gate!
+  "Probe every mounted arm and answer
+  `{:probes [...] :yield-free-ok? bool :failing [ids]}`."
+  [mounts]
+  (-> (rows/chain [] mounts (fn [acc mnt] (-> (probe-arm! mnt) (.then #(conj acc %)))))
+      (.then (fn [probes]
+               (let [failing (into [] (comp (remove :commits-without-yield?) (map :arm)) probes)
+                     failing-in-flush (into [] (comp (remove :commits-in-flush-window?)
+                                                     (map :arm))
+                                            probes)]
+                 {:probes                probes
+                  :failing               failing
+                  :failing-in-flush      failing-in-flush
+                  :yield-free-ok?        (empty? failing)
+                  :in-flush-window-ok?   (empty? failing-in-flush)})))))
+
+;; ---------------------------------------------------------------------------
+;; The paired measurement
+;; ---------------------------------------------------------------------------
+
+(def ^:private windows
+  "The published window and the two yield-free candidates.
+
+  `:no-yield` is `timed-write!` with the microtask deleted and nothing
+  else changed — the literal ablation the bead asks for. `:in-flush`
+  additionally moves the write inside a `react-dom/flushSync`, which is
+  the shape `rf2-0fgth`'s non-vacuity check pins; it is the only other
+  yield-free window available, so leaving it unmeasured would answer
+  'the yield stays' without having asked the obvious follow-up."
+  {:yield    rows/timed-write!
+   :no-yield rows/timed-write-no-yield!
+   :in-flush rows/timed-write-in-flush!})
+
+(def ^:private window-ids [:yield :no-yield :in-flush])
+
+(defn- window-order
+  "Which window goes first at this (sample, slot). Rotating, so no window
+  is systematically first into a cold cache — the same reason the arms
+  rotate and reflect."
+  [s j]
+  (let [n (count window-ids)
+        r (mod (+ s j) n)]
+    (into (subvec window-ids r) (subvec window-ids 0 r))))
+
+(defn- n-writes!
+  "`n` writes on one arm through one window, timed as one sample. Every
+  write carries a fresh value and every one is read back out of the DOM."
+  [write! mnt kind n]
+  (rows/chain {:ms 0 :write-ms 0 :gap-ms 0 :force-ms 0 :bad 0} (range n)
+    (fn [acc _]
+      (let [val (rows/next-gen!)
+            i   (if (= kind :broad) :all (mod val rows/cells-n))]
+        (-> (write! mnt i val)
+            (.then (fn [{:keys [ms write-ms gap-ms force-ms ok? ok2?]}]
+                     (cond-> (-> acc
+                                 (update :ms + ms)
+                                 (update :write-ms + write-ms)
+                                 (update :gap-ms + gap-ms)
+                                 (update :force-ms + force-ms))
+                       (not (and ok? ok2?)) (update :bad inc)))))))))
+
+(defn- round!
+  [mounts kind]
+  (let [k     (count mounts)
+        total (+ (:warmup sampling) (:samples sampling))
+        n     (get rows/writes-per-sample kind)
+        ids   (mapv #(:id (:arm %)) mounts)
+        blank (zipmap ids (repeat (zipmap window-ids (repeat []))))]
+    (rows/chain {:readings blank
+                 :legs     blank
+                 :bad      (zipmap ids (repeat (zipmap window-ids (repeat 0))))
+                 :writes   (zipmap ids (repeat (zipmap window-ids (repeat 0))))}
+                (for [s (range total) j (h/slot-order k s) w (window-order s j)] [s j w])
+                (fn [acc [s j w]]
+                  (let [mnt (nth mounts j)
+                        id  (:id (:arm mnt))]
+                    (-> (n-writes! (get windows w) mnt kind n)
+                        (.then (fn [{:keys [ms write-ms gap-ms force-ms bad]}]
+                                 (cond-> (-> acc
+                                             (update-in [:bad id w] + bad)
+                                             (update-in [:writes id w] + n))
+                                   (>= s (:warmup sampling))
+                                   (-> (update-in [:readings id w] conj ms)
+                                       (update-in [:legs id w] conj
+                                                  {:write write-ms
+                                                   :gap   gap-ms
+                                                   :force force-ms})))))))))))
+
+(defn- p50s
+  "Per-arm, per-window p50 of one round, in ms per SAMPLE."
+  [readings]
+  (into {} (map (fn [[id ws]]
+                  [id (into {} (map (fn [[w xs]] [w (when (seq xs) (:p50 (m/summarise xs)))])) ws)]))
+        readings))
+
+(defn- legs-of
+  [legs]
+  (into {} (map (fn [[id ws]]
+                  [id (into {} (map (fn [[w xs]]
+                                      [w (when (seq xs)
+                                           {:write-ms (:p50 (m/summarise (map :write xs)))
+                                            :gap-ms   (:p50 (m/summarise (map :gap xs)))
+                                            :force-ms (:p50 (m/summarise (map :force xs)))})]))
+                            ws)]))
+        legs))
+
+(defn- range-of [xs]
+  (let [xs (remove nil? xs)]
+    (when (seq xs)
+      {:min (apply min xs) :max (apply max xs) :p50 (:p50 (m/summarise xs)) :rounds (count xs)})))
+
+(defn- overlap?
+  [a b]
+  (and a b (<= (:min a) (:max b)) (<= (:min b) (:max a))))
+
+(defn- summarise
+  "Fold the per-round p50s into a range per arm per window, and answer the
+  verdict the operator actually asked for: did the yield matter?
+
+  `:indistinguishable?` is the house rule — overlapping ranges across
+  rounds mean the two windows are not separable at this instrument's
+  resolution, and no percentage may be quoted off them."
+  [per-round]
+  (into {}
+        (map (fn [id]
+               (let [rs (into {} (map (fn [w] [w (range-of (map #(get-in % [id w]) per-round))]))
+                              window-ids)
+                     y  (:yield rs)]
+                 [id (into rs
+                           (map (fn [w]
+                                  (let [r (get rs w)]
+                                    [(keyword (str "vs-yield-" (name w)))
+                                     (when (and y r)
+                                       {:delta-p50          (- (:p50 r) (:p50 y))
+                                        :ratio              (when (pos? (:p50 y))
+                                                              (/ (:p50 r) (:p50 y)))
+                                        :indistinguishable? (overlap? y r)})])))
+                           (remove #{:yield} window-ids))])))
+        (keys (first per-round))))
+
+(defn- control-check
+  "Predicted against measured, in every window. The spin arm's sample is
+  the floor arm's plus `control-ms` PER WRITE — and the per-write factor
+  is not decoration: the first run of this entry predicted a flat
+  `+2.0 ms` and read `+39.1` on the narrow row, because a narrow SAMPLE
+  is twenty writes and the spin is paid on every one of them. The control
+  caught the harness's arithmetic, which is what a control is for."
+  [summary kind]
+  (let [per-sample (* control-ms (get rows/writes-per-sample kind))]
+    (into {:predicted-delta-ms per-sample
+           :writes-per-sample  (get rows/writes-per-sample kind)
+           :arm                :floor+spin
+           :note (str "the floor arm with a CPU spin of " control-ms
+                      " ms wrapped around its own drain, paid on every write of the sample")}
+          (map (fn [w]
+                 (let [f (get-in summary [:floor w :p50])
+                       s (get-in summary [:floor+spin w :p50])]
+                   [w {:floor-p50 f
+                       :spin-p50  s
+                       :predicted (when f (+ f per-sample))
+                       :measured  s
+                       :error-ms  (when (and f s) (- s (+ f per-sample)))
+                       :error-pct (when (and f s (pos? (+ f per-sample)))
+                                    (* 100.0 (/ (- s (+ f per-sample)) (+ f per-sample))))}]))
+               window-ids))))
+
+;; ---------------------------------------------------------------------------
+;; Entry
+;; ---------------------------------------------------------------------------
+
+(defn- fail! [why]
+  (set! (.-B6_ERROR js/window) (str why))
+  (js/console.error (str ";; B6 YIELD FAILED — " why)))
+
+(defn- record! [k v]
+  (let [acc (or (.-B6_RESULTS js/window) #js {})]
+    (aset acc (name k) (pr-str v))
+    (set! (.-B6_RESULTS js/window) acc)
+    v))
+
+(defn- measure!
+  [mounts kind gate]
+  (-> (rows/chain [] (range rounds)
+                  (fn [acc _]
+                    (-> (rows/seed-update-arms! mounts)
+                        (.then (fn [_] (round! mounts kind)))
+                        (.then (fn [rd] (conj acc rd))))))
+      (.then (fn [rds]
+               (let [per-round (mapv #(p50s (:readings %)) rds)
+                     summary   (summarise per-round)
+                     merge+    (fn [ms] (apply merge-with (partial merge-with +) ms))
+                     bad-by    (merge+ (map :bad rds))
+                     writes-by (merge+ (map :writes rds))
+                     tot       (fn [m] (reduce + (mapcat vals (vals m))))
+                     bad       (tot bad-by)
+                     writes    (tot writes-by)]
+                 (record!
+                   (keyword (str "yield-" (name kind)))
+                   {:benchmark (keyword "B6" (str "update-" (name kind) "-yield-ablation"))
+                    :doc       (str "the published window (write, ONE microtask, forced drain) "
+                                    "against the same window with the microtask removed, "
+                                    "interleaved at the sample level")
+                    :bead      :rf2-vxfjt
+                    :revision  (prov/detect-revision)
+                    :build     (prov/detect-build)
+                    :host      (prov/detect-host)
+                    :runtime   "Chromium via Playwright, :advanced, goog.DEBUG false"
+                    :fixture   {:cells             rows/cells-n
+                                :kind              kind
+                                :arms              (mapv #(:id (:arm %)) mounts)
+                                :adapter           :rf.adapter/uix
+                                :writes-per-sample (get rows/writes-per-sample kind)
+                                :unverified-writes bad
+                                :total-writes      writes
+                                :unverified-by-arm bad-by
+                                :writes-by-arm     writes-by
+                                :measurement-method
+                                (str "two windows over one set of mounts, alternating at the "
+                                     "sample level so neither is systematically first; arms "
+                                     "rotating AND reflecting on the sample index (rf2-88pie); "
+                                     rounds " rounds of " (:warmup sampling) " warmup + "
+                                     (:samples sampling) " samples; every write read back out "
+                                     "of the DOM inside its own window")}
+                    :non-vacuity gate
+                    :control     (control-check summary kind)
+                    :per-round   per-round
+                    :legs        (mapv #(legs-of (:legs %)) rds)
+                    :summary     summary
+                    :status      :evidence})
+                 {:summary summary :bad bad :writes writes})))))
+
+(defn ^:export -main
+  []
+  (try
+    (rf/init! react-substrate/adapter)
+    (h/leave-act-environment!)
+    (let [mounts (rows/mount-update-arms! (make-arms))
+          held   (volatile! nil)]
+      (-> (gate! mounts)
+          (.then (fn [gate]
+                   (vreset! held gate)
+                   (record! :non-vacuity gate)
+                   (js/console.log (str ";; B6 YIELD GATE " (pr-str gate)))
+                   (when-not (:yield-free-ok? gate)
+                     ;; NOT a hard stop. An arm whose commit lands outside
+                     ;; the yield-free window is the ANSWER to the bead, and
+                     ;; the measurement below still prices what the other
+                     ;; arms do — but the failure is on the record first, so
+                     ;; no reader can take the row as a clean re-take.
+                     (js/console.warn
+                       (str ";; B6 YIELD — these arms do NOT commit inside a yield-free "
+                            "window: " (pr-str (:failing gate)))))
+                   (measure! mounts :broad gate)))
+          (.then (fn [_] (measure! mounts :narrow @held)))
+          (.then (fn [_]
+                   (rows/release-update-arms! mounts)
+                   (set! (.-B6_DONE js/window) true)
+                   (js/console.log ";; B6 YIELD DONE")
+                   nil))
+          (.catch (fn [e]
+                    (rows/release-update-arms! mounts)
+                    (fail! (str "yield ablation rejected: " e))
+                    (set! (.-B6_DONE js/window) true)))))
+    (catch :default e
+      (fail! (str "yield ablation threw: " e))
+      (set! (.-B6_DONE js/window) true))))

--- a/implementation/freehand/test/re_frame/freehand/bench/b8_run.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b8_run.cjs
@@ -32,10 +32,22 @@
 // constant including the instrument's own footprint. A retention
 // instrument reads this control as zero.
 
+//
+// THE ARM ORDER IS A MEASURED PROPERTY OF THIS RUN, NOT AN ASSUMPTION.
+// `rf2-88pie`: a figure taken from a plan run in one order has not been
+// checked. `order_guard.cjs` schedules the arms so every one of them is
+// measured after at least two different predecessors, labels every window
+// with what preceded it and where in the run it sat, and REFUSES to let
+// this driver exit 0 on a figure that either factor separates. Its
+// self-test runs before anything is measured, exactly as the key-renaming
+// integrity probe does.
+
 const { spawnSync } = require('node:child_process');
 const fs = require('node:fs');
 const http = require('node:http');
 const path = require('node:path');
+
+const guard = require('./order_guard.cjs');
 
 const IMPL = path.resolve(__dirname, '../../../../..');
 const OUT = path.join(IMPL, 'out', 'b8');
@@ -109,6 +121,17 @@ const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 // ---------------------------------------------------------------------------
 
 async function main() {
+  // --- does the arm-order guard still catch the faults it was built for? --
+  // Ahead of the browser, because a broken guard makes every figure below
+  // unpublishable and finding that out after a fifteen-minute run is
+  // wasteful. The checks are fixtures replayed from `rf2-jr76s`'s recorded
+  // readings, so this is deterministic.
+  const guardSelf = guard.selfTest();
+  for (const c of guardSelf.checks) {
+    console.error(`[b8] order-guard ${c.ok ? 'ok  ' : 'FAIL'} ${c.name}`);
+  }
+  if (!guardSelf.ok) throw new Error('order guard self-test FAILED — nothing may be measured');
+
   const { chromium } = require('playwright');
   const browser = await chromium.launch({
     args: [
@@ -435,18 +458,31 @@ async function main() {
     }
   }
 
+  // Every window carries its POSITION in the run and the LABEL of the
+  // window that ran immediately before it. `guard.schedule` rotates AND
+  // reflects, because the plain `(j + round) % n` rotation this loop used
+  // to do changes which arm goes first without changing which arm follows
+  // which — see `order_guard.cjs`.
   const rows = [];
+  let position = 0;
+  let previous = null;
+  const take = async (round, arm, kind, doubles, published, n) => {
+    const w = await window_(arm, kind, doubles, published, n);
+    const label = `${arm}/D=${doubles}${published ? '/pub' : ''}`;
+    rows.push({ round, position: position++, predecessor: previous, ...w });
+    previous = label;
+  };
   for (const kind of KINDS) {
     for (let round = 0; round < ROUNDS; round++) {
       console.error(`[b8] ${kind}: round ${round + 1}/${ROUNDS}`);
-      for (let j = 0; j < ARMS.length; j++) {
-        const arm = ARMS[(j + round) % ARMS.length];
+      for (const j of guard.schedule(ARMS.length, round)) {
+        const arm = ARMS[j];
         const n0 = nFor[kind][arm][0];
-        rows.push({ round, ...(await window_(arm, kind, 0, false, n0)) });
-        rows.push({ round, ...(await window_(arm, kind, 0, true, n0)) });
+        await take(round, arm, kind, 0, false, n0);
+        await take(round, arm, kind, 0, true, n0);
         if (LADDER_ARMS.includes(arm)) {
-          rows.push({ round, ...(await window_(arm, kind, CTL_1, false, nFor[kind][arm][CTL_1])) });
-          rows.push({ round, ...(await window_(arm, kind, CTL_2, false, nFor[kind][arm][CTL_2])) });
+          await take(round, arm, kind, CTL_1, false, nFor[kind][arm][CTL_1]);
+          await take(round, arm, kind, CTL_2, false, nFor[kind][arm][CTL_2]);
         }
       }
     }
@@ -496,6 +532,7 @@ function report(out) {
   const REF = out.refBytesPerDouble;
   const kinds = [...new Set(rows.map((r) => r.kind))];
   const summary = {};
+  const refusals = [];
 
   for (const kind of kinds) {
     const of = (arm, doubles, published) =>
@@ -556,6 +593,32 @@ function report(out) {
         `${all.filter((r) => r.arm !== 'instrument').length * WRITES} ` +
         `(the instrument arm renders no cell and is excluded)`
     );
+
+    // --- arm order, before any figure is read ------------------------------
+    // The published per-arm figure is `inPage.perWrite` off the D=0 mirror
+    // windows, so those are the samples the guard adjudicates. Tolerance
+    // 25%: an allocation counter reading the same code twice is stable to
+    // a fraction of a percent, but the arms differ by three orders of
+    // magnitude in window sizing and a narrow arm's window is small enough
+    // that a page boundary moves it several percent. The recorded fault
+    // was 101%.
+    const orderSamples = [];
+    for (const arm of ARMS) {
+      for (const r of of(arm, 0, false)) {
+        orderSamples.push({
+          arm,
+          value: r.inPage.perWrite,
+          predecessor: r.predecessor,
+          position: r.position,
+        });
+      }
+    }
+    const orderVerdict = guard.verdict(orderSamples, { tolerance: 0.25 });
+    console.log(';;');
+    for (const line of guard.format(orderVerdict, `${kind} — the published per-arm figure`)) {
+      console.log(line);
+    }
+    if (orderVerdict.refuse) refusals.push(kind);
 
     // --- positive control -------------------------------------------------
     console.log(';;');
@@ -729,6 +792,7 @@ function report(out) {
     );
 
     summary[kind] = { per, above, ratioAboveFloor: rs, ratioAbsolute: rrs, control: ctl,
+                      orderVerdict,
                       viewLeg: { reagent: vRs, freehand: vFs, ratio: vRatio },
                       writeLeg: { reagent: wR, freehand: wF },
                       windows: { accepted: acc.length, total: all.length,
@@ -776,6 +840,15 @@ function report(out) {
       ` of what was allocated; it is a retention instrument.`
   );
 
+  if (refusals.length) {
+    console.log('\n;; ==== ARM ORDER: THESE FIGURES ARE NOT REPORTABLE ====');
+    console.log(
+      `;;   ${refusals.join(', ')} — at least one arm reads differently for what preceded it ` +
+        'or for where in the run it was measured (rf2-88pie). The table above stands only as ' +
+        'raw data; nothing in it may be quoted.'
+    );
+  }
+  summary.orderRefusals = refusals;
   return summary;
 }
 
@@ -803,6 +876,15 @@ function report(out) {
   if (failed) {
     console.error(`[b8] FAILED: ${failed}`);
     process.exit(1);
+  }
+  // A run whose figures the arm-order guard refused is not a green run.
+  // The data is printed and the raw file is written — the refusal is about
+  // what may be QUOTED, not about throwing the measurement away.
+  if (out && out.summary && out.summary.orderRefusals && out.summary.orderRefusals.length) {
+    console.error(
+      `[b8] REFUSED by the arm-order guard (rf2-88pie): ${out.summary.orderRefusals.join(', ')}`
+    );
+    process.exit(2);
   }
   console.error('[b8] ok');
 })();

--- a/implementation/freehand/test/re_frame/freehand/bench/order_guard.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/order_guard.cjs
@@ -1,0 +1,620 @@
+'use strict';
+// The ARM-ORDER guard — no reported figure may depend on WHERE IN THE PLAN
+// it was measured.
+//
+//   node .../order_guard.cjs                     the deterministic self-test
+//   node --expose-gc --min-semi-space-size=32 \
+//        --max-semi-space-size=64 .../order_guard.cjs --live
+//
+// ## The fault this exists for
+//
+// `rf2-jr76s` measured one control two ways in a single process. A
+// `.slice()` of a packed SMI array — predicted 8.000 B/slot, because slot
+// width is a build fact on an uncompressed V8 — read:
+//
+//     FORWARD arm order    16.1052 B/slot   (2.01x its prediction)
+//     REVERSED arm order    8.0027 B/slot   (+0.03%)
+//     plain node, no harness ~8.5  B/slot
+//
+// It was caught only because the whole plan was run in both orders and the
+// two controls disagreed with EACH OTHER rather than with a prediction.
+// `rf2-88pie` filed it as *a large-object arm doubles the reading of its
+// immediate successor*.
+//
+// ## What a live reproduction says, and why it changes the remedy
+//
+// [[liveReproduction]] rebuilds that control in plain node and separates
+// the factors a reversal moves together. Measured on node 24.13.0 /
+// V8 13.6, pointer compression OFF (`--expose-gc --min-semi-space-size=32
+// --max-semi-space-size=64`):
+//
+//   POSITION IN THE RUN, nothing else varying — the same control, sixteen
+//   consecutive windows:
+//       42.32 | 10.26 10.26 10.26 10.33 10.28 | 8.12 8.12 8.12 ... 8.12
+//   The first window reads 5.3x the prediction, the next five read +27%,
+//   and from the seventh it sits at 8.122 for ever. Nothing changed but
+//   how many times the site had run.
+//
+//   THE IMMEDIATE PREDECESSOR, position held fixed — a fresh process per
+//   reading, the control measured first in both:
+//       after an 87 KB-object arm   10.2900
+//       after a 3-element arm       10.2588      0.3% apart
+//
+//   THE WINDOW SIZE — a knob with nothing to do with order. Measured COLD,
+//   in a fresh process, 32 slices per window read 16.50 B/slot against 8
+//   slices' 8.12: **2.03x**, the magnitude `rf2-jr76s` recorded. Measured
+//   WARM it is 8.2515 against 8.1377, +1.4%. So that 2x is warm-up too.
+//
+// So the immediate predecessor is worth a third of a percent, and
+// everything else on this control is one effect wearing three hats: a
+// site that has not run enough times yet reads 1.26x to 5.3x its settled
+// value, and both a plan reversal and a change of window size move where
+// in that curve each arm is measured. **Reversing a plan moves position
+// and adjacency together**, so forward-versus-reversed cannot say which of
+// them it caught — and a plan re-ordered to keep large arms away from
+// small ones fixes the factor that measured smallest.
+//
+// This does not restate what happened inside `rf2-jr76s`'s own harness;
+// that harness is not reproduced here and its mechanism stays undiagnosed.
+// It does say that the REMEDY the bead proposed — order the plan, or run
+// it in both orders — is not sufficient on its own.
+//
+// ## The property, and why this one
+//
+// Three remedies were available.
+//
+// **Randomise the order.** Rejected. Randomising SPREADS a contaminant
+// across every arm instead of concentrating it in one, converting a
+// visible 2x on one arm into an invisible smear on all of them — wider
+// ranges, no verdict, and a figure wrong by an amount nobody can name.
+//
+// **Order the plan so no arm follows a much larger one.** Rejected. It
+// needs each arm's per-call allocation BEFORE measuring it, which is the
+// thing being measured; it is unfalsifiable, since a plan ordered by that
+// rule produces no evidence the rule worked; and the live reproduction
+// says adjacency is the smallest of the three effects anyway.
+//
+// **Stratify and REFUSE.** Chosen, and widened past the bead's proposal:
+//
+//   1. [[schedule]] builds a run order in which every arm has at least two
+//      DISTINCT immediate predecessors across rounds. Cyclic rotation —
+//      which is what every interleaved harness in this repository was
+//      doing — does not have that property; see below.
+//   2. Every sample carries what ran immediately before it AND its
+//      position in the run.
+//   3. [[verdict]] partitions each arm's samples by EACH of those factors
+//      and applies the house rule: OVERLAPPING RANGES MEAN
+//      INDISTINGUISHABLE. A stratification is a finding only if the ranges
+//      are disjoint AND the medians differ by more than a stated
+//      tolerance.
+//   4. An arm with one stratum on a factor is `unchecked`, and `unchecked`
+//      refuses as loudly as `contaminated`: a single-order result has not
+//      been checked and may not be reported.
+//
+// ## Cyclic rotation does not vary adjacency, and that is the trap
+//
+// `b8_run.cjs` and `b6_rows.cljs` both chose the arm for slot `j` of round
+// `r` as `ARMS[(j + r) % n]`, and both published that as "arm order
+// rotating with the round". A cyclic rotation changes which arm goes
+// FIRST; it does not change which arm follows which. Arm `a` sits at slot
+// `(a - r) mod n`, so its predecessor is `ARMS[(a - 1) mod n]` in every
+// round. The only sample with a different predecessor is the one at the
+// round seam — exactly one of the arm's `R`.
+//
+// [[schedule]] reflects the rotation on odd rounds, which replaces every
+// `a -> a+1` adjacency with `a -> a-1`. `selfTest` proves both halves of
+// that arithmetically.
+
+// ---------------------------------------------------------------------------
+// The schedule
+// ---------------------------------------------------------------------------
+
+/** Slot order for `n` arms in `round`: rotate forward, then REFLECT on odd rounds. */
+function schedule(n, round) {
+  const xs = [];
+  for (let j = 0; j < n; j++) xs.push((j + round) % n);
+  return round % 2 === 1 ? xs.reverse() : xs;
+}
+
+/** The plain cyclic rotation, kept so `selfTest` can price it. */
+function rotationOnly(n, round) {
+  const xs = [];
+  for (let j = 0; j < n; j++) xs.push((j + round) % n);
+  return xs;
+}
+
+/**
+ * Flatten `rounds` rounds of `sched(n, round)` into the sequence that
+ * actually runs, and answer, per arm, the predecessor strata it produces.
+ * The round seam counts: the rounds run back to back in one process, so
+ * the last arm of round `r` really does precede the first of round `r+1`.
+ */
+function adjacency(n, rounds, sched, opts = {}) {
+  const seams = opts.seams !== false;
+  const seq = [];
+  const rounded = [];
+  for (let r = 0; r < rounds; r++) {
+    const slots = sched(n, r);
+    for (let k = 0; k < slots.length; k++) {
+      seq.push(slots[k]);
+      rounded.push(k === 0);
+    }
+  }
+  const preds = new Map();
+  for (let i = 0; i < seq.length; i++) {
+    const a = seq[i];
+    const roundFirst = rounded[i];
+    if (!seams && roundFirst) continue; // the seam is a different question
+    if (!preds.has(a)) preds.set(a, new Map());
+    const m = preds.get(a);
+    const p = i === 0 || (!seams && roundFirst) ? null : seq[i - 1];
+    m.set(p, (m.get(p) || 0) + 1);
+  }
+  const arms = {};
+  for (const [a, m] of preds) {
+    const counts = [...m.values()];
+    const total = counts.reduce((x, y) => x + y, 0);
+    arms[a] = {
+      distinct: m.size,
+      samples: total,
+      modalShare: Math.max(...counts) / total,
+    };
+  }
+  return { sequence: seq, arms };
+}
+
+// ---------------------------------------------------------------------------
+// The verdict
+// ---------------------------------------------------------------------------
+
+function median(xs) {
+  const s = [...xs].sort((a, b) => a - b);
+  const m = s.length >> 1;
+  return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
+}
+
+function summarise(predecessor, values) {
+  return {
+    stratum: predecessor,
+    n: values.length,
+    min: Math.min(...values),
+    max: Math.max(...values),
+    p50: median(values),
+  };
+}
+
+/**
+ * The nuisance factors a plan varies whether it means to or not.
+ *
+ * `predecessor` is the bead's factor. `phase` is the one the live
+ * reproduction says is larger: split an arm's own samples at the median of
+ * their positions in the run, so EARLY and LATE are the same arm measured
+ * at two points in the process's history. A warm-up effect, a pretenuring
+ * transition or a growing heap all land here, and all of them move when a
+ * plan is reversed.
+ */
+const FACTORS = {
+  predecessor: (s) => (s.predecessor === null || s.predecessor === undefined
+    ? '<none>'
+    : String(s.predecessor)),
+  phase: null, // computed per arm, below
+};
+
+function stratifyArm(samples, factor) {
+  const m = new Map();
+  if (factor === 'phase') {
+    // THIRDS, not halves, and the middle is discarded. A warm-up step
+    // lands somewhere inside the run; a median split can put the step in
+    // the middle of the EARLY stratum, which then straddles it, and a
+    // straddling stratum's range overlaps everything. First third against
+    // last third is the beginning-versus-end contrast without that trap.
+    const withPos = samples
+      .filter((s) => Number.isFinite(s.position))
+      .sort((a, b) => a.position - b.position);
+    if (withPos.length < 2) return [];
+    const t = Math.max(1, Math.floor(withPos.length / 3));
+    m.set('FIRST-THIRD', withPos.slice(0, t).map((s) => s.value));
+    m.set('LAST-THIRD', withPos.slice(withPos.length - t).map((s) => s.value));
+  } else {
+    const key = FACTORS[factor];
+    for (const s of samples) {
+      const k = key(s);
+      if (!m.has(k)) m.set(k, []);
+      m.get(k).push(s.value);
+    }
+  }
+  return [...m.entries()]
+    .map(([k, vs]) => summarise(k, vs))
+    .sort((a, b) => a.p50 - b.p50);
+}
+
+/**
+ * Adjudicate one arm's strata on one factor.
+ *
+ * Strata of a single sample carry no range, so they are adjudicated on the
+ * ratio alone — and only when there is no better-powered pair available,
+ * because a powered comparison should decide the question when one exists.
+ * `rf2-jr76s`'s recorded fault is exactly the unpowered case (one forward
+ * reading, one reversed) and must still fire.
+ */
+function adjudicate(strata, tolerance) {
+  if (strata.length < 2) {
+    return {
+      strata,
+      status: 'unchecked',
+      why: `only ${strata.length} stratum — the question was never asked`,
+    };
+  }
+  const powered = strata.filter((s) => s.n >= 2);
+  const use = powered.length >= 2 ? powered : strata;
+  const lo = use[0];
+  const hi = use[use.length - 1];
+  const ratio = lo.p50 === 0 ? Infinity : hi.p50 / lo.p50;
+  const disjoint = hi.min > lo.max;
+  const degenerate = lo.n < 2 || hi.n < 2;
+  const beyond = Math.abs(ratio - 1) > tolerance;
+  const hit = beyond && (disjoint || degenerate);
+  return {
+    strata,
+    worst: { low: lo.stratum, high: hi.stratum, ratio, disjoint, degenerate },
+    underpowered: degenerate,
+    status: hit ? 'contaminated' : 'clean',
+    why: hit
+      ? `${hi.stratum} reads ${ratio.toFixed(4)}x ${lo.stratum}` +
+        (degenerate ? ' (n=1 strata: a ratio, not a range)' : ', ranges disjoint')
+      : beyond
+        ? `medians ${ratio.toFixed(4)}x apart but the ranges OVERLAP — indistinguishable`
+        : `within ${(tolerance * 100).toFixed(0)}%`,
+  };
+}
+
+/**
+ * Does any arm's figure depend on where in the plan it was measured?
+ *
+ * `samples` — `[{arm, value, predecessor, position}]`. `tolerance` is a
+ * relative difference of medians and the caller must choose it knowing its
+ * own noise; the default 0.10 sits far below the 2.01x the recorded fault
+ * produced and far above the 0.4% the same study's uncontaminated arms
+ * reproduced to.
+ *
+ * Answers `{ tolerance, arms, contaminated, unchecked, refuse }`. `refuse`
+ * is the one a driver acts on: a single-order result and a contaminated
+ * one are both unreportable.
+ */
+function verdict(samples, opts = {}) {
+  const tolerance = opts.tolerance === undefined ? 0.1 : opts.tolerance;
+  const factors = opts.factors || ['predecessor', 'phase'];
+  const byArm = new Map();
+  for (const s of samples) {
+    if (!Number.isFinite(s.value)) continue;
+    if (!byArm.has(s.arm)) byArm.set(s.arm, []);
+    byArm.get(s.arm).push(s);
+  }
+  const arms = {};
+  let contaminated = false;
+  let unchecked = false;
+  for (const [arm, ss] of byArm) {
+    const per = {};
+    for (const f of factors) {
+      const strata = stratifyArm(ss, f);
+      // `phase` is only askable when positions were recorded; a driver
+      // that does not record them is not thereby excused the predecessor
+      // question, so an empty phase stratification is skipped rather than
+      // failed.
+      if (f === 'phase' && strata.length === 0) continue;
+      per[f] = adjudicate(strata, tolerance);
+      if (per[f].status === 'contaminated') contaminated = true;
+      if (per[f].status === 'unchecked') unchecked = true;
+    }
+    arms[arm] = { n: ss.length, factors: per };
+  }
+  return { tolerance, arms, contaminated, unchecked, refuse: contaminated || unchecked };
+}
+
+const num = (v) =>
+  !Number.isFinite(v) ? String(v) : Math.abs(v) >= 1000 ? Math.round(v).toLocaleString('en-US') : v.toFixed(4);
+
+function format(v, title) {
+  const out = [];
+  out.push(`;; ==== ARM-ORDER GUARD${title ? ' — ' + title : ''} ====`);
+  out.push(
+    ';;   every arm partitioned by WHAT RAN BEFORE IT and by WHERE IN THE RUN it was ' +
+      `measured; tolerance ${(v.tolerance * 100).toFixed(0)}%, overlapping ranges are ` +
+      'indistinguishable'
+  );
+  for (const [arm, a] of Object.entries(v.arms)) {
+    out.push(`;;   ${arm}  (${a.n} samples)`);
+    for (const [f, r] of Object.entries(a.factors)) {
+      const mark = r.status === 'clean' ? 'ok  ' : r.status === 'unchecked' ? 'UNCH' : 'FAIL';
+      out.push(`;;     [${mark}] by ${f.padEnd(12)} ${r.why}`);
+      for (const s of r.strata) {
+        out.push(
+          `;;              ${String(s.stratum).padEnd(24)} n=${String(s.n).padStart(2)}  ` +
+            `p50 ${num(s.p50).padStart(12)}  [${num(s.min)}–${num(s.max)}]`
+        );
+      }
+    }
+  }
+  out.push(
+    v.refuse
+      ? ';;   VERDICT: REFUSE — no figure above may be published as measured'
+      : ';;   VERDICT: reportable — no arm reads differently for its position in the plan'
+  );
+  return out;
+}
+
+/** Throw unless every arm was checked on every factor and passed. */
+function assertClean(samples, opts = {}) {
+  const v = verdict(samples, opts);
+  if (v.refuse) {
+    throw new Error('arm-order guard REFUSED (rf2-88pie)\n' + format(v, opts.title).join('\n'));
+  }
+  return v;
+}
+
+// ---------------------------------------------------------------------------
+// The self-test — deterministic, and it is the proof the guard catches the
+// cases it was built for. Drivers run it before measuring.
+// ---------------------------------------------------------------------------
+
+function selfTest() {
+  const checks = [];
+  const check = (name, ok, detail) => checks.push({ name, ok: !!ok, detail });
+  const one = (v, arm, factor) => v.arms[arm].factors[factor];
+
+  // 1. THE RECORDED 2x, replayed from `rf2-jr76s`. A packed-SMI `.slice()`
+  //    control, predicted 8.000 B/slot, read once in forward arm order and
+  //    once in reversed. Both strata are n=1, which is the whole difficulty:
+  //    a guard that insisted on ranges would have passed this.
+  const smi = [
+    { arm: 'CTL-SMI-slice', predecessor: 'DBL-10000', position: 9, value: 16.1052 },
+    { arm: 'CTL-SMI-slice', predecessor: 'P-VALS', position: 2, value: 8.0027 },
+  ];
+  const vSmi = verdict(smi, { tolerance: 0.1 });
+  check(
+    'the recorded 2.01x is REFUSED',
+    vSmi.refuse &&
+      one(vSmi, 'CTL-SMI-slice', 'predecessor').status === 'contaminated' &&
+      Math.abs(one(vSmi, 'CTL-SMI-slice', 'predecessor').worst.ratio - 2.0125) < 0.001,
+    `ratio ${one(vSmi, 'CTL-SMI-slice', 'predecessor').worst.ratio.toFixed(4)}`
+  );
+
+  // 2. THE UNCONTAMINATED ARM FROM THE SAME STUDY must pass. The
+  //    per-subscription slope reproduced 2,830.7 forward against 2,842.8
+  //    reversed — 0.43% — and a guard that failed this would be useless.
+  const slope = [
+    { arm: 'RFWRITE-slope', predecessor: 'RFWRITE-150', position: 3, value: 2830.7 },
+    { arm: 'RFWRITE-slope', predecessor: 'RFWRITE-300', position: 8, value: 2842.8 },
+  ];
+  check(
+    "the same study's uncontaminated slope passes",
+    !verdict(slope, { tolerance: 0.1 }).refuse,
+    'forward 2830.7 / reversed 2842.8'
+  );
+
+  // 3. A SINGLE-ORDER RESULT IS REFUSED — the bead's first actionable: a
+  //    study that ran one order has not checked this.
+  const oneOrder = [
+    { arm: 'A', predecessor: 'B', position: 0, value: 100 },
+    { arm: 'A', predecessor: 'B', position: 1, value: 101 },
+    { arm: 'A', predecessor: 'B', position: 2, value: 99 },
+  ];
+  const vOne = verdict(oneOrder, { tolerance: 0.1, factors: ['predecessor'] });
+  check(
+    'a single-order result is refused as UNCHECKED',
+    vOne.refuse && vOne.unchecked && one(vOne, 'A', 'predecessor').status === 'unchecked',
+    one(vOne, 'A', 'predecessor').why
+  );
+
+  // 4. THE HOUSE RULE. Medians 20% apart with overlapping ranges is
+  //    indistinguishable, not a finding. A guard that fired here would
+  //    manufacture contamination out of ordinary noise.
+  const overlapping = [
+    { arm: 'A', predecessor: 'X', position: 0, value: 100 },
+    { arm: 'A', predecessor: 'X', position: 2, value: 140 },
+    { arm: 'A', predecessor: 'X', position: 4, value: 120 },
+    { arm: 'A', predecessor: 'Y', position: 1, value: 90 },
+    { arm: 'A', predecessor: 'Y', position: 3, value: 135 },
+    { arm: 'A', predecessor: 'Y', position: 5, value: 100 },
+  ];
+  const vOv = verdict(overlapping, { tolerance: 0.1 });
+  check(
+    'overlapping ranges are indistinguishable even 20% apart in median',
+    !vOv.refuse,
+    one(vOv, 'A', 'predecessor').why
+  );
+
+  // 5. THE WARM-UP STEP, from `liveReproduction`'s own measured sweep: the
+  //    SAME control, nothing else running, sixteen consecutive windows.
+  //    The predecessor is identical throughout, so ONLY the phase factor
+  //    can catch it — and a guard built to the bead's literal proposal
+  //    (reverse the plan, compare) would not have.
+  const warmup = [
+    10.3223, 10.2627, 10.2588, 10.2588, 10.334, 10.2832,
+    8.1221, 8.1221, 8.1221, 8.1221, 8.1221, 8.1221,
+  ].map((value, i) => ({ arm: 'CTL-SMI-slice', predecessor: 'CTL-SMI-slice', position: i, value }));
+  const vWarm = verdict(warmup, { tolerance: 0.1 });
+  check(
+    'the measured warm-up step is caught by PHASE, which no reversal would show',
+    vWarm.refuse &&
+      one(vWarm, 'CTL-SMI-slice', 'phase').status === 'contaminated' &&
+      one(vWarm, 'CTL-SMI-slice', 'predecessor').status === 'unchecked',
+    `phase: ${one(vWarm, 'CTL-SMI-slice', 'phase').why}`
+  );
+
+  // 6. CYCLIC ROTATION DOES NOT VARY ADJACENCY. Every arm keeps one
+  //    predecessor in every round but the seam, so the order question is
+  //    asked with a single sample in R. The reflecting schedule splits it.
+  const R = 6;
+  const N = 4;
+  const rot = adjacency(N, R, rotationOnly, { seams: false });
+  const ref = adjacency(N, R, schedule, { seams: false });
+  const rotDistinct = Object.values(rot.arms).map((a) => a.distinct);
+  const refDistinct = Object.values(ref.arms).map((a) => a.distinct);
+  const refShare = Math.max(...Object.values(ref.arms).map((a) => a.modalShare));
+  check(
+    'cyclic rotation gives every arm exactly ONE within-round predecessor',
+    rotDistinct.every((d) => d === 1),
+    `rotation over ${R} rounds: distinct predecessors per arm ${rotDistinct.join(',')} ` +
+      '(only the round seam ever differs, and that is one sample in R)'
+  );
+  check(
+    'the reflecting schedule gives every arm TWO, in balance',
+    refDistinct.every((d) => d >= 2) && refShare <= 0.75,
+    `reflected: ${refDistinct.join(',')} predecessors per arm, largest modal share ` +
+      `${(refShare * 100).toFixed(0)}%`
+  );
+
+  return { ok: checks.every((c) => c.ok), checks };
+}
+
+// ---------------------------------------------------------------------------
+// The live reproduction — best effort, never a gate
+// ---------------------------------------------------------------------------
+//
+// The fixtures above prove the guard catches the RECORDED faults. This
+// produces them again from scratch, in plain node, and prices the three
+// factors a plan reversal moves together. It needs a nursery big enough
+// that a window is not truncated by a scavenge — the same flags `b8_run`
+// gives Chromium — and it says so rather than reporting a truncated
+// window as data.
+
+function liveReproduction(opts = {}) {
+  const slots = opts.slots || 1024;
+  const calls = opts.calls || 8;
+  const windows = opts.windows || 16;
+  if (typeof global.gc !== 'function') {
+    return { ran: false, why: 'needs --expose-gc' };
+  }
+  const v8 = require('node:v8');
+  const used = () => v8.getHeapStatistics().used_heap_size;
+
+  // PACKED_SMI and PACKED_DOUBLE, built by push so neither is holey. A
+  // holey array's `.slice()` does not take the packed fast path and the
+  // prediction would be a fiction — `rf2-jr76s`'s own control ladder
+  // records that mistake.
+  const smi = [];
+  for (let i = 0; i < slots; i++) smi.push(i);
+  const dbl = [];
+  for (let i = 0; i < 10000; i++) dbl.push(i + 0.5);
+  const tiny = [1, 2, 3];
+  let sink = 0;
+  let keep = null;
+
+  // One call site per arm. A single site serving arrays of three elements
+  // kinds goes polymorphic, which is a harness artefact wearing a V8
+  // finding's clothes.
+  const runSmi = (n) => { for (let i = 0; i < n; i++) { const c = smi.slice(); sink += c[i % slots]; keep = c; } };
+  const runDbl = (n) => { for (let i = 0; i < n; i++) { const c = dbl.slice(); sink += c[i % 10000]; keep = c; } };
+  const runTiny = (n) => { for (let i = 0; i < n; i++) { const c = tiny.slice(); sink += c[i % 3]; keep = c; } };
+
+  const measure = (n) => {
+    global.gc();
+    const a = used();
+    runSmi(n);
+    return (used() - a) / (n * slots);
+  };
+
+  // --- FACTOR 1: position in the run, nothing else varying ---------------
+  const position = [];
+  for (let k = 0; k < windows; k++) position.push(measure(calls));
+
+  // --- FACTOR 2: the immediate predecessor, position held fixed ----------
+  // Warm first, so both readings sit on the settled side of the step above
+  // and the comparison is about adjacency and nothing else.
+  const predecessor = [];
+  for (let k = 0; k < 6; k++) {
+    runDbl(20);
+    predecessor.push({ arm: 'CTL-SMI-slice', predecessor: 'DBL-10000', position: 2 * k, value: measure(calls) });
+    runTiny(20);
+    predecessor.push({ arm: 'CTL-SMI-slice', predecessor: 'TINY-3', position: 2 * k + 1, value: measure(calls) });
+  }
+
+  // --- FACTOR 3: the window size ----------------------------------------
+  const windowSize = {};
+  for (const n of [calls, calls * 4]) windowSize[n] = measure(n);
+
+  const pc = !!(
+    process.config && process.config.variables && process.config.variables.v8_enable_pointer_compression
+  );
+  // PREDICTED: one tagged slot per element, plus a FixedArray header,
+  // divided over `slots`. 8 bytes a slot on an uncompressed build, 4 on a
+  // compressed one. Page-tail filler is NOT in the prediction and is why a
+  // settled reading lands a little above it.
+  const predicted = (pc ? 4 : 8) + 16 / slots;
+  const settled = position[position.length - 1];
+  const truncated = settled < predicted * 0.8;
+  return {
+    ran: true,
+    sink,
+    kept: keep && keep.length,
+    runtime: `node ${process.version} / V8 ${process.versions.v8}, pointer compression ${pc ? 'ON' : 'OFF'}`,
+    predictedBytesPerSlot: predicted,
+    settledBytesPerSlot: settled,
+    coldBytesPerSlot: position[0],
+    truncated,
+    why: truncated
+      ? 'the settled control reads below its prediction — the window is being truncated by a ' +
+        'scavenge; re-run with --min-semi-space-size=32 --max-semi-space-size=64'
+      : null,
+    position,
+    predecessor,
+    windowSize,
+    predecessorVerdict: verdict(predecessor, { tolerance: 0.1, factors: ['predecessor'] }),
+    positionVerdict: verdict(
+      position.map((value, i) => ({ arm: 'CTL-SMI-slice', predecessor: 'CTL-SMI-slice', position: i, value })),
+      { tolerance: 0.1 }
+    ),
+  };
+}
+
+module.exports = {
+  schedule,
+  rotationOnly,
+  adjacency,
+  median,
+  verdict,
+  format,
+  assertClean,
+  selfTest,
+  liveReproduction,
+};
+
+if (require.main === module) {
+  const st = selfTest();
+  for (const c of st.checks) {
+    console.log(`${c.ok ? 'ok  ' : 'FAIL'}  ${c.name}${c.detail ? '  — ' + c.detail : ''}`);
+  }
+  if (process.argv.includes('--live')) {
+    const live = liveReproduction();
+    console.log('\n;; ==== LIVE REPRODUCTION — plain node, no browser ====');
+    if (!live.ran) {
+      console.log(`;;   skipped: ${live.why}`);
+    } else {
+      console.log(`;;   runtime: ${live.runtime}`);
+      console.log(
+        `;;   POSITIVE CONTROL packed-SMI .slice(): predicted ` +
+          `${live.predictedBytesPerSlot.toFixed(3)} B/slot, settled ` +
+          `${live.settledBytesPerSlot.toFixed(4)}, cold ${live.coldBytesPerSlot.toFixed(4)}`
+      );
+      if (live.truncated) console.log(`;;   WARNING: ${live.why}`);
+      console.log(`;;   FACTOR position:  ${live.position.map((x) => x.toFixed(2)).join(' ')}`);
+      console.log(
+        `;;   FACTOR window size: ${Object.entries(live.windowSize)
+          .map(([n, v]) => `${n} slices -> ${v.toFixed(4)}`)
+          .join(' | ')}`
+      );
+      for (const line of format(live.predecessorVerdict, 'the immediate predecessor, position held fixed')) {
+        console.log(line);
+      }
+      for (const line of format(live.positionVerdict, 'position in the run, predecessor held fixed')) {
+        console.log(line);
+      }
+    }
+  }
+  if (!st.ok) {
+    console.error('\norder guard self-test FAILED');
+    process.exit(1);
+  }
+  console.log('\norder guard self-test ok');
+}


### PR DESCRIPTION
Two repairs to the measurement apparatus, not two measurements.

## rf2-88pie — a figure that moves with the arm order cannot be reported

`rf2-jr76s` recorded a control reading **16.1052 B/slot forward and
8.0027 reversed** against a prediction of 8.000, and filed the class as
*a large-object arm doubles its immediate successor*. Building the remedy
turned up two things.

**The mitigation every B6/B8 row claimed does not exist.** `b8_run.cjs`,
`b6-harness/round!` and `b6-rows/update-round!` all chose the arm for
slot `j` of round `r` as `ARMS[(j + r) % n]`, and all three published
that as *"arm order rotating"*. A cyclic rotation changes which arm goes
FIRST; it does not change which arm follows which — arm `a` sits at slot
`(a − r) mod n`, so its predecessor is arm `(a − 1) mod n` in every
round. Over six rounds of four arms, rotation gives every arm **exactly
one** within-round predecessor; only the round seam differs, one sample
in six. All three now rotate **and reflect** on odd indices.

**A live reproduction says the predecessor is the smallest factor.**
Plain node 24.13.0 / V8 13.6, pointer compression OFF, the same
packed-SMI `.slice()` control:

| factor | reading |
|---|---|
| position in the run, nothing else varying | `10.32 10.26 10.26 10.26 10.33 10.28` then `8.12` ×10 — **+27% for six windows**, then a step to its 8.016 prediction |
| the immediate predecessor, position held fixed | 8.1377 after an 87 KB-object arm, 8.1377 after a 3-element one — **0.0–0.3%** |
| window size, cold vs warm | **2.03×** cold, +1.4% warm |

Both a plan reversal and a change of window size move where in that curve
an arm sits, so **forward-versus-reversed confounds adjacency with
position** and cannot say which it caught.

**The property.** `order_guard.cjs` partitions every arm's samples by
what ran immediately before it **and** by where in the run it was
measured, and applies this repository's own rule: overlapping ranges are
indistinguishable, so a stratification is a finding only when the ranges
are disjoint *and* the medians differ beyond a stated tolerance. One
stratum on a factor is `unchecked`, and **unchecked refuses as loudly as
contaminated** — a single-order result has not been checked and may not
be quoted. `b8_run.cjs` runs the guard's self-test before the browser
starts, the way the key-renaming integrity probe runs before any figure
is read, and **exits 2 on a refusal** with the table printed but marked
unquotable.

The self-test is fixtures replayed from the recorded readings, so it is
deterministic. It **refuses the 2.01× on strata of one sample each**,
passes the same study's 0.43% slope, refuses a single-order plan,
declines to fire on medians 20% apart whose ranges overlap, catches the
measured warm-up step — *which the bead's own proposed remedy would have
missed* — and proves the rotation arithmetic both ways.

**On its first real B8 run** (`B8_ROUNDS=4 --kind narrow`, this repo's
Chromium harness, exit 2) it caught the `instrument` arm — the pseudo-arm
whose whole purpose is to price the harness footprint as a *constant* —
reading **4,361 B/write in its first window and 440 in its last, 9.9×**.
Meanwhile the predecessor factor came out clean on every substantive arm,
and its strata are the ladder's **100 KB-per-write** windows: `floor`
142,167 [141,682–142,652] after one, 146,232 [143,663–148,801] after the
other. **The contaminant on this surface is how long the process has been
running, not what ran immediately before.**

## rf2-vxfjt — the yield stays

`b6_yield_app` rides `b6_prod_run.cjs`'s `B6_INIT_FN` seam, so the
driver, arms and fixture are the published ones. **Chromium 147 headless
via Playwright, `:advanced`, `goog.DEBUG false`.** Six rounds of 3 warm-up
+ 8 samples; three windows and five arms interleaved at the sample level.

**The non-vacuity gate, before any figure.** Both Freehand arms FAIL the
yield-free window. Across both rows **2,772 writes of 20,790 failed their
read-back and every one is a Freehand arm in the `no-yield` window** — 66
of 66 per arm broad, 1,320 of 1,320 per arm narrow, and **0 in every
other one of the fifteen (arm, window) cells**. The write sits outside
any flush, so #7133's closer never fires and the empty `flushSync` after
it has nothing to commit.

| broad, p50 ms/write | `yield` | `no-yield` | `in-flush` |
|---|---:|---:|---:|
| floor | 0.1 [0.1–0.2] | 0.1 [0.1–0.2] | 0.2 [0.1–0.2] |
| **freehand-interpreted** | **3.5** [3.2–4.3] | *0.7* [0.6–0.8] ✗ | **3.5** [3.4–4.7] |
| **freehand-compiled** | **3.1** [3.0–3.8] | *0.6* [0.6–0.8] ✗ | **3.2** [3.0–3.8] |
| reagent | 0.4 [0.3–0.5] | 0.4 [0.3–0.5] | 0.3 [0.3–0.5] |
| `floor+spin` control | 2.1 [2.1–2.1] | 2.1 [2.1–2.1] | 2.1 [2.0–2.1] |

✗ = every write in that cell failed the DOM read-back. A 5× "speed-up"
that is the commit landing outside the measured window.

**The one yield-free window that DOES verify buys nothing.**
`flushSync(write)` then the arm's drain verifies on all four arms and
reads **3.5 [3.4–4.7] against the published 3.5 [3.2–4.3]** — overlapping
ranges on every arm. The legs say where it went: write 0.6–0.8 + gap
2.5–3.2 becomes write 3.4–4.7 + gap 0.0. Same work, third
re-attribution.

**The narrow row is the caution.** There the invalid window's range
*overlaps* the published one (7.5–9.9 against 8.9–11.5), so the clock
alone would have accepted a window in which 1,320 of 1,320 writes never
reached the page. **Only the DOM read-back caught it.**

`b6-rows`' docstring, its published `:measurement-method` string and
`b6_update_dom_cljs_test`'s namespace docstring have all stopped calling
the yield removable.

## Controls, and "N unverified of M"

**Positive control (timing)** — `:floor+spin`, the floor arm with a 2.0 ms
CPU spin around its own drain, predicted to read the floor's plus 2.0 ms
*per write of the sample*:

| | predicted | measured | error |
|---|---:|---:|---:|
| broad, `yield` | 2.1 ms | 2.1 | **0.0** |
| broad, `no-yield` | 2.1 | 2.1 | **0.0** |
| broad, `in-flush` | 2.2 | 2.1 | −0.1 (one clock quantum) |
| narrow, `yield` | 41.7 | 41.1 | −0.6 (**−1.4%**) |
| narrow, `no-yield` | 41.6 | 41.2 | −0.4 (−1.0%) |
| narrow, `in-flush` | 41.7 | 41.1 | −0.6 (−1.4%) |

The per-write factor is not decoration: the first run predicted a flat
+2.0 ms and read +39.1 on the narrow row. **The control caught the
harness's own arithmetic.**

**Positive control (allocation)** — packed-SMI `.slice()`, predicted
**8.016 B/slot** (one 8-byte tagged slot plus a 16-byte header, over
1,024 slots, uncompressed): settled **8.1221** (+1.3%), cold **10.3193**
(+28.7%).

**Unverified writes.** rf2-vxfjt: **132 of 990** broad and **2,640 of
19,800** narrow, all of them the two Freehand arms in the `no-yield`
window, 0 in the other thirteen cells. B8 smoke: **0 of 1,600**.
`bench:freehand-browser`: 0 failures of 465 assertions.

**Runtime labels.** Every timing figure is Chromium 147 headless,
`:advanced`, `goog.DEBUG false`. Every allocation figure in the guard's
live reproduction is node 24.13.0 / V8 13.6 with pointer compression
**OFF** — Chrome's is ON, so a tagged slot is 4 bytes there and 8 here.
Shares transfer; absolutes do not.

## What could not be determined

- **The V8 mechanism** behind the warm-up step is still undiagnosed; the
  bead said so and this does not change it.
- **`rf2-jr76s`'s own harness is not reproduced here** and lives outside
  this PR's fence, so nothing above restates what happened inside it.
  The claim is about the *remedy*, not about that run.
- **No re-take of B8's published figures.** Their provenance now carries
  the correction that the rotation was not a mitigation; whether the
  numbers moved is unmeasured and not claimed.
- **B8's warm-up is not widened.** The guard detects an insufficient
  warm-up rather than preventing it, which is why the smoke run exits 2.

## Quality gates

| gate | result | exit |
|---|---|---:|
| `npm run bench:freehand-browser` | 30 tests / 465 assertions, 0 failures 0 errors | **0** |
| `implementation/freehand` JVM `clojure -M:test` | 1,284 tests / 8,803 assertions, 0 failures 0 errors | **0** |
| `npm run test:browser` (correctness lane unaffected) | 841 tests / 5,459 assertions, 0 failures 0 errors | **0** |
| `node order_guard.cjs --live` (self-test + live reproduction) | 7 of 7 checks ok | **0** |
| `B8_ROUNDS=4 b8_run.cjs --kind narrow` | 0 unverified of 1,600; **guard REFUSED** — see above, this is the feature | **2** |
| `b6_prod_run.cjs` via `B6_INIT_FN=…b6-yield-app/-main` | 6 rounds × 2 rows, gate + control on the record | **0** |

Everything slower — `test:cljs`, the full B8/B7 sweeps, mcp-conformance —
is **deferred to CI**.
