### PR TITLE
bench: the SMI control predicts what it measures, and C-FRAME looks up something real (rf2-l3jv4, rf2-c0awb)

### DIFF
--- a/docs/design/freehand/studio/freehand-vs-reagent-allocation.md
+++ b/docs/design/freehand/studio/freehand-vs-reagent-allocation.md
@@ -574,16 +574,27 @@ shipped spellings allocate essentially nothing, and the retired-vs-shipped
 the same stratum. The exception is the hoist, where the shipped half was
 also truncated: **744.1 B/sub saved, not 758.1**.
 
-- **A second discrepancy this exposed, not yet isolated.** The `SMI-*`
-  control reads **almost exactly twice** its own prediction — 1681.7
-  B/copy at D=100 against 848 predicted (+98.3%), 3293.5 against 1648
-  (+99.9%) — so the printed `SMI slope` of 16.11 B/slot is 2× the 8 B a
-  tagged slot occupies with pointer compression off. It is *not* the box
-  above: the `SMI-*` arms store an Smi, and the 2× survives the fix
-  unchanged. The regime conclusion the pair exists to draw is still the
-  right one (16.11 > the 6.0 threshold → compression OFF), and the `DBL`
-  slope it is read beside lands at +0.04%, so no figure here rests on it.
-  Filed rather than guessed at.
+- **A second discrepancy this exposed, since isolated and fixed.** The
+  `SMI-*` control read **almost exactly twice** its own prediction —
+  1664.3 B/copy at D=100 against 848 predicted, 3275.7 against 1648 — so
+  the printed `SMI slope` of 16.11 B/slot was 2× the 8 B a tagged slot
+  occupies with pointer compression off. It was *not* the box above: the
+  `SMI-*` arms store an Smi and the 2× survived that fix unchanged. The
+  fault was the **instrument's, not the prediction's** (`rf2-l3jv4`).
+  `.slice()`'s clone fast path is keyed on the receiver's elements kind,
+  and V8 keeps one inline cache per call *site* — per function body,
+  shared by every closure made from it. The six control arms were built
+  from one factory body, so the harness had **one `.slice()` site that
+  saw both `PACKED_SMI_ELEMENTS` and `PACKED_DOUBLE_ELEMENTS`**, and at
+  that polymorphic site the SMI receiver loses the fast path and the
+  clone allocates its elements store *twice*: `32 + 2 × (16 + 8D)` =
+  1664 at D=100, measured 1664.3. The double receivers keep their fast
+  path, which is why only half the pair was ever wrong. Splitting the
+  site per elements kind returns the arm to **848.3 B/copy against 848
+  predicted (+0.04%)** and the slope to **8.0027 B/slot (+0.03%)**. The
+  regime conclusion the pair exists to draw was the right one throughout
+  (compression OFF), and no figure in this document rested on the
+  absolute, so nothing here moves.
 - **`read-attribution` passes**, both factors, every arm, with its
   controls landing at **+0.000%** predicted against measured on both
   rungs (JVM, exact TLAB accounting).

--- a/implementation/core/test/re_frame/bench/write_attribution.cljs
+++ b/implementation/core/test/re_frame/bench/write_attribution.cljs
@@ -96,23 +96,30 @@
     happens to use — which a `FixedArray`-of-SMI control would NOT have been
     (4 B/slot compressed, 8 uncompressed).
 
-  Predicted and measured are both printed. If they disagree, suspect the
-  control first, and report the miss either way. Two misses are on record
-  and both are real:
+  Predicted and measured are both printed, for EVERY size and not merely
+  as a slope. If they disagree, suspect the control first, and report the
+  miss either way. Two misses are on record:
 
     * The SMALL double pair (D 100->200) lands, at +0.5%. The LARGE pair
       (1000->10000) reads +9%, because the 8 B/element model omits V8's
       page-tail filler — an 87 KB object wastes ~7% of a 256 KB page and
       that filler is genuine used-heap. It is a LARGE-object effect and
       every arm here allocates small ones, so the instrument is calibrated
-      in the regime it is used in.
-    * The SMI control reads 16.1 B/slot in forward arm order and 8.0027 in
-      REVERSED order — the difference being whether the 87 KB arm ran
-      immediately before it. A large-object arm inflates its successor,
-      reproducibly, and nothing in the method predicted that (rf2-88pie).
-      It is why every figure here is taken in both orders, and why the
-      pointer-compression regime is read off `process.config` rather than
-      off this control.
+      in the regime it is used in. STILL OPEN, and correctly so.
+    * The SMI control used to read 16.1 B/slot — twice its own prediction,
+      at both sizes. RESOLVED (rf2-l3jv4), and the fault was the
+      instrument's, not the prediction's: `arm-ctl` was ONE function body
+      closed over both kinds of template, so the harness had ONE
+      `.slice()` call site that saw both PACKED_SMI_ELEMENTS and
+      PACKED_DOUBLE_ELEMENTS receivers, and at that polymorphic site the
+      SMI receiver loses `.slice()`'s clone fast path and allocates its
+      elements store TWICE. Splitting the site per elements kind returns
+      the arm to 8.0 B/slot. See `arm-ctl-smi`. The effect is
+      order-INDEPENDENT — it does not depend on which kind the site saw
+      first — so it does not account for the reversed-order reading of
+      8.0027 recorded against this arm under rf2-88pie, which predates
+      several rebuilds of it and is not re-litigated here. Both orders are
+      still run, and both must now meet the prediction.
 
   ## The ladder
 
@@ -325,8 +332,40 @@
 
 (defn- ctl-key [kind d] (str kind "-" d))
 
-(defn- arm-ctl [kind d]
-  (let [t (get @ctl-templates (ctl-key kind d))]
+;; rf2-l3jv4 — TWO factories, one per ELEMENT KIND, and the duplication is the
+;; whole point.
+;;
+;; `.slice()`'s clone fast path is keyed on the RECEIVER'S ELEMENTS KIND, and
+;; V8 has one inline cache per call SITE — that is, per function BODY, shared
+;; by every closure made from it. A single `arm-ctl` body closed over both
+;; kinds of template therefore gave the harness ONE `.slice()` site with two
+;; receiver maps, and at that polymorphic site the PACKED_SMI receiver loses
+;; the fast path: the clone allocates its elements store TWICE, so a copy costs
+;; `32 + 2 x (16 + 8D)` rather than `32 + 16 + 8D`. The PACKED_DOUBLE receivers
+;; keep theirs and are unaffected, which is why only the SMI half of the pair
+;; was ever wrong.
+;;
+;; Measured in isolation, one node process, the same method, both shapes side
+;; by side (node 24.13.0 / V8 13.6, pointer compression OFF):
+;;
+;;                 shared site        split sites      predicted
+;;   SMI D=100     1665.9 B/copy      849.1 B/copy     848
+;;   SMI D=200     3275.8            1651.8          1648
+;;   DBL D=100      849.8             849.8            848
+;;
+;; So the PREDICTION was right and the INSTRUMENT was wrong — the arm was not
+;; measuring `.slice()` of a packed SMI array, it was measuring `.slice()` of a
+;; packed SMI array at a site that had also been shown doubles.
+;;
+;; Do not factor these two back together. If they are merged the SMI control
+;; silently doubles again, which is why the CONTROLS readout now prints
+;; predicted vs measured for every size rather than only a slope.
+
+(defn- arm-ctl-dbl
+  "The PACKED_DOUBLE control. Its `.slice()` site must never see any other
+  elements kind — see `arm-ctl-smi`, which is this body's deliberate twin."
+  [d]
+  (let [t (get @ctl-templates (ctl-key "DBL" d))]
     (fn []
       ;; rf2-xu0ma — element 0 goes through `keep!`, NOT into `sink` directly.
       ;; The read is what stops Closure deleting the copy, and it is preserved;
@@ -337,6 +376,23 @@
       (let [c (.slice t)]
         (keep! (aget c 0)))
       nil)))
+
+(defn- arm-ctl-smi
+  "The PACKED_SMI control, character-for-character `arm-ctl-dbl`'s body and
+  separate from it on purpose (rf2-l3jv4). Sharing one body gives V8 one
+  polymorphic `.slice()` site and doubles this arm's reading."
+  [d]
+  (let [t (get @ctl-templates (ctl-key "SMI" d))]
+    (fn []
+      (let [c (.slice t)]
+        (keep! (aget c 0)))
+      nil)))
+
+(defn- arm-ctl
+  "Dispatch to the per-kind factory. This function is not itself a `.slice()`
+  site; it only chooses which one the arm will use."
+  [kind d]
+  (if (= "SMI" kind) (arm-ctl-smi d) (arm-ctl-dbl d)))
 
 (defn- slope
   "Bytes per element between two control readings — the reading that cancels
@@ -973,10 +1029,39 @@
                            (fmt (apply min rnd)) (fmt (apply max rnd))))))
       (println ";;")
       (println ";; CONTROLS")
+      ;; rf2-l3jv4 — the ABSOLUTE, checked, at every size. The slopes below
+      ;; cancel both headers and so cannot see a constant FACTOR; printing only
+      ;; them is how an arm reading exactly twice its prediction at BOTH sizes
+      ;; went unremarked for as long as it did.
+      ;;
+      ;; The double control is checked against an asserted layout — JSArray
+      ;; 32 B + `FixedDoubleArray` (16 B header + 8 B x D) — which is safe
+      ;; because V8 never pointer-compresses a double, so that prediction holds
+      ;; in either regime.
+      ;;
+      ;; The SMI control is NOT checked that way, because its whole job is to
+      ;; READ the regime and predicting it from an assumed slot width would be
+      ;; circular. It is checked against the DOUBLE control at the SAME D
+      ;; instead — one measurement against another, from the same process and
+      ;; the same window, with no header asserted anywhere. With pointer
+      ;; compression OFF a tagged slot is 8 bytes and the two copies have
+      ;; identical layout, so the ratio must be 1.0000; with it ON every slot
+      ;; and both headers halve and it must be about 0.50.
       (doseq [d ctl-double-ds]
-        (println (gstring/format ";;   DBL D=%-6d %12s B/copy" d (fmt (b (ctl-key "DBL" d))))))
+        (let [m (b (ctl-key "DBL" d))
+              p (+ 32 16 (* 8 d))]
+          (println (gstring/format ";;   DBL D=%-6d %12s B/copy   predicted %7d  %+.2f%%"
+                           d (fmt m) p (* 100.0 (/ (- m p) p))))))
       (doseq [d ctl-smi-ds]
-        (println (gstring/format ";;   SMI D=%-6d %12s B/copy" d (fmt (b (ctl-key "SMI" d))))))
+        (let [m (b (ctl-key "SMI" d))
+              r (b (ctl-key "DBL" d))]
+          (println (gstring/format
+                     ";;   SMI D=%-6d %12s B/copy   x%.4f of DBL D=%d (%s B)  -> %s"
+                     d (fmt m) (/ m r) d (fmt r)
+                     (cond
+                       (< 0.95 (/ m r) 1.05) "8 B/slot, compression OFF"
+                       (< 0.45 (/ m r) 0.55) "4 B/slot, compression ON"
+                       :else                 "*** NEITHER — the SMI arm is not measuring a tagged-slot copy ***")))))
       (let [sm (slope b (ctl-key "DBL" 100) 100 (ctl-key "DBL" 200) 200)
             lg (slope b (ctl-key "DBL" 1000) 1000 (ctl-key "DBL" 10000) 10000)
             si (slope b (ctl-key "SMI" 100) 100 (ctl-key "SMI" 200) 200)]
@@ -986,10 +1071,15 @@
         (println (gstring/format
                    ";;   DBL slope, LARGE pair (1000->10000)  %.4f B/double  predicted 8.0000  %+.2f%%"
                    lg (* 100.0 (/ (- lg 8.0) 8.0))))
+        ;; rf2-l3jv4 — the regime is READ off this slope, so it cannot also be
+        ;; predicted from an assumed slot width. What CAN be checked, without
+        ;; circularity, is how close the slope sits to the exact width of the
+        ;; regime it just selected: a tagged slot is 8 bytes or 4, never 16.1.
         (println (gstring/format
-                   ";;   SMI slope, SMALL pair (100->200)     %.4f B/slot    -> pointer compression %s"
+                   ";;   SMI slope, SMALL pair (100->200)     %.4f B/slot    -> pointer compression %s   %+.2f%% off that width"
                    si (if (< si 6.0) "ON (4 B/slot, Chrome-like)"
-                          "OFF (8 B/slot, Node default)"))))
+                          "OFF (8 B/slot, Node default)")
+                   (let [w (if (< si 6.0) 4.0 8.0)] (* 100.0 (/ (- si w) w))))))
       (println ";;")
       (println ";; THE LADDER — bytes per WRITE")
       (doseq [[lbl v] [["MKDB      the application's own new-db value" (b "MKDB")]

--- a/implementation/core/test/re_frame/bench/write_attribution.cljs
+++ b/implementation/core/test/re_frame/bench/write_attribution.cljs
@@ -408,7 +408,23 @@
 
 (defn- next-gen! [] (vswap! gen inc))
 
-(def ^:private fid :wa/frame)
+(def ^:private fid
+  "A frame-id-SHAPED keyword, and nothing more: the key `arm-c-bump` bumps in
+  this file's stand-in epoch map, and the frame-id the memo wrappers carry into
+  their trace tags. Neither of those looks it up in the registry — `subs.memo`
+  passes `frame-id` straight through to `emit-sub-skip!` / `validate-and-trace`
+  as a tag value — so it does not need to be registered, and is not.
+
+  rf2-c0awb: `C-FRAME` used to look this up, and THAT did need it registered.
+  `build-rig!` builds `:wa/frame0` … `:wa/frame3` and never `:wa/frame`, so
+  the arm published as `commit-frame-transition!`'s registry lookup was
+  pricing a registry MISS. See `arm-c-frame`."
+  :wa/frame)
+
+(def ^:private absent-fid
+  "Deliberately never registered — `arm-c-frame-miss` is the miss half of
+  `C-FRAME`'s pair, and it has to be a miss on purpose rather than by accident."
+  :wa/no-such-frame)
 
 (defn- db-of [cells-n v] {:cells (vec (repeat cells-n v))})
 
@@ -464,7 +480,19 @@
 ;; so an attribution that does not add up says so.
 ;;
 ;;   C-FRAME    `(frame/frame id)` — the registry lookup `commit-frame-
-;;              transition!` does before anything else
+;;              transition!` does before anything else, on a frame the rig
+;;              REGISTERED, so the visibility walk behind the registry `get`
+;;              actually runs (rf2-c0awb)
+;;   C-FRAMEX   the same call on an id that was never registered. PAIRED
+;;              CONTROL: `frame/frame` short-circuits on the `get`, so the
+;;              miss is strictly less work than the hit and only `C-FRAME`
+;;              belongs in the attribution. This arm is what `C-FRAME` was
+;;              measuring by accident until rf2-c0awb.
+;;   C-FRAMEG   the registry `get` ALONE on the same hit, which is what says
+;;              WHICH HALF of `frame/frame` a hit-vs-miss difference is in.
+;;              It reads 0.0, so the `get` is free and the difference is the
+;;              visibility walk. That difference is DISPUTED between the two
+;;              entry points and is not quotable — see rf2-tmzie.
 ;;   C-PARTS    `commit-frame-record-transition!`'s partition bookkeeping:
 ;;              the two `contains?`, the four `get`, the `next-fs` map, the
 ;;              `changed` cond-> set, the two `not=` partition comparisons and
@@ -495,9 +523,56 @@
   one per write."
   (fnil inc 0))
 
-(defn- arm-c-frame []
-  (keep! (frame/frame fid))
-  nil)
+;; rf2-c0awb — `commit-frame-transition!`'s first act is `(frame/frame id)`, and
+;; this arm is what that costs. It has to be a HIT to be that.
+;;
+;; `frame/frame` is `(when-let [f (get @frames id)] (when (visible? id f) f))`,
+;; so a miss short-circuits on the registry `get` and never reaches the
+;; visibility predicate — the two-level `:lifecycle`/`:construction` walk that
+;; a real commit's lookup always runs. The arm used to be handed `:wa/frame`,
+;; which `build-rig!` never registers, so it priced the short-circuit.
+;;
+;; A factory rather than a bare arm, so the id is resolved ONCE at plan-build
+;; time: `(nth (:frames @rig) 0)` inside the measured body would charge this
+;; arm a rig lookup it is not measuring. Frame 0 is the one `RFWRITE-0` writes
+;; through, which is the rung this figure is subtracted from.
+;;
+;; The miss is kept beside it as `C-FRAMEX` rather than discarded. Both halves
+;; live in one process on one registry — the `P-VALS`/`P-RKV` discipline — so
+;; the pair MEASURES what the hit costs over the miss instead of assuming it,
+;; and an arm that silently reverts to a miss shows up as the pair collapsing.
+
+(defn- arm-c-frame
+  "The HIT: the registry lookup a commit performs, on a frame that exists."
+  []
+  (let [id (nth (:frames @rig) 0)]
+    (fn []
+      (keep! (frame/frame id))
+      nil)))
+
+(defn- arm-c-frame-miss
+  "The MISS: the same call on an id that was never registered, which is what
+  this arm measured before rf2-c0awb."
+  []
+  (let [id absent-fid]
+    (fn []
+      (keep! (frame/frame id))
+      nil)))
+
+(defn- arm-c-frame-get
+  "`frame/frame`'s registry `get` ALONE, on the same hit — the first half of
+  the lookup with the visibility predicate removed. `frames` is public, so
+  this is the `Q-SCHED` discipline: the expression re-spelled in the harness
+  so what is measured is pinned here and cannot drift under the attribution.
+
+  It exists because the HIT/MISS pair alone cannot say WHICH half of
+  `frame/frame` a non-zero difference is in — the miss short-circuits on the
+  `get`, so it skips both halves at once."
+  []
+  (let [id (nth (:frames @rig) 0)]
+    (fn []
+      (keep! (get @frame/frames id))
+      nil)))
 
 (defn- arm-c-parts []
   (let [{:keys [fs-a fs-b db-a db-b]} @rig
@@ -948,7 +1023,11 @@
                         ;; rf2-78ejq — the rungs under RFWRITE-0
                         ["SPINE0B"   arm-spine0b          1]
                         ["SPINE0P"   arm-spine0p          1]
-                        ["C-FRAME"   arm-c-frame          1]
+                        ;; rf2-c0awb — the registry lookup, HIT / MISS / the
+                        ;; `get` on its own, all three in one process
+                        ["C-FRAME"   (arm-c-frame)        1]
+                        ["C-FRAMEX"  (arm-c-frame-miss)   1]
+                        ["C-FRAMEG"  (arm-c-frame-get)    1]
                         ["C-PARTS"   arm-c-parts          1]
                         ["C-TAGPAIR" arm-c-tagpair        1]
                         ["C-BUMP"    arm-c-bump           1]
@@ -1127,7 +1206,7 @@
             sp0    (b "SPINE0")
             delta  (- rf0 sp0)
             proj   (- (b "SPINE0P") (b "SPINE0B"))
-            comps  [["C-FRAME    (frame id) registry lookup" (b "C-FRAME")]
+            comps  [["C-FRAME    (frame id) registry lookup, HIT" (b "C-FRAME")]
                     ["C-PARTS    partition bookkeeping"      (b "C-PARTS")]
                     ["C-TAGPAIR  two [::ok v] pairs"         (b "C-TAGPAIR")]
                     ["C-PROJ     the two projections"        proj]
@@ -1145,7 +1224,23 @@
                          (fmt (b "SPINE0B")) (fmt (b "SPINE0P"))))
         (println (gstring/format ";;   C-BUMP %s B vs C-BUMPH %s B  -> hoisting (fnil inc 0) predicts %s B/write"
                          (fmt (b "C-BUMP")) (fmt (b "C-BUMPH"))
-                         (fmt (- (b "C-BUMP") (b "C-BUMPH"))))))
+                         (fmt (- (b "C-BUMP") (b "C-BUMPH")))))
+        ;; rf2-c0awb — the lookup, paired. Only C-FRAME (the HIT) is a component
+        ;; of the delta above; C-FRAMEX is here to say what the hit costs OVER
+        ;; the miss rather than leaving it assumed, and to make it visible if
+        ;; this arm ever reverts to pricing the short-circuit again.
+        (println (gstring/format ";;   C-FRAME (registry HIT) %s B vs C-FRAMEX (MISS) %s B  -> a HIT costs %s B/lookup more than a miss"
+                         (fmt (b "C-FRAME")) (fmt (b "C-FRAMEX"))
+                         (fmt (- (b "C-FRAME") (b "C-FRAMEX")))))
+        (println (gstring/format ";;   C-FRAMEG (the registry `get` alone, same hit) %s B  -> the visibility walk is the remaining %s B"
+                         (fmt (b "C-FRAMEG"))
+                         (fmt (- (b "C-FRAME") (b "C-FRAMEG")))))
+        (println ";;   ^ that non-zero is DISPUTED and may NOT be quoted (rf2-tmzie): `-diagnose`")
+        (println ";;     PROBE 4 sweeps the SAME closure and reads a CONSTANT 32 B per WINDOW from")
+        (println ";;     reps=64 to reps=4000 — i.e. ~0 B/call — where the plan reads 32 B/CALL at")
+        (println ";;     reps=4000. One of the two is wrong and it is not yet known which. What IS")
+        (println ";;     settled is that the arm takes the HIT path now, and that the registry")
+        (println ";;     `get` is free in both."))
       ;; --- arm order, LAST, and it governs everything above ----------------
       ;; The figures are printed and the refusal is about what may be QUOTED,
       ;; not about throwing the measurement away — so the exit code carries
@@ -1347,5 +1442,34 @@
           (println (gstring/format ";;     -> step %10s B/call  (%s B per inner iteration)"
                            (fmt (- (/ (:p50 dbl) reps) (/ (:p50 smi) reps)))
                            (fmt (/ (- (/ (:p50 dbl) reps) (/ (:p50 smi) reps)) iters))))))
+      ;; ---- PROBE 4 — is C-FRAME's step real, or the instrument's floor? ----
+      ;; rf2-c0awb pointed `C-FRAME` at a frame the rig actually registers and
+      ;; the arm went from 0.0 to 32.0 B/call. 32.0 B/call at reps=4000 is
+      ;; exactly what `P-SCOPEH` — an arm that allocates essentially nothing —
+      ;; also reads, so the figure has to be separated from the floor before it
+      ;; is quoted. A REAL per-call allocation is rep-INDEPENDENT; a floor is a
+      ;; roughly fixed number of bytes per WINDOW and therefore falls as 1/reps.
+      ;; Both halves of the pair are swept, because the miss is the matched
+      ;; control: identical arm shape, identical windows, one branch different.
+      (println ";;")
+      (println ";; PROBE 4 — C-FRAME hit vs miss, swept across window sizes")
+      (println ";;   rep-INDEPENDENT B/call = real allocation; ~constant B/window = the floor")
+      (doseq [[label f* seed verify]
+              [["C-FRAME  HIT s=1"     (arm-c-frame)      1         (advanced-by 1)]
+               ;; `-main` never resets the counter — it stands near 1.2e8 by the
+               ;; time C-FRAME is measured there. That is still an Smi with
+               ;; pointer compression off, but rf2-xu0ma WAS a counter-state
+               ;; effect, so the magnitude is swept rather than assumed away.
+               ["C-FRAME  HIT s=1.2e8" (arm-c-frame)      120000000 (advanced-by 1)]
+               ["C-FRAMEG get-only"    (arm-c-frame-get)  1         (advanced-by 1)]
+               ["C-FRAMEX MISS"        (arm-c-frame-miss) 1
+                ;; the miss feeds `keep!` a nil, so the counter must NOT move —
+                ;; a window where it did was not measuring the miss
+                (fn [before after _] (== after before))]]]
+        (dotimes [_ 3] (f*))
+        (dotimes [_ 6] (measure f* 256 1))
+        (doseq [reps sweep]
+          (let [r (probe f* reps windows seed verify)]
+            (probe-line label reps r reps))))
       (println ";;")
       (println (gstring/format ";; sink %s %s" @sink (some? @sink2))))))


### PR DESCRIPTION
Two loose ends `rf2-xu0ma` (PR #7229) deliberately did not fold into its own fix. Both live in `implementation/core/test/re_frame/bench/write_attribution.cljs`.

## rf2-l3jv4 — the prediction was right, the instrument was wrong

**`.slice()`'s clone fast path is keyed on the receiver's elements kind, and V8 keeps one inline cache per call SITE — per function body, shared by every closure made from it.** `arm-ctl` was ONE body closed over all six control templates, so the harness had ONE `.slice()` site that saw both `PACKED_SMI_ELEMENTS` and `PACKED_DOUBLE_ELEMENTS` receivers. At that polymorphic site the SMI receiver loses the fast path and the clone allocates its elements store **twice**:

```
32 + 2 x (16 + 8D)  =  1664 B at D=100   measured 1664.3
```

rather than `32 + 16 + 8D = 848`. The double receivers keep their fast path, which is why only the SMI half of the pair was ever wrong — and why every box-shaped hypothesis failed.

**Established in isolation before the fix**, one node process, the same method, both shapes side by side:

| | shared site | split sites | predicted |
|---|---|---|---|
| SMI D=100 | 1665.9 B/copy | **849.1** | 848 |
| SMI D=200 | 3275.8 | **1651.8** | 1648 |
| DBL D=100 | 849.8 | 849.8 | 848 |

The effect is **order-independent** — warming the shared site with doubles first or with Smis first both read 1667.4 — so it does **not** account for the reversed-order 8.0027 recorded against this arm under `rf2-88pie`, and that is not re-litigated here.

**After, in the harness** (node 24.13.0 / V8 13.6.233.17-node.37, pointer compression OFF, `:advanced` + `goog.DEBUG=false`), three consecutive runs, forward order:

| control | measured | predicted | |
|---|---|---|---|
| SMI D=100 | **848.3** B/copy (was 1664.3) | 848 | +0.04% |
| SMI D=200 | **1648.6** (was 3275.7) | 1648 | +0.04% |
| SMI slope | **8.0027** B/slot | 8 | +0.03% |
| DBL D=100 | 848.2 (unchanged) | 848 | +0.03% |

No other arm moves outside its own round range. The pointer-compression regime the pair exists to read was right throughout, so **no published figure moves.**

**The readout is what let this stand, so it changes too.** The CONTROLS block printed only a slope, and a slope cancels both headers and cannot see a constant *factor*. It now prints the absolute at every size. The SMI absolute is checked against the **double control at the same D** rather than an asserted slot width — one measurement against another, same process, same window, no header asserted anywhere — because the SMI pair's job is to *read* the pointer-compression regime and predicting it from an assumed width would be circular. The slope line now also states how far it sits from the exact width of the regime it just selected: a tagged slot is 8 bytes or 4, never 16.1.

## rf2-c0awb — C-FRAME now looks up something real, and the published figure moves

`arm-c-frame` was handed `:wa/frame`; `build-rig!` only builds `:wa/frame0` … `:wa/frame3`. `frame/frame` is `(when-let [f (get @frames id)] (when (visible? id f) f))`, so an unregistered id short-circuits on the registry `get` and never reaches the visibility walk a real commit's lookup always runs. **Chosen outcome: register what it means to look up** — the arm now looks up frame 0, the frame `RFWRITE-0` writes through, resolved once at plan-build time so it is not charged a rig lookup it is not measuring.

**The figure moves, and it is one of `rf2-78ejq`'s five components:**

> `C-FRAME (frame id) registry lookup` — was **0.0 B / 0.0% of the delta**, now **32.0 B / 1.3%**.

`rf2-78ejq` is CLOSED and its close reason quotes `C-FRAME registry lookup 0.0 B`. Nothing under `docs/` or `spec/` quotes it.

**Two arms are added, not one**, because a hit/miss pair alone cannot say which half of `frame/frame` a difference is in — the miss skips both halves at once. reps=4000, 42 windows, identical across three runs:

| arm | | |
|---|---|---|
| `C-FRAME` | full lookup, registered id | **32.0** B/call `[32.0 – 32.0]` |
| `C-FRAMEG` | the registry `get` alone, same hit | **0.0** |
| `C-FRAMEX` | full lookup, absent id (the MISS) | **0.0** |

So the `get` is free and the 32.0 B is the visibility walk.

**That non-zero is DISPUTED, and the harness now says so in its own output.** `-diagnose` gains **PROBE 4**, which sweeps the same three closures across window sizes on the principle that a real per-call allocation is rep-*independent* while a floor is a fixed number of bytes per *window* and falls as 1/reps. `C-FRAME` reads a **constant 32 B per WINDOW at reps 64/128/256/512/1024/2048/4000** — i.e. ~0 B/call — against the plan's 32 B/CALL at reps=4000. A factor of ~4000 on one closure. Ruled out in the sweep: the registry `get` (0.0 in both), `keep!`'s branch (`C-FRAMEG` feeds it a truthy value too and reads 0.0), `rf2-xu0ma`'s counter magnitude (seeded at 1 **and** at 1.2e8, both 32 B/window), and window size itself. **Filed as `rf2-tmzie`**; the printed pair line names it and says the figure may not be quoted.

## The order guard

**Untouched — neither copy, neither self-test.** Both self-tests pass 8/8 in every gate below.

One run of the final plan **did refuse**, and it is reported rather than smoothed over: `P-RKV` by **PHASE** (FIRST-THIRD 113.5 vs LAST-THIRD 85.4 B/call, ranges disjoint, ratio 1.33). That is a near-zero arm at the instrument's floor — not an arm this PR changed — and the plan grew from 33 arms to 35, which reshuffles every arm's strata. It did not recur: the three runs of the final build are all `reportable`. It is consistent with the standing caveat that 0.1–0.3 B/sub is an upper bound at the floor, not a measurement. **The guard was not loosened.**

## Every control, predicted vs measured

| control | runtime | predicted | measured | |
|---|---|---|---|---|
| DBL D=100 | node | 848 | 848.2 | +0.03% |
| DBL D=200 | node | 1648 | 1648.6 | +0.04% |
| DBL D=1000 | node | 8048 | 8178.1 | +1.62% |
| DBL D=10000 | node | 80048 | 86738.8 | +8.36% — page-tail filler, a known LARGE-object effect, still open by design |
| DBL slope, small pair | node | 8.0000 | 8.0033 | +0.04% |
| SMI D=100 | node | 848 (= DBL D=100) | 848.3 | x1.0001 |
| SMI D=200 | node | 1648 (= DBL D=200) | 1648.6 | x1.0000 |
| SMI slope | node | 8.0000 | 8.0027 | +0.03% |
| read-attribution CTRL-S | **JVM** | 244,800 | 244,800 | **+0.000%** |
| read-attribution CTRL-L | **JVM** | 2,404,800 | 2,404,800 | **+0.000%** |
| B7 heap positive control | node/CDP | 4,700,000 | 4,700,288 | +0.006% |

`0 unverified of 5` at every PROBE 4 point; `0 unverified of 56 mounts` on B7; `0 dropped of 42` on every write-attribution arm. **Node figures are node's** — pointer compression is OFF here and ON in Chrome, so a tagged slot is 8 bytes here and 4 there. Shares transfer, absolutes do not.

## Quality gates

| gate | exit |
|---|---|
| `shadow-cljs release ui-bench` — `-main` | **0** |
| `shadow-cljs release ui-bench` — `-diagnose` | **0** |
| `node --expose-gc out/write-attribution.js` — run 1 | **0** — `VERDICT: reportable`, all 35 arms |
| `node --expose-gc out/write-attribution.js` — run 2 | **0** — `reportable` |
| `node --expose-gc out/write-attribution.js` — run 3 | **0** — `reportable` |
| `node --expose-gc out/wa-diagnose.js` (PROBE 4) | **0** — 0 unverified of 5 at every point |
| `re-frame.bench.read-attribution` (JVM) | **0** — `reportable`, controls +0.000% |
| order-guard self-test, CLJC (8 checks) | **0** — in write-attribution AND read-attribution |
| order-guard self-test, CJS (8 checks) | **0** — in `b7_run.cjs` |
| `b7_run.cjs --only heap` | **0** — `reportable`, 0 unverified of 56 mounts, positive control +0.006% |
| `npm run test:cljs` | **0** — 11,893 tests / 59,341 assertions, 0 failures, 0 errors |

Nothing slower was run here; the full spine is deferred to CI. Raw logs are local-only under `ai/findings/2026-07-28.wa-controls-*.log`.

No Freehand-versus-Reagent verdict is drawn or implied.
