### PR TITLE
bench(write-attribution): the refusing arms' step is a boxed HeapNumber belonging to the control arm (rf2-xu0ma)

### DIFF
--- a/docs/design/freehand/studio/freehand-vs-reagent-allocation.md
+++ b/docs/design/freehand/studio/freehand-vs-reagent-allocation.md
@@ -506,14 +506,84 @@ same recorded fixtures so neither can drift quietly. Eight checks each.
   **4,700,288 B measured against 4,700,000 predicted (+0.006%)** on
   reader A. It is a retention harness, so this says nothing about
   allocation; it says the arm order was not moving its figures.
-- **`write-attribution` refuses**, and on the three arms whose own
+- **`write-attribution` refused**, and on the three arms whose own
   allocation is nearest zero — all of them the SHIPPED half of a paired
-  control. `P-SCOPEH` reads 32.00 B/call in one stratum and 637.96 in the
+  control. `P-SCOPEH` read 32.00 B/call in one stratum and 637.96 in the
   other; `P-INHERH` 48.00 against 653.96; `P-RKV` 80.94 against 686.93.
   Zero variance inside each stratum, and the same ~606 B/call step on all
-  three. Tracked as `rf2-xu0ma`. **Node, uncompressed pointers** — a
-  tagged slot is 8 B there and 4 in Chrome, so shares transfer and
-  absolutes do not.
+  three. **Node, uncompressed pointers** — a tagged slot is 8 B there and
+  4 in Chrome, so shares transfer and absolutes do not. The cause is now
+  known, and is below.
+
+#### What the step was (rf2-xu0ma)
+
+The three arms were being charged for **a boxed number that belonged to
+another arm**.
+
+Every arm feeds `keep!`, which increments one shared counter. The
+increment is type-PRESERVING: given an Smi it yields an Smi and allocates
+nothing, given a double it yields a double, and storing that double back
+into the volatile's tagged field boxes a fresh `HeapNumber` — 16 B with
+pointer compression off. The four `DBL-*` control arms used to *store*
+their sampled element into that same counter, and `packed-doubles`
+element 0 is `0.5`. So after any `DBL-*` arm the counter was a double,
+and it stayed one until an `SMI-*` arm put an integer back.
+
+`slot-order` runs the plan ascending on even rounds — where `SMI-200`
+resets the counter before the body — and descending on odd ones, where a
+`DBL-*` arm is the last control the body sees. An arm with a
+300-iteration inner loop therefore carried **300 × 16 = 4800 B/call on
+odd rounds and nothing on even ones**, deterministically, which is the
+step and its zero within-stratum variance. `P-RKV`'s contaminated
+stratum is labelled with the predecessor `DBL-100` in the guard's own
+report — the arm that put the double there.
+
+Priced against a prediction stated before the measurement — 16 B × 300
+iterations = 4800 B/call — the probe reads **+0.00% at reps 64, 128, 256,
+512 and 1024**, and `P-EMIT`, the one 4000-rep arm with no `keep!` in it,
+does not move at all (0.0 B/call under both seeds).
+
+The bead's second puzzle — the step reading ~606 B/call in one run and
+~4800 in another, "a fixed block whose size varies run to run" — is the
+same 4800, **truncated**. `calibrate` caps reps at 4000, and at that cap
+these arms' contaminated windows are 19.2 MB, far past the nursery, so
+scavenges run *inside* the measurement window and the counter reads
+survivors rather than allocation. The residue is 2,423,840 B, to the
+byte, in every run that hit the cap. Which figure a run showed was
+decided by nothing more than whether `calibrate`'s four-rep probe landed
+on the cap that time.
+
+With the control arms feeding `keep!` instead of clobbering it, `keep!`
+is the sole writer of the counter, the counter is an Smi for the whole
+run, and the harness returns **`reportable` on all 33 arms** in three
+consecutive runs. The `DBL-100` control falls from 864.9 to **848.2
+B/copy against 848 predicted (+0.02%)** — that is the box leaving, and it
+is the cleanest confirmation available that the 16 B was real and is
+gone.
+
+**What it cost.** Every arm with a 300-iteration inner loop was
+over-read by 16.0 B/sub; the ladder's `RFWRITE-*` rungs and the
+`Q-SCHED*` pair contain no `keep!` and were untouched. Corrected against
+contaminated, per sub, node: `P-SCOPEM` 744.2 (was 760.2), `P-INHER`
+240.2 (was 256.2), `P-SCOPE` 120.1 (was 136.1), `P-BODY` 280.9 (was
+296.2), `P-VALS` 308.6 (was 321.8), `P-MEMO` 641.3 (was 644.9). The
+shipped halves move by more than their own size: `P-INHERH` **0.2 (was
+16.2)**, `P-RKV` **0.3 (was 16.3)**, `P-SCOPEH` **0.1 (was 2.1)** — the
+shipped spellings allocate essentially nothing, and the retired-vs-shipped
+*differences* mostly survive because both halves carried the same 16 B in
+the same stratum. The exception is the hoist, where the shipped half was
+also truncated: **744.1 B/sub saved, not 758.1**.
+
+- **A second discrepancy this exposed, not yet isolated.** The `SMI-*`
+  control reads **almost exactly twice** its own prediction — 1681.7
+  B/copy at D=100 against 848 predicted (+98.3%), 3293.5 against 1648
+  (+99.9%) — so the printed `SMI slope` of 16.11 B/slot is 2× the 8 B a
+  tagged slot occupies with pointer compression off. It is *not* the box
+  above: the `SMI-*` arms store an Smi, and the 2× survives the fix
+  unchanged. The regime conclusion the pair exists to draw is still the
+  right one (16.11 > the 6.0 threshold → compression OFF), and the `DBL`
+  slope it is read beside lands at +0.04%, so no figure here rests on it.
+  Filed rather than guessed at.
 - **`read-attribution` passes**, both factors, every arm, with its
   controls landing at **+0.000%** predicted against measured on both
   rungs (JVM, exact TLAB accounting).

--- a/implementation/core/test/re_frame/bench/write_attribution.cljs
+++ b/implementation/core/test/re_frame/bench/write_attribution.cljs
@@ -252,6 +252,27 @@
 ;; sinks — Closure is entitled to delete an expression nothing reads, and this
 ;; surface has already published a `layout-ms` of exactly 0.000 because a
 ;; property read was dropped. Every arm feeds one of these.
+;;
+;; rf2-xu0ma — `sink` IS THE INSTRUMENT, so its own type is load-bearing.
+;; `keep!` is a type-PRESERVING increment: given an Smi it produces an Smi and
+;; allocates nothing; given a double it produces a double, and storing that
+;; double into the volatile's tagged field boxes a fresh `HeapNumber` — 16 B
+;; with pointer compression OFF, 12 B with it ON. An arm with a 300-iteration
+;; inner loop therefore reads 4800 B/call MORE than it costs, purely because
+;; something earlier in the plan left a double in this slot.
+;;
+;; It did. `arm-ctl` used to store `(aget c 0)` here, and `packed-doubles`
+;; element 0 is `0.5`, so every arm that ran after a `DBL-*` control and before
+;; an `SMI-*` one was charged that 4800 B — which under the reflecting schedule
+;; is exactly the odd-numbered rounds. Measured at +0.00% against the 4800 B
+;; prediction at five window sizes (node 24.13.0 / V8 13.6, pointer compression
+;; OFF); `-diagnose` re-runs the proof.
+;;
+;; THE INVARIANT, and it is why this comment is here: **`keep!` is the only
+;; writer of `sink`**. It is seeded with an Smi and only ever incremented, so it
+;; is an Smi for the whole run and no arm can allocate on another's behalf.
+;; Anything that wants to retain a VALUE rather than count one uses `sink2`,
+;; which no arm reads back and which is written at most once per call.
 
 (defonce ^:private sink (volatile! 0))
 (defonce ^:private sink2 (volatile! nil))
@@ -307,8 +328,14 @@
 (defn- arm-ctl [kind d]
   (let [t (get @ctl-templates (ctl-key kind d))]
     (fn []
+      ;; rf2-xu0ma — element 0 goes through `keep!`, NOT into `sink` directly.
+      ;; The read is what stops Closure deleting the copy, and it is preserved;
+      ;; what is dropped is the STORE, which used to put a double (`0.5`) in the
+      ;; counter every `DBL-*` call and leave it there for every arm that ran
+      ;; next. The control's own figure loses the 16 B box with it, which is
+      ;; the check: `DBL-100` is predicted to fall from 864 B/copy to 848.
       (let [c (.slice t)]
-        (vreset! sink (aget c 0)))
+        (keep! (aget c 0)))
       nil)))
 
 (defn- slope
@@ -1047,3 +1074,188 @@
           (println ";;   may be quoted.")
           (set! (.-exitCode js/process) 2))))
     (println (gstring/format ";; sink %s %s" @sink (some? @sink2)))))
+
+;; ---------------------------------------------------------------------------
+;; rf2-xu0ma — the sink-typing probe
+;;
+;; `-main` above refuses on `P-SCOPEH`, `P-INHERH` and `P-RKV`, whose figures
+;; step by ~4800 B/call with the round's PARITY. This entry point prices the
+;; mechanism directly rather than inferring it, and it is the same instrument:
+;; the same `collect!`, the same `used-heap`, the same `measure`, the same rig.
+;;
+;; The claim under test, in one line: `keep!` increments a SHARED counter whose
+;; TYPE the control arms decide, and an increment of a double allocates.
+;;
+;;   - `keep!` is `(vreset! sink (if v (inc @sink) @sink))` — type-PRESERVING.
+;;   - `arm-ctl` is `(vreset! sink (aget c 0))` — it CLOBBERS the same slot with
+;;     an element of the control template.
+;;   - `packed-doubles` element 0 is `0.5`; `packed-smis` element 0 is `1`.
+;;
+;; So after any `DBL-*` arm the counter is a double and every subsequent `keep!`
+;; boxes a fresh `HeapNumber` — 8 B map word + 8 B payload = 16 B with pointer
+;; compression OFF — until an `SMI-*` arm puts an Smi back. `slot-order` runs
+;; the plan ASCENDING on even rounds (so `SMI-200` resets the counter before the
+;; body) and DESCENDING on odd ones (so a `DBL-*` arm is the last control the
+;; body sees). An arm with a 300-iteration inner loop therefore carries
+;; 300 x 16 = 4800 B/call on odd rounds and 0 on even ones.
+;;
+;; PREDICTION, stated before the measurement: seeding the counter with `0.5`
+;; rather than `1` costs `16 x iters` B/call, and nothing else about the loop
+;; changes. `WA_PROBE_REPS` sweeps the window size, because the second half of
+;; the bead — the step reading 606 B/call in one run and 4800 in another — is
+;; predicted to be this same 4800 TRUNCATED by scavenges once `reps x 4800`
+;; outgrows the nursery, and a sweep is what tells linear from truncated.
+
+(defn- sink-loop
+  "`iters` bare `keep!` calls and nothing else — the inner loop every refusing
+  arm shares, with the arm's own body removed."
+  [iters]
+  (fn [] (dotimes [_ iters] (keep! true)) nil))
+
+(defn- probe
+  "`windows` collection-free windows of `reps` calls of `f`, after seeding the
+  shared counter with `seed`. Answers RAW bytes per window plus a READ-BACK:
+  `verify` is handed the counter's value before and after the window and says
+  whether the writes the window was CREDITED with actually landed. A window
+  that fails it is UNVERIFIED and is reported as such rather than quietly
+  pooled."
+  [f reps windows seed verify]
+  (let [ds (array) unverified (volatile! 0)]
+    (dotimes [_ windows]
+      (vreset! sink seed)
+      (collect!)
+      (let [before @sink
+            h0     (used-heap)]
+        (dotimes [_ reps] (f))
+        (let [d (- (used-heap) h0)]
+          (when-not (verify before @sink reps) (vswap! unverified inc))
+          (.push ds d))))
+    (.sort ds (fn [a b] (- a b)))
+    {:lo (aget ds 0)
+     :p50 (aget ds (js/Math.floor (/ (alength ds) 2)))
+     :hi (aget ds (dec (alength ds)))
+     :unverified @unverified
+     :windows windows}))
+
+(defn- advanced-by
+  "READ-BACK for an arm that increments the counter `per` times per call: the
+  counter must have moved by exactly `per x reps`."
+  [per]
+  (fn [before after reps] (== (- after before) (* per reps))))
+
+(defn- probe-line [label reps r per-call-divisor]
+  (println (gstring/format ";;   %-22s reps=%-6d raw [%12s – %12s]  p50 %12s B   %10s B/call   %d unverified of %d"
+                   label reps
+                   (fmt (:lo r)) (fmt (:hi r)) (fmt (:p50 r))
+                   (fmt (/ (:p50 r) per-call-divisor))
+                   (:unverified r) (:windows r))))
+
+(defn ^:export -diagnose [& _]
+  (let [iters   (env-int "WA_N" 300)
+        windows (env-int "WA_PROBE_WINDOWS" 5)
+        sweep   (mapv #(js/parseInt % 10)
+                      (.split (env "WA_PROBE_REPS" "64,128,256,512,1024,2048,4000") ","))
+        pc-off? (not= 1 (gobj/getValueByKeys js/process "config" "variables"
+                                             "v8_enable_pointer_compression"))
+        box-b   (if pc-off? 16 12)]
+    (rf/init! (spine/make-react-adapter
+                (spine/make-react-spine
+                  {:substrate-name        "write-attribution"
+                   :gensym-prefix-sub     "wa-sub-"
+                   :gensym-prefix-derived "wa-derived-"
+                   :gensym-prefix-use-sub "wa-use-sub-"
+                   :use-memo              (fn [t _] (t))
+                   :use-callback          (fn [t _] t)
+                   :use-context           (fn [_] nil)})
+                {:kind :rf.adapter/write-attribution :frame-provider nil}))
+    (vreset! ctl-templates
+             (into {} (concat (map (fn [d] [(ctl-key "DBL" d) (packed-doubles d)]) ctl-double-ds)
+                              (map (fn [d] [(ctl-key "SMI" d) (packed-smis d)]) ctl-smi-ds))))
+    (build-rig! iters iters [0 (js/Math.round (/ iters 4)) (js/Math.round (/ iters 2)) iters] true)
+    (println ";; rf2-xu0ma — SINK-TYPING PROBE for write-attribution's refusing arms")
+    (println (gstring/format ";; node %s  V8 %s  pointer-compression=%s  debug-enabled?=%s  gc-exposed?=%s"
+                     (.-node js/process.versions) (.-v8 js/process.versions)
+                     (if pc-off? "OFF" "ON") interop/debug-enabled?
+                     (some? (gobj/get js/globalThis "gc"))))
+    (println (gstring/format ";; iters/call=%d  windows/point=%d  HeapNumber predicted at %d B"
+                     iters windows box-b))
+    ;; ---- the control templates, read back --------------------------------
+    (let [d0 (aget (get @ctl-templates (ctl-key "DBL" 100)) 0)
+          s0 (aget (get @ctl-templates (ctl-key "SMI" 100)) 0)]
+      (println (gstring/format ";; DBL template elt0 = %s (integral? %s)   SMI template elt0 = %s (integral? %s)"
+                       d0 (js/Number.isInteger d0) s0 (js/Number.isInteger s0))))
+    ;; ---- warm, the same discipline the measured plan uses -----------------
+    (let [f (sink-loop iters)]
+      (dotimes [_ 3] (f))
+      (dotimes [_ 6] (measure f 256 1))
+      (println ";;")
+      (println ";; PROBE 1 — the bare keep! loop, counter seeded Smi vs double")
+      (println (gstring/format ";;   PREDICTED difference: %d B x %d iters = %d B/call, at EVERY reps"
+                       box-b iters (* box-b iters)))
+      (doseq [reps sweep]
+        (let [smi (probe f reps windows 1 (advanced-by iters))
+              dbl (probe f reps windows 0.5 (advanced-by iters))
+              step (- (/ (:p50 dbl) reps) (/ (:p50 smi) reps))]
+          (probe-line "keep!-loop  seed=Smi" reps smi reps)
+          (probe-line "keep!-loop  seed=dbl" reps dbl reps)
+          (println (gstring/format ";;     -> step %10s B/call   predicted %d   %+.2f%%   (window at seed=dbl would be %s B if linear)"
+                           (fmt step) (* box-b iters)
+                           (* 100.0 (/ (- step (* box-b iters)) (* box-b iters)))
+                           (fmt (* reps (+ (* box-b iters) (/ (:p50 smi) reps))))))))
+      ;; ---- PROBE 2 — the positive control, predicted vs measured ----------
+      (println ";;")
+      (println ";; PROBE 2 — POSITIVE CONTROL: .slice() of a packed array, predicted vs measured")
+      (println ";;   predicted per copy = JSArray 32 B + backing store (16 B header + 8 B x D),")
+      (println ";;   and, in the RETIRED counter spelling only, one 16 B HeapNumber for the")
+      (println ";;   double the DBL arms store into the shared counter. The SMI arms store an")
+      (println ";;   Smi, so they are predicted to carry no box in EITHER spelling — which is")
+      (println ";;   what makes the pair diagnostic rather than decorative.")
+      (doseq [[kind d] (concat (map (fn [d] ["DBL" d]) ctl-double-ds)
+                               (map (fn [d] ["SMI" d]) ctl-smi-ds))]
+        (let [pred (+ 32 16 (* 8 d))
+              boxed? (= "DBL" kind)
+              pred-box (if boxed? (+ pred box-b) pred)
+              reps (max 1 (js/Math.round (/ 500000 pred)))
+              elt0 (aget (get @ctl-templates (ctl-key kind d)) 0)
+              ;; READ-BACK for the control: it writes the copy's element 0 into
+              ;; the counter, so after the window the counter must HOLD that
+              ;; element. A window where the copy was optimised away fails it.
+              ctl-arm (arm-ctl kind d)
+              _    (do (dotimes [_ 3] (ctl-arm)) (dotimes [_ 6] (measure ctl-arm 64 1)))
+              ;; The control is the ONE arm whose counter spelling this bead
+              ;; changes, so the read-back accepts either: the RETIRED spelling
+              ;; leaves the counter HOLDING elt0, the shipped one ADVANCES it
+              ;; once per call. Neither is satisfied if the copy did not run.
+              r    (probe ctl-arm reps windows 0.5
+                          (fn [before after reps]
+                            (or (== after elt0) (== (- after before) reps))))
+              meas (/ (:p50 r) reps)]
+          (println (gstring/format ";;   %s D=%-6d reps=%-5d measured %10s B/copy   no-box %6d (%+.2f%%)   +box %6d (%+.2f%%)   %d unverified of %d"
+                           kind d reps (fmt meas)
+                           pred (* 100.0 (/ (- meas pred) pred))
+                           pred-box (* 100.0 (/ (- meas pred-box) pred-box))
+                           (:unverified r) (:windows r)))))
+      ;; ---- PROBE 3 — the three refusing arms, both seeds ------------------
+      (println ";;")
+      (println ";; PROBE 3 — the refusing arms themselves, counter seeded both ways")
+      (doseq [[label f* reps per] [["P-SCOPEH" arm-p-scope-h 4000 iters]
+                                   ["P-SCOPEH" arm-p-scope-h 818  iters]
+                                   ["P-INHERH" arm-p-inher-h 818  iters]
+                                   ["P-INHERH" arm-p-inher-h 4000 iters]
+                                   ["P-RKV"    arm-p-rkv     1269 iters]
+                                   ["P-RKV"    arm-p-rkv     4000 iters]
+                                   ;; P-EMIT is the NEGATIVE control: it is the
+                                   ;; one 4000-rep arm with no `keep!` in it, and
+                                   ;; the one the guard passes. It must not step.
+                                   ["P-EMIT"   arm-p-emit    4000 0]]]
+        (dotimes [_ 3] (f*))
+        (dotimes [_ 6] (measure f* 256 1))
+        (let [smi (probe f* reps windows 1 (advanced-by per))
+              dbl (probe f* reps windows 0.5 (advanced-by per))]
+          (probe-line (str label " seed=Smi") reps smi reps)
+          (probe-line (str label " seed=dbl") reps dbl reps)
+          (println (gstring/format ";;     -> step %10s B/call  (%s B per inner iteration)"
+                           (fmt (- (/ (:p50 dbl) reps) (/ (:p50 smi) reps)))
+                           (fmt (/ (- (/ (:p50 dbl) reps) (/ (:p50 smi) reps)) iters))))))
+      (println ";;")
+      (println (gstring/format ";; sink %s %s" @sink (some? @sink2))))))


### PR DESCRIPTION
Diagnoses `rf2-xu0ma` and fixes it. The guard was right, the step was real, and it is not adjacency, not warm-up, and not `collect!` failing to settle.

## What the step was

The three refusing arms were being charged for **a boxed number that belonged to another arm**.

`keep!`, the sink every arm feeds, is a type-**preserving** increment of one shared counter:

```clojure
(defn- keep! [v] (vreset! sink (if v (inc @sink) @sink)) nil)
```

Given an Smi it yields an Smi and allocates nothing. Given a double it yields a double, and storing that double back into the volatile's tagged field boxes a fresh `HeapNumber` — 8 B map word + 8 B payload = **16 B** with pointer compression off. And the control arms *clobbered* that same counter:

```clojure
(vreset! sink (aget c 0))      ; arm-ctl, before
```

`packed-doubles`' element 0 is `0.5`; `packed-smis`' is `1`. So after any `DBL-*` control the counter was a double and stayed one until an `SMI-*` control put an integer back.

`slot-order` runs the plan **ascending** on even rounds — where `SMI-200` (plan index 5) resets the counter before the entire body — and **descending** on odd ones, where a `DBL-*` arm is the last control the body sees. An arm with a 300-iteration inner loop therefore carried `300 x 16 = 4800 B/call` on odd rounds and nothing on even ones. Deterministic, which is the zero within-stratum variance. The guard's own report names the culprit: `P-RKV`'s contaminated stratum is labelled with the predecessor **`DBL-100`**.

## The proof, in the same instrument

A `-diagnose` entry point on the same harness — same `collect!`, same `used-heap`, same `measure`, same rig. **Prediction stated before the measurement: 16 B x 300 iters = 4800 B/call, at every window size.**

| reps | window | step B/call | vs predicted 4800 |
|---|---|---|---|
| 64 | 0.31 MB | 4800.0 | **+0.00%** |
| 128 | 0.61 MB | 4800.0 | **+0.00%** |
| 256 | 1.23 MB | 4800.0 | **+0.00%** |
| 512 | 2.46 MB | 4800.0 | **+0.00%** |
| 1024 | 4.92 MB | 4800.1 | **+0.00%** |

`P-EMIT` — the one 4000-rep arm with no `keep!` in it, and the one the guard passed — reads **0.0 B/call under both seeds**.

**Positive control**, `.slice()` of a packed double array, predicted `JSArray 32 + FixedDoubleArray (16 header + 8 x D)` plus one 16 B box in the retired spelling. **0 unverified of 5** at every point:

| | measured | predicted | |
|---|---|---|---|
| DBL D=100 | 864.6 | 864 | +0.07% |
| DBL D=200 | 1666.9 | 1664 | +0.17% |
| DBL D=1000 | 8129.8 | 8064 | +0.82% |
| DBL D=10000 | 83720.0 | 80064 | +4.57% |

## Why the magnitude moved between runs

The bead's second puzzle — ~606 B/call in one run, ~4800 in another, "a fixed block whose size varies" — is the **same 4800, truncated**. `calibrate` caps reps at 4000; at that cap the contaminated window is **19.2 MB**, far past the nursery (node's new space starts at 1 MiB), so scavenges run *inside* the measurement window and the counter reads survivors instead of allocation:

| reps | window if linear | step B/call |
|---|---|---|
| 2048 | 9.83 MB | 704.2 (−85.3%) |
| 4000 | 19.20 MB | 606.0 (−87.4%) |

The residue is **2,423,840 B to the byte** — the exact block the bead recorded. Which figure a run showed was decided by nothing but whether `calibrate`'s four-rep probe landed on the cap that time (`P-INHERH`: 4000, then 844, then 818 across three runs).

## The fix

Element 0 goes through `keep!` instead of into `sink`, so **`keep!` is the sole writer of the counter** and the counter is an Smi for the whole run. The read that stops Closure deleting the copy is preserved; only the store is dropped.

Cross-check built into the fix: `DBL-100` should lose its box. It falls from 864.9 to **848.2 B/copy against 848 predicted (+0.02%)**.

## What moves

Every arm with a 300-iteration `keep!` loop was over-read by 16.0 B/sub. The `RFWRITE-*` ladder rungs, `SPINE0*`, `C-TAGPAIR`, `C-BUMP*`, `Q-SCHED` and `Q-SCHEDJS` contain no `keep!` and are unchanged.

| per sub, node | contaminated | corrected |
|---|---|---|
| P-SCOPEM | 760.2 | 744.2 |
| P-INHER | 256.2 | 240.2 |
| P-SCOPE | 136.1 | 120.1 |
| P-BODY | 296.2 | 280.9 |
| P-VALS | 321.8 | 308.6 |
| P-MEMO | 644.9 | 641.3 |
| **P-SCOPEH** | **2.1** | **0.1** |
| **P-INHERH** | **16.2** | **0.2** |
| **P-RKV** | **16.3** | **0.3** |
| DBL-100 control | 864.9 B/copy | 848.2 B/copy |
| per-sub slope | 836.4 | 835.1 |

The paired-control **differences** mostly survive, because both halves carried the same 16 B in the same stratum: inherit 240.0 → 240.1, reduce-kv 305.5 → 308.3. The one headline that moves is the hoist, where the shipped half was *also* truncated: **`rf2-zxv06`'s saving is 744.1 B/sub, not 758.1**.

The real correction is the shipped halves: `P-INHERH`, `P-RKV` and `P-SCOPEH` allocate **essentially nothing**, not the 2–16 B/sub previously quoted.

## Stated, not smoothed over

- **Near-zero arms retain a window-size-dependent floor.** `P-SCOPEH` reads 0.2 B/call at reps=818 and 32.0 at reps=4000; `P-RKV` 106.8 at 1269 and 64.9 at 4000. So 0.1–0.3 B/sub is an **upper bound at the instrument's floor**, not a measurement.
- **The `SMI-*` control reads 2x its own prediction** (1681.7 vs 848 at D=100). Not the box — the SMI arms store an Smi and the 2x survives the fix. Filed as `rf2-l3jv4`.
- **`C-FRAME` looks up `:wa/frame`, which the rig never registers** — it measures a registry *miss*. It surfaced here because it is the one truthy-looking `keep!` arm that never stepped. Filed as `rf2-c0awb`.

The guard's recorded caveat is vindicated exactly: a `:predecessor` finding says *the figure moves with the plan*, and here the mechanism was a **state the plan carried**, not adjacency. `order_guard.cljc` and `order_guard.cjs` are untouched — nothing needed loosening.

## Quality gates

| gate | exit |
|---|---|
| `node --expose-gc out/write-attribution.js` — run 1 | **0** — `VERDICT: reportable`, all 33 arms |
| `node --expose-gc out/write-attribution.js` — run 2 | **0** — `reportable` |
| `node --expose-gc out/write-attribution.js` — run 3 | **0** — `reportable` |
| `re-frame.bench.read-attribution` (JVM) | **0** — `reportable`, controls +0.000% |
| order-guard self-test, CLJC (8 checks, in both harnesses) | **0** |
| order-guard self-test, CJS (8 checks, in `b7_run.cjs`) | **0** |
| B7 heap (`b7_run.cjs --only heap`) | **0** — `reportable`, 0 unverified of 56 mounts, positive control 4,700,288 B measured vs 4,700,000 predicted (+0.006%) |
| `npm run test:cljs` | **0** — 0 failures, 0 errors |
| `shadow-cljs release ui-bench` x2 entry points | **0** |

Figures are identical across all three post-fix runs at the reported resolution (`P-SCOPEM` 744.2 / 744.2 / 744.2; `P-SCOPEH` 0.1 / 0.1 / 0.1; `P-INHERH` 0.2 / 0.2 / 0.2; `P-RKV` 0.3 / 0.3 / 0.3; `DBL-100` 848.2 / 848.2 / 848.2).

Raw logs are local-only under `ai/findings/2026-07-28.xu0ma-*.log`.
