### PR TITLE
bench: the order guard reaches the core harnesses, and B8's warm-up is wide enough (rf2-om73r, rf2-tb345)

### DIFF
--- a/docs/design/freehand/studio/freehand-vs-reagent-allocation.md
+++ b/docs/design/freehand/studio/freehand-vs-reagent-allocation.md
@@ -437,6 +437,93 @@ than green.
 
 Raw: `ai/findings/2026-07-28.88pie-b8-order-guard-raw.txt` (local-only).
 
+### The warm-up, widened — and the run goes green (rf2-tb345)
+
+Four writes size a window; they do not warm one. Each `(arm, D)` now gets
+a floor of six FULL-SIZE windows that are thrown away, and keeps warming
+while the guard's own phase rule still separates the trajectory's first
+third from its last, to a ceiling of ten. Asking the settling question
+the way the guard will ask it is the only way the loop can promise
+anything about the guard — and a first draft that instead asked whether
+the last three windows agreed within 10% could not tell a site that is
+still warming from one that is merely noisy, so `reagent/D=0` (which
+spreads 23,977–28,515 B/write when fully warm) would have warmed to the
+ceiling for ever.
+
+**The `instrument` arm is the one that justifies the ceiling**, and it does
+not decay smoothly — it is bimodal. Three consecutive `--kind narrow` runs
+in this repository's Chromium harness, its D=0 warm-up trajectory each
+time:
+
+```
+5,969   466  10,968  440   9,512  440  440  440
+11,824  6,041 16,372 440   5,846  440  440  440  440  14,109
+7,047   466  29,156  440   8,862  440
+```
+
+Its value in all 84 MEASURED windows of each run was **440 [440–440]**.
+So the first full-size window read 13.6×, 26.9× and 16.0× the figure the
+arm actually has, and the spiking runs several windows deep. The 9.9×
+this page recorded above understated it, and a single four-write
+calibration window charged all of it to round 1.
+
+`ROUNDS` also moves from five to six, because the guard splits an arm's
+samples into thirds: at five a third is ONE sample, which carries no
+range, and the phase question has to be adjudicated on a bare ratio.
+
+**With both changes the run exits 0 and the guard reports `reportable` —
+no arm reads differently for its position in the plan** — where the same
+driver exited 2 before. Three consecutive runs agree. Per run: 84 of 84
+windows verified at the DOM, **0 unverified writes of 2,400**, bookkeeping
+identity exact (worst residual 0 B), in-page rising-step sum against the
+CDP bracket worst 3.3–4.7%, every site settled inside the ceiling.
+
+The positive control still misses, and the miss is the documented one: the
+control object is priced at **16.002 B/double by the retention pass** and
+the allocation instrument's slope reads **11.907** on `instrument`
+(−25.6%), 10.770 on `freehand-interpreted` (−32.7%) and 6.934 on
+`reagent` (−56.7%). A collection inside a window nets the reclaimed bytes
+away inside whichever rising step contained it, so the slope UNDER-states
+— which is why the ladder rungs are 100 KB-per-write windows and why the
+per-arm figures are taken at D=0. Warming the sites did not change that
+and was never going to.
+
+### What the same guard did on the CORE harnesses (rf2-om73r)
+
+`order_guard.cjs` is a CommonJS module for a Node driver holding a
+Chromium page. Neither of core's allocation harnesses can consume it —
+`read-attribution` is JVM Clojure with no JavaScript runtime in the
+process, and `write-attribution` is ClojureScript inside
+`implementation/core`, which may not require out of
+`implementation/freehand`. So the rule is expressed twice, as
+`re-frame.bench.order-guard` (CLJC), with both self-tests replaying the
+same recorded fixtures so neither can drift quietly. Eight checks each.
+
+- **B7 carried the same false rotation** — `HEAP_ARMS[(j + round) % n]`,
+  published as "order rotating with the round" — and now rotates and
+  reflects. Guarded, it **passes**: `reportable` on both factors for all
+  seven arms, 0 unverified of 49 mounts, and its own positive control at
+  **4,700,288 B measured against 4,700,000 predicted (+0.006%)** on
+  reader A. It is a retention harness, so this says nothing about
+  allocation; it says the arm order was not moving its figures.
+- **`write-attribution` refuses**, and on the three arms whose own
+  allocation is nearest zero — all of them the SHIPPED half of a paired
+  control. `P-SCOPEH` reads 32.00 B/call in one stratum and 637.96 in the
+  other; `P-INHERH` 48.00 against 653.96; `P-RKV` 80.94 against 686.93.
+  Zero variance inside each stratum, and the same ~606 B/call step on all
+  three. Tracked as `rf2-xu0ma`. **Node, uncompressed pointers** — a
+  tagged slot is 8 B there and 4 in Chrome, so shares transfer and
+  absolutes do not.
+- **`read-attribution` passes**, both factors, every arm, with its
+  controls landing at **+0.000%** predicted against measured on both
+  rungs (JVM, exact TLAB accounting).
+
+One limitation is recorded rather than papered over: under a
+rotate-and-reflect schedule an arm's predecessor is a function of the
+round's PARITY, so a `predecessor` stratum establishes that *the figure
+moves with the plan* — reason enough to refuse — but not that adjacency
+is the mechanism. Separating them needs a third distinct order per arm.
+
 ---
 
 ## 6. What this does not cover
@@ -482,7 +569,11 @@ Raw: `ai/findings/2026-07-28.88pie-b8-order-guard-raw.txt` (local-only).
   predecessor effectively fixed. The driver now rotates and reflects, and
   refuses a figure that either the predecessor or the position in the run
   separates — a re-take under the guard would be needed to say the
-  figures below were unaffected, and none is claimed.
+  figures below were unaffected, and none is claimed. **The single
+  calibration window was also not the warm-up it reads as**: §5 shows the
+  `instrument` arm reading 13.6× to 26.9× its measured value in its first
+  full-size window. Each `(arm, D)` now warms for at least six discarded
+  full-size windows, and the same re-take caveat applies.
 - Gates green before any figure was read: bookkeeping identity exact in
   120/120 windows; kept÷dropped 1.0001; DOM read-back 0 unverified of
   2,400 per row; harness integrity probe passing inside the `:advanced`

--- a/implementation/core/test/re_frame/bench/order_guard.cljc
+++ b/implementation/core/test/re_frame/bench/order_guard.cljc
@@ -1,0 +1,473 @@
+(ns re-frame.bench.order-guard
+  "rf2-88pie / rf2-om73r — the ARM-ORDER guard, for the harnesses that cannot
+  reach the JavaScript one.
+
+  No reported figure may depend on WHERE IN THE PLAN it was measured. That
+  rule already exists, in
+  `implementation/freehand/test/re_frame/freehand/bench/order_guard.cjs`,
+  where it guards `b8_run.cjs`, `b7_run.cjs` and the B6 harness.
+
+  ## Why the rule is expressed twice, and what stops the two drifting
+
+  The `.cjs` module is a CommonJS file loaded by a Node driver that owns a
+  Chromium page. Neither of the harnesses this namespace serves can consume
+  it:
+
+    * `re-frame.bench.read-attribution` is JVM Clojure. It measures with
+      `com.sun.management.ThreadMXBean/getThreadAllocatedBytes` and there is
+      no JavaScript runtime in the process at all.
+    * `re-frame.bench.write-attribution` is ClojureScript, but it lives in
+      `implementation/core`, and core may not `:require` out of
+      `implementation/freehand`. A test harness that reached across that
+      boundary would put the dependency arrow the wrong way round.
+
+  So the honest shape is a SHARED RULE EXPRESSED TWICE, and the thing that
+  stops the two copies drifting apart is that [[self-test]] replays the same
+  RECORDED FIXTURES as the `.cjs` `selfTest` — the same 2.0125x, the same
+  0.43% slope, the same twelve-window warm-up sweep, the same rotation
+  arithmetic. A copy that drifts fails its own self-test on numbers taken
+  from the live study, not on a restatement of itself. Both self-tests run
+  before their harness measures anything.
+
+  ## The property
+
+  Three remedies were available and the `.cjs` header argues them out in
+  full; this is the summary.
+
+  **Randomise the order** — rejected: randomising spreads a contaminant
+  across every arm instead of concentrating it in one, turning a visible 2x
+  on one arm into an invisible smear on all of them.
+
+  **Order the plan so no arm follows a much larger one** — rejected: it
+  needs each arm's per-call allocation before measuring it, which is the
+  thing being measured, and it is unfalsifiable, since a plan ordered by
+  that rule produces no evidence the rule worked.
+
+  **Stratify and REFUSE** — chosen:
+
+    1. [[slot-order]] builds a run order in which every arm has at least two
+       DISTINCT immediate predecessors across rounds.
+    2. Every sample carries what ran immediately before it AND its position
+       in the run.
+    3. [[verdict]] partitions each arm's samples by EACH of those factors
+       and applies the house rule: OVERLAPPING RANGES MEAN
+       INDISTINGUISHABLE. A stratification is a finding only if the ranges
+       are disjoint AND the medians differ by more than a stated tolerance.
+    4. An arm with one stratum on a factor is `:unchecked`, and `:unchecked`
+       refuses as loudly as `:contaminated` — a single-order result has not
+       been checked and may not be reported.
+
+  ## Cyclic rotation does not vary adjacency, and that is the trap
+
+  `b8_run.cjs`, `b7_run.cjs`, `b6-harness/round!` and `b6-rows` all chose
+  the arm for slot `j` of round `r` as `ARMS[(j + r) % n]`, and all of them
+  published that as \"arm order rotating with the round\". A cyclic rotation
+  changes which arm goes FIRST; it does not change which arm follows which.
+  Arm `a` sits at slot `(a - r) mod n`, so its predecessor is `(a - 1) mod n`
+  in every round, and the only sample with a different predecessor is the one
+  at the round seam — exactly one of the arm's `R`.
+
+  [[slot-order]] reflects the rotation on odd rounds, which replaces every
+  `a -> a+1` adjacency with `a -> a-1`. [[self-test]] proves both halves of
+  that arithmetically.
+
+  ## What the `:predecessor` factor can and cannot attribute (rf2-om73r)
+
+  Under [[slot-order]] an arm's predecessor is `(a - 1) mod n` on EVEN
+  rounds and `(a + 1) mod n` on ODD ones, so with only two orders available
+  the predecessor is a function of the round's PARITY. The two strata are
+  therefore \"even rounds\" and \"odd rounds\" wearing predecessor labels,
+  and a `:predecessor` finding says *this figure moves with the plan* —
+  which is the whole property, and reason enough to refuse — but it does NOT
+  establish that the immediate predecessor is the mechanism. Anything else
+  that alternates with the round direction lands in the same stratum.
+
+  Separating the two would need a third distinct order per arm, and
+  randomising instead is worse for the reasons above. It is stated here so
+  that no report quotes a `:predecessor` stratum as evidence about adjacency
+  specifically.
+
+  ## Position dominates adjacency
+
+  The `.cjs` module's live reproduction measured, in plain node with nothing
+  varying but how many times the site had run, the same control over sixteen
+  consecutive windows:
+
+      42.32 | 10.26 10.26 10.26 10.33 10.28 | 8.12 8.12 ... 8.12
+
+  and, with position held fixed, an immediate predecessor worth 0.0–0.3%. So
+  a plan run FORWARD and then REVERSED moves position and adjacency together
+  and cannot say which of them it caught. Both factors are checked here, and
+  a harness that records no positions is not thereby excused the predecessor
+  question."
+  (:require [clojure.string :as str]))
+
+;; ---------------------------------------------------------------------------
+;; The schedule
+
+(defn slot-order
+  "Slot order for `n` arms in `round`: rotate forward by `round`, then REFLECT
+  on odd rounds. The same arithmetic as `order_guard.cjs`'s `schedule` and
+  `b6-harness/slot-order`."
+  [n round]
+  (let [xs (mapv #(mod (+ % round) n) (range n))]
+    (if (odd? round) (vec (rseq xs)) xs)))
+
+(defn rotation-only
+  "The plain cyclic rotation, kept so [[self-test]] can price it."
+  [n round]
+  (mapv #(mod (+ % round) n) (range n)))
+
+(defn adjacency
+  "Flatten `rounds` rounds of `(order-fn n round)` into the sequence that
+  actually runs, and answer, per arm, the predecessor strata it produces.
+
+  `:seams?` decides whether the round seam counts. It does when the rounds
+  run back to back in one process — the last arm of round `r` really does
+  precede the first of round `r+1` — and pricing a schedule's WITHIN-ROUND
+  variety means turning it off."
+  ([n rounds order-fn] (adjacency n rounds order-fn {}))
+  ([n rounds order-fn {:keys [seams?] :or {seams? true}}]
+   (let [slots (mapcat (fn [r] (map-indexed vector (order-fn n r))) (range rounds))
+         seq*  (vec (map second slots))
+         first? (vec (map (fn [[k _]] (zero? k)) slots))
+         preds (reduce
+                 (fn [acc i]
+                   (let [a (nth seq* i)
+                         round-first? (nth first? i)]
+                     (if (and (not seams?) round-first?)
+                       acc
+                       (let [p (if (zero? i) nil (nth seq* (dec i)))]
+                         (update-in acc [a p] (fnil inc 0))))))
+                 {}
+                 (range (count seq*)))]
+     {:sequence seq*
+      :arms     (into {}
+                      (map (fn [[a m]]
+                             (let [counts (vals m)
+                                   total  (reduce + counts)]
+                               [a {:distinct    (count m)
+                                   :samples     total
+                                   :modal-share (/ (double (apply max counts))
+                                                   (double total))}])))
+                      preds)})))
+
+;; ---------------------------------------------------------------------------
+;; The verdict
+
+(defn median
+  [xs]
+  (let [s (vec (sort xs))
+        c (count s)
+        m (quot c 2)]
+    (if (odd? c) (nth s m) (/ (+ (nth s (dec m)) (nth s m)) 2.0))))
+
+(defn- summarise [stratum values]
+  {:stratum stratum
+   :n       (count values)
+   :min     (apply min values)
+   :max     (apply max values)
+   :p50     (median values)})
+
+(defn- finite? [x]
+  (and (number? x)
+       #?(:clj  (Double/isFinite (double x))
+          :cljs (js/isFinite x))))
+
+(defn stratify
+  "Partition one arm's samples on one nuisance factor.
+
+  `:predecessor` is the bead's factor. `:phase` is the one the live
+  reproduction says is larger: THIRDS, not halves, and the middle is
+  discarded. A warm-up step lands somewhere inside the run; a median split
+  can put the step inside the EARLY stratum, which then straddles it, and a
+  straddling stratum's range overlaps everything. First third against last
+  third is the beginning-versus-end contrast without that trap."
+  [samples factor]
+  (let [grouped
+        (if (= factor :phase)
+          (let [with-pos (vec (sort-by :position (filter #(finite? (:position %)) samples)))
+                c        (count with-pos)]
+            (if (< c 2)
+              nil
+              (let [t (max 1 (quot c 3))]
+                [["FIRST-THIRD" (mapv :value (subvec with-pos 0 t))]
+                 ["LAST-THIRD"  (mapv :value (subvec with-pos (- c t)))]])))
+          (->> samples
+               (reduce (fn [acc s]
+                         (let [k (if (nil? (:predecessor s)) "<none>" (str (:predecessor s)))]
+                           (update acc k (fnil conj []) (:value s))))
+                       {})
+               (into [])))]
+    (->> grouped
+         (map (fn [[k vs]] (summarise k vs)))
+         (sort-by :p50)
+         vec)))
+
+(defn adjudicate
+  "Adjudicate one arm's strata on one factor.
+
+  Strata of a single sample carry no range, so they are adjudicated on the
+  ratio alone — and only when there is no better-powered pair available,
+  because a powered comparison should decide the question when one exists.
+  `rf2-jr76s`'s recorded fault is exactly the unpowered case (one forward
+  reading, one reversed) and must still fire."
+  [strata tolerance]
+  (if (< (count strata) 2)
+    {:strata strata
+     :status :unchecked
+     :why    (str "only " (count strata) " stratum — the question was never asked")}
+    (let [powered    (filterv #(>= (:n %) 2) strata)
+          use        (if (>= (count powered) 2) powered strata)
+          lo         (first use)
+          hi         (peek use)
+          ;; An arm that allocates NOTHING reads zero in every stratum, and
+          ;; `0/0` is not an infinite separation — it is no separation at
+          ;; all. Left as `Infinity` this manufactures contamination out of
+          ;; two strata that agree exactly, which is the one thing the house
+          ;; rule exists to prevent (`read-attribution`'s CACHEGET and NOOP
+          ;; arms are both identically zero and both were flagged).
+          ratio      (cond
+                       (== (:p50 hi) (:p50 lo)) 1.0
+                       (zero? (:p50 lo))        #?(:clj Double/POSITIVE_INFINITY
+                                                   :cljs js/Infinity)
+                       :else (/ (double (:p50 hi)) (double (:p50 lo))))
+          disjoint?  (> (:min hi) (:max lo))
+          degenerate (or (< (:n lo) 2) (< (:n hi) 2))
+          beyond?    (> (#?(:clj Math/abs :cljs js/Math.abs) (- ratio 1.0)) tolerance)
+          hit?       (and beyond? (or disjoint? degenerate))]
+      {:strata       strata
+       :worst        {:low (:stratum lo) :high (:stratum hi) :ratio ratio
+                      :disjoint? disjoint? :degenerate? degenerate}
+       :underpowered degenerate
+       :status       (if hit? :contaminated :clean)
+       :why          (cond
+                       hit? (str (:stratum hi) " reads "
+                                 #?(:clj (format "%.4f" ratio) :cljs (.toFixed ratio 4))
+                                 "x " (:stratum lo)
+                                 (if degenerate
+                                   " (n=1 strata: a ratio, not a range)"
+                                   ", ranges disjoint"))
+                       beyond? (str "medians "
+                                    #?(:clj (format "%.4f" ratio) :cljs (.toFixed ratio 4))
+                                    "x apart but the ranges OVERLAP — indistinguishable")
+                       :else (str "within "
+                                  #?(:clj (format "%.0f" (* 100.0 tolerance))
+                                     :cljs (.toFixed (* 100.0 tolerance) 0))
+                                  "%"))})))
+
+(defn verdict
+  "Does any arm's figure depend on where in the plan it was measured?
+
+  `samples` — a seq of `{:arm :value :predecessor :position}`. `tolerance` is
+  a relative difference of medians and the caller must choose it knowing its
+  own noise.
+
+  Answers `{:tolerance :arms :contaminated? :unchecked? :refuse?}`.
+  `:refuse?` is the one a driver acts on: a single-order result and a
+  contaminated one are both unreportable."
+  ([samples] (verdict samples {}))
+  ([samples {:keys [tolerance factors] :or {tolerance 0.10
+                                            factors   [:predecessor :phase]}}]
+   (let [by-arm (reduce (fn [acc s]
+                          (if (finite? (:value s))
+                            (update acc (:arm s) (fnil conj []) s)
+                            acc))
+                        {}
+                        samples)
+         arms   (into {}
+                      (map (fn [[arm ss]]
+                             [arm {:n       (count ss)
+                                   :factors (reduce
+                                              (fn [acc f]
+                                                (let [strata (stratify ss f)]
+                                                  ;; `:phase` is only askable when
+                                                  ;; positions were recorded; a
+                                                  ;; harness that does not record
+                                                  ;; them is not thereby excused
+                                                  ;; the predecessor question, so
+                                                  ;; an empty phase stratification
+                                                  ;; is skipped rather than failed.
+                                                  (if (and (= f :phase) (empty? strata))
+                                                    acc
+                                                    (assoc acc f (adjudicate strata tolerance)))))
+                                              {}
+                                              factors)}]))
+                      by-arm)
+         status (fn [k] (some (fn [[_ a]]
+                                (some (fn [[_ r]] (= k (:status r))) (:factors a)))
+                              arms))
+         cont?  (boolean (status :contaminated))
+         unch?  (boolean (status :unchecked))]
+     {:tolerance     tolerance
+      :arms          arms
+      :contaminated? cont?
+      :unchecked?    unch?
+      :refuse?       (or cont? unch?)})))
+
+;; ---------------------------------------------------------------------------
+;; The report
+
+(defn- pad-r [s w] (let [s (str s)] (str s (str/join (repeat (max 0 (- w (count s))) " ")))))
+(defn- pad-l [s w] (let [s (str s)] (str (str/join (repeat (max 0 (- w (count s))) " ")) s)))
+
+(defn- num* [x]
+  (cond
+    (not (finite? x)) (str x)
+    (>= (#?(:clj Math/abs :cljs js/Math.abs) (double x)) 1000.0)
+    (str (long #?(:clj (Math/round (double x)) :cljs (js/Math.round x))))
+    :else #?(:clj (format "%.4f" (double x)) :cljs (.toFixed (double x) 4))))
+
+(defn report-lines
+  "The `;;`-prefixed report a harness prints beside its table."
+  ([v] (report-lines v nil))
+  ([v title]
+   (concat
+     [(str ";; ==== ARM-ORDER GUARD" (when title (str " — " title)) " ====")
+      (str ";;   every arm partitioned by WHAT RAN BEFORE IT and by WHERE IN THE RUN it was "
+           "measured; tolerance "
+           #?(:clj (format "%.0f" (* 100.0 (:tolerance v)))
+              :cljs (.toFixed (* 100.0 (:tolerance v)) 0))
+           "%, overlapping ranges are indistinguishable")]
+     (mapcat
+       (fn [[arm a]]
+         (concat
+           [(str ";;   " arm "  (" (:n a) " samples)")]
+           (mapcat
+             (fn [[f r]]
+               (concat
+                 [(str ";;     ["
+                       (case (:status r) :clean "ok  " :unchecked "UNCH" "FAIL")
+                       "] by " (pad-r (name f) 12) " " (:why r))]
+                 (map (fn [s]
+                        (str ";;              " (pad-r (:stratum s) 24)
+                             " n=" (pad-l (:n s) 2)
+                             "  p50 " (pad-l (num* (:p50 s)) 12)
+                             "  [" (num* (:min s)) "–" (num* (:max s)) "]"))
+                      (:strata r))))
+             (:factors a))))
+       (sort-by key (:arms v)))
+     [(if (:refuse? v)
+        ";;   VERDICT: REFUSE — no figure above may be published as measured"
+        ";;   VERDICT: reportable — no arm reads differently for its position in the plan")])))
+
+;; ---------------------------------------------------------------------------
+;; The self-test — deterministic, and it is the proof this copy of the rule
+;; still behaves like the one in `order_guard.cjs`. Harnesses run it before
+;; measuring, exactly as `b8_run.cjs` does.
+
+(defn self-test []
+  (let [one    (fn [v arm factor] (get-in v [:arms arm :factors factor]))
+
+        ;; 1. THE RECORDED 2x, replayed from `rf2-jr76s`. A packed-SMI
+        ;;    `.slice()` control, predicted 8.000 B/slot, read once in
+        ;;    forward arm order and once in reversed. Both strata are n=1,
+        ;;    which is the whole difficulty: a guard that insisted on ranges
+        ;;    would have passed this.
+        smi    [{:arm "CTL-SMI-slice" :predecessor "DBL-10000" :position 9 :value 16.1052}
+                {:arm "CTL-SMI-slice" :predecessor "P-VALS"    :position 2 :value 8.0027}]
+        v-smi  (verdict smi {:tolerance 0.10})
+
+        ;; 2. THE UNCONTAMINATED ARM FROM THE SAME STUDY must pass. The
+        ;;    per-subscription slope reproduced 2,830.7 forward against
+        ;;    2,842.8 reversed — 0.43% — and a guard that failed this would
+        ;;    be useless.
+        slope  [{:arm "RFWRITE-slope" :predecessor "RFWRITE-150" :position 3 :value 2830.7}
+                {:arm "RFWRITE-slope" :predecessor "RFWRITE-300" :position 8 :value 2842.8}]
+
+        ;; 3. A SINGLE-ORDER RESULT IS REFUSED — the bead's first actionable:
+        ;;    a study that ran one order has not checked this.
+        one-order (mapv (fn [[p v]] {:arm "A" :predecessor "B" :position p :value v})
+                        [[0 100] [1 101] [2 99]])
+        v-one  (verdict one-order {:tolerance 0.10 :factors [:predecessor]})
+
+        ;; 4. THE HOUSE RULE. Medians 20% apart with overlapping ranges is
+        ;;    indistinguishable, not a finding.
+        overlapping (mapv (fn [[p pred v]] {:arm "A" :predecessor pred :position p :value v})
+                          [[0 "X" 100] [2 "X" 140] [4 "X" 120]
+                           [1 "Y" 90]  [3 "Y" 135] [5 "Y" 100]])
+        v-ov   (verdict overlapping {:tolerance 0.10})
+
+        ;; 5. THE WARM-UP STEP, from the `.cjs` module's own measured sweep:
+        ;;    the SAME control, nothing else running, consecutive windows.
+        ;;    The predecessor is identical throughout, so ONLY the phase
+        ;;    factor can catch it — and a guard built to the bead's literal
+        ;;    proposal (reverse the plan, compare) would not have.
+        warmup (map-indexed (fn [i v] {:arm "CTL-SMI-slice" :predecessor "CTL-SMI-slice"
+                                       :position i :value v})
+                            [10.3223 10.2627 10.2588 10.2588 10.334 10.2832
+                             8.1221 8.1221 8.1221 8.1221 8.1221 8.1221])
+        v-warm (verdict warmup {:tolerance 0.10})
+
+        ;; 6. AN ARM THAT ALLOCATES NOTHING IS NOT INFINITELY CONTAMINATED.
+        ;;    `read-attribution`'s CACHEGET reads exactly 0 B in every round,
+        ;;    so both strata are zero; the pair is n=1 apiece here, which is
+        ;;    the case adjudicated on the ratio alone and therefore the case
+        ;;    that fires. It must not.
+        zeros  [{:arm "CACHEGET" :predecessor "PORT"  :position 0 :value 0}
+                {:arm "CACHEGET" :predecessor "DEREF" :position 1 :value 0}]
+        v-zero (verdict zeros {:tolerance 0.10 :factors [:predecessor]})
+
+        ;; 7. CYCLIC ROTATION DOES NOT VARY ADJACENCY. Every arm keeps one
+        ;;    predecessor in every round but the seam, so the order question
+        ;;    is asked with a single sample in R. The reflecting schedule
+        ;;    splits it.
+        r 6
+        n 4
+        rot   (adjacency n r rotation-only {:seams? false})
+        refl  (adjacency n r slot-order    {:seams? false})
+        rot-d (mapv :distinct (vals (:arms rot)))
+        ref-d (mapv :distinct (vals (:arms refl)))
+        ref-s (apply max (map :modal-share (vals (:arms refl))))
+
+        checks
+        [{:name "the recorded 2.01x is REFUSED"
+          :ok   (and (:refuse? v-smi)
+                     (= :contaminated (:status (one v-smi "CTL-SMI-slice" :predecessor)))
+                     (< (#?(:clj Math/abs :cljs js/Math.abs)
+                         (- (get-in (one v-smi "CTL-SMI-slice" :predecessor) [:worst :ratio])
+                            2.0125))
+                        0.001))
+          :detail (str "ratio " (num* (get-in (one v-smi "CTL-SMI-slice" :predecessor)
+                                              [:worst :ratio])))}
+         {:name "the same study's uncontaminated slope passes"
+          :ok   (not (:refuse? (verdict slope {:tolerance 0.10})))
+          :detail "forward 2830.7 / reversed 2842.8"}
+         {:name "a single-order result is refused as UNCHECKED"
+          :ok   (and (:refuse? v-one) (:unchecked? v-one)
+                     (= :unchecked (:status (one v-one "A" :predecessor))))
+          :detail (:why (one v-one "A" :predecessor))}
+         {:name "overlapping ranges are indistinguishable even 20% apart in median"
+          :ok   (not (:refuse? v-ov))
+          :detail (:why (one v-ov "A" :predecessor))}
+         {:name "the measured warm-up step is caught by PHASE, which no reversal would show"
+          :ok   (and (:refuse? v-warm)
+                     (= :contaminated (:status (one v-warm "CTL-SMI-slice" :phase)))
+                     (= :unchecked (:status (one v-warm "CTL-SMI-slice" :predecessor))))
+          :detail (str "phase: " (:why (one v-warm "CTL-SMI-slice" :phase)))}
+         {:name "an arm that reads exactly zero in both strata is indistinguishable, not infinite"
+          :ok   (= :clean (:status (one v-zero "CACHEGET" :predecessor)))
+          :detail (:why (one v-zero "CACHEGET" :predecessor))}
+         {:name "cyclic rotation gives every arm exactly ONE within-round predecessor"
+          :ok   (every? #(= 1 %) rot-d)
+          :detail (str "rotation over " r " rounds: distinct predecessors per arm "
+                       (str/join "," rot-d)
+                       " (only the round seam ever differs, and that is one sample in R)")}
+         {:name "the reflecting schedule gives every arm TWO, in balance"
+          :ok   (and (every? #(>= % 2) ref-d) (<= ref-s 0.75))
+          :detail (str "reflected: " (str/join "," ref-d)
+                       " predecessors per arm, largest modal share "
+                       #?(:clj (format "%.0f" (* 100.0 ref-s))
+                          :cljs (.toFixed (* 100.0 ref-s) 0)) "%")}]]
+    {:ok?     (every? :ok checks)
+     :checks  checks}))
+
+(defn print-self-test!
+  "Run [[self-test]], print each check, and answer whether it passed. A
+  harness that gets `false` must measure nothing."
+  []
+  (let [st (self-test)]
+    (doseq [c (:checks st)]
+      (println (str ";; order-guard " (if (:ok c) "ok  " "FAIL") " " (:name c)
+                    (when (:detail c) (str "  — " (:detail c))))))
+    (:ok? st)))

--- a/implementation/core/test/re_frame/bench/read_attribution.clj
+++ b/implementation/core/test/re_frame/bench/read_attribution.clj
@@ -110,6 +110,37 @@
   `NOOP` is the fixed per-pass overhead every arm carries; every figure
   is reported both raw and net of it.
 
+  ## The arm order is a MEASURED property of this run (rf2-88pie/rf2-om73r)
+
+  Until `rf2-om73r` this file made one pass over the plan and reported one
+  mean per arm. `RM_ORDER=rev` offered a second pass in a SECOND PROCESS
+  whose numbers nothing here ever joined up, and a mean alone carries no
+  range — both against standing method.
+
+  So the plan now runs in `RM_ROUNDS` rounds, and the arm order ROTATES AND
+  REFLECTS with the round (`re-frame.bench.order-guard/slot-order`). A bare
+  cyclic rotation would not do: arm `a` sits at slot `(a - r) mod n`, so its
+  predecessor is `(a - 1) mod n` in every round and only the seam differs.
+  Reflecting on odd rounds replaces every `a -> a+1` adjacency with
+  `a -> a-1`, so each arm is measured after two different predecessors and
+  at spread positions in the run. Each arm reports the p50 ACROSS ROUNDS
+  with the full round range, never a mean alone.
+
+  `order-guard` then partitions every arm's per-round figures by WHAT RAN
+  BEFORE IT and by WHERE IN THE RUN it sat, applies the house rule —
+  overlapping ranges are indistinguishable — and REFUSES the run (exit code
+  2) if either factor separates an arm. It is the same rule as
+  `implementation/freehand/test/re_frame/freehand/bench/order_guard.cjs`,
+  expressed twice because this harness is JVM Clojure and there is no
+  JavaScript runtime in the process; both copies replay the same recorded
+  fixtures in their self-tests.
+
+  The whole plan is also warmed BEFORE any arm is measured, rather than each
+  arm warming itself immediately before its own reading. A site reads above
+  its settled value until it has run several times (`rf2-tb345`), and a
+  per-arm warm-up leaves that curve aligned with position in the plan, which
+  is exactly the confound the phase factor refuses.
+
   ## What does NOT transfer to ClojureScript
 
   Byte counts do not, and neither does one behaviour: the JVM plain-atom
@@ -126,11 +157,16 @@
       clojure -M:test -m re-frame.bench.read-attribution
 
   Environment: RM_N (dependencies, default 300), RM_ITERS, RM_WARMUP,
-  RM_ALLOC, RM_ORDER=rev (run the arms back-to-front — if the answer
-  survives that, arm order and the JIT state each arm inherits are not
-  confounds), RM_SUITE=port|subs|all (which ladder to run; `port` is the
-  default and is exactly the original thirteen arms)."
-  (:require [re-frame.core :as rf]
+  RM_ALLOC (timing and allocation passes per arm across ALL rounds),
+  RM_ROUNDS (default 6 — at least six, so the guard's phase thirds are
+  ranges rather than single samples), RM_TOLERANCE (the guard's
+  relative-median tolerance, default 0.10 — TLAB accounting is exact, so a
+  real arm reproduces to a fraction of a percent), RM_ORDER=rev (reverse the
+  base plan before scheduling — a knob now, not the mitigation),
+  RM_SUITE=port|subs|all (which ladder to run; `port` is the default and is
+  exactly the original thirteen arms)."
+  (:require [re-frame.bench.order-guard :as guard]
+            [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.interop :as interop]
             [re-frame.late-bind :as late-bind]
@@ -151,6 +187,8 @@
   (.getThreadAllocatedBytes tmx (.getId (Thread/currentThread))))
 
 (defn- env-int [k d] (Integer/parseInt (or (System/getenv k) (str d))))
+
+(defn- env-num [k d] (Double/parseDouble (or (System/getenv k) (str d))))
 
 (def ^:private fid :rf/default)
 
@@ -521,10 +559,17 @@
             (range n))))
 
 (defn run
-  "Measure every arm and print the attribution. Answers the results map."
-  [{:keys [n iters warmup alloc-iters reverse-order? suite]
+  "Measure every arm and print the attribution. Answers the results map,
+  keyed by arm label, plus `::refused?` — the arm-order guard's verdict on
+  whether anything in it may be quoted."
+  [{:keys [n iters warmup alloc-iters reverse-order? suite rounds tolerance]
     :or   {n 300 iters 400 warmup 400 alloc-iters 200 reverse-order? false
-           suite "port"}}]
+           suite "port" rounds 6 tolerance 0.10}}]
+  ;; Ahead of everything: a broken guard makes every figure below
+  ;; unpublishable, and the checks are fixtures replayed from recorded
+  ;; readings, so this is deterministic and costs nothing.
+  (when-not (guard/print-self-test!)
+    (throw (ex-info "order guard self-test FAILED — nothing may be measured" {})))
   (.setThreadAllocatedMemoryEnabled tmx true)
   (let [sub-ids (mapv #(keyword "ra" (str "s" %)) (range n))
         qs      (mapv vector sub-ids)
@@ -534,9 +579,11 @@
       (rf/reg-sub id (fn [db _] (get-in db [:items i]))))
     (live-frame/make-frame {:id fid})
     (frame/replace-app-db! fid (db-of 0))
-    (println (format ";; debug-enabled? = %s  n=%d iters=%d warmup=%d alloc-iters=%d order=%s suite=%s"
-                     interop/debug-enabled? n iters warmup alloc-iters
+    (println (format ";; debug-enabled? = %s  n=%d iters=%d warmup=%d alloc-iters=%d rounds=%d base order=%s suite=%s"
+                     interop/debug-enabled? n iters warmup alloc-iters rounds
                      (if reverse-order? "REVERSED" "forward") suite))
+    (println (format ";; arm order ROTATES AND REFLECTS with the round (rf2-88pie); guard tolerance %.0f%%"
+                     (* 100.0 tolerance)))
     (binding [frame/*current-frame* fid]
       ;; Hold n subscriptions the way a mounted application holds them, so
       ;; every node is live for the whole run — which is what makes `probe`
@@ -580,10 +627,13 @@
                           {:gen g :probe probe-v :rgread rg-v :deref dr-v :raw raw-v}))))
       (let [advance! (fn [] (vswap! gen inc)
                        (frame/replace-app-db! fid (db-of @gen)))
-            measure
-            (fn [label f]
-              (dotimes [_ warmup] (advance!) (f n))
-              (let [us (/ (p50 (vec (repeatedly iters
+            ;; ONE round of one arm. Split out of the old `measure` so the
+            ;; plan can be walked several times in several orders — a figure
+            ;; taken from a plan run in one order has not been checked
+            ;; (rf2-88pie).
+            round!
+            (fn [f its allocs]
+              (let [us (/ (p50 (vec (repeatedly its
                                       (fn [] (advance!)
                                         (let [t0 (System/nanoTime)]
                                           (f n)
@@ -591,17 +641,14 @@
                           1000.0)
                     bs (double
                          (/ (loop [k 0 acc 0]
-                              (if (< k alloc-iters)
+                              (if (< k allocs)
                                 (do (advance!)
                                     (let [a0 (alloc-bytes)]
                                       (f n)
                                       (recur (inc k) (+ acc (- (alloc-bytes) a0)))))
                                 acc))
-                            alloc-iters))]
-                (println (format ";; %-9s %9.1f us %11.0f bytes %9.1f B/read"
-                                 label us bs (/ bs (double n))))
-                (flush)
-                {:label label :us us :bytes bs}))
+                            allocs))]
+                {:us us :bytes bs}))
             controls [["NOOP"    arm-noop]
                       ["CTRL-S"  arm-ctrl-small]
                       ["CTRL-L"  arm-ctrl-large]]
@@ -628,16 +675,63 @@
                        ["N-LOOKGEN" arm-n-lookgen]  ["N-LOOKATOM" arm-n-lookatom]]
             port?     (contains? #{"port" "all"} suite)
             subs?     (contains? #{"subs" "all"} suite)
-            plan (concat controls
-                         (when port? port-plan)
-                         (when subs? (if port? (rest subs-plan) subs-plan)))
-            res  (reduce (fn [acc [l f]] (assoc acc l (measure l f)))
-                         {}
-                         (if reverse-order? (reverse plan) plan))
+            plan (vec (concat controls
+                              (when port? port-plan)
+                              (when subs? (if port? (rest subs-plan) subs-plan))))
+            ;; The order the SCHEDULE indexes into. `plan` itself stays in
+            ;; base order, because the report below reads `(rest plan)` to
+            ;; skip NOOP.
+            ordered   (if reverse-order? (vec (reverse plan)) plan)
+            k         (count ordered)
+            its-per   (max 1 (quot iters rounds))
+            allocs-per (max 1 (quot alloc-iters rounds))
+            ;; --- warm the WHOLE plan before measuring any of it -----------
+            ;; A per-arm warm-up immediately before that arm's reading leaves
+            ;; the settling curve aligned with position in the plan, which is
+            ;; the confound the phase factor refuses (rf2-tb345).
+            _ (do (println (format ";; warming %d arms x %d passes before the first measured round"
+                                   k warmup))
+                  (flush)
+                  (doseq [[_ f] ordered]
+                    (dotimes [_ warmup] (advance!) (f n))))
+            ;; --- the measured rounds -------------------------------------
+            walked (reduce
+                     (fn [acc [round j]]
+                       (let [[label f] (nth ordered j)
+                             m         (round! f its-per allocs-per)]
+                         (-> acc
+                             (update-in [:us label] (fnil conj []) (:us m))
+                             (update-in [:bytes label] (fnil conj []) (:bytes m))
+                             (update :order conj {:arm         label
+                                                  :value       (:bytes m)
+                                                  :predecessor (:prev acc)
+                                                  :position    (count (:order acc))
+                                                  :round       round})
+                             (assoc :prev label))))
+                     {:us {} :bytes {} :order [] :prev nil}
+                     (vec (for [round (range rounds)
+                                j     (guard/slot-order k round)]
+                            [round j])))
+            res  (into {}
+                       (map (fn [[l _]]
+                              (let [bs (get-in walked [:bytes l])]
+                                [l {:label    l
+                                    :us       (p50 (get-in walked [:us l]))
+                                    :bytes    (p50 bs)
+                                    :bytes-lo (apply min bs)
+                                    :bytes-hi (apply max bs)
+                                    :rounds   bs}])))
+                       plan)
             b    (fn [l] (:bytes (get res l)))
             noop (b "NOOP")
             net  (fn [l] (- (b l) noop))
             per  (fn [l] (/ (net l) (double n)))]
+        (doseq [[l _] plan]
+          (let [r (get res l)]
+            (println (format ";; %-9s %9.1f us %11.0f bytes %9.1f B/read   rounds [%.0f – %.0f]"
+                             l (:us r) (:bytes r) (/ (:bytes r) (double n))
+                             (:bytes-lo r) (:bytes-hi r)))))
+        (flush)
         (println ";;")
         (doseq [[lbl elems] [["CTRL-S" ctrl-small-n] ["CTRL-L" ctrl-large-n]]]
           (let [pred (double (ctrl-bytes n elems))]
@@ -719,15 +813,39 @@
                           (- (net "PORT") (net "RESOLVE") (net "DEREF"))]]]
           (println (format ";;   %-38s %8.1f B/read  %5.1f%% of PORT"
                            lbl (/ v (double n)) (* 100.0 (/ v (net "PORT")))))))
-        res))))
+        ;; --- arm order, LAST, and it governs everything above -------------
+        ;; The refusal is about what may be QUOTED, not about throwing the
+        ;; measurement away, so the figures are printed either way and the
+        ;; exit code carries the verdict.
+        (println ";;")
+        (let [v (guard/verdict (:order walked) {:tolerance tolerance})]
+          (doseq [line (guard/report-lines v "the per-arm allocation figure, one round-mean per round")]
+            (println line))
+          (when (:refuse? v)
+            (println ";;")
+            (println ";; ==== ARM ORDER: THESE FIGURES ARE NOT REPORTABLE ====")
+            (println (str ";;   at least one arm reads differently for what preceded it, or for "
+                          "where in the run it"))
+            (println (str ";;   was measured (rf2-88pie). The table above stands as raw data; "
+                          "nothing in it may"))
+            (println ";;   be quoted."))
+          (flush)
+          (assoc res ::refused? (:refuse? v)))))))
 
 (defn -main [& _]
-  ((test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
-   (fn []
-     (run {:n              (env-int "RM_N" 300)
-           :iters          (env-int "RM_ITERS" 400)
-           :warmup         (env-int "RM_WARMUP" 400)
-           :alloc-iters    (env-int "RM_ALLOC" 200)
-           :suite          (or (System/getenv "RM_SUITE") "port")
-           :reverse-order? (= "rev" (System/getenv "RM_ORDER"))})))
-  (shutdown-agents))
+  (let [refused? (volatile! false)]
+    ((test-support/make-reset-runtime-fixture {:adapter plain-atom/adapter})
+     (fn []
+       (vreset! refused?
+                (::refused?
+                 (run {:n              (env-int "RM_N" 300)
+                       :iters          (env-int "RM_ITERS" 400)
+                       :warmup         (env-int "RM_WARMUP" 400)
+                       :alloc-iters    (env-int "RM_ALLOC" 200)
+                       :rounds         (max 2 (env-int "RM_ROUNDS" 6))
+                       :tolerance      (env-num "RM_TOLERANCE" 0.10)
+                       :suite          (or (System/getenv "RM_SUITE") "port")
+                       :reverse-order? (= "rev" (System/getenv "RM_ORDER"))})))))
+    (shutdown-agents)
+    ;; A run whose figures the arm-order guard refused is not a green run.
+    (when @refused? (System/exit 2))))

--- a/implementation/core/test/re_frame/bench/write_attribution.cljs
+++ b/implementation/core/test/re_frame/bench/write_attribution.cljs
@@ -42,6 +42,45 @@
   standing rule that ranges are quoted and overlapping ranges mean
   INDISTINGUISHABLE.
 
+  ## The arm order is a MEASURED property of this run, not an assumption
+
+  This harness is where `rf2-88pie`'s fault was FOUND: the SMI control read
+  16.1052 B/slot with the plan run forwards and 8.0027 with it run
+  backwards, and it was caught only because somebody happened to run both.
+  Running one order and reporting the answer is exactly the thing that
+  cannot be checked, and until `rf2-om73r` that is what this file did — a
+  single pass over the plan, each arm measured once, in one place, after one
+  predecessor. `WA_ORDER=rev` gave a second reading in a SECOND PROCESS
+  whose numbers nothing here ever joined up.
+
+  So the plan now runs in `WA_ROUNDS` rounds and the arm order ROTATES AND
+  REFLECTS with the round (`order-guard/slot-order`). A bare cyclic rotation
+  would not do: arm `a` sits at slot `(a - r) mod n`, so its predecessor is
+  `(a - 1) mod n` in every round and only the round seam differs. Reflecting
+  on odd rounds replaces every `a -> a+1` adjacency with `a -> a-1`, so
+  every arm is measured after two different predecessors and at spread
+  positions in the run.
+
+  `re-frame.bench.order-guard` then partitions each arm's per-round figures
+  by WHAT RAN BEFORE IT and by WHERE IN THE RUN it sat, applies the house
+  rule — overlapping ranges are indistinguishable — and REFUSES the run
+  (exit code 2) if either factor separates an arm. It is the same rule as
+  `implementation/freehand/test/re_frame/freehand/bench/order_guard.cjs`,
+  expressed twice because a JVM harness and a `core` CLJS harness can reach
+  neither that file nor its runtime; both copies replay the same recorded
+  fixtures in their self-tests, which is what keeps them honest.
+
+  ## Warm-up, because position beats adjacency
+
+  The same study measured one control in plain node over sixteen
+  consecutive windows, nothing else varying: `42.32` then six windows at
+  `10.3` then `8.12` for ever. The FIRST window read 5.3x the settled value
+  and the next six read +27%. So `WA_WARM_WINDOWS` full-size windows per arm
+  are run and thrown away before any round is measured, on top of
+  `WA_WARMUP` bare calls and the calibration probe. Under-warming does not
+  produce a slightly-off number; it produces a number that moves with where
+  in the plan the arm sat, which is precisely what the guard refuses.
+
   ## The control
 
   A control whose size is asserted rather than checked has already been
@@ -167,13 +206,19 @@
   the missing browser figures. Ratios between two arms measured the same way
   are unaffected by any of this.
 
-  Environment: WA_N (subscriptions, default 300), WA_SAMPLES,
-  WA_WARMUP, WA_ORDER=rev (run the arms back-to-front — if the answer
-  survives that, arm order is not a confound), WA_COORDS=0 (register the
-  ladder's subs WITHOUT source coords — the control arm, not the default)."
+  Environment: WA_N (subscriptions, default 300), WA_SAMPLES (samples per
+  arm across ALL rounds, default 40), WA_ROUNDS (default 6 — at least six,
+  so the guard's phase thirds are ranges rather than single samples),
+  WA_WARM_WINDOWS (full-size discarded windows per arm before the first
+  measured round, default 6), WA_WARMUP (bare calls before calibration,
+  default 3), WA_TOLERANCE (the guard's relative-median tolerance, default
+  0.25), WA_ORDER=rev (reverse the base plan before scheduling — a knob
+  now, not the mitigation), WA_COORDS=0 (register the ladder's subs WITHOUT
+  source coords — the control arm, not the default)."
   (:require [goog.object :as gobj]
             [goog.string :as gstring]
             [goog.string.format]
+            [re-frame.bench.order-guard :as guard]
             [re-frame.core :as rf]
             [re-frame.frame :as frame]
             [re-frame.interop :as interop]
@@ -200,6 +245,8 @@
   (or (gobj/get (.-env js/process) k) d))
 
 (defn- env-int [k d] (js/parseInt (env k (str d)) 10))
+
+(defn- env-num [k d] (js/parseFloat (env k (str d))))
 
 ;; ---------------------------------------------------------------------------
 ;; sinks — Closure is entitled to delete an expression nothing reads, and this
@@ -581,7 +628,9 @@
 
 (defn- measure
   "Run `f` `reps` times inside one collection-free sample, `samples` times.
-  Answers `{:p50 … :lo … :hi … :accepted … :dropped …}` in bytes per CALL."
+  Answers `{:p50 … :lo … :hi … :xs … :accepted … :dropped …}` in bytes per
+  CALL. `:xs` is the accepted samples themselves, because a round's figures
+  have to be poolable across rounds and a p50 of p50s is not one."
   [f reps samples]
   (let [acc (array)
         dropped (volatile! 0)]
@@ -598,8 +647,19 @@
       {:p50      (if (pos? c) (aget acc (js/Math.floor (/ c 2))) -1)
        :lo       (if (pos? c) (aget acc 0) -1)
        :hi       (if (pos? c) (aget acc (dec c)) -1)
+       :xs       (vec acc)
        :accepted c
        :dropped  @dropped})))
+
+(defn- summarise
+  "Pool an arm's accepted samples from every round into one figure."
+  [xs]
+  (let [s (vec (sort xs))
+        c (count s)]
+    {:p50      (if (pos? c) (nth s (js/Math.floor (/ c 2))) -1)
+     :lo       (if (pos? c) (first s) -1)
+     :hi       (if (pos? c) (peek s) -1)
+     :accepted c}))
 
 (defn- calibrate
   "Pick a rep count that puts one sample near `target` bytes, so no sample
@@ -723,9 +783,19 @@
 (defn- fmt [x] (.toFixed x 1))
 
 (defn ^:export -main [& _]
+  ;; Ahead of everything, because a broken guard makes every figure below
+  ;; unpublishable and finding that out after the run is wasteful. The checks
+  ;; are fixtures replayed from `rf2-jr76s`'s recorded readings, so this is
+  ;; deterministic — exactly as `b8_run.cjs` does it.
+  (when-not (guard/print-self-test!)
+    (throw (ex-info "order guard self-test FAILED — nothing may be measured" {})))
   (let [n        (env-int "WA_N" 300)
         samples  (env-int "WA_SAMPLES" 40)
         warmup   (env-int "WA_WARMUP" 3)
+        warm-windows (env-int "WA_WARM_WINDOWS" 6)
+        rounds   (max 2 (env-int "WA_ROUNDS" 6))
+        per-round (max 1 (js/Math.ceil (/ samples rounds)))
+        tolerance (env-num "WA_TOLERANCE" 0.25)
         rev?     (= "rev" (env "WA_ORDER" ""))
         ;; rf2-4k5hs — the coord-carrying registration is the DEFAULT, because
         ;; that is what a consumer's macro-registered subs give the registrar.
@@ -753,9 +823,12 @@
     (println (gstring/format ";; node %s  V8 %s  pointer-compression=%s (Chrome ships it ON: a tagged slot is 4 B there, 8 B here)"
                      (.-node js/process.versions) (.-v8 js/process.versions)
                      (if (= 1 (gobj/getValueByKeys js/process "config" "variables" "v8_enable_pointer_compression")) "ON" "OFF")))
-    (println (gstring/format ";; n=%d samples=%d warmup=%d order=%s frames=%s"
-                     n samples warmup (if rev? "REVERSED" "forward")
+    (println (gstring/format ";; n=%d samples=%d (%d rounds x %d) warmup=%d calls + %d windows  base order=%s frames=%s"
+                     n samples rounds per-round warmup warm-windows
+                     (if rev? "REVERSED" "forward")
                      (pr-str ns-per-frame)))
+    (println (gstring/format ";; arm order ROTATES AND REFLECTS with the round (rf2-88pie); guard tolerance %s"
+                     (.toFixed (* 100.0 tolerance) 0)))
     (println (gstring/format ";; registration = %s"
                      (if coords?
                        "COORD-CARRYING (default — the shape a real application registers)"
@@ -816,18 +889,61 @@
                              ["P-VALS"  arm-p-vals  n]
                              ["P-RKV"   arm-p-rkv   n]]))
           plan (if rev? (vec (reverse plan)) plan)
-          res  (reduce
-                 (fn [acc [label f per]]
-                   (dotimes [_ warmup] (f))
-                   (let [reps (calibrate f 2000000)
-                         r    (measure f reps samples)]
-                     (println (gstring/format ";; %-12s reps=%-6d %12s B/call  [%s – %s]  per-unit %10s B  (%d ok, %d dropped)"
-                                      label reps (fmt (:p50 r)) (fmt (:lo r)) (fmt (:hi r))
-                                      (fmt (/ (:p50 r) per)) (:accepted r) (:dropped r)))
-                     (assoc acc label (assoc r :per per))))
-                 {}
-                 plan)
+          k    (count plan)
+          ;; --- warm-up and calibration, one pass, nothing read ------------
+          ;; rf2-tb345: a site reads 1.26x to 5.3x its settled value until it
+          ;; has run several full-size windows. Charged to round 1 that reads
+          ;; as allocation, and — worse — it reads as an arm whose figure
+          ;; moves with where in the plan it sat, which the guard below
+          ;; refuses. So every arm is walked to its settled value first.
+          reps (mapv (fn [[label f _]]
+                       (dotimes [_ warmup] (f))
+                       (let [r (calibrate f 2000000)]
+                         (dotimes [_ warm-windows] (measure f r 1))
+                         (println (gstring/format ";; warm %-12s reps=%-6d %d discarded windows"
+                                          label r warm-windows))
+                         r))
+                     plan)
+          ;; --- the measured rounds ----------------------------------------
+          ;; Every sample carries the label of the arm that ran immediately
+          ;; before it and its position in the whole run; those two are what
+          ;; the guard stratifies on.
+          run  (reduce
+                 (fn [acc [round j]]
+                   (let [[label f _] (nth plan j)
+                         r (measure f (nth reps j) per-round)]
+                     (-> acc
+                         (update-in [:xs label] (fnil into []) (:xs r))
+                         (update-in [:dropped label] (fnil + 0) (:dropped r))
+                         (update :order conj {:arm         label
+                                              :value       (:p50 r)
+                                              :predecessor (:prev acc)
+                                              :position    (count (:order acc))
+                                              :round       round})
+                         (assoc :prev label))))
+                 {:xs {} :dropped {} :order [] :prev nil}
+                 (vec (for [round (range rounds)
+                            j     (guard/slot-order k round)]
+                        [round j])))
+          res  (into {}
+                     (map-indexed
+                       (fn [i [label _ per]]
+                         (let [pooled (summarise (get-in run [:xs label] []))
+                               rnd    (mapv :value (filter #(= label (:arm %)) (:order run)))]
+                           [label (assoc pooled
+                                         :per     per
+                                         :reps    (nth reps i)
+                                         :rounds  rnd
+                                         :dropped (get-in run [:dropped label] 0))]))
+                       plan))
           b    (fn [l] (:p50 (get res l)))]
+      (doseq [[label _ per] plan]
+        (let [r   (get res label)
+              rnd (:rounds r)]
+          (println (gstring/format ";; %-12s reps=%-6d %12s B/call  [%s – %s]  per-unit %10s B  (%d ok, %d dropped)  rounds p50 [%s – %s]"
+                           label (:reps r) (fmt (:p50 r)) (fmt (:lo r)) (fmt (:hi r))
+                           (fmt (/ (:p50 r) per)) (:accepted r) (:dropped r)
+                           (fmt (apply min rnd)) (fmt (apply max rnd))))))
       (println ";;")
       (println ";; CONTROLS")
       (doseq [d ctl-double-ds]
@@ -912,5 +1028,22 @@
                          (fmt (b "SPINE0B")) (fmt (b "SPINE0P"))))
         (println (gstring/format ";;   C-BUMP %s B vs C-BUMPH %s B  -> hoisting (fnil inc 0) predicts %s B/write"
                          (fmt (b "C-BUMP")) (fmt (b "C-BUMPH"))
-                         (fmt (- (b "C-BUMP") (b "C-BUMPH")))))))
+                         (fmt (- (b "C-BUMP") (b "C-BUMPH"))))))
+      ;; --- arm order, LAST, and it governs everything above ----------------
+      ;; The figures are printed and the refusal is about what may be QUOTED,
+      ;; not about throwing the measurement away — so the exit code carries
+      ;; it rather than an exception.
+      (println ";;")
+      (let [v (guard/verdict (:order run) {:tolerance tolerance})]
+        (doseq [line (guard/report-lines v "the per-arm figure, one p50 per round")]
+          (println line))
+        (when (:refuse? v)
+          (println ";;")
+          (println ";; ==== ARM ORDER: THESE FIGURES ARE NOT REPORTABLE ====")
+          (println (str ";;   at least one arm reads differently for what preceded it, or for where "
+                        "in the run"))
+          (println (str ";;   it was measured (rf2-88pie). The table above stands as raw data; "
+                        "nothing in it"))
+          (println ";;   may be quoted.")
+          (set! (.-exitCode js/process) 2))))
     (println (gstring/format ";; sink %s %s" @sink (some? @sink2)))))

--- a/implementation/freehand/test/re_frame/freehand/bench/b7_run.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b7_run.cjs
@@ -50,12 +50,26 @@
 // read as SIX KILOBYTES on all three readers — V8 does not materialise
 // `'x'.repeat(n)`. The instrument was fine and the control was a
 // fiction. It is worth knowing that a control can fail this way.
+//
+// THE ARM ORDER IS A MEASURED PROPERTY OF THIS RUN, NOT AN ASSUMPTION.
+// The heap row used to select the arm for slot `j` of round `r` as
+// `HEAP_ARMS[(j + round) % n]` and describe it as "order rotating with the
+// round". A cyclic rotation changes which arm goes FIRST; it does not
+// change which arm follows which — arm `a` sits at slot `(a - r) mod n`,
+// so its predecessor is `(a - 1) mod n` in EVERY round and only the round
+// seam differs. It read as a mitigation and was not one (rf2-88pie,
+// rf2-om73r). `order_guard.cjs` now schedules the arms so every one of
+// them is measured after at least two different predecessors, labels every
+// reading with what preceded it and where in the run it sat, and REFUSES to
+// let this driver exit 0 on a figure that either factor separates. Its
+// self-test runs before the bundle is even built.
 
 const { spawnSync } = require('node:child_process');
 const fs = require('node:fs');
 const http = require('node:http');
 const path = require('node:path');
 
+const guard = require('./order_guard.cjs');
 const { navigate, NAV_TIMEOUT_MS } = require('./navigate.cjs');
 
 const IMPL = path.resolve(__dirname, '../../../../..');
@@ -69,6 +83,11 @@ const ROOTS = Number(process.env.B7_ROOTS || 10);
 const CONTROL_DOUBLES = Number(process.env.B7_CONTROL_DOUBLES || 587500);
 const CONTROL_PREDICTED = CONTROL_DOUBLES * 8;
 const WANT_SNAPSHOT = process.env.B7_SNAPSHOT !== '0';
+// A relative difference of medians. A retention reading taken across a
+// mount/collect/release cycle moves several percent between rounds where an
+// allocation counter reading the same code twice does not, so this sits
+// above B8's noise floor and far below the 2.01x the recorded fault made.
+const TOLERANCE = Number(process.env.B7_TOLERANCE || 0.25);
 
 // The published arm set. `B7_ARMS` (comma-separated) overrides it, and
 // `B7_INIT_FN` points the bundle at a different `:init-fn` — the two seams
@@ -298,6 +317,9 @@ async function heapRow(chromium) {
   const { cdp, gc, read } = await makeReaders(page);
 
   const rounds = [];
+  const orderSamples = [];
+  let position = 0;
+  let previous = null;
   let unverified = 0;
   let mounts = 0;
 
@@ -338,10 +360,14 @@ async function heapRow(chromium) {
       baselineDriftCdp: ctlAfter.cdp - ctlBefore.cdp,
     };
 
-    // --- the arms, order rotating with the round -------------------------
+    // --- the arms, order rotating AND REFLECTING with the round ----------
+    // `guard.schedule` reflects on odd rounds, which is what actually
+    // varies which arm follows which; the bare rotation this loop used to
+    // do did not. Every reading carries the label of the arm measured
+    // immediately before it and its position in the whole run.
     const arms = {};
-    for (let j = 0; j < HEAP_ARMS.length; j++) {
-      const arm = HEAP_ARMS[(j + round) % HEAP_ARMS.length];
+    for (const j of guard.schedule(HEAP_ARMS.length, round)) {
+      const arm = HEAP_ARMS[j];
       await gc();
       const pre = await read();
       const verify = await page.evaluate(
@@ -364,6 +390,13 @@ async function heapRow(chromium) {
         bytesPerBoundaryPerf: (held.perf - pre.perf) / boundaries,
         raw: { pre, held, post },
       };
+      orderSamples.push({
+        arm,
+        value: arms[arm].bytesPerBoundaryCdp,
+        predecessor: previous,
+        position: position++,
+      });
+      previous = arm;
     }
     rounds.push({ round, control, arms });
   }
@@ -427,6 +460,7 @@ async function heapRow(chromium) {
     control: { shape: 'dense JS array of doubles', doubles: CONTROL_DOUBLES, predictedBytes: CONTROL_PREDICTED },
     verification: { mounts, unverified },
     perRound: rounds,
+    orderVerdict: guard.verdict(orderSamples, { tolerance: TOLERANCE }),
     snapshots,
   };
 }
@@ -489,14 +523,42 @@ function summariseHeap(row) {
         `${String(Math.round(res.mean)).padStart(10)}`
     );
   }
+  console.log(';;');
+  for (const line of guard.format(row.orderVerdict, 'B7 heap — retained B/boundary, reader A')) {
+    console.log(line);
+  }
+  if (row.orderVerdict.refuse) {
+    console.log(';;');
+    console.log(';; ==== ARM ORDER: THESE FIGURES ARE NOT REPORTABLE ====');
+    console.log(
+      ';;   at least one arm reads differently for what preceded it or for where in the run ' +
+        'it was measured (rf2-88pie). The table above stands only as raw data; nothing in it ' +
+        'may be quoted.'
+    );
+  }
 }
 
 (async () => {
+  // Does the arm-order guard still catch the faults it was built for?
+  // Ahead of the build, because a broken guard makes every figure below
+  // unpublishable and finding that out after a fifteen-minute run is
+  // wasteful. The checks are fixtures replayed from recorded readings, so
+  // this is deterministic.
+  const guardSelf = guard.selfTest();
+  for (const c of guardSelf.checks) {
+    console.error(`[b7] order-guard ${c.ok ? 'ok  ' : 'FAIL'} ${c.name}`);
+  }
+  if (!guardSelf.ok) {
+    console.error('[b7] order guard self-test FAILED — nothing may be measured');
+    process.exit(1);
+  }
+
   build();
   const server = serve();
   const { chromium } = require('playwright');
   const out = { generatedAt: new Date().toISOString() };
   let failed = null;
+  let refused = false;
   try {
     if (ONLY !== 'heap') {
       console.error('[b7] mount-frame row ...');
@@ -515,6 +577,7 @@ function summariseHeap(row) {
       if (out.heap.verification.unverified > 0) {
         failed = `heap: ${out.heap.verification.unverified} unverified mounts`;
       }
+      refused = out.heap.orderVerdict.refuse;
     }
   } catch (e) {
     failed = String(e && e.stack ? e.stack : e);
@@ -530,6 +593,14 @@ function summariseHeap(row) {
   if (failed) {
     console.error(`[b7] FAILED: ${failed}`);
     process.exit(1);
+  }
+  // A run whose figures the arm-order guard refused is not a green run. The
+  // data is printed and the raw file is written — the refusal is about what
+  // may be QUOTED, not about throwing the measurement away. Exit 2, the
+  // same code `b8_run.cjs` uses for the same verdict.
+  if (refused) {
+    console.error('[b7] REFUSED by the arm-order guard (rf2-88pie): heap');
+    process.exit(2);
   }
   console.error('[b7] ok');
 })();

--- a/implementation/freehand/test/re_frame/freehand/bench/b8_run.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/b8_run.cjs
@@ -59,8 +59,41 @@ function arg(name, dflt) {
   return i === -1 ? dflt : process.argv[i + 1];
 }
 
-const ROUNDS = Number(process.env.B8_ROUNDS || 5);
+// SIX, not five. The guard splits an arm's samples into thirds and
+// compares the first against the last; at five samples a third is ONE, and
+// a single-sample stratum carries no range, so the phase question has to be
+// adjudicated on a bare ratio. At six it is a range against a range, which
+// is the house rule the whole instrument is built on (rf2-tb345).
+const ROUNDS = Number(process.env.B8_ROUNDS || 6);
 const WRITES = Number(process.env.B8_WRITES || 40);
+
+// --- warm-up (rf2-tb345) ---------------------------------------------------
+//
+// A measurement site reads well above its settled value until it has run
+// several FULL-SIZE windows, and this driver used to warm each (arm, D) with
+// the single four-write calibration probe. Two independent readings say that
+// is nowhere near enough:
+//
+//   plain node, packed-SMI .slice() control, nothing else varying, sixteen
+//   consecutive windows:
+//       42.32 | 10.32 10.26 10.26 10.26 10.33 10.28 | 8.12 8.12 ... 8.12
+//   the first window 5.3x the settled value, the next SIX at +27%.
+//
+//   this driver's own first guarded run, B8_ROUNDS=4 --kind narrow: the
+//   `instrument` arm — the pseudo-arm whose entire purpose is to price the
+//   harness's own footprint as a CONSTANT — read 4,361 B/write in its first
+//   window and 440 in its last. 9.9x.
+//
+// So each (arm, D) is now warmed at its REAL window size, and warmed until
+// it has stopped TRENDING rather than for a fixed count somebody guessed: a
+// floor of `B8_WARMUP` windows, then keep going while the guard's own phase
+// rule still separates the first third of the trajectory from the last, to
+// a ceiling of `B8_WARMUP_MAX`. The whole trajectory is recorded and
+// printed, so "wide enough" is a claim the output can be checked against
+// rather than an assertion.
+const WARMUP = Number(process.env.B8_WARMUP || 6);
+const WARMUP_MAX = Number(process.env.B8_WARMUP_MAX || 10);
+const SETTLE_TOL = Number(process.env.B8_SETTLE_TOL || 0.10);
 const KINDS = (arg('kind', 'broad,narrow')).split(',');
 const NO_BUILD = process.argv.includes('--no-build');
 
@@ -452,21 +485,75 @@ async function main() {
   // the number of writes that fits its own allocation into one nursery.
   const TARGET = Number(process.env.B8_TARGET_BYTES || 3.0e6);
   const nFor = {};
+  const warmth = {};
   for (const kind of KINDS) {
     nFor[kind] = {};
+    warmth[kind] = {};
     for (const arm of ARMS) {
       nFor[kind][arm] = {};
+      warmth[kind][arm] = {};
       for (const d of arm === 'instrument' || LADDER_ARMS.includes(arm) ? [0, CTL_1, CTL_2] : [0]) {
-        // A calibration window, never read as data. It doubles as the
-        // warm-up pass — first-call compilation, inline caches and
-        // one-time module state are not what this asks about, and charged
-        // to round 1 they read as allocation per write.
+        // A calibration window, never read as data. Four writes is enough
+        // to SIZE the window and nothing like enough to warm it — which is
+        // the whole of rf2-tb345 — so it no longer doubles as the warm-up.
         const probe = await window_(arm, kind, d, false, 4);
         const perWrite = Math.max(1, probe.inPage.posSum / 4);
         const n = Math.max(2, Math.min(WRITES, Math.round(TARGET / perWrite)));
         nFor[kind][arm][d] = n;
+
+        // Now warm at the REAL window size, and keep going until the site
+        // has stopped TRENDING. Nothing here is read as data either; the
+        // trajectory is kept only so the claim "warm enough" can be checked.
+        //
+        // "Stopped trending" is asked with the GUARD'S OWN RULE rather than
+        // a second one invented here — `phase`, first third against last
+        // third, disjoint ranges AND medians beyond tolerance. That matters,
+        // because a first draft asked whether the last three windows sat
+        // within 10% of each other and could not tell a site that is still
+        // warming from one that is merely noisy: `reagent/D=0` spreads
+        // 23,637–54,096 B/write when fully warm and would have warmed to the
+        // ceiling for ever, while `instrument/D=0` genuinely oscillates
+        // 5,969 → 466 → 10,968 → 440 → 9,512 → 440 → 440 → 440 and must not
+        // stop at six. Asking the question the way the guard will ask it is
+        // also the only way this loop can promise anything about the guard.
+        const trail = [];
+        let settled = false;
+        while (trail.length < WARMUP_MAX) {
+          const w = await window_(arm, kind, d, false, n);
+          trail.push(w.inPage.posSum / n);
+          if (trail.length >= Math.max(4, WARMUP)) {
+            const v = guard.verdict(
+              trail.map((value, i) => ({ arm, value, predecessor: arm, position: i })),
+              { tolerance: SETTLE_TOL, factors: ['phase'] }
+            );
+            if (!v.contaminated) {
+              settled = true;
+              break;
+            }
+          }
+        }
+        // The settled value is the LAST THIRD'S MEDIAN, not the last
+        // window. `instrument/D=0` runs 11,824 → 6,041 → 16,372 → 440 →
+        // 5,846 → 440 → 440 → 440 → 440 → 14,109: it is not trending, which
+        // is what `settled` asks, but it is bimodal, and whichever window
+        // the loop happens to stop on would otherwise become the
+        // denominator. A median over the same third the guard adjudicates
+        // is the figure that does not depend on where the loop stopped.
+        const cold = trail[0];
+        const settledValue = guard.median(trail.slice(-Math.max(1, Math.floor(trail.length / 3))));
+        warmth[kind][arm][d] = {
+          writes: n,
+          windows: trail.length,
+          settled,
+          cold,
+          settledValue,
+          coldOverSettled: settledValue > 0 ? cold / settledValue : null,
+          trail,
+        };
         console.error(
-          `[b8] ${kind}/${arm}/D=${d}: ~${Math.round(perWrite)} B per write -> ${n} writes per window`
+          `[b8] ${kind}/${arm}/D=${d}: ~${Math.round(perWrite)} B per write -> ${n} writes per ` +
+            `window; warmed ${trail.length} windows, ${settled ? 'SETTLED' : 'STILL MOVING'} ` +
+            `[${trail.map((x) => Math.round(x)).join(' ')}]`
         );
       }
     }
@@ -519,7 +606,7 @@ async function main() {
   const sampler = await samplerControl(KINDS[0], nFor[KINDS[0]]['freehand-interpreted'][0], refBpd);
 
   await browser.close();
-  return { rows, sampler, retention, keptDropped, refBytesPerDouble: refBpd, nFor,
+  return { rows, sampler, retention, keptDropped, refBytesPerDouble: refBpd, nFor, warmth,
            integrity: integ, precise: { probes } };
 }
 
@@ -534,6 +621,56 @@ function stat(xs) {
   return { mean, min: s[0], max: s[s.length - 1], n: s.length };
 }
 const fmt = (v) => (v === null || v === undefined ? '-' : Math.round(v).toLocaleString('en-US'));
+
+// rf2-tb345. Was the warm-up wide enough? The claim is checkable, so it is
+// checked rather than asserted: every (arm, D) reports how far its FIRST
+// full-size window sat above the last one, how many windows it took to stop
+// moving, and whether it stopped at all inside the ceiling. A combination
+// that never settled is named — its arm's figures were taken on a moving
+// site and the guard's phase factor is the thing that will say so.
+function reportWarmth(warmth) {
+  console.log('\n;; ==== WARM-UP — how long each site takes to stop moving (rf2-tb345) ====');
+  console.log(
+    `;;   floor ${WARMUP} windows, ceiling ${WARMUP_MAX}, settled = the guard's own phase rule ` +
+      `no longer separates the trajectory's first third from its last at ` +
+      `${(SETTLE_TOL * 100).toFixed(0)}%; the calibration probe is NOT counted`
+  );
+  console.log(
+    ';;   kind/arm/D                      writes  windows   first window     settled  cold/settled  settled?'
+  );
+  const unsettled = [];
+  let worst = null;
+  for (const [kind, arms] of Object.entries(warmth || {})) {
+    for (const [arm, ds] of Object.entries(arms)) {
+      for (const [d, w] of Object.entries(ds)) {
+        const label = `${kind}/${arm}/D=${d}`;
+        if (!w.settled) unsettled.push(label);
+        if (w.coldOverSettled !== null && (worst === null || w.coldOverSettled > worst.r)) {
+          worst = { label, r: w.coldOverSettled };
+        }
+        console.log(
+          `;;   ${label.padEnd(32)}${String(w.writes).padStart(6)}` +
+            `${String(w.windows).padStart(9)}` +
+            `${fmt(w.cold).padStart(15)}${fmt(w.settledValue).padStart(12)}` +
+            `${(w.coldOverSettled === null ? '-' : w.coldOverSettled.toFixed(2) + 'x').padStart(14)}` +
+            `  ${w.settled ? 'yes' : 'NO — still trending'}`
+        );
+      }
+    }
+  }
+  if (worst) {
+    console.log(
+      `;;   worst first-window inflation: ${worst.label} read ${worst.r.toFixed(2)}x its settled ` +
+        'value — that is what a single calibration window used to charge to round 1'
+    );
+  }
+  console.log(
+    unsettled.length
+      ? `;;   NOT SETTLED inside the ceiling: ${unsettled.join(', ')} — raise B8_WARMUP_MAX`
+      : ';;   every site settled inside the ceiling'
+  );
+  return unsettled;
+}
 
 function report(out) {
   const { rows, sampler } = out;
@@ -853,6 +990,8 @@ function report(out) {
     `;;   -> the sampler reports ${((sampler.samplerTotal / sampler.counterAllocated) * 100).toFixed(1)}%` +
       ` of what was allocated; it is a retention instrument.`
   );
+
+  summary.warmupUnsettled = reportWarmth(out.warmth);
 
   if (refusals.length) {
     console.log('\n;; ==== ARM ORDER: THESE FIGURES ARE NOT REPORTABLE ====');

--- a/implementation/freehand/test/re_frame/freehand/bench/order_guard.cjs
+++ b/implementation/freehand/test/re_frame/freehand/bench/order_guard.cjs
@@ -104,6 +104,22 @@
 // [[schedule]] reflects the rotation on odd rounds, which replaces every
 // `a -> a+1` adjacency with `a -> a-1`. `selfTest` proves both halves of
 // that arithmetically.
+//
+// ## What the `predecessor` factor can and cannot attribute (rf2-om73r)
+//
+// Under [[schedule]] an arm's predecessor is `(a - 1) mod n` on EVEN rounds
+// and `(a + 1) mod n` on ODD ones, so with only two orders available the
+// predecessor is a function of the round's PARITY. The two strata are
+// therefore "even rounds" and "odd rounds" wearing predecessor labels, and
+// a `predecessor` finding says *this figure moves with the plan* — which is
+// the whole property and reason enough to refuse — but it does NOT
+// establish that the immediate predecessor is the mechanism. Anything else
+// that alternates with the round direction lands in the same stratum.
+//
+// That is not a defect to paper over with a randomised order (see above for
+// why randomising is worse), and separating the two would need a third
+// distinct order per arm. It is stated here so that no report quotes a
+// `predecessor` stratum as evidence about adjacency specifically.
 
 // ---------------------------------------------------------------------------
 // The schedule
@@ -249,7 +265,14 @@ function adjudicate(strata, tolerance) {
   const use = powered.length >= 2 ? powered : strata;
   const lo = use[0];
   const hi = use[use.length - 1];
-  const ratio = lo.p50 === 0 ? Infinity : hi.p50 / lo.p50;
+  // An arm that allocates NOTHING reads zero in every stratum, and `0/0` is
+  // not an infinite separation — it is no separation at all. Left as
+  // `Infinity` this manufactures contamination out of two strata that agree
+  // exactly, and on two n=1 strata (which are adjudicated on the ratio
+  // alone) it FIRES — the one thing the house rule exists to prevent.
+  // `read-attribution`'s CACHEGET and NOOP arms are identically zero in
+  // every round and were the reproduction (rf2-om73r).
+  const ratio = hi.p50 === lo.p50 ? 1 : lo.p50 === 0 ? Infinity : hi.p50 / lo.p50;
   const disjoint = hi.min > lo.max;
   const degenerate = lo.n < 2 || hi.n < 2;
   const beyond = Math.abs(ratio - 1) > tolerance;
@@ -442,7 +465,23 @@ function selfTest() {
     `phase: ${one(vWarm, 'CTL-SMI-slice', 'phase').why}`
   );
 
-  // 6. CYCLIC ROTATION DOES NOT VARY ADJACENCY. Every arm keeps one
+  // 6. AN ARM THAT ALLOCATES NOTHING IS NOT INFINITELY CONTAMINATED.
+  //    `read-attribution`'s CACHEGET reads exactly 0 B in every round, so
+  //    both strata are zero; the pair is n=1 apiece here, which is the
+  //    case adjudicated on the ratio alone and therefore the case that
+  //    fires. It must not.
+  const zeros = [
+    { arm: 'CACHEGET', predecessor: 'PORT', position: 0, value: 0 },
+    { arm: 'CACHEGET', predecessor: 'DEREF', position: 1, value: 0 },
+  ];
+  const vZero = verdict(zeros, { tolerance: 0.1, factors: ['predecessor'] });
+  check(
+    'an arm that reads exactly zero in both strata is indistinguishable, not infinite',
+    one(vZero, 'CACHEGET', 'predecessor').status === 'clean',
+    one(vZero, 'CACHEGET', 'predecessor').why
+  );
+
+  // 7. CYCLIC ROTATION DOES NOT VARY ADJACENCY. Every arm keeps one
   //    predecessor in every round but the seam, so the order question is
   //    asked with a single sample in R. The reflecting schedule splits it.
   const R = 6;


### PR DESCRIPTION
PR #7223 built the arm-order guard and wired it into `b8_run.cjs` and the B6
harness. It could not reach `implementation/core`, and it left B8's warm-up
alone — which is why B8's first guarded run exited 2. Two beads, two commits,
plus one to record the evidence.

## Does the guard transfer to the core harnesses?

**Not as a file, and saying so is the first finding.** `order_guard.cjs` is a
CommonJS module for a Node driver holding a Chromium page. Neither core
harness can consume it:

- `re-frame.bench.read-attribution` is **JVM Clojure**, measuring through
  `ThreadMXBean/getThreadAllocatedBytes`. There is no JavaScript runtime in
  the process at all.
- `re-frame.bench.write-attribution` is ClojureScript, but it lives in
  `implementation/core`, which may not `:require` out of
  `implementation/freehand`. A test harness reaching across that boundary
  would put the dependency arrow the wrong way round.

So the honest shape is **a shared rule expressed twice**:
`implementation/core/test/re_frame/bench/order_guard.cljc` carries the same
schedule and the same verdict for both. What stops the two copies drifting is
that both self-tests replay the **same recorded fixtures** — the same
2.0125x, the same 0.43% slope, the same twelve-window warm-up sweep, the same
rotation arithmetic. Eight checks each; they agree line for line. A copy that
drifts fails on numbers taken from the live study rather than on a
restatement of itself.

B7 is in the same artefact as the guard, so it just requires it.

## Does core carry the same false rotation?

**B7 did, exactly.** `b7_run.cjs` selected `HEAP_ARMS[(j + round) % n]` and
published it as "the arms, order rotating with the round". It now rotates
**and reflects**, labels every reading with its predecessor and position, and
exits 2 on refusal — the same code B8 uses.

`write_attribution` and `read_attribution` had **no rotation at all**: one
pass, one order, and a `WA_ORDER=rev` / `RM_ORDER=rev` knob producing a
second reading in a *second process* whose numbers nothing ever joined up.
That is the `unchecked` case the guard refuses by construction. Both now walk
the plan in rounds under `slot-order`, and both report the p50 across rounds
**with the round range** — `read_attribution` previously reported a mean
alone, against standing method.

## What the guard found

**`read-attribution` passes** — both factors, every arm, JVM, exact TLAB
accounting. Positive controls **+0.000%** predicted against measured on both
rungs (244,800 and 2,404,800 B).

**B7 passes** — `reportable` for all seven arms, **0 unverified of 49
mounts**, positive control **4,700,288 B measured against 4,700,000 predicted
(+0.006%)** on reader A.

**`write-attribution` refuses**, reproducibly, on the three arms whose own
allocation is nearest zero — and all three are the SHIPPED half of a paired
control, the half whose whole purpose is to price a saving. Two full runs,
fresh `:advanced` build each, node 24.13.0 / V8 13.6, **pointer compression
OFF**:

| arm | low stratum | high stratum |
|---|---:|---:|
| `P-SCOPEH` | 32.00 [32.00–32.00] | 637.96 [637.96–637.96] |
| `P-INHERH` | 48.00 [48.00–48.00] | 4,848 [4,848–4,848] |
| `P-RKV` | 82.93 [82.90–82.93] | 4,883 [4,883–4,883] |

Zero variance inside every stratum, n=3 each. The phase factor is **clean on
all 33 arms**. Filed as **rf2-xu0ma** — the step's magnitude moves between
runs while its structure does not, which argues for a fixed block the
collection did not settle rather than an undersized window. Control on that
harness: **DBL slope 8.0446 B/double against 8.0000 predicted, +0.56%**
(small pair; the large pair's +9.11% is the documented page-tail effect).

**Node ≠ Chrome and JVM ≠ CLJS.** A tagged slot is 8 B on this node build and
4 in Chrome; shares transfer, absolutes do not.

## B8's warm-up (rf2-tb345)

Four writes size a window; they do not warm one. Each `(arm, D)` now gets a
floor of **six full-size discarded windows** and keeps warming while the site
is still **trending**, to a ceiling of ten. `ROUNDS` moves 5 → 6 so the
guard's phase thirds are ranges rather than single samples.

"Still trending" is asked with the **guard's own phase rule**, not a second
rule invented here. That is load-bearing: a first draft asked whether the
last three windows agreed within 10% and could not tell a site that is still
warming from one that is merely noisy — `reagent/D=0` spreads 23,977–28,515
B/write when fully warm and warmed to the ceiling for ever.

The evidence that six is enough is the `instrument` arm — the pseudo-arm that
installs no state and drains nothing. Its D=0 warm-up trajectory, three
consecutive runs:

```
5,969   466  10,968  440   9,512  440  440  440
11,824  6,041 16,372 440   5,846  440  440  440  440  14,109
7,047   466  29,156  440   8,862  440
```

Its value in all 84 **measured** windows of each run was `440 [440–440]`. So
the first full-size window read 13.6x, 26.9x and 16.0x the figure the arm
actually has, and it is **bimodal rather than merely cold** — which is why
the settled value is reported as the last third's median and not the last
window. The bead's recorded 9.9x understated it.

**The guard now passes on B8.** Three consecutive `--kind narrow` runs, all
`VERDICT: reportable`, all exit 0 where the same driver exited 2 before. Per
run: 84 of 84 windows verified at the DOM, **0 unverified writes of 2,400**,
bookkeeping identity exact (worst residual 0 B), in-page sum against the CDP
bracket worst 3.3–4.7%, every site settled inside the ceiling.

The positive control still misses and the miss is the documented one:
16.002 B/double by retention against a slope of 11.907 (`instrument`, −25.6%)
/ 10.770 (`freehand-interpreted`, −32.7%) / 6.934 (`reagent`, −56.7%). A
collection inside a window nets the reclaimed bytes away inside whichever
rising step contained it. Warming the sites was never going to change that.

## A defect in the guard itself

Pointing it at an arm that allocates nothing found one. `ratio` was
`lo.p50 === 0 ? Infinity : hi/lo`, so two strata **both reading exactly zero**
came out infinitely far apart — and on two n=1 strata, the case adjudicated
on the ratio alone, that **fires**, manufacturing contamination out of two
readings that agree exactly. `read-attribution`'s `CACHEGET` and `NOOP` arms
are identically zero in every round and are the reproduction. Fixed in both
copies with a fixture in both self-tests.

## One limitation, recorded rather than papered over

Under a rotate-and-reflect schedule an arm's predecessor is a function of the
round's **parity**, so a `predecessor` stratum establishes that *the figure
moves with the plan* — reason enough to refuse — but **not** that adjacency
is the mechanism. Separating them needs a third distinct order per arm.
Stated in both guard headers so no report quotes a `predecessor` stratum as
evidence about adjacency specifically.

## Scope

No Freehand-versus-Reagent verdict is added or changed; §1's table is
untouched. `implementation/core/src/**` and `implementation/freehand/src/**`
are untouched — no production source. No navigation was added; the
navigation-ceiling policy test passes.


## Rebased onto main (2026-07-28)

`#7225` landed `bench/navigate.cjs` — the drivers' one navigation, with a
REQUIRED `timeoutMs` / `waitUntil` — and routed `b7_run.cjs` and `b8_run.cjs`
through it at `'commit'` on an explicit 60s budget. This branch was editing
the same two drivers, so it was rebuilt on that main.

Exactly one hunk conflicted: the require block at the top of `b7_run.cjs`,
where main added `require('./navigate.cjs')` and this branch added
`require('./order_guard.cjs')` into the same three lines. **Both are kept**,
in the order `b8_run.cjs` already uses on main — guard first, navigation
second, adjacent. Nothing else in either driver overlapped, so main's
`newPage(chromium, query, budget)` signature, its two budget-naming call
sites and both `navigate(...)` calls are present verbatim alongside this
branch's rotate-and-reflect schedule, warm-up loop and refusal exits.

Faithfulness, checked rather than asserted: five of the seven files come
through with an **identical blob SHA** (`order_guard.cljc`,
`read_attribution.clj`, `write_attribution.cljs`, `order_guard.cjs`, the
design doc). For the two that moved, the diff **post-rebase against the
pre-rebase tip** is byte-for-byte main's contribution, and the diff
**post-rebase against main** is byte-for-byte this branch's contribution —
the only line in neither is the blank line that used to separate the two
`require`s.

## Quality gates

Re-run in full after the rebase.

| gate | exit |
|---|---|
| `order_guard.cjs` self-test (8 checks) | 0 |
| `re-frame.bench.order-guard` self-test, JVM (8 checks) | 0 |
| the two self-tests' output, diffed line for line | identical |
| `b8_run.cjs --kind narrow` (`B8_ROUNDS=6`), x3 | 0, 0, 0 |
| `b7_run.cjs --only heap` (`B7_SNAPSHOT=0`) | 0 |
| `read-attribution`, `RM_SUITE=all` | 0 |
| `write-attribution`, `WA_N=300` | **2 — the guard refusing, rf2-xu0ma** |
| `npm run test:script-policy` (incl. `_navigation-ceiling-policy`, 3 passed) | 0 |
| `npm run bench:freehand-browser` (30 tests, 465 assertions) | 0 |
| `npm run test:browser` (841 tests, 5,459 assertions) | 0 |

Both self-tests still replay the same fixtures — the 2.0125x ratio, the
2830.7 / 2842.8 slope pair, the 1.2633x twelve-window phase step, the
`1,1,1,1` rotation against the `2,2,2,2` reflection — and their eight lines
are identical after normalising the JVM console's em-dash encoding.

All three B8 runs: `VERDICT: reportable`, 84 of 84 windows, **0 unverified
writes of 2,400**, worst bookkeeping residual **0 B**, every site settled
inside the ceiling. B7 heap: `reportable`, **0 unverified of 49 mounts**,
positive control **4,700,288 B measured against 4,700,000 predicted
(+0.006%)**. `read-attribution`: `reportable`, positive controls
**+0.000%** on both rungs (244,800 and 2,404,800 B).

`write-attribution`'s exit 2 is the instrument working: it prints every
figure and refuses to let them be quoted. The three refusing arms are
unchanged — `P-SCOPEH`, `P-INHERH`, `P-RKV`, each `[FAIL] by predecessor,
ranges disjoint`. Everything slower — the full JVM and CLJS suites, the docs
build — is deferred to CI.

Closes rf2-om73r, rf2-tb345. Files rf2-xu0ma.
