### PR TITLE
ci: the bench and docs navigations name their own ceilings (rf2-p9fa3, rf2-rbyyx)

### DIFF
--- a/docs/scripts/generate-story-tutorial-screenshots.cjs
+++ b/docs/scripts/generate-story-tutorial-screenshots.cjs
@@ -29,6 +29,34 @@ const { chromium } = require(require.resolve('playwright', { paths: [IMPL_ROOT] 
 
 const VIEWPORT = { width: 1440, height: 900 };
 
+/*
+ * The two ceilings `captureShot` used to leave anonymous (rf2-rbyyx).
+ *
+ * `page.goto(url, { waitUntil: 'networkidle' })` and `locator.waitFor(...)`
+ * both apply Playwright's 30s default when no `timeout:` is passed. Neither
+ * number appeared in this file, so a stall printed `Timeout 30000ms exceeded`
+ * without saying which of the two it was — or that a NAVIGATION, rather than
+ * a missing element, is what failed. The sibling generator beside this one
+ * (`generate-tutorial-screenshots.cjs`) already passes `{ waitUntil: 'load',
+ * timeout: 30000 }` and an explicit locator timeout; this one never got the
+ * same treatment.
+ *
+ * `networkidle` is KEPT, and deliberately. A screenshot generator wants a
+ * SETTLED page — that is the artefact, and the PNGs it writes are committed.
+ * `'load'` or `'commit'` would shoot a page whose bundle may still be
+ * mounting, quietly changing the images this repo ships. So the event stays
+ * and only the number is named.
+ *
+ * The number is doubled to 60s rather than copied from the sibling's 30s,
+ * because `networkidle` settles strictly LATER than the `load` that sibling
+ * waits for; 30s here would re-enact the default it replaces. Demonstrated
+ * (rf2-rbyyx): against a page whose subresource is held 35s, a bare
+ * `goto{waitUntil:'networkidle'}` dies at 30016ms, and the same call with
+ * `timeout: 60000` resolves at 35519ms.
+ */
+const NAV_TIMEOUT_MS = 60000;
+const SHOT_VISIBLE_TIMEOUT_MS = 30000;
+
 const APPS = {
   '/login': {
     html: path.join(REPO_ROOT, 'tools', 'story', 'testbeds', 'login_form', 'index.html'),
@@ -203,8 +231,22 @@ async function withServer(fn) {
 
 async function captureShot(page, baseUrl, shot) {
   const url = `${baseUrl}${shot.app}/${shot.query || ''}${shot.hash || ''}`;
-  await page.goto(url, { waitUntil: 'networkidle' });
-  await page.locator(shot.waitFor).first().waitFor({ state: 'visible' });
+  try {
+    await page.goto(url, { waitUntil: 'networkidle', timeout: NAV_TIMEOUT_MS });
+  } catch (err) {
+    throw new Error(
+      `NAVIGATION FAILED for ${shot.file} — this is the page.goto ceiling ` +
+        `(waitUntil: 'networkidle', timeout: ${NAV_TIMEOUT_MS}ms), NOT the ` +
+        `${SHOT_VISIBLE_TIMEOUT_MS}ms wait for \`${shot.waitFor}\`, which had ` +
+        `not yet started. The page never settled, so no screenshot was taken ` +
+        `and the committed PNG is unchanged (rf2-rbyyx). Underlying: ` +
+        `${err.message}`
+    );
+  }
+  await page
+    .locator(shot.waitFor)
+    .first()
+    .waitFor({ state: 'visible', timeout: SHOT_VISIBLE_TIMEOUT_MS });
   if (shot.before) {
     await shot.before(page);
   }

--- a/docs/tools/playground/test/smoke.test.mjs
+++ b/docs/tools/playground/test/smoke.test.mjs
@@ -392,7 +392,46 @@ const page = await browser.newPage();
 const pageErrors = [];
 page.on("pageerror", (e) => pageErrors.push(e.message));
 
-await page.goto(url, { waitUntil: "networkidle" });
+/*
+ * The navigation's OWN ceiling, named (rf2-rbyyx).
+ *
+ * This `goto` carried no `timeout:`, so it took Playwright's 30s default —
+ * a budget nothing in this file could see or move, and one whose failure
+ * line (`Timeout 30000ms exceeded`) is indistinguishable from the 20000ms
+ * assertion waits immediately below it. The failure is worse here than
+ * elsewhere in the class because `networkidle` settles strictly LATER than
+ * `load`, so the default bites sooner relative to what is being waited for.
+ *
+ * `networkidle` is KEPT, and this is the site where keeping it matters most:
+ * the page under test deliberately ships NO Scittle <script>, because the
+ * contract being smoked is that the production bootstrap injects one — from
+ * `https://cdn.jsdelivr.net/npm/scittle@…` (see src/playground.mjs
+ * `SCITTLE_BASE`). So this page's settle genuinely depends on a fetch across
+ * the public internet from a CI runner. Switching to `'load'` or `'commit'`
+ * would push that CDN fetch onto the 20000ms `waitForFunction` below and make
+ * the lane FLAKIER, not tighter.
+ *
+ * 60s, therefore: three times the assertion budgets it must stay
+ * distinguishable from, and generous enough that a slow-but-working jsDelivr
+ * is not read as a broken bootstrap. Demonstrated (rf2-rbyyx): against a page
+ * whose subresource is held 35s, a bare `goto{waitUntil:'networkidle'}` dies
+ * at 30016ms, and the same call with `timeout: 60000` resolves at 35519ms.
+ */
+const NAV_TIMEOUT_MS = 60000;
+
+try {
+  await page.goto(url, { waitUntil: "networkidle", timeout: NAV_TIMEOUT_MS });
+} catch (e) {
+  throw new Error(
+    "NAVIGATION FAILED — this is the page.goto ceiling (waitUntil: " +
+      `'networkidle', timeout: ${NAV_TIMEOUT_MS}ms), NOT any of the 20000ms ` +
+      "assertion waits below, none of which had started. The page never " +
+      "settled, so nothing about the playground bundles has been observed. " +
+      "Note that settling requires the bootstrap's Scittle fetch from " +
+      "cdn.jsdelivr.net, so a CDN stall lands here (rf2-rbyyx). Underlying: " +
+      e.message
+  );
+}
 
 // The bootstrap must inject Scittle and mount the cells.
 await page.waitForFunction(

--- a/implementation/freehand/test/re_frame/freehand/bench/b10_prod_run.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b10_prod_run.cjs
@@ -28,6 +28,8 @@ const fs = require('node:fs');
 const http = require('node:http');
 const path = require('node:path');
 
+const { navigate, NAV_TIMEOUT_MS } = require('./navigate.cjs');
+
 const IMPL = path.resolve(__dirname, '../../../../..');
 const OUT_DIR = process.env.B10_OUT_DIR || 'out/b10-prod';
 const INIT_FN = process.env.B10_INIT_FN || 're-frame.freehand.bench.b10-prod-app/-main';
@@ -123,7 +125,19 @@ async function run() {
   // during page load, so the `load` event cannot fire until the whole run
   // yields — waiting for it would be waiting for the benchmark, against a
   // budget separate from the one below.
-  await page.goto(`http://127.0.0.1:${PORT}/`, { waitUntil: 'commit', timeout: 60 * 1000 });
+  //
+  // This call was RIGHT and its four siblings were wrong, hand-patched here
+  // and nowhere else — which is how rf2-p9fa3 got filed. It now routes
+  // through the directory's shared navigation, at the same event and the same
+  // 60s (`NAV_TIMEOUT_MS` is this call's number, kept), so there is one
+  // navigation to get right instead of five to keep in step. It gains the one
+  // thing it was still missing: a failure that says it is the navigation
+  // ceiling and not the twenty-minute wait below.
+  await navigate(page, `http://127.0.0.1:${PORT}/`, {
+    waitUntil: 'commit',
+    timeoutMs: NAV_TIMEOUT_MS,
+    budget: 'the 20-minute wait for `window.B10_DONE`',
+  });
   await page.waitForFunction('window.B10_DONE === true || window.B10_ERROR', null, {
     timeout: 20 * 60 * 1000,
   });

--- a/implementation/freehand/test/re_frame/freehand/bench/b6_prod_run.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b6_prod_run.cjs
@@ -19,6 +19,8 @@ const fs = require('node:fs');
 const http = require('node:http');
 const path = require('node:path');
 
+const { navigate, NAV_TIMEOUT_MS } = require('./navigate.cjs');
+
 const IMPL = path.resolve(__dirname, '../../../../..');
 // `B6_INIT_FN` / `B6_OUT_DIR` point this driver at a different entry —
 // the seam an ABLATION LADDER rides so that it reuses this window rather
@@ -86,7 +88,19 @@ async function run() {
     if (t.startsWith(';; B6')) console.log(t);
   });
   page.on('pageerror', (e) => console.error('[b6] page error:', e.message));
-  await page.goto(`http://127.0.0.1:${PORT}/${QUERY}`, { waitUntil: 'load' });
+  // `'commit'`, not `'load'` (rf2-p9fa3). `b6-prod-app/-main` is this
+  // bundle's `:init-fn`, so it runs inside the `<script>` — the parity pass
+  // and every mount row are measured while the document is still loading,
+  // and only then does the promise chain start the update rows. `load`
+  // therefore cannot fire until the published run has yielded, which is
+  // exactly what `B6_DONE` waits for below, against a budget thirty times
+  // larger. Waiting for `load` was waiting for the benchmark against a
+  // ceiling nothing here could see or move.
+  await navigate(page, `http://127.0.0.1:${PORT}/${QUERY}`, {
+    waitUntil: 'commit',
+    timeoutMs: NAV_TIMEOUT_MS,
+    budget: 'the 15-minute wait for `window.B6_DONE`',
+  });
   await page.waitForFunction('window.B6_DONE === true || window.B6_ERROR', null, {
     timeout: 15 * 60 * 1000,
   });

--- a/implementation/freehand/test/re_frame/freehand/bench/b6_profile_run.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b6_profile_run.cjs
@@ -23,6 +23,8 @@ const fs = require('node:fs');
 const http = require('node:http');
 const path = require('node:path');
 
+const { navigate, NAV_TIMEOUT_MS } = require('./navigate.cjs');
+
 const IMPL = path.resolve(__dirname, '../../../../..');
 const OUT = path.join(IMPL, 'out', 'b6-profile');
 const PORT = Number(process.env.B6_PORT || 8129);
@@ -92,7 +94,19 @@ async function run() {
     if (t.startsWith(';; B6')) console.error(t);
   });
   page.on('pageerror', (e) => console.error('[b6p] page error:', e.message));
-  await page.goto(`http://127.0.0.1:${PORT}/`, { waitUntil: 'load' });
+  // `'commit'`, not `'load'` (rf2-p9fa3). `b6-profile-app/-main` is this
+  // bundle's `:init-fn`: it mounts the profiled arm, mounts the reference arm
+  // and canonicalises BOTH pages for the parity gate — all synchronously,
+  // inside the `<script>`, before the seed promise flips `B6_READY`. `load`
+  // is downstream of every one of those, so it cannot fire until the wait
+  // below is already satisfiable. A `:pseudo-names` bundle is also the
+  // largest artefact any driver here serves, which makes this the site most
+  // likely to have quietly spent seconds of the anonymous 30s on parse alone.
+  await navigate(page, `http://127.0.0.1:${PORT}/`, {
+    waitUntil: 'commit',
+    timeoutMs: NAV_TIMEOUT_MS,
+    budget: 'the 5-minute wait for `window.B6_READY`',
+  });
   await page.waitForFunction('window.B6_READY === true || window.B6_ERROR', null, {
     timeout: 5 * 60 * 1000,
   });

--- a/implementation/freehand/test/re_frame/freehand/bench/b7_run.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b7_run.cjs
@@ -56,6 +56,8 @@ const fs = require('node:fs');
 const http = require('node:http');
 const path = require('node:path');
 
+const { navigate, NAV_TIMEOUT_MS } = require('./navigate.cjs');
+
 const IMPL = path.resolve(__dirname, '../../../../..');
 const OUT = path.join(IMPL, process.env.B7_OUT_DIR || path.join('out', 'b7'));
 const PORT = Number(process.env.B7_PORT || 8131);
@@ -138,7 +140,12 @@ function serve() {
     .listen(PORT);
 }
 
-async function newPage(chromium, query) {
+// `budget` names the sentinel wait each caller is about to make, so a
+// navigation failure cannot be read as that wait. The two modes are bounded
+// very differently — 120s for the heap instrument, fifteen minutes for the
+// mount-frame run — which is the second reason the ceiling has to say which
+// one it is NOT.
+async function newPage(chromium, query, budget) {
   const browser = await chromium.launch({
     args: ['--enable-precise-memory-info', '--js-flags=--expose-gc'],
   });
@@ -148,7 +155,20 @@ async function newPage(chromium, query) {
     if (t.startsWith(';; B7')) console.log(t);
   });
   page.on('pageerror', (e) => console.error('[b7] page error:', e.message));
-  await page.goto(`http://127.0.0.1:${PORT}/${query}`, { waitUntil: 'load' });
+  // `'commit'`, not `'load'` (rf2-p9fa3), and this is the SHARPEST instance of
+  // the class in the repo. `b7-app/-main` is the bundle's `:init-fn`, and in
+  // `?mode=mount-frame` it runs `run-mount-frame!` — the parity pass plus six
+  // rounds over every witness — SYNCHRONOUSLY, inside the `<script>`. The
+  // `load` event is therefore downstream of a run this file gives FIFTEEN
+  // MINUTES, and `page.goto` was silently capping it at thirty seconds.
+  // Demonstrated against exactly this shape: a page that burns 35s during
+  // load dies at 30007ms bare, and resolves at 35020ms on `'commit'` plus the
+  // poll that already owned the wait.
+  await navigate(page, `http://127.0.0.1:${PORT}/${query}`, {
+    waitUntil: 'commit',
+    timeoutMs: NAV_TIMEOUT_MS,
+    budget,
+  });
   return { browser, page };
 }
 
@@ -264,7 +284,9 @@ function snapshotTotal(cdp) {
 // ---------------------------------------------------------------------------
 
 async function heapRow(chromium) {
-  const { browser, page } = await newPage(chromium, '?mode=heap');
+  const { browser, page } = await newPage(
+    chromium, '?mode=heap', 'the 120s wait for `window.B7_READY`'
+  );
   await page.waitForFunction('window.B7_READY === true || window.B7_ERROR', null, { timeout: 120000 });
   const err = await page.evaluate('window.B7_ERROR || null');
   if (err) {
@@ -415,7 +437,9 @@ async function heapRow(chromium) {
 
 async function mountFrameRow(chromium) {
   const q = process.env.B7_MOUNT_QUERY || '';
-  const { browser, page } = await newPage(chromium, `?mode=mount-frame${q}`);
+  const { browser, page } = await newPage(
+    chromium, `?mode=mount-frame${q}`, 'the 15-minute wait for `window.B7_DONE`'
+  );
   await page.waitForFunction('window.B7_DONE === true || window.B7_ERROR', null, {
     timeout: 15 * 60 * 1000,
   });

--- a/implementation/freehand/test/re_frame/freehand/bench/b8_run.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b8_run.cjs
@@ -48,6 +48,7 @@ const http = require('node:http');
 const path = require('node:path');
 
 const guard = require('./order_guard.cjs');
+const { navigate, NAV_TIMEOUT_MS } = require('./navigate.cjs');
 
 const IMPL = path.resolve(__dirname, '../../../../..');
 const OUT = path.join(IMPL, 'out', 'b8');
@@ -149,7 +150,20 @@ async function main() {
     if (t.startsWith(';; B8')) console.error(t);
   });
   page.on('pageerror', (e) => console.error('[b8] page error:', e.message));
-  await page.goto(`http://127.0.0.1:${PORT}/`, { waitUntil: 'load' });
+  // `'commit'`, not `'load'` (rf2-p9fa3). `b8-app/-main` is the bundle's
+  // `:init-fn`: it mounts all four update arms and installs `window.B8`
+  // synchronously inside the `<script>`, and only the seed that follows is
+  // async. `load` cannot fire before any of that, so waiting for it duplicates
+  // the `B8_READY` wait below against a budget ten times smaller — and a
+  // driver that died there would have burned the `:advanced` build for
+  // nothing, with a line naming the wrong budget. The arm-order guard has
+  // already self-tested by this point, deliberately ahead of Chromium; this
+  // navigation cannot reach it either way.
+  await navigate(page, `http://127.0.0.1:${PORT}/`, {
+    waitUntil: 'commit',
+    timeoutMs: NAV_TIMEOUT_MS,
+    budget: 'the 5-minute wait for `window.B8_READY`',
+  });
   await page.waitForFunction('window.B8_READY === true || window.B8_ERROR', null, {
     timeout: 5 * 60 * 1000,
   });

--- a/implementation/freehand/test/re_frame/freehand/bench/navigate.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/navigate.cjs
@@ -1,0 +1,100 @@
+'use strict';
+
+/*
+ * The bench drivers' ONE navigation, with its ceiling NAMED (rf2-p9fa3).
+ *
+ * THE DEFECT
+ * ----------
+ * `page.goto(url, { waitUntil: 'load' })` with no `timeout:` takes
+ * Playwright's 30s default. On a bench driver that default is a SECOND
+ * budget: invisible in the source, unreachable from the driver's own knob,
+ * and — the part that costs an afternoon — indistinguishable in a log from
+ * the budget the driver does own. `page.goto: Timeout 30000ms exceeded`
+ * reads like the bench's own timeout, so the fix reached for is a bigger
+ * bench timeout, which cannot move it.
+ *
+ * `'load'` is not merely tight here, it is the WRONG EVENT. Every bench page
+ * in this directory is a plain `:browser` module whose `:init-fn` runs at
+ * bundle-execution time — inside the `<script>` the document is still
+ * loading. So `load` cannot fire until the benchmark has yielded, which is
+ * precisely what each driver's own `waitForFunction` sentinel already waits
+ * for, against a budget of five to twenty MINUTES. Waiting for `load` is
+ * waiting for the measurement, against the one budget that was never meant
+ * to bound it.
+ *
+ * Demonstrated (rf2-p9fa3), against this exact document shape — a page whose
+ * script burns 35s synchronously during load:
+ *
+ *     goto{waitUntil:'load'}                      30007ms  THREW (30000ms)
+ *     goto{waitUntil:'commit',timeout:60000}+poll 35020ms  RESOLVED
+ *
+ * WHY THIS FILE EXISTS RATHER THAN FIVE COPIES
+ * --------------------------------------------
+ * `b10_prod_run.cjs` was ALREADY given `{ waitUntil: 'commit', timeout:
+ * 60000 }` by hand while its four siblings kept the defect — one driver hit
+ * the ceiling, one driver was patched, and the directory drifted. Per-file
+ * drift is the failure mode, so the directory gets one navigation and the
+ * per-site judgement stays where it belongs: at the call, in the `budget` it
+ * names.
+ *
+ * WHY `timeoutMs` IS REQUIRED AND NOT DEFAULTED
+ * ---------------------------------------------
+ * A default would be the anonymous ceiling again, merely relocated into our
+ * own source. `NAV_TIMEOUT_MS` below is the number every driver here passes;
+ * it is exported so there is one of it, and passed explicitly so each call
+ * still says so.
+ */
+
+/*
+ * 60s for a `'commit'` — the point at which the local `http.createServer`
+ * these drivers stand up has answered with headers. That is a filesystem
+ * read over loopback; 60s is enormous for it, and enormously smaller than
+ * the five-to-twenty-minute sentinel waits it must stay distinguishable
+ * from. Handing the navigation the bench's own budget would trade a
+ * mislabelled failure for a silent one: a driver that never reached its page
+ * would sit for twenty minutes looking like a slow benchmark.
+ *
+ * The number is `b10_prod_run.cjs`'s, kept: it was the one site that had
+ * already made this call correctly.
+ */
+const NAV_TIMEOUT_MS = 60 * 1000;
+
+/**
+ * Navigate, and make a navigation failure say that it IS one.
+ *
+ * @param page        Playwright page.
+ * @param url         Where to go.
+ * @param timeoutMs   REQUIRED. This navigation's own ceiling.
+ * @param waitUntil   REQUIRED. `'commit'` for every bench page today — see above.
+ * @param budget      What this ceiling is NOT, in words, for the failure line.
+ */
+async function navigate(page, url, { timeoutMs, waitUntil, budget } = {}) {
+  if (typeof timeoutMs !== 'number' || !Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    throw new Error(
+      `navigate: timeoutMs is REQUIRED and must be a positive number (got ` +
+        `${JSON.stringify(timeoutMs)}). Omitting it hands the navigation ` +
+        "Playwright's 30s default — a ceiling no bench budget can reach, and " +
+        "whose failure line reads like the bench's own timeout (rf2-p9fa3)."
+    );
+  }
+  if (!waitUntil) {
+    throw new Error(
+      'navigate: waitUntil is REQUIRED. Omitting it takes Playwright\'s ' +
+        "'load', which on a bench page cannot fire until the benchmark has " +
+        'yielded (rf2-p9fa3).'
+    );
+  }
+  try {
+    await page.goto(url, { waitUntil, timeout: timeoutMs });
+  } catch (err) {
+    throw new Error(
+      `NAVIGATION FAILED — this is the page.goto ceiling (waitUntil: ` +
+        `'${waitUntil}', timeout: ${timeoutMs}ms), NOT ${budget}, which had ` +
+        `not yet started. The page at ${url} was never reached, so nothing ` +
+        `was measured and there is no figure to distrust. Raising the bench ` +
+        `budget cannot move this (rf2-p9fa3). Underlying: ${err.message}`
+    );
+  }
+}
+
+module.exports = { navigate, NAV_TIMEOUT_MS };


### PR DESCRIPTION
Closes rf2-p9fa3, rf2-rbyyx. The last six sites of the class #7193 opened, #7221 widened and #7224 swept — the six #7224 could not reach, and waived by name.

`page.goto(url)` with no `timeout:` takes Playwright's 30s default. That default is a **second budget**: invisible in the source, unreachable from the runner's own knob, and — the part that costs an afternoon — indistinguishable in a log from the budget the runner *does* own. `Timeout 30000ms exceeded` reads like the lane timeout, so the fix reached for is a bigger lane timeout, which cannot move it.

Following #7224's rule: **decided per site, not rewritten mechanically.** Four switch event, two keep it.

## The demonstration

Both shapes, against real headless Chromium, held 35s. Every lane budget in view is five to twenty **minutes**:

```
--- the BENCH shape: the bundle burns synchronously during load ---
1. goto{waitUntil:'load'}            (today, bare)     30007ms  THREW: Timeout 30000ms exceeded
2. goto{waitUntil:'commit',timeout:60000} + poll       35020ms  RESOLVED

--- the DOCS shape: networkidle, subresource held ---
3. goto{waitUntil:'networkidle'}      (today, bare)    30016ms  THREW: Timeout 30000ms exceeded
4. goto{waitUntil:'networkidle',timeout:60000}         35519ms  RESOLVED
```

Row 4 is #7224's row 3 restated for the sharper event: a site that legitimately wants a settled page is rescued by **naming the number alone**. Rows 1 and 3 are what these six files carried.

## The four bench drivers — switched to `'commit'` (rf2-p9fa3)

`'load'` was the **wrong event** here, not merely a tight one. Every bench page is a plain `:browser` module whose `:init-fn` runs at bundle-execution time — inside the `<script>`, while the document is still loading. So `load` is downstream of the measurement itself, which is exactly what each driver's own sentinel poll already waits for:

| driver | what runs during load | the poll that already owned the wait |
|---|---|---|
| `b7_run.cjs` (`?mode=mount-frame`) | `run-mount-frame!` — parity pass + 6 rounds over every witness, **synchronously** | `waitForFunction(B7_DONE)`, **15 min** |
| `b7_run.cjs` (`?mode=heap`) | `heap/install!` | `waitForFunction(B7_READY)`, 120s |
| `b6_prod_run.cjs` | parity pass + every mount row, then the update chain | `waitForFunction(B6_DONE)`, **15 min** |
| `b6_profile_run.cjs` | mounts the profiled arm, mounts the reference arm, canonicalises both for the parity gate | `waitForFunction(B6_READY)`, 5 min |
| `b8_run.cjs` | mounts all four update arms, installs `window.B8` | `waitForFunction(B8_READY)`, 5 min |

b7's mount-frame row is the sharpest instance in the repo: a fifteen-minute run whose navigation was silently capped at thirty seconds.

**60s, not the driver's own budget.** For a `'commit'` the navigation only has to reach headers from a local `http.createServer` reading off the filesystem — 60s is enormous for that, and enormously smaller than the sentinel waits it must stay distinguishable from. Handing the navigation the bench's budget would trade a mislabelled failure for a silent one: a driver that never reached its page would sit for twenty minutes looking like a slow benchmark. The number is `b10_prod_run.cjs`'s, kept.

### One navigation for the directory, and why b10 is in the diff

`b10_prod_run.cjs` had **already** been given `{ waitUntil: 'commit', timeout: 60000 }` by hand while its four siblings kept the defect — one driver hit the ceiling, one driver was patched, the directory drifted. That drift is what filed this bead, so the structural fix is one navigation rather than five kept in step: `bench/navigate.cjs`. b10 routes through it at the same event and the same number, and gains the one thing it was still missing — a failure that says it is the navigation ceiling and not the twenty-minute wait below.

`timeoutMs` is **required, never defaulted** (as in #7224's helpers): a default would be the anonymous ceiling relocated into our own source. `waitUntil` is required for the same reason — omitting it silently restores `'load'`.

Driven against a real Chromium on the real bench shape (a page burning 8s during load):

```
1. the helper REFUSES an anonymous ceiling
  ok  no options / empty options / non-numeric / zero timeoutMs: refused, naming timeoutMs
  ok  missing waitUntil: refused, naming waitUntil
2. it NAVIGATES a page that burns 8000ms during load
  ok  commit returned at 8ms — before the burn ended
  ok  the driver's own poll saw the sentinel at 8025ms
3. when the ceiling DOES fire, the failure names it
  NAVIGATION FAILED — this is the page.goto ceiling (waitUntil: 'commit',
  timeout: 1500ms), NOT the 15-minute wait for `window.B7_DONE`, which had not
  yet started. The page at http://127.0.0.1:9/ was never reached, so nothing
  was measured and there is no figure to distrust. Raising the bench budget
  cannot move this (rf2-p9fa3).
```

`bench/order_guard.cjs` (#7223) is untouched, still runs ahead of Chromium, and still exits 2 on a refusal. Its 7 self-test checks pass; this navigation cannot reach it either way.

## The two docs sites — kept `networkidle` (rf2-rbyyx)

Both keep the event, and in both cases that is the load-bearing decision:

| site | why `networkidle` stays |
|---|---|
| `docs/scripts/generate-story-tutorial-screenshots.cjs` | a screenshot generator wants a **settled** page — that *is* the artefact, and the PNGs it writes are **committed**. `'load'` would shoot a page that may still be mounting and quietly change the images the site ships. |
| `docs/tools/playground/test/smoke.test.mjs` | the page ships **no Scittle `<script>` on purpose** — the contract under test is that the bootstrap injects one, from `cdn.jsdelivr.net` (`SCITTLE_BASE` in `src/playground.mjs`). Its settle genuinely depends on a public-CDN fetch, so `'load'`/`'commit'` would push that fetch onto the 20000ms `waitForFunction` below and make the lane **flakier**, not tighter — #7224's "keep `'load'`" reasoning, one event later. |

**60s, not the sibling's 30s.** `docs/scripts/generate-tutorial-screenshots.cjs` — beside the first of these — already passes `{ waitUntil: 'load', timeout: 30000 }`; this one never got the same treatment. But `networkidle` settles strictly *later* than `load`, so copying 30s would re-enact the default it replaces.

Measured against the **real committed** `docs/cljs/playground.js`, one plain-eval cell:

```
networkidle settled at         3572ms
ceiling now named in source   60000ms
Playwright's anonymous default 30000ms   (what it was)
scittle global installed      true
CDN requests observed         1
  https://cdn.jsdelivr.net/npm/scittle@0.8.31/dist/scittle.js
```

A healthy run settles in 3.6s — 17x under the new ceiling — and the CDN dependency that justifies keeping `networkidle` is confirmed rather than assumed.

The screenshot generator's **locator** wait carried the same anonymous 30s default one line later, so it is named too, at its existing effective value: a stall there and a stall in the navigation printed the identical line, and now they don't.

## Which waiver rows can now be removed — reported, not edited

**All six.** `implementation/scripts/_navigation-ceiling-policy.test.cjs` is #7224's file and is untouched here.

The waiver is an upper bound, so a passing gate does not by itself prove a row is dead. So the **real sweep was run with its `WAIVED` table emptied in memory** (source patched in a string, compiled at its own path; nothing on disk touched, `git status` clean after):

```
emptying the waiver (6 rows):
  implementation/freehand/test/re_frame/freehand/bench/b6_prod_run.cjs
  implementation/freehand/test/re_frame/freehand/bench/b6_profile_run.cjs
  implementation/freehand/test/re_frame/freehand/bench/b7_run.cjs
  implementation/freehand/test/re_frame/freehand/bench/b8_run.cjs
  docs/scripts/generate-story-tutorial-screenshots.cjs
  docs/tools/playground/test/smoke.test.mjs

running the REAL sweep with NO waiver ...
navigation-ceiling-policy tests: 3 passed.            EXIT=0
```

Every row is dead; the whole `WAIVED` table can go, and with it the `max`/`bead` bookkeeping. **The upper bound was correct** — each of the six had exactly the one bare navigation it was budgeted for, and none needed more than its `max: 1`.

New file `bench/navigate.cjs` is itself in the sweep's scan and passes: its single `page.goto` carries an explicit `timeout:`.

## Does any green lane change behaviour?

**No green lane changes.** Two independent reasons, and one of them is stronger than #7224's:

- **The four bench drivers are not in CI at all.** Nothing in `implementation/package.json` or `.github/workflows/**` invokes `b6_prod_run` / `b6_profile_run` / `b7_run` / `b8_run` / `b10_prod_run` (grep is empty). They are standalone manual instruments — `node .../b7_run.cjs` — each an `:advanced` release build plus a 5–20 minute measurement. `npm run bench:freehand-browser` is a *different* artefact (`browser-test-freehand-bench` via `serve-and-run-browser-tests.cjs`, already fixed by #7193) and does not touch these files.
- **Both docs sites kept their event and their effective behaviour.** A green run navigates in seconds; raising a ceiling only affects a run that was going to fail at the old one.

What changes is the **failing** path, in three ways, all improvements:

- a bench driver whose page is slow no longer dies at a 30s ceiling that was never the constraint — the sentinel poll that owns the wait gets its documented 5–20 minutes, and the `'commit'` return is *ahead* of the burn rather than behind it (measured: 8ms vs 8025ms);
- every one of the eight touched navigations now fails with a line naming **which** ceiling fired and **which** budget it is not, instead of a bare `Timeout 30000ms exceeded`;
- the screenshot generator's two 30s budgets stop being the same anonymous number.

## Quality gates

Run from the worker worktree, foreground, to completion. Rebased onto `origin/main` **after #7224 merged**, so the sweep below is the real merged one.

| gate | exit |
|---|---|
| `npm run test:script-policy` — 29 suites, 291 assertions, incl. #7224's merged `_navigation-ceiling-policy.test.cjs` | **0** |
| `_navigation-ceiling-policy.test.cjs` alone, against this tree (3 passed) | **0** |
| the same sweep with the `WAIVED` table **emptied** — proves all six rows dead (3 passed) | **0** |
| `bench/order_guard.cjs` self-test — 7 checks, undisturbed by this change | **0** |
| navigation-ceiling demonstration, both shapes (30007 / 35020 / 30016 / 35519 ms) | **0** |
| `bench/navigate.cjs` driven against real Chromium — 5 refusals, 2 navigation timings, 5 message assertions | **0** |
| playground `networkidle` settle measured against the real committed bundle (3572ms, jsDelivr fetch observed) | **0** |
| `node --check` on all 8 touched files | **0** |

**Deferred to CI**, with reasons:

- **the four bench drivers themselves** — no CI lane runs them (see above), and each is an `:advanced` shadow-cljs release build plus a 5–20 minute measurement. Their changed code path was driven directly against a real Chromium instead, on the document shape they actually serve.
- **`npm run smoke` (playground)** — `docs/cljs/playground-rf2.js` is a generated, untracked artefact needing a JVM + shadow-cljs + `npm ci` in `docs/tools/playground/`. The `tools-playground` job builds it. The navigation this PR changes was measured against the real committed `playground.js` bundle instead.
- **the Story screenshot generator** — needs three compiled Story testbed bundles (`shadow-cljs compile :examples/…`) and writes committed PNGs; not a PR lane.
- **`shellcheck`** — not installed on this box; no shell script was touched.
